### PR TITLE
fix: add windowsHide to all spawn/exec calls

### DIFF
--- a/.claude/workflow-state.json
+++ b/.claude/workflow-state.json
@@ -1,0 +1,8 @@
+{
+  "tasksCreated": false,
+  "taskCount": 0,
+  "memorySearched": false,
+  "interactionCount": 1,
+  "sessionStart": "2026-03-17T01:20:01.043Z",
+  "lastBlockedAt": null
+}

--- a/v2/bin/start-ui.js
+++ b/v2/bin/start-ui.js
@@ -40,7 +40,7 @@ export async function launchUI(args = []) {
                 : 'xdg-open';
 
           const { exec } = await import('child_process');
-          exec(`${openCommand} http://localhost:${port}/console`);
+          exec(`${openCommand} http://localhost:${port}/console`, { windowsHide: true });
         } catch {
           // Browser opening failed, that's okay
         }

--- a/v2/bin/swarm-ui.js
+++ b/v2/bin/swarm-ui.js
@@ -613,6 +613,7 @@ class SwarmUI {
       // Windows: Use wmic to find and kill processes
       exec(
         'wmic process where "commandline like \'%claude-flow swarm%\'" get processid',
+        { windowsHide: true },
         (error, stdout) => {
           if (!error && stdout) {
             const pids = stdout
@@ -621,7 +622,7 @@ class SwarmUI {
               .filter((line) => /^\d+$/.test(line));
 
             pids.forEach((pid) => {
-              exec(`taskkill /F /PID ${pid}`, (killError) => {
+              exec(`taskkill /F /PID ${pid}`, { windowsHide: true }, (killError) => {
                 if (!killError) {
                   this.log(`Stopped orphaned process PID: ${pid}`);
                 }
@@ -632,7 +633,7 @@ class SwarmUI {
       );
     } else {
       // Unix-like systems: Use ps and grep
-      exec('ps aux | grep "claude-flow swarm" | grep -v grep', (error, stdout) => {
+      exec('ps aux | grep "claude-flow swarm" | grep -v grep', { windowsHide: true }, (error, stdout) => {
         if (!error && stdout) {
           const lines = stdout.split('\n').filter((line) => line.trim());
           lines.forEach((line) => {
@@ -657,7 +658,7 @@ class SwarmUI {
 
     try {
       const { exec } = require('child_process');
-      exec(command, (error, stdout, stderr) => {
+      exec(command, { windowsHide: true }, (error, stdout, stderr) => {
         if (error) {
           this.log(`Command error: ${error.message}`, 'error');
         } else {

--- a/v2/scripts/build-monitor.js
+++ b/v2/scripts/build-monitor.js
@@ -29,7 +29,7 @@ class BuildMonitor {
   async runBuild() {
     return new Promise((resolve, reject) => {
       console.log('🔨 Running build verification...');
-      exec('npm run build', (error, stdout, stderr) => {
+      exec('npm run build', { windowsHide: true }, (error, stdout, stderr) => {
         const buildOutput = stderr || stdout;
         const errors = this.parseErrors(buildOutput);
         
@@ -70,7 +70,8 @@ class BuildMonitor {
     try {
       // Check for swarm agent updates
       const result = await new Promise((resolve) => {
-        exec('npx ruv-swarm hook pre-search --query "agent-progress" --cache-results true', 
+        exec('npx ruv-swarm hook pre-search --query "agent-progress" --cache-results true',
+          { windowsHide: true },
           (error, stdout) => {
             resolve(stdout || '');
           }

--- a/v2/src/cli/commands/start/start-command.ts
+++ b/v2/src/cli/commands/start/start-command.ts
@@ -121,7 +121,7 @@ export const startCommand = new Command()
 
           try {
             const { exec } = await import('child_process');
-            exec(`${openCommand} http://localhost:${options.port}/console`);
+            exec(`${openCommand} http://localhost:${options.port}/console`, { windowsHide: true });
           } catch {
             // Browser opening failed, that's okay
           }

--- a/v2/src/terminal/adapters/native.ts
+++ b/v2/src/terminal/adapters/native.ts
@@ -386,7 +386,7 @@ export class NativeAdapter implements ITerminalAdapter {
     try {
       const testConfig = this.getTestCommand();
       const { spawnSync } = require('child_process');
-      const result = spawnSync(testConfig.cmd, testConfig.args, { stdio: 'ignore' });
+      const result = spawnSync(testConfig.cmd, testConfig.args, { stdio: 'ignore', windowsHide: true });
 
       if (result.status !== 0) {
         throw new Error('Shell test failed');
@@ -434,7 +434,7 @@ export class NativeAdapter implements ITerminalAdapter {
       // Check if PowerShell is available
       try {
         const { spawnSync } = require('child_process');
-        const result = spawnSync('powershell', ['-Version'], { stdio: 'ignore' });
+        const result = spawnSync('powershell', ['-Version'], { stdio: 'ignore', windowsHide: true });
         if (result.status === 0) {
           return 'powershell';
         }
@@ -458,7 +458,7 @@ export class NativeAdapter implements ITerminalAdapter {
       for (const shell of shells) {
         try {
           const { spawnSync } = require('child_process');
-          const result = spawnSync('which', [shell], { stdio: 'ignore' });
+          const result = spawnSync('which', [shell], { stdio: 'ignore', windowsHide: true });
           if (result.status === 0) {
             return shell;
           }

--- a/v3/@claude-flow/browser/src/infrastructure/agent-browser-adapter.ts
+++ b/v3/@claude-flow/browser/src/infrastructure/agent-browser-adapter.ts
@@ -75,6 +75,7 @@ export class AgentBrowserAdapter {
           encoding: 'utf-8',
           timeout: this.timeout + 5000,
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
         });
 
         const duration = Date.now() - startTime;
@@ -641,6 +642,7 @@ export class AgentBrowserAdapter {
         const result = execSync(`agent-browser ${args.join(' ')}`, {
           encoding: 'utf-8',
           timeout: 300000, // 5 minutes for download
+          windowsHide: true,
         });
         resolve({ success: true, data: result });
       } catch (error) {

--- a/v3/@claude-flow/browser/tests/e2e/browser-e2e.test.ts
+++ b/v3/@claude-flow/browser/tests/e2e/browser-e2e.test.ts
@@ -19,6 +19,7 @@ function browser(command: string): string {
     const result = execSync(`agent-browser --session ${SESSION} --json ${command}`, {
       encoding: 'utf-8',
       timeout: 30000,
+      windowsHide: true,
     });
     return result;
   } catch (error) {

--- a/v3/@claude-flow/cli/.claude/helpers/github-safe.js
+++ b/v3/@claude-flow/cli/.claude/helpers/github-safe.js
@@ -80,9 +80,10 @@ if ((command === 'issue' || command === 'pr') &&
       const ghCommand = `gh ${command} ${subcommand} ${newArgs.join(' ')}`;
       console.log(`Executing: ${ghCommand}`);
       
-      const result = execSync(ghCommand, { 
+      const result = execSync(ghCommand, {
         stdio: 'inherit',
-        timeout: 30000 // 30 second timeout
+        timeout: 30000, // 30 second timeout
+        windowsHide: true,
       });
       
     } catch (error) {
@@ -98,9 +99,9 @@ if ((command === 'issue' || command === 'pr') &&
     }
   } else {
     // No body content, execute normally
-    execSync(`gh ${args.join(' ')}`, { stdio: 'inherit' });
+    execSync(`gh ${args.join(' ')}`, { stdio: 'inherit', windowsHide: true });
   }
 } else {
   // Other commands, execute normally
-  execSync(`gh ${args.join(' ')}`, { stdio: 'inherit' });
+  execSync(`gh ${args.join(' ')}`, { stdio: 'inherit', windowsHide: true });
 }

--- a/v3/@claude-flow/cli/src/commands/memory.ts
+++ b/v3/@claude-flow/cli/src/commands/memory.ts
@@ -2431,7 +2431,7 @@ const codeMapCommand: Command = {
     try {
       raw = execSync(
         `git ls-files -- "*.ts" "*.tsx" "*.js" "*.mjs" "*.jsx"`,
-        { cwd, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
+        { cwd, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, windowsHide: true }
       ).trim();
     } catch {
       output.printError('Failed to list source files via git. Is this a git repository?');

--- a/v3/@claude-flow/cli/src/commands/orc.ts
+++ b/v3/@claude-flow/cli/src/commands/orc.ts
@@ -363,6 +363,7 @@ function runClaudeSession(
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env },
       shell: true,
+      windowsHide: true,
     });
 
     let stdout = '';

--- a/v3/@claude-flow/codex/src/dual-mode/cli.ts
+++ b/v3/@claude-flow/codex/src/dual-mode/cli.ts
@@ -172,7 +172,7 @@ function createStatusCommand(): Command {
       const proc = spawn('npx', [
         'claude-flow@alpha', 'memory', 'list',
         '--namespace', options.namespace
-      ], { stdio: 'inherit' });
+      ], { stdio: 'inherit', windowsHide: true });
 
       proc.on('close', () => {
         console.log();

--- a/v3/@claude-flow/codex/src/dual-mode/orchestrator.ts
+++ b/v3/@claude-flow/codex/src/dual-mode/orchestrator.ts
@@ -163,6 +163,7 @@ export class DualModeOrchestrator extends EventEmitter {
         cwd: projectPath,
         env: { ...process.env, FORCE_COLOR: '0' },
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
       });
 
       this.processes.set(config.id, proc);
@@ -344,7 +345,7 @@ Remember: Other agents depend on your results in shared memory. Be concise and s
    */
   private runCommand(command: string, args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const proc = spawn(command, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      const proc = spawn(command, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
       let output = '';
       let error = '';
 


### PR DESCRIPTION
## Summary
- Adds `windowsHide: true` to all 12 source files with spawn/exec calls that were missing it
- Covers v2 and v3 codebases — spawn(), exec(), execSync(), spawnSync()
- Eliminates the need for the post-install `windows-hide-spawn.mjs` patch

## Test plan
- [ ] Verify no phantom console windows appear on Windows when running moflo commands
- [ ] Verify spawn/exec behavior unchanged on macOS/Linux (windowsHide is a no-op)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)