### PR TITLE
fix: prevent Stop hook from hanging on MCP timeout

### DIFF
--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -1621,12 +1621,20 @@ const sessionEndCommand: Command = {
 
       return { success: true, data: result };
     } catch (error) {
-      if (error instanceof MCPClientError) {
-        output.printError(`Session-end hook failed: ${error.message}`);
+      const msg = error instanceof Error ? error.message : String(error);
+      const isTimeout = msg.includes('timed out');
+
+      if (isTimeout) {
+        // Timeout is expected when MCP server is slow — exit cleanly
+        output.writeln(output.dim('Session-end timed out — exiting cleanly.'));
+      } else if (error instanceof MCPClientError) {
+        output.printError(`Session-end hook failed: ${msg}`);
       } else {
-        output.printError(`Unexpected error: ${String(error)}`);
+        output.printError(`Unexpected error: ${msg}`);
       }
-      return { success: false, exitCode: 1 };
+
+      // Force exit to prevent hanging when MCP call is stuck
+      process.exit(0);
     }
   }
 };


### PR DESCRIPTION
## Summary
- Add `process.exit(0)` to session-end catch block so the hook process terminates
- The 3-second timeout was already there but the process stayed alive after catching
- Timeout message is now a dim info line, not an error

## Test plan
- [ ] `npx moflo hooks session-end` exits within 3 seconds even if MCP is unresponsive
- [ ] Re-enable Stop hook in motailz settings and verify no hanging

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)