### PR TITLE
feat: clean dependency tree for self-contained OOTB

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "semver": "^7.6.0",
+    "sql.js": "^1.12.0",
     "zod": "^3.22.4"
   },
   "optionalDependencies": {
@@ -64,8 +65,8 @@
     "@ruvector/attention": "^0.1.3",
     "@ruvector/core": "^0.1.30",
     "@ruvector/router": "^0.1.27",
-    "@ruvector/router-linux-x64-gnu": "^0.1.27",
     "@ruvector/sona": "^0.1.5",
+    "@xenova/transformers": "^2.17.0",
     "agentdb": "^3.0.0-alpha.9",
     "agentic-flow": "^2.0.7"
   },


### PR DESCRIPTION
## Summary
- `sql.js` added to hard dependencies (WASM SQLite, no native build)
- `@xenova/transformers` added to optionalDependencies (neural embeddings)
- Removed `@ruvector/router-linux-x64-gnu` (platform-specific)

Core works with zero native deps: sql.js + hash embeddings.

## Test plan
- [ ] `npm install moflo` on Windows with no build tools — succeeds
- [ ] `moflo init --yes && moflo memory store --key test --value hello` works
- [ ] `moflo memory search --query test` returns results

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)