### PR TITLE
feat: consolidate background process management (zombie prevention)

### DIFF
--- a/.claude/helpers/hook-handler.cjs
+++ b/.claude/helpers/hook-handler.cjs
@@ -122,7 +122,7 @@ const handlers = {
     console.log('[OK] Edit recorded');
   },
 
-  'session-restore': () => {
+  'session-restore': async () => {
     if (session) {
       var existing = session.restore && session.restore();
       if (!existing) {
@@ -142,38 +142,30 @@ const handlers = {
     }
 
     // Auto-index guidance, code map, and patterns on session start
+    // Delegates to shared ProcessManager for dedup + PID tracking + cleanup.
     try {
       var projectDir = path.resolve(path.dirname(helpersDir), '..');
-      var cp = require('child_process');
-      var pidFile = path.join(projectDir, '.claude-flow', 'background-pids.json');
-      var lockFile = path.join(projectDir, '.claude-flow', 'session-restore.lock');
 
-      // ── Kill stale background processes tracked from previous session-restore ──
-      try {
-        if (fs.existsSync(pidFile)) {
-          var stalePids = JSON.parse(fs.readFileSync(pidFile, 'utf-8'));
-          for (var i = 0; i < stalePids.length; i++) {
-            try { process.kill(stalePids[i].pid, 0); } catch (e) { continue; }
-            try { process.kill(stalePids[i].pid, 'SIGTERM'); } catch (e) { /* already gone */ }
-          }
-          fs.unlinkSync(pidFile);
-        }
-      } catch (e) { /* non-fatal: best-effort cleanup */ }
+      // Dynamic import of ESM process-manager from CJS context
+      var pmMod = await import(
+        'file:///' + path.join(projectDir, 'node_modules', 'moflo', 'bin', 'lib', 'process-manager.mjs').replace(/\\/g, '/')
+      ).catch(function() {
+        // Fallback: try local bin/ (for moflo repo itself)
+        return import(
+          'file:///' + path.join(projectDir, 'bin', 'lib', 'process-manager.mjs').replace(/\\/g, '/')
+        );
+      }).catch(function() { return null; });
 
-      // ── Guard: prevent concurrent/rapid session-restore from spawning duplicate processes ──
-      // Uses a lock file with a timestamp. If the lock is < 30s old, skip spawning entirely.
-      // This is the primary zombie prevention: only one session-restore per 30s window can spawn.
-      try {
-        if (fs.existsSync(lockFile)) {
-          var lockAge = Date.now() - parseInt(fs.readFileSync(lockFile, 'utf-8'), 10);
-          if (lockAge < 30000) {
-            return; // Another session-restore already spawned background tasks recently
-          }
-        }
-        var lockDir = path.dirname(lockFile);
-        if (!fs.existsSync(lockDir)) fs.mkdirSync(lockDir, { recursive: true });
-        fs.writeFileSync(lockFile, String(Date.now()));
-      } catch (e) { /* non-fatal: proceed without lock */ }
+      if (!pmMod) return; // No process manager available
+
+      var pm = pmMod.createProcessManager(projectDir);
+
+      // Kill stale background processes from previous session
+      pm.killAll();
+
+      // Guard: prevent concurrent session-restores from spawning duplicates
+      if (pm.isLocked()) return;
+      pm.acquireLock();
 
       // Read moflo.yaml auto_index flags (default: both true)
       var autoGuidance = true;
@@ -212,33 +204,16 @@ const handlers = {
         return null;
       }
 
-      // Track PIDs of background processes so next session can clean them up
-      var trackedPids = [];
-
-      function spawnBackground(script, label, extraArgs) {
-        var args = [script].concat(extraArgs || []);
-        var child = cp.spawn('node', args, {
-          stdio: 'ignore',
-          cwd: projectDir,
-          detached: true,
-          windowsHide: true
-        });
-        if (child.pid) {
-          trackedPids.push({ pid: child.pid, script: label, startedAt: new Date().toISOString() });
-        }
-        child.unref();
-      }
-
       // 1. Index guidance docs (with embeddings for semantic search)
       if (autoGuidance) {
         var guidanceScript = findMofloScript('index-guidance.mjs');
-        if (guidanceScript) spawnBackground(guidanceScript, 'index-guidance');
+        if (guidanceScript) pm.spawn('node', [guidanceScript], 'index-guidance');
       }
 
       // 2. Generate code map (structural index of source files)
       if (autoCodeMap) {
         var codeMapScript = findMofloScript('generate-code-map.mjs');
-        if (codeMapScript) spawnBackground(codeMapScript, 'generate-code-map');
+        if (codeMapScript) pm.spawn('node', [codeMapScript], 'generate-code-map');
       }
 
       // 3. Start learning service (pattern research on codebase)
@@ -252,48 +227,27 @@ const handlers = {
         var nmLearn = path.join(projectDir, 'node_modules', 'moflo', '.claude', 'helpers', 'learning-service.mjs');
         if (fs.existsSync(nmLearn)) learnScript = nmLearn;
       }
-      if (learnScript) spawnBackground(learnScript, 'learning-service');
-
-      // Persist tracked PIDs — APPEND to existing file to avoid losing concurrent PIDs
-      if (trackedPids.length > 0) {
-        try {
-          var pidDir = path.dirname(pidFile);
-          if (!fs.existsSync(pidDir)) fs.mkdirSync(pidDir, { recursive: true });
-          var existing = [];
-          if (fs.existsSync(pidFile)) {
-            try { existing = JSON.parse(fs.readFileSync(pidFile, 'utf-8')); } catch (e) { existing = []; }
-          }
-          // Prune dead PIDs from existing list before appending
-          var alive = [];
-          for (var ep = 0; ep < existing.length; ep++) {
-            try { process.kill(existing[ep].pid, 0); alive.push(existing[ep]); } catch (e) { /* dead, skip */ }
-          }
-          fs.writeFileSync(pidFile, JSON.stringify(alive.concat(trackedPids)));
-        } catch (e) { /* non-fatal */ }
-      }
+      if (learnScript) pm.spawn('node', [learnScript], 'learning-service');
 
     } catch (e) { /* non-fatal: session-start indexing is best-effort */ }
   },
 
   'session-end': () => {
-    // Kill all tracked background processes on session end
+    // Kill all tracked background processes using shared sync helper.
+    // Must be SYNCHRONOUS — process.exit(0) fires in finally{} so async would never resolve.
     var projectDir = path.resolve(path.dirname(helpersDir), '..');
-    var pidFile = path.join(projectDir, '.claude-flow', 'background-pids.json');
-    var lockFile = path.join(projectDir, '.claude-flow', 'session-restore.lock');
     try {
-      if (fs.existsSync(pidFile)) {
-        var pids = JSON.parse(fs.readFileSync(pidFile, 'utf-8'));
-        var killed = 0;
-        for (var i = 0; i < pids.length; i++) {
-          try { process.kill(pids[i].pid, 0); } catch (e) { continue; }
-          try { process.kill(pids[i].pid, 'SIGTERM'); killed++; } catch (e) { /* ok */ }
-        }
-        fs.unlinkSync(pidFile);
-        if (killed > 0) console.log('[CLEANUP] Killed ' + killed + ' background process(es)');
-      }
-    } catch (e) { /* non-fatal */ }
-    // Remove session-restore lock
-    try { if (fs.existsSync(lockFile)) fs.unlinkSync(lockFile); } catch (e) { /* ok */ }
+      var cleanup = require(path.join(projectDir, 'node_modules', 'moflo', 'bin', 'lib', 'registry-cleanup.cjs'));
+      var killed = cleanup.killTrackedSync(projectDir);
+      if (killed > 0) console.log('[CLEANUP] Killed ' + killed + ' background process(es)');
+    } catch (e) {
+      // Fallback: try local bin/ (for moflo repo itself)
+      try {
+        var cleanup2 = require(path.join(projectDir, 'bin', 'lib', 'registry-cleanup.cjs'));
+        var killed2 = cleanup2.killTrackedSync(projectDir);
+        if (killed2 > 0) console.log('[CLEANUP] Killed ' + killed2 + ' background process(es)');
+      } catch (e2) { /* non-fatal */ }
+    }
 
     if (intelligence && intelligence.consolidate) {
       try {
@@ -368,7 +322,7 @@ const handlers = {
 
 if (command && handlers[command]) {
     try {
-      handlers[command]();
+      await handlers[command]();
     } catch (e) {
       console.log('[WARN] Hook ' + command + ' encountered an error: ' + e.message);
     }

--- a/bin/hook-handler.cjs
+++ b/bin/hook-handler.cjs
@@ -63,9 +63,16 @@ readStdin().then(function(stdinData) {
       bumpMetric('tasksCompleted');
       console.log('[OK] Task completed');
       break;
-    case 'session-end':
+    case 'session-end': {
+      // Kill tracked background processes via shared sync helper
+      try {
+        var cleanup = require('./lib/registry-cleanup.cjs');
+        var killed = cleanup.killTrackedSync(PROJECT_DIR);
+        if (killed > 0) console.log('[CLEANUP] Killed ' + killed + ' background process(es)');
+      } catch (e) { /* non-fatal: cleanup module not available */ }
       console.log('[OK] Session ended');
       break;
+    }
     case 'notification':
       // Silent — just acknowledge
       break;

--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -23,11 +23,13 @@ import { spawn } from 'child_process';
 import { existsSync, appendFileSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { createProcessManager } from './lib/process-manager.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = resolve(__dirname, '../..');
 const logFile = resolve(projectRoot, '.swarm/hooks.log');
+const pm = createProcessManager(projectRoot);
 
 // Parse command line args
 const args = process.argv.slice(2);
@@ -318,6 +320,12 @@ async function main() {
       }
 
       case 'session-end': {
+        // Kill all tracked background processes before ending session
+        const killResult = pm.killAll();
+        if (killResult.killed > 0) {
+          log('info', `Killed ${killResult.killed} background process(es) on session end`);
+        }
+
         // Run ReasoningBank and MicroLoRA training in background on session end
         log('info', 'Session ending - starting background learning...');
 
@@ -397,19 +405,15 @@ async function runIndexGuidance(specificFile = null) {
   return 0;
 }
 
-// Spawn a background process that's truly windowless on Windows
+// Spawn a background process via the shared ProcessManager (dedup + PID tracking).
 function spawnWindowless(cmd, args, description) {
-  const proc = spawn(cmd, args, {
-    cwd: projectRoot,
-    stdio: 'ignore',
-    detached: true,
-    shell: false,
-    windowsHide: true
-  });
-
-  proc.unref();
-  log('info', `Started ${description} (PID: ${proc.pid})`);
-  return proc;
+  const result = pm.spawn(cmd, args, description);
+  if (result.skipped) {
+    log('info', `Skipped ${description} (already running, PID: ${result.pid})`);
+  } else if (result.pid) {
+    log('info', `Started ${description} (PID: ${result.pid})`);
+  }
+  return result;
 }
 
 // Resolve a moflo npm bin script, falling back to local .claude/scripts/ copy

--- a/bin/lib/process-manager.mjs
+++ b/bin/lib/process-manager.mjs
@@ -1,0 +1,241 @@
+/**
+ * Shared background process manager for moflo.
+ *
+ * All background spawn paths (hooks.mjs, hook-handler.cjs, session-start-launcher.mjs)
+ * delegate here so that PID tracking, dedup, and cleanup happen in one place.
+ *
+ * API:
+ *   spawn(cmd, args, label)  — spawn with label-based dedup + PID tracking
+ *   killAll()                — SIGTERM every tracked process, prune registry
+ *   getActive()              — list currently alive tracked processes
+ *   prune()                  — remove dead entries from registry
+ *
+ * Registry: .claude-flow/background-pids.json
+ * Lock:     .claude-flow/spawn.lock  (30 s TTL — prevents thundering-herd)
+ */
+
+import { spawn } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync, statSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const LOCK_TTL_MS = 30_000;
+
+/** Resolve the project root (two levels up from bin/lib/). */
+function defaultRoot() {
+  return resolve(__dirname, '../..');
+}
+
+/** Ensure .claude-flow/ directory exists. */
+function ensureDir(dir) {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+/** Check if a PID is alive (cross-platform). */
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Registry I/O ────────────────────────────────────────────────────────────
+
+function registryPath(root) {
+  return resolve(root, '.claude-flow', 'background-pids.json');
+}
+
+function lockPath(root) {
+  return resolve(root, '.claude-flow', 'spawn.lock');
+}
+
+function readRegistry(root) {
+  const p = registryPath(root);
+  if (!existsSync(p)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf-8'));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Atomic write: write to tmp file then rename to avoid torn reads. */
+function writeRegistry(root, entries) {
+  const p = registryPath(root);
+  const tmp = p + '.tmp.' + process.pid;
+  ensureDir(dirname(p));
+  writeFileSync(tmp, JSON.stringify(entries, null, 2));
+  renameSync(tmp, p);
+}
+
+// ── Lock (30 s TTL) ────────────────────────────────────────────────────────
+
+function checkLock(root) {
+  const lp = lockPath(root);
+  if (!existsSync(lp)) return false;
+  try {
+    const age = Date.now() - statSync(lp).mtimeMs;
+    return age < LOCK_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+/** Atomic lock acquisition using exclusive-create flag. */
+function writeLock(root) {
+  const lp = lockPath(root);
+  ensureDir(dirname(lp));
+  try {
+    writeFileSync(lp, String(Date.now()), { flag: 'wx' });
+  } catch {
+    // File already exists — overwrite if stale, otherwise skip
+    try {
+      const age = Date.now() - statSync(lp).mtimeMs;
+      if (age >= LOCK_TTL_MS) {
+        unlinkSync(lp);
+        writeFileSync(lp, String(Date.now()), { flag: 'wx' });
+      }
+    } catch { /* lost race on stale cleanup — non-fatal */ }
+  }
+}
+
+function clearLock(root) {
+  const lp = lockPath(root);
+  try {
+    if (existsSync(lp)) unlinkSync(lp);
+  } catch { /* non-fatal */ }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Create a ProcessManager bound to a project root.
+ * @param {string} [root] — project root (defaults to two levels above bin/lib/)
+ */
+export function createProcessManager(root) {
+  const projectRoot = root || defaultRoot();
+
+  return {
+    /**
+     * Spawn a background process with label-based dedup and PID tracking.
+     *
+     * If a process with the same `label` is already alive, the spawn is skipped.
+     *
+     * @param {string} cmd   — executable (e.g. 'node')
+     * @param {string[]} args — arguments
+     * @param {string} label — unique label for dedup (e.g. 'index-guidance')
+     * @returns {{ pid: number|null, skipped: boolean }}
+     */
+    spawn(cmd, args, label) {
+      // Dedup: skip if same label is already alive
+      const entries = readRegistry(projectRoot);
+      const existing = entries.find(e => e.label === label);
+      if (existing && isAlive(existing.pid)) {
+        return { pid: existing.pid, skipped: true };
+      }
+
+      try {
+        const proc = spawn(cmd, args, {
+          cwd: projectRoot,
+          stdio: 'ignore',
+          detached: true,
+          shell: false,
+          windowsHide: true,
+        });
+
+        proc.unref();
+
+        if (proc.pid) {
+          // Remove any stale entry with the same label, then append new
+          const fresh = entries.filter(e => e.label !== label);
+          fresh.push({
+            pid: proc.pid,
+            label,
+            cmd: `${cmd} ${args.join(' ')}`.substring(0, 200),
+            startedAt: new Date().toISOString(),
+          });
+          writeRegistry(projectRoot, fresh);
+        }
+
+        return { pid: proc.pid || null, skipped: false };
+      } catch {
+        return { pid: null, skipped: false };
+      }
+    },
+
+    /**
+     * Kill all tracked background processes.
+     * @returns {{ killed: number, total: number }}
+     */
+    killAll() {
+      const entries = readRegistry(projectRoot);
+      let killed = 0;
+
+      for (const entry of entries) {
+        if (!isAlive(entry.pid)) continue;
+        try {
+          process.kill(entry.pid, 'SIGTERM');
+          killed++;
+        } catch { /* already gone */ }
+      }
+
+      // Clear registry and lock
+      writeRegistry(projectRoot, []);
+      clearLock(projectRoot);
+
+      return { killed, total: entries.length };
+    },
+
+    /**
+     * Return list of currently alive tracked processes.
+     * @returns {Array<{ pid: number, label: string, cmd: string, startedAt: string }>}
+     */
+    getActive() {
+      const entries = readRegistry(projectRoot);
+      return entries.filter(e => isAlive(e.pid));
+    },
+
+    /**
+     * Remove dead entries from the registry.
+     * @returns {{ pruned: number, remaining: number }}
+     */
+    prune() {
+      const entries = readRegistry(projectRoot);
+      const alive = entries.filter(e => isAlive(e.pid));
+      writeRegistry(projectRoot, alive);
+      return { pruned: entries.length - alive.length, remaining: alive.length };
+    },
+
+    /**
+     * Check if the spawn lock is held (another session-restore spawned recently).
+     */
+    isLocked() {
+      return checkLock(projectRoot);
+    },
+
+    /**
+     * Acquire the spawn lock (30 s TTL).
+     */
+    acquireLock() {
+      writeLock(projectRoot);
+    },
+
+    /**
+     * Release the spawn lock.
+     */
+    releaseLock() {
+      clearLock(projectRoot);
+    },
+
+    /** Expose the project root for callers that need it. */
+    get root() {
+      return projectRoot;
+    },
+  };
+}

--- a/bin/lib/registry-cleanup.cjs
+++ b/bin/lib/registry-cleanup.cjs
@@ -1,0 +1,41 @@
+/**
+ * Synchronous cleanup of the ProcessManager background-pids registry.
+ *
+ * Safe to call from CJS hooks that run under process.exit() — no async,
+ * no ESM imports, pure fs + process.kill.
+ *
+ * Used by: .claude/helpers/hook-handler.cjs, bin/hook-handler.cjs (session-end)
+ */
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+/**
+ * Kill all tracked background processes and clear the registry.
+ * @param {string} projectDir - absolute path to the project root
+ * @returns {number} count of processes killed
+ */
+function killTrackedSync(projectDir) {
+  var pidFile = path.join(projectDir, '.claude-flow', 'background-pids.json');
+  var lockFile = path.join(projectDir, '.claude-flow', 'spawn.lock');
+  var killed = 0;
+
+  try {
+    if (fs.existsSync(pidFile)) {
+      var entries = JSON.parse(fs.readFileSync(pidFile, 'utf-8'));
+      if (!Array.isArray(entries)) entries = [];
+      for (var i = 0; i < entries.length; i++) {
+        try { process.kill(entries[i].pid, 0); } catch (e) { continue; }
+        try { process.kill(entries[i].pid, 'SIGTERM'); killed++; } catch (e) { /* ok */ }
+      }
+      fs.writeFileSync(pidFile, '[]');
+    }
+  } catch (e) { /* non-fatal */ }
+
+  try { if (fs.existsSync(lockFile)) fs.unlinkSync(lockFile); } catch (e) { /* ok */ }
+
+  return killed;
+}
+
+module.exports = { killTrackedSync };

--- a/src/@claude-flow/cli/src/commands/doctor.ts
+++ b/src/@claude-flow/cli/src/commands/doctor.ts
@@ -7,7 +7,7 @@
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
-import { existsSync, readFileSync, statSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync, exec } from 'child_process';
@@ -655,6 +655,37 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+// Fast path: kill processes tracked in the shared ProcessManager registry.
+// This avoids the expensive OS-level process scan for known background tasks.
+function killTrackedProcesses(): number {
+  const registryFile = join(process.cwd(), '.claude-flow', 'background-pids.json');
+  const lockFile = join(process.cwd(), '.claude-flow', 'spawn.lock');
+  let killed = 0;
+  try {
+    if (existsSync(registryFile)) {
+      const entries = JSON.parse(readFileSync(registryFile, 'utf-8'));
+      for (const entry of entries) {
+        if (!isProcessAlive(entry.pid)) continue;
+        try {
+          if (process.platform === 'win32') {
+            execSync(`taskkill /F /PID ${entry.pid}`, { timeout: 5000, windowsHide: true });
+          } else {
+            process.kill(entry.pid, 'SIGKILL');
+          }
+          killed++;
+        } catch { /* already gone */ }
+      }
+      // Clear registry
+      writeFileSync(registryFile, '[]');
+    }
+  } catch { /* non-fatal */ }
+  // Remove spawn lock
+  try {
+    if (existsSync(lockFile)) unlinkSync(lockFile);
+  } catch { /* ok */ }
+  return killed;
+}
+
 // Find and optionally kill orphaned moflo/claude-flow node processes.
 // A process is only "orphaned" if its parent is no longer alive — meaning
 // nothing will clean it up. MCP servers spawned by a live Claude Code session
@@ -809,13 +840,21 @@ export const doctorCommand: Command = {
       output.writeln(output.bold('Zombie Process Scan'));
       output.writeln();
 
-      // First scan without killing to show what would be killed
+      // Fast path: kill tracked processes from the shared registry first
+      const registryKilled = killTrackedProcesses();
+      if (registryKilled > 0) {
+        output.writeln(output.success(`  Killed ${registryKilled} tracked background process(es) from registry`));
+      }
+
+      // Slow path: OS-level scan for any remaining orphans
       const scan = await findZombieProcesses(false);
 
       if (scan.found === 0) {
-        output.writeln(output.success('  No orphaned moflo processes found'));
+        if (registryKilled === 0) {
+          output.writeln(output.success('  No orphaned moflo processes found'));
+        }
       } else {
-        output.writeln(output.warning(`  Found ${scan.found} orphaned process(es): PIDs ${scan.pids.join(', ')}`));
+        output.writeln(output.warning(`  Found ${scan.found} additional orphaned process(es): PIDs ${scan.pids.join(', ')}`));
 
         // Kill them
         const result = await findZombieProcesses(true);

--- a/tests/bin/process-manager.test.ts
+++ b/tests/bin/process-manager.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for bin/lib/process-manager.mjs
+ *
+ * Covers: spawn, dedup, killAll, getActive, prune, lock guard.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, writeFileSync, utimesSync, mkdirSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { pathToFileURL } from 'url';
+import { execFileSync } from 'child_process';
+
+// We test via a small Node script that imports the ESM module,
+// since vitest may run in CJS mode and can't directly import .mjs.
+const BIN_LIB = resolve(__dirname, '../../bin/lib');
+const PM_PATH = resolve(BIN_LIB, 'process-manager.mjs');
+
+/** Create an isolated temp project root for each test. */
+function makeTempRoot(): string {
+  const root = resolve(__dirname, '../../.test-pm-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
+  mkdirSync(resolve(root, '.claude-flow'), { recursive: true });
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* ok */ }
+}
+
+/** Run a snippet that imports process-manager.mjs and returns JSON output. */
+function runPM(root: string, code: string): any {
+  const pmURL = pathToFileURL(PM_PATH).href;
+  const script = `
+    import { createProcessManager } from '${pmURL}';
+    const pm = createProcessManager('${root.replace(/\\/g, '/')}');
+    const result = await (async () => { ${code} })();
+    process.stdout.write(JSON.stringify(result));
+  `;
+  const out = execFileSync('node', ['--input-type=module', '-e', script], {
+    encoding: 'utf-8',
+    timeout: 10000,
+    cwd: root,
+  });
+  return JSON.parse(out.trim());
+}
+
+describe('process-manager.mjs', () => {
+  it('exists on disk', () => {
+    expect(existsSync(PM_PATH)).toBe(true);
+  });
+
+  it('parses as valid ESM', () => {
+    try {
+      execFileSync('node', ['--check', PM_PATH], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (err: any) {
+      throw new Error(`Syntax error: ${err.stderr || err.message}`);
+    }
+  });
+});
+
+describe('spawn()', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot(); });
+  afterEach(() => { cleanTempRoot(root); });
+
+  it('spawns a process and tracks PID in registry', () => {
+    // Spawn a long-running sleep process
+    const result = runPM(root, `
+      const r = pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'test-sleep');
+      return { pid: r.pid, skipped: r.skipped };
+    `);
+    expect(result.pid).toBeGreaterThan(0);
+    expect(result.skipped).toBe(false);
+
+    // Verify registry
+    const registry = JSON.parse(readFileSync(join(root, '.claude-flow', 'background-pids.json'), 'utf-8'));
+    expect(registry).toHaveLength(1);
+    expect(registry[0].label).toBe('test-sleep');
+    expect(registry[0].pid).toBe(result.pid);
+
+    // Cleanup: kill the spawned process
+    try { process.kill(result.pid, 'SIGTERM'); } catch { /* ok */ }
+  });
+
+  it('deduplicates by label when process is still alive', () => {
+    // Spawn first
+    const r1 = runPM(root, `
+      const r = pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'dedup-test');
+      return { pid: r.pid, skipped: r.skipped };
+    `);
+    expect(r1.skipped).toBe(false);
+
+    // Spawn again with same label — should be skipped
+    const r2 = runPM(root, `
+      const r = pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'dedup-test');
+      return { pid: r.pid, skipped: r.skipped };
+    `);
+    expect(r2.skipped).toBe(true);
+    expect(r2.pid).toBe(r1.pid);
+
+    // Cleanup
+    try { process.kill(r1.pid, 'SIGTERM'); } catch { /* ok */ }
+  });
+
+  it('allows respawn after previous process dies', () => {
+    // Spawn a process that exits immediately
+    const r1 = runPM(root, `
+      const r = pm.spawn('node', ['-e', 'process.exit(0)'], 'short-lived');
+      return { pid: r.pid };
+    `);
+
+    // Wait a moment for it to exit
+    try { execFileSync('node', ['-e', 'setTimeout(()=>{},500)'], { timeout: 2000 }); } catch { /* ok */ }
+
+    // Respawn with same label should succeed (not skipped)
+    const r2 = runPM(root, `
+      const r = pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'short-lived');
+      return { pid: r.pid, skipped: r.skipped };
+    `);
+    expect(r2.skipped).toBe(false);
+    expect(r2.pid).not.toBe(r1.pid);
+
+    // Cleanup
+    try { process.kill(r2.pid, 'SIGTERM'); } catch { /* ok */ }
+  });
+});
+
+describe('killAll()', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot(); });
+  afterEach(() => { cleanTempRoot(root); });
+
+  it('kills all tracked processes and clears registry', () => {
+    // Spawn two processes
+    runPM(root, `
+      pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'kill-a');
+      pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'kill-b');
+      return true;
+    `);
+
+    const regBefore = JSON.parse(readFileSync(join(root, '.claude-flow', 'background-pids.json'), 'utf-8'));
+    expect(regBefore).toHaveLength(2);
+
+    // Kill all
+    const result = runPM(root, `return pm.killAll();`);
+    expect(result.killed).toBe(2);
+
+    // Registry should be empty
+    const regAfter = JSON.parse(readFileSync(join(root, '.claude-flow', 'background-pids.json'), 'utf-8'));
+    expect(regAfter).toHaveLength(0);
+  });
+});
+
+describe('getActive() and prune()', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot(); });
+  afterEach(() => { cleanTempRoot(root); });
+
+  it('getActive returns only alive processes', () => {
+    // Spawn one that stays alive and one that exits
+    runPM(root, `
+      pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'alive');
+      pm.spawn('node', ['-e', 'process.exit(0)'], 'dead');
+      return true;
+    `);
+
+    // Wait for the short-lived one to exit
+    try { execFileSync('node', ['-e', 'setTimeout(()=>{},500)'], { timeout: 2000 }); } catch { /* ok */ }
+
+    const active = runPM(root, `return pm.getActive();`);
+    expect(active.length).toBe(1);
+    expect(active[0].label).toBe('alive');
+
+    // Cleanup
+    try { process.kill(active[0].pid, 'SIGTERM'); } catch { /* ok */ }
+  });
+
+  it('prune removes dead entries', () => {
+    // Seed registry with a fake dead PID
+    writeFileSync(
+      join(root, '.claude-flow', 'background-pids.json'),
+      JSON.stringify([{ pid: 99999999, label: 'ghost', cmd: 'node -e ...', startedAt: new Date().toISOString() }]),
+    );
+
+    const result = runPM(root, `return pm.prune();`);
+    expect(result.pruned).toBe(1);
+    expect(result.remaining).toBe(0);
+  });
+});
+
+describe('lock guard', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot(); });
+  afterEach(() => { cleanTempRoot(root); });
+
+  it('acquires and checks lock', () => {
+    const r1 = runPM(root, `
+      const before = pm.isLocked();
+      pm.acquireLock();
+      const after = pm.isLocked();
+      return { before, after };
+    `);
+    expect(r1.before).toBe(false);
+    expect(r1.after).toBe(true);
+  });
+
+  it('lock expires after TTL (simulated by backdating mtime)', () => {
+    // Write a lock file, then backdate its mtime by 60s
+    const lockFile = join(root, '.claude-flow', 'spawn.lock');
+    writeFileSync(lockFile, String(Date.now()));
+    const past = new Date(Date.now() - 60000);
+    utimesSync(lockFile, past, past);
+
+    const result = runPM(root, `return pm.isLocked();`);
+    expect(result).toBe(false);
+  });
+
+  it('killAll releases the lock', () => {
+    runPM(root, `pm.acquireLock(); return true;`);
+    expect(existsSync(join(root, '.claude-flow', 'spawn.lock'))).toBe(true);
+
+    runPM(root, `pm.killAll(); return true;`);
+    expect(existsSync(join(root, '.claude-flow', 'spawn.lock'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Consolidates 3 independent background spawn paths into a single shared `ProcessManager` module (`bin/lib/process-manager.mjs`)
- Extracts synchronous CJS cleanup helper (`bin/lib/registry-cleanup.cjs`) for session-end handlers
- Wires `doctor --kill-zombies` fast-path through the shared registry before expensive OS-level process scan
- Adds atomic lock acquisition (`wx` flag) and atomic registry writes (tmp+rename) to prevent TOCTOU races

## Changes

| File | Change |
|------|--------|
| `bin/lib/process-manager.mjs` | **NEW** — shared ESM module: spawn (dedup), killAll, getActive, prune, lock |
| `bin/lib/registry-cleanup.cjs` | **NEW** — shared CJS sync cleanup for session-end |
| `bin/hooks.mjs` | Delegates to ProcessManager, adds killAll on session-end |
| `.claude/helpers/hook-handler.cjs` | Replaces ~60 lines inline spawn/PID/lock with PM calls |
| `bin/hook-handler.cjs` | Adds session-end cleanup via shared helper |
| `doctor.ts` | Fast-path registry kill before OS-level zombie scan |
| `tests/bin/process-manager.test.ts` | **NEW** — 11 tests: spawn, dedup, killAll, prune, lock guard |

## Testing

- [x] 11 new unit tests for process-manager (spawn, dedup, killAll, getActive, prune, lock TTL, lock release)
- [x] All 97 existing bin/ tests pass
- [x] Syntax check passes on all modified files

Closes #41

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)