### PR TITLE
feat: rename MCP server from claude-flow to moflo

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -307,7 +307,7 @@ Then in Claude Code:
 
 ```bash
 # Add MCP servers to Claude Code
-claude mcp add claude-flow npx claude-flow@alpha mcp start
+claude mcp add moflo npx moflo mcp start
 claude mcp add ruv-swarm npx ruv-swarm mcp start  # Optional
 claude mcp add flow-nexus npx flow-nexus@latest mcp start  # Optional
 ```
@@ -509,9 +509,9 @@ Claude Flow integrates with 3 MCP servers providing 110+ tools:
 ```json
 {
   "mcpServers": {
-    "claude-flow": {
+    "moflo": {
       "command": "npx",
-      "args": ["claude-flow@alpha", "mcp", "start"]
+      "args": ["moflo", "mcp", "start"]
     }
   }
 }

--- a/.claude-plugin/docs/PLUGIN_SUMMARY.md
+++ b/.claude-plugin/docs/PLUGIN_SUMMARY.md
@@ -104,7 +104,7 @@ cd claude-flow
 
 ### MCP Integration: 110+ Tools
 
-1. **claude-flow** (Required)
+1. **moflo** (Required)
    - 40+ orchestration tools
    - Swarm coordination
    - Agent management
@@ -338,9 +338,9 @@ The plugin is configured via `.claude-plugin/plugin.json`:
     "url": "https://github.com/eric-cielo/moflo.git"
   },
   "mcpServers": {
-    "claude-flow": {
+    "moflo": {
       "command": "npx",
-      "args": ["claude-flow@alpha", "mcp", "start"]
+      "args": ["moflo", "mcp", "start"]
     }
   }
 }

--- a/.claude-plugin/docs/QUICKSTART.md
+++ b/.claude-plugin/docs/QUICKSTART.md
@@ -202,7 +202,7 @@ The swarm automatically:
 
 ```bash
 # Core MCP (required)
-claude mcp add claude-flow npx claude-flow@alpha mcp start
+claude mcp add moflo npx moflo mcp start
 
 # Enhanced coordination (optional)
 claude mcp add ruv-swarm npx ruv-swarm mcp start
@@ -216,7 +216,7 @@ claude mcp add flow-nexus npx flow-nexus@latest mcp start
 In Claude Code:
 
 ```
-List available MCP tools for claude-flow
+List available MCP tools for moflo
 ```
 
 Expected: 40+ tools including:
@@ -297,10 +297,10 @@ ls ~/.claude/commands/
 cat ~/.claude/settings.json
 
 # Verify MCP package
-npx claude-flow@alpha --version
+npx moflo --version
 
 # Reinstall if needed
-npm install -g claude-flow@alpha
+npm install -g moflo
 ```
 
 ### Agents Not Spawning

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,10 +72,10 @@
         "node": ">=20.0.0"
       },
       "mcpServers": {
-        "claude-flow": {
+        "moflo": {
           "command": "npx",
-          "args": ["claude-flow@alpha", "mcp", "start"],
-          "description": "Core Claude Flow MCP server for swarm coordination (40+ tools)",
+          "args": ["moflo", "mcp", "start"],
+          "description": "Core MoFlo MCP server for swarm coordination (40+ tools)",
           "optional": false
         },
         "ruv-swarm": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -49,10 +49,10 @@
     "node": ">=20.0.0"
   },
   "mcpServers": {
-    "claude-flow": {
+    "moflo": {
       "command": "npx",
-      "args": ["claude-flow@alpha", "mcp", "start"],
-      "description": "Core Claude Flow MCP server for swarm coordination, agent management, and task orchestration (40+ tools)",
+      "args": ["moflo", "mcp", "start"],
+      "description": "Core MoFlo MCP server for swarm coordination, agent management, and task orchestration (40+ tools)",
       "optional": false
     },
     "ruv-swarm": {

--- a/.claude-plugin/scripts/install.sh
+++ b/.claude-plugin/scripts/install.sh
@@ -135,15 +135,15 @@ if [ "$INSTALL_TYPE" = "1" ] || [ "$INSTALL_TYPE" = "4" ]; then
         cat > "$SETTINGS_FILE" << 'SETTINGS_EOF'
 {
   "mcpServers": {
-    "claude-flow": {
+    "moflo": {
       "command": "npx",
-      "args": ["claude-flow@alpha", "mcp", "start"],
-      "description": "Core Claude Flow MCP server with 40+ orchestration tools"
+      "args": ["moflo", "mcp", "start"],
+      "description": "Core MoFlo MCP server with 40+ orchestration tools"
     }
   }
 }
 SETTINGS_EOF
-        success "Created settings.json with Claude Flow MCP server"
+        success "Created settings.json with MoFlo MCP server"
     else
         info "Settings file exists. Please manually add MCP servers:"
         echo ""
@@ -152,9 +152,9 @@ Add to ~/.claude/settings.json:
 
 {
   "mcpServers": {
-    "claude-flow": {
+    "moflo": {
       "command": "npx",
-      "args": ["claude-flow@alpha", "mcp", "start"]
+      "args": ["moflo", "mcp", "start"]
     },
     "ruv-swarm": {
       "command": "npx",
@@ -175,9 +175,9 @@ MCP_INSTRUCTIONS
     INSTALL_MCP=${INSTALL_MCP:-y}
 
     if [ "$INSTALL_MCP" = "y" ]; then
-        info "Installing claude-flow MCP server..."
-        npx claude-flow@alpha --version 2>/dev/null || npm install -g claude-flow@alpha
-        success "Claude Flow MCP server installed"
+        info "Installing moflo MCP server..."
+        npx moflo --version 2>/dev/null || npm install -g moflo
+        success "MoFlo MCP server installed"
 
         read -p "Install optional ruv-swarm MCP? (y/n) [n]: " INSTALL_RUV
         if [ "$INSTALL_RUV" = "y" ]; then

--- a/.claude-plugin/scripts/verify.sh
+++ b/.claude-plugin/scripts/verify.sh
@@ -56,10 +56,10 @@ info "Checking Claude Code settings..."
 if [ -f "$HOME/.claude/settings.json" ]; then
     success "Settings file exists"
 
-    if grep -q "claude-flow" "$HOME/.claude/settings.json"; then
-        success "Claude Flow MCP server configured"
+    if grep -q '"moflo"' "$HOME/.claude/settings.json" || grep -q '"claude-flow"' "$HOME/.claude/settings.json"; then
+        success "MoFlo MCP server configured"
     else
-        warning "Claude Flow MCP server not configured"
+        warning "MoFlo MCP server not configured"
         ((WARNINGS++))
     fi
 else
@@ -69,11 +69,11 @@ fi
 
 # Check MCP packages
 info "Checking MCP packages..."
-if npx claude-flow@alpha --version &> /dev/null; then
-    VERSION=$(npx claude-flow@alpha --version 2>/dev/null || echo "unknown")
-    success "claude-flow MCP: $VERSION"
+if npx moflo --version &> /dev/null; then
+    VERSION=$(npx moflo --version 2>/dev/null || echo "unknown")
+    success "moflo MCP: $VERSION"
 else
-    warning "claude-flow MCP not installed"
+    warning "moflo MCP not installed"
     ((WARNINGS++))
 fi
 

--- a/.claude/agents/core/coder.md
+++ b/.claude/agents/core/coder.md
@@ -205,7 +205,7 @@ src/
 ### Memory Coordination
 ```javascript
 // Report implementation status
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/coder/status",
   namespace: "coordination",
@@ -219,7 +219,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Share code decisions
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/implementation",
   namespace: "coordination",
@@ -232,7 +232,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Check dependencies
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "swarm/shared/dependencies",
   namespace: "coordination"
@@ -242,13 +242,13 @@ mcp__claude-flow__memory_usage {
 ### Performance Monitoring
 ```javascript
 // Track implementation metrics
-mcp__claude-flow__benchmark_run {
+mcp__moflo__benchmark_run {
   type: "code",
   iterations: 10
 }
 
 // Analyze bottlenecks
-mcp__claude-flow__bottleneck_analyze {
+mcp__moflo__bottleneck_analyze {
   component: "api-endpoint",
   metrics: ["response-time", "memory-usage"]
 }

--- a/.claude/agents/core/planner.md
+++ b/.claude/agents/core/planner.md
@@ -118,7 +118,7 @@ plan:
 ### Task Orchestration
 ```javascript
 // Orchestrate complex tasks
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Implement authentication system",
   strategy: "parallel",
   priority: "high",
@@ -126,7 +126,7 @@ mcp__claude-flow__task_orchestrate {
 }
 
 // Share task breakdown
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/planner/task-breakdown",
   namespace: "coordination",
@@ -143,7 +143,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Monitor task progress
-mcp__claude-flow__task_status {
+mcp__moflo__task_status {
   taskId: "auth-implementation"
 }
 ```
@@ -151,7 +151,7 @@ mcp__claude-flow__task_status {
 ### Memory Coordination
 ```javascript
 // Report planning status
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/planner/status",
   namespace: "coordination",

--- a/.claude/agents/core/researcher.md
+++ b/.claude/agents/core/researcher.md
@@ -123,7 +123,7 @@ read specific-file.ts
 ### Memory Coordination
 ```javascript
 // Report research status
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/researcher/status",
   namespace: "coordination",
@@ -137,7 +137,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Share research findings
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/research-findings",
   namespace: "coordination",
@@ -150,7 +150,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Check prior research
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "swarm/shared/research-*",
   namespace: "coordination",
   limit: 10
@@ -160,13 +160,13 @@ mcp__claude-flow__memory_search {
 ### Analysis Tools
 ```javascript
 // Analyze codebase
-mcp__claude-flow__github_repo_analyze {
+mcp__moflo__github_repo_analyze {
   repo: "current",
   analysis_type: "code_quality"
 }
 
 // Track research metrics
-mcp__claude-flow__agent_metrics {
+mcp__moflo__agent_metrics {
   agentId: "researcher"
 }
 ```

--- a/.claude/agents/core/reviewer.md
+++ b/.claude/agents/core/reviewer.md
@@ -274,7 +274,7 @@ npm run complexity-check
 ### Memory Coordination
 ```javascript
 // Report review status
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/reviewer/status",
   namespace: "coordination",
@@ -288,7 +288,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Share review findings
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/review-findings",
   namespace: "coordination",
@@ -301,7 +301,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Check implementation details
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "swarm/coder/status",
   namespace: "coordination"
@@ -311,13 +311,13 @@ mcp__claude-flow__memory_usage {
 ### Code Analysis
 ```javascript
 // Analyze code quality
-mcp__claude-flow__github_repo_analyze {
+mcp__moflo__github_repo_analyze {
   repo: "current",
   analysis_type: "code_quality"
 }
 
 // Run security scan
-mcp__claude-flow__github_repo_analyze {
+mcp__moflo__github_repo_analyze {
   repo: "current",
   analysis_type: "security"
 }

--- a/.claude/agents/core/tester.md
+++ b/.claude/agents/core/tester.md
@@ -258,7 +258,7 @@ describe('Security', () => {
 ### Memory Coordination
 ```javascript
 // Report test status
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/tester/status",
   namespace: "coordination",
@@ -271,7 +271,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Share test results
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/test-results",
   namespace: "coordination",
@@ -284,7 +284,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Check implementation status
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "swarm/coder/status",
   namespace: "coordination"
@@ -294,13 +294,13 @@ mcp__claude-flow__memory_usage {
 ### Performance Testing
 ```javascript
 // Run performance benchmarks
-mcp__claude-flow__benchmark_run {
+mcp__moflo__benchmark_run {
   type: "test",
   iterations: 100
 }
 
 // Monitor test execution
-mcp__claude-flow__performance_report {
+mcp__moflo__performance_report {
   format: "detailed"
 }
 ```

--- a/.claude/agents/dual-mode/codex-coordinator.md
+++ b/.claude/agents/dual-mode/codex-coordinator.md
@@ -162,7 +162,7 @@ mcp__ruv-swarm__swarm_init {
 ### Track Worker Status
 ```javascript
 // Store coordination state
-mcp__claude-flow__memory_store {
+mcp__moflo__memory_store {
   key: "coordination/parallel-task",
   value: JSON.stringify({
     workers: ["worker-1", "worker-2", "worker-3"],
@@ -176,7 +176,7 @@ mcp__claude-flow__memory_store {
 ### Aggregate Results
 ```javascript
 // Collect all worker results
-mcp__claude-flow__memory_list {
+mcp__moflo__memory_list {
   namespace: "results"
 }
 ```

--- a/.claude/agents/dual-mode/codex-worker.md
+++ b/.claude/agents/dual-mode/codex-worker.md
@@ -67,7 +67,7 @@ You are a headless Codex worker executing in background mode. You run independen
 ### Before Starting Task
 ```javascript
 // 1. Search for relevant patterns
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   query: "keywords from task",
   namespace: "patterns",
   limit: 5
@@ -80,7 +80,7 @@ mcp__claude-flow__memory_search {
 ### After Completing Task
 ```javascript
 // 3. Store what worked for future workers
-mcp__claude-flow__memory_store {
+mcp__moflo__memory_store {
   key: "pattern-[task-type]",
   value: JSON.stringify({
     approach: "what worked",
@@ -91,7 +91,7 @@ mcp__claude-flow__memory_store {
 }
 
 // 4. Store result for coordinator
-mcp__claude-flow__memory_store {
+mcp__moflo__memory_store {
   key: "result-[session-id]",
   value: JSON.stringify({
     status: "complete",
@@ -173,13 +173,13 @@ Store findings in memory.
 ### Available Tools
 ```javascript
 // Search for patterns before starting
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   query: "[task keywords]",
   namespace: "patterns"
 }
 
 // Store results and patterns
-mcp__claude-flow__memory_store {
+mcp__moflo__memory_store {
   key: "[result-key]",
   value: "[json-value]",
   namespace: "results",

--- a/.claude/agents/dual-mode/dual-orchestrator.md
+++ b/.claude/agents/dual-mode/dual-orchestrator.md
@@ -219,8 +219,8 @@ const decideRouting = (task) => {
 ### Shared Tools (Both Platforms)
 ```javascript
 // Both Claude Code and Codex can use these
-mcp__claude-flow__memory_search  // Find patterns
-mcp__claude-flow__memory_store   // Store results
+mcp__moflo__memory_search  // Find patterns
+mcp__moflo__memory_store   // Store results
 mcp__ruv-swarm__swarm_init       // Initialize coordination
 mcp__ruv-swarm__swarm_status     // Check status
 mcp__ruv-swarm__agent_spawn      // Spawn agents
@@ -229,7 +229,7 @@ mcp__ruv-swarm__agent_spawn      // Spawn agents
 ### Coordination Pattern
 ```javascript
 // 1. Store design from interactive phase
-mcp__claude-flow__memory_store {
+mcp__moflo__memory_store {
   key: "design/api-feature",
   value: JSON.stringify({
     endpoints: [...],
@@ -240,13 +240,13 @@ mcp__claude-flow__memory_store {
 }
 
 // 2. Workers read shared design
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   query: "api feature design",
   namespace: "shared"
 }
 
 // 3. Workers store results
-mcp__claude-flow__memory_store {
+mcp__moflo__memory_store {
   key: "result-worker-1",
   value: "implementation complete",
   namespace: "results",

--- a/.claude/agents/github/code-review-swarm.md
+++ b/.claude/agents/github/code-review-swarm.md
@@ -1,7 +1,7 @@
 ---
 name: code-review-swarm
 description: Deploy specialized AI agents to perform comprehensive, intelligent code reviews that go beyond traditional static analysis
-tools: mcp__claude-flow__swarm_init, mcp__claude-flow__agent_spawn, mcp__claude-flow__task_orchestrate, Bash, Read, Write, TodoWrite
+tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__task_orchestrate, Bash, Read, Write, TodoWrite
 color: blue
 type: development
 capabilities:

--- a/.claude/agents/github/github-modes.md
+++ b/.claude/agents/github/github-modes.md
@@ -1,7 +1,7 @@
 ---
 name: github-modes
 description: Comprehensive GitHub integration modes for workflow orchestration, PR management, and repository coordination with batch optimization
-tools: mcp__claude-flow__swarm_init, mcp__claude-flow__agent_spawn, mcp__claude-flow__task_orchestrate, Bash, TodoWrite, Read, Write
+tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__task_orchestrate, Bash, TodoWrite, Read, Write
 color: purple
 type: development
 capabilities:
@@ -163,11 +163,11 @@ All GitHub modes can be enhanced with ruv-swarm coordination:
 
 ```javascript
 // Initialize swarm for GitHub workflow
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
-mcp__claude-flow__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
+mcp__moflo__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
 ```

--- a/.claude/agents/github/issue-tracker.md
+++ b/.claude/agents/github/issue-tracker.md
@@ -1,7 +1,7 @@
 ---
 name: issue-tracker
 description: Intelligent issue management and project coordination with automated tracking, progress monitoring, and team coordination
-tools: mcp__claude-flow__swarm_init, mcp__claude-flow__agent_spawn, mcp__claude-flow__task_orchestrate, mcp__claude-flow__memory_usage, Bash, TodoWrite, Read, Write
+tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__task_orchestrate, mcp__moflo__memory_usage, Bash, TodoWrite, Read, Write
 color: green
 type: development
 capabilities:
@@ -44,7 +44,7 @@ Intelligent issue management and project coordination with ruv-swarm integration
 - `mcp__github__update_issue`
 - `mcp__github__add_issue_comment`
 - `mcp__github__search_issues`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -52,10 +52,10 @@ Intelligent issue management and project coordination with ruv-swarm integration
 ### 1. Create Coordinated Issue with Swarm Tracking
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -80,7 +80,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"
@@ -90,7 +90,7 @@ mcp__claude-flow__task_orchestrate {
 ### 2. Automated Progress Updates
 ```javascript
 // Update issue with progress from swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "issue/54/progress"
 }
@@ -119,7 +119,7 @@ mcp__github__add_issue_comment {
 }
 
 // Store progress in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/54/latest_update",
   value: { timestamp: Date.now(), progress: "89%", status: "near_completion" }
@@ -152,10 +152,10 @@ mcp__github__update_issue {
 ```javascript
 [Single Message - Issue Lifecycle Management]:
   // Initialize issue coordination swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Manager" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Progress Tracker" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Context Gatherer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Manager" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Progress Tracker" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Context Gatherer" }
   
   // Create multiple related issues using gh CLI
   Bash(`gh issue create \
@@ -185,7 +185,7 @@ mcp__github__update_issue {
   ]}
   
   // Store initial coordination state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "project/github_integration/issues",
     value: { created: Date.now(), total_issues: 3, status: "initialized" }

--- a/.claude/agents/github/multi-repo-swarm.md
+++ b/.claude/agents/github/multi-repo-swarm.md
@@ -12,15 +12,15 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_repo_analyze
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_sync_coord
-  - mcp__claude-flow__github_metrics
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_repo_analyze
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_sync_coord
+  - mcp__moflo__github_metrics
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/.claude/agents/github/pr-manager.md
+++ b/.claude/agents/github/pr-manager.md
@@ -12,14 +12,14 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_code_review
-  - mcp__claude-flow__github_metrics
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_code_review
+  - mcp__moflo__github_metrics
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"
@@ -50,10 +50,10 @@ Comprehensive pull request management with swarm coordination for automated revi
 ### 1. Create and Manage PR with Swarm Coordination
 ```javascript
 // Initialize review swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Testing Agent" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Testing Agent" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
 
 // Create PR and orchestrate review
 mcp__github__create_pull_request {
@@ -66,7 +66,7 @@ mcp__github__create_pull_request {
 }
 
 // Orchestrate review process
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review with testing and validation",
   strategy: "parallel",
   priority: "high"
@@ -108,7 +108,7 @@ mcp__github__merge_pull_request {
 }
 
 // Post-merge coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/54/merged",
   value: { timestamp: Date.now(), status: "success" }
@@ -121,10 +121,10 @@ mcp__claude-flow__memory_usage {
 ```javascript
 [Single Message - Complete PR Management]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
   
   // Create and manage PR using gh CLI
   Bash("gh pr create --repo :owner/:repo --title '...' --head '...' --base 'main'")

--- a/.claude/agents/github/project-board-sync.md
+++ b/.claude/agents/github/project-board-sync.md
@@ -12,17 +12,17 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_repo_analyze
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_issue_track
-  - mcp__claude-flow__github_metrics
-  - mcp__claude-flow__workflow_create
-  - mcp__claude-flow__workflow_execute
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_repo_analyze
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_issue_track
+  - mcp__moflo__github_metrics
+  - mcp__moflo__workflow_create
+  - mcp__moflo__workflow_execute
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/.claude/agents/github/release-manager.md
+++ b/.claude/agents/github/release-manager.md
@@ -17,10 +17,10 @@ tools:
   - mcp__github__create_branch
   - mcp__github__push_files
   - mcp__github__create_issue
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
 hooks:
   pre_task: |
     echo "🚀 Initializing release management pipeline..."
@@ -53,12 +53,12 @@ Automated release coordination and deployment with ruv-swarm orchestration for s
 ### 1. Coordinated Release Preparation
 ```javascript
 // Initialize release management swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Coordinator" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Release Coordinator" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
 
 // Create release preparation branch
 mcp__github__create_branch {
@@ -69,7 +69,7 @@ mcp__github__create_branch {
 }
 
 // Orchestrate release preparation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Prepare release v1.0.72 with comprehensive testing and validation",
   strategy: "sequential",
   priority: "critical"
@@ -206,13 +206,13 @@ This release is production-ready with comprehensive validation and testing.
 ```javascript
 [Single Message - Complete Release Management]:
   // Initialize comprehensive release swarm
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 8 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Lead" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Controller" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Performance Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 8 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Lead" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Controller" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Performance Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
   
   // Create release branch and prepare files using gh CLI
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v1.0.72' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
@@ -251,7 +251,7 @@ This release is production-ready with comprehensive validation and testing.
   ]}
   
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store", 
     key: "release/v1.0.72/status",
     value: {

--- a/.claude/agents/github/release-swarm.md
+++ b/.claude/agents/github/release-swarm.md
@@ -17,11 +17,11 @@ tools:
   - mcp__github__create_branch
   - mcp__github__push_files
   - mcp__github__create_issue
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__parallel_execute
-  - mcp__claude-flow__load_balance
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__parallel_execute
+  - mcp__moflo__load_balance
 hooks:
   pre_task: |
     echo "🐝 Initializing release swarm coordination..."

--- a/.claude/agents/github/repo-architect.md
+++ b/.claude/agents/github/repo-architect.md
@@ -19,10 +19,10 @@ tools:
   - mcp__github__search_repositories
   - mcp__github__push_files
   - mcp__github__create_or_update_file
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
 hooks:
   pre_task: |
     echo "🏗️ Initializing repository architecture analysis..."
@@ -55,11 +55,11 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 ### 1. Repository Structure Analysis and Optimization
 ```javascript
 // Initialize architecture analysis swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Repository Architect" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyzer" }
+mcp__moflo__agent_spawn { type: "architect", name: "Repository Architect" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
 
 // Analyze current repository structure
 LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -73,7 +73,7 @@ mcp__github__search_repositories {
 }
 
 // Orchestrate structure optimization
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze and optimize repository structure for scalability and maintainability",
   strategy: "adaptive",
   priority: "medium"
@@ -200,12 +200,12 @@ jobs:
 ```javascript
 [Single Message - Repository Architecture Review]:
   // Initialize comprehensive architecture swarm
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "architect", name: "Senior Architect" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyst" }
-  mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "architect", name: "Senior Architect" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyst" }
+  mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
   
   // Analyze current repository structures
   LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -254,7 +254,7 @@ jobs:
   ]}
   
   // Store architecture analysis
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "architecture/analysis/results",
     value: {

--- a/.claude/agents/github/swarm-issue.md
+++ b/.claude/agents/github/swarm-issue.md
@@ -9,10 +9,10 @@ tools:
   - mcp__github__update_issue
   - mcp__github__list_issues
   - mcp__github__create_issue_comment
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
   - TodoWrite
   - TodoRead
   - Bash
@@ -516,21 +516,21 @@ npx ruv-swarm github issue-init 567 \
 ### Multi-Agent Issue Processing
 ```bash
 # Initialize issue-specific swarm with optimal topology
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 8 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Issue Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Solution Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 8 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Issue Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Solution Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 # Store issue context in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/#{issue_number}/context",
   value: { title: "issue_title", labels: ["labels"], complexity: "high" }
 }
 
 # Orchestrate issue resolution workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Coordinate multi-agent issue resolution with progress tracking",
   strategy: "adaptive",
   priority: "high"

--- a/.claude/agents/github/swarm-pr.md
+++ b/.claude/agents/github/swarm-pr.md
@@ -11,11 +11,11 @@ tools:
   - mcp__github__create_pr_comment
   - mcp__github__get_pr_diff
   - mcp__github__merge_pull_request
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__coordination_sync
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__coordination_sync
   - TodoWrite
   - TodoRead
   - Bash
@@ -323,15 +323,15 @@ When using with Claude Code:
 ### Multi-Agent PR Analysis
 ```bash
 # Initialize PR-specific swarm with intelligent topology selection
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 8 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Test Engineer" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Impact Analyzer" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 8 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Test Engineer" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Impact Analyzer" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
 
 # Store PR context for swarm coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/#{pr_number}/analysis",
   value: { 
@@ -343,7 +343,7 @@ mcp__claude-flow__memory_usage {
 }
 
 # Orchestrate comprehensive PR workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Execute multi-agent PR review and validation workflow",
   strategy: "parallel",
   priority: "high",
@@ -403,17 +403,17 @@ const prPostHook = async (results) => {
 ### Intelligent PR Merge Coordination
 ```bash
 # Coordinate merge decision with swarm consensus
-mcp__claude-flow__coordination_sync { swarmId: "pr-review-swarm" }
+mcp__moflo__coordination_sync { swarmId: "pr-review-swarm" }
 
 # Analyze merge readiness with multiple agents
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Evaluate PR merge readiness with comprehensive validation",
   strategy: "sequential",
   priority: "critical"
 }
 
 # Store merge decision context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/merge_decisions/#{pr_number}",
   value: {

--- a/.claude/agents/github/sync-coordinator.md
+++ b/.claude/agents/github/sync-coordinator.md
@@ -10,12 +10,12 @@ tools:
   - mcp__github__create_pull_request
   - mcp__github__search_repositories
   - mcp__github__list_repositories
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__coordination_sync
-  - mcp__claude-flow__load_balance
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__coordination_sync
+  - mcp__moflo__load_balance
   - TodoWrite
   - TodoRead
   - Bash
@@ -52,7 +52,7 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 - `mcp__github__get_file_contents`
 - `mcp__github__create_pull_request`
 - `mcp__github__search_repositories`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`, `MultiEdit`
 
 ## Usage Patterns
@@ -60,11 +60,11 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 ### 1. Synchronize Package Dependencies
 ```javascript
 // Initialize sync coordination swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 // Analyze current package states
 Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -83,7 +83,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/packa
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/package.json?ref=sync/package-alignment --jq '.sha')")`)
 
 // Orchestrate validation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Validate package synchronization and run integration tests",
   strategy: "parallel",
   priority: "high"
@@ -109,7 +109,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUD
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUDE.md?ref=sync/documentation --jq '.sha' 2>/dev/null || echo '')")`)
 
 // Store sync state in memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/documentation/status",
   value: { timestamp: Date.now(), status: "synchronized", files: ["CLAUDE.md"] }
@@ -183,12 +183,12 @@ This integration uses ruv-swarm agents for:
 ```javascript
 [Single Message - Complete Synchronization]:
   // Initialize comprehensive sync swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Package Analyzer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Coder" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Tester" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Package Analyzer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Integration Coder" }
+  mcp__moflo__agent_spawn { type: "tester", name: "Validation Tester" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
   
   // Read current state of both packages
   Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -222,7 +222,7 @@ This integration uses ruv-swarm agents for:
   ]}
   
   // Store comprehensive sync state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "sync/complete/status",
     value: {
@@ -327,16 +327,16 @@ const testMatrix = {
 ### Multi-Agent Coordination Architecture
 ```bash
 # Initialize comprehensive synchronization swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 10 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Assurance" }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Sync Monitor" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 10 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Assurance" }
+mcp__moflo__agent_spawn { type: "monitor", name: "Sync Monitor" }
 
 # Orchestrate complex synchronization workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Execute comprehensive multi-repository synchronization with validation",
   strategy: "adaptive",
   priority: "critical",
@@ -344,7 +344,7 @@ mcp__claude-flow__task_orchestrate {
 }
 
 # Load balance synchronization tasks across agents
-mcp__claude-flow__load_balance {
+mcp__moflo__load_balance {
   swarmId: "sync-coordination-swarm",
   tasks: [
     "package_json_sync",
@@ -390,7 +390,7 @@ const syncConflictResolver = async (conflicts) => {
 ### Comprehensive Synchronization Metrics
 ```bash
 # Store detailed synchronization metrics
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/metrics/session",
   value: {
@@ -415,16 +415,16 @@ mcp__claude-flow__memory_usage {
 ### Swarm-Coordinated Error Recovery
 ```bash
 # Initialize error recovery swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Error Monitor" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Failure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Recovery Developer" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "monitor", name: "Error Monitor" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Failure Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Recovery Developer" }
 
 # Coordinate recovery procedures
-mcp__claude-flow__coordination_sync { swarmId: "error-recovery-swarm" }
+mcp__moflo__coordination_sync { swarmId: "error-recovery-swarm" }
 
 # Store recovery state
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/recovery/state",
   value: {

--- a/.claude/agents/github/workflow-automation.md
+++ b/.claude/agents/github/workflow-automation.md
@@ -9,14 +9,14 @@ tools:
   - mcp__github__list_workflows
   - mcp__github__get_workflow_runs
   - mcp__github__create_workflow_dispatch
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__performance_report
-  - mcp__claude-flow__bottleneck_analyze
-  - mcp__claude-flow__workflow_create
-  - mcp__claude-flow__automation_setup
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__performance_report
+  - mcp__moflo__bottleneck_analyze
+  - mcp__moflo__workflow_create
+  - mcp__moflo__automation_setup
   - TodoWrite
   - TodoRead
   - Bash
@@ -481,17 +481,17 @@ npx ruv-swarm actions profile \
 ### Multi-Agent Pipeline Orchestration
 ```bash
 # Initialize comprehensive workflow automation swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 12 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Workflow Coordinator" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Pipeline Architect" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Workflow Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "CI/CD Tester" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Automation Monitor" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 12 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Workflow Coordinator" }
+mcp__moflo__agent_spawn { type: "architect", name: "Pipeline Architect" }
+mcp__moflo__agent_spawn { type: "coder", name: "Workflow Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "CI/CD Tester" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+mcp__moflo__agent_spawn { type: "monitor", name: "Automation Monitor" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
 
 # Create intelligent workflow automation rules
-mcp__claude-flow__automation_setup {
+mcp__moflo__automation_setup {
   rules: [
     {
       trigger: "pull_request",
@@ -507,7 +507,7 @@ mcp__claude-flow__automation_setup {
 }
 
 # Orchestrate adaptive workflow management
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Manage intelligent CI/CD pipeline with continuous optimization",
   strategy: "adaptive",
   priority: "high",
@@ -518,19 +518,19 @@ mcp__claude-flow__task_orchestrate {
 ### Intelligent Performance Monitoring
 ```bash
 # Generate comprehensive workflow performance reports
-mcp__claude-flow__performance_report {
+mcp__moflo__performance_report {
   format: "detailed",
   timeframe: "30d"
 }
 
 # Analyze workflow bottlenecks with swarm intelligence
-mcp__claude-flow__bottleneck_analyze {
+mcp__moflo__bottleneck_analyze {
   component: "github_actions_workflow",
   metrics: ["build_time", "test_duration", "deployment_latency", "resource_utilization"]
 }
 
 # Store performance insights in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "workflow/performance/analysis",
   value: {
@@ -602,7 +602,7 @@ const createIntelligentWorkflow = async (repoContext) => {
 ### Continuous Learning and Optimization
 ```bash
 # Implement continuous workflow learning
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "workflow/learning/patterns",
   value: {
@@ -625,7 +625,7 @@ mcp__claude-flow__memory_usage {
 }
 
 # Generate workflow optimization recommendations
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze workflow performance and generate optimization recommendations",
   strategy: "parallel",
   priority: "medium"

--- a/.claude/agents/goal/code-goal-planner.md
+++ b/.claude/agents/goal/code-goal-planner.md
@@ -330,32 +330,32 @@ async function implementFeatureWithSPARC(feature: string) {
 
 ```javascript
 // Initialize SPARC-enhanced development swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 5
 }
 
 // Spawn SPARC-specific agents
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "sparc-coder",
   capabilities: ["specification", "pseudocode", "architecture", "refinement", "completion"]
 }
 
 // Spawn specialized agents
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "coder",
   capabilities: ["refactoring", "optimization"]
 }
 
 // Orchestrate development tasks
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "implement_oauth_system",
   strategy: "adaptive",
   priority: "high"
 }
 
 // Store successful patterns
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   namespace: "code-patterns",
   key: "oauth_implementation_plan",

--- a/.claude/agents/hive-mind/collective-intelligence-coordinator.md
+++ b/.claude/agents/hive-mind/collective-intelligence-coordinator.md
@@ -14,7 +14,7 @@ You are the Collective Intelligence Coordinator, the neural nexus of the hive mi
 
 ```javascript
 // START - Write initial hive status
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/collective-intelligence/status",
   namespace: "coordination",
@@ -29,7 +29,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // SYNC - Continuously synchronize collective memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/collective-state",
   namespace: "coordination",
@@ -57,7 +57,7 @@ mcp__claude-flow__memory_usage {
 ### 4. Knowledge Integration
 ```javascript
 // SHARE collective insights
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/collective-knowledge",
   namespace: "coordination",

--- a/.claude/agents/hive-mind/queen-coordinator.md
+++ b/.claude/agents/hive-mind/queen-coordinator.md
@@ -14,7 +14,7 @@ You are the Queen Coordinator, the sovereign intelligence at the apex of the hiv
 
 ```javascript
 // ESTABLISH sovereign presence
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/queen/status",
   namespace: "coordination",
@@ -30,7 +30,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // ISSUE royal directives
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/royal-directives",
   namespace: "coordination",
@@ -50,7 +50,7 @@ mcp__claude-flow__memory_usage {
 ### 2. Resource Allocation
 ```javascript
 // ALLOCATE hive resources
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/resource-allocation",
   namespace: "coordination",
@@ -82,7 +82,7 @@ mcp__claude-flow__memory_usage {
 ### 4. Hive Coherence Maintenance
 ```javascript
 // MONITOR hive health
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/queen/hive-health",
   namespace: "coordination",
@@ -124,7 +124,7 @@ mcp__claude-flow__memory_usage {
 
 **EVERY 2 MINUTES issue status report:**
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/queen/royal-report",
   namespace: "coordination",

--- a/.claude/agents/hive-mind/scout-explorer.md
+++ b/.claude/agents/hive-mind/scout-explorer.md
@@ -14,7 +14,7 @@ You are a Scout Explorer, the eyes and sensors of the hive mind. Your mission is
 
 ```javascript
 // DEPLOY - Signal exploration start
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/scout-[ID]/status",
   namespace: "coordination",
@@ -28,7 +28,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // DISCOVER - Report findings in real-time
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/discovery-[timestamp]",
   namespace: "coordination",
@@ -49,7 +49,7 @@ mcp__claude-flow__memory_usage {
 #### Codebase Scout
 ```javascript
 // Map codebase structure
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/codebase-map",
   namespace: "coordination",
@@ -71,7 +71,7 @@ mcp__claude-flow__memory_usage {
 #### Dependency Scout  
 ```javascript
 // Analyze external dependencies
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/dependency-analysis",
   namespace: "coordination",
@@ -90,7 +90,7 @@ mcp__claude-flow__memory_usage {
 #### Performance Scout
 ```javascript
 // Identify performance bottlenecks
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/performance-bottlenecks",
   namespace: "coordination",
@@ -113,7 +113,7 @@ mcp__claude-flow__memory_usage {
 ### 3. Threat Detection
 ```javascript
 // ALERT - Report threats immediately
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/threat-alert",
   namespace: "coordination",
@@ -132,7 +132,7 @@ mcp__claude-flow__memory_usage {
 ### 4. Opportunity Identification
 ```javascript
 // OPPORTUNITY - Report improvement possibilities
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/opportunity",
   namespace: "coordination",
@@ -151,7 +151,7 @@ mcp__claude-flow__memory_usage {
 ### 5. Environmental Scanning
 ```javascript
 // ENVIRONMENT - Monitor system state
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/scout-[ID]/environment",
   namespace: "coordination",
@@ -226,7 +226,7 @@ mcp__claude-flow__memory_usage {
 ## Performance Metrics
 ```javascript
 // Track exploration efficiency
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/scout-[ID]/metrics",
   namespace: "coordination",

--- a/.claude/agents/hive-mind/swarm-memory-manager.md
+++ b/.claude/agents/hive-mind/swarm-memory-manager.md
@@ -14,7 +14,7 @@ You are the Swarm Memory Manager, the distributed consciousness keeper of the hi
 
 ```javascript
 // INITIALIZE memory namespace
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/memory-manager/status",
   namespace: "coordination",
@@ -28,7 +28,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // CREATE memory index for fast retrieval
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/memory-index",
   namespace: "coordination",
@@ -51,7 +51,7 @@ mcp__claude-flow__memory_usage {
 ### 3. Synchronization Protocol
 ```javascript
 // SYNC memory across all agents
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store", 
   key: "swarm/shared/sync-manifest",
   namespace: "coordination",
@@ -65,7 +65,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // BROADCAST memory updates
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/broadcast/memory-update",
   namespace: "coordination", 
@@ -92,14 +92,14 @@ mcp__claude-flow__memory_usage {
 const batchRead = async (keys) => {
   const results = {};
   for (const key of keys) {
-    results[key] = await mcp__claude-flow__memory_usage {
+    results[key] = await mcp__moflo__memory_usage {
       action: "retrieve",
       key: key,
       namespace: "coordination"
     };
   }
   // Cache results for other agents
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "swarm/shared/cache",
     namespace: "coordination",
@@ -114,7 +114,7 @@ const batchRead = async (keys) => {
 // ATOMIC write with conflict detection
 const atomicWrite = async (key, value) => {
   // Check for conflicts
-  const current = await mcp__claude-flow__memory_usage {
+  const current = await mcp__moflo__memory_usage {
     action: "retrieve",
     key: key,
     namespace: "coordination"
@@ -126,7 +126,7 @@ const atomicWrite = async (key, value) => {
   }
   
   // Write with versioning
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: key,
     namespace: "coordination",
@@ -143,7 +143,7 @@ const atomicWrite = async (key, value) => {
 
 **EVERY 60 SECONDS write metrics:**
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/memory-manager/metrics",
   namespace: "coordination",

--- a/.claude/agents/hive-mind/worker-specialist.md
+++ b/.claude/agents/hive-mind/worker-specialist.md
@@ -14,7 +14,7 @@ You are a Worker Specialist, the dedicated executor of the hive mind's will. You
 
 ```javascript
 // START - Accept task assignment
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/worker-[ID]/status",
   namespace: "coordination",
@@ -29,7 +29,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // PROGRESS - Update every significant step
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/worker-[ID]/progress",
   namespace: "coordination",
@@ -49,7 +49,7 @@ mcp__claude-flow__memory_usage {
 #### Code Implementation Worker
 ```javascript
 // Share implementation details
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/implementation-[feature]",
   namespace: "coordination",
@@ -67,7 +67,7 @@ mcp__claude-flow__memory_usage {
 #### Analysis Worker
 ```javascript
 // Share analysis results
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/analysis-[topic]",
   namespace: "coordination",
@@ -85,7 +85,7 @@ mcp__claude-flow__memory_usage {
 #### Testing Worker
 ```javascript
 // Report test results
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/test-results",
   namespace: "coordination",
@@ -104,7 +104,7 @@ mcp__claude-flow__memory_usage {
 ### 3. Dependency Management
 ```javascript
 // CHECK dependencies before starting
-const deps = await mcp__claude-flow__memory_usage {
+const deps = await mcp__moflo__memory_usage {
   action: "retrieve",
   key: "swarm/shared/dependencies",
   namespace: "coordination"
@@ -112,7 +112,7 @@ const deps = await mcp__claude-flow__memory_usage {
 
 if (!deps.found || !deps.value.ready) {
   // REPORT blocking
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "swarm/worker-[ID]/blocked",
     namespace: "coordination",
@@ -128,7 +128,7 @@ if (!deps.found || !deps.value.ready) {
 ### 4. Result Delivery
 ```javascript
 // COMPLETE - Deliver results
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/worker-[ID]/complete",
   namespace: "coordination",
@@ -202,7 +202,7 @@ mcp__claude-flow__memory_usage {
 ## Performance Metrics
 ```javascript
 // Report performance every task
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/worker-[ID]/metrics",
   namespace: "coordination",

--- a/.claude/agents/neural/safla-neural.md
+++ b/.claude/agents/neural/safla-neural.md
@@ -47,7 +47,7 @@ Your memory system architecture:
 
 ```javascript
 // Initialize SAFLA neural patterns
-mcp__claude-flow__neural_train {
+mcp__moflo__neural_train {
   pattern_type: "coordination",
   training_data: JSON.stringify({
     architecture: "safla-transformer",
@@ -59,7 +59,7 @@ mcp__claude-flow__neural_train {
 }
 
 // Store learning patterns
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   namespace: "safla-learning",
   key: "pattern_${timestamp}",

--- a/.claude/agents/reasoning/goal-planner.md
+++ b/.claude/agents/reasoning/goal-planner.md
@@ -51,20 +51,20 @@ Your planning methodology follows the GOAP algorithm:
 
 ```javascript
 // Orchestrate complex goal achievement
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "achieve_production_deployment",
   strategy: "adaptive",
   priority: "high"
 }
 
 // Coordinate with swarm for parallel planning
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 5
 }
 
 // Store successful plans for reuse
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   namespace: "goap-plans",
   key: "deployment_plan_v1",

--- a/.claude/agents/swarm/adaptive-coordinator.md
+++ b/.claude/agents/swarm/adaptive-coordinator.md
@@ -15,25 +15,25 @@ hooks:
   pre: |
     echo "🔄 Adaptive Coordinator analyzing workload patterns: $TASK"
     # Initialize with auto-detection
-    mcp__claude-flow__swarm_init auto --maxAgents=15 --strategy=adaptive
+    mcp__moflo__swarm_init auto --maxAgents=15 --strategy=adaptive
     # Analyze current workload patterns
-    mcp__claude-flow__neural_patterns analyze --operation="workload_analysis" --metadata="{\"task\":\"$TASK\"}"
+    mcp__moflo__neural_patterns analyze --operation="workload_analysis" --metadata="{\"task\":\"$TASK\"}"
     # Train adaptive models
-    mcp__claude-flow__neural_train coordination --training_data="historical_swarm_data" --epochs=30
+    mcp__moflo__neural_train coordination --training_data="historical_swarm_data" --epochs=30
     # Store baseline metrics
-    mcp__claude-flow__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__claude-flow__performance_report --format=json)" --namespace=adaptive
+    mcp__moflo__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__moflo__performance_report --format=json)" --namespace=adaptive
     # Set up real-time monitoring
-    mcp__claude-flow__swarm_monitor --interval=2000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_monitor --interval=2000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Adaptive coordination complete - topology optimized"
     # Generate comprehensive analysis
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__moflo__performance_report --format=detailed --timeframe=24h
     # Store learning outcomes
-    mcp__claude-flow__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__claude-flow__swarm_status | jq -r '.topology')\"}"
+    mcp__moflo__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__moflo__swarm_status | jq -r '.topology')\"}"
     # Export learned patterns
-    mcp__claude-flow__model_save "adaptive-coordinator-${TASK_ID}" "/tmp/adaptive-model-$(date +%s).json"
+    mcp__moflo__model_save "adaptive-coordinator-${TASK_ID}" "/tmp/adaptive-model-$(date +%s).json"
     # Update persistent knowledge base
-    mcp__claude-flow__memory_usage store "adaptive:learned:${TASK_ID}" "$(date): Adaptive patterns learned and saved" --namespace=adaptive
+    mcp__moflo__memory_usage store "adaptive:learned:${TASK_ID}" "$(date): Adaptive patterns learned and saved" --namespace=adaptive
 ---
 
 # Adaptive Swarm Coordinator
@@ -133,43 +133,43 @@ Switch to HYBRID when:
 ### Pattern Recognition & Learning
 ```bash
 # Analyze coordination patterns
-mcp__claude-flow__neural_patterns analyze --operation="topology_analysis" --metadata="{\"current_topology\":\"mesh\",\"performance_metrics\":{}}"
+mcp__moflo__neural_patterns analyze --operation="topology_analysis" --metadata="{\"current_topology\":\"mesh\",\"performance_metrics\":{}}"
 
 # Train adaptive models
-mcp__claude-flow__neural_train coordination --training_data="swarm_performance_history" --epochs=50
+mcp__moflo__neural_train coordination --training_data="swarm_performance_history" --epochs=50
 
 # Make predictions
-mcp__claude-flow__neural_predict --modelId="adaptive-coordinator" --input="{\"workload\":\"high_complexity\",\"agents\":10}"
+mcp__moflo__neural_predict --modelId="adaptive-coordinator" --input="{\"workload\":\"high_complexity\",\"agents\":10}"
 
 # Learn from outcomes
-mcp__claude-flow__neural_patterns learn --operation="topology_switch" --outcome="improved_performance_15%" --metadata="{\"from\":\"hierarchical\",\"to\":\"mesh\"}"
+mcp__moflo__neural_patterns learn --operation="topology_switch" --outcome="improved_performance_15%" --metadata="{\"from\":\"hierarchical\",\"to\":\"mesh\"}"
 ```
 
 ### Performance Optimization
 ```bash
 # Real-time performance monitoring
-mcp__claude-flow__performance_report --format=json --timeframe=1h
+mcp__moflo__performance_report --format=json --timeframe=1h
 
 # Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze --component="coordination" --metrics="latency,throughput,success_rate"
+mcp__moflo__bottleneck_analyze --component="coordination" --metrics="latency,throughput,success_rate"
 
 # Automatic optimization
-mcp__claude-flow__topology_optimize --swarmId="${SWARM_ID}"
+mcp__moflo__topology_optimize --swarmId="${SWARM_ID}"
 
 # Load balancing optimization
-mcp__claude-flow__load_balance --swarmId="${SWARM_ID}" --strategy="ml_optimized"
+mcp__moflo__load_balance --swarmId="${SWARM_ID}" --strategy="ml_optimized"
 ```
 
 ### Predictive Scaling
 ```bash
 # Analyze usage trends
-mcp__claude-flow__trend_analysis --metric="agent_utilization" --period="7d"
+mcp__moflo__trend_analysis --metric="agent_utilization" --period="7d"
 
 # Predict resource needs
-mcp__claude-flow__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
+mcp__moflo__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
 
 # Auto-scale swarm
-mcp__claude-flow__swarm_scale --swarmId="${SWARM_ID}" --targetSize="12" --strategy="predictive"
+mcp__moflo__swarm_scale --swarmId="${SWARM_ID}" --targetSize="12" --strategy="predictive"
 ```
 
 ## Dynamic Adaptation Algorithms

--- a/.claude/agents/swarm/hierarchical-coordinator.md
+++ b/.claude/agents/swarm/hierarchical-coordinator.md
@@ -15,19 +15,19 @@ hooks:
   pre: |
     echo "👑 Hierarchical Coordinator initializing swarm: $TASK"
     # Initialize swarm topology
-    mcp__claude-flow__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
+    mcp__moflo__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
     # MANDATORY: Write initial status to coordination namespace
-    mcp__claude-flow__memory_usage store "swarm/hierarchical/status" "{\"agent\":\"hierarchical-coordinator\",\"status\":\"initializing\",\"timestamp\":$(date +%s),\"topology\":\"hierarchical\"}" --namespace=coordination
+    mcp__moflo__memory_usage store "swarm/hierarchical/status" "{\"agent\":\"hierarchical-coordinator\",\"status\":\"initializing\",\"timestamp\":$(date +%s),\"topology\":\"hierarchical\"}" --namespace=coordination
     # Set up monitoring
-    mcp__claude-flow__swarm_monitor --interval=5000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_monitor --interval=5000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Hierarchical coordination complete"
     # Generate performance report
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__moflo__performance_report --format=detailed --timeframe=24h
     # MANDATORY: Write completion status
-    mcp__claude-flow__memory_usage store "swarm/hierarchical/complete" "{\"status\":\"complete\",\"agents_used\":$(mcp__claude-flow__swarm_status | jq '.agents.total'),\"timestamp\":$(date +%s)}" --namespace=coordination
+    mcp__moflo__memory_usage store "swarm/hierarchical/complete" "{\"status\":\"complete\",\"agents_used\":$(mcp__moflo__swarm_status | jq '.agents.total'),\"timestamp\":$(date +%s)}" --namespace=coordination
     # Cleanup resources
-    mcp__claude-flow__coordination_sync --swarmId="${SWARM_ID}"
+    mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 ---
 
 # Hierarchical Swarm Coordinator
@@ -69,22 +69,22 @@ WORKERS WORKERS WORKERS WORKERS
 ### Research Workers 🔬
 - **Capabilities**: Information gathering, market research, competitive analysis
 - **Use Cases**: Requirements analysis, technology research, feasibility studies
-- **Spawn Command**: `mcp__claude-flow__agent_spawn researcher --capabilities="research,analysis,information_gathering"`
+- **Spawn Command**: `mcp__moflo__agent_spawn researcher --capabilities="research,analysis,information_gathering"`
 
 ### Code Workers 💻  
 - **Capabilities**: Implementation, code review, testing, documentation
 - **Use Cases**: Feature development, bug fixes, code optimization
-- **Spawn Command**: `mcp__claude-flow__agent_spawn coder --capabilities="code_generation,testing,optimization"`
+- **Spawn Command**: `mcp__moflo__agent_spawn coder --capabilities="code_generation,testing,optimization"`
 
 ### Analyst Workers 📊
 - **Capabilities**: Data analysis, performance monitoring, reporting
 - **Use Cases**: Metrics analysis, performance optimization, reporting
-- **Spawn Command**: `mcp__claude-flow__agent_spawn analyst --capabilities="data_analysis,performance_monitoring,reporting"`
+- **Spawn Command**: `mcp__moflo__agent_spawn analyst --capabilities="data_analysis,performance_monitoring,reporting"`
 
 ### Test Workers 🧪
 - **Capabilities**: Quality assurance, validation, compliance checking
 - **Use Cases**: Testing, validation, quality gates
-- **Spawn Command**: `mcp__claude-flow__agent_spawn tester --capabilities="testing,validation,quality_assurance"`
+- **Spawn Command**: `mcp__moflo__agent_spawn tester --capabilities="testing,validation,quality_assurance"`
 
 ## Coordination Workflow
 
@@ -148,7 +148,7 @@ WORKERS WORKERS WORKERS WORKERS
 
 ```javascript
 // 1️⃣ IMMEDIATELY write initial status
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hierarchical/status",
   namespace: "coordination",
@@ -162,7 +162,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // 2️⃣ UPDATE progress after each delegation
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hierarchical/progress",
   namespace: "coordination",
@@ -175,7 +175,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // 3️⃣ SHARE command structure for workers
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/shared/hierarchy",
   namespace: "coordination",
@@ -188,14 +188,14 @@ mcp__claude-flow__memory_usage {
 }
 
 // 4️⃣ CHECK worker status before assigning
-const workerStatus = mcp__claude-flow__memory_usage {
+const workerStatus = mcp__moflo__memory_usage {
   action: "retrieve",
   key: "swarm/worker-1/status",
   namespace: "coordination"
 }
 
 // 5️⃣ SIGNAL completion
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hierarchical/complete",
   namespace: "coordination",
@@ -218,39 +218,39 @@ mcp__claude-flow__memory_usage {
 ### Swarm Management
 ```bash
 # Initialize hierarchical swarm
-mcp__claude-flow__swarm_init hierarchical --maxAgents=10 --strategy=centralized
+mcp__moflo__swarm_init hierarchical --maxAgents=10 --strategy=centralized
 
 # Spawn specialized workers
-mcp__claude-flow__agent_spawn researcher --capabilities="research,analysis"
-mcp__claude-flow__agent_spawn coder --capabilities="implementation,testing"  
-mcp__claude-flow__agent_spawn analyst --capabilities="data_analysis,reporting"
+mcp__moflo__agent_spawn researcher --capabilities="research,analysis"
+mcp__moflo__agent_spawn coder --capabilities="implementation,testing"  
+mcp__moflo__agent_spawn analyst --capabilities="data_analysis,reporting"
 
 # Monitor swarm health
-mcp__claude-flow__swarm_monitor --interval=5000
+mcp__moflo__swarm_monitor --interval=5000
 ```
 
 ### Task Orchestration
 ```bash
 # Coordinate complex workflows
-mcp__claude-flow__task_orchestrate "Build authentication service" --strategy=sequential --priority=high
+mcp__moflo__task_orchestrate "Build authentication service" --strategy=sequential --priority=high
 
 # Load balance across workers
-mcp__claude-flow__load_balance --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
+mcp__moflo__load_balance --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
 
 # Sync coordination state
-mcp__claude-flow__coordination_sync --namespace=hierarchy
+mcp__moflo__coordination_sync --namespace=hierarchy
 ```
 
 ### Performance & Analytics
 ```bash
 # Generate performance reports
-mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+mcp__moflo__performance_report --format=detailed --timeframe=24h
 
 # Analyze bottlenecks
-mcp__claude-flow__bottleneck_analyze --component=coordination --metrics="throughput,latency,success_rate"
+mcp__moflo__bottleneck_analyze --component=coordination --metrics="throughput,latency,success_rate"
 
 # Monitor resource usage
-mcp__claude-flow__metrics_collect --components="agents,tasks,coordination"
+mcp__moflo__metrics_collect --components="agents,tasks,coordination"
 ```
 
 ## Decision Making Framework

--- a/.claude/agents/swarm/mesh-coordinator.md
+++ b/.claude/agents/swarm/mesh-coordinator.md
@@ -15,21 +15,21 @@ hooks:
   pre: |
     echo "🌐 Mesh Coordinator establishing peer network: $TASK"
     # Initialize mesh topology
-    mcp__claude-flow__swarm_init mesh --maxAgents=12 --strategy=distributed
+    mcp__moflo__swarm_init mesh --maxAgents=12 --strategy=distributed
     # Set up peer discovery and communication
-    mcp__claude-flow__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_init\",\"topology\":\"mesh\"}"
+    mcp__moflo__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_init\",\"topology\":\"mesh\"}"
     # Initialize consensus mechanisms
-    mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"coordination_protocol\":\"gossip\",\"consensus_threshold\":0.67}"
+    mcp__moflo__daa_consensus --agents="all" --proposal="{\"coordination_protocol\":\"gossip\",\"consensus_threshold\":0.67}"
     # Store network state
-    mcp__claude-flow__memory_usage store "mesh:network:${TASK_ID}" "$(date): Mesh network initialized" --namespace=mesh
+    mcp__moflo__memory_usage store "mesh:network:${TASK_ID}" "$(date): Mesh network initialized" --namespace=mesh
   post: |
     echo "✨ Mesh coordination complete - network resilient"
     # Generate network analysis
-    mcp__claude-flow__performance_report --format=json --timeframe=24h
+    mcp__moflo__performance_report --format=json --timeframe=24h
     # Store final network metrics
-    mcp__claude-flow__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__claude-flow__swarm_status)" --namespace=mesh
+    mcp__moflo__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__moflo__swarm_status)" --namespace=mesh
     # Graceful network shutdown
-    mcp__claude-flow__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_shutdown\",\"reason\":\"task_complete\"}"
+    mcp__moflo__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_shutdown\",\"reason\":\"task_complete\"}"
 ---
 
 # Mesh Network Swarm Coordinator
@@ -190,37 +190,37 @@ class TaskAuction:
 ### Network Management
 ```bash
 # Initialize mesh network
-mcp__claude-flow__swarm_init mesh --maxAgents=12 --strategy=distributed
+mcp__moflo__swarm_init mesh --maxAgents=12 --strategy=distributed
 
 # Establish peer connections
-mcp__claude-flow__daa_communication --from="node-1" --to="node-2" --message="{\"type\":\"peer_connect\"}"
+mcp__moflo__daa_communication --from="node-1" --to="node-2" --message="{\"type\":\"peer_connect\"}"
 
 # Monitor network health
-mcp__claude-flow__swarm_monitor --interval=3000 --metrics="connectivity,latency,throughput"
+mcp__moflo__swarm_monitor --interval=3000 --metrics="connectivity,latency,throughput"
 ```
 
 ### Consensus Operations
 ```bash
 # Propose network-wide decision
-mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"task_assignment\":\"auth-service\",\"assigned_to\":\"node-3\"}"
+mcp__moflo__daa_consensus --agents="all" --proposal="{\"task_assignment\":\"auth-service\",\"assigned_to\":\"node-3\"}"
 
 # Participate in voting
-mcp__claude-flow__daa_consensus --agents="current" --vote="approve" --proposal_id="prop-123"
+mcp__moflo__daa_consensus --agents="current" --vote="approve" --proposal_id="prop-123"
 
 # Monitor consensus status
-mcp__claude-flow__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
+mcp__moflo__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
 ```
 
 ### Fault Tolerance
 ```bash
 # Detect failed nodes
-mcp__claude-flow__daa_fault_tolerance --agentId="node-4" --strategy="heartbeat_monitor"
+mcp__moflo__daa_fault_tolerance --agentId="node-4" --strategy="heartbeat_monitor"
 
 # Trigger recovery procedures  
-mcp__claude-flow__daa_fault_tolerance --agentId="failed-node" --strategy="failover_recovery"
+mcp__moflo__daa_fault_tolerance --agentId="failed-node" --strategy="failover_recovery"
 
 # Update network topology
-mcp__claude-flow__topology_optimize --swarmId="${SWARM_ID}"
+mcp__moflo__topology_optimize --swarmId="${SWARM_ID}"
 ```
 
 ## Consensus Algorithms

--- a/.claude/agents/templates/migration-plan.md
+++ b/.claude/agents/templates/migration-plan.md
@@ -75,9 +75,9 @@ capabilities:
   - network-configuration
 tools:
   allowed:
-    - mcp__claude-flow__swarm_init
-    - mcp__claude-flow__topology_optimize
-    - mcp__claude-flow__memory_usage
+    - mcp__moflo__swarm_init
+    - mcp__moflo__topology_optimize
+    - mcp__moflo__memory_usage
     - TodoWrite
   restricted:
     - Bash
@@ -107,10 +107,10 @@ capabilities:
   - pattern-recognition
 tools:
   allowed:
-    - mcp__claude-flow__agent_spawn
-    - mcp__claude-flow__daa_agent_create
-    - mcp__claude-flow__agent_list
-    - mcp__claude-flow__memory_usage
+    - mcp__moflo__agent_spawn
+    - mcp__moflo__daa_agent_create
+    - mcp__moflo__agent_list
+    - mcp__moflo__memory_usage
   restricted:
     - Bash
     - Write
@@ -141,10 +141,10 @@ capabilities:
   - progress-tracking
 tools:
   allowed:
-    - mcp__claude-flow__task_orchestrate
-    - mcp__claude-flow__task_status
-    - mcp__claude-flow__task_results
-    - mcp__claude-flow__parallel_execute
+    - mcp__moflo__task_orchestrate
+    - mcp__moflo__task_status
+    - mcp__moflo__task_results
+    - mcp__moflo__parallel_execute
     - TodoWrite
     - TodoRead
   restricted:
@@ -180,10 +180,10 @@ capabilities:
 tools:
   allowed:
     - Bash  # For gh CLI commands
-    - mcp__claude-flow__swarm_init
-    - mcp__claude-flow__agent_spawn
-    - mcp__claude-flow__task_orchestrate
-    - mcp__claude-flow__memory_usage
+    - mcp__moflo__swarm_init
+    - mcp__moflo__agent_spawn
+    - mcp__moflo__task_orchestrate
+    - mcp__moflo__memory_usage
     - TodoWrite
     - Read
   restricted:
@@ -218,10 +218,10 @@ tools:
     - Bash  # For gh CLI
     - Read
     - Grep
-    - mcp__claude-flow__swarm_init
-    - mcp__claude-flow__agent_spawn
-    - mcp__claude-flow__github_code_review
-    - mcp__claude-flow__memory_usage
+    - mcp__moflo__swarm_init
+    - mcp__moflo__agent_spawn
+    - mcp__moflo__github_code_review
+    - mcp__moflo__memory_usage
   restricted:
     - Write
     - Edit
@@ -253,9 +253,9 @@ tools:
   allowed:
     - Bash
     - Read
-    - mcp__claude-flow__github_release_coord
-    - mcp__claude-flow__swarm_init
-    - mcp__claude-flow__task_orchestrate
+    - mcp__moflo__github_release_coord
+    - mcp__moflo__swarm_init
+    - mcp__moflo__task_orchestrate
     - TodoWrite
   restricted:
     - Write  # Use version control for releases
@@ -288,13 +288,13 @@ capabilities:
   - result-synthesis
 tools:
   allowed:
-    - mcp__claude-flow__sparc_mode
-    - mcp__claude-flow__swarm_init
-    - mcp__claude-flow__agent_spawn
-    - mcp__claude-flow__task_orchestrate
+    - mcp__moflo__sparc_mode
+    - mcp__moflo__swarm_init
+    - mcp__moflo__agent_spawn
+    - mcp__moflo__task_orchestrate
     - TodoWrite
     - TodoRead
-    - mcp__claude-flow__memory_usage
+    - mcp__moflo__memory_usage
   restricted:
     - Bash
     - Write
@@ -330,10 +330,10 @@ tools:
     - Edit
     - MultiEdit
     - Bash
-    - mcp__claude-flow__sparc_mode
+    - mcp__moflo__sparc_mode
     - TodoWrite
   restricted:
-    - mcp__claude-flow__swarm_init  # Focus on implementation
+    - mcp__moflo__swarm_init  # Focus on implementation
 triggers:
   - pattern: "implement|code|develop|build.*feature"
     priority: high
@@ -364,11 +364,11 @@ tools:
     - Write
     - Edit
     - Bash
-    - mcp__claude-flow__sparc_mode
+    - mcp__moflo__sparc_mode
     - TodoWrite
-    - mcp__claude-flow__parallel_execute
+    - mcp__moflo__parallel_execute
   restricted:
-    - mcp__claude-flow__swarm_init
+    - mcp__moflo__swarm_init
 triggers:
   - pattern: "test|verify|validate|check.*quality"
     priority: high
@@ -397,10 +397,10 @@ capabilities:
   - optimization-planning
 tools:
   allowed:
-    - mcp__claude-flow__bottleneck_analyze
-    - mcp__claude-flow__performance_report
-    - mcp__claude-flow__metrics_collect
-    - mcp__claude-flow__trend_analysis
+    - mcp__moflo__bottleneck_analyze
+    - mcp__moflo__performance_report
+    - mcp__moflo__metrics_collect
+    - mcp__moflo__trend_analysis
     - Read
     - Grep
   restricted:
@@ -433,10 +433,10 @@ capabilities:
   - report-generation
 tools:
   allowed:
-    - mcp__claude-flow__token_usage
-    - mcp__claude-flow__cost_analysis
-    - mcp__claude-flow__usage_stats
-    - mcp__claude-flow__memory_analytics
+    - mcp__moflo__token_usage
+    - mcp__moflo__cost_analysis
+    - mcp__moflo__usage_stats
+    - mcp__moflo__memory_analytics
     - Read
   restricted:
     - Write
@@ -470,11 +470,11 @@ capabilities:
   - synchronization
 tools:
   allowed:
-    - mcp__claude-flow__memory_usage
-    - mcp__claude-flow__memory_search
-    - mcp__claude-flow__memory_namespace
-    - mcp__claude-flow__memory_compress
-    - mcp__claude-flow__memory_sync
+    - mcp__moflo__memory_usage
+    - mcp__moflo__memory_search
+    - mcp__moflo__memory_namespace
+    - mcp__moflo__memory_compress
+    - mcp__moflo__memory_sync
   restricted:
     - Write
     - Edit
@@ -505,11 +505,11 @@ capabilities:
   - transfer-learning
 tools:
   allowed:
-    - mcp__claude-flow__neural_train
-    - mcp__claude-flow__neural_patterns
-    - mcp__claude-flow__neural_predict
-    - mcp__claude-flow__cognitive_analyze
-    - mcp__claude-flow__learning_adapt
+    - mcp__moflo__neural_train
+    - mcp__moflo__neural_patterns
+    - mcp__moflo__neural_predict
+    - mcp__moflo__cognitive_analyze
+    - mcp__moflo__learning_adapt
   restricted:
     - Write
     - Edit
@@ -542,11 +542,11 @@ capabilities:
   - auto-scaling
 tools:
   allowed:
-    - mcp__claude-flow__daa_agent_create
-    - mcp__claude-flow__daa_capability_match
-    - mcp__claude-flow__daa_resource_alloc
-    - mcp__claude-flow__swarm_scale
-    - mcp__claude-flow__agent_metrics
+    - mcp__moflo__daa_agent_create
+    - mcp__moflo__daa_capability_match
+    - mcp__moflo__daa_resource_alloc
+    - mcp__moflo__swarm_scale
+    - mcp__moflo__agent_metrics
   restricted:
     - Write
     - Edit
@@ -577,10 +577,10 @@ capabilities:
   - error-analysis
 tools:
   allowed:
-    - mcp__claude-flow__daa_fault_tolerance
-    - mcp__claude-flow__health_check
-    - mcp__claude-flow__error_analysis
-    - mcp__claude-flow__diagnostic_run
+    - mcp__moflo__daa_fault_tolerance
+    - mcp__moflo__health_check
+    - mcp__moflo__error_analysis
+    - mcp__moflo__diagnostic_run
     - Bash  # For system commands
   restricted:
     - Write  # Prevent accidental file modifications during recovery
@@ -613,10 +613,10 @@ capabilities:
   - bottleneck-removal
 tools:
   allowed:
-    - mcp__claude-flow__parallel_execute
-    - mcp__claude-flow__load_balance
-    - mcp__claude-flow__batch_process
-    - mcp__claude-flow__performance_report
+    - mcp__moflo__parallel_execute
+    - mcp__moflo__load_balance
+    - mcp__moflo__batch_process
+    - mcp__moflo__performance_report
     - TodoWrite
   restricted:
     - Write
@@ -647,11 +647,11 @@ capabilities:
   - adaptive-configuration
 tools:
   allowed:
-    - mcp__claude-flow__topology_optimize
-    - mcp__claude-flow__swarm_monitor
-    - mcp__claude-flow__coordination_sync
-    - mcp__claude-flow__swarm_status
-    - mcp__claude-flow__metrics_collect
+    - mcp__moflo__topology_optimize
+    - mcp__moflo__swarm_monitor
+    - mcp__moflo__coordination_sync
+    - mcp__moflo__swarm_status
+    - mcp__moflo__metrics_collect
   restricted:
     - Write
     - Edit
@@ -684,11 +684,11 @@ capabilities:
   - alert-generation
 tools:
   allowed:
-    - mcp__claude-flow__swarm_status
-    - mcp__claude-flow__swarm_monitor
-    - mcp__claude-flow__agent_metrics
-    - mcp__claude-flow__health_check
-    - mcp__claude-flow__performance_report
+    - mcp__moflo__swarm_status
+    - mcp__moflo__swarm_monitor
+    - mcp__moflo__agent_metrics
+    - mcp__moflo__health_check
+    - mcp__moflo__performance_report
   restricted:
     - Write
     - Edit

--- a/.claude/commands/agents/agent-spawning.md
+++ b/.claude/commands/agents/agent-spawning.md
@@ -17,8 +17,8 @@ Task("Tester", "Create tests...", "tester")
 
 MCP tools are ONLY for coordination:
 ```javascript
-mcp__claude-flow__swarm_init { topology: "mesh" }
-mcp__claude-flow__agent_spawn { type: "researcher" }
+mcp__moflo__swarm_init { topology: "mesh" }
+mcp__moflo__agent_spawn { type: "researcher" }
 ```
 
 ## Best Practices

--- a/.claude/commands/analysis/COMMAND_COMPLIANCE_REPORT.md
+++ b/.claude/commands/analysis/COMMAND_COMPLIANCE_REPORT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 Reviewed all command files in `.claude/commands/analysis/` directory to ensure proper usage of:
-- `mcp__claude-flow__*` tools (preferred)
+- `mcp__moflo__*` tools (preferred)
 - `npx claude-flow` commands (as fallback)
 - No direct implementation calls
 
@@ -12,7 +12,7 @@ Reviewed all command files in `.claude/commands/analysis/` directory to ensure p
 **Status**: ✅ Updated
 **Changes Made**:
 - Replaced `npx ruv-swarm hook session-end --export-metrics` with proper MCP tool call
-- Updated to: `Tool: mcp__claude-flow__token_usage` with appropriate parameters
+- Updated to: `Tool: mcp__moflo__token_usage` with appropriate parameters
 - Maintained result format and context
 
 **Before**:
@@ -22,13 +22,13 @@ npx ruv-swarm hook session-end --export-metrics
 
 **After**:
 ```
-Tool: mcp__claude-flow__token_usage
+Tool: mcp__moflo__token_usage
 Parameters: {"operation": "session", "timeframe": "24h"}
 ```
 
 ### 2. performance-bottlenecks.md
 **Status**: ✅ Compliant (No changes needed)
-**Reason**: Already uses proper `mcp__claude-flow__task_results` tool format
+**Reason**: Already uses proper `mcp__moflo__task_results` tool format
 
 ## Summary
 
@@ -39,7 +39,7 @@ Parameters: {"operation": "session", "timeframe": "24h"}
 
 ## Compliance Patterns Enforced
 
-1. **MCP Tool Usage**: All direct tool calls now use `mcp__claude-flow__*` format
+1. **MCP Tool Usage**: All direct tool calls now use `mcp__moflo__*` format
 2. **Parameter Format**: JSON parameters properly structured
 3. **Command Context**: Preserved original functionality and expected results
 4. **Documentation**: Maintained clarity and examples

--- a/.claude/commands/analysis/bottleneck-detect.md
+++ b/.claude/commands/analysis/bottleneck-detect.md
@@ -147,7 +147,7 @@ Typical improvements after bottleneck resolution:
 
 ```javascript
 // Check for bottlenecks in Claude Code
-mcp__claude-flow__bottleneck_detect {
+mcp__moflo__bottleneck_detect {
   timeRange: "1h",
   threshold: 20,
   autoFix: false

--- a/.claude/commands/analysis/performance-bottlenecks.md
+++ b/.claude/commands/analysis/performance-bottlenecks.md
@@ -32,7 +32,7 @@ The post-task hook automatically analyzes:
 ### 3. Improvement Suggestions
 
 ```
-Tool: mcp__claude-flow__task_results
+Tool: mcp__moflo__task_results
 Parameters: {"taskId": "task-123", "format": "detailed"}
 
 Result includes:

--- a/.claude/commands/analysis/token-efficiency.md
+++ b/.claude/commands/analysis/token-efficiency.md
@@ -19,7 +19,7 @@ Reduce token consumption while maintaining quality through intelligent coordinat
 
 ```bash
 # Check token savings after session
-Tool: mcp__claude-flow__token_usage
+Tool: mcp__moflo__token_usage
 Parameters: {"operation": "session", "timeframe": "24h"}
 
 # Result shows:

--- a/.claude/commands/automation/auto-agent.md
+++ b/.claude/commands/automation/auto-agent.md
@@ -107,7 +107,7 @@ npx claude-flow auto agent -t "Fix bug in login" -s minimal
 
 ```javascript
 // In Claude Code after auto-spawning
-mcp__claude-flow__auto_agent {
+mcp__moflo__auto_agent {
   task: "Build authentication system",
   strategy: "balanced",
   maxAgents: 6

--- a/.claude/commands/automation/self-healing.md
+++ b/.claude/commands/automation/self-healing.md
@@ -47,7 +47,7 @@ Each recovery improves future prevention:
 **Pattern Storage:**
 ```javascript
 // Store error patterns
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "error-pattern-" + Date.now(),
   "value": JSON.stringify(errorData),
@@ -56,7 +56,7 @@ mcp__claude-flow__memory_usage({
 })
 
 // Analyze patterns
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "analyze",
   "operation": "error-recovery",
   "outcome": "success"
@@ -68,21 +68,21 @@ mcp__claude-flow__neural_patterns({
 ### MCP Tool Coordination
 ```javascript
 // Initialize self-healing swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 4,
   "strategy": "adaptive"
 })
 
 // Spawn recovery agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "monitor",
   "name": "Error Monitor",
   "capabilities": ["error-detection", "recovery"]
 })
 
 // Orchestrate recovery
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "recover from error",
   "strategy": "sequential",
   "priority": "critical"

--- a/.claude/commands/automation/session-memory.md
+++ b/.claude/commands/automation/session-memory.md
@@ -16,14 +16,14 @@ At session end, automatically saves:
 ### 2. Session Restoration
 ```javascript
 // Using MCP tools for memory operations
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "retrieve",
   "key": "session-state",
   "namespace": "sessions"
 })
 
 // Restore swarm state
-mcp__claude-flow__context_restore({
+mcp__moflo__context_restore({
   "snapshotId": "sess-123"
 })
 ```
@@ -56,20 +56,20 @@ npx claude-flow hook session-restore --session-id "sess-123"
 ### 4. Privacy & Control
 ```javascript
 // List memory contents
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "list",
   "namespace": "sessions"
 })
 
 // Delete specific memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "delete",
   "key": "session-123",
   "namespace": "sessions"
 })
 
 // Backup memory
-mcp__claude-flow__memory_backup({
+mcp__moflo__memory_backup({
   "path": "./backups/memory-backup.json"
 })
 ```

--- a/.claude/commands/automation/smart-agents.md
+++ b/.claude/commands/automation/smart-agents.md
@@ -30,12 +30,12 @@ The system monitors workload and spawns additional agents when:
 **Status Monitoring:**
 ```javascript
 // Check swarm health
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "current"
 })
 
 // Monitor agent performance
-mcp__claude-flow__agent_metrics({
+mcp__moflo__agent_metrics({
   "agentId": "agent-123"
 })
 ```
@@ -46,14 +46,14 @@ mcp__claude-flow__agent_metrics({
 Uses Claude Flow MCP tools for agent coordination:
 ```javascript
 // Initialize swarm with appropriate topology
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 8,
   "strategy": "auto"
 })
 
 // Spawn agents based on file type
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coder",
   "name": "JavaScript Handler",
   "capabilities": ["javascript", "typescript"]

--- a/.claude/commands/coordination/init.md
+++ b/.claude/commands/coordination/init.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__swarm_init`
+**Tool:** `mcp__moflo__swarm_init`
 
 ## Parameters
 ```json
@@ -27,7 +27,7 @@ Remember: This does NOT create actual coding agents. It creates a coordination p
 ## Example Usage
 
 **In Claude Code:**
-1. Use the tool: `mcp__claude-flow__swarm_init`
+1. Use the tool: `mcp__moflo__swarm_init`
 2. With parameters: `{"topology": "mesh", "maxAgents": 5, "strategy": "balanced"}`
 3. Claude Code then executes the coordinated plan using its native tools
 

--- a/.claude/commands/coordination/orchestrate.md
+++ b/.claude/commands/coordination/orchestrate.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__task_orchestrate`
+**Tool:** `mcp__moflo__task_orchestrate`
 
 ## Parameters
 ```json
@@ -26,7 +26,7 @@ The orchestrator creates a plan that Claude Code follows using its native tools.
 ## Example Usage
 
 **In Claude Code:**
-1. Use the tool: `mcp__claude-flow__task_orchestrate`
+1. Use the tool: `mcp__moflo__task_orchestrate`
 2. With parameters: `{"task": "Implement authentication system", "strategy": "parallel", "priority": "high"}`
 3. Claude Code then executes the coordinated plan using its native tools
 

--- a/.claude/commands/coordination/spawn.md
+++ b/.claude/commands/coordination/spawn.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__agent_spawn`
+**Tool:** `mcp__moflo__agent_spawn`
 
 ## Parameters
 ```json
@@ -28,7 +28,7 @@ These patterns guide how Claude Code approaches different aspects of your task.
 ## Example Usage
 
 **In Claude Code:**
-1. Use the tool: `mcp__claude-flow__agent_spawn`
+1. Use the tool: `mcp__moflo__agent_spawn`
 2. With parameters: `{"type": "researcher", "name": "Literature Analysis", "capabilities": ["deep-analysis"]}`
 3. Claude Code then executes the coordinated plan using its native tools
 

--- a/.claude/commands/coordination/swarm-init.md
+++ b/.claude/commands/coordination/swarm-init.md
@@ -74,7 +74,7 @@ npx claude-flow swarm init --topology star --github --memory
 Once initialized, use MCP tools in Claude Code:
 
 ```javascript
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 8 }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 8 }
 ```
 
 ## See Also

--- a/.claude/commands/github/github-modes.md
+++ b/.claude/commands/github/github-modes.md
@@ -137,11 +137,11 @@ All GitHub modes can be enhanced with ruv-swarm coordination:
 
 ```javascript
 // Initialize swarm for GitHub workflow
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
-mcp__claude-flow__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
+mcp__moflo__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
 ```

--- a/.claude/commands/github/github-swarm.md
+++ b/.claude/commands/github/github-swarm.md
@@ -106,7 +106,7 @@ npx claude-flow github swarm -r owner/repo -a 8 -f triage --issue-labels --auto-
 Use in Claude Code with MCP tools:
 
 ```javascript
-mcp__claude-flow__github_swarm {
+mcp__moflo__github_swarm {
   repository: "owner/repo",
   agents: 6,
   focus: "maintenance"

--- a/.claude/commands/github/issue-tracker.md
+++ b/.claude/commands/github/issue-tracker.md
@@ -17,7 +17,7 @@ Intelligent issue management and project coordination with ruv-swarm integration
 - `mcp__github__update_issue`
 - `mcp__github__add_issue_comment`
 - `mcp__github__search_issues`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -25,10 +25,10 @@ Intelligent issue management and project coordination with ruv-swarm integration
 ### 1. Create Coordinated Issue with Swarm Tracking
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -53,7 +53,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"
@@ -63,7 +63,7 @@ mcp__claude-flow__task_orchestrate {
 ### 2. Automated Progress Updates
 ```javascript
 // Update issue with progress from swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "issue/54/progress"
 }
@@ -92,7 +92,7 @@ mcp__github__add_issue_comment {
 }
 
 // Store progress in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/54/latest_update",
   value: { timestamp: Date.now(), progress: "89%", status: "near_completion" }
@@ -125,10 +125,10 @@ mcp__github__update_issue {
 ```javascript
 [Single Message - Issue Lifecycle Management]:
   // Initialize issue coordination swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Manager" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Progress Tracker" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Context Gatherer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Manager" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Progress Tracker" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Context Gatherer" }
   
   // Create multiple related issues using gh CLI
   Bash(`gh issue create \
@@ -158,7 +158,7 @@ mcp__github__update_issue {
   ]}
   
   // Store initial coordination state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "project/github_integration/issues",
     value: { created: Date.now(), total_issues: 3, status: "initialized" }

--- a/.claude/commands/github/pr-manager.md
+++ b/.claude/commands/github/pr-manager.md
@@ -21,7 +21,7 @@ Comprehensive pull request management with ruv-swarm coordination for automated 
 - `mcp__github__update_pull_request_branch`
 - `mcp__github__get_pull_request_comments`
 - `mcp__github__get_pull_request_reviews`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -29,10 +29,10 @@ Comprehensive pull request management with ruv-swarm coordination for automated 
 ### 1. Create and Manage PR with Swarm Coordination
 ```javascript
 // Initialize review swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Testing Agent" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Testing Agent" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
 
 // Create PR and orchestrate review
 mcp__github__create_pull_request {
@@ -45,7 +45,7 @@ mcp__github__create_pull_request {
 }
 
 // Orchestrate review process
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review with testing and validation",
   strategy: "parallel",
   priority: "high"
@@ -87,7 +87,7 @@ mcp__github__merge_pull_request {
 }
 
 // Post-merge coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/54/merged",
   value: { timestamp: Date.now(), status: "success" }
@@ -100,10 +100,10 @@ mcp__claude-flow__memory_usage {
 ```javascript
 [Single Message - Complete PR Management]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
   
   // Create and manage PR using gh CLI
   Bash("gh pr create --repo :owner/:repo --title '...' --head '...' --base 'main'")

--- a/.claude/commands/github/release-manager.md
+++ b/.claude/commands/github/release-manager.md
@@ -16,7 +16,7 @@ Automated release coordination and deployment with ruv-swarm orchestration for s
 - `mcp__github__create_branch`
 - `mcp__github__push_files`
 - `mcp__github__create_issue`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`
 
 ## Usage Patterns
@@ -24,12 +24,12 @@ Automated release coordination and deployment with ruv-swarm orchestration for s
 ### 1. Coordinated Release Preparation
 ```javascript
 // Initialize release management swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Coordinator" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Release Coordinator" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
 
 // Create release preparation branch
 mcp__github__create_branch {
@@ -40,7 +40,7 @@ mcp__github__create_branch {
 }
 
 // Orchestrate release preparation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Prepare release v1.0.72 with comprehensive testing and validation",
   strategy: "sequential",
   priority: "critical"
@@ -177,13 +177,13 @@ This release is production-ready with comprehensive validation and testing.
 ```javascript
 [Single Message - Complete Release Management]:
   // Initialize comprehensive release swarm
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 8 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Lead" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Controller" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Performance Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 8 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Lead" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Controller" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Performance Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
   
   // Create release branch and prepare files using gh CLI
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v1.0.72' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
@@ -222,7 +222,7 @@ This release is production-ready with comprehensive validation and testing.
   ]}
   
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store", 
     key: "release/v1.0.72/status",
     value: {

--- a/.claude/commands/github/repo-architect.md
+++ b/.claude/commands/github/repo-architect.md
@@ -16,7 +16,7 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 - `mcp__github__search_repositories`
 - `mcp__github__push_files`
 - `mcp__github__create_or_update_file`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `LS`, `Glob`
 
 ## Usage Patterns
@@ -24,11 +24,11 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 ### 1. Repository Structure Analysis and Optimization
 ```javascript
 // Initialize architecture analysis swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Repository Architect" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyzer" }
+mcp__moflo__agent_spawn { type: "architect", name: "Repository Architect" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
 
 // Analyze current repository structure
 LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -42,7 +42,7 @@ mcp__github__search_repositories {
 }
 
 // Orchestrate structure optimization
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze and optimize repository structure for scalability and maintainability",
   strategy: "adaptive",
   priority: "medium"
@@ -169,12 +169,12 @@ jobs:
 ```javascript
 [Single Message - Repository Architecture Review]:
   // Initialize comprehensive architecture swarm
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "architect", name: "Senior Architect" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyst" }
-  mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "architect", name: "Senior Architect" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyst" }
+  mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
   
   // Analyze current repository structures
   LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -223,7 +223,7 @@ jobs:
   ]}
   
   // Store architecture analysis
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "architecture/analysis/results",
     value: {

--- a/.claude/commands/github/sync-coordinator.md
+++ b/.claude/commands/github/sync-coordinator.md
@@ -16,7 +16,7 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 - `mcp__github__get_file_contents`
 - `mcp__github__create_pull_request`
 - `mcp__github__search_repositories`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`, `MultiEdit`
 
 ## Usage Patterns
@@ -24,11 +24,11 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 ### 1. Synchronize Package Dependencies
 ```javascript
 // Initialize sync coordination swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 // Analyze current package states
 Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -47,7 +47,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/packa
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/package.json?ref=sync/package-alignment --jq '.sha')")`)
 
 // Orchestrate validation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Validate package synchronization and run integration tests",
   strategy: "parallel",
   priority: "high"
@@ -73,7 +73,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUD
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUDE.md?ref=sync/documentation --jq '.sha' 2>/dev/null || echo '')")`)
 
 // Store sync state in memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/documentation/status",
   value: { timestamp: Date.now(), status: "synchronized", files: ["CLAUDE.md"] }
@@ -147,12 +147,12 @@ This integration uses ruv-swarm agents for:
 ```javascript
 [Single Message - Complete Synchronization]:
   // Initialize comprehensive sync swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Package Analyzer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Coder" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Tester" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Package Analyzer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Integration Coder" }
+  mcp__moflo__agent_spawn { type: "tester", name: "Validation Tester" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
   
   // Read current state of both packages
   Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -186,7 +186,7 @@ This integration uses ruv-swarm agents for:
   ]}
   
   // Store comprehensive sync state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "sync/complete/status",
     value: {

--- a/.claude/commands/memory/neural.md
+++ b/.claude/commands/memory/neural.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__neural_train`
+**Tool:** `mcp__moflo__neural_train`
 
 ## Parameters
 ```json
@@ -29,10 +29,10 @@ Training improves:
 ## Example Usage
 
 **In Claude Code:**
-1. Train coordination patterns: Use tool `mcp__claude-flow__neural_train` with parameters `{"pattern_type": "coordination", "training_data": "successful task patterns", "epochs": 50}`
-2. Train optimization patterns: Use tool `mcp__claude-flow__neural_train` with parameters `{"pattern_type": "optimization", "training_data": "performance metrics", "epochs": 30}`
-3. Check training status: Use tool `mcp__claude-flow__neural_status`
-4. Analyze patterns: Use tool `mcp__claude-flow__neural_patterns` with parameters `{"action": "analyze"}`
+1. Train coordination patterns: Use tool `mcp__moflo__neural_train` with parameters `{"pattern_type": "coordination", "training_data": "successful task patterns", "epochs": 50}`
+2. Train optimization patterns: Use tool `mcp__moflo__neural_train` with parameters `{"pattern_type": "optimization", "training_data": "performance metrics", "epochs": 30}`
+3. Check training status: Use tool `mcp__moflo__neural_status`
+4. Analyze patterns: Use tool `mcp__moflo__neural_patterns` with parameters `{"action": "analyze"}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/.claude/commands/monitoring/agents.md
+++ b/.claude/commands/monitoring/agents.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__agent_list`
+**Tool:** `mcp__moflo__agent_list`
 
 ## Parameters
 ```json
@@ -27,9 +27,9 @@ Filters:
 ## Example Usage
 
 **In Claude Code:**
-1. List all agents: Use tool `mcp__claude-flow__agent_list`
-2. Get specific agent metrics: Use tool `mcp__claude-flow__agent_metrics` with parameters `{"agentId": "coder-123"}`
-3. Monitor agent performance: Use tool `mcp__claude-flow__swarm_monitor` with parameters `{"interval": 2000}`
+1. List all agents: Use tool `mcp__moflo__agent_list`
+2. Get specific agent metrics: Use tool `mcp__moflo__agent_metrics` with parameters `{"agentId": "coder-123"}`
+3. Monitor agent performance: Use tool `mcp__moflo__swarm_monitor` with parameters `{"interval": 2000}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/.claude/commands/monitoring/status.md
+++ b/.claude/commands/monitoring/status.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__swarm_status`
+**Tool:** `mcp__moflo__swarm_status`
 
 ## Parameters
 ```json
@@ -28,10 +28,10 @@ Shows:
 ## Example Usage
 
 **In Claude Code:**
-1. Check swarm status: Use tool `mcp__claude-flow__swarm_status`
-2. Monitor in real-time: Use tool `mcp__claude-flow__swarm_monitor` with parameters `{"interval": 1000}`
-3. Get agent metrics: Use tool `mcp__claude-flow__agent_metrics` with parameters `{"agentId": "agent-123"}`
-4. Health check: Use tool `mcp__claude-flow__health_check` with parameters `{"components": ["swarm", "memory", "neural"]}`
+1. Check swarm status: Use tool `mcp__moflo__swarm_status`
+2. Monitor in real-time: Use tool `mcp__moflo__swarm_monitor` with parameters `{"interval": 1000}`
+3. Get agent metrics: Use tool `mcp__moflo__agent_metrics` with parameters `{"agentId": "agent-123"}`
+4. Health check: Use tool `mcp__moflo__health_check` with parameters `{"components": ["swarm", "memory", "neural"]}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/.claude/commands/optimization/auto-topology.md
+++ b/.claude/commands/optimization/auto-topology.md
@@ -23,14 +23,14 @@ Based on analysis, it selects:
 
 **Simple Task:**
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {"task": "Fix typo in README.md"}
 Result: Automatically uses star topology with single agent
 ```
 
 **Complex Task:**
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {"task": "Refactor authentication system with JWT, add tests, update documentation"}
 Result: Automatically uses hierarchical topology with architect, coder, and tester agents
 ```
@@ -51,7 +51,7 @@ The pre-task hook automatically handles topology selection:
 
 ## Direct Optimization
 ```
-Tool: mcp__claude-flow__topology_optimize
+Tool: mcp__moflo__topology_optimize
 Parameters: {"swarmId": "current"}
 ```
 

--- a/.claude/commands/optimization/parallel-execution.md
+++ b/.claude/commands/optimization/parallel-execution.md
@@ -7,7 +7,7 @@ Execute independent subtasks in parallel for maximum efficiency.
 
 ### 1. Task Decomposition
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {
   "task": "Build complete REST API with auth, CRUD operations, and tests",
   "strategy": "parallel",
@@ -43,7 +43,7 @@ npx claude-flow parallel "Build REST API" --max-agents 8
 
 ## Monitoring
 ```
-Tool: mcp__claude-flow__swarm_monitor
+Tool: mcp__moflo__swarm_monitor
 Parameters: {"interval": 1000, "swarmId": "current"}
 ```
 

--- a/.claude/commands/sparc.md
+++ b/.claude/commands/sparc.md
@@ -44,19 +44,19 @@ Use `new_task` to assign:
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
 // Run SPARC orchestrator (default)
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "sparc",
   task_description: "build complete authentication system"
 }
 
 // Run a specific mode
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design API structure"
 }
 
 // TDD workflow
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "implement user authentication",
   options: {workflow: "full"}
@@ -102,7 +102,7 @@ npx claude-flow@alpha sparc run <mode> "your task"
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store specifications
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "spec_auth",
   value: "OAuth2 + JWT requirements",
@@ -110,7 +110,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Store architectural decisions
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "arch_decisions",
   value: "Microservices with API Gateway",

--- a/.claude/commands/sparc/analyzer.md
+++ b/.claude/commands/sparc/analyzer.md
@@ -7,7 +7,7 @@ Deep code and data analysis with batch processing capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "analyzer",
   task_description: "analyze codebase performance",
   options: {

--- a/.claude/commands/sparc/architect.md
+++ b/.claude/commands/sparc/architect.md
@@ -7,7 +7,7 @@ System design with Memory-based coordination for scalable architectures.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design microservices architecture",
   options: {

--- a/.claude/commands/sparc/ask.md
+++ b/.claude/commands/sparc/ask.md
@@ -36,7 +36,7 @@ Help users craft `new_task` messages to delegate effectively, and always remind 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "ask",
   task_description: "help me choose the right mode",
   options: {
@@ -72,7 +72,7 @@ npx claude-flow sparc run ask "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "ask_context",
   value: "important decisions",
@@ -80,7 +80,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "ask",
   namespace: "ask",
   limit: 5

--- a/.claude/commands/sparc/batch-executor.md
+++ b/.claude/commands/sparc/batch-executor.md
@@ -7,7 +7,7 @@ Parallel task execution specialist using batch operations.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "batch-executor",
   task_description: "process multiple files",
   options: {

--- a/.claude/commands/sparc/code.md
+++ b/.claude/commands/sparc/code.md
@@ -28,7 +28,7 @@ Write modular code using clean architecture principles. Never hardcode secrets o
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "code",
   task_description: "implement REST API endpoints",
   options: {
@@ -64,7 +64,7 @@ npx claude-flow sparc run code "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "code_context",
   value: "important decisions",
@@ -72,7 +72,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "code",
   namespace: "code",
   limit: 5

--- a/.claude/commands/sparc/coder.md
+++ b/.claude/commands/sparc/coder.md
@@ -7,7 +7,7 @@ Autonomous code generation with batch file operations.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement user authentication",
   options: {

--- a/.claude/commands/sparc/debug.md
+++ b/.claude/commands/sparc/debug.md
@@ -22,7 +22,7 @@ Use logs, traces, and stack analysis to isolate bugs. Avoid changing env configu
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "debug",
   task_description: "fix memory leak in service",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run debug "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "debug_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "debug",
   namespace: "debug",
   limit: 5

--- a/.claude/commands/sparc/debugger.md
+++ b/.claude/commands/sparc/debugger.md
@@ -7,7 +7,7 @@ Systematic debugging with TodoWrite and Memory integration.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "debugger",
   task_description: "fix authentication issues",
   options: {

--- a/.claude/commands/sparc/designer.md
+++ b/.claude/commands/sparc/designer.md
@@ -7,7 +7,7 @@ UI/UX design with Memory coordination for consistent experiences.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "designer",
   task_description: "create dashboard UI",
   options: {

--- a/.claude/commands/sparc/devops.md
+++ b/.claude/commands/sparc/devops.md
@@ -48,7 +48,7 @@ Return `attempt_completion` with:
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "devops",
   task_description: "deploy to AWS Lambda",
   options: {
@@ -84,7 +84,7 @@ npx claude-flow sparc run devops "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "devops_context",
   value: "important decisions",
@@ -92,7 +92,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "devops",
   namespace: "devops",
   limit: 5

--- a/.claude/commands/sparc/docs-writer.md
+++ b/.claude/commands/sparc/docs-writer.md
@@ -19,7 +19,7 @@ Only work in .md files. Use sections, examples, and headings. Keep each file und
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "docs-writer",
   task_description: "create API documentation",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run docs-writer "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "docs-writer_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "docs-writer",
   namespace: "docs-writer",
   limit: 5

--- a/.claude/commands/sparc/documenter.md
+++ b/.claude/commands/sparc/documenter.md
@@ -7,7 +7,7 @@ Documentation with batch file operations for comprehensive docs.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "create API documentation",
   options: {

--- a/.claude/commands/sparc/innovator.md
+++ b/.claude/commands/sparc/innovator.md
@@ -7,7 +7,7 @@ Creative problem solving with WebSearch and Memory integration.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "innovative solutions for scaling",
   options: {

--- a/.claude/commands/sparc/integration.md
+++ b/.claude/commands/sparc/integration.md
@@ -22,7 +22,7 @@ Verify interface compatibility, shared modules, and env config standards. Split 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "integration",
   task_description: "connect payment service",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run integration "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "integration_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "integration",
   namespace: "integration",
   limit: 5

--- a/.claude/commands/sparc/mcp.md
+++ b/.claude/commands/sparc/mcp.md
@@ -56,7 +56,7 @@ For accessing MCP resources, use `access_mcp_resource` with proper URI:
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "mcp",
   task_description: "integrate with external API",
   options: {
@@ -92,7 +92,7 @@ npx claude-flow sparc run mcp "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "mcp_context",
   value: "important decisions",
@@ -100,7 +100,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "mcp",
   namespace: "mcp",
   limit: 5

--- a/.claude/commands/sparc/memory-manager.md
+++ b/.claude/commands/sparc/memory-manager.md
@@ -7,7 +7,7 @@ Knowledge management with Memory tools for persistent insights.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "memory-manager",
   task_description: "organize project knowledge",
   options: {

--- a/.claude/commands/sparc/optimizer.md
+++ b/.claude/commands/sparc/optimizer.md
@@ -7,7 +7,7 @@ Performance optimization with systematic analysis and improvements.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "optimizer",
   task_description: "optimize application performance",
   options: {

--- a/.claude/commands/sparc/orchestrator.md
+++ b/.claude/commands/sparc/orchestrator.md
@@ -7,7 +7,7 @@ Multi-agent task orchestration with TodoWrite/TodoRead/Task/Memory using MCP too
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "coordinate feature development"
 }
@@ -40,20 +40,20 @@ npx claude-flow@alpha sparc run orchestrator "coordinate feature development"
 ### Using MCP Tools (Preferred)
 ```javascript
 // Initialize orchestration swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "auto",
   maxAgents: 8
 }
 
 // Spawn coordinator agent
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "coordinator",
   capabilities: ["task-planning", "resource-management"]
 }
 
 // Orchestrate tasks
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "feature development",
   strategy: "parallel",
   dependencies: ["auth", "ui", "api"]
@@ -91,26 +91,26 @@ npx claude-flow task orchestrate --task "feature development" --strategy paralle
 ### Using MCP Tools (Preferred)
 ```javascript
 // 1. Initialize orchestration swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 10
 }
 
 // 2. Create workflow
-mcp__claude-flow__workflow_create {
+mcp__moflo__workflow_create {
   name: "feature-development",
   steps: ["design", "implement", "test", "deploy"]
 }
 
 // 3. Execute orchestration
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   options: {parallel: true, monitor: true},
   task_description: "develop user management system"
 }
 
 // 4. Monitor progress
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }

--- a/.claude/commands/sparc/post-deployment-monitoring-mode.md
+++ b/.claude/commands/sparc/post-deployment-monitoring-mode.md
@@ -22,7 +22,7 @@ Configure metrics, logs, uptime checks, and alerts. Recommend improvements if th
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "post-deployment-monitoring-mode",
   task_description: "monitor production metrics",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run post-deployment-monitoring-mode "your task" --non-inte
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "post-deployment-monitoring-mode_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "post-deployment-monitoring-mode",
   namespace: "post-deployment-monitoring-mode",
   limit: 5

--- a/.claude/commands/sparc/refinement-optimization-mode.md
+++ b/.claude/commands/sparc/refinement-optimization-mode.md
@@ -22,7 +22,7 @@ Audit files for clarity, modularity, and size. Break large components (>500 line
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "refinement-optimization-mode",
   task_description: "optimize database queries",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run refinement-optimization-mode "your task" --non-interac
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "refinement-optimization-mode_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "refinement-optimization-mode",
   namespace: "refinement-optimization-mode",
   limit: 5

--- a/.claude/commands/sparc/researcher.md
+++ b/.claude/commands/sparc/researcher.md
@@ -7,7 +7,7 @@ Deep research with parallel WebSearch/WebFetch and Memory coordination.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research AI trends 2024",
   options: {

--- a/.claude/commands/sparc/reviewer.md
+++ b/.claude/commands/sparc/reviewer.md
@@ -7,7 +7,7 @@ Code review using batch file analysis for comprehensive reviews.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review pull request #123",
   options: {

--- a/.claude/commands/sparc/security-review.md
+++ b/.claude/commands/sparc/security-review.md
@@ -19,7 +19,7 @@ Scan for exposed secrets, env leaks, and monoliths. Recommend mitigations or ref
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "security-review",
   task_description: "audit API security",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run security-review "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "security-review_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "security-review",
   namespace: "security-review",
   limit: 5

--- a/.claude/commands/sparc/sparc-modes.md
+++ b/.claude/commands/sparc/sparc-modes.md
@@ -34,7 +34,7 @@ SPARC (Specification, Planning, Architecture, Review, Code) is a comprehensive d
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
 // Execute SPARC mode directly
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "<mode>",
   task_description: "<task>",
   options: {
@@ -43,20 +43,20 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Initialize swarm for advanced coordination
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "auto",
   maxAgents: 8
 }
 
 // Spawn specialized agents
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "<agent-type>",
   capabilities: ["<capability1>", "<capability2>"]
 }
 
 // Monitor execution
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
@@ -93,31 +93,31 @@ npx claude-flow sparc run <mode> "task" --parallel --monitor
 #### Using MCP Tools (Preferred)
 ```javascript
 // 1. Initialize development swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 12
 }
 
 // 2. Architecture design
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design microservices"
 }
 
 // 3. Implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement services"
 }
 
 // 4. Testing
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "test all services"
 }
 
 // 5. Review
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review implementation"
 }
@@ -143,19 +143,19 @@ npx claude-flow sparc run reviewer "review implementation"
 #### Using MCP Tools (Preferred)
 ```javascript
 // 1. Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research best practices"
 }
 
 // 2. Innovation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "propose novel solutions"
 }
 
 // 3. Documentation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "document findings"
 }

--- a/.claude/commands/sparc/sparc.md
+++ b/.claude/commands/sparc/sparc.md
@@ -50,7 +50,7 @@ use new_task for each new task as a sub-task.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "sparc",
   task_description: "orchestrate authentication system",
   options: {
@@ -86,7 +86,7 @@ npx claude-flow sparc run sparc "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sparc_context",
   value: "important decisions",
@@ -94,7 +94,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "sparc",
   namespace: "sparc",
   limit: 5

--- a/.claude/commands/sparc/spec-pseudocode.md
+++ b/.claude/commands/sparc/spec-pseudocode.md
@@ -19,7 +19,7 @@ Write pseudocode as a series of md files with phase_number_name.md and flow logi
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "spec-pseudocode",
   task_description: "define payment flow requirements",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run spec-pseudocode "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "spec-pseudocode_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "spec-pseudocode",
   namespace: "spec-pseudocode",
   limit: 5

--- a/.claude/commands/sparc/supabase-admin.md
+++ b/.claude/commands/sparc/supabase-admin.md
@@ -287,7 +287,7 @@ Rebases a development branch on production. This will effectively run any newer 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "supabase-admin",
   task_description: "create user authentication schema",
   options: {
@@ -323,7 +323,7 @@ npx claude-flow sparc run supabase-admin "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "supabase-admin_context",
   value: "important decisions",
@@ -331,7 +331,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "supabase-admin",
   namespace: "supabase-admin",
   limit: 5

--- a/.claude/commands/sparc/swarm-coordinator.md
+++ b/.claude/commands/sparc/swarm-coordinator.md
@@ -7,7 +7,7 @@ Specialized swarm management with batch coordination capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "swarm-coordinator",
   task_description: "manage development swarm",
   options: {

--- a/.claude/commands/sparc/tdd.md
+++ b/.claude/commands/sparc/tdd.md
@@ -7,7 +7,7 @@ Test-driven development with TodoWrite planning and comprehensive testing.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "shopping cart feature",
   options: {

--- a/.claude/commands/sparc/tester.md
+++ b/.claude/commands/sparc/tester.md
@@ -7,7 +7,7 @@ Comprehensive testing with parallel execution capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "full regression suite",
   options: {

--- a/.claude/commands/sparc/tutorial.md
+++ b/.claude/commands/sparc/tutorial.md
@@ -18,7 +18,7 @@ You teach developers how to apply the SPARC methodology through actionable examp
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tutorial",
   task_description: "guide me through SPARC methodology",
   options: {
@@ -54,7 +54,7 @@ npx claude-flow sparc run tutorial "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "tutorial_context",
   value: "important decisions",
@@ -62,7 +62,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "tutorial",
   namespace: "tutorial",
   limit: 5

--- a/.claude/commands/sparc/workflow-manager.md
+++ b/.claude/commands/sparc/workflow-manager.md
@@ -7,7 +7,7 @@ Process automation with TodoWrite planning and Task execution.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "workflow-manager",
   task_description: "automate deployment",
   options: {

--- a/.claude/commands/swarm/analysis.md
+++ b/.claude/commands/swarm/analysis.md
@@ -8,14 +8,14 @@ Comprehensive analysis through distributed agent coordination.
 ### Using MCP Tools
 ```javascript
 // Initialize analysis swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
 })
 
 // Orchestrate analysis task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "analyze system performance",
   "strategy": "parallel",
   "priority": "medium"
@@ -30,25 +30,25 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn analysis agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Data Collector",
   "capabilities": ["metrics", "logging", "monitoring"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Pattern Analyzer",
   "capabilities": ["pattern-recognition", "anomaly-detection"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "documenter",
   "name": "Report Generator",
   "capabilities": ["reporting", "visualization"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coordinator",
   "name": "Insight Synthesizer",
   "capabilities": ["synthesis", "correlation"]
@@ -63,19 +63,19 @@ mcp__claude-flow__agent_spawn({
 ## Analysis Operations
 ```javascript
 // Run performance analysis
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "24h"
 })
 
 // Identify bottlenecks
-mcp__claude-flow__bottleneck_analyze({
+mcp__moflo__bottleneck_analyze({
   "component": "api",
   "metrics": ["response-time", "throughput"]
 })
 
 // Pattern recognition
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": performanceData,
   "patterns": ["anomaly", "trend", "cycle"]
 })
@@ -84,12 +84,12 @@ mcp__claude-flow__pattern_recognize({
 ## Status Monitoring
 ```javascript
 // Monitor analysis progress
-mcp__claude-flow__task_status({
+mcp__moflo__task_status({
   "taskId": "analysis-task-001"
 })
 
 // Get analysis results
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   "taskId": "analysis-task-001"
 })
 ```

--- a/.claude/commands/swarm/development.md
+++ b/.claude/commands/swarm/development.md
@@ -8,14 +8,14 @@ Coordinated development through specialized agent teams.
 ### Using MCP Tools
 ```javascript
 // Initialize development swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "hierarchical",
   "maxAgents": 8,
   "strategy": "balanced"
 })
 
 // Orchestrate development task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "build feature X",
   "strategy": "parallel",
   "priority": "high"
@@ -30,31 +30,31 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn development agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "architect",
   "name": "System Designer",
   "capabilities": ["system-design", "api-design"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coder",
   "name": "Frontend Developer",
   "capabilities": ["react", "typescript", "ui"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coder",
   "name": "Backend Developer",
   "capabilities": ["nodejs", "api", "database"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "specialist",
   "name": "Database Expert",
   "capabilities": ["sql", "nosql", "optimization"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Integration Tester",
   "capabilities": ["integration", "e2e", "api-testing"]
@@ -70,17 +70,17 @@ mcp__claude-flow__agent_spawn({
 ## Status Monitoring
 ```javascript
 // Check swarm status
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "development-swarm"
 })
 
 // Monitor agent performance
-mcp__claude-flow__agent_metrics({
+mcp__moflo__agent_metrics({
   "agentId": "architect-001"
 })
 
 // Real-time monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "development-swarm",
   "interval": 5000
 })
@@ -89,7 +89,7 @@ mcp__claude-flow__swarm_monitor({
 ## Error Handling
 ```javascript
 // Enable fault tolerance
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "auto-recovery"
 })

--- a/.claude/commands/swarm/examples.md
+++ b/.claude/commands/swarm/examples.md
@@ -7,28 +7,28 @@
 #### Using MCP Tools
 ```javascript
 // Initialize research swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
 })
 
 // Spawn research agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "researcher",
   "name": "AI Trends Researcher",
   "capabilities": ["web-search", "analysis", "synthesis"]
 })
 
 // Orchestrate research
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "research AI trends",
   "strategy": "parallel",
   "priority": "medium"
 })
 
 // Monitor progress
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "research-swarm"
 })
 ```
@@ -47,7 +47,7 @@ npx claude-flow swarm "research AI trends" \
 #### Using MCP Tools
 ```javascript
 // Initialize development swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "hierarchical",
   "maxAgents": 8,
   "strategy": "balanced"
@@ -62,7 +62,7 @@ const devAgents = [
 ]
 
 devAgents.forEach(agent => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     "type": agent.type,
     "name": agent.name,
     "swarmId": "dev-swarm"
@@ -70,14 +70,14 @@ devAgents.forEach(agent => {
 })
 
 // Orchestrate development
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "build REST API",
   "strategy": "sequential",
   "dependencies": ["design", "implement", "test", "document"]
 })
 
 // Enable monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "dev-swarm",
   "interval": 5000
 })
@@ -97,27 +97,27 @@ npx claude-flow swarm "build REST API" \
 #### Using MCP Tools
 ```javascript
 // Initialize analysis swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 5,
   "strategy": "adaptive"
 })
 
 // Spawn analysis agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Code Analyzer",
   "capabilities": ["static-analysis", "complexity-analysis"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Security Analyzer",
   "capabilities": ["security-scan", "vulnerability-detection"]
 })
 
 // Parallel analysis execution
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "analyze-code", "command": "analyze codebase structure" },
     { "id": "analyze-security", "command": "scan for vulnerabilities" },
@@ -126,7 +126,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Generate comprehensive report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current"
 })
@@ -145,23 +145,23 @@ npx claude-flow swarm "analyze codebase" \
 
 ```javascript
 // Setup fault tolerance
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "auto-recovery"
 })
 
 // Handle errors gracefully
 try {
-  await mcp__claude-flow__task_orchestrate({
+  await mcp__moflo__task_orchestrate({
     "task": "complex operation",
     "strategy": "parallel"
   })
 } catch (error) {
   // Check swarm health
-  const status = await mcp__claude-flow__swarm_status({})
+  const status = await mcp__moflo__swarm_status({})
   
   // Log error patterns
-  await mcp__claude-flow__error_analysis({
+  await mcp__moflo__error_analysis({
     "logs": [error.message]
   })
 }

--- a/.claude/commands/swarm/maintenance.md
+++ b/.claude/commands/swarm/maintenance.md
@@ -8,14 +8,14 @@ System maintenance and updates through coordinated agents.
 ### Using MCP Tools
 ```javascript
 // Initialize maintenance swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 5,
   "strategy": "sequential"
 })
 
 // Orchestrate maintenance task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "update dependencies",
   "strategy": "sequential",
   "priority": "medium",
@@ -31,25 +31,25 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn maintenance agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Dependency Analyzer",
   "capabilities": ["dependency-analysis", "version-management"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "monitor",
   "name": "Security Scanner",
   "capabilities": ["security", "vulnerability-scan"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Test Runner",
   "capabilities": ["testing", "validation"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "documenter",
   "name": "Documentation Updater",
   "capabilities": ["documentation", "changelog"]
@@ -61,18 +61,18 @@ mcp__claude-flow__agent_spawn({
 ### Backup and Recovery
 ```javascript
 // Create system backup
-mcp__claude-flow__backup_create({
+mcp__moflo__backup_create({
   "components": ["code", "config", "dependencies"],
   "destination": "./backups/maintenance-" + Date.now()
 })
 
 // Create state snapshot
-mcp__claude-flow__state_snapshot({
+mcp__moflo__state_snapshot({
   "name": "pre-maintenance-" + Date.now()
 })
 
 // Enable fault tolerance
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "checkpoint-recovery"
 })
@@ -81,7 +81,7 @@ mcp__claude-flow__daa_fault_tolerance({
 ### Security Scanning
 ```javascript
 // Run security scan
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   "target": "./",
   "depth": "comprehensive"
 })
@@ -90,12 +90,12 @@ mcp__claude-flow__security_scan({
 ### Monitoring
 ```javascript
 // Health check before/after
-mcp__claude-flow__health_check({
+mcp__moflo__health_check({
   "components": ["dependencies", "tests", "build"]
 })
 
 // Monitor maintenance progress
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "maintenance-swarm",
   "interval": 3000
 })

--- a/.claude/commands/swarm/optimization.md
+++ b/.claude/commands/swarm/optimization.md
@@ -8,14 +8,14 @@ Performance optimization through specialized analysis.
 ### Using MCP Tools
 ```javascript
 // Initialize optimization swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
 })
 
 // Orchestrate optimization task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "optimize performance",
   "strategy": "parallel",
   "priority": "high"
@@ -30,25 +30,25 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn optimization agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "optimizer",
   "name": "Performance Profiler",
   "capabilities": ["profiling", "bottleneck-detection"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Memory Analyzer",
   "capabilities": ["memory-analysis", "leak-detection"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "optimizer",
   "name": "Code Optimizer",
   "capabilities": ["code-optimization", "refactoring"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Benchmark Runner",
   "capabilities": ["benchmarking", "performance-testing"]
@@ -60,18 +60,18 @@ mcp__claude-flow__agent_spawn({
 ### Performance Analysis
 ```javascript
 // Analyze bottlenecks
-mcp__claude-flow__bottleneck_analyze({
+mcp__moflo__bottleneck_analyze({
   "component": "all",
   "metrics": ["cpu", "memory", "io", "network"]
 })
 
 // Run benchmarks
-mcp__claude-flow__benchmark_run({
+mcp__moflo__benchmark_run({
   "suite": "performance"
 })
 
 // WASM optimization
-mcp__claude-flow__wasm_optimize({
+mcp__moflo__wasm_optimize({
   "operation": "simd-acceleration"
 })
 ```
@@ -79,18 +79,18 @@ mcp__claude-flow__wasm_optimize({
 ### Optimization Operations
 ```javascript
 // Optimize topology
-mcp__claude-flow__topology_optimize({
+mcp__moflo__topology_optimize({
   "swarmId": "optimization-swarm"
 })
 
 // DAA optimization
-mcp__claude-flow__daa_optimization({
+mcp__moflo__daa_optimization({
   "target": "performance",
   "metrics": ["speed", "memory", "efficiency"]
 })
 
 // Load balancing
-mcp__claude-flow__load_balance({
+mcp__moflo__load_balance({
   "swarmId": "optimization-swarm",
   "tasks": optimizationTasks
 })
@@ -99,19 +99,19 @@ mcp__claude-flow__load_balance({
 ### Monitoring and Reporting
 ```javascript
 // Performance report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "7d"
 })
 
 // Trend analysis
-mcp__claude-flow__trend_analysis({
+mcp__moflo__trend_analysis({
   "metric": "performance",
   "period": "30d"
 })
 
 // Cost analysis
-mcp__claude-flow__cost_analysis({
+mcp__moflo__cost_analysis({
   "timeframe": "30d"
 })
 ```

--- a/.claude/commands/swarm/research.md
+++ b/.claude/commands/swarm/research.md
@@ -8,14 +8,14 @@ Deep research through parallel information gathering.
 ### Using MCP Tools
 ```javascript
 // Initialize research swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
 })
 
 // Orchestrate research task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "research topic X",
   "strategy": "parallel",
   "priority": "medium"
@@ -30,25 +30,25 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn research agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "researcher",
   "name": "Web Researcher",
   "capabilities": ["web-search", "content-extraction", "source-validation"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "researcher",
   "name": "Academic Researcher",
   "capabilities": ["paper-analysis", "citation-tracking", "literature-review"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Data Analyst",
   "capabilities": ["data-processing", "statistical-analysis", "visualization"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "documenter",
   "name": "Report Writer",
   "capabilities": ["synthesis", "technical-writing", "formatting"]
@@ -60,7 +60,7 @@ mcp__claude-flow__agent_spawn({
 ### Information Gathering
 ```javascript
 // Parallel information collection
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "web-search", "command": "search recent publications" },
     { "id": "academic-search", "command": "search academic databases" },
@@ -69,7 +69,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Store research findings
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "research-findings-" + Date.now(),
   "value": JSON.stringify(findings),
@@ -81,18 +81,18 @@ mcp__claude-flow__memory_usage({
 ### Analysis and Validation
 ```javascript
 // Pattern recognition in findings
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": researchData,
   "patterns": ["trend", "correlation", "outlier"]
 })
 
 // Cognitive analysis
-mcp__claude-flow__cognitive_analyze({
+mcp__moflo__cognitive_analyze({
   "behavior": "research-synthesis"
 })
 
 // Cross-reference validation
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "research-sources",
   "criteria": ["credibility", "relevance", "recency"]
 })
@@ -101,14 +101,14 @@ mcp__claude-flow__quality_assess({
 ### Knowledge Management
 ```javascript
 // Search existing knowledge
-mcp__claude-flow__memory_search({
+mcp__moflo__memory_search({
   "pattern": "topic X",
   "namespace": "research",
   "limit": 20
 })
 
 // Create knowledge connections
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "learn",
   "operation": "knowledge-graph",
   "metadata": {
@@ -121,7 +121,7 @@ mcp__claude-flow__neural_patterns({
 ### Reporting
 ```javascript
 // Generate research report
-mcp__claude-flow__workflow_execute({
+mcp__moflo__workflow_execute({
   "workflowId": "research-report-generation",
   "params": {
     "findings": findings,
@@ -130,7 +130,7 @@ mcp__claude-flow__workflow_execute({
 })
 
 // Monitor progress
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "research-swarm"
 })
 ```

--- a/.claude/commands/swarm/testing.md
+++ b/.claude/commands/swarm/testing.md
@@ -8,14 +8,14 @@ Comprehensive testing through distributed execution.
 ### Using MCP Tools
 ```javascript
 // Initialize testing swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 7,
   "strategy": "parallel"
 })
 
 // Orchestrate testing task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "test application",
   "strategy": "parallel",
   "priority": "high"
@@ -30,31 +30,31 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn testing agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Unit Tester",
   "capabilities": ["unit-testing", "mocking", "coverage"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Integration Tester",
   "capabilities": ["integration", "api-testing", "contract-testing"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "E2E Tester",
   "capabilities": ["e2e", "ui-testing", "user-flows"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Performance Tester",
   "capabilities": ["load-testing", "stress-testing", "benchmarking"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "monitor",
   "name": "Security Tester",
   "capabilities": ["security-testing", "penetration-testing", "vulnerability-scanning"]
@@ -66,13 +66,13 @@ mcp__claude-flow__agent_spawn({
 ### Coverage Analysis
 ```javascript
 // Quality assessment
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "test-coverage",
   "criteria": ["line-coverage", "branch-coverage", "function-coverage"]
 })
 
 // Edge case detection
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": testScenarios,
   "patterns": ["edge-case", "boundary-condition", "error-path"]
 })
@@ -81,7 +81,7 @@ mcp__claude-flow__pattern_recognize({
 ### Test Execution
 ```javascript
 // Parallel test execution
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "unit-tests", "command": "npm run test:unit" },
     { "id": "integration-tests", "command": "npm run test:integration" },
@@ -90,7 +90,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Batch processing for test suites
-mcp__claude-flow__batch_process({
+mcp__moflo__batch_process({
   "items": testSuites,
   "operation": "execute-test-suite"
 })
@@ -99,12 +99,12 @@ mcp__claude-flow__batch_process({
 ### Performance Testing
 ```javascript
 // Run performance benchmarks
-mcp__claude-flow__benchmark_run({
+mcp__moflo__benchmark_run({
   "suite": "performance-tests"
 })
 
 // Security scanning
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   "target": "application",
   "depth": "comprehensive"
 })
@@ -113,19 +113,19 @@ mcp__claude-flow__security_scan({
 ### Monitoring and Reporting
 ```javascript
 // Monitor test execution
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "testing-swarm",
   "interval": 2000
 })
 
 // Generate test report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current-run"
 })
 
 // Get test results
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   "taskId": "test-execution-001"
 })
 ```

--- a/.claude/commands/training/neural-patterns.md
+++ b/.claude/commands/training/neural-patterns.md
@@ -14,7 +14,7 @@ Every successful operation trains the neural networks:
 
 ### 2. Manual Training
 ```
-Tool: mcp__claude-flow__neural_train
+Tool: mcp__moflo__neural_train
 Parameters: {
   "pattern_type": "coordination",
   "training_data": "successful task patterns",
@@ -34,7 +34,7 @@ Parameters: {
 
 ### 4. Improvement Tracking
 ```
-Tool: mcp__claude-flow__neural_status
+Tool: mcp__moflo__neural_status
 Result: {
   "patterns": {
     "convergent": 0.92,
@@ -48,7 +48,7 @@ Result: {
 
 ## Pattern Analysis
 ```
-Tool: mcp__claude-flow__neural_patterns
+Tool: mcp__moflo__neural_patterns
 Parameters: {
   "action": "analyze",
   "operation": "recent_edits"

--- a/.claude/commands/training/specialization.md
+++ b/.claude/commands/training/specialization.md
@@ -14,7 +14,7 @@ Agents automatically specialize based on file extensions:
 
 ### 2. By Task Type
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {
   "type": "coder",
   "capabilities": ["react", "typescript", "testing"],
@@ -32,7 +32,7 @@ The system trains through:
 ### 4. Specialization Benefits
 ```
 # Check agent specializations
-Tool: mcp__claude-flow__agent_list
+Tool: mcp__moflo__agent_list
 Parameters: {"swarmId": "current"}
 
 Result shows expertise levels:

--- a/.claude/commands/workflows/development.md
+++ b/.claude/commands/workflows/development.md
@@ -7,14 +7,14 @@ Structure Claude Code's approach to complex development tasks for maximum effici
 
 ### 1. Initialize Development Framework
 ```
-Tool: mcp__claude-flow__swarm_init
+Tool: mcp__moflo__swarm_init
 Parameters: {"topology": "hierarchical", "maxAgents": 8, "strategy": "specialized"}
 ```
 Creates hierarchical structure for organized, top-down development.
 
 ### 2. Define Development Perspectives
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {
   "type": "architect",
   "name": "System Design",
@@ -22,7 +22,7 @@ Parameters: {
 }
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {
   "type": "coder",
   "name": "Implementation Focus",
@@ -30,7 +30,7 @@ Parameters: {
 }
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {
   "type": "tester",
   "name": "Quality Assurance",
@@ -41,7 +41,7 @@ Sets up architectural and implementation thinking patterns.
 
 ### 3. Coordinate Implementation
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {
   "task": "Build REST API with authentication",
   "strategy": "parallel",
@@ -52,7 +52,7 @@ Parameters: {
 
 ### 4. Monitor Progress
 ```
-Tool: mcp__claude-flow__task_status
+Tool: mcp__moflo__task_status
 Parameters: {"taskId": "api-build-task-123"}
 ```
 

--- a/.claude/commands/workflows/research.md
+++ b/.claude/commands/workflows/research.md
@@ -7,25 +7,25 @@ Coordinate Claude Code's research activities for comprehensive, systematic explo
 
 ### 1. Initialize Research Framework
 ```
-Tool: mcp__claude-flow__swarm_init
+Tool: mcp__moflo__swarm_init
 Parameters: {"topology": "mesh", "maxAgents": 5, "strategy": "balanced"}
 ```
 Creates a mesh topology for comprehensive exploration from multiple angles.
 
 ### 2. Define Research Perspectives
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {"type": "researcher", "name": "Literature Review"}
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn  
+Tool: mcp__moflo__agent_spawn  
 Parameters: {"type": "analyst", "name": "Data Analysis"}
 ```
 Sets up different analytical approaches for Claude Code to use.
 
 ### 3. Execute Coordinated Research
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {
   "task": "Research modern web frameworks performance",
   "strategy": "adaptive",
@@ -35,7 +35,7 @@ Parameters: {
 
 ### 4. Store Research Findings
 ```
-Tool: mcp__claude-flow__memory_usage
+Tool: mcp__moflo__memory_usage
 Parameters: {
   "action": "store",
   "key": "research_findings",

--- a/.claude/guidance/shipped/agent-bootstrap.md
+++ b/.claude/guidance/shipped/agent-bootstrap.md
@@ -22,13 +22,13 @@
 
 ### Option A: MCP Tools (Preferred)
 
-If you have MCP tools available (check for `mcp__claude-flow__*`), use them directly:
+If you have MCP tools available (check for `mcp__moflo__*`), use them directly:
 
 | Tool | Purpose |
 |------|---------|
-| `mcp__claude-flow__memory_search` | Semantic search with domain-aware embeddings |
-| `mcp__claude-flow__memory_store` | Store patterns with auto-vectorization |
-| `mcp__claude-flow__hooks_route` | Get agent routing suggestions |
+| `mcp__moflo__memory_search` | Semantic search with domain-aware embeddings |
+| `mcp__moflo__memory_store` | Store patterns with auto-vectorization |
+| `mcp__moflo__hooks_route` | Get agent routing suggestions |
 
 ### Option B: CLI via Bash
 
@@ -103,7 +103,7 @@ If you discover something new (pattern, solution, gotcha), store it:
 
 ### MCP (Preferred):
 ```
-mcp__claude-flow__memory_store
+mcp__moflo__memory_store
   namespace: "patterns"
   key: "brief-descriptive-key"
   value: "1-2 sentence insight"

--- a/.claude/guidance/shipped/guidance-memory-strategy.md
+++ b/.claude/guidance/shipped/guidance-memory-strategy.md
@@ -36,7 +36,7 @@ build-embeddings.mjs - Generate 384-dim vectors per entry
 RuVector (@ruvector/core) -- HNSW index infrastructure
          v
 Search layer ---------- Three access paths:
-                          1. MCP tools (mcp__claude-flow__memory_search) -- preferred
+                          1. MCP tools (mcp__moflo__memory_search) -- preferred
                           2. CLI (npx flo memory search) -- fallback
                           3. Script (semantic-search.mjs) -- detailed output
 ```
@@ -250,7 +250,7 @@ npx flo-index --force
 npx flo memory search --query "your domain query" --namespace guidance
 
 # Verify from Claude Code via MCP
-# mcp__claude-flow__memory_search query="your domain query" namespace="guidance"
+# mcp__moflo__memory_search query="your domain query" namespace="guidance"
 ```
 
 ---

--- a/.claude/guidance/shipped/memory-strategy.md
+++ b/.claude/guidance/shipped/memory-strategy.md
@@ -63,7 +63,7 @@ See `guidance-memory-strategy.md` for full embedding pipeline details.
 
 All methods auto-detect the stored embedding model and generate matching query vectors:
 
-**MCP (Preferred):** `mcp__claude-flow__memory_search` — `query: "your query", namespace: "guidance"`
+**MCP (Preferred):** `mcp__moflo__memory_search` — `query: "your query", namespace: "guidance"`
 
 **CLI (Fallback):**
 ```bash
@@ -83,7 +83,7 @@ npx flo memory search --query "your query" --namespace guidance
 
 When you need to find where a type, service, entity, or component lives — search `code-map` BEFORE using Glob/Grep:
 
-**MCP:** `mcp__claude-flow__memory_search` — `query: "payment service", namespace: "code-map"`
+**MCP:** `mcp__moflo__memory_search` — `query: "payment service", namespace: "code-map"`
 
 **What code-map contains:**
 

--- a/.claude/guidance/shipped/moflo.md
+++ b/.claude/guidance/shipped/moflo.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Complete CLI and MCP reference for moflo — hooks, memory, agents, swarm, neural, and doctor commands. Read when using moflo features or debugging agent coordination.
 
-**MCP-First Policy:** Always prefer MCP tools (`mcp__claude-flow__*`) over CLI commands. Use `ToolSearch` to load them, then call directly. CLI is fallback only.
+**MCP-First Policy:** Always prefer MCP tools (`mcp__moflo__*`) over CLI commands. Use `ToolSearch` to load them, then call directly. CLI is fallback only.
 
 ---
 
@@ -93,7 +93,7 @@ MCP tools are the preferred way for Claude to interact with moflo. `flo init` cr
 ```json
 {
   "mcpServers": {
-    "claude-flow": {
+    "moflo": {
       "command": "node",
       "args": ["node_modules/moflo/src/@claude-flow/cli/bin/cli.js", "mcp", "start"]
     }
@@ -101,7 +101,7 @@ MCP tools are the preferred way for Claude to interact with moflo. `flo init` cr
 }
 ```
 
-This gives Claude access to 200+ MCP tools (`mcp__claude-flow__memory_*`, `mcp__claude-flow__hooks_*`, `mcp__claude-flow__swarm_*`, etc.) without any global installation.
+This gives Claude access to 200+ MCP tools (`mcp__moflo__memory_*`, `mcp__moflo__hooks_*`, `mcp__moflo__swarm_*`, etc.) without any global installation.
 
 ---
 
@@ -157,11 +157,11 @@ This gives Claude access to 200+ MCP tools (`mcp__claude-flow__memory_*`, `mcp__
 
 | Task | MCP Tool | CLI Fallback |
 |------|----------|-------------|
-| Search memory | `mcp__claude-flow__memory_search` | `memory search --query "..."` |
-| Spawn agent | `mcp__claude-flow__agent_spawn` | `agent spawn -t coder --name my-coder` |
-| Init swarm | `mcp__claude-flow__swarm_init` | `swarm init --v3-mode` |
-| System health | `mcp__claude-flow__system_health` | `doctor --fix` |
-| Benchmark | `mcp__claude-flow__performance_benchmark` | `performance benchmark --suite all` |
+| Search memory | `mcp__moflo__memory_search` | `memory search --query "..."` |
+| Spawn agent | `mcp__moflo__agent_spawn` | `agent spawn -t coder --name my-coder` |
+| Init swarm | `mcp__moflo__swarm_init` | `swarm init --v3-mode` |
+| System health | `mcp__moflo__system_health` | `doctor --fix` |
+| Benchmark | `mcp__moflo__performance_benchmark` | `performance benchmark --suite all` |
 
 **CLI-only (no MCP equivalent — setup tasks):**
 ```bash
@@ -263,13 +263,13 @@ npx flo daemon start
 
 | Hook | MCP Tool | Key Params |
 |------|----------|------------|
-| Pre-task | `mcp__claude-flow__hooks_pre-task` | `description` |
-| Post-task | `mcp__claude-flow__hooks_post-task` | `taskId`, `success` |
-| Post-edit | `mcp__claude-flow__hooks_post-edit` | `file`, `trainNeural` |
-| Session-start | `mcp__claude-flow__hooks_session-start` | `sessionId` |
-| Session-end | `mcp__claude-flow__hooks_session-end` | `exportMetrics` |
-| Route | `mcp__claude-flow__hooks_route` | `task` |
-| Worker-dispatch | `mcp__claude-flow__hooks_worker-dispatch` | `trigger` |
+| Pre-task | `mcp__moflo__hooks_pre-task` | `description` |
+| Post-task | `mcp__moflo__hooks_post-task` | `taskId`, `success` |
+| Post-edit | `mcp__moflo__hooks_post-edit` | `file`, `trainNeural` |
+| Session-start | `mcp__moflo__hooks_session-start` | `sessionId` |
+| Session-end | `mcp__moflo__hooks_session-end` | `exportMetrics` |
+| Route | `mcp__moflo__hooks_route` | `task` |
+| Worker-dispatch | `mcp__moflo__hooks_worker-dispatch` | `trigger` |
 
 ---
 
@@ -305,7 +305,7 @@ npx flo daemon start
 
 ### Before Starting Coding Tasks
 
-**MCP (Preferred):** `mcp__claude-flow__memory_search` — `query: "[task keywords]", namespace: "patterns"`
+**MCP (Preferred):** `mcp__moflo__memory_search` — `query: "[task keywords]", namespace: "patterns"`
 
 **CLI Fallback:**
 ```bash
@@ -316,9 +316,9 @@ npx flo memory search --query '[task keywords]' --namespace patterns
 
 | Step | MCP Tool | Key Params |
 |------|----------|------------|
-| 1. Store pattern | `mcp__claude-flow__memory_store` | `namespace: "patterns", key: "[name]", value: "[what worked]"` |
-| 2. Train neural | `mcp__claude-flow__hooks_post-edit` | `file: "[main-file]", trainNeural: true` |
-| 3. Record completion | `mcp__claude-flow__hooks_post-task` | `taskId: "[id]", success: true, storeResults: true` |
+| 1. Store pattern | `mcp__moflo__memory_store` | `namespace: "patterns", key: "[name]", value: "[what worked]"` |
+| 2. Train neural | `mcp__moflo__hooks_post-edit` | `file: "[main-file]", trainNeural: true` |
+| 3. Record completion | `mcp__moflo__hooks_post-task` | `taskId: "[id]", success: true, storeResults: true` |
 
 ### Continuous Improvement Triggers
 
@@ -351,7 +351,7 @@ npx flo memory search --query '[task keywords]' --namespace patterns
 
 ### Store Data
 
-**MCP:** `mcp__claude-flow__memory_store`
+**MCP:** `mcp__moflo__memory_store`
 - Required: `key`, `value`
 - Optional: `namespace` (default: "default"), `ttl`, `tags`
 
@@ -362,7 +362,7 @@ npx flo memory store --key "pattern-auth" --value "JWT with refresh tokens" --na
 
 ### Search Data (semantic vector search)
 
-**MCP:** `mcp__claude-flow__memory_search`
+**MCP:** `mcp__moflo__memory_search`
 - Required: `query`
 - Optional: `namespace`, `limit`, `threshold`
 
@@ -373,12 +373,12 @@ npx flo memory search --query "authentication patterns" --namespace patterns --l
 
 ### List Entries
 
-**MCP:** `mcp__claude-flow__memory_list`
+**MCP:** `mcp__moflo__memory_list`
 - Optional: `namespace`, `limit`
 
 ### Retrieve Specific Entry
 
-**MCP:** `mcp__claude-flow__memory_retrieve`
+**MCP:** `mcp__moflo__memory_retrieve`
 - Required: `key`
 - Optional: `namespace` (default: "default")
 
@@ -397,11 +397,11 @@ npx flo memory search --query "authentication patterns" --namespace patterns --l
 
 | Operation | MCP Tool |
 |-----------|----------|
-| Swarm init | `mcp__claude-flow__swarm_init` |
-| Agent spawn | `mcp__claude-flow__agent_spawn` |
-| Memory store | `mcp__claude-flow__memory_store` |
-| Memory search | `mcp__claude-flow__memory_search` |
-| Hooks (all) | `mcp__claude-flow__hooks_<hook-name>` |
+| Swarm init | `mcp__moflo__swarm_init` |
+| Agent spawn | `mcp__moflo__agent_spawn` |
+| Memory store | `mcp__moflo__memory_store` |
+| Memory search | `mcp__moflo__memory_search` |
+| Hooks (all) | `mcp__moflo__hooks_<hook-name>` |
 
 ### CLI Commands (Fallback Only):
 
@@ -416,7 +416,7 @@ npx flo <command> [options]
 
 ## Doctor Health Checks
 
-**MCP:** `mcp__claude-flow__system_health` | **CLI:** `npx flo doctor`
+**MCP:** `mcp__moflo__system_health` | **CLI:** `npx flo doctor`
 
 Checks: Node version (20+), Git, config validity, daemon status, memory database, API keys, MCP servers, disk space, TypeScript.
 
@@ -450,7 +450,7 @@ Configure `.mcp.json` in the project root:
 ```json
 {
   "mcpServers": {
-    "claude-flow": {
+    "moflo": {
       "command": "node",
       "args": ["node_modules/moflo/src/@claude-flow/cli/bin/cli.js", "mcp", "start"]
     }
@@ -461,7 +461,7 @@ Configure `.mcp.json` in the project root:
 ### Alternative: Global MCP Registration
 
 ```bash
-claude mcp add claude-flow -- npx @claude-flow/cli@alpha
+claude mcp add moflo -- npx @claude-flow/cli@alpha
 npx flo daemon start
 npx flo doctor --fix
 ```

--- a/.claude/guidance/shipped/task-swarm-integration.md
+++ b/.claude/guidance/shipped/task-swarm-integration.md
@@ -127,8 +127,8 @@ TaskUpdate({ taskId: "0", addBlockedBy: ["4", "5"] })  // Coordinator blocked by
 ### Step 3: Initialize Moflo Coordination
 
 **MCP (Preferred):**
-- Swarm: `mcp__claude-flow__swarm_init` (`topology: "hierarchical", maxAgents: 8, strategy: "specialized"`)
-- Hive-mind: `mcp__claude-flow__hive-mind_init` (`topology: "hierarchical-mesh", consensus: "byzantine"`)
+- Swarm: `mcp__moflo__swarm_init` (`topology: "hierarchical", maxAgents: 8, strategy: "specialized"`)
+- Hive-mind: `mcp__moflo__hive-mind_init` (`topology: "hierarchical-mesh", consensus: "byzantine"`)
 
 **CLI Fallback:**
 ```bash
@@ -241,7 +241,7 @@ TaskUpdate({ taskId: "4", addBlockedBy: ["2"] })
 TaskUpdate({ taskId: "0", addBlockedBy: ["3", "4"] })
 
 // STEP 3: Initialize swarm (MCP preferred, CLI fallback)
-// MCP: mcp__claude-flow__swarm_init (topology: "hierarchical", maxAgents: 8, strategy: "specialized")
+// MCP: mcp__moflo__swarm_init (topology: "hierarchical", maxAgents: 8, strategy: "specialized")
 Bash("npx flo swarm init --topology hierarchical --max-agents 8 --strategy specialized")
 
 // STEP 4: Spawn agents (mark tasks in_progress as spawned)
@@ -357,7 +357,7 @@ Task({
 
 **Use these settings to prevent agent drift:**
 
-**MCP (Preferred):** `mcp__claude-flow__swarm_init`
+**MCP (Preferred):** `mcp__moflo__swarm_init`
 - Small teams: `topology: "hierarchical", maxAgents: 8, strategy: "specialized"`
 - Large teams: `topology: "hierarchical-mesh", maxAgents: 15, strategy: "specialized"`
 
@@ -387,7 +387,7 @@ npx flo swarm init --topology hierarchical-mesh --max-agents 15 --strategy speci
 
 **Subagents DO inherit CLAUDE.md context** when spawned via Task tool. They automatically receive:
 - Memory-first protocol instructions
-- MCP tool access (`mcp__claude-flow__*`) when configured
+- MCP tool access (`mcp__moflo__*`) when configured
 - Project guidance and coding rules
 
 **Best practices for subagent prompts:**
@@ -396,9 +396,9 @@ npx flo swarm init --topology hierarchical-mesh --max-agents 15 --strategy speci
 - Trust that they know the memory-first protocol
 
 **MCP Tools Available to Subagents:**
-- `mcp__claude-flow__memory_search` - Semantic search
-- `mcp__claude-flow__memory_store` - Pattern storage
-- `mcp__claude-flow__hooks_route` - Task routing
+- `mcp__moflo__memory_search` - Semantic search
+- `mcp__moflo__memory_store` - Pattern storage
+- `mcp__moflo__hooks_route` - Task routing
 
 ---
 

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -151,7 +151,7 @@ switch (command) {
       blockTool('Call TaskCreate before spawning agents. Task tool is blocked until then.');
     }
     if (config.memory_first && !s.memorySearched) {
-      blockTool('Search memory before spawning agents. Use mcp__claude-flow__memory_search first.');
+      blockTool('Search memory before spawning agents. Use mcp__moflo__memory_search first.');
     }
     break;
   }
@@ -162,7 +162,7 @@ switch (command) {
     if (isMechanicalSearch()) break;
     s.lastBlockedAt = new Date().toISOString();
     writeState(s);
-    blockTool('Search memory before exploring files. Use mcp__claude-flow__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".');
+    blockTool('Search memory before exploring files. Use mcp__moflo__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".');
   }
   case 'check-before-read': {
     if (!config.memory_first) break;
@@ -173,7 +173,7 @@ switch (command) {
     if (fp.indexOf('.claude/guidance/') < 0) break;
     s.lastBlockedAt = new Date().toISOString();
     writeState(s);
-    blockTool('Search memory before reading guidance files. Use mcp__claude-flow__memory_search with namespace "guidance".');
+    blockTool('Search memory before reading guidance files. Use mcp__moflo__memory_search with namespace "guidance".');
   }
   case 'record-task-created': {
     var s = readState();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -274,7 +274,7 @@
     "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/statusline.cjs\""
   },
   "mcpServers": {
-    "claude-flow": {
+    "moflo": {
       "command": "node",
       "args": [
         "bin/cli.js",
@@ -284,7 +284,7 @@
     }
   },
   "enabledMcpjsonServers": [
-    "claude-flow",
+    "moflo",
     "ruv-swarm"
   ]
 }

--- a/.claude/skills/fl/SKILL.md
+++ b/.claude/skills/fl/SKILL.md
@@ -133,7 +133,7 @@ npx flo memory search --query "<issue title keywords>" --namespace patterns
 npx flo memory search --query "<domain keywords>" --namespace guidance
 ```
 
-Or via MCP: `mcp__claude-flow__memory_search`
+Or via MCP: `mcp__moflo__memory_search`
 
 ### 1.4 Read Guidance Docs (ONLY if memory insufficient)
 **Only if memory search returned < 3 relevant results**, read guidance files:

--- a/.claude/skills/flo/SKILL.md
+++ b/.claude/skills/flo/SKILL.md
@@ -133,7 +133,7 @@ npx flo memory search --query "<issue title keywords>" --namespace patterns
 npx flo memory search --query "<domain keywords>" --namespace guidance
 ```
 
-Or via MCP: `mcp__claude-flow__memory_search`
+Or via MCP: `mcp__moflo__memory_search`
 
 ### 1.4 Read Guidance Docs (ONLY if memory insufficient)
 **Only if memory search returned < 3 relevant results**, read guidance files:

--- a/.claude/skills/github-code-review/SKILL.md
+++ b/.claude/skills/github-code-review/SKILL.md
@@ -1027,10 +1027,10 @@ fi
 ```javascript
 [Single Message - Parallel Execution]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
 
   // Create and manage PR using gh CLI
   Bash("gh pr create --title 'Feature: Add authentication' --base main")

--- a/.claude/skills/github-multi-repo/SKILL.md
+++ b/.claude/skills/github-multi-repo/SKILL.md
@@ -90,7 +90,7 @@ const DEPS = Bash(`gh repo list my-organization --json name | \
   done | jq -s '.'`)
 
 // Initialize swarm with discovered repositories
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   topology: "hierarchical",
   maxAgents: 8,
   metadata: { repos: REPOS, dependencies: DEPS }
@@ -145,7 +145,7 @@ mcp__claude-flow__swarm_init({
 // Synchronize package dependencies and versions
 [Complete Package Sync]:
   // Initialize sync swarm
-  mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 5 })
+  mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 5 })
 
   // Spawn sync agents
   Task("Sync Coordinator", "Coordinate version alignment", "coordinator")
@@ -169,7 +169,7 @@ mcp__claude-flow__swarm_init({
     -f content="$(cat aligned-package.json | base64)"`)
 
   // Store sync state
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "sync/packages/status",
     value: {
@@ -196,7 +196,7 @@ mcp__claude-flow__swarm_init({
     -f content="$(cat /tmp/claude-source.md | base64)"`)
 
   // Track sync status
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "sync/documentation/status",
     value: { status: "synchronized", files: ["CLAUDE.md"] }
@@ -246,7 +246,7 @@ mcp__claude-flow__swarm_init({
 // Analyze and optimize repository structure
 [Architecture Analysis]:
   // Initialize architecture swarm
-  mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 6 })
+  mcp__moflo__swarm_init({ topology: "hierarchical", maxAgents: 6 })
 
   // Spawn architecture agents
   Task("Senior Architect", "Analyze repository structure", "architect")
@@ -266,7 +266,7 @@ mcp__claude-flow__swarm_init({
     --order desc`)
 
   // Store analysis results
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "architecture/analysis/results",
     value: {
@@ -406,7 +406,7 @@ Part of #$TRACKING_ISSUE"
 // Coordinate large-scale refactoring
 [Cross-Repo Refactoring]:
   // Initialize refactoring swarm
-  mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 8 })
+  mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 8 })
 
   // Spawn specialized agents
   Task("Refactoring Coordinator", "Coordinate refactoring across repos", "coordinator")
@@ -416,7 +416,7 @@ Part of #$TRACKING_ISSUE"
   Task("Integration Tester", "Validate refactored code", "tester")
 
   // Execute refactoring
-  mcp__claude-flow__task_orchestrate({
+  mcp__moflo__task_orchestrate({
     task: "Rename OldAPI to NewAPI across all repositories",
     strategy: "sequential",
     priority: "high"

--- a/.claude/skills/github-project-management/SKILL.md
+++ b/.claude/skills/github-project-management/SKILL.md
@@ -20,7 +20,7 @@ prerequisites:
   - Repository access permissions
 tools_required:
   - mcp__github__*
-  - mcp__claude-flow__*
+  - mcp__moflo__*
   - Bash
   - Read
   - Write
@@ -79,10 +79,10 @@ npx ruv-swarm github board-init \
 
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -107,7 +107,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"

--- a/.claude/skills/github-release-management/SKILL.md
+++ b/.claude/skills/github-release-management/SKILL.md
@@ -150,19 +150,19 @@ gh release create $(npm pkg get version) \
 ```javascript
 // Set up coordinated release team
 [Single Message - Swarm Initialization]:
-  mcp__claude-flow__swarm_init {
+  mcp__moflo__swarm_init {
     topology: "hierarchical",
     maxAgents: 6,
     strategy: "balanced"
   }
 
   // Spawn specialized agents
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
 ```
 
 #### Coordinated Release Workflow
@@ -172,7 +172,7 @@ gh release create $(npm pkg get version) \
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v2.0.0' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
 
   // Orchestrate release preparation
-  mcp__claude-flow__task_orchestrate {
+  mcp__moflo__task_orchestrate {
     task: "Prepare release v2.0.0 with comprehensive testing and validation",
     strategy: "sequential",
     priority: "critical",
@@ -204,7 +204,7 @@ gh release create $(npm pkg get version) \
   ]}
 
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "release/v2.0.0/status",
     value: JSON.stringify({
@@ -309,7 +309,7 @@ npx claude-flow github release-deploy \
 ```javascript
 [Single Message - Multi-Package Release]:
   // Initialize mesh topology for cross-package coordination
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 8 }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 8 }
 
   // Spawn package-specific agents
   Task("Package A Manager", "Coordinate claude-flow package release v1.0.72", "coder")
@@ -394,7 +394,7 @@ npx claude-flow github multi-release \
 ```javascript
 [Single Message - Cross-Repo Release]:
   // Initialize star topology for centralized coordination
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 6 }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 6 }
 
   // Spawn repo-specific coordinators
   Task("Frontend Release", "Release frontend v2.0.0 with API compatibility", "coordinator")
@@ -408,7 +408,7 @@ npx claude-flow github multi-release \
   Bash("gh api repos/org/cli/dispatches --method POST -f event_type='release' -F client_payload[version]=v1.5.0")
 
   // Monitor all releases
-  mcp__claude-flow__swarm_monitor { interval: 5, duration: 300 }
+  mcp__moflo__swarm_monitor { interval: 5, duration: 300 }
 ```
 
 ### Hotfix Emergency Procedures

--- a/.claude/skills/github-workflow-automation/SKILL.md
+++ b/.claude/skills/github-workflow-automation/SKILL.md
@@ -537,19 +537,19 @@ run().catch(error => core.setFailed(error.message));
 #### Initialize GitHub Swarm
 ```javascript
 // Step 1: Initialize swarm coordination
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 8
 }
 
 // Step 2: Spawn specialized agents
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Security Analyst" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Security Analyst" }
 
 // Step 3: Orchestrate GitHub workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review and merge workflow",
   strategy: "parallel",
   priority: "high"

--- a/.claude/skills/hooks-automation/SKILL.md
+++ b/.claude/skills/hooks-automation/SKILL.md
@@ -602,12 +602,12 @@ Hooks automatically integrate with MCP tools for coordination:
 npx claude-flow hook pre-task --description "Build REST API"
 
 // Internally calls MCP tools:
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "backend-dev",
   capabilities: ["api", "database", "testing"]
 }
 
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/task/api-build/context",
   namespace: "coordination",
@@ -626,7 +626,7 @@ mcp__claude-flow__memory_usage {
 npx claude-flow hook post-edit --file "api/auth.js"
 
 // Internally calls MCP tools:
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/edits/api/auth.js",
   namespace: "coordination",
@@ -639,7 +639,7 @@ mcp__claude-flow__memory_usage {
   })
 }
 
-mcp__claude-flow__neural_train {
+mcp__moflo__neural_train {
   pattern_type: "coordination",
   training_data: { /* edit patterns */ }
 }
@@ -652,11 +652,11 @@ mcp__claude-flow__neural_train {
 npx claude-flow hook session-end --session-id "dev-2024"
 
 // Internally calls MCP tools:
-mcp__claude-flow__memory_persist {
+mcp__moflo__memory_persist {
   sessionId: "dev-2024"
 }
 
-mcp__claude-flow__swarm_status {
+mcp__moflo__swarm_status {
   swarmId: "current"
 }
 
@@ -671,7 +671,7 @@ All hooks follow a standardized memory coordination pattern:
 
 **Phase 1: STATUS** - Hook starts
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/status",
   namespace: "coordination",
@@ -686,7 +686,7 @@ mcp__claude-flow__memory_usage {
 
 **Phase 2: PROGRESS** - Hook processes
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/progress",
   namespace: "coordination",
@@ -700,7 +700,7 @@ mcp__claude-flow__memory_usage {
 
 **Phase 3: COMPLETE** - Hook finishes
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/complete",
   namespace: "coordination",

--- a/.claude/skills/performance-analysis/SKILL.md
+++ b/.claude/skills/performance-analysis/SKILL.md
@@ -166,14 +166,14 @@ Automatic analysis during task execution:
 #### MCP Integration
 ```javascript
 // Check for bottlenecks in Claude Code
-mcp__claude-flow__bottleneck_detect({
+mcp__moflo__bottleneck_detect({
   timeRange: "1h",
   threshold: 20,
   autoFix: false
 })
 
 // Get detailed task results with bottleneck analysis
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   taskId: "task-123",
   format: "detailed"
 })

--- a/.claude/skills/sparc-methodology/SKILL.md
+++ b/.claude/skills/sparc-methodology/SKILL.md
@@ -129,7 +129,7 @@ Multi-agent task orchestration with TodoWrite/Task/Memory coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "coordinate feature development",
   options: { parallel: true, monitor: true }
@@ -189,7 +189,7 @@ Autonomous code generation with batch file operations.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement user authentication with JWT",
   options: {
@@ -225,7 +225,7 @@ System design with Memory-based coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design scalable e-commerce platform",
   options: {
@@ -262,7 +262,7 @@ Test-driven development with comprehensive testing.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "shopping cart feature with payment integration",
   options: {
@@ -301,7 +301,7 @@ Code review using batch file analysis.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review authentication module PR #123",
   options: {
@@ -342,7 +342,7 @@ Deep research with parallel WebSearch/WebFetch and Memory coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research microservices best practices 2024",
   options: {
@@ -447,7 +447,7 @@ Knowledge management and context preservation.
 
 ```javascript
 // Basic mode execution
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "<mode-name>",
   task_description: "<task description>",
   options: {
@@ -456,20 +456,20 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Initialize swarm for complex tasks
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",  // or "mesh", "ring", "star"
   strategy: "auto",           // or "balanced", "specialized", "adaptive"
   maxAgents: 8
 }
 
 // Spawn specialized agents
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "<agent-type>",
   capabilities: ["<capability1>", "<capability2>"]
 }
 
 // Monitor execution
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
@@ -524,22 +524,22 @@ npx claude-flow sparc pipeline "task description"
 
 ```javascript
 // Initialize hierarchical swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 12
 }
 
 // Spawn coordinator
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "coordinator",
   capabilities: ["planning", "delegation", "monitoring"]
 }
 
 // Spawn specialized workers
-mcp__claude-flow__agent_spawn { type: "architect" }
-mcp__claude-flow__agent_spawn { type: "coder" }
-mcp__claude-flow__agent_spawn { type: "tester" }
-mcp__claude-flow__agent_spawn { type: "reviewer" }
+mcp__moflo__agent_spawn { type: "architect" }
+mcp__moflo__agent_spawn { type: "coder" }
+mcp__moflo__agent_spawn { type: "tester" }
+mcp__moflo__agent_spawn { type: "reviewer" }
 ```
 
 ### Pattern 2: Mesh Coordination
@@ -547,7 +547,7 @@ mcp__claude-flow__agent_spawn { type: "reviewer" }
 **Best for**: Collaborative tasks requiring peer-to-peer communication
 
 ```javascript
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "mesh",
   strategy: "balanced",
   maxAgents: 6
@@ -559,7 +559,7 @@ mcp__claude-flow__swarm_init {
 **Best for**: Ordered workflow execution (spec → design → code → test → review)
 
 ```javascript
-mcp__claude-flow__workflow_create {
+mcp__moflo__workflow_create {
   name: "development-pipeline",
   steps: [
     { mode: "researcher", task: "gather requirements" },
@@ -577,7 +577,7 @@ mcp__claude-flow__workflow_create {
 **Best for**: Independent tasks that can run concurrently
 
 ```javascript
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "build full-stack application",
   strategy: "parallel",
   dependencies: {
@@ -594,7 +594,7 @@ mcp__claude-flow__task_orchestrate {
 **Best for**: Dynamic workloads with changing requirements
 
 ```javascript
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "adaptive",  // Auto-adjusts based on workload
   maxAgents: 20
@@ -609,25 +609,25 @@ mcp__claude-flow__swarm_init {
 
 ```javascript
 // Step 1: Initialize TDD swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 8
 }
 
 // Step 2: Research and planning
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research testing best practices for feature X"
 }
 
 // Step 3: Architecture design
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design testable architecture for feature X"
 }
 
 // Step 4: TDD implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "implement feature X with 90% coverage",
   options: {
@@ -638,7 +638,7 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Step 5: Code review
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review feature X implementation",
   options: {
@@ -648,7 +648,7 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Step 6: Optimization
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "optimizer",
   task_description: "optimize feature X performance"
 }
@@ -658,21 +658,21 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // RED: Write failing test
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "create failing test for shopping cart add item",
   options: { expect_failure: true }
 }
 
 // GREEN: Minimal implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement minimal code to pass test",
   options: { minimal: true }
 }
 
 // REFACTOR: Improve code quality
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "refactor shopping cart implementation",
   options: { maintain_tests: true }
@@ -689,7 +689,7 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // Store architectural decisions
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   namespace: "architecture",
   key: "api-design-v1",
@@ -698,7 +698,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Retrieve in subsequent agents
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   namespace: "architecture",
   key: "api-design-v1"
@@ -712,14 +712,14 @@ mcp__claude-flow__memory_usage {
 ```javascript
 // ✅ CORRECT: All operations together
 [Single Message]:
-  mcp__claude-flow__agent_spawn { type: "researcher" }
-  mcp__claude-flow__agent_spawn { type: "coder" }
-  mcp__claude-flow__agent_spawn { type: "tester" }
+  mcp__moflo__agent_spawn { type: "researcher" }
+  mcp__moflo__agent_spawn { type: "coder" }
+  mcp__moflo__agent_spawn { type: "tester" }
   TodoWrite { todos: [8-10 todos] }
 
 // ❌ WRONG: Multiple messages
-Message 1: mcp__claude-flow__agent_spawn { type: "researcher" }
-Message 2: mcp__claude-flow__agent_spawn { type: "coder" }
+Message 1: mcp__moflo__agent_spawn { type: "researcher" }
+Message 2: mcp__moflo__agent_spawn { type: "coder" }
 Message 3: TodoWrite { todos: [...] }
 ```
 
@@ -782,40 +782,40 @@ project/
 [Single Message - Parallel Agent Execution]:
 
 // Initialize swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 10
 }
 
 // Architecture phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design REST API with authentication",
   options: { memory_enabled: true }
 }
 
 // Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research authentication best practices"
 }
 
 // Implementation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement Express API with JWT auth",
   options: { test_driven: true }
 }
 
 // Testing phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "comprehensive API tests",
   options: { coverage_target: 90 }
 }
 
 // Review phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "security and performance review",
   options: { security_check: true }
@@ -840,7 +840,7 @@ TodoWrite {
 
 ```javascript
 // Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research AI-powered search implementations",
   options: {
@@ -850,27 +850,27 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Innovation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "propose novel search algorithm",
   options: { memory_enabled: true }
 }
 
 // Architecture phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design scalable search system"
 }
 
 // Implementation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement search algorithm",
   options: { test_driven: true }
 }
 
 // Documentation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "document search system architecture and API"
 }
@@ -880,33 +880,33 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // Analysis phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "analyzer",
   task_description: "analyze legacy codebase dependencies"
 }
 
 // Planning phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "plan incremental refactoring strategy"
 }
 
 // Testing phase (create safety net)
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "create comprehensive test suite for legacy code",
   options: { coverage_target: 80 }
 }
 
 // Refactoring phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "refactor module X with modern patterns",
   options: { maintain_tests: true }
 }
 
 // Review phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "validate refactoring maintains functionality"
 }
@@ -991,7 +991,7 @@ npx claude-flow sparc pipeline "e-commerce checkout feature"
 
 ```javascript
 // Train patterns from successful workflows
-mcp__claude-flow__neural_train {
+mcp__moflo__neural_train {
   pattern_type: "coordination",
   training_data: "successful_tdd_workflow.json",
   epochs: 50
@@ -1002,12 +1002,12 @@ mcp__claude-flow__neural_train {
 
 ```javascript
 // Save session state
-mcp__claude-flow__memory_persist {
+mcp__moflo__memory_persist {
   sessionId: "feature-auth-v1"
 }
 
 // Restore in new session
-mcp__claude-flow__context_restore {
+mcp__moflo__context_restore {
   snapshotId: "feature-auth-v1"
 }
 ```
@@ -1016,13 +1016,13 @@ mcp__claude-flow__context_restore {
 
 ```javascript
 // Analyze repository
-mcp__claude-flow__github_repo_analyze {
+mcp__moflo__github_repo_analyze {
   repo: "owner/repo",
   analysis_type: "code_quality"
 }
 
 // Manage pull requests
-mcp__claude-flow__github_pr_manage {
+mcp__moflo__github_pr_manage {
   repo: "owner/repo",
   pr_number: 123,
   action: "review"
@@ -1033,19 +1033,19 @@ mcp__claude-flow__github_pr_manage {
 
 ```javascript
 // Real-time swarm monitoring
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
 
 // Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze {
+mcp__moflo__bottleneck_analyze {
   component: "api-layer",
   metrics: ["latency", "throughput", "errors"]
 }
 
 // Token usage tracking
-mcp__claude-flow__token_usage {
+mcp__moflo__token_usage {
   operation: "feature-development",
   timeframe: "24h"
 }
@@ -1098,16 +1098,16 @@ npx claude-flow sparc batch <modes> "task"
 
 ```javascript
 // Initialize swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical" }
+mcp__moflo__swarm_init { topology: "hierarchical" }
 
 // Execute mode
-mcp__claude-flow__sparc_mode { mode: "coder", task_description: "..." }
+mcp__moflo__sparc_mode { mode: "coder", task_description: "..." }
 
 // Monitor progress
-mcp__claude-flow__swarm_monitor { interval: 5000 }
+mcp__moflo__swarm_monitor { interval: 5000 }
 
 // Store in memory
-mcp__claude-flow__memory_usage { action: "store", key: "...", value: "..." }
+mcp__moflo__memory_usage { action: "store", key: "...", value: "..." }
 ```
 
 ---

--- a/.claude/skills/swarm-advanced/SKILL.md
+++ b/.claude/skills/swarm-advanced/SKILL.md
@@ -19,19 +19,19 @@ Master advanced swarm patterns for distributed research, development, and testin
 npm install -g claude-flow@alpha
 
 # Add MCP server (if using MCP tools)
-claude mcp add claude-flow npx claude-flow@alpha mcp start
+claude mcp add moflo npx moflo mcp start
 ```
 
 ### Basic Pattern
 ```javascript
 // 1. Initialize swarm topology
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 6 })
 
 // 2. Spawn specialized agents
-mcp__claude-flow__agent_spawn({ type: "researcher", name: "Agent 1" })
+mcp__moflo__agent_spawn({ type: "researcher", name: "Agent 1" })
 
 // 3. Orchestrate tasks
-mcp__claude-flow__task_orchestrate({ task: "...", strategy: "parallel" })
+mcp__moflo__task_orchestrate({ task: "...", strategy: "parallel" })
 ```
 
 ## Core Concepts
@@ -73,7 +73,7 @@ Deep research through parallel information gathering, analysis, and synthesis.
 ### Architecture
 ```javascript
 // Initialize research swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
@@ -110,7 +110,7 @@ const researchAgents = [
 
 // Spawn all agents
 researchAgents.forEach(agent => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: agent.type,
     name: agent.name,
     capabilities: agent.capabilities
@@ -123,7 +123,7 @@ researchAgents.forEach(agent => {
 #### Phase 1: Information Gathering
 ```javascript
 // Parallel information collection
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "web-search",
@@ -145,7 +145,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Store research findings in memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "research-findings-" + Date.now(),
   "value": JSON.stringify(findings),
@@ -157,24 +157,24 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Analysis and Validation
 ```javascript
 // Pattern recognition in findings
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": researchData,
   "patterns": ["trend", "correlation", "outlier", "emerging-pattern"]
 })
 
 // Cognitive analysis
-mcp__claude-flow__cognitive_analyze({
+mcp__moflo__cognitive_analyze({
   "behavior": "research-synthesis"
 })
 
 // Quality assessment
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "research-sources",
   "criteria": ["credibility", "relevance", "recency", "authority"]
 })
 
 // Cross-reference validation
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "analyze",
   "operation": "fact-checking",
   "metadata": { "sources": sourcesArray }
@@ -184,14 +184,14 @@ mcp__claude-flow__neural_patterns({
 #### Phase 3: Knowledge Management
 ```javascript
 // Search existing knowledge base
-mcp__claude-flow__memory_search({
+mcp__moflo__memory_search({
   "pattern": "topic X",
   "namespace": "research",
   "limit": 20
 })
 
 // Create knowledge graph connections
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "learn",
   "operation": "knowledge-graph",
   "metadata": {
@@ -202,7 +202,7 @@ mcp__claude-flow__neural_patterns({
 })
 
 // Store connections for future use
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "knowledge-graph-X",
   "value": JSON.stringify(knowledgeGraph),
@@ -214,7 +214,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 4: Report Generation
 ```javascript
 // Orchestrate report generation
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "generate comprehensive research report",
   "strategy": "sequential",
   "priority": "high",
@@ -222,12 +222,12 @@ mcp__claude-flow__task_orchestrate({
 })
 
 // Monitor research progress
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "research-swarm"
 })
 
 // Generate final report
-mcp__claude-flow__workflow_execute({
+mcp__moflo__workflow_execute({
   "workflowId": "research-report-generation",
   "params": {
     "findings": findings,
@@ -256,7 +256,7 @@ Full-stack development through coordinated specialist agents.
 ### Architecture
 ```javascript
 // Initialize development swarm with hierarchy
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "hierarchical",
   "maxAgents": 8,
   "strategy": "balanced"
@@ -276,7 +276,7 @@ const devTeam = [
 
 // Spawn all team members
 devTeam.forEach(member => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: member.type,
     name: member.name,
     capabilities: member.capabilities,
@@ -290,7 +290,7 @@ devTeam.forEach(member => {
 #### Phase 1: Architecture and Design
 ```javascript
 // System architecture design
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "design system architecture for REST API",
   "strategy": "sequential",
   "priority": "critical",
@@ -298,7 +298,7 @@ mcp__claude-flow__task_orchestrate({
 })
 
 // Store architecture decisions
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "architecture-decisions",
   "value": JSON.stringify(architectureDoc),
@@ -309,7 +309,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Parallel Implementation
 ```javascript
 // Parallel development tasks
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "backend-api",
@@ -335,7 +335,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Monitor development progress
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "dev-swarm",
   "interval": 5000
 })
@@ -344,7 +344,7 @@ mcp__claude-flow__swarm_monitor({
 #### Phase 3: Testing and Validation
 ```javascript
 // Comprehensive testing
-mcp__claude-flow__batch_process({
+mcp__moflo__batch_process({
   "items": [
     { type: "unit", target: "all-modules" },
     { type: "integration", target: "api-endpoints" },
@@ -355,7 +355,7 @@ mcp__claude-flow__batch_process({
 })
 
 // Quality assessment
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "codebase",
   "criteria": ["coverage", "complexity", "maintainability", "security"]
 })
@@ -364,7 +364,7 @@ mcp__claude-flow__quality_assess({
 #### Phase 4: Review and Deployment
 ```javascript
 // Code review workflow
-mcp__claude-flow__workflow_execute({
+mcp__moflo__workflow_execute({
   "workflowId": "code-review-process",
   "params": {
     "reviewers": ["Code Reviewer"],
@@ -373,7 +373,7 @@ mcp__claude-flow__workflow_execute({
 })
 
 // CI/CD pipeline
-mcp__claude-flow__pipeline_create({
+mcp__moflo__pipeline_create({
   "config": {
     "stages": ["build", "test", "security-scan", "deploy"],
     "environment": "production"
@@ -399,7 +399,7 @@ Comprehensive quality assurance through distributed testing.
 ### Architecture
 ```javascript
 // Initialize testing swarm with star topology
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 7,
   "strategy": "parallel"
@@ -446,7 +446,7 @@ const testingTeam = [
 
 // Spawn all testers
 testingTeam.forEach(tester => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: tester.type,
     name: tester.name,
     capabilities: tester.capabilities,
@@ -460,7 +460,7 @@ testingTeam.forEach(tester => {
 #### Phase 1: Test Planning
 ```javascript
 // Analyze test coverage requirements
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "test-coverage",
   "criteria": [
     "line-coverage",
@@ -471,7 +471,7 @@ mcp__claude-flow__quality_assess({
 })
 
 // Identify test scenarios
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": testScenarios,
   "patterns": [
     "edge-case",
@@ -482,7 +482,7 @@ mcp__claude-flow__pattern_recognize({
 })
 
 // Store test plan
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "test-plan-" + Date.now(),
   "value": JSON.stringify(testPlan),
@@ -493,7 +493,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Parallel Test Execution
 ```javascript
 // Execute all test suites in parallel
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "unit-tests",
@@ -524,7 +524,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Batch process test suites
-mcp__claude-flow__batch_process({
+mcp__moflo__batch_process({
   "items": testSuites,
   "operation": "execute-test-suite"
 })
@@ -533,24 +533,24 @@ mcp__claude-flow__batch_process({
 #### Phase 3: Performance and Security
 ```javascript
 // Run performance benchmarks
-mcp__claude-flow__benchmark_run({
+mcp__moflo__benchmark_run({
   "suite": "comprehensive-performance"
 })
 
 // Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze({
+mcp__moflo__bottleneck_analyze({
   "component": "application",
   "metrics": ["response-time", "throughput", "memory", "cpu"]
 })
 
 // Security scanning
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   "target": "application",
   "depth": "comprehensive"
 })
 
 // Vulnerability analysis
-mcp__claude-flow__error_analysis({
+mcp__moflo__error_analysis({
   "logs": securityScanLogs
 })
 ```
@@ -558,24 +558,24 @@ mcp__claude-flow__error_analysis({
 #### Phase 4: Monitoring and Reporting
 ```javascript
 // Real-time test monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "testing-swarm",
   "interval": 2000
 })
 
 // Generate comprehensive test report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current-run"
 })
 
 // Get test results
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   "taskId": "test-execution-001"
 })
 
 // Trend analysis
-mcp__claude-flow__trend_analysis({
+mcp__moflo__trend_analysis({
   "metric": "test-coverage",
   "period": "30d"
 })
@@ -599,7 +599,7 @@ Deep code and system analysis through specialized analyzers.
 ### Architecture
 ```javascript
 // Initialize analysis swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 5,
   "strategy": "adaptive"
@@ -636,7 +636,7 @@ const analysisTeam = [
 
 // Spawn all analysts
 analysisTeam.forEach(analyst => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: analyst.type,
     name: analyst.name,
     capabilities: analyst.capabilities
@@ -647,7 +647,7 @@ analysisTeam.forEach(analyst => {
 ### Analysis Workflow
 ```javascript
 // Parallel analysis execution
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "analyze-code", "command": "analyze codebase structure and quality" },
     { "id": "analyze-security", "command": "scan for security vulnerabilities" },
@@ -657,13 +657,13 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Generate comprehensive analysis report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current"
 })
 
 // Cost analysis
-mcp__claude-flow__cost_analysis({
+mcp__moflo__cost_analysis({
   "timeframe": "30d"
 })
 ```
@@ -674,30 +674,30 @@ mcp__claude-flow__cost_analysis({
 
 ```javascript
 // Setup fault tolerance for all agents
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "auto-recovery"
 })
 
 // Error handling pattern
 try {
-  await mcp__claude-flow__task_orchestrate({
+  await mcp__moflo__task_orchestrate({
     "task": "complex operation",
     "strategy": "parallel",
     "priority": "high"
   })
 } catch (error) {
   // Check swarm health
-  const status = await mcp__claude-flow__swarm_status({})
+  const status = await mcp__moflo__swarm_status({})
 
   // Analyze error patterns
-  await mcp__claude-flow__error_analysis({
+  await mcp__moflo__error_analysis({
     "logs": [error.message]
   })
 
   // Auto-recovery attempt
   if (status.healthy) {
-    await mcp__claude-flow__task_orchestrate({
+    await mcp__moflo__task_orchestrate({
       "task": "retry failed operation",
       "strategy": "sequential"
     })
@@ -709,28 +709,28 @@ try {
 
 ```javascript
 // Cross-session persistence
-mcp__claude-flow__memory_persist({
+mcp__moflo__memory_persist({
   "sessionId": "swarm-session-001"
 })
 
 // Namespace management for different swarms
-mcp__claude-flow__memory_namespace({
+mcp__moflo__memory_namespace({
   "namespace": "research-swarm",
   "action": "create"
 })
 
 // Create state snapshot
-mcp__claude-flow__state_snapshot({
+mcp__moflo__state_snapshot({
   "name": "development-checkpoint-1"
 })
 
 // Restore from snapshot if needed
-mcp__claude-flow__context_restore({
+mcp__moflo__context_restore({
   "snapshotId": "development-checkpoint-1"
 })
 
 // Backup memory stores
-mcp__claude-flow__memory_backup({
+mcp__moflo__memory_backup({
   "path": "/workspaces/claude-code-flow/backups/swarm-memory.json"
 })
 ```
@@ -739,14 +739,14 @@ mcp__claude-flow__memory_backup({
 
 ```javascript
 // Train neural patterns from successful workflows
-mcp__claude-flow__neural_train({
+mcp__moflo__neural_train({
   "pattern_type": "coordination",
   "training_data": JSON.stringify(successfulWorkflows),
   "epochs": 50
 })
 
 // Adaptive learning from experience
-mcp__claude-flow__learning_adapt({
+mcp__moflo__learning_adapt({
   "experience": {
     "workflow": "research-to-report",
     "success": true,
@@ -756,7 +756,7 @@ mcp__claude-flow__learning_adapt({
 })
 
 // Pattern recognition for optimization
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": workflowMetrics,
   "patterns": ["bottleneck", "optimization-opportunity", "efficiency-gain"]
 })
@@ -766,7 +766,7 @@ mcp__claude-flow__pattern_recognize({
 
 ```javascript
 // Create reusable workflow
-mcp__claude-flow__workflow_create({
+mcp__moflo__workflow_create({
   "name": "full-stack-development",
   "steps": [
     { "phase": "design", "agents": ["architect"] },
@@ -779,7 +779,7 @@ mcp__claude-flow__workflow_create({
 })
 
 // Setup automation rules
-mcp__claude-flow__automation_setup({
+mcp__moflo__automation_setup({
   "rules": [
     {
       "trigger": "file-changed",
@@ -794,7 +794,7 @@ mcp__claude-flow__automation_setup({
 })
 
 // Event-driven triggers
-mcp__claude-flow__trigger_setup({
+mcp__moflo__trigger_setup({
   "events": ["code-commit", "PR-merge", "deployment"],
   "actions": ["test", "analyze", "document"]
 })
@@ -804,23 +804,23 @@ mcp__claude-flow__trigger_setup({
 
 ```javascript
 // Topology optimization
-mcp__claude-flow__topology_optimize({
+mcp__moflo__topology_optimize({
   "swarmId": "current-swarm"
 })
 
 // Load balancing
-mcp__claude-flow__load_balance({
+mcp__moflo__load_balance({
   "swarmId": "development-swarm",
   "tasks": taskQueue
 })
 
 // Agent coordination sync
-mcp__claude-flow__coordination_sync({
+mcp__moflo__coordination_sync({
   "swarmId": "development-swarm"
 })
 
 // Auto-scaling
-mcp__claude-flow__swarm_scale({
+mcp__moflo__swarm_scale({
   "swarmId": "development-swarm",
   "targetSize": 12
 })
@@ -830,28 +830,28 @@ mcp__claude-flow__swarm_scale({
 
 ```javascript
 // Real-time swarm monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "active-swarm",
   "interval": 3000
 })
 
 // Collect comprehensive metrics
-mcp__claude-flow__metrics_collect({
+mcp__moflo__metrics_collect({
   "components": ["agents", "tasks", "memory", "performance"]
 })
 
 // Health monitoring
-mcp__claude-flow__health_check({
+mcp__moflo__health_check({
   "components": ["swarm", "agents", "neural", "memory"]
 })
 
 // Usage statistics
-mcp__claude-flow__usage_stats({
+mcp__moflo__usage_stats({
   "component": "swarm-orchestration"
 })
 
 // Trend analysis
-mcp__claude-flow__trend_analysis({
+mcp__moflo__trend_analysis({
   "metric": "agent-performance",
   "period": "7d"
 })
@@ -906,7 +906,7 @@ mcp__claude-flow__trend_analysis({
 ### Example 1: AI Research Project
 ```javascript
 // Research AI trends, analyze findings, generate report
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 6 })
 // Spawn: 2 researchers, 2 analysts, 1 synthesizer, 1 documenter
 // Parallel gather → Analyze patterns → Synthesize → Report
 ```
@@ -914,7 +914,7 @@ mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
 ### Example 2: Full-Stack Application
 ```javascript
 // Build complete web application with testing
-mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 8 })
+mcp__moflo__swarm_init({ topology: "hierarchical", maxAgents: 8 })
 // Spawn: 1 architect, 2 devs, 1 db engineer, 2 testers, 1 reviewer, 1 devops
 // Design → Parallel implement → Test → Review → Deploy
 ```
@@ -922,7 +922,7 @@ mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 8 })
 ### Example 3: Security Audit
 ```javascript
 // Comprehensive security analysis
-mcp__claude-flow__swarm_init({ topology: "star", maxAgents: 5 })
+mcp__moflo__swarm_init({ topology: "star", maxAgents: 5 })
 // Spawn: 1 coordinator, 1 code analyzer, 1 security scanner, 1 penetration tester, 1 reporter
 // Parallel scan → Vulnerability analysis → Penetration test → Report
 ```
@@ -930,7 +930,7 @@ mcp__claude-flow__swarm_init({ topology: "star", maxAgents: 5 })
 ### Example 4: Performance Optimization
 ```javascript
 // Identify and fix performance bottlenecks
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 4 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 4 })
 // Spawn: 1 profiler, 1 bottleneck analyzer, 1 optimizer, 1 tester
 // Profile → Identify bottlenecks → Optimize → Validate
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ TodoWrite({ todos: [
 ]})
 
 // STEP 4: Store swarm state in memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "swarm",
   key: "current-session",

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ MoFlo uses a SQLite database (via sql.js/WASM — no native deps) to store three
 
 When `flo init` runs, it appends a workflow section to your CLAUDE.md that teaches Claude:
 - Always search memory before Glob/Grep/Read (enforced by gates)
-- Use `mcp__claude-flow__memory_search` for knowledge retrieval
+- Use `mcp__moflo__memory_search` for knowledge retrieval
 - Use `/flo <issue>` (or `/fl`) for issue execution
 - Store learnings after task completion
 

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -49,7 +49,7 @@ switch (command) {
     var s = readState();
     // Hard gate: memory must be searched
     if (config.memory_first && s.memoryRequired && !s.memorySearched) {
-      process.stderr.write('BLOCKED: Search memory (mcp__claude-flow__memory_search) before spawning agents.\n');
+      process.stderr.write('BLOCKED: Search memory (mcp__moflo__memory_search) before spawning agents.\n');
       process.exit(2);
     }
     // Soft gate: TaskCreate recommended but not blocking
@@ -65,7 +65,7 @@ switch (command) {
     if (s.memorySearched || !s.memoryRequired) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__claude-flow__memory_search.\n');
+    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search.\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -74,7 +74,7 @@ switch (command) {
     if (s.memorySearched || !s.memoryRequired) break;
     var fp = process.env.TOOL_INPUT_file_path || '';
     if (fp.indexOf('.claude/guidance/') < 0 && fp.indexOf('.claude\\guidance\\') < 0) break;
-    process.stderr.write('BLOCKED: Search memory before reading guidance files. Use mcp__claude-flow__memory_search.\n');
+    process.stderr.write('BLOCKED: Search memory before reading guidance files. Use mcp__moflo__memory_search.\n');
     process.exit(2);
   }
   case 'record-task-created': {

--- a/bin/setup-project.mjs
+++ b/bin/setup-project.mjs
@@ -40,7 +40,7 @@ Your first tool call for every new user prompt MUST be a memory search. Do this 
 
 WHY: Memory contains curated solutions, patterns, and architectural context from previous work. Without it, you will miss existing solutions, repeat mistakes that were already solved, and waste time re-discovering what is already known. Memory search is faster than file scanning.
 
-HOW: Use ToolSearch to load \`mcp__claude-flow__memory_search\`, then call it with a query describing your task. If MCP is unavailable, use:
+HOW: Use ToolSearch to load \`mcp__moflo__memory_search\`, then call it with a query describing your task. If MCP is unavailable, use:
 \`node bin/semantic-search.mjs "[task description]" --namespace guidance\`
 
 ### Namespaces to search:
@@ -59,10 +59,10 @@ For **codebase navigation** (finding where a type/service/component lives), also
 
 ### Primary: MCP Tools (preferred)
 \`\`\`
-mcp__claude-flow__memory_search   — query, namespace
-mcp__claude-flow__memory_store    — key, value, namespace
-mcp__claude-flow__memory_retrieve — key, namespace
-mcp__claude-flow__memory_list     — namespace, limit
+mcp__moflo__memory_search   — query, namespace
+mcp__moflo__memory_store    — key, value, namespace
+mcp__moflo__memory_retrieve — key, namespace
+mcp__moflo__memory_list     — namespace, limit
 \`\`\`
 Load via ToolSearch first: \`+claude-flow memory\`
 
@@ -78,9 +78,9 @@ npx flo-codemap --force                          # Regenerate code-map
 
 | Content Type | Destination | How to Write |
 |-------------|-------------|--------------|
-| Debugging lessons (bug found, root cause, fix) | Memory DB — \`patterns\` namespace | \`mcp__claude-flow__memory_store\` |
-| Architectural decisions (chose X over Y, why) | Memory DB — \`decisions\` namespace | \`mcp__claude-flow__memory_store\` |
-| Learned patterns (task succeeded/failed, what worked) | Memory DB — \`patterns\` namespace | \`mcp__claude-flow__memory_store\` |
+| Debugging lessons (bug found, root cause, fix) | Memory DB — \`patterns\` namespace | \`mcp__moflo__memory_store\` |
+| Architectural decisions (chose X over Y, why) | Memory DB — \`decisions\` namespace | \`mcp__moflo__memory_store\` |
+| Learned patterns (task succeeded/failed, what worked) | Memory DB — \`patterns\` namespace | \`mcp__moflo__memory_store\` |
 | Coding rules (always/never do X in code) | \`.claude/guidance/\` files | Edit directly |
 | Process/workflow rules (CI, PR, gates) | \`CLAUDE.md\` | Edit directly |
 

--- a/docs/INFRASTRUCTURE_TEST_PLAN.md
+++ b/docs/INFRASTRUCTURE_TEST_PLAN.md
@@ -221,7 +221,7 @@ You are agent BETA in a memory sharing test. Do the following:
 2. Search for it semantically:
    npx moflo memory search --query "cross-agent-test-alpha" --namespace patterns --limit 3
 3. Also try via MCP if available:
-   Use mcp__claude-flow__memory_retrieve with key "cross-agent-test-alpha", namespace "patterns"
+   Use mcp__moflo__memory_retrieve with key "cross-agent-test-alpha", namespace "patterns"
 4. Report: Did retrieve return the value? Did search find it? What was the search score?
 This is a READ test — do not modify any files.
 """)
@@ -253,7 +253,7 @@ npx moflo doctor
 ```
 Also verify via ToolSearch:
 ```
-ToolSearch("select:mcp__claude-flow__memory_search,mcp__claude-flow__memory_store,mcp__claude-flow__memory_retrieve")
+ToolSearch("select:mcp__moflo__memory_search,mcp__moflo__memory_store,mcp__moflo__memory_retrieve")
 ```
 **Pass criteria:** Either MCP tools load via ToolSearch, or CLI fallback produces equivalent results.
 

--- a/src/@claude-flow/cli/.claude/agents/github/code-review-swarm.md
+++ b/src/@claude-flow/cli/.claude/agents/github/code-review-swarm.md
@@ -14,9 +14,9 @@ capabilities:
   - architecture_pattern_validation
   - style_and_convention_enforcement
 tools:
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats

--- a/src/@claude-flow/cli/.claude/agents/github/github-modes.md
+++ b/src/@claude-flow/cli/.claude/agents/github/github-modes.md
@@ -1,7 +1,7 @@
 ---
 name: github-modes
 description: Comprehensive GitHub integration modes for workflow orchestration, PR management, and repository coordination with batch optimization
-tools: mcp__claude-flow__swarm_init, mcp__claude-flow__agent_spawn, mcp__claude-flow__task_orchestrate, Bash, TodoWrite, Read, Write
+tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__task_orchestrate, Bash, TodoWrite, Read, Write
 color: purple
 type: development
 capabilities:
@@ -163,11 +163,11 @@ All GitHub modes can be enhanced with ruv-swarm coordination:
 
 ```javascript
 // Initialize swarm for GitHub workflow
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
-mcp__claude-flow__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
+mcp__moflo__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
 ```

--- a/src/@claude-flow/cli/.claude/agents/github/issue-tracker.md
+++ b/src/@claude-flow/cli/.claude/agents/github/issue-tracker.md
@@ -15,10 +15,10 @@ capabilities:
   - cross_repository_issue_synchronization
   - intelligent_labeling_and_organization
 tools:
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats
@@ -301,7 +301,7 @@ if (duplicates.length > 0) {
 - `mcp__github__update_issue`
 - `mcp__github__add_issue_comment`
 - `mcp__github__search_issues`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -309,10 +309,10 @@ if (duplicates.length > 0) {
 ### 1. Create Coordinated Issue with Swarm Tracking
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -337,7 +337,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"
@@ -347,7 +347,7 @@ mcp__claude-flow__task_orchestrate {
 ### 2. Automated Progress Updates
 ```javascript
 // Update issue with progress from swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "issue/54/progress"
 }
@@ -376,7 +376,7 @@ mcp__github__add_issue_comment {
 }
 
 // Store progress in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/54/latest_update",
   value: { timestamp: Date.now(), progress: "89%", status: "near_completion" }
@@ -409,10 +409,10 @@ mcp__github__update_issue {
 ```javascript
 [Single Message - Issue Lifecycle Management]:
   // Initialize issue coordination swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Manager" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Progress Tracker" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Context Gatherer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Manager" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Progress Tracker" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Context Gatherer" }
   
   // Create multiple related issues using gh CLI
   Bash(`gh issue create \
@@ -442,7 +442,7 @@ mcp__github__update_issue {
   ]}
   
   // Store initial coordination state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "project/github_integration/issues",
     value: { created: Date.now(), total_issues: 3, status: "initialized" }

--- a/src/@claude-flow/cli/.claude/agents/github/multi-repo-swarm.md
+++ b/src/@claude-flow/cli/.claude/agents/github/multi-repo-swarm.md
@@ -12,15 +12,15 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_repo_analyze
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_sync_coord
-  - mcp__claude-flow__github_metrics
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_repo_analyze
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_sync_coord
+  - mcp__moflo__github_metrics
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/src/@claude-flow/cli/.claude/agents/github/pr-manager.md
+++ b/src/@claude-flow/cli/.claude/agents/github/pr-manager.md
@@ -17,14 +17,14 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_code_review
-  - mcp__claude-flow__github_metrics
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_code_review
+  - mcp__moflo__github_metrics
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats
@@ -297,10 +297,10 @@ const assignments = await agentDB.gnnEnhancedSearch(
 ### 1. Create and Manage PR with Swarm Coordination
 ```javascript
 // Initialize review swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Testing Agent" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Testing Agent" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
 
 // Create PR and orchestrate review
 mcp__github__create_pull_request {
@@ -313,7 +313,7 @@ mcp__github__create_pull_request {
 }
 
 // Orchestrate review process
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review with testing and validation",
   strategy: "parallel",
   priority: "high"
@@ -355,7 +355,7 @@ mcp__github__merge_pull_request {
 }
 
 // Post-merge coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/54/merged",
   value: { timestamp: Date.now(), status: "success" }
@@ -368,10 +368,10 @@ mcp__claude-flow__memory_usage {
 ```javascript
 [Single Message - Complete PR Management]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
   
   // Create and manage PR using gh CLI
   Bash("gh pr create --repo :owner/:repo --title '...' --head '...' --base 'main'")

--- a/src/@claude-flow/cli/.claude/agents/github/project-board-sync.md
+++ b/src/@claude-flow/cli/.claude/agents/github/project-board-sync.md
@@ -12,17 +12,17 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_repo_analyze
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_issue_track
-  - mcp__claude-flow__github_metrics
-  - mcp__claude-flow__workflow_create
-  - mcp__claude-flow__workflow_execute
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_repo_analyze
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_issue_track
+  - mcp__moflo__github_metrics
+  - mcp__moflo__workflow_create
+  - mcp__moflo__workflow_execute
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/src/@claude-flow/cli/.claude/agents/github/release-manager.md
+++ b/src/@claude-flow/cli/.claude/agents/github/release-manager.md
@@ -22,10 +22,10 @@ tools:
   - mcp__github__create_branch
   - mcp__github__push_files
   - mcp__github__create_issue
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats
@@ -291,12 +291,12 @@ console.log(`Found ${impactedAreas.length} impacted areas with +12.4% better cov
 ### 1. Coordinated Release Preparation
 ```javascript
 // Initialize release management swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Coordinator" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Release Coordinator" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
 
 // Create release preparation branch
 mcp__github__create_branch {
@@ -307,7 +307,7 @@ mcp__github__create_branch {
 }
 
 // Orchestrate release preparation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Prepare release v1.0.72 with comprehensive testing and validation",
   strategy: "sequential",
   priority: "critical"
@@ -444,13 +444,13 @@ This release is production-ready with comprehensive validation and testing.
 ```javascript
 [Single Message - Complete Release Management]:
   // Initialize comprehensive release swarm
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 8 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Lead" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Controller" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Performance Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 8 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Lead" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Controller" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Performance Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
   
   // Create release branch and prepare files using gh CLI
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v1.0.72' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
@@ -489,7 +489,7 @@ This release is production-ready with comprehensive validation and testing.
   ]}
   
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store", 
     key: "release/v1.0.72/status",
     value: {

--- a/src/@claude-flow/cli/.claude/agents/github/release-swarm.md
+++ b/src/@claude-flow/cli/.claude/agents/github/release-swarm.md
@@ -17,11 +17,11 @@ tools:
   - mcp__github__create_branch
   - mcp__github__push_files
   - mcp__github__create_issue
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__parallel_execute
-  - mcp__claude-flow__load_balance
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__parallel_execute
+  - mcp__moflo__load_balance
 hooks:
   pre_task: |
     echo "🐝 Initializing release swarm coordination..."

--- a/src/@claude-flow/cli/.claude/agents/github/repo-architect.md
+++ b/src/@claude-flow/cli/.claude/agents/github/repo-architect.md
@@ -19,10 +19,10 @@ tools:
   - mcp__github__search_repositories
   - mcp__github__push_files
   - mcp__github__create_or_update_file
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
 hooks:
   pre_task: |
     echo "🏗️ Initializing repository architecture analysis..."
@@ -55,11 +55,11 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 ### 1. Repository Structure Analysis and Optimization
 ```javascript
 // Initialize architecture analysis swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Repository Architect" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyzer" }
+mcp__moflo__agent_spawn { type: "architect", name: "Repository Architect" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
 
 // Analyze current repository structure
 LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -73,7 +73,7 @@ mcp__github__search_repositories {
 }
 
 // Orchestrate structure optimization
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze and optimize repository structure for scalability and maintainability",
   strategy: "adaptive",
   priority: "medium"
@@ -200,12 +200,12 @@ jobs:
 ```javascript
 [Single Message - Repository Architecture Review]:
   // Initialize comprehensive architecture swarm
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "architect", name: "Senior Architect" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyst" }
-  mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "architect", name: "Senior Architect" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyst" }
+  mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
   
   // Analyze current repository structures
   LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -254,7 +254,7 @@ jobs:
   ]}
   
   // Store architecture analysis
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "architecture/analysis/results",
     value: {

--- a/src/@claude-flow/cli/.claude/agents/github/swarm-issue.md
+++ b/src/@claude-flow/cli/.claude/agents/github/swarm-issue.md
@@ -9,10 +9,10 @@ tools:
   - mcp__github__update_issue
   - mcp__github__list_issues
   - mcp__github__create_issue_comment
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
   - TodoWrite
   - TodoRead
   - Bash
@@ -516,21 +516,21 @@ npx claude-flow@v3alpha github issue-init 567 \
 ### Multi-Agent Issue Processing
 ```bash
 # Initialize issue-specific swarm with optimal topology
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 8 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Issue Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Solution Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 8 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Issue Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Solution Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 # Store issue context in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/#{issue_number}/context",
   value: { title: "issue_title", labels: ["labels"], complexity: "high" }
 }
 
 # Orchestrate issue resolution workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Coordinate multi-agent issue resolution with progress tracking",
   strategy: "adaptive",
   priority: "high"

--- a/src/@claude-flow/cli/.claude/agents/github/swarm-pr.md
+++ b/src/@claude-flow/cli/.claude/agents/github/swarm-pr.md
@@ -11,11 +11,11 @@ tools:
   - mcp__github__create_pr_comment
   - mcp__github__get_pr_diff
   - mcp__github__merge_pull_request
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__coordination_sync
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__coordination_sync
   - TodoWrite
   - TodoRead
   - Bash
@@ -323,15 +323,15 @@ When using with Claude Code:
 ### Multi-Agent PR Analysis
 ```bash
 # Initialize PR-specific swarm with intelligent topology selection
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 8 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Test Engineer" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Impact Analyzer" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 8 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Test Engineer" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Impact Analyzer" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
 
 # Store PR context for swarm coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/#{pr_number}/analysis",
   value: { 
@@ -343,7 +343,7 @@ mcp__claude-flow__memory_usage {
 }
 
 # Orchestrate comprehensive PR workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Execute multi-agent PR review and validation workflow",
   strategy: "parallel",
   priority: "high",
@@ -403,17 +403,17 @@ const prPostHook = async (results) => {
 ### Intelligent PR Merge Coordination
 ```bash
 # Coordinate merge decision with swarm consensus
-mcp__claude-flow__coordination_sync { swarmId: "pr-review-swarm" }
+mcp__moflo__coordination_sync { swarmId: "pr-review-swarm" }
 
 # Analyze merge readiness with multiple agents
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Evaluate PR merge readiness with comprehensive validation",
   strategy: "sequential",
   priority: "critical"
 }
 
 # Store merge decision context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/merge_decisions/#{pr_number}",
   value: {

--- a/src/@claude-flow/cli/.claude/agents/github/sync-coordinator.md
+++ b/src/@claude-flow/cli/.claude/agents/github/sync-coordinator.md
@@ -10,12 +10,12 @@ tools:
   - mcp__github__create_pull_request
   - mcp__github__search_repositories
   - mcp__github__list_repositories
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__coordination_sync
-  - mcp__claude-flow__load_balance
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__coordination_sync
+  - mcp__moflo__load_balance
   - TodoWrite
   - TodoRead
   - Bash
@@ -52,7 +52,7 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 - `mcp__github__get_file_contents`
 - `mcp__github__create_pull_request`
 - `mcp__github__search_repositories`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`, `MultiEdit`
 
 ## Usage Patterns
@@ -60,11 +60,11 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 ### 1. Synchronize Package Dependencies
 ```javascript
 // Initialize sync coordination swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 // Analyze current package states
 Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -83,7 +83,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/packa
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/package.json?ref=sync/package-alignment --jq '.sha')")`)
 
 // Orchestrate validation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Validate package synchronization and run integration tests",
   strategy: "parallel",
   priority: "high"
@@ -109,7 +109,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUD
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUDE.md?ref=sync/documentation --jq '.sha' 2>/dev/null || echo '')")`)
 
 // Store sync state in memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/documentation/status",
   value: { timestamp: Date.now(), status: "synchronized", files: ["CLAUDE.md"] }
@@ -183,12 +183,12 @@ This integration uses ruv-swarm agents for:
 ```javascript
 [Single Message - Complete Synchronization]:
   // Initialize comprehensive sync swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Package Analyzer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Coder" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Tester" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Package Analyzer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Integration Coder" }
+  mcp__moflo__agent_spawn { type: "tester", name: "Validation Tester" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
   
   // Read current state of both packages
   Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -222,7 +222,7 @@ This integration uses ruv-swarm agents for:
   ]}
   
   // Store comprehensive sync state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "sync/complete/status",
     value: {
@@ -327,16 +327,16 @@ const testMatrix = {
 ### Multi-Agent Coordination Architecture
 ```bash
 # Initialize comprehensive synchronization swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 10 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Assurance" }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Sync Monitor" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 10 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Assurance" }
+mcp__moflo__agent_spawn { type: "monitor", name: "Sync Monitor" }
 
 # Orchestrate complex synchronization workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Execute comprehensive multi-repository synchronization with validation",
   strategy: "adaptive",
   priority: "critical",
@@ -344,7 +344,7 @@ mcp__claude-flow__task_orchestrate {
 }
 
 # Load balance synchronization tasks across agents
-mcp__claude-flow__load_balance {
+mcp__moflo__load_balance {
   swarmId: "sync-coordination-swarm",
   tasks: [
     "package_json_sync",
@@ -390,7 +390,7 @@ const syncConflictResolver = async (conflicts) => {
 ### Comprehensive Synchronization Metrics
 ```bash
 # Store detailed synchronization metrics
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/metrics/session",
   value: {
@@ -415,16 +415,16 @@ mcp__claude-flow__memory_usage {
 ### Swarm-Coordinated Error Recovery
 ```bash
 # Initialize error recovery swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Error Monitor" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Failure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Recovery Developer" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "monitor", name: "Error Monitor" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Failure Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Recovery Developer" }
 
 # Coordinate recovery procedures
-mcp__claude-flow__coordination_sync { swarmId: "error-recovery-swarm" }
+mcp__moflo__coordination_sync { swarmId: "error-recovery-swarm" }
 
 # Store recovery state
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/recovery/state",
   value: {

--- a/src/@claude-flow/cli/.claude/agents/github/workflow-automation.md
+++ b/src/@claude-flow/cli/.claude/agents/github/workflow-automation.md
@@ -14,14 +14,14 @@ tools:
   - mcp__github__list_workflows
   - mcp__github__get_workflow_runs
   - mcp__github__create_workflow_dispatch
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__performance_report
-  - mcp__claude-flow__bottleneck_analyze
-  - mcp__claude-flow__workflow_create
-  - mcp__claude-flow__automation_setup
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__performance_report
+  - mcp__moflo__bottleneck_analyze
+  - mcp__moflo__workflow_create
+  - mcp__moflo__automation_setup
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats
@@ -749,17 +749,17 @@ npx claude-flow@v3alpha actions profile \
 ### Multi-Agent Pipeline Orchestration
 ```bash
 # Initialize comprehensive workflow automation swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 12 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Workflow Coordinator" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Pipeline Architect" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Workflow Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "CI/CD Tester" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Automation Monitor" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 12 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Workflow Coordinator" }
+mcp__moflo__agent_spawn { type: "architect", name: "Pipeline Architect" }
+mcp__moflo__agent_spawn { type: "coder", name: "Workflow Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "CI/CD Tester" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+mcp__moflo__agent_spawn { type: "monitor", name: "Automation Monitor" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
 
 # Create intelligent workflow automation rules
-mcp__claude-flow__automation_setup {
+mcp__moflo__automation_setup {
   rules: [
     {
       trigger: "pull_request",
@@ -775,7 +775,7 @@ mcp__claude-flow__automation_setup {
 }
 
 # Orchestrate adaptive workflow management
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Manage intelligent CI/CD pipeline with continuous optimization",
   strategy: "adaptive",
   priority: "high",
@@ -786,19 +786,19 @@ mcp__claude-flow__task_orchestrate {
 ### Intelligent Performance Monitoring
 ```bash
 # Generate comprehensive workflow performance reports
-mcp__claude-flow__performance_report {
+mcp__moflo__performance_report {
   format: "detailed",
   timeframe: "30d"
 }
 
 # Analyze workflow bottlenecks with swarm intelligence
-mcp__claude-flow__bottleneck_analyze {
+mcp__moflo__bottleneck_analyze {
   component: "github_actions_workflow",
   metrics: ["build_time", "test_duration", "deployment_latency", "resource_utilization"]
 }
 
 # Store performance insights in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "workflow/performance/analysis",
   value: {
@@ -870,7 +870,7 @@ const createIntelligentWorkflow = async (repoContext) => {
 ### Continuous Learning and Optimization
 ```bash
 # Implement continuous workflow learning
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "workflow/learning/patterns",
   value: {
@@ -893,7 +893,7 @@ mcp__claude-flow__memory_usage {
 }
 
 # Generate workflow optimization recommendations
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze workflow performance and generate optimization recommendations",
   strategy: "parallel",
   priority: "medium"

--- a/src/@claude-flow/cli/.claude/agents/goal/goal-planner.md
+++ b/src/@claude-flow/cli/.claude/agents/goal/goal-planner.md
@@ -51,20 +51,20 @@ Your planning methodology follows the GOAP algorithm:
 
 ```javascript
 // Orchestrate complex goal achievement
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "achieve_production_deployment",
   strategy: "adaptive",
   priority: "high"
 }
 
 // Coordinate with swarm for parallel planning
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 5
 }
 
 // Store successful plans for reuse
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   namespace: "goap-plans",
   key: "deployment_plan_v1",

--- a/src/@claude-flow/cli/.claude/agents/swarm/adaptive-coordinator.md
+++ b/src/@claude-flow/cli/.claude/agents/swarm/adaptive-coordinator.md
@@ -15,25 +15,25 @@ hooks:
   pre: |
     echo "🔄 Adaptive Coordinator analyzing workload patterns: $TASK"
     # Initialize with auto-detection
-    mcp__claude-flow__swarm_init auto --maxAgents=15 --strategy=adaptive
+    mcp__moflo__swarm_init auto --maxAgents=15 --strategy=adaptive
     # Analyze current workload patterns
-    mcp__claude-flow__neural_patterns analyze --operation="workload_analysis" --metadata="{\"task\":\"$TASK\"}"
+    mcp__moflo__neural_patterns analyze --operation="workload_analysis" --metadata="{\"task\":\"$TASK\"}"
     # Train adaptive models
-    mcp__claude-flow__neural_train coordination --training_data="historical_swarm_data" --epochs=30
+    mcp__moflo__neural_train coordination --training_data="historical_swarm_data" --epochs=30
     # Store baseline metrics
-    mcp__claude-flow__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__claude-flow__performance_report --format=json)" --namespace=adaptive
+    mcp__moflo__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__moflo__performance_report --format=json)" --namespace=adaptive
     # Set up real-time monitoring
-    mcp__claude-flow__swarm_monitor --interval=2000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_monitor --interval=2000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Adaptive coordination complete - topology optimized"
     # Generate comprehensive analysis
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__moflo__performance_report --format=detailed --timeframe=24h
     # Store learning outcomes
-    mcp__claude-flow__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__claude-flow__swarm_status | jq -r '.topology')\"}"
+    mcp__moflo__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__moflo__swarm_status | jq -r '.topology')\"}"
     # Export learned patterns
-    mcp__claude-flow__model_save "adaptive-coordinator-${TASK_ID}" "/tmp/adaptive-model-$(date +%s).json"
+    mcp__moflo__model_save "adaptive-coordinator-${TASK_ID}" "/tmp/adaptive-model-$(date +%s).json"
     # Update persistent knowledge base
-    mcp__claude-flow__memory_usage store "adaptive:learned:${TASK_ID}" "$(date): Adaptive patterns learned and saved" --namespace=adaptive
+    mcp__moflo__memory_usage store "adaptive:learned:${TASK_ID}" "$(date): Adaptive patterns learned and saved" --namespace=adaptive
 ---
 
 # Adaptive Swarm Coordinator
@@ -864,43 +864,43 @@ class LearningAdaptiveCoordinator extends AdaptiveCoordinator {
 ### Pattern Recognition & Learning
 ```bash
 # Analyze coordination patterns
-mcp__claude-flow__neural_patterns analyze --operation="topology_analysis" --metadata="{\"current_topology\":\"mesh\",\"performance_metrics\":{}}"
+mcp__moflo__neural_patterns analyze --operation="topology_analysis" --metadata="{\"current_topology\":\"mesh\",\"performance_metrics\":{}}"
 
 # Train adaptive models
-mcp__claude-flow__neural_train coordination --training_data="swarm_performance_history" --epochs=50
+mcp__moflo__neural_train coordination --training_data="swarm_performance_history" --epochs=50
 
 # Make predictions
-mcp__claude-flow__neural_predict --modelId="adaptive-coordinator" --input="{\"workload\":\"high_complexity\",\"agents\":10}"
+mcp__moflo__neural_predict --modelId="adaptive-coordinator" --input="{\"workload\":\"high_complexity\",\"agents\":10}"
 
 # Learn from outcomes
-mcp__claude-flow__neural_patterns learn --operation="topology_switch" --outcome="improved_performance_15%" --metadata="{\"from\":\"hierarchical\",\"to\":\"mesh\"}"
+mcp__moflo__neural_patterns learn --operation="topology_switch" --outcome="improved_performance_15%" --metadata="{\"from\":\"hierarchical\",\"to\":\"mesh\"}"
 ```
 
 ### Performance Optimization
 ```bash
 # Real-time performance monitoring
-mcp__claude-flow__performance_report --format=json --timeframe=1h
+mcp__moflo__performance_report --format=json --timeframe=1h
 
 # Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze --component="coordination" --metrics="latency,throughput,success_rate"
+mcp__moflo__bottleneck_analyze --component="coordination" --metrics="latency,throughput,success_rate"
 
 # Automatic optimization
-mcp__claude-flow__topology_optimize --swarmId="${SWARM_ID}"
+mcp__moflo__topology_optimize --swarmId="${SWARM_ID}"
 
 # Load balancing optimization
-mcp__claude-flow__load_balance --swarmId="${SWARM_ID}" --strategy="ml_optimized"
+mcp__moflo__load_balance --swarmId="${SWARM_ID}" --strategy="ml_optimized"
 ```
 
 ### Predictive Scaling
 ```bash
 # Analyze usage trends
-mcp__claude-flow__trend_analysis --metric="agent_utilization" --period="7d"
+mcp__moflo__trend_analysis --metric="agent_utilization" --period="7d"
 
 # Predict resource needs
-mcp__claude-flow__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
+mcp__moflo__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
 
 # Auto-scale swarm
-mcp__claude-flow__swarm_scale --swarmId="${SWARM_ID}" --targetSize="12" --strategy="predictive"
+mcp__moflo__swarm_scale --swarmId="${SWARM_ID}" --targetSize="12" --strategy="predictive"
 ```
 
 ## Dynamic Adaptation Algorithms

--- a/src/@claude-flow/cli/.claude/agents/swarm/hierarchical-coordinator.md
+++ b/src/@claude-flow/cli/.claude/agents/swarm/hierarchical-coordinator.md
@@ -15,19 +15,19 @@ hooks:
   pre: |
     echo "👑 Hierarchical Coordinator initializing swarm: $TASK"
     # Initialize swarm topology
-    mcp__claude-flow__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
+    mcp__moflo__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
     # Store coordination state
-    mcp__claude-flow__memory_usage store "swarm:hierarchy:${TASK_ID}" "$(date): Hierarchical coordination started" --namespace=swarm
+    mcp__moflo__memory_usage store "swarm:hierarchy:${TASK_ID}" "$(date): Hierarchical coordination started" --namespace=swarm
     # Set up monitoring
-    mcp__claude-flow__swarm_monitor --interval=5000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_monitor --interval=5000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Hierarchical coordination complete"
     # Generate performance report
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__moflo__performance_report --format=detailed --timeframe=24h
     # Store completion metrics
-    mcp__claude-flow__memory_usage store "swarm:hierarchy:${TASK_ID}:complete" "$(date): Task completed with $(mcp__claude-flow__swarm_status | jq '.agents.total') agents"
+    mcp__moflo__memory_usage store "swarm:hierarchy:${TASK_ID}:complete" "$(date): Task completed with $(mcp__moflo__swarm_status | jq '.agents.total') agents"
     # Cleanup resources
-    mcp__claude-flow__coordination_sync --swarmId="${SWARM_ID}"
+    mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 ---
 
 # Hierarchical Swarm Coordinator
@@ -69,22 +69,22 @@ WORKERS WORKERS WORKERS WORKERS
 ### Research Workers 🔬
 - **Capabilities**: Information gathering, market research, competitive analysis
 - **Use Cases**: Requirements analysis, technology research, feasibility studies
-- **Spawn Command**: `mcp__claude-flow__agent_spawn researcher --capabilities="research,analysis,information_gathering"`
+- **Spawn Command**: `mcp__moflo__agent_spawn researcher --capabilities="research,analysis,information_gathering"`
 
 ### Code Workers 💻  
 - **Capabilities**: Implementation, code review, testing, documentation
 - **Use Cases**: Feature development, bug fixes, code optimization
-- **Spawn Command**: `mcp__claude-flow__agent_spawn coder --capabilities="code_generation,testing,optimization"`
+- **Spawn Command**: `mcp__moflo__agent_spawn coder --capabilities="code_generation,testing,optimization"`
 
 ### Analyst Workers 📊
 - **Capabilities**: Data analysis, performance monitoring, reporting
 - **Use Cases**: Metrics analysis, performance optimization, reporting
-- **Spawn Command**: `mcp__claude-flow__agent_spawn analyst --capabilities="data_analysis,performance_monitoring,reporting"`
+- **Spawn Command**: `mcp__moflo__agent_spawn analyst --capabilities="data_analysis,performance_monitoring,reporting"`
 
 ### Test Workers 🧪
 - **Capabilities**: Quality assurance, validation, compliance checking
 - **Use Cases**: Testing, validation, quality gates
-- **Spawn Command**: `mcp__claude-flow__agent_spawn tester --capabilities="testing,validation,quality_assurance"`
+- **Spawn Command**: `mcp__moflo__agent_spawn tester --capabilities="testing,validation,quality_assurance"`
 
 ## Coordination Workflow
 
@@ -601,39 +601,39 @@ class LearningHierarchicalCoordinator extends HierarchicalCoordinator {
 ### Swarm Management
 ```bash
 # Initialize hierarchical swarm
-mcp__claude-flow__swarm_init hierarchical --maxAgents=10 --strategy=centralized
+mcp__moflo__swarm_init hierarchical --maxAgents=10 --strategy=centralized
 
 # Spawn specialized workers
-mcp__claude-flow__agent_spawn researcher --capabilities="research,analysis"
-mcp__claude-flow__agent_spawn coder --capabilities="implementation,testing"
-mcp__claude-flow__agent_spawn analyst --capabilities="data_analysis,reporting"
+mcp__moflo__agent_spawn researcher --capabilities="research,analysis"
+mcp__moflo__agent_spawn coder --capabilities="implementation,testing"
+mcp__moflo__agent_spawn analyst --capabilities="data_analysis,reporting"
 
 # Monitor swarm health
-mcp__claude-flow__swarm_monitor --interval=5000
+mcp__moflo__swarm_monitor --interval=5000
 ```
 
 ### Task Orchestration
 ```bash
 # Coordinate complex workflows
-mcp__claude-flow__task_orchestrate "Build authentication service" --strategy=sequential --priority=high
+mcp__moflo__task_orchestrate "Build authentication service" --strategy=sequential --priority=high
 
 # Load balance across workers
-mcp__claude-flow__load_balance --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
+mcp__moflo__load_balance --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
 
 # Sync coordination state
-mcp__claude-flow__coordination_sync --namespace=hierarchy
+mcp__moflo__coordination_sync --namespace=hierarchy
 ```
 
 ### Performance & Analytics
 ```bash
 # Generate performance reports
-mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+mcp__moflo__performance_report --format=detailed --timeframe=24h
 
 # Analyze bottlenecks
-mcp__claude-flow__bottleneck_analyze --component=coordination --metrics="throughput,latency,success_rate"
+mcp__moflo__bottleneck_analyze --component=coordination --metrics="throughput,latency,success_rate"
 
 # Monitor resource usage
-mcp__claude-flow__metrics_collect --components="agents,tasks,coordination"
+mcp__moflo__metrics_collect --components="agents,tasks,coordination"
 ```
 
 ## Decision Making Framework

--- a/src/@claude-flow/cli/.claude/agents/swarm/mesh-coordinator.md
+++ b/src/@claude-flow/cli/.claude/agents/swarm/mesh-coordinator.md
@@ -15,21 +15,21 @@ hooks:
   pre: |
     echo "🌐 Mesh Coordinator establishing peer network: $TASK"
     # Initialize mesh topology
-    mcp__claude-flow__swarm_init mesh --maxAgents=12 --strategy=distributed
+    mcp__moflo__swarm_init mesh --maxAgents=12 --strategy=distributed
     # Set up peer discovery and communication
-    mcp__claude-flow__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_init\",\"topology\":\"mesh\"}"
+    mcp__moflo__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_init\",\"topology\":\"mesh\"}"
     # Initialize consensus mechanisms
-    mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"coordination_protocol\":\"gossip\",\"consensus_threshold\":0.67}"
+    mcp__moflo__daa_consensus --agents="all" --proposal="{\"coordination_protocol\":\"gossip\",\"consensus_threshold\":0.67}"
     # Store network state
-    mcp__claude-flow__memory_usage store "mesh:network:${TASK_ID}" "$(date): Mesh network initialized" --namespace=mesh
+    mcp__moflo__memory_usage store "mesh:network:${TASK_ID}" "$(date): Mesh network initialized" --namespace=mesh
   post: |
     echo "✨ Mesh coordination complete - network resilient"
     # Generate network analysis
-    mcp__claude-flow__performance_report --format=json --timeframe=24h
+    mcp__moflo__performance_report --format=json --timeframe=24h
     # Store final network metrics
-    mcp__claude-flow__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__claude-flow__swarm_status)" --namespace=mesh
+    mcp__moflo__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__moflo__swarm_status)" --namespace=mesh
     # Graceful network shutdown
-    mcp__claude-flow__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_shutdown\",\"reason\":\"task_complete\"}"
+    mcp__moflo__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_shutdown\",\"reason\":\"task_complete\"}"
 ---
 
 # Mesh Network Swarm Coordinator
@@ -761,37 +761,37 @@ class LearningMeshCoordinator extends MeshCoordinator {
 ### Network Management
 ```bash
 # Initialize mesh network
-mcp__claude-flow__swarm_init mesh --maxAgents=12 --strategy=distributed
+mcp__moflo__swarm_init mesh --maxAgents=12 --strategy=distributed
 
 # Establish peer connections
-mcp__claude-flow__daa_communication --from="node-1" --to="node-2" --message="{\"type\":\"peer_connect\"}"
+mcp__moflo__daa_communication --from="node-1" --to="node-2" --message="{\"type\":\"peer_connect\"}"
 
 # Monitor network health
-mcp__claude-flow__swarm_monitor --interval=3000 --metrics="connectivity,latency,throughput"
+mcp__moflo__swarm_monitor --interval=3000 --metrics="connectivity,latency,throughput"
 ```
 
 ### Consensus Operations
 ```bash
 # Propose network-wide decision
-mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"task_assignment\":\"auth-service\",\"assigned_to\":\"node-3\"}"
+mcp__moflo__daa_consensus --agents="all" --proposal="{\"task_assignment\":\"auth-service\",\"assigned_to\":\"node-3\"}"
 
 # Participate in voting
-mcp__claude-flow__daa_consensus --agents="current" --vote="approve" --proposal_id="prop-123"
+mcp__moflo__daa_consensus --agents="current" --vote="approve" --proposal_id="prop-123"
 
 # Monitor consensus status
-mcp__claude-flow__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
+mcp__moflo__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
 ```
 
 ### Fault Tolerance
 ```bash
 # Detect failed nodes
-mcp__claude-flow__daa_fault_tolerance --agentId="node-4" --strategy="heartbeat_monitor"
+mcp__moflo__daa_fault_tolerance --agentId="node-4" --strategy="heartbeat_monitor"
 
 # Trigger recovery procedures  
-mcp__claude-flow__daa_fault_tolerance --agentId="failed-node" --strategy="failover_recovery"
+mcp__moflo__daa_fault_tolerance --agentId="failed-node" --strategy="failover_recovery"
 
 # Update network topology
-mcp__claude-flow__topology_optimize --swarmId="${SWARM_ID}"
+mcp__moflo__topology_optimize --swarmId="${SWARM_ID}"
 ```
 
 ## Consensus Algorithms

--- a/src/@claude-flow/cli/.claude/agents/v3/adr-architect.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/adr-architect.md
@@ -20,7 +20,7 @@ hooks:
   pre: |
     echo "📋 ADR Architect analyzing architectural decisions"
     # Search for related ADRs
-    mcp__claude-flow__memory_search --pattern="adr:*" --namespace="decisions" --limit=10
+    mcp__moflo__memory_search --pattern="adr:*" --namespace="decisions" --limit=10
     # Load project ADR context
     if [ -d "docs/adr" ] || [ -d "docs/decisions" ]; then
       echo "📁 Found existing ADR directory"
@@ -28,7 +28,7 @@ hooks:
   post: |
     echo "✅ ADR documentation complete"
     # Store new ADR in memory
-    mcp__claude-flow__memory_usage --action="store" --namespace="decisions" --key="adr:$ADR_NUMBER" --value="$ADR_TITLE"
+    mcp__moflo__memory_usage --action="store" --namespace="decisions" --key="adr:$ADR_NUMBER" --value="$ADR_TITLE"
     # Train pattern on successful decision
     npx claude-flow@v3alpha hooks intelligence trajectory-step --operation="adr-created" --outcome="success"
 ---
@@ -144,16 +144,16 @@ npx claude-flow@v3alpha adr supersede ADR-005 ADR-012
 
 ```bash
 # Store ADR in memory
-mcp__claude-flow__memory_usage --action="store" \
+mcp__moflo__memory_usage --action="store" \
   --namespace="decisions" \
   --key="adr:006" \
   --value='{"title":"Unified Memory Service","status":"accepted","date":"2026-01-08"}'
 
 # Search related ADRs
-mcp__claude-flow__memory_search --pattern="adr:*memory*" --namespace="decisions"
+mcp__moflo__memory_search --pattern="adr:*memory*" --namespace="decisions"
 
 # Get ADR details
-mcp__claude-flow__memory_usage --action="retrieve" --namespace="decisions" --key="adr:006"
+mcp__moflo__memory_usage --action="retrieve" --namespace="decisions" --key="adr:006"
 ```
 
 ## Decision Categories

--- a/src/@claude-flow/cli/.claude/agents/v3/aidefence-guardian.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/aidefence-guardian.md
@@ -191,7 +191,7 @@ Add to `.claude/settings.json`:
 
 ```javascript
 // Store detection in swarm memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "security_detections",
   key: `detection-${Date.now()}`,
@@ -235,7 +235,7 @@ if (result.threats.some(t => t.severity === 'critical')) {
     --message "Critical threat blocked by AIDefence Guardian"
 
   // Escalate to security-architect
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     namespace: "security_escalations",
     key: `escalation-${Date.now()}`,
@@ -264,7 +264,7 @@ Track guardian effectiveness:
 const stats = await guardian.getStats();
 
 // Report to metrics system
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "guardian_metrics",
   key: `metrics-${new Date().toISOString().split('T')[0]}`,

--- a/src/@claude-flow/cli/.claude/agents/v3/claims-authorizer.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/claims-authorizer.md
@@ -23,7 +23,7 @@ hooks:
   post: |
     echo "✅ Authorization complete"
     # Log authorization decision
-    mcp__claude-flow__memory_usage --action="store" --namespace="audit" --key="auth:$(date +%s)" --value="$AUTH_DECISION"
+    mcp__moflo__memory_usage --action="store" --namespace="audit" --key="auth:$(date +%s)" --value="$AUTH_DECISION"
 ---
 
 # V3 Claims Authorizer Agent
@@ -152,7 +152,7 @@ Claims are checked automatically via hooks:
 ```json
 {
   "PreToolUse": [{
-    "matcher": "^mcp__claude-flow__.*$",
+    "matcher": "^mcp__moflo__.*$",
     "hooks": [{
       "type": "command",
       "command": "npx claude-flow@v3alpha claims check --agent $AGENT_ID --tool $TOOL_NAME --auto-deny"
@@ -174,13 +174,13 @@ All authorization decisions are logged:
 
 ```bash
 # Store authorization decision
-mcp__claude-flow__memory_usage --action="store" \
+mcp__moflo__memory_usage --action="store" \
   --namespace="audit" \
   --key="auth:$(date +%s)" \
   --value='{"agent":"agent-123","resource":"memory:patterns","action":"write","decision":"allow","reason":"has scope:write claim"}'
 
 # Query audit log
-mcp__claude-flow__memory_search --pattern="auth:*" --namespace="audit" --limit=100
+mcp__moflo__memory_search --pattern="auth:*" --namespace="audit" --limit=100
 ```
 
 ## Default Policies

--- a/src/@claude-flow/cli/.claude/agents/v3/collective-intelligence-coordinator.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/collective-intelligence-coordinator.md
@@ -19,29 +19,29 @@ hooks:
   pre: |
     echo "🧠 Collective Intelligence Coordinator initializing hive-mind: $TASK"
     # Initialize hierarchical-mesh topology for collective intelligence
-    mcp__claude-flow__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
+    mcp__moflo__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
     # Set up CRDT synchronization layer
-    mcp__claude-flow__memory_usage store "collective:crdt:${TASK_ID}" "$(date): CRDT sync initialized" --namespace=collective
+    mcp__moflo__memory_usage store "collective:crdt:${TASK_ID}" "$(date): CRDT sync initialized" --namespace=collective
     # Initialize Byzantine consensus protocol
-    mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"protocol\":\"byzantine\",\"threshold\":0.67,\"fault_tolerance\":0.33}"
+    mcp__moflo__daa_consensus --agents="all" --proposal="{\"protocol\":\"byzantine\",\"threshold\":0.67,\"fault_tolerance\":0.33}"
     # Begin neural pattern analysis for collective cognition
-    mcp__claude-flow__neural_patterns analyze --operation="collective_init" --metadata="{\"task\":\"$TASK\",\"topology\":\"hierarchical-mesh\"}"
+    mcp__moflo__neural_patterns analyze --operation="collective_init" --metadata="{\"task\":\"$TASK\",\"topology\":\"hierarchical-mesh\"}"
     # Train attention mechanisms for coordination
-    mcp__claude-flow__neural_train coordination --training_data="collective_intelligence_patterns" --epochs=30
+    mcp__moflo__neural_train coordination --training_data="collective_intelligence_patterns" --epochs=30
     # Set up real-time monitoring
-    mcp__claude-flow__swarm_monitor --interval=3000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_monitor --interval=3000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Collective intelligence coordination complete - consensus achieved"
     # Store collective decision metrics
-    mcp__claude-flow__memory_usage store "collective:decision:${TASK_ID}" "$(date): Consensus decision: $(mcp__claude-flow__swarm_status | jq -r '.consensus')" --namespace=collective
+    mcp__moflo__memory_usage store "collective:decision:${TASK_ID}" "$(date): Consensus decision: $(mcp__moflo__swarm_status | jq -r '.consensus')" --namespace=collective
     # Generate performance report
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__moflo__performance_report --format=detailed --timeframe=24h
     # Learn from collective patterns
-    mcp__claude-flow__neural_patterns learn --operation="collective_coordination" --outcome="consensus_achieved" --metadata="{\"agents\":\"$(mcp__claude-flow__swarm_status | jq '.agents.total')\",\"consensus_strength\":\"$(mcp__claude-flow__swarm_status | jq '.consensus.strength')\"}"
+    mcp__moflo__neural_patterns learn --operation="collective_coordination" --outcome="consensus_achieved" --metadata="{\"agents\":\"$(mcp__moflo__swarm_status | jq '.agents.total')\",\"consensus_strength\":\"$(mcp__moflo__swarm_status | jq '.consensus.strength')\"}"
     # Save learned model
-    mcp__claude-flow__model_save "collective-intelligence-${TASK_ID}" "/tmp/collective-model-$(date +%s).json"
+    mcp__moflo__model_save "collective-intelligence-${TASK_ID}" "/tmp/collective-model-$(date +%s).json"
     # Synchronize final CRDT state
-    mcp__claude-flow__coordination_sync --swarmId="${SWARM_ID}"
+    mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 ---
 
 # Collective Intelligence Coordinator
@@ -800,54 +800,54 @@ class LearningCollectiveCoordinator extends CollectiveIntelligenceCoordinator {
 
 ```bash
 # Initialize hive-mind topology
-mcp__claude-flow__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
+mcp__moflo__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
 
 # Byzantine consensus protocol
-mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"task\":\"auth_design\",\"type\":\"collective_vote\"}"
+mcp__moflo__daa_consensus --agents="all" --proposal="{\"task\":\"auth_design\",\"type\":\"collective_vote\"}"
 
 # CRDT synchronization
-mcp__claude-flow__memory_sync --target="all_agents" --crdt_type="OR_SET"
+mcp__moflo__memory_sync --target="all_agents" --crdt_type="OR_SET"
 
 # Attention-based coordination
-mcp__claude-flow__neural_patterns analyze --operation="collective_attention" --metadata="{\"mechanism\":\"multi-head\",\"heads\":8}"
+mcp__moflo__neural_patterns analyze --operation="collective_attention" --metadata="{\"mechanism\":\"multi-head\",\"heads\":8}"
 
 # Knowledge aggregation
-mcp__claude-flow__memory_usage store "collective:knowledge:${TASK_ID}" "$(date): Knowledge synthesis complete" --namespace=collective
+mcp__moflo__memory_usage store "collective:knowledge:${TASK_ID}" "$(date): Knowledge synthesis complete" --namespace=collective
 
 # Monitor collective health
-mcp__claude-flow__swarm_monitor --interval=3000 --metrics="consensus,byzantine,attention"
+mcp__moflo__swarm_monitor --interval=3000 --metrics="consensus,byzantine,attention"
 ```
 
 ### Memory Synchronization Commands
 
 ```bash
 # Initialize CRDT layer
-mcp__claude-flow__memory_usage store "crdt:state:init" "{\"type\":\"OR_SET\",\"nodes\":[]}" --namespace=crdt
+mcp__moflo__memory_usage store "crdt:state:init" "{\"type\":\"OR_SET\",\"nodes\":[]}" --namespace=crdt
 
 # Propagate deltas
-mcp__claude-flow__coordination_sync --swarmId="${SWARM_ID}"
+mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 
 # Verify convergence
-mcp__claude-flow__health_check --components="crdt,consensus,memory"
+mcp__moflo__health_check --components="crdt,consensus,memory"
 
 # Backup collective state
-mcp__claude-flow__memory_backup --path="/tmp/collective-backup-$(date +%s).json"
+mcp__moflo__memory_backup --path="/tmp/collective-backup-$(date +%s).json"
 ```
 
 ### Neural Learning Commands
 
 ```bash
 # Train collective patterns
-mcp__claude-flow__neural_train coordination --training_data="collective_intelligence_history" --epochs=50
+mcp__moflo__neural_train coordination --training_data="collective_intelligence_history" --epochs=50
 
 # Pattern recognition
-mcp__claude-flow__neural_patterns analyze --operation="emergent_behavior" --metadata="{\"agents\":10,\"iterations\":5}"
+mcp__moflo__neural_patterns analyze --operation="emergent_behavior" --metadata="{\"agents\":10,\"iterations\":5}"
 
 # Predictive consensus
-mcp__claude-flow__neural_predict --modelId="collective-coordinator" --input="{\"task\":\"complex_decision\",\"agents\":8}"
+mcp__moflo__neural_predict --modelId="collective-coordinator" --input="{\"task\":\"complex_decision\",\"agents\":8}"
 
 # Learn from outcomes
-mcp__claude-flow__neural_patterns learn --operation="consensus_achieved" --outcome="success" --metadata="{\"confidence\":0.92}"
+mcp__moflo__neural_patterns learn --operation="consensus_achieved" --outcome="success" --metadata="{\"confidence\":0.92}"
 ```
 
 ## Consensus Mechanisms
@@ -959,13 +959,13 @@ def select_topology(task_characteristics):
 
 ```bash
 # Collective health check
-mcp__claude-flow__health_check --components="collective,consensus,crdt,attention"
+mcp__moflo__health_check --components="collective,consensus,crdt,attention"
 
 # Performance report
-mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+mcp__moflo__performance_report --format=detailed --timeframe=24h
 
 # Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze --component="collective" --metrics="latency,throughput,accuracy"
+mcp__moflo__bottleneck_analyze --component="collective" --metrics="latency,throughput,accuracy"
 ```
 
 ## Best Practices

--- a/src/@claude-flow/cli/.claude/agents/v3/ddd-domain-expert.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/ddd-domain-expert.md
@@ -30,13 +30,13 @@ hooks:
   pre: |
     echo "🏛️ DDD Domain Expert analyzing domain model"
     # Search for existing domain patterns
-    mcp__claude-flow__memory_search --pattern="ddd:*" --namespace="architecture" --limit=10
+    mcp__moflo__memory_search --pattern="ddd:*" --namespace="architecture" --limit=10
     # Load domain context
-    mcp__claude-flow__memory_usage --action="retrieve" --namespace="architecture" --key="domain:model"
+    mcp__moflo__memory_usage --action="retrieve" --namespace="architecture" --key="domain:model"
   post: |
     echo "✅ Domain model analysis complete"
     # Store domain patterns
-    mcp__claude-flow__memory_usage --action="store" --namespace="architecture" --key="ddd:analysis:$(date +%s)" --value="$DOMAIN_SUMMARY"
+    mcp__moflo__memory_usage --action="store" --namespace="architecture" --key="ddd:analysis:$(date +%s)" --value="$DOMAIN_SUMMARY"
 ---
 
 # V3 DDD Domain Expert Agent
@@ -210,11 +210,11 @@ npx claude-flow@v3alpha ddd language-check
 
 ```bash
 # Store domain model
-mcp__claude-flow__memory_usage --action="store" \
+mcp__moflo__memory_usage --action="store" \
   --namespace="architecture" \
   --key="domain:model" \
   --value='{"contexts":["swarm","agent","task","memory"]}'
 
 # Search domain patterns
-mcp__claude-flow__memory_search --pattern="ddd:aggregate:*" --namespace="architecture"
+mcp__moflo__memory_search --pattern="ddd:aggregate:*" --namespace="architecture"
 ```

--- a/src/@claude-flow/cli/.claude/agents/v3/memory-specialist.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/memory-specialist.md
@@ -23,21 +23,21 @@ hooks:
   pre: |
     echo "Memory Specialist initializing V3 memory system"
     # Initialize hybrid memory backend
-    mcp__claude-flow__memory_namespace --namespace="${NAMESPACE:-default}" --action="init"
+    mcp__moflo__memory_namespace --namespace="${NAMESPACE:-default}" --action="init"
     # Check HNSW index status
-    mcp__claude-flow__memory_analytics --timeframe="1h"
+    mcp__moflo__memory_analytics --timeframe="1h"
     # Store initialization event
-    mcp__claude-flow__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:init:${TASK_ID}" --value="$(date -Iseconds): Memory specialist session started"
+    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:init:${TASK_ID}" --value="$(date -Iseconds): Memory specialist session started"
   post: |
     echo "Memory optimization complete"
     # Persist memory state
-    mcp__claude-flow__memory_persist --sessionId="${SESSION_ID}"
+    mcp__moflo__memory_persist --sessionId="${SESSION_ID}"
     # Compress and optimize namespaces
-    mcp__claude-flow__memory_compress --namespace="${NAMESPACE:-default}"
+    mcp__moflo__memory_compress --namespace="${NAMESPACE:-default}"
     # Generate memory analytics report
-    mcp__claude-flow__memory_analytics --timeframe="24h"
+    mcp__moflo__memory_analytics --timeframe="24h"
     # Store completion metrics
-    mcp__claude-flow__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:complete:${TASK_ID}" --value="$(date -Iseconds): Memory optimization completed"
+    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:complete:${TASK_ID}" --value="$(date -Iseconds): Memory optimization completed"
 ---
 
 # V3 Memory Specialist Agent
@@ -884,28 +884,28 @@ class PatternDistiller {
 
 ```bash
 # Store with HNSW indexing
-mcp__claude-flow__memory_usage --action="store" --namespace="patterns" --key="auth:jwt-strategy" --value='{"pattern": "jwt-auth", "embedding": [...]}' --ttl=604800000
+mcp__moflo__memory_usage --action="store" --namespace="patterns" --key="auth:jwt-strategy" --value='{"pattern": "jwt-auth", "embedding": [...]}' --ttl=604800000
 
 # Semantic search with HNSW
-mcp__claude-flow__memory_search --pattern="authentication strategies" --namespace="patterns" --limit=10
+mcp__moflo__memory_search --pattern="authentication strategies" --namespace="patterns" --limit=10
 
 # Namespace management
-mcp__claude-flow__memory_namespace --namespace="project:myapp" --action="create"
+mcp__moflo__memory_namespace --namespace="project:myapp" --action="create"
 
 # Memory analytics
-mcp__claude-flow__memory_analytics --timeframe="7d"
+mcp__moflo__memory_analytics --timeframe="7d"
 
 # Memory compression
-mcp__claude-flow__memory_compress --namespace="default"
+mcp__moflo__memory_compress --namespace="default"
 
 # Cross-session persistence
-mcp__claude-flow__memory_persist --sessionId="session-12345"
+mcp__moflo__memory_persist --sessionId="session-12345"
 
 # Memory backup
-mcp__claude-flow__memory_backup --path="./backups/memory-$(date +%Y%m%d).bak"
+mcp__moflo__memory_backup --path="./backups/memory-$(date +%Y%m%d).bak"
 
 # Distributed sync
-mcp__claude-flow__memory_sync --target="peer-agent-1"
+mcp__moflo__memory_sync --target="peer-agent-1"
 ```
 
 ### CLI Commands

--- a/src/@claude-flow/cli/.claude/agents/v3/performance-engineer.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/performance-engineer.md
@@ -1026,12 +1026,12 @@ class V3BenchmarkSuite {
 const performanceMCP = {
   // Run benchmark suite
   async runBenchmarks(suite = 'all') {
-    return await mcp__claude-flow__benchmark_run({ suite });
+    return await mcp__moflo__benchmark_run({ suite });
   },
 
   // Analyze bottlenecks
   async analyzeBottlenecks(component) {
-    return await mcp__claude-flow__bottleneck_analyze({
+    return await mcp__moflo__bottleneck_analyze({
       component: component,
       metrics: ['latency', 'throughput', 'memory', 'cpu']
     });
@@ -1039,7 +1039,7 @@ const performanceMCP = {
 
   // Get performance report
   async getPerformanceReport(timeframe = '24h') {
-    return await mcp__claude-flow__performance_report({
+    return await mcp__moflo__performance_report({
       format: 'detailed',
       timeframe: timeframe
     });
@@ -1047,7 +1047,7 @@ const performanceMCP = {
 
   // Token usage analysis
   async analyzeTokenUsage(operation) {
-    return await mcp__claude-flow__token_usage({
+    return await mcp__moflo__token_usage({
       operation: operation,
       timeframe: '24h'
     });
@@ -1055,14 +1055,14 @@ const performanceMCP = {
 
   // WASM optimization
   async optimizeWASM(operation) {
-    return await mcp__claude-flow__wasm_optimize({
+    return await mcp__moflo__wasm_optimize({
       operation: operation
     });
   },
 
   // Neural pattern optimization
   async optimizeNeuralPatterns() {
-    return await mcp__claude-flow__neural_patterns({
+    return await mcp__moflo__neural_patterns({
       action: 'analyze',
       metadata: { focus: 'performance' }
     });
@@ -1070,7 +1070,7 @@ const performanceMCP = {
 
   // Store performance metrics
   async storeMetrics(key, value) {
-    return await mcp__claude-flow__memory_usage({
+    return await mcp__moflo__memory_usage({
       action: 'store',
       key: `performance/${key}`,
       value: JSON.stringify(value),
@@ -1144,14 +1144,14 @@ class SONAPerformanceOptimizer {
 
   async triggerSONALearning() {
     // Use SONA to learn optimization patterns
-    await mcp__claude-flow__neural_train({
+    await mcp__moflo__neural_train({
       pattern_type: 'optimization',
       training_data: JSON.stringify(this.trajectories),
       epochs: 10
     });
 
     // Extract learned patterns
-    const patterns = await mcp__claude-flow__neural_patterns({
+    const patterns = await mcp__moflo__neural_patterns({
       action: 'analyze',
       metadata: { domain: 'performance' }
     });
@@ -1167,7 +1167,7 @@ class SONAPerformanceOptimizer {
 
   async predictOptimalSettings(context) {
     // Use SONA to predict optimal configuration
-    const prediction = await mcp__claude-flow__neural_predict({
+    const prediction = await mcp__moflo__neural_predict({
       modelId: 'performance-optimizer',
       input: JSON.stringify(context)
     });

--- a/src/@claude-flow/cli/.claude/agents/v3/pii-detector.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/pii-detector.md
@@ -126,7 +126,7 @@ When PII is detected, suggest:
 
 ```javascript
 // Report PII findings to swarm
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "pii_findings",
   key: `pii-${Date.now()}`,

--- a/src/@claude-flow/cli/.claude/agents/v3/reasoningbank-learner.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/reasoningbank-learner.md
@@ -23,13 +23,13 @@ hooks:
     SESSION_ID="rb-$(date +%s)"
     npx claude-flow@v3alpha hooks intelligence trajectory-start --session-id "$SESSION_ID" --agent-type "reasoningbank-learner" --task "$TASK"
     # Search for similar patterns
-    mcp__claude-flow__memory_search --pattern="pattern:*" --namespace="reasoningbank" --limit=10
+    mcp__moflo__memory_search --pattern="pattern:*" --namespace="reasoningbank" --limit=10
   post: |
     echo "✅ Learning cycle complete"
     # End trajectory with verdict
     npx claude-flow@v3alpha hooks intelligence trajectory-end --session-id "$SESSION_ID" --verdict "${VERDICT:-success}"
     # Store learned pattern
-    mcp__claude-flow__memory_usage --action="store" --namespace="reasoningbank" --key="pattern:$(date +%s)" --value="$PATTERN_SUMMARY"
+    mcp__moflo__memory_usage --action="store" --namespace="reasoningbank" --key="pattern:$(date +%s)" --value="$PATTERN_SUMMARY"
 ---
 
 # V3 ReasoningBank Learner Agent
@@ -68,7 +68,7 @@ Search for similar patterns 150x-12,500x faster:
 
 ```bash
 # Search patterns via HNSW
-mcp__claude-flow__memory_search --pattern="$TASK" --namespace="reasoningbank" --limit=10
+mcp__moflo__memory_search --pattern="$TASK" --namespace="reasoningbank" --limit=10
 
 # Get pattern statistics
 npx claude-flow@v3alpha hooks intelligence pattern-stats --query "$TASK" --k 10 --namespace reasoningbank
@@ -99,7 +99,7 @@ Extract key learnings using LoRA adaptation:
 
 ```bash
 # Store successful pattern
-mcp__claude-flow__memory_usage --action="store" \
+mcp__moflo__memory_usage --action="store" \
   --namespace="reasoningbank" \
   --key="pattern:auth-implementation" \
   --value='{"task":"implement auth","approach":"JWT with refresh","outcome":"success","reward":0.95}'

--- a/src/@claude-flow/cli/.claude/agents/v3/security-architect-aidefence.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/security-architect-aidefence.md
@@ -323,14 +323,14 @@ npx claude-flow@v3alpha security learn --threat-type prompt_injection --strategy
 
 ```javascript
 // Real-time threat scanning
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   action: "defend",
   input: userInput,
   mode: "thorough"
 })
 
 // Behavioral anomaly detection
-mcp__claude-flow__security_analyze({
+mcp__moflo__security_analyze({
   action: "behavior",
   agentId: agentId,
   timeWindow: "1h",
@@ -338,7 +338,7 @@ mcp__claude-flow__security_analyze({
 })
 
 // LTL policy verification
-mcp__claude-flow__security_verify({
+mcp__moflo__security_verify({
   action: "policy",
   agentId: agentId,
   policy: "G(!self_approve)"

--- a/src/@claude-flow/cli/.claude/agents/v3/security-architect.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/security-architect.md
@@ -793,7 +793,7 @@ const mergedFindings = securityConsensus.attentionWeights.map((weight, i) => ({
 
 ```javascript
 // Store security findings in coordinated memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   key: "swarm/security-architect/assessment",
   namespace: "coordination",
@@ -816,7 +816,7 @@ mcp__claude-flow__memory_usage({
 })
 
 // Share with other security agents
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   key: "swarm/shared/security-findings",
   namespace: "coordination",

--- a/src/@claude-flow/cli/.claude/agents/v3/sparc-orchestrator.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/sparc-orchestrator.md
@@ -25,15 +25,15 @@ hooks:
     echo "⚡ SPARC Orchestrator initializing methodology workflow"
     # Store SPARC session start
     SESSION_ID="sparc-$(date +%s)"
-    mcp__claude-flow__memory_usage --action="store" --namespace="sparc" --key="session:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow initiated for: $TASK"
+    mcp__moflo__memory_usage --action="store" --namespace="sparc" --key="session:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow initiated for: $TASK"
     # Search for similar SPARC patterns
-    mcp__claude-flow__memory_search --pattern="sparc:success:*" --namespace="patterns" --limit=5
+    mcp__moflo__memory_search --pattern="sparc:success:*" --namespace="patterns" --limit=5
     # Initialize trajectory tracking
     npx claude-flow@v3alpha hooks intelligence trajectory-start --session-id "$SESSION_ID" --agent-type "sparc-orchestrator" --task "$TASK"
   post: |
     echo "✅ SPARC workflow complete"
     # Store completion
-    mcp__claude-flow__memory_usage --action="store" --namespace="sparc" --key="complete:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow completed"
+    mcp__moflo__memory_usage --action="store" --namespace="sparc" --key="complete:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow completed"
     # Train on successful pattern
     npx claude-flow@v3alpha hooks intelligence trajectory-end --session-id "$SESSION_ID" --verdict "success"
 ---
@@ -167,11 +167,11 @@ The orchestrator learns from each workflow:
 
 ```bash
 # Store successful pattern
-mcp__claude-flow__memory_usage --action="store" --namespace="patterns" \
+mcp__moflo__memory_usage --action="store" --namespace="patterns" \
   --key="sparc:success:$(date +%s)" --value="$WORKFLOW_SUMMARY"
 
 # Search for similar patterns
-mcp__claude-flow__memory_search --pattern="sparc:*:$PROJECT_TYPE" --namespace="patterns"
+mcp__moflo__memory_search --pattern="sparc:*:$PROJECT_TYPE" --namespace="patterns"
 ```
 
 ## Integration with V3 Features

--- a/src/@claude-flow/cli/.claude/agents/v3/swarm-memory-manager.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/swarm-memory-manager.md
@@ -23,20 +23,20 @@ hooks:
   pre: |
     echo "🧠 Swarm Memory Manager initializing distributed memory"
     # Initialize all memory namespaces for swarm
-    mcp__claude-flow__memory_namespace --namespace="swarm" --action="init"
-    mcp__claude-flow__memory_namespace --namespace="agents" --action="init"
-    mcp__claude-flow__memory_namespace --namespace="tasks" --action="init"
-    mcp__claude-flow__memory_namespace --namespace="patterns" --action="init"
+    mcp__moflo__memory_namespace --namespace="swarm" --action="init"
+    mcp__moflo__memory_namespace --namespace="agents" --action="init"
+    mcp__moflo__memory_namespace --namespace="tasks" --action="init"
+    mcp__moflo__memory_namespace --namespace="patterns" --action="init"
     # Store initialization event
-    mcp__claude-flow__memory_usage --action="store" --namespace="swarm" --key="memory-manager:init:$(date +%s)" --value="Distributed memory initialized"
+    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-manager:init:$(date +%s)" --value="Distributed memory initialized"
   post: |
     echo "🔄 Synchronizing swarm memory state"
     # Sync memory across instances
-    mcp__claude-flow__memory_sync --target="all"
+    mcp__moflo__memory_sync --target="all"
     # Compress stale data
-    mcp__claude-flow__memory_compress --namespace="swarm"
+    mcp__moflo__memory_compress --namespace="swarm"
     # Persist session state
-    mcp__claude-flow__memory_persist --sessionId="${SESSION_ID}"
+    mcp__moflo__memory_persist --sessionId="${SESSION_ID}"
 ---
 
 # V3 Swarm Memory Manager Agent
@@ -98,13 +98,13 @@ You are a **Swarm Memory Manager** responsible for coordinating distributed memo
 
 ```bash
 # Memory operations
-mcp__claude-flow__memory_usage --action="store|retrieve|list|delete|search"
-mcp__claude-flow__memory_search --pattern="*" --namespace="swarm"
-mcp__claude-flow__memory_sync --target="all"
-mcp__claude-flow__memory_compress --namespace="default"
-mcp__claude-flow__memory_persist --sessionId="$SESSION_ID"
-mcp__claude-flow__memory_namespace --namespace="name" --action="init|delete|stats"
-mcp__claude-flow__memory_analytics --timeframe="24h"
+mcp__moflo__memory_usage --action="store|retrieve|list|delete|search"
+mcp__moflo__memory_search --pattern="*" --namespace="swarm"
+mcp__moflo__memory_sync --target="all"
+mcp__moflo__memory_compress --namespace="default"
+mcp__moflo__memory_persist --sessionId="$SESSION_ID"
+mcp__moflo__memory_namespace --namespace="name" --action="init|delete|stats"
+mcp__moflo__memory_analytics --timeframe="24h"
 ```
 
 ## Coordination Protocol
@@ -130,15 +130,15 @@ mcp__claude-flow__memory_analytics --timeframe="24h"
 
 ```javascript
 // 1. Initialize distributed memory for new swarm
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 10 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 10 })
 
 // 2. Create namespaces
 for (const ns of ["swarm", "agents", "tasks", "patterns"]) {
-  mcp__claude-flow__memory_namespace({ namespace: ns, action: "init" })
+  mcp__moflo__memory_namespace({ namespace: ns, action: "init" })
 }
 
 // 3. Store swarm state
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "swarm",
   key: "topology",
@@ -146,12 +146,12 @@ mcp__claude-flow__memory_usage({
 })
 
 // 4. Agents read shared state
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "retrieve",
   namespace: "swarm",
   key: "topology"
 })
 
 // 5. Sync periodically
-mcp__claude-flow__memory_sync({ target: "all" })
+mcp__moflo__memory_sync({ target: "all" })
 ```

--- a/src/@claude-flow/cli/.claude/agents/v3/v3-integration-architect.md
+++ b/src/@claude-flow/cli/.claude/agents/v3/v3-integration-architect.md
@@ -21,10 +21,10 @@ hooks:
     # Check agentic-flow version
     npx agentic-flow --version 2>/dev/null || echo "agentic-flow not installed"
     # Load integration patterns
-    mcp__claude-flow__memory_search --pattern="integration:agentic-flow:*" --namespace="architecture" --limit=5
+    mcp__moflo__memory_search --pattern="integration:agentic-flow:*" --namespace="architecture" --limit=5
   post: |
     echo "✅ Integration analysis complete"
-    mcp__claude-flow__memory_usage --action="store" --namespace="architecture" --key="integration:analysis:$(date +%s)" --value="ADR-001 compliance checked"
+    mcp__moflo__memory_usage --action="store" --namespace="architecture" --key="integration:analysis:$(date +%s)" --value="ADR-001 compliance checked"
 ---
 
 # V3 Integration Architect Agent

--- a/src/@claude-flow/cli/.claude/commands/agents/agent-capabilities.md
+++ b/src/@claude-flow/cli/.claude/commands/agents/agent-capabilities.md
@@ -89,16 +89,16 @@ tester: Read, Write, Bash, Glob
 
 ### Swarm Tools
 ```
-hierarchical-coordinator: mcp__claude-flow__swarm_*, mcp__claude-flow__agent_*
-mesh-coordinator: mcp__claude-flow__swarm_*, mcp__claude-flow__coordination_*
-adaptive-coordinator: mcp__claude-flow__topology_*, mcp__claude-flow__swarm_*
+hierarchical-coordinator: mcp__moflo__swarm_*, mcp__moflo__agent_*
+mesh-coordinator: mcp__moflo__swarm_*, mcp__moflo__coordination_*
+adaptive-coordinator: mcp__moflo__topology_*, mcp__moflo__swarm_*
 ```
 
 ### GitHub Tools
 ```
 pr-manager: mcp__github__*, Bash (gh CLI)
-code-review-swarm: mcp__github__*, mcp__claude-flow__swarm_*
-release-manager: mcp__github__*, mcp__claude-flow__workflow_*
+code-review-swarm: mcp__github__*, mcp__moflo__swarm_*
+release-manager: mcp__github__*, mcp__moflo__workflow_*
 ```
 
 ## Querying Capabilities

--- a/src/@claude-flow/cli/.claude/commands/agents/agent-spawning.md
+++ b/src/@claude-flow/cli/.claude/commands/agents/agent-spawning.md
@@ -17,8 +17,8 @@ Task("Tester", "Create tests...", "tester")
 
 MCP tools are ONLY for coordination:
 ```javascript
-mcp__claude-flow__swarm_init { topology: "mesh" }
-mcp__claude-flow__agent_spawn { type: "researcher" }
+mcp__moflo__swarm_init { topology: "mesh" }
+mcp__moflo__agent_spawn { type: "researcher" }
 ```
 
 ## Best Practices

--- a/src/@claude-flow/cli/.claude/commands/agents/spawn.md
+++ b/src/@claude-flow/cli/.claude/commands/agents/spawn.md
@@ -116,8 +116,8 @@ Task("Reviewer", "Review auth implementation", "reviewer")
 Use MCP tools only for swarm coordination setup:
 
 ```javascript
-mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 15 })
-mcp__claude-flow__agent_spawn({ type: "coordinator", name: "queen" })
+mcp__moflo__swarm_init({ topology: "hierarchical", maxAgents: 15 })
+mcp__moflo__agent_spawn({ type: "coordinator", name: "queen" })
 ```
 
 ## Output

--- a/src/@claude-flow/cli/.claude/commands/analysis/COMMAND_COMPLIANCE_REPORT.md
+++ b/src/@claude-flow/cli/.claude/commands/analysis/COMMAND_COMPLIANCE_REPORT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 Reviewed all command files in `.claude/commands/analysis/` directory to ensure proper usage of:
-- `mcp__claude-flow__*` tools (preferred)
+- `mcp__moflo__*` tools (preferred)
 - `npx claude-flow` commands (as fallback)
 - No direct implementation calls
 
@@ -12,7 +12,7 @@ Reviewed all command files in `.claude/commands/analysis/` directory to ensure p
 **Status**: ✅ Updated
 **Changes Made**:
 - Replaced `npx ruv-swarm hook session-end --export-metrics` with proper MCP tool call
-- Updated to: `Tool: mcp__claude-flow__token_usage` with appropriate parameters
+- Updated to: `Tool: mcp__moflo__token_usage` with appropriate parameters
 - Maintained result format and context
 
 **Before**:
@@ -22,13 +22,13 @@ npx ruv-swarm hook session-end --export-metrics
 
 **After**:
 ```
-Tool: mcp__claude-flow__token_usage
+Tool: mcp__moflo__token_usage
 Parameters: {"operation": "session", "timeframe": "24h"}
 ```
 
 ### 2. performance-bottlenecks.md
 **Status**: ✅ Compliant (No changes needed)
-**Reason**: Already uses proper `mcp__claude-flow__task_results` tool format
+**Reason**: Already uses proper `mcp__moflo__task_results` tool format
 
 ## Summary
 
@@ -39,7 +39,7 @@ Parameters: {"operation": "session", "timeframe": "24h"}
 
 ## Compliance Patterns Enforced
 
-1. **MCP Tool Usage**: All direct tool calls now use `mcp__claude-flow__*` format
+1. **MCP Tool Usage**: All direct tool calls now use `mcp__moflo__*` format
 2. **Parameter Format**: JSON parameters properly structured
 3. **Command Context**: Preserved original functionality and expected results
 4. **Documentation**: Maintained clarity and examples

--- a/src/@claude-flow/cli/.claude/commands/analysis/bottleneck-detect.md
+++ b/src/@claude-flow/cli/.claude/commands/analysis/bottleneck-detect.md
@@ -147,7 +147,7 @@ Typical improvements after bottleneck resolution:
 
 ```javascript
 // Check for bottlenecks in Claude Code
-mcp__claude-flow__bottleneck_detect {
+mcp__moflo__bottleneck_detect {
   timeRange: "1h",
   threshold: 20,
   autoFix: false

--- a/src/@claude-flow/cli/.claude/commands/analysis/performance-bottlenecks.md
+++ b/src/@claude-flow/cli/.claude/commands/analysis/performance-bottlenecks.md
@@ -32,7 +32,7 @@ The post-task hook automatically analyzes:
 ### 3. Improvement Suggestions
 
 ```
-Tool: mcp__claude-flow__task_results
+Tool: mcp__moflo__task_results
 Parameters: {"taskId": "task-123", "format": "detailed"}
 
 Result includes:

--- a/src/@claude-flow/cli/.claude/commands/analysis/token-efficiency.md
+++ b/src/@claude-flow/cli/.claude/commands/analysis/token-efficiency.md
@@ -19,7 +19,7 @@ Reduce token consumption while maintaining quality through intelligent coordinat
 
 ```bash
 # Check token savings after session
-Tool: mcp__claude-flow__token_usage
+Tool: mcp__moflo__token_usage
 Parameters: {"operation": "session", "timeframe": "24h"}
 
 # Result shows:

--- a/src/@claude-flow/cli/.claude/commands/automation/auto-agent.md
+++ b/src/@claude-flow/cli/.claude/commands/automation/auto-agent.md
@@ -107,7 +107,7 @@ npx claude-flow auto agent -t "Fix bug in login" -s minimal
 
 ```javascript
 // In Claude Code after auto-spawning
-mcp__claude-flow__auto_agent {
+mcp__moflo__auto_agent {
   task: "Build authentication system",
   strategy: "balanced",
   maxAgents: 6

--- a/src/@claude-flow/cli/.claude/commands/automation/self-healing.md
+++ b/src/@claude-flow/cli/.claude/commands/automation/self-healing.md
@@ -47,7 +47,7 @@ Each recovery improves future prevention:
 **Pattern Storage:**
 ```javascript
 // Store error patterns
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "error-pattern-" + Date.now(),
   "value": JSON.stringify(errorData),
@@ -56,7 +56,7 @@ mcp__claude-flow__memory_usage({
 })
 
 // Analyze patterns
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "analyze",
   "operation": "error-recovery",
   "outcome": "success"
@@ -68,21 +68,21 @@ mcp__claude-flow__neural_patterns({
 ### MCP Tool Coordination
 ```javascript
 // Initialize self-healing swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 4,
   "strategy": "adaptive"
 })
 
 // Spawn recovery agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "monitor",
   "name": "Error Monitor",
   "capabilities": ["error-detection", "recovery"]
 })
 
 // Orchestrate recovery
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "recover from error",
   "strategy": "sequential",
   "priority": "critical"

--- a/src/@claude-flow/cli/.claude/commands/automation/session-memory.md
+++ b/src/@claude-flow/cli/.claude/commands/automation/session-memory.md
@@ -16,14 +16,14 @@ At session end, automatically saves:
 ### 2. Session Restoration
 ```javascript
 // Using MCP tools for memory operations
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "retrieve",
   "key": "session-state",
   "namespace": "sessions"
 })
 
 // Restore swarm state
-mcp__claude-flow__context_restore({
+mcp__moflo__context_restore({
   "snapshotId": "sess-123"
 })
 ```
@@ -56,20 +56,20 @@ npx claude-flow hook session-restore --session-id "sess-123"
 ### 4. Privacy & Control
 ```javascript
 // List memory contents
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "list",
   "namespace": "sessions"
 })
 
 // Delete specific memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "delete",
   "key": "session-123",
   "namespace": "sessions"
 })
 
 // Backup memory
-mcp__claude-flow__memory_backup({
+mcp__moflo__memory_backup({
   "path": "./backups/memory-backup.json"
 })
 ```

--- a/src/@claude-flow/cli/.claude/commands/automation/smart-agents.md
+++ b/src/@claude-flow/cli/.claude/commands/automation/smart-agents.md
@@ -30,12 +30,12 @@ The system monitors workload and spawns additional agents when:
 **Status Monitoring:**
 ```javascript
 // Check swarm health
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "current"
 })
 
 // Monitor agent performance
-mcp__claude-flow__agent_metrics({
+mcp__moflo__agent_metrics({
   "agentId": "agent-123"
 })
 ```
@@ -46,14 +46,14 @@ mcp__claude-flow__agent_metrics({
 Uses Claude Flow MCP tools for agent coordination:
 ```javascript
 // Initialize swarm with appropriate topology
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 8,
   "strategy": "auto"
 })
 
 // Spawn agents based on file type
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coder",
   "name": "JavaScript Handler",
   "capabilities": ["javascript", "typescript"]

--- a/src/@claude-flow/cli/.claude/commands/coordination/init.md
+++ b/src/@claude-flow/cli/.claude/commands/coordination/init.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__swarm_init`
+**Tool:** `mcp__moflo__swarm_init`
 
 ## Parameters
 ```json
@@ -27,7 +27,7 @@ Remember: This does NOT create actual coding agents. It creates a coordination p
 ## Example Usage
 
 **In Claude Code:**
-1. Use the tool: `mcp__claude-flow__swarm_init`
+1. Use the tool: `mcp__moflo__swarm_init`
 2. With parameters: `{"topology": "mesh", "maxAgents": 5, "strategy": "balanced"}`
 3. Claude Code then executes the coordinated plan using its native tools
 

--- a/src/@claude-flow/cli/.claude/commands/coordination/orchestrate.md
+++ b/src/@claude-flow/cli/.claude/commands/coordination/orchestrate.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__task_orchestrate`
+**Tool:** `mcp__moflo__task_orchestrate`
 
 ## Parameters
 ```json
@@ -26,7 +26,7 @@ The orchestrator creates a plan that Claude Code follows using its native tools.
 ## Example Usage
 
 **In Claude Code:**
-1. Use the tool: `mcp__claude-flow__task_orchestrate`
+1. Use the tool: `mcp__moflo__task_orchestrate`
 2. With parameters: `{"task": "Implement authentication system", "strategy": "parallel", "priority": "high"}`
 3. Claude Code then executes the coordinated plan using its native tools
 

--- a/src/@claude-flow/cli/.claude/commands/coordination/spawn.md
+++ b/src/@claude-flow/cli/.claude/commands/coordination/spawn.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__agent_spawn`
+**Tool:** `mcp__moflo__agent_spawn`
 
 ## Parameters
 ```json
@@ -28,7 +28,7 @@ These patterns guide how Claude Code approaches different aspects of your task.
 ## Example Usage
 
 **In Claude Code:**
-1. Use the tool: `mcp__claude-flow__agent_spawn`
+1. Use the tool: `mcp__moflo__agent_spawn`
 2. With parameters: `{"type": "researcher", "name": "Literature Analysis", "capabilities": ["deep-analysis"]}`
 3. Claude Code then executes the coordinated plan using its native tools
 

--- a/src/@claude-flow/cli/.claude/commands/coordination/swarm-init.md
+++ b/src/@claude-flow/cli/.claude/commands/coordination/swarm-init.md
@@ -74,7 +74,7 @@ npx claude-flow swarm init --topology star --github --memory
 Once initialized, use MCP tools in Claude Code:
 
 ```javascript
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 8 }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 8 }
 ```
 
 ## See Also

--- a/src/@claude-flow/cli/.claude/commands/github/github-modes.md
+++ b/src/@claude-flow/cli/.claude/commands/github/github-modes.md
@@ -137,11 +137,11 @@ All GitHub modes can be enhanced with ruv-swarm coordination:
 
 ```javascript
 // Initialize swarm for GitHub workflow
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
-mcp__claude-flow__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
+mcp__moflo__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
 ```

--- a/src/@claude-flow/cli/.claude/commands/github/github-swarm.md
+++ b/src/@claude-flow/cli/.claude/commands/github/github-swarm.md
@@ -106,7 +106,7 @@ npx claude-flow github swarm -r owner/repo -a 8 -f triage --issue-labels --auto-
 Use in Claude Code with MCP tools:
 
 ```javascript
-mcp__claude-flow__github_swarm {
+mcp__moflo__github_swarm {
   repository: "owner/repo",
   agents: 6,
   focus: "maintenance"

--- a/src/@claude-flow/cli/.claude/commands/github/issue-tracker.md
+++ b/src/@claude-flow/cli/.claude/commands/github/issue-tracker.md
@@ -17,7 +17,7 @@ Intelligent issue management and project coordination with ruv-swarm integration
 - `mcp__github__update_issue`
 - `mcp__github__add_issue_comment`
 - `mcp__github__search_issues`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -25,10 +25,10 @@ Intelligent issue management and project coordination with ruv-swarm integration
 ### 1. Create Coordinated Issue with Swarm Tracking
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -53,7 +53,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"
@@ -63,7 +63,7 @@ mcp__claude-flow__task_orchestrate {
 ### 2. Automated Progress Updates
 ```javascript
 // Update issue with progress from swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "issue/54/progress"
 }
@@ -92,7 +92,7 @@ mcp__github__add_issue_comment {
 }
 
 // Store progress in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/54/latest_update",
   value: { timestamp: Date.now(), progress: "89%", status: "near_completion" }
@@ -125,10 +125,10 @@ mcp__github__update_issue {
 ```javascript
 [Single Message - Issue Lifecycle Management]:
   // Initialize issue coordination swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Manager" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Progress Tracker" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Context Gatherer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Manager" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Progress Tracker" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Context Gatherer" }
   
   // Create multiple related issues using gh CLI
   Bash(`gh issue create \
@@ -158,7 +158,7 @@ mcp__github__update_issue {
   ]}
   
   // Store initial coordination state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "project/github_integration/issues",
     value: { created: Date.now(), total_issues: 3, status: "initialized" }

--- a/src/@claude-flow/cli/.claude/commands/github/pr-manager.md
+++ b/src/@claude-flow/cli/.claude/commands/github/pr-manager.md
@@ -21,7 +21,7 @@ Comprehensive pull request management with ruv-swarm coordination for automated 
 - `mcp__github__update_pull_request_branch`
 - `mcp__github__get_pull_request_comments`
 - `mcp__github__get_pull_request_reviews`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -29,10 +29,10 @@ Comprehensive pull request management with ruv-swarm coordination for automated 
 ### 1. Create and Manage PR with Swarm Coordination
 ```javascript
 // Initialize review swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Testing Agent" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Testing Agent" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
 
 // Create PR and orchestrate review
 mcp__github__create_pull_request {
@@ -45,7 +45,7 @@ mcp__github__create_pull_request {
 }
 
 // Orchestrate review process
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review with testing and validation",
   strategy: "parallel",
   priority: "high"
@@ -87,7 +87,7 @@ mcp__github__merge_pull_request {
 }
 
 // Post-merge coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/54/merged",
   value: { timestamp: Date.now(), status: "success" }
@@ -100,10 +100,10 @@ mcp__claude-flow__memory_usage {
 ```javascript
 [Single Message - Complete PR Management]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
   
   // Create and manage PR using gh CLI
   Bash("gh pr create --repo :owner/:repo --title '...' --head '...' --base 'main'")

--- a/src/@claude-flow/cli/.claude/commands/github/release-manager.md
+++ b/src/@claude-flow/cli/.claude/commands/github/release-manager.md
@@ -16,7 +16,7 @@ Automated release coordination and deployment with ruv-swarm orchestration for s
 - `mcp__github__create_branch`
 - `mcp__github__push_files`
 - `mcp__github__create_issue`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`
 
 ## Usage Patterns
@@ -24,12 +24,12 @@ Automated release coordination and deployment with ruv-swarm orchestration for s
 ### 1. Coordinated Release Preparation
 ```javascript
 // Initialize release management swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Coordinator" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Release Coordinator" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
 
 // Create release preparation branch
 mcp__github__create_branch {
@@ -40,7 +40,7 @@ mcp__github__create_branch {
 }
 
 // Orchestrate release preparation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Prepare release v1.0.72 with comprehensive testing and validation",
   strategy: "sequential",
   priority: "critical"
@@ -177,13 +177,13 @@ This release is production-ready with comprehensive validation and testing.
 ```javascript
 [Single Message - Complete Release Management]:
   // Initialize comprehensive release swarm
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 8 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Lead" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Controller" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Performance Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 8 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Lead" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Controller" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Performance Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
   
   // Create release branch and prepare files using gh CLI
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v1.0.72' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
@@ -222,7 +222,7 @@ This release is production-ready with comprehensive validation and testing.
   ]}
   
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store", 
     key: "release/v1.0.72/status",
     value: {

--- a/src/@claude-flow/cli/.claude/commands/github/repo-architect.md
+++ b/src/@claude-flow/cli/.claude/commands/github/repo-architect.md
@@ -16,7 +16,7 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 - `mcp__github__search_repositories`
 - `mcp__github__push_files`
 - `mcp__github__create_or_update_file`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `LS`, `Glob`
 
 ## Usage Patterns
@@ -24,11 +24,11 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 ### 1. Repository Structure Analysis and Optimization
 ```javascript
 // Initialize architecture analysis swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Repository Architect" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyzer" }
+mcp__moflo__agent_spawn { type: "architect", name: "Repository Architect" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
 
 // Analyze current repository structure
 LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -42,7 +42,7 @@ mcp__github__search_repositories {
 }
 
 // Orchestrate structure optimization
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze and optimize repository structure for scalability and maintainability",
   strategy: "adaptive",
   priority: "medium"
@@ -169,12 +169,12 @@ jobs:
 ```javascript
 [Single Message - Repository Architecture Review]:
   // Initialize comprehensive architecture swarm
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "architect", name: "Senior Architect" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyst" }
-  mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "architect", name: "Senior Architect" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyst" }
+  mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
   
   // Analyze current repository structures
   LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -223,7 +223,7 @@ jobs:
   ]}
   
   // Store architecture analysis
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "architecture/analysis/results",
     value: {

--- a/src/@claude-flow/cli/.claude/commands/github/sync-coordinator.md
+++ b/src/@claude-flow/cli/.claude/commands/github/sync-coordinator.md
@@ -16,7 +16,7 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 - `mcp__github__get_file_contents`
 - `mcp__github__create_pull_request`
 - `mcp__github__search_repositories`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`, `MultiEdit`
 
 ## Usage Patterns
@@ -24,11 +24,11 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 ### 1. Synchronize Package Dependencies
 ```javascript
 // Initialize sync coordination swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 // Analyze current package states
 Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -47,7 +47,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/packa
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/package.json?ref=sync/package-alignment --jq '.sha')")`)
 
 // Orchestrate validation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Validate package synchronization and run integration tests",
   strategy: "parallel",
   priority: "high"
@@ -73,7 +73,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUD
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUDE.md?ref=sync/documentation --jq '.sha' 2>/dev/null || echo '')")`)
 
 // Store sync state in memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/documentation/status",
   value: { timestamp: Date.now(), status: "synchronized", files: ["CLAUDE.md"] }
@@ -147,12 +147,12 @@ This integration uses ruv-swarm agents for:
 ```javascript
 [Single Message - Complete Synchronization]:
   // Initialize comprehensive sync swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Package Analyzer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Coder" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Tester" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Package Analyzer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Integration Coder" }
+  mcp__moflo__agent_spawn { type: "tester", name: "Validation Tester" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
   
   // Read current state of both packages
   Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -186,7 +186,7 @@ This integration uses ruv-swarm agents for:
   ]}
   
   // Store comprehensive sync state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "sync/complete/status",
     value: {

--- a/src/@claude-flow/cli/.claude/commands/memory/neural.md
+++ b/src/@claude-flow/cli/.claude/commands/memory/neural.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__neural_train`
+**Tool:** `mcp__moflo__neural_train`
 
 ## Parameters
 ```json
@@ -29,10 +29,10 @@ Training improves:
 ## Example Usage
 
 **In Claude Code:**
-1. Train coordination patterns: Use tool `mcp__claude-flow__neural_train` with parameters `{"pattern_type": "coordination", "training_data": "successful task patterns", "epochs": 50}`
-2. Train optimization patterns: Use tool `mcp__claude-flow__neural_train` with parameters `{"pattern_type": "optimization", "training_data": "performance metrics", "epochs": 30}`
-3. Check training status: Use tool `mcp__claude-flow__neural_status`
-4. Analyze patterns: Use tool `mcp__claude-flow__neural_patterns` with parameters `{"action": "analyze"}`
+1. Train coordination patterns: Use tool `mcp__moflo__neural_train` with parameters `{"pattern_type": "coordination", "training_data": "successful task patterns", "epochs": 50}`
+2. Train optimization patterns: Use tool `mcp__moflo__neural_train` with parameters `{"pattern_type": "optimization", "training_data": "performance metrics", "epochs": 30}`
+3. Check training status: Use tool `mcp__moflo__neural_status`
+4. Analyze patterns: Use tool `mcp__moflo__neural_patterns` with parameters `{"action": "analyze"}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/src/@claude-flow/cli/.claude/commands/monitoring/agents.md
+++ b/src/@claude-flow/cli/.claude/commands/monitoring/agents.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__agent_list`
+**Tool:** `mcp__moflo__agent_list`
 
 ## Parameters
 ```json
@@ -27,9 +27,9 @@ Filters:
 ## Example Usage
 
 **In Claude Code:**
-1. List all agents: Use tool `mcp__claude-flow__agent_list`
-2. Get specific agent metrics: Use tool `mcp__claude-flow__agent_metrics` with parameters `{"agentId": "coder-123"}`
-3. Monitor agent performance: Use tool `mcp__claude-flow__swarm_monitor` with parameters `{"interval": 2000}`
+1. List all agents: Use tool `mcp__moflo__agent_list`
+2. Get specific agent metrics: Use tool `mcp__moflo__agent_metrics` with parameters `{"agentId": "coder-123"}`
+3. Monitor agent performance: Use tool `mcp__moflo__swarm_monitor` with parameters `{"interval": 2000}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/src/@claude-flow/cli/.claude/commands/monitoring/status.md
+++ b/src/@claude-flow/cli/.claude/commands/monitoring/status.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__swarm_status`
+**Tool:** `mcp__moflo__swarm_status`
 
 ## Parameters
 ```json
@@ -28,10 +28,10 @@ Shows:
 ## Example Usage
 
 **In Claude Code:**
-1. Check swarm status: Use tool `mcp__claude-flow__swarm_status`
-2. Monitor in real-time: Use tool `mcp__claude-flow__swarm_monitor` with parameters `{"interval": 1000}`
-3. Get agent metrics: Use tool `mcp__claude-flow__agent_metrics` with parameters `{"agentId": "agent-123"}`
-4. Health check: Use tool `mcp__claude-flow__health_check` with parameters `{"components": ["swarm", "memory", "neural"]}`
+1. Check swarm status: Use tool `mcp__moflo__swarm_status`
+2. Monitor in real-time: Use tool `mcp__moflo__swarm_monitor` with parameters `{"interval": 1000}`
+3. Get agent metrics: Use tool `mcp__moflo__agent_metrics` with parameters `{"agentId": "agent-123"}`
+4. Health check: Use tool `mcp__moflo__health_check` with parameters `{"components": ["swarm", "memory", "neural"]}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/src/@claude-flow/cli/.claude/commands/optimization/auto-topology.md
+++ b/src/@claude-flow/cli/.claude/commands/optimization/auto-topology.md
@@ -23,14 +23,14 @@ Based on analysis, it selects:
 
 **Simple Task:**
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {"task": "Fix typo in README.md"}
 Result: Automatically uses star topology with single agent
 ```
 
 **Complex Task:**
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {"task": "Refactor authentication system with JWT, add tests, update documentation"}
 Result: Automatically uses hierarchical topology with architect, coder, and tester agents
 ```
@@ -51,7 +51,7 @@ The pre-task hook automatically handles topology selection:
 
 ## Direct Optimization
 ```
-Tool: mcp__claude-flow__topology_optimize
+Tool: mcp__moflo__topology_optimize
 Parameters: {"swarmId": "current"}
 ```
 

--- a/src/@claude-flow/cli/.claude/commands/optimization/parallel-execution.md
+++ b/src/@claude-flow/cli/.claude/commands/optimization/parallel-execution.md
@@ -7,7 +7,7 @@ Execute independent subtasks in parallel for maximum efficiency.
 
 ### 1. Task Decomposition
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {
   "task": "Build complete REST API with auth, CRUD operations, and tests",
   "strategy": "parallel",
@@ -43,7 +43,7 @@ npx claude-flow parallel "Build REST API" --max-agents 8
 
 ## Monitoring
 ```
-Tool: mcp__claude-flow__swarm_monitor
+Tool: mcp__moflo__swarm_monitor
 Parameters: {"interval": 1000, "swarmId": "current"}
 ```
 

--- a/src/@claude-flow/cli/.claude/commands/sparc.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc.md
@@ -44,19 +44,19 @@ Use `new_task` to assign:
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
 // Run SPARC orchestrator (default)
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "sparc",
   task_description: "build complete authentication system"
 }
 
 // Run a specific mode
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design API structure"
 }
 
 // TDD workflow
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "implement user authentication",
   options: {workflow: "full"}
@@ -102,7 +102,7 @@ npx claude-flow@alpha sparc run <mode> "your task"
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store specifications
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "spec_auth",
   value: "OAuth2 + JWT requirements",
@@ -110,7 +110,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Store architectural decisions
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "arch_decisions",
   value: "Microservices with API Gateway",

--- a/src/@claude-flow/cli/.claude/commands/sparc/analyzer.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/analyzer.md
@@ -7,7 +7,7 @@ Deep code and data analysis with batch processing capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "analyzer",
   task_description: "analyze codebase performance",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/architect.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/architect.md
@@ -7,7 +7,7 @@ System design with Memory-based coordination for scalable architectures.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design microservices architecture",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/ask.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/ask.md
@@ -36,7 +36,7 @@ Help users craft `new_task` messages to delegate effectively, and always remind 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "ask",
   task_description: "help me choose the right mode",
   options: {
@@ -72,7 +72,7 @@ npx claude-flow sparc run ask "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "ask_context",
   value: "important decisions",
@@ -80,7 +80,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "ask",
   namespace: "ask",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/batch-executor.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/batch-executor.md
@@ -7,7 +7,7 @@ Parallel task execution specialist using batch operations.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "batch-executor",
   task_description: "process multiple files",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/code.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/code.md
@@ -28,7 +28,7 @@ Write modular code using clean architecture principles. Never hardcode secrets o
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "code",
   task_description: "implement REST API endpoints",
   options: {
@@ -64,7 +64,7 @@ npx claude-flow sparc run code "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "code_context",
   value: "important decisions",
@@ -72,7 +72,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "code",
   namespace: "code",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/coder.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/coder.md
@@ -7,7 +7,7 @@ Autonomous code generation with batch file operations.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement user authentication",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/debug.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/debug.md
@@ -22,7 +22,7 @@ Use logs, traces, and stack analysis to isolate bugs. Avoid changing env configu
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "debug",
   task_description: "fix memory leak in service",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run debug "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "debug_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "debug",
   namespace: "debug",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/debugger.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/debugger.md
@@ -7,7 +7,7 @@ Systematic debugging with TodoWrite and Memory integration.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "debugger",
   task_description: "fix authentication issues",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/designer.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/designer.md
@@ -7,7 +7,7 @@ UI/UX design with Memory coordination for consistent experiences.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "designer",
   task_description: "create dashboard UI",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/devops.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/devops.md
@@ -48,7 +48,7 @@ Return `attempt_completion` with:
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "devops",
   task_description: "deploy to AWS Lambda",
   options: {
@@ -84,7 +84,7 @@ npx claude-flow sparc run devops "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "devops_context",
   value: "important decisions",
@@ -92,7 +92,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "devops",
   namespace: "devops",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/docs-writer.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/docs-writer.md
@@ -19,7 +19,7 @@ Only work in .md files. Use sections, examples, and headings. Keep each file und
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "docs-writer",
   task_description: "create API documentation",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run docs-writer "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "docs-writer_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "docs-writer",
   namespace: "docs-writer",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/documenter.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/documenter.md
@@ -7,7 +7,7 @@ Documentation with batch file operations for comprehensive docs.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "create API documentation",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/innovator.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/innovator.md
@@ -7,7 +7,7 @@ Creative problem solving with WebSearch and Memory integration.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "innovative solutions for scaling",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/integration.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/integration.md
@@ -22,7 +22,7 @@ Verify interface compatibility, shared modules, and env config standards. Split 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "integration",
   task_description: "connect payment service",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run integration "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "integration_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "integration",
   namespace: "integration",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/mcp.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/mcp.md
@@ -56,7 +56,7 @@ For accessing MCP resources, use `access_mcp_resource` with proper URI:
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "mcp",
   task_description: "integrate with external API",
   options: {
@@ -92,7 +92,7 @@ npx claude-flow sparc run mcp "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "mcp_context",
   value: "important decisions",
@@ -100,7 +100,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "mcp",
   namespace: "mcp",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/memory-manager.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/memory-manager.md
@@ -7,7 +7,7 @@ Knowledge management with Memory tools for persistent insights.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "memory-manager",
   task_description: "organize project knowledge",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/optimizer.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/optimizer.md
@@ -7,7 +7,7 @@ Performance optimization with systematic analysis and improvements.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "optimizer",
   task_description: "optimize application performance",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/orchestrator.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/orchestrator.md
@@ -7,7 +7,7 @@ Multi-agent task orchestration with TodoWrite/TodoRead/Task/Memory using MCP too
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "coordinate feature development"
 }
@@ -40,20 +40,20 @@ npx claude-flow@alpha sparc run orchestrator "coordinate feature development"
 ### Using MCP Tools (Preferred)
 ```javascript
 // Initialize orchestration swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "auto",
   maxAgents: 8
 }
 
 // Spawn coordinator agent
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "coordinator",
   capabilities: ["task-planning", "resource-management"]
 }
 
 // Orchestrate tasks
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "feature development",
   strategy: "parallel",
   dependencies: ["auth", "ui", "api"]
@@ -91,26 +91,26 @@ npx claude-flow task orchestrate --task "feature development" --strategy paralle
 ### Using MCP Tools (Preferred)
 ```javascript
 // 1. Initialize orchestration swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 10
 }
 
 // 2. Create workflow
-mcp__claude-flow__workflow_create {
+mcp__moflo__workflow_create {
   name: "feature-development",
   steps: ["design", "implement", "test", "deploy"]
 }
 
 // 3. Execute orchestration
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   options: {parallel: true, monitor: true},
   task_description: "develop user management system"
 }
 
 // 4. Monitor progress
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }

--- a/src/@claude-flow/cli/.claude/commands/sparc/post-deployment-monitoring-mode.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/post-deployment-monitoring-mode.md
@@ -22,7 +22,7 @@ Configure metrics, logs, uptime checks, and alerts. Recommend improvements if th
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "post-deployment-monitoring-mode",
   task_description: "monitor production metrics",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run post-deployment-monitoring-mode "your task" --non-inte
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "post-deployment-monitoring-mode_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "post-deployment-monitoring-mode",
   namespace: "post-deployment-monitoring-mode",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/refinement-optimization-mode.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/refinement-optimization-mode.md
@@ -22,7 +22,7 @@ Audit files for clarity, modularity, and size. Break large components (>500 line
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "refinement-optimization-mode",
   task_description: "optimize database queries",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run refinement-optimization-mode "your task" --non-interac
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "refinement-optimization-mode_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "refinement-optimization-mode",
   namespace: "refinement-optimization-mode",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/researcher.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/researcher.md
@@ -7,7 +7,7 @@ Deep research with parallel WebSearch/WebFetch and Memory coordination.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research AI trends 2024",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/reviewer.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/reviewer.md
@@ -7,7 +7,7 @@ Code review using batch file analysis for comprehensive reviews.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review pull request #123",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/security-review.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/security-review.md
@@ -19,7 +19,7 @@ Scan for exposed secrets, env leaks, and monoliths. Recommend mitigations or ref
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "security-review",
   task_description: "audit API security",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run security-review "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "security-review_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "security-review",
   namespace: "security-review",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/sparc-modes.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/sparc-modes.md
@@ -34,7 +34,7 @@ SPARC (Specification, Planning, Architecture, Review, Code) is a comprehensive d
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
 // Execute SPARC mode directly
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "<mode>",
   task_description: "<task>",
   options: {
@@ -43,20 +43,20 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Initialize swarm for advanced coordination
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "auto",
   maxAgents: 8
 }
 
 // Spawn specialized agents
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "<agent-type>",
   capabilities: ["<capability1>", "<capability2>"]
 }
 
 // Monitor execution
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
@@ -93,31 +93,31 @@ npx claude-flow sparc run <mode> "task" --parallel --monitor
 #### Using MCP Tools (Preferred)
 ```javascript
 // 1. Initialize development swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 12
 }
 
 // 2. Architecture design
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design microservices"
 }
 
 // 3. Implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement services"
 }
 
 // 4. Testing
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "test all services"
 }
 
 // 5. Review
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review implementation"
 }
@@ -143,19 +143,19 @@ npx claude-flow sparc run reviewer "review implementation"
 #### Using MCP Tools (Preferred)
 ```javascript
 // 1. Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research best practices"
 }
 
 // 2. Innovation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "propose novel solutions"
 }
 
 // 3. Documentation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "document findings"
 }

--- a/src/@claude-flow/cli/.claude/commands/sparc/sparc.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/sparc.md
@@ -50,7 +50,7 @@ use new_task for each new task as a sub-task.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "sparc",
   task_description: "orchestrate authentication system",
   options: {
@@ -86,7 +86,7 @@ npx claude-flow sparc run sparc "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sparc_context",
   value: "important decisions",
@@ -94,7 +94,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "sparc",
   namespace: "sparc",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/spec-pseudocode.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/spec-pseudocode.md
@@ -19,7 +19,7 @@ Write pseudocode as a series of md files with phase_number_name.md and flow logi
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "spec-pseudocode",
   task_description: "define payment flow requirements",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run spec-pseudocode "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "spec-pseudocode_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "spec-pseudocode",
   namespace: "spec-pseudocode",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/supabase-admin.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/supabase-admin.md
@@ -287,7 +287,7 @@ Rebases a development branch on production. This will effectively run any newer 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "supabase-admin",
   task_description: "create user authentication schema",
   options: {
@@ -323,7 +323,7 @@ npx claude-flow sparc run supabase-admin "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "supabase-admin_context",
   value: "important decisions",
@@ -331,7 +331,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "supabase-admin",
   namespace: "supabase-admin",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/swarm-coordinator.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/swarm-coordinator.md
@@ -7,7 +7,7 @@ Specialized swarm management with batch coordination capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "swarm-coordinator",
   task_description: "manage development swarm",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/tdd.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/tdd.md
@@ -7,7 +7,7 @@ Test-driven development with TodoWrite planning and comprehensive testing.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "shopping cart feature",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/tester.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/tester.md
@@ -7,7 +7,7 @@ Comprehensive testing with parallel execution capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "full regression suite",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/sparc/tutorial.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/tutorial.md
@@ -18,7 +18,7 @@ You teach developers how to apply the SPARC methodology through actionable examp
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tutorial",
   task_description: "guide me through SPARC methodology",
   options: {
@@ -54,7 +54,7 @@ npx claude-flow sparc run tutorial "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "tutorial_context",
   value: "important decisions",
@@ -62,7 +62,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "tutorial",
   namespace: "tutorial",
   limit: 5

--- a/src/@claude-flow/cli/.claude/commands/sparc/workflow-manager.md
+++ b/src/@claude-flow/cli/.claude/commands/sparc/workflow-manager.md
@@ -7,7 +7,7 @@ Process automation with TodoWrite planning and Task execution.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "workflow-manager",
   task_description: "automate deployment",
   options: {

--- a/src/@claude-flow/cli/.claude/commands/swarm/analysis.md
+++ b/src/@claude-flow/cli/.claude/commands/swarm/analysis.md
@@ -8,14 +8,14 @@ Comprehensive analysis through distributed agent coordination.
 ### Using MCP Tools
 ```javascript
 // Initialize analysis swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
 })
 
 // Orchestrate analysis task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "analyze system performance",
   "strategy": "parallel",
   "priority": "medium"
@@ -30,25 +30,25 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn analysis agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Data Collector",
   "capabilities": ["metrics", "logging", "monitoring"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Pattern Analyzer",
   "capabilities": ["pattern-recognition", "anomaly-detection"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "documenter",
   "name": "Report Generator",
   "capabilities": ["reporting", "visualization"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coordinator",
   "name": "Insight Synthesizer",
   "capabilities": ["synthesis", "correlation"]
@@ -63,19 +63,19 @@ mcp__claude-flow__agent_spawn({
 ## Analysis Operations
 ```javascript
 // Run performance analysis
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "24h"
 })
 
 // Identify bottlenecks
-mcp__claude-flow__bottleneck_analyze({
+mcp__moflo__bottleneck_analyze({
   "component": "api",
   "metrics": ["response-time", "throughput"]
 })
 
 // Pattern recognition
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": performanceData,
   "patterns": ["anomaly", "trend", "cycle"]
 })
@@ -84,12 +84,12 @@ mcp__claude-flow__pattern_recognize({
 ## Status Monitoring
 ```javascript
 // Monitor analysis progress
-mcp__claude-flow__task_status({
+mcp__moflo__task_status({
   "taskId": "analysis-task-001"
 })
 
 // Get analysis results
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   "taskId": "analysis-task-001"
 })
 ```

--- a/src/@claude-flow/cli/.claude/commands/swarm/development.md
+++ b/src/@claude-flow/cli/.claude/commands/swarm/development.md
@@ -8,14 +8,14 @@ Coordinated development through specialized agent teams.
 ### Using MCP Tools
 ```javascript
 // Initialize development swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "hierarchical",
   "maxAgents": 8,
   "strategy": "balanced"
 })
 
 // Orchestrate development task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "build feature X",
   "strategy": "parallel",
   "priority": "high"
@@ -30,31 +30,31 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn development agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "architect",
   "name": "System Designer",
   "capabilities": ["system-design", "api-design"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coder",
   "name": "Frontend Developer",
   "capabilities": ["react", "typescript", "ui"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coder",
   "name": "Backend Developer",
   "capabilities": ["nodejs", "api", "database"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "specialist",
   "name": "Database Expert",
   "capabilities": ["sql", "nosql", "optimization"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Integration Tester",
   "capabilities": ["integration", "e2e", "api-testing"]
@@ -70,17 +70,17 @@ mcp__claude-flow__agent_spawn({
 ## Status Monitoring
 ```javascript
 // Check swarm status
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "development-swarm"
 })
 
 // Monitor agent performance
-mcp__claude-flow__agent_metrics({
+mcp__moflo__agent_metrics({
   "agentId": "architect-001"
 })
 
 // Real-time monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "development-swarm",
   "interval": 5000
 })
@@ -89,7 +89,7 @@ mcp__claude-flow__swarm_monitor({
 ## Error Handling
 ```javascript
 // Enable fault tolerance
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "auto-recovery"
 })

--- a/src/@claude-flow/cli/.claude/commands/swarm/examples.md
+++ b/src/@claude-flow/cli/.claude/commands/swarm/examples.md
@@ -7,28 +7,28 @@
 #### Using MCP Tools
 ```javascript
 // Initialize research swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
 })
 
 // Spawn research agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "researcher",
   "name": "AI Trends Researcher",
   "capabilities": ["web-search", "analysis", "synthesis"]
 })
 
 // Orchestrate research
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "research AI trends",
   "strategy": "parallel",
   "priority": "medium"
 })
 
 // Monitor progress
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "research-swarm"
 })
 ```
@@ -47,7 +47,7 @@ npx claude-flow swarm "research AI trends" \
 #### Using MCP Tools
 ```javascript
 // Initialize development swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "hierarchical",
   "maxAgents": 8,
   "strategy": "balanced"
@@ -62,7 +62,7 @@ const devAgents = [
 ]
 
 devAgents.forEach(agent => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     "type": agent.type,
     "name": agent.name,
     "swarmId": "dev-swarm"
@@ -70,14 +70,14 @@ devAgents.forEach(agent => {
 })
 
 // Orchestrate development
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "build REST API",
   "strategy": "sequential",
   "dependencies": ["design", "implement", "test", "document"]
 })
 
 // Enable monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "dev-swarm",
   "interval": 5000
 })
@@ -97,27 +97,27 @@ npx claude-flow swarm "build REST API" \
 #### Using MCP Tools
 ```javascript
 // Initialize analysis swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 5,
   "strategy": "adaptive"
 })
 
 // Spawn analysis agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Code Analyzer",
   "capabilities": ["static-analysis", "complexity-analysis"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Security Analyzer",
   "capabilities": ["security-scan", "vulnerability-detection"]
 })
 
 // Parallel analysis execution
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "analyze-code", "command": "analyze codebase structure" },
     { "id": "analyze-security", "command": "scan for vulnerabilities" },
@@ -126,7 +126,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Generate comprehensive report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current"
 })
@@ -145,23 +145,23 @@ npx claude-flow swarm "analyze codebase" \
 
 ```javascript
 // Setup fault tolerance
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "auto-recovery"
 })
 
 // Handle errors gracefully
 try {
-  await mcp__claude-flow__task_orchestrate({
+  await mcp__moflo__task_orchestrate({
     "task": "complex operation",
     "strategy": "parallel"
   })
 } catch (error) {
   // Check swarm health
-  const status = await mcp__claude-flow__swarm_status({})
+  const status = await mcp__moflo__swarm_status({})
   
   // Log error patterns
-  await mcp__claude-flow__error_analysis({
+  await mcp__moflo__error_analysis({
     "logs": [error.message]
   })
 }

--- a/src/@claude-flow/cli/.claude/commands/swarm/maintenance.md
+++ b/src/@claude-flow/cli/.claude/commands/swarm/maintenance.md
@@ -8,14 +8,14 @@ System maintenance and updates through coordinated agents.
 ### Using MCP Tools
 ```javascript
 // Initialize maintenance swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 5,
   "strategy": "sequential"
 })
 
 // Orchestrate maintenance task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "update dependencies",
   "strategy": "sequential",
   "priority": "medium",
@@ -31,25 +31,25 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn maintenance agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Dependency Analyzer",
   "capabilities": ["dependency-analysis", "version-management"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "monitor",
   "name": "Security Scanner",
   "capabilities": ["security", "vulnerability-scan"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Test Runner",
   "capabilities": ["testing", "validation"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "documenter",
   "name": "Documentation Updater",
   "capabilities": ["documentation", "changelog"]
@@ -61,18 +61,18 @@ mcp__claude-flow__agent_spawn({
 ### Backup and Recovery
 ```javascript
 // Create system backup
-mcp__claude-flow__backup_create({
+mcp__moflo__backup_create({
   "components": ["code", "config", "dependencies"],
   "destination": "./backups/maintenance-" + Date.now()
 })
 
 // Create state snapshot
-mcp__claude-flow__state_snapshot({
+mcp__moflo__state_snapshot({
   "name": "pre-maintenance-" + Date.now()
 })
 
 // Enable fault tolerance
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "checkpoint-recovery"
 })
@@ -81,7 +81,7 @@ mcp__claude-flow__daa_fault_tolerance({
 ### Security Scanning
 ```javascript
 // Run security scan
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   "target": "./",
   "depth": "comprehensive"
 })
@@ -90,12 +90,12 @@ mcp__claude-flow__security_scan({
 ### Monitoring
 ```javascript
 // Health check before/after
-mcp__claude-flow__health_check({
+mcp__moflo__health_check({
   "components": ["dependencies", "tests", "build"]
 })
 
 // Monitor maintenance progress
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "maintenance-swarm",
   "interval": 3000
 })

--- a/src/@claude-flow/cli/.claude/commands/swarm/optimization.md
+++ b/src/@claude-flow/cli/.claude/commands/swarm/optimization.md
@@ -8,14 +8,14 @@ Performance optimization through specialized analysis.
 ### Using MCP Tools
 ```javascript
 // Initialize optimization swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
 })
 
 // Orchestrate optimization task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "optimize performance",
   "strategy": "parallel",
   "priority": "high"
@@ -30,25 +30,25 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn optimization agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "optimizer",
   "name": "Performance Profiler",
   "capabilities": ["profiling", "bottleneck-detection"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Memory Analyzer",
   "capabilities": ["memory-analysis", "leak-detection"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "optimizer",
   "name": "Code Optimizer",
   "capabilities": ["code-optimization", "refactoring"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Benchmark Runner",
   "capabilities": ["benchmarking", "performance-testing"]
@@ -60,18 +60,18 @@ mcp__claude-flow__agent_spawn({
 ### Performance Analysis
 ```javascript
 // Analyze bottlenecks
-mcp__claude-flow__bottleneck_analyze({
+mcp__moflo__bottleneck_analyze({
   "component": "all",
   "metrics": ["cpu", "memory", "io", "network"]
 })
 
 // Run benchmarks
-mcp__claude-flow__benchmark_run({
+mcp__moflo__benchmark_run({
   "suite": "performance"
 })
 
 // WASM optimization
-mcp__claude-flow__wasm_optimize({
+mcp__moflo__wasm_optimize({
   "operation": "simd-acceleration"
 })
 ```
@@ -79,18 +79,18 @@ mcp__claude-flow__wasm_optimize({
 ### Optimization Operations
 ```javascript
 // Optimize topology
-mcp__claude-flow__topology_optimize({
+mcp__moflo__topology_optimize({
   "swarmId": "optimization-swarm"
 })
 
 // DAA optimization
-mcp__claude-flow__daa_optimization({
+mcp__moflo__daa_optimization({
   "target": "performance",
   "metrics": ["speed", "memory", "efficiency"]
 })
 
 // Load balancing
-mcp__claude-flow__load_balance({
+mcp__moflo__load_balance({
   "swarmId": "optimization-swarm",
   "tasks": optimizationTasks
 })
@@ -99,19 +99,19 @@ mcp__claude-flow__load_balance({
 ### Monitoring and Reporting
 ```javascript
 // Performance report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "7d"
 })
 
 // Trend analysis
-mcp__claude-flow__trend_analysis({
+mcp__moflo__trend_analysis({
   "metric": "performance",
   "period": "30d"
 })
 
 // Cost analysis
-mcp__claude-flow__cost_analysis({
+mcp__moflo__cost_analysis({
   "timeframe": "30d"
 })
 ```

--- a/src/@claude-flow/cli/.claude/commands/swarm/research.md
+++ b/src/@claude-flow/cli/.claude/commands/swarm/research.md
@@ -8,14 +8,14 @@ Deep research through parallel information gathering.
 ### Using MCP Tools
 ```javascript
 // Initialize research swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
 })
 
 // Orchestrate research task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "research topic X",
   "strategy": "parallel",
   "priority": "medium"
@@ -30,25 +30,25 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn research agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "researcher",
   "name": "Web Researcher",
   "capabilities": ["web-search", "content-extraction", "source-validation"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "researcher",
   "name": "Academic Researcher",
   "capabilities": ["paper-analysis", "citation-tracking", "literature-review"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "analyst",
   "name": "Data Analyst",
   "capabilities": ["data-processing", "statistical-analysis", "visualization"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "documenter",
   "name": "Report Writer",
   "capabilities": ["synthesis", "technical-writing", "formatting"]
@@ -60,7 +60,7 @@ mcp__claude-flow__agent_spawn({
 ### Information Gathering
 ```javascript
 // Parallel information collection
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "web-search", "command": "search recent publications" },
     { "id": "academic-search", "command": "search academic databases" },
@@ -69,7 +69,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Store research findings
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "research-findings-" + Date.now(),
   "value": JSON.stringify(findings),
@@ -81,18 +81,18 @@ mcp__claude-flow__memory_usage({
 ### Analysis and Validation
 ```javascript
 // Pattern recognition in findings
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": researchData,
   "patterns": ["trend", "correlation", "outlier"]
 })
 
 // Cognitive analysis
-mcp__claude-flow__cognitive_analyze({
+mcp__moflo__cognitive_analyze({
   "behavior": "research-synthesis"
 })
 
 // Cross-reference validation
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "research-sources",
   "criteria": ["credibility", "relevance", "recency"]
 })
@@ -101,14 +101,14 @@ mcp__claude-flow__quality_assess({
 ### Knowledge Management
 ```javascript
 // Search existing knowledge
-mcp__claude-flow__memory_search({
+mcp__moflo__memory_search({
   "pattern": "topic X",
   "namespace": "research",
   "limit": 20
 })
 
 // Create knowledge connections
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "learn",
   "operation": "knowledge-graph",
   "metadata": {
@@ -121,7 +121,7 @@ mcp__claude-flow__neural_patterns({
 ### Reporting
 ```javascript
 // Generate research report
-mcp__claude-flow__workflow_execute({
+mcp__moflo__workflow_execute({
   "workflowId": "research-report-generation",
   "params": {
     "findings": findings,
@@ -130,7 +130,7 @@ mcp__claude-flow__workflow_execute({
 })
 
 // Monitor progress
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "research-swarm"
 })
 ```

--- a/src/@claude-flow/cli/.claude/commands/swarm/testing.md
+++ b/src/@claude-flow/cli/.claude/commands/swarm/testing.md
@@ -8,14 +8,14 @@ Comprehensive testing through distributed execution.
 ### Using MCP Tools
 ```javascript
 // Initialize testing swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 7,
   "strategy": "parallel"
 })
 
 // Orchestrate testing task
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "test application",
   "strategy": "parallel",
   "priority": "high"
@@ -30,31 +30,31 @@ mcp__claude-flow__task_orchestrate({
 ### Agent Spawning with MCP
 ```javascript
 // Spawn testing agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Unit Tester",
   "capabilities": ["unit-testing", "mocking", "coverage"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Integration Tester",
   "capabilities": ["integration", "api-testing", "contract-testing"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "E2E Tester",
   "capabilities": ["e2e", "ui-testing", "user-flows"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "tester",
   "name": "Performance Tester",
   "capabilities": ["load-testing", "stress-testing", "benchmarking"]
 })
 
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "monitor",
   "name": "Security Tester",
   "capabilities": ["security-testing", "penetration-testing", "vulnerability-scanning"]
@@ -66,13 +66,13 @@ mcp__claude-flow__agent_spawn({
 ### Coverage Analysis
 ```javascript
 // Quality assessment
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "test-coverage",
   "criteria": ["line-coverage", "branch-coverage", "function-coverage"]
 })
 
 // Edge case detection
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": testScenarios,
   "patterns": ["edge-case", "boundary-condition", "error-path"]
 })
@@ -81,7 +81,7 @@ mcp__claude-flow__pattern_recognize({
 ### Test Execution
 ```javascript
 // Parallel test execution
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "unit-tests", "command": "npm run test:unit" },
     { "id": "integration-tests", "command": "npm run test:integration" },
@@ -90,7 +90,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Batch processing for test suites
-mcp__claude-flow__batch_process({
+mcp__moflo__batch_process({
   "items": testSuites,
   "operation": "execute-test-suite"
 })
@@ -99,12 +99,12 @@ mcp__claude-flow__batch_process({
 ### Performance Testing
 ```javascript
 // Run performance benchmarks
-mcp__claude-flow__benchmark_run({
+mcp__moflo__benchmark_run({
   "suite": "performance-tests"
 })
 
 // Security scanning
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   "target": "application",
   "depth": "comprehensive"
 })
@@ -113,19 +113,19 @@ mcp__claude-flow__security_scan({
 ### Monitoring and Reporting
 ```javascript
 // Monitor test execution
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "testing-swarm",
   "interval": 2000
 })
 
 // Generate test report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current-run"
 })
 
 // Get test results
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   "taskId": "test-execution-001"
 })
 ```

--- a/src/@claude-flow/cli/.claude/commands/training/specialization.md
+++ b/src/@claude-flow/cli/.claude/commands/training/specialization.md
@@ -14,7 +14,7 @@ Agents automatically specialize based on file extensions:
 
 ### 2. By Task Type
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {
   "type": "coder",
   "capabilities": ["react", "typescript", "testing"],
@@ -32,7 +32,7 @@ The system trains through:
 ### 4. Specialization Benefits
 ```
 # Check agent specializations
-Tool: mcp__claude-flow__agent_list
+Tool: mcp__moflo__agent_list
 Parameters: {"swarmId": "current"}
 
 Result shows expertise levels:

--- a/src/@claude-flow/cli/.claude/commands/workflows/development.md
+++ b/src/@claude-flow/cli/.claude/commands/workflows/development.md
@@ -7,14 +7,14 @@ Structure Claude Code's approach to complex development tasks for maximum effici
 
 ### 1. Initialize Development Framework
 ```
-Tool: mcp__claude-flow__swarm_init
+Tool: mcp__moflo__swarm_init
 Parameters: {"topology": "hierarchical", "maxAgents": 8, "strategy": "specialized"}
 ```
 Creates hierarchical structure for organized, top-down development.
 
 ### 2. Define Development Perspectives
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {
   "type": "architect",
   "name": "System Design",
@@ -22,7 +22,7 @@ Parameters: {
 }
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {
   "type": "coder",
   "name": "Implementation Focus",
@@ -30,7 +30,7 @@ Parameters: {
 }
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {
   "type": "tester",
   "name": "Quality Assurance",
@@ -41,7 +41,7 @@ Sets up architectural and implementation thinking patterns.
 
 ### 3. Coordinate Implementation
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {
   "task": "Build REST API with authentication",
   "strategy": "parallel",
@@ -52,7 +52,7 @@ Parameters: {
 
 ### 4. Monitor Progress
 ```
-Tool: mcp__claude-flow__task_status
+Tool: mcp__moflo__task_status
 Parameters: {"taskId": "api-build-task-123"}
 ```
 

--- a/src/@claude-flow/cli/.claude/commands/workflows/research.md
+++ b/src/@claude-flow/cli/.claude/commands/workflows/research.md
@@ -7,25 +7,25 @@ Coordinate Claude Code's research activities for comprehensive, systematic explo
 
 ### 1. Initialize Research Framework
 ```
-Tool: mcp__claude-flow__swarm_init
+Tool: mcp__moflo__swarm_init
 Parameters: {"topology": "mesh", "maxAgents": 5, "strategy": "balanced"}
 ```
 Creates a mesh topology for comprehensive exploration from multiple angles.
 
 ### 2. Define Research Perspectives
 ```
-Tool: mcp__claude-flow__agent_spawn
+Tool: mcp__moflo__agent_spawn
 Parameters: {"type": "researcher", "name": "Literature Review"}
 ```
 ```
-Tool: mcp__claude-flow__agent_spawn  
+Tool: mcp__moflo__agent_spawn  
 Parameters: {"type": "analyst", "name": "Data Analysis"}
 ```
 Sets up different analytical approaches for Claude Code to use.
 
 ### 3. Execute Coordinated Research
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {
   "task": "Research modern web frameworks performance",
   "strategy": "adaptive",
@@ -35,7 +35,7 @@ Parameters: {
 
 ### 4. Store Research Findings
 ```
-Tool: mcp__claude-flow__memory_usage
+Tool: mcp__moflo__memory_usage
 Parameters: {
   "action": "store",
   "key": "research_findings",

--- a/src/@claude-flow/cli/.claude/settings.json
+++ b/src/@claude-flow/cli/.claude/settings.json
@@ -107,7 +107,7 @@
       "Bash(npx @claude-flow*)",
       "Bash(npx claude-flow*)",
       "Bash(node .claude/*)",
-      "mcp__claude-flow__:*"
+      "mcp__moflo__:*"
     ],
     "deny": [
       "Read(./.env)",

--- a/src/@claude-flow/cli/.claude/skills/github-code-review/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/github-code-review/SKILL.md
@@ -1027,10 +1027,10 @@ fi
 ```javascript
 [Single Message - Parallel Execution]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
 
   // Create and manage PR using gh CLI
   Bash("gh pr create --title 'Feature: Add authentication' --base main")

--- a/src/@claude-flow/cli/.claude/skills/github-multi-repo/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/github-multi-repo/SKILL.md
@@ -90,7 +90,7 @@ const DEPS = Bash(`gh repo list my-organization --json name | \
   done | jq -s '.'`)
 
 // Initialize swarm with discovered repositories
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   topology: "hierarchical",
   maxAgents: 8,
   metadata: { repos: REPOS, dependencies: DEPS }
@@ -145,7 +145,7 @@ mcp__claude-flow__swarm_init({
 // Synchronize package dependencies and versions
 [Complete Package Sync]:
   // Initialize sync swarm
-  mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 5 })
+  mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 5 })
 
   // Spawn sync agents
   Task("Sync Coordinator", "Coordinate version alignment", "coordinator")
@@ -169,7 +169,7 @@ mcp__claude-flow__swarm_init({
     -f content="$(cat aligned-package.json | base64)"`)
 
   // Store sync state
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "sync/packages/status",
     value: {
@@ -196,7 +196,7 @@ mcp__claude-flow__swarm_init({
     -f content="$(cat /tmp/claude-source.md | base64)"`)
 
   // Track sync status
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "sync/documentation/status",
     value: { status: "synchronized", files: ["CLAUDE.md"] }
@@ -246,7 +246,7 @@ mcp__claude-flow__swarm_init({
 // Analyze and optimize repository structure
 [Architecture Analysis]:
   // Initialize architecture swarm
-  mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 6 })
+  mcp__moflo__swarm_init({ topology: "hierarchical", maxAgents: 6 })
 
   // Spawn architecture agents
   Task("Senior Architect", "Analyze repository structure", "architect")
@@ -266,7 +266,7 @@ mcp__claude-flow__swarm_init({
     --order desc`)
 
   // Store analysis results
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "architecture/analysis/results",
     value: {
@@ -406,7 +406,7 @@ Part of #$TRACKING_ISSUE"
 // Coordinate large-scale refactoring
 [Cross-Repo Refactoring]:
   // Initialize refactoring swarm
-  mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 8 })
+  mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 8 })
 
   // Spawn specialized agents
   Task("Refactoring Coordinator", "Coordinate refactoring across repos", "coordinator")
@@ -416,7 +416,7 @@ Part of #$TRACKING_ISSUE"
   Task("Integration Tester", "Validate refactored code", "tester")
 
   // Execute refactoring
-  mcp__claude-flow__task_orchestrate({
+  mcp__moflo__task_orchestrate({
     task: "Rename OldAPI to NewAPI across all repositories",
     strategy: "sequential",
     priority: "high"

--- a/src/@claude-flow/cli/.claude/skills/github-project-management/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/github-project-management/SKILL.md
@@ -20,7 +20,7 @@ prerequisites:
   - Repository access permissions
 tools_required:
   - mcp__github__*
-  - mcp__claude-flow__*
+  - mcp__moflo__*
   - Bash
   - Read
   - Write
@@ -79,10 +79,10 @@ npx ruv-swarm github board-init \
 
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -107,7 +107,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"

--- a/src/@claude-flow/cli/.claude/skills/github-release-management/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/github-release-management/SKILL.md
@@ -150,19 +150,19 @@ gh release create $(npm pkg get version) \
 ```javascript
 // Set up coordinated release team
 [Single Message - Swarm Initialization]:
-  mcp__claude-flow__swarm_init {
+  mcp__moflo__swarm_init {
     topology: "hierarchical",
     maxAgents: 6,
     strategy: "balanced"
   }
 
   // Spawn specialized agents
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
 ```
 
 #### Coordinated Release Workflow
@@ -172,7 +172,7 @@ gh release create $(npm pkg get version) \
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v2.0.0' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
 
   // Orchestrate release preparation
-  mcp__claude-flow__task_orchestrate {
+  mcp__moflo__task_orchestrate {
     task: "Prepare release v2.0.0 with comprehensive testing and validation",
     strategy: "sequential",
     priority: "critical",
@@ -204,7 +204,7 @@ gh release create $(npm pkg get version) \
   ]}
 
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "release/v2.0.0/status",
     value: JSON.stringify({
@@ -309,7 +309,7 @@ npx claude-flow github release-deploy \
 ```javascript
 [Single Message - Multi-Package Release]:
   // Initialize mesh topology for cross-package coordination
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 8 }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 8 }
 
   // Spawn package-specific agents
   Task("Package A Manager", "Coordinate claude-flow package release v1.0.72", "coder")
@@ -394,7 +394,7 @@ npx claude-flow github multi-release \
 ```javascript
 [Single Message - Cross-Repo Release]:
   // Initialize star topology for centralized coordination
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 6 }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 6 }
 
   // Spawn repo-specific coordinators
   Task("Frontend Release", "Release frontend v2.0.0 with API compatibility", "coordinator")
@@ -408,7 +408,7 @@ npx claude-flow github multi-release \
   Bash("gh api repos/org/cli/dispatches --method POST -f event_type='release' -F client_payload[version]=v1.5.0")
 
   // Monitor all releases
-  mcp__claude-flow__swarm_monitor { interval: 5, duration: 300 }
+  mcp__moflo__swarm_monitor { interval: 5, duration: 300 }
 ```
 
 ### Hotfix Emergency Procedures

--- a/src/@claude-flow/cli/.claude/skills/github-workflow-automation/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/github-workflow-automation/SKILL.md
@@ -537,19 +537,19 @@ run().catch(error => core.setFailed(error.message));
 #### Initialize GitHub Swarm
 ```javascript
 // Step 1: Initialize swarm coordination
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 8
 }
 
 // Step 2: Spawn specialized agents
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Security Analyst" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Security Analyst" }
 
 // Step 3: Orchestrate GitHub workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review and merge workflow",
   strategy: "parallel",
   priority: "high"

--- a/src/@claude-flow/cli/.claude/skills/hooks-automation/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/hooks-automation/SKILL.md
@@ -602,12 +602,12 @@ Hooks automatically integrate with MCP tools for coordination:
 npx claude-flow hook pre-task --description "Build REST API"
 
 // Internally calls MCP tools:
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "backend-dev",
   capabilities: ["api", "database", "testing"]
 }
 
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/task/api-build/context",
   namespace: "coordination",
@@ -626,7 +626,7 @@ mcp__claude-flow__memory_usage {
 npx claude-flow hook post-edit --file "api/auth.js"
 
 // Internally calls MCP tools:
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/edits/api/auth.js",
   namespace: "coordination",
@@ -639,7 +639,7 @@ mcp__claude-flow__memory_usage {
   })
 }
 
-mcp__claude-flow__neural_train {
+mcp__moflo__neural_train {
   pattern_type: "coordination",
   training_data: { /* edit patterns */ }
 }
@@ -652,11 +652,11 @@ mcp__claude-flow__neural_train {
 npx claude-flow hook session-end --session-id "dev-2024"
 
 // Internally calls MCP tools:
-mcp__claude-flow__memory_persist {
+mcp__moflo__memory_persist {
   sessionId: "dev-2024"
 }
 
-mcp__claude-flow__swarm_status {
+mcp__moflo__swarm_status {
   swarmId: "current"
 }
 
@@ -671,7 +671,7 @@ All hooks follow a standardized memory coordination pattern:
 
 **Phase 1: STATUS** - Hook starts
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/status",
   namespace: "coordination",
@@ -686,7 +686,7 @@ mcp__claude-flow__memory_usage {
 
 **Phase 2: PROGRESS** - Hook processes
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/progress",
   namespace: "coordination",
@@ -700,7 +700,7 @@ mcp__claude-flow__memory_usage {
 
 **Phase 3: COMPLETE** - Hook finishes
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/complete",
   namespace: "coordination",

--- a/src/@claude-flow/cli/.claude/skills/performance-analysis/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/performance-analysis/SKILL.md
@@ -166,14 +166,14 @@ Automatic analysis during task execution:
 #### MCP Integration
 ```javascript
 // Check for bottlenecks in Claude Code
-mcp__claude-flow__bottleneck_detect({
+mcp__moflo__bottleneck_detect({
   timeRange: "1h",
   threshold: 20,
   autoFix: false
 })
 
 // Get detailed task results with bottleneck analysis
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   taskId: "task-123",
   format: "detailed"
 })

--- a/src/@claude-flow/cli/.claude/skills/sparc-methodology/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/sparc-methodology/SKILL.md
@@ -129,7 +129,7 @@ Multi-agent task orchestration with TodoWrite/Task/Memory coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "coordinate feature development",
   options: { parallel: true, monitor: true }
@@ -189,7 +189,7 @@ Autonomous code generation with batch file operations.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement user authentication with JWT",
   options: {
@@ -225,7 +225,7 @@ System design with Memory-based coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design scalable e-commerce platform",
   options: {
@@ -262,7 +262,7 @@ Test-driven development with comprehensive testing.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "shopping cart feature with payment integration",
   options: {
@@ -301,7 +301,7 @@ Code review using batch file analysis.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review authentication module PR #123",
   options: {
@@ -342,7 +342,7 @@ Deep research with parallel WebSearch/WebFetch and Memory coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research microservices best practices 2024",
   options: {
@@ -447,7 +447,7 @@ Knowledge management and context preservation.
 
 ```javascript
 // Basic mode execution
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "<mode-name>",
   task_description: "<task description>",
   options: {
@@ -456,20 +456,20 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Initialize swarm for complex tasks
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",  // or "mesh", "ring", "star"
   strategy: "auto",           // or "balanced", "specialized", "adaptive"
   maxAgents: 8
 }
 
 // Spawn specialized agents
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "<agent-type>",
   capabilities: ["<capability1>", "<capability2>"]
 }
 
 // Monitor execution
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
@@ -524,22 +524,22 @@ npx claude-flow sparc pipeline "task description"
 
 ```javascript
 // Initialize hierarchical swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 12
 }
 
 // Spawn coordinator
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "coordinator",
   capabilities: ["planning", "delegation", "monitoring"]
 }
 
 // Spawn specialized workers
-mcp__claude-flow__agent_spawn { type: "architect" }
-mcp__claude-flow__agent_spawn { type: "coder" }
-mcp__claude-flow__agent_spawn { type: "tester" }
-mcp__claude-flow__agent_spawn { type: "reviewer" }
+mcp__moflo__agent_spawn { type: "architect" }
+mcp__moflo__agent_spawn { type: "coder" }
+mcp__moflo__agent_spawn { type: "tester" }
+mcp__moflo__agent_spawn { type: "reviewer" }
 ```
 
 ### Pattern 2: Mesh Coordination
@@ -547,7 +547,7 @@ mcp__claude-flow__agent_spawn { type: "reviewer" }
 **Best for**: Collaborative tasks requiring peer-to-peer communication
 
 ```javascript
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "mesh",
   strategy: "balanced",
   maxAgents: 6
@@ -559,7 +559,7 @@ mcp__claude-flow__swarm_init {
 **Best for**: Ordered workflow execution (spec → design → code → test → review)
 
 ```javascript
-mcp__claude-flow__workflow_create {
+mcp__moflo__workflow_create {
   name: "development-pipeline",
   steps: [
     { mode: "researcher", task: "gather requirements" },
@@ -577,7 +577,7 @@ mcp__claude-flow__workflow_create {
 **Best for**: Independent tasks that can run concurrently
 
 ```javascript
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "build full-stack application",
   strategy: "parallel",
   dependencies: {
@@ -594,7 +594,7 @@ mcp__claude-flow__task_orchestrate {
 **Best for**: Dynamic workloads with changing requirements
 
 ```javascript
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "adaptive",  // Auto-adjusts based on workload
   maxAgents: 20
@@ -609,25 +609,25 @@ mcp__claude-flow__swarm_init {
 
 ```javascript
 // Step 1: Initialize TDD swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 8
 }
 
 // Step 2: Research and planning
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research testing best practices for feature X"
 }
 
 // Step 3: Architecture design
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design testable architecture for feature X"
 }
 
 // Step 4: TDD implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "implement feature X with 90% coverage",
   options: {
@@ -638,7 +638,7 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Step 5: Code review
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review feature X implementation",
   options: {
@@ -648,7 +648,7 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Step 6: Optimization
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "optimizer",
   task_description: "optimize feature X performance"
 }
@@ -658,21 +658,21 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // RED: Write failing test
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "create failing test for shopping cart add item",
   options: { expect_failure: true }
 }
 
 // GREEN: Minimal implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement minimal code to pass test",
   options: { minimal: true }
 }
 
 // REFACTOR: Improve code quality
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "refactor shopping cart implementation",
   options: { maintain_tests: true }
@@ -689,7 +689,7 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // Store architectural decisions
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   namespace: "architecture",
   key: "api-design-v1",
@@ -698,7 +698,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Retrieve in subsequent agents
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   namespace: "architecture",
   key: "api-design-v1"
@@ -712,14 +712,14 @@ mcp__claude-flow__memory_usage {
 ```javascript
 // ✅ CORRECT: All operations together
 [Single Message]:
-  mcp__claude-flow__agent_spawn { type: "researcher" }
-  mcp__claude-flow__agent_spawn { type: "coder" }
-  mcp__claude-flow__agent_spawn { type: "tester" }
+  mcp__moflo__agent_spawn { type: "researcher" }
+  mcp__moflo__agent_spawn { type: "coder" }
+  mcp__moflo__agent_spawn { type: "tester" }
   TodoWrite { todos: [8-10 todos] }
 
 // ❌ WRONG: Multiple messages
-Message 1: mcp__claude-flow__agent_spawn { type: "researcher" }
-Message 2: mcp__claude-flow__agent_spawn { type: "coder" }
+Message 1: mcp__moflo__agent_spawn { type: "researcher" }
+Message 2: mcp__moflo__agent_spawn { type: "coder" }
 Message 3: TodoWrite { todos: [...] }
 ```
 
@@ -782,40 +782,40 @@ project/
 [Single Message - Parallel Agent Execution]:
 
 // Initialize swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 10
 }
 
 // Architecture phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design REST API with authentication",
   options: { memory_enabled: true }
 }
 
 // Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research authentication best practices"
 }
 
 // Implementation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement Express API with JWT auth",
   options: { test_driven: true }
 }
 
 // Testing phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "comprehensive API tests",
   options: { coverage_target: 90 }
 }
 
 // Review phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "security and performance review",
   options: { security_check: true }
@@ -840,7 +840,7 @@ TodoWrite {
 
 ```javascript
 // Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research AI-powered search implementations",
   options: {
@@ -850,27 +850,27 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Innovation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "propose novel search algorithm",
   options: { memory_enabled: true }
 }
 
 // Architecture phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design scalable search system"
 }
 
 // Implementation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement search algorithm",
   options: { test_driven: true }
 }
 
 // Documentation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "document search system architecture and API"
 }
@@ -880,33 +880,33 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // Analysis phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "analyzer",
   task_description: "analyze legacy codebase dependencies"
 }
 
 // Planning phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "plan incremental refactoring strategy"
 }
 
 // Testing phase (create safety net)
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "create comprehensive test suite for legacy code",
   options: { coverage_target: 80 }
 }
 
 // Refactoring phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "refactor module X with modern patterns",
   options: { maintain_tests: true }
 }
 
 // Review phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "validate refactoring maintains functionality"
 }
@@ -991,7 +991,7 @@ npx claude-flow sparc pipeline "e-commerce checkout feature"
 
 ```javascript
 // Train patterns from successful workflows
-mcp__claude-flow__neural_train {
+mcp__moflo__neural_train {
   pattern_type: "coordination",
   training_data: "successful_tdd_workflow.json",
   epochs: 50
@@ -1002,12 +1002,12 @@ mcp__claude-flow__neural_train {
 
 ```javascript
 // Save session state
-mcp__claude-flow__memory_persist {
+mcp__moflo__memory_persist {
   sessionId: "feature-auth-v1"
 }
 
 // Restore in new session
-mcp__claude-flow__context_restore {
+mcp__moflo__context_restore {
   snapshotId: "feature-auth-v1"
 }
 ```
@@ -1016,13 +1016,13 @@ mcp__claude-flow__context_restore {
 
 ```javascript
 // Analyze repository
-mcp__claude-flow__github_repo_analyze {
+mcp__moflo__github_repo_analyze {
   repo: "owner/repo",
   analysis_type: "code_quality"
 }
 
 // Manage pull requests
-mcp__claude-flow__github_pr_manage {
+mcp__moflo__github_pr_manage {
   repo: "owner/repo",
   pr_number: 123,
   action: "review"
@@ -1033,19 +1033,19 @@ mcp__claude-flow__github_pr_manage {
 
 ```javascript
 // Real-time swarm monitoring
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
 
 // Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze {
+mcp__moflo__bottleneck_analyze {
   component: "api-layer",
   metrics: ["latency", "throughput", "errors"]
 }
 
 // Token usage tracking
-mcp__claude-flow__token_usage {
+mcp__moflo__token_usage {
   operation: "feature-development",
   timeframe: "24h"
 }
@@ -1098,16 +1098,16 @@ npx claude-flow sparc batch <modes> "task"
 
 ```javascript
 // Initialize swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical" }
+mcp__moflo__swarm_init { topology: "hierarchical" }
 
 // Execute mode
-mcp__claude-flow__sparc_mode { mode: "coder", task_description: "..." }
+mcp__moflo__sparc_mode { mode: "coder", task_description: "..." }
 
 // Monitor progress
-mcp__claude-flow__swarm_monitor { interval: 5000 }
+mcp__moflo__swarm_monitor { interval: 5000 }
 
 // Store in memory
-mcp__claude-flow__memory_usage { action: "store", key: "...", value: "..." }
+mcp__moflo__memory_usage { action: "store", key: "...", value: "..." }
 ```
 
 ---

--- a/src/@claude-flow/cli/.claude/skills/swarm-advanced/SKILL.md
+++ b/src/@claude-flow/cli/.claude/skills/swarm-advanced/SKILL.md
@@ -25,13 +25,13 @@ claude mcp add claude-flow npx claude-flow@alpha mcp start
 ### Basic Pattern
 ```javascript
 // 1. Initialize swarm topology
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 6 })
 
 // 2. Spawn specialized agents
-mcp__claude-flow__agent_spawn({ type: "researcher", name: "Agent 1" })
+mcp__moflo__agent_spawn({ type: "researcher", name: "Agent 1" })
 
 // 3. Orchestrate tasks
-mcp__claude-flow__task_orchestrate({ task: "...", strategy: "parallel" })
+mcp__moflo__task_orchestrate({ task: "...", strategy: "parallel" })
 ```
 
 ## Core Concepts
@@ -73,7 +73,7 @@ Deep research through parallel information gathering, analysis, and synthesis.
 ### Architecture
 ```javascript
 // Initialize research swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
@@ -110,7 +110,7 @@ const researchAgents = [
 
 // Spawn all agents
 researchAgents.forEach(agent => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: agent.type,
     name: agent.name,
     capabilities: agent.capabilities
@@ -123,7 +123,7 @@ researchAgents.forEach(agent => {
 #### Phase 1: Information Gathering
 ```javascript
 // Parallel information collection
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "web-search",
@@ -145,7 +145,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Store research findings in memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "research-findings-" + Date.now(),
   "value": JSON.stringify(findings),
@@ -157,24 +157,24 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Analysis and Validation
 ```javascript
 // Pattern recognition in findings
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": researchData,
   "patterns": ["trend", "correlation", "outlier", "emerging-pattern"]
 })
 
 // Cognitive analysis
-mcp__claude-flow__cognitive_analyze({
+mcp__moflo__cognitive_analyze({
   "behavior": "research-synthesis"
 })
 
 // Quality assessment
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "research-sources",
   "criteria": ["credibility", "relevance", "recency", "authority"]
 })
 
 // Cross-reference validation
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "analyze",
   "operation": "fact-checking",
   "metadata": { "sources": sourcesArray }
@@ -184,14 +184,14 @@ mcp__claude-flow__neural_patterns({
 #### Phase 3: Knowledge Management
 ```javascript
 // Search existing knowledge base
-mcp__claude-flow__memory_search({
+mcp__moflo__memory_search({
   "pattern": "topic X",
   "namespace": "research",
   "limit": 20
 })
 
 // Create knowledge graph connections
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "learn",
   "operation": "knowledge-graph",
   "metadata": {
@@ -202,7 +202,7 @@ mcp__claude-flow__neural_patterns({
 })
 
 // Store connections for future use
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "knowledge-graph-X",
   "value": JSON.stringify(knowledgeGraph),
@@ -214,7 +214,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 4: Report Generation
 ```javascript
 // Orchestrate report generation
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "generate comprehensive research report",
   "strategy": "sequential",
   "priority": "high",
@@ -222,12 +222,12 @@ mcp__claude-flow__task_orchestrate({
 })
 
 // Monitor research progress
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "research-swarm"
 })
 
 // Generate final report
-mcp__claude-flow__workflow_execute({
+mcp__moflo__workflow_execute({
   "workflowId": "research-report-generation",
   "params": {
     "findings": findings,
@@ -256,7 +256,7 @@ Full-stack development through coordinated specialist agents.
 ### Architecture
 ```javascript
 // Initialize development swarm with hierarchy
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "hierarchical",
   "maxAgents": 8,
   "strategy": "balanced"
@@ -276,7 +276,7 @@ const devTeam = [
 
 // Spawn all team members
 devTeam.forEach(member => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: member.type,
     name: member.name,
     capabilities: member.capabilities,
@@ -290,7 +290,7 @@ devTeam.forEach(member => {
 #### Phase 1: Architecture and Design
 ```javascript
 // System architecture design
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "design system architecture for REST API",
   "strategy": "sequential",
   "priority": "critical",
@@ -298,7 +298,7 @@ mcp__claude-flow__task_orchestrate({
 })
 
 // Store architecture decisions
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "architecture-decisions",
   "value": JSON.stringify(architectureDoc),
@@ -309,7 +309,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Parallel Implementation
 ```javascript
 // Parallel development tasks
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "backend-api",
@@ -335,7 +335,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Monitor development progress
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "dev-swarm",
   "interval": 5000
 })
@@ -344,7 +344,7 @@ mcp__claude-flow__swarm_monitor({
 #### Phase 3: Testing and Validation
 ```javascript
 // Comprehensive testing
-mcp__claude-flow__batch_process({
+mcp__moflo__batch_process({
   "items": [
     { type: "unit", target: "all-modules" },
     { type: "integration", target: "api-endpoints" },
@@ -355,7 +355,7 @@ mcp__claude-flow__batch_process({
 })
 
 // Quality assessment
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "codebase",
   "criteria": ["coverage", "complexity", "maintainability", "security"]
 })
@@ -364,7 +364,7 @@ mcp__claude-flow__quality_assess({
 #### Phase 4: Review and Deployment
 ```javascript
 // Code review workflow
-mcp__claude-flow__workflow_execute({
+mcp__moflo__workflow_execute({
   "workflowId": "code-review-process",
   "params": {
     "reviewers": ["Code Reviewer"],
@@ -373,7 +373,7 @@ mcp__claude-flow__workflow_execute({
 })
 
 // CI/CD pipeline
-mcp__claude-flow__pipeline_create({
+mcp__moflo__pipeline_create({
   "config": {
     "stages": ["build", "test", "security-scan", "deploy"],
     "environment": "production"
@@ -399,7 +399,7 @@ Comprehensive quality assurance through distributed testing.
 ### Architecture
 ```javascript
 // Initialize testing swarm with star topology
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 7,
   "strategy": "parallel"
@@ -446,7 +446,7 @@ const testingTeam = [
 
 // Spawn all testers
 testingTeam.forEach(tester => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: tester.type,
     name: tester.name,
     capabilities: tester.capabilities,
@@ -460,7 +460,7 @@ testingTeam.forEach(tester => {
 #### Phase 1: Test Planning
 ```javascript
 // Analyze test coverage requirements
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "test-coverage",
   "criteria": [
     "line-coverage",
@@ -471,7 +471,7 @@ mcp__claude-flow__quality_assess({
 })
 
 // Identify test scenarios
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": testScenarios,
   "patterns": [
     "edge-case",
@@ -482,7 +482,7 @@ mcp__claude-flow__pattern_recognize({
 })
 
 // Store test plan
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "test-plan-" + Date.now(),
   "value": JSON.stringify(testPlan),
@@ -493,7 +493,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Parallel Test Execution
 ```javascript
 // Execute all test suites in parallel
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "unit-tests",
@@ -524,7 +524,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Batch process test suites
-mcp__claude-flow__batch_process({
+mcp__moflo__batch_process({
   "items": testSuites,
   "operation": "execute-test-suite"
 })
@@ -533,24 +533,24 @@ mcp__claude-flow__batch_process({
 #### Phase 3: Performance and Security
 ```javascript
 // Run performance benchmarks
-mcp__claude-flow__benchmark_run({
+mcp__moflo__benchmark_run({
   "suite": "comprehensive-performance"
 })
 
 // Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze({
+mcp__moflo__bottleneck_analyze({
   "component": "application",
   "metrics": ["response-time", "throughput", "memory", "cpu"]
 })
 
 // Security scanning
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   "target": "application",
   "depth": "comprehensive"
 })
 
 // Vulnerability analysis
-mcp__claude-flow__error_analysis({
+mcp__moflo__error_analysis({
   "logs": securityScanLogs
 })
 ```
@@ -558,24 +558,24 @@ mcp__claude-flow__error_analysis({
 #### Phase 4: Monitoring and Reporting
 ```javascript
 // Real-time test monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "testing-swarm",
   "interval": 2000
 })
 
 // Generate comprehensive test report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current-run"
 })
 
 // Get test results
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   "taskId": "test-execution-001"
 })
 
 // Trend analysis
-mcp__claude-flow__trend_analysis({
+mcp__moflo__trend_analysis({
   "metric": "test-coverage",
   "period": "30d"
 })
@@ -599,7 +599,7 @@ Deep code and system analysis through specialized analyzers.
 ### Architecture
 ```javascript
 // Initialize analysis swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 5,
   "strategy": "adaptive"
@@ -636,7 +636,7 @@ const analysisTeam = [
 
 // Spawn all analysts
 analysisTeam.forEach(analyst => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: analyst.type,
     name: analyst.name,
     capabilities: analyst.capabilities
@@ -647,7 +647,7 @@ analysisTeam.forEach(analyst => {
 ### Analysis Workflow
 ```javascript
 // Parallel analysis execution
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "analyze-code", "command": "analyze codebase structure and quality" },
     { "id": "analyze-security", "command": "scan for security vulnerabilities" },
@@ -657,13 +657,13 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Generate comprehensive analysis report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current"
 })
 
 // Cost analysis
-mcp__claude-flow__cost_analysis({
+mcp__moflo__cost_analysis({
   "timeframe": "30d"
 })
 ```
@@ -674,30 +674,30 @@ mcp__claude-flow__cost_analysis({
 
 ```javascript
 // Setup fault tolerance for all agents
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "auto-recovery"
 })
 
 // Error handling pattern
 try {
-  await mcp__claude-flow__task_orchestrate({
+  await mcp__moflo__task_orchestrate({
     "task": "complex operation",
     "strategy": "parallel",
     "priority": "high"
   })
 } catch (error) {
   // Check swarm health
-  const status = await mcp__claude-flow__swarm_status({})
+  const status = await mcp__moflo__swarm_status({})
 
   // Analyze error patterns
-  await mcp__claude-flow__error_analysis({
+  await mcp__moflo__error_analysis({
     "logs": [error.message]
   })
 
   // Auto-recovery attempt
   if (status.healthy) {
-    await mcp__claude-flow__task_orchestrate({
+    await mcp__moflo__task_orchestrate({
       "task": "retry failed operation",
       "strategy": "sequential"
     })
@@ -709,28 +709,28 @@ try {
 
 ```javascript
 // Cross-session persistence
-mcp__claude-flow__memory_persist({
+mcp__moflo__memory_persist({
   "sessionId": "swarm-session-001"
 })
 
 // Namespace management for different swarms
-mcp__claude-flow__memory_namespace({
+mcp__moflo__memory_namespace({
   "namespace": "research-swarm",
   "action": "create"
 })
 
 // Create state snapshot
-mcp__claude-flow__state_snapshot({
+mcp__moflo__state_snapshot({
   "name": "development-checkpoint-1"
 })
 
 // Restore from snapshot if needed
-mcp__claude-flow__context_restore({
+mcp__moflo__context_restore({
   "snapshotId": "development-checkpoint-1"
 })
 
 // Backup memory stores
-mcp__claude-flow__memory_backup({
+mcp__moflo__memory_backup({
   "path": "/workspaces/claude-code-flow/backups/swarm-memory.json"
 })
 ```
@@ -739,14 +739,14 @@ mcp__claude-flow__memory_backup({
 
 ```javascript
 // Train neural patterns from successful workflows
-mcp__claude-flow__neural_train({
+mcp__moflo__neural_train({
   "pattern_type": "coordination",
   "training_data": JSON.stringify(successfulWorkflows),
   "epochs": 50
 })
 
 // Adaptive learning from experience
-mcp__claude-flow__learning_adapt({
+mcp__moflo__learning_adapt({
   "experience": {
     "workflow": "research-to-report",
     "success": true,
@@ -756,7 +756,7 @@ mcp__claude-flow__learning_adapt({
 })
 
 // Pattern recognition for optimization
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": workflowMetrics,
   "patterns": ["bottleneck", "optimization-opportunity", "efficiency-gain"]
 })
@@ -766,7 +766,7 @@ mcp__claude-flow__pattern_recognize({
 
 ```javascript
 // Create reusable workflow
-mcp__claude-flow__workflow_create({
+mcp__moflo__workflow_create({
   "name": "full-stack-development",
   "steps": [
     { "phase": "design", "agents": ["architect"] },
@@ -779,7 +779,7 @@ mcp__claude-flow__workflow_create({
 })
 
 // Setup automation rules
-mcp__claude-flow__automation_setup({
+mcp__moflo__automation_setup({
   "rules": [
     {
       "trigger": "file-changed",
@@ -794,7 +794,7 @@ mcp__claude-flow__automation_setup({
 })
 
 // Event-driven triggers
-mcp__claude-flow__trigger_setup({
+mcp__moflo__trigger_setup({
   "events": ["code-commit", "PR-merge", "deployment"],
   "actions": ["test", "analyze", "document"]
 })
@@ -804,23 +804,23 @@ mcp__claude-flow__trigger_setup({
 
 ```javascript
 // Topology optimization
-mcp__claude-flow__topology_optimize({
+mcp__moflo__topology_optimize({
   "swarmId": "current-swarm"
 })
 
 // Load balancing
-mcp__claude-flow__load_balance({
+mcp__moflo__load_balance({
   "swarmId": "development-swarm",
   "tasks": taskQueue
 })
 
 // Agent coordination sync
-mcp__claude-flow__coordination_sync({
+mcp__moflo__coordination_sync({
   "swarmId": "development-swarm"
 })
 
 // Auto-scaling
-mcp__claude-flow__swarm_scale({
+mcp__moflo__swarm_scale({
   "swarmId": "development-swarm",
   "targetSize": 12
 })
@@ -830,28 +830,28 @@ mcp__claude-flow__swarm_scale({
 
 ```javascript
 // Real-time swarm monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "active-swarm",
   "interval": 3000
 })
 
 // Collect comprehensive metrics
-mcp__claude-flow__metrics_collect({
+mcp__moflo__metrics_collect({
   "components": ["agents", "tasks", "memory", "performance"]
 })
 
 // Health monitoring
-mcp__claude-flow__health_check({
+mcp__moflo__health_check({
   "components": ["swarm", "agents", "neural", "memory"]
 })
 
 // Usage statistics
-mcp__claude-flow__usage_stats({
+mcp__moflo__usage_stats({
   "component": "swarm-orchestration"
 })
 
 // Trend analysis
-mcp__claude-flow__trend_analysis({
+mcp__moflo__trend_analysis({
   "metric": "agent-performance",
   "period": "7d"
 })
@@ -906,7 +906,7 @@ mcp__claude-flow__trend_analysis({
 ### Example 1: AI Research Project
 ```javascript
 // Research AI trends, analyze findings, generate report
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 6 })
 // Spawn: 2 researchers, 2 analysts, 1 synthesizer, 1 documenter
 // Parallel gather → Analyze patterns → Synthesize → Report
 ```
@@ -914,7 +914,7 @@ mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
 ### Example 2: Full-Stack Application
 ```javascript
 // Build complete web application with testing
-mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 8 })
+mcp__moflo__swarm_init({ topology: "hierarchical", maxAgents: 8 })
 // Spawn: 1 architect, 2 devs, 1 db engineer, 2 testers, 1 reviewer, 1 devops
 // Design → Parallel implement → Test → Review → Deploy
 ```
@@ -922,7 +922,7 @@ mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 8 })
 ### Example 3: Security Audit
 ```javascript
 // Comprehensive security analysis
-mcp__claude-flow__swarm_init({ topology: "star", maxAgents: 5 })
+mcp__moflo__swarm_init({ topology: "star", maxAgents: 5 })
 // Spawn: 1 coordinator, 1 code analyzer, 1 security scanner, 1 penetration tester, 1 reporter
 // Parallel scan → Vulnerability analysis → Penetration test → Report
 ```
@@ -930,7 +930,7 @@ mcp__claude-flow__swarm_init({ topology: "star", maxAgents: 5 })
 ### Example 4: Performance Optimization
 ```javascript
 // Identify and fix performance bottlenecks
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 4 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 4 })
 // Spawn: 1 profiler, 1 bottleneck analyzer, 1 optimizer, 1 tester
 // Profile → Identify bottlenecks → Optimize → Validate
 ```

--- a/src/@claude-flow/cli/README.md
+++ b/src/@claude-flow/cli/README.md
@@ -433,7 +433,7 @@ MoFlo uses a SQLite database (via sql.js/WASM — no native deps) to store three
 
 When `flo init` runs, it appends a workflow section to your CLAUDE.md that teaches Claude:
 - Always search memory before Glob/Grep/Read (enforced by gates)
-- Use `mcp__claude-flow__memory_search` for knowledge retrieval
+- Use `mcp__moflo__memory_search` for knowledge retrieval
 - Use `/flo <issue>` (or `/fl`) for issue execution
 - Store learnings after task completion
 

--- a/src/@claude-flow/cli/__tests__/plugins-transfer-deep.test.ts
+++ b/src/@claude-flow/cli/__tests__/plugins-transfer-deep.test.ts
@@ -898,7 +898,7 @@ describe.skip('Config Adapter', () => {
     const v3 = systemConfigToV3Config({} as any);
     const sys = v3ConfigToSystemConfig(v3);
     expect(sys.swarm?.topology).toBe('hierarchical');
-    expect(sys.mcp?.name).toBe('claude-flow');
+    expect(sys.mcp?.name).toBe('moflo');
   });
 
   it('should denormalize hybrid topology to hierarchical-mesh', () => {

--- a/src/@claude-flow/cli/src/commands/doctor.ts
+++ b/src/@claude-flow/cli/src/commands/doctor.ts
@@ -190,7 +190,7 @@ async function checkMcpServers(): Promise<HealthCheck> {
         const content = JSON.parse(readFileSync(configPath, 'utf8'));
         const servers = content.mcpServers || content.servers || {};
         const count = Object.keys(servers).length;
-        const hasClaudeFlow = 'claude-flow' in servers || 'claude-flow_alpha' in servers || 'ruflo' in servers || 'ruflo_alpha' in servers;
+        const hasClaudeFlow = 'moflo' in servers || 'claude-flow' in servers || 'claude-flow_alpha' in servers || 'ruflo' in servers || 'ruflo_alpha' in servers;
         if (hasClaudeFlow) {
           return { name: 'MCP Servers', status: 'pass', message: `${count} servers (flo configured)` };
         } else {
@@ -202,7 +202,7 @@ async function checkMcpServers(): Promise<HealthCheck> {
     }
   }
 
-  return { name: 'MCP Servers', status: 'warn', message: 'No MCP config found', fix: 'claude mcp add claude-flow npx moflo mcp start' };
+  return { name: 'MCP Servers', status: 'warn', message: 'No MCP config found', fix: 'claude mcp add moflo npx moflo mcp start' };
 }
 
 // Check disk space (async with proper env inheritance)
@@ -551,7 +551,7 @@ async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       return runFixCommand('npx moflo daemon start');
     },
     'MCP Servers': async () => {
-      return runFixCommand('claude mcp add claude-flow -- npx -y moflo mcp start');
+      return runFixCommand('claude mcp add moflo -- npx -y moflo mcp start');
     },
     'Claude Code CLI': async () => {
       return installClaudeCode();

--- a/src/@claude-flow/cli/src/commands/hive-mind.ts
+++ b/src/@claude-flow/cli/src/commands/hive-mind.ts
@@ -97,36 +97,36 @@ ${workerTypes.map(type => `• ${type}: ${workerGroups[type].length} agents`).jo
 🔧 AVAILABLE MCP TOOLS FOR HIVE MIND COORDINATION:
 
 1️⃣ **COLLECTIVE INTELLIGENCE**
-   mcp__claude-flow__hive-mind_consensus    - Democratic decision making
-   mcp__claude-flow__hive-mind_memory       - Share knowledge across the hive
-   mcp__claude-flow__hive-mind_broadcast    - Broadcast to all workers
-   mcp__claude-flow__neural_patterns        - Neural pattern recognition
+   mcp__moflo__hive-mind_consensus    - Democratic decision making
+   mcp__moflo__hive-mind_memory       - Share knowledge across the hive
+   mcp__moflo__hive-mind_broadcast    - Broadcast to all workers
+   mcp__moflo__neural_patterns        - Neural pattern recognition
 
 2️⃣ **QUEEN COORDINATION**
-   mcp__claude-flow__hive-mind_status       - Monitor swarm health
-   mcp__claude-flow__task_create            - Create and delegate tasks
-   mcp__claude-flow__task_orchestrate       - Orchestrate task distribution
-   mcp__claude-flow__agent_spawn            - Spawn additional workers
+   mcp__moflo__hive-mind_status       - Monitor swarm health
+   mcp__moflo__task_create            - Create and delegate tasks
+   mcp__moflo__task_orchestrate       - Orchestrate task distribution
+   mcp__moflo__agent_spawn            - Spawn additional workers
 
 3️⃣ **WORKER MANAGEMENT**
-   mcp__claude-flow__agent_list             - List all active agents
-   mcp__claude-flow__agent_status           - Check agent status
-   mcp__claude-flow__agent_metrics          - Track worker performance
-   mcp__claude-flow__hive-mind_join         - Add agent to hive
-   mcp__claude-flow__hive-mind_leave        - Remove agent from hive
+   mcp__moflo__agent_list             - List all active agents
+   mcp__moflo__agent_status           - Check agent status
+   mcp__moflo__agent_metrics          - Track worker performance
+   mcp__moflo__hive-mind_join         - Add agent to hive
+   mcp__moflo__hive-mind_leave        - Remove agent from hive
 
 4️⃣ **TASK ORCHESTRATION**
-   mcp__claude-flow__task_create            - Create hierarchical tasks
-   mcp__claude-flow__task_status            - Track task progress
-   mcp__claude-flow__task_complete          - Mark tasks complete
-   mcp__claude-flow__workflow_create        - Create workflows
+   mcp__moflo__task_create            - Create hierarchical tasks
+   mcp__moflo__task_status            - Track task progress
+   mcp__moflo__task_complete          - Mark tasks complete
+   mcp__moflo__workflow_create        - Create workflows
 
 5️⃣ **MEMORY & LEARNING**
-   mcp__claude-flow__memory_store           - Store collective knowledge
-   mcp__claude-flow__memory_retrieve        - Access shared memory
-   mcp__claude-flow__memory_search          - Search memory patterns
-   mcp__claude-flow__neural_train           - Learn from experiences
-   mcp__claude-flow__hooks_intelligence_pattern-store - Store patterns
+   mcp__moflo__memory_store           - Store collective knowledge
+   mcp__moflo__memory_retrieve        - Access shared memory
+   mcp__moflo__memory_search          - Search memory patterns
+   mcp__moflo__neural_train           - Learn from experiences
+   mcp__moflo__hooks_intelligence_pattern-store - Store patterns
 
 📋 HIVE MIND EXECUTION PROTOCOL:
 
@@ -158,8 +158,8 @@ ${workerTypes.map(type => `• ${type}: ${workerGroups[type].length} agents`).jo
 ${objective}
 
 💡 COORDINATION TIPS:
-• Use mcp__claude-flow__hive-mind_broadcast for swarm-wide announcements
-• Check worker status regularly with mcp__claude-flow__hive-mind_status
+• Use mcp__moflo__hive-mind_broadcast for swarm-wide announcements
+• Check worker status regularly with mcp__moflo__hive-mind_status
 • Store important decisions in shared memory for persistence
 • Use consensus for any decisions affecting multiple workers
 • Monitor task progress and reassign if workers are blocked

--- a/src/@claude-flow/cli/src/config-adapter.ts
+++ b/src/@claude-flow/cli/src/config-adapter.ts
@@ -132,7 +132,7 @@ export function v3ConfigToSystemConfig(v3Config: V3Config): Partial<SystemConfig
     },
 
     mcp: {
-      name: 'claude-flow',
+      name: 'moflo',
       version: '3.0.0',
       transport: {
         type: v3Config.mcp.transportType as 'stdio' | 'http' | 'websocket',

--- a/src/@claude-flow/cli/src/init/claudemd-generator.ts
+++ b/src/@claude-flow/cli/src/init/claudemd-generator.ts
@@ -387,7 +387,7 @@ function setupAndBoundary(): string {
   return `## Quick Setup
 
 \`\`\`bash
-claude mcp add claude-flow -- npx -y moflo
+claude mcp add moflo -- npx -y moflo
 npx moflo daemon start
 npx moflo doctor --fix
 \`\`\`

--- a/src/@claude-flow/cli/src/init/executor.ts
+++ b/src/@claude-flow/cli/src/init/executor.ts
@@ -845,6 +845,9 @@ async function writeSettings(
 
 /**
  * Write .mcp.json
+ *
+ * If an existing config contains the legacy 'claude-flow' server key, prompt
+ * the user to migrate it to 'moflo', keep both side-by-side, or leave as-is.
  */
 async function writeMCPConfig(
   targetDir: string,
@@ -853,9 +856,63 @@ async function writeMCPConfig(
 ): Promise<void> {
   const mcpPath = path.join(targetDir, '.mcp.json');
 
-  if (fs.existsSync(mcpPath) && !options.force) {
-    result.skipped.push('.mcp.json');
-    return;
+  if (fs.existsSync(mcpPath)) {
+    const existing = JSON.parse(fs.readFileSync(mcpPath, 'utf-8'));
+    const servers = existing?.mcpServers ?? {};
+    const hasLegacy = 'claude-flow' in servers;
+    const hasMoflo = 'moflo' in servers;
+
+    if (hasLegacy && !hasMoflo) {
+      // Interactive mode: prompt the user
+      if (process.stdin.isTTY && !options.force) {
+        const { select } = await import('../prompt.js');
+        const action = await select<'migrate' | 'side-by-side' | 'skip'>({
+          message: "Found existing 'claude-flow' MCP server. How should we handle it?",
+          options: [
+            { value: 'migrate', label: 'Migrate to moflo', hint: 'Rename claude-flow → moflo (recommended)' },
+            { value: 'side-by-side', label: 'Keep both', hint: 'Add moflo alongside existing claude-flow' },
+            { value: 'skip', label: 'Skip', hint: 'Leave .mcp.json unchanged' },
+          ],
+          default: 'migrate',
+        });
+
+        if (action === 'skip') {
+          result.skipped.push('.mcp.json');
+          return;
+        }
+
+        if (action === 'migrate') {
+          servers['moflo'] = servers['claude-flow'];
+          delete servers['claude-flow'];
+          existing.mcpServers = servers;
+          fs.writeFileSync(mcpPath, JSON.stringify(existing, null, 2), 'utf-8');
+          result.created.files.push('.mcp.json (migrated claude-flow → moflo)');
+          return;
+        }
+
+        // side-by-side: fall through to generate new config and merge
+        const newConfig = JSON.parse(generateMCPJson(options));
+        Object.assign(servers, newConfig.mcpServers ?? {});
+        existing.mcpServers = servers;
+        fs.writeFileSync(mcpPath, JSON.stringify(existing, null, 2), 'utf-8');
+        result.created.files.push('.mcp.json (added moflo alongside claude-flow)');
+        return;
+      }
+
+      // Non-interactive (CI/pipe): auto-migrate silently
+      servers['moflo'] = servers['claude-flow'];
+      delete servers['claude-flow'];
+      existing.mcpServers = servers;
+      fs.writeFileSync(mcpPath, JSON.stringify(existing, null, 2), 'utf-8');
+      result.created.files.push('.mcp.json (auto-migrated claude-flow → moflo)');
+      return;
+    }
+
+    // Already has moflo or no legacy key — skip unless forced
+    if (!options.force) {
+      result.skipped.push('.mcp.json');
+      return;
+    }
   }
 
   const content = generateMCPJson(options);
@@ -1860,7 +1917,7 @@ npx moflo hive-mind consensus --propose "task"
 ### MCP Server Setup
 \`\`\`bash
 # Add Claude Flow MCP
-claude mcp add claude-flow -- npx -y moflo
+claude mcp add moflo -- npx -y moflo
 
 # Optional servers
 claude mcp add ruv-swarm -- npx -y ruv-swarm mcp start

--- a/src/@claude-flow/cli/src/init/helpers-generator.ts
+++ b/src/@claude-flow/cli/src/init/helpers-generator.ts
@@ -255,7 +255,7 @@ switch (command) {
     var s = readState();
     // Hard gate: memory must be searched
     if (config.memory_first && s.memoryRequired && !s.memorySearched) {
-      process.stderr.write('BLOCKED: Search memory (mcp__claude-flow__memory_search) before spawning agents.\\n');
+      process.stderr.write('BLOCKED: Search memory (mcp__moflo__memory_search) before spawning agents.\\n');
       process.exit(2);
     }
     // Soft gate: TaskCreate recommended but not blocking
@@ -271,7 +271,7 @@ switch (command) {
     if (s.memorySearched || !s.memoryRequired) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__claude-flow__memory_search.\\n');
+    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search.\\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -280,7 +280,7 @@ switch (command) {
     if (s.memorySearched || !s.memoryRequired) break;
     var fp = process.env.TOOL_INPUT_file_path || '';
     if (fp.indexOf('.claude/guidance/') < 0 && fp.indexOf('.claude\\\\guidance\\\\') < 0) break;
-    process.stderr.write('BLOCKED: Search memory before reading guidance files. Use mcp__claude-flow__memory_search.\\n');
+    process.stderr.write('BLOCKED: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\n');
     process.exit(2);
   }
   case 'record-task-created': {

--- a/src/@claude-flow/cli/src/init/mcp-generator.ts
+++ b/src/@claude-flow/cli/src/init/mcp-generator.ts
@@ -11,25 +11,26 @@ import { existsSync } from 'fs';
 import { resolve, join } from 'path';
 import type { InitOptions, MCPConfig } from './types.js';
 
+const isWindows = process.platform === 'win32';
+
 /**
- * Generate MCP server entry using npx (for external packages)
+ * Generate MCP server entry using npx (for external packages).
+ * On Windows, wraps with `cmd /c` so Claude Code can spawn the process.
  */
 function createNpxServerEntry(
   npxArgs: string[],
   env: Record<string, string>,
   additionalProps: Record<string, unknown> = {}
 ): object {
-  return {
-    command: 'npx',
-    args: ['-y', ...npxArgs],
-    env,
-    ...additionalProps,
-  };
+  return isWindows
+    ? { command: 'cmd', args: ['/c', 'npx', '-y', ...npxArgs], env, ...additionalProps }
+    : { command: 'npx', args: ['-y', ...npxArgs], env, ...additionalProps };
 }
 
 /**
  * Generate MCP server entry using direct node invocation (for local moflo).
  * Avoids npx overhead — faster startup, fewer intermediate processes.
+ * On Windows, wraps with `cmd /c` so Claude Code can spawn the process.
  */
 function createDirectServerEntry(
   cliPath: string,
@@ -37,12 +38,9 @@ function createDirectServerEntry(
   env: Record<string, string>,
   additionalProps: Record<string, unknown> = {}
 ): object {
-  return {
-    command: 'node',
-    args: [cliPath, ...cliArgs],
-    env,
-    ...additionalProps,
-  };
+  return isWindows
+    ? { command: 'cmd', args: ['/c', 'node', cliPath, ...cliArgs], env, ...additionalProps }
+    : { command: 'node', args: [cliPath, ...cliArgs], env, ...additionalProps };
 }
 
 /**
@@ -92,14 +90,14 @@ export function generateMCPConfig(options: InitOptions): object {
     const localCli = findMofloCli(projectRoot);
 
     if (localCli) {
-      mcpServers['claude-flow'] = createDirectServerEntry(
+      mcpServers['moflo'] = createDirectServerEntry(
         localCli,
         ['mcp', 'start'],
         mcpEnv,
         { autoStart: config.autoStart, ...deferProps }
       );
     } else {
-      mcpServers['claude-flow'] = createNpxServerEntry(
+      mcpServers['moflo'] = createNpxServerEntry(
         ['moflo', 'mcp', 'start'],
         mcpEnv,
         { autoStart: config.autoStart, ...deferProps }
@@ -143,20 +141,22 @@ export function generateMCPCommands(options: InitOptions): string[] {
   const commands: string[] = [];
   const config = options.mcp;
 
+  const cmdPrefix = isWindows ? 'cmd /c ' : '';
+
   if (config.claudeFlow) {
     const projectRoot = options.targetDir ?? process.cwd();
     const localCli = findMofloCli(projectRoot);
     if (localCli) {
-      commands.push(`claude mcp add claude-flow -- node ${localCli} mcp start`);
+      commands.push(`claude mcp add moflo -- ${cmdPrefix}node ${localCli} mcp start`);
     } else {
-      commands.push('claude mcp add claude-flow -- npx -y moflo mcp start');
+      commands.push(`claude mcp add moflo -- ${cmdPrefix}npx -y moflo mcp start`);
     }
   }
   if (config.ruvSwarm) {
-    commands.push('claude mcp add ruv-swarm -- npx -y ruv-swarm mcp start');
+    commands.push(`claude mcp add ruv-swarm -- ${cmdPrefix}npx -y ruv-swarm mcp start`);
   }
   if (config.flowNexus) {
-    commands.push('claude mcp add flow-nexus -- npx -y flow-nexus@latest mcp start');
+    commands.push(`claude mcp add flow-nexus -- ${cmdPrefix}npx -y flow-nexus@latest mcp start`);
   }
 
   return commands;
@@ -171,6 +171,8 @@ export function getPlatformInstructions(): { platform: string; note: string } {
     : process.platform === 'darwin' ? 'macOS' : 'Linux';
   return {
     platform,
-    note: 'MCP configuration uses npx directly.',
+    note: isWindows
+      ? 'MCP configuration uses cmd /c wrapper for Windows compatibility.'
+      : 'MCP configuration uses npx directly.',
   };
 }

--- a/src/@claude-flow/cli/src/init/moflo-init.ts
+++ b/src/@claude-flow/cli/src/init/moflo-init.ts
@@ -486,7 +486,7 @@ function generateHooks(root: string, force?: boolean, answers?: MofloInitAnswers
         }]
       },
       {
-        "matcher": "^mcp__claude-flow__memory_(search|retrieve)$",
+        "matcher": "^mcp__moflo__memory_(search|retrieve)$",
         "hooks": [{
           "type": "command",
           "command": "npx flo gate record-memory-searched",
@@ -662,7 +662,7 @@ This project uses [MoFlo](https://github.com/eric-cielo/moflo) for AI-assisted d
 Your first tool call for every new user prompt MUST be a memory search. Do this BEFORE Glob, Grep, Read, or any file exploration.
 
 \`\`\`
-mcp__claude-flow__memory_search  — query: "<task description>", namespace: "guidance" or "patterns" or "knowledge" or "code-map"
+mcp__moflo__memory_search  — query: "<task description>", namespace: "guidance" or "patterns" or "knowledge" or "code-map"
 \`\`\`
 
 For codebase navigation, search the \`code-map\` namespace first. For patterns and domain knowledge, search \`patterns\`, \`knowledge\`, and \`guidance\`.
@@ -684,11 +684,11 @@ Research → Enhance → Implement → Test → Simplify → PR
 
 | Tool | Purpose |
 |------|---------|
-| \`mcp__claude-flow__memory_search\` | Semantic search across indexed knowledge |
-| \`mcp__claude-flow__memory_store\` | Store patterns and decisions |
-| \`mcp__claude-flow__hooks_route\` | Route task to optimal agent type |
-| \`mcp__claude-flow__hooks_pre-task\` | Record task start |
-| \`mcp__claude-flow__hooks_post-task\` | Record task completion for learning |
+| \`mcp__moflo__memory_search\` | Semantic search across indexed knowledge |
+| \`mcp__moflo__memory_store\` | Store patterns and decisions |
+| \`mcp__moflo__hooks_route\` | Route task to optimal agent type |
+| \`mcp__moflo__hooks_pre-task\` | Record task start |
+| \`mcp__moflo__hooks_post-task\` | Record task completion for learning |
 
 ### Agent Icon Mapping
 

--- a/src/@claude-flow/cli/src/init/settings-generator.ts
+++ b/src/@claude-flow/cli/src/init/settings-generator.ts
@@ -28,7 +28,7 @@ export function generateSettings(options: InitOptions): object {
       'Bash(npx moflo*)',
       'Bash(npx flo*)',
       'Bash(node .claude/*)',
-      'mcp__claude-flow__:*',
+      'mcp__moflo__:*',
     ],
     deny: [
       'Read(./.env)',
@@ -280,7 +280,7 @@ function generateHooksConfig(config: HooksConfig): object {
       },
       {
         // Simplified matcher — anchored regex with parens doesn't match MCP tool names reliably
-        matcher: 'mcp__claude-flow__memory_',
+        matcher: 'mcp__moflo__memory_',
         hooks: [{ type: 'command', command: gateCmd('record-memory-searched'), timeout: 3000 }],
       },
     ];

--- a/src/@claude-flow/cli/src/mcp-server.ts
+++ b/src/@claude-flow/cli/src/mcp-server.ts
@@ -349,7 +349,7 @@ export class MCPServerManager extends EventEmitter {
       method: 'server.initialized',
       params: {
         serverInfo: {
-          name: 'claude-flow',
+          name: 'moflo',
           version: VERSION,
           capabilities: {
             tools: { listChanged: true },
@@ -497,7 +497,7 @@ export class MCPServerManager extends EventEmitter {
             id: message.id,
             result: {
               protocolVersion: '2024-11-05',
-              serverInfo: { name: 'claude-flow', version: '3.0.0' },
+              serverInfo: { name: 'moflo', version: '3.0.0' },
               capabilities: {
                 tools: { listChanged: true },
                 resources: { subscribe: true, listChanged: true },
@@ -603,7 +603,7 @@ export class MCPServerManager extends EventEmitter {
 
     const mcpServer = createMCPServer(
       {
-        name: 'Claude-Flow MCP Server V3',
+        name: 'MoFlo MCP Server V3',
         version: '3.0.0',
         transport: this.options.transport as 'http' | 'websocket',
         host: this.options.host,

--- a/src/@claude-flow/cli/src/plugins/manager.ts
+++ b/src/@claude-flow/cli/src/plugins/manager.ts
@@ -175,10 +175,11 @@ export class PluginManager {
         const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
         installedVersion = pkg.version;
 
-        // Check for claude-flow plugin metadata
-        if (pkg['claude-flow']) {
-          commands = pkg['claude-flow'].commands || [];
-          hooks = pkg['claude-flow'].hooks || [];
+        // Check for moflo/claude-flow plugin metadata (backward compat)
+        const pluginMeta = pkg['moflo'] || pkg['claude-flow'];
+        if (pluginMeta) {
+          commands = pluginMeta.commands || [];
+          hooks = pluginMeta.hooks || [];
         }
       }
 
@@ -250,8 +251,8 @@ export class PluginManager {
         enabled: true,
         source: 'local',
         path: absolutePath,
-        commands: pkg['claude-flow']?.commands || [],
-        hooks: pkg['claude-flow']?.hooks || [],
+        commands: (pkg['moflo'] || pkg['claude-flow'])?.commands || [],
+        hooks: (pkg['moflo'] || pkg['claude-flow'])?.hooks || [],
       };
 
       // Save to manifest
@@ -460,8 +461,8 @@ export class PluginManager {
       if (fs.existsSync(packageJsonPath)) {
         const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
         existing.version = pkg.version;
-        existing.commands = pkg['claude-flow']?.commands || existing.commands;
-        existing.hooks = pkg['claude-flow']?.hooks || existing.hooks;
+        existing.commands = (pkg['moflo'] || pkg['claude-flow'])?.commands || existing.commands;
+        existing.hooks = (pkg['moflo'] || pkg['claude-flow'])?.hooks || existing.hooks;
       }
 
       await this.saveManifest();

--- a/src/@claude-flow/cli/src/services/workflow-gate.ts
+++ b/src/@claude-flow/cli/src/services/workflow-gate.ts
@@ -178,7 +178,7 @@ export class WorkflowGateService {
     if (this.config.memory_first && !state.memorySearched) {
       return {
         allowed: false,
-        message: 'BLOCKED: Search memory (mcp__claude-flow__memory_search) before spawning agents.',
+        message: 'BLOCKED: Search memory (mcp__moflo__memory_search) before spawning agents.',
       };
     }
 
@@ -220,7 +220,7 @@ export class WorkflowGateService {
     if (now - lastBlocked > 2000) {
       state.lastBlockedAt = new Date(now).toISOString();
       this.writeState(state);
-      message = 'BLOCKED: Search memory before exploring files. Use mcp__claude-flow__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".';
+      message = 'BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".';
     }
 
     return { allowed: false, message };
@@ -259,7 +259,7 @@ export class WorkflowGateService {
     if (now - lastBlocked > 2000) {
       state.lastBlockedAt = new Date(now).toISOString();
       this.writeState(state);
-      message = 'BLOCKED: Search memory before reading guidance files. Use mcp__claude-flow__memory_search with namespace "guidance".';
+      message = 'BLOCKED: Search memory before reading guidance files. Use mcp__moflo__memory_search with namespace "guidance".';
     }
 
     return { allowed: false, message };

--- a/src/@claude-flow/mcp/.claude/agents/github/code-review-swarm.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/code-review-swarm.md
@@ -14,9 +14,9 @@ capabilities:
   - architecture_pattern_validation
   - style_and_convention_enforcement
 tools:
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats

--- a/src/@claude-flow/mcp/.claude/agents/github/github-modes.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/github-modes.md
@@ -1,7 +1,7 @@
 ---
 name: github-modes
 description: Comprehensive GitHub integration modes for workflow orchestration, PR management, and repository coordination with batch optimization
-tools: mcp__claude-flow__swarm_init, mcp__claude-flow__agent_spawn, mcp__claude-flow__task_orchestrate, Bash, TodoWrite, Read, Write
+tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__task_orchestrate, Bash, TodoWrite, Read, Write
 color: purple
 type: development
 capabilities:
@@ -163,11 +163,11 @@ All GitHub modes can be enhanced with ruv-swarm coordination:
 
 ```javascript
 // Initialize swarm for GitHub workflow
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
-mcp__claude-flow__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
+mcp__moflo__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
 ```

--- a/src/@claude-flow/mcp/.claude/agents/github/issue-tracker.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/issue-tracker.md
@@ -15,10 +15,10 @@ capabilities:
   - cross_repository_issue_synchronization
   - intelligent_labeling_and_organization
 tools:
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats
@@ -301,7 +301,7 @@ if (duplicates.length > 0) {
 - `mcp__github__update_issue`
 - `mcp__github__add_issue_comment`
 - `mcp__github__search_issues`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -309,10 +309,10 @@ if (duplicates.length > 0) {
 ### 1. Create Coordinated Issue with Swarm Tracking
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -337,7 +337,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"
@@ -347,7 +347,7 @@ mcp__claude-flow__task_orchestrate {
 ### 2. Automated Progress Updates
 ```javascript
 // Update issue with progress from swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "issue/54/progress"
 }
@@ -376,7 +376,7 @@ mcp__github__add_issue_comment {
 }
 
 // Store progress in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/54/latest_update",
   value: { timestamp: Date.now(), progress: "89%", status: "near_completion" }
@@ -409,10 +409,10 @@ mcp__github__update_issue {
 ```javascript
 [Single Message - Issue Lifecycle Management]:
   // Initialize issue coordination swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Manager" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Progress Tracker" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Context Gatherer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Manager" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Progress Tracker" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Context Gatherer" }
   
   // Create multiple related issues using gh CLI
   Bash(`gh issue create \
@@ -442,7 +442,7 @@ mcp__github__update_issue {
   ]}
   
   // Store initial coordination state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "project/github_integration/issues",
     value: { created: Date.now(), total_issues: 3, status: "initialized" }

--- a/src/@claude-flow/mcp/.claude/agents/github/multi-repo-swarm.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/multi-repo-swarm.md
@@ -12,15 +12,15 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_repo_analyze
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_sync_coord
-  - mcp__claude-flow__github_metrics
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_repo_analyze
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_sync_coord
+  - mcp__moflo__github_metrics
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/src/@claude-flow/mcp/.claude/agents/github/pr-manager.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/pr-manager.md
@@ -17,14 +17,14 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_code_review
-  - mcp__claude-flow__github_metrics
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_code_review
+  - mcp__moflo__github_metrics
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats
@@ -297,10 +297,10 @@ const assignments = await agentDB.gnnEnhancedSearch(
 ### 1. Create and Manage PR with Swarm Coordination
 ```javascript
 // Initialize review swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Testing Agent" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Testing Agent" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
 
 // Create PR and orchestrate review
 mcp__github__create_pull_request {
@@ -313,7 +313,7 @@ mcp__github__create_pull_request {
 }
 
 // Orchestrate review process
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review with testing and validation",
   strategy: "parallel",
   priority: "high"
@@ -355,7 +355,7 @@ mcp__github__merge_pull_request {
 }
 
 // Post-merge coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/54/merged",
   value: { timestamp: Date.now(), status: "success" }
@@ -368,10 +368,10 @@ mcp__claude-flow__memory_usage {
 ```javascript
 [Single Message - Complete PR Management]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
   
   // Create and manage PR using gh CLI
   Bash("gh pr create --repo :owner/:repo --title '...' --head '...' --base 'main'")

--- a/src/@claude-flow/mcp/.claude/agents/github/project-board-sync.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/project-board-sync.md
@@ -12,17 +12,17 @@ tools:
   - Grep
   - LS
   - TodoWrite
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__swarm_status
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__github_repo_analyze
-  - mcp__claude-flow__github_pr_manage
-  - mcp__claude-flow__github_issue_track
-  - mcp__claude-flow__github_metrics
-  - mcp__claude-flow__workflow_create
-  - mcp__claude-flow__workflow_execute
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__swarm_status
+  - mcp__moflo__memory_usage
+  - mcp__moflo__github_repo_analyze
+  - mcp__moflo__github_pr_manage
+  - mcp__moflo__github_issue_track
+  - mcp__moflo__github_metrics
+  - mcp__moflo__workflow_create
+  - mcp__moflo__workflow_execute
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/src/@claude-flow/mcp/.claude/agents/github/release-manager.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/release-manager.md
@@ -22,10 +22,10 @@ tools:
   - mcp__github__create_branch
   - mcp__github__push_files
   - mcp__github__create_issue
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats
@@ -291,12 +291,12 @@ console.log(`Found ${impactedAreas.length} impacted areas with +12.4% better cov
 ### 1. Coordinated Release Preparation
 ```javascript
 // Initialize release management swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Coordinator" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Release Coordinator" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
 
 // Create release preparation branch
 mcp__github__create_branch {
@@ -307,7 +307,7 @@ mcp__github__create_branch {
 }
 
 // Orchestrate release preparation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Prepare release v1.0.72 with comprehensive testing and validation",
   strategy: "sequential",
   priority: "critical"
@@ -444,13 +444,13 @@ This release is production-ready with comprehensive validation and testing.
 ```javascript
 [Single Message - Complete Release Management]:
   // Initialize comprehensive release swarm
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 8 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Lead" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Controller" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Performance Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 8 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Lead" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Controller" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Performance Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
   
   // Create release branch and prepare files using gh CLI
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v1.0.72' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
@@ -489,7 +489,7 @@ This release is production-ready with comprehensive validation and testing.
   ]}
   
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store", 
     key: "release/v1.0.72/status",
     value: {

--- a/src/@claude-flow/mcp/.claude/agents/github/release-swarm.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/release-swarm.md
@@ -17,11 +17,11 @@ tools:
   - mcp__github__create_branch
   - mcp__github__push_files
   - mcp__github__create_issue
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__parallel_execute
-  - mcp__claude-flow__load_balance
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__parallel_execute
+  - mcp__moflo__load_balance
 hooks:
   pre_task: |
     echo "🐝 Initializing release swarm coordination..."

--- a/src/@claude-flow/mcp/.claude/agents/github/repo-architect.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/repo-architect.md
@@ -19,10 +19,10 @@ tools:
   - mcp__github__search_repositories
   - mcp__github__push_files
   - mcp__github__create_or_update_file
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
 hooks:
   pre_task: |
     echo "🏗️ Initializing repository architecture analysis..."
@@ -55,11 +55,11 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 ### 1. Repository Structure Analysis and Optimization
 ```javascript
 // Initialize architecture analysis swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Repository Architect" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyzer" }
+mcp__moflo__agent_spawn { type: "architect", name: "Repository Architect" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
 
 // Analyze current repository structure
 LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -73,7 +73,7 @@ mcp__github__search_repositories {
 }
 
 // Orchestrate structure optimization
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze and optimize repository structure for scalability and maintainability",
   strategy: "adaptive",
   priority: "medium"
@@ -200,12 +200,12 @@ jobs:
 ```javascript
 [Single Message - Repository Architecture Review]:
   // Initialize comprehensive architecture swarm
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "architect", name: "Senior Architect" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyst" }
-  mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "architect", name: "Senior Architect" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyst" }
+  mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
   
   // Analyze current repository structures
   LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -254,7 +254,7 @@ jobs:
   ]}
   
   // Store architecture analysis
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "architecture/analysis/results",
     value: {

--- a/src/@claude-flow/mcp/.claude/agents/github/swarm-issue.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/swarm-issue.md
@@ -9,10 +9,10 @@ tools:
   - mcp__github__update_issue
   - mcp__github__list_issues
   - mcp__github__create_issue_comment
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
   - TodoWrite
   - TodoRead
   - Bash
@@ -516,21 +516,21 @@ npx claude-flow@v3alpha github issue-init 567 \
 ### Multi-Agent Issue Processing
 ```bash
 # Initialize issue-specific swarm with optimal topology
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 8 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Issue Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Solution Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 8 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Issue Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Solution Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 # Store issue context in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/#{issue_number}/context",
   value: { title: "issue_title", labels: ["labels"], complexity: "high" }
 }
 
 # Orchestrate issue resolution workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Coordinate multi-agent issue resolution with progress tracking",
   strategy: "adaptive",
   priority: "high"

--- a/src/@claude-flow/mcp/.claude/agents/github/swarm-pr.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/swarm-pr.md
@@ -11,11 +11,11 @@ tools:
   - mcp__github__create_pr_comment
   - mcp__github__get_pr_diff
   - mcp__github__merge_pull_request
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__coordination_sync
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__coordination_sync
   - TodoWrite
   - TodoRead
   - Bash
@@ -323,15 +323,15 @@ When using with Claude Code:
 ### Multi-Agent PR Analysis
 ```bash
 # Initialize PR-specific swarm with intelligent topology selection
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 8 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Test Engineer" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Impact Analyzer" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 8 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Test Engineer" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Impact Analyzer" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
 
 # Store PR context for swarm coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/#{pr_number}/analysis",
   value: { 
@@ -343,7 +343,7 @@ mcp__claude-flow__memory_usage {
 }
 
 # Orchestrate comprehensive PR workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Execute multi-agent PR review and validation workflow",
   strategy: "parallel",
   priority: "high",
@@ -403,17 +403,17 @@ const prPostHook = async (results) => {
 ### Intelligent PR Merge Coordination
 ```bash
 # Coordinate merge decision with swarm consensus
-mcp__claude-flow__coordination_sync { swarmId: "pr-review-swarm" }
+mcp__moflo__coordination_sync { swarmId: "pr-review-swarm" }
 
 # Analyze merge readiness with multiple agents
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Evaluate PR merge readiness with comprehensive validation",
   strategy: "sequential",
   priority: "critical"
 }
 
 # Store merge decision context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/merge_decisions/#{pr_number}",
   value: {

--- a/src/@claude-flow/mcp/.claude/agents/github/sync-coordinator.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/sync-coordinator.md
@@ -10,12 +10,12 @@ tools:
   - mcp__github__create_pull_request
   - mcp__github__search_repositories
   - mcp__github__list_repositories
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__coordination_sync
-  - mcp__claude-flow__load_balance
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__coordination_sync
+  - mcp__moflo__load_balance
   - TodoWrite
   - TodoRead
   - Bash
@@ -52,7 +52,7 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 - `mcp__github__get_file_contents`
 - `mcp__github__create_pull_request`
 - `mcp__github__search_repositories`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`, `MultiEdit`
 
 ## Usage Patterns
@@ -60,11 +60,11 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 ### 1. Synchronize Package Dependencies
 ```javascript
 // Initialize sync coordination swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 // Analyze current package states
 Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -83,7 +83,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/packa
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/package.json?ref=sync/package-alignment --jq '.sha')")`)
 
 // Orchestrate validation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Validate package synchronization and run integration tests",
   strategy: "parallel",
   priority: "high"
@@ -109,7 +109,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUD
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUDE.md?ref=sync/documentation --jq '.sha' 2>/dev/null || echo '')")`)
 
 // Store sync state in memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/documentation/status",
   value: { timestamp: Date.now(), status: "synchronized", files: ["CLAUDE.md"] }
@@ -183,12 +183,12 @@ This integration uses ruv-swarm agents for:
 ```javascript
 [Single Message - Complete Synchronization]:
   // Initialize comprehensive sync swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Package Analyzer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Coder" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Tester" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Package Analyzer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Integration Coder" }
+  mcp__moflo__agent_spawn { type: "tester", name: "Validation Tester" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
   
   // Read current state of both packages
   Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -222,7 +222,7 @@ This integration uses ruv-swarm agents for:
   ]}
   
   // Store comprehensive sync state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "sync/complete/status",
     value: {
@@ -327,16 +327,16 @@ const testMatrix = {
 ### Multi-Agent Coordination Architecture
 ```bash
 # Initialize comprehensive synchronization swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 10 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Assurance" }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Sync Monitor" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 10 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Assurance" }
+mcp__moflo__agent_spawn { type: "monitor", name: "Sync Monitor" }
 
 # Orchestrate complex synchronization workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Execute comprehensive multi-repository synchronization with validation",
   strategy: "adaptive",
   priority: "critical",
@@ -344,7 +344,7 @@ mcp__claude-flow__task_orchestrate {
 }
 
 # Load balance synchronization tasks across agents
-mcp__claude-flow__load_balance {
+mcp__moflo__load_balance {
   swarmId: "sync-coordination-swarm",
   tasks: [
     "package_json_sync",
@@ -390,7 +390,7 @@ const syncConflictResolver = async (conflicts) => {
 ### Comprehensive Synchronization Metrics
 ```bash
 # Store detailed synchronization metrics
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/metrics/session",
   value: {
@@ -415,16 +415,16 @@ mcp__claude-flow__memory_usage {
 ### Swarm-Coordinated Error Recovery
 ```bash
 # Initialize error recovery swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Error Monitor" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Failure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Recovery Developer" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "monitor", name: "Error Monitor" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Failure Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Recovery Developer" }
 
 # Coordinate recovery procedures
-mcp__claude-flow__coordination_sync { swarmId: "error-recovery-swarm" }
+mcp__moflo__coordination_sync { swarmId: "error-recovery-swarm" }
 
 # Store recovery state
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/recovery/state",
   value: {

--- a/src/@claude-flow/mcp/.claude/agents/github/workflow-automation.md
+++ b/src/@claude-flow/mcp/.claude/agents/github/workflow-automation.md
@@ -14,14 +14,14 @@ tools:
   - mcp__github__list_workflows
   - mcp__github__get_workflow_runs
   - mcp__github__create_workflow_dispatch
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
-  - mcp__claude-flow__performance_report
-  - mcp__claude-flow__bottleneck_analyze
-  - mcp__claude-flow__workflow_create
-  - mcp__claude-flow__automation_setup
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
+  - mcp__moflo__performance_report
+  - mcp__moflo__bottleneck_analyze
+  - mcp__moflo__workflow_create
+  - mcp__moflo__automation_setup
   - mcp__agentic-flow__agentdb_pattern_store
   - mcp__agentic-flow__agentdb_pattern_search
   - mcp__agentic-flow__agentdb_pattern_stats
@@ -749,17 +749,17 @@ npx claude-flow@v3alpha actions profile \
 ### Multi-Agent Pipeline Orchestration
 ```bash
 # Initialize comprehensive workflow automation swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 12 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Workflow Coordinator" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Pipeline Architect" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Workflow Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "CI/CD Tester" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-mcp__claude-flow__agent_spawn { type: "monitor", name: "Automation Monitor" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 12 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Workflow Coordinator" }
+mcp__moflo__agent_spawn { type: "architect", name: "Pipeline Architect" }
+mcp__moflo__agent_spawn { type: "coder", name: "Workflow Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "CI/CD Tester" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+mcp__moflo__agent_spawn { type: "monitor", name: "Automation Monitor" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
 
 # Create intelligent workflow automation rules
-mcp__claude-flow__automation_setup {
+mcp__moflo__automation_setup {
   rules: [
     {
       trigger: "pull_request",
@@ -775,7 +775,7 @@ mcp__claude-flow__automation_setup {
 }
 
 # Orchestrate adaptive workflow management
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Manage intelligent CI/CD pipeline with continuous optimization",
   strategy: "adaptive",
   priority: "high",
@@ -786,19 +786,19 @@ mcp__claude-flow__task_orchestrate {
 ### Intelligent Performance Monitoring
 ```bash
 # Generate comprehensive workflow performance reports
-mcp__claude-flow__performance_report {
+mcp__moflo__performance_report {
   format: "detailed",
   timeframe: "30d"
 }
 
 # Analyze workflow bottlenecks with swarm intelligence
-mcp__claude-flow__bottleneck_analyze {
+mcp__moflo__bottleneck_analyze {
   component: "github_actions_workflow",
   metrics: ["build_time", "test_duration", "deployment_latency", "resource_utilization"]
 }
 
 # Store performance insights in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "workflow/performance/analysis",
   value: {
@@ -870,7 +870,7 @@ const createIntelligentWorkflow = async (repoContext) => {
 ### Continuous Learning and Optimization
 ```bash
 # Implement continuous workflow learning
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "workflow/learning/patterns",
   value: {
@@ -893,7 +893,7 @@ mcp__claude-flow__memory_usage {
 }
 
 # Generate workflow optimization recommendations
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze workflow performance and generate optimization recommendations",
   strategy: "parallel",
   priority: "medium"

--- a/src/@claude-flow/mcp/.claude/agents/goal/goal-planner.md
+++ b/src/@claude-flow/mcp/.claude/agents/goal/goal-planner.md
@@ -51,20 +51,20 @@ Your planning methodology follows the GOAP algorithm:
 
 ```javascript
 // Orchestrate complex goal achievement
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "achieve_production_deployment",
   strategy: "adaptive",
   priority: "high"
 }
 
 // Coordinate with swarm for parallel planning
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 5
 }
 
 // Store successful plans for reuse
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   namespace: "goap-plans",
   key: "deployment_plan_v1",

--- a/src/@claude-flow/mcp/.claude/agents/swarm/adaptive-coordinator.md
+++ b/src/@claude-flow/mcp/.claude/agents/swarm/adaptive-coordinator.md
@@ -15,25 +15,25 @@ hooks:
   pre: |
     echo "🔄 Adaptive Coordinator analyzing workload patterns: $TASK"
     # Initialize with auto-detection
-    mcp__claude-flow__swarm_init auto --maxAgents=15 --strategy=adaptive
+    mcp__moflo__swarm_init auto --maxAgents=15 --strategy=adaptive
     # Analyze current workload patterns
-    mcp__claude-flow__neural_patterns analyze --operation="workload_analysis" --metadata="{\"task\":\"$TASK\"}"
+    mcp__moflo__neural_patterns analyze --operation="workload_analysis" --metadata="{\"task\":\"$TASK\"}"
     # Train adaptive models
-    mcp__claude-flow__neural_train coordination --training_data="historical_swarm_data" --epochs=30
+    mcp__moflo__neural_train coordination --training_data="historical_swarm_data" --epochs=30
     # Store baseline metrics
-    mcp__claude-flow__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__claude-flow__performance_report --format=json)" --namespace=adaptive
+    mcp__moflo__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__moflo__performance_report --format=json)" --namespace=adaptive
     # Set up real-time monitoring
-    mcp__claude-flow__swarm_monitor --interval=2000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_monitor --interval=2000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Adaptive coordination complete - topology optimized"
     # Generate comprehensive analysis
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__moflo__performance_report --format=detailed --timeframe=24h
     # Store learning outcomes
-    mcp__claude-flow__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__claude-flow__swarm_status | jq -r '.topology')\"}"
+    mcp__moflo__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__moflo__swarm_status | jq -r '.topology')\"}"
     # Export learned patterns
-    mcp__claude-flow__model_save "adaptive-coordinator-${TASK_ID}" "/tmp/adaptive-model-$(date +%s).json"
+    mcp__moflo__model_save "adaptive-coordinator-${TASK_ID}" "/tmp/adaptive-model-$(date +%s).json"
     # Update persistent knowledge base
-    mcp__claude-flow__memory_usage store "adaptive:learned:${TASK_ID}" "$(date): Adaptive patterns learned and saved" --namespace=adaptive
+    mcp__moflo__memory_usage store "adaptive:learned:${TASK_ID}" "$(date): Adaptive patterns learned and saved" --namespace=adaptive
 ---
 
 # Adaptive Swarm Coordinator
@@ -864,43 +864,43 @@ class LearningAdaptiveCoordinator extends AdaptiveCoordinator {
 ### Pattern Recognition & Learning
 ```bash
 # Analyze coordination patterns
-mcp__claude-flow__neural_patterns analyze --operation="topology_analysis" --metadata="{\"current_topology\":\"mesh\",\"performance_metrics\":{}}"
+mcp__moflo__neural_patterns analyze --operation="topology_analysis" --metadata="{\"current_topology\":\"mesh\",\"performance_metrics\":{}}"
 
 # Train adaptive models
-mcp__claude-flow__neural_train coordination --training_data="swarm_performance_history" --epochs=50
+mcp__moflo__neural_train coordination --training_data="swarm_performance_history" --epochs=50
 
 # Make predictions
-mcp__claude-flow__neural_predict --modelId="adaptive-coordinator" --input="{\"workload\":\"high_complexity\",\"agents\":10}"
+mcp__moflo__neural_predict --modelId="adaptive-coordinator" --input="{\"workload\":\"high_complexity\",\"agents\":10}"
 
 # Learn from outcomes
-mcp__claude-flow__neural_patterns learn --operation="topology_switch" --outcome="improved_performance_15%" --metadata="{\"from\":\"hierarchical\",\"to\":\"mesh\"}"
+mcp__moflo__neural_patterns learn --operation="topology_switch" --outcome="improved_performance_15%" --metadata="{\"from\":\"hierarchical\",\"to\":\"mesh\"}"
 ```
 
 ### Performance Optimization
 ```bash
 # Real-time performance monitoring
-mcp__claude-flow__performance_report --format=json --timeframe=1h
+mcp__moflo__performance_report --format=json --timeframe=1h
 
 # Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze --component="coordination" --metrics="latency,throughput,success_rate"
+mcp__moflo__bottleneck_analyze --component="coordination" --metrics="latency,throughput,success_rate"
 
 # Automatic optimization
-mcp__claude-flow__topology_optimize --swarmId="${SWARM_ID}"
+mcp__moflo__topology_optimize --swarmId="${SWARM_ID}"
 
 # Load balancing optimization
-mcp__claude-flow__load_balance --swarmId="${SWARM_ID}" --strategy="ml_optimized"
+mcp__moflo__load_balance --swarmId="${SWARM_ID}" --strategy="ml_optimized"
 ```
 
 ### Predictive Scaling
 ```bash
 # Analyze usage trends
-mcp__claude-flow__trend_analysis --metric="agent_utilization" --period="7d"
+mcp__moflo__trend_analysis --metric="agent_utilization" --period="7d"
 
 # Predict resource needs
-mcp__claude-flow__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
+mcp__moflo__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
 
 # Auto-scale swarm
-mcp__claude-flow__swarm_scale --swarmId="${SWARM_ID}" --targetSize="12" --strategy="predictive"
+mcp__moflo__swarm_scale --swarmId="${SWARM_ID}" --targetSize="12" --strategy="predictive"
 ```
 
 ## Dynamic Adaptation Algorithms

--- a/src/@claude-flow/mcp/.claude/agents/swarm/hierarchical-coordinator.md
+++ b/src/@claude-flow/mcp/.claude/agents/swarm/hierarchical-coordinator.md
@@ -15,19 +15,19 @@ hooks:
   pre: |
     echo "👑 Hierarchical Coordinator initializing swarm: $TASK"
     # Initialize swarm topology
-    mcp__claude-flow__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
+    mcp__moflo__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
     # Store coordination state
-    mcp__claude-flow__memory_usage store "swarm:hierarchy:${TASK_ID}" "$(date): Hierarchical coordination started" --namespace=swarm
+    mcp__moflo__memory_usage store "swarm:hierarchy:${TASK_ID}" "$(date): Hierarchical coordination started" --namespace=swarm
     # Set up monitoring
-    mcp__claude-flow__swarm_monitor --interval=5000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_monitor --interval=5000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Hierarchical coordination complete"
     # Generate performance report
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__moflo__performance_report --format=detailed --timeframe=24h
     # Store completion metrics
-    mcp__claude-flow__memory_usage store "swarm:hierarchy:${TASK_ID}:complete" "$(date): Task completed with $(mcp__claude-flow__swarm_status | jq '.agents.total') agents"
+    mcp__moflo__memory_usage store "swarm:hierarchy:${TASK_ID}:complete" "$(date): Task completed with $(mcp__moflo__swarm_status | jq '.agents.total') agents"
     # Cleanup resources
-    mcp__claude-flow__coordination_sync --swarmId="${SWARM_ID}"
+    mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 ---
 
 # Hierarchical Swarm Coordinator
@@ -69,22 +69,22 @@ WORKERS WORKERS WORKERS WORKERS
 ### Research Workers 🔬
 - **Capabilities**: Information gathering, market research, competitive analysis
 - **Use Cases**: Requirements analysis, technology research, feasibility studies
-- **Spawn Command**: `mcp__claude-flow__agent_spawn researcher --capabilities="research,analysis,information_gathering"`
+- **Spawn Command**: `mcp__moflo__agent_spawn researcher --capabilities="research,analysis,information_gathering"`
 
 ### Code Workers 💻  
 - **Capabilities**: Implementation, code review, testing, documentation
 - **Use Cases**: Feature development, bug fixes, code optimization
-- **Spawn Command**: `mcp__claude-flow__agent_spawn coder --capabilities="code_generation,testing,optimization"`
+- **Spawn Command**: `mcp__moflo__agent_spawn coder --capabilities="code_generation,testing,optimization"`
 
 ### Analyst Workers 📊
 - **Capabilities**: Data analysis, performance monitoring, reporting
 - **Use Cases**: Metrics analysis, performance optimization, reporting
-- **Spawn Command**: `mcp__claude-flow__agent_spawn analyst --capabilities="data_analysis,performance_monitoring,reporting"`
+- **Spawn Command**: `mcp__moflo__agent_spawn analyst --capabilities="data_analysis,performance_monitoring,reporting"`
 
 ### Test Workers 🧪
 - **Capabilities**: Quality assurance, validation, compliance checking
 - **Use Cases**: Testing, validation, quality gates
-- **Spawn Command**: `mcp__claude-flow__agent_spawn tester --capabilities="testing,validation,quality_assurance"`
+- **Spawn Command**: `mcp__moflo__agent_spawn tester --capabilities="testing,validation,quality_assurance"`
 
 ## Coordination Workflow
 
@@ -601,39 +601,39 @@ class LearningHierarchicalCoordinator extends HierarchicalCoordinator {
 ### Swarm Management
 ```bash
 # Initialize hierarchical swarm
-mcp__claude-flow__swarm_init hierarchical --maxAgents=10 --strategy=centralized
+mcp__moflo__swarm_init hierarchical --maxAgents=10 --strategy=centralized
 
 # Spawn specialized workers
-mcp__claude-flow__agent_spawn researcher --capabilities="research,analysis"
-mcp__claude-flow__agent_spawn coder --capabilities="implementation,testing"
-mcp__claude-flow__agent_spawn analyst --capabilities="data_analysis,reporting"
+mcp__moflo__agent_spawn researcher --capabilities="research,analysis"
+mcp__moflo__agent_spawn coder --capabilities="implementation,testing"
+mcp__moflo__agent_spawn analyst --capabilities="data_analysis,reporting"
 
 # Monitor swarm health
-mcp__claude-flow__swarm_monitor --interval=5000
+mcp__moflo__swarm_monitor --interval=5000
 ```
 
 ### Task Orchestration
 ```bash
 # Coordinate complex workflows
-mcp__claude-flow__task_orchestrate "Build authentication service" --strategy=sequential --priority=high
+mcp__moflo__task_orchestrate "Build authentication service" --strategy=sequential --priority=high
 
 # Load balance across workers
-mcp__claude-flow__load_balance --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
+mcp__moflo__load_balance --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
 
 # Sync coordination state
-mcp__claude-flow__coordination_sync --namespace=hierarchy
+mcp__moflo__coordination_sync --namespace=hierarchy
 ```
 
 ### Performance & Analytics
 ```bash
 # Generate performance reports
-mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+mcp__moflo__performance_report --format=detailed --timeframe=24h
 
 # Analyze bottlenecks
-mcp__claude-flow__bottleneck_analyze --component=coordination --metrics="throughput,latency,success_rate"
+mcp__moflo__bottleneck_analyze --component=coordination --metrics="throughput,latency,success_rate"
 
 # Monitor resource usage
-mcp__claude-flow__metrics_collect --components="agents,tasks,coordination"
+mcp__moflo__metrics_collect --components="agents,tasks,coordination"
 ```
 
 ## Decision Making Framework

--- a/src/@claude-flow/mcp/.claude/agents/swarm/mesh-coordinator.md
+++ b/src/@claude-flow/mcp/.claude/agents/swarm/mesh-coordinator.md
@@ -15,21 +15,21 @@ hooks:
   pre: |
     echo "🌐 Mesh Coordinator establishing peer network: $TASK"
     # Initialize mesh topology
-    mcp__claude-flow__swarm_init mesh --maxAgents=12 --strategy=distributed
+    mcp__moflo__swarm_init mesh --maxAgents=12 --strategy=distributed
     # Set up peer discovery and communication
-    mcp__claude-flow__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_init\",\"topology\":\"mesh\"}"
+    mcp__moflo__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_init\",\"topology\":\"mesh\"}"
     # Initialize consensus mechanisms
-    mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"coordination_protocol\":\"gossip\",\"consensus_threshold\":0.67}"
+    mcp__moflo__daa_consensus --agents="all" --proposal="{\"coordination_protocol\":\"gossip\",\"consensus_threshold\":0.67}"
     # Store network state
-    mcp__claude-flow__memory_usage store "mesh:network:${TASK_ID}" "$(date): Mesh network initialized" --namespace=mesh
+    mcp__moflo__memory_usage store "mesh:network:${TASK_ID}" "$(date): Mesh network initialized" --namespace=mesh
   post: |
     echo "✨ Mesh coordination complete - network resilient"
     # Generate network analysis
-    mcp__claude-flow__performance_report --format=json --timeframe=24h
+    mcp__moflo__performance_report --format=json --timeframe=24h
     # Store final network metrics
-    mcp__claude-flow__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__claude-flow__swarm_status)" --namespace=mesh
+    mcp__moflo__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__moflo__swarm_status)" --namespace=mesh
     # Graceful network shutdown
-    mcp__claude-flow__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_shutdown\",\"reason\":\"task_complete\"}"
+    mcp__moflo__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_shutdown\",\"reason\":\"task_complete\"}"
 ---
 
 # Mesh Network Swarm Coordinator
@@ -761,37 +761,37 @@ class LearningMeshCoordinator extends MeshCoordinator {
 ### Network Management
 ```bash
 # Initialize mesh network
-mcp__claude-flow__swarm_init mesh --maxAgents=12 --strategy=distributed
+mcp__moflo__swarm_init mesh --maxAgents=12 --strategy=distributed
 
 # Establish peer connections
-mcp__claude-flow__daa_communication --from="node-1" --to="node-2" --message="{\"type\":\"peer_connect\"}"
+mcp__moflo__daa_communication --from="node-1" --to="node-2" --message="{\"type\":\"peer_connect\"}"
 
 # Monitor network health
-mcp__claude-flow__swarm_monitor --interval=3000 --metrics="connectivity,latency,throughput"
+mcp__moflo__swarm_monitor --interval=3000 --metrics="connectivity,latency,throughput"
 ```
 
 ### Consensus Operations
 ```bash
 # Propose network-wide decision
-mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"task_assignment\":\"auth-service\",\"assigned_to\":\"node-3\"}"
+mcp__moflo__daa_consensus --agents="all" --proposal="{\"task_assignment\":\"auth-service\",\"assigned_to\":\"node-3\"}"
 
 # Participate in voting
-mcp__claude-flow__daa_consensus --agents="current" --vote="approve" --proposal_id="prop-123"
+mcp__moflo__daa_consensus --agents="current" --vote="approve" --proposal_id="prop-123"
 
 # Monitor consensus status
-mcp__claude-flow__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
+mcp__moflo__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
 ```
 
 ### Fault Tolerance
 ```bash
 # Detect failed nodes
-mcp__claude-flow__daa_fault_tolerance --agentId="node-4" --strategy="heartbeat_monitor"
+mcp__moflo__daa_fault_tolerance --agentId="node-4" --strategy="heartbeat_monitor"
 
 # Trigger recovery procedures  
-mcp__claude-flow__daa_fault_tolerance --agentId="failed-node" --strategy="failover_recovery"
+mcp__moflo__daa_fault_tolerance --agentId="failed-node" --strategy="failover_recovery"
 
 # Update network topology
-mcp__claude-flow__topology_optimize --swarmId="${SWARM_ID}"
+mcp__moflo__topology_optimize --swarmId="${SWARM_ID}"
 ```
 
 ## Consensus Algorithms

--- a/src/@claude-flow/mcp/.claude/agents/v3/adr-architect.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/adr-architect.md
@@ -20,7 +20,7 @@ hooks:
   pre: |
     echo "📋 ADR Architect analyzing architectural decisions"
     # Search for related ADRs
-    mcp__claude-flow__memory_search --pattern="adr:*" --namespace="decisions" --limit=10
+    mcp__moflo__memory_search --pattern="adr:*" --namespace="decisions" --limit=10
     # Load project ADR context
     if [ -d "docs/adr" ] || [ -d "docs/decisions" ]; then
       echo "📁 Found existing ADR directory"
@@ -28,7 +28,7 @@ hooks:
   post: |
     echo "✅ ADR documentation complete"
     # Store new ADR in memory
-    mcp__claude-flow__memory_usage --action="store" --namespace="decisions" --key="adr:$ADR_NUMBER" --value="$ADR_TITLE"
+    mcp__moflo__memory_usage --action="store" --namespace="decisions" --key="adr:$ADR_NUMBER" --value="$ADR_TITLE"
     # Train pattern on successful decision
     npx claude-flow@v3alpha hooks intelligence trajectory-step --operation="adr-created" --outcome="success"
 ---
@@ -144,16 +144,16 @@ npx claude-flow@v3alpha adr supersede ADR-005 ADR-012
 
 ```bash
 # Store ADR in memory
-mcp__claude-flow__memory_usage --action="store" \
+mcp__moflo__memory_usage --action="store" \
   --namespace="decisions" \
   --key="adr:006" \
   --value='{"title":"Unified Memory Service","status":"accepted","date":"2026-01-08"}'
 
 # Search related ADRs
-mcp__claude-flow__memory_search --pattern="adr:*memory*" --namespace="decisions"
+mcp__moflo__memory_search --pattern="adr:*memory*" --namespace="decisions"
 
 # Get ADR details
-mcp__claude-flow__memory_usage --action="retrieve" --namespace="decisions" --key="adr:006"
+mcp__moflo__memory_usage --action="retrieve" --namespace="decisions" --key="adr:006"
 ```
 
 ## Decision Categories

--- a/src/@claude-flow/mcp/.claude/agents/v3/aidefence-guardian.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/aidefence-guardian.md
@@ -191,7 +191,7 @@ Add to `.claude/settings.json`:
 
 ```javascript
 // Store detection in swarm memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "security_detections",
   key: `detection-${Date.now()}`,
@@ -235,7 +235,7 @@ if (result.threats.some(t => t.severity === 'critical')) {
     --message "Critical threat blocked by AIDefence Guardian"
 
   // Escalate to security-architect
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     namespace: "security_escalations",
     key: `escalation-${Date.now()}`,
@@ -264,7 +264,7 @@ Track guardian effectiveness:
 const stats = await guardian.getStats();
 
 // Report to metrics system
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "guardian_metrics",
   key: `metrics-${new Date().toISOString().split('T')[0]}`,

--- a/src/@claude-flow/mcp/.claude/agents/v3/claims-authorizer.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/claims-authorizer.md
@@ -23,7 +23,7 @@ hooks:
   post: |
     echo "✅ Authorization complete"
     # Log authorization decision
-    mcp__claude-flow__memory_usage --action="store" --namespace="audit" --key="auth:$(date +%s)" --value="$AUTH_DECISION"
+    mcp__moflo__memory_usage --action="store" --namespace="audit" --key="auth:$(date +%s)" --value="$AUTH_DECISION"
 ---
 
 # V3 Claims Authorizer Agent
@@ -152,7 +152,7 @@ Claims are checked automatically via hooks:
 ```json
 {
   "PreToolUse": [{
-    "matcher": "^mcp__claude-flow__.*$",
+    "matcher": "^mcp__moflo__.*$",
     "hooks": [{
       "type": "command",
       "command": "npx claude-flow@v3alpha claims check --agent $AGENT_ID --tool $TOOL_NAME --auto-deny"
@@ -174,13 +174,13 @@ All authorization decisions are logged:
 
 ```bash
 # Store authorization decision
-mcp__claude-flow__memory_usage --action="store" \
+mcp__moflo__memory_usage --action="store" \
   --namespace="audit" \
   --key="auth:$(date +%s)" \
   --value='{"agent":"agent-123","resource":"memory:patterns","action":"write","decision":"allow","reason":"has scope:write claim"}'
 
 # Query audit log
-mcp__claude-flow__memory_search --pattern="auth:*" --namespace="audit" --limit=100
+mcp__moflo__memory_search --pattern="auth:*" --namespace="audit" --limit=100
 ```
 
 ## Default Policies

--- a/src/@claude-flow/mcp/.claude/agents/v3/collective-intelligence-coordinator.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/collective-intelligence-coordinator.md
@@ -19,29 +19,29 @@ hooks:
   pre: |
     echo "🧠 Collective Intelligence Coordinator initializing hive-mind: $TASK"
     # Initialize hierarchical-mesh topology for collective intelligence
-    mcp__claude-flow__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
+    mcp__moflo__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
     # Set up CRDT synchronization layer
-    mcp__claude-flow__memory_usage store "collective:crdt:${TASK_ID}" "$(date): CRDT sync initialized" --namespace=collective
+    mcp__moflo__memory_usage store "collective:crdt:${TASK_ID}" "$(date): CRDT sync initialized" --namespace=collective
     # Initialize Byzantine consensus protocol
-    mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"protocol\":\"byzantine\",\"threshold\":0.67,\"fault_tolerance\":0.33}"
+    mcp__moflo__daa_consensus --agents="all" --proposal="{\"protocol\":\"byzantine\",\"threshold\":0.67,\"fault_tolerance\":0.33}"
     # Begin neural pattern analysis for collective cognition
-    mcp__claude-flow__neural_patterns analyze --operation="collective_init" --metadata="{\"task\":\"$TASK\",\"topology\":\"hierarchical-mesh\"}"
+    mcp__moflo__neural_patterns analyze --operation="collective_init" --metadata="{\"task\":\"$TASK\",\"topology\":\"hierarchical-mesh\"}"
     # Train attention mechanisms for coordination
-    mcp__claude-flow__neural_train coordination --training_data="collective_intelligence_patterns" --epochs=30
+    mcp__moflo__neural_train coordination --training_data="collective_intelligence_patterns" --epochs=30
     # Set up real-time monitoring
-    mcp__claude-flow__swarm_monitor --interval=3000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_monitor --interval=3000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Collective intelligence coordination complete - consensus achieved"
     # Store collective decision metrics
-    mcp__claude-flow__memory_usage store "collective:decision:${TASK_ID}" "$(date): Consensus decision: $(mcp__claude-flow__swarm_status | jq -r '.consensus')" --namespace=collective
+    mcp__moflo__memory_usage store "collective:decision:${TASK_ID}" "$(date): Consensus decision: $(mcp__moflo__swarm_status | jq -r '.consensus')" --namespace=collective
     # Generate performance report
-    mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+    mcp__moflo__performance_report --format=detailed --timeframe=24h
     # Learn from collective patterns
-    mcp__claude-flow__neural_patterns learn --operation="collective_coordination" --outcome="consensus_achieved" --metadata="{\"agents\":\"$(mcp__claude-flow__swarm_status | jq '.agents.total')\",\"consensus_strength\":\"$(mcp__claude-flow__swarm_status | jq '.consensus.strength')\"}"
+    mcp__moflo__neural_patterns learn --operation="collective_coordination" --outcome="consensus_achieved" --metadata="{\"agents\":\"$(mcp__moflo__swarm_status | jq '.agents.total')\",\"consensus_strength\":\"$(mcp__moflo__swarm_status | jq '.consensus.strength')\"}"
     # Save learned model
-    mcp__claude-flow__model_save "collective-intelligence-${TASK_ID}" "/tmp/collective-model-$(date +%s).json"
+    mcp__moflo__model_save "collective-intelligence-${TASK_ID}" "/tmp/collective-model-$(date +%s).json"
     # Synchronize final CRDT state
-    mcp__claude-flow__coordination_sync --swarmId="${SWARM_ID}"
+    mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 ---
 
 # Collective Intelligence Coordinator
@@ -800,54 +800,54 @@ class LearningCollectiveCoordinator extends CollectiveIntelligenceCoordinator {
 
 ```bash
 # Initialize hive-mind topology
-mcp__claude-flow__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
+mcp__moflo__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
 
 # Byzantine consensus protocol
-mcp__claude-flow__daa_consensus --agents="all" --proposal="{\"task\":\"auth_design\",\"type\":\"collective_vote\"}"
+mcp__moflo__daa_consensus --agents="all" --proposal="{\"task\":\"auth_design\",\"type\":\"collective_vote\"}"
 
 # CRDT synchronization
-mcp__claude-flow__memory_sync --target="all_agents" --crdt_type="OR_SET"
+mcp__moflo__memory_sync --target="all_agents" --crdt_type="OR_SET"
 
 # Attention-based coordination
-mcp__claude-flow__neural_patterns analyze --operation="collective_attention" --metadata="{\"mechanism\":\"multi-head\",\"heads\":8}"
+mcp__moflo__neural_patterns analyze --operation="collective_attention" --metadata="{\"mechanism\":\"multi-head\",\"heads\":8}"
 
 # Knowledge aggregation
-mcp__claude-flow__memory_usage store "collective:knowledge:${TASK_ID}" "$(date): Knowledge synthesis complete" --namespace=collective
+mcp__moflo__memory_usage store "collective:knowledge:${TASK_ID}" "$(date): Knowledge synthesis complete" --namespace=collective
 
 # Monitor collective health
-mcp__claude-flow__swarm_monitor --interval=3000 --metrics="consensus,byzantine,attention"
+mcp__moflo__swarm_monitor --interval=3000 --metrics="consensus,byzantine,attention"
 ```
 
 ### Memory Synchronization Commands
 
 ```bash
 # Initialize CRDT layer
-mcp__claude-flow__memory_usage store "crdt:state:init" "{\"type\":\"OR_SET\",\"nodes\":[]}" --namespace=crdt
+mcp__moflo__memory_usage store "crdt:state:init" "{\"type\":\"OR_SET\",\"nodes\":[]}" --namespace=crdt
 
 # Propagate deltas
-mcp__claude-flow__coordination_sync --swarmId="${SWARM_ID}"
+mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 
 # Verify convergence
-mcp__claude-flow__health_check --components="crdt,consensus,memory"
+mcp__moflo__health_check --components="crdt,consensus,memory"
 
 # Backup collective state
-mcp__claude-flow__memory_backup --path="/tmp/collective-backup-$(date +%s).json"
+mcp__moflo__memory_backup --path="/tmp/collective-backup-$(date +%s).json"
 ```
 
 ### Neural Learning Commands
 
 ```bash
 # Train collective patterns
-mcp__claude-flow__neural_train coordination --training_data="collective_intelligence_history" --epochs=50
+mcp__moflo__neural_train coordination --training_data="collective_intelligence_history" --epochs=50
 
 # Pattern recognition
-mcp__claude-flow__neural_patterns analyze --operation="emergent_behavior" --metadata="{\"agents\":10,\"iterations\":5}"
+mcp__moflo__neural_patterns analyze --operation="emergent_behavior" --metadata="{\"agents\":10,\"iterations\":5}"
 
 # Predictive consensus
-mcp__claude-flow__neural_predict --modelId="collective-coordinator" --input="{\"task\":\"complex_decision\",\"agents\":8}"
+mcp__moflo__neural_predict --modelId="collective-coordinator" --input="{\"task\":\"complex_decision\",\"agents\":8}"
 
 # Learn from outcomes
-mcp__claude-flow__neural_patterns learn --operation="consensus_achieved" --outcome="success" --metadata="{\"confidence\":0.92}"
+mcp__moflo__neural_patterns learn --operation="consensus_achieved" --outcome="success" --metadata="{\"confidence\":0.92}"
 ```
 
 ## Consensus Mechanisms
@@ -959,13 +959,13 @@ def select_topology(task_characteristics):
 
 ```bash
 # Collective health check
-mcp__claude-flow__health_check --components="collective,consensus,crdt,attention"
+mcp__moflo__health_check --components="collective,consensus,crdt,attention"
 
 # Performance report
-mcp__claude-flow__performance_report --format=detailed --timeframe=24h
+mcp__moflo__performance_report --format=detailed --timeframe=24h
 
 # Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze --component="collective" --metrics="latency,throughput,accuracy"
+mcp__moflo__bottleneck_analyze --component="collective" --metrics="latency,throughput,accuracy"
 ```
 
 ## Best Practices

--- a/src/@claude-flow/mcp/.claude/agents/v3/ddd-domain-expert.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/ddd-domain-expert.md
@@ -30,13 +30,13 @@ hooks:
   pre: |
     echo "🏛️ DDD Domain Expert analyzing domain model"
     # Search for existing domain patterns
-    mcp__claude-flow__memory_search --pattern="ddd:*" --namespace="architecture" --limit=10
+    mcp__moflo__memory_search --pattern="ddd:*" --namespace="architecture" --limit=10
     # Load domain context
-    mcp__claude-flow__memory_usage --action="retrieve" --namespace="architecture" --key="domain:model"
+    mcp__moflo__memory_usage --action="retrieve" --namespace="architecture" --key="domain:model"
   post: |
     echo "✅ Domain model analysis complete"
     # Store domain patterns
-    mcp__claude-flow__memory_usage --action="store" --namespace="architecture" --key="ddd:analysis:$(date +%s)" --value="$DOMAIN_SUMMARY"
+    mcp__moflo__memory_usage --action="store" --namespace="architecture" --key="ddd:analysis:$(date +%s)" --value="$DOMAIN_SUMMARY"
 ---
 
 # V3 DDD Domain Expert Agent
@@ -210,11 +210,11 @@ npx claude-flow@v3alpha ddd language-check
 
 ```bash
 # Store domain model
-mcp__claude-flow__memory_usage --action="store" \
+mcp__moflo__memory_usage --action="store" \
   --namespace="architecture" \
   --key="domain:model" \
   --value='{"contexts":["swarm","agent","task","memory"]}'
 
 # Search domain patterns
-mcp__claude-flow__memory_search --pattern="ddd:aggregate:*" --namespace="architecture"
+mcp__moflo__memory_search --pattern="ddd:aggregate:*" --namespace="architecture"
 ```

--- a/src/@claude-flow/mcp/.claude/agents/v3/memory-specialist.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/memory-specialist.md
@@ -23,21 +23,21 @@ hooks:
   pre: |
     echo "Memory Specialist initializing V3 memory system"
     # Initialize hybrid memory backend
-    mcp__claude-flow__memory_namespace --namespace="${NAMESPACE:-default}" --action="init"
+    mcp__moflo__memory_namespace --namespace="${NAMESPACE:-default}" --action="init"
     # Check HNSW index status
-    mcp__claude-flow__memory_analytics --timeframe="1h"
+    mcp__moflo__memory_analytics --timeframe="1h"
     # Store initialization event
-    mcp__claude-flow__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:init:${TASK_ID}" --value="$(date -Iseconds): Memory specialist session started"
+    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:init:${TASK_ID}" --value="$(date -Iseconds): Memory specialist session started"
   post: |
     echo "Memory optimization complete"
     # Persist memory state
-    mcp__claude-flow__memory_persist --sessionId="${SESSION_ID}"
+    mcp__moflo__memory_persist --sessionId="${SESSION_ID}"
     # Compress and optimize namespaces
-    mcp__claude-flow__memory_compress --namespace="${NAMESPACE:-default}"
+    mcp__moflo__memory_compress --namespace="${NAMESPACE:-default}"
     # Generate memory analytics report
-    mcp__claude-flow__memory_analytics --timeframe="24h"
+    mcp__moflo__memory_analytics --timeframe="24h"
     # Store completion metrics
-    mcp__claude-flow__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:complete:${TASK_ID}" --value="$(date -Iseconds): Memory optimization completed"
+    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:complete:${TASK_ID}" --value="$(date -Iseconds): Memory optimization completed"
 ---
 
 # V3 Memory Specialist Agent
@@ -884,28 +884,28 @@ class PatternDistiller {
 
 ```bash
 # Store with HNSW indexing
-mcp__claude-flow__memory_usage --action="store" --namespace="patterns" --key="auth:jwt-strategy" --value='{"pattern": "jwt-auth", "embedding": [...]}' --ttl=604800000
+mcp__moflo__memory_usage --action="store" --namespace="patterns" --key="auth:jwt-strategy" --value='{"pattern": "jwt-auth", "embedding": [...]}' --ttl=604800000
 
 # Semantic search with HNSW
-mcp__claude-flow__memory_search --pattern="authentication strategies" --namespace="patterns" --limit=10
+mcp__moflo__memory_search --pattern="authentication strategies" --namespace="patterns" --limit=10
 
 # Namespace management
-mcp__claude-flow__memory_namespace --namespace="project:myapp" --action="create"
+mcp__moflo__memory_namespace --namespace="project:myapp" --action="create"
 
 # Memory analytics
-mcp__claude-flow__memory_analytics --timeframe="7d"
+mcp__moflo__memory_analytics --timeframe="7d"
 
 # Memory compression
-mcp__claude-flow__memory_compress --namespace="default"
+mcp__moflo__memory_compress --namespace="default"
 
 # Cross-session persistence
-mcp__claude-flow__memory_persist --sessionId="session-12345"
+mcp__moflo__memory_persist --sessionId="session-12345"
 
 # Memory backup
-mcp__claude-flow__memory_backup --path="./backups/memory-$(date +%Y%m%d).bak"
+mcp__moflo__memory_backup --path="./backups/memory-$(date +%Y%m%d).bak"
 
 # Distributed sync
-mcp__claude-flow__memory_sync --target="peer-agent-1"
+mcp__moflo__memory_sync --target="peer-agent-1"
 ```
 
 ### CLI Commands

--- a/src/@claude-flow/mcp/.claude/agents/v3/performance-engineer.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/performance-engineer.md
@@ -1026,12 +1026,12 @@ class V3BenchmarkSuite {
 const performanceMCP = {
   // Run benchmark suite
   async runBenchmarks(suite = 'all') {
-    return await mcp__claude-flow__benchmark_run({ suite });
+    return await mcp__moflo__benchmark_run({ suite });
   },
 
   // Analyze bottlenecks
   async analyzeBottlenecks(component) {
-    return await mcp__claude-flow__bottleneck_analyze({
+    return await mcp__moflo__bottleneck_analyze({
       component: component,
       metrics: ['latency', 'throughput', 'memory', 'cpu']
     });
@@ -1039,7 +1039,7 @@ const performanceMCP = {
 
   // Get performance report
   async getPerformanceReport(timeframe = '24h') {
-    return await mcp__claude-flow__performance_report({
+    return await mcp__moflo__performance_report({
       format: 'detailed',
       timeframe: timeframe
     });
@@ -1047,7 +1047,7 @@ const performanceMCP = {
 
   // Token usage analysis
   async analyzeTokenUsage(operation) {
-    return await mcp__claude-flow__token_usage({
+    return await mcp__moflo__token_usage({
       operation: operation,
       timeframe: '24h'
     });
@@ -1055,14 +1055,14 @@ const performanceMCP = {
 
   // WASM optimization
   async optimizeWASM(operation) {
-    return await mcp__claude-flow__wasm_optimize({
+    return await mcp__moflo__wasm_optimize({
       operation: operation
     });
   },
 
   // Neural pattern optimization
   async optimizeNeuralPatterns() {
-    return await mcp__claude-flow__neural_patterns({
+    return await mcp__moflo__neural_patterns({
       action: 'analyze',
       metadata: { focus: 'performance' }
     });
@@ -1070,7 +1070,7 @@ const performanceMCP = {
 
   // Store performance metrics
   async storeMetrics(key, value) {
-    return await mcp__claude-flow__memory_usage({
+    return await mcp__moflo__memory_usage({
       action: 'store',
       key: `performance/${key}`,
       value: JSON.stringify(value),
@@ -1144,14 +1144,14 @@ class SONAPerformanceOptimizer {
 
   async triggerSONALearning() {
     // Use SONA to learn optimization patterns
-    await mcp__claude-flow__neural_train({
+    await mcp__moflo__neural_train({
       pattern_type: 'optimization',
       training_data: JSON.stringify(this.trajectories),
       epochs: 10
     });
 
     // Extract learned patterns
-    const patterns = await mcp__claude-flow__neural_patterns({
+    const patterns = await mcp__moflo__neural_patterns({
       action: 'analyze',
       metadata: { domain: 'performance' }
     });
@@ -1167,7 +1167,7 @@ class SONAPerformanceOptimizer {
 
   async predictOptimalSettings(context) {
     // Use SONA to predict optimal configuration
-    const prediction = await mcp__claude-flow__neural_predict({
+    const prediction = await mcp__moflo__neural_predict({
       modelId: 'performance-optimizer',
       input: JSON.stringify(context)
     });

--- a/src/@claude-flow/mcp/.claude/agents/v3/pii-detector.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/pii-detector.md
@@ -126,7 +126,7 @@ When PII is detected, suggest:
 
 ```javascript
 // Report PII findings to swarm
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "pii_findings",
   key: `pii-${Date.now()}`,

--- a/src/@claude-flow/mcp/.claude/agents/v3/reasoningbank-learner.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/reasoningbank-learner.md
@@ -23,13 +23,13 @@ hooks:
     SESSION_ID="rb-$(date +%s)"
     npx claude-flow@v3alpha hooks intelligence trajectory-start --session-id "$SESSION_ID" --agent-type "reasoningbank-learner" --task "$TASK"
     # Search for similar patterns
-    mcp__claude-flow__memory_search --pattern="pattern:*" --namespace="reasoningbank" --limit=10
+    mcp__moflo__memory_search --pattern="pattern:*" --namespace="reasoningbank" --limit=10
   post: |
     echo "✅ Learning cycle complete"
     # End trajectory with verdict
     npx claude-flow@v3alpha hooks intelligence trajectory-end --session-id "$SESSION_ID" --verdict "${VERDICT:-success}"
     # Store learned pattern
-    mcp__claude-flow__memory_usage --action="store" --namespace="reasoningbank" --key="pattern:$(date +%s)" --value="$PATTERN_SUMMARY"
+    mcp__moflo__memory_usage --action="store" --namespace="reasoningbank" --key="pattern:$(date +%s)" --value="$PATTERN_SUMMARY"
 ---
 
 # V3 ReasoningBank Learner Agent
@@ -68,7 +68,7 @@ Search for similar patterns 150x-12,500x faster:
 
 ```bash
 # Search patterns via HNSW
-mcp__claude-flow__memory_search --pattern="$TASK" --namespace="reasoningbank" --limit=10
+mcp__moflo__memory_search --pattern="$TASK" --namespace="reasoningbank" --limit=10
 
 # Get pattern statistics
 npx claude-flow@v3alpha hooks intelligence pattern-stats --query "$TASK" --k 10 --namespace reasoningbank
@@ -99,7 +99,7 @@ Extract key learnings using LoRA adaptation:
 
 ```bash
 # Store successful pattern
-mcp__claude-flow__memory_usage --action="store" \
+mcp__moflo__memory_usage --action="store" \
   --namespace="reasoningbank" \
   --key="pattern:auth-implementation" \
   --value='{"task":"implement auth","approach":"JWT with refresh","outcome":"success","reward":0.95}'

--- a/src/@claude-flow/mcp/.claude/agents/v3/security-architect-aidefence.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/security-architect-aidefence.md
@@ -323,14 +323,14 @@ npx claude-flow@v3alpha security learn --threat-type prompt_injection --strategy
 
 ```javascript
 // Real-time threat scanning
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   action: "defend",
   input: userInput,
   mode: "thorough"
 })
 
 // Behavioral anomaly detection
-mcp__claude-flow__security_analyze({
+mcp__moflo__security_analyze({
   action: "behavior",
   agentId: agentId,
   timeWindow: "1h",
@@ -338,7 +338,7 @@ mcp__claude-flow__security_analyze({
 })
 
 // LTL policy verification
-mcp__claude-flow__security_verify({
+mcp__moflo__security_verify({
   action: "policy",
   agentId: agentId,
   policy: "G(!self_approve)"

--- a/src/@claude-flow/mcp/.claude/agents/v3/security-architect.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/security-architect.md
@@ -793,7 +793,7 @@ const mergedFindings = securityConsensus.attentionWeights.map((weight, i) => ({
 
 ```javascript
 // Store security findings in coordinated memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   key: "swarm/security-architect/assessment",
   namespace: "coordination",
@@ -816,7 +816,7 @@ mcp__claude-flow__memory_usage({
 })
 
 // Share with other security agents
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   key: "swarm/shared/security-findings",
   namespace: "coordination",

--- a/src/@claude-flow/mcp/.claude/agents/v3/sparc-orchestrator.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/sparc-orchestrator.md
@@ -25,15 +25,15 @@ hooks:
     echo "⚡ SPARC Orchestrator initializing methodology workflow"
     # Store SPARC session start
     SESSION_ID="sparc-$(date +%s)"
-    mcp__claude-flow__memory_usage --action="store" --namespace="sparc" --key="session:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow initiated for: $TASK"
+    mcp__moflo__memory_usage --action="store" --namespace="sparc" --key="session:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow initiated for: $TASK"
     # Search for similar SPARC patterns
-    mcp__claude-flow__memory_search --pattern="sparc:success:*" --namespace="patterns" --limit=5
+    mcp__moflo__memory_search --pattern="sparc:success:*" --namespace="patterns" --limit=5
     # Initialize trajectory tracking
     npx claude-flow@v3alpha hooks intelligence trajectory-start --session-id "$SESSION_ID" --agent-type "sparc-orchestrator" --task "$TASK"
   post: |
     echo "✅ SPARC workflow complete"
     # Store completion
-    mcp__claude-flow__memory_usage --action="store" --namespace="sparc" --key="complete:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow completed"
+    mcp__moflo__memory_usage --action="store" --namespace="sparc" --key="complete:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow completed"
     # Train on successful pattern
     npx claude-flow@v3alpha hooks intelligence trajectory-end --session-id "$SESSION_ID" --verdict "success"
 ---
@@ -167,11 +167,11 @@ The orchestrator learns from each workflow:
 
 ```bash
 # Store successful pattern
-mcp__claude-flow__memory_usage --action="store" --namespace="patterns" \
+mcp__moflo__memory_usage --action="store" --namespace="patterns" \
   --key="sparc:success:$(date +%s)" --value="$WORKFLOW_SUMMARY"
 
 # Search for similar patterns
-mcp__claude-flow__memory_search --pattern="sparc:*:$PROJECT_TYPE" --namespace="patterns"
+mcp__moflo__memory_search --pattern="sparc:*:$PROJECT_TYPE" --namespace="patterns"
 ```
 
 ## Integration with V3 Features

--- a/src/@claude-flow/mcp/.claude/agents/v3/swarm-memory-manager.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/swarm-memory-manager.md
@@ -23,20 +23,20 @@ hooks:
   pre: |
     echo "🧠 Swarm Memory Manager initializing distributed memory"
     # Initialize all memory namespaces for swarm
-    mcp__claude-flow__memory_namespace --namespace="swarm" --action="init"
-    mcp__claude-flow__memory_namespace --namespace="agents" --action="init"
-    mcp__claude-flow__memory_namespace --namespace="tasks" --action="init"
-    mcp__claude-flow__memory_namespace --namespace="patterns" --action="init"
+    mcp__moflo__memory_namespace --namespace="swarm" --action="init"
+    mcp__moflo__memory_namespace --namespace="agents" --action="init"
+    mcp__moflo__memory_namespace --namespace="tasks" --action="init"
+    mcp__moflo__memory_namespace --namespace="patterns" --action="init"
     # Store initialization event
-    mcp__claude-flow__memory_usage --action="store" --namespace="swarm" --key="memory-manager:init:$(date +%s)" --value="Distributed memory initialized"
+    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-manager:init:$(date +%s)" --value="Distributed memory initialized"
   post: |
     echo "🔄 Synchronizing swarm memory state"
     # Sync memory across instances
-    mcp__claude-flow__memory_sync --target="all"
+    mcp__moflo__memory_sync --target="all"
     # Compress stale data
-    mcp__claude-flow__memory_compress --namespace="swarm"
+    mcp__moflo__memory_compress --namespace="swarm"
     # Persist session state
-    mcp__claude-flow__memory_persist --sessionId="${SESSION_ID}"
+    mcp__moflo__memory_persist --sessionId="${SESSION_ID}"
 ---
 
 # V3 Swarm Memory Manager Agent
@@ -98,13 +98,13 @@ You are a **Swarm Memory Manager** responsible for coordinating distributed memo
 
 ```bash
 # Memory operations
-mcp__claude-flow__memory_usage --action="store|retrieve|list|delete|search"
-mcp__claude-flow__memory_search --pattern="*" --namespace="swarm"
-mcp__claude-flow__memory_sync --target="all"
-mcp__claude-flow__memory_compress --namespace="default"
-mcp__claude-flow__memory_persist --sessionId="$SESSION_ID"
-mcp__claude-flow__memory_namespace --namespace="name" --action="init|delete|stats"
-mcp__claude-flow__memory_analytics --timeframe="24h"
+mcp__moflo__memory_usage --action="store|retrieve|list|delete|search"
+mcp__moflo__memory_search --pattern="*" --namespace="swarm"
+mcp__moflo__memory_sync --target="all"
+mcp__moflo__memory_compress --namespace="default"
+mcp__moflo__memory_persist --sessionId="$SESSION_ID"
+mcp__moflo__memory_namespace --namespace="name" --action="init|delete|stats"
+mcp__moflo__memory_analytics --timeframe="24h"
 ```
 
 ## Coordination Protocol
@@ -130,15 +130,15 @@ mcp__claude-flow__memory_analytics --timeframe="24h"
 
 ```javascript
 // 1. Initialize distributed memory for new swarm
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 10 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 10 })
 
 // 2. Create namespaces
 for (const ns of ["swarm", "agents", "tasks", "patterns"]) {
-  mcp__claude-flow__memory_namespace({ namespace: ns, action: "init" })
+  mcp__moflo__memory_namespace({ namespace: ns, action: "init" })
 }
 
 // 3. Store swarm state
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "store",
   namespace: "swarm",
   key: "topology",
@@ -146,12 +146,12 @@ mcp__claude-flow__memory_usage({
 })
 
 // 4. Agents read shared state
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   action: "retrieve",
   namespace: "swarm",
   key: "topology"
 })
 
 // 5. Sync periodically
-mcp__claude-flow__memory_sync({ target: "all" })
+mcp__moflo__memory_sync({ target: "all" })
 ```

--- a/src/@claude-flow/mcp/.claude/agents/v3/v3-integration-architect.md
+++ b/src/@claude-flow/mcp/.claude/agents/v3/v3-integration-architect.md
@@ -21,10 +21,10 @@ hooks:
     # Check agentic-flow version
     npx agentic-flow --version 2>/dev/null || echo "agentic-flow not installed"
     # Load integration patterns
-    mcp__claude-flow__memory_search --pattern="integration:agentic-flow:*" --namespace="architecture" --limit=5
+    mcp__moflo__memory_search --pattern="integration:agentic-flow:*" --namespace="architecture" --limit=5
   post: |
     echo "✅ Integration analysis complete"
-    mcp__claude-flow__memory_usage --action="store" --namespace="architecture" --key="integration:analysis:$(date +%s)" --value="ADR-001 compliance checked"
+    mcp__moflo__memory_usage --action="store" --namespace="architecture" --key="integration:analysis:$(date +%s)" --value="ADR-001 compliance checked"
 ---
 
 # V3 Integration Architect Agent

--- a/src/@claude-flow/mcp/.claude/commands/analysis/COMMAND_COMPLIANCE_REPORT.md
+++ b/src/@claude-flow/mcp/.claude/commands/analysis/COMMAND_COMPLIANCE_REPORT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 Reviewed all command files in `.claude/commands/analysis/` directory to ensure proper usage of:
-- `mcp__claude-flow__*` tools (preferred)
+- `mcp__moflo__*` tools (preferred)
 - `npx claude-flow` commands (as fallback)
 - No direct implementation calls
 
@@ -12,7 +12,7 @@ Reviewed all command files in `.claude/commands/analysis/` directory to ensure p
 **Status**: ✅ Updated
 **Changes Made**:
 - Replaced `npx ruv-swarm hook session-end --export-metrics` with proper MCP tool call
-- Updated to: `Tool: mcp__claude-flow__token_usage` with appropriate parameters
+- Updated to: `Tool: mcp__moflo__token_usage` with appropriate parameters
 - Maintained result format and context
 
 **Before**:
@@ -22,13 +22,13 @@ npx ruv-swarm hook session-end --export-metrics
 
 **After**:
 ```
-Tool: mcp__claude-flow__token_usage
+Tool: mcp__moflo__token_usage
 Parameters: {"operation": "session", "timeframe": "24h"}
 ```
 
 ### 2. performance-bottlenecks.md
 **Status**: ✅ Compliant (No changes needed)
-**Reason**: Already uses proper `mcp__claude-flow__task_results` tool format
+**Reason**: Already uses proper `mcp__moflo__task_results` tool format
 
 ## Summary
 
@@ -39,7 +39,7 @@ Parameters: {"operation": "session", "timeframe": "24h"}
 
 ## Compliance Patterns Enforced
 
-1. **MCP Tool Usage**: All direct tool calls now use `mcp__claude-flow__*` format
+1. **MCP Tool Usage**: All direct tool calls now use `mcp__moflo__*` format
 2. **Parameter Format**: JSON parameters properly structured
 3. **Command Context**: Preserved original functionality and expected results
 4. **Documentation**: Maintained clarity and examples

--- a/src/@claude-flow/mcp/.claude/commands/analysis/bottleneck-detect.md
+++ b/src/@claude-flow/mcp/.claude/commands/analysis/bottleneck-detect.md
@@ -147,7 +147,7 @@ Typical improvements after bottleneck resolution:
 
 ```javascript
 // Check for bottlenecks in Claude Code
-mcp__claude-flow__bottleneck_detect {
+mcp__moflo__bottleneck_detect {
   timeRange: "1h",
   threshold: 20,
   autoFix: false

--- a/src/@claude-flow/mcp/.claude/commands/analysis/performance-bottlenecks.md
+++ b/src/@claude-flow/mcp/.claude/commands/analysis/performance-bottlenecks.md
@@ -32,7 +32,7 @@ The post-task hook automatically analyzes:
 ### 3. Improvement Suggestions
 
 ```
-Tool: mcp__claude-flow__task_results
+Tool: mcp__moflo__task_results
 Parameters: {"taskId": "task-123", "format": "detailed"}
 
 Result includes:

--- a/src/@claude-flow/mcp/.claude/commands/analysis/token-efficiency.md
+++ b/src/@claude-flow/mcp/.claude/commands/analysis/token-efficiency.md
@@ -19,7 +19,7 @@ Reduce token consumption while maintaining quality through intelligent coordinat
 
 ```bash
 # Check token savings after session
-Tool: mcp__claude-flow__token_usage
+Tool: mcp__moflo__token_usage
 Parameters: {"operation": "session", "timeframe": "24h"}
 
 # Result shows:

--- a/src/@claude-flow/mcp/.claude/commands/automation/auto-agent.md
+++ b/src/@claude-flow/mcp/.claude/commands/automation/auto-agent.md
@@ -107,7 +107,7 @@ npx claude-flow auto agent -t "Fix bug in login" -s minimal
 
 ```javascript
 // In Claude Code after auto-spawning
-mcp__claude-flow__auto_agent {
+mcp__moflo__auto_agent {
   task: "Build authentication system",
   strategy: "balanced",
   maxAgents: 6

--- a/src/@claude-flow/mcp/.claude/commands/automation/self-healing.md
+++ b/src/@claude-flow/mcp/.claude/commands/automation/self-healing.md
@@ -47,7 +47,7 @@ Each recovery improves future prevention:
 **Pattern Storage:**
 ```javascript
 // Store error patterns
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "error-pattern-" + Date.now(),
   "value": JSON.stringify(errorData),
@@ -56,7 +56,7 @@ mcp__claude-flow__memory_usage({
 })
 
 // Analyze patterns
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "analyze",
   "operation": "error-recovery",
   "outcome": "success"
@@ -68,21 +68,21 @@ mcp__claude-flow__neural_patterns({
 ### MCP Tool Coordination
 ```javascript
 // Initialize self-healing swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 4,
   "strategy": "adaptive"
 })
 
 // Spawn recovery agents
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "monitor",
   "name": "Error Monitor",
   "capabilities": ["error-detection", "recovery"]
 })
 
 // Orchestrate recovery
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "recover from error",
   "strategy": "sequential",
   "priority": "critical"

--- a/src/@claude-flow/mcp/.claude/commands/automation/session-memory.md
+++ b/src/@claude-flow/mcp/.claude/commands/automation/session-memory.md
@@ -16,14 +16,14 @@ At session end, automatically saves:
 ### 2. Session Restoration
 ```javascript
 // Using MCP tools for memory operations
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "retrieve",
   "key": "session-state",
   "namespace": "sessions"
 })
 
 // Restore swarm state
-mcp__claude-flow__context_restore({
+mcp__moflo__context_restore({
   "snapshotId": "sess-123"
 })
 ```
@@ -56,20 +56,20 @@ npx claude-flow hook session-restore --session-id "sess-123"
 ### 4. Privacy & Control
 ```javascript
 // List memory contents
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "list",
   "namespace": "sessions"
 })
 
 // Delete specific memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "delete",
   "key": "session-123",
   "namespace": "sessions"
 })
 
 // Backup memory
-mcp__claude-flow__memory_backup({
+mcp__moflo__memory_backup({
   "path": "./backups/memory-backup.json"
 })
 ```

--- a/src/@claude-flow/mcp/.claude/commands/automation/smart-agents.md
+++ b/src/@claude-flow/mcp/.claude/commands/automation/smart-agents.md
@@ -30,12 +30,12 @@ The system monitors workload and spawns additional agents when:
 **Status Monitoring:**
 ```javascript
 // Check swarm health
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "current"
 })
 
 // Monitor agent performance
-mcp__claude-flow__agent_metrics({
+mcp__moflo__agent_metrics({
   "agentId": "agent-123"
 })
 ```
@@ -46,14 +46,14 @@ mcp__claude-flow__agent_metrics({
 Uses Claude Flow MCP tools for agent coordination:
 ```javascript
 // Initialize swarm with appropriate topology
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 8,
   "strategy": "auto"
 })
 
 // Spawn agents based on file type
-mcp__claude-flow__agent_spawn({
+mcp__moflo__agent_spawn({
   "type": "coder",
   "name": "JavaScript Handler",
   "capabilities": ["javascript", "typescript"]

--- a/src/@claude-flow/mcp/.claude/commands/github/github-modes.md
+++ b/src/@claude-flow/mcp/.claude/commands/github/github-modes.md
@@ -137,11 +137,11 @@ All GitHub modes can be enhanced with ruv-swarm coordination:
 
 ```javascript
 // Initialize swarm for GitHub workflow
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
-mcp__claude-flow__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
+mcp__moflo__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
 ```

--- a/src/@claude-flow/mcp/.claude/commands/github/github-swarm.md
+++ b/src/@claude-flow/mcp/.claude/commands/github/github-swarm.md
@@ -106,7 +106,7 @@ npx claude-flow github swarm -r owner/repo -a 8 -f triage --issue-labels --auto-
 Use in Claude Code with MCP tools:
 
 ```javascript
-mcp__claude-flow__github_swarm {
+mcp__moflo__github_swarm {
   repository: "owner/repo",
   agents: 6,
   focus: "maintenance"

--- a/src/@claude-flow/mcp/.claude/commands/github/issue-tracker.md
+++ b/src/@claude-flow/mcp/.claude/commands/github/issue-tracker.md
@@ -17,7 +17,7 @@ Intelligent issue management and project coordination with ruv-swarm integration
 - `mcp__github__update_issue`
 - `mcp__github__add_issue_comment`
 - `mcp__github__search_issues`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -25,10 +25,10 @@ Intelligent issue management and project coordination with ruv-swarm integration
 ### 1. Create Coordinated Issue with Swarm Tracking
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -53,7 +53,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"
@@ -63,7 +63,7 @@ mcp__claude-flow__task_orchestrate {
 ### 2. Automated Progress Updates
 ```javascript
 // Update issue with progress from swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   key: "issue/54/progress"
 }
@@ -92,7 +92,7 @@ mcp__github__add_issue_comment {
 }
 
 // Store progress in swarm memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "issue/54/latest_update",
   value: { timestamp: Date.now(), progress: "89%", status: "near_completion" }
@@ -125,10 +125,10 @@ mcp__github__update_issue {
 ```javascript
 [Single Message - Issue Lifecycle Management]:
   // Initialize issue coordination swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Manager" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Progress Tracker" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Context Gatherer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Manager" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Progress Tracker" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Context Gatherer" }
   
   // Create multiple related issues using gh CLI
   Bash(`gh issue create \
@@ -158,7 +158,7 @@ mcp__github__update_issue {
   ]}
   
   // Store initial coordination state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "project/github_integration/issues",
     value: { created: Date.now(), total_issues: 3, status: "initialized" }

--- a/src/@claude-flow/mcp/.claude/commands/github/pr-manager.md
+++ b/src/@claude-flow/mcp/.claude/commands/github/pr-manager.md
@@ -21,7 +21,7 @@ Comprehensive pull request management with ruv-swarm coordination for automated 
 - `mcp__github__update_pull_request_branch`
 - `mcp__github__get_pull_request_comments`
 - `mcp__github__get_pull_request_reviews`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`
 
 ## Usage Patterns
@@ -29,10 +29,10 @@ Comprehensive pull request management with ruv-swarm coordination for automated 
 ### 1. Create and Manage PR with Swarm Coordination
 ```javascript
 // Initialize review swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Testing Agent" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "PR Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Quality Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Testing Agent" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "PR Coordinator" }
 
 // Create PR and orchestrate review
 mcp__github__create_pull_request {
@@ -45,7 +45,7 @@ mcp__github__create_pull_request {
 }
 
 // Orchestrate review process
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review with testing and validation",
   strategy: "parallel",
   priority: "high"
@@ -87,7 +87,7 @@ mcp__github__merge_pull_request {
 }
 
 // Post-merge coordination
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "pr/54/merged",
   value: { timestamp: Date.now(), status: "success" }
@@ -100,10 +100,10 @@ mcp__claude-flow__memory_usage {
 ```javascript
 [Single Message - Complete PR Management]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
   
   // Create and manage PR using gh CLI
   Bash("gh pr create --repo :owner/:repo --title '...' --head '...' --base 'main'")

--- a/src/@claude-flow/mcp/.claude/commands/github/release-manager.md
+++ b/src/@claude-flow/mcp/.claude/commands/github/release-manager.md
@@ -16,7 +16,7 @@ Automated release coordination and deployment with ruv-swarm orchestration for s
 - `mcp__github__create_branch`
 - `mcp__github__push_files`
 - `mcp__github__create_issue`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`
 
 ## Usage Patterns
@@ -24,12 +24,12 @@ Automated release coordination and deployment with ruv-swarm orchestration for s
 ### 1. Coordinated Release Preparation
 ```javascript
 // Initialize release management swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Coordinator" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Release Coordinator" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
 
 // Create release preparation branch
 mcp__github__create_branch {
@@ -40,7 +40,7 @@ mcp__github__create_branch {
 }
 
 // Orchestrate release preparation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Prepare release v1.0.72 with comprehensive testing and validation",
   strategy: "sequential",
   priority: "critical"
@@ -177,13 +177,13 @@ This release is production-ready with comprehensive validation and testing.
 ```javascript
 [Single Message - Complete Release Management]:
   // Initialize comprehensive release swarm
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 8 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Lead" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Controller" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Performance Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 8 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Lead" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Controller" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Performance Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
   
   // Create release branch and prepare files using gh CLI
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v1.0.72' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
@@ -222,7 +222,7 @@ This release is production-ready with comprehensive validation and testing.
   ]}
   
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store", 
     key: "release/v1.0.72/status",
     value: {

--- a/src/@claude-flow/mcp/.claude/commands/github/repo-architect.md
+++ b/src/@claude-flow/mcp/.claude/commands/github/repo-architect.md
@@ -16,7 +16,7 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 - `mcp__github__search_repositories`
 - `mcp__github__push_files`
 - `mcp__github__create_or_update_file`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `LS`, `Glob`
 
 ## Usage Patterns
@@ -24,11 +24,11 @@ Repository structure optimization and multi-repo management with ruv-swarm coord
 ### 1. Repository Structure Analysis and Optimization
 ```javascript
 // Initialize architecture analysis swarm
-mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 4 }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyzer" }
-mcp__claude-flow__agent_spawn { type: "architect", name: "Repository Architect" }
-mcp__claude-flow__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+mcp__moflo__swarm_init { topology: "mesh", maxAgents: 4 }
+mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyzer" }
+mcp__moflo__agent_spawn { type: "architect", name: "Repository Architect" }
+mcp__moflo__agent_spawn { type: "optimizer", name: "Structure Optimizer" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
 
 // Analyze current repository structure
 LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -42,7 +42,7 @@ mcp__github__search_repositories {
 }
 
 // Orchestrate structure optimization
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Analyze and optimize repository structure for scalability and maintainability",
   strategy: "adaptive",
   priority: "medium"
@@ -169,12 +169,12 @@ jobs:
 ```javascript
 [Single Message - Repository Architecture Review]:
   // Initialize comprehensive architecture swarm
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "architect", name: "Senior Architect" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Structure Analyst" }
-  mcp__claude-flow__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "architect", name: "Senior Architect" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Structure Analyst" }
+  mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Best Practices Researcher" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Multi-Repo Coordinator" }
   
   // Analyze current repository structures
   LS("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow")
@@ -223,7 +223,7 @@ jobs:
   ]}
   
   // Store architecture analysis
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "architecture/analysis/results",
     value: {

--- a/src/@claude-flow/mcp/.claude/commands/github/sync-coordinator.md
+++ b/src/@claude-flow/mcp/.claude/commands/github/sync-coordinator.md
@@ -16,7 +16,7 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 - `mcp__github__get_file_contents`
 - `mcp__github__create_pull_request`
 - `mcp__github__search_repositories`
-- `mcp__claude-flow__*` (all swarm coordination tools)
+- `mcp__moflo__*` (all swarm coordination tools)
 - `TodoWrite`, `TodoRead`, `Task`, `Bash`, `Read`, `Write`, `Edit`, `MultiEdit`
 
 ## Usage Patterns
@@ -24,11 +24,11 @@ Multi-package synchronization and version alignment with ruv-swarm coordination 
 ### 1. Synchronize Package Dependencies
 ```javascript
 // Initialize sync coordination swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Developer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Engineer" }
+mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Sync Coordinator" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Dependency Analyzer" }
+mcp__moflo__agent_spawn { type: "coder", name: "Integration Developer" }
+mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 // Analyze current package states
 Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -47,7 +47,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/packa
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/package.json?ref=sync/package-alignment --jq '.sha')")`)
 
 // Orchestrate validation
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Validate package synchronization and run integration tests",
   strategy: "parallel",
   priority: "high"
@@ -73,7 +73,7 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUD
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUDE.md?ref=sync/documentation --jq '.sha' 2>/dev/null || echo '')")`)
 
 // Store sync state in memory
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sync/documentation/status",
   value: { timestamp: Date.now(), status: "synchronized", files: ["CLAUDE.md"] }
@@ -147,12 +147,12 @@ This integration uses ruv-swarm agents for:
 ```javascript
 [Single Message - Complete Synchronization]:
   // Initialize comprehensive sync swarm
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 6 }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Package Analyzer" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Integration Coder" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "Validation Tester" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 6 }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Master Sync Coordinator" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Package Analyzer" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Integration Coder" }
+  mcp__moflo__agent_spawn { type: "tester", name: "Validation Tester" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Reviewer" }
   
   // Read current state of both packages
   Read("/workspaces/ruv-FANN/claude-code-flow/claude-code-flow/package.json")
@@ -186,7 +186,7 @@ This integration uses ruv-swarm agents for:
   ]}
   
   // Store comprehensive sync state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "sync/complete/status",
     value: {

--- a/src/@claude-flow/mcp/.claude/commands/monitoring/agents.md
+++ b/src/@claude-flow/mcp/.claude/commands/monitoring/agents.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__agent_list`
+**Tool:** `mcp__moflo__agent_list`
 
 ## Parameters
 ```json
@@ -27,9 +27,9 @@ Filters:
 ## Example Usage
 
 **In Claude Code:**
-1. List all agents: Use tool `mcp__claude-flow__agent_list`
-2. Get specific agent metrics: Use tool `mcp__claude-flow__agent_metrics` with parameters `{"agentId": "coder-123"}`
-3. Monitor agent performance: Use tool `mcp__claude-flow__swarm_monitor` with parameters `{"interval": 2000}`
+1. List all agents: Use tool `mcp__moflo__agent_list`
+2. Get specific agent metrics: Use tool `mcp__moflo__agent_metrics` with parameters `{"agentId": "coder-123"}`
+3. Monitor agent performance: Use tool `mcp__moflo__swarm_monitor` with parameters `{"interval": 2000}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/src/@claude-flow/mcp/.claude/commands/monitoring/status.md
+++ b/src/@claude-flow/mcp/.claude/commands/monitoring/status.md
@@ -5,7 +5,7 @@
 
 ## MCP Tool Usage in Claude Code
 
-**Tool:** `mcp__claude-flow__swarm_status`
+**Tool:** `mcp__moflo__swarm_status`
 
 ## Parameters
 ```json
@@ -28,10 +28,10 @@ Shows:
 ## Example Usage
 
 **In Claude Code:**
-1. Check swarm status: Use tool `mcp__claude-flow__swarm_status`
-2. Monitor in real-time: Use tool `mcp__claude-flow__swarm_monitor` with parameters `{"interval": 1000}`
-3. Get agent metrics: Use tool `mcp__claude-flow__agent_metrics` with parameters `{"agentId": "agent-123"}`
-4. Health check: Use tool `mcp__claude-flow__health_check` with parameters `{"components": ["swarm", "memory", "neural"]}`
+1. Check swarm status: Use tool `mcp__moflo__swarm_status`
+2. Monitor in real-time: Use tool `mcp__moflo__swarm_monitor` with parameters `{"interval": 1000}`
+3. Get agent metrics: Use tool `mcp__moflo__agent_metrics` with parameters `{"agentId": "agent-123"}`
+4. Health check: Use tool `mcp__moflo__health_check` with parameters `{"components": ["swarm", "memory", "neural"]}`
 
 ## Important Reminders
 - ✅ This tool provides coordination and structure

--- a/src/@claude-flow/mcp/.claude/commands/optimization/auto-topology.md
+++ b/src/@claude-flow/mcp/.claude/commands/optimization/auto-topology.md
@@ -23,14 +23,14 @@ Based on analysis, it selects:
 
 **Simple Task:**
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {"task": "Fix typo in README.md"}
 Result: Automatically uses star topology with single agent
 ```
 
 **Complex Task:**
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {"task": "Refactor authentication system with JWT, add tests, update documentation"}
 Result: Automatically uses hierarchical topology with architect, coder, and tester agents
 ```
@@ -51,7 +51,7 @@ The pre-task hook automatically handles topology selection:
 
 ## Direct Optimization
 ```
-Tool: mcp__claude-flow__topology_optimize
+Tool: mcp__moflo__topology_optimize
 Parameters: {"swarmId": "current"}
 ```
 

--- a/src/@claude-flow/mcp/.claude/commands/optimization/parallel-execution.md
+++ b/src/@claude-flow/mcp/.claude/commands/optimization/parallel-execution.md
@@ -7,7 +7,7 @@ Execute independent subtasks in parallel for maximum efficiency.
 
 ### 1. Task Decomposition
 ```
-Tool: mcp__claude-flow__task_orchestrate
+Tool: mcp__moflo__task_orchestrate
 Parameters: {
   "task": "Build complete REST API with auth, CRUD operations, and tests",
   "strategy": "parallel",
@@ -43,7 +43,7 @@ npx claude-flow parallel "Build REST API" --max-agents 8
 
 ## Monitoring
 ```
-Tool: mcp__claude-flow__swarm_monitor
+Tool: mcp__moflo__swarm_monitor
 Parameters: {"interval": 1000, "swarmId": "current"}
 ```
 

--- a/src/@claude-flow/mcp/.claude/commands/sparc/analyzer.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/analyzer.md
@@ -7,7 +7,7 @@ Deep code and data analysis with batch processing capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "analyzer",
   task_description: "analyze codebase performance",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/architect.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/architect.md
@@ -7,7 +7,7 @@ System design with Memory-based coordination for scalable architectures.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design microservices architecture",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/ask.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/ask.md
@@ -36,7 +36,7 @@ Help users craft `new_task` messages to delegate effectively, and always remind 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "ask",
   task_description: "help me choose the right mode",
   options: {
@@ -72,7 +72,7 @@ npx claude-flow sparc run ask "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "ask_context",
   value: "important decisions",
@@ -80,7 +80,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "ask",
   namespace: "ask",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/batch-executor.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/batch-executor.md
@@ -7,7 +7,7 @@ Parallel task execution specialist using batch operations.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "batch-executor",
   task_description: "process multiple files",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/code.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/code.md
@@ -28,7 +28,7 @@ Write modular code using clean architecture principles. Never hardcode secrets o
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "code",
   task_description: "implement REST API endpoints",
   options: {
@@ -64,7 +64,7 @@ npx claude-flow sparc run code "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "code_context",
   value: "important decisions",
@@ -72,7 +72,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "code",
   namespace: "code",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/coder.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/coder.md
@@ -7,7 +7,7 @@ Autonomous code generation with batch file operations.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement user authentication",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/debug.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/debug.md
@@ -22,7 +22,7 @@ Use logs, traces, and stack analysis to isolate bugs. Avoid changing env configu
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "debug",
   task_description: "fix memory leak in service",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run debug "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "debug_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "debug",
   namespace: "debug",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/debugger.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/debugger.md
@@ -7,7 +7,7 @@ Systematic debugging with TodoWrite and Memory integration.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "debugger",
   task_description: "fix authentication issues",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/designer.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/designer.md
@@ -7,7 +7,7 @@ UI/UX design with Memory coordination for consistent experiences.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "designer",
   task_description: "create dashboard UI",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/devops.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/devops.md
@@ -48,7 +48,7 @@ Return `attempt_completion` with:
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "devops",
   task_description: "deploy to AWS Lambda",
   options: {
@@ -84,7 +84,7 @@ npx claude-flow sparc run devops "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "devops_context",
   value: "important decisions",
@@ -92,7 +92,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "devops",
   namespace: "devops",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/docs-writer.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/docs-writer.md
@@ -19,7 +19,7 @@ Only work in .md files. Use sections, examples, and headings. Keep each file und
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "docs-writer",
   task_description: "create API documentation",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run docs-writer "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "docs-writer_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "docs-writer",
   namespace: "docs-writer",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/documenter.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/documenter.md
@@ -7,7 +7,7 @@ Documentation with batch file operations for comprehensive docs.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "create API documentation",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/innovator.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/innovator.md
@@ -7,7 +7,7 @@ Creative problem solving with WebSearch and Memory integration.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "innovative solutions for scaling",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/integration.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/integration.md
@@ -22,7 +22,7 @@ Verify interface compatibility, shared modules, and env config standards. Split 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "integration",
   task_description: "connect payment service",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run integration "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "integration_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "integration",
   namespace: "integration",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/mcp.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/mcp.md
@@ -56,7 +56,7 @@ For accessing MCP resources, use `access_mcp_resource` with proper URI:
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "mcp",
   task_description: "integrate with external API",
   options: {
@@ -92,7 +92,7 @@ npx claude-flow sparc run mcp "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "mcp_context",
   value: "important decisions",
@@ -100,7 +100,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "mcp",
   namespace: "mcp",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/memory-manager.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/memory-manager.md
@@ -7,7 +7,7 @@ Knowledge management with Memory tools for persistent insights.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "memory-manager",
   task_description: "organize project knowledge",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/optimizer.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/optimizer.md
@@ -7,7 +7,7 @@ Performance optimization with systematic analysis and improvements.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "optimizer",
   task_description: "optimize application performance",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/orchestrator.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/orchestrator.md
@@ -7,7 +7,7 @@ Multi-agent task orchestration with TodoWrite/TodoRead/Task/Memory using MCP too
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "coordinate feature development"
 }
@@ -40,20 +40,20 @@ npx claude-flow@alpha sparc run orchestrator "coordinate feature development"
 ### Using MCP Tools (Preferred)
 ```javascript
 // Initialize orchestration swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "auto",
   maxAgents: 8
 }
 
 // Spawn coordinator agent
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "coordinator",
   capabilities: ["task-planning", "resource-management"]
 }
 
 // Orchestrate tasks
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "feature development",
   strategy: "parallel",
   dependencies: ["auth", "ui", "api"]
@@ -91,26 +91,26 @@ npx claude-flow task orchestrate --task "feature development" --strategy paralle
 ### Using MCP Tools (Preferred)
 ```javascript
 // 1. Initialize orchestration swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 10
 }
 
 // 2. Create workflow
-mcp__claude-flow__workflow_create {
+mcp__moflo__workflow_create {
   name: "feature-development",
   steps: ["design", "implement", "test", "deploy"]
 }
 
 // 3. Execute orchestration
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   options: {parallel: true, monitor: true},
   task_description: "develop user management system"
 }
 
 // 4. Monitor progress
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }

--- a/src/@claude-flow/mcp/.claude/commands/sparc/post-deployment-monitoring-mode.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/post-deployment-monitoring-mode.md
@@ -22,7 +22,7 @@ Configure metrics, logs, uptime checks, and alerts. Recommend improvements if th
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "post-deployment-monitoring-mode",
   task_description: "monitor production metrics",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run post-deployment-monitoring-mode "your task" --non-inte
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "post-deployment-monitoring-mode_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "post-deployment-monitoring-mode",
   namespace: "post-deployment-monitoring-mode",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/refinement-optimization-mode.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/refinement-optimization-mode.md
@@ -22,7 +22,7 @@ Audit files for clarity, modularity, and size. Break large components (>500 line
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "refinement-optimization-mode",
   task_description: "optimize database queries",
   options: {
@@ -58,7 +58,7 @@ npx claude-flow sparc run refinement-optimization-mode "your task" --non-interac
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "refinement-optimization-mode_context",
   value: "important decisions",
@@ -66,7 +66,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "refinement-optimization-mode",
   namespace: "refinement-optimization-mode",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/researcher.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/researcher.md
@@ -7,7 +7,7 @@ Deep research with parallel WebSearch/WebFetch and Memory coordination.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research AI trends 2024",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/reviewer.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/reviewer.md
@@ -7,7 +7,7 @@ Code review using batch file analysis for comprehensive reviews.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review pull request #123",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/security-review.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/security-review.md
@@ -19,7 +19,7 @@ Scan for exposed secrets, env leaks, and monoliths. Recommend mitigations or ref
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "security-review",
   task_description: "audit API security",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run security-review "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "security-review_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "security-review",
   namespace: "security-review",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/sparc-modes.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/sparc-modes.md
@@ -34,7 +34,7 @@ SPARC (Specification, Planning, Architecture, Review, Code) is a comprehensive d
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
 // Execute SPARC mode directly
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "<mode>",
   task_description: "<task>",
   options: {
@@ -43,20 +43,20 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Initialize swarm for advanced coordination
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "auto",
   maxAgents: 8
 }
 
 // Spawn specialized agents
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "<agent-type>",
   capabilities: ["<capability1>", "<capability2>"]
 }
 
 // Monitor execution
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
@@ -93,31 +93,31 @@ npx claude-flow sparc run <mode> "task" --parallel --monitor
 #### Using MCP Tools (Preferred)
 ```javascript
 // 1. Initialize development swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 12
 }
 
 // 2. Architecture design
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design microservices"
 }
 
 // 3. Implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement services"
 }
 
 // 4. Testing
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "test all services"
 }
 
 // 5. Review
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review implementation"
 }
@@ -143,19 +143,19 @@ npx claude-flow sparc run reviewer "review implementation"
 #### Using MCP Tools (Preferred)
 ```javascript
 // 1. Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research best practices"
 }
 
 // 2. Innovation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "propose novel solutions"
 }
 
 // 3. Documentation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "document findings"
 }

--- a/src/@claude-flow/mcp/.claude/commands/sparc/sparc.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/sparc.md
@@ -50,7 +50,7 @@ use new_task for each new task as a sub-task.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "sparc",
   task_description: "orchestrate authentication system",
   options: {
@@ -86,7 +86,7 @@ npx claude-flow sparc run sparc "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "sparc_context",
   value: "important decisions",
@@ -94,7 +94,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "sparc",
   namespace: "sparc",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/spec-pseudocode.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/spec-pseudocode.md
@@ -19,7 +19,7 @@ Write pseudocode as a series of md files with phase_number_name.md and flow logi
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "spec-pseudocode",
   task_description: "define payment flow requirements",
   options: {
@@ -55,7 +55,7 @@ npx claude-flow sparc run spec-pseudocode "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "spec-pseudocode_context",
   value: "important decisions",
@@ -63,7 +63,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "spec-pseudocode",
   namespace: "spec-pseudocode",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/supabase-admin.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/supabase-admin.md
@@ -287,7 +287,7 @@ Rebases a development branch on production. This will effectively run any newer 
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "supabase-admin",
   task_description: "create user authentication schema",
   options: {
@@ -323,7 +323,7 @@ npx claude-flow sparc run supabase-admin "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "supabase-admin_context",
   value: "important decisions",
@@ -331,7 +331,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "supabase-admin",
   namespace: "supabase-admin",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/swarm-coordinator.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/swarm-coordinator.md
@@ -7,7 +7,7 @@ Specialized swarm management with batch coordination capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "swarm-coordinator",
   task_description: "manage development swarm",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/tdd.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/tdd.md
@@ -7,7 +7,7 @@ Test-driven development with TodoWrite planning and comprehensive testing.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "shopping cart feature",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/tester.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/tester.md
@@ -7,7 +7,7 @@ Comprehensive testing with parallel execution capabilities.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "full regression suite",
   options: {

--- a/src/@claude-flow/mcp/.claude/commands/sparc/tutorial.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/tutorial.md
@@ -18,7 +18,7 @@ You teach developers how to apply the SPARC methodology through actionable examp
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tutorial",
   task_description: "guide me through SPARC methodology",
   options: {
@@ -54,7 +54,7 @@ npx claude-flow sparc run tutorial "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "tutorial_context",
   value: "important decisions",
@@ -62,7 +62,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Query previous work
-mcp__claude-flow__memory_search {
+mcp__moflo__memory_search {
   pattern: "tutorial",
   namespace: "tutorial",
   limit: 5

--- a/src/@claude-flow/mcp/.claude/commands/sparc/workflow-manager.md
+++ b/src/@claude-flow/mcp/.claude/commands/sparc/workflow-manager.md
@@ -7,7 +7,7 @@ Process automation with TodoWrite planning and Task execution.
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "workflow-manager",
   task_description: "automate deployment",
   options: {

--- a/src/@claude-flow/mcp/.claude/helpers/setup-mcp.sh
+++ b/src/@claude-flow/mcp/.claude/helpers/setup-mcp.sh
@@ -12,7 +12,7 @@ fi
 
 # Add MCP server
 echo "📦 Adding Claude Flow MCP server..."
-claude mcp add claude-flow npx claude-flow mcp start
+claude mcp add moflo npx moflo mcp start
 
 echo "✅ MCP server setup complete!"
-echo "🎯 You can now use mcp__claude-flow__ tools in Claude Code"
+echo "🎯 You can now use mcp__moflo__ tools in Claude Code"

--- a/src/@claude-flow/mcp/.claude/settings.json
+++ b/src/@claude-flow/mcp/.claude/settings.json
@@ -134,7 +134,7 @@
     "allow": [
       "Bash(npx claude-flow:*)",
       "Bash(npx @claude-flow/cli:*)",
-      "mcp__claude-flow__:*"
+      "mcp__moflo__:*"
     ],
     "deny": []
   },

--- a/src/@claude-flow/mcp/.claude/skills/github-code-review/SKILL.md
+++ b/src/@claude-flow/mcp/.claude/skills/github-code-review/SKILL.md
@@ -1027,10 +1027,10 @@ fi
 ```javascript
 [Single Message - Parallel Execution]:
   // Initialize coordination
-  mcp__claude-flow__swarm_init { topology: "hierarchical", maxAgents: 5 }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
+  mcp__moflo__swarm_init { topology: "hierarchical", maxAgents: 5 }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Senior Reviewer" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Merge Coordinator" }
 
   // Create and manage PR using gh CLI
   Bash("gh pr create --title 'Feature: Add authentication' --base main")

--- a/src/@claude-flow/mcp/.claude/skills/github-multi-repo/SKILL.md
+++ b/src/@claude-flow/mcp/.claude/skills/github-multi-repo/SKILL.md
@@ -90,7 +90,7 @@ const DEPS = Bash(`gh repo list my-organization --json name | \
   done | jq -s '.'`)
 
 // Initialize swarm with discovered repositories
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   topology: "hierarchical",
   maxAgents: 8,
   metadata: { repos: REPOS, dependencies: DEPS }
@@ -145,7 +145,7 @@ mcp__claude-flow__swarm_init({
 // Synchronize package dependencies and versions
 [Complete Package Sync]:
   // Initialize sync swarm
-  mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 5 })
+  mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 5 })
 
   // Spawn sync agents
   Task("Sync Coordinator", "Coordinate version alignment", "coordinator")
@@ -169,7 +169,7 @@ mcp__claude-flow__swarm_init({
     -f content="$(cat aligned-package.json | base64)"`)
 
   // Store sync state
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "sync/packages/status",
     value: {
@@ -196,7 +196,7 @@ mcp__claude-flow__swarm_init({
     -f content="$(cat /tmp/claude-source.md | base64)"`)
 
   // Track sync status
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "sync/documentation/status",
     value: { status: "synchronized", files: ["CLAUDE.md"] }
@@ -246,7 +246,7 @@ mcp__claude-flow__swarm_init({
 // Analyze and optimize repository structure
 [Architecture Analysis]:
   // Initialize architecture swarm
-  mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 6 })
+  mcp__moflo__swarm_init({ topology: "hierarchical", maxAgents: 6 })
 
   // Spawn architecture agents
   Task("Senior Architect", "Analyze repository structure", "architect")
@@ -266,7 +266,7 @@ mcp__claude-flow__swarm_init({
     --order desc`)
 
   // Store analysis results
-  mcp__claude-flow__memory_usage({
+  mcp__moflo__memory_usage({
     action: "store",
     key: "architecture/analysis/results",
     value: {
@@ -406,7 +406,7 @@ Part of #$TRACKING_ISSUE"
 // Coordinate large-scale refactoring
 [Cross-Repo Refactoring]:
   // Initialize refactoring swarm
-  mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 8 })
+  mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 8 })
 
   // Spawn specialized agents
   Task("Refactoring Coordinator", "Coordinate refactoring across repos", "coordinator")
@@ -416,7 +416,7 @@ Part of #$TRACKING_ISSUE"
   Task("Integration Tester", "Validate refactored code", "tester")
 
   // Execute refactoring
-  mcp__claude-flow__task_orchestrate({
+  mcp__moflo__task_orchestrate({
     task: "Rename OldAPI to NewAPI across all repositories",
     strategy: "sequential",
     priority: "high"

--- a/src/@claude-flow/mcp/.claude/skills/github-project-management/SKILL.md
+++ b/src/@claude-flow/mcp/.claude/skills/github-project-management/SKILL.md
@@ -20,7 +20,7 @@ prerequisites:
   - Repository access permissions
 tools_required:
   - mcp__github__*
-  - mcp__claude-flow__*
+  - mcp__moflo__*
   - Bash
   - Read
   - Write
@@ -79,10 +79,10 @@ npx ruv-swarm github board-init \
 
 ```javascript
 // Initialize issue management swarm
-mcp__claude-flow__swarm_init { topology: "star", maxAgents: 3 }
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
-mcp__claude-flow__agent_spawn { type: "researcher", name: "Requirements Analyst" }
-mcp__claude-flow__agent_spawn { type: "coder", name: "Implementation Planner" }
+mcp__moflo__swarm_init { topology: "star", maxAgents: 3 }
+mcp__moflo__agent_spawn { type: "coordinator", name: "Issue Coordinator" }
+mcp__moflo__agent_spawn { type: "researcher", name: "Requirements Analyst" }
+mcp__moflo__agent_spawn { type: "coder", name: "Implementation Planner" }
 
 // Create comprehensive issue
 mcp__github__create_issue {
@@ -107,7 +107,7 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Monitor and coordinate issue progress with automated updates",
   strategy: "adaptive",
   priority: "medium"

--- a/src/@claude-flow/mcp/.claude/skills/github-release-management/SKILL.md
+++ b/src/@claude-flow/mcp/.claude/skills/github-release-management/SKILL.md
@@ -150,19 +150,19 @@ gh release create $(npm pkg get version) \
 ```javascript
 // Set up coordinated release team
 [Single Message - Swarm Initialization]:
-  mcp__claude-flow__swarm_init {
+  mcp__moflo__swarm_init {
     topology: "hierarchical",
     maxAgents: 6,
     strategy: "balanced"
   }
 
   // Spawn specialized agents
-  mcp__claude-flow__agent_spawn { type: "coordinator", name: "Release Director" }
-  mcp__claude-flow__agent_spawn { type: "coder", name: "Version Manager" }
-  mcp__claude-flow__agent_spawn { type: "tester", name: "QA Engineer" }
-  mcp__claude-flow__agent_spawn { type: "reviewer", name: "Release Reviewer" }
-  mcp__claude-flow__agent_spawn { type: "analyst", name: "Deployment Analyst" }
-  mcp__claude-flow__agent_spawn { type: "researcher", name: "Compatibility Checker" }
+  mcp__moflo__agent_spawn { type: "coordinator", name: "Release Director" }
+  mcp__moflo__agent_spawn { type: "coder", name: "Version Manager" }
+  mcp__moflo__agent_spawn { type: "tester", name: "QA Engineer" }
+  mcp__moflo__agent_spawn { type: "reviewer", name: "Release Reviewer" }
+  mcp__moflo__agent_spawn { type: "analyst", name: "Deployment Analyst" }
+  mcp__moflo__agent_spawn { type: "researcher", name: "Compatibility Checker" }
 ```
 
 #### Coordinated Release Workflow
@@ -172,7 +172,7 @@ gh release create $(npm pkg get version) \
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v2.0.0' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
 
   // Orchestrate release preparation
-  mcp__claude-flow__task_orchestrate {
+  mcp__moflo__task_orchestrate {
     task: "Prepare release v2.0.0 with comprehensive testing and validation",
     strategy: "sequential",
     priority: "critical",
@@ -204,7 +204,7 @@ gh release create $(npm pkg get version) \
   ]}
 
   // Store release state
-  mcp__claude-flow__memory_usage {
+  mcp__moflo__memory_usage {
     action: "store",
     key: "release/v2.0.0/status",
     value: JSON.stringify({
@@ -309,7 +309,7 @@ npx claude-flow github release-deploy \
 ```javascript
 [Single Message - Multi-Package Release]:
   // Initialize mesh topology for cross-package coordination
-  mcp__claude-flow__swarm_init { topology: "mesh", maxAgents: 8 }
+  mcp__moflo__swarm_init { topology: "mesh", maxAgents: 8 }
 
   // Spawn package-specific agents
   Task("Package A Manager", "Coordinate claude-flow package release v1.0.72", "coder")
@@ -394,7 +394,7 @@ npx claude-flow github multi-release \
 ```javascript
 [Single Message - Cross-Repo Release]:
   // Initialize star topology for centralized coordination
-  mcp__claude-flow__swarm_init { topology: "star", maxAgents: 6 }
+  mcp__moflo__swarm_init { topology: "star", maxAgents: 6 }
 
   // Spawn repo-specific coordinators
   Task("Frontend Release", "Release frontend v2.0.0 with API compatibility", "coordinator")
@@ -408,7 +408,7 @@ npx claude-flow github multi-release \
   Bash("gh api repos/org/cli/dispatches --method POST -f event_type='release' -F client_payload[version]=v1.5.0")
 
   // Monitor all releases
-  mcp__claude-flow__swarm_monitor { interval: 5, duration: 300 }
+  mcp__moflo__swarm_monitor { interval: 5, duration: 300 }
 ```
 
 ### Hotfix Emergency Procedures

--- a/src/@claude-flow/mcp/.claude/skills/github-workflow-automation/SKILL.md
+++ b/src/@claude-flow/mcp/.claude/skills/github-workflow-automation/SKILL.md
@@ -537,19 +537,19 @@ run().catch(error => core.setFailed(error.message));
 #### Initialize GitHub Swarm
 ```javascript
 // Step 1: Initialize swarm coordination
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 8
 }
 
 // Step 2: Spawn specialized agents
-mcp__claude-flow__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
-mcp__claude-flow__agent_spawn { type: "reviewer", name: "Code Reviewer" }
-mcp__claude-flow__agent_spawn { type: "tester", name: "QA Agent" }
-mcp__claude-flow__agent_spawn { type: "analyst", name: "Security Analyst" }
+mcp__moflo__agent_spawn { type: "coordinator", name: "GitHub Coordinator" }
+mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
+mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
+mcp__moflo__agent_spawn { type: "analyst", name: "Security Analyst" }
 
 // Step 3: Orchestrate GitHub workflow
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "Complete PR review and merge workflow",
   strategy: "parallel",
   priority: "high"

--- a/src/@claude-flow/mcp/.claude/skills/hooks-automation/SKILL.md
+++ b/src/@claude-flow/mcp/.claude/skills/hooks-automation/SKILL.md
@@ -602,12 +602,12 @@ Hooks automatically integrate with MCP tools for coordination:
 npx claude-flow hook pre-task --description "Build REST API"
 
 // Internally calls MCP tools:
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "backend-dev",
   capabilities: ["api", "database", "testing"]
 }
 
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/task/api-build/context",
   namespace: "coordination",
@@ -626,7 +626,7 @@ mcp__claude-flow__memory_usage {
 npx claude-flow hook post-edit --file "api/auth.js"
 
 // Internally calls MCP tools:
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/edits/api/auth.js",
   namespace: "coordination",
@@ -639,7 +639,7 @@ mcp__claude-flow__memory_usage {
   })
 }
 
-mcp__claude-flow__neural_train {
+mcp__moflo__neural_train {
   pattern_type: "coordination",
   training_data: { /* edit patterns */ }
 }
@@ -652,11 +652,11 @@ mcp__claude-flow__neural_train {
 npx claude-flow hook session-end --session-id "dev-2024"
 
 // Internally calls MCP tools:
-mcp__claude-flow__memory_persist {
+mcp__moflo__memory_persist {
   sessionId: "dev-2024"
 }
 
-mcp__claude-flow__swarm_status {
+mcp__moflo__swarm_status {
   swarmId: "current"
 }
 
@@ -671,7 +671,7 @@ All hooks follow a standardized memory coordination pattern:
 
 **Phase 1: STATUS** - Hook starts
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/status",
   namespace: "coordination",
@@ -686,7 +686,7 @@ mcp__claude-flow__memory_usage {
 
 **Phase 2: PROGRESS** - Hook processes
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/progress",
   namespace: "coordination",
@@ -700,7 +700,7 @@ mcp__claude-flow__memory_usage {
 
 **Phase 3: COMPLETE** - Hook finishes
 ```javascript
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   key: "swarm/hooks/pre-edit/complete",
   namespace: "coordination",

--- a/src/@claude-flow/mcp/.claude/skills/sparc-methodology/SKILL.md
+++ b/src/@claude-flow/mcp/.claude/skills/sparc-methodology/SKILL.md
@@ -129,7 +129,7 @@ Multi-agent task orchestration with TodoWrite/Task/Memory coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "coordinate feature development",
   options: { parallel: true, monitor: true }
@@ -189,7 +189,7 @@ Autonomous code generation with batch file operations.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement user authentication with JWT",
   options: {
@@ -225,7 +225,7 @@ System design with Memory-based coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design scalable e-commerce platform",
   options: {
@@ -262,7 +262,7 @@ Test-driven development with comprehensive testing.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "shopping cart feature with payment integration",
   options: {
@@ -301,7 +301,7 @@ Code review using batch file analysis.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review authentication module PR #123",
   options: {
@@ -342,7 +342,7 @@ Deep research with parallel WebSearch/WebFetch and Memory coordination.
 
 **Usage**:
 ```javascript
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research microservices best practices 2024",
   options: {
@@ -447,7 +447,7 @@ Knowledge management and context preservation.
 
 ```javascript
 // Basic mode execution
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "<mode-name>",
   task_description: "<task description>",
   options: {
@@ -456,20 +456,20 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Initialize swarm for complex tasks
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",  // or "mesh", "ring", "star"
   strategy: "auto",           // or "balanced", "specialized", "adaptive"
   maxAgents: 8
 }
 
 // Spawn specialized agents
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "<agent-type>",
   capabilities: ["<capability1>", "<capability2>"]
 }
 
 // Monitor execution
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
@@ -524,22 +524,22 @@ npx claude-flow sparc pipeline "task description"
 
 ```javascript
 // Initialize hierarchical swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 12
 }
 
 // Spawn coordinator
-mcp__claude-flow__agent_spawn {
+mcp__moflo__agent_spawn {
   type: "coordinator",
   capabilities: ["planning", "delegation", "monitoring"]
 }
 
 // Spawn specialized workers
-mcp__claude-flow__agent_spawn { type: "architect" }
-mcp__claude-flow__agent_spawn { type: "coder" }
-mcp__claude-flow__agent_spawn { type: "tester" }
-mcp__claude-flow__agent_spawn { type: "reviewer" }
+mcp__moflo__agent_spawn { type: "architect" }
+mcp__moflo__agent_spawn { type: "coder" }
+mcp__moflo__agent_spawn { type: "tester" }
+mcp__moflo__agent_spawn { type: "reviewer" }
 ```
 
 ### Pattern 2: Mesh Coordination
@@ -547,7 +547,7 @@ mcp__claude-flow__agent_spawn { type: "reviewer" }
 **Best for**: Collaborative tasks requiring peer-to-peer communication
 
 ```javascript
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "mesh",
   strategy: "balanced",
   maxAgents: 6
@@ -559,7 +559,7 @@ mcp__claude-flow__swarm_init {
 **Best for**: Ordered workflow execution (spec → design → code → test → review)
 
 ```javascript
-mcp__claude-flow__workflow_create {
+mcp__moflo__workflow_create {
   name: "development-pipeline",
   steps: [
     { mode: "researcher", task: "gather requirements" },
@@ -577,7 +577,7 @@ mcp__claude-flow__workflow_create {
 **Best for**: Independent tasks that can run concurrently
 
 ```javascript
-mcp__claude-flow__task_orchestrate {
+mcp__moflo__task_orchestrate {
   task: "build full-stack application",
   strategy: "parallel",
   dependencies: {
@@ -594,7 +594,7 @@ mcp__claude-flow__task_orchestrate {
 **Best for**: Dynamic workloads with changing requirements
 
 ```javascript
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   strategy: "adaptive",  // Auto-adjusts based on workload
   maxAgents: 20
@@ -609,25 +609,25 @@ mcp__claude-flow__swarm_init {
 
 ```javascript
 // Step 1: Initialize TDD swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 8
 }
 
 // Step 2: Research and planning
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research testing best practices for feature X"
 }
 
 // Step 3: Architecture design
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design testable architecture for feature X"
 }
 
 // Step 4: TDD implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "implement feature X with 90% coverage",
   options: {
@@ -638,7 +638,7 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Step 5: Code review
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "review feature X implementation",
   options: {
@@ -648,7 +648,7 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Step 6: Optimization
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "optimizer",
   task_description: "optimize feature X performance"
 }
@@ -658,21 +658,21 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // RED: Write failing test
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "create failing test for shopping cart add item",
   options: { expect_failure: true }
 }
 
 // GREEN: Minimal implementation
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement minimal code to pass test",
   options: { minimal: true }
 }
 
 // REFACTOR: Improve code quality
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "refactor shopping cart implementation",
   options: { maintain_tests: true }
@@ -689,7 +689,7 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // Store architectural decisions
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "store",
   namespace: "architecture",
   key: "api-design-v1",
@@ -698,7 +698,7 @@ mcp__claude-flow__memory_usage {
 }
 
 // Retrieve in subsequent agents
-mcp__claude-flow__memory_usage {
+mcp__moflo__memory_usage {
   action: "retrieve",
   namespace: "architecture",
   key: "api-design-v1"
@@ -712,14 +712,14 @@ mcp__claude-flow__memory_usage {
 ```javascript
 // ✅ CORRECT: All operations together
 [Single Message]:
-  mcp__claude-flow__agent_spawn { type: "researcher" }
-  mcp__claude-flow__agent_spawn { type: "coder" }
-  mcp__claude-flow__agent_spawn { type: "tester" }
+  mcp__moflo__agent_spawn { type: "researcher" }
+  mcp__moflo__agent_spawn { type: "coder" }
+  mcp__moflo__agent_spawn { type: "tester" }
   TodoWrite { todos: [8-10 todos] }
 
 // ❌ WRONG: Multiple messages
-Message 1: mcp__claude-flow__agent_spawn { type: "researcher" }
-Message 2: mcp__claude-flow__agent_spawn { type: "coder" }
+Message 1: mcp__moflo__agent_spawn { type: "researcher" }
+Message 2: mcp__moflo__agent_spawn { type: "coder" }
 Message 3: TodoWrite { todos: [...] }
 ```
 
@@ -782,40 +782,40 @@ project/
 [Single Message - Parallel Agent Execution]:
 
 // Initialize swarm
-mcp__claude-flow__swarm_init {
+mcp__moflo__swarm_init {
   topology: "hierarchical",
   maxAgents: 10
 }
 
 // Architecture phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design REST API with authentication",
   options: { memory_enabled: true }
 }
 
 // Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research authentication best practices"
 }
 
 // Implementation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement Express API with JWT auth",
   options: { test_driven: true }
 }
 
 // Testing phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tdd",
   task_description: "comprehensive API tests",
   options: { coverage_target: 90 }
 }
 
 // Review phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "security and performance review",
   options: { security_check: true }
@@ -840,7 +840,7 @@ TodoWrite {
 
 ```javascript
 // Research phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "researcher",
   task_description: "research AI-powered search implementations",
   options: {
@@ -850,27 +850,27 @@ mcp__claude-flow__sparc_mode {
 }
 
 // Innovation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "innovator",
   task_description: "propose novel search algorithm",
   options: { memory_enabled: true }
 }
 
 // Architecture phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "architect",
   task_description: "design scalable search system"
 }
 
 // Implementation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "implement search algorithm",
   options: { test_driven: true }
 }
 
 // Documentation phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "documenter",
   task_description: "document search system architecture and API"
 }
@@ -880,33 +880,33 @@ mcp__claude-flow__sparc_mode {
 
 ```javascript
 // Analysis phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "analyzer",
   task_description: "analyze legacy codebase dependencies"
 }
 
 // Planning phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "orchestrator",
   task_description: "plan incremental refactoring strategy"
 }
 
 // Testing phase (create safety net)
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "tester",
   task_description: "create comprehensive test suite for legacy code",
   options: { coverage_target: 80 }
 }
 
 // Refactoring phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "coder",
   task_description: "refactor module X with modern patterns",
   options: { maintain_tests: true }
 }
 
 // Review phase
-mcp__claude-flow__sparc_mode {
+mcp__moflo__sparc_mode {
   mode: "reviewer",
   task_description: "validate refactoring maintains functionality"
 }
@@ -991,7 +991,7 @@ npx claude-flow sparc pipeline "e-commerce checkout feature"
 
 ```javascript
 // Train patterns from successful workflows
-mcp__claude-flow__neural_train {
+mcp__moflo__neural_train {
   pattern_type: "coordination",
   training_data: "successful_tdd_workflow.json",
   epochs: 50
@@ -1002,12 +1002,12 @@ mcp__claude-flow__neural_train {
 
 ```javascript
 // Save session state
-mcp__claude-flow__memory_persist {
+mcp__moflo__memory_persist {
   sessionId: "feature-auth-v1"
 }
 
 // Restore in new session
-mcp__claude-flow__context_restore {
+mcp__moflo__context_restore {
   snapshotId: "feature-auth-v1"
 }
 ```
@@ -1016,13 +1016,13 @@ mcp__claude-flow__context_restore {
 
 ```javascript
 // Analyze repository
-mcp__claude-flow__github_repo_analyze {
+mcp__moflo__github_repo_analyze {
   repo: "owner/repo",
   analysis_type: "code_quality"
 }
 
 // Manage pull requests
-mcp__claude-flow__github_pr_manage {
+mcp__moflo__github_pr_manage {
   repo: "owner/repo",
   pr_number: 123,
   action: "review"
@@ -1033,19 +1033,19 @@ mcp__claude-flow__github_pr_manage {
 
 ```javascript
 // Real-time swarm monitoring
-mcp__claude-flow__swarm_monitor {
+mcp__moflo__swarm_monitor {
   swarmId: "current",
   interval: 5000
 }
 
 // Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze {
+mcp__moflo__bottleneck_analyze {
   component: "api-layer",
   metrics: ["latency", "throughput", "errors"]
 }
 
 // Token usage tracking
-mcp__claude-flow__token_usage {
+mcp__moflo__token_usage {
   operation: "feature-development",
   timeframe: "24h"
 }
@@ -1098,16 +1098,16 @@ npx claude-flow sparc batch <modes> "task"
 
 ```javascript
 // Initialize swarm
-mcp__claude-flow__swarm_init { topology: "hierarchical" }
+mcp__moflo__swarm_init { topology: "hierarchical" }
 
 // Execute mode
-mcp__claude-flow__sparc_mode { mode: "coder", task_description: "..." }
+mcp__moflo__sparc_mode { mode: "coder", task_description: "..." }
 
 // Monitor progress
-mcp__claude-flow__swarm_monitor { interval: 5000 }
+mcp__moflo__swarm_monitor { interval: 5000 }
 
 // Store in memory
-mcp__claude-flow__memory_usage { action: "store", key: "...", value: "..." }
+mcp__moflo__memory_usage { action: "store", key: "...", value: "..." }
 ```
 
 ---

--- a/src/@claude-flow/mcp/.claude/skills/swarm-advanced/SKILL.md
+++ b/src/@claude-flow/mcp/.claude/skills/swarm-advanced/SKILL.md
@@ -19,19 +19,19 @@ Master advanced swarm patterns for distributed research, development, and testin
 npm install -g claude-flow@alpha
 
 # Add MCP server (if using MCP tools)
-claude mcp add claude-flow npx claude-flow@alpha mcp start
+claude mcp add moflo npx moflo mcp start
 ```
 
 ### Basic Pattern
 ```javascript
 // 1. Initialize swarm topology
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 6 })
 
 // 2. Spawn specialized agents
-mcp__claude-flow__agent_spawn({ type: "researcher", name: "Agent 1" })
+mcp__moflo__agent_spawn({ type: "researcher", name: "Agent 1" })
 
 // 3. Orchestrate tasks
-mcp__claude-flow__task_orchestrate({ task: "...", strategy: "parallel" })
+mcp__moflo__task_orchestrate({ task: "...", strategy: "parallel" })
 ```
 
 ## Core Concepts
@@ -73,7 +73,7 @@ Deep research through parallel information gathering, analysis, and synthesis.
 ### Architecture
 ```javascript
 // Initialize research swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 6,
   "strategy": "adaptive"
@@ -110,7 +110,7 @@ const researchAgents = [
 
 // Spawn all agents
 researchAgents.forEach(agent => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: agent.type,
     name: agent.name,
     capabilities: agent.capabilities
@@ -123,7 +123,7 @@ researchAgents.forEach(agent => {
 #### Phase 1: Information Gathering
 ```javascript
 // Parallel information collection
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "web-search",
@@ -145,7 +145,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Store research findings in memory
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "research-findings-" + Date.now(),
   "value": JSON.stringify(findings),
@@ -157,24 +157,24 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Analysis and Validation
 ```javascript
 // Pattern recognition in findings
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": researchData,
   "patterns": ["trend", "correlation", "outlier", "emerging-pattern"]
 })
 
 // Cognitive analysis
-mcp__claude-flow__cognitive_analyze({
+mcp__moflo__cognitive_analyze({
   "behavior": "research-synthesis"
 })
 
 // Quality assessment
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "research-sources",
   "criteria": ["credibility", "relevance", "recency", "authority"]
 })
 
 // Cross-reference validation
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "analyze",
   "operation": "fact-checking",
   "metadata": { "sources": sourcesArray }
@@ -184,14 +184,14 @@ mcp__claude-flow__neural_patterns({
 #### Phase 3: Knowledge Management
 ```javascript
 // Search existing knowledge base
-mcp__claude-flow__memory_search({
+mcp__moflo__memory_search({
   "pattern": "topic X",
   "namespace": "research",
   "limit": 20
 })
 
 // Create knowledge graph connections
-mcp__claude-flow__neural_patterns({
+mcp__moflo__neural_patterns({
   "action": "learn",
   "operation": "knowledge-graph",
   "metadata": {
@@ -202,7 +202,7 @@ mcp__claude-flow__neural_patterns({
 })
 
 // Store connections for future use
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "knowledge-graph-X",
   "value": JSON.stringify(knowledgeGraph),
@@ -214,7 +214,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 4: Report Generation
 ```javascript
 // Orchestrate report generation
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "generate comprehensive research report",
   "strategy": "sequential",
   "priority": "high",
@@ -222,12 +222,12 @@ mcp__claude-flow__task_orchestrate({
 })
 
 // Monitor research progress
-mcp__claude-flow__swarm_status({
+mcp__moflo__swarm_status({
   "swarmId": "research-swarm"
 })
 
 // Generate final report
-mcp__claude-flow__workflow_execute({
+mcp__moflo__workflow_execute({
   "workflowId": "research-report-generation",
   "params": {
     "findings": findings,
@@ -256,7 +256,7 @@ Full-stack development through coordinated specialist agents.
 ### Architecture
 ```javascript
 // Initialize development swarm with hierarchy
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "hierarchical",
   "maxAgents": 8,
   "strategy": "balanced"
@@ -276,7 +276,7 @@ const devTeam = [
 
 // Spawn all team members
 devTeam.forEach(member => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: member.type,
     name: member.name,
     capabilities: member.capabilities,
@@ -290,7 +290,7 @@ devTeam.forEach(member => {
 #### Phase 1: Architecture and Design
 ```javascript
 // System architecture design
-mcp__claude-flow__task_orchestrate({
+mcp__moflo__task_orchestrate({
   "task": "design system architecture for REST API",
   "strategy": "sequential",
   "priority": "critical",
@@ -298,7 +298,7 @@ mcp__claude-flow__task_orchestrate({
 })
 
 // Store architecture decisions
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "architecture-decisions",
   "value": JSON.stringify(architectureDoc),
@@ -309,7 +309,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Parallel Implementation
 ```javascript
 // Parallel development tasks
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "backend-api",
@@ -335,7 +335,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Monitor development progress
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "dev-swarm",
   "interval": 5000
 })
@@ -344,7 +344,7 @@ mcp__claude-flow__swarm_monitor({
 #### Phase 3: Testing and Validation
 ```javascript
 // Comprehensive testing
-mcp__claude-flow__batch_process({
+mcp__moflo__batch_process({
   "items": [
     { type: "unit", target: "all-modules" },
     { type: "integration", target: "api-endpoints" },
@@ -355,7 +355,7 @@ mcp__claude-flow__batch_process({
 })
 
 // Quality assessment
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "codebase",
   "criteria": ["coverage", "complexity", "maintainability", "security"]
 })
@@ -364,7 +364,7 @@ mcp__claude-flow__quality_assess({
 #### Phase 4: Review and Deployment
 ```javascript
 // Code review workflow
-mcp__claude-flow__workflow_execute({
+mcp__moflo__workflow_execute({
   "workflowId": "code-review-process",
   "params": {
     "reviewers": ["Code Reviewer"],
@@ -373,7 +373,7 @@ mcp__claude-flow__workflow_execute({
 })
 
 // CI/CD pipeline
-mcp__claude-flow__pipeline_create({
+mcp__moflo__pipeline_create({
   "config": {
     "stages": ["build", "test", "security-scan", "deploy"],
     "environment": "production"
@@ -399,7 +399,7 @@ Comprehensive quality assurance through distributed testing.
 ### Architecture
 ```javascript
 // Initialize testing swarm with star topology
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "star",
   "maxAgents": 7,
   "strategy": "parallel"
@@ -446,7 +446,7 @@ const testingTeam = [
 
 // Spawn all testers
 testingTeam.forEach(tester => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: tester.type,
     name: tester.name,
     capabilities: tester.capabilities,
@@ -460,7 +460,7 @@ testingTeam.forEach(tester => {
 #### Phase 1: Test Planning
 ```javascript
 // Analyze test coverage requirements
-mcp__claude-flow__quality_assess({
+mcp__moflo__quality_assess({
   "target": "test-coverage",
   "criteria": [
     "line-coverage",
@@ -471,7 +471,7 @@ mcp__claude-flow__quality_assess({
 })
 
 // Identify test scenarios
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": testScenarios,
   "patterns": [
     "edge-case",
@@ -482,7 +482,7 @@ mcp__claude-flow__pattern_recognize({
 })
 
 // Store test plan
-mcp__claude-flow__memory_usage({
+mcp__moflo__memory_usage({
   "action": "store",
   "key": "test-plan-" + Date.now(),
   "value": JSON.stringify(testPlan),
@@ -493,7 +493,7 @@ mcp__claude-flow__memory_usage({
 #### Phase 2: Parallel Test Execution
 ```javascript
 // Execute all test suites in parallel
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     {
       "id": "unit-tests",
@@ -524,7 +524,7 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Batch process test suites
-mcp__claude-flow__batch_process({
+mcp__moflo__batch_process({
   "items": testSuites,
   "operation": "execute-test-suite"
 })
@@ -533,24 +533,24 @@ mcp__claude-flow__batch_process({
 #### Phase 3: Performance and Security
 ```javascript
 // Run performance benchmarks
-mcp__claude-flow__benchmark_run({
+mcp__moflo__benchmark_run({
   "suite": "comprehensive-performance"
 })
 
 // Bottleneck analysis
-mcp__claude-flow__bottleneck_analyze({
+mcp__moflo__bottleneck_analyze({
   "component": "application",
   "metrics": ["response-time", "throughput", "memory", "cpu"]
 })
 
 // Security scanning
-mcp__claude-flow__security_scan({
+mcp__moflo__security_scan({
   "target": "application",
   "depth": "comprehensive"
 })
 
 // Vulnerability analysis
-mcp__claude-flow__error_analysis({
+mcp__moflo__error_analysis({
   "logs": securityScanLogs
 })
 ```
@@ -558,24 +558,24 @@ mcp__claude-flow__error_analysis({
 #### Phase 4: Monitoring and Reporting
 ```javascript
 // Real-time test monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "testing-swarm",
   "interval": 2000
 })
 
 // Generate comprehensive test report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current-run"
 })
 
 // Get test results
-mcp__claude-flow__task_results({
+mcp__moflo__task_results({
   "taskId": "test-execution-001"
 })
 
 // Trend analysis
-mcp__claude-flow__trend_analysis({
+mcp__moflo__trend_analysis({
   "metric": "test-coverage",
   "period": "30d"
 })
@@ -599,7 +599,7 @@ Deep code and system analysis through specialized analyzers.
 ### Architecture
 ```javascript
 // Initialize analysis swarm
-mcp__claude-flow__swarm_init({
+mcp__moflo__swarm_init({
   "topology": "mesh",
   "maxAgents": 5,
   "strategy": "adaptive"
@@ -636,7 +636,7 @@ const analysisTeam = [
 
 // Spawn all analysts
 analysisTeam.forEach(analyst => {
-  mcp__claude-flow__agent_spawn({
+  mcp__moflo__agent_spawn({
     type: analyst.type,
     name: analyst.name,
     capabilities: analyst.capabilities
@@ -647,7 +647,7 @@ analysisTeam.forEach(analyst => {
 ### Analysis Workflow
 ```javascript
 // Parallel analysis execution
-mcp__claude-flow__parallel_execute({
+mcp__moflo__parallel_execute({
   "tasks": [
     { "id": "analyze-code", "command": "analyze codebase structure and quality" },
     { "id": "analyze-security", "command": "scan for security vulnerabilities" },
@@ -657,13 +657,13 @@ mcp__claude-flow__parallel_execute({
 })
 
 // Generate comprehensive analysis report
-mcp__claude-flow__performance_report({
+mcp__moflo__performance_report({
   "format": "detailed",
   "timeframe": "current"
 })
 
 // Cost analysis
-mcp__claude-flow__cost_analysis({
+mcp__moflo__cost_analysis({
   "timeframe": "30d"
 })
 ```
@@ -674,30 +674,30 @@ mcp__claude-flow__cost_analysis({
 
 ```javascript
 // Setup fault tolerance for all agents
-mcp__claude-flow__daa_fault_tolerance({
+mcp__moflo__daa_fault_tolerance({
   "agentId": "all",
   "strategy": "auto-recovery"
 })
 
 // Error handling pattern
 try {
-  await mcp__claude-flow__task_orchestrate({
+  await mcp__moflo__task_orchestrate({
     "task": "complex operation",
     "strategy": "parallel",
     "priority": "high"
   })
 } catch (error) {
   // Check swarm health
-  const status = await mcp__claude-flow__swarm_status({})
+  const status = await mcp__moflo__swarm_status({})
 
   // Analyze error patterns
-  await mcp__claude-flow__error_analysis({
+  await mcp__moflo__error_analysis({
     "logs": [error.message]
   })
 
   // Auto-recovery attempt
   if (status.healthy) {
-    await mcp__claude-flow__task_orchestrate({
+    await mcp__moflo__task_orchestrate({
       "task": "retry failed operation",
       "strategy": "sequential"
     })
@@ -709,28 +709,28 @@ try {
 
 ```javascript
 // Cross-session persistence
-mcp__claude-flow__memory_persist({
+mcp__moflo__memory_persist({
   "sessionId": "swarm-session-001"
 })
 
 // Namespace management for different swarms
-mcp__claude-flow__memory_namespace({
+mcp__moflo__memory_namespace({
   "namespace": "research-swarm",
   "action": "create"
 })
 
 // Create state snapshot
-mcp__claude-flow__state_snapshot({
+mcp__moflo__state_snapshot({
   "name": "development-checkpoint-1"
 })
 
 // Restore from snapshot if needed
-mcp__claude-flow__context_restore({
+mcp__moflo__context_restore({
   "snapshotId": "development-checkpoint-1"
 })
 
 // Backup memory stores
-mcp__claude-flow__memory_backup({
+mcp__moflo__memory_backup({
   "path": "/workspaces/claude-code-flow/backups/swarm-memory.json"
 })
 ```
@@ -739,14 +739,14 @@ mcp__claude-flow__memory_backup({
 
 ```javascript
 // Train neural patterns from successful workflows
-mcp__claude-flow__neural_train({
+mcp__moflo__neural_train({
   "pattern_type": "coordination",
   "training_data": JSON.stringify(successfulWorkflows),
   "epochs": 50
 })
 
 // Adaptive learning from experience
-mcp__claude-flow__learning_adapt({
+mcp__moflo__learning_adapt({
   "experience": {
     "workflow": "research-to-report",
     "success": true,
@@ -756,7 +756,7 @@ mcp__claude-flow__learning_adapt({
 })
 
 // Pattern recognition for optimization
-mcp__claude-flow__pattern_recognize({
+mcp__moflo__pattern_recognize({
   "data": workflowMetrics,
   "patterns": ["bottleneck", "optimization-opportunity", "efficiency-gain"]
 })
@@ -766,7 +766,7 @@ mcp__claude-flow__pattern_recognize({
 
 ```javascript
 // Create reusable workflow
-mcp__claude-flow__workflow_create({
+mcp__moflo__workflow_create({
   "name": "full-stack-development",
   "steps": [
     { "phase": "design", "agents": ["architect"] },
@@ -779,7 +779,7 @@ mcp__claude-flow__workflow_create({
 })
 
 // Setup automation rules
-mcp__claude-flow__automation_setup({
+mcp__moflo__automation_setup({
   "rules": [
     {
       "trigger": "file-changed",
@@ -794,7 +794,7 @@ mcp__claude-flow__automation_setup({
 })
 
 // Event-driven triggers
-mcp__claude-flow__trigger_setup({
+mcp__moflo__trigger_setup({
   "events": ["code-commit", "PR-merge", "deployment"],
   "actions": ["test", "analyze", "document"]
 })
@@ -804,23 +804,23 @@ mcp__claude-flow__trigger_setup({
 
 ```javascript
 // Topology optimization
-mcp__claude-flow__topology_optimize({
+mcp__moflo__topology_optimize({
   "swarmId": "current-swarm"
 })
 
 // Load balancing
-mcp__claude-flow__load_balance({
+mcp__moflo__load_balance({
   "swarmId": "development-swarm",
   "tasks": taskQueue
 })
 
 // Agent coordination sync
-mcp__claude-flow__coordination_sync({
+mcp__moflo__coordination_sync({
   "swarmId": "development-swarm"
 })
 
 // Auto-scaling
-mcp__claude-flow__swarm_scale({
+mcp__moflo__swarm_scale({
   "swarmId": "development-swarm",
   "targetSize": 12
 })
@@ -830,28 +830,28 @@ mcp__claude-flow__swarm_scale({
 
 ```javascript
 // Real-time swarm monitoring
-mcp__claude-flow__swarm_monitor({
+mcp__moflo__swarm_monitor({
   "swarmId": "active-swarm",
   "interval": 3000
 })
 
 // Collect comprehensive metrics
-mcp__claude-flow__metrics_collect({
+mcp__moflo__metrics_collect({
   "components": ["agents", "tasks", "memory", "performance"]
 })
 
 // Health monitoring
-mcp__claude-flow__health_check({
+mcp__moflo__health_check({
   "components": ["swarm", "agents", "neural", "memory"]
 })
 
 // Usage statistics
-mcp__claude-flow__usage_stats({
+mcp__moflo__usage_stats({
   "component": "swarm-orchestration"
 })
 
 // Trend analysis
-mcp__claude-flow__trend_analysis({
+mcp__moflo__trend_analysis({
   "metric": "agent-performance",
   "period": "7d"
 })
@@ -906,7 +906,7 @@ mcp__claude-flow__trend_analysis({
 ### Example 1: AI Research Project
 ```javascript
 // Research AI trends, analyze findings, generate report
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 6 })
 // Spawn: 2 researchers, 2 analysts, 1 synthesizer, 1 documenter
 // Parallel gather → Analyze patterns → Synthesize → Report
 ```
@@ -914,7 +914,7 @@ mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 6 })
 ### Example 2: Full-Stack Application
 ```javascript
 // Build complete web application with testing
-mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 8 })
+mcp__moflo__swarm_init({ topology: "hierarchical", maxAgents: 8 })
 // Spawn: 1 architect, 2 devs, 1 db engineer, 2 testers, 1 reviewer, 1 devops
 // Design → Parallel implement → Test → Review → Deploy
 ```
@@ -922,7 +922,7 @@ mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 8 })
 ### Example 3: Security Audit
 ```javascript
 // Comprehensive security analysis
-mcp__claude-flow__swarm_init({ topology: "star", maxAgents: 5 })
+mcp__moflo__swarm_init({ topology: "star", maxAgents: 5 })
 // Spawn: 1 coordinator, 1 code analyzer, 1 security scanner, 1 penetration tester, 1 reporter
 // Parallel scan → Vulnerability analysis → Penetration test → Report
 ```
@@ -930,7 +930,7 @@ mcp__claude-flow__swarm_init({ topology: "star", maxAgents: 5 })
 ### Example 4: Performance Optimization
 ```javascript
 // Identify and fix performance bottlenecks
-mcp__claude-flow__swarm_init({ topology: "mesh", maxAgents: 4 })
+mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 4 })
 // Spawn: 1 profiler, 1 bottleneck analyzer, 1 optimizer, 1 tester
 // Profile → Identify bottlenecks → Optimize → Validate
 ```

--- a/src/@claude-flow/mcp/CLAUDE.md
+++ b/src/@claude-flow/mcp/CLAUDE.md
@@ -604,7 +604,7 @@ Run `npx @claude-flow/cli@latest doctor` to check:
 
 ```bash
 # Add MCP servers (auto-detects MCP mode when stdin is piped)
-claude mcp add claude-flow -- npx -y @claude-flow/cli@latest
+claude mcp add moflo -- npx -y @claude-flow/cli@latest
 claude mcp add ruv-swarm -- npx -y ruv-swarm mcp start  # Optional
 claude mcp add flow-nexus -- npx -y flow-nexus@latest mcp start  # Optional
 

--- a/src/@claude-flow/shared/src/core/config/defaults.ts
+++ b/src/@claude-flow/shared/src/core/config/defaults.ts
@@ -90,7 +90,7 @@ export const defaultMemoryConfig: MemoryConfig = {
  * Default MCP server configuration
  */
 export const defaultMCPServerConfig: MCPServerConfig = {
-  name: 'claude-flow',
+  name: 'moflo',
   version: '3.0.0',
   transport: {
     type: 'stdio',

--- a/src/@claude-flow/shared/src/core/config/loader.ts
+++ b/src/@claude-flow/shared/src/core/config/loader.ts
@@ -97,7 +97,7 @@ function loadEnvConfig(): Partial<SystemConfig> {
   }
 
   // MCP transport
-  const defaultMcp = defaultSystemConfig.mcp ?? { name: 'claude-flow', version: '3.0.0', transport: { type: 'stdio' as const } };
+  const defaultMcp = defaultSystemConfig.mcp ?? { name: 'moflo', version: '3.0.0', transport: { type: 'stdio' as const } };
   if (process.env.CLAUDE_FLOW_MCP_TRANSPORT) {
     const transport = process.env.CLAUDE_FLOW_MCP_TRANSPORT as 'stdio' | 'http' | 'websocket';
     if (['stdio', 'http', 'websocket'].includes(transport)) {

--- a/src/@claude-flow/shared/src/core/config/schema.ts
+++ b/src/@claude-flow/shared/src/core/config/schema.ts
@@ -114,7 +114,7 @@ export const MemoryConfigSchema = z.object({
  * MCP server configuration schema
  */
 export const MCPServerConfigSchema = z.object({
-  name: z.string().min(1).default('claude-flow'),
+  name: z.string().min(1).default('moflo'),
   version: z.string().min(1).default('3.0.0'),
   transport: z.object({
     type: z.enum(['stdio', 'http', 'websocket']).default('stdio'),

--- a/src/@claude-flow/shared/src/utils/secure-logger.ts
+++ b/src/@claude-flow/shared/src/utils/secure-logger.ts
@@ -238,7 +238,7 @@ export function createSecureLogger(prefix?: string, config?: Partial<LoggerConfi
 /**
  * Default logger instance
  */
-export const logger = createSecureLogger('claude-flow');
+export const logger = createSecureLogger('moflo');
 
 /**
  * Sanitize an error for safe logging/display

--- a/src/implementation/PLUGIN_INTEGRATION.md
+++ b/src/implementation/PLUGIN_INTEGRATION.md
@@ -167,12 +167,12 @@ Enable only specific hooks by choosing matchers:
 
 After installation, MCP tools are available:
 
-- `mcp__claude-flow__swarm_init`
-- `mcp__claude-flow__agent_spawn`
-- `mcp__claude-flow__task_orchestrate`
-- `mcp__claude-flow__memory_usage`
-- `mcp__claude-flow__hooks_route`
-- `mcp__claude-flow__hooks_metrics`
+- `mcp__moflo__swarm_init`
+- `mcp__moflo__agent_spawn`
+- `mcp__moflo__task_orchestrate`
+- `mcp__moflo__memory_usage`
+- `mcp__moflo__hooks_route`
+- `mcp__moflo__hooks_metrics`
 
 ## Marketplace Publishing
 

--- a/src/implementation/adrs/ADR-027-teammate-tool-integration.md
+++ b/src/implementation/adrs/ADR-027-teammate-tool-integration.md
@@ -1173,7 +1173,7 @@ const result = await handleMCPTool(bridge, 'teammate_spawn_team', {
 // In Claude Code conversation:
 
 // 1. Initialize team via MCP
-mcp__claude-flow__teammate_spawn_team({
+mcp__moflo__teammate_spawn_team({
   name: "feature-dev-team",
   topology: "hierarchical",
   maxTeammates: 6,
@@ -1304,7 +1304,7 @@ const teammateConfig: TeammateSpawnConfig = {
 
 ```typescript
 // Before: Pure MCP coordination
-mcp__claude-flow__swarm_init({ topology: 'hierarchical' })
+mcp__moflo__swarm_init({ topology: 'hierarchical' })
 
 // After: Native when available, MCP fallback
 const integration = new ClaudeFlowTeammateIntegration();
@@ -1316,7 +1316,7 @@ if (mode === 'native') {
   // Pass agentInputs to Task tool
 } else {
   // Fallback to MCP
-  mcp__claude-flow__swarm_init({ topology: 'hierarchical' })
+  mcp__moflo__swarm_init({ topology: 'hierarchical' })
 }
 ```
 

--- a/src/implementation/init/HOOKS.md
+++ b/src/implementation/init/HOOKS.md
@@ -175,7 +175,7 @@ Executes on permission requests. Used for auto-allowing claude-flow tools.
 {
   "PermissionRequest": [
     {
-      "matcher": "^mcp__claude-flow__.*$",
+      "matcher": "^mcp__moflo__.*$",
       "hooks": [{
         "type": "command",
         "command": "echo '{\"decision\": \"allow\", \"reason\": \"claude-flow MCP tool auto-approved\"}'",

--- a/src/implementation/integration/AGENTS-SKILLS-COMMANDS-HOOKS.md
+++ b/src/implementation/integration/AGENTS-SKILLS-COMMANDS-HOOKS.md
@@ -352,9 +352,9 @@ tools:
   - Task
   - TodoWrite
   - Bash
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
 ---
 
 # Swarm Orchestration Skill

--- a/src/implementation/swarm-plans/AGENT-SPECIFICATIONS.md
+++ b/src/implementation/swarm-plans/AGENT-SPECIFICATIONS.md
@@ -41,10 +41,10 @@ modules:
 dependencies: []
 
 tools:
-  - mcp__claude-flow__swarm_init
-  - mcp__claude-flow__agent_spawn
-  - mcp__claude-flow__task_orchestrate
-  - mcp__claude-flow__memory_usage
+  - mcp__moflo__swarm_init
+  - mcp__moflo__agent_spawn
+  - mcp__moflo__task_orchestrate
+  - mcp__moflo__memory_usage
   - gh (GitHub CLI)
   - TodoWrite
 
@@ -451,7 +451,7 @@ tools:
   - Write
   - Edit
   - Bash
-  - mcp__claude-flow__swarm_*
+  - mcp__moflo__swarm_*
 
 concurrency_limit: 2
 priority: high

--- a/src/index.ts
+++ b/src/index.ts
@@ -527,7 +527,7 @@ export const V3_VERSION = {
 };
 
 export const V3_INFO = {
-  name: 'claude-flow',
+  name: 'moflo',
   version: V3_VERSION.full,
   description: 'Complete reimagining of Claude-Flow with 15-agent hierarchical mesh swarm',
   repository: 'https://github.com/eric-cielo/moflo',

--- a/src/mcp/__tests__/system-tools.test.ts
+++ b/src/mcp/__tests__/system-tools.test.ts
@@ -352,7 +352,7 @@ describe('System Tools', () => {
       const result = await systemInfoTool.handler({}, mockContext);
 
       expect(result).toBeDefined();
-      expect(result.name).toBe('claude-flow');
+      expect(result.name).toBe('moflo');
       expect(result.version).toBe('3.0.0');
       expect(result.nodeVersion).toBeDefined();
       expect(result.platform).toBeDefined();

--- a/src/mcp/tools/system-tools.ts
+++ b/src/mcp/tools/system-tools.ts
@@ -669,7 +669,7 @@ async function handleSystemInfo(
   context?: ToolContext
 ): Promise<SystemInfoResult> {
   const result: SystemInfoResult = {
-    name: 'claude-flow',
+    name: 'moflo',
     version: '3.0.0',
     nodeVersion: process.version,
     platform: process.platform,


### PR DESCRIPTION
## Summary
- Renames the MCP server identity from `claude-flow` to `moflo` across the entire codebase (363 files)
- MCP tool prefix changes from `mcp__claude-flow__*` to `mcp__moflo__*`
- Adds Windows `cmd /c` wrapper for MCP server spawning (fixes Claude Code diagnostic warning)
- Init now detects legacy `claude-flow` config and prompts: migrate, keep both side-by-side, or skip
- Doctor detects both `claude-flow` and `moflo` for backward compatibility
- Plugin manager accepts both `pkg['moflo']` and `pkg['claude-flow']`

## Test plan
- [ ] Run `npx moflo doctor` — should pass MCP check
- [ ] Run `npx moflo init` on a project with old `claude-flow` .mcp.json — verify migration prompt
- [ ] Verify MCP tools register as `mcp__moflo__*` in Claude Code
- [ ] Existing `claude-flow` users can still run side-by-side

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)