### PR TITLE
fix: MCP server reports as moflo in bin/cli.js entry point

### DIFF
--- a/src/@claude-flow/cli/bin/cli.js
+++ b/src/@claude-flow/cli/bin/cli.js
@@ -96,7 +96,7 @@ if (isMCPMode) {
           id: message.id,
           result: {
             protocolVersion: '2024-11-05',
-            serverInfo: { name: 'claude-flow', version: VERSION },
+            serverInfo: { name: 'moflo', version: VERSION },
             capabilities: {
               tools: { listChanged: true },
               resources: { subscribe: true, listChanged: true },


### PR DESCRIPTION
## Summary
- The inline MCP handler in `cli/bin/cli.js` still reported `serverInfo.name: 'claude-flow'` — missed in the bulk rename (#46) because it's a `.js` file
- Verified against peer test project: MCP now reports `"name":"moflo","version":"4.8.10"`
- Doctor passes, init migration works correctly

## Test plan
- [x] `echo '{"jsonrpc":"2.0",...}' | node bin/cli.js mcp start` returns `name: "moflo"`
- [x] `npx moflo doctor` passes MCP check in test project
- [x] Init auto-migrates `claude-flow` → `moflo` in existing `.mcp.json`

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)