### PR TITLE
feat: auto_index flags for all three indexers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -794,6 +794,7 @@ Run `npx moflo doctor` to check:
 - MCP servers
 - Disk space
 - TypeScript installation
+- Test directories (validates dirs from moflo.yaml, reports auto_index status)
 
 ## Quick Setup
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ npm install --save-dev moflo
 npx flo init
 ```
 
-`flo init` automatically scans your project to find where your guidance and code live, then writes the results into `moflo.yaml`. It looks for:
+`flo init` automatically scans your project to find where your guidance, code, and tests live, then writes the results into `moflo.yaml`. It looks for:
 
 | What | Directories it checks | Default if none found |
 |------|----------------------|----------------------|
 | **Guidance** | `.claude/guidance`, `docs/guides`, `docs`, `architecture`, `adr`, `.cursor/rules` | `.claude/guidance` |
 | **Source code** | `src`, `packages`, `lib`, `app`, `apps`, `services`, `server`, `client` | `src` |
+| **Tests** | `tests`, `test`, `__tests__`, `spec`, `e2e`, plus `__tests__` dirs inside `src/` | `tests` |
 | **Languages** | Scans detected source dirs for file extensions | `.ts`, `.tsx`, `.js`, `.jsx` |
 
 It also generates:
@@ -100,7 +101,20 @@ code_map:
   exclude: [node_modules, dist, .next, coverage]
 ```
 
-MoFlo chunks your guidance files into semantic embeddings and indexes your code structure, so Claude searches your knowledge base before touching any files. Adjust these directories to match your project:
+**Tests** — test files to index for "what tests cover X?" reverse mapping:
+
+```yaml
+tests:
+  directories:
+    - tests               # your test files
+    - __tests__            # jest-style test dirs
+  patterns: ["*.test.*", "*.spec.*", "*.test-*"]
+  extensions: [".ts", ".tsx", ".js", ".jsx"]
+  exclude: [node_modules, coverage, dist]
+  namespace: tests
+```
+
+MoFlo chunks your guidance files into semantic embeddings, indexes your code structure, and maps test files back to their source targets — so Claude searches your knowledge base before touching any files. Adjust these directories to match your project:
 
 ```yaml
 # Monorepo with shared docs
@@ -276,6 +290,13 @@ code_map:
   exclude: [node_modules, dist]
   namespace: code-map
 
+tests:
+  directories: [tests, __tests__]
+  patterns: ["*.test.*", "*.spec.*", "*.test-*"]
+  extensions: [".ts", ".tsx", ".js", ".jsx"]
+  exclude: [node_modules, coverage, dist]
+  namespace: tests
+
 gates:
   memory_first: true                 # Must search memory before file exploration
   task_create_first: true            # Must TaskCreate before Agent tool
@@ -284,6 +305,7 @@ gates:
 auto_index:
   guidance: true                     # Auto-index docs on session start
   code_map: true                     # Auto-index code on session start
+  tests: true                        # Auto-index test files on session start
 
 mcp:
   tool_defer: true                   # Defer 150+ tool schemas; loaded on demand via ToolSearch

--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -437,6 +437,22 @@ function resolveBinOrLocal(binName, localScript) {
 
 // Run the guidance indexer in background (non-blocking - used for session start and file changes)
 function runIndexGuidanceBackground(specificFile = null) {
+  // Check auto_index.guidance flag in moflo.yaml (default: true)
+  // Only gate full indexing on session-start; per-file calls from post-edit always run
+  if (!specificFile) {
+    const yamlPath = resolve(projectRoot, 'moflo.yaml');
+    if (existsSync(yamlPath)) {
+      try {
+        const content = readFileSync(yamlPath, 'utf-8');
+        const match = content.match(/auto_index:\s*\n(?:.*\n)*?\s+guidance:\s*(true|false)/);
+        if (match && match[1] === 'false') {
+          log('info', 'Guidance indexing disabled (auto_index.guidance: false)');
+          return;
+        }
+      } catch { /* ignore, proceed with indexing */ }
+    }
+  }
+
   const indexScript = resolveBinOrLocal('flo-index', 'index-guidance.mjs');
 
   if (!indexScript) {
@@ -453,6 +469,19 @@ function runIndexGuidanceBackground(specificFile = null) {
 
 // Run structural code map generator in background (non-blocking)
 function runCodeMapBackground() {
+  // Check auto_index.code_map flag in moflo.yaml (default: true)
+  const yamlPath = resolve(projectRoot, 'moflo.yaml');
+  if (existsSync(yamlPath)) {
+    try {
+      const content = readFileSync(yamlPath, 'utf-8');
+      const match = content.match(/auto_index:\s*\n(?:.*\n)*?\s+code_map:\s*(true|false)/);
+      if (match && match[1] === 'false') {
+        log('info', 'Code map generation disabled (auto_index.code_map: false)');
+        return;
+      }
+    } catch { /* ignore, proceed with indexing */ }
+  }
+
   const codeMapScript = resolveBinOrLocal('flo-codemap', 'generate-code-map.mjs');
 
   if (!codeMapScript) {

--- a/src/@claude-flow/cli/src/commands/doctor.ts
+++ b/src/@claude-flow/cli/src/commands/doctor.ts
@@ -632,11 +632,16 @@ async function checkTestDirs(): Promise<HealthCheck> {
     const existing = dirs.filter(d => existsSync(join(process.cwd(), d)));
     const missing = dirs.filter(d => !existsSync(join(process.cwd(), d)));
 
+    // Check auto_index.tests flag
+    const autoIndexMatch = content.match(/auto_index:\s*\n(?:.*\n)*?\s+tests:\s*(true|false)/);
+    const autoIndexEnabled = !autoIndexMatch || autoIndexMatch[1] !== 'false';
+    const indexLabel = autoIndexEnabled ? 'auto-index: on' : 'auto-index: off';
+
     if (missing.length > 0 && existing.length === 0) {
       return {
         name: 'Test Directories',
         status: 'warn',
-        message: `No configured test dirs exist: ${missing.join(', ')}`,
+        message: `No configured test dirs exist: ${missing.join(', ')} (${indexLabel})`,
       };
     }
 
@@ -644,11 +649,11 @@ async function checkTestDirs(): Promise<HealthCheck> {
       return {
         name: 'Test Directories',
         status: 'warn',
-        message: `${existing.length} OK, ${missing.length} missing: ${missing.join(', ')}`,
+        message: `${existing.length} OK, ${missing.length} missing: ${missing.join(', ')} (${indexLabel})`,
       };
     }
 
-    return { name: 'Test Directories', status: 'pass', message: `${existing.length} directories: ${existing.join(', ')}` };
+    return { name: 'Test Directories', status: 'pass', message: `${existing.length} directories: ${existing.join(', ')} (${indexLabel})` };
   } catch {
     return { name: 'Test Directories', status: 'warn', message: 'Unable to parse moflo.yaml' };
   }

--- a/tests/hooks-test-indexing.test.ts
+++ b/tests/hooks-test-indexing.test.ts
@@ -1,10 +1,10 @@
 /**
- * Tests for hooks.mjs test indexing integration
+ * Tests for hooks.mjs indexing integration (guidance, code-map, tests)
  *
  * Verifies:
- * - runTestIndexBackground function exists
- * - Test indexer is spawned during session-start
- * - Respects auto_index.tests flag from moflo.yaml
+ * - All three background indexer functions exist
+ * - All are spawned during session-start
+ * - All respect their auto_index flags from moflo.yaml
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
@@ -13,19 +13,20 @@ import { resolve } from 'path';
 
 const HOOKS_FILE = resolve(__dirname, '../bin/hooks.mjs');
 
-describe('hooks.mjs test indexing', () => {
+describe('hooks.mjs indexing integration', () => {
   let content: string;
 
   beforeAll(() => {
     content = readFileSync(HOOKS_FILE, 'utf-8');
   });
 
+  // ── Test indexer ──────────────────────────────────────────────────
+
   it('defines runTestIndexBackground function', () => {
     expect(content).toContain('function runTestIndexBackground()');
   });
 
   it('calls runTestIndexBackground in session-start', () => {
-    // The session-start case should call the test indexer
     const sessionStart = content.substring(
       content.indexOf("case 'session-start':"),
       content.indexOf("case 'session-restore':")
@@ -35,18 +36,48 @@ describe('hooks.mjs test indexing', () => {
 
   it('checks auto_index.tests flag in moflo.yaml', () => {
     expect(content).toContain('auto_index.tests');
-    expect(content).toContain("match[1] === 'false'");
   });
 
   it('resolves index-tests.mjs via resolveBinOrLocal', () => {
     expect(content).toContain("resolveBinOrLocal('flo-testmap', 'index-tests.mjs')");
   });
 
-  it('uses spawnWindowless for background execution', () => {
+  it('uses spawnWindowless for background test execution', () => {
     const fn = content.substring(
       content.indexOf('function runTestIndexBackground'),
-      content.indexOf('function runBackgroundTraining') // next function
+      content.indexOf('function runBackgroundTraining')
     );
     expect(fn).toContain('spawnWindowless');
+  });
+
+  // ── Guidance indexer ──────────────────────────────────────────────
+
+  it('checks auto_index.guidance flag in runIndexGuidanceBackground', () => {
+    const fn = content.substring(
+      content.indexOf('function runIndexGuidanceBackground'),
+      content.indexOf('function runCodeMapBackground')
+    );
+    expect(fn).toContain('auto_index.guidance');
+    expect(fn).toContain("match[1] === 'false'");
+  });
+
+  it('only gates full guidance indexing, not per-file calls', () => {
+    const fn = content.substring(
+      content.indexOf('function runIndexGuidanceBackground'),
+      content.indexOf('function runCodeMapBackground')
+    );
+    // The flag check should be inside an if (!specificFile) block
+    expect(fn).toContain('if (!specificFile)');
+  });
+
+  // ── Code map indexer ──────────────────────────────────────────────
+
+  it('checks auto_index.code_map flag in runCodeMapBackground', () => {
+    const fn = content.substring(
+      content.indexOf('function runCodeMapBackground'),
+      content.indexOf('function runTestIndexBackground')
+    );
+    expect(fn).toContain('auto_index.code_map');
+    expect(fn).toContain("match[1] === 'false'");
   });
 });


### PR DESCRIPTION
## Summary
- Add `auto_index.guidance` flag checking to `runIndexGuidanceBackground()` in hooks.mjs (only gates full session-start runs, not per-file post-edit calls)
- Add `auto_index.code_map` flag checking to `runCodeMapBackground()` in hooks.mjs
- Doctor `checkTestDirs()` now reports auto_index on/off status
- README: document `tests:` config section, `auto_index.tests` flag, test directory discovery
- CLAUDE.md: add test directories to doctor health checks list
- Expanded hooks indexing tests from 5 to 8 covering all three indexers

## Test plan
- [x] All 40 epic #45 tests pass (5 test files)
- [x] Verified in peer project: indexer skips when `auto_index.tests: false`
- [x] Verified in peer project: all three flags parse correctly from moflo.yaml
- [x] Full test suite: 147 passed, 1 pre-existing failure (system-tools.test.ts)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)