### PR TITLE
fix: guidance indexer stale cleanup + system-tools name

### DIFF
--- a/bin/index-guidance.mjs
+++ b/bin/index-guidance.mjs
@@ -694,9 +694,11 @@ function indexDirectory(db, dirConfig) {
 
 /**
  * Remove stale entries for files that no longer exist on disk.
- * Runs after indexing to keep the memory DB clean.
+ * Uses the set of docKeys seen during the current indexing run to determine
+ * which entries are stale, rather than reconstructing file paths from keys
+ * (which breaks for files in subdirectories).
  */
-function cleanStaleEntries(db) {
+function cleanStaleEntries(db, currentDocKeys) {
   const docsStmt = db.prepare(
     `SELECT DISTINCT key FROM memory_entries WHERE namespace = ? AND key LIKE 'doc-%'`
   );
@@ -707,36 +709,19 @@ function cleanStaleEntries(db) {
 
   let staleCount = 0;
 
-  // Build a lookup of all indexed directory configs for stale detection
-  const prefixToDirMap = {};
-  for (const dirConfig of GUIDANCE_DIRS) {
-    const dirPath = dirConfig.absolute ? dirConfig.path : resolve(projectRoot, dirConfig.path);
-    prefixToDirMap[dirConfig.prefix] = dirPath;
-  }
-
   for (const { key } of docs) {
-    // Convert key back to file path by matching doc-{prefix}-{filename}
-    let filePath;
-    for (const [prefix, dirPath] of Object.entries(prefixToDirMap)) {
-      const docPrefix = `doc-${prefix}-`;
-      if (key.startsWith(docPrefix)) {
-        filePath = resolve(dirPath, key.replace(docPrefix, '') + '.md');
-        break;
-      }
-    }
-    if (!filePath) continue; // Unknown prefix, skip
+    // If this doc key was seen during the current indexing run, it's not stale
+    if (currentDocKeys.has(key)) continue;
 
-    if (!existsSync(filePath)) {
-      const chunkPrefix = key.replace('doc-', 'chunk-');
-      const countBefore = db.exec(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = '${NAMESPACE}'`)[0]?.values[0][0] || 0;
-      db.run(`DELETE FROM memory_entries WHERE namespace = ? AND key LIKE ?`, [NAMESPACE, `${chunkPrefix}%`]);
-      db.run(`DELETE FROM memory_entries WHERE namespace = ? AND key = ?`, [NAMESPACE, key]);
-      const countAfter = db.exec(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = '${NAMESPACE}'`)[0]?.values[0][0] || 0;
-      const removed = countBefore - countAfter;
-      if (removed > 0) {
-        log(`  Removed ${removed} stale entries for deleted file: ${key}`);
-        staleCount += removed;
-      }
+    const chunkPrefix = key.replace('doc-', 'chunk-');
+    const countBefore = db.exec(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = '${NAMESPACE}'`)[0]?.values[0][0] || 0;
+    db.run(`DELETE FROM memory_entries WHERE namespace = ? AND key LIKE ?`, [NAMESPACE, `${chunkPrefix}%`]);
+    db.run(`DELETE FROM memory_entries WHERE namespace = ? AND key = ?`, [NAMESPACE, key]);
+    const countAfter = db.exec(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = '${NAMESPACE}'`)[0]?.values[0][0] || 0;
+    const removed = countBefore - countAfter;
+    if (removed > 0) {
+      log(`  Removed ${removed} stale entries for deleted file: ${key}`);
+      staleCount += removed;
     }
   }
 
@@ -774,6 +759,7 @@ let docsIndexed = 0;
 let chunksIndexed = 0;
 let unchanged = 0;
 let errors = 0;
+const currentDocKeys = new Set();
 
 if (specificFile) {
   // Index single file
@@ -806,6 +792,9 @@ if (specificFile) {
     const results = indexDirectory(db, dir);
 
     for (const result of results) {
+      if (result.status === 'indexed' || result.status === 'unchanged') {
+        currentDocKeys.add(result.docKey);
+      }
       if (result.status === 'indexed') {
         log(`  ✅ ${result.docKey} (${result.chunks} chunks)`);
         docsIndexed++;
@@ -824,7 +813,7 @@ if (specificFile) {
 let staleRemoved = 0;
 if (!specificFile) {
   log('Cleaning stale entries for deleted files...');
-  staleRemoved = cleanStaleEntries(db);
+  staleRemoved = cleanStaleEntries(db, currentDocKeys);
   if (staleRemoved === 0) {
     log('  No stale entries found');
   }

--- a/src/mcp/tools/system-tools.js
+++ b/src/mcp/tools/system-tools.js
@@ -495,7 +495,7 @@ async function handleSystemHealth(input, context) {
  */
 async function handleSystemInfo(input, context) {
     const result = {
-        name: 'claude-flow',
+        name: 'moflo',
         version: '3.0.0',
         nodeVersion: process.version,
         platform: process.platform,


### PR DESCRIPTION
## Summary
- **Guidance indexer stale cleanup bug**: `cleanStaleEntries()` reconstructed file paths from doc keys assuming flat directory, but guidance files live in subdirectories (`shipped/`, `internal/`). Every guidance entry was deleted as "stale" immediately after indexing, resulting in 0 guidance entries in the DB. Fixed by tracking docKeys seen during the current run and only deleting keys not in that set.
- **system-tools.js stale name**: Compiled `.js` file still had `name: 'claude-flow'` instead of `'moflo'`, causing `system/info` test to fail.

## Test plan
- [x] Guidance indexer now retains all 139 entries (was 0 before fix)
- [x] All namespaces populated: code-map (1030), guidance (139), tests (553)
- [x] system-tools.test.ts: all 38 tests pass
- [x] hooks-test-indexing.test.ts: all 8 tests pass

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)