### PR TITLE
fix: github command cross-platform + README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,21 @@ flo doctor --verbose             # Verbose output
 
 While `doctor` checks your environment, `diagnose` exercises every subsystem end-to-end: memory CRUD, embedding generation, semantic search, swarm lifecycle, hive-mind consensus, task management, hooks, config, neural patterns, and init idempotency. All test data is cleaned up after each test — nothing is left behind.
 
+### GitHub Repository Setup
+
+```bash
+flo github setup                  # One-shot: generate CI + apply repo settings + branch protection
+flo github setup --dry-run        # Preview everything without making changes
+flo github ci                     # Generate .github/workflows/ci.yml from project config
+flo github ci --dry-run           # Print workflow to stdout
+flo github settings               # Apply repo settings + branch protection via gh CLI
+flo github settings --dry-run     # Preview settings changes
+```
+
+`flo github ci` auto-detects your package manager (npm/pnpm/yarn/bun), TypeScript, and test directories from `moflo.yaml` and `package.json`, then generates a CI workflow with install, build, lint, type-check, and test steps.
+
+`flo github settings` applies recommended defaults via `gh` CLI: delete-branch-on-merge, squash merge with PR title/body, auto-merge, linear history, and configurable branch protection (required reviews, dismiss stale reviews, block force pushes). Requires `gh auth login`.
+
 ### System
 
 ```bash

--- a/src/@claude-flow/cli/src/commands/github.ts
+++ b/src/@claude-flow/cli/src/commands/github.ts
@@ -17,13 +17,14 @@ import { execSync } from 'child_process';
 // Helpers
 // ============================================================================
 
-function runGh(args: string, cwd: string, timeout = 15000): string {
+function runGh(args: string, cwd: string, timeout = 15000, stdin?: string): string {
   return execSync(`gh ${args}`, {
     encoding: 'utf8',
     cwd,
     timeout,
     windowsHide: true,
-    stdio: ['pipe', 'pipe', 'pipe'],
+    input: stdin,
+    stdio: stdin ? ['pipe', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
   }).trim();
 }
 
@@ -337,33 +338,52 @@ const settingsCommand: Command = {
 
     // ── Repo-level settings ──────────────────────────────────────────
     if (!skipRepo) {
-      const repoSettings = [
-        { field: 'delete_branch_on_merge', value: true, label: 'Delete branch on merge' },
-        { field: 'allow_squash_merge', value: true, label: 'Allow squash merge' },
-        { field: 'allow_merge_commit', value: true, label: 'Allow merge commits' },
-        { field: 'allow_rebase_merge', value: true, label: 'Allow rebase merge' },
-        { field: 'squash_merge_commit_title', value: 'PR_TITLE', label: 'Squash commit title: PR title' },
-        { field: 'squash_merge_commit_message', value: 'PR_BODY', label: 'Squash commit message: PR body' },
-        { field: 'allow_auto_merge', value: true, label: 'Allow auto-merge' },
-        { field: 'allow_update_branch', value: true, label: 'Allow update branch button' },
+      // Group settings into batches — some fields must be set together
+      const settingsBatches: { payload: Record<string, unknown>; labels: string[] }[] = [
+        {
+          payload: {
+            delete_branch_on_merge: true,
+            allow_squash_merge: true,
+            allow_merge_commit: true,
+            allow_rebase_merge: true,
+            allow_auto_merge: true,
+            allow_update_branch: true,
+            // Title + message must be set together or message fails
+            squash_merge_commit_title: 'PR_TITLE',
+            squash_merge_commit_message: 'PR_BODY',
+          },
+          labels: [
+            'Delete branch on merge',
+            'Allow squash merge',
+            'Allow merge commits',
+            'Allow rebase merge',
+            'Squash defaults: PR title + body',
+            'Allow auto-merge',
+            'Allow update branch button',
+          ],
+        },
       ];
 
-      for (const setting of repoSettings) {
+      for (const batch of settingsBatches) {
         if (dryRun) {
-          output.writeln(`  ${output.dim('○')} ${setting.label}`);
-          applied.push(setting.label);
+          for (const label of batch.labels) {
+            output.writeln(`  ${output.dim('○')} ${label}`);
+          }
+          applied.push(...batch.labels);
           continue;
         }
         try {
-          const payload = JSON.stringify({ [setting.field]: setting.value });
-          runGh(`api repos/${slug} -X PATCH --input - <<< '${payload}'`, cwd);
-          output.writeln(`  ${output.success('✓')} ${setting.label}`);
-          applied.push(setting.label);
+          runGh(`api repos/${slug} -X PATCH --input -`, cwd, 15000, JSON.stringify(batch.payload));
+          for (const label of batch.labels) {
+            output.writeln(`  ${output.success('✓')} ${label}`);
+          }
+          applied.push(...batch.labels);
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
-          // Non-fatal: some settings may not be available on all plans
-          output.writeln(`  ${output.warning('⚠')} ${setting.label} — ${msg.split('\n')[0]}`);
-          errors.push(setting.label);
+          for (const label of batch.labels) {
+            output.writeln(`  ${output.warning('⚠')} ${label} — ${msg.split('\n')[0]}`);
+          }
+          errors.push(...batch.labels);
         }
       }
 
@@ -411,14 +431,7 @@ const settingsCommand: Command = {
       } else {
         try {
           const payload = JSON.stringify(protection);
-          // Use stdin piping via echo for cross-platform compatibility
-          execSync(`echo '${payload}' | gh api repos/${slug}/branches/${branch}/protection -X PUT --input -`, {
-            encoding: 'utf8',
-            cwd,
-            timeout: 15000,
-            windowsHide: true,
-            stdio: ['pipe', 'pipe', 'pipe'],
-          });
+          runGh(`api repos/${slug}/branches/${branch}/protection -X PUT --input -`, cwd, 15000, payload);
 
           for (const item of protectionItems) {
             output.writeln(`  ${output.success('✓')} ${item}`);


### PR DESCRIPTION
## Summary

- Fix cross-platform compatibility: replace shell heredoc (`<<<`) with Node `execSync` stdin for Windows
- Batch all repo settings into a single GitHub API call (squash title + message must be set together)
- Add `flo github` section to README under Commands
- Includes dry-run flag fix from PR #54

## Test plan

- [x] Created fresh dummy repo (`eric-cielo/moflo-github-test`)
- [x] `flo github setup` — 14/14 settings applied, CI workflow generated
- [x] Verified repo settings via `gh api` (delete_branch_on_merge, squash defaults, auto-merge)
- [x] Verified branch protection via `gh api` (1 required review, dismiss stale, linear history, no force push)
- [x] `flo github ci --dry-run` prints without writing
- [x] Build clean, 148/148 tests pass

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)