### PR TITLE
chore: update moflo devDependency to ^4.8.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moflo",
-  "version": "4.8.12",
+  "version": "4.8.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moflo",
-      "version": "4.8.12",
+      "version": "4.8.13",
       "license": "MIT",
       "dependencies": {
         "@ruvector/learning-wasm": "^0.1.29",
@@ -21,7 +21,6 @@
         "flo-codemap": "bin/generate-code-map.mjs",
         "flo-embeddings": "bin/build-embeddings.mjs",
         "flo-index": "bin/index-guidance.mjs",
-        "flo-learn": ".claude/helpers/learning-service.mjs",
         "flo-search": "bin/semantic-search.mjs",
         "flo-setup": "bin/setup-project.mjs",
         "flo-testmap": "bin/index-tests.mjs",
@@ -31,7 +30,7 @@
         "@types/bcrypt": "^5.0.2",
         "@types/node": "^20.19.37",
         "eslint": "^8.0.0",
-        "moflo": "^4.8.11",
+        "moflo": "^4.8.13",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -10180,9 +10179,9 @@
       "optional": true
     },
     "node_modules/moflo": {
-      "version": "4.8.11",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.11.tgz",
-      "integrity": "sha512-R7gpGQcniF6iGYhdIZlAdqqD3rMgEviRvC0h48qw4drnuVztA41BtbJ+mKvoNxvfQ9KWr4PUZbajmMNRAe9PdA==",
+      "version": "4.8.13",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.13.tgz",
+      "integrity": "sha512-a+HpJR7E1BAgUYpt4yFjMOZ4rNe/qldM491HVRqooE+9mtNOlDN9JglwlfAKAYmhs1uw02loQn5vGPZeUsdDIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10198,7 +10197,6 @@
         "flo-codemap": "bin/generate-code-map.mjs",
         "flo-embeddings": "bin/build-embeddings.mjs",
         "flo-index": "bin/index-guidance.mjs",
-        "flo-learn": ".claude/helpers/learning-service.mjs",
         "flo-search": "bin/semantic-search.mjs",
         "flo-setup": "bin/setup-project.mjs",
         "flo-testmap": "bin/index-tests.mjs",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@types/bcrypt": "^5.0.2",
     "@types/node": "^20.19.37",
     "eslint": "^8.0.0",
-    "moflo": "^4.8.11",
+    "moflo": "^4.8.13",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- Update moflo devDependency from ^4.8.11 to ^4.8.13 to align with published package version
- Lock file regenerated with resolved 4.8.13

## Test plan
- [x] `npm install` resolves correctly
- [x] No functional changes

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)