### PR TITLE
fix: Linux session-start failures — missing lib/ sync, statusLine, guidance build

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -117,6 +117,18 @@ try {
         for (const file of scriptFiles) {
           syncFile(resolve(binDir, file), resolve(scriptsDir, file), `.claude/scripts/${file}`);
         }
+
+        // Sync lib/ subdirectory (process-manager.mjs, registry-cleanup.cjs, etc.)
+        // hooks.mjs imports ./lib/process-manager.mjs — without this, session-start
+        // silently fails and the daemon, indexer, and pretrain never run.
+        const libSrcDir = resolve(binDir, 'lib');
+        const libDestDir = resolve(scriptsDir, 'lib');
+        if (existsSync(libSrcDir)) {
+          if (!existsSync(libDestDir)) mkdirSync(libDestDir, { recursive: true });
+          for (const file of readdirSync(libSrcDir)) {
+            syncFile(resolve(libSrcDir, file), resolve(libDestDir, file), `.claude/scripts/lib/${file}`);
+          }
+        }
       }
 
       // Sync helpers from bin/ and source .claude/helpers/

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "build:ts": "cd src/@claude-flow/cli && npm run build || true",
+    "build:guidance": "cd src/@claude-flow/guidance && npx tsc -p tsconfig.json || true",
+    "prepublishOnly": "npm run build:ts && npm run build:guidance",
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:security": "vitest run src/__tests__/security/",

--- a/src/@claude-flow/cli/src/init/executor.ts
+++ b/src/@claude-flow/cli/src/init/executor.ts
@@ -517,6 +517,36 @@ export async function executeUpgrade(targetDir: string, upgradeSettings = false)
           // Non-fatal — skip individual script on error
         }
       }
+
+      // Sync lib/ subdirectory (process-manager.mjs, registry-cleanup.cjs, etc.)
+      // hooks.mjs imports ./lib/process-manager.mjs — without this, session-start
+      // silently fails and the daemon, indexer, and pretrain never run.
+      const libSrcDir = path.join(binDir, 'lib');
+      const libDestDir = path.join(scriptsDir, 'lib');
+      if (fs.existsSync(libSrcDir)) {
+        if (!fs.existsSync(libDestDir)) {
+          fs.mkdirSync(libDestDir, { recursive: true });
+        }
+        for (const file of fs.readdirSync(libSrcDir)) {
+          const srcPath = path.join(libSrcDir, file);
+          const destPath = path.join(libDestDir, file);
+          try {
+            const srcStat = fs.statSync(srcPath);
+            if (!srcStat.isFile()) continue;
+            const destExists = fs.existsSync(destPath);
+            if (!destExists || srcStat.mtimeMs > fs.statSync(destPath).mtimeMs) {
+              fs.copyFileSync(srcPath, destPath);
+              if (destExists) {
+                result.updated.push(`.claude/scripts/lib/${file}`);
+              } else {
+                result.created.push(`.claude/scripts/lib/${file}`);
+              }
+            }
+          } catch {
+            // Non-fatal
+          }
+        }
+      }
     }
 
     // 1c. Build manifest of files we're installing, clean up stale ones

--- a/src/@claude-flow/cli/src/init/settings-generator.ts
+++ b/src/@claude-flow/cli/src/init/settings-generator.ts
@@ -17,8 +17,12 @@ export function generateSettings(options: InitOptions): object {
     settings.hooks = generateHooksConfig(options.hooks);
   }
 
-  // Add statusLine configuration if enabled
-  if (options.statusline.enabled) {
+  // Add statusLine configuration when the statusline component is enabled.
+  // Previously only checked options.statusline.enabled, which could be unset
+  // even when options.components.statusline was true (the guard used by
+  // executor.ts to generate the statusline script). This left settings.json
+  // without a statusLine entry, so the dashboard never appeared.
+  if (options.components.statusline || options.statusline?.enabled) {
     settings.statusLine = generateStatusLineConfig(options);
   }
 

--- a/tests/bin/lib-sync.test.ts
+++ b/tests/bin/lib-sync.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for bin/lib/ subdirectory sync in session-start-launcher.mjs and executor.ts
+ *
+ * Validates that:
+ * 1. hooks.mjs can import ./lib/process-manager.mjs when lib/ is synced
+ * 2. session-start-launcher syncs bin/lib/ to .claude/scripts/lib/
+ * 3. executor.ts upgrade path syncs bin/lib/ to .claude/scripts/lib/
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync } from 'fs';
+import { resolve, join } from 'path';
+
+function makeTempRoot(): string {
+  const root = resolve(__dirname, '../../.test-lib-sync-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
+  mkdirSync(resolve(root, '.claude-flow'), { recursive: true });
+  mkdirSync(resolve(root, '.claude/scripts'), { recursive: true });
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* ok */ }
+}
+
+describe('bin/lib/ subdirectory sync', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot(); });
+  afterEach(() => { cleanTempRoot(root); });
+
+  it('lib/ directory exists in bin/ source with required files', () => {
+    const binLibDir = resolve(__dirname, '../../bin/lib');
+    expect(existsSync(binLibDir)).toBe(true);
+
+    const files = readdirSync(binLibDir);
+    expect(files).toContain('process-manager.mjs');
+    expect(files).toContain('registry-cleanup.cjs');
+  });
+
+  it('hooks.mjs imports ./lib/process-manager.mjs', () => {
+    const hooksPath = resolve(__dirname, '../../bin/hooks.mjs');
+    const content = readFileSync(hooksPath, 'utf-8');
+    expect(content).toContain('./lib/process-manager.mjs');
+  });
+
+  it('session-start-launcher.mjs syncs lib/ subdirectory', () => {
+    const launcherPath = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+    const content = readFileSync(launcherPath, 'utf-8');
+
+    // Verify the launcher has the lib/ sync logic
+    expect(content).toContain("resolve(binDir, 'lib')");
+    expect(content).toContain("resolve(scriptsDir, 'lib')");
+  });
+
+  it('executor.ts syncs lib/ subdirectory during upgrade', () => {
+    const executorPath = resolve(__dirname, '../../src/@claude-flow/cli/src/init/executor.ts');
+    const content = readFileSync(executorPath, 'utf-8');
+
+    // Verify the executor has the lib/ sync logic
+    expect(content).toContain("path.join(binDir, 'lib')");
+    expect(content).toContain("path.join(scriptsDir, 'lib')");
+  });
+
+  it('simulates lib/ sync and verifies all files are copied', () => {
+    // Create a fake bin/lib/ source
+    const fakeBinLib = join(root, 'bin', 'lib');
+    mkdirSync(fakeBinLib, { recursive: true });
+    writeFileSync(join(fakeBinLib, 'process-manager.mjs'), 'export function spawn() {}');
+    writeFileSync(join(fakeBinLib, 'registry-cleanup.cjs'), 'module.exports = {}');
+    writeFileSync(join(fakeBinLib, 'moflo-resolve.mjs'), 'export function resolve() {}');
+
+    // Simulate the sync logic from session-start-launcher.mjs
+    const libSrcDir = fakeBinLib;
+    const libDestDir = join(root, '.claude', 'scripts', 'lib');
+    if (!existsSync(libDestDir)) mkdirSync(libDestDir, { recursive: true });
+    for (const file of readdirSync(libSrcDir)) {
+      const src = join(libSrcDir, file);
+      const dest = join(libDestDir, file);
+      writeFileSync(dest, readFileSync(src));
+    }
+
+    // Verify all files synced
+    expect(existsSync(join(libDestDir, 'process-manager.mjs'))).toBe(true);
+    expect(existsSync(join(libDestDir, 'registry-cleanup.cjs'))).toBe(true);
+    expect(existsSync(join(libDestDir, 'moflo-resolve.mjs'))).toBe(true);
+  });
+});

--- a/tests/guidance-build.test.ts
+++ b/tests/guidance-build.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for @claude-flow/guidance package build configuration
+ *
+ * Validates that:
+ * 1. The guidance package has source files
+ * 2. The tsconfig.json is configured to output to dist/
+ * 3. The package.json exports reference dist/ paths
+ * 4. The prepublishOnly script includes guidance build
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { resolve } from 'path';
+
+const guidancePkgDir = resolve(__dirname, '../src/@claude-flow/guidance');
+const rootPkgPath = resolve(__dirname, '../package.json');
+
+describe('@claude-flow/guidance package build', () => {
+  it('has TypeScript source files', () => {
+    const srcDir = resolve(guidancePkgDir, 'src');
+    expect(existsSync(srcDir)).toBe(true);
+
+    const tsFiles = readdirSync(srcDir).filter(f => f.endsWith('.ts'));
+    expect(tsFiles.length).toBeGreaterThan(0);
+    expect(tsFiles).toContain('compiler.ts');
+    expect(tsFiles).toContain('retriever.ts');
+    expect(tsFiles).toContain('gates.ts');
+  });
+
+  it('has tsconfig.json targeting dist/', () => {
+    const tsconfigPath = resolve(guidancePkgDir, 'tsconfig.json');
+    expect(existsSync(tsconfigPath)).toBe(true);
+
+    const tsconfig = JSON.parse(readFileSync(tsconfigPath, 'utf-8'));
+    expect(tsconfig.compilerOptions.outDir).toBe('./dist');
+    expect(tsconfig.compilerOptions.rootDir).toBe('./src');
+  });
+
+  it('package.json exports reference dist/ paths', () => {
+    const pkgPath = resolve(guidancePkgDir, 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+
+    expect(pkg.main).toBe('./dist/index.js');
+    expect(pkg.exports['.']).toHaveProperty('import', './dist/index.js');
+    expect(pkg.exports['./compiler']).toHaveProperty('import', './dist/compiler.js');
+    expect(pkg.exports['./retriever']).toHaveProperty('import', './dist/retriever.js');
+    expect(pkg.exports['./gates']).toHaveProperty('import', './dist/gates.js');
+  });
+
+  it('root package.json includes guidance dist in files array', () => {
+    const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
+    const files: string[] = rootPkg.files || [];
+
+    expect(files.some((f: string) => f.includes('@claude-flow/guidance/dist'))).toBe(true);
+  });
+
+  it('root package.json has prepublishOnly that builds guidance', () => {
+    const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
+    const prepublish = rootPkg.scripts?.prepublishOnly || '';
+
+    expect(prepublish).toContain('build:guidance');
+  });
+
+  it('root package.json has build:guidance script', () => {
+    const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
+    const buildGuidance = rootPkg.scripts?.['build:guidance'] || '';
+
+    expect(buildGuidance).toContain('@claude-flow/guidance');
+    expect(buildGuidance).toContain('tsc');
+  });
+});

--- a/tests/settings-statusline.test.ts
+++ b/tests/settings-statusline.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for statusLine configuration in settings-generator.ts
+ *
+ * Validates that:
+ * 1. statusLine is included in settings.json when components.statusline is true
+ * 2. statusLine is included when options.statusline.enabled is true
+ * 3. statusLine command uses the correct helper script path
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('settings-generator statusLine config', () => {
+  const generatorPath = resolve(__dirname, '../src/@claude-flow/cli/src/init/settings-generator.ts');
+
+  it('checks both components.statusline and statusline.enabled', () => {
+    const content = readFileSync(generatorPath, 'utf-8');
+
+    // The guard should use options.components.statusline OR options.statusline?.enabled
+    // Previously it only checked options.statusline.enabled, missing cases where
+    // components.statusline was true but statusline.enabled was unset
+    expect(content).toMatch(/options\.components\.statusline\s*\|\|\s*options\.statusline\??\.\s*enabled/);
+  });
+
+  it('generates statusLine with correct command format', () => {
+    const content = readFileSync(generatorPath, 'utf-8');
+
+    // The statusLine command should reference the local helper script
+    expect(content).toContain('statusline.cjs');
+    expect(content).toContain("type: 'command'");
+  });
+
+  it('statusLine command does not use cmd /c wrapper', () => {
+    const content = readFileSync(generatorPath, 'utf-8');
+
+    // Per the comment in the source: statusline must NOT use cmd /c
+    // Claude Code manages stdin directly for statusline commands
+    const statusLineSection = content.slice(
+      content.indexOf('generateStatusLineConfig'),
+      content.indexOf('}', content.indexOf('generateStatusLineConfig') + 200) + 1
+    );
+    expect(statusLineSection).not.toContain('cmd /c');
+  });
+});


### PR DESCRIPTION
## Summary

- **bin/lib/ not synced** — `hooks.mjs` imports `./lib/process-manager.mjs` but neither `session-start-launcher.mjs` nor `executor.ts` copied the `lib/` subdirectory. On fresh Linux installs, session-start silently fails (`ERR_MODULE_NOT_FOUND`), so the daemon, indexer, code-map, and pretrain never run.
- **statusLine missing from settings.json** — `settings-generator.ts` only checked `options.statusline.enabled`, missing cases where `options.components.statusline` was true. The compact 2-line dashboard never appeared.
- **@claude-flow/guidance dist not built before publish** — source exists but no build step produces `dist/`. Added `build:guidance` script and `prepublishOnly` hook.

## Root cause analysis

The `lib/` sync gap was introduced in #43 (consolidated ProcessManager) which added `bin/lib/process-manager.mjs` but didn't update the two script-sync paths. The fire-and-forget spawn in `session-start-launcher.mjs` swallowed the error silently.

Worked on Windows because scripts were likely synced via a different init flow or pre-existing from an earlier install.

## Test plan

- [x] `tests/bin/lib-sync.test.ts` — verifies lib/ exists, hooks.mjs imports it, both sync paths include it
- [x] `tests/settings-statusline.test.ts` — verifies the guard checks both flags, correct command format
- [x] `tests/guidance-build.test.ts` — verifies source, tsconfig, exports, and prepublishOnly wiring
- [ ] Manual: `moflo init` on fresh Linux project, verify daemon starts on session-start
- [ ] Manual: verify statusLine appears in generated settings.json

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)