### PR TITLE
fix: correct non-existent decisions namespace in agent-bootstrap.md

### DIFF
--- a/.claude/guidance/shipped/agent-bootstrap.md
+++ b/.claude/guidance/shipped/agent-bootstrap.md
@@ -79,7 +79,7 @@ Project guidance always takes precedence over generic patterns.
 - Search memory before exploring files
 - Store discoveries back to memory when done
 - Use `patterns` namespace for solutions and gotchas
-- Use `decisions` namespace for architectural choices
+- Use `knowledge` namespace for architectural choices and user-requested knowledge
 
 ### Git/Branches
 - Use conventional commit prefixes: `feat:`, `fix:`, `refactor:`, `test:`, `chore:`


### PR DESCRIPTION
## Summary

- The Memory Protocol section in `agent-bootstrap.md` referenced a `decisions` namespace that doesn't exist in `moflo.yaml`
- Changed to `knowledge`, which is the namespace CLAUDE.md documents for user-stored knowledge

## Context

Found during guidance docs audit (#62). All other guidance docs (project-overview, coding-standards, testing, known-bugs) were verified accurate.

Refs #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)