### PR TITLE
fix: add missing statusLine to moflo init, suppress agentdb patch warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moflo",
-  "version": "4.8.16",
+  "version": "4.8.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moflo",
-      "version": "4.8.16",
+      "version": "4.8.18",
       "license": "MIT",
       "dependencies": {
         "@ruvector/learning-wasm": "^0.1.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moflo",
-  "version": "4.8.16",
+  "version": "4.8.18",
   "description": "MoFlo — AI agent orchestration for Claude Code. Forked from ruflo/claude-flow with patches applied to source, plus feature-level orchestration.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/@claude-flow/cli/bin/cli.js
+++ b/src/@claude-flow/cli/bin/cli.js
@@ -8,6 +8,11 @@
  * This allows: echo '{"jsonrpc":"2.0",...}' | npx @claude-flow/cli
  */
 
+// Suppress agentic-flow's agentdb-runtime-patch warning. The patch targets
+// agentdb v1.x (dist/controllers/) but v3+ uses dist/src/controllers/ and
+// already ships with correct .js extensions — the patch is unnecessary.
+process.env.SKIP_AGENTDB_PATCH ??= '1';
+
 import { randomUUID } from 'crypto';
 
 // Check if we should run in MCP server mode

--- a/src/@claude-flow/cli/dist/src/init/moflo-init.js
+++ b/src/@claude-flow/cli/dist/src/init/moflo-init.js
@@ -558,6 +558,15 @@ function generateHooks(root, force, answers) {
     };
     // Merge: preserve existing non-MoFlo hooks, add MoFlo hooks
     existing.hooks = hooks;
+    // Ensure statusLine is always present (required for dashboard display).
+    // The executor.ts / settings-generator.ts code path adds this, but
+    // moflo-init.ts uses its own generateHooks() which was missing it.
+    if (!existing.statusLine) {
+        existing.statusLine = {
+            type: 'command',
+            command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/statusline.cjs"',
+        };
+    }
     fs.writeFileSync(settingsPath, JSON.stringify(existing, null, 2), 'utf-8');
     return { name: '.claude/settings.json', status: existing.hooks ? 'updated' : 'created', detail: '14 hooks configured (gates, lifecycle, routing, session)' };
 }

--- a/src/@claude-flow/cli/dist/src/services/agentic-flow-bridge.js
+++ b/src/@claude-flow/cli/dist/src/services/agentic-flow-bridge.js
@@ -1,0 +1,103 @@
+/**
+ * agentic-flow v3 integration bridge
+ *
+ * Provides a single lazy-loading entry point for all agentic-flow v3
+ * subpath exports. Every accessor returns `null` when agentic-flow is
+ * not installed — callers never throw on missing optional dependency.
+ *
+ * @module agentic-flow-bridge
+ */
+// Suppress agentic-flow's agentdb-runtime-patch warning. The patch targets
+// agentdb v1.x (dist/controllers/) but v3+ uses dist/src/controllers/ and
+// already ships with correct .js extensions — the patch is unnecessary.
+if (typeof process !== 'undefined' && !process.env.SKIP_AGENTDB_PATCH) {
+    process.env.SKIP_AGENTDB_PATCH = '1';
+}
+// ---------------------------------------------------------------------------
+// Cached module handles (Promise-based to prevent TOCTOU races)
+// ---------------------------------------------------------------------------
+let _reasoningBankP = null;
+let _routerP = null;
+let _orchestrationP = null;
+// ---------------------------------------------------------------------------
+// Public loaders
+// ---------------------------------------------------------------------------
+/**
+ * Load the ReasoningBank module (4-step learning pipeline).
+ * Returns null if agentic-flow is not installed.
+ * Race-safe: concurrent callers share the same import Promise.
+ */
+export function getReasoningBank() {
+    if (_reasoningBankP === null) {
+        _reasoningBankP = import('agentic-flow/reasoningbank').catch(() => null);
+    }
+    return _reasoningBankP;
+}
+/**
+ * Load the ModelRouter module (multi-provider LLM routing).
+ * Returns null if agentic-flow is not installed.
+ */
+export function getRouter() {
+    if (_routerP === null) {
+        _routerP = import('agentic-flow/router').catch(() => null);
+    }
+    return _routerP;
+}
+/**
+ * Load the Orchestration module (workflow engine).
+ * Returns null if agentic-flow is not installed.
+ */
+export function getOrchestration() {
+    if (_orchestrationP === null) {
+        // Use dynamic string to prevent vite from statically resolving the subpath
+        const mod = 'agentic-flow' + '/orchestration';
+        _orchestrationP = import(/* @vite-ignore */ mod).catch(() => null);
+    }
+    return _orchestrationP;
+}
+// ---------------------------------------------------------------------------
+// Convenience helpers
+// ---------------------------------------------------------------------------
+/**
+ * Compute an embedding vector via ReasoningBank, falling back to null.
+ */
+export async function computeEmbedding(text) {
+    const rb = await getReasoningBank();
+    if (!rb?.computeEmbedding)
+        return null;
+    return rb.computeEmbedding(text);
+}
+/**
+ * Retrieve memories matching a query via ReasoningBank.
+ */
+export async function retrieveMemories(query, opts) {
+    const rb = await getReasoningBank();
+    if (!rb?.retrieveMemories)
+        return [];
+    return rb.retrieveMemories(query, opts);
+}
+/**
+ * Check whether agentic-flow v3 is available at runtime.
+ */
+export async function isAvailable() {
+    const rb = await getReasoningBank();
+    return rb !== null;
+}
+/**
+ * Return a summary of available agentic-flow v3 capabilities.
+ */
+export async function capabilities() {
+    const [rb, router, orch] = await Promise.all([
+        getReasoningBank(),
+        getRouter(),
+        getOrchestration(),
+    ]);
+    return {
+        available: rb !== null || router !== null || orch !== null,
+        reasoningBank: rb !== null,
+        router: router !== null,
+        orchestration: orch !== null,
+        version: rb?.VERSION ?? null,
+    };
+}
+//# sourceMappingURL=agentic-flow-bridge.js.map

--- a/src/@claude-flow/cli/package.json
+++ b/src/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moflo/cli",
-  "version": "4.8.16",
+  "version": "4.8.18",
   "type": "module",
   "description": "MoFlo CLI — AI agent orchestration with specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/src/@claude-flow/cli/src/init/moflo-init.ts
+++ b/src/@claude-flow/cli/src/init/moflo-init.ts
@@ -619,6 +619,16 @@ function generateHooks(root: string, force?: boolean, answers?: MofloInitAnswers
   // Merge: preserve existing non-MoFlo hooks, add MoFlo hooks
   existing.hooks = hooks;
 
+  // Ensure statusLine is always present (required for dashboard display).
+  // The executor.ts / settings-generator.ts code path adds this, but
+  // moflo-init.ts uses its own generateHooks() which was missing it.
+  if (!existing.statusLine) {
+    existing.statusLine = {
+      type: 'command',
+      command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/statusline.cjs"',
+    };
+  }
+
   fs.writeFileSync(settingsPath, JSON.stringify(existing, null, 2), 'utf-8');
   return { name: '.claude/settings.json', status: existing.hooks ? 'updated' : 'created', detail: '14 hooks configured (gates, lifecycle, routing, session)' };
 }

--- a/src/@claude-flow/cli/src/services/agentic-flow-bridge.ts
+++ b/src/@claude-flow/cli/src/services/agentic-flow-bridge.ts
@@ -8,6 +8,15 @@
  * @module agentic-flow-bridge
  */
 
+// Suppress the agentic-flow agentdb-runtime-patch warning.
+// The patch targets agentdb v1.3.9 (dist/controllers/index.js) but
+// agentdb v3+ moved to dist/src/controllers/ and already ships with
+// correct .js extensions. The patch is unnecessary and prints a
+// confusing "[AgentDB Patch] Controller index not found" warning.
+if (typeof process !== 'undefined' && !process.env.SKIP_AGENTDB_PATCH) {
+  process.env.SKIP_AGENTDB_PATCH = '1';
+}
+
 // ---------------------------------------------------------------------------
 // Cached module handles (Promise-based to prevent TOCTOU races)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **statusLine missing from `moflo init`**: `generateHooks()` in `moflo-init.ts` only writes hooks to settings.json — the `statusLine` config from `settings-generator.ts` is never reached. Users get a blank status line on fresh projects.
- **AgentDB patch warning noise**: `agentic-flow` prints `[AgentDB Patch] Controller index not found` on every invocation. Set `SKIP_AGENTDB_PATCH=1` since the patch is unnecessary for agentdb v3+.

## Test plan

- [x] `npx flo doctor --fix` — 16/16 passing
- [x] `npx flo diagnose` — 14/14 integration tests passing
- [x] No `[AgentDB Patch]` warning on any CLI/hook invocation
- [x] Status line displays after `moflo init` on fresh project
- [x] Windows compatibility audit — zero breakages found

🤖 Generated with [Claude Code](https://claude.com/claude-code)