### PR TITLE
fix: remove confusing next-steps from init output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moflo",
-  "version": "4.8.21",
+  "version": "4.8.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moflo",
-      "version": "4.8.21",
+      "version": "4.8.27",
       "license": "MIT",
       "dependencies": {
         "@ruvector/learning-wasm": "^0.1.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moflo",
-  "version": "4.8.26",
+  "version": "4.8.27",
   "description": "MoFlo — AI agent orchestration for Claude Code. Forked from ruflo/claude-flow with patches applied to source, plus feature-level orchestration.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/@claude-flow/cli/package.json
+++ b/src/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moflo/cli",
-  "version": "4.8.26",
+  "version": "4.8.27",
   "type": "module",
   "description": "MoFlo CLI — AI agent orchestration with specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/src/@claude-flow/cli/src/commands/init.ts
+++ b/src/@claude-flow/cli/src/commands/init.ts
@@ -299,8 +299,6 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
       output.writeln(output.bold('Next steps:'));
       output.printList([
         `Restart Claude Code to activate hooks and index guidance/code (recommended)`,
-        `Or run ${output.highlight('claude-flow init --start-all')} to start services and index now`,
-        `Run ${output.highlight('claude-flow daemon start')} to start background workers`,
         options.components.settings ? `Review ${output.highlight('.claude/settings.json')} for hook configurations` : '',
       ].filter(Boolean));
     }


### PR DESCRIPTION
## Summary
- Remove "claude-flow init --start-all" and "claude-flow daemon start" lines from `flo init` output
- These instructions confused users — the daemon and indexing start automatically via hooks
- Bumps version to 4.8.27

## Test plan
- [ ] Run `npx flo init` in a fresh project and verify only "Restart Claude Code" appears in next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)