### PR TITLE
fix(indexers): backfill missing embeddings on incremental runs

### DIFF
--- a/bin/generate-code-map.mjs
+++ b/bin/generate-code-map.mjs
@@ -176,6 +176,15 @@ function countNamespace(db) {
   return count;
 }
 
+function countMissingEmbeddings(db) {
+  const stmt = db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = ? AND (embedding IS NULL OR embedding = '')`);
+  stmt.bind([NAMESPACE]);
+  let count = 0;
+  if (stmt.step()) count = stmt.getAsObject().cnt;
+  stmt.free();
+  return count;
+}
+
 // ---------------------------------------------------------------------------
 // Source file enumeration — git ls-files with filesystem fallback
 // ---------------------------------------------------------------------------
@@ -831,9 +840,15 @@ async function main() {
   if (isUnchanged(currentHash)) {
     const db = await getDb();
     const count = countNamespace(db);
+    const missing = countMissingEmbeddings(db);
     db.close();
     if (count > 0) {
-      log(`Skipping — file list unchanged (${count} chunks in DB, hash ${currentHash.slice(0, 12)}...)`);
+      if (missing > 0 && !skipEmbeddings) {
+        log(`File list unchanged but ${missing}/${count} entries missing embeddings — generating...`);
+        await runEmbeddings();
+      } else {
+        log(`Skipping — file list unchanged (${count} chunks in DB, hash ${currentHash.slice(0, 12)}...)`);
+      }
       return;
     }
     log('File list unchanged but no chunks in DB — forcing regeneration');
@@ -910,25 +925,28 @@ async function main() {
 
   // 7. Generate embeddings inline (not detached — ensures Xenova runs reliably)
   if (!skipEmbeddings) {
-    // Prefer moflo's own bin script, fall back to project's .claude/scripts/
-    const embedCandidates = [
-      resolve(dirname(fileURLToPath(import.meta.url)), 'build-embeddings.mjs'),
-      resolve(projectRoot, '.claude/scripts/build-embeddings.mjs'),
-    ];
-    const embedScript = embedCandidates.find(p => existsSync(p));
-    if (embedScript) {
-      log('Generating embeddings for code-map...');
-      try {
-        execSync(`node "${embedScript}" --namespace code-map`, {
-          cwd: projectRoot,
-          stdio: 'inherit',
-          timeout: 120000,
-          windowsHide: true,
-        });
-      } catch (err) {
-        log(`Warning: embedding generation failed: ${err.message?.split('\n')[0]}`);
-      }
-    }
+    await runEmbeddings();
+  }
+}
+
+async function runEmbeddings() {
+  const embedCandidates = [
+    resolve(dirname(fileURLToPath(import.meta.url)), 'build-embeddings.mjs'),
+    resolve(projectRoot, '.claude/scripts/build-embeddings.mjs'),
+  ];
+  const embedScript = embedCandidates.find(p => existsSync(p));
+  if (!embedScript) return;
+
+  log('Generating embeddings for code-map...');
+  try {
+    execSync(`node "${embedScript}" --namespace code-map`, {
+      cwd: projectRoot,
+      stdio: 'inherit',
+      timeout: 120000,
+      windowsHide: true,
+    });
+  } catch (err) {
+    log(`Warning: embedding generation failed: ${err.message?.split('\n')[0]}`);
   }
 }
 

--- a/bin/index-guidance.mjs
+++ b/bin/index-guidance.mjs
@@ -819,8 +819,17 @@ if (!specificFile) {
   }
 }
 
-// Write changes back to disk and close
+// Write changes back to disk
 if (docsIndexed > 0 || chunksIndexed > 0 || staleRemoved > 0) saveDb(db);
+
+// Check for entries missing embeddings (e.g. prior background run failed)
+let missingEmbeddings = 0;
+{
+  const stmt = db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = ? AND (embedding IS NULL OR embedding = '')`);
+  stmt.bind([NAMESPACE]);
+  if (stmt.step()) missingEmbeddings = stmt.getAsObject().cnt;
+  stmt.free();
+}
 db.close();
 
 console.log('');
@@ -840,9 +849,13 @@ log(`    • Hierarchical links (h2 -> h3 parent/children)`);
 log(`    • Context overlap: ${overlapPercent}% (contextBefore/contextAfter)`);
 log('═══════════════════════════════════════════════════════════');
 
-// Generate embeddings for new entries (unless skipped or nothing changed)
+// Generate embeddings for new entries or backfill missing ones
 // Runs in BACKGROUND to avoid blocking startup
-if (!skipEmbeddings && (docsIndexed > 0 || chunksIndexed > 0)) {
+const needsEmbeddings = (docsIndexed > 0 || chunksIndexed > 0 || missingEmbeddings > 0);
+if (!skipEmbeddings && needsEmbeddings) {
+  if (missingEmbeddings > 0 && docsIndexed === 0 && chunksIndexed === 0) {
+    log(`${missingEmbeddings} entries missing embeddings — backfilling...`);
+  }
   console.log('');
   log('Spawning embedding generation in background...');
 

--- a/bin/index-tests.mjs
+++ b/bin/index-tests.mjs
@@ -153,6 +153,15 @@ function countNamespace(db) {
   return count;
 }
 
+function countMissingEmbeddings(db) {
+  const stmt = db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = ? AND (embedding IS NULL OR embedding = '')`);
+  stmt.bind([NAMESPACE]);
+  let count = 0;
+  if (stmt.step()) count = stmt.getAsObject().cnt;
+  stmt.free();
+  return count;
+}
+
 // ---------------------------------------------------------------------------
 // Test directory discovery
 // ---------------------------------------------------------------------------
@@ -618,9 +627,15 @@ async function main() {
   if (isUnchanged(currentHash)) {
     const db = await getDb();
     const count = countNamespace(db);
+    const missing = countMissingEmbeddings(db);
     db.close();
     if (count > 0) {
-      log(`Skipping — file list unchanged (${count} chunks in DB, hash ${currentHash.slice(0, 12)}...)`);
+      if (missing > 0 && !skipEmbeddings) {
+        log(`File list unchanged but ${missing}/${count} entries missing embeddings — generating...`);
+        await runEmbeddings();
+      } else {
+        log(`Skipping — file list unchanged (${count} chunks in DB, hash ${currentHash.slice(0, 12)}...)`);
+      }
       return;
     }
     log('File list unchanged but no chunks in DB — forcing regeneration');
@@ -683,24 +698,28 @@ async function main() {
 
   // 7. Generate embeddings (inline, like code-map)
   if (!skipEmbeddings && allChunks.length > 0) {
-    const embedCandidates = [
-      resolve(dirname(fileURLToPath(import.meta.url)), 'build-embeddings.mjs'),
-      resolve(projectRoot, '.claude/scripts/build-embeddings.mjs'),
-    ];
-    const embedScript = embedCandidates.find(p => existsSync(p));
-    if (embedScript) {
-      log('Generating embeddings for tests...');
-      try {
-        execSync(`node "${embedScript}" --namespace tests`, {
-          cwd: projectRoot,
-          stdio: 'inherit',
-          timeout: 120000,
-          windowsHide: true,
-        });
-      } catch (err) {
-        log(`Warning: embedding generation failed: ${err.message?.split('\n')[0]}`);
-      }
-    }
+    await runEmbeddings();
+  }
+}
+
+async function runEmbeddings() {
+  const embedCandidates = [
+    resolve(dirname(fileURLToPath(import.meta.url)), 'build-embeddings.mjs'),
+    resolve(projectRoot, '.claude/scripts/build-embeddings.mjs'),
+  ];
+  const embedScript = embedCandidates.find(p => existsSync(p));
+  if (!embedScript) return;
+
+  log('Generating embeddings for tests...');
+  try {
+    execSync(`node "${embedScript}" --namespace tests`, {
+      cwd: projectRoot,
+      stdio: 'inherit',
+      timeout: 120000,
+      windowsHide: true,
+    });
+  } catch (err) {
+    log(`Warning: embedding generation failed: ${err.message?.split('\n')[0]}`);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moflo",
-  "version": "4.8.25",
+  "version": "4.8.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moflo",
-      "version": "4.8.25",
+      "version": "4.8.28",
       "license": "MIT",
       "dependencies": {
         "@ruvector/learning-wasm": "^0.1.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moflo",
-  "version": "4.8.25",
+  "version": "4.8.28",
   "description": "MoFlo — AI agent orchestration for Claude Code. Forked from ruflo/claude-flow with patches applied to source, plus feature-level orchestration.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/@claude-flow/cli/package.json
+++ b/src/@claude-flow/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moflo/cli",
-  "version": "4.8.25",
+  "version": "4.8.28",
   "type": "module",
   "description": "MoFlo CLI — AI agent orchestration with specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- When hash-cache indicates no file changes, indexers now check for entries missing embeddings and backfill them without re-indexing content
- Fixes issue where a failed embedding step (OOM, timeout) left entries permanently unembedded
- Applied to all three indexers: `index-tests.mjs`, `generate-code-map.mjs`, `index-guidance.mjs`
- Extracted `runEmbeddings()` / `countMissingEmbeddings()` helpers for reuse in both early-exit and main paths

## Test plan
- [x] `npm test` — 151 passed, 2 pre-existing failures (unrelated OOM/process.exit)
- [x] Verified hash-hit path skips cleanly when embeddings present
- [x] Verified hash-hit path triggers backfill when embeddings missing
- [x] Verified full reindex path still generates embeddings
- [x] `--stats` mode works for all three indexers
- [x] Syntax check passes for index-guidance.mjs

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)