### PR TITLE
chore: update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "moflo": "bin/cli.js"
       },
       "devDependencies": {
-        "@types/bcrypt": "^5.0.2",
         "@types/node": "^20.19.37",
         "eslint": "^8.0.0",
         "moflo": "^4.8.47",
@@ -4977,16 +4976,6 @@
       "integrity": "sha512-vBkIh9AY22kVOCEKo5CJlyCgmSWvasC+SWUxL/x/vOwRobMpI/HG1xp/Ae3AqmSiZeLUbOhW0FCD3ZjqqUxmXw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/bcrypt": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
-      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",


### PR DESCRIPTION
## Summary
- Refreshed package-lock.json after local dep update to v4.8.48

## Test plan
- [x] `npm install` clean
- [x] Lockfile-only change (no code changes)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)