### PR TITLE
feat(swarm): MessageStore schema + CRUD (Story #111)

### DIFF
--- a/src/packages/swarm/src/index.ts
+++ b/src/packages/swarm/src/index.ts
@@ -83,6 +83,9 @@ export type {
   PerformanceReport,
   AgentPoolConfig,
   AgentPoolState,
+  AgentMessage,
+  AgentMessageStatus,
+  IMessageStore,
 } from './types.js';
 
 // =============================================================================
@@ -174,8 +177,17 @@ export {
   MessageBus,
   createMessageBus,
   WriteThroughAdapter,
+  MessageStore,
 } from './message-bus.js';
-export type { WriteThroughConfig, MemoryStoreFunction, MemoryDeleteFunction, MemoryListFunction } from './message-bus.js';
+export type {
+  WriteThroughConfig,
+  MemoryStoreFunction,
+  MemoryDeleteFunction,
+  MemoryListFunction,
+  MessageStoreConfig,
+  MemoryListWithValueFunction,
+  MemoryRetrieveFunction,
+} from './message-bus.js';
 
 // =============================================================================
 // Agent Pool

--- a/src/packages/swarm/src/message-bus.ts
+++ b/src/packages/swarm/src/message-bus.ts
@@ -3,5 +3,5 @@
  * @see ./message-bus/ for implementation
  */
 
-export { MessageBus, createMessageBus, Deque, PriorityMessageQueue, WriteThroughAdapter } from './message-bus/index.js';
-export type { MessageQueueEntry, WriteThroughConfig, MemoryStoreFunction, MemoryDeleteFunction, MemoryListFunction } from './message-bus/index.js';
+export { MessageBus, createMessageBus, Deque, PriorityMessageQueue, WriteThroughAdapter, MessageStore } from './message-bus/index.js';
+export type { MessageQueueEntry, WriteThroughConfig, MemoryStoreFunction, MemoryDeleteFunction, MemoryListFunction, MessageStoreConfig, MemoryListWithValueFunction, MemoryRetrieveFunction } from './message-bus/index.js';

--- a/src/packages/swarm/src/message-bus/index.ts
+++ b/src/packages/swarm/src/message-bus/index.ts
@@ -11,6 +11,7 @@ export { Deque } from './deque.js';
 export { PriorityMessageQueue, type MessageQueueEntry } from './priority-queue.js';
 export { MessageBus } from './message-bus.js';
 export { WriteThroughAdapter, type WriteThroughConfig, type MemoryStoreFunction, type MemoryDeleteFunction, type MemoryListFunction } from './write-through-adapter.js';
+export { MessageStore, type MessageStoreConfig, type MemoryListWithValueFunction, type MemoryRetrieveFunction } from './message-store.js';
 
 import type { MessageBusConfig } from '../types.js';
 import { MessageBus } from './message-bus.js';

--- a/src/packages/swarm/src/message-bus/message-store.ts
+++ b/src/packages/swarm/src/message-bus/message-store.ts
@@ -1,0 +1,289 @@
+/**
+ * MessageStore — Persistent message storage backed by memory DB.
+ *
+ * Cross-process, session-scoped, queryable message persistence.
+ * Messages stored in `messages` namespace with key format: msg:{sessionId}:{channel}:{id}
+ *
+ * Story #111: Message Namespace Schema + CRUD
+ */
+
+import { randomBytes } from 'crypto';
+import type {
+  AgentMessage,
+  IMessageStore,
+} from '../types.js';
+import type { MemoryStoreFunction, MemoryDeleteFunction } from './write-through-adapter.js';
+
+/** Extended list function that returns full entry values */
+export type MemoryListWithValueFunction = (options: {
+  namespace: string;
+  limit?: number;
+}) => Promise<{
+  entries: Array<{
+    key: string;
+    value?: string;
+    metadata?: Record<string, unknown>;
+  }>;
+}>;
+
+/** Memory retrieve function for single entry lookup */
+export type MemoryRetrieveFunction = (options: {
+  key: string;
+  namespace: string;
+}) => Promise<{ value?: string; metadata?: Record<string, unknown> } | null>;
+
+export interface MessageStoreConfig {
+  /** Memory DB store function */
+  store: MemoryStoreFunction;
+  /** Memory DB delete function */
+  delete: MemoryDeleteFunction;
+  /** Memory DB list function (with values) */
+  list: MemoryListWithValueFunction;
+  /** Memory DB retrieve function */
+  retrieve: MemoryRetrieveFunction;
+  /** Default session ID (can be overridden per message) */
+  sessionId: string;
+  /** Default TTL for session GC in ms (default: 24h) */
+  sessionMaxAge?: number;
+}
+
+const NAMESPACE = 'messages';
+const DEFAULT_SESSION_MAX_AGE = 24 * 60 * 60 * 1000;
+const MAX_LIST_LIMIT = 10_000;
+
+export class MessageStore implements IMessageStore {
+  private config: MessageStoreConfig;
+
+  constructor(config: MessageStoreConfig) {
+    this.config = config;
+  }
+
+  private generateId(): string {
+    const timestamp = Date.now().toString(36);
+    const random = randomBytes(6).toString('hex');
+    return `${timestamp}_${random}`;
+  }
+
+  private messageKey(sessionId: string, channel: string, id: string): string {
+    return `msg:${sessionId}:${channel}:${id}`;
+  }
+
+  private buildTags(msg: AgentMessage): string[] {
+    return [msg.channel, msg.type, `session:${msg.sessionId}`];
+  }
+
+  private async persistMessage(msg: AgentMessage, ttlSeconds?: number): Promise<void> {
+    const key = this.messageKey(msg.sessionId, msg.channel, msg.id);
+    await this.config.store({
+      key,
+      value: JSON.stringify(msg),
+      namespace: NAMESPACE,
+      tags: this.buildTags(msg),
+      ttl: ttlSeconds,
+      upsert: true,
+    });
+  }
+
+  async send(
+    msg: Omit<AgentMessage, 'id' | 'createdAt' | 'readBy' | 'status'>,
+  ): Promise<string> {
+    const id = this.generateId();
+    const message: AgentMessage = {
+      ...msg,
+      id,
+      createdAt: Date.now(),
+      readBy: [],
+      status: 'pending',
+    };
+
+    const ttlSeconds = msg.ttlMs ? Math.ceil(msg.ttlMs / 1000) : undefined;
+    await this.persistMessage(message, ttlSeconds);
+    return id;
+  }
+
+  async receive(
+    agentId: string,
+    channel: string,
+    opts?: { since?: number; unreadOnly?: boolean; limit?: number },
+  ): Promise<AgentMessage[]> {
+    const messages = await this.listChannelMessages(channel, this.config.sessionId);
+
+    let filtered = messages.filter((m) => {
+      if (m.to !== '*' && m.to !== agentId) return false;
+      if (this.isExpired(m)) return false;
+      if (opts?.since !== undefined && m.createdAt <= opts.since) return false;
+      if (opts?.unreadOnly && m.readBy.includes(agentId)) return false;
+      return true;
+    });
+
+    // Deterministic ordering: epoch for chronology, id for same-ms tiebreaker
+    filtered.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
+
+    if (opts?.limit !== undefined) {
+      filtered = filtered.slice(0, opts.limit);
+    }
+
+    return filtered;
+  }
+
+  async markRead(agentId: string, messageIds: string[]): Promise<void> {
+    const sessionMessages = await this.listSessionMessages(this.config.sessionId);
+    const byId = new Map(sessionMessages.map((m) => [m.id, m]));
+    const writes: Promise<void>[] = [];
+
+    for (const msgId of messageIds) {
+      const message = byId.get(msgId);
+      if (!message) continue;
+
+      if (!message.readBy.includes(agentId)) {
+        message.readBy.push(agentId);
+      }
+      if (message.to === agentId || message.to === '*') {
+        message.status = 'read';
+      }
+
+      writes.push(this.persistMessage(message));
+    }
+
+    await Promise.all(writes);
+  }
+
+  async broadcast(
+    channel: string,
+    msg: Omit<AgentMessage, 'id' | 'createdAt' | 'readBy' | 'status' | 'to'>,
+  ): Promise<string> {
+    return this.send({ ...msg, to: '*', channel });
+  }
+
+  async getThread(replyTo: string): Promise<AgentMessage[]> {
+    const allMessages = await this.listSessionMessages(this.config.sessionId);
+    const thread: AgentMessage[] = [];
+
+    const root = allMessages.find((m) => m.id === replyTo);
+    if (root) thread.push(root);
+
+    // Index children by replyTo for O(1) lookups
+    const childrenOf = new Map<string, AgentMessage[]>();
+    for (const msg of allMessages) {
+      if (msg.replyTo) {
+        const list = childrenOf.get(msg.replyTo) ?? [];
+        list.push(msg);
+        childrenOf.set(msg.replyTo, list);
+      }
+    }
+
+    const seen = new Set<string>([replyTo]);
+    let frontier = [replyTo];
+
+    while (frontier.length > 0) {
+      const nextFrontier: string[] = [];
+      for (const parentId of frontier) {
+        for (const child of childrenOf.get(parentId) ?? []) {
+          if (!seen.has(child.id)) {
+            thread.push(child);
+            seen.add(child.id);
+            nextFrontier.push(child.id);
+          }
+        }
+      }
+      frontier = nextFrontier;
+    }
+
+    thread.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
+    return thread;
+  }
+
+  async expire(): Promise<number> {
+    const allMessages = await this.listAllMessages();
+    const toDelete = allMessages.filter((m) => this.isExpired(m));
+
+    await Promise.all(
+      toDelete.map((m) =>
+        this.config.delete({
+          key: this.messageKey(m.sessionId, m.channel, m.id),
+          namespace: NAMESPACE,
+        }),
+      ),
+    );
+
+    return toDelete.length;
+  }
+
+  async channelHistory(channel: string, limit?: number): Promise<AgentMessage[]> {
+    const messages = await this.listChannelMessages(channel, this.config.sessionId);
+    const sorted = messages
+      .filter((m) => !this.isExpired(m))
+      .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
+
+    return limit ? sorted.slice(-limit) : sorted;
+  }
+
+  async endSession(sessionId: string): Promise<number> {
+    const messages = await this.listSessionMessages(sessionId);
+    const toDelete = messages.filter((m) => m.status === 'pending' || m.status === 'delivered');
+
+    await Promise.all(
+      toDelete.map((m) =>
+        this.config.delete({
+          key: this.messageKey(m.sessionId, m.channel, m.id),
+          namespace: NAMESPACE,
+        }),
+      ),
+    );
+
+    return toDelete.length;
+  }
+
+  async gc(maxAge?: number): Promise<number> {
+    const age = maxAge ?? this.config.sessionMaxAge ?? DEFAULT_SESSION_MAX_AGE;
+    const cutoff = Date.now() - age;
+    const allMessages = await this.listAllMessages();
+    const toDelete = allMessages.filter((m) => m.createdAt < cutoff);
+
+    await Promise.all(
+      toDelete.map((m) =>
+        this.config.delete({
+          key: this.messageKey(m.sessionId, m.channel, m.id),
+          namespace: NAMESPACE,
+        }),
+      ),
+    );
+
+    return toDelete.length;
+  }
+
+  private isExpired(msg: AgentMessage): boolean {
+    if (!msg.ttlMs) return false;
+    return Date.now() - msg.createdAt > msg.ttlMs;
+  }
+
+  private async listAllMessages(): Promise<AgentMessage[]> {
+    const result = await this.config.list({ namespace: NAMESPACE, limit: MAX_LIST_LIMIT });
+    return this.parseEntries(result.entries);
+  }
+
+  private async listSessionMessages(sessionId: string): Promise<AgentMessage[]> {
+    const all = await this.listAllMessages();
+    return all.filter((m) => m.sessionId === sessionId);
+  }
+
+  private async listChannelMessages(channel: string, sessionId: string): Promise<AgentMessage[]> {
+    const all = await this.listAllMessages();
+    return all.filter((m) => m.sessionId === sessionId && m.channel === channel);
+  }
+
+  private parseEntries(
+    entries: Array<{ key: string; value?: string; metadata?: Record<string, unknown> }>,
+  ): AgentMessage[] {
+    const messages: AgentMessage[] = [];
+    for (const entry of entries) {
+      if (!entry.value) continue;
+      try {
+        messages.push(JSON.parse(entry.value) as AgentMessage);
+      } catch {
+        // Skip malformed entries
+      }
+    }
+    return messages;
+  }
+}

--- a/src/packages/swarm/src/types.ts
+++ b/src/packages/swarm/src/types.ts
@@ -597,6 +597,68 @@ export interface IMessageBus {
   getQueueDepth(): number;
 }
 
+// ===== MESSAGE STORE TYPES (Story #111) =====
+
+/** Message status in the persistent store */
+export type AgentMessageStatus = 'pending' | 'delivered' | 'read' | 'expired';
+
+/**
+ * Persistent agent message — stored in memory DB `messages` namespace.
+ * Extends UnifiedMessage with persistence fields: sessionId, readBy, status, replyTo.
+ */
+export interface AgentMessage {
+  id: string;
+  /** Channel for routing, e.g. "swarm:abc123", "hive:consensus", "workflow:step3" */
+  channel: string;
+  from: string;
+  to: string | '*';
+  type: MessageType;
+  priority: MessagePriority;
+  payload: Record<string, unknown>;
+  /** Optional text content (sugar for string payloads) */
+  content?: string;
+  /** ID of message this replies to (threading) */
+  replyTo?: string;
+  /** Time-to-live in ms (auto-expire) */
+  ttlMs?: number;
+  /** Epoch ms */
+  createdAt: number;
+  /** Agent IDs that have read this message */
+  readBy: string[];
+  status: AgentMessageStatus;
+  /** Session scoping — messages are invisible across sessions */
+  sessionId: string;
+}
+
+/**
+ * Persistent message store backed by memory DB.
+ * Cross-process, session-scoped, queryable message persistence.
+ */
+export interface IMessageStore {
+  /** Send a message, returns message ID */
+  send(msg: Omit<AgentMessage, 'id' | 'createdAt' | 'readBy' | 'status'>): Promise<string>;
+  /** Retrieve messages for an agent on a channel */
+  receive(agentId: string, channel: string, opts?: {
+    since?: number;
+    unreadOnly?: boolean;
+    limit?: number;
+  }): Promise<AgentMessage[]>;
+  /** Mark messages as read by an agent */
+  markRead(agentId: string, messageIds: string[]): Promise<void>;
+  /** Broadcast to all agents on a channel */
+  broadcast(channel: string, msg: Omit<AgentMessage, 'id' | 'createdAt' | 'readBy' | 'status' | 'to'>): Promise<string>;
+  /** Get a conversation thread by replyTo chain */
+  getThread(replyTo: string): Promise<AgentMessage[]>;
+  /** Clean up TTL-expired and session-expired messages, return count */
+  expire(): Promise<number>;
+  /** Get message history for a channel */
+  channelHistory(channel: string, limit?: number): Promise<AgentMessage[]>;
+  /** Expire all unhandled messages for a session, return count */
+  endSession(sessionId: string): Promise<number>;
+  /** Remove old session messages (default maxAge: 24h), return count */
+  gc(maxAge?: number): Promise<number>;
+}
+
 export interface IAgentPool {
   initialize(config: AgentPoolConfig): Promise<void>;
   acquire(): Promise<AgentState | undefined>;

--- a/tests/message-store.test.ts
+++ b/tests/message-store.test.ts
@@ -1,0 +1,594 @@
+/**
+ * Tests for Story #111: Message Namespace Schema + CRUD
+ *
+ * Covers:
+ * - AgentMessage type fields
+ * - MessageStore send/receive/markRead/broadcast
+ * - getThread (conversation threading)
+ * - expire (TTL cleanup)
+ * - channelHistory
+ * - Session isolation (endSession, gc)
+ * - Message ordering (createdAt + id tiebreaker)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MessageStore } from '../src/packages/swarm/src/message-bus/message-store.js';
+import type { MessageStoreConfig } from '../src/packages/swarm/src/message-bus/message-store.js';
+import type { AgentMessage } from '../src/packages/swarm/src/types.js';
+
+/** In-memory mock for Memory DB */
+function createMockMemoryDb() {
+  const storage = new Map<string, { value: string; tags?: string[]; ttl?: number }>();
+
+  return {
+    storage,
+    store: async (opts: { key: string; value: string; namespace: string; tags?: string[]; ttl?: number; upsert?: boolean }) => {
+      storage.set(`${opts.namespace}:${opts.key}`, { value: opts.value, tags: opts.tags, ttl: opts.ttl });
+      return { success: true, id: opts.key };
+    },
+    delete: async (opts: { key: string; namespace: string }) => {
+      storage.delete(`${opts.namespace}:${opts.key}`);
+      return { success: true };
+    },
+    list: async (opts: { namespace: string; limit?: number }) => {
+      const entries: Array<{ key: string; value?: string; metadata?: Record<string, unknown> }> = [];
+      for (const [compositeKey, data] of storage) {
+        if (compositeKey.startsWith(`${opts.namespace}:`)) {
+          const key = compositeKey.slice(opts.namespace.length + 1);
+          entries.push({ key, value: data.value });
+        }
+        if (opts.limit && entries.length >= opts.limit) break;
+      }
+      return { entries };
+    },
+    retrieve: async (opts: { key: string; namespace: string }) => {
+      const data = storage.get(`${opts.namespace}:${opts.key}`);
+      if (!data) return null;
+      return { value: data.value };
+    },
+  };
+}
+
+function createStore(sessionId = 'test-session'): { store: MessageStore; db: ReturnType<typeof createMockMemoryDb> } {
+  const db = createMockMemoryDb();
+  const config: MessageStoreConfig = {
+    store: db.store,
+    delete: db.delete,
+    list: db.list,
+    retrieve: db.retrieve,
+    sessionId,
+  };
+  return { store: new MessageStore(config), db };
+}
+
+describe('MessageStore — Schema + CRUD (Story #111)', () => {
+  let store: MessageStore;
+  let db: ReturnType<typeof createMockMemoryDb>;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ now: 1000000 });
+    ({ store, db } = createStore());
+  });
+
+  // =========================================================================
+  // send()
+  // =========================================================================
+
+  describe('send()', () => {
+    it('stores a message and returns an ID', async () => {
+      const id = await store.send({
+        channel: 'swarm:abc',
+        from: 'agent-1',
+        to: 'agent-2',
+        type: 'task_assign',
+        priority: 'normal',
+        payload: { task: 'build' },
+        sessionId: 'test-session',
+      });
+
+      expect(id).toBeTruthy();
+      expect(typeof id).toBe('string');
+      expect(db.storage.size).toBe(1);
+    });
+
+    it('sets default fields: readBy=[], status=pending, createdAt=now', async () => {
+      const id = await store.send({
+        channel: 'swarm:abc',
+        from: 'agent-1',
+        to: 'agent-2',
+        type: 'task_assign',
+        priority: 'normal',
+        payload: {},
+        sessionId: 'test-session',
+      });
+
+      const messages = await store.receive('agent-2', 'swarm:abc');
+      expect(messages).toHaveLength(1);
+      expect(messages[0].id).toBe(id);
+      expect(messages[0].readBy).toEqual([]);
+      expect(messages[0].status).toBe('pending');
+      expect(messages[0].createdAt).toBe(1000000);
+    });
+
+    it('persists all AgentMessage fields', async () => {
+      await store.send({
+        channel: 'hive:consensus',
+        from: 'queen',
+        to: 'worker-3',
+        type: 'consensus_propose',
+        priority: 'urgent',
+        payload: { proposal: 'merge' },
+        content: 'Propose merge',
+        replyTo: 'prev-msg-id',
+        ttlMs: 30000,
+        sessionId: 'test-session',
+      });
+
+      const msgs = await store.receive('worker-3', 'hive:consensus');
+      expect(msgs[0].channel).toBe('hive:consensus');
+      expect(msgs[0].from).toBe('queen');
+      expect(msgs[0].to).toBe('worker-3');
+      expect(msgs[0].type).toBe('consensus_propose');
+      expect(msgs[0].priority).toBe('urgent');
+      expect(msgs[0].payload).toEqual({ proposal: 'merge' });
+      expect(msgs[0].content).toBe('Propose merge');
+      expect(msgs[0].replyTo).toBe('prev-msg-id');
+      expect(msgs[0].ttlMs).toBe(30000);
+    });
+
+    it('generates unique IDs for each message', async () => {
+      const id1 = await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      const id2 = await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  // =========================================================================
+  // receive()
+  // =========================================================================
+
+  describe('receive()', () => {
+    it('receives messages addressed to the agent', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { n: 1 }, sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'ch', from: 'a', to: 'c', type: 'direct',
+        priority: 'normal', payload: { n: 2 }, sessionId: 'test-session',
+      });
+
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].payload).toEqual({ n: 1 });
+    });
+
+    it('receives broadcast messages', async () => {
+      await store.broadcast('ch', {
+        from: 'orchestrator', type: 'broadcast',
+        priority: 'normal', payload: { info: 'hello' }, sessionId: 'test-session',
+      });
+
+      const msgs = await store.receive('any-agent', 'ch');
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].to).toBe('*');
+    });
+
+    it('filters by since timestamp', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { n: 1 }, sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(100);
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { n: 2 }, sessionId: 'test-session',
+      });
+
+      const msgs = await store.receive('b', 'ch', { since: 1000000 });
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].payload).toEqual({ n: 2 });
+    });
+
+    it('filters unread only', async () => {
+      const id = await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      await store.markRead('b', [id]);
+
+      const unread = await store.receive('b', 'ch', { unreadOnly: true });
+      expect(unread).toHaveLength(0);
+
+      const all = await store.receive('b', 'ch');
+      expect(all).toHaveLength(1);
+    });
+
+    it('limits results', async () => {
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(1);
+        await store.send({
+          channel: 'ch', from: 'a', to: 'b', type: 'direct',
+          priority: 'normal', payload: { n: i }, sessionId: 'test-session',
+        });
+      }
+
+      const msgs = await store.receive('b', 'ch', { limit: 3 });
+      expect(msgs).toHaveLength(3);
+      // Should be ordered by createdAt
+      expect(msgs[0].payload).toEqual({ n: 0 });
+      expect(msgs[2].payload).toEqual({ n: 2 });
+    });
+
+    it('excludes expired messages', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { expired: true },
+        ttlMs: 100, sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(200);
+
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs).toHaveLength(0);
+    });
+
+    it('orders by createdAt ascending', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { n: 1 }, sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(100);
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { n: 2 }, sessionId: 'test-session',
+      });
+
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].payload).toEqual({ n: 1 });
+      expect(msgs[1].payload).toEqual({ n: 2 });
+      expect(msgs[0].createdAt).toBeLessThan(msgs[1].createdAt);
+    });
+  });
+
+  // =========================================================================
+  // markRead()
+  // =========================================================================
+
+  describe('markRead()', () => {
+    it('adds agent to readBy array', async () => {
+      const id = await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      await store.markRead('b', [id]);
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs[0].readBy).toContain('b');
+    });
+
+    it('updates status to read for intended recipient', async () => {
+      const id = await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      await store.markRead('b', [id]);
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs[0].status).toBe('read');
+    });
+
+    it('does not duplicate readBy entries', async () => {
+      const id = await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      await store.markRead('b', [id]);
+      await store.markRead('b', [id]);
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs[0].readBy.filter((r: string) => r === 'b')).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // broadcast()
+  // =========================================================================
+
+  describe('broadcast()', () => {
+    it('sends with to=* on the specified channel', async () => {
+      const id = await store.broadcast('swarm:updates', {
+        from: 'orchestrator', type: 'status_update',
+        priority: 'normal', payload: { status: 'running' }, sessionId: 'test-session',
+      });
+
+      expect(id).toBeTruthy();
+      const msgs = await store.receive('any-agent', 'swarm:updates');
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].to).toBe('*');
+      expect(msgs[0].channel).toBe('swarm:updates');
+    });
+  });
+
+  // =========================================================================
+  // getThread()
+  // =========================================================================
+
+  describe('getThread()', () => {
+    it('returns root message and all replies', async () => {
+      const rootId = await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'query',
+        priority: 'normal', payload: { q: 'status?' }, sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(10);
+      await store.send({
+        channel: 'ch', from: 'b', to: 'a', type: 'result',
+        priority: 'normal', payload: { a: 'ok' },
+        replyTo: rootId, sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(10);
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'result',
+        priority: 'normal', payload: { a: 'thanks' },
+        replyTo: rootId, sessionId: 'test-session',
+      });
+
+      const thread = await store.getThread(rootId);
+      expect(thread).toHaveLength(3);
+      expect(thread[0].id).toBe(rootId);
+      expect(thread[0].createdAt).toBeLessThan(thread[1].createdAt);
+    });
+
+    it('returns transitive replies (nested threads)', async () => {
+      const rootId = await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'query',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(10);
+      const replyId = await store.send({
+        channel: 'ch', from: 'b', to: 'a', type: 'result',
+        priority: 'normal', payload: {},
+        replyTo: rootId, sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(10);
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'result',
+        priority: 'normal', payload: {},
+        replyTo: replyId, sessionId: 'test-session',
+      });
+
+      const thread = await store.getThread(rootId);
+      expect(thread).toHaveLength(3);
+    });
+
+    it('returns empty array for unknown replyTo', async () => {
+      const thread = await store.getThread('nonexistent-id');
+      expect(thread).toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  // expire()
+  // =========================================================================
+
+  describe('expire()', () => {
+    it('removes TTL-expired messages', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, ttlMs: 100, sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(200);
+      const count = await store.expire();
+      expect(count).toBe(1);
+
+      // Non-expired message still accessible
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // channelHistory()
+  // =========================================================================
+
+  describe('channelHistory()', () => {
+    it('returns messages for a channel sorted by time', async () => {
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(1);
+        await store.send({
+          channel: 'history-ch', from: 'a', to: 'b', type: 'direct',
+          priority: 'normal', payload: { n: i }, sessionId: 'test-session',
+        });
+      }
+
+      const history = await store.channelHistory('history-ch');
+      expect(history).toHaveLength(5);
+      expect(history[0].createdAt).toBeLessThan(history[4].createdAt);
+    });
+
+    it('limits to last N messages', async () => {
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(1);
+        await store.send({
+          channel: 'ch', from: 'a', to: 'b', type: 'direct',
+          priority: 'normal', payload: { n: i }, sessionId: 'test-session',
+        });
+      }
+
+      const history = await store.channelHistory('ch', 3);
+      expect(history).toHaveLength(3);
+      // Last 3 messages
+      expect(history[0].payload).toEqual({ n: 2 });
+      expect(history[2].payload).toEqual({ n: 4 });
+    });
+
+    it('excludes expired messages', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, ttlMs: 50, sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(100);
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      const history = await store.channelHistory('ch');
+      expect(history).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // Session isolation
+  // =========================================================================
+
+  describe('session isolation', () => {
+    it('receive() only returns messages from current session', async () => {
+      // Message in different session
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { session: 'other' },
+        sessionId: 'other-session',
+      });
+      // Message in current session
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { session: 'current' },
+        sessionId: 'test-session',
+      });
+
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].payload).toEqual({ session: 'current' });
+    });
+
+    it('endSession() expires all unhandled messages', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'ch', from: 'a', to: 'c', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      const count = await store.endSession('test-session');
+      expect(count).toBe(2);
+
+      // Messages should be gone
+      const msgs = await store.receive('b', 'ch');
+      expect(msgs).toHaveLength(0);
+    });
+
+    it('endSession() does not affect other sessions', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'session-keep',
+      });
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'session-end',
+      });
+
+      await store.endSession('session-end');
+
+      // Create a new store with the kept session to check
+      const { store: keepStore } = createStore('session-keep');
+      // Re-use same DB by recreating — but since endSession only deletes session-end,
+      // the session-keep message should still be in the mock DB
+      // We need to verify via db.storage
+      let keepMessages = 0;
+      for (const [, data] of db.storage) {
+        const parsed = JSON.parse(data.value) as AgentMessage;
+        if (parsed.sessionId === 'session-keep') keepMessages++;
+      }
+      expect(keepMessages).toBe(1);
+    });
+  });
+
+  // =========================================================================
+  // gc()
+  // =========================================================================
+
+  describe('gc()', () => {
+    it('removes messages older than maxAge', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { old: true }, sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(60 * 60 * 1000); // 1 hour
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { new: true }, sessionId: 'test-session',
+      });
+
+      // GC with 30 min maxAge
+      const removed = await store.gc(30 * 60 * 1000);
+      expect(removed).toBe(1);
+    });
+
+    it('uses default 24h maxAge when not specified', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000); // 25 hours
+      const removed = await store.gc();
+      expect(removed).toBe(1);
+    });
+
+    it('keeps messages within maxAge', async () => {
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(1000); // 1 second
+      const removed = await store.gc();
+      expect(removed).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Persistence
+  // =========================================================================
+
+  describe('persistence', () => {
+    it('messages survive across MessageStore instances (same DB)', async () => {
+      await store.send({
+        channel: 'persist-ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: { persisted: true }, sessionId: 'test-session',
+      });
+
+      // Create new store with same DB
+      const config: MessageStoreConfig = {
+        store: db.store,
+        delete: db.delete,
+        list: db.list,
+        retrieve: db.retrieve,
+        sessionId: 'test-session',
+      };
+      const store2 = new MessageStore(config);
+      const msgs = await store2.receive('b', 'persist-ch');
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].payload).toEqual({ persisted: true });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `AgentMessage` type and `IMessageStore` interface to swarm types
- Implements `MessageStore` class backed by memory DB `messages` namespace
- Session-scoped, cross-process persistent messaging with send/receive, broadcast, threading, TTL expiry, session lifecycle, and GC
- 29 unit tests covering all CRUD operations and session isolation

## Changes
- `src/packages/swarm/src/types.ts` — `AgentMessage`, `AgentMessageStatus`, `IMessageStore` types
- `src/packages/swarm/src/message-bus/message-store.ts` — `MessageStore` implementation
- `src/packages/swarm/src/message-bus/index.ts` — re-export
- `src/packages/swarm/src/message-bus.ts` — barrel re-export
- `src/packages/swarm/src/index.ts` — public API export
- `tests/message-store.test.ts` — 29 unit tests

## Testing
- [x] Unit tests pass (29/29)
- [x] Full suite passes (5058 tests, 0 new failures)
- [x] Build clean (tsc -b)
- [x] Code reviewed by 3 parallel agents (reuse, quality, efficiency)

Closes #111

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)