### PR TITLE
feat(swarm): semantic search + summarize for MessageStore (Story #115)

### DIFF
--- a/src/packages/swarm/src/index.ts
+++ b/src/packages/swarm/src/index.ts
@@ -86,6 +86,10 @@ export type {
   AgentMessage,
   AgentMessageStatus,
   IMessageStore,
+  MessageSearchOptions,
+  ScoredMessage,
+  MessageSummarizeOptions,
+  MessageSummary,
 } from './types.js';
 
 // =============================================================================
@@ -187,6 +191,7 @@ export type {
   MessageStoreConfig,
   MemoryListWithValueFunction,
   MemoryRetrieveFunction,
+  EmbeddingFunction,
 } from './message-bus.js';
 
 // =============================================================================

--- a/src/packages/swarm/src/message-bus.ts
+++ b/src/packages/swarm/src/message-bus.ts
@@ -4,4 +4,4 @@
  */
 
 export { MessageBus, createMessageBus, Deque, PriorityMessageQueue, WriteThroughAdapter, MessageStore } from './message-bus/index.js';
-export type { MessageQueueEntry, WriteThroughConfig, MemoryStoreFunction, MemoryDeleteFunction, MemoryListFunction, MessageStoreConfig, MemoryListWithValueFunction, MemoryRetrieveFunction } from './message-bus/index.js';
+export type { MessageQueueEntry, WriteThroughConfig, MemoryStoreFunction, MemoryDeleteFunction, MemoryListFunction, MessageStoreConfig, MemoryListWithValueFunction, MemoryRetrieveFunction, EmbeddingFunction } from './message-bus/index.js';

--- a/src/packages/swarm/src/message-bus/index.ts
+++ b/src/packages/swarm/src/message-bus/index.ts
@@ -11,7 +11,7 @@ export { Deque } from './deque.js';
 export { PriorityMessageQueue, type MessageQueueEntry } from './priority-queue.js';
 export { MessageBus } from './message-bus.js';
 export { WriteThroughAdapter, type WriteThroughConfig, type MemoryStoreFunction, type MemoryDeleteFunction, type MemoryListFunction } from './write-through-adapter.js';
-export { MessageStore, type MessageStoreConfig, type MemoryListWithValueFunction, type MemoryRetrieveFunction } from './message-store.js';
+export { MessageStore, type MessageStoreConfig, type MemoryListWithValueFunction, type MemoryRetrieveFunction, type EmbeddingFunction } from './message-store.js';
 
 import type { MessageBusConfig } from '../types.js';
 import { MessageBus } from './message-bus.js';

--- a/src/packages/swarm/src/message-bus/message-store.ts
+++ b/src/packages/swarm/src/message-bus/message-store.ts
@@ -5,12 +5,18 @@
  * Messages stored in `messages` namespace with key format: msg:{sessionId}:{channel}:{id}
  *
  * Story #111: Message Namespace Schema + CRUD
+ * Story #115: Message History & Semantic Queryability
  */
 
 import { randomBytes } from 'crypto';
 import type {
   AgentMessage,
   IMessageStore,
+  MessageSearchOptions,
+  MessageSummarizeOptions,
+  MessageSummary,
+  MessageType,
+  ScoredMessage,
 } from '../types.js';
 import type { MemoryStoreFunction, MemoryDeleteFunction } from './write-through-adapter.js';
 
@@ -32,6 +38,11 @@ export type MemoryRetrieveFunction = (options: {
   namespace: string;
 }) => Promise<{ value?: string; metadata?: Record<string, unknown> } | null>;
 
+/** Duck-typed embedding service — avoids hard dependency on @claude-flow/embeddings */
+export interface EmbeddingFunction {
+  embed(text: string): Promise<{ embedding: Float32Array | number[] }>;
+}
+
 export interface MessageStoreConfig {
   /** Memory DB store function */
   store: MemoryStoreFunction;
@@ -45,11 +56,23 @@ export interface MessageStoreConfig {
   sessionId: string;
   /** Default TTL for session GC in ms (default: 24h) */
   sessionMaxAge?: number;
+  /** Embedding service for semantic search (optional, Story #115) */
+  embeddingService?: EmbeddingFunction;
 }
 
 const NAMESPACE = 'messages';
 const DEFAULT_SESSION_MAX_AGE = 24 * 60 * 60 * 1000;
 const MAX_LIST_LIMIT = 10_000;
+const DEFAULT_SEARCH_THRESHOLD = 0.3;
+const DEFAULT_SEARCH_LIMIT = 10;
+
+/** Message types that are not worth embedding (noise, no semantic value) */
+const SKIP_EMBEDDING_TYPES: Set<MessageType> = new Set([
+  'heartbeat',
+  'status_update',
+  'agent_join',
+  'agent_leave',
+]);
 
 export class MessageStore implements IMessageStore {
   private config: MessageStoreConfig;
@@ -84,6 +107,27 @@ export class MessageStore implements IMessageStore {
     });
   }
 
+  /** Extract embeddable text from a message (content field or stringified payload) */
+  private getEmbeddableText(msg: AgentMessage): string | null {
+    if (SKIP_EMBEDDING_TYPES.has(msg.type)) return null;
+    if (msg.content) return msg.content;
+    if (msg.payload && typeof msg.payload === 'object' && Object.keys(msg.payload).length > 0) {
+      const text = JSON.stringify(msg.payload);
+      if (text.length > 10) return text;
+    }
+    return null;
+  }
+
+  private async generateEmbedding(text: string): Promise<number[] | undefined> {
+    if (!this.config.embeddingService) return undefined;
+    try {
+      const result = await this.config.embeddingService.embed(text);
+      return Array.from(result.embedding);
+    } catch {
+      return undefined;
+    }
+  }
+
   async send(
     msg: Omit<AgentMessage, 'id' | 'createdAt' | 'readBy' | 'status'>,
   ): Promise<string> {
@@ -95,6 +139,12 @@ export class MessageStore implements IMessageStore {
       readBy: [],
       status: 'pending',
     };
+
+    // Generate embedding for semantic search if service available
+    const text = this.getEmbeddableText(message);
+    if (text) {
+      message.embedding = await this.generateEmbedding(text);
+    }
 
     const ttlSeconds = msg.ttlMs ? Math.ceil(msg.ttlMs / 1000) : undefined;
     await this.persistMessage(message, ttlSeconds);
@@ -116,7 +166,6 @@ export class MessageStore implements IMessageStore {
       return true;
     });
 
-    // Deterministic ordering: epoch for chronology, id for same-ms tiebreaker
     filtered.sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
 
     if (opts?.limit !== undefined) {
@@ -162,7 +211,6 @@ export class MessageStore implements IMessageStore {
     const root = allMessages.find((m) => m.id === replyTo);
     if (root) thread.push(root);
 
-    // Index children by replyTo for O(1) lookups
     const childrenOf = new Map<string, AgentMessage[]>();
     for (const msg of allMessages) {
       if (msg.replyTo) {
@@ -252,6 +300,65 @@ export class MessageStore implements IMessageStore {
     return toDelete.length;
   }
 
+  // === Semantic Search (Story #115) ===
+
+  async search(query: string, opts?: MessageSearchOptions): Promise<ScoredMessage[]> {
+    if (!this.config.embeddingService) {
+      throw new Error('Embedding service required for semantic search');
+    }
+
+    const queryEmbedding = await this.generateEmbedding(query);
+    if (!queryEmbedding) return [];
+
+    const messages = await this.listSessionMessages(this.config.sessionId);
+    const threshold = opts?.threshold ?? DEFAULT_SEARCH_THRESHOLD;
+    const limit = opts?.limit ?? DEFAULT_SEARCH_LIMIT;
+
+    const scored: ScoredMessage[] = [];
+
+    for (const msg of messages) {
+      if (!msg.embedding) continue;
+      if (this.isExpired(msg)) continue;
+      if (opts?.channel && msg.channel !== opts.channel) continue;
+      if (opts?.type && msg.type !== opts.type) continue;
+      if (opts?.from && msg.from !== opts.from) continue;
+      if (opts?.since !== undefined && msg.createdAt <= opts.since) continue;
+
+      const score = cosineSimilarity(queryEmbedding, msg.embedding);
+      if (score >= threshold) {
+        scored.push({ message: msg, score });
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit);
+  }
+
+  async summarize(channel: string, opts?: MessageSummarizeOptions): Promise<MessageSummary> {
+    const messages = await this.listChannelMessages(channel, this.config.sessionId);
+    const groupBy = opts?.groupBy ?? 'type';
+    const groups: Record<string, number> = {};
+    let earliest: number | undefined;
+    let latest: number | undefined;
+    let count = 0;
+
+    for (const msg of messages) {
+      if (this.isExpired(msg)) continue;
+      if (opts?.since !== undefined && msg.createdAt <= opts.since) continue;
+
+      count++;
+      const key = groupBy === 'type' ? msg.type : msg.from;
+      groups[key] = (groups[key] ?? 0) + 1;
+
+      if (earliest === undefined || msg.createdAt < earliest) earliest = msg.createdAt;
+      if (latest === undefined || msg.createdAt > latest) latest = msg.createdAt;
+    }
+
+    return { channel, totalMessages: count, groups, earliest, latest };
+  }
+
+  // === Private helpers ===
+
   private isExpired(msg: AgentMessage): boolean {
     if (!msg.ttlMs) return false;
     return Date.now() - msg.createdAt > msg.ttlMs;
@@ -286,4 +393,19 @@ export class MessageStore implements IMessageStore {
     }
     return messages;
   }
+}
+
+/** Cosine similarity between two vectors (0-1 range for normalized vectors) */
+function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dotProduct / denom;
 }

--- a/src/packages/swarm/src/types.ts
+++ b/src/packages/swarm/src/types.ts
@@ -628,6 +628,8 @@ export interface AgentMessage {
   status: AgentMessageStatus;
   /** Session scoping — messages are invisible across sessions */
   sessionId: string;
+  /** Embedding vector for semantic search (Story #115, stored as number[]) */
+  embedding?: number[];
 }
 
 /**
@@ -657,6 +659,47 @@ export interface IMessageStore {
   endSession(sessionId: string): Promise<number>;
   /** Remove old session messages (default maxAge: 24h), return count */
   gc(maxAge?: number): Promise<number>;
+
+  // === Semantic search (Story #115) ===
+
+  /** Semantic search over message history */
+  search(query: string, opts?: MessageSearchOptions): Promise<ScoredMessage[]>;
+  /** Aggregate message counts by type or sender */
+  summarize(channel: string, opts?: MessageSummarizeOptions): Promise<MessageSummary>;
+}
+
+/** Options for semantic message search */
+export interface MessageSearchOptions {
+  channel?: string;
+  type?: MessageType;
+  from?: string;
+  since?: number;
+  limit?: number;
+  /** Minimum similarity threshold 0-1 (default: 0.3) */
+  threshold?: number;
+}
+
+/** Message with similarity score */
+export interface ScoredMessage {
+  message: AgentMessage;
+  score: number;
+}
+
+/** Options for message summarization */
+export interface MessageSummarizeOptions {
+  since?: number;
+  groupBy?: 'type' | 'from';
+}
+
+/** Aggregated message summary */
+export interface MessageSummary {
+  channel: string;
+  totalMessages: number;
+  groups: Record<string, number>;
+  /** Epoch ms of earliest message in summary */
+  earliest?: number;
+  /** Epoch ms of latest message in summary */
+  latest?: number;
 }
 
 export interface IAgentPool {

--- a/tests/message-store-search.test.ts
+++ b/tests/message-store-search.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Tests for Story #115: Message History & Semantic Queryability
+ *
+ * Covers:
+ * - Embedding generation on send (text payloads get embeddings)
+ * - Heartbeat/status messages skip embedding
+ * - search() returns semantically relevant messages
+ * - search() filters by channel, type, from, since
+ * - search() throws without embedding service
+ * - summarize() aggregates by type and from
+ * - TTL-expired messages excluded from search/summarize
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MessageStore } from '../src/packages/swarm/src/message-bus/message-store.js';
+import type { MessageStoreConfig, EmbeddingFunction } from '../src/packages/swarm/src/message-bus/message-store.js';
+
+/** In-memory mock for Memory DB */
+function createMockMemoryDb() {
+  const storage = new Map<string, { value: string; tags?: string[]; ttl?: number }>();
+
+  return {
+    storage,
+    store: async (opts: { key: string; value: string; namespace: string; tags?: string[]; ttl?: number; upsert?: boolean }) => {
+      storage.set(`${opts.namespace}:${opts.key}`, { value: opts.value, tags: opts.tags, ttl: opts.ttl });
+      return { success: true, id: opts.key };
+    },
+    delete: async (opts: { key: string; namespace: string }) => {
+      storage.delete(`${opts.namespace}:${opts.key}`);
+      return { success: true };
+    },
+    list: async (opts: { namespace: string; limit?: number }) => {
+      const entries: Array<{ key: string; value?: string; metadata?: Record<string, unknown> }> = [];
+      for (const [compositeKey, data] of storage) {
+        if (compositeKey.startsWith(`${opts.namespace}:`)) {
+          const key = compositeKey.slice(opts.namespace.length + 1);
+          entries.push({ key, value: data.value });
+        }
+        if (opts.limit && entries.length >= opts.limit) break;
+      }
+      return { entries };
+    },
+    retrieve: async (opts: { key: string; namespace: string }) => {
+      const data = storage.get(`${opts.namespace}:${opts.key}`);
+      if (!data) return null;
+      return { value: data.value };
+    },
+  };
+}
+
+/**
+ * Mock embedding service that produces deterministic embeddings.
+ * Uses a simple hash-based approach: each unique text gets a distinct vector.
+ * Similar texts (sharing words) will have higher cosine similarity.
+ */
+function createMockEmbeddingService(): EmbeddingFunction & { callCount: number } {
+  const cache = new Map<string, number[]>();
+  let callCount = 0;
+
+  return {
+    get callCount() { return callCount; },
+    async embed(text: string) {
+      callCount++;
+      if (cache.has(text)) {
+        return { embedding: cache.get(text)! };
+      }
+
+      // Create a 16-dim embedding based on word hashes
+      const dims = 16;
+      const embedding = new Array(dims).fill(0);
+      const words = text.toLowerCase().split(/\s+/);
+      for (const word of words) {
+        let hash = 0;
+        for (let i = 0; i < word.length; i++) {
+          hash = ((hash << 5) - hash + word.charCodeAt(i)) | 0;
+        }
+        for (let d = 0; d < dims; d++) {
+          embedding[d] += Math.sin(hash * (d + 1) * 0.1);
+        }
+      }
+      // Normalize
+      const norm = Math.sqrt(embedding.reduce((s: number, v: number) => s + v * v, 0));
+      if (norm > 0) {
+        for (let d = 0; d < dims; d++) embedding[d] /= norm;
+      }
+
+      cache.set(text, embedding);
+      return { embedding };
+    },
+  };
+}
+
+function createStoreWithEmbeddings(sessionId = 'test-session') {
+  const db = createMockMemoryDb();
+  const embeddingService = createMockEmbeddingService();
+  const config: MessageStoreConfig = {
+    store: db.store,
+    delete: db.delete,
+    list: db.list,
+    retrieve: db.retrieve,
+    sessionId,
+    embeddingService,
+  };
+  return { store: new MessageStore(config), db, embeddingService };
+}
+
+function createStoreWithoutEmbeddings(sessionId = 'test-session') {
+  const db = createMockMemoryDb();
+  const config: MessageStoreConfig = {
+    store: db.store,
+    delete: db.delete,
+    list: db.list,
+    retrieve: db.retrieve,
+    sessionId,
+  };
+  return { store: new MessageStore(config), db };
+}
+
+describe('MessageStore — Semantic Search (Story #115)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: 1000000 });
+  });
+
+  // =========================================================================
+  // Embedding generation on send
+  // =========================================================================
+
+  describe('embedding generation', () => {
+    it('generates embeddings for messages with content', async () => {
+      const { store, db } = createStoreWithEmbeddings();
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {},
+        content: 'What is the authentication status?',
+        sessionId: 'test-session',
+      });
+
+      // Check stored message has embedding
+      const entries = [...db.storage.values()];
+      const msg = JSON.parse(entries[0].value);
+      expect(msg.embedding).toBeDefined();
+      expect(msg.embedding.length).toBe(16);
+    });
+
+    it('generates embeddings for messages with meaningful payloads', async () => {
+      const { store, db } = createStoreWithEmbeddings();
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'result',
+        priority: 'normal',
+        payload: { result: 'authentication succeeded', user: 'admin' },
+        sessionId: 'test-session',
+      });
+
+      const entries = [...db.storage.values()];
+      const msg = JSON.parse(entries[0].value);
+      expect(msg.embedding).toBeDefined();
+    });
+
+    it('skips embedding for heartbeat messages', async () => {
+      const { store, embeddingService } = createStoreWithEmbeddings();
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'heartbeat',
+        priority: 'normal', payload: { alive: true },
+        content: 'heartbeat ping',
+        sessionId: 'test-session',
+      });
+
+      expect(embeddingService.callCount).toBe(0);
+    });
+
+    it('skips embedding for status_update messages', async () => {
+      const { store, embeddingService } = createStoreWithEmbeddings();
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'status_update',
+        priority: 'normal', payload: { status: 'running' },
+        sessionId: 'test-session',
+      });
+
+      expect(embeddingService.callCount).toBe(0);
+    });
+
+    it('skips embedding for agent_join/agent_leave messages', async () => {
+      const { store, embeddingService } = createStoreWithEmbeddings();
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'agent_join',
+        priority: 'normal', payload: {},
+        sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'agent_leave',
+        priority: 'normal', payload: {},
+        sessionId: 'test-session',
+      });
+
+      expect(embeddingService.callCount).toBe(0);
+    });
+
+    it('works without embedding service (no embedding stored)', async () => {
+      const { store, db } = createStoreWithoutEmbeddings();
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'direct',
+        priority: 'normal', payload: {},
+        content: 'some content',
+        sessionId: 'test-session',
+      });
+
+      const entries = [...db.storage.values()];
+      const msg = JSON.parse(entries[0].value);
+      expect(msg.embedding).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // search()
+  // =========================================================================
+
+  describe('search()', () => {
+    it('returns semantically relevant messages ranked by score', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'researcher', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Authentication token validation failed for user admin',
+        sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(10);
+      await store.send({
+        channel: 'ch', from: 'coder', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Database migration completed successfully',
+        sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(10);
+      await store.send({
+        channel: 'ch', from: 'researcher', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'User authentication requires token refresh',
+        sessionId: 'test-session',
+      });
+
+      const results = await store.search('authentication token');
+      expect(results.length).toBeGreaterThan(0);
+      // All results should have scores
+      for (const r of results) {
+        expect(r.score).toBeGreaterThan(0);
+        expect(r.message).toBeDefined();
+      }
+      // Results should be sorted by score descending
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+      }
+    });
+
+    it('filters by channel', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'security', from: 'a', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Authentication check passed',
+        sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'database', from: 'b', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Authentication table updated',
+        sessionId: 'test-session',
+      });
+
+      const results = await store.search('authentication', { channel: 'security' });
+      for (const r of results) {
+        expect(r.message.channel).toBe('security');
+      }
+    });
+
+    it('filters by type', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'query',
+        priority: 'normal', payload: {},
+        content: 'What is the authentication status?',
+        sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'ch', from: 'b', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Authentication is working fine',
+        sessionId: 'test-session',
+      });
+
+      const results = await store.search('authentication', { type: 'result' });
+      for (const r of results) {
+        expect(r.message.type).toBe('result');
+      }
+    });
+
+    it('filters by from', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'researcher', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Found authentication bug',
+        sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'ch', from: 'coder', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Fixed authentication bug',
+        sessionId: 'test-session',
+      });
+
+      const results = await store.search('authentication', { from: 'researcher' });
+      for (const r of results) {
+        expect(r.message.from).toBe('researcher');
+      }
+    });
+
+    it('respects threshold filter', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Completely unrelated topic about cooking recipes',
+        sessionId: 'test-session',
+      });
+
+      const results = await store.search('authentication security', { threshold: 0.9 });
+      // With high threshold, unrelated content should be filtered out
+      for (const r of results) {
+        expect(r.score).toBeGreaterThanOrEqual(0.9);
+      }
+    });
+
+    it('limits results', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      for (let i = 0; i < 10; i++) {
+        vi.advanceTimersByTime(1);
+        await store.send({
+          channel: 'ch', from: 'a', to: '*', type: 'result',
+          priority: 'normal', payload: {},
+          content: `Authentication check number ${i}`,
+          sessionId: 'test-session',
+        });
+      }
+
+      const results = await store.search('authentication', { limit: 3 });
+      expect(results.length).toBeLessThanOrEqual(3);
+    });
+
+    it('excludes expired messages', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Authentication expired message',
+        ttlMs: 100,
+        sessionId: 'test-session',
+      });
+
+      vi.advanceTimersByTime(200);
+      const results = await store.search('authentication');
+      expect(results).toHaveLength(0);
+    });
+
+    it('throws error without embedding service', async () => {
+      const { store } = createStoreWithoutEmbeddings();
+
+      await expect(store.search('query')).rejects.toThrow('Embedding service required');
+    });
+
+    it('skips messages without embeddings', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      // Heartbeat has no embedding
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'heartbeat',
+        priority: 'normal', payload: { alive: true },
+        sessionId: 'test-session',
+      });
+      // This one has an embedding
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'result',
+        priority: 'normal', payload: {},
+        content: 'Some actual content',
+        sessionId: 'test-session',
+      });
+
+      const results = await store.search('content');
+      // Only the result message should appear, not the heartbeat
+      for (const r of results) {
+        expect(r.message.type).not.toBe('heartbeat');
+      }
+    });
+  });
+
+  // =========================================================================
+  // summarize()
+  // =========================================================================
+
+  describe('summarize()', () => {
+    it('aggregates by type (default)', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'query',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(10);
+      await store.send({
+        channel: 'ch', from: 'b', to: 'a', type: 'result',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(10);
+      await store.send({
+        channel: 'ch', from: 'a', to: 'b', type: 'query',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      const summary = await store.summarize('ch');
+      expect(summary.channel).toBe('ch');
+      expect(summary.totalMessages).toBe(3);
+      expect(summary.groups['query']).toBe(2);
+      expect(summary.groups['result']).toBe(1);
+      expect(summary.earliest).toBeDefined();
+      expect(summary.latest).toBeDefined();
+      expect(summary.earliest!).toBeLessThan(summary.latest!);
+    });
+
+    it('aggregates by from', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'alice', to: '*', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'ch', from: 'bob', to: '*', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      await store.send({
+        channel: 'ch', from: 'alice', to: '*', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      const summary = await store.summarize('ch', { groupBy: 'from' });
+      expect(summary.groups['alice']).toBe(2);
+      expect(summary.groups['bob']).toBe(1);
+    });
+
+    it('filters by since', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(100);
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      const summary = await store.summarize('ch', { since: 1000000 });
+      expect(summary.totalMessages).toBe(1);
+    });
+
+    it('excludes expired messages', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'direct',
+        priority: 'normal', payload: {}, ttlMs: 50,
+        sessionId: 'test-session',
+      });
+      vi.advanceTimersByTime(100);
+      await store.send({
+        channel: 'ch', from: 'a', to: '*', type: 'direct',
+        priority: 'normal', payload: {}, sessionId: 'test-session',
+      });
+
+      const summary = await store.summarize('ch');
+      expect(summary.totalMessages).toBe(1);
+    });
+
+    it('returns zero summary for empty channel', async () => {
+      const { store } = createStoreWithEmbeddings();
+
+      const summary = await store.summarize('nonexistent-channel');
+      expect(summary.totalMessages).toBe(0);
+      expect(summary.groups).toEqual({});
+      expect(summary.earliest).toBeUndefined();
+      expect(summary.latest).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `search()` for semantic message search powered by pluggable `EmbeddingFunction` interface
- Adds `summarize()` for aggregating message counts by type or sender
- Generates embeddings on `send()` for text payloads; skips heartbeat/status noise
- Self-contained `cosineSimilarity` for scoring (no hard dependency on embeddings package)
- 20 new tests covering embedding generation, search filtering, and summarization

## Changes
- `src/packages/swarm/src/types.ts` — `IMessageStore.search/summarize`, `ScoredMessage`, `MessageSummary`, `MessageSearchOptions` types, `embedding` field on `AgentMessage`
- `src/packages/swarm/src/message-bus/message-store.ts` — `search()`, `summarize()`, `EmbeddingFunction` interface, embedding generation on send, `cosineSimilarity`
- Export wiring in index/barrel files
- `tests/message-store-search.test.ts` — 20 tests

## Testing
- [x] Unit tests pass (49/49 — 29 from #111 + 20 from #115)
- [x] Full suite passes (5079 tests, 0 new failures)
- [x] Build clean (tsc -b)

**Depends on:** #127 (Story #111)
Closes #115

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)