### PR TITLE
feat(workflows): add StepCommand interface and StepCommandRegistry (Story #101)

### DIFF
--- a/src/packages/workflows/__tests__/step-command-registry.test.ts
+++ b/src/packages/workflows/__tests__/step-command-registry.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Step Command Registry Tests
+ *
+ * Story #101: Workflow Step Command Interface
+ * Tests: register/retrieve, duplicate prevention, list, get unknown, context flow
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { StepCommandRegistry } from '../src/core/step-command-registry.js';
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  ValidationResult,
+  OutputDescriptor,
+  WorkflowContext,
+  CredentialAccessor,
+  MemoryAccessor,
+} from '../src/types/step-command.types.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createMockCommand(type: string, outputs?: OutputDescriptor[]): StepCommand {
+  return {
+    type,
+    description: `Mock ${type} command`,
+    configSchema: { type: 'object', properties: {} },
+    validate(_config: StepConfig, _context: WorkflowContext): ValidationResult {
+      return { valid: true, errors: [] };
+    },
+    async execute(_config: StepConfig, _context: WorkflowContext): Promise<StepOutput> {
+      return { success: true, data: { result: `${type} executed` } };
+    },
+    describeOutputs(): OutputDescriptor[] {
+      return outputs ?? [{ name: 'result', type: 'string' }];
+    },
+  };
+}
+
+function createMockContext(overrides?: Partial<WorkflowContext>): WorkflowContext {
+  const credentials: CredentialAccessor = {
+    async get() { return undefined; },
+    async has() { return false; },
+  };
+
+  const memory: MemoryAccessor = {
+    async read() { return null; },
+    async write() {},
+    async search() { return []; },
+  };
+
+  return {
+    variables: {},
+    args: {},
+    credentials,
+    memory,
+    taskId: 'test-task-1',
+    workflowId: 'test-workflow-1',
+    stepIndex: 0,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('StepCommandRegistry', () => {
+  let registry: StepCommandRegistry;
+
+  beforeEach(() => {
+    registry = new StepCommandRegistry();
+  });
+
+  describe('register', () => {
+    it('should register a command and retrieve it by type', () => {
+      const command = createMockCommand('shell');
+      registry.register(command);
+
+      expect(registry.get('shell')).toBe(command);
+      expect(registry.has('shell')).toBe(true);
+      expect(registry.size).toBe(1);
+    });
+
+    it('should reject duplicate type registration', () => {
+      const command1 = createMockCommand('shell');
+      const command2 = createMockCommand('shell');
+
+      registry.register(command1);
+
+      expect(() => registry.register(command2)).toThrow(
+        'Step command type "shell" is already registered'
+      );
+    });
+
+    it('should reject commands with empty type', () => {
+      const command = createMockCommand('');
+
+      expect(() => registry.register(command)).toThrow(
+        'StepCommand must have a non-empty string type'
+      );
+    });
+
+    it('should register multiple different commands', () => {
+      registry.register(createMockCommand('shell'));
+      registry.register(createMockCommand('memory-read'));
+      registry.register(createMockCommand('http'));
+
+      expect(registry.size).toBe(3);
+      expect(registry.has('shell')).toBe(true);
+      expect(registry.has('memory-read')).toBe(true);
+      expect(registry.has('http')).toBe(true);
+    });
+  });
+
+  describe('get', () => {
+    it('should return undefined for unknown type', () => {
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+
+    it('should return the registered command', () => {
+      const command = createMockCommand('shell');
+      registry.register(command);
+
+      const retrieved = registry.get('shell');
+      expect(retrieved).toBe(command);
+      expect(retrieved?.type).toBe('shell');
+    });
+  });
+
+  describe('has', () => {
+    it('should return false for unregistered type', () => {
+      expect(registry.has('unknown')).toBe(false);
+    });
+
+    it('should return true for registered type', () => {
+      registry.register(createMockCommand('shell'));
+      expect(registry.has('shell')).toBe(true);
+    });
+  });
+
+  describe('list', () => {
+    it('should return empty array when no commands registered', () => {
+      expect(registry.list()).toEqual([]);
+    });
+
+    it('should return all registered commands', () => {
+      registry.register(createMockCommand('shell'));
+      registry.register(createMockCommand('memory-read'));
+
+      const entries = registry.list();
+      expect(entries).toHaveLength(2);
+      expect(entries[0].command.type).toBe('shell');
+      expect(entries[1].command.type).toBe('memory-read');
+      expect(entries[0].registeredAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('types', () => {
+    it('should return all registered type names', () => {
+      registry.register(createMockCommand('shell'));
+      registry.register(createMockCommand('http'));
+
+      expect(registry.types()).toEqual(['shell', 'http']);
+    });
+  });
+
+  describe('unregister', () => {
+    it('should remove a registered command', () => {
+      registry.register(createMockCommand('shell'));
+      expect(registry.has('shell')).toBe(true);
+
+      const removed = registry.unregister('shell');
+      expect(removed).toBe(true);
+      expect(registry.has('shell')).toBe(false);
+      expect(registry.size).toBe(0);
+    });
+
+    it('should return false for unknown type', () => {
+      expect(registry.unregister('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all registered commands', () => {
+      registry.register(createMockCommand('shell'));
+      registry.register(createMockCommand('http'));
+      expect(registry.size).toBe(2);
+
+      registry.clear();
+      expect(registry.size).toBe(0);
+      expect(registry.list()).toEqual([]);
+    });
+  });
+
+  describe('StepCommand interface', () => {
+    it('should validate config synchronously', () => {
+      const command = createMockCommand('shell');
+      const context = createMockContext();
+
+      const result = command.validate({ cmd: 'echo hello' }, context);
+      expect(result).toEqual({ valid: true, errors: [] });
+    });
+
+    it('should support async validation', async () => {
+      const command: StepCommand = {
+        ...createMockCommand('credential-check'),
+        async validate(_config: StepConfig, context: WorkflowContext) {
+          const exists = await context.credentials.has('API_KEY');
+          return exists
+            ? { valid: true, errors: [] }
+            : { valid: false, errors: [{ path: 'credentials', message: 'API_KEY not found' }] };
+        },
+      };
+      const context = createMockContext();
+
+      const result = await command.validate({}, context);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toBe('API_KEY not found');
+    });
+
+    it('should execute command and return output', async () => {
+      const command = createMockCommand('shell');
+      const context = createMockContext();
+
+      const output = await command.execute({ cmd: 'echo hello' }, context);
+      expect(output.success).toBe(true);
+      expect(output.data.result).toBe('shell executed');
+    });
+
+    it('should describe outputs', () => {
+      const outputs: OutputDescriptor[] = [
+        { name: 'stdout', type: 'string', description: 'Standard output' },
+        { name: 'exitCode', type: 'number', required: true },
+      ];
+      const command = createMockCommand('shell', outputs);
+
+      expect(command.describeOutputs()).toEqual(outputs);
+    });
+
+    it('should support optional rollback', async () => {
+      let rolledBack = false;
+      const command: StepCommand = {
+        ...createMockCommand('shell'),
+        async rollback() {
+          rolledBack = true;
+        },
+      };
+
+      const context = createMockContext();
+      await command.rollback!({}, context);
+      expect(rolledBack).toBe(true);
+    });
+  });
+
+  describe('WorkflowContext', () => {
+    it('should carry variables from prior steps', () => {
+      const context = createMockContext({
+        variables: {
+          'step1.output': 'hello',
+          'step2.count': 42,
+        },
+      });
+
+      expect(context.variables['step1.output']).toBe('hello');
+      expect(context.variables['step2.count']).toBe(42);
+    });
+
+    it('should carry workflow args', () => {
+      const context = createMockContext({
+        args: { issueNumber: '123', dryRun: true },
+      });
+
+      expect(context.args.issueNumber).toBe('123');
+      expect(context.args.dryRun).toBe(true);
+    });
+
+    it('should provide credential access', async () => {
+      const credentials: CredentialAccessor = {
+        async get(name: string) {
+          return name === 'API_KEY' ? 'secret-123' : undefined;
+        },
+        async has(name: string) {
+          return name === 'API_KEY';
+        },
+      };
+
+      const context = createMockContext({ credentials });
+      expect(await context.credentials.has('API_KEY')).toBe(true);
+      expect(await context.credentials.get('API_KEY')).toBe('secret-123');
+      expect(await context.credentials.get('MISSING')).toBeUndefined();
+    });
+
+    it('should provide memory access', async () => {
+      const store = new Map<string, unknown>();
+      const memory: MemoryAccessor = {
+        async read(_ns: string, key: string) {
+          return store.get(key) ?? null;
+        },
+        async write(_ns: string, key: string, value: unknown) {
+          store.set(key, value);
+        },
+        async search() {
+          return [];
+        },
+      };
+
+      const context = createMockContext({ memory });
+      await context.memory.write('tasklist', 'key1', { data: 'value' });
+      const result = await context.memory.read('tasklist', 'key1');
+      expect(result).toEqual({ data: 'value' });
+    });
+  });
+});

--- a/src/packages/workflows/package.json
+++ b/src/packages/workflows/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@claude-flow/workflows",
+  "version": "3.0.0-alpha.1",
+  "description": "Generalized Workflow Engine for Claude Flow V3 - Step Commands, Registry, and YAML/JSON Definitions",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "@claude-flow/plugins": "^3.0.0-alpha.1",
+    "@claude-flow/memory": "^3.0.0-alpha.2"
+  },
+  "peerDependenciesMeta": {
+    "@claude-flow/plugins": {
+      "optional": true
+    },
+    "@claude-flow/memory": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0",
+    "vitest": "^4.0.16"
+  },
+  "keywords": [
+    "claude-flow",
+    "workflow-engine",
+    "step-commands",
+    "orchestration"
+  ],
+  "author": "MoFlo Team",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/src/packages/workflows/src/core/step-command-registry.ts
+++ b/src/packages/workflows/src/core/step-command-registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Step Command Registry
+ *
+ * Plugin-style registry for workflow step commands.
+ * Duplicate type names are rejected to prevent silent overwrites.
+ */
+
+import type {
+  StepCommand,
+  StepCommandEntry,
+} from '../types/step-command.types.js';
+
+// ============================================================================
+// Step Command Registry
+// ============================================================================
+
+export class StepCommandRegistry {
+  private readonly commands = new Map<string, StepCommandEntry>();
+
+  /** @throws if a command with the same type is already registered. */
+  register(command: StepCommand): void {
+    if (!command.type || typeof command.type !== 'string') {
+      throw new Error('StepCommand must have a non-empty string type');
+    }
+
+    if (this.commands.has(command.type)) {
+      throw new Error(
+        `Step command type "${command.type}" is already registered`
+      );
+    }
+
+    this.commands.set(command.type, {
+      command,
+      registeredAt: new Date(),
+    });
+  }
+
+  /** @returns true if removed, false if not found. */
+  unregister(type: string): boolean {
+    return this.commands.delete(type);
+  }
+
+  get(type: string): StepCommand | undefined {
+    return this.commands.get(type)?.command;
+  }
+
+  has(type: string): boolean {
+    return this.commands.has(type);
+  }
+
+  list(): StepCommandEntry[] {
+    return Array.from(this.commands.values());
+  }
+
+  types(): string[] {
+    return Array.from(this.commands.keys());
+  }
+
+  get size(): number {
+    return this.commands.size;
+  }
+
+  clear(): void {
+    this.commands.clear();
+  }
+}

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @claude-flow/workflows
+ *
+ * Generalized Workflow Engine for Claude Flow V3.
+ *
+ * Provides a pluggable, YAML/JSON-defined workflow system where every step type
+ * implements a StepCommand interface — testable, reusable, and extensible.
+ *
+ * @packageDocumentation
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  StepCommandEntry,
+  OutputDescriptor,
+  ValidationResult,
+  ValidationError,
+  JSONSchema,
+  WorkflowContext,
+  CredentialAccessor,
+  MemoryAccessor,
+} from './types/step-command.types.js';
+
+// ============================================================================
+// Core
+// ============================================================================
+
+export { StepCommandRegistry } from './core/step-command-registry.js';

--- a/src/packages/workflows/src/types/step-command.types.ts
+++ b/src/packages/workflows/src/types/step-command.types.ts
@@ -1,0 +1,114 @@
+/**
+ * Workflow Step Command Type Definitions
+ */
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+export interface ValidationResult {
+  readonly valid: boolean;
+  readonly errors: ValidationError[];
+}
+
+export interface ValidationError {
+  readonly path: string;
+  readonly message: string;
+  readonly code?: string;
+}
+
+// ============================================================================
+// JSON Schema (minimal subset for config validation)
+// ============================================================================
+
+export interface JSONSchema {
+  type?: string;
+  properties?: Record<string, JSONSchema>;
+  required?: string[];
+  items?: JSONSchema;
+  enum?: unknown[];
+  description?: string;
+  default?: unknown;
+  additionalProperties?: boolean | JSONSchema;
+}
+
+// ============================================================================
+// Step Configuration
+// ============================================================================
+
+export interface StepConfig {
+  readonly [key: string]: unknown;
+}
+
+// ============================================================================
+// Step Output
+// ============================================================================
+
+export interface StepOutput {
+  readonly success: boolean;
+  readonly data: Record<string, unknown>;
+  readonly error?: string;
+  readonly duration?: number;
+}
+
+export interface OutputDescriptor {
+  readonly name: string;
+  readonly type: 'string' | 'number' | 'boolean' | 'object' | 'array';
+  readonly description?: string;
+  readonly required?: boolean;
+}
+
+// ============================================================================
+// Workflow Context
+// ============================================================================
+
+export interface CredentialAccessor {
+  get(name: string): Promise<string | undefined>;
+  has(name: string): Promise<boolean>;
+}
+
+export interface MemoryAccessor {
+  read(namespace: string, key: string): Promise<unknown | null>;
+  write(namespace: string, key: string, value: unknown): Promise<void>;
+  search(namespace: string, query: string): Promise<Array<{ key: string; value: unknown; score: number }>>;
+}
+
+export interface WorkflowContext {
+  readonly variables: Record<string, unknown>;
+  readonly args: Record<string, unknown>;
+  readonly credentials: CredentialAccessor;
+  readonly memory: MemoryAccessor;
+  readonly taskId: string;
+  readonly workflowId: string;
+  readonly stepIndex: number;
+  readonly abortSignal?: AbortSignal;
+}
+
+// ============================================================================
+// Step Command Interface
+// ============================================================================
+
+/**
+ * Foundational abstraction for workflow steps.
+ * Commands are stateless — all state flows through WorkflowContext.
+ */
+export interface StepCommand {
+  readonly type: string;
+  readonly description: string;
+  readonly configSchema: JSONSchema;
+
+  /** Validate may be async (e.g. checking credentials or remote state). */
+  validate(config: StepConfig, context: WorkflowContext): ValidationResult | Promise<ValidationResult>;
+  execute(config: StepConfig, context: WorkflowContext): Promise<StepOutput>;
+  describeOutputs(): OutputDescriptor[];
+  rollback?(config: StepConfig, context: WorkflowContext): Promise<void>;
+}
+
+// ============================================================================
+// Registry Types
+// ============================================================================
+
+export interface StepCommandEntry {
+  readonly command: StepCommand;
+  readonly registeredAt: Date;
+}

--- a/src/packages/workflows/tsconfig.json
+++ b/src/packages/workflows/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "incremental": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}


### PR DESCRIPTION
## Summary
- Introduces the `@claude-flow/workflows` package as the foundation for Epic #100 (Generalized Workflow Engine)
- Defines the `StepCommand` interface — the core abstraction for all workflow step types
- Implements `StepCommandRegistry` with type-safe registration and duplicate prevention
- Defines `WorkflowContext` carrying variables, args, credentials, memory, and abort signal

## Changes
- **New package:** `src/packages/workflows/` with full TypeScript, vitest, and package.json setup
- `StepCommand` interface: `type`, `description`, `configSchema` (JSONSchema), `validate` (sync/async), `execute`, `describeOutputs`, optional `rollback`
- `StepCommandRegistry`: `register`, `unregister`, `get`, `has`, `list`, `types`, `size`, `clear`
- `WorkflowContext`: `variables`, `args`, `CredentialAccessor`, `MemoryAccessor`, `taskId`, `workflowId`, `stepIndex`, `abortSignal`
- 23 unit tests covering all registry operations, interface contracts, and context plumbing

## Testing
- [x] Unit tests pass (23/23)
- [x] Full test suite passes (139 passed, 3 pre-existing worker crashes)
- [x] TypeScript strict-mode compilation clean
- [x] /simplify review completed — improved validate() to support async, typed configSchema as JSONSchema

Closes #101