### PR TITLE
feat(workflows): add 8 built-in step commands and variable interpolation (Story #102)

### DIFF
--- a/src/packages/workflows/__tests__/built-in-commands.test.ts
+++ b/src/packages/workflows/__tests__/built-in-commands.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Built-in Step Commands Tests
+ *
+ * Story #102: Tests for all 8 built-in step commands.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { agentCommand } from '../src/commands/agent-command.js';
+import { bashCommand } from '../src/commands/bash-command.js';
+import { conditionCommand } from '../src/commands/condition-command.js';
+import { promptCommand } from '../src/commands/prompt-command.js';
+import { memoryCommand } from '../src/commands/memory-command.js';
+import { waitCommand } from '../src/commands/wait-command.js';
+import { loopCommand } from '../src/commands/loop-command.js';
+import { browserCommand } from '../src/commands/browser-command.js';
+import { builtinCommands } from '../src/commands/index.js';
+import type { MemoryAccessor } from '../src/types/step-command.types.js';
+import { createMockContext as createContext } from './helpers.js';
+
+// ============================================================================
+// Registry
+// ============================================================================
+
+describe('builtinCommands', () => {
+  it('should have all 8 commands', () => {
+    expect(builtinCommands).toHaveLength(8);
+    const types = builtinCommands.map(c => c.type);
+    expect(types).toEqual(['agent', 'bash', 'condition', 'prompt', 'memory', 'wait', 'loop', 'browser']);
+  });
+
+  it('should have unique types', () => {
+    const types = builtinCommands.map(c => c.type);
+    expect(new Set(types).size).toBe(types.length);
+  });
+});
+
+// ============================================================================
+// Agent Command
+// ============================================================================
+
+describe('agentCommand', () => {
+  it('should validate with valid config', () => {
+    const result = agentCommand.validate({ prompt: 'analyze code' }, createContext());
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject missing prompt', () => {
+    const result = agentCommand.validate({}, createContext());
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].path).toBe('prompt');
+  });
+
+  it('should execute and return agent config', async () => {
+    const ctx = createContext();
+    const output = await agentCommand.execute(
+      { prompt: 'test task', agentType: 'researcher', background: true },
+      ctx,
+    );
+    expect(output.success).toBe(true);
+    expect(output.data.agentType).toBe('researcher');
+    expect(output.data.prompt).toBe('test task');
+    expect(output.data.background).toBe(true);
+  });
+
+  it('should interpolate variables in prompt', async () => {
+    const ctx = createContext({ variables: { step1: { file: 'main.ts' } } });
+    const output = await agentCommand.execute(
+      { prompt: 'Review {step1.file}' },
+      ctx,
+    );
+    expect(output.data.prompt).toBe('Review main.ts');
+  });
+});
+
+// ============================================================================
+// Bash Command
+// ============================================================================
+
+describe('bashCommand', () => {
+  it('should validate with valid config', () => {
+    const result = bashCommand.validate({ command: 'echo hello' }, createContext());
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject missing command', () => {
+    const result = bashCommand.validate({}, createContext());
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject invalid timeout', () => {
+    const result = bashCommand.validate({ command: 'echo hi', timeout: -1 }, createContext());
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].path).toBe('timeout');
+  });
+
+  it('should execute and capture stdout', async () => {
+    const ctx = createContext();
+    const output = await bashCommand.execute({ command: 'echo hello' }, ctx);
+    expect(output.success).toBe(true);
+    expect(output.data.stdout).toBe('hello');
+    expect(output.data.exitCode).toBe(0);
+  });
+
+  it('should capture stderr on error', async () => {
+    const ctx = createContext();
+    const output = await bashCommand.execute(
+      { command: 'echo error >&2 && exit 1', failOnError: false },
+      ctx,
+    );
+    expect(output.success).toBe(true); // failOnError=false
+    expect(output.data.stderr).toBe('error');
+  });
+
+  it('should fail on non-zero exit when failOnError is true', async () => {
+    const ctx = createContext();
+    const output = await bashCommand.execute(
+      { command: 'exit 1', failOnError: true },
+      ctx,
+    );
+    expect(output.success).toBe(false);
+    expect(output.error).toContain('exited with code');
+  });
+
+  it('should interpolate variables in command', async () => {
+    const ctx = createContext({ variables: { s1: { msg: 'world' } } });
+    const output = await bashCommand.execute({ command: 'echo {s1.msg}' }, ctx);
+    expect(output.data.stdout).toBe('world');
+  });
+});
+
+// ============================================================================
+// Condition Command
+// ============================================================================
+
+describe('conditionCommand', () => {
+  it('should validate with valid config', () => {
+    const result = conditionCommand.validate({ if: 'true' }, createContext());
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject missing if expression', () => {
+    const result = conditionCommand.validate({}, createContext());
+    expect(result.valid).toBe(false);
+  });
+
+  it('should evaluate truthy string as true', async () => {
+    const ctx = createContext({ variables: { s1: { status: 'active' } } });
+    const output = await conditionCommand.execute(
+      { if: '{s1.status}', then: 'step-a', else: 'step-b' },
+      ctx,
+    );
+    expect(output.data.result).toBe(true);
+    expect(output.data.branch).toBe('then');
+    expect(output.data.nextStep).toBe('step-a');
+  });
+
+  it('should evaluate false string as false', async () => {
+    const ctx = createContext({ variables: { s1: { ok: 'false' } } });
+    const output = await conditionCommand.execute(
+      { if: '{s1.ok}', then: 'step-a', else: 'step-b' },
+      ctx,
+    );
+    expect(output.data.result).toBe(false);
+    expect(output.data.branch).toBe('else');
+    expect(output.data.nextStep).toBe('step-b');
+  });
+
+  it('should evaluate equality operator', async () => {
+    const ctx = createContext({ variables: { s1: { count: '5' } } });
+    const output = await conditionCommand.execute(
+      { if: '{s1.count}==5' },
+      ctx,
+    );
+    expect(output.data.result).toBe(true);
+  });
+
+  it('should evaluate inequality', async () => {
+    const ctx = createContext({ variables: { s1: { count: '3' } } });
+    const output = await conditionCommand.execute(
+      { if: '{s1.count}!=5' },
+      ctx,
+    );
+    expect(output.data.result).toBe(true);
+  });
+
+  it('should evaluate comparison operators', async () => {
+    const ctx = createContext({ variables: { s1: { count: '10' } } });
+    const gt = await conditionCommand.execute({ if: '{s1.count}>5' }, ctx);
+    expect(gt.data.result).toBe(true);
+
+    const lt = await conditionCommand.execute({ if: '{s1.count}<5' }, ctx);
+    expect(lt.data.result).toBe(false);
+  });
+});
+
+// ============================================================================
+// Prompt Command
+// ============================================================================
+
+describe('promptCommand', () => {
+  it('should validate with valid config', () => {
+    const result = promptCommand.validate({ message: 'Enter name:' }, createContext());
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject missing message', () => {
+    const result = promptCommand.validate({}, createContext());
+    expect(result.valid).toBe(false);
+  });
+
+  it('should return prompt config with defaults', async () => {
+    const output = await promptCommand.execute(
+      { message: 'Continue?', options: ['yes', 'no'], default: 'yes' },
+      createContext(),
+    );
+    expect(output.success).toBe(true);
+    expect(output.data.message).toBe('Continue?');
+    expect(output.data.response).toBe('yes');
+    expect(output.data.outputVar).toBe('response');
+  });
+});
+
+// ============================================================================
+// Memory Command
+// ============================================================================
+
+describe('memoryCommand', () => {
+  it('should validate read config', () => {
+    const result = memoryCommand.validate(
+      { action: 'read', namespace: 'tasks', key: 'task-1' },
+      createContext(),
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject invalid action', () => {
+    const result = memoryCommand.validate(
+      { action: 'invalid', namespace: 'tasks' },
+      createContext(),
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject write without value', () => {
+    const result = memoryCommand.validate(
+      { action: 'write', namespace: 'tasks', key: 'k1' },
+      createContext(),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].path).toBe('value');
+  });
+
+  it('should reject search without query', () => {
+    const result = memoryCommand.validate(
+      { action: 'search', namespace: 'tasks' },
+      createContext(),
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it('should write and read from memory', async () => {
+    const store = new Map<string, unknown>();
+    const memory: MemoryAccessor = {
+      async read(_ns, key) { return store.get(key) ?? null; },
+      async write(_ns, key, value) { store.set(key, value); },
+      async search() { return []; },
+    };
+    const ctx = createContext({ memory });
+
+    const writeResult = await memoryCommand.execute(
+      { action: 'write', namespace: 'tasks', key: 'k1', value: 'data' },
+      ctx,
+    );
+    expect(writeResult.success).toBe(true);
+    expect(writeResult.data.written).toBe(true);
+
+    const readResult = await memoryCommand.execute(
+      { action: 'read', namespace: 'tasks', key: 'k1' },
+      ctx,
+    );
+    expect(readResult.data.value).toBe('data');
+    expect(readResult.data.found).toBe(true);
+  });
+
+  it('should search memory', async () => {
+    const memory: MemoryAccessor = {
+      async read() { return null; },
+      async write() {},
+      async search() {
+        return [{ key: 'k1', value: 'found', score: 0.9 }];
+      },
+    };
+    const ctx = createContext({ memory });
+
+    const result = await memoryCommand.execute(
+      { action: 'search', namespace: 'tasks', query: 'find something' },
+      ctx,
+    );
+    expect(result.data.count).toBe(1);
+    expect(result.data.results).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// Wait Command
+// ============================================================================
+
+describe('waitCommand', () => {
+  it('should validate with valid duration', () => {
+    const result = waitCommand.validate({ duration: 100 }, createContext());
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject negative duration', () => {
+    const result = waitCommand.validate({ duration: -1 }, createContext());
+    expect(result.valid).toBe(false);
+  });
+
+  it('should wait for specified duration', async () => {
+    const output = await waitCommand.execute({ duration: 10 }, createContext());
+    expect(output.success).toBe(true);
+    expect(output.data.waited).toBe(10);
+    expect(output.duration).toBeGreaterThanOrEqual(10);
+  });
+});
+
+// ============================================================================
+// Loop Command
+// ============================================================================
+
+describe('loopCommand', () => {
+  it('should validate with valid config', () => {
+    const result = loopCommand.validate(
+      { over: [1, 2, 3] },
+      createContext(),
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject missing over', () => {
+    const result = loopCommand.validate({}, createContext());
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject non-array over', () => {
+    const result = loopCommand.validate({ over: 'not-array' }, createContext());
+    expect(result.valid).toBe(false);
+  });
+
+  it('should iterate over array', async () => {
+    const output = await loopCommand.execute(
+      { over: ['a', 'b', 'c'] },
+      createContext(),
+    );
+    expect(output.success).toBe(true);
+    expect(output.data.totalItems).toBe(3);
+    expect(output.data.iterations).toBe(3);
+    expect(output.data.truncated).toBe(false);
+    expect(output.data.items).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should respect maxIterations guard', async () => {
+    const output = await loopCommand.execute(
+      { over: [1, 2, 3, 4, 5], maxIterations: 3 },
+      createContext(),
+    );
+    expect(output.data.iterations).toBe(3);
+    expect(output.data.truncated).toBe(true);
+    expect(output.data.items).toEqual([1, 2, 3]);
+  });
+
+  it('should use custom variable names', async () => {
+    const output = await loopCommand.execute(
+      { over: [1], itemVar: 'file', indexVar: 'i' },
+      createContext(),
+    );
+    expect(output.data.itemVar).toBe('file');
+    expect(output.data.indexVar).toBe('i');
+  });
+});
+
+// ============================================================================
+// Browser Command (Stub)
+// ============================================================================
+
+describe('browserCommand', () => {
+  it('should validate with valid config', () => {
+    const result = browserCommand.validate({ action: 'navigate' }, createContext());
+    expect(result.valid).toBe(true);
+  });
+
+  it('should fail execution with Playwright required error', async () => {
+    const output = await browserCommand.execute(
+      { action: 'navigate', url: 'https://example.com' },
+      createContext(),
+    );
+    expect(output.success).toBe(false);
+    expect(output.error).toContain('Playwright');
+  });
+});

--- a/src/packages/workflows/__tests__/helpers.ts
+++ b/src/packages/workflows/__tests__/helpers.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared test helpers for workflow tests.
+ */
+
+import type {
+  WorkflowContext,
+  CredentialAccessor,
+  MemoryAccessor,
+} from '../src/types/step-command.types.js';
+
+export function createMockContext(overrides?: Partial<WorkflowContext>): WorkflowContext {
+  const credentials: CredentialAccessor = {
+    async get() { return undefined; },
+    async has() { return false; },
+  };
+  const memory: MemoryAccessor = {
+    async read() { return null; },
+    async write() {},
+    async search() { return []; },
+  };
+  return {
+    variables: {},
+    args: {},
+    credentials,
+    memory,
+    taskId: 'test',
+    workflowId: 'wf-1',
+    stepIndex: 0,
+    ...overrides,
+  };
+}

--- a/src/packages/workflows/__tests__/interpolation.test.ts
+++ b/src/packages/workflows/__tests__/interpolation.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Variable Interpolation Tests
+ *
+ * Story #102: Built-in Step Commands — interpolation utility
+ */
+
+import { describe, it, expect } from 'vitest';
+import { interpolateString, interpolateConfig } from '../src/core/interpolation.js';
+import { createMockContext as createContext } from './helpers.js';
+
+describe('interpolateString', () => {
+  it('should resolve simple variable references', () => {
+    const ctx = createContext({ variables: { step1: { output: 'hello' } } });
+    expect(interpolateString('{step1.output}', ctx)).toBe('hello');
+  });
+
+  it('should resolve nested variable paths', () => {
+    const ctx = createContext({
+      variables: { fetch: { data: { users: { count: 42 } } } },
+    });
+    expect(interpolateString('Found {fetch.data.users.count} users', ctx)).toBe('Found 42 users');
+  });
+
+  it('should resolve args as fallback', () => {
+    const ctx = createContext({ args: { issueNumber: '123' } });
+    expect(interpolateString('Issue #{issueNumber}', ctx)).toBe('Issue #123');
+  });
+
+  it('should resolve args. prefix', () => {
+    const ctx = createContext({ args: { dryRun: 'true' } });
+    expect(interpolateString('{args.dryRun}', ctx)).toBe('true');
+  });
+
+  it('should pass through strings without placeholders', () => {
+    const ctx = createContext();
+    expect(interpolateString('no variables here', ctx)).toBe('no variables here');
+  });
+
+  it('should resolve multiple placeholders in one string', () => {
+    const ctx = createContext({
+      variables: { a: { x: 'hello' }, b: { y: 'world' } },
+    });
+    expect(interpolateString('{a.x} {b.y}!', ctx)).toBe('hello world!');
+  });
+
+  it('should throw on missing variable', () => {
+    const ctx = createContext();
+    expect(() => interpolateString('{missing.var}', ctx)).toThrow('Variable not found: missing.var');
+  });
+
+  it('should coerce non-string values to string', () => {
+    const ctx = createContext({ variables: { step1: { count: 42, ok: true } } });
+    expect(interpolateString('{step1.count}', ctx)).toBe('42');
+    expect(interpolateString('{step1.ok}', ctx)).toBe('true');
+  });
+});
+
+describe('interpolateConfig', () => {
+  it('should interpolate all string values in a config', () => {
+    const ctx = createContext({ variables: { s1: { name: 'test' } } });
+    const result = interpolateConfig({ cmd: 'echo {s1.name}', timeout: 5000 }, ctx);
+    expect(result.cmd).toBe('echo test');
+    expect(result.timeout).toBe(5000);
+  });
+
+  it('should interpolate strings inside arrays', () => {
+    const ctx = createContext({ args: { env: 'prod' } });
+    const result = interpolateConfig({ tags: ['deploy-{env}', 'latest'] }, ctx);
+    expect(result.tags).toEqual(['deploy-prod', 'latest']);
+  });
+
+  it('should pass non-string non-array values unchanged', () => {
+    const ctx = createContext();
+    const result = interpolateConfig({ flag: true, count: 3, obj: { nested: true } }, ctx);
+    expect(result.flag).toBe(true);
+    expect(result.count).toBe(3);
+    expect(result.obj).toEqual({ nested: true });
+  });
+});

--- a/src/packages/workflows/src/commands/agent-command.ts
+++ b/src/packages/workflows/src/commands/agent-command.ts
@@ -1,0 +1,69 @@
+/**
+ * Agent Step Command — spawns a Claude subagent.
+ */
+
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  WorkflowContext,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+} from '../types/step-command.types.js';
+import { interpolateString } from '../core/interpolation.js';
+
+export const agentCommand: StepCommand = {
+  type: 'agent',
+  description: 'Spawn a Claude subagent to perform a task',
+  configSchema: {
+    type: 'object',
+    properties: {
+      agentType: { type: 'string', description: 'Agent type (e.g. researcher, coder, tester)' },
+      prompt: { type: 'string', description: 'Task prompt for the agent' },
+      background: { type: 'boolean', description: 'Run in background', default: false },
+    },
+    required: ['prompt'],
+  } satisfies JSONSchema,
+
+  validate(config: StepConfig): ValidationResult {
+    const errors = [];
+    if (!config.prompt || typeof config.prompt !== 'string') {
+      errors.push({ path: 'prompt', message: 'prompt is required and must be a string' });
+    }
+    if (config.agentType !== undefined && typeof config.agentType !== 'string') {
+      errors.push({ path: 'agentType', message: 'agentType must be a string' });
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(config: StepConfig, context: WorkflowContext): Promise<StepOutput> {
+    const start = Date.now();
+    const prompt = interpolateString(config.prompt as string, context);
+    const agentType = config.agentType
+      ? interpolateString(config.agentType as string, context)
+      : 'general-purpose';
+
+    // Agent execution is delegated to the workflow runner's agent spawner.
+    // This command prepares the invocation; actual spawning is handled externally.
+    return {
+      success: true,
+      data: {
+        agentType,
+        prompt,
+        background: Boolean(config.background),
+        result: `Agent task prepared: ${agentType}`,
+      },
+      duration: Date.now() - start,
+    };
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'agentType', type: 'string' },
+      { name: 'prompt', type: 'string' },
+      { name: 'background', type: 'boolean' },
+      { name: 'result', type: 'string' },
+    ];
+  },
+};

--- a/src/packages/workflows/src/commands/bash-command.ts
+++ b/src/packages/workflows/src/commands/bash-command.ts
@@ -1,0 +1,78 @@
+/**
+ * Bash Step Command — runs a shell command.
+ */
+
+import { exec } from 'node:child_process';
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  WorkflowContext,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+} from '../types/step-command.types.js';
+import { interpolateString } from '../core/interpolation.js';
+
+export const bashCommand: StepCommand = {
+  type: 'bash',
+  description: 'Run a shell command and capture output',
+  configSchema: {
+    type: 'object',
+    properties: {
+      command: { type: 'string', description: 'Shell command to execute' },
+      timeout: { type: 'number', description: 'Timeout in milliseconds', default: 30000 },
+      failOnError: { type: 'boolean', description: 'Fail step on non-zero exit', default: true },
+    },
+    required: ['command'],
+  } satisfies JSONSchema,
+
+  validate(config: StepConfig): ValidationResult {
+    const errors = [];
+    if (!config.command || typeof config.command !== 'string') {
+      errors.push({ path: 'command', message: 'command is required and must be a string' });
+    }
+    if (config.timeout !== undefined && (typeof config.timeout !== 'number' || config.timeout <= 0)) {
+      errors.push({ path: 'timeout', message: 'timeout must be a positive number' });
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(config: StepConfig, context: WorkflowContext): Promise<StepOutput> {
+    const start = Date.now();
+    const command = interpolateString(config.command as string, context);
+    const timeout = (config.timeout as number) ?? 30000;
+    const failOnError = config.failOnError !== false;
+
+    return new Promise<StepOutput>((resolve) => {
+      const onAbort = () => child.kill();
+      context.abortSignal?.addEventListener('abort', onAbort, { once: true });
+
+      const child = exec(command, { timeout }, (error, stdout, stderr) => {
+        context.abortSignal?.removeEventListener('abort', onAbort);
+        // child.exitCode is the numeric exit code; error.code can be a string like 'ETIMEDOUT'
+        const exitCode = child.exitCode ?? (error ? 1 : 0);
+        const success = !failOnError || exitCode === 0;
+
+        resolve({
+          success,
+          data: {
+            stdout: stdout.trim(),
+            stderr: stderr.trim(),
+            exitCode,
+          },
+          error: success ? undefined : `Command exited with code ${exitCode}`,
+          duration: Date.now() - start,
+        });
+      });
+    });
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'stdout', type: 'string', required: true },
+      { name: 'stderr', type: 'string', required: true },
+      { name: 'exitCode', type: 'number', required: true },
+    ];
+  },
+};

--- a/src/packages/workflows/src/commands/browser-command.ts
+++ b/src/packages/workflows/src/commands/browser-command.ts
@@ -1,0 +1,56 @@
+/**
+ * Browser Step Command — Playwright web automation (stub).
+ *
+ * This is a placeholder until Story #107 (Playwright Browser Automation) lands.
+ * Throws a clear error if invoked without Playwright installed.
+ */
+
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+} from '../types/step-command.types.js';
+
+export const browserCommand: StepCommand = {
+  type: 'browser',
+  description: 'Web automation via Playwright (requires playwright peer dependency)',
+  configSchema: {
+    type: 'object',
+    properties: {
+      action: { type: 'string', description: 'Browser action (navigate, click, fill, screenshot, etc.)' },
+      url: { type: 'string', description: 'URL to navigate to' },
+      selector: { type: 'string', description: 'CSS selector for element actions' },
+      value: { type: 'string', description: 'Value for fill actions' },
+    },
+    required: ['action'],
+  } satisfies JSONSchema,
+
+  validate(config: StepConfig): ValidationResult {
+    const errors = [];
+    if (!config.action || typeof config.action !== 'string') {
+      errors.push({ path: 'action', message: 'action is required' });
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(): Promise<StepOutput> {
+    return {
+      success: false,
+      data: {},
+      error:
+        'Browser step requires Playwright. Install it with: npm install playwright\n' +
+        'This step will be fully implemented in Story #107.',
+    };
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'html', type: 'string', description: 'Page HTML content' },
+      { name: 'screenshot', type: 'string', description: 'Base64 screenshot' },
+      { name: 'text', type: 'string', description: 'Extracted text content' },
+    ];
+  },
+};

--- a/src/packages/workflows/src/commands/condition-command.ts
+++ b/src/packages/workflows/src/commands/condition-command.ts
@@ -1,0 +1,98 @@
+/**
+ * Condition Step Command — branches on expression evaluation.
+ *
+ * Evaluates a simple expression string against context variables.
+ * Returns which branch (then/else) should execute next.
+ */
+
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  WorkflowContext,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+} from '../types/step-command.types.js';
+import { interpolateString } from '../core/interpolation.js';
+
+/**
+ * Evaluate a simple condition expression.
+ * Supports: truthy checks, equality (==, !=), comparison (>, <, >=, <=).
+ */
+function evaluateCondition(expression: string, context: WorkflowContext): boolean {
+  const resolved = interpolateString(expression, context);
+
+  // Equality operators
+  for (const op of ['!=', '==', '>=', '<=', '>', '<'] as const) {
+    const idx = resolved.indexOf(op);
+    if (idx !== -1) {
+      const left = resolved.slice(0, idx).trim();
+      const right = resolved.slice(idx + op.length).trim();
+      const leftNum = Number(left);
+      const rightNum = Number(right);
+      const useNum = !isNaN(leftNum) && !isNaN(rightNum);
+
+      switch (op) {
+        case '==': return useNum ? leftNum === rightNum : left === right;
+        case '!=': return useNum ? leftNum !== rightNum : left !== right;
+        case '>': return useNum ? leftNum > rightNum : left > right;
+        case '<': return useNum ? leftNum < rightNum : left < right;
+        case '>=': return useNum ? leftNum >= rightNum : left >= right;
+        case '<=': return useNum ? leftNum <= rightNum : left <= right;
+      }
+    }
+  }
+
+  // Truthy check
+  return resolved !== '' && resolved !== '0' && resolved !== 'false' && resolved !== 'null' && resolved !== 'undefined';
+}
+
+export const conditionCommand: StepCommand = {
+  type: 'condition',
+  description: 'Branch workflow based on expression evaluation',
+  configSchema: {
+    type: 'object',
+    properties: {
+      if: { type: 'string', description: 'Expression to evaluate' },
+      then: { type: 'string', description: 'Step ID to run if true' },
+      else: { type: 'string', description: 'Step ID to run if false' },
+    },
+    required: ['if'],
+  } satisfies JSONSchema,
+
+  validate(config: StepConfig): ValidationResult {
+    const errors = [];
+    if (!config.if || typeof config.if !== 'string') {
+      errors.push({ path: 'if', message: 'if expression is required' });
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(config: StepConfig, context: WorkflowContext): Promise<StepOutput> {
+    const start = Date.now();
+    const expression = config.if as string;
+    const result = evaluateCondition(expression, context);
+    const nextStep = result
+      ? (config.then as string | undefined)
+      : (config.else as string | undefined);
+
+    return {
+      success: true,
+      data: {
+        result,
+        branch: result ? 'then' : 'else',
+        nextStep: nextStep ?? null,
+      },
+      duration: Date.now() - start,
+    };
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'result', type: 'boolean', required: true },
+      { name: 'branch', type: 'string', required: true },
+      { name: 'nextStep', type: 'string' },
+    ];
+  },
+};

--- a/src/packages/workflows/src/commands/index.ts
+++ b/src/packages/workflows/src/commands/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Built-in Step Commands
+ */
+
+import type { StepCommand } from '../types/step-command.types.js';
+import { agentCommand } from './agent-command.js';
+import { bashCommand } from './bash-command.js';
+import { conditionCommand } from './condition-command.js';
+import { promptCommand } from './prompt-command.js';
+import { memoryCommand } from './memory-command.js';
+import { waitCommand } from './wait-command.js';
+import { loopCommand } from './loop-command.js';
+import { browserCommand } from './browser-command.js';
+
+export {
+  agentCommand,
+  bashCommand,
+  conditionCommand,
+  promptCommand,
+  memoryCommand,
+  waitCommand,
+  loopCommand,
+  browserCommand,
+};
+
+/** All built-in step commands. */
+export const builtinCommands: readonly StepCommand[] = [
+  agentCommand,
+  bashCommand,
+  conditionCommand,
+  promptCommand,
+  memoryCommand,
+  waitCommand,
+  loopCommand,
+  browserCommand,
+];

--- a/src/packages/workflows/src/commands/loop-command.ts
+++ b/src/packages/workflows/src/commands/loop-command.ts
@@ -1,0 +1,77 @@
+/**
+ * Loop Step Command — iterates over an array, executing sub-steps for each item.
+ *
+ * The actual sub-step execution is delegated to the workflow runner.
+ * This command evaluates the iteration config and provides the loop metadata.
+ */
+
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  WorkflowContext,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+} from '../types/step-command.types.js';
+
+export const loopCommand: StepCommand = {
+  type: 'loop',
+  description: 'Iterate over an array, running sub-steps for each item',
+  configSchema: {
+    type: 'object',
+    properties: {
+      over: { type: 'array', description: 'Array to iterate over (or variable reference)' },
+      steps: { type: 'array', description: 'Step IDs to execute per iteration' },
+      maxIterations: { type: 'number', description: 'Safety limit on iterations', default: 100 },
+      itemVar: { type: 'string', description: 'Variable name for current item', default: 'item' },
+      indexVar: { type: 'string', description: 'Variable name for current index', default: 'index' },
+    },
+    required: ['over'],
+  } satisfies JSONSchema,
+
+  validate(config: StepConfig): ValidationResult {
+    const errors = [];
+    if (config.over === undefined) {
+      errors.push({ path: 'over', message: 'over is required (array to iterate)' });
+    } else if (!Array.isArray(config.over)) {
+      errors.push({ path: 'over', message: 'over must be an array' });
+    }
+    if (config.maxIterations !== undefined && (typeof config.maxIterations !== 'number' || config.maxIterations <= 0)) {
+      errors.push({ path: 'maxIterations', message: 'maxIterations must be a positive number' });
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(config: StepConfig): Promise<StepOutput> {
+    const start = Date.now();
+    const items = config.over as unknown[];
+    const maxIterations = (config.maxIterations as number) ?? 100;
+    const actualCount = Math.min(items.length, maxIterations);
+    const truncated = items.length > maxIterations;
+
+    // Loop execution is delegated to the workflow runner.
+    // This command prepares the iteration metadata.
+    return {
+      success: true,
+      data: {
+        totalItems: items.length,
+        iterations: actualCount,
+        truncated,
+        itemVar: (config.itemVar as string) ?? 'item',
+        indexVar: (config.indexVar as string) ?? 'index',
+        items: items.slice(0, actualCount),
+      },
+      duration: Date.now() - start,
+    };
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'totalItems', type: 'number', required: true },
+      { name: 'iterations', type: 'number', required: true },
+      { name: 'truncated', type: 'boolean', required: true },
+      { name: 'items', type: 'array' },
+    ];
+  },
+};

--- a/src/packages/workflows/src/commands/memory-command.ts
+++ b/src/packages/workflows/src/commands/memory-command.ts
@@ -1,0 +1,106 @@
+/**
+ * Memory Step Command — read/write/search shared workflow state via MemoryAccessor.
+ */
+
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  WorkflowContext,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+} from '../types/step-command.types.js';
+import { interpolateString } from '../core/interpolation.js';
+
+type MemoryAction = 'read' | 'write' | 'search';
+
+const VALID_ACTIONS: readonly MemoryAction[] = ['read', 'write', 'search'];
+
+export const memoryCommand: StepCommand = {
+  type: 'memory',
+  description: 'Read, write, or search shared workflow state',
+  configSchema: {
+    type: 'object',
+    properties: {
+      action: { type: 'string', enum: ['read', 'write', 'search'], description: 'Memory operation' },
+      namespace: { type: 'string', description: 'Memory namespace' },
+      key: { type: 'string', description: 'Key to read/write (required for read/write)' },
+      value: { description: 'Value to write (required for write)' },
+      query: { type: 'string', description: 'Search query (required for search)' },
+    },
+    required: ['action', 'namespace'],
+  } satisfies JSONSchema,
+
+  validate(config: StepConfig): ValidationResult {
+    const errors = [];
+    const action = config.action as string;
+
+    if (!action || !VALID_ACTIONS.includes(action as MemoryAction)) {
+      errors.push({ path: 'action', message: `action must be one of: ${VALID_ACTIONS.join(', ')}` });
+    }
+    if (!config.namespace || typeof config.namespace !== 'string') {
+      errors.push({ path: 'namespace', message: 'namespace is required' });
+    }
+    if ((action === 'read' || action === 'write') && (!config.key || typeof config.key !== 'string')) {
+      errors.push({ path: 'key', message: 'key is required for read/write operations' });
+    }
+    if (action === 'write' && config.value === undefined) {
+      errors.push({ path: 'value', message: 'value is required for write operations' });
+    }
+    if (action === 'search' && (!config.query || typeof config.query !== 'string')) {
+      errors.push({ path: 'query', message: 'query is required for search operations' });
+    }
+
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(config: StepConfig, context: WorkflowContext): Promise<StepOutput> {
+    const start = Date.now();
+    const action = config.action as MemoryAction;
+    const namespace = interpolateString(config.namespace as string, context);
+
+    switch (action) {
+      case 'read': {
+        const key = interpolateString(config.key as string, context);
+        const value = await context.memory.read(namespace, key);
+        return {
+          success: true,
+          data: { value, found: value !== null },
+          duration: Date.now() - start,
+        };
+      }
+      case 'write': {
+        const key = interpolateString(config.key as string, context);
+        const value = typeof config.value === 'string'
+          ? interpolateString(config.value, context)
+          : config.value;
+        await context.memory.write(namespace, key, value);
+        return {
+          success: true,
+          data: { written: true, key },
+          duration: Date.now() - start,
+        };
+      }
+      case 'search': {
+        const query = interpolateString(config.query as string, context);
+        const results = await context.memory.search(namespace, query);
+        return {
+          success: true,
+          data: { results, count: results.length },
+          duration: Date.now() - start,
+        };
+      }
+    }
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'value', type: 'object', description: 'Read result' },
+      { name: 'found', type: 'boolean', description: 'Whether key was found (read)' },
+      { name: 'written', type: 'boolean', description: 'Write success' },
+      { name: 'results', type: 'array', description: 'Search results' },
+      { name: 'count', type: 'number', description: 'Search result count' },
+    ];
+  },
+};

--- a/src/packages/workflows/src/commands/prompt-command.ts
+++ b/src/packages/workflows/src/commands/prompt-command.ts
@@ -1,0 +1,72 @@
+/**
+ * Prompt Step Command — asks the user a question.
+ *
+ * In non-interactive mode (no stdin), returns a placeholder.
+ * The workflow runner can override this with a real prompt implementation.
+ */
+
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  WorkflowContext,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+} from '../types/step-command.types.js';
+import { interpolateString } from '../core/interpolation.js';
+
+export const promptCommand: StepCommand = {
+  type: 'prompt',
+  description: 'Ask the user a question and capture the response',
+  configSchema: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', description: 'Question to ask' },
+      options: { type: 'array', items: { type: 'string' }, description: 'Choices (if multiple choice)' },
+      outputVar: { type: 'string', description: 'Variable name to store the response' },
+      default: { type: 'string', description: 'Default value if no input' },
+    },
+    required: ['message'],
+  } satisfies JSONSchema,
+
+  validate(config: StepConfig): ValidationResult {
+    const errors = [];
+    if (!config.message || typeof config.message !== 'string') {
+      errors.push({ path: 'message', message: 'message is required' });
+    }
+    if (config.options !== undefined && !Array.isArray(config.options)) {
+      errors.push({ path: 'options', message: 'options must be an array' });
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(config: StepConfig, context: WorkflowContext): Promise<StepOutput> {
+    const start = Date.now();
+    const message = interpolateString(config.message as string, context);
+    const defaultValue = config.default
+      ? interpolateString(config.default as string, context)
+      : undefined;
+
+    // Prompt execution is delegated to the workflow runner's I/O handler.
+    // This command prepares the prompt config; actual user interaction is external.
+    return {
+      success: true,
+      data: {
+        message,
+        options: config.options ?? null,
+        outputVar: config.outputVar ?? 'response',
+        response: defaultValue ?? '',
+      },
+      duration: Date.now() - start,
+    };
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'message', type: 'string' },
+      { name: 'response', type: 'string', required: true },
+      { name: 'outputVar', type: 'string' },
+    ];
+  },
+};

--- a/src/packages/workflows/src/commands/wait-command.ts
+++ b/src/packages/workflows/src/commands/wait-command.ts
@@ -1,0 +1,62 @@
+/**
+ * Wait Step Command — pauses for a duration or until a condition is met.
+ */
+
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  WorkflowContext,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+} from '../types/step-command.types.js';
+
+export const waitCommand: StepCommand = {
+  type: 'wait',
+  description: 'Pause workflow for a duration',
+  configSchema: {
+    type: 'object',
+    properties: {
+      duration: { type: 'number', description: 'Wait duration in milliseconds' },
+    },
+    required: ['duration'],
+  } satisfies JSONSchema,
+
+  validate(config: StepConfig): ValidationResult {
+    const errors = [];
+    if (config.duration === undefined || typeof config.duration !== 'number' || config.duration < 0) {
+      errors.push({ path: 'duration', message: 'duration must be a non-negative number (milliseconds)' });
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(config: StepConfig, context: WorkflowContext): Promise<StepOutput> {
+    const start = Date.now();
+    const duration = config.duration as number;
+
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(new Error('Wait aborted'));
+      };
+      const timer = setTimeout(() => {
+        context.abortSignal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, duration);
+      context.abortSignal?.addEventListener('abort', onAbort, { once: true });
+    });
+
+    return {
+      success: true,
+      data: { waited: duration },
+      duration: Date.now() - start,
+    };
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'waited', type: 'number', description: 'Actual wait time in ms' },
+    ];
+  },
+};

--- a/src/packages/workflows/src/core/interpolation.ts
+++ b/src/packages/workflows/src/core/interpolation.ts
@@ -1,0 +1,85 @@
+/**
+ * Variable Interpolation
+ *
+ * Resolves `{stepId.outputKey}` placeholders in workflow step configs.
+ * Nested property access is supported: `{step1.data.nested.value}`.
+ */
+
+import type { WorkflowContext } from '../types/step-command.types.js';
+
+const INTERPOLATION_PATTERN = /\{([^}]+)\}/g;
+
+/**
+ * Resolve a dot-separated path against the context variables.
+ * Returns undefined if any segment is missing.
+ */
+/**
+ * Resolution precedence:
+ * 1. {args.key} — explicit args prefix (depth-2 only)
+ * 2. {stepId.outputKey} — walk context.variables
+ * 3. {key} — single-segment fallback to context.args
+ */
+function resolveVariable(path: string, context: WorkflowContext): unknown {
+  const segments = path.split('.');
+
+  // Explicit args. prefix: {args.key}
+  if (segments[0] === 'args' && segments.length === 2) {
+    const val = context.args[segments[1]];
+    if (val !== undefined) return val;
+  }
+
+  // Walk context.variables (step outputs): {stepId.outputKey}
+  let value: unknown = context.variables;
+  for (const segment of segments) {
+    if (value === null || value === undefined || typeof value !== 'object') {
+      value = undefined;
+      break;
+    }
+    value = (value as Record<string, unknown>)[segment];
+  }
+  if (value !== undefined) return value;
+
+  // Fallback: single-segment matches args directly: {issueNumber}
+  if (segments.length === 1) {
+    return context.args[segments[0]];
+  }
+
+  return undefined;
+}
+
+/**
+ * Interpolate all `{path}` placeholders in a string.
+ * @throws if a referenced variable is not found.
+ */
+export function interpolateString(template: string, context: WorkflowContext): string {
+  return template.replace(INTERPOLATION_PATTERN, (match, path: string) => {
+    const value = resolveVariable(path, context);
+    if (value === undefined) {
+      throw new Error(`Variable not found: ${path}`);
+    }
+    return String(value);
+  });
+}
+
+/**
+ * Interpolate string values in a config object (shallow — top-level keys only).
+ * Non-string values and nested objects are passed through unchanged.
+ */
+export function interpolateConfig(
+  config: Record<string, unknown>,
+  context: WorkflowContext,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'string') {
+      result[key] = interpolateString(value, context);
+    } else if (Array.isArray(value)) {
+      result[key] = value.map(item =>
+        typeof item === 'string' ? interpolateString(item, context) : item
+      );
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -32,3 +32,20 @@ export type {
 // ============================================================================
 
 export { StepCommandRegistry } from './core/step-command-registry.js';
+export { interpolateString, interpolateConfig } from './core/interpolation.js';
+
+// ============================================================================
+// Built-in Commands
+// ============================================================================
+
+export {
+  agentCommand,
+  bashCommand,
+  conditionCommand,
+  promptCommand,
+  memoryCommand,
+  waitCommand,
+  loopCommand,
+  browserCommand,
+  builtinCommands,
+} from './commands/index.js';


### PR DESCRIPTION
## Summary
- Implements all 8 built-in step commands: `agent`, `bash`, `condition`, `prompt`, `memory`, `wait`, `loop`, `browser` (stub)
- Adds `{stepId.outputKey}` variable interpolation with documented resolution precedence
- All commands implement `StepCommand` interface with `validate()` and `execute()`

## Changes
- **8 command files** in `src/packages/workflows/src/commands/` — each implements StepCommand
- **interpolation.ts** — `interpolateString()` and `interpolateConfig()` for variable resolution
- **commands/index.ts** — barrel export + `builtinCommands` array
- **51 tests** across interpolation and all commands (74 total in workflows package)
- **helpers.ts** — shared test context factory

## Testing
- [x] Unit tests pass (74/74 in workflows, 5181 total)
- [x] Full test suite passes (141 passed, 3 pre-existing worker crashes)
- [x] TypeScript strict-mode compilation clean
- [x] /simplify review: fixed abort listener leaks, error.code type confusion, doc accuracy, deduplicated test helpers

## Depends On
- #131 (Story #101 — StepCommand interface)

Closes #102