### PR TITLE
feat(workflows): condition branching in WorkflowRunner (Story #136)

### DIFF
--- a/src/packages/workflows/__tests__/runner.test.ts
+++ b/src/packages/workflows/__tests__/runner.test.ts
@@ -712,3 +712,177 @@ describe('WorkflowRunner — callback safety', () => {
     expect(result.steps).toHaveLength(2);
   });
 });
+
+// ============================================================================
+// Condition Branching (Story #136)
+// ============================================================================
+
+describe('WorkflowRunner — condition branching', () => {
+  function createConditionCommand(result: boolean, nextStep: string | null): StepCommand {
+    return createMockCommand({
+      type: 'condition',
+      execute: async () => ({
+        success: true,
+        data: { result, branch: result ? 'then' : 'else', nextStep },
+        duration: 1,
+      }),
+    });
+  }
+
+  it('should jump to "then" step when condition is true', async () => {
+    registry.register(createConditionCommand(true, 'then-step'));
+    registry.register(createMockCommand({ type: 'action' }));
+
+    const definition = simpleWorkflow([
+      { id: 'check', type: 'condition', config: {}, output: 'check' },
+      { id: 'skipped-step', type: 'action', config: {} },
+      { id: 'then-step', type: 'action', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    // Should have executed: check, then-step (skipped-step was jumped over)
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].stepId).toBe('check');
+    expect(result.steps[1].stepId).toBe('then-step');
+  });
+
+  it('should jump to "else" step when condition is false', async () => {
+    registry.register(createConditionCommand(false, 'else-step'));
+    registry.register(createMockCommand({ type: 'action' }));
+
+    const definition = simpleWorkflow([
+      { id: 'check', type: 'condition', config: {}, output: 'check' },
+      { id: 'then-step', type: 'action', config: {} },
+      { id: 'else-step', type: 'action', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].stepId).toBe('check');
+    expect(result.steps[1].stepId).toBe('else-step');
+  });
+
+  it('should fail with CONDITION_TARGET_NOT_FOUND for nonexistent target', async () => {
+    registry.register(createConditionCommand(true, 'nonexistent'));
+    registry.register(createMockCommand({ type: 'action' }));
+
+    const definition = simpleWorkflow([
+      { id: 'check', type: 'condition', config: {} },
+      { id: 'action', type: 'action', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe('CONDITION_TARGET_NOT_FOUND');
+    expect(result.errors[0].message).toContain('nonexistent');
+    // Remaining steps should be skipped
+    expect(result.steps[1].status).toBe('skipped');
+  });
+
+  it('should handle chained conditions (condition → condition → action)', async () => {
+    // First condition jumps to second condition, second jumps to final action
+    const condA = createMockCommand({
+      type: 'cond-a',
+      execute: async () => ({
+        success: true,
+        data: { result: true, branch: 'then', nextStep: 'cond-b' },
+        duration: 1,
+      }),
+    });
+    const condB = createMockCommand({
+      type: 'cond-b',
+      execute: async () => ({
+        success: true,
+        data: { result: false, branch: 'else', nextStep: 'final' },
+        duration: 1,
+      }),
+    });
+    const action = createMockCommand({
+      type: 'action',
+      execute: async () => ({
+        success: true,
+        data: { done: true },
+        duration: 1,
+      }),
+    });
+
+    registry.register(condA);
+    registry.register(condB);
+    registry.register(action);
+
+    const definition = simpleWorkflow([
+      { id: 'cond-a', type: 'cond-a', config: {}, output: 'cond-a' },
+      { id: 'skipped-1', type: 'action', config: {} },
+      { id: 'cond-b', type: 'cond-b', config: {}, output: 'cond-b' },
+      { id: 'skipped-2', type: 'action', config: {} },
+      { id: 'final', type: 'action', config: {}, output: 'final' },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(3);
+    expect(result.steps[0].stepId).toBe('cond-a');
+    expect(result.steps[1].stepId).toBe('cond-b');
+    expect(result.steps[2].stepId).toBe('final');
+  });
+
+  it('should preserve variable context across jumps', async () => {
+    let capturedVars: Record<string, unknown> = {};
+
+    registry.register(createMockCommand({
+      type: 'setup',
+      execute: async () => ({
+        success: true,
+        data: { value: 'preserved' },
+        duration: 1,
+      }),
+    }));
+    registry.register(createConditionCommand(true, 'consumer'));
+    registry.register(createMockCommand({
+      type: 'consumer',
+      execute: async (_config, ctx) => {
+        capturedVars = { ...ctx.variables };
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 'setup', type: 'setup', config: {}, output: 'setup' },
+      { id: 'check', type: 'condition', config: {}, output: 'check' },
+      { id: 'skipped', type: 'consumer', config: {} },
+      { id: 'consumer', type: 'consumer', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    // Variables from setup step should be available in the jumped-to consumer step
+    const setupData = capturedVars['setup'] as Record<string, unknown>;
+    expect(setupData?.value).toBe('preserved');
+  });
+
+  it('should continue sequentially when nextStep is null', async () => {
+    // Condition returns null nextStep — should proceed to next step normally
+    registry.register(createConditionCommand(true, null));
+    registry.register(createMockCommand({ type: 'action' }));
+
+    const definition = simpleWorkflow([
+      { id: 'check', type: 'condition', config: {}, output: 'check' },
+      { id: 'next', type: 'action', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].stepId).toBe('check');
+    expect(result.steps[1].stepId).toBe('next');
+  });
+});

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -222,7 +222,26 @@ export class WorkflowRunner {
 
     await this.storeProgress(workflowId, 'running', 0, definition.steps.length);
 
+    // Build step-ID → index map for O(1) condition branching lookups
+    const stepIndex = new Map<string, number>();
+    for (let idx = 0; idx < definition.steps.length; idx++) {
+      stepIndex.set(definition.steps[idx].id, idx);
+    }
+
+    // Guard against infinite loops from backward condition jumps
+    const maxIterations = definition.steps.length * 10;
+    let iterations = 0;
+
     for (let i = 0; i < definition.steps.length; i++) {
+      if (++iterations > maxIterations) {
+        errors.push({
+          code: 'STEP_EXECUTION_FAILED',
+          message: `Workflow exceeded maximum iterations (${maxIterations}); possible infinite condition loop`,
+        });
+        this.markRemainingSteps(definition, i, 'skipped', stepResults);
+        break;
+      }
+
       if (options.signal?.aborted) {
         cancelled = true;
         this.markRemainingSteps(definition, i, 'cancelled', stepResults);
@@ -230,7 +249,6 @@ export class WorkflowRunner {
       }
 
       const step = definition.steps[i];
-      // TODO(#136): condition branching — inspect result.output.data.nextStep to jump
       // TODO(#137): loop iteration — execute step.steps for each item in loop output
       const result = await this.executeStep(step, state, i);
 
@@ -241,8 +259,25 @@ export class WorkflowRunner {
           variables[step.output] = result.output.data;
         }
         variables[step.id] = result.output.data;
-        // Stash the config that was actually executed (returned from executeStep)
         completedSteps.push({ step, config: result.interpolatedConfig ?? {} });
+
+        // Condition branching: jump to the target step if nextStep is set
+        const nextStep = result.output.data?.nextStep;
+        if (typeof nextStep === 'string' && nextStep.length > 0) {
+          const targetIdx = stepIndex.get(nextStep);
+          if (targetIdx === undefined) {
+            errors.push({
+              stepId: step.id,
+              code: 'CONDITION_TARGET_NOT_FOUND',
+              message: `Condition step "${step.id}" targets step "${nextStep}" which does not exist`,
+            });
+            await this.rollbackSteps(completedSteps, state, stepResults);
+            this.markRemainingSteps(definition, i + 1, 'skipped', stepResults);
+            break;
+          }
+          // Jump: set i so the next loop increment lands on targetIdx
+          i = targetIdx - 1;
+        }
       }
 
       if (result.status === 'cancelled') {
@@ -265,7 +300,7 @@ export class WorkflowRunner {
         }
       }
 
-      await this.storeProgress(workflowId, 'running', i + 1, definition.steps.length);
+      await this.storeProgress(workflowId, 'running', stepResults.length, definition.steps.length);
       try { options.onStepComplete?.(result, i, definition.steps.length); } catch { /* callback errors must not crash the workflow */ }
     }
 

--- a/src/packages/workflows/src/types/runner.types.ts
+++ b/src/packages/workflows/src/types/runner.types.ts
@@ -12,6 +12,7 @@ import type { StepOutput, ValidationError } from './step-command.types.js';
 
 export type WorkflowErrorCode =
   | 'ARGUMENT_VALIDATION_FAILED'
+  | 'CONDITION_TARGET_NOT_FOUND'
   | 'DEFINITION_VALIDATION_FAILED'
   | 'STEP_VALIDATION_FAILED'
   | 'STEP_EXECUTION_FAILED'


### PR DESCRIPTION
## Summary
- Implement condition-based branching: when a step returns `output.data.nextStep`, the runner jumps to the target step ID instead of proceeding sequentially
- Add `CONDITION_TARGET_NOT_FOUND` error code for invalid jump targets
- Add infinite loop guard (max iterations = steps × 10) to prevent backward jump cycles

## Changes
- `runner.ts`: Build step-ID→index map, branch on `nextStep`, guard against infinite loops
- `runner.types.ts`: Add `CONDITION_TARGET_NOT_FOUND` to `WorkflowErrorCode`
- `runner.test.ts`: 6 new tests (true/false branching, missing target, chained conditions, variable preservation, null fallthrough)

## Testing
- [x] Unit tests pass (34/34 in runner, 151/151 across workflow package)
- [x] Integration tests pass
- [ ] Manual testing done

Closes #136

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)