### PR TITLE
feat(workflows): loop iteration with nested steps (Story #137)

### DIFF
--- a/src/packages/workflows/__tests__/runner.test.ts
+++ b/src/packages/workflows/__tests__/runner.test.ts
@@ -886,3 +886,195 @@ describe('WorkflowRunner — condition branching', () => {
     expect(result.steps[1].stepId).toBe('next');
   });
 });
+
+// ============================================================================
+// Loop Iteration (Story #137)
+// ============================================================================
+
+describe('WorkflowRunner — loop iteration', () => {
+  function createLoopCommand(items: unknown[], opts?: { maxIterations?: number; itemVar?: string; indexVar?: string }): StepCommand {
+    return createMockCommand({
+      type: 'loop',
+      execute: async () => {
+        const max = opts?.maxIterations ?? 100;
+        const actual = Math.min(items.length, max);
+        return {
+          success: true,
+          data: {
+            totalItems: items.length,
+            iterations: actual,
+            truncated: items.length > max,
+            itemVar: opts?.itemVar ?? 'item',
+            indexVar: opts?.indexVar ?? 'index',
+            items: items.slice(0, actual),
+          },
+          duration: 1,
+        };
+      },
+    });
+  }
+
+  it('should iterate over 3 items executing 2 nested steps each', async () => {
+    const execLog: string[] = [];
+
+    registry.register(createLoopCommand(['a', 'b', 'c']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        execLog.push(`${ctx.variables['item']}-${ctx.variables['index']}`);
+        return { success: true, data: { processed: ctx.variables['item'] }, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [
+          { id: 'nested-a', type: 'nested', config: {}, output: 'nested-a' },
+          { id: 'nested-b', type: 'nested', config: {}, output: 'nested-b' },
+        ],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(execLog).toEqual(['a-0', 'a-0', 'b-1', 'b-1', 'c-2', 'c-2']);
+    const loopData = result.outputs['loop1'] as Record<string, unknown>;
+    expect(loopData.iterationOutputs).toBeDefined();
+    const iterOutputs = loopData.iterationOutputs as Array<Record<string, unknown>>;
+    expect(iterOutputs).toHaveLength(3);
+  });
+
+  it('should respect maxIterations and stop early', async () => {
+    const execLog: string[] = [];
+
+    registry.register(createLoopCommand(['a', 'b', 'c', 'd', 'e'], { maxIterations: 2 }));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        execLog.push(String(ctx.variables['item']));
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(execLog).toEqual(['a', 'b']);
+  });
+
+  it('should continue to next iteration with continueOnError', async () => {
+    const execLog: string[] = [];
+
+    registry.register(createLoopCommand(['a', 'b', 'c']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        const item = ctx.variables['item'] as string;
+        execLog.push(item);
+        if (item === 'b') {
+          return { success: false, data: {}, error: 'b failed', duration: 1 };
+        }
+        return { success: true, data: { processed: item }, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        continueOnError: true,
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    // continueOnError on loop step means failed iterations are skipped
+    expect(result.success).toBe(false); // errors were recorded
+    expect(execLog).toEqual(['a', 'b', 'c']);
+    expect(result.errors.some(e => e.message.includes('iteration 1'))).toBe(true);
+  });
+
+  it('should stop loop on nested failure without continueOnError', async () => {
+    const execLog: string[] = [];
+
+    registry.register(createLoopCommand(['a', 'b', 'c']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        const item = ctx.variables['item'] as string;
+        execLog.push(item);
+        if (item === 'b') {
+          return { success: false, data: {}, error: 'b failed', duration: 1 };
+        }
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {},
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(execLog).toEqual(['a', 'b']); // stopped at 'b'
+  });
+
+  it('should make loop variables accessible in nested step configs via interpolation', async () => {
+    let capturedVars: Record<string, unknown> = {};
+
+    registry.register(createLoopCommand(['hello', 'world']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        capturedVars = { item: ctx.variables['item'], index: ctx.variables['index'] };
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    // Last iteration should have these values
+    expect(capturedVars.item).toBe('world');
+    expect(capturedVars.index).toBe(1);
+  });
+
+  it('should complete with no iterations for empty items array', async () => {
+    registry.register(createLoopCommand([]));
+    registry.register(createMockCommand({ type: 'nested' }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    const loopData = result.outputs['loop1'] as Record<string, unknown>;
+    const iterOutputs = loopData.iterationOutputs as unknown[];
+    expect(iterOutputs).toHaveLength(0);
+  });
+});

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -249,7 +249,6 @@ export class WorkflowRunner {
       }
 
       const step = definition.steps[i];
-      // TODO(#137): loop iteration — execute step.steps for each item in loop output
       const result = await this.executeStep(step, state, i);
 
       stepResults.push(result);
@@ -260,6 +259,23 @@ export class WorkflowRunner {
         }
         variables[step.id] = result.output.data;
         completedSteps.push({ step, config: result.interpolatedConfig ?? {} });
+
+        // Loop iteration: execute nested steps for each item
+        if (step.type === 'loop' && step.steps && step.steps.length > 0) {
+          const loopResult = await this.executeLoopIterations(step, result.output, state, errors);
+          // Store accumulated iteration outputs under the loop step
+          const loopData = { ...result.output.data, iterationOutputs: loopResult.outputs };
+          if (step.output) {
+            variables[step.output] = loopData;
+          }
+          variables[step.id] = loopData;
+
+          if (!loopResult.success && !step.continueOnError) {
+            await this.rollbackSteps(completedSteps, state, stepResults);
+            this.markRemainingSteps(definition, i + 1, 'skipped', stepResults);
+            break;
+          }
+        }
 
         // Condition branching: jump to the target step if nextStep is set
         const nextStep = result.output.data?.nextStep;
@@ -317,7 +333,8 @@ export class WorkflowRunner {
     const outputs: Record<string, unknown> = {};
     for (const sr of stepResults) {
       if (sr.status === 'succeeded' && sr.output) {
-        outputs[sr.stepId] = sr.output.data;
+        // Prefer enriched variable data (e.g. loop steps add iterationOutputs)
+        outputs[sr.stepId] = variables[sr.stepId] ?? sr.output.data;
       }
     }
 
@@ -443,6 +460,81 @@ export class WorkflowRunner {
       duration: Date.now() - stepStart,
       interpolatedConfig,
     };
+  }
+
+  // --------------------------------------------------------------------------
+  // Private — Loop Iteration
+  // --------------------------------------------------------------------------
+
+  private async executeLoopIterations(
+    loopStep: StepDefinition,
+    loopOutput: StepOutput,
+    state: ExecutionState,
+    errors: WorkflowError[],
+  ): Promise<{ success: boolean; outputs: Array<Record<string, unknown>> }> {
+    const data = loopOutput.data as Record<string, unknown>;
+    const items = data.items as unknown[];
+    const itemVar = (data.itemVar as string) || 'item';
+    const indexVar = (data.indexVar as string) || 'index';
+    const nestedSteps = loopStep.steps!;
+    const iterationOutputs: Array<Record<string, unknown>> = [];
+    let allSucceeded = true;
+
+    // Save pre-existing variables that loop vars might shadow
+    const hadItem = itemVar in state.variables;
+    const prevItem = state.variables[itemVar];
+    const hadIndex = indexVar in state.variables;
+    const prevIndex = state.variables[indexVar];
+
+    for (let idx = 0; idx < items.length; idx++) {
+      if (state.options.signal?.aborted) break;
+
+      state.variables[itemVar] = items[idx];
+      state.variables[indexVar] = idx;
+
+      const iterOutput: Record<string, unknown> = {};
+      let iterFailed = false;
+
+      for (let s = 0; s < nestedSteps.length; s++) {
+        if (state.options.signal?.aborted) break;
+
+        const nested = nestedSteps[s];
+        const result = await this.executeStep(nested, state, s);
+
+        if (result.status === 'succeeded' && result.output) {
+          if (nested.output) {
+            state.variables[nested.output] = result.output.data;
+          }
+          state.variables[nested.id] = result.output.data;
+          iterOutput[nested.id] = result.output.data;
+        }
+
+        if (result.status === 'failed') {
+          errors.push({
+            stepId: nested.id,
+            code: result.errorCode ?? 'STEP_EXECUTION_FAILED',
+            message: `Loop "${loopStep.id}" iteration ${idx}, step "${nested.id}": ${result.error ?? 'failed'}`,
+          });
+          iterFailed = true;
+          allSucceeded = false;
+          break;
+        }
+      }
+
+      iterationOutputs.push(iterOutput);
+
+      if (iterFailed && !loopStep.continueOnError) {
+        break;
+      }
+    }
+
+    // Restore previous values or clean up loop variables
+    if (hadItem) state.variables[itemVar] = prevItem;
+    else delete state.variables[itemVar];
+    if (hadIndex) state.variables[indexVar] = prevIndex;
+    else delete state.variables[indexVar];
+
+    return { success: allSucceeded, outputs: iterationOutputs };
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Implement loop iteration: when a `loop` step executes, the runner iterates over items and runs nested `step.steps` for each iteration
- Loop variables (`itemVar`/`indexVar`) injected into context with save/restore to prevent shadowing
- Type-based loop dispatch (`step.type === 'loop'`) instead of structural heuristic
- Accumulated iteration outputs stored as `iterationOutputs` on loop step data

## Changes
- `runner.ts`: Add `executeLoopIterations` method, type-based loop detection, variable save/restore, output enrichment
- `runner.test.ts`: 6 new loop iteration tests

## Testing
- [x] Unit tests pass (40/40 in runner, 157/157 across workflow package)
- [x] Integration tests pass
- [ ] Manual testing done

Closes #137

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)