### PR TITLE
feat(workflows): definition layering — shipped + user override (Story #138)

### DIFF
--- a/src/packages/workflows/__tests__/definition-loader.test.ts
+++ b/src/packages/workflows/__tests__/definition-loader.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Definition Loader Tests
+ *
+ * Story #138: Tests for two-tier workflow definition layering.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadWorkflowDefinitions, loadWorkflowByName } from '../src/loaders/definition-loader.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+let testDir: string;
+
+function makeDir(...segments: string[]): string {
+  const dir = join(testDir, ...segments);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeYaml(dir: string, filename: string, content: string): void {
+  writeFileSync(join(dir, filename), content, 'utf-8');
+}
+
+const SHIPPED_WORKFLOW = `
+name: deploy
+description: Shipped deploy workflow
+steps:
+  - id: build
+    type: bash
+    config:
+      command: npm run build
+`;
+
+const USER_OVERRIDE_WORKFLOW = `
+name: deploy
+description: User-customized deploy workflow
+steps:
+  - id: build
+    type: bash
+    config:
+      command: npm run build:custom
+`;
+
+const USER_NEW_WORKFLOW = `
+name: lint-check
+description: User-defined lint workflow
+steps:
+  - id: lint
+    type: bash
+    config:
+      command: npm run lint
+`;
+
+const JSON_WORKFLOW = JSON.stringify({
+  name: 'json-workflow',
+  description: 'JSON format workflow',
+  steps: [{ id: 'step1', type: 'bash', config: { command: 'echo hello' } }],
+});
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `wf-loader-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('DefinitionLoader — shipped definitions', () => {
+  it('should load shipped workflow definitions', () => {
+    const shippedDir = makeDir('shipped');
+    writeYaml(shippedDir, 'deploy.yaml', SHIPPED_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      shippedDir,
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(1);
+
+    const deploy = result.workflows.get('deploy');
+    expect(deploy).toBeDefined();
+    expect(deploy!.definition.name).toBe('deploy');
+    expect(deploy!.tier).toBe('shipped');
+    expect(deploy!.sourceFile).toContain('deploy.yaml');
+  });
+});
+
+describe('DefinitionLoader — user override', () => {
+  it('should override shipped workflow by name match', () => {
+    const shippedDir = makeDir('shipped');
+    const userDir = makeDir('user');
+    writeYaml(shippedDir, 'deploy.yaml', SHIPPED_WORKFLOW);
+    writeYaml(userDir, 'deploy.yaml', USER_OVERRIDE_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      shippedDir,
+      userDirs: [userDir],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(1);
+
+    const deploy = result.workflows.get('deploy');
+    expect(deploy!.tier).toBe('user');
+    expect(deploy!.definition.description).toBe('User-customized deploy workflow');
+  });
+
+  it('should add user workflow with new name additively', () => {
+    const shippedDir = makeDir('shipped');
+    const userDir = makeDir('user');
+    writeYaml(shippedDir, 'deploy.yaml', SHIPPED_WORKFLOW);
+    writeYaml(userDir, 'lint-check.yaml', USER_NEW_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      shippedDir,
+      userDirs: [userDir],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(2);
+    expect(result.workflows.has('deploy')).toBe(true);
+    expect(result.workflows.has('lint-check')).toBe(true);
+
+    expect(result.workflows.get('deploy')!.tier).toBe('shipped');
+    expect(result.workflows.get('lint-check')!.tier).toBe('user');
+  });
+});
+
+describe('DefinitionLoader — custom paths', () => {
+  it('should load from multiple user directories', () => {
+    const userDir1 = makeDir('user1');
+    const userDir2 = makeDir('user2');
+    writeYaml(userDir1, 'deploy.yaml', SHIPPED_WORKFLOW);
+    writeYaml(userDir2, 'lint.yaml', USER_NEW_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [userDir1, userDir2],
+      skipValidation: true,
+    });
+
+    expect(result.workflows.size).toBe(2);
+  });
+
+  it('should not error when user path does not exist', () => {
+    const result = loadWorkflowDefinitions({
+      userDirs: [join(testDir, 'nonexistent')],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(0);
+  });
+
+  it('should not error when shipped path does not exist', () => {
+    const result = loadWorkflowDefinitions({
+      shippedDir: join(testDir, 'nonexistent'),
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(0);
+  });
+});
+
+describe('DefinitionLoader — format support', () => {
+  it('should load JSON format workflow definitions', () => {
+    const dir = makeDir('json');
+    writeFileSync(join(dir, 'wf.json'), JSON_WORKFLOW, 'utf-8');
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [dir],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(1);
+    expect(result.workflows.get('json-workflow')!.definition.name).toBe('json-workflow');
+  });
+
+  it('should load .yml extension', () => {
+    const dir = makeDir('yml');
+    writeYaml(dir, 'deploy.yml', SHIPPED_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [dir],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(1);
+  });
+
+  it('should ignore non-workflow files', () => {
+    const dir = makeDir('mixed');
+    writeYaml(dir, 'deploy.yaml', SHIPPED_WORKFLOW);
+    writeFileSync(join(dir, 'readme.md'), '# README', 'utf-8');
+    writeFileSync(join(dir, 'notes.txt'), 'some notes', 'utf-8');
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [dir],
+      skipValidation: true,
+    });
+
+    expect(result.workflows.size).toBe(1);
+  });
+});
+
+describe('DefinitionLoader — error handling', () => {
+  it('should collect parse errors without failing other files', () => {
+    const dir = makeDir('errors');
+    writeYaml(dir, 'good.yaml', SHIPPED_WORKFLOW);
+    writeFileSync(join(dir, 'bad.yaml'), '{{invalid yaml', 'utf-8');
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [dir],
+      skipValidation: true,
+    });
+
+    expect(result.workflows.size).toBe(1);
+    expect(result.workflows.has('deploy')).toBe(true);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].file).toContain('bad.yaml');
+  });
+});
+
+describe('DefinitionLoader — loadWorkflowByName', () => {
+  it('should load a specific workflow by name', () => {
+    const shippedDir = makeDir('shipped');
+    writeYaml(shippedDir, 'deploy.yaml', SHIPPED_WORKFLOW);
+
+    const result = loadWorkflowByName('deploy', {
+      shippedDir,
+      skipValidation: true,
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.definition.name).toBe('deploy');
+  });
+
+  it('should return undefined for unknown workflow name', () => {
+    const result = loadWorkflowByName('nonexistent', {
+      shippedDir: join(testDir, 'empty'),
+      skipValidation: true,
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -76,3 +76,16 @@ export type {
 
 export { parseYaml, parseJson, parseWorkflow } from './schema/parser.js';
 export { validateWorkflowDefinition, resolveArguments, type ValidatorOptions } from './schema/validator.js';
+
+// ============================================================================
+// Definition Loader (shipped + user override)
+// ============================================================================
+
+export {
+  loadWorkflowDefinitions,
+  loadWorkflowByName,
+  type LoaderOptions,
+  type LoadedWorkflow,
+  type LoadResult,
+  type LoadError,
+} from './loaders/definition-loader.js';

--- a/src/packages/workflows/src/loaders/definition-loader.ts
+++ b/src/packages/workflows/src/loaders/definition-loader.ts
@@ -1,0 +1,143 @@
+/**
+ * Workflow Definition Loader
+ *
+ * Two-tier definition system:
+ *   Tier 1 — Shipped definitions bundled with moflo (read-only defaults)
+ *   Tier 2 — User definitions at configurable project path (override by name)
+ *
+ * Resolution: load shipped first, then user. User definitions with the same
+ * name replace shipped ones; new names are additive.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { parseWorkflow } from '../schema/parser.js';
+import { validateWorkflowDefinition } from '../schema/validator.js';
+import type { WorkflowDefinition, ParsedWorkflow } from '../types/workflow-definition.types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LoaderOptions {
+  /** Shipped definitions directory (absolute path). */
+  readonly shippedDir?: string;
+  /** User definition directories (absolute paths), searched in order. */
+  readonly userDirs?: readonly string[];
+  /** Step types known to the registry (passed to validator). */
+  readonly knownStepTypes?: readonly string[];
+  /** If true, skip validation (useful for testing). */
+  readonly skipValidation?: boolean;
+}
+
+export interface LoadedWorkflow {
+  readonly definition: WorkflowDefinition;
+  readonly sourceFile: string;
+  readonly tier: 'shipped' | 'user';
+}
+
+export interface LoadResult {
+  readonly workflows: Map<string, LoadedWorkflow>;
+  readonly errors: readonly LoadError[];
+}
+
+export interface LoadError {
+  readonly file: string;
+  readonly message: string;
+}
+
+// ============================================================================
+// Loader
+// ============================================================================
+
+const WORKFLOW_EXTENSIONS = new Set(['.yaml', '.yml', '.json']);
+
+/**
+ * Load workflow definitions from shipped + user directories.
+ * User definitions override shipped ones by workflow name match.
+ */
+export function loadWorkflowDefinitions(options: LoaderOptions = {}): LoadResult {
+  const workflows = new Map<string, LoadedWorkflow>();
+  const errors: LoadError[] = [];
+
+  // Tier 1: Shipped definitions (lowest priority)
+  if (options.shippedDir) {
+    loadFromDirectory(options.shippedDir, 'shipped', workflows, errors, options);
+  }
+
+  // Tier 2: User definitions (override shipped by name)
+  if (options.userDirs) {
+    for (const dir of options.userDirs) {
+      loadFromDirectory(dir, 'user', workflows, errors, options);
+    }
+  }
+
+  return { workflows, errors };
+}
+
+/**
+ * Load a single workflow definition by name from the merged registry.
+ */
+export function loadWorkflowByName(
+  name: string,
+  options: LoaderOptions = {},
+): LoadedWorkflow | undefined {
+  const { workflows } = loadWorkflowDefinitions(options);
+  return workflows.get(name);
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+function loadFromDirectory(
+  dir: string,
+  tier: 'shipped' | 'user',
+  workflows: Map<string, LoadedWorkflow>,
+  errors: LoadError[],
+  options: LoaderOptions,
+): void {
+  if (!existsSync(dir)) return;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  const files = entries.filter(f => WORKFLOW_EXTENSIONS.has(extname(f).toLowerCase()));
+
+  for (const file of files) {
+    const filePath = join(dir, file);
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      const parsed = parseWorkflow(content, filePath);
+
+      if (!options.skipValidation) {
+        const validation = validateWorkflowDefinition(parsed.definition, {
+          knownStepTypes: options.knownStepTypes as string[],
+        });
+        if (!validation.valid) {
+          errors.push({
+            file: filePath,
+            message: validation.errors.map(e => e.message).join('; '),
+          });
+          continue;
+        }
+      }
+
+      const key = parsed.definition.name;
+      workflows.set(key, {
+        definition: parsed.definition,
+        sourceFile: filePath,
+        tier,
+      });
+    } catch (err) {
+      errors.push({
+        file: filePath,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `DefinitionLoader` for two-tier workflow definitions: shipped (bundled defaults) + user (project-local overrides)
- User definitions override shipped by name match; new names are additive
- Supports YAML, YML, and JSON formats with graceful per-file error handling

## Changes
- `src/loaders/definition-loader.ts`: New `loadWorkflowDefinitions()` and `loadWorkflowByName()` functions
- `src/index.ts`: Export loader types and functions
- `__tests__/definition-loader.test.ts`: 12 tests covering shipped load, user override, additive, custom paths, missing paths, format support, error handling

## Testing
- [x] Unit tests pass (12/12 loader, 169/169 across workflow package)
- [x] Integration tests pass
- [ ] Manual testing done

Closes #138

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)