### PR TITLE
feat(workflows): runner factory + MCP bridge for tool integration (Story #139)

### DIFF
--- a/src/packages/workflows/__tests__/runner-bridge.test.ts
+++ b/src/packages/workflows/__tests__/runner-bridge.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Runner Bridge & Factory Tests
+ *
+ * Story #139: Tests for MCP tool integration bridge.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bridgeRunWorkflow,
+  bridgeCancelWorkflow,
+  bridgeIsRunning,
+  bridgeActiveWorkflows,
+} from '../src/factory/runner-bridge.js';
+import { createRunner, runWorkflowFromContent } from '../src/factory/runner-factory.js';
+
+// ============================================================================
+// Runner Factory
+// ============================================================================
+
+describe('createRunner', () => {
+  it('should create a runner with built-in commands registered', async () => {
+    const runner = createRunner();
+    const definition = {
+      name: 'test',
+      steps: [{ id: 's1', type: 'bash', config: { command: 'echo hello' } }],
+    };
+
+    // Should not throw for known step type 'bash'
+    const result = await runner.run(definition, {}, { dryRun: true });
+    expect(result.workflowId).toBeDefined();
+  });
+});
+
+describe('runWorkflowFromContent', () => {
+  it('should parse and run a YAML workflow', async () => {
+    const yaml = `
+name: test-workflow
+steps:
+  - id: step1
+    type: wait
+    config:
+      duration: 0
+`;
+    const result = await runWorkflowFromContent(yaml, 'test.yaml');
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0].stepId).toBe('step1');
+  });
+
+  it('should return structured error for invalid YAML', async () => {
+    const result = await runWorkflowFromContent('{{invalid', 'bad.yaml');
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe('DEFINITION_VALIDATION_FAILED');
+    expect(result.errors[0].message).toContain('Parse error');
+  });
+
+  it('should return structured error for invalid definition', async () => {
+    const yaml = `
+name: ""
+steps: []
+`;
+    const result = await runWorkflowFromContent(yaml, 'invalid.yaml');
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('DEFINITION_VALIDATION_FAILED');
+  });
+
+  it('should support dry-run mode', async () => {
+    const yaml = `
+name: dry-test
+steps:
+  - id: s1
+    type: wait
+    config:
+      duration: 0
+`;
+    const result = await runWorkflowFromContent(yaml, 'test.yaml', { dryRun: true });
+
+    expect(result.success).toBe(true);
+    // Dry run doesn't produce step results
+    expect(result.steps).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Runner Bridge
+// ============================================================================
+
+describe('bridgeRunWorkflow', () => {
+  it('should run a workflow from content and track it', async () => {
+    const yaml = `
+name: bridge-test
+steps:
+  - id: s1
+    type: wait
+    config:
+      duration: 0
+`;
+    const result = await bridgeRunWorkflow(yaml, 'test.yaml', {});
+
+    expect(result.success).toBe(true);
+    expect(result.workflowId).toMatch(/^wf-\d+$/);
+    // After completion, should no longer be tracked
+    expect(bridgeIsRunning(result.workflowId)).toBe(false);
+  });
+});
+
+describe('bridgeCancelWorkflow', () => {
+  it('should return false for unknown workflow ID', () => {
+    expect(bridgeCancelWorkflow('nonexistent')).toBe(false);
+  });
+});
+
+describe('bridgeActiveWorkflows', () => {
+  it('should return empty array when no workflows running', () => {
+    expect(bridgeActiveWorkflows()).toEqual([]);
+  });
+});

--- a/src/packages/workflows/src/factory/runner-bridge.ts
+++ b/src/packages/workflows/src/factory/runner-bridge.ts
@@ -1,0 +1,96 @@
+/**
+ * Runner Bridge
+ *
+ * Provides a high-level, context-free API for MCP tool integration.
+ * Each function is self-contained — no setup required. The bridge
+ * creates runners on demand with built-in commands.
+ *
+ * This module is the integration point between MCP workflow tools
+ * and the WorkflowRunner engine.
+ */
+
+import type { WorkflowResult } from '../types/runner.types.js';
+import type { MemoryAccessor } from '../types/step-command.types.js';
+import { createRunner, runWorkflowFromContent } from './runner-factory.js';
+
+// Track active workflows for cancellation
+const activeWorkflows = new Map<string, AbortController>();
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Run a workflow from raw file content (YAML/JSON).
+ */
+export async function bridgeRunWorkflow(
+  content: string,
+  sourceFile: string | undefined,
+  args: Record<string, unknown>,
+  options: { dryRun?: boolean; memory?: MemoryAccessor } = {},
+): Promise<WorkflowResult> {
+  const workflowId = `wf-${Date.now()}`;
+  const controller = new AbortController();
+  activeWorkflows.set(workflowId, controller);
+
+  try {
+    const result = await runWorkflowFromContent(content, sourceFile, {
+      workflowId,
+      args,
+      dryRun: options.dryRun,
+      signal: controller.signal,
+      memory: options.memory,
+    });
+    return result;
+  } finally {
+    activeWorkflows.delete(workflowId);
+  }
+}
+
+/**
+ * Run a WorkflowDefinition directly (for workflow_execute).
+ */
+export async function bridgeExecuteWorkflow(
+  definition: import('../types/workflow-definition.types.js').WorkflowDefinition,
+  args: Record<string, unknown>,
+  options: { workflowId?: string; memory?: MemoryAccessor } = {},
+): Promise<WorkflowResult> {
+  const workflowId = options.workflowId ?? `wf-${Date.now()}`;
+  const controller = new AbortController();
+  activeWorkflows.set(workflowId, controller);
+
+  try {
+    const runner = createRunner({ memory: options.memory });
+    return await runner.run(definition, args, {
+      workflowId,
+      signal: controller.signal,
+    });
+  } finally {
+    activeWorkflows.delete(workflowId);
+  }
+}
+
+/**
+ * Cancel a running workflow by ID.
+ */
+export function bridgeCancelWorkflow(workflowId: string): boolean {
+  const controller = activeWorkflows.get(workflowId);
+  if (!controller) return false;
+  controller.abort();
+  activeWorkflows.delete(workflowId);
+  return true;
+}
+
+/**
+ * Check if a workflow is currently running.
+ */
+export function bridgeIsRunning(workflowId: string): boolean {
+  return activeWorkflows.has(workflowId);
+}
+
+/**
+ * Get IDs of all currently running workflows.
+ */
+export function bridgeActiveWorkflows(): string[] {
+  return [...activeWorkflows.keys()];
+}

--- a/src/packages/workflows/src/factory/runner-factory.ts
+++ b/src/packages/workflows/src/factory/runner-factory.ts
@@ -1,0 +1,107 @@
+/**
+ * Runner Factory
+ *
+ * Creates a fully configured WorkflowRunner with the built-in command registry,
+ * credentials, and memory accessors. Provides a high-level API for MCP tool
+ * integration and CLI usage.
+ */
+
+import type { CredentialAccessor, MemoryAccessor } from '../types/step-command.types.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.types.js';
+import type { RunnerOptions, WorkflowResult } from '../types/runner.types.js';
+import { StepCommandRegistry } from '../core/step-command-registry.js';
+import { WorkflowRunner } from '../core/runner.js';
+import { builtinCommands } from '../commands/index.js';
+import { parseWorkflow } from '../schema/parser.js';
+import { validateWorkflowDefinition } from '../schema/validator.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RunnerFactoryOptions {
+  readonly credentials?: CredentialAccessor;
+  readonly memory?: MemoryAccessor;
+}
+
+export interface RunWorkflowOptions extends RunnerOptions {
+  /** Arguments to pass to the workflow. */
+  readonly args?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Create a WorkflowRunner with built-in commands registered.
+ */
+export function createRunner(options: RunnerFactoryOptions = {}): WorkflowRunner {
+  const registry = new StepCommandRegistry();
+  for (const cmd of builtinCommands) {
+    registry.register(cmd);
+  }
+
+  const credentials = options.credentials ?? noopCredentials;
+  const memory = options.memory ?? noopMemory;
+
+  return new WorkflowRunner(registry, credentials, memory);
+}
+
+/**
+ * Parse, validate, and run a workflow from raw YAML/JSON content.
+ * Returns a structured result — never throws.
+ */
+export async function runWorkflowFromContent(
+  content: string,
+  sourceFile: string | undefined,
+  options: RunWorkflowOptions & RunnerFactoryOptions = {},
+): Promise<WorkflowResult> {
+  let definition: WorkflowDefinition;
+  try {
+    const parsed = parseWorkflow(content, sourceFile);
+    definition = parsed.definition;
+  } catch (err) {
+    return {
+      workflowId: options.workflowId ?? `wf-${Date.now()}`,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'DEFINITION_VALIDATION_FAILED', message: `Parse error: ${err instanceof Error ? err.message : String(err)}` }],
+      duration: 0,
+      cancelled: false,
+    };
+  }
+
+  const validation = validateWorkflowDefinition(definition);
+  if (!validation.valid) {
+    return {
+      workflowId: options.workflowId ?? `wf-${Date.now()}`,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'DEFINITION_VALIDATION_FAILED', message: validation.errors.map(e => e.message).join('; ') }],
+      duration: 0,
+      cancelled: false,
+    };
+  }
+
+  const runner = createRunner(options);
+  const { args = {}, ...runnerOptions } = options;
+  return runner.run(definition, args, runnerOptions);
+}
+
+// ============================================================================
+// Noop Accessors (for standalone usage without full CLI context)
+// ============================================================================
+
+const noopCredentials: CredentialAccessor = {
+  async get() { return undefined; },
+  async has() { return false; },
+};
+
+const noopMemory: MemoryAccessor = {
+  async read() { return null; },
+  async write() { /* noop */ },
+  async search() { return []; },
+};

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -89,3 +89,22 @@ export {
   type LoadResult,
   type LoadError,
 } from './loaders/definition-loader.js';
+
+// ============================================================================
+// Runner Factory (MCP + CLI integration)
+// ============================================================================
+
+export {
+  createRunner,
+  runWorkflowFromContent,
+  type RunnerFactoryOptions,
+  type RunWorkflowOptions,
+} from './factory/runner-factory.js';
+
+export {
+  bridgeRunWorkflow,
+  bridgeExecuteWorkflow,
+  bridgeCancelWorkflow,
+  bridgeIsRunning,
+  bridgeActiveWorkflows,
+} from './factory/runner-bridge.js';


### PR DESCRIPTION
## Summary
- Add `runner-factory.ts`: `createRunner()` with built-in commands, `runWorkflowFromContent()` for parse-validate-run in one call
- Add `runner-bridge.ts`: MCP integration layer with `bridgeRunWorkflow()`, `bridgeCancelWorkflow()`, and active workflow tracking via AbortControllers
- Export all integration APIs from the workflows package index

## Changes
- `src/factory/runner-factory.ts`: Runner creation with noop defaults for standalone usage
- `src/factory/runner-bridge.ts`: Active workflow tracking, cancellation support
- `src/index.ts`: Export factory and bridge APIs
- `__tests__/runner-bridge.test.ts`: 8 tests covering factory, content parsing, dry-run, bridge run, cancel, active tracking

## Testing
- [x] Unit tests pass (8/8 bridge, 177/177 across workflow package)
- [x] Integration tests pass
- [ ] Manual testing done

Closes #139

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)