### PR TITLE
feat(workflows): add pause/resume with serialized state persistence (Story #140)

### DIFF
--- a/src/packages/workflows/__tests__/pause-resume.test.ts
+++ b/src/packages/workflows/__tests__/pause-resume.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Pause/Resume Tests
+ *
+ * Story #140: Tests for workflow pause/resume mechanism.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { MemoryAccessor } from '../src/types/step-command.types.js';
+import type { StepResult } from '../src/types/runner.types.js';
+import type { WorkflowDefinition } from '../src/types/workflow-definition.types.js';
+import {
+  buildPausedState,
+  persistPausedState,
+  resumeWorkflow,
+  cleanupStalePaused,
+} from '../src/factory/pause-resume.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockMemory(): MemoryAccessor & { store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    async read(ns: string, key: string) { return store.get(`${ns}:${key}`) ?? null; },
+    async write(ns: string, key: string, value: unknown) {
+      if (value === null) store.delete(`${ns}:${key}`);
+      else store.set(`${ns}:${key}`, value);
+    },
+    async search(ns: string) {
+      const results: Array<{ key: string; value: unknown; score: number }> = [];
+      for (const [key, val] of store.entries()) {
+        if (key.startsWith(`${ns}:`)) results.push({ key, value: val, score: 1.0 });
+      }
+      return results;
+    },
+  };
+}
+
+const TEST_DEFINITION: WorkflowDefinition = {
+  name: 'test-workflow',
+  steps: [
+    { id: 's1', type: 'wait', config: { duration: 0 } },
+    { id: 's2', type: 'wait', config: { duration: 0 } },
+    { id: 's3', type: 'wait', config: { duration: 0 } },
+    { id: 's4', type: 'wait', config: { duration: 0 } },
+    { id: 's5', type: 'wait', config: { duration: 0 } },
+  ],
+};
+
+const COMPLETED_RESULTS: StepResult[] = [
+  { stepId: 's1', stepType: 'wait', status: 'succeeded', duration: 1, output: { success: true, data: { done: true }, duration: 1 } },
+  { stepId: 's2', stepType: 'wait', status: 'succeeded', duration: 1, output: { success: true, data: { done: true }, duration: 1 } },
+];
+
+// ============================================================================
+// buildPausedState
+// ============================================================================
+
+describe('buildPausedState', () => {
+  it('should create a serializable paused state', () => {
+    const state = buildPausedState(
+      'wf-123',
+      TEST_DEFINITION,
+      2, // next step index
+      { s1: { done: true }, s2: { done: true } },
+      COMPLETED_RESULTS,
+      { target: 'production' },
+    );
+
+    expect(state.workflowId).toBe('wf-123');
+    expect(state.definitionName).toBe('test-workflow');
+    expect(state.nextStepIndex).toBe(2);
+    expect(state.variables).toEqual({ s1: { done: true }, s2: { done: true } });
+    expect(state.completedStepResults).toHaveLength(2);
+    expect(state.args).toEqual({ target: 'production' });
+    expect(state.pausedAt).toBeDefined();
+    expect(JSON.parse(state.definition)).toEqual(TEST_DEFINITION);
+  });
+});
+
+// ============================================================================
+// persistPausedState + resumeWorkflow
+// ============================================================================
+
+describe('persistPausedState + resumeWorkflow', () => {
+  it('should pause after step 2 and resume from step 3', async () => {
+    const memory = createMockMemory();
+
+    // Build and persist paused state (simulating pause after step 2 of 5)
+    const state = buildPausedState(
+      'wf-pause-test',
+      TEST_DEFINITION,
+      2,
+      { s1: { done: true }, s2: { done: true } },
+      COMPLETED_RESULTS,
+      {},
+    );
+    await persistPausedState(state, memory);
+
+    // Resume should continue from step 3
+    const result = await resumeWorkflow('wf-pause-test', { memory });
+
+    expect(result.success).toBe(true);
+    // Total steps: 2 completed before pause + 3 from resume
+    expect(result.steps).toHaveLength(5);
+    expect(result.steps[0].stepId).toBe('s1');
+    expect(result.steps[1].stepId).toBe('s2');
+    expect(result.steps[2].stepId).toBe('s3');
+    expect(result.steps[3].stepId).toBe('s4');
+    expect(result.steps[4].stepId).toBe('s5');
+  });
+
+  it('should support modified variables on resume', async () => {
+    const memory = createMockMemory();
+
+    const state = buildPausedState(
+      'wf-vars-test',
+      TEST_DEFINITION,
+      2,
+      { s1: { value: 'original' } },
+      COMPLETED_RESULTS,
+      {},
+    );
+    await persistPausedState(state, memory);
+
+    // Resume with user-injected variable overrides
+    const result = await resumeWorkflow('wf-vars-test', {
+      memory,
+      variables: { userOverride: 'injected' },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Serialization roundtrip
+// ============================================================================
+
+describe('Serialization roundtrip', () => {
+  it('should survive memory persistence and reconstruction', async () => {
+    const memory = createMockMemory();
+
+    const originalState = buildPausedState(
+      'wf-serial-test',
+      TEST_DEFINITION,
+      3,
+      { s1: { nested: { deep: [1, 2, 3] } } },
+      COMPLETED_RESULTS,
+      { key: 'value' },
+    );
+
+    await persistPausedState(originalState, memory);
+
+    // Read back
+    const raw = await memory.read('workflow-paused', 'wf-serial-test');
+    const reconstructed = raw as typeof originalState;
+
+    expect(reconstructed.workflowId).toBe('wf-serial-test');
+    expect(reconstructed.nextStepIndex).toBe(3);
+    expect(reconstructed.variables).toEqual({ s1: { nested: { deep: [1, 2, 3] } } });
+    expect(JSON.parse(reconstructed.definition).name).toBe('test-workflow');
+  });
+});
+
+// ============================================================================
+// Error cases
+// ============================================================================
+
+describe('resumeWorkflow — errors', () => {
+  it('should return error for nonexistent workflow ID', async () => {
+    const memory = createMockMemory();
+
+    const result = await resumeWorkflow('nonexistent', { memory });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('No paused state found');
+  });
+
+  it('should reject stale paused state', async () => {
+    const memory = createMockMemory();
+
+    const state = buildPausedState(
+      'wf-stale-test',
+      TEST_DEFINITION,
+      1,
+      {},
+      [],
+      {},
+      1, // 1ms stale timeout
+    );
+
+    // Persist with already-expired timeout
+    await persistPausedState(state, memory);
+
+    // Wait just enough for it to expire
+    await new Promise(r => setTimeout(r, 5));
+
+    const result = await resumeWorkflow('wf-stale-test', { memory });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].message).toContain('expired');
+    // State should be cleaned up
+    expect(await memory.read('workflow-paused', 'wf-stale-test')).toBeNull();
+  });
+});
+
+// ============================================================================
+// Cleanup
+// ============================================================================
+
+describe('cleanupStalePaused', () => {
+  it('should remove stale entries and keep fresh ones', async () => {
+    const memory = createMockMemory();
+
+    // Stale entry (1ms timeout)
+    const stale = buildPausedState('wf-stale', TEST_DEFINITION, 0, {}, [], {}, 1);
+    await persistPausedState(stale, memory);
+
+    // Fresh entry (24h timeout)
+    const fresh = buildPausedState('wf-fresh', TEST_DEFINITION, 0, {}, [], {});
+    await persistPausedState(fresh, memory);
+
+    await new Promise(r => setTimeout(r, 5));
+
+    const cleaned = await cleanupStalePaused(memory);
+
+    expect(cleaned).toBe(1);
+    expect(await memory.read('workflow-paused', 'wf-stale')).toBeNull();
+    expect(await memory.read('workflow-paused', 'wf-fresh')).not.toBeNull();
+  });
+});

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -207,7 +207,7 @@ export class WorkflowRunner {
     options: RunnerOptions,
     startTime: number,
   ): Promise<WorkflowResult> {
-    const variables: Record<string, unknown> = {};
+    const variables: Record<string, unknown> = { ...options.initialVariables };
     const stepResults: StepResult[] = [];
     const errors: WorkflowError[] = [];
     const completedSteps: Array<{ step: StepDefinition; config: Record<string, unknown> }> = [];

--- a/src/packages/workflows/src/factory/pause-resume.ts
+++ b/src/packages/workflows/src/factory/pause-resume.ts
@@ -1,0 +1,191 @@
+/**
+ * Workflow Pause/Resume
+ *
+ * Serializes workflow execution state to memory for cross-conversation
+ * survival, and reconstructs it for resumption.
+ */
+
+import type { MemoryAccessor } from '../types/step-command.types.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.types.js';
+import type { WorkflowResult, StepResult } from '../types/runner.types.js';
+import { createRunner, noopMemory } from './runner-factory.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PausedState {
+  readonly workflowId: string;
+  readonly definitionName: string;
+  /** Serialized workflow definition (JSON). */
+  readonly definition: string;
+  /** Index of the next step to execute (0-based). */
+  readonly nextStepIndex: number;
+  /** Variable context at pause time. */
+  readonly variables: Record<string, unknown>;
+  /** Results of steps completed before pause. */
+  readonly completedStepResults: StepResult[];
+  /** Arguments originally passed to the workflow. */
+  readonly args: Record<string, unknown>;
+  /** ISO timestamp of when the workflow was paused. */
+  readonly pausedAt: string;
+  /** Configurable timeout (ms) after which paused state is considered stale. */
+  readonly staleAfterMs: number;
+}
+
+export interface ResumeOptions {
+  /** Override variables before resuming (e.g. user edits between pause/resume). */
+  readonly variables?: Record<string, unknown>;
+  /** Memory accessor for reading paused state and storing progress. */
+  readonly memory?: MemoryAccessor;
+}
+
+const PAUSE_NAMESPACE = 'workflow-paused';
+const DEFAULT_STALE_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours
+
+// ============================================================================
+// Pause
+// ============================================================================
+
+/**
+ * Persist paused workflow state to memory.
+ */
+export async function persistPausedState(
+  state: PausedState,
+  memory: MemoryAccessor,
+): Promise<void> {
+  await memory.write(PAUSE_NAMESPACE, state.workflowId, state);
+}
+
+/**
+ * Create a PausedState from execution context.
+ */
+export function buildPausedState(
+  workflowId: string,
+  definition: WorkflowDefinition,
+  nextStepIndex: number,
+  variables: Record<string, unknown>,
+  completedStepResults: StepResult[],
+  args: Record<string, unknown>,
+  staleAfterMs: number = DEFAULT_STALE_TIMEOUT,
+): PausedState {
+  return {
+    workflowId,
+    definitionName: definition.name,
+    definition: JSON.stringify(definition),
+    nextStepIndex,
+    variables: structuredClone(variables),
+    completedStepResults: structuredClone(completedStepResults),
+    args: structuredClone(args),
+    pausedAt: new Date().toISOString(),
+    staleAfterMs,
+  };
+}
+
+// ============================================================================
+// Resume
+// ============================================================================
+
+/**
+ * Load paused state from memory and resume execution.
+ */
+export async function resumeWorkflow(
+  workflowId: string,
+  options: ResumeOptions = {},
+): Promise<WorkflowResult> {
+  const memory = options.memory ?? noopMemory;
+  const raw = await memory.read(PAUSE_NAMESPACE, workflowId);
+
+  if (!raw) {
+    return {
+      workflowId,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'PAUSED_STATE_NOT_FOUND', message: `No paused state found for workflow "${workflowId}"` }],
+      duration: 0,
+      cancelled: false,
+    };
+  }
+
+  const state = raw as PausedState;
+
+  // Check staleness
+  const pausedTime = new Date(state.pausedAt).getTime();
+  if (Date.now() - pausedTime > state.staleAfterMs) {
+    await memory.write(PAUSE_NAMESPACE, workflowId, null);
+    return {
+      workflowId,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'PAUSED_STATE_EXPIRED', message: `Paused state for "${workflowId}" has expired (stale after ${state.staleAfterMs}ms)` }],
+      duration: 0,
+      cancelled: false,
+    };
+  }
+
+  // Reconstruct definition
+  const definition: WorkflowDefinition = JSON.parse(state.definition);
+
+  // Merge user-provided variable overrides
+  const variables = { ...state.variables, ...options.variables };
+
+  // Create runner and execute remaining steps
+  const runner = createRunner({ memory });
+  const remainingDefinition: WorkflowDefinition = {
+    ...definition,
+    steps: definition.steps.slice(state.nextStepIndex),
+  };
+
+  const startTime = Date.now();
+  const result = await runner.run(remainingDefinition, state.args, { workflowId, initialVariables: variables });
+
+  // Clean up paused state on completion
+  await memory.write(PAUSE_NAMESPACE, workflowId, null);
+
+  // Merge completed step results from before pause with resume results
+  const allSteps = [...state.completedStepResults, ...result.steps];
+  const allOutputs: Record<string, unknown> = {};
+  for (const sr of allSteps) {
+    if (sr.status === 'succeeded' && sr.output) {
+      allOutputs[sr.stepId] = sr.output.data;
+    }
+  }
+
+  return {
+    workflowId,
+    success: result.success,
+    steps: allSteps,
+    outputs: { ...allOutputs, ...result.outputs },
+    errors: result.errors,
+    duration: Date.now() - startTime,
+    cancelled: result.cancelled,
+  };
+}
+
+// ============================================================================
+// Cleanup
+// ============================================================================
+
+/**
+ * Remove stale paused workflows. Returns number of cleaned entries.
+ */
+export async function cleanupStalePaused(memory: MemoryAccessor): Promise<number> {
+  const results = await memory.search(PAUSE_NAMESPACE, '');
+  let cleaned = 0;
+
+  for (const entry of results) {
+    const state = entry.value as PausedState | undefined;
+    if (state?.pausedAt && state?.staleAfterMs) {
+      const pausedTime = new Date(state.pausedAt).getTime();
+      if (Date.now() - pausedTime > state.staleAfterMs) {
+        await memory.write(PAUSE_NAMESPACE, state.workflowId, null);
+        cleaned++;
+      }
+    }
+  }
+
+  return cleaned;
+}
+

--- a/src/packages/workflows/src/factory/runner-factory.ts
+++ b/src/packages/workflows/src/factory/runner-factory.ts
@@ -100,7 +100,7 @@ const noopCredentials: CredentialAccessor = {
   async has() { return false; },
 };
 
-const noopMemory: MemoryAccessor = {
+export const noopMemory: MemoryAccessor = {
   async read() { return null; },
   async write() { /* noop */ },
   async search() { return []; },

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -108,3 +108,16 @@ export {
   bridgeIsRunning,
   bridgeActiveWorkflows,
 } from './factory/runner-bridge.js';
+
+// ============================================================================
+// Pause/Resume
+// ============================================================================
+
+export {
+  buildPausedState,
+  persistPausedState,
+  resumeWorkflow,
+  cleanupStalePaused,
+  type PausedState,
+  type ResumeOptions,
+} from './factory/pause-resume.js';

--- a/src/packages/workflows/src/types/runner.types.ts
+++ b/src/packages/workflows/src/types/runner.types.ts
@@ -20,6 +20,8 @@ export type WorkflowErrorCode =
   | 'STEP_CANCELLED'
   | 'UNKNOWN_STEP_TYPE'
   | 'ROLLBACK_FAILED'
+  | 'PAUSED_STATE_NOT_FOUND'
+  | 'PAUSED_STATE_EXPIRED'
   | 'WORKFLOW_CANCELLED';
 
 // ============================================================================
@@ -106,4 +108,7 @@ export interface RunnerOptions {
 
   /** Literal credential values to redact from step output (matched as exact strings). */
   readonly credentialValues?: readonly string[];
+
+  /** Pre-seeded variables for resuming from a paused workflow. */
+  readonly initialVariables?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Add workflow pause/resume mechanism with memory-backed state serialization
- `buildPausedState` creates serializable snapshots with `structuredClone` for safe deep copies
- `resumeWorkflow` reconstructs definition, merges variable overrides, and runs remaining steps
- `cleanupStalePaused` removes expired entries (default 24h stale timeout)
- Added `PAUSED_STATE_NOT_FOUND` and `PAUSED_STATE_EXPIRED` error codes to `WorkflowErrorCode`
- Added `initialVariables` to `RunnerOptions` for pre-seeding resumed variable context
- Exported `noopMemory` from runner-factory to eliminate duplication

## Test plan
- [x] 7 test cases covering: build state, pause+resume roundtrip, variable overrides, serialization, nonexistent ID error, stale state rejection, cleanup
- [x] All 184 workflow tests pass
- [x] Code review via /simplify — fixed 2 bugs (cleanupStalePaused entry.value access, variables not passed to runner)

Closes #140

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)