### PR TITLE
feat(workflows): control flow, layering, integration & docs (Epic #142)

### DIFF
--- a/.claude/guidance/shipped/moflo-workflow-engine.md
+++ b/.claude/guidance/shipped/moflo-workflow-engine.md
@@ -1,0 +1,379 @@
+# Workflow Engine — Running, Creating, and Customizing Workflows
+
+**Purpose:** How to run workflows via MCP tools, create new workflow definitions, register custom step commands, and understand the shipped vs user override layering system. Reference when a user asks to run, create, or modify workflows.
+
+---
+
+## Running a Workflow via MCP Tools
+
+**Use `mcp__moflo__workflow_run` to execute a workflow from a YAML/JSON file.** The bridge layer handles parsing, validation, and runner lifecycle automatically.
+
+| MCP Tool | Purpose |
+|----------|---------|
+| `mcp__moflo__workflow_run` | Run workflow from file content (YAML/JSON) |
+| `mcp__moflo__workflow_execute` | Execute a workflow definition object directly |
+| `mcp__moflo__workflow_cancel` | Cancel a running workflow by ID |
+| `mcp__moflo__workflow_status` | Check if a workflow is currently running |
+| `mcp__moflo__workflow_pause` | Pause a running workflow for later resumption |
+| `mcp__moflo__workflow_resume` | Resume a previously paused workflow |
+
+**Dry-run mode validates without executing.** Pass `dryRun: true` to check definition validity, argument resolution, and step config schemas before committing to execution.
+
+---
+
+## Workflow Definition Format
+
+**Workflows are YAML or JSON files.** YAML is preferred for readability. Every definition must have `name` and `steps`.
+
+```yaml
+name: deploy-staging
+arguments:
+  environment:
+    type: string
+    required: true
+    description: Target environment
+  dry_run:
+    type: boolean
+    default: false
+steps:
+  - id: check-branch
+    type: bash
+    config:
+      command: "git branch --show-current"
+  - id: run-tests
+    type: bash
+    config:
+      command: "npm test"
+      failOnError: true
+  - id: deploy
+    type: bash
+    config:
+      command: "deploy.sh {args.environment}"
+    continueOnError: false
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Unique workflow identifier |
+| `steps` | array | Ordered list of step definitions |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `arguments` | object | Typed arguments with `type`, `required`, `default`, `enum`, `description` |
+| `description` | string | Human-readable workflow description |
+
+### Step Definition Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Unique step identifier (used in variable interpolation) |
+| `type` | string | Yes | Step command type (see Step Command Types below) |
+| `config` | object | Yes | Type-specific configuration |
+| `output` | string | No | Variable name to store step output |
+| `continueOnError` | boolean | No | Continue workflow if this step fails (default: false) |
+| `timeout` | number | No | Step timeout in ms (overrides runner default of 300s) |
+
+---
+
+## Variable Interpolation
+
+**Use `{reference}` syntax to reference previous step outputs and arguments.** Variables are resolved at execution time, not parse time.
+
+| Pattern | Resolves To |
+|---------|-------------|
+| `{args.environment}` | Workflow argument value |
+| `{check-branch.stdout}` | Output field from step `check-branch` |
+| `{credentials.API_KEY}` | Credential value (redacted in logs) |
+
+Interpolation works in all string values within step `config`. Nested object values and arrays are interpolated recursively.
+
+```yaml
+steps:
+  - id: fetch-url
+    type: bash
+    config:
+      command: "curl -s {args.api_url}"
+  - id: process
+    type: agent
+    config:
+      prompt: "Analyze this response: {fetch-url.stdout}"
+```
+
+---
+
+## Step Command Types
+
+**Eight built-in step types are registered automatically.** Each implements `execute()`, `validate()`, `describeOutputs()`, and optional `rollback()`.
+
+### bash — Run a Shell Command
+
+```yaml
+- id: build
+  type: bash
+  config:
+    command: "npm run build"    # Required. Shell command to execute.
+    timeout: 30000              # Optional. Timeout in ms (default: 30000).
+    failOnError: true           # Optional. Fail step on non-zero exit (default: true).
+```
+
+**Outputs:** `stdout` (string), `stderr` (string), `exitCode` (number).
+
+---
+
+### agent — Spawn a Claude Subagent
+
+```yaml
+- id: research
+  type: agent
+  config:
+    agentType: "researcher"     # Required. Agent type (researcher, coder, tester, etc.).
+    prompt: "Find all API endpoints in {args.directory}"  # Required. Task prompt.
+    background: false           # Optional. Run in background (default: false).
+```
+
+**Outputs:** `result` (string), `agentType` (string), `prompt` (string).
+
+---
+
+### condition — Branch Workflow Execution
+
+```yaml
+- id: check-env
+  type: condition
+  config:
+    if: "{args.environment} === 'production'"  # Required. Expression to evaluate.
+    then: "deploy-prod"                        # Optional. Step ID to jump to if true.
+    else: "deploy-staging"                     # Optional. Step ID to jump to if false.
+```
+
+**Outputs:** `result` (boolean), `branch` (string: "then" or "else"), `nextStep` (string).
+
+The runner uses `nextStep` to jump to the target step ID. Jumps can go forward or backward. A max-iteration guard (`steps.length * 10`) prevents infinite loops.
+
+---
+
+### loop — Iterate Over an Array
+
+```yaml
+- id: process-files
+  type: loop
+  config:
+    over: ["{args.files}"]        # Required. Array to iterate (or variable reference).
+    maxIterations: 100            # Optional. Safety limit (default: 100).
+    itemVar: "file"               # Optional. Current item variable name (default: "item").
+    indexVar: "idx"               # Optional. Current index variable name (default: "index").
+  steps:                          # Nested steps run for each item.
+    - id: process-one
+      type: bash
+      config:
+        command: "process.sh {file}"
+```
+
+**Outputs:** `totalItems` (number), `iterations` (number), `truncated` (boolean), `items` (array).
+
+Nested `steps` are defined on the step definition (not inside `config`). The runner executes all nested steps per iteration, injecting `itemVar` and `indexVar` into the variable context. Previous values are saved and restored after the loop completes.
+
+---
+
+### memory — Read, Write, or Search Shared State
+
+```yaml
+- id: load-config
+  type: memory
+  config:
+    action: "read"              # Required. One of: read, write, search.
+    namespace: "workflow-state"  # Required. Memory namespace.
+    key: "last-deploy"          # Required for read/write. Memory key.
+    value: "{deploy.stdout}"    # Required for write. Value to store.
+    query: "deploy status"      # Required for search. Semantic query.
+```
+
+**Outputs:** `value` (object), `found` (boolean), `written` (boolean), `results` (array), `count` (number).
+
+---
+
+### prompt — Ask User for Input
+
+```yaml
+- id: confirm
+  type: prompt
+  config:
+    message: "Deploy to {args.environment}?"  # Required. Question text.
+    options: ["yes", "no"]                    # Optional. Multiple choice options.
+    default: "no"                              # Optional. Default if no input.
+    outputVar: "user_choice"                   # Optional. Variable to store response.
+```
+
+**Outputs:** `response` (string), `message` (string), `outputVar` (string).
+
+---
+
+### wait — Pause Execution
+
+```yaml
+- id: cooldown
+  type: wait
+  config:
+    duration: 5000  # Required. Wait duration in milliseconds.
+```
+
+**Outputs:** `waited` (number — actual wait time in ms).
+
+---
+
+### browser — Web Automation (Requires Playwright)
+
+```yaml
+- id: screenshot
+  type: browser
+  config:
+    action: "navigate"          # Required. navigate, click, fill, screenshot, etc.
+    url: "https://example.com"  # Required for navigate.
+    selector: "#login"          # Required for click/fill.
+    value: "username"           # Required for fill.
+```
+
+**Outputs:** `html` (string), `screenshot` (string — base64), `text` (string).
+
+Requires `playwright` as a peer dependency. The command checks for Playwright availability at execution time and returns a clear error if missing.
+
+---
+
+## Shipped vs User Definition Layering
+
+**Shipped definitions are bundled defaults. User definitions override shipped ones by name match.**
+
+| Tier | Source | Priority |
+|------|--------|----------|
+| Shipped | Bundled in moflo package source (`workflows/shipped/`) | Lower |
+| User | Project-local path (configurable via `moflo.yaml`) | Higher — overrides shipped by name |
+
+### How Layering Works
+
+1. `loadWorkflowDefinitions()` loads shipped definitions first
+2. Then loads user definitions from configured directories
+3. If a user definition has the same `name` as a shipped one, the user version wins
+4. New names in user directories are additive (they extend, not replace, the set)
+
+### Loading Definitions Programmatically
+
+```typescript
+import { loadWorkflowDefinitions, loadWorkflowByName } from '@claude-flow/workflows';
+
+// Load all definitions with layering
+const { workflows, errors } = loadWorkflowDefinitions({
+  shippedDir: 'node_modules/moflo/workflows/shipped',
+  userDirs: ['.claude/workflows', 'workflows/'],
+});
+
+// Load a specific workflow by name (user override wins)
+const result = loadWorkflowByName('deploy-staging', {
+  shippedDir: 'node_modules/moflo/workflows/shipped',
+  userDirs: ['.claude/workflows'],
+});
+```
+
+---
+
+## Error Handling and Rollback
+
+**The runner collects errors without throwing.** `WorkflowResult` always returns — check `result.success` and `result.errors`.
+
+| Error Code | Meaning |
+|------------|---------|
+| `DEFINITION_VALIDATION_FAILED` | Invalid YAML/JSON or schema violation |
+| `ARGUMENT_VALIDATION_FAILED` | Missing required argument or type mismatch |
+| `UNKNOWN_STEP_TYPE` | No step command registered for this type |
+| `STEP_VALIDATION_FAILED` | Step config fails command's schema validation |
+| `STEP_EXECUTION_FAILED` | Step threw during execution |
+| `STEP_TIMEOUT` | Step exceeded its timeout |
+| `STEP_CANCELLED` | Workflow cancelled via AbortSignal |
+| `CONDITION_TARGET_NOT_FOUND` | Condition branch references nonexistent step ID |
+| `PAUSED_STATE_NOT_FOUND` | No paused state for workflow ID on resume |
+| `PAUSED_STATE_EXPIRED` | Paused state exceeded stale timeout |
+| `ROLLBACK_FAILED` | Rollback of completed steps failed |
+| `WORKFLOW_CANCELLED` | Entire workflow was cancelled |
+
+### continueOnError
+
+**Set `continueOnError: true` on a step to keep running after failure.** The failed step is recorded in results but execution continues. Without this flag, a step failure triggers rollback of completed steps and terminates the workflow.
+
+---
+
+## Pause and Resume
+
+**Pause serializes workflow state to memory. Resume reconstructs and continues from where it left off.**
+
+```typescript
+import { buildPausedState, persistPausedState, resumeWorkflow } from '@claude-flow/workflows';
+
+// Pause after step 2 of 5
+const state = buildPausedState(workflowId, definition, 2, variables, completedResults, args);
+await persistPausedState(state, memory);
+
+// Later: resume from step 3
+const result = await resumeWorkflow(workflowId, { memory, variables: { override: 'value' } });
+```
+
+**Stale timeout is 24 hours by default.** Paused state older than this is rejected on resume and cleaned up. Use `cleanupStalePaused(memory)` to sweep expired entries.
+
+**Variable overrides on resume** allow injecting or modifying context between pause and resume (e.g., user edits a value in between).
+
+---
+
+## Creating New Workflow Definitions
+
+**To create a workflow for a user, write a `.yaml` file in their project's workflow directory** (typically `.claude/workflows/` or a path configured in `moflo.yaml`).
+
+1. Start with `name` and `steps`
+2. Add `arguments` for any user-provided values
+3. Use `{args.argName}` and `{stepId.outputKey}` for interpolation
+4. Set `continueOnError: true` on non-critical steps
+5. Add `timeout` on steps that may hang (network calls, long builds)
+
+### Validation Checklist
+
+| Check | How |
+|-------|-----|
+| All step IDs are unique | Validator enforces this |
+| All step types are registered | Dry-run catches unknown types |
+| Condition `then`/`else` reference valid step IDs | Runner checks at branch time |
+| Loop `over` resolves to an array | Loop command validates at execution |
+| No circular condition jumps | Max-iteration guard catches these |
+
+---
+
+## Dry-Run Validation
+
+**Always dry-run before executing a new or modified workflow.** Dry-run validates the definition, resolves arguments, and checks step configs without executing anything.
+
+```typescript
+import { runWorkflowFromContent } from '@claude-flow/workflows';
+
+const result = await runWorkflowFromContent(yamlContent, 'my-workflow.yaml', { dryRun: true });
+if (!result.success) {
+  console.error('Validation errors:', result.errors);
+}
+```
+
+Via MCP: pass `dryRun: true` to `mcp__moflo__workflow_run`.
+
+---
+
+## Credential Handling
+
+**Credentials are accessed via `{credentials.KEY}` in interpolation.** The credential accessor is injected into the runner at creation time — workflows never store credentials directly.
+
+Credential values listed in `RunnerOptions.credentialValues` are automatically redacted from step output to prevent accidental exposure in logs or results.
+
+---
+
+## See Also
+
+- `.claude/guidance/shipped/moflo-workflow-engine-architecture.md` — Architecture decisions for Epic #100
+- `.claude/guidance/shipped/moflo-core-guidance.md` — CLI, hooks, swarm, memory reference
+- `.claude/guidance/shipped/moflo-subagents.md` — Subagents protocol

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ MoFlo makes deliberate choices so you don't have to:
 | **Guidance Indexing** | Chunks your project docs (`.claude/guidance/`, `docs/`) and makes them searchable. |
 | **Workflow Gates** | Enforces memory-first and task-creation patterns via Claude Code hooks. Prevents Claude from skipping steps. |
 | **Learned Routing** | Routes tasks to the right agent type. Learns from outcomes — gets better over time. |
+| **Workflow Engine** | Define multi-step automations as YAML — shell commands, agent spawns, conditionals, loops, memory ops. [Full documentation →](docs/WORKFLOWS.md) |
 | **`/flo` Skill** | Execute GitHub issues through a full workflow: research → enhance → implement → test → simplify → PR. (Also available as `/fl`.) |
 | **Context Tracking** | Monitors context window usage (FRESH → MODERATE → DEPLETED → CRITICAL) and advises accordingly. |
 | **Cross-Platform** | Works on macOS, Linux, and Windows. |

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,507 @@
+# Workflow Engine
+
+MoFlo includes a generalized workflow engine that lets you define multi-step automation as YAML or JSON files. Each step in a workflow is executed by a typed **step command** — a pluggable unit that knows how to run a shell command, spawn an agent, branch on a condition, loop over items, and more.
+
+The engine is what powers `/flo` under the hood, but you can also use it directly to build your own workflows for any repeatable process: deployment pipelines, data processing, code generation, review flows, or anything else you'd otherwise script by hand.
+
+## How It Works
+
+A workflow is a definition file (YAML or JSON) plus a runner that executes it step by step.
+
+```
+                  ┌─────────────────────────┐
+                  │   Workflow Definition    │
+                  │   (YAML / JSON file)     │
+                  └────────────┬────────────┘
+                               │ parse + validate
+                               v
+                  ┌─────────────────────────┐
+                  │    WorkflowRunner        │
+                  │    Sequential executor   │
+                  └────────────┬────────────┘
+                               │ for each step
+                               v
+               ┌───────────────────────────────┐
+               │     StepCommandRegistry       │
+               │  Looks up command by type      │
+               └───────┬───────┬───────┬───────┘
+                       │       │       │
+                 ┌─────┘  ┌────┘  ┌────┘
+                 v        v       v
+              [bash]  [agent] [condition] [loop] [memory] ...
+              Each step command implements:
+                execute()  — run the step
+                validate() — check config before running
+                rollback() — undo on failure (optional)
+```
+
+1. **Parse** — The runner reads your YAML/JSON file and validates it against the workflow schema.
+2. **Resolve arguments** — Typed arguments (with defaults, enums, and required flags) are resolved from caller-provided values.
+3. **Execute steps** — Steps run sequentially. Each step's output is available to later steps via variable interpolation. If a step fails, the runner rolls back completed steps (unless `continueOnError` is set).
+4. **Return results** — The runner returns a structured result with per-step status, outputs, errors, and timing.
+
+## Writing a Workflow
+
+Here's a complete example — a deployment workflow that checks the branch, runs tests, and deploys:
+
+```yaml
+name: deploy
+description: Build, test, and deploy to a target environment
+
+arguments:
+  environment:
+    type: string
+    required: true
+    description: Target environment (staging or production)
+    enum: [staging, production]
+  skip_tests:
+    type: boolean
+    default: false
+    description: Skip the test step (use with caution)
+
+steps:
+  - id: check-branch
+    type: bash
+    config:
+      command: git branch --show-current
+
+  - id: guard-production
+    type: condition
+    config:
+      if: "{args.environment} === 'production' && {check-branch.stdout} !== 'main'"
+      then: abort-wrong-branch
+      else: run-tests
+
+  - id: abort-wrong-branch
+    type: bash
+    config:
+      command: "echo 'Production deploys must be from main branch' && exit 1"
+
+  - id: run-tests
+    type: bash
+    config:
+      command: npm test
+      timeout: 120000
+    continueOnError: false
+
+  - id: deploy
+    type: bash
+    config:
+      command: "./scripts/deploy.sh {args.environment}"
+      timeout: 300000
+
+  - id: notify
+    type: memory
+    config:
+      action: write
+      namespace: deployments
+      key: "last-deploy-{args.environment}"
+      value: "{deploy.stdout}"
+```
+
+### Definition Structure
+
+Every workflow definition needs two things: a `name` and a list of `steps`.
+
+**Top-level fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier for this workflow |
+| `description` | No | Human-readable explanation |
+| `arguments` | No | Typed inputs the workflow accepts (see [Arguments](#arguments)) |
+| `steps` | Yes | Ordered list of steps to execute |
+
+**Step fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier within the workflow (used in interpolation) |
+| `type` | Yes | Which step command to run (`bash`, `agent`, `condition`, etc.) |
+| `config` | Yes | Type-specific configuration (see [Step Types](#step-types)) |
+| `output` | No | Variable name to store this step's output under |
+| `continueOnError` | No | If `true`, workflow continues even if this step fails |
+| `timeout` | No | Step-specific timeout in ms (overrides the runner's 5-minute default) |
+| `steps` | No | Nested step definitions (used by `loop` type only) |
+
+### Arguments
+
+Arguments let callers pass typed values into a workflow. Each argument has a name, type, and optional constraints:
+
+```yaml
+arguments:
+  target:
+    type: string          # string, number, boolean, or array
+    required: true
+    description: Deployment target
+    enum: [dev, staging, prod]
+  retries:
+    type: number
+    default: 3
+  verbose:
+    type: boolean
+    default: false
+```
+
+The runner validates arguments before execution — missing required args or type mismatches produce a structured error without running any steps.
+
+### Variable Interpolation
+
+Steps can reference outputs from earlier steps and workflow arguments using `{reference}` syntax:
+
+| Pattern | What it resolves to |
+|---------|-------------------|
+| `{args.environment}` | A workflow argument |
+| `{check-branch.stdout}` | The `stdout` field from step `check-branch`'s output |
+| `{run-tests.exitCode}` | The `exitCode` field from step `run-tests` |
+| `{credentials.API_KEY}` | A credential value (redacted in logs) |
+
+Interpolation happens at execution time, just before each step runs. It works recursively in all string values inside `config` — including strings nested inside objects and arrays.
+
+```yaml
+- id: greet
+  type: bash
+  config:
+    command: "echo 'Deploying {args.environment} from branch {check-branch.stdout}'"
+```
+
+If a referenced variable doesn't exist, interpolation throws — catching typos early rather than passing broken values through.
+
+## Step Types
+
+The engine ships with eight built-in step commands. Each one handles a specific kind of work.
+
+### `bash` — Run a Shell Command
+
+Executes a command in a child process and captures stdout, stderr, and the exit code.
+
+```yaml
+- id: build
+  type: bash
+  config:
+    command: npm run build       # The shell command to run
+    timeout: 60000               # Kill after 60s (default: 30s)
+    failOnError: true            # Fail the step on non-zero exit (default: true)
+```
+
+**Outputs:** `stdout`, `stderr`, `exitCode`
+
+Set `failOnError: false` to capture the exit code without failing the workflow — useful for commands where a non-zero exit is informational rather than fatal.
+
+### `agent` — Spawn a Claude Subagent
+
+Delegates a task to a Claude subagent and captures its response.
+
+```yaml
+- id: research
+  type: agent
+  config:
+    agentType: researcher        # Agent specialization
+    prompt: "Find all API endpoints in the project"
+    background: false            # Wait for completion (default: false)
+```
+
+**Outputs:** `result`, `agentType`, `prompt`
+
+The `agentType` maps to your AI client's agent types — `researcher`, `coder`, `tester`, `reviewer`, etc.
+
+### `condition` — Branch the Workflow
+
+Evaluates an expression and jumps to a different step based on the result.
+
+```yaml
+- id: check-env
+  type: condition
+  config:
+    if: "{args.environment} === 'production'"
+    then: production-deploy      # Step ID to jump to if true
+    else: staging-deploy         # Step ID to jump to if false
+```
+
+**Outputs:** `result` (boolean), `branch` ("then" or "else"), `nextStep` (target step ID)
+
+**How branching works:** When a condition step executes, the runner doesn't just continue to the next step — it jumps to the step ID specified in `then` or `else`. This means steps between the condition and its target are skipped. Jumps can go forward or backward in the step list.
+
+**Infinite loop protection:** A max-iteration guard (`total steps x 10`) prevents condition chains that loop forever. If the guard trips, the workflow terminates with an error.
+
+The `if` expression supports JavaScript-style comparisons. The condition command evaluates the interpolated expression and returns `true` or `false`.
+
+### `loop` — Iterate Over Items
+
+Runs a set of nested steps once per item in an array.
+
+```yaml
+- id: process-files
+  type: loop
+  config:
+    over: "{args.files}"         # Array to iterate over
+    itemVar: file                # Variable name for current item (default: "item")
+    indexVar: idx                # Variable name for current index (default: "index")
+    maxIterations: 50            # Safety cap (default: 100)
+  steps:
+    - id: process-one
+      type: bash
+      config:
+        command: "process.sh {file}"
+    - id: log-progress
+      type: bash
+      config:
+        command: "echo 'Done with item {idx}: {file}'"
+```
+
+**Outputs:** `totalItems`, `iterations`, `truncated`, `items`
+
+Nested steps are defined on the step itself (the `steps` field), not inside `config`. For each iteration, the runner injects `itemVar` and `indexVar` into the variable context, runs all nested steps, then moves to the next item. If those variable names already exist in the workflow context, the runner saves their values before the loop and restores them after.
+
+### `memory` — Read, Write, or Search Shared State
+
+Interacts with MoFlo's memory database during workflow execution.
+
+```yaml
+# Write
+- id: save-result
+  type: memory
+  config:
+    action: write
+    namespace: my-workflow
+    key: last-run
+    value: "{build.stdout}"
+
+# Read
+- id: load-prev
+  type: memory
+  config:
+    action: read
+    namespace: my-workflow
+    key: last-run
+
+# Search
+- id: find-related
+  type: memory
+  config:
+    action: search
+    namespace: patterns
+    query: "deployment failures"
+```
+
+**Outputs:** `value`, `found` (for read), `written` (for write), `results`, `count` (for search)
+
+### `prompt` — Ask for User Input
+
+Pauses the workflow to ask the user a question.
+
+```yaml
+- id: confirm
+  type: prompt
+  config:
+    message: "Deploy to {args.environment}? This cannot be undone."
+    options: [yes, no]           # Multiple choice (optional)
+    default: "no"                # Default if no input (optional)
+```
+
+**Outputs:** `response`, `message`
+
+### `wait` — Pause Execution
+
+Delays the workflow for a specified duration. Useful for rate limiting, cooldowns, or waiting for external processes.
+
+```yaml
+- id: cooldown
+  type: wait
+  config:
+    duration: 5000               # Milliseconds to wait
+```
+
+**Outputs:** `waited` (actual elapsed time in ms)
+
+### `browser` — Web Automation
+
+Drives a browser via Playwright for scraping, testing, or interaction.
+
+```yaml
+- id: screenshot
+  type: browser
+  config:
+    action: navigate
+    url: "https://example.com"
+
+- id: login
+  type: browser
+  config:
+    action: fill
+    selector: "#username"
+    value: "{credentials.USERNAME}"
+```
+
+**Outputs:** `html`, `screenshot` (base64), `text`
+
+Requires `playwright` as a peer dependency — the step checks for it at runtime and returns a clear error if it's not installed.
+
+## Error Handling
+
+The runner never throws. It always returns a structured `WorkflowResult` with a `success` flag, per-step results, and an `errors` array.
+
+### What happens when a step fails
+
+By default, a step failure triggers this sequence:
+
+1. The failed step is recorded with status `failed`
+2. The runner attempts to **rollback** all previously completed steps (calling each command's `rollback()` method in reverse order)
+3. Remaining steps are marked as `skipped`
+4. The workflow result has `success: false`
+
+### `continueOnError`
+
+Set `continueOnError: true` on a step to skip the rollback-and-abort behavior for that step. The failure is still recorded, but execution continues with the next step.
+
+```yaml
+- id: optional-lint
+  type: bash
+  config:
+    command: npm run lint
+  continueOnError: true          # Lint failures don't block the workflow
+
+- id: required-tests
+  type: bash
+  config:
+    command: npm test
+  # continueOnError defaults to false — test failure stops everything
+```
+
+### Error codes
+
+Each error in the result carries a code that tells you what went wrong:
+
+| Code | Meaning |
+|------|---------|
+| `DEFINITION_VALIDATION_FAILED` | The YAML/JSON is malformed or violates the schema |
+| `ARGUMENT_VALIDATION_FAILED` | A required argument is missing or has the wrong type |
+| `UNKNOWN_STEP_TYPE` | A step uses a type that isn't registered |
+| `STEP_VALIDATION_FAILED` | A step's config doesn't match its command's schema |
+| `STEP_EXECUTION_FAILED` | A step threw an error during execution |
+| `STEP_TIMEOUT` | A step exceeded its timeout |
+| `STEP_CANCELLED` | The workflow was cancelled while this step was running |
+| `CONDITION_TARGET_NOT_FOUND` | A condition's `then`/`else` references a step ID that doesn't exist |
+| `ROLLBACK_FAILED` | Rollback of a completed step failed |
+| `WORKFLOW_CANCELLED` | The entire workflow was cancelled via AbortSignal |
+
+## Dry Run
+
+Dry-run mode validates everything without executing anything. It checks:
+
+- Definition schema validity
+- Argument resolution (types, required flags, enums)
+- Step config validation against each command's schema
+- That all referenced step types are registered
+
+```yaml
+# Run via MCP with dryRun: true, or programmatically:
+```
+
+```typescript
+import { runWorkflowFromContent } from '@claude-flow/workflows';
+
+const result = await runWorkflowFromContent(yamlContent, 'deploy.yaml', {
+  dryRun: true,
+  args: { environment: 'staging' },
+});
+
+if (!result.success) {
+  console.error(result.errors);
+}
+```
+
+Use dry run to catch definition errors before committing to execution — especially useful when building or modifying workflows.
+
+## Pause and Resume
+
+Long-running workflows can be paused mid-execution and resumed later — even in a different conversation or session. The engine serializes the workflow's state (completed step results, variable context, position) to memory, then reconstructs it on resume.
+
+### How it works
+
+1. **Pause** — The engine snapshots the current state: which steps completed, what their outputs were, the current variable context, and which step comes next. This snapshot is serialized to MoFlo's memory database.
+
+2. **Wait** — The paused state sits in memory with a configurable stale timeout (default: 24 hours). After that, it's considered expired and will be cleaned up.
+
+3. **Resume** — The engine loads the snapshot from memory, reconstructs the workflow definition, merges any variable overrides the caller provides, and creates a new runner that picks up from the next unexecuted step. Completed step results from before the pause are prepended to the final result, so the caller sees the full execution history.
+
+### Variable overrides on resume
+
+When resuming, you can inject or modify variables — useful when a human needs to review intermediate results and provide input before the workflow continues:
+
+```typescript
+const result = await resumeWorkflow('wf-12345', {
+  memory,
+  variables: { approved: true, reviewer: 'alice' },
+});
+```
+
+The override merges with the paused variable context (overrides win on conflict), and the resumed steps see the combined result.
+
+## Definition Layering
+
+Workflow definitions use a two-tier system, following the same pattern as MoFlo's guidance files:
+
+| Tier | Source | Priority |
+|------|--------|----------|
+| **Shipped** | Bundled with MoFlo (built-in workflows) | Lower |
+| **User** | Your project's workflow directory | Higher |
+
+If you create a workflow with the same `name` as a shipped one, your version wins. New names are additive — they extend the available set without replacing anything.
+
+The loader checks for `.yaml`, `.yml`, and `.json` files. Invalid files produce warnings but don't block loading of valid ones.
+
+### Where to put your workflows
+
+By default, user workflows live in `.claude/workflows/` or a path you configure in `moflo.yaml`. Create a YAML file there and it's automatically available:
+
+```
+.claude/workflows/
+  deploy.yaml          # Your custom deploy workflow
+  data-pipeline.yaml   # Your data processing workflow
+```
+
+## Using the MCP Tools
+
+Your AI client interacts with the workflow engine through MCP tools:
+
+| Tool | What it does |
+|------|-------------|
+| `mcp__moflo__workflow_run` | Run a workflow from YAML/JSON content |
+| `mcp__moflo__workflow_execute` | Execute a workflow definition object directly |
+| `mcp__moflo__workflow_cancel` | Cancel a running workflow by ID |
+| `mcp__moflo__workflow_status` | Check if a workflow is running |
+| `mcp__moflo__workflow_pause` | Pause a running workflow |
+| `mcp__moflo__workflow_resume` | Resume a paused workflow |
+
+Each running workflow gets a unique ID (e.g., `wf-1711644123456`) that you can use to check status, cancel, or resume.
+
+## Programmatic Usage
+
+You can also use the workflow engine directly from TypeScript:
+
+```typescript
+import { createRunner, runWorkflowFromContent } from '@claude-flow/workflows';
+
+// Option 1: Run from YAML content (parse + validate + execute in one call)
+const result = await runWorkflowFromContent(yamlString, 'my-workflow.yaml', {
+  args: { environment: 'staging' },
+});
+
+// Option 2: Create a runner and execute a definition object
+const runner = createRunner({ memory: myMemoryAccessor });
+const result = await runner.run(definition, args, {
+  workflowId: 'my-custom-id',
+  signal: abortController.signal,        // For cancellation
+  onStepComplete: (step, i, total) => {   // Progress callback
+    console.log(`Step ${i + 1}/${total}: ${step.stepId} — ${step.status}`);
+  },
+});
+
+console.log(result.success);     // true or false
+console.log(result.steps);       // Per-step results
+console.log(result.errors);      // Structured errors (if any)
+console.log(result.duration);    // Total execution time in ms
+```
+
+`createRunner()` registers all eight built-in step commands automatically. The runner accepts optional `memory` and `credentials` accessors — if you don't provide them, it uses no-op defaults (memory reads return null, credential lookups return undefined).

--- a/src/packages/workflows/__tests__/definition-loader.test.ts
+++ b/src/packages/workflows/__tests__/definition-loader.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Definition Loader Tests
+ *
+ * Story #138: Tests for two-tier workflow definition layering.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadWorkflowDefinitions, loadWorkflowByName } from '../src/loaders/definition-loader.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+let testDir: string;
+
+function makeDir(...segments: string[]): string {
+  const dir = join(testDir, ...segments);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeYaml(dir: string, filename: string, content: string): void {
+  writeFileSync(join(dir, filename), content, 'utf-8');
+}
+
+const SHIPPED_WORKFLOW = `
+name: deploy
+description: Shipped deploy workflow
+steps:
+  - id: build
+    type: bash
+    config:
+      command: npm run build
+`;
+
+const USER_OVERRIDE_WORKFLOW = `
+name: deploy
+description: User-customized deploy workflow
+steps:
+  - id: build
+    type: bash
+    config:
+      command: npm run build:custom
+`;
+
+const USER_NEW_WORKFLOW = `
+name: lint-check
+description: User-defined lint workflow
+steps:
+  - id: lint
+    type: bash
+    config:
+      command: npm run lint
+`;
+
+const JSON_WORKFLOW = JSON.stringify({
+  name: 'json-workflow',
+  description: 'JSON format workflow',
+  steps: [{ id: 'step1', type: 'bash', config: { command: 'echo hello' } }],
+});
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `wf-loader-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('DefinitionLoader — shipped definitions', () => {
+  it('should load shipped workflow definitions', () => {
+    const shippedDir = makeDir('shipped');
+    writeYaml(shippedDir, 'deploy.yaml', SHIPPED_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      shippedDir,
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(1);
+
+    const deploy = result.workflows.get('deploy');
+    expect(deploy).toBeDefined();
+    expect(deploy!.definition.name).toBe('deploy');
+    expect(deploy!.tier).toBe('shipped');
+    expect(deploy!.sourceFile).toContain('deploy.yaml');
+  });
+});
+
+describe('DefinitionLoader — user override', () => {
+  it('should override shipped workflow by name match', () => {
+    const shippedDir = makeDir('shipped');
+    const userDir = makeDir('user');
+    writeYaml(shippedDir, 'deploy.yaml', SHIPPED_WORKFLOW);
+    writeYaml(userDir, 'deploy.yaml', USER_OVERRIDE_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      shippedDir,
+      userDirs: [userDir],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(1);
+
+    const deploy = result.workflows.get('deploy');
+    expect(deploy!.tier).toBe('user');
+    expect(deploy!.definition.description).toBe('User-customized deploy workflow');
+  });
+
+  it('should add user workflow with new name additively', () => {
+    const shippedDir = makeDir('shipped');
+    const userDir = makeDir('user');
+    writeYaml(shippedDir, 'deploy.yaml', SHIPPED_WORKFLOW);
+    writeYaml(userDir, 'lint-check.yaml', USER_NEW_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      shippedDir,
+      userDirs: [userDir],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(2);
+    expect(result.workflows.has('deploy')).toBe(true);
+    expect(result.workflows.has('lint-check')).toBe(true);
+
+    expect(result.workflows.get('deploy')!.tier).toBe('shipped');
+    expect(result.workflows.get('lint-check')!.tier).toBe('user');
+  });
+});
+
+describe('DefinitionLoader — custom paths', () => {
+  it('should load from multiple user directories', () => {
+    const userDir1 = makeDir('user1');
+    const userDir2 = makeDir('user2');
+    writeYaml(userDir1, 'deploy.yaml', SHIPPED_WORKFLOW);
+    writeYaml(userDir2, 'lint.yaml', USER_NEW_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [userDir1, userDir2],
+      skipValidation: true,
+    });
+
+    expect(result.workflows.size).toBe(2);
+  });
+
+  it('should not error when user path does not exist', () => {
+    const result = loadWorkflowDefinitions({
+      userDirs: [join(testDir, 'nonexistent')],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(0);
+  });
+
+  it('should not error when shipped path does not exist', () => {
+    const result = loadWorkflowDefinitions({
+      shippedDir: join(testDir, 'nonexistent'),
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(0);
+  });
+});
+
+describe('DefinitionLoader — format support', () => {
+  it('should load JSON format workflow definitions', () => {
+    const dir = makeDir('json');
+    writeFileSync(join(dir, 'wf.json'), JSON_WORKFLOW, 'utf-8');
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [dir],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(1);
+    expect(result.workflows.get('json-workflow')!.definition.name).toBe('json-workflow');
+  });
+
+  it('should load .yml extension', () => {
+    const dir = makeDir('yml');
+    writeYaml(dir, 'deploy.yml', SHIPPED_WORKFLOW);
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [dir],
+      skipValidation: true,
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.workflows.size).toBe(1);
+  });
+
+  it('should ignore non-workflow files', () => {
+    const dir = makeDir('mixed');
+    writeYaml(dir, 'deploy.yaml', SHIPPED_WORKFLOW);
+    writeFileSync(join(dir, 'readme.md'), '# README', 'utf-8');
+    writeFileSync(join(dir, 'notes.txt'), 'some notes', 'utf-8');
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [dir],
+      skipValidation: true,
+    });
+
+    expect(result.workflows.size).toBe(1);
+  });
+});
+
+describe('DefinitionLoader — error handling', () => {
+  it('should collect parse errors without failing other files', () => {
+    const dir = makeDir('errors');
+    writeYaml(dir, 'good.yaml', SHIPPED_WORKFLOW);
+    writeFileSync(join(dir, 'bad.yaml'), '{{invalid yaml', 'utf-8');
+
+    const result = loadWorkflowDefinitions({
+      userDirs: [dir],
+      skipValidation: true,
+    });
+
+    expect(result.workflows.size).toBe(1);
+    expect(result.workflows.has('deploy')).toBe(true);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].file).toContain('bad.yaml');
+  });
+});
+
+describe('DefinitionLoader — loadWorkflowByName', () => {
+  it('should load a specific workflow by name', () => {
+    const shippedDir = makeDir('shipped');
+    writeYaml(shippedDir, 'deploy.yaml', SHIPPED_WORKFLOW);
+
+    const result = loadWorkflowByName('deploy', {
+      shippedDir,
+      skipValidation: true,
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.definition.name).toBe('deploy');
+  });
+
+  it('should return undefined for unknown workflow name', () => {
+    const result = loadWorkflowByName('nonexistent', {
+      shippedDir: join(testDir, 'empty'),
+      skipValidation: true,
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/packages/workflows/__tests__/pause-resume.test.ts
+++ b/src/packages/workflows/__tests__/pause-resume.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Pause/Resume Tests
+ *
+ * Story #140: Tests for workflow pause/resume mechanism.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { MemoryAccessor } from '../src/types/step-command.types.js';
+import type { StepResult } from '../src/types/runner.types.js';
+import type { WorkflowDefinition } from '../src/types/workflow-definition.types.js';
+import {
+  buildPausedState,
+  persistPausedState,
+  resumeWorkflow,
+  cleanupStalePaused,
+} from '../src/factory/pause-resume.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockMemory(): MemoryAccessor & { store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    async read(ns: string, key: string) { return store.get(`${ns}:${key}`) ?? null; },
+    async write(ns: string, key: string, value: unknown) {
+      if (value === null) store.delete(`${ns}:${key}`);
+      else store.set(`${ns}:${key}`, value);
+    },
+    async search(ns: string) {
+      const results: Array<{ key: string; value: unknown; score: number }> = [];
+      for (const [key, val] of store.entries()) {
+        if (key.startsWith(`${ns}:`)) results.push({ key, value: val, score: 1.0 });
+      }
+      return results;
+    },
+  };
+}
+
+const TEST_DEFINITION: WorkflowDefinition = {
+  name: 'test-workflow',
+  steps: [
+    { id: 's1', type: 'wait', config: { duration: 0 } },
+    { id: 's2', type: 'wait', config: { duration: 0 } },
+    { id: 's3', type: 'wait', config: { duration: 0 } },
+    { id: 's4', type: 'wait', config: { duration: 0 } },
+    { id: 's5', type: 'wait', config: { duration: 0 } },
+  ],
+};
+
+const COMPLETED_RESULTS: StepResult[] = [
+  { stepId: 's1', stepType: 'wait', status: 'succeeded', duration: 1, output: { success: true, data: { done: true }, duration: 1 } },
+  { stepId: 's2', stepType: 'wait', status: 'succeeded', duration: 1, output: { success: true, data: { done: true }, duration: 1 } },
+];
+
+// ============================================================================
+// buildPausedState
+// ============================================================================
+
+describe('buildPausedState', () => {
+  it('should create a serializable paused state', () => {
+    const state = buildPausedState(
+      'wf-123',
+      TEST_DEFINITION,
+      2, // next step index
+      { s1: { done: true }, s2: { done: true } },
+      COMPLETED_RESULTS,
+      { target: 'production' },
+    );
+
+    expect(state.workflowId).toBe('wf-123');
+    expect(state.definitionName).toBe('test-workflow');
+    expect(state.nextStepIndex).toBe(2);
+    expect(state.variables).toEqual({ s1: { done: true }, s2: { done: true } });
+    expect(state.completedStepResults).toHaveLength(2);
+    expect(state.args).toEqual({ target: 'production' });
+    expect(state.pausedAt).toBeDefined();
+    expect(JSON.parse(state.definition)).toEqual(TEST_DEFINITION);
+  });
+});
+
+// ============================================================================
+// persistPausedState + resumeWorkflow
+// ============================================================================
+
+describe('persistPausedState + resumeWorkflow', () => {
+  it('should pause after step 2 and resume from step 3', async () => {
+    const memory = createMockMemory();
+
+    // Build and persist paused state (simulating pause after step 2 of 5)
+    const state = buildPausedState(
+      'wf-pause-test',
+      TEST_DEFINITION,
+      2,
+      { s1: { done: true }, s2: { done: true } },
+      COMPLETED_RESULTS,
+      {},
+    );
+    await persistPausedState(state, memory);
+
+    // Resume should continue from step 3
+    const result = await resumeWorkflow('wf-pause-test', { memory });
+
+    expect(result.success).toBe(true);
+    // Total steps: 2 completed before pause + 3 from resume
+    expect(result.steps).toHaveLength(5);
+    expect(result.steps[0].stepId).toBe('s1');
+    expect(result.steps[1].stepId).toBe('s2');
+    expect(result.steps[2].stepId).toBe('s3');
+    expect(result.steps[3].stepId).toBe('s4');
+    expect(result.steps[4].stepId).toBe('s5');
+  });
+
+  it('should support modified variables on resume', async () => {
+    const memory = createMockMemory();
+
+    const state = buildPausedState(
+      'wf-vars-test',
+      TEST_DEFINITION,
+      2,
+      { s1: { value: 'original' } },
+      COMPLETED_RESULTS,
+      {},
+    );
+    await persistPausedState(state, memory);
+
+    // Resume with user-injected variable overrides
+    const result = await resumeWorkflow('wf-vars-test', {
+      memory,
+      variables: { userOverride: 'injected' },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Serialization roundtrip
+// ============================================================================
+
+describe('Serialization roundtrip', () => {
+  it('should survive memory persistence and reconstruction', async () => {
+    const memory = createMockMemory();
+
+    const originalState = buildPausedState(
+      'wf-serial-test',
+      TEST_DEFINITION,
+      3,
+      { s1: { nested: { deep: [1, 2, 3] } } },
+      COMPLETED_RESULTS,
+      { key: 'value' },
+    );
+
+    await persistPausedState(originalState, memory);
+
+    // Read back
+    const raw = await memory.read('workflow-paused', 'wf-serial-test');
+    const reconstructed = raw as typeof originalState;
+
+    expect(reconstructed.workflowId).toBe('wf-serial-test');
+    expect(reconstructed.nextStepIndex).toBe(3);
+    expect(reconstructed.variables).toEqual({ s1: { nested: { deep: [1, 2, 3] } } });
+    expect(JSON.parse(reconstructed.definition).name).toBe('test-workflow');
+  });
+});
+
+// ============================================================================
+// Error cases
+// ============================================================================
+
+describe('resumeWorkflow — errors', () => {
+  it('should return error for nonexistent workflow ID', async () => {
+    const memory = createMockMemory();
+
+    const result = await resumeWorkflow('nonexistent', { memory });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('No paused state found');
+  });
+
+  it('should reject stale paused state', async () => {
+    const memory = createMockMemory();
+
+    const state = buildPausedState(
+      'wf-stale-test',
+      TEST_DEFINITION,
+      1,
+      {},
+      [],
+      {},
+      1, // 1ms stale timeout
+    );
+
+    // Persist with already-expired timeout
+    await persistPausedState(state, memory);
+
+    // Wait just enough for it to expire
+    await new Promise(r => setTimeout(r, 5));
+
+    const result = await resumeWorkflow('wf-stale-test', { memory });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].message).toContain('expired');
+    // State should be cleaned up
+    expect(await memory.read('workflow-paused', 'wf-stale-test')).toBeNull();
+  });
+});
+
+// ============================================================================
+// Cleanup
+// ============================================================================
+
+describe('cleanupStalePaused', () => {
+  it('should remove stale entries and keep fresh ones', async () => {
+    const memory = createMockMemory();
+
+    // Stale entry (1ms timeout)
+    const stale = buildPausedState('wf-stale', TEST_DEFINITION, 0, {}, [], {}, 1);
+    await persistPausedState(stale, memory);
+
+    // Fresh entry (24h timeout)
+    const fresh = buildPausedState('wf-fresh', TEST_DEFINITION, 0, {}, [], {});
+    await persistPausedState(fresh, memory);
+
+    await new Promise(r => setTimeout(r, 5));
+
+    const cleaned = await cleanupStalePaused(memory);
+
+    expect(cleaned).toBe(1);
+    expect(await memory.read('workflow-paused', 'wf-stale')).toBeNull();
+    expect(await memory.read('workflow-paused', 'wf-fresh')).not.toBeNull();
+  });
+});

--- a/src/packages/workflows/__tests__/runner-bridge.test.ts
+++ b/src/packages/workflows/__tests__/runner-bridge.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Runner Bridge & Factory Tests
+ *
+ * Story #139: Tests for MCP tool integration bridge.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bridgeRunWorkflow,
+  bridgeCancelWorkflow,
+  bridgeIsRunning,
+  bridgeActiveWorkflows,
+} from '../src/factory/runner-bridge.js';
+import { createRunner, runWorkflowFromContent } from '../src/factory/runner-factory.js';
+
+// ============================================================================
+// Runner Factory
+// ============================================================================
+
+describe('createRunner', () => {
+  it('should create a runner with built-in commands registered', async () => {
+    const runner = createRunner();
+    const definition = {
+      name: 'test',
+      steps: [{ id: 's1', type: 'bash', config: { command: 'echo hello' } }],
+    };
+
+    // Should not throw for known step type 'bash'
+    const result = await runner.run(definition, {}, { dryRun: true });
+    expect(result.workflowId).toBeDefined();
+  });
+});
+
+describe('runWorkflowFromContent', () => {
+  it('should parse and run a YAML workflow', async () => {
+    const yaml = `
+name: test-workflow
+steps:
+  - id: step1
+    type: wait
+    config:
+      duration: 0
+`;
+    const result = await runWorkflowFromContent(yaml, 'test.yaml');
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0].stepId).toBe('step1');
+  });
+
+  it('should return structured error for invalid YAML', async () => {
+    const result = await runWorkflowFromContent('{{invalid', 'bad.yaml');
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe('DEFINITION_VALIDATION_FAILED');
+    expect(result.errors[0].message).toContain('Parse error');
+  });
+
+  it('should return structured error for invalid definition', async () => {
+    const yaml = `
+name: ""
+steps: []
+`;
+    const result = await runWorkflowFromContent(yaml, 'invalid.yaml');
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('DEFINITION_VALIDATION_FAILED');
+  });
+
+  it('should support dry-run mode', async () => {
+    const yaml = `
+name: dry-test
+steps:
+  - id: s1
+    type: wait
+    config:
+      duration: 0
+`;
+    const result = await runWorkflowFromContent(yaml, 'test.yaml', { dryRun: true });
+
+    expect(result.success).toBe(true);
+    // Dry run doesn't produce step results
+    expect(result.steps).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Runner Bridge
+// ============================================================================
+
+describe('bridgeRunWorkflow', () => {
+  it('should run a workflow from content and track it', async () => {
+    const yaml = `
+name: bridge-test
+steps:
+  - id: s1
+    type: wait
+    config:
+      duration: 0
+`;
+    const result = await bridgeRunWorkflow(yaml, 'test.yaml', {});
+
+    expect(result.success).toBe(true);
+    expect(result.workflowId).toMatch(/^wf-\d+$/);
+    // After completion, should no longer be tracked
+    expect(bridgeIsRunning(result.workflowId)).toBe(false);
+  });
+});
+
+describe('bridgeCancelWorkflow', () => {
+  it('should return false for unknown workflow ID', () => {
+    expect(bridgeCancelWorkflow('nonexistent')).toBe(false);
+  });
+});
+
+describe('bridgeActiveWorkflows', () => {
+  it('should return empty array when no workflows running', () => {
+    expect(bridgeActiveWorkflows()).toEqual([]);
+  });
+});

--- a/src/packages/workflows/__tests__/runner.test.ts
+++ b/src/packages/workflows/__tests__/runner.test.ts
@@ -1,0 +1,714 @@
+/**
+ * Workflow Runner Tests
+ *
+ * Story #104: Tests for sequential workflow executor.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WorkflowRunner } from '../src/core/runner.js';
+import { StepCommandRegistry } from '../src/core/step-command-registry.js';
+import type {
+  StepCommand,
+  CredentialAccessor,
+  MemoryAccessor,
+} from '../src/types/step-command.types.js';
+import type { WorkflowDefinition } from '../src/types/workflow-definition.types.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockCommand(overrides?: Partial<StepCommand>): StepCommand {
+  return {
+    type: 'mock',
+    description: 'Mock command',
+    configSchema: { type: 'object' },
+    validate: () => ({ valid: true, errors: [] }),
+    execute: async () => ({ success: true, data: { result: 'ok' }, duration: 10 }),
+    describeOutputs: () => [{ name: 'result', type: 'string' }],
+    ...overrides,
+  };
+}
+
+function createFailingCommand(error = 'Step failed'): StepCommand {
+  return createMockCommand({
+    type: 'failing',
+    execute: async () => ({ success: false, data: {}, error, duration: 5 }),
+  });
+}
+
+function createMockCredentials(): CredentialAccessor {
+  return {
+    async get(name: string) { return name === 'secret' ? 's3cr3t' : undefined; },
+    async has(name: string) { return name === 'secret'; },
+  };
+}
+
+function createMockMemory(): MemoryAccessor {
+  const store = new Map<string, unknown>();
+  return {
+    async read(ns: string, key: string) { return store.get(`${ns}:${key}`) ?? null; },
+    async write(ns: string, key: string, value: unknown) { store.set(`${ns}:${key}`, value); },
+    async search() { return []; },
+  };
+}
+
+function simpleWorkflow(steps: WorkflowDefinition['steps']): WorkflowDefinition {
+  return { name: 'test-workflow', steps };
+}
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+let registry: StepCommandRegistry;
+let runner: WorkflowRunner;
+let memory: MemoryAccessor;
+
+beforeEach(() => {
+  registry = new StepCommandRegistry();
+  memory = createMockMemory();
+  runner = new WorkflowRunner(registry, createMockCredentials(), memory);
+});
+
+// ============================================================================
+// Sequential Execution
+// ============================================================================
+
+describe('WorkflowRunner — sequential execution', () => {
+  it('should execute a 3-step workflow passing outputs forward', async () => {
+    let callOrder = 0;
+
+    const step1 = createMockCommand({
+      type: 'step1',
+      execute: async () => {
+        callOrder++;
+        return { success: true, data: { value: 'from-step-1', order: callOrder }, duration: 1 };
+      },
+    });
+    const step2 = createMockCommand({
+      type: 'step2',
+      execute: async (_config, ctx) => {
+        callOrder++;
+        const prev = ctx.variables['s1'] as Record<string, unknown>;
+        return {
+          success: true,
+          data: { combined: `${prev?.value}-and-step-2`, order: callOrder },
+          duration: 1,
+        };
+      },
+    });
+    const step3 = createMockCommand({
+      type: 'step3',
+      execute: async (_config, ctx) => {
+        callOrder++;
+        const prev = ctx.variables['s2'] as Record<string, unknown>;
+        return {
+          success: true,
+          data: { final: `${prev?.combined}-and-step-3`, order: callOrder },
+          duration: 1,
+        };
+      },
+    });
+
+    registry.register(step1);
+    registry.register(step2);
+    registry.register(step3);
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'step1', config: {}, output: 's1' },
+      { id: 's2', type: 'step2', config: {}, output: 's2' },
+      { id: 's3', type: 'step3', config: {}, output: 's3' },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(3);
+    expect(result.steps.every(s => s.status === 'succeeded')).toBe(true);
+    expect(result.outputs['s3']).toEqual({
+      final: 'from-step-1-and-step-2-and-step-3',
+      order: 3,
+    });
+  });
+
+  it('should execute steps in order', async () => {
+    const order: string[] = [];
+
+    const cmd = createMockCommand({
+      execute: async (_config, ctx) => {
+        order.push(`step-${ctx.stepIndex}`);
+        return { success: true, data: {}, duration: 1 };
+      },
+    });
+    registry.register(cmd);
+
+    const definition = simpleWorkflow([
+      { id: 'a', type: 'mock', config: {} },
+      { id: 'b', type: 'mock', config: {} },
+      { id: 'c', type: 'mock', config: {} },
+    ]);
+
+    await runner.run(definition, {});
+    expect(order).toEqual(['step-0', 'step-1', 'step-2']);
+  });
+});
+
+// ============================================================================
+// Error Handling & Rollback
+// ============================================================================
+
+describe('WorkflowRunner — error handling', () => {
+  it('should stop on step failure (default behavior)', async () => {
+    const rollbackFn = vi.fn();
+
+    registry.register(createMockCommand({ type: 'good', rollback: rollbackFn }));
+    registry.register(createFailingCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'good', config: {}, output: 's1' },
+      { id: 's2', type: 'failing', config: {} },
+      { id: 's3', type: 'good', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(result.steps).toHaveLength(3);
+    expect(result.steps[0].status).toBe('rolled_back');
+    expect(result.steps[1].status).toBe('failed');
+    expect(result.steps[2].status).toBe('skipped');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].stepId).toBe('s2');
+    expect(rollbackFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should continue when continueOnError is true', async () => {
+    registry.register(createMockCommand());
+    registry.register(createFailingCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+      { id: 's2', type: 'failing', config: {}, continueOnError: true },
+      { id: 's3', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(result.steps[0].status).toBe('succeeded');
+    expect(result.steps[1].status).toBe('failed');
+    expect(result.steps[2].status).toBe('succeeded');
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('should aggregate errors with multiple failures under continueOnError', async () => {
+    registry.register(createMockCommand());
+    registry.register(createFailingCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'failing', config: {}, continueOnError: true },
+      { id: 's2', type: 'failing', config: {}, continueOnError: true },
+      { id: 's3', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0].stepId).toBe('s1');
+    expect(result.errors[1].stepId).toBe('s2');
+    expect(result.steps[2].status).toBe('succeeded');
+  });
+
+  it('should rollback completed steps in reverse order on failure', async () => {
+    const rollbackOrder: string[] = [];
+
+    const makeCmd = (type: string): StepCommand => createMockCommand({
+      type,
+      rollback: async () => { rollbackOrder.push(type); },
+    });
+
+    registry.register(makeCmd('a'));
+    registry.register(makeCmd('b'));
+    registry.register(createFailingCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'a', config: {}, output: 's1' },
+      { id: 's2', type: 'b', config: {}, output: 's2' },
+      { id: 's3', type: 'failing', config: {} },
+    ]);
+
+    await runner.run(definition, {});
+    expect(rollbackOrder).toEqual(['b', 'a']);
+  });
+
+  it('should continue rollback if one rollback fails', async () => {
+    const rollbackOrder: string[] = [];
+
+    const cmdA = createMockCommand({
+      type: 'a',
+      rollback: async () => { rollbackOrder.push('a'); },
+    });
+    const cmdB = createMockCommand({
+      type: 'b',
+      rollback: async () => { throw new Error('rollback-b failed'); },
+    });
+
+    registry.register(cmdA);
+    registry.register(cmdB);
+    registry.register(createFailingCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'a', config: {}, output: 's1' },
+      { id: 's2', type: 'b', config: {}, output: 's2' },
+      { id: 's3', type: 'failing', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    // Both rollbacks attempted: b first (reverse order), then a
+    expect(rollbackOrder).toEqual(['a']); // a succeeded
+    const s2Result = result.steps.find(s => s.stepId === 's2');
+    expect(s2Result?.rollbackAttempted).toBe(true);
+    expect(s2Result?.rollbackError).toContain('rollback-b failed');
+  });
+
+  it('should report partial completion', async () => {
+    registry.register(createMockCommand());
+    registry.register(createFailingCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+      { id: 's2', type: 'mock', config: {} },
+      { id: 's3', type: 'failing', config: {} },
+      { id: 's4', type: 'mock', config: {} },
+      { id: 's5', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    const succeeded = result.steps.filter(s => s.status === 'succeeded').length;
+    const failed = result.steps.filter(s => s.status === 'failed').length;
+    const skipped = result.steps.filter(s => s.status === 'skipped').length;
+
+    expect(succeeded).toBe(2);
+    expect(failed).toBe(1);
+    expect(skipped).toBe(2);
+  });
+});
+
+// ============================================================================
+// Argument Validation
+// ============================================================================
+
+describe('WorkflowRunner — argument validation', () => {
+  it('should fail before step 1 if required arg is missing', async () => {
+    registry.register(createMockCommand());
+
+    const definition: WorkflowDefinition = {
+      name: 'test',
+      arguments: {
+        name: { type: 'string', required: true },
+      },
+      steps: [{ id: 's1', type: 'mock', config: {} }],
+    };
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(result.steps).toHaveLength(0);
+    expect(result.errors[0].code).toBe('ARGUMENT_VALIDATION_FAILED');
+  });
+
+  it('should resolve default argument values', async () => {
+    let receivedArgs: Record<string, unknown> = {};
+
+    registry.register(createMockCommand({
+      execute: async (_config, ctx) => {
+        receivedArgs = { ...ctx.args };
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition: WorkflowDefinition = {
+      name: 'test',
+      arguments: {
+        greeting: { type: 'string', default: 'hello' },
+      },
+      steps: [{ id: 's1', type: 'mock', config: {} }],
+    };
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(receivedArgs.greeting).toBe('hello');
+  });
+});
+
+// ============================================================================
+// Timeout
+// ============================================================================
+
+describe('WorkflowRunner — timeout', () => {
+  it('should kill step that exceeds timeout', async () => {
+    registry.register(createMockCommand({
+      execute: () => new Promise((resolve) => {
+        setTimeout(() => resolve({ success: true, data: {}, duration: 1000 }), 5000);
+      }),
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {}, { defaultStepTimeout: 50 });
+
+    expect(result.success).toBe(false);
+    expect(result.steps[0].status).toBe('failed');
+    expect(result.steps[0].errorCode).toBe('STEP_TIMEOUT');
+  });
+});
+
+// ============================================================================
+// Cancellation
+// ============================================================================
+
+describe('WorkflowRunner — cancellation', () => {
+  it('should cancel workflow and mark remaining steps as cancelled', async () => {
+    const controller = new AbortController();
+
+    registry.register(createMockCommand({
+      execute: async () => {
+        // Cancel after first step completes
+        controller.abort();
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {}, output: 's1' },
+      { id: 's2', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {}, { signal: controller.signal });
+
+    expect(result.cancelled).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.steps.some(s => s.status === 'cancelled')).toBe(true);
+    expect(result.errors.some(e => e.code === 'WORKFLOW_CANCELLED')).toBe(true);
+  });
+});
+
+// ============================================================================
+// Credential Masking
+// ============================================================================
+
+describe('WorkflowRunner — credential masking', () => {
+  it('should mask credential values in step output', async () => {
+    registry.register(createMockCommand({
+      execute: async () => ({
+        success: true,
+        data: { message: 'token is s3cr3t and password is p@ssw0rd' },
+        duration: 1,
+      }),
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {}, {
+      credentialValues: ['s3cr3t', 'p@ssw0rd'],
+    });
+
+    expect(result.success).toBe(true);
+    const output = result.outputs['s1'] as Record<string, unknown>;
+    expect(output.message).not.toContain('s3cr3t');
+    expect(output.message).not.toContain('p@ssw0rd');
+    expect(output.message).toContain('***REDACTED***');
+  });
+});
+
+// ============================================================================
+// Dry Run
+// ============================================================================
+
+describe('WorkflowRunner — dry run', () => {
+  it('should validate without executing', async () => {
+    const executeFn = vi.fn().mockResolvedValue({ success: true, data: {}, duration: 1 });
+
+    registry.register(createMockCommand({ execute: executeFn }));
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+      { id: 's2', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {}, { dryRun: true });
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(0); // No actual step results
+    expect(executeFn).not.toHaveBeenCalled();
+  });
+
+  it('should report step details in dry run', async () => {
+    registry.register(createMockCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: { key: 'value' } },
+    ]);
+
+    const dryResult = await runner.dryRun(definition, {});
+
+    expect(dryResult.valid).toBe(true);
+    expect(dryResult.steps).toHaveLength(1);
+    expect(dryResult.steps[0].stepId).toBe('s1');
+    expect(dryResult.steps[0].stepType).toBe('mock');
+    expect(dryResult.steps[0].interpolatedConfig).toEqual({ key: 'value' });
+    expect(dryResult.steps[0].hasRollback).toBe(false);
+  });
+
+  it('should detect unknown step types in dry run', async () => {
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'nonexistent', config: {} },
+    ]);
+
+    const dryResult = await runner.dryRun(definition, {});
+
+    expect(dryResult.valid).toBe(false);
+    expect(dryResult.steps[0].validationResult.valid).toBe(false);
+  });
+});
+
+// ============================================================================
+// Definition Validation
+// ============================================================================
+
+describe('WorkflowRunner — definition validation', () => {
+  it('should reject invalid definition', async () => {
+    const result = await runner.run(
+      { name: '', steps: [] } as unknown as WorkflowDefinition,
+      {},
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('DEFINITION_VALIDATION_FAILED');
+  });
+
+  it('should reject unknown step types', async () => {
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'nonexistent', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('DEFINITION_VALIDATION_FAILED');
+  });
+});
+
+// ============================================================================
+// Progress Tracking
+// ============================================================================
+
+describe('WorkflowRunner — progress tracking', () => {
+  it('should store progress in memory namespace', async () => {
+    registry.register(createMockCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+    ]);
+
+    const writeSpy = vi.spyOn(memory, 'write');
+
+    await runner.run(definition, {});
+
+    // Should have been called for initial + after step + completion
+    const tasklistWrites = writeSpy.mock.calls.filter(c => c[0] === 'tasklist');
+    expect(tasklistWrites.length).toBeGreaterThanOrEqual(2);
+
+    // Final write should show completed
+    const lastWrite = tasklistWrites[tasklistWrites.length - 1];
+    expect((lastWrite[2] as Record<string, unknown>).status).toBe('completed');
+  });
+
+  it('should invoke onStepComplete callback', async () => {
+    registry.register(createMockCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+      { id: 's2', type: 'mock', config: {} },
+    ]);
+
+    const callback = vi.fn();
+
+    await runner.run(definition, {}, { onStepComplete: callback });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ stepId: 's1', status: 'succeeded' }),
+      0,
+      2,
+    );
+  });
+});
+
+// ============================================================================
+// Async Validation
+// ============================================================================
+
+describe('WorkflowRunner — async validation', () => {
+  it('should handle async validate that returns a promise', async () => {
+    registry.register(createMockCommand({
+      validate: async () => {
+        await new Promise(r => setTimeout(r, 5));
+        return { valid: true, errors: [] };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Step Validation Failure
+// ============================================================================
+
+describe('WorkflowRunner — step validation failure', () => {
+  it('should fail step when validation rejects config', async () => {
+    registry.register(createMockCommand({
+      validate: () => ({
+        valid: false,
+        errors: [{ path: 'config.key', message: 'required field missing' }],
+      }),
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(result.steps[0].status).toBe('failed');
+    expect(result.steps[0].errorCode).toBe('STEP_VALIDATION_FAILED');
+  });
+});
+
+// ============================================================================
+// Variable Interpolation in Runner
+// ============================================================================
+
+describe('WorkflowRunner — variable interpolation', () => {
+  it('should interpolate step output references in config', async () => {
+    let capturedConfig: Record<string, unknown> = {};
+
+    registry.register(createMockCommand({
+      type: 'producer',
+      execute: async () => ({
+        success: true,
+        data: { greeting: 'hello world' },
+        duration: 1,
+      }),
+    }));
+    registry.register(createMockCommand({
+      type: 'consumer',
+      execute: async (config) => {
+        capturedConfig = config as Record<string, unknown>;
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 'produce', type: 'producer', config: {}, output: 'produce' },
+      { id: 'consume', type: 'consumer', config: { message: '{produce.greeting}' } },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(capturedConfig.message).toBe('hello world');
+  });
+
+  it('should fail step when interpolation references missing variable', async () => {
+    registry.register(createMockCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: { ref: '{nonexistent.value}' } },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    // Definition validation will catch this as a forward reference
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// Workflow ID
+// ============================================================================
+
+describe('WorkflowRunner — workflowId', () => {
+  it('should expose auto-generated workflowId on result', async () => {
+    registry.register(createMockCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.workflowId).toBeDefined();
+    expect(result.workflowId).toMatch(/^wf-\d+$/);
+  });
+
+  it('should use caller-specified workflowId', async () => {
+    registry.register(createMockCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {}, { workflowId: 'my-custom-id' });
+
+    expect(result.workflowId).toBe('my-custom-id');
+  });
+
+  it('should expose workflowId on failure results', async () => {
+    const result = await runner.run(
+      { name: '', steps: [] } as unknown as WorkflowDefinition,
+      {},
+      { workflowId: 'fail-id' },
+    );
+
+    expect(result.workflowId).toBe('fail-id');
+  });
+});
+
+// ============================================================================
+// Callback Safety
+// ============================================================================
+
+describe('WorkflowRunner — callback safety', () => {
+  it('should not crash if onStepComplete throws', async () => {
+    registry.register(createMockCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: {} },
+      { id: 's2', type: 'mock', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {}, {
+      onStepComplete: () => { throw new Error('callback exploded'); },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(2);
+  });
+});

--- a/src/packages/workflows/__tests__/runner.test.ts
+++ b/src/packages/workflows/__tests__/runner.test.ts
@@ -712,3 +712,177 @@ describe('WorkflowRunner — callback safety', () => {
     expect(result.steps).toHaveLength(2);
   });
 });
+
+// ============================================================================
+// Condition Branching (Story #136)
+// ============================================================================
+
+describe('WorkflowRunner — condition branching', () => {
+  function createConditionCommand(result: boolean, nextStep: string | null): StepCommand {
+    return createMockCommand({
+      type: 'condition',
+      execute: async () => ({
+        success: true,
+        data: { result, branch: result ? 'then' : 'else', nextStep },
+        duration: 1,
+      }),
+    });
+  }
+
+  it('should jump to "then" step when condition is true', async () => {
+    registry.register(createConditionCommand(true, 'then-step'));
+    registry.register(createMockCommand({ type: 'action' }));
+
+    const definition = simpleWorkflow([
+      { id: 'check', type: 'condition', config: {}, output: 'check' },
+      { id: 'skipped-step', type: 'action', config: {} },
+      { id: 'then-step', type: 'action', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    // Should have executed: check, then-step (skipped-step was jumped over)
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].stepId).toBe('check');
+    expect(result.steps[1].stepId).toBe('then-step');
+  });
+
+  it('should jump to "else" step when condition is false', async () => {
+    registry.register(createConditionCommand(false, 'else-step'));
+    registry.register(createMockCommand({ type: 'action' }));
+
+    const definition = simpleWorkflow([
+      { id: 'check', type: 'condition', config: {}, output: 'check' },
+      { id: 'then-step', type: 'action', config: {} },
+      { id: 'else-step', type: 'action', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].stepId).toBe('check');
+    expect(result.steps[1].stepId).toBe('else-step');
+  });
+
+  it('should fail with CONDITION_TARGET_NOT_FOUND for nonexistent target', async () => {
+    registry.register(createConditionCommand(true, 'nonexistent'));
+    registry.register(createMockCommand({ type: 'action' }));
+
+    const definition = simpleWorkflow([
+      { id: 'check', type: 'condition', config: {} },
+      { id: 'action', type: 'action', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].code).toBe('CONDITION_TARGET_NOT_FOUND');
+    expect(result.errors[0].message).toContain('nonexistent');
+    // Remaining steps should be skipped
+    expect(result.steps[1].status).toBe('skipped');
+  });
+
+  it('should handle chained conditions (condition → condition → action)', async () => {
+    // First condition jumps to second condition, second jumps to final action
+    const condA = createMockCommand({
+      type: 'cond-a',
+      execute: async () => ({
+        success: true,
+        data: { result: true, branch: 'then', nextStep: 'cond-b' },
+        duration: 1,
+      }),
+    });
+    const condB = createMockCommand({
+      type: 'cond-b',
+      execute: async () => ({
+        success: true,
+        data: { result: false, branch: 'else', nextStep: 'final' },
+        duration: 1,
+      }),
+    });
+    const action = createMockCommand({
+      type: 'action',
+      execute: async () => ({
+        success: true,
+        data: { done: true },
+        duration: 1,
+      }),
+    });
+
+    registry.register(condA);
+    registry.register(condB);
+    registry.register(action);
+
+    const definition = simpleWorkflow([
+      { id: 'cond-a', type: 'cond-a', config: {}, output: 'cond-a' },
+      { id: 'skipped-1', type: 'action', config: {} },
+      { id: 'cond-b', type: 'cond-b', config: {}, output: 'cond-b' },
+      { id: 'skipped-2', type: 'action', config: {} },
+      { id: 'final', type: 'action', config: {}, output: 'final' },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(3);
+    expect(result.steps[0].stepId).toBe('cond-a');
+    expect(result.steps[1].stepId).toBe('cond-b');
+    expect(result.steps[2].stepId).toBe('final');
+  });
+
+  it('should preserve variable context across jumps', async () => {
+    let capturedVars: Record<string, unknown> = {};
+
+    registry.register(createMockCommand({
+      type: 'setup',
+      execute: async () => ({
+        success: true,
+        data: { value: 'preserved' },
+        duration: 1,
+      }),
+    }));
+    registry.register(createConditionCommand(true, 'consumer'));
+    registry.register(createMockCommand({
+      type: 'consumer',
+      execute: async (_config, ctx) => {
+        capturedVars = { ...ctx.variables };
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 'setup', type: 'setup', config: {}, output: 'setup' },
+      { id: 'check', type: 'condition', config: {}, output: 'check' },
+      { id: 'skipped', type: 'consumer', config: {} },
+      { id: 'consumer', type: 'consumer', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    // Variables from setup step should be available in the jumped-to consumer step
+    const setupData = capturedVars['setup'] as Record<string, unknown>;
+    expect(setupData?.value).toBe('preserved');
+  });
+
+  it('should continue sequentially when nextStep is null', async () => {
+    // Condition returns null nextStep — should proceed to next step normally
+    registry.register(createConditionCommand(true, null));
+    registry.register(createMockCommand({ type: 'action' }));
+
+    const definition = simpleWorkflow([
+      { id: 'check', type: 'condition', config: {}, output: 'check' },
+      { id: 'next', type: 'action', config: {} },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].stepId).toBe('check');
+    expect(result.steps[1].stepId).toBe('next');
+  });
+});

--- a/src/packages/workflows/__tests__/runner.test.ts
+++ b/src/packages/workflows/__tests__/runner.test.ts
@@ -886,3 +886,195 @@ describe('WorkflowRunner — condition branching', () => {
     expect(result.steps[1].stepId).toBe('next');
   });
 });
+
+// ============================================================================
+// Loop Iteration (Story #137)
+// ============================================================================
+
+describe('WorkflowRunner — loop iteration', () => {
+  function createLoopCommand(items: unknown[], opts?: { maxIterations?: number; itemVar?: string; indexVar?: string }): StepCommand {
+    return createMockCommand({
+      type: 'loop',
+      execute: async () => {
+        const max = opts?.maxIterations ?? 100;
+        const actual = Math.min(items.length, max);
+        return {
+          success: true,
+          data: {
+            totalItems: items.length,
+            iterations: actual,
+            truncated: items.length > max,
+            itemVar: opts?.itemVar ?? 'item',
+            indexVar: opts?.indexVar ?? 'index',
+            items: items.slice(0, actual),
+          },
+          duration: 1,
+        };
+      },
+    });
+  }
+
+  it('should iterate over 3 items executing 2 nested steps each', async () => {
+    const execLog: string[] = [];
+
+    registry.register(createLoopCommand(['a', 'b', 'c']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        execLog.push(`${ctx.variables['item']}-${ctx.variables['index']}`);
+        return { success: true, data: { processed: ctx.variables['item'] }, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [
+          { id: 'nested-a', type: 'nested', config: {}, output: 'nested-a' },
+          { id: 'nested-b', type: 'nested', config: {}, output: 'nested-b' },
+        ],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(execLog).toEqual(['a-0', 'a-0', 'b-1', 'b-1', 'c-2', 'c-2']);
+    const loopData = result.outputs['loop1'] as Record<string, unknown>;
+    expect(loopData.iterationOutputs).toBeDefined();
+    const iterOutputs = loopData.iterationOutputs as Array<Record<string, unknown>>;
+    expect(iterOutputs).toHaveLength(3);
+  });
+
+  it('should respect maxIterations and stop early', async () => {
+    const execLog: string[] = [];
+
+    registry.register(createLoopCommand(['a', 'b', 'c', 'd', 'e'], { maxIterations: 2 }));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        execLog.push(String(ctx.variables['item']));
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    expect(execLog).toEqual(['a', 'b']);
+  });
+
+  it('should continue to next iteration with continueOnError', async () => {
+    const execLog: string[] = [];
+
+    registry.register(createLoopCommand(['a', 'b', 'c']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        const item = ctx.variables['item'] as string;
+        execLog.push(item);
+        if (item === 'b') {
+          return { success: false, data: {}, error: 'b failed', duration: 1 };
+        }
+        return { success: true, data: { processed: item }, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        continueOnError: true,
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    // continueOnError on loop step means failed iterations are skipped
+    expect(result.success).toBe(false); // errors were recorded
+    expect(execLog).toEqual(['a', 'b', 'c']);
+    expect(result.errors.some(e => e.message.includes('iteration 1'))).toBe(true);
+  });
+
+  it('should stop loop on nested failure without continueOnError', async () => {
+    const execLog: string[] = [];
+
+    registry.register(createLoopCommand(['a', 'b', 'c']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        const item = ctx.variables['item'] as string;
+        execLog.push(item);
+        if (item === 'b') {
+          return { success: false, data: {}, error: 'b failed', duration: 1 };
+        }
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {},
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(false);
+    expect(execLog).toEqual(['a', 'b']); // stopped at 'b'
+  });
+
+  it('should make loop variables accessible in nested step configs via interpolation', async () => {
+    let capturedVars: Record<string, unknown> = {};
+
+    registry.register(createLoopCommand(['hello', 'world']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => {
+        capturedVars = { item: ctx.variables['item'], index: ctx.variables['index'] };
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    // Last iteration should have these values
+    expect(capturedVars.item).toBe('world');
+    expect(capturedVars.index).toBe(1);
+  });
+
+  it('should complete with no iterations for empty items array', async () => {
+    registry.register(createLoopCommand([]));
+    registry.register(createMockCommand({ type: 'nested' }));
+
+    const definition = simpleWorkflow([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const result = await runner.run(definition, {});
+
+    expect(result.success).toBe(true);
+    const loopData = result.outputs['loop1'] as Record<string, unknown>;
+    const iterOutputs = loopData.iterationOutputs as unknown[];
+    expect(iterOutputs).toHaveLength(0);
+  });
+});

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -207,7 +207,7 @@ export class WorkflowRunner {
     options: RunnerOptions,
     startTime: number,
   ): Promise<WorkflowResult> {
-    const variables: Record<string, unknown> = {};
+    const variables: Record<string, unknown> = { ...options.initialVariables };
     const stepResults: StepResult[] = [];
     const errors: WorkflowError[] = [];
     const completedSteps: Array<{ step: StepDefinition; config: Record<string, unknown> }> = [];

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -249,7 +249,6 @@ export class WorkflowRunner {
       }
 
       const step = definition.steps[i];
-      // TODO(#137): loop iteration — execute step.steps for each item in loop output
       const result = await this.executeStep(step, state, i);
 
       stepResults.push(result);
@@ -260,6 +259,23 @@ export class WorkflowRunner {
         }
         variables[step.id] = result.output.data;
         completedSteps.push({ step, config: result.interpolatedConfig ?? {} });
+
+        // Loop iteration: execute nested steps for each item
+        if (step.type === 'loop' && step.steps && step.steps.length > 0) {
+          const loopResult = await this.executeLoopIterations(step, result.output, state, errors);
+          // Store accumulated iteration outputs under the loop step
+          const loopData = { ...result.output.data, iterationOutputs: loopResult.outputs };
+          if (step.output) {
+            variables[step.output] = loopData;
+          }
+          variables[step.id] = loopData;
+
+          if (!loopResult.success && !step.continueOnError) {
+            await this.rollbackSteps(completedSteps, state, stepResults);
+            this.markRemainingSteps(definition, i + 1, 'skipped', stepResults);
+            break;
+          }
+        }
 
         // Condition branching: jump to the target step if nextStep is set
         const nextStep = result.output.data?.nextStep;
@@ -317,7 +333,8 @@ export class WorkflowRunner {
     const outputs: Record<string, unknown> = {};
     for (const sr of stepResults) {
       if (sr.status === 'succeeded' && sr.output) {
-        outputs[sr.stepId] = sr.output.data;
+        // Prefer enriched variable data (e.g. loop steps add iterationOutputs)
+        outputs[sr.stepId] = variables[sr.stepId] ?? sr.output.data;
       }
     }
 
@@ -443,6 +460,81 @@ export class WorkflowRunner {
       duration: Date.now() - stepStart,
       interpolatedConfig,
     };
+  }
+
+  // --------------------------------------------------------------------------
+  // Private — Loop Iteration
+  // --------------------------------------------------------------------------
+
+  private async executeLoopIterations(
+    loopStep: StepDefinition,
+    loopOutput: StepOutput,
+    state: ExecutionState,
+    errors: WorkflowError[],
+  ): Promise<{ success: boolean; outputs: Array<Record<string, unknown>> }> {
+    const data = loopOutput.data as Record<string, unknown>;
+    const items = data.items as unknown[];
+    const itemVar = (data.itemVar as string) || 'item';
+    const indexVar = (data.indexVar as string) || 'index';
+    const nestedSteps = loopStep.steps!;
+    const iterationOutputs: Array<Record<string, unknown>> = [];
+    let allSucceeded = true;
+
+    // Save pre-existing variables that loop vars might shadow
+    const hadItem = itemVar in state.variables;
+    const prevItem = state.variables[itemVar];
+    const hadIndex = indexVar in state.variables;
+    const prevIndex = state.variables[indexVar];
+
+    for (let idx = 0; idx < items.length; idx++) {
+      if (state.options.signal?.aborted) break;
+
+      state.variables[itemVar] = items[idx];
+      state.variables[indexVar] = idx;
+
+      const iterOutput: Record<string, unknown> = {};
+      let iterFailed = false;
+
+      for (let s = 0; s < nestedSteps.length; s++) {
+        if (state.options.signal?.aborted) break;
+
+        const nested = nestedSteps[s];
+        const result = await this.executeStep(nested, state, s);
+
+        if (result.status === 'succeeded' && result.output) {
+          if (nested.output) {
+            state.variables[nested.output] = result.output.data;
+          }
+          state.variables[nested.id] = result.output.data;
+          iterOutput[nested.id] = result.output.data;
+        }
+
+        if (result.status === 'failed') {
+          errors.push({
+            stepId: nested.id,
+            code: result.errorCode ?? 'STEP_EXECUTION_FAILED',
+            message: `Loop "${loopStep.id}" iteration ${idx}, step "${nested.id}": ${result.error ?? 'failed'}`,
+          });
+          iterFailed = true;
+          allSucceeded = false;
+          break;
+        }
+      }
+
+      iterationOutputs.push(iterOutput);
+
+      if (iterFailed && !loopStep.continueOnError) {
+        break;
+      }
+    }
+
+    // Restore previous values or clean up loop variables
+    if (hadItem) state.variables[itemVar] = prevItem;
+    else delete state.variables[itemVar];
+    if (hadIndex) state.variables[indexVar] = prevIndex;
+    else delete state.variables[indexVar];
+
+    return { success: allSucceeded, outputs: iterationOutputs };
   }
 
   // --------------------------------------------------------------------------

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -222,7 +222,26 @@ export class WorkflowRunner {
 
     await this.storeProgress(workflowId, 'running', 0, definition.steps.length);
 
+    // Build step-ID → index map for O(1) condition branching lookups
+    const stepIndex = new Map<string, number>();
+    for (let idx = 0; idx < definition.steps.length; idx++) {
+      stepIndex.set(definition.steps[idx].id, idx);
+    }
+
+    // Guard against infinite loops from backward condition jumps
+    const maxIterations = definition.steps.length * 10;
+    let iterations = 0;
+
     for (let i = 0; i < definition.steps.length; i++) {
+      if (++iterations > maxIterations) {
+        errors.push({
+          code: 'STEP_EXECUTION_FAILED',
+          message: `Workflow exceeded maximum iterations (${maxIterations}); possible infinite condition loop`,
+        });
+        this.markRemainingSteps(definition, i, 'skipped', stepResults);
+        break;
+      }
+
       if (options.signal?.aborted) {
         cancelled = true;
         this.markRemainingSteps(definition, i, 'cancelled', stepResults);
@@ -230,7 +249,6 @@ export class WorkflowRunner {
       }
 
       const step = definition.steps[i];
-      // TODO(#136): condition branching — inspect result.output.data.nextStep to jump
       // TODO(#137): loop iteration — execute step.steps for each item in loop output
       const result = await this.executeStep(step, state, i);
 
@@ -241,8 +259,25 @@ export class WorkflowRunner {
           variables[step.output] = result.output.data;
         }
         variables[step.id] = result.output.data;
-        // Stash the config that was actually executed (returned from executeStep)
         completedSteps.push({ step, config: result.interpolatedConfig ?? {} });
+
+        // Condition branching: jump to the target step if nextStep is set
+        const nextStep = result.output.data?.nextStep;
+        if (typeof nextStep === 'string' && nextStep.length > 0) {
+          const targetIdx = stepIndex.get(nextStep);
+          if (targetIdx === undefined) {
+            errors.push({
+              stepId: step.id,
+              code: 'CONDITION_TARGET_NOT_FOUND',
+              message: `Condition step "${step.id}" targets step "${nextStep}" which does not exist`,
+            });
+            await this.rollbackSteps(completedSteps, state, stepResults);
+            this.markRemainingSteps(definition, i + 1, 'skipped', stepResults);
+            break;
+          }
+          // Jump: set i so the next loop increment lands on targetIdx
+          i = targetIdx - 1;
+        }
       }
 
       if (result.status === 'cancelled') {
@@ -265,7 +300,7 @@ export class WorkflowRunner {
         }
       }
 
-      await this.storeProgress(workflowId, 'running', i + 1, definition.steps.length);
+      await this.storeProgress(workflowId, 'running', stepResults.length, definition.steps.length);
       try { options.onStepComplete?.(result, i, definition.steps.length); } catch { /* callback errors must not crash the workflow */ }
     }
 

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -230,8 +230,8 @@ export class WorkflowRunner {
       }
 
       const step = definition.steps[i];
-      // TODO(Epic #200): condition branching — inspect result.output.data.nextStep to jump
-      // TODO(Epic #200): loop iteration — execute step.steps for each item in loop output
+      // TODO(#136): condition branching — inspect result.output.data.nextStep to jump
+      // TODO(#137): loop iteration — execute step.steps for each item in loop output
       const result = await this.executeStep(step, state, i);
 
       stepResults.push(result);

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -1,0 +1,586 @@
+/**
+ * Workflow Runner
+ *
+ * Sequential executor that drives a parsed WorkflowDefinition step by step.
+ */
+
+import type {
+  WorkflowContext,
+  StepOutput,
+  CredentialAccessor,
+  MemoryAccessor,
+  ValidationError,
+} from '../types/step-command.types.js';
+import type {
+  WorkflowDefinition,
+  StepDefinition,
+} from '../types/workflow-definition.types.js';
+import type {
+  RunnerOptions,
+  WorkflowResult,
+  WorkflowError,
+  StepResult,
+  StepStatus,
+  DryRunResult,
+  DryRunStepReport,
+} from '../types/runner.types.js';
+import { StepCommandRegistry } from './step-command-registry.js';
+import { interpolateConfig } from './interpolation.js';
+import { validateWorkflowDefinition, resolveArguments } from '../schema/validator.js';
+
+const DEFAULT_STEP_TIMEOUT = 300_000; // 5 minutes
+
+interface ExecutionState {
+  readonly variables: Record<string, unknown>;
+  readonly resolvedArgs: Record<string, unknown>;
+  readonly workflowId: string;
+  readonly options: RunnerOptions;
+  readonly credentialPatterns: RegExp[];
+}
+
+export class WorkflowRunner {
+  constructor(
+    private readonly registry: StepCommandRegistry,
+    private readonly credentials: CredentialAccessor,
+    private readonly memory: MemoryAccessor,
+  ) {}
+
+  /**
+   * Execute a workflow definition with the given arguments.
+   */
+  async run(
+    definition: WorkflowDefinition,
+    args: Record<string, unknown>,
+    options: RunnerOptions = {},
+  ): Promise<WorkflowResult> {
+    const startTime = Date.now();
+
+    const defValidation = validateWorkflowDefinition(definition, {
+      knownStepTypes: this.registry.types(),
+    });
+    const workflowId = options.workflowId ?? `wf-${Date.now()}`;
+
+    if (!defValidation.valid) {
+      return this.failureResult(workflowId, startTime, [{
+        code: 'DEFINITION_VALIDATION_FAILED',
+        message: 'Workflow definition is invalid',
+        details: defValidation.errors,
+      }]);
+    }
+
+    const { resolved: resolvedArgs, errors: argErrors } = resolveArguments(
+      definition.arguments ?? {},
+      args,
+    );
+    if (argErrors.length > 0) {
+      return this.failureResult(workflowId, startTime, [{
+        code: 'ARGUMENT_VALIDATION_FAILED',
+        message: 'Argument validation failed',
+        details: argErrors,
+      }]);
+    }
+
+    if (options.dryRun) {
+      const dryResult = await this.dryRunValidated(definition, resolvedArgs, defValidation, options);
+      return {
+        workflowId,
+        success: dryResult.valid,
+        steps: [],
+        outputs: {},
+        errors: dryResult.valid ? [] : [{
+          code: 'DEFINITION_VALIDATION_FAILED',
+          message: 'Dry-run validation failed',
+          details: [
+            ...dryResult.argumentErrors,
+            ...dryResult.definitionErrors,
+            ...dryResult.steps.flatMap(s => s.validationResult.errors),
+          ],
+        }],
+        duration: Date.now() - startTime,
+        cancelled: false,
+      };
+    }
+
+    return this.executeSteps(definition, resolvedArgs, workflowId, options, startTime);
+  }
+
+  /**
+   * Validate a workflow without executing it.
+   * Reports what WOULD happen at each step.
+   */
+  async dryRun(
+    definition: WorkflowDefinition,
+    resolvedArgs: Record<string, unknown>,
+    options: RunnerOptions = {},
+  ): Promise<DryRunResult> {
+    const defValidation = validateWorkflowDefinition(definition, {
+      knownStepTypes: this.registry.types(),
+    });
+    return this.dryRunValidated(definition, resolvedArgs, defValidation, options);
+  }
+
+  private async dryRunValidated(
+    definition: WorkflowDefinition,
+    resolvedArgs: Record<string, unknown>,
+    defValidation: { valid: boolean; errors: ValidationError[] },
+    options: RunnerOptions,
+  ): Promise<DryRunResult> {
+    const argErrors: ValidationError[] = [];
+    if (definition.arguments) {
+      const { errors } = resolveArguments(definition.arguments, resolvedArgs);
+      argErrors.push(...errors);
+    }
+
+    const workflowId = `dryrun-${Date.now()}`;
+    const variables: Record<string, unknown> = {};
+    const stepReports: DryRunStepReport[] = [];
+
+    for (let i = 0; i < definition.steps.length; i++) {
+      const step = definition.steps[i];
+      const command = this.registry.get(step.type);
+
+      let interpolatedConfig: Record<string, unknown> | null = null;
+      let validationResult = { valid: true, errors: [] as ValidationError[] };
+
+      if (command) {
+        const context = this.buildContext(variables, resolvedArgs, workflowId, i, options.signal);
+        try {
+          interpolatedConfig = interpolateConfig(
+            step.config as Record<string, unknown>,
+            context,
+          );
+        } catch {
+          interpolatedConfig = null;
+          validationResult = {
+            valid: false,
+            errors: [{ path: `steps[${i}].config`, message: 'Variable interpolation failed' }],
+          };
+        }
+
+        if (interpolatedConfig) {
+          const vr = await command.validate(interpolatedConfig, context);
+          validationResult = { valid: vr.valid, errors: [...vr.errors] };
+        }
+
+        if (step.output) {
+          variables[step.output] = { _dryRun: true };
+        }
+      } else {
+        validationResult = {
+          valid: false,
+          errors: [{ path: `steps[${i}].type`, message: `Unknown step type: "${step.type}"` }],
+        };
+      }
+
+      stepReports.push({
+        stepId: step.id,
+        stepType: step.type,
+        description: command?.description ?? 'unknown command',
+        interpolatedConfig,
+        validationResult,
+        continueOnError: step.continueOnError ?? false,
+        hasRollback: command?.rollback !== undefined,
+      });
+    }
+
+    const allValid =
+      defValidation.valid &&
+      argErrors.length === 0 &&
+      stepReports.every(s => s.validationResult.valid);
+
+    return {
+      valid: allValid,
+      argumentErrors: argErrors,
+      definitionErrors: defValidation.errors,
+      steps: stepReports,
+    };
+  }
+
+  // --------------------------------------------------------------------------
+  // Private — Execution
+  // --------------------------------------------------------------------------
+
+  private async executeSteps(
+    definition: WorkflowDefinition,
+    resolvedArgs: Record<string, unknown>,
+    workflowId: string,
+    options: RunnerOptions,
+    startTime: number,
+  ): Promise<WorkflowResult> {
+    const variables: Record<string, unknown> = {};
+    const stepResults: StepResult[] = [];
+    const errors: WorkflowError[] = [];
+    const completedSteps: Array<{ step: StepDefinition; config: Record<string, unknown> }> = [];
+    let cancelled = false;
+
+    // Pre-compile credential patterns once for the entire run
+    const credentialPatterns = (options.credentialValues ?? []).map(
+      v => new RegExp(v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+    );
+
+    const state: ExecutionState = { variables, resolvedArgs, workflowId, options, credentialPatterns };
+
+    await this.storeProgress(workflowId, 'running', 0, definition.steps.length);
+
+    for (let i = 0; i < definition.steps.length; i++) {
+      if (options.signal?.aborted) {
+        cancelled = true;
+        this.markRemainingSteps(definition, i, 'cancelled', stepResults);
+        break;
+      }
+
+      const step = definition.steps[i];
+      // TODO(Epic #200): condition branching — inspect result.output.data.nextStep to jump
+      // TODO(Epic #200): loop iteration — execute step.steps for each item in loop output
+      const result = await this.executeStep(step, state, i);
+
+      stepResults.push(result);
+
+      if (result.status === 'succeeded' && result.output) {
+        if (step.output) {
+          variables[step.output] = result.output.data;
+        }
+        variables[step.id] = result.output.data;
+        // Stash the config that was actually executed (returned from executeStep)
+        completedSteps.push({ step, config: result.interpolatedConfig ?? {} });
+      }
+
+      if (result.status === 'cancelled') {
+        cancelled = true;
+        this.markRemainingSteps(definition, i + 1, 'cancelled', stepResults);
+        break;
+      }
+
+      if (result.status === 'failed') {
+        errors.push({
+          stepId: step.id,
+          code: result.errorCode ?? 'STEP_EXECUTION_FAILED',
+          message: result.error ?? 'Step failed',
+        });
+
+        if (!step.continueOnError) {
+          await this.rollbackSteps(completedSteps, state, stepResults);
+          this.markRemainingSteps(definition, i + 1, 'skipped', stepResults);
+          break;
+        }
+      }
+
+      await this.storeProgress(workflowId, 'running', i + 1, definition.steps.length);
+      try { options.onStepComplete?.(result, i, definition.steps.length); } catch { /* callback errors must not crash the workflow */ }
+    }
+
+    if (cancelled) {
+      if (completedSteps.length > 0) {
+        await this.rollbackSteps(completedSteps, state, stepResults);
+      }
+      errors.push({ code: 'WORKFLOW_CANCELLED', message: 'Workflow was cancelled' });
+    }
+
+    const finalStatus = cancelled ? 'cancelled' : errors.length > 0 ? 'failed' : 'completed';
+    await this.storeProgress(workflowId, finalStatus, stepResults.length, definition.steps.length);
+
+    const outputs: Record<string, unknown> = {};
+    for (const sr of stepResults) {
+      if (sr.status === 'succeeded' && sr.output) {
+        outputs[sr.stepId] = sr.output.data;
+      }
+    }
+
+    return {
+      workflowId,
+      success: errors.length === 0 && !cancelled,
+      steps: stepResults,
+      outputs,
+      errors,
+      duration: Date.now() - startTime,
+      cancelled,
+    };
+  }
+
+  private async executeStep(
+    step: StepDefinition,
+    state: ExecutionState,
+    index: number,
+  ): Promise<StepResult & { interpolatedConfig?: Record<string, unknown> }> {
+    const stepStart = Date.now();
+    const command = this.registry.get(step.type);
+
+    if (!command) {
+      return {
+        stepId: step.id,
+        stepType: step.type,
+        status: 'failed',
+        error: `Unknown step type: "${step.type}"`,
+        errorCode: 'UNKNOWN_STEP_TYPE',
+        duration: Date.now() - stepStart,
+      };
+    }
+
+    const context = this.buildContext(
+      state.variables, state.resolvedArgs, state.workflowId, index, state.options.signal,
+    );
+
+    let interpolatedConfig: Record<string, unknown>;
+    try {
+      interpolatedConfig = interpolateConfig(
+        step.config as Record<string, unknown>,
+        context,
+      );
+    } catch (err) {
+      return {
+        stepId: step.id,
+        stepType: step.type,
+        status: 'failed',
+        error: `Variable interpolation failed: ${err instanceof Error ? err.message : String(err)}`,
+        errorCode: 'STEP_EXECUTION_FAILED',
+        duration: Date.now() - stepStart,
+      };
+    }
+
+    const validation = await command.validate(interpolatedConfig, context);
+    if (!validation.valid) {
+      return {
+        stepId: step.id,
+        stepType: step.type,
+        status: 'failed',
+        error: `Step validation failed: ${validation.errors.map(e => e.message).join('; ')}`,
+        errorCode: 'STEP_VALIDATION_FAILED',
+        duration: Date.now() - stepStart,
+      };
+    }
+
+    const timeout = state.options.defaultStepTimeout ?? DEFAULT_STEP_TIMEOUT;
+    let output: StepOutput;
+
+    try {
+      output = await this.executeWithTimeout(
+        () => command.execute(interpolatedConfig, context),
+        timeout,
+        state.options.signal,
+      );
+    } catch (err) {
+      const isCancelled = state.options.signal?.aborted;
+      const isTimeout = err instanceof Error && err.message === 'Step timed out';
+
+      return {
+        stepId: step.id,
+        stepType: step.type,
+        status: isCancelled ? 'cancelled' : 'failed',
+        error: err instanceof Error ? err.message : String(err),
+        errorCode: isCancelled ? 'STEP_CANCELLED' : isTimeout ? 'STEP_TIMEOUT' : 'STEP_EXECUTION_FAILED',
+        duration: Date.now() - stepStart,
+      };
+    }
+
+    const maskedOutput = this.maskCredentials(output, state.credentialPatterns);
+
+    if (!maskedOutput.success) {
+      let rollbackAttempted = false;
+      let rollbackError: string | undefined;
+
+      if (command.rollback) {
+        rollbackAttempted = true;
+        try {
+          await command.rollback(interpolatedConfig, context);
+        } catch (rbErr) {
+          rollbackError = rbErr instanceof Error ? rbErr.message : String(rbErr);
+        }
+      }
+
+      return {
+        stepId: step.id,
+        stepType: step.type,
+        status: 'failed',
+        output: maskedOutput,
+        error: maskedOutput.error ?? 'Step execution returned failure',
+        errorCode: 'STEP_EXECUTION_FAILED',
+        duration: Date.now() - stepStart,
+        rollbackAttempted,
+        rollbackError,
+      };
+    }
+
+    return {
+      stepId: step.id,
+      stepType: step.type,
+      status: 'succeeded',
+      output: maskedOutput,
+      duration: Date.now() - stepStart,
+      interpolatedConfig,
+    };
+  }
+
+  // --------------------------------------------------------------------------
+  // Private — Rollback
+  // --------------------------------------------------------------------------
+
+  private async rollbackSteps(
+    completedSteps: Array<{ step: StepDefinition; config: Record<string, unknown> }>,
+    state: ExecutionState,
+    stepResults: StepResult[],
+  ): Promise<void> {
+    for (let i = completedSteps.length - 1; i >= 0; i--) {
+      const { step, config } = completedSteps[i];
+      const command = this.registry.get(step.type);
+
+      if (!command?.rollback) continue;
+
+      const context = this.buildContext(
+        state.variables, state.resolvedArgs, state.workflowId, i, state.options.signal,
+      );
+      try {
+        await command.rollback(config, context);
+        const idx = stepResults.findIndex(r => r.stepId === step.id);
+        if (idx !== -1) {
+          stepResults[idx] = { ...stepResults[idx], status: 'rolled_back', rollbackAttempted: true };
+        }
+      } catch (err) {
+        const idx = stepResults.findIndex(r => r.stepId === step.id);
+        if (idx !== -1) {
+          stepResults[idx] = {
+            ...stepResults[idx],
+            rollbackAttempted: true,
+            rollbackError: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Private — Helpers
+  // --------------------------------------------------------------------------
+
+  private markRemainingSteps(
+    definition: WorkflowDefinition,
+    fromIndex: number,
+    status: StepStatus,
+    stepResults: StepResult[],
+  ): void {
+    for (let j = fromIndex; j < definition.steps.length; j++) {
+      stepResults.push({
+        stepId: definition.steps[j].id,
+        stepType: definition.steps[j].type,
+        status,
+        duration: 0,
+      });
+    }
+  }
+
+  private buildContext(
+    variables: Record<string, unknown>,
+    args: Record<string, unknown>,
+    workflowId: string,
+    stepIndex: number,
+    signal?: AbortSignal,
+  ): WorkflowContext {
+    return {
+      variables,
+      args,
+      credentials: this.credentials,
+      memory: this.memory,
+      taskId: `${workflowId}-step-${stepIndex}`,
+      workflowId,
+      stepIndex,
+      abortSignal: signal,
+    };
+  }
+
+  private executeWithTimeout<T>(
+    fn: () => Promise<T>,
+    timeout: number,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      let settled = false;
+
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', onAbort);
+      };
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          signal?.removeEventListener('abort', onAbort);
+          reject(new Error('Step timed out'));
+        }
+      }, timeout);
+
+      const onAbort = (): void => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          reject(new Error('Step cancelled'));
+        }
+      };
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+
+      fn().then(
+        (result) => {
+          if (!settled) {
+            settled = true;
+            cleanup();
+            resolve(result);
+          }
+        },
+        (err) => {
+          if (!settled) {
+            settled = true;
+            cleanup();
+            reject(err);
+          }
+        },
+      );
+    });
+  }
+
+  private maskCredentials(output: StepOutput, patterns: RegExp[]): StepOutput {
+    if (patterns.length === 0) return output;
+
+    const serialized = JSON.stringify(output.data);
+    let masked = serialized;
+    for (const pattern of patterns) {
+      pattern.lastIndex = 0;
+      masked = masked.replace(pattern, '***REDACTED***');
+    }
+
+    if (masked === serialized) return output;
+
+    return {
+      ...output,
+      data: JSON.parse(masked) as Record<string, unknown>,
+    };
+  }
+
+  private async storeProgress(
+    workflowId: string,
+    status: string,
+    completedSteps: number,
+    totalSteps: number,
+  ): Promise<void> {
+    try {
+      await this.memory.write('tasklist', workflowId, {
+        status,
+        completedSteps,
+        totalSteps,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch {
+      // Best-effort — don't fail the workflow for progress tracking
+    }
+  }
+
+  private failureResult(workflowId: string, startTime: number, errors: WorkflowError[]): WorkflowResult {
+    return {
+      workflowId,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors,
+      duration: Date.now() - startTime,
+      cancelled: false,
+    };
+  }
+}

--- a/src/packages/workflows/src/factory/pause-resume.ts
+++ b/src/packages/workflows/src/factory/pause-resume.ts
@@ -1,0 +1,191 @@
+/**
+ * Workflow Pause/Resume
+ *
+ * Serializes workflow execution state to memory for cross-conversation
+ * survival, and reconstructs it for resumption.
+ */
+
+import type { MemoryAccessor } from '../types/step-command.types.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.types.js';
+import type { WorkflowResult, StepResult } from '../types/runner.types.js';
+import { createRunner, noopMemory } from './runner-factory.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PausedState {
+  readonly workflowId: string;
+  readonly definitionName: string;
+  /** Serialized workflow definition (JSON). */
+  readonly definition: string;
+  /** Index of the next step to execute (0-based). */
+  readonly nextStepIndex: number;
+  /** Variable context at pause time. */
+  readonly variables: Record<string, unknown>;
+  /** Results of steps completed before pause. */
+  readonly completedStepResults: StepResult[];
+  /** Arguments originally passed to the workflow. */
+  readonly args: Record<string, unknown>;
+  /** ISO timestamp of when the workflow was paused. */
+  readonly pausedAt: string;
+  /** Configurable timeout (ms) after which paused state is considered stale. */
+  readonly staleAfterMs: number;
+}
+
+export interface ResumeOptions {
+  /** Override variables before resuming (e.g. user edits between pause/resume). */
+  readonly variables?: Record<string, unknown>;
+  /** Memory accessor for reading paused state and storing progress. */
+  readonly memory?: MemoryAccessor;
+}
+
+const PAUSE_NAMESPACE = 'workflow-paused';
+const DEFAULT_STALE_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours
+
+// ============================================================================
+// Pause
+// ============================================================================
+
+/**
+ * Persist paused workflow state to memory.
+ */
+export async function persistPausedState(
+  state: PausedState,
+  memory: MemoryAccessor,
+): Promise<void> {
+  await memory.write(PAUSE_NAMESPACE, state.workflowId, state);
+}
+
+/**
+ * Create a PausedState from execution context.
+ */
+export function buildPausedState(
+  workflowId: string,
+  definition: WorkflowDefinition,
+  nextStepIndex: number,
+  variables: Record<string, unknown>,
+  completedStepResults: StepResult[],
+  args: Record<string, unknown>,
+  staleAfterMs: number = DEFAULT_STALE_TIMEOUT,
+): PausedState {
+  return {
+    workflowId,
+    definitionName: definition.name,
+    definition: JSON.stringify(definition),
+    nextStepIndex,
+    variables: structuredClone(variables),
+    completedStepResults: structuredClone(completedStepResults),
+    args: structuredClone(args),
+    pausedAt: new Date().toISOString(),
+    staleAfterMs,
+  };
+}
+
+// ============================================================================
+// Resume
+// ============================================================================
+
+/**
+ * Load paused state from memory and resume execution.
+ */
+export async function resumeWorkflow(
+  workflowId: string,
+  options: ResumeOptions = {},
+): Promise<WorkflowResult> {
+  const memory = options.memory ?? noopMemory;
+  const raw = await memory.read(PAUSE_NAMESPACE, workflowId);
+
+  if (!raw) {
+    return {
+      workflowId,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'PAUSED_STATE_NOT_FOUND', message: `No paused state found for workflow "${workflowId}"` }],
+      duration: 0,
+      cancelled: false,
+    };
+  }
+
+  const state = raw as PausedState;
+
+  // Check staleness
+  const pausedTime = new Date(state.pausedAt).getTime();
+  if (Date.now() - pausedTime > state.staleAfterMs) {
+    await memory.write(PAUSE_NAMESPACE, workflowId, null);
+    return {
+      workflowId,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'PAUSED_STATE_EXPIRED', message: `Paused state for "${workflowId}" has expired (stale after ${state.staleAfterMs}ms)` }],
+      duration: 0,
+      cancelled: false,
+    };
+  }
+
+  // Reconstruct definition
+  const definition: WorkflowDefinition = JSON.parse(state.definition);
+
+  // Merge user-provided variable overrides
+  const variables = { ...state.variables, ...options.variables };
+
+  // Create runner and execute remaining steps
+  const runner = createRunner({ memory });
+  const remainingDefinition: WorkflowDefinition = {
+    ...definition,
+    steps: definition.steps.slice(state.nextStepIndex),
+  };
+
+  const startTime = Date.now();
+  const result = await runner.run(remainingDefinition, state.args, { workflowId, initialVariables: variables });
+
+  // Clean up paused state on completion
+  await memory.write(PAUSE_NAMESPACE, workflowId, null);
+
+  // Merge completed step results from before pause with resume results
+  const allSteps = [...state.completedStepResults, ...result.steps];
+  const allOutputs: Record<string, unknown> = {};
+  for (const sr of allSteps) {
+    if (sr.status === 'succeeded' && sr.output) {
+      allOutputs[sr.stepId] = sr.output.data;
+    }
+  }
+
+  return {
+    workflowId,
+    success: result.success,
+    steps: allSteps,
+    outputs: { ...allOutputs, ...result.outputs },
+    errors: result.errors,
+    duration: Date.now() - startTime,
+    cancelled: result.cancelled,
+  };
+}
+
+// ============================================================================
+// Cleanup
+// ============================================================================
+
+/**
+ * Remove stale paused workflows. Returns number of cleaned entries.
+ */
+export async function cleanupStalePaused(memory: MemoryAccessor): Promise<number> {
+  const results = await memory.search(PAUSE_NAMESPACE, '');
+  let cleaned = 0;
+
+  for (const entry of results) {
+    const state = entry.value as PausedState | undefined;
+    if (state?.pausedAt && state?.staleAfterMs) {
+      const pausedTime = new Date(state.pausedAt).getTime();
+      if (Date.now() - pausedTime > state.staleAfterMs) {
+        await memory.write(PAUSE_NAMESPACE, state.workflowId, null);
+        cleaned++;
+      }
+    }
+  }
+
+  return cleaned;
+}
+

--- a/src/packages/workflows/src/factory/runner-bridge.ts
+++ b/src/packages/workflows/src/factory/runner-bridge.ts
@@ -1,0 +1,96 @@
+/**
+ * Runner Bridge
+ *
+ * Provides a high-level, context-free API for MCP tool integration.
+ * Each function is self-contained — no setup required. The bridge
+ * creates runners on demand with built-in commands.
+ *
+ * This module is the integration point between MCP workflow tools
+ * and the WorkflowRunner engine.
+ */
+
+import type { WorkflowResult } from '../types/runner.types.js';
+import type { MemoryAccessor } from '../types/step-command.types.js';
+import { createRunner, runWorkflowFromContent } from './runner-factory.js';
+
+// Track active workflows for cancellation
+const activeWorkflows = new Map<string, AbortController>();
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Run a workflow from raw file content (YAML/JSON).
+ */
+export async function bridgeRunWorkflow(
+  content: string,
+  sourceFile: string | undefined,
+  args: Record<string, unknown>,
+  options: { dryRun?: boolean; memory?: MemoryAccessor } = {},
+): Promise<WorkflowResult> {
+  const workflowId = `wf-${Date.now()}`;
+  const controller = new AbortController();
+  activeWorkflows.set(workflowId, controller);
+
+  try {
+    const result = await runWorkflowFromContent(content, sourceFile, {
+      workflowId,
+      args,
+      dryRun: options.dryRun,
+      signal: controller.signal,
+      memory: options.memory,
+    });
+    return result;
+  } finally {
+    activeWorkflows.delete(workflowId);
+  }
+}
+
+/**
+ * Run a WorkflowDefinition directly (for workflow_execute).
+ */
+export async function bridgeExecuteWorkflow(
+  definition: import('../types/workflow-definition.types.js').WorkflowDefinition,
+  args: Record<string, unknown>,
+  options: { workflowId?: string; memory?: MemoryAccessor } = {},
+): Promise<WorkflowResult> {
+  const workflowId = options.workflowId ?? `wf-${Date.now()}`;
+  const controller = new AbortController();
+  activeWorkflows.set(workflowId, controller);
+
+  try {
+    const runner = createRunner({ memory: options.memory });
+    return await runner.run(definition, args, {
+      workflowId,
+      signal: controller.signal,
+    });
+  } finally {
+    activeWorkflows.delete(workflowId);
+  }
+}
+
+/**
+ * Cancel a running workflow by ID.
+ */
+export function bridgeCancelWorkflow(workflowId: string): boolean {
+  const controller = activeWorkflows.get(workflowId);
+  if (!controller) return false;
+  controller.abort();
+  activeWorkflows.delete(workflowId);
+  return true;
+}
+
+/**
+ * Check if a workflow is currently running.
+ */
+export function bridgeIsRunning(workflowId: string): boolean {
+  return activeWorkflows.has(workflowId);
+}
+
+/**
+ * Get IDs of all currently running workflows.
+ */
+export function bridgeActiveWorkflows(): string[] {
+  return [...activeWorkflows.keys()];
+}

--- a/src/packages/workflows/src/factory/runner-factory.ts
+++ b/src/packages/workflows/src/factory/runner-factory.ts
@@ -1,0 +1,107 @@
+/**
+ * Runner Factory
+ *
+ * Creates a fully configured WorkflowRunner with the built-in command registry,
+ * credentials, and memory accessors. Provides a high-level API for MCP tool
+ * integration and CLI usage.
+ */
+
+import type { CredentialAccessor, MemoryAccessor } from '../types/step-command.types.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.types.js';
+import type { RunnerOptions, WorkflowResult } from '../types/runner.types.js';
+import { StepCommandRegistry } from '../core/step-command-registry.js';
+import { WorkflowRunner } from '../core/runner.js';
+import { builtinCommands } from '../commands/index.js';
+import { parseWorkflow } from '../schema/parser.js';
+import { validateWorkflowDefinition } from '../schema/validator.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RunnerFactoryOptions {
+  readonly credentials?: CredentialAccessor;
+  readonly memory?: MemoryAccessor;
+}
+
+export interface RunWorkflowOptions extends RunnerOptions {
+  /** Arguments to pass to the workflow. */
+  readonly args?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Create a WorkflowRunner with built-in commands registered.
+ */
+export function createRunner(options: RunnerFactoryOptions = {}): WorkflowRunner {
+  const registry = new StepCommandRegistry();
+  for (const cmd of builtinCommands) {
+    registry.register(cmd);
+  }
+
+  const credentials = options.credentials ?? noopCredentials;
+  const memory = options.memory ?? noopMemory;
+
+  return new WorkflowRunner(registry, credentials, memory);
+}
+
+/**
+ * Parse, validate, and run a workflow from raw YAML/JSON content.
+ * Returns a structured result — never throws.
+ */
+export async function runWorkflowFromContent(
+  content: string,
+  sourceFile: string | undefined,
+  options: RunWorkflowOptions & RunnerFactoryOptions = {},
+): Promise<WorkflowResult> {
+  let definition: WorkflowDefinition;
+  try {
+    const parsed = parseWorkflow(content, sourceFile);
+    definition = parsed.definition;
+  } catch (err) {
+    return {
+      workflowId: options.workflowId ?? `wf-${Date.now()}`,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'DEFINITION_VALIDATION_FAILED', message: `Parse error: ${err instanceof Error ? err.message : String(err)}` }],
+      duration: 0,
+      cancelled: false,
+    };
+  }
+
+  const validation = validateWorkflowDefinition(definition);
+  if (!validation.valid) {
+    return {
+      workflowId: options.workflowId ?? `wf-${Date.now()}`,
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'DEFINITION_VALIDATION_FAILED', message: validation.errors.map(e => e.message).join('; ') }],
+      duration: 0,
+      cancelled: false,
+    };
+  }
+
+  const runner = createRunner(options);
+  const { args = {}, ...runnerOptions } = options;
+  return runner.run(definition, args, runnerOptions);
+}
+
+// ============================================================================
+// Noop Accessors (for standalone usage without full CLI context)
+// ============================================================================
+
+const noopCredentials: CredentialAccessor = {
+  async get() { return undefined; },
+  async has() { return false; },
+};
+
+const noopMemory: MemoryAccessor = {
+  async read() { return null; },
+  async write() { /* noop */ },
+  async search() { return []; },
+};

--- a/src/packages/workflows/src/factory/runner-factory.ts
+++ b/src/packages/workflows/src/factory/runner-factory.ts
@@ -100,7 +100,7 @@ const noopCredentials: CredentialAccessor = {
   async has() { return false; },
 };
 
-const noopMemory: MemoryAccessor = {
+export const noopMemory: MemoryAccessor = {
   async read() { return null; },
   async write() { /* noop */ },
   async search() { return []; },

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -76,3 +76,16 @@ export type {
 
 export { parseYaml, parseJson, parseWorkflow } from './schema/parser.js';
 export { validateWorkflowDefinition, resolveArguments, type ValidatorOptions } from './schema/validator.js';
+
+// ============================================================================
+// Definition Loader (shipped + user override)
+// ============================================================================
+
+export {
+  loadWorkflowDefinitions,
+  loadWorkflowByName,
+  type LoaderOptions,
+  type LoadedWorkflow,
+  type LoadResult,
+  type LoadError,
+} from './loaders/definition-loader.js';

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -108,3 +108,16 @@ export {
   bridgeIsRunning,
   bridgeActiveWorkflows,
 } from './factory/runner-bridge.js';
+
+// ============================================================================
+// Pause/Resume
+// ============================================================================
+
+export {
+  buildPausedState,
+  persistPausedState,
+  resumeWorkflow,
+  cleanupStalePaused,
+  type PausedState,
+  type ResumeOptions,
+} from './factory/pause-resume.js';

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -27,12 +27,24 @@ export type {
   MemoryAccessor,
 } from './types/step-command.types.js';
 
+export type {
+  RunnerOptions,
+  WorkflowResult,
+  WorkflowError,
+  WorkflowErrorCode,
+  StepResult,
+  StepStatus,
+  DryRunResult,
+  DryRunStepReport,
+} from './types/runner.types.js';
+
 // ============================================================================
 // Core
 // ============================================================================
 
 export { StepCommandRegistry } from './core/step-command-registry.js';
 export { interpolateString, interpolateConfig } from './core/interpolation.js';
+export { WorkflowRunner } from './core/runner.js';
 
 // ============================================================================
 // Built-in Commands

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -89,3 +89,22 @@ export {
   type LoadResult,
   type LoadError,
 } from './loaders/definition-loader.js';
+
+// ============================================================================
+// Runner Factory (MCP + CLI integration)
+// ============================================================================
+
+export {
+  createRunner,
+  runWorkflowFromContent,
+  type RunnerFactoryOptions,
+  type RunWorkflowOptions,
+} from './factory/runner-factory.js';
+
+export {
+  bridgeRunWorkflow,
+  bridgeExecuteWorkflow,
+  bridgeCancelWorkflow,
+  bridgeIsRunning,
+  bridgeActiveWorkflows,
+} from './factory/runner-bridge.js';

--- a/src/packages/workflows/src/loaders/definition-loader.ts
+++ b/src/packages/workflows/src/loaders/definition-loader.ts
@@ -1,0 +1,143 @@
+/**
+ * Workflow Definition Loader
+ *
+ * Two-tier definition system:
+ *   Tier 1 — Shipped definitions bundled with moflo (read-only defaults)
+ *   Tier 2 — User definitions at configurable project path (override by name)
+ *
+ * Resolution: load shipped first, then user. User definitions with the same
+ * name replace shipped ones; new names are additive.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { parseWorkflow } from '../schema/parser.js';
+import { validateWorkflowDefinition } from '../schema/validator.js';
+import type { WorkflowDefinition, ParsedWorkflow } from '../types/workflow-definition.types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LoaderOptions {
+  /** Shipped definitions directory (absolute path). */
+  readonly shippedDir?: string;
+  /** User definition directories (absolute paths), searched in order. */
+  readonly userDirs?: readonly string[];
+  /** Step types known to the registry (passed to validator). */
+  readonly knownStepTypes?: readonly string[];
+  /** If true, skip validation (useful for testing). */
+  readonly skipValidation?: boolean;
+}
+
+export interface LoadedWorkflow {
+  readonly definition: WorkflowDefinition;
+  readonly sourceFile: string;
+  readonly tier: 'shipped' | 'user';
+}
+
+export interface LoadResult {
+  readonly workflows: Map<string, LoadedWorkflow>;
+  readonly errors: readonly LoadError[];
+}
+
+export interface LoadError {
+  readonly file: string;
+  readonly message: string;
+}
+
+// ============================================================================
+// Loader
+// ============================================================================
+
+const WORKFLOW_EXTENSIONS = new Set(['.yaml', '.yml', '.json']);
+
+/**
+ * Load workflow definitions from shipped + user directories.
+ * User definitions override shipped ones by workflow name match.
+ */
+export function loadWorkflowDefinitions(options: LoaderOptions = {}): LoadResult {
+  const workflows = new Map<string, LoadedWorkflow>();
+  const errors: LoadError[] = [];
+
+  // Tier 1: Shipped definitions (lowest priority)
+  if (options.shippedDir) {
+    loadFromDirectory(options.shippedDir, 'shipped', workflows, errors, options);
+  }
+
+  // Tier 2: User definitions (override shipped by name)
+  if (options.userDirs) {
+    for (const dir of options.userDirs) {
+      loadFromDirectory(dir, 'user', workflows, errors, options);
+    }
+  }
+
+  return { workflows, errors };
+}
+
+/**
+ * Load a single workflow definition by name from the merged registry.
+ */
+export function loadWorkflowByName(
+  name: string,
+  options: LoaderOptions = {},
+): LoadedWorkflow | undefined {
+  const { workflows } = loadWorkflowDefinitions(options);
+  return workflows.get(name);
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+function loadFromDirectory(
+  dir: string,
+  tier: 'shipped' | 'user',
+  workflows: Map<string, LoadedWorkflow>,
+  errors: LoadError[],
+  options: LoaderOptions,
+): void {
+  if (!existsSync(dir)) return;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  const files = entries.filter(f => WORKFLOW_EXTENSIONS.has(extname(f).toLowerCase()));
+
+  for (const file of files) {
+    const filePath = join(dir, file);
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      const parsed = parseWorkflow(content, filePath);
+
+      if (!options.skipValidation) {
+        const validation = validateWorkflowDefinition(parsed.definition, {
+          knownStepTypes: options.knownStepTypes as string[],
+        });
+        if (!validation.valid) {
+          errors.push({
+            file: filePath,
+            message: validation.errors.map(e => e.message).join('; '),
+          });
+          continue;
+        }
+      }
+
+      const key = parsed.definition.name;
+      workflows.set(key, {
+        definition: parsed.definition,
+        sourceFile: filePath,
+        tier,
+      });
+    } catch (err) {
+      errors.push({
+        file: filePath,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/src/packages/workflows/src/types/runner.types.ts
+++ b/src/packages/workflows/src/types/runner.types.ts
@@ -1,0 +1,108 @@
+/**
+ * Workflow Runner Types
+ *
+ * Types for the sequential workflow executor.
+ */
+
+import type { StepOutput, ValidationError } from './step-command.types.js';
+
+// ============================================================================
+// Error Codes
+// ============================================================================
+
+export type WorkflowErrorCode =
+  | 'ARGUMENT_VALIDATION_FAILED'
+  | 'DEFINITION_VALIDATION_FAILED'
+  | 'STEP_VALIDATION_FAILED'
+  | 'STEP_EXECUTION_FAILED'
+  | 'STEP_TIMEOUT'
+  | 'STEP_CANCELLED'
+  | 'UNKNOWN_STEP_TYPE'
+  | 'ROLLBACK_FAILED'
+  | 'WORKFLOW_CANCELLED';
+
+// ============================================================================
+// Step Result
+// ============================================================================
+
+export type StepStatus = 'succeeded' | 'failed' | 'skipped' | 'rolled_back' | 'cancelled';
+
+export interface StepResult {
+  readonly stepId: string;
+  readonly stepType: string;
+  readonly status: StepStatus;
+  readonly output?: StepOutput;
+  readonly error?: string;
+  readonly errorCode?: WorkflowErrorCode;
+  readonly duration: number;
+  readonly rollbackAttempted?: boolean;
+  readonly rollbackError?: string;
+  /** The interpolated config that was actually executed (for rollback). */
+  readonly interpolatedConfig?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Workflow Result
+// ============================================================================
+
+export interface WorkflowResult {
+  readonly workflowId: string;
+  readonly success: boolean;
+  readonly steps: StepResult[];
+  readonly outputs: Record<string, unknown>;
+  readonly errors: WorkflowError[];
+  readonly duration: number;
+  readonly cancelled: boolean;
+}
+
+export interface WorkflowError {
+  readonly stepId?: string;
+  readonly code: WorkflowErrorCode;
+  readonly message: string;
+  readonly details?: ValidationError[];
+}
+
+// ============================================================================
+// Dry-Run Result
+// ============================================================================
+
+export interface DryRunStepReport {
+  readonly stepId: string;
+  readonly stepType: string;
+  readonly description: string;
+  readonly interpolatedConfig: Record<string, unknown> | null;
+  readonly validationResult: { valid: boolean; errors: ValidationError[] };
+  readonly continueOnError: boolean;
+  readonly hasRollback: boolean;
+}
+
+export interface DryRunResult {
+  readonly valid: boolean;
+  readonly argumentErrors: ValidationError[];
+  readonly definitionErrors: ValidationError[];
+  readonly steps: DryRunStepReport[];
+}
+
+// ============================================================================
+// Runner Options
+// ============================================================================
+
+export interface RunnerOptions {
+  /** Caller-specified workflow ID for status correlation. Auto-generated if omitted. */
+  readonly workflowId?: string;
+
+  /** Default timeout per step in milliseconds (default: 300000 — 5 min). */
+  readonly defaultStepTimeout?: number;
+
+  /** Dry-run mode: validate without executing (default: false). */
+  readonly dryRun?: boolean;
+
+  /** AbortSignal for cancellation. */
+  readonly signal?: AbortSignal;
+
+  /** Progress callback invoked after each step completes. */
+  readonly onStepComplete?: (result: StepResult, index: number, total: number) => void;
+
+  /** Literal credential values to redact from step output (matched as exact strings). */
+  readonly credentialValues?: readonly string[];
+}

--- a/src/packages/workflows/src/types/runner.types.ts
+++ b/src/packages/workflows/src/types/runner.types.ts
@@ -12,6 +12,7 @@ import type { StepOutput, ValidationError } from './step-command.types.js';
 
 export type WorkflowErrorCode =
   | 'ARGUMENT_VALIDATION_FAILED'
+  | 'CONDITION_TARGET_NOT_FOUND'
   | 'DEFINITION_VALIDATION_FAILED'
   | 'STEP_VALIDATION_FAILED'
   | 'STEP_EXECUTION_FAILED'

--- a/src/packages/workflows/src/types/runner.types.ts
+++ b/src/packages/workflows/src/types/runner.types.ts
@@ -20,6 +20,8 @@ export type WorkflowErrorCode =
   | 'STEP_CANCELLED'
   | 'UNKNOWN_STEP_TYPE'
   | 'ROLLBACK_FAILED'
+  | 'PAUSED_STATE_NOT_FOUND'
+  | 'PAUSED_STATE_EXPIRED'
   | 'WORKFLOW_CANCELLED';
 
 // ============================================================================
@@ -106,4 +108,7 @@ export interface RunnerOptions {
 
   /** Literal credential values to redact from step output (matched as exact strings). */
   readonly credentialValues?: readonly string[];
+
+  /** Pre-seeded variables for resuming from a paused workflow. */
+  readonly initialVariables?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Completes Epic #142 — Workflow Engine Completion. Builds on PR #135 (WorkflowRunner foundation).

**Stories delivered:**
- **#136** Condition branching — `nextStep` jump protocol with step-ID→index Map, max-iteration guard
- **#137** Loop iteration — nested step execution per item, variable save/restore for shadowed vars
- **#138** Definition layering — two-tier shipped + user override loader (.yaml/.yml/.json)
- **#139** MCP integration — runner factory + bridge with AbortController tracking
- **#140** Pause/resume — serialized state persistence to memory, staleness detection, variable overrides
- **#141** Documentation — shipped guidance for Claude + human-facing docs/WORKFLOWS.md

**Key additions:**
- 14 files changed, ~2,600 lines added
- 2 new error codes: `PAUSED_STATE_NOT_FOUND`, `PAUSED_STATE_EXPIRED`
- `initialVariables` on RunnerOptions for resume support
- `noopMemory` exported from runner-factory (deduplicated)

## Test plan
- [x] 184 workflow tests pass (8 test files)
- [x] Tests cover: condition branching (6), loop iteration (6), definition loader (12), runner bridge (8), pause/resume (7)
- [x] /simplify code review run on each story
- [x] All pre-existing tests unaffected

Closes #136, #137, #138, #139, #140, #141, #142

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)