### PR TITLE
feat(workflows): workflow registry + /flo -wf integration

### DIFF
--- a/.claude/skills/fl/SKILL.md
+++ b/.claude/skills/fl/SKILL.md
@@ -23,6 +23,15 @@ Research, create tickets for, and execute GitHub issues automatically.
 
 Also available as `/fl` (shorthand alias).
 
+### Workflow Engine Mode (-wf)
+
+```
+/flo -wf sa ./src            # Run security-audit workflow with target=./src
+/flo -wf security-audit ./src  # Same, using full name
+/flo -wf list                # List available workflows
+/flo -wf info sa             # Show workflow details, arguments, steps
+```
+
 ### Execution Mode (how work is done)
 
 ```
@@ -58,6 +67,10 @@ Also available as `/fl` (shorthand alias).
 ### Combined Examples
 
 ```
+/flo -wf sa ./src                     # Run security-audit workflow (abbreviation)
+/flo -wf security-audit ./src         # Run security-audit workflow (full name)
+/flo -wf list                         # List available workflows
+/flo -wf info sa                      # Show workflow details + arguments
 /flo 123                              # Normal + full workflow (default) - includes ALL tests
 /flo 42                               # If #42 is epic, processes stories sequentially
 /flo -s 123                           # Swarm + full workflow (multi-agent coordination)
@@ -454,16 +467,59 @@ function extractStories(epicBody) {
 
 ```javascript
 const args = "$ARGUMENTS".trim().split(/\s+/);
-let workflowMode = "full";    // full, ticket, research
+let workflowMode = "full";    // full, ticket, research, workflow
 let execMode = "normal";      // normal (default), swarm, hive
 let issueNumber = null;
 let titleWords = [];
 
+// Workflow engine (-wf) state
+let wfName = null;             // workflow name or abbreviation
+let wfSubcommand = null;       // "list" or "info"
+let wfArgs = [];               // positional args after workflow name
+let wfNamedArgs = {};          // --key=value or --key value args
+
 for (let i = 0; i < args.length; i++) {
   const arg = args[i];
 
+  // Workflow engine mode
+  if (arg === "-wf" || arg === "--workflow") {
+    workflowMode = "workflow";
+    // Next arg is the workflow name or subcommand
+    if (i + 1 < args.length) {
+      const next = args[++i];
+      if (next === "list") {
+        wfSubcommand = "list";
+      } else if (next === "info") {
+        wfSubcommand = "info";
+        // Next arg after "info" is the query
+        if (i + 1 < args.length) {
+          wfName = args[++i];
+        }
+      } else {
+        wfName = next;
+      }
+    }
+    // Collect remaining args as workflow arguments
+    for (let j = i + 1; j < args.length; j++) {
+      const wa = args[j];
+      if (wa.startsWith("--")) {
+        const eqIdx = wa.indexOf("=");
+        if (eqIdx !== -1) {
+          wfNamedArgs[wa.slice(2, eqIdx)] = wa.slice(eqIdx + 1);
+        } else if (j + 1 < args.length && !args[j + 1].startsWith("-")) {
+          wfNamedArgs[wa.slice(2)] = args[++j];
+        } else {
+          wfNamedArgs[wa.slice(2)] = "true";
+        }
+      } else {
+        wfArgs.push(wa);
+      }
+    }
+    break; // -wf consumes all remaining args
+  }
+
   // Workflow mode (what to do)
-  if (arg === "-t" || arg === "--ticket") {
+  else if (arg === "-t" || arg === "--ticket") {
     workflowMode = "ticket";
   } else if (arg === "-r" || arg === "--research") {
     workflowMode = "research";
@@ -487,22 +543,30 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
-// In ticket mode, a title can be given instead of an issue number
-let ticketTitle = titleWords.join(" ");
-if (!issueNumber && !ticketTitle) {
-  throw new Error("Issue number or title required. Usage: /flo <issue-number | title>");
-}
-if (!issueNumber && workflowMode !== "ticket") {
-  throw new Error("Issue number required for full/research mode. Use -t for new tickets.");
-}
+// Validation
+if (workflowMode === "workflow") {
+  if (!wfName && !wfSubcommand) {
+    throw new Error("Workflow name or subcommand required. Usage: /flo -wf <name|list|info> [args]");
+  }
+  console.log("WORKFLOW ENGINE MODE: " + (wfSubcommand || wfName));
+} else {
+  // In ticket mode, a title can be given instead of an issue number
+  let ticketTitle = titleWords.join(" ");
+  if (!issueNumber && !ticketTitle) {
+    throw new Error("Issue number or title required. Usage: /flo <issue-number | title>");
+  }
+  if (!issueNumber && workflowMode !== "ticket") {
+    throw new Error("Issue number required for full/research mode. Use -t for new tickets.");
+  }
 
-// Log execution mode to prevent silent skipping
-console.log("Execution mode: " + execMode.toUpperCase());
-if (execMode === "swarm") {
-  console.log("SWARM MODE: Will spawn agents via Task tool. Do NOT skip this.");
+  // Log execution mode to prevent silent skipping
+  console.log("Execution mode: " + execMode.toUpperCase());
+  if (execMode === "swarm") {
+    console.log("SWARM MODE: Will spawn agents via Task tool. Do NOT skip this.");
+  }
+  console.log("TESTING: Unit + Integration + E2E tests REQUIRED before PR.");
+  console.log("SIMPLIFY: /simplify command runs on changed code before PR.");
 }
-console.log("TESTING: Unit + Integration + E2E tests REQUIRED before PR.");
-console.log("SIMPLIFY: /simplify command runs on changed code before PR.");
 ```
 
 ## Execution Flow
@@ -515,6 +579,9 @@ console.log("SIMPLIFY: /simplify command runs on changed code before PR.");
 | **Epic** | `/flo 42` (epic) | For each story: Full workflow sequentially | All story PRs created |
 | **Ticket** | `/flo -t 123` | Research -> Ticket | Issue updated |
 | **Research** | `/flo -r 123` | Research | Findings output |
+| **Workflow** | `/flo -wf sa ./src` | Load registry -> Resolve workflow -> Execute with args | Workflow complete |
+| **WF List** | `/flo -wf list` | Load registry -> Print all workflows | List printed |
+| **WF Info** | `/flo -wf info sa` | Load registry -> Print workflow details | Info printed |
 
 ### Execution Modes (how to do it)
 
@@ -570,6 +637,52 @@ Single Claude execution without spawning sub-agents.
 - Still creates tasks for visibility
 - Post-task neural learning hooks still fire
 - Just doesn't spawn multiple agents
+
+### WORKFLOW ENGINE Mode (-wf, --workflow)
+
+When `-wf` is used, the /flo skill switches to the generalized workflow engine
+instead of the hardcoded coding workflow. This uses the `WorkflowRegistry` from
+`@claude-flow/workflows` to resolve and run YAML/JSON workflow definitions.
+
+**Scan directories** (in priority order):
+1. Shipped: `src/packages/workflows/definitions/` (bundled with moflo)
+2. User: `workflows/` and `.claude/workflows/` (project-level overrides)
+
+**Registry behavior:**
+- Each workflow file defines `name` and optional `abbreviation` in frontmatter
+- Registry builds lookup map: abbreviation -> file path, full name -> file path
+- Duplicate abbreviations produce a collision error on load
+- User definitions override shipped ones by name match
+
+**Subcommands:**
+
+`/flo -wf list` — List all available workflows:
+```
+Use WorkflowRegistry.list() to get all registered workflows.
+Print a table: name | abbreviation | description | tier (shipped/user)
+```
+
+`/flo -wf info <name|abbreviation>` — Show workflow details:
+```
+Use WorkflowRegistry.info(query) to get detailed info.
+Print: name, abbreviation, description, version, source file, arguments, step count, step types
+```
+
+`/flo -wf <name|abbreviation> [positional-args] [--named-args]` — Execute a workflow:
+```
+1. Use WorkflowRegistry.resolve(wfName) to find the workflow
+2. Map positional args to required arguments in order
+3. Parse named args: --key=value or --key value
+4. Use runWorkflowFromContent() or createRunner().run() to execute
+5. Print step-by-step progress and final result
+```
+
+**Argument mapping:**
+- Positional args mapped to required arguments in definition order
+- Named args: `--severity=critical` or `--severity critical`
+- Boolean flags: `--autofix` (true if present)
+- Example: `/flo -wf sa ./src --severity critical --autofix`
+  Maps to: `{ target: "./src", severity: "critical", autofix: "true" }`
 
 ---
 

--- a/.claude/skills/flo/SKILL.md
+++ b/.claude/skills/flo/SKILL.md
@@ -23,6 +23,15 @@ Research, create tickets for, and execute GitHub issues automatically.
 
 Also available as `/fl` (shorthand alias).
 
+### Workflow Engine Mode (-wf)
+
+```
+/flo -wf sa ./src            # Run security-audit workflow with target=./src
+/flo -wf security-audit ./src  # Same, using full name
+/flo -wf list                # List available workflows
+/flo -wf info sa             # Show workflow details, arguments, steps
+```
+
 ### Execution Mode (how work is done)
 
 ```
@@ -58,6 +67,10 @@ Also available as `/fl` (shorthand alias).
 ### Combined Examples
 
 ```
+/flo -wf sa ./src                     # Run security-audit workflow (abbreviation)
+/flo -wf security-audit ./src         # Run security-audit workflow (full name)
+/flo -wf list                         # List available workflows
+/flo -wf info sa                      # Show workflow details + arguments
 /flo 123                              # Normal + full workflow (default) - includes ALL tests
 /flo 42                               # If #42 is epic, processes stories sequentially
 /flo -s 123                           # Swarm + full workflow (multi-agent coordination)
@@ -454,16 +467,59 @@ function extractStories(epicBody) {
 
 ```javascript
 const args = "$ARGUMENTS".trim().split(/\s+/);
-let workflowMode = "full";    // full, ticket, research
+let workflowMode = "full";    // full, ticket, research, workflow
 let execMode = "normal";      // normal (default), swarm, hive
 let issueNumber = null;
 let titleWords = [];
 
+// Workflow engine (-wf) state
+let wfName = null;             // workflow name or abbreviation
+let wfSubcommand = null;       // "list" or "info"
+let wfArgs = [];               // positional args after workflow name
+let wfNamedArgs = {};          // --key=value or --key value args
+
 for (let i = 0; i < args.length; i++) {
   const arg = args[i];
 
+  // Workflow engine mode
+  if (arg === "-wf" || arg === "--workflow") {
+    workflowMode = "workflow";
+    // Next arg is the workflow name or subcommand
+    if (i + 1 < args.length) {
+      const next = args[++i];
+      if (next === "list") {
+        wfSubcommand = "list";
+      } else if (next === "info") {
+        wfSubcommand = "info";
+        // Next arg after "info" is the query
+        if (i + 1 < args.length) {
+          wfName = args[++i];
+        }
+      } else {
+        wfName = next;
+      }
+    }
+    // Collect remaining args as workflow arguments
+    for (let j = i + 1; j < args.length; j++) {
+      const wa = args[j];
+      if (wa.startsWith("--")) {
+        const eqIdx = wa.indexOf("=");
+        if (eqIdx !== -1) {
+          wfNamedArgs[wa.slice(2, eqIdx)] = wa.slice(eqIdx + 1);
+        } else if (j + 1 < args.length && !args[j + 1].startsWith("-")) {
+          wfNamedArgs[wa.slice(2)] = args[++j];
+        } else {
+          wfNamedArgs[wa.slice(2)] = "true";
+        }
+      } else {
+        wfArgs.push(wa);
+      }
+    }
+    break; // -wf consumes all remaining args
+  }
+
   // Workflow mode (what to do)
-  if (arg === "-t" || arg === "--ticket") {
+  else if (arg === "-t" || arg === "--ticket") {
     workflowMode = "ticket";
   } else if (arg === "-r" || arg === "--research") {
     workflowMode = "research";
@@ -487,22 +543,30 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
-// In ticket mode, a title can be given instead of an issue number
-let ticketTitle = titleWords.join(" ");
-if (!issueNumber && !ticketTitle) {
-  throw new Error("Issue number or title required. Usage: /flo <issue-number | title>");
-}
-if (!issueNumber && workflowMode !== "ticket") {
-  throw new Error("Issue number required for full/research mode. Use -t for new tickets.");
-}
+// Validation
+if (workflowMode === "workflow") {
+  if (!wfName && !wfSubcommand) {
+    throw new Error("Workflow name or subcommand required. Usage: /flo -wf <name|list|info> [args]");
+  }
+  console.log("WORKFLOW ENGINE MODE: " + (wfSubcommand || wfName));
+} else {
+  // In ticket mode, a title can be given instead of an issue number
+  let ticketTitle = titleWords.join(" ");
+  if (!issueNumber && !ticketTitle) {
+    throw new Error("Issue number or title required. Usage: /flo <issue-number | title>");
+  }
+  if (!issueNumber && workflowMode !== "ticket") {
+    throw new Error("Issue number required for full/research mode. Use -t for new tickets.");
+  }
 
-// Log execution mode to prevent silent skipping
-console.log("Execution mode: " + execMode.toUpperCase());
-if (execMode === "swarm") {
-  console.log("SWARM MODE: Will spawn agents via Task tool. Do NOT skip this.");
+  // Log execution mode to prevent silent skipping
+  console.log("Execution mode: " + execMode.toUpperCase());
+  if (execMode === "swarm") {
+    console.log("SWARM MODE: Will spawn agents via Task tool. Do NOT skip this.");
+  }
+  console.log("TESTING: Unit + Integration + E2E tests REQUIRED before PR.");
+  console.log("SIMPLIFY: /simplify command runs on changed code before PR.");
 }
-console.log("TESTING: Unit + Integration + E2E tests REQUIRED before PR.");
-console.log("SIMPLIFY: /simplify command runs on changed code before PR.");
 ```
 
 ## Execution Flow
@@ -515,6 +579,9 @@ console.log("SIMPLIFY: /simplify command runs on changed code before PR.");
 | **Epic** | `/flo 42` (epic) | For each story: Full workflow sequentially | All story PRs created |
 | **Ticket** | `/flo -t 123` | Research -> Ticket | Issue updated |
 | **Research** | `/flo -r 123` | Research | Findings output |
+| **Workflow** | `/flo -wf sa ./src` | Load registry -> Resolve workflow -> Execute with args | Workflow complete |
+| **WF List** | `/flo -wf list` | Load registry -> Print all workflows | List printed |
+| **WF Info** | `/flo -wf info sa` | Load registry -> Print workflow details | Info printed |
 
 ### Execution Modes (how to do it)
 
@@ -570,6 +637,52 @@ Single Claude execution without spawning sub-agents.
 - Still creates tasks for visibility
 - Post-task neural learning hooks still fire
 - Just doesn't spawn multiple agents
+
+### WORKFLOW ENGINE Mode (-wf, --workflow)
+
+When `-wf` is used, the /flo skill switches to the generalized workflow engine
+instead of the hardcoded coding workflow. This uses the `WorkflowRegistry` from
+`@claude-flow/workflows` to resolve and run YAML/JSON workflow definitions.
+
+**Scan directories** (in priority order):
+1. Shipped: `src/packages/workflows/definitions/` (bundled with moflo)
+2. User: `workflows/` and `.claude/workflows/` (project-level overrides)
+
+**Registry behavior:**
+- Each workflow file defines `name` and optional `abbreviation` in frontmatter
+- Registry builds lookup map: abbreviation -> file path, full name -> file path
+- Duplicate abbreviations produce a collision error on load
+- User definitions override shipped ones by name match
+
+**Subcommands:**
+
+`/flo -wf list` — List all available workflows:
+```
+Use WorkflowRegistry.list() to get all registered workflows.
+Print a table: name | abbreviation | description | tier (shipped/user)
+```
+
+`/flo -wf info <name|abbreviation>` — Show workflow details:
+```
+Use WorkflowRegistry.info(query) to get detailed info.
+Print: name, abbreviation, description, version, source file, arguments, step count, step types
+```
+
+`/flo -wf <name|abbreviation> [positional-args] [--named-args]` — Execute a workflow:
+```
+1. Use WorkflowRegistry.resolve(wfName) to find the workflow
+2. Map positional args to required arguments in order
+3. Parse named args: --key=value or --key value
+4. Use runWorkflowFromContent() or createRunner().run() to execute
+5. Print step-by-step progress and final result
+```
+
+**Argument mapping:**
+- Positional args mapped to required arguments in definition order
+- Named args: `--severity=critical` or `--severity critical`
+- Boolean flags: `--autofix` (true if present)
+- Example: `/flo -wf sa ./src --severity critical --autofix`
+  Maps to: `{ target: "./src", severity: "critical", autofix: "true" }`
 
 ---
 

--- a/src/packages/workflows/__tests__/workflow-registry.test.ts
+++ b/src/packages/workflows/__tests__/workflow-registry.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Workflow Registry Tests
+ *
+ * Story #105: Abbreviation lookup, collision detection, list/info.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { WorkflowRegistry } from '../src/registry/workflow-registry.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+let testDir: string;
+
+function makeDir(...segments: string[]): string {
+  const dir = join(testDir, ...segments);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeYaml(dir: string, filename: string, content: string): void {
+  writeFileSync(join(dir, filename), content, 'utf-8');
+}
+
+const SECURITY_AUDIT = `
+name: security-audit
+abbreviation: sa
+description: "Run a security audit"
+version: "1.0"
+arguments:
+  target:
+    type: string
+    required: true
+  severity:
+    type: string
+    default: "high"
+steps:
+  - id: scan
+    type: agent
+    config:
+      prompt: "Scan {args.target}"
+`;
+
+const DOC_GENERATION = `
+name: doc-generation
+abbreviation: dg
+description: "Generate documentation"
+steps:
+  - id: analyze
+    type: bash
+    config:
+      command: echo analyze
+  - id: write
+    type: bash
+    config:
+      command: echo write
+`;
+
+const LINT_CHECK = `
+name: lint-check
+description: "Run lint checks (no abbreviation)"
+steps:
+  - id: lint
+    type: bash
+    config:
+      command: npm run lint
+`;
+
+const COLLISION_1 = `
+name: workflow-a
+abbreviation: dup
+description: "Workflow A"
+steps:
+  - id: a
+    type: bash
+    config:
+      command: echo a
+`;
+
+const COLLISION_2 = `
+name: workflow-b
+abbreviation: dup
+description: "Workflow B"
+steps:
+  - id: b
+    type: bash
+    config:
+      command: echo b
+`;
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `wf-registry-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+// ============================================================================
+// Discovery + Registration
+// ============================================================================
+
+describe('WorkflowRegistry — discovery', () => {
+  it('should discover and register workflows from directories', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+    writeYaml(dir, 'doc-generation.yaml', DOC_GENERATION);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    const result = registry.load();
+
+    expect(result.workflows.size).toBe(2);
+    expect(result.errors).toHaveLength(0);
+    expect(result.collisions).toHaveLength(0);
+  });
+
+  it('should build abbreviation map from workflow frontmatter', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+    writeYaml(dir, 'doc-generation.yaml', DOC_GENERATION);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    const result = registry.load();
+
+    expect(result.abbreviations.size).toBe(2);
+    expect(result.abbreviations.get('sa')).toBe('security-audit');
+    expect(result.abbreviations.get('dg')).toBe('doc-generation');
+  });
+
+  it('should handle workflows without abbreviation', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'lint-check.yaml', LINT_CHECK);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    const result = registry.load();
+
+    expect(result.workflows.size).toBe(1);
+    expect(result.abbreviations.size).toBe(0);
+  });
+});
+
+// ============================================================================
+// Abbreviation lookup
+// ============================================================================
+
+describe('WorkflowRegistry — resolve', () => {
+  it('should resolve by full name', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    const result = registry.resolve('security-audit');
+    expect(result).toBeDefined();
+    expect(result!.definition.name).toBe('security-audit');
+  });
+
+  it('should resolve by abbreviation', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    const result = registry.resolve('sa');
+    expect(result).toBeDefined();
+    expect(result!.definition.name).toBe('security-audit');
+  });
+
+  it('should return undefined for unknown query', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    expect(registry.resolve('nonexistent')).toBeUndefined();
+  });
+
+  it('should auto-load on first resolve if not loaded', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    // No explicit load() call
+    const result = registry.resolve('sa');
+    expect(result).toBeDefined();
+    expect(result!.definition.name).toBe('security-audit');
+  });
+});
+
+// ============================================================================
+// Collision detection
+// ============================================================================
+
+describe('WorkflowRegistry — collision detection', () => {
+  it('should detect duplicate abbreviations', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'workflow-a.yaml', COLLISION_1);
+    writeYaml(dir, 'workflow-b.yaml', COLLISION_2);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    const result = registry.load();
+
+    expect(result.collisions).toHaveLength(1);
+    expect(result.collisions[0].abbreviation).toBe('dup');
+    expect(result.collisions[0].workflows).toContain('workflow-a');
+    expect(result.collisions[0].workflows).toContain('workflow-b');
+  });
+
+  it('should not include colliding abbreviations in abbreviation map', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'workflow-a.yaml', COLLISION_1);
+    writeYaml(dir, 'workflow-b.yaml', COLLISION_2);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    const result = registry.load();
+
+    expect(result.abbreviations.has('dup')).toBe(false);
+  });
+
+  it('should still allow full name resolution for colliding workflows', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'workflow-a.yaml', COLLISION_1);
+    writeYaml(dir, 'workflow-b.yaml', COLLISION_2);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    expect(registry.resolve('workflow-a')).toBeDefined();
+    expect(registry.resolve('workflow-b')).toBeDefined();
+    expect(registry.resolve('dup')).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// List
+// ============================================================================
+
+describe('WorkflowRegistry — list', () => {
+  it('should list all workflows sorted by name', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+    writeYaml(dir, 'doc-generation.yaml', DOC_GENERATION);
+    writeYaml(dir, 'lint-check.yaml', LINT_CHECK);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    const list = registry.list();
+    expect(list).toHaveLength(3);
+    expect(list[0].name).toBe('doc-generation');
+    expect(list[0].abbreviation).toBe('dg');
+    expect(list[1].name).toBe('lint-check');
+    expect(list[1].abbreviation).toBeUndefined();
+    expect(list[2].name).toBe('security-audit');
+    expect(list[2].abbreviation).toBe('sa');
+  });
+
+  it('should show tier for each workflow', () => {
+    const shippedDir = makeDir('shipped');
+    const userDir = makeDir('user');
+    writeYaml(shippedDir, 'sa.yaml', SECURITY_AUDIT);
+    writeYaml(userDir, 'dg.yaml', DOC_GENERATION);
+
+    const registry = new WorkflowRegistry({ shippedDir, userDirs: [userDir], skipValidation: true });
+    registry.load();
+
+    const list = registry.list();
+    const sa = list.find(e => e.name === 'security-audit');
+    const dg = list.find(e => e.name === 'doc-generation');
+    expect(sa!.tier).toBe('shipped');
+    expect(dg!.tier).toBe('user');
+  });
+});
+
+// ============================================================================
+// Info
+// ============================================================================
+
+describe('WorkflowRegistry — info', () => {
+  it('should return detailed info by name', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    const info = registry.info('security-audit');
+    expect(info).toBeDefined();
+    expect(info!.name).toBe('security-audit');
+    expect(info!.abbreviation).toBe('sa');
+    expect(info!.description).toBe('Run a security audit');
+    expect(info!.version).toBe('1.0');
+    expect(info!.stepCount).toBe(1);
+    expect(info!.stepTypes).toEqual(['agent']);
+    expect(info!.arguments).toHaveProperty('target');
+    expect(info!.arguments).toHaveProperty('severity');
+  });
+
+  it('should return detailed info by abbreviation', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'security-audit.yaml', SECURITY_AUDIT);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    const info = registry.info('sa');
+    expect(info).toBeDefined();
+    expect(info!.name).toBe('security-audit');
+  });
+
+  it('should return undefined for unknown query', () => {
+    const dir = makeDir('workflows');
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    expect(registry.info('unknown')).toBeUndefined();
+  });
+
+  it('should count nested steps', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'nested.yaml', `
+name: nested-workflow
+steps:
+  - id: loop1
+    type: loop
+    config: {}
+    steps:
+      - id: inner1
+        type: bash
+        config:
+          command: echo 1
+      - id: inner2
+        type: bash
+        config:
+          command: echo 2
+  - id: final
+    type: bash
+    config:
+      command: echo done
+`);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    const info = registry.info('nested-workflow');
+    expect(info!.stepCount).toBe(4); // loop1, inner1, inner2, final
+    expect(info!.stepTypes).toEqual(['bash', 'loop']);
+  });
+});
+
+// ============================================================================
+// Cache invalidation
+// ============================================================================
+
+describe('WorkflowRegistry — cache', () => {
+  it('should cache results after first load', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'sa.yaml', SECURITY_AUDIT);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    // Add a new file after loading
+    writeYaml(dir, 'dg.yaml', DOC_GENERATION);
+
+    // Should still show only 1 (cached)
+    expect(registry.list()).toHaveLength(1);
+  });
+
+  it('should reload after invalidate()', () => {
+    const dir = makeDir('workflows');
+    writeYaml(dir, 'sa.yaml', SECURITY_AUDIT);
+
+    const registry = new WorkflowRegistry({ userDirs: [dir], skipValidation: true });
+    registry.load();
+
+    writeYaml(dir, 'dg.yaml', DOC_GENERATION);
+    registry.invalidate();
+
+    expect(registry.list()).toHaveLength(2);
+  });
+});
+
+// ============================================================================
+// Extra directories (convenience alias)
+// ============================================================================
+
+describe('WorkflowRegistry — extraDirs', () => {
+  it('should scan extraDirs in addition to userDirs', () => {
+    const userDir = makeDir('user');
+    const extraDir = makeDir('extra');
+    writeYaml(userDir, 'sa.yaml', SECURITY_AUDIT);
+    writeYaml(extraDir, 'dg.yaml', DOC_GENERATION);
+
+    const registry = new WorkflowRegistry({
+      userDirs: [userDir],
+      extraDirs: [extraDir],
+      skipValidation: true,
+    });
+    const result = registry.load();
+
+    expect(result.workflows.size).toBe(2);
+  });
+});
+
+// ============================================================================
+// /flo regression: existing behavior unchanged
+// ============================================================================
+
+describe('WorkflowRegistry — does not affect existing /flo behavior', () => {
+  it('should work with empty directories', () => {
+    const registry = new WorkflowRegistry({
+      shippedDir: join(testDir, 'nonexistent'),
+      userDirs: [join(testDir, 'also-nonexistent')],
+      skipValidation: true,
+    });
+
+    const result = registry.load();
+    expect(result.workflows.size).toBe(0);
+    expect(result.abbreviations.size).toBe(0);
+    expect(result.collisions).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -121,3 +121,16 @@ export {
   type PausedState,
   type ResumeOptions,
 } from './factory/pause-resume.js';
+
+// ============================================================================
+// Workflow Registry (abbreviation lookup + list/info)
+// ============================================================================
+
+export {
+  WorkflowRegistry,
+  type RegistryOptions,
+  type RegistryResult,
+  type AbbreviationCollision,
+  type WorkflowInfo,
+  type WorkflowListEntry,
+} from './registry/workflow-registry.js';

--- a/src/packages/workflows/src/registry/workflow-registry.ts
+++ b/src/packages/workflows/src/registry/workflow-registry.ts
@@ -1,0 +1,195 @@
+/**
+ * Workflow Registry
+ *
+ * Maps workflow names AND abbreviations to loaded workflow definitions.
+ * Wraps the definition-loader with abbreviation-based lookup, collision
+ * detection, and list/info capabilities.
+ *
+ * Story #105: Workflow Registry + /flo -wf Integration
+ */
+
+import { loadWorkflowDefinitions } from '../loaders/definition-loader.js';
+import type { LoaderOptions, LoadedWorkflow, LoadError } from '../loaders/definition-loader.js';
+import type { WorkflowDefinition, ArgumentDefinition, StepDefinition } from '../types/workflow-definition.types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RegistryOptions extends LoaderOptions {
+  /** Additional directories to scan (convenience alias for userDirs). */
+  readonly extraDirs?: readonly string[];
+}
+
+export interface RegistryResult {
+  readonly workflows: ReadonlyMap<string, LoadedWorkflow>;
+  readonly abbreviations: ReadonlyMap<string, string>;
+  readonly collisions: readonly AbbreviationCollision[];
+  readonly errors: readonly LoadError[];
+}
+
+export interface AbbreviationCollision {
+  readonly abbreviation: string;
+  readonly workflows: readonly string[];
+}
+
+export interface WorkflowInfo {
+  readonly name: string;
+  readonly abbreviation?: string;
+  readonly description?: string;
+  readonly version?: string;
+  readonly sourceFile: string;
+  readonly tier: 'shipped' | 'user';
+  readonly arguments: Record<string, ArgumentDefinition>;
+  readonly stepCount: number;
+  readonly stepTypes: readonly string[];
+}
+
+export interface WorkflowListEntry {
+  readonly name: string;
+  readonly abbreviation?: string;
+  readonly description?: string;
+  readonly tier: 'shipped' | 'user';
+}
+
+// ============================================================================
+// Registry
+// ============================================================================
+
+export class WorkflowRegistry {
+  private readonly loaderOptions: LoaderOptions;
+  private cachedResult: RegistryResult | null = null;
+
+  constructor(options: RegistryOptions = {}) {
+    const userDirs = [
+      ...(options.userDirs ?? []),
+      ...(options.extraDirs ?? []),
+    ];
+    this.loaderOptions = {
+      shippedDir: options.shippedDir,
+      userDirs,
+      knownStepTypes: options.knownStepTypes,
+      skipValidation: options.skipValidation,
+    };
+  }
+
+  /**
+   * Load and index all workflow definitions.
+   * Builds the abbreviation map and detects collisions.
+   */
+  load(): RegistryResult {
+    const { workflows, errors } = loadWorkflowDefinitions(this.loaderOptions);
+    const abbreviations = new Map<string, string>();
+    const collisionMap = new Map<string, string[]>();
+
+    for (const [name, loaded] of workflows) {
+      const abbr = loaded.definition.abbreviation;
+      if (!abbr) continue;
+
+      if (collisionMap.has(abbr)) {
+        collisionMap.get(abbr)!.push(name);
+      } else if (abbreviations.has(abbr)) {
+        const existing = abbreviations.get(abbr)!;
+        collisionMap.set(abbr, [existing, name]);
+        abbreviations.delete(abbr);
+      } else {
+        abbreviations.set(abbr, name);
+      }
+    }
+
+    const collisions: AbbreviationCollision[] = [];
+    for (const [abbreviation, names] of collisionMap) {
+      collisions.push({ abbreviation, workflows: names });
+    }
+
+    this.cachedResult = { workflows, abbreviations, collisions, errors };
+    return this.cachedResult;
+  }
+
+  /**
+   * Resolve a query (abbreviation OR full name) to a loaded workflow.
+   * Returns undefined if no match is found.
+   */
+  resolve(query: string): LoadedWorkflow | undefined {
+    const result = this.cachedResult ?? this.load();
+
+    // Try full name first
+    const byName = result.workflows.get(query);
+    if (byName) return byName;
+
+    // Try abbreviation
+    const fullName = result.abbreviations.get(query);
+    if (fullName) return result.workflows.get(fullName);
+
+    return undefined;
+  }
+
+  /**
+   * List all registered workflows (name, abbreviation, description, tier).
+   */
+  list(): readonly WorkflowListEntry[] {
+    const result = this.cachedResult ?? this.load();
+    const entries: WorkflowListEntry[] = [];
+
+    for (const [, loaded] of result.workflows) {
+      entries.push({
+        name: loaded.definition.name,
+        abbreviation: loaded.definition.abbreviation,
+        description: loaded.definition.description,
+        tier: loaded.tier,
+      });
+    }
+
+    return entries.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
+   * Get detailed info about a specific workflow (by name or abbreviation).
+   */
+  info(query: string): WorkflowInfo | undefined {
+    const loaded = this.resolve(query);
+    if (!loaded) return undefined;
+
+    const def = loaded.definition;
+    const { count, types } = analyzeSteps(def.steps);
+
+    return {
+      name: def.name,
+      abbreviation: def.abbreviation,
+      description: def.description,
+      version: def.version,
+      sourceFile: loaded.sourceFile,
+      tier: loaded.tier,
+      arguments: def.arguments ?? {},
+      stepCount: count,
+      stepTypes: [...types].sort(),
+    };
+  }
+
+  /**
+   * Invalidate the cached load result, forcing a re-scan on next access.
+   */
+  invalidate(): void {
+    this.cachedResult = null;
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Single-pass step analysis: counts steps and collects unique types. */
+function analyzeSteps(
+  steps: readonly StepDefinition[],
+  types: Set<string> = new Set(),
+): { count: number; types: Set<string> } {
+  let count = 0;
+  for (const step of steps) {
+    count++;
+    types.add(step.type);
+    if (step.steps) {
+      count += analyzeSteps(step.steps, types).count;
+    }
+  }
+  return { count, types };
+}


### PR DESCRIPTION
## Summary
- Add `WorkflowRegistry` class that scans directories, maps abbreviations to workflow definitions, detects abbreviation collisions, and provides list/info capabilities
- Integrate with `/flo` skill via `-wf` flag: `list`, `info`, and workflow execution with positional + named argument parsing
- 20 new tests covering discovery, abbreviation lookup, collision detection, list, info, caching, and regression

## Changes
- **New:** `src/packages/workflows/src/registry/workflow-registry.ts` — Registry with resolve, list, info, cache invalidation
- **New:** `src/packages/workflows/__tests__/workflow-registry.test.ts` — 20 tests (all passing)
- **Modified:** `src/packages/workflows/src/index.ts` — Export registry types
- **Modified:** `.claude/skills/fl/SKILL.md` + `.claude/skills/flo/SKILL.md` — `-wf` flag parsing, docs, execution flow

## Testing
- [x] Unit tests pass (20/20 new + 184 existing = 204 total)
- [x] No regressions in workflow package
- [x] Build succeeds

Closes #105