### PR TITLE
feat(workflows): encrypted credential store (Story #106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ hive-mind-prompt-*.txt
 # Ephemeral / test artifacts
 .claude/workflow-state.json
 test-database-provider.rvf
+
+# Local guidance docs (generated, not tracked)
+.claude/guidance/

--- a/src/packages/workflows/__tests__/credential-store.test.ts
+++ b/src/packages/workflows/__tests__/credential-store.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Credential Store Tests
+ *
+ * Story #106: Encrypted Credential Storage
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { CredentialStore, CredentialStoreError } from '../src/credentials/credential-store.js';
+import { existsSync, unlinkSync, readFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function tempFilePath(): string {
+  const dir = join(tmpdir(), 'moflo-cred-tests');
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return join(dir, `creds-${randomBytes(8).toString('hex')}.json`);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('CredentialStore', () => {
+  let filePath: string;
+
+  beforeEach(() => {
+    filePath = tempFilePath();
+  });
+
+  afterEach(() => {
+    if (existsSync(filePath)) unlinkSync(filePath);
+  });
+
+  // --------------------------------------------------------------------------
+  // Store and retrieve
+  // --------------------------------------------------------------------------
+
+  it('stores and retrieves a credential', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store.store('api-key', 'sk-abc123');
+    const value = await store.get('api-key');
+    expect(value).toBe('sk-abc123');
+    store.lock();
+  });
+
+  it('returns undefined for non-existent credential', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    const value = await store.get('missing');
+    expect(value).toBeUndefined();
+    store.lock();
+  });
+
+  it('overwrites existing credential on re-store', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store.store('token', 'old-value');
+    await store.store('token', 'new-value');
+    expect(await store.get('token')).toBe('new-value');
+    store.lock();
+  });
+
+  // --------------------------------------------------------------------------
+  // Persistence across instances
+  // --------------------------------------------------------------------------
+
+  it('persists credentials across store instances', async () => {
+    const store1 = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store1.store('secret', 'persisted-value');
+    store1.lock();
+
+    const store2 = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    expect(await store2.get('secret')).toBe('persisted-value');
+    store2.lock();
+  });
+
+  // --------------------------------------------------------------------------
+  // Encryption verification
+  // --------------------------------------------------------------------------
+
+  it('stores values encrypted on disk (not plaintext)', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    const secret = 'super-secret-value-12345';
+    await store.store('key', secret);
+    store.lock();
+
+    const raw = readFileSync(filePath, 'utf-8');
+    expect(raw).not.toContain(secret);
+    // Should contain hex-encoded ciphertext
+    const data = JSON.parse(raw);
+    expect(data.credentials.key.ciphertext).toBeDefined();
+    expect(data.credentials.key.iv).toBeDefined();
+    expect(data.credentials.key.tag).toBeDefined();
+  });
+
+  // --------------------------------------------------------------------------
+  // Wrong passphrase
+  // --------------------------------------------------------------------------
+
+  it('throws on decryption with wrong passphrase', async () => {
+    const store1 = new CredentialStore({ filePath, passphrase: 'correct-pass' });
+    await store1.store('secret', 'value');
+    store1.lock();
+
+    const store2 = new CredentialStore({ filePath, passphrase: 'wrong-pass' });
+    await expect(store2.get('secret')).rejects.toThrow(CredentialStoreError);
+    await expect(store2.get('secret')).rejects.toThrow('Failed to decrypt credential');
+    store2.lock();
+  });
+
+  // --------------------------------------------------------------------------
+  // Lock / unlock
+  // --------------------------------------------------------------------------
+
+  it('throws when accessing locked store', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    store.lock();
+    await expect(store.get('any')).rejects.toThrow(CredentialStoreError);
+    await expect(store.get('any')).rejects.toThrow('store is locked');
+  });
+
+  it('creates store in locked mode when no passphrase provided', async () => {
+    const store = new CredentialStore({ filePath });
+    await expect(store.get('any')).rejects.toThrow('store is locked');
+  });
+
+  it('unlocks a previously locked store', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store.store('key', 'value');
+    store.lock();
+
+    store.unlock('test-pass');
+    expect(await store.get('key')).toBe('value');
+    store.lock();
+  });
+
+  // --------------------------------------------------------------------------
+  // has / exists / delete
+  // --------------------------------------------------------------------------
+
+  it('has() returns true for existing and false for missing', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store.store('present', 'val');
+    expect(await store.has('present')).toBe(true);
+    expect(await store.has('absent')).toBe(false);
+    store.lock();
+  });
+
+  it('delete() removes a credential and returns true', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store.store('key', 'val');
+    expect(await store.delete('key')).toBe(true);
+    expect(await store.has('key')).toBe(false);
+    expect(await store.get('key')).toBeUndefined();
+    store.lock();
+  });
+
+  it('delete() returns false for non-existent credential', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    expect(await store.delete('nope')).toBe(false);
+    store.lock();
+  });
+
+  // --------------------------------------------------------------------------
+  // list
+  // --------------------------------------------------------------------------
+
+  it('list() returns metadata without values', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store.store('api-key', 'secret1', 'API key for service');
+    await store.store('db-pass', 'secret2');
+
+    const list = await store.list();
+    expect(list).toHaveLength(2);
+
+    const apiKey = list.find(c => c.name === 'api-key');
+    expect(apiKey).toBeDefined();
+    expect(apiKey!.description).toBe('API key for service');
+    expect(apiKey!.createdAt).toBeDefined();
+    expect(apiKey!.updatedAt).toBeDefined();
+    // Ensure no value field leaks
+    expect((apiKey as Record<string, unknown>)['value']).toBeUndefined();
+
+    const dbPass = list.find(c => c.name === 'db-pass');
+    expect(dbPass).toBeDefined();
+    expect(dbPass!.description).toBeUndefined();
+    store.lock();
+  });
+
+  // --------------------------------------------------------------------------
+  // allValues (for redaction)
+  // --------------------------------------------------------------------------
+
+  it('allValues() returns all decrypted values', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store.store('a', 'val-a');
+    await store.store('b', 'val-b');
+    await store.store('c', 'val-c');
+
+    const values = await store.allValues();
+    expect(values).toHaveLength(3);
+    expect([...values].sort()).toEqual(['val-a', 'val-b', 'val-c']);
+    store.lock();
+  });
+
+  // --------------------------------------------------------------------------
+  // Metadata timestamps
+  // --------------------------------------------------------------------------
+
+  it('preserves createdAt on update, bumps updatedAt', async () => {
+    const store = new CredentialStore({ filePath, passphrase: 'test-pass' });
+    await store.store('key', 'v1');
+    const list1 = await store.list();
+    const created = list1[0].createdAt;
+    const updated1 = list1[0].updatedAt;
+
+    // Small delay to ensure timestamp difference
+    await new Promise(r => setTimeout(r, 10));
+    await store.store('key', 'v2');
+
+    const list2 = await store.list();
+    expect(list2[0].createdAt).toBe(created);
+    expect(list2[0].updatedAt).not.toBe(updated1);
+    store.lock();
+  });
+
+  // --------------------------------------------------------------------------
+  // File creation
+  // --------------------------------------------------------------------------
+
+  it('creates the file and parent directories on first store', async () => {
+    const deepPath = join(tmpdir(), `moflo-cred-tests/${randomBytes(4).toString('hex')}/nested/creds.json`);
+    const store = new CredentialStore({ filePath: deepPath, passphrase: 'test-pass' });
+    await store.store('key', 'val');
+    expect(existsSync(deepPath)).toBe(true);
+    store.lock();
+    unlinkSync(deepPath);
+  });
+});

--- a/src/packages/workflows/__tests__/runner.test.ts
+++ b/src/packages/workflows/__tests__/runner.test.ts
@@ -431,6 +431,63 @@ describe('WorkflowRunner — credential masking', () => {
 });
 
 // ============================================================================
+// Credential Interpolation ({credentials.NAME})
+// ============================================================================
+
+describe('WorkflowRunner — credential interpolation', () => {
+  it('resolves {credentials.NAME} in step config', async () => {
+    let capturedConfig: Record<string, unknown> = {};
+    registry.register(createMockCommand({
+      execute: async (config) => {
+        capturedConfig = config;
+        return { success: true, data: { result: 'ok' }, duration: 1 };
+      },
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: { token: '{credentials.secret}' } },
+    ]);
+
+    const result = await runner.run(definition, {});
+    expect(result.success).toBe(true);
+    expect(capturedConfig.token).toBe('s3cr3t');
+  });
+
+  it('redacts credential values resolved from {credentials.NAME}', async () => {
+    registry.register(createMockCommand({
+      execute: async () => ({
+        success: true,
+        data: { message: 'the secret is s3cr3t' },
+        duration: 1,
+      }),
+    }));
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: { token: '{credentials.secret}' } },
+    ]);
+
+    const result = await runner.run(definition, {});
+    expect(result.success).toBe(true);
+    const output = result.outputs['s1'] as Record<string, unknown>;
+    expect(output.message).not.toContain('s3cr3t');
+    expect(output.message).toContain('***REDACTED***');
+  });
+
+  it('leaves {credentials.NAME} unresolved when credential is missing', async () => {
+    registry.register(createMockCommand());
+
+    const definition = simpleWorkflow([
+      { id: 's1', type: 'mock', config: { token: '{credentials.nonexistent}' } },
+    ]);
+
+    // Should fail interpolation since credentials.nonexistent is not in variables
+    const result = await runner.run(definition, {});
+    expect(result.success).toBe(false);
+    expect(result.errors[0].message).toContain('Variable not found');
+  });
+});
+
+// ============================================================================
 // Dry Run
 // ============================================================================
 

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -30,6 +30,11 @@ import { validateWorkflowDefinition, resolveArguments } from '../schema/validato
 
 const DEFAULT_STEP_TIMEOUT = 300_000; // 5 minutes
 
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+
 interface ExecutionState {
   readonly variables: Record<string, unknown>;
   readonly resolvedArgs: Record<string, unknown>;
@@ -215,8 +220,22 @@ export class WorkflowRunner {
 
     // Pre-compile credential patterns once for the entire run
     const credentialPatterns = (options.credentialValues ?? []).map(
-      v => new RegExp(v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+      v => new RegExp(escapeRegExp(v), 'g'),
     );
+
+    // Pre-resolve {credentials.NAME} references so synchronous interpolation works
+    const credentialNames = this.collectCredentialNames(definition.steps);
+    if (credentialNames.size > 0) {
+      const resolved: Record<string, unknown> = {};
+      await Promise.all([...credentialNames].map(async (name) => {
+        const value = await this.credentials.get(name);
+        if (value !== undefined) {
+          resolved[name] = value;
+          credentialPatterns.push(new RegExp(escapeRegExp(value), 'g'));
+        }
+      }));
+      variables.credentials = resolved;
+    }
 
     const state: ExecutionState = { variables, resolvedArgs, workflowId, options, credentialPatterns };
 
@@ -697,6 +716,35 @@ export class WorkflowRunner {
     } catch {
       // Best-effort — don't fail the workflow for progress tracking
     }
+  }
+
+  /**
+   * Scan all step configs (including nested loop steps) for {credentials.NAME} references.
+   */
+  private collectCredentialNames(steps: readonly StepDefinition[]): Set<string> {
+    const names = new Set<string>();
+
+    const scan = (value: unknown): void => {
+      if (typeof value === 'string') {
+        for (const match of value.matchAll(/\{credentials\.([^}]+)\}/g)) {
+          names.add(match[1]);
+        }
+      } else if (Array.isArray(value)) {
+        for (const item of value) scan(item);
+      } else if (value !== null && typeof value === 'object') {
+        for (const v of Object.values(value as Record<string, unknown>)) scan(v);
+      }
+    };
+
+    const scanSteps = (stepsToScan: readonly StepDefinition[]): void => {
+      for (const step of stepsToScan) {
+        scan(step.config);
+        if (step.steps) scanSteps(step.steps);
+      }
+    };
+
+    scanSteps(steps);
+    return names;
   }
 
   private failureResult(workflowId: string, startTime: number, errors: WorkflowError[]): WorkflowResult {

--- a/src/packages/workflows/src/credentials/credential-store.ts
+++ b/src/packages/workflows/src/credentials/credential-store.ts
@@ -1,0 +1,273 @@
+/**
+ * Encrypted Credential Store
+ *
+ * Provides at-rest encryption for workflow secrets using AES-256-GCM
+ * with PBKDF2 key derivation. Implements the CredentialAccessor interface
+ * so workflows can reference secrets by name via {credentials.NAME}.
+ *
+ * Story #106: Encrypted Credential Storage
+ */
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  pbkdf2Sync,
+} from 'node:crypto';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { CredentialAccessor } from '../types/step-command.types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface CredentialMeta {
+  readonly name: string;
+  readonly description?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface CredentialStoreOptions {
+  /** Path to the encrypted credentials file. */
+  readonly filePath: string;
+  /** Passphrase for key derivation. If omitted, store operates in locked mode. */
+  readonly passphrase?: string;
+}
+
+interface EncryptedEntry {
+  iv: string;
+  tag: string;
+  ciphertext: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface StoreData {
+  salt: string;
+  credentials: Record<string, EncryptedEntry>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const SALT_BYTES = 32;
+const KEY_BYTES = 32;
+const PBKDF2_ITERATIONS = 100_000;
+const PBKDF2_DIGEST = 'sha512';
+
+// ============================================================================
+// Encryption Helpers
+// ============================================================================
+
+function deriveKey(passphrase: string, salt: Buffer): Buffer {
+  return pbkdf2Sync(passphrase, salt, PBKDF2_ITERATIONS, KEY_BYTES, PBKDF2_DIGEST);
+}
+
+function encrypt(plaintext: string, key: Buffer): { iv: string; tag: string; ciphertext: string } {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return {
+    iv: iv.toString('hex'),
+    tag: tag.toString('hex'),
+    ciphertext: encrypted.toString('hex'),
+  };
+}
+
+function decrypt(entry: { iv: string; tag: string; ciphertext: string }, key: Buffer): string {
+  const iv = Buffer.from(entry.iv, 'hex');
+  const tag = Buffer.from(entry.tag, 'hex');
+  const ciphertext = Buffer.from(entry.ciphertext, 'hex');
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return decrypted.toString('utf-8');
+}
+
+// ============================================================================
+// Credential Store
+// ============================================================================
+
+export class CredentialStore implements CredentialAccessor {
+  private readonly filePath: string;
+  private derivedKey: Buffer | null = null;
+  private data: StoreData | null = null;
+
+  constructor(options: CredentialStoreOptions) {
+    this.filePath = options.filePath;
+    if (options.passphrase) {
+      this.unlock(options.passphrase);
+    }
+  }
+
+  /**
+   * Unlock the store with a passphrase.
+   * Derives the encryption key and loads existing data.
+   */
+  unlock(passphrase: string): void {
+    this.data = this.readFile();
+    const salt = Buffer.from(this.data.salt, 'hex');
+    this.derivedKey = deriveKey(passphrase, salt);
+  }
+
+  /**
+   * Lock the store, clearing the derived key from memory.
+   */
+  lock(): void {
+    if (this.derivedKey) {
+      this.derivedKey.fill(0);
+    }
+    this.derivedKey = null;
+    this.data = null;
+  }
+
+  /**
+   * Store an encrypted credential.
+   */
+  async store(name: string, value: string, description?: string): Promise<void> {
+    this.ensureUnlocked();
+    const now = new Date().toISOString();
+    const encrypted = encrypt(value, this.derivedKey!);
+
+    const existing = this.data!.credentials[name];
+    this.data!.credentials[name] = {
+      ...encrypted,
+      description: description ?? existing?.description,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    this.writeFile(this.data!);
+  }
+
+  /**
+   * Retrieve a decrypted credential value.
+   * Implements CredentialAccessor.get().
+   */
+  async get(name: string): Promise<string | undefined> {
+    this.ensureUnlocked();
+    const entry = this.data!.credentials[name];
+    if (!entry) return undefined;
+
+    try {
+      return decrypt(entry, this.derivedKey!);
+    } catch {
+      throw new CredentialStoreError(
+        `Failed to decrypt credential "${name}". Wrong passphrase?`,
+        'DECRYPTION_FAILED',
+      );
+    }
+  }
+
+  /**
+   * Check if a credential exists.
+   * Implements CredentialAccessor.has().
+   */
+  async has(name: string): Promise<boolean> {
+    this.ensureUnlocked();
+    return name in this.data!.credentials;
+  }
+
+  /**
+   * Delete a credential.
+   */
+  async delete(name: string): Promise<boolean> {
+    this.ensureUnlocked();
+    if (!(name in this.data!.credentials)) return false;
+    delete this.data!.credentials[name];
+    this.writeFile(this.data!);
+    return true;
+  }
+
+  /**
+   * List credential metadata (names + descriptions, never values).
+   */
+  async list(): Promise<readonly CredentialMeta[]> {
+    this.ensureUnlocked();
+    return Object.entries(this.data!.credentials).map(([name, entry]) => ({
+      name,
+      description: entry.description,
+      createdAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
+    }));
+  }
+
+  /**
+   * Collect all decrypted values for output redaction.
+   * Used by the runner to build credential patterns.
+   */
+  async allValues(): Promise<readonly string[]> {
+    this.ensureUnlocked();
+    const values: string[] = [];
+    for (const entry of Object.values(this.data!.credentials)) {
+      try {
+        values.push(decrypt(entry, this.derivedKey!));
+      } catch {
+        // Skip entries that can't be decrypted
+      }
+    }
+    return values;
+  }
+
+  // --------------------------------------------------------------------------
+  // Private
+  // --------------------------------------------------------------------------
+
+  private ensureUnlocked(): void {
+    if (!this.derivedKey || !this.data) {
+      throw new CredentialStoreError(
+        'Credential store is locked. Call unlock(passphrase) first.',
+        'STORE_LOCKED',
+      );
+    }
+  }
+
+  private readFile(): StoreData {
+    try {
+      const content = readFileSync(this.filePath, 'utf-8');
+      return JSON.parse(content) as StoreData;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {
+          salt: randomBytes(SALT_BYTES).toString('hex'),
+          credentials: {},
+        };
+      }
+      throw new CredentialStoreError(
+        `Failed to read credential store at ${this.filePath}`,
+        'READ_FAILED',
+      );
+    }
+  }
+
+  private writeFile(data: StoreData): void {
+    mkdirSync(dirname(this.filePath), { recursive: true });
+    writeFileSync(this.filePath, JSON.stringify(data, null, 2), 'utf-8');
+  }
+}
+
+// ============================================================================
+// Error
+// ============================================================================
+
+export type CredentialStoreErrorCode = 'DECRYPTION_FAILED' | 'STORE_LOCKED' | 'READ_FAILED';
+
+export class CredentialStoreError extends Error {
+  constructor(
+    message: string,
+    public readonly code: CredentialStoreErrorCode,
+  ) {
+    super(message);
+    this.name = 'CredentialStoreError';
+  }
+}

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -123,6 +123,18 @@ export {
 } from './factory/pause-resume.js';
 
 // ============================================================================
+// Credential Store
+// ============================================================================
+
+export {
+  CredentialStore,
+  CredentialStoreError,
+  type CredentialMeta,
+  type CredentialStoreOptions,
+  type CredentialStoreErrorCode,
+} from './credentials/credential-store.js';
+
+// ============================================================================
 // Workflow Registry (abbreviation lookup + list/info)
 // ============================================================================
 

--- a/src/packages/workflows/src/schema/validator.ts
+++ b/src/packages/workflows/src/schema/validator.ts
@@ -232,6 +232,11 @@ function checkStringReferences(
       continue;
     }
 
+    // {credentials.NAME} — resolved at runtime by the runner
+    if (segments[0] === 'credentials' && segments.length === 2) {
+      continue;
+    }
+
     // {stepId.outputKey} — check step has been declared before this point
     if (segments.length >= 2) {
       const stepId = segments[0];


### PR DESCRIPTION
## Summary
- Add `CredentialStore` class with AES-256-GCM encryption and PBKDF2 key derivation for at-rest secret storage
- Wire `{credentials.NAME}` interpolation in the workflow runner with automatic output redaction
- Update validator to recognize credential namespace references
- 16 unit tests for credential store + 3 runner integration tests for interpolation/redaction

## Changes
- **New:** `src/packages/workflows/src/credentials/credential-store.ts` — encrypted store implementing `CredentialAccessor`
- **Modified:** `src/packages/workflows/src/core/runner.ts` — pre-resolve `{credentials.NAME}` before interpolation, add `escapeRegExp` helper, parallelize resolution with `Promise.all`
- **Modified:** `src/packages/workflows/src/schema/validator.ts` — allow `{credentials.NAME}` references without false-positive forward-reference errors
- **Modified:** `src/packages/workflows/src/index.ts` — export `CredentialStore`, `CredentialStoreError`, `CredentialStoreErrorCode`, `CredentialMeta`, `CredentialStoreOptions`
- **New:** `src/packages/workflows/__tests__/credential-store.test.ts` — 16 tests covering store/retrieve, encryption, wrong passphrase, lock/unlock, delete, list, allValues, timestamps, file creation
- **Modified:** `src/packages/workflows/__tests__/runner.test.ts` — 3 tests for credential interpolation and redaction

## Testing
- [x] Unit tests pass (16 credential store + 3 runner interpolation)
- [x] Full workflow test suite passes (223 tests across 10 files)
- [x] Code review via /simplify (TOCTOU fixes, typed error codes, escapeRegExp extraction, Promise.all parallelization)

Closes #106

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)