### PR TITLE
feat(epic): configurable admin merge and default strategy

### DIFF
--- a/.claude/guidance/shipped/moflo-epic-processing.md
+++ b/.claude/guidance/shipped/moflo-epic-processing.md
@@ -1,0 +1,62 @@
+# Epic Processing
+
+**Purpose:** Configuration and behavioral rules for `flo epic run` and `/flo` epic detection. Reference when processing epics, merging story PRs, or configuring epic behavior.
+
+---
+
+## Configuration (moflo.yaml)
+
+**Add an `epic` section to `moflo.yaml` to control epic behavior.** All settings have sensible defaults.
+
+```yaml
+epic:
+  admin_merge: true              # Use --admin on gh pr merge (bypasses branch protection)
+  default_strategy: single-branch  # single-branch | auto-merge
+```
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `admin_merge` | boolean | `true` | Pass `--admin` to `gh pr merge` in auto-merge strategy. Set `false` if the user lacks admin rights or wants branch protection enforced. |
+| `default_strategy` | string | `single-branch` | Default branching strategy when `--strategy` flag is not passed. Overridden by `--strategy` CLI flag or YAML feature definition. |
+
+---
+
+## Branching Strategies
+
+| Strategy | Branches | PRs | Merge behavior |
+|----------|----------|-----|----------------|
+| `single-branch` (default) | One shared `epic/<number>-<slug>` | One consolidated PR after all stories | No per-story merge |
+| `auto-merge` | Per-story branches | Per-story PRs, each merged before next story | Squash merge with `--admin` (configurable) |
+
+---
+
+## Admin Merge Behavior
+
+**In auto-merge strategy, use `--admin` on `gh pr merge` by default.** This bypasses branch protection rules that would otherwise block automated sequential processing.
+
+| Condition | Action |
+|-----------|--------|
+| `epic.admin_merge: true` (default) | `gh pr merge <number> --squash --delete-branch --admin` |
+| `epic.admin_merge: false` | `gh pr merge <number> --squash --delete-branch` (may fail on protected branches) |
+| Single-branch strategy | No merge during processing; consolidated PR created at end |
+
+**Never stop to ask whether a PR can be merged during epic auto-merge processing.** If the merge fails, log the error and halt the epic — do not prompt the user mid-sequence.
+
+---
+
+## Strategy Resolution Order
+
+The strategy is resolved with this precedence (highest first):
+
+1. `--strategy` CLI flag (`flo epic run 42 --strategy auto-merge`)
+2. `strategy` field in YAML feature definition
+3. `epic.default_strategy` in `moflo.yaml`
+4. Hard-coded fallback: `single-branch`
+
+---
+
+## See Also
+
+- `src/packages/cli/src/commands/epic.ts` — Epic command implementation
+- `src/packages/cli/src/config/moflo-config.ts` — `MofloConfig.epic` interface and defaults
+- `.claude/skills/fl/SKILL.md` — `/flo` skill epic handling section

--- a/.claude/skills/fl/SKILL.md
+++ b/.claude/skills/fl/SKILL.md
@@ -443,7 +443,7 @@ Each story gets its own branch and PR. After each story's PR is created, it is s
 3. SEQUENTIAL PROCESSING - For each story:
    a. Checkout and pull latest base branch
    b. Run `/flo <issue> <flags>` (normal mode — creates branch + PR)
-   c. Auto-merge the PR (`--squash --delete-branch`)
+   c. Auto-merge the PR (`--squash --delete-branch --admin` by default; controlled by `epic.admin_merge` in moflo.yaml)
    d. Pull merged changes, check off the story in the epic body
    e. Move to the next unchecked story
 4. COMPLETION - All stories checked off, epic marked as ready-for-review

--- a/src/packages/cli/src/commands/epic.ts
+++ b/src/packages/cli/src/commands/epic.ts
@@ -20,6 +20,7 @@ import { spawn, execSync } from 'child_process';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 import type { Command, CommandContext, CommandResult } from '../types.js';
+import { loadMofloConfig } from '../config/moflo-config.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Types
@@ -610,7 +611,8 @@ async function runFeature(
     ? await loadFeatureFromIssue(parseInt(source, 10))
     : await loadFeatureDefinition(source);
   const feature = featureDef.feature;
-  const strategy: EpicStrategy = strategyOverride || feature.strategy || 'single-branch';
+  const mofloConfig = loadMofloConfig(feature.repository);
+  const strategy: EpicStrategy = strategyOverride || feature.strategy || mofloConfig.epic.default_strategy;
   const plan = resolveExecutionOrder(feature.stories);
 
   // ── Dry run ───────────────────────────────────────────────────────────
@@ -833,7 +835,8 @@ async function runFeature(
       prNumber = prInfo.number;
 
       try {
-        execSync(`gh pr merge ${prInfo.number} --squash --delete-branch`, {
+        const adminFlag = mofloConfig.epic.admin_merge ? ' --admin' : '';
+        execSync(`gh pr merge ${prInfo.number} --squash --delete-branch${adminFlag}`, {
           cwd: feature.repository,
           stdio: 'pipe',
         });

--- a/src/packages/cli/src/config/moflo-config.ts
+++ b/src/packages/cli/src/config/moflo-config.ts
@@ -88,6 +88,11 @@ export interface MofloConfig {
     helpers: boolean;
   };
 
+  epic: {
+    admin_merge: boolean;
+    default_strategy: 'single-branch' | 'auto-merge';
+  };
+
   status_line: {
     enabled: boolean;
     branding: string;
@@ -169,6 +174,10 @@ const DEFAULT_CONFIG: MofloConfig = {
     enabled: true,
     scripts: true,
     helpers: true,
+  },
+  epic: {
+    admin_merge: true,
+    default_strategy: 'single-branch',
   },
   status_line: {
     enabled: true,
@@ -271,6 +280,10 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
       enabled: raw.auto_update?.enabled ?? raw.autoUpdate?.enabled ?? DEFAULT_CONFIG.auto_update.enabled,
       scripts: raw.auto_update?.scripts ?? raw.autoUpdate?.scripts ?? DEFAULT_CONFIG.auto_update.scripts,
       helpers: raw.auto_update?.helpers ?? raw.autoUpdate?.helpers ?? DEFAULT_CONFIG.auto_update.helpers,
+    },
+    epic: {
+      admin_merge: raw.epic?.admin_merge ?? raw.epic?.adminMerge ?? DEFAULT_CONFIG.epic.admin_merge,
+      default_strategy: raw.epic?.default_strategy ?? raw.epic?.defaultStrategy ?? DEFAULT_CONFIG.epic.default_strategy,
     },
     status_line: {
       enabled: raw.status_line?.enabled ?? raw.statusLine?.enabled ?? DEFAULT_CONFIG.status_line.enabled,
@@ -440,6 +453,11 @@ auto_update:
   enabled: true                  # Master toggle for version-change auto-sync
   scripts: true                  # Sync .claude/scripts/ from moflo bin/
   helpers: true                  # Sync .claude/helpers/ from moflo source
+
+# Epic processing (flo epic run)
+epic:
+  admin_merge: true              # Use --admin flag on gh pr merge (bypasses branch protection)
+  default_strategy: single-branch  # single-branch (one PR) or auto-merge (per-story PRs)
 
 # Status line items (show/hide individual sections)
 status_line:

--- a/tests/epic-command.test.ts
+++ b/tests/epic-command.test.ts
@@ -223,6 +223,50 @@ describe('flo command epic-branch flag', () => {
   });
 });
 
+describe('epic config: admin_merge', () => {
+  it('should build merge command with --admin when admin_merge is true', () => {
+    const adminMerge = true;
+    const prNumber = 42;
+    const adminFlag = adminMerge ? ' --admin' : '';
+    const cmd = `gh pr merge ${prNumber} --squash --delete-branch${adminFlag}`;
+    expect(cmd).toBe('gh pr merge 42 --squash --delete-branch --admin');
+  });
+
+  it('should build merge command without --admin when admin_merge is false', () => {
+    const adminMerge = false;
+    const prNumber = 42;
+    const adminFlag = adminMerge ? ' --admin' : '';
+    const cmd = `gh pr merge ${prNumber} --squash --delete-branch${adminFlag}`;
+    expect(cmd).toBe('gh pr merge 42 --squash --delete-branch');
+  });
+});
+
+describe('epic config: default_strategy', () => {
+  it('should use config default_strategy when no override or feature strategy', () => {
+    const strategyOverride = undefined;
+    const featureStrategy = undefined;
+    const configDefault: string = 'auto-merge';
+    const strategy = strategyOverride || featureStrategy || configDefault;
+    expect(strategy).toBe('auto-merge');
+  });
+
+  it('should prefer CLI flag over config default', () => {
+    const strategyOverride = 'auto-merge';
+    const featureStrategy = undefined;
+    const configDefault = 'single-branch';
+    const strategy = strategyOverride || featureStrategy || configDefault;
+    expect(strategy).toBe('auto-merge');
+  });
+
+  it('should prefer feature definition over config default', () => {
+    const strategyOverride = undefined;
+    const featureStrategy = 'auto-merge';
+    const configDefault = 'single-branch';
+    const strategy = strategyOverride || featureStrategy || configDefault;
+    expect(strategy).toBe('auto-merge');
+  });
+});
+
 describe('topological sort (execution order)', () => {
   // Test the Kahn's algorithm for dependency resolution
 


### PR DESCRIPTION
## Summary
- Add `epic` config section to `moflo.yaml` with `admin_merge` and `default_strategy`
- Epic auto-merge mode uses `--admin` on `gh pr merge` by default (configurable)
- Strategy resolution: CLI flag > YAML feature def > moflo.yaml config > hard-coded default
- Shipped guidance doc at `.claude/guidance/shipped/moflo-epic-processing.md`

## Changes
- `src/packages/cli/src/config/moflo-config.ts` — New `epic` config section (type, defaults, merge, YAML template)
- `src/packages/cli/src/commands/epic.ts` — Reads config for admin_merge and default_strategy
- `.claude/guidance/shipped/moflo-epic-processing.md` — Shipped guidance for epic behavior
- `.claude/skills/fl/SKILL.md` — Updated auto-merge description
- `tests/epic-command.test.ts` — 5 new tests for admin_merge and strategy precedence

## Testing
- [x] All 25 epic tests pass
- [x] Build passes
- [x] Full suite: 1 pre-existing flaky failure (process-manager.test.ts), unrelated

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)