### PR TITLE
fix(bin): correct npx-safe-launch.js CLI path for consumer projects

### DIFF
--- a/bin/npx-safe-launch.js
+++ b/bin/npx-safe-launch.js
@@ -5,5 +5,5 @@ import { pathToFileURL, fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const cliPath = join(__dirname, '..', 'v3', '@claude-flow', 'cli', 'bin', 'cli.js');
+const cliPath = join(__dirname, '..', 'src', 'packages', 'cli', 'bin', 'cli.js');
 await import(pathToFileURL(cliPath).href);


### PR DESCRIPTION
## Summary
- Fix broken path in `bin/npx-safe-launch.js` that referenced non-existent `v3/@claude-flow` directory
- Aligns with `bin/cli.js` which correctly resolves to `src/packages/cli/bin/cli.js`
- This would cause failures when moflo is installed as a dependency in consumer projects

## Test plan
- [x] Build passes
- [x] Path verified to match bin/cli.js

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)