### PR TITLE
feat(workflows): MoFlo integration levels (Story #109)

### DIFF
--- a/src/packages/workflows/__tests__/moflo-levels.test.ts
+++ b/src/packages/workflows/__tests__/moflo-levels.test.ts
@@ -1,0 +1,489 @@
+/**
+ * MoFlo Integration Levels Tests
+ *
+ * Story #109: Tests for MoFlo integration level resolution, validation,
+ * and enforcement in the workflow engine.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isValidMofloLevel,
+  compareMofloLevels,
+  getDefaultMofloLevel,
+  resolveMofloLevel,
+} from '../src/core/capability-validator.js';
+import { MOFLO_LEVEL_ORDER, DEFAULT_MAX_NESTING_DEPTH } from '../src/types/step-command.types.js';
+import type { MofloLevel, StepCommand } from '../src/types/step-command.types.js';
+import type { StepDefinition, WorkflowDefinition } from '../src/types/workflow-definition.types.js';
+import { WorkflowRunner } from '../src/core/runner.js';
+import { StepCommandRegistry } from '../src/core/step-command-registry.js';
+import type { CredentialAccessor, MemoryAccessor } from '../src/types/step-command.types.js';
+import { validateWorkflowDefinition } from '../src/schema/validator.js';
+import {
+  agentCommand,
+  bashCommand,
+  conditionCommand,
+  waitCommand,
+  loopCommand,
+  memoryCommand,
+  browserCommand,
+  promptCommand,
+} from '../src/commands/index.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeStep(overrides: Partial<StepDefinition> = {}): StepDefinition {
+  return {
+    id: 'test-step',
+    type: 'bash',
+    config: { command: 'echo hello' },
+    ...overrides,
+  };
+}
+
+function makeCommand(overrides: Partial<StepCommand> = {}): StepCommand {
+  return {
+    type: 'mock',
+    description: 'Mock command',
+    configSchema: { type: 'object' },
+    validate: () => ({ valid: true, errors: [] }),
+    execute: async () => ({ success: true, data: { result: 'ok' }, duration: 1 }),
+    describeOutputs: () => [{ name: 'result', type: 'string' }],
+    ...overrides,
+  };
+}
+
+function makeWorkflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    name: 'test-workflow',
+    steps: [makeStep()],
+    ...overrides,
+  };
+}
+
+function createMockMemory(): MemoryAccessor {
+  const store = new Map<string, unknown>();
+  return {
+    async read(ns: string, key: string) { return store.get(`${ns}:${key}`) ?? null; },
+    async write(ns: string, key: string, value: unknown) { store.set(`${ns}:${key}`, value); },
+    async search() { return []; },
+  };
+}
+
+function createMockCredentials(): CredentialAccessor {
+  return {
+    async get() { return undefined; },
+    async has() { return false; },
+  };
+}
+
+// ============================================================================
+// isValidMofloLevel
+// ============================================================================
+
+describe('isValidMofloLevel', () => {
+  it('should accept all valid levels', () => {
+    for (const level of MOFLO_LEVEL_ORDER) {
+      expect(isValidMofloLevel(level)).toBe(true);
+    }
+  });
+
+  it('should reject invalid levels', () => {
+    expect(isValidMofloLevel('admin')).toBe(false);
+    expect(isValidMofloLevel('')).toBe(false);
+    expect(isValidMofloLevel('NONE')).toBe(false);
+    expect(isValidMofloLevel('memory-plus')).toBe(false);
+  });
+});
+
+// ============================================================================
+// compareMofloLevels
+// ============================================================================
+
+describe('compareMofloLevels', () => {
+  it('should return 0 for equal levels', () => {
+    expect(compareMofloLevels('none', 'none')).toBe(0);
+    expect(compareMofloLevels('full', 'full')).toBe(0);
+  });
+
+  it('should return negative when first is less permissive', () => {
+    expect(compareMofloLevels('none', 'memory')).toBeLessThan(0);
+    expect(compareMofloLevels('memory', 'hooks')).toBeLessThan(0);
+    expect(compareMofloLevels('hooks', 'full')).toBeLessThan(0);
+    expect(compareMofloLevels('full', 'recursive')).toBeLessThan(0);
+    expect(compareMofloLevels('none', 'recursive')).toBeLessThan(0);
+  });
+
+  it('should return positive when first is more permissive', () => {
+    expect(compareMofloLevels('recursive', 'none')).toBeGreaterThan(0);
+    expect(compareMofloLevels('full', 'memory')).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// getDefaultMofloLevel
+// ============================================================================
+
+describe('getDefaultMofloLevel', () => {
+  it('should return none when no command is provided', () => {
+    expect(getDefaultMofloLevel('agent')).toBe('none');
+    expect(getDefaultMofloLevel('bash')).toBe('none');
+    expect(getDefaultMofloLevel('custom-step')).toBe('none');
+  });
+
+  it('should return command defaultMofloLevel when set', () => {
+    const command = makeCommand({ defaultMofloLevel: 'hooks' });
+    expect(getDefaultMofloLevel('bash', command)).toBe('hooks');
+  });
+
+  it('should return none when command has no defaultMofloLevel', () => {
+    const command = makeCommand({ defaultMofloLevel: undefined });
+    expect(getDefaultMofloLevel('agent', command)).toBe('none');
+  });
+
+  it('should return correct level for built-in agent command', () => {
+    expect(getDefaultMofloLevel('agent', agentCommand)).toBe('memory');
+  });
+
+  it('should return correct level for built-in bash command', () => {
+    expect(getDefaultMofloLevel('bash', bashCommand)).toBe('none');
+  });
+});
+
+// ============================================================================
+// resolveMofloLevel
+// ============================================================================
+
+describe('resolveMofloLevel', () => {
+  it('should use command default when no overrides', () => {
+    const step = makeStep({ type: 'agent' });
+    const command = makeCommand({ defaultMofloLevel: 'memory' });
+    expect(resolveMofloLevel(step, command, undefined, undefined)).toBe('memory');
+  });
+
+  it('should allow step to narrow below workflow level', () => {
+    const step = makeStep({ mofloLevel: 'none' });
+    const command = makeCommand({ defaultMofloLevel: 'memory' });
+    expect(resolveMofloLevel(step, command, 'full', undefined)).toBe('none');
+  });
+
+  it('should cap step level at workflow level', () => {
+    const step = makeStep({ mofloLevel: 'full' });
+    const command = makeCommand({ defaultMofloLevel: 'memory' });
+    expect(resolveMofloLevel(step, command, 'memory', undefined)).toBe('memory');
+  });
+
+  it('should cap at parent level for recursive workflows', () => {
+    const step = makeStep({ mofloLevel: 'full' });
+    const command = makeCommand({ defaultMofloLevel: 'memory' });
+    expect(resolveMofloLevel(step, command, 'recursive', 'hooks')).toBe('hooks');
+  });
+
+  it('should not escalate beyond parent even without workflow level', () => {
+    const step = makeStep({ type: 'agent' });
+    const command = makeCommand({ defaultMofloLevel: 'full' });
+    expect(resolveMofloLevel(step, command, undefined, 'memory')).toBe('memory');
+  });
+
+  it('should fall back to none when no command provided', () => {
+    const step = makeStep({ type: 'agent' });
+    expect(resolveMofloLevel(step, undefined, undefined, undefined)).toBe('none');
+  });
+});
+
+// ============================================================================
+// mofloLevel validation (via validateWorkflowDefinition)
+// ============================================================================
+
+describe('mofloLevel validation', () => {
+  it('should pass with no mofloLevel set', () => {
+    const def = makeWorkflow();
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should pass with valid workflow mofloLevel', () => {
+    const def = makeWorkflow({ mofloLevel: 'memory' });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject invalid workflow mofloLevel', () => {
+    const def = makeWorkflow({ mofloLevel: 'admin' as MofloLevel });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.path === 'mofloLevel' && e.message.includes('invalid mofloLevel'))).toBe(true);
+  });
+
+  it('should pass with valid step mofloLevel', () => {
+    const def = makeWorkflow({
+      steps: [makeStep({ mofloLevel: 'memory' })],
+    });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject invalid step mofloLevel', () => {
+    const def = makeWorkflow({
+      steps: [makeStep({ mofloLevel: 'super' as MofloLevel })],
+    });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('invalid mofloLevel'))).toBe(true);
+  });
+
+  it('should reject step mofloLevel that exceeds workflow level', () => {
+    const def = makeWorkflow({
+      mofloLevel: 'memory',
+      steps: [makeStep({ mofloLevel: 'full' })],
+    });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('exceeds workflow-level'))).toBe(true);
+  });
+
+  it('should allow step level equal to workflow level', () => {
+    const def = makeWorkflow({
+      mofloLevel: 'hooks',
+      steps: [makeStep({ mofloLevel: 'hooks' })],
+    });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should allow step level below workflow level', () => {
+    const def = makeWorkflow({
+      mofloLevel: 'full',
+      steps: [makeStep({ mofloLevel: 'none' })],
+    });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should validate nested steps in loops', () => {
+    const def = makeWorkflow({
+      mofloLevel: 'memory',
+      steps: [{
+        id: 'loop1',
+        type: 'loop',
+        config: { over: [1, 2] },
+        steps: [makeStep({ id: 'nested1', mofloLevel: 'recursive' })],
+      }],
+    });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('exceeds workflow-level'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// Schema validation integration
+// ============================================================================
+
+describe('validateWorkflowDefinition with mofloLevel', () => {
+  it('should pass validation with valid mofloLevel', () => {
+    const def = makeWorkflow({
+      mofloLevel: 'hooks',
+      steps: [makeStep({ mofloLevel: 'none' })],
+    });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should fail validation with escalating step level', () => {
+    const def = makeWorkflow({
+      mofloLevel: 'none',
+      steps: [makeStep({ mofloLevel: 'full' })],
+    });
+    const result = validateWorkflowDefinition(def);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('exceeds'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// Built-in command defaultMofloLevel
+// ============================================================================
+
+describe('built-in command defaultMofloLevel', () => {
+  it('agent command defaults to memory', () => {
+    expect(agentCommand.defaultMofloLevel).toBe('memory');
+  });
+
+  it('bash command defaults to none', () => {
+    expect(bashCommand.defaultMofloLevel).toBe('none');
+  });
+
+  it('memory command defaults to memory', () => {
+    expect(memoryCommand.defaultMofloLevel).toBe('memory');
+  });
+
+  it('browser command defaults to memory', () => {
+    expect(browserCommand.defaultMofloLevel).toBe('memory');
+  });
+
+  it('condition command defaults to none', () => {
+    expect(conditionCommand.defaultMofloLevel).toBe('none');
+  });
+
+  it('wait command defaults to none', () => {
+    expect(waitCommand.defaultMofloLevel).toBe('none');
+  });
+
+  it('loop command defaults to none', () => {
+    expect(loopCommand.defaultMofloLevel).toBe('none');
+  });
+
+  it('prompt command defaults to none', () => {
+    expect(promptCommand.defaultMofloLevel).toBe('none');
+  });
+});
+
+// ============================================================================
+// Runner integration — mofloLevel in context
+// ============================================================================
+
+describe('WorkflowRunner — mofloLevel enforcement', () => {
+  let registry: StepCommandRegistry;
+  let runner: WorkflowRunner;
+
+  beforeEach(() => {
+    registry = new StepCommandRegistry();
+    runner = new WorkflowRunner(registry, createMockCredentials(), createMockMemory());
+  });
+
+  it('should pass mofloLevel to step context', async () => {
+    let capturedLevel: string | undefined;
+    registry.register(makeCommand({
+      defaultMofloLevel: 'memory',
+      execute: async (_config, context) => {
+        capturedLevel = context.mofloLevel;
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const def = makeWorkflow({
+      steps: [{ id: 's1', type: 'mock', config: {} }],
+    });
+
+    const result = await runner.run(def, {});
+    expect(result.success).toBe(true);
+    expect(capturedLevel).toBe('memory');
+  });
+
+  it('should resolve step-level override', async () => {
+    let capturedLevel: string | undefined;
+    registry.register(makeCommand({
+      defaultMofloLevel: 'memory',
+      execute: async (_config, context) => {
+        capturedLevel = context.mofloLevel;
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const def = makeWorkflow({
+      mofloLevel: 'full',
+      steps: [{ id: 's1', type: 'mock', config: {}, mofloLevel: 'none' }],
+    });
+
+    const result = await runner.run(def, {});
+    expect(result.success).toBe(true);
+    expect(capturedLevel).toBe('none');
+  });
+
+  it('should cap step level at workflow level', async () => {
+    let capturedLevel: string | undefined;
+    registry.register(makeCommand({
+      defaultMofloLevel: 'full',
+      execute: async (_config, context) => {
+        capturedLevel = context.mofloLevel;
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const def = makeWorkflow({
+      mofloLevel: 'memory',
+      steps: [{ id: 's1', type: 'mock', config: {} }],
+    });
+
+    const result = await runner.run(def, {});
+    expect(result.success).toBe(true);
+    expect(capturedLevel).toBe('memory');
+  });
+
+  it('should enforce parent level constraint on per-step resolution', async () => {
+    let capturedLevel: string | undefined;
+    registry.register(makeCommand({
+      defaultMofloLevel: 'full',
+      execute: async (_config, context) => {
+        capturedLevel = context.mofloLevel;
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    // Workflow does NOT declare mofloLevel (so no workflow-level vs parent check),
+    // but the command's default 'full' should be capped by parentMofloLevel 'hooks'
+    const def = makeWorkflow({
+      steps: [{ id: 's1', type: 'mock', config: {} }],
+    });
+
+    const result = await runner.run(def, {}, { parentMofloLevel: 'hooks' });
+    expect(result.success).toBe(true);
+    expect(capturedLevel).toBe('hooks');
+  });
+
+  it('should fail nested workflow that exceeds parent level', async () => {
+    registry.register(makeCommand());
+
+    const def = makeWorkflow({
+      mofloLevel: 'full',
+      steps: [{ id: 's1', type: 'mock', config: {} }],
+    });
+
+    const result = await runner.run(def, {}, { parentMofloLevel: 'memory' });
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('MOFLO_LEVEL_DENIED');
+  });
+
+  it('should pass nestingDepth to context', async () => {
+    let capturedDepth: number | undefined;
+    registry.register(makeCommand({
+      execute: async (_config, context) => {
+        capturedDepth = context.nestingDepth;
+        return { success: true, data: {}, duration: 1 };
+      },
+    }));
+
+    const def = makeWorkflow({
+      steps: [{ id: 's1', type: 'mock', config: {} }],
+    });
+
+    const result = await runner.run(def, {}, { nestingDepth: 2 });
+    expect(result.success).toBe(true);
+    expect(capturedDepth).toBe(2);
+  });
+
+  it('should report mofloLevel in dry-run step reports', async () => {
+    registry.register(makeCommand({ defaultMofloLevel: 'hooks' }));
+
+    const def = makeWorkflow({
+      steps: [{ id: 's1', type: 'mock', config: {} }],
+    });
+
+    const result = await runner.dryRun(def, {});
+    expect(result.valid).toBe(true);
+    expect(result.steps[0].mofloLevel).toBe('hooks');
+  });
+});
+
+// ============================================================================
+// DEFAULT_MAX_NESTING_DEPTH
+// ============================================================================
+
+describe('DEFAULT_MAX_NESTING_DEPTH', () => {
+  it('should be 3', () => {
+    expect(DEFAULT_MAX_NESTING_DEPTH).toBe(3);
+  });
+});

--- a/src/packages/workflows/src/commands/agent-command.ts
+++ b/src/packages/workflows/src/commands/agent-command.ts
@@ -17,6 +17,7 @@ export const agentCommand: StepCommand = {
   type: 'agent',
   description: 'Spawn a Claude subagent to perform a task',
   capabilities: [{ type: 'agent' }],
+  defaultMofloLevel: 'memory',
   configSchema: {
     type: 'object',
     properties: {

--- a/src/packages/workflows/src/commands/bash-command.ts
+++ b/src/packages/workflows/src/commands/bash-command.ts
@@ -22,6 +22,7 @@ export const bashCommand: StepCommand = {
     { type: 'fs:read' },
     { type: 'fs:write' },
   ],
+  defaultMofloLevel: 'none',
   configSchema: {
     type: 'object',
     properties: {

--- a/src/packages/workflows/src/commands/browser-command.ts
+++ b/src/packages/workflows/src/commands/browser-command.ts
@@ -215,6 +215,7 @@ async function executeAction(
 export const browserCommand: StepCommand = {
   type: 'browser',
   description: 'Web automation via Playwright (requires playwright peer dependency)',
+  defaultMofloLevel: 'memory',
 
   configSchema: {
     type: 'object',

--- a/src/packages/workflows/src/commands/condition-command.ts
+++ b/src/packages/workflows/src/commands/condition-command.ts
@@ -81,6 +81,7 @@ function evaluateCondition(expression: string, context: WorkflowContext): boolea
 export const conditionCommand: StepCommand = {
   type: 'condition',
   description: 'Branch workflow based on expression evaluation',
+  defaultMofloLevel: 'none',
   configSchema: {
     type: 'object',
     properties: {

--- a/src/packages/workflows/src/commands/loop-command.ts
+++ b/src/packages/workflows/src/commands/loop-command.ts
@@ -18,6 +18,7 @@ import type {
 export const loopCommand: StepCommand = {
   type: 'loop',
   description: 'Iterate over an array, running sub-steps for each item',
+  defaultMofloLevel: 'none',
   configSchema: {
     type: 'object',
     properties: {

--- a/src/packages/workflows/src/commands/memory-command.ts
+++ b/src/packages/workflows/src/commands/memory-command.ts
@@ -21,6 +21,7 @@ export const memoryCommand: StepCommand = {
   type: 'memory',
   description: 'Read, write, or search shared workflow state',
   capabilities: [{ type: 'memory' }],
+  defaultMofloLevel: 'memory',
   configSchema: {
     type: 'object',
     properties: {

--- a/src/packages/workflows/src/commands/prompt-command.ts
+++ b/src/packages/workflows/src/commands/prompt-command.ts
@@ -19,6 +19,7 @@ import { interpolateString } from '../core/interpolation.js';
 export const promptCommand: StepCommand = {
   type: 'prompt',
   description: 'Ask the user a question and capture the response',
+  defaultMofloLevel: 'none',
   configSchema: {
     type: 'object',
     properties: {

--- a/src/packages/workflows/src/commands/wait-command.ts
+++ b/src/packages/workflows/src/commands/wait-command.ts
@@ -15,6 +15,7 @@ import type {
 export const waitCommand: StepCommand = {
   type: 'wait',
   description: 'Pause workflow for a duration',
+  defaultMofloLevel: 'none',
   configSchema: {
     type: 'object',
     properties: {

--- a/src/packages/workflows/src/core/capability-validator.ts
+++ b/src/packages/workflows/src/core/capability-validator.ts
@@ -7,7 +7,8 @@
  * before execution and blocks undeclared access.
  */
 
-import type { StepCapability, CapabilityType, StepCommand } from '../types/step-command.types.js';
+import type { StepCapability, CapabilityType, StepCommand, MofloLevel } from '../types/step-command.types.js';
+import { MOFLO_LEVEL_ORDER } from '../types/step-command.types.js';
 import type { StepDefinition } from '../types/workflow-definition.types.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────
@@ -201,3 +202,74 @@ export function enforceScope(
 export function formatViolations(violations: readonly CapabilityViolation[]): string {
   return violations.map(v => `[${v.capability}] ${v.reason}`).join('; ');
 }
+
+// ── MoFlo Integration Levels ─────────────────────────────────────────────
+
+const VALID_MOFLO_LEVELS: ReadonlySet<string> = new Set<MofloLevel>(MOFLO_LEVEL_ORDER);
+
+/**
+ * Check if a string is a valid MofloLevel.
+ */
+export function isValidMofloLevel(level: string): level is MofloLevel {
+  return VALID_MOFLO_LEVELS.has(level);
+}
+
+/**
+ * Compare two MoFlo levels. Returns:
+ *  - negative if a < b (a is less permissive)
+ *  - 0 if equal
+ *  - positive if a > b (a is more permissive)
+ */
+export function compareMofloLevels(a: MofloLevel, b: MofloLevel): number {
+  return MOFLO_LEVEL_ORDER.indexOf(a) - MOFLO_LEVEL_ORDER.indexOf(b);
+}
+
+/**
+ * Get the default MoFlo integration level for a step type.
+ * The command's `defaultMofloLevel` is the authoritative source;
+ * falls back to 'none' when no command is available.
+ */
+export function getDefaultMofloLevel(_stepType: string, command?: StepCommand): MofloLevel {
+  return command?.defaultMofloLevel ?? 'none';
+}
+
+/**
+ * Resolve the effective MoFlo level for a step given workflow defaults,
+ * step overrides, command defaults, and parent constraints.
+ *
+ * Resolution order (most specific wins, but can only narrow):
+ * 1. Command declares its default level
+ * 2. Workflow definition may set a workflow-wide level
+ * 3. Step may override with its own level (must not exceed workflow level)
+ * 4. Parent workflow constrains the maximum level (for recursive invocation)
+ */
+export function resolveMofloLevel(
+  step: StepDefinition,
+  command: StepCommand | undefined,
+  workflowLevel: MofloLevel | undefined,
+  parentLevel: MofloLevel | undefined,
+): MofloLevel {
+  const commandDefault = getDefaultMofloLevel(step.type, command);
+  const wfLevel = workflowLevel ?? commandDefault;
+
+  // Step can narrow but not exceed the workflow-level default
+  let effective: MofloLevel;
+  if (step.mofloLevel) {
+    effective = compareMofloLevels(step.mofloLevel, wfLevel) <= 0
+      ? step.mofloLevel
+      : wfLevel; // Capped at workflow level
+  } else {
+    // Use the more restrictive of workflow level and command default
+    effective = compareMofloLevels(commandDefault, wfLevel) <= 0
+      ? commandDefault
+      : wfLevel;
+  }
+
+  // Parent constraint: child cannot exceed parent's level
+  if (parentLevel && compareMofloLevels(effective, parentLevel) > 0) {
+    effective = parentLevel;
+  }
+
+  return effective;
+}
+

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -28,7 +28,13 @@ import type {
 import { StepCommandRegistry } from './step-command-registry.js';
 import { interpolateConfig } from './interpolation.js';
 import { validateWorkflowDefinition, resolveArguments } from '../schema/validator.js';
-import { checkCapabilities, formatViolations } from './capability-validator.js';
+import {
+  checkCapabilities,
+  formatViolations,
+  resolveMofloLevel,
+  compareMofloLevels,
+} from './capability-validator.js';
+import { DEFAULT_MAX_NESTING_DEPTH } from '../types/step-command.types.js';
 
 const DEFAULT_STEP_TIMEOUT = 300_000; // 5 minutes
 
@@ -45,6 +51,14 @@ interface ExecutionState {
   readonly credentialPatterns: RegExp[];
   /** All resolved credentials (for per-step scoping, NOT shared in variables) */
   readonly resolvedCredentials: Record<string, unknown>;
+  /** Workflow-level MoFlo integration level. */
+  readonly workflowMofloLevel: MofloLevel | undefined;
+  /** Parent workflow's MoFlo level (for recursive nesting constraint). */
+  readonly parentMofloLevel: MofloLevel | undefined;
+  /** Current nesting depth (0 = top-level). */
+  readonly nestingDepth: number;
+  /** Maximum allowed nesting depth. */
+  readonly maxNestingDepth: number;
 }
 
 export class WorkflowRunner {
@@ -75,6 +89,16 @@ export class WorkflowRunner {
         message: 'Workflow definition is invalid',
         details: defValidation.errors,
       }]);
+    }
+
+    // Enforce parent-level constraint for recursive workflows
+    if (options.parentMofloLevel && definition.mofloLevel) {
+      if (compareMofloLevels(definition.mofloLevel, options.parentMofloLevel) > 0) {
+        return this.failureResult(workflowId, startTime, [{
+          code: 'MOFLO_LEVEL_DENIED',
+          message: `Nested workflow mofloLevel "${definition.mofloLevel}" exceeds parent level "${options.parentMofloLevel}"`,
+        }]);
+      }
     }
 
     const { resolved: resolvedArgs, errors: argErrors } = resolveArguments(
@@ -196,6 +220,11 @@ export class WorkflowRunner {
         };
       }
 
+      // Resolve moflo level for dry-run report
+      const stepMofloLevel = command
+        ? resolveMofloLevel(step, command, definition.mofloLevel, options.parentMofloLevel)
+        : undefined;
+
       stepReports.push({
         stepId: step.id,
         stepType: step.type,
@@ -204,6 +233,7 @@ export class WorkflowRunner {
         validationResult,
         continueOnError: step.continueOnError ?? false,
         hasRollback: command?.rollback !== undefined,
+        mofloLevel: stepMofloLevel,
       });
     }
 
@@ -260,7 +290,18 @@ export class WorkflowRunner {
       }));
     }
 
-    const state: ExecutionState = { variables, resolvedArgs, workflowId, options, credentialPatterns, resolvedCredentials };
+    const state: ExecutionState = {
+      variables,
+      resolvedArgs,
+      workflowId,
+      options,
+      credentialPatterns,
+      resolvedCredentials,
+      workflowMofloLevel: definition.mofloLevel,
+      parentMofloLevel: options.parentMofloLevel,
+      nestingDepth: options.nestingDepth ?? 0,
+      maxNestingDepth: options.maxNestingDepth ?? DEFAULT_MAX_NESTING_DEPTH,
+    };
 
     await this.storeProgress(workflowId, 'running', 0, definition.steps.length);
 
@@ -481,8 +522,34 @@ export class WorkflowRunner {
       };
     }
 
-    // Inject effective capabilities into context for scope enforcement
-    const scopedContext = { ...context, effectiveCaps: capCheck.effectiveCaps };
+    // Resolve MoFlo integration level for this step
+    const resolvedLevel = resolveMofloLevel(
+      step,
+      command,
+      state.workflowMofloLevel,
+      state.parentMofloLevel,
+    );
+
+    // Enforce nesting depth for recursive level
+    if (resolvedLevel === 'recursive' && state.nestingDepth >= state.maxNestingDepth) {
+      return {
+        stepId: step.id,
+        stepType: step.type,
+        status: 'failed',
+        error: `Recursive workflow nesting depth ${state.nestingDepth} exceeds maximum ${state.maxNestingDepth}`,
+        errorCode: 'MOFLO_LEVEL_DENIED',
+        duration: Date.now() - stepStart,
+      };
+    }
+
+    // Inject effective capabilities and moflo level into context for scope enforcement
+    const scopedContext = {
+      ...context,
+      effectiveCaps: capCheck.effectiveCaps,
+      mofloLevel: resolvedLevel,
+      nestingDepth: state.nestingDepth,
+      maxNestingDepth: state.maxNestingDepth,
+    };
 
     const timeout = state.options.defaultStepTimeout ?? DEFAULT_STEP_TIMEOUT;
     let output: StepOutput;

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -27,6 +27,12 @@ export type {
   MemoryAccessor,
   StepCapability,
   CapabilityType,
+  MofloLevel,
+} from './types/step-command.types.js';
+
+export {
+  MOFLO_LEVEL_ORDER,
+  DEFAULT_MAX_NESTING_DEPTH,
 } from './types/step-command.types.js';
 
 export type {
@@ -53,6 +59,10 @@ export {
   isValidCapabilityType,
   validateStepCapabilities,
   formatViolations,
+  isValidMofloLevel,
+  compareMofloLevels,
+  getDefaultMofloLevel,
+  resolveMofloLevel,
   type CapabilityViolation,
   type CapabilityCheckResult,
 } from './core/capability-validator.js';

--- a/src/packages/workflows/src/schema/validator.ts
+++ b/src/packages/workflows/src/schema/validator.ts
@@ -17,7 +17,9 @@ import type {
   ArgumentDefinition,
   ArgumentType,
 } from '../types/workflow-definition.types.js';
-import { validateStepCapabilities } from '../core/capability-validator.js';
+import { validateStepCapabilities, isValidMofloLevel, compareMofloLevels } from '../core/capability-validator.js';
+import { MOFLO_LEVEL_ORDER } from '../types/step-command.types.js';
+import type { MofloLevel } from '../types/step-command.types.js';
 
 const VALID_ARG_TYPES: readonly ArgumentType[] = ['string', 'number', 'boolean', 'string[]'];
 
@@ -36,13 +38,22 @@ export function validateWorkflowDefinition(
   const errors: ValidationError[] = [];
 
   validateTopLevel(def, errors);
+
+  // Validate workflow-level mofloLevel
+  if (def.mofloLevel !== undefined && !isValidMofloLevel(def.mofloLevel)) {
+    errors.push({
+      path: 'mofloLevel',
+      message: `invalid mofloLevel: "${def.mofloLevel}". Valid levels: ${MOFLO_LEVEL_ORDER.join(', ')}`,
+    });
+  }
+
   if (def.arguments) {
     validateArguments(def.arguments, errors);
   }
   if (def.steps) {
     const stepIds = new Set<string>();
     const outputVars = new Set<string>();
-    validateSteps(def.steps, errors, stepIds, outputVars, options);
+    validateSteps(def.steps, errors, stepIds, outputVars, options, 'steps', def.mofloLevel);
     validateVariableReferences(def.steps, outputVars, def.arguments, errors);
   }
 
@@ -127,6 +138,7 @@ function validateSteps(
   outputVars: Set<string>,
   options?: ValidatorOptions,
   prefix = 'steps',
+  workflowLevel?: MofloLevel,
 ): void {
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i];
@@ -159,9 +171,24 @@ function validateSteps(
     const capErrors = validateStepCapabilities(step, path);
     errors.push(...capErrors);
 
+    // Validate mofloLevel if declared
+    if (step.mofloLevel !== undefined) {
+      if (!isValidMofloLevel(step.mofloLevel)) {
+        errors.push({
+          path: `${path}.mofloLevel`,
+          message: `invalid mofloLevel: "${step.mofloLevel}". Valid levels: ${MOFLO_LEVEL_ORDER.join(', ')}`,
+        });
+      } else if (workflowLevel && compareMofloLevels(step.mofloLevel, workflowLevel) > 0) {
+        errors.push({
+          path: `${path}.mofloLevel`,
+          message: `step mofloLevel "${step.mofloLevel}" exceeds workflow-level "${workflowLevel}" — steps can only narrow, not escalate`,
+        });
+      }
+    }
+
     // Recurse into nested steps (condition/loop)
     if (step.steps && Array.isArray(step.steps)) {
-      validateSteps(step.steps, errors, stepIds, outputVars, options, `${path}.steps`);
+      validateSteps(step.steps, errors, stepIds, outputVars, options, `${path}.steps`, workflowLevel);
     }
   }
 }

--- a/src/packages/workflows/src/types/runner.types.ts
+++ b/src/packages/workflows/src/types/runner.types.ts
@@ -4,7 +4,7 @@
  * Types for the sequential workflow executor.
  */
 
-import type { StepOutput, ValidationError } from './step-command.types.js';
+import type { StepOutput, ValidationError, MofloLevel } from './step-command.types.js';
 
 // ============================================================================
 // Error Codes
@@ -20,6 +20,7 @@ export type WorkflowErrorCode =
   | 'STEP_CANCELLED'
   | 'UNKNOWN_STEP_TYPE'
   | 'CAPABILITY_DENIED'
+  | 'MOFLO_LEVEL_DENIED'
   | 'ROLLBACK_FAILED'
   | 'PAUSED_STATE_NOT_FOUND'
   | 'PAUSED_STATE_EXPIRED'
@@ -78,6 +79,8 @@ export interface DryRunStepReport {
   readonly validationResult: { valid: boolean; errors: ValidationError[] };
   readonly continueOnError: boolean;
   readonly hasRollback: boolean;
+  /** Resolved MoFlo integration level for this step. */
+  readonly mofloLevel?: MofloLevel;
 }
 
 export interface DryRunResult {
@@ -112,4 +115,13 @@ export interface RunnerOptions {
 
   /** Pre-seeded variables for resuming from a paused workflow. */
   readonly initialVariables?: Record<string, unknown>;
+
+  /** Current nesting depth for recursive workflow invocation (0 = top-level). */
+  readonly nestingDepth?: number;
+
+  /** Maximum nesting depth for recursive workflows (default: 3). */
+  readonly maxNestingDepth?: number;
+
+  /** Parent workflow's MoFlo level — child workflows cannot exceed this. */
+  readonly parentMofloLevel?: MofloLevel;
 }

--- a/src/packages/workflows/src/types/step-command.types.ts
+++ b/src/packages/workflows/src/types/step-command.types.ts
@@ -97,7 +97,31 @@ export interface WorkflowContext {
   readonly abortSignal?: AbortSignal;
   /** Effective capabilities after merging command defaults with step restrictions. */
   readonly effectiveCaps?: readonly StepCapability[];
+  /** Resolved MoFlo integration level for this step. */
+  readonly mofloLevel?: MofloLevel;
+  /** Nesting depth for recursive workflow invocations (0 = top-level). */
+  readonly nestingDepth?: number;
+  /** Maximum allowed nesting depth for recursive workflows. */
+  readonly maxNestingDepth?: number;
 }
+
+// ============================================================================
+// MoFlo Integration Levels
+// ============================================================================
+
+/**
+ * Integration levels controlling access to MoFlo capabilities.
+ * Ordered from least to most permissive (ordinal comparison).
+ */
+export type MofloLevel = 'none' | 'memory' | 'hooks' | 'full' | 'recursive';
+
+/** Ordered list for ordinal comparison. */
+export const MOFLO_LEVEL_ORDER: readonly MofloLevel[] = [
+  'none', 'memory', 'hooks', 'full', 'recursive',
+];
+
+/** Default max nesting depth for recursive workflows. */
+export const DEFAULT_MAX_NESTING_DEPTH = 3;
 
 // ============================================================================
 // Step Capabilities
@@ -140,6 +164,8 @@ export interface StepCommand<TConfig extends StepConfig = StepConfig> {
   readonly configSchema: JSONSchema;
   /** Capabilities this command requires by default. */
   readonly capabilities?: readonly StepCapability[];
+  /** Default MoFlo integration level for this command type. */
+  readonly defaultMofloLevel?: MofloLevel;
 
   /** Validate may be async (e.g. checking credentials or remote state). */
   validate(config: TConfig, context: WorkflowContext): ValidationResult | Promise<ValidationResult>;

--- a/src/packages/workflows/src/types/workflow-definition.types.ts
+++ b/src/packages/workflows/src/types/workflow-definition.types.ts
@@ -4,7 +4,7 @@
  * TypeScript types for YAML/JSON workflow definition files.
  */
 
-import type { CapabilityType } from './step-command.types.js';
+import type { CapabilityType, MofloLevel } from './step-command.types.js';
 
 // ============================================================================
 // Argument Definitions
@@ -34,6 +34,8 @@ export interface StepDefinition {
   readonly steps?: readonly StepDefinition[];
   /** Capability restrictions for this step (narrows the command's defaults). */
   readonly capabilities?: Partial<Record<CapabilityType, readonly string[]>>;
+  /** MoFlo integration level — controls access to memory, hooks, swarms, nested workflows. */
+  readonly mofloLevel?: MofloLevel;
 }
 
 // ============================================================================
@@ -47,6 +49,8 @@ export interface WorkflowDefinition {
   readonly version?: string;
   readonly arguments?: Record<string, ArgumentDefinition>;
   readonly steps: readonly StepDefinition[];
+  /** Default MoFlo integration level for all steps (can be narrowed per-step). */
+  readonly mofloLevel?: MofloLevel;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add ordinal MoFlo integration levels (`none` → `memory` → `hooks` → `full` → `recursive`) to constrain what MoFlo features each workflow step can access
- Steps can only narrow, never escalate beyond workflow or parent level
- Nesting depth enforcement for recursive workflows (default max: 3)
- All 8 built-in commands declare their `defaultMofloLevel`
- 43 new tests covering level resolution, validation, and runner enforcement

## Changes
- **Types**: `MofloLevel` type, `MOFLO_LEVEL_ORDER`, `DEFAULT_MAX_NESTING_DEPTH`, context/options extensions
- **Capability validator**: `isValidMofloLevel`, `compareMofloLevels`, `getDefaultMofloLevel`, `resolveMofloLevel`
- **Validator**: Inline mofloLevel validation in `validateWorkflowDefinition` and `validateSteps`
- **Runner**: Level resolution per step, parent constraint enforcement, nesting depth checks, dry-run reporting
- **Commands**: `defaultMofloLevel` on all 8 built-in commands (agent/browser/memory → `'memory'`, rest → `'none'`)
- **Exports**: All new types and functions exported from package index

## Testing
- [x] 43 new unit tests in `moflo-levels.test.ts`
- [x] All 304 existing tests pass (3 pre-existing credential test failures unrelated)
- [x] Build passes cleanly
- [x] Code reviewed via /simplify (3-agent review)

Closes #109

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)