### PR TITLE
feat(workflows): scheduled workflow execution (Story #117)

### DIFF
--- a/src/packages/workflows/__tests__/scheduler.test.ts
+++ b/src/packages/workflows/__tests__/scheduler.test.ts
@@ -1,0 +1,806 @@
+/**
+ * Scheduler Tests
+ *
+ * Tests for cron parsing, interval parsing, schedule validation,
+ * next-run computation, and WorkflowScheduler lifecycle.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  parseCron,
+  parseInterval,
+  parseAt,
+  computeNextRun,
+  nextRunFromCron,
+  nextRunFromInterval,
+  nextRunFromAt,
+  validateSchedule,
+} from '../src/scheduler/cron-parser.js';
+import { WorkflowScheduler } from '../src/scheduler/scheduler.js';
+import type { WorkflowExecutor, SchedulerEvent } from '../src/scheduler/scheduler.js';
+import type { MemoryAccessor } from '../src/types/step-command.types.js';
+import type { WorkflowResult } from '../src/types/runner.types.js';
+
+// ============================================================================
+// parseInterval
+// ============================================================================
+
+describe('parseInterval', () => {
+  it('parses seconds', () => {
+    expect(parseInterval('90s')).toBe(90_000);
+  });
+
+  it('parses minutes', () => {
+    expect(parseInterval('30m')).toBe(1_800_000);
+  });
+
+  it('parses hours', () => {
+    expect(parseInterval('6h')).toBe(21_600_000);
+  });
+
+  it('parses days', () => {
+    expect(parseInterval('1d')).toBe(86_400_000);
+  });
+
+  it('returns null for invalid format', () => {
+    expect(parseInterval('abc')).toBeNull();
+    expect(parseInterval('')).toBeNull();
+    expect(parseInterval('10')).toBeNull();
+    expect(parseInterval('10w')).toBeNull();
+  });
+
+  it('returns null for zero value', () => {
+    expect(parseInterval('0h')).toBeNull();
+  });
+
+  it('trims whitespace', () => {
+    expect(parseInterval('  5m  ')).toBe(300_000);
+  });
+});
+
+// ============================================================================
+// parseAt
+// ============================================================================
+
+describe('parseAt', () => {
+  it('parses ISO 8601 datetime', () => {
+    const ts = parseAt('2026-04-01T09:00:00Z');
+    expect(ts).toBe(Date.parse('2026-04-01T09:00:00Z'));
+  });
+
+  it('parses date without time', () => {
+    const ts = parseAt('2026-04-01');
+    expect(ts).not.toBeNull();
+  });
+
+  it('returns null for invalid date', () => {
+    expect(parseAt('not-a-date')).toBeNull();
+    expect(parseAt('')).toBeNull();
+  });
+});
+
+// ============================================================================
+// parseCron
+// ============================================================================
+
+describe('parseCron', () => {
+  it('parses every-minute cron', () => {
+    const parsed = parseCron('* * * * *');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.minutes.size).toBe(60);
+    expect(parsed!.hours.size).toBe(24);
+  });
+
+  it('parses specific time cron', () => {
+    const parsed = parseCron('0 2 * * *');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.minutes).toEqual(new Set([0]));
+    expect(parsed!.hours).toEqual(new Set([2]));
+  });
+
+  it('parses step notation', () => {
+    const parsed = parseCron('*/15 * * * *');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.minutes).toEqual(new Set([0, 15, 30, 45]));
+  });
+
+  it('parses range notation', () => {
+    const parsed = parseCron('0 9-17 * * *');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.hours).toEqual(new Set([9, 10, 11, 12, 13, 14, 15, 16, 17]));
+  });
+
+  it('parses list notation', () => {
+    const parsed = parseCron('0 0 * * 1,3,5');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.daysOfWeek).toEqual(new Set([1, 3, 5]));
+  });
+
+  it('parses range with step', () => {
+    const parsed = parseCron('0-30/10 * * * *');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.minutes).toEqual(new Set([0, 10, 20, 30]));
+  });
+
+  it('returns null for invalid field count', () => {
+    expect(parseCron('* * *')).toBeNull();
+    expect(parseCron('* * * * * *')).toBeNull();
+  });
+
+  it('returns null for out-of-range values', () => {
+    expect(parseCron('60 * * * *')).toBeNull();
+    expect(parseCron('* 25 * * *')).toBeNull();
+    expect(parseCron('* * 32 * *')).toBeNull();
+    expect(parseCron('* * * 13 *')).toBeNull();
+    expect(parseCron('* * * * 7')).toBeNull();
+  });
+
+  it('returns null for invalid range', () => {
+    expect(parseCron('5-2 * * * *')).toBeNull(); // start > end
+  });
+});
+
+// ============================================================================
+// nextRunFromCron
+// ============================================================================
+
+describe('nextRunFromCron', () => {
+  it('finds the next minute for every-minute cron', () => {
+    const cron = parseCron('* * * * *')!;
+    const now = new Date('2026-03-28T10:30:45Z').getTime();
+    const next = nextRunFromCron(cron, now);
+    expect(next).not.toBeNull();
+    const nextDate = new Date(next!);
+    expect(nextDate.getUTCMinutes()).toBe(31);
+    expect(nextDate.getUTCSeconds()).toBe(0);
+  });
+
+  it('finds next 2 AM for daily cron', () => {
+    const cron = parseCron('0 2 * * *')!;
+    // Use local time: 3 AM today → next match is 2 AM tomorrow
+    const now = new Date();
+    now.setHours(3, 0, 0, 0);
+    const next = nextRunFromCron(cron, now.getTime());
+    expect(next).not.toBeNull();
+    const nextDate = new Date(next!);
+    expect(nextDate.getHours()).toBe(2);
+    expect(nextDate.getMinutes()).toBe(0);
+    // Should be next day since 2 AM already passed
+    expect(nextDate.getDate()).toBe(now.getDate() + 1);
+  });
+
+  it('finds next matching day of week', () => {
+    const cron = parseCron('0 0 * * 1')!; // Monday
+    const now = new Date('2026-03-28T00:00:00Z').getTime(); // Saturday
+    const next = nextRunFromCron(cron, now);
+    expect(next).not.toBeNull();
+    expect(new Date(next!).getUTCDay()).toBe(1); // Monday
+  });
+});
+
+// ============================================================================
+// nextRunFromInterval
+// ============================================================================
+
+describe('nextRunFromInterval', () => {
+  it('returns now when no lastRunAt', () => {
+    const now = Date.now();
+    expect(nextRunFromInterval(3600_000, undefined, now)).toBe(now);
+  });
+
+  it('returns lastRunAt + interval when in the future', () => {
+    const now = 1000;
+    expect(nextRunFromInterval(500, 800, now)).toBe(1300);
+  });
+
+  it('returns now when next run is past due', () => {
+    const now = 2000;
+    expect(nextRunFromInterval(500, 100, now)).toBe(now);
+  });
+});
+
+// ============================================================================
+// nextRunFromAt
+// ============================================================================
+
+describe('nextRunFromAt', () => {
+  it('returns timestamp when not yet run', () => {
+    const at = Date.parse('2026-04-01T09:00:00Z');
+    expect(nextRunFromAt(at, undefined)).toBe(at);
+  });
+
+  it('returns null when already run', () => {
+    const at = Date.parse('2026-04-01T09:00:00Z');
+    expect(nextRunFromAt(at, Date.now())).toBeNull();
+  });
+});
+
+// ============================================================================
+// computeNextRun
+// ============================================================================
+
+describe('computeNextRun', () => {
+  it('computes next run from cron', () => {
+    // Use local time: set to 1 AM so noon is in the future
+    const now = new Date();
+    now.setHours(1, 0, 0, 0);
+    const next = computeNextRun({ cron: '0 12 * * *' }, now.getTime());
+    expect(next).not.toBeNull();
+    expect(new Date(next!).getHours()).toBe(12);
+  });
+
+  it('computes next run from interval', () => {
+    const now = 10_000;
+    const next = computeNextRun({ interval: '1h', lastRunAt: 5_000 }, now);
+    // 5000 + 3600000 = 3605000, which is in the future relative to now=10000
+    expect(next).toBe(3_605_000);
+  });
+
+  it('computes next run from at', () => {
+    const at = '2026-04-01T09:00:00Z';
+    const next = computeNextRun({ at });
+    expect(next).toBe(Date.parse(at));
+  });
+
+  it('returns null for invalid cron', () => {
+    expect(computeNextRun({ cron: 'bad' })).toBeNull();
+  });
+
+  it('returns null for invalid interval', () => {
+    expect(computeNextRun({ interval: 'bad' })).toBeNull();
+  });
+
+  it('returns null when no schedule type specified', () => {
+    expect(computeNextRun({})).toBeNull();
+  });
+});
+
+// ============================================================================
+// validateSchedule
+// ============================================================================
+
+describe('validateSchedule', () => {
+  it('accepts valid cron schedule', () => {
+    const errors = validateSchedule({ cron: '0 2 * * *' }, 'schedule');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts valid interval schedule', () => {
+    const errors = validateSchedule({ interval: '6h' }, 'schedule');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts valid at schedule', () => {
+    const errors = validateSchedule({ at: '2026-04-01T09:00:00Z' }, 'schedule');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects empty schedule (no cron/interval/at)', () => {
+    const errors = validateSchedule({}, 'schedule');
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toContain('exactly one of');
+  });
+
+  it('rejects multiple schedule types', () => {
+    const errors = validateSchedule({ cron: '* * * * *', interval: '1h' }, 'schedule');
+    expect(errors.some(e => e.message.includes('found multiple'))).toBe(true);
+  });
+
+  it('rejects invalid cron', () => {
+    const errors = validateSchedule({ cron: 'bad' }, 'schedule');
+    expect(errors.some(e => e.path === 'schedule.cron')).toBe(true);
+  });
+
+  it('rejects invalid interval', () => {
+    const errors = validateSchedule({ interval: 'bad' }, 'schedule');
+    expect(errors.some(e => e.path === 'schedule.interval')).toBe(true);
+  });
+
+  it('rejects invalid at', () => {
+    const errors = validateSchedule({ at: 'not-a-date' }, 'schedule');
+    expect(errors.some(e => e.path === 'schedule.at')).toBe(true);
+  });
+
+  it('rejects non-boolean enabled', () => {
+    const errors = validateSchedule({ cron: '* * * * *', enabled: 'yes' as unknown as boolean }, 'schedule');
+    expect(errors.some(e => e.path === 'schedule.enabled')).toBe(true);
+  });
+});
+
+// ============================================================================
+// Workflow Definition with schedule block (validator integration)
+// ============================================================================
+
+describe('validateWorkflowDefinition with schedule', () => {
+  // Lazy import to avoid circular dependency issues in test setup
+  let validateWorkflowDefinition: typeof import('../src/schema/validator.js').validateWorkflowDefinition;
+
+  beforeEach(async () => {
+    const mod = await import('../src/schema/validator.js');
+    validateWorkflowDefinition = mod.validateWorkflowDefinition;
+  });
+
+  it('accepts workflow with valid cron schedule', () => {
+    const result = validateWorkflowDefinition({
+      name: 'nightly-audit',
+      steps: [{ id: 's1', type: 'bash', config: { command: 'echo hi' } }],
+      schedule: { cron: '0 2 * * *' },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts workflow without schedule', () => {
+    const result = validateWorkflowDefinition({
+      name: 'manual-wf',
+      steps: [{ id: 's1', type: 'bash', config: { command: 'echo hi' } }],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects workflow with invalid schedule', () => {
+    const result = validateWorkflowDefinition({
+      name: 'bad-schedule',
+      steps: [{ id: 's1', type: 'bash', config: { command: 'echo hi' } }],
+      schedule: { cron: 'invalid' },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.path.startsWith('schedule'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// WorkflowScheduler
+// ============================================================================
+
+describe('WorkflowScheduler', () => {
+  let memory: MemoryAccessor;
+  let executor: WorkflowExecutor;
+  let scheduler: WorkflowScheduler;
+  let store: Map<string, Map<string, unknown>>;
+
+  function makeSuccessResult(): WorkflowResult {
+    return {
+      workflowId: 'wf-1',
+      success: true,
+      steps: [],
+      outputs: {},
+      errors: [],
+      duration: 100,
+      cancelled: false,
+    };
+  }
+
+  function makeFailResult(): WorkflowResult {
+    return {
+      workflowId: 'wf-1',
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [{ code: 'STEP_EXECUTION_FAILED', message: 'step failed' }],
+      duration: 50,
+      cancelled: false,
+    };
+  }
+
+  beforeEach(() => {
+    store = new Map();
+
+    memory = {
+      async read(namespace: string, key: string) {
+        return store.get(namespace)?.get(key) ?? null;
+      },
+      async write(namespace: string, key: string, value: unknown) {
+        if (!store.has(namespace)) store.set(namespace, new Map());
+        store.get(namespace)!.set(key, value);
+      },
+      async search(namespace: string) {
+        const ns = store.get(namespace);
+        if (!ns) return [];
+        return [...ns.entries()].map(([key, value]) => ({ key, value, score: 1 }));
+      },
+    };
+
+    executor = {
+      execute: vi.fn().mockResolvedValue(makeSuccessResult()),
+      exists: vi.fn().mockReturnValue(true),
+    };
+
+    scheduler = new WorkflowScheduler(memory, executor, {
+      pollIntervalMs: 100,
+      maxConcurrent: 2,
+      catchUpWindowMs: 3_600_000,
+    });
+  });
+
+  afterEach(async () => {
+    await scheduler.stop();
+  });
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────
+
+  it('starts and stops', () => {
+    scheduler.start();
+    expect(scheduler.isRunning).toBe(true);
+    scheduler.stop();
+    expect(scheduler.isRunning).toBe(false);
+  });
+
+  it('does not start twice', () => {
+    scheduler.start();
+    scheduler.start(); // should be a no-op
+    expect(scheduler.isRunning).toBe(true);
+  });
+
+  // ── Schedule CRUD ──────────────────────────────────────────────────────
+
+  it('creates an ad-hoc schedule', async () => {
+    const schedule = await scheduler.createSchedule({
+      workflowName: 'test-wf',
+      workflowPath: '/workflows/test.yaml',
+      interval: '1h',
+    });
+
+    expect(schedule.id).toMatch(/^sched-adhoc-/);
+    expect(schedule.workflowName).toBe('test-wf');
+    expect(schedule.enabled).toBe(true);
+    expect(schedule.source).toBe('adhoc');
+  });
+
+  it('registers from workflow definition', async () => {
+    const definition = {
+      name: 'nightly-audit',
+      steps: [{ id: 's1', type: 'bash', config: { command: 'echo hi' } }],
+      schedule: { cron: '0 2 * * *' },
+    };
+
+    const schedule = await scheduler.registerFromDefinition(definition, '/workflows/nightly.yaml');
+    expect(schedule).not.toBeNull();
+    expect(schedule!.id).toBe('sched-def-nightly-audit');
+    expect(schedule!.source).toBe('definition');
+    expect(schedule!.cron).toBe('0 2 * * *');
+  });
+
+  it('returns null when definition has no schedule', async () => {
+    const definition = {
+      name: 'manual-wf',
+      steps: [{ id: 's1', type: 'bash', config: { command: 'echo hi' } }],
+    };
+
+    const schedule = await scheduler.registerFromDefinition(definition, '/workflows/manual.yaml');
+    expect(schedule).toBeNull();
+  });
+
+  it('cancels a schedule', async () => {
+    await scheduler.createSchedule({
+      workflowName: 'test-wf',
+      workflowPath: '/path',
+      interval: '1h',
+    });
+
+    const schedules = await scheduler.listSchedules();
+    expect(schedules).toHaveLength(1);
+
+    const cancelled = await scheduler.cancelSchedule(schedules[0].id);
+    expect(cancelled).toBe(true);
+
+    const updated = await scheduler.getSchedule(schedules[0].id);
+    expect(updated!.enabled).toBe(false);
+  });
+
+  it('returns false when cancelling non-existent schedule', async () => {
+    const cancelled = await scheduler.cancelSchedule('nonexistent');
+    expect(cancelled).toBe(false);
+  });
+
+  it('lists all schedules', async () => {
+    await scheduler.createSchedule({ workflowName: 'wf1', workflowPath: '/p1', interval: '1h' });
+    await scheduler.createSchedule({ workflowName: 'wf2', workflowPath: '/p2', cron: '0 * * * *' });
+
+    const schedules = await scheduler.listSchedules();
+    expect(schedules).toHaveLength(2);
+  });
+
+  // ── Polling & Execution ───────────��────────────────────────────────────
+
+  it('executes a due workflow on poll', async () => {
+    // Create a schedule that is already due
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-test', {
+      id: 'sched-test',
+      workflowName: 'test-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      nextRunAt: now - 1000, // already due
+      enabled: true,
+      createdAt: now - 3600_000,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+
+    expect(executor.execute).toHaveBeenCalledWith('test-wf', {}, expect.any(AbortSignal));
+  });
+
+  it('skips disabled schedules', async () => {
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-disabled', {
+      id: 'sched-disabled',
+      workflowName: 'test-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      nextRunAt: now - 1000,
+      enabled: false,
+      createdAt: now,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it('skips schedules not yet due', async () => {
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-future', {
+      id: 'sched-future',
+      workflowName: 'test-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      nextRunAt: now + 60_000, // 1 minute in the future
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it('disables schedule when workflow no longer exists', async () => {
+    (executor.exists as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-deleted', {
+      id: 'sched-deleted',
+      workflowName: 'deleted-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      nextRunAt: now - 1000,
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+
+    expect(executor.execute).not.toHaveBeenCalled();
+    const updated = await scheduler.getSchedule('sched-deleted');
+    expect(updated!.enabled).toBe(false);
+  });
+
+  it('skips expired catch-up runs', async () => {
+    const events: SchedulerEvent[] = [];
+    scheduler.on(e => events.push(e));
+
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-old', {
+      id: 'sched-old',
+      workflowName: 'test-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      nextRunAt: now - 7_200_000, // 2 hours ago — exceeds 1h catch-up window
+      enabled: true,
+      createdAt: now - 86_400_000,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+
+    expect(executor.execute).not.toHaveBeenCalled();
+    expect(events.some(e => e.type === 'schedule:skipped')).toBe(true);
+  });
+
+  it('prevents overlapping executions', async () => {
+    // Make executor hang
+    let resolveExecution: () => void;
+    (executor.execute as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<WorkflowResult>(resolve => {
+        resolveExecution = () => resolve(makeSuccessResult());
+      }),
+    );
+
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-overlap', {
+      id: 'sched-overlap',
+      workflowName: 'slow-wf',
+      workflowPath: '/path',
+      interval: '1m',
+      nextRunAt: now - 1000,
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    });
+
+    // First poll starts execution
+    await scheduler.poll();
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+
+    // Second poll should skip because first is still running
+    await scheduler.poll();
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+
+    // Resolve the first execution
+    resolveExecution!();
+    // Wait for the async execution to complete
+    await new Promise(resolve => setTimeout(resolve, 10));
+  });
+
+  it('respects maxConcurrent limit', async () => {
+    let resolvers: Array<() => void> = [];
+    (executor.execute as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<WorkflowResult>(resolve => {
+        resolvers.push(() => resolve(makeSuccessResult()));
+      }),
+    );
+
+    const now = Date.now();
+    // Create 3 due schedules, but maxConcurrent is 2
+    for (let i = 0; i < 3; i++) {
+      await memory.write('scheduled-workflows', `sched-${i}`, {
+        id: `sched-${i}`,
+        workflowName: `wf-${i}`,
+        workflowPath: '/path',
+        interval: '1h',
+        nextRunAt: now - 1000,
+        enabled: true,
+        createdAt: now,
+        source: 'adhoc',
+      });
+    }
+
+    await scheduler.poll();
+
+    // Only 2 should have been started
+    expect(executor.execute).toHaveBeenCalledTimes(2);
+
+    // Resolve them
+    for (const r of resolvers) r();
+    await new Promise(resolve => setTimeout(resolve, 10));
+  });
+
+  // ── Events ─────────────────────────────────────────────────────────────
+
+  it('emits events during execution', async () => {
+    const events: SchedulerEvent[] = [];
+    scheduler.on(e => events.push(e));
+
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-events', {
+      id: 'sched-events',
+      workflowName: 'test-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      nextRunAt: now - 1000,
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+    // Wait for async execution
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const types = events.map(e => e.type);
+    expect(types).toContain('schedule:due');
+    expect(types).toContain('schedule:started');
+    expect(types).toContain('schedule:completed');
+  });
+
+  it('emits failed event on execution error', async () => {
+    (executor.execute as ReturnType<typeof vi.fn>).mockResolvedValue(makeFailResult());
+
+    const events: SchedulerEvent[] = [];
+    scheduler.on(e => events.push(e));
+
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-fail', {
+      id: 'sched-fail',
+      workflowName: 'fail-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      nextRunAt: now - 1000,
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(events.some(e => e.type === 'schedule:failed')).toBe(true);
+  });
+
+  it('unsubscribes event listener', () => {
+    const events: SchedulerEvent[] = [];
+    const unsub = scheduler.on(e => events.push(e));
+    unsub();
+
+    // No events should be captured after unsub
+    scheduler['emit']({
+      type: 'schedule:due',
+      scheduleId: 'test',
+      workflowName: 'test',
+      message: 'test',
+      timestamp: Date.now(),
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  // ── One-time (at) schedules ────────────────────────────────────────────
+
+  it('auto-disables one-time schedule after execution', async () => {
+    const future = Date.now() - 1000; // already due
+    await memory.write('scheduled-workflows', 'sched-once', {
+      id: 'sched-once',
+      workflowName: 'once-wf',
+      workflowPath: '/path',
+      at: new Date(future).toISOString(),
+      nextRunAt: future,
+      enabled: true,
+      createdAt: Date.now() - 10_000,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const updated = await scheduler.getSchedule('sched-once');
+    expect(updated!.enabled).toBe(false);
+  });
+
+  // ── Execution history ────────────���─────────────────────────────────────
+
+  it('stores execution history', async () => {
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-hist', {
+      id: 'sched-hist',
+      workflowName: 'hist-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      nextRunAt: now - 1000,
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const history = await scheduler.getExecutionHistory('sched-hist');
+    expect(history.length).toBeGreaterThan(0);
+    expect(history[0].scheduleId).toBe('sched-hist');
+    expect(history[0].success).toBe(true);
+  });
+
+  // ── Args passing ─────────────────���─────────────────────────────────────
+
+  it('passes args to workflow executor', async () => {
+    const now = Date.now();
+    await memory.write('scheduled-workflows', 'sched-args', {
+      id: 'sched-args',
+      workflowName: 'args-wf',
+      workflowPath: '/path',
+      interval: '1h',
+      args: { target: './src' },
+      nextRunAt: now - 1000,
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    });
+
+    await scheduler.poll();
+
+    expect(executor.execute).toHaveBeenCalledWith('args-wf', { target: './src' }, expect.any(AbortSignal));
+  });
+});

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -95,6 +95,10 @@ export type {
   ParsedWorkflow,
 } from './types/workflow-definition.types.js';
 
+export type {
+  ScheduleDefinition,
+} from './scheduler/schedule.types.js';
+
 export { parseYaml, parseJson, parseWorkflow } from './schema/parser.js';
 export { validateWorkflowDefinition, resolveArguments, type ValidatorOptions } from './schema/validator.js';
 
@@ -167,3 +171,34 @@ export {
   type WorkflowInfo,
   type WorkflowListEntry,
 } from './registry/workflow-registry.js';
+
+// ============================================================================
+// Scheduler (cron, interval, one-time scheduling)
+// ============================================================================
+
+export {
+  parseCron,
+  parseInterval,
+  parseAt,
+  computeNextRun,
+  nextRunFromCron,
+  nextRunFromInterval,
+  nextRunFromAt,
+  validateSchedule,
+  type ParsedCron,
+  type NextRunInput,
+} from './scheduler/cron-parser.js';
+
+export {
+  WorkflowScheduler,
+  type WorkflowExecutor,
+  type SchedulerEvent,
+  type SchedulerEventType,
+  type SchedulerListener,
+} from './scheduler/scheduler.js';
+
+export type {
+  WorkflowSchedule,
+  ScheduleExecution,
+  SchedulerOptions,
+} from './scheduler/schedule.types.js';

--- a/src/packages/workflows/src/scheduler/cron-parser.ts
+++ b/src/packages/workflows/src/scheduler/cron-parser.ts
@@ -1,0 +1,303 @@
+/**
+ * Cron & Interval Parser
+ *
+ * Parses standard 5-field cron expressions, human-readable intervals,
+ * and ISO 8601 datetimes. Computes the next run time from a reference date.
+ */
+
+import type { ValidationError } from '../types/step-command.types.js';
+import type { ScheduleDefinition } from './schedule.types.js';
+
+// ============================================================================
+// Interval Parsing
+// ============================================================================
+
+const INTERVAL_PATTERN = /^(\d+)(s|m|h|d)$/;
+
+const INTERVAL_MULTIPLIERS: Record<string, number> = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+/**
+ * Parse an interval string like "6h", "30m", "1d", "90s" into milliseconds.
+ * Returns null if the format is invalid.
+ */
+export function parseInterval(interval: string): number | null {
+  const match = interval.trim().match(INTERVAL_PATTERN);
+  if (!match) return null;
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  if (value <= 0) return null;
+  return value * INTERVAL_MULTIPLIERS[unit];
+}
+
+/**
+ * Compute next run time for an interval schedule.
+ */
+export function nextRunFromInterval(intervalMs: number, lastRunAt: number | undefined, now: number): number {
+  if (!lastRunAt) return now;
+  const next = lastRunAt + intervalMs;
+  return next <= now ? now : next;
+}
+
+// ============================================================================
+// ISO 8601 "at" Parsing
+// ============================================================================
+
+/**
+ * Parse an ISO 8601 datetime string. Returns epoch ms or null if invalid.
+ */
+export function parseAt(at: string): number | null {
+  const ts = Date.parse(at);
+  if (isNaN(ts)) return null;
+  return ts;
+}
+
+/**
+ * Compute next run time for a one-time schedule. Returns the timestamp
+ * if it hasn't run yet and is in the future (or within catch-up window),
+ * or null if already executed or expired.
+ */
+export function nextRunFromAt(atMs: number, lastRunAt: number | undefined): number | null {
+  if (lastRunAt) return null; // already ran
+  return atMs;
+}
+
+// ============================================================================
+// 5-Field Cron Parsing
+// ============================================================================
+
+/**
+ * Parsed cron expression with expanded field values.
+ */
+export interface ParsedCron {
+  readonly minutes: ReadonlySet<number>;
+  readonly hours: ReadonlySet<number>;
+  readonly daysOfMonth: ReadonlySet<number>;
+  readonly months: ReadonlySet<number>;
+  readonly daysOfWeek: ReadonlySet<number>;
+}
+
+const FIELD_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0, 59],   // minute
+  [0, 23],   // hour
+  [1, 31],   // day of month
+  [1, 12],   // month
+  [0, 6],    // day of week (0=Sunday)
+];
+
+/**
+ * Parse a standard 5-field cron expression.
+ * Supports: *, ranges (1-5), lists (1,3,5), steps (star/5, 1-10/2).
+ * Returns null if invalid.
+ */
+export function parseCron(expression: string): ParsedCron | null {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) return null;
+
+  const parsed: Set<number>[] = [];
+  for (let i = 0; i < 5; i++) {
+    const values = parseField(fields[i], FIELD_RANGES[i][0], FIELD_RANGES[i][1]);
+    if (!values) return null;
+    parsed.push(values);
+  }
+
+  return {
+    minutes: parsed[0],
+    hours: parsed[1],
+    daysOfMonth: parsed[2],
+    months: parsed[3],
+    daysOfWeek: parsed[4],
+  };
+}
+
+function parseField(field: string, min: number, max: number): Set<number> | null {
+  const values = new Set<number>();
+
+  for (const part of field.split(',')) {
+    const stepMatch = part.match(/^(.+)\/(\d+)$/);
+    let range: string;
+    let step = 1;
+
+    if (stepMatch) {
+      range = stepMatch[1];
+      step = parseInt(stepMatch[2], 10);
+      if (step <= 0) return null;
+    } else {
+      range = part;
+    }
+
+    if (range === '*') {
+      for (let v = min; v <= max; v += step) values.add(v);
+    } else if (range.includes('-')) {
+      const [startStr, endStr] = range.split('-');
+      const start = parseInt(startStr, 10);
+      const end = parseInt(endStr, 10);
+      if (isNaN(start) || isNaN(end) || start < min || end > max || start > end) return null;
+      for (let v = start; v <= end; v += step) values.add(v);
+    } else {
+      const val = parseInt(range, 10);
+      if (isNaN(val) || val < min || val > max) return null;
+      values.add(val);
+    }
+  }
+
+  return values.size > 0 ? values : null;
+}
+
+/**
+ * Compute the next run time for a cron schedule after `after` (epoch ms).
+ * Searches up to 366 days ahead. Returns epoch ms or null if no match found.
+ */
+export function nextRunFromCron(cron: ParsedCron, after: number): number | null {
+  const d = new Date(after);
+  // Start from the next minute
+  d.setSeconds(0, 0);
+  d.setMinutes(d.getMinutes() + 1);
+
+  const limit = after + 366 * 86_400_000; // 1 year max search
+
+  while (d.getTime() <= limit) {
+    const month = d.getMonth() + 1; // 1-12
+    if (!cron.months.has(month)) {
+      // Skip to next month
+      d.setMonth(d.getMonth() + 1, 1);
+      d.setHours(0, 0, 0, 0);
+      continue;
+    }
+
+    const dayOfMonth = d.getDate();
+    const dayOfWeek = d.getDay();
+    if (!cron.daysOfMonth.has(dayOfMonth) || !cron.daysOfWeek.has(dayOfWeek)) {
+      // Skip to next day
+      d.setDate(d.getDate() + 1);
+      d.setHours(0, 0, 0, 0);
+      continue;
+    }
+
+    const hour = d.getHours();
+    if (!cron.hours.has(hour)) {
+      d.setHours(d.getHours() + 1, 0, 0, 0);
+      continue;
+    }
+
+    const minute = d.getMinutes();
+    if (!cron.minutes.has(minute)) {
+      d.setMinutes(d.getMinutes() + 1, 0, 0);
+      continue;
+    }
+
+    return d.getTime();
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Unified Next-Run Computation
+// ============================================================================
+
+export type NextRunInput = Pick<ScheduleDefinition, 'cron' | 'interval' | 'at'> & {
+  lastRunAt?: number;
+};
+
+// Small LRU-ish cache to avoid re-parsing the same cron expression on every poll tick.
+const cronCache = new Map<string, ParsedCron>();
+const CRON_CACHE_MAX = 64;
+
+function getCachedCron(expression: string): ParsedCron | null {
+  const cached = cronCache.get(expression);
+  if (cached) return cached;
+  const parsed = parseCron(expression);
+  if (!parsed) return null;
+  if (cronCache.size >= CRON_CACHE_MAX) {
+    // Evict oldest entry
+    const firstKey = cronCache.keys().next().value;
+    if (firstKey !== undefined) cronCache.delete(firstKey);
+  }
+  cronCache.set(expression, parsed);
+  return parsed;
+}
+
+/**
+ * Compute the next run time given any schedule type.
+ * Returns epoch ms or null if no future run is possible.
+ */
+export function computeNextRun(input: NextRunInput, now: number = Date.now()): number | null {
+  if (input.cron) {
+    const parsed = getCachedCron(input.cron);
+    if (!parsed) return null;
+    const after = input.lastRunAt ?? now - 60_000; // start searching from now
+    return nextRunFromCron(parsed, after > now ? after : now - 60_000);
+  }
+
+  if (input.interval) {
+    const ms = parseInterval(input.interval);
+    if (!ms) return null;
+    return nextRunFromInterval(ms, input.lastRunAt, now);
+  }
+
+  if (input.at) {
+    const atMs = parseAt(input.at);
+    if (!atMs) return null;
+    return nextRunFromAt(atMs, input.lastRunAt);
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validate a schedule definition, returning errors for invalid fields.
+ */
+export function validateSchedule(
+  schedule: ScheduleDefinition,
+  path: string,
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const types = [schedule.cron, schedule.interval, schedule.at].filter(v => v !== undefined);
+
+  if (types.length === 0) {
+    errors.push({ path, message: 'schedule must specify exactly one of: cron, interval, at' });
+    return errors;
+  }
+  if (types.length > 1) {
+    errors.push({ path, message: 'schedule must specify exactly one of: cron, interval, at (found multiple)' });
+  }
+
+  if (schedule.cron !== undefined) {
+    if (typeof schedule.cron !== 'string') {
+      errors.push({ path: `${path}.cron`, message: 'cron must be a string' });
+    } else if (!parseCron(schedule.cron)) {
+      errors.push({ path: `${path}.cron`, message: `invalid cron expression: "${schedule.cron}"` });
+    }
+  }
+
+  if (schedule.interval !== undefined) {
+    if (typeof schedule.interval !== 'string') {
+      errors.push({ path: `${path}.interval`, message: 'interval must be a string' });
+    } else if (!parseInterval(schedule.interval)) {
+      errors.push({ path: `${path}.interval`, message: `invalid interval: "${schedule.interval}". Use format: <number><s|m|h|d> (e.g., "6h", "30m")` });
+    }
+  }
+
+  if (schedule.at !== undefined) {
+    if (typeof schedule.at !== 'string') {
+      errors.push({ path: `${path}.at`, message: 'at must be a string' });
+    } else if (parseAt(schedule.at) === null) {
+      errors.push({ path: `${path}.at`, message: `invalid ISO 8601 datetime: "${schedule.at}"` });
+    }
+  }
+
+  if (schedule.enabled !== undefined && typeof schedule.enabled !== 'boolean') {
+    errors.push({ path: `${path}.enabled`, message: 'enabled must be a boolean' });
+  }
+
+  return errors;
+}

--- a/src/packages/workflows/src/scheduler/index.ts
+++ b/src/packages/workflows/src/scheduler/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Scheduler Module
+ *
+ * Scheduled workflow execution: cron, interval, and one-time scheduling.
+ */
+
+export type {
+  ScheduleDefinition,
+  WorkflowSchedule,
+  ScheduleExecution,
+  SchedulerOptions,
+} from './schedule.types.js';
+
+export {
+  parseCron,
+  parseInterval,
+  parseAt,
+  computeNextRun,
+  nextRunFromCron,
+  nextRunFromInterval,
+  nextRunFromAt,
+  validateSchedule,
+  type ParsedCron,
+  type NextRunInput,
+} from './cron-parser.js';
+
+export {
+  WorkflowScheduler,
+  type WorkflowExecutor,
+  type SchedulerEvent,
+  type SchedulerEventType,
+  type SchedulerListener,
+} from './scheduler.js';

--- a/src/packages/workflows/src/scheduler/schedule.types.ts
+++ b/src/packages/workflows/src/scheduler/schedule.types.ts
@@ -1,0 +1,74 @@
+/**
+ * Workflow Schedule Types
+ *
+ * Types for scheduled workflow execution — cron, interval, and one-time scheduling.
+ */
+
+// ============================================================================
+// Schedule Definition (in workflow YAML/JSON)
+// ============================================================================
+
+/**
+ * Schedule block for a workflow definition.
+ * Exactly one of `cron`, `interval`, or `at` must be specified.
+ */
+export interface ScheduleDefinition {
+  /** Standard 5-field cron expression (minute hour day-of-month month day-of-week). */
+  readonly cron?: string;
+  /** Interval string: e.g., "6h", "30m", "1d", "90s". */
+  readonly interval?: string;
+  /** ISO 8601 datetime for one-time execution. */
+  readonly at?: string;
+  /** Whether the schedule is enabled (default: true). */
+  readonly enabled?: boolean;
+}
+
+// ============================================================================
+// Schedule Record (persisted in memory DB)
+// ============================================================================
+
+export interface WorkflowSchedule {
+  readonly id: string;
+  readonly workflowName: string;
+  readonly workflowPath: string;
+  readonly cron?: string;
+  readonly interval?: string;
+  readonly at?: string;
+  readonly args?: Record<string, unknown>;
+  readonly lastRunAt?: number;
+  readonly nextRunAt: number;
+  readonly enabled: boolean;
+  readonly createdAt: number;
+  /** Source: 'definition' (from YAML schedule block) or 'adhoc' (CLI-created). */
+  readonly source: 'definition' | 'adhoc';
+}
+
+// ============================================================================
+// Execution Record (audit trail)
+// ============================================================================
+
+export interface ScheduleExecution {
+  readonly id: string;
+  readonly scheduleId: string;
+  readonly workflowName: string;
+  readonly startedAt: number;
+  readonly completedAt?: number;
+  readonly success?: boolean;
+  readonly error?: string;
+  readonly workflowId: string;
+  readonly duration?: number;
+}
+
+// ============================================================================
+// Scheduler Options
+// ============================================================================
+
+export interface SchedulerOptions {
+  /** Poll interval in milliseconds (default: 60000 — 1 minute). */
+  readonly pollIntervalMs?: number;
+  /** Maximum concurrent scheduled workflow executions (default: 2). */
+  readonly maxConcurrent?: number;
+  /** Catch-up window: max age in ms for missed runs to still execute (default: 3600000 — 1 hour). */
+  readonly catchUpWindowMs?: number;
+}
+

--- a/src/packages/workflows/src/scheduler/scheduler.ts
+++ b/src/packages/workflows/src/scheduler/scheduler.ts
@@ -1,0 +1,435 @@
+/**
+ * Workflow Scheduler
+ *
+ * Manages scheduled workflow execution: polls for due workflows, prevents
+ * overlap, tracks execution history, and handles catch-up after restarts.
+ */
+
+import type { MemoryAccessor } from '../types/step-command.types.js';
+import type { WorkflowDefinition } from '../types/workflow-definition.types.js';
+import type { WorkflowResult } from '../types/runner.types.js';
+import type {
+  WorkflowSchedule,
+  ScheduleExecution,
+  SchedulerOptions,
+} from './schedule.types.js';
+import { computeNextRun } from './cron-parser.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+const DEFAULT_MAX_CONCURRENT = 2;
+const DEFAULT_CATCH_UP_WINDOW_MS = 3_600_000; // 1 hour
+const NAMESPACE_SCHEDULES = 'scheduled-workflows';
+const NAMESPACE_EXECUTIONS = 'schedule-executions';
+
+// ============================================================================
+// Executor Interface (injected by the daemon/CLI)
+// ============================================================================
+
+export interface WorkflowExecutor {
+  /** Execute a workflow by name with given args. Returns the result. */
+  execute(workflowName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<WorkflowResult>;
+  /** Check if a workflow definition exists. */
+  exists(workflowName: string): boolean;
+}
+
+// ============================================================================
+// Scheduler Events
+// ============================================================================
+
+export type SchedulerEventType =
+  | 'schedule:due'
+  | 'schedule:started'
+  | 'schedule:completed'
+  | 'schedule:failed'
+  | 'schedule:skipped'
+  | 'schedule:disabled'
+  | 'schedule:catchup';
+
+export interface SchedulerEvent {
+  readonly type: SchedulerEventType;
+  readonly scheduleId: string;
+  readonly workflowName: string;
+  readonly message: string;
+  readonly timestamp: number;
+}
+
+export type SchedulerListener = (event: SchedulerEvent) => void;
+
+// ============================================================================
+// WorkflowScheduler
+// ============================================================================
+
+export class WorkflowScheduler {
+  private readonly memory: MemoryAccessor;
+  private readonly executor: WorkflowExecutor;
+  private readonly pollIntervalMs: number;
+  private readonly maxConcurrent: number;
+  private readonly catchUpWindowMs: number;
+
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly runningWorkflows = new Map<string, AbortController>();
+  private readonly inflightPromises = new Map<string, Promise<void>>();
+  private readonly listeners: SchedulerListener[] = [];
+
+  constructor(
+    memory: MemoryAccessor,
+    executor: WorkflowExecutor,
+    options: SchedulerOptions = {},
+  ) {
+    this.memory = memory;
+    this.executor = executor;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.maxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+    this.catchUpWindowMs = options.catchUpWindowMs ?? DEFAULT_CATCH_UP_WINDOW_MS;
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  /**
+   * Start the polling loop. Performs an initial poll immediately.
+   */
+  start(): void {
+    if (this.pollTimer) return;
+    this.poll(); // immediate first poll
+    this.pollTimer = setInterval(() => this.poll(), this.pollIntervalMs);
+  }
+
+  /**
+   * Stop the polling loop and cancel all running workflows.
+   */
+  async stop(): Promise<void> {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    for (const [, controller] of this.runningWorkflows) {
+      controller.abort();
+    }
+    // Wait for in-flight executions to settle before clearing state
+    if (this.inflightPromises.size > 0) {
+      await Promise.allSettled([...this.inflightPromises.values()]);
+    }
+    this.runningWorkflows.clear();
+    this.inflightPromises.clear();
+  }
+
+  get isRunning(): boolean {
+    return this.pollTimer !== null;
+  }
+
+  // ── Event Listeners ──────────────────────────────────────────────────────
+
+  on(listener: SchedulerListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const idx = this.listeners.indexOf(listener);
+      if (idx >= 0) this.listeners.splice(idx, 1);
+    };
+  }
+
+  private emit(event: SchedulerEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // Prevent a throwing listener from breaking the scheduler loop
+      }
+    }
+  }
+
+  // ── Schedule CRUD ────────────────────────────────────────────────────────
+
+  /**
+   * Register a schedule from a workflow definition's `schedule` block.
+   */
+  async registerFromDefinition(
+    definition: WorkflowDefinition,
+    workflowPath: string,
+  ): Promise<WorkflowSchedule | null> {
+    if (!definition.schedule) return null;
+    const { cron, interval, at, enabled } = definition.schedule;
+
+    const now = Date.now();
+    const nextRunAt = computeNextRun({ cron, interval, at }, now);
+
+    if (nextRunAt === null) return null;
+
+    const record: WorkflowSchedule = {
+      id: `sched-def-${definition.name}`,
+      workflowName: definition.name,
+      workflowPath,
+      cron,
+      interval,
+      at,
+      nextRunAt,
+      enabled: enabled !== false,
+      createdAt: now,
+      source: 'definition',
+    };
+
+    await this.memory.write(NAMESPACE_SCHEDULES, record.id, record);
+    return record;
+  }
+
+  /**
+   * Create an ad-hoc schedule via CLI.
+   */
+  async createSchedule(params: {
+    workflowName: string;
+    workflowPath: string;
+    cron?: string;
+    interval?: string;
+    at?: string;
+    args?: Record<string, unknown>;
+  }): Promise<WorkflowSchedule> {
+    const now = Date.now();
+    const nextRunAt = computeNextRun({
+      cron: params.cron,
+      interval: params.interval,
+      at: params.at,
+    }, now);
+
+    if (nextRunAt === null) {
+      throw new Error('Could not compute next run time from provided schedule');
+    }
+
+    const id = `sched-adhoc-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const record: WorkflowSchedule = {
+      id,
+      workflowName: params.workflowName,
+      workflowPath: params.workflowPath,
+      cron: params.cron,
+      interval: params.interval,
+      at: params.at,
+      args: params.args,
+      nextRunAt,
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    };
+
+    await this.memory.write(NAMESPACE_SCHEDULES, record.id, record);
+    return record;
+  }
+
+  /**
+   * Cancel (disable) a schedule by ID.
+   */
+  async cancelSchedule(scheduleId: string): Promise<boolean> {
+    const record = await this.getSchedule(scheduleId);
+    if (!record) return false;
+
+    const updated: WorkflowSchedule = { ...record, enabled: false };
+    await this.memory.write(NAMESPACE_SCHEDULES, scheduleId, updated);
+
+    this.emit({
+      type: 'schedule:disabled',
+      scheduleId,
+      workflowName: record.workflowName,
+      message: `Schedule ${scheduleId} disabled`,
+      timestamp: Date.now(),
+    });
+
+    return true;
+  }
+
+  /**
+   * Get a single schedule by ID.
+   */
+  async getSchedule(scheduleId: string): Promise<WorkflowSchedule | null> {
+    const raw = await this.memory.read(NAMESPACE_SCHEDULES, scheduleId);
+    return raw as WorkflowSchedule | null;
+  }
+
+  /**
+   * List all schedules.
+   */
+  async listSchedules(): Promise<WorkflowSchedule[]> {
+    const results = await this.memory.search(NAMESPACE_SCHEDULES, '*');
+    return results.map(r => r.value as WorkflowSchedule);
+  }
+
+  /**
+   * Get execution history for a schedule.
+   */
+  async getExecutionHistory(scheduleId: string, limit = 10): Promise<ScheduleExecution[]> {
+    const results = await this.memory.search(NAMESPACE_EXECUTIONS, scheduleId);
+    return results
+      .map(r => r.value as ScheduleExecution)
+      .sort((a, b) => b.startedAt - a.startedAt)
+      .slice(0, limit);
+  }
+
+  // ── Polling ──────────────────────────────────────────────────────────────
+
+  /**
+   * Poll for due workflows and execute them.
+   * This is the core method called by the polling loop.
+   */
+  async poll(): Promise<void> {
+    const schedules = await this.listSchedules();
+    const now = Date.now();
+
+    for (const schedule of schedules) {
+      if (!schedule.enabled) continue;
+
+      // Auto-disable if workflow no longer exists (cancelSchedule emits the event)
+      if (!this.executor.exists(schedule.workflowName)) {
+        await this.cancelSchedule(schedule.id);
+        continue;
+      }
+
+      // Not due yet
+      if (schedule.nextRunAt > now) continue;
+
+      // Catch-up check: skip if missed run is too old
+      if (now - schedule.nextRunAt > this.catchUpWindowMs) {
+        this.emit({
+          type: 'schedule:skipped',
+          scheduleId: schedule.id,
+          workflowName: schedule.workflowName,
+          message: `Missed run is older than catch-up window (${this.catchUpWindowMs}ms) — skipping`,
+          timestamp: now,
+        });
+        await this.advanceNextRun(schedule, now);
+        continue;
+      }
+
+      // Overlap check: skip if this workflow is still running
+      if (this.runningWorkflows.has(schedule.id)) {
+        this.emit({
+          type: 'schedule:skipped',
+          scheduleId: schedule.id,
+          workflowName: schedule.workflowName,
+          message: 'Prior run still active — skipping overlapping execution',
+          timestamp: now,
+        });
+        continue;
+      }
+
+      // Concurrency check
+      if (this.runningWorkflows.size >= this.maxConcurrent) {
+        continue; // will pick up on next poll
+      }
+
+      this.emit({
+        type: 'schedule:due',
+        scheduleId: schedule.id,
+        workflowName: schedule.workflowName,
+        message: `Workflow "${schedule.workflowName}" is due for execution`,
+        timestamp: now,
+      });
+
+      const promise = this.executeScheduled(schedule, now).catch(() => {
+        // Errors are already handled inside executeScheduled; suppress unhandled rejection
+      });
+      this.inflightPromises.set(schedule.id, promise);
+    }
+  }
+
+  // ── Execution ────────────────────────────────────────────────────────────
+
+  private async executeScheduled(schedule: WorkflowSchedule, now: number): Promise<void> {
+    const controller = new AbortController();
+    this.runningWorkflows.set(schedule.id, controller);
+
+    const executionId = `exec-${schedule.id}-${now}`;
+    const execution: ScheduleExecution = {
+      id: executionId,
+      scheduleId: schedule.id,
+      workflowName: schedule.workflowName,
+      startedAt: now,
+      workflowId: `scheduled-${schedule.workflowName}-${now}`,
+    };
+
+    await this.memory.write(NAMESPACE_EXECUTIONS, executionId, execution);
+
+    this.emit({
+      type: 'schedule:started',
+      scheduleId: schedule.id,
+      workflowName: schedule.workflowName,
+      message: `Started scheduled execution ${executionId}`,
+      timestamp: now,
+    });
+
+    try {
+      const result = await this.executor.execute(
+        schedule.workflowName,
+        schedule.args ?? {},
+        controller.signal,
+      );
+
+      const completedAt = Date.now();
+      const completedExecution: ScheduleExecution = {
+        ...execution,
+        completedAt,
+        success: result.success,
+        error: result.success ? undefined : result.errors.map(e => e.message).join('; '),
+        duration: completedAt - now,
+      };
+      await this.memory.write(NAMESPACE_EXECUTIONS, executionId, completedExecution);
+
+      this.emit({
+        type: result.success ? 'schedule:completed' : 'schedule:failed',
+        scheduleId: schedule.id,
+        workflowName: schedule.workflowName,
+        message: result.success
+          ? `Completed in ${completedExecution.duration}ms`
+          : `Failed: ${completedExecution.error}`,
+        timestamp: completedAt,
+      });
+    } catch (err) {
+      const completedAt = Date.now();
+      const failedExecution: ScheduleExecution = {
+        ...execution,
+        completedAt,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+        duration: completedAt - now,
+      };
+      await this.memory.write(NAMESPACE_EXECUTIONS, executionId, failedExecution);
+
+      this.emit({
+        type: 'schedule:failed',
+        scheduleId: schedule.id,
+        workflowName: schedule.workflowName,
+        message: `Error: ${failedExecution.error}`,
+        timestamp: completedAt,
+      });
+    } finally {
+      this.runningWorkflows.delete(schedule.id);
+      this.inflightPromises.delete(schedule.id);
+      await this.advanceNextRun(schedule, Date.now());
+    }
+  }
+
+  /**
+   * Advance the schedule's nextRunAt after execution or skip.
+   * For one-time (`at`) schedules, auto-disables after execution.
+   */
+  private async advanceNextRun(schedule: WorkflowSchedule, now: number): Promise<void> {
+    // One-time schedule: disable after run
+    if (schedule.at) {
+      const updated: WorkflowSchedule = { ...schedule, enabled: false, lastRunAt: now };
+      await this.memory.write(NAMESPACE_SCHEDULES, schedule.id, updated);
+      return;
+    }
+
+    const nextRunAt = computeNextRun({
+      cron: schedule.cron,
+      interval: schedule.interval,
+      lastRunAt: now,
+    }, now);
+
+    const updated: WorkflowSchedule = {
+      ...schedule,
+      lastRunAt: now,
+      nextRunAt: nextRunAt ?? now + this.pollIntervalMs, // fallback shouldn't happen
+    };
+    await this.memory.write(NAMESPACE_SCHEDULES, schedule.id, updated);
+  }
+}

--- a/src/packages/workflows/src/schema/validator.ts
+++ b/src/packages/workflows/src/schema/validator.ts
@@ -20,6 +20,7 @@ import type {
 import { validateStepCapabilities, isValidMofloLevel, compareMofloLevels } from '../core/capability-validator.js';
 import { MOFLO_LEVEL_ORDER } from '../types/step-command.types.js';
 import type { MofloLevel } from '../types/step-command.types.js';
+import { validateSchedule } from '../scheduler/cron-parser.js';
 
 const VALID_ARG_TYPES: readonly ArgumentType[] = ['string', 'number', 'boolean', 'string[]'];
 
@@ -47,6 +48,9 @@ export function validateWorkflowDefinition(
     });
   }
 
+  if (def.schedule) {
+    errors.push(...validateSchedule(def.schedule, 'schedule'));
+  }
   if (def.arguments) {
     validateArguments(def.arguments, errors);
   }

--- a/src/packages/workflows/src/types/workflow-definition.types.ts
+++ b/src/packages/workflows/src/types/workflow-definition.types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { CapabilityType, MofloLevel } from './step-command.types.js';
+import type { ScheduleDefinition } from '../scheduler/schedule.types.js';
 
 // ============================================================================
 // Argument Definitions
@@ -51,6 +52,8 @@ export interface WorkflowDefinition {
   readonly steps: readonly StepDefinition[];
   /** Default MoFlo integration level for all steps (can be narrowed per-step). */
   readonly mofloLevel?: MofloLevel;
+  /** Schedule for automatic execution (cron, interval, or one-time). */
+  readonly schedule?: ScheduleDefinition;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add `schedule` block to workflow YAML definitions (cron, interval, one-time `at`)
- `WorkflowScheduler` service: polls for due workflows, prevents overlap, handles catch-up after restart
- 5-field cron parser with hierarchical skip optimization and bounded LRU cache
- Interval parsing (`6h`, `30m`, `1d`, `90s`) and ISO 8601 one-time scheduling
- Execution history tracking for audit, auto-disable for one-time and deleted workflows
- Schedule validation integrated into `validateWorkflowDefinition`

## Changes
- **New module**: `src/packages/workflows/src/scheduler/` (4 files)
  - `schedule.types.ts` — `ScheduleDefinition`, `WorkflowSchedule`, `ScheduleExecution`
  - `cron-parser.ts` — `parseCron`, `parseInterval`, `parseAt`, `computeNextRun`, `validateSchedule`
  - `scheduler.ts` — `WorkflowScheduler` class with poll loop, CRUD, events, overlap/catch-up
  - `index.ts` — re-exports
- **Modified**: `workflow-definition.types.ts` — added `schedule?: ScheduleDefinition`
- **Modified**: `validator.ts` — validates schedule blocks
- **Modified**: `index.ts` — exports scheduler module

## Testing
- [x] 66 new tests in `scheduler.test.ts`
- [x] All 5499 existing tests pass (3 pre-existing credential failures only)
- [x] Build passes cleanly
- [x] Code reviewed via /simplify (3-agent review, 9 fixes applied)

Closes #117

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)