### PR TITLE
fix(gates): harden TaskCreate gate, reword messages, add /simplify wrapper

### DIFF
--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -1,0 +1,51 @@
+---
+description: Review changed code for reuse, quality, and efficiency, then fix any issues found.
+---
+
+# /simplify — Gate-Compliant Code Review
+
+Review all changed files for reuse opportunities, code quality, and efficiency improvements.
+
+## Prerequisites (MANDATORY — do these FIRST)
+
+1. **Memory search**: Search for relevant patterns before reviewing
+```
+mcp__moflo__memory_search — query: "code quality patterns", namespace: "patterns"
+```
+
+2. **Create task**: Track the simplification work
+```
+TaskCreate — subject: "🔍 [Reviewer] Simplify changed code", description: "Review changed files for reuse, quality, and efficiency"
+```
+
+## Execution
+
+After prerequisites are satisfied, get the list of changed files:
+
+```bash
+git diff --name-only HEAD~1
+```
+
+Then launch 3 reviewer agents **in parallel** (single message, multiple Agent tool calls):
+
+### Agent 1: Reuse Reviewer
+```
+Agent — name: "reuse-reviewer", prompt: "Review these changed files for code reuse opportunities. Look for: duplicated logic that could use existing utilities, patterns already solved elsewhere in the codebase, opportunities to extract shared helpers. Files: $CHANGED_FILES", subagent_type: "reviewer"
+```
+
+### Agent 2: Quality Reviewer
+```
+Agent — name: "quality-reviewer", prompt: "Review these changed files for code quality issues. Look for: unclear naming, overly complex logic, missing error handling at system boundaries, potential bugs, consistency with existing patterns. Files: $CHANGED_FILES", subagent_type: "reviewer"
+```
+
+### Agent 3: Efficiency Reviewer
+```
+Agent — name: "efficiency-reviewer", prompt: "Review these changed files for efficiency improvements. Look for: unnecessary allocations, O(n^2) where O(n) is possible, redundant operations, opportunities to batch or cache. Files: $CHANGED_FILES", subagent_type: "reviewer"
+```
+
+## Post-Review
+
+1. Collect findings from all 3 reviewers
+2. Apply fixes that preserve ALL existing functionality — no behavior changes
+3. If fixes were made, re-run tests to confirm nothing broke
+4. If tests fail after fixes, revert the simplification changes

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -54,15 +54,15 @@ var TASK_RE = /\b(fix|bug|error|implement|add|create|build|write|refactor|debug|
 switch (command) {
   case 'check-before-agent': {
     var s = readState();
-    // Hard gate: memory must be searched
-    if (config.memory_first && s.memoryRequired && !s.memorySearched) {
-      process.stderr.write('BLOCKED: Search memory (mcp__moflo__memory_search) before spawning agents.\n');
+    // Hard gate: TaskCreate must be called before agent spawn
+    if (config.task_create_first && !s.tasksCreated) {
+      process.stderr.write('Gate policy: TaskCreate required before agent spawn.\n');
       process.exit(2);
     }
-    // Soft gate: TaskCreate recommended but not blocking
-    // (TaskCreate PostToolUse doesn't fire in Claude Code, so we can't track it reliably)
-    if (config.task_create_first && !s.tasksCreated) {
-      process.stdout.write('REMINDER: Use TaskCreate before spawning agents. Task tool is blocked until then.\n');
+    // Hard gate: memory must be searched before agent spawn
+    if (config.memory_first && s.memoryRequired && !s.memorySearched) {
+      process.stderr.write('Gate policy: memory search required before agent spawn.\n');
+      process.exit(2);
     }
     break;
   }
@@ -72,7 +72,7 @@ switch (command) {
     if (s.memorySearched || !s.memoryRequired) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".\n');
+    process.stderr.write('Gate policy: memory search required before file exploration.\n');
     process.exit(2);
     break; // unreachable but prevents fall-through lint warnings
   }
@@ -85,7 +85,7 @@ switch (command) {
     // NOT exempt: .claude/guidance/ (guidance files must require memory search)
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before reading files. Use mcp__moflo__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".\n');
+    process.stderr.write('Gate policy: memory search required before reading files.\n');
     process.exit(2);
     break; // unreachable but prevents fall-through lint warnings
   }

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -54,15 +54,15 @@ var TASK_RE = /\b(fix|bug|error|implement|add|create|build|write|refactor|debug|
 switch (command) {
   case 'check-before-agent': {
     var s = readState();
-    // Hard gate: memory must be searched
-    if (config.memory_first && s.memoryRequired && !s.memorySearched) {
-      process.stderr.write('BLOCKED: Search memory (mcp__moflo__memory_search) before spawning agents.\n');
+    // Hard gate: TaskCreate must be called before agent spawn
+    if (config.task_create_first && !s.tasksCreated) {
+      process.stderr.write('Gate policy: TaskCreate required before agent spawn.\n');
       process.exit(2);
     }
-    // Soft gate: TaskCreate recommended but not blocking
-    // (TaskCreate PostToolUse doesn't fire in Claude Code, so we can't track it reliably)
-    if (config.task_create_first && !s.tasksCreated) {
-      process.stdout.write('REMINDER: Use TaskCreate before spawning agents. Task tool is blocked until then.\n');
+    // Hard gate: memory must be searched before agent spawn
+    if (config.memory_first && s.memoryRequired && !s.memorySearched) {
+      process.stderr.write('Gate policy: memory search required before agent spawn.\n');
+      process.exit(2);
     }
     break;
   }
@@ -72,7 +72,7 @@ switch (command) {
     if (s.memorySearched || !s.memoryRequired) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".\n');
+    process.stderr.write('Gate policy: memory search required before file exploration.\n');
     process.exit(2);
     break; // unreachable but prevents fall-through lint warnings
   }
@@ -85,7 +85,7 @@ switch (command) {
     // NOT exempt: .claude/guidance/ (guidance files must require memory search)
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before reading files. Use mcp__moflo__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".\n');
+    process.stderr.write('Gate policy: memory search required before reading files.\n');
     process.exit(2);
     break; // unreachable but prevents fall-through lint warnings
   }

--- a/src/packages/cli/src/services/workflow-gate.ts
+++ b/src/packages/cli/src/services/workflow-gate.ts
@@ -176,17 +176,19 @@ export class WorkflowGateService {
 
     const state = this.readState();
 
+    // Hard gate: TaskCreate must be called before agent spawn
     if (this.config.task_create_first && !state.tasksCreated) {
       return {
         allowed: false,
-        message: 'BLOCKED: Call TaskCreate before spawning agents.',
+        message: 'Gate policy: TaskCreate required before agent spawn.',
       };
     }
 
-    if (this.config.memory_first && !state.memorySearched) {
+    // Hard gate: memory must be searched before agent spawn
+    if (this.config.memory_first && state.memoryRequired && !state.memorySearched) {
       return {
         allowed: false,
-        message: 'BLOCKED: Search memory (mcp__moflo__memory_search) before spawning agents.',
+        message: 'Gate policy: memory search required before agent spawn.',
       };
     }
 
@@ -228,7 +230,7 @@ export class WorkflowGateService {
     if (now - lastBlocked > 2000) {
       state.lastBlockedAt = new Date(now).toISOString();
       this.writeState(state);
-      message = 'BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search with namespace "code-map", "patterns", "knowledge", or "guidance".';
+      message = 'Gate policy: memory search required before file exploration.';
     }
 
     return { allowed: false, message };
@@ -267,7 +269,7 @@ export class WorkflowGateService {
     if (now - lastBlocked > 2000) {
       state.lastBlockedAt = new Date(now).toISOString();
       this.writeState(state);
-      message = 'BLOCKED: Search memory before reading guidance files. Use mcp__moflo__memory_search with namespace "guidance".';
+      message = 'Gate policy: memory search required before reading guidance files.';
     }
 
     return { allowed: false, message };

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -216,43 +216,49 @@ describe('gate.cjs: check-dangerous-command', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('gate.cjs: check-before-agent', () => {
-  it('blocks when memory not searched (exit 2)', () => {
-    writeState(tmpDir, { memoryRequired: true, memorySearched: false });
+  it('blocks when tasks not created (exit 2)', () => {
+    writeState(tmpDir, { memoryRequired: true, memorySearched: true, tasksCreated: false });
     const r = runGate('check-before-agent', baseEnv(tmpDir));
     expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('Gate policy');
+    expect(r.stderr).toContain('TaskCreate');
+  });
+
+  it('blocks when memory not searched (exit 2)', () => {
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false, tasksCreated: true });
+    const r = runGate('check-before-agent', baseEnv(tmpDir));
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('Gate policy');
     expect(r.stderr).toContain('memory');
   });
 
-  it('allows when memory already searched', () => {
-    writeState(tmpDir, { memoryRequired: true, memorySearched: true });
+  it('blocks when both gates fail — TaskCreate checked first', () => {
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false, tasksCreated: false });
     const r = runGate('check-before-agent', baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('TaskCreate');
   });
 
-  it('allows when memory not required', () => {
-    writeState(tmpDir, { memoryRequired: false, memorySearched: false });
-    const r = runGate('check-before-agent', baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-  });
-
-  it('shows TaskCreate reminder when tasks not created', () => {
-    writeState(tmpDir, { memoryRequired: true, memorySearched: true, tasksCreated: false });
-    const r = runGate('check-before-agent', baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('REMINDER');
-    expect(r.stdout).toContain('TaskCreate');
-  });
-
-  it('no reminder when tasks already created', () => {
+  it('allows when both gates pass', () => {
     writeState(tmpDir, { memoryRequired: true, memorySearched: true, tasksCreated: true });
     const r = runGate('check-before-agent', baseEnv(tmpDir));
     expect(r.exitCode).toBe(0);
-    expect(r.stdout).not.toContain('REMINDER');
+  });
+
+  it('allows when memory not required (tasks still required)', () => {
+    writeState(tmpDir, { memoryRequired: false, memorySearched: false, tasksCreated: true });
+    const r = runGate('check-before-agent', baseEnv(tmpDir));
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('blocks when memory not required but tasks not created', () => {
+    writeState(tmpDir, { memoryRequired: false, memorySearched: false, tasksCreated: false });
+    const r = runGate('check-before-agent', baseEnv(tmpDir));
+    expect(r.exitCode).toBe(2);
   });
 
   it('uses defaults when no state file exists', () => {
-    // Default: memoryRequired=true, memorySearched=false → should block
+    // Default: tasksCreated=false → should block on TaskCreate first
     const r = runGate('check-before-agent', baseEnv(tmpDir));
     expect(r.exitCode).toBe(2);
   });
@@ -270,7 +276,7 @@ describe('gate.cjs: check-before-scan', () => {
     env.TOOL_INPUT_path = 'src/';
     const r = runGate('check-before-scan', env);
     expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('Gate policy');
   });
 
   it('allows scan when memory searched', () => {
@@ -334,7 +340,7 @@ describe('gate.cjs: check-before-read', () => {
     env.TOOL_INPUT_file_path = '/project/.claude/guidance/rules.md';
     const r = runGate('check-before-read', env);
     expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('Gate policy');
   });
 
   it('blocks reading non-exempt files when memory not searched', () => {
@@ -343,7 +349,7 @@ describe('gate.cjs: check-before-read', () => {
     env.TOOL_INPUT_file_path = '/project/src/index.ts';
     const r = runGate('check-before-read', env);
     expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('Gate policy');
   });
 
   it('allows reading any file when memory searched', () => {
@@ -691,16 +697,16 @@ describe('gate.cjs: unknown commands', () => {
 describe('gate.cjs: moflo.yaml config', () => {
   it('disables memory_first gate when config says false', () => {
     writeFileSync(join(tmpDir, 'moflo.yaml'), 'gates:\n  memory_first: false\n');
-    writeState(tmpDir, { memoryRequired: true, memorySearched: false });
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false, tasksCreated: true });
     const r = runGate('check-before-agent', baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0); // Not blocked
+    expect(r.exitCode).toBe(0); // Not blocked — memory gate disabled
   });
 
-  it('disables task_create_first reminder when config says false', () => {
+  it('disables task_create_first gate when config says false', () => {
     writeFileSync(join(tmpDir, 'moflo.yaml'), 'gates:\n  task_create_first: false\n');
     writeState(tmpDir, { memoryRequired: true, memorySearched: true, tasksCreated: false });
     const r = runGate('check-before-agent', baseEnv(tmpDir));
-    expect(r.stdout).not.toContain('REMINDER');
+    expect(r.exitCode).toBe(0); // Not blocked — task gate disabled
   });
 
   it('disables context tracking when config says false', () => {
@@ -737,7 +743,7 @@ describe('gate-hook.mjs: stdin integration', () => {
       hook_event_name: 'PreToolUse',
     }, baseEnv(tmpDir));
     expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('Dangerous command');
   });
 
   it('allows safe commands via stdin JSON', async () => {
@@ -778,7 +784,7 @@ describe('gate-hook.mjs: stdin integration', () => {
       hook_event_name: 'PreToolUse',
     }, baseEnv(tmpDir));
     expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('Gate policy');
   });
 });
 
@@ -945,9 +951,10 @@ describe('end-to-end: workflow lifecycle', () => {
     s = readState(tmpDir);
     expect(s.memoryRequired).toBe(true);
 
-    // 3. Agent spawn should be blocked (no memory search yet)
+    // 3. Agent spawn should be blocked (no TaskCreate yet)
     let r = runGate('check-before-agent', env);
     expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('TaskCreate');
 
     // 4. Memory search via bash
     env.TOOL_INPUT_command = 'npx moflo memory search --query "auth"';
@@ -955,22 +962,27 @@ describe('end-to-end: workflow lifecycle', () => {
     s = readState(tmpDir);
     expect(s.memorySearched).toBe(true);
 
-    // 5. Agent spawn should now be allowed
+    // 5. Agent spawn still blocked (TaskCreate not done yet)
     r = runGate('check-before-agent', env);
-    expect(r.exitCode).toBe(0);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('TaskCreate');
 
     // 6. Record task created
     runGate('record-task-created', env);
     s = readState(tmpDir);
     expect(s.tasksCreated).toBe(true);
 
-    // 7. Next prompt resets memorySearched
+    // 7. Agent spawn should now be allowed (both gates pass)
+    r = runGate('check-before-agent', env);
+    expect(r.exitCode).toBe(0);
+
+    // 8. Next prompt resets memorySearched
     env.CLAUDE_USER_PROMPT = 'now add tests for it';
     runGate('prompt-reminder', env);
     s = readState(tmpDir);
     expect(s.memorySearched).toBe(false);
 
-    // 8. Direct memory search via MCP (record-memory-searched)
+    // 9. Direct memory search via MCP (record-memory-searched)
     runGate('record-memory-searched', env);
     s = readState(tmpDir);
     expect(s.memorySearched).toBe(true);


### PR DESCRIPTION
## Summary

- **Harden TaskCreate gate** — Make `tasksCreated` a hard gate (exit 2) in both CJS and TS versions. Was a soft reminder in CJS, causing agents to bypass TaskCreate requirement.
- **Reword gate messages** — Change all `"BLOCKED: ..."` messages to informational `"Gate policy: ..."` phrasing. The `PreToolUse:Agent hook error` prefix from Claude Code is scary enough; our message should be calm and descriptive.
- **Add `/simplify` wrapper** — Override the built-in `/simplify` with a gate-compliant version that does memory search + TaskCreate before spawning reviewer agents (reuse, quality, efficiency).

## Test plan

- [x] 92/92 gate-helpers tests pass
- [x] TypeScript compiles clean
- [ ] Verify `/simplify` invocation does memory search + TaskCreate before spawning agents
- [ ] Verify gate errors now show "Gate policy: ..." instead of "BLOCKED: ..."

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)