### PR TITLE
fix(hooks): remove broken ^Task$ PreToolUse hook causing Agent errors

### DIFF
--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -6,6 +6,8 @@ description: Review changed code for reuse, quality, and efficiency, then fix an
 
 Review all changed files for reuse opportunities, code quality, and efficiency improvements.
 
+**This command overrides any built-in simplify skill.** Follow these steps exactly.
+
 ## Prerequisites (MANDATORY — do these FIRST)
 
 1. **Memory search**: Search for relevant patterns before reviewing
@@ -26,21 +28,23 @@ After prerequisites are satisfied, get the list of changed files:
 git diff --name-only HEAD~1
 ```
 
-Then launch 3 reviewer agents **in parallel** (single message, multiple Agent tool calls):
+Then launch 3 reviewer agents **in parallel** (single message, multiple Agent tool calls).
+
+**CRITICAL**: Each agent prompt below includes a mandatory memory search step. This is required because subagents must satisfy the memory-first gate independently before using Glob, Grep, or Read tools. Do NOT remove the memory search from agent prompts.
 
 ### Agent 1: Reuse Reviewer
 ```
-Agent — name: "reuse-reviewer", prompt: "Review these changed files for code reuse opportunities. Look for: duplicated logic that could use existing utilities, patterns already solved elsewhere in the codebase, opportunities to extract shared helpers. Files: $CHANGED_FILES", subagent_type: "reviewer"
+Agent — name: "reuse-reviewer", run_in_background: true, subagent_type: "reviewer", prompt: "FIRST ACTION: Run mcp__moflo__memory_search with query 'code reuse patterns' and namespace 'patterns'. You MUST do this before any Glob, Grep, or Read calls. THEN review these changed files for code reuse opportunities. Look for: duplicated logic that could use existing utilities, patterns already solved elsewhere in the codebase, opportunities to extract shared helpers. Files: $CHANGED_FILES"
 ```
 
 ### Agent 2: Quality Reviewer
 ```
-Agent — name: "quality-reviewer", prompt: "Review these changed files for code quality issues. Look for: unclear naming, overly complex logic, missing error handling at system boundaries, potential bugs, consistency with existing patterns. Files: $CHANGED_FILES", subagent_type: "reviewer"
+Agent — name: "quality-reviewer", run_in_background: true, subagent_type: "reviewer", prompt: "FIRST ACTION: Run mcp__moflo__memory_search with query 'code quality patterns' and namespace 'patterns'. You MUST do this before any Glob, Grep, or Read calls. THEN review these changed files for code quality issues. Look for: unclear naming, overly complex logic, missing error handling at system boundaries, potential bugs, consistency with existing patterns. Files: $CHANGED_FILES"
 ```
 
 ### Agent 3: Efficiency Reviewer
 ```
-Agent — name: "efficiency-reviewer", prompt: "Review these changed files for efficiency improvements. Look for: unnecessary allocations, O(n^2) where O(n) is possible, redundant operations, opportunities to batch or cache. Files: $CHANGED_FILES", subagent_type: "reviewer"
+Agent — name: "efficiency-reviewer", run_in_background: true, subagent_type: "reviewer", prompt: "FIRST ACTION: Run mcp__moflo__memory_search with query 'performance optimization patterns' and namespace 'patterns'. You MUST do this before any Glob, Grep, or Read calls. THEN review these changed files for efficiency improvements. Look for: unnecessary allocations, O(n^2) where O(n) is possible, redundant operations, opportunities to batch or cache. Files: $CHANGED_FILES"
 ```
 
 ## Post-Review

--- a/.claude/helpers/subagent-start.cjs
+++ b/.claude/helpers/subagent-start.cjs
@@ -12,8 +12,9 @@ const output = {
   hookSpecificOutput: {
     hookEventName: 'SubagentStart',
     additionalContext:
-      'IMPORTANT: Before doing any work, read `.claude/guidance/shipped/moflo-subagents.md` and follow its protocol. ' +
-      'You MUST search memory (mcp__moflo__memory_search) before using Glob, Grep, or Read tools.',
+      'MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). ' +
+      'The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. ' +
+      'After memory search, follow `.claude/guidance/shipped/moflo-subagents.md` protocol.',
   },
 };
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,16 +58,6 @@
         ]
       },
       {
-        "matcher": "^Task$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx flo hooks pre-task",
-            "timeout": 5000
-          }
-        ]
-      },
-      {
         "matcher": "^Bash$",
         "hooks": [
           {

--- a/src/packages/cli/dist/src/init/moflo-init.js
+++ b/src/packages/cli/dist/src/init/moflo-init.js
@@ -438,16 +438,6 @@ function generateHooks(root, force, answers) {
                     }]
             },
             {
-                "matcher": "^Task$",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "npx flo hooks pre-task",
-                        "timeout": 5000
-                    }
-                ]
-            },
-            {
                 "matcher": "^Bash$",
                 "hooks": [{
                         "type": "command",

--- a/src/packages/cli/src/init/moflo-init.ts
+++ b/src/packages/cli/src/init/moflo-init.ts
@@ -498,16 +498,6 @@ function generateHooks(root: string, force?: boolean, answers?: MofloInitAnswers
         }]
       },
       {
-        "matcher": "^Task$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx flo hooks pre-task",
-            "timeout": 5000
-          }
-        ]
-      },
-      {
         "matcher": "^Bash$",
         "hooks": [{
           "type": "command",


### PR DESCRIPTION
## Summary
- Removed `^Task$` PreToolUse hook that called `npx flo hooks pre-task` — always crashed (exit 1, missing required args) and caused "PreToolUse:Agent hook error" on every Agent tool invocation
- No tool named exactly "Task" exists in Claude Code (they're TaskCreate, TaskGet, etc.) so the hook never matched its intended target
- Memory-first gating is unaffected — enforced by `check-before-scan` (Glob/Grep) and `check-before-read` (Read) hooks
- Strengthened subagent memory-first compliance: simplify.md agent prompts and subagent-start.cjs directive

## Test plan
- [x] 5812/6300 tests pass (427 skipped, 3 pre-existing worker OOM)
- [x] Spawned 6 subagents with zero "PreToolUse:Agent hook error" after fix
- [x] Verified memory-first gates still block Glob/Grep/Read when memory not searched
- [x] gate-helpers.test.ts: 91/91 pass

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)