### PR TITLE
chore(gitignore): ignore untracked ephemeral files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,8 +170,11 @@ hive-mind-prompt-*.txt
 .testoutput/
 
 # Ephemeral / test artifacts
-.claude/workflow-state.json
+.claude/projects/
+**/workflow-state.json
+src/packages/*/package-lock.json
 test-database-provider.rvf
+.vitest-results.json
 
 # Local guidance docs (generated, not tracked)
 .claude/guidance/


### PR DESCRIPTION
## Summary
- Broadens `workflow-state.json` ignore from root-only to all nested instances (`**/workflow-state.json`)
- Adds `.claude/projects/` (local auto-memory, per-machine)
- Adds `src/packages/*/package-lock.json` (sub-package lockfiles; root lockfile is authoritative)
- Adds `.vitest-results.json` (test artifact)

## Test plan
- [x] `git status` shows clean working tree after change

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)