### PR TITLE
chore: sync .claude/scripts with bin/ additions

### DIFF
--- a/.claude/scripts/index-patterns.mjs
+++ b/.claude/scripts/index-patterns.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+/**
+ * Index code patterns into claude-flow memory under the `patterns` namespace
+ *
+ * Extracts per-file patterns (not just aggregate summaries like pretrain):
+ *   - Service/controller/repository class patterns
+ *   - API route definitions and middleware usage
+ *   - Error handling strategies per file
+ *   - Export conventions per module
+ *   - Test patterns (describe/it structure)
+ *   - Configuration patterns
+ *
+ * Chunk types:
+ *   pattern:file:{path}     — Per-file pattern summary
+ *   pattern:service:{name}  — Service class patterns
+ *   pattern:route:{path}    — API route patterns
+ *   pattern:error:{path}    — Error handling patterns per file
+ *
+ * Usage:
+ *   node node_modules/moflo/bin/index-patterns.mjs             # Incremental
+ *   node node_modules/moflo/bin/index-patterns.mjs --force     # Full reindex
+ *   node node_modules/moflo/bin/index-patterns.mjs --verbose   # Detailed logging
+ *   node node_modules/moflo/bin/index-patterns.mjs --stats     # Print stats and exit
+ *   npx flo-patterns                                           # Via npx
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'fs';
+import { resolve, dirname, relative, basename, extname } from 'path';
+import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
+import { spawn } from 'child_process';
+import { mofloResolveURL } from './lib/moflo-resolve.mjs';
+const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function findProjectRoot() {
+  let dir = process.cwd();
+  const root = resolve(dir, '/');
+  while (dir !== root) {
+    if (existsSync(resolve(dir, 'package.json'))) return dir;
+    dir = dirname(dir);
+  }
+  return process.cwd();
+}
+
+const projectRoot = findProjectRoot();
+const NAMESPACE = 'patterns';
+const DB_PATH = resolve(projectRoot, '.swarm/memory.db');
+const HASH_CACHE_PATH = resolve(projectRoot, '.swarm/patterns-hash.txt');
+
+const args = process.argv.slice(2);
+const force = args.includes('--force');
+const verbose = args.includes('--verbose') || args.includes('-v');
+const statsOnly = args.includes('--stats');
+
+function log(msg) { console.log(`[index-patterns] ${msg}`); }
+function debug(msg) { if (verbose) console.log(`[index-patterns]   ${msg}`); }
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.py', '.go', '.rs']);
+const EXCLUDE_DIRS = new Set([
+  'node_modules', 'dist', 'build', '.next', 'coverage',
+  '.claude', '.swarm', '.claude-flow', '.git', 'template',
+]);
+
+// ---------------------------------------------------------------------------
+// Database helpers
+// ---------------------------------------------------------------------------
+
+function ensureDbDir() {
+  const dir = dirname(DB_PATH);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+async function getDb() {
+  ensureDbDir();
+  const SQL = await initSqlJs();
+  let db;
+  if (existsSync(DB_PATH)) {
+    const buffer = readFileSync(DB_PATH);
+    db = new SQL.Database(buffer);
+  } else {
+    db = new SQL.Database();
+  }
+  db.run(`
+    CREATE TABLE IF NOT EXISTS memory_entries (
+      id TEXT PRIMARY KEY,
+      key TEXT NOT NULL,
+      namespace TEXT DEFAULT 'default',
+      content TEXT NOT NULL,
+      type TEXT DEFAULT 'semantic',
+      embedding TEXT,
+      embedding_model TEXT DEFAULT 'local',
+      embedding_dimensions INTEGER,
+      tags TEXT,
+      metadata TEXT,
+      owner_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+      updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+      expires_at INTEGER,
+      last_accessed_at INTEGER,
+      access_count INTEGER DEFAULT 0,
+      status TEXT DEFAULT 'active',
+      UNIQUE(namespace, key)
+    )
+  `);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_memory_key_ns ON memory_entries(key, namespace)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_memory_namespace ON memory_entries(namespace)`);
+  return db;
+}
+
+function saveDb(db) {
+  const data = db.export();
+  writeFileSync(DB_PATH, Buffer.from(data));
+}
+
+function generateId() {
+  return `mem_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+function storeEntry(db, key, content, tags = []) {
+  const now = Date.now();
+  const id = generateId();
+  db.run(`
+    INSERT OR REPLACE INTO memory_entries
+    (id, key, namespace, content, metadata, tags, created_at, updated_at, status)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active')
+  `, [id, key, NAMESPACE, content, '{}', JSON.stringify(tags), now, now]);
+}
+
+function deleteNamespace(db) {
+  db.run(`DELETE FROM memory_entries WHERE namespace = ?`, [NAMESPACE]);
+}
+
+function countNamespace(db) {
+  const stmt = db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = ?`);
+  stmt.bind([NAMESPACE]);
+  let count = 0;
+  if (stmt.step()) count = stmt.getAsObject().cnt;
+  stmt.free();
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// File collection
+// ---------------------------------------------------------------------------
+
+function collectSourceFiles(dir, maxDepth = 8, depth = 0) {
+  if (depth > maxDepth) return [];
+  const files = [];
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return []; }
+  for (const entry of entries) {
+    if (EXCLUDE_DIRS.has(entry.name)) continue;
+    const fullPath = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath, maxDepth, depth + 1));
+    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern extraction — per-file
+// ---------------------------------------------------------------------------
+
+function extractFilePatterns(filePath, content) {
+  const lines = content.split('\n');
+  const relPath = relative(projectRoot, filePath);
+  const patterns = [];
+  const tags = [];
+
+  // Collect metrics
+  const imports = [];
+  const exports = [];
+  const classes = [];
+  const functions = [];
+  const routes = [];
+  const errorHandling = [];
+  const interfaces = [];
+
+  for (const line of lines) {
+    const t = line.trim();
+
+    // Imports
+    const impMatch = t.match(/^import\s+.*?from\s+['"]([^'"]+)['"]/);
+    if (impMatch) imports.push(impMatch[1]);
+
+    // Exports
+    if (/^export\s+default\b/.test(t)) exports.push('default');
+    const namedExp = t.match(/^export\s+(?:const|function|class|interface|type|enum)\s+(\w+)/);
+    if (namedExp) exports.push(namedExp[1]);
+
+    // Classes
+    const classMatch = t.match(/^(?:export\s+)?(?:abstract\s+)?class\s+(\w+)/);
+    if (classMatch) {
+      classes.push(classMatch[1]);
+      if (/Service\b/.test(classMatch[1])) tags.push('service');
+      if (/Controller\b/.test(classMatch[1])) tags.push('controller');
+      if (/Repository\b/.test(classMatch[1])) tags.push('repository');
+      if (/Provider\b/.test(classMatch[1])) tags.push('provider');
+    }
+
+    // Functions
+    const fnMatch = t.match(/^(?:export\s+)?(?:async\s+)?function\s+(\w+)/);
+    if (fnMatch) functions.push(fnMatch[1]);
+    const arrowMatch = t.match(/^(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s+)?\(/);
+    if (arrowMatch) functions.push(arrowMatch[1]);
+
+    // Interfaces/types
+    const ifaceMatch = t.match(/^(?:export\s+)?(?:interface|type)\s+(\w+)/);
+    if (ifaceMatch) interfaces.push(ifaceMatch[1]);
+
+    // Routes
+    const routeMatch = t.match(/\.(get|post|put|patch|delete)\s*\(\s*['"]([^'"]*)['"]/i);
+    if (routeMatch) routes.push(`${routeMatch[1].toUpperCase()} ${routeMatch[2]}`);
+    if (/@(Get|Post|Put|Delete|Patch)\s*\(/.test(t)) {
+      const dec = t.match(/@(\w+)\s*\(\s*['"]([^'"]*)['"]/);
+      if (dec) routes.push(`${dec[1].toUpperCase()} ${dec[2]}`);
+    }
+
+    // Error handling
+    if (/\bcatch\s*\(/.test(t)) errorHandling.push('try-catch');
+    if (/\.catch\(/.test(t)) errorHandling.push('promise-catch');
+    if (/throw\s+new\s+(\w+)/.test(t)) {
+      const err = t.match(/throw\s+new\s+(\w+)/);
+      if (err) errorHandling.push(`throws:${err[1]}`);
+    }
+  }
+
+  // Only create entries for files with meaningful patterns
+  if (classes.length === 0 && functions.length < 2 && routes.length === 0 && interfaces.length < 2) {
+    return [];
+  }
+
+  // Build human-readable pattern summary for this file
+  const parts = [];
+  if (classes.length > 0) parts.push(`Classes: ${classes.join(', ')}`);
+  if (functions.length > 0) parts.push(`Functions: ${functions.slice(0, 10).join(', ')}${functions.length > 10 ? ` (+${functions.length - 10} more)` : ''}`);
+  if (interfaces.length > 0) parts.push(`Types: ${interfaces.slice(0, 8).join(', ')}${interfaces.length > 8 ? ` (+${interfaces.length - 8} more)` : ''}`);
+  if (routes.length > 0) parts.push(`Routes: ${routes.join(', ')}`);
+  if (exports.length > 0) parts.push(`Exports: ${exports.slice(0, 8).join(', ')}${exports.length > 8 ? ` (+${exports.length - 8} more)` : ''}`);
+  if (errorHandling.length > 0) {
+    const unique = [...new Set(errorHandling)];
+    parts.push(`Error handling: ${unique.join(', ')}`);
+  }
+
+  const summary = `# ${relPath}\n${parts.join('\n')}`;
+
+  // File-level pattern entry
+  patterns.push({
+    key: `pattern:file:${relPath}`,
+    content: summary,
+    tags: ['file-pattern', ...tags],
+  });
+
+  // Service/controller entries get their own chunk for better search
+  for (const cls of classes) {
+    if (/Service|Controller|Repository|Provider|Handler|Manager/.test(cls)) {
+      const clsMethods = functions.filter(f => f !== cls); // rough heuristic
+      patterns.push({
+        key: `pattern:class:${cls}`,
+        content: `# ${cls} (${relPath})\nType: ${tags.filter(t => ['service', 'controller', 'repository', 'provider'].includes(t)).join(', ') || 'class'}\nMethods: ${clsMethods.slice(0, 15).join(', ') || 'none detected'}`,
+        tags: ['class-pattern', ...tags],
+      });
+    }
+  }
+
+  // Route entries
+  if (routes.length > 0) {
+    patterns.push({
+      key: `pattern:routes:${relPath}`,
+      content: `# Routes in ${relPath}\n${routes.join('\n')}`,
+      tags: ['route-pattern', 'api'],
+    });
+  }
+
+  return patterns;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const startTime = Date.now();
+
+  // Stats mode
+  if (statsOnly) {
+    const db = await getDb();
+    const count = countNamespace(db);
+    const files = collectSourceFiles(projectRoot);
+    log(`${files.length} source files, ${count} chunks in patterns namespace`);
+    db.close();
+    return;
+  }
+
+  // Collect files
+  const files = collectSourceFiles(projectRoot);
+  log(`Found ${files.length} source files`);
+
+  if (files.length === 0) {
+    log('No source files found');
+    return;
+  }
+
+  // Hash check for incremental
+  const hashInput = files.map(f => {
+    try { return `${f}:${statSync(f).mtimeMs}`; } catch { return f; }
+  }).join('\n');
+  const currentHash = createHash('sha256').update(hashInput).digest('hex');
+
+  if (!force && existsSync(HASH_CACHE_PATH)) {
+    const cached = readFileSync(HASH_CACHE_PATH, 'utf-8').trim();
+    if (cached === currentHash) {
+      log('No changes detected (use --force to reindex)');
+      return;
+    }
+  }
+
+  // Extract patterns from all files
+  const allPatterns = [];
+  let filesWithPatterns = 0;
+
+  for (const filePath of files) {
+    let content;
+    try { content = readFileSync(filePath, 'utf-8'); } catch { continue; }
+    const patterns = extractFilePatterns(filePath, content);
+    if (patterns.length > 0) {
+      filesWithPatterns++;
+      allPatterns.push(...patterns);
+    }
+    debug(`${relative(projectRoot, filePath)}: ${patterns.length} patterns`);
+  }
+
+  log(`Extracted ${allPatterns.length} pattern chunks from ${filesWithPatterns} files`);
+
+  // Write to database
+  const db = await getDb();
+  deleteNamespace(db);
+
+  for (const p of allPatterns) {
+    storeEntry(db, p.key, p.content, p.tags);
+  }
+
+  saveDb(db);
+  db.close();
+
+  // Save hash
+  writeFileSync(HASH_CACHE_PATH, currentHash, 'utf-8');
+
+  // Trigger embedding generation in background
+  try {
+    // Check __dirname first (works in both dev bin/ and consumer .claude/scripts/),
+    // then fall back to node_modules/moflo/bin/ for consumer projects
+    const candidates = [
+      resolve(__dirname, 'build-embeddings.mjs'),
+      resolve(projectRoot, 'node_modules/moflo/bin/build-embeddings.mjs'),
+      resolve(projectRoot, '.claude/scripts/build-embeddings.mjs'),
+    ];
+    const embeddingScript = candidates.find(p => existsSync(p));
+    if (embeddingScript) {
+      const child = spawn('node', [embeddingScript, '--namespace', NAMESPACE], {
+        cwd: projectRoot,
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      child.unref();
+      debug('Embedding generation started in background');
+    }
+  } catch { /* ignore */ }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  log(`Done in ${elapsed}s — ${allPatterns.length} pattern chunks written`);
+}
+
+main().catch(err => {
+  log(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -165,7 +165,7 @@ try {
           resolve(projectRoot, 'node_modules/moflo/src/packages/cli/.claude/helpers'),
         ];
         const sourceHelperFiles = [
-          'auto-memory-hook.mjs', 'statusline.cjs', 'intelligence.cjs', 'pre-commit', 'post-commit',
+          'auto-memory-hook.mjs', 'statusline.cjs', 'intelligence.cjs', 'subagent-start.cjs', 'pre-commit', 'post-commit',
         ];
         for (const file of sourceHelperFiles) {
           const dest = resolve(helpersDir, file);

--- a/.claude/scripts/setup-project.mjs
+++ b/.claude/scripts/setup-project.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/**
+ * MoFlo Project Setup
+ *
+ * Copies the subagents guidance into the consuming project and
+ * adds a CLAUDE.md section so subagents automatically follow the protocol.
+ *
+ * Usage:
+ *   npx flo-setup            # First-time setup
+ *   npx flo-setup --update   # Refresh bootstrap file after moflo upgrade
+ *   npx flo-setup --check    # Check if setup is current
+ *
+ * What it does:
+ *   1. Copies .claude/guidance/shipped/moflo-subagents.md → project's .claude/guidance/moflo-bootstrap.md
+ *   2. Appends a subagent protocol section to CLAUDE.md (idempotent, with markers)
+ *
+ * The project can layer its own guidance files on top for
+ * project-specific rules (companyId, entity templates, etc.).
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const mofloRoot = resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const updateOnly = args.includes('--update');
+const checkOnly = args.includes('--check');
+
+// Markers for idempotent CLAUDE.md updates — keep in sync with claudemd-generator.ts
+const MARKER_START = '<!-- MOFLO:INJECTED:START -->';
+const MARKER_END = '<!-- MOFLO:INJECTED:END -->';
+// Legacy markers to detect and replace
+const LEGACY_STARTS = ['<!-- MOFLO:SUBAGENT-PROTOCOL:START -->', '<!-- MOFLO:START -->'];
+const LEGACY_ENDS = ['<!-- MOFLO:SUBAGENT-PROTOCOL:END -->', '<!-- MOFLO:END -->'];
+
+// Minimal injection — just enough for Claude to work with moflo.
+// All detailed docs live in .claude/guidance/shipped/moflo-core-guidance.md.
+const CLAUDE_MD_SECTION = `${MARKER_START}
+## MoFlo — AI Agent Orchestration
+
+This project uses [MoFlo](https://github.com/eric-cielo/moflo) for AI-assisted development workflows.
+
+### FIRST ACTION ON EVERY PROMPT: Search Memory
+
+Your first tool call for every new user prompt MUST be a memory search. Do this BEFORE Glob, Grep, Read, or any file exploration.
+
+\`\`\`
+mcp__moflo__memory_search — query: "<task description>", namespace: "guidance" or "patterns" or "code-map"
+\`\`\`
+
+Search \`guidance\` and \`patterns\` namespaces on every prompt. Search \`code-map\` when navigating the codebase.
+When the user asks you to remember something: \`mcp__moflo__memory_store\` with namespace \`knowledge\`.
+
+### Workflow Gates (enforced automatically)
+
+- **Memory-first**: Must search memory before Glob/Grep/Read
+- **TaskCreate-first**: Must call TaskCreate before spawning Agent tool
+
+- **Task Icons**: \`TaskCreate\` MUST use ICON+[Role] format — see \`.claude/guidance/moflo-task-icons.md\`
+
+### MCP Tools (preferred over CLI)
+
+| Tool | Purpose |
+|------|---------|
+| \`mcp__moflo__memory_search\` | Semantic search across indexed knowledge |
+| \`mcp__moflo__memory_store\` | Store patterns and decisions |
+| \`mcp__moflo__hooks_route\` | Route task to optimal agent type |
+| \`mcp__moflo__hooks_pre-task\` | Record task start |
+| \`mcp__moflo__hooks_post-task\` | Record task completion for learning |
+
+### CLI Fallback
+
+\`\`\`bash
+npx flo-search "[query]" --namespace guidance   # Semantic search
+npx flo doctor --fix                             # Health check
+\`\`\`
+
+### Full Reference
+
+For CLI commands, hooks, agents, swarm config, memory commands, and moflo.yaml options, see:
+\`.claude/guidance/shipped/moflo-core-guidance.md\`
+${MARKER_END}`;
+
+function log(msg) {
+  console.log(`[flo-setup] ${msg}`);
+}
+
+function findProjectRoot() {
+  // Walk up from cwd looking for package.json that depends on moflo
+  let dir = process.cwd();
+  const root = resolve(dir, '/');
+
+  while (dir !== root) {
+    const pkgPath = join(dir, 'package.json');
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+        if (deps && deps.moflo) {
+          return dir;
+        }
+      } catch { /* ignore parse errors */ }
+    }
+    dir = dirname(dir);
+  }
+
+  // Fallback: use cwd if it has a package.json
+  if (existsSync(join(process.cwd(), 'package.json'))) {
+    return process.cwd();
+  }
+
+  return null;
+}
+
+function copyBootstrap(projectRoot) {
+  const shippedSource = join(mofloRoot, '.claude', 'guidance', 'shipped', 'moflo-subagents.md');
+  const source = existsSync(shippedSource)
+    ? shippedSource
+    : join(mofloRoot, '.claude', 'guidance', 'moflo-subagents.md');
+  const targetDir = join(projectRoot, '.claude', 'guidance');
+  const target = join(targetDir, 'moflo-bootstrap.md');
+
+  if (!existsSync(source)) {
+    log('❌ Source bootstrap not found in moflo package');
+    return false;
+  }
+
+  // Read source content and prepend auto-generated notice
+  const content = readFileSync(source, 'utf-8');
+  const header = `<!-- AUTO-GENERATED by flo-setup. Do not edit — changes will be overwritten. -->
+<!-- Source: node_modules/moflo/.claude/guidance/shipped/moflo-subagents.md -->
+<!-- To customize, add project-specific guidance in .claude/guidance/. -->
+
+`;
+
+  mkdirSync(targetDir, { recursive: true });
+
+  // Check if file exists and is current
+  if (existsSync(target)) {
+    const existing = readFileSync(target, 'utf-8');
+    const newContent = header + content;
+    if (existing === newContent) {
+      log('✅ moflo-bootstrap.md is current');
+      return true;
+    }
+    log('📝 Updating moflo-bootstrap.md');
+  } else {
+    log('📝 Creating .claude/guidance/moflo-bootstrap.md');
+  }
+
+  if (!checkOnly) {
+    writeFileSync(target, header + content, 'utf-8');
+  }
+  return true;
+}
+
+function updateClaudeMd(projectRoot) {
+  const claudeMdPath = join(projectRoot, 'CLAUDE.md');
+
+  if (!existsSync(claudeMdPath)) {
+    if (checkOnly) {
+      log('⚠️  No CLAUDE.md found');
+      return false;
+    }
+    log('📝 Creating CLAUDE.md with subagent protocol section');
+    writeFileSync(claudeMdPath, `# Project Configuration\n\n${CLAUDE_MD_SECTION}\n`, 'utf-8');
+    return true;
+  }
+
+  const content = readFileSync(claudeMdPath, 'utf-8');
+
+  // Check for current or legacy markers and replace
+  const allStarts = [MARKER_START, ...LEGACY_STARTS];
+  const allEnds = [MARKER_END, ...LEGACY_ENDS];
+
+  for (let i = 0; i < allStarts.length; i++) {
+    if (content.includes(allStarts[i])) {
+      const startIdx = content.indexOf(allStarts[i]);
+      const endIdx = content.indexOf(allEnds[i]);
+
+      if (endIdx > startIdx) {
+        // If current markers and content matches, we're up to date
+        if (i === 0) {
+          const existingSection = content.substring(startIdx, endIdx + allEnds[i].length);
+          if (existingSection === CLAUDE_MD_SECTION) {
+            log('✅ CLAUDE.md moflo section is current');
+            return true;
+          }
+        }
+
+        // Replace (current or legacy) with new section
+        if (!checkOnly) {
+          const updated = content.substring(0, startIdx) + CLAUDE_MD_SECTION + content.substring(endIdx + allEnds[i].length);
+          writeFileSync(claudeMdPath, updated, 'utf-8');
+          log(i === 0 ? '📝 Updated CLAUDE.md moflo section' : '📝 Replaced legacy CLAUDE.md section with minimal moflo injection');
+        } else {
+          log('⚠️  CLAUDE.md moflo section needs update');
+        }
+        return true;
+      }
+    }
+  }
+
+  if (updateOnly) {
+    log('⚠️  CLAUDE.md has no moflo section (run without --update to add)');
+    return false;
+  }
+
+  if (checkOnly) {
+    log('⚠️  CLAUDE.md missing subagent protocol section');
+    return false;
+  }
+
+  // Append section to end of CLAUDE.md
+  const separator = content.endsWith('\n') ? '\n' : '\n\n';
+  writeFileSync(claudeMdPath, content + separator + CLAUDE_MD_SECTION + '\n', 'utf-8');
+  log('📝 Added subagent protocol section to CLAUDE.md');
+  return true;
+}
+
+function main() {
+  console.log('');
+  console.log('MoFlo Project Setup');
+  console.log('───────────────────');
+
+  const projectRoot = findProjectRoot();
+  if (!projectRoot) {
+    log('❌ Could not find project root (no package.json with moflo dependency)');
+    process.exit(1);
+  }
+
+  log(`Project: ${projectRoot}`);
+  console.log('');
+
+  // Step 1: Copy bootstrap file
+  const bootstrapOk = copyBootstrap(projectRoot);
+
+  // Step 2: Update CLAUDE.md (skip on --update, only refresh the file)
+  const claudeOk = updateOnly ? true : updateClaudeMd(projectRoot);
+
+  console.log('');
+  if (checkOnly) {
+    log(bootstrapOk && claudeOk ? '✅ Setup is current' : '⚠️  Setup needs attention');
+  } else {
+    log('✅ Done. Subagents will now follow the MoFlo bootstrap protocol.');
+  }
+  console.log('');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `index-patterns.mjs` and `setup-project.mjs` to `.claude/scripts/` (mirrors existing `bin/` scripts)
- Add `subagent-start.cjs` to session-start-launcher helper file sync list

## Test plan
- [x] Scripts match their `bin/` counterparts
- [x] No code changes, only script sync

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)