### PR TITLE
feat(skills): add /connector-builder skill for scaffolding connectors and steps

### DIFF
--- a/.claude/skills/connector-builder/SKILL.md
+++ b/.claude/skills/connector-builder/SKILL.md
@@ -1,0 +1,502 @@
+---
+name: "Connector Builder"
+description: "Scaffold new workflow connectors and step commands with type-safe TypeScript code. Use when creating custom connectors for external services, building new step commands for workflows, or extending the workflow engine with new capabilities."
+---
+
+# Connector Builder
+
+Scaffold production-ready workflow connectors (`WorkflowConnector`) and step commands (`StepCommand`) with proper types, tests, and registration.
+
+## Prerequisites
+
+- MoFlo project with `@claude-flow/workflows` package
+- TypeScript 5+
+- Vitest for testing
+
+## What This Skill Does
+
+1. Guides you through building a **connector** (external service bridge) or **step command** (workflow step logic)
+2. Generates type-safe TypeScript implementing the correct interface
+3. Creates a test file with vitest mocks
+4. Shows how to register the component and use it in workflow YAML
+
+---
+
+## Quick Start
+
+Ask the user:
+
+> **What do you want to build?**
+> 1. **Connector** — bridges an external service (HTTP API, CLI tool, database, etc.)
+> 2. **Step command** — executes logic within a workflow step (transform data, control flow, etc.)
+
+Then follow the appropriate section below.
+
+---
+
+## Building a Connector
+
+### Step 1: Gather Requirements
+
+Ask the user for:
+
+| Field | Required | Example |
+|-------|----------|---------|
+| **Name** | Yes | `slack`, `jira`, `s3` |
+| **Description** | Yes | `Slack messaging via API` |
+| **Version** | Yes (default `1.0.0`) | `1.0.0` |
+| **Capabilities** | Yes | `read`, `write`, `search`, `subscribe`, `authenticate` |
+| **Actions** | Yes (at least 1) | `send-message`, `list-channels`, `upload-file` |
+
+For each action, ask:
+- Action name (kebab-case)
+- Description
+- Input parameters (name, type, required?)
+- Output fields (name, type)
+
+### Step 2: Generate Connector Source
+
+Create the file at `src/packages/workflows/src/connectors/<name>.ts`.
+
+Follow this template, using `github-cli.ts` as the reference implementation:
+
+```typescript
+/**
+ * <Name> Workflow Connector
+ *
+ * <Description>
+ *
+ * Actions: <comma-separated action names>
+ */
+
+import type {
+  WorkflowConnector,
+  ConnectorAction,
+  ConnectorOutput,
+  ConnectorCapability,
+} from '../types/workflow-connector.types.js';
+
+export type <Name>Action = '<action-1>' | '<action-2>';
+
+export const VALID_ACTIONS: readonly <Name>Action[] = [
+  '<action-1>', '<action-2>',
+];
+
+async function execute<Action1>(
+  params: Record<string, unknown>,
+  start: number,
+): Promise<ConnectorOutput> {
+  // Implementation
+  return { success: true, data: { /* result */ }, duration: Date.now() - start };
+}
+
+export function validate<Name>Action(
+  action: string,
+  params: Record<string, unknown>,
+): string[] {
+  const errors: string[] = [];
+  if (!action || !VALID_ACTIONS.includes(action as <Name>Action)) {
+    errors.push(`action must be one of: ${VALID_ACTIONS.join(', ')}`);
+    return errors;
+  }
+  switch (action) {
+    case '<action-1>':
+      if (!params.<requiredParam>) errors.push('<action-1> requires <requiredParam>');
+      break;
+  }
+  return errors;
+}
+
+const ACTIONS: ConnectorAction[] = [
+  {
+    name: '<action-1>',
+    description: '<action description>',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        // Define input params with types and descriptions
+      },
+      required: ['<required-param>'],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        // Define output fields
+      },
+    },
+  },
+];
+
+export const <name>Connector: WorkflowConnector = {
+  name: '<name>',
+  description: '<Description>',
+  version: '<version>',
+  capabilities: [<capabilities>] as readonly ConnectorCapability[],
+
+  async initialize(config: Record<string, unknown>): Promise<void> {
+    // Validate prerequisites (CLI tools, auth, API keys, etc.)
+  },
+
+  async dispose(): Promise<void> {
+    // Clean up connections/resources
+  },
+
+  async execute(action: string, params: Record<string, unknown>): Promise<ConnectorOutput> {
+    const start = Date.now();
+    const errors = validate<Name>Action(action, params);
+    if (errors.length > 0) {
+      return { success: false, data: {}, error: errors.join('; '), duration: Date.now() - start };
+    }
+    switch (action) {
+      case '<action-1>':
+        return execute<Action1>(params, start);
+      default:
+        return { success: false, data: {}, error: `Unknown action: ${action}`, duration: Date.now() - start };
+    }
+  },
+
+  listActions(): ConnectorAction[] {
+    return ACTIONS;
+  },
+};
+```
+
+### Step 3: Generate Connector Test
+
+Create at `tests/packages/workflows/connectors/<name>.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { <name>Connector, validate<Name>Action } from
+  '../../../../src/packages/workflows/src/connectors/<name>.js';
+
+describe('<name>Connector', () => {
+  describe('metadata', () => {
+    it('has required properties', () => {
+      expect(<name>Connector.name).toBe('<name>');
+      expect(<name>Connector.description).toBeTruthy();
+      expect(<name>Connector.version).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(<name>Connector.capabilities.length).toBeGreaterThan(0);
+    });
+
+    it('lists actions with schemas', () => {
+      const actions = <name>Connector.listActions();
+      expect(actions.length).toBeGreaterThan(0);
+      for (const action of actions) {
+        expect(action.name).toBeTruthy();
+        expect(action.description).toBeTruthy();
+        expect(action.inputSchema).toBeDefined();
+        expect(action.outputSchema).toBeDefined();
+      }
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects unknown actions', () => {
+      const errors = validate<Name>Action('unknown', {});
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('validates required params for <action-1>', () => {
+      const errors = validate<Name>Action('<action-1>', {});
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('accepts valid params for <action-1>', () => {
+      const errors = validate<Name>Action('<action-1>', { <requiredParam>: 'value' });
+      expect(errors).toEqual([]);
+    });
+  });
+
+  describe('execute', () => {
+    it('returns error for unknown action', async () => {
+      const result = await <name>Connector.execute('unknown', {});
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unknown action');
+    });
+
+    // Add per-action execution tests with mocked externals
+  });
+
+  describe('lifecycle', () => {
+    it('initializes without error', async () => {
+      // Mock prerequisites as available
+      await expect(<name>Connector.initialize({})).resolves.not.toThrow();
+    });
+
+    it('disposes without error', async () => {
+      await expect(<name>Connector.dispose()).resolves.not.toThrow();
+    });
+  });
+});
+```
+
+### Step 4: Register the Connector
+
+Add to `src/packages/workflows/src/connectors/index.ts`:
+
+```typescript
+import { <name>Connector } from './<name>.js';
+
+export { <name>Connector };
+
+// Add to the builtinConnectors array:
+export const builtinConnectors: WorkflowConnector[] = [
+  httpConnector,
+  githubCliConnector,
+  playwrightConnector,
+  <name>Connector,  // <-- add here
+];
+```
+
+### Step 5: Example Workflow YAML
+
+```yaml
+name: example-with-<name>
+version: "1.0"
+description: Example workflow using the <name> connector
+
+connectors:
+  - <name>
+
+steps:
+  - name: do-something
+    type: bash
+    config:
+      command: "echo 'preparing...'"
+
+  - name: use-<name>
+    type: agent
+    config:
+      prompt: |
+        Use the <name> connector to <action-1>.
+        Access via context.tools.execute('<name>', '<action-1>', { ... })
+```
+
+---
+
+## Building a Step Command
+
+### Step 1: Gather Requirements
+
+Ask the user for:
+
+| Field | Required | Example |
+|-------|----------|---------|
+| **Type** | Yes (kebab-case) | `transform`, `notify`, `validate-schema` |
+| **Description** | Yes | `Transform data using jq-like expressions` |
+| **Config fields** | Yes (at least 1) | `expression: string`, `input: object` |
+| **Capabilities** | No | `fs:read`, `fs:write`, `net`, `shell`, `memory`, `credentials`, `browser`, `agent` |
+| **MoFlo level** | No (default `none`) | `none`, `memory`, `hooks`, `full`, `recursive` |
+| **Prerequisites** | No | External CLI tools needed |
+
+### Step 2: Generate Step Command Source
+
+Create at `src/packages/workflows/src/commands/<type>-command.ts`.
+
+Follow this template, using `bash-command.ts` as the reference implementation:
+
+```typescript
+/**
+ * <Type> Step Command — <description>.
+ */
+
+import type {
+  StepCommand,
+  StepConfig,
+  StepOutput,
+  WorkflowContext,
+  ValidationResult,
+  OutputDescriptor,
+  JSONSchema,
+  StepCapability,
+} from '../types/step-command.types.js';
+
+/** Typed config for the <type> step command. */
+export interface <Type>StepConfig extends StepConfig {
+  readonly <field1>: <type1>;
+  readonly <field2>?: <type2>;
+}
+
+export const <type>Command: StepCommand<<Type>StepConfig> = {
+  type: '<type>',
+  description: '<Description>',
+  capabilities: [
+    // { type: 'fs:read' },
+  ] as readonly StepCapability[],
+  defaultMofloLevel: 'none',
+  configSchema: {
+    type: 'object',
+    properties: {
+      <field1>: { type: '<json-type>', description: '<Field description>' },
+      <field2>: { type: '<json-type>', description: '<Field description>' },
+    },
+    required: ['<field1>'],
+  } satisfies JSONSchema,
+
+  validate(config: <Type>StepConfig): ValidationResult {
+    const errors = [];
+    if (!config.<field1> || typeof config.<field1> !== '<expected-type>') {
+      errors.push({ path: '<field1>', message: '<field1> is required and must be a <expected-type>' });
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  async execute(config: <Type>StepConfig, context: WorkflowContext): Promise<StepOutput> {
+    const start = Date.now();
+    try {
+      // Implementation here
+      const result = {}; // compute result
+
+      return {
+        success: true,
+        data: { result },
+        duration: Date.now() - start,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: {},
+        error: err instanceof Error ? err.message : String(err),
+        duration: Date.now() - start,
+      };
+    }
+  },
+
+  describeOutputs(): OutputDescriptor[] {
+    return [
+      { name: 'result', type: 'object', description: 'The computed result' },
+    ];
+  },
+
+  // Optional: rollback on failure
+  // async rollback(config, context) { /* undo side effects */ },
+};
+```
+
+Alternatively, use the `createStepCommand()` factory from `src/packages/workflows/src/commands/create-step-command.ts` for compile-time type safety.
+
+### Step 3: Generate Step Command Test
+
+Create at `tests/packages/workflows/commands/<type>-command.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { <type>Command } from
+  '../../../../src/packages/workflows/src/commands/<type>-command.js';
+import type { WorkflowContext } from
+  '../../../../src/packages/workflows/src/types/step-command.types.js';
+
+const mockContext: WorkflowContext = {
+  variables: {},
+  args: {},
+  credentials: { get: vi.fn(), has: vi.fn() },
+  memory: { read: vi.fn(), write: vi.fn(), search: vi.fn() },
+  taskId: 'test-task',
+  workflowId: 'test-workflow',
+  stepIndex: 0,
+};
+
+describe('<type>Command', () => {
+  describe('metadata', () => {
+    it('has required properties', () => {
+      expect(<type>Command.type).toBe('<type>');
+      expect(<type>Command.description).toBeTruthy();
+      expect(<type>Command.configSchema).toBeDefined();
+      expect(<type>Command.configSchema.required).toContain('<field1>');
+    });
+  });
+
+  describe('validate', () => {
+    it('rejects missing required fields', () => {
+      const result = <type>Command.validate({} as any, mockContext);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('accepts valid config', () => {
+      const result = <type>Command.validate(
+        { <field1>: '<valid-value>' } as any,
+        mockContext,
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('execute', () => {
+    it('succeeds with valid config', async () => {
+      const result = await <type>Command.execute(
+        { <field1>: '<valid-value>' } as any,
+        mockContext,
+      );
+      expect(result.success).toBe(true);
+      expect(result.duration).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('describeOutputs', () => {
+    it('returns output descriptors', () => {
+      const outputs = <type>Command.describeOutputs();
+      expect(outputs.length).toBeGreaterThan(0);
+      for (const output of outputs) {
+        expect(output.name).toBeTruthy();
+        expect(output.type).toBeTruthy();
+      }
+    });
+  });
+});
+```
+
+### Step 4: Register the Step Command
+
+Add to `src/packages/workflows/src/commands/index.ts`:
+
+```typescript
+import { <type>Command } from './<type>-command.js';
+
+export { <type>Command };
+export type { <Type>StepConfig } from './<type>-command.js';
+
+// Add to the builtinCommands array:
+export const builtinCommands: readonly StepCommand[] = [
+  agentCommand,
+  bashCommand,
+  // ... existing commands
+  <type>Command,  // <-- add here
+];
+```
+
+### Step 5: Example Workflow YAML
+
+```yaml
+name: example-with-<type>
+version: "1.0"
+description: Example workflow using the <type> step
+
+steps:
+  - name: my-step
+    type: <type>
+    config:
+      <field1>: "value"
+      <field2>: "optional-value"
+```
+
+---
+
+## Reference
+
+### Type Definitions
+
+- **Connector interface:** `src/packages/workflows/src/types/workflow-connector.types.ts` — `WorkflowConnector`, `ConnectorAction`, `ConnectorOutput`, `ConnectorCapability`
+- **Step command interface:** `src/packages/workflows/src/types/step-command.types.ts` — `StepCommand`, `StepConfig`, `StepOutput`, `WorkflowContext`, `JSONSchema`
+- **Step factory:** `src/packages/workflows/src/commands/create-step-command.ts` — `createStepCommand()`
+
+### Existing Components
+
+**Shipped connectors** (`src/packages/workflows/src/connectors/`): `http` (http-tool.ts), `github-cli` (github-cli.ts), `playwright` (playwright.ts)
+
+**Built-in step commands** (`src/packages/workflows/src/commands/`): `agent` (agent-command.ts), `bash` (bash-command.ts), `condition` (condition-command.ts), `prompt` (prompt-command.ts), `memory` (memory-command.ts), `wait` (wait-command.ts), `loop` (loop-command.ts), `browser` (browser-command.ts), `github` (github-command.ts)
+
+### Related Skills
+
+- [/workflow-builder](../workflow-builder/) (#240) — composes connectors and steps into workflow definitions; references this skill when a needed connector doesn't exist

--- a/tests/skills/connector-builder.test.ts
+++ b/tests/skills/connector-builder.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Connector Builder Skill — Content Validation Tests
+ *
+ * Validates that the SKILL.md file is well-formed and contains
+ * all required sections for scaffolding connectors and step commands.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const SKILL_PATH = path.resolve(__dirname, '../../.claude/skills/connector-builder/SKILL.md');
+
+describe('connector-builder skill', () => {
+  let content: string;
+  let fmName: string;
+  let fmDescription: string;
+  let connectorSection: string;
+  let stepSection: string;
+
+  beforeAll(() => {
+    content = fs.readFileSync(SKILL_PATH, 'utf-8');
+
+    const fm = content.match(/^---\n([\s\S]*?)---/);
+    expect(fm).not.toBeNull();
+    const nameMatch = fm![1].match(/name:\s*"([^"]+)"/);
+    const descMatch = fm![1].match(/description:\s*"([^"]+)"/);
+    expect(nameMatch).not.toBeNull();
+    expect(descMatch).not.toBeNull();
+    fmName = nameMatch![1];
+    fmDescription = descMatch![1];
+
+    const sections = content.split('## Building a Step Command');
+    connectorSection = sections[0];
+    stepSection = sections[1];
+  });
+
+  describe('file structure', () => {
+    it('is non-empty', () => {
+      expect(content.length).toBeGreaterThan(100);
+    });
+  });
+
+  describe('YAML frontmatter', () => {
+    it('starts with YAML frontmatter delimiters', () => {
+      expect(content.startsWith('---\n')).toBe(true);
+    });
+
+    it('has a name field under 64 characters', () => {
+      expect(fmName.length).toBeLessThanOrEqual(64);
+      expect(fmName.length).toBeGreaterThan(0);
+    });
+
+    it('has a description field under 1024 characters', () => {
+      expect(fmDescription.length).toBeLessThanOrEqual(1024);
+    });
+
+    it('description mentions connectors and steps', () => {
+      const desc = fmDescription.toLowerCase();
+      expect(desc).toContain('connector');
+      expect(desc).toContain('step');
+    });
+
+    it('description includes a "when" trigger clause', () => {
+      const desc = fmDescription.toLowerCase();
+      expect(desc).toMatch(/use when|when creating|when building|when extending/);
+    });
+  });
+
+  describe('connector scaffolding', () => {
+    it('contains a connector building section', () => {
+      expect(content).toMatch(/## Building a Connector/i);
+    });
+
+    it('references WorkflowConnector interface', () => {
+      expect(content).toContain('WorkflowConnector');
+    });
+
+    it('references ConnectorAction type', () => {
+      expect(content).toContain('ConnectorAction');
+    });
+
+    it('references ConnectorOutput type', () => {
+      expect(content).toContain('ConnectorOutput');
+    });
+
+    it('includes connector capabilities list', () => {
+      const capSection = content.match(/Capabilities.*?`read`.*?`write`.*?`search`.*?`subscribe`.*?`authenticate`/s);
+      expect(capSection).not.toBeNull();
+    });
+
+    it('shows connector registration in index.ts', () => {
+      expect(content).toContain('connectors/index.ts');
+      expect(content).toContain('builtinConnectors');
+    });
+
+    it('includes initialize and dispose lifecycle methods', () => {
+      expect(content).toContain('initialize');
+      expect(content).toContain('dispose');
+    });
+
+    it('includes listActions method', () => {
+      expect(content).toContain('listActions');
+    });
+  });
+
+  describe('step command scaffolding', () => {
+    it('contains a step building section', () => {
+      expect(content).toMatch(/## Building a Step Command/i);
+    });
+
+    it('references StepCommand interface', () => {
+      expect(content).toContain('StepCommand');
+    });
+
+    it('references StepConfig type', () => {
+      expect(content).toContain('StepConfig');
+    });
+
+    it('references StepOutput type', () => {
+      expect(content).toContain('StepOutput');
+    });
+
+    it('references WorkflowContext type', () => {
+      expect(content).toContain('WorkflowContext');
+    });
+
+    it('includes configSchema with JSONSchema', () => {
+      expect(content).toContain('configSchema');
+      expect(content).toContain('JSONSchema');
+    });
+
+    it('includes validate and execute methods', () => {
+      expect(content).toContain('validate');
+      expect(content).toContain('execute');
+    });
+
+    it('includes describeOutputs method', () => {
+      expect(content).toContain('describeOutputs');
+    });
+
+    it('shows step registration in commands/index.ts', () => {
+      expect(content).toContain('commands/index.ts');
+      expect(content).toContain('builtinCommands');
+    });
+
+    it('mentions createStepCommand factory', () => {
+      expect(content).toContain('createStepCommand');
+    });
+  });
+
+  describe('test generation', () => {
+    it('includes connector test template', () => {
+      expect(content).toMatch(/Generate Connector Test/i);
+      expect(content).toContain('vitest');
+    });
+
+    it('includes step command test template', () => {
+      expect(content).toMatch(/Generate Step Command Test/i);
+      expect(content).toContain('mockContext');
+    });
+  });
+
+  describe('workflow YAML examples', () => {
+    it('includes connector workflow YAML example', () => {
+      expect(connectorSection).toContain('```yaml');
+    });
+
+    it('includes step command workflow YAML example', () => {
+      expect(stepSection).toContain('```yaml');
+    });
+  });
+
+  describe('reference tables', () => {
+    it('lists existing shipped connectors', () => {
+      expect(content).toContain('github-cli');
+      expect(content).toContain('http');
+      expect(content).toContain('playwright');
+    });
+
+    it('lists existing built-in step commands', () => {
+      expect(content).toContain('agent-command');
+      expect(content).toContain('bash-command');
+      expect(content).toContain('condition-command');
+      expect(content).toContain('memory-command');
+    });
+
+    it('references the workflow-builder skill (#240)', () => {
+      expect(content).toContain('workflow-builder');
+      expect(content).toContain('#240');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `/connector-builder` Claude Code skill that guides users through creating workflow connectors (`WorkflowConnector`) and step commands (`StepCommand`)
- Skill provides complete TypeScript templates, test scaffolding, registration instructions, and workflow YAML examples
- Add content validation tests (31 tests) verifying skill structure, frontmatter, and completeness

## Test plan

- [x] 31 vitest tests pass validating SKILL.md content
- [x] YAML frontmatter has valid `name` (< 64 chars) and `description` (< 1024 chars)
- [x] Connector scaffolding section covers: interface, actions, capabilities, lifecycle, registration
- [x] Step command section covers: interface, config, validation, execution, registration
- [x] Test templates and workflow YAML examples included for both types
- [x] Reference section lists existing connectors and step commands
- [x] Cross-references #240 (workflow-builder skill)

Closes #238

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)