### PR TITLE
refactor(workflows): consolidate shared workflow type definitions (#230)

### DIFF
--- a/src/packages/cli/src/commands/workflow.ts
+++ b/src/packages/cli/src/commands/workflow.ts
@@ -11,6 +11,15 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
+import type {
+  WorkflowRunResponse,
+  WorkflowStatusResponse,
+  WorkflowListResponse,
+  WorkflowCancelResponse,
+  WorkflowTemplateListResponse,
+  WorkflowTemplateInfoResponse,
+  WorkflowErrorResponse,
+} from '../mcp-tools/workflow-response.types.js';
 
 // Shared table column definitions
 const REGISTRY_COLUMNS = [
@@ -28,7 +37,7 @@ const STEP_COLUMNS = [
   { key: 'error', header: 'Error', width: 30, format: (v: unknown) => v ? String(v) : '' },
 ];
 
-function printWorkflowErrors(errors: Array<{ code: string; message: string }>): void {
+function printWorkflowErrors(errors: WorkflowErrorResponse[]): void {
   if (errors.length === 0) return;
   output.writeln();
   output.writeln(output.bold(output.error('Errors')));
@@ -77,9 +86,7 @@ const runCommand: Command = {
       // Interactive: list available workflows and let user pick
       if (ctx.interactive) {
         try {
-          const listResult = await callMCPTool<{
-            definitions?: Array<{ name: string; abbreviation?: string; description?: string; tier: string }>;
-          }>('workflow_list', { source: 'registry' });
+          const listResult = await callMCPTool<WorkflowListResponse>('workflow_list', { source: 'registry' });
 
           const defs = listResult.definitions ?? [];
           if (defs.length === 0) {
@@ -124,23 +131,7 @@ const runCommand: Command = {
     try {
       spinner.start();
 
-      const result = await callMCPTool<{
-        workflowId: string;
-        success: boolean;
-        cancelled: boolean;
-        duration: number;
-        stepCount: number;
-        steps: Array<{
-          stepId: string;
-          stepType: string;
-          status: string;
-          duration: number;
-          error?: string;
-        }>;
-        outputs: Record<string, unknown>;
-        errors: Array<{ code: string; message: string }>;
-        error?: string;
-      }>('workflow_run', {
+      const result = await callMCPTool<WorkflowRunResponse>('workflow_run', {
         name: name || undefined,
         file: file || undefined,
         args,
@@ -222,12 +213,7 @@ const validateCommand: Command = {
     output.printInfo(`Validating: ${file}`);
 
     try {
-      const result = await callMCPTool<{
-        workflowId: string;
-        success: boolean;
-        errors: Array<{ code: string; message: string }>;
-        steps: Array<{ stepId: string; stepType: string; status: string }>;
-      }>('workflow_run', {
+      const result = await callMCPTool<WorkflowRunResponse>('workflow_run', {
         file,
         dryRun: true,
       });
@@ -282,12 +268,7 @@ const listCommand: Command = {
     const limit = ctx.flags.limit as number;
 
     try {
-      const result = await callMCPTool<{
-        definitions?: Array<{ name: string; abbreviation?: string; description?: string; tier: string }>;
-        runs?: Array<{ workflowId: string; name: string; status: string; startedAt: string; completedAt?: string }>;
-        activeWorkflows?: string[];
-        registryError?: string;
-      }>('workflow_list', { source, limit });
+      const result = await callMCPTool<WorkflowListResponse>('workflow_list', { source, limit });
 
       if (ctx.flags.format === 'json') {
         output.printJson(result);
@@ -356,21 +337,7 @@ const statusCommand: Command = {
     }
 
     try {
-      const result = await callMCPTool<{
-        workflowId: string;
-        name?: string;
-        status: string;
-        success?: boolean;
-        duration?: number;
-        stepCount?: number;
-        completedSteps?: number;
-        progress?: number;
-        startedAt?: string;
-        completedAt?: string;
-        steps?: Array<{ stepId: string; stepType: string; status: string; duration: number; error?: string }>;
-        errors?: Array<{ code: string; message: string }>;
-        error?: string;
-      }>('workflow_status', {
+      const result = await callMCPTool<WorkflowStatusResponse>('workflow_status', {
         workflowId,
         verbose: true,
       });
@@ -449,13 +416,7 @@ const stopCommand: Command = {
     }
 
     try {
-      const result = await callMCPTool<{
-        workflowId: string;
-        status: string;
-        cancelledAt?: string;
-        reason?: string;
-        error?: string;
-      }>('workflow_cancel', {
+      const result = await callMCPTool<WorkflowCancelResponse>('workflow_cancel', {
         workflowId,
         reason: 'Stopped via CLI',
       });
@@ -488,12 +449,7 @@ const templateCommand: Command = {
       description: 'List available workflow templates',
       action: async (ctx: CommandContext): Promise<CommandResult> => {
         try {
-          const result = await callMCPTool<{
-            action: string;
-            templates: Array<{ name: string; abbreviation?: string; description?: string; tier: string }>;
-            total: number;
-            error?: string;
-          }>('workflow_template', { action: 'list' });
+          const result = await callMCPTool<WorkflowTemplateListResponse>('workflow_template', { action: 'list' });
 
           if (result.error) {
             output.printError(result.error);
@@ -544,19 +500,7 @@ const templateCommand: Command = {
         }
 
         try {
-          const result = await callMCPTool<{
-            action: string;
-            name?: string;
-            abbreviation?: string;
-            description?: string;
-            version?: string;
-            sourceFile?: string;
-            tier?: string;
-            arguments?: Record<string, unknown>;
-            stepCount?: number;
-            stepTypes?: string[];
-            error?: string;
-          }>('workflow_template', { action: 'info', query });
+          const result = await callMCPTool<WorkflowTemplateInfoResponse>('workflow_template', { action: 'info', query });
 
           if (result.error) {
             output.printError(result.error);

--- a/src/packages/cli/src/epic/runner-adapter.ts
+++ b/src/packages/cli/src/epic/runner-adapter.ts
@@ -8,11 +8,11 @@
  * Story #229: Uses shared engine loader instead of inline dynamic import.
  */
 
-import { loadWorkflowEngine, type WorkflowResultLike } from '../services/engine-loader.js';
+import { loadWorkflowEngine, type WorkflowResult } from '../services/engine-loader.js';
 
 /** Minimal workflow result shape matching WorkflowResult from @claude-flow/workflows. */
 export type EpicWorkflowResult = Pick<
-  WorkflowResultLike,
+  WorkflowResult,
   'workflowId' | 'success' | 'outputs' | 'duration' | 'cancelled'
 > & {
   steps: Array<{

--- a/src/packages/cli/src/mcp-tools/workflow-response.types.ts
+++ b/src/packages/cli/src/mcp-tools/workflow-response.types.ts
@@ -1,0 +1,119 @@
+/**
+ * Workflow MCP Response Types
+ *
+ * Shared type definitions for workflow MCP tool responses.
+ * Used by both the MCP tool handlers (workflow-tools.ts) and
+ * the CLI workflow command (commands/workflow.ts) for type-safe
+ * callMCPTool<T>() deserialization.
+ *
+ * Story #230: Extract shared workflow type definitions.
+ */
+
+/** Response from workflow_run / workflow_execute MCP tools. */
+export interface WorkflowRunResponse {
+  workflowId: string;
+  success: boolean;
+  cancelled: boolean;
+  duration: number;
+  stepCount: number;
+  steps: WorkflowStepResponse[];
+  outputs: Record<string, unknown>;
+  errors: WorkflowErrorResponse[];
+  error?: string;
+}
+
+/** Serialized step in a workflow MCP response. */
+export interface WorkflowStepResponse {
+  [key: string]: unknown;
+  stepId: string;
+  stepType: string;
+  status: string;
+  duration: number;
+  error?: string;
+  errorCode?: string;
+  outputData?: unknown;
+}
+
+/** Serialized error in a workflow MCP response. */
+export interface WorkflowErrorResponse {
+  code: string;
+  message: string;
+  stepId?: string;
+}
+
+/** Response from workflow_status MCP tool. */
+export interface WorkflowStatusResponse {
+  workflowId: string;
+  name?: string;
+  status: string;
+  success?: boolean;
+  duration?: number;
+  stepCount?: number;
+  completedSteps?: number;
+  progress?: number;
+  startedAt?: string;
+  completedAt?: string;
+  steps?: WorkflowStepResponse[];
+  errors?: WorkflowErrorResponse[];
+  outputs?: Record<string, unknown>;
+  error?: string;
+}
+
+/** Entry in a workflow registry list response. */
+export interface WorkflowRegistryEntry {
+  [key: string]: unknown;
+  name: string;
+  abbreviation?: string;
+  description?: string;
+  tier: string;
+}
+
+/** Response from workflow_list MCP tool. */
+export interface WorkflowListResponse {
+  definitions?: WorkflowRegistryEntry[];
+  runs?: WorkflowRunEntry[];
+  activeWorkflows?: string[];
+  registryError?: string;
+}
+
+/** A tracked workflow run entry. */
+export interface WorkflowRunEntry {
+  [key: string]: unknown;
+  workflowId: string;
+  name: string;
+  status: string;
+  startedAt: string;
+  completedAt?: string;
+}
+
+/** Response from workflow_cancel MCP tool. */
+export interface WorkflowCancelResponse {
+  workflowId: string;
+  status: string;
+  cancelledAt?: string;
+  reason?: string;
+  error?: string;
+}
+
+/** Response from workflow_template list action. */
+export interface WorkflowTemplateListResponse {
+  action: string;
+  templates: WorkflowRegistryEntry[];
+  total: number;
+  error?: string;
+}
+
+/** Response from workflow_template info action. */
+export interface WorkflowTemplateInfoResponse {
+  action: string;
+  name?: string;
+  abbreviation?: string;
+  description?: string;
+  version?: string;
+  sourceFile?: string;
+  tier?: string;
+  arguments?: Record<string, unknown>;
+  stepCount?: number;
+  stepTypes?: string[];
+  error?: string;
+}

--- a/src/packages/cli/src/mcp-tools/workflow-tools.ts
+++ b/src/packages/cli/src/mcp-tools/workflow-tools.ts
@@ -13,9 +13,9 @@ import {
   loadWorkflowEngine,
   getCachedEngine,
   type EngineModule,
-  type WorkflowResultLike,
-  type WorkflowDefinitionLike,
-  type WorkflowRegistryLike,
+  type WorkflowResult,
+  type WorkflowDefinition,
+  type WorkflowRegistry,
 } from '../services/engine-loader.js';
 import { findProjectRoot } from '../services/project-root.js';
 
@@ -52,7 +52,7 @@ interface TrackedWorkflow {
   name: string;
   description?: string;
   status: WfStatus;
-  result?: WorkflowResultLike;
+  result?: WorkflowResult;
   startedAt: string;
   completedAt?: string;
 }
@@ -80,7 +80,7 @@ function trackStart(workflowId: string, name: string, description?: string): Tra
   return tracked;
 }
 
-function trackResult(tracked: TrackedWorkflow, result: WorkflowResultLike): void {
+function trackResult(tracked: TrackedWorkflow, result: WorkflowResult): void {
   tracked.status = result.cancelled ? WF_STATUS.CANCELLED : result.success ? WF_STATUS.COMPLETED : WF_STATUS.FAILED;
   tracked.result = result;
   tracked.completedAt = new Date().toISOString();
@@ -89,7 +89,7 @@ function trackResult(tracked: TrackedWorkflow, result: WorkflowResultLike): void
 /** Execute a definition via the engine with tracking and error handling. */
 async function executeAndTrack(
   engine: EngineModule,
-  definition: WorkflowDefinitionLike,
+  definition: WorkflowDefinition,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const workflowId = `wf-${Date.now()}`;
@@ -110,10 +110,10 @@ async function executeAndTrack(
 // Registry singleton (created once per session)
 // ============================================================================
 
-let registryInstance: WorkflowRegistryLike | null = null;
-let pendingRegistry: Promise<WorkflowRegistryLike> | null = null;
+let registryInstance: WorkflowRegistry | null = null;
+let pendingRegistry: Promise<WorkflowRegistry> | null = null;
 
-async function getRegistry(): Promise<WorkflowRegistryLike> {
+async function getRegistry(): Promise<WorkflowRegistry> {
   if (registryInstance) return registryInstance;
   if (pendingRegistry) return pendingRegistry;
 
@@ -153,7 +153,7 @@ function errorMsg(err: unknown): string {
 }
 
 /** Serialize a single step for MCP responses. */
-function serializeStep(s: WorkflowResultLike['steps'][number]) {
+function serializeStep(s: WorkflowResult['steps'][number]) {
   return {
     stepId: s.stepId,
     stepType: s.stepType,
@@ -166,12 +166,12 @@ function serializeStep(s: WorkflowResultLike['steps'][number]) {
 }
 
 /** Count succeeded steps in a result. */
-function countCompleted(result: WorkflowResultLike): number {
+function countCompleted(result: WorkflowResult): number {
   return result.steps.filter(s => s.status === 'succeeded').length;
 }
 
 /** Serialize a WorkflowResult for MCP response (typed errors, step details). */
-function serializeResult(result: WorkflowResultLike): Record<string, unknown> {
+function serializeResult(result: WorkflowResult): Record<string, unknown> {
   return {
     workflowId: result.workflowId,
     success: result.success,
@@ -289,8 +289,8 @@ export const workflowTools: MCPTool[] = [
       const steps = (input.steps as Array<{ id?: string; type?: string; config?: Record<string, unknown> }>) ?? [];
       const args = input.arguments as Record<string, unknown> | undefined;
 
-      // Build a WorkflowDefinition-compatible object
-      const definition: WorkflowDefinitionLike = {
+      // Build a WorkflowDefinition-compatible object from untyped MCP input
+      const definition = {
         name,
         description,
         arguments: args,
@@ -299,7 +299,7 @@ export const workflowTools: MCPTool[] = [
           type: s.type ?? 'bash',
           config: s.config ?? {},
         })),
-      };
+      } as WorkflowDefinition;
 
       return {
         name,
@@ -328,7 +328,7 @@ export const workflowTools: MCPTool[] = [
       required: ['definition'],
     },
     handler: async (input) => {
-      const definition = input.definition as WorkflowDefinitionLike;
+      const definition = input.definition as WorkflowDefinition;
       const args = (input.args as Record<string, unknown>) ?? {};
 
       if (!definition || !definition.name || !definition.steps) {

--- a/src/packages/cli/src/services/engine-loader.ts
+++ b/src/packages/cli/src/services/engine-loader.ts
@@ -6,73 +6,52 @@
  * this instead of maintaining their own import/cache logic.
  *
  * Story #229: Extract shared engine loader.
+ * Story #230: Replaced *Like interfaces with import type from @claude-flow/workflows.
  */
 
-// Minimal type shapes to avoid static cross-package dependency on @claude-flow/workflows.
+import type {
+  WorkflowResult,
+} from '../../../../packages/workflows/src/types/runner.types.js';
+import type {
+  WorkflowDefinition,
+} from '../../../../packages/workflows/src/types/workflow-definition.types.js';
+import type {
+  WorkflowRegistry,
+  RegistryOptions,
+} from '../../../../packages/workflows/src/registry/workflow-registry.js';
 
-export interface WorkflowResultLike {
-  workflowId: string;
-  success: boolean;
-  steps: Array<{
-    stepId: string;
-    stepType: string;
-    status: string;
-    output?: { success: boolean; data?: unknown; error?: string };
-    error?: string;
-    errorCode?: string;
-    duration: number;
-  }>;
-  outputs: Record<string, unknown>;
-  errors: Array<{ stepId?: string; code: string; message: string; details?: unknown[] }>;
-  duration: number;
-  cancelled: boolean;
-}
+// Re-export workflow types so consumers import from engine-loader (single boundary).
+export type { WorkflowResult };
+export type { WorkflowDefinition };
+export type { WorkflowRegistry };
 
-export interface WorkflowDefinitionLike {
-  name: string;
-  abbreviation?: string;
-  description?: string;
-  version?: string;
-  arguments?: Record<string, unknown>;
-  steps: readonly Record<string, unknown>[];
-  mofloLevel?: string;
-}
-
-export interface WorkflowRegistryLike {
-  load(): {
-    workflows: ReadonlyMap<string, { definition: WorkflowDefinitionLike; sourceFile: string; tier: string }>;
-    errors: readonly { file: string; message: string }[];
-  };
-  resolve(query: string): { definition: WorkflowDefinitionLike; sourceFile: string; tier: string } | undefined;
-  list(): readonly { name: string; abbreviation?: string; description?: string; tier: string }[];
-  info(query: string): {
-    name: string; abbreviation?: string; description?: string; version?: string;
-    sourceFile: string; tier: string; arguments: Record<string, unknown>;
-    stepCount: number; stepTypes: readonly string[];
-  } | undefined;
-}
-
+/**
+ * Shape of the dynamically imported workflow engine module.
+ *
+ * Uses the canonical types from @claude-flow/workflows (type-only, no runtime dep).
+ * The actual module is loaded via dynamic import() at runtime.
+ */
 export interface EngineModule {
   bridgeRunWorkflow: (
     content: string,
     sourceFile: string | undefined,
     args: Record<string, unknown>,
     options?: { dryRun?: boolean },
-  ) => Promise<WorkflowResultLike>;
+  ) => Promise<WorkflowResult>;
   bridgeExecuteWorkflow: (
-    definition: WorkflowDefinitionLike,
+    definition: WorkflowDefinition,
     args: Record<string, unknown>,
     options?: { workflowId?: string },
-  ) => Promise<WorkflowResultLike>;
+  ) => Promise<WorkflowResult>;
   bridgeCancelWorkflow: (workflowId: string) => boolean;
   bridgeIsRunning: (workflowId: string) => boolean;
   bridgeActiveWorkflows: () => string[];
-  WorkflowRegistry: new (options?: Record<string, unknown>) => WorkflowRegistryLike;
+  WorkflowRegistry: new (options?: RegistryOptions) => WorkflowRegistry;
   runWorkflowFromContent: (
     content: string,
     sourceFile: string | undefined,
     options?: Record<string, unknown>,
-  ) => Promise<WorkflowResultLike>;
+  ) => Promise<WorkflowResult>;
 }
 
 let cachedEngine: EngineModule | null = null;

--- a/src/packages/cli/tsconfig.json
+++ b/src/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
   "exclude": ["node_modules", "dist"],
   "references": [
     { "path": "../shared" },
-    { "path": "../swarm" }
+    { "path": "../swarm" },
+    { "path": "../workflows" }
   ]
 }


### PR DESCRIPTION
## Summary
- Replaced 3 duplicate `*Like` interfaces in `engine-loader.ts` with `import type` from `@claude-flow/workflows` (compile-time only, zero runtime impact)
- Created `workflow-response.types.ts` with shared MCP response type definitions
- Updated 7 inline `callMCPTool<{...}>` type annotations in `workflow.ts` CLI command to use shared types
- Added tsconfig project reference from CLI to workflows package

## Changes
- **`engine-loader.ts`**: Removed `WorkflowResultLike`, `WorkflowDefinitionLike`, `WorkflowRegistryLike` (~40 lines). `EngineModule` now uses canonical types.
- **`workflow-response.types.ts`** (new): Shared MCP response interfaces for workflow tools
- **`workflow.ts`**: All `callMCPTool<>` calls use named shared types instead of inline definitions
- **`workflow-tools.ts`**: Uses `WorkflowResult`, `WorkflowDefinition`, `WorkflowRegistry` from engine-loader
- **`runner-adapter.ts`**: Uses `WorkflowResult` instead of `WorkflowResultLike`
- **`tsconfig.json`**: Added `{ "path": "../workflows" }` reference

## Testing
- [x] Build passes (`tsc -b` clean)
- [x] Engine-loader tests pass (6/6)
- [x] Workflow package tests pass (771/771 across 36 files)
- [x] Full test suite: all failures are pre-existing worker OOM crashes (unrelated)

Closes #230

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)