### PR TITLE
fix(workflows): add registry refresh to invalidate stale definition cache (#231)

### DIFF
--- a/src/packages/cli/__tests__/workflow-tools-engine.test.ts
+++ b/src/packages/cli/__tests__/workflow-tools-engine.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { workflowTools } from '../src/mcp-tools/workflow-tools.js';
+import { workflowTools, invalidateRegistry } from '../src/mcp-tools/workflow-tools.js';
 
 function findTool(name: string) {
   const tool = workflowTools.find(t => t.name === name);
@@ -257,6 +257,44 @@ steps:
     const tool = findTool('workflow_template');
     const result: any = await tool.handler({ action: 'unknown' });
     expect(result.error).toMatch(/unknown action/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Registry invalidation (Story #231)
+  // -------------------------------------------------------------------------
+
+  it('workflow_list with refresh=true returns refreshed=true', async () => {
+    const tool = findTool('workflow_list');
+    const result: any = await tool.handler({ source: 'registry', refresh: true });
+    expect(result.refreshed).toBe(true);
+    expect(result.definitions).toBeDefined();
+  });
+
+  it('workflow_list without refresh does not include refreshed flag', async () => {
+    const tool = findTool('workflow_list');
+    const result: any = await tool.handler({ source: 'registry' });
+    expect(result.refreshed).toBeUndefined();
+  });
+
+  it('invalidateRegistry can be called without error when no instance exists', () => {
+    // Clear any existing instance first, then call again — should not throw
+    invalidateRegistry();
+    invalidateRegistry();
+  });
+
+  it('registry returns fresh data after invalidation', async () => {
+    const tool = findTool('workflow_list');
+
+    // First call loads and caches the registry
+    const first: any = await tool.handler({ source: 'registry' });
+    expect(first.definitions).toBeDefined();
+
+    // Refresh forces a re-scan — should still return valid data
+    const second: any = await tool.handler({ source: 'registry', refresh: true });
+    expect(second.refreshed).toBe(true);
+    expect(second.definitions).toBeDefined();
+    // Same shipped definitions should be present
+    expect(second.definitions.length).toBe(first.definitions.length);
   });
 
   // -------------------------------------------------------------------------

--- a/src/packages/cli/src/commands/workflow.ts
+++ b/src/packages/cli/src/commands/workflow.ts
@@ -262,13 +262,21 @@ const listCommand: Command = {
       type: 'number',
       default: 20,
     },
+    {
+      name: 'refresh',
+      short: 'r',
+      description: 'Re-scan definition files before listing (invalidate cache)',
+      type: 'boolean',
+      default: false,
+    },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const source = (ctx.flags.source as string) ?? 'all';
     const limit = ctx.flags.limit as number;
+    const refresh = ctx.flags.refresh as boolean;
 
     try {
-      const result = await callMCPTool<WorkflowListResponse>('workflow_list', { source, limit });
+      const result = await callMCPTool<WorkflowListResponse>('workflow_list', { source, limit, refresh: refresh || undefined });
 
       if (ctx.flags.format === 'json') {
         output.printJson(result);

--- a/src/packages/cli/src/mcp-tools/workflow-response.types.ts
+++ b/src/packages/cli/src/mcp-tools/workflow-response.types.ts
@@ -74,6 +74,7 @@ export interface WorkflowListResponse {
   runs?: WorkflowRunEntry[];
   activeWorkflows?: string[];
   registryError?: string;
+  refreshed?: boolean;
 }
 
 /** A tracked workflow run entry. */

--- a/src/packages/cli/src/mcp-tools/workflow-tools.ts
+++ b/src/packages/cli/src/mcp-tools/workflow-tools.ts
@@ -107,7 +107,7 @@ async function executeAndTrack(
 }
 
 // ============================================================================
-// Registry singleton (created once per session)
+// Registry singleton (created once per session, refreshable on demand)
 // ============================================================================
 
 let registryInstance: WorkflowRegistry | null = null;
@@ -141,6 +141,11 @@ async function getRegistry(): Promise<WorkflowRegistry> {
   })();
 
   return pendingRegistry;
+}
+
+/** Drop the cached registry singleton, forcing a fresh re-scan on next access. */
+export function invalidateRegistry(): void {
+  registryInstance = null;
 }
 
 // ============================================================================
@@ -430,12 +435,18 @@ export const workflowTools: MCPTool[] = [
         source: { type: 'string', enum: ['registry', 'runs', 'all'], description: 'What to list (default: all)' },
         status: { type: 'string', description: 'Filter runs by status' },
         limit: { type: 'number', description: 'Max items to return' },
+        refresh: { type: 'boolean', description: 'Invalidate cached registry and re-scan definition files before listing' },
       },
     },
     handler: async (input) => {
       const source = (input.source as string) ?? LIST_SOURCE.ALL;
       const limit = (input.limit as number) ?? 20;
       const result: Record<string, unknown> = {};
+
+      if (input.refresh) {
+        invalidateRegistry();
+        result.refreshed = true;
+      }
 
       if (source === LIST_SOURCE.REGISTRY || source === LIST_SOURCE.ALL) {
         try {


### PR DESCRIPTION
## Summary
- Added `refresh` flag to `workflow_list` MCP tool that invalidates the cached WorkflowRegistry singleton before listing
- Added `--refresh/-r` CLI flag to `moflo workflow list` command
- Exported `invalidateRegistry()` for programmatic use

## Changes
- **`workflow-tools.ts`**: Added `invalidateRegistry()` function and `refresh` param to `workflow_list` schema/handler
- **`workflow.ts`**: Added `--refresh/-r` option to CLI `list` subcommand
- **`workflow-response.types.ts`**: Added `refreshed?: boolean` to `WorkflowListResponse`
- **Tests**: 4 new tests for invalidation behavior (25/25 total pass)

## Testing
- [x] Unit tests pass (25/25 workflow-tools-engine tests)
- [x] Build passes (tsc -b clean)
- [x] /simplify reviewed — simplified invalidateRegistry to single-line null

Closes #231

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)