### PR TITLE
chore(workflows): remove deprecated tool→connector aliases

### DIFF
--- a/.claude/guidance/shipped/moflo-workflow-engine.md
+++ b/.claude/guidance/shipped/moflo-workflow-engine.md
@@ -490,6 +490,8 @@ Credential values listed in `RunnerOptions.credentialValues` are automatically r
 
 ## See Also
 
+- `.claude/guidance/shipped/moflo-workflow-connectors.md` — Connectors: resource adapters, registry, step-vs-connector decision
+- `.claude/guidance/shipped/moflo-workflow-sandboxing.md` — Capability-based security for steps
 - `.claude/guidance/shipped/moflo-workflow-engine-architecture.md` — Architecture decisions for Epic #100
 - `.claude/guidance/shipped/moflo-core-guidance.md` — CLI, hooks, swarm, memory reference
 - `.claude/guidance/shipped/moflo-subagents.md` — Subagents protocol

--- a/src/packages/workflows/src/connectors/index.ts
+++ b/src/packages/workflows/src/connectors/index.ts
@@ -18,12 +18,3 @@ export const builtinConnectors: WorkflowConnector[] = [
   playwrightConnector,
 ];
 
-// Backwards-compatibility aliases (one release cycle)
-/** @deprecated Use `httpConnector` instead. */
-export const httpTool = httpConnector;
-/** @deprecated Use `githubCliConnector` instead. */
-export const githubCliTool = githubCliConnector;
-/** @deprecated Use `playwrightConnector` instead. */
-export const playwrightTool = playwrightConnector;
-/** @deprecated Use `builtinConnectors` instead. */
-export const builtinTools = builtinConnectors;

--- a/src/packages/workflows/src/core/connector-accessor.ts
+++ b/src/packages/workflows/src/core/connector-accessor.ts
@@ -50,6 +50,3 @@ export class ConnectorAccessorImpl implements ConnectorAccessor {
     return connector.execute(action, params);
   }
 }
-
-/** @deprecated Use `ConnectorAccessorImpl` instead. */
-export const ToolAccessorImpl = ConnectorAccessorImpl;

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -55,7 +55,7 @@ export type {
 
 export { StepCommandRegistry } from './core/step-command-registry.js';
 export { WorkflowRunner } from './core/runner.js';
-export { ConnectorAccessorImpl, ToolAccessorImpl } from './core/connector-accessor.js';
+export { ConnectorAccessorImpl } from './core/connector-accessor.js';
 export {
   checkCapabilities,
   type CapabilityViolation,
@@ -223,26 +223,13 @@ export type {
   ConnectorAccessor,
   ConnectorRegistryEntry,
   ConnectorSource,
-  // Backwards-compatibility aliases
-  WorkflowTool,
-  ToolView,
-  ToolOutput,
-  ToolAction,
-  ToolCapability,
-  ToolAccessor,
-  ToolRegistryEntry,
-  ToolSource,
 } from './types/workflow-connector.types.js';
 
 export {
   WorkflowConnectorRegistry,
-  WorkflowToolRegistry,
   type ConnectorRegistryOptions,
   type ConnectorScanResult,
   type ConnectorScanError,
-  type ToolRegistryOptions,
-  type ToolScanResult,
-  type ToolScanError,
 } from './registry/connector-registry.js';
 
 // ============================================================================
@@ -254,9 +241,4 @@ export {
   githubCliConnector,
   playwrightConnector,
   builtinConnectors,
-  // Backwards-compatibility aliases
-  httpTool,
-  githubCliTool,
-  playwrightTool,
-  builtinTools,
 } from './connectors/index.js';

--- a/src/packages/workflows/src/registry/connector-registry.ts
+++ b/src/packages/workflows/src/registry/connector-registry.ts
@@ -269,16 +269,3 @@ function discoverNpmConnectors(projectRoot: string): NpmConnectorDiscovery[] {
 
   return results;
 }
-
-// ============================================================================
-// Backwards-Compatibility Aliases (one release cycle)
-// ============================================================================
-
-/** @deprecated Use `WorkflowConnectorRegistry` instead. */
-export const WorkflowToolRegistry = WorkflowConnectorRegistry;
-/** @deprecated Use `ConnectorRegistryOptions` instead. */
-export type ToolRegistryOptions = ConnectorRegistryOptions;
-/** @deprecated Use `ConnectorScanResult` instead. */
-export type ToolScanResult = ConnectorScanResult;
-/** @deprecated Use `ConnectorScanError` instead. */
-export type ToolScanError = ConnectorScanError;

--- a/src/packages/workflows/src/types/workflow-connector.types.ts
+++ b/src/packages/workflows/src/types/workflow-connector.types.ts
@@ -92,22 +92,3 @@ export interface ConnectorRegistryEntry {
 export type ConnectorSource = 'shipped' | 'user' | 'npm';
 
 // ============================================================================
-// Backwards-Compatibility Aliases (one release cycle)
-// ============================================================================
-
-/** @deprecated Use `ConnectorOutput` instead. */
-export type ToolOutput = ConnectorOutput;
-/** @deprecated Use `ConnectorAction` instead. */
-export type ToolAction = ConnectorAction;
-/** @deprecated Use `ConnectorCapability` instead. */
-export type ToolCapability = ConnectorCapability;
-/** @deprecated Use `ConnectorView` instead. */
-export type ToolView = ConnectorView;
-/** @deprecated Use `ConnectorAccessor` instead. */
-export type ToolAccessor = ConnectorAccessor;
-/** @deprecated Use `WorkflowConnector` instead. */
-export type WorkflowTool = WorkflowConnector;
-/** @deprecated Use `ConnectorRegistryEntry` instead. */
-export type ToolRegistryEntry = ConnectorRegistryEntry;
-/** @deprecated Use `ConnectorSource` instead. */
-export type ToolSource = ConnectorSource;


### PR DESCRIPTION
## Summary
- Removes all `@deprecated` backwards-compatibility aliases from the tools→connectors rename (#239)
- These shims were kept for one release cycle which has now passed
- Net deletion of 63 lines across 5 workflow source files
- Adds cross-references to connectors and sandboxing guidance docs

## Test plan
- [ ] `npm run build` passes (removed exports are unused)
- [ ] `npm test` passes (no consumers of deprecated aliases remain)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)