### PR TITLE
fix: make full test suite green — zero failing tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
 - ALWAYS read a file before editing it
 - NEVER commit secrets, credentials, or .env files
 - ALWAYS write or update tests when changing testable code — no testable change ships without a corresponding test change
+- ZERO TOLERANCE for failing tests — if any test fails, fix it before proceeding, whether we caused the failure or not. Pre-existing failures are not acceptable; they must be fixed on sight.
 
 ## File Organization
 

--- a/scripts/test-runner.mjs
+++ b/scripts/test-runner.mjs
@@ -26,7 +26,7 @@ const child = spawn(
   ],
   {
     stdio: 'inherit',
-    env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=4096' },
+    env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=8192' },
   }
 );
 

--- a/src/packages/cli/__tests__/p1-commands.test.ts
+++ b/src/packages/cli/__tests__/p1-commands.test.ts
@@ -1060,5 +1060,5 @@ describe('Command Index Exports', () => {
     expect(commands).toContain(status);
     expect(commands).toContain(task);
     expect(commands).toContain(session);
-  });
+  }, 15_000);
 });

--- a/src/packages/embeddings/src/chunking.ts
+++ b/src/packages/embeddings/src/chunking.ts
@@ -114,7 +114,10 @@ function chunkByCharacter(
   config: Required<ChunkingConfig>
 ): Chunk[] {
   const chunks: Chunk[] = [];
-  const { maxChunkSize, overlap } = config;
+  const { maxChunkSize } = config;
+  // Clamp overlap to prevent infinite loops when overlap >= maxChunkSize
+  const overlap = Math.min(config.overlap, maxChunkSize - 1);
+  const step = maxChunkSize - overlap;
 
   let pos = 0;
   let index = 0;
@@ -132,11 +135,8 @@ function chunkByCharacter(
       tokenCount: Math.ceil(chunkText.length / 4),
     });
 
-    // Move position with overlap
-    pos = endPos - overlap;
-    if (pos >= text.length - overlap) {
-      break;
-    }
+    pos += step;
+    if (endPos >= text.length) break;
     index++;
   }
 

--- a/src/packages/plugins/package.json
+++ b/src/packages/plugins/package.json
@@ -25,7 +25,7 @@
     "./providers": {
       "types": "./dist/providers/index.d.ts",
       "import": "./dist/providers/index.js"
-    },
+    }
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/tests/skills/connector-builder.test.ts
+++ b/tests/skills/connector-builder.test.ts
@@ -21,7 +21,7 @@ describe('connector-builder skill', () => {
   beforeAll(() => {
     content = fs.readFileSync(SKILL_PATH, 'utf-8');
 
-    const fm = content.match(/^---\n([\s\S]*?)---/);
+    const fm = content.match(/^---\r?\n([\s\S]*?)---/);
     expect(fm).not.toBeNull();
     const nameMatch = fm![1].match(/name:\s*"([^"]+)"/);
     const descMatch = fm![1].match(/description:\s*"([^"]+)"/);
@@ -43,7 +43,7 @@ describe('connector-builder skill', () => {
 
   describe('YAML frontmatter', () => {
     it('starts with YAML frontmatter delimiters', () => {
-      expect(content.startsWith('---\n')).toBe(true);
+      expect(content.startsWith('---\r\n') || content.startsWith('---\n')).toBe(true);
     });
 
     it('has a name field under 64 characters', () => {

--- a/tests/skills/workflow-builder.test.ts
+++ b/tests/skills/workflow-builder.test.ts
@@ -20,7 +20,7 @@ describe('workflow-builder skill', () => {
   beforeAll(() => {
     content = fs.readFileSync(SKILL_PATH, 'utf-8');
 
-    const fm = content.match(/^---\n([\s\S]*?)---/);
+    const fm = content.match(/^---\r?\n([\s\S]*?)---/);
     expect(fm).not.toBeNull();
     const nameMatch = fm![1].match(/name:\s*"([^"]+)"/);
     const descMatch = fm![1].match(/description:\s*"([^"]+)"/);
@@ -39,7 +39,7 @@ describe('workflow-builder skill', () => {
 
   describe('YAML frontmatter', () => {
     it('starts with YAML frontmatter delimiters', () => {
-      expect(content.startsWith('---\n')).toBe(true);
+      expect(content.startsWith('---\r\n') || content.startsWith('---\n')).toBe(true);
     });
 
     it('has a name field under 64 characters', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     // heavy test suites (ruvector-bridge, analyzer, etc.) that otherwise
     // kill workers and cause vitest to exit 1 even when all tests pass.
     // Vitest 4 moved pool options to top-level (poolOptions is removed).
-    execArgv: ['--max-old-space-size=8192'],
+    execArgv: ['--max-old-space-size=12288'],
     // Limit concurrency to reduce memory pressure on Windows
     maxForks: 2,
     minForks: 1,


### PR DESCRIPTION
## Summary

- Fix trailing comma in `plugins/package.json` that broke all 11 plugin test files
- Fix CRLF-incompatible frontmatter regex in `connector-builder.test.ts` and `workflow-builder.test.ts`
- Fix infinite loop in `chunkByCharacter()` when `overlap >= maxChunkSize` (caused OOM during full suite)
- Increase test timeout for p1-commands dynamic import (5s → 15s) to survive concurrent load
- Bump vitest worker heap to 12GB, main process to 8GB to reduce OOM worker crashes
- Add zero-tolerance test failure policy to CLAUDE.md

## Testing

- [x] Full suite: 188 passed, 0 failed, 3 skipped, 6200 tests pass
- [x] Test runner exits 0

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)