### PR TITLE
docs(workflows): document execution constraint principle

### DIFF
--- a/.claude/guidance/shipped/moflo-workflow-engine.md
+++ b/.claude/guidance/shipped/moflo-workflow-engine.md
@@ -4,6 +4,21 @@
 
 ---
 
+## Claude's Role During Workflow Execution
+
+**Claude MUST treat the workflow definition as a strict contract — execute only what it specifies, using only the capabilities it declares.** This applies equally whether the workflow is run manually, via MCP, or on a schedule by the daemon.
+
+| Constraint | Detail |
+|-----------|--------|
+| Step config is the complete instruction | Do not add commands, flags, arguments, or actions beyond what `config` contains |
+| Capability restrictions are absolute | If a step restricts `fs:read` to `["./src/"]`, do not read files outside `./src/` even if helpful |
+| `CAPABILITY_DENIED` means stop | Do not attempt workarounds — report the denial and halt the step |
+| No improvisation between steps | Do not perform actions outside of step boundaries, even if "obvious" (e.g., do not auto-fix a failing step's output before passing it to the next step unless the workflow defines a step for that) |
+
+See `.claude/guidance/shipped/moflo-workflow-sandboxing.md` for the full Execution Constraint Principle and capability type reference.
+
+---
+
 ## Running a Workflow via MCP Tools
 
 **Use `mcp__moflo__workflow_run` to execute a workflow from a YAML/JSON file.** The bridge layer handles parsing, validation, and runner lifecycle automatically.

--- a/docs/WORKFLOW-SANDBOXING.md
+++ b/docs/WORKFLOW-SANDBOXING.md
@@ -4,6 +4,19 @@ MoFlo enforces **least-privilege access** for workflow steps. Every step command
 
 This is defense-in-depth without containers — using capability declarations and runtime enforcement.
 
+## Execution Constraint Principle
+
+When executing within a workflow, Claude **only performs actions explicitly authorized by the workflow definition, step configuration, and declared capabilities**. This is the foundational security contract:
+
+- **Only do what the step says.** A step's `config` defines the complete scope of work. A `bash` step with `command: "npm test"` runs `npm test` — nothing else.
+- **Respect all capability restrictions.** If a step restricts `fs:read` to `["./config/"]`, files outside that path are off-limits.
+- **Never escalate privileges.** A `CAPABILITY_DENIED` error is intentional — not a problem to work around.
+- **No implicit side effects.** No creating files, making network requests, spawning agents, or modifying state unless a step explicitly authorizes it.
+- **Scheduled workflows have the same restrictions as manual ones.** Automation does not grant additional permissions.
+- **The workflow definition is the complete specification.** If it doesn't instruct an action, that action is not authorized.
+
+This predictability is what makes automated and scheduled workflows safe to deploy.
+
 ## Capability Types
 
 | Capability | What It Grants | Commands That Use It |

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -689,6 +689,64 @@ Each error in the result carries a code that tells you what went wrong:
 | `ROLLBACK_FAILED` | Rollback of a completed step failed |
 | `WORKFLOW_CANCELLED` | The entire workflow was cancelled via AbortSignal |
 
+## Security and Sandboxing
+
+Workflows run with **least-privilege enforcement**. Every step command declares the capabilities it needs (file access, shell execution, network, etc.), and the runner blocks anything undeclared. This means a workflow can only do what its definition explicitly authorizes — nothing more.
+
+### How it works
+
+Each built-in step command has a fixed set of capabilities baked into its code. For example, `bash` declares `shell`, `fs:read`, and `fs:write`. The `condition` and `wait` commands declare nothing — they're pure computation.
+
+When you write a workflow, you can **restrict** a step's capabilities further, but you can never **expand** them:
+
+```yaml
+steps:
+  # This bash step can only read from ./config/ and only run cat and jq
+  - id: read-config
+    type: bash
+    capabilities:
+      fs:read: ["./config/"]
+      shell: ["cat", "jq"]
+    config:
+      command: "cat config/settings.json | jq '.database'"
+
+  # This bash step uses all default capabilities (unrestricted)
+  - id: build
+    type: bash
+    config:
+      command: "npm run build"
+```
+
+If a step's YAML tries to grant a capability the command doesn't have, execution is blocked:
+
+```
+Capability violation: step type "bash" does not declare capability "browser"
+— cannot grant new capabilities
+```
+
+### Capability types
+
+| Capability | What it grants | Step types that use it |
+|-----------|----------------|----------------------|
+| `fs:read` | Read files from disk | `bash`, `browser` |
+| `fs:write` | Write files to disk | `bash`, `browser` |
+| `net` | Network access (HTTP, WebSocket) | `browser` |
+| `shell` | Execute shell commands | `bash` |
+| `memory` | Read/write/search the workflow memory store | `memory` |
+| `credentials` | Access the encrypted credential store | Any step using `{credentials.X}` |
+| `browser` | Launch and control browser sessions | `browser` |
+| `agent` | Spawn Claude subagents | `agent` |
+
+Control-flow commands (`condition`, `loop`, `wait`, `prompt`) perform no I/O and require no capabilities.
+
+### The execution constraint
+
+The capability system enforces limits in code, but the principle goes deeper: **when Claude executes a workflow, it treats the definition as a strict contract.** It performs only the actions the steps specify, using only the capabilities they declare. It does not infer additional actions, add helpful extras, or work around denied capabilities. If the workflow definition doesn't instruct something, that something doesn't happen.
+
+This is what makes workflows safe for unattended and scheduled execution. You can read a workflow YAML file and know exactly what it will do — the definition is the complete specification.
+
+For full details on the sandboxing tiers, restriction rules, and how to declare capabilities on custom step commands, see [Workflow Sandboxing](WORKFLOW-SANDBOXING.md).
+
 ## Dry Run
 
 Dry-run mode validates everything without executing anything. It checks:
@@ -812,4 +870,5 @@ console.log(result.duration);    // Total execution time in ms
 
 ## Further Reading
 
-- [Workflow Sandboxing](WORKFLOW-SANDBOXING.md) — Capability-based security for workflow steps
+- [Workflow Sandboxing](WORKFLOW-SANDBOXING.md) — Full sandboxing reference: capability types, restriction rules, enforcement tiers, and the Execution Constraint Principle
+- [Build & Publish](BUILD.md) — Building and publishing MoFlo


### PR DESCRIPTION
## Summary
- Documents Claude's execution constraints during workflow runs in the workflow engine guidance
- Adds the Execution Constraint Principle to WORKFLOW-SANDBOXING.md — the foundational security contract
- Adds a Security and Sandboxing section to WORKFLOWS.md with capability types, restriction rules, and examples

## Test plan
- [ ] Verify docs render correctly on GitHub
- [ ] Confirm cross-references between WORKFLOWS.md and WORKFLOW-SANDBOXING.md link correctly

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)