### PR TITLE
feat(daemon): add install/uninstall for OS-native service registration

### DIFF
--- a/src/packages/cli/__tests__/services/daemon-service.test.ts
+++ b/src/packages/cli/__tests__/services/daemon-service.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Daemon Service Tests
+ *
+ * Validates OS-native service installation/uninstallation
+ * for macOS (launchd), Linux (systemd), and Windows (schtasks).
+ *
+ * Uses real temp directories with platform mocking.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Import internals for testing
+import {
+  isDaemonInstalled,
+  installDaemonService,
+  uninstallDaemonService,
+  _generatePlist,
+  _generateSystemdUnit,
+  _plistPath,
+  _systemdUnitPath,
+  _schtasksName,
+  _projectRootSlug,
+} from '../../src/services/daemon-service.js';
+
+describe('daemon-service', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'daemon-service-test-'));
+    mkdirSync(join(tempDir, '.claude-flow'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  // =========================================================================
+  // projectRootSlug
+  // =========================================================================
+  describe('projectRootSlug', () => {
+    it('should create a filesystem-safe slug', () => {
+      const slug = _projectRootSlug('/home/user/my-project');
+      expect(slug).toMatch(/^[a-z0-9-]+$/);
+      expect(slug.length).toBeLessThanOrEqual(60);
+    });
+
+    it('should produce different slugs for different paths', () => {
+      const slug1 = _projectRootSlug('/home/user/project-a');
+      const slug2 = _projectRootSlug('/home/user/project-b');
+      expect(slug1).not.toBe(slug2);
+    });
+  });
+
+  // =========================================================================
+  // macOS plist generation
+  // =========================================================================
+  describe('generatePlist', () => {
+    it('should produce valid XML with correct keys', () => {
+      const plist = _generatePlist('/Users/dev/myapp', '/usr/local/bin/node', '/usr/local/lib/cli.js');
+
+      expect(plist).toContain('<?xml version="1.0"');
+      expect(plist).toContain('<key>Label</key>');
+      expect(plist).toContain('com.moflo.daemon');
+      expect(plist).toContain('<key>ProgramArguments</key>');
+      expect(plist).toContain('/usr/local/bin/node');
+      expect(plist).toContain('/usr/local/lib/cli.js');
+      expect(plist).toContain('<key>RunAtLoad</key>');
+      expect(plist).toContain('<true/>');
+      expect(plist).toContain('<key>WorkingDirectory</key>');
+      expect(plist).toContain('/Users/dev/myapp');
+      expect(plist).toContain('daemon');
+      expect(plist).toContain('start');
+      expect(plist).toContain('--foreground');
+      expect(plist).toContain('--quiet');
+    });
+
+    it('should escape XML special characters in paths', () => {
+      const plist = _generatePlist('/Users/dev/my&app', '/usr/bin/node', '/cli.js');
+      expect(plist).toContain('my&amp;app');
+      expect(plist).not.toContain('my&app');
+    });
+  });
+
+  // =========================================================================
+  // Linux systemd unit generation
+  // =========================================================================
+  describe('generateSystemdUnit', () => {
+    it('should produce a valid systemd unit file', () => {
+      const unit = _generateSystemdUnit('/home/dev/myapp', '/usr/bin/node', '/usr/lib/cli.js');
+
+      expect(unit).toContain('[Unit]');
+      expect(unit).toContain('[Service]');
+      expect(unit).toContain('[Install]');
+      expect(unit).toContain('Type=simple');
+      expect(unit).toContain('ExecStart="/usr/bin/node" "/usr/lib/cli.js" daemon start --foreground --quiet');
+      expect(unit).toContain('WorkingDirectory=/home/dev/myapp');
+      expect(unit).toContain('WantedBy=default.target');
+      expect(unit).toContain('Restart=on-failure');
+      expect(unit).toContain('CLAUDE_FLOW_DAEMON=1');
+    });
+  });
+
+  // =========================================================================
+  // Windows schtasks name
+  // =========================================================================
+  describe('schtasksName', () => {
+    it('should produce a name with project slug suffix', () => {
+      const name = _schtasksName('C:\\Users\\dev\\myapp');
+      expect(name).toMatch(/^MoFloDaemon-/);
+      expect(name.length).toBeGreaterThan('MoFloDaemon-'.length);
+    });
+  });
+
+  // =========================================================================
+  // isDaemonInstalled (macOS/Linux — file-based detection)
+  // =========================================================================
+  describe('isDaemonInstalled', () => {
+    it('should return false when no service file exists (darwin)', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'darwin', writable: true });
+
+      try {
+        expect(isDaemonInstalled(tempDir)).toBe(false);
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+      }
+    });
+
+    it('should return false when no service file exists (linux)', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux', writable: true });
+
+      try {
+        expect(isDaemonInstalled(tempDir)).toBe(false);
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+      }
+    });
+  });
+
+  // =========================================================================
+  // Install and uninstall (macOS)
+  // =========================================================================
+  describe('install/uninstall macOS', () => {
+    const originalPlatform = process.platform;
+
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', writable: true });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+    });
+
+    it('should write plist file on install', () => {
+      const result = installDaemonService(tempDir);
+
+      expect(result.success).toBe(true);
+      expect(result.servicePath).toBeTruthy();
+      expect(result.message).toContain('installed');
+      expect(result.message).toContain('login');
+
+      // Verify file exists
+      expect(existsSync(result.servicePath!)).toBe(true);
+
+      // Verify content
+      const content = readFileSync(result.servicePath!, 'utf-8');
+      expect(content).toContain('<key>Label</key>');
+      expect(content).toContain('<key>RunAtLoad</key>');
+    });
+
+    it('should be idempotent — second install overwrites without error', () => {
+      const first = installDaemonService(tempDir);
+      expect(first.success).toBe(true);
+
+      const second = installDaemonService(tempDir);
+      expect(second.success).toBe(true);
+      expect(second.servicePath).toBe(first.servicePath);
+    });
+
+    it('should remove plist file on uninstall', () => {
+      // Install first
+      const installResult = installDaemonService(tempDir);
+      expect(installResult.success).toBe(true);
+      expect(existsSync(installResult.servicePath!)).toBe(true);
+
+      // launchctl unload will fail in tests (not a real plist) but the try/catch handles it
+      const uninstallResult = uninstallDaemonService(tempDir);
+      expect(uninstallResult.success).toBe(true);
+      expect(uninstallResult.message).toContain('removed');
+      expect(existsSync(installResult.servicePath!)).toBe(false);
+    });
+
+    it('should succeed gracefully when uninstalling with no service', () => {
+      const result = uninstallDaemonService(tempDir);
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('not installed');
+    });
+
+    it('should detect installed service', () => {
+      expect(isDaemonInstalled(tempDir)).toBe(false);
+
+      installDaemonService(tempDir);
+      expect(isDaemonInstalled(tempDir)).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // Install and uninstall (Linux)
+  // =========================================================================
+  describe('install/uninstall Linux', () => {
+    const originalPlatform = process.platform;
+
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'linux', writable: true });
+      // systemctl calls will fail in tests but the try/catch handles it
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+    });
+
+    it('should write systemd unit file on install', () => {
+      const result = installDaemonService(tempDir);
+
+      expect(result.success).toBe(true);
+      expect(result.servicePath).toBeTruthy();
+      expect(result.message).toContain('installed');
+
+      // Verify file exists
+      expect(existsSync(result.servicePath!)).toBe(true);
+
+      // Verify content
+      const content = readFileSync(result.servicePath!, 'utf-8');
+      expect(content).toContain('[Unit]');
+      expect(content).toContain('[Service]');
+      expect(content).toContain('Type=simple');
+      expect(content).toContain('WantedBy=default.target');
+    });
+
+    it('should be idempotent — second install overwrites without error', () => {
+      const first = installDaemonService(tempDir);
+      expect(first.success).toBe(true);
+
+      const second = installDaemonService(tempDir);
+      expect(second.success).toBe(true);
+    });
+
+    it('should remove unit file on uninstall', () => {
+      const installResult = installDaemonService(tempDir);
+      expect(installResult.success).toBe(true);
+      expect(existsSync(installResult.servicePath!)).toBe(true);
+
+      const uninstallResult = uninstallDaemonService(tempDir);
+      expect(uninstallResult.success).toBe(true);
+      expect(uninstallResult.message).toContain('removed');
+      expect(existsSync(installResult.servicePath!)).toBe(false);
+    });
+
+    it('should succeed gracefully when uninstalling with no service', () => {
+      const result = uninstallDaemonService(tempDir);
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('not installed');
+    });
+  });
+
+  // =========================================================================
+  // Path validation
+  // =========================================================================
+  describe('path validation', () => {
+    it('should reject project roots with null bytes', () => {
+      expect(() => installDaemonService('/tmp/bad\0path')).toThrow('null bytes');
+    });
+
+    it('should reject project roots with shell metacharacters', () => {
+      expect(() => installDaemonService('/tmp/bad;rm -rf /')).toThrow('shell metacharacters');
+      expect(() => installDaemonService('/tmp/bad|path')).toThrow('shell metacharacters');
+      expect(() => installDaemonService('/tmp/bad&path')).toThrow('shell metacharacters');
+    });
+  });
+
+  // =========================================================================
+  // Unsupported platform
+  // =========================================================================
+  describe('unsupported platform', () => {
+    it('should return failure for unknown platforms', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'freebsd', writable: true });
+
+      try {
+        const result = installDaemonService(tempDir);
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('Unsupported platform');
+
+        const uninstallResult = uninstallDaemonService(tempDir);
+        expect(uninstallResult.success).toBe(false);
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+      }
+    });
+
+    it('should return false for isDaemonInstalled on unknown platform', () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'freebsd', writable: true });
+
+      try {
+        expect(isDaemonInstalled(tempDir)).toBe(false);
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+      }
+    });
+  });
+});

--- a/src/packages/cli/src/commands/daemon.ts
+++ b/src/packages/cli/src/commands/daemon.ts
@@ -7,6 +7,7 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { WorkerDaemon, getDaemon, startDaemon, stopDaemon, type WorkerType, type DaemonConfig } from '../services/worker-daemon.js';
 import { acquireDaemonLock, releaseDaemonLock, getDaemonLockHolder, transferDaemonLock, lockPath } from '../services/daemon-lock.js';
+import { installDaemonService, uninstallDaemonService, isDaemonInstalled } from '../services/daemon-service.js';
 import { spawn, execFile } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join, resolve, isAbsolute } from 'path';
@@ -627,6 +628,77 @@ const enableCommand: Command = {
   },
 };
 
+// Install subcommand - register as OS-native login service
+const installCommand: Command = {
+  name: 'install',
+  description: 'Register the daemon as an OS-native login service (survives reboots)',
+  options: [
+    { name: 'quiet', short: 'Q', type: 'boolean', description: 'Suppress output' },
+  ],
+  examples: [
+    { command: 'claude-flow daemon install', description: 'Register daemon as login service' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const quiet = ctx.flags.quiet as boolean;
+    const projectRoot = process.cwd();
+
+    try {
+      const result = installDaemonService(projectRoot);
+
+      if (!quiet) {
+        if (result.success) {
+          output.printSuccess(result.message);
+          output.printInfo('Remove anytime with: moflo daemon uninstall');
+        } else {
+          output.printError(result.message);
+        }
+      }
+
+      return { success: result.success, exitCode: result.success ? 0 : 1 };
+    } catch (error) {
+      if (!quiet) {
+        output.printError(`Failed to install daemon service: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      return { success: false, exitCode: 1 };
+    }
+  },
+};
+
+// Uninstall subcommand - remove OS-native login service
+const uninstallCommand: Command = {
+  name: 'uninstall',
+  description: 'Remove the daemon OS-native login service',
+  options: [
+    { name: 'quiet', short: 'Q', type: 'boolean', description: 'Suppress output' },
+  ],
+  examples: [
+    { command: 'claude-flow daemon uninstall', description: 'Remove daemon login service' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const quiet = ctx.flags.quiet as boolean;
+    const projectRoot = process.cwd();
+
+    try {
+      const result = uninstallDaemonService(projectRoot);
+
+      if (!quiet) {
+        if (result.success) {
+          output.printSuccess(result.message);
+        } else {
+          output.printError(result.message);
+        }
+      }
+
+      return { success: result.success, exitCode: result.success ? 0 : 1 };
+    } catch (error) {
+      if (!quiet) {
+        output.printError(`Failed to uninstall daemon service: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      return { success: false, exitCode: 1 };
+    }
+  },
+};
+
 // Helper functions for time formatting
 function formatTimeAgo(date: Date): string {
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
@@ -657,6 +729,8 @@ export const daemonCommand: Command = {
     statusCommand,
     triggerCommand,
     enableCommand,
+    installCommand,
+    uninstallCommand,
   ],
   options: [],
   examples: [
@@ -665,6 +739,8 @@ export const daemonCommand: Command = {
     { command: 'claude-flow daemon status', description: 'Check daemon status' },
     { command: 'claude-flow daemon stop', description: 'Stop the daemon' },
     { command: 'claude-flow daemon trigger -w audit', description: 'Run security audit' },
+    { command: 'claude-flow daemon install', description: 'Register as OS login service' },
+    { command: 'claude-flow daemon uninstall', description: 'Remove OS login service' },
   ],
   action: async (): Promise<CommandResult> => {
     output.writeln();
@@ -697,11 +773,13 @@ export const daemonCommand: Command = {
     output.writeln();
     output.writeln(output.bold('Subcommands'));
     output.printList([
-      `${output.highlight('start')}   - Start the daemon`,
-      `${output.highlight('stop')}    - Stop the daemon`,
-      `${output.highlight('status')}  - Show daemon status`,
-      `${output.highlight('trigger')} - Manually run a worker`,
-      `${output.highlight('enable')}  - Enable/disable a worker`,
+      `${output.highlight('start')}     - Start the daemon`,
+      `${output.highlight('stop')}      - Stop the daemon`,
+      `${output.highlight('status')}    - Show daemon status`,
+      `${output.highlight('trigger')}   - Manually run a worker`,
+      `${output.highlight('enable')}    - Enable/disable a worker`,
+      `${output.highlight('install')}   - Register as OS login service`,
+      `${output.highlight('uninstall')} - Remove OS login service`,
     ]);
 
     output.writeln();

--- a/src/packages/cli/src/services/daemon-service.ts
+++ b/src/packages/cli/src/services/daemon-service.ts
@@ -1,0 +1,402 @@
+/**
+ * OS-Native Daemon Service Registration
+ *
+ * Registers/removes the moflo daemon as a user-level login service
+ * so scheduled workflows survive reboots without Docker.
+ *
+ * - macOS:   launchd plist in ~/Library/LaunchAgents/
+ * - Linux:   systemd --user unit in ~/.config/systemd/user/
+ * - Windows: Task Scheduler ONLOGON trigger via schtasks
+ */
+
+import * as fs from 'fs';
+import { createHash } from 'crypto';
+import { dirname, join, resolve } from 'path';
+import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ServiceInstallResult {
+  success: boolean;
+  servicePath: string | null;
+  message: string;
+}
+
+export interface ServiceUninstallResult {
+  success: boolean;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PLIST_LABEL = 'com.moflo.daemon';
+const SYSTEMD_UNIT = 'moflo-daemon.service';
+const SCHTASKS_NAME = 'MoFloDaemon';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if the daemon service is registered for the current platform.
+ */
+export function isDaemonInstalled(projectRoot: string): boolean {
+  const resolvedRoot = resolve(projectRoot);
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    return isDaemonInstalledMacOS(resolvedRoot);
+  } else if (platform === 'linux') {
+    return isDaemonInstalledLinux(resolvedRoot);
+  } else if (platform === 'win32') {
+    return isDaemonInstalledWindows(resolvedRoot);
+  }
+
+  return false;
+}
+
+/**
+ * Install the daemon as an OS-native login service.
+ */
+export function installDaemonService(projectRoot: string): ServiceInstallResult {
+  const resolvedRoot = resolve(projectRoot);
+  validateProjectRoot(resolvedRoot);
+
+  const platform = process.platform;
+  const nodePath = process.execPath;
+  const cliPath = resolveCliPath();
+
+  if (platform === 'darwin') {
+    return installMacOS(resolvedRoot, nodePath, cliPath);
+  } else if (platform === 'linux') {
+    return installLinux(resolvedRoot, nodePath, cliPath);
+  } else if (platform === 'win32') {
+    return installWindows(resolvedRoot, nodePath, cliPath);
+  }
+
+  return {
+    success: false,
+    servicePath: null,
+    message: `Unsupported platform: ${platform}`,
+  };
+}
+
+/**
+ * Uninstall the daemon OS-native login service.
+ */
+export function uninstallDaemonService(projectRoot: string): ServiceUninstallResult {
+  const resolvedRoot = resolve(projectRoot);
+  validateProjectRoot(resolvedRoot);
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    return uninstallMacOS(resolvedRoot);
+  } else if (platform === 'linux') {
+    return uninstallLinux(resolvedRoot);
+  } else if (platform === 'win32') {
+    return uninstallWindows(resolvedRoot);
+  }
+
+  return {
+    success: false,
+    message: `Unsupported platform: ${platform}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// macOS — launchd
+// ---------------------------------------------------------------------------
+
+function plistPath(projectRoot: string): string {
+  const slug = projectRootSlug(projectRoot);
+  return join(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.${slug}.plist`);
+}
+
+function generatePlist(projectRoot: string, nodePath: string, cliPath: string): string {
+  const slug = projectRootSlug(projectRoot);
+  const label = `${PLIST_LABEL}.${slug}`;
+
+  // XML plist — launchd specification
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    '<dict>',
+    `  <key>Label</key>`,
+    `  <string>${escapeXml(label)}</string>`,
+    `  <key>ProgramArguments</key>`,
+    `  <array>`,
+    `    <string>${escapeXml(nodePath)}</string>`,
+    `    <string>${escapeXml(cliPath)}</string>`,
+    `    <string>daemon</string>`,
+    `    <string>start</string>`,
+    `    <string>--foreground</string>`,
+    `    <string>--quiet</string>`,
+    `  </array>`,
+    `  <key>WorkingDirectory</key>`,
+    `  <string>${escapeXml(projectRoot)}</string>`,
+    `  <key>RunAtLoad</key>`,
+    `  <true/>`,
+    `  <key>KeepAlive</key>`,
+    `  <false/>`,
+    `  <key>StandardOutPath</key>`,
+    `  <string>${escapeXml(join(projectRoot, '.claude-flow', 'daemon.log'))}</string>`,
+    `  <key>StandardErrorPath</key>`,
+    `  <string>${escapeXml(join(projectRoot, '.claude-flow', 'daemon.log'))}</string>`,
+    '</dict>',
+    '</plist>',
+    '',
+  ].join('\n');
+}
+
+function installMacOS(projectRoot: string, nodePath: string, cliPath: string): ServiceInstallResult {
+  const dest = plistPath(projectRoot);
+  const dir = dirname(dest);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const content = generatePlist(projectRoot, nodePath, cliPath);
+  fs.writeFileSync(dest, content, 'utf-8');
+
+  return {
+    success: true,
+    servicePath: dest,
+    message: `Daemon service installed at ${dest}. It will start automatically on login.`,
+  };
+}
+
+function uninstallMacOS(projectRoot: string): ServiceUninstallResult {
+  const dest = plistPath(projectRoot);
+
+  if (!fs.existsSync(dest)) {
+    return { success: true, message: 'Daemon service is not installed.' };
+  }
+
+  // Unload before removing (ignore errors — may not be loaded)
+  try {
+    execSync(`launchctl unload "${dest}"`, { timeout: 5000, stdio: 'ignore' });
+  } catch { /* not loaded — fine */ }
+
+  fs.unlinkSync(dest);
+  return { success: true, message: `Daemon service removed from ${dest}.` };
+}
+
+function isDaemonInstalledMacOS(projectRoot: string): boolean {
+  return fs.existsSync(plistPath(projectRoot));
+}
+
+// ---------------------------------------------------------------------------
+// Linux — systemd --user
+// ---------------------------------------------------------------------------
+
+function systemdUnitPath(projectRoot: string): string {
+  const slug = projectRootSlug(projectRoot);
+  const configDir = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(configDir, 'systemd', 'user', `${SYSTEMD_UNIT.replace('.service', '')}-${slug}.service`);
+}
+
+function generateSystemdUnit(projectRoot: string, nodePath: string, cliPath: string): string {
+  return [
+    '[Unit]',
+    `Description=MoFlo Daemon (${projectRoot})`,
+    'After=default.target',
+    '',
+    '[Service]',
+    'Type=simple',
+    `ExecStart="${nodePath}" "${cliPath}" daemon start --foreground --quiet`,
+    `WorkingDirectory=${projectRoot}`,
+    'Restart=on-failure',
+    'RestartSec=10',
+    `Environment=CLAUDE_FLOW_DAEMON=1`,
+    '',
+    '[Install]',
+    'WantedBy=default.target',
+    '',
+  ].join('\n');
+}
+
+function installLinux(projectRoot: string, nodePath: string, cliPath: string): ServiceInstallResult {
+  const dest = systemdUnitPath(projectRoot);
+  const dir = dirname(dest);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const content = generateSystemdUnit(projectRoot, nodePath, cliPath);
+  fs.writeFileSync(dest, content, 'utf-8');
+
+  // Reload systemd and enable
+  try {
+    execSync('systemctl --user daemon-reload', { timeout: 10000, stdio: 'ignore' });
+    const unitName = dest.split('/').pop()!;
+    execSync(`systemctl --user enable ${unitName}`, { timeout: 10000, stdio: 'ignore' });
+  } catch {
+    // systemctl may not be available in all environments
+  }
+
+  return {
+    success: true,
+    servicePath: dest,
+    message: `Daemon service installed at ${dest}. It will start automatically on login.`,
+  };
+}
+
+function uninstallLinux(projectRoot: string): ServiceUninstallResult {
+  const dest = systemdUnitPath(projectRoot);
+
+  if (!fs.existsSync(dest)) {
+    return { success: true, message: 'Daemon service is not installed.' };
+  }
+
+  // Disable and stop before removing
+  try {
+    const unitName = dest.split('/').pop()!;
+    execSync(`systemctl --user disable ${unitName}`, { timeout: 10000, stdio: 'ignore' });
+    execSync(`systemctl --user stop ${unitName}`, { timeout: 10000, stdio: 'ignore' });
+  } catch { /* may not be running */ }
+
+  fs.unlinkSync(dest);
+
+  // Reload systemd
+  try {
+    execSync('systemctl --user daemon-reload', { timeout: 10000, stdio: 'ignore' });
+  } catch { /* ignore */ }
+
+  return { success: true, message: `Daemon service removed from ${dest}.` };
+}
+
+function isDaemonInstalledLinux(projectRoot: string): boolean {
+  return fs.existsSync(systemdUnitPath(projectRoot));
+}
+
+// ---------------------------------------------------------------------------
+// Windows — Task Scheduler
+// ---------------------------------------------------------------------------
+
+function schtasksName(projectRoot: string): string {
+  const slug = projectRootSlug(projectRoot);
+  return `${SCHTASKS_NAME}-${slug}`;
+}
+
+function installWindows(projectRoot: string, nodePath: string, cliPath: string): ServiceInstallResult {
+  const taskName = schtasksName(projectRoot);
+
+  // Build schtasks command — ONLOGON trigger, user-level
+  // Use /F to force overwrite if already exists (idempotent)
+  try {
+    execSync(
+      `schtasks /Create /TN "${taskName}" /TR "\\"${nodePath}\\" \\"${cliPath}\\" daemon start --foreground --quiet" /SC ONLOGON /F`,
+      { timeout: 15000, windowsHide: true, cwd: projectRoot, stdio: 'ignore' },
+    );
+  } catch (err) {
+    return {
+      success: false,
+      servicePath: null,
+      message: `Failed to create scheduled task: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  return {
+    success: true,
+    servicePath: taskName,
+    message: `Daemon task "${taskName}" registered in Task Scheduler. It will start automatically on login.`,
+  };
+}
+
+function uninstallWindows(projectRoot: string): ServiceUninstallResult {
+  const taskName = schtasksName(projectRoot);
+
+  try {
+    execSync(
+      `schtasks /Delete /TN "${taskName}" /F`,
+      { timeout: 15000, windowsHide: true, stdio: 'ignore' },
+    );
+  } catch {
+    // schtasks /Delete /F returns non-zero when task doesn't exist
+    return { success: true, message: 'Daemon service is not installed.' };
+  }
+
+  return { success: true, message: `Daemon task "${taskName}" removed from Task Scheduler.` };
+}
+
+function isDaemonInstalledWindows(projectRoot: string): boolean {
+  const taskName = schtasksName(projectRoot);
+  try {
+    execSync(`schtasks /Query /TN "${taskName}"`, {
+      timeout: 10000,
+      windowsHide: true,
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve CLI path from moflo's own package (using import.meta.url, not process.cwd()).
+ */
+function resolveCliPath(): string {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  // dist/src/services -> dist/src -> dist -> package root -> bin/cli.js
+  return resolve(join(__dirname, '..', '..', '..', 'bin', 'cli.js'));
+}
+
+/**
+ * Create a filesystem-safe slug from a project root path.
+ * Used to differentiate per-project services.
+ */
+function projectRootSlug(projectRoot: string): string {
+  const resolved = resolve(projectRoot);
+  const hash = createHash('sha256').update(resolved).digest('hex').slice(0, 8);
+  const tail = resolved
+    .replace(/[^a-zA-Z0-9]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+    .slice(-40);
+  return `${tail}-${hash}`;
+}
+
+/**
+ * Validate project root for path safety.
+ */
+function validateProjectRoot(path: string): void {
+  if (path.includes('\0')) {
+    throw new Error('Project root contains null bytes');
+  }
+  if (/[;&|`$<>]/.test(path)) {
+    throw new Error('Project root contains shell metacharacters');
+  }
+}
+
+/**
+ * Escape special characters for XML plist values.
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+// Export for testing
+export {
+  generatePlist as _generatePlist,
+  generateSystemdUnit as _generateSystemdUnit,
+  plistPath as _plistPath,
+  systemdUnitPath as _systemdUnitPath,
+  schtasksName as _schtasksName,
+  projectRootSlug as _projectRootSlug,
+  resolveCliPath as _resolveCliPath,
+};


### PR DESCRIPTION
## Summary
- Add `moflo daemon install` and `moflo daemon uninstall` subcommands for OS-native service registration
- macOS: launchd plist, Linux: systemd --user unit, Windows: Task Scheduler ONLOGON
- User-level services only (no root/admin required), one service per project root
- 21 new tests covering all platforms, path validation, idempotency, and edge cases

## Test plan
- [x] Unit tests for plist generation (XML content, escaping)
- [x] Unit tests for systemd unit generation (quoted ExecStart paths)
- [x] Unit tests for Windows schtasks name generation
- [x] isDaemonInstalled returns correct boolean per platform
- [x] Install/uninstall round-trip on macOS and Linux (file-based)
- [x] Idempotent install (second install overwrites without error)
- [x] Graceful uninstall when not installed
- [x] Path validation rejects null bytes and shell metacharacters
- [x] Unsupported platform returns failure gracefully
- [x] Full test suite passes (6251/6678, 427 skipped)

Closes #255

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)