### PR TITLE
feat(workflow): lazy daemon readiness check on schedule creation

### DIFF
--- a/src/packages/cli/__tests__/commands/workflow-schedule.test.ts
+++ b/src/packages/cli/__tests__/commands/workflow-schedule.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Workflow Schedule Command Tests
+ *
+ * Tests the schedule subcommand: create, list, cancel.
+ * Mocks MCP tools and daemon readiness for isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CommandContext, CommandResult } from '../../src/types.js';
+
+// Mock MCP client
+vi.mock('../../src/mcp-client.js', () => ({
+  callMCPTool: vi.fn(),
+  MCPClientError: class MCPClientError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'MCPClientError';
+    }
+  },
+}));
+
+// Mock daemon readiness
+vi.mock('../../src/services/daemon-readiness.js', () => ({
+  ensureDaemonForScheduling: vi.fn(),
+}));
+
+// Mock output (suppress console output in tests)
+vi.mock('../../src/output.js', () => {
+  const noopFmt = (s: unknown) => String(s ?? '');
+  return {
+    output: {
+      writeln: vi.fn(),
+      printError: vi.fn(),
+      printSuccess: vi.fn(),
+      printWarning: vi.fn(),
+      printInfo: vi.fn(),
+      printBox: vi.fn(),
+      printJson: vi.fn(),
+      printTable: vi.fn(),
+      printList: vi.fn(),
+      bold: noopFmt,
+      highlight: noopFmt,
+      success: noopFmt,
+      error: noopFmt,
+      dim: noopFmt,
+      warning: noopFmt,
+      createSpinner: () => ({ start: vi.fn(), succeed: vi.fn(), fail: vi.fn(), stop: vi.fn() }),
+    },
+  };
+});
+
+import { callMCPTool } from '../../src/mcp-client.js';
+import { ensureDaemonForScheduling } from '../../src/services/daemon-readiness.js';
+import { scheduleCommand } from '../../src/commands/workflow-schedule.js';
+
+const mockCallMCP = vi.mocked(callMCPTool);
+const mockEnsureDaemon = vi.mocked(ensureDaemonForScheduling);
+
+// Helper to find a subcommand
+function findSub(name: string) {
+  return scheduleCommand.subcommands!.find(c => c.name === name)!;
+}
+
+function makeCtx(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    args: [],
+    flags: { _: [] },
+    cwd: '/test/project',
+    interactive: true,
+    ...overrides,
+  };
+}
+
+describe('workflow schedule command', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockEnsureDaemon.mockResolvedValue({
+      daemonRunning: true,
+      daemonInstalled: true,
+      warnings: [],
+    });
+  });
+
+  // ── Structure ─────────────────────────────────────────────────────────────
+
+  it('should have create, list, and cancel subcommands', () => {
+    const names = scheduleCommand.subcommands!.map(c => c.name);
+    expect(names).toContain('create');
+    expect(names).toContain('list');
+    expect(names).toContain('cancel');
+  });
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    const createCmd = () => findSub('create');
+
+    it('should create a schedule with --cron', async () => {
+      mockCallMCP.mockResolvedValue({});
+
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'audit', cron: '0 9 * * *' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(true);
+      expect(mockCallMCP).toHaveBeenCalledWith('memory_store', expect.objectContaining({
+        namespace: 'scheduled-workflows',
+      }));
+      expect(mockEnsureDaemon).toHaveBeenCalled();
+    });
+
+    it('should create a schedule with --interval', async () => {
+      mockCallMCP.mockResolvedValue({});
+
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'check', interval: '6h' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should create a schedule with --at', async () => {
+      mockCallMCP.mockResolvedValue({});
+
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'report', at: '2026-04-01T09:00:00Z' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should error when no timing option provided', async () => {
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'audit' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should error when multiple timing options provided', async () => {
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'audit', cron: '0 9 * * *', interval: '6h' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should error when no name provided', async () => {
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], cron: '0 9 * * *' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid cron expression', async () => {
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'audit', cron: 'invalid' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid interval format', async () => {
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'audit', interval: 'bad' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid datetime', async () => {
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'audit', at: 'not-a-date' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should still create schedule when daemon is not running', async () => {
+      mockEnsureDaemon.mockResolvedValue({
+        daemonRunning: false,
+        daemonInstalled: false,
+        warnings: ['Daemon is not running.'],
+      });
+      mockCallMCP.mockResolvedValue({});
+
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'audit', cron: '0 9 * * *' },
+      })) as CommandResult;
+
+      // Schedule is always created regardless of daemon state
+      expect(result.success).toBe(true);
+      expect(mockCallMCP).toHaveBeenCalledWith('memory_store', expect.anything());
+    });
+  });
+
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  describe('list', () => {
+    const listCmd = () => findSub('list');
+
+    it('should list schedules', async () => {
+      mockCallMCP.mockResolvedValue({
+        results: [
+          {
+            key: 'sched-adhoc-123',
+            value: JSON.stringify({
+              id: 'sched-adhoc-123',
+              workflowName: 'audit',
+              cron: '0 9 * * *',
+              nextRunAt: Date.now() + 60000,
+              enabled: true,
+            }),
+          },
+        ],
+      });
+
+      const result = await listCmd().action!(makeCtx()) as CommandResult;
+      expect(result.success).toBe(true);
+      expect(mockCallMCP).toHaveBeenCalledWith('memory_list', expect.objectContaining({
+        namespace: 'scheduled-workflows',
+      }));
+    });
+
+    it('should show empty message when no schedules', async () => {
+      mockCallMCP.mockResolvedValue({ results: [] });
+
+      const result = await listCmd().action!(makeCtx()) as CommandResult;
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ── Cancel ────────────────────────────────────────────────────────────────
+
+  describe('cancel', () => {
+    const cancelCmd = () => findSub('cancel');
+
+    it('should cancel a schedule by ID', async () => {
+      mockCallMCP.mockResolvedValueOnce({
+        value: JSON.stringify({
+          id: 'sched-adhoc-123',
+          workflowName: 'audit',
+          enabled: true,
+        }),
+      }).mockResolvedValueOnce({});
+
+      const result = await cancelCmd().action!(makeCtx({
+        args: ['sched-adhoc-123'],
+      })) as CommandResult;
+
+      expect(result.success).toBe(true);
+      // Second call should write the updated (disabled) record
+      expect(mockCallMCP).toHaveBeenCalledTimes(2);
+    });
+
+    it('should error when schedule ID not provided', async () => {
+      const result = await cancelCmd().action!(makeCtx()) as CommandResult;
+      expect(result.success).toBe(false);
+    });
+
+    it('should error when schedule not found', async () => {
+      mockCallMCP.mockResolvedValue({ value: null });
+
+      const result = await cancelCmd().action!(makeCtx({
+        args: ['nonexistent-id'],
+      })) as CommandResult;
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/packages/cli/__tests__/services/daemon-readiness.test.ts
+++ b/src/packages/cli/__tests__/services/daemon-readiness.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Daemon Readiness Tests
+ *
+ * Validates the three-state lazy daemon check for scheduled workflows:
+ * 1. Daemon running + installed → no prompts, clean result
+ * 2. Daemon running + not installed (interactive) → prompts to install
+ * 3. Daemon running + not installed (non-interactive) → warns
+ * 4. Daemon not running (interactive) → prompts to start, then checks install
+ * 5. Daemon not running (non-interactive) → warns
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ensureDaemonForScheduling } from '../../src/services/daemon-readiness.js';
+
+// Mock dependencies
+vi.mock('../../src/services/daemon-lock.js', () => ({
+  getDaemonLockHolder: vi.fn(),
+}));
+
+vi.mock('../../src/services/daemon-service.js', () => ({
+  isDaemonInstalled: vi.fn(),
+  installDaemonService: vi.fn(),
+}));
+
+import { getDaemonLockHolder } from '../../src/services/daemon-lock.js';
+import { isDaemonInstalled, installDaemonService } from '../../src/services/daemon-service.js';
+
+const mockGetHolder = vi.mocked(getDaemonLockHolder);
+const mockIsInstalled = vi.mocked(isDaemonInstalled);
+const mockInstall = vi.mocked(installDaemonService);
+
+describe('ensureDaemonForScheduling', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // ── State 1: Daemon running + installed ───────────────────────────────────
+
+  it('should return clean result when daemon is running and installed', async () => {
+    mockGetHolder.mockReturnValue(12345);
+    mockIsInstalled.mockReturnValue(true);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: true,
+      promptConfirm: vi.fn(),
+      startDaemon: vi.fn(),
+    });
+
+    expect(result.daemonRunning).toBe(true);
+    expect(result.daemonInstalled).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // ── State 2: Daemon running + not installed (interactive) ─────────────────
+
+  it('should prompt to install when daemon is running but not installed (interactive, accepts)', async () => {
+    mockGetHolder.mockReturnValue(12345);
+    mockIsInstalled.mockReturnValue(false);
+    mockInstall.mockReturnValue({ success: true, servicePath: '/test/service', message: 'Installed' });
+
+    const promptFn = vi.fn().mockResolvedValue(true);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: true,
+      promptConfirm: promptFn,
+      startDaemon: vi.fn(),
+    });
+
+    expect(result.daemonRunning).toBe(true);
+    expect(result.daemonInstalled).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+    expect(promptFn).toHaveBeenCalledWith(
+      expect.stringContaining('login service'),
+    );
+    expect(mockInstall).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('should warn when user declines install (interactive)', async () => {
+    mockGetHolder.mockReturnValue(12345);
+    mockIsInstalled.mockReturnValue(false);
+
+    const promptFn = vi.fn().mockResolvedValue(false);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: true,
+      promptConfirm: promptFn,
+      startDaemon: vi.fn(),
+    });
+
+    expect(result.daemonRunning).toBe(true);
+    expect(result.daemonInstalled).toBe(false);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('reboot');
+  });
+
+  // ── State 3: Daemon running + not installed (non-interactive) ─────────────
+
+  it('should warn without prompting in non-interactive mode', async () => {
+    mockGetHolder.mockReturnValue(12345);
+    mockIsInstalled.mockReturnValue(false);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: false,
+    });
+
+    expect(result.daemonRunning).toBe(true);
+    expect(result.daemonInstalled).toBe(false);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('moflo daemon install');
+  });
+
+  // ── State 4: Daemon not running (interactive) ─────────────────────────────
+
+  it('should prompt to start daemon when not running (interactive, accepts)', async () => {
+    mockGetHolder.mockReturnValue(null);
+    mockIsInstalled.mockReturnValue(true); // already installed as OS service
+
+    const promptFn = vi.fn().mockResolvedValue(true);
+    const startFn = vi.fn().mockResolvedValue(true);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: true,
+      promptConfirm: promptFn,
+      startDaemon: startFn,
+    });
+
+    expect(result.daemonRunning).toBe(true);
+    expect(result.daemonInstalled).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+    expect(promptFn).toHaveBeenCalledWith(
+      expect.stringContaining('Start it now'),
+    );
+    expect(startFn).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('should warn when user declines to start daemon (interactive)', async () => {
+    mockGetHolder.mockReturnValue(null);
+    mockIsInstalled.mockReturnValue(false);
+
+    const promptFn = vi.fn().mockResolvedValue(false);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: true,
+      promptConfirm: promptFn,
+      startDaemon: vi.fn(),
+    });
+
+    expect(result.daemonRunning).toBe(false);
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings[0]).toContain('will not run until the daemon starts');
+  });
+
+  it('should warn when daemon start fails (interactive)', async () => {
+    mockGetHolder.mockReturnValue(null);
+    mockIsInstalled.mockReturnValue(false);
+
+    const promptFn = vi.fn().mockResolvedValue(true);
+    const startFn = vi.fn().mockResolvedValue(false);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: true,
+      promptConfirm: promptFn,
+      startDaemon: startFn,
+    });
+
+    expect(result.daemonRunning).toBe(false);
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining('Failed to start daemon'),
+    );
+  });
+
+  // ── State 5: Daemon not running (non-interactive) ─────────────────────────
+
+  it('should warn without prompting when daemon not running (non-interactive)', async () => {
+    mockGetHolder.mockReturnValue(null);
+    mockIsInstalled.mockReturnValue(false);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: false,
+    });
+
+    expect(result.daemonRunning).toBe(false);
+    // Only one warning: daemon not running. Install check is skipped because
+    // the daemon isn't running — no point warning about service registration.
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('moflo daemon start');
+  });
+
+  // ── Install failure ───────────────────────────────────────────────────────
+
+  it('should warn when install fails (interactive)', async () => {
+    mockGetHolder.mockReturnValue(12345);
+    mockIsInstalled.mockReturnValue(false);
+    mockInstall.mockReturnValue({ success: false, servicePath: null, message: 'Permission denied' });
+
+    const promptFn = vi.fn().mockResolvedValue(true);
+
+    const result = await ensureDaemonForScheduling({
+      projectRoot: '/test/project',
+      interactive: true,
+      promptConfirm: promptFn,
+      startDaemon: vi.fn(),
+    });
+
+    expect(result.daemonInstalled).toBe(false);
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining('Permission denied'),
+    );
+  });
+});

--- a/src/packages/cli/src/commands/workflow-schedule.ts
+++ b/src/packages/cli/src/commands/workflow-schedule.ts
@@ -1,0 +1,314 @@
+/**
+ * Workflow Schedule Subcommand
+ *
+ * CLI interface for creating, listing, and cancelling scheduled workflows.
+ * Includes lazy daemon readiness check on schedule creation.
+ *
+ * Schedule records are persisted to the 'scheduled-workflows' memory namespace —
+ * the same namespace the daemon's WorkflowScheduler polls. The daemon picks up
+ * new schedules on its next poll cycle (or via catch-up window after restart).
+ */
+
+import type { Command, CommandContext, CommandResult } from '../types.js';
+import { output } from '../output.js';
+import { callMCPTool, MCPClientError } from '../mcp-client.js';
+import { ensureDaemonForScheduling } from '../services/daemon-readiness.js';
+
+const NAMESPACE_SCHEDULES = 'scheduled-workflows';
+
+async function getSchedulerUtils() {
+  try {
+    // Resolve from moflo's own install location (import.meta.url), not process.cwd()
+    const { dirname, join } = await import('path');
+    const { fileURLToPath, pathToFileURL } = await import('url');
+    const here = dirname(fileURLToPath(import.meta.url));
+    // dist/src/commands -> dist/src -> dist -> cli -> packages -> workflows/dist/scheduler
+    const cronParserPath = join(here, '..', '..', '..', '..', 'workflows', 'dist', 'scheduler', 'cron-parser.js');
+    return await import(pathToFileURL(cronParserPath).href);
+  } catch {
+    return null;
+  }
+}
+
+function formatMCPError(error: unknown, action: string): CommandResult {
+  const msg = error instanceof MCPClientError ? error.message : String(error);
+  output.printError(`Failed to ${action}: ${msg}`);
+  return { success: false, exitCode: 1 };
+}
+
+// ── Schedule Create ───────────────────────────────────────────────────────────
+
+const createCommand: Command = {
+  name: 'create',
+  description: 'Create a scheduled workflow',
+  options: [
+    { name: 'name', short: 'n', description: 'Workflow name or abbreviation', type: 'string', required: true },
+    { name: 'cron', short: 'c', description: 'Cron expression (5-field)', type: 'string' },
+    { name: 'interval', short: 'i', description: 'Interval (e.g., "6h", "30m", "1d")', type: 'string' },
+    { name: 'at', short: 'a', description: 'One-time ISO 8601 datetime', type: 'string' },
+  ],
+  examples: [
+    { command: 'moflo workflow schedule create -n audit --cron "0 9 * * *"', description: 'Daily at 9am' },
+    { command: 'moflo workflow schedule create -n security-audit --interval 6h', description: 'Every 6 hours' },
+    { command: 'moflo workflow schedule create -n report --at 2026-04-01T09:00:00Z', description: 'One-time run' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const name = (ctx.flags.name as string) || ctx.args[0];
+    const cron = ctx.flags.cron as string | undefined;
+    const interval = ctx.flags.interval as string | undefined;
+    const at = ctx.flags.at as string | undefined;
+
+    if (!name) {
+      output.printError('Workflow name is required. Use --name or -n');
+      return { success: false, exitCode: 1 };
+    }
+
+    const timingCount = [cron, interval, at].filter(Boolean).length;
+    if (timingCount === 0) {
+      output.printError('Exactly one timing option is required: --cron, --interval, or --at');
+      return { success: false, exitCode: 1 };
+    }
+    if (timingCount > 1) {
+      output.printError('Only one timing option allowed: --cron, --interval, or --at');
+      return { success: false, exitCode: 1 };
+    }
+
+    // Validate and compute next run using the workflows package
+    const utils = await getSchedulerUtils();
+    const now = Date.now();
+    let nextRunAt: number;
+
+    if (utils) {
+      const validation = utils.validateSchedule({ cron, interval, at });
+      if (!validation.valid) {
+        output.printError(`Invalid schedule: ${validation.errors.map((e: { message: string }) => e.message).join(', ')}`);
+        return { success: false, exitCode: 1 };
+      }
+      const computed = utils.computeNextRun({ cron, interval, at }, now);
+      if (computed === null) {
+        output.printError('Could not compute next run time from the provided schedule');
+        return { success: false, exitCode: 1 };
+      }
+      nextRunAt = computed;
+    } else {
+      // Fallback: basic validation if workflows package unavailable
+      if (cron && !/^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/.test(cron.trim())) {
+        output.printError('Invalid cron expression: must be 5 fields (minute hour day month weekday)');
+        return { success: false, exitCode: 1 };
+      }
+      if (interval && !/^\d+[smhd]$/.test(interval.trim())) {
+        output.printError('Invalid interval: use format like "30m", "6h", "1d", "90s"');
+        return { success: false, exitCode: 1 };
+      }
+      if (at && isNaN(Date.parse(at))) {
+        output.printError('Invalid datetime: use ISO 8601 format (e.g., 2026-04-01T09:00:00Z)');
+        return { success: false, exitCode: 1 };
+      }
+      // Approximate next run for fallback path
+      if (interval) {
+        const match = interval.trim().match(/^(\d+)([smhd])$/)!;
+        const mult: Record<string, number> = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+        nextRunAt = now + (Number(match[1]) * mult[match[2]]);
+      } else if (at) {
+        nextRunAt = Date.parse(at);
+      } else {
+        nextRunAt = now + 60_000;
+      }
+    }
+
+    // Daemon readiness check (lazy — only on schedule creation)
+    const projectRoot = ctx.cwd || process.cwd();
+    const readiness = await ensureDaemonForScheduling({
+      projectRoot,
+      interactive: ctx.interactive,
+    });
+
+    for (const warning of readiness.warnings) {
+      output.printWarning(warning);
+    }
+
+    // Always create the schedule, regardless of daemon state
+    const id = `sched-adhoc-${now}-${Math.random().toString(36).slice(2, 8)}`;
+    const record = {
+      id,
+      workflowName: name,
+      workflowPath: '',  // resolved by scheduler at poll time
+      cron,
+      interval,
+      at,
+      nextRunAt,
+      enabled: true,
+      createdAt: now,
+      source: 'adhoc',
+    };
+
+    try {
+      await callMCPTool('memory_store', {
+        namespace: NAMESPACE_SCHEDULES,
+        key: id,
+        value: JSON.stringify(record),
+      });
+    } catch (error) {
+      return formatMCPError(error, 'save schedule');
+    }
+
+    if (ctx.flags.format === 'json') {
+      output.printJson(record);
+      return { success: true, data: record };
+    }
+
+    output.writeln();
+    output.printSuccess('Schedule created');
+    output.printBox(
+      [
+        `ID: ${id}`,
+        `Workflow: ${name}`,
+        cron ? `Cron: ${cron}` : null,
+        interval ? `Interval: ${interval}` : null,
+        at ? `At: ${at}` : null,
+        `Next Run: ${new Date(nextRunAt).toLocaleString()}`,
+        `Daemon: ${readiness.daemonRunning ? 'running' : 'not running'}`,
+        `Service: ${readiness.daemonInstalled ? 'installed' : 'not installed'}`,
+      ].filter(Boolean).join('\n'),
+      'Scheduled Workflow',
+    );
+
+    return { success: true, data: record };
+  },
+};
+
+// ── Schedule List ─────────────────────────────────────────────────────────────
+
+const scheduleListCommand: Command = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List all scheduled workflows',
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    try {
+      const result = await callMCPTool<{ results: Array<{ key: string; value: string }> }>('memory_list', {
+        namespace: NAMESPACE_SCHEDULES,
+      });
+
+      const schedules = (result.results ?? []).map(r => {
+        try {
+          return typeof r.value === 'string' ? JSON.parse(r.value) : r.value;
+        } catch {
+          return null;
+        }
+      }).filter(Boolean);
+
+      if (ctx.flags.format === 'json') {
+        output.printJson(schedules);
+        return { success: true, data: schedules };
+      }
+
+      if (schedules.length === 0) {
+        output.writeln();
+        output.printInfo('No scheduled workflows');
+        return { success: true, data: [] };
+      }
+
+      output.writeln();
+      output.writeln(output.bold('Scheduled Workflows'));
+      output.writeln();
+      output.printTable({
+        columns: [
+          { key: 'id', header: 'ID', width: 30 },
+          { key: 'workflowName', header: 'Workflow', width: 20 },
+          { key: 'timing', header: 'Schedule', width: 20 },
+          { key: 'nextRun', header: 'Next Run', width: 22 },
+          { key: 'enabled', header: 'Enabled', width: 8, format: (v: unknown) => v ? output.success('yes') : output.error('no') },
+        ],
+        data: schedules.map((s: Record<string, unknown>) => ({
+          id: s.id,
+          workflowName: s.workflowName,
+          timing: s.cron || s.interval || s.at || '-',
+          nextRun: s.nextRunAt ? new Date(s.nextRunAt as number).toLocaleString() : '-',
+          enabled: s.enabled,
+        })),
+      });
+
+      output.writeln();
+      output.printInfo(`Total: ${schedules.length} schedule(s)`);
+
+      return { success: true, data: schedules };
+    } catch (error) {
+      return formatMCPError(error, 'list schedules');
+    }
+  },
+};
+
+// ── Schedule Cancel ───────────────────────────────────────────────────────────
+
+const cancelCommand: Command = {
+  name: 'cancel',
+  description: 'Cancel (disable) a scheduled workflow',
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const scheduleId = ctx.args[0];
+
+    if (!scheduleId) {
+      output.printError('Schedule ID is required');
+      return { success: false, exitCode: 1 };
+    }
+
+    try {
+      // Fetch the current schedule
+      const fetchResult = await callMCPTool<{ value: string | null }>('memory_retrieve', {
+        namespace: NAMESPACE_SCHEDULES,
+        key: scheduleId,
+      });
+
+      if (!fetchResult.value) {
+        output.printError(`Schedule not found: ${scheduleId}`);
+        return { success: false, exitCode: 1 };
+      }
+
+      const schedule = typeof fetchResult.value === 'string'
+        ? JSON.parse(fetchResult.value)
+        : fetchResult.value;
+
+      // Disable it
+      const updated = { ...schedule, enabled: false };
+      await callMCPTool('memory_store', {
+        namespace: NAMESPACE_SCHEDULES,
+        key: scheduleId,
+        value: JSON.stringify(updated),
+      });
+
+      output.printSuccess(`Schedule ${scheduleId} cancelled`);
+      return { success: true, data: updated };
+    } catch (error) {
+      return formatMCPError(error, 'cancel schedule');
+    }
+  },
+};
+
+// ── Schedule Command (parent) ─────────────────────────────────────────────────
+
+export const scheduleCommand: Command = {
+  name: 'schedule',
+  description: 'Manage scheduled workflows',
+  subcommands: [createCommand, scheduleListCommand, cancelCommand],
+  examples: [
+    { command: 'moflo workflow schedule create -n audit --cron "0 9 * * *"', description: 'Schedule daily audit' },
+    { command: 'moflo workflow schedule list', description: 'List all schedules' },
+    { command: 'moflo workflow schedule cancel <id>', description: 'Cancel a schedule' },
+  ],
+  action: async (): Promise<CommandResult> => {
+    output.writeln();
+    output.writeln(output.bold('Schedule Commands'));
+    output.writeln();
+    output.writeln('Usage: moflo workflow schedule <subcommand> [options]');
+    output.writeln();
+    output.writeln('Subcommands:');
+    output.printList([
+      `${output.highlight('create')}  - Create a scheduled workflow`,
+      `${output.highlight('list')}    - List all scheduled workflows`,
+      `${output.highlight('cancel')}  - Cancel (disable) a schedule`,
+    ]);
+
+    return { success: true };
+  },
+};
+
+export default scheduleCommand;

--- a/src/packages/cli/src/commands/workflow.ts
+++ b/src/packages/cli/src/commands/workflow.ts
@@ -20,6 +20,7 @@ import type {
   WorkflowTemplateInfoResponse,
   WorkflowErrorResponse,
 } from '../mcp-tools/workflow-response.types.js';
+import { scheduleCommand } from './workflow-schedule.js';
 
 // Shared table column definitions
 const REGISTRY_COLUMNS = [
@@ -583,7 +584,7 @@ const templateCommand: Command = {
 export const workflowCommand: Command = {
   name: 'workflow',
   description: 'Workflow execution and management',
-  subcommands: [runCommand, validateCommand, listCommand, statusCommand, stopCommand, templateCommand],
+  subcommands: [runCommand, validateCommand, listCommand, statusCommand, stopCommand, templateCommand, scheduleCommand],
   options: [],
   examples: [
     { command: 'moflo workflow run -n development', description: 'Run workflow by name' },
@@ -606,6 +607,7 @@ export const workflowCommand: Command = {
       `${output.highlight('status')}    - Show workflow status`,
       `${output.highlight('stop')}      - Cancel running workflow`,
       `${output.highlight('template')}  - Browse registry templates`,
+      `${output.highlight('schedule')}  - Manage scheduled workflows`,
     ]);
     output.writeln();
     output.writeln('Run "moflo workflow <subcommand> --help" for more info');

--- a/src/packages/cli/src/services/daemon-readiness.ts
+++ b/src/packages/cli/src/services/daemon-readiness.ts
@@ -1,0 +1,160 @@
+/**
+ * Daemon Readiness Check for Scheduled Workflows
+ *
+ * Lazy three-state flow: only triggered when creating schedules.
+ * 1. Is daemon running? If not, prompt to start it.
+ * 2. Is daemon installed as OS service? If not, prompt to install.
+ * Always creates the schedule regardless — the daemon picks it up on next start.
+ */
+
+import { resolve, dirname, join } from 'path';
+import { existsSync, mkdirSync, openSync, closeSync } from 'fs';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { getDaemonLockHolder } from './daemon-lock.js';
+import { isDaemonInstalled, installDaemonService } from './daemon-service.js';
+
+export interface DaemonReadinessResult {
+  /** Whether the daemon is currently running. */
+  daemonRunning: boolean;
+  /** Whether the daemon is installed as an OS-native login service. */
+  daemonInstalled: boolean;
+  /** Non-fatal warnings about daemon state. */
+  warnings: string[];
+}
+
+export interface DaemonReadinessOptions {
+  /** Project root directory. */
+  projectRoot: string;
+  /** Whether the CLI is running interactively (can prompt). */
+  interactive: boolean;
+  /** Prompt the user for confirmation. Injected for testability. */
+  promptConfirm?: (message: string) => Promise<boolean>;
+  /** Start the daemon in the background. Injected for testability. */
+  startDaemon?: (projectRoot: string) => Promise<boolean>;
+}
+
+/**
+ * Ensure the daemon is ready for scheduled workflow execution.
+ *
+ * Checks daemon state and prompts the user to start/install as needed.
+ * Always returns — never throws. The caller should create the schedule
+ * regardless of the result, since the daemon can pick it up later.
+ */
+export async function ensureDaemonForScheduling(
+  options: DaemonReadinessOptions,
+): Promise<DaemonReadinessResult> {
+  const resolvedRoot = resolve(options.projectRoot);
+  const promptFn = options.promptConfirm ?? defaultPromptConfirm;
+  const startFn = options.startDaemon ?? defaultStartDaemon;
+
+  const result: DaemonReadinessResult = {
+    daemonRunning: false,
+    daemonInstalled: false,
+    warnings: [],
+  };
+
+  // Step 1: Check if daemon is running
+  const holderPid = getDaemonLockHolder(resolvedRoot);
+  result.daemonRunning = holderPid !== null;
+
+  if (!result.daemonRunning) {
+    if (options.interactive) {
+      const shouldStart = await promptFn(
+        'Scheduled workflows need the daemon. Start it now?',
+      );
+      if (shouldStart) {
+        const started = await startFn(resolvedRoot);
+        result.daemonRunning = started;
+        if (!started) {
+          result.warnings.push('Failed to start daemon. Schedule will run when daemon starts manually.');
+        }
+      } else {
+        result.warnings.push('Daemon not started. Schedule is saved but will not run until the daemon starts.');
+      }
+    } else {
+      result.warnings.push('Daemon is not running. Start it with: moflo daemon start');
+    }
+  }
+
+  // Step 2: Check if daemon is installed as OS service
+  if (result.daemonRunning) {
+    result.daemonInstalled = isDaemonInstalled(resolvedRoot);
+  }
+
+  if (result.daemonRunning && !result.daemonInstalled) {
+    if (options.interactive) {
+      const shouldInstall = await promptFn(
+        'Register the daemon as a login service so schedules survive reboots?',
+      );
+      if (shouldInstall) {
+        const installResult = installDaemonService(resolvedRoot);
+        result.daemonInstalled = installResult.success;
+        if (!installResult.success) {
+          result.warnings.push(`Failed to install daemon service: ${installResult.message}`);
+        }
+      } else {
+        result.warnings.push('Daemon is running but not installed as a login service. Schedules will stop after reboot.');
+      }
+    } else {
+      result.warnings.push('Daemon is not registered as a login service. Install with: moflo daemon install');
+    }
+  }
+
+  return result;
+}
+
+async function defaultPromptConfirm(message: string): Promise<boolean> {
+  // Dynamic import to avoid pulling in readline at module load
+  const { confirm } = await import('../prompt.js');
+  return confirm({ message, default: true });
+}
+
+async function defaultStartDaemon(projectRoot: string): Promise<boolean> {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  // dist/src/services -> dist/src -> dist -> package root -> bin/cli.js
+  const cliPath = resolve(join(__dirname, '..', '..', '..', 'bin', 'cli.js'));
+
+  if (!existsSync(cliPath)) return false;
+
+  const stateDir = join(projectRoot, '.claude-flow');
+  mkdirSync(stateDir, { recursive: true });
+
+  const logFile = join(stateDir, 'daemon.log');
+  const isWin = process.platform === 'win32';
+
+  // Open file descriptors before spawn so we can close them on error
+  let stdoutFd: number | undefined;
+  let stderrFd: number | undefined;
+  try {
+    stdoutFd = openSync(logFile, 'a');
+    stderrFd = openSync(logFile, 'a');
+
+    const child = spawn(process.execPath, [cliPath, 'daemon', 'start', '--foreground', '--quiet'], {
+      cwd: projectRoot,
+      detached: !isWin,
+      stdio: ['ignore', stdoutFd, stderrFd],
+      env: {
+        ...process.env,
+        CLAUDE_FLOW_DAEMON: '1',
+        ...(process.platform === 'darwin' ? { NOHUP: '1' } : {}),
+      },
+      ...(isWin ? { shell: true, windowsHide: true } : {}),
+    });
+
+    child.unref();
+
+    // Poll for daemon lock acquisition (up to 2s, checking every 200ms)
+    for (let i = 0; i < 10; i++) {
+      await new Promise(r => setTimeout(r, 200));
+      if (getDaemonLockHolder(projectRoot) !== null) return true;
+    }
+    return false;
+  } catch {
+    // Close file descriptors on spawn failure to prevent leaks
+    if (stdoutFd !== undefined) try { closeSync(stdoutFd); } catch { /* ignore */ }
+    if (stderrFd !== undefined) try { closeSync(stderrFd); } catch { /* ignore */ }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `moflo workflow schedule` subcommand with `create`, `list`, and `cancel` sub-commands
- Implements lazy three-state daemon readiness check that only fires when creating schedules
- Uses `@claude-flow/workflows` cron-parser for proper validation and next-run computation
- 25 new tests covering all daemon states and schedule CRUD operations

## Changes

### New Files
- `src/packages/cli/src/services/daemon-readiness.ts` — Three-state flow: checks daemon running → prompts to start → checks OS service installed → prompts to install. Always creates the schedule regardless of daemon state.
- `src/packages/cli/src/commands/workflow-schedule.ts` — Schedule subcommand: `create` (with `--cron`/`--interval`/`--at`), `list`, `cancel`
- `src/packages/cli/__tests__/services/daemon-readiness.test.ts` — 9 tests for daemon readiness states
- `src/packages/cli/__tests__/commands/workflow-schedule.test.ts` — 16 tests for schedule CRUD

### Modified
- `src/packages/cli/src/commands/workflow.ts` — Wired `scheduleCommand` into subcommands + help text

## Key Design Decisions

- **Schedule always persisted** regardless of daemon state — daemon picks it up via catch-up window on next start
- **Zero friction for non-scheduling users** — readiness check only fires on `schedule create`, never on `run`, `list`, etc.
- **Dependency injection for testability** — `promptConfirm` and `startDaemon` are injectable, enabling full unit testing without spawning real daemons
- **File descriptor safety** — spawn FDs are properly closed on failure (review feedback)
- **Poll-based startup detection** — checks daemon lock every 200ms up to 2s instead of fixed 500ms sleep (review feedback)

## Testing

- [x] Unit tests pass (25 new, 6276 total)
- [x] Integration tests pass
- [x] Full test suite: 194/194 files, 0 failures
- [x] Build passes
- [x] `npm pack --dry-run` confirms new files ship in published package

Closes #256

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)