### PR TITLE
feat(workflows): close CapabilityGateway enforcement gaps

### DIFF
--- a/src/packages/workflows/__tests__/built-in-commands.test.ts
+++ b/src/packages/workflows/__tests__/built-in-commands.test.ts
@@ -16,6 +16,7 @@ import { browserCommand } from '../src/commands/browser-command.js';
 import { validateBrowserUrl } from '../src/commands/browser-url-validator.js';
 import { builtinCommands } from '../src/commands/index.js';
 import type { MemoryAccessor } from '../src/types/step-command.types.js';
+import { CapabilityGateway } from '../src/core/capability-gateway.js';
 import { createMockContext as createContext } from './helpers.js';
 
 // ============================================================================
@@ -423,8 +424,10 @@ describe('memoryCommand', () => {
   // --- Scope enforcement (Issue #178) ---
 
   it('should block write to namespace outside memory scope', async () => {
+    const caps = [{ type: 'memory' as const, scope: ['allowed-ns'] }];
     const ctx = createContext({
-      effectiveCaps: [{ type: 'memory', scope: ['allowed-ns'] }],
+      effectiveCaps: caps,
+      gateway: new CapabilityGateway(caps, 'test', 'memory'),
     });
     const output = await memoryCommand.execute(
       { action: 'write', namespace: 'forbidden-ns', key: 'k1', value: 'data' },
@@ -661,11 +664,13 @@ describe('browserCommand', () => {
   // --- Scope enforcement (Issue #178) ---
 
   it('should block open to URL outside net scope', async () => {
+    const caps = [
+      { type: 'browser' as const },
+      { type: 'net' as const, scope: ['https://allowed.com'] },
+    ];
     const ctx = createContext({
-      effectiveCaps: [
-        { type: 'browser' },
-        { type: 'net', scope: ['https://allowed.com'] },
-      ],
+      effectiveCaps: caps,
+      gateway: new CapabilityGateway(caps, 'test', 'browser'),
     });
     const output = await browserCommand.execute(
       { actions: [{ action: 'open', url: 'https://blocked.com/page' }] },
@@ -677,11 +682,13 @@ describe('browserCommand', () => {
   });
 
   it('should allow open to URL within net scope', async () => {
+    const caps = [
+      { type: 'browser' as const },
+      { type: 'net' as const, scope: ['https://allowed.com'] },
+    ];
     const ctx = createContext({
-      effectiveCaps: [
-        { type: 'browser' },
-        { type: 'net', scope: ['https://allowed.com'] },
-      ],
+      effectiveCaps: caps,
+      gateway: new CapabilityGateway(caps, 'test', 'browser'),
     });
     const output = await browserCommand.execute(
       { actions: [{ action: 'open', url: 'https://allowed.com/page' }] },
@@ -732,13 +739,17 @@ describe('browserCommand', () => {
   // --- Evaluate capability gate (Issue #176) ---
 
   it('should reject evaluate without browser:evaluate capability', async () => {
-    const ctx = createContext({ effectiveCaps: [{ type: 'browser' }, { type: 'net' }] });
+    const caps = [{ type: 'browser' as const }, { type: 'net' as const }];
+    const ctx = createContext({
+      effectiveCaps: caps,
+      gateway: new CapabilityGateway(caps, 'test', 'browser'),
+    });
     const output = await browserCommand.execute(
       { actions: [{ action: 'evaluate', expression: 'document.title' }] },
       ctx,
     );
     expect(output.success).toBe(false);
-    expect(output.error).toContain("'browser:evaluate' capability");
+    expect(output.error).toContain('browser:evaluate');
   });
 
   it('should allow evaluate with browser:evaluate capability', async () => {

--- a/src/packages/workflows/__tests__/capability-gateway-hardening.test.ts
+++ b/src/packages/workflows/__tests__/capability-gateway-hardening.test.ts
@@ -1,0 +1,198 @@
+/**
+ * CapabilityGateway Hardening Tests
+ *
+ * Epic #270: Tests for enforcement gap closures:
+ *   #265: GatedConnectorAccessor
+ *   #266: Non-optional gateway (DenyAllGateway)
+ *   #267: Capability disclosure extraction
+ *   #268: checkCredentials()
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CapabilityGateway,
+  CapabilityDeniedError,
+  DenyAllGateway,
+  DENY_ALL_GATEWAY,
+  discloseStep,
+  discloseWorkflow,
+  formatStepDisclosure,
+  formatWorkflowDisclosure,
+  type ICapabilityGateway,
+} from '../src/core/capability-gateway.js';
+import {
+  discloseStep as disclosureDiscloseStep,
+  discloseWorkflow as disclosureDiscloseWorkflow,
+} from '../src/core/capability-disclosure.js';
+import { GatedConnectorAccessor } from '../src/core/gated-connector-accessor.js';
+import type { ConnectorAccessor, ConnectorOutput } from '../src/types/workflow-connector.types.js';
+import type { StepCapability } from '../src/types/step-command.types.js';
+import { ALLOW_ALL_GATEWAY } from './helpers.js';
+
+// ============================================================================
+// #265 — GatedConnectorAccessor
+// ============================================================================
+
+describe('#265 — GatedConnectorAccessor', () => {
+  function makeMockConnectorAccessor(): ConnectorAccessor & { executeCalls: Array<[string, string]> } {
+    const executeCalls: Array<[string, string]> = [];
+    return {
+      executeCalls,
+      get: () => undefined,
+      has: (name) => name === 'test-conn',
+      list: () => [],
+      execute: async (name, action) => {
+        executeCalls.push([name, action]);
+        return { success: true, data: {} };
+      },
+    };
+  }
+
+  it('should delegate execute to inner when gateway allows', async () => {
+    const inner = makeMockConnectorAccessor();
+    const gated = new GatedConnectorAccessor(inner, ALLOW_ALL_GATEWAY);
+
+    const result = await gated.execute('test-conn', 'fetch', {});
+    expect(result.success).toBe(true);
+    expect(inner.executeCalls).toEqual([['test-conn', 'fetch']]);
+  });
+
+  it('should block execute when gateway denies net capability', async () => {
+    const inner = makeMockConnectorAccessor();
+    const caps: StepCapability[] = [{ type: 'shell' }]; // no 'net'
+    const gateway = new CapabilityGateway(caps, 'test-step', 'test');
+    const gated = new GatedConnectorAccessor(inner, gateway);
+
+    const result = await gated.execute('test-conn', 'fetch', {});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('test-conn');
+    expect(result.error).toContain('blocked by capability gateway');
+    expect(inner.executeCalls).toHaveLength(0);
+  });
+
+  it('should allow execute when gateway grants net capability', async () => {
+    const inner = makeMockConnectorAccessor();
+    const caps: StepCapability[] = [{ type: 'net' }];
+    const gateway = new CapabilityGateway(caps, 'test-step', 'test');
+    const gated = new GatedConnectorAccessor(inner, gateway);
+
+    const result = await gated.execute('test-conn', 'fetch', {});
+    expect(result.success).toBe(true);
+    expect(inner.executeCalls).toHaveLength(1);
+  });
+
+  it('should pass through get, has, list without gateway checks', () => {
+    const inner = makeMockConnectorAccessor();
+    const gated = new GatedConnectorAccessor(inner, DENY_ALL_GATEWAY);
+
+    // Read-only operations should not trigger gateway
+    expect(gated.has('test-conn')).toBe(true);
+    expect(gated.get('test-conn')).toBeUndefined();
+    expect(gated.list()).toEqual([]);
+  });
+});
+
+// ============================================================================
+// #266 — DenyAllGateway
+// ============================================================================
+
+describe('#266 — DenyAllGateway', () => {
+  it('should be a singleton', () => {
+    expect(DENY_ALL_GATEWAY).toBeInstanceOf(DenyAllGateway);
+  });
+
+  it('should deny all capability checks', () => {
+    const gw = DENY_ALL_GATEWAY;
+    expect(() => gw.checkNet('http://example.com')).toThrow(CapabilityDeniedError);
+    expect(() => gw.checkShell('echo')).toThrow(CapabilityDeniedError);
+    expect(() => gw.checkFsRead('/etc')).toThrow(CapabilityDeniedError);
+    expect(() => gw.checkFsWrite('/tmp')).toThrow(CapabilityDeniedError);
+    expect(() => gw.checkAgent('general')).toThrow(CapabilityDeniedError);
+    expect(() => gw.checkMemory('ns')).toThrow(CapabilityDeniedError);
+    expect(() => gw.checkBrowser()).toThrow(CapabilityDeniedError);
+    expect(() => gw.checkBrowserEvaluate()).toThrow(CapabilityDeniedError);
+    expect(() => gw.checkCredentials('key')).toThrow(CapabilityDeniedError);
+  });
+
+  it('should include "no scoped gateway" in denial reason', () => {
+    try {
+      DENY_ALL_GATEWAY.checkNet('http://example.com');
+    } catch (err) {
+      expect((err as CapabilityDeniedError).violation.reason).toContain('no scoped gateway');
+    }
+  });
+});
+
+// ============================================================================
+// #268 — checkCredentials()
+// ============================================================================
+
+describe('#268 — checkCredentials', () => {
+  it('should allow when credentials capability is granted', () => {
+    const gw = new CapabilityGateway([{ type: 'credentials' }], 'step-1', 'test');
+    expect(() => gw.checkCredentials('API_KEY')).not.toThrow();
+  });
+
+  it('should deny when credentials capability is not granted', () => {
+    const gw = new CapabilityGateway([{ type: 'shell' }], 'step-1', 'test');
+    expect(() => gw.checkCredentials('API_KEY')).toThrow(CapabilityDeniedError);
+  });
+
+  it('should enforce scope on credential names', () => {
+    const gw = new CapabilityGateway(
+      [{ type: 'credentials', scope: ['API_'] }],
+      'step-1', 'test',
+    );
+    expect(() => gw.checkCredentials('API_KEY')).not.toThrow();
+    expect(() => gw.checkCredentials('DB_PASSWORD')).toThrow(CapabilityDeniedError);
+  });
+});
+
+// ============================================================================
+// #267 — Disclosure extraction
+// ============================================================================
+
+describe('#267 — Disclosure extraction', () => {
+  it('should re-export disclosure functions from capability-gateway', () => {
+    // Verify re-exports work and match the dedicated module
+    expect(discloseStep).toBe(disclosureDiscloseStep);
+    expect(discloseWorkflow).toBe(disclosureDiscloseWorkflow);
+  });
+
+  it('discloseStep returns granted and denied capabilities', () => {
+    const caps: StepCapability[] = [{ type: 'shell' }, { type: 'net', scope: ['https://api.com'] }];
+    const summary = discloseStep('my-step', caps);
+    expect(summary.stepName).toBe('my-step');
+    expect(summary.granted).toHaveLength(2);
+    expect(summary.denied).toContain('fs:read');
+    expect(summary.denied).not.toContain('shell');
+  });
+
+  it('discloseWorkflow aggregates across steps', () => {
+    const steps = [
+      { name: 'step-1', caps: [{ type: 'shell' as const }] },
+      { name: 'step-2', caps: [{ type: 'net' as const }, { type: 'shell' as const }] },
+    ];
+    const summary = discloseWorkflow('test-wf', steps);
+    expect(summary.stepCount).toBe(2);
+    expect(summary.aggregate.get('shell')).toEqual(['step-1', 'step-2']);
+    expect(summary.aggregate.get('net')).toEqual(['step-2']);
+    expect(summary.unused).toContain('fs:read');
+  });
+
+  it('formatStepDisclosure produces readable output', () => {
+    const summary = discloseStep('s1', [{ type: 'shell' }]);
+    const text = formatStepDisclosure(summary);
+    expect(text).toContain('shell');
+    expect(text).toContain('Execute shell commands');
+  });
+
+  it('formatWorkflowDisclosure produces readable output', () => {
+    const summary = discloseWorkflow('wf', [
+      { name: 's1', caps: [{ type: 'shell' }] },
+    ]);
+    const text = formatWorkflowDisclosure(summary);
+    expect(text).toContain('shell');
+    expect(text).toContain('s1');
+  });
+});

--- a/src/packages/workflows/__tests__/connector-lifecycle.test.ts
+++ b/src/packages/workflows/__tests__/connector-lifecycle.test.ts
@@ -65,6 +65,7 @@ function createConnectorCallingCommand(connectorName: string): StepCommand {
     type: 'connector-call',
     description: 'Calls a connector',
     configSchema: { type: 'object' },
+    capabilities: [{ type: 'net' }],
     validate: () => ({ valid: true, errors: [] }),
     execute: async (_config: unknown, context: WorkflowContext) => {
       const tools = context.tools;
@@ -259,6 +260,7 @@ describe('WorkflowRunner — connector lifecycle', () => {
       type: 'use-and-cancel',
       description: 'Uses connector then cancels',
       configSchema: { type: 'object' },
+      capabilities: [{ type: 'net' }],
       validate: () => ({ valid: true, errors: [] }),
       execute: async (_config: unknown, context: WorkflowContext) => {
         const tools = context.tools;

--- a/src/packages/workflows/__tests__/github-command.test.ts
+++ b/src/packages/workflows/__tests__/github-command.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { githubCommand } from '../src/commands/github-command.js';
 import type { GitHubStepConfig } from '../src/commands/github-command.js';
 import type { WorkflowContext, MemoryAccessor, CredentialAccessor } from '../src/types/step-command.types.js';
+import { ALLOW_ALL_GATEWAY } from './helpers.js';
 
 // ============================================================================
 // Mock child_process (exec + execFile for prerequisite-checker)
@@ -58,6 +59,7 @@ function makeContext(overrides?: Partial<WorkflowContext>): WorkflowContext {
     taskId: 'test-task',
     workflowId: 'test-wf',
     stepIndex: 0,
+    gateway: ALLOW_ALL_GATEWAY,
     ...overrides,
   };
 }

--- a/src/packages/workflows/__tests__/helpers.ts
+++ b/src/packages/workflows/__tests__/helpers.ts
@@ -9,6 +9,20 @@ import type {
   CredentialAccessor,
   MemoryAccessor,
 } from '../src/types/step-command.types.js';
+import type { ICapabilityGateway } from '../src/core/capability-gateway.js';
+
+/** Allow-all gateway for tests — no capability is denied. */
+export const ALLOW_ALL_GATEWAY: ICapabilityGateway = {
+  checkNet() {},
+  checkShell() {},
+  checkFsRead() {},
+  checkFsWrite() {},
+  checkAgent() {},
+  checkMemory() {},
+  checkBrowser() {},
+  checkBrowserEvaluate() {},
+  checkCredentials() {},
+};
 import type { StepDefinition } from '../src/types/workflow-definition.types.js';
 import type { WorkflowResult } from '../src/types/runner.types.js';
 
@@ -58,6 +72,7 @@ export function createMockContext(overrides?: Partial<WorkflowContext>): Workflo
     taskId: 'test',
     workflowId: 'wf-1',
     stepIndex: 0,
+    gateway: ALLOW_ALL_GATEWAY,
     ...overrides,
   };
 }

--- a/src/packages/workflows/src/commands/agent-command.ts
+++ b/src/packages/workflows/src/commands/agent-command.ts
@@ -66,17 +66,15 @@ export const agentCommand: StepCommand<AgentStepConfig> = {
       : 'general-purpose';
 
     // Enforce agent capability scope (Issue #258 — gateway enforcement)
-    if (context.gateway) {
-      try {
-        context.gateway.checkAgent(agentType);
-      } catch (err) {
-        return {
-          success: false,
-          data: { agentType, prompt },
-          error: (err as Error).message,
-          duration: Date.now() - start,
-        };
-      }
+    try {
+      context.gateway.checkAgent(agentType);
+    } catch (err) {
+      return {
+        success: false,
+        data: { agentType, prompt },
+        error: (err as Error).message,
+        duration: Date.now() - start,
+      };
     }
 
     // Agent execution is delegated to the workflow runner's agent spawner.

--- a/src/packages/workflows/src/commands/bash-command.ts
+++ b/src/packages/workflows/src/commands/bash-command.ts
@@ -59,21 +59,16 @@ export const bashCommand: StepCommand<BashStepConfig> = {
     const timeout = config.timeout ?? 30000;
     const failOnError = config.failOnError !== false;
 
-    // ── Scope enforcement (Issue #178, #258 — gateway migration) ───────
-    //
-    // Prefer the gateway for shell capability checks. Fall back to inline
-    // enforceScope() for fs:read / fs:write path extraction (best-effort).
-    if (context.gateway) {
-      try {
-        context.gateway.checkShell(command);
-      } catch (err) {
-        return {
-          success: false,
-          data: { stdout: '', stderr: '', exitCode: -1 },
-          error: (err as Error).message,
-          duration: Date.now() - start,
-        };
-      }
+    // ── Scope enforcement (#258, #266 — gateway always present) ────────
+    try {
+      context.gateway.checkShell(command);
+    } catch (err) {
+      return {
+        success: false,
+        data: { stdout: '', stderr: '', exitCode: -1 },
+        error: (err as Error).message,
+        duration: Date.now() - start,
+      };
     }
 
     // Best-effort fs path scope check — extracts absolute paths from the

--- a/src/packages/workflows/src/commands/browser-command.ts
+++ b/src/packages/workflows/src/commands/browser-command.ts
@@ -27,7 +27,6 @@ import type {
   Prerequisite,
 } from '../types/step-command.types.js';
 import { validateBrowserUrl } from './browser-url-validator.js';
-import { enforceScope, formatViolations } from '../core/capability-validator.js';
 import {
   loadPlaywright,
   executeBrowserAction,
@@ -50,11 +49,6 @@ export interface BrowserStepConfig extends StepConfig {
 
 type ActionName = (typeof SUPPORTED_ACTIONS)[number];
 
-// ── Evaluate capability check ────────────────────────────────────────────
-
-function hasEvaluateCapability(context: WorkflowContext): boolean {
-  return context.effectiveCaps?.some(c => c.type === 'browser:evaluate') === true;
-}
 
 // ── Prerequisites ────────────────────────────────────────────────────────
 
@@ -154,25 +148,15 @@ export const browserCommand: StepCommand<BrowserStepConfig> = {
 
     // Pre-flight: check all security constraints before loading Playwright.
     // This catches policy violations early without paying browser launch cost.
-    // Prefers the gateway (Issue #258) with inline enforceScope() as fallback.
     for (let i = 0; i < actions.length; i++) {
       const action = actions[i];
       try {
         if (action.action === 'evaluate') {
-          if (context.gateway) {
-            context.gateway.checkBrowserEvaluate();
-          } else if (!hasEvaluateCapability(context)) {
-            throw new Error("evaluate action requires explicit 'browser:evaluate' capability");
-          }
+          context.gateway.checkBrowserEvaluate();
         }
         if (action.action === 'open' && action.url) {
           validateBrowserUrl(action.url);
-          if (context.gateway) {
-            context.gateway.checkNet(action.url);
-          } else if (context.effectiveCaps) {
-            const violation = enforceScope(context.effectiveCaps, 'net', action.url, context.taskId, 'browser');
-            if (violation) throw new Error(formatViolations([violation]));
-          }
+          context.gateway.checkNet(action.url);
         }
         if (action.action === 'wait' && action.urlPattern) {
           if (!action.urlPattern.startsWith('/') && !action.urlPattern.includes('*')) {

--- a/src/packages/workflows/src/commands/github-command.ts
+++ b/src/packages/workflows/src/commands/github-command.ts
@@ -130,16 +130,14 @@ export const githubCommand: StepCommand<GitHubStepConfig> = {
 
   async execute(config: GitHubStepConfig, context: WorkflowContext): Promise<StepOutput> {
     // Enforce shell capability scope on the gh action (Issue #258 — gateway enforcement)
-    if (context.gateway) {
-      try {
-        context.gateway.checkShell(`gh ${config.action}`);
-      } catch (err) {
-        return {
-          success: false,
-          data: { action: config.action },
-          error: (err as Error).message,
-        };
-      }
+    try {
+      context.gateway.checkShell(`gh ${config.action}`);
+    } catch (err) {
+      return {
+        success: false,
+        data: { action: config.action },
+        error: (err as Error).message,
+      };
     }
 
     // Interpolate string values before passing to tool

--- a/src/packages/workflows/src/commands/memory-command.ts
+++ b/src/packages/workflows/src/commands/memory-command.ts
@@ -12,7 +12,6 @@ import type {
   JSONSchema,
 } from '../types/step-command.types.js';
 import { interpolateString } from '../core/interpolation.js';
-import { enforceScope, formatViolations } from '../core/capability-validator.js';
 
 type MemoryAction = 'read' | 'write' | 'search';
 
@@ -72,28 +71,16 @@ export const memoryCommand: StepCommand<MemoryStepConfig> = {
     const action = config.action;
     const namespace = interpolateString(config.namespace, context);
 
-    // Enforce memory capability scope on namespace (Issue #178, #258 — gateway migration)
-    if (context.gateway) {
-      try {
-        context.gateway.checkMemory(namespace);
-      } catch (err) {
-        return {
-          success: false,
-          data: {},
-          error: (err as Error).message,
-          duration: Date.now() - start,
-        };
-      }
-    } else if (context.effectiveCaps) {
-      const violation = enforceScope(context.effectiveCaps, 'memory', namespace, context.taskId, 'memory');
-      if (violation) {
-        return {
-          success: false,
-          data: {},
-          error: formatViolations([violation]),
-          duration: Date.now() - start,
-        };
-      }
+    // Enforce memory capability scope on namespace (#266 — gateway always present)
+    try {
+      context.gateway.checkMemory(namespace);
+    } catch (err) {
+      return {
+        success: false,
+        data: {},
+        error: (err as Error).message,
+        duration: Date.now() - start,
+      };
     }
 
     switch (action) {

--- a/src/packages/workflows/src/core/capability-disclosure.ts
+++ b/src/packages/workflows/src/core/capability-disclosure.ts
@@ -1,0 +1,135 @@
+/**
+ * Capability Disclosure
+ *
+ * Issue #267: Extracted from capability-gateway.ts to separate disclosure
+ * (transparency) from enforcement (security). Disclosure functions generate
+ * human-readable summaries of what capabilities each step/workflow has.
+ */
+
+import type {
+  StepCapability,
+  CapabilityType,
+} from '../types/step-command.types.js';
+import { VALID_CAPABILITY_TYPES } from './capability-validator.js';
+
+/** All known capability types, derived from the canonical set in capability-validator. */
+const ALL_CAPABILITY_TYPES = [...VALID_CAPABILITY_TYPES] as CapabilityType[];
+
+/** Human-readable descriptions for capability types. */
+const CAPABILITY_LABELS: Record<CapabilityType, string> = {
+  'fs:read': 'Read files',
+  'fs:write': 'Write files',
+  'net': 'Access the network',
+  'shell': 'Execute shell commands',
+  'memory': 'Access memory namespaces',
+  'credentials': 'Access credentials',
+  'browser': 'Launch browser sessions',
+  'browser:evaluate': 'Execute JavaScript in browser',
+  'agent': 'Spawn sub-agents',
+};
+
+interface CapabilityDisclosure {
+  readonly name: string;
+  readonly type: CapabilityType;
+  readonly label: string;
+  readonly scope?: readonly string[];
+}
+
+export interface StepDisclosureSummary {
+  readonly stepName: string;
+  readonly granted: readonly CapabilityDisclosure[];
+  readonly denied: readonly CapabilityType[];
+}
+
+export interface WorkflowDisclosureSummary {
+  readonly workflowName: string;
+  readonly stepCount: number;
+  /** Capability type -> list of step names that use it. */
+  readonly aggregate: ReadonlyMap<CapabilityType, readonly string[]>;
+  /** Capability types not used by any step. */
+  readonly unused: readonly CapabilityType[];
+}
+
+/**
+ * Generate a disclosure summary for a single step's capabilities.
+ */
+export function discloseStep(stepName: string, caps: readonly StepCapability[]): StepDisclosureSummary {
+  const grantedTypes = new Set(caps.map(c => c.type));
+
+  const granted: CapabilityDisclosure[] = caps.map(c => ({
+    name: c.type,
+    type: c.type,
+    label: CAPABILITY_LABELS[c.type],
+    scope: c.scope,
+  }));
+
+  const denied = ALL_CAPABILITY_TYPES.filter(t => !grantedTypes.has(t));
+
+  return { stepName, granted, denied };
+}
+
+/**
+ * Generate an aggregate disclosure summary across all steps in a workflow.
+ */
+export function discloseWorkflow(
+  workflowName: string,
+  steps: ReadonlyArray<{ name: string; caps: readonly StepCapability[] }>,
+): WorkflowDisclosureSummary {
+  const aggregate = new Map<CapabilityType, string[]>();
+  const usedTypes = new Set<CapabilityType>();
+
+  for (const step of steps) {
+    for (const cap of step.caps) {
+      usedTypes.add(cap.type);
+      const existing = aggregate.get(cap.type) ?? [];
+      existing.push(step.name);
+      aggregate.set(cap.type, existing);
+    }
+  }
+
+  const unused = ALL_CAPABILITY_TYPES.filter(t => !usedTypes.has(t));
+
+  return { workflowName, stepCount: steps.length, aggregate, unused };
+}
+
+/**
+ * Format a step disclosure summary as a human-readable string.
+ */
+export function formatStepDisclosure(summary: StepDisclosureSummary): string {
+  const lines: string[] = [];
+
+  lines.push(`  Capabilities:`);
+  for (const cap of summary.granted) {
+    const scopeNote = cap.scope?.length
+      ? ` (scoped to: ${cap.scope.join(', ')})`
+      : '';
+    lines.push(`    \u2726 ${cap.type.padEnd(18)} \u2014 ${cap.label}${scopeNote}`);
+  }
+
+  if (summary.denied.length > 0) {
+    const deniedLabels = summary.denied.map(t => CAPABILITY_LABELS[t].toLowerCase());
+    lines.push('');
+    lines.push(`  This step cannot: ${deniedLabels.join(', ')}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format a workflow disclosure summary as a human-readable string.
+ */
+export function formatWorkflowDisclosure(summary: WorkflowDisclosureSummary): string {
+  const lines: string[] = [];
+
+  lines.push(`  Aggregate capabilities:`);
+  for (const [capType, stepNames] of summary.aggregate) {
+    lines.push(`    \u2726 ${capType.padEnd(18)} \u2014 Steps: ${stepNames.join(', ')}`);
+  }
+
+  if (summary.unused.length > 0) {
+    lines.push('');
+    lines.push(`  No steps use: ${summary.unused.join(', ')}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/packages/workflows/src/core/capability-gateway.ts
+++ b/src/packages/workflows/src/core/capability-gateway.ts
@@ -11,7 +11,7 @@ import type {
   StepCapability,
   CapabilityType,
 } from '../types/step-command.types.js';
-import { enforceScope, formatViolations, VALID_CAPABILITY_TYPES, type CapabilityViolation } from './capability-validator.js';
+import { enforceScope, formatViolations, type CapabilityViolation } from './capability-validator.js';
 
 // ── Error ────────────────────────────────────────────────────────────────
 
@@ -44,6 +44,8 @@ export interface ICapabilityGateway {
   checkBrowser(): void;
   /** Check browser:evaluate capability. */
   checkBrowserEvaluate(): void;
+  /** Check credential access at runtime (#268). */
+  checkCredentials(name: string): void;
 }
 
 // ── Implementation ───────────────────────────────────────────────────────
@@ -95,6 +97,10 @@ export class CapabilityGateway implements ICapabilityGateway {
     this.enforce('browser:evaluate', '');
   }
 
+  checkCredentials(name: string): void {
+    this.enforce('credentials', name);
+  }
+
   private enforce(capabilityType: CapabilityType, resource: string): void {
     const violation = enforceScope(this.caps, capabilityType, resource, this.stepId, this.stepType);
     if (violation) {
@@ -103,124 +109,42 @@ export class CapabilityGateway implements ICapabilityGateway {
   }
 }
 
-/** All known capability types, derived from the canonical set in capability-validator. */
-const ALL_CAPABILITY_TYPES = [...VALID_CAPABILITY_TYPES] as CapabilityType[];
-
-/** Human-readable descriptions for capability types. */
-const CAPABILITY_LABELS: Record<CapabilityType, string> = {
-  'fs:read': 'Read files',
-  'fs:write': 'Write files',
-  'net': 'Access the network',
-  'shell': 'Execute shell commands',
-  'memory': 'Access memory namespaces',
-  'credentials': 'Access credentials',
-  'browser': 'Launch browser sessions',
-  'browser:evaluate': 'Execute JavaScript in browser',
-  'agent': 'Spawn sub-agents',
-};
-
-interface CapabilityDisclosure {
-  readonly name: string;
-  readonly type: CapabilityType;
-  readonly label: string;
-  readonly scope?: readonly string[];
-}
-
-export interface StepDisclosureSummary {
-  readonly stepName: string;
-  readonly granted: readonly CapabilityDisclosure[];
-  readonly denied: readonly CapabilityType[];
-}
-
-export interface WorkflowDisclosureSummary {
-  readonly workflowName: string;
-  readonly stepCount: number;
-  /** Capability type -> list of step names that use it. */
-  readonly aggregate: ReadonlyMap<CapabilityType, readonly string[]>;
-  /** Capability types not used by any step. */
-  readonly unused: readonly CapabilityType[];
-}
-
 /**
- * Generate a disclosure summary for a single step's capabilities.
+ * Deny-all gateway used as the default on WorkflowContext (#266).
+ * Any code path that reaches a gateway check without going through
+ * step-executor (which installs a properly-scoped gateway) will hit
+ * this and fail loud rather than silently skipping enforcement.
  */
-export function discloseStep(stepName: string, caps: readonly StepCapability[]): StepDisclosureSummary {
-  const grantedTypes = new Set(caps.map(c => c.type));
+export class DenyAllGateway implements ICapabilityGateway {
+  private deny(capabilityType: CapabilityType, resource: string): never {
+    throw new CapabilityDeniedError({
+      capability: capabilityType,
+      stepId: 'unknown',
+      stepType: 'unknown',
+      reason: `Capability "${capabilityType}" denied for "${resource}" — no scoped gateway configured for this code path`,
+    });
+  }
 
-  const granted: CapabilityDisclosure[] = caps.map(c => ({
-    name: c.type,
-    type: c.type,
-    label: CAPABILITY_LABELS[c.type],
-    scope: c.scope,
-  }));
-
-  const denied = ALL_CAPABILITY_TYPES.filter(t => !grantedTypes.has(t));
-
-  return { stepName, granted, denied };
+  checkNet(url: string): void { this.deny('net', url); }
+  checkShell(command: string): void { this.deny('shell', command); }
+  checkFsRead(path: string): void { this.deny('fs:read', path); }
+  checkFsWrite(path: string): void { this.deny('fs:write', path); }
+  checkAgent(agentType: string): void { this.deny('agent', agentType); }
+  checkMemory(namespace: string): void { this.deny('memory', namespace); }
+  checkBrowser(): void { this.deny('browser', ''); }
+  checkBrowserEvaluate(): void { this.deny('browser:evaluate', ''); }
+  checkCredentials(name: string): void { this.deny('credentials', name); }
 }
 
-/**
- * Generate an aggregate disclosure summary across all steps in a workflow.
- */
-export function discloseWorkflow(
-  workflowName: string,
-  steps: ReadonlyArray<{ name: string; caps: readonly StepCapability[] }>,
-): WorkflowDisclosureSummary {
-  const aggregate = new Map<CapabilityType, string[]>();
-  const usedTypes = new Set<CapabilityType>();
+/** Shared singleton — immutable, safe to reuse across contexts. */
+export const DENY_ALL_GATEWAY: ICapabilityGateway = new DenyAllGateway();
 
-  for (const step of steps) {
-    for (const cap of step.caps) {
-      usedTypes.add(cap.type);
-      const existing = aggregate.get(cap.type) ?? [];
-      existing.push(step.name);
-      aggregate.set(cap.type, existing);
-    }
-  }
-
-  const unused = ALL_CAPABILITY_TYPES.filter(t => !usedTypes.has(t));
-
-  return { workflowName, stepCount: steps.length, aggregate, unused };
-}
-
-/**
- * Format a step disclosure summary as a human-readable string.
- */
-export function formatStepDisclosure(summary: StepDisclosureSummary): string {
-  const lines: string[] = [];
-
-  lines.push(`  Capabilities:`);
-  for (const cap of summary.granted) {
-    const scopeNote = cap.scope?.length
-      ? ` (scoped to: ${cap.scope.join(', ')})`
-      : '';
-    lines.push(`    \u2726 ${cap.type.padEnd(18)} \u2014 ${cap.label}${scopeNote}`);
-  }
-
-  if (summary.denied.length > 0) {
-    const deniedLabels = summary.denied.map(t => CAPABILITY_LABELS[t].toLowerCase());
-    lines.push('');
-    lines.push(`  This step cannot: ${deniedLabels.join(', ')}`);
-  }
-
-  return lines.join('\n');
-}
-
-/**
- * Format a workflow disclosure summary as a human-readable string.
- */
-export function formatWorkflowDisclosure(summary: WorkflowDisclosureSummary): string {
-  const lines: string[] = [];
-
-  lines.push(`  Aggregate capabilities:`);
-  for (const [capType, stepNames] of summary.aggregate) {
-    lines.push(`    \u2726 ${capType.padEnd(18)} \u2014 Steps: ${stepNames.join(', ')}`);
-  }
-
-  if (summary.unused.length > 0) {
-    lines.push('');
-    lines.push(`  No steps use: ${summary.unused.join(', ')}`);
-  }
-
-  return lines.join('\n');
-}
+// Re-export disclosure functions from their dedicated module (#267)
+export {
+  discloseStep,
+  discloseWorkflow,
+  formatStepDisclosure,
+  formatWorkflowDisclosure,
+  type StepDisclosureSummary,
+  type WorkflowDisclosureSummary,
+} from './capability-disclosure.js';

--- a/src/packages/workflows/src/core/gated-connector-accessor.ts
+++ b/src/packages/workflows/src/core/gated-connector-accessor.ts
@@ -1,0 +1,44 @@
+/**
+ * Gated Connector Accessor
+ *
+ * Issue #265: Wraps a ConnectorAccessor with CapabilityGateway enforcement.
+ * Every execute() call passes through gateway.checkNet() before delegation,
+ * closing the ungated I/O path through connectors.
+ */
+
+import type { ConnectorAccessor, ConnectorView, ConnectorOutput, ConnectorCapability } from '../types/workflow-connector.types.js';
+import type { ICapabilityGateway } from './capability-gateway.js';
+
+export class GatedConnectorAccessor implements ConnectorAccessor {
+  constructor(
+    private readonly inner: ConnectorAccessor,
+    private readonly gateway: ICapabilityGateway,
+  ) {}
+
+  get(name: string): ConnectorView | undefined {
+    return this.inner.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.inner.has(name);
+  }
+
+  list(): ReadonlyArray<{ name: string; description: string; capabilities: readonly ConnectorCapability[] }> {
+    return this.inner.list();
+  }
+
+  async execute(connectorName: string, action: string, params: Record<string, unknown>): Promise<ConnectorOutput> {
+    // Connectors are external resource bridges — enforce net capability before any I/O
+    try {
+      this.gateway.checkNet(connectorName);
+    } catch (err) {
+      return {
+        success: false,
+        data: {},
+        error: `Connector "${connectorName}" blocked by capability gateway: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    return this.inner.execute(connectorName, action, params);
+  }
+}

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -30,6 +30,7 @@ import { rollbackSteps, type CompletedStep } from './rollback-orchestrator.js';
 import { buildCredentialPatterns, addCredentialPattern, collectCredentialNames } from './credential-masker.js';
 import { executeSingleStep, type StepExecutionState } from './step-executor.js';
 import { collectPrerequisites, checkPrerequisites, formatPrerequisiteErrors } from './prerequisite-checker.js';
+import { DENY_ALL_GATEWAY } from './capability-gateway.js';
 
 export class WorkflowRunner {
   private readonly connectorAccessor?: ConnectorAccessorImpl;
@@ -326,6 +327,7 @@ export class WorkflowRunner {
   ): WorkflowContext {
     return { variables, args, credentials: this.credentials, memory: this.memory,
       taskId: `${workflowId}-step-${stepIndex}`, workflowId, stepIndex, abortSignal: signal,
+      gateway: DENY_ALL_GATEWAY,
       ...(this.connectorAccessor ? { tools: this.connectorAccessor } : {}) };
   }
 

--- a/src/packages/workflows/src/core/step-executor.ts
+++ b/src/packages/workflows/src/core/step-executor.ts
@@ -33,6 +33,7 @@ import {
 } from './credential-masker.js';
 import { executeWithTimeout } from './timeout-executor.js';
 import { CapabilityGateway } from './capability-gateway.js';
+import { GatedConnectorAccessor } from './gated-connector-accessor.js';
 
 const DEFAULT_STEP_TIMEOUT = 300_000; // 5 minutes
 
@@ -129,6 +130,8 @@ export async function executeSingleStep(
   const scopedContext = {
     ...context, effectiveCaps: capCheck.effectiveCaps, gateway,
     mofloLevel: resolvedLevel, nestingDepth: state.nestingDepth, maxNestingDepth: state.maxNestingDepth,
+    // Wrap connector accessor with gateway enforcement (#265)
+    tools: context.tools ? new GatedConnectorAccessor(context.tools, gateway) : undefined,
   };
 
   const timeout = state.options.defaultStepTimeout ?? DEFAULT_STEP_TIMEOUT;

--- a/src/packages/workflows/src/index.ts
+++ b/src/packages/workflows/src/index.ts
@@ -56,6 +56,7 @@ export type {
 export { StepCommandRegistry } from './core/step-command-registry.js';
 export { WorkflowRunner } from './core/runner.js';
 export { ConnectorAccessorImpl } from './core/connector-accessor.js';
+export { GatedConnectorAccessor } from './core/gated-connector-accessor.js';
 export {
   checkCapabilities,
   type CapabilityViolation,
@@ -64,6 +65,8 @@ export {
 export {
   CapabilityGateway,
   CapabilityDeniedError,
+  DenyAllGateway,
+  DENY_ALL_GATEWAY,
   discloseStep,
   discloseWorkflow,
   formatStepDisclosure,

--- a/src/packages/workflows/src/types/step-command.types.ts
+++ b/src/packages/workflows/src/types/step-command.types.ts
@@ -105,8 +105,8 @@ export interface WorkflowContext {
   readonly maxNestingDepth?: number;
   /** Workflow connectors accessor — available when a connector registry is configured. */
   readonly tools?: import('./workflow-connector.types.js').ConnectorAccessor;
-  /** Capability gateway for structural enforcement (Issue #258). */
-  readonly gateway?: import('../core/capability-gateway.js').ICapabilityGateway;
+  /** Capability gateway for structural enforcement (Issue #258, #266 — non-optional). */
+  readonly gateway: import('../core/capability-gateway.js').ICapabilityGateway;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes enforcement gaps in CapabilityGateway before the extensions registry (#259) ships:

- **#265** Wire `ConnectorAccessorImpl` to gateway — `GatedConnectorAccessor` enforces `checkNet()` before any connector `execute()`, closing the ungated I/O path
- **#266** Make gateway non-optional on `WorkflowContext` — `DenyAllGateway` as fail-closed default eliminates silent enforcement skip
- **#268** Add `checkCredentials()` to `ICapabilityGateway` — runtime credential scope enforcement
- **#267** Extract disclosure into `capability-disclosure.ts` — separates transparency from enforcement
- **#269** Update sandboxing guidance enforcement status table

All 5 command files simplified by removing `if (context.gateway)` guards.

## Changes

- New: `GatedConnectorAccessor` — decorator wrapping `ConnectorAccessor` with gateway checks
- New: `DenyAllGateway` / `DENY_ALL_GATEWAY` — fail-closed default gateway
- New: `capability-disclosure.ts` — extracted disclosure functions
- New: `checkCredentials(name)` on `ICapabilityGateway` + `CapabilityGateway`
- Changed: `WorkflowContext.gateway` from optional to required
- Changed: `runner.ts` provides `DENY_ALL_GATEWAY` in `buildContext()`
- Changed: `step-executor.ts` wraps `context.tools` with `GatedConnectorAccessor`
- Simplified: 5 command files (agent, bash, browser, github, memory) — removed optional guards

## Testing

- [x] 196 test files, 6313 tests passing
- [x] New `capability-gateway-hardening.test.ts` covering all 4 code stories
- [x] Updated existing tests (built-in-commands, connector-lifecycle, github-command)
- [x] `/simplify` run — 3 quality items fixed

Closes #270, Closes #265, Closes #266, Closes #267, Closes #268, Closes #269

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)