### PR TITLE
chore: gitignore compiled artifacts in neural src/

### DIFF
--- a/src/packages/neural/.gitignore
+++ b/src/packages/neural/.gitignore
@@ -1,0 +1,5 @@
+# Compiled output (should only exist in dist/)
+src/**/*.js
+src/**/*.js.map
+src/**/*.d.ts
+src/**/*.d.ts.map


### PR DESCRIPTION
## Summary
- Removes 7 stale compiled files (.js, .d.ts, .map) that leaked into `src/packages/neural/src/` from an accidental in-place `tsc` run
- Adds `.gitignore` to the neural package to prevent compiled output from being tracked in `src/` (should only exist in `dist/`)

## Test plan
- [x] Verified `.ts` source files exist for all removed artifacts
- [x] Confirmed `tsconfig.json` already has `outDir: "./dist"` — this was a one-off accident
- [x] `.gitignore` patterns match only compiled output under `src/`

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)