### PR TITLE
chore: sync helpers/scripts and add learnings gate

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -10,7 +10,7 @@ function readState() {
   try {
     if (fs.existsSync(STATE_FILE)) return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
   } catch (e) { /* reset on corruption */ }
-  return { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+  return { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
 }
 
 function writeState(s) {
@@ -110,6 +110,38 @@ switch (command) {
     }
     break;
   }
+  case 'check-task-transition': {
+    // When a task moves to in_progress, reset memorySearched so the next
+    // story/work-unit in a multi-task prompt must search memory again.
+    var status = process.env.TOOL_INPUT_status || '';
+    if (status === 'in_progress') {
+      var s = readState();
+      if (s.memorySearched && s.memoryRequired) {
+        s.memorySearched = false;
+        s.learningsStored = false;
+        writeState(s);
+      }
+    }
+    break;
+  }
+  case 'record-learnings-stored': {
+    var s = readState();
+    s.learningsStored = true;
+    writeState(s);
+    break;
+  }
+  case 'check-before-pr': {
+    // Block `gh pr create` if no learnings have been stored since last reset.
+    var cmd = process.env.TOOL_INPUT_command || '';
+    if (/gh\s+pr\s+create/.test(cmd)) {
+      var s = readState();
+      if (!s.learningsStored) {
+        process.stderr.write('BLOCKED: Store learnings before creating a PR. Use mcp__moflo__memory_store to record what was learned.\n');
+        process.exit(2);
+      }
+    }
+    break;
+  }
   case 'check-dangerous-command': {
     var cmd = (process.env.TOOL_INPUT_command || '').toLowerCase();
     for (var i = 0; i < DANGEROUS.length; i++) {
@@ -123,6 +155,7 @@ switch (command) {
   case 'prompt-reminder': {
     var s = readState();
     s.memorySearched = false;
+    s.learningsStored = false;
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
     var isEscaped = prompt.indexOf(ESCAPE_PREFIX) === 0;
     if (isEscaped) prompt = prompt.slice(ESCAPE_PREFIX.length).trimStart();
@@ -144,7 +177,7 @@ switch (command) {
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
     break;
   }
   default:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,6 +64,11 @@
             "type": "command",
             "command": "npx flo gate check-dangerous-command",
             "timeout": 2000
+          },
+          {
+            "type": "command",
+            "command": "npx flo gate check-before-pr",
+            "timeout": 2000
           }
         ]
       }
@@ -115,6 +120,26 @@
           {
             "type": "command",
             "command": "npx flo gate record-memory-searched",
+            "timeout": 2000
+          }
+        ]
+      },
+      {
+        "matcher": "^TaskUpdate$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx flo gate check-task-transition",
+            "timeout": 2000
+          }
+        ]
+      },
+      {
+        "matcher": "^mcp__moflo__memory_store$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx flo gate record-learnings-stored",
             "timeout": 2000
           }
         ]

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -10,7 +10,7 @@ function readState() {
   try {
     if (fs.existsSync(STATE_FILE)) return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
   } catch (e) { /* reset on corruption */ }
-  return { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+  return { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
 }
 
 function writeState(s) {
@@ -110,6 +110,38 @@ switch (command) {
     }
     break;
   }
+  case 'check-task-transition': {
+    // When a task moves to in_progress, reset memorySearched so the next
+    // story/work-unit in a multi-task prompt must search memory again.
+    var status = process.env.TOOL_INPUT_status || '';
+    if (status === 'in_progress') {
+      var s = readState();
+      if (s.memorySearched && s.memoryRequired) {
+        s.memorySearched = false;
+        s.learningsStored = false;
+        writeState(s);
+      }
+    }
+    break;
+  }
+  case 'record-learnings-stored': {
+    var s = readState();
+    s.learningsStored = true;
+    writeState(s);
+    break;
+  }
+  case 'check-before-pr': {
+    // Block `gh pr create` if no learnings have been stored since last reset.
+    var cmd = process.env.TOOL_INPUT_command || '';
+    if (/gh\s+pr\s+create/.test(cmd)) {
+      var s = readState();
+      if (!s.learningsStored) {
+        process.stderr.write('BLOCKED: Store learnings before creating a PR. Use mcp__moflo__memory_store to record what was learned.\n');
+        process.exit(2);
+      }
+    }
+    break;
+  }
   case 'check-dangerous-command': {
     var cmd = (process.env.TOOL_INPUT_command || '').toLowerCase();
     for (var i = 0; i < DANGEROUS.length; i++) {
@@ -123,6 +155,7 @@ switch (command) {
   case 'prompt-reminder': {
     var s = readState();
     s.memorySearched = false;
+    s.learningsStored = false;
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
     var isEscaped = prompt.indexOf(ESCAPE_PREFIX) === 0;
     if (isEscaped) prompt = prompt.slice(ESCAPE_PREFIX.length).trimStart();
@@ -144,7 +177,7 @@ switch (command) {
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
     break;
   }
   default:

--- a/src/packages/cli/src/commands/doctor-checks-deep.ts
+++ b/src/packages/cli/src/commands/doctor-checks-deep.ts
@@ -14,7 +14,7 @@
  * Created with motailz.com
  */
 
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { pathToFileURL, fileURLToPath } from 'url';
 
@@ -467,4 +467,149 @@ export async function checkMcpWorkflowIntegration(): Promise<HealthCheck> {
     const msg = err instanceof Error ? err.message : String(err);
     return { name: 'MCP Workflow Integration', status: 'fail', message: `MCP workflow bridge error: ${msg}`, fix: 'npm run build' };
   }
+}
+
+// ============================================================================
+// Gate Health Check
+// ============================================================================
+
+/** Required gate cases that must exist in gate.cjs for full enforcement. */
+const REQUIRED_GATE_CASES = [
+  'check-before-agent',
+  'check-before-scan',
+  'check-before-read',
+  'record-task-created',
+  'record-memory-searched',
+  'check-bash-memory',
+  'check-task-transition',
+  'record-learnings-stored',
+  'check-before-pr',
+  'check-dangerous-command',
+  'prompt-reminder',
+  'session-reset',
+];
+
+/** Required hook matchers that must exist in settings.json for gate enforcement. */
+const REQUIRED_HOOK_WIRING = [
+  { event: 'PreToolUse', pattern: 'check-before-scan' },
+  { event: 'PreToolUse', pattern: 'check-before-read' },
+  { event: 'PreToolUse', pattern: 'check-dangerous-command' },
+  { event: 'PreToolUse', pattern: 'check-before-pr' },
+  { event: 'PostToolUse', pattern: 'record-task-created' },
+  { event: 'PostToolUse', pattern: 'record-memory-searched' },
+  { event: 'PostToolUse', pattern: 'check-task-transition' },
+  { event: 'PostToolUse', pattern: 'record-learnings-stored' },
+  { event: 'PostToolUse', pattern: 'check-bash-memory' },
+  { event: 'UserPromptSubmit', pattern: 'prompt-reminder' },
+];
+
+/**
+ * Verify gate infrastructure health:
+ * 1. gate.cjs exists and contains all required cases
+ * 2. settings.json hooks reference all required gates
+ * 3. bin/gate.cjs and .claude/helpers/gate.cjs are in sync
+ * 4. workflow-state.json is parseable (if it exists)
+ */
+export async function checkGateHealth(): Promise<HealthCheck> {
+  const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const issues: string[] = [];
+  const warnings: string[] = [];
+
+  // 1. Check gate.cjs exists and has all required cases
+  const helperGate = join(projectDir, '.claude', 'helpers', 'gate.cjs');
+  if (!existsSync(helperGate)) {
+    return {
+      name: 'Gate Health',
+      status: 'fail',
+      message: '.claude/helpers/gate.cjs not found',
+      fix: 'npx moflo init --fix',
+    };
+  }
+
+  let gateContent: string;
+  try {
+    gateContent = readFileSync(helperGate, 'utf8');
+  } catch {
+    return { name: 'Gate Health', status: 'fail', message: 'Cannot read .claude/helpers/gate.cjs', fix: 'npx moflo init --fix' };
+  }
+
+  const missingCases = REQUIRED_GATE_CASES.filter(c => !gateContent.includes(`case '${c}'`));
+  if (missingCases.length > 0) {
+    issues.push(`gate.cjs missing cases: ${missingCases.join(', ')}`);
+  }
+
+  // 2. Check bin/gate.cjs sync
+  const binGate = join(projectDir, 'bin', 'gate.cjs');
+  if (existsSync(binGate)) {
+    try {
+      const binContent = readFileSync(binGate, 'utf8');
+      if (binContent !== gateContent) {
+        // Check if it's a size difference (likely out of sync) vs whitespace
+        const sizeDiff = Math.abs(binContent.length - gateContent.length);
+        if (sizeDiff > 10) {
+          issues.push(`bin/gate.cjs out of sync with .claude/helpers/gate.cjs (${sizeDiff} chars differ)`);
+        } else {
+          warnings.push('bin/gate.cjs minor drift from .claude/helpers/gate.cjs');
+        }
+      }
+    } catch { /* non-fatal */ }
+  }
+
+  // 3. Check settings.json hook wiring
+  const settingsPath = join(projectDir, '.claude', 'settings.json');
+  if (existsSync(settingsPath)) {
+    try {
+      const settingsContent = readFileSync(settingsPath, 'utf8');
+      const missingHooks = REQUIRED_HOOK_WIRING.filter(h => !settingsContent.includes(h.pattern));
+      if (missingHooks.length > 0) {
+        issues.push(`settings.json missing hook wiring: ${missingHooks.map(h => h.pattern).join(', ')}`);
+      }
+    } catch {
+      warnings.push('Cannot parse .claude/settings.json');
+    }
+  } else {
+    issues.push('.claude/settings.json not found — no hooks configured');
+  }
+
+  // 4. Check workflow-state.json is valid (if exists)
+  const statePath = join(projectDir, '.claude', 'workflow-state.json');
+  if (existsSync(statePath)) {
+    try {
+      const stateContent = readFileSync(statePath, 'utf8');
+      const state = JSON.parse(stateContent);
+      // Verify expected keys exist
+      const expectedKeys = ['tasksCreated', 'memorySearched', 'memoryRequired', 'learningsStored'];
+      const missingKeys = expectedKeys.filter(k => !(k in state));
+      if (missingKeys.length > 0) {
+        warnings.push(`workflow-state.json missing keys: ${missingKeys.join(', ')} (will auto-fix on next gate call)`);
+      }
+    } catch {
+      warnings.push('workflow-state.json corrupt — will auto-reset on next gate call');
+    }
+  }
+
+  // Build result
+  if (issues.length > 0) {
+    return {
+      name: 'Gate Health',
+      status: 'fail',
+      message: issues.join('; '),
+      fix: 'npx moflo init --fix or manually sync gate files',
+    };
+  }
+  if (warnings.length > 0) {
+    return {
+      name: 'Gate Health',
+      status: 'warn',
+      message: warnings.join('; '),
+    };
+  }
+
+  const caseCount = REQUIRED_GATE_CASES.length;
+  const hookCount = REQUIRED_HOOK_WIRING.length;
+  return {
+    name: 'Gate Health',
+    status: 'pass',
+    message: `${caseCount} gate cases, ${hookCount} hook bindings, state file OK`,
+  };
 }

--- a/src/packages/cli/src/commands/doctor.ts
+++ b/src/packages/cli/src/commands/doctor.ts
@@ -20,6 +20,7 @@ import {
   checkMcpToolInvocation,
   checkHookExecution,
   checkMcpWorkflowIntegration,
+  checkGateHealth,
   getMofloRoot,
 } from './doctor-checks-deep.js';
 
@@ -1332,6 +1333,7 @@ export const doctorCommand: Command = {
       checkMcpToolInvocation,
       checkMcpWorkflowIntegration,
       checkHookExecution,
+      checkGateHealth,
     ];
 
     const componentMap: Record<string, () => Promise<HealthCheck>> = {
@@ -1362,6 +1364,8 @@ export const doctorCommand: Command = {
       'mcp-tools': checkMcpToolInvocation,
       'mcp-workflow': checkMcpWorkflowIntegration,
       'hooks': checkHookExecution,
+      'gates': checkGateHealth,
+      'gate': checkGateHealth,
     };
 
     let checksToRun = allChecks;

--- a/src/packages/cli/src/init/helpers-generator.ts
+++ b/src/packages/cli/src/init/helpers-generator.ts
@@ -216,7 +216,7 @@ function readState() {
   try {
     if (fs.existsSync(STATE_FILE)) return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
   } catch (e) { /* reset on corruption */ }
-  return { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+  return { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
 }
 
 function writeState(s) {
@@ -304,6 +304,35 @@ switch (command) {
     }
     break;
   }
+  case 'check-task-transition': {
+    var status = process.env.TOOL_INPUT_status || '';
+    if (status === 'in_progress') {
+      var s = readState();
+      if (s.memorySearched && s.memoryRequired) {
+        s.memorySearched = false;
+        s.learningsStored = false;
+        writeState(s);
+      }
+    }
+    break;
+  }
+  case 'record-learnings-stored': {
+    var s = readState();
+    s.learningsStored = true;
+    writeState(s);
+    break;
+  }
+  case 'check-before-pr': {
+    var cmd = process.env.TOOL_INPUT_command || '';
+    if (/gh\\s+pr\\s+create/.test(cmd)) {
+      var s = readState();
+      if (!s.learningsStored) {
+        process.stderr.write('BLOCKED: Store learnings before creating a PR. Use mcp__moflo__memory_store to record what was learned.\\n');
+        process.exit(2);
+      }
+    }
+    break;
+  }
   case 'check-dangerous-command': {
     var cmd = (process.env.TOOL_INPUT_command || '').toLowerCase();
     for (var i = 0; i < DANGEROUS.length; i++) {
@@ -317,6 +346,7 @@ switch (command) {
   case 'prompt-reminder': {
     var s = readState();
     s.memorySearched = false;
+    s.learningsStored = false;
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
     s.memoryRequired = prompt.length >= 4 && !DIRECTIVE_RE.test(prompt) && (TASK_RE.test(prompt) || prompt.length > 80);
     s.interactionCount = (s.interactionCount || 0) + 1;

--- a/src/packages/cli/src/init/settings-generator.ts
+++ b/src/packages/cli/src/init/settings-generator.ts
@@ -250,7 +250,10 @@ function generateHooksConfig(config: HooksConfig): object {
       },
       {
         matcher: '^Bash$',
-        hooks: [{ type: 'command', command: gateHookCmd('check-dangerous-command'), timeout: 2000 }],
+        hooks: [
+          { type: 'command', command: gateHookCmd('check-dangerous-command'), timeout: 2000 },
+          { type: 'command', command: gateHookCmd('check-before-pr'), timeout: 2000 },
+        ],
       },
     ];
   }
@@ -280,6 +283,14 @@ function generateHooksConfig(config: HooksConfig): object {
         // Simplified matcher — anchored regex with parens doesn't match MCP tool names reliably
         matcher: 'mcp__moflo__memory_',
         hooks: [{ type: 'command', command: gateCmd('record-memory-searched'), timeout: 3000 }],
+      },
+      {
+        matcher: '^TaskUpdate$',
+        hooks: [{ type: 'command', command: gateCmd('check-task-transition'), timeout: 2000 }],
+      },
+      {
+        matcher: '^mcp__moflo__memory_store$',
+        hooks: [{ type: 'command', command: gateCmd('record-learnings-stored'), timeout: 2000 }],
       },
     ];
   }

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -979,4 +979,107 @@ describe('end-to-end: workflow lifecycle', () => {
     s = readState(tmpDir);
     expect(s.memorySearched).toBe(true);
   });
+
+  describe('task transition gate (check-task-transition)', () => {
+    it('resets memorySearched when task moves to in_progress', () => {
+      const env = baseEnv(tmpDir);
+
+      // Set up: memory searched, required
+      env.CLAUDE_USER_PROMPT = 'implement the feature';
+      runGate('prompt-reminder', env);
+      runGate('record-memory-searched', env);
+      let s = readState(tmpDir);
+      expect(s.memorySearched).toBe(true);
+      expect(s.memoryRequired).toBe(true);
+
+      // Transition a task to in_progress — should reset
+      env.TOOL_INPUT_status = 'in_progress';
+      runGate('check-task-transition', env);
+      s = readState(tmpDir);
+      expect(s.memorySearched).toBe(false);
+      expect(s.learningsStored).toBe(false);
+    });
+
+    it('does not reset for non-in_progress transitions', () => {
+      const env = baseEnv(tmpDir);
+
+      env.CLAUDE_USER_PROMPT = 'implement the feature';
+      runGate('prompt-reminder', env);
+      runGate('record-memory-searched', env);
+
+      env.TOOL_INPUT_status = 'completed';
+      runGate('check-task-transition', env);
+      const s = readState(tmpDir);
+      expect(s.memorySearched).toBe(true);
+    });
+
+    it('does not reset when memory was not yet searched', () => {
+      const env = baseEnv(tmpDir);
+
+      env.CLAUDE_USER_PROMPT = 'implement the feature';
+      runGate('prompt-reminder', env);
+      // Don't search memory
+
+      env.TOOL_INPUT_status = 'in_progress';
+      runGate('check-task-transition', env);
+      const s = readState(tmpDir);
+      expect(s.memorySearched).toBe(false); // stays false, no redundant reset
+    });
+  });
+
+  describe('learnings gate (check-before-pr)', () => {
+    it('blocks gh pr create when learnings not stored', () => {
+      const env = baseEnv(tmpDir);
+
+      env.CLAUDE_USER_PROMPT = 'create the pr';
+      runGate('prompt-reminder', env);
+      runGate('record-memory-searched', env);
+
+      env.TOOL_INPUT_command = 'gh pr create --title "test"';
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode).toBe(2);
+      expect(r.stderr).toContain('BLOCKED');
+      expect(r.stderr).toContain('learnings');
+    });
+
+    it('allows gh pr create after memory_store', () => {
+      const env = baseEnv(tmpDir);
+
+      env.CLAUDE_USER_PROMPT = 'create the pr';
+      runGate('prompt-reminder', env);
+      runGate('record-memory-searched', env);
+      runGate('record-learnings-stored', env);
+
+      env.TOOL_INPUT_command = 'gh pr create --title "test"';
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode).toBe(0);
+    });
+
+    it('does not block non-PR bash commands', () => {
+      const env = baseEnv(tmpDir);
+
+      env.CLAUDE_USER_PROMPT = 'run tests';
+      runGate('prompt-reminder', env);
+
+      env.TOOL_INPUT_command = 'npm test';
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode).toBe(0);
+    });
+
+    it('resets learningsStored on new prompt', () => {
+      const env = baseEnv(tmpDir);
+
+      env.CLAUDE_USER_PROMPT = 'first task';
+      runGate('prompt-reminder', env);
+      runGate('record-learnings-stored', env);
+      let s = readState(tmpDir);
+      expect(s.learningsStored).toBe(true);
+
+      // New prompt resets
+      env.CLAUDE_USER_PROMPT = 'second task needs a pr';
+      runGate('prompt-reminder', env);
+      s = readState(tmpDir);
+      expect(s.learningsStored).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `learningsStored` gate state and three new gate commands: `check-task-transition`, `record-learnings-stored`, `check-before-pr`
- New deep doctor checks and corresponding settings/generator updates
- Re-syncs generated helpers/scripts from moflo reinstall

## Test plan
- [x] New tests in `tests/bin/gate-helpers.test.ts`
- [ ] Verify `npx flo doctor` runs new deep checks

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)