### PR TITLE
fix(epic): stash dirty worktree + upsert dashboard executions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moflo",
-  "version": "4.8.52-rc.4",
+  "version": "4.8.52-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moflo",
-      "version": "4.8.52-rc.4",
+      "version": "4.8.52-rc.6",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1",
@@ -29,7 +29,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.19.37",
         "eslint": "^8.0.0",
-        "moflo": "^4.8.52-rc.4",
+        "moflo": "^4.8.52-rc.6",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -10165,9 +10165,9 @@
       "optional": true
     },
     "node_modules/moflo": {
-      "version": "4.8.52",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.52.tgz",
-      "integrity": "sha512-bDLIdZB/tZY6B53+MQcMDIzKyV8kU1rJsA6o3SjK3eBXpyMh7lF7ufQbXa+O6lGgNm7U+VLhREmgkOGKpVs6aA==",
+      "version": "4.8.52-rc.6",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.52-rc.6.tgz",
+      "integrity": "sha512-0UOA+kSHt8vlu/5LORpZVSRochY9M/Jx1zRo1+n/g2J8uWLP33CnWBls6yfRQ9n0pEvgO1k8wDQe848hBLDtAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moflo",
-  "version": "4.8.52-rc.5",
+  "version": "4.8.52-rc.6",
   "description": "MoFlo — AI agent orchestration for Claude Code. Forked from ruflo/claude-flow with patches applied to source, plus feature-level orchestration.",
   "main": "dist/index.js",
   "type": "module",
@@ -112,7 +112,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.37",
     "eslint": "^8.0.0",
-    "moflo": "^4.8.52-rc.4",
+    "moflo": "^4.8.52-rc.5",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moflo/cli",
-  "version": "4.8.52-rc.5",
+  "version": "4.8.52-rc.6",
   "type": "module",
   "description": "MoFlo CLI — AI agent orchestration with specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",

--- a/src/packages/cli/src/epic/workflows/auto-merge.yaml
+++ b/src/packages/cli/src/epic/workflows/auto-merge.yaml
@@ -57,7 +57,7 @@ steps:
       - id: checkout-base
         type: bash
         config:
-          command: "git checkout {args.base_branch} && git pull origin {args.base_branch}"
+          command: "git stash --include-untracked -q 2>/dev/null; git checkout {args.base_branch} && git pull origin {args.base_branch}; git stash pop -q 2>/dev/null || true"
           failOnError: true
 
       # 2: Run /flo in normal mode (creates branch + PR)
@@ -90,7 +90,7 @@ steps:
       - id: pull-merged
         type: bash
         config:
-          command: "git checkout {args.base_branch} && git pull origin {args.base_branch}"
+          command: "git stash --include-untracked -q 2>/dev/null; git checkout {args.base_branch} && git pull origin {args.base_branch}; git stash pop -q 2>/dev/null || true"
           failOnError: true
 
       # 6: Comment on epic with progress

--- a/src/packages/cli/src/epic/workflows/single-branch.yaml
+++ b/src/packages/cli/src/epic/workflows/single-branch.yaml
@@ -55,7 +55,7 @@ steps:
   - id: create-branch
     type: bash
     config:
-      command: "git checkout {args.base_branch} && git pull origin {args.base_branch} && (git checkout epic/{args.epic_number}-{args.epic_slug} 2>/dev/null || git checkout -b epic/{args.epic_number}-{args.epic_slug})"
+      command: "git stash --include-untracked -q 2>/dev/null; git checkout {args.base_branch} && git pull origin {args.base_branch} && (git show-ref --verify --quiet refs/heads/epic/{args.epic_number}-{args.epic_slug} && git checkout epic/{args.epic_number}-{args.epic_slug} || git checkout -b epic/{args.epic_number}-{args.epic_slug}); git stash pop -q 2>/dev/null || true"
       failOnError: true
 
   # Step 2: Loop over stories sequentially

--- a/src/packages/cli/src/services/daemon-dashboard.ts
+++ b/src/packages/cli/src/services/daemon-dashboard.ts
@@ -50,7 +50,7 @@ export async function createDashboardMemoryAccessor(): Promise<MemoryAccessor> {
       }
     },
     async write(namespace: string, key: string, value: unknown): Promise<void> {
-      await storeEntry({ key, value: typeof value === 'string' ? value : JSON.stringify(value), namespace });
+      await storeEntry({ key, value: typeof value === 'string' ? value : JSON.stringify(value), namespace, upsert: true });
     },
     async search(namespace: string, query: string): Promise<Array<{ key: string; value: unknown; score: number }>> {
       try {


### PR DESCRIPTION
## Summary
- Epic branch checkout now stashes dirty working tree before switching branches and uses `git show-ref` to detect existing branches (fixes `fatal: branch already exists` on resume)
- Dashboard execution records now use `upsert: true` so workflow status updates overwrite instead of inserting duplicates (fixes empty Executions tab)
- Same stash pattern applied to auto-merge workflow checkout steps

## Test plan
- [x] `tests/epic-command.test.ts` — 28 pass
- [x] `src/packages/cli/__tests__/daemon-dashboard.test.ts` — 13 pass
- [x] `src/packages/workflows/__tests__/runner.test.ts` — 44 pass
- [x] End-to-end: verified `tasklist` record shows `"status":"completed"` after workflow run

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)