### PR TITLE
chore: clean up epic diagnostic logging, add flo init injection

### DIFF
--- a/flo
+++ b/flo
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Thin wrapper — avoids npx overhead on Windows.
+# Runs the local moflo CLI directly via node.
+exec node node_modules/moflo/bin/cli.js "$@"

--- a/src/packages/cli/src/init/executor.ts
+++ b/src/packages/cli/src/init/executor.ts
@@ -220,6 +220,10 @@ export async function executeInit(options: InitOptions): Promise<InitResult> {
       await writeClaudeMd(targetDir, options, result);
     }
 
+    // Inject "flo" npm script into consumer's package.json
+    // (avoids npx overhead on Windows — npm scripts resolve .bin directly)
+    await injectFloScript(targetDir, result);
+
     // Count enabled hooks
     result.summary.hooksEnabled = countEnabledHooks(options);
 
@@ -2127,6 +2131,25 @@ function countFiles(dir: string, ext: string): number {
   }
 
   return count;
+}
+
+/**
+ * Inject "flo" npm script into the consumer's package.json.
+ * This lets users run `npm run flo -- <args>` without npx overhead.
+ */
+async function injectFloScript(targetDir: string, result: InitResult): Promise<void> {
+  const pkgPath = path.join(targetDir, 'package.json');
+  if (!fs.existsSync(pkgPath)) return;
+
+  const raw = fs.readFileSync(pkgPath, 'utf-8');
+  const pkg = JSON.parse(raw);
+
+  if (!pkg.scripts) pkg.scripts = {};
+  if (pkg.scripts.flo) return; // already present
+
+  pkg.scripts.flo = 'flo';
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8');
+  result.created.files.push('package.json (flo script)');
 }
 
 /**

--- a/src/packages/workflows/src/commands/bash-command.ts
+++ b/src/packages/workflows/src/commands/bash-command.ts
@@ -88,7 +88,6 @@ export const bashCommand: StepCommand<BashStepConfig> = {
     }
 
     return new Promise<StepOutput>((resolve) => {
-      const isWin = platform() === 'win32';
       let timedOut = false;
 
       const child = exec(command, {
@@ -98,33 +97,11 @@ export const bashCommand: StepCommand<BashStepConfig> = {
         maxBuffer: 10 * 1024 * 1024,
       });
 
+      // Close stdin so child processes that read from it don't hang
       child.stdin?.end();
-
-      console.log(`[bash] pid=${child.pid} timeout=${timeout}ms cmd=${command.slice(0, 120)}`);
-
-      // ── Diagnostic event logging ──────────────────────────────────
-      const t0 = Date.now();
-      const elapsed = () => `${Date.now() - t0}ms`;
-
-      child.on('exit', (code, signal) => {
-        console.log(`[bash] pid=${child.pid} EVENT:exit code=${code} signal=${signal} at ${elapsed()}`);
-      });
-      child.on('close', (code, signal) => {
-        console.log(`[bash] pid=${child.pid} EVENT:close code=${code} signal=${signal} at ${elapsed()}`);
-      });
-      child.on('error', (err) => {
-        console.log(`[bash] pid=${child.pid} EVENT:error ${err.message} at ${elapsed()}`);
-      });
-      child.stdout?.on('end', () => {
-        console.log(`[bash] pid=${child.pid} EVENT:stdout-end at ${elapsed()}`);
-      });
-      child.stderr?.on('end', () => {
-        console.log(`[bash] pid=${child.pid} EVENT:stderr-end at ${elapsed()}`);
-      });
 
       // ── Manual timeout with process tree kill ─────────────────────
       const timer = setTimeout(() => {
-        console.log(`[bash] pid=${child.pid} TIMEOUT fired at ${elapsed()} — killing process tree`);
         timedOut = true;
         killProcessTree(child);
       }, timeout);
@@ -164,8 +141,6 @@ export const bashCommand: StepCommand<BashStepConfig> = {
             errorMsg += ' (stdout tail: ' + stdout.trim().slice(-500) + ')';
           }
         }
-
-        console.log(`[bash] pid=${child.pid} RESOLVE exit=${exitCode} timedOut=${timedOut} dur=${elapsed()}`);
 
         resolve({
           success,


### PR DESCRIPTION
## Summary
- Strip diagnostic EVENT logging from `bash-command.ts` (added during npx hang debugging, no longer needed)
- Add `injectFloScript()` to `executor.ts` so `moflo init` adds `"flo": "flo"` to consumer `package.json` scripts
- Add root `flo` wrapper script for dev-repo convenience

## Test plan
- [ ] `npm run build` passes
- [ ] `npm test` shows no new failures (pre-existing failures unchanged)
- [ ] `npm pack --dry-run` confirms YAML workflows and init executor ship

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)