### PR TITLE
feat(dashboard): group executions by run with step detail

### DIFF
--- a/src/packages/cli/src/commands/epic.ts
+++ b/src/packages/cli/src/commands/epic.ts
@@ -231,11 +231,12 @@ async function runEpic(
       }
 
       // Build actionable error message from first failure
-      const firstError = result.errors[0]?.message ?? 'Unknown error';
-      const remediation = getRemediation(firstError);
-      const summary = remediation
-        ? `Epic failed: ${firstError}\n  → ${remediation}`
-        : `Epic failed: ${firstError}`;
+      const firstErr = result.errors[0] as Record<string, unknown> | undefined;
+      const rawMsg = firstErr?.message as string ?? 'Unknown error';
+      const summary = buildFailureSummary(rawMsg, {
+        stepId: firstErr?.stepId as string | undefined,
+        stepType: result.steps?.find(s => s.status === 'failed')?.stepType,
+      });
       return { success: false, message: summary, data: result };
     }
   } catch (err) {
@@ -244,11 +245,7 @@ async function runEpic(
     if (error.stack) {
       console.error(error.stack);
     }
-    const remediation = getRemediation(error.message);
-    const summary = remediation
-      ? `Epic execution error: ${error.message}\n  → ${remediation}`
-      : `Epic execution error: ${error.message}`;
-    return { success: false, message: summary };
+    return { success: false, message: buildFailureSummary(error.message) };
   }
 }
 
@@ -319,6 +316,40 @@ const REMEDIATION_PATTERNS: Array<{ pattern: RegExp; hint: string }> = [
   { pattern: /ENOENT|not found|cannot find/i, hint: 'A required file or command was not found. Check that all dependencies are installed' },
   { pattern: /timeout/i, hint: 'A step timed out. Retry the epic — it will resume from where it left off' },
 ];
+
+/** Strip wrapper noise from bash command errors to surface the actual message. */
+function cleanError(raw: string): string {
+  // "Command exited with code 1: ERROR: actual message" → "actual message"
+  let msg = raw.replace(/^Command exited with code \d+:\s*/i, '');
+  msg = msg.replace(/^ERROR:\s*/i, '');
+  return msg.trim() || raw;
+}
+
+/**
+ * Build an actionable failure summary.
+ * Always includes the cleaned error. Adds a remediation hint when a known
+ * pattern matches. When no pattern matches, includes the raw error so
+ * Claude (or any AI assistant in the session) can interpret it for the user.
+ */
+function buildFailureSummary(rawError: string, context?: { stepId?: string; stepType?: string }): string {
+  const cleaned = cleanError(rawError);
+  const hint = getRemediation(rawError);
+
+  const lines: string[] = [];
+  if (context?.stepId) {
+    lines.push(`Epic failed at step "${context.stepId}" [${context.stepType ?? 'unknown'}]`);
+  } else {
+    lines.push('Epic failed');
+  }
+  lines.push(`  Error: ${cleaned}`);
+  if (hint) {
+    lines.push(`  Fix: ${hint}`);
+  }
+  if (rawError !== cleaned) {
+    lines.push(`  Raw: ${rawError}`);
+  }
+  return lines.join('\n');
+}
 
 function getRemediation(errorMessage: string): string | undefined {
   for (const { pattern, hint } of REMEDIATION_PATTERNS) {

--- a/src/packages/cli/src/commands/epic.ts
+++ b/src/packages/cli/src/commands/epic.ts
@@ -230,7 +230,13 @@ async function runEpic(
         }
       }
 
-      return { success: false, message: 'Epic failed', data: result };
+      // Build actionable error message from first failure
+      const firstError = result.errors[0]?.message ?? 'Unknown error';
+      const remediation = getRemediation(firstError);
+      const summary = remediation
+        ? `Epic failed: ${firstError}\n  → ${remediation}`
+        : `Epic failed: ${firstError}`;
+      return { success: false, message: summary, data: result };
     }
   } catch (err) {
     const error = err as Error;
@@ -238,7 +244,11 @@ async function runEpic(
     if (error.stack) {
       console.error(error.stack);
     }
-    return { success: false, message: `Epic execution error: ${error.message}` };
+    const remediation = getRemediation(error.message);
+    const summary = remediation
+      ? `Epic execution error: ${error.message}\n  → ${remediation}`
+      : `Epic execution error: ${error.message}`;
+    return { success: false, message: summary };
   }
 }
 
@@ -293,6 +303,28 @@ async function resetEpic(epicNumber: string): Promise<CommandResult> {
   }
 
   return { success: true };
+}
+
+// ============================================================================
+// Error remediation hints
+// ============================================================================
+
+const REMEDIATION_PATTERNS: Array<{ pattern: RegExp; hint: string }> = [
+  { pattern: /working tree is dirty/i, hint: 'Commit, stash, or discard your changes first: git stash --include-untracked' },
+  { pattern: /unmerged files/i, hint: 'Resolve merge conflicts first: git status to see which files, then git add after fixing' },
+  { pattern: /not an epic/i, hint: 'Add child stories as checklist items (- [ ] #123) or a ## Stories section to the issue body' },
+  { pattern: /authentication|401|403/i, hint: 'Check your GitHub credentials: gh auth status' },
+  { pattern: /branch.*already exists/i, hint: 'The epic branch already exists. Use: flo epic reset <number> then retry, or delete the branch manually' },
+  { pattern: /conflict/i, hint: 'Merge conflicts detected. Pull latest changes and resolve: git pull origin main' },
+  { pattern: /ENOENT|not found|cannot find/i, hint: 'A required file or command was not found. Check that all dependencies are installed' },
+  { pattern: /timeout/i, hint: 'A step timed out. Retry the epic — it will resume from where it left off' },
+];
+
+function getRemediation(errorMessage: string): string | undefined {
+  for (const { pattern, hint } of REMEDIATION_PATTERNS) {
+    if (pattern.test(errorMessage)) return hint;
+  }
+  return undefined;
 }
 
 // ============================================================================

--- a/src/packages/cli/src/services/daemon-dashboard.ts
+++ b/src/packages/cli/src/services/daemon-dashboard.ts
@@ -344,6 +344,9 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
     .api-links { margin-top: 12px; padding: 12px 16px; background: #161b22; border: 1px solid #30363d; border-radius: 6px; }
     .api-links a { color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-right: 16px; }
     .api-links a:hover { text-decoration: underline; }
+    .wf-group.collapsed .wf-group-body { display: none; }
+    .wf-group.collapsed .wf-chevron { transform: rotate(-90deg); }
+    .wf-chevron { transition: transform 0.15s; display: inline-block; }
   </style>
 </head>
 <body>
@@ -466,16 +469,51 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       const el = document.getElementById('panel-executions');
       if (!w || !w.available) { el.innerHTML = '<div class="empty">Scheduler not connected</div>'; return; }
       if (w.executions.length === 0) { el.innerHTML = '<div class="empty">No recent executions</div>'; return; }
-      const rows = w.executions.map(e =>
-        '<tr><td>' + esc(e.workflowName) + '</td>' +
-        '<td>' + (e.success === true ? badge('pass','green') : e.success === false ? badge('fail','red') : badge('running','yellow')) + '</td>' +
-        '<td>' + fmtTime(e.startedAt) + '</td>' +
-        '<td>' + fmtDuration(e.duration) + '</td>' +
-        '<td>' + (e.error ? '<span style="color:#f85149;font-size:0.8rem">' + esc(e.error.substring(0,80)) + '</span>' : '-') + '</td></tr>'
-      ).join('');
-      el.innerHTML = '<h2>Recent Executions</h2>' +
-        '<table><thead><tr><th>Workflow</th><th>Status</th><th>Started</th><th>Duration</th><th>Error</th></tr></thead>' +
-        '<tbody>' + rows + '</tbody></table>';
+
+      let html = '<h2>Recent Executions</h2>';
+      w.executions.forEach(e => {
+        const name = e.workflowName || 'Unknown Workflow';
+        const runId = e.id || '-';
+        const statusBadge = e.success === true ? badge('pass','green') : e.success === false ? badge('fail','red') : badge('running','yellow');
+        const progress = e.totalSteps ? (e.completedSteps || 0) + '/' + e.totalSteps + ' steps' : '';
+        const steps = Array.isArray(e.steps) ? e.steps : [];
+
+        html += '<div class="wf-group" style="margin-bottom:16px">';
+        // Header: workflow name, run ID, status, timing
+        html += '<div class="wf-group-header" style="display:flex;align-items:center;gap:8px;padding:8px 12px;background:#161b22;border:1px solid #30363d;border-radius:6px 6px 0 0;cursor:pointer" onclick="this.parentElement.classList.toggle(\\'collapsed\\')">';
+        html += '<span style="color:#58a6ff;font-weight:600">' + esc(name) + '</span> ';
+        html += statusBadge + ' ';
+        html += '<span style="color:#8b949e;font-size:0.8rem">' + progress + ' &middot; ' + fmtDuration(e.duration) + ' &middot; ' + fmtTimeAgo(e.startedAt) + '</span>';
+        if (e.error) html += '<span style="color:#f85149;font-size:0.75rem;margin-left:8px" title="' + esc(e.error) + '">' + esc(e.error.substring(0, 60)) + '</span>';
+        html += '<span style="margin-left:auto;color:#484f58;font-size:0.75rem">' + esc(runId) + '</span>';
+        html += '<span style="color:#484f58;font-size:0.75rem;margin-left:8px" class="wf-chevron">&#9660;</span>';
+        html += '</div>';
+
+        // Body: step-level detail table
+        html += '<div class="wf-group-body">';
+        if (steps.length > 0) {
+          const stepRows = steps.map((s, idx) => {
+            const sBadge = s.status === 'succeeded' ? badge('pass','green')
+              : s.status === 'failed' ? badge('fail','red')
+              : s.status === 'skipped' ? badge('skip','gray')
+              : s.status === 'cancelled' ? badge('cancel','gray')
+              : badge(s.status || '?','yellow');
+            return '<tr><td style="color:#8b949e">' + (idx + 1) + '</td>' +
+              '<td>' + esc(s.stepId) + '</td>' +
+              '<td>' + badge(s.stepType || '-','gray') + '</td>' +
+              '<td>' + sBadge + '</td>' +
+              '<td>' + fmtDuration(s.duration) + '</td>' +
+              '<td>' + (s.error ? '<span style="color:#f85149;font-size:0.8rem">' + esc(s.error.substring(0, 80)) + '</span>' : '-') + '</td></tr>';
+          }).join('');
+          html += '<table style="border-radius:0 0 6px 6px;border-top:none"><thead><tr><th>#</th><th>Step</th><th>Type</th><th>Status</th><th>Duration</th><th>Error</th></tr></thead>';
+          html += '<tbody>' + stepRows + '</tbody></table>';
+        } else {
+          html += '<div class="empty" style="border:1px solid #21262d;border-top:none;border-radius:0 0 6px 6px">No step details available for this run</div>';
+        }
+        html += '</div></div>';
+      });
+
+      el.innerHTML = html;
     }
 
     function renderMemory(m) {

--- a/src/packages/workflows/src/core/runner.ts
+++ b/src/packages/workflows/src/core/runner.ts
@@ -259,7 +259,7 @@ export class WorkflowRunner {
       // Fire onStepComplete for every step (success, failure, cancelled)
       console.log(`[workflow] Step ${i + 1}/${definition.steps.length}: ${result.status} "${step.id}" (${result.duration}ms)${result.error ? ' — ' + result.error.slice(0, 200) : ''}`);
       await this.storeProgress(workflowId, 'running', stepResults.length, definition.steps.length, {
-        workflowName: definition.name, startedAt: startTime,
+        workflowName: definition.name, startedAt: startTime, steps: stepResults,
       });
       try { options.onStepComplete?.(result, i, definition.steps.length); } catch { /* safe */ }
 
@@ -287,7 +287,7 @@ export class WorkflowRunner {
 
     const finalStatus = cancelled ? 'cancelled' : errors.length > 0 ? 'failed' : 'completed';
     await this.storeProgress(workflowId, finalStatus, stepResults.length, definition.steps.length, {
-      workflowName: definition.name, startedAt: startTime, errors,
+      workflowName: definition.name, startedAt: startTime, errors, steps: stepResults,
     });
 
     const outputs: Record<string, unknown> = {};
@@ -342,7 +342,7 @@ export class WorkflowRunner {
 
   private async storeProgress(
     wfId: string, status: string, done: number, total: number,
-    extra?: { workflowName?: string; startedAt?: number; errors?: WorkflowError[] },
+    extra?: { workflowName?: string; startedAt?: number; errors?: WorkflowError[]; steps?: StepResult[] },
   ) {
     try {
       const now = Date.now();
@@ -361,6 +361,13 @@ export class WorkflowRunner {
       // Include error summary on terminal states
       if (extra?.errors && extra.errors.length > 0 && (status === 'failed' || status === 'cancelled')) {
         record.error = extra.errors.map(e => e.message).join('; ');
+      }
+      // Include per-step results for dashboard diagnostics
+      if (extra?.steps && extra.steps.length > 0) {
+        record.steps = extra.steps.map(s => ({
+          stepId: s.stepId, stepType: s.stepType, status: s.status,
+          duration: s.duration, error: s.error,
+        }));
       }
       await this.memory.write('tasklist', wfId, record);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Dashboard Executions tab now groups by individual workflow run (not workflow type)
- Each run is a collapsible card showing workflow name, status, duration, and step progress
- Expanding a run shows a per-step table with step ID, type, status, duration, and error
- Workflow runner now persists step-level results to the `tasklist` memory namespace

## Test plan
- [x] `vitest run src/packages/cli/__tests__/daemon-dashboard.test.ts` — 13 passed
- [x] `vitest run src/packages/workflows/__tests__/runner.test.ts` — 44 passed
- [x] Verified via Playwright screenshot that grouping, collapse/expand, and step tables render correctly
- [ ] Run a full epic to confirm step data populates in production dashboard

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)