### PR TITLE
chore: remove stale ruvector-bridge reference from vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     // Use forks to prevent segfaults from native modules (agentdb/sql.js)
     pool: 'forks',
     // Increase heap limit for worker forks — prevents OOM crashes on
-    // heavy test suites (ruvector-bridge, analyzer, etc.) that otherwise
+    // heavy test suites (analyzer, etc.) that otherwise
     // kill workers and cause vitest to exit 1 even when all tests pass.
     // Vitest 4 moved pool options to top-level (poolOptions is removed).
     execArgv: ['--max-old-space-size=12288'],


### PR DESCRIPTION
## Summary
- Remove outdated ruvector-bridge mention from vitest config comment (package was removed in #314)

## Test plan
- [ ] No functional change — comment-only edit

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)