### PR TITLE
chore: strip unused fields from internal package.json files

### DIFF
--- a/src/packages/aidefence/package.json
+++ b/src/packages/aidefence/package.json
@@ -1,7 +1,5 @@
 {
   "name": "@moflo/aidefence",
-  "version": "3.0.2",
-  "description": "AI Manipulation Defense System (AIMDS) with self-learning, prompt injection detection, and vector search integration",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,10 +17,6 @@
       "types": "./dist/domain/services/threat-learning-service.d.ts"
     }
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
@@ -42,35 +36,5 @@
     "@types/node": "^20.10.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
-  },
-  "keywords": [
-    "ai-security",
-    "prompt-injection",
-    "jailbreak-detection",
-    "threat-detection",
-    "pii-detection",
-    "claude-flow",
-    "vector-search",
-    "self-learning",
-    "aimds",
-    "llm-security"
-  ],
-  "author": "Eric Cielo <eric@motailz.com>",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/eric-cielo/moflo.git",
-    "directory": "v3/@moflo/aidefence"
-  },
-  "bugs": {
-    "url": "https://github.com/eric-cielo/moflo/issues"
-  },
-  "homepage": "https://github.com/eric-cielo/moflo/tree/main/v3/@moflo/aidefence#readme",
-  "publishConfig": {
-    "access": "public",
-    "tag": "alpha"
-  },
-  "engines": {
-    "node": ">=18.0.0"
   }
 }

--- a/src/packages/claims/package.json
+++ b/src/packages/claims/package.json
@@ -1,7 +1,5 @@
 {
   "name": "@moflo/claims",
-  "version": "3.0.0-alpha.8",
-  "description": "Issue claiming and work coordination module for Claude Flow V3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
@@ -22,10 +20,6 @@
       "types": "./dist/api/mcp-tools.d.ts"
     }
   },
-  "files": [
-    "dist",
-    "src"
-  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -36,26 +30,6 @@
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit"
   },
-  "keywords": [
-    "claude-flow",
-    "claims",
-    "issue-tracking",
-    "work-coordination",
-    "multi-agent",
-    "swarm",
-    "mcp"
-  ],
-  "author": "Claude Flow Team",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/eric-cielo/moflo.git",
-    "directory": "v3/@moflo/claims"
-  },
-  "bugs": {
-    "url": "https://github.com/eric-cielo/moflo/issues"
-  },
-  "homepage": "https://github.com/eric-cielo/moflo#readme",
   "dependencies": {
     "zod": "^3.22.4"
   },
@@ -73,12 +47,5 @@
     "@moflo/shared": {
       "optional": true
     }
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/cli/package.json
+++ b/src/packages/cli/package.json
@@ -2,7 +2,6 @@
   "name": "@moflo/cli",
   "version": "4.8.52-rc.12",
   "type": "module",
-  "description": "MoFlo CLI — AI agent orchestration with specialized agents, swarm coordination, MCP server, self-learning hooks, and vector memory for Claude Code",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "sideEffects": false,
@@ -11,41 +10,6 @@
     "claude-flow": "./bin/cli.js",
     "claude-flow-mcp": "./bin/mcp-server.js"
   },
-  "homepage": "https://github.com/eric-cielo/moflo#readme",
-  "bugs": {
-    "url": "https://github.com/eric-cielo/moflo/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/eric-cielo/moflo.git",
-    "directory": "v3/@moflo/cli"
-  },
-  "keywords": [
-    "claude",
-    "claude-code",
-    "anthropic",
-    "ai-agents",
-    "multi-agent",
-    "swarm",
-    "mcp",
-    "model-context-protocol",
-    "llm",
-    "cli",
-    "orchestration",
-    "automation",
-    "developer-tools",
-    "coding-assistant",
-    "vector-database",
-    "embeddings",
-    "self-learning",
-    "enterprise"
-  ],
-  "author": {
-    "name": "Eric Cielo",
-    "email": "eric@motailz.com",
-    "url": "https://github.com/eric-cielo"
-  },
-  "license": "MIT",
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
@@ -64,12 +28,6 @@
       "import": "./dist/src/mcp-tools/index.js"
     }
   },
-  "files": [
-    "dist",
-    "bin",
-    ".claude",
-    "README.md"
-  ],
   "scripts": {
     "preversion": "echo 'ERROR: Run npm version from the repo root, not from src/packages/cli/' && exit 1",
     "build": "tsc && node -e \"const{cpSync}=require('fs');cpSync('src/epic/workflows','dist/src/epic/workflows',{recursive:true})\"",
@@ -95,9 +53,5 @@
     "@moflo/memory": "file:../memory",
     "@claude-flow/plugin-gastown-bridge": "^0.1.3",
     "agentic-flow": "^2.0.7"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "latest"
   }
 }

--- a/src/packages/embeddings/package.json
+++ b/src/packages/embeddings/package.json
@@ -1,7 +1,5 @@
 {
   "name": "@moflo/embeddings",
-  "version": "3.0.0-alpha.12",
-  "description": "V3 Embedding Service - OpenAI, Transformers.js, Agentic-Flow (ONNX), Mock providers with hyperbolic embeddings, normalization, and chunking",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -11,10 +9,6 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist",
-    "src"
-  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
@@ -22,22 +16,6 @@
     "lint": "eslint src --ext .ts",
     "clean": "rm -rf dist"
   },
-  "keywords": [
-    "embeddings",
-    "openai",
-    "transformers",
-    "vector",
-    "similarity",
-    "claude-flow",
-    "v3",
-    "hyperbolic",
-    "poincare",
-    "normalization",
-    "chunking",
-    "neural-substrate"
-  ],
-  "author": "Claude Flow Team",
-  "license": "MIT",
   "dependencies": {
     "@xenova/transformers": "^2.17.0",
     "sql.js": "^1.13.0"
@@ -55,12 +33,5 @@
     "agentic-flow": {
       "optional": true
     }
-  },
-  "engines": {
-    "node": ">=20.0.0"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/guidance/package.json
+++ b/src/packages/guidance/package.json
@@ -1,7 +1,5 @@
 {
   "name": "@moflo/guidance",
-  "version": "3.0.0-alpha.1",
-  "description": "Guidance Control Plane - Compiles, retrieves, enforces, and evolves guidance rules for Claude Code sessions",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -127,10 +125,6 @@
       "import": "./dist/analyzer.js"
     }
   },
-  "files": [
-    "dist",
-    "wasm-pkg"
-  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rm -rf dist",
@@ -148,51 +142,5 @@
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0",
     "vitest": "^4.0.16"
-  },
-  "engines": {
-    "node": ">=20.0.0"
-  },
-  "keywords": [
-    "claude-flow",
-    "claude-code",
-    "claude",
-    "anthropic",
-    "ai-agent",
-    "ai-governance",
-    "agent-governance",
-    "guidance",
-    "control-plane",
-    "policy-enforcement",
-    "enforcement-gates",
-    "proof-chain",
-    "trust-system",
-    "long-horizon",
-    "autonomous-agent",
-    "claude-md",
-    "CLAUDE.md",
-    "memory-governance",
-    "adversarial-defense",
-    "prompt-injection",
-    "wasm",
-    "ruvbot",
-    "ruv",
-    "ai-safety",
-    "agent-orchestration",
-    "multi-agent",
-    "code-generation",
-    "llm-governance",
-    "mcp",
-    "model-context-protocol"
-  ],
-  "author": "Claude Flow Team",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/eric-cielo/moflo.git",
-    "directory": "v3/@moflo/guidance"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/hooks/package.json
+++ b/src/packages/hooks/package.json
@@ -1,7 +1,5 @@
 {
   "name": "@moflo/hooks",
-  "version": "3.0.0-alpha.7",
-  "description": "V3 Hooks System - Event-driven lifecycle hooks with ReasoningBank learning integration",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,11 +37,6 @@
       "import": "./dist/reasoningbank/guidance-provider.js"
     }
   },
-  "files": [
-    "dist",
-    "bin",
-    "scripts"
-  ],
   "bin": {
     "hooks-daemon": "./bin/hooks-daemon.js",
     "statusline": "./bin/statusline.js",
@@ -66,7 +59,6 @@
     "@moflo/swarm": "^3.0.0-alpha.1",
     "zod": "^3.23.0"
   },
-  "optionalDependencies": {},
   "devDependencies": {
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0",
@@ -74,28 +66,5 @@
   },
   "peerDependencies": {
     "@moflo/shared": "^3.0.0-alpha.1"
-  },
-  "engines": {
-    "node": ">=20.0.0"
-  },
-  "keywords": [
-    "claude-flow",
-    "hooks",
-    "daemons",
-    "statusline",
-    "reasoningbank",
-    "mcp",
-    "agents"
-  ],
-  "author": "Claude Flow Team",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/eric-cielo/moflo.git",
-    "directory": "v3/@moflo/hooks"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/memory/package.json
+++ b/src/packages/memory/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@moflo/memory",
-  "version": "3.0.0-alpha.11",
   "type": "module",
-  "description": "Memory module - AgentDB unification, HNSW indexing, vector search, hybrid SQLite+AgentDB backend (ADR-009)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -23,14 +21,6 @@
   "devDependencies": {
     "@types/sql.js": "^1.4.9",
     "vitest": "^4.0.16"
-  },
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   },
   "os": [
     "darwin",

--- a/src/packages/neural/package.json
+++ b/src/packages/neural/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@moflo/neural",
-  "version": "3.0.0-alpha.7",
   "type": "module",
-  "description": "Neural module - SONA learning integration, neural modes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -17,9 +15,5 @@
   },
   "optionalDependencies": {
     "agentdb": "^2.0.0 || ^3.0.0-alpha.1"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/plugins/package.json
+++ b/src/packages/plugins/package.json
@@ -1,7 +1,5 @@
 {
   "name": "@moflo/plugins",
-  "version": "3.0.0-alpha.7",
-  "description": "Unified Plugin SDK for Claude Flow V3 - Worker, Hook, and Provider Integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
@@ -53,28 +51,5 @@
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0",
     "vitest": "^4.0.16"
-  },
-  "keywords": [
-    "claude-flow",
-    "plugins",
-    "sdk",
-    "workers",
-    "hooks",
-    "agentic-flow",
-    "agentdb",
-    "ai-agents",
-    "hnsw",
-    "vector-search",
-    "lora",
-    "neural-adaptation"
-  ],
-  "author": "Claude Flow Team",
-  "license": "MIT",
-  "engines": {
-    "node": ">=20.0.0"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/security/package.json
+++ b/src/packages/security/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@moflo/security",
-  "version": "3.0.0-alpha.6",
   "type": "module",
-  "description": "Security module - CVE fixes, input validation, path security",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -20,9 +18,5 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "vitest": "^4.0.16"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/shared/package.json
+++ b/src/packages/shared/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@moflo/shared",
-  "version": "3.0.0-alpha.6",
   "type": "module",
-  "description": "Shared module - common types, events, utilities, core interfaces",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -34,9 +32,5 @@
     "vitest": "^4.0.16",
     "ws": "^8.16.0",
     "zod": "^3.22.4"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/swarm/package.json
+++ b/src/packages/swarm/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@moflo/swarm",
-  "version": "3.0.0-alpha.6",
   "type": "module",
-  "description": "Standalone swarm coordination - up to 100+ agents, 4 topologies, hive-mind, consensus",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -15,18 +13,5 @@
   },
   "devDependencies": {
     "vitest": "^4.0.16"
-  },
-  "keywords": [
-    "swarm",
-    "multi-agent",
-    "coordination",
-    "consensus",
-    "hive-mind",
-    "distributed",
-    "ai-agents"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/testing/package.json
+++ b/src/packages/testing/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@moflo/testing",
-  "version": "3.0.0-alpha.6",
   "type": "module",
-  "description": "Testing module - TDD London School framework, test utilities, fixtures, and mock services for V3 Claude-Flow",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,15 +30,6 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "keywords": [
-    "claude-flow",
-    "testing",
-    "vitest",
-    "tdd",
-    "london-school",
-    "mocks",
-    "fixtures"
-  ],
   "peerDependencies": {
     "@moflo/memory": "^3.0.0-alpha.2",
     "@moflo/shared": "^3.0.0-alpha.1",
@@ -53,9 +42,5 @@
     "@moflo/swarm": "^3.0.0-alpha.1",
     "typescript": "^5.3.0",
     "vitest": "^4.0.16"
-  },
-  "publishConfig": {
-    "access": "public",
-    "tag": "v3alpha"
   }
 }

--- a/src/packages/workflows/package.json
+++ b/src/packages/workflows/package.json
@@ -1,7 +1,5 @@
 {
   "name": "@moflo/workflows",
-  "version": "3.0.0-alpha.1",
-  "description": "Generalized Workflow Engine for MoFlo V4 - Step Commands, Registry, and YAML/JSON Definitions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
@@ -37,16 +35,5 @@
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0",
     "vitest": "^4.0.16"
-  },
-  "keywords": [
-    "claude-flow",
-    "workflow-engine",
-    "step-commands",
-    "orchestration"
-  ],
-  "author": "MoFlo Team",
-  "license": "MIT",
-  "engines": {
-    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Removed irrelevant metadata fields (version, license, description, repository, keywords, author, bugs, homepage, engines, publishConfig, files) from 14 internal module `package.json` files under `src/packages/`
- Retained CLI `version` field since it's required by the build version-sync process
- Cleaned up empty `optionalDependencies: {}` in `@moflo/hooks`
- 323 lines deleted, zero added

## Testing
- [x] `npm run build` passes
- [x] `npm test` passes (184 files, 5891 tests, 0 failures)
- [x] Version sync test (#74) passes — CLI version field preserved
- [x] No import resolution failures

Closes #323

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)