### PR TITLE
feat(workflow): add ENGINE_VERSION constant to runner

### DIFF
--- a/src/modules/workflows/__tests__/runner.test.ts
+++ b/src/modules/workflows/__tests__/runner.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { WorkflowRunner } from '../src/core/runner.js';
+import { WorkflowRunner, ENGINE_VERSION } from '../src/core/runner.js';
 import { StepCommandRegistry } from '../src/core/step-command-registry.js';
 import type {
   StepCommand,
@@ -74,6 +74,12 @@ beforeEach(() => {
 // ============================================================================
 // Sequential Execution
 // ============================================================================
+
+describe('ENGINE_VERSION constant', () => {
+  it('should equal 1.0.0', () => {
+    expect(ENGINE_VERSION).toBe('1.0.0');
+  });
+});
 
 describe('WorkflowRunner — sequential execution', () => {
   it('should execute a 3-step workflow passing outputs forward', async () => {

--- a/src/modules/workflows/src/core/runner.ts
+++ b/src/modules/workflows/src/core/runner.ts
@@ -33,6 +33,8 @@ import { executeSingleStep, type StepExecutionState } from './step-executor.js';
 import { collectPrerequisites, checkPrerequisites, formatPrerequisiteErrors } from './prerequisite-checker.js';
 import { DENY_ALL_GATEWAY } from './capability-gateway.js';
 
+export const ENGINE_VERSION = '1.0.0';
+
 export class WorkflowRunner {
   private readonly connectorAccessor?: ConnectorAccessorImpl;
 


### PR DESCRIPTION
## Summary

- Adds `ENGINE_VERSION = '1.0.0'` exported constant to the workflow runner
- Adds test for the constant

Cherry-picked from #312. Dropped the `bash-command.ts` errorMsg change which had a duplicate `let errorMsg` declaration that would fail to compile.

## Testing

- [x] Build passes
- [x] Runner tests pass (47/47)

Closes #285
Supersedes #312

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)