### PR TITLE
chore: allow git and gh bash permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -211,6 +211,8 @@
   },
   "permissions": {
     "allow": [
+      "Bash(git *)",
+      "Bash(gh *)",
       "Bash(npx moflo*)",
       "Bash(npx flo*)",
       "Bash(flo*)",


### PR DESCRIPTION
## Summary
- Adds `Bash(git *)` and `Bash(gh *)` to allowed permissions in `.claude/settings.json`

## Test plan
- [x] Verify settings.json is valid JSON
- [x] Permissions are additive only

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)