### PR TITLE
chore: bump to 4.8.53-rc.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.19.37",
         "eslint": "^8.0.0",
-        "moflo": "^4.8.53-rc.4",
+        "moflo": "^4.8.53-rc.5",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -10290,9 +10290,9 @@
       "optional": true
     },
     "node_modules/moflo": {
-      "version": "4.8.53-rc.4",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.53-rc.4.tgz",
-      "integrity": "sha512-35L3ZIY0ykUbex8fLCPQ6hSoCrh/0Es2t/1NmyDZHE+vqbdVhG2ZqHZ06vmqq9yBxMTJzA0KqMQgYsOkAgPXSQ==",
+      "version": "4.8.53-rc.5",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.53-rc.5.tgz",
+      "integrity": "sha512-SdHUOmSwUqSa+Gj+cd3Fe+9bv1kUtZn6oFH0Dqzav4vR6IMT3L+ut2WMmdDducQ4cLlRiR4ID6fHnEU5bYvS4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.37",
     "eslint": "^8.0.0",
-    "moflo": "^4.8.53-rc.4",
+    "moflo": "^4.8.53-rc.5",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- Bump moflo devDependency from 4.8.53-rc.4 to 4.8.53-rc.5

## Test plan
- [ ] `npm install` resolves correctly
- [ ] Existing tests pass

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)