### PR TITLE
feat: global flo shim for bare CLI usage

### DIFF
--- a/bin/lib/install-global-shim.mjs
+++ b/bin/lib/install-global-shim.mjs
@@ -1,0 +1,156 @@
+/**
+ * Install a global `flo` shim into npm's global bin directory.
+ *
+ * The shim is a tiny wrapper that finds and runs the LOCAL project's
+ * node_modules/.bin/flo, so bare `flo` always uses the correct version
+ * for the current project — no npx, no global moflo install needed.
+ *
+ * Usage:
+ *   import { installGlobalShim } from './lib/install-global-shim.mjs';
+ *   const result = await installGlobalShim();  // { installed: true, path: '...' }
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, writeFileSync, readFileSync, chmodSync } from 'fs';
+import { join } from 'path';
+
+// ── Shim content ────────────────────────────────────────────────────────────
+
+const SHIM_SH = `#!/bin/sh
+# MoFlo CLI shim — finds and runs the local project's flo binary.
+# Installed by: npx flo init
+dir="$PWD"
+while [ "$dir" != "/" ]; do
+  if [ -f "$dir/node_modules/.bin/flo" ]; then
+    exec "$dir/node_modules/.bin/flo" "$@"
+  fi
+  dir=$(dirname "$dir")
+done
+echo "flo: no moflo installation found in any parent directory" >&2
+echo "Run 'npm install moflo' in your project first." >&2
+exit 1
+`;
+
+const SHIM_CMD = `@echo off
+rem MoFlo CLI shim — finds and runs the local project's flo binary.
+rem Installed by: npx flo init
+setlocal
+set "dir=%CD%"
+:loop
+if exist "%dir%\\node_modules\\.bin\\flo.cmd" (
+  "%dir%\\node_modules\\.bin\\flo.cmd" %*
+  exit /b %ERRORLEVEL%
+)
+for %%I in ("%dir%\\..") do set "parent=%%~fI"
+if "%parent%"=="%dir%" goto notfound
+set "dir=%parent%"
+goto loop
+:notfound
+echo flo: no moflo installation found in any parent directory >&2
+echo Run 'npm install moflo' in your project first. >&2
+exit /b 1
+`;
+
+const SHIM_PS1 = `#!/usr/bin/env pwsh
+# MoFlo CLI shim — finds and runs the local project's flo binary.
+# Installed by: npx flo init
+$dir = $PWD.Path
+while ($dir -ne [System.IO.Path]::GetPathRoot($dir)) {
+  $candidate = Join-Path $dir 'node_modules/.bin/flo.ps1'
+  if (Test-Path $candidate) {
+    & $candidate @args
+    exit $LASTEXITCODE
+  }
+  $dir = Split-Path $dir -Parent
+}
+Write-Error "flo: no moflo installation found in any parent directory"
+Write-Error "Run 'npm install moflo' in your project first."
+exit 1
+`;
+
+// Marker to identify our shim vs user-installed flo
+const SHIM_MARKER = 'MoFlo CLI shim';
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the npm global bin directory.
+ */
+export function resolveGlobalBin() {
+  const globalPrefix = execSync('npm prefix -g', { encoding: 'utf8' }).trim();
+  const isWindows = process.platform === 'win32';
+  return isWindows ? globalPrefix : join(globalPrefix, 'bin');
+}
+
+/**
+ * Install the global flo shim. Returns { installed, skipped, path, error }.
+ * @param {object} opts
+ * @param {boolean} [opts.silent] - Suppress output
+ * @param {string} [opts.globalBin] - Override global bin directory (for testing)
+ */
+export function installGlobalShim({ silent = false, globalBin: globalBinOverride } = {}) {
+  try {
+    const isWindows = process.platform === 'win32';
+    const globalBin = globalBinOverride || resolveGlobalBin();
+
+    if (!existsSync(globalBin)) {
+      return { installed: false, skipped: true, error: `Global bin directory not found: ${globalBin}` };
+    }
+
+    let installed = false;
+
+    // Unix shell shim (always create — works in Git Bash on Windows too)
+    const shPath = join(globalBin, 'flo');
+    if (!isOurShim(shPath)) {
+      writeFileSync(shPath, SHIM_SH, { mode: 0o755 });
+      installed = true;
+    }
+
+    // Windows cmd shim
+    if (isWindows) {
+      const cmdPath = join(globalBin, 'flo.cmd');
+      if (!isOurShim(cmdPath)) {
+        writeFileSync(cmdPath, SHIM_CMD);
+        installed = true;
+      }
+
+      const ps1Path = join(globalBin, 'flo.ps1');
+      if (!isOurShim(ps1Path)) {
+        writeFileSync(ps1Path, SHIM_PS1);
+        installed = true;
+      }
+    }
+
+    return { installed, skipped: false, path: globalBin };
+  } catch (err) {
+    return { installed: false, skipped: true, error: err.message };
+  }
+}
+
+/**
+ * Check if a shim file exists and is ours (vs something else named flo).
+ */
+function isOurShim(filePath) {
+  if (!existsSync(filePath)) return false;
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    return content.includes(SHIM_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if the global flo shim is installed.
+ * @param {string} [globalBin] - Override global bin directory (for testing)
+ */
+export function isGlobalShimInstalled(globalBin) {
+  try {
+    const bin = globalBin || resolveGlobalBin();
+    const isWindows = process.platform === 'win32';
+    const shPath = join(bin, isWindows ? 'flo.cmd' : 'flo');
+    return isOurShim(shPath);
+  } catch {
+    return false;
+  }
+}

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -330,6 +330,19 @@ try {
   }
 } catch { /* non-fatal */ }
 
+// ── 3d. Ensure global `flo` shim exists ─────────────────────────────────────
+// Installs a tiny shim into npm's global bin so bare `flo` resolves to the
+// local project's node_modules/.bin/flo. Idempotent — skips if already present.
+try {
+  const shimLib = resolve(projectRoot, 'node_modules/moflo/bin/lib/install-global-shim.mjs');
+  const localShimLib = resolve(projectRoot, 'bin/lib/install-global-shim.mjs');
+  const shimPath = existsSync(shimLib) ? shimLib : existsSync(localShimLib) ? localShimLib : null;
+  if (shimPath) {
+    const { installGlobalShim } = await import(`file://${shimPath.replace(/\\/g, '/')}`);
+    installGlobalShim({ silent: true });
+  }
+} catch { /* non-fatal — flo still works via npx */ }
+
 // ── 4. Spawn background tasks ───────────────────────────────────────────────
 const localCli = resolve(projectRoot, 'node_modules/moflo/src/modules/cli/bin/cli.js');
 const hasLocalCli = existsSync(localCli);

--- a/flo
+++ b/flo
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Thin wrapper — avoids npx overhead on Windows.
-# Runs the local moflo CLI directly via node.
-exec node node_modules/moflo/bin/cli.js "$@"

--- a/src/modules/cli/__tests__/global-shim.test.ts
+++ b/src/modules/cli/__tests__/global-shim.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the global `flo` CLI shim installer.
+ *
+ * The shim is installed into npm's global bin directory so bare `flo`
+ * resolves to the local project's node_modules/.bin/flo without npx.
+ *
+ * Tests verify:
+ * 1. Shim files are created with correct content
+ * 2. Idempotency — re-running doesn't overwrite existing shims
+ * 3. Non-moflo flo binaries are detected and replaced
+ * 4. Graceful failure when global bin dir doesn't exist
+ * 5. isGlobalShimInstalled detection
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Import the shared shim installer
+const shimModulePath = path.resolve(process.cwd(), 'bin/lib/install-global-shim.mjs');
+const shimUrl = `file://${shimModulePath.replace(/\\/g, '/')}`;
+
+describe('install-global-shim', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-shim-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should create shim files in the global bin directory', async () => {
+    const { installGlobalShim } = await import(shimUrl);
+
+    const result = installGlobalShim({ globalBin: tmpDir });
+
+    expect(result.installed).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(result.path).toBe(tmpDir);
+
+    // Verify Unix shim exists and has correct content
+    const shFile = path.join(tmpDir, 'flo');
+    expect(fs.existsSync(shFile)).toBe(true);
+    const shContent = fs.readFileSync(shFile, 'utf-8');
+    expect(shContent).toContain('#!/bin/sh');
+    expect(shContent).toContain('MoFlo CLI shim');
+    expect(shContent).toContain('node_modules/.bin/flo');
+
+    if (process.platform === 'win32') {
+      // Verify Windows cmd shim
+      const cmdFile = path.join(tmpDir, 'flo.cmd');
+      expect(fs.existsSync(cmdFile)).toBe(true);
+      const cmdContent = fs.readFileSync(cmdFile, 'utf-8');
+      expect(cmdContent).toContain('MoFlo CLI shim');
+      expect(cmdContent).toContain('node_modules\\.bin\\flo.cmd');
+
+      // Verify PowerShell shim
+      const ps1File = path.join(tmpDir, 'flo.ps1');
+      expect(fs.existsSync(ps1File)).toBe(true);
+      const ps1Content = fs.readFileSync(ps1File, 'utf-8');
+      expect(ps1Content).toContain('MoFlo CLI shim');
+    }
+  });
+
+  it('should be idempotent — skip if shim already installed', async () => {
+    const { installGlobalShim } = await import(shimUrl);
+
+    // First install
+    const first = installGlobalShim({ globalBin: tmpDir });
+    expect(first.installed).toBe(true);
+
+    // Second install — should not overwrite
+    const second = installGlobalShim({ globalBin: tmpDir });
+    expect(second.installed).toBe(false);
+  });
+
+  it('should replace a non-moflo flo binary', async () => {
+    const { installGlobalShim } = await import(shimUrl);
+
+    // Create a pre-existing flo that is NOT our shim
+    const existingFlo = path.join(tmpDir, 'flo');
+    fs.writeFileSync(existingFlo, '#!/bin/sh\necho "I am a different flo"\n');
+
+    const result = installGlobalShim({ globalBin: tmpDir });
+
+    // Should overwrite since it's not our shim
+    expect(result.installed).toBe(true);
+
+    // Verify it's now our shim
+    const content = fs.readFileSync(existingFlo, 'utf-8');
+    expect(content).toContain('MoFlo CLI shim');
+  });
+
+  it('should handle missing global bin directory gracefully', async () => {
+    const { installGlobalShim } = await import(shimUrl);
+
+    const fakePath = path.join(tmpDir, 'nonexistent', 'deep', 'path');
+    const result = installGlobalShim({ globalBin: fakePath });
+
+    expect(result.installed).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(result.error).toContain('not found');
+  });
+
+  it('should detect installed shim via isGlobalShimInstalled', async () => {
+    const { installGlobalShim, isGlobalShimInstalled } = await import(shimUrl);
+
+    // Not installed yet
+    expect(isGlobalShimInstalled(tmpDir)).toBe(false);
+
+    // Install
+    installGlobalShim({ globalBin: tmpDir });
+
+    // Now installed
+    expect(isGlobalShimInstalled(tmpDir)).toBe(true);
+  });
+
+  it('Unix shim should walk up directories to find node_modules/.bin/flo', async () => {
+    const { installGlobalShim } = await import(shimUrl);
+
+    installGlobalShim({ globalBin: tmpDir });
+
+    const shFile = path.join(tmpDir, 'flo');
+    const content = fs.readFileSync(shFile, 'utf-8');
+
+    // Verify the directory-walking logic is present
+    expect(content).toContain('while [ "$dir" != "/" ]');
+    expect(content).toContain('node_modules/.bin/flo');
+    expect(content).toContain('dir=$(dirname "$dir")');
+    expect(content).toContain('no moflo installation found');
+  });
+
+  if (process.platform === 'win32') {
+    it('Windows cmd shim should walk up directories to find flo.cmd', async () => {
+      const { installGlobalShim } = await import(shimUrl);
+
+      installGlobalShim({ globalBin: tmpDir });
+
+      const cmdFile = path.join(tmpDir, 'flo.cmd');
+      const content = fs.readFileSync(cmdFile, 'utf-8');
+
+      // Verify the directory-walking logic is present
+      expect(content).toContain(':loop');
+      expect(content).toContain('node_modules\\.bin\\flo.cmd');
+      expect(content).toContain('no moflo installation found');
+    });
+
+    it('PowerShell shim should walk up directories to find flo.ps1', async () => {
+      const { installGlobalShim } = await import(shimUrl);
+
+      installGlobalShim({ globalBin: tmpDir });
+
+      const ps1File = path.join(tmpDir, 'flo.ps1');
+      const content = fs.readFileSync(ps1File, 'utf-8');
+
+      // Verify the directory-walking logic is present
+      expect(content).toContain('while');
+      expect(content).toContain('node_modules/.bin/flo.ps1');
+      expect(content).toContain('no moflo installation found');
+    });
+  }
+});

--- a/src/modules/cli/src/init/moflo-init.ts
+++ b/src/modules/cli/src/init/moflo-init.ts
@@ -293,6 +293,9 @@ export async function initMoflo(options: MofloInitOptions): Promise<MofloInitRes
   // Step 8: Sync ALL shipped guidance docs from moflo to project
   steps.push(...syncAllShippedGuidance(projectRoot, force));
 
+  // Step 9: Install global `flo` shim so bare `flo` command works without npx
+  steps.push(installGlobalFloShim(projectRoot));
+
   return { steps };
 }
 
@@ -945,4 +948,44 @@ function syncAllShippedGuidance(root: string, force?: boolean): MofloInitResult[
   }
 
   return results;
+}
+
+// ============================================================================
+// Step 9: Install global `flo` CLI shim
+// Places a tiny shim in npm's global bin directory so bare `flo` works
+// everywhere without npx. The shim walks up from cwd to find and exec the
+// local project's node_modules/.bin/flo — correct version always runs.
+// ============================================================================
+
+function installGlobalFloShim(root: string): MofloInitResult['steps'][0] {
+  try {
+    const shimLibCandidates = [
+      path.join(root, 'node_modules', 'moflo', 'bin', 'lib', 'install-global-shim.mjs'),
+      path.join(root, 'bin', 'lib', 'install-global-shim.mjs'),
+    ];
+    const shimLib = shimLibCandidates.find(p => fs.existsSync(p));
+
+    if (!shimLib) {
+      return { name: 'global flo shim', status: 'skipped', detail: 'Shim installer not found' };
+    }
+
+    // Dynamic import of the ESM shim installer
+    // We use a sync approach: spawn a child process to run the installer
+    const { execSync } = require('child_process');
+    const result = execSync(
+      `node -e "import('file://${shimLib.replace(/\\/g, '/')}').then(m => { const r = m.installGlobalShim(); console.log(JSON.stringify(r)); })"`,
+      { encoding: 'utf8', timeout: 10000 },
+    ).trim();
+
+    const parsed = JSON.parse(result);
+    if (parsed.installed) {
+      return { name: 'global flo shim', status: 'created', detail: `Installed to ${parsed.path}` };
+    } else if (parsed.skipped) {
+      return { name: 'global flo shim', status: 'skipped', detail: parsed.error || 'Already installed' };
+    }
+    return { name: 'global flo shim', status: 'skipped', detail: 'Already up to date' };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { name: 'global flo shim', status: 'error', detail: msg };
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `bin/lib/install-global-shim.mjs` — shared cross-platform shim installer that places `flo`, `flo.cmd`, and `flo.ps1` into npm's global bin directory
- Shim walks up from cwd to find `node_modules/.bin/flo`, always running the correct per-project version
- Wired into both `flo init` (Step 9) and `session-start-launcher` (section 3d)
- Removes old project-root `flo` script in favor of global approach
- 8 new tests covering creation, idempotency, replacement, error handling, and detection

## Test plan
- [x] All 191 test files pass (6390 tests)
- [x] Verified `flo --version` and `flo doctor` work as bare commands after shim install
- [x] Verified idempotency (second install skips)
- [ ] Test on Linux/Mac to verify Unix shim behavior

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)