### PR TITLE
chore: sync devDep to rc.6 and wire global flo shim into session-start

### DIFF
--- a/.claude/scripts/lib/install-global-shim.mjs
+++ b/.claude/scripts/lib/install-global-shim.mjs
@@ -1,0 +1,156 @@
+/**
+ * Install a global `flo` shim into npm's global bin directory.
+ *
+ * The shim is a tiny wrapper that finds and runs the LOCAL project's
+ * node_modules/.bin/flo, so bare `flo` always uses the correct version
+ * for the current project — no npx, no global moflo install needed.
+ *
+ * Usage:
+ *   import { installGlobalShim } from './lib/install-global-shim.mjs';
+ *   const result = await installGlobalShim();  // { installed: true, path: '...' }
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, writeFileSync, readFileSync, chmodSync } from 'fs';
+import { join } from 'path';
+
+// ── Shim content ────────────────────────────────────────────────────────────
+
+const SHIM_SH = `#!/bin/sh
+# MoFlo CLI shim — finds and runs the local project's flo binary.
+# Installed by: npx flo init
+dir="$PWD"
+while [ "$dir" != "/" ]; do
+  if [ -f "$dir/node_modules/.bin/flo" ]; then
+    exec "$dir/node_modules/.bin/flo" "$@"
+  fi
+  dir=$(dirname "$dir")
+done
+echo "flo: no moflo installation found in any parent directory" >&2
+echo "Run 'npm install moflo' in your project first." >&2
+exit 1
+`;
+
+const SHIM_CMD = `@echo off
+rem MoFlo CLI shim — finds and runs the local project's flo binary.
+rem Installed by: npx flo init
+setlocal
+set "dir=%CD%"
+:loop
+if exist "%dir%\\node_modules\\.bin\\flo.cmd" (
+  "%dir%\\node_modules\\.bin\\flo.cmd" %*
+  exit /b %ERRORLEVEL%
+)
+for %%I in ("%dir%\\..") do set "parent=%%~fI"
+if "%parent%"=="%dir%" goto notfound
+set "dir=%parent%"
+goto loop
+:notfound
+echo flo: no moflo installation found in any parent directory >&2
+echo Run 'npm install moflo' in your project first. >&2
+exit /b 1
+`;
+
+const SHIM_PS1 = `#!/usr/bin/env pwsh
+# MoFlo CLI shim — finds and runs the local project's flo binary.
+# Installed by: npx flo init
+$dir = $PWD.Path
+while ($dir -ne [System.IO.Path]::GetPathRoot($dir)) {
+  $candidate = Join-Path $dir 'node_modules/.bin/flo.ps1'
+  if (Test-Path $candidate) {
+    & $candidate @args
+    exit $LASTEXITCODE
+  }
+  $dir = Split-Path $dir -Parent
+}
+Write-Error "flo: no moflo installation found in any parent directory"
+Write-Error "Run 'npm install moflo' in your project first."
+exit 1
+`;
+
+// Marker to identify our shim vs user-installed flo
+const SHIM_MARKER = 'MoFlo CLI shim';
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the npm global bin directory.
+ */
+export function resolveGlobalBin() {
+  const globalPrefix = execSync('npm prefix -g', { encoding: 'utf8' }).trim();
+  const isWindows = process.platform === 'win32';
+  return isWindows ? globalPrefix : join(globalPrefix, 'bin');
+}
+
+/**
+ * Install the global flo shim. Returns { installed, skipped, path, error }.
+ * @param {object} opts
+ * @param {boolean} [opts.silent] - Suppress output
+ * @param {string} [opts.globalBin] - Override global bin directory (for testing)
+ */
+export function installGlobalShim({ silent = false, globalBin: globalBinOverride } = {}) {
+  try {
+    const isWindows = process.platform === 'win32';
+    const globalBin = globalBinOverride || resolveGlobalBin();
+
+    if (!existsSync(globalBin)) {
+      return { installed: false, skipped: true, error: `Global bin directory not found: ${globalBin}` };
+    }
+
+    let installed = false;
+
+    // Unix shell shim (always create — works in Git Bash on Windows too)
+    const shPath = join(globalBin, 'flo');
+    if (!isOurShim(shPath)) {
+      writeFileSync(shPath, SHIM_SH, { mode: 0o755 });
+      installed = true;
+    }
+
+    // Windows cmd shim
+    if (isWindows) {
+      const cmdPath = join(globalBin, 'flo.cmd');
+      if (!isOurShim(cmdPath)) {
+        writeFileSync(cmdPath, SHIM_CMD);
+        installed = true;
+      }
+
+      const ps1Path = join(globalBin, 'flo.ps1');
+      if (!isOurShim(ps1Path)) {
+        writeFileSync(ps1Path, SHIM_PS1);
+        installed = true;
+      }
+    }
+
+    return { installed, skipped: false, path: globalBin };
+  } catch (err) {
+    return { installed: false, skipped: true, error: err.message };
+  }
+}
+
+/**
+ * Check if a shim file exists and is ours (vs something else named flo).
+ */
+function isOurShim(filePath) {
+  if (!existsSync(filePath)) return false;
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    return content.includes(SHIM_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if the global flo shim is installed.
+ * @param {string} [globalBin] - Override global bin directory (for testing)
+ */
+export function isGlobalShimInstalled(globalBin) {
+  try {
+    const bin = globalBin || resolveGlobalBin();
+    const isWindows = process.platform === 'win32';
+    const shPath = join(bin, isWindows ? 'flo.cmd' : 'flo');
+    return isOurShim(shPath);
+  } catch {
+    return false;
+  }
+}

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -330,6 +330,19 @@ try {
   }
 } catch { /* non-fatal */ }
 
+// ── 3d. Ensure global `flo` shim exists ─────────────────────────────────────
+// Installs a tiny shim into npm's global bin so bare `flo` resolves to the
+// local project's node_modules/.bin/flo. Idempotent — skips if already present.
+try {
+  const shimLib = resolve(projectRoot, 'node_modules/moflo/bin/lib/install-global-shim.mjs');
+  const localShimLib = resolve(projectRoot, 'bin/lib/install-global-shim.mjs');
+  const shimPath = existsSync(shimLib) ? shimLib : existsSync(localShimLib) ? localShimLib : null;
+  if (shimPath) {
+    const { installGlobalShim } = await import(`file://${shimPath.replace(/\\/g, '/')}`);
+    installGlobalShim({ silent: true });
+  }
+} catch { /* non-fatal — flo still works via npx */ }
+
 // ── 4. Spawn background tasks ───────────────────────────────────────────────
 const localCli = resolve(projectRoot, 'node_modules/moflo/src/modules/cli/bin/cli.js');
 const hasLocalCli = existsSync(localCli);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moflo",
-  "version": "4.8.53-rc.5",
+  "version": "4.8.53-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moflo",
-      "version": "4.8.53-rc.5",
+      "version": "4.8.53-rc.6",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1",
@@ -29,7 +29,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.19.37",
         "eslint": "^8.0.0",
-        "moflo": "^4.8.53-rc.5",
+        "moflo": "^4.8.53-rc.6",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -10290,9 +10290,9 @@
       "optional": true
     },
     "node_modules/moflo": {
-      "version": "4.8.53-rc.5",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.53-rc.5.tgz",
-      "integrity": "sha512-SdHUOmSwUqSa+Gj+cd3Fe+9bv1kUtZn6oFH0Dqzav4vR6IMT3L+ut2WMmdDducQ4cLlRiR4ID6fHnEU5bYvS4w==",
+      "version": "4.8.53-rc.6",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.53-rc.6.tgz",
+      "integrity": "sha512-1V3yXfjqXAIojZZnaJBPnMrHOLILEaXR14ZJJDa4/pobrXGlxfkAirX+vePTJxYLj5MuwbMERgI6T5iQjzUuTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.37",
     "eslint": "^8.0.0",
-    "moflo": "^4.8.53-rc.5",
+    "moflo": "^4.8.53-rc.6",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- Updates `moflo` devDependency from rc.5 to rc.6 (package.json + lockfile)
- Wires the global `flo` shim installer into session-start so bare `flo` works without `npx`
- Adds `.claude/scripts/lib/install-global-shim.mjs`

## Test plan
- [x] All 6,390 tests pass (191 files)
- [x] `flo doctor --fix` — 25/25 checks pass

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)