### PR TITLE
chore: bump to 4.8.53-rc.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moflo",
-  "version": "4.8.53-rc.6",
+  "version": "4.8.53-rc.7",
   "description": "MoFlo — AI agent orchestration for Claude Code. Forked from ruflo/claude-flow with patches applied to source, plus feature-level orchestration.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/modules/cli/package.json
+++ b/src/modules/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moflo/cli",
-  "version": "4.8.53-rc.6",
+  "version": "4.8.53-rc.7",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump version to 4.8.53-rc.7
- Includes epic #287 trivial constants (ENGINE_VERSION, MODULE_ID)

## Test plan
- [x] 191 test files pass (6,390 tests)
- [x] Build succeeds

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)