### PR TITLE
fix(gate): MCP memory_search writes memorySearched flag directly (#354)

### DIFF
--- a/src/modules/cli/src/mcp-tools/memory-tools.ts
+++ b/src/modules/cli/src/mcp-tools/memory-tools.ts
@@ -13,6 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import type { MCPTool } from './types.js';
+import { WorkflowGateService } from '../services/workflow-gate.js';
 
 // Legacy JSON store interface (for migration)
 interface LegacyMemoryEntry {
@@ -50,6 +51,23 @@ function ensureMemoryDir(): void {
   const dir = getMemoryDir();
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
+  }
+}
+
+/**
+ * Notify the workflow gate that a memory search occurred.
+ * PostToolUse hooks don't fire reliably for MCP tools (#354),
+ * so the handler writes the flag directly via WorkflowGateService.
+ */
+let _gateNotified = false;
+function notifyMemoryGate(): void {
+  if (_gateNotified) return;
+  try {
+    new WorkflowGateService().recordMemorySearched();
+    _gateNotified = true;
+  } catch (err) {
+    // Non-fatal — gate will still work via bash fallback
+    if (process.env.DEBUG) process.stderr.write(`notifyMemoryGate: ${err}\n`);
   }
 }
 
@@ -273,6 +291,8 @@ export const memoryTools: MCPTool[] = [
             // Keep as string
           }
 
+          notifyMemoryGate();
+
           return {
             key,
             namespace,
@@ -357,6 +377,8 @@ export const memoryTools: MCPTool[] = [
             similarity: r.score,
           };
         });
+
+        notifyMemoryGate();
 
         return {
           query,

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -439,6 +439,26 @@ describe('gate.cjs: state recording', () => {
     const s = readState(tmpDir);
     expect(s.memorySearched).toBe(true);
   });
+
+  it('record-memory-searched is idempotent when already set', () => {
+    writeState(tmpDir, { memorySearched: true, taskCount: 5 });
+    runGate('record-memory-searched', baseEnv(tmpDir));
+    const s = readState(tmpDir);
+    expect(s.memorySearched).toBe(true);
+    expect(s.taskCount).toBe(5); // other state preserved
+  });
+
+  it('any writer of memorySearched=true satisfies the scan gate (#354)', () => {
+    // The MCP memory_search handler writes memorySearched directly to
+    // workflow-state.json (via WorkflowGateService) because PostToolUse
+    // hooks don't fire reliably for MCP tools. This test verifies the
+    // contract: regardless of who sets the flag, the gate passes.
+    writeState(tmpDir, { memorySearched: true, memoryRequired: true });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_pattern = '**/*.ts';
+    const r = runGate('check-before-scan', env);
+    expect(r.exitCode).toBe(0);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -992,11 +1012,12 @@ describe('end-to-end: workflow lifecycle', () => {
       expect(s.memorySearched).toBe(true);
       expect(s.memoryRequired).toBe(true);
 
-      // Transition a task to in_progress — should reset
+      // Transition a task to in_progress — no longer resets (#352)
+      // Memory gate only resets on new user prompts via prompt-reminder.
       env.TOOL_INPUT_status = 'in_progress';
       runGate('check-task-transition', env);
       s = readState(tmpDir);
-      expect(s.memorySearched).toBe(false);
+      expect(s.memorySearched).toBe(true);
       expect(s.learningsStored).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- MCP `memory_search` and `memory_retrieve` handlers now call `WorkflowGateService.recordMemorySearched()` directly, bypassing unreliable PostToolUse hooks
- Adds in-memory `_gateNotified` guard to skip redundant filesystem I/O after first notification
- Fixes stale test expecting `check-task-transition` to reset `memorySearched` (removed in #352)

## Test plan
- [x] All 100 gate-helpers tests pass (98 existing + 2 new)
- [x] TypeScript type-check passes
- [x] CLI module builds cleanly
- [ ] Manual: call `mcp__moflo__memory_search`, then Grep — should not be blocked

Closes #354

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)