### PR TITLE
chore(deps): bump moflo devDependency to 4.8.53-rc.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.19.37",
         "eslint": "^8.0.0",
-        "moflo": "^4.8.53-rc.10",
+        "moflo": "^4.8.53-rc.11",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -10290,9 +10290,9 @@
       "optional": true
     },
     "node_modules/moflo": {
-      "version": "4.8.53-rc.10",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.53-rc.10.tgz",
-      "integrity": "sha512-whmGSXTUkZSYkeBQt8juDu3OJd+2x1q5qrKIIA5s/x/YbtqKJYBrYDqB2PzvH+HXCpkc25nI8E5qyEDMkev7HA==",
+      "version": "4.8.53-rc.11",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.53-rc.11.tgz",
+      "integrity": "sha512-GQ2juZagw1z8RpqTeEBiJLdyBzf6W+Qo+vBgZwWOubWJihKNpCWUqbz7blxg6km/C6SGfWrEjQ2jPoEtp92Ddw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.37",
     "eslint": "^8.0.0",
-    "moflo": "^4.8.53-rc.10",
+    "moflo": "^4.8.53-rc.11",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- Bumps `moflo` devDependency from `^4.8.53-rc.10` to `^4.8.53-rc.11`
- Updates `package-lock.json` accordingly

## Test plan
- [x] `npm test` — 6772 passed, 0 failures
- [x] `moflo doctor --fix` — 25/25 checks passed

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)