### PR TITLE
revert: reset epic 287 for re-testing

### DIFF
--- a/src/modules/plugins/src/index.ts
+++ b/src/modules/plugins/src/index.ts
@@ -288,7 +288,6 @@ export {
 // Version
 // ============================================================================
 
-export const MODULE_ID = '@claude-flow/plugins';
 export const VERSION = '3.0.0-alpha.1';
 export const SDK_VERSION = '1.0.0';
 

--- a/src/modules/workflows/src/core/runner.ts
+++ b/src/modules/workflows/src/core/runner.ts
@@ -6,8 +6,6 @@
  * credential masking, and timeout handling to focused modules.
  */
 
-export const ENGINE_VERSION = '1.0.0';
-
 import type {
   WorkflowContext,
   StepOutput,


### PR DESCRIPTION
## Summary
- Remove trivial constants (ENGINE_VERSION, MODULE_ID) added by epic 287 stories #284/#285/#286
- Epic-state memory entries already cleared
- Allows epic 287 to be re-run as a clean test fixture

## Test plan
- [x] Build passes
- [x] 201 test files, 6,774 tests pass
- [x] No references to reverted constants remain

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)