### PR TITLE
refactor(cli): rename workflow commands to spell with wizard terminology

### DIFF
--- a/src/modules/cli/__tests__/spell-command.test.ts
+++ b/src/modules/cli/__tests__/spell-command.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Spell CLI Command Tests
+ *
+ * Story #370: Verifies CLI workflow→spell rename is correct.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spellCommand } from '../src/commands/spell.js';
+import { scheduleCommand } from '../src/commands/spell-schedule.js';
+
+describe('Spell CLI Command', () => {
+  it('command name is "spell"', () => {
+    expect(spellCommand.name).toBe('spell');
+  });
+
+  it('has "workflow" as backwards-compat alias', () => {
+    expect(spellCommand.aliases).toContain('workflow');
+  });
+
+  it('description uses spell terminology', () => {
+    expect(spellCommand.description).toMatch(/spell/i);
+    expect(spellCommand.description).not.toMatch(/workflow/i);
+  });
+
+  it('has expected subcommands', () => {
+    const subNames = spellCommand.subcommands!.map(s => s.name).sort();
+    expect(subNames).toEqual(['cast', 'list', 'schedule', 'status', 'stop', 'template', 'validate']);
+  });
+
+  it('cast subcommand has "run" alias for backwards compat', () => {
+    const cast = spellCommand.subcommands!.find(s => s.name === 'cast');
+    expect(cast).toBeDefined();
+    expect(cast!.aliases).toContain('run');
+  });
+
+  it('stop subcommand has "dispel" alias', () => {
+    const stop = spellCommand.subcommands!.find(s => s.name === 'stop');
+    expect(stop).toBeDefined();
+    expect(stop!.aliases).toContain('dispel');
+  });
+
+  it('template subcommand has "grimoire" alias', () => {
+    const template = spellCommand.subcommands!.find(s => s.name === 'template');
+    expect(template).toBeDefined();
+    expect(template!.aliases).toContain('grimoire');
+  });
+
+  it('examples use "moflo spell" not "moflo workflow"', () => {
+    for (const ex of spellCommand.examples ?? []) {
+      expect(ex.command).toMatch(/^moflo spell/);
+      expect(ex.command).not.toMatch(/moflo workflow/);
+    }
+  });
+});
+
+describe('Spell Schedule Subcommand', () => {
+  it('schedule command name is "schedule"', () => {
+    expect(scheduleCommand.name).toBe('schedule');
+  });
+
+  it('has create, list, cancel subcommands', () => {
+    const subNames = scheduleCommand.subcommands!.map(s => s.name).sort();
+    expect(subNames).toEqual(['cancel', 'create', 'list']);
+  });
+
+  it('examples use "moflo spell schedule"', () => {
+    for (const ex of scheduleCommand.examples ?? []) {
+      expect(ex.command).toMatch(/moflo spell schedule/);
+      expect(ex.command).not.toMatch(/moflo workflow/);
+    }
+  });
+});
+
+describe('Command index registration', () => {
+  it('spellCommand is registered in commands index', async () => {
+    const { hasCommand, getCommandAsync } = await import('../src/commands/index.js');
+    expect(hasCommand('spell')).toBe(true);
+    const cmd = await getCommandAsync('spell');
+    expect(cmd).toBeDefined();
+    expect(cmd!.name).toBe('spell');
+  });
+
+  it('no "workflow" as a primary command name in loaders', async () => {
+    const { getCommandNames } = await import('../src/commands/index.js');
+    const names = getCommandNames();
+    // "spell" should be present, "workflow" should not be a loader key
+    expect(names).toContain('spell');
+    // workflow may exist as an alias via commandRegistry from spellCommand.aliases
+    // but should NOT be in commandLoaders as a separate entry
+  });
+});
+
+describe('Completions include spell', () => {
+  it('TOP_LEVEL_COMMANDS has spell, not workflow', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const source = readFileSync(
+      resolve(import.meta.dirname, '../src/commands/completions.ts'),
+      'utf-8',
+    );
+    expect(source).toContain("'spell'");
+    expect(source).not.toContain("'workflow'");
+    expect(source).toContain('spell:Spell casting');
+  });
+});

--- a/src/modules/cli/src/commands/completions.ts
+++ b/src/modules/cli/src/commands/completions.ts
@@ -10,7 +10,7 @@ import { output } from '../output.js';
 
 // Get all top-level commands for completions
 const TOP_LEVEL_COMMANDS = [
-  'swarm', 'agent', 'task', 'session', 'config', 'memory', 'workflow',
+  'swarm', 'agent', 'task', 'session', 'config', 'memory', 'spell',
   'hive-mind', 'hooks', 'daemon', 'neural', 'security', 'performance',
   'providers', 'plugins', 'deployment', 'claims', 'embeddings',
   'doctor', 'completions', 'help', 'version'
@@ -150,7 +150,7 @@ _claude_flow() {
         'session:Session management'
         'config:Configuration management'
         'memory:Memory operations with AgentDB'
-        'workflow:Workflow automation'
+        'spell:Spell casting & automation'
         'hive-mind:Queen-led consensus coordination'
         'hooks:Self-learning automation hooks'
         'daemon:Background service management'

--- a/src/modules/cli/src/commands/hive-mind.ts
+++ b/src/modules/cli/src/commands/hive-mind.ts
@@ -119,7 +119,7 @@ ${workerTypes.map(type => `• ${type}: ${workerGroups[type].length} agents`).jo
    mcp__moflo__task_create            - Create hierarchical tasks
    mcp__moflo__task_status            - Track task progress
    mcp__moflo__task_complete          - Mark tasks complete
-   mcp__moflo__workflow_create        - Create workflows
+   mcp__moflo__workflow_create        - Create spells
 
 5️⃣ **MEMORY & LEARNING**
    mcp__moflo__memory_store           - Store collective knowledge

--- a/src/modules/cli/src/commands/index.ts
+++ b/src/modules/cli/src/commands/index.ts
@@ -36,7 +36,7 @@ const commandLoaders: Record<string, CommandLoader> = {
   config: () => import('./config.js'),
   migrate: () => import('./migrate.js'),
   hooks: () => import('./hooks.js'),
-  workflow: () => import('./workflow.js'),
+  spell: () => import('./spell.js'),
   'hive-mind': () => import('./hive-mind.js'),
   process: () => import('./process.js'),
   daemon: () => import('./daemon.js'),
@@ -138,7 +138,7 @@ import { hiveMindCommand } from './hive-mind.js';
 import { configCommand } from './config.js';
 import { completionsCommand } from './completions.js';
 import { migrateCommand } from './migrate.js';
-import { workflowCommand } from './workflow.js';
+import { spellCommand } from './spell.js';
 import { analyzeCommand } from './analyze.js';
 import { routeCommand } from './route.js';
 import { progressCommand } from './progress.js';
@@ -206,7 +206,7 @@ export { githubCommand } from './github.js';
 // Lazy-loaded command re-exports (for backwards compatibility, but async-only)
 export async function getConfigCommand() { return loadCommand('config'); }
 export async function getMigrateCommand() { return loadCommand('migrate'); }
-export async function getWorkflowCommand() { return loadCommand('workflow'); }
+export async function getSpellCommand() { return loadCommand('spell'); }
 export async function getHiveMindCommand() { return loadCommand('hive-mind'); }
 export async function getProcessCommand() { return loadCommand('process'); }
 export async function getTaskCommand() { return loadCommand('task'); }
@@ -286,7 +286,7 @@ export const commandsByCategory = {
     daemonCommand,
     completionsCommand,
     migrateCommand,
-    workflowCommand,
+    spellCommand,
   ],
   analysis: [
     analyzeCommand,

--- a/src/modules/cli/src/commands/spell-schedule.ts
+++ b/src/modules/cli/src/commands/spell-schedule.ts
@@ -1,8 +1,10 @@
 /**
- * Workflow Schedule Subcommand
+ * Spell Schedule Subcommand
  *
- * CLI interface for creating, listing, and cancelling scheduled workflows.
+ * CLI interface for creating, listing, and cancelling scheduled spells.
  * Includes lazy daemon readiness check on schedule creation.
+ *
+ * Story #370: Renamed from workflow-schedule.ts with wizard terminology.
  *
  * Schedule records are persisted to the 'scheduled-workflows' memory namespace —
  * the same namespace the daemon's SpellScheduler polls. The daemon picks up
@@ -40,17 +42,17 @@ function formatMCPError(error: unknown, action: string): CommandResult {
 
 const createCommand: Command = {
   name: 'create',
-  description: 'Create a scheduled workflow',
+  description: 'Create a scheduled spell',
   options: [
-    { name: 'name', short: 'n', description: 'Workflow name or abbreviation', type: 'string', required: true },
+    { name: 'name', short: 'n', description: 'Spell name or abbreviation', type: 'string', required: true },
     { name: 'cron', short: 'c', description: 'Cron expression (5-field)', type: 'string' },
     { name: 'interval', short: 'i', description: 'Interval (e.g., "6h", "30m", "1d")', type: 'string' },
     { name: 'at', short: 'a', description: 'One-time ISO 8601 datetime', type: 'string' },
   ],
   examples: [
-    { command: 'moflo workflow schedule create -n audit --cron "0 9 * * *"', description: 'Daily at 9am' },
-    { command: 'moflo workflow schedule create -n security-audit --interval 6h', description: 'Every 6 hours' },
-    { command: 'moflo workflow schedule create -n report --at 2026-04-01T09:00:00Z', description: 'One-time run' },
+    { command: 'moflo spell schedule create -n audit --cron "0 9 * * *"', description: 'Daily at 9am' },
+    { command: 'moflo spell schedule create -n security-audit --interval 6h', description: 'Every 6 hours' },
+    { command: 'moflo spell schedule create -n report --at 2026-04-01T09:00:00Z', description: 'One-time cast' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const name = (ctx.flags.name as string) || ctx.args[0];
@@ -59,7 +61,7 @@ const createCommand: Command = {
     const at = ctx.flags.at as string | undefined;
 
     if (!name) {
-      output.printError('Workflow name is required. Use --name or -n');
+      output.printError('Spell name is required. Use --name or -n');
       return { success: false, exitCode: 1 };
     }
 
@@ -162,15 +164,15 @@ const createCommand: Command = {
     output.printBox(
       [
         `ID: ${id}`,
-        `Workflow: ${name}`,
+        `Spell: ${name}`,
         cron ? `Cron: ${cron}` : null,
         interval ? `Interval: ${interval}` : null,
         at ? `At: ${at}` : null,
-        `Next Run: ${new Date(nextRunAt).toLocaleString()}`,
+        `Next Cast: ${new Date(nextRunAt).toLocaleString()}`,
         `Daemon: ${readiness.daemonRunning ? 'running' : 'not running'}`,
         `Service: ${readiness.daemonInstalled ? 'installed' : 'not installed'}`,
       ].filter(Boolean).join('\n'),
-      'Scheduled Workflow',
+      'Scheduled Spell',
     );
 
     return { success: true, data: record };
@@ -182,7 +184,7 @@ const createCommand: Command = {
 const scheduleListCommand: Command = {
   name: 'list',
   aliases: ['ls'],
-  description: 'List all scheduled workflows',
+  description: 'List all scheduled spells',
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     try {
       const result = await callMCPTool<{ results: Array<{ key: string; value: string }> }>('memory_list', {
@@ -204,19 +206,19 @@ const scheduleListCommand: Command = {
 
       if (schedules.length === 0) {
         output.writeln();
-        output.printInfo('No scheduled workflows');
+        output.printInfo('No scheduled spells');
         return { success: true, data: [] };
       }
 
       output.writeln();
-      output.writeln(output.bold('Scheduled Workflows'));
+      output.writeln(output.bold('Scheduled Spells'));
       output.writeln();
       output.printTable({
         columns: [
           { key: 'id', header: 'ID', width: 30 },
-          { key: 'workflowName', header: 'Workflow', width: 20 },
+          { key: 'workflowName', header: 'Spell', width: 20 },
           { key: 'timing', header: 'Schedule', width: 20 },
-          { key: 'nextRun', header: 'Next Run', width: 22 },
+          { key: 'nextRun', header: 'Next Cast', width: 22 },
           { key: 'enabled', header: 'Enabled', width: 8, format: (v: unknown) => v ? output.success('yes') : output.error('no') },
         ],
         data: schedules.map((s: Record<string, unknown>) => ({
@@ -242,7 +244,7 @@ const scheduleListCommand: Command = {
 
 const cancelCommand: Command = {
   name: 'cancel',
-  description: 'Cancel (disable) a scheduled workflow',
+  description: 'Cancel (disable) a scheduled spell',
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const scheduleId = ctx.args[0];
 
@@ -287,23 +289,23 @@ const cancelCommand: Command = {
 
 export const scheduleCommand: Command = {
   name: 'schedule',
-  description: 'Manage scheduled workflows',
+  description: 'Manage scheduled spells',
   subcommands: [createCommand, scheduleListCommand, cancelCommand],
   examples: [
-    { command: 'moflo workflow schedule create -n audit --cron "0 9 * * *"', description: 'Schedule daily audit' },
-    { command: 'moflo workflow schedule list', description: 'List all schedules' },
-    { command: 'moflo workflow schedule cancel <id>', description: 'Cancel a schedule' },
+    { command: 'moflo spell schedule create -n audit --cron "0 9 * * *"', description: 'Schedule daily audit' },
+    { command: 'moflo spell schedule list', description: 'List all schedules' },
+    { command: 'moflo spell schedule cancel <id>', description: 'Cancel a schedule' },
   ],
   action: async (): Promise<CommandResult> => {
     output.writeln();
     output.writeln(output.bold('Schedule Commands'));
     output.writeln();
-    output.writeln('Usage: moflo workflow schedule <subcommand> [options]');
+    output.writeln('Usage: moflo spell schedule <subcommand> [options]');
     output.writeln();
     output.writeln('Subcommands:');
     output.printList([
-      `${output.highlight('create')}  - Create a scheduled workflow`,
-      `${output.highlight('list')}    - List all scheduled workflows`,
+      `${output.highlight('create')}  - Create a scheduled spell`,
+      `${output.highlight('list')}    - List all scheduled spells`,
       `${output.highlight('cancel')}  - Cancel (disable) a schedule`,
     ]);
 

--- a/src/modules/cli/src/commands/spell.ts
+++ b/src/modules/cli/src/commands/spell.ts
@@ -1,7 +1,8 @@
 /**
- * V3 CLI Workflow Command
- * Workflow execution, validation, and template management
+ * V3 CLI Spell Command
+ * Spell casting, validation, and grimoire management
  *
+ * Story #370: Renamed from workflow.ts to spell.ts with wizard terminology.
  * Story #225: Replaced hardcoded WORKFLOW_TEMPLATES with engine registry.
  * The MCP workflow tools now call the real engine, so the CLI just
  * passes parameters through via callMCPTool().
@@ -20,7 +21,7 @@ import type {
   WorkflowTemplateInfoResponse,
   WorkflowErrorResponse,
 } from '../mcp-tools/workflow-response.types.js';
-import { scheduleCommand } from './workflow-schedule.js';
+import { scheduleCommand } from './spell-schedule.js';
 
 // Shared table column definitions
 const REGISTRY_COLUMNS = [
@@ -38,7 +39,7 @@ const STEP_COLUMNS = [
   { key: 'error', header: 'Error', width: 30, format: (v: unknown) => v ? String(v) : '' },
 ];
 
-function printWorkflowErrors(errors: WorkflowErrorResponse[]): void {
+function printSpellErrors(errors: WorkflowErrorResponse[]): void {
   if (errors.length === 0) return;
   output.writeln();
   output.writeln(output.bold(output.error('Errors')));
@@ -47,35 +48,36 @@ function printWorkflowErrors(errors: WorkflowErrorResponse[]): void {
   }
 }
 
-// Run subcommand
-const runCommand: Command = {
-  name: 'run',
-  description: 'Execute a workflow',
+// Cast subcommand (formerly "run")
+const castCommand: Command = {
+  name: 'cast',
+  aliases: ['run'],
+  description: 'Cast a spell',
   options: [
     {
       name: 'name',
       short: 'n',
-      description: 'Workflow name or abbreviation (resolved via registry)',
+      description: 'Spell name or abbreviation (resolved via grimoire)',
       type: 'string',
     },
     {
       name: 'file',
       short: 'f',
-      description: 'Workflow definition file (YAML/JSON)',
+      description: 'Spell definition file (YAML/JSON)',
       type: 'string',
     },
     {
       name: 'dry-run',
       short: 'd',
-      description: 'Validate without executing',
+      description: 'Validate without casting',
       type: 'boolean',
       default: false,
     },
   ],
   examples: [
-    { command: 'moflo workflow run -n development', description: 'Run workflow by name' },
-    { command: 'moflo workflow run -f ./workflow.yaml', description: 'Run from file' },
-    { command: 'moflo workflow run -n sa --dry-run', description: 'Validate via abbreviation' },
+    { command: 'moflo spell cast -n development', description: 'Cast spell by name' },
+    { command: 'moflo spell cast -f ./spell.yaml', description: 'Cast from file' },
+    { command: 'moflo spell cast -n sa --dry-run', description: 'Validate via abbreviation' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const name = (ctx.flags.name as string) || ctx.args[0];
@@ -84,39 +86,39 @@ const runCommand: Command = {
     const args = (ctx.flags.args as unknown as Record<string, unknown>) ?? {};
 
     if (!name && !file) {
-      // Interactive: list available workflows and let user pick
+      // Interactive: list available spells and let user pick
       if (ctx.interactive) {
         try {
           const listResult = await callMCPTool<WorkflowListResponse>('workflow_list', { source: 'registry' });
 
           const defs = listResult.definitions ?? [];
           if (defs.length === 0) {
-            output.printInfo('No workflow definitions found in the registry.');
+            output.printInfo('No spell definitions found in the grimoire.');
             output.printInfo('Add YAML/JSON files to workflows/ or .claude/workflows/ in your project.');
             return { success: false, exitCode: 1 };
           }
 
           output.writeln();
-          output.writeln(output.bold('Available Workflows'));
+          output.writeln(output.bold('Available Spells'));
           output.writeln();
           output.printTable({ columns: REGISTRY_COLUMNS, data: defs });
 
           output.writeln();
-          const chosen = await input({ message: 'Enter workflow name or abbreviation:' });
+          const chosen = await input({ message: 'Enter spell name or abbreviation:' });
           if (!chosen) {
             return { success: false, exitCode: 1 };
           }
 
           // Re-run with chosen name
-          const result = await runCommand.action!({ ...ctx, flags: { ...ctx.flags, name: chosen } });
+          const result = await castCommand.action!({ ...ctx, flags: { ...ctx.flags, name: chosen } });
           return result ?? { success: false, exitCode: 1 };
         } catch {
-          output.printError('Workflow name or file is required. Use --name or --file');
+          output.printError('Spell name or file is required. Use --name or --file');
           return { success: false, exitCode: 1 };
         }
       }
 
-      output.printError('Workflow name or file is required. Use --name or --file');
+      output.printError('Spell name or file is required. Use --name or --file');
       return { success: false, exitCode: 1 };
     }
 
@@ -124,10 +126,10 @@ const runCommand: Command = {
     if (dryRun) {
       output.writeln(output.warning('DRY RUN MODE - No changes will be made'));
     }
-    output.writeln(output.bold(`Workflow: ${name || file}`));
+    output.writeln(output.bold(`Spell: ${name || file}`));
     output.writeln();
 
-    const spinner = output.createSpinner({ text: 'Running workflow...', spinner: 'dots' });
+    const spinner = output.createSpinner({ text: 'Casting spell...', spinner: 'dots' });
 
     try {
       spinner.start();
@@ -140,14 +142,14 @@ const runCommand: Command = {
       });
 
       if (result.error) {
-        spinner.fail(`Workflow failed: ${result.error}`);
+        spinner.fail(`Spell failed: ${result.error}`);
         return { success: false, exitCode: 1 };
       }
 
       if (dryRun) {
-        spinner.succeed('Workflow validated successfully');
+        spinner.succeed('Spell validated successfully');
       } else {
-        spinner.succeed(result.success ? 'Workflow completed' : 'Workflow finished with errors');
+        spinner.succeed(result.success ? 'Spell completed' : 'Spell finished with errors');
       }
 
       if (ctx.flags.format === 'json') {
@@ -163,7 +165,7 @@ const runCommand: Command = {
           `Steps: ${result.stepCount}`,
           `Duration: ${(result.duration / 1000).toFixed(1)}s`,
         ].join('\n'),
-        'Workflow Result',
+        'Spell Result',
       );
 
       if (result.steps.length > 0) {
@@ -172,13 +174,13 @@ const runCommand: Command = {
         output.printTable({ columns: STEP_COLUMNS, data: result.steps });
       }
 
-      printWorkflowErrors(result.errors);
+      printSpellErrors(result.errors);
 
       return { success: result.success, data: result };
     } catch (error) {
-      spinner.fail('Workflow failed');
+      spinner.fail('Spell failed');
       if (error instanceof MCPClientError) {
-        output.printError(`Workflow error: ${error.message}`);
+        output.printError(`Spell error: ${error.message}`);
       } else {
         output.printError(`Unexpected error: ${String(error)}`);
       }
@@ -190,24 +192,24 @@ const runCommand: Command = {
 // Validate subcommand
 const validateCommand: Command = {
   name: 'validate',
-  description: 'Validate a workflow definition',
+  description: 'Validate a spell definition',
   options: [
     {
       name: 'file',
       short: 'f',
-      description: 'Workflow definition file',
+      description: 'Spell definition file',
       type: 'string',
       required: true,
     },
   ],
   examples: [
-    { command: 'moflo workflow validate -f ./workflow.yaml', description: 'Validate workflow file' },
+    { command: 'moflo spell validate -f ./spell.yaml', description: 'Validate spell file' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const file = (ctx.flags.file as string) || ctx.args[0];
 
     if (!file) {
-      output.printError('Workflow file is required. Use --file or -f');
+      output.printError('Spell file is required. Use --file or -f');
       return { success: false, exitCode: 1 };
     }
 
@@ -225,10 +227,10 @@ const validateCommand: Command = {
       }
 
       if (result.success) {
-        output.printSuccess(`Workflow is valid (${result.steps.length} steps)`);
+        output.printSuccess(`Spell is valid (${result.steps.length} steps)`);
       } else {
-        output.printError('Workflow validation failed');
-        printWorkflowErrors(result.errors);
+        output.printError('Spell validation failed');
+        printSpellErrors(result.errors);
       }
 
       return { success: result.success, data: result };
@@ -247,14 +249,14 @@ const validateCommand: Command = {
 const listCommand: Command = {
   name: 'list',
   aliases: ['ls'],
-  description: 'List workflows (registry definitions and recent runs)',
+  description: 'List spells (grimoire definitions and recent casts)',
   options: [
     {
       name: 'source',
       short: 's',
-      description: 'What to list: registry, runs, or all',
+      description: 'What to list: grimoire, runs, or all',
       type: 'string',
-      choices: ['registry', 'runs', 'all'],
+      choices: ['grimoire', 'runs', 'all'],
     },
     {
       name: 'limit',
@@ -272,7 +274,9 @@ const listCommand: Command = {
     },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const source = (ctx.flags.source as string) ?? 'all';
+    const rawSource = (ctx.flags.source as string) ?? 'all';
+    // Map wizard terminology to engine API values
+    const source = rawSource === 'grimoire' ? 'registry' : rawSource;
     const limit = ctx.flags.limit as number;
     const refresh = ctx.flags.refresh as boolean;
 
@@ -286,45 +290,45 @@ const listCommand: Command = {
 
       if (result.definitions && result.definitions.length > 0) {
         output.writeln();
-        output.writeln(output.bold('Registry Definitions'));
+        output.writeln(output.bold('Grimoire'));
         output.writeln();
         output.printTable({ columns: REGISTRY_COLUMNS, data: result.definitions });
       } else if (source === 'registry' || source === 'all') {
         output.writeln();
         if (result.registryError) {
-          output.printError(`Registry: ${result.registryError}`);
+          output.printError(`Grimoire: ${result.registryError}`);
         } else {
-          output.printInfo('No workflow definitions found. Add YAML/JSON files to workflows/ or .claude/workflows/');
+          output.printInfo('No spell definitions found. Add YAML/JSON files to workflows/ or .claude/workflows/');
         }
       }
 
       if (result.runs && result.runs.length > 0) {
         output.writeln();
-        output.writeln(output.bold('Recent Runs'));
+        output.writeln(output.bold('Recent Casts'));
         output.writeln();
         output.printTable({
           columns: [
             { key: 'workflowId', header: 'ID', width: 20 },
             { key: 'name', header: 'Name', width: 20 },
             { key: 'status', header: 'Status', width: 12, format: formatStageStatus },
-            { key: 'startedAt', header: 'Started', width: 22, format: (v) => v ? new Date(String(v)).toLocaleString() : '-' },
+            { key: 'startedAt', header: 'Cast At', width: 22, format: (v) => v ? new Date(String(v)).toLocaleString() : '-' },
           ],
           data: result.runs,
         });
       } else if (source === 'runs' || source === 'all') {
         output.writeln();
-        output.printInfo('No recent workflow runs');
+        output.printInfo('No recent spell casts');
       }
 
       if (result.activeWorkflows && result.activeWorkflows.length > 0) {
         output.writeln();
-        output.printInfo(`Currently running: ${result.activeWorkflows.join(', ')}`);
+        output.printInfo(`Currently casting: ${result.activeWorkflows.join(', ')}`);
       }
 
       return { success: true, data: result };
     } catch (error) {
       if (error instanceof MCPClientError) {
-        output.printError(`Failed to list workflows: ${error.message}`);
+        output.printError(`Failed to list spells: ${error.message}`);
       } else {
         output.printError(`Unexpected error: ${String(error)}`);
       }
@@ -336,12 +340,12 @@ const listCommand: Command = {
 // Status subcommand
 const statusCommand: Command = {
   name: 'status',
-  description: 'Show workflow status',
+  description: 'Show spell status',
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const workflowId = ctx.args[0];
 
     if (!workflowId) {
-      output.printError('Workflow ID is required');
+      output.printError('Spell ID is required');
       return { success: false, exitCode: 1 };
     }
 
@@ -370,7 +374,7 @@ const statusCommand: Command = {
           result.progress != null ? `Progress: ${result.progress.toFixed(0)}%` : null,
           result.duration != null ? `Duration: ${(result.duration / 1000).toFixed(1)}s` : null,
         ].filter(Boolean).join('\n'),
-        'Workflow Status',
+        'Spell Status',
       );
 
       if (result.steps && result.steps.length > 0) {
@@ -391,10 +395,11 @@ const statusCommand: Command = {
   },
 };
 
-// Stop subcommand
+// Stop subcommand (dispel)
 const stopCommand: Command = {
   name: 'stop',
-  description: 'Stop a running workflow',
+  aliases: ['dispel'],
+  description: 'Stop a running spell',
   options: [
     {
       name: 'force',
@@ -409,13 +414,13 @@ const stopCommand: Command = {
     const force = ctx.flags.force as boolean;
 
     if (!workflowId) {
-      output.printError('Workflow ID is required');
+      output.printError('Spell ID is required');
       return { success: false, exitCode: 1 };
     }
 
     if (!force && ctx.interactive) {
       const confirmed = await confirm({
-        message: `Cancel workflow ${workflowId}?`,
+        message: `Dispel ${workflowId}?`,
         default: false,
       });
       if (!confirmed) {
@@ -427,7 +432,7 @@ const stopCommand: Command = {
     try {
       const result = await callMCPTool<WorkflowCancelResponse>('workflow_cancel', {
         workflowId,
-        reason: 'Stopped via CLI',
+        reason: 'Dispelled via CLI',
       });
 
       if (result.error) {
@@ -435,11 +440,11 @@ const stopCommand: Command = {
         return { success: false, exitCode: 1 };
       }
 
-      output.printSuccess(`Workflow ${workflowId} cancelled`);
+      output.printSuccess(`Spell ${workflowId} dispelled`);
       return { success: true, data: result };
     } catch (error) {
       if (error instanceof MCPClientError) {
-        output.printError(`Failed to stop workflow: ${error.message}`);
+        output.printError(`Failed to dispel: ${error.message}`);
       } else {
         output.printError(`Unexpected error: ${String(error)}`);
       }
@@ -448,14 +453,15 @@ const stopCommand: Command = {
   },
 };
 
-// Template subcommand
+// Template subcommand (grimoire)
 const templateCommand: Command = {
   name: 'template',
-  description: 'Browse workflow templates from the registry',
+  aliases: ['grimoire'],
+  description: 'Browse spell templates from the grimoire',
   subcommands: [
     {
       name: 'list',
-      description: 'List available workflow templates',
+      description: 'List available spell templates',
       action: async (ctx: CommandContext): Promise<CommandResult> => {
         try {
           const result = await callMCPTool<WorkflowTemplateListResponse>('workflow_template', { action: 'list' });
@@ -471,11 +477,11 @@ const templateCommand: Command = {
           }
 
           output.writeln();
-          output.writeln(output.bold('Available Workflow Templates'));
+          output.writeln(output.bold('Grimoire — Spell Templates'));
           output.writeln();
 
           if (result.templates.length === 0) {
-            output.printInfo('No workflow definitions found.');
+            output.printInfo('No spell definitions found.');
             output.printInfo('Add YAML/JSON files to workflows/ or .claude/workflows/ in your project.');
             return { success: true, data: result };
           }
@@ -532,7 +538,7 @@ const templateCommand: Command = {
               `Steps: ${result.stepCount}`,
               `Step Types: ${result.stepTypes?.join(', ') ?? 'none'}`,
             ].filter(Boolean).join('\n'),
-            'Template Details',
+            'Spell Details',
           );
 
           if (result.arguments && Object.keys(result.arguments).length > 0) {
@@ -566,13 +572,13 @@ const templateCommand: Command = {
   ],
   action: async (): Promise<CommandResult> => {
     output.writeln();
-    output.writeln(output.bold('Template Management'));
+    output.writeln(output.bold('Grimoire'));
     output.writeln();
-    output.writeln('Usage: moflo workflow template <subcommand>');
+    output.writeln('Usage: moflo spell template <subcommand>');
     output.writeln();
     output.writeln('Subcommands:');
     output.printList([
-      `${output.highlight('list')}  - List available workflow templates`,
+      `${output.highlight('list')}  - List available spell templates`,
       `${output.highlight('show')}  - Show template details`,
     ]);
 
@@ -580,37 +586,38 @@ const templateCommand: Command = {
   },
 };
 
-// Main workflow command
-export const workflowCommand: Command = {
-  name: 'workflow',
-  description: 'Workflow execution and management',
-  subcommands: [runCommand, validateCommand, listCommand, statusCommand, stopCommand, templateCommand, scheduleCommand],
+// Main spell command
+export const spellCommand: Command = {
+  name: 'spell',
+  aliases: ['workflow'],
+  description: 'Spell casting and management',
+  subcommands: [castCommand, validateCommand, listCommand, statusCommand, stopCommand, templateCommand, scheduleCommand],
   options: [],
   examples: [
-    { command: 'moflo workflow run -n development', description: 'Run workflow by name' },
-    { command: 'moflo workflow run -f ./workflow.yaml', description: 'Run from file' },
-    { command: 'moflo workflow list', description: 'List workflows' },
-    { command: 'moflo workflow template list', description: 'List registry templates' },
-    { command: 'moflo workflow template show sa', description: 'Show workflow details' },
+    { command: 'moflo spell cast -n development', description: 'Cast spell by name' },
+    { command: 'moflo spell cast -f ./spell.yaml', description: 'Cast from file' },
+    { command: 'moflo spell list', description: 'List spells' },
+    { command: 'moflo spell template list', description: 'List grimoire templates' },
+    { command: 'moflo spell template show sa', description: 'Show spell details' },
   ],
   action: async (): Promise<CommandResult> => {
     output.writeln();
-    output.writeln(output.bold('Workflow Commands'));
+    output.writeln(output.bold('Spell Commands'));
     output.writeln();
-    output.writeln('Usage: moflo workflow <subcommand> [options]');
+    output.writeln('Usage: moflo spell <subcommand> [options]');
     output.writeln();
     output.writeln('Subcommands:');
     output.printList([
-      `${output.highlight('run')}       - Execute a workflow`,
-      `${output.highlight('validate')}  - Validate workflow definition`,
-      `${output.highlight('list')}      - List workflows (registry + runs)`,
-      `${output.highlight('status')}    - Show workflow status`,
-      `${output.highlight('stop')}      - Cancel running workflow`,
-      `${output.highlight('template')}  - Browse registry templates`,
-      `${output.highlight('schedule')}  - Manage scheduled workflows`,
+      `${output.highlight('cast')}      - Cast a spell`,
+      `${output.highlight('validate')}  - Validate spell definition`,
+      `${output.highlight('list')}      - List spells (grimoire + casts)`,
+      `${output.highlight('status')}    - Show spell status`,
+      `${output.highlight('stop')}      - Dispel a running spell`,
+      `${output.highlight('template')}  - Browse grimoire templates`,
+      `${output.highlight('schedule')}  - Manage scheduled spells`,
     ]);
     output.writeln();
-    output.writeln('Run "moflo workflow <subcommand> --help" for more info');
+    output.writeln('Run "moflo spell <subcommand> --help" for more info');
 
     return { success: true };
   },
@@ -642,4 +649,4 @@ function formatStageStatus(status: unknown): string {
   }
 }
 
-export default workflowCommand;
+export default spellCommand;


### PR DESCRIPTION
## Summary

- Renames CLI `flo workflow` command to `flo spell` with wizard-themed subcommands (`cast`, `grimoire`, `dispel`)
- Adds backwards-compat aliases so `flo workflow`, `flo spell run`, `flo spell template` still work
- Updates shell completions, command index, and hive-mind help text references

## Changes

| File | Change |
|------|--------|
| `spell.ts` (new) | Replaces `workflow.ts` — command name `spell`, subcommand `run`→`cast`, UI text uses wizard terminology |
| `spell-schedule.ts` (new) | Replaces `workflow-schedule.ts` — updated help text and examples |
| `index.ts` | Updated imports, loader key, category entry, lazy getter |
| `completions.ts` | `'workflow'`→`'spell'` in commands array and zsh descriptions |
| `hive-mind.ts` | Updated description text for workflow_create tool |
| `spell-command.test.ts` (new) | 14 tests verifying rename, aliases, subcommands, completions |

## Backwards Compatibility

| Old | New | Alias |
|-----|-----|-------|
| `flo workflow` | `flo spell` | `workflow` alias on `spell` |
| `flo workflow run` | `flo spell cast` | `run` alias on `cast` |
| `flo workflow template` | `flo spell template` | `grimoire` alias on `template` |
| `flo workflow stop` | `flo spell stop` | `dispel` alias on `stop` |

## Testing

- [x] Build succeeds (`npm run build` in cli package)
- [x] 25 existing workflow-tools-engine tests pass
- [x] 14 new spell-command tests pass (39 total)
- [x] /simplify review — no new issues (all findings pre-existing)

Closes #370

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)