### PR TITLE
refactor(spells): rename schedule namespace and fields to spell terminology

### DIFF
--- a/src/modules/cli/src/commands/spell-schedule.ts
+++ b/src/modules/cli/src/commands/spell-schedule.ts
@@ -6,7 +6,7 @@
  *
  * Story #370: Renamed from workflow-schedule.ts with wizard terminology.
  *
- * Schedule records are persisted to the 'scheduled-workflows' memory namespace —
+ * Schedule records are persisted to the 'scheduled-spells' memory namespace —
  * the same namespace the daemon's SpellScheduler polls. The daemon picks up
  * new schedules on its next poll cycle (or via catch-up window after restart).
  */
@@ -18,7 +18,7 @@ import { TOOL_MEMORY_STORE, TOOL_MEMORY_LIST, TOOL_MEMORY_RETRIEVE } from '../mc
 import { handleMCPError } from '../services/cli-formatters.js';
 import { ensureDaemonForScheduling } from '../services/daemon-readiness.js';
 
-const NAMESPACE_SCHEDULES = 'scheduled-workflows';
+const NAMESPACE_SCHEDULES = 'scheduled-spells';
 
 async function getSchedulerUtils() {
   try {
@@ -129,8 +129,8 @@ const createCommand: Command = {
     const id = `sched-adhoc-${now}-${Math.random().toString(36).slice(2, 8)}`;
     const record = {
       id,
-      workflowName: name,
-      workflowPath: '',  // resolved by scheduler at poll time
+      spellName: name,
+      spellPath: '',  // resolved by scheduler at poll time
       cron,
       interval,
       at,
@@ -212,14 +212,14 @@ const scheduleListCommand: Command = {
       output.printTable({
         columns: [
           { key: 'id', header: 'ID', width: 30 },
-          { key: 'workflowName', header: 'Spell', width: 20 },
+          { key: 'spellName', header: 'Spell', width: 20 },
           { key: 'timing', header: 'Schedule', width: 20 },
           { key: 'nextRun', header: 'Next Cast', width: 22 },
           { key: 'enabled', header: 'Enabled', width: 8, format: (v: unknown) => v ? output.success('yes') : output.error('no') },
         ],
         data: schedules.map((s: Record<string, unknown>) => ({
           id: s.id,
-          workflowName: s.workflowName,
+          spellName: s.spellName,
           timing: s.cron || s.interval || s.at || '-',
           nextRun: s.nextRunAt ? new Date(s.nextRunAt as number).toLocaleString() : '-',
           enabled: s.enabled,

--- a/src/modules/cli/src/services/daemon-dashboard.ts
+++ b/src/modules/cli/src/services/daemon-dashboard.ts
@@ -136,7 +136,7 @@ async function handleSchedules(memory?: MemoryAccessor): Promise<object> {
     return { schedules: [], available: false };
   }
   try {
-    const results = await memory.search('scheduled-workflows', '*');
+    const results = await memory.search('scheduled-spells', '*');
     const schedules = results.map(r => {
       const data = typeof r.value === 'string' ? tryParse(r.value) : (r.value as Record<string, unknown> ?? {});
       return { id: r.key, ...(data as Record<string, unknown>) };
@@ -594,15 +594,15 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       if (!sc || !sc.available) { el.innerHTML = '<div class="empty">Scheduler not connected</div>'; return; }
       if (sc.schedules.length === 0) { el.innerHTML = '<div class="empty">No active schedules</div>'; return; }
       const rows = sc.schedules.map(s =>
-        '<tr><td>' + esc(s.workflowName) + '</td>' +
+        '<tr><td>' + esc(s.spellName) + '</td>' +
         '<td>' + esc(s.cron || s.interval || s.at || '-') + '</td>' +
         '<td>' + (s.enabled ? badge('on','green') : badge('off','gray')) + '</td>' +
         '<td>' + (s.lastRunAt ? fmtTime(s.lastRunAt) : '-') + '</td>' +
         '<td>' + fmtTime(s.nextRunAt) + '</td>' +
         '<td>' + badge(s.source,'gray') + '</td></tr>'
       ).join('');
-      el.innerHTML = '<h2>Scheduled Workflows</h2>' +
-        '<table><thead><tr><th>Workflow</th><th>Schedule</th><th>Enabled</th><th>Last Run</th><th>Next Run</th><th>Source</th></tr></thead>' +
+      el.innerHTML = '<h2>Scheduled Spells</h2>' +
+        '<table><thead><tr><th>Spell</th><th>Schedule</th><th>Enabled</th><th>Last Run</th><th>Next Run</th><th>Source</th></tr></thead>' +
         '<tbody>' + rows + '</tbody></table>';
     }
 

--- a/src/modules/spells/__tests__/scheduler.test.ts
+++ b/src/modules/spells/__tests__/scheduler.test.ts
@@ -362,7 +362,7 @@ describe('SpellScheduler', () => {
 
   function makeSuccessResult(): WorkflowResult {
     return {
-      workflowId: 'wf-1',
+      spellId: 'wf-1',
       success: true,
       steps: [],
       outputs: {},
@@ -374,7 +374,7 @@ describe('SpellScheduler', () => {
 
   function makeFailResult(): WorkflowResult {
     return {
-      workflowId: 'wf-1',
+      spellId: 'wf-1',
       success: false,
       steps: [],
       outputs: {},
@@ -437,13 +437,13 @@ describe('SpellScheduler', () => {
 
   it('creates an ad-hoc schedule', async () => {
     const schedule = await scheduler.createSchedule({
-      workflowName: 'test-wf',
-      workflowPath: '/workflows/test.yaml',
+      spellName: 'test-wf',
+      spellPath: '/workflows/test.yaml',
       interval: '1h',
     });
 
     expect(schedule.id).toMatch(/^sched-adhoc-/);
-    expect(schedule.workflowName).toBe('test-wf');
+    expect(schedule.spellName).toBe('test-wf');
     expect(schedule.enabled).toBe(true);
     expect(schedule.source).toBe('adhoc');
   });
@@ -474,8 +474,8 @@ describe('SpellScheduler', () => {
 
   it('cancels a schedule', async () => {
     await scheduler.createSchedule({
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
     });
 
@@ -495,8 +495,8 @@ describe('SpellScheduler', () => {
   });
 
   it('lists all schedules', async () => {
-    await scheduler.createSchedule({ workflowName: 'wf1', workflowPath: '/p1', interval: '1h' });
-    await scheduler.createSchedule({ workflowName: 'wf2', workflowPath: '/p2', cron: '0 * * * *' });
+    await scheduler.createSchedule({ spellName: 'wf1', spellPath: '/p1', interval: '1h' });
+    await scheduler.createSchedule({ spellName: 'wf2', spellPath: '/p2', cron: '0 * * * *' });
 
     const schedules = await scheduler.listSchedules();
     expect(schedules).toHaveLength(2);
@@ -507,10 +507,10 @@ describe('SpellScheduler', () => {
   it('executes a due workflow on poll', async () => {
     // Create a schedule that is already due
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-test', {
+    await memory.write('scheduled-spells', 'sched-test', {
       id: 'sched-test',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 1000, // already due
       enabled: true,
@@ -525,10 +525,10 @@ describe('SpellScheduler', () => {
 
   it('skips disabled schedules', async () => {
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-disabled', {
+    await memory.write('scheduled-spells', 'sched-disabled', {
       id: 'sched-disabled',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 1000,
       enabled: false,
@@ -543,10 +543,10 @@ describe('SpellScheduler', () => {
 
   it('skips schedules not yet due', async () => {
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-future', {
+    await memory.write('scheduled-spells', 'sched-future', {
       id: 'sched-future',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now + 60_000, // 1 minute in the future
       enabled: true,
@@ -563,10 +563,10 @@ describe('SpellScheduler', () => {
     (executor.exists as ReturnType<typeof vi.fn>).mockReturnValue(false);
 
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-deleted', {
+    await memory.write('scheduled-spells', 'sched-deleted', {
       id: 'sched-deleted',
-      workflowName: 'deleted-wf',
-      workflowPath: '/path',
+      spellName: 'deleted-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 1000,
       enabled: true,
@@ -586,10 +586,10 @@ describe('SpellScheduler', () => {
     scheduler.on(e => events.push(e));
 
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-old', {
+    await memory.write('scheduled-spells', 'sched-old', {
       id: 'sched-old',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 7_200_000, // 2 hours ago — exceeds 1h catch-up window
       enabled: true,
@@ -613,10 +613,10 @@ describe('SpellScheduler', () => {
     );
 
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-overlap', {
+    await memory.write('scheduled-spells', 'sched-overlap', {
       id: 'sched-overlap',
-      workflowName: 'slow-wf',
-      workflowPath: '/path',
+      spellName: 'slow-wf',
+      spellPath: '/path',
       interval: '1m',
       nextRunAt: now - 1000,
       enabled: true,
@@ -649,10 +649,10 @@ describe('SpellScheduler', () => {
     const now = Date.now();
     // Create 3 due schedules, but maxConcurrent is 2
     for (let i = 0; i < 3; i++) {
-      await memory.write('scheduled-workflows', `sched-${i}`, {
+      await memory.write('scheduled-spells', `sched-${i}`, {
         id: `sched-${i}`,
-        workflowName: `wf-${i}`,
-        workflowPath: '/path',
+        spellName: `wf-${i}`,
+        spellPath: '/path',
         interval: '1h',
         nextRunAt: now - 1000,
         enabled: true,
@@ -678,10 +678,10 @@ describe('SpellScheduler', () => {
     scheduler.on(e => events.push(e));
 
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-events', {
+    await memory.write('scheduled-spells', 'sched-events', {
       id: 'sched-events',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 1000,
       enabled: true,
@@ -706,10 +706,10 @@ describe('SpellScheduler', () => {
     scheduler.on(e => events.push(e));
 
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-fail', {
+    await memory.write('scheduled-spells', 'sched-fail', {
       id: 'sched-fail',
-      workflowName: 'fail-wf',
-      workflowPath: '/path',
+      spellName: 'fail-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 1000,
       enabled: true,
@@ -732,7 +732,7 @@ describe('SpellScheduler', () => {
     scheduler['emit']({
       type: 'schedule:due',
       scheduleId: 'test',
-      workflowName: 'test',
+      spellName: 'test',
       message: 'test',
       timestamp: Date.now(),
     });
@@ -743,10 +743,10 @@ describe('SpellScheduler', () => {
 
   it('auto-disables one-time schedule after execution', async () => {
     const future = Date.now() - 1000; // already due
-    await memory.write('scheduled-workflows', 'sched-once', {
+    await memory.write('scheduled-spells', 'sched-once', {
       id: 'sched-once',
-      workflowName: 'once-wf',
-      workflowPath: '/path',
+      spellName: 'once-wf',
+      spellPath: '/path',
       at: new Date(future).toISOString(),
       nextRunAt: future,
       enabled: true,
@@ -765,10 +765,10 @@ describe('SpellScheduler', () => {
 
   it('stores execution history', async () => {
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-hist', {
+    await memory.write('scheduled-spells', 'sched-hist', {
       id: 'sched-hist',
-      workflowName: 'hist-wf',
-      workflowPath: '/path',
+      spellName: 'hist-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 1000,
       enabled: true,
@@ -795,10 +795,10 @@ describe('SpellScheduler', () => {
     });
 
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-capped', {
+    await memory.write('scheduled-spells', 'sched-capped', {
       id: 'sched-capped',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 1000,
       enabled: true,
@@ -824,10 +824,10 @@ describe('SpellScheduler', () => {
     });
 
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-narrow', {
+    await memory.write('scheduled-spells', 'sched-narrow', {
       id: 'sched-narrow',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       mofloLevel: 'memory',
       nextRunAt: now - 1000,
@@ -854,10 +854,10 @@ describe('SpellScheduler', () => {
     });
 
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-widen', {
+    await memory.write('scheduled-spells', 'sched-widen', {
       id: 'sched-widen',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       mofloLevel: 'full',
       nextRunAt: now - 1000,
@@ -878,10 +878,10 @@ describe('SpellScheduler', () => {
 
   it('passes undefined mofloLevel when no caps are set (default behavior)', async () => {
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-nocp', {
+    await memory.write('scheduled-spells', 'sched-nocp', {
       id: 'sched-nocp',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       nextRunAt: now - 1000,
       enabled: true,
@@ -899,10 +899,10 @@ describe('SpellScheduler', () => {
 
   it('uses only per-schedule cap when no scheduler-level cap exists', async () => {
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-only', {
+    await memory.write('scheduled-spells', 'sched-only', {
       id: 'sched-only',
-      workflowName: 'test-wf',
-      workflowPath: '/path',
+      spellName: 'test-wf',
+      spellPath: '/path',
       interval: '1h',
       mofloLevel: 'hooks',
       nextRunAt: now - 1000,
@@ -923,10 +923,10 @@ describe('SpellScheduler', () => {
 
   it('passes args to workflow executor', async () => {
     const now = Date.now();
-    await memory.write('scheduled-workflows', 'sched-args', {
+    await memory.write('scheduled-spells', 'sched-args', {
       id: 'sched-args',
-      workflowName: 'args-wf',
-      workflowPath: '/path',
+      spellName: 'args-wf',
+      spellPath: '/path',
       interval: '1h',
       args: { target: './src' },
       nextRunAt: now - 1000,

--- a/src/modules/spells/src/scheduler/schedule.types.ts
+++ b/src/modules/spells/src/scheduler/schedule.types.ts
@@ -1,17 +1,17 @@
 /**
- * Workflow Schedule Types
+ * Spell Schedule Types
  *
- * Types for scheduled workflow execution — cron, interval, and one-time scheduling.
+ * Types for scheduled spell execution — cron, interval, and one-time scheduling.
  */
 
 import type { MofloLevel } from '../types/step-command.types.js';
 
 // ============================================================================
-// Schedule Definition (in workflow YAML/JSON)
+// Schedule Definition (in spell YAML/JSON)
 // ============================================================================
 
 /**
- * Schedule block for a workflow definition.
+ * Schedule block for a spell definition.
  * Exactly one of `cron`, `interval`, or `at` must be specified.
  */
 export interface ScheduleDefinition {
@@ -33,8 +33,8 @@ export interface ScheduleDefinition {
 
 export interface WorkflowSchedule {
   readonly id: string;
-  readonly workflowName: string;
-  readonly workflowPath: string;
+  readonly spellName: string;
+  readonly spellPath: string;
   readonly cron?: string;
   readonly interval?: string;
   readonly at?: string;
@@ -56,12 +56,12 @@ export interface WorkflowSchedule {
 export interface ScheduleExecution {
   readonly id: string;
   readonly scheduleId: string;
-  readonly workflowName: string;
+  readonly spellName: string;
   readonly startedAt: number;
   readonly completedAt?: number;
   readonly success?: boolean;
   readonly error?: string;
-  readonly workflowId: string;
+  readonly spellId: string;
   readonly duration?: number;
 }
 
@@ -72,11 +72,11 @@ export interface ScheduleExecution {
 export interface SchedulerOptions {
   /** Poll interval in milliseconds (default: 60000 — 1 minute). */
   readonly pollIntervalMs?: number;
-  /** Maximum concurrent scheduled workflow executions (default: 2). */
+  /** Maximum concurrent scheduled spell executions (default: 2). */
   readonly maxConcurrent?: number;
   /** Catch-up window: max age in ms for missed runs to still execute (default: 3600000 — 1 hour). */
   readonly catchUpWindowMs?: number;
-  /** Global MoFlo level cap for all scheduler-initiated workflows. Per-schedule caps can only narrow, not widen. */
+  /** Global MoFlo level cap for all scheduler-initiated spells. Per-schedule caps can only narrow, not widen. */
   readonly maxMofloLevel?: MofloLevel;
 }
 

--- a/src/modules/spells/src/scheduler/scheduler.ts
+++ b/src/modules/spells/src/scheduler/scheduler.ts
@@ -1,7 +1,7 @@
 /**
- * Workflow Scheduler
+ * Spell Scheduler
  *
- * Manages scheduled workflow execution: polls for due workflows, prevents
+ * Manages scheduled spell execution: polls for due spells, prevents
  * overlap, tracks execution history, and handles catch-up after restarts.
  */
 
@@ -24,7 +24,7 @@ import { compareMofloLevels } from '../core/capability-validator.js';
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const DEFAULT_MAX_CONCURRENT = 2;
 const DEFAULT_CATCH_UP_WINDOW_MS = 3_600_000; // 1 hour
-const NAMESPACE_SCHEDULES = 'scheduled-workflows';
+const NAMESPACE_SCHEDULES = 'scheduled-spells';
 const NAMESPACE_EXECUTIONS = 'schedule-executions';
 
 // ============================================================================
@@ -54,7 +54,7 @@ export type SchedulerEventType =
 export interface SchedulerEvent {
   readonly type: SchedulerEventType;
   readonly scheduleId: string;
-  readonly workflowName: string;
+  readonly spellName: string;
   readonly message: string;
   readonly timestamp: number;
 }
@@ -103,7 +103,7 @@ export class SpellScheduler {
   }
 
   /**
-   * Stop the polling loop and cancel all running workflows.
+   * Stop the polling loop and cancel all running spells.
    */
   async stop(): Promise<void> {
     if (this.pollTimer) {
@@ -148,11 +148,11 @@ export class SpellScheduler {
   // ── Schedule CRUD ────────────────────────────────────────────────────────
 
   /**
-   * Register a schedule from a workflow definition's `schedule` block.
+   * Register a schedule from a spell definition's `schedule` block.
    */
   async registerFromDefinition(
     definition: SpellDefinition,
-    workflowPath: string,
+    spellPath: string,
   ): Promise<WorkflowSchedule | null> {
     if (!definition.schedule) return null;
     const { cron, interval, at, enabled } = definition.schedule;
@@ -164,8 +164,8 @@ export class SpellScheduler {
 
     const record: WorkflowSchedule = {
       id: `sched-def-${definition.name}`,
-      workflowName: definition.name,
-      workflowPath,
+      spellName: definition.name,
+      spellPath,
       cron,
       interval,
       at,
@@ -183,8 +183,8 @@ export class SpellScheduler {
    * Create an ad-hoc schedule via CLI.
    */
   async createSchedule(params: {
-    workflowName: string;
-    workflowPath: string;
+    spellName: string;
+    spellPath: string;
     cron?: string;
     interval?: string;
     at?: string;
@@ -204,8 +204,8 @@ export class SpellScheduler {
     const id = `sched-adhoc-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const record: WorkflowSchedule = {
       id,
-      workflowName: params.workflowName,
-      workflowPath: params.workflowPath,
+      spellName: params.spellName,
+      spellPath: params.spellPath,
       cron: params.cron,
       interval: params.interval,
       at: params.at,
@@ -233,7 +233,7 @@ export class SpellScheduler {
     this.emit({
       type: 'schedule:disabled',
       scheduleId,
-      workflowName: record.workflowName,
+      spellName: record.spellName,
       message: `Schedule ${scheduleId} disabled`,
       timestamp: Date.now(),
     });
@@ -271,7 +271,7 @@ export class SpellScheduler {
   // ── Polling ──────────────────────────────────────────────────────────────
 
   /**
-   * Poll for due workflows and execute them.
+   * Poll for due spells and execute them.
    * This is the core method called by the polling loop.
    */
   async poll(): Promise<void> {
@@ -281,8 +281,8 @@ export class SpellScheduler {
     for (const schedule of schedules) {
       if (!schedule.enabled) continue;
 
-      // Auto-disable if workflow no longer exists (cancelSchedule emits the event)
-      if (!this.executor.exists(schedule.workflowName)) {
+      // Auto-disable if spell no longer exists (cancelSchedule emits the event)
+      if (!this.executor.exists(schedule.spellName)) {
         await this.cancelSchedule(schedule.id);
         continue;
       }
@@ -295,7 +295,7 @@ export class SpellScheduler {
         this.emit({
           type: 'schedule:skipped',
           scheduleId: schedule.id,
-          workflowName: schedule.workflowName,
+          spellName: schedule.spellName,
           message: `Missed run is older than catch-up window (${this.catchUpWindowMs}ms) — skipping`,
           timestamp: now,
         });
@@ -303,12 +303,12 @@ export class SpellScheduler {
         continue;
       }
 
-      // Overlap check: skip if this workflow is still running
+      // Overlap check: skip if this spell is still running
       if (this.runningWorkflows.has(schedule.id)) {
         this.emit({
           type: 'schedule:skipped',
           scheduleId: schedule.id,
-          workflowName: schedule.workflowName,
+          spellName: schedule.spellName,
           message: 'Prior run still active — skipping overlapping execution',
           timestamp: now,
         });
@@ -323,8 +323,8 @@ export class SpellScheduler {
       this.emit({
         type: 'schedule:due',
         scheduleId: schedule.id,
-        workflowName: schedule.workflowName,
-        message: `Workflow "${schedule.workflowName}" is due for execution`,
+        spellName: schedule.spellName,
+        message: `Spell "${schedule.spellName}" is due for casting`,
         timestamp: now,
       });
 
@@ -345,9 +345,9 @@ export class SpellScheduler {
     const execution: ScheduleExecution = {
       id: executionId,
       scheduleId: schedule.id,
-      workflowName: schedule.workflowName,
+      spellName: schedule.spellName,
       startedAt: now,
-      workflowId: `scheduled-${schedule.workflowName}-${now}`,
+      spellId: `scheduled-${schedule.spellName}-${now}`,
     };
 
     await this.memory.write(NAMESPACE_EXECUTIONS, executionId, execution);
@@ -355,7 +355,7 @@ export class SpellScheduler {
     this.emit({
       type: 'schedule:started',
       scheduleId: schedule.id,
-      workflowName: schedule.workflowName,
+      spellName: schedule.spellName,
       message: `Started scheduled execution ${executionId}`,
       timestamp: now,
     });
@@ -365,7 +365,7 @@ export class SpellScheduler {
       const effectiveLevel = this.resolveEffectiveMofloLevel(schedule.mofloLevel);
 
       const result = await this.executor.execute(
-        schedule.workflowName,
+        schedule.spellName,
         schedule.args ?? {},
         controller.signal,
         effectiveLevel,
@@ -384,7 +384,7 @@ export class SpellScheduler {
       this.emit({
         type: result.success ? 'schedule:completed' : 'schedule:failed',
         scheduleId: schedule.id,
-        workflowName: schedule.workflowName,
+        spellName: schedule.spellName,
         message: result.success
           ? `Completed in ${completedExecution.duration}ms`
           : `Failed: ${completedExecution.error}`,
@@ -404,7 +404,7 @@ export class SpellScheduler {
       this.emit({
         type: 'schedule:failed',
         scheduleId: schedule.id,
-        workflowName: schedule.workflowName,
+        spellName: schedule.spellName,
         message: `Error: ${failedExecution.error}`,
         timestamp: completedAt,
       });


### PR DESCRIPTION
## Summary

- Renames `scheduled-workflows` memory namespace to `scheduled-spells`
- Renames schedule record fields: `workflowName`→`spellName`, `workflowPath`→`spellPath`, `workflowId`→`spellId`
- Safe breaking change — no users have persisted schedule records yet

## Changes

| File | Change |
|------|--------|
| `spell-schedule.ts` | Namespace constant + record fields + table column |
| `scheduler.ts` | Namespace constant + all schedule handling + log messages |
| `schedule.types.ts` | Type definitions |
| `daemon-dashboard.ts` | Namespace search + HTML column |
| `scheduler.test.ts` | All 71 test assertions updated |

## Not Changed (engine-internal, separate concern)

- `runner.ts` / `runner.types.ts` — engine `workflowName` field
- `capability-disclosure.ts` — engine capability types
- `workflow-tools.ts` — MCP tool handlers
- `github.ts` — GitHub Actions `workflowPath` (unrelated)

## Testing

- [x] Build succeeds (CLI + spells packages)
- [x] 158 tests pass (87 CLI + 71 scheduler)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)