### PR TITLE
fix(cli): remove redundant error message in castCommand

### DIFF
--- a/src/modules/cli/src/commands/spell.ts
+++ b/src/modules/cli/src/commands/spell.ts
@@ -124,8 +124,7 @@ const castCommand: Command = {
           const result = await castCommand.action!({ ...ctx, flags: { ...ctx.flags, name: chosen } });
           return result ?? { success: false, exitCode: 1 };
         } catch {
-          output.printError('Spell name or file is required. Use --name or --file');
-          return { success: false, exitCode: 1 };
+          // Fall through to the shared error message below
         }
       }
 


### PR DESCRIPTION
## Summary

- The `castCommand` interactive path had a catch block that printed the same error as the fallthrough below it
- Changed the catch to fall through to the shared error message

1 insertion, 2 deletions.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)