### PR TITLE
refactor(mcp): rename workflow_* MCP tools to spell_* with wizard terminology

### DIFF
--- a/.claude/agents/github/project-board-sync.md
+++ b/.claude/agents/github/project-board-sync.md
@@ -21,8 +21,8 @@ tools:
   - mcp__moflo__github_pr_manage
   - mcp__moflo__github_issue_track
   - mcp__moflo__github_metrics
-  - mcp__moflo__workflow_create
-  - mcp__moflo__workflow_execute
+  - mcp__moflo__spell_create
+  - mcp__moflo__spell_cast
 hooks:
   pre:
     - "gh auth status || (echo 'GitHub CLI not authenticated' && exit 1)"

--- a/.claude/agents/github/workflow-automation.md
+++ b/.claude/agents/github/workflow-automation.md
@@ -15,7 +15,7 @@ tools:
   - mcp__moflo__memory_usage
   - mcp__moflo__performance_report
   - mcp__moflo__bottleneck_analyze
-  - mcp__moflo__workflow_create
+  - mcp__moflo__spell_create
   - mcp__moflo__automation_setup
   - TodoWrite
   - TodoRead

--- a/.claude/commands/sparc/orchestrator.md
+++ b/.claude/commands/sparc/orchestrator.md
@@ -97,7 +97,7 @@ mcp__moflo__swarm_init {
 }
 
 // 2. Create workflow
-mcp__moflo__workflow_create {
+mcp__moflo__spell_create {
   name: "feature-development",
   steps: ["design", "implement", "test", "deploy"]
 }

--- a/.claude/skills/sparc-methodology/SKILL.md
+++ b/.claude/skills/sparc-methodology/SKILL.md
@@ -559,7 +559,7 @@ mcp__moflo__swarm_init {
 **Best for**: Ordered workflow execution (spec → design → code → test → review)
 
 ```javascript
-mcp__moflo__workflow_create {
+mcp__moflo__spell_create {
   name: "development-pipeline",
   steps: [
     { mode: "researcher", task: "gather requirements" },

--- a/.claude/skills/swarm-advanced/SKILL.md
+++ b/.claude/skills/swarm-advanced/SKILL.md
@@ -227,7 +227,7 @@ mcp__moflo__swarm_status({
 })
 
 // Generate final report
-mcp__moflo__workflow_execute({
+mcp__moflo__spell_cast({
   "workflowId": "research-report-generation",
   "params": {
     "findings": findings,
@@ -364,7 +364,7 @@ mcp__moflo__quality_assess({
 #### Phase 4: Review and Deployment
 ```javascript
 // Code review workflow
-mcp__moflo__workflow_execute({
+mcp__moflo__spell_cast({
   "workflowId": "code-review-process",
   "params": {
     "reviewers": ["Code Reviewer"],
@@ -766,7 +766,7 @@ mcp__moflo__pattern_recognize({
 
 ```javascript
 // Create reusable workflow
-mcp__moflo__workflow_create({
+mcp__moflo__spell_create({
   "name": "full-stack-development",
   "steps": [
     { "phase": "design", "agents": ["architect"] },

--- a/.claude/skills/workflow-builder/SKILL.md
+++ b/.claude/skills/workflow-builder/SKILL.md
@@ -140,7 +140,7 @@ Ask the user where to save the workflow:
 
 Use the MCP tool to create the workflow if available:
 ```
-mcp__moflo__workflow_create — name, definition (YAML string), description
+mcp__moflo__spell_create — name, definition (YAML string), description
 ```
 
 Or write the file directly to the chosen directory.
@@ -151,7 +151,7 @@ Or write the file directly to the chosen directory.
 
 ### Step 1: Load the Workflow
 
-Ask for the workflow file path, or use `mcp__moflo__workflow_list` to browse available workflows.
+Ask for the workflow file path, or use `mcp__moflo__spell_list` to browse available workflows.
 
 Read the YAML/JSON file and parse the current definition.
 
@@ -278,10 +278,10 @@ Check against all engine validation rules:
 
 | Tool | Purpose |
 |------|---------|
-| `mcp__moflo__workflow_create` | Create a new workflow definition |
-| `mcp__moflo__workflow_list` | List available workflows |
-| `mcp__moflo__workflow_run` | Execute a workflow |
-| `mcp__moflo__workflow_status` | Check workflow execution status |
+| `mcp__moflo__spell_create` | Create a new workflow definition |
+| `mcp__moflo__spell_list` | List available workflows |
+| `mcp__moflo__spell_cast` | Execute a workflow |
+| `mcp__moflo__spell_status` | Check workflow execution status |
 
 ### MoFlo Integration Levels
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -822,12 +822,12 @@ Your AI client interacts with the workflow engine through MCP tools:
 
 | Tool | What it does |
 |------|-------------|
-| `mcp__moflo__workflow_run` | Run a workflow from YAML/JSON content |
-| `mcp__moflo__workflow_execute` | Execute a workflow definition object directly |
-| `mcp__moflo__workflow_cancel` | Cancel a running workflow by ID |
-| `mcp__moflo__workflow_status` | Check if a workflow is running |
-| `mcp__moflo__workflow_pause` | Pause a running workflow |
-| `mcp__moflo__workflow_resume` | Resume a paused workflow |
+| `mcp__moflo__spell_cast` | Cast a spell from YAML/JSON scroll content |
+| `mcp__moflo__spell_execute` | Execute a spell definition object directly |
+| `mcp__moflo__spell_cancel` | Dispel (cancel) a running spell by ID |
+| `mcp__moflo__spell_status` | Scry the status of a running spell |
+| `mcp__moflo__spell_suspend` | Suspend a running spell |
+| `mcp__moflo__spell_resume` | Resume a suspended spell |
 
 Each running workflow gets a unique ID (e.g., `wf-1711644123456`) that you can use to check status, cancel, or resume.
 

--- a/src/modules/cli/__tests__/mcp-tools-deep.test.ts
+++ b/src/modules/cli/__tests__/mcp-tools-deep.test.ts
@@ -187,7 +187,7 @@ import { systemTools } from '../src/mcp-tools/system-tools.js';
 import { taskTools } from '../src/mcp-tools/task-tools.js';
 import { terminalTools } from '../src/mcp-tools/terminal-tools.js';
 import { transferTools } from '../src/mcp-tools/transfer-tools.js';
-import { workflowTools } from '../src/mcp-tools/workflow-tools.js';
+import { spellTools } from '../src/mcp-tools/spell-tools.js';
 import { hooksTools } from '../src/mcp-tools/hooks-tools.js';
 
 import type { MCPTool } from '../src/mcp-tools/types.js';
@@ -225,7 +225,7 @@ const ALL_MODULES: ToolModule[] = [
   { name: 'task-tools', tools: taskTools },
   { name: 'terminal-tools', tools: terminalTools },
   { name: 'transfer-tools', tools: transferTools },
-  { name: 'workflow-tools', tools: workflowTools },
+  { name: 'spell-tools', tools: spellTools },
 ];
 
 const ALL_TOOLS: MCPTool[] = ALL_MODULES.flatMap(m => m.tools);
@@ -287,7 +287,7 @@ describe('MCP Tools Deep Test Suite', () => {
         'task-tools': 7,
         'terminal-tools': 5,
         'transfer-tools': 11,
-        'workflow-tools': 10,
+        'spell-tools': 10,
       };
 
       for (const mod of ALL_MODULES) {
@@ -668,19 +668,19 @@ describe('MCP Tools Deep Test Suite', () => {
   });
 
   // --------------------------------------------------------------------------
-  // 12. Handler Invocation - Workflow Tools
+  // 12. Handler Invocation - Spell Tools
   // --------------------------------------------------------------------------
-  describe('Workflow Tools - Handler Invocation', () => {
-    it('workflow_list returns workflow data', async () => {
-      const tool = workflowTools.find(t => t.name === 'workflow_list')!;
+  describe('Spell Tools - Handler Invocation', () => {
+    it('spell_list returns spell data', async () => {
+      const tool = spellTools.find(t => t.name === 'spell_list')!;
       const result: any = await tool.handler({});
       // Engine-backed: returns runs and/or definitions
       expect(result.runs).toBeDefined();
     });
 
-    it('workflow_create creates a workflow definition', async () => {
-      const tool = workflowTools.find(t => t.name === 'workflow_create')!;
-      const result: any = await tool.handler({ name: 'test-wf', description: 'Test workflow' });
+    it('spell_create creates a spell definition', async () => {
+      const tool = spellTools.find(t => t.name === 'spell_create')!;
+      const result: any = await tool.handler({ name: 'test-wf', description: 'Test spell' });
       expect(result.definition).toBeDefined();
       expect(result.name).toBe('test-wf');
     });

--- a/src/modules/cli/__tests__/tool-names.test.ts
+++ b/src/modules/cli/__tests__/tool-names.test.ts
@@ -3,18 +3,19 @@
  *
  * Story #380: Validates tool name constants match expected values
  * and that command files use constants instead of string literals.
+ * Story #371: Renamed workflow tool constants to spell_* names.
  */
 
 import { describe, it, expect } from 'vitest';
 import * as toolNames from '../src/mcp-tools/tool-names.js';
 
 describe('MCP Tool Name Constants', () => {
-  it('exports workflow tool names', () => {
-    expect(toolNames.TOOL_WORKFLOW_RUN).toBe('workflow_run');
-    expect(toolNames.TOOL_WORKFLOW_LIST).toBe('workflow_list');
-    expect(toolNames.TOOL_WORKFLOW_STATUS).toBe('workflow_status');
-    expect(toolNames.TOOL_WORKFLOW_CANCEL).toBe('workflow_cancel');
-    expect(toolNames.TOOL_WORKFLOW_TEMPLATE).toBe('workflow_template');
+  it('exports spell tool names', () => {
+    expect(toolNames.TOOL_SPELL_CAST).toBe('spell_cast');
+    expect(toolNames.TOOL_SPELL_LIST).toBe('spell_list');
+    expect(toolNames.TOOL_SPELL_STATUS).toBe('spell_status');
+    expect(toolNames.TOOL_SPELL_CANCEL).toBe('spell_cancel');
+    expect(toolNames.TOOL_SPELL_TEMPLATE).toBe('spell_template');
   });
 
   it('exports memory tool names', () => {
@@ -63,17 +64,17 @@ describe('spell.ts uses tool name constants (no string literals)', () => {
     );
     // Should import from tool-names
     expect(source).toContain("from '../mcp-tools/tool-names.js'");
-    // Should NOT have raw string tool calls
-    expect(source).not.toContain("callMCPTool<WorkflowRunResponse>('workflow_run'");
-    expect(source).not.toContain("callMCPTool<WorkflowListResponse>('workflow_list'");
-    expect(source).not.toContain("callMCPTool<WorkflowStatusResponse>('workflow_status'");
-    expect(source).not.toContain("callMCPTool<WorkflowCancelResponse>('workflow_cancel'");
-    // Should use TOOL_ constants instead
-    expect(source).toContain('TOOL_WORKFLOW_RUN');
-    expect(source).toContain('TOOL_WORKFLOW_LIST');
-    expect(source).toContain('TOOL_WORKFLOW_STATUS');
-    expect(source).toContain('TOOL_WORKFLOW_CANCEL');
-    expect(source).toContain('TOOL_WORKFLOW_TEMPLATE');
+    // Should NOT have raw string tool calls with old workflow_* names
+    expect(source).not.toContain("callMCPTool<WorkflowRunResponse>('spell_cast'");
+    expect(source).not.toContain("callMCPTool<WorkflowListResponse>('spell_list'");
+    expect(source).not.toContain("callMCPTool<WorkflowStatusResponse>('spell_status'");
+    expect(source).not.toContain("callMCPTool<WorkflowCancelResponse>('spell_cancel'");
+    // Should use TOOL_SPELL_ constants instead
+    expect(source).toContain('TOOL_SPELL_CAST');
+    expect(source).toContain('TOOL_SPELL_LIST');
+    expect(source).toContain('TOOL_SPELL_STATUS');
+    expect(source).toContain('TOOL_SPELL_CANCEL');
+    expect(source).toContain('TOOL_SPELL_TEMPLATE');
   });
 
   it('spell-schedule.ts imports from tool-names.ts', async () => {

--- a/src/modules/cli/__tests__/workflow-tools-engine.test.ts
+++ b/src/modules/cli/__tests__/workflow-tools-engine.test.ts
@@ -1,56 +1,57 @@
 /**
- * Workflow MCP Tools — Engine Integration Tests
+ * Spell MCP Tools — Engine Integration Tests
  *
- * Story #225: Verifies that MCP workflow tool handlers call the real
- * workflow engine via runner-bridge, not a mock file-based store.
+ * Story #225: Verifies that MCP spell tool handlers call the real
+ * spell engine via runner-bridge, not a mock file-based store.
+ * Story #371: Renamed workflow_* tools to spell_* with wizard terminology.
  */
 
 import { describe, it, expect } from 'vitest';
-import { workflowTools, invalidateRegistry } from '../src/mcp-tools/workflow-tools.js';
+import { spellTools, invalidateRegistry } from '../src/mcp-tools/spell-tools.js';
 
 function findTool(name: string) {
-  const tool = workflowTools.find(t => t.name === name);
+  const tool = spellTools.find(t => t.name === name);
   if (!tool) throw new Error(`Tool ${name} not found`);
   return tool;
 }
 
-describe('Workflow MCP Tools — Engine Integration', () => {
+describe('Spell MCP Tools — Engine Integration', () => {
   // -------------------------------------------------------------------------
   // Tool registration
   // -------------------------------------------------------------------------
 
-  it('exports exactly 10 workflow tools', () => {
-    expect(workflowTools).toHaveLength(10);
-    const names = workflowTools.map(t => t.name).sort();
+  it('exports exactly 10 spell tools', () => {
+    expect(spellTools).toHaveLength(10);
+    const names = spellTools.map(t => t.name).sort();
     expect(names).toEqual([
-      'workflow_cancel',
-      'workflow_create',
-      'workflow_delete',
-      'workflow_execute',
-      'workflow_list',
-      'workflow_pause',
-      'workflow_resume',
-      'workflow_run',
-      'workflow_status',
-      'workflow_template',
+      'spell_cancel',
+      'spell_cast',
+      'spell_create',
+      'spell_delete',
+      'spell_execute',
+      'spell_list',
+      'spell_resume',
+      'spell_status',
+      'spell_suspend',
+      'spell_template',
     ]);
   });
 
-  it('all tools have category "workflow"', () => {
-    for (const tool of workflowTools) {
-      expect(tool.category).toBe('workflow');
+  it('all tools have category "spell"', () => {
+    for (const tool of spellTools) {
+      expect(tool.category).toBe('spell');
     }
   });
 
   // -------------------------------------------------------------------------
-  // workflow_create — returns a definition, not a file-based record
+  // spell_create — returns a definition, not a file-based record
   // -------------------------------------------------------------------------
 
-  it('workflow_create returns a definition object with steps', async () => {
-    const tool = findTool('workflow_create');
+  it('spell_create returns a definition object with steps', async () => {
+    const tool = findTool('spell_create');
     const result: any = await tool.handler({
       name: 'test-create',
-      description: 'Integration test workflow',
+      description: 'Integration test spell',
       steps: [
         { id: 'step-1', type: 'bash', config: { command: 'echo hello' } },
         { id: 'step-2', type: 'bash', config: { command: 'echo world' } },
@@ -69,23 +70,23 @@ describe('Workflow MCP Tools — Engine Integration', () => {
   });
 
   // -------------------------------------------------------------------------
-  // workflow_run — requires content, file, or name (no hardcoded templates)
+  // spell_cast — requires content, file, or name (no hardcoded templates)
   // -------------------------------------------------------------------------
 
-  it('workflow_run returns error when no source provided', async () => {
-    const tool = findTool('workflow_run');
+  it('spell_cast returns error when no source provided', async () => {
+    const tool = findTool('spell_cast');
     const result: any = await tool.handler({});
     expect(result.error).toMatch(/name.*file.*content.*required/i);
   });
 
-  it('workflow_run returns error for non-existent file', async () => {
-    const tool = findTool('workflow_run');
+  it('spell_cast returns error for non-existent file', async () => {
+    const tool = findTool('spell_cast');
     const result: any = await tool.handler({ file: '/tmp/nonexistent-workflow-xyz.yaml' });
     expect(result.error).toMatch(/not found/i);
   });
 
-  it('workflow_run executes inline YAML content via engine', async () => {
-    const tool = findTool('workflow_run');
+  it('spell_cast executes inline YAML content via engine', async () => {
+    const tool = findTool('spell_cast');
     const yamlContent = `
 name: inline-test
 steps:
@@ -107,8 +108,8 @@ steps:
     expect(result.duration).toBeGreaterThanOrEqual(0);
   });
 
-  it('workflow_run dry-run validates without executing', async () => {
-    const tool = findTool('workflow_run');
+  it('spell_cast dry-run validates without executing', async () => {
+    const tool = findTool('spell_cast');
     const yamlContent = `
 name: dryrun-test
 steps:
@@ -124,11 +125,11 @@ steps:
   });
 
   // -------------------------------------------------------------------------
-  // workflow_execute — takes a definition object
+  // spell_execute — takes a definition object
   // -------------------------------------------------------------------------
 
-  it('workflow_execute runs a definition via the engine', async () => {
-    const tool = findTool('workflow_execute');
+  it('spell_execute runs a definition via the engine', async () => {
+    const tool = findTool('spell_execute');
     const definition = {
       name: 'execute-test',
       steps: [
@@ -143,32 +144,32 @@ steps:
     expect(result.steps[0].status).toBe('succeeded');
   });
 
-  it('workflow_execute returns error for invalid definition', async () => {
-    const tool = findTool('workflow_execute');
+  it('spell_execute returns error for invalid definition', async () => {
+    const tool = findTool('spell_execute');
     const result: any = await tool.handler({ definition: { name: null, steps: null } });
     expect(result.error).toBeDefined();
   });
 
   // -------------------------------------------------------------------------
-  // workflow_status — tracks results from engine runs
+  // spell_status — tracks results from engine runs
   // -------------------------------------------------------------------------
 
-  it('workflow_status returns not-found for unknown ID', async () => {
-    const tool = findTool('workflow_status');
+  it('spell_status returns not-found for unknown ID', async () => {
+    const tool = findTool('spell_status');
     const result: any = await tool.handler({ workflowId: 'nonexistent-id' });
     expect(result.error).toMatch(/not found/i);
   });
 
-  it('workflow_status returns result for completed workflow', async () => {
-    // First, run a workflow to get a tracked ID
-    const runTool = findTool('workflow_run');
+  it('spell_status returns result for completed spell', async () => {
+    // First, cast a spell to get a tracked ID
+    const runTool = findTool('spell_cast');
     const runResult: any = await runTool.handler({
       content: 'name: status-test\nsteps:\n  - id: s1\n    type: bash\n    config:\n      command: echo ok',
     });
     const workflowId = runResult.workflowId;
 
     // Now query status
-    const statusTool = findTool('workflow_status');
+    const statusTool = findTool('spell_status');
     const statusResult: any = await statusTool.handler({ workflowId, verbose: true });
 
     expect(statusResult.workflowId).toBe(workflowId);
@@ -178,83 +179,83 @@ steps:
   });
 
   // -------------------------------------------------------------------------
-  // workflow_list — returns registry definitions and tracked runs
+  // spell_list — returns grimoire definitions and tracked castings
   // -------------------------------------------------------------------------
 
-  it('workflow_list returns runs array', async () => {
-    const tool = findTool('workflow_list');
+  it('spell_list returns runs array', async () => {
+    const tool = findTool('spell_list');
     const result: any = await tool.handler({ source: 'runs' });
     expect(result.runs).toBeDefined();
     expect(Array.isArray(result.runs)).toBe(true);
   });
 
-  it('workflow_list returns activeWorkflows array', async () => {
-    const tool = findTool('workflow_list');
+  it('spell_list returns activeWorkflows array', async () => {
+    const tool = findTool('spell_list');
     const result: any = await tool.handler({ source: 'all' });
     expect(result.activeWorkflows).toBeDefined();
     expect(Array.isArray(result.activeWorkflows)).toBe(true);
   });
 
   // -------------------------------------------------------------------------
-  // workflow_cancel — uses engine AbortController
+  // spell_cancel — uses engine AbortController
   // -------------------------------------------------------------------------
 
-  it('workflow_cancel returns not-found for unknown ID', async () => {
-    const tool = findTool('workflow_cancel');
+  it('spell_cancel returns not-found for unknown ID', async () => {
+    const tool = findTool('spell_cancel');
     const result: any = await tool.handler({ workflowId: 'nonexistent' });
     expect(result.error).toMatch(/not found/i);
   });
 
   // -------------------------------------------------------------------------
-  // workflow_delete — removes from tracked map
+  // spell_delete — removes from tracked map
   // -------------------------------------------------------------------------
 
-  it('workflow_delete returns deleted=false for unknown ID', async () => {
-    const tool = findTool('workflow_delete');
+  it('spell_delete returns deleted=false for unknown ID', async () => {
+    const tool = findTool('spell_delete');
     const result: any = await tool.handler({ workflowId: 'nonexistent' });
     expect(result.deleted).toBe(false);
   });
 
   // -------------------------------------------------------------------------
-  // workflow_pause — honest about limitations
+  // spell_suspend — honest about limitations
   // -------------------------------------------------------------------------
 
-  it('workflow_pause returns error for non-running workflow', async () => {
-    const tool = findTool('workflow_pause');
+  it('spell_suspend returns error for non-active spell', async () => {
+    const tool = findTool('spell_suspend');
     const result: any = await tool.handler({ workflowId: 'nonexistent' });
-    expect(result.error).toMatch(/not running/i);
+    expect(result.error).toMatch(/not.*active/i);
   });
 
   // -------------------------------------------------------------------------
-  // workflow_resume — honest about limitations
+  // spell_resume — honest about limitations
   // -------------------------------------------------------------------------
 
-  it('workflow_resume returns error for unknown workflow', async () => {
-    const tool = findTool('workflow_resume');
+  it('spell_resume returns error for unknown spell', async () => {
+    const tool = findTool('spell_resume');
     const result: any = await tool.handler({ workflowId: 'nonexistent' });
     expect(result.error).toMatch(/not found/i);
   });
 
   // -------------------------------------------------------------------------
-  // workflow_template — delegates to registry
+  // spell_template — delegates to grimoire
   // -------------------------------------------------------------------------
 
-  it('workflow_template list returns templates array', async () => {
-    const tool = findTool('workflow_template');
+  it('spell_template list returns templates array', async () => {
+    const tool = findTool('spell_template');
     const result: any = await tool.handler({ action: 'list' });
     expect(result.action).toBe('list');
     expect(result.templates).toBeDefined();
     expect(Array.isArray(result.templates)).toBe(true);
   });
 
-  it('workflow_template info returns error for unknown workflow', async () => {
-    const tool = findTool('workflow_template');
+  it('spell_template info returns error for unknown spell', async () => {
+    const tool = findTool('spell_template');
     const result: any = await tool.handler({ action: 'info', query: 'nonexistent-workflow-xyz' });
     expect(result.error).toMatch(/not found/i);
   });
 
-  it('workflow_template with unknown action returns error', async () => {
-    const tool = findTool('workflow_template');
+  it('spell_template with unknown action returns error', async () => {
+    const tool = findTool('spell_template');
     const result: any = await tool.handler({ action: 'unknown' });
     expect(result.error).toMatch(/unknown action/i);
   });
@@ -263,15 +264,15 @@ steps:
   // Registry invalidation (Story #231)
   // -------------------------------------------------------------------------
 
-  it('workflow_list with refresh=true returns refreshed=true', async () => {
-    const tool = findTool('workflow_list');
+  it('spell_list with refresh=true returns refreshed=true', async () => {
+    const tool = findTool('spell_list');
     const result: any = await tool.handler({ source: 'registry', refresh: true });
     expect(result.refreshed).toBe(true);
     expect(result.definitions).toBeDefined();
   });
 
-  it('workflow_list without refresh does not include refreshed flag', async () => {
-    const tool = findTool('workflow_list');
+  it('spell_list without refresh does not include refreshed flag', async () => {
+    const tool = findTool('spell_list');
     const result: any = await tool.handler({ source: 'registry' });
     expect(result.refreshed).toBeUndefined();
   });
@@ -283,7 +284,7 @@ steps:
   });
 
   it('registry returns fresh data after invalidation', async () => {
-    const tool = findTool('workflow_list');
+    const tool = findTool('spell_list');
 
     // First call loads and caches the registry
     const first: any = await tool.handler({ source: 'registry' });
@@ -306,7 +307,7 @@ steps:
     const { readFileSync } = await import('node:fs');
     const { resolve } = await import('node:path');
     const source = readFileSync(
-      resolve(import.meta.dirname, '../src/mcp-tools/workflow-tools.ts'),
+      resolve(import.meta.dirname, '../src/mcp-tools/spell-tools.ts'),
       'utf-8',
     );
     expect(source).not.toContain('store.json');

--- a/src/modules/cli/src/commands/doctor-checks-deep.ts
+++ b/src/modules/cli/src/commands/doctor-checks-deep.ts
@@ -462,7 +462,7 @@ export async function checkMcpWorkflowIntegration(): Promise<HealthCheck> {
       name: 'MCP Workflow Integration',
       status: 'fail',
       message: 'Bridge returned success but no real stdout — MCP tools may not invoke the engine',
-      fix: 'Ensure workflow-tools.ts imports from runner-bridge.ts',
+      fix: 'Ensure spell-tools.ts imports from runner-bridge.ts',
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/modules/cli/src/commands/hive-mind.ts
+++ b/src/modules/cli/src/commands/hive-mind.ts
@@ -119,7 +119,7 @@ ${workerTypes.map(type => `• ${type}: ${workerGroups[type].length} agents`).jo
    mcp__moflo__task_create            - Create hierarchical tasks
    mcp__moflo__task_status            - Track task progress
    mcp__moflo__task_complete          - Mark tasks complete
-   mcp__moflo__workflow_create        - Create spells
+   mcp__moflo__spell_create           - Scribe new spells
 
 5️⃣ **MEMORY & LEARNING**
    mcp__moflo__memory_store           - Store collective knowledge

--- a/src/modules/cli/src/commands/spell.ts
+++ b/src/modules/cli/src/commands/spell.ts
@@ -22,11 +22,11 @@ import type {
   WorkflowErrorResponse,
 } from '../mcp-tools/workflow-response.types.js';
 import {
-  TOOL_WORKFLOW_RUN,
-  TOOL_WORKFLOW_LIST,
-  TOOL_WORKFLOW_STATUS,
-  TOOL_WORKFLOW_CANCEL,
-  TOOL_WORKFLOW_TEMPLATE,
+  TOOL_SPELL_CAST,
+  TOOL_SPELL_LIST,
+  TOOL_SPELL_STATUS,
+  TOOL_SPELL_CANCEL,
+  TOOL_SPELL_TEMPLATE,
 } from '../mcp-tools/tool-names.js';
 import { formatStatus, handleMCPError } from '../services/cli-formatters.js';
 import { scheduleCommand } from './spell-schedule.js';
@@ -100,7 +100,7 @@ const castCommand: Command = {
       // Interactive: list available spells and let user pick
       if (ctx.interactive) {
         try {
-          const listResult = await callMCPTool<WorkflowListResponse>(TOOL_WORKFLOW_LIST, { source: 'registry' });
+          const listResult = await callMCPTool<WorkflowListResponse>(TOOL_SPELL_LIST, { source: 'registry' });
 
           const defs = listResult.definitions ?? [];
           if (defs.length === 0) {
@@ -144,7 +144,7 @@ const castCommand: Command = {
     try {
       spinner.start();
 
-      const result = await callMCPTool<WorkflowRunResponse>(TOOL_WORKFLOW_RUN, {
+      const result = await callMCPTool<WorkflowRunResponse>(TOOL_SPELL_CAST, {
         name: name || undefined,
         file: file || undefined,
         args,
@@ -221,7 +221,7 @@ const validateCommand: Command = {
     output.printInfo(`Validating: ${file}`);
 
     try {
-      const result = await callMCPTool<WorkflowRunResponse>(TOOL_WORKFLOW_RUN, {
+      const result = await callMCPTool<WorkflowRunResponse>(TOOL_SPELL_CAST, {
         file,
         dryRun: true,
       });
@@ -281,7 +281,7 @@ const listCommand: Command = {
     const refresh = ctx.flags.refresh as boolean;
 
     try {
-      const result = await callMCPTool<WorkflowListResponse>(TOOL_WORKFLOW_LIST, { source, limit, refresh: refresh || undefined });
+      const result = await callMCPTool<WorkflowListResponse>(TOOL_SPELL_LIST, { source, limit, refresh: refresh || undefined });
 
       if (ctx.flags.format === 'json') {
         output.printJson(result);
@@ -345,7 +345,7 @@ const statusCommand: Command = {
     }
 
     try {
-      const result = await callMCPTool<WorkflowStatusResponse>(TOOL_WORKFLOW_STATUS, {
+      const result = await callMCPTool<WorkflowStatusResponse>(TOOL_SPELL_STATUS, {
         workflowId,
         verbose: true,
       });
@@ -420,7 +420,7 @@ const stopCommand: Command = {
     }
 
     try {
-      const result = await callMCPTool<WorkflowCancelResponse>(TOOL_WORKFLOW_CANCEL, {
+      const result = await callMCPTool<WorkflowCancelResponse>(TOOL_SPELL_CANCEL, {
         workflowId,
         reason: 'Dispelled via CLI',
       });
@@ -449,7 +449,7 @@ const templateCommand: Command = {
       description: 'List available spell templates',
       action: async (ctx: CommandContext): Promise<CommandResult> => {
         try {
-          const result = await callMCPTool<WorkflowTemplateListResponse>(TOOL_WORKFLOW_TEMPLATE, { action: 'list' });
+          const result = await callMCPTool<WorkflowTemplateListResponse>(TOOL_SPELL_TEMPLATE, { action: 'list' });
 
           if (result.error) {
             output.printError(result.error);
@@ -495,7 +495,7 @@ const templateCommand: Command = {
         }
 
         try {
-          const result = await callMCPTool<WorkflowTemplateInfoResponse>(TOOL_WORKFLOW_TEMPLATE, { action: 'info', query });
+          const result = await callMCPTool<WorkflowTemplateInfoResponse>(TOOL_SPELL_TEMPLATE, { action: 'info', query });
 
           if (result.error) {
             output.printError(result.error);

--- a/src/modules/cli/src/mcp-client.ts
+++ b/src/modules/cli/src/mcp-client.ts
@@ -19,7 +19,7 @@ import { hooksTools } from './mcp-tools/hooks-tools.js';
 import { taskTools } from './mcp-tools/task-tools.js';
 import { sessionTools } from './mcp-tools/session-tools.js';
 import { hiveMindTools } from './mcp-tools/hive-mind-tools.js';
-import { workflowTools } from './mcp-tools/workflow-tools.js';
+import { spellTools } from './mcp-tools/spell-tools.js';
 import { analyzeTools } from './mcp-tools/analyze-tools.js';
 import { progressTools } from './mcp-tools/progress-tools.js';
 import { embeddingsTools } from './mcp-tools/embeddings-tools.js';
@@ -61,7 +61,7 @@ registerTools([
   ...taskTools,
   ...sessionTools,
   ...hiveMindTools,
-  ...workflowTools,
+  ...spellTools,
   ...analyzeTools,
   ...progressTools,
   ...embeddingsTools,

--- a/src/modules/cli/src/mcp-tools/daa-tools.ts
+++ b/src/modules/cli/src/mcp-tools/daa-tools.ts
@@ -192,15 +192,15 @@ export const daaTools: MCPTool[] = [
     },
   },
   {
-    name: 'daa_workflow_create',
-    description: 'Create an autonomous workflow',
+    name: 'daa_spell_create',
+    description: 'Scribe an autonomous spell',
     category: 'daa',
     inputSchema: {
       type: 'object',
       properties: {
-        id: { type: 'string', description: 'Workflow ID' },
-        name: { type: 'string', description: 'Workflow name' },
-        steps: { type: 'array', items: { type: 'object' }, description: 'Workflow steps' },
+        id: { type: 'string', description: 'Spell ID' },
+        name: { type: 'string', description: 'Spell name' },
+        steps: { type: 'array', items: { type: 'object' }, description: 'Spell steps' },
         strategy: { type: 'string', enum: ['parallel', 'sequential', 'adaptive'], description: 'Execution strategy' },
         dependencies: { type: 'object', description: 'Step dependencies' },
       },
@@ -236,13 +236,13 @@ export const daaTools: MCPTool[] = [
     },
   },
   {
-    name: 'daa_workflow_execute',
-    description: 'Execute a DAA workflow',
+    name: 'daa_spell_cast',
+    description: 'Cast a DAA spell',
     category: 'daa',
     inputSchema: {
       type: 'object',
       properties: {
-        workflowId: { type: 'string', description: 'Workflow ID' },
+        workflowId: { type: 'string', description: 'Spell invocation ID' },
         agentIds: { type: 'array', items: { type: 'string' }, description: 'Agent IDs to use' },
         parallelExecution: { type: 'boolean', description: 'Enable parallel execution' },
       },
@@ -254,7 +254,7 @@ export const daaTools: MCPTool[] = [
       const workflow = store.workflows[workflowId];
 
       if (!workflow) {
-        return { success: false, error: 'Workflow not found' };
+        return { success: false, error: 'Spell not found' };
       }
 
       workflow.status = 'running';

--- a/src/modules/cli/src/mcp-tools/index.ts
+++ b/src/modules/cli/src/mcp-tools/index.ts
@@ -13,7 +13,7 @@ export { hooksTools } from './hooks-tools.js';
 export { taskTools } from './task-tools.js';
 export { sessionTools } from './session-tools.js';
 export { hiveMindTools } from './hive-mind-tools.js';
-export { workflowTools } from './workflow-tools.js';
+export { spellTools } from './spell-tools.js';
 export { coverageRouterTools } from './coverage-tools.js';
 export { analyzeTools } from './analyze-tools.js';
 export { progressTools } from './progress-tools.js';

--- a/src/modules/cli/src/mcp-tools/spell-tools.ts
+++ b/src/modules/cli/src/mcp-tools/spell-tools.ts
@@ -1,8 +1,9 @@
 /**
- * Workflow MCP Tools for CLI
+ * Spell MCP Tools for CLI
  *
- * Wired to the real workflow engine via runner-bridge.ts.
+ * Wired to the real spell engine via runner-bridge.ts.
  * Story #225: Replace mock file-based store with engine integration.
+ * Story #371: Rename workflow_* tools to spell_* with wizard terminology.
  */
 
 import { readFileSync } from 'node:fs';
@@ -197,22 +198,22 @@ function serializeResult(result: WorkflowResult): Record<string, unknown> {
 // MCP Tool Definitions
 // ============================================================================
 
-export const workflowTools: MCPTool[] = [
+export const spellTools: MCPTool[] = [
   // --------------------------------------------------------------------------
-  // workflow_run — Run a workflow from a file, registry name, or template
+  // spell_cast — Cast a spell from a file, grimoire name, or incantation
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_run',
-    description: 'Run a workflow from a YAML/JSON file, registry name/abbreviation, or inline content',
-    category: 'workflow',
+    name: 'spell_cast',
+    description: 'Cast a spell from a YAML/JSON scroll, grimoire name/abbreviation, or inline incantation',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        name: { type: 'string', description: 'Workflow name or abbreviation (resolved via registry)' },
-        file: { type: 'string', description: 'Path to a YAML/JSON workflow definition file' },
-        content: { type: 'string', description: 'Inline YAML/JSON workflow content' },
-        args: { type: 'object', description: 'Arguments to pass to the workflow' },
-        dryRun: { type: 'boolean', description: 'Validate without executing' },
+        name: { type: 'string', description: 'Spell name or abbreviation (resolved via grimoire)' },
+        file: { type: 'string', description: 'Path to a YAML/JSON spell scroll file' },
+        content: { type: 'string', description: 'Inline YAML/JSON spell incantation' },
+        args: { type: 'object', description: 'Reagents (arguments) to pass to the spell' },
+        dryRun: { type: 'boolean', description: 'Preview the spell without casting' },
       },
     },
     handler: async (input) => {
@@ -224,7 +225,7 @@ export const workflowTools: MCPTool[] = [
         const registry = await getRegistry();
         const loaded = registry.resolve(input.name as string);
         if (!loaded) {
-          return { error: `Workflow not found in registry: ${input.name}` };
+          return { error: `Spell not found in grimoire: ${input.name}` };
         }
         const engine = await loadSpellEngine();
         return executeAndTrack(engine, loaded.definition, args);
@@ -243,12 +244,12 @@ export const workflowTools: MCPTool[] = [
         try {
           content = readFileSync(filePath, 'utf-8');
         } catch {
-          return { error: `Workflow file not found or unreadable: ${filePath}` };
+          return { error: `Spell scroll not found or unreadable: ${filePath}` };
         }
         sourceFile = filePath;
         workflowName = String(input.file);
       } else {
-        return { error: 'One of name, file, or content is required' };
+        return { error: 'One of name, file, or content is required to cast a spell' };
       }
 
       // Run from raw content via bridge
@@ -261,20 +262,20 @@ export const workflowTools: MCPTool[] = [
   },
 
   // --------------------------------------------------------------------------
-  // workflow_create — Create a workflow definition (returns parseable YAML)
+  // spell_create — Scribe a new spell definition (returns parseable YAML)
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_create',
-    description: 'Create a workflow definition from steps (returns YAML content)',
-    category: 'workflow',
+    name: 'spell_create',
+    description: 'Scribe a new spell definition from steps (returns YAML scroll)',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        name: { type: 'string', description: 'Workflow name' },
-        description: { type: 'string', description: 'Workflow description' },
+        name: { type: 'string', description: 'Spell name' },
+        description: { type: 'string', description: 'Spell description' },
         steps: {
           type: 'array',
-          description: 'Workflow steps',
+          description: 'Spell steps (incantation sequence)',
           items: {
             type: 'object',
             properties: {
@@ -284,7 +285,7 @@ export const workflowTools: MCPTool[] = [
             },
           },
         },
-        arguments: { type: 'object', description: 'Workflow argument definitions' },
+        arguments: { type: 'object', description: 'Spell reagent definitions (arguments)' },
       },
       required: ['name'],
     },
@@ -311,24 +312,24 @@ export const workflowTools: MCPTool[] = [
         description,
         stepCount: definition.steps.length,
         definition,
-        message: 'Workflow definition created. Pass it to workflow_execute or workflow_run to run it.',
+        message: 'Spell scribed. Pass it to spell_execute or spell_cast to invoke it.',
       };
     },
   },
 
   // --------------------------------------------------------------------------
-  // workflow_execute — Execute a workflow definition directly
+  // spell_execute — Execute a spell from a definition object
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_execute',
-    description: 'Execute a workflow from a definition object',
-    category: 'workflow',
+    name: 'spell_execute',
+    description: 'Execute a spell from a definition object directly',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        definition: { type: 'object', description: 'SpellDefinition object (from workflow_create or parsed YAML)' },
-        args: { type: 'object', description: 'Runtime arguments' },
-        dryRun: { type: 'boolean', description: 'Validate without executing' },
+        definition: { type: 'object', description: 'SpellDefinition object (from spell_create or parsed YAML scroll)' },
+        args: { type: 'object', description: 'Reagents (runtime arguments)' },
+        dryRun: { type: 'boolean', description: 'Preview the spell without casting' },
       },
       required: ['definition'],
     },
@@ -356,17 +357,17 @@ export const workflowTools: MCPTool[] = [
   },
 
   // --------------------------------------------------------------------------
-  // workflow_status — Get status of a tracked workflow
+  // spell_status — Scry the status of a tracked spell
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_status',
-    description: 'Get workflow execution status',
-    category: 'workflow',
+    name: 'spell_status',
+    description: 'Scry the execution status of a cast spell',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        workflowId: { type: 'string', description: 'Workflow ID' },
-        verbose: { type: 'boolean', description: 'Include step details' },
+        workflowId: { type: 'string', description: 'Spell invocation ID' },
+        verbose: { type: 'boolean', description: 'Include step details in the scrying' },
       },
       required: ['workflowId'],
     },
@@ -378,7 +379,7 @@ export const workflowTools: MCPTool[] = [
       const isRunning = getCachedEngine()?.bridgeIsRunning(workflowId) ?? false;
 
       if (!tracked && !isRunning) {
-        return { workflowId, error: 'Workflow not found' };
+        return { workflowId, error: 'Spell invocation not found' };
       }
 
       if (isRunning) {
@@ -423,19 +424,19 @@ export const workflowTools: MCPTool[] = [
   },
 
   // --------------------------------------------------------------------------
-  // workflow_list — List workflows from registry and tracked runs
+  // spell_list — List spells from grimoire and tracked castings
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_list',
-    description: 'List available workflows from registry and recent runs',
-    category: 'workflow',
+    name: 'spell_list',
+    description: 'List available spells from the grimoire and recent castings',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
         source: { type: 'string', enum: ['registry', 'runs', 'all'], description: 'What to list (default: all)' },
-        status: { type: 'string', description: 'Filter runs by status' },
-        limit: { type: 'number', description: 'Max items to return' },
-        refresh: { type: 'boolean', description: 'Invalidate cached registry and re-scan definition files before listing' },
+        status: { type: 'string', description: 'Filter castings by status' },
+        limit: { type: 'number', description: 'Max spells to return' },
+        refresh: { type: 'boolean', description: 'Re-scan grimoire scrolls before listing' },
       },
     },
     handler: async (input) => {
@@ -454,7 +455,7 @@ export const workflowTools: MCPTool[] = [
           result.definitions = registry.list();
         } catch {
           result.definitions = [];
-          result.registryError = 'Workflow engine not available';
+          result.registryError = 'Spell engine not available';
         }
       }
 
@@ -486,16 +487,16 @@ export const workflowTools: MCPTool[] = [
   },
 
   // --------------------------------------------------------------------------
-  // workflow_pause — Pause is not supported by the engine (workflows run to completion)
+  // spell_suspend — Suspend a running spell (converts to dispel — spells run to completion)
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_pause',
-    description: 'Pause a running workflow (converts to cancel — engine workflows run to completion)',
-    category: 'workflow',
+    name: 'spell_suspend',
+    description: 'Suspend a running spell (converts to dispel — spells run to completion)',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        workflowId: { type: 'string', description: 'Workflow ID' },
+        workflowId: { type: 'string', description: 'Spell invocation ID' },
       },
       required: ['workflowId'],
     },
@@ -504,7 +505,7 @@ export const workflowTools: MCPTool[] = [
       const engine = await loadSpellEngine();
 
       if (!engine.bridgeIsRunning(workflowId)) {
-        return { workflowId, error: 'Workflow not running' };
+        return { workflowId, error: 'Spell not currently active' };
       }
 
       // Engine doesn't support pause — cancel via AbortController
@@ -520,23 +521,23 @@ export const workflowTools: MCPTool[] = [
       return {
         workflowId,
         status: cancelled ? WF_STATUS.CANCELLED : 'not_found',
-        note: 'Engine workflows cannot be paused — cancelled instead. Use workflow_run to restart.',
+        note: 'Spells cannot be suspended mid-cast — dispelled instead. Use spell_cast to re-invoke.',
       };
     },
   },
 
   // --------------------------------------------------------------------------
-  // workflow_resume — Resume is not supported (re-run instead)
+  // spell_resume — Resume a spell (re-casts from beginning — mid-spell resume not supported)
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_resume',
-    description: 'Resume a workflow (re-runs from beginning — engine does not support mid-workflow resume)',
-    category: 'workflow',
+    name: 'spell_resume',
+    description: 'Resume a spell (re-casts from beginning — mid-spell resume not yet supported)',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        workflowId: { type: 'string', description: 'Workflow ID of a previously tracked workflow' },
-        args: { type: 'object', description: 'Override arguments for the re-run' },
+        workflowId: { type: 'string', description: 'Spell invocation ID of a previously tracked spell' },
+        args: { type: 'object', description: 'Override reagents for the re-cast' },
       },
       required: ['workflowId'],
     },
@@ -545,7 +546,7 @@ export const workflowTools: MCPTool[] = [
       const tracked = trackedWorkflows.get(workflowId);
 
       if (!tracked) {
-        return { workflowId, error: 'Workflow not found in tracked runs' };
+        return { workflowId, error: 'Spell not found in tracked castings' };
       }
 
       if (!tracked.result) {
@@ -557,7 +558,7 @@ export const workflowTools: MCPTool[] = [
       // but MCP tools don't currently persist paused definitions. This re-runs from start.
       return {
         workflowId,
-        note: 'Mid-workflow resume is not yet supported via MCP tools. Use workflow_run to re-execute the workflow.',
+        note: 'Mid-spell resume is not yet supported. Use spell_cast to re-invoke the spell.',
         previousStatus: tracked.status,
         previousResult: {
           success: tracked.result.success,
@@ -569,17 +570,17 @@ export const workflowTools: MCPTool[] = [
   },
 
   // --------------------------------------------------------------------------
-  // workflow_cancel — Cancel a running workflow
+  // spell_cancel — Dispel a running spell
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_cancel',
-    description: 'Cancel a running workflow',
-    category: 'workflow',
+    name: 'spell_cancel',
+    description: 'Dispel (cancel) a running spell',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        workflowId: { type: 'string', description: 'Workflow ID' },
-        reason: { type: 'string', description: 'Cancellation reason' },
+        workflowId: { type: 'string', description: 'Spell invocation ID' },
+        reason: { type: 'string', description: 'Reason for dispelling' },
       },
       required: ['workflowId'],
     },
@@ -606,24 +607,24 @@ export const workflowTools: MCPTool[] = [
       // Check if it's a tracked but already finished workflow
       const tracked = trackedWorkflows.get(workflowId);
       if (tracked) {
-        return { workflowId, error: `Workflow already ${tracked.status}` };
+        return { workflowId, error: `Spell already ${tracked.status}` };
       }
 
-      return { workflowId, error: 'Workflow not found' };
+      return { workflowId, error: 'Spell invocation not found' };
     },
   },
 
   // --------------------------------------------------------------------------
-  // workflow_delete — Remove a tracked workflow from memory
+  // spell_delete — Remove a tracked spell record from memory
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_delete',
-    description: 'Delete a tracked workflow record',
-    category: 'workflow',
+    name: 'spell_delete',
+    description: 'Delete a tracked spell casting record',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        workflowId: { type: 'string', description: 'Workflow ID' },
+        workflowId: { type: 'string', description: 'Spell invocation ID' },
       },
       required: ['workflowId'],
     },
@@ -632,7 +633,7 @@ export const workflowTools: MCPTool[] = [
 
       // Only check engine if already loaded (avoid unnecessary dynamic import)
       if (getCachedEngine()?.bridgeIsRunning(workflowId)) {
-        return { workflowId, error: 'Cannot delete a running workflow — cancel it first' };
+        return { workflowId, error: 'Cannot delete an active spell — dispel it first' };
       }
 
       const existed = trackedWorkflows.delete(workflowId);
@@ -645,17 +646,17 @@ export const workflowTools: MCPTool[] = [
   },
 
   // --------------------------------------------------------------------------
-  // workflow_template — List/info from the workflow registry
+  // spell_template — Browse spell templates from the grimoire
   // --------------------------------------------------------------------------
   {
-    name: 'workflow_template',
-    description: 'Browse workflow templates from the registry',
-    category: 'workflow',
+    name: 'spell_template',
+    description: 'Browse spell templates from the grimoire',
+    category: 'spell',
     inputSchema: {
       type: 'object',
       properties: {
-        action: { type: 'string', enum: ['list', 'info'], description: 'Template action' },
-        query: { type: 'string', description: 'Workflow name or abbreviation (for info)' },
+        action: { type: 'string', enum: ['list', 'info'], description: 'Grimoire action' },
+        query: { type: 'string', description: 'Spell name or abbreviation (for info)' },
       },
       required: ['action'],
     },
@@ -685,7 +686,7 @@ export const workflowTools: MCPTool[] = [
           const registry = await getRegistry();
           const info = registry.info(query);
           if (!info) {
-            return { action, error: `Workflow not found: ${query}` };
+            return { action, error: `Spell not found in grimoire: ${query}` };
           }
           return { action, ...info };
         } catch (err) {

--- a/src/modules/cli/src/mcp-tools/tool-names.ts
+++ b/src/modules/cli/src/mcp-tools/tool-names.ts
@@ -5,12 +5,12 @@
  * These match the tool names registered in the MCP server (mcp-tools/*.ts).
  */
 
-// Workflow / Spell tools
-export const TOOL_WORKFLOW_RUN = 'workflow_run' as const;
-export const TOOL_WORKFLOW_LIST = 'workflow_list' as const;
-export const TOOL_WORKFLOW_STATUS = 'workflow_status' as const;
-export const TOOL_WORKFLOW_CANCEL = 'workflow_cancel' as const;
-export const TOOL_WORKFLOW_TEMPLATE = 'workflow_template' as const;
+// Spell tools (wizard-themed, formerly workflow_*)
+export const TOOL_SPELL_CAST = 'spell_cast' as const;
+export const TOOL_SPELL_LIST = 'spell_list' as const;
+export const TOOL_SPELL_STATUS = 'spell_status' as const;
+export const TOOL_SPELL_CANCEL = 'spell_cancel' as const;
+export const TOOL_SPELL_TEMPLATE = 'spell_template' as const;
 
 // Memory tools
 export const TOOL_MEMORY_STORE = 'memory_store' as const;

--- a/src/modules/cli/src/mcp-tools/workflow-response.types.ts
+++ b/src/modules/cli/src/mcp-tools/workflow-response.types.ts
@@ -1,15 +1,16 @@
 /**
- * Workflow MCP Response Types
+ * Spell MCP Response Types
  *
- * Shared type definitions for workflow MCP tool responses.
- * Used by both the MCP tool handlers (workflow-tools.ts) and
- * the CLI workflow command (commands/workflow.ts) for type-safe
+ * Shared type definitions for spell MCP tool responses.
+ * Used by both the MCP tool handlers (spell-tools.ts) and
+ * the CLI spell command (commands/spell.ts) for type-safe
  * callMCPTool<T>() deserialization.
  *
  * Story #230: Extract shared workflow type definitions.
+ * Story #371: Rename workflow tools to spell tools.
  */
 
-/** Response from workflow_run / workflow_execute MCP tools. */
+/** Response from spell_cast / spell_execute MCP tools. */
 export interface WorkflowRunResponse {
   workflowId: string;
   success: boolean;
@@ -41,7 +42,7 @@ export interface WorkflowErrorResponse {
   stepId?: string;
 }
 
-/** Response from workflow_status MCP tool. */
+/** Response from spell_status MCP tool. */
 export interface WorkflowStatusResponse {
   workflowId: string;
   name?: string;
@@ -68,7 +69,7 @@ export interface GrimoireEntry {
   tier: string;
 }
 
-/** Response from workflow_list MCP tool. */
+/** Response from spell_list MCP tool. */
 export interface WorkflowListResponse {
   definitions?: GrimoireEntry[];
   runs?: WorkflowRunEntry[];
@@ -87,7 +88,7 @@ export interface WorkflowRunEntry {
   completedAt?: string;
 }
 
-/** Response from workflow_cancel MCP tool. */
+/** Response from spell_cancel MCP tool. */
 export interface WorkflowCancelResponse {
   workflowId: string;
   status: string;
@@ -96,7 +97,7 @@ export interface WorkflowCancelResponse {
   error?: string;
 }
 
-/** Response from workflow_template list action. */
+/** Response from spell_template list action. */
 export interface WorkflowTemplateListResponse {
   action: string;
   templates: GrimoireEntry[];
@@ -104,7 +105,7 @@ export interface WorkflowTemplateListResponse {
   error?: string;
 }
 
-/** Response from workflow_template info action. */
+/** Response from spell_template info action. */
 export interface WorkflowTemplateInfoResponse {
   action: string;
   name?: string;

--- a/src/modules/cli/src/services/engine-loader.ts
+++ b/src/modules/cli/src/services/engine-loader.ts
@@ -2,7 +2,7 @@
  * Shared Workflow Engine Loader
  *
  * Centralizes dynamic import + caching of the @moflo/spells package.
- * Both workflow-tools.ts (MCP layer) and runner-adapter.ts (epic runner) use
+ * Both spell-tools.ts (MCP layer) and runner-adapter.ts (epic runner) use
  * this instead of maintaining their own import/cache logic.
  *
  * Story #229: Extract shared engine loader.

--- a/src/modules/spells/src/factory/runner-bridge.ts
+++ b/src/modules/spells/src/factory/runner-bridge.ts
@@ -49,7 +49,7 @@ export async function bridgeRunWorkflow(
 }
 
 /**
- * Run a SpellDefinition directly (for workflow_execute).
+ * Run a SpellDefinition directly (for spell_execute).
  */
 export async function bridgeExecuteWorkflow(
   definition: import('../types/workflow-definition.types.js').SpellDefinition,

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -1154,7 +1154,7 @@ describe('settings.json: PostToolUse matcher coverage', () => {
   });
 
   it('non-memory MCP tools do not match memory matchers', () => {
-    const entry = findMatchingEntry('mcp__moflo__workflow_run');
+    const entry = findMatchingEntry('mcp__moflo__spell_cast');
     // Should either not match or not trigger memory-related hooks
     if (entry) {
       const cmds = entry.hooks.map(h => h.command);

--- a/tests/skills/workflow-builder.test.ts
+++ b/tests/skills/workflow-builder.test.ts
@@ -227,12 +227,12 @@ describe('workflow-builder skill', () => {
       expect(content).toContain('#238');
     });
 
-    it('references MCP workflow_create tool', () => {
-      expect(content).toContain('mcp__moflo__workflow_create');
+    it('references MCP spell_create tool', () => {
+      expect(content).toContain('mcp__moflo__spell_create');
     });
 
-    it('references MCP workflow_list tool', () => {
-      expect(content).toContain('mcp__moflo__workflow_list');
+    it('references MCP spell_list tool', () => {
+      expect(content).toContain('mcp__moflo__spell_list');
     });
   });
 


### PR DESCRIPTION
## Summary
- Rename `workflow-tools.ts` → `spell-tools.ts` with all 10 tool definitions renamed (`spell_cast`, `spell_create`, `spell_execute`, `spell_status`, `spell_list`, `spell_suspend`, `spell_resume`, `spell_cancel`, `spell_delete`, `spell_template`)
- Update tool descriptions with wizard-themed language (grimoire, scry, dispel, incantation)
- Rename `daa_workflow_create` → `daa_spell_create` and `daa_workflow_execute` → `daa_spell_cast` in DAA tools
- Update `TOOL_WORKFLOW_*` constants to `TOOL_SPELL_*` in tool-names.ts
- Update all imports, registrations, CLI commands, tests, and documentation references

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] All 299 affected tests pass (workflow-tools-engine, tool-names, mcp-tools-deep, gate-helpers, workflow-builder)
- [x] Full test suite: 6437 passed, 0 new failures (3 pre-existing failures on main confirmed)
- [x] `/simplify` review completed — fixed stale descriptions in daa-tools.ts

Closes #371

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)