### PR TITLE
refactor(dashboard): migrate dashboard and database namespace to spell terminology (#374)

### DIFF
--- a/src/modules/cli/__tests__/daemon-dashboard.test.ts
+++ b/src/modules/cli/__tests__/daemon-dashboard.test.ts
@@ -202,22 +202,22 @@ describe('DaemonDashboard', () => {
     expect(data.schedules).toEqual([]);
   });
 
-  it('returns workflow executions at GET /api/workflows', async () => {
+  it('returns spell executions at GET /api/spells', async () => {
     const daemon = makeMockDaemon();
     const memory = makeMockMemory({
       'schedule-executions': [{
         key: 'exec-1',
-        value: JSON.stringify({ workflowName: 'security-audit', startedAt: 1711875600000, success: true, duration: 60000 }),
+        value: JSON.stringify({ spellName: 'security-audit', startedAt: 1711875600000, success: true, duration: 60000 }),
         score: 1,
       }],
     });
     dashboard = await startDashboard(daemon, { port: testPort, memory });
 
-    const res = await fetchDashboard(testPort, '/api/workflows');
+    const res = await fetchDashboard(testPort, '/api/spells');
     const data = JSON.parse(res.body);
     expect(data.available).toBe(true);
     expect(data.executions).toHaveLength(1);
-    expect(data.executions[0].workflowName).toBe('security-audit');
+    expect(data.executions[0].spellName).toBe('security-audit');
     expect(data.executions[0].success).toBe(true);
     expect(data.executions[0].duration).toBe(60000);
   });
@@ -293,7 +293,7 @@ describe('DaemonDashboard', () => {
     const daemon = makeMockDaemon();
     dashboard = await startDashboard(daemon, { port: testPort });
 
-    const endpoints = ['/api/status', '/api/schedules', '/api/workflows', '/api/memory/stats'];
+    const endpoints = ['/api/status', '/api/schedules', '/api/spells', '/api/memory/stats'];
     for (const ep of endpoints) {
       const res = await fetchDashboard(testPort, ep);
       expect(res.headers['content-type']).toContain('application/json');
@@ -304,19 +304,19 @@ describe('DaemonDashboard', () => {
     expect(DEFAULT_DASHBOARD_PORT).toBe(3117);
   });
 
-  it('returns context metadata in workflow executions', async () => {
+  it('returns context metadata in spell executions', async () => {
     const daemon = makeMockDaemon();
     const context = { type: 'ticket', label: '#350 \u2014 Replace zod with valibot', issueNumber: 350, issueTitle: 'Replace zod with valibot', execMode: 'normal' };
     const memory = makeMockMemory({
       'tasklist': [{
         key: 'flo-run-1',
-        value: JSON.stringify({ workflowName: '#350 \u2014 Replace zod with valibot', startedAt: 1711875600000, success: true, duration: 120000, context }),
+        value: JSON.stringify({ spellName: '#350 \u2014 Replace zod with valibot', startedAt: 1711875600000, success: true, duration: 120000, context }),
         score: 1,
       }],
     });
     dashboard = await startDashboard(daemon, { port: testPort, memory });
 
-    const res = await fetchDashboard(testPort, '/api/workflows');
+    const res = await fetchDashboard(testPort, '/api/spells');
     const data = JSON.parse(res.body);
     expect(data.executions).toHaveLength(1);
     expect(data.executions[0].context).toEqual(context);
@@ -348,9 +348,9 @@ describe('buildFloRunContext', () => {
     expect(ctx.epicProgress).toEqual([3, 5]);
   });
 
-  it('builds workflow context with name and args', () => {
-    const ctx = buildFloRunContext({ workflowName: 'security-audit', workflowArgs: ['./src'] });
-    expect(ctx.type).toBe('workflow');
+  it('builds spell context with name and args', () => {
+    const ctx = buildFloRunContext({ spellName: 'security-audit', spellArgs: ['./src'] });
+    expect(ctx.type).toBe('spell');
     expect(ctx.label).toContain('security-audit');
     expect(ctx.label).toContain('./src');
   });

--- a/src/modules/cli/src/services/daemon-dashboard.ts
+++ b/src/modules/cli/src/services/daemon-dashboard.ts
@@ -1,7 +1,7 @@
 /**
  * Daemon Dashboard — Lightweight localhost HTTP server
  *
- * Serves a read-only VanJS dashboard for daemon status, workflow logs,
+ * Serves a read-only VanJS dashboard for daemon status, spell logs,
  * and memory stats. Binds to 127.0.0.1 only (no auth needed).
  *
  * @module daemon-dashboard
@@ -65,7 +65,7 @@ export async function createDashboardMemoryAccessor(): Promise<MemoryAccessor> {
         const listResult = await listEntries({ namespace, limit: 100 });
         if (!listResult.success || listResult.entries.length === 0) {
           // Fall back to semantic search with a meaningful query
-          const result = await searchEntries({ query: query === '*' ? 'workflow execution status' : query, namespace, limit: 100 });
+          const result = await searchEntries({ query: query === '*' ? 'spell execution status' : query, namespace, limit: 100 });
           if (!result.success) return [];
           return result.results.map(r => ({ key: r.key, value: r.content, score: r.score }));
         }
@@ -147,7 +147,7 @@ async function handleSchedules(memory?: MemoryAccessor): Promise<object> {
   }
 }
 
-async function handleWorkflows(memory?: MemoryAccessor): Promise<object> {
+async function handleSpells(memory?: MemoryAccessor): Promise<object> {
   if (!memory) {
     return { executions: [], available: false };
   }
@@ -198,8 +198,8 @@ async function handleMemoryStats(): Promise<object> {
 export function buildFloRunContext(opts: {
   issueNumber?: number;
   issueTitle?: string;
-  workflowName?: string;
-  workflowArgs?: string[];
+  spellName?: string;
+  spellArgs?: string[];
   execMode?: 'normal' | 'swarm' | 'hive';
   epicProgress?: readonly [number, number];
   isEpic?: boolean;
@@ -209,13 +209,13 @@ export function buildFloRunContext(opts: {
 }): FloRunContext {
   const execMode = opts.execMode ?? 'normal';
 
-  if (opts.workflowName) {
-    const argStr = opts.workflowArgs?.length ? ` ${opts.workflowArgs.join(' ')}` : '';
+  if (opts.spellName) {
+    const argStr = opts.spellArgs?.length ? ` ${opts.spellArgs.join(' ')}` : '';
     return {
-      type: 'workflow',
-      label: `${opts.workflowName}${argStr ? ' \u2192 ' + argStr.trim() : ''}`,
-      workflowName: opts.workflowName,
-      workflowArgs: opts.workflowArgs,
+      type: 'spell',
+      label: `${opts.spellName}${argStr ? ' \u2192 ' + argStr.trim() : ''}`,
+      spellName: opts.spellName,
+      spellArgs: opts.spellArgs,
       execMode,
     };
   }
@@ -264,7 +264,7 @@ export function buildFloRunContext(opts: {
 
 /**
  * Store a flo run record to the tasklist namespace for dashboard display.
- * Used by non-workflow-engine /flo invocations (ticket, research, epic).
+ * Used by non-spell-engine /flo invocations (ticket, research, epic).
  */
 export async function storeFloRunRecord(
   memory: MemoryAccessor,
@@ -277,7 +277,7 @@ export async function storeFloRunRecord(
     const record: Record<string, unknown> = {
       status,
       context,
-      workflowName: context.label,
+      spellName: context.label,
       updatedAt: new Date().toISOString(),
     };
     if (extra?.startedAt) record.startedAt = extra.startedAt;
@@ -342,8 +342,8 @@ async function handleRequest(
       sendJson(res, 200, handleStatus(daemon));
     } else if (url === '/api/schedules') {
       sendJson(res, 200, await handleSchedules(opts.memory));
-    } else if (url === '/api/workflows') {
-      sendJson(res, 200, await handleWorkflows(opts.memory));
+    } else if (url === '/api/spells') {
+      sendJson(res, 200, await handleSpells(opts.memory));
     } else if (url === '/api/memory/stats') {
       sendJson(res, 200, await handleMemoryStats());
     } else {
@@ -623,12 +623,12 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       w.executions.forEach(e => {
         const ctx = e.context;
         const contextLabel = fmtContext(ctx);
-        const name = contextLabel || e.workflowName || 'Unknown Workflow';
+        const name = contextLabel || e.spellName || e.workflowName || 'Unknown Spell';
         const runId = e.id || '-';
         const statusBadge = e.success === true ? badge('pass','green') : e.success === false ? badge('fail','red') : badge('running','yellow');
         const progress = e.totalSteps ? (e.completedSteps || 0) + '/' + e.totalSteps + ' steps' : '';
         const steps = Array.isArray(e.steps) ? e.steps : [];
-        const typeBadge = ctx ? badge(ctx.type, ctx.type === 'epic' ? 'yellow' : ctx.type === 'workflow' ? 'gray' : 'green') : '';
+        const typeBadge = ctx ? badge(ctx.type, ctx.type === 'epic' ? 'yellow' : ctx.type === 'spell' ? 'gray' : 'green') : '';
 
         html += '<div class="wf-group" style="margin-bottom:16px">';
         // Header: context label, type badge, status, timing
@@ -689,7 +689,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         const [s, sc, w, m] = await Promise.all([
           fetch('/api/status').then(r => r.json()),
           fetch('/api/schedules').then(r => r.json()),
-          fetch('/api/workflows').then(r => r.json()),
+          fetch('/api/spells').then(r => r.json()),
           fetch('/api/memory/stats').then(r => r.json()),
         ]);
         renderStatus(s);

--- a/src/modules/spells/__tests__/pause-resume.test.ts
+++ b/src/modules/spells/__tests__/pause-resume.test.ts
@@ -155,7 +155,7 @@ describe('Serialization roundtrip', () => {
     await persistPausedState(originalState, memory);
 
     // Read back
-    const raw = await memory.read('workflow-paused', 'wf-serial-test');
+    const raw = await memory.read('spell-paused', 'wf-serial-test');
     const reconstructed = raw as typeof originalState;
 
     expect(reconstructed.workflowId).toBe('wf-serial-test');
@@ -204,7 +204,7 @@ describe('resumeWorkflow — errors', () => {
     expect(result.success).toBe(false);
     expect(result.errors[0].message).toContain('expired');
     // State should be cleaned up
-    expect(await memory.read('workflow-paused', 'wf-stale-test')).toBeNull();
+    expect(await memory.read('spell-paused', 'wf-stale-test')).toBeNull();
   });
 });
 
@@ -229,7 +229,7 @@ describe('cleanupStalePaused', () => {
     const cleaned = await cleanupStalePaused(memory);
 
     expect(cleaned).toBe(1);
-    expect(await memory.read('workflow-paused', 'wf-stale')).toBeNull();
-    expect(await memory.read('workflow-paused', 'wf-fresh')).not.toBeNull();
+    expect(await memory.read('spell-paused', 'wf-stale')).toBeNull();
+    expect(await memory.read('spell-paused', 'wf-fresh')).not.toBeNull();
   });
 });

--- a/src/modules/spells/src/core/runner.ts
+++ b/src/modules/spells/src/core/runner.ts
@@ -177,7 +177,7 @@ export class SpellCaster {
 
     try {
     await this.storeProgress(workflowId, 'running', 0, definition.steps.length, {
-      workflowName: definition.name, startedAt: startTime, context,
+      spellName: definition.name, startedAt: startTime, context,
     });
 
     const stepIndex = new Map<string, number>();
@@ -268,7 +268,7 @@ export class SpellCaster {
       // Fire onStepComplete for every step (success, failure, cancelled)
       console.log(`[workflow] Step ${i + 1}/${definition.steps.length}: ${result.status} "${step.id}" (${result.duration}ms)${result.error ? ' — ' + result.error.slice(0, 200) : ''}`);
       await this.storeProgress(workflowId, 'running', stepResults.length, definition.steps.length, {
-        workflowName: definition.name, startedAt: startTime, steps: stepResults, context,
+        spellName: definition.name, startedAt: startTime, steps: stepResults, context,
       });
       try { options.onStepComplete?.(result, i, definition.steps.length); } catch { /* safe */ }
 
@@ -296,7 +296,7 @@ export class SpellCaster {
 
     const finalStatus = cancelled ? 'cancelled' : errors.length > 0 ? 'failed' : 'completed';
     await this.storeProgress(workflowId, finalStatus, stepResults.length, definition.steps.length, {
-      workflowName: definition.name, startedAt: startTime, errors, steps: stepResults, context,
+      spellName: definition.name, startedAt: startTime, errors, steps: stepResults, context,
     });
 
     const outputs: Record<string, unknown> = {};
@@ -351,14 +351,14 @@ export class SpellCaster {
 
   private async storeProgress(
     wfId: string, status: string, done: number, total: number,
-    extra?: { workflowName?: string; startedAt?: number; errors?: WorkflowError[]; steps?: StepResult[]; context?: FloRunContext },
+    extra?: { spellName?: string; startedAt?: number; errors?: WorkflowError[]; steps?: StepResult[]; context?: FloRunContext },
   ) {
     try {
       const now = Date.now();
       const record: Record<string, unknown> = {
         status, completedSteps: done, totalSteps: total, updatedAt: new Date().toISOString(),
       };
-      if (extra?.workflowName) record.workflowName = extra.workflowName;
+      if (extra?.spellName) record.spellName = extra.spellName;
       if (extra?.context) record.context = extra.context;
       if (extra?.startedAt) {
         record.startedAt = extra.startedAt;
@@ -385,9 +385,9 @@ export class SpellCaster {
     }
   }
 
-  private async failureResult(workflowId: string, startTime: number, errors: WorkflowError[], workflowName?: string): Promise<WorkflowResult> {
+  private async failureResult(workflowId: string, startTime: number, errors: WorkflowError[], spellName?: string): Promise<WorkflowResult> {
     await this.storeProgress(workflowId, 'failed', 0, 0, {
-      workflowName, startedAt: startTime, errors,
+      spellName, startedAt: startTime, errors,
     });
     return { workflowId, success: false, steps: [], outputs: {}, errors,
       duration: Date.now() - startTime, cancelled: false };

--- a/src/modules/spells/src/factory/pause-resume.ts
+++ b/src/modules/spells/src/factory/pause-resume.ts
@@ -1,7 +1,7 @@
 /**
- * Workflow Pause/Resume
+ * Spell Pause/Resume
  *
- * Serializes workflow execution state to memory for cross-conversation
+ * Serializes spell execution state to memory for cross-conversation
  * survival, and reconstructs it for resumption.
  */
 
@@ -42,7 +42,9 @@ export interface ResumeOptions {
   readonly memory?: MemoryAccessor;
 }
 
-const PAUSE_NAMESPACE = 'workflow-paused';
+const PAUSE_NAMESPACE = 'spell-paused';
+/** Legacy namespace — checked for migration from pre-spell terminology. */
+const LEGACY_PAUSE_NAMESPACE = 'workflow-paused';
 const DEFAULT_STALE_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours
 
 // ============================================================================
@@ -96,7 +98,17 @@ export async function resumeWorkflow(
   options: ResumeOptions = {},
 ): Promise<WorkflowResult> {
   const memory = options.memory ?? noopMemory;
-  const raw = await memory.read(PAUSE_NAMESPACE, workflowId);
+  let raw = await memory.read(PAUSE_NAMESPACE, workflowId);
+
+  // Migrate from legacy namespace if not found in new one
+  if (!raw) {
+    raw = await memory.read(LEGACY_PAUSE_NAMESPACE, workflowId);
+    if (raw) {
+      // Migrate: write to new namespace, clear legacy
+      await memory.write(PAUSE_NAMESPACE, workflowId, raw);
+      await memory.write(LEGACY_PAUSE_NAMESPACE, workflowId, null);
+    }
+  }
 
   if (!raw) {
     return {
@@ -104,7 +116,7 @@ export async function resumeWorkflow(
       success: false,
       steps: [],
       outputs: {},
-      errors: [{ code: 'PAUSED_STATE_NOT_FOUND', message: `No paused state found for workflow "${workflowId}"` }],
+      errors: [{ code: 'PAUSED_STATE_NOT_FOUND', message: `No paused state found for spell "${workflowId}"` }],
       duration: 0,
       cancelled: false,
     };
@@ -188,15 +200,25 @@ export async function resumeWorkflow(
  * Remove stale paused workflows. Returns number of cleaned entries.
  */
 export async function cleanupStalePaused(memory: MemoryAccessor): Promise<number> {
-  const results = await memory.search(PAUSE_NAMESPACE, '');
+  // Clean both current and legacy namespaces
+  const [currentResults, legacyResults] = await Promise.all([
+    memory.search(PAUSE_NAMESPACE, ''),
+    memory.search(LEGACY_PAUSE_NAMESPACE, '').catch(() => []),
+  ]);
   let cleaned = 0;
 
-  for (const entry of results) {
-    const state = entry.value as PausedState | undefined;
+  // Tag entries with their source namespace to avoid redundant writes
+  const tagged: Array<{ ns: string; value: unknown }> = [
+    ...currentResults.map(e => ({ ns: PAUSE_NAMESPACE, value: e.value })),
+    ...legacyResults.map(e => ({ ns: LEGACY_PAUSE_NAMESPACE, value: e.value })),
+  ];
+
+  for (const { ns, value } of tagged) {
+    const state = value as PausedState | undefined;
     if (state?.pausedAt && state?.staleAfterMs) {
       const pausedTime = new Date(state.pausedAt).getTime();
       if (Date.now() - pausedTime > state.staleAfterMs) {
-        await memory.write(PAUSE_NAMESPACE, state.workflowId, null);
+        await memory.write(ns, state.workflowId, null);
         cleaned++;
       }
     }

--- a/src/modules/spells/src/types/runner.types.ts
+++ b/src/modules/spells/src/types/runner.types.ts
@@ -1,7 +1,7 @@
 /**
- * Workflow Runner Types
+ * Spell Runner Types
  *
- * Types for the sequential workflow executor.
+ * Types for the sequential spell executor.
  */
 
 import type { StepOutput, ValidationError, MofloLevel, PrerequisiteResult } from './step-command.types.js';
@@ -99,18 +99,18 @@ export interface DryRunResult {
 // ============================================================================
 
 export interface FloRunContext {
-  /** Workflow type: ticket, epic, workflow, research, new-ticket */
-  readonly type: 'ticket' | 'epic' | 'workflow' | 'research' | 'new-ticket';
+  /** Run type: ticket, epic, spell, research, new-ticket */
+  readonly type: 'ticket' | 'epic' | 'spell' | 'research' | 'new-ticket';
   /** Human-readable display label, e.g. "#350 — Replace zod with valibot" */
   readonly label: string;
   /** GitHub issue number (if applicable) */
   readonly issueNumber?: number;
   /** GitHub issue title (if applicable) */
   readonly issueTitle?: string;
-  /** Workflow name for -wf runs */
-  readonly workflowName?: string;
+  /** Spell name for -wf runs */
+  readonly spellName?: string;
   /** Positional args for -wf runs */
-  readonly workflowArgs?: string[];
+  readonly spellArgs?: string[];
   /** Execution mode badge */
   readonly execMode?: 'normal' | 'swarm' | 'hive';
   /** Epic story progress: [completed, total] */


### PR DESCRIPTION
## Summary
- Rename workflow → spell across dashboard UI, API routes (`/api/workflows` → `/api/spells`), FloRunContext type, and runner stored records
- Migrate pause-resume namespace from `workflow-paused` to `spell-paused` with automatic legacy fallback migration
- Dashboard HTML backward-compat reads both `spellName` and `workflowName` from stored records

## Changes
- **runner.types.ts**: FloRunContext `type: 'workflow'` → `'spell'`, `workflowName` → `spellName`, `workflowArgs` → `spellArgs`
- **runner.ts**: `storeProgress`/`failureResult` store `spellName` instead of `workflowName`
- **daemon-dashboard.ts**: API route `/api/spells`, `handleSpells`, `buildFloRunContext` opts, `storeFloRunRecord`, dashboard HTML labels
- **pause-resume.ts**: `PAUSE_NAMESPACE` → `'spell-paused'` with `LEGACY_PAUSE_NAMESPACE` migration on first access; cleanup tracks source namespace
- **Tests**: Updated dashboard and pause-resume tests for new terminology

## Test plan
- [x] All 25 daemon-dashboard tests pass
- [x] All 7 pause-resume tests pass
- [x] Full spells + cli test suite: 848 tests pass
- [x] Legacy namespace migration verified (read-fallback-then-migrate pattern)
- [x] /simplify review completed — fixed cleanup efficiency

Closes #374

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)