### PR TITLE
refactor(output): update user-facing strings for spell terminology (#376)

### DIFF
--- a/moflo.yaml
+++ b/moflo.yaml
@@ -41,7 +41,7 @@ tests:
   exclude: [node_modules, coverage, dist]
   namespace: tests
 
-# Workflow gates (enforced via Claude Code hooks)
+# Spell gates (enforced via Claude Code hooks)
 gates:
   memory_first: true
   task_create_first: true
@@ -65,7 +65,7 @@ hooks:
   post_edit: true              # Record edit outcomes, train neural patterns
   pre_task: true               # Get agent routing before task spawn
   post_task: true              # Record task results for learning
-  gate: true                   # Workflow gate enforcement (memory-first, task-create-first)
+  gate: true                   # Spell gate enforcement (memory-first, task-create-first)
   route: true                  # Intelligent task routing on each prompt
   stop_hook: true              # Session-end persistence and metric export
   session_restore: true        # Restore session state on start

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -22,7 +22,7 @@ npm install && npm run build && npm test
 | `@moflo/embeddings` | `modules/embeddings/` | Vector embeddings (sql.js, HNSW) |
 | `@moflo/neural` | `modules/neural/` | Neural patterns (SONA) |
 | `@moflo/plugins` | `modules/plugins/` | Plugin system |
-| `@moflo/spells` | `modules/spells/` | Spell engine (workflows) |
+| `@moflo/spells` | `modules/spells/` | Spell engine |
 
 ## Code Quality
 

--- a/src/modules/cli/__tests__/doctor-checks-deep.test.ts
+++ b/src/modules/cli/__tests__/doctor-checks-deep.test.ts
@@ -38,13 +38,13 @@ describe('doctor-checks-deep', () => {
   describe('checkWorkflowExecution', () => {
     it('should return a HealthCheck object', async () => {
       const result = await checkWorkflowExecution();
-      expect(result).toHaveProperty('name', 'Workflow Execution');
+      expect(result).toHaveProperty('name', 'Spell Execution');
       expect(result).toHaveProperty('status');
       expect(result).toHaveProperty('message');
       expect(['pass', 'warn', 'fail']).toContain(result.status);
     });
 
-    it('should pass when workflow engine is built', async () => {
+    it('should pass when spell engine is built', async () => {
       const result = await checkWorkflowExecution();
       // In the dev repo with a successful build, this should pass
       if (result.status === 'pass') {
@@ -88,7 +88,7 @@ describe('doctor-checks-deep', () => {
   describe('checkMcpWorkflowIntegration', () => {
     it('should return a HealthCheck object', async () => {
       const result = await checkMcpWorkflowIntegration();
-      expect(result).toHaveProperty('name', 'MCP Workflow Integration');
+      expect(result).toHaveProperty('name', 'MCP Spell Integration');
       expect(result).toHaveProperty('status');
       expect(result).toHaveProperty('message');
       expect(['pass', 'warn', 'fail']).toContain(result.status);

--- a/src/modules/cli/__tests__/services/engine-loader.test.ts
+++ b/src/modules/cli/__tests__/services/engine-loader.test.ts
@@ -47,7 +47,7 @@ describe('engine-loader', () => {
 
     const mod = await import('../../src/services/engine-loader.js');
     await expect(mod.loadSpellEngine()).rejects.toThrow(
-      'Workflow engine not available',
+      'Spell engine not available',
     );
   });
 

--- a/src/modules/cli/src/commands/doctor-checks-deep.ts
+++ b/src/modules/cli/src/commands/doctor-checks-deep.ts
@@ -191,11 +191,11 @@ export async function checkSubagentHealth(): Promise<HealthCheck> {
 }
 
 // ============================================================================
-// 2. Workflow Execution Check
+// 2. Spell Execution Check
 // ============================================================================
 
 /**
- * Runs a minimal workflow (single echo step) through the full engine pipeline:
+ * Runs a minimal spell (single echo step) through the full engine pipeline:
  * parse → validate → execute → collect result.
  */
 export async function checkWorkflowExecution(): Promise<HealthCheck> {
@@ -204,12 +204,12 @@ export async function checkWorkflowExecution(): Promise<HealthCheck> {
       'src/modules/spells/dist/factory/runner-factory.js',
     );
     if (!modulePath) {
-      return { name: 'Workflow Execution', status: 'warn', message: 'Workflow runner-factory not found', fix: 'npm run build' };
+      return { name: 'Spell Execution', status: 'warn', message: 'Spell runner-factory not found', fix: 'npm run build' };
     }
 
     const { runWorkflowFromContent } = await import(toImportUrl(modulePath));
     if (typeof runWorkflowFromContent !== 'function') {
-      return { name: 'Workflow Execution', status: 'fail', message: 'runWorkflowFromContent is not a function', fix: 'npm run build' };
+      return { name: 'Spell Execution', status: 'fail', message: 'runWorkflowFromContent is not a function', fix: 'npm run build' };
     }
 
     const minimalWorkflow = `
@@ -229,20 +229,20 @@ steps:
     });
 
     if (!result) {
-      return { name: 'Workflow Execution', status: 'fail', message: 'Runner returned no result' };
+      return { name: 'Spell Execution', status: 'fail', message: 'Runner returned no result' };
     }
 
     if (result.success) {
       const stepCount = result.steps?.length ?? 0;
       const duration = result.duration != null ? `${result.duration}ms` : 'unknown';
-      return { name: 'Workflow Execution', status: 'pass', message: `Probe OK (${stepCount} step, ${duration})` };
+      return { name: 'Spell Execution', status: 'pass', message: `Probe OK (${stepCount} step, ${duration})` };
     }
 
     const errMsg = result.errors?.map((e: { message: string }) => e.message).join('; ') || 'unknown error';
-    return { name: 'Workflow Execution', status: 'fail', message: `Probe failed: ${errMsg}`, fix: 'npm run build' };
+    return { name: 'Spell Execution', status: 'fail', message: `Probe failed: ${errMsg}`, fix: 'npm run build' };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { name: 'Workflow Execution', status: 'fail', message: `Workflow engine error: ${msg}`, fix: 'npm run build' };
+    return { name: 'Spell Execution', status: 'fail', message: `Spell engine error: ${msg}`, fix: 'npm run build' };
   }
 }
 
@@ -400,11 +400,11 @@ export async function checkHookExecution(): Promise<HealthCheck> {
 }
 
 // ============================================================================
-// 5. MCP Workflow Integration Check
+// 5. MCP Spell Integration Check
 // ============================================================================
 
 /**
- * Verifies that the MCP workflow tools invoke the real engine via runner-bridge.
+ * Verifies that the MCP spell tools invoke the real engine via runner-bridge.
  * Calls bridgeExecuteWorkflow() with a minimal definition and checks for real
  * bash step stdout, not mock/simulated output.
  */
@@ -414,12 +414,12 @@ export async function checkMcpWorkflowIntegration(): Promise<HealthCheck> {
       'src/modules/spells/dist/factory/runner-bridge.js',
     );
     if (!bridgePath) {
-      return { name: 'MCP Workflow Integration', status: 'warn', message: 'runner-bridge not found', fix: 'npm run build' };
+      return { name: 'MCP Spell Integration', status: 'warn', message: 'runner-bridge not found', fix: 'npm run build' };
     }
 
     const bridge = await import(toImportUrl(bridgePath));
     if (typeof bridge.bridgeExecuteWorkflow !== 'function') {
-      return { name: 'MCP Workflow Integration', status: 'fail', message: 'bridgeExecuteWorkflow is not a function', fix: 'npm run build' };
+      return { name: 'MCP Spell Integration', status: 'fail', message: 'bridgeExecuteWorkflow is not a function', fix: 'npm run build' };
     }
 
     const definition = {
@@ -438,12 +438,12 @@ export async function checkMcpWorkflowIntegration(): Promise<HealthCheck> {
     const result = await bridge.bridgeExecuteWorkflow(definition, {});
 
     if (!result) {
-      return { name: 'MCP Workflow Integration', status: 'fail', message: 'Bridge returned no result' };
+      return { name: 'MCP Spell Integration', status: 'fail', message: 'Bridge returned no result' };
     }
 
     if (!result.success) {
       const errMsg = result.errors?.map((e: { message: string }) => e.message).join('; ') || 'unknown';
-      return { name: 'MCP Workflow Integration', status: 'fail', message: `Bridge execution failed: ${errMsg}`, fix: 'npm run build' };
+      return { name: 'MCP Spell Integration', status: 'fail', message: `Bridge execution failed: ${errMsg}`, fix: 'npm run build' };
     }
 
     // Verify real step output — if MCP tools were still using mocks, there
@@ -455,18 +455,18 @@ export async function checkMcpWorkflowIntegration(): Promise<HealthCheck> {
 
     if (typeof stdout === 'string' && stdout.includes('mcp-bridge-ok')) {
       const duration = result.duration != null ? `${result.duration}ms` : 'unknown';
-      return { name: 'MCP Workflow Integration', status: 'pass', message: `Bridge → engine OK, real stdout captured (${duration})` };
+      return { name: 'MCP Spell Integration', status: 'pass', message: `Bridge → engine OK, real stdout captured (${duration})` };
     }
 
     return {
-      name: 'MCP Workflow Integration',
+      name: 'MCP Spell Integration',
       status: 'fail',
-      message: 'Bridge returned success but no real stdout — MCP tools may not invoke the engine',
+      message: 'Bridge returned success but no real stdout — MCP spell tools may not invoke the engine',
       fix: 'Ensure spell-tools.ts imports from runner-bridge.ts',
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { name: 'MCP Workflow Integration', status: 'fail', message: `MCP workflow bridge error: ${msg}`, fix: 'npm run build' };
+    return { name: 'MCP Spell Integration', status: 'fail', message: `MCP spell bridge error: ${msg}`, fix: 'npm run build' };
   }
 }
 

--- a/src/modules/cli/src/commands/doctor.ts
+++ b/src/modules/cli/src/commands/doctor.ts
@@ -1300,13 +1300,13 @@ export const doctorCommand: Command = {
       }
     };
 
-    // Check Workflow Engine health — validates core modules, built output, and step commands
+    // Check Spell Engine health — validates core modules, built output, and step commands
     async function checkSpellEngine(): Promise<HealthCheck> {
       try {
         // Resolve relative to the moflo package root (works in both dev and consumer)
         const mofloRoot = getMofloRoot();
         if (!mofloRoot) {
-          return { name: 'Workflow Engine', status: 'warn', message: 'Could not locate moflo package root', fix: 'npm run build' };
+          return { name: 'Spell Engine', status: 'warn', message: 'Could not locate moflo package root', fix: 'npm run build' };
         }
 
         // Prefer compiled dist/, fall back to src/ in dev repo
@@ -1316,7 +1316,7 @@ export const doctorCommand: Command = {
         const hasSrcDir = existsSync(srcDir);
 
         if (!hasDistDir && !hasSrcDir) {
-          return { name: 'Workflow Engine', status: 'warn', message: 'Workflow engine not found', fix: 'npm run build' };
+          return { name: 'Spell Engine', status: 'warn', message: 'Spell engine not found', fix: 'npm run build' };
         }
 
         // Core compiled modules that must exist
@@ -1347,7 +1347,7 @@ export const doctorCommand: Command = {
 
         if (missing.length > 0) {
           return {
-            name: 'Workflow Engine',
+            name: 'Spell Engine',
             status: 'warn',
             message: `Missing modules: ${missing.join(', ')}`,
             fix: 'npm run build',
@@ -1358,7 +1358,7 @@ export const doctorCommand: Command = {
         const commandsDir = join(baseDir, 'commands');
         const hasCommands = existsSync(commandsDir);
 
-        // Check for workflow definition loaders
+        // Check for spell definition loaders
         const loadersDir = join(baseDir, 'loaders');
         const hasLoaders = existsSync(loadersDir);
 
@@ -1372,12 +1372,12 @@ export const doctorCommand: Command = {
         if (hasIndex) parts.push('index');
 
         return {
-          name: 'Workflow Engine',
+          name: 'Spell Engine',
           status: 'pass',
           message: parts.join(', '),
         };
       } catch {
-        return { name: 'Workflow Engine', status: 'warn', message: 'Unable to check workflow engine' };
+        return { name: 'Spell Engine', status: 'warn', message: 'Unable to check spell engine' };
       }
     }
 

--- a/src/modules/cli/src/commands/epic.ts
+++ b/src/modules/cli/src/commands/epic.ts
@@ -140,7 +140,7 @@ async function runEpic(
 
   if (dryRun) {
     console.log('[epic] Dry-run mode — showing execution plan:');
-    console.log(`[epic] Workflow: ${strategy}`);
+    console.log(`[epic] Strategy: ${strategy}`);
     console.log(`[epic] Args: ${JSON.stringify(args, null, 2)}`);
     console.log('[epic] Stories would be processed in order:');
     for (const num of storyNumbers) {
@@ -154,9 +154,9 @@ async function runEpic(
       });
 
       if (result.success) {
-        console.log('[epic] Dry-run: workflow is valid');
+        console.log('[epic] Dry-run: spell is valid');
       } else {
-        console.log('[epic] Dry-run: workflow has validation errors:');
+        console.log('[epic] Dry-run: spell has validation errors:');
         for (const err of result.errors) {
           console.log(`  - ${err.message}`);
           const details = (err as Record<string, unknown>).details;
@@ -175,7 +175,7 @@ async function runEpic(
   }
 
   // 6. Execute workflow
-  console.log(`[epic] Executing ${strategy} workflow...`);
+  console.log(`[epic] Casting ${strategy} spell...`);
   let stepCount = 0;
 
   try {
@@ -258,7 +258,7 @@ async function showStatus(epicNumber: string): Promise<CommandResult> {
     return { success: false, message: 'Usage: flo epic status <epic-number>' };
   }
   console.log(`[epic] Status for epic #${epicNumber}:`);
-  console.log('[epic] Reading from workflow memory...');
+  console.log('[epic] Reading from spell memory...');
 
   try {
     const result = await runEpicWorkflow(
@@ -364,7 +364,7 @@ function getRemediation(errorMessage: string): string | undefined {
 
 const epicCommand: Command = {
   name: 'epic',
-  description: 'Epic orchestrator — runs GitHub epics through workflow engine',
+  description: 'Epic orchestrator — runs GitHub epics through spell engine',
   options: [],
   examples: [
     { command: 'flo epic 42', description: 'Execute epic (default: run with single-branch strategy)' },
@@ -383,7 +383,7 @@ const epicCommand: Command = {
       console.log('');
       console.log('Commands:');
       console.log('  <issue-number>           Execute epic (shorthand for "run")');
-      console.log('  run <issue-number>       Execute a GitHub epic via workflow engine');
+      console.log('  run <issue-number>       Execute a GitHub epic via spell engine');
       console.log('  status <epic-number>     Check epic progress');
       console.log('  reset <epic-number>      Reset epic state for re-run');
       console.log('');

--- a/src/modules/cli/src/commands/gate.ts
+++ b/src/modules/cli/src/commands/gate.ts
@@ -45,7 +45,7 @@ const gateCommand: Command = {
       console.log('  record-memory-searched Record memory search');
       console.log('  check-bash-memory      Detect memory search in Bash commands');
       console.log('  prompt-reminder        Reset memory gate, show context bracket');
-      console.log('  session-reset          Reset all workflow state');
+      console.log('  session-reset          Reset all spell state');
       return { success: true };
     }
 

--- a/src/modules/cli/src/epic/runner-adapter.ts
+++ b/src/modules/cli/src/epic/runner-adapter.ts
@@ -1,7 +1,7 @@
 /**
  * Epic Workflow Runner Adapter
  *
- * Bridges the CLI epic command to the workflow engine without direct
+ * Bridges the CLI epic command to the spell engine without direct
  * cross-package imports (avoids tsconfig rootDir issues).
  *
  * Story #197: Thin adapter for running workflow YAML from epic command.
@@ -36,7 +36,7 @@ export interface EpicRunOptions {
 let memoryAccessor: Awaited<ReturnType<typeof createDashboardMemoryAccessor>> | null = null;
 
 /**
- * Run a workflow YAML string via the workflow engine.
+ * Run a spell YAML string via the spell engine.
  *
  * Uses the shared engine loader (services/engine-loader.ts) which caches the
  * dynamically imported module. The workflows package must be built first.
@@ -52,10 +52,10 @@ export async function runEpicWorkflow(
   if (!memoryAccessor) {
     try {
       memoryAccessor = await createDashboardMemoryAccessor();
-      console.log('[epic] Memory accessor ready — workflow progress will be persisted');
+      console.log('[epic] Memory accessor ready — spell progress will be persisted');
     } catch (err) {
       console.warn(`[epic] ⚠ Dashboard memory unavailable: ${(err as Error).message ?? err}`);
-      console.warn('[epic] ⚠ Workflow executions will NOT appear in the dashboard');
+      console.warn('[epic] ⚠ Spell executions will NOT appear in the dashboard');
     }
   }
 

--- a/src/modules/cli/src/services/agentic-flow-bridge.ts
+++ b/src/modules/cli/src/services/agentic-flow-bridge.ts
@@ -53,7 +53,7 @@ export function getRouter() {
 }
 
 /**
- * Load the Orchestration module (workflow engine).
+ * Load the Orchestration module (spell engine).
  * Returns null if agentic-flow is not installed.
  */
 export function getOrchestration() {

--- a/src/modules/cli/src/services/claim-service.ts
+++ b/src/modules/cli/src/services/claim-service.ts
@@ -1,7 +1,7 @@
 /**
  * V3 Collaborative Issue Claims Service
  *
- * Implements ADR-016: Collaborative Issue Claims for Human-Agent Workflows
+ * Implements ADR-016: Collaborative Issue Claims for Human-Agent Spells
  *
  * Features:
  * - Issue claiming/releasing for humans and agents

--- a/src/modules/cli/src/services/daemon-readiness.ts
+++ b/src/modules/cli/src/services/daemon-readiness.ts
@@ -1,5 +1,5 @@
 /**
- * Daemon Readiness Check for Scheduled Workflows
+ * Daemon Readiness Check for Scheduled Spells
  *
  * Lazy three-state flow: only triggered when creating schedules.
  * 1. Is daemon running? If not, prompt to start it.
@@ -35,7 +35,7 @@ export interface DaemonReadinessOptions {
 }
 
 /**
- * Ensure the daemon is ready for scheduled workflow execution.
+ * Ensure the daemon is ready for scheduled spell execution.
  *
  * Checks daemon state and prompts the user to start/install as needed.
  * Always returns — never throws. The caller should create the schedule
@@ -61,7 +61,7 @@ export async function ensureDaemonForScheduling(
   if (!result.daemonRunning) {
     if (options.interactive) {
       const shouldStart = await promptFn(
-        'Scheduled workflows need the daemon. Start it now?',
+        'Scheduled spells need the daemon. Start it now?',
       );
       if (shouldStart) {
         const started = await startFn(resolvedRoot);

--- a/src/modules/cli/src/services/daemon-service.ts
+++ b/src/modules/cli/src/services/daemon-service.ts
@@ -2,7 +2,7 @@
  * OS-Native Daemon Service Registration
  *
  * Registers/removes the moflo daemon as a user-level login service
- * so scheduled workflows survive reboots without Docker.
+ * so scheduled spells survive reboots without Docker.
  *
  * - macOS:   launchd plist in ~/Library/LaunchAgents/
  * - Linux:   systemd --user unit in ~/.config/systemd/user/

--- a/src/modules/cli/src/services/engine-loader.ts
+++ b/src/modules/cli/src/services/engine-loader.ts
@@ -1,5 +1,5 @@
 /**
- * Shared Workflow Engine Loader
+ * Shared Spell Engine Loader
  *
  * Centralizes dynamic import + caching of the @moflo/spells package.
  * Both spell-tools.ts (MCP layer) and runner-adapter.ts (epic runner) use
@@ -23,13 +23,13 @@ import type {
   RegistryOptions,
 } from '../../../../modules/spells/src/registry/workflow-registry.js';
 
-// Re-export workflow types so consumers import from engine-loader (single boundary).
+// Re-export spell types so consumers import from engine-loader (single boundary).
 export type { WorkflowResult };
 export type { SpellDefinition };
 export type { Grimoire };
 
 /**
- * Shape of the dynamically imported workflow engine module.
+ * Shape of the dynamically imported spell engine module.
  *
  * Uses the canonical types from @moflo/spells (type-only, no runtime dep).
  * The actual module is loaded via dynamic import() at runtime.
@@ -61,7 +61,7 @@ let cachedEngine: EngineModule | null = null;
 let pendingImport: Promise<EngineModule> | null = null;
 
 /**
- * Dynamically import the workflow engine, caching after first successful load.
+ * Dynamically import the spell engine, caching after first successful load.
  * Uses a pending-promise guard to prevent duplicate imports under concurrency.
  */
 export async function loadSpellEngine(): Promise<EngineModule> {
@@ -87,7 +87,7 @@ export async function loadSpellEngine(): Promise<EngineModule> {
       return cachedEngine;
     } catch {
       throw new Error(
-        'Workflow engine not available. Run `npm run build` to compile the workflows package.',
+        'Spell engine not available. Run `npm run build` to compile the spells package.',
       );
     } finally {
       pendingImport = null;

--- a/src/modules/cli/src/services/project-root.ts
+++ b/src/modules/cli/src/services/project-root.ts
@@ -2,7 +2,7 @@
  * Project Root Discovery
  *
  * Walks up from cwd to find the nearest directory containing package.json or .git.
- * Extracted from workflow-tools.ts for reuse (#229).
+ * Extracted from spell-tools.ts for reuse (#229).
  */
 
 import { existsSync } from 'node:fs';

--- a/src/modules/cli/src/services/workflow-gate.ts
+++ b/src/modules/cli/src/services/workflow-gate.ts
@@ -1,5 +1,5 @@
 /**
- * Workflow Gate Service
+ * Spell Gate Service
  * Enforces TaskCreate + memory-first patterns before agent spawning
  * and file exploration. Tracks context bracket by interaction count.
  *
@@ -360,7 +360,7 @@ export class WorkflowGateService {
   }
 
   /**
-   * Reset all workflow state (new session).
+   * Reset all spell state (new session).
    */
   sessionReset(): void {
     this.writeState({
@@ -375,7 +375,7 @@ export class WorkflowGateService {
 // ============================================================================
 
 /**
- * Process a workflow gate command from CLI args.
+ * Process a spell gate command from CLI args.
  * Used by hooks.mjs dispatcher.
  */
 export function processGateCommand(command: string, env: Record<string, string | undefined> = process.env): void {

--- a/src/modules/guidance/src/generators.ts
+++ b/src/modules/guidance/src/generators.ts
@@ -710,7 +710,7 @@ function getDefaultAgents(profile: ProjectProfile): AgentDefinition[] {
   agents.push({
     name: 'coordinator',
     type: 'coordinator',
-    description: `Coordinates multi-agent workflows for ${profile.name}`,
+    description: `Coordinates multi-agent spells for ${profile.name}`,
     category: 'core',
     color: '#4A90D9',
     capabilities: ['task-decomposition', 'agent-routing', 'context-management', 'progress-tracking'],
@@ -822,7 +822,7 @@ function getDefaultSkills(profile: ProjectProfile): SkillDefinition[] {
       profile.testCommand || `${profile.packageManager || 'npm'} test`,
       '```',
       '',
-      '## Workflow',
+      '## Spell Workflow',
       '',
       '1. Run the build first to catch type errors',
       '2. Run tests to verify correctness',

--- a/src/modules/shared/src/plugins/official/maestro-plugin.ts
+++ b/src/modules/shared/src/plugins/official/maestro-plugin.ts
@@ -179,11 +179,11 @@ export class MaestroPlugin implements ClaudeFlowPlugin {
   async executeWorkflow(workflowId: string): Promise<OrchestrationResult> {
     const workflow = this.workflows.get(workflowId);
     if (!workflow) {
-      throw new Error(`Workflow not found: ${workflowId}`);
+      throw new Error(`Spell not found: ${workflowId}`);
     }
 
     if (this.activeWorkflows >= this.config.maxConcurrentWorkflows) {
-      throw new Error('Maximum concurrent workflows reached');
+      throw new Error('Maximum concurrent spells reached');
     }
 
     const startTime = Date.now();
@@ -248,7 +248,7 @@ export class MaestroPlugin implements ClaudeFlowPlugin {
   async resumeWorkflow(workflowId: string): Promise<OrchestrationResult> {
     const workflow = this.workflows.get(workflowId);
     if (!workflow || workflow.status !== 'paused') {
-      throw new Error('Workflow cannot be resumed');
+      throw new Error('Spell cannot be resumed');
     }
 
     // Restore from checkpoint and continue

--- a/src/modules/spells/__tests__/moflo-levels.test.ts
+++ b/src/modules/spells/__tests__/moflo-levels.test.ts
@@ -241,7 +241,7 @@ describe('mofloLevel validation', () => {
     });
     const result = validateSpellDefinition(def);
     expect(result.valid).toBe(false);
-    expect(result.errors.some(e => e.message.includes('exceeds workflow-level'))).toBe(true);
+    expect(result.errors.some(e => e.message.includes('exceeds spell-level'))).toBe(true);
   });
 
   it('should allow step level equal to spell level', () => {
@@ -274,7 +274,7 @@ describe('mofloLevel validation', () => {
     });
     const result = validateSpellDefinition(def);
     expect(result.valid).toBe(false);
-    expect(result.errors.some(e => e.message.includes('exceeds workflow-level'))).toBe(true);
+    expect(result.errors.some(e => e.message.includes('exceeds spell-level'))).toBe(true);
   });
 });
 

--- a/src/modules/spells/__tests__/schema.test.ts
+++ b/src/modules/spells/__tests__/schema.test.ts
@@ -1,5 +1,5 @@
 /**
- * Workflow Definition Schema Tests
+ * Spell Definition Schema Tests
  *
  * Story #103: YAML/JSON parsing, validation, and argument resolution.
  */
@@ -82,7 +82,7 @@ describe('parseJson', () => {
   });
 
   it('should reject malformed JSON', () => {
-    expect(() => parseJson('not json', 'bad.json')).toThrow('Invalid workflow JSON');
+    expect(() => parseJson('not json', 'bad.json')).toThrow('Invalid spell JSON');
   });
 
   it('should reject non-object JSON', () => {

--- a/src/modules/spells/__tests__/tool-registry.test.ts
+++ b/src/modules/spells/__tests__/tool-registry.test.ts
@@ -38,7 +38,7 @@ describe('SpellConnectorRegistry', () => {
   it('throws on duplicate registration', () => {
     registry.register(makeConnector('http'));
     expect(() => registry.register(makeConnector('http'))).toThrow(
-      'Workflow connector "http" is already registered'
+      'Spell connector "http" is already registered'
     );
   });
 

--- a/src/modules/spells/src/core/runner.ts
+++ b/src/modules/spells/src/core/runner.ts
@@ -203,7 +203,7 @@ export class SpellCaster {
       }
 
       const step = definition.steps[i];
-      console.log(`[workflow] Step ${i + 1}/${definition.steps.length}: starting "${step.id}" [${step.type}]`);
+      console.log(`[spell] Step ${i + 1}/${definition.steps.length}: starting "${step.id}" [${step.type}]`);
       let result = await this.runStep(step, state, i);
       const resultIdx = stepResults.length;
       stepResults.push(result);
@@ -266,7 +266,7 @@ export class SpellCaster {
       }
 
       // Fire onStepComplete for every step (success, failure, cancelled)
-      console.log(`[workflow] Step ${i + 1}/${definition.steps.length}: ${result.status} "${step.id}" (${result.duration}ms)${result.error ? ' — ' + result.error.slice(0, 200) : ''}`);
+      console.log(`[spell] Step ${i + 1}/${definition.steps.length}: ${result.status} "${step.id}" (${result.duration}ms)${result.error ? ' — ' + result.error.slice(0, 200) : ''}`);
       await this.storeProgress(workflowId, 'running', stepResults.length, definition.steps.length, {
         spellName: definition.name, startedAt: startTime, steps: stepResults, context,
       });
@@ -381,7 +381,7 @@ export class SpellCaster {
       }
       await this.memory.write('tasklist', wfId, record);
     } catch (err) {
-      console.warn(`[workflow] storeProgress(${wfId}, ${status}) failed: ${(err as Error).message ?? err}`);
+      console.warn(`[spell] storeProgress(${wfId}, ${status}) failed: ${(err as Error).message ?? err}`);
     }
   }
 

--- a/src/modules/spells/src/index.ts
+++ b/src/modules/spells/src/index.ts
@@ -1,9 +1,9 @@
 /**
  * @moflo/spells
  *
- * Generalized Workflow Engine for MoFlo V4.
+ * Generalized Spell Engine for MoFlo V4.
  *
- * Provides a pluggable, YAML/JSON-defined workflow system where every step type
+ * Provides a pluggable, YAML/JSON-defined spell system where every step type
  * implements a StepCommand interface — testable, reusable, and extensible.
  *
  * @packageDocumentation

--- a/src/modules/spells/src/registry/connector-registry.ts
+++ b/src/modules/spells/src/registry/connector-registry.ts
@@ -80,7 +80,7 @@ export class SpellConnectorRegistry {
 
     if (this.connectors.has(connector.name)) {
       throw new Error(
-        `Workflow connector "${connector.name}" is already registered`
+        `Spell connector "${connector.name}" is already registered`
       );
     }
 

--- a/src/modules/spells/src/scheduler/index.ts
+++ b/src/modules/spells/src/scheduler/index.ts
@@ -1,7 +1,7 @@
 /**
  * Scheduler Module
  *
- * Scheduled workflow execution: cron, interval, and one-time scheduling.
+ * Scheduled spell execution: cron, interval, and one-time scheduling.
  */
 
 export type {

--- a/src/modules/spells/src/schema/parser.ts
+++ b/src/modules/spells/src/schema/parser.ts
@@ -1,5 +1,5 @@
 /**
- * Workflow Definition Parser
+ * Spell Definition Parser
  *
  * Parses YAML/JSON into SpellDefinition objects.
  * NOTE: Parsed output is UNVALIDATED — always call validateSpellDefinition() after parsing.
@@ -16,7 +16,7 @@ import { sanitizeObjectKeys } from '../core/interpolation.js';
 export function parseYaml(content: string, sourceFile?: string): ParsedWorkflow {
   const raw = yamlLoad(content, { schema: JSON_SCHEMA });
   if (!raw || typeof raw !== 'object') {
-    throw new Error(`Invalid workflow YAML${sourceFile ? ` in ${sourceFile}` : ''}: expected an object`);
+    throw new Error(`Invalid spell YAML${sourceFile ? ` in ${sourceFile}` : ''}: expected an object`);
   }
   const sanitized = sanitizeObjectKeys(raw) as Record<string, unknown>;
   return {
@@ -36,11 +36,11 @@ export function parseJson(content: string, sourceFile?: string): ParsedWorkflow 
     raw = JSON.parse(content);
   } catch (e) {
     throw new Error(
-      `Invalid workflow JSON${sourceFile ? ` in ${sourceFile}` : ''}: ${(e as Error).message}`
+      `Invalid spell JSON${sourceFile ? ` in ${sourceFile}` : ''}: ${(e as Error).message}`
     );
   }
   if (!raw || typeof raw !== 'object') {
-    throw new Error(`Invalid workflow JSON${sourceFile ? ` in ${sourceFile}` : ''}: expected an object`);
+    throw new Error(`Invalid spell JSON${sourceFile ? ` in ${sourceFile}` : ''}: expected an object`);
   }
   const sanitized = sanitizeObjectKeys(raw) as Record<string, unknown>;
   return {
@@ -51,7 +51,7 @@ export function parseJson(content: string, sourceFile?: string): ParsedWorkflow 
 }
 
 /**
- * Parse a workflow file by detecting format from extension or content.
+ * Parse a spell file by detecting format from extension or content.
  */
 export function parseWorkflow(content: string, sourceFile?: string): ParsedWorkflow {
   if (sourceFile) {

--- a/src/modules/spells/src/schema/validator.ts
+++ b/src/modules/spells/src/schema/validator.ts
@@ -187,7 +187,7 @@ function validateSteps(
       } else if (workflowLevel && compareMofloLevels(step.mofloLevel, workflowLevel) > 0) {
         errors.push({
           path: `${path}.mofloLevel`,
-          message: `step mofloLevel "${step.mofloLevel}" exceeds workflow-level "${workflowLevel}" — steps can only narrow, not escalate`,
+          message: `step mofloLevel "${step.mofloLevel}" exceeds spell-level "${workflowLevel}" — steps can only narrow, not escalate`,
         });
       }
     }

--- a/src/modules/spells/src/types/runner.types.ts
+++ b/src/modules/spells/src/types/runner.types.ts
@@ -122,7 +122,7 @@ export interface FloRunContext {
 // ============================================================================
 
 export interface RunnerOptions {
-  /** Caller-specified workflow ID for status correlation. Auto-generated if omitted. */
+  /** Caller-specified spell ID for status correlation. Auto-generated if omitted. */
   readonly workflowId?: string;
 
   /** Default timeout per step in milliseconds (default: 300000 — 5 min). */
@@ -140,16 +140,16 @@ export interface RunnerOptions {
   /** Literal credential values to redact from step output (matched as exact strings). */
   readonly credentialValues?: readonly string[];
 
-  /** Pre-seeded variables for resuming from a paused workflow. */
+  /** Pre-seeded variables for resuming from a paused spell. */
   readonly initialVariables?: Record<string, unknown>;
 
-  /** Current nesting depth for recursive workflow invocation (0 = top-level). */
+  /** Current nesting depth for recursive spell invocation (0 = top-level). */
   readonly nestingDepth?: number;
 
-  /** Maximum nesting depth for recursive workflows (default: 3). */
+  /** Maximum nesting depth for recursive spells (default: 3). */
   readonly maxNestingDepth?: number;
 
-  /** Parent workflow's MoFlo level — child workflows cannot exceed this. */
+  /** Parent spell's MoFlo level — child spells cannot exceed this. */
   readonly parentMofloLevel?: MofloLevel;
 
   /** Human-readable context metadata for dashboard display. */

--- a/src/modules/spells/src/types/step-command.types.ts
+++ b/src/modules/spells/src/types/step-command.types.ts
@@ -101,9 +101,9 @@ export interface CastingContext {
   readonly mofloLevel?: MofloLevel;
   /** Nesting depth for recursive workflow invocations (0 = top-level). */
   readonly nestingDepth?: number;
-  /** Maximum allowed nesting depth for recursive workflows. */
+  /** Maximum allowed nesting depth for recursive spells. */
   readonly maxNestingDepth?: number;
-  /** Workflow connectors accessor — available when a connector registry is configured. */
+  /** Spell connectors accessor — available when a connector registry is configured. */
   readonly tools?: import('./workflow-connector.types.js').ConnectorAccessor;
   /** Capability gateway for structural enforcement (Issue #258, #266 — non-optional). */
   readonly gateway: import('../core/capability-gateway.js').ICapabilityGateway;


### PR DESCRIPTION
## Summary
- Updated all user-facing log messages, error messages, health check names, config comments, and JSDoc from "workflow" to "spell" terminology across 29 files
- Final polish pass for wizard theme epic (#368), following #371-#375
- Key renames: `[workflow]` → `[spell]` log prefix, `Workflow Execution` → `Spell Execution` health checks, `MCP Workflow Integration` → `MCP Spell Integration`, error messages in parser/validator/maestro-plugin

## Test plan
- [x] Unit tests pass (161 tests across 5 affected test suites)
- [x] Build passes (pre-existing playwright errors only)
- [x] `/simplify` review completed — caught 2 missed spots (doctor.ts health check names, doctor-checks-deep.ts line 462)
- [x] Test expectations updated to match new health check names

Closes #376

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)