### PR TITLE
fix: increase timeout for rapid spawn-kill stress test

### DIFF
--- a/tests/bin/process-manager-stress.test.ts
+++ b/tests/bin/process-manager-stress.test.ts
@@ -388,7 +388,7 @@ describe('rapid spawn-kill cycles', () => {
   beforeEach(() => { root = makeTempRoot(); });
   afterEach(() => { cleanTempRoot(root); });
 
-  it('5 rapid cycles of spawn → killAll', () => {
+  it('5 rapid cycles of spawn → killAll', { timeout: 30000 }, () => {
     for (let i = 0; i < 5; i++) {
       const spawned = runPM(root, `
         pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'cycle-a');


### PR DESCRIPTION
## Summary
- Bumps test timeout from default 5s to 30s for the `5 rapid cycles of spawn → killAll` stress test
- The test runs 10 sequential `execFileSync` calls with ESM module loading, which takes 5-10s on Windows
- Known flaky test that commonly disrupts CI flow

## Test plan
- [x] Verified all 29 tests in `process-manager-stress.test.ts` pass
- [x] Full suite: 6864 passed, 0 failures with this fix

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)