### PR TITLE
feat(spells): macOS sandbox-exec integration for bash steps

### DIFF
--- a/src/modules/spells/__tests__/bash-sandbox-exec.test.ts
+++ b/src/modules/spells/__tests__/bash-sandbox-exec.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Bash Command — Sandbox-exec Integration Tests
+ *
+ * Tests that the bash step command correctly integrates with sandbox-exec
+ * wrapping when sandbox is enabled on macOS.
+ *
+ * @see https://github.com/eric-cielo/moflo/issues/410
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CastingContext, StepCapability } from '../src/types/step-command.types.js';
+import type { EffectiveSandbox, SandboxCapability, SandboxConfig } from '../src/core/platform-sandbox.js';
+import { DENY_ALL_GATEWAY, CapabilityGateway } from '../src/core/capability-gateway.js';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+// Mock child_process to intercept spawn calls
+const mockSpawn = vi.fn();
+vi.mock('node:child_process', () => ({
+  exec: vi.fn(),
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+// Mock platform
+vi.mock('node:os', () => ({
+  platform: vi.fn(() => 'darwin'),
+  tmpdir: vi.fn(() => '/private/tmp'),
+}));
+
+// Mock fs for sandbox-profile.ts
+vi.mock('node:fs', () => ({
+  writeFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  existsSync: vi.fn(() => true),
+}));
+
+vi.mock('node:crypto', () => ({
+  randomBytes: vi.fn(() => ({ toString: () => 'testprofile12345' })),
+}));
+
+// Mock the interpolation module to pass commands through
+vi.mock('../src/core/interpolation.js', () => ({
+  shellInterpolateString: (s: string) => s,
+  interpolateConfig: (c: unknown) => c,
+}));
+
+// Mock the capability validator — keep real exports, override functions
+vi.mock('../src/core/capability-validator.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    checkCapabilities: () => ({ allowed: true, effectiveCaps: [], violations: [] }),
+    enforceScope: () => null,
+    formatViolations: (v: unknown[]) => Array.isArray(v) ? v.join(', ') : String(v),
+  };
+});
+
+// Mock permission resolver
+vi.mock('../src/core/permission-resolver.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    resolvePermissions: () => ({ cliArgs: [] }),
+  };
+});
+
+// Mock destructive pattern checker
+vi.mock('../src/commands/destructive-pattern-checker.js', () => ({
+  checkDestructivePatterns: () => null,
+  formatDestructiveError: (m: unknown) => String(m),
+}));
+
+import { bashCommand, type BashStepConfig } from '../src/commands/bash-command.js';
+import { EventEmitter } from 'node:events';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  proc.pid = 12345;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+
+  // Need destroy methods for cleanup
+  (proc.stdout as EventEmitter & { destroy: () => void }).destroy = vi.fn();
+  (proc.stderr as EventEmitter & { destroy: () => void }).destroy = vi.fn();
+
+  return proc;
+}
+
+function makeSandbox(useOsSandbox: boolean): EffectiveSandbox {
+  const capability: SandboxCapability = {
+    platform: 'darwin',
+    available: useOsSandbox,
+    tool: useOsSandbox ? 'sandbox-exec' : null,
+    overhead: useOsSandbox ? 'low' : null,
+  };
+  const config: SandboxConfig = { enabled: true, tier: 'auto' };
+  return {
+    useOsSandbox,
+    capability,
+    config,
+    displayStatus: useOsSandbox ? 'OS sandbox: sandbox-exec (darwin)' : 'OS sandbox: disabled',
+  };
+}
+
+const CAPS: StepCapability[] = [
+  { type: 'shell' },
+  { type: 'fs:read' },
+];
+
+function makeContext(sandbox?: EffectiveSandbox): CastingContext {
+  const gateway = new CapabilityGateway(CAPS, 'test-step-0', 'bash');
+  return {
+    variables: { projectRoot: '/Users/dev/project' },
+    args: {},
+    credentials: { get: async () => undefined },
+    memory: {
+      get: async () => undefined,
+      set: async () => {},
+      search: async () => [],
+    },
+    taskId: 'test-step-0',
+    spellId: 'test-spell',
+    stepIndex: 0,
+    effectiveCaps: CAPS,
+    gateway,
+    sandbox,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('bash command sandbox-exec integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('spawns with sandbox-exec when sandbox is enabled on macOS', async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const config: BashStepConfig = { command: 'echo hello' };
+    const context = makeContext(makeSandbox(true));
+
+    const promise = bashCommand.execute(config, context);
+
+    // Emit close to resolve the promise
+    setTimeout(() => {
+      proc.stdout.emit('data', Buffer.from('hello\n'));
+      proc.emit('close', 0, null);
+    }, 10);
+
+    const result = await promise;
+
+    // Should have spawned sandbox-exec, not bash directly
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [bin, args] = mockSpawn.mock.calls[0];
+    expect(bin).toBe('/usr/bin/sandbox-exec');
+    expect(args[0]).toBe('-f');
+    expect(args[1]).toMatch(/moflo-sandbox-.*\.sb$/);
+    expect(args[2]).toBe('bash');
+    expect(args[3]).toBe('-c');
+    expect(args[4]).toBe('echo hello');
+    expect(result.success).toBe(true);
+  });
+
+  it('spawns bash directly when sandbox is not enabled', async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const config: BashStepConfig = { command: 'echo hello' };
+    const context = makeContext(makeSandbox(false));
+
+    const promise = bashCommand.execute(config, context);
+
+    setTimeout(() => {
+      proc.stdout.emit('data', Buffer.from('hello\n'));
+      proc.emit('close', 0, null);
+    }, 10);
+
+    const result = await promise;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [bin, args] = mockSpawn.mock.calls[0];
+    // Should NOT be sandbox-exec
+    expect(bin).not.toBe('/usr/bin/sandbox-exec');
+    expect(args).toEqual(['-c', 'echo hello']);
+    expect(result.success).toBe(true);
+  });
+
+  it('spawns bash directly when no sandbox context provided', async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const config: BashStepConfig = { command: 'echo hello' };
+    const context = makeContext(); // no sandbox
+
+    const promise = bashCommand.execute(config, context);
+
+    setTimeout(() => {
+      proc.stdout.emit('data', Buffer.from('hello\n'));
+      proc.emit('close', 0, null);
+    }, 10);
+
+    const result = await promise;
+
+    const [bin] = mockSpawn.mock.calls[0];
+    expect(bin).not.toBe('/usr/bin/sandbox-exec');
+    expect(result.success).toBe(true);
+  });
+
+  it('falls back to unsandboxed when sandbox-exec spawn fails', async () => {
+    const failProc = createMockProcess();
+    const fallbackProc = createMockProcess();
+
+    let callCount = 0;
+    mockSpawn.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return failProc;
+      return fallbackProc;
+    });
+
+    const config: BashStepConfig = { command: 'echo hello' };
+    const context = makeContext(makeSandbox(true));
+
+    const promise = bashCommand.execute(config, context);
+
+    // Simulate sandbox-exec failing to spawn (ENOENT)
+    setTimeout(() => {
+      const err = new Error('spawn ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      failProc.emit('error', err);
+    }, 10);
+
+    // Fallback child should succeed
+    setTimeout(() => {
+      fallbackProc.stdout.emit('data', Buffer.from('hello\n'));
+      fallbackProc.emit('close', 0, null);
+    }, 30);
+
+    const result = await promise;
+
+    // Two spawn calls: sandbox-exec (failed) then bash (fallback)
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+    expect(result.data.stdout).toBe('hello');
+  });
+});

--- a/src/modules/spells/__tests__/sandbox-profile.test.ts
+++ b/src/modules/spells/__tests__/sandbox-profile.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Sandbox Profile Generator Tests
+ *
+ * Tests for macOS sandbox-exec profile generation and command wrapping.
+ * Uses mocking to test on any platform.
+ *
+ * @see https://github.com/eric-cielo/moflo/issues/410
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { StepCapability } from '../src/types/step-command.types.js';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockWriteFileSync = vi.fn();
+const mockUnlinkSync = vi.fn();
+const mockRandomBytes = vi.fn(() => ({ toString: () => 'abcdef0123456789' }));
+
+vi.mock('node:fs', () => ({
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  unlinkSync: (...args: unknown[]) => mockUnlinkSync(...args),
+  existsSync: vi.fn(() => false),
+}));
+
+vi.mock('node:crypto', () => ({
+  randomBytes: (...args: unknown[]) => mockRandomBytes(...args),
+}));
+
+import {
+  generateSandboxProfile,
+  wrapWithSandboxExec,
+} from '../src/core/sandbox-profile.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ============================================================================
+// generateSandboxProfile()
+// ============================================================================
+
+describe('generateSandboxProfile', () => {
+  const PROJECT_ROOT = '/Users/dev/myproject';
+
+  it('generates deny-default profile with no capabilities', () => {
+    const profile = generateSandboxProfile([], PROJECT_ROOT);
+    expect(profile).toContain('(version 1)');
+    expect(profile).toContain('(deny default)');
+    expect(profile).toContain('(allow process-exec)');
+    expect(profile).toContain('(allow process-fork)');
+    expect(profile).toContain('(allow signal)');
+    // System paths always allowed
+    expect(profile).toContain('(allow file-read* (subpath "/usr"))');
+    expect(profile).toContain('(allow file-read* (subpath "/bin"))');
+    expect(profile).toContain('(allow file-read* (subpath "/Library"))');
+    expect(profile).toContain('(allow file-read* (subpath "/System"))');
+    // No fs or net rules beyond system paths
+    expect(profile).not.toContain('Filesystem read access');
+    expect(profile).not.toContain('Filesystem write access');
+    expect(profile).not.toContain('Network access');
+  });
+
+  it('adds file-read* for unscoped fs:read', () => {
+    const caps: StepCapability[] = [{ type: 'fs:read' }];
+    const profile = generateSandboxProfile(caps, PROJECT_ROOT);
+    expect(profile).toContain('; Filesystem read access');
+    expect(profile).toContain(`(allow file-read* (subpath "${PROJECT_ROOT}"))`);
+  });
+
+  it('adds file-read* for scoped fs:read paths', () => {
+    const caps: StepCapability[] = [
+      { type: 'fs:read', scope: ['/usr/local/share', './config/'] },
+    ];
+    const profile = generateSandboxProfile(caps, PROJECT_ROOT);
+    expect(profile).toContain('(allow file-read* (subpath "/usr/local/share"))');
+    // Relative path gets joined with project root — use regex to handle platform separators
+    expect(profile).toMatch(/\(allow file-read\* \(subpath ".*config.*"\)\)/);
+  });
+
+  it('adds file-write* for unscoped fs:write', () => {
+    const caps: StepCapability[] = [{ type: 'fs:write' }];
+    const profile = generateSandboxProfile(caps, PROJECT_ROOT);
+    expect(profile).toContain('; Filesystem write access');
+    expect(profile).toContain(`(allow file-write* (subpath "${PROJECT_ROOT}"))`);
+  });
+
+  it('adds file-write* for scoped fs:write paths', () => {
+    const caps: StepCapability[] = [
+      { type: 'fs:write', scope: ['./dist/', '/tmp/output'] },
+    ];
+    const profile = generateSandboxProfile(caps, PROJECT_ROOT);
+    // Relative path gets joined — use regex to handle platform separators
+    expect(profile).toMatch(/\(allow file-write\* \(subpath ".*dist.*"\)\)/);
+    expect(profile).toContain('(allow file-write* (subpath "/tmp/output"))');
+  });
+
+  it('adds network* when net capability present', () => {
+    const caps: StepCapability[] = [{ type: 'net' }];
+    const profile = generateSandboxProfile(caps, PROJECT_ROOT);
+    expect(profile).toContain('; Network access');
+    expect(profile).toContain('(allow network*)');
+  });
+
+  it('omits network rules when net capability absent', () => {
+    const caps: StepCapability[] = [{ type: 'fs:read' }, { type: 'shell' }];
+    const profile = generateSandboxProfile(caps, PROJECT_ROOT);
+    expect(profile).not.toContain('network');
+    expect(profile).not.toContain('Network');
+  });
+
+  it('combines all capability types', () => {
+    const caps: StepCapability[] = [
+      { type: 'fs:read', scope: ['./src/'] },
+      { type: 'fs:write', scope: ['./dist/'] },
+      { type: 'net' },
+      { type: 'shell' },
+    ];
+    const profile = generateSandboxProfile(caps, PROJECT_ROOT);
+    expect(profile).toContain('Filesystem read access');
+    expect(profile).toContain('Filesystem write access');
+    expect(profile).toContain('Network access');
+    expect(profile).toContain('(allow network*)');
+  });
+
+  it('always includes temp directory access', () => {
+    const profile = generateSandboxProfile([], PROJECT_ROOT);
+    expect(profile).toContain('(allow file-read* (subpath "/private/tmp"))');
+    expect(profile).toContain('(allow file-write* (subpath "/private/tmp"))');
+  });
+
+  it('handles absolute scope paths without joining', () => {
+    const caps: StepCapability[] = [
+      { type: 'fs:read', scope: ['/opt/data', '/var/log'] },
+    ];
+    const profile = generateSandboxProfile(caps, PROJECT_ROOT);
+    expect(profile).toContain('(allow file-read* (subpath "/opt/data"))');
+    expect(profile).toContain('(allow file-read* (subpath "/var/log"))');
+  });
+});
+
+// ============================================================================
+// wrapWithSandboxExec()
+// ============================================================================
+
+describe('wrapWithSandboxExec', () => {
+  const PROJECT_ROOT = '/Users/dev/myproject';
+
+  it('returns sandbox-exec binary and correct args', () => {
+    const caps: StepCapability[] = [{ type: 'fs:read' }];
+    const result = wrapWithSandboxExec('echo hello', caps, PROJECT_ROOT);
+
+    expect(result.bin).toBe('/usr/bin/sandbox-exec');
+    expect(result.args[0]).toBe('-f');
+    expect(result.args[1]).toMatch(/moflo-sandbox-.*\.sb$/);
+    expect(result.args[2]).toBe('bash');
+    expect(result.args[3]).toBe('-c');
+    expect(result.args[4]).toBe('echo hello');
+  });
+
+  it('writes profile to temp file', () => {
+    const caps: StepCapability[] = [{ type: 'net' }];
+    wrapWithSandboxExec('curl example.com', caps, PROJECT_ROOT);
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const [path, content, encoding] = mockWriteFileSync.mock.calls[0];
+    expect(path).toMatch(/moflo-sandbox-.*\.sb$/);
+    expect(content).toContain('(version 1)');
+    expect(content).toContain('(allow network*)');
+    expect(encoding).toBe('utf8');
+  });
+
+  it('cleanup removes the temp profile', () => {
+    const caps: StepCapability[] = [];
+    const result = wrapWithSandboxExec('ls', caps, PROJECT_ROOT);
+
+    result.cleanup();
+    expect(mockUnlinkSync).toHaveBeenCalledTimes(1);
+    expect(mockUnlinkSync.mock.calls[0][0]).toMatch(/moflo-sandbox-.*\.sb$/);
+  });
+
+  it('cleanup swallows errors on missing file', () => {
+    mockUnlinkSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    const caps: StepCapability[] = [];
+    const result = wrapWithSandboxExec('ls', caps, PROJECT_ROOT);
+
+    // Should not throw
+    expect(() => result.cleanup()).not.toThrow();
+  });
+});

--- a/src/modules/spells/src/commands/bash-command.ts
+++ b/src/modules/spells/src/commands/bash-command.ts
@@ -19,6 +19,7 @@ import { shellInterpolateString } from '../core/interpolation.js';
 import { enforceScope, formatViolations } from '../core/capability-validator.js';
 import { resolvePermissions, type PermissionLevel } from '../core/permission-resolver.js';
 import { checkDestructivePatterns, formatDestructiveError } from './destructive-pattern-checker.js';
+import { wrapWithSandboxExec, type SandboxWrapResult } from '../core/sandbox-profile.js';
 
 /** Typed config for the bash step command. */
 export interface BashStepConfig extends StepConfig {
@@ -128,16 +129,31 @@ export const bashCommand: StepCommand<BashStepConfig> = {
     // Resolve shell: prefer Git Bash on Windows to avoid WSL bash hanging.
     const resolvedShell = platform() === 'win32' ? resolveGitBash() : 'bash';
 
+    // ── macOS sandbox-exec wrapping (#410) ─────────────────────────────
+    // When on macOS with OS sandbox enabled, wrap via sandbox-exec.
+    let sandboxWrap: SandboxWrapResult | null = null;
+    if (context.sandbox?.useOsSandbox && context.sandbox.capability.tool === 'sandbox-exec') {
+      try {
+        const projectRoot = (context.variables.projectRoot as string) || process.cwd();
+        const caps = context.effectiveCaps ?? [];
+        sandboxWrap = wrapWithSandboxExec(command, caps, projectRoot);
+      } catch (err) {
+        console.log(`[bash] sandbox-exec profile generation failed, running unsandboxed: ${(err as Error).message}`);
+      }
+    }
+
     return new Promise<StepOutput>((resolve) => {
       let timedOut = false;
       let resolved = false;
       let lastStdoutLine = '';
+      const cleanupSandbox = () => sandboxWrap?.cleanup();
 
       const finish = (code: number | null, signal: string | null, stdout: string, stderr: string) => {
         if (resolved) return;
         resolved = true;
         clearTimeout(timer);
         clearInterval(heartbeat);
+        cleanupSandbox();
         context.abortSignal?.removeEventListener('abort', onAbort);
 
         const exitCode = code ?? (timedOut ? -1 : 1);
@@ -167,15 +183,50 @@ export const bashCommand: StepCommand<BashStepConfig> = {
         });
       };
 
-      // Use spawn (not exec) with stdin set to 'ignore' from the start.
-      // exec() creates a pipe for stdin then we close it — but the shell
-      // may read from stdin before we get a chance to close it, causing a
-      // hang on Windows. 'ignore' maps stdin to /dev/null at spawn time.
-      const child = spawn(resolvedShell, ['-c', command], {
-        stdio: ['ignore', 'pipe', 'pipe'],
+      // Shared spawn options — stdin ignored to avoid WSL hangs on Windows.
+      const spawnOpts = {
+        stdio: ['ignore', 'pipe', 'pipe'] as ['ignore', 'pipe', 'pipe'],
         env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
         windowsHide: true,
-      });
+      };
+
+      // Determine spawn binary and args.
+      const spawnBin = sandboxWrap ? sandboxWrap.bin : resolvedShell;
+      const spawnArgs = sandboxWrap ? [...sandboxWrap.args] : ['-c', command];
+
+      let closeStdout = '';
+      let closeStderr = '';
+
+      // Wire stdout/stderr collectors onto a child process.
+      const wireOutputs = (child: ChildProcess) => {
+        child.stdout?.on('data', (chunk: Buffer) => {
+          const text = chunk.toString();
+          closeStdout += text;
+          const lines = text.split(/\r?\n/).filter(l => l.trim());
+          if (lines.length > 0) lastStdoutLine = lines[lines.length - 1];
+        });
+        child.stderr?.on('data', (chunk: Buffer) => { closeStderr += chunk.toString(); });
+        child.on('close', (code, signal) => { finish(code, signal, closeStdout, closeStderr); });
+      };
+
+      // activeChild tracks the running process for heartbeat/timeout (may change on fallback).
+      let activeChild: ChildProcess = spawn(spawnBin, spawnArgs, spawnOpts);
+      wireOutputs(activeChild);
+
+      // ── Sandbox-exec fallback (#410) ───────────────────────────────
+      // If sandbox-exec spawn itself fails (ENOENT, permission error),
+      // fall back to unsandboxed execution with new child.
+      if (sandboxWrap) {
+        activeChild.on('error', (err: NodeJS.ErrnoException) => {
+          if (resolved) return;
+          console.log(`[bash] sandbox-exec failed (${err.code ?? err.message}), retrying unsandboxed`);
+          cleanupSandbox();
+          closeStdout = '';
+          closeStderr = '';
+          activeChild = spawn(resolvedShell, ['-c', command], spawnOpts);
+          wireOutputs(activeChild);
+        });
+      }
 
       // ── Heartbeat — show the user the step is alive ──────────────
       const HEARTBEAT_INTERVAL = 15_000; // 15 seconds
@@ -184,33 +235,17 @@ export const bashCommand: StepCommand<BashStepConfig> = {
         const activity = lastStdoutLine
           ? ` | ${lastStdoutLine.slice(0, 80)}`
           : '';
-        console.log(`[bash] still running (${elapsed()}) pid=${child.pid ?? '?'} cmd=${cmdPreview}${activity}`);
+        console.log(`[bash] still running (${elapsed()}) pid=${activeChild.pid ?? '?'} cmd=${cmdPreview}${activity}`);
       }, HEARTBEAT_INTERVAL);
 
       // ── Manual timeout with process tree kill ─────────────────────
       const onAbort = () => {
         timedOut = true;
-        console.log(`[bash] killing step after ${elapsed()} (timeout=${timeout}ms) pid=${child.pid ?? '?'}`);
-        killProcessTree(child);
+        console.log(`[bash] killing step after ${elapsed()} (timeout=${timeout}ms) pid=${activeChild.pid ?? '?'}`);
+        killProcessTree(activeChild);
       };
       const timer = setTimeout(onAbort, timeout);
       context.abortSignal?.addEventListener('abort', onAbort, { once: true });
-
-      // ── Collect stdout/stderr, track last line for heartbeat ──────
-      let closeStdout = '';
-      let closeStderr = '';
-      child.stdout?.on('data', (chunk: Buffer) => {
-        const text = chunk.toString();
-        closeStdout += text;
-        const lines = text.split(/\r?\n/).filter(l => l.trim());
-        if (lines.length > 0) lastStdoutLine = lines[lines.length - 1];
-      });
-      child.stderr?.on('data', (chunk: Buffer) => { closeStderr += chunk.toString(); });
-
-      // Resolve when the process exits and all stdio streams close
-      child.on('close', (code, signal) => {
-        finish(code, signal, closeStdout, closeStderr);
-      });
     });
   },
 

--- a/src/modules/spells/src/core/runner.ts
+++ b/src/modules/spells/src/core/runner.ts
@@ -37,6 +37,7 @@ import { DENY_ALL_GATEWAY } from './capability-gateway.js';
 import {
   resolveEffectiveSandbox, formatSandboxLog,
   DEFAULT_SANDBOX_CONFIG,
+  type EffectiveSandbox,
 } from './platform-sandbox.js';
 
 export class SpellCaster {
@@ -126,11 +127,12 @@ export class SpellCaster {
       };
     }
 
-    // Log OS sandbox status at spell start
+    // Resolve OS sandbox status at spell start (#410)
+    let effectiveSandbox: EffectiveSandbox | undefined;
     try {
       const sandboxCfg = options.sandboxConfig ?? DEFAULT_SANDBOX_CONFIG;
-      const effective = resolveEffectiveSandbox(sandboxCfg);
-      console.log(formatSandboxLog(effective));
+      effectiveSandbox = resolveEffectiveSandbox(sandboxCfg);
+      console.log(formatSandboxLog(effectiveSandbox));
     } catch (err) {
       // tier: full but no sandbox available — fail the spell
       return this.failureResult(spellId, startTime, [{
@@ -139,7 +141,7 @@ export class SpellCaster {
       }], definition.name);
     }
 
-    return this.executeSteps(definition, resolvedArgs, spellId, options, startTime);
+    return this.executeSteps(definition, resolvedArgs, spellId, options, startTime, effectiveSandbox);
   }
 
   async dryRun(
@@ -164,6 +166,7 @@ export class SpellCaster {
   private async executeSteps(
     definition: SpellDefinition, resolvedArgs: Record<string, unknown>,
     spellId: string, options: RunnerOptions, startTime: number,
+    effectiveSandbox?: EffectiveSandbox,
   ): Promise<SpellResult> {
     const context = options.context;
     const variables: Record<string, unknown> = { ...options.initialVariables };
@@ -192,6 +195,7 @@ export class SpellCaster {
       parentMofloLevel: options.parentMofloLevel,
       nestingDepth: options.nestingDepth ?? 0,
       maxNestingDepth: options.maxNestingDepth ?? DEFAULT_MAX_NESTING_DEPTH,
+      effectiveSandbox,
     };
 
     try {
@@ -343,12 +347,14 @@ export class SpellCaster {
     step: import('../types/spell-definition.types.js').StepDefinition,
     state: StepExecutionState, index: number,
   ) {
-    return executeSingleStep(step, state, index, this.registry, this.buildContext.bind(this));
+    const ctxBuilder = (v: Record<string, unknown>, a: Record<string, unknown>, sid: string, si: number, sig?: AbortSignal) =>
+      this.buildContext(v, a, sid, si, sig, state.effectiveSandbox);
+    return executeSingleStep(step, state, index, this.registry, ctxBuilder);
   }
 
   private async doRollback(completed: CompletedStep[], state: StepExecutionState, results: StepResult[]) {
     await rollbackSteps(completed, this.registry,
-      (i) => this.buildContext(state.variables, state.resolvedArgs, state.spellId, i, state.options.signal),
+      (i) => this.buildContext(state.variables, state.resolvedArgs, state.spellId, i, state.options.signal, state.effectiveSandbox),
       results);
   }
 
@@ -361,11 +367,13 @@ export class SpellCaster {
   private buildContext(
     variables: Record<string, unknown>, args: Record<string, unknown>,
     spellId: string, stepIndex: number, signal?: AbortSignal,
+    sandbox?: EffectiveSandbox,
   ): CastingContext {
     return { variables, args, credentials: this.credentials, memory: this.memory,
       taskId: `${spellId}-step-${stepIndex}`, spellId, stepIndex, abortSignal: signal,
       gateway: DENY_ALL_GATEWAY,
-      ...(this.connectorAccessor ? { tools: this.connectorAccessor } : {}) };
+      ...(this.connectorAccessor ? { tools: this.connectorAccessor } : {}),
+      ...(sandbox ? { sandbox } : {}) };
   }
 
   private async storeProgress(

--- a/src/modules/spells/src/core/sandbox-profile.ts
+++ b/src/modules/spells/src/core/sandbox-profile.ts
@@ -1,0 +1,175 @@
+/**
+ * macOS Sandbox Profile Generator
+ *
+ * Generates sandbox-exec `.sb` profiles dynamically from step capabilities
+ * and wraps bash commands for sandboxed execution.
+ *
+ * @see https://github.com/eric-cielo/moflo/issues/410
+ */
+
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import type { StepCapability } from '../types/step-command.types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SandboxWrapResult {
+  /** Shell binary to spawn (sandbox-exec). */
+  readonly bin: string;
+  /** Args array: ['-f', profilePath, 'bash', '-c', command]. */
+  readonly args: readonly string[];
+  /** Call after process exits to remove the temp profile. */
+  readonly cleanup: () => void;
+}
+
+// ============================================================================
+// Profile Generation
+// ============================================================================
+
+/**
+ * Generate a macOS sandbox-exec profile (.sb) from step capabilities.
+ *
+ * Rules:
+ *   - Deny all by default
+ *   - Always allow process execution and signal handling
+ *   - Always allow read access to /usr, /bin, /Library, /System (system libs)
+ *   - fs:read scoped → allow file-read* to scoped paths
+ *   - fs:read unscoped → allow file-read* to projectRoot
+ *   - fs:write scoped → allow file-write* to scoped paths
+ *   - fs:write unscoped → allow file-write* to projectRoot
+ *   - net capability → allow network*
+ *   - No net capability → network denied (default deny covers it)
+ */
+export function generateSandboxProfile(
+  capabilities: readonly StepCapability[],
+  projectRoot: string,
+): string {
+  const lines: string[] = [
+    '(version 1)',
+    '(deny default)',
+    '',
+    '; Process execution (required for bash)',
+    '(allow process-exec)',
+    '(allow process-fork)',
+    '(allow signal)',
+    '(allow sysctl-read)',
+    '',
+    '; System libraries and binaries (always needed)',
+    '(allow file-read* (subpath "/usr"))',
+    '(allow file-read* (subpath "/bin"))',
+    '(allow file-read* (subpath "/Library"))',
+    '(allow file-read* (subpath "/System"))',
+    '(allow file-read* (subpath "/private/var"))',
+    '(allow file-read* (subpath "/private/etc"))',
+    '(allow file-read* (subpath "/dev"))',
+    '(allow file-read-metadata)',
+    '',
+    '; Temp directory access (for profile itself and command temp files)',
+    '(allow file-read* (subpath "/private/tmp"))',
+    '(allow file-write* (subpath "/private/tmp"))',
+    `(allow file-read* (subpath "${escapeSbPath(tmpdir())}"))`,
+    `(allow file-write* (subpath "${escapeSbPath(tmpdir())}"))`,
+  ];
+
+  // ── fs:read ──────────────────────────────────────────────────────────
+  const fsRead = capabilities.find(c => c.type === 'fs:read');
+  if (fsRead) {
+    lines.push('');
+    lines.push('; Filesystem read access');
+    if (fsRead.scope && fsRead.scope.length > 0) {
+      for (const scopePath of fsRead.scope) {
+        const resolved = resolveScopePath(scopePath, projectRoot);
+        lines.push(`(allow file-read* (subpath "${escapeSbPath(resolved)}"))`);
+      }
+    } else {
+      lines.push(`(allow file-read* (subpath "${escapeSbPath(projectRoot)}"))`);
+    }
+  }
+
+  // ── fs:write ─────────────────────────────────────────────────────────
+  const fsWrite = capabilities.find(c => c.type === 'fs:write');
+  if (fsWrite) {
+    lines.push('');
+    lines.push('; Filesystem write access');
+    if (fsWrite.scope && fsWrite.scope.length > 0) {
+      for (const scopePath of fsWrite.scope) {
+        const resolved = resolveScopePath(scopePath, projectRoot);
+        lines.push(`(allow file-write* (subpath "${escapeSbPath(resolved)}"))`);
+      }
+    } else {
+      lines.push(`(allow file-write* (subpath "${escapeSbPath(projectRoot)}"))`);
+    }
+  }
+
+  // ── net ──────────────────────────────────────────────────────────────
+  const hasNet = capabilities.some(c => c.type === 'net');
+  if (hasNet) {
+    lines.push('');
+    lines.push('; Network access');
+    lines.push('(allow network*)');
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ============================================================================
+// Command Wrapping
+// ============================================================================
+
+/**
+ * Wrap a bash command for execution under macOS sandbox-exec.
+ *
+ * Writes a temporary `.sb` profile and returns the sandbox-exec invocation.
+ * The caller MUST call `cleanup()` after the process exits.
+ */
+export function wrapWithSandboxExec(
+  command: string,
+  capabilities: readonly StepCapability[],
+  projectRoot: string,
+): SandboxWrapResult {
+  const profile = generateSandboxProfile(capabilities, projectRoot);
+  const profilePath = join(tmpdir(), `moflo-sandbox-${randomBytes(8).toString('hex')}.sb`);
+
+  writeFileSync(profilePath, profile, 'utf8');
+
+  return {
+    bin: '/usr/bin/sandbox-exec',
+    args: ['-f', profilePath, 'bash', '-c', command],
+    cleanup: () => {
+      try {
+        unlinkSync(profilePath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          console.log(`[sandbox] failed to clean up profile ${profilePath}: ${(err as Error).message}`);
+        }
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Resolve a scope path relative to project root.
+ * Absolute paths pass through; relative paths are joined with projectRoot.
+ */
+function resolveScopePath(scopePath: string, projectRoot: string): string {
+  if (scopePath.startsWith('/')) return scopePath;
+  const cleaned = scopePath.replace(/^\.\//, '');
+  return join(projectRoot, cleaned);
+}
+
+/**
+ * Escape a path for use inside a sandbox profile string literal.
+ * Backslashes and double quotes need escaping in Scheme strings.
+ */
+function escapeSbPath(path: string): string {
+  return path.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}

--- a/src/modules/spells/src/core/step-executor.ts
+++ b/src/modules/spells/src/core/step-executor.ts
@@ -48,6 +48,8 @@ export interface StepExecutionState {
   readonly parentMofloLevel: MofloLevel | undefined;
   readonly nestingDepth: number;
   readonly maxNestingDepth: number;
+  /** Resolved sandbox state for this spell run (Issue #410). */
+  readonly effectiveSandbox?: import('./platform-sandbox.js').EffectiveSandbox;
 }
 
 /**

--- a/src/modules/spells/src/index.ts
+++ b/src/modules/spells/src/index.ts
@@ -98,6 +98,12 @@ export {
 } from './core/platform-sandbox.js';
 
 export {
+  generateSandboxProfile,
+  wrapWithSandboxExec,
+  type SandboxWrapResult,
+} from './core/sandbox-profile.js';
+
+export {
   resolvePermissions,
   buildClaudeCommand,
   isValidPermissionLevel,

--- a/src/modules/spells/src/types/step-command.types.ts
+++ b/src/modules/spells/src/types/step-command.types.ts
@@ -109,6 +109,8 @@ export interface CastingContext {
   readonly gateway: import('../core/capability-gateway.js').ICapabilityGateway;
   /** Permission level declared on the step definition (controls Claude CLI invocation flags). */
   readonly permissionLevel?: import('../core/permission-resolver.js').PermissionLevel;
+  /** Effective sandbox state for OS-level confinement (Issue #410). */
+  readonly sandbox?: import('../core/platform-sandbox.js').EffectiveSandbox;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Wraps bash step commands in `sandbox-exec` on macOS when OS-level sandbox is enabled
- Generates `.sb` profiles dynamically from step capabilities (fs:read, fs:write, net)
- Graceful fallback to unsandboxed execution if sandbox-exec fails (ENOENT, permissions)
- Sandbox state flows through `StepExecutionState` (concurrency-safe for parallel `run()` calls)

## Changes

- **New:** `sandbox-profile.ts` — profile generator and sandbox-exec wrapper
- **Modified:** `bash-command.ts` — integrates sandbox wrapping in spawn path with shared `wireOutputs` helper and `activeChild` tracking for correct timeout/heartbeat on fallback
- **Modified:** `runner.ts` — resolves effective sandbox and passes through `StepExecutionState` (not instance field)
- **Modified:** `step-executor.ts` — added `effectiveSandbox` to `StepExecutionState`
- **Modified:** `step-command.types.ts` — added `sandbox` to `CastingContext`
- **New:** 18 tests (14 unit + 4 integration) — all 1002 tests pass

## Testing
- [x] Unit tests pass (14 sandbox-profile tests)
- [x] Integration tests pass (4 bash-sandbox-exec tests)
- [x] All existing 1002 tests pass (no regressions)
- [ ] E2E on macOS CI (sandbox-exec only available on macOS)

Closes #410

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)