### PR TITLE
feat(spells): Linux bwrap integration for bash steps

### DIFF
--- a/src/modules/spells/__tests__/bash-bwrap.test.ts
+++ b/src/modules/spells/__tests__/bash-bwrap.test.ts
@@ -1,16 +1,16 @@
 /**
- * Bash Command — Sandbox-exec Integration Tests
+ * Bash Command — Bubblewrap (bwrap) Integration Tests
  *
- * Tests that the bash step command correctly integrates with sandbox-exec
- * wrapping when sandbox is enabled on macOS.
+ * Tests that the bash step command correctly integrates with bwrap
+ * wrapping when sandbox is enabled on Linux.
  *
- * @see https://github.com/eric-cielo/moflo/issues/410
+ * @see https://github.com/eric-cielo/moflo/issues/411
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ============================================================================
-// Mocks
+// Mocks (must be before imports that use mocked modules)
 // ============================================================================
 
 const mockSpawn = vi.fn();
@@ -20,8 +20,8 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('node:os', () => ({
-  platform: vi.fn(() => 'darwin'),
-  tmpdir: vi.fn(() => '/private/tmp'),
+  platform: vi.fn(() => 'linux'),
+  tmpdir: vi.fn(() => '/tmp'),
 }));
 
 vi.mock('node:fs', () => ({
@@ -69,17 +69,17 @@ import { createMockProcess, makeSandbox, makeContext } from './helpers/bash-test
 // Tests
 // ============================================================================
 
-describe('bash command sandbox-exec integration', () => {
+describe('bash command bwrap integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('spawns with sandbox-exec when sandbox is enabled on macOS', async () => {
+  it('spawns with bwrap when sandbox is enabled on Linux', async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
 
     const config: BashStepConfig = { command: 'echo hello' };
-    const context = makeContext('/Users/dev/project', makeSandbox(true, 'darwin', 'sandbox-exec'));
+    const context = makeContext('/home/user/project', makeSandbox(true, 'linux', 'bwrap'));
 
     const promise = bashCommand.execute(config, context);
 
@@ -92,12 +92,14 @@ describe('bash command sandbox-exec integration', () => {
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [bin, args] = mockSpawn.mock.calls[0];
-    expect(bin).toBe('/usr/bin/sandbox-exec');
-    expect(args[0]).toBe('-f');
-    expect(args[1]).toMatch(/moflo-sandbox-.*\.sb$/);
-    expect(args[2]).toBe('bash');
-    expect(args[3]).toBe('-c');
-    expect(args[4]).toBe('echo hello');
+    expect(bin).toBe('bwrap');
+    expect(args).toContain('--ro-bind');
+    expect(args).toContain('--unshare-pid');
+    expect(args).toContain('--unshare-net');
+    const bashIdx = args.indexOf('bash');
+    expect(bashIdx).toBeGreaterThan(-1);
+    expect(args[bashIdx + 1]).toBe('-c');
+    expect(args[bashIdx + 2]).toBe('echo hello');
     expect(result.success).toBe(true);
   });
 
@@ -106,7 +108,7 @@ describe('bash command sandbox-exec integration', () => {
     mockSpawn.mockReturnValue(proc);
 
     const config: BashStepConfig = { command: 'echo hello' };
-    const context = makeContext('/Users/dev/project', makeSandbox(false, 'darwin', 'sandbox-exec'));
+    const context = makeContext('/home/user/project', makeSandbox(false, 'linux', 'bwrap'));
 
     const promise = bashCommand.execute(config, context);
 
@@ -119,7 +121,7 @@ describe('bash command sandbox-exec integration', () => {
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [bin, args] = mockSpawn.mock.calls[0];
-    expect(bin).not.toBe('/usr/bin/sandbox-exec');
+    expect(bin).not.toBe('bwrap');
     expect(args).toEqual(['-c', 'echo hello']);
     expect(result.success).toBe(true);
   });
@@ -129,7 +131,7 @@ describe('bash command sandbox-exec integration', () => {
     mockSpawn.mockReturnValue(proc);
 
     const config: BashStepConfig = { command: 'echo hello' };
-    const context = makeContext('/Users/dev/project');
+    const context = makeContext('/home/user/project');
 
     const promise = bashCommand.execute(config, context);
 
@@ -141,11 +143,11 @@ describe('bash command sandbox-exec integration', () => {
     const result = await promise;
 
     const [bin] = mockSpawn.mock.calls[0];
-    expect(bin).not.toBe('/usr/bin/sandbox-exec');
+    expect(bin).not.toBe('bwrap');
     expect(result.success).toBe(true);
   });
 
-  it('falls back to unsandboxed when sandbox-exec spawn fails', async () => {
+  it('falls back to unsandboxed when bwrap spawn fails', async () => {
     const failProc = createMockProcess();
     const fallbackProc = createMockProcess();
 
@@ -157,7 +159,7 @@ describe('bash command sandbox-exec integration', () => {
     });
 
     const config: BashStepConfig = { command: 'echo hello' };
-    const context = makeContext('/Users/dev/project', makeSandbox(true, 'darwin', 'sandbox-exec'));
+    const context = makeContext('/home/user/project', makeSandbox(true, 'linux', 'bwrap'));
 
     const promise = bashCommand.execute(config, context);
 

--- a/src/modules/spells/__tests__/bwrap-sandbox.test.ts
+++ b/src/modules/spells/__tests__/bwrap-sandbox.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Bubblewrap (bwrap) Sandbox — Unit Tests
+ *
+ * Tests bwrap argument generation from step capabilities.
+ *
+ * @see https://github.com/eric-cielo/moflo/issues/411
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildBwrapArgs, wrapWithBwrap } from '../src/core/bwrap-sandbox.js';
+import type { StepCapability } from '../src/types/step-command.types.js';
+
+const PROJECT_ROOT = '/home/user/project';
+
+describe('buildBwrapArgs', () => {
+  it('generates default args with no capabilities', () => {
+    const args = buildBwrapArgs('echo hello', [], PROJECT_ROOT);
+
+    expect(args).toContain('--ro-bind');
+    expect(args).toContain('--dev');
+    expect(args).toContain('--proc');
+    expect(args).toContain('--tmpfs');
+    expect(args).toContain('--unshare-net');
+    expect(args).toContain('--unshare-pid');
+
+    // Command at the end
+    const bashIdx = args.indexOf('bash');
+    expect(bashIdx).toBeGreaterThan(-1);
+    expect(args[bashIdx + 1]).toBe('-c');
+    expect(args[bashIdx + 2]).toBe('echo hello');
+  });
+
+  it('adds writable bind mount for unscoped fs:write', () => {
+    const caps: StepCapability[] = [{ type: 'fs:write' }];
+    const args = buildBwrapArgs('touch file.txt', caps, PROJECT_ROOT);
+
+    // Should have --bind projectRoot projectRoot (writable)
+    const bindIdx = args.indexOf('--bind');
+    expect(bindIdx).toBeGreaterThan(-1);
+    expect(args[bindIdx + 1]).toBe(PROJECT_ROOT);
+    expect(args[bindIdx + 2]).toBe(PROJECT_ROOT);
+  });
+
+  it('adds writable bind mounts for scoped fs:write', () => {
+    const caps: StepCapability[] = [
+      { type: 'fs:write', scope: ['./dist', '/tmp/output'] },
+    ];
+    const args = buildBwrapArgs('build', caps, PROJECT_ROOT);
+
+    // Should have --bind for each scoped path
+    const bindIndices: number[] = [];
+    args.forEach((a, i) => { if (a === '--bind') bindIndices.push(i); });
+
+    expect(bindIndices.length).toBe(2);
+    // Relative path resolved
+    expect(args[bindIndices[0] + 1]).toBe('/home/user/project/dist');
+    // Absolute path passed through
+    expect(args[bindIndices[1] + 1]).toBe('/tmp/output');
+  });
+
+  it('adds read-only bind mounts for scoped fs:read', () => {
+    const caps: StepCapability[] = [
+      { type: 'fs:read', scope: ['./src', './config'] },
+    ];
+    const args = buildBwrapArgs('cat src/index.ts', caps, PROJECT_ROOT);
+
+    // Count --ro-bind occurrences (root + 2 scoped)
+    const roBind: number[] = [];
+    args.forEach((a, i) => { if (a === '--ro-bind') roBind.push(i); });
+
+    // Root bind + 2 scoped = 3
+    expect(roBind.length).toBe(3);
+    expect(args[roBind[1] + 1]).toBe('/home/user/project/src');
+    expect(args[roBind[2] + 1]).toBe('/home/user/project/config');
+  });
+
+  it('omits --unshare-net when net capability is granted', () => {
+    const caps: StepCapability[] = [{ type: 'net' }];
+    const args = buildBwrapArgs('curl example.com', caps, PROJECT_ROOT);
+
+    expect(args).not.toContain('--unshare-net');
+  });
+
+  it('includes --unshare-net when no net capability', () => {
+    const caps: StepCapability[] = [{ type: 'fs:read' }];
+    const args = buildBwrapArgs('echo test', caps, PROJECT_ROOT);
+
+    expect(args).toContain('--unshare-net');
+  });
+
+  it('does not duplicate --ro-bind for paths already covered by --bind (fs:write)', () => {
+    const caps: StepCapability[] = [
+      { type: 'fs:read', scope: ['./src'] },
+      { type: 'fs:write', scope: ['./src'] },
+    ];
+    const args = buildBwrapArgs('test', caps, PROJECT_ROOT);
+
+    // ./src should appear as --bind (writable), not also as --ro-bind
+    const resolvedSrc = '/home/user/project/src';
+    const roBind: string[] = [];
+    const rwBind: string[] = [];
+    args.forEach((a, i) => {
+      if (a === '--ro-bind' && args[i + 1] === resolvedSrc) roBind.push(args[i + 1]);
+      if (a === '--bind' && args[i + 1] === resolvedSrc) rwBind.push(args[i + 1]);
+    });
+
+    expect(rwBind.length).toBe(1);
+    expect(roBind.length).toBe(0);
+  });
+
+  it('always includes --unshare-pid', () => {
+    const caps: StepCapability[] = [{ type: 'shell' }, { type: 'net' }];
+    const args = buildBwrapArgs('ps aux', caps, PROJECT_ROOT);
+
+    expect(args).toContain('--unshare-pid');
+  });
+});
+
+describe('wrapWithBwrap', () => {
+  it('returns SandboxWrapResult with bin=bwrap', () => {
+    const result = wrapWithBwrap('echo test', [], PROJECT_ROOT);
+
+    expect(result.bin).toBe('bwrap');
+    expect(result.args).toContain('bash');
+    expect(result.args[result.args.length - 1]).toBe('echo test');
+  });
+
+  it('cleanup is a safe no-op', () => {
+    const result = wrapWithBwrap('echo test', [], PROJECT_ROOT);
+
+    // Should not throw
+    expect(() => result.cleanup()).not.toThrow();
+  });
+});

--- a/src/modules/spells/__tests__/helpers/bash-test-utils.ts
+++ b/src/modules/spells/__tests__/helpers/bash-test-utils.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared test helpers for bash command sandbox integration tests.
+ *
+ * Used by both bash-sandbox-exec.test.ts and bash-bwrap.test.ts.
+ */
+
+import { vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { CastingContext, StepCapability } from '../../src/types/step-command.types.js';
+import type { EffectiveSandbox, SandboxCapability, SandboxConfig } from '../../src/core/platform-sandbox.js';
+import { CapabilityGateway } from '../../src/core/capability-gateway.js';
+
+export function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  proc.pid = 12345;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  (proc.stdout as EventEmitter & { destroy: () => void }).destroy = vi.fn();
+  (proc.stderr as EventEmitter & { destroy: () => void }).destroy = vi.fn();
+  return proc;
+}
+
+export function makeSandbox(
+  useOsSandbox: boolean,
+  platform: 'darwin' | 'linux',
+  tool: string | null,
+): EffectiveSandbox {
+  const capability: SandboxCapability = {
+    platform,
+    available: useOsSandbox,
+    tool: useOsSandbox ? tool : null,
+    overhead: useOsSandbox ? 'low' : null,
+  };
+  const config: SandboxConfig = { enabled: true, tier: 'auto' };
+  return {
+    useOsSandbox,
+    capability,
+    config,
+    displayStatus: useOsSandbox ? `OS sandbox: ${tool} (${platform})` : 'OS sandbox: disabled',
+  };
+}
+
+export const DEFAULT_CAPS: StepCapability[] = [
+  { type: 'shell' },
+  { type: 'fs:read' },
+];
+
+export function makeContext(
+  projectRoot: string,
+  sandbox?: EffectiveSandbox,
+  caps: StepCapability[] = DEFAULT_CAPS,
+): CastingContext {
+  const gateway = new CapabilityGateway(caps, 'test-step-0', 'bash');
+  return {
+    variables: { projectRoot },
+    args: {},
+    credentials: { get: async () => undefined },
+    memory: {
+      get: async () => undefined,
+      set: async () => {},
+      search: async () => [],
+    },
+    taskId: 'test-step-0',
+    spellId: 'test-spell',
+    stepIndex: 0,
+    effectiveCaps: caps,
+    gateway,
+    sandbox,
+  };
+}

--- a/src/modules/spells/src/commands/bash-command.ts
+++ b/src/modules/spells/src/commands/bash-command.ts
@@ -19,7 +19,9 @@ import { shellInterpolateString } from '../core/interpolation.js';
 import { enforceScope, formatViolations } from '../core/capability-validator.js';
 import { resolvePermissions, type PermissionLevel } from '../core/permission-resolver.js';
 import { checkDestructivePatterns, formatDestructiveError } from './destructive-pattern-checker.js';
-import { wrapWithSandboxExec, type SandboxWrapResult } from '../core/sandbox-profile.js';
+import type { SandboxWrapResult } from '../core/sandbox-utils.js';
+import { wrapWithSandboxExec } from '../core/sandbox-profile.js';
+import { wrapWithBwrap } from '../core/bwrap-sandbox.js';
 
 /** Typed config for the bash step command. */
 export interface BashStepConfig extends StepConfig {
@@ -129,16 +131,21 @@ export const bashCommand: StepCommand<BashStepConfig> = {
     // Resolve shell: prefer Git Bash on Windows to avoid WSL bash hanging.
     const resolvedShell = platform() === 'win32' ? resolveGitBash() : 'bash';
 
-    // ── macOS sandbox-exec wrapping (#410) ─────────────────────────────
-    // When on macOS with OS sandbox enabled, wrap via sandbox-exec.
+    // ── OS sandbox wrapping (#410 macOS, #411 Linux) ────────────────────
+    // When OS sandbox is enabled, wrap via the platform-specific tool.
     let sandboxWrap: SandboxWrapResult | null = null;
-    if (context.sandbox?.useOsSandbox && context.sandbox.capability.tool === 'sandbox-exec') {
+    if (context.sandbox?.useOsSandbox) {
+      const tool = context.sandbox.capability.tool;
       try {
         const projectRoot = (context.variables.projectRoot as string) || process.cwd();
         const caps = context.effectiveCaps ?? [];
-        sandboxWrap = wrapWithSandboxExec(command, caps, projectRoot);
+        if (tool === 'sandbox-exec') {
+          sandboxWrap = wrapWithSandboxExec(command, caps, projectRoot);
+        } else if (tool === 'bwrap') {
+          sandboxWrap = wrapWithBwrap(command, caps, projectRoot);
+        }
       } catch (err) {
-        console.log(`[bash] sandbox-exec profile generation failed, running unsandboxed: ${(err as Error).message}`);
+        console.log(`[bash] ${tool} wrapping failed, running unsandboxed: ${(err as Error).message}`);
       }
     }
 
@@ -213,13 +220,13 @@ export const bashCommand: StepCommand<BashStepConfig> = {
       let activeChild: ChildProcess = spawn(spawnBin, spawnArgs, spawnOpts);
       wireOutputs(activeChild);
 
-      // ── Sandbox-exec fallback (#410) ───────────────────────────────
-      // If sandbox-exec spawn itself fails (ENOENT, permission error),
+      // ── Sandbox fallback (#410, #411) ──────────────────────────────
+      // If the sandbox tool spawn fails (ENOENT, permission error),
       // fall back to unsandboxed execution with new child.
       if (sandboxWrap) {
         activeChild.on('error', (err: NodeJS.ErrnoException) => {
           if (resolved) return;
-          console.log(`[bash] sandbox-exec failed (${err.code ?? err.message}), retrying unsandboxed`);
+          console.log(`[bash] sandbox failed (${err.code ?? err.message}), retrying unsandboxed`);
           cleanupSandbox();
           closeStdout = '';
           closeStderr = '';

--- a/src/modules/spells/src/core/bwrap-sandbox.ts
+++ b/src/modules/spells/src/core/bwrap-sandbox.ts
@@ -1,0 +1,111 @@
+/**
+ * Linux Bubblewrap (bwrap) Sandbox Wrapper
+ *
+ * Generates bwrap command-line arguments from step capabilities and wraps
+ * bash commands for sandboxed execution inside a Linux namespace.
+ *
+ * Unlike macOS sandbox-exec (which needs a temp .sb profile file), bwrap
+ * takes all its configuration as CLI arguments, so no temp files are needed.
+ *
+ * @see https://github.com/eric-cielo/moflo/issues/411
+ */
+
+import type { StepCapability } from '../types/step-command.types.js';
+import { resolveScopePath, type SandboxWrapResult } from './sandbox-utils.js';
+
+/**
+ * Build bwrap CLI arguments from step capabilities.
+ *
+ * Default posture: deny-all via read-only root bind, unshared PID and network.
+ * Capabilities grant specific permissions:
+ *   - fs:read scoped  -> --ro-bind for each scope path
+ *   - fs:read unscoped -> --ro-bind for projectRoot (already covered by / bind)
+ *   - fs:write scoped  -> --bind (read-write) for each scope path
+ *   - fs:write unscoped -> --bind (read-write) for projectRoot
+ *   - net              -> omit --unshare-net
+ */
+export function buildBwrapArgs(
+  command: string,
+  capabilities: readonly StepCapability[],
+  projectRoot: string,
+): readonly string[] {
+  const args: string[] = [];
+
+  // ── Root filesystem (read-only by default) ──────────────────────────
+  args.push('--ro-bind', '/', '/');
+
+  // ── Device and proc filesystems ─────────────────────────────────────
+  args.push('--dev', '/dev');
+  args.push('--proc', '/proc');
+
+  // ── Writable tmpfs at /tmp ──────────────────────────────────────────
+  args.push('--tmpfs', '/tmp');
+
+  // ── fs:write — grant read-write bind mounts ─────────────────────────
+  const fsWrite = capabilities.find(c => c.type === 'fs:write');
+  if (fsWrite) {
+    if (fsWrite.scope && fsWrite.scope.length > 0) {
+      for (const scopePath of fsWrite.scope) {
+        const resolved = resolveScopePath(scopePath, projectRoot);
+        args.push('--bind', resolved, resolved);
+      }
+    } else {
+      // Unscoped fs:write -> writable project root
+      args.push('--bind', projectRoot, projectRoot);
+    }
+  }
+
+  // ── fs:read scoped — explicit read-only bind mounts ─────────────────
+  // Unscoped fs:read is already covered by the --ro-bind / / at the top.
+  const fsRead = capabilities.find(c => c.type === 'fs:read');
+  if (fsRead && fsRead.scope && fsRead.scope.length > 0) {
+    for (const scopePath of fsRead.scope) {
+      const resolved = resolveScopePath(scopePath, projectRoot);
+      // Only add if not already covered by an fs:write --bind for same path
+      const alreadyWritable = fsWrite?.scope?.some(
+        wp => resolveScopePath(wp, projectRoot) === resolved,
+      );
+      if (!alreadyWritable) {
+        args.push('--ro-bind', resolved, resolved);
+      }
+    }
+  }
+
+  // ── Network isolation ───────────────────────────────────────────────
+  const hasNet = capabilities.some(c => c.type === 'net');
+  if (!hasNet) {
+    args.push('--unshare-net');
+  }
+
+  // ── PID isolation (always) ──────────────────────────────────────────
+  args.push('--unshare-pid');
+
+  // ── Command ─────────────────────────────────────────────────────────
+  args.push('bash', '-c', command);
+
+  return args;
+}
+
+/**
+ * Wrap a bash command for execution under Linux bubblewrap (bwrap).
+ *
+ * Returns a `SandboxWrapResult` compatible with the macOS sandbox-exec wrapper,
+ * so `bash-command.ts` can use either interchangeably.
+ *
+ * Unlike sandbox-exec, bwrap uses CLI args only — no temp files are created,
+ * so `cleanup()` is a no-op.
+ */
+export function wrapWithBwrap(
+  command: string,
+  capabilities: readonly StepCapability[],
+  projectRoot: string,
+): SandboxWrapResult {
+  const args = buildBwrapArgs(command, capabilities, projectRoot);
+
+  return {
+    bin: 'bwrap',
+    args,
+    cleanup: () => {},
+  };
+}
+

--- a/src/modules/spells/src/core/sandbox-profile.ts
+++ b/src/modules/spells/src/core/sandbox-profile.ts
@@ -12,19 +12,9 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import type { StepCapability } from '../types/step-command.types.js';
+import { resolveScopePath, type SandboxWrapResult } from './sandbox-utils.js';
 
-// ============================================================================
-// Types
-// ============================================================================
-
-export interface SandboxWrapResult {
-  /** Shell binary to spawn (sandbox-exec). */
-  readonly bin: string;
-  /** Args array: ['-f', profilePath, 'bash', '-c', command]. */
-  readonly args: readonly string[];
-  /** Call after process exits to remove the temp profile. */
-  readonly cleanup: () => void;
-}
+export type { SandboxWrapResult } from './sandbox-utils.js';
 
 // ============================================================================
 // Profile Generation
@@ -155,16 +145,6 @@ export function wrapWithSandboxExec(
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/**
- * Resolve a scope path relative to project root.
- * Absolute paths pass through; relative paths are joined with projectRoot.
- */
-function resolveScopePath(scopePath: string, projectRoot: string): string {
-  if (scopePath.startsWith('/')) return scopePath;
-  const cleaned = scopePath.replace(/^\.\//, '');
-  return join(projectRoot, cleaned);
-}
 
 /**
  * Escape a path for use inside a sandbox profile string literal.

--- a/src/modules/spells/src/core/sandbox-utils.ts
+++ b/src/modules/spells/src/core/sandbox-utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared Sandbox Utilities
+ *
+ * Common types and helpers used by both macOS sandbox-exec and Linux bwrap wrappers.
+ *
+ * @see https://github.com/eric-cielo/moflo/issues/410
+ * @see https://github.com/eric-cielo/moflo/issues/411
+ */
+
+import { posix, isAbsolute } from 'node:path';
+
+/**
+ * Result of wrapping a bash command for OS-level sandbox execution.
+ * Used by both sandbox-exec (macOS) and bwrap (Linux).
+ */
+export interface SandboxWrapResult {
+  /** Binary to spawn (e.g. '/usr/bin/sandbox-exec' or 'bwrap'). */
+  readonly bin: string;
+  /** Args array for the spawn call. */
+  readonly args: readonly string[];
+  /** Call after process exits to clean up temp files (no-op for bwrap). */
+  readonly cleanup: () => void;
+}
+
+/**
+ * Resolve a scope path relative to project root.
+ * Absolute paths pass through; relative paths are joined with projectRoot.
+ * Uses POSIX paths since sandboxing only runs on macOS and Linux.
+ */
+export function resolveScopePath(scopePath: string, projectRoot: string): string {
+  if (isAbsolute(scopePath)) return scopePath;
+  const cleaned = scopePath.replace(/^\.\//, '');
+  return posix.join(projectRoot, cleaned);
+}

--- a/src/modules/spells/src/index.ts
+++ b/src/modules/spells/src/index.ts
@@ -98,10 +98,19 @@ export {
 } from './core/platform-sandbox.js';
 
 export {
+  resolveScopePath,
+  type SandboxWrapResult,
+} from './core/sandbox-utils.js';
+
+export {
   generateSandboxProfile,
   wrapWithSandboxExec,
-  type SandboxWrapResult,
 } from './core/sandbox-profile.js';
+
+export {
+  buildBwrapArgs,
+  wrapWithBwrap,
+} from './core/bwrap-sandbox.js';
 
 export {
   resolvePermissions,


### PR DESCRIPTION
## Summary

- Add Linux bubblewrap (bwrap) sandbox wrapping for spell bash steps, mirroring macOS sandbox-exec (#410)
- Extract shared `SandboxWrapResult` type and `resolveScopePath()` into `sandbox-utils.ts` to eliminate DRY violation
- Extract shared test helpers into `__tests__/helpers/bash-test-utils.ts`

## Changes

**New files:**
- `src/modules/spells/src/core/bwrap-sandbox.ts` — bwrap arg generation + command wrapping
- `src/modules/spells/src/core/sandbox-utils.ts` — shared sandbox types and helpers
- `src/modules/spells/__tests__/bwrap-sandbox.test.ts` — unit tests for bwrap arg builder
- `src/modules/spells/__tests__/bash-bwrap.test.ts` — integration tests for bash+bwrap
- `src/modules/spells/__tests__/helpers/bash-test-utils.ts` — shared test fixtures

**Modified files:**
- `bash-command.ts` — dispatch to bwrap wrapper when `tool === 'bwrap'`
- `sandbox-profile.ts` — import shared types/helpers from sandbox-utils
- `index.ts` — export new bwrap and shared utils APIs

## Testing

- [x] Unit tests: bwrap arg generation (8 tests)
- [x] Integration tests: bash+bwrap wrapping (4 tests)
- [x] Regression: existing sandbox-exec tests pass (4 tests)
- [x] Regression: platform-sandbox detection tests pass (25 tests)
- [x] Build passes (tsc clean)

Closes #411

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)