### PR TITLE
fix(cli): resolve broken cross-package runtime imports to @moflo/spells

### DIFF
--- a/src/modules/cli/src/commands/doctor.ts
+++ b/src/modules/cli/src/commands/doctor.ts
@@ -9,7 +9,8 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, statSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { resolve } from 'path';
 import { execSync, exec } from 'child_process';
 import { promisify } from 'util';
 import os from 'os';
@@ -1384,8 +1385,16 @@ export const doctorCommand: Command = {
     // Check sandbox tier — reports which OS-level sandbox is available (#412)
     async function checkSandboxTier(): Promise<HealthCheck> {
       try {
+        // Walk up to CLI package root, then resolve sibling spells package
+        // (works from both src/ and dist/src/ locations)
+        const __doctorDir = dirname(fileURLToPath(import.meta.url));
+        let cliPkgRoot = __doctorDir;
+        while (cliPkgRoot !== dirname(cliPkgRoot) && !existsSync(join(cliPkgRoot, 'package.json'))) {
+          cliPkgRoot = dirname(cliPkgRoot);
+        }
+        const sandboxPath = resolve(cliPkgRoot, '..', 'spells', 'dist', 'core', 'platform-sandbox.js');
         const { detectSandboxCapability } = await import(
-          '../../../spells/src/core/platform-sandbox.js'
+          pathToFileURL(sandboxPath).href
         );
         const cap = detectSandboxCapability();
 

--- a/src/modules/cli/src/commands/hive-mind.ts
+++ b/src/modules/cli/src/commands/hive-mind.ts
@@ -13,7 +13,19 @@ import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { spawn as childSpawn, execSync } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
-import { resolvePermissions } from '../../../spells/src/core/permission-resolver.js';
+// Inline permission resolver to avoid cross-package runtime import
+// (cli rootDir:"." produces dist/src/ which breaks relative paths to spells/)
+const PERM_TOOLS: Record<string, readonly string[]> = {
+  readonly:  ['Read', 'Glob', 'Grep'],
+  standard:  ['Edit', 'Write', 'Read', 'Glob', 'Grep'],
+  elevated:  ['Edit', 'Write', 'Bash', 'Read', 'Glob', 'Grep'],
+};
+function resolvePermissions(level?: string): { cliArgs: string[] } {
+  const args = ['--dangerously-skip-permissions'];
+  const tools = level && level !== 'autonomous' ? PERM_TOOLS[level] : undefined;
+  if (tools) args.push('--allowedTools', tools.join(','));
+  return { cliArgs: args };
+}
 
 // Worker type definitions for prompt generation
 interface HiveWorker {
@@ -259,7 +271,7 @@ async function spawnClaudeCodeInstance(
       // is always included — but --allowedTools restricts the blast radius.
       const noAutoPerms = flags['no-auto-permissions'];
       if (!noAutoPerms) {
-        const permLevel = flags['permission-level'] ?? 'elevated';
+        const permLevel = (flags['permission-level'] as string) ?? 'elevated';
         const resolved = resolvePermissions(permLevel);
         claudeArgs.push(...resolved.cliArgs);
       }


### PR DESCRIPTION
## Summary
- Fix `moflo doctor` crash: `Cannot find module` for `platform-sandbox.js` — used walk-up-to-package-root dynamic import pattern (matching `engine-loader.ts`)
- Fix `hive-mind` crash: broken relative import to `permission-resolver.js` — inlined the small permission resolution logic
- Root cause: CLI's `rootDir: "."` produces `dist/src/` layout, making relative paths to sibling `spells/` package resolve one level too shallow at runtime

## Test plan
- [x] `moflo doctor` — sandbox tier check now passes (was `Cannot find module` error)
- [x] Full test suite: 217 files, 7143 passed, 21 skipped (platform-conditional)
- [x] Build passes cleanly

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)