### PR TITLE
chore: install moflo@4.8.56-rc.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.19.37",
         "eslint": "^8.0.0",
-        "moflo": "^4.8.56-rc.9",
+        "moflo": "^4.8.56-rc.10",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -10290,9 +10290,9 @@
       "optional": true
     },
     "node_modules/moflo": {
-      "version": "4.8.56-rc.9",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.56-rc.9.tgz",
-      "integrity": "sha512-6FxVbL5DEjND/G02480CH14qiy8OLIOrJujwlyITocojt7ZkijVthUawHrzkq3eFCp1GbS3SSRq+L+JPYL3Ycw==",
+      "version": "4.8.56-rc.10",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.8.56-rc.10.tgz",
+      "integrity": "sha512-GjM0RCDV9jtTS7iMOW5Nq5IMgZWEddQAIicRuCKJ+GB/Gf0PbpauTAjuZQWnmNHezP0n88nwC6KFmDE3AOlpGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.37",
     "eslint": "^8.0.0",
-    "moflo": "^4.8.56-rc.9",
+    "moflo": "^4.8.56-rc.10",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"


### PR DESCRIPTION
## Summary
- Bump local moflo devDependency to rc.10 (least-privilege permission escalation + log redaction)

## Test plan
- [x] `npm install` succeeded

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)