### PR TITLE
feat(spells): preflight severity + interactive resolutions

### DIFF
--- a/.claude/skills/connector-builder/SKILL.md
+++ b/.claude/skills/connector-builder/SKILL.md
@@ -414,12 +414,64 @@ export const <type>Command: StepCommand<<Type>StepConfig> = {
     ];
   },
 
+  // Optional: runtime preflight checks — run BEFORE any step executes.
+  // Use for validating runtime state (issue open, service reachable, etc).
+  // CRITICAL: the `reason` string IS the message the end user sees.
+  // Write it in plain English. State the problem AND the fix. No tool
+  // jargon, no exit codes, no internal identifiers.
+  //
+  // Default severity is 'fatal' (abort on failure). Set severity: 'warning'
+  // + resolutions when the user can safely choose how to proceed; in
+  // interactive runs they'll be prompted, in non-interactive runs warnings
+  // behave like fatals.
+  //
+  // preflight: [
+  //   {
+  //     name: '<service> reachable',
+  //     severity: 'fatal',
+  //     check: async (config, ctx) => {
+  //       const ok = await ping(config.endpoint);
+  //       if (ok) return { passed: true };
+  //       return {
+  //         passed: false,
+  //         reason: `Can't reach ${config.endpoint}. Check your network connection or the service URL in your spell config.`,
+  //       };
+  //     },
+  //   },
+  //   {
+  //     name: 'local cache fresh',
+  //     severity: 'warning',
+  //     resolutions: [
+  //       { label: 'Refresh the cache now', command: '<type>-cli cache refresh' },
+  //       { label: 'Continue with stale cache' },
+  //     ],
+  //     check: async (config) => {
+  //       const stale = await isCacheStale(config.endpoint);
+  //       return stale
+  //         ? { passed: false, reason: 'Your local cache is more than 24 hours old and may produce outdated results.' }
+  //         : { passed: true };
+  //     },
+  //   },
+  // ],
+
   // Optional: rollback on failure
   // async rollback(config, context) { /* undo side effects */ },
 };
 ```
 
 Alternatively, use the `createStepCommand()` factory from `src/modules/spells/src/commands/create-step-command.ts` for compile-time type safety.
+
+#### Preflight `reason` strings — write for humans
+
+When your step declares `preflight` checks, the `reason` string returned on failure is shown verbatim to end users as the error message. Treat it as user-facing copy:
+
+- Plain English, no command names, exit codes, or internal identifiers.
+- State BOTH the problem and the fix.
+- Assume a non-technical reader.
+
+Good: `"You're not signed in to GitHub. Run: gh auth login"`
+Bad: `"gh auth status exited with code 1"` — leaks implementation detail
+Bad: `"auth check failed"` — tells the user nothing actionable
 
 ### Step 3: Generate Step Command Test
 

--- a/.claude/skills/spell-builder/SKILL.md
+++ b/.claude/skills/spell-builder/SKILL.md
@@ -136,6 +136,65 @@ Permissions for step "analyze-logs":
 - `{credentials.NAME}` — references a credential (resolved at runtime)
 - `{stepId.outputKey}` — references output from a previous step
 
+#### REQUIRED: Preflight checks with human-readable hints
+
+When a step depends on runtime state the user controls (clean git tree, logged-in CLI, reachable host, etc.), declare a `preflight:` block so the spell fails fast with a helpful message BEFORE any side effects occur.
+
+**Every preflight MUST include a `hint:` field.** The hint is what the end user will see when the check fails. Without it they get raw shell output (`command "git diff --quiet" exited with 1, expected 0`), which looks like a bug in the spell engine.
+
+Good hints:
+- Speak in plain English (no command names, exit codes, or tool jargon).
+- State the problem AND the fix in one or two sentences.
+- Assume a non-technical reader.
+
+```yaml
+steps:
+  - id: create-branch
+    type: bash
+    preflight:
+      - name: "working tree clean (tracked changes)"
+        command: "git diff --quiet"
+        hint: "You have uncommitted changes to tracked files. Commit them or stash them (git stash) before running this spell."
+      - name: "gh cli authenticated"
+        command: "gh auth status"
+        hint: "The GitHub CLI isn't signed in. Run: gh auth login"
+    config:
+      command: "git checkout -b feature/new"
+```
+
+Bad hint (don't do this):
+```yaml
+hint: "git diff --quiet failed with exit code 1"   # leaks command name + exit code
+hint: "Precondition violated"                       # tells user nothing actionable
+```
+
+Preflights with no `hint` still work but produce unfriendly default output — flag this to the user as a quality issue before saving the spell.
+
+##### Fatal vs warning severity
+
+By default every preflight is `severity: fatal` — if it fails, the spell aborts. Some preflights are better expressed as `severity: warning`: the user gets to choose how to handle the problem, and the spell continues if they pick a resolution.
+
+Use `warning` ONLY when:
+- The underlying problem has a safe, one-step fix the user might reasonably want to apply.
+- Proceeding is viable either way — the step itself is robust to the condition.
+
+Warning preflights MUST declare `resolutions:` — a list of options the user can pick from. Each resolution has a `label` and an optional `command` to run before continuing. If `command` is omitted, picking the resolution just proceeds (useful for "I'll handle it myself").
+
+```yaml
+preflight:
+  - name: "working tree clean (tracked changes)"
+    command: "git diff --quiet"
+    severity: "warning"
+    hint: "You have uncommitted changes. If you want them carried onto the new branch, pick 'Stash and carry over'."
+    resolutions:
+      - label: "Stash changes and carry them onto the new branch"
+        command: "git stash push --include-untracked --message 'pre-spell autostash'"
+      - label: "Commit changes to the current branch first, then continue"
+        command: "git commit -am 'wip: pre-spell snapshot'"
+```
+
+In non-interactive contexts (CI, daemons, scheduled spells) warnings automatically behave like fatals, because there is no one to prompt. Don't use `warning` as a way to silently ignore a problem — if ignoring it is always safe, the check shouldn't be there.
+
 ### Step 4: Generate the Spell YAML
 
 Assemble the definition into YAML format following this structure:
@@ -407,6 +466,13 @@ arguments:
 steps:
   - id: scan-deps
     type: bash
+    preflight:
+      - name: "npm available"
+        command: "npm --version"
+        hint: "npm isn't installed or isn't on your PATH. Install Node.js from https://nodejs.org and try again."
+      - name: "target directory exists"
+        command: "test -d \"{args.target}\""
+        hint: "The directory you passed as --target doesn't exist. Check the path and try again."
     config:
       command: "npm audit --json"
       cwd: "{args.target}"

--- a/src/modules/cli/src/commands/epic.ts
+++ b/src/modules/cli/src/commands/epic.ts
@@ -25,7 +25,12 @@ import {
   resolveExecutionOrder,
 } from '../epic/index.js';
 import type { EpicStrategy } from '../epic/types.js';
-import { runEpicSpell } from '../epic/runner-adapter.js';
+import {
+  runEpicSpell,
+  type PreflightWarning,
+  type PreflightWarningDecision,
+} from '../epic/runner-adapter.js';
+import { select } from '../prompt.js';
 
 // ============================================================================
 // Spell Template Loader
@@ -223,6 +228,7 @@ async function runEpic(
           console.log(`[epic]   └─ ${stepResult.error}`);
         }
       },
+      onPreflightWarnings: isInteractive() ? resolvePreflightWarningsInteractively : undefined,
     });
 
     if (result.success) {
@@ -235,9 +241,19 @@ async function runEpic(
       }
       return { success: true, message: 'Epic completed', data: result };
     } else {
+      const firstErr = result.errors[0] as Record<string, unknown> | undefined;
+      const errCode = firstErr?.code as string | undefined;
+
+      // Preflight failures are user environment problems, not epic bugs.
+      // Show only the friendly prerequisite message, nothing else.
+      if (errCode === 'PREFLIGHT_FAILED' && typeof firstErr?.message === 'string') {
+        console.log(`\n${firstErr.message}`);
+        console.log('\nThe epic was not started. Fix the item(s) above and try again.');
+        return { success: false, message: firstErr.message, data: result };
+      }
+
       console.log(`\n[epic] Epic #${issueNumber} failed`);
 
-      // Print step-level results for visibility
       if (result.steps && result.steps.length > 0) {
         for (const step of result.steps) {
           const icon = step.status === 'succeeded' ? '✓' : step.status === 'skipped' ? '○' : '✗';
@@ -249,7 +265,6 @@ async function runEpic(
         }
       }
 
-      // Print spell-level errors with full detail
       for (const err of result.errors) {
         const prefix = (err as Record<string, unknown>).stepId
           ? `  [${(err as Record<string, unknown>).stepId}]`
@@ -263,8 +278,6 @@ async function runEpic(
         }
       }
 
-      // Build actionable error message from first failure
-      const firstErr = result.errors[0] as Record<string, unknown> | undefined;
       const rawMsg = firstErr?.message as string ?? 'Unknown error';
       const summary = buildFailureSummary(rawMsg, {
         stepId: firstErr?.stepId as string | undefined,
@@ -356,6 +369,45 @@ async function resetEpic(epicNumber: string): Promise<CommandResult> {
 
   console.log(`[epic] Cleared ${cleared} memory entries for epic #${epicNumber}`);
   return { success: true };
+}
+
+// ============================================================================
+// Preflight warning interactive resolver
+// ============================================================================
+
+function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY) && process.env.CI !== 'true';
+}
+
+async function resolvePreflightWarningsInteractively(
+  warnings: readonly PreflightWarning[],
+): Promise<readonly PreflightWarningDecision[]> {
+  console.log('\nBefore this spell starts, some things need your attention:\n');
+
+  const decisions: PreflightWarningDecision[] = [];
+  for (let i = 0; i < warnings.length; i++) {
+    const w = warnings[i];
+    const choices = [
+      ...w.resolutions.map((r, idx) => ({
+        label: r.label,
+        value: { action: 'resolve', resolutionIndex: idx } as PreflightWarningDecision,
+      })),
+      { label: "Continue anyway (I'll handle it)", value: { action: 'continue' } as PreflightWarningDecision },
+      { label: 'Abort the spell', value: { action: 'abort' } as PreflightWarningDecision },
+    ];
+
+    const decision = await select<PreflightWarningDecision>({
+      message: `${i + 1}. ${w.reason}`,
+      options: choices,
+    });
+    decisions.push(decision);
+
+    if (decision.action === 'abort') {
+      while (decisions.length < warnings.length) decisions.push({ action: 'abort' });
+      break;
+    }
+  }
+  return decisions;
 }
 
 // ============================================================================

--- a/src/modules/cli/src/epic/runner-adapter.ts
+++ b/src/modules/cli/src/epic/runner-adapter.ts
@@ -9,7 +9,12 @@
  */
 
 import * as readline from 'node:readline';
-import { loadSpellEngine, type SpellResult } from '../services/engine-loader.js';
+import {
+  loadSpellEngine,
+  type SpellResult,
+  type PreflightWarning,
+  type PreflightWarningDecision,
+} from '../services/engine-loader.js';
 import { createDashboardMemoryAccessor } from '../services/daemon-dashboard.js';
 
 /** Minimal spell result shape matching SpellResult from @moflo/spells. */
@@ -31,7 +36,11 @@ export interface EpicRunOptions {
   args?: Record<string, unknown>;
   dryRun?: boolean;
   onStepComplete?: (step: { stepId: string; status: string; duration: number; error?: string }, index: number, total: number) => void;
+  /** Called when one or more warning-severity preflights fail. */
+  onPreflightWarnings?: (warnings: readonly PreflightWarning[]) => Promise<readonly PreflightWarningDecision[]>;
 }
+
+export type { PreflightWarning, PreflightWarningDecision };
 
 /** Cached memory accessor — created once per process. */
 let memoryAccessor: Awaited<ReturnType<typeof createDashboardMemoryAccessor>> | null = null;

--- a/src/modules/cli/src/epic/spells/auto-merge.yaml
+++ b/src/modules/cli/src/epic/spells/auto-merge.yaml
@@ -62,14 +62,31 @@ steps:
           - name: "no unmerged files"
             command: "git diff --name-only --diff-filter=U"
             expectExitCode: 0
+            hint: "You have unresolved merge conflicts. Resolve them and commit before running this spell."
           - name: "working tree clean (tracked changes)"
             command: "git diff --quiet"
+            severity: "warning"
+            hint: "You have uncommitted changes to tracked files. If you want them carried onto the epic branch, pick 'Stash and carry over'."
+            resolutions:
+              - label: "Stash changes and carry them onto the epic branch"
+                command: "git stash push --include-untracked --message 'moflo-epic-autostash'"
+              - label: "Commit changes to the current branch first, then continue"
+                command: "git commit -am 'wip: pre-epic snapshot'"
           - name: "working tree clean (staged changes)"
             command: "git diff --cached --quiet"
+            severity: "warning"
+            hint: "You have staged changes that aren't committed. If you want them carried onto the epic branch, pick 'Stash and carry over'."
+            resolutions:
+              - label: "Stash staged changes and carry them onto the epic branch"
+                command: "git stash push --include-untracked --message 'moflo-epic-autostash'"
+              - label: "Commit staged changes to the current branch first, then continue"
+                command: "git commit -m 'wip: pre-epic snapshot'"
           - name: "gh cli authenticated"
             command: "gh auth status"
+            hint: "The GitHub CLI isn't signed in. Run: gh auth login"
           - name: "origin remote configured"
             command: "git remote get-url origin"
+            hint: "This repo has no 'origin' remote. Set one with: git remote add origin <url>"
         config:
           command: "git stash --include-untracked -q 2>/dev/null; git checkout {args.base_branch} && git pull origin {args.base_branch}; git stash pop -q 2>/dev/null || true"
           failOnError: true

--- a/src/modules/cli/src/epic/spells/single-branch.yaml
+++ b/src/modules/cli/src/epic/spells/single-branch.yaml
@@ -59,12 +59,28 @@ steps:
       - name: "no unmerged files"
         command: "git diff --name-only --diff-filter=U"
         expectExitCode: 0
+        hint: "You have unresolved merge conflicts. Resolve them and commit before running this spell."
       - name: "working tree clean (tracked changes)"
         command: "git diff --quiet"
+        severity: "warning"
+        hint: "You have uncommitted changes to tracked files. If you want them carried onto the epic branch, pick 'Stash and carry over'."
+        resolutions:
+          - label: "Stash changes and carry them onto the epic branch"
+            command: "git stash push --include-untracked --message 'moflo-epic-autostash'"
+          - label: "Commit changes to the current branch first, then continue"
+            command: "git commit -am 'wip: pre-epic snapshot'"
       - name: "working tree clean (staged changes)"
         command: "git diff --cached --quiet"
+        severity: "warning"
+        hint: "You have staged changes that aren't committed. If you want them carried onto the epic branch, pick 'Stash and carry over'."
+        resolutions:
+          - label: "Stash staged changes and carry them onto the epic branch"
+            command: "git stash push --include-untracked --message 'moflo-epic-autostash'"
+          - label: "Commit staged changes to the current branch first, then continue"
+            command: "git commit -m 'wip: pre-epic snapshot'"
       - name: "gh cli authenticated"
         command: "gh auth status"
+        hint: "The GitHub CLI isn't signed in. Run: gh auth login"
     config:
       command: "git stash --include-untracked -q 2>/dev/null; git checkout {args.base_branch} && git pull origin {args.base_branch} && (git show-ref --verify --quiet refs/heads/epic/{args.epic_number}-{args.epic_slug} && git checkout epic/{args.epic_number}-{args.epic_slug} || git checkout -b epic/{args.epic_number}-{args.epic_slug}); git stash pop -q 2>/dev/null || true"
       timeout: 120000

--- a/src/modules/cli/src/init/moflo-init.ts
+++ b/src/modules/cli/src/init/moflo-init.ts
@@ -817,10 +817,17 @@ function isStale(srcPath: string, destPath: string): boolean {
 
 function updateGitignore(root: string): MofloInitResult['steps'][0] {
   const gitignorePath = path.join(root, '.gitignore');
-  const entries = ['.claude-epic/', '.swarm/', '.moflo/'];
+  const entries = [
+    '.claude-epic/',
+    '.claude-flow/',
+    '.swarm/',
+    '.moflo/',
+    '.claude/settings.local.json',
+    '.claude/scheduled_tasks.lock',
+    '**/workflow-state.json',
+  ];
 
   if (!fs.existsSync(gitignorePath)) {
-    // Create .gitignore with common defaults + MoFlo entries
     const defaultEntries = ['node_modules/', 'dist/', '.env', '.env.*', ''];
     const content = '# Dependencies\n' + defaultEntries.join('\n') + '\n# MoFlo state\n' + entries.join('\n') + '\n';
     fs.writeFileSync(gitignorePath, content, 'utf-8');
@@ -828,13 +835,17 @@ function updateGitignore(root: string): MofloInitResult['steps'][0] {
   }
 
   const existing = fs.readFileSync(gitignorePath, 'utf-8');
-  const toAdd = entries.filter(e => !existing.includes(e));
+  const existingLines = new Set(
+    existing.split(/\r?\n/).map(l => l.trim()).filter(l => l && !l.startsWith('#')),
+  );
+  const toAdd = entries.filter(e => !existingLines.has(e));
 
   if (toAdd.length === 0) {
     return { name: '.gitignore', status: 'skipped', detail: 'Entries already present' };
   }
 
-  fs.appendFileSync(gitignorePath, '\n# MoFlo state (gitignored)\n' + toAdd.join('\n') + '\n');
+  const sep = existing.endsWith('\n') ? '' : '\n';
+  fs.appendFileSync(gitignorePath, sep + '\n# MoFlo state (gitignored)\n' + toAdd.join('\n') + '\n');
   return { name: '.gitignore', status: 'updated', detail: `Added: ${toAdd.join(', ')}` };
 }
 

--- a/src/modules/cli/src/services/engine-loader.ts
+++ b/src/modules/cli/src/services/engine-loader.ts
@@ -14,6 +14,9 @@ import { existsSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type {
   SpellResult,
+  PreflightWarning,
+  PreflightWarningDecision,
+  PreflightWarningHandler,
 } from '../../../../modules/spells/src/types/runner.types.js';
 import type {
   SpellDefinition,
@@ -27,6 +30,7 @@ import type {
 export type { SpellResult };
 export type { SpellDefinition };
 export type { Grimoire };
+export type { PreflightWarning, PreflightWarningDecision, PreflightWarningHandler };
 
 /**
  * Shape of the dynamically imported spell engine module.

--- a/src/modules/spells/__tests__/preflight-severity.test.ts
+++ b/src/modules/spells/__tests__/preflight-severity.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Preflight Severity Tests
+ *
+ * Verifies fatal vs warning behavior, handler invocation, and resolution
+ * command execution when a warning-severity preflight fails.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { SpellCaster } from '../src/core/runner.js';
+import { StepCommandRegistry } from '../src/core/step-command-registry.js';
+import type {
+  StepCommand,
+  CredentialAccessor,
+  MemoryAccessor,
+} from '../src/types/step-command.types.js';
+import type { SpellDefinition } from '../src/types/spell-definition.types.js';
+import type {
+  PreflightWarning,
+  PreflightWarningDecision,
+} from '../src/types/runner.types.js';
+
+function createMockCredentials(): CredentialAccessor {
+  return { async get() { return undefined; }, async has() { return false; } };
+}
+
+function createMockMemory(): MemoryAccessor {
+  const store = new Map<string, unknown>();
+  return {
+    async read(ns: string, key: string) { return store.get(`${ns}:${key}`) ?? null; },
+    async write(ns: string, key: string, value: unknown) { store.set(`${ns}:${key}`, value); },
+    async search() { return []; },
+  };
+}
+
+function bashCommand(): StepCommand {
+  return {
+    type: 'bash',
+    description: 'mock bash',
+    configSchema: { type: 'object' },
+    validate: () => ({ valid: true, errors: [] }),
+    execute: async () => ({ success: true, data: { result: 'ok' }, duration: 1 }),
+    describeOutputs: () => [{ name: 'result', type: 'string' }],
+  };
+}
+
+function makeRunner(): SpellCaster {
+  const registry = new StepCommandRegistry();
+  registry.register(bashCommand());
+  return new SpellCaster(registry, createMockCredentials(), createMockMemory());
+}
+
+const alwaysFailCmd = process.platform === 'win32' ? 'exit 1' : 'false';
+const alwaysPassCmd = process.platform === 'win32' ? 'exit 0' : 'true';
+
+function spellWith(preflight: SpellDefinition['steps'][0]['preflight']): SpellDefinition {
+  return {
+    name: 'severity-test',
+    steps: [{ id: 's1', type: 'bash', config: { command: 'echo ok' }, preflight }],
+  };
+}
+
+describe('preflight severity', () => {
+  it('fatal failure aborts spell with PREFLIGHT_FAILED (default severity)', async () => {
+    const result = await makeRunner().run(
+      spellWith([{ name: 'must-pass', command: alwaysFailCmd, hint: 'nope' }]),
+      {},
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('PREFLIGHT_FAILED');
+  });
+
+  it('warning failure without handler is treated as fatal', async () => {
+    const result = await makeRunner().run(
+      spellWith([{
+        name: 'soft',
+        command: alwaysFailCmd,
+        severity: 'warning',
+        hint: 'soft problem',
+      }]),
+      {},
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('PREFLIGHT_FAILED');
+  });
+
+  it('warning failure with handler calls handler with warning payload', async () => {
+    const handler = vi.fn(async (_warnings: readonly PreflightWarning[]) => {
+      return [{ action: 'continue' }] as readonly PreflightWarningDecision[];
+    });
+    const result = await makeRunner().run(
+      spellWith([{
+        name: 'soft',
+        command: alwaysFailCmd,
+        severity: 'warning',
+        hint: 'soft problem',
+        resolutions: [{ label: 'Skip it' }],
+      }]),
+      {},
+      { onPreflightWarnings: handler },
+    );
+    expect(handler).toHaveBeenCalledOnce();
+    const [warnings] = handler.mock.calls[0];
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].reason).toBe('soft problem');
+    expect(warnings[0].resolutions).toHaveLength(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('handler decision "abort" aborts the spell', async () => {
+    const result = await makeRunner().run(
+      spellWith([{ name: 'soft', command: alwaysFailCmd, severity: 'warning' }]),
+      {},
+      { onPreflightWarnings: async () => [{ action: 'abort' }] },
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('PREFLIGHT_FAILED');
+  });
+
+  it('handler decision "resolve" runs the chosen resolution command', async () => {
+    const result = await makeRunner().run(
+      spellWith([{
+        name: 'soft',
+        command: alwaysFailCmd,
+        severity: 'warning',
+        resolutions: [{ label: 'fix', command: alwaysPassCmd }],
+      }]),
+      {},
+      { onPreflightWarnings: async () => [{ action: 'resolve', resolutionIndex: 0 }] },
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('resolution command failure aborts with a clear message', async () => {
+    const result = await makeRunner().run(
+      spellWith([{
+        name: 'soft',
+        command: alwaysFailCmd,
+        severity: 'warning',
+        resolutions: [{ label: 'fix', command: alwaysFailCmd }],
+      }]),
+      {},
+      { onPreflightWarnings: async () => [{ action: 'resolve', resolutionIndex: 0 }] },
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('PREFLIGHT_FAILED');
+    expect(result.errors[0].message).toMatch(/Resolution "fix" failed/);
+  });
+
+  it('fatal + warning together: fatal aborts before handler is called', async () => {
+    const handler = vi.fn(async () => [{ action: 'continue' }] as readonly PreflightWarningDecision[]);
+    const result = await makeRunner().run(
+      spellWith([
+        { name: 'hard', command: alwaysFailCmd, hint: 'hard-fail' },
+        { name: 'soft', command: alwaysFailCmd, severity: 'warning' },
+      ]),
+      {},
+      { onPreflightWarnings: handler },
+    );
+    expect(result.success).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('invalid resolution index aborts with an error', async () => {
+    const result = await makeRunner().run(
+      spellWith([{
+        name: 'soft',
+        command: alwaysFailCmd,
+        severity: 'warning',
+        resolutions: [{ label: 'fix', command: alwaysPassCmd }],
+      }]),
+      {},
+      { onPreflightWarnings: async () => [{ action: 'resolve', resolutionIndex: 5 }] },
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors[0].message).toMatch(/Invalid resolution index/);
+  });
+
+  it('handler that returns wrong decision count aborts', async () => {
+    const result = await makeRunner().run(
+      spellWith([
+        { name: 'w1', command: alwaysFailCmd, severity: 'warning' },
+        { name: 'w2', command: alwaysFailCmd, severity: 'warning' },
+      ]),
+      {},
+      { onPreflightWarnings: async () => [{ action: 'continue' }] },
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors[0].message).toMatch(/returned 1 decisions for 2 warnings/);
+  });
+});

--- a/src/modules/spells/__tests__/preflights.test.ts
+++ b/src/modules/spells/__tests__/preflights.test.ts
@@ -219,14 +219,29 @@ describe('YAML declarative preflights', () => {
 });
 
 describe('formatPreflightErrors', () => {
-  it('summarizes failures with step id and reason', () => {
+  it('summarizes failures with human-friendly header and reason', () => {
     const out = formatPreflightErrors([
       { stepId: 's1', name: 'issue-exists', passed: false, reason: 'issue #10 not found' },
       { stepId: 's2', name: 'tree-clean', passed: true },
     ]);
-    expect(out).toContain('[s1] issue-exists');
+    expect(out).toContain('prerequisite');
     expect(out).toContain('issue #10 not found');
     expect(out).not.toContain('tree-clean');
+  });
+
+  it('falls back to check name when no reason is provided', () => {
+    const out = formatPreflightErrors([
+      { stepId: 's1', name: 'working tree clean', passed: false },
+    ]);
+    expect(out).toContain('working tree clean');
+  });
+
+  it('uses plural header for multiple failures', () => {
+    const out = formatPreflightErrors([
+      { stepId: 's1', name: 'a', passed: false, reason: 'fail-a' },
+      { stepId: 's2', name: 'b', passed: false, reason: 'fail-b' },
+    ]);
+    expect(out).toContain('2 prerequisites');
   });
 
   it('returns empty string when all pass', () => {

--- a/src/modules/spells/src/core/preflight-checker.ts
+++ b/src/modules/spells/src/core/preflight-checker.ts
@@ -32,6 +32,10 @@ import type {
 import type { StepCommandRegistry } from './step-command-registry.js';
 import { interpolateString } from './interpolation.js';
 import type { CastingContext } from '../types/step-command.types.js';
+import type {
+  PreflightSeverity,
+  PreflightResolution,
+} from '../types/spell-definition.types.js';
 
 // ============================================================================
 // Types
@@ -42,6 +46,8 @@ interface BoundPreflight {
   readonly stepId: string;
   readonly stepIndex: number;
   readonly name: string;
+  readonly severity: PreflightSeverity;
+  readonly resolutions?: readonly PreflightResolution[];
   readonly run: () => Promise<{ passed: boolean; reason?: string }>;
 }
 
@@ -114,6 +120,8 @@ function bindCommandPreflight(
     stepId: step.id,
     stepIndex,
     name: check.name,
+    severity: check.severity ?? 'fatal',
+    resolutions: check.resolutions,
     run: () => {
       const ctx: PreflightContext = {
         args: context.args,
@@ -136,12 +144,17 @@ function bindYamlPreflight(
     stepId: step.id,
     stepIndex,
     name: spec.name,
+    severity: spec.severity ?? 'fatal',
+    resolutions: spec.resolutions,
     run: async () => {
       const command = interpolateSafe(spec.command, context.args);
       const expected = spec.expectExitCode ?? 0;
       const timeoutMs = spec.timeoutMs ?? 10_000;
       const actualExitCode = await runShellExitCode(command, timeoutMs);
       if (actualExitCode === expected) return { passed: true };
+      if (spec.hint) {
+        return { passed: false, reason: spec.hint };
+      }
       return {
         passed: false,
         reason: `command "${command}" exited with ${actualExitCode}, expected ${expected}`,
@@ -167,6 +180,8 @@ export async function checkPreflights(
           name: pf.name,
           passed: result.passed,
           reason: result.reason,
+          severity: pf.severity,
+          resolutions: pf.resolutions,
         };
       } catch (err) {
         return {
@@ -174,10 +189,26 @@ export async function checkPreflights(
           name: pf.name,
           passed: false,
           reason: (err as Error).message,
+          severity: pf.severity,
+          resolutions: pf.resolutions,
         };
       }
     }),
   );
+}
+
+/**
+ * Run a resolution shell command chosen by the user.
+ * Returns true iff the command exits 0 (or no command was provided).
+ */
+export async function runResolutionCommand(
+  resolution: PreflightResolution,
+  args: Record<string, unknown>,
+): Promise<{ ok: boolean; exitCode: number }> {
+  if (!resolution.command) return { ok: true, exitCode: 0 };
+  const cmd = interpolateSafe(resolution.command, args);
+  const exitCode = await runShellExitCode(cmd, resolution.timeoutMs ?? 30_000);
+  return { ok: exitCode === 0, exitCode };
 }
 
 /** Format failed preflights into a user-friendly error message. */
@@ -185,11 +216,29 @@ export function formatPreflightErrors(results: readonly PreflightResult[]): stri
   const failed = results.filter(r => !r.passed);
   if (failed.length === 0) return '';
 
-  const lines = ['Preflight checks failed:'];
+  const header = failed.length === 1
+    ? 'A prerequisite for this spell was not met:'
+    : `${failed.length} prerequisites for this spell were not met:`;
+  const lines = [header];
   for (const f of failed) {
-    lines.push(`  - [${f.stepId}] ${f.name}${f.reason ? `: ${f.reason}` : ''}`);
+    const message = f.reason && f.reason.trim().length > 0 ? f.reason : f.name;
+    lines.push(`  - ${message}`);
   }
   return lines.join('\n');
+}
+
+/** Partition preflight results by severity. */
+export function partitionPreflightResults(
+  results: readonly PreflightResult[],
+): { fatals: readonly PreflightResult[]; warnings: readonly PreflightResult[] } {
+  const fatals: PreflightResult[] = [];
+  const warnings: PreflightResult[] = [];
+  for (const r of results) {
+    if (r.passed) continue;
+    if (r.severity === 'warning') warnings.push(r);
+    else fatals.push(r);
+  }
+  return { fatals, warnings };
 }
 
 // ============================================================================

--- a/src/modules/spells/src/core/runner.ts
+++ b/src/modules/spells/src/core/runner.ts
@@ -30,7 +30,14 @@ import { rollbackSteps, type CompletedStep } from './rollback-orchestrator.js';
 import { buildCredentialPatterns, addCredentialPattern, collectCredentialNames } from './credential-masker.js';
 import { executeSingleStep, type StepExecutionState } from './step-executor.js';
 import { collectPrerequisites, checkPrerequisites, formatPrerequisiteErrors } from './prerequisite-checker.js';
-import { collectPreflights, checkPreflights, formatPreflightErrors } from './preflight-checker.js';
+import {
+  collectPreflights,
+  checkPreflights,
+  formatPreflightErrors,
+  partitionPreflightResults,
+  runResolutionCommand,
+} from './preflight-checker.js';
+import type { PreflightWarning } from '../types/runner.types.js';
 import { DENY_ALL_GATEWAY } from './capability-gateway.js';
 import {
   resolveEffectiveSandbox, formatSandboxLog,
@@ -157,19 +164,13 @@ export class SpellCaster {
       }
 
       // Preflight runtime-state checks — fail fast before any step runs.
-      const preflights = collectPreflights(definition, this.registry, {
-        args: resolvedArgs,
-        credentials: this.credentials,
-      });
-      if (preflights.length > 0) {
-        const preflightResults = await checkPreflights(preflights);
-        if (preflightResults.some(r => !r.passed)) {
-          console.log(`[spell] ${formatPreflightErrors(preflightResults)}`);
-          return this.failureResult(spellId, startTime, [{
-            code: 'PREFLIGHT_FAILED',
-            message: formatPreflightErrors(preflightResults),
-          }], definition.name);
-        }
+      const preflightFailure = await this.runPreflights(definition, resolvedArgs, options);
+      if (preflightFailure) {
+        return this.failureResult(
+          spellId, startTime,
+          [{ code: 'PREFLIGHT_FAILED', message: preflightFailure }],
+          definition.name,
+        );
       }
     }
 
@@ -408,6 +409,60 @@ export class SpellCaster {
   // --------------------------------------------------------------------------
   // Private — Helpers
   // --------------------------------------------------------------------------
+
+  /**
+   * Run every preflight declared by the spell.
+   * Returns a user-facing failure message, or null if the spell may proceed.
+   */
+  private async runPreflights(
+    definition: SpellDefinition,
+    resolvedArgs: Record<string, unknown>,
+    options: RunnerOptions,
+  ): Promise<string | null> {
+    const preflights = collectPreflights(definition, this.registry, {
+      args: resolvedArgs,
+      credentials: this.credentials,
+    });
+    if (preflights.length === 0) return null;
+
+    const results = await checkPreflights(preflights);
+    const { fatals, warnings } = partitionPreflightResults(results);
+
+    if (fatals.length > 0) return formatPreflightErrors(fatals);
+    if (warnings.length === 0) return null;
+    if (!options.onPreflightWarnings) return formatPreflightErrors(warnings);
+
+    const payload: PreflightWarning[] = warnings.map(w => ({
+      stepId: w.stepId,
+      name: w.name,
+      reason: w.reason ?? w.name,
+      resolutions: w.resolutions ?? [],
+    }));
+
+    const decisions = await options.onPreflightWarnings(payload);
+    if (decisions.length !== warnings.length) {
+      return `Preflight warning handler returned ${decisions.length} decisions for ${warnings.length} warnings`;
+    }
+
+    for (let i = 0; i < decisions.length; i++) {
+      const decision = decisions[i];
+      const warn = warnings[i];
+      if (decision.action === 'abort') {
+        return formatPreflightErrors([warn]);
+      }
+      if (decision.action === 'resolve') {
+        const chosen = (warn.resolutions ?? [])[decision.resolutionIndex];
+        if (!chosen) {
+          return `Invalid resolution index ${decision.resolutionIndex} for "${warn.name}"`;
+        }
+        const { ok, exitCode } = await runResolutionCommand(chosen, resolvedArgs);
+        if (!ok) {
+          return `Resolution "${chosen.label}" failed (exit code ${exitCode}). Fix the underlying issue and try again.`;
+        }
+      }
+    }
+    return null;
+  }
 
   private runStep(
     step: import('../types/spell-definition.types.js').StepDefinition,

--- a/src/modules/spells/src/index.ts
+++ b/src/modules/spells/src/index.ts
@@ -51,6 +51,9 @@ export type {
   DryRunResult,
   DryRunStepReport,
   FloRunContext,
+  PreflightWarning,
+  PreflightWarningDecision,
+  PreflightWarningHandler,
 } from './types/runner.types.js';
 
 // ============================================================================
@@ -177,6 +180,8 @@ export type {
   ArgumentType,
   ParsedSpell,
   PreflightSpec,
+  PreflightSeverity,
+  PreflightResolution,
 } from './types/spell-definition.types.js';
 
 export type {

--- a/src/modules/spells/src/schema/validator.ts
+++ b/src/modules/spells/src/schema/validator.ts
@@ -224,6 +224,34 @@ function validateSteps(
           if (pf.timeoutMs !== undefined && (typeof pf.timeoutMs !== 'number' || pf.timeoutMs <= 0)) {
             errors.push({ path: `${pfPath}.timeoutMs`, message: 'timeoutMs must be a positive number' });
           }
+          if (pf.hint !== undefined && typeof pf.hint !== 'string') {
+            errors.push({ path: `${pfPath}.hint`, message: 'hint must be a string' });
+          }
+          if (pf.severity !== undefined && pf.severity !== 'fatal' && pf.severity !== 'warning') {
+            errors.push({ path: `${pfPath}.severity`, message: 'severity must be "fatal" or "warning"' });
+          }
+          if (pf.resolutions !== undefined) {
+            if (!Array.isArray(pf.resolutions)) {
+              errors.push({ path: `${pfPath}.resolutions`, message: 'resolutions must be an array' });
+            } else {
+              pf.resolutions.forEach((r: Record<string, unknown>, ri: number) => {
+                const rPath = `${pfPath}.resolutions[${ri}]`;
+                if (!r || typeof r !== 'object') {
+                  errors.push({ path: rPath, message: 'resolution must be an object' });
+                  return;
+                }
+                if (typeof r.label !== 'string' || r.label.length === 0) {
+                  errors.push({ path: `${rPath}.label`, message: 'resolution.label is required' });
+                }
+                if (r.command !== undefined && typeof r.command !== 'string') {
+                  errors.push({ path: `${rPath}.command`, message: 'resolution.command must be a string' });
+                }
+                if (r.timeoutMs !== undefined && (typeof r.timeoutMs !== 'number' || r.timeoutMs <= 0)) {
+                  errors.push({ path: `${rPath}.timeoutMs`, message: 'resolution.timeoutMs must be a positive number' });
+                }
+              });
+            }
+          }
         });
       }
     }

--- a/src/modules/spells/src/types/runner.types.ts
+++ b/src/modules/spells/src/types/runner.types.ts
@@ -8,6 +8,7 @@ import type { StepOutput, ValidationError, MofloLevel, PrerequisiteResult } from
 import type { PermissionLevel, ResolvedPermissions } from '../core/permission-resolver.js';
 import type { PermissionWarning, RiskLevel } from '../core/permission-disclosure.js';
 import type { SandboxConfig } from '../core/platform-sandbox.js';
+import type { PreflightResolution } from './spell-definition.types.js';
 
 // ============================================================================
 // Error Codes
@@ -186,4 +187,41 @@ export interface RunnerOptions {
 
   /** Skip the first-run acceptance gate (e.g. for internal/nested spells). */
   readonly skipAcceptanceCheck?: boolean;
+
+  /**
+   * Handler invoked when one or more warning-severity preflights fail but
+   * no fatal ones did. The handler decides whether to abort, continue, or
+   * resolve each warning via its declared resolutions.
+   *
+   * If not provided, warnings are treated as fatal (safer default for
+   * non-interactive contexts like CI, daemons, and scheduled spells).
+   */
+  readonly onPreflightWarnings?: PreflightWarningHandler;
 }
+
+// ============================================================================
+// Preflight warning handling
+// ============================================================================
+
+/** A single warning preflight surfaced to the user for a decision. */
+export interface PreflightWarning {
+  readonly stepId: string;
+  readonly name: string;
+  readonly reason: string;
+  readonly resolutions: readonly PreflightResolution[];
+}
+
+/** Per-warning decision returned by the handler. */
+export type PreflightWarningDecision =
+  | { readonly action: 'abort' }
+  | { readonly action: 'continue' }
+  | { readonly action: 'resolve'; readonly resolutionIndex: number };
+
+/**
+ * Called with the full list of warnings. Must return one decision per warning
+ * (same length, same order). Any 'abort' aborts the whole spell. 'resolve'
+ * runs the chosen resolution's command before the spell continues.
+ */
+export type PreflightWarningHandler = (
+  warnings: readonly PreflightWarning[],
+) => Promise<readonly PreflightWarningDecision[]>;

--- a/src/modules/spells/src/types/spell-definition.types.ts
+++ b/src/modules/spells/src/types/spell-definition.types.ts
@@ -57,12 +57,53 @@ export interface StepDefinition {
   readonly preflight?: readonly PreflightSpec[];
 }
 
+/**
+ * Severity of a preflight failure.
+ *   fatal   — always aborts the spell (default).
+ *   warning — surfaces resolution options via the runner's warning handler.
+ *             If no handler is configured (non-interactive run), warnings
+ *             behave like fatals.
+ */
+export type PreflightSeverity = 'fatal' | 'warning';
+
+/**
+ * One user-pickable resolution for a failed warning preflight.
+ * When the user selects a resolution, its optional `command` runs before
+ * the spell proceeds; if the command fails, the spell aborts.
+ */
+export interface PreflightResolution {
+  /** User-facing label (imperative, e.g. "Stash changes and continue"). */
+  readonly label: string;
+  /**
+   * Shell command to run when the user picks this resolution.
+   * Interpolated against spell args. If omitted, picking the resolution
+   * proceeds without running anything — useful for "I'll handle it" opts.
+   */
+  readonly command?: string;
+  /** Timeout in ms for the resolution command (default: 30_000). */
+  readonly timeoutMs?: number;
+}
+
 /** Declarative preflight check in a step definition. */
 export interface PreflightSpec {
   readonly name: string;
   readonly command: string;
   readonly expectExitCode?: number;
   readonly timeoutMs?: number;
+  /**
+   * Human-readable message shown to the user when this check fails.
+   * Should explain the problem and how to fix it, in plain language
+   * (no command names, exit codes, or tool jargon).
+   * Example: "You have uncommitted changes. Commit or stash them first."
+   */
+  readonly hint?: string;
+  /** Failure severity. Defaults to 'fatal'. */
+  readonly severity?: PreflightSeverity;
+  /**
+   * Resolution options offered to the user when this warning fires.
+   * Only relevant when severity is 'warning'.
+   */
+  readonly resolutions?: readonly PreflightResolution[];
 }
 
 // ============================================================================

--- a/src/modules/spells/src/types/step-command.types.ts
+++ b/src/modules/spells/src/types/step-command.types.ts
@@ -2,6 +2,8 @@
  * Spell Step Command Type Definitions
  */
 
+import type { PreflightSeverity, PreflightResolution } from './spell-definition.types.js';
+
 // ============================================================================
 // Validation
 // ============================================================================
@@ -201,6 +203,10 @@ export interface PreflightResult {
   readonly name: string;
   readonly passed: boolean;
   readonly reason?: string;
+  /** Severity of this check. Always resolved to a concrete value. */
+  readonly severity: PreflightSeverity;
+  /** Resolution options available (only meaningful when failed + warning). */
+  readonly resolutions?: readonly PreflightResolution[];
 }
 
 /**
@@ -211,6 +217,10 @@ export interface PreflightResult {
  */
 export interface PreflightCheck<TConfig extends StepConfig = StepConfig> {
   readonly name: string;
+  /** Failure severity. Defaults to 'fatal'. */
+  readonly severity?: PreflightSeverity;
+  /** Resolution options offered when a warning fires. */
+  readonly resolutions?: readonly PreflightResolution[];
   check(config: TConfig, context: PreflightContext): Promise<{ passed: boolean; reason?: string }>;
 }
 


### PR DESCRIPTION
## Summary
- Preflight checks can declare `severity: warning` with `resolutions`; the runner invokes an `onPreflightWarnings` handler so interactive contexts can prompt the user and optionally run a resolution command before proceeding. Non-interactive runs still treat warnings as fatal.
- Fatal preflight failures now surface as \"A prerequisite for this spell was not met: <hint>\" instead of raw shell exit codes, and the epic CLI suppresses the \"Epic #N failed\" wrapper when the real cause is an unmet environment prerequisite.
- Epic spells mark tracked/staged-change checks as warnings with stash-or-commit resolutions; gh-auth, unmerged-files, and origin checks stay fatal with hints.
- Bonus: `moflo init` now adds \`.claude-flow/\`, \`**/workflow-state.json\`, \`.claude/settings.local.json\`, and \`.claude/scheduled_tasks.lock\` to consumer \`.gitignore\` so the flo skill's runtime artifacts don't appear as dirty working tree.

## Test plan
- [x] \`src/modules/spells/__tests__/preflight-severity.test.ts\` (9 cases): fatal aborts, warning-without-handler fallback, handler payload shape, abort/continue/resolve decisions, resolution failure, fatal-wins-over-warning, handler contract violations
- [x] \`src/modules/spells/__tests__/preflights.test.ts\` updated for new friendly error format
- [x] \`tests/epic-spells.test.ts\` still passes with new YAML
- [x] \`@moflo/spells\` and \`@moflo/cli\` both \`tsc --noEmit\` clean
- [x] \`npx flo doctor --fix\` — 26 passed, 1 intrinsic warning (win32 sandbox tier)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)