### PR TITLE
fix(spells): default sandbox to off; opt-in via moflo.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ hive-mind-prompt-*.txt
 
 # Ephemeral / test artifacts
 .claude/projects/
+.claude/scheduled_tasks.lock
 **/workflow-state.json
 src/modules/*/package-lock.json
 test-database-provider.rvf

--- a/src/modules/cli/src/config/moflo-config.ts
+++ b/src/modules/cli/src/config/moflo-config.ts
@@ -181,7 +181,7 @@ const DEFAULT_CONFIG: MofloConfig = {
     helpers: true,
   },
   sandbox: {
-    enabled: true,
+    enabled: false,
     tier: 'auto',
   },
   epic: {
@@ -470,7 +470,7 @@ auto_update:
 # OS-level sandbox for spell bash steps
 # Denylist always runs regardless of this setting
 sandbox:
-  enabled: true                  # false to disable OS sandbox (keeps denylist)
+  enabled: false                 # true to enable OS sandbox (denylist runs either way)
   tier: auto                     # auto | denylist-only | full
                                  # auto = best available, graceful fallback
                                  # denylist-only = skip OS sandbox

--- a/src/modules/spells/__tests__/platform-sandbox.test.ts
+++ b/src/modules/spells/__tests__/platform-sandbox.test.ts
@@ -235,7 +235,7 @@ describe('resolveSandboxConfig', () => {
 
   it('ignores non-boolean enabled values', () => {
     const config = resolveSandboxConfig({ enabled: 'yes' });
-    expect(config.enabled).toBe(true); // default
+    expect(config.enabled).toBe(false); // default (sandbox off unless opted in)
   });
 });
 
@@ -291,7 +291,7 @@ describe('formatSandboxLog', () => {
   it('formats the log message with [spell] prefix', () => {
     mockPlatform.mockReturnValue('darwin');
     mockExistsSync.mockReturnValue(true);
-    const effective = resolveEffectiveSandbox(DEFAULT_SANDBOX_CONFIG);
+    const effective = resolveEffectiveSandbox({ enabled: true, tier: 'auto' });
     const log = formatSandboxLog(effective);
     expect(log).toBe('[spell] OS sandbox: sandbox-exec (darwin)');
   });

--- a/src/modules/spells/__tests__/sandbox-tier-integration.test.ts
+++ b/src/modules/spells/__tests__/sandbox-tier-integration.test.ts
@@ -496,7 +496,7 @@ describe('full pipeline: config through execution', () => {
 
   it('default config values are sensible', () => {
     const config = resolveSandboxConfig();
-    expect(config.enabled).toBe(true);
+    expect(config.enabled).toBe(false);
     expect(config.tier).toBe('auto');
   });
 });

--- a/src/modules/spells/src/core/platform-sandbox.ts
+++ b/src/modules/spells/src/core/platform-sandbox.ts
@@ -48,7 +48,7 @@ export interface SandboxConfig {
 }
 
 export const DEFAULT_SANDBOX_CONFIG: SandboxConfig = {
-  enabled: true,
+  enabled: false,
   tier: 'auto',
 };
 


### PR DESCRIPTION
## Summary
- Flip `DEFAULT_SANDBOX_CONFIG.enabled` from `true` to `false` so spells run without OS sandbox by default. Users opt in via `sandbox.enabled: true` in `moflo.yaml`.
- Denylist (`checkDestructivePatterns`) still runs regardless — safety floor unchanged.
- Gitignore `.claude/scheduled_tasks.lock` and drop one-off `probe-bwrap-fix.mjs`.

## Test plan
- [x] `npm test` — all 7192 tests pass
- [x] Updated `platform-sandbox.test.ts` + `sandbox-tier-integration.test.ts` to reflect new default

Co-Authored-By: moflo <noreply@motailz.com>

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)