### PR TITLE
feat(config): auto-append sandbox block to moflo.yaml on session start

### DIFF
--- a/.claude/guidance/internal/upgrade-contract.md
+++ b/.claude/guidance/internal/upgrade-contract.md
@@ -1,0 +1,62 @@
+# MoFlo Upgrade Contract
+
+> **The rule: a user bumping their moflo version must never have to run `moflo init` again.** Every new capability we ship must auto-apply on the next session start after `npm install moflo@latest`. No manual action, no "re-run init to pick up the new thing," no "set this flag in your yaml." If a user has to do anything except restart their session, we've shipped a broken upgrade.
+
+This is a CRITICAL invariant. Every PR that adds or changes a config surface MUST respect it.
+
+## Scope — what auto-upgrades
+
+| Artifact | Mechanism | Where wired |
+|----------|-----------|-------------|
+| `.claude/scripts/*.mjs`, `.claude/scripts/lib/*` | Static file sync on version change | `bin/session-start-launcher.mjs` scriptFiles list |
+| `.claude/helpers/*` | Static file sync on version change | `bin/session-start-launcher.mjs` helper list |
+| `.claude/guidance/**` (shipped) | `syncAllShippedGuidance()` on init; also session-start refresh | `src/modules/cli/src/init/moflo-init.ts` |
+| `.claude/settings.json` hooks | Merge on session-start / init | `src/modules/cli/src/init/settings-generator.ts` |
+| `moflo.yaml` top-level sections | **Idempotent append** of missing sections on session start | See §"Yaml upgrade pattern" |
+| `CLAUDE.md` moflo block | Regenerated between marker comments | `src/modules/cli/src/init/claudemd-generator.ts` |
+
+If you add a new artifact class, wire it into one of these paths. Do **not** invent new upgrade mechanisms that require user intervention.
+
+## Yaml upgrade pattern (the sandbox lesson)
+
+When we added the `sandbox:` config block, the default was `enabled: false` and the block was invisible in user yaml files. Users couldn't discover the feature because:
+
+1. `generateConfig()` in `moflo-init.ts` only writes `moflo.yaml` if it doesn't exist — existing projects never saw the new block
+2. No session-start step appended missing sections
+
+**The correct pattern for adding a new top-level config section:**
+
+1. Add the block (with sensible defaults and inline comments) to the init template in `src/modules/cli/src/init/moflo-init.ts`
+2. Add the schema + defaults to `src/modules/cli/src/config/moflo-config.ts` (`DEFAULT_CONFIG`, type, parser)
+3. Register the section in the session-start yaml upgrader so that existing projects get the block appended idempotently on next version bump
+4. Document in `docs/` — any setting that can't be discovered by reading `moflo.yaml` has failed the contract
+
+The upgrader must:
+- Parse existing yaml (section headers only; we don't rewrite user values)
+- For each registered section, append `# <comment>\n<section-name>:\n  <defaults>` if the top-level key is absent
+- Never modify user-set values
+- Never reorder or reformat the file
+- Log what was appended (visible in session-start output)
+
+## Tension with "static files, not dynamic generation" (shipped core-guidance §Session Start Automation)
+
+That rule applies to **static helper scripts** — files with no per-project content should ship as pre-built files in `bin/`, not be generated at runtime. It does **not** forbid yaml patches:
+
+- Helper scripts: ship static, sync by copy. ✅
+- User's yaml config: patch idempotently on version change, appending only missing sections. ✅
+- Never: regenerate the user's yaml from a template on every start (would clobber user edits). ❌
+
+The distinction is *user-owned files get additive patches; tool-owned files get replaced*.
+
+## Pre-merge checklist for config-surface changes
+
+Before merging any PR that touches config, ask:
+
+- [ ] If a user upgrades moflo and does **nothing else**, does the new capability work?
+- [ ] If the answer involves "they need to run `moflo init`" or "they need to add X to their yaml" — the PR is incomplete
+- [ ] Are defaults chosen so the feature is discoverable (either on-by-default or clearly commented when off)?
+- [ ] Is the yaml block documented in the relevant `docs/` page, including how to change it?
+
+## Historical violations (don't repeat)
+
+- **v4.x sandbox block** — shipped with `enabled: false` and no auto-append; users couldn't find the setting even though it existed in the schema. Fixed by (1) adding block to init template, (2) adding session-start yaml upgrader.

--- a/.claude/guidance/shipped/moflo-core-guidance.md
+++ b/.claude/guidance/shipped/moflo-core-guidance.md
@@ -584,7 +584,15 @@ status_line:
   show_adrs: true                # ADR compliance (dashboard only)
   show_agentdb: true             # AgentDB vectors/size (dashboard only)
   show_tests: true               # Test file count (dashboard only)
+
+# Spell step sandboxing (OS-level process isolation for bash steps)
+# Platform support: macOS (sandbox-exec), Linux/WSL (bwrap). Windows has no OS sandbox.
+sandbox:
+  enabled: false                 # Set to true to wrap bash steps in an OS sandbox
+  tier: auto                     # auto | denylist-only | full
 ```
+
+If your `moflo.yaml` predates the `sandbox:` block, it is auto-appended on the next session start — you never need to re-run `moflo init` after a version bump.
 
 ### Key Behaviors
 
@@ -606,6 +614,9 @@ status_line:
 | `model_routing.enabled: true` | Auto-select haiku/sonnet/opus based on task complexity |
 | `status_line.mode: dashboard` | Switch to multi-line status display |
 | `status_line.show_swarm: false` | Hide swarm agent count from status bar |
+| `sandbox.enabled: true` | Wrap bash steps in an OS sandbox (macOS/Linux/WSL) — absolute disable when `false`, regardless of tier |
+| `sandbox.tier: full` | Require OS sandbox; throw at runtime if the platform tool is unavailable |
+| `sandbox.tier: denylist-only` | Keep Layer 1 denylist only; skip OS isolation even when enabled |
 
 ---
 

--- a/.claude/guidance/shipped/moflo-spell-sandboxing.md
+++ b/.claude/guidance/shipped/moflo-spell-sandboxing.md
@@ -210,6 +210,29 @@ The engine **automatically rewrites** `claude -p` commands in bash steps — str
 | **[SENSITIVE]** | `agent`, `net`, `browser` | Can read external data or spawn processes |
 | **[DESTRUCTIVE]** | `shell`, `fs:write`, `browser:evaluate`, `credentials` | Can permanently modify/delete data |
 
+## OS-Level Sandbox Configuration (`moflo.yaml`)
+
+Capabilities and the gateway always apply. An **additional** OS-level process sandbox (Layer 3) wraps bash steps on macOS (`sandbox-exec`) and Linux/WSL (`bwrap`). It is controlled by the `sandbox:` block in `moflo.yaml`:
+
+```yaml
+sandbox:
+  enabled: false   # Master toggle — false = OS sandbox off (denylist + gateway still apply)
+  tier: auto       # auto | denylist-only | full
+```
+
+Semantics (from `resolveEffectiveSandbox()` in `src/modules/spells/src/core/platform-sandbox.ts`):
+
+| `enabled` | `tier` | Tool available | OS sandbox runs? | Notes |
+|-----------|--------|----------------|------------------|-------|
+| `false` | (any) | (any) | No | **Absolute disable** — master toggle wins |
+| `true` | `auto` | Yes | Yes | Use detected tool (bwrap/sandbox-exec) |
+| `true` | `auto` | No | No | Graceful fallback; logs "not available" |
+| `true` | `denylist-only` | (any) | No | Layer 1 only, skip OS isolation |
+| `true` | `full` | Yes | Yes | Require OS sandbox |
+| `true` | `full` | No | — | **Throws** at spell start |
+
+Existing projects that predate this block get it auto-appended on session start — never require `moflo init` to re-run after a version bump.
+
 ## See Also
 
 - `.claude/guidance/shipped/moflo-spell-engine.md` — Spell engine usage and YAML format

--- a/bin/lib/yaml-upgrader.mjs
+++ b/bin/lib/yaml-upgrader.mjs
@@ -1,0 +1,80 @@
+/**
+ * moflo.yaml section upgrader.
+ *
+ * Users must never be required to re-run `moflo init` after upgrading moflo.
+ * When we ship a new top-level config section (e.g. `sandbox:`), this module
+ * idempotently appends the missing block — with sensible defaults and inline
+ * comments — to the user's existing moflo.yaml, without touching any values
+ * they've already set.
+ *
+ * See: .claude/guidance/internal/upgrade-contract.md
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+
+/**
+ * Registry of top-level config sections that moflo ships with default blocks.
+ *
+ * Each entry: { key, block } where `block` is the raw YAML snippet (including
+ * its leading comment) to append when the top-level `<key>:` is absent.
+ *
+ * When adding a new top-level section to the init template in moflo-init.ts,
+ * also add the same block here so existing users get it on their next session.
+ */
+export const REQUIRED_SECTIONS = [
+  {
+    key: 'sandbox',
+    block: `# Spell step sandboxing (OS-level process isolation for bash steps)
+# Platform support: macOS (sandbox-exec), Linux/WSL (bwrap). Windows has no OS sandbox.
+# Tiers:
+#   auto          — Use best available sandbox for this platform (recommended when enabled)
+#   denylist-only — Layer 1 only: block catastrophic commands, no OS isolation
+#   full          — Require full OS isolation; throws if the sandbox tool is unavailable
+sandbox:
+  enabled: false                 # Set to true to wrap bash steps in an OS sandbox
+  tier: auto                     # auto | denylist-only | full
+`,
+  },
+];
+
+/**
+ * Return true if the YAML text already defines the given top-level key.
+ * Matches `^<key>:` at column 0 on any line, which is how YAML roots look.
+ */
+export function hasTopLevelSection(yamlText, key) {
+  const pattern = new RegExp(`^${key}\\s*:`, 'm');
+  return pattern.test(yamlText);
+}
+
+/**
+ * Compute what ensureYamlSections() would append, without writing anything.
+ * Returns the list of section keys that are missing from the given yaml text.
+ */
+export function missingSections(yamlText, registry = REQUIRED_SECTIONS) {
+  return registry
+    .filter((entry) => !hasTopLevelSection(yamlText, entry.key))
+    .map((entry) => entry.key);
+}
+
+/**
+ * Append any missing registered sections to the yaml file at `yamlPath`.
+ *
+ * - Idempotent: sections already present are left alone.
+ * - Non-destructive: user values are never read, parsed, or rewritten.
+ * - Returns the list of section keys that were appended (empty if no change).
+ */
+export function ensureYamlSections(yamlPath, registry = REQUIRED_SECTIONS) {
+  if (!existsSync(yamlPath)) return [];
+
+  const original = readFileSync(yamlPath, 'utf-8');
+  const toAppend = registry.filter((entry) => !hasTopLevelSection(original, entry.key));
+  if (toAppend.length === 0) return [];
+
+  const needsTrailingNewline = !original.endsWith('\n');
+  const separator = needsTrailingNewline ? '\n\n' : original.endsWith('\n\n') ? '' : '\n';
+  const appended = toAppend.map((entry) => entry.block.trimEnd()).join('\n\n');
+  const next = `${original}${separator}${appended}\n`;
+
+  writeFileSync(yamlPath, next, 'utf-8');
+  return toAppend.map((entry) => entry.key);
+}

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -355,6 +355,25 @@ try {
   }
 } catch { /* non-fatal */ }
 
+// ── 3d-yaml. Append missing top-level sections to moflo.yaml ───────────────
+// Users must never be required to re-run `moflo init` after a version bump.
+// When moflo ships a new top-level config section (e.g. sandbox:), append it
+// with defaults + comments if the user's yaml doesn't already have it.
+// Fully idempotent and never touches user-set values.
+// See: .claude/guidance/internal/upgrade-contract.md
+try {
+  const upgraderPaths = [
+    resolve(projectRoot, 'node_modules/moflo/bin/lib/yaml-upgrader.mjs'),
+    resolve(projectRoot, 'bin/lib/yaml-upgrader.mjs'),
+  ];
+  const upgraderPath = upgraderPaths.find((p) => existsSync(p));
+  const mofloYaml = resolve(projectRoot, 'moflo.yaml');
+  if (upgraderPath && existsSync(mofloYaml)) {
+    const { ensureYamlSections } = await import(`file://${upgraderPath.replace(/\\/g, '/')}`);
+    ensureYamlSections(mofloYaml);
+  }
+} catch { /* non-fatal — yaml stays as-is, user can still edit manually */ }
+
 // ── 3d. Ensure global `flo` shim exists ─────────────────────────────────────
 // Installs a tiny shim into npm's global bin so bare `flo` resolves to the
 // local project's node_modules/.bin/flo. Idempotent — skips if already present.

--- a/docs/SPELL-SANDBOXING.md
+++ b/docs/SPELL-SANDBOXING.md
@@ -246,6 +246,28 @@ On macOS and Linux, MoFlo automatically wraps bash steps in an OS-level sandbox 
 
 **Windows users:** Layers 1 and 2 provide meaningful protection — the denylist catches catastrophic mistakes, and the gateway enforces capability boundaries in code. However, these are application-level controls that a sufficiently crafted command could bypass. Review spell permissions carefully, especially for spells from untrusted sources.
 
+### Configuring Sandboxing in `moflo.yaml`
+
+OS-level process isolation is controlled by the `sandbox:` block in your project's `moflo.yaml`:
+
+```yaml
+sandbox:
+  enabled: false     # Set to true to wrap bash steps in an OS sandbox
+  tier: auto         # auto | denylist-only | full
+```
+
+**Defaults:** `enabled: false`, `tier: auto`. When enabled is `false`, only Layers 1 and 2 (denylist + capability gateway) apply — bash steps run unwrapped.
+
+**Tiers:**
+
+| Tier | Behavior |
+|------|----------|
+| `auto` | Use the best available sandbox for the platform (`sandbox-exec` on macOS, `bwrap` on Linux/WSL). Falls back to denylist-only if unavailable. Recommended when `enabled: true`. |
+| `denylist-only` | Skip OS sandboxing even if available — Layer 1 denylist still blocks catastrophic commands. |
+| `full` | Require full OS isolation; `resolveEffectiveSandbox()` throws if the sandbox tool is not installed. Use this when a security policy requires OS isolation. |
+
+**On upgrade:** If your `moflo.yaml` predates the `sandbox:` block, MoFlo appends it with default values + inline comments on the next session start. Your existing values in other sections are left untouched. You never need to re-run `moflo init`.
+
 ### Checking Your Sandbox Tier
 
 Run `flo doctor` to see which sandbox tier is active on your system:

--- a/src/modules/cli/src/init/moflo-init.ts
+++ b/src/modules/cli/src/init/moflo-init.ts
@@ -396,6 +396,16 @@ mcp:
   tool_defer: deferred           # Defer 150+ tool schemas; loaded on demand via ToolSearch
   auto_start: false              # Auto-start MCP server on session begin
 
+# Spell step sandboxing (OS-level process isolation for bash steps)
+# Platform support: macOS (sandbox-exec), Linux/WSL (bwrap). Windows has no OS sandbox.
+# Tiers:
+#   auto          — Use best available sandbox for this platform (recommended when enabled)
+#   denylist-only — Layer 1 only: block catastrophic commands, no OS isolation
+#   full          — Require full OS isolation; throws if the sandbox tool is unavailable
+sandbox:
+  enabled: false                 # Set to true to wrap bash steps in an OS sandbox
+  tier: auto                     # auto | denylist-only | full
+
 # Status line display (shown at bottom of Claude Code)
 # mode: "compact" (default), "single-line", or "dashboard" (full multi-line)
 status_line:

--- a/tests/bin/yaml-upgrader.test.ts
+++ b/tests/bin/yaml-upgrader.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for bin/lib/yaml-upgrader.mjs — the idempotent section upgrader
+ * that keeps existing moflo.yaml files current without requiring re-init.
+ *
+ * See: .claude/guidance/internal/upgrade-contract.md
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { resolve } from 'path';
+
+// Dynamic import so Vitest can resolve the .mjs from this .ts test file.
+const upgraderUrl = 'file://' + resolve(__dirname, '../../bin/lib/yaml-upgrader.mjs').replace(/\\/g, '/');
+const {
+  REQUIRED_SECTIONS,
+  hasTopLevelSection,
+  missingSections,
+  ensureYamlSections,
+} = await import(upgraderUrl);
+
+function makeTempRoot(): string {
+  const root = resolve(__dirname, '../../.testoutput/.test-yaml-upgrader-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
+  mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* ok */ }
+}
+
+describe('yaml-upgrader', () => {
+  let root: string;
+  let yamlPath: string;
+
+  beforeEach(() => {
+    root = makeTempRoot();
+    yamlPath = resolve(root, 'moflo.yaml');
+  });
+  afterEach(() => cleanTempRoot(root));
+
+  describe('REQUIRED_SECTIONS registry', () => {
+    it('includes sandbox as a registered section', () => {
+      const keys = REQUIRED_SECTIONS.map((s: any) => s.key);
+      expect(keys).toContain('sandbox');
+    });
+
+    it('each section has a key and a block that starts with a comment', () => {
+      for (const section of REQUIRED_SECTIONS) {
+        expect(typeof section.key).toBe('string');
+        expect(section.key.length).toBeGreaterThan(0);
+        expect(typeof section.block).toBe('string');
+        expect(section.block.trim().startsWith('#')).toBe(true);
+        expect(section.block).toContain(`${section.key}:`);
+      }
+    });
+  });
+
+  describe('hasTopLevelSection', () => {
+    it('finds top-level keys', () => {
+      const yaml = 'project:\n  name: foo\nsandbox:\n  enabled: true\n';
+      expect(hasTopLevelSection(yaml, 'project')).toBe(true);
+      expect(hasTopLevelSection(yaml, 'sandbox')).toBe(true);
+    });
+
+    it('returns false for nested keys', () => {
+      const yaml = 'project:\n  enabled: true\n';
+      expect(hasTopLevelSection(yaml, 'enabled')).toBe(false);
+    });
+
+    it('returns false for missing keys', () => {
+      const yaml = 'project:\n  name: foo\n';
+      expect(hasTopLevelSection(yaml, 'sandbox')).toBe(false);
+    });
+  });
+
+  describe('missingSections', () => {
+    it('returns all registered sections when yaml is empty', () => {
+      const missing = missingSections('');
+      expect(missing).toEqual(REQUIRED_SECTIONS.map((s: any) => s.key));
+    });
+
+    it('returns only sections the yaml lacks', () => {
+      const yaml = 'sandbox:\n  enabled: true\n';
+      const missing = missingSections(yaml);
+      expect(missing).not.toContain('sandbox');
+    });
+  });
+
+  describe('ensureYamlSections', () => {
+    it('returns empty list when yaml file does not exist', () => {
+      const result = ensureYamlSections(yamlPath);
+      expect(result).toEqual([]);
+      expect(existsSync(yamlPath)).toBe(false);
+    });
+
+    it('appends sandbox block when missing', () => {
+      writeFileSync(yamlPath, 'project:\n  name: foo\n', 'utf-8');
+      const appended = ensureYamlSections(yamlPath);
+
+      expect(appended).toContain('sandbox');
+      const content = readFileSync(yamlPath, 'utf-8');
+      expect(content).toMatch(/^sandbox:/m);
+      expect(content).toContain('enabled: false');
+      expect(content).toContain('tier: auto');
+    });
+
+    it('is idempotent when sandbox is already present', () => {
+      const existing = 'project:\n  name: foo\nsandbox:\n  enabled: true\n  tier: full\n';
+      writeFileSync(yamlPath, existing, 'utf-8');
+
+      const firstRun = ensureYamlSections(yamlPath);
+      expect(firstRun).toEqual([]);
+      expect(readFileSync(yamlPath, 'utf-8')).toBe(existing);
+
+      const secondRun = ensureYamlSections(yamlPath);
+      expect(secondRun).toEqual([]);
+      expect(readFileSync(yamlPath, 'utf-8')).toBe(existing);
+    });
+
+    it('never modifies existing user values in other sections', () => {
+      const existing = 'project:\n  name: my-app\nmodels:\n  default: opus\n';
+      writeFileSync(yamlPath, existing, 'utf-8');
+
+      ensureYamlSections(yamlPath);
+
+      const content = readFileSync(yamlPath, 'utf-8');
+      expect(content).toContain('name: my-app');
+      expect(content).toContain('default: opus');
+      // And the appended block shows up at the end
+      expect(content).toMatch(/sandbox:\s*\n\s+enabled: false/);
+    });
+
+    it('preserves original content byte-for-byte before the appended block', () => {
+      const existing = 'project:\n  name: foo\n';
+      writeFileSync(yamlPath, existing, 'utf-8');
+
+      ensureYamlSections(yamlPath);
+
+      const content = readFileSync(yamlPath, 'utf-8');
+      expect(content.startsWith(existing)).toBe(true);
+    });
+
+    it('works with a custom registry', () => {
+      writeFileSync(yamlPath, 'project:\n  name: foo\n', 'utf-8');
+      const customRegistry = [
+        { key: 'custom_feature', block: '# Custom\ncustom_feature:\n  on: true\n' },
+      ];
+      const appended = ensureYamlSections(yamlPath, customRegistry);
+      expect(appended).toEqual(['custom_feature']);
+      expect(readFileSync(yamlPath, 'utf-8')).toMatch(/^custom_feature:/m);
+    });
+  });
+
+  describe('init template parity', () => {
+    it('init template contains a sandbox block identical in intent to the registry', () => {
+      // The two sources of truth must stay in sync: moflo-init.ts template emits
+      // the same block for new projects that yaml-upgrader appends to existing ones.
+      const initPath = resolve(__dirname, '../../src/modules/cli/src/init/moflo-init.ts');
+      const initSource = readFileSync(initPath, 'utf-8');
+      const sandboxEntry = REQUIRED_SECTIONS.find((s: any) => s.key === 'sandbox');
+      expect(sandboxEntry).toBeTruthy();
+
+      // The template must define sandbox and share the key config lines
+      expect(initSource).toContain('sandbox:');
+      expect(initSource).toContain('enabled: false');
+      expect(initSource).toContain('tier: auto');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Makes the `sandbox:` config block discoverable to existing users after a moflo upgrade — no `moflo init` required
- Adds a reusable, idempotent yaml-section upgrader (`bin/lib/yaml-upgrader.mjs`) that appends missing top-level sections on session start without touching user values
- Codifies the "never require re-run of `moflo init`" invariant as internal guidance so future config additions follow the same pattern

## Problem

Users who upgrade moflo couldn't discover the `sandbox:` setting because `generateConfig()` in `moflo-init.ts` only writes `moflo.yaml` on first run. The schema already supported `sandbox.enabled` / `sandbox.tier`, but the block never appeared in existing yaml files. Claude-in-project also couldn't find the flag and concluded it didn't exist.

## Changes

1. `src/modules/cli/src/init/moflo-init.ts` — `sandbox:` block added to the init template with tier-explanation comments
2. `bin/lib/yaml-upgrader.mjs` *(new)* — `REQUIRED_SECTIONS` registry + `ensureYamlSections()` idempotently appends missing top-level blocks; auto-syncs to consumers via the existing `bin/lib/` readdir sync
3. `bin/session-start-launcher.mjs` — step 3d-yaml calls the upgrader every session (same pattern as settings.json migration)
4. `tests/bin/yaml-upgrader.test.ts` *(new)* — 14 tests covering registry shape, top-level key detection, idempotency, user-value preservation, custom registries, and init-template parity
5. `docs/SPELL-SANDBOXING.md` — new "Configuring Sandboxing in `moflo.yaml`" section with the block, tier table, and auto-append note
6. `.claude/guidance/shipped/moflo-core-guidance.md` — `sandbox:` added to Full Configuration Reference + Key Behaviors table (synced to consumer projects)
7. `.claude/guidance/shipped/moflo-spell-sandboxing.md` — full `enabled` × `tier` × tool-available semantics matrix
8. `.claude/guidance/internal/upgrade-contract.md` *(new)* — internal guidance codifying the upgrade invariant with a pre-merge checklist

## Semantics

`sandbox.enabled: false` is an absolute disable — OS sandbox off regardless of tier. `enabled: true` + `tier: auto` uses the detected tool with graceful fallback; `tier: full` throws if the tool is missing; `tier: denylist-only` keeps Layer 1 only.

## Test plan

- [x] `npx vitest run tests/bin/yaml-upgrader.test.ts` — 14 pass
- [x] `npx vitest run tests/bin/lib-sync.test.ts src/modules/cli/__tests__/services/auto-update.test.ts` — 35 pass (no regressions)
- [ ] Manual: on a project with old `moflo.yaml` (no `sandbox:` block), start a Claude session → `sandbox:` block appears at end of file with default values and comments
- [ ] Manual: second session start is a no-op (file byte-identical)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)