### PR TITLE
fix(mcp): load sandbox config from moflo.yaml in spell tools

### DIFF
--- a/src/modules/cli/src/mcp-tools/spell-tools.ts
+++ b/src/modules/cli/src/mcp-tools/spell-tools.ts
@@ -97,7 +97,8 @@ async function executeAndTrack(
   const tracked = trackStart(spellId, definition.name, definition.description);
 
   try {
-    const result = await engine.bridgeExecuteSpell(definition, args, { spellId });
+    const sandboxConfig = await engine.loadSandboxConfigFromProject(findProjectRoot());
+    const result = await engine.bridgeExecuteSpell(definition, args, { spellId, sandboxConfig });
     trackResult(tracked, result);
     return serializeResult(result);
   } catch (err) {
@@ -254,7 +255,8 @@ export const spellTools: MCPTool[] = [
 
       // Run from raw content via bridge
       const engine = await loadSpellEngine();
-      const result = await engine.bridgeRunSpell(content, sourceFile, args, { dryRun });
+      const sandboxConfig = await engine.loadSandboxConfigFromProject(findProjectRoot());
+      const result = await engine.bridgeRunSpell(content, sourceFile, args, { dryRun, sandboxConfig });
       const tracked = trackStart(result.spellId, spellName);
       trackResult(tracked, result);
       return serializeResult(result);

--- a/src/modules/cli/src/services/engine-loader.ts
+++ b/src/modules/cli/src/services/engine-loader.ts
@@ -61,6 +61,7 @@ export interface EngineModule {
     sourceFile: string | undefined,
     options?: Record<string, unknown>,
   ) => Promise<SpellResult>;
+  loadSandboxConfigFromProject: (projectRoot: string) => Promise<SandboxConfig>;
 }
 
 let cachedEngine: EngineModule | null = null;


### PR DESCRIPTION
## Summary
- MCP `spell_cast`/`spell_execute` weren't loading the consumer project's sandbox config, so bash steps ran without OS-level isolation even when `moflo.yaml` set `sandbox.enabled: true`.
- Fix loads `sandboxConfig` at the MCP callsite and passes it through the bridge. Consumer projects on Linux/macOS with `enabled: true` now get `bwrap`/`sandbox-exec` isolation as expected.
- Did not thread `projectRoot` directly — that field also activates the permission acceptance gate, an unrelated concern that would break existing tests.

## Test plan
- [x] `npm test` — 7333 passed, 0 failed
- [x] `npx flo doctor` — 27/27 checks pass
- [ ] After publish, verify in WSL consumer project that spell log shows `OS sandbox: bwrap (linux)` instead of `disabled (denylist active)`

## Test gap identified (follow-up)
Existing MCP integration tests assert spell success but not sandbox state. `runner-bridge` tests passed `projectRoot` explicitly, never exercising the actual CLI→bridge callsite. The moflo repo's own `moflo.yaml` has no `sandbox:` block, so tests running from the repo silently used the buggy default. Suggest adding an integration test that writes a tmp moflo.yaml with `sandbox.enabled: true` and asserts the resolved `displayStatus`.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)