### PR TITLE
feat(spells): Docker sandbox image with claude + gh

### DIFF
--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -1,0 +1,38 @@
+# MoFlo Spell Sandbox Image
+#
+# Pre-installs Claude Code CLI and GitHub CLI so spell steps that invoke
+# `claude -p` or `gh` work inside Docker sandboxing on Windows.
+#
+# Base: node:20-bookworm (Debian 12) — same as the previous default image,
+# so git, npm, and common POSIX tools are already present.
+#
+# Published to: ghcr.io/eric-cielo/moflo-sandbox
+#
+# Rebuild:
+#   docker build -t ghcr.io/eric-cielo/moflo-sandbox:latest docker/sandbox/
+#   docker push ghcr.io/eric-cielo/moflo-sandbox:latest
+
+FROM node:20-bookworm
+
+# ── GitHub CLI ────────────────────────────────────────────────────────────
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gpg \
+ && mkdir -p /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# ── Claude Code CLI ──────────────────────────────────────────────────────
+RUN npm install -g @anthropic-ai/claude-code
+
+# Verify both tools are on PATH
+RUN claude --version && gh --version && git --version
+
+WORKDIR /workspace

--- a/docs/SPELL-SANDBOXING.md
+++ b/docs/SPELL-SANDBOXING.md
@@ -282,7 +282,7 @@ On Windows, OS-level sandboxing runs each bash step inside a Docker container. S
      enabled: true
    ```
 
-That's it. On the first spell run, MoFlo auto-pulls the default image (`node:20-bookworm`) and caches it. The image includes node, npm, bash, git, curl, and ssh.
+That's it. On the first spell run, MoFlo auto-pulls the default image (`ghcr.io/eric-cielo/moflo-sandbox`) and caches it. The image includes node, npm, bash, git, curl, ssh, Claude Code CLI, and GitHub CLI.
 
 To use a custom image instead, set `dockerImage` in your config:
 ```yaml
@@ -293,7 +293,7 @@ sandbox:
 
 **Verify** with `flo doctor sandbox`. You should see:
 ```
-✓ Sandbox Tier — docker ready (win32, node:20-bookworm)
+✓ Sandbox Tier — docker ready (win32, ghcr.io/eric-cielo/moflo-sandbox:latest)
 ```
 
 **How the Docker sandbox works:**

--- a/src/modules/spells/__tests__/platform-sandbox.test.ts
+++ b/src/modules/spells/__tests__/platform-sandbox.test.ts
@@ -325,7 +325,7 @@ describe('resolveEffectiveSandbox', () => {
         tier: 'auto',
       });
       expect(effective.useOsSandbox).toBe(true);
-      expect(effective.config.dockerImage).toBe('node:20-bookworm');
+      expect(effective.config.dockerImage).toBe('ghcr.io/eric-cielo/moflo-sandbox:latest');
     });
 
     it('auto-pulls image when configured but not present locally', () => {

--- a/src/modules/spells/src/core/platform-sandbox.ts
+++ b/src/modules/spells/src/core/platform-sandbox.ts
@@ -64,7 +64,7 @@ export const DEFAULT_SANDBOX_CONFIG: SandboxConfig = {
 };
 
 /** Recommended image for first-time Windows Docker sandbox setup. */
-export const RECOMMENDED_DOCKER_IMAGE = 'node:20-bookworm';
+export const RECOMMENDED_DOCKER_IMAGE = 'ghcr.io/eric-cielo/moflo-sandbox:latest';
 
 // ============================================================================
 // Detection (cached)
@@ -356,7 +356,7 @@ function formatWindowsDockerNotReadyMessage(): string {
     '     Wait for the whale icon in your system tray to stop animating —',
     '     that means Docker is ready.',
     '',
-    `MoFlo will auto-pull the default image (${RECOMMENDED_DOCKER_IMAGE}) on`,
+    `MoFlo will auto-pull the sandbox image (${RECOMMENDED_DOCKER_IMAGE}) on`,
     'the first spell run.',
     '',
     'Not ready to set this up? Turn sandboxing off by setting',


### PR DESCRIPTION
## Summary
- Adds `docker/sandbox/Dockerfile` based on `node:20-bookworm` with Claude Code CLI and GitHub CLI pre-installed
- Published to `ghcr.io/eric-cielo/moflo-sandbox:latest` (public, free)
- Updates `RECOMMENDED_DOCKER_IMAGE` to use the new image
- Fixes `claude: command not found` on Windows Docker sandbox

## Context
On Windows with Docker sandboxing enabled, spell steps that invoke `claude -p` or `gh` failed because the base `node:20-bookworm` image doesn't include those tools. Unlike bwrap (Linux) and sandbox-exec (macOS) which inherit the host filesystem, Docker starts from a clean image.

## Test plan
- [x] Build passes
- [x] 52 sandbox unit tests pass
- [x] Image built and pushed to ghcr.io
- [x] `claude --version`, `gh --version`, `git --version` verified inside container

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)