### PR TITLE
feat(daemon): wire SpellScheduler into daemon lifecycle (#445)

### DIFF
--- a/src/modules/cli/__tests__/services/daemon-spell-executor.test.ts
+++ b/src/modules/cli/__tests__/services/daemon-spell-executor.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Daemon Spell Executor Tests
+ *
+ * Unit tests for DaemonSpellExecutor: Grimoire resolution, mofloLevel
+ * fallback chain, abort-signal propagation to bridgeCancelSpell, and
+ * error handling when the engine throws.
+ *
+ * Story #445.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { DaemonSpellExecutor } from '../../src/services/daemon-spell-executor.js';
+import type { EngineModule, SandboxConfig } from '../../src/services/engine-loader.js';
+import type { SpellResult } from '../../../spells/src/types/runner.types.js';
+import type { SpellDefinition } from '../../../spells/src/types/spell-definition.types.js';
+import type { MofloLevel, MemoryAccessor } from '../../../spells/src/types/step-command.types.js';
+import type { Grimoire } from '../../../spells/src/registry/spell-registry.js';
+
+function makeSuccess(spellId: string): SpellResult {
+  return {
+    spellId,
+    success: true,
+    steps: [],
+    outputs: {},
+    errors: [],
+    duration: 5,
+    cancelled: false,
+  };
+}
+
+function makeDefinition(overrides: Partial<SpellDefinition> = {}): SpellDefinition {
+  return {
+    name: 'test-spell',
+    steps: [{ id: 's1', type: 'bash', config: { command: 'echo hi' } }],
+    ...overrides,
+  } as SpellDefinition;
+}
+
+function makeEngine(): EngineModule & {
+  bridgeExecuteSpell: Mock;
+  bridgeCancelSpell: Mock;
+  loadSandboxConfigFromProject: Mock;
+} {
+  const emptySandbox: SandboxConfig = {
+    enabled: false,
+    tier: 'none',
+    platform: 'bwrap',
+    allowlist: [],
+    denylist: [],
+  } as unknown as SandboxConfig;
+
+  return {
+    bridgeRunSpell: vi.fn(),
+    bridgeExecuteSpell: vi.fn().mockImplementation(
+      (_def, _args, opts: { spellId?: string }) => Promise.resolve(makeSuccess(opts?.spellId ?? 'spell-x')),
+    ),
+    bridgeCancelSpell: vi.fn().mockReturnValue(true),
+    bridgeIsRunning: vi.fn().mockReturnValue(false),
+    bridgeActiveSpells: vi.fn().mockReturnValue([]),
+    Grimoire: vi.fn() as unknown as EngineModule['Grimoire'],
+    SpellScheduler: vi.fn() as unknown as EngineModule['SpellScheduler'],
+    runSpellFromContent: vi.fn(),
+    loadSandboxConfigFromProject: vi.fn().mockResolvedValue(emptySandbox),
+  };
+}
+
+function makeRegistry(map: Record<string, SpellDefinition>): Grimoire {
+  return {
+    resolve: vi.fn((name: string) => {
+      const def = map[name];
+      return def ? { definition: def, sourceFile: `/spells/${name}.yaml`, tier: 'user' } : undefined;
+    }),
+    list: vi.fn(() => Object.values(map).map(d => ({ name: d.name, tier: 'user' }))),
+    info: vi.fn(),
+    load: vi.fn(),
+  } as unknown as Grimoire;
+}
+
+describe('DaemonSpellExecutor', () => {
+  let engine: ReturnType<typeof makeEngine>;
+  let memory: MemoryAccessor;
+
+  beforeEach(() => {
+    engine = makeEngine();
+    memory = {
+      read: vi.fn().mockResolvedValue(null),
+      write: vi.fn().mockResolvedValue(undefined),
+      search: vi.fn().mockResolvedValue([]),
+    };
+  });
+
+  describe('exists', () => {
+    it('returns true when the Grimoire resolves the spell', () => {
+      const registry = makeRegistry({ 'my-spell': makeDefinition({ name: 'my-spell' }) });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      expect(exec.exists('my-spell')).toBe(true);
+    });
+
+    it('returns false when the spell is not in the grimoire', () => {
+      const registry = makeRegistry({});
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      expect(exec.exists('missing')).toBe(false);
+    });
+  });
+
+  describe('execute', () => {
+    it('resolves the spell via Grimoire and calls bridgeExecuteSpell', async () => {
+      const def = makeDefinition({ name: 'wf' });
+      const registry = makeRegistry({ wf: def });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', memory, engine });
+
+      await exec.execute('wf', { foo: 'bar' });
+
+      expect(engine.bridgeExecuteSpell).toHaveBeenCalledTimes(1);
+      const [passedDef, passedArgs, passedOpts] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(passedDef.name).toBe('wf');
+      expect(passedArgs).toEqual({ foo: 'bar' });
+      expect(passedOpts.projectRoot).toBe('/p');
+      expect(passedOpts.memory).toBe(memory);
+      expect(passedOpts.spellId).toMatch(/^scheduled-wf-/);
+    });
+
+    it('returns a failed SpellResult when the spell is missing (race after exists check)', async () => {
+      const registry = makeRegistry({});
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      const result = await exec.execute('ghost', {});
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0].message).toMatch(/not found in grimoire/);
+      expect(engine.bridgeExecuteSpell).not.toHaveBeenCalled();
+    });
+
+    it('returns a failed SpellResult when the engine throws', async () => {
+      const registry = makeRegistry({ wf: makeDefinition({ name: 'wf' }) });
+      engine.bridgeExecuteSpell.mockRejectedValueOnce(new Error('engine explosion'));
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      const result = await exec.execute('wf', {});
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0].message).toBe('engine explosion');
+    });
+
+    it('uses the scheduled mofloLevel when provided', async () => {
+      const def = makeDefinition({ name: 'wf', mofloLevel: 'full' as MofloLevel });
+      const registry = makeRegistry({ wf: def });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      await exec.execute('wf', {}, undefined, 'hooks' as MofloLevel);
+
+      const [passedDef] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(passedDef.mofloLevel).toBe('hooks');
+    });
+
+    it("falls back to the definition's mofloLevel when scheduler gives none", async () => {
+      const def = makeDefinition({ name: 'wf', mofloLevel: 'memory' as MofloLevel });
+      const registry = makeRegistry({ wf: def });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      await exec.execute('wf', {});
+
+      const [passedDef] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(passedDef.mofloLevel).toBe('memory');
+    });
+
+    it('falls back to defaultMofloLevel when neither schedule nor definition set one', async () => {
+      const def = makeDefinition({ name: 'wf' });
+      const registry = makeRegistry({ wf: def });
+      const exec = new DaemonSpellExecutor({
+        registry,
+        projectRoot: '/p',
+        engine,
+        defaultMofloLevel: 'hooks' as MofloLevel,
+      });
+
+      await exec.execute('wf', {});
+
+      const [passedDef] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(passedDef.mofloLevel).toBe('hooks');
+    });
+
+    it('leaves mofloLevel unset when no source supplies one', async () => {
+      const def = makeDefinition({ name: 'wf' });
+      const registry = makeRegistry({ wf: def });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      await exec.execute('wf', {});
+
+      const [passedDef] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(passedDef.mofloLevel).toBeUndefined();
+    });
+
+    it('propagates abort to the engine via bridgeCancelSpell', async () => {
+      const def = makeDefinition({ name: 'wf' });
+      const registry = makeRegistry({ wf: def });
+      // Make execution hang so we can abort mid-flight
+      let release!: (r: SpellResult) => void;
+      engine.bridgeExecuteSpell.mockImplementation(
+        (_d, _a, opts: { spellId?: string }) => new Promise<SpellResult>((resolve) => {
+          release = (r) => resolve({ ...r, spellId: opts?.spellId ?? r.spellId });
+        }),
+      );
+      // Supply sandbox explicitly so bridgeExecuteSpell is the only await gate
+      const sandbox = { enabled: false } as unknown as SandboxConfig;
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine, sandboxConfig: sandbox });
+
+      const controller = new AbortController();
+      const pending = exec.execute('wf', {}, controller.signal);
+
+      // Yield the microtask queue so bridgeExecuteSpell is reached and
+      // the abort listener is registered before we cancel
+      await Promise.resolve();
+      await Promise.resolve();
+
+      controller.abort();
+      const [, , opts] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(engine.bridgeCancelSpell).toHaveBeenCalledWith(opts.spellId);
+
+      release(makeSuccess(opts.spellId));
+      await pending;
+    });
+
+    it('cancels immediately when the signal is already aborted before execute', async () => {
+      const def = makeDefinition({ name: 'wf' });
+      const registry = makeRegistry({ wf: def });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      const controller = new AbortController();
+      controller.abort();
+      await exec.execute('wf', {}, controller.signal);
+
+      expect(engine.bridgeCancelSpell).toHaveBeenCalled();
+    });
+
+    it('uses the explicit sandbox config when provided, skipping auto-load', async () => {
+      const def = makeDefinition({ name: 'wf' });
+      const registry = makeRegistry({ wf: def });
+      const customSandbox = { enabled: true, tier: 'strict' } as unknown as SandboxConfig;
+      const exec = new DaemonSpellExecutor({
+        registry, projectRoot: '/p', engine, sandboxConfig: customSandbox,
+      });
+
+      await exec.execute('wf', {});
+
+      expect(engine.loadSandboxConfigFromProject).not.toHaveBeenCalled();
+      const [, , opts] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(opts.sandboxConfig).toBe(customSandbox);
+    });
+  });
+});

--- a/src/modules/cli/__tests__/services/worker-daemon-scheduler.test.ts
+++ b/src/modules/cli/__tests__/services/worker-daemon-scheduler.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Worker Daemon Scheduler Integration Tests
+ *
+ * Verifies that WorkerDaemon.attachScheduler correctly wires a scheduler
+ * into the daemon lifecycle: events are forwarded through the daemon's
+ * EventEmitter, the poll loop starts when the daemon is running, and
+ * detach/stop cleans up properly.
+ *
+ * Story #445.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn().mockImplementation((path: string) => {
+      if (path.includes('daemon-state.json') || path.includes('config.json')) return '{}';
+      throw new Error('ENOENT');
+    }),
+    appendFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../../src/services/headless-worker-executor.js', () => ({
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
+    isAvailable: vi.fn().mockResolvedValue(false),
+    on: vi.fn(),
+  })),
+  HEADLESS_WORKER_TYPES: [],
+  HEADLESS_WORKER_CONFIGS: {},
+  isHeadlessWorker: vi.fn().mockReturnValue(false),
+}));
+
+const originalOn = process.on.bind(process);
+vi.spyOn(process, 'on').mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+  if (['SIGTERM', 'SIGINT', 'SIGHUP'].includes(event)) return process;
+  return originalOn(event, handler);
+});
+
+import { WorkerDaemon } from '../../src/services/worker-daemon.js';
+import type { SpellScheduler, SchedulerListener, SchedulerEvent } from '../../../spells/src/scheduler/scheduler.js';
+
+function makeFakeScheduler(): {
+  scheduler: SpellScheduler;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  fire: (ev: SchedulerEvent) => void;
+  isRunning: () => boolean;
+} {
+  let listeners: SchedulerListener[] = [];
+  let running = false;
+
+  const start = vi.fn(() => { running = true; });
+  const stop = vi.fn(async () => { running = false; });
+
+  const scheduler = {
+    get isRunning() { return running; },
+    start,
+    stop,
+    on(listener: SchedulerListener) {
+      listeners.push(listener);
+      return () => { listeners = listeners.filter(l => l !== listener); };
+    },
+  } as unknown as SpellScheduler;
+
+  return {
+    scheduler,
+    start,
+    stop,
+    fire(ev) { for (const l of listeners) l(ev); },
+    isRunning: () => running,
+  };
+}
+
+describe('WorkerDaemon scheduler integration', () => {
+  let daemon: WorkerDaemon;
+
+  beforeEach(() => {
+    daemon = new WorkerDaemon('/tmp/test-project', {
+      autoStart: false,
+      workers: [],
+    });
+  });
+
+  afterEach(async () => {
+    await daemon.stop();
+  });
+
+  it('getScheduler returns null before any attach', () => {
+    expect(daemon.getScheduler()).toBeNull();
+  });
+
+  it('attachScheduler before start defers the poll loop until start', async () => {
+    const fake = makeFakeScheduler();
+    await daemon.attachScheduler(fake.scheduler);
+
+    expect(fake.start).not.toHaveBeenCalled();
+    expect(daemon.getScheduler()).toBe(fake.scheduler);
+
+    await daemon.start();
+    expect(fake.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('attachScheduler after start immediately starts the poll loop', async () => {
+    await daemon.start();
+    const fake = makeFakeScheduler();
+
+    await daemon.attachScheduler(fake.scheduler);
+    expect(fake.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards scheduler events through the daemon EventEmitter', async () => {
+    const fake = makeFakeScheduler();
+    await daemon.attachScheduler(fake.scheduler);
+
+    const generic = vi.fn();
+    const specific = vi.fn();
+    daemon.on('scheduler:event', generic);
+    daemon.on('schedule:completed', specific);
+
+    const event: SchedulerEvent = {
+      type: 'schedule:completed',
+      scheduleId: 's1',
+      spellName: 'wf1',
+      message: 'done',
+      timestamp: Date.now(),
+    };
+    fake.fire(event);
+
+    expect(generic).toHaveBeenCalledWith(event);
+    expect(specific).toHaveBeenCalledWith(event);
+  });
+
+  it('stops the attached scheduler when the daemon stops', async () => {
+    const fake = makeFakeScheduler();
+    await daemon.attachScheduler(fake.scheduler);
+    await daemon.start();
+
+    await daemon.stop();
+
+    expect(fake.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('detachScheduler stops the current scheduler and clears the reference', async () => {
+    const fake = makeFakeScheduler();
+    await daemon.attachScheduler(fake.scheduler);
+    await daemon.start();
+
+    await daemon.detachScheduler();
+
+    expect(fake.stop).toHaveBeenCalledTimes(1);
+    expect(daemon.getScheduler()).toBeNull();
+  });
+
+  it('replacing an existing scheduler stops the old one and wires the new', async () => {
+    const first = makeFakeScheduler();
+    const second = makeFakeScheduler();
+
+    await daemon.attachScheduler(first.scheduler);
+    await daemon.start();
+    await daemon.attachScheduler(second.scheduler);
+
+    // First must be stopped; replacement runs under the live daemon
+    expect(first.stop).toHaveBeenCalled();
+    expect(second.start).toHaveBeenCalledTimes(1);
+    expect(daemon.getScheduler()).toBe(second.scheduler);
+  });
+
+  it('re-attaching the same scheduler is a no-op', async () => {
+    const fake = makeFakeScheduler();
+    await daemon.attachScheduler(fake.scheduler);
+    await daemon.start();
+    expect(fake.start).toHaveBeenCalledTimes(1);
+
+    await daemon.attachScheduler(fake.scheduler);
+    expect(fake.start).toHaveBeenCalledTimes(1);
+    expect(fake.stop).not.toHaveBeenCalled();
+  });
+
+  it('events stop flowing after detach', async () => {
+    const fake = makeFakeScheduler();
+    await daemon.attachScheduler(fake.scheduler);
+    const listener = vi.fn();
+    daemon.on('scheduler:event', listener);
+
+    await daemon.detachScheduler();
+    fake.fire({
+      type: 'schedule:due',
+      scheduleId: 's1',
+      spellName: 'wf1',
+      message: 'x',
+      timestamp: Date.now(),
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/cli/src/commands/daemon.ts
+++ b/src/modules/cli/src/commands/daemon.ts
@@ -9,6 +9,9 @@ import { WorkerDaemon, getDaemon, startDaemon, stopDaemon, type WorkerType, type
 import { acquireDaemonLock, releaseDaemonLock, getDaemonLockHolder, transferDaemonLock, lockPath } from '../services/daemon-lock.js';
 import { installDaemonService, uninstallDaemonService, isDaemonInstalled } from '../services/daemon-service.js';
 import { startDashboard, createDashboardMemoryAccessor, DEFAULT_DASHBOARD_PORT, type DashboardHandle } from '../services/daemon-dashboard.js';
+import { bootstrapDaemonScheduler } from '../services/daemon-scheduler-bootstrap.js';
+import type { MemoryAccessor } from '../../../spells/src/types/step-command.types.js';
+import type { SchedulerEvent } from '../../../spells/src/scheduler/scheduler.js';
 import { spawn, execFile, execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join, resolve, isAbsolute } from 'path';
@@ -127,17 +130,9 @@ const startCommand: Command = {
 
         spinner.succeed('Worker daemon started (foreground mode)');
 
-        // Start dashboard unless disabled
-        let dashboard: DashboardHandle | null = null;
-        if (!noDashboard) {
-          try {
-            const memory = await createDashboardMemoryAccessor();
-            dashboard = await startDashboard(daemon, { port: dashboardPort, memory });
-            output.printSuccess(`Dashboard: http://localhost:${dashboard.port}`);
-          } catch (err) {
-            output.printWarning(`Dashboard failed to start: ${err instanceof Error ? err.message : String(err)}`);
-          }
-        }
+        const { dashboard } = await attachDaemonServices(daemon, {
+          projectRoot, noDashboard, dashboardPort, verbose: true,
+        });
 
         output.writeln();
         output.printBox(
@@ -190,16 +185,17 @@ const startCommand: Command = {
           output.writeln(output.error(`[daemon] Worker failed: ${type} - ${error}`));
         });
 
+        daemon.on('scheduler:event', (ev: SchedulerEvent) => {
+          const line = `[scheduler] ${ev.type} ${ev.spellName}: ${ev.message}`;
+          if (ev.type === 'schedule:failed') output.writeln(output.error(line));
+          else output.writeln(output.dim(line));
+        });
+
         // Keep process alive
         await new Promise(() => {}); // Never resolves - daemon runs until killed
       } else {
         const daemon = await startDaemon(projectRoot, config);
-        if (!noDashboard) {
-          try {
-            const memory = await createDashboardMemoryAccessor();
-            await startDashboard(daemon, { port: dashboardPort, memory });
-          } catch { /* dashboard is best-effort in quiet mode */ }
-        }
+        await attachDaemonServices(daemon, { projectRoot, noDashboard, dashboardPort, verbose: false });
         await new Promise(() => {}); // Keep alive
       }
 
@@ -210,6 +206,50 @@ const startCommand: Command = {
     }
   },
 };
+
+/**
+ * Create a shared memory accessor, start the dashboard (unless disabled),
+ * and bootstrap the spell scheduler. `verbose: true` prints progress to
+ * the user; `verbose: false` logs warnings via the daemon log file only.
+ *
+ * Each step is best-effort — the daemon's own worker tick loop keeps
+ * running even if dashboard or scheduler wiring fails.
+ */
+async function attachDaemonServices(
+  daemon: WorkerDaemon,
+  opts: { projectRoot: string; noDashboard?: boolean; dashboardPort: number; verbose: boolean },
+): Promise<{ dashboard: DashboardHandle | null; memory: MemoryAccessor | null }> {
+  const logWarn = (msg: string) => opts.verbose
+    ? output.printWarning(msg)
+    : daemon.emit('log', { level: 'warn', message: msg, timestamp: new Date().toISOString() });
+
+  let memory: MemoryAccessor | null = null;
+  try {
+    memory = await createDashboardMemoryAccessor();
+  } catch (err) {
+    logWarn(`Memory accessor unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    return { dashboard: null, memory: null };
+  }
+
+  let dashboard: DashboardHandle | null = null;
+  if (!opts.noDashboard) {
+    try {
+      dashboard = await startDashboard(daemon, { port: opts.dashboardPort, memory });
+      if (opts.verbose) output.printSuccess(`Dashboard: http://localhost:${dashboard.port}`);
+    } catch (err) {
+      logWarn(`Dashboard failed to start: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  try {
+    await bootstrapDaemonScheduler(daemon, { projectRoot: opts.projectRoot, memory });
+    if (opts.verbose) output.printSuccess('Spell scheduler attached');
+  } catch (err) {
+    logWarn(`Spell scheduler not started: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return { dashboard, memory };
+}
 
 /**
  * Validate path for security - prevents path traversal and injection

--- a/src/modules/cli/src/mcp-tools/spell-tools.ts
+++ b/src/modules/cli/src/mcp-tools/spell-tools.ts
@@ -7,8 +7,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import type { MCPTool } from './types.js';
 import {
   loadSpellEngine,
@@ -19,7 +18,7 @@ import {
   type Grimoire,
 } from '../services/engine-loader.js';
 import { findProjectRoot } from '../services/project-root.js';
-import { loadMofloConfig } from '../config/moflo-config.js';
+import { buildGrimoire } from '../services/grimoire-builder.js';
 
 
 // ============================================================================
@@ -122,22 +121,8 @@ async function getRegistry(): Promise<Grimoire> {
 
   pendingRegistry = (async () => {
     try {
-      const engine = await loadSpellEngine();
-      const projectRoot = findProjectRoot();
-      const config = loadMofloConfig(projectRoot);
-
-      const defaultShippedDir = resolve(
-        dirname(fileURLToPath(import.meta.url)),
-        '../../../../modules/spells/definitions',
-      );
-      const shippedDir = config.spells.shippedDir
-        ? resolve(projectRoot, config.spells.shippedDir)
-        : defaultShippedDir;
-
-      const userDirs = config.spells.userDirs.map(d => resolve(projectRoot, d));
-
-      registryInstance = new engine.Grimoire({ shippedDir, userDirs });
-
+      const { registry } = await buildGrimoire(findProjectRoot());
+      registryInstance = registry;
       return registryInstance;
     } finally {
       pendingRegistry = null;

--- a/src/modules/cli/src/services/daemon-scheduler-bootstrap.ts
+++ b/src/modules/cli/src/services/daemon-scheduler-bootstrap.ts
@@ -1,0 +1,51 @@
+/**
+ * Daemon Scheduler Bootstrap
+ *
+ * Wires the SpellScheduler into a running WorkerDaemon. Builds the
+ * Grimoire registry, pre-resolves the sandbox config (so per-execute
+ * runs don't re-read moflo.yaml), constructs a DaemonSpellExecutor,
+ * instantiates the scheduler, and attaches it.
+ */
+
+import type { WorkerDaemon } from './worker-daemon.js';
+import type { MemoryAccessor } from '../../../spells/src/types/step-command.types.js';
+import type { SpellScheduler } from '../../../spells/src/scheduler/scheduler.js';
+import { loadSpellEngine } from './engine-loader.js';
+import { buildGrimoire } from './grimoire-builder.js';
+import { DaemonSpellExecutor } from './daemon-spell-executor.js';
+
+export interface BootstrapSchedulerOptions {
+  readonly projectRoot: string;
+  readonly memory: MemoryAccessor;
+}
+
+/**
+ * Load the spell registry, build the executor, and attach a fresh scheduler
+ * to the daemon. Returns the scheduler for callers that want to observe
+ * events directly. Throws if the spells package can't be loaded — the
+ * caller decides whether scheduler bootstrap failure is fatal for the
+ * daemon as a whole.
+ */
+export async function bootstrapDaemonScheduler(
+  daemon: WorkerDaemon,
+  options: BootstrapSchedulerOptions,
+): Promise<SpellScheduler> {
+  const engine = await loadSpellEngine();
+  const { registry } = await buildGrimoire(options.projectRoot, engine);
+
+  // Pre-resolve the sandbox config so the executor doesn't re-read
+  // moflo.yaml + re-parse YAML on every scheduled execute.
+  const sandboxConfig = await engine.loadSandboxConfigFromProject(options.projectRoot);
+
+  const executor = new DaemonSpellExecutor({
+    registry,
+    projectRoot: options.projectRoot,
+    memory: options.memory,
+    engine,
+    sandboxConfig,
+  });
+
+  const scheduler = new engine.SpellScheduler(options.memory, executor);
+  daemon.attachScheduler(scheduler);
+  return scheduler;
+}

--- a/src/modules/cli/src/services/daemon-spell-executor.ts
+++ b/src/modules/cli/src/services/daemon-spell-executor.ts
@@ -1,0 +1,136 @@
+/**
+ * Daemon Spell Executor
+ *
+ * Production SpellExecutor implementation for the worker daemon.
+ * Resolves spells via the Grimoire registry, delegates execution to the
+ * shared spell engine (same path as `flo spell cast`), and propagates
+ * abort signals to the engine's internal spell tracker.
+ */
+
+import type {
+  SpellExecutor,
+} from '../../../spells/src/scheduler/scheduler.js';
+import type {
+  MofloLevel,
+  MemoryAccessor,
+} from '../../../spells/src/types/step-command.types.js';
+import type { SpellResult, SpellErrorCode } from '../../../spells/src/types/runner.types.js';
+import type { SpellDefinition } from '../../../spells/src/types/spell-definition.types.js';
+import type { Grimoire } from '../../../spells/src/registry/spell-registry.js';
+import {
+  loadSpellEngine,
+  type EngineModule,
+  type SandboxConfig,
+} from './engine-loader.js';
+
+export interface DaemonSpellExecutorOptions {
+  /** Pre-built Grimoire used to resolve spell names at poll time. */
+  readonly registry: Grimoire;
+  /** Project root passed through to the engine for sandbox + path resolution. */
+  readonly projectRoot: string;
+  /** Memory accessor shared with the scheduler; also passed to the runner. */
+  readonly memory?: MemoryAccessor;
+  /** Fallback level when a scheduled spell + definition both omit one. */
+  readonly defaultMofloLevel?: MofloLevel;
+  /** Optional pre-loaded engine module (else loaded lazily on first execute). */
+  readonly engine?: EngineModule;
+  /** Optional sandbox config override (else auto-loaded from moflo.yaml). */
+  readonly sandboxConfig?: SandboxConfig;
+}
+
+export class DaemonSpellExecutor implements SpellExecutor {
+  private readonly registry: Grimoire;
+  private readonly projectRoot: string;
+  private readonly memory?: MemoryAccessor;
+  private readonly defaultMofloLevel?: MofloLevel;
+  private readonly explicitSandbox?: SandboxConfig;
+  private engine?: EngineModule;
+
+  constructor(opts: DaemonSpellExecutorOptions) {
+    this.registry = opts.registry;
+    this.projectRoot = opts.projectRoot;
+    this.memory = opts.memory;
+    this.defaultMofloLevel = opts.defaultMofloLevel;
+    this.engine = opts.engine;
+    this.explicitSandbox = opts.sandboxConfig;
+  }
+
+  exists(spellName: string): boolean {
+    return this.registry.resolve(spellName) !== undefined;
+  }
+
+  async execute(
+    spellName: string,
+    args: Record<string, unknown>,
+    signal?: AbortSignal,
+    mofloLevel?: MofloLevel,
+  ): Promise<SpellResult> {
+    const loaded = this.registry.resolve(spellName);
+    if (!loaded) {
+      return failedResult(
+        `scheduled-${spellName}-${Date.now()}`,
+        'STEP_EXECUTION_FAILED',
+        `Spell not found in grimoire: ${spellName}`,
+      );
+    }
+
+    const engine = await this.ensureEngine();
+    const definition = this.applyMofloLevel(loaded.definition, mofloLevel);
+    const spellId = `scheduled-${loaded.definition.name}-${Date.now()}`;
+
+    const onAbort = () => {
+      try {
+        engine.bridgeCancelSpell(spellId);
+      } catch (err) {
+        // Cancellation is best-effort — the engine may have already finished.
+        // Emit to stderr so daemon logs capture the case without disrupting
+        // the poll loop or propagating the failure back to the scheduler.
+        console.warn(`[daemon-spell-executor] bridgeCancelSpell(${spellId}) failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    };
+    if (signal?.aborted) onAbort();
+    signal?.addEventListener('abort', onAbort, { once: true });
+
+    try {
+      const sandboxConfig = this.explicitSandbox
+        ?? await engine.loadSandboxConfigFromProject(this.projectRoot);
+      return await engine.bridgeExecuteSpell(definition, args, {
+        spellId,
+        projectRoot: this.projectRoot,
+        memory: this.memory,
+        sandboxConfig,
+      });
+    } catch (err) {
+      return failedResult(
+        spellId,
+        'STEP_EXECUTION_FAILED',
+        err instanceof Error ? err.message : String(err),
+      );
+    } finally {
+      signal?.removeEventListener('abort', onAbort);
+    }
+  }
+
+  private async ensureEngine(): Promise<EngineModule> {
+    if (!this.engine) this.engine = await loadSpellEngine();
+    return this.engine;
+  }
+
+  private applyMofloLevel(definition: SpellDefinition, scheduled?: MofloLevel): SpellDefinition {
+    const effective = scheduled ?? definition.mofloLevel ?? this.defaultMofloLevel;
+    if (!effective || effective === definition.mofloLevel) return definition;
+    return { ...definition, mofloLevel: effective };
+  }
+}
+
+function failedResult(spellId: string, code: SpellErrorCode, message: string): SpellResult {
+  return {
+    spellId,
+    success: false,
+    steps: [],
+    outputs: {},
+    errors: [{ code, message }],
+    duration: 0,
+    cancelled: false,
+  };
+}

--- a/src/modules/cli/src/services/engine-loader.ts
+++ b/src/modules/cli/src/services/engine-loader.ts
@@ -26,6 +26,12 @@ import type {
   RegistryOptions,
 } from '../../../../modules/spells/src/registry/spell-registry.js';
 import type { SandboxConfig } from '../../../../modules/spells/src/core/platform-sandbox.js';
+import type {
+  SpellScheduler,
+  SpellExecutor,
+} from '../../../../modules/spells/src/scheduler/scheduler.js';
+import type { SchedulerOptions } from '../../../../modules/spells/src/scheduler/schedule.types.js';
+import type { MemoryAccessor } from '../../../../modules/spells/src/types/step-command.types.js';
 
 // Re-export spell types so consumers import from engine-loader (single boundary).
 export type { SpellResult };
@@ -33,6 +39,7 @@ export type { SpellDefinition };
 export type { Grimoire };
 export type { PreflightWarning, PreflightWarningDecision, PreflightWarningHandler };
 export type { SandboxConfig };
+export type { SpellScheduler, SpellExecutor, SchedulerOptions };
 
 /**
  * Shape of the dynamically imported spell engine module.
@@ -56,6 +63,11 @@ export interface EngineModule {
   bridgeIsRunning: (spellId: string) => boolean;
   bridgeActiveSpells: () => string[];
   Grimoire: new (options?: RegistryOptions) => Grimoire;
+  SpellScheduler: new (
+    memory: MemoryAccessor,
+    executor: SpellExecutor,
+    options?: SchedulerOptions,
+  ) => SpellScheduler;
   runSpellFromContent: (
     content: string,
     sourceFile: string | undefined,

--- a/src/modules/cli/src/services/grimoire-builder.ts
+++ b/src/modules/cli/src/services/grimoire-builder.ts
@@ -1,0 +1,51 @@
+/**
+ * Grimoire Builder
+ *
+ * Shared helper for constructing the spell registry (Grimoire) from a
+ * project's moflo.yaml + shipped definitions path. Used by the MCP spell
+ * tools and by the daemon scheduler bootstrap so both discover the same
+ * set of spells under the same precedence rules.
+ */
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Grimoire } from '../../../../modules/spells/src/registry/spell-registry.js';
+import { loadMofloConfig } from '../config/moflo-config.js';
+import { loadSpellEngine, type EngineModule } from './engine-loader.js';
+
+/**
+ * Resolve the shipped + user spell directories for a project.
+ *
+ * `shippedDir` defaults to the bundled `modules/spells/definitions` folder
+ * relative to this file, so it keeps working in both source and dist layouts
+ * per `feedback_consumer_path_resolution` (always anchored to `import.meta.url`).
+ */
+export function resolveSpellDirs(projectRoot: string): { shippedDir: string; userDirs: string[] } {
+  const config = loadMofloConfig(projectRoot);
+
+  const defaultShippedDir = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../../modules/spells/definitions',
+  );
+  const shippedDir = config.spells.shippedDir
+    ? resolve(projectRoot, config.spells.shippedDir)
+    : defaultShippedDir;
+  const userDirs = config.spells.userDirs.map(d => resolve(projectRoot, d));
+
+  return { shippedDir, userDirs };
+}
+
+/**
+ * Build (and eagerly load) a Grimoire for the given project. Reuses an
+ * already-loaded engine module when provided; otherwise loads lazily.
+ */
+export async function buildGrimoire(
+  projectRoot: string,
+  engine?: EngineModule,
+): Promise<{ registry: Grimoire; engine: EngineModule }> {
+  const loaded = engine ?? await loadSpellEngine();
+  const { shippedDir, userDirs } = resolveSpellDirs(projectRoot);
+  const registry = new loaded.Grimoire({ shippedDir, userDirs });
+  registry.load();
+  return { registry, engine: loaded };
+}

--- a/src/modules/cli/src/services/worker-daemon.ts
+++ b/src/modules/cli/src/services/worker-daemon.ts
@@ -22,6 +22,10 @@ import {
   type HeadlessWorkerType,
   type HeadlessExecutionResult,
 } from './headless-worker-executor.js';
+import type {
+  SpellScheduler,
+  SchedulerEvent,
+} from '../../../spells/src/scheduler/scheduler.js';
 
 // Worker types matching hooks-tools.ts
 export type WorkerType =
@@ -122,6 +126,9 @@ export class WorkerDaemon extends EventEmitter {
   // Headless execution support
   private headlessExecutor: HeadlessWorkerExecutor | null = null;
   private headlessAvailable: boolean = false;
+
+  private scheduler: SpellScheduler | null = null;
+  private unsubScheduler: (() => void) | null = null;
 
   // Preserve the original constructor config so we can detect explicit overrides
   // during state restoration (R1: constructor config takes priority over stale state)
@@ -456,6 +463,11 @@ export class WorkerDaemon extends EventEmitter {
       }
     }
 
+    if (this.scheduler && !this.scheduler.isRunning) {
+      this.scheduler.start();
+      this.log('info', 'Spell scheduler poll loop started');
+    }
+
     // Save state
     this.saveState();
 
@@ -479,10 +491,77 @@ export class WorkerDaemon extends EventEmitter {
     }
     this.timers.clear();
 
+    // Stop the spell scheduler if attached
+    if (this.scheduler && this.scheduler.isRunning) {
+      try {
+        await this.scheduler.stop();
+        this.log('info', 'Spell scheduler stopped');
+      } catch (err) {
+        this.log('warn', `Scheduler stop error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
     this.running = false;
     this.saveState();
     this.emit('stopped', { stoppedAt: new Date() });
     this.log('info', 'Daemon stopped');
+  }
+
+  /**
+   * Attach a SpellScheduler to the daemon lifecycle.
+   *
+   * The scheduler's poll loop starts immediately if the daemon is already
+   * running; otherwise it starts when `start()` is called. Scheduler events
+   * are forwarded through this daemon's EventEmitter (both as a generic
+   * `scheduler:event` and as the specific event type — e.g. `schedule:due`),
+   * so dashboard/logging consumers receive live updates.
+   *
+   * If a different scheduler is already attached, awaits detach before
+   * wiring the new one so the old scheduler's stop doesn't race with the
+   * new assignment.
+   */
+  async attachScheduler(scheduler: SpellScheduler): Promise<void> {
+    if (this.scheduler === scheduler) return;
+    if (this.scheduler) {
+      this.log('warn', 'Replacing previously attached scheduler');
+      await this.detachScheduler();
+    }
+
+    this.scheduler = scheduler;
+    this.unsubScheduler = scheduler.on((event: SchedulerEvent) => {
+      this.emit('scheduler:event', event);
+      this.emit(event.type, event);
+    });
+
+    if (this.running && !scheduler.isRunning) {
+      scheduler.start();
+      this.log('info', 'Spell scheduler poll loop started');
+    }
+  }
+
+  /**
+   * Detach and stop the currently attached scheduler, if any. Errors during
+   * stop are logged but do not propagate — detach must be non-fatal so
+   * daemon shutdown can always complete.
+   */
+  async detachScheduler(): Promise<void> {
+    if (this.unsubScheduler) {
+      this.unsubScheduler();
+      this.unsubScheduler = null;
+    }
+    if (this.scheduler) {
+      try {
+        await this.scheduler.stop();
+      } catch (err) {
+        this.log('warn', `Scheduler stop during detach failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      this.scheduler = null;
+    }
+  }
+
+  /** The currently attached scheduler, or null if none. */
+  getScheduler(): SpellScheduler | null {
+    return this.scheduler;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Daemon now instantiates a `SpellScheduler` at startup and attaches it via a new `attachScheduler` / `detachScheduler` lifecycle API on `WorkerDaemon`. Persisted schedules now actually fire.
- New `DaemonSpellExecutor` implements `SpellExecutor` by resolving spells via `Grimoire` and delegating to the existing engine bridge (`bridgeExecuteSpell`) — the same path `flo spell cast` uses.
- Grimoire construction extracted to a shared `grimoire-builder.ts` so the scheduler bootstrap and `spell-tools.ts` stop duplicating shippedDir/userDirs logic.
- Scheduler events are re-emitted on the `WorkerDaemon` `EventEmitter` (both as `scheduler:event` and as the specific event type) so dashboard/log consumers get live updates. The existing dashboard panel, which reads from memory namespaces, populates automatically because the scheduler already persists schedules and execution records.
- Sandbox config is pre-resolved once during bootstrap so scheduled runs don't re-parse `moflo.yaml` on every execute.

## Acceptance criteria

- [x] `DaemonSpellExecutor` class implements `SpellExecutor`
- [x] `worker-daemon.ts` instantiates `Scheduler` on startup with executor + `MemoryAccessor`
- [x] Poll loop starts on daemon ready and stops cleanly on shutdown
- [x] Scheduler events forwarded through the daemon EventEmitter (`scheduler:event` and specific types)
- [x] Catch-up after restart works (delegated to the `SpellScheduler`'s existing 1h window — scheduler is started on daemon bootstrap which triggers the first poll immediately)
- [x] No regressions in the existing daemon worker tick loop

Out of scope (other stories on epic #443):
- #446 — `moflo.yaml` scheduler config
- #447 — dashboard panel replacement
- #448 — scheduler test suite + docs

## Test plan

- [x] New unit tests: `daemon-spell-executor.test.ts` (12 cases: Grimoire resolve, mofloLevel fallback chain, abort propagation to `bridgeCancelSpell`, engine error handling, explicit sandbox override)
- [x] New wiring tests: `worker-daemon-scheduler.test.ts` (9 cases: attach/detach, event forwarding, replace race, re-attach no-op, event flow stops after detach)
- [x] Regression: existing `scheduler.test.ts`, `worker-daemon.test.ts`, `engine-loader.test.ts`, `spell-tools-engine.test.ts`, `spell-schedule.test.ts`, `daemon-dashboard.test.ts` — all still green (150+ tests passing together)
- [ ] Manual: `flo daemon start` + `flo spell schedule create -n <spell> --cron '* * * * *'` — schedule fires within ~60s (deferred to #446 once the moflo.yaml config lands)

Closes #445

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)