### PR TITLE
test(flaky): fix three full-suite-only test failures

### DIFF
--- a/src/modules/security/__tests__/token-generator.test.ts
+++ b/src/modules/security/__tests__/token-generator.test.ts
@@ -307,13 +307,12 @@ describe('TokenGenerator', () => {
     });
 
     it('should use timing-safe comparison', () => {
-      // This test verifies the comparison takes consistent time
-      // regardless of where the mismatch occurs
       const token = generator.generate();
-      const mismatchEarly = 'X' + token.slice(1);
-      const mismatchLate = token.slice(0, -1) + 'X';
+      // '!' is outside the base64url alphabet, so it's guaranteed to differ
+      // from token[0]/token[-1] regardless of random generator output.
+      const mismatchEarly = '!' + token.slice(1);
+      const mismatchLate = token.slice(0, -1) + '!';
 
-      // Both comparisons should work (timing consistency is internal)
       expect(generator.compare(token, mismatchEarly)).toBe(false);
       expect(generator.compare(token, mismatchLate)).toBe(false);
     });

--- a/src/modules/spells/__tests__/sandbox-tier-integration.test.ts
+++ b/src/modules/spells/__tests__/sandbox-tier-integration.test.ts
@@ -458,25 +458,24 @@ describe('full pipeline: config through execution', () => {
   });
 
   it('resolveSandboxConfig → resolveEffectiveSandbox produces consistent state', () => {
-    // Windows auto-defaults dockerImage and auto-pulls if missing. Provide the
-    // image in config so the test doesn't trigger a real docker pull.
-    const opts: Record<string, unknown> = { enabled: true, tier: 'auto' };
-    if (IS_WINDOWS) {
-      opts.dockerImage = 'node:20-bookworm';
-    }
+    // Pass explicit capabilities so this config-consistency test doesn't depend
+    // on the host's real Docker/bwrap availability (Windows without Docker
+    // Desktop running would otherwise hit the throw path).
+    const opts: Record<string, unknown> = { enabled: true, tier: 'auto', dockerImage: 'node:20-bookworm' };
     const config = resolveSandboxConfig(opts);
     expect(config.enabled).toBe(true);
     expect(config.tier).toBe('auto');
 
-    const effective = resolveEffectiveSandbox(config);
-    expect(effective.config).toEqual(config);
-    expect(effective.capability.platform).toBe(platform());
-    // On auto tier: useOsSandbox matches capability.available
-    if (effective.capability.available) {
-      expect(effective.useOsSandbox).toBe(true);
-    } else {
-      expect(effective.useOsSandbox).toBe(false);
-    }
+    const availableCap = { platform: 'linux' as NodeJS.Platform, available: true, tool: 'bwrap', overhead: 'low' as const };
+    const unavailableCap = { platform: 'linux' as NodeJS.Platform, available: false, tool: null, overhead: null };
+
+    const effectiveAvailable = resolveEffectiveSandbox(config, availableCap);
+    expect(effectiveAvailable.config).toEqual(config);
+    expect(effectiveAvailable.useOsSandbox).toBe(true);
+
+    const effectiveUnavailable = resolveEffectiveSandbox(config, unavailableCap);
+    expect(effectiveUnavailable.config).toEqual(config);
+    expect(effectiveUnavailable.useOsSandbox).toBe(false);
   });
 
   it('denylist-only config always results in useOsSandbox: false', () => {

--- a/src/modules/spells/__tests__/tool-accessor.test.ts
+++ b/src/modules/spells/__tests__/tool-accessor.test.ts
@@ -78,8 +78,9 @@ describe('ConnectorAccessorImpl', () => {
 });
 
 describe('SpellCaster connector integration', () => {
-  it('runner works without connector registry (backward compat)', async () => {
-    // Import dynamically to avoid circular issues
+  // Dynamic imports + factory init are slow under Windows parallel-fork load;
+  // 5s default isn't enough when worker cold-starts contend for CPU.
+  it('runner works without connector registry (backward compat)', { timeout: 30000 }, async () => {
     const { createRunner } = await import('../src/factory/runner-factory.js');
     const runner = createRunner();
 


### PR DESCRIPTION
## Summary
- `token-generator:317` — not actually flaky; `'X' + token.slice(1)` self-matched ~1.5% of runs when random base64url tokens started with `X`. Use `'!'` (outside alphabet) so the mismatch is guaranteed.
- `tool-accessor:81` — raise per-test timeout to 30s; dynamic-import + factory cold-start exceeds 5s under Windows parallel-fork load.
- `sandbox-tier-integration:460` — pass explicit capabilities so the config-consistency test doesn't depend on host Docker/bwrap state (Windows without Docker Desktop hit the throw path).

## Test plan
- [x] `npm test` — 7526/7526 passing locally (was 3 failing)
- [x] Each fix verified individually in isolation

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)