### PR TITLE
feat(cli): add top-level `flo cast` as shortcut for `flo spell cast`

### DIFF
--- a/src/modules/cli/__tests__/spell-command.test.ts
+++ b/src/modules/cli/__tests__/spell-command.test.ts
@@ -80,6 +80,22 @@ describe('Command index registration', () => {
     expect(cmd!.name).toBe('spell');
   });
 
+  it('castCommand is registered as a top-level command', async () => {
+    const { hasCommand, getCommandAsync } = await import('../src/commands/index.js');
+    expect(hasCommand('cast')).toBe(true);
+    const cmd = await getCommandAsync('cast');
+    expect(cmd).toBeDefined();
+    expect(cmd!.name).toBe('cast');
+  });
+
+  it('top-level cast and spell cast share the same Command object', async () => {
+    const { getCommandAsync } = await import('../src/commands/index.js');
+    const topCast = await getCommandAsync('cast');
+    const spell = await getCommandAsync('spell');
+    const spellCast = spell!.subcommands!.find(s => s.name === 'cast');
+    expect(topCast).toBe(spellCast);
+  });
+
   it('no "workflow" as a primary command name in loaders', async () => {
     const { getCommandNames } = await import('../src/commands/index.js');
     const names = getCommandNames();

--- a/src/modules/cli/src/commands/completions.ts
+++ b/src/modules/cli/src/commands/completions.ts
@@ -10,7 +10,7 @@ import { output } from '../output.js';
 
 // Get all top-level commands for completions
 const TOP_LEVEL_COMMANDS = [
-  'swarm', 'agent', 'task', 'session', 'config', 'memory', 'spell',
+  'swarm', 'agent', 'task', 'session', 'config', 'memory', 'spell', 'cast',
   'hive-mind', 'hooks', 'daemon', 'neural', 'security', 'performance',
   'providers', 'plugins', 'deployment', 'claims', 'embeddings',
   'doctor', 'completions', 'help', 'version'
@@ -151,6 +151,7 @@ _claude_flow() {
         'config:Configuration management'
         'memory:Memory operations with AgentDB'
         'spell:Spell casting & automation'
+        'cast:Cast a spell (shortcut for spell cast)'
         'hive-mind:Queen-led consensus coordination'
         'hooks:Self-learning automation hooks'
         'daemon:Background service management'

--- a/src/modules/cli/src/commands/index.ts
+++ b/src/modules/cli/src/commands/index.ts
@@ -37,6 +37,7 @@ const commandLoaders: Record<string, CommandLoader> = {
   migrate: () => import('./migrate.js'),
   hooks: () => import('./hooks.js'),
   spell: () => import('./spell.js'),
+  cast: () => import('./spell.js').then(m => ({ default: m.castCommand })),
   'hive-mind': () => import('./hive-mind.js'),
   process: () => import('./process.js'),
   daemon: () => import('./daemon.js'),
@@ -138,7 +139,7 @@ import { hiveMindCommand } from './hive-mind.js';
 import { configCommand } from './config.js';
 import { completionsCommand } from './completions.js';
 import { migrateCommand } from './migrate.js';
-import { spellCommand } from './spell.js';
+import { spellCommand, castCommand } from './spell.js';
 import { analyzeCommand } from './analyze.js';
 import { routeCommand } from './route.js';
 import { progressCommand } from './progress.js';
@@ -167,6 +168,7 @@ loadedCommands.set('mcp', mcpCommand);
 loadedCommands.set('hooks', hooksCommand);
 loadedCommands.set('daemon', daemonCommand);
 loadedCommands.set('doctor', doctorCommand);
+loadedCommands.set('cast', castCommand);
 loadedCommands.set('embeddings', embeddingsCommand);
 loadedCommands.set('neural', neuralCommand);
 loadedCommands.set('performance', performanceCommand);
@@ -245,6 +247,7 @@ export const commands: Command[] = [
   hooksCommand,
   daemonCommand,
   doctorCommand,
+  castCommand,
   embeddingsCommand,
   neuralCommand,
   performanceCommand,
@@ -263,6 +266,7 @@ export const commandsByCategory = {
     initCommand,
     startCommand,
     statusCommand,
+    castCommand,
     agentCommand,
     swarmCommand,
     memoryCommand,

--- a/src/modules/cli/src/commands/spell.ts
+++ b/src/modules/cli/src/commands/spell.ts
@@ -127,7 +127,7 @@ function printSpellErrors(errors: SpellErrorResponse[]): void {
 }
 
 // Cast subcommand (formerly "run")
-const castCommand: Command = {
+export const castCommand: Command = {
   name: 'cast',
   aliases: ['run'],
   description: 'Cast a spell',


### PR DESCRIPTION
## Summary
- Expose existing `castCommand` at top level: `flo cast <name>` → same as `flo spell cast -n <name>`
- Same Command object reused, all options and flags work identically
- Added shell completions for `cast` and 2 new registration tests

## Test plan
- [x] `npx vitest run src/modules/cli/__tests__/spell-command.test.ts` (14 → 16 passing)
- [x] Full CLI package builds cleanly
- [x] `hasCommand('cast')` returns true, points to same object as `spell cast` subcommand

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)