### PR TITLE
perf(tests): batch isolation pass into single vitest invocation

### DIFF
--- a/scripts/test-runner.mjs
+++ b/scripts/test-runner.mjs
@@ -100,33 +100,37 @@ async function main() {
     console.log(`\n✓ Parallel suite: ${main.passed} tests passed`);
   }
 
-  // ── Pass 2: Isolation tests (sequential) ──
-  if (isolationTests.length > 0) {
-    console.log(`\n━━ Pass 2: Isolation tests (${isolationTests.length} files, sequential) ━━\n`);
+  // ── Pass 2: Isolation tests (single batch, serialized via maxForks:1) ──
+  //
+  // Previously this spawned one vitest process per file. Each cold-boot
+  // costs 3-6s for ts-node + plugin + transform setup, adding 30-60s of
+  // pure startup overhead across the list. A single invocation with
+  // maxForks:1 gives us the same one-at-a-time execution with a single
+  // cold-boot, typically cutting Pass 2 wall time in half.
+  const presentIsolationTests = isolationTests.filter((t) => {
+    if (existsSync(resolve(root, t))) return true;
+    console.log(`  ⚠ skipped (not found): ${t}`);
+    return false;
+  });
 
-    for (const testFile of isolationTests) {
-      const fullPath = resolve(root, testFile);
-      if (!existsSync(fullPath)) {
-        console.log(`  ⚠ skipped (not found): ${testFile}`);
-        continue;
-      }
+  if (presentIsolationTests.length > 0) {
+    console.log(`\n━━ Pass 2: Isolation tests (${presentIsolationTests.length} files, single batch) ━━\n`);
 
-      const result = await runVitest([
-        'run',
-        testFile,
-        '--reporter=default',
-        '--reporter=json',
-        `--outputFile.json=${jsonFile}`,
-      ], { config: isolationConfig });
+    const result = await runVitest([
+      'run',
+      ...presentIsolationTests,
+      '--reporter=default',
+      '--reporter=json',
+      `--outputFile.json=${jsonFile}`,
+    ], { config: isolationConfig });
 
-      totalPassed += result.passed;
-      totalFailed += result.failed;
+    totalPassed += result.passed;
+    totalFailed += result.failed;
 
-      if (result.failed > 0) {
-        console.log(`  ✗ ${testFile}: ${result.failed} failure(s)`);
-      } else {
-        console.log(`  ✓ ${testFile}: ${result.passed} passed`);
-      }
+    if (result.failed > 0) {
+      console.log(`\n✗ Isolation batch: ${result.failed} failure(s)`);
+    } else {
+      console.log(`\n✓ Isolation batch: ${result.passed} tests passed`);
     }
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,9 +20,6 @@ export const isolationTests = [
   // Timing-based parallelism assertion — Windows maxForks contention pushes
   // the 75ms threshold over on full-suite runs; passes alone consistently.
   'src/modules/spells/__tests__/preflights.test.ts',
-  // 47 tests sharing one AgentDB instance via beforeAll; _clearForTest + 12
-  // storePattern calls exceed 30s under Linux CI parallel load (186s file total).
-  'src/modules/hooks/src/__tests__/guidance-provider.test.ts',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Pass 2 of `scripts/test-runner.mjs` used to spawn one `vitest` process per isolation file (10+ cold-boots). Now it passes all isolation files to a single `vitest run` with `maxForks:1`, keeping sequential execution but only paying the startup cost once.
- Drop `guidance-provider.test.ts` from `isolationTests` — #455's `useMockEmbeddings` short-circuit made its ReasoningBank init fast enough for the parallel pass.

## Impact
- Local Pass 2 wall-time: **~60s → 7.14s** (9 files, 179 tests).
- CI baseline (Linux Tests job) was **~1m 55s** after #455. Expecting **<1m** after this change.
- All 7528 tests still pass locally; zero regressions.

## Test plan
- [x] `npm test` passes locally
- [ ] Linux CI Tests job drops below 1m

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)