### PR TITLE
refactor(neural): consolidate ReasoningBank on @moflo/memory (C4)

### DIFF
--- a/docs/memory-stack-audit-neural-hooks.md
+++ b/docs/memory-stack-audit-neural-hooks.md
@@ -12,7 +12,7 @@ Verdict: **Green for Option B** (remove + rely on fallbacks), with two caveats n
 | Pattern-learning hooks | Degrades silently | M | In-memory fallback works; persistence + HNSW lost |
 | Trajectory recording | Degrades silently | M | In-memory fallback; trajectories lost across process restart |
 | SONA | Unaffected | — | Persists to `.swarm/sona-patterns.json`; never touched agentdb |
-| ReasoningBank (neural/) | Degrades silently | M | Brute-force cosine fallback wired at `reasoning-bank.ts:277` |
+| ReasoningBank (neural/) | Unified on @moflo/memory | L | Consolidated on the bridge-backed AgentDBAdapter in C4 (issue #468); brute-force fallback retained for `enableAgentDB: false` |
 | agentic-flow subprocess | Unaffected | — | Zero static imports; only 6 lazy `import('agentic-flow/…').catch(() => null)` sites |
 
 Two caveats for the decision memo:
@@ -132,12 +132,21 @@ None.
 
 ### 5. ReasoningBank (neural module)
 
+> **Update 2026-04-20 (C4, issue #468):** consolidated on the moflo-owned
+> `AgentDBAdapter` from `@moflo/memory`. The neural ReasoningBank no longer
+> imports the external `agentdb` package; both neural/ and hooks/ paths now
+> share the same adapter + HNSW index. `optionalDependencies.agentdb` was
+> removed from `@moflo/neural`. Brute-force fallback retained for
+> `enableAgentDB: false`. The divergence noted below in "known gaps" #2 is
+> closed.
+
 **Entry points**
-- `src/modules/neural/src/reasoning-bank.ts` (1279 LOC) — the 4-step RETRIEVE/JUDGE/DISTILL/CONSOLIDATE pipeline
-- Imported by: `src/modules/neural/src/reasoningbank-adapter.ts`, `src/modules/hooks/src/reasoningbank/index.ts`
+- `src/modules/neural/src/reasoning-bank.ts` (~1290 LOC) — the 4-step RETRIEVE/JUDGE/DISTILL/CONSOLIDATE pipeline
+- Imported by: `src/modules/neural/src/index.ts` (NeuralLearningSystem), `src/modules/neural/__tests__/patterns.test.ts`
+- No external consumers outside `@moflo/neural` (grep-verified)
 
 **Code path**
-`ReasoningBank.initialize()` → `ensureAgentDBImport()` → if `AgentDB !== undefined`, constructs `new AgentDB({ dbPath, namespace, vectorDimension, vectorBackend: 'auto' })` at `reasoning-bank.ts:209`. On any throw, `this.agentdbAvailable = false` (line 220).
+`ReasoningBank.initialize()` → `ensureAgentDBAdapterImport()` → dynamic `import('@moflo/memory')` via a variable specifier (same pattern as hooks/). If the module resolves, constructs `new AgentDBAdapter({ dimensions, defaultNamespace, persistenceEnabled, persistencePath })`. On any throw, `this.agentdbAvailable = false`.
 
 Retrieval (`reasoning-bank.ts:251-290`):
 ```ts
@@ -234,10 +243,7 @@ Eight total. Zero are static imports. All dynamic imports are either wrapped in 
 
 1. **No "agentdb-absent" integration test.** Every test that exercises agentdb-dependent code initializes it in-memory or mocks the sub-components. Gate 3 (consumer smoke harness) is the right venue to prove the fallback end-to-end.
 
-2. **In-process vs. bridge-backed ReasoningBank divergence.** There are two ReasoningBank implementations:
-   - `neural/src/reasoning-bank.ts` — in-process `Map` + brute-force; no persistence without agentdb
-   - `hooks/src/reasoningbank/index.ts` — routes through `memory-bridge.ts` which has a sql.js fallback that *does* persist
-   On Option B removal, the hooks layer survives with persistence; the neural layer loses persistence. If both are user-facing, consumers will see inconsistent durability. Worth a human decision: consolidate to the bridge-backed path, or document the two tiers.
+2. **In-process vs. bridge-backed ReasoningBank divergence.** ✅ RESOLVED in C4 (issue #468, 2026-04-20). Both neural/ and hooks/ ReasoningBank now share `@moflo/memory`'s `AgentDBAdapter` + `HNSWIndex`. Persistence behaviour is uniform (whatever the adapter provides — currently in-memory; real disk persistence is scheduled for a later C-phase). The external `agentdb` package is no longer referenced from either module.
 
 3. **Silent degradation vs. visible warning.** Every fallback path returns `null` / `[]` / no-op. No console warning is emitted when agentdb is missing at runtime. If we land Option B, a single init-time warning ("agentdb not available; using sql.js fallback with reduced features") would massively help users understand what changed.
 

--- a/src/modules/neural/package.json
+++ b/src/modules/neural/package.json
@@ -12,8 +12,5 @@
   },
   "dependencies": {
     "@moflo/memory": "^3.0.0-alpha.2"
-  },
-  "optionalDependencies": {
-    "agentdb": "^2.0.0 || ^3.0.0-alpha.1"
   }
 }

--- a/src/modules/neural/src/reasoning-bank.ts
+++ b/src/modules/neural/src/reasoning-bank.ts
@@ -27,21 +27,26 @@ import type {
 } from './types.js';
 
 // ============================================================================
-// AgentDB Integration
+// Persistence via @moflo/memory (shared with hooks/ReasoningBank)
 // ============================================================================
 
-let AgentDB: any;
+let AgentDBAdapter: any;
+let createDefaultEntry: ((input: any) => any) | undefined;
 let agentdbImportPromise: Promise<void> | undefined;
 
-async function ensureAgentDBImport(): Promise<void> {
+async function ensureAgentDBAdapterImport(): Promise<void> {
   if (!agentdbImportPromise) {
     agentdbImportPromise = (async () => {
       try {
-        const agentdbModule: any = await import('agentdb');
-        AgentDB = agentdbModule.AgentDB || agentdbModule.default;
+        // Variable specifier so tsc/bundlers skip static resolution;
+        // @moflo/memory is an optional runtime peer installed by the consumer.
+        const moduleName = '@moflo/memory';
+        const memoryModule: any = await import(/* webpackIgnore: true */ moduleName);
+        AgentDBAdapter = memoryModule.AgentDBAdapter;
+        createDefaultEntry = memoryModule.createDefaultEntry;
       } catch {
-        // AgentDB not available - will use fallback
-        AgentDB = undefined;
+        AgentDBAdapter = undefined;
+        createDefaultEntry = undefined;
       }
     })();
   }
@@ -171,9 +176,8 @@ export class ReasoningBank {
   private patterns: Map<string, Pattern> = new Map();
   private eventListeners: Set<NeuralEventListener> = new Set();
 
-  // AgentDB instance for vector storage
+  // @moflo/memory adapter for vector storage (shared with hooks/ReasoningBank)
   private agentdb: any = null;
-  private agentdbAvailable: boolean = false;
   private initialized: boolean = false;
 
   // Performance tracking
@@ -195,29 +199,27 @@ export class ReasoningBank {
   // ==========================================================================
 
   /**
-   * Initialize ReasoningBank with AgentDB
+   * Initialize ReasoningBank with the @moflo/memory AgentDBAdapter.
    */
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
     if (this.config.enableAgentDB) {
-      await ensureAgentDBImport();
-      this.agentdbAvailable = AgentDB !== undefined;
-
-      if (this.agentdbAvailable) {
+      await ensureAgentDBAdapterImport();
+      if (AgentDBAdapter !== undefined) {
         try {
-          this.agentdb = new AgentDB({
-            dbPath: this.config.dbPath || ':memory:',
-            namespace: this.config.namespace,
-            vectorDimension: this.config.vectorDimension,
-            vectorBackend: 'auto',
+          this.agentdb = new AgentDBAdapter({
+            dimensions: this.config.vectorDimension,
+            defaultNamespace: this.config.namespace,
+            persistenceEnabled: Boolean(this.config.dbPath),
+            persistencePath: this.config.dbPath,
           });
 
           await this.agentdb.initialize();
           this.emitEvent({ type: 'memory_consolidated', memoriesCount: 0 });
         } catch (error) {
-          console.warn('AgentDB initialization failed, using fallback:', error);
-          this.agentdbAvailable = false;
+          console.warn('AgentDBAdapter initialization failed, using fallback:', error);
+          this.agentdb = null;
         }
       }
     }
@@ -230,7 +232,7 @@ export class ReasoningBank {
    */
   async shutdown(): Promise<void> {
     if (this.agentdb) {
-      await this.agentdb.close?.();
+      await this.agentdb.shutdown();
     }
     this.initialized = false;
   }
@@ -259,7 +261,7 @@ export class ReasoningBank {
     let candidates: Array<{ entry: MemoryEntry; relevance: number }> = [];
 
     // Try AgentDB HNSW search first
-    if (this.agentdb && this.agentdbAvailable) {
+    if (this.agentdb) {
       try {
         const results = await this.searchWithAgentDB(queryEmbedding, retrieveK * 3);
         candidates = results
@@ -268,8 +270,8 @@ export class ReasoningBank {
             return entry ? { entry, relevance: r.similarity } : null;
           })
           .filter((c): c is { entry: MemoryEntry; relevance: number } => c !== null);
-      } catch {
-        // Fall through to brute-force
+      } catch (error) {
+        console.warn('AgentDB search failed, falling back to brute-force:', error);
       }
     }
 
@@ -484,7 +486,7 @@ export class ReasoningBank {
     this.memories.set(memory.memoryId, entry);
 
     // Store in AgentDB for vector search
-    if (this.agentdb && this.agentdbAvailable) {
+    if (this.agentdb) {
       await this.storeInAgentDB(memory);
     }
 
@@ -731,7 +733,7 @@ export class ReasoningBank {
         .filter(e => e.consolidated).length,
       successfulTrajectories: this.getSuccessfulTrajectories().length,
       failedTrajectories: this.getFailedTrajectories().length,
-      agentdbEnabled: this.agentdbAvailable ? 1 : 0,
+      agentdbEnabled: this.agentdb ? 1 : 0,
       retrievalCount: this.retrievalCount,
       distillationCount: this.distillationCount,
       judgeCount: this.judgeCount,
@@ -827,32 +829,36 @@ export class ReasoningBank {
   // ==========================================================================
 
   /**
-   * Store memory in AgentDB for vector search
+   * Store memory in the @moflo/memory adapter for vector search.
    */
   private async storeInAgentDB(memory: DistilledMemory): Promise<void> {
-    if (!this.agentdb) return;
+    if (!this.agentdb || !createDefaultEntry) return;
 
     try {
-      if (typeof this.agentdb.store === 'function') {
-        await this.agentdb.store(memory.memoryId, {
-          content: memory.strategy,
-          embedding: memory.embedding,
-          metadata: {
-            trajectoryId: memory.trajectoryId,
-            quality: memory.quality,
-            keyLearnings: memory.keyLearnings,
-            usageCount: memory.usageCount,
-            lastUsed: memory.lastUsed,
-          },
-        });
-      }
+      const entry = createDefaultEntry({
+        key: memory.memoryId,
+        content: memory.strategy,
+        type: 'semantic',
+        namespace: this.config.namespace,
+        tags: ['reasoning-bank', 'distilled-memory'],
+        metadata: {
+          trajectoryId: memory.trajectoryId,
+          quality: memory.quality,
+          keyLearnings: memory.keyLearnings,
+          usageCount: memory.usageCount,
+          lastUsed: memory.lastUsed,
+        },
+      });
+      entry.id = memory.memoryId;
+      entry.embedding = memory.embedding;
+      await this.agentdb.store(entry);
     } catch (error) {
-      console.warn('Failed to store in AgentDB:', error);
+      console.warn('Failed to store in AgentDB adapter:', error);
     }
   }
 
   /**
-   * Search using AgentDB HNSW index
+   * Search via the @moflo/memory adapter's HNSW index.
    */
   private async searchWithAgentDB(
     queryEmbedding: Float32Array,
@@ -861,38 +867,24 @@ export class ReasoningBank {
     if (!this.agentdb) return [];
 
     try {
-      if (typeof this.agentdb.search === 'function') {
-        return await this.agentdb.search(queryEmbedding, k);
-      }
-
-      // Try HNSW controller if available
-      const hnsw = this.agentdb.getController?.('hnsw');
-      if (hnsw) {
-        const results = await hnsw.search(queryEmbedding, k);
-        return results.map((r: any) => ({
-          id: String(r.id),
-          similarity: r.similarity || 1 - r.distance,
-        }));
-      }
-    } catch {
-      // Fall through to return empty
+      const results = await this.agentdb.search(queryEmbedding, { k });
+      return results.map((r: any) => ({ id: r.entry.id, similarity: r.score }));
+    } catch (error) {
+      console.warn('AgentDB search failed:', error);
+      return [];
     }
-
-    return [];
   }
 
   /**
-   * Delete from AgentDB
+   * Delete from the @moflo/memory adapter.
    */
   private async deleteFromAgentDB(memoryId: string): Promise<void> {
     if (!this.agentdb) return;
 
     try {
-      if (typeof this.agentdb.delete === 'function') {
-        await this.agentdb.delete(memoryId);
-      }
-    } catch {
-      // Ignore deletion errors
+      await this.agentdb.delete(memoryId);
+    } catch (error) {
+      console.warn('AgentDB delete failed:', error);
     }
   }
 
@@ -1250,7 +1242,7 @@ export class ReasoningBank {
    * Check if AgentDB is available and initialized
    */
   isAgentDBAvailable(): boolean {
-    return this.agentdbAvailable;
+    return this.agentdb !== null;
   }
 }
 


### PR DESCRIPTION
## Summary
- C4 of epic #464 (agentdb removal). Swaps the external \`agentdb\` package in neural/ReasoningBank for the moflo-owned \`AgentDBAdapter\` from \`@moflo/memory\` — the same backend hooks/ReasoningBank already uses.
- Closes the Gate-2 open question #2 in \`docs/memory-stack-audit-neural-hooks.md\` about divergent persistence between the neural and hooks layers.
- Dynamic import via a variable specifier, matching the hooks-side loader pattern; \`@moflo/memory\` stays an optional runtime peer.

## Changes
- \`src/modules/neural/src/reasoning-bank.ts\`: switch backend to \`AgentDBAdapter\`; use \`createDefaultEntry\` from \`@moflo/memory\` to construct \`MemoryEntry\`; drop redundant \`agentdbAvailable\` field in favor of \`this.agentdb !== null\`; add \`console.warn\` to previously-silent search/delete catches (per feedback_no_silent_failures).
- \`src/modules/neural/package.json\`: drop \`optionalDependencies.agentdb\` entry.
- \`docs/memory-stack-audit-neural-hooks.md\`: update section 5; close open-question #2 with RESOLVED marker.

## Testing
- [x] \`@moflo/neural\` build — clean (tsc)
- [x] Unit tests — 108/108 pass (3 test files) in \`src/modules/neural\`
- [x] Consumer smoke harness — 14/14 PASS (\`node harness/consumer-smoke/run.mjs\`)
- [x] Existing \`patterns.test.ts\` passes unchanged — proves neural ReasoningBank public API is backward-compatible

Closes #468