### PR TITLE
feat(memory): Phase C5 — 4 moflo-owned High-effort controllers (#464)

### DIFF
--- a/src/modules/memory/src/controller-registry.ts
+++ b/src/modules/memory/src/controller-registry.ts
@@ -515,8 +515,11 @@ export class ControllerRegistry extends EventEmitter {
       case 'memoryGraph':
         return !!(this.config.memory?.memoryGraph || this.backend);
 
-      // Security — enabled if AgentDB available
+      // MutationGuard is moflo-owned + in-memory — no DB needed (epic #464 Phase C5).
       case 'mutationGuard':
+        return true;
+
+      // Security — enabled if AgentDB available (for sql.js handle)
       case 'attestationLog':
         return this.agentdb !== null;
 
@@ -780,6 +783,17 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'causalGraph': {
+        // Prefer moflo-owned impl (epic #464 Phase C5).
+        if (this.agentdb?.database) {
+          try {
+            const { CausalGraph } = await import('./controllers/causal-graph.js');
+            const graph = new CausalGraph(this.agentdb.database);
+            await graph.initializeDatabase();
+            return graph;
+          } catch {
+            // Fall through to agentdb.
+          }
+        }
         if (!this.agentdb || typeof this.agentdb.getController !== 'function') return null;
         try {
           return this.agentdb.getController(name) ?? null;
@@ -787,6 +801,17 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'learningSystem': {
+        // Prefer moflo-owned impl (epic #464 Phase C5).
+        if (this.agentdb?.database) {
+          try {
+            const { LearningSystem } = await import('./controllers/learning-system.js');
+            const ls = new LearningSystem(this.agentdb.database);
+            await ls.initializeDatabase();
+            return ls;
+          } catch {
+            // Fall through to agentdb.
+          }
+        }
         if (!this.agentdb) return null;
         try {
           const agentdbModule: any = await import('agentdb');
@@ -862,8 +887,13 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'mutationGuard': {
-        // MutationGuard exported from agentdb 3.0.0-alpha.10 (ADR-060)
-        // Constructor: (config?) where config.dimension, config.maxElements, config.enableWasmProofs
+        // Prefer moflo-owned impl (epic #464 Phase C5) — pure in-memory, no DB needed.
+        try {
+          const { MutationGuard } = await import('./controllers/mutation-guard.js');
+          return new MutationGuard();
+        } catch {
+          // Fall through to agentdb.
+        }
         if (!this.agentdb) return null;
         try {
           const agentdbModule: any = await import('agentdb');

--- a/src/modules/memory/src/controllers/_shared.ts
+++ b/src/modules/memory/src/controllers/_shared.ts
@@ -139,6 +139,20 @@ export function generateId(prefix: string): string {
 }
 
 /**
+ * Bounded-value helpers shared by controllers. `clamp01` is the common
+ * score/weight path; `clampInt` coerces pagination/limit arguments.
+ */
+export function clamp01(n: unknown): number {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+export function clampInt(n: unknown, min: number, max: number, fallback: number = min): number {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}
+
+/**
  * Runtime duck-type check. Small helper so controller-registry can detect
  * moflo-owned controllers without a static import-cycle on the classes.
  */

--- a/src/modules/memory/src/controllers/causal-graph.test.ts
+++ b/src/modules/memory/src/controllers/causal-graph.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import initSqlJs, { Database } from 'sql.js';
+import { CausalGraph } from './causal-graph.js';
+
+let SQL: any;
+
+beforeAll(async () => {
+  SQL = await initSqlJs();
+});
+
+describe('CausalGraph', () => {
+  let db: Database;
+  let graph: CausalGraph;
+
+  beforeEach(() => {
+    db = new SQL.Database();
+    graph = new CausalGraph(db as any);
+  });
+
+  it('rejects null db', () => {
+    expect(() => new CausalGraph(null as any)).toThrow(/requires a sql\.js/i);
+  });
+
+  it('creates schema idempotently', () => {
+    const second = new CausalGraph(db as any);
+    expect(second.count()).toBe(0);
+  });
+
+  it('addEdge rejects missing source/target/relation', () => {
+    expect(() => graph.addEdge('', 'b', { relation: 'r' })).toThrow(/source and target/);
+    expect(() => graph.addEdge('a', '', { relation: 'r' })).toThrow(/source and target/);
+    expect(() => graph.addEdge('a', 'b', { relation: '' } as any)).toThrow(/relation/);
+  });
+
+  it('adds edges and counts them', () => {
+    graph.addEdge('a', 'b', { relation: 'caused', weight: 0.9 });
+    graph.addEdge('b', 'c', { relation: 'caused', weight: 0.7 });
+    expect(graph.count()).toBe(2);
+  });
+
+  it('dedupes on (source, target, relation)', () => {
+    graph.addEdge('a', 'b', { relation: 'caused', weight: 0.5 });
+    graph.addEdge('a', 'b', { relation: 'caused', weight: 0.9 });
+    expect(graph.count()).toBe(1);
+    const [edge] = graph.edges({ source: 'a' });
+    expect(edge.weight).toBeCloseTo(0.9);
+  });
+
+  it('neighbors returns direct outgoing edges sorted by weight', () => {
+    graph.addEdge('a', 'b', { relation: 'caused', weight: 0.3 });
+    graph.addEdge('a', 'c', { relation: 'caused', weight: 0.8 });
+    graph.addEdge('a', 'd', { relation: 'preceded', weight: 0.5 });
+    const out = graph.neighbors('a');
+    expect(out.map((e) => e.target)).toEqual(['c', 'd', 'b']);
+  });
+
+  it('neighbors filters by relation', () => {
+    graph.addEdge('a', 'b', { relation: 'caused' });
+    graph.addEdge('a', 'c', { relation: 'preceded' });
+    const caused = graph.neighbors('a', { relation: 'caused' });
+    expect(caused).toHaveLength(1);
+    expect(caused[0].target).toBe('b');
+  });
+
+  it('neighbors supports direction: in', () => {
+    graph.addEdge('a', 'x', { relation: 'caused' });
+    graph.addEdge('b', 'x', { relation: 'caused' });
+    const incoming = graph.neighbors('x', { direction: 'in' });
+    expect(incoming.map((e) => e.source).sort()).toEqual(['a', 'b']);
+  });
+
+  it('neighbors supports direction: both', () => {
+    graph.addEdge('a', 'x', { relation: 'caused' });
+    graph.addEdge('x', 'b', { relation: 'caused' });
+    const both = graph.neighbors('x', { direction: 'both' });
+    expect(both).toHaveLength(2);
+  });
+
+  it('clamps weight into [0,1] and defaults timestamp', () => {
+    graph.addEdge('a', 'b', { relation: 'r', weight: 5 });
+    graph.addEdge('c', 'd', { relation: 'r', weight: -1 });
+    const all = graph.edges({});
+    const byTarget = Object.fromEntries(all.map((e) => [e.target, e]));
+    expect(byTarget.b.weight).toBe(1);
+    expect(byTarget.d.weight).toBe(0);
+    expect(byTarget.b.timestamp).toBeGreaterThan(0);
+  });
+
+  it('clear empties the table', () => {
+    graph.addEdge('a', 'b', { relation: 'r' });
+    graph.clear();
+    expect(graph.count()).toBe(0);
+  });
+
+  it('roundtrips metadata JSON', () => {
+    graph.addEdge('a', 'b', { relation: 'r', metadata: { note: 'seen' } });
+    const [edge] = graph.edges({});
+    expect(edge.metadata).toEqual({ note: 'seen' });
+  });
+});

--- a/src/modules/memory/src/controllers/causal-graph.ts
+++ b/src/modules/memory/src/controllers/causal-graph.ts
@@ -1,0 +1,173 @@
+/**
+ * CausalGraph — moflo-owned causal edge store.
+ *
+ * Replaces `agentdb.CausalGraph.addEdge`. Stores typed edges between
+ * memory-entry IDs in a sql.js-backed table with composite indexes so
+ * CausalRecall's BFS walks don't hit a full scan on the relation filter.
+ */
+
+import { clamp01, clampInt, parseJsonSafe } from './_shared.js';
+import type { SqlJsDatabaseLike } from './types.js';
+
+const TABLE = 'moflo_causal_edges';
+
+export interface CausalEdgeInput {
+  relation: string;
+  weight?: number;
+  timestamp?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CausalEdge {
+  id: number;
+  source: string;
+  target: string;
+  relation: string;
+  weight: number;
+  timestamp: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface NeighborOptions {
+  direction?: 'out' | 'in' | 'both';
+  relation?: string;
+  limit?: number;
+}
+
+export interface EdgeQuery {
+  source?: string;
+  target?: string;
+  relation?: string;
+  limit?: number;
+}
+
+export class CausalGraph {
+  static TABLE = TABLE;
+
+  private db: SqlJsDatabaseLike;
+
+  constructor(db: SqlJsDatabaseLike) {
+    if (!db) throw new Error('CausalGraph requires a sql.js Database');
+    this.db = db;
+    this.ensureSchema();
+  }
+
+  async initializeDatabase(): Promise<void> {
+    this.ensureSchema();
+  }
+
+  addEdge(source: string, target: string, input: CausalEdgeInput): void {
+    if (!source || !target) throw new Error('addEdge requires source and target ids');
+    if (!input?.relation) throw new Error('addEdge requires a relation');
+    const weight = typeof input.weight === 'number' && Number.isFinite(input.weight)
+      ? clamp01(input.weight)
+      : 1.0;
+    const ts = typeof input.timestamp === 'number' ? input.timestamp : Date.now();
+    const metaJson = JSON.stringify(input.metadata ?? {});
+    this.db.run(
+      `INSERT OR REPLACE INTO ${TABLE} (source, target, relation, weight, ts, metadata)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [String(source), String(target), String(input.relation), weight, ts, metaJson],
+    );
+  }
+
+  neighbors(id: string, options: NeighborOptions = {}): CausalEdge[] {
+    if (!id) return [];
+    const direction = options.direction ?? 'out';
+    const limit = clampInt(options.limit, 1, 500, 500);
+    const where: string[] = [];
+    const params: any[] = [];
+    if (direction === 'out') {
+      where.push('source = ?');
+      params.push(id);
+    } else if (direction === 'in') {
+      where.push('target = ?');
+      params.push(id);
+    } else {
+      where.push('(source = ? OR target = ?)');
+      params.push(id, id);
+    }
+    if (options.relation) {
+      where.push('relation = ?');
+      params.push(options.relation);
+    }
+    const sql = `SELECT id, source, target, relation, weight, ts, metadata
+      FROM ${TABLE}
+      WHERE ${where.join(' AND ')}
+      ORDER BY weight DESC, ts DESC
+      LIMIT ${limit}`;
+    return this.query(sql, params);
+  }
+
+  edges(options: EdgeQuery = {}): CausalEdge[] {
+    const limit = clampInt(options.limit, 1, 1000, 1000);
+    const where: string[] = [];
+    const params: any[] = [];
+    if (options.source) { where.push('source = ?'); params.push(options.source); }
+    if (options.target) { where.push('target = ?'); params.push(options.target); }
+    if (options.relation) { where.push('relation = ?'); params.push(options.relation); }
+    const filter = where.length ? `WHERE ${where.join(' AND ')}` : '';
+    const sql = `SELECT id, source, target, relation, weight, ts, metadata
+      FROM ${TABLE} ${filter} ORDER BY id ASC LIMIT ${limit}`;
+    return this.query(sql, params);
+  }
+
+  count(): number {
+    const stmt = this.db.prepare(`SELECT COUNT(*) AS n FROM ${TABLE}`);
+    try {
+      stmt.step();
+      return Number(stmt.getAsObject().n ?? 0);
+    } finally {
+      stmt.free();
+    }
+  }
+
+  clear(): void {
+    this.db.run(`DELETE FROM ${TABLE}`);
+  }
+
+  private query(sql: string, params: any[]): CausalEdge[] {
+    const stmt = this.db.prepare(sql);
+    const out: CausalEdge[] = [];
+    try {
+      if (typeof stmt.bind === 'function') stmt.bind(params);
+      while (stmt.step()) {
+        out.push(rowToEdge(stmt.getAsObject()));
+      }
+    } finally {
+      stmt.free();
+    }
+    return out;
+  }
+
+  private ensureSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS ${TABLE} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source TEXT NOT NULL,
+        target TEXT NOT NULL,
+        relation TEXT NOT NULL,
+        weight REAL NOT NULL,
+        ts INTEGER NOT NULL,
+        metadata TEXT NOT NULL,
+        UNIQUE(source, target, relation)
+      );
+      CREATE INDEX IF NOT EXISTS idx_${TABLE}_source_rel ON ${TABLE}(source, relation);
+      CREATE INDEX IF NOT EXISTS idx_${TABLE}_target_rel ON ${TABLE}(target, relation);
+    `);
+  }
+}
+
+function rowToEdge(r: Record<string, any>): CausalEdge {
+  return {
+    id: Number(r.id),
+    source: String(r.source),
+    target: String(r.target),
+    relation: String(r.relation),
+    weight: Number(r.weight),
+    timestamp: Number(r.ts),
+    metadata: parseJsonSafe(r.metadata),
+  };
+}
+
+export default CausalGraph;

--- a/src/modules/memory/src/controllers/causal-recall.test.ts
+++ b/src/modules/memory/src/controllers/causal-recall.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import initSqlJs, { Database } from 'sql.js';
+import { CausalGraph } from './causal-graph.js';
+import { CausalRecall } from './causal-recall.js';
+
+let SQL: any;
+
+beforeAll(async () => {
+  SQL = await initSqlJs();
+});
+
+describe('CausalRecall', () => {
+  let db: Database;
+  let graph: CausalGraph;
+  let recall: CausalRecall;
+
+  beforeEach(() => {
+    db = new SQL.Database();
+    graph = new CausalGraph(db as any);
+    recall = new CausalRecall(graph);
+  });
+
+  it('rejects null graph', () => {
+    expect(() => new CausalRecall(null as any)).toThrow(/requires a CausalGraph/);
+  });
+
+  it('returns empty walk when start node missing', () => {
+    expect(recall.walk({ start: '' })).toEqual([]);
+  });
+
+  it('walks one hop by default', () => {
+    graph.addEdge('a', 'b', { relation: 'caused', weight: 0.9 });
+    graph.addEdge('a', 'c', { relation: 'caused', weight: 0.6 });
+    const paths = recall.walk({ start: 'a' });
+    expect(paths).toHaveLength(2);
+    expect(paths[0].nodes).toEqual(['a', 'b']); // higher weight ranks first
+    expect(paths[1].nodes).toEqual(['a', 'c']);
+  });
+
+  it('walks multi-hop up to maxDepth', () => {
+    graph.addEdge('a', 'b', { relation: 'caused', weight: 0.8 });
+    graph.addEdge('b', 'c', { relation: 'caused', weight: 0.7 });
+    graph.addEdge('c', 'd', { relation: 'caused', weight: 0.6 });
+    const paths = recall.walk({ start: 'a', maxDepth: 3 });
+    const maxDepth = Math.max(...paths.map((p) => p.depth));
+    expect(maxDepth).toBe(3);
+    const dPath = paths.find((p) => p.nodes[p.nodes.length - 1] === 'd');
+    expect(dPath?.nodes).toEqual(['a', 'b', 'c', 'd']);
+    // score = 0.8 * 0.7 * 0.6 = 0.336
+    expect(dPath?.score).toBeCloseTo(0.336, 3);
+  });
+
+  it('does not loop on cycles', () => {
+    graph.addEdge('a', 'b', { relation: 'caused' });
+    graph.addEdge('b', 'c', { relation: 'caused' });
+    graph.addEdge('c', 'a', { relation: 'caused' });
+    const paths = recall.walk({ start: 'a', maxDepth: 4 });
+    // Visited set ensures each node appears at most once across the walk.
+    const all = paths.flatMap((p) => p.nodes);
+    const unique = new Set(all);
+    expect(unique.size).toBeLessThanOrEqual(3);
+  });
+
+  it('filters by minWeight', () => {
+    graph.addEdge('a', 'b', { relation: 'caused', weight: 0.9 });
+    graph.addEdge('a', 'c', { relation: 'caused', weight: 0.1 });
+    const paths = recall.walk({ start: 'a', minWeight: 0.5 });
+    expect(paths.map((p) => p.nodes[1])).toEqual(['b']);
+  });
+
+  it('filters by relation', () => {
+    graph.addEdge('a', 'b', { relation: 'caused' });
+    graph.addEdge('a', 'c', { relation: 'preceded' });
+    const paths = recall.walk({ start: 'a', relation: 'caused' });
+    expect(paths.map((p) => p.nodes[1])).toEqual(['b']);
+  });
+
+  it('shortestPath reaches the target', () => {
+    graph.addEdge('a', 'b', { relation: 'caused' });
+    graph.addEdge('b', 'c', { relation: 'caused' });
+    graph.addEdge('c', 'd', { relation: 'caused' });
+    const path = recall.shortestPath('a', 'd', { maxDepth: 4 });
+    expect(path?.nodes).toEqual(['a', 'b', 'c', 'd']);
+    expect(path?.depth).toBe(3);
+  });
+
+  it('shortestPath returns null when unreachable', () => {
+    graph.addEdge('a', 'b', { relation: 'caused' });
+    expect(recall.shortestPath('a', 'z')).toBeNull();
+  });
+
+  it('shortestPath to self returns empty path', () => {
+    expect(recall.shortestPath('a', 'a')).toEqual({ nodes: ['a'], edges: [], score: 1, depth: 0 });
+  });
+});
+
+describe('CausalRecall benchmark', () => {
+  it('3-hop query < 200ms on 1000-edge graph', () => {
+    const db = new SQL.Database();
+    const graph = new CausalGraph(db as any);
+    const recall = new CausalRecall(graph);
+    // Generate a random DAG-ish graph: 500 nodes, 1000 edges.
+    const nodes = Array.from({ length: 500 }, (_, i) => `n${i}`);
+    let edgeCount = 0;
+    for (let i = 0; i < nodes.length && edgeCount < 1000; i++) {
+      // Each node links to up to 3 later nodes; a few back-edges to exercise
+      // the visited-set without creating cycles that explode the walk.
+      for (let k = 1; k <= 3 && i + k < nodes.length && edgeCount < 1000; k++) {
+        graph.addEdge(nodes[i], nodes[i + k], { relation: 'caused', weight: 0.5 + (k / 10) });
+        edgeCount++;
+      }
+    }
+    expect(graph.count()).toBeGreaterThanOrEqual(1000);
+    const start = performance.now();
+    const paths = recall.walk({ start: nodes[0], maxDepth: 3, maxPaths: 50 });
+    const elapsed = performance.now() - start;
+    expect(paths.length).toBeGreaterThan(0);
+    expect(elapsed).toBeLessThan(200);
+  });
+});

--- a/src/modules/memory/src/controllers/causal-recall.ts
+++ b/src/modules/memory/src/controllers/causal-recall.ts
@@ -1,0 +1,142 @@
+/**
+ * CausalRecall — multi-hop walker over CausalGraph.
+ *
+ * BFS with a visited set bounds the walk to O(V+E); each node is reached
+ * via at most one path (shortest-first), ranked by accumulated edge
+ * weight. Paths are reconstructed from a parents map so we allocate
+ * O(V) instead of an O(V*depth) array-copy per hop.
+ */
+
+import { clampInt } from './_shared.js';
+import type { CausalEdge, CausalGraph } from './causal-graph.js';
+
+const MAX_DEPTH = 4;
+const MAX_PATHS = 50;
+const DEFAULT_DEPTH = 2;
+const DEFAULT_PATHS = 20;
+
+export interface WalkOptions {
+  start: string;
+  maxDepth?: number;
+  maxPaths?: number;
+  relation?: string;
+  minWeight?: number;
+}
+
+export interface CausalPath {
+  nodes: string[];
+  edges: CausalEdge[];
+  score: number;
+  depth: number;
+}
+
+export class CausalRecall {
+  private graph: CausalGraph;
+
+  constructor(graph: CausalGraph) {
+    if (!graph) throw new Error('CausalRecall requires a CausalGraph');
+    this.graph = graph;
+  }
+
+  async initializeDatabase(): Promise<void> {
+    // CausalGraph owns the schema.
+  }
+
+  walk(options: WalkOptions): CausalPath[] {
+    if (!options?.start) return [];
+    const maxDepth = clampInt(options.maxDepth, 1, MAX_DEPTH, DEFAULT_DEPTH);
+    const maxPaths = clampInt(options.maxPaths, 1, MAX_PATHS, DEFAULT_PATHS);
+    const minWeight = typeof options.minWeight === 'number' ? options.minWeight : 0;
+
+    interface Parent { edge: CausalEdge; depth: number; score: number }
+    const parents = new Map<string, Parent>();
+    const discovered: string[] = [];
+    const visited = new Set<string>([options.start]);
+    const queue: Array<{ node: string; depth: number; score: number }> = [
+      { node: options.start, depth: 0, score: 1 },
+    ];
+
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      if (cur.depth >= maxDepth) continue;
+      const neighbors = this.graph.neighbors(cur.node, {
+        direction: 'out',
+        relation: options.relation,
+      });
+      for (const edge of neighbors) {
+        if (edge.weight < minWeight) continue;
+        if (visited.has(edge.target)) continue;
+        visited.add(edge.target);
+        const score = cur.score * edge.weight;
+        parents.set(edge.target, { edge, depth: cur.depth + 1, score });
+        discovered.push(edge.target);
+        if (cur.depth + 1 < maxDepth) {
+          queue.push({ node: edge.target, depth: cur.depth + 1, score });
+        }
+      }
+    }
+
+    return discovered
+      .map((target) => reconstructPath(options.start, target, parents))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, maxPaths);
+  }
+
+  shortestPath(
+    start: string,
+    target: string,
+    options: { maxDepth?: number; relation?: string } = {},
+  ): CausalPath | null {
+    if (!start || !target) return null;
+    if (start === target) {
+      return { nodes: [start], edges: [], score: 1, depth: 0 };
+    }
+    const maxDepth = clampInt(options.maxDepth, 1, MAX_DEPTH, MAX_DEPTH);
+    const visited = new Set<string>([start]);
+    const parents = new Map<string, { edge: CausalEdge; depth: number; score: number }>();
+    const queue: Array<{ node: string; depth: number; score: number }> = [
+      { node: start, depth: 0, score: 1 },
+    ];
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      if (cur.depth >= maxDepth) continue;
+      const neighbors = this.graph.neighbors(cur.node, {
+        direction: 'out',
+        relation: options.relation,
+      });
+      for (const edge of neighbors) {
+        if (visited.has(edge.target)) continue;
+        visited.add(edge.target);
+        const score = cur.score * edge.weight;
+        parents.set(edge.target, { edge, depth: cur.depth + 1, score });
+        if (edge.target === target) {
+          return reconstructPath(start, target, parents);
+        }
+        queue.push({ node: edge.target, depth: cur.depth + 1, score });
+      }
+    }
+    return null;
+  }
+}
+
+function reconstructPath(
+  start: string,
+  target: string,
+  parents: Map<string, { edge: CausalEdge; depth: number; score: number }>,
+): CausalPath {
+  const terminal = parents.get(target);
+  const score = terminal?.score ?? (target === start ? 1 : 0);
+  const edges: CausalEdge[] = [];
+  const nodes: string[] = [target];
+  let cursor = target;
+  while (cursor !== start) {
+    const parent = parents.get(cursor);
+    if (!parent) break;
+    edges.unshift(parent.edge);
+    nodes.unshift(parent.edge.source);
+    cursor = parent.edge.source;
+  }
+  return { nodes, edges, score, depth: edges.length };
+}
+
+export default CausalRecall;

--- a/src/modules/memory/src/controllers/learning-system.test.ts
+++ b/src/modules/memory/src/controllers/learning-system.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import initSqlJs, { Database } from 'sql.js';
+import { LearningSystem } from './learning-system.js';
+
+let SQL: any;
+
+beforeAll(async () => {
+  SQL = await initSqlJs();
+});
+
+describe('LearningSystem', () => {
+  let db: Database;
+  let ls: LearningSystem;
+
+  beforeEach(() => {
+    db = new SQL.Database();
+    ls = new LearningSystem(db as any);
+  });
+
+  it('rejects null db', () => {
+    expect(() => new LearningSystem(null as any)).toThrow(/requires a sql\.js/i);
+  });
+
+  it('creates schema idempotently', () => {
+    const second = new LearningSystem(db as any);
+    expect(second.count()).toBe(0);
+  });
+
+  it('recordFeedback persists a row', async () => {
+    await ls.recordFeedback({
+      taskId: 'build-42',
+      success: true,
+      quality: 0.9,
+      agent: 'coder',
+    });
+    expect(ls.count()).toBe(1);
+  });
+
+  it('record(3-arg) normalizes into recordFeedback', async () => {
+    await ls.record('build-42', 0.8, 'success');
+    await ls.record('build-42', 0.2, 'failure');
+    expect(ls.count()).toBe(2);
+    const stats = ls.stats('build');
+    expect(stats).toHaveLength(1);
+    expect(stats[0].samples).toBe(2);
+    expect(stats[0].successes).toBe(1);
+    expect(stats[0].failures).toBe(1);
+    expect(stats[0].meanQuality).toBeCloseTo(0.5);
+  });
+
+  it('groups stats by (task_signature, algorithm)', async () => {
+    await ls.recordFeedback({ taskId: 'build-1', success: true, quality: 0.9, algorithm: 'coder' });
+    await ls.recordFeedback({ taskId: 'build-2', success: true, quality: 0.7, algorithm: 'coder' });
+    await ls.recordFeedback({ taskId: 'build-3', success: true, quality: 0.5, algorithm: 'reviewer' });
+    const stats = ls.stats('build');
+    const byAlgo = Object.fromEntries(stats.map((s) => [s.algorithm, s]));
+    expect(byAlgo.coder.samples).toBe(2);
+    expect(byAlgo.coder.meanQuality).toBeCloseTo(0.8);
+    expect(byAlgo.reviewer.samples).toBe(1);
+  });
+
+  it('recommendAlgorithm returns neutral default on cold start', async () => {
+    const rec = await ls.recommendAlgorithm('unknown-task');
+    expect(rec.confidence).toBe(0.5);
+    expect(rec.samples).toBe(0);
+    expect(rec.algorithm).toBeTypeOf('string');
+  });
+
+  it('recommendAlgorithm returns highest-quality algorithm for the signature', async () => {
+    await ls.recordFeedback({ taskId: 'build-1', success: true, quality: 0.95, algorithm: 'coder' });
+    await ls.recordFeedback({ taskId: 'build-2', success: true, quality: 0.95, algorithm: 'coder' });
+    await ls.recordFeedback({ taskId: 'build-3', success: false, quality: 0.3, algorithm: 'reviewer' });
+    const rec = await ls.recommendAlgorithm('build');
+    expect(rec.algorithm).toBe('coder');
+    expect(rec.confidence).toBeCloseTo(0.95);
+    expect(rec.samples).toBe(3);
+  });
+
+  it('recommendAlgorithm is deterministic within a session', async () => {
+    await ls.recordFeedback({ taskId: 'route-1', success: true, quality: 0.8, algorithm: 'A' });
+    await ls.recordFeedback({ taskId: 'route-2', success: true, quality: 0.6, algorithm: 'B' });
+    const first = await ls.recommendAlgorithm('route');
+    const second = await ls.recommendAlgorithm('route-x');
+    expect(first.algorithm).toBe(second.algorithm);
+    expect(first.confidence).toBeCloseTo(second.confidence);
+  });
+
+  it('stats(undefined) returns all groups', async () => {
+    await ls.recordFeedback({ taskId: 'a-1', success: true, quality: 0.9, algorithm: 'X' });
+    await ls.recordFeedback({ taskId: 'b-1', success: true, quality: 0.5, algorithm: 'Y' });
+    const all = ls.stats();
+    expect(all).toHaveLength(2);
+  });
+
+  it('quality is clamped to [0,1]', async () => {
+    await ls.recordFeedback({ taskId: 'x-1', success: true, quality: 5, algorithm: 'A' });
+    await ls.recordFeedback({ taskId: 'x-2', success: false, quality: -2, algorithm: 'A' });
+    const stats = ls.stats('x');
+    expect(stats[0].meanQuality).toBeCloseTo(0.5); // (1 + 0) / 2
+  });
+
+  it('decay lowers score for older entries', async () => {
+    // Two algorithms, same mean quality, different ages.
+    const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    await ls.recordFeedback({ taskId: 'p-1', success: true, quality: 0.9, algorithm: 'old', timestamp: weekAgo });
+    await ls.recordFeedback({ taskId: 'p-2', success: true, quality: 0.9, algorithm: 'new' });
+    const rec = await ls.recommendAlgorithm('p');
+    expect(rec.algorithm).toBe('new');
+  });
+});

--- a/src/modules/memory/src/controllers/learning-system.ts
+++ b/src/modules/memory/src/controllers/learning-system.ts
@@ -1,0 +1,258 @@
+/**
+ * LearningSystem — reward-tracking + algorithm recommender.
+ *
+ * Rolling-mean quality per (task-signature, algorithm) with a time-decayed
+ * recency factor — deliberately simpler than agentdb's Q-learning. The
+ * recommender has to be deterministic within a session for spell
+ * reproducibility, which rules out anything stochastic.
+ */
+
+import { clamp01 } from './_shared.js';
+import type { SqlJsDatabaseLike } from './types.js';
+
+const FEEDBACK_TABLE = 'moflo_learning_feedback';
+const ALGO_TABLE = 'moflo_learning_algorithms';
+
+const DEFAULT_DECAY_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_ALGORITHMS = ['coder', 'researcher', 'tester', 'reviewer'];
+
+export interface FeedbackInput {
+  taskId: string;
+  success: boolean;
+  quality: number;
+  agent?: string;
+  algorithm?: string;
+  duration?: number;
+  timestamp?: number;
+  taskSignature?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AlgorithmStats {
+  taskSignature: string;
+  algorithm: string;
+  samples: number;
+  meanQuality: number;
+  successes: number;
+  failures: number;
+  lastSeenAt: number;
+}
+
+export interface Recommendation {
+  algorithm: string;
+  confidence: number;
+  agents: string[];
+  samples: number;
+}
+
+export interface LearningSystemOptions {
+  decayHalfLifeMs?: number;
+  defaultAlgorithms?: string[];
+}
+
+export class LearningSystem {
+  private db: SqlJsDatabaseLike;
+  private decayHalfLifeMs: number;
+  private defaults: string[];
+
+  constructor(db: SqlJsDatabaseLike, options: LearningSystemOptions = {}) {
+    if (!db) throw new Error('LearningSystem requires a sql.js Database');
+    this.db = db;
+    this.decayHalfLifeMs = options.decayHalfLifeMs ?? DEFAULT_DECAY_HALF_LIFE_MS;
+    this.defaults = options.defaultAlgorithms ?? DEFAULT_ALGORITHMS;
+    this.ensureSchema();
+  }
+
+  async initializeDatabase(): Promise<void> {
+    this.ensureSchema();
+  }
+
+  async recordFeedback(input: FeedbackInput): Promise<void> {
+    if (!input?.taskId) return;
+    const quality = clamp01(input.quality);
+    const success = input.success === true;
+    const ts = typeof input.timestamp === 'number' ? input.timestamp : Date.now();
+    const agent = typeof input.agent === 'string' ? input.agent : '';
+    const algorithm = pickAlgorithm(input, agent);
+    const taskSignature = pickSignature(input);
+    const durationMs = typeof input.duration === 'number' ? Math.max(0, input.duration) : 0;
+    const metaJson = JSON.stringify(input.metadata ?? {});
+
+    this.db.run(
+      `INSERT INTO ${FEEDBACK_TABLE}
+         (task_id, task_signature, algorithm, agent, quality, success, duration_ms, ts, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [input.taskId, taskSignature, algorithm, agent, quality, success ? 1 : 0, durationMs, ts, metaJson],
+    );
+    this.upsertAlgorithmStats(taskSignature, algorithm, agent, quality, success, ts);
+  }
+
+  /** 3-arg fallback memory-bridge uses when `recordFeedback` is absent. */
+  async record(taskId: string, quality: number, verdict: 'success' | 'failure' | string): Promise<void> {
+    await this.recordFeedback({
+      taskId,
+      success: verdict === 'success',
+      quality,
+    });
+  }
+
+  async recommendAlgorithm(task: string): Promise<Recommendation> {
+    const taskSignature = signatureFromTaskId(task);
+    const rows = this.listAlgorithmStats(taskSignature);
+    if (rows.length === 0) {
+      const fallback = this.defaults[0] ?? 'coder';
+      const agents = this.defaults.slice(0, 2);
+      return {
+        algorithm: fallback,
+        confidence: 0.5,
+        agents: agents.length > 0 ? agents : [fallback],
+        samples: 0,
+      };
+    }
+    const now = Date.now();
+    const ranked = rows
+      .map((r) => ({
+        row: r,
+        score: decayedScore(r.meanQuality, r.lastSeenAt, now, this.decayHalfLifeMs) * sampleBoost(r.samples),
+      }))
+      .sort((a, b) => b.score - a.score);
+    const best = ranked[0].row;
+    const totalSamples = rows.reduce((acc, r) => acc + r.samples, 0);
+    return {
+      algorithm: best.algorithm,
+      confidence: clamp01(best.meanQuality),
+      agents: [best.algorithm],
+      samples: totalSamples,
+    };
+  }
+
+  stats(taskSignature?: string): AlgorithmStats[] {
+    return this.listAlgorithmStats(taskSignature ?? null);
+  }
+
+  count(): number {
+    const stmt = this.db.prepare(`SELECT COUNT(*) AS n FROM ${FEEDBACK_TABLE}`);
+    try {
+      stmt.step();
+      return Number(stmt.getAsObject().n ?? 0);
+    } finally {
+      stmt.free();
+    }
+  }
+
+  private upsertAlgorithmStats(
+    taskSignature: string,
+    algorithm: string,
+    agent: string,
+    quality: number,
+    success: boolean,
+    ts: number,
+  ): void {
+    const successDelta = success ? 1 : 0;
+    const failureDelta = success ? 0 : 1;
+    this.db.run(
+      `INSERT INTO ${ALGO_TABLE}
+         (task_signature, algorithm, samples, sum_quality, successes, failures, last_seen_at, agent)
+       VALUES (?, ?, 1, ?, ?, ?, ?, ?)
+       ON CONFLICT(task_signature, algorithm) DO UPDATE SET
+         samples = samples + 1,
+         sum_quality = sum_quality + excluded.sum_quality,
+         successes = successes + excluded.successes,
+         failures = failures + excluded.failures,
+         last_seen_at = excluded.last_seen_at,
+         agent = excluded.agent`,
+      [taskSignature, algorithm, quality, successDelta, failureDelta, ts, agent],
+    );
+  }
+
+  private listAlgorithmStats(taskSignature: string | null): AlgorithmStats[] {
+    const sql = taskSignature
+      ? `SELECT task_signature, algorithm, samples, sum_quality, successes, failures, last_seen_at
+         FROM ${ALGO_TABLE} WHERE task_signature = ? ORDER BY last_seen_at DESC`
+      : `SELECT task_signature, algorithm, samples, sum_quality, successes, failures, last_seen_at
+         FROM ${ALGO_TABLE} ORDER BY last_seen_at DESC LIMIT 500`;
+    const stmt = this.db.prepare(sql);
+    const out: AlgorithmStats[] = [];
+    try {
+      if (taskSignature && typeof stmt.bind === 'function') stmt.bind([taskSignature]);
+      while (stmt.step()) {
+        const r = stmt.getAsObject();
+        const samples = Number(r.samples ?? 0);
+        const sumQuality = Number(r.sum_quality ?? 0);
+        out.push({
+          taskSignature: String(r.task_signature),
+          algorithm: String(r.algorithm),
+          samples,
+          meanQuality: samples > 0 ? sumQuality / samples : 0,
+          successes: Number(r.successes ?? 0),
+          failures: Number(r.failures ?? 0),
+          lastSeenAt: Number(r.last_seen_at ?? 0),
+        });
+      }
+    } finally {
+      stmt.free();
+    }
+    return out;
+  }
+
+  private ensureSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS ${FEEDBACK_TABLE} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id TEXT NOT NULL,
+        task_signature TEXT NOT NULL,
+        algorithm TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        quality REAL NOT NULL,
+        success INTEGER NOT NULL,
+        duration_ms INTEGER NOT NULL,
+        ts INTEGER NOT NULL,
+        metadata TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_${FEEDBACK_TABLE}_sig ON ${FEEDBACK_TABLE}(task_signature);
+      CREATE INDEX IF NOT EXISTS idx_${FEEDBACK_TABLE}_algo ON ${FEEDBACK_TABLE}(algorithm);
+      CREATE TABLE IF NOT EXISTS ${ALGO_TABLE} (
+        task_signature TEXT NOT NULL,
+        algorithm TEXT NOT NULL,
+        samples INTEGER NOT NULL,
+        sum_quality REAL NOT NULL,
+        successes INTEGER NOT NULL,
+        failures INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL,
+        agent TEXT NOT NULL,
+        PRIMARY KEY(task_signature, algorithm)
+      );
+    `);
+  }
+}
+
+function pickAlgorithm(input: FeedbackInput, agent: string): string {
+  if (typeof input.algorithm === 'string' && input.algorithm.length > 0) return input.algorithm;
+  if (agent) return agent;
+  return 'default';
+}
+
+function pickSignature(input: FeedbackInput): string {
+  if (typeof input.taskSignature === 'string' && input.taskSignature.length > 0) return input.taskSignature;
+  return signatureFromTaskId(input.taskId);
+}
+
+function signatureFromTaskId(value: string): string {
+  // First alphanumeric token collapses variants like "build:abc123" and
+  // "build-42" into the same signature "build" so their stats aggregate.
+  const token = String(value ?? '').trim().split(/[^a-z0-9]+/i)[0];
+  return (token || 'default').toLowerCase();
+}
+
+function decayedScore(mean: number, lastSeenAt: number, now: number, halfLife: number): number {
+  const age = Math.max(0, now - lastSeenAt);
+  return mean * Math.pow(0.5, age / halfLife);
+}
+
+function sampleBoost(samples: number): number {
+  // log2(n+2) maps samples=0→1, samples=1→1.58, samples=10→3.58 — a mild
+  // boost that still lets a newer high-quality algorithm overtake an old one.
+  return Math.log2(Math.max(0, samples) + 2);
+}
+
+export default LearningSystem;

--- a/src/modules/memory/src/controllers/mutation-guard.test.ts
+++ b/src/modules/memory/src/controllers/mutation-guard.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MutationGuard } from './mutation-guard.js';
+
+describe('MutationGuard', () => {
+  let guard: MutationGuard;
+
+  beforeEach(() => {
+    guard = new MutationGuard();
+  });
+
+  it('requires an operation string', () => {
+    expect(guard.validate({} as any)).toEqual({ allowed: false, reason: 'operation is required' });
+    expect(guard.validate({ operation: '' } as any).allowed).toBe(false);
+  });
+
+  it('passes through un-watched operations', () => {
+    expect(guard.validate({ operation: 'unknown-op', params: {} })).toEqual({ allowed: true });
+  });
+
+  it('allows a first-time store', () => {
+    expect(
+      guard.validate({ operation: 'store', params: { key: 'k', value: 'hello' } }),
+    ).toEqual({ allowed: true });
+  });
+
+  it('rejects duplicate within dedupe window', () => {
+    const params = { key: 'k', value: 'same' };
+    expect(guard.validate({ operation: 'store', params, timestamp: 1000 }).allowed).toBe(true);
+    const second = guard.validate({ operation: 'store', params, timestamp: 1500 });
+    expect(second.allowed).toBe(false);
+    expect(second.reason).toMatch(/duplicate/i);
+  });
+
+  it('allows duplicate after dedupe window expires', () => {
+    const params = { key: 'k', value: 'same' };
+    expect(guard.validate({ operation: 'store', params, timestamp: 1000 }).allowed).toBe(true);
+    const later = guard.validate({ operation: 'store', params, timestamp: 10_000 });
+    expect(later.allowed).toBe(true);
+  });
+
+  it('applies rate limit per operation per second', () => {
+    const g = new MutationGuard({ maxOpsPerSecond: 3 });
+    // Vary payloads to bypass the dedupe check — we want rate limit alone.
+    const r1 = g.validate({ operation: 'store', params: { value: '1' }, timestamp: 1000 });
+    const r2 = g.validate({ operation: 'store', params: { value: '2' }, timestamp: 1100 });
+    const r3 = g.validate({ operation: 'store', params: { value: '3' }, timestamp: 1200 });
+    const r4 = g.validate({ operation: 'store', params: { value: '4' }, timestamp: 1300 });
+    expect([r1, r2, r3].every((r) => r.allowed)).toBe(true);
+    expect(r4.allowed).toBe(false);
+    expect(r4.reason).toMatch(/rate limit/i);
+  });
+
+  it('rejects values shorter than minValueLength', () => {
+    const g = new MutationGuard({ minValueLength: 5 });
+    const res = g.validate({ operation: 'store', params: { value: 'hi' } });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toMatch(/too short/i);
+  });
+
+  it('segregates state per operation', () => {
+    const g = new MutationGuard({ maxOpsPerSecond: 1 });
+    const a = g.validate({ operation: 'store', params: { value: 'x' }, timestamp: 1000 });
+    const b = g.validate({ operation: 'update', params: { value: 'x' }, timestamp: 1100 });
+    expect(a.allowed).toBe(true);
+    expect(b.allowed).toBe(true);
+  });
+
+  it('reset clears rate-limit and dedupe state', () => {
+    const g = new MutationGuard({ maxOpsPerSecond: 1 });
+    g.validate({ operation: 'store', params: { value: '1' }, timestamp: 1000 });
+    g.validate({ operation: 'store', params: { value: '2' }, timestamp: 1100 });
+    g.reset();
+    expect(g.validate({ operation: 'store', params: { value: '3' }, timestamp: 1200 }).allowed).toBe(true);
+  });
+
+  it('dedupe hash is order-insensitive for param keys', () => {
+    const first = guard.validate({
+      operation: 'store',
+      params: { a: 1, b: 2, value: 'v' },
+      timestamp: 1000,
+    });
+    const second = guard.validate({
+      operation: 'store',
+      params: { b: 2, a: 1, value: 'v' },
+      timestamp: 1500,
+    });
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(false);
+  });
+
+  it('custom watched operations override defaults', () => {
+    const g = new MutationGuard({ watchedOperations: ['write-only'] });
+    expect(g.validate({ operation: 'store', params: { value: 'x' } }).allowed).toBe(true);
+    const first = g.validate({ operation: 'write-only', params: { value: 'x' }, timestamp: 1000 });
+    const second = g.validate({ operation: 'write-only', params: { value: 'x' }, timestamp: 1500 });
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(false);
+  });
+});

--- a/src/modules/memory/src/controllers/mutation-guard.ts
+++ b/src/modules/memory/src/controllers/mutation-guard.ts
@@ -1,0 +1,144 @@
+/**
+ * MutationGuard — pre-write anomaly detector. Three deterministic
+ * checks instead of agentdb's WASM-backed ZK proofs; cryptographic
+ * provenance belongs to AttestationLog.
+ */
+
+import { createHash } from 'node:crypto';
+
+export interface ValidateInput {
+  operation: string;
+  params?: Record<string, unknown>;
+  timestamp?: number;
+}
+
+export interface ValidateResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface MutationGuardOptions {
+  dedupeWindowMs?: number;
+  maxOpsPerSecond?: number;
+  minValueLength?: number;
+  watchedOperations?: string[];
+}
+
+const DEFAULT_OPTIONS: Required<MutationGuardOptions> = {
+  dedupeWindowMs: 2_000,
+  maxOpsPerSecond: 50,
+  minValueLength: 0,
+  watchedOperations: ['store', 'update', 'delete', 'bulk-store', 'hierarchical-store'],
+};
+
+interface RecentEntry {
+  hash: string;
+  ts: number;
+}
+
+export class MutationGuard {
+  private opts: Required<MutationGuardOptions>;
+  private recent: Map<string, RecentEntry[]> = new Map();
+
+  constructor(options: MutationGuardOptions = {}) {
+    this.opts = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  validate(input: ValidateInput): ValidateResult {
+    if (!input || typeof input.operation !== 'string' || input.operation.length === 0) {
+      return { allowed: false, reason: 'operation is required' };
+    }
+    const op = input.operation;
+    const ts = typeof input.timestamp === 'number' ? input.timestamp : Date.now();
+
+    if (!this.isWatched(op)) return { allowed: true };
+
+    const value = extractValueString(input.params);
+    if (value !== null && value.length < this.opts.minValueLength) {
+      return {
+        allowed: false,
+        reason: `value too short (${value.length} < ${this.opts.minValueLength})`,
+      };
+    }
+
+    const entries = this.pruneAndFetch(op, ts);
+
+    if (entries.length >= this.opts.maxOpsPerSecond) {
+      // Rate limit and dedupe share the same recent-window buffer; we
+      // count any entry within the last second for rate, not just those
+      // in the (wider) dedupe window.
+      const rateWindowStart = ts - 1000;
+      const inLastSecond = entries.reduce((acc, e) => (e.ts >= rateWindowStart ? acc + 1 : acc), 0);
+      if (inLastSecond >= this.opts.maxOpsPerSecond) {
+        return {
+          allowed: false,
+          reason: `rate limit exceeded for ${op} (${this.opts.maxOpsPerSecond}/s)`,
+        };
+      }
+    }
+
+    const hash = hashParams(op, input.params);
+    if (entries.some((e) => e.hash === hash)) {
+      return { allowed: false, reason: 'duplicate mutation within dedupe window' };
+    }
+
+    this.record(op, entries, hash, ts);
+    return { allowed: true };
+  }
+
+  reset(): void {
+    this.recent.clear();
+  }
+
+  private isWatched(op: string): boolean {
+    return this.opts.watchedOperations.includes(op);
+  }
+
+  /**
+   * Drop entries older than the dedupe window and delete the op's key
+   * entirely if nothing recent remains — prevents operations that fire
+   * once and never again from keeping their buffer alive forever.
+   */
+  private pruneAndFetch(op: string, ts: number): RecentEntry[] {
+    const stored = this.recent.get(op);
+    if (!stored) return [];
+    const windowStart = ts - this.opts.dedupeWindowMs;
+    const pruned = stored.filter((e) => e.ts >= windowStart);
+    if (pruned.length === 0) {
+      this.recent.delete(op);
+    } else if (pruned.length !== stored.length) {
+      this.recent.set(op, pruned);
+    }
+    return pruned;
+  }
+
+  private record(op: string, entries: RecentEntry[], hash: string, ts: number): void {
+    entries.push({ hash, ts });
+    const cap = Math.max(10, this.opts.maxOpsPerSecond * 4);
+    if (entries.length > cap) entries.splice(0, entries.length - cap);
+    this.recent.set(op, entries);
+  }
+}
+
+function extractValueString(params: Record<string, unknown> | undefined): string | null {
+  if (!params) return null;
+  const v = params.value ?? params.content ?? params.data;
+  return typeof v === 'string' ? v : null;
+}
+
+function hashParams(op: string, params: Record<string, unknown> | undefined): string {
+  const canonical = JSON.stringify({ op, p: canonicalize(params ?? {}) });
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+    sorted[k] = canonicalize((value as Record<string, unknown>)[k]);
+  }
+  return sorted;
+}
+
+export default MutationGuard;


### PR DESCRIPTION
## Summary

Epic #464 Phase C5 of 7. Replaces the 4 remaining agentdb-provided controllers the consumer surface still reaches with moflo-owned sql.js-backed modules.

- `causal-graph.ts` — edges table with composite `(source,relation)` and `(target,relation)` indexes so recall walks avoid a full scan when filtering by relation
- `causal-recall.ts` — BFS with a parents-map for path reconstruction; O(V) allocations instead of array-cloning per hop. 3-hop / 1000-edge benchmark < 200ms
- `learning-system.ts` — rolling-mean quality per (task-signature, algorithm) with decayed recency. Deliberately deterministic within a session for spell reproducibility — tradeoff doc'd in the issue
- `mutation-guard.ts` — three in-process checks (length, rate, dedupe) against a single `RecentEntry` buffer; no WASM ZK proofs (that layer belongs to `AttestationLog`). Lazy key GC prevents unbounded growth from ops that fire once and never again

`controller-registry.ts` prefers the moflo impl with try/catch fallback to agentdb, mirroring the C3 pattern shipped in #472. `mutationGuard.isEnabled()` now returns `true` unconditionally since it needs no DB.

Also consolidated three local `clamp` copies into `clamp01` / `clampInt` exports on `_shared.ts`.

## Changes

- 8 new files: 4 controllers + 4 test files under `src/modules/memory/src/controllers/`
- `controller-registry.ts`: moflo-preferred branches for causalGraph / learningSystem / mutationGuard; `isEnabled` update
- `_shared.ts`: `clamp01` / `clampInt` helpers

## Testing

- [x] Unit tests pass — 45 new assertions across the 4 controllers
- [x] Integration: @moflo/memory full suite 466/466 green
- [x] E2E: repo-wide `npm test` 7671/7671 green
- [x] Benchmark: 3-hop walk on 1000-edge graph < 200ms (see `causal-recall.test.ts`)
- [x] Consumer smoke (`node harness/consumer-smoke/run.mjs`) — 14/14 green
- [x] Simplify pass: 3 reviewer agents run; consolidated clamp helpers, fixed MutationGuard redundant-state + once-op leak, tightened CausalRecall allocations

Closes #469

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)