### PR TITLE
refactor(memory): rename AgentDB* identifiers to MofloDb* (#477)

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -16,7 +16,7 @@ npm install && npm run build && npm test
 | `@moflo/cli` | `modules/cli/` | CLI entry point (40+ commands) |
 | `@moflo/guidance` | `modules/guidance/` | Governance control plane |
 | `@moflo/hooks` | `modules/hooks/` | Hooks + workers |
-| `@moflo/memory` | `modules/memory/` | AgentDB + HNSW vector search |
+| `@moflo/memory` | `modules/memory/` | sql.js + HNSW vector search (MofloDb) |
 | `@moflo/shared` | `modules/shared/` | Shared types and utilities |
 | `@moflo/security` | `modules/security/` | Input validation, CVE remediation |
 | `@moflo/embeddings` | `modules/embeddings/` | Vector embeddings (sql.js, HNSW) |

--- a/src/modules/cli/src/memory/memory-bridge.ts
+++ b/src/modules/cli/src/memory/memory-bridge.ts
@@ -1,18 +1,18 @@
 /**
- * Memory Bridge — Routes CLI memory operations through ControllerRegistry + AgentDB v3
+ * Memory Bridge — Routes CLI memory operations through ControllerRegistry + MofloDb
  *
  * Per ADR-053 Phases 1-6: Full controller activation pipeline.
- * CLI → ControllerRegistry → AgentDB v3 controllers.
+ * CLI → ControllerRegistry → moflo-owned controllers.
  *
  * Phase 1: Core CRUD + embeddings + HNSW + controller access (complete)
  * Phase 2: BM25 hybrid search, TieredCache read/write, MutationGuard validation
  * Phase 3: ReasoningBank pattern store, recordFeedback, CausalMemoryGraph edges
  * Phase 4: SkillLibrary promotion, ExplainableRecall provenance, AttestationLog
  * Phase 5: ReflexionMemory session lifecycle, WitnessChain attestation
- * Phase 6: AgentDB MCP tools (separate file), COW branching
+ * Phase 6: MofloDb MCP tools (separate file), COW branching
  *
- * Uses better-sqlite3 API (synchronous .all()/.get()/.run()) since that's
- * what AgentDB v3 uses internally.
+ * Uses sql.js synchronous API (.all()/.get()/.run()) since that's what
+ * the moflo-owned controllers use internally.
  *
  * @module v3/cli/memory-bridge
  */
@@ -132,7 +132,7 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
           const msg = String(args[0] ?? '');
           if (msg.includes('Transformers.js') ||
               
-              msg.includes('[AgentDB]') ||
+              msg.includes('[MofloDb]') ||
               msg.includes('[HNSWLibBackend]') ||
               msg.includes('MoVector graph')) return;
           origLog.apply(console, args);
@@ -322,14 +322,14 @@ async function logAttestation(
 }
 
 /**
- * Get the AgentDB database handle and ensure memory_entries table exists.
+ * Get the MofloDb database handle and ensure memory_entries table exists.
  * Returns null if not available.
  */
 function getDb(registry: any): any | null {
-  const agentdb = registry.getAgentDB();
-  if (!agentdb?.database) return null;
+  const mofloDb = registry.getMofloDb();
+  if (!mofloDb?.database) return null;
 
-  const db = agentdb.database;
+  const db = mofloDb.database;
 
   // Ensure memory_entries table exists (idempotent)
   try {
@@ -361,7 +361,7 @@ function getDb(registry: any): any | null {
     // Table already exists or db is read-only — that's fine
   }
 
-  return { db, agentdb };
+  return { db, mofloDb };
 }
 
 // ===== Bridge functions — match memory-initializer.ts signatures =====
@@ -413,7 +413,7 @@ export async function bridgeStoreEntry(options: {
 
     if (options.generateEmbeddingFlag !== false && value.length > 0) {
       try {
-        const embedder = ctx.agentdb.embedder;
+        const embedder = ctx.mofloDb.embedder;
         if (embedder) {
           const emb = await embedder.embed(value);
           if (emb) {
@@ -513,7 +513,7 @@ export async function bridgeSearchEntries(options: {
     // Generate query embedding
     let queryEmbedding: number[] | null = null;
     try {
-      const embedder = ctx.agentdb.embedder;
+      const embedder = ctx.mofloDb.embedder;
       if (embedder) {
         const emb = await embedder.embed(queryStr);
         queryEmbedding = Array.from(emb);
@@ -887,8 +887,8 @@ export async function bridgeGenerateEmbedding(
   if (!registry) return null;
 
   try {
-    const agentdb = registry.getAgentDB();
-    const embedder = agentdb?.embedder;
+    const mofloDb = registry.getMofloDb();
+    const embedder = mofloDb?.embedder;
     if (!embedder) return null;
 
     const emb = await embedder.embed(text);
@@ -905,7 +905,7 @@ export async function bridgeGenerateEmbedding(
 }
 
 /**
- * Load embedding model via AgentDB v3 (it loads on init).
+ * Load embedding model via MofloDb (it loads on init).
  * Returns null if unavailable.
  */
 export async function bridgeLoadEmbeddingModel(
@@ -921,8 +921,8 @@ export async function bridgeLoadEmbeddingModel(
   if (!registry) return null;
 
   try {
-    const agentdb = registry.getAgentDB();
-    const embedder = agentdb?.embedder;
+    const mofloDb = registry.getMofloDb();
+    const embedder = mofloDb?.embedder;
     if (!embedder) return null;
 
     // Verify embedder works by generating a test embedding

--- a/src/modules/hooks/src/reasoningbank/index.ts
+++ b/src/modules/hooks/src/reasoningbank/index.ts
@@ -1,13 +1,13 @@
 /**
- * V3 ReasoningBank - Pattern Learning with AgentDB
+ * V3 ReasoningBank - Pattern Learning with MofloDb
  *
- * Connects hooks to persistent vector storage using AgentDB adapter.
+ * Connects hooks to persistent vector storage using MofloDb adapter.
  * No JSON - all patterns stored as vectors in memory.db
  *
  * Features:
  * - Real HNSW indexing (M=16, efConstruction=200) for 150x+ faster search
  * - ONNX embeddings via @moflo/embeddings (MiniLM-L6 384-dim)
- * - AgentDB backend for persistence
+ * - MofloDb backend for persistence
  * - Pattern promotion from short-term to long-term memory
  *
  * @module @moflo/hooks/reasoningbank
@@ -17,12 +17,12 @@ import { EventEmitter } from 'node:events';
 import type { HookContext, HookEvent } from '../types.js';
 
 // Dynamic imports for optional dependencies
-let AgentDBAdapter: any = null;
+let MofloDbAdapter: any = null;
 let HNSWIndex: any = null;
 let EmbeddingServiceImpl: any = null;
 
 /**
- * Pattern stored in AgentDB
+ * Pattern stored in MofloDb
  */
 export interface GuidancePattern {
   id: string;
@@ -183,12 +183,12 @@ const DOMAIN_GUIDANCE: Record<string, string[]> = {
 /**
  * ReasoningBank - Vector-based pattern storage and retrieval
  *
- * Uses AgentDB adapter for HNSW-indexed pattern storage.
+ * Uses MofloDb adapter for HNSW-indexed pattern storage.
  * Provides guidance generation from learned patterns.
  */
 export class ReasoningBank extends EventEmitter {
   private config: ReasoningBankConfig;
-  private agentDB: any = null;
+  private mofloDb: any = null;
   private hnswIndex: any = null;
   private embeddingService: IEmbeddingService;
   private initialized = false;
@@ -219,7 +219,7 @@ export class ReasoningBank extends EventEmitter {
   }
 
   /**
-   * Initialize ReasoningBank with AgentDB backend and real HNSW
+   * Initialize ReasoningBank with MofloDb backend and real HNSW
    */
   async initialize(): Promise<void> {
     if (this.initialized) return;
@@ -242,7 +242,7 @@ export class ReasoningBank extends EventEmitter {
       // Try to load real implementations
       await this.loadDependencies();
 
-      if (AgentDBAdapter && HNSWIndex) {
+      if (MofloDbAdapter && HNSWIndex) {
         // Initialize real HNSW index
         this.hnswIndex = new HNSWIndex({
           dimensions: this.config.dimensions,
@@ -252,8 +252,8 @@ export class ReasoningBank extends EventEmitter {
           metric: 'cosine',
         });
 
-        // Initialize AgentDB adapter
-        this.agentDB = new AgentDBAdapter({
+        // Initialize MofloDb adapter
+        this.mofloDb = new MofloDbAdapter({
           dimensions: this.config.dimensions,
           hnswM: this.config.hnswM,
           hnswEfConstruction: this.config.hnswEfConstruction,
@@ -263,7 +263,7 @@ export class ReasoningBank extends EventEmitter {
           embeddingGenerator: (text: string) => this.embeddingService.embed(text),
         });
 
-        await this.agentDB.initialize();
+        await this.mofloDb.initialize();
         this.useRealBackend = true;
 
         // Try to use real embedding service
@@ -277,7 +277,7 @@ export class ReasoningBank extends EventEmitter {
         }
 
         await this.loadPatterns();
-        console.log(`[ReasoningBank] Initialized with AgentDB + HNSW (M=${this.config.hnswM}, efConstruction=${this.config.hnswEfConstruction})`);
+        console.log(`[ReasoningBank] Initialized with MofloDb + HNSW (M=${this.config.hnswM}, efConstruction=${this.config.hnswEfConstruction})`);
       } else {
         throw new Error('Dependencies not available');
       }
@@ -290,7 +290,7 @@ export class ReasoningBank extends EventEmitter {
       });
     } catch (error) {
       // Fallback to in-memory only mode
-      console.warn('[ReasoningBank] AgentDB not available, using in-memory mode');
+      console.warn('[ReasoningBank] MofloDb not available, using in-memory mode');
       this.useRealBackend = false;
       this.initialized = true;
     }
@@ -311,7 +311,7 @@ export class ReasoningBank extends EventEmitter {
 
     const memoryModule = await dynamicImport('@moflo/memory');
     if (memoryModule) {
-      AgentDBAdapter = memoryModule.AgentDBAdapter;
+      MofloDbAdapter = memoryModule.MofloDbAdapter;
       HNSWIndex = memoryModule.HNSWIndex;
     }
 
@@ -369,7 +369,7 @@ export class ReasoningBank extends EventEmitter {
       await this.hnswIndex.addPoint(pattern.id, embedding);
     }
 
-    await this.storeInAgentDB(pattern, 'short_term');
+    await this.storeInMofloDb(pattern, 'short_term');
 
     this.metrics.patternsStored++;
     this.emit('pattern:stored', { id: pattern.id, domain });
@@ -669,7 +669,7 @@ export class ReasoningBank extends EventEmitter {
   }
 
   /**
-   * Test-only: drop all in-memory patterns + reset metrics without re-initializing AgentDB.
+   * Test-only: drop all in-memory patterns + reset metrics without re-initializing MofloDb.
    * Lets test suites share one expensive initialize() across tests.
    */
   async _clearForTest(): Promise<void> {
@@ -698,15 +698,15 @@ export class ReasoningBank extends EventEmitter {
         // Leave stale index; tests tolerate this since shortTermPatterns Map is the source of truth
       }
     }
-    // Purge AgentDB-backed patterns so the next test starts clean
-    if (this.agentDB) {
+    // Purge MofloDb-backed patterns so the next test starts clean
+    if (this.mofloDb) {
       try {
         const entries = [
-          ...(await this.agentDB.query({ namespace: 'patterns:short_term', limit: this.config.maxShortTerm })),
-          ...(await this.agentDB.query({ namespace: 'patterns:long_term', limit: this.config.maxLongTerm })),
+          ...(await this.mofloDb.query({ namespace: 'patterns:short_term', limit: this.config.maxShortTerm })),
+          ...(await this.mofloDb.query({ namespace: 'patterns:long_term', limit: this.config.maxLongTerm })),
         ];
         for (const entry of entries) {
-          await this.agentDB.delete(entry.id || entry.key);
+          await this.mofloDb.delete(entry.id || entry.key);
         }
       } catch {
         // Best-effort; in-memory Maps are source of truth for test assertions
@@ -731,7 +731,7 @@ export class ReasoningBank extends EventEmitter {
         if (this.hnswIndex) {
           await this.hnswIndex.addPoint(pattern.id, pattern.embedding);
         }
-        await this.storeInAgentDB(pattern, 'short_term');
+        await this.storeInMofloDb(pattern, 'short_term');
         imported++;
       }
     }
@@ -742,7 +742,7 @@ export class ReasoningBank extends EventEmitter {
         if (this.hnswIndex) {
           await this.hnswIndex.addPoint(pattern.id, pattern.embedding);
         }
-        await this.storeInAgentDB(pattern, 'long_term');
+        await this.storeInMofloDb(pattern, 'long_term');
         imported++;
       }
     }
@@ -759,11 +759,11 @@ export class ReasoningBank extends EventEmitter {
   }
 
   private async loadPatterns(): Promise<void> {
-    if (!this.agentDB) return;
+    if (!this.mofloDb) return;
 
     try {
-      // Load from AgentDB namespaces
-      const shortTermEntries = await this.agentDB.query({
+      // Load from MofloDb namespaces
+      const shortTermEntries = await this.mofloDb.query({
         namespace: 'patterns:short_term',
         limit: this.config.maxShortTerm,
       });
@@ -776,7 +776,7 @@ export class ReasoningBank extends EventEmitter {
         }
       }
 
-      const longTermEntries = await this.agentDB.query({
+      const longTermEntries = await this.mofloDb.query({
         namespace: 'patterns:long_term',
         limit: this.config.maxLongTerm,
       });
@@ -793,11 +793,11 @@ export class ReasoningBank extends EventEmitter {
     }
   }
 
-  private async storeInAgentDB(pattern: GuidancePattern, type: 'short_term' | 'long_term'): Promise<void> {
-    if (!this.agentDB) return;
+  private async storeInMofloDb(pattern: GuidancePattern, type: 'short_term' | 'long_term'): Promise<void> {
+    if (!this.mofloDb) return;
 
     try {
-      await this.agentDB.store({
+      await this.mofloDb.store({
         key: pattern.id,
         namespace: `patterns:${type}`,
         content: pattern.strategy,
@@ -818,10 +818,10 @@ export class ReasoningBank extends EventEmitter {
   }
 
   private async updateInStorage(pattern: GuidancePattern): Promise<void> {
-    if (!this.agentDB) return;
+    if (!this.mofloDb) return;
 
     try {
-      await this.agentDB.update(pattern.id, {
+      await this.mofloDb.update(pattern.id, {
         metadata: {
           quality: pattern.quality,
           usageCount: pattern.usageCount,
@@ -835,10 +835,10 @@ export class ReasoningBank extends EventEmitter {
   }
 
   private async deleteFromStorage(id: string): Promise<void> {
-    if (!this.agentDB) return;
+    if (!this.mofloDb) return;
 
     try {
-      await this.agentDB.delete(id);
+      await this.mofloDb.delete(id);
     } catch (error) {
       console.warn('[ReasoningBank] Failed to delete pattern:', error);
     }
@@ -950,7 +950,7 @@ export class ReasoningBank extends EventEmitter {
 
     // Update storage
     await this.deleteFromStorage(pattern.id);
-    await this.storeInAgentDB(pattern, 'long_term');
+    await this.storeInMofloDb(pattern, 'long_term');
 
     this.metrics.promotions++;
     this.emit('pattern:promoted', { id: pattern.id });
@@ -1103,7 +1103,7 @@ export const reasoningBank = new ReasoningBank();
 
 /**
  * Hook handler: session-start → import auto memory, build graph.
- * Called by the session-start hook to hydrate AgentDB with previous learnings.
+ * Called by the session-start hook to hydrate MofloDb with previous learnings.
  *
  * @param bridge - An initialized AutoMemoryBridge instance
  */

--- a/src/modules/memory/src/auto-memory-bridge.ts
+++ b/src/modules/memory/src/auto-memory-bridge.ts
@@ -273,7 +273,7 @@ export class AutoMemoryBridge extends EventEmitter {
     this.insights.push(insight);
 
     // Store in AgentDB
-    const key = await this.storeInsightInAgentDB(insight);
+    const key = await this.storeInsightInMofloDb(insight);
     this.syncedInsightKeys.add(key);
 
     // If sync-on-write, write immediately to files
@@ -594,7 +594,7 @@ export class AutoMemoryBridge extends EventEmitter {
     }
   }
 
-  private async storeInsightInAgentDB(insight: MemoryInsight): Promise<string> {
+  private async storeInsightInMofloDb(insight: MemoryInsight): Promise<string> {
     const content = insight.detail
       ? `${insight.summary}\n\n${insight.detail}`
       : insight.summary;

--- a/src/modules/memory/src/controller-registry.test.ts
+++ b/src/modules/memory/src/controller-registry.test.ts
@@ -8,7 +8,7 @@
  * - Health check aggregation
  * - Shutdown ordering
  * - Cross-platform path handling (Linux/Mac/Windows)
- * - AgentDB unavailable scenarios
+ * - MofloDb unavailable scenarios
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -253,8 +253,8 @@ describe('ControllerRegistry', () => {
   // ----- Graceful Degradation -----
 
   describe('graceful degradation', () => {
-    it('should continue when AgentDB is unavailable', async () => {
-      // No AgentDB module available — should still init CLI-layer controllers
+    it('should continue when MofloDb is unavailable', async () => {
+      // No sql.js handle available — should still init CLI-layer controllers
       await registry.initialize({ backend: mockBackend });
       expect(registry.isInitialized()).toBe(true);
     });
@@ -263,7 +263,7 @@ describe('ControllerRegistry', () => {
       await registry.initialize({ backend: mockBackend });
       const report = await registry.healthCheck();
 
-      // Some controllers should be unavailable (no AgentDB)
+      // Some controllers should be unavailable (no MofloDb)
       // but the registry itself should be functional
       expect(report.status).not.toBe('unhealthy');
     });
@@ -272,14 +272,14 @@ describe('ControllerRegistry', () => {
       const handler = vi.fn();
       registry.on('controller:failed', handler);
 
-      // Enable a controller that requires AgentDB (which is unavailable)
+      // Enable a controller that requires MofloDb (which is unavailable)
       await registry.initialize({
         backend: mockBackend,
         controllers: { reasoningBank: true },
       });
 
-      // ReasoningBank requires AgentDB, so it should fail or be unavailable
-      // The exact behavior depends on whether agentdb is importable
+      // ReasoningBank requires MofloDb, so it should fail or be unavailable
+      // The exact behavior depends on whether the sql.js handle is available
     });
 
     it('should handle null backend gracefully', async () => {
@@ -365,7 +365,7 @@ describe('ControllerRegistry', () => {
     it('should not enable optional controllers by default', async () => {
       await registry.initialize({ backend: mockBackend });
 
-      // semanticRouter was moved from opt-in to auto-enable when agentdb is
+      // semanticRouter was moved from opt-in to auto-enable when mofloDb is
       // available (see controller-registry.ts). Exclude it from this list —
       // it is no longer an "optional by default" controller.
       expect(registry.isEnabled('hybridSearch')).toBe(false);
@@ -420,10 +420,10 @@ describe('ControllerRegistry', () => {
       expect(report.totalControllers).toBeGreaterThanOrEqual(report.activeControllers);
     });
 
-    it('should report agentdb availability', async () => {
+    it('should report mofloDb availability', async () => {
       await registry.initialize({ backend: mockBackend });
       const report = await registry.healthCheck();
-      expect(typeof report.agentdbAvailable).toBe('boolean');
+      expect(typeof report.mofloDbAvailable).toBe('boolean');
     });
 
     it('should classify status correctly', async () => {
@@ -509,21 +509,21 @@ describe('ControllerRegistry', () => {
     });
   });
 
-  // ----- AgentDB Integration -----
+  // ----- MofloDb Integration -----
 
-  describe('AgentDB integration', () => {
-    it('should handle missing agentdb module', async () => {
-      // With no agentdb installed, should still work
+  describe('MofloDb integration', () => {
+    it('should handle missing sql.js handle', async () => {
+      // With no sql.js handle available, should still work
       await registry.initialize({ backend: mockBackend });
       expect(registry.isInitialized()).toBe(true);
     });
 
-    it('should return null AgentDB when unavailable', async () => {
+    it('should return null MofloDb when unavailable', async () => {
       await registry.initialize({ backend: mockBackend });
       // May or may not be available depending on test environment
-      const agentdb = registry.getAgentDB();
+      const mofloDb = registry.getMofloDb();
       // Just ensure it doesn't throw
-      expect(agentdb === null || agentdb !== null).toBe(true);
+      expect(mofloDb === null || mofloDb !== null).toBe(true);
     });
   });
 
@@ -650,11 +650,11 @@ describe('ControllerRegistry', () => {
   // ----- Event Emission -----
 
   describe('events', () => {
-    it('should emit agentdb:unavailable when module missing', async () => {
+    it('should emit mofloDb:unavailable when sql.js handle missing', async () => {
       const handler = vi.fn();
-      registry.on('agentdb:unavailable', handler);
+      registry.on('mofloDb:unavailable', handler);
       await registry.initialize({ backend: mockBackend });
-      // AgentDB may or may not be available in test environment
+      // MofloDb may or may not be available in test environment
       // Just verify the listener doesn't break anything
     });
 

--- a/src/modules/memory/src/controller-registry.ts
+++ b/src/modules/memory/src/controller-registry.ts
@@ -32,7 +32,7 @@ import type { CacheConfig } from './types.js';
  * `reasoningBank` has no moflo implementation yet — it registers as
  * unavailable and consumers must null-check.
  */
-export type AgentDBControllerName =
+export type MofloDbControllerName =
   | 'reasoningBank'
   | 'skills'
   | 'reflexion'
@@ -60,7 +60,7 @@ export type CLIControllerName =
 /**
  * All controller names
  */
-export type ControllerName = AgentDBControllerName | CLIControllerName;
+export type ControllerName = MofloDbControllerName | CLIControllerName;
 
 /**
  * Initialization level for dependency ordering
@@ -86,7 +86,7 @@ export interface ControllerHealth {
 export interface RegistryHealthReport {
   status: 'healthy' | 'degraded' | 'unhealthy';
   controllers: ControllerHealth[];
-  agentdbAvailable: boolean;
+  mofloDbAvailable: boolean;
   initTimeMs: number;
   timestamp: number;
   activeControllers: number;
@@ -145,7 +145,7 @@ interface ControllerEntry {
 
 /**
  * Minimal wrapper holding the sql.js Database handle used by moflo-owned
- * controllers. Exposed via `getAgentDB()` for backwards-compatible callers.
+ * controllers. Exposed via `getMofloDb()` to consumers.
  */
 interface SqlJsHandle {
   database: SqlJsDatabase;
@@ -207,8 +207,8 @@ export const INIT_LEVELS: InitLevel[] = [
  */
 export class ControllerRegistry extends EventEmitter {
   private controllers: Map<ControllerName, ControllerEntry> = new Map();
-  /** sql.js Database handle — field name preserved for API stability. */
-  private agentdb: SqlJsHandle | null = null;
+  /** sql.js Database handle wrapped as MofloDb. */
+  private mofloDb: SqlJsHandle | null = null;
   private backend: IMemoryBackend | null = null;
   private config: RuntimeConfig = {};
   private initialized = false;
@@ -301,13 +301,13 @@ export class ControllerRegistry extends EventEmitter {
     }
 
     // Close sql.js handle
-    if (this.agentdb) {
+    if (this.mofloDb) {
       try {
-        await this.agentdb.close();
+        await this.mofloDb.close();
       } catch {
         // Best-effort cleanup
       }
-      this.agentdb = null;
+      this.mofloDb = null;
     }
 
     this.controllers.clear();
@@ -367,7 +367,7 @@ export class ControllerRegistry extends EventEmitter {
     return {
       status,
       controllers: controllerHealth,
-      agentdbAvailable: this.agentdb !== null,
+      mofloDbAvailable: this.mofloDb !== null,
       initTimeMs: this.initTimeMs,
       timestamp: Date.now(),
       activeControllers: active,
@@ -376,10 +376,10 @@ export class ControllerRegistry extends EventEmitter {
   }
 
   /**
-   * Get the underlying sql.js handle (exposed as `agentdb` for API stability).
+   * Get the underlying sql.js handle wrapped as MofloDb.
    */
-  getAgentDB(): SqlJsHandle | null {
-    return this.agentdb;
+  getMofloDb(): SqlJsHandle | null {
+    return this.mofloDb;
   }
 
   /**
@@ -421,7 +421,7 @@ export class ControllerRegistry extends EventEmitter {
   // ===== Private Methods =====
 
   /**
-   * Open a sql.js Database and expose it via `this.agentdb.database` to the
+   * Open a sql.js Database and expose it via `this.mofloDb.database` to the
    * moflo controllers that need one.
    */
   private async initSqlJs(config: RuntimeConfig): Promise<void> {
@@ -431,22 +431,22 @@ export class ControllerRegistry extends EventEmitter {
       if (dbPath !== ':memory:') {
         const resolved = path.resolve(dbPath);
         if (resolved.includes('..')) {
-          this.emit('agentdb:unavailable', { reason: 'Invalid dbPath' });
+          this.emit('mofloDb:unavailable', { reason: 'Invalid dbPath' });
           return;
         }
       }
 
       const database = await openSqlJsDatabase(dbPath, config.wasmPath);
 
-      this.agentdb = {
+      this.mofloDb = {
         database,
         close: async () => database.close(),
       };
-      this.emit('agentdb:initialized');
+      this.emit('mofloDb:initialized');
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      this.emit('agentdb:unavailable', { reason: msg.substring(0, 200) });
-      this.agentdb = null;
+      this.emit('mofloDb:unavailable', { reason: msg.substring(0, 200) });
+      this.mofloDb = null;
     }
   }
 
@@ -490,7 +490,7 @@ export class ControllerRegistry extends EventEmitter {
       case 'nightlyLearner':
       case 'memoryConsolidation':
       case 'batchOperations':
-        return this.agentdb !== null;
+        return this.mofloDb !== null;
 
       // Require explicit enabling via config.controllers.
       case 'hybridSearch':
@@ -609,10 +609,10 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'hierarchicalMemory': {
-        if (!this.agentdb?.database) return this.createTieredMemoryStub();
+        if (!this.mofloDb?.database) return this.createTieredMemoryStub();
         const { HierarchicalMemory } = await import('./controllers/hierarchical-memory.js');
         const embedder = this.config.embeddingGenerator;
-        const hm = new HierarchicalMemory(this.agentdb.database, { embedder });
+        const hm = new HierarchicalMemory(this.mofloDb.database, { embedder });
         await hm.initializeDatabase();
         return hm;
       }
@@ -635,9 +635,9 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'skills': {
-        if (!this.agentdb?.database) return null;
+        if (!this.mofloDb?.database) return null;
         const { Skills } = await import('./controllers/skills.js');
-        const skills = new Skills(this.agentdb.database, {
+        const skills = new Skills(this.mofloDb.database, {
           embedder: this.config.embeddingGenerator,
         });
         await skills.initializeDatabase();
@@ -645,9 +645,9 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'reflexion': {
-        if (!this.agentdb?.database) return null;
+        if (!this.mofloDb?.database) return null;
         const { Reflexion } = await import('./controllers/reflexion.js');
-        const reflexion = new Reflexion(this.agentdb.database, {
+        const reflexion = new Reflexion(this.mofloDb.database, {
           embedder: this.config.embeddingGenerator,
         });
         await reflexion.initializeDatabase();
@@ -655,17 +655,17 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'causalGraph': {
-        if (!this.agentdb?.database) return null;
+        if (!this.mofloDb?.database) return null;
         const { CausalGraph } = await import('./controllers/causal-graph.js');
-        const graph = new CausalGraph(this.agentdb.database);
+        const graph = new CausalGraph(this.mofloDb.database);
         await graph.initializeDatabase();
         return graph;
       }
 
       case 'learningSystem': {
-        if (!this.agentdb?.database) return null;
+        if (!this.mofloDb?.database) return null;
         const { LearningSystem } = await import('./controllers/learning-system.js');
-        const ls = new LearningSystem(this.agentdb.database);
+        const ls = new LearningSystem(this.mofloDb.database);
         await ls.initializeDatabase();
         return ls;
       }
@@ -689,9 +689,9 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'batchOperations': {
-        if (!this.agentdb?.database) return null;
+        if (!this.mofloDb?.database) return null;
         const { BatchOperations } = await import('./controllers/batch-operations.js');
-        return new BatchOperations(this.agentdb.database, this.config.embeddingGenerator);
+        return new BatchOperations(this.mofloDb.database, this.config.embeddingGenerator);
       }
 
       case 'contextSynthesizer': {
@@ -706,9 +706,9 @@ export class ControllerRegistry extends EventEmitter {
       }
 
       case 'attestationLog': {
-        if (!this.agentdb?.database) return null;
+        if (!this.mofloDb?.database) return null;
         const { AttestationLog } = await import('./controllers/attestation-log.js');
-        return new AttestationLog(this.agentdb.database);
+        return new AttestationLog(this.mofloDb.database);
       }
 
       default:

--- a/src/modules/memory/src/index.ts
+++ b/src/modules/memory/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @moflo/memory - V3 Unified Memory System
  *
- * Provides a unified memory interface backed by AgentDB with HNSW indexing
+ * Provides a unified memory interface backed by MofloDb with HNSW indexing
  * for 150x-12,500x faster vector search compared to brute-force approaches.
  *
  * @module @moflo/memory
@@ -168,7 +168,7 @@ export type {
 // ===== Controller Registry (ADR-053) =====
 export { ControllerRegistry, INIT_LEVELS } from './controller-registry.js';
 export type {
-  AgentDBControllerName,
+  MofloDbControllerName,
   CLIControllerName,
   ControllerName,
   InitLevel,
@@ -178,8 +178,8 @@ export type {
 } from './controller-registry.js';
 
 // ===== Core Components =====
-export { AgentDBAdapter } from './agentdb-adapter.js';
-export type { AgentDBAdapterConfig } from './agentdb-adapter.js';
+export { MofloDbAdapter } from './moflo-db-adapter.js';
+export type { MofloDbAdapterConfig } from './moflo-db-adapter.js';
 export { SqlJsBackend } from './sqljs-backend.js';
 export type { SqlJsBackendConfig } from './sqljs-backend.js';
 export { RvfBackend } from './rvf-backend.js';
@@ -211,13 +211,13 @@ import {
   MigrationConfig,
   MigrationResult,
 } from './types.js';
-import { AgentDBAdapter, AgentDBAdapterConfig } from './agentdb-adapter.js';
+import { MofloDbAdapter, MofloDbAdapterConfig } from './moflo-db-adapter.js';
 import { MemoryMigrator } from './migration.js';
 
 /**
  * Configuration for UnifiedMemoryService
  */
-export interface UnifiedMemoryServiceConfig extends Partial<AgentDBAdapterConfig> {
+export interface UnifiedMemoryServiceConfig extends Partial<MofloDbAdapterConfig> {
   /** Enable automatic embedding generation */
   autoEmbed?: boolean;
 
@@ -240,7 +240,7 @@ export interface UnifiedMemoryServiceConfig extends Partial<AgentDBAdapterConfig
  * - Performance monitoring
  */
 export class UnifiedMemoryService extends EventEmitter implements IMemoryBackend {
-  private adapter: AgentDBAdapter;
+  private adapter: MofloDbAdapter;
   private config: UnifiedMemoryServiceConfig;
   private initialized: boolean = false;
 
@@ -253,7 +253,7 @@ export class UnifiedMemoryService extends EventEmitter implements IMemoryBackend
       ...config,
     };
 
-    this.adapter = new AgentDBAdapter({
+    this.adapter = new MofloDbAdapter({
       dimensions: this.config.dimensions,
       cacheEnabled: this.config.cacheEnabled,
       cacheSize: this.config.cacheSize,
@@ -496,7 +496,7 @@ export class UnifiedMemoryService extends EventEmitter implements IMemoryBackend
   /**
    * Get the underlying adapter for advanced operations
    */
-  getAdapter(): AgentDBAdapter {
+  getAdapter(): MofloDbAdapter {
     return this.adapter;
   }
 
@@ -547,7 +547,7 @@ export function createEmbeddingService(
 }
 
 /**
- * Create a hybrid memory service (SQLite + AgentDB)
+ * Create a hybrid memory service (SQLite + MofloDb)
  * This is the DEFAULT recommended configuration per ADR-009
  *
  * @example
@@ -558,7 +558,7 @@ export function createEmbeddingService(
  * // Structured queries go to SQLite
  * const user = await memory.getByKey('users', 'john@example.com');
  *
- * // Semantic queries go to AgentDB
+ * // Semantic queries go to MofloDb
  * const similar = await memory.semanticSearch('authentication patterns', 10);
  * ```
  */

--- a/src/modules/memory/src/infrastructure/index.ts
+++ b/src/modules/memory/src/infrastructure/index.ts
@@ -14,8 +14,8 @@ export {
 } from './repositories/hybrid-memory-repository.js';
 
 // Re-export existing adapters
-export { AgentDBAdapter } from '../agentdb-adapter.js';
-export type { AgentDBAdapterConfig } from '../agentdb-adapter.js';
+export { MofloDbAdapter } from '../moflo-db-adapter.js';
+export type { MofloDbAdapterConfig } from '../moflo-db-adapter.js';
 export { HNSWIndex } from '../hnsw-index.js';
 export type { HNSWConfig } from '../types.js';
 export { CacheManager } from '../cache-manager.js';

--- a/src/modules/memory/src/migration.ts
+++ b/src/modules/memory/src/migration.ts
@@ -22,7 +22,7 @@ import {
   EmbeddingGenerator,
   createDefaultEntry,
 } from './types.js';
-import { AgentDBAdapter } from './agentdb-adapter.js';
+import { MofloDbAdapter } from './moflo-db-adapter.js';
 
 /**
  * Default migration configuration
@@ -64,12 +64,12 @@ interface LegacyEntry {
  */
 export class MemoryMigrator extends EventEmitter {
   private config: MigrationConfig;
-  private target: AgentDBAdapter;
+  private target: MofloDbAdapter;
   private embeddingGenerator?: EmbeddingGenerator;
   private progress: MigrationProgress;
 
   constructor(
-    target: AgentDBAdapter,
+    target: MofloDbAdapter,
     config: Partial<MigrationConfig>,
     embeddingGenerator?: EmbeddingGenerator
   ) {
@@ -627,7 +627,7 @@ export class MemoryMigrator extends EventEmitter {
  * Convenience function to create a migrator
  */
 export function createMigrator(
-  target: AgentDBAdapter,
+  target: MofloDbAdapter,
   source: MigrationSource,
   sourcePath: string,
   options: Partial<MigrationConfig> = {},
@@ -644,7 +644,7 @@ export function createMigrator(
  * Migrate from multiple sources
  */
 export async function migrateMultipleSources(
-  target: AgentDBAdapter,
+  target: MofloDbAdapter,
   sources: Array<{ source: MigrationSource; path: string }>,
   options: Partial<MigrationConfig> = {},
   embeddingGenerator?: EmbeddingGenerator

--- a/src/modules/memory/src/moflo-db-adapter.ts
+++ b/src/modules/memory/src/moflo-db-adapter.ts
@@ -1,10 +1,11 @@
 /**
- * V3 AgentDB Adapter
+ * MofloDb Adapter
  *
- * Unified memory backend implementation using AgentDB with HNSW indexing
- * for 150x-12,500x faster vector search. Implements IMemoryBackend interface.
+ * Moflo-owned in-memory backend with HNSW indexing for 150x-12,500x faster
+ * vector search. Implements IMemoryBackend interface. Backed by Map + HNSW
+ * with optional sql.js persistence; has no external agentdb dependency.
  *
- * @module v3/memory/agentdb-adapter
+ * @module v3/memory/moflo-db-adapter
  */
 
 import { EventEmitter } from 'node:events';
@@ -30,9 +31,9 @@ import { HNSWIndex } from './hnsw-index.js';
 import { CacheManager } from './cache-manager.js';
 
 /**
- * Configuration for AgentDB Adapter
+ * Configuration for MofloDb Adapter
  */
-export interface AgentDBAdapterConfig {
+export interface MofloDbAdapterConfig {
   /** Vector dimensions for embeddings (default: 1536 for OpenAI) */
   dimensions: number;
 
@@ -70,7 +71,7 @@ export interface AgentDBAdapterConfig {
 /**
  * Default configuration values
  */
-const DEFAULT_CONFIG: AgentDBAdapterConfig = {
+const DEFAULT_CONFIG: MofloDbAdapterConfig = {
   dimensions: 1536,
   maxEntries: 1000000,
   cacheEnabled: true,
@@ -83,7 +84,7 @@ const DEFAULT_CONFIG: AgentDBAdapterConfig = {
 };
 
 /**
- * AgentDB Memory Backend Adapter
+ * MofloDb Memory Backend Adapter
  *
  * Provides unified memory storage with:
  * - HNSW-based vector search (150x-12,500x faster than brute force)
@@ -92,8 +93,8 @@ const DEFAULT_CONFIG: AgentDBAdapterConfig = {
  * - Full-text and metadata filtering
  * - Event-driven architecture
  */
-export class AgentDBAdapter extends EventEmitter implements IMemoryBackend {
-  private config: AgentDBAdapterConfig;
+export class MofloDbAdapter extends EventEmitter implements IMemoryBackend {
+  private config: MofloDbAdapterConfig;
   private entries: Map<string, MemoryEntry> = new Map();
   private index: HNSWIndex;
   private cache: CacheManager<MemoryEntry>;
@@ -112,7 +113,7 @@ export class AgentDBAdapter extends EventEmitter implements IMemoryBackend {
     totalWriteTime: 0,
   };
 
-  constructor(config: Partial<AgentDBAdapterConfig> = {}) {
+  constructor(config: Partial<MofloDbAdapterConfig> = {}) {
     super();
     this.config = { ...DEFAULT_CONFIG, ...config };
 
@@ -1034,4 +1035,4 @@ export class AgentDBAdapter extends EventEmitter implements IMemoryBackend {
   }
 }
 
-export default AgentDBAdapter;
+export default MofloDbAdapter;

--- a/src/modules/neural/src/reasoning-bank.ts
+++ b/src/modules/neural/src/reasoning-bank.ts
@@ -1,14 +1,14 @@
 /**
- * ReasoningBank Integration with AgentDB
+ * ReasoningBank Integration with MofloDb
  *
  * Implements the 4-step learning pipeline with real vector storage:
- * 1. RETRIEVE - Top-k memory injection with MMR diversity (using AgentDB HNSW)
+ * 1. RETRIEVE - Top-k memory injection with MMR diversity (using MofloDb HNSW)
  * 2. JUDGE - LLM-as-judge trajectory evaluation
  * 3. DISTILL - Extract strategy memories from trajectories
  * 4. CONSOLIDATE - Dedup, detect contradictions, prune old patterns
  *
  * Performance Targets:
- * - Retrieval: <10ms with AgentDB HNSW (150x faster than brute-force)
+ * - Retrieval: <10ms with MofloDb HNSW (150x faster than brute-force)
  * - Learning step: <10ms
  * - Consolidation: <100ms
  *
@@ -30,27 +30,27 @@ import type {
 // Persistence via @moflo/memory (shared with hooks/ReasoningBank)
 // ============================================================================
 
-let AgentDBAdapter: any;
+let MofloDbAdapter: any;
 let createDefaultEntry: ((input: any) => any) | undefined;
-let agentdbImportPromise: Promise<void> | undefined;
+let mofloDbImportPromise: Promise<void> | undefined;
 
-async function ensureAgentDBAdapterImport(): Promise<void> {
-  if (!agentdbImportPromise) {
-    agentdbImportPromise = (async () => {
+async function ensureMofloDbAdapterImport(): Promise<void> {
+  if (!mofloDbImportPromise) {
+    mofloDbImportPromise = (async () => {
       try {
         // Variable specifier so tsc/bundlers skip static resolution;
         // @moflo/memory is an optional runtime peer installed by the consumer.
         const moduleName = '@moflo/memory';
         const memoryModule: any = await import(/* webpackIgnore: true */ moduleName);
-        AgentDBAdapter = memoryModule.AgentDBAdapter;
+        MofloDbAdapter = memoryModule.MofloDbAdapter;
         createDefaultEntry = memoryModule.createDefaultEntry;
       } catch {
-        AgentDBAdapter = undefined;
+        MofloDbAdapter = undefined;
         createDefaultEntry = undefined;
       }
     })();
   }
-  return agentdbImportPromise;
+  return mofloDbImportPromise;
 }
 
 // ============================================================================
@@ -88,11 +88,11 @@ export interface ReasoningBankConfig {
   /** Vector dimension for embeddings */
   vectorDimension: number;
 
-  /** Namespace for AgentDB storage */
+  /** Namespace for MofloDb storage */
   namespace: string;
 
-  /** Enable AgentDB vector storage */
-  enableAgentDB: boolean;
+  /** Enable MofloDb vector storage */
+  enableMofloDb: boolean;
 }
 
 /**
@@ -109,7 +109,7 @@ const DEFAULT_CONFIG: ReasoningBankConfig = {
   dbPath: undefined,
   vectorDimension: 768,
   namespace: 'reasoning-bank',
-  enableAgentDB: true,
+  enableMofloDb: true,
 };
 
 // ============================================================================
@@ -161,7 +161,7 @@ interface StepAnalysis {
 // ============================================================================
 
 /**
- * ReasoningBank - Trajectory storage and learning pipeline with AgentDB
+ * ReasoningBank - Trajectory storage and learning pipeline with MofloDb
  *
  * This class implements a complete learning pipeline for AI agents:
  * - Store and retrieve trajectories using vector similarity
@@ -177,7 +177,7 @@ export class ReasoningBank {
   private eventListeners: Set<NeuralEventListener> = new Set();
 
   // @moflo/memory adapter for vector storage (shared with hooks/ReasoningBank)
-  private agentdb: any = null;
+  private mofloDb: any = null;
   private initialized: boolean = false;
 
   // Performance tracking
@@ -199,27 +199,27 @@ export class ReasoningBank {
   // ==========================================================================
 
   /**
-   * Initialize ReasoningBank with the @moflo/memory AgentDBAdapter.
+   * Initialize ReasoningBank with the @moflo/memory MofloDbAdapter.
    */
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
-    if (this.config.enableAgentDB) {
-      await ensureAgentDBAdapterImport();
-      if (AgentDBAdapter !== undefined) {
+    if (this.config.enableMofloDb) {
+      await ensureMofloDbAdapterImport();
+      if (MofloDbAdapter !== undefined) {
         try {
-          this.agentdb = new AgentDBAdapter({
+          this.mofloDb = new MofloDbAdapter({
             dimensions: this.config.vectorDimension,
             defaultNamespace: this.config.namespace,
             persistenceEnabled: Boolean(this.config.dbPath),
             persistencePath: this.config.dbPath,
           });
 
-          await this.agentdb.initialize();
+          await this.mofloDb.initialize();
           this.emitEvent({ type: 'memory_consolidated', memoriesCount: 0 });
         } catch (error) {
-          console.warn('AgentDBAdapter initialization failed, using fallback:', error);
-          this.agentdb = null;
+          console.warn('MofloDbAdapter initialization failed, using fallback:', error);
+          this.mofloDb = null;
         }
       }
     }
@@ -231,8 +231,8 @@ export class ReasoningBank {
    * Shutdown and cleanup resources
    */
   async shutdown(): Promise<void> {
-    if (this.agentdb) {
-      await this.agentdb.shutdown();
+    if (this.mofloDb) {
+      await this.mofloDb.shutdown();
     }
     this.initialized = false;
   }
@@ -244,7 +244,7 @@ export class ReasoningBank {
   /**
    * Retrieve relevant memories using Maximal Marginal Relevance (MMR)
    *
-   * Uses AgentDB HNSW index for 150x faster retrieval when available.
+   * Uses MofloDb HNSW index for 150x faster retrieval when available.
    *
    * @param queryEmbedding - Query vector for similarity search
    * @param k - Number of results to return (default: config.retrievalK)
@@ -260,10 +260,10 @@ export class ReasoningBank {
 
     let candidates: Array<{ entry: MemoryEntry; relevance: number }> = [];
 
-    // Try AgentDB HNSW search first
-    if (this.agentdb) {
+    // Try MofloDb HNSW search first
+    if (this.mofloDb) {
       try {
-        const results = await this.searchWithAgentDB(queryEmbedding, retrieveK * 3);
+        const results = await this.searchWithMofloDb(queryEmbedding, retrieveK * 3);
         candidates = results
           .map(r => {
             const entry = this.memories.get(r.id);
@@ -271,7 +271,7 @@ export class ReasoningBank {
           })
           .filter((c): c is { entry: MemoryEntry; relevance: number } => c !== null);
       } catch (error) {
-        console.warn('AgentDB search failed, falling back to brute-force:', error);
+        console.warn('MofloDb search failed, falling back to brute-force:', error);
       }
     }
 
@@ -485,9 +485,9 @@ export class ReasoningBank {
     };
     this.memories.set(memory.memoryId, entry);
 
-    // Store in AgentDB for vector search
-    if (this.agentdb) {
-      await this.storeInAgentDB(memory);
+    // Store in MofloDb for vector search
+    if (this.mofloDb) {
+      await this.storeInMofloDb(memory);
     }
 
     // Also store trajectory reference
@@ -733,7 +733,7 @@ export class ReasoningBank {
         .filter(e => e.consolidated).length,
       successfulTrajectories: this.getSuccessfulTrajectories().length,
       failedTrajectories: this.getFailedTrajectories().length,
-      agentdbEnabled: this.agentdb ? 1 : 0,
+      mofloDbEnabled: this.mofloDb ? 1 : 0,
       retrievalCount: this.retrievalCount,
       distillationCount: this.distillationCount,
       judgeCount: this.judgeCount,
@@ -825,14 +825,14 @@ export class ReasoningBank {
   }
 
   // ==========================================================================
-  // AgentDB Integration Helpers
+  // MofloDb Integration Helpers
   // ==========================================================================
 
   /**
    * Store memory in the @moflo/memory adapter for vector search.
    */
-  private async storeInAgentDB(memory: DistilledMemory): Promise<void> {
-    if (!this.agentdb || !createDefaultEntry) return;
+  private async storeInMofloDb(memory: DistilledMemory): Promise<void> {
+    if (!this.mofloDb || !createDefaultEntry) return;
 
     try {
       const entry = createDefaultEntry({
@@ -851,26 +851,26 @@ export class ReasoningBank {
       });
       entry.id = memory.memoryId;
       entry.embedding = memory.embedding;
-      await this.agentdb.store(entry);
+      await this.mofloDb.store(entry);
     } catch (error) {
-      console.warn('Failed to store in AgentDB adapter:', error);
+      console.warn('Failed to store in MofloDb adapter:', error);
     }
   }
 
   /**
    * Search via the @moflo/memory adapter's HNSW index.
    */
-  private async searchWithAgentDB(
+  private async searchWithMofloDb(
     queryEmbedding: Float32Array,
     k: number
   ): Promise<Array<{ id: string; similarity: number }>> {
-    if (!this.agentdb) return [];
+    if (!this.mofloDb) return [];
 
     try {
-      const results = await this.agentdb.search(queryEmbedding, { k });
+      const results = await this.mofloDb.search(queryEmbedding, { k });
       return results.map((r: any) => ({ id: r.entry.id, similarity: r.score }));
     } catch (error) {
-      console.warn('AgentDB search failed:', error);
+      console.warn('MofloDb search failed:', error);
       return [];
     }
   }
@@ -878,13 +878,13 @@ export class ReasoningBank {
   /**
    * Delete from the @moflo/memory adapter.
    */
-  private async deleteFromAgentDB(memoryId: string): Promise<void> {
-    if (!this.agentdb) return;
+  private async deleteFromMofloDb(memoryId: string): Promise<void> {
+    if (!this.mofloDb) return;
 
     try {
-      await this.agentdb.delete(memoryId);
+      await this.mofloDb.delete(memoryId);
     } catch (error) {
-      console.warn('AgentDB delete failed:', error);
+      console.warn('MofloDb delete failed:', error);
     }
   }
 
@@ -1095,10 +1095,10 @@ export class ReasoningBank {
           // Keep the higher quality one
           if (entries[i][1].memory.quality >= entries[j][1].memory.quality) {
             this.memories.delete(entries[j][0]);
-            await this.deleteFromAgentDB(entries[j][0]);
+            await this.deleteFromMofloDb(entries[j][0]);
           } else {
             this.memories.delete(entries[i][0]);
-            await this.deleteFromAgentDB(entries[i][0]);
+            await this.deleteFromMofloDb(entries[i][0]);
           }
           removed++;
         }
@@ -1239,10 +1239,10 @@ export class ReasoningBank {
   }
 
   /**
-   * Check if AgentDB is available and initialized
+   * Check if MofloDb is available and initialized
    */
-  isAgentDBAvailable(): boolean {
-    return this.agentdb !== null;
+  isMofloDbAvailable(): boolean {
+    return this.mofloDb !== null;
   }
 }
 


### PR DESCRIPTION
## Summary

- Renames every `AgentDB*` / `agentdb` / `getAgentDB` identifier in `@moflo/memory`, `@moflo/neural`, `@moflo/hooks`, and `@moflo/cli` to the `MofloDb*` / `mofloDb` / `getMofloDb` naming chosen in #477.
- Pure identifier rename — no public API shape change beyond the names themselves. No behavior change.
- File `src/modules/memory/src/agentdb-adapter.ts` renamed to `moflo-db-adapter.ts`.

Closes #477. Part of epic #476 (follow-up to #464).

## Changes

- Class `AgentDBAdapter` → `MofloDbAdapter` (+ `Config` interface)
- Type `AgentDBControllerName` → `MofloDbControllerName`
- Method `ControllerRegistry.getAgentDB()` → `getMofloDb()`
- Field `RegistryHealthReport.agentdbAvailable` → `mofloDbAvailable`
- Private fields `this.agentdb` / `this.agentDB` → `this.mofloDb` (registry, neural ReasoningBank, hooks ReasoningBank)
- Config key `ReasoningBankConfig.enableAgentDB` → `enableMofloDb` — **breaking**, no shim per CLAUDE.md policy. Only caller in moflo source was the default config.
- Events `agentdb:initialized` / `agentdb:unavailable` → `mofloDb:*`
- Dynamic import helpers `ensureAgentDBAdapterImport` / `agentdbImportPromise` → `ensureMofloDbAdapterImport` / `mofloDbImportPromise`
- Private helpers `storeInAgentDB` / `searchWithAgentDB` / `deleteFromAgentDB` / `storeInsightInAgentDB` → `storeInMofloDb` / `searchWithMofloDb` / `deleteFromMofloDb` / `storeInsightInMofloDb`
- Stats field `agentdbEnabled` → `mofloDbEnabled`
- `isAgentDBAvailable()` → `isMofloDbAvailable()`
- `src/CLAUDE.md`: `@moflo/memory` row `"AgentDB + HNSW vector search"` → `"sql.js + HNSW vector search (MofloDb)"`

## Out of scope (intentionally deferred)

- On-disk directory paths (`.agentdb/`, `.swarm/agentdb/`, `.claude-flow/agentdb/`) — touching user data, needs migration
- MCP tool IDs `mcp__moflo__agentdb_*` — user-visible tool IDs, breaks consumer configs
- `moflo.yaml` config key `show_agentdb` — user config, breaks on rename
- Persistent metadata values like `source: 'agentdb'` — on-disk data
- Shipped guidance docs in `.claude/guidance/shipped/` — separate docs pass
- `statusline-generator.ts` internal `getAgentDBStats()` — reads on-disk agentdb/ directory paths; couples to the above

## Testing

- [x] `@moflo/memory`: tsc clean, 445/445 tests green
- [x] `@moflo/neural`: 108/108 tests green
- [x] `@moflo/hooks`: 156/156 tests green
- [x] Full repo: 7643/0 green
- [x] `grep` confirms no non-comment `AgentDB*` / `agentdb` / `agentDB` identifier references remain in the four scoped paths

Closes #477