### PR TITLE
refactor(memory): delete dead reasoningBank registry slot (#478)

### DIFF
--- a/src/modules/cli/src/mcp-tools/hooks-tools.ts
+++ b/src/modules/cli/src/mcp-tools/hooks-tools.ts
@@ -2570,18 +2570,18 @@ export const hooksPatternStore: MCPTool = {
     const timestamp = new Date().toISOString();
     const patternId = `pattern-${Date.now()}-${Math.random().toString(36).substring(7)}`;
 
-    // Phase 3: Try ReasoningBank via bridge first
-    let reasoningResult: { success: boolean; patternId: string; controller: string } | null = null;
+    // Try pattern bridge first (HNSW-indexed raw SQL)
+    let bridgeResult: { success: boolean; patternId: string; controller: string } | null = null;
     try {
       const bridge = await import('../memory/memory-bridge.js');
-      reasoningResult = await bridge.bridgeStorePattern({ pattern, type, confidence, metadata: metadata as Record<string, unknown> | undefined });
+      bridgeResult = await bridge.bridgeStorePattern({ pattern, type, confidence, metadata: metadata as Record<string, unknown> | undefined });
     } catch {
       // Bridge not available
     }
 
     // Fallback: persist using memory-initializer store
     let storeResult: { success: boolean; id?: string; embedding?: { dimensions: number; model: string }; error?: string } = { success: false };
-    if (!reasoningResult) {
+    if (!bridgeResult) {
       const storeFn = await getRealStoreFunction();
       if (storeFn) {
         try {
@@ -2598,23 +2598,21 @@ export const hooksPatternStore: MCPTool = {
       }
     }
 
-    const success = reasoningResult?.success || storeResult.success;
-    const controller = reasoningResult?.controller || (storeResult.success ? 'bridge-store' : 'none');
+    const success = bridgeResult?.success || storeResult.success;
+    const controller = bridgeResult?.controller || (storeResult.success ? 'bridge-store' : 'none');
 
     return {
-      patternId: reasoningResult?.patternId || storeResult.id || patternId,
+      patternId: bridgeResult?.patternId || storeResult.id || patternId,
       pattern,
       type,
       confidence,
       indexed: success,
-      hnswIndexed: success && (!!storeResult.embedding || controller === 'reasoningBank'),
+      hnswIndexed: success && !!storeResult.embedding,
       embedding: storeResult.embedding,
       timestamp,
       controller,
-      implementation: controller === 'reasoningBank' ? 'reasoning-bank-controller' : (storeResult.success ? 'real-hnsw-indexed' : 'memory-only'),
-      note: controller === 'reasoningBank'
-        ? 'Pattern stored via ReasoningBank controller with HNSW indexing'
-        : (storeResult.success ? 'Pattern stored with vector embedding for semantic search' : (storeResult.error || 'Store function unavailable')),
+      implementation: storeResult.success ? 'real-hnsw-indexed' : 'memory-only',
+      note: storeResult.success ? 'Pattern stored with vector embedding for semantic search' : (storeResult.error || 'Store function unavailable'),
     };
   },
 };
@@ -2638,14 +2636,14 @@ export const hooksPatternSearch: MCPTool = {
     const minConfidence = (params.minConfidence as number) || 0.3;
     const namespace = (params.namespace as string) || 'patterns';
 
-    // Phase 3: Try ReasoningBank search via bridge first
+    // Try pattern bridge first (BM25 + cosine fusion)
     try {
       const bridge = await import('../memory/memory-bridge.js');
-      const rbResult = await bridge.bridgeSearchPatterns({ query, topK, minConfidence });
-      if (rbResult && rbResult.results.length > 0) {
+      const bridgeResult = await bridge.bridgeSearchPatterns({ query, topK, minConfidence });
+      if (bridgeResult && bridgeResult.results.length > 0) {
         return {
           query,
-          results: rbResult.results.map(r => ({
+          results: bridgeResult.results.map(r => ({
             patternId: r.id,
             pattern: r.content,
             similarity: r.score,
@@ -2653,8 +2651,8 @@ export const hooksPatternSearch: MCPTool = {
             namespace,
           })),
           searchTimeMs: 0,
-          backend: rbResult.controller,
-          note: `Results from ${rbResult.controller} controller`,
+          backend: bridgeResult.controller,
+          note: `Results from ${bridgeResult.controller} controller`,
         };
       }
     } catch {

--- a/src/modules/cli/src/memory/memory-bridge.ts
+++ b/src/modules/cli/src/memory/memory-bridge.ts
@@ -143,7 +143,6 @@ async function getRegistry(dbPath?: string): Promise<any | null> {
             dbPath: dbPath || getDbPath(),
             dimension: 384,
             controllers: {
-              reasoningBank: true,
               learningBridge: false,
               tieredCache: true,
               hierarchicalMemory: true,
@@ -1180,11 +1179,10 @@ export async function shutdownBridge(): Promise<void> {
   }
 }
 
-// ===== Phase 3: ReasoningBank pattern operations =====
+// ===== Pattern operations (raw-SQL bridge) =====
 
 /**
- * Store a pattern via ReasoningBank controller.
- * Falls back to raw SQL if ReasoningBank unavailable.
+ * Store a pattern via raw-SQL bridge with embedding + tags.
  */
 export async function bridgeStorePattern(options: {
   pattern: string;
@@ -1193,26 +1191,9 @@ export async function bridgeStorePattern(options: {
   metadata?: Record<string, unknown>;
   dbPath?: string;
 }): Promise<{ success: boolean; patternId: string; controller: string } | null> {
-  const registry = await getRegistry(options.dbPath);
-  if (!registry) return null;
-
   try {
-    const reasoningBank = registry.get('reasoningBank');
     const patternId = generateId('pattern');
 
-    if (reasoningBank && typeof reasoningBank.store === 'function') {
-      await reasoningBank.store({
-        id: patternId,
-        content: options.pattern,
-        type: options.type,
-        confidence: options.confidence,
-        metadata: options.metadata,
-        timestamp: Date.now(),
-      });
-      return { success: true, patternId, controller: 'reasoningBank' };
-    }
-
-    // Fallback: store via bridge SQL
     const result = await bridgeStoreEntry({
       key: patternId,
       value: JSON.stringify({ pattern: options.pattern, type: options.type, confidence: options.confidence, metadata: options.metadata }),
@@ -1222,14 +1203,14 @@ export async function bridgeStorePattern(options: {
       dbPath: options.dbPath,
     });
 
-    return result ? { success: true, patternId: result.id, controller: 'bridge-fallback' } : null;
+    return result ? { success: true, patternId: result.id, controller: 'bridge' } : null;
   } catch {
     return null;
   }
 }
 
 /**
- * Search patterns via ReasoningBank controller.
+ * Search patterns via raw-SQL bridge with BM25 + cosine fusion.
  */
 export async function bridgeSearchPatterns(options: {
   query: string;
@@ -1237,28 +1218,7 @@ export async function bridgeSearchPatterns(options: {
   minConfidence?: number;
   dbPath?: string;
 }): Promise<{ results: Array<{ id: string; content: string; score: number }>; controller: string } | null> {
-  const registry = await getRegistry(options.dbPath);
-  if (!registry) return null;
-
   try {
-    const reasoningBank = registry.get('reasoningBank');
-
-    if (reasoningBank && typeof reasoningBank.search === 'function') {
-      const results = await reasoningBank.search(options.query, {
-        topK: options.topK || 5,
-        minScore: options.minConfidence || 0.3,
-      });
-      return {
-        results: Array.isArray(results) ? results.map((r: any) => ({
-          id: r.id || r.patternId || '',
-          content: r.content || r.pattern || '',
-          score: r.score ?? r.confidence ?? 0,
-        })) : [],
-        controller: 'reasoningBank',
-      };
-    }
-
-    // Fallback: search via bridge
     const result = await bridgeSearchEntries({
       query: options.query,
       namespace: 'pattern',
@@ -1269,17 +1229,17 @@ export async function bridgeSearchPatterns(options: {
 
     return result ? {
       results: result.results.map(r => ({ id: r.id, content: r.content, score: r.score })),
-      controller: 'bridge-fallback',
+      controller: 'bridge',
     } : null;
   } catch {
     return null;
   }
 }
 
-// ===== Phase 3: Feedback recording =====
+// ===== Feedback recording =====
 
 /**
- * Record task feedback for learning via ReasoningBank or LearningSystem.
+ * Record task feedback for learning via LearningSystem + SkillLibrary + bridge store.
  * Wired into hooks_post-task handler.
  */
 export async function bridgeRecordFeedback(options: {
@@ -1312,25 +1272,6 @@ export async function bridgeRecordFeedback(options: {
         } else if (typeof learningSystem.record === 'function') {
           await learningSystem.record(options.taskId, options.quality, options.success ? 'success' : 'failure');
           controller = 'learningSystem';
-          updated++;
-        }
-      } catch { /* API mismatch — skip */ }
-    }
-
-    // Also record in ReasoningBank for pattern reinforcement
-    const reasoningBank = registry.get('reasoningBank');
-    if (reasoningBank) {
-      try {
-        if (typeof reasoningBank.recordOutcome === 'function') {
-          await reasoningBank.recordOutcome({
-            taskId: options.taskId, verdict: options.success ? 'success' : 'failure',
-            score: options.quality, timestamp: Date.now(),
-          });
-          controller = controller === 'none' ? 'reasoningBank' : `${controller}+reasoningBank`;
-          updated++;
-        } else if (typeof reasoningBank.record === 'function') {
-          await reasoningBank.record(options.taskId, options.quality);
-          controller = controller === 'none' ? 'reasoningBank' : `${controller}+reasoningBank`;
           updated++;
         }
       } catch { /* API mismatch — skip */ }

--- a/src/modules/memory/src/controller-registry.test.ts
+++ b/src/modules/memory/src/controller-registry.test.ts
@@ -211,7 +211,7 @@ describe('ControllerRegistry', () => {
 
     it('should include core controllers in level 1', () => {
       const level1 = INIT_LEVELS.find((l) => l.level === 1);
-      expect(level1?.controllers).toContain('reasoningBank');
+      expect(level1?.controllers).toContain('hierarchicalMemory');
       expect(level1?.controllers).toContain('learningBridge');
       expect(level1?.controllers).toContain('tieredCache');
     });
@@ -275,10 +275,10 @@ describe('ControllerRegistry', () => {
       // Enable a controller that requires MofloDb (which is unavailable)
       await registry.initialize({
         backend: mockBackend,
-        controllers: { reasoningBank: true },
+        controllers: { skills: true },
       });
 
-      // ReasoningBank requires MofloDb, so it should fail or be unavailable
+      // Skills requires MofloDb, so it should fail or be unavailable
       // The exact behavior depends on whether the sql.js handle is available
     });
 
@@ -700,7 +700,7 @@ describe('ControllerRegistry', () => {
       for (let i = 0; i < 1000; i++) {
         registry.get('learningBridge');
         registry.get('tieredCache');
-        registry.isEnabled('reasoningBank');
+        registry.isEnabled('skills');
       }
       const duration = performance.now() - start;
 

--- a/src/modules/memory/src/controller-registry.ts
+++ b/src/modules/memory/src/controller-registry.ts
@@ -29,11 +29,8 @@ import type { CacheConfig } from './types.js';
 
 /**
  * Controllers that require the shared sql.js Database handle.
- * `reasoningBank` has no moflo implementation yet — it registers as
- * unavailable and consumers must null-check.
  */
 export type MofloDbControllerName =
-  | 'reasoningBank'
   | 'skills'
   | 'reflexion'
   | 'causalGraph'
@@ -163,7 +160,7 @@ export const INIT_LEVELS: InitLevel[] = [
   // Level 0: Foundation - already exists
   { level: 0, controllers: [] },
   // Level 1: Core intelligence
-  { level: 1, controllers: ['reasoningBank', 'hierarchicalMemory', 'learningBridge', 'hybridSearch', 'tieredCache'] },
+  { level: 1, controllers: ['hierarchicalMemory', 'learningBridge', 'hybridSearch', 'tieredCache'] },
   // Level 2: Graph & security
   { level: 2, controllers: ['memoryGraph', 'agentMemoryScope', 'mutationGuard'] },
   // Level 3: Specialization
@@ -468,10 +465,6 @@ export class ControllerRegistry extends EventEmitter {
       case 'hierarchicalMemory':
         return true;
 
-      // No moflo implementation yet — see createController.
-      case 'reasoningBank':
-        return false;
-
       case 'memoryGraph':
         return !!(this.config.memory?.memoryGraph || this.backend);
 
@@ -543,8 +536,7 @@ export class ControllerRegistry extends EventEmitter {
   }
 
   /**
-   * Factory method to create a controller instance. `reasoningBank` has no
-   * moflo implementation yet and returns null — consumers null-check already.
+   * Factory method to create a controller instance.
    */
   private async createController(name: ControllerName): Promise<unknown> {
     switch (name) {
@@ -625,13 +617,6 @@ export class ControllerRegistry extends EventEmitter {
           return new MemoryConsolidation(hm);
         }
         return this.createConsolidationStub();
-      }
-
-      case 'reasoningBank': {
-        // @moflo/neural's ReasoningBank has a trajectory-based API that
-        // doesn't match what memory-bridge expects (title/description/content).
-        // Null-returning keeps pattern-store calls as no-ops at the bridge.
-        return null;
       }
 
       case 'skills': {


### PR DESCRIPTION
## Summary

- The `reasoningBank` slot in `ControllerRegistry` always returned `null` — `createController` explicitly returned null, `isControllerEnabled` returned false by default, and @moflo/neural's trajectory-based ReasoningBank API doesn't match what `memory-bridge` expected.
- All 3 `registry.get('reasoningBank')` call sites in `memory-bridge.ts` had dead `typeof X === 'function'` guards; the raw-SQL `bridgeStoreEntry` path was the de-facto primary implementation all along.
- Renamed the success label from `'bridge-fallback'` → `'bridge'` in `bridgeStorePattern`/`bridgeSearchPatterns` to reflect reality. Dropped dead `controller === 'reasoningBank'` branches in `hooks-tools.ts` that could never fire.

## Changes

- `controller-registry.ts`: remove `reasoningBank` from `MofloDbControllerName` union, `INIT_LEVELS` level 1, `isControllerEnabled`, `createController`
- `controller-registry.test.ts`: retarget 3 assertions at live controllers (`hierarchicalMemory`, `skills`) instead of the dead slot
- `memory-bridge.ts`: drop `reasoningBank: true` from `initialize()` config; remove 3 dead `registry.get('reasoningBank')` blocks; rename `bridgeStorePattern`/`bridgeSearchPatterns` success label; drop redundant outer `getRegistry()` gates (inner calls already gate); retitle section headers/JSDoc to match reality
- `hooks-tools.ts`: drop 3 dead `controller === 'reasoningBank'` branches from `hooksPatternStore` output; rename `reasoningResult`/`rbResult` → `bridgeResult`

## Notes

- Issue body estimated "20+ call sites" — actual count in `memory-bridge.ts` was 3.
- The `bridge-fallback` label in `bridgeRecordCausalEdge` remains untouched — that's a real `causalGraph` fallback, not a dead reasoningBank path.
- `@moflo/neural`'s `ReasoningBank` class (trajectory-based) is a separate subsystem and untouched by this PR.
- Part of epic #476 (agentdb removal follow-up), per the issue's recommended Option A.

## Test plan

- [x] Unit: `controller-registry.test.ts` (58/58 pass)
- [x] Integration: `memory-movector-deep.test.ts` + `mcp-tools-deep.test.ts` (243/243 pass)
- [x] Broader: `memory-bridge` + `hooks-tools` touched-surface sweep (374/374 pass)
- [x] Full suite: 7464 passed / 16 skipped / 0 failed
- [ ] Manual sanity check on `hooks_intelligence_pattern-store` MCP tool output after merge

Closes #478

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)