### PR TITLE
fix(reasoning-bank): validate @moflo/memory export shape on dynamic import

### DIFF
--- a/src/modules/cli/src/memory/memory-initializer.ts
+++ b/src/modules/cli/src/memory/memory-initializer.ts
@@ -407,7 +407,15 @@ export async function getHNSWIndex(options?: {
 
   try {
     // Use HnswLite pure TS implementation (no native dependencies)
-    const { HnswLite } = await import('@moflo/memory') as any;
+    const memoryModule = await import('@moflo/memory') as any;
+    if (!('HnswLite' in memoryModule) || memoryModule.HnswLite === undefined) {
+      // Shape-check (issue #482): warn loudly and bail — the outer catch
+      // would otherwise swallow a cryptic "undefined is not a constructor".
+      console.warn('[getHNSWIndex] @moflo/memory missing expected export: HnswLite');
+      hnswInitializing = false;
+      return null;
+    }
+    const { HnswLite } = memoryModule;
 
     // Persistent storage paths
     const swarmDir = path.join(process.cwd(), '.swarm');

--- a/src/modules/cli/src/services/moflo-require.ts
+++ b/src/modules/cli/src/services/moflo-require.ts
@@ -25,23 +25,46 @@ const mofloRequire = createRequire(fileURLToPath(import.meta.url));
  * On Windows, `createRequire.resolve()` returns a native path (C:\...) which
  * `import()` rejects — it requires a file:// URL.  We convert via pathToFileURL.
  *
- * @param specifier  Package specifier, e.g. 'sql.js' or '@xenova/transformers'
- * @returns          The imported module, or null if not available
+ * @param specifier       Package specifier, e.g. 'sql.js' or '@xenova/transformers'
+ * @param expectedExports Optional list of named exports the caller relies on.
+ *                        When provided, the module is validated after load; if any
+ *                        named export is missing, a warning is emitted and null
+ *                        is returned (issue #482 — prevent silent shape mismatches).
+ * @returns               The imported module, or null if not available / shape mismatch
  */
-export async function mofloImport(specifier: string): Promise<any> {
+export async function mofloImport(
+  specifier: string,
+  expectedExports?: readonly string[],
+): Promise<any> {
+  let mod: any;
   try {
     const resolved = mofloRequire.resolve(specifier);
     // Convert native path → file:// URL (required on Windows for ESM import())
     const url = pathToFileURL(resolved).href;
-    return await import(url);
+    mod = await import(url);
   } catch {
     // Local resolution failed — try bare import as last resort
     try {
-      return await import(specifier);
+      mod = await import(specifier);
     } catch {
       return null;
     }
   }
+
+  if (expectedExports && expectedExports.length > 0) {
+    // `in` distinguishes missing-export from present-but-undefined re-exports.
+    const missing = expectedExports.filter(
+      k => !(k in mod) || mod[k] === undefined
+    );
+    if (missing.length > 0) {
+      console.warn(
+        `[mofloImport] '${specifier}' missing expected exports: ${missing.join(', ')}`
+      );
+      return null;
+    }
+  }
+
+  return mod;
 }
 
 /**

--- a/src/modules/hooks/src/reasoningbank/index.ts
+++ b/src/modules/hooks/src/reasoningbank/index.ts
@@ -300,22 +300,37 @@ export class ReasoningBank extends EventEmitter {
    * Load optional dependencies
    */
   private async loadDependencies(): Promise<void> {
-    // Try to load optional peer dependencies at runtime
-    const dynamicImport = async (moduleName: string): Promise<any> => {
+    // Shape-check each optional peer so a renamed/missing export is noisy instead
+    // of silently no-op'ing into the in-memory fallback (issue #482).
+    const dynamicImport = async (
+      moduleName: string,
+      requiredExports: readonly string[],
+    ): Promise<any> => {
       try {
-        return await import(/* webpackIgnore: true */ moduleName);
+        const mod: any = await import(/* webpackIgnore: true */ moduleName);
+        // `in` distinguishes missing-export from present-but-undefined re-exports.
+        const missing = requiredExports.filter(
+          k => !(k in mod) || mod[k] === undefined
+        );
+        if (missing.length > 0) {
+          console.warn(
+            `[ReasoningBank] ${moduleName} missing expected exports: ${missing.join(', ')} — feature disabled`
+          );
+          return null;
+        }
+        return mod;
       } catch {
         return null;
       }
     };
 
-    const memoryModule = await dynamicImport('@moflo/memory');
+    const memoryModule = await dynamicImport('@moflo/memory', ['MofloDbAdapter', 'HNSWIndex']);
     if (memoryModule) {
       MofloDbAdapter = memoryModule.MofloDbAdapter;
       HNSWIndex = memoryModule.HNSWIndex;
     }
 
-    const embeddingsModule = await dynamicImport('@moflo/embeddings');
+    const embeddingsModule = await dynamicImport('@moflo/embeddings', ['createEmbeddingService']);
     if (embeddingsModule) {
       EmbeddingServiceImpl = embeddingsModule.createEmbeddingService;
     }

--- a/src/modules/neural/__tests__/reasoning-bank-import.test.ts
+++ b/src/modules/neural/__tests__/reasoning-bank-import.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for ReasoningBank's @moflo/memory dynamic-import shape validation (issue #482).
+ *
+ * The production code silently swallows two failure modes:
+ *   1. @moflo/memory not installed (expected — optional peer)
+ *   2. @moflo/memory installed but exports renamed (dangerous — degrades to pass-through)
+ *
+ * This file asserts that case (2) emits a warning.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Hoisted mock — returns an empty module so the production code sees a module
+// that loads but has none of the expected exports (simulating a rename).
+vi.mock('@moflo/memory', () => ({}));
+
+describe('ReasoningBank @moflo/memory import contract', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns when @moflo/memory is present but expected exports are missing', async () => {
+    const { ReasoningBank } = await import('../src/reasoning-bank.js');
+    const bank = new ReasoningBank({ enableMofloDb: true });
+    await bank.initialize();
+
+    const missingExportsCalls = warnSpy.mock.calls.filter(call =>
+      typeof call[0] === 'string' && call[0].includes('missing expected exports'),
+    );
+    expect(missingExportsCalls.length).toBeGreaterThan(0);
+    expect(missingExportsCalls[0][0]).toContain('MofloDbAdapter');
+    expect(missingExportsCalls[0][0]).toContain('createDefaultEntry');
+    // Persistence must stay off so we don't call undefined as a constructor
+    expect(bank.isMofloDbAvailable()).toBe(false);
+
+    await bank.shutdown();
+  });
+});

--- a/src/modules/neural/src/reasoning-bank.ts
+++ b/src/modules/neural/src/reasoning-bank.ts
@@ -34,6 +34,8 @@ let MofloDbAdapter: any;
 let createDefaultEntry: ((input: any) => any) | undefined;
 let mofloDbImportPromise: Promise<void> | undefined;
 
+const REQUIRED_MEMORY_EXPORTS = ['MofloDbAdapter', 'createDefaultEntry'] as const;
+
 async function ensureMofloDbAdapterImport(): Promise<void> {
   if (!mofloDbImportPromise) {
     mofloDbImportPromise = (async () => {
@@ -42,9 +44,26 @@ async function ensureMofloDbAdapterImport(): Promise<void> {
         // @moflo/memory is an optional runtime peer installed by the consumer.
         const moduleName = '@moflo/memory';
         const memoryModule: any = await import(/* webpackIgnore: true */ moduleName);
+
+        // Shape-check so a renamed/missing export is noisy instead of silently
+        // downgrading ReasoningBank into a pass-through (issue #482). `in`
+        // distinguishes missing-export from present-but-undefined re-exports.
+        const missing = REQUIRED_MEMORY_EXPORTS.filter(
+          k => !(k in memoryModule) || memoryModule[k] === undefined
+        );
+        if (missing.length > 0) {
+          console.warn(
+            `[ReasoningBank] @moflo/memory missing expected exports: ${missing.join(', ')} — persistence disabled`
+          );
+          MofloDbAdapter = undefined;
+          createDefaultEntry = undefined;
+          return;
+        }
+
         MofloDbAdapter = memoryModule.MofloDbAdapter;
         createDefaultEntry = memoryModule.createDefaultEntry;
       } catch {
+        // @moflo/memory not installed — expected when consumers opt out of persistence.
         MofloDbAdapter = undefined;
         createDefaultEntry = undefined;
       }


### PR DESCRIPTION
## Summary

- Dynamic imports of optional peer `@moflo/memory` via variable specifier silently swallowed two failure modes — "not installed" (expected) and "installed but exports renamed" (dangerous: silently degrades ReasoningBank into a pass-through with no log, no error, no test signal).
- Add shape validation after each dynamic import at four call sites. Warn with the names of the missing exports and leave module references unset so the in-memory fallback kicks in.
- New unit test stubs `@moflo/memory` with an empty module and asserts the warning fires.

## Changes

- `src/modules/neural/src/reasoning-bank.ts` — check `MofloDbAdapter` + `createDefaultEntry` after dynamic import; warn on shape mismatch.
- `src/modules/hooks/src/reasoningbank/index.ts` — generalize the local `dynamicImport` helper to accept a required-exports list; check `@moflo/memory` (`MofloDbAdapter`, `HNSWIndex`) and `@moflo/embeddings` (`createEmbeddingService`).
- `src/modules/cli/src/memory/memory-initializer.ts:410` — check `HnswLite` after dynamic import; warn + return null (was a silent outer-catch path on TypeError).
- `src/modules/cli/src/services/moflo-require.ts` — add optional `expectedExports?: readonly string[]` parameter to `mofloImport`; warn + return null on shape mismatch.
- `src/modules/neural/__tests__/reasoning-bank-import.test.ts` — new test asserting the warning fires when `@moflo/memory` loads but exports are missing.

### Notes on the implementation

- Uses `!(k in mod) || mod[k] === undefined` rather than `typeof mod[k] === 'undefined'`. The `in` operator (a) sidesteps an ESM namespace access anomaly observed under vitest's `vi.mock`, and (b) distinguishes "not exported" from "exported as undefined" re-exports.
- Did not extract to `@moflo/shared`: `neural`, `hooks`, and `cli` have no current dep on `shared`, so a shared helper would cost three new inter-package deps for four call sites of a three-line filter. Ticket's "consider generalizing into `mofloImport`" is architecturally blocked because neural/hooks cannot depend on cli (wrong direction).
- Divergent required-export lists between `neural` (`createDefaultEntry`) and `hooks` (`HNSWIndex`) reflect genuinely different feature use — not a bug.

## Testing

- [x] `npm test` from root: **7654 / 7654 passing** (no regressions, isolation batch clean).
- [x] New unit test in `src/modules/neural/__tests__/reasoning-bank-import.test.ts` asserts the warning fires on shape mismatch and `isMofloDbAvailable()` stays false.
- [x] Manual verification via debug log: `vi.mock('@moflo/memory', () => ({}))` + `new ReasoningBank({enableMofloDb: true}).initialize()` emits `[ReasoningBank] @moflo/memory missing expected exports: MofloDbAdapter, createDefaultEntry — persistence disabled`.

Closes #482

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)