### PR TITLE
docs(guidance): drop agentdb refs from shipped core guidance

### DIFF
--- a/.claude/guidance/shipped/moflo-core-guidance.md
+++ b/.claude/guidance/shipped/moflo-core-guidance.md
@@ -149,7 +149,7 @@ This gives Claude access to 200+ MCP tools (`mcp__moflo__memory_*`, `mcp__moflo_
 | `init`      | 4           | Project initialization with wizard, presets, skills, hooks               |
 | `agent`     | 8           | Agent lifecycle (spawn, list, status, stop, metrics, pool, health, logs) |
 | `swarm`     | 6           | Multi-agent swarm coordination and orchestration                         |
-| `memory`    | 11          | AgentDB memory with vector search (150x-12,500x faster)                  |
+| `memory`    | 11          | sql.js + HNSW vector search, 150x-12,500x faster                         |
 | `mcp`       | 9           | MCP server management and tool execution                                 |
 | `task`      | 6           | Task creation, assignment, and lifecycle                                 |
 | `session`   | 7           | Session state management and persistence                                 |
@@ -535,7 +535,7 @@ auto_index:
 
 # Memory backend
 memory:
-  backend: sql.js                 # sql.js (WASM) | agentdb | json
+  backend: sql.js                 # sql.js (WASM) | json
   embedding_model: Xenova/all-MiniLM-L6-v2   # 384-dim neural embeddings
   namespace: default              # Default namespace for memory operations
 
@@ -582,7 +582,7 @@ status_line:
   show_mcp: true                 # MCP server count
   show_security: true            # CVE/security status (dashboard only)
   show_adrs: true                # ADR compliance (dashboard only)
-  show_agentdb: true             # AgentDB vectors/size (dashboard only)
+  show_agentdb: true             # MofloDb vectors/size (dashboard only)
   show_tests: true               # Test file count (dashboard only)
 
 # Spell step sandboxing (OS-level process isolation for bash steps)


### PR DESCRIPTION
## Summary
- Remove three stale `AgentDB` references from `.claude/guidance/shipped/moflo-core-guidance.md` — the external `agentdb` package was removed in #475, so this doc shipping to every consumer `.claude/guidance/shipped/` directory was misleading.
- Preserve user-facing surfaces: the `show_agentdb` YAML key is kept (only its trailing comment is updated) so existing consumer `moflo.yaml` configs don't break.

## Changes
- L152: `memory` command row now reads `sql.js + HNSW vector search, 150x-12,500x faster`
- L538: backend comment drops the removed `agentdb` option (`# sql.js (WASM) | json`)
- L585: `show_agentdb` comment points at `MofloDb vectors/size (dashboard only)` (key literally unchanged)

## Non-goals (unchanged)
- `show_agentdb` YAML key — preserved
- MCP tool IDs (`mcp__moflo__agentdb_*`) — untouched
- On-disk paths (`.agentdb/`, `.swarm/agentdb/`) and `source: 'agentdb'` metadata default — untouched (these need a migration plan, not a doc pass)

## Testing
- [x] `grep -n "AgentDB|agentdb" .claude/guidance/shipped/` — only the `show_agentdb` config key remains (expected per non-goals)
- [x] `tests/guidance/lint-guidance.test.ts` — 182/182 pass
- [x] No behavioral changes (doc-only, 3-line string edit)

Part of #476 (follow-up to epic #464).

Closes #484