### PR TITLE
docs(memory): replace AgentDB prose with MofloDb in @moflo/memory

### DIFF
--- a/src/modules/memory/src/agent-memory-scope.ts
+++ b/src/modules/memory/src/agent-memory-scope.ts
@@ -151,7 +151,7 @@ export function resolveAgentMemoryDir(
  * the correct memory directory based on agent name and scope, then
  * delegates to AutoMemoryBridge for the actual sync logic.
  *
- * @param backend - The AgentDB memory backend
+ * @param backend - The MofloDb memory backend
  * @param config - Agent-scoped configuration
  * @returns A configured AutoMemoryBridge instance
  *

--- a/src/modules/memory/src/auto-memory-bridge.test.ts
+++ b/src/modules/memory/src/auto-memory-bridge.test.ts
@@ -2,7 +2,7 @@
  * Tests for AutoMemoryBridge
  *
  * TDD London School (mock-first) tests for the bidirectional bridge
- * between Claude Code auto memory and AgentDB.
+ * between Claude Code auto memory and MofloDb.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -371,7 +371,7 @@ describe('AutoMemoryBridge', () => {
   });
 
   describe('recordInsight', () => {
-    it('should store insight in AgentDB', async () => {
+    it('should store insight in MofloDb', async () => {
       const insight = createTestInsight();
       await bridge.recordInsight(insight);
 
@@ -480,11 +480,11 @@ describe('AutoMemoryBridge', () => {
       expect(bridge.getStatus().bufferedInsights).toBe(0);
     });
 
-    it('should skip AgentDB entries already synced from the buffer', async () => {
-      // Record an insight (stored in buffer AND AgentDB)
+    it('should skip MofloDb entries already synced from the buffer', async () => {
+      // Record an insight (stored in buffer AND MofloDb)
       await bridge.recordInsight(createTestInsight());
 
-      // Mock backend.query to return the same insight from AgentDB
+      // Mock backend.query to return the same insight from MofloDb
       const mockEntry: Partial<MemoryEntry> = {
         id: 'test-1',
         key: 'insight:debugging:12345',
@@ -525,7 +525,7 @@ describe('AutoMemoryBridge', () => {
       expect(backend.bulkInsert).toHaveBeenCalled();
     });
 
-    it('should skip entries already in AgentDB', async () => {
+    it('should skip entries already in MofloDb', async () => {
       const topicContent = `# Test
 
 ## Existing

--- a/src/modules/memory/src/auto-memory-bridge.ts
+++ b/src/modules/memory/src/auto-memory-bridge.ts
@@ -1,9 +1,9 @@
 /**
- * AutoMemoryBridge - Bidirectional sync between Claude Code Auto Memory and AgentDB
+ * AutoMemoryBridge - Bidirectional sync between Claude Code Auto Memory and MofloDb
  *
  * Per ADR-048: Bridges Claude Code's auto memory (markdown files at
  * ~/.claude/projects/<project>/memory/) with claude-flow's unified memory
- * system (AgentDB + HNSW).
+ * system (MofloDb: sql.js + HNSW).
  *
  * Auto memory files are human-readable markdown that Claude loads into its
  * system prompt. MEMORY.md (first 200 lines) is the entrypoint; topic files
@@ -102,7 +102,7 @@ export interface MemoryInsight {
   /** Confidence score (0-1), used for curation priority */
   confidence: number;
 
-  /** AgentDB entry ID for cross-reference */
+  /** MofloDb entry ID for cross-reference */
   agentDbId?: string;
 }
 
@@ -126,7 +126,7 @@ export interface ImportResult {
   /** Number of entries imported */
   imported: number;
 
-  /** Number of entries skipped (already in AgentDB) */
+  /** Number of entries skipped (already in MofloDb) */
   skipped: number;
 
   /** Files processed */
@@ -182,7 +182,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
 // ===== AutoMemoryBridge =====
 
 /**
- * Bidirectional bridge between Claude Code auto memory and AgentDB.
+ * Bidirectional bridge between Claude Code auto memory and MofloDb.
  *
  * @example
  * ```typescript
@@ -201,7 +201,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
  * // Sync to auto memory files
  * await bridge.syncToAutoMemory();
  *
- * // Import auto memory into AgentDB
+ * // Import auto memory into MofloDb
  * await bridge.importFromAutoMemory();
  * ```
  */
@@ -211,7 +211,7 @@ export class AutoMemoryBridge extends EventEmitter {
   private lastSyncTime: number = 0;
   private syncTimer: ReturnType<typeof setInterval> | null = null;
   private insights: MemoryInsight[] = [];
-  /** Track AgentDB keys of insights already written to files during this session */
+  /** Track MofloDb keys of insights already written to files during this session */
   private syncedInsightKeys = new Set<string>();
   /** Monotonic counter to prevent key collisions within the same ms */
   private insightCounter = 0;
@@ -272,7 +272,7 @@ export class AutoMemoryBridge extends EventEmitter {
   async recordInsight(insight: MemoryInsight): Promise<void> {
     this.insights.push(insight);
 
-    // Store in AgentDB
+    // Store in MofloDb
     const key = await this.storeInsightInMofloDb(insight);
     this.syncedInsightKeys.add(key);
 
@@ -290,7 +290,7 @@ export class AutoMemoryBridge extends EventEmitter {
   }
 
   /**
-   * Sync high-confidence AgentDB entries to auto memory files.
+   * Sync high-confidence MofloDb entries to auto memory files.
    * Called on session-end or periodically.
    */
   async syncToAutoMemory(): Promise<SyncResult> {
@@ -320,7 +320,7 @@ export class AutoMemoryBridge extends EventEmitter {
         }
       }
 
-      // Query AgentDB for high-confidence entries since last sync,
+      // Query MofloDb for high-confidence entries since last sync,
       // skipping entries we already wrote from the buffer above
       const entries = await this.queryRecentInsights();
       for (const entry of entries) {
@@ -371,8 +371,8 @@ export class AutoMemoryBridge extends EventEmitter {
   }
 
   /**
-   * Import auto memory files into AgentDB.
-   * Called on session-start to hydrate AgentDB with previous learnings.
+   * Import auto memory files into MofloDb.
+   * Called on session-start to hydrate MofloDb with previous learnings.
    * Uses bulk insert for efficiency.
    */
   async importFromAutoMemory(): Promise<ImportResult> {

--- a/src/modules/memory/src/domain/repositories/memory-repository.interface.ts
+++ b/src/modules/memory/src/domain/repositories/memory-repository.interface.ts
@@ -72,7 +72,7 @@ export interface MemoryStatistics {
  * Memory Repository Interface
  *
  * Defines all operations for memory persistence.
- * Implementations can use SQLite, AgentDB, or hybrid backends.
+ * Implementations can use SQLite, MofloDb, or hybrid backends.
  */
 export interface IMemoryRepository {
   // Basic CRUD Operations

--- a/src/modules/memory/src/infrastructure/repositories/hybrid-memory-repository.ts
+++ b/src/modules/memory/src/infrastructure/repositories/hybrid-memory-repository.ts
@@ -1,7 +1,7 @@
 /**
  * Hybrid Memory Repository - Infrastructure Layer
  *
- * Implements IMemoryRepository using SQLite + AgentDB hybrid backend.
+ * Implements IMemoryRepository using SQLite + MofloDb hybrid backend.
  * Per ADR-009, this is the default memory backend.
  *
  * @module v3/memory/infrastructure/repositories
@@ -39,7 +39,7 @@ interface CacheEntry {
 /**
  * Hybrid Memory Repository
  *
- * Uses SQLite for metadata and AgentDB for vectors.
+ * Uses SQLite for metadata and MofloDb for vectors.
  * Implements hot caching for frequently accessed entries.
  */
 export class HybridMemoryRepository implements IMemoryRepository {
@@ -58,7 +58,7 @@ export class HybridMemoryRepository implements IMemoryRepository {
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
-    // In production, would initialize SQLite and AgentDB connections
+    // In production, would initialize SQLite and MofloDb connections
     // For now, using in-memory implementation
     this.entries = new Map();
     this.namespaceIndex = new Map();

--- a/src/modules/memory/src/learning-bridge.ts
+++ b/src/modules/memory/src/learning-bridge.ts
@@ -133,7 +133,7 @@ export class LearningBridge extends EventEmitter {
   // ===== Public API =====
 
   /**
-   * Notify the bridge that an insight has been recorded in AgentDB.
+   * Notify the bridge that an insight has been recorded in MofloDb.
    * Creates a learning trajectory so the neural system can track the
    * insight's lifecycle.
    */

--- a/src/modules/memory/src/migration.ts
+++ b/src/modules/memory/src/migration.ts
@@ -2,7 +2,7 @@
  * V3 Memory Migration Utility
  *
  * Migrates data from legacy memory systems (SQLite, Markdown, JSON, etc.)
- * to the unified AgentDB-backed memory system with HNSW indexing.
+ * to the unified MofloDb-backed memory system with HNSW indexing.
  *
  * @module v3/memory/migration
  */

--- a/src/modules/memory/src/sqljs-backend.ts
+++ b/src/modules/memory/src/sqljs-backend.ts
@@ -654,7 +654,7 @@ export class SqlJsBackend extends EventEmitter implements IMemoryBackend {
       message: 'No vector index (brute-force search)',
     };
 
-    recommendations.push('Consider using AgentDB with HNSW for faster vector search');
+    recommendations.push('Consider using MofloDbAdapter for HNSW-indexed vector search');
 
     // Cache health (not applicable for sql.js)
     const cacheHealth: ComponentHealth = {

--- a/src/modules/memory/src/types.ts
+++ b/src/modules/memory/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * V3 Unified Memory Types
  *
- * Type definitions for the unified memory system based on AgentDB with HNSW indexing.
+ * Type definitions for the unified memory system based on sql.js with HNSW indexing.
  * Supports 150x-12,500x faster vector search compared to brute-force approaches.
  *
  * @module v3/memory/types


### PR DESCRIPTION
## Summary
- Finishes the prose half of epic #476. #477 renamed AgentDB* symbols to MofloDb*, but ~25 docstrings/comments still described the current system as "AgentDB" — implying a dependency that no longer exists.
- Updates docstrings, file headers, @param docs, and test descriptions to say MofloDb / sql.js + HNSW.
- sqljs-backend health recommendation now points at MofloDbAdapter (in-tree) instead of a legacy external package.

## Scope (what did NOT change)
Per the epic's user-data / consumer-config boundaries:
- Path strings (`.agentdb/` on disk)
- MCP tool IDs (`mcp__moflo__agentdb_*`)
- Metadata default `source: 'agentdb'`
- `controllers/*` "Replaces `agentdb.X`" comments — historical legacy markers
- `moflo-db-adapter.ts` "has no external agentdb dependency" — explanatory

## Acceptance
- `grep -rn "AgentDB\|agentdb" src/modules/memory/src` only returns the excluded cases listed above
- `auto-memory-bridge.test.ts` `it(...)` descriptions updated to say "MofloDb"
- `sqljs-backend.ts` recommendation text no longer suggests a non-existent package
- 455 tests pass (same as main); only string literals in descriptions changed

## Test plan
- [x] Unit tests pass (`npm test` in `src/modules/memory` — 455/455)
- [x] Acceptance grep verified (only legacy/excluded refs remain)
- [ ] Review prose diff

Closes #491

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)