### PR TITLE
refactor(memory-bridge): shrink to <1000 lines via facade + stub parity

### DIFF
--- a/src/modules/cli/src/memory/bridge-core.ts
+++ b/src/modules/cli/src/memory/bridge-core.ts
@@ -1,0 +1,278 @@
+/**
+ * Memory bridge — shared primitives: registry singleton, db handle,
+ * wrapper, id generation, cosine similarity, vector-stats cache.
+ *
+ * @module v3/cli/bridge-core
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
+
+// When run via npx, CWD may be node_modules/moflo — walk up to find actual project
+let _projectRoot: string | undefined;
+function getProjectRoot(): string {
+  if (_projectRoot) return _projectRoot;
+  if (process.env.CLAUDE_PROJECT_DIR) {
+    _projectRoot = process.env.CLAUDE_PROJECT_DIR;
+    return _projectRoot;
+  }
+  let dir = process.cwd();
+  const root = path.parse(dir).root;
+  while (dir !== root) {
+    if (fs.existsSync(path.join(dir, '.swarm', 'memory.db'))) {
+      _projectRoot = dir;
+      return _projectRoot;
+    }
+    if (fs.existsSync(path.join(dir, 'CLAUDE.md')) && fs.existsSync(path.join(dir, 'package.json'))) {
+      _projectRoot = dir;
+      return _projectRoot;
+    }
+    if (path.basename(dir) === 'node_modules') {
+      dir = path.dirname(dir);
+      continue;
+    }
+    dir = path.dirname(dir);
+  }
+  _projectRoot = process.cwd();
+  return _projectRoot;
+}
+
+let registryPromise: Promise<any | null> | null = null;
+// Sync handle populated once the promise resolves. Lets sync callers
+// (refreshVectorStatsCache) read the registry without awaiting.
+let resolvedRegistry: any | null = null;
+const schemaInitialized = new WeakSet<object>();
+
+function getDbPath(customPath?: string): string {
+  const swarmDir = path.resolve(getProjectRoot(), '.swarm');
+  if (!customPath) return path.join(swarmDir, 'memory.db');
+  if (customPath === ':memory:') return ':memory:';
+  const resolved = path.resolve(customPath);
+  const root = getProjectRoot();
+  const rel = path.relative(root, resolved);
+  // Reject anything that escapes the project root or is an absolute path
+  // outside it (path.relative returns an absolute path on different drives).
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return path.join(swarmDir, 'memory.db');
+  }
+  return resolved;
+}
+
+export function generateId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${crypto.randomBytes(8).toString('hex')}`;
+}
+
+/**
+ * Returns null if @moflo/memory cannot be loaded or sql.js fails to open —
+ * callers fall back to raw sql.js.
+ */
+export async function getRegistry(dbPath?: string): Promise<any | null> {
+  if (!registryPromise) {
+    registryPromise = (async () => {
+      try {
+        const { ControllerRegistry } = await import('@moflo/memory');
+        const registry = new ControllerRegistry();
+
+        // Suppress noisy init logs
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => {
+          const msg = String(args[0] ?? '');
+          if (msg.includes('Transformers.js') ||
+              msg.includes('[MofloDb]') ||
+              msg.includes('[HNSWLibBackend]') ||
+              msg.includes('MoVector graph')) return;
+          origLog.apply(console, args);
+        };
+
+        try {
+          await registry.initialize({
+            dbPath: dbPath || getDbPath(),
+            dimension: 384,
+            controllers: {
+              learningBridge: false,
+              tieredCache: true,
+              hierarchicalMemory: true,
+              memoryConsolidation: true,
+              memoryGraph: true,
+            },
+          });
+        } finally {
+          console.log = origLog;
+        }
+
+        resolvedRegistry = registry;
+        return registry;
+      } catch {
+        registryPromise = null;
+        return null;
+      }
+    })();
+  }
+
+  return registryPromise;
+}
+
+export interface BridgeDbContext {
+  db: any;
+  mofloDb: any;
+}
+
+// Kept in sync with MEMORY_SCHEMA_V3.memory_entries in memory-initializer.ts.
+// Running `CREATE TABLE IF NOT EXISTS` is a no-op if the initializer already
+// ran; when the bridge runs first, matching CHECKs here prevents drift.
+const MEMORY_ENTRIES_DDL = `CREATE TABLE IF NOT EXISTS memory_entries (
+  id TEXT PRIMARY KEY,
+  key TEXT NOT NULL,
+  namespace TEXT DEFAULT 'default',
+  content TEXT NOT NULL,
+  type TEXT DEFAULT 'semantic' CHECK(type IN ('semantic', 'episodic', 'procedural', 'working', 'pattern')),
+  embedding TEXT,
+  embedding_model TEXT DEFAULT 'local',
+  embedding_dimensions INTEGER,
+  tags TEXT,
+  metadata TEXT,
+  owner_id TEXT,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  expires_at INTEGER,
+  last_accessed_at INTEGER,
+  access_count INTEGER DEFAULT 0,
+  status TEXT DEFAULT 'active' CHECK(status IN ('active', 'archived', 'deleted')),
+  UNIQUE(namespace, key)
+)`;
+
+export function getDb(registry: any): BridgeDbContext | null {
+  const mofloDb = registry.getMofloDb();
+  if (!mofloDb?.database) return null;
+
+  const db = mofloDb.database;
+
+  if (!schemaInitialized.has(db)) {
+    try {
+      db.exec(MEMORY_ENTRIES_DDL);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_ns ON memory_entries(namespace)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_key ON memory_entries(key)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_status ON memory_entries(status)`);
+      schemaInitialized.add(db);
+    } catch {
+      // Table already exists or db is read-only — that's fine
+    }
+  }
+
+  return { db, mofloDb };
+}
+
+/**
+ * Resolve registry + db, run fn, return null on any unexpected failure so
+ * the caller falls back to raw sql.js.
+ */
+export async function withDb<T>(
+  dbPath: string | undefined,
+  fn: (ctx: BridgeDbContext, registry: any) => Promise<T | null>,
+): Promise<T | null> {
+  const registry = await getRegistry(dbPath);
+  if (!registry) return null;
+  const ctx = getDb(registry);
+  if (!ctx) return null;
+  try {
+    return await fn(ctx, registry);
+  } catch {
+    return null;
+  }
+}
+
+export async function isBridgeAvailable(dbPath?: string): Promise<boolean> {
+  const registry = await getRegistry(dbPath);
+  return registry !== null;
+}
+
+export async function getControllerRegistry(dbPath?: string): Promise<any | null> {
+  return getRegistry(dbPath);
+}
+
+export async function shutdownBridge(): Promise<void> {
+  if (!registryPromise) return;
+  const registry = await registryPromise;
+  registryPromise = null;
+  resolvedRegistry = null;
+  if (registry) {
+    try {
+      await registry.shutdown();
+    } catch {
+      // Best-effort
+    }
+  }
+}
+
+export function cosineSim(a: number[], b: number[]): number {
+  if (!a || !b || a.length === 0 || b.length === 0) return 0;
+  const len = Math.min(a.length, b.length);
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < len; i++) {
+    const ai = a[i], bi = b[i];
+    dot += ai * bi;
+    normA += ai * ai;
+    normB += bi * bi;
+  }
+  const mag = Math.sqrt(normA * normB);
+  return mag === 0 ? 0 : dot / mag;
+}
+
+/**
+ * Write vector-stats.json cache file used by the statusline. Runs
+ * synchronously — only fires when the registry is already resolved, so
+ * no await is needed on the store/delete hot path.
+ */
+export function refreshVectorStatsCache(dbPathOverride?: string): void {
+  const registry = resolvedRegistry;
+  if (!registry) return;
+
+  try {
+    const ctx = getDb(registry);
+    if (!ctx?.db) return;
+
+    let vectorCount = 0;
+    let namespaces = 0;
+    let dbSizeKB = 0;
+    let hasHnsw = false;
+
+    try {
+      const countRow = ctx.db.prepare(
+        'SELECT COUNT(*) as c FROM memory_entries WHERE status = ? AND embedding IS NOT NULL',
+      ).get('active') as { c: number } | undefined;
+      vectorCount = countRow?.c ?? 0;
+
+      const nsRow = ctx.db.prepare(
+        'SELECT COUNT(DISTINCT namespace) as n FROM memory_entries WHERE status = ?',
+      ).get('active') as { n: number } | undefined;
+      namespaces = nsRow?.n ?? 0;
+    } catch {
+      // Table may not exist yet
+    }
+
+    const dbFile = dbPathOverride || getDbPath();
+    try {
+      const stat = fs.statSync(dbFile);
+      dbSizeKB = Math.floor(stat.size / 1024);
+    } catch { /* file may not exist */ }
+
+    const root = getProjectRoot();
+    const hnswPaths = [
+      path.join(root, '.swarm', 'hnsw.index'),
+      path.join(root, '.claude-flow', 'hnsw.index'),
+    ];
+    for (const p of hnswPaths) {
+      try { fs.statSync(p); hasHnsw = true; break; } catch { /* nope */ }
+    }
+
+    const cacheDir = path.join(root, '.claude-flow');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'vector-stats.json'),
+      JSON.stringify({ vectorCount, dbSizeKB, namespaces, hasHnsw, updatedAt: Date.now() }),
+    );
+  } catch {
+    // Non-fatal — statusline falls back to file size estimate
+  }
+}

--- a/src/modules/cli/src/memory/bridge-entries.ts
+++ b/src/modules/cli/src/memory/bridge-entries.ts
@@ -1,0 +1,530 @@
+/**
+ * Bridge entries store — CLI-facing memory_entries operations.
+ *
+ * This is the sql.js `memory_entries` table the bridge owns directly
+ * (not a moflo controller table). Separated out of memory-bridge.ts
+ * to keep the top-level bridge a thin controller-op wrapper.
+ *
+ * @module v3/cli/bridge-entries
+ */
+
+import { cosineSim, generateId, refreshVectorStatsCache, withDb } from './bridge-core.js';
+
+function makeEntryCacheKey(namespace: string, key: string): string {
+  const safeNs = String(namespace).replace(/:/g, '_');
+  const safeKey = String(key).replace(/:/g, '_');
+  return `entry:${safeNs}:${safeKey}`;
+}
+
+function bm25Score(
+  queryTerms: string[],
+  docContent: string,
+  avgDocLength: number,
+  docCount: number,
+  termDocFreqs: Map<string, number>,
+): number {
+  const k1 = 1.2;
+  const b = 0.75;
+  const docWords = docContent.toLowerCase().split(/\s+/);
+  const docLength = docWords.length;
+
+  let score = 0;
+  for (const term of queryTerms) {
+    const tf = docWords.filter(w => w === term || w.includes(term)).length;
+    if (tf === 0) continue;
+
+    const df = termDocFreqs.get(term) || 1;
+    const idf = Math.log((docCount - df + 0.5) / (df + 0.5) + 1);
+    const tfNorm = (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (docLength / Math.max(1, avgDocLength))));
+    score += idf * tfNorm;
+  }
+
+  return score;
+}
+
+function computeTermDocFreqs(
+  queryTerms: string[],
+  rows: Array<{ content: string }>,
+): { termDocFreqs: Map<string, number>; avgDocLength: number } {
+  const termDocFreqs = new Map<string, number>();
+  let totalLength = 0;
+
+  for (const row of rows) {
+    const content = (row.content || '').toLowerCase();
+    const words = content.split(/\s+/);
+    totalLength += words.length;
+
+    for (const term of queryTerms) {
+      if (content.includes(term)) {
+        termDocFreqs.set(term, (termDocFreqs.get(term) || 0) + 1);
+      }
+    }
+  }
+
+  return { termDocFreqs, avgDocLength: rows.length > 0 ? totalLength / rows.length : 1 };
+}
+
+async function cacheGet(registry: any, cacheKey: string): Promise<any | null> {
+  const cache = registry.get('tieredCache');
+  if (!cache) return null;
+  return (await cache.get(cacheKey)) ?? null;
+}
+
+async function cacheSet(registry: any, cacheKey: string, value: any): Promise<void> {
+  const cache = registry.get('tieredCache');
+  if (!cache) return;
+  await cache.set(cacheKey, value);
+}
+
+async function cacheInvalidate(registry: any, cacheKey: string): Promise<void> {
+  const cache = registry.get('tieredCache');
+  if (!cache) return;
+  cache.delete(cacheKey);
+}
+
+async function guardValidate(
+  registry: any,
+  operation: string,
+  params: Record<string, unknown>,
+): Promise<{ allowed: boolean; reason?: string }> {
+  const guard = registry.get('mutationGuard');
+  if (!guard) return { allowed: true };
+  const result = guard.validate({ operation, params, timestamp: Date.now() });
+  return { allowed: result?.allowed === true, reason: result?.reason };
+}
+
+async function logAttestation(
+  registry: any,
+  operation: string,
+  entryId: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  const attestation = registry.get('attestationLog');
+  if (!attestation) return;
+  try {
+    attestation.record({ operation, entryId, timestamp: Date.now(), ...metadata });
+  } catch {
+    // Non-fatal — attestation is observability, not correctness
+  }
+}
+
+/**
+ * Store an entry. Returns null to signal fallback to sql.js.
+ */
+export async function bridgeStoreEntry(options: {
+  key: string;
+  value: string;
+  namespace?: string;
+  generateEmbeddingFlag?: boolean;
+  tags?: string[];
+  ttl?: number;
+  dbPath?: string;
+  upsert?: boolean;
+}): Promise<{
+  success: boolean;
+  id: string;
+  embedding?: { dimensions: number; model: string };
+  guarded?: boolean;
+  cached?: boolean;
+  attested?: boolean;
+  error?: string;
+} | null> {
+  return withDb(options.dbPath, async (ctx, registry) => {
+    const { key, value, namespace = 'default', tags = [], ttl } = options;
+    const id = generateId('entry');
+    const now = Date.now();
+
+    const guardResult = await guardValidate(registry, 'store', { key, namespace, size: value.length });
+    if (!guardResult.allowed) {
+      return { success: false, id, error: `MutationGuard rejected: ${guardResult.reason}` };
+    }
+
+    let embeddingJson: string | null = null;
+    let dimensions = 0;
+    let model = 'local';
+
+    if (options.generateEmbeddingFlag !== false && value.length > 0) {
+      try {
+        const embedder = ctx.mofloDb.embedder;
+        if (embedder) {
+          const emb = await embedder.embed(value);
+          if (emb) {
+            embeddingJson = JSON.stringify(Array.from(emb));
+            dimensions = emb.length;
+            model = 'Xenova/all-MiniLM-L6-v2';
+          }
+        }
+      } catch {
+        // Embedding failed — store without
+      }
+    }
+
+    const insertSql = options.upsert
+      ? `INSERT OR REPLACE INTO memory_entries (
+          id, key, namespace, content, type,
+          embedding, embedding_dimensions, embedding_model,
+          tags, metadata, created_at, updated_at, expires_at, status
+        ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`
+      : `INSERT INTO memory_entries (
+          id, key, namespace, content, type,
+          embedding, embedding_dimensions, embedding_model,
+          tags, metadata, created_at, updated_at, expires_at, status
+        ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`;
+
+    const stmt = ctx.db.prepare(insertSql);
+    stmt.run(
+      id, key, namespace, value,
+      embeddingJson, dimensions || null, model,
+      tags.length > 0 ? JSON.stringify(tags) : null,
+      '{}',
+      now, now,
+      ttl ? now + (ttl * 1000) : null,
+    );
+
+    const cacheKey = makeEntryCacheKey(namespace, key);
+    await cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson });
+
+    await logAttestation(registry, 'store', id, { key, namespace, hasEmbedding: !!embeddingJson });
+
+    if (embeddingJson) refreshVectorStatsCache();
+
+    return {
+      success: true,
+      id,
+      embedding: embeddingJson ? { dimensions, model } : undefined,
+      guarded: true,
+      cached: true,
+      attested: true,
+    };
+  });
+}
+
+/**
+ * Search entries with hybrid BM25 + cosine scoring.
+ */
+export async function bridgeSearchEntries(options: {
+  query: string;
+  namespace?: string;
+  limit?: number;
+  threshold?: number;
+  dbPath?: string;
+}): Promise<{
+  success: boolean;
+  results: {
+    id: string;
+    key: string;
+    content: string;
+    score: number;
+    namespace: string;
+    provenance?: string;
+  }[];
+  searchTime: number;
+  searchMethod?: string;
+  error?: string;
+} | null> {
+  return withDb(options.dbPath, async (ctx) => {
+    const { query: queryStr, namespace = 'default', limit = 10, threshold = 0.3 } = options;
+    const startTime = Date.now();
+
+    let queryEmbedding: number[] | null = null;
+    try {
+      const embedder = ctx.mofloDb.embedder;
+      if (embedder) {
+        const emb = await embedder.embed(queryStr);
+        queryEmbedding = Array.from(emb);
+      }
+    } catch {
+      // Fall back to keyword search
+    }
+
+    const nsFilter = namespace !== 'all' ? `AND namespace = ?` : '';
+
+    let rows: any[];
+    try {
+      const stmt = ctx.db.prepare(`
+        SELECT id, key, namespace, content, embedding
+        FROM memory_entries
+        WHERE status = 'active' ${nsFilter}
+        LIMIT 1000
+      `);
+      rows = namespace !== 'all' ? stmt.all(namespace) : stmt.all();
+    } catch {
+      return null;
+    }
+
+    const queryTerms = queryStr.toLowerCase().split(/\s+/).filter(t => t.length > 1);
+    const { termDocFreqs, avgDocLength } = computeTermDocFreqs(queryTerms, rows);
+    const docCount = rows.length;
+
+    const results: { id: string; key: string; content: string; score: number; namespace: string; provenance?: string }[] = [];
+
+    for (const row of rows) {
+      let semanticScore = 0;
+      let bm25ScoreVal = 0;
+
+      if (queryEmbedding && row.embedding) {
+        try {
+          const embedding = JSON.parse(row.embedding) as number[];
+          semanticScore = cosineSim(queryEmbedding, embedding);
+        } catch {
+          // Invalid embedding
+        }
+      }
+
+      if (queryTerms.length > 0 && row.content) {
+        bm25ScoreVal = bm25Score(queryTerms, row.content, avgDocLength, docCount, termDocFreqs);
+        bm25ScoreVal = Math.min(bm25ScoreVal / 10, 1.0);
+      }
+
+      const usedSemantic = queryEmbedding != null;
+      const score = usedSemantic ? 0.7 * semanticScore + 0.3 * bm25ScoreVal : bm25ScoreVal;
+
+      if (score >= threshold) {
+        const provenance = usedSemantic
+          ? `semantic:${semanticScore.toFixed(3)}+bm25:${bm25ScoreVal.toFixed(3)}`
+          : `bm25:${bm25ScoreVal.toFixed(3)}`;
+
+        results.push({
+          id: String(row.id).substring(0, 12),
+          key: row.key || String(row.id).substring(0, 15),
+          content: (row.content || '').substring(0, 60) + ((row.content || '').length > 60 ? '...' : ''),
+          score,
+          namespace: row.namespace || 'default',
+          provenance,
+        });
+      }
+    }
+
+    results.sort((a, b) => b.score - a.score);
+
+    return {
+      success: true,
+      results: results.slice(0, limit),
+      searchTime: Date.now() - startTime,
+      searchMethod: queryEmbedding ? 'hybrid-bm25-semantic' : 'bm25-only',
+    };
+  });
+}
+
+export async function bridgeListEntries(options: {
+  namespace?: string;
+  limit?: number;
+  offset?: number;
+  dbPath?: string;
+}): Promise<{
+  success: boolean;
+  entries: {
+    id: string;
+    key: string;
+    namespace: string;
+    size: number;
+    accessCount: number;
+    createdAt: string;
+    updatedAt: string;
+    hasEmbedding: boolean;
+  }[];
+  total: number;
+  error?: string;
+} | null> {
+  return withDb(options.dbPath, async (ctx) => {
+    const { namespace, limit = 20, offset = 0 } = options;
+    const nsFilter = namespace ? `AND namespace = ?` : '';
+    const nsParams = namespace ? [namespace] : [];
+
+    let total = 0;
+    try {
+      const countStmt = ctx.db.prepare(
+        `SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active' ${nsFilter}`,
+      );
+      const countRow = countStmt.get(...nsParams);
+      total = countRow?.cnt ?? 0;
+    } catch {
+      return null;
+    }
+
+    const entries: any[] = [];
+    try {
+      const stmt = ctx.db.prepare(`
+        SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at
+        FROM memory_entries
+        WHERE status = 'active' ${nsFilter}
+        ORDER BY updated_at DESC
+        LIMIT ? OFFSET ?
+      `);
+      const rows = stmt.all(...nsParams, limit, offset);
+      for (const row of rows) {
+        entries.push({
+          id: String(row.id).substring(0, 20),
+          key: row.key || String(row.id).substring(0, 15),
+          namespace: row.namespace || 'default',
+          size: (row.content || '').length,
+          accessCount: row.access_count ?? 0,
+          createdAt: row.created_at || new Date().toISOString(),
+          updatedAt: row.updated_at || new Date().toISOString(),
+          hasEmbedding: !!(row.embedding && String(row.embedding).length > 10),
+        });
+      }
+    } catch {
+      return null;
+    }
+
+    return { success: true, entries, total };
+  });
+}
+
+/**
+ * Get a specific entry via TieredCache → DB.
+ */
+export async function bridgeGetEntry(options: {
+  key: string;
+  namespace?: string;
+  dbPath?: string;
+}): Promise<{
+  success: boolean;
+  found: boolean;
+  entry?: {
+    id: string;
+    key: string;
+    namespace: string;
+    content: string;
+    accessCount: number;
+    createdAt: string;
+    updatedAt: string;
+    hasEmbedding: boolean;
+    tags: string[];
+  };
+  cacheHit?: boolean;
+  error?: string;
+} | null> {
+  return withDb(options.dbPath, async (ctx, registry) => {
+    const { key, namespace = 'default' } = options;
+
+    const cacheKey = makeEntryCacheKey(namespace, key);
+    const cached = await cacheGet(registry, cacheKey);
+    if (cached && cached.content) {
+      return {
+        success: true,
+        found: true,
+        cacheHit: true,
+        entry: {
+          id: String(cached.id || ''),
+          key: cached.key || key,
+          namespace: cached.namespace || namespace,
+          content: cached.content || '',
+          accessCount: cached.accessCount ?? 0,
+          createdAt: cached.createdAt || new Date().toISOString(),
+          updatedAt: cached.updatedAt || new Date().toISOString(),
+          hasEmbedding: !!cached.embedding,
+          tags: cached.tags || [],
+        },
+      };
+    }
+
+    let row: any;
+    try {
+      const stmt = ctx.db.prepare(`
+        SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at, tags
+        FROM memory_entries
+        WHERE status = 'active' AND key = ? AND namespace = ?
+        LIMIT 1
+      `);
+      row = stmt.get(key, namespace);
+    } catch {
+      return null;
+    }
+
+    if (!row) return { success: true, found: false };
+
+    try {
+      ctx.db.prepare(
+        `UPDATE memory_entries SET access_count = access_count + 1, last_accessed_at = ? WHERE id = ?`,
+      ).run(Date.now(), row.id);
+    } catch {
+      // Non-fatal
+    }
+
+    let tags: string[] = [];
+    if (row.tags) {
+      try { tags = JSON.parse(row.tags); } catch { /* invalid */ }
+    }
+
+    const entry = {
+      id: String(row.id),
+      key: row.key || String(row.id),
+      namespace: row.namespace || 'default',
+      content: row.content || '',
+      accessCount: (row.access_count ?? 0) + 1,
+      createdAt: row.created_at || new Date().toISOString(),
+      updatedAt: row.updated_at || new Date().toISOString(),
+      hasEmbedding: !!(row.embedding && String(row.embedding).length > 10),
+      tags,
+    };
+
+    await cacheSet(registry, cacheKey, entry);
+
+    return { success: true, found: true, cacheHit: false, entry };
+  });
+}
+
+/**
+ * Soft-delete an entry. Guarded, cache-invalidated, attested.
+ */
+export async function bridgeDeleteEntry(options: {
+  key: string;
+  namespace?: string;
+  dbPath?: string;
+}): Promise<{
+  success: boolean;
+  deleted: boolean;
+  key: string;
+  namespace: string;
+  remainingEntries: number;
+  guarded?: boolean;
+  error?: string;
+} | null> {
+  return withDb(options.dbPath, async (ctx, registry) => {
+    const { key, namespace = 'default' } = options;
+
+    const guardResult = await guardValidate(registry, 'delete', { key, namespace });
+    if (!guardResult.allowed) {
+      return { success: false, deleted: false, key, namespace, remainingEntries: 0, error: `MutationGuard rejected: ${guardResult.reason}` };
+    }
+
+    let changes = 0;
+    try {
+      const result = ctx.db.prepare(`
+        UPDATE memory_entries
+        SET status = 'deleted', updated_at = ?
+        WHERE key = ? AND namespace = ? AND status = 'active'
+      `).run(Date.now(), key, namespace);
+      changes = result?.changes ?? 0;
+    } catch {
+      return null;
+    }
+
+    await cacheInvalidate(registry, makeEntryCacheKey(namespace, key));
+
+    if (changes > 0) {
+      await logAttestation(registry, 'delete', key, { namespace });
+    }
+
+    let remaining = 0;
+    try {
+      const row = ctx.db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active'`).get();
+      remaining = row?.cnt ?? 0;
+    } catch {
+      // Non-fatal
+    }
+
+    if (changes > 0) refreshVectorStatsCache();
+
+    return {
+      success: true,
+      deleted: changes > 0,
+      key,
+      namespace,
+      remainingEntries: remaining,
+      guarded: true,
+    };
+  });
+}

--- a/src/modules/cli/src/memory/memory-bridge.ts
+++ b/src/modules/cli/src/memory/memory-bridge.ts
@@ -1,728 +1,44 @@
 /**
- * Memory Bridge — Routes CLI memory operations through any + MofloDb.
+ * Memory Bridge — Routes CLI memory operations through @moflo/memory + MofloDb.
  *
- * Controllers are moflo-owned and typed (see @moflo/memory), so this bridge
- * calls them directly. System-boundary try/catch remains around sql.js and fs
- * operations. Inner catch { return null } still signals "registry unavailable,
- * caller should fall back to raw sql.js" — that contract is used by
- * memory-initializer.ts.
+ * Top-level facade. Primitives live in `./bridge-core.ts`, the sql.js entries
+ * store lives in `./bridge-entries.ts`. This module holds controller-op
+ * wrappers (hierarchical memory, consolidation, batch, context, session,
+ * routing, feedback, causal, HNSW, pattern, health) and re-exports the
+ * public surface.
  *
  * @module v3/cli/memory-bridge
  */
 
-import * as path from 'path';
-import * as fs from 'fs';
-import * as crypto from 'crypto';
-
-// ===== Project root resolution =====
-// When run via npx, CWD may be node_modules/moflo — walk up to find actual project
-
-let _projectRoot: string | undefined;
-function getProjectRoot(): string {
-  if (_projectRoot) return _projectRoot;
-  if (process.env.CLAUDE_PROJECT_DIR) {
-    _projectRoot = process.env.CLAUDE_PROJECT_DIR;
-    return _projectRoot;
-  }
-  let dir = process.cwd();
-  const root = path.parse(dir).root;
-  while (dir !== root) {
-    if (fs.existsSync(path.join(dir, '.swarm', 'memory.db'))) {
-      _projectRoot = dir;
-      return _projectRoot;
-    }
-    if (fs.existsSync(path.join(dir, 'CLAUDE.md')) && fs.existsSync(path.join(dir, 'package.json'))) {
-      _projectRoot = dir;
-      return _projectRoot;
-    }
-    if (path.basename(dir) === 'node_modules') {
-      dir = path.dirname(dir);
-      continue;
-    }
-    dir = path.dirname(dir);
-  }
-  _projectRoot = process.cwd();
-  return _projectRoot;
-}
-
-// ===== Lazy singleton =====
-
-let registryPromise: Promise<any | null> | null = null;
-// Sync handle populated once the promise resolves. Lets sync callers
-// (refreshVectorStatsCache) read the registry without awaiting.
-let resolvedRegistry: any | null = null;
-const schemaInitialized = new WeakSet<object>();
-
-/**
- * Resolve database path with path traversal protection.
- */
-function getDbPath(customPath?: string): string {
-  const swarmDir = path.resolve(getProjectRoot(), '.swarm');
-  if (!customPath) return path.join(swarmDir, 'memory.db');
-  if (customPath === ':memory:') return ':memory:';
-  const resolved = path.resolve(customPath);
-  const cwd = getProjectRoot();
-  if (!resolved.startsWith(cwd)) {
-    return path.join(swarmDir, 'memory.db');
-  }
-  return resolved;
-}
-
-function generateId(prefix: string): string {
-  return `${prefix}_${Date.now()}_${crypto.randomBytes(8).toString('hex')}`;
-}
-
-/**
- * Lazily initialize the any singleton.
- * Returns null if @moflo/memory cannot be loaded or sql.js fails to open.
- */
-async function getRegistry(dbPath?: string): Promise<any | null> {
-  if (!registryPromise) {
-    registryPromise = (async () => {
-      try {
-        const { ControllerRegistry } = await import('@moflo/memory');
-        const registry = new ControllerRegistry();
-
-        // Suppress noisy init logs
-        const origLog = console.log;
-        console.log = (...args: unknown[]) => {
-          const msg = String(args[0] ?? '');
-          if (msg.includes('Transformers.js') ||
-              msg.includes('[MofloDb]') ||
-              msg.includes('[HNSWLibBackend]') ||
-              msg.includes('MoVector graph')) return;
-          origLog.apply(console, args);
-        };
-
-        try {
-          await registry.initialize({
-            dbPath: dbPath || getDbPath(),
-            dimension: 384,
-            controllers: {
-              learningBridge: false,
-              tieredCache: true,
-              hierarchicalMemory: true,
-              memoryConsolidation: true,
-              memoryGraph: true,
-            },
-          });
-        } finally {
-          console.log = origLog;
-        }
-
-        resolvedRegistry = registry;
-        return registry;
-      } catch {
-        registryPromise = null;
-        return null;
-      }
-    })();
-  }
-
-  return registryPromise;
-}
-
-// ===== BM25 hybrid scoring =====
-
-function bm25Score(
-  queryTerms: string[],
-  docContent: string,
-  avgDocLength: number,
-  docCount: number,
-  termDocFreqs: Map<string, number>,
-): number {
-  const k1 = 1.2;
-  const b = 0.75;
-  const docWords = docContent.toLowerCase().split(/\s+/);
-  const docLength = docWords.length;
-
-  let score = 0;
-  for (const term of queryTerms) {
-    const tf = docWords.filter(w => w === term || w.includes(term)).length;
-    if (tf === 0) continue;
-
-    const df = termDocFreqs.get(term) || 1;
-    const idf = Math.log((docCount - df + 0.5) / (df + 0.5) + 1);
-    const tfNorm = (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (docLength / Math.max(1, avgDocLength))));
-    score += idf * tfNorm;
-  }
-
-  return score;
-}
-
-function computeTermDocFreqs(
-  queryTerms: string[],
-  rows: Array<{ content: string }>,
-): { termDocFreqs: Map<string, number>; avgDocLength: number } {
-  const termDocFreqs = new Map<string, number>();
-  let totalLength = 0;
-
-  for (const row of rows) {
-    const content = (row.content || '').toLowerCase();
-    const words = content.split(/\s+/);
-    totalLength += words.length;
-
-    for (const term of queryTerms) {
-      if (content.includes(term)) {
-        termDocFreqs.set(term, (termDocFreqs.get(term) || 0) + 1);
-      }
-    }
-  }
-
-  return { termDocFreqs, avgDocLength: rows.length > 0 ? totalLength / rows.length : 1 };
-}
-
-// ===== Cache helpers (tieredCache is always enabled) =====
-
-async function cacheGet(registry: any, cacheKey: string): Promise<any | null> {
-  const cache = registry.get('tieredCache');
-  if (!cache) return null;
-  return (await cache.get(cacheKey)) ?? null;
-}
-
-async function cacheSet(registry: any, cacheKey: string, value: any): Promise<void> {
-  const cache = registry.get('tieredCache');
-  if (!cache) return;
-  await cache.set(cacheKey, value);
-}
-
-async function cacheInvalidate(registry: any, cacheKey: string): Promise<void> {
-  const cache = registry.get('tieredCache');
-  if (!cache) return;
-  cache.delete(cacheKey);
-}
-
-// ===== MutationGuard (always enabled) =====
-
-/**
- * Validate a mutation through MutationGuard. Returns allowed=true by default;
- * returns allowed=false only if the guard explicitly rejects.
- */
-async function guardValidate(
-  registry: any,
-  operation: string,
-  params: Record<string, unknown>,
-): Promise<{ allowed: boolean; reason?: string }> {
-  const guard = registry.get('mutationGuard');
-  if (!guard) return { allowed: true };
-  const result = guard.validate({ operation, params, timestamp: Date.now() });
-  return { allowed: result?.allowed === true, reason: result?.reason };
-}
-
-// ===== AttestationLog helpers =====
-
-/**
- * Log an audit entry for a write operation. Observability only —
- * failures are non-fatal.
- */
-async function logAttestation(
-  registry: any,
-  operation: string,
-  entryId: string,
-  metadata?: Record<string, unknown>,
-): Promise<void> {
-  const attestation = registry.get('attestationLog');
-  if (!attestation) return;
-  try {
-    attestation.record({ operation, entryId, timestamp: Date.now(), ...metadata });
-  } catch {
-    // Non-fatal — attestation is observability, not correctness
-  }
-}
-
-/**
- * Get the MofloDb database handle and ensure memory_entries table exists.
- * Schema DDL runs once per database handle (tracked in schemaInitialized).
- */
-function getDb(registry: any): { db: any; mofloDb: any } | null {
-  const mofloDb = registry.getMofloDb();
-  if (!mofloDb?.database) return null;
-
-  const db = mofloDb.database;
-
-  if (!schemaInitialized.has(db)) {
-    try {
-      db.exec(`CREATE TABLE IF NOT EXISTS memory_entries (
-        id TEXT PRIMARY KEY,
-        key TEXT NOT NULL,
-        namespace TEXT DEFAULT 'default',
-        content TEXT NOT NULL,
-        type TEXT DEFAULT 'semantic',
-        embedding TEXT,
-        embedding_model TEXT DEFAULT 'local',
-        embedding_dimensions INTEGER,
-        tags TEXT,
-        metadata TEXT,
-        owner_id TEXT,
-        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
-        updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
-        expires_at INTEGER,
-        last_accessed_at INTEGER,
-        access_count INTEGER DEFAULT 0,
-        status TEXT DEFAULT 'active',
-        UNIQUE(namespace, key)
-      )`);
-      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_ns ON memory_entries(namespace)`);
-      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_key ON memory_entries(key)`);
-      db.exec(`CREATE INDEX IF NOT EXISTS idx_bridge_status ON memory_entries(status)`);
-      schemaInitialized.add(db);
-    } catch {
-      // Table already exists or db is read-only — that's fine
-    }
-  }
-
-  return { db, mofloDb };
-}
-
-// ===== Shared wrapper =====
-
-/**
- * Common bridge-function prelude: resolve registry + db, run fn, return null
- * on any unexpected failure so the caller falls back to raw sql.js.
- */
-async function withDb<T>(
-  dbPath: string | undefined,
-  fn: (ctx: { db: any; mofloDb: any }, registry: any) => Promise<T | null>,
-): Promise<T | null> {
-  const registry = await getRegistry(dbPath);
-  if (!registry) return null;
-  const ctx = getDb(registry);
-  if (!ctx) return null;
-  try {
-    return await fn(ctx, registry);
-  } catch {
-    return null;
-  }
-}
-
-// ===== Bridge functions — match memory-initializer.ts signatures =====
-
-/**
- * Store an entry. Returns null to signal fallback to sql.js.
- */
-export async function bridgeStoreEntry(options: {
-  key: string;
-  value: string;
-  namespace?: string;
-  generateEmbeddingFlag?: boolean;
-  tags?: string[];
-  ttl?: number;
-  dbPath?: string;
-  upsert?: boolean;
-}): Promise<{
-  success: boolean;
-  id: string;
-  embedding?: { dimensions: number; model: string };
-  guarded?: boolean;
-  cached?: boolean;
-  attested?: boolean;
-  error?: string;
-} | null> {
-  return withDb(options.dbPath, async (ctx, registry) => {
-    const { key, value, namespace = 'default', tags = [], ttl } = options;
-    const id = generateId('entry');
-    const now = Date.now();
-
-    const guardResult = await guardValidate(registry, 'store', { key, namespace, size: value.length });
-    if (!guardResult.allowed) {
-      return { success: false, id, error: `MutationGuard rejected: ${guardResult.reason}` };
-    }
-
-    let embeddingJson: string | null = null;
-    let dimensions = 0;
-    let model = 'local';
-
-    if (options.generateEmbeddingFlag !== false && value.length > 0) {
-      try {
-        const embedder = ctx.mofloDb.embedder;
-        if (embedder) {
-          const emb = await embedder.embed(value);
-          if (emb) {
-            embeddingJson = JSON.stringify(Array.from(emb));
-            dimensions = emb.length;
-            model = 'Xenova/all-MiniLM-L6-v2';
-          }
-        }
-      } catch {
-        // Embedding failed — store without
-      }
-    }
-
-    const insertSql = options.upsert
-      ? `INSERT OR REPLACE INTO memory_entries (
-          id, key, namespace, content, type,
-          embedding, embedding_dimensions, embedding_model,
-          tags, metadata, created_at, updated_at, expires_at, status
-        ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`
-      : `INSERT INTO memory_entries (
-          id, key, namespace, content, type,
-          embedding, embedding_dimensions, embedding_model,
-          tags, metadata, created_at, updated_at, expires_at, status
-        ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`;
-
-    const stmt = ctx.db.prepare(insertSql);
-    stmt.run(
-      id, key, namespace, value,
-      embeddingJson, dimensions || null, model,
-      tags.length > 0 ? JSON.stringify(tags) : null,
-      '{}',
-      now, now,
-      ttl ? now + (ttl * 1000) : null,
-    );
-
-    const safeNs = String(namespace).replace(/:/g, '_');
-    const safeKey = String(key).replace(/:/g, '_');
-    const cacheKey = `entry:${safeNs}:${safeKey}`;
-    await cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson });
-
-    await logAttestation(registry, 'store', id, { key, namespace, hasEmbedding: !!embeddingJson });
-
-    if (embeddingJson) refreshVectorStatsCache();
-
-    return {
-      success: true,
-      id,
-      embedding: embeddingJson ? { dimensions, model } : undefined,
-      guarded: true,
-      cached: true,
-      attested: true,
-    };
-  });
-}
-
-/**
- * Search entries with hybrid BM25 + cosine scoring.
- */
-export async function bridgeSearchEntries(options: {
-  query: string;
-  namespace?: string;
-  limit?: number;
-  threshold?: number;
-  dbPath?: string;
-}): Promise<{
-  success: boolean;
-  results: {
-    id: string;
-    key: string;
-    content: string;
-    score: number;
-    namespace: string;
-    provenance?: string;
-  }[];
-  searchTime: number;
-  searchMethod?: string;
-  error?: string;
-} | null> {
-  return withDb(options.dbPath, async (ctx) => {
-    const { query: queryStr, namespace = 'default', limit = 10, threshold = 0.3 } = options;
-    const startTime = Date.now();
-
-    let queryEmbedding: number[] | null = null;
-    try {
-      const embedder = ctx.mofloDb.embedder;
-      if (embedder) {
-        const emb = await embedder.embed(queryStr);
-        queryEmbedding = Array.from(emb);
-      }
-    } catch {
-      // Fall back to keyword search
-    }
-
-    const nsFilter = namespace !== 'all' ? `AND namespace = ?` : '';
-
-    let rows: any[];
-    try {
-      const stmt = ctx.db.prepare(`
-        SELECT id, key, namespace, content, embedding
-        FROM memory_entries
-        WHERE status = 'active' ${nsFilter}
-        LIMIT 1000
-      `);
-      rows = namespace !== 'all' ? stmt.all(namespace) : stmt.all();
-    } catch {
-      return null;
-    }
-
-    const queryTerms = queryStr.toLowerCase().split(/\s+/).filter(t => t.length > 1);
-    const { termDocFreqs, avgDocLength } = computeTermDocFreqs(queryTerms, rows);
-    const docCount = rows.length;
-
-    const results: { id: string; key: string; content: string; score: number; namespace: string; provenance?: string }[] = [];
-
-    for (const row of rows) {
-      let semanticScore = 0;
-      let bm25ScoreVal = 0;
-
-      if (queryEmbedding && row.embedding) {
-        try {
-          const embedding = JSON.parse(row.embedding) as number[];
-          semanticScore = cosineSim(queryEmbedding, embedding);
-        } catch {
-          // Invalid embedding
-        }
-      }
-
-      if (queryTerms.length > 0 && row.content) {
-        bm25ScoreVal = bm25Score(queryTerms, row.content, avgDocLength, docCount, termDocFreqs);
-        bm25ScoreVal = Math.min(bm25ScoreVal / 10, 1.0);
-      }
-
-      const usedSemantic = queryEmbedding != null;
-      const score = usedSemantic ? 0.7 * semanticScore + 0.3 * bm25ScoreVal : bm25ScoreVal;
-
-      if (score >= threshold) {
-        const provenance = usedSemantic
-          ? `semantic:${semanticScore.toFixed(3)}+bm25:${bm25ScoreVal.toFixed(3)}`
-          : `bm25:${bm25ScoreVal.toFixed(3)}`;
-
-        results.push({
-          id: String(row.id).substring(0, 12),
-          key: row.key || String(row.id).substring(0, 15),
-          content: (row.content || '').substring(0, 60) + ((row.content || '').length > 60 ? '...' : ''),
-          score,
-          namespace: row.namespace || 'default',
-          provenance,
-        });
-      }
-    }
-
-    results.sort((a, b) => b.score - a.score);
-
-    return {
-      success: true,
-      results: results.slice(0, limit),
-      searchTime: Date.now() - startTime,
-      searchMethod: queryEmbedding ? 'hybrid-bm25-semantic' : 'bm25-only',
-    };
-  });
-}
-
-export async function bridgeListEntries(options: {
-  namespace?: string;
-  limit?: number;
-  offset?: number;
-  dbPath?: string;
-}): Promise<{
-  success: boolean;
-  entries: {
-    id: string;
-    key: string;
-    namespace: string;
-    size: number;
-    accessCount: number;
-    createdAt: string;
-    updatedAt: string;
-    hasEmbedding: boolean;
-  }[];
-  total: number;
-  error?: string;
-} | null> {
-  return withDb(options.dbPath, async (ctx) => {
-    const { namespace, limit = 20, offset = 0 } = options;
-    const nsFilter = namespace ? `AND namespace = ?` : '';
-    const nsParams = namespace ? [namespace] : [];
-
-    let total = 0;
-    try {
-      const countStmt = ctx.db.prepare(
-        `SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active' ${nsFilter}`,
-      );
-      const countRow = countStmt.get(...nsParams);
-      total = countRow?.cnt ?? 0;
-    } catch {
-      return null;
-    }
-
-    const entries: any[] = [];
-    try {
-      const stmt = ctx.db.prepare(`
-        SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at
-        FROM memory_entries
-        WHERE status = 'active' ${nsFilter}
-        ORDER BY updated_at DESC
-        LIMIT ? OFFSET ?
-      `);
-      const rows = stmt.all(...nsParams, limit, offset);
-      for (const row of rows) {
-        entries.push({
-          id: String(row.id).substring(0, 20),
-          key: row.key || String(row.id).substring(0, 15),
-          namespace: row.namespace || 'default',
-          size: (row.content || '').length,
-          accessCount: row.access_count ?? 0,
-          createdAt: row.created_at || new Date().toISOString(),
-          updatedAt: row.updated_at || new Date().toISOString(),
-          hasEmbedding: !!(row.embedding && String(row.embedding).length > 10),
-        });
-      }
-    } catch {
-      return null;
-    }
-
-    return { success: true, entries, total };
-  });
-}
-
-/**
- * Get a specific entry via TieredCache → DB.
- */
-export async function bridgeGetEntry(options: {
-  key: string;
-  namespace?: string;
-  dbPath?: string;
-}): Promise<{
-  success: boolean;
-  found: boolean;
-  entry?: {
-    id: string;
-    key: string;
-    namespace: string;
-    content: string;
-    accessCount: number;
-    createdAt: string;
-    updatedAt: string;
-    hasEmbedding: boolean;
-    tags: string[];
-  };
-  cacheHit?: boolean;
-  error?: string;
-} | null> {
-  return withDb(options.dbPath, async (ctx, registry) => {
-    const { key, namespace = 'default' } = options;
-
-    const safeNs = String(namespace).replace(/:/g, '_');
-    const safeKey = String(key).replace(/:/g, '_');
-    const cacheKey = `entry:${safeNs}:${safeKey}`;
-    const cached = await cacheGet(registry, cacheKey);
-    if (cached && cached.content) {
-      return {
-        success: true,
-        found: true,
-        cacheHit: true,
-        entry: {
-          id: String(cached.id || ''),
-          key: cached.key || key,
-          namespace: cached.namespace || namespace,
-          content: cached.content || '',
-          accessCount: cached.accessCount ?? 0,
-          createdAt: cached.createdAt || new Date().toISOString(),
-          updatedAt: cached.updatedAt || new Date().toISOString(),
-          hasEmbedding: !!cached.embedding,
-          tags: cached.tags || [],
-        },
-      };
-    }
-
-    let row: any;
-    try {
-      const stmt = ctx.db.prepare(`
-        SELECT id, key, namespace, content, embedding, access_count, created_at, updated_at, tags
-        FROM memory_entries
-        WHERE status = 'active' AND key = ? AND namespace = ?
-        LIMIT 1
-      `);
-      row = stmt.get(key, namespace);
-    } catch {
-      return null;
-    }
-
-    if (!row) return { success: true, found: false };
-
-    try {
-      ctx.db.prepare(
-        `UPDATE memory_entries SET access_count = access_count + 1, last_accessed_at = ? WHERE id = ?`,
-      ).run(Date.now(), row.id);
-    } catch {
-      // Non-fatal
-    }
-
-    let tags: string[] = [];
-    if (row.tags) {
-      try { tags = JSON.parse(row.tags); } catch { /* invalid */ }
-    }
-
-    const entry = {
-      id: String(row.id),
-      key: row.key || String(row.id),
-      namespace: row.namespace || 'default',
-      content: row.content || '',
-      accessCount: (row.access_count ?? 0) + 1,
-      createdAt: row.created_at || new Date().toISOString(),
-      updatedAt: row.updated_at || new Date().toISOString(),
-      hasEmbedding: !!(row.embedding && String(row.embedding).length > 10),
-      tags,
-    };
-
-    await cacheSet(registry, cacheKey, entry);
-
-    return { success: true, found: true, cacheHit: false, entry };
-  });
-}
-
-/**
- * Soft-delete an entry. Guarded, cache-invalidated, attested.
- */
-export async function bridgeDeleteEntry(options: {
-  key: string;
-  namespace?: string;
-  dbPath?: string;
-}): Promise<{
-  success: boolean;
-  deleted: boolean;
-  key: string;
-  namespace: string;
-  remainingEntries: number;
-  guarded?: boolean;
-  error?: string;
-} | null> {
-  return withDb(options.dbPath, async (ctx, registry) => {
-    const { key, namespace = 'default' } = options;
-
-    const guardResult = await guardValidate(registry, 'delete', { key, namespace });
-    if (!guardResult.allowed) {
-      return { success: false, deleted: false, key, namespace, remainingEntries: 0, error: `MutationGuard rejected: ${guardResult.reason}` };
-    }
-
-    let changes = 0;
-    try {
-      const result = ctx.db.prepare(`
-        UPDATE memory_entries
-        SET status = 'deleted', updated_at = ?
-        WHERE key = ? AND namespace = ? AND status = 'active'
-      `).run(Date.now(), key, namespace);
-      changes = result?.changes ?? 0;
-    } catch {
-      return null;
-    }
-
-    const safeNs = String(namespace).replace(/:/g, '_');
-    const safeKey = String(key).replace(/:/g, '_');
-    await cacheInvalidate(registry, `entry:${safeNs}:${safeKey}`);
-
-    if (changes > 0) {
-      await logAttestation(registry, 'delete', key, { namespace });
-    }
-
-    let remaining = 0;
-    try {
-      const row = ctx.db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active'`).get();
-      remaining = row?.cnt ?? 0;
-    } catch {
-      // Non-fatal
-    }
-
-    if (changes > 0) refreshVectorStatsCache();
-
-    return {
-      success: true,
-      deleted: changes > 0,
-      key,
-      namespace,
-      remainingEntries: remaining,
-      guarded: true,
-    };
-  });
-}
+import {
+  cosineSim,
+  generateId,
+  getRegistry,
+  withDb,
+} from './bridge-core.js';
+import {
+  bridgeSearchEntries,
+  bridgeStoreEntry,
+} from './bridge-entries.js';
+
+// ===== Re-exports: primitives =====
+
+export {
+  getControllerRegistry,
+  isBridgeAvailable,
+  refreshVectorStatsCache,
+  shutdownBridge,
+} from './bridge-core.js';
+
+// ===== Re-exports: entries store =====
+
+export {
+  bridgeDeleteEntry,
+  bridgeGetEntry,
+  bridgeListEntries,
+  bridgeSearchEntries,
+  bridgeStoreEntry,
+} from './bridge-entries.js';
 
 // ===== Embedding bridge =====
 
@@ -906,29 +222,6 @@ export async function bridgeListControllers(
 ): Promise<Array<{ name: string; enabled: boolean; level: number }> | null> {
   const registry = await getRegistry(dbPath);
   return registry ? registry.listControllers() : null;
-}
-
-export async function isBridgeAvailable(dbPath?: string): Promise<boolean> {
-  const registry = await getRegistry(dbPath);
-  return registry !== null;
-}
-
-export async function getControllerRegistry(dbPath?: string): Promise<any | null> {
-  return getRegistry(dbPath);
-}
-
-export async function shutdownBridge(): Promise<void> {
-  if (!registryPromise) return;
-  const registry = await registryPromise;
-  registryPromise = null;
-  resolvedRegistry = null;
-  if (registry) {
-    try {
-      await registry.shutdown();
-    } catch {
-      // Best-effort
-    }
-  }
 }
 
 // ===== Pattern operations =====
@@ -1232,11 +525,6 @@ export async function bridgeHealthCheck(
 }
 
 // ===== Hierarchical memory, consolidation, batch, context, semantic route =====
-//
-// HierarchicalMemory has two shapes: the real controller (async store returning
-// id, has `getStats`+`promote`) and the in-memory stub from any
-// (sync store, no promote). We branch on `typeof promote === 'function'` to
-// pick the right call shape — this is polymorphism, not duck-typing.
 
 /**
  * Store to hierarchical memory with tier (working, episodic, semantic).
@@ -1253,16 +541,11 @@ export async function bridgeHierarchicalStore(params: {
     const hm = registry.get('hierarchicalMemory');
     if (!hm) return { success: false, error: 'HierarchicalMemory not available' };
     const tier = params.tier || 'working';
-
-    if (typeof hm.promote === 'function') {
-      const id = await hm.store(params.value, params.importance || 0.5, tier, {
-        metadata: { key: params.key },
-        tags: [params.key],
-      });
-      return { success: true, id, key: params.key, tier };
-    }
-    hm.store(params.key, params.value, tier);
-    return { success: true, key: params.key, tier };
+    const id = await hm.store(params.value, params.importance || 0.5, tier, {
+      metadata: { key: params.key },
+      tags: [params.key],
+    });
+    return { success: true, id, key: params.key, tier };
   } catch (e: any) { return { success: false, error: e.message }; }
 }
 
@@ -1276,19 +559,10 @@ export async function bridgeHierarchicalRecall(params: {
   try {
     const hm = registry.get('hierarchicalMemory');
     if (!hm) return { results: [], error: 'HierarchicalMemory not available' };
-
-    if (typeof hm.promote === 'function') {
-      const memoryQuery: any = { query: params.query, k: params.topK || 5 };
-      if (params.tier) memoryQuery.tier = params.tier;
-      const results = await hm.recall(memoryQuery);
-      return { results: results || [], controller: 'hierarchicalMemory' };
-    }
-
-    const results = hm.recall(params.query, params.topK || 5);
-    const filtered = params.tier
-      ? results.filter((r: any) => r.tier === params.tier)
-      : results;
-    return { results: filtered, controller: 'hierarchicalMemory' };
+    const memoryQuery: any = { query: params.query, k: params.topK || 5 };
+    if (params.tier) memoryQuery.tier = params.tier;
+    const results = await hm.recall(memoryQuery);
+    return { results: results || [], controller: 'hierarchicalMemory' };
   } catch (e: any) { return { results: [], error: e.message }; }
 }
 
@@ -1351,9 +625,7 @@ export async function bridgeContextSynthesize(params: { query: string; maxEntrie
     const hm = registry.get('hierarchicalMemory');
     let memories: any[] = [];
     if (hm) {
-      const recalled = typeof hm.promote === 'function'
-        ? await hm.recall({ query: params.query, k: params.maxEntries || 10 })
-        : hm.recall(params.query, params.maxEntries || 10);
+      const recalled = await hm.recall({ query: params.query, k: params.maxEntries || 10 });
       memories = (recalled || []).map((r: any) => ({
         content: r.value || r.content || '',
         key: r.key || r.id || '',
@@ -1375,80 +647,4 @@ export async function bridgeSemanticRoute(params: { input: string }): Promise<an
     const result = await router.route(params.input);
     return { route: result, controller: 'semanticRouter' };
   } catch (e: any) { return { route: null, error: e.message }; }
-}
-
-// ===== Utility =====
-
-function cosineSim(a: number[], b: number[]): number {
-  if (!a || !b || a.length === 0 || b.length === 0) return 0;
-  const len = Math.min(a.length, b.length);
-  let dot = 0, normA = 0, normB = 0;
-  for (let i = 0; i < len; i++) {
-    const ai = a[i], bi = b[i];
-    dot += ai * bi;
-    normA += ai * ai;
-    normB += bi * bi;
-  }
-  const mag = Math.sqrt(normA * normB);
-  return mag === 0 ? 0 : dot / mag;
-}
-
-// ===== Vector stats cache for statusline =====
-
-/**
- * Write vector-stats.json cache file used by the statusline.
- * No-ops if registry isn't loaded.
- */
-export function refreshVectorStatsCache(dbPathOverride?: string): void {
-  // Synchronous — only runs when the registry is already resolved.
-  const registry = resolvedRegistry;
-  if (!registry) return;
-
-  try {
-    const ctx = getDb(registry);
-    if (!ctx?.db) return;
-
-    let vectorCount = 0;
-    let namespaces = 0;
-    let dbSizeKB = 0;
-    let hasHnsw = false;
-
-    try {
-      const countRow = ctx.db.prepare(
-        'SELECT COUNT(*) as c FROM memory_entries WHERE status = ? AND embedding IS NOT NULL',
-      ).get('active') as { c: number } | undefined;
-      vectorCount = countRow?.c ?? 0;
-
-      const nsRow = ctx.db.prepare(
-        'SELECT COUNT(DISTINCT namespace) as n FROM memory_entries WHERE status = ?',
-      ).get('active') as { n: number } | undefined;
-      namespaces = nsRow?.n ?? 0;
-    } catch {
-      // Table may not exist yet
-    }
-
-    const dbFile = dbPathOverride || getDbPath();
-    try {
-      const stat = fs.statSync(dbFile);
-      dbSizeKB = Math.floor(stat.size / 1024);
-    } catch { /* file may not exist */ }
-
-    const root = getProjectRoot();
-    const hnswPaths = [
-      path.join(root, '.swarm', 'hnsw.index'),
-      path.join(root, '.claude-flow', 'hnsw.index'),
-    ];
-    for (const p of hnswPaths) {
-      try { fs.statSync(p); hasHnsw = true; break; } catch { /* nope */ }
-    }
-
-    const cacheDir = path.join(root, '.claude-flow');
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(cacheDir, 'vector-stats.json'),
-      JSON.stringify({ vectorCount, dbSizeKB, namespaces, hasHnsw, updatedAt: Date.now() }),
-    );
-  } catch {
-    // Non-fatal — statusline falls back to file size estimate
-  }
 }

--- a/src/modules/memory/src/controllers/hierarchical-memory.test.ts
+++ b/src/modules/memory/src/controllers/hierarchical-memory.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import initSqlJs, { Database } from 'sql.js';
-import { HierarchicalMemory } from './hierarchical-memory.js';
+import { HierarchicalMemory, HierarchicalMemoryStub, hierarchicalMemorySpec } from './hierarchical-memory.js';
 
 let SQL: any;
 
@@ -112,5 +112,75 @@ describe('HierarchicalMemory', () => {
     const list = hm.listTier('working');
     expect(list[0].content).toBe('first');
     expect((list[0] as any).embedding).toBeUndefined();
+  });
+});
+
+describe('HierarchicalMemoryStub', () => {
+  let stub: HierarchicalMemoryStub;
+
+  beforeEach(() => {
+    stub = new HierarchicalMemoryStub();
+  });
+
+  it('store returns ids and counts per tier', async () => {
+    const id = await stub.store('hello', 0.5, 'working');
+    expect(id).toMatch(/^hm-stub-/);
+    expect(stub.count('working')).toBe(1);
+    expect(stub.count()).toBe(1);
+  });
+
+  it('recall honours tier filter and object-form query', async () => {
+    await stub.store('working-item', 0.5, 'working');
+    await stub.store('semantic-item', 0.5, 'semantic');
+    const working = await stub.recall({ query: 'item', tier: 'working', k: 5 });
+    expect(working.every((r) => r.tier === 'working')).toBe(true);
+  });
+
+  it('recall supports legacy (string, number) signature', async () => {
+    await stub.store('legacy call form', 0.5);
+    const hits = await stub.recall('legacy' as any, 3 as any);
+    expect(hits.length).toBeGreaterThan(0);
+  });
+
+  it('promote moves item between tiers', async () => {
+    const id = await stub.store('migratory', 0.5, 'working');
+    expect(await stub.promote(id, 'working', 'episodic')).toBe(true);
+    expect(stub.count('working')).toBe(0);
+    expect(stub.count('episodic')).toBe(1);
+  });
+
+  it('promote returns false for unknown id', async () => {
+    expect(await stub.promote('missing', 'working', 'semantic')).toBe(false);
+  });
+
+  it('forget removes by id', async () => {
+    const id = await stub.store('ephemeral', 0.5);
+    expect(await stub.forget(id)).toBe(true);
+    expect(await stub.forget('missing')).toBe(false);
+    expect(stub.count()).toBe(0);
+  });
+
+  it('getStats returns per-tier counts + total', async () => {
+    await stub.store('a', 0.5, 'working');
+    await stub.store('b', 0.5, 'episodic');
+    await stub.store('c', 0.5, 'semantic');
+    const stats = stub.getStats();
+    expect(stats.working).toBe(1);
+    expect(stats.episodic).toBe(1);
+    expect(stats.semantic).toBe(1);
+    expect(stats.total).toBe(3);
+  });
+
+  it('hierarchicalMemorySpec returns stub when mofloDb lacks database', async () => {
+    const result = await hierarchicalMemorySpec.create({
+      mofloDb: null,
+      embedder: undefined,
+      registry: { get: () => null, isEnabled: () => false },
+      config: {},
+      backend: null,
+    } as any);
+    expect(result).toBeInstanceOf(HierarchicalMemoryStub);
+    expect(typeof (result as any).promote).toBe('function');
+    expect(typeof (result as any).getStats).toBe('function');
   });
 });

--- a/src/modules/memory/src/controllers/hierarchical-memory.ts
+++ b/src/modules/memory/src/controllers/hierarchical-memory.ts
@@ -16,8 +16,9 @@
  *   getStats()                                          → Record<tier, n>
  *   promote(id, fromTier, toTier)                       → boolean
  *
- * Detection: memory-bridge treats a controller as the "real" impl when
- * both `getStats` and `promote` are functions on it.
+ * `HierarchicalMemoryStub` shadows the same public shape so callers can
+ * invoke the API unconditionally without duck-type probes when sql.js
+ * is unavailable.
  */
 
 import {
@@ -361,46 +362,132 @@ function rowToItem(r: Record<string, any>): InternalRow {
 }
 
 /**
- * Lightweight in-memory tiered store used when the real HierarchicalMemory
- * can't bind to a sql.js handle. Enforces per-tier size limits so the
- * stub doesn't grow unbounded.
+ * In-memory fallback used when sql.js is unavailable. Mirrors the public
+ * surface of {@link HierarchicalMemory} so callers can invoke the API
+ * unconditionally — no duck-type probes.
  */
-function createTieredMemoryStub() {
-  const MAX_PER_TIER = 5000;
-  const tiers: Record<string, Map<string, { value: string; ts: number }>> = {
-    working: new Map(),
-    episodic: new Map(),
-    semantic: new Map(),
-  };
-  return {
-    store(key: string, value: string, tier = 'working') {
-      const t = tiers[tier] || tiers.working;
-      if (t.size >= MAX_PER_TIER) {
-        const oldest = t.keys().next().value;
-        if (oldest !== undefined) t.delete(oldest);
-      }
-      t.set(key, { value: value.substring(0, 100_000), ts: Date.now() });
-    },
-    recall(query: string, topK = 5) {
-      const safeTopK = Math.min(Math.max(1, topK), 100);
-      const q = query.toLowerCase().substring(0, 10_000);
-      const results: Array<{ key: string; value: string; tier: string; ts: number }> = [];
-      for (const [tierName, map] of Object.entries(tiers)) {
-        for (const [key, entry] of map) {
-          if (key.toLowerCase().includes(q) || entry.value.toLowerCase().includes(q)) {
-            results.push({ key, value: entry.value, tier: tierName, ts: entry.ts });
-            if (results.length >= safeTopK * 3) break;
-          }
+export class HierarchicalMemoryStub {
+  private static readonly MAX_PER_TIER = 5000;
+  private readonly tiers = new Map<Tier, Map<string, InternalStubRow>>();
+
+  constructor() {
+    for (const tier of TIERS) this.tiers.set(tier, new Map());
+  }
+
+  async store(
+    content: string,
+    importance: number = 0.5,
+    tier: Tier | string = 'working',
+    options: HierarchicalStoreOptions = {},
+  ): Promise<string> {
+    const tierName = coerceTier(tier);
+    const id = generateId('hm-stub');
+    const keyMeta = typeof options.metadata?.key === 'string' ? (options.metadata.key as string) : undefined;
+    const key = options.key ?? keyMeta ?? id;
+    const row: InternalStubRow = {
+      id,
+      key,
+      tier: tierName,
+      content: String(content ?? '').substring(0, 100_000),
+      importance: clamp(importance, 0, 1),
+      metadata: options.metadata ?? {},
+      tags: options.tags ?? [],
+      timestamp: Date.now(),
+      accessCount: 0,
+    };
+    const bucket = this.tiers.get(tierName)!;
+    if (bucket.size >= HierarchicalMemoryStub.MAX_PER_TIER) {
+      const oldest = bucket.keys().next().value;
+      if (oldest !== undefined) bucket.delete(oldest);
+    }
+    bucket.set(id, row);
+    return id;
+  }
+
+  async recall(query: MemoryQuery | string, legacyK?: number): Promise<MemoryItem[]> {
+    if (typeof query === 'string') {
+      return this.recall({ query, k: typeof legacyK === 'number' ? legacyK : 10 });
+    }
+    if (!query || typeof query.query !== 'string') return [];
+    const k = Math.max(1, Math.min(query.k ?? 10, 1000));
+    const tierFilter = query.tier ? coerceTier(query.tier) : null;
+    const q = query.query.toLowerCase().substring(0, 10_000);
+
+    const matches: MemoryItem[] = [];
+    for (const [tierName, bucket] of this.tiers) {
+      if (tierFilter && tierName !== tierFilter) continue;
+      for (const row of bucket.values()) {
+        if (row.key.toLowerCase().includes(q) || row.content.toLowerCase().includes(q)) {
+          row.accessCount += 1;
+          matches.push({
+            id: row.id,
+            key: row.key,
+            tier: row.tier,
+            content: row.content,
+            importance: row.importance,
+            metadata: row.metadata,
+            tags: row.tags,
+            score: 1,
+            timestamp: row.timestamp,
+            accessCount: row.accessCount,
+          });
         }
       }
-      return results.sort((a, b) => b.ts - a.ts).slice(0, safeTopK);
-    },
-    getTierStats() {
-      return Object.fromEntries(
-        Object.entries(tiers).map(([name, map]) => [name, map.size]),
-      );
-    },
-  };
+    }
+    return matches.sort((a, b) => b.timestamp - a.timestamp).slice(0, k);
+  }
+
+  async promote(id: string, _fromTier: Tier | string, toTier: Tier | string): Promise<boolean> {
+    const target = coerceTier(toTier);
+    for (const [tierName, bucket] of this.tiers) {
+      const row = bucket.get(id);
+      if (!row) continue;
+      if (tierName === target) return true;
+      bucket.delete(id);
+      row.tier = target;
+      this.tiers.get(target)!.set(id, row);
+      return true;
+    }
+    return false;
+  }
+
+  async forget(id: string): Promise<boolean> {
+    for (const bucket of this.tiers.values()) {
+      if (bucket.delete(id)) return true;
+    }
+    return false;
+  }
+
+  getStats(): Record<string, number> {
+    const stats: Record<string, number> = {};
+    let total = 0;
+    for (const tier of TIERS) {
+      const n = this.tiers.get(tier)?.size ?? 0;
+      stats[tier] = n;
+      total += n;
+    }
+    stats.total = total;
+    return stats;
+  }
+
+  count(tier?: Tier | string): number {
+    if (tier) return this.tiers.get(coerceTier(tier))?.size ?? 0;
+    let total = 0;
+    for (const bucket of this.tiers.values()) total += bucket.size;
+    return total;
+  }
+}
+
+interface InternalStubRow {
+  id: string;
+  key: string;
+  tier: Tier;
+  content: string;
+  importance: number;
+  metadata: Record<string, unknown>;
+  tags: string[];
+  timestamp: number;
+  accessCount: number;
 }
 
 export const hierarchicalMemorySpec: ControllerSpec = {
@@ -408,7 +495,7 @@ export const hierarchicalMemorySpec: ControllerSpec = {
   level: 1,
   enabledByDefault: true,
   create: async ({ mofloDb, embedder }) => {
-    if (!mofloDb?.database) return createTieredMemoryStub();
+    if (!mofloDb?.database) return new HierarchicalMemoryStub();
     const hm = new HierarchicalMemory(mofloDb.database, { embedder });
     await hm.initializeDatabase();
     return hm;


### PR DESCRIPTION
## Summary
- Split `memory-bridge.ts` (1454 → **650 lines**) into `bridge-core.ts` (primitives) and `bridge-entries.ts` (sql.js `memory_entries` CRUD); `memory-bridge.ts` becomes a thin facade + controller-op wrapper.
- Upgraded `createTieredMemoryStub()` to a full `HierarchicalMemoryStub` class that mirrors `HierarchicalMemory`'s async surface, so the bridge no longer needs `typeof hm.promote === 'function'` duck-typing (4 sites eliminated).
- Fixed a subpath-traversal collision in `getDbPath` (`startsWith` → `path.relative`).

## Changes
- `src/modules/cli/src/memory/bridge-core.ts` **(new, 278 lines)** — registry singleton, `getDb`/`withDb`, `generateId`, `cosineSim`, `refreshVectorStatsCache`, `MEMORY_ENTRIES_DDL` (now includes the `CHECK(type IN …)` / `CHECK(status IN …)` constraints from `MEMORY_SCHEMA_V3` to prevent schema drift).
- `src/modules/cli/src/memory/bridge-entries.ts` **(new, 530 lines)** — `bridgeStoreEntry`/`SearchEntries`/`ListEntries`/`GetEntry`/`DeleteEntry` + BM25 + cache/guard/attestation helpers + `makeEntryCacheKey` (deduped 3 inline `entry:${ns}:${key}` sanitizations).
- `src/modules/cli/src/memory/memory-bridge.ts` — now 650 lines; re-exports from the two new files and keeps controller-op wrappers (hierarchical, consolidate, batch, context, session, semantic route, feedback, causal, HNSW, pattern, health).
- `src/modules/memory/src/controllers/hierarchical-memory.ts` — `createTieredMemoryStub()` → `HierarchicalMemoryStub` class with `async store/recall/promote/forget/getStats/count`.
- `hierarchical-memory.test.ts` — 8 new stub-parity tests (signature, tier filter, promote, forget, getStats, spec factory returns stub when sql.js unavailable).

## Acceptance
- [x] `memory-bridge.ts` **under 1000 lines** (650)
- [x] `typeof … === 'function'` on controller instances: **zero** hits
- [x] Try-blocks in `memory-bridge.ts`: 35 → **14** (stretch <30)
- [x] Public exports preserved (re-exports from bridge-entries keep `memory-initializer.ts`, `agentdb-tools.ts`, `aidefence-agentdb-store.ts` imports stable)

## Testing
- [x] `src/modules/memory/**` — **497 tests** pass (incl. 20 hierarchical-memory tests with stub parity)
- [x] `src/modules/cli/**` — **2152 tests** pass (incl. `aidefence-agentdb-store`, `memory-initializer`, `mcp-tools-deep`, `memory-movector-deep`)
- [x] `tsc --noEmit` clean in `@moflo/cli`
- [x] `/simplify` pass — fixed schema drift (added missing `CHECK` constraints), subpath-traversal bug, cache-key dedupe, narrative comment cleanup

Pre-existing sql-wasm.wasm unhandled rejection in `controller-registry.test.ts` was verified against main — not introduced here.

Closes #492