### PR TITLE
fix(memory): complete HierarchicalMemoryStub parity (#493)

### DIFF
--- a/src/modules/memory/src/controller-registry.test.ts
+++ b/src/modules/memory/src/controller-registry.test.ts
@@ -23,6 +23,7 @@ import { CONTROLLER_SPECS } from './controller-specs.js';
 import { LearningBridge } from './learning-bridge.js';
 import { MemoryGraph } from './memory-graph.js';
 import { TieredCacheManager } from './cache-manager.js';
+import { HIERARCHICAL_MEMORY_SURFACE } from './controllers/hierarchical-memory.js';
 import type {
   IMemoryBackend,
   MemoryEntry,
@@ -754,9 +755,10 @@ describe('ControllerRegistry', () => {
       await registry.initialize({ backend: mockBackend });
       const hm: any = registry.get('hierarchicalMemory');
       expect(hm).not.toBeNull();
-      // Stub exposes store/recall/getTierStats; no listTier/promote
-      expect(typeof hm.store).toBe('function');
-      expect(typeof hm.recall).toBe('function');
+      // Stub mirrors the full HierarchicalMemory surface (issue #493).
+      for (const method of HIERARCHICAL_MEMORY_SURFACE) {
+        expect(typeof hm[method]).toBe('function');
+      }
     });
 
     it('should compose memoryConsolidation from hierarchicalMemory via registry', async () => {

--- a/src/modules/memory/src/controllers/hierarchical-memory.test.ts
+++ b/src/modules/memory/src/controllers/hierarchical-memory.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import initSqlJs, { Database } from 'sql.js';
-import { HierarchicalMemory, HierarchicalMemoryStub, hierarchicalMemorySpec } from './hierarchical-memory.js';
+import {
+  HierarchicalMemory,
+  HierarchicalMemoryStub,
+  HIERARCHICAL_MEMORY_SURFACE,
+  hierarchicalMemorySpec,
+} from './hierarchical-memory.js';
 
 let SQL: any;
 
@@ -171,6 +176,44 @@ describe('HierarchicalMemoryStub', () => {
     expect(stats.total).toBe(3);
   });
 
+  it('listTier returns bucket items oldest-first and respects limit', async () => {
+    await stub.store('first', 0.5, 'working');
+    await new Promise((r) => setTimeout(r, 2));
+    await stub.store('second', 0.5, 'working');
+    await new Promise((r) => setTimeout(r, 2));
+    await stub.store('third', 0.5, 'working');
+    const all = stub.listTier('working');
+    expect(all.map((r) => r.content)).toEqual(['first', 'second', 'third']);
+    const capped = stub.listTier('working', 2);
+    expect(capped).toHaveLength(2);
+    expect(capped[0].content).toBe('first');
+  });
+
+  it('listTier returns empty array for tier with no items', () => {
+    expect(stub.listTier('semantic')).toEqual([]);
+  });
+
+  it('transaction runs the fn and returns its result', async () => {
+    const result = await stub.transaction(async () => {
+      await stub.store('inside-txn', 0.5, 'working');
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(stub.count('working')).toBe(1);
+  });
+
+  it('transaction propagates thrown errors', async () => {
+    await expect(
+      stub.transaction(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+  });
+
+  it('initializeDatabase is a callable no-op', async () => {
+    await expect(stub.initializeDatabase()).resolves.toBeUndefined();
+  });
+
   it('hierarchicalMemorySpec returns stub when mofloDb lacks database', async () => {
     const result = await hierarchicalMemorySpec.create({
       mofloDb: null,
@@ -180,7 +223,10 @@ describe('HierarchicalMemoryStub', () => {
       backend: null,
     } as any);
     expect(result).toBeInstanceOf(HierarchicalMemoryStub);
-    expect(typeof (result as any).promote).toBe('function');
-    expect(typeof (result as any).getStats).toBe('function');
+    // Stub must expose the full HierarchicalMemory surface (issue #493) so
+    // callers never need `typeof hm.X === 'function'` duck-type guards.
+    for (const method of HIERARCHICAL_MEMORY_SURFACE) {
+      expect(typeof (result as any)[method]).toBe('function');
+    }
   });
 });

--- a/src/modules/memory/src/controllers/hierarchical-memory.ts
+++ b/src/modules/memory/src/controllers/hierarchical-memory.ts
@@ -16,9 +16,11 @@
  *   getStats()                                          → Record<tier, n>
  *   promote(id, fromTier, toTier)                       → boolean
  *
- * `HierarchicalMemoryStub` shadows the same public shape so callers can
- * invoke the API unconditionally without duck-type probes when sql.js
- * is unavailable.
+ * `HierarchicalMemoryStub` shadows the same public shape (including
+ * listTier/transaction/initializeDatabase) so callers can invoke the API
+ * unconditionally without duck-type probes when sql.js is unavailable.
+ * Downstream controllers should accept the `HierarchicalMemoryLike` alias
+ * exported below rather than the concrete class.
  */
 
 import {
@@ -345,6 +347,21 @@ function parseTags(value: unknown): string[] {
   }
 }
 
+function stubRowToItem(row: InternalStubRow, score: number): MemoryItem {
+  return {
+    id: row.id,
+    key: row.key,
+    tier: row.tier,
+    content: row.content,
+    importance: row.importance,
+    metadata: row.metadata,
+    tags: row.tags,
+    score,
+    timestamp: row.timestamp,
+    accessCount: row.accessCount,
+  };
+}
+
 function rowToItem(r: Record<string, any>): InternalRow {
   return {
     id: String(r.id),
@@ -419,18 +436,7 @@ export class HierarchicalMemoryStub {
       for (const row of bucket.values()) {
         if (row.key.toLowerCase().includes(q) || row.content.toLowerCase().includes(q)) {
           row.accessCount += 1;
-          matches.push({
-            id: row.id,
-            key: row.key,
-            tier: row.tier,
-            content: row.content,
-            importance: row.importance,
-            metadata: row.metadata,
-            tags: row.tags,
-            score: 1,
-            timestamp: row.timestamp,
-            accessCount: row.accessCount,
-          });
+          matches.push(stubRowToItem(row, 1));
         }
       }
     }
@@ -456,6 +462,28 @@ export class HierarchicalMemoryStub {
       if (bucket.delete(id)) return true;
     }
     return false;
+  }
+
+  async initializeDatabase(): Promise<void> {
+    // In-memory stub has no schema to create.
+  }
+
+  listTier(tier: Tier | string, limit: number = 1000): MemoryItem[] {
+    const t = coerceTier(tier);
+    const bucket = this.tiers.get(t);
+    if (!bucket) return [];
+    const safeLimit = Math.max(1, Math.min(limit, 100_000));
+    const out: MemoryItem[] = [];
+    for (const row of bucket.values()) out.push(stubRowToItem(row, 0));
+    out.sort((a, b) => a.timestamp - b.timestamp);
+    return out.slice(0, safeLimit);
+  }
+
+  async transaction<T>(fn: () => T | Promise<T>): Promise<T> {
+    // Stub has no durable state — a thrown error propagates but any
+    // in-memory writes made by fn are NOT rolled back (the real class
+    // emits SQL ROLLBACK; we have nothing to revert against).
+    return Promise.resolve().then(() => fn());
   }
 
   getStats(): Record<string, number> {
@@ -489,6 +517,30 @@ interface InternalStubRow {
   timestamp: number;
   accessCount: number;
 }
+
+/**
+ * Shared surface between {@link HierarchicalMemory} and
+ * {@link HierarchicalMemoryStub}. Use this where a caller must work with
+ * either implementation (e.g. MemoryConsolidation).
+ */
+export type HierarchicalMemoryLike = HierarchicalMemory | HierarchicalMemoryStub;
+
+/**
+ * Method names that MUST exist on both HierarchicalMemory and
+ * HierarchicalMemoryStub (issue #493 — stub parity). Tests iterate this
+ * to verify no duck-typing is needed on the consumer side.
+ */
+export const HIERARCHICAL_MEMORY_SURFACE = [
+  'store',
+  'recall',
+  'promote',
+  'forget',
+  'getStats',
+  'count',
+  'listTier',
+  'transaction',
+  'initializeDatabase',
+] as const;
 
 export const hierarchicalMemorySpec: ControllerSpec = {
   name: 'hierarchicalMemory',

--- a/src/modules/memory/src/controllers/memory-consolidation.ts
+++ b/src/modules/memory/src/controllers/memory-consolidation.ts
@@ -12,7 +12,7 @@
  *   consolidate() → ConsolidationReport
  */
 
-import type { HierarchicalMemory, MemoryItem, Tier } from './hierarchical-memory.js';
+import type { HierarchicalMemoryLike, MemoryItem, Tier } from './hierarchical-memory.js';
 import type { ControllerSpec } from '../controller-spec.js';
 
 export interface ConsolidationReport {
@@ -44,10 +44,10 @@ const DEFAULTS: Required<MemoryConsolidationOptions> = {
 };
 
 export class MemoryConsolidation {
-  private hm: HierarchicalMemory;
+  private readonly hm: HierarchicalMemoryLike;
   private opts: Required<MemoryConsolidationOptions>;
 
-  constructor(hm: HierarchicalMemory, options: MemoryConsolidationOptions = {}) {
+  constructor(hm: HierarchicalMemoryLike, options: MemoryConsolidationOptions = {}) {
     if (!hm) throw new Error('MemoryConsolidation requires a HierarchicalMemory');
     this.hm = hm;
     this.opts = { ...DEFAULTS, ...options };
@@ -113,32 +113,16 @@ export class MemoryConsolidation {
 // Re-export types needed by controller-registry consumers.
 export type { Tier, MemoryItem };
 
-/**
- * No-op consolidation used when the real HierarchicalMemory isn't
- * available (in-memory stub only supports store/recall).
- */
-function createConsolidationStub() {
-  return {
-    consolidate() {
-      return { promoted: 0, pruned: 0, timestamp: Date.now() };
-    },
-  };
-}
-
 export const memoryConsolidationSpec: ControllerSpec = {
   name: 'memoryConsolidation',
   level: 3,
   enabledByDefault: true,
   create: ({ registry }) => {
-    const hm = registry.get<HierarchicalMemory>('hierarchicalMemory');
-    if (
-      hm &&
-      typeof (hm as any).listTier === 'function' &&
-      typeof (hm as any).promote === 'function'
-    ) {
-      return new MemoryConsolidation(hm);
-    }
-    return createConsolidationStub();
+    // hm is always present unless a consumer explicitly disables
+    // hierarchicalMemory via config.controllers.hierarchicalMemory=false.
+    const hm = registry.get<HierarchicalMemoryLike>('hierarchicalMemory');
+    if (!hm) return null;
+    return new MemoryConsolidation(hm);
   },
 };
 


### PR DESCRIPTION
Closes #493.

## Summary

- Adds \`listTier\`, \`transaction\`, \`initializeDatabase\` to \`HierarchicalMemoryStub\` as semantics-correct no-ops — finishes the stub parity started in #495.
- Exports \`HierarchicalMemoryLike\` union + \`HIERARCHICAL_MEMORY_SURFACE\` method-name const.
- \`MemoryConsolidation\` accepts \`HierarchicalMemoryLike\`; drops duck-typing in \`memoryConsolidationSpec.create\`; deletes redundant \`createConsolidationStub\`.
- \`transaction\` stub docstring is explicit: it does NOT roll back in-memory writes (unlike the real class's SQL ROLLBACK).

## Acceptance (from #493)

- [x] Every method on \`HierarchicalMemory\` exists on \`HierarchicalMemoryStub\` — verified by \`HIERARCHICAL_MEMORY_SURFACE\` in two tests.
- [x] \`memory-bridge.ts\` no longer needs \`typeof hm.X === 'function'\` (already true since #495).
- [x] Full test suite green — stub code path exercised by new tests that call \`promote()\`, \`listTier()\`, \`transaction()\` via the registry path without sql.js.

## Follow-up

Opened #496 for ~13 pre-existing DRY touch points in the same directory (\`clamp\` → \`clamp01\`, inline \`Math.max(1, Math.min(...))\` → \`clampInt\`, repeated SELECT column list). Deferred to keep this PR focused on the acceptance criteria.

## Test plan
- [x] \`npm test\` in \`src/modules/memory\` — 468/468 pass
- [x] \`npx vitest run src/modules/cli/__tests__/memory-movector-deep.test.ts src/modules/cli/__tests__/mcp-tools-deep.test.ts\` — 243/243 pass
- [x] \`tsc\` clean

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)