### PR TITLE
refactor(memory): dedupe clamp/clampInt/SELECT_COLS via _shared helpers

### DIFF
--- a/src/modules/memory/src/controllers/_shared.ts
+++ b/src/modules/memory/src/controllers/_shared.ts
@@ -173,7 +173,7 @@ export async function vectorSearchRows<T extends { embedding: Float32Array | nul
   dimension: number,
   getContent: (row: T) => string,
 ): Promise<Array<T & { score: number }>> {
-  const safeK = Math.max(1, Math.min(k, 1000));
+  const safeK = clampInt(k, 1, 1000, 10);
   if (rows.length === 0) return [];
   const queryVec = await embedWithFallback(embedder, queryText, dimension);
   const withContent = rows.map((r) => ({ ...r, content: getContent(r) }));

--- a/src/modules/memory/src/controllers/attestation-log.ts
+++ b/src/modules/memory/src/controllers/attestation-log.ts
@@ -15,7 +15,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { parseJsonSafe } from './_shared.js';
+import { clampInt, parseJsonSafe } from './_shared.js';
 import type { SqlJsDatabaseLike } from './types.js';
 import type { ControllerSpec } from '../controller-spec.js';
 
@@ -77,7 +77,7 @@ export class AttestationLog {
    * future admin tooling.
    */
   list(limit: number = 100): AttestationEntry[] {
-    const safeLimit = Math.max(1, Math.min(limit, 10_000));
+    const safeLimit = clampInt(limit, 1, 10_000, 100);
     const stmt = this.db.prepare(
       `SELECT operation, entry_id, ts, metadata, prev_hash, entry_hash
        FROM ${TABLE}

--- a/src/modules/memory/src/controllers/context-synthesizer.ts
+++ b/src/modules/memory/src/controllers/context-synthesizer.ts
@@ -12,6 +12,7 @@
  *   { content, key, reward, verdict }[]
  */
 
+import { clampInt } from './_shared.js';
 import type { MemoryPattern } from './types.js';
 import type { ControllerSpec } from '../controller-spec.js';
 
@@ -109,7 +110,7 @@ function buildSummary(memories: MemoryPattern[], maxContent: number): string {
     if (budget <= 0) break;
     const label = m.key ? `[${m.key}] ` : '';
     const trimmed = m.content.trim().replace(/\s+/g, ' ');
-    const room = Math.max(60, Math.min(400, budget));
+    const room = clampInt(budget, 60, 400, 60);
     const excerpt = trimmed.length > room ? trimmed.slice(0, room - 1) + '…' : trimmed;
     excerpts.push(`${label}${excerpt}`);
     budget -= excerpt.length + label.length + 2;

--- a/src/modules/memory/src/controllers/hierarchical-memory.ts
+++ b/src/modules/memory/src/controllers/hierarchical-memory.ts
@@ -24,6 +24,8 @@
  */
 
 import {
+  clamp01,
+  clampInt,
   deserializeEmbedding,
   embedWithFallback,
   generateId,
@@ -36,6 +38,7 @@ import type { SqlJsDatabaseLike } from './types.js';
 import type { ControllerSpec } from '../controller-spec.js';
 
 const TABLE = 'moflo_hierarchical_memory';
+const SELECT_COLS = 'id, key, tier, content, importance, metadata, tags, embedding, created_at, access_count';
 
 export type Tier = 'working' | 'episodic' | 'semantic' | 'metaCognitive';
 const TIERS: Tier[] = ['working', 'episodic', 'semantic', 'metaCognitive'];
@@ -117,7 +120,7 @@ export class HierarchicalMemory {
     const blob = serializeEmbedding(embedding);
     const metaJson = JSON.stringify(options.metadata ?? {});
     const tagsJson = JSON.stringify(options.tags ?? []);
-    const clampedImportance = clamp(importance, 0, 1);
+    const clampedImportance = clamp01(importance);
     this.db.run(
       `INSERT INTO ${TABLE}
          (id, key, tier, content, importance, metadata, tags, embedding, created_at, accessed_at, access_count)
@@ -134,7 +137,7 @@ export class HierarchicalMemory {
       return this.recall({ query, k: typeof legacyK === 'number' ? legacyK : 10 });
     }
     if (!query || typeof query.query !== 'string') return [];
-    const k = Math.max(1, Math.min(query.k ?? 10, 1000));
+    const k = clampInt(query.k, 1, 1000, 10);
     const tier = query.tier ? coerceTier(query.tier) : null;
     const threshold = typeof query.threshold === 'number' ? query.threshold : 0;
     const rows = this.loadByTier(tier);
@@ -214,9 +217,9 @@ export class HierarchicalMemory {
    */
   listTier(tier: Tier | string, limit: number = 1000): MemoryItem[] {
     const t = coerceTier(tier);
-    const safeLimit = Math.max(1, Math.min(limit, 100_000));
+    const safeLimit = clampInt(limit, 1, 100_000, 1000);
     const stmt = this.db.prepare(
-      `SELECT id, key, tier, content, importance, metadata, tags, embedding, created_at, access_count
+      `SELECT ${SELECT_COLS}
        FROM ${TABLE}
        WHERE tier = ?
        ORDER BY created_at ASC
@@ -241,10 +244,8 @@ export class HierarchicalMemory {
 
   private loadByTier(tier: Tier | null): InternalRow[] {
     const sql = tier
-      ? `SELECT id, key, tier, content, importance, metadata, tags, embedding, created_at, access_count
-         FROM ${TABLE} WHERE tier = ?`
-      : `SELECT id, key, tier, content, importance, metadata, tags, embedding, created_at, access_count
-         FROM ${TABLE}`;
+      ? `SELECT ${SELECT_COLS} FROM ${TABLE} WHERE tier = ?`
+      : `SELECT ${SELECT_COLS} FROM ${TABLE}`;
     const stmt = this.db.prepare(sql);
     const rows: InternalRow[] = [];
     try {
@@ -331,11 +332,6 @@ function coerceTier(tier: Tier | string): Tier {
   return (TIERS as string[]).includes(t) ? (t as Tier) : 'working';
 }
 
-function clamp(n: number, lo: number, hi: number): number {
-  if (typeof n !== 'number' || Number.isNaN(n)) return lo;
-  return Math.max(lo, Math.min(hi, n));
-}
-
 function parseTags(value: unknown): string[] {
   if (Array.isArray(value)) return value.map(String);
   if (typeof value !== 'string' || value.length === 0) return [];
@@ -406,7 +402,7 @@ export class HierarchicalMemoryStub {
       key,
       tier: tierName,
       content: String(content ?? '').substring(0, 100_000),
-      importance: clamp(importance, 0, 1),
+      importance: clamp01(importance),
       metadata: options.metadata ?? {},
       tags: options.tags ?? [],
       timestamp: Date.now(),
@@ -426,7 +422,7 @@ export class HierarchicalMemoryStub {
       return this.recall({ query, k: typeof legacyK === 'number' ? legacyK : 10 });
     }
     if (!query || typeof query.query !== 'string') return [];
-    const k = Math.max(1, Math.min(query.k ?? 10, 1000));
+    const k = clampInt(query.k, 1, 1000, 10);
     const tierFilter = query.tier ? coerceTier(query.tier) : null;
     const q = query.query.toLowerCase().substring(0, 10_000);
 
@@ -472,7 +468,7 @@ export class HierarchicalMemoryStub {
     const t = coerceTier(tier);
     const bucket = this.tiers.get(t);
     if (!bucket) return [];
-    const safeLimit = Math.max(1, Math.min(limit, 100_000));
+    const safeLimit = clampInt(limit, 1, 100_000, 1000);
     const out: MemoryItem[] = [];
     for (const row of bucket.values()) out.push(stubRowToItem(row, 0));
     out.sort((a, b) => a.timestamp - b.timestamp);

--- a/src/modules/memory/src/controllers/reflexion.ts
+++ b/src/modules/memory/src/controllers/reflexion.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  clampInt,
   deserializeEmbedding,
   embedWithFallback,
   generateId,
@@ -177,7 +178,7 @@ export class Reflexion {
   }
 
   listEpisodes(limit: number = 100): EpisodeRow[] {
-    const safeLimit = Math.max(1, Math.min(limit, 10_000));
+    const safeLimit = clampInt(limit, 1, 10_000, 100);
     const stmt = this.db.prepare(
       `SELECT session_id, started_at, ended_at, context, summary, tasks_completed, patterns_learned
        FROM ${EPISODES_TABLE}

--- a/src/modules/memory/src/controllers/skills.ts
+++ b/src/modules/memory/src/controllers/skills.ts
@@ -18,6 +18,7 @@
  */
 
 import {
+  clampInt,
   deserializeEmbedding,
   embedWithFallback,
   generateId,
@@ -190,7 +191,7 @@ export class Skills {
 
   // Admin: return all skills (newest first). Used by nightly learner and tests.
   list(limit: number = 100): SkillRow[] {
-    const safeLimit = Math.max(1, Math.min(limit, 10_000));
+    const safeLimit = clampInt(limit, 1, 10_000, 100);
     const stmt = this.db.prepare(
       `SELECT id, name, description, code, quality, uses, metadata, embedding, created_at, updated_at
        FROM ${TABLE}


### PR DESCRIPTION
## Summary

Three pre-existing DRY opportunities in `src/modules/memory/src/controllers/`, all mechanical — no behavior change in practice.

## Changes

- **`clamp01`**: Deleted local `function clamp(n, lo, hi)` in `hierarchical-memory.ts`; replaced `clamp(importance, 0, 1)` with `clamp01(importance)` at 2 sites (real class + stub).
- **`clampInt`**: Replaced 9× inline `Math.max(1, Math.min(x, cap))` across:
  - `hierarchical-memory.ts` (4 sites: recall k real+stub, listTier limit real+stub)
  - `attestation-log.ts:80`, `reflexion.ts:180`, `skills.ts:193` (each `list(limit)`)
  - `context-synthesizer.ts:112` (`buildSummary` inner loop)
  - `_shared.ts:176` (`vectorSearchRows` safeK — the helper file using the helper)
- **`SELECT_COLS`**: Extracted the 10-column SELECT list into a file-local `const SELECT_COLS` in `hierarchical-memory.ts`; 3 inline occurrences (listTier + 2 loadByTier branches) now interpolate.

Convention: `clampInt` fallback = method's default param (`limit=100` → fallback=100), so parameterless calls stay equivalent. This also fixes a latent `LIMIT NaN` bug if callers passed `NaN`.

## Acceptance

- [x] `function clamp` in `hierarchical-memory.ts` deleted
- [x] Zero `Math.max(1, Math.min(` patterns in `src/modules/memory/src/controllers/`
- [x] `SELECT_COLS` extracted; column list appears exactly once in `hierarchical-memory.ts`
- [x] All existing tests green (7667/7667)

## Out of scope (deferred)

- Similar SELECT repeats in `attestation-log` / `reflexion` / `skills` / `causal-graph` / `learning-system` — 2-3× each, worth a follow-up pass.
- New tests for `clamp01`/`clampInt` and JSDoc on helpers — ticket carved out "No new tests required."

## Testing

- [x] Memory package: 468/468 passed
- [x] Full monorepo: 7667/7667 passed
- [x] `/simplify` review run (3 agents: reuse, quality, efficiency)

Closes #496