### PR TITLE
fix(memory): drain stdio before exit to avoid libuv crash on Windows

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -7,13 +7,8 @@
 import { existsSync, mkdirSync, writeFileSync, readdirSync, rmSync, statSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
-import { run, runNode, flo, NPM_CMD, IS_WIN } from './proc.mjs';
+import { run, runNode, flo, NPM_CMD } from './proc.mjs';
 import { section, record, recordExit, log } from './report.mjs';
-
-// Regex for the Windows-specific libuv async-handle teardown assertion that
-// crashes `flo memory list` at process exit after printing correct output
-// (bug in moflo; fix tracked separately). We downgrade to WARN in that case.
-const WIN_LIBUV_TEARDOWN_RE = /Assertion failed.*async\.c/i;
 
 // Epic #501 acceptance criterion: a fresh `npm install moflo` consumer sees
 // zero of the following packages anywhere in its dep tree.
@@ -180,18 +175,7 @@ export function memoryCrud(consumerDir) {
 
   recordExit('memory-search', flo(consumerDir, ['memory', 'search', '-q', 'smoke', '--namespace', 'smoke', '--limit', '5']));
 
-  const list = flo(consumerDir, ['memory', 'list', '--namespace', 'smoke']);
-  // `memory list` can crash at teardown on Windows (libuv async-handle
-  // assertion) after printing correct output; downgrade to WARN in that case.
-  const listedOk = /Memory Entries/.test(list.stdout);
-  const winTeardownCrash = IS_WIN && WIN_LIBUV_TEARDOWN_RE.test(list.stderr);
-  if (list.code === 0) {
-    record('memory-list', 'pass');
-  } else if (listedOk && winTeardownCrash) {
-    record('memory-list', 'warn', 'Windows libuv teardown crash after correct output (moflo bug)');
-  } else {
-    record('memory-list', 'fail', `exit ${list.code}: ${list.stderr.trim().slice(0, 200)}`);
-  }
+  recordExit('memory-list', flo(consumerDir, ['memory', 'list', '--namespace', 'smoke']));
 
   recordExit('memory-delete', flo(consumerDir, ['memory', 'delete', '-k', key, '--namespace', 'smoke']));
 }

--- a/src/modules/cli/src/index.ts
+++ b/src/modules/cli/src/index.ts
@@ -19,6 +19,29 @@ export { VERSION };
 
 const LONG_RUNNING_COMMANDS = ['mcp', 'daemon'];
 
+/**
+ * Flush stdout/stderr, shut down the memory bridge if it was initialized,
+ * then `process.exit(code)`. Prevents the libuv `uv_async_send` assertion
+ * on Windows when stdout is an async pipe (issue #504).
+ */
+async function drainAndExit(code: number): Promise<void> {
+  try {
+    const { shutdownBridge } = await import('./memory/memory-bridge.js');
+    await shutdownBridge();
+  } catch {
+    // Bridge may not have been loaded — that's fine
+  }
+
+  const flush = (stream: NodeJS.WriteStream) =>
+    new Promise<void>((resolve) => {
+      if (!stream.writable) return resolve();
+      stream.write('', () => resolve());
+    });
+
+  await Promise.all([flush(process.stdout), flush(process.stderr)]);
+  process.exit(code);
+}
+
 export interface CLIOptions {
   name?: string;
   description?: string;
@@ -247,8 +270,12 @@ export class CLI {
           || 'JEST_WORKER_ID' in process.env
           || process.env.NODE_ENV === 'test';
         if (!LONG_RUNNING_COMMANDS.includes(commandName) && !isTestEnv) {
-          // Use setImmediate to let any pending I/O flush before exit
-          setImmediate(() => process.exit(0));
+          // On Windows, stdout/stderr are async pipes when captured by a
+          // parent process; `process.exit` fires uv_async_send on an already-
+          // closing handle and trips libuv's assertion in src/win/async.c
+          // (issue #504). Drain the streams and stop the memory-bridge timers
+          // before exiting.
+          void drainAndExit(0);
         }
       } else {
         // No action - show command help

--- a/src/modules/memory/src/cache-manager.ts
+++ b/src/modules/memory/src/cache-manager.ts
@@ -447,6 +447,9 @@ export class CacheManager<T = MemoryEntry> extends EventEmitter {
     this.cleanupInterval = setInterval(() => {
       this.cleanupExpired();
     }, 60000);
+    // Don't keep the event loop alive — short-lived CLI commands shouldn't
+    // have to wait for cleanup to decide to exit (issue #504).
+    this.cleanupInterval.unref?.();
   }
 
   private cleanupExpired(): void {

--- a/src/modules/memory/src/sqljs-backend.ts
+++ b/src/modules/memory/src/sqljs-backend.ts
@@ -140,6 +140,9 @@ export class SqlJsBackend extends EventEmitter implements IMemoryBackend {
           this.emit('error', { operation: 'auto-persist', error: err });
         });
       }, this.config.autoPersistInterval);
+      // Don't keep the event loop alive — short-lived CLI commands shouldn't
+      // have to wait for auto-persist to decide to exit (issue #504).
+      this.persistTimer.unref?.();
     }
 
     this.initialized = true;


### PR DESCRIPTION
## Summary
- Windows libuv assertion `!(handle->flags & UV_HANDLE_CLOSING)` in `src/win/async.c` when `flo memory list` exited under a captured-pipe stdout.
- Root cause: after successful commands, `src/modules/cli/src/index.ts` called `setImmediate(() => process.exit(0))`. On Windows, stdout is async when captured by a parent process, so `uv_async_send` was still pending when `process.exit` fired `uv_close`, tripping the assertion.
- `list` tripped it reliably because it prints the most bytes among memory subcommands.

## Changes
- `src/modules/cli/src/index.ts` — replaced the forced immediate exit with a new `drainAndExit(code)` helper that:
  - dynamically imports and awaits `shutdownBridge` (stops @moflo/memory timers, closes sql.js),
  - flushes stdout and stderr via `stream.write('', cb)` in `Promise.all`,
  - then calls `process.exit(code)`.
- `src/modules/memory/src/sqljs-backend.ts` — `.unref?.()` the auto-persist `setInterval` so it can't keep short-lived CLIs alive.
- `src/modules/memory/src/cache-manager.ts` — `.unref?.()` the 60s expiry cleanup `setInterval`.
- `harness/consumer-smoke/lib/checks.mjs` — dropped the `WIN_LIBUV_TEARDOWN_RE` downgrade workaround; `memory-list` now uses plain `recordExit`.

## Testing
- [x] Unit tests: 7667/7667 pass (`npm test`).
- [x] Memory module tests: 468/468 pass.
- [x] Consumer smoke harness: `memory-list` PASS (was WARN); 21/21 checks green.
- [x] Manual: `node bin/cli.js memory list` on populated and empty namespaces — exit 0, no assertion.

Closes #504