### PR TITLE
fix(spells): waitCommand honors strict "wait at least N ms" contract

### DIFF
--- a/src/modules/spells/__tests__/built-in-commands.test.ts
+++ b/src/modules/spells/__tests__/built-in-commands.test.ts
@@ -511,13 +511,10 @@ describe('waitCommand', () => {
   });
 
   it('should wait for specified duration', async () => {
-    const target = 10;
-    const output = await waitCommand.execute({ duration: target }, createContext());
+    const output = await waitCommand.execute({ duration: 10 }, createContext());
     expect(output.success).toBe(true);
-    expect(output.data.waited).toBe(target);
-    // Allow 1ms of timer jitter: Date.now() has integer-ms resolution and Node's
-    // setTimeout may fire slightly before the target on fast Linux CI runners.
-    expect(output.duration).toBeGreaterThanOrEqual(target - 1);
+    expect(output.data.waited).toBe(10);
+    expect(output.duration).toBeGreaterThanOrEqual(10);
   });
 
   it('should reject on abort signal', async () => {

--- a/src/modules/spells/src/commands/wait-command.ts
+++ b/src/modules/spells/src/commands/wait-command.ts
@@ -41,17 +41,24 @@ export const waitCommand: StepCommand<WaitStepConfig> = {
     const start = Date.now();
     const duration = config.duration;
 
-    await new Promise<void>((resolve, reject) => {
-      const onAbort = () => {
-        clearTimeout(timer);
-        reject(new Error('Wait aborted'));
-      };
-      const timer = setTimeout(() => {
-        context.abortSignal?.removeEventListener('abort', onAbort);
-        resolve();
-      }, duration);
-      context.abortSignal?.addEventListener('abort', onAbort, { once: true });
-    });
+    // Loop to honor "wait AT LEAST duration ms". libuv's setTimeout can fire up
+    // to ~1ms before the requested delay, so a single setTimeout call is not a
+    // sufficient guarantee. Typically converges in 1–2 iterations.
+    while (true) {
+      const remaining = duration - (Date.now() - start);
+      if (remaining <= 0) break;
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          clearTimeout(timer);
+          reject(new Error('Wait aborted'));
+        };
+        const timer = setTimeout(() => {
+          context.abortSignal?.removeEventListener('abort', onAbort);
+          resolve();
+        }, remaining);
+        context.abortSignal?.addEventListener('abort', onAbort, { once: true });
+      });
+    }
 
     return {
       success: true,


### PR DESCRIPTION
## Summary

Follow-up to #508. PR #508 had a timing assertion fail in CI (`expected 9 to be greater than or equal to 10` in `waitCommand > should wait for specified duration`), and I fixed it there with a 1ms tolerance in the test. That was a cop-out — it masked a real contract violation in the implementation.

**Root cause:** libuv's `setTimeout` can fire up to ~1ms before the requested delay. A single `setTimeout(cb, duration)` call therefore does NOT guarantee the natural contract of "pause for at least `duration` ms." On fast Linux CI runners this surfaces as `Date.now() - start` returning 9 after a 10ms wait.

**Real fix:** loop the wait until the deadline is met. Typically converges in 1–2 iterations; no observable cost. Abort semantics preserved (rejects immediately on any iteration).

## Changes

- `src/modules/spells/src/commands/wait-command.ts` — `execute()` now loops `setTimeout` calls against the deadline instead of relying on a single fire.
- `src/modules/spells/__tests__/built-in-commands.test.ts` — restore strict assertion `duration >= target` (was `>= target - 1`).

## Testing

- [x] Target test ran 10× in a loop locally — all passing
- [x] Full `built-in-commands.test.ts` file: 78/78 pass
- [x] `npm run build` clean

Closes the outstanding flake from #508.