### PR TITLE
feat(spells): preflight prerequisites walker with interactive prompt

### DIFF
--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -110,6 +110,7 @@ Every spell definition needs two things: a `name` and a list of `steps`.
 | `name` | Yes | Unique identifier for this spell |
 | `description` | No | Human-readable explanation |
 | `arguments` | No | Typed inputs the spell accepts (see [Arguments](#arguments)) |
+| `prerequisites` | No | External deps (env vars, CLI binaries, files) checked before step 1 (see [Prerequisites](#prerequisites)) |
 | `steps` | Yes | Ordered list of steps to execute |
 
 **Step fields:**
@@ -123,6 +124,7 @@ Every spell definition needs two things: a `name` and a list of `steps`.
 | `continueOnError` | No | If `true`, spell continues even if this step fails |
 | `timeout` | No | Step-specific timeout in ms (overrides the runner's 5-minute default) |
 | `steps` | No | Nested step definitions (used by `loop` type only) |
+| `prerequisites` | No | External deps scoped to this step; folded into the spell-level preflight at cast time |
 
 ### Arguments
 
@@ -144,6 +146,44 @@ arguments:
 ```
 
 The runner validates arguments before execution — missing required args or type mismatches produce a structured error without running any steps.
+
+### Prerequisites
+
+Declare external dependencies the spell needs — environment variables, CLI binaries, or files — and the engine will check them before step 1 runs. On an interactive terminal, unmet env-type prerequisites prompt the user once for the value and write it into `process.env` so downstream steps inherit it. In non-interactive runs (CI, piped stdin), missing prerequisites fail the spell up front with a single report listing every unmet dep and its docs URL, instead of letting the spell fail mid-cast with a cryptic error.
+
+```yaml
+prerequisites:
+  - name: GRAPH_ACCESS_TOKEN
+    description: Microsoft Graph access token for reading your inbox
+    docsUrl: https://developer.microsoft.com/en-us/graph/graph-explorer
+    detect:
+      type: env
+      key: GRAPH_ACCESS_TOKEN
+    promptOnMissing: true    # default: true
+
+  - name: gh-cli
+    description: GitHub CLI
+    docsUrl: https://cli.github.com
+    detect:
+      type: command
+      command: gh
+    promptOnMissing: false   # no useful prompt for a missing binary
+
+  - name: deploy-key
+    detect:
+      type: file
+      path: /etc/deploy-keys/prod.pem
+```
+
+**Detector types:**
+
+| Type | Detects | Can resolve via prompt? |
+|------|---------|-------------------------|
+| `env` | `process.env[key]` is set to a non-empty string | Yes — answer is written to `process.env[key]` |
+| `command` | `which <cmd>` / `where <cmd>` succeeds | No — surfaces the docs URL only |
+| `file` | `fs.access(path)` succeeds | No — surfaces the docs URL only |
+
+Prerequisites can also be declared on individual steps (`StepDefinition.prerequisites`); the engine walks every step — including nested `loop` / `condition` / `parallel` bodies — and deduplicates by `name` (first occurrence wins) before running any detectors. Dry-run mode (`flo cast --dry-run`) skips the prompt path so validations stay side-effect-free.
 
 ### Variable Interpolation
 

--- a/src/modules/spells/__tests__/prerequisites.test.ts
+++ b/src/modules/spells/__tests__/prerequisites.test.ts
@@ -9,6 +9,9 @@ import {
   collectPrerequisites,
   checkPrerequisites,
   formatPrerequisiteErrors,
+  compilePrerequisiteSpec,
+  resolveUnmetPrerequisites,
+  type PromptLineFn,
 } from '../src/core/prerequisite-checker.js';
 import { StepCommandRegistry } from '../src/core/step-command-registry.js';
 import { SpellCaster } from '../src/core/runner.js';
@@ -19,7 +22,13 @@ import type {
   CredentialAccessor,
   MemoryAccessor,
 } from '../src/types/step-command.types.js';
-import type { SpellDefinition } from '../src/types/spell-definition.types.js';
+import type {
+  SpellDefinition,
+  PrerequisiteSpec,
+} from '../src/types/spell-definition.types.js';
+import * as fsPromises from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
 
 // ============================================================================
 // Helpers
@@ -262,6 +271,30 @@ describe('SpellCaster — prerequisite integration', () => {
     expect(result.errors.every(e => e.code !== 'PREREQUISITES_FAILED')).toBe(true);
   });
 
+  it('collects and fails on spell-level YAML prereq', async () => {
+    registry.register(makeCommand('bash'));
+
+    const def: SpellDefinition = {
+      name: 'needs-env',
+      prerequisites: [{
+        name: 'FLO_TEST_MISSING_460',
+        description: 'Test env var',
+        docsUrl: 'https://example.com/460',
+        detect: { type: 'env', key: 'FLO_TEST_MISSING_460' },
+        promptOnMissing: false, // force non-prompt fail-fast path
+      }],
+      steps: [{ id: 's1', type: 'bash', config: {} }],
+    };
+
+    delete process.env.FLO_TEST_MISSING_460;
+    const result = await runner.run(def, {});
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('PREREQUISITES_FAILED');
+    expect(result.errors[0].message).toContain('FLO_TEST_MISSING_460');
+    expect(result.errors[0].message).toContain('https://example.com/460');
+  });
+
   it('reports prerequisite status in dry-run step reports', async () => {
     const ghPrereq = makePrereq('gh', true);
     const claudePrereq = makePrereq('claude', false);
@@ -282,5 +315,294 @@ describe('SpellCaster — prerequisite integration', () => {
 
     expect(s2Report.prerequisiteResults).toHaveLength(1);
     expect(s2Report.prerequisiteResults![0].satisfied).toBe(false);
+  });
+});
+
+// ============================================================================
+// compilePrerequisiteSpec — detectors (#460)
+// ============================================================================
+
+describe('compilePrerequisiteSpec', () => {
+  it('env detector: passes when env var is set to non-empty', async () => {
+    process.env.FLO_PREREQ_TEST_ENV = 'value';
+    const compiled = compilePrerequisiteSpec({
+      name: 'TEST_ENV',
+      detect: { type: 'env', key: 'FLO_PREREQ_TEST_ENV' },
+    });
+    expect(await compiled.check()).toBe(true);
+    expect(compiled.envKey).toBe('FLO_PREREQ_TEST_ENV');
+    delete process.env.FLO_PREREQ_TEST_ENV;
+  });
+
+  it('env detector: fails when env var is unset', async () => {
+    delete process.env.FLO_PREREQ_TEST_ENV;
+    const compiled = compilePrerequisiteSpec({
+      name: 'TEST_ENV',
+      detect: { type: 'env', key: 'FLO_PREREQ_TEST_ENV' },
+    });
+    expect(await compiled.check()).toBe(false);
+  });
+
+  it('env detector: fails when env var is an empty string', async () => {
+    process.env.FLO_PREREQ_TEST_ENV = '';
+    const compiled = compilePrerequisiteSpec({
+      name: 'TEST_ENV',
+      detect: { type: 'env', key: 'FLO_PREREQ_TEST_ENV' },
+    });
+    expect(await compiled.check()).toBe(false);
+    delete process.env.FLO_PREREQ_TEST_ENV;
+  });
+
+  it('file detector: passes when file exists, fails when missing', async () => {
+    const tmp = path.join(os.tmpdir(), `flo-prereq-${Date.now()}.txt`);
+    await fsPromises.writeFile(tmp, 'x');
+    try {
+      const present = compilePrerequisiteSpec({
+        name: 'CFG',
+        detect: { type: 'file', path: tmp },
+      });
+      expect(await present.check()).toBe(true);
+    } finally {
+      await fsPromises.unlink(tmp);
+    }
+
+    const missing = compilePrerequisiteSpec({
+      name: 'CFG',
+      detect: { type: 'file', path: path.join(os.tmpdir(), 'flo-prereq-nonexistent-xyz') },
+    });
+    expect(await missing.check()).toBe(false);
+  });
+
+  it('command detector: fails when command is not on PATH', async () => {
+    const compiled = compilePrerequisiteSpec({
+      name: 'UNICORN',
+      detect: { type: 'command', command: 'this-command-definitely-does-not-exist-xyz-460' },
+    });
+    expect(await compiled.check()).toBe(false);
+    expect(compiled.envKey).toBeUndefined();
+  });
+
+  it('defaults promptOnMissing to true, url passes through from docsUrl', () => {
+    const compiled = compilePrerequisiteSpec({
+      name: 'X',
+      docsUrl: 'https://docs.example',
+      detect: { type: 'env', key: 'X' },
+    });
+    expect(compiled.promptOnMissing).toBe(true);
+    expect(compiled.url).toBe('https://docs.example');
+  });
+
+  it('respects explicit promptOnMissing=false', () => {
+    const compiled = compilePrerequisiteSpec({
+      name: 'X',
+      promptOnMissing: false,
+      detect: { type: 'env', key: 'X' },
+    });
+    expect(compiled.promptOnMissing).toBe(false);
+  });
+});
+
+// ============================================================================
+// collectPrerequisites — YAML + step + nested walker (#460)
+// ============================================================================
+
+describe('collectPrerequisites — YAML walker', () => {
+  it('picks up spell-level YAML prereqs', () => {
+    const registry = new StepCommandRegistry();
+    registry.register(makeCommand('bash'));
+    const def: SpellDefinition = {
+      name: 'x',
+      prerequisites: [{ name: 'TOK', detect: { type: 'env', key: 'TOK' } }],
+      steps: [{ id: 's1', type: 'bash', config: {} }],
+    };
+    const prereqs = collectPrerequisites(def, registry);
+    expect(prereqs.map(p => p.name)).toContain('TOK');
+    expect(prereqs.find(p => p.name === 'TOK')!.envKey).toBe('TOK');
+  });
+
+  it('picks up step-level YAML prereqs', () => {
+    const registry = new StepCommandRegistry();
+    registry.register(makeCommand('bash'));
+    const def: SpellDefinition = {
+      name: 'x',
+      steps: [{
+        id: 's1', type: 'bash', config: {},
+        prerequisites: [{ name: 'GH', detect: { type: 'command', command: 'gh' } }],
+      }],
+    };
+    expect(collectPrerequisites(def, registry).map(p => p.name)).toEqual(['GH']);
+  });
+
+  it('walks nested loop/condition/parallel step bodies', () => {
+    const registry = new StepCommandRegistry();
+    registry.register(makeCommand('loop'));
+    registry.register(makeCommand('bash'));
+    const def: SpellDefinition = {
+      name: 'x',
+      steps: [{
+        id: 'outer', type: 'loop', config: {},
+        steps: [{
+          id: 'inner', type: 'bash', config: {},
+          prerequisites: [{ name: 'NESTED', detect: { type: 'env', key: 'NESTED' } }],
+        }],
+      }],
+    };
+    expect(collectPrerequisites(def, registry).map(p => p.name)).toContain('NESTED');
+  });
+
+  it('dedupes across spell + step + step-command built-in (first wins)', () => {
+    const registry = new StepCommandRegistry();
+    const builtin = makePrereq('SHARED', true, 'builtin-hint');
+    registry.register(makeCommand('github', [builtin]));
+
+    const spellSpec: PrerequisiteSpec = {
+      name: 'SHARED',
+      description: 'spell-level',
+      detect: { type: 'env', key: 'SHARED' },
+    };
+    const def: SpellDefinition = {
+      name: 'x',
+      prerequisites: [spellSpec],
+      steps: [{ id: 's1', type: 'github', config: {} }],
+    };
+
+    const prereqs = collectPrerequisites(def, registry);
+    expect(prereqs).toHaveLength(1);
+    // Spell-level declaration wins (compiled from the YAML spec)
+    expect(prereqs[0].description).toBe('spell-level');
+    expect(prereqs[0].installHint).toBe('spell-level');
+    expect(prereqs[0].envKey).toBe('SHARED');
+  });
+});
+
+// ============================================================================
+// resolveUnmetPrerequisites — prompt + fail-fast (#460)
+// ============================================================================
+
+describe('resolveUnmetPrerequisites', () => {
+  const ENV_KEY = 'FLO_RESOLVE_TEST_460';
+
+  beforeEach(() => { delete process.env[ENV_KEY]; });
+
+  it('returns ok immediately when every prereq is satisfied', async () => {
+    const result = await resolveUnmetPrerequisites([makePrereq('ok', true)], {
+      interactive: false,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedNames).toEqual([]);
+  });
+
+  it('non-TTY path: fails fast with a report listing every unmet prereq', async () => {
+    const prereqs: Prerequisite[] = [
+      compilePrerequisiteSpec({
+        name: 'TOK_A',
+        docsUrl: 'https://a.example',
+        detect: { type: 'env', key: 'TOK_A_460' },
+      }),
+      compilePrerequisiteSpec({
+        name: 'TOK_B',
+        docsUrl: 'https://b.example',
+        detect: { type: 'env', key: 'TOK_B_460' },
+      }),
+    ];
+    const result = await resolveUnmetPrerequisites(prereqs, { interactive: false });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('TOK_A');
+    expect(result.message).toContain('TOK_B');
+    expect(result.message).toContain('https://a.example');
+    expect(result.message).toContain('https://b.example');
+  });
+
+  it('TTY path: prompts for unmet env prereq and writes answer into process.env', async () => {
+    const spec: PrerequisiteSpec = {
+      name: 'GRAPH_TOKEN',
+      description: 'Graph token',
+      docsUrl: 'https://graph.example',
+      detect: { type: 'env', key: ENV_KEY },
+      promptOnMissing: true,
+    };
+    const prereq = compilePrerequisiteSpec(spec);
+    const promptLine = vi.fn<PromptLineFn>(async () => 'provided-value');
+    const logged: string[] = [];
+    const result = await resolveUnmetPrerequisites([prereq], {
+      interactive: true,
+      promptLine,
+      log: (l) => logged.push(l),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.resolvedNames).toEqual(['GRAPH_TOKEN']);
+    expect(process.env[ENV_KEY]).toBe('provided-value');
+    expect(promptLine).toHaveBeenCalledTimes(1);
+    expect(logged.some(l => l.includes('Preflight'))).toBe(true);
+    expect(logged.some(l => l.includes('Graph token'))).toBe(true);
+    expect(logged.some(l => l.includes('https://graph.example'))).toBe(true);
+  });
+
+  it('TTY path: empty answer fails with "was not provided"', async () => {
+    const prereq = compilePrerequisiteSpec({
+      name: 'X',
+      detect: { type: 'env', key: ENV_KEY },
+    });
+    const promptLine = vi.fn<PromptLineFn>(async () => '');
+    const result = await resolveUnmetPrerequisites([prereq], {
+      interactive: true,
+      promptLine,
+      log: () => {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('was not provided');
+    expect(process.env[ENV_KEY]).toBeUndefined();
+  });
+
+  it('command-type unmet prereq with no promptable partner fails fast even on TTY', async () => {
+    const prereq = compilePrerequisiteSpec({
+      name: 'UNICORN_CLI',
+      detect: { type: 'command', command: 'this-command-does-not-exist-xyz-460' },
+    });
+    const promptLine = vi.fn<PromptLineFn>(async () => 'ignored');
+    const result = await resolveUnmetPrerequisites([prereq], {
+      interactive: true,
+      promptLine,
+      log: () => {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('UNICORN_CLI');
+    expect(promptLine).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt when promptOnMissing is explicitly false', async () => {
+    const prereq = compilePrerequisiteSpec({
+      name: 'OPT_OUT',
+      promptOnMissing: false,
+      detect: { type: 'env', key: ENV_KEY },
+    });
+    const promptLine = vi.fn<PromptLineFn>(async () => 'ignored');
+    const result = await resolveUnmetPrerequisites([prereq], {
+      interactive: true,
+      promptLine,
+      log: () => {},
+    });
+    expect(result.ok).toBe(false);
+    expect(promptLine).not.toHaveBeenCalled();
+  });
+
+  it('aborts mid-prompt when abortSignal fires', async () => {
+    const controller = new AbortController();
+    const prereq = compilePrerequisiteSpec({
+      name: 'X',
+      detect: { type: 'env', key: ENV_KEY },
+    });
+    const promptLine: PromptLineFn = async (_line, signal) => {
+      controller.abort();
+      if (signal?.aborted) throw new Error('Prompt aborted');
+      return '';
+    };
+    const result = await resolveUnmetPrerequisites([prereq], {
+      interactive: true,
+      promptLine,
+      abortSignal: controller.signal,
+      log: () => {},
+    });
+    expect(result.ok).toBe(false);
   });
 });

--- a/src/modules/spells/__tests__/schema.test.ts
+++ b/src/modules/spells/__tests__/schema.test.ts
@@ -453,3 +453,121 @@ describe('nested step variable validation', () => {
     expect(result.errors.some(e => e.message.includes('undefined argument'))).toBe(true);
   });
 });
+
+// ============================================================================
+// PrerequisiteSpec validation (#460)
+// ============================================================================
+
+describe('validateSpellDefinition — prerequisites', () => {
+  const minimalStep = { id: 's1', type: 'bash', config: {} };
+
+  it('accepts a well-formed spell-level prerequisite', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      prerequisites: [{
+        name: 'GRAPH_TOKEN',
+        description: 'graph token',
+        docsUrl: 'https://docs.example',
+        detect: { type: 'env', key: 'GRAPH_TOKEN' },
+        promptOnMissing: true,
+      }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects prerequisites that is not an array', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      // @ts-expect-error intentionally wrong shape
+      prerequisites: { name: 'X', detect: { type: 'env', key: 'X' } },
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.path === 'prerequisites')).toBe(true);
+  });
+
+  it('rejects missing name', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      // @ts-expect-error missing name
+      prerequisites: [{ detect: { type: 'env', key: 'X' } }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('prerequisite.name is required'))).toBe(true);
+  });
+
+  it('rejects duplicate names within the same block', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      prerequisites: [
+        { name: 'DUP', detect: { type: 'env', key: 'A' } },
+        { name: 'DUP', detect: { type: 'env', key: 'B' } },
+      ],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('duplicate prerequisite name'))).toBe(true);
+  });
+
+  it('rejects unknown detect.type', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      prerequisites: [{
+        name: 'X',
+        // @ts-expect-error unknown type
+        detect: { type: 'magic', key: 'X' },
+      }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.path.endsWith('.detect.type'))).toBe(true);
+  });
+
+  it('rejects env detector missing key', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      // @ts-expect-error missing key for env detector
+      prerequisites: [{ name: 'X', detect: { type: 'env' } }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('detect.key is required'))).toBe(true);
+  });
+
+  it('rejects command detector missing command', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      // @ts-expect-error missing command
+      prerequisites: [{ name: 'X', detect: { type: 'command' } }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('detect.command is required'))).toBe(true);
+  });
+
+  it('rejects file detector missing path', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      // @ts-expect-error missing path
+      prerequisites: [{ name: 'X', detect: { type: 'file' } }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('detect.path is required'))).toBe(true);
+  });
+
+  it('validates step-level prerequisites under step path', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      steps: [{
+        id: 's1', type: 'bash', config: {},
+        // @ts-expect-error intentionally wrong
+        prerequisites: [{ name: 'X' }],
+      }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.path.startsWith('steps[0].prerequisites'))).toBe(true);
+  });
+});

--- a/src/modules/spells/src/commands/prompt-command.ts
+++ b/src/modules/spells/src/commands/prompt-command.ts
@@ -11,7 +11,6 @@
  *   3. empty string
  */
 
-import * as readline from 'node:readline';
 import type {
   StepCommand,
   StepConfig,
@@ -23,6 +22,7 @@ import type {
 } from '../types/step-command.types.js';
 import { interpolateString } from '../core/interpolation.js';
 import { acquireTTYLock } from '../core/tty-lock.js';
+import { readLineFromStdin } from '../core/stdin-reader.js';
 
 /** Typed config for the prompt step command. */
 export interface PromptStepConfig extends StepConfig {
@@ -63,29 +63,6 @@ export function resolveDefault(
     return new Date(now - fallbackDaysAgo * 86_400_000).toISOString();
   }
   return '';
-}
-
-/**
- * Read one line from stdin. Resolves with the trimmed line (empty string
- * if the user just hit enter). Honors the provided abort signal.
- */
-async function readLineFromStdin(
-  prompt: string,
-  abortSignal?: AbortSignal,
-): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    const onAbort = () => { rl.close(); reject(new Error('Prompt aborted')); };
-    if (abortSignal) {
-      if (abortSignal.aborted) { rl.close(); reject(new Error('Prompt aborted')); return; }
-      abortSignal.addEventListener('abort', onAbort, { once: true });
-    }
-    rl.question(prompt, (answer) => {
-      if (abortSignal) abortSignal.removeEventListener('abort', onAbort);
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
 }
 
 export const promptCommand: StepCommand<PromptStepConfig> = {

--- a/src/modules/spells/src/core/prerequisite-checker.ts
+++ b/src/modules/spells/src/core/prerequisite-checker.ts
@@ -1,17 +1,31 @@
 /**
  * Prerequisite Checker
  *
- * Collects and deduplicates prerequisites from all spell steps,
- * runs each check once, and returns structured results.
+ * Collects prerequisites from three sources (declarative YAML at spell and
+ * step level + imperative step-command-owned), dedupes by name, runs each
+ * detector once, and — when stdin is a TTY — prompts for unmet env-type
+ * prereqs and writes the answer into process.env so downstream steps
+ * (including nested loop bodies) inherit it.
  *
- * Story #193: Spell engine prerequisites system.
+ * Non-TTY failure path reports every unmet prereq with its docs URL so the
+ * caller sees the full picture rather than failing mid-cast.
+ *
+ * Story #193: initial step-command-owned prereqs.
+ * Issue #460: YAML-declared + interactive preflight walker.
  */
 
 import { execFile } from 'node:child_process';
+import { access } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import type { StepCommand, Prerequisite, PrerequisiteResult } from '../types/step-command.types.js';
-import type { SpellDefinition } from '../types/spell-definition.types.js';
+import type {
+  SpellDefinition,
+  StepDefinition,
+  PrerequisiteSpec,
+} from '../types/spell-definition.types.js';
 import type { StepCommandRegistry } from './step-command-registry.js';
+import { acquireTTYLock } from './tty-lock.js';
+import { readLineFromStdin } from './stdin-reader.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -27,8 +41,60 @@ export async function commandExists(cmd: string): Promise<boolean> {
 }
 
 /**
- * Collect unique prerequisites from all steps in a spell definition.
- * Deduplicates by prerequisite name (first occurrence wins).
+ * Compile a declarative YAML `PrerequisiteSpec` into the imperative
+ * `Prerequisite` shape — synthesizes a `check()` that dispatches on the
+ * detector type and populates the prompt-resolution metadata.
+ */
+export function compilePrerequisiteSpec(spec: PrerequisiteSpec): Prerequisite {
+  const detect = spec.detect;
+  const check = async (): Promise<boolean> => {
+    switch (detect.type) {
+      case 'env': {
+        const val = process.env[detect.key];
+        return typeof val === 'string' && val.length > 0;
+      }
+      case 'command':
+        return commandExists(detect.command);
+      case 'file':
+        try {
+          await access(detect.path);
+          return true;
+        } catch {
+          return false;
+        }
+    }
+  };
+
+  const installHint = spec.description ?? defaultHintForDetect(spec);
+  const envKey = detect.type === 'env' ? detect.key : undefined;
+  const promptOnMissing = spec.promptOnMissing ?? true;
+
+  return {
+    name: spec.name,
+    check,
+    installHint,
+    url: spec.docsUrl,
+    description: spec.description,
+    promptOnMissing,
+    envKey,
+  };
+}
+
+function defaultHintForDetect(spec: PrerequisiteSpec): string {
+  switch (spec.detect.type) {
+    case 'env': return `Set the ${spec.detect.key} environment variable`;
+    case 'command': return `Install "${spec.detect.command}" and add it to your PATH`;
+    case 'file': return `Ensure the file exists: ${spec.detect.path}`;
+  }
+}
+
+/**
+ * Collect unique prerequisites from a spell. Sources, in order:
+ *   1. spell-level YAML (`definition.prerequisites`)
+ *   2. step-level YAML (including nested loop/condition/parallel bodies)
+ *   3. step-command built-ins (imperative, from the registry)
+ *
+ * Deduplicates by name — first occurrence wins.
  */
 export function collectPrerequisites(
   definition: SpellDefinition,
@@ -36,18 +102,45 @@ export function collectPrerequisites(
 ): Prerequisite[] {
   const seen = new Map<string, Prerequisite>();
 
-  for (const step of definition.steps) {
-    const command: StepCommand | undefined = registry.get(step.type);
-    if (!command?.prerequisites) continue;
-
-    for (const prereq of command.prerequisites) {
-      if (!seen.has(prereq.name)) {
-        seen.set(prereq.name, prereq);
+  if (definition.prerequisites) {
+    for (const spec of definition.prerequisites) {
+      if (!seen.has(spec.name)) {
+        seen.set(spec.name, compilePrerequisiteSpec(spec));
       }
     }
   }
 
+  collectFromSteps(definition.steps, registry, seen);
   return Array.from(seen.values());
+}
+
+function collectFromSteps(
+  steps: readonly StepDefinition[],
+  registry: StepCommandRegistry,
+  seen: Map<string, Prerequisite>,
+): void {
+  for (const step of steps) {
+    if (step.prerequisites) {
+      for (const spec of step.prerequisites) {
+        if (!seen.has(spec.name)) {
+          seen.set(spec.name, compilePrerequisiteSpec(spec));
+        }
+      }
+    }
+
+    const command: StepCommand | undefined = registry.get(step.type);
+    if (command?.prerequisites) {
+      for (const prereq of command.prerequisites) {
+        if (!seen.has(prereq.name)) {
+          seen.set(prereq.name, prereq);
+        }
+      }
+    }
+
+    if (step.steps && step.steps.length > 0) {
+      collectFromSteps(step.steps, registry, seen);
+    }
+  }
 }
 
 /**
@@ -87,4 +180,129 @@ export function formatPrerequisiteErrors(results: readonly PrerequisiteResult[])
     if (f.url) lines.push(`    ${f.url}`);
   }
   return lines.join('\n');
+}
+
+// ============================================================================
+// Interactive resolution (TTY prompt + env write-back)
+// ============================================================================
+
+/** One-line reader, injectable for tests. */
+export type PromptLineFn = (promptText: string, abortSignal?: AbortSignal) => Promise<string>;
+
+export interface ResolvePrerequisitesOptions {
+  /** Force interactive/non-interactive mode. Defaults to real stdin+stdout TTY. */
+  readonly interactive?: boolean;
+  readonly abortSignal?: AbortSignal;
+  /** Injectable line reader for tests. Defaults to a readline-based stdin reader. */
+  readonly promptLine?: PromptLineFn;
+  /** Sink for preflight UI output. Defaults to console.log. */
+  readonly log?: (line: string) => void;
+}
+
+export interface ResolvePrerequisitesResult {
+  readonly ok: boolean;
+  /** Present when ok === false. Suitable for surfacing as a SpellError message. */
+  readonly message?: string;
+  /** Names of prereqs that were prompted and resolved this call. */
+  readonly resolvedNames: readonly string[];
+}
+
+/**
+ * Evaluate all prereqs. On a TTY, prompts the user for unmet env-type prereqs
+ * whose spec opted into `promptOnMissing`, writes answers into process.env,
+ * then re-checks. Non-TTY calls and non-promptable unmet prereqs short-circuit
+ * to a single formatted failure report.
+ */
+export async function resolveUnmetPrerequisites(
+  prerequisites: readonly Prerequisite[],
+  options: ResolvePrerequisitesOptions = {},
+): Promise<ResolvePrerequisitesResult> {
+  if (prerequisites.length === 0) {
+    return { ok: true, resolvedNames: [] };
+  }
+
+  const interactive = options.interactive
+    ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const log = options.log ?? ((line: string) => console.log(line));
+
+  const initial = await checkPrerequisites(prerequisites);
+  const unmet = prerequisites.filter((_, i) => !initial[i].satisfied);
+  if (unmet.length === 0) {
+    return { ok: true, resolvedNames: [] };
+  }
+
+  const promptable = unmet.filter(
+    p => interactive && p.promptOnMissing === true && typeof p.envKey === 'string',
+  );
+
+  if (!interactive || promptable.length === 0) {
+    return {
+      ok: false,
+      message: formatPrerequisiteErrors(initial),
+      resolvedNames: [],
+    };
+  }
+
+  printPreflightBanner(log, unmet.length);
+
+  const promptLine = options.promptLine ?? readLineFromStdin;
+  const resolvedNames: string[] = [];
+  const lock = acquireTTYLock();
+  try {
+    for (const prereq of promptable) {
+      if (options.abortSignal?.aborted) {
+        return {
+          ok: false,
+          message: 'Prerequisite resolution aborted',
+          resolvedNames,
+        };
+      }
+      if (prereq.description) log(prereq.description);
+      if (prereq.url) log(`  Docs: ${prereq.url}`);
+      const prompt = `  ${prereq.name} > `;
+      let answer: string;
+      try {
+        answer = await promptLine(prompt, options.abortSignal);
+      } catch (err) {
+        return {
+          ok: false,
+          message: `Prerequisite "${prereq.name}" prompt failed: ${(err as Error).message}`,
+          resolvedNames,
+        };
+      }
+      if (!answer || answer.length === 0) {
+        return {
+          ok: false,
+          message: `Prerequisite "${prereq.name}" was not provided`,
+          resolvedNames,
+        };
+      }
+      if (prereq.envKey) {
+        process.env[prereq.envKey] = answer;
+      }
+      resolvedNames.push(prereq.name);
+    }
+  } finally {
+    lock.release();
+  }
+
+  // Re-check everything — any still unmet (e.g. command/file prereqs that
+  // couldn't be resolved via prompt) fail now with the up-to-date report.
+  const rerun = await checkPrerequisites(prerequisites);
+  const stillUnmet = rerun.filter(r => !r.satisfied);
+  if (stillUnmet.length > 0) {
+    return {
+      ok: false,
+      message: formatPrerequisiteErrors(rerun),
+      resolvedNames,
+    };
+  }
+  return { ok: true, resolvedNames };
+}
+
+function printPreflightBanner(log: (line: string) => void, unmetCount: number): void {
+  log('');
+  log('\x1b[1;36m━━━ Preflight: missing prerequisites ━━━\x1b[0m');
+  log(`${unmetCount} prerequisite${unmetCount === 1 ? '' : 's'} need${unmetCount === 1 ? 's' : ''} a value before this spell can cast.`);
+  log('');
 }

--- a/src/modules/spells/src/core/runner.ts
+++ b/src/modules/spells/src/core/runner.ts
@@ -29,7 +29,7 @@ import { executeParallelSteps } from './parallel-executor.js';
 import { rollbackSteps, type CompletedStep } from './rollback-orchestrator.js';
 import { buildCredentialPatterns, addCredentialPattern, collectCredentialNames } from './credential-masker.js';
 import { executeSingleStep, type StepExecutionState } from './step-executor.js';
-import { collectPrerequisites, checkPrerequisites, formatPrerequisiteErrors } from './prerequisite-checker.js';
+import { collectPrerequisites, resolveUnmetPrerequisites } from './prerequisite-checker.js';
 import {
   collectPreflights,
   checkPreflights,
@@ -152,15 +152,18 @@ export class SpellCaster {
       }
     }
 
-    // Pre-flight prerequisite checks (Story #193)
+    // Pre-flight prerequisite checks — walks YAML + step-command sources,
+    // prompts on a TTY for unmet env-type prereqs (issue #460).
     if (!options.dryRun) {
       const prerequisites = collectPrerequisites(definition, this.registry);
       if (prerequisites.length > 0) {
-        const prereqResults = await checkPrerequisites(prerequisites);
-        if (prereqResults.some(r => !r.satisfied)) {
+        const resolution = await resolveUnmetPrerequisites(prerequisites, {
+          abortSignal: options.signal,
+        });
+        if (!resolution.ok) {
           return this.failureResult(spellId, startTime, [{
             code: 'PREREQUISITES_FAILED',
-            message: formatPrerequisiteErrors(prereqResults),
+            message: resolution.message ?? 'Prerequisites failed',
           }], definition.name);
         }
       }

--- a/src/modules/spells/src/core/stdin-reader.ts
+++ b/src/modules/spells/src/core/stdin-reader.ts
@@ -1,0 +1,31 @@
+/**
+ * Stdin reader — shared interactive-line-of-input helper.
+ *
+ * Used by both the `prompt` step command and the issue-#460 prerequisite
+ * preflight walker; keeps the abort-signal + trimming semantics in one place.
+ */
+import * as readline from 'node:readline';
+
+/**
+ * Read one line from stdin, emitting `promptText` first. Resolves with the
+ * user's trimmed answer (empty string if they just hit enter). Honors an
+ * optional abort signal — rejects with `Error('Prompt aborted')` if fired.
+ */
+export async function readLineFromStdin(
+  promptText: string,
+  abortSignal?: AbortSignal,
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const onAbort = () => { rl.close(); reject(new Error('Prompt aborted')); };
+    if (abortSignal) {
+      if (abortSignal.aborted) { rl.close(); reject(new Error('Prompt aborted')); return; }
+      abortSignal.addEventListener('abort', onAbort, { once: true });
+    }
+    rl.question(promptText, (answer) => {
+      if (abortSignal) abortSignal.removeEventListener('abort', onAbort);
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}

--- a/src/modules/spells/src/index.ts
+++ b/src/modules/spells/src/index.ts
@@ -87,6 +87,11 @@ export {
   checkPrerequisites,
   formatPrerequisiteErrors,
   commandExists,
+  compilePrerequisiteSpec,
+  resolveUnmetPrerequisites,
+  type PromptLineFn,
+  type ResolvePrerequisitesOptions,
+  type ResolvePrerequisitesResult,
 } from './core/prerequisite-checker.js';
 
 export {
@@ -190,6 +195,8 @@ export type {
   PreflightSpec,
   PreflightSeverity,
   PreflightResolution,
+  PrerequisiteSpec,
+  PrerequisiteDetect,
 } from './types/spell-definition.types.js';
 
 export type {

--- a/src/modules/spells/src/schema/validator.ts
+++ b/src/modules/spells/src/schema/validator.ts
@@ -16,6 +16,7 @@ import type {
   StepDefinition,
   ArgumentDefinition,
   ArgumentType,
+  PrerequisiteSpec,
 } from '../types/spell-definition.types.js';
 import { validateStepCapabilities, isValidMofloLevel, compareMofloLevels } from '../core/capability-validator.js';
 import { MOFLO_LEVEL_ORDER } from '../types/step-command.types.js';
@@ -55,6 +56,9 @@ export function validateSpellDefinition(
   }
   if (def.arguments) {
     validateArguments(def.arguments, errors);
+  }
+  if (def.prerequisites !== undefined) {
+    validatePrerequisites(def.prerequisites, errors, 'prerequisites');
   }
   if (def.steps) {
     const stepIds = new Set<string>();
@@ -201,6 +205,11 @@ function validateSteps(
       });
     }
 
+    // Validate declarative prerequisite specs (external deps)
+    if (step.prerequisites !== undefined) {
+      validatePrerequisites(step.prerequisites, errors, `${path}.prerequisites`);
+    }
+
     // Validate declarative preflight specs (runtime state checks)
     if (step.preflight !== undefined) {
       if (!Array.isArray(step.preflight)) {
@@ -266,6 +275,77 @@ function validateSteps(
       }
     }
   }
+}
+
+// ============================================================================
+// Prerequisite spec validation
+// ============================================================================
+
+const VALID_DETECT_TYPES = ['env', 'command', 'file'] as const;
+
+function validatePrerequisites(
+  prereqs: readonly PrerequisiteSpec[],
+  errors: ValidationError[],
+  path: string,
+): void {
+  if (!Array.isArray(prereqs)) {
+    errors.push({ path, message: 'prerequisites must be an array' });
+    return;
+  }
+
+  const seenNames = new Set<string>();
+  prereqs.forEach((p, i) => {
+    const pPath = `${path}[${i}]`;
+    if (!p || typeof p !== 'object') {
+      errors.push({ path: pPath, message: 'prerequisite entry must be an object' });
+      return;
+    }
+    if (typeof p.name !== 'string' || p.name.length === 0) {
+      errors.push({ path: `${pPath}.name`, message: 'prerequisite.name is required' });
+    } else if (seenNames.has(p.name)) {
+      errors.push({
+        path: `${pPath}.name`,
+        message: `duplicate prerequisite name "${p.name}" in the same block`,
+      });
+    } else {
+      seenNames.add(p.name);
+    }
+    if (p.description !== undefined && typeof p.description !== 'string') {
+      errors.push({ path: `${pPath}.description`, message: 'description must be a string' });
+    }
+    if (p.docsUrl !== undefined && typeof p.docsUrl !== 'string') {
+      errors.push({ path: `${pPath}.docsUrl`, message: 'docsUrl must be a string' });
+    }
+    if (p.promptOnMissing !== undefined && typeof p.promptOnMissing !== 'boolean') {
+      errors.push({ path: `${pPath}.promptOnMissing`, message: 'promptOnMissing must be a boolean' });
+    }
+
+    const detect = p.detect as PrerequisiteSpec['detect'] | undefined;
+    if (!detect || typeof detect !== 'object') {
+      errors.push({ path: `${pPath}.detect`, message: 'detect is required and must be an object' });
+      return;
+    }
+    if (!VALID_DETECT_TYPES.includes(detect.type as typeof VALID_DETECT_TYPES[number])) {
+      errors.push({
+        path: `${pPath}.detect.type`,
+        message: `detect.type must be one of: ${VALID_DETECT_TYPES.join(', ')}`,
+      });
+      return;
+    }
+    if (detect.type === 'env') {
+      if (typeof detect.key !== 'string' || detect.key.length === 0) {
+        errors.push({ path: `${pPath}.detect.key`, message: 'detect.key is required for env detector' });
+      }
+    } else if (detect.type === 'command') {
+      if (typeof detect.command !== 'string' || detect.command.length === 0) {
+        errors.push({ path: `${pPath}.detect.command`, message: 'detect.command is required for command detector' });
+      }
+    } else if (detect.type === 'file') {
+      if (typeof detect.path !== 'string' || detect.path.length === 0) {
+        errors.push({ path: `${pPath}.detect.path`, message: 'detect.path is required for file detector' });
+      }
+    }
+  });
 }
 
 // ============================================================================

--- a/src/modules/spells/src/types/spell-definition.types.ts
+++ b/src/modules/spells/src/types/spell-definition.types.ts
@@ -55,6 +55,12 @@ export interface StepDefinition {
    * resolved against spell args only (no prior step outputs yet).
    */
   readonly preflight?: readonly PreflightSpec[];
+  /**
+   * Declarative prerequisites required for this step (env vars, CLI binaries,
+   * files). Collected at cast time across the whole spell tree (including
+   * nested loop/condition/parallel bodies) and evaluated before step 1.
+   */
+  readonly prerequisites?: readonly PrerequisiteSpec[];
 }
 
 /**
@@ -82,6 +88,47 @@ export interface PreflightResolution {
   readonly command?: string;
   /** Timeout in ms for the resolution command (default: 30_000). */
   readonly timeoutMs?: number;
+}
+
+// ============================================================================
+// Prerequisite Specs (declarative, YAML-authored)
+// ============================================================================
+//
+// Distinct from the imperative step-command-owned `Prerequisite` (which carries
+// a `check()` callback) and the step-level `PreflightSpec` (runtime state
+// checks via shell command). A `PrerequisiteSpec` is a declarative, detector-
+// based description of an external dependency (env var, CLI binary, file).
+// Collected at cast time, compiled into the imperative `Prerequisite` shape,
+// and evaluated BEFORE step 1. When unmet on a TTY, the engine prompts once
+// per prereq (env-type writes the answer to `process.env`).
+
+/** Detector discriminator — how to check whether a prerequisite is satisfied. */
+export type PrerequisiteDetect =
+  /** Satisfied when `process.env[key]` is set to a non-empty string. */
+  | { readonly type: 'env'; readonly key: string }
+  /** Satisfied when `command` is resolvable on the system PATH. */
+  | { readonly type: 'command'; readonly command: string }
+  /** Satisfied when `path` exists on disk. */
+  | { readonly type: 'file'; readonly path: string };
+
+/** YAML-declared prerequisite on a spell or step. */
+export interface PrerequisiteSpec {
+  /** Stable name used for dedupe across spell + step + built-in sources. */
+  readonly name: string;
+  /** Short human-readable explanation shown when the prereq is unmet. */
+  readonly description?: string;
+  /** Link to setup docs, shown alongside the description in preflight output. */
+  readonly docsUrl?: string;
+  /** How to detect whether this prereq is satisfied. */
+  readonly detect: PrerequisiteDetect;
+  /**
+   * When true and stdin+stdout are a TTY, prompt the user for the value when
+   * unmet. For `env`-type prereqs the answer is written to `process.env[key]`
+   * so downstream steps (including nested loop bodies) can read it directly.
+   * For `command`/`file` types the prompt surfaces guidance only (no write-back).
+   * Defaults to `true`.
+   */
+  readonly promptOnMissing?: boolean;
 }
 
 /** Declarative preflight check in a step definition. */
@@ -121,6 +168,12 @@ export interface SpellDefinition {
   readonly mofloLevel?: MofloLevel;
   /** Schedule for automatic execution (cron, interval, or one-time). */
   readonly schedule?: ScheduleDefinition;
+  /**
+   * Declarative prerequisites required for this spell (env vars, CLI binaries,
+   * files). Evaluated before step 1; missing env prereqs on a TTY trigger an
+   * interactive prompt. See `PrerequisiteSpec` for detector details.
+   */
+  readonly prerequisites?: readonly PrerequisiteSpec[];
 }
 
 // ============================================================================

--- a/src/modules/spells/src/types/step-command.types.ts
+++ b/src/modules/spells/src/types/step-command.types.ts
@@ -165,12 +165,32 @@ export interface StepCapability {
 /**
  * A prerequisite that must be satisfied before a step command can execute.
  * E.g., `gh` CLI installed and authenticated, Playwright browsers available.
+ *
+ * Optional declarative fields are populated by `compilePrerequisiteSpec()`
+ * when collecting YAML-authored `PrerequisiteSpec` entries — they let the
+ * engine offer interactive resolution (prompt + env write-back) instead of
+ * just failing fast. Step-command-owned prereqs leave these unset and keep
+ * the original install-hint behavior.
  */
 export interface Prerequisite {
   readonly name: string;
   readonly check: () => Promise<boolean>;
   readonly installHint: string;
   readonly url?: string;
+  /** Short description shown in preflight output (from YAML `description`). */
+  readonly description?: string;
+  /**
+   * When true and stdin+stdout are a TTY, prompt the user for the value
+   * when unmet. For env-type prereqs the answer is written to
+   * `process.env[envKey]`; other types surface guidance only.
+   */
+  readonly promptOnMissing?: boolean;
+  /**
+   * Environment variable to write the prompted answer into. Set only when
+   * the prereq compiles from an `env`-type detector. Presence of this field
+   * is what makes a prereq resolvable via prompt.
+   */
+  readonly envKey?: string;
 }
 
 /** Result of checking a single prerequisite. */


### PR DESCRIPTION
## Summary

Adds first-class declarative prerequisites for spells (issue #460).

- Authors can now declare `prerequisites:` at the spell or step level with `detect: { type: env | command | file, key | command | path }`.
- Engine walks the whole spell tree (top-level + nested loop / condition / parallel bodies), dedupes by name across YAML + step-command built-ins, runs the detectors, and — on an interactive TTY — prompts once per unmet env-type prereq, writing the answer into `process.env` so downstream steps (including inside loops) inherit it.
- Non-interactive runs fail fast with a single preflight report listing every unmet prereq and its `docsUrl`, so CI surfaces the full picture instead of failing mid-cast.

## Design note: three concepts, three types

Three related-but-distinct types now coexist in `src/modules/spells`:

| Type | Shape | Purpose |
|------|-------|---------|
| `Prerequisite` | imperative (has `check()` callback) | step-command-owned external deps |
| `PreflightSpec` | declarative, shell-based | per-step runtime state (clean git, dir exists) |
| `PrerequisiteSpec` | declarative, detector-based | **new** — spell/step-level external deps |

`PrerequisiteSpec` compiles into the imperative `Prerequisite` shape at collection time, so `checkPrerequisites` / `formatPrerequisiteErrors` plumbing stays unchanged. The existing `Prerequisite` interface is extended with optional `description` / `promptOnMissing` / `envKey` fields so step-command-owned prereqs can also opt into prompt UX.

## Changes

- `types/spell-definition.types.ts` — add `PrerequisiteSpec`, `PrerequisiteDetect`; `prerequisites?` on `SpellDefinition` + `StepDefinition`.
- `types/step-command.types.ts` — extend `Prerequisite` with optional `description` / `promptOnMissing` / `envKey`.
- `schema/validator.ts` — validate the new block (name, detect.type + detector-specific keys, dedupe within a block).
- `core/prerequisite-checker.ts` — `compilePrerequisiteSpec()`, extended `collectPrerequisites()` walker, new `resolveUnmetPrerequisites()` that gates on `stdin.isTTY && stdout.isTTY` and prompts or fails fast.
- `core/stdin-reader.ts` — **new** shared `readLineFromStdin` helper. `prompt-command.ts` now imports from here instead of duplicating the readline logic.
- `core/runner.ts` — call `resolveUnmetPrerequisites` instead of `collectPrerequisites` → `checkPrerequisites` inline.
- `index.ts` — re-export new types + functions.
- Tests: 20 new unit/integration cases across `prerequisites.test.ts` + `schema.test.ts`.

## Testing

- [x] Unit tests pass — `npx vitest run --config vitest.isolation.config.ts src/modules/spells/__tests__/prerequisites.test.ts` → 34/34
- [x] Full `@moflo/spells` suite — 1139/1139 across 54 files
- [x] `@moflo/cli` suite (downstream consumer) — 2011/2011 (+11 skipped)
- [x] Typecheck clean — `npx tsc --noEmit`

## Out of scope (followup)

- Retrofitting `spells/dev/outlook-attachment-processor.yaml` to drop the hand-rolled `env-graph` / `ask-graph-token` / `env-slack` / `ask-slack-url` chain — lands in a separate PR once this ships.

Closes #460

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: moflo <noreply@motailz.com>