### PR TITLE
feat(epic): declare gh / git / claude as spell-level prerequisites

### DIFF
--- a/src/modules/cli/src/epic/spells/auto-merge.yaml
+++ b/src/modules/cli/src/epic/spells/auto-merge.yaml
@@ -32,6 +32,32 @@ arguments:
 
 mofloLevel: hooks
 
+# Command-presence checks — fail fast with an actionable message if any
+# of these aren't on PATH. Runtime-state checks (auth, dirty tree, remote)
+# still live on the individual steps that need them via `preflight:`.
+prerequisites:
+  - name: gh-cli
+    description: GitHub CLI is required to read issues and manage PRs
+    docsUrl: https://cli.github.com
+    detect:
+      type: command
+      command: gh
+    promptOnMissing: false
+  - name: git
+    description: Git is required for branch management
+    docsUrl: https://git-scm.com/downloads
+    detect:
+      type: command
+      command: git
+    promptOnMissing: false
+  - name: claude-cli
+    description: Claude Code CLI is required to run the story implementer subagent
+    docsUrl: https://docs.anthropic.com/en/docs/claude-code
+    detect:
+      type: command
+      command: claude
+    promptOnMissing: false
+
 steps:
   # Step 1: Initialize epic state in memory (enables resume)
   - id: init-state

--- a/src/modules/cli/src/epic/spells/single-branch.yaml
+++ b/src/modules/cli/src/epic/spells/single-branch.yaml
@@ -37,6 +37,32 @@ arguments:
 
 mofloLevel: hooks
 
+# Command-presence checks — fail fast with an actionable message if any
+# of these aren't on PATH. Runtime-state checks (auth, dirty tree, remote)
+# still live on the individual steps that need them via `preflight:`.
+prerequisites:
+  - name: gh-cli
+    description: GitHub CLI is required to read issues and manage PRs
+    docsUrl: https://cli.github.com
+    detect:
+      type: command
+      command: gh
+    promptOnMissing: false
+  - name: git
+    description: Git is required for branch management
+    docsUrl: https://git-scm.com/downloads
+    detect:
+      type: command
+      command: git
+    promptOnMissing: false
+  - name: claude-cli
+    description: Claude Code CLI is required to run the story implementer subagent
+    docsUrl: https://docs.anthropic.com/en/docs/claude-code
+    detect:
+      type: command
+      command: claude
+    promptOnMissing: false
+
 steps:
   # Step 1: Initialize epic state in memory (enables resume)
   - id: init-state


### PR DESCRIPTION
## Summary

Dogfoods the #460 prerequisites walker (merged via #517) on the first-party epic spells.

Adds a spell-level `prerequisites:` block to both `epic-single-branch` and `epic-auto-merge` declaring `gh`, `git`, and `claude` as command-type prereqs with install-docs URLs. All three use `promptOnMissing: false` — you can't paste a binary into a prompt.

## Why

The existing step-level `preflight:` blocks already cover *runtime state* (`gh auth status`, dirty tree, remote configured). They do NOT cover tool *presence*. If `gh` (or `git` or `claude`) isn't on PATH, the current preflight fails with a cryptic exit code instead of "install `gh` from cli.github.com". This retrofit closes that UX gap.

## Changes

- `src/modules/cli/src/epic/spells/single-branch.yaml` — `prerequisites:` block with `gh-cli`, `git`, `claude-cli`.
- `src/modules/cli/src/epic/spells/auto-merge.yaml` — same block.

Runtime-state preflights inside individual steps are unchanged.

## Testing

- [x] Both retrofitted YAMLs parse + validate cleanly against the shipped #460 validator.
- [x] No step definitions touched; existing behavior preserved.

Closes #519

(Supersedes #520 — that PR auto-closed when its base branch `feature/460-...` was deleted on merge of #517.)