### PR TITLE
feat(spells): retrofit OAP to declarative prerequisites + {env.KEY}

### DIFF
--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -192,6 +192,7 @@ Steps can reference outputs from earlier steps and spell arguments using `{refer
 | Pattern | What it resolves to |
 |---------|-------------------|
 | `{args.environment}` | A spell argument |
+| `{env.GRAPH_ACCESS_TOKEN}` | An environment variable (typically populated by a `prerequisites:` entry with `promptOnMissing: true`) |
 | `{check-branch.stdout}` | The `stdout` field from step `check-branch`'s output |
 | `{run-tests.exitCode}` | The `exitCode` field from step `run-tests` |
 | `{credentials.API_KEY}` | A credential value (redacted in logs) |

--- a/spells/dev/outlook-attachment-processor.yaml
+++ b/spells/dev/outlook-attachment-processor.yaml
@@ -5,7 +5,7 @@ description: >
   downloads any attachments to ~/Downloads/attachments/, then posts a
   summary to Slack. Uses GRAPH_ACCESS_TOKEN env (Graph Explorer token
   works for quick tests; ~1h lifetime). Requires SLACK_WEBHOOK_URL.
-version: "5.0"
+version: "5.1"
 mofloLevel: memory
 
 arguments:
@@ -22,52 +22,36 @@ arguments:
     required: false
     default: "~/Downloads/attachments"
 
+prerequisites:
+  - name: GRAPH_ACCESS_TOKEN
+    description: >
+      Microsoft Graph access token for reading your Outlook/Microsoft 365 inbox.
+      Get one (expires in ~1h): open Graph Explorer, sign in with the account
+      whose mailbox you want to scan, click the "Access token" tab, copy the token.
+    docsUrl: https://developer.microsoft.com/en-us/graph/graph-explorer
+    detect:
+      type: env
+      key: GRAPH_ACCESS_TOKEN
+    promptOnMissing: true
+
+  - name: SLACK_WEBHOOK_URL
+    description: >
+      Slack incoming-webhook URL for the scan summary notification.
+      Get one: open https://api.slack.com/apps, pick or create an app, enable
+      Incoming Webhooks, "Add New Webhook to Workspace", pick the target channel,
+      copy the https://hooks.slack.com/... URL.
+    docsUrl: https://api.slack.com/messaging/webhooks
+    detect:
+      type: env
+      key: SLACK_WEBHOOK_URL
+    promptOnMissing: true
+
 steps:
   - id: ensure-dir
     type: bash
     config:
       command: |
         node -e "var fs=require('fs'),os=require('os');var d='{args.downloadDir}'.replace(/^~/,os.homedir());var o=new Object();o.recursive=true;fs.mkdirSync(d,o);console.log(d);"
-
-  - id: env-graph
-    type: bash
-    config:
-      command: |
-        node -e "process.stdout.write(process.env.GRAPH_ACCESS_TOKEN||'')"
-    output: graphEnv
-
-  - id: ask-graph-token
-    type: prompt
-    config:
-      message: |
-        Microsoft Graph access token needed to read your Outlook/Microsoft 365 inbox.
-        Get one (expires in ~1h):
-          1. Open https://developer.microsoft.com/en-us/graph/graph-explorer
-          2. Sign in with the Microsoft 365 account whose mailbox you want to scan
-          3. Click the "Access token" tab and copy the full token string
-        Paste the token now (or set GRAPH_ACCESS_TOKEN env to skip this prompt)
-      default: "{graphEnv.stdout}"
-    output: graphToken
-
-  - id: env-slack
-    type: bash
-    config:
-      command: |
-        node -e "process.stdout.write(process.env.SLACK_WEBHOOK_URL||'')"
-    output: slackEnv
-
-  - id: ask-slack-url
-    type: prompt
-    config:
-      message: |
-        Slack incoming-webhook URL for the scan summary notification.
-        Get one:
-          1. Open https://api.slack.com/apps → pick (or create) an app
-          2. Features → "Incoming Webhooks" → toggle on → "Add New Webhook to Workspace"
-          3. Pick the channel to post into; copy the https://hooks.slack.com/... URL
-        Paste the webhook URL now (or set SLACK_WEBHOOK_URL env to skip this prompt)
-      default: "{slackEnv.stdout}"
-    output: slackUrl
 
   - id: last-run
     type: memory
@@ -89,7 +73,7 @@ steps:
     type: graph
     config:
       action: read-inbox
-      accessToken: "{graphToken.response}"
+      accessToken: "{env.GRAPH_ACCESS_TOKEN}"
       limit: "{args.maxEmails}"
       sinceDate: "{startDate.response}"
     output: inbox
@@ -111,7 +95,7 @@ steps:
         type: graph
         config:
           action: download-attachments
-          accessToken: "{graphToken.response}"
+          accessToken: "{env.GRAPH_ACCESS_TOKEN}"
           id: "{loop.item.id}"
           downloadDir: "{args.downloadDir}"
 
@@ -119,7 +103,7 @@ steps:
     type: slack
     config:
       action: post-webhook
-      webhookUrl: "{slackUrl.response}"
+      webhookUrl: "{env.SLACK_WEBHOOK_URL}"
       text: |
         📧 Inbox scan complete
         Scanned since: {inbox.sinceDate}

--- a/src/modules/spells/__tests__/interpolation.test.ts
+++ b/src/modules/spells/__tests__/interpolation.test.ts
@@ -4,7 +4,7 @@
  * Story #102: Built-in Step Commands — interpolation utility
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { interpolateString, interpolateConfig } from '../src/core/interpolation.js';
 import { createMockContext as createContext } from './helpers.js';
 
@@ -108,6 +108,45 @@ describe('interpolateString', () => {
     const ctx = createContext({ variables: { step1: { count: 42, ok: true } } });
     expect(interpolateString('{step1.count}', ctx)).toBe('42');
     expect(interpolateString('{step1.ok}', ctx)).toBe('true');
+  });
+
+  describe('{env.KEY} prefix (#518)', () => {
+    const ENV_KEY = 'FLO_INTERP_TEST_518';
+
+    afterEach(() => { delete process.env[ENV_KEY]; });
+
+    it('resolves an env-var reference when set', () => {
+      process.env[ENV_KEY] = 'secret-value';
+      const ctx = createContext();
+      expect(interpolateString(`Bearer {env.${ENV_KEY}}`, ctx)).toBe('Bearer secret-value');
+    });
+
+    it('throws "Variable not found" when env var is unset', () => {
+      delete process.env[ENV_KEY];
+      const ctx = createContext();
+      expect(() => interpolateString(`{env.${ENV_KEY}}`, ctx))
+        .toThrow(`Variable not found: env.${ENV_KEY}`);
+    });
+
+    it('throws when env var is an empty string (matches prereq env detector)', () => {
+      process.env[ENV_KEY] = '';
+      const ctx = createContext();
+      expect(() => interpolateString(`{env.${ENV_KEY}}`, ctx))
+        .toThrow(`Variable not found: env.${ENV_KEY}`);
+    });
+
+    it('does not collide with a step output also named "env"', () => {
+      // If a spell had a step with id "env" producing a field "KEY", that
+      // {env.KEY} would now hit the env-prefix branch first. Document the
+      // expected behaviour: env-prefix wins; when the env var is unset,
+      // interpolation falls through to the variables walk.
+      process.env[ENV_KEY] = 'from-env';
+      const ctx = createContext({ variables: { env: { [ENV_KEY]: 'from-step-output' } } });
+      expect(interpolateString(`{env.${ENV_KEY}}`, ctx)).toBe('from-env');
+
+      delete process.env[ENV_KEY];
+      expect(interpolateString(`{env.${ENV_KEY}}`, ctx)).toBe('from-step-output');
+    });
   });
 });
 

--- a/src/modules/spells/__tests__/prerequisites.test.ts
+++ b/src/modules/spells/__tests__/prerequisites.test.ts
@@ -15,6 +15,8 @@ import {
 } from '../src/core/prerequisite-checker.js';
 import { StepCommandRegistry } from '../src/core/step-command-registry.js';
 import { SpellCaster } from '../src/core/runner.js';
+import { parseSpell } from '../src/schema/parser.js';
+import { validateSpellDefinition } from '../src/schema/validator.js';
 import type {
   StepCommand,
   Prerequisite,
@@ -27,8 +29,10 @@ import type {
   PrerequisiteSpec,
 } from '../src/types/spell-definition.types.js';
 import * as fsPromises from 'node:fs/promises';
+import { accessSync } from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
 
 // ============================================================================
 // Helpers
@@ -604,5 +608,108 @@ describe('resolveUnmetPrerequisites', () => {
       log: () => {},
     });
     expect(result.ok).toBe(false);
+  });
+});
+
+// ============================================================================
+// OAP retrofit (#518) — outlook-attachment-processor.yaml end-to-end
+// ============================================================================
+//
+// Acceptance criteria from issue #518:
+//   - Both tokens are declared as spell-level `prerequisites:`.
+//   - The four hand-rolled preflight steps are removed.
+//   - Casting on a non-TTY without env vars fails fast with BOTH tokens listed
+//     and both docs URLs present in the error report (no partial run).
+
+describe('OAP spell retrofit (#518)', () => {
+  // Walk up from this test file until we find the repo root (where `spells/`
+  // lives). Avoids hard-coding ../ counts, which drift if the test file moves.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  function findOapPath(): string {
+    let dir = here;
+    for (let i = 0; i < 10; i++) {
+      const candidate = path.join(dir, 'spells', 'dev', 'outlook-attachment-processor.yaml');
+      try {
+        accessSync(candidate);
+        return candidate;
+      } catch {
+        // keep walking
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    throw new Error(`Cannot locate spells/dev/outlook-attachment-processor.yaml above ${here}`);
+  }
+  const oapPath = findOapPath();
+
+  async function loadOap(): Promise<SpellDefinition> {
+    const yaml = await fsPromises.readFile(oapPath, 'utf8');
+    const parsed = parseSpell(yaml, oapPath);
+    return parsed.definition;
+  }
+
+  it('parses + validates with both prerequisites declared at spell level', async () => {
+    const def = await loadOap();
+    const result = validateSpellDefinition(def);
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+
+    const prereqNames = (def.prerequisites ?? []).map(p => p.name);
+    expect(prereqNames).toEqual(['GRAPH_ACCESS_TOKEN', 'SLACK_WEBHOOK_URL']);
+  });
+
+  it('has no hand-rolled preflight steps (env-graph/ask-graph-token/env-slack/ask-slack-url)', async () => {
+    const def = await loadOap();
+    const stepIds = def.steps.map(s => s.id);
+    expect(stepIds).not.toContain('env-graph');
+    expect(stepIds).not.toContain('ask-graph-token');
+    expect(stepIds).not.toContain('env-slack');
+    expect(stepIds).not.toContain('ask-slack-url');
+  });
+
+  it('non-TTY without env vars fails fast with both tokens + docs URLs', async () => {
+    const prevGraph = process.env.GRAPH_ACCESS_TOKEN;
+    const prevSlack = process.env.SLACK_WEBHOOK_URL;
+    delete process.env.GRAPH_ACCESS_TOKEN;
+    delete process.env.SLACK_WEBHOOK_URL;
+    try {
+      const def = await loadOap();
+      const prereqs = (def.prerequisites ?? []).map(compilePrerequisiteSpec);
+      const result = await resolveUnmetPrerequisites(prereqs, { interactive: false });
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('GRAPH_ACCESS_TOKEN');
+      expect(result.message).toContain('SLACK_WEBHOOK_URL');
+      expect(result.message).toContain('https://developer.microsoft.com/en-us/graph/graph-explorer');
+      expect(result.message).toContain('https://api.slack.com/messaging/webhooks');
+    } finally {
+      if (prevGraph !== undefined) process.env.GRAPH_ACCESS_TOKEN = prevGraph;
+      if (prevSlack !== undefined) process.env.SLACK_WEBHOOK_URL = prevSlack;
+    }
+  });
+
+  it('with both env vars set, preflight passes without prompting', async () => {
+    const prevGraph = process.env.GRAPH_ACCESS_TOKEN;
+    const prevSlack = process.env.SLACK_WEBHOOK_URL;
+    process.env.GRAPH_ACCESS_TOKEN = 'test-graph-token';
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    try {
+      const def = await loadOap();
+      const prereqs = (def.prerequisites ?? []).map(compilePrerequisiteSpec);
+      const promptLine = vi.fn<PromptLineFn>(async () => 'unreachable');
+      const result = await resolveUnmetPrerequisites(prereqs, {
+        interactive: true,
+        promptLine,
+        log: () => {},
+      });
+      expect(result.ok).toBe(true);
+      expect(result.resolvedNames).toEqual([]);
+      expect(promptLine).not.toHaveBeenCalled();
+    } finally {
+      if (prevGraph === undefined) delete process.env.GRAPH_ACCESS_TOKEN;
+      else process.env.GRAPH_ACCESS_TOKEN = prevGraph;
+      if (prevSlack === undefined) delete process.env.SLACK_WEBHOOK_URL;
+      else process.env.SLACK_WEBHOOK_URL = prevSlack;
+    }
   });
 });

--- a/src/modules/spells/src/core/interpolation.ts
+++ b/src/modules/spells/src/core/interpolation.ts
@@ -31,8 +31,10 @@ export const VAR_REF_PATTERN = /(?<!\$)\{([A-Za-z_][A-Za-z0-9_.-]*)\}/g;
 /**
  * Resolution precedence:
  * 1. {args.key} — explicit args prefix (depth-2 only)
- * 2. {stepId.outputKey} — walk context.variables
- * 3. {key} — single-segment fallback to context.args
+ * 2. {env.KEY} — environment variable (depth-2 only); typically populated
+ *    by a spell-level `prerequisites:` entry with `promptOnMissing: true`
+ * 3. {stepId.outputKey} — walk context.variables
+ * 4. {key} — single-segment fallback to context.args
  */
 function resolveVariable(path: string, context: CastingContext): unknown {
   const segments = path.split('.');
@@ -41,6 +43,12 @@ function resolveVariable(path: string, context: CastingContext): unknown {
   if (segments[0] === 'args' && segments.length === 2) {
     const val = context.args[segments[1]];
     if (val !== undefined) return val;
+  }
+
+  // Environment variable prefix: {env.KEY}
+  if (segments[0] === 'env' && segments.length === 2) {
+    const val = process.env[segments[1]];
+    if (val !== undefined && val.length > 0) return val;
   }
 
   // Walk context.variables (step outputs): {stepId.outputKey}

--- a/src/modules/spells/src/schema/validator.ts
+++ b/src/modules/spells/src/schema/validator.ts
@@ -434,6 +434,12 @@ function checkStringReferences(
       continue;
     }
 
+    // {env.KEY} — resolved at runtime from process.env, typically populated
+    // by a spell-level `prerequisites:` entry with promptOnMissing: true.
+    if (segments[0] === 'env' && segments.length === 2) {
+      continue;
+    }
+
     // {loop.varName} — resolved at runtime by the loop executor
     if (segments[0] === 'loop') {
       continue;
@@ -484,7 +490,12 @@ function validateParallelCrossReferences(
       while ((match = VAR_REF_PATTERN.exec(value)) !== null) {
         const ref = match[1];
         const segments = ref.split('.');
-        if (segments.length >= 2 && segments[0] !== 'args' && segments[0] !== 'credentials') {
+        if (
+          segments.length >= 2
+          && segments[0] !== 'args'
+          && segments[0] !== 'credentials'
+          && segments[0] !== 'env'
+        ) {
           if (siblingIds.has(segments[0]) && segments[0] !== step.id) {
             errors.push({
               path: `${path}.config.${key}`,


### PR DESCRIPTION
## Summary

Resolves #518.

The outlook-attachment-processor spell carried four hand-rolled preflight
steps (`env-graph`/`ask-graph-token`/`env-slack`/`ask-slack-url`) that
duplicated functionality now provided by the prerequisites walker. This PR
retires them and introduces the `{env.KEY}` interpolation primitive so
prereq-populated env vars can be threaded into step config explicitly.

### Design decision (from the ticket's open call)

Picked **Option 1** (new `{env.KEY}` interpolation). Option 2 (connector
env-fallback) is already wired in both `slack.ts:180` and `graph.ts:277-279`
— so the token would flow through regardless — but Option 1 is reusable
across every future spell and keeps the data flow **visible** in YAML
rather than happening silently inside each connector.

## Changes

- `src/modules/spells/src/core/interpolation.ts` — `resolveVariable()` now
  resolves `{env.KEY}` against `process.env[KEY]` (empty string = unset,
  matching the env-detector's rule). Precedence: args > env > variables.
- `src/modules/spells/src/schema/validator.ts` — teach both the
  forward-reference check and the parallel sibling-reference check that
  `env` is a reserved interpolation prefix, not a step id.
- `spells/dev/outlook-attachment-processor.yaml` — declare
  `GRAPH_ACCESS_TOKEN` + `SLACK_WEBHOOK_URL` as spell-level `prerequisites:`
  with detectors + docs URLs; drop the four hand-rolled steps;
  switch `accessToken:` / `webhookUrl:` to `{env.GRAPH_ACCESS_TOKEN}` /
  `{env.SLACK_WEBHOOK_URL}`.
- `docs/SPELLS.md` — add `{env.VARNAME}` to the interpolation reference table.

## Testing

- [x] Unit tests (interpolation): 23/23 pass, including new `{env.KEY}` cases:
      set → resolves; unset/empty → throws `Variable not found: env.KEY`;
      precedence when a step is also named `env`.
- [x] Integration tests (prerequisites.test.ts): 38/38 pass, including four
      new OAP-end-to-end cases — YAML parses + validates, no hand-rolled
      preflight step IDs remain, non-TTY without env vars fails fast listing
      both tokens + both docs URLs, both env vars set → no prompts fire.
- [x] Full spells test suite: 1143/1143 pass.
- [x] Full CLI test suite: 2011/2011 pass (11 skipped).
- [ ] Manual smoke: `flo cast oap` from a fresh shell — deferred to consumer
      project (requires real Graph + Slack tokens).

## Cross-platform

All touched code paths use `process.env`, `path.join`, `fileURLToPath`, and
`accessSync` from `node:fs` — no POSIX-only assumptions, no shell-specific
syntax. The retained `ensure-dir` bash step (untouched by this PR) already
uses `node -e` with `fs`/`os` for Windows compatibility.

Closes #518