### PR TITLE
feat(embeddings): resumable batch re-embed migration driver (#529)

### DIFF
--- a/src/modules/cli/__tests__/memory-movector-deep.test.ts
+++ b/src/modules/cli/__tests__/memory-movector-deep.test.ts
@@ -246,6 +246,12 @@ describe('Memory Initializer', () => {
       expect(sql).toContain("'3.0.0'");
       expect(sql).toContain("'sql.js'");
     });
+
+    it('should seed embeddings_version=2 for fresh databases (epic #527)', async () => {
+      const { getInitialMetadata } = await import('../src/memory/memory-initializer.js');
+      const sql = getInitialMetadata('sql.js');
+      expect(sql).toContain("('embeddings_version', '2')");
+    });
   });
 
   describe('HNSW status', () => {

--- a/src/modules/cli/src/memory/memory-initializer.ts
+++ b/src/modules/cli/src/memory/memory-initializer.ts
@@ -940,7 +940,8 @@ INSERT OR REPLACE INTO metadata (key, value) VALUES
   ('vector_embeddings', 'enabled'),
   ('pattern_learning', 'enabled'),
   ('temporal_decay', 'enabled'),
-  ('hnsw_indexing', 'enabled');
+  ('hnsw_indexing', 'enabled'),
+  ('embeddings_version', '2');
 
 -- Create default vector index configuration
 INSERT OR IGNORE INTO vector_indexes (id, name, dimensions) VALUES

--- a/src/modules/embeddings/__tests__/migration/migrate-store.test.ts
+++ b/src/modules/embeddings/__tests__/migration/migrate-store.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Unit tests for the resumable batch-embed migration driver.
+ *
+ * All tests run against {@link InMemoryMigrationStore} + {@link MockBatchEmbedder}
+ * so they're fully offline and cover the driver's contract without needing
+ * a real ONNX runtime or sql.js file.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  EMBEDDINGS_VERSION,
+  InMemoryMigrationStore,
+  MockBatchEmbedder,
+  migrateStore,
+  type InMemoryItem,
+  type MigrationProgress,
+} from '../../src/migration/index.js';
+
+function makeItems(count: number): InMemoryItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `id-${String(i).padStart(4, '0')}`,
+    sourceText: `content-${i}`,
+  }));
+}
+
+describe('migrateStore', () => {
+  describe('happy path', () => {
+    it('embeds every item, bumps version, clears cursor', async () => {
+      const store = new InMemoryMigrationStore({
+        storeId: 'mem:entries',
+        items: makeItems(5),
+        initialVersion: null,
+      });
+      const embedder = new MockBatchEmbedder(8);
+
+      const result = await migrateStore({ store, embedder, batchSize: 2 });
+
+      expect(result.success).toBe(true);
+      expect(result.itemsMigrated).toBe(5);
+      expect(result.itemsTotal).toBe(5);
+      expect(result.aborted).toBe(false);
+      expect(result.resumed).toBe(false);
+      expect(result.versionBumped).toBe(true);
+      expect(store.getVersionSync()).toBe(EMBEDDINGS_VERSION);
+      expect(store.getCursor()).toBeNull();
+
+      // Every item got its embedding written.
+      for (const item of store.snapshot()) {
+        expect(item.embedding).toBeInstanceOf(Float32Array);
+        expect(item.embedding!.length).toBe(8);
+      }
+    });
+
+    it('handles empty store by bumping version immediately', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: [] });
+      const embedder = new MockBatchEmbedder();
+
+      const result = await migrateStore({ store, embedder });
+
+      expect(result.success).toBe(true);
+      expect(result.itemsMigrated).toBe(0);
+      expect(store.getVersionSync()).toBe(EMBEDDINGS_VERSION);
+      expect(store.stats.beginTransaction).toBe(0);
+    });
+
+    it('skips items with empty source text when counting and iterating', async () => {
+      const store = new InMemoryMigrationStore({
+        storeId: 's',
+        items: [
+          { id: 'a', sourceText: 'hello' },
+          { id: 'b', sourceText: '' },
+          { id: 'c', sourceText: 'world' },
+        ],
+      });
+      const embedder = new MockBatchEmbedder();
+
+      const result = await migrateStore({ store, embedder, batchSize: 10 });
+
+      expect(result.itemsTotal).toBe(2);
+      expect(result.itemsMigrated).toBe(2);
+      expect(embedder.lastInputs).toEqual(['hello', 'world']);
+    });
+  });
+
+  describe('progress events', () => {
+    it('emits start, one batch per commit, and finish in order', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(5) });
+      const embedder = new MockBatchEmbedder();
+      const events: MigrationProgress[] = [];
+
+      await migrateStore({
+        store,
+        embedder,
+        batchSize: 2,
+        onProgress: (p) => events.push(p),
+      });
+
+      // 5 items / batchSize 2 → 3 batches → 1 start + 3 batch + 1 finish.
+      expect(events.map((e) => e.step)).toEqual([
+        'start',
+        'batch',
+        'batch',
+        'batch',
+        'finish',
+      ]);
+      expect(events[0]!.itemsDone).toBe(0);
+      expect(events[1]!.itemsDone).toBe(2);
+      expect(events[2]!.itemsDone).toBe(4);
+      expect(events[3]!.itemsDone).toBe(5);
+      expect(events[4]!.itemsDone).toBe(5);
+      expect(events[4]!.itemsTotal).toBe(5);
+      // Batch events carry a non-negative batchMs.
+      for (const ev of events.slice(1, 4)) {
+        expect(ev.batchMs).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('callback errors do not break the migration', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(4) });
+      const embedder = new MockBatchEmbedder();
+      const callback = vi.fn(() => {
+        throw new Error('subscriber explosion');
+      });
+
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 2,
+        onProgress: callback,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.itemsMigrated).toBe(4);
+      expect(callback.mock.calls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('transaction rollback + retry', () => {
+    it('rolls back and retries on embedder failure, then succeeds', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(3) });
+      // Fail on the first call; the retry re-embeds and commits.
+      const embedder = new MockBatchEmbedder(8, { failAt: 1 });
+      const events: MigrationProgress[] = [];
+
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 3,
+        backoffMs: 0,
+        onProgress: (p) => events.push(p),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.itemsMigrated).toBe(3);
+      expect(embedder.calls).toBe(2); // first attempt failed; retry succeeded.
+      // Embedder throws before `beginTransaction`, so no rollback is needed.
+      expect(store.stats.rollback).toBe(0);
+      expect(events.some((e) => e.step === 'retry' && e.attempt === 1)).toBe(true);
+    });
+
+    it('rolls back and retries on updateBatch failure', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(2) });
+      let tripped = false;
+      store.injector.beforeUpdate = () => {
+        if (!tripped) {
+          tripped = true;
+          throw new Error('injected updateBatch failure');
+        }
+      };
+      const embedder = new MockBatchEmbedder();
+
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 2,
+        backoffMs: 0,
+      });
+
+      expect(result.success).toBe(true);
+      expect(store.stats.rollback).toBe(1);
+      expect(store.stats.commit).toBe(1);
+      expect(embedder.calls).toBe(2); // re-embedded on retry
+    });
+
+    it('gives up after maxRetries and returns success=false without bumping version', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(2) });
+      store.injector.beforeCommit = () => {
+        throw new Error('commit always fails');
+      };
+      const embedder = new MockBatchEmbedder();
+
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 2,
+        maxRetries: 2,
+        backoffMs: 0,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.versionBumped).toBe(false);
+      expect(store.getVersionSync()).toBeNull();
+      expect(store.stats.rollback).toBe(3); // 1 initial + 2 retries = 3 attempts
+      expect(result.errors.length).toBe(3);
+    });
+
+    it('surfaces rollback failures in the errors list without masking the original', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 'store-x', items: makeItems(2) });
+      store.injector.beforeUpdate = () => {
+        throw new Error('original failure');
+      };
+      store.injector.beforeRollback = () => {
+        throw new Error('rollback exploded');
+      };
+      const embedder = new MockBatchEmbedder();
+
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 2,
+        maxRetries: 0,
+        backoffMs: 0,
+      });
+
+      expect(result.success).toBe(false);
+      // Both the original failure and the rollback failure make it into errors,
+      // tagged with the store id so operators can find which store failed.
+      expect(result.errors.some((e) => e.includes('[store-x]') && e.includes('original failure'))).toBe(true);
+      expect(result.errors.some((e) => e.includes('[store-x]') && e.includes('rollback failed: rollback exploded'))).toBe(true);
+    });
+
+    it('rejects an embedder that returns the wrong count of vectors', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(3) });
+      const embedder = new MockBatchEmbedder(8, { miscountAt: 1 });
+
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 3,
+        maxRetries: 0,
+        backoffMs: 0,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors[0]).toMatch(/returned 2 vectors for 3 inputs/);
+    });
+  });
+
+  describe('version bump semantics', () => {
+    it('does not bump version on interrupted runs', async () => {
+      const store = new InMemoryMigrationStore({
+        storeId: 's',
+        items: makeItems(6),
+        initialVersion: 1,
+      });
+      const controller = new AbortController();
+
+      const embedder = new MockBatchEmbedder();
+      const stopAfter = 2; // batches
+      let batchesSeen = 0;
+
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 2,
+        signal: controller.signal,
+        onProgress: (p) => {
+          if (p.step === 'batch') {
+            batchesSeen++;
+            if (batchesSeen === stopAfter) controller.abort('user cancelled');
+          }
+        },
+      });
+
+      expect(result.aborted).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.versionBumped).toBe(false);
+      expect(store.getVersionSync()).toBe(1); // unchanged
+      expect(result.itemsMigrated).toBe(4);
+      expect(store.getCursor()).not.toBeNull();
+    });
+
+    it('only bumps version after every batch commits', async () => {
+      const store = new InMemoryMigrationStore({
+        storeId: 's',
+        items: makeItems(10),
+        initialVersion: null,
+      });
+      const embedder = new MockBatchEmbedder();
+
+      // Observe: version must stay null during batches, flip to EMBEDDINGS_VERSION after finish.
+      const versionsDuring: (number | null)[] = [];
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 2,
+        onProgress: (p) => {
+          if (p.step === 'batch') versionsDuring.push(store.getVersionSync());
+        },
+      });
+
+      expect(result.success).toBe(true);
+      for (const v of versionsDuring) expect(v).toBeNull();
+      expect(store.getVersionSync()).toBe(EMBEDDINGS_VERSION);
+    });
+  });
+
+  describe('resumability + idempotency', () => {
+    it('resumes from persisted cursor after an abort and produces identical end state', async () => {
+      const items = makeItems(6);
+
+      // First run: abort after 2 batches.
+      const storeA = new InMemoryMigrationStore({ storeId: 's', items, initialVersion: null });
+      const controller = new AbortController();
+      let batches = 0;
+
+      await migrateStore({
+        store: storeA,
+        embedder: new MockBatchEmbedder(),
+        batchSize: 2,
+        signal: controller.signal,
+        onProgress: (p) => {
+          if (p.step === 'batch') {
+            batches++;
+            if (batches === 2) controller.abort();
+          }
+        },
+      });
+
+      // Confirm cursor was persisted and some items have embeddings.
+      const cursorMid = storeA.getCursor();
+      expect(cursorMid).not.toBeNull();
+      expect(cursorMid!.itemsDone).toBe(4);
+      expect(storeA.getVersionSync()).toBeNull();
+
+      // Second run: resume. (New embedder so we can count calls cleanly.)
+      const embedderB = new MockBatchEmbedder();
+      const result = await migrateStore({
+        store: storeA,
+        embedder: embedderB,
+        batchSize: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.resumed).toBe(true);
+      expect(result.itemsMigrated).toBe(6); // running total from cursor
+      expect(storeA.getVersionSync()).toBe(EMBEDDINGS_VERSION);
+      expect(storeA.getCursor()).toBeNull();
+
+      // On resume we only re-embedded the remaining 2 items (1 batch).
+      expect(embedderB.calls).toBe(1);
+      expect(embedderB.history[0]!.sort()).toEqual(['content-4', 'content-5']);
+
+      // Compare final state against a clean full run — they should match.
+      const storeC = new InMemoryMigrationStore({ storeId: 's', items, initialVersion: null });
+      await migrateStore({ store: storeC, embedder: new MockBatchEmbedder(), batchSize: 2 });
+
+      const a = storeA.snapshot();
+      const c = storeC.snapshot();
+      expect(a.length).toBe(c.length);
+      for (let i = 0; i < a.length; i++) {
+        expect(a[i]!.id).toBe(c[i]!.id);
+        expect(Array.from(a[i]!.embedding!)).toEqual(Array.from(c[i]!.embedding!));
+      }
+    });
+
+    it('re-running a completed migration is a no-op against the same store', async () => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(3) });
+      const embedder = new MockBatchEmbedder();
+
+      await migrateStore({ store, embedder, batchSize: 2 });
+      const firstVersion = store.getVersionSync();
+      const firstSnapshot = store.snapshot();
+
+      // Second call: no cursor → walks items, re-embeds them (idempotent),
+      // bumps version again to the same value. The driver does not
+      // short-circuit based on the existing version — that check belongs to
+      // the caller that decides whether to trigger migration in the first
+      // place (story 3). We just assert it does not corrupt anything.
+      const second = await migrateStore({ store, embedder, batchSize: 2 });
+      expect(second.success).toBe(true);
+      expect(store.getVersionSync()).toBe(firstVersion);
+      expect(store.snapshot().map((i) => i.id)).toEqual(firstSnapshot.map((i) => i.id));
+    });
+  });
+
+  describe('abort', () => {
+    it('returns cleanly when aborted before any batch', async () => {
+      const controller = new AbortController();
+      controller.abort('cancelled before start');
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(4) });
+      const embedder = new MockBatchEmbedder();
+
+      const result = await migrateStore({
+        store,
+        embedder,
+        batchSize: 2,
+        signal: controller.signal,
+      });
+
+      expect(result.aborted).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.itemsMigrated).toBe(0);
+      expect(embedder.calls).toBe(0);
+      expect(store.getVersionSync()).toBeNull();
+    });
+  });
+
+  describe('option validation', () => {
+    it.each([
+      { name: 'batchSize <= 0', opt: { batchSize: 0 } },
+      { name: 'maxRetries < 0', opt: { maxRetries: -1 } },
+      { name: 'backoffMs < 0', opt: { backoffMs: -1 } },
+    ])('rejects $name', async ({ opt }) => {
+      const store = new InMemoryMigrationStore({ storeId: 's', items: makeItems(1) });
+      const embedder = new MockBatchEmbedder();
+      await expect(migrateStore({ store, embedder, ...opt })).rejects.toThrow(RangeError);
+    });
+  });
+});

--- a/src/modules/embeddings/__tests__/migration/sqljs-helpers.test.ts
+++ b/src/modules/embeddings/__tests__/migration/sqljs-helpers.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for sqljs-helpers — the shared cursor/version utilities every real
+ * store adapter uses. Runs against an in-memory sql.js database so it
+ * exercises the actual SQL, not a mock.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import {
+  EMBEDDINGS_VERSION_KEY,
+  clearCursorRow,
+  ensureCursorTable,
+  ensureMetadataTable,
+  loadCursorRow,
+  readEmbeddingsVersion,
+  saveCursorRow,
+  writeEmbeddingsVersion,
+  type SqlJsDatabase,
+} from '../../src/migration/index.js';
+
+// Shared sql.js module, loaded once.
+type SqlJsStatic = { Database: new () => SqlJsDatabase };
+let SQL: SqlJsStatic;
+
+beforeAll(async () => {
+  const initSqlJs = (await import('sql.js')).default;
+  SQL = (await initSqlJs()) as SqlJsStatic;
+});
+
+function freshDb(): SqlJsDatabase {
+  return new SQL.Database();
+}
+
+describe('version marker helpers', () => {
+  it('returns null when no metadata table exists', () => {
+    const db = freshDb();
+    expect(readEmbeddingsVersion(db)).toBeNull();
+  });
+
+  it('returns null when marker row is absent', () => {
+    const db = freshDb();
+    ensureMetadataTable(db);
+    expect(readEmbeddingsVersion(db)).toBeNull();
+  });
+
+  it('round-trips the version', () => {
+    const db = freshDb();
+    writeEmbeddingsVersion(db, 2);
+    expect(readEmbeddingsVersion(db)).toBe(2);
+  });
+
+  it('upserts rather than duplicating the row', () => {
+    const db = freshDb();
+    writeEmbeddingsVersion(db, 1);
+    writeEmbeddingsVersion(db, 2);
+    writeEmbeddingsVersion(db, 3);
+    expect(readEmbeddingsVersion(db)).toBe(3);
+    const count = db.exec(
+      `SELECT COUNT(*) FROM metadata WHERE key = '${EMBEDDINGS_VERSION_KEY}'`,
+    );
+    expect(Number(count[0]!.values[0]![0])).toBe(1);
+  });
+
+  it('uses the shared `metadata` table so it coexists with existing keys', () => {
+    const db = freshDb();
+    ensureMetadataTable(db);
+    db.run(`INSERT INTO metadata (key, value) VALUES ('schema_version', '3.0.0')`);
+    writeEmbeddingsVersion(db, 2);
+    expect(readEmbeddingsVersion(db)).toBe(2);
+    const otherResult = db.exec(
+      `SELECT value FROM metadata WHERE key = 'schema_version'`,
+    );
+    expect(String(otherResult[0]!.values[0]![0])).toBe('3.0.0');
+  });
+});
+
+describe('cursor helpers', () => {
+  const now = 1_700_000_000_000;
+
+  it('returns null when the cursor row is absent', () => {
+    const db = freshDb();
+    expect(loadCursorRow(db, 'my-store')).toBeNull();
+  });
+
+  it('round-trips a cursor', () => {
+    const db = freshDb();
+    saveCursorRow(db, {
+      storeId: 'mem:entries',
+      lastProcessedId: 'id-0042',
+      itemsDone: 42,
+      itemsTotal: 100,
+      startedAt: now,
+      updatedAt: now + 500,
+    });
+    const loaded = loadCursorRow(db, 'mem:entries');
+    expect(loaded).toEqual({
+      storeId: 'mem:entries',
+      lastProcessedId: 'id-0042',
+      itemsDone: 42,
+      itemsTotal: 100,
+      startedAt: now,
+      updatedAt: now + 500,
+    });
+  });
+
+  it('scopes rows by store id — multiple stores in one DB do not collide', () => {
+    const db = freshDb();
+    saveCursorRow(db, {
+      storeId: 'memory:entries',
+      lastProcessedId: 'a-100',
+      itemsDone: 100,
+      itemsTotal: 200,
+      startedAt: now,
+      updatedAt: now,
+    });
+    saveCursorRow(db, {
+      storeId: 'memory:patterns',
+      lastProcessedId: 'p-7',
+      itemsDone: 7,
+      itemsTotal: 20,
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    const entries = loadCursorRow(db, 'memory:entries');
+    const patterns = loadCursorRow(db, 'memory:patterns');
+    expect(entries?.itemsDone).toBe(100);
+    expect(patterns?.itemsDone).toBe(7);
+  });
+
+  it('upserts on repeated save', () => {
+    const db = freshDb();
+    saveCursorRow(db, {
+      storeId: 's',
+      lastProcessedId: 'x-1',
+      itemsDone: 1,
+      itemsTotal: 10,
+      startedAt: now,
+      updatedAt: now,
+    });
+    saveCursorRow(db, {
+      storeId: 's',
+      lastProcessedId: 'x-5',
+      itemsDone: 5,
+      itemsTotal: 10,
+      startedAt: now,
+      updatedAt: now + 10,
+    });
+    expect(loadCursorRow(db, 's')?.itemsDone).toBe(5);
+  });
+
+  it('clearCursorRow removes only the targeted store', () => {
+    const db = freshDb();
+    saveCursorRow(db, {
+      storeId: 'a',
+      lastProcessedId: 'a-1',
+      itemsDone: 1,
+      itemsTotal: 2,
+      startedAt: now,
+      updatedAt: now,
+    });
+    saveCursorRow(db, {
+      storeId: 'b',
+      lastProcessedId: 'b-1',
+      itemsDone: 1,
+      itemsTotal: 2,
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    clearCursorRow(db, 'a');
+    expect(loadCursorRow(db, 'a')).toBeNull();
+    expect(loadCursorRow(db, 'b')).not.toBeNull();
+  });
+
+  it('ensureCursorTable is idempotent', () => {
+    const db = freshDb();
+    ensureCursorTable(db);
+    ensureCursorTable(db);
+    ensureCursorTable(db);
+    saveCursorRow(db, {
+      storeId: 's',
+      lastProcessedId: null,
+      itemsDone: 0,
+      itemsTotal: 5,
+      startedAt: now,
+      updatedAt: now,
+    });
+    expect(loadCursorRow(db, 's')?.lastProcessedId).toBeNull();
+  });
+});

--- a/src/modules/embeddings/src/index.ts
+++ b/src/modules/embeddings/src/index.ts
@@ -43,6 +43,35 @@ export { RvfEmbeddingService } from './rvf-embedding-service.js';
 // Fastembed embedding service (ONNX-based neural embeddings via Qdrant's fastembed)
 export { FastembedEmbeddingService } from './fastembed-embedding-service.js';
 
+// Embeddings-version migration driver (resumable batch re-embed)
+export {
+  EMBEDDINGS_VERSION,
+  EMBEDDINGS_VERSION_KEY,
+  migrateStore,
+  ensureCursorTable,
+  ensureMetadataTable,
+  readEmbeddingsVersion,
+  writeEmbeddingsVersion,
+  loadCursorRow,
+  saveCursorRow,
+  clearCursorRow,
+  InMemoryMigrationStore,
+  MockBatchEmbedder,
+  type MigrateStoreOptions,
+  type MigrationBatchUpdate,
+  type MigrationCursor,
+  type MigrationEmbedder,
+  type MigrationItem,
+  type MigrationProgress,
+  type MigrationResult,
+  type MigrationStore,
+  type InMemoryItem,
+  type InMemoryStoreOptions,
+  type FailureInjector,
+  type SqlJsDatabase,
+  type SqlJsStatement,
+} from './migration/index.js';
+
 // RVF embedding cache (binary file persistence)
 export {
   RvfEmbeddingCache,

--- a/src/modules/embeddings/src/migration/in-memory-store.ts
+++ b/src/modules/embeddings/src/migration/in-memory-store.ts
@@ -1,0 +1,246 @@
+/**
+ * In-memory reference `MigrationStore` — the test fixture for the driver.
+ *
+ * Backed by plain maps, with optional per-call failure injection so unit
+ * tests can exercise rollback and retry without wiring up sql.js. New
+ * adapters can mirror this shape when they land.
+ *
+ * @module @moflo/embeddings/migration/in-memory-store
+ */
+
+import type {
+  MigrationBatchUpdate,
+  MigrationCursor,
+  MigrationItem,
+  MigrationStore,
+} from './types.js';
+
+export interface InMemoryItem {
+  id: string;
+  sourceText: string;
+  embedding?: Float32Array;
+}
+
+export interface InMemoryStoreOptions {
+  storeId: string;
+  items: InMemoryItem[];
+  initialVersion?: number | null;
+}
+
+/**
+ * Injection points: each hook returns `void` to pass and `throws` to fail.
+ * `trip` set to a positive number counts down and throws at 0, allowing
+ * precise control over which attempt fails inside a retry loop.
+ */
+export interface FailureInjector {
+  beforeEmbed?: () => void;
+  beforeUpdate?: () => void;
+  beforeCommit?: () => void;
+  beforeRollback?: () => void;
+  /** `null` = abort only at the next batch boundary (async check). */
+  abortAt?: number | null;
+}
+
+export class InMemoryMigrationStore implements MigrationStore {
+  readonly storeId: string;
+
+  private items: InMemoryItem[];
+  private version: number | null;
+  private cursor: MigrationCursor | null = null;
+
+  // Transaction shadow state — mutations are staged here until commit.
+  private inTx = false;
+  private txUpdates: MigrationBatchUpdate[] = [];
+  private txCursor: MigrationCursor | null = null;
+  private txCursorStaged = false;
+
+  // Stats exposed for assertions.
+  public stats = {
+    beginTransaction: 0,
+    commit: 0,
+    rollback: 0,
+    updateBatchCalls: 0,
+    saveCursorCalls: 0,
+    embedCallArgs: [] as string[][],
+  };
+
+  public injector: FailureInjector = {};
+
+  constructor(opts: InMemoryStoreOptions) {
+    this.storeId = opts.storeId;
+    // Keep a sorted-by-id snapshot so `iterItems` is deterministic.
+    this.items = [...opts.items].sort((a, b) => compareIds(a.id, b.id));
+    this.version = opts.initialVersion ?? null;
+  }
+
+  async countItems(): Promise<number> {
+    return this.items.filter((i) => i.sourceText.length > 0).length;
+  }
+
+  async iterItems(afterId: string | null, limit: number): Promise<MigrationItem[]> {
+    const startIndex = afterId === null ? 0 : indexAfter(this.items, afterId);
+    const out: MigrationItem[] = [];
+    for (let i = startIndex; i < this.items.length && out.length < limit; i++) {
+      const item = this.items[i]!;
+      if (item.sourceText.length === 0) continue;
+      out.push({ id: item.id, sourceText: item.sourceText });
+    }
+    return out;
+  }
+
+  async updateBatch(updates: readonly MigrationBatchUpdate[]): Promise<void> {
+    this.stats.updateBatchCalls++;
+    this.assertInTx('updateBatch');
+    this.injector.beforeUpdate?.();
+    // Stage — do not touch `items` until commit.
+    this.txUpdates.push(...updates);
+  }
+
+  async saveCursor(cursor: MigrationCursor): Promise<void> {
+    this.stats.saveCursorCalls++;
+    this.assertInTx('saveCursor');
+    this.txCursor = { ...cursor };
+    this.txCursorStaged = true;
+  }
+
+  async loadCursor(): Promise<MigrationCursor | null> {
+    return this.cursor ? { ...this.cursor } : null;
+  }
+
+  async clearCursor(): Promise<void> {
+    this.cursor = null;
+  }
+
+  async getVersion(): Promise<number | null> {
+    return this.version;
+  }
+
+  async setVersion(version: number): Promise<void> {
+    this.version = version;
+  }
+
+  async beginTransaction(): Promise<void> {
+    if (this.inTx) {
+      throw new Error(
+        `[${this.storeId}] beginTransaction called while already in transaction`,
+      );
+    }
+    this.stats.beginTransaction++;
+    this.inTx = true;
+    this.resetTxState();
+  }
+
+  async commit(): Promise<void> {
+    this.assertInTx('commit');
+    this.injector.beforeCommit?.();
+    // Apply staged updates atomically.
+    for (const update of this.txUpdates) {
+      const idx = this.items.findIndex((item) => item.id === update.id);
+      if (idx === -1) {
+        throw new Error(`[${this.storeId}] commit: no item with id=${update.id}`);
+      }
+      this.items[idx] = { ...this.items[idx]!, embedding: update.embedding };
+    }
+    if (this.txCursorStaged) {
+      this.cursor = this.txCursor;
+    }
+    this.stats.commit++;
+    this.inTx = false;
+    this.resetTxState();
+  }
+
+  async rollback(): Promise<void> {
+    this.assertInTx('rollback');
+    this.injector.beforeRollback?.();
+    this.stats.rollback++;
+    this.inTx = false;
+    this.resetTxState();
+  }
+
+  private resetTxState(): void {
+    this.txUpdates = [];
+    this.txCursor = null;
+    this.txCursorStaged = false;
+  }
+
+  snapshot(): ReadonlyArray<InMemoryItem> {
+    return this.items.map((i) => ({ ...i, embedding: i.embedding?.slice() }));
+  }
+
+  getCursor(): MigrationCursor | null {
+    return this.cursor ? { ...this.cursor } : null;
+  }
+
+  getVersionSync(): number | null {
+    return this.version;
+  }
+
+  private assertInTx(op: string): void {
+    if (!this.inTx) {
+      throw new Error(`[${this.storeId}] ${op} called outside of a transaction`);
+    }
+  }
+}
+
+/**
+ * A deterministic mock embedder — returns a `Float32Array` of `dimensions`
+ * length seeded from the text so assertions can verify "the right text was
+ * embedded" without relying on a real ONNX runtime.
+ *
+ * Pass `failAt: N` to make the Nth call throw (1-indexed), exercising retry
+ * semantics. Pass `miscountAt: N` to return the wrong number of vectors on
+ * the Nth call, exercising defensive validation in the driver.
+ */
+export class MockBatchEmbedder {
+  public calls = 0;
+  public lastInputs: string[] = [];
+  public history: string[][] = [];
+
+  constructor(
+    private readonly dimensions = 8,
+    private readonly options: { failAt?: number; miscountAt?: number } = {},
+  ) {}
+
+  async embedBatch(texts: string[]): Promise<Float32Array[]> {
+    this.calls++;
+    this.lastInputs = [...texts];
+    this.history.push([...texts]);
+
+    if (this.options.failAt === this.calls) {
+      throw new Error(`mock embedder: injected failure on call ${this.calls}`);
+    }
+
+    const out: Float32Array[] = texts.map((text) => seedVector(text, this.dimensions));
+    if (this.options.miscountAt === this.calls) {
+      return out.slice(0, Math.max(0, out.length - 1));
+    }
+    return out;
+  }
+}
+
+function seedVector(text: string, dim: number): Float32Array {
+  const v = new Float32Array(dim);
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = (h * 0x01000193) >>> 0;
+  }
+  for (let i = 0; i < dim; i++) {
+    // Deterministic per (text, index). Small numbers so equality is easy.
+    v[i] = ((h ^ (i * 0x9e3779b1)) >>> 0) / 0xffffffff;
+  }
+  return v;
+}
+
+function indexAfter(items: InMemoryItem[], afterId: string): number {
+  // Linear scan is plenty for tests and reference use.
+  for (let i = 0; i < items.length; i++) {
+    if (compareIds(items[i]!.id, afterId) > 0) return i;
+  }
+  return items.length;
+}
+
+function compareIds(a: string, b: string): number {
+  // Natural string compare — consumers should use sortable IDs (UUIDv7, ULID, etc.).
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/src/modules/embeddings/src/migration/index.ts
+++ b/src/modules/embeddings/src/migration/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Embeddings migration — barrel file.
+ *
+ * @module @moflo/embeddings/migration
+ */
+
+export {
+  EMBEDDINGS_VERSION,
+  type MigrateStoreOptions,
+  type MigrationBatchUpdate,
+  type MigrationCursor,
+  type MigrationEmbedder,
+  type MigrationItem,
+  type MigrationProgress,
+  type MigrationResult,
+  type MigrationStore,
+} from './types.js';
+
+export { migrateStore } from './migrate-store.js';
+
+export {
+  InMemoryMigrationStore,
+  MockBatchEmbedder,
+  type FailureInjector,
+  type InMemoryItem,
+  type InMemoryStoreOptions,
+} from './in-memory-store.js';
+
+export {
+  EMBEDDINGS_VERSION_KEY,
+  ensureMetadataTable,
+  readEmbeddingsVersion,
+  writeEmbeddingsVersion,
+  ensureCursorTable,
+  loadCursorRow,
+  saveCursorRow,
+  clearCursorRow,
+  type SqlJsDatabase,
+  type SqlJsStatement,
+} from './sqljs-helpers.js';

--- a/src/modules/embeddings/src/migration/migrate-store.ts
+++ b/src/modules/embeddings/src/migration/migrate-store.ts
@@ -1,0 +1,306 @@
+/**
+ * Resumable, transactional batch-embed migration driver.
+ *
+ * Walks every eligible row in a store, re-embeds its `sourceText` through
+ * the supplied embedder, writes new vectors back in batch transactions, and
+ * bumps the store's `embeddings_version` marker to {@link EMBEDDINGS_VERSION}
+ * only once the final batch commits.
+ *
+ * Semantics:
+ *   - Resumable: persists a cursor per store; a second call with the same
+ *     arguments after an abort picks up exactly where the previous call left
+ *     off and yields the same end state.
+ *   - Transactional per batch: `beginTransaction` → `updateBatch` +
+ *     `saveCursor` → `commit`. On any error inside the critical section the
+ *     driver calls `rollback` and retries the batch up to `maxRetries` times
+ *     with exponential backoff.
+ *   - Abort-safe: the signal is checked at batch boundaries. When fired, the
+ *     driver flushes the in-flight batch (if any), persists the cursor, and
+ *     returns `aborted: true` — it never leaves a half-written batch.
+ *   - One-shot version bump: `setVersion(EMBEDDINGS_VERSION)` runs only after
+ *     the last batch commits; interrupted runs leave the old version (or
+ *     `null`) intact so the next open re-triggers migration.
+ *
+ * @module @moflo/embeddings/migration/migrate-store
+ */
+
+import {
+  EMBEDDINGS_VERSION,
+  type MigrateStoreOptions,
+  type MigrationBatchUpdate,
+  type MigrationCursor,
+  type MigrationItem,
+  type MigrationProgress,
+  type MigrationResult,
+} from './types.js';
+
+const DEFAULT_BATCH_SIZE = 32;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BACKOFF_MS = 50;
+
+export async function migrateStore(options: MigrateStoreOptions): Promise<MigrationResult> {
+  const {
+    store,
+    embedder,
+    batchSize = DEFAULT_BATCH_SIZE,
+    maxRetries = DEFAULT_MAX_RETRIES,
+    backoffMs = DEFAULT_BACKOFF_MS,
+    onProgress,
+    signal,
+  } = options;
+
+  if (batchSize <= 0) throw new RangeError('batchSize must be > 0');
+  if (maxRetries < 0) throw new RangeError('maxRetries must be >= 0');
+  if (backoffMs < 0) throw new RangeError('backoffMs must be >= 0');
+
+  const emit = (progress: MigrationProgress): void => {
+    if (!onProgress) return;
+    try {
+      onProgress(progress);
+    } catch {
+      // Progress callbacks are strictly informational — swallow subscriber
+      // failures so they cannot break the migration itself.
+    }
+  };
+
+  const startedAt = Date.now();
+  const errors: string[] = [];
+
+  const itemsTotal = await store.countItems();
+  const existing = await store.loadCursor();
+  const resumed = existing !== null;
+
+  const cursor: MigrationCursor = existing ?? {
+    storeId: store.storeId,
+    lastProcessedId: null,
+    itemsDone: 0,
+    itemsTotal,
+    startedAt,
+    updatedAt: startedAt,
+  };
+  // If total changed between runs (rows added/removed), prefer the current count.
+  cursor.itemsTotal = itemsTotal;
+
+  emit({ step: 'start', itemsDone: cursor.itemsDone, itemsTotal, batchMs: 0 });
+
+  if (itemsTotal === 0) {
+    // Nothing to do — still bump the version so fresh stores mark correctly.
+    await store.setVersion(EMBEDDINGS_VERSION);
+    await store.clearCursor();
+    emit({ step: 'finish', itemsDone: 0, itemsTotal: 0, batchMs: 0 });
+    return {
+      success: true,
+      itemsMigrated: 0,
+      itemsTotal: 0,
+      durationMs: Date.now() - startedAt,
+      resumed,
+      aborted: false,
+      versionBumped: true,
+      errors,
+    };
+  }
+
+  while (true) {
+    if (signal?.aborted) {
+      emit({
+        step: 'aborted',
+        itemsDone: cursor.itemsDone,
+        itemsTotal: cursor.itemsTotal,
+        batchMs: 0,
+        error: describeAbort(signal),
+      });
+      return {
+        success: false,
+        itemsMigrated: cursor.itemsDone,
+        itemsTotal: cursor.itemsTotal,
+        durationMs: Date.now() - startedAt,
+        resumed,
+        aborted: true,
+        versionBumped: false,
+        errors,
+      };
+    }
+
+    const batch = await store.iterItems(cursor.lastProcessedId, batchSize);
+    if (batch.length === 0) break;
+
+    const batchStart = Date.now();
+    const committed = await commitBatchWithRetry({
+      store,
+      embedder,
+      batch,
+      cursor,
+      maxRetries,
+      backoffMs,
+      emit,
+      errors,
+    });
+
+    if (!committed) {
+      // Exhausted retries — bail out without bumping the version so the next
+      // run re-tries this batch from the last good cursor.
+      return {
+        success: false,
+        itemsMigrated: cursor.itemsDone,
+        itemsTotal: cursor.itemsTotal,
+        durationMs: Date.now() - startedAt,
+        resumed,
+        aborted: false,
+        versionBumped: false,
+        errors,
+      };
+    }
+
+    const batchMs = Date.now() - batchStart;
+    emit({
+      step: 'batch',
+      itemsDone: cursor.itemsDone,
+      itemsTotal: cursor.itemsTotal,
+      batchMs,
+    });
+  }
+
+  // All batches committed — mark the schema and drop the resume cursor.
+  await store.setVersion(EMBEDDINGS_VERSION);
+  await store.clearCursor();
+
+  emit({
+    step: 'finish',
+    itemsDone: cursor.itemsDone,
+    itemsTotal: cursor.itemsTotal,
+    batchMs: 0,
+  });
+
+  return {
+    success: true,
+    itemsMigrated: cursor.itemsDone,
+    itemsTotal: cursor.itemsTotal,
+    durationMs: Date.now() - startedAt,
+    resumed,
+    aborted: false,
+    versionBumped: true,
+    errors,
+  };
+}
+
+interface CommitContext {
+  store: MigrateStoreOptions['store'];
+  embedder: MigrateStoreOptions['embedder'];
+  batch: MigrationItem[];
+  cursor: MigrationCursor;
+  maxRetries: number;
+  backoffMs: number;
+  emit: (p: MigrationProgress) => void;
+  errors: string[];
+}
+
+/**
+ * Embed a batch, write it, and commit — retrying the whole sequence (including
+ * re-embedding) up to `maxRetries` times on failure. Returns `true` on success,
+ * `false` when retries are exhausted.
+ */
+async function commitBatchWithRetry(ctx: CommitContext): Promise<boolean> {
+  const { store, batch, cursor, maxRetries, backoffMs, emit, errors } = ctx;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const outcome = await attemptBatchOnce(ctx);
+    if (outcome.ok) return true;
+
+    const firstId = batch[0]?.id ?? '?';
+    errors.push(
+      `[${store.storeId}] batch attempt ${attempt + 1} (ids ${firstId}..): ${outcome.error}`,
+    );
+    emit({
+      step: 'retry',
+      itemsDone: cursor.itemsDone,
+      itemsTotal: cursor.itemsTotal,
+      batchMs: 0,
+      attempt: attempt + 1,
+      error: outcome.error,
+    });
+
+    if (attempt === maxRetries) return false;
+    await sleep(backoffMs * Math.pow(2, attempt));
+  }
+  return false;
+}
+
+type AttemptOutcome = { ok: true } | { ok: false; error: string };
+
+/**
+ * A single embed+commit attempt. Any thrown error (embed, update, save, or
+ * commit) is caught once here, rollback is attempted, and the error is
+ * surfaced through the returned outcome. This keeps the retry loop flat.
+ */
+async function attemptBatchOnce(ctx: CommitContext): Promise<AttemptOutcome> {
+  const { store, embedder, batch, cursor, errors } = ctx;
+
+  try {
+    const texts = batch.map((item) => item.sourceText);
+    const vectors = await embedder.embedBatch(texts);
+    if (vectors.length !== batch.length) {
+      throw new Error(
+        `embedder returned ${vectors.length} vectors for ${batch.length} inputs`,
+      );
+    }
+
+    const updates: MigrationBatchUpdate[] = batch.map((item, i) => ({
+      id: item.id,
+      // Safe: `vectors.length === batch.length` guarded above.
+      embedding: vectors[i]!,
+    }));
+
+    await store.beginTransaction();
+    try {
+      await store.updateBatch(updates);
+      const lastId = batch[batch.length - 1]!.id;
+      const next: MigrationCursor = {
+        ...cursor,
+        lastProcessedId: lastId,
+        itemsDone: cursor.itemsDone + batch.length,
+        updatedAt: Date.now(),
+      };
+      await store.saveCursor(next);
+      await store.commit();
+      cursor.lastProcessedId = next.lastProcessedId;
+      cursor.itemsDone = next.itemsDone;
+      cursor.updatedAt = next.updatedAt;
+      return { ok: true };
+    } catch (inner) {
+      await safeRollback(store, errors);
+      throw inner;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+/**
+ * Roll back, but never mask the original error. A rollback failure is still
+ * recorded in `errors` so an operator can see it — just demoted so the real
+ * cause (the thing that made us roll back) remains the one that bubbles up.
+ */
+async function safeRollback(
+  store: MigrateStoreOptions['store'],
+  errors: string[],
+): Promise<void> {
+  try {
+    await store.rollback();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    errors.push(`[${store.storeId}] rollback failed: ${message}`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function describeAbort(signal: AbortSignal): string {
+  const reason = (signal as AbortSignal & { reason?: unknown }).reason;
+  if (reason instanceof Error) return reason.message;
+  if (typeof reason === 'string' && reason.length > 0) return reason;
+  return 'aborted';
+}

--- a/src/modules/embeddings/src/migration/sqljs-helpers.ts
+++ b/src/modules/embeddings/src/migration/sqljs-helpers.ts
@@ -1,0 +1,149 @@
+/**
+ * Generic sql.js helpers for the migration driver.
+ *
+ * Two pieces of infrastructure live inside each target store's DB:
+ *
+ *   1. A `metadata` key/value table that carries the `embeddings_version`
+ *      marker. Most moflo stores already have one; this helper guards the
+ *      DDL with `IF NOT EXISTS` so it's safe to run against either.
+ *
+ *   2. An `embeddings_migration_cursor` table that persists the resume
+ *      cursor per-store (so multiple stores sharing a DB file — e.g.
+ *      `.swarm/memory.db` with both `memory_entries` and `patterns` —
+ *      each get their own row).
+ *
+ * The helpers are framework-agnostic: they accept a minimal `SqlJsDatabase`
+ * interface so callers can use `sql.js` directly or wrap it.
+ *
+ * @module @moflo/embeddings/migration/sqljs-helpers
+ */
+
+import type { MigrationCursor } from './types.js';
+
+/**
+ * Minimal shape we need from a sql.js `Database` — matches what the moflo
+ * memory and embeddings modules already use, without taking a hard type
+ * dependency on `sql.js`.
+ */
+export interface SqlJsDatabase {
+  run(sql: string, params?: unknown[]): unknown;
+  exec(sql: string): Array<{ columns: string[]; values: unknown[][] }>;
+  prepare(sql: string): SqlJsStatement;
+}
+
+export interface SqlJsStatement {
+  bind(params: unknown[]): boolean;
+  step(): boolean;
+  getAsObject(): Record<string, unknown>;
+  free(): void;
+}
+
+// --------------------------------------------------------------------------
+// Version marker (in the shared `metadata` table)
+// --------------------------------------------------------------------------
+
+export const EMBEDDINGS_VERSION_KEY = 'embeddings_version';
+
+const METADATA_DDL = `
+  CREATE TABLE IF NOT EXISTS metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at INTEGER DEFAULT (strftime('%s', 'now') * 1000)
+  )
+`;
+
+export function ensureMetadataTable(db: SqlJsDatabase): void {
+  db.run(METADATA_DDL);
+}
+
+export function readEmbeddingsVersion(db: SqlJsDatabase): number | null {
+  ensureMetadataTable(db);
+  const result = db.exec(
+    `SELECT value FROM metadata WHERE key = '${EMBEDDINGS_VERSION_KEY}'`,
+  );
+  const raw = result[0]?.values[0]?.[0];
+  if (raw === undefined || raw === null) return null;
+  const parsed = Number.parseInt(String(raw), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function writeEmbeddingsVersion(db: SqlJsDatabase, version: number): void {
+  ensureMetadataTable(db);
+  db.run(
+    `INSERT INTO metadata (key, value, updated_at) VALUES (?, ?, strftime('%s', 'now') * 1000)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    [EMBEDDINGS_VERSION_KEY, String(version)],
+  );
+}
+
+// --------------------------------------------------------------------------
+// Resume cursor table
+// --------------------------------------------------------------------------
+
+const CURSOR_DDL = `
+  CREATE TABLE IF NOT EXISTS embeddings_migration_cursor (
+    store_id TEXT PRIMARY KEY,
+    last_processed_id TEXT,
+    items_done INTEGER NOT NULL DEFAULT 0,
+    items_total INTEGER NOT NULL DEFAULT 0,
+    started_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )
+`;
+
+export function ensureCursorTable(db: SqlJsDatabase): void {
+  db.run(CURSOR_DDL);
+}
+
+export function loadCursorRow(db: SqlJsDatabase, storeId: string): MigrationCursor | null {
+  ensureCursorTable(db);
+  const stmt = db.prepare(
+    `SELECT store_id, last_processed_id, items_done, items_total, started_at, updated_at
+     FROM embeddings_migration_cursor WHERE store_id = ?`,
+  );
+  stmt.bind([storeId]);
+  try {
+    if (!stmt.step()) return null;
+    const row = stmt.getAsObject();
+    return {
+      storeId: String(row.store_id),
+      lastProcessedId:
+        row.last_processed_id === null || row.last_processed_id === undefined
+          ? null
+          : String(row.last_processed_id),
+      itemsDone: Number(row.items_done ?? 0),
+      itemsTotal: Number(row.items_total ?? 0),
+      startedAt: Number(row.started_at ?? 0),
+      updatedAt: Number(row.updated_at ?? 0),
+    };
+  } finally {
+    stmt.free();
+  }
+}
+
+export function saveCursorRow(db: SqlJsDatabase, cursor: MigrationCursor): void {
+  ensureCursorTable(db);
+  db.run(
+    `INSERT INTO embeddings_migration_cursor
+       (store_id, last_processed_id, items_done, items_total, started_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(store_id) DO UPDATE SET
+       last_processed_id = excluded.last_processed_id,
+       items_done        = excluded.items_done,
+       items_total       = excluded.items_total,
+       updated_at        = excluded.updated_at`,
+    [
+      cursor.storeId,
+      cursor.lastProcessedId,
+      cursor.itemsDone,
+      cursor.itemsTotal,
+      cursor.startedAt,
+      cursor.updatedAt,
+    ],
+  );
+}
+
+export function clearCursorRow(db: SqlJsDatabase, storeId: string): void {
+  ensureCursorTable(db);
+  db.run(`DELETE FROM embeddings_migration_cursor WHERE store_id = ?`, [storeId]);
+}

--- a/src/modules/embeddings/src/migration/types.ts
+++ b/src/modules/embeddings/src/migration/types.ts
@@ -1,0 +1,172 @@
+/**
+ * Embeddings migration types — interfaces for the resumable batch-embed driver.
+ *
+ * The driver is a generic, pure function that walks a store's items,
+ * re-embeds their source text through a replacement embedder, and writes
+ * the new vectors back in batch-sized transactions with resume, rollback,
+ * and abort support.
+ *
+ * @module @moflo/embeddings/migration
+ */
+
+/**
+ * The schema version introduced by the neural-embeddings epic (#527).
+ *
+ * - Stores with `embeddings_version` unset or `< 2` need migration on open.
+ * - A successful migration bumps the marker to exactly this value.
+ * - Fresh stores created after this ships seed the marker to this value.
+ */
+export const EMBEDDINGS_VERSION = 2 as const;
+
+/**
+ * A single item in a store that carries an embedding derived from source text.
+ */
+export interface MigrationItem {
+  /** Stable row identifier. Used as the resume cursor. */
+  id: string;
+
+  /** The source text that produced the current embedding. Re-embedded as-is. */
+  sourceText: string;
+}
+
+/**
+ * A replacement embedding for a single row, produced by the new embedder.
+ */
+export interface MigrationBatchUpdate {
+  id: string;
+  embedding: Float32Array;
+}
+
+/**
+ * Persisted resume cursor. One row per store, keyed by `storeId`.
+ */
+export interface MigrationCursor {
+  storeId: string;
+  /** `null` until the first batch commits successfully. */
+  lastProcessedId: string | null;
+  itemsDone: number;
+  itemsTotal: number;
+  startedAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Progress event emitted once per committed batch (and on start/finish).
+ */
+export interface MigrationProgress {
+  step:
+    | 'start'
+    | 'batch'
+    | 'retry'
+    | 'finish'
+    | 'aborted';
+  itemsDone: number;
+  itemsTotal: number;
+  /** Wall-clock time the last batch took to embed + commit. 0 on `start`. */
+  batchMs: number;
+  /** Populated on `retry` events only. */
+  attempt?: number;
+  /** Populated on `retry`/`aborted` when an error triggered the event. */
+  error?: string;
+}
+
+/**
+ * Final result of a `migrateStore` call.
+ */
+export interface MigrationResult {
+  success: boolean;
+  /** Total items re-embedded, including those from resumed runs. */
+  itemsMigrated: number;
+  itemsTotal: number;
+  durationMs: number;
+  /** True if the run picked up from a previously persisted cursor. */
+  resumed: boolean;
+  /** True if the caller-supplied `AbortSignal` fired. */
+  aborted: boolean;
+  /** True iff `embeddings_version` was bumped to `EMBEDDINGS_VERSION`. */
+  versionBumped: boolean;
+  errors: string[];
+}
+
+/**
+ * Embedder adapter — a subset of `IEmbeddingService` the driver needs.
+ *
+ * The driver never touches caches or events: it just converts text → vectors.
+ */
+export interface MigrationEmbedder {
+  /**
+   * Embed a batch of texts. The returned array MUST be the same length and
+   * order as the input. Each embedding MUST be a `Float32Array`.
+   */
+  embedBatch(texts: string[]): Promise<Float32Array[]>;
+}
+
+/**
+ * Store adapter — what a persistence layer (sql.js DB, in-memory fake, etc.)
+ * must expose so the driver can migrate it.
+ *
+ * The driver issues calls in a strict pattern per batch:
+ *   iterItems → beginTransaction → updateBatch → saveCursor → commit
+ * On failure anywhere inside the transaction, `rollback` is called and the
+ * batch is retried with backoff. All calls are serial.
+ */
+export interface MigrationStore {
+  /** Stable ID used to scope the cursor row (e.g. `memory.db:memory_entries`). */
+  readonly storeId: string;
+
+  /** Count of items eligible for migration (non-empty `sourceText`). */
+  countItems(): Promise<number>;
+
+  /**
+   * Return the next slice of items whose `id > afterId` (or all items when
+   * `afterId` is `null`), ordered by `id` ascending, capped at `limit`.
+   * Returning an empty array signals end-of-stream.
+   */
+  iterItems(afterId: string | null, limit: number): Promise<MigrationItem[]>;
+
+  /**
+   * Persist the new embeddings for the rows in this batch. Must be called
+   * between `beginTransaction` and `commit`.
+   */
+  updateBatch(updates: readonly MigrationBatchUpdate[]): Promise<void>;
+
+  /**
+   * Persist the resume cursor. Must be called between `beginTransaction` and
+   * `commit` so resuming lands on a consistent snapshot.
+   */
+  saveCursor(cursor: MigrationCursor): Promise<void>;
+
+  /** Load the persisted cursor for this store, or `null` if no run is in flight. */
+  loadCursor(): Promise<MigrationCursor | null>;
+
+  /** Remove the cursor row (called after a successful full migration). */
+  clearCursor(): Promise<void>;
+
+  /** Read `embeddings_version`. Returns `null` when the marker is absent. */
+  getVersion(): Promise<number | null>;
+
+  /** Write `embeddings_version`. Only called once, after a fully successful run. */
+  setVersion(version: number): Promise<void>;
+
+  beginTransaction(): Promise<void>;
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
+}
+
+/**
+ * Options accepted by `migrateStore`.
+ */
+export interface MigrateStoreOptions {
+  store: MigrationStore;
+  embedder: MigrationEmbedder;
+  /** Items per batch. Defaults to `32`. */
+  batchSize?: number;
+  /** Max retries for a failing batch. Defaults to `3`. */
+  maxRetries?: number;
+  /** Base backoff delay in ms. Exponential: `base * 2^attempt`. Defaults to `50`. */
+  backoffMs?: number;
+  /** Progress callback invoked on `start`, each committed batch, and `finish`/`aborted`. */
+  onProgress?: (progress: MigrationProgress) => void;
+  /** Abort signal. When fired, the driver returns `aborted: true` at the next batch boundary. */
+  signal?: AbortSignal;
+}

--- a/src/modules/embeddings/src/persistent-cache.ts
+++ b/src/modules/embeddings/src/persistent-cache.ts
@@ -90,7 +90,8 @@ export class PersistentEmbeddingCache {
       }
 
       // Load existing database or create new
-      if (existsSync(this.dbPath)) {
+      const dbExisted = existsSync(this.dbPath);
+      if (dbExisted) {
         const fileBuffer = readFileSync(this.dbPath);
         this.db = new this.SQL.Database(fileBuffer);
       } else {
@@ -110,6 +111,24 @@ export class PersistentEmbeddingCache {
       `);
       this.db.run('CREATE INDEX IF NOT EXISTS idx_accessed_at ON embeddings(accessed_at)');
       this.db.run('CREATE INDEX IF NOT EXISTS idx_created_at ON embeddings(created_at)');
+
+      // `embeddings_version` marker for the migration driver (epic #527).
+      // Only seed the marker when the DB file is brand new. Pre-existing
+      // caches deliberately lack the marker so story 3's open-time check can
+      // treat them as pre-v2 (hash-backed) and invalidate them on upgrade.
+      this.db.run(`
+        CREATE TABLE IF NOT EXISTS metadata (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          updated_at INTEGER DEFAULT (strftime('%s', 'now') * 1000)
+        )
+      `);
+      if (!dbExisted) {
+        this.db.run(
+          `INSERT OR IGNORE INTO metadata (key, value, updated_at)
+           VALUES ('embeddings_version', '2', strftime('%s', 'now') * 1000)`,
+        );
+      }
 
       // Clean expired entries on startup
       this.cleanExpired();


### PR DESCRIPTION
## Summary

- Adds `src/modules/embeddings/src/migration/` — a pure, generic library (`migrateStore` driver + `MigrationStore`/`MigrationEmbedder` interfaces + reusable sql.js helpers + in-memory reference adapter for tests).
- Seeds the `embeddings_version=2` marker in the two stores that actually persist embeddings today (`.swarm/memory.db` via `memory-initializer.ts`, and the embedding cache in `persistent-cache.ts`). Pre-existing DBs intentionally lack the marker so the open-time check in story 3 treats them as pre-v2.
- Story 2 of epic #527. No caller is wired up — the library exists as-is; story 3 hooks it into session-start UX, story 4 deletes the hash fallback paths.

## What the driver does

- Batches items via the adapter (`iterItems` / `updateBatch`) through an embedder (`embedBatch`) in configurable chunks (default 32).
- Per-batch transaction: `beginTransaction` → embed → updateBatch + saveCursor → commit. Rollback + retry (3×, exponential backoff) on any failure. `AbortSignal` support at batch boundaries.
- Resume cursor in a dedicated `embeddings_migration_cursor` table keyed by `store_id` — so multiple stores sharing a DB file each track independent progress.
- `setVersion(EMBEDDINGS_VERSION)` runs exactly once, after the final batch commits. Interrupted runs leave the old marker intact so the next open re-triggers migration.
- Progress callback errors are swallowed (subscriber bugs must not break the migration). Rollback failures are surfaced into the returned `errors[]` array with `[storeId]` context — never silent.

## Scope notes

The ticket enumerates five target stores. In practice only two hold persistent embeddings:

| Ticket item | Reality |
|---|---|
| `.swarm/memory.db` | ✅ Marker seeded in `getInitialMetadata()` |
| `.swarm/embeddings-*.db` (persistent cache) | ✅ Marker seeded on fresh init (not on reopen) |
| Guidance retriever index | ⚠️ No separate persistent store — data flows through `memory.db` |
| ReasoningBank trajectory store | ⚠️ Patterns live in `memory.db` `patterns` table |
| movector vector DB | ⚠️ In-memory only (`src/modules/cli/src/movector/vector-db.ts`) |

The generic `MigrationStore` / sql.js helpers work against any future adapter, so adding guidance/reasoningbank-specific stores later is a drop-in.

## Test plan

- [x] 29 new migration tests pass (`__tests__/migration/{migrate-store,sqljs-helpers}.test.ts`)
- [x] 1 new assertion in `memory-movector-deep.test.ts` verifies `embeddings_version=2` seeding
- [x] Full embeddings suite + cli memory test: 279 passing, 1 skipped (pre-existing)
- [x] Clean monorepo `npm run build`
- [ ] Story 3 wires the driver into the session-start upgrade flow (separate PR)

Closes #529
Part of #527

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)