### PR TITLE
feat(embeddings): permanent guard against hash-fallback regression (#532)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,125 @@
+/**
+ * Hash-embedding regression guard (epic #527, story #532).
+ *
+ * Story 4 (#531) deleted every hash-embedding code path from moflo. This
+ * config installs a standing guard so no future PR can silently reintroduce
+ * one. The one rule below is the entire point of this file — do not add
+ * unrelated lint rules here without a separate discussion.
+ */
+
+const BANNED_EMBEDDING_MESSAGE =
+  'Hash embeddings are permanently banned (epic #527, story #532). ' +
+  'Use the fastembed-backed IEmbeddingService from @moflo/embeddings instead. ' +
+  'Test-only deterministic mocks belong under __tests__/.';
+
+const BANNED_IDENTIFIERS = [
+  'HashEmbeddingProvider',
+  'createHashEmbedding',
+  'generateHashEmbedding',
+  'RvfEmbeddingService',
+  'RvfEmbeddingCache',
+];
+
+const BANNED_IDENTIFIER_PATTERN = `^(${BANNED_IDENTIFIERS.join('|')})$`;
+// Matches any literal starting with "domain-aware-hash", including the
+// original `domain-aware-hash-384` dim variant, `domain-aware-hash-v1` model
+// tag, and any future suffix a contributor might try to sneak through.
+const BANNED_LITERAL_PATTERN = '^domain-aware-hash';
+
+const bannedEmbeddingRules = {
+  'no-restricted-syntax': [
+    'error',
+    {
+      selector: `Identifier[name=/${BANNED_IDENTIFIER_PATTERN}/]`,
+      message: BANNED_EMBEDDING_MESSAGE,
+    },
+    {
+      selector: `Literal[value=/${BANNED_LITERAL_PATTERN}/]`,
+      message: BANNED_EMBEDDING_MESSAGE,
+    },
+    {
+      selector: `TemplateElement[value.raw=/${BANNED_LITERAL_PATTERN}/]`,
+      message: BANNED_EMBEDDING_MESSAGE,
+    },
+  ],
+  'no-restricted-imports': [
+    'error',
+    {
+      paths: [
+        {
+          name: '@xenova/transformers',
+          message:
+            '@xenova/transformers was removed in epic #527. Import from @moflo/embeddings (fastembed-backed) instead.',
+        },
+      ],
+    },
+  ],
+};
+
+module.exports = {
+  root: true,
+  ignorePatterns: [
+    'node_modules/',
+    'dist/',
+    '**/dist/**',
+    '.moflo/',
+    '.claude-flow/',
+    '.swarm/',
+    'harness/**/.work/**',
+    'spells/',
+    'scripts/',
+    'examples/',
+    'data/',
+    'docs/',
+    'tests/fixtures/**',
+    '**/*.d.ts',
+  ],
+  overrides: [
+    {
+      files: ['src/**/*.ts', 'src/**/*.tsx', 'src/**/*.mts', 'src/**/*.cts'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      // Plugin is registered here only so existing `eslint-disable-next-line
+      // @typescript-eslint/*` comments in source do not trip "rule not found"
+      // errors. No rules from this plugin are enabled — this config is
+      // intentionally scoped to the hash-embedding guard.
+      plugins: ['@typescript-eslint'],
+      rules: bannedEmbeddingRules,
+    },
+    {
+      files: [
+        'src/**/*.js',
+        'src/**/*.mjs',
+        'src/**/*.cjs',
+        'bin/**/*.js',
+        'bin/**/*.mjs',
+        'bin/**/*.cjs',
+      ],
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      rules: bannedEmbeddingRules,
+    },
+    {
+      // Test-only deterministic mocks are explicitly allowed to reference the
+      // hash-embedding identifiers so existing guidance-retriever test
+      // fixtures continue to work. They are NOT exported from any package.
+      files: [
+        'src/**/__tests__/**',
+        'src/**/*.test.ts',
+        'src/**/*.test.js',
+        'src/**/*.spec.ts',
+        'src/**/*.spec.js',
+        'src/__tests__/**',
+      ],
+      rules: {
+        'no-restricted-syntax': 'off',
+        'no-restricted-imports': 'off',
+      },
+    },
+  ],
+};

--- a/bin/build-embeddings.mjs
+++ b/bin/build-embeddings.mjs
@@ -1,24 +1,22 @@
 #!/usr/bin/env node
 /**
- * Generate embeddings for all memory entries and build HNSW index
+ * Generate neural embeddings for memory entries and invalidate the HNSW index.
  *
- * Embedding Strategy (in order of preference):
- * 1. Transformers.js with all-MiniLM-L6-v2 (best quality, requires sharp)
- * 2. Domain-aware semantic hash embeddings (fast, good quality, no deps)
+ * Neural embeddings are required — epic #527 removed every hash fallback. If
+ * the fastembed model cannot load (missing download, broken network, etc.)
+ * this script exits non-zero rather than silently degrading to hashed vectors.
  *
- * The domain-aware hash embeddings use:
- * - Domain clustering for semantic grouping (database, frontend, backend, testing, etc.)
- * - SimHash-style word encoding with multiple hash positions
- * - N-gram features (bigrams, trigrams) for phrase detection
- * - L2 normalization for cosine similarity
+ * Model: `fast-all-MiniLM-L6-v2` via the `fastembed` npm package (384 dims,
+ * L2-normalised). Matches the shape and vector space of entries embedded by
+ * `@moflo/embeddings`'s `FastembedEmbeddingService`.
  *
  * Usage:
- *   node node_modules/moflo/bin/build-embeddings.mjs           # Embed entries without embeddings
- *   flo-embeddings --force                               # Re-embed all entries
- *   flo-embeddings --namespace guidance                   # Only specific namespace
+ *   node node_modules/moflo/bin/build-embeddings.mjs          # embed rows with no embedding
+ *   flo-embeddings --force                                    # re-embed every row
+ *   flo-embeddings --namespace guidance                       # scope to one namespace
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
@@ -34,16 +32,16 @@ function findProjectRoot() {
 }
 
 const projectRoot = findProjectRoot();
-
 const DB_PATH = resolve(projectRoot, '.swarm/memory.db');
 
-// Embedding config
-const EMBEDDING_MODEL_NEURAL = 'Xenova/all-MiniLM-L6-v2';
-const EMBEDDING_MODEL_HASH = 'domain-aware-hash-v1';
+// Canonical model name emitted into `memory_entries.embedding_model`. The
+// semantic-search bin script accepts this plus a short set of legacy aliases
+// for entries embedded by earlier moflo versions that still share this
+// vector space (all-MiniLM-L6-v2 regardless of runtime).
+const EMBEDDING_MODEL = 'fast-all-MiniLM-L6-v2';
 const EMBEDDING_DIMS = 384;
-const BATCH_SIZE = 100;
+const BATCH_SIZE = 32;
 
-// Parse args
 const args = process.argv.slice(2);
 const force = args.includes('--force');
 const namespaceFilter = args.includes('--namespace')
@@ -51,217 +49,45 @@ const namespaceFilter = args.includes('--namespace')
   : null;
 const verbose = args.includes('--verbose') || args.includes('-v');
 
-let pipeline = null;
-let useTransformers = false;
-let embeddingModel = EMBEDDING_MODEL_HASH;
-
 function log(msg) {
   console.log(`[build-embeddings] ${msg}`);
 }
-
 function debug(msg) {
   if (verbose) console.log(`[build-embeddings]   ${msg}`);
 }
 
 // ============================================================================
-// Domain-Aware Semantic Hash Embeddings
+// Fastembed loader — neural embeddings are required, no fallback
 // ============================================================================
 
-// Domain clusters for semantic grouping
-const DOMAIN_CLUSTERS = {
-  database: ['typeorm', 'mongodb', 'database', 'entity', 'schema', 'table', 'collection',
-             'query', 'sql', 'nosql', 'orm', 'model', 'migration', 'repository', 'column',
-             'relation', 'foreign', 'primary', 'index', 'constraint', 'transaction'],
-  frontend: ['react', 'component', 'ui', 'styling', 'css', 'html', 'jsx', 'tsx', 'frontend',
-             'material', 'mui', 'tailwind', 'dom', 'render', 'hook', 'state', 'props',
-             'redux', 'context', 'styled', 'emotion', 'theme', 'layout', 'responsive'],
-  backend: ['fastify', 'api', 'route', 'handler', 'rest', 'endpoint', 'server', 'controller',
-            'middleware', 'request', 'response', 'http', 'express', 'nest', 'graphql',
-            'websocket', 'socket', 'cors', 'auth', 'jwt', 'session', 'cookie'],
-  testing: ['test', 'testing', 'vitest', 'jest', 'mock', 'spy', 'assert', 'expect', 'describe',
-            'it', 'spec', 'unit', 'integration', 'e2e', 'playwright', 'cypress', 'coverage',
-            'fixture', 'stub', 'fake', 'snapshot', 'beforeeach', 'aftereach'],
-  tenancy: ['tenant', 'tenancy', 'companyid', 'company', 'isolation', 'multi', 'multitenant',
-            'organization', 'workspace', 'account', 'customer', 'client'],
-  security: ['security', 'auth', 'authentication', 'authorization', 'permission', 'role',
-             'access', 'token', 'jwt', 'oauth', 'password', 'encrypt', 'hash', 'salt',
-             'csrf', 'xss', 'injection', 'sanitize', 'validate'],
-  patterns: ['pattern', 'service', 'factory', 'singleton', 'decorator', 'adapter', 'facade',
-             'observer', 'strategy', 'command', 'repository', 'usecase', 'domain', 'ddd',
-             'clean', 'architecture', 'solid', 'dry', 'kiss'],
-  workflow: ['workflow', 'pipeline', 'ci', 'cd', 'deploy', 'build', 'actions',
-             'hook', 'trigger', 'job', 'step', 'artifact', 'release', 'version', 'tag'],
-  memory: ['memory', 'cache', 'store', 'persist', 'storage', 'redis', 'session', 'state',
-           'buffer', 'queue', 'stack', 'heap', 'gc', 'leak', 'embedding', 'vector', 'hnsw',
-           'semantic', 'search', 'index', 'retrieval'],
-  agent: ['agent', 'swarm', 'coordinator', 'orchestrator', 'task', 'worker', 'spawn',
-          'parallel', 'concurrent', 'async', 'promise', 'queue', 'priority', 'schedule'],
-  github: ['github', 'issue', 'branch', 'pr', 'pull', 'request', 'merge', 'commit', 'push',
-           'clone', 'fork', 'remote', 'origin', 'main', 'master', 'checkout', 'rebase',
-           'squash', 'repository', 'repo', 'gh', 'git', 'assignee', 'label', 'mandatory',
-           'checklist', 'closes', 'fixes', 'conventional', 'feat', 'refactor'],
-  documentation: ['guidance', 'documentation', 'docs', 'readme', 'guide', 'tutorial',
-                  'reference', 'standard', 'convention', 'rule', 'policy', 'template',
-                  'example', 'usage', 'instruction', 'meta', 'index', 'umbrella', 'claude',
-                  'optimized', 'audience', 'structure', 'format', 'markdown']
-};
+let fastembedModel = null;
 
-// Common words to downweight
-const COMMON_WORDS = new Set([
-  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being', 'have', 'has', 'had',
-  'do', 'does', 'did', 'will', 'would', 'could', 'should', 'may', 'might', 'must', 'shall',
-  'can', 'need', 'to', 'of', 'in', 'for', 'on', 'with', 'at', 'by', 'from', 'as', 'into',
-  'through', 'during', 'before', 'after', 'above', 'below', 'between', 'under', 'and', 'but',
-  'or', 'nor', 'so', 'yet', 'both', 'either', 'neither', 'not', 'only', 'own', 'same', 'than',
-  'too', 'very', 'just', 'also', 'this', 'that', 'these', 'those', 'it', 'its', 'if', 'then',
-  'else', 'when', 'where', 'why', 'how', 'all', 'each', 'every', 'any', 'some', 'no', 'yes',
-  'use', 'using', 'used', 'uses', 'get', 'set', 'new', 'see', 'like', 'make', 'made'
-]);
+async function loadModel() {
+  if (fastembedModel) return fastembedModel;
 
-// MurmurHash3-inspired hash function for better distribution
-function hash(str, seed = 0) {
-  let h = seed ^ str.length;
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i);
-    h = Math.imul(h, 0x5bd1e995);
-    h ^= h >>> 15;
-  }
-  return h >>> 0;
+  log('Loading fastembed model (fast-all-MiniLM-L6-v2)...');
+  const mod = await import(mofloResolveURL('fastembed'));
+  const { FlagEmbedding, EmbeddingModel } = mod;
+
+  fastembedModel = await FlagEmbedding.init({
+    model: EmbeddingModel.AllMiniLML6V2,
+    showDownloadProgress: true,
+  });
+  log('fastembed model ready');
+  return fastembedModel;
 }
 
-// Pre-compute domain signature vectors
-const domainSignatures = {};
-for (const [domain, keywords] of Object.entries(DOMAIN_CLUSTERS)) {
-  const sig = new Float32Array(EMBEDDING_DIMS);
-  for (const kw of keywords) {
-    // Use multiple positions per keyword for robustness
-    for (let h = 0; h < 2; h++) {
-      const idx = hash(kw + '_dom_' + domain, h) % EMBEDDING_DIMS;
-      sig[idx] = 1;
-    }
+async function generateEmbeddings(texts) {
+  const model = await loadModel();
+  const out = [];
+  for await (const batch of model.embed(texts, BATCH_SIZE)) {
+    for (const vec of batch) out.push(vec);
   }
-  domainSignatures[domain] = sig;
-}
-
-/**
- * Generate domain-aware semantic hash embedding
- * @param {string} text - Text to embed
- * @param {number} dims - Embedding dimensions
- * @returns {Float32Array} - Normalized embedding vector
- */
-function semanticHashEmbed(text, dims = EMBEDDING_DIMS) {
-  const vec = new Float32Array(dims);
-  const lowerText = text.toLowerCase();
-  const words = lowerText.replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(w => w.length > 1);
-
-  if (words.length === 0) {
-    // Empty text - return zero vector (will have low similarity to everything)
-    return vec;
-  }
-
-  // 1. Add domain signatures for matched domains
-  for (const [domain, keywords] of Object.entries(DOMAIN_CLUSTERS)) {
-    let matchCount = 0;
-    for (const kw of keywords) {
-      if (lowerText.includes(kw)) {
-        matchCount++;
-      }
-    }
-    if (matchCount > 0) {
-      const weight = Math.min(2.0, 0.5 + matchCount * 0.3); // More matches = stronger signal
-      const sig = domainSignatures[domain];
-      for (let i = 0; i < dims; i++) {
-        vec[i] += sig[i] * weight;
-      }
-    }
-  }
-
-  // 2. Add word features (simhash-style with multiple positions)
-  for (let i = 0; i < words.length; i++) {
-    const word = words[i];
-    const isCommon = COMMON_WORDS.has(word);
-    const weight = isCommon ? 0.2 : (word.length > 6 ? 0.8 : 0.5);
-
-    // Multiple hash positions per word
-    for (let h = 0; h < 3; h++) {
-      const idx = hash(word, h * 17) % dims;
-      const sign = (hash(word, h * 31 + 1) % 2 === 0) ? 1 : -1;
-      vec[idx] += sign * weight;
-    }
-  }
-
-  // 3. Add bigram features for local context
-  for (let i = 0; i < words.length - 1; i++) {
-    if (COMMON_WORDS.has(words[i]) && COMMON_WORDS.has(words[i + 1])) continue;
-    const bigram = words[i] + '_' + words[i + 1];
-    const idx = hash(bigram, 42) % dims;
-    const sign = (hash(bigram, 43) % 2 === 0) ? 1 : -1;
-    vec[idx] += sign * 0.4;
-  }
-
-  // 4. Add trigram features for phrase detection
-  for (let i = 0; i < words.length - 2; i++) {
-    const trigram = words[i] + '_' + words[i + 1] + '_' + words[i + 2];
-    const idx = hash(trigram, 99) % dims;
-    const sign = (hash(trigram, 100) % 2 === 0) ? 1 : -1;
-    vec[idx] += sign * 0.3;
-  }
-
-  // 5. L2 normalize
-  let norm = 0;
-  for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
-  norm = Math.sqrt(norm);
-  if (norm > 0) {
-    for (let i = 0; i < dims; i++) vec[i] /= norm;
-  }
-
-  return vec;
+  return out;
 }
 
 // ============================================================================
-// Transformers.js Neural Embeddings (fallback)
-// ============================================================================
-
-async function loadTransformersModel() {
-  if (pipeline) return pipeline;
-
-  log('Attempting to load Transformers.js neural model...');
-
-  try {
-    const { env, pipeline: createPipeline } = await import(mofloResolveURL('@xenova/transformers'));
-    env.allowLocalModels = false;
-    env.backends.onnx.wasm.numThreads = 1;
-
-    pipeline = await createPipeline('feature-extraction', EMBEDDING_MODEL_NEURAL, {
-      quantized: false,
-    });
-
-    useTransformers = true;
-    embeddingModel = EMBEDDING_MODEL_NEURAL;
-    log('Transformers.js model loaded successfully');
-    return pipeline;
-  } catch (err) {
-    const errMsg = err.message?.split('\n')[0] || err.message;
-    log(`Transformers.js not available: ${errMsg}`);
-    log('Using domain-aware hash embeddings (fast, good quality)');
-    useTransformers = false;
-    embeddingModel = EMBEDDING_MODEL_HASH;
-    return null;
-  }
-}
-
-async function generateEmbeddingNeural(text) {
-  if (!pipeline) return null;
-  try {
-    const output = await pipeline(text, { pooling: 'mean', normalize: true });
-    return Array.from(output.data);
-  } catch {
-    return null;
-  }
-}
-
-// ============================================================================
-// Database Operations
+// Database operations
 // ============================================================================
 
 async function getDb() {
@@ -278,36 +104,32 @@ function saveDb(db) {
   writeFileSync(DB_PATH, Buffer.from(data));
 }
 
-function getEntriesNeedingEmbeddings(db, namespace = null, forceAll = false) {
+function getEntriesNeedingEmbeddings(db, namespace, forceAll) {
   let sql = `SELECT id, key, namespace, content FROM memory_entries WHERE status = 'active'`;
   const params = [];
 
   if (!forceAll) {
-    // Include entries with no embedding OR entries with hash/fallback embeddings
-    // that should be upgraded to Xenova when available
-    sql += ` AND (embedding IS NULL OR embedding = '' OR embedding_model IN ('domain-aware-hash-v1', 'hash-fallback', 'local'))`;
+    sql += ` AND (embedding IS NULL OR embedding = '')`;
   }
-
   if (namespace) {
     sql += ` AND namespace = ?`;
     params.push(namespace);
   }
-
   sql += ` ORDER BY created_at DESC`;
 
   const stmt = db.prepare(sql);
   stmt.bind(params);
-  const results = [];
-  while (stmt.step()) results.push(stmt.getAsObject());
+  const rows = [];
+  while (stmt.step()) rows.push(stmt.getAsObject());
   stmt.free();
-  return results;
+  return rows;
 }
 
-function updateEmbedding(db, id, embedding, model) {
+function updateEmbedding(db, id, embedding) {
   const stmt = db.prepare(
-    `UPDATE memory_entries SET embedding = ?, embedding_model = ?, embedding_dimensions = ?, updated_at = ? WHERE id = ?`
+    `UPDATE memory_entries SET embedding = ?, embedding_model = ?, embedding_dimensions = ?, updated_at = ? WHERE id = ?`,
   );
-  stmt.run([JSON.stringify(embedding), model, EMBEDDING_DIMS, Date.now(), id]);
+  stmt.run([JSON.stringify(embedding), EMBEDDING_MODEL, EMBEDDING_DIMS, Date.now(), id]);
   stmt.free();
 }
 
@@ -316,18 +138,17 @@ function getNamespaceStats(db) {
     SELECT
       namespace,
       COUNT(*) as total,
-      SUM(CASE WHEN embedding IS NOT NULL AND embedding != '' AND embedding_model != 'domain-aware-hash-v1' THEN 1 ELSE 0 END) as vectorized,
-      SUM(CASE WHEN embedding IS NULL OR embedding = '' THEN 1 ELSE 0 END) as missing,
-      SUM(CASE WHEN embedding_model = 'domain-aware-hash-v1' THEN 1 ELSE 0 END) as hash_only
+      SUM(CASE WHEN embedding IS NOT NULL AND embedding != '' THEN 1 ELSE 0 END) as vectorized,
+      SUM(CASE WHEN embedding IS NULL OR embedding = '' THEN 1 ELSE 0 END) as missing
     FROM memory_entries
     WHERE status = 'active'
     GROUP BY namespace
     ORDER BY namespace
   `);
-  const results = [];
-  while (stmt.step()) results.push(stmt.getAsObject());
+  const rows = [];
+  while (stmt.step()) rows.push(stmt.getAsObject());
   stmt.free();
-  return results;
+  return rows;
 }
 
 function getEmbeddingStats(db) {
@@ -347,8 +168,29 @@ function getEmbeddingStats(db) {
   return {
     total: total?.cnt || 0,
     withEmbeddings: withEmbed?.cnt || 0,
-    byModel
+    byModel,
   };
+}
+
+function writeVectorStatsCache(stats, nsCount) {
+  try {
+    const dbSizeKB = Math.floor(readFileSync(DB_PATH).length / 1024);
+    const hnswExists = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
+      || existsSync(resolve(projectRoot, '.claude-flow', 'hnsw.index'));
+    const cacheData = {
+      vectorCount: stats.withEmbeddings,
+      dbSizeKB,
+      namespaces: nsCount,
+      hasHnsw: hnswExists,
+      updatedAt: Date.now(),
+    };
+    for (const cacheDir of [resolve(projectRoot, '.claude-flow'), resolve(projectRoot, '.swarm')]) {
+      if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+      writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
+    }
+  } catch (err) {
+    debug(`vector-stats cache write failed (non-fatal): ${err.message}`);
+  }
 }
 
 // ============================================================================
@@ -364,109 +206,70 @@ async function main() {
 
   const db = await getDb();
 
-  // Get entries needing embeddings
   const entries = getEntriesNeedingEmbeddings(db, namespaceFilter, force);
-
   if (entries.length === 0) {
     log('All entries already have embeddings');
     const stats = getEmbeddingStats(db);
     log(`Total: ${stats.withEmbeddings}/${stats.total} entries embedded`);
-
-    // Update vector-stats cache even on early exit
-    try {
-      const nsStats = getNamespaceStats(db);
-      const dbSizeKB = Math.floor(readFileSync(DB_PATH).length / 1024);
-      const hnswExists = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
-        || existsSync(resolve(projectRoot, '.claude-flow', 'hnsw.index'));
-      const cacheData = {
-        vectorCount: stats.withEmbeddings,
-        dbSizeKB,
-        namespaces: nsStats.length,
-        hasHnsw: hnswExists,
-        updatedAt: Date.now(),
-      };
-      for (const cacheDir of [resolve(projectRoot, '.claude-flow'), resolve(projectRoot, '.swarm')]) {
-        if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
-        writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
-      }
-    } catch { /* non-fatal */ }
-
+    writeVectorStatsCache(stats, getNamespaceStats(db).length);
     db.close();
     return;
   }
 
   log(`Found ${entries.length} entries to embed`);
 
-  // Try to load Transformers.js, fall back to hash embeddings
-  await loadTransformersModel();
-
-  log(`Using embedding model: ${embeddingModel}`);
-  console.log('');
-
   let embedded = 0;
   let failed = 0;
   const startTime = Date.now();
 
-  // Process entries
-  for (let i = 0; i < entries.length; i++) {
-    const entry = entries[i];
+  // Embed in batches to match fastembed's streaming API while keeping progress
+  // output tied to the source row order.
+  for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+    const slice = entries.slice(i, i + BATCH_SIZE);
+    const texts = slice.map(e => String(e.content ?? '').substring(0, 1500));
 
+    let vectors;
     try {
-      // Truncate content for embedding (first 1500 chars for context)
-      const text = entry.content.substring(0, 1500);
-
-      let embedding;
-      if (useTransformers && pipeline) {
-        embedding = await generateEmbeddingNeural(text);
-      }
-
-      // Fall back to hash embedding if neural failed or not available
-      if (!embedding || embedding.length !== EMBEDDING_DIMS) {
-        embedding = Array.from(semanticHashEmbed(text));
-      }
-
-      if (embedding && embedding.length === EMBEDDING_DIMS) {
-        updateEmbedding(db, entry.id, embedding, embeddingModel);
-        embedded++;
-      } else {
-        failed++;
-      }
-
-      // Progress update
-      if ((i + 1) % 50 === 0 || i === entries.length - 1) {
-        const pct = Math.round(((i + 1) / entries.length) * 100);
-        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-        process.stdout.write(`\r[build-embeddings] Progress: ${i + 1}/${entries.length} (${pct}%) - ${elapsed}s elapsed`);
-      }
+      vectors = await generateEmbeddings(texts);
     } catch (err) {
-      debug(`Failed to embed ${entry.key}: ${err.message}`);
-      failed++;
+      log(`Batch ${i}-${i + slice.length} failed: ${err.message}`);
+      failed += slice.length;
+      continue;
     }
-  }
 
-  console.log(''); // New line after progress
+    for (let j = 0; j < slice.length; j++) {
+      const vec = vectors[j];
+      if (!Array.isArray(vec) || vec.length !== EMBEDDING_DIMS) {
+        failed++;
+        continue;
+      }
+      updateEmbedding(db, slice[j].id, vec);
+      embedded++;
+    }
+
+    const processed = Math.min(i + slice.length, entries.length);
+    const pct = Math.round((processed / entries.length) * 100);
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    process.stdout.write(`\r[build-embeddings] Progress: ${processed}/${entries.length} (${pct}%) - ${elapsed}s elapsed`);
+  }
+  console.log('');
 
   const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
-  const stats = getEmbeddingStats(db);
 
-  // Write changes back to disk (sql.js operates in-memory)
   if (embedded > 0) {
     saveDb(db);
-
-    // Delete stale HNSW index so the CLI rebuilds from fresh vectors
-    const hnswPaths = [
+    for (const p of [
       resolve(projectRoot, '.swarm/hnsw.index'),
       resolve(projectRoot, '.swarm/hnsw.metadata.json'),
-    ];
-    for (const p of hnswPaths) {
+    ]) {
       if (existsSync(p)) {
-        const { unlinkSync } = await import('fs');
         unlinkSync(p);
         log(`Deleted stale HNSW index: ${p}`);
       }
     }
   }
 
+  const stats = getEmbeddingStats(db);
   console.log('');
   log('═══════════════════════════════════════════════════════════');
   log('  Embedding Generation Complete');
@@ -474,7 +277,7 @@ async function main() {
   log(`  Embedded:     ${embedded} entries`);
   log(`  Failed:       ${failed} entries`);
   log(`  Time:         ${totalTime}s`);
-  log(`  Model:        ${embeddingModel}`);
+  log(`  Model:        ${EMBEDDING_MODEL}`);
   log(`  Dimensions:   ${EMBEDDING_DIMS}`);
   log('');
   log(`  Total Coverage: ${stats.withEmbeddings}/${stats.total} entries`);
@@ -486,60 +289,33 @@ async function main() {
   }
   log('');
 
-  // Per-namespace health report
   const nsStats = getNamespaceStats(db);
   if (nsStats.length > 0) {
     log('  Namespace Health:');
-    log('  ┌─────────────────┬───────┬────────────┬─────────┬───────────┐');
-    log('  │ Namespace       │ Total │ Vectorized │ Missing │ Hash-Only │');
-    log('  ├─────────────────┼───────┼────────────┼─────────┼───────────┤');
+    log('  ┌─────────────────┬───────┬────────────┬─────────┐');
+    log('  │ Namespace       │ Total │ Vectorized │ Missing │');
+    log('  ├─────────────────┼───────┼────────────┼─────────┤');
     let hasWarnings = false;
     for (const ns of nsStats) {
       const name = String(ns.namespace).padEnd(15);
       const total = String(ns.total).padStart(5);
       const vectorized = String(ns.vectorized).padStart(10);
       const missing = String(ns.missing).padStart(7);
-      const hashOnly = String(ns.hash_only).padStart(9);
-      const warn = (ns.missing > 0 || ns.hash_only > 0) ? ' ⚠' : '  ';
-      log(`  │ ${name} │${total} │${vectorized} │${missing} │${hashOnly} │${warn}`);
-      if (ns.missing > 0 || ns.hash_only > 0) hasWarnings = true;
+      const warn = ns.missing > 0 ? ' ⚠' : '  ';
+      log(`  │ ${name} │${total} │${vectorized} │${missing} │${warn}`);
+      if (ns.missing > 0) hasWarnings = true;
     }
-    log('  └─────────────────┴───────┴────────────┴─────────┴───────────┘');
+    log('  └─────────────────┴───────┴────────────┴─────────┘');
     if (hasWarnings) {
       log('');
-      log('  ⚠ Some namespaces have entries without Xenova embeddings.');
-      log('  Run with --force to re-embed all entries:');
-      log('    node node_modules/moflo/bin/build-embeddings.mjs --force');
-      if (!useTransformers) {
-        log('');
-        log('  ⚠ Xenova model not available — using hash fallback.');
-        log('  Install @xenova/transformers for neural embeddings:');
-        log('    npm install @xenova/transformers');
-      }
+      log('  ⚠ Some namespaces have rows missing embeddings.');
+      log('    Re-run with --force to re-embed everything:');
+      log('      node node_modules/moflo/bin/build-embeddings.mjs --force');
     }
   }
-
   log('═══════════════════════════════════════════════════════════');
 
-  // Update vector-stats cache for statusline display
-  try {
-    const dbSizeKB = Math.floor(readFileSync(DB_PATH).length / 1024);
-    const hnswExists = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
-      || existsSync(resolve(projectRoot, '.claude-flow', 'hnsw.index'));
-    const cacheData = {
-      vectorCount: stats.withEmbeddings,
-      dbSizeKB,
-      namespaces: nsStats.length,
-      hasHnsw: hnswExists,
-      updatedAt: Date.now(),
-    };
-    // Write to both locations so statusline finds it regardless of which dir it checks
-    for (const cacheDir of [resolve(projectRoot, '.claude-flow'), resolve(projectRoot, '.swarm')]) {
-      if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
-      writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
-    }
-  } catch { /* non-fatal */ }
-
+  writeVectorStatsCache(stats, nsStats.length);
   db.close();
 }
 

--- a/bin/semantic-search.mjs
+++ b/bin/semantic-search.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 /**
- * Semantic search using 384-dim embeddings (Xenova/all-MiniLM-L6-v2 or hash fallback)
+ * Semantic search over stored moflo memory entries.
  *
- * Query embedding MUST match stored embedding model:
- * 1. Transformers.js with all-MiniLM-L6-v2 (best quality, matches build-embeddings)
- * 2. Domain-aware semantic hash embeddings (fallback when transformers unavailable)
+ * Query embeddings are produced by fastembed (`fast-all-MiniLM-L6-v2`,
+ * 384-dim, L2-normalised). This matches `bin/build-embeddings.mjs` and the
+ * in-process `FastembedEmbeddingService` so all three share a vector space.
+ *
+ * Neural embeddings are required — epic #527 removed every hash fallback.
+ * If the model cannot load, the script reports the error and exits 1.
  *
  * Usage:
  *   node node_modules/moflo/bin/semantic-search.mjs "your search query"
@@ -30,25 +33,28 @@ function findProjectRoot() {
 }
 
 const projectRoot = findProjectRoot();
-
 const DB_PATH = resolve(projectRoot, '.swarm/memory.db');
-const EMBEDDING_DIMS = 384;
-const EMBEDDING_MODEL_NEURAL = 'Xenova/all-MiniLM-L6-v2';
-const EMBEDDING_MODEL_HASH = 'domain-aware-hash-v1';
-// 'onnx' is a legacy alias for the Xenova model — treat them as compatible vector spaces
-const NEURAL_ALIASES = new Set([EMBEDDING_MODEL_NEURAL, 'onnx']);
 
-// Parse args
+const EMBEDDING_MODEL = 'fast-all-MiniLM-L6-v2';
+const EMBEDDING_DIMS = 384;
+// Legacy aliases share the same vector space (all-MiniLM-L6-v2 regardless of
+// runtime), so entries tagged with these model names are still valid search
+// candidates against fastembed-generated query vectors.
+const COMPATIBLE_MODELS = new Set([
+  EMBEDDING_MODEL,
+  'Xenova/all-MiniLM-L6-v2',
+  'onnx',
+]);
+
 const args = process.argv.slice(2);
 const query = args.find(a => !a.startsWith('--'));
 const limit = args.includes('--limit') ? parseInt(args[args.indexOf('--limit') + 1]) : 5;
-let namespace = args.includes('--namespace') ? args[args.indexOf('--namespace') + 1] : null;
+const namespace = args.includes('--namespace') ? args[args.indexOf('--namespace') + 1] : null;
 const withTests = args.includes('--with-tests');
 const threshold = args.includes('--threshold') ? parseFloat(args[args.indexOf('--threshold') + 1]) : 0.3;
 const json = args.includes('--json');
 const debug = args.includes('--debug');
 
-// Auto-routing: when query mentions test-related terms, also search tests namespace
 const TEST_KEYWORDS = /\b(test|spec|coverage|assert|mock|stub|fixture|describe|jest|vitest|mocha|e2e|integration test)\b/i;
 
 if (!query) {
@@ -57,239 +63,43 @@ if (!query) {
 }
 
 // ============================================================================
-// Transformers.js Neural Embeddings (primary — matches build-embeddings.mjs)
+// Fastembed loader — neural embeddings are required, no fallback
 // ============================================================================
 
-let pipeline = null;
-let useTransformers = false;
+let fastembedModel = null;
 
-async function loadTransformersModel() {
-  try {
-    const { env, pipeline: createPipeline } = await import(mofloResolveURL('@xenova/transformers'));
-    env.allowLocalModels = false;
-    env.backends.onnx.wasm.numThreads = 1;
+async function loadModel() {
+  if (fastembedModel) return fastembedModel;
 
-    pipeline = await createPipeline('feature-extraction', EMBEDDING_MODEL_NEURAL, {
-      quantized: false,
-    });
+  const mod = await import(mofloResolveURL('fastembed'));
+  const { FlagEmbedding, EmbeddingModel } = mod;
 
-    useTransformers = true;
-    if (debug) console.error('[semantic-search] Using Transformers.js neural model');
-    return true;
-  } catch (err) {
-    if (debug) console.error(`[semantic-search] Transformers.js unavailable: ${err.message?.split('\n')[0]}`);
-    useTransformers = false;
-    return false;
-  }
+  fastembedModel = await FlagEmbedding.init({
+    model: EmbeddingModel.AllMiniLML6V2,
+    showDownloadProgress: false,
+  });
+  if (debug) console.error('[semantic-search] fastembed model loaded');
+  return fastembedModel;
 }
 
-async function generateNeuralEmbedding(text) {
-  if (!pipeline) return null;
-  try {
-    const output = await pipeline(text, { pooling: 'mean', normalize: true });
-    return Array.from(output.data);
-  } catch {
-    return null;
+async function generateQueryEmbedding(text) {
+  const model = await loadModel();
+  const vec = await model.queryEmbed(text);
+  if (!Array.isArray(vec) || vec.length !== EMBEDDING_DIMS) {
+    throw new Error(`fastembed returned unexpected vector shape (got length ${vec?.length ?? 'none'})`);
   }
-}
-
-// ============================================================================
-// Domain-Aware Semantic Hash Embeddings (fallback)
-// ============================================================================
-
-const DOMAIN_CLUSTERS = {
-  database: ['typeorm', 'mongodb', 'database', 'entity', 'schema', 'table', 'collection',
-             'query', 'sql', 'nosql', 'orm', 'model', 'migration', 'repository', 'column',
-             'relation', 'foreign', 'primary', 'index', 'constraint', 'transaction',
-             'mikroorm', 'mikro', 'postgresql', 'postgres', 'soft', 'delete', 'deletedat'],
-  frontend: ['react', 'component', 'ui', 'styling', 'css', 'html', 'jsx', 'tsx', 'frontend',
-             'material', 'mui', 'tailwind', 'dom', 'render', 'hook', 'state', 'props',
-             'redux', 'context', 'styled', 'emotion', 'theme', 'layout', 'responsive',
-             'mantis', 'syncfusion', 'scheduler', 'i18n', 'intl', 'locale'],
-  backend: ['fastify', 'api', 'route', 'handler', 'rest', 'endpoint', 'server', 'controller',
-            'middleware', 'request', 'response', 'http', 'express', 'nest', 'graphql',
-            'websocket', 'socket', 'cors', 'auth', 'jwt', 'session', 'cookie',
-            'awilix', 'dependency', 'injection', 'scope'],
-  testing: ['test', 'testing', 'vitest', 'jest', 'mock', 'spy', 'assert', 'expect', 'describe',
-            'it', 'spec', 'unit', 'integration', 'e2e', 'playwright', 'cypress', 'coverage',
-            'fixture', 'stub', 'fake', 'snapshot', 'beforeeach', 'aftereach',
-            'anti-pattern', 'antipattern', 'mocking'],
-  tenancy: ['tenant', 'tenancy', 'companyid', 'company', 'isolation', 'multi', 'multitenant',
-            'organization', 'workspace', 'account', 'customer', 'client', 'subdomain'],
-  security: ['security', 'auth', 'authentication', 'authorization', 'permission', 'role',
-             'access', 'token', 'jwt', 'oauth', 'password', 'encrypt', 'hash', 'salt',
-             'csrf', 'xss', 'injection', 'sanitize', 'validate', 'rbac'],
-  patterns: ['pattern', 'service', 'factory', 'singleton', 'decorator', 'adapter', 'facade',
-             'observer', 'strategy', 'command', 'repository', 'usecase', 'domain', 'ddd',
-             'clean', 'architecture', 'solid', 'dry', 'kiss', 'functional', 'pipeasync'],
-  workflow: ['workflow', 'pipeline', 'ci', 'cd', 'deploy', 'build', 'actions',
-             'hook', 'trigger', 'job', 'step', 'artifact', 'release', 'version', 'tag'],
-  memory: ['memory', 'cache', 'store', 'persist', 'storage', 'redis', 'session', 'state',
-           'buffer', 'queue', 'stack', 'heap', 'gc', 'leak', 'embedding', 'vector', 'hnsw',
-           'semantic', 'search', 'index', 'retrieval'],
-  agent: ['agent', 'swarm', 'coordinator', 'orchestrator', 'task', 'worker', 'spawn',
-          'parallel', 'concurrent', 'async', 'promise', 'queue', 'priority', 'schedule'],
-  github: ['github', 'issue', 'branch', 'pr', 'pull', 'request', 'merge', 'commit', 'push',
-           'clone', 'fork', 'remote', 'origin', 'main', 'master', 'checkout', 'rebase',
-           'squash', 'repository', 'repo', 'gh', 'git', 'assignee', 'label', 'mandatory',
-           'checklist', 'closes', 'fixes', 'conventional', 'feat', 'refactor'],
-  documentation: ['guidance', 'documentation', 'docs', 'readme', 'guide', 'tutorial',
-                  'reference', 'standard', 'convention', 'rule', 'policy', 'template',
-                  'example', 'usage', 'instruction', 'meta', 'index', 'umbrella', 'claude',
-                  'optimized', 'audience', 'structure', 'format', 'markdown']
-};
-
-const COMMON_WORDS = new Set([
-  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being', 'have', 'has', 'had',
-  'do', 'does', 'did', 'will', 'would', 'could', 'should', 'may', 'might', 'must', 'shall',
-  'can', 'need', 'to', 'of', 'in', 'for', 'on', 'with', 'at', 'by', 'from', 'as', 'into',
-  'through', 'during', 'before', 'after', 'above', 'below', 'between', 'under', 'and', 'but',
-  'or', 'nor', 'so', 'yet', 'both', 'either', 'neither', 'not', 'only', 'own', 'same', 'than',
-  'too', 'very', 'just', 'also', 'this', 'that', 'these', 'those', 'it', 'its', 'if', 'then',
-  'else', 'when', 'where', 'why', 'how', 'all', 'each', 'every', 'any', 'some', 'no', 'yes',
-  'use', 'using', 'used', 'uses', 'get', 'set', 'new', 'see', 'like', 'make', 'made'
-]);
-
-function hash(str, seed = 0) {
-  let h = seed ^ str.length;
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i);
-    h = Math.imul(h, 0x5bd1e995);
-    h ^= h >>> 15;
-  }
-  return h >>> 0;
-}
-
-// Pre-compute domain signatures
-const domainSignatures = {};
-for (const [domain, keywords] of Object.entries(DOMAIN_CLUSTERS)) {
-  const sig = new Float32Array(EMBEDDING_DIMS);
-  for (const kw of keywords) {
-    for (let h = 0; h < 2; h++) {
-      const idx = hash(kw + '_dom_' + domain, h) % EMBEDDING_DIMS;
-      sig[idx] = 1;
-    }
-  }
-  domainSignatures[domain] = sig;
-}
-
-function semanticHashEmbed(text, dims = EMBEDDING_DIMS) {
-  const vec = new Float32Array(dims);
-  const lowerText = text.toLowerCase();
-  const words = lowerText.replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(w => w.length > 1);
-
-  if (words.length === 0) return vec;
-
-  // Add domain signatures
-  for (const [domain, keywords] of Object.entries(DOMAIN_CLUSTERS)) {
-    let matchCount = 0;
-    for (const kw of keywords) {
-      if (lowerText.includes(kw)) matchCount++;
-    }
-    if (matchCount > 0) {
-      const weight = Math.min(2.0, 0.5 + matchCount * 0.3);
-      const sig = domainSignatures[domain];
-      for (let i = 0; i < dims; i++) {
-        vec[i] += sig[i] * weight;
-      }
-    }
-  }
-
-  // Add word features
-  for (const word of words) {
-    const isCommon = COMMON_WORDS.has(word);
-    const weight = isCommon ? 0.2 : (word.length > 6 ? 0.8 : 0.5);
-    for (let h = 0; h < 3; h++) {
-      const idx = hash(word, h * 17) % dims;
-      const sign = (hash(word, h * 31 + 1) % 2 === 0) ? 1 : -1;
-      vec[idx] += sign * weight;
-    }
-  }
-
-  // Add bigrams
-  for (let i = 0; i < words.length - 1; i++) {
-    if (COMMON_WORDS.has(words[i]) && COMMON_WORDS.has(words[i + 1])) continue;
-    const bigram = words[i] + '_' + words[i + 1];
-    const idx = hash(bigram, 42) % dims;
-    const sign = (hash(bigram, 43) % 2 === 0) ? 1 : -1;
-    vec[idx] += sign * 0.4;
-  }
-
-  // Add trigrams
-  for (let i = 0; i < words.length - 2; i++) {
-    const trigram = words[i] + '_' + words[i + 1] + '_' + words[i + 2];
-    const idx = hash(trigram, 99) % dims;
-    const sign = (hash(trigram, 100) % 2 === 0) ? 1 : -1;
-    vec[idx] += sign * 0.3;
-  }
-
-  // L2 normalize
-  let norm = 0;
-  for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
-  norm = Math.sqrt(norm);
-  if (norm > 0) {
-    for (let i = 0; i < dims; i++) vec[i] /= norm;
-  }
-
   return vec;
 }
 
 // ============================================================================
-// Unified Embedding Generator (matches stored embeddings)
-// ============================================================================
-
-/**
- * Generate query embedding using the SAME model as stored embeddings.
- * Checks what model was used for stored entries and matches it.
- */
-async function generateQueryEmbedding(queryText, db) {
-  // Check what model the stored entries use
-  let modelCheckSql = `SELECT embedding_model, COUNT(*) as cnt FROM memory_entries
-     WHERE status = 'active' AND embedding IS NOT NULL AND embedding != ''
-     ${namespace ? "AND namespace = ?" : ""}
-     GROUP BY embedding_model ORDER BY cnt DESC LIMIT 1`;
-  const modelStmt = db.prepare(modelCheckSql);
-  modelStmt.bind(namespace ? [namespace] : []);
-  const modelCheck = modelStmt.step() ? modelStmt.getAsObject() : null;
-  modelStmt.free();
-
-  const storedModel = modelCheck?.embedding_model || EMBEDDING_MODEL_HASH;
-
-  if (debug) console.error(`[semantic-search] Stored model: ${storedModel}`);
-
-  // If stored embeddings are neural, try to use neural for query too
-  // Accept both canonical name and legacy 'onnx' tag (both use the same Xenova pipeline)
-  if (storedModel === EMBEDDING_MODEL_NEURAL || storedModel === 'onnx') {
-    await loadTransformersModel();
-    if (useTransformers) {
-      const neuralEmb = await generateNeuralEmbedding(queryText);
-      if (neuralEmb && neuralEmb.length === EMBEDDING_DIMS) {
-        return { embedding: neuralEmb, model: EMBEDDING_MODEL_NEURAL };
-      }
-    }
-    // Neural failed — warn about model mismatch
-    if (!json) {
-      console.error('[semantic-search] WARNING: Stored embeddings use neural model but Transformers.js unavailable.');
-      console.error('[semantic-search] Results may be poor. Run: flo-embeddings --force');
-    }
-  }
-
-  // Use hash embeddings (either matching stored hash model, or as fallback)
-  const hashEmb = Array.from(semanticHashEmbed(queryText));
-  return { embedding: hashEmb, model: EMBEDDING_MODEL_HASH };
-}
-
-// ============================================================================
-// Search Functions
+// Search
 // ============================================================================
 
 function cosineSimilarity(a, b) {
   if (!a || !b || a.length !== b.length) return 0;
   let dot = 0;
-  for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-  }
-  return dot; // Already L2 normalized
+  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  return dot; // vectors are L2-normalised on both sides
 }
 
 async function getDb() {
@@ -302,74 +112,71 @@ async function getDb() {
 }
 
 async function semanticSearch(queryText, options = {}) {
-  const { limit = 5, namespace = null, threshold = 0.3 } = options;
+  const { limit = 5, namespace: ns = null, threshold: th = 0.3 } = options;
   const startTime = performance.now();
 
   const db = await getDb();
+  const queryEmbedding = await generateQueryEmbedding(queryText);
 
-  // Generate query embedding matching the stored model
-  const { embedding: queryEmbedding, model: queryModel } = await generateQueryEmbedding(queryText, db);
-
-  if (debug) console.error(`[semantic-search] Query model: ${queryModel}`);
-
-  // Get all entries with embeddings
   let sql = `
     SELECT id, key, namespace, content, embedding, embedding_model, metadata
     FROM memory_entries
     WHERE status = 'active' AND embedding IS NOT NULL AND embedding != ''
   `;
   const params = [];
-
-  if (namespace) {
+  if (ns) {
     sql += ` AND namespace = ?`;
-    params.push(namespace);
+    params.push(ns);
   }
 
   const stmt = db.prepare(sql);
   stmt.bind(params);
 
-  // Calculate similarity scores
   const results = [];
+  let skippedIncompat = 0;
   while (stmt.step()) {
     const entry = stmt.getAsObject();
     try {
-      const storedIsNeural = NEURAL_ALIASES.has(entry.embedding_model);
-      const queryIsNeural = NEURAL_ALIASES.has(queryModel);
-      if (entry.embedding_model && entry.embedding_model !== queryModel && !(storedIsNeural && queryIsNeural)) continue;
+      if (entry.embedding_model && !COMPATIBLE_MODELS.has(entry.embedding_model)) {
+        skippedIncompat++;
+        continue;
+      }
 
       const embedding = JSON.parse(entry.embedding);
       if (!Array.isArray(embedding) || embedding.length !== EMBEDDING_DIMS) continue;
 
       const similarity = cosineSimilarity(queryEmbedding, embedding);
+      if (similarity < th) continue;
 
-      if (similarity >= threshold) {
-        let metadata = {};
-        try {
-          metadata = JSON.parse(entry.metadata || '{}');
-        } catch {}
-
-        results.push({
-          key: entry.key,
-          namespace: entry.namespace,
-          score: similarity,
-          preview: entry.content.substring(0, 150).replace(/\n/g, ' '),
-          type: metadata.type || 'unknown',
-          parentDoc: metadata.parentDoc || null,
-          chunkTitle: metadata.chunkTitle || null,
-        });
+      let metadata = {};
+      try {
+        metadata = JSON.parse(entry.metadata || '{}');
+      } catch (err) {
+        if (debug) console.error(`[semantic-search] metadata parse failed for ${entry.key}: ${err.message}`);
       }
-    } catch {
-      // Skip entries with invalid embeddings
+
+      results.push({
+        key: entry.key,
+        namespace: entry.namespace,
+        score: similarity,
+        preview: entry.content.substring(0, 150).replace(/\n/g, ' '),
+        type: metadata.type || 'unknown',
+        parentDoc: metadata.parentDoc || null,
+        chunkTitle: metadata.chunkTitle || null,
+      });
+    } catch (err) {
+      if (debug) console.error(`[semantic-search] skipped ${entry.key}: ${err.message}`);
     }
   }
   stmt.free();
-
   db.close();
 
-  // Sort by similarity (descending) and limit
+  if (debug && skippedIncompat > 0) {
+    console.error(`[semantic-search] Skipped ${skippedIncompat} rows with incompatible embedding_model`);
+  }
+
   results.sort((a, b) => b.score - a.score);
   const topResults = results.slice(0, limit);
-
   const searchTime = performance.now() - startTime;
 
   return {
@@ -378,7 +185,7 @@ async function semanticSearch(queryText, options = {}) {
     totalMatches: results.length,
     searchTime: `${searchTime.toFixed(0)}ms`,
     indexType: 'vector-cosine',
-    model: queryModel,
+    model: EMBEDDING_MODEL,
   };
 }
 
@@ -393,8 +200,6 @@ async function main() {
   }
 
   try {
-    // --with-tests: search both the specified namespace (or code-map) and tests
-    // Auto-route: if query contains test keywords and no namespace specified, also search tests
     const autoRouteTests = !namespace && TEST_KEYWORDS.test(query);
     let results;
 
@@ -403,7 +208,6 @@ async function main() {
       const primaryResults = await semanticSearch(query, { limit, namespace: primaryNs, threshold });
       const testResults = await semanticSearch(query, { limit, namespace: 'tests', threshold });
 
-      // Merge and re-sort by score
       const merged = [...primaryResults.results, ...testResults.results]
         .sort((a, b) => b.score - a.score)
         .slice(0, limit);
@@ -417,7 +221,7 @@ async function main() {
       };
 
       if (!json && autoRouteTests) {
-        console.log(`[semantic-search] Auto-routed to tests namespace (query contains test keywords)`);
+        console.log('[semantic-search] Auto-routed to tests namespace (query contains test keywords)');
       }
     } else {
       results = await semanticSearch(query, { limit, namespace, threshold });
@@ -436,11 +240,9 @@ async function main() {
       return;
     }
 
-    // Display results
     console.log('┌─────────────────────────────────────────────────────────────────────────────┐');
     console.log('│ Rank │ Score │ Key                          │ Type   │ Preview             │');
     console.log('├─────────────────────────────────────────────────────────────────────────────┤');
-
     for (let i = 0; i < results.results.length; i++) {
       const r = results.results[i];
       const rank = String(i + 1).padStart(4);
@@ -448,13 +250,10 @@ async function main() {
       const key = r.key.substring(0, 28).padEnd(28);
       const type = (r.type || '').substring(0, 6).padEnd(6);
       const preview = r.preview.substring(0, 18).padEnd(18);
-
       console.log(`│ ${rank} │ ${score} │ ${key} │ ${type} │ ${preview}… │`);
     }
-
     console.log('└─────────────────────────────────────────────────────────────────────────────┘');
 
-    // Show chunk context
     console.log('');
     console.log('Top result details:');
     const top = results.results[0];
@@ -463,7 +262,6 @@ async function main() {
     if (top.chunkTitle) console.log(`  Section: ${top.chunkTitle}`);
     if (top.parentDoc) console.log(`  Parent: ${top.parentDoc}`);
     console.log(`  Preview: ${top.preview}...`);
-
   } catch (err) {
     console.error(`[semantic-search] Error: ${err.message}`);
     process.exit(1);

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -13,13 +13,41 @@ import { findOrphans } from '../../../scripts/clean-dist.mjs';
 
 // Epic #501 acceptance criterion: a fresh `npm install moflo` consumer sees
 // zero of the following packages anywhere in its dep tree.
+// Epic #527 (story #532) extended this list with `@xenova/transformers` —
+// the archived transformers runtime replaced by `fastembed`.
+//
+// Note: `onnxruntime-node` was previously forbidden (it came in via agentdb).
+// After epic #527 `fastembed` is a required hard dep and legitimately pulls
+// `onnxruntime-node` in as the ONNX runtime. Its binaries are pruned by
+// epic #527 story 6 (#533); the package itself is expected and allowed.
 export const FORBIDDEN_DEPS = [
   'agentdb',
   'agentic-flow',
   '@ruvector',
   'ruvector',
-  'onnxruntime-node',
+  '@xenova/transformers',
 ];
+
+// Epic #527 (story #532): dependencies that MUST be present in a fresh
+// consumer install. Fastembed is the required neural runtime — if it's
+// missing we have regressed to hash-fallback silently.
+export const REQUIRED_DEPS = [
+  'fastembed',
+];
+
+// Epic #527 (story #532): banned identifiers that must not appear anywhere
+// in the published dist tree. If any of these leak through into compiled
+// output, hash-fallback code has crept back in.
+export const BANNED_EMBEDDING_IDENTIFIERS = [
+  'HashEmbeddingProvider',
+  'createHashEmbedding',
+  'generateHashEmbedding',
+  'RvfEmbeddingService',
+  'RvfEmbeddingCache',
+];
+// Literal pattern — `domain-aware-hash-384`, `domain-aware-hash-v1`, or
+// anything else starting with the banned prefix.
+export const BANNED_EMBEDDING_LITERAL_RE = /domain-aware-hash/;
 
 // Known regressions that still leak through until a dedicated fix lands. Each
 // entry MUST reference the tracking issue. Leaking deps in this list are
@@ -148,6 +176,111 @@ export function verifyForbiddenDeps(consumerDir) {
   }
   for (const w of [...leaked].filter(d => KNOWN_FORBIDDEN_REGRESSIONS.has(d))) {
     record(`forbidden-deps:${w}`, 'warn', 'known regression — leaking until tracking fix lands');
+  }
+}
+
+/**
+ * Epic #527 story #532: asserts every required dep landed in the consumer
+ * install. If `fastembed` is missing, moflo has either regressed to
+ * hash-fallback or the publish manifest is broken — either way, hard fail.
+ */
+export function verifyRequiredDeps(consumerDir) {
+  section('Verify required deps present');
+  const nm = join(consumerDir, 'node_modules');
+  const missing = [];
+  for (const name of REQUIRED_DEPS) {
+    const dir = name.startsWith('@')
+      ? join(nm, ...name.split('/'))
+      : join(nm, name);
+    if (!existsSync(join(dir, 'package.json'))) {
+      missing.push(name);
+    }
+  }
+  if (missing.length > 0) {
+    record('required-deps', 'fail', `missing: ${missing.join(', ')}`);
+    return;
+  }
+  record('required-deps', 'pass', `${REQUIRED_DEPS.join(', ')} present`);
+}
+
+/**
+ * Epic #527 story #532: scans the installed moflo dist tree for any banned
+ * hash-embedding identifier. The ESLint guard catches these in source; this
+ * check catches them in compiled output — e.g. a bundled copy, a transform
+ * that resurrects a deleted helper, or a vendored file that slipped past
+ * lint.
+ */
+export function verifyNoBannedEmbeddings(consumerDir) {
+  section('Verify no banned embedding identifiers in dist');
+  const mofloDir = join(consumerDir, 'node_modules', 'moflo');
+  if (!existsSync(mofloDir)) {
+    record('no-banned-embeddings', 'fail', 'node_modules/moflo missing');
+    return;
+  }
+
+  const bannedRe = new RegExp(
+    `\\b(${BANNED_EMBEDDING_IDENTIFIERS.join('|')})\\b|${BANNED_EMBEDDING_LITERAL_RE.source}`,
+  );
+
+  const hits = [];
+  let filesScanned = 0;
+
+  for (const file of walkJsFiles(mofloDir)) {
+    filesScanned++;
+    let text;
+    try {
+      text = readFileSync(file, 'utf8');
+    } catch (err) {
+      log(`  skipped unreadable file ${file}: ${err.message}`);
+      continue;
+    }
+    const match = text.match(bannedRe);
+    if (match) {
+      hits.push({ file, match: match[0] });
+    }
+  }
+
+  if (hits.length > 0) {
+    const preview = hits
+      .slice(0, 5)
+      .map(h => `${relative(consumerDir, h.file)}:${h.match}`)
+      .join(' | ');
+    const suffix = hits.length > 5 ? ` (+${hits.length - 5} more)` : '';
+    record(
+      'no-banned-embeddings',
+      'fail',
+      `hash-embedding code leaked into dist — ${hits.length} hit(s): ${preview}${suffix}`,
+    );
+    return;
+  }
+
+  record(
+    'no-banned-embeddings',
+    'pass',
+    `${filesScanned} JS file(s) scanned, no banned identifiers`,
+  );
+}
+
+function* walkJsFiles(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    log(`  walkJsFiles: cannot read ${dir}: ${err.message}`);
+    return;
+  }
+  for (const entry of entries) {
+    // Don't recurse into nested node_modules — moflo doesn't bundle its deps,
+    // so anything under moflo/node_modules is someone else's code and not
+    // our concern. This also prevents the scan from exploding in size.
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      yield* walkJsFiles(join(dir, entry.name));
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!/\.(m?js|cjs)$/.test(entry.name)) continue;
+    yield join(dir, entry.name);
   }
 }
 

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -11,6 +11,12 @@
  * invariant: no `agentdb`, `agentic-flow`, `@ruvector/*`, `ruvector`, or
  * `onnxruntime-node` in a fresh consumer install.
  *
+ * Epic #527 Story #532 — extends the invariant: no `@xenova/transformers`
+ * and no hash-embedding identifiers (HashEmbeddingProvider, createHashEmbedding,
+ * generateHashEmbedding, RvfEmbeddingService, RvfEmbeddingCache,
+ * `domain-aware-hash-*`) in the installed dist tree. Also asserts the
+ * required neural runtime (`fastembed`) is present.
+ *
  * Usage:
  *   node harness/consumer-smoke/run.mjs                # full run
  *   node harness/consumer-smoke/run.mjs --skip-pack    # reuse last tarball
@@ -64,6 +70,8 @@ function main() {
 
     const checks = [
       () => check.verifyForbiddenDeps(consumerDir),
+      () => check.verifyRequiredDeps(consumerDir),
+      () => check.verifyNoBannedEmbeddings(consumerDir),
       () => check.cliLoads(consumerDir),
       () => check.doctor(consumerDir),
       () => check.memoryInit(consumerDir),

--- a/package-lock.json
+++ b/package-lock.json
@@ -717,15 +717,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1648,6 +1639,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cli-progress": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
@@ -2138,36 +2138,6 @@
         "tar": "^6.2.0"
       }
     },
-    "node_modules/fastembed/node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fastembed/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/fastembed/node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/fastembed/node_modules/onnxruntime-common": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
@@ -2189,31 +2159,6 @@
         "global-agent": "^3.0.0",
         "onnxruntime-common": "1.21.0",
         "tar": "^7.0.1"
-      }
-    },
-    "node_modules/fastembed/node_modules/onnxruntime-node/node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/fastembed/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/fastq": {
@@ -2308,30 +2253,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3058,49 +2979,24 @@
       }
     },
     "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 18"
       }
     },
     "node_modules/moflo": {
@@ -3710,30 +3606,19 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/text-table": {
@@ -4131,10 +4016,13 @@
       "license": "ISC"
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.12.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.0.0",
         "moflo": "^4.8.87-rc.1",
         "tsx": "^4.21.0",
@@ -1140,6 +1142,225 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -1332,6 +1553,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1365,6 +1596,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/callsites": {
@@ -1540,6 +1784,19 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -1824,6 +2081,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1968,6 +2255,19 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -2152,6 +2452,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2280,6 +2601,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
@@ -2689,6 +3020,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2934,6 +3289,16 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3244,6 +3609,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3412,6 +3787,32 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3470,7 +3871,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "test:ui": "vitest --ui",
     "test:security": "vitest run src/__tests__/security/",
     "test:smoke": "node harness/consumer-smoke/run.mjs",
-    "lint": "cd src/modules/cli && npm run lint || true",
+    "lint": "eslint src/ bin/ --ext .ts,.tsx,.mts,.cts,.js,.mjs,.cjs --max-warnings 0",
     "security:audit": "npm audit --audit-level high",
     "security:fix": "npm audit fix",
     "security:test": "npm run test:security",
@@ -108,6 +108,8 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.12.2",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^8.0.0",
     "moflo": "^4.8.87-rc.1",
     "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
   "overrides": {
     "hono": ">=4.11.4",
     "picomatch": ">=2.3.2",
-    "protobufjs": ">=7.5.5"
+    "protobufjs": ">=7.5.5",
+    "tar": ">=7.5.11"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## Summary

Part of epic #527 (story 5). Installs **standing CI gates** so a future PR cannot silently bring hash-based embedding code back into moflo. Story 4 (#531) removed the code; this PR makes sure it stays gone.

## Changes

**ESLint guard** — new `.eslintrc.cjs` (ESLint 8, legacy config)
- `no-restricted-syntax` + `no-restricted-imports` at `error` scoped to `src/**` and `bin/**`
- bans identifiers: `HashEmbeddingProvider`, `createHashEmbedding`, `generateHashEmbedding`, `RvfEmbeddingService`, `RvfEmbeddingCache`
- bans any literal matching `^domain-aware-hash` (catches `domain-aware-hash-384`, `-v1`, or any future suffix)
- bans `@xenova/transformers` imports
- `__tests__/` override keeps deterministic mocks working
- Error message references #527 + #532 so reviewers see the context inline
- Registers `@typescript-eslint` plugin (without enabling rules) so existing `eslint-disable-next-line @typescript-eslint/*` comments in source don't trip "rule not found"
- Root `lint` script replaced: was `cd src/modules/cli && npm run lint || true` (silent no-op — `@moflo/cli` has no lint script and `|| true` masked any failure); now `eslint src/ bin/ --max-warnings 0`

**Consumer smoke gate** — extends `harness/consumer-smoke/lib/checks.mjs`
- new `verifyRequiredDeps` asserts `fastembed` is in the install tree
- new `verifyNoBannedEmbeddings` greps installed `node_modules/moflo/**` for banned identifiers / literals (single combined regex, skips nested `node_modules/`, logs unreadable dirs)
- `FORBIDDEN_DEPS` adds `@xenova/transformers`; drops `onnxruntime-node` (now a legitimate transitive of the hard-dep `fastembed`; binaries still pruned by story 6 / #533)
- Smoke CI already runs on matrix (linux+macos+windows) — no workflow change needed

**bin/ cleanup** (story 4 miss, caught by the new smoke gate)
- `bin/build-embeddings.mjs` and `bin/semantic-search.mjs` still carried `semanticHashEmbed`, `domain-aware-hash-v1`, and `@xenova/transformers` imports. Rewritten to use `fastembed` via `mofloResolveURL`; hard-fail on load failure (no fallback). Dropped ~500 lines of hash / domain-clustering code

**New devDeps**
- `@typescript-eslint/parser@^7.18.0` — needed to parse `.ts` files syntactically
- `@typescript-eslint/eslint-plugin@^7.18.0` — registered only so `@typescript-eslint/*` disable directives in source don't error

## Test plan

- [x] `npm run lint` — passes clean on main state (src/ + bin/)
- [x] `npm run lint` — fails with the #527 message when banned identifier / literal / `@xenova/transformers` import is introduced to `src/**` or `bin/**`
- [x] Lint rule allows banned identifiers under `**/__tests__/**`, `*.test.{ts,js}`, `*.spec.{ts,js}`
- [x] `npm run test:smoke` — passes 26/0 on current main state
- [x] Smoke `verifyRequiredDeps` fails (caught during dev run) when `fastembed` is missing
- [x] Smoke `verifyNoBannedEmbeddings` fails when any banned identifier appears in installed `dist/`
- [x] Smoke `forbidden-deps` fails when `@xenova/transformers` is in the consumer install
- [x] `npm test` — 7780 passed, 0 failed (including a local-var rename fix in `tests/semantic-search-tests.test.ts` contract assertions)
- [ ] CI `lint` and `smoke` jobs both fail on a synthetic regression PR (to be confirmed post-merge via a throwaway PR)

Closes #532