### PR TITLE
feat(embeddings): prune onnxruntime-node binaries on postinstall (#533)

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -10,6 +10,7 @@ import { join, relative } from 'node:path';
 import { run, runNode, flo, NPM_CMD } from './proc.mjs';
 import { section, record, recordExit, log } from './report.mjs';
 import { findOrphans } from '../../../scripts/clean-dist.mjs';
+import { findOrtPackages } from '../../../scripts/prune-native-binaries.mjs';
 
 // Epic #501 acceptance criterion: a fresh `npm install moflo` consumer sees
 // zero of the following packages anywhere in its dep tree.
@@ -485,6 +486,92 @@ export function installSurface(consumerDir) {
   }
   const sz = folderSize(mofloDir);
   record('moflo-install-size', 'info', `${(sz / 1024 / 1024).toFixed(1)} MB`);
+}
+
+/** Inspect one onnxruntime-node install; return a problem string or null. */
+function inspectOrtInstall(ortDir, consumerDir) {
+  const napi = join(ortDir, 'bin', 'napi-v3');
+  if (!existsSync(napi)) return null; // future layout change, not a prune failure
+  const rel = relative(consumerDir, ortDir);
+  const dirNames = (d) => readdirSync(d, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name);
+
+  const platforms = dirNames(napi);
+  const platExtras = platforms.filter(p => p !== process.platform);
+  if (platExtras.length > 0) return `${rel}: extra platforms present — ${platExtras.join(', ')}`;
+  if (!platforms.includes(process.platform)) return `${rel}: current platform dir missing (${process.platform})`;
+
+  const archs = dirNames(join(napi, process.platform));
+  const archExtras = archs.filter(a => a !== process.arch);
+  if (archExtras.length > 0) return `${rel}: extra archs under ${process.platform} — ${archExtras.join(', ')}`;
+  if (!archs.includes(process.arch)) return `${rel}: current arch dir missing (${process.arch})`;
+  return null;
+}
+
+/**
+ * After postinstall, every onnxruntime-node install should retain only the
+ * current `<platform>/<arch>` subtree under `bin/napi-v3/`. Hard-fail on any
+ * non-current platform directory or any extra arch under the kept platform.
+ */
+export function verifyPrunedBinaries(consumerDir) {
+  section('Verify onnxruntime-node binaries pruned to current platform');
+  const nm = join(consumerDir, 'node_modules');
+  const ortInstalls = findOrtPackages(nm);
+
+  if (ortInstalls.length === 0) {
+    record('ort-pruned', 'info', 'no onnxruntime-node install found');
+    return;
+  }
+
+  const problems = [];
+  for (const ort of ortInstalls) {
+    const p = inspectOrtInstall(ort, consumerDir);
+    if (p) problems.push(p);
+  }
+
+  if (problems.length > 0) {
+    record('ort-pruned', 'fail', `prune incomplete — ${problems.join(' | ')}`);
+    return;
+  }
+  record('ort-pruned', 'pass', `${ortInstalls.length} install(s) pruned to ${process.platform}/${process.arch}`);
+}
+
+/**
+ * `@anush008/tokenizers` ships its native binary via the sharp-style
+ * optional-subpackage pattern. A healthy install has exactly one
+ * `@anush008/tokenizers-<platform>-<arch>[-<abi>]` sibling — zero means npm's
+ * optional-dep selection failed (broken install), multiple means something is
+ * packaging too many variants.
+ */
+export function verifyTokenizerSubpackage(consumerDir) {
+  section('Verify @anush008/tokenizers native subpackage');
+  const scopeDir = join(consumerDir, 'node_modules', '@anush008');
+  if (!existsSync(scopeDir)) {
+    record('tokenizer-subpackage', 'fail', '@anush008/ scope missing — fastembed cannot tokenize');
+    return;
+  }
+  let entries;
+  try { entries = readdirSync(scopeDir); }
+  catch (err) {
+    record('tokenizer-subpackage', 'fail', `cannot read @anush008/: ${err.message}`);
+    return;
+  }
+  const hasBase = entries.includes('tokenizers');
+  const platformPkgs = entries.filter(n => /^tokenizers-/.test(n));
+  if (!hasBase) {
+    record('tokenizer-subpackage', 'fail', '@anush008/tokenizers base package missing');
+    return;
+  }
+  if (platformPkgs.length === 0) {
+    record('tokenizer-subpackage', 'fail', 'no @anush008/tokenizers-<platform> subpackage installed (optional-dep selection failed)');
+    return;
+  }
+  if (platformPkgs.length > 1) {
+    record('tokenizer-subpackage', 'fail', `expected exactly one platform subpackage, found ${platformPkgs.length}: ${platformPkgs.join(', ')}`);
+    return;
+  }
+  record('tokenizer-subpackage', 'pass', `@anush008/${platformPkgs[0]} present`);
 }
 
 function folderSize(dir) {

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -7,15 +7,12 @@
  * facing surface: memory CRUD, spell list, MCP tools registration, hooks,
  * `/flo` skill packaging, and flo-search CLI.
  *
- * Epic #464 Gate 3 / Epic #501 Story 2 — also asserts the forbidden-dep
- * invariant: no `agentdb`, `agentic-flow`, `@ruvector/*`, `ruvector`, or
- * `onnxruntime-node` in a fresh consumer install.
- *
- * Epic #527 Story #532 — extends the invariant: no `@xenova/transformers`
- * and no hash-embedding identifiers (HashEmbeddingProvider, createHashEmbedding,
+ * Also asserts forbidden-dep invariants in the installed dist tree:
+ * `agentdb`, `agentic-flow`, `@ruvector/*`, `ruvector`, `@xenova/transformers`,
+ * and any hash-embedding identifiers (HashEmbeddingProvider, createHashEmbedding,
  * generateHashEmbedding, RvfEmbeddingService, RvfEmbeddingCache,
- * `domain-aware-hash-*`) in the installed dist tree. Also asserts the
- * required neural runtime (`fastembed`) is present.
+ * `domain-aware-hash-*`). Asserts required deps present (`fastembed`) and
+ * that postinstall pruned onnxruntime-node to the current platform+arch.
  *
  * Usage:
  *   node harness/consumer-smoke/run.mjs                # full run
@@ -84,6 +81,8 @@ function main() {
       () => check.floSkillPackaged(consumerDir),
       () => check.consumerInvariants(consumerDir),
       () => check.installSurface(consumerDir),
+      () => check.verifyPrunedBinaries(consumerDir),
+      () => check.verifyTokenizerSubpackage(consumerDir),
     ];
     for (const fn of checks) {
       try { fn(); } catch (err) {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "!.claude/**/*.map",
     "spells/shipped/**",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "scripts/prune-native-binaries.mjs"
   ],
   "scripts": {
     "dev": "tsx watch src/index.ts",
@@ -80,6 +81,7 @@
     "build:neural": "cd src/modules/neural && npx tsc -p tsconfig.json",
     "build:guidance": "cd src/modules/guidance && npx tsc -p tsconfig.json",
     "prepublishOnly": "node scripts/check-version-sync.mjs && npm run build",
+    "postinstall": "node scripts/prune-native-binaries.mjs",
     "test": "node scripts/test-runner.mjs",
     "test:ui": "vitest --ui",
     "test:security": "vitest run src/__tests__/security/",

--- a/scripts/prune-native-binaries.mjs
+++ b/scripts/prune-native-binaries.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Postinstall native-binary pruner for consumer moflo installs.
+ *
+ * Trims `onnxruntime-node`'s multi-platform binary bundle under
+ * `bin/napi-v3/<platform>/<arch>/` down to just the current combination,
+ * reclaiming ~150 MB per install. `fastembed` pulls the full bundle by
+ * default.
+ *
+ * Escape hatches:
+ *   - `MOFLO_NO_PRUNE=1`             → skip entirely
+ *   - script is inside moflo source  → skip (dev/CI needs the full set)
+ *   - no `node_modules/` (Yarn PnP)  → skip with info log
+ *   - no onnxruntime-node installed  → no-op
+ *
+ * Failure posture: a consumer install must NEVER fail because of this
+ * script. All errors are logged and swallowed; exit is always 0.
+ *
+ * Pure Node — no shell invocations, no dependencies. Must work during
+ * `npm install` before any of moflo's own compiled code exists on disk.
+ */
+
+import { existsSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, sep } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const BYTES_PER_MB = 1024 * 1024;
+const NODE_MODULES_SEGMENT = `${sep}node_modules${sep}`;
+
+function info(msg) { console.log(`moflo:prune ${msg}`); }
+function warn(msg) { console.warn(`moflo:prune warn: ${msg}`); }
+
+/**
+ * True only when the script is running from within the moflo source repo
+ * itself — detected by absence of any `node_modules/` segment in the path
+ * AND a nearest-ancestor `package.json` with `"name": "moflo"`. Any other
+ * weird state (no package.json found, unreadable, different name) returns
+ * `false` so `run()` falls through to the normal consumer-root path and
+ * skips with a clear reason. This avoids silently disabling prune in
+ * unusual-but-real consumer layouts.
+ */
+export function isSourceRepo(scriptPath) {
+  if (scriptPath.includes(NODE_MODULES_SEGMENT)) return false;
+  let dir = dirname(scriptPath);
+  while (true) {
+    const pkgPath = join(dir, 'package.json');
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+        return pkg?.name === 'moflo';
+      } catch {
+        return false;
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+}
+
+/**
+ * Extract the consumer project root from the script path. When installed as a
+ * dep the script lives at `<consumerRoot>/node_modules/moflo/scripts/…`.
+ * Uses the outermost `node_modules/` segment so nested npm installs still
+ * resolve to the consumer's real project root (not an intermediate package).
+ */
+export function findConsumerRoot(scriptPath) {
+  const idx = scriptPath.indexOf(NODE_MODULES_SEGMENT);
+  if (idx === -1) return null;
+  return scriptPath.slice(0, idx);
+}
+
+/**
+ * Collect every `onnxruntime-node` directory under `nodeModulesDir`. Checks
+ * the two common layouts first (hoisted + nested under fastembed) to avoid
+ * walking a large consumer `node_modules/` tree in the common case, and
+ * falls back to a bounded recursive walk for non-standard layouts.
+ */
+export function findOrtPackages(nodeModulesDir, maxDepth = 10) {
+  const fast = [
+    join(nodeModulesDir, 'fastembed', 'node_modules', 'onnxruntime-node'),
+    join(nodeModulesDir, 'onnxruntime-node'),
+  ].filter(existsSync);
+  if (fast.length > 0) return fast;
+
+  const hits = [];
+
+  function scanNodeModules(nmDir, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try { entries = readdirSync(nmDir, { withFileTypes: true }); }
+    catch { return; }
+    for (const ent of entries) {
+      if (!ent.isDirectory()) continue;
+      const pkgDir = join(nmDir, ent.name);
+      if (ent.name === 'onnxruntime-node') { hits.push(pkgDir); continue; }
+      if (ent.name.startsWith('@')) { scanScope(pkgDir, depth + 1); continue; }
+      scanNodeModules(join(pkgDir, 'node_modules'), depth + 1);
+    }
+  }
+
+  function scanScope(scopeDir, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try { entries = readdirSync(scopeDir, { withFileTypes: true }); }
+    catch { return; }
+    for (const ent of entries) {
+      if (!ent.isDirectory()) continue;
+      const pkgDir = join(scopeDir, ent.name);
+      if (ent.name === 'onnxruntime-node') hits.push(pkgDir);
+      scanNodeModules(join(pkgDir, 'node_modules'), depth + 1);
+    }
+  }
+
+  scanNodeModules(nodeModulesDir, 0);
+  return hits;
+}
+
+function dirSize(dir) {
+  let total = 0;
+  const stack = [dir];
+  while (stack.length) {
+    const d = stack.pop();
+    let entries;
+    try { entries = readdirSync(d, { withFileTypes: true }); }
+    catch { continue; }
+    for (const ent of entries) {
+      const full = join(d, ent.name);
+      if (ent.isDirectory()) { stack.push(full); continue; }
+      try { total += statSync(full).size; } catch { /* ignore */ }
+    }
+  }
+  return total;
+}
+
+/**
+ * Remove a directory, tolerating one `EBUSY` retry (Windows file-locking).
+ * When `measure` is true, walks the tree first to compute reclaimed bytes —
+ * otherwise returns 0 and skips the extra walk entirely. Returns 0 on any
+ * failure; the script never fails the install.
+ */
+export function removeDir(dir, { rm = rmSync, measure = false } = {}) {
+  const size = measure ? dirSize(dir) : 0;
+  try {
+    rm(dir, { recursive: true, force: true, maxRetries: 1, retryDelay: 250 });
+    return size;
+  } catch (err) {
+    warn(`could not remove ${dir}: ${err.code || err.message} (leaving in place)`);
+    return 0;
+  }
+}
+
+/**
+ * Prune `bin/napi-v3/<platform>/<arch>/` from one onnxruntime-node package,
+ * keeping only the current combination.
+ */
+export function pruneOrtPackage(ortDir, {
+  keepPlatform = process.platform,
+  keepArch = process.arch,
+  rm = rmSync,
+  measure = false,
+} = {}) {
+  const napiDir = join(ortDir, 'bin', 'napi-v3');
+  let platforms;
+  try { platforms = readdirSync(napiDir, { withFileTypes: true }); }
+  catch { return 0; }
+
+  let bytes = 0;
+  for (const p of platforms) {
+    if (!p.isDirectory()) continue;
+    const pDir = join(napiDir, p.name);
+    if (p.name !== keepPlatform) {
+      bytes += removeDir(pDir, { rm, measure });
+      continue;
+    }
+    let archs;
+    try { archs = readdirSync(pDir, { withFileTypes: true }); }
+    catch (err) { warn(`cannot read ${pDir}: ${err.message}`); continue; }
+    for (const a of archs) {
+      if (!a.isDirectory() || a.name === keepArch) continue;
+      bytes += removeDir(join(pDir, a.name), { rm, measure });
+    }
+  }
+  return bytes;
+}
+
+/**
+ * Whole-run entry point. Returns `{ code, bytesReclaimed, packagesPruned, reason }`.
+ * Never throws — all errors are caught and downgraded to `warn`.
+ */
+export function run({
+  scriptPath = SCRIPT_PATH,
+  env = process.env,
+  verbose = false,
+} = {}) {
+  if (env.MOFLO_NO_PRUNE === '1') {
+    info('MOFLO_NO_PRUNE=1 set — skipping native-binary prune');
+    return { code: 0, bytesReclaimed: 0, packagesPruned: 0, reason: 'opt-out' };
+  }
+
+  if (isSourceRepo(scriptPath)) {
+    if (verbose) info('running inside moflo source repo — skipping prune');
+    return { code: 0, bytesReclaimed: 0, packagesPruned: 0, reason: 'source-repo' };
+  }
+
+  const consumerRoot = findConsumerRoot(scriptPath);
+  if (!consumerRoot) {
+    info('could not resolve consumer root — skipping prune');
+    return { code: 0, bytesReclaimed: 0, packagesPruned: 0, reason: 'no-root' };
+  }
+
+  const nmDir = join(consumerRoot, 'node_modules');
+  if (!existsSync(nmDir)) {
+    info('no node_modules/ (Yarn PnP or pre-install) — skipping prune');
+    return { code: 0, bytesReclaimed: 0, packagesPruned: 0, reason: 'no-node-modules' };
+  }
+
+  const ortPkgs = findOrtPackages(nmDir);
+  if (ortPkgs.length === 0) {
+    if (verbose) info('no onnxruntime-node installs found — nothing to prune');
+    return { code: 0, bytesReclaimed: 0, packagesPruned: 0, reason: 'no-ort' };
+  }
+
+  let totalBytes = 0;
+  for (const pkg of ortPkgs) {
+    totalBytes += pruneOrtPackage(pkg, { measure: verbose });
+  }
+
+  if (verbose) {
+    const mb = (totalBytes / BYTES_PER_MB).toFixed(1);
+    info(`pruned ${ortPkgs.length} onnxruntime-node install(s), reclaimed ${mb} MB`);
+  }
+
+  return {
+    code: 0,
+    bytesReclaimed: totalBytes,
+    packagesPruned: ortPkgs.length,
+    reason: 'pruned',
+  };
+}
+
+// Auto-run when executed directly (project convention: URL-normalized compare
+// for Windows drive-letter/case safety — see scripts/clean-dist.mjs).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const verbose = process.argv.includes('--verbose') || process.env.MOFLO_PRUNE_VERBOSE === '1';
+    const result = run({ verbose });
+    process.exit(result.code);
+  } catch (err) {
+    warn(`unexpected error: ${err?.stack || err?.message || err}`);
+    process.exit(0);
+  }
+}

--- a/tests/scripts/prune-native-binaries.test.mts
+++ b/tests/scripts/prune-native-binaries.test.mts
@@ -1,0 +1,331 @@
+/**
+ * Tests for scripts/prune-native-binaries.mjs — walker + prune logic
+ * exercised on temp fixtures; never touches the real node_modules tree.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  findConsumerRoot,
+  findOrtPackages,
+  isSourceRepo,
+  pruneOrtPackage,
+  removeDir,
+  run,
+} from '../../scripts/prune-native-binaries.mjs';
+
+const ALL_PLATFORMS = ['darwin', 'linux', 'win32'] as const;
+const ALL_ARCHES = ['arm64', 'x64'] as const;
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'moflo-prune-'));
+});
+
+afterEach(() => {
+  if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+});
+
+/** Build an `onnxruntime-node/bin/napi-v3/<plat>/<arch>/` fixture tree. */
+function buildOrtTree(
+  root: string,
+  combos: Array<{ platform: string; arch: string; bytes?: number }>,
+): string {
+  const ortDir = join(root, 'onnxruntime-node');
+  const napi = join(ortDir, 'bin', 'napi-v3');
+  mkdirSync(napi, { recursive: true });
+  for (const { platform, arch, bytes = 1024 } of combos) {
+    const leaf = join(napi, platform, arch);
+    mkdirSync(leaf, { recursive: true });
+    writeFileSync(join(leaf, 'onnxruntime_binding.node'), Buffer.alloc(bytes));
+  }
+  // Non-binary sibling file to confirm we don't touch anything outside napi-v3
+  writeFileSync(join(ortDir, 'package.json'), '{"name":"onnxruntime-node"}');
+  return ortDir;
+}
+
+describe('findOrtPackages', () => {
+  it('finds a single top-level onnxruntime-node', () => {
+    const nm = join(tmp, 'node_modules');
+    mkdirSync(join(nm, 'onnxruntime-node'), { recursive: true });
+    const hits = findOrtPackages(nm);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toBe(join(nm, 'onnxruntime-node'));
+  });
+
+  it('finds nested onnxruntime-node under another package', () => {
+    const nm = join(tmp, 'node_modules');
+    mkdirSync(join(nm, 'fastembed', 'node_modules', 'onnxruntime-node'), { recursive: true });
+    const hits = findOrtPackages(nm);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toBe(join(nm, 'fastembed', 'node_modules', 'onnxruntime-node'));
+  });
+
+  it('finds both hoisted and nested copies in the same tree', () => {
+    const nm = join(tmp, 'node_modules');
+    mkdirSync(join(nm, 'onnxruntime-node'), { recursive: true });
+    mkdirSync(join(nm, 'fastembed', 'node_modules', 'onnxruntime-node'), { recursive: true });
+    const hits = findOrtPackages(nm);
+    expect(hits).toHaveLength(2);
+  });
+
+  it('descends into scoped @org dirs', () => {
+    const nm = join(tmp, 'node_modules');
+    mkdirSync(join(nm, '@scope', 'pkg', 'node_modules', 'onnxruntime-node'), { recursive: true });
+    const hits = findOrtPackages(nm);
+    expect(hits).toHaveLength(1);
+  });
+
+  it('returns empty array when node_modules has no onnxruntime-node', () => {
+    const nm = join(tmp, 'node_modules');
+    mkdirSync(join(nm, 'lodash'), { recursive: true });
+    expect(findOrtPackages(nm)).toEqual([]);
+  });
+
+  it('tolerates a non-existent directory', () => {
+    expect(findOrtPackages(join(tmp, 'does-not-exist'))).toEqual([]);
+  });
+});
+
+describe('pruneOrtPackage', () => {
+  it('keeps only the current platform+arch, removes all others', () => {
+    const combos = ALL_PLATFORMS.flatMap((p) => ALL_ARCHES.map((a) => ({ platform: p, arch: a })));
+    const ortDir = buildOrtTree(tmp, combos);
+
+    const bytes = pruneOrtPackage(ortDir, { keepPlatform: 'linux', keepArch: 'x64', measure: true });
+    expect(bytes).toBeGreaterThan(0);
+
+    const napi = join(ortDir, 'bin', 'napi-v3');
+    const survivors = readdirSync(napi);
+    expect(survivors).toEqual(['linux']);
+    expect(readdirSync(join(napi, 'linux'))).toEqual(['x64']);
+  });
+
+  it('skips the directory-size walk when measure is false (default hot path)', () => {
+    const combos = ALL_PLATFORMS.flatMap((p) => ALL_ARCHES.map((a) => ({ platform: p, arch: a })));
+    const ortDir = buildOrtTree(tmp, combos);
+
+    const bytes = pruneOrtPackage(ortDir, { keepPlatform: 'linux', keepArch: 'x64' });
+    // Default path returns 0 bytes — size walk is skipped; prune still happens.
+    expect(bytes).toBe(0);
+    expect(readdirSync(join(ortDir, 'bin', 'napi-v3'))).toEqual(['linux']);
+  });
+
+  it('deletes non-current archs under the kept platform', () => {
+    const ortDir = buildOrtTree(tmp, [
+      { platform: 'linux', arch: 'x64' },
+      { platform: 'linux', arch: 'arm64' },
+    ]);
+
+    pruneOrtPackage(ortDir, { keepPlatform: 'linux', keepArch: 'x64' });
+
+    expect(existsSync(join(ortDir, 'bin', 'napi-v3', 'linux', 'x64'))).toBe(true);
+    expect(existsSync(join(ortDir, 'bin', 'napi-v3', 'linux', 'arm64'))).toBe(false);
+  });
+
+  it('is a no-op when only the current platform+arch exists', () => {
+    const ortDir = buildOrtTree(tmp, [{ platform: 'linux', arch: 'x64' }]);
+
+    const bytes = pruneOrtPackage(ortDir, { keepPlatform: 'linux', keepArch: 'x64' });
+
+    expect(bytes).toBe(0);
+    expect(existsSync(join(ortDir, 'bin', 'napi-v3', 'linux', 'x64'))).toBe(true);
+  });
+
+  it('returns 0 when bin/napi-v3 is missing (future layout change)', () => {
+    const ortDir = join(tmp, 'onnxruntime-node');
+    mkdirSync(ortDir, { recursive: true });
+    expect(pruneOrtPackage(ortDir)).toBe(0);
+  });
+
+  it('preserves sibling files outside bin/napi-v3', () => {
+    const ortDir = buildOrtTree(tmp, [
+      { platform: 'linux', arch: 'x64' },
+      { platform: 'win32', arch: 'x64' },
+    ]);
+    pruneOrtPackage(ortDir, { keepPlatform: 'linux', keepArch: 'x64' });
+    expect(existsSync(join(ortDir, 'package.json'))).toBe(true);
+  });
+
+  it('retries once on EBUSY then swallows persistent failures', () => {
+    const ortDir = buildOrtTree(tmp, [
+      { platform: 'linux', arch: 'x64' },
+      { platform: 'win32', arch: 'x64' },
+    ]);
+
+    // Spy that always throws EBUSY-like error — mirrors Windows file lock.
+    let calls = 0;
+    const rm = () => {
+      calls++;
+      const err = new Error('resource busy') as NodeJS.ErrnoException;
+      err.code = 'EBUSY';
+      throw err;
+    };
+
+    // Should not throw; returns 0 bytes on failure.
+    expect(() => pruneOrtPackage(ortDir, { keepPlatform: 'linux', keepArch: 'x64', rm })).not.toThrow();
+    expect(calls).toBeGreaterThan(0);
+    // The original tree is still intact because rm was a no-op spy.
+    expect(existsSync(join(ortDir, 'bin', 'napi-v3', 'win32', 'x64'))).toBe(true);
+  });
+});
+
+describe('removeDir', () => {
+  it('returns bytes reclaimed when measure is true', () => {
+    const target = join(tmp, 'removeme');
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, 'a.bin'), Buffer.alloc(2048));
+    writeFileSync(join(target, 'b.bin'), Buffer.alloc(1024));
+
+    const bytes = removeDir(target, { measure: true });
+    expect(bytes).toBe(3072);
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it('returns 0 and still removes when measure is false', () => {
+    const target = join(tmp, 'removeme');
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, 'a.bin'), Buffer.alloc(512));
+
+    const bytes = removeDir(target);
+    expect(bytes).toBe(0);
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it('returns 0 and logs when rm throws', () => {
+    const dir = join(tmp, 'never-removed');
+    mkdirSync(dir);
+    const err = new Error('perm') as NodeJS.ErrnoException;
+    err.code = 'EPERM';
+    const rm = () => { throw err; };
+    expect(removeDir(dir, { rm })).toBe(0);
+    expect(existsSync(dir)).toBe(true);
+  });
+});
+
+describe('isSourceRepo', () => {
+  it('returns true when the script path has no node_modules segment and nearest package.json is moflo', () => {
+    const scriptPath = join(tmp, 'scripts', 'prune-native-binaries.mjs');
+    mkdirSync(join(tmp, 'scripts'), { recursive: true });
+    writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'moflo' }));
+    expect(isSourceRepo(scriptPath)).toBe(true);
+  });
+
+  it('returns false when path includes node_modules (consumer install)', () => {
+    const scriptPath = join(tmp, 'node_modules', 'moflo', 'scripts', 'prune.mjs');
+    expect(isSourceRepo(scriptPath)).toBe(false);
+  });
+
+  it('returns false when nearest package.json is not named moflo', () => {
+    const scriptPath = join(tmp, 'scripts', 'prune.mjs');
+    mkdirSync(join(tmp, 'scripts'), { recursive: true });
+    writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'some-other-project' }));
+    expect(isSourceRepo(scriptPath)).toBe(false);
+  });
+});
+
+describe('findConsumerRoot', () => {
+  it('extracts the path before the first node_modules segment', () => {
+    const scriptPath = join('C:', 'workspace', 'app', 'node_modules', 'moflo', 'scripts', 'x.mjs');
+    expect(findConsumerRoot(scriptPath)).toBe(join('C:', 'workspace', 'app'));
+  });
+
+  it('returns null when path has no node_modules segment', () => {
+    expect(findConsumerRoot(join(tmp, 'scripts', 'x.mjs'))).toBeNull();
+  });
+
+  it('uses the outermost node_modules segment for nested installs', () => {
+    // If moflo is installed non-hoisted under another package, the path will
+    // contain two `node_modules/` segments. The OUTERMOST one marks the real
+    // consumer root — otherwise we'd scan only the intermediate package's
+    // node_modules/ and miss hoisted onnxruntime-node at the consumer root.
+    const p = join('C:', 'app', 'node_modules', 'some-pkg', 'node_modules', 'moflo', 'scripts', 'x.mjs');
+    expect(findConsumerRoot(p)).toBe(join('C:', 'app'));
+  });
+});
+
+describe('run (end-to-end dry flows)', () => {
+  /**
+   * Build a consumer-install-shaped fixture and return the fake
+   * script path pointing at `<consumerRoot>/node_modules/moflo/scripts/x.mjs`.
+   */
+  function buildConsumerFixture(): { scriptPath: string; consumerRoot: string; ortDir: string } {
+    const consumerRoot = tmp;
+    const mofloScripts = join(consumerRoot, 'node_modules', 'moflo', 'scripts');
+    mkdirSync(mofloScripts, { recursive: true });
+    const scriptPath = join(mofloScripts, 'prune-native-binaries.mjs');
+    writeFileSync(scriptPath, '// placeholder\n');
+    const ortDir = buildOrtTree(
+      join(consumerRoot, 'node_modules', 'fastembed', 'node_modules'),
+      ALL_PLATFORMS.flatMap((p) => ALL_ARCHES.map((a) => ({ platform: p, arch: a }))),
+    );
+    return { scriptPath, consumerRoot, ortDir };
+  }
+
+  it('prunes every non-current combo in a simulated consumer install', () => {
+    const { scriptPath, ortDir } = buildConsumerFixture();
+
+    // verbose: true so bytesReclaimed is measured (default hot path skips the
+    // walk for speed — exercised separately).
+    const result = run({ scriptPath, env: {}, verbose: true });
+
+    expect(result.reason).toBe('pruned');
+    expect(result.packagesPruned).toBe(1);
+    expect(result.bytesReclaimed).toBeGreaterThan(0);
+
+    const survivors = readdirSync(join(ortDir, 'bin', 'napi-v3'));
+    expect(survivors).toEqual([process.platform]);
+    expect(readdirSync(join(ortDir, 'bin', 'napi-v3', process.platform))).toEqual([process.arch]);
+  });
+
+  it('skips when MOFLO_NO_PRUNE=1 — preserves the full tree', () => {
+    const { scriptPath, ortDir } = buildConsumerFixture();
+
+    const result = run({ scriptPath, env: { MOFLO_NO_PRUNE: '1' } });
+
+    expect(result.reason).toBe('opt-out');
+    expect(result.bytesReclaimed).toBe(0);
+    // Full tree intact
+    const survivors = readdirSync(join(ortDir, 'bin', 'napi-v3')).sort();
+    expect(survivors).toEqual(['darwin', 'linux', 'win32']);
+  });
+
+  it('skips source-repo installs', () => {
+    const scriptPath = join(tmp, 'scripts', 'prune-native-binaries.mjs');
+    mkdirSync(join(tmp, 'scripts'), { recursive: true });
+    writeFileSync(join(tmp, 'package.json'), JSON.stringify({ name: 'moflo' }));
+
+    const result = run({ scriptPath, env: {} });
+    expect(result.reason).toBe('source-repo');
+  });
+
+  it('skips gracefully when node_modules is missing (Yarn PnP)', () => {
+    // `run()` doesn't require the script file to exist on disk — it only reads
+    // the path string. Under PnP, the consumer root has no `node_modules/`
+    // directory even though npm-style postinstall may still fire. Pass a
+    // purely synthetic script path and assert the skip branch.
+    const syntheticConsumerRoot = join(tmp, 'pnp-consumer');
+    mkdirSync(syntheticConsumerRoot, { recursive: true });
+    const scriptPath = join(syntheticConsumerRoot, 'node_modules', 'moflo', 'scripts', 'x.mjs');
+    // Deliberately do NOT create node_modules on disk.
+
+    const result = run({ scriptPath, env: {} });
+    expect(result.reason).toBe('no-node-modules');
+  });
+
+  it('is a no-op when no onnxruntime-node is present', () => {
+    const consumerRoot = tmp;
+    const scriptPath = join(consumerRoot, 'node_modules', 'moflo', 'scripts', 'x.mjs');
+    mkdirSync(join(consumerRoot, 'node_modules', 'moflo', 'scripts'), { recursive: true });
+    writeFileSync(scriptPath, '');
+    mkdirSync(join(consumerRoot, 'node_modules', 'lodash'), { recursive: true });
+
+    const result = run({ scriptPath, env: {} });
+    expect(result.reason).toBe('no-ort');
+    expect(result.bytesReclaimed).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Part of epic #527, story 6. Trims `onnxruntime-node`'s ~210 MB multi-platform binary bundle down to just the current platform+arch via a pure-Node postinstall script, reclaiming ~150 MB per consumer install.

## Changes

- **`scripts/prune-native-binaries.mjs`** (new): walks the consumer's `node_modules/`, finds every `onnxruntime-node/` package (handling hoisted + nested-under-fastembed layouts), and deletes every `bin/napi-v3/<platform>/<arch>/` subtree except the current one. Fast-paths the two common layouts first so 99% of installs skip the recursive walk entirely.
- **Escape hatches**: `MOFLO_NO_PRUNE=1`, moflo source-repo auto-skip (so `npm install` in this repo preserves the full binary set for dev/CI), Yarn PnP skip, missing-onnxruntime-node no-op. Script never fails the install — all errors are logged and swallowed.
- **Windows EBUSY** handled via `fs.rmSync({ maxRetries: 1, retryDelay: 250 })`.
- **Entry-point detection** uses `pathToFileURL(process.argv[1]).href === import.meta.url` (per `scripts/clean-dist.mjs` convention) to stay Windows-safe.
- **`package.json`**: adds `postinstall` and ships the script via the `files` array.
- **`harness/consumer-smoke/`**: two new invariants — `ort-pruned` (only current `<platform>/<arch>` survives under any `bin/napi-v3/`) and `tokenizer-subpackage` (exactly one `@anush008/tokenizers-<platform>-<arch>[-<abi>]` sibling installed). The harness imports `findOrtPackages` from the script directly so prune and verify can't disagree on where to look.
- **`tests/scripts/prune-native-binaries.test.mts`** (new): 27 unit tests on the walker, pruner, and end-to-end `run()` flows using temp fixtures.

## Testing

- [x] Unit tests pass (27 new tests)
- [x] Full suite passes (7805 passed / 0 failed)
- [x] Consumer smoke harness passes (28/28 including new `ort-pruned` + `tokenizer-subpackage` checks)
- [x] Lint clean (`npm run lint`)
- [x] Manually confirmed on Windows x64 — smoke reports `1 install(s) pruned to win32/x64` and `@anush008/tokenizers-win32-x64-msvc present`
- [ ] CI matrix verification on linux-x64, linux-arm64, darwin-arm64 (per `feedback_cross_platform_mandatory.md`)

## Epic footprint note

Post-prune consumer install size check from the smoke harness: `moflo-install-size — 8.7 MB` (the prune trims the fastembed-nested onnxruntime-node bundle but fastembed itself is in the consumer's `node_modules/`, not under `moflo/`). Epic acceptance criterion #7 is satisfied.

Closes #533