### PR TITLE
fix(swarm): remove inline hash embeddings in coordinators (#542)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -56,6 +56,35 @@ const bannedEmbeddingRules = {
   ],
 };
 
+// Structural guard: any function that both constructs a Float32Array AND
+// calls charCodeAt is a hash embedding regardless of method name. The
+// identifier ban above missed the inline implementations removed in #542
+// because their enclosing methods used generic names.
+const INLINE_HASH_EMBEDDING_MESSAGE =
+  'Inline hash-embedding pattern detected (Float32Array + charCodeAt in the ' +
+  'same function). Inject a fastembed-backed IEmbeddingProvider from ' +
+  '@moflo/embeddings instead.';
+
+const INLINE_HASH_EMBEDDING_SELECTORS = [
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+  'MethodDefinition > FunctionExpression',
+].map(fn => ({
+  selector:
+    `${fn}:has(NewExpression[callee.name='Float32Array'])` +
+    `:has(CallExpression[callee.property.name='charCodeAt'])`,
+  message: INLINE_HASH_EMBEDDING_MESSAGE,
+}));
+
+const swarmSrcRules = {
+  'no-restricted-syntax': [
+    'error',
+    ...bannedEmbeddingRules['no-restricted-syntax'].slice(1),
+    ...INLINE_HASH_EMBEDDING_SELECTORS,
+  ],
+};
+
 module.exports = {
   root: true,
   ignorePatterns: [
@@ -103,6 +132,18 @@ module.exports = {
         sourceType: 'module',
       },
       rules: bannedEmbeddingRules,
+    },
+    {
+      // Issue #542: structural ban on inline hash embeddings in swarm
+      // coordinators. Layered on top of the repo-wide identifier/literal ban.
+      files: ['src/modules/swarm/src/**/*.ts'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      plugins: ['@typescript-eslint'],
+      rules: swarmSrcRules,
     },
     {
       // Test-only deterministic mocks are explicitly allowed to reference the

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -205,6 +205,61 @@ export function verifyRequiredDeps(consumerDir) {
 }
 
 /**
+ * Structural check: any file in the swarm dist that contains both
+ * `new Float32Array(` AND `charCodeAt(` is a hash-embedding regardless of
+ * method name. Layered on top of the identifier guard because the identifier
+ * ban alone missed the inline implementations removed in #542.
+ */
+export function verifyNoInlineHashEmbeddingsInSwarm(consumerDir) {
+  section('Verify no inline hash embeddings in @moflo/swarm dist');
+  const swarmDist = join(
+    consumerDir,
+    'node_modules',
+    'moflo',
+    'src',
+    'modules',
+    'swarm',
+    'dist',
+  );
+  if (!existsSync(swarmDist)) {
+    record('no-inline-hash-embeddings:swarm', 'info', 'swarm dist not present in consumer');
+    return;
+  }
+
+  const hits = [];
+  let filesScanned = 0;
+  for (const file of walkJsFiles(swarmDist)) {
+    filesScanned++;
+    let text;
+    try {
+      text = readFileSync(file, 'utf8');
+    } catch (err) {
+      log(`  skipped unreadable file ${file}: ${err.message}`);
+      continue;
+    }
+    if (text.includes('new Float32Array(') && text.includes('charCodeAt(')) {
+      hits.push(relative(consumerDir, file));
+    }
+  }
+
+  if (hits.length > 0) {
+    const preview = hits.slice(0, 5).join(' | ');
+    const suffix = hits.length > 5 ? ` (+${hits.length - 5} more)` : '';
+    record(
+      'no-inline-hash-embeddings:swarm',
+      'fail',
+      `inline hash-embedding pattern leaked into swarm dist — ${hits.length} file(s): ${preview}${suffix}`,
+    );
+    return;
+  }
+  record(
+    'no-inline-hash-embeddings:swarm',
+    'pass',
+    `${filesScanned} swarm JS file(s) scanned, no inline hash pattern`,
+  );
+}
+
+/**
  * Epic #527 story #532: scans the installed moflo dist tree for any banned
  * hash-embedding identifier. The ESLint guard catches these in source; this
  * check catches them in compiled output — e.g. a bundled copy, a transform

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -11,8 +11,11 @@
  * `agentdb`, `agentic-flow`, `@ruvector/*`, `ruvector`, `@xenova/transformers`,
  * and any hash-embedding identifiers (HashEmbeddingProvider, createHashEmbedding,
  * generateHashEmbedding, RvfEmbeddingService, RvfEmbeddingCache,
- * `domain-aware-hash-*`). Asserts required deps present (`fastembed`) and
- * that postinstall pruned onnxruntime-node to the current platform+arch.
+ * `domain-aware-hash-*`). Also applies a structural guard over the swarm
+ * dist: any file containing both `new Float32Array(` and `charCodeAt(` is
+ * rejected regardless of method name. Asserts required deps present
+ * (`fastembed`) and that postinstall pruned onnxruntime-node to the current
+ * platform+arch.
  *
  * Usage:
  *   node harness/consumer-smoke/run.mjs                # full run
@@ -69,6 +72,7 @@ function main() {
       () => check.verifyForbiddenDeps(consumerDir),
       () => check.verifyRequiredDeps(consumerDir),
       () => check.verifyNoBannedEmbeddings(consumerDir),
+      () => check.verifyNoInlineHashEmbeddingsInSwarm(consumerDir),
       () => check.cliLoads(consumerDir),
       () => check.doctor(consumerDir),
       () => check.memoryInit(consumerDir),

--- a/src/modules/swarm/__tests__/attention-coordinator.test.ts
+++ b/src/modules/swarm/__tests__/attention-coordinator.test.ts
@@ -1,0 +1,117 @@
+/**
+ * AttentionCoordinator tests — issue #542.
+ *
+ * The prior implementation created hash-based embeddings inline. After #542
+ * the coordinator takes an injected IEmbeddingProvider; these tests verify
+ * the provider is actually called and that pairwise attention methods work
+ * end-to-end with a deterministic mock.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  AttentionCoordinator,
+  createAttentionCoordinator,
+  type AgentOutput,
+  type IEmbeddingProvider,
+} from '../src/attention-coordinator.js';
+
+/**
+ * Deterministic mock provider. Every call returns the same fixed zero-filled
+ * 64-dim vector; cosine similarity is then 0/0 → handled by the epsilon in
+ * computeAttentionScore. Identity doesn't matter for these tests — we only
+ * care that the provider is invoked and the coordinator completes.
+ */
+function createMockEmbeddingProvider(): IEmbeddingProvider {
+  const vec = () => {
+    const v = new Float32Array(64);
+    v[0] = 1; // non-zero so cosine similarity is stable
+    return v;
+  };
+  return {
+    embed: vi.fn().mockImplementation(async () => vec()),
+    batchEmbed: vi.fn().mockImplementation(async (texts: string[]) =>
+      texts.map(() => vec())
+    ),
+  };
+}
+
+function createOutput(id: string, content: string): AgentOutput {
+  return { agentId: id, content, confidence: 0.8 };
+}
+
+describe('AttentionCoordinator (issue #542)', () => {
+  it('throws when constructed without an embedding provider', () => {
+    expect(() => new AttentionCoordinator(undefined as never)).toThrow(
+      /IEmbeddingProvider/
+    );
+  });
+
+  it('createAttentionCoordinator wires the provider through', () => {
+    const provider = createMockEmbeddingProvider();
+    const coord = createAttentionCoordinator(provider);
+    expect(coord).toBeInstanceOf(AttentionCoordinator);
+  });
+
+  it('batch-embeds agent outputs on a flash coordination pass', async () => {
+    const provider = createMockEmbeddingProvider();
+    const coord = createAttentionCoordinator(provider);
+    const outputs = [
+      createOutput('a1', 'task one'),
+      createOutput('a2', 'task two'),
+      createOutput('a3', 'task three'),
+    ];
+
+    const result = await coord.coordinateAgents(outputs, 'flash');
+
+    expect(result.success).toBe(true);
+    expect(provider.batchEmbed).toHaveBeenCalledTimes(1);
+    expect(provider.batchEmbed).toHaveBeenCalledWith([
+      'task one',
+      'task two',
+      'task three',
+    ]);
+    // The coordinator caches the returned embeddings on each output.
+    for (const o of outputs) {
+      expect(o.embedding).toBeInstanceOf(Float32Array);
+    }
+  });
+
+  it('skips the provider call when every output already carries an embedding', async () => {
+    const provider = createMockEmbeddingProvider();
+    const coord = createAttentionCoordinator(provider);
+    const preEmbedded = [
+      { ...createOutput('a1', 'x'), embedding: new Float32Array([1, 0]) },
+      { ...createOutput('a2', 'y'), embedding: new Float32Array([0, 1]) },
+    ];
+
+    await coord.coordinateAgents(preEmbedded, 'flash');
+
+    expect(provider.batchEmbed).not.toHaveBeenCalled();
+  });
+
+  it('embeds only the subset of outputs that are missing embeddings', async () => {
+    const provider = createMockEmbeddingProvider();
+    const coord = createAttentionCoordinator(provider);
+    const outputs: AgentOutput[] = [
+      { ...createOutput('a1', 'cached'), embedding: new Float32Array([1, 0]) },
+      createOutput('a2', 'needs-embed'),
+    ];
+
+    await coord.coordinateAgents(outputs, 'flash');
+
+    expect(provider.batchEmbed).toHaveBeenCalledTimes(1);
+    expect(provider.batchEmbed).toHaveBeenCalledWith(['needs-embed']);
+  });
+
+  it('hyperbolic coordination triggers the batch embed', async () => {
+    const provider = createMockEmbeddingProvider();
+    const coord = createAttentionCoordinator(provider);
+    const outputs = [createOutput('a1', 'x'), createOutput('a2', 'y')];
+
+    const result = await coord.coordinateAgents(outputs, 'hyperbolic');
+
+    expect(result.success).toBe(true);
+    expect(provider.batchEmbed).toHaveBeenCalled();
+  });
+});

--- a/src/modules/swarm/__tests__/queen-coordinator.test.ts
+++ b/src/modules/swarm/__tests__/queen-coordinator.test.ts
@@ -22,6 +22,7 @@ import {
   type ISwarmCoordinator,
   type INeuralLearningSystem,
   type IMemoryService,
+  type IEmbeddingProvider,
   type TaskAnalysis,
   type DelegationPlan,
   type HealthReport,
@@ -81,6 +82,21 @@ function createMockMemoryService(): IMemoryService {
   return {
     semanticSearch: vi.fn().mockResolvedValue([]),
     store: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * Deterministic embedding provider — issue #542. Produces a stable zero-filled
+ * 768-dim vector so test outputs don't depend on any neural runtime. The queen
+ * only passes these embeddings to the mock neural system (which ignores them),
+ * so identity doesn't matter for these tests — only that the call is awaited.
+ */
+function createMockEmbeddingProvider(): IEmbeddingProvider {
+  return {
+    embed: vi.fn().mockImplementation(async () => new Float32Array(768)),
+    batchEmbed: vi.fn().mockImplementation(async (texts: string[]) =>
+      texts.map(() => new Float32Array(768))
+    ),
   };
 }
 
@@ -277,12 +293,14 @@ describe('QueenCoordinator', () => {
   let mockSwarm: ISwarmCoordinator;
   let mockNeural: INeuralLearningSystem;
   let mockMemory: IMemoryService;
+  let mockEmbedding: IEmbeddingProvider;
 
   beforeEach(() => {
     vi.useFakeTimers();
     mockSwarm = createMockSwarmCoordinator();
     mockNeural = createMockNeuralSystem();
     mockMemory = createMockMemoryService();
+    mockEmbedding = createMockEmbeddingProvider();
   });
 
   afterEach(async () => {
@@ -311,14 +329,14 @@ describe('QueenCoordinator', () => {
         healthCheckIntervalMs: 5000,
       };
 
-      queen = createQueenCoordinator(mockSwarm, config, mockNeural, mockMemory);
+      queen = createQueenCoordinator(mockSwarm, config, mockNeural, mockMemory, mockEmbedding);
 
       expect(queen).toBeInstanceOf(QueenCoordinator);
       expect(queen.isLearningEnabled()).toBe(true);
     });
 
     it('should initialize neural system when learning is enabled', async () => {
-      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural);
+      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, undefined, mockEmbedding);
 
       await queen.initialize();
 
@@ -351,7 +369,7 @@ describe('QueenCoordinator', () => {
     });
 
     it('should trigger learning on shutdown when enabled', async () => {
-      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural);
+      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, undefined, mockEmbedding);
       await queen.initialize();
 
       await queen.shutdown();
@@ -381,7 +399,7 @@ describe('QueenCoordinator', () => {
 
   describe('Strategic Task Analysis', () => {
     beforeEach(async () => {
-      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural);
+      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, undefined, mockEmbedding);
       await queen.initialize();
     });
 
@@ -450,7 +468,7 @@ describe('QueenCoordinator', () => {
 
     it('should filter patterns below threshold', async () => {
       const config = { enableLearning: true, patternThreshold: 0.7 };
-      queen = createQueenCoordinator(mockSwarm, config, mockNeural);
+      queen = createQueenCoordinator(mockSwarm, config, mockNeural, undefined, mockEmbedding);
       await queen.initialize();
 
       vi.mocked(mockNeural.findPatterns).mockResolvedValue([
@@ -1002,7 +1020,7 @@ describe('QueenCoordinator', () => {
 
   describe('Learning from Outcomes', () => {
     beforeEach(async () => {
-      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, mockMemory);
+      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, mockMemory, mockEmbedding);
       await queen.initialize();
     });
 
@@ -1202,7 +1220,7 @@ describe('QueenCoordinator', () => {
 
     it('should work with NeuralLearningSystem interface', async () => {
       const neural = createMockNeuralSystem();
-      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, neural);
+      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, neural, undefined, mockEmbedding);
       await queen.initialize();
 
       expect(neural.initialize).toHaveBeenCalled();
@@ -1210,7 +1228,7 @@ describe('QueenCoordinator', () => {
 
     it('should work with UnifiedMemoryService interface', async () => {
       const memory = createMockMemoryService();
-      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, memory);
+      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, memory, mockEmbedding);
       await queen.initialize();
 
       const task = createMockTask('task_1', 'coding');
@@ -1237,7 +1255,7 @@ describe('QueenCoordinator', () => {
       queen = createQueenCoordinator(mockSwarm, { enableLearning: false });
       expect(queen.isLearningEnabled()).toBe(false);
 
-      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural);
+      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, undefined, mockEmbedding);
       expect(queen.isLearningEnabled()).toBe(true);
     });
   });
@@ -1275,7 +1293,7 @@ describe('QueenCoordinator', () => {
     });
 
     it('should handle neural system errors gracefully', async () => {
-      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural);
+      queen = createQueenCoordinator(mockSwarm, { enableLearning: true }, mockNeural, undefined, mockEmbedding);
       await queen.initialize();
 
       vi.mocked(mockNeural.findPatterns).mockRejectedValue(new Error('Neural error'));

--- a/src/modules/swarm/src/attention-coordinator.ts
+++ b/src/modules/swarm/src/attention-coordinator.ts
@@ -24,6 +24,19 @@ import { EventEmitter } from 'events';
 // =============================================================================
 
 /**
+ * Injectable neural embedding provider.
+ *
+ * Mirrors the shape of the same-named interface in `@moflo/guidance`; kept
+ * local so `@moflo/swarm` doesn't take a dependency on guidance. Production
+ * wires a fastembed-backed service from `@moflo/embeddings`; tests inject a
+ * deterministic mock. Hash fallbacks are banned (epic #527).
+ */
+export interface IEmbeddingProvider {
+  embed(text: string): Promise<Float32Array>;
+  batchEmbed(texts: string[]): Promise<Float32Array[]>;
+}
+
+/**
  * Attention mechanism types
  */
 export type AttentionType =
@@ -179,6 +192,7 @@ const DEFAULT_CONFIG: AttentionCoordinatorConfig = {
  */
 export class AttentionCoordinator extends EventEmitter {
   private config: AttentionCoordinatorConfig;
+  private embeddingProvider: IEmbeddingProvider;
   private performanceStats = {
     totalCoordinations: 0,
     totalLatency: 0,
@@ -186,8 +200,19 @@ export class AttentionCoordinator extends EventEmitter {
     memoryReduction: 0,
   };
 
-  constructor(config: Partial<AttentionCoordinatorConfig> = {}) {
+  constructor(
+    embeddingProvider: IEmbeddingProvider,
+    config: Partial<AttentionCoordinatorConfig> = {}
+  ) {
     super();
+    if (!embeddingProvider) {
+      throw new Error(
+        'AttentionCoordinator requires an IEmbeddingProvider. Pass a ' +
+          'fastembed-backed provider from @moflo/embeddings in production ' +
+          'and a deterministic mock in tests.'
+      );
+    }
+    this.embeddingProvider = embeddingProvider;
     this.config = { ...DEFAULT_CONFIG, ...config };
   }
 
@@ -379,6 +404,8 @@ export class AttentionCoordinator extends EventEmitter {
   private async flashAttentionCoordination(
     agentOutputs: AgentOutput[]
   ): Promise<CoordinationResult> {
+    await this.ensureEmbeddings(agentOutputs);
+
     const n = agentOutputs.length;
     const blockSize = this.config.flashAttention.blockSize;
 
@@ -431,6 +458,8 @@ export class AttentionCoordinator extends EventEmitter {
   private async multiHeadAttentionCoordination(
     agentOutputs: AgentOutput[]
   ): Promise<CoordinationResult> {
+    await this.ensureEmbeddings(agentOutputs);
+
     const n = agentOutputs.length;
     const numHeads = 8;
     const headDim = 64;
@@ -526,6 +555,8 @@ export class AttentionCoordinator extends EventEmitter {
     curvature: number = this.config.hyperbolic.curvature,
     hierarchicalWeights?: number[]
   ): Promise<CoordinationResult> {
+    await this.ensureEmbeddings(agentOutputs);
+
     const n = agentOutputs.length;
     const c = Math.abs(curvature);
 
@@ -548,9 +579,8 @@ export class AttentionCoordinator extends EventEmitter {
       let totalWeight = 0;
 
       for (let j = 0; j < n; j++) {
-        // Use embeddings or create synthetic vectors
-        const embI = this.getOrCreateEmbedding(agentOutputs[i]);
-        const embJ = this.getOrCreateEmbedding(agentOutputs[j]);
+        const embI = this.requireEmbedding(agentOutputs[i]);
+        const embJ = this.requireEmbedding(agentOutputs[j]);
 
         const distance = hyperbolicDistance(
           Array.from(embI),
@@ -678,6 +708,8 @@ export class AttentionCoordinator extends EventEmitter {
     agentOutputs: AgentOutput[],
     positionEncodings: Map<string, number[]>
   ): Promise<CoordinationResult> {
+    await this.ensureEmbeddings(agentOutputs);
+
     const n = agentOutputs.length;
     const attentionWeights = new Array(n).fill(0);
 
@@ -728,8 +760,8 @@ export class AttentionCoordinator extends EventEmitter {
     head?: number
   ): number {
     // Compute similarity-based attention score
-    const emb1 = this.getOrCreateEmbedding(output1);
-    const emb2 = this.getOrCreateEmbedding(output2);
+    const emb1 = this.requireEmbedding(output1);
+    const emb2 = this.requireEmbedding(output2);
 
     // Cosine similarity
     let dot = 0;
@@ -752,35 +784,49 @@ export class AttentionCoordinator extends EventEmitter {
     return similarity * (conf1 + conf2) / 2;
   }
 
-  private getOrCreateEmbedding(output: AgentOutput): Float32Array {
-    if (output.embedding) {
-      return output.embedding instanceof Float32Array
-        ? output.embedding
-        : new Float32Array(output.embedding);
+  /**
+   * Batch-embed any outputs missing a cached embedding and write results back
+   * onto `output.embedding`. Call once per coordination pass before invoking
+   * any of the pairwise similarity methods.
+   *
+   * Centralizing the embed call keeps attention math sync and collapses O(n²)
+   * pairwise similarity into a single O(n) provider batch.
+   */
+  private async ensureEmbeddings(outputs: AgentOutput[]): Promise<void> {
+    const missing: AgentOutput[] = [];
+    const texts: string[] = [];
+    for (const output of outputs) {
+      if (output.embedding) continue;
+      missing.push(output);
+      texts.push(
+        typeof output.content === 'string'
+          ? output.content
+          : JSON.stringify(output.content)
+      );
     }
+    if (missing.length === 0) return;
 
-    // Create hash-based embedding from content
-    const content = typeof output.content === 'string'
-      ? output.content
-      : JSON.stringify(output.content);
-
-    const dim = 64;
-    const embedding = new Float32Array(dim);
-
-    for (let i = 0; i < content.length; i++) {
-      const idx = i % dim;
-      embedding[idx] += content.charCodeAt(i) / 1000;
+    const embeddings = await this.embeddingProvider.batchEmbed(texts);
+    for (let i = 0; i < missing.length; i++) {
+      missing[i].embedding = embeddings[i];
     }
+  }
 
-    // Normalize
-    const norm = Math.sqrt(embedding.reduce((s, v) => s + v * v, 0));
-    if (norm > 0) {
-      for (let i = 0; i < dim; i++) {
-        embedding[i] /= norm;
-      }
+  /**
+   * Sync lookup for a cached embedding. Callers MUST invoke
+   * {@link ensureEmbeddings} first — otherwise this throws. Kept sync so
+   * pairwise similarity loops stay tight and allocation-free.
+   */
+  private requireEmbedding(output: AgentOutput): Float32Array {
+    if (!output.embedding) {
+      throw new Error(
+        `AttentionCoordinator: missing embedding for agent '${output.agentId}'. ` +
+          'Call ensureEmbeddings(outputs) before pairwise similarity.'
+      );
     }
-
-    return embedding;
+    return output.embedding instanceof Float32Array
+      ? output.embedding
+      : new Float32Array(output.embedding);
   }
 
   private computeWeightedConsensus(
@@ -835,11 +881,15 @@ export class AttentionCoordinator extends EventEmitter {
     agents: SpecializedAgent[]
   ): Promise<Map<string, number>> {
     const scores = new Map<string, number>();
-    const taskEmbedding = this.getOrCreateEmbedding({
-      agentId: 'task',
-      content: task.content,
-      embedding: task.embedding,
-    });
+
+    let taskEmbedding: Float32Array;
+    if (task.embedding) {
+      taskEmbedding = task.embedding instanceof Float32Array
+        ? task.embedding
+        : new Float32Array(task.embedding);
+    } else {
+      taskEmbedding = await this.embeddingProvider.embed(task.content);
+    }
 
     for (const agent of agents) {
       const agentEmbedding = agent.embedding instanceof Float32Array
@@ -992,9 +1042,10 @@ export class AttentionCoordinator extends EventEmitter {
 // =============================================================================
 
 export function createAttentionCoordinator(
+  embeddingProvider: IEmbeddingProvider,
   config?: Partial<AttentionCoordinatorConfig>
 ): AttentionCoordinator {
-  return new AttentionCoordinator(config);
+  return new AttentionCoordinator(embeddingProvider, config);
 }
 
 export default AttentionCoordinator;

--- a/src/modules/swarm/src/index.ts
+++ b/src/modules/swarm/src/index.ts
@@ -293,6 +293,7 @@ export {
   type SpecializedAgent,
   type SwarmTopology,
   type GraphContext,
+  type IEmbeddingProvider,
 } from './attention-coordinator.js';
 
 // =============================================================================

--- a/src/modules/swarm/src/queen-coordinator.ts
+++ b/src/modules/swarm/src/queen-coordinator.ts
@@ -460,6 +460,9 @@ export interface IMemoryService {
   store(entry: MemoryStoreEntry): Promise<void>;
 }
 
+import type { IEmbeddingProvider } from './attention-coordinator.js';
+export type { IEmbeddingProvider };
+
 /**
  * Search result entry from memory service
  */
@@ -502,6 +505,8 @@ export class QueenCoordinator extends EventEmitter {
   private swarm: ISwarmCoordinator;
   private neural?: INeuralLearningSystem;
   private memory?: IMemoryService;
+  private embeddingProvider?: IEmbeddingProvider;
+  private taskEmbeddingCache: WeakMap<TaskDefinition, Float32Array> = new WeakMap();
 
   // Internal state
   private analysisCache: Map<string, TaskAnalysis> = new Map();
@@ -529,13 +534,36 @@ export class QueenCoordinator extends EventEmitter {
     swarm: ISwarmCoordinator,
     config: Partial<QueenCoordinatorConfig> = {},
     neural?: INeuralLearningSystem,
-    memory?: IMemoryService
+    memory?: IMemoryService,
+    embeddingProvider?: IEmbeddingProvider
   ) {
     super();
     this.swarm = swarm;
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.neural = neural;
     this.memory = memory;
+    this.embeddingProvider = embeddingProvider;
+  }
+
+  /**
+   * Memoized embed of a task's description. Both findMatchingPatterns (during
+   * analyzeTask) and learnFromOutcome need the same vector for the same task;
+   * caching skips the second fastembed round-trip per task.
+   */
+  private async embedTaskText(task: TaskDefinition): Promise<Float32Array> {
+    const cached = this.taskEmbeddingCache.get(task);
+    if (cached) return cached;
+    if (!this.embeddingProvider) {
+      throw new Error(
+        'QueenCoordinator: learning is enabled but no IEmbeddingProvider was ' +
+          'injected. Pass one as the 5th arg to createQueenCoordinator.'
+      );
+    }
+    const embedding = await this.embeddingProvider.embed(
+      task.description || task.name
+    );
+    this.taskEmbeddingCache.set(task, embedding);
+    return embedding;
   }
 
   // ===========================================================================
@@ -987,8 +1015,7 @@ export class QueenCoordinator extends EventEmitter {
     }
 
     try {
-      // Create a simple embedding from task description
-      const embedding = this.createSimpleEmbedding(task.description || task.name);
+      const embedding = await this.embedTaskText(task);
 
       // Query ReasoningBank for similar patterns
       const results = await this.neural.findPatterns(embedding, this.config.patternRetrievalK);
@@ -1010,39 +1037,6 @@ export class QueenCoordinator extends EventEmitter {
     }
 
     return patterns;
-  }
-
-  /**
-   * Create a simple embedding from text using hash-based approach.
-   * For higher quality embeddings, integrate agentic-flow's computeEmbedding.
-   */
-  private createSimpleEmbedding(text: string): Float32Array {
-    // Hash-based embedding - lightweight and fast for local similarity matching
-    // For production ML embeddings, use: import('agentic-flow').computeEmbedding
-    const embedding = new Float32Array(768);
-    const words = text.toLowerCase().split(/\s+/);
-
-    for (let i = 0; i < words.length; i++) {
-      const word = words[i];
-      for (let j = 0; j < word.length; j++) {
-        const idx = (word.charCodeAt(j) * (i + 1) * (j + 1)) % 768;
-        embedding[idx] += 1 / words.length;
-      }
-    }
-
-    // Normalize
-    let norm = 0;
-    for (let i = 0; i < embedding.length; i++) {
-      norm += embedding[i] * embedding[i];
-    }
-    norm = Math.sqrt(norm);
-    if (norm > 0) {
-      for (let i = 0; i < embedding.length; i++) {
-        embedding[i] /= norm;
-      }
-    }
-
-    return embedding;
   }
 
   /**
@@ -1872,7 +1866,7 @@ export class QueenCoordinator extends EventEmitter {
     );
 
     // Record the execution step
-    const embedding = this.createSimpleEmbedding(task.description || task.name);
+    const embedding = await this.embedTaskText(task);
     const reward = result.success
       ? result.metrics.qualityScore * 0.8 + 0.2
       : result.metrics.qualityScore * 0.3;
@@ -2017,9 +2011,10 @@ export function createQueenCoordinator(
   swarm: ISwarmCoordinator,
   config?: Partial<QueenCoordinatorConfig>,
   neural?: INeuralLearningSystem,
-  memory?: IMemoryService
+  memory?: IMemoryService,
+  embeddingProvider?: IEmbeddingProvider
 ): QueenCoordinator {
-  return new QueenCoordinator(swarm, config, neural, memory);
+  return new QueenCoordinator(swarm, config, neural, memory, embeddingProvider);
 }
 
 export default QueenCoordinator;


### PR DESCRIPTION
## Summary

- Deletes `getOrCreateEmbedding` (attention-coordinator) and `createSimpleEmbedding` (queen-coordinator) — the last two inline hash-embedding implementations that slipped past epic #527 because their enclosing methods used generic names.
- Replaces both with an injected `IEmbeddingProvider` (required in attention, required-when-learning in queen), matching the existing `@moflo/guidance` `ShardRetriever` pattern.
- Tightens the regression guard so this class of pattern can't be reintroduced under another innocuous name.

## Changes

- **src/modules/swarm/src/attention-coordinator.ts** — added `IEmbeddingProvider` interface; constructor takes the provider as a required arg; `ensureEmbeddings(outputs)` batch-embeds once per coordination pass, caching on `output.embedding`; pairwise similarity (flash, multi-head, hyperbolic, graph-rope) uses sync `requireEmbedding` lookup. Factory signature now `createAttentionCoordinator(provider, config?)`.
- **src/modules/swarm/src/queen-coordinator.ts** — constructor takes optional `embeddingProvider` as 5th arg (required at call-sites when learning is active). `embedTaskText(task)` memoizes via `WeakMap<TaskDefinition, Float32Array>` so `findMatchingPatterns` and `learnFromOutcome` don't re-embed the same task.description. Re-exports the shared `IEmbeddingProvider` type.
- **.eslintrc.cjs** — new structural rule scoped to `src/modules/swarm/src/**/*.ts` using `no-restricted-syntax` with `:has()` selectors to flag any function that both constructs a `Float32Array` and calls `charCodeAt` (catches the anti-pattern regardless of method name).
- **harness/consumer-smoke/lib/checks.mjs** — new `verifyNoInlineHashEmbeddingsInSwarm` walks the compiled swarm dist and rejects any file containing both `new Float32Array(` and `charCodeAt(`. Defends compiled output; wired into `run.mjs`.
- **src/modules/swarm/__tests__/attention-coordinator.test.ts** — new tests verifying injection, batch-embed collapsing, skip-when-cached, hyperbolic path.
- **src/modules/swarm/__tests__/queen-coordinator.test.ts** — every learning-enabled test now injects a deterministic `mockEmbeddingProvider`.

## Acceptance (from #542)

- [x] `getOrCreateEmbedding` and `createSimpleEmbedding` deleted from `src/modules/swarm/`.
- [x] Both coordinators call an injected fastembed-backed provider.
- [x] Coordinator tests inject a deterministic test provider.
- [x] `git grep -nE "charCodeAt.*Float32Array|Float32Array.*charCodeAt" src/modules/swarm/` returns zero matches.
- [x] Regression guard updated — ESLint rejects the same structural pattern under any new name (verified with a sanity probe).
- [x] Full repo test suite passes (7813 tests).

## Test plan

- [x] `npm test` — 7813 passed
- [x] `npm run build` — clean
- [x] `npx eslint src/modules/swarm/src/` — clean
- [x] ESLint sanity probe — a freshly-introduced `new Float32Array + charCodeAt` in swarm src trips the guard with the expected message
- [ ] Consumer smoke harness (manual — runs in CI)

Closes #542

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)