### PR TITLE
refactor(embeddings): remove live hashEmbed call-sites from memory + learning-service

### DIFF
--- a/src/modules/cli/src/services/index.ts
+++ b/src/modules/cli/src/services/index.ts
@@ -54,7 +54,6 @@ export {
   LearningService,
   getLearningService,
   HNSWIndex,
-  hashEmbed,
   cosineSimilarity,
   LEARNING_CONFIG,
   type PatternSearchResult,

--- a/src/modules/cli/src/services/learning-service.ts
+++ b/src/modules/cli/src/services/learning-service.ts
@@ -16,6 +16,10 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { mofloImport } from './moflo-require.js';
+import {
+  createNeuralEmbeddingProvider,
+  type NeuralEmbeddingProvider,
+} from './neural-embedding-provider.js';
 
 // ============================================================================
 // Configuration
@@ -334,36 +338,7 @@ function dbRun(db: SqlJsDatabase, sql: string, params: unknown[] = []): { change
   return { changes: db.getRowsModified() as number };
 }
 
-// ============================================================================
-// Embedding (deterministic hash-based fallback)
-// ============================================================================
-
-function hashEmbed(text: string): Float32Array {
-  const embedding = new Float32Array(CONFIG.embedding.dimension);
-  const normalized = text.toLowerCase().trim();
-
-  for (let i = 0; i < embedding.length; i++) {
-    let hash = 0;
-    for (let j = 0; j < normalized.length; j++) {
-      hash = ((hash << 5) - hash + normalized.charCodeAt(j) * (i + 1)) | 0;
-    }
-    embedding[i] = (Math.sin(hash) + 1) / 2;
-  }
-
-  // L2 normalize
-  let norm = 0;
-  for (let i = 0; i < embedding.length; i++) {
-    norm += embedding[i] * embedding[i];
-  }
-  norm = Math.sqrt(norm);
-  if (norm > 0) {
-    for (let i = 0; i < embedding.length; i++) {
-      embedding[i] /= norm;
-    }
-  }
-
-  return embedding;
-}
+// Neural-only per ADR-EMB-001; see createNeuralEmbeddingProvider for lazy-load.
 
 function cosineSimilarity(a: Float32Array, b: Float32Array): number {
   let dot = 0, normA = 0, normB = 0;
@@ -387,11 +362,18 @@ export class LearningService {
   private dirty = false;
   private dbPath: string;
   private dataDir: string;
+  private embedderPromise: Promise<NeuralEmbeddingProvider> | null = null;
 
-  constructor(projectRoot?: string) {
+  constructor(projectRoot?: string, embedder?: NeuralEmbeddingProvider) {
     const root = projectRoot || process.cwd();
     this.dataDir = join(root, '.swarm');
     this.dbPath = join(this.dataDir, 'memory.db');
+    if (embedder) this.embedderPromise = Promise.resolve(embedder);
+  }
+
+  private getEmbedder(): Promise<NeuralEmbeddingProvider> {
+    this.embedderPromise ??= createNeuralEmbeddingProvider();
+    return this.embedderPromise;
   }
 
   /**
@@ -427,7 +409,8 @@ export class LearningService {
       quality = CONFIG.patterns.qualityThreshold;
     }
 
-    const embedding = hashEmbed(pattern);
+    const embedder = await this.getEmbedder();
+    const embedding = await embedder.embed(pattern);
 
     // Check for duplicates via HNSW
     const { results } = this.shortTermIndex.search(embedding, 1);
@@ -477,7 +460,8 @@ export class LearningService {
   async searchPatterns(query: string, k = 5): Promise<PatternSearchResult[]> {
     this.requireDb();
 
-    const embedding = hashEmbed(query);
+    const embedder = await this.getEmbedder();
+    const embedding = await embedder.embed(query);
     const results: (SearchResult & { type: string })[] = [];
 
     // Search long-term first (higher quality)
@@ -835,5 +819,5 @@ export function getLearningService(projectRoot?: string): LearningService {
   return _instance;
 }
 
-export { CONFIG as LEARNING_CONFIG, HNSWIndex, hashEmbed, cosineSimilarity };
+export { CONFIG as LEARNING_CONFIG, HNSWIndex, cosineSimilarity };
 export type { PatternSearchResult, StoreResult, ConsolidateResult, LearningStats, PatternRow };

--- a/src/modules/memory/src/controllers/_shared.test.ts
+++ b/src/modules/memory/src/controllers/_shared.test.ts
@@ -2,45 +2,26 @@ import { describe, it, expect } from 'vitest';
 import {
   cosine,
   deserializeEmbedding,
-  embedWithFallback,
-  hashEmbed,
+  embedText,
   rankByVector,
   serializeEmbedding,
 } from './_shared.js';
+import { deterministicTestEmbedder } from './_test-embedder.js';
 
 describe('_shared vector helpers', () => {
-  it('hashEmbed produces a unit-normalized vector', () => {
-    const v = hashEmbed('hello world', 64);
-    expect(v.length).toBe(64);
-    let mag = 0;
-    for (let i = 0; i < v.length; i++) mag += v[i] * v[i];
-    expect(Math.sqrt(mag)).toBeCloseTo(1, 4);
-  });
-
-  it('hashEmbed returns zero vector for empty input', () => {
-    const v = hashEmbed('', 16);
-    expect(v.every((x) => x === 0)).toBe(true);
-  });
-
-  it('hashEmbed is deterministic', () => {
-    const a = hashEmbed('stable tokens', 32);
-    const b = hashEmbed('stable tokens', 32);
-    expect(Array.from(a)).toEqual(Array.from(b));
-  });
-
   it('cosine of identical vectors is 1', () => {
-    const v = hashEmbed('abc', 16);
+    const v = Float32Array.from([0.3, 0.4, 0.5]);
     expect(cosine(v, v)).toBeCloseTo(1, 6);
   });
 
   it('cosine of zero vector is 0', () => {
-    const zero = new Float32Array(8);
-    const v = hashEmbed('abc', 8);
+    const zero = new Float32Array(4);
+    const v = Float32Array.from([1, 0, 0, 0]);
     expect(cosine(zero, v)).toBe(0);
   });
 
   it('serialize/deserialize round-trips embeddings', () => {
-    const v = hashEmbed('payload', 32);
+    const v = Float32Array.from([0.1, -0.2, 0.3, -0.4, 0.5, -0.6, 0.7, -0.8]);
     const blob = serializeEmbedding(v);
     expect(blob).toBeInstanceOf(Uint8Array);
     const restored = deserializeEmbedding(blob);
@@ -50,22 +31,28 @@ describe('_shared vector helpers', () => {
 
   it('deserialize rejects malformed blobs', () => {
     expect(deserializeEmbedding(null)).toBeNull();
-    expect(deserializeEmbedding('not a blob' as any)).toBeNull();
+    expect(deserializeEmbedding('not a blob' as unknown)).toBeNull();
     expect(deserializeEmbedding(new Uint8Array(3))).toBeNull(); // not mult of 4
   });
 
-  it('embedWithFallback uses embedder when provided, else hashEmbed', async () => {
-    const custom = async () => Float32Array.from([1, 0, 0, 0]);
-    const a = await embedWithFallback(custom, 'ignored', 4);
-    expect(Array.from(a)).toEqual([1, 0, 0, 0]);
-    const b = await embedWithFallback(undefined, 'anything', 4);
-    expect(b.length).toBe(4);
+  it('embedText uses the supplied embedder', async () => {
+    const v = await embedText(deterministicTestEmbedder, 'alpha beta');
+    expect(v).toBeInstanceOf(Float32Array);
+    expect(v.length).toBe(384);
+    // Token-bag: two unique tokens light up exactly two slots.
+    const ones = Array.from(v).filter((x) => x === 1).length;
+    expect(ones).toBe(2);
   });
 
-  it('embedWithFallback falls back when embedder throws', async () => {
-    const bad = async () => { throw new Error('no embedder'); };
-    const v = await embedWithFallback(bad, 'fallback', 8);
-    expect(v.length).toBe(8);
+  it('embedText throws when no embedder is configured', async () => {
+    await expect(embedText(undefined, 'anything')).rejects.toThrow(/ADR-EMB-001/);
+  });
+
+  it('embedText propagates embedder failures (no silent fallback)', async () => {
+    const boom = async () => {
+      throw new Error('fastembed model missing');
+    };
+    await expect(embedText(boom, 'x')).rejects.toThrow(/fastembed model missing/);
   });
 
   it('rankByVector sorts by cosine and honours k', () => {

--- a/src/modules/memory/src/controllers/_shared.ts
+++ b/src/modules/memory/src/controllers/_shared.ts
@@ -5,12 +5,11 @@
  * hierarchical-memory don't each reinvent cosine and BLOB serialization.
  */
 
-import { createHash, randomBytes } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 
 /**
- * Embedder signature matches the one @moflo/memory already uses
- * (`EmbeddingGenerator`). Accept both Float32Array and number[] for
- * compatibility with agentdb's embed() shape.
+ * Matches `EmbeddingGenerator` in controller-spec; accepts number[] so
+ * fastembed's raw return shape doesn't need coercing at every call site.
  */
 export type Embedder = (text: string) => Promise<Float32Array | number[]>;
 
@@ -57,46 +56,26 @@ export function cosine(a: Float32Array, b: Float32Array): number {
 }
 
 /**
- * Deterministic hash-based embedding. Produces a unit-normalized vector
- * so controllers can function when no real embedder is configured. Good
- * enough for tests and for token-overlap-style recall; swap in a real
- * embedder (Xenova/all-MiniLM-L6-v2) for semantic quality.
+ * Embed `text` with the supplied neural embedder.
+ *
+ * Throws if no embedder is configured or if the embedder itself fails.
+ * ADR-EMB-001 makes neural embeddings a hard requirement — silent
+ * degradation to hash-quality vectors is a correctness hazard, so this
+ * never falls back. Wire a fastembed-backed provider through the
+ * controller registry's `embeddingGenerator` config.
  */
-export function hashEmbed(text: string, dimension = 384): Float32Array {
-  const out = new Float32Array(dimension);
-  const tokens = String(text).toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
-  if (tokens.length === 0) return out;
-  for (const tok of tokens) {
-    const digest = createHash('sha256').update(tok).digest();
-    // Spread each token across `dimension` slots by walking the digest.
-    for (let i = 0; i < dimension; i++) {
-      const byte = digest[i % digest.length];
-      out[i] += ((byte / 255) * 2) - 1;
-    }
-  }
-  let mag = 0;
-  for (let i = 0; i < dimension; i++) mag += out[i] * out[i];
-  mag = Math.sqrt(mag);
-  if (mag > 0) {
-    for (let i = 0; i < dimension; i++) out[i] /= mag;
-  }
-  return out;
-}
-
-export async function embedWithFallback(
+export async function embedText(
   embedder: Embedder | undefined,
   text: string,
-  dimension = 384,
 ): Promise<Float32Array> {
-  if (embedder) {
-    try {
-      const vec = await embedder(text);
-      return toFloat32(vec);
-    } catch {
-      // Fall through to the deterministic fallback.
-    }
+  if (!embedder) {
+    throw new Error(
+      '[@moflo/memory] No embedder configured. ADR-EMB-001 requires a ' +
+        'fastembed-backed IEmbeddingProvider — hash fallbacks are banned. ' +
+        "Supply one via RuntimeConfig.embeddingGenerator.",
+    );
   }
-  return hashEmbed(text, dimension);
+  return toFloat32(await embedder(text));
 }
 
 /**
@@ -170,12 +149,11 @@ export async function vectorSearchRows<T extends { embedding: Float32Array | nul
   queryText: string,
   k: number,
   embedder: Embedder | undefined,
-  dimension: number,
   getContent: (row: T) => string,
 ): Promise<Array<T & { score: number }>> {
   const safeK = clampInt(k, 1, 1000, 10);
   if (rows.length === 0) return [];
-  const queryVec = await embedWithFallback(embedder, queryText, dimension);
+  const queryVec = await embedText(embedder, queryText);
   const withContent = rows.map((r) => ({ ...r, content: getContent(r) }));
   const ranked = rankByVector(withContent, queryVec, queryText, safeK);
   return ranked.map(({ content: _content, ...rest }) => rest as unknown as T & { score: number });

--- a/src/modules/memory/src/controllers/_test-embedder.ts
+++ b/src/modules/memory/src/controllers/_test-embedder.ts
@@ -1,0 +1,28 @@
+/**
+ * Deterministic 384-dim token-bag embedder for controller tests.
+ *
+ * ADR-EMB-001 forbids production hash fallbacks, so tests inject their
+ * own provider. This one is stateless: the token→slot map is a pure
+ * function, so there's no cross-file state leak and no cap on unique
+ * token counts (collisions are accepted above DIM — benchmarks with
+ * 1000+ fixtures rely on this).
+ */
+
+const DIM = 384;
+
+function slotOf(token: string): number {
+  let h = 0;
+  for (let i = 0; i < token.length; i++) {
+    h = ((h << 5) - h + token.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % DIM;
+}
+
+export async function deterministicTestEmbedder(text: string): Promise<Float32Array> {
+  const out = new Float32Array(DIM);
+  const tokens = String(text).toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  for (const tok of tokens) {
+    out[slotOf(tok)] = 1;
+  }
+  return out;
+}

--- a/src/modules/memory/src/controllers/hierarchical-memory.test.ts
+++ b/src/modules/memory/src/controllers/hierarchical-memory.test.ts
@@ -6,6 +6,7 @@ import {
   HIERARCHICAL_MEMORY_SURFACE,
   hierarchicalMemorySpec,
 } from './hierarchical-memory.js';
+import { deterministicTestEmbedder } from './_test-embedder.js';
 
 let SQL: any;
 
@@ -19,7 +20,7 @@ describe('HierarchicalMemory', () => {
 
   beforeEach(() => {
     db = new SQL.Database();
-    hm = new HierarchicalMemory(db as any);
+    hm = new HierarchicalMemory(db as any, { embedder: deterministicTestEmbedder });
   });
 
   it('rejects null db', () => {
@@ -101,6 +102,7 @@ describe('HierarchicalMemory', () => {
 
   it('enforces per-tier capacity', async () => {
     const small = new HierarchicalMemory(new SQL.Database() as any, {
+      embedder: deterministicTestEmbedder,
       capacities: { working: 3 } as any,
     });
     for (let i = 0; i < 6; i++) {

--- a/src/modules/memory/src/controllers/hierarchical-memory.ts
+++ b/src/modules/memory/src/controllers/hierarchical-memory.ts
@@ -27,7 +27,7 @@ import {
   clamp01,
   clampInt,
   deserializeEmbedding,
-  embedWithFallback,
+  embedText,
   generateId,
   parseJsonSafe,
   rankByVector,
@@ -116,7 +116,7 @@ export class HierarchicalMemory {
     const now = Date.now();
     const keyMeta = typeof options.metadata?.key === 'string' ? (options.metadata.key as string) : undefined;
     const key = options.key ?? keyMeta ?? id;
-    const embedding = await embedWithFallback(this.embedder, String(content ?? ''), this.dimension);
+    const embedding = await embedText(this.embedder, String(content ?? ''));
     const blob = serializeEmbedding(embedding);
     const metaJson = JSON.stringify(options.metadata ?? {});
     const tagsJson = JSON.stringify(options.tags ?? []);
@@ -142,7 +142,7 @@ export class HierarchicalMemory {
     const threshold = typeof query.threshold === 'number' ? query.threshold : 0;
     const rows = this.loadByTier(tier);
     if (rows.length === 0) return [];
-    const queryVec = await embedWithFallback(this.embedder, query.query, this.dimension);
+    const queryVec = await embedText(this.embedder, query.query);
     const ranked = rankByVector(rows, queryVec, query.query, k)
       .filter((r) => r.score >= threshold)
       .slice(0, k);

--- a/src/modules/memory/src/controllers/memory-consolidation.test.ts
+++ b/src/modules/memory/src/controllers/memory-consolidation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import initSqlJs, { Database } from 'sql.js';
 import { HierarchicalMemory } from './hierarchical-memory.js';
 import { MemoryConsolidation } from './memory-consolidation.js';
+import { deterministicTestEmbedder } from './_test-embedder.js';
 
 let SQL: any;
 
@@ -16,7 +17,7 @@ describe('MemoryConsolidation', () => {
 
   beforeEach(() => {
     db = new SQL.Database();
-    hm = new HierarchicalMemory(db as any);
+    hm = new HierarchicalMemory(db as any, { embedder: deterministicTestEmbedder });
     // Zero TTLs so the first consolidate() fires all rules deterministically.
     mc = new MemoryConsolidation(hm, {
       workingTtlMs: 0,

--- a/src/modules/memory/src/controllers/nightly-learner.test.ts
+++ b/src/modules/memory/src/controllers/nightly-learner.test.ts
@@ -5,6 +5,7 @@ import { MemoryConsolidation } from './memory-consolidation.js';
 import { Reflexion } from './reflexion.js';
 import { Skills } from './skills.js';
 import { NightlyLearner } from './nightly-learner.js';
+import { deterministicTestEmbedder } from './_test-embedder.js';
 
 let SQL: any;
 
@@ -22,10 +23,10 @@ describe('NightlyLearner', () => {
 
   beforeEach(() => {
     db = new SQL.Database();
-    hm = new HierarchicalMemory(db as any);
+    hm = new HierarchicalMemory(db as any, { embedder: deterministicTestEmbedder });
     mc = new MemoryConsolidation(hm, { workingTtlMs: 0 });
-    reflexion = new Reflexion(db as any);
-    skills = new Skills(db as any);
+    reflexion = new Reflexion(db as any, { embedder: deterministicTestEmbedder });
+    skills = new Skills(db as any, { embedder: deterministicTestEmbedder });
     nightly = new NightlyLearner({
       memoryConsolidation: mc,
       reflexion,

--- a/src/modules/memory/src/controllers/reflexion.bench.test.ts
+++ b/src/modules/memory/src/controllers/reflexion.bench.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import initSqlJs from 'sql.js';
 import { Reflexion } from './reflexion.js';
+import { deterministicTestEmbedder } from './_test-embedder.js';
 
 let SQL: any;
 
@@ -28,7 +29,7 @@ beforeAll(async () => {
 describe('Reflexion benchmark @ N=1000', () => {
   it('recall@10 ≥ 0.85 and p95 latency < 500ms', async () => {
     const db = new SQL.Database();
-    const reflexion = new Reflexion(db as any);
+    const reflexion = new Reflexion(db as any, { embedder: deterministicTestEmbedder });
 
     const N = 1000;
     const fixtures: Array<{ id: string; action: string; keyword: string }> = [];

--- a/src/modules/memory/src/controllers/reflexion.test.ts
+++ b/src/modules/memory/src/controllers/reflexion.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import initSqlJs, { Database } from 'sql.js';
 import { Reflexion } from './reflexion.js';
+import { deterministicTestEmbedder } from './_test-embedder.js';
 
 let SQL: any;
 
@@ -14,7 +15,7 @@ describe('Reflexion', () => {
 
   beforeEach(() => {
     db = new SQL.Database();
-    reflexion = new Reflexion(db as any);
+    reflexion = new Reflexion(db as any, { embedder: deterministicTestEmbedder });
   });
 
   it('rejects null db', () => {
@@ -22,7 +23,7 @@ describe('Reflexion', () => {
   });
 
   it('creates schema idempotently', () => {
-    const second = new Reflexion(db as any);
+    const second = new Reflexion(db as any, { embedder: deterministicTestEmbedder });
     expect(second.count()).toBe(0);
   });
 

--- a/src/modules/memory/src/controllers/reflexion.ts
+++ b/src/modules/memory/src/controllers/reflexion.ts
@@ -19,7 +19,7 @@
 import {
   clampInt,
   deserializeEmbedding,
-  embedWithFallback,
+  embedText,
   generateId,
   parseJsonSafe,
   serializeEmbedding,
@@ -94,7 +94,7 @@ export class Reflexion {
     const id = generateId('rfx');
     const ts = Date.now();
     const text = `${input.action}\n${input.outcome}\n${input.reflection}`;
-    const embedding = await embedWithFallback(this.embedder, text, this.dimension);
+    const embedding = await embedText(this.embedder, text);
     const blob = serializeEmbedding(embedding);
     this.db.run(
       `INSERT INTO ${REFLEXIONS_TABLE}
@@ -111,7 +111,6 @@ export class Reflexion {
       query,
       k,
       this.embedder,
-      this.dimension,
       (r) => `${r.action} ${r.outcome} ${r.reflection}`,
     );
   }

--- a/src/modules/memory/src/controllers/skills.test.ts
+++ b/src/modules/memory/src/controllers/skills.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import initSqlJs, { Database } from 'sql.js';
 import { Skills } from './skills.js';
+import { deterministicTestEmbedder } from './_test-embedder.js';
 
 let SQL: any;
 
@@ -14,7 +15,7 @@ describe('Skills', () => {
 
   beforeEach(() => {
     db = new SQL.Database();
-    skills = new Skills(db as any);
+    skills = new Skills(db as any, { embedder: deterministicTestEmbedder });
   });
 
   it('rejects null db', () => {

--- a/src/modules/memory/src/controllers/skills.ts
+++ b/src/modules/memory/src/controllers/skills.ts
@@ -20,7 +20,7 @@
 import {
   clampInt,
   deserializeEmbedding,
-  embedWithFallback,
+  embedText,
   generateId,
   parseJsonSafe,
   serializeEmbedding,
@@ -99,7 +99,7 @@ export class Skills {
     const description = String(input.description ?? '');
     const code = String(input.code ?? '');
     const text = `${input.name}\n${description}\n${code}`;
-    const embedding = await embedWithFallback(this.embedder, text, this.dimension);
+    const embedding = await embedText(this.embedder, text);
     const blob = serializeEmbedding(embedding);
     this.db.run(
       `INSERT INTO ${TABLE}
@@ -155,7 +155,6 @@ export class Skills {
       query,
       k,
       this.embedder,
-      this.dimension,
       (r) => `${r.name} ${r.description} ${r.code}`,
     );
   }


### PR DESCRIPTION
## Summary

Closes #544. Deletes the two remaining production hash-embedding paths that survived PR #539's identifier-whitelist guard, per **ADR-EMB-001** (neural embeddings are hard-required).

- `src/modules/memory/src/controllers/_shared.ts`: removed `hashEmbed` and `embedWithFallback` (with its silent `catch {}`). New `embedText(embedder, text)` helper throws when no embedder is configured or when the embedder itself fails — no fallback, no silent degradation. Drops the dead `dimension` parameter from `vectorSearchRows`.
- `src/modules/cli/src/services/learning-service.ts`: removed local `hashEmbed`. `LearningService` now accepts an optional `NeuralEmbeddingProvider` via the constructor and lazy-loads the fastembed-backed provider via the existing `createNeuralEmbeddingProvider()`. `storePattern`/`searchPatterns` both await the neural embedder.
- Public re-exports of `hashEmbed` dropped from `learning-service.ts:838` and `services/index.ts:57`.
- Memory controller tests gained a stateless deterministic `_test-embedder.ts`; `_shared.test.ts` rewritten to cover the new hard-fail contract.

## Acceptance criteria

- [x] `hashEmbed` and `embedWithFallback` deleted from both files
- [x] Call-sites inject an `IEmbeddingProvider` (via fastembed) instead
- [x] Silent `catch {}` removed; embedder failures propagate per ADR-EMB-001
- [x] Public re-export dropped (`learning-service.ts:838`, `services/index.ts:57`)
- [x] No behavioural regression in `storePattern` / `searchPatterns` tests
- [x] `npm run lint` + smoke both pass

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 7811 passed, 0 failed
- [x] `npm run test:smoke` — 29/29 pass; `no-banned-embeddings` scans 595 dist files clean
- [x] `reflexion.bench.test.ts` (1000 fixtures, recall@10 ≥ 0.85, p95 < 500ms) — passes with injected deterministic embedder

## Out of scope (tracked separately per #544 AC)

The companion work to extend the ESLint identifier guard and the smoke-harness banned list to include `hashEmbed`/`embedWithFallback` (so future PRs can't silently reintroduce them by name) is deliberately left out of this PR — the issue explicitly calls it out as a companion issue.

Parent: #527

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)