### PR TITLE
fix(guard): harden hash-fallback regression guard (#545)

### DIFF
--- a/.claude/scripts/build-embeddings.mjs
+++ b/.claude/scripts/build-embeddings.mjs
@@ -1,24 +1,22 @@
 #!/usr/bin/env node
 /**
- * Generate embeddings for all memory entries and build HNSW index
+ * Generate neural embeddings for memory entries and invalidate the HNSW index.
  *
- * Embedding Strategy (in order of preference):
- * 1. Transformers.js with all-MiniLM-L6-v2 (best quality, requires sharp)
- * 2. Domain-aware semantic hash embeddings (fast, good quality, no deps)
+ * Neural embeddings are required — epic #527 removed every hash fallback. If
+ * the fastembed model cannot load (missing download, broken network, etc.)
+ * this script exits non-zero rather than silently degrading to hashed vectors.
  *
- * The domain-aware hash embeddings use:
- * - Domain clustering for semantic grouping (database, frontend, backend, testing, etc.)
- * - SimHash-style word encoding with multiple hash positions
- * - N-gram features (bigrams, trigrams) for phrase detection
- * - L2 normalization for cosine similarity
+ * Model: `fast-all-MiniLM-L6-v2` via the `fastembed` npm package (384 dims,
+ * L2-normalised). Matches the shape and vector space of entries embedded by
+ * `@moflo/embeddings`'s `FastembedEmbeddingService`.
  *
  * Usage:
- *   node node_modules/moflo/bin/build-embeddings.mjs           # Embed entries without embeddings
- *   flo-embeddings --force                               # Re-embed all entries
- *   flo-embeddings --namespace guidance                   # Only specific namespace
+ *   node node_modules/moflo/bin/build-embeddings.mjs          # embed rows with no embedding
+ *   flo-embeddings --force                                    # re-embed every row
+ *   flo-embeddings --namespace guidance                       # scope to one namespace
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
@@ -34,16 +32,16 @@ function findProjectRoot() {
 }
 
 const projectRoot = findProjectRoot();
-
 const DB_PATH = resolve(projectRoot, '.swarm/memory.db');
 
-// Embedding config
-const EMBEDDING_MODEL_NEURAL = 'Xenova/all-MiniLM-L6-v2';
-const EMBEDDING_MODEL_HASH = 'domain-aware-hash-v1';
+// Canonical model name emitted into `memory_entries.embedding_model`. The
+// semantic-search bin script accepts this plus a short set of legacy aliases
+// for entries embedded by earlier moflo versions that still share this
+// vector space (all-MiniLM-L6-v2 regardless of runtime).
+const EMBEDDING_MODEL = 'fast-all-MiniLM-L6-v2';
 const EMBEDDING_DIMS = 384;
-const BATCH_SIZE = 100;
+const BATCH_SIZE = 32;
 
-// Parse args
 const args = process.argv.slice(2);
 const force = args.includes('--force');
 const namespaceFilter = args.includes('--namespace')
@@ -51,217 +49,45 @@ const namespaceFilter = args.includes('--namespace')
   : null;
 const verbose = args.includes('--verbose') || args.includes('-v');
 
-let pipeline = null;
-let useTransformers = false;
-let embeddingModel = EMBEDDING_MODEL_HASH;
-
 function log(msg) {
   console.log(`[build-embeddings] ${msg}`);
 }
-
 function debug(msg) {
   if (verbose) console.log(`[build-embeddings]   ${msg}`);
 }
 
 // ============================================================================
-// Domain-Aware Semantic Hash Embeddings
+// Fastembed loader — neural embeddings are required, no fallback
 // ============================================================================
 
-// Domain clusters for semantic grouping
-const DOMAIN_CLUSTERS = {
-  database: ['typeorm', 'mongodb', 'database', 'entity', 'schema', 'table', 'collection',
-             'query', 'sql', 'nosql', 'orm', 'model', 'migration', 'repository', 'column',
-             'relation', 'foreign', 'primary', 'index', 'constraint', 'transaction'],
-  frontend: ['react', 'component', 'ui', 'styling', 'css', 'html', 'jsx', 'tsx', 'frontend',
-             'material', 'mui', 'tailwind', 'dom', 'render', 'hook', 'state', 'props',
-             'redux', 'context', 'styled', 'emotion', 'theme', 'layout', 'responsive'],
-  backend: ['fastify', 'api', 'route', 'handler', 'rest', 'endpoint', 'server', 'controller',
-            'middleware', 'request', 'response', 'http', 'express', 'nest', 'graphql',
-            'websocket', 'socket', 'cors', 'auth', 'jwt', 'session', 'cookie'],
-  testing: ['test', 'testing', 'vitest', 'jest', 'mock', 'spy', 'assert', 'expect', 'describe',
-            'it', 'spec', 'unit', 'integration', 'e2e', 'playwright', 'cypress', 'coverage',
-            'fixture', 'stub', 'fake', 'snapshot', 'beforeeach', 'aftereach'],
-  tenancy: ['tenant', 'tenancy', 'companyid', 'company', 'isolation', 'multi', 'multitenant',
-            'organization', 'workspace', 'account', 'customer', 'client'],
-  security: ['security', 'auth', 'authentication', 'authorization', 'permission', 'role',
-             'access', 'token', 'jwt', 'oauth', 'password', 'encrypt', 'hash', 'salt',
-             'csrf', 'xss', 'injection', 'sanitize', 'validate'],
-  patterns: ['pattern', 'service', 'factory', 'singleton', 'decorator', 'adapter', 'facade',
-             'observer', 'strategy', 'command', 'repository', 'usecase', 'domain', 'ddd',
-             'clean', 'architecture', 'solid', 'dry', 'kiss'],
-  workflow: ['workflow', 'pipeline', 'ci', 'cd', 'deploy', 'build', 'actions',
-             'hook', 'trigger', 'job', 'step', 'artifact', 'release', 'version', 'tag'],
-  memory: ['memory', 'cache', 'store', 'persist', 'storage', 'redis', 'session', 'state',
-           'buffer', 'queue', 'stack', 'heap', 'gc', 'leak', 'embedding', 'vector', 'hnsw',
-           'semantic', 'search', 'index', 'retrieval'],
-  agent: ['agent', 'swarm', 'coordinator', 'orchestrator', 'task', 'worker', 'spawn',
-          'parallel', 'concurrent', 'async', 'promise', 'queue', 'priority', 'schedule'],
-  github: ['github', 'issue', 'branch', 'pr', 'pull', 'request', 'merge', 'commit', 'push',
-           'clone', 'fork', 'remote', 'origin', 'main', 'master', 'checkout', 'rebase',
-           'squash', 'repository', 'repo', 'gh', 'git', 'assignee', 'label', 'mandatory',
-           'checklist', 'closes', 'fixes', 'conventional', 'feat', 'refactor'],
-  documentation: ['guidance', 'documentation', 'docs', 'readme', 'guide', 'tutorial',
-                  'reference', 'standard', 'convention', 'rule', 'policy', 'template',
-                  'example', 'usage', 'instruction', 'meta', 'index', 'umbrella', 'claude',
-                  'optimized', 'audience', 'structure', 'format', 'markdown']
-};
+let fastembedModel = null;
 
-// Common words to downweight
-const COMMON_WORDS = new Set([
-  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being', 'have', 'has', 'had',
-  'do', 'does', 'did', 'will', 'would', 'could', 'should', 'may', 'might', 'must', 'shall',
-  'can', 'need', 'to', 'of', 'in', 'for', 'on', 'with', 'at', 'by', 'from', 'as', 'into',
-  'through', 'during', 'before', 'after', 'above', 'below', 'between', 'under', 'and', 'but',
-  'or', 'nor', 'so', 'yet', 'both', 'either', 'neither', 'not', 'only', 'own', 'same', 'than',
-  'too', 'very', 'just', 'also', 'this', 'that', 'these', 'those', 'it', 'its', 'if', 'then',
-  'else', 'when', 'where', 'why', 'how', 'all', 'each', 'every', 'any', 'some', 'no', 'yes',
-  'use', 'using', 'used', 'uses', 'get', 'set', 'new', 'see', 'like', 'make', 'made'
-]);
+async function loadModel() {
+  if (fastembedModel) return fastembedModel;
 
-// MurmurHash3-inspired hash function for better distribution
-function hash(str, seed = 0) {
-  let h = seed ^ str.length;
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i);
-    h = Math.imul(h, 0x5bd1e995);
-    h ^= h >>> 15;
-  }
-  return h >>> 0;
+  log('Loading fastembed model (fast-all-MiniLM-L6-v2)...');
+  const mod = await import(mofloResolveURL('fastembed'));
+  const { FlagEmbedding, EmbeddingModel } = mod;
+
+  fastembedModel = await FlagEmbedding.init({
+    model: EmbeddingModel.AllMiniLML6V2,
+    showDownloadProgress: true,
+  });
+  log('fastembed model ready');
+  return fastembedModel;
 }
 
-// Pre-compute domain signature vectors
-const domainSignatures = {};
-for (const [domain, keywords] of Object.entries(DOMAIN_CLUSTERS)) {
-  const sig = new Float32Array(EMBEDDING_DIMS);
-  for (const kw of keywords) {
-    // Use multiple positions per keyword for robustness
-    for (let h = 0; h < 2; h++) {
-      const idx = hash(kw + '_dom_' + domain, h) % EMBEDDING_DIMS;
-      sig[idx] = 1;
-    }
+async function generateEmbeddings(texts) {
+  const model = await loadModel();
+  const out = [];
+  for await (const batch of model.embed(texts, BATCH_SIZE)) {
+    for (const vec of batch) out.push(vec);
   }
-  domainSignatures[domain] = sig;
-}
-
-/**
- * Generate domain-aware semantic hash embedding
- * @param {string} text - Text to embed
- * @param {number} dims - Embedding dimensions
- * @returns {Float32Array} - Normalized embedding vector
- */
-function semanticHashEmbed(text, dims = EMBEDDING_DIMS) {
-  const vec = new Float32Array(dims);
-  const lowerText = text.toLowerCase();
-  const words = lowerText.replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(w => w.length > 1);
-
-  if (words.length === 0) {
-    // Empty text - return zero vector (will have low similarity to everything)
-    return vec;
-  }
-
-  // 1. Add domain signatures for matched domains
-  for (const [domain, keywords] of Object.entries(DOMAIN_CLUSTERS)) {
-    let matchCount = 0;
-    for (const kw of keywords) {
-      if (lowerText.includes(kw)) {
-        matchCount++;
-      }
-    }
-    if (matchCount > 0) {
-      const weight = Math.min(2.0, 0.5 + matchCount * 0.3); // More matches = stronger signal
-      const sig = domainSignatures[domain];
-      for (let i = 0; i < dims; i++) {
-        vec[i] += sig[i] * weight;
-      }
-    }
-  }
-
-  // 2. Add word features (simhash-style with multiple positions)
-  for (let i = 0; i < words.length; i++) {
-    const word = words[i];
-    const isCommon = COMMON_WORDS.has(word);
-    const weight = isCommon ? 0.2 : (word.length > 6 ? 0.8 : 0.5);
-
-    // Multiple hash positions per word
-    for (let h = 0; h < 3; h++) {
-      const idx = hash(word, h * 17) % dims;
-      const sign = (hash(word, h * 31 + 1) % 2 === 0) ? 1 : -1;
-      vec[idx] += sign * weight;
-    }
-  }
-
-  // 3. Add bigram features for local context
-  for (let i = 0; i < words.length - 1; i++) {
-    if (COMMON_WORDS.has(words[i]) && COMMON_WORDS.has(words[i + 1])) continue;
-    const bigram = words[i] + '_' + words[i + 1];
-    const idx = hash(bigram, 42) % dims;
-    const sign = (hash(bigram, 43) % 2 === 0) ? 1 : -1;
-    vec[idx] += sign * 0.4;
-  }
-
-  // 4. Add trigram features for phrase detection
-  for (let i = 0; i < words.length - 2; i++) {
-    const trigram = words[i] + '_' + words[i + 1] + '_' + words[i + 2];
-    const idx = hash(trigram, 99) % dims;
-    const sign = (hash(trigram, 100) % 2 === 0) ? 1 : -1;
-    vec[idx] += sign * 0.3;
-  }
-
-  // 5. L2 normalize
-  let norm = 0;
-  for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
-  norm = Math.sqrt(norm);
-  if (norm > 0) {
-    for (let i = 0; i < dims; i++) vec[i] /= norm;
-  }
-
-  return vec;
+  return out;
 }
 
 // ============================================================================
-// Transformers.js Neural Embeddings (fallback)
-// ============================================================================
-
-async function loadTransformersModel() {
-  if (pipeline) return pipeline;
-
-  log('Attempting to load Transformers.js neural model...');
-
-  try {
-    const { env, pipeline: createPipeline } = await import(mofloResolveURL('@xenova/transformers'));
-    env.allowLocalModels = false;
-    env.backends.onnx.wasm.numThreads = 1;
-
-    pipeline = await createPipeline('feature-extraction', EMBEDDING_MODEL_NEURAL, {
-      quantized: false,
-    });
-
-    useTransformers = true;
-    embeddingModel = EMBEDDING_MODEL_NEURAL;
-    log('Transformers.js model loaded successfully');
-    return pipeline;
-  } catch (err) {
-    const errMsg = err.message?.split('\n')[0] || err.message;
-    log(`Transformers.js not available: ${errMsg}`);
-    log('Using domain-aware hash embeddings (fast, good quality)');
-    useTransformers = false;
-    embeddingModel = EMBEDDING_MODEL_HASH;
-    return null;
-  }
-}
-
-async function generateEmbeddingNeural(text) {
-  if (!pipeline) return null;
-  try {
-    const output = await pipeline(text, { pooling: 'mean', normalize: true });
-    return Array.from(output.data);
-  } catch {
-    return null;
-  }
-}
-
-// ============================================================================
-// Database Operations
+// Database operations
 // ============================================================================
 
 async function getDb() {
@@ -278,36 +104,32 @@ function saveDb(db) {
   writeFileSync(DB_PATH, Buffer.from(data));
 }
 
-function getEntriesNeedingEmbeddings(db, namespace = null, forceAll = false) {
+function getEntriesNeedingEmbeddings(db, namespace, forceAll) {
   let sql = `SELECT id, key, namespace, content FROM memory_entries WHERE status = 'active'`;
   const params = [];
 
   if (!forceAll) {
-    // Include entries with no embedding OR entries with hash/fallback embeddings
-    // that should be upgraded to Xenova when available
-    sql += ` AND (embedding IS NULL OR embedding = '' OR embedding_model IN ('domain-aware-hash-v1', 'hash-fallback', 'local'))`;
+    sql += ` AND (embedding IS NULL OR embedding = '')`;
   }
-
   if (namespace) {
     sql += ` AND namespace = ?`;
     params.push(namespace);
   }
-
   sql += ` ORDER BY created_at DESC`;
 
   const stmt = db.prepare(sql);
   stmt.bind(params);
-  const results = [];
-  while (stmt.step()) results.push(stmt.getAsObject());
+  const rows = [];
+  while (stmt.step()) rows.push(stmt.getAsObject());
   stmt.free();
-  return results;
+  return rows;
 }
 
-function updateEmbedding(db, id, embedding, model) {
+function updateEmbedding(db, id, embedding) {
   const stmt = db.prepare(
-    `UPDATE memory_entries SET embedding = ?, embedding_model = ?, embedding_dimensions = ?, updated_at = ? WHERE id = ?`
+    `UPDATE memory_entries SET embedding = ?, embedding_model = ?, embedding_dimensions = ?, updated_at = ? WHERE id = ?`,
   );
-  stmt.run([JSON.stringify(embedding), model, EMBEDDING_DIMS, Date.now(), id]);
+  stmt.run([JSON.stringify(embedding), EMBEDDING_MODEL, EMBEDDING_DIMS, Date.now(), id]);
   stmt.free();
 }
 
@@ -316,18 +138,17 @@ function getNamespaceStats(db) {
     SELECT
       namespace,
       COUNT(*) as total,
-      SUM(CASE WHEN embedding IS NOT NULL AND embedding != '' AND embedding_model != 'domain-aware-hash-v1' THEN 1 ELSE 0 END) as vectorized,
-      SUM(CASE WHEN embedding IS NULL OR embedding = '' THEN 1 ELSE 0 END) as missing,
-      SUM(CASE WHEN embedding_model = 'domain-aware-hash-v1' THEN 1 ELSE 0 END) as hash_only
+      SUM(CASE WHEN embedding IS NOT NULL AND embedding != '' THEN 1 ELSE 0 END) as vectorized,
+      SUM(CASE WHEN embedding IS NULL OR embedding = '' THEN 1 ELSE 0 END) as missing
     FROM memory_entries
     WHERE status = 'active'
     GROUP BY namespace
     ORDER BY namespace
   `);
-  const results = [];
-  while (stmt.step()) results.push(stmt.getAsObject());
+  const rows = [];
+  while (stmt.step()) rows.push(stmt.getAsObject());
   stmt.free();
-  return results;
+  return rows;
 }
 
 function getEmbeddingStats(db) {
@@ -347,8 +168,29 @@ function getEmbeddingStats(db) {
   return {
     total: total?.cnt || 0,
     withEmbeddings: withEmbed?.cnt || 0,
-    byModel
+    byModel,
   };
+}
+
+function writeVectorStatsCache(stats, nsCount) {
+  try {
+    const dbSizeKB = Math.floor(readFileSync(DB_PATH).length / 1024);
+    const hnswExists = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
+      || existsSync(resolve(projectRoot, '.claude-flow', 'hnsw.index'));
+    const cacheData = {
+      vectorCount: stats.withEmbeddings,
+      dbSizeKB,
+      namespaces: nsCount,
+      hasHnsw: hnswExists,
+      updatedAt: Date.now(),
+    };
+    for (const cacheDir of [resolve(projectRoot, '.claude-flow'), resolve(projectRoot, '.swarm')]) {
+      if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+      writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
+    }
+  } catch (err) {
+    debug(`vector-stats cache write failed (non-fatal): ${err.message}`);
+  }
 }
 
 // ============================================================================
@@ -364,109 +206,70 @@ async function main() {
 
   const db = await getDb();
 
-  // Get entries needing embeddings
   const entries = getEntriesNeedingEmbeddings(db, namespaceFilter, force);
-
   if (entries.length === 0) {
     log('All entries already have embeddings');
     const stats = getEmbeddingStats(db);
     log(`Total: ${stats.withEmbeddings}/${stats.total} entries embedded`);
-
-    // Update vector-stats cache even on early exit
-    try {
-      const nsStats = getNamespaceStats(db);
-      const dbSizeKB = Math.floor(readFileSync(DB_PATH).length / 1024);
-      const hnswExists = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
-        || existsSync(resolve(projectRoot, '.claude-flow', 'hnsw.index'));
-      const cacheData = {
-        vectorCount: stats.withEmbeddings,
-        dbSizeKB,
-        namespaces: nsStats.length,
-        hasHnsw: hnswExists,
-        updatedAt: Date.now(),
-      };
-      for (const cacheDir of [resolve(projectRoot, '.claude-flow'), resolve(projectRoot, '.swarm')]) {
-        if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
-        writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
-      }
-    } catch { /* non-fatal */ }
-
+    writeVectorStatsCache(stats, getNamespaceStats(db).length);
     db.close();
     return;
   }
 
   log(`Found ${entries.length} entries to embed`);
 
-  // Try to load Transformers.js, fall back to hash embeddings
-  await loadTransformersModel();
-
-  log(`Using embedding model: ${embeddingModel}`);
-  console.log('');
-
   let embedded = 0;
   let failed = 0;
   const startTime = Date.now();
 
-  // Process entries
-  for (let i = 0; i < entries.length; i++) {
-    const entry = entries[i];
+  // Embed in batches to match fastembed's streaming API while keeping progress
+  // output tied to the source row order.
+  for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+    const slice = entries.slice(i, i + BATCH_SIZE);
+    const texts = slice.map(e => String(e.content ?? '').substring(0, 1500));
 
+    let vectors;
     try {
-      // Truncate content for embedding (first 1500 chars for context)
-      const text = entry.content.substring(0, 1500);
-
-      let embedding;
-      if (useTransformers && pipeline) {
-        embedding = await generateEmbeddingNeural(text);
-      }
-
-      // Fall back to hash embedding if neural failed or not available
-      if (!embedding || embedding.length !== EMBEDDING_DIMS) {
-        embedding = Array.from(semanticHashEmbed(text));
-      }
-
-      if (embedding && embedding.length === EMBEDDING_DIMS) {
-        updateEmbedding(db, entry.id, embedding, embeddingModel);
-        embedded++;
-      } else {
-        failed++;
-      }
-
-      // Progress update
-      if ((i + 1) % 50 === 0 || i === entries.length - 1) {
-        const pct = Math.round(((i + 1) / entries.length) * 100);
-        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-        process.stdout.write(`\r[build-embeddings] Progress: ${i + 1}/${entries.length} (${pct}%) - ${elapsed}s elapsed`);
-      }
+      vectors = await generateEmbeddings(texts);
     } catch (err) {
-      debug(`Failed to embed ${entry.key}: ${err.message}`);
-      failed++;
+      log(`Batch ${i}-${i + slice.length} failed: ${err.message}`);
+      failed += slice.length;
+      continue;
     }
-  }
 
-  console.log(''); // New line after progress
+    for (let j = 0; j < slice.length; j++) {
+      const vec = vectors[j];
+      if (!Array.isArray(vec) || vec.length !== EMBEDDING_DIMS) {
+        failed++;
+        continue;
+      }
+      updateEmbedding(db, slice[j].id, vec);
+      embedded++;
+    }
+
+    const processed = Math.min(i + slice.length, entries.length);
+    const pct = Math.round((processed / entries.length) * 100);
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    process.stdout.write(`\r[build-embeddings] Progress: ${processed}/${entries.length} (${pct}%) - ${elapsed}s elapsed`);
+  }
+  console.log('');
 
   const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
-  const stats = getEmbeddingStats(db);
 
-  // Write changes back to disk (sql.js operates in-memory)
   if (embedded > 0) {
     saveDb(db);
-
-    // Delete stale HNSW index so the CLI rebuilds from fresh vectors
-    const hnswPaths = [
+    for (const p of [
       resolve(projectRoot, '.swarm/hnsw.index'),
       resolve(projectRoot, '.swarm/hnsw.metadata.json'),
-    ];
-    for (const p of hnswPaths) {
+    ]) {
       if (existsSync(p)) {
-        const { unlinkSync } = await import('fs');
         unlinkSync(p);
         log(`Deleted stale HNSW index: ${p}`);
       }
     }
   }
 
+  const stats = getEmbeddingStats(db);
   console.log('');
   log('═══════════════════════════════════════════════════════════');
   log('  Embedding Generation Complete');
@@ -474,7 +277,7 @@ async function main() {
   log(`  Embedded:     ${embedded} entries`);
   log(`  Failed:       ${failed} entries`);
   log(`  Time:         ${totalTime}s`);
-  log(`  Model:        ${embeddingModel}`);
+  log(`  Model:        ${EMBEDDING_MODEL}`);
   log(`  Dimensions:   ${EMBEDDING_DIMS}`);
   log('');
   log(`  Total Coverage: ${stats.withEmbeddings}/${stats.total} entries`);
@@ -486,60 +289,33 @@ async function main() {
   }
   log('');
 
-  // Per-namespace health report
   const nsStats = getNamespaceStats(db);
   if (nsStats.length > 0) {
     log('  Namespace Health:');
-    log('  ┌─────────────────┬───────┬────────────┬─────────┬───────────┐');
-    log('  │ Namespace       │ Total │ Vectorized │ Missing │ Hash-Only │');
-    log('  ├─────────────────┼───────┼────────────┼─────────┼───────────┤');
+    log('  ┌─────────────────┬───────┬────────────┬─────────┐');
+    log('  │ Namespace       │ Total │ Vectorized │ Missing │');
+    log('  ├─────────────────┼───────┼────────────┼─────────┤');
     let hasWarnings = false;
     for (const ns of nsStats) {
       const name = String(ns.namespace).padEnd(15);
       const total = String(ns.total).padStart(5);
       const vectorized = String(ns.vectorized).padStart(10);
       const missing = String(ns.missing).padStart(7);
-      const hashOnly = String(ns.hash_only).padStart(9);
-      const warn = (ns.missing > 0 || ns.hash_only > 0) ? ' ⚠' : '  ';
-      log(`  │ ${name} │${total} │${vectorized} │${missing} │${hashOnly} │${warn}`);
-      if (ns.missing > 0 || ns.hash_only > 0) hasWarnings = true;
+      const warn = ns.missing > 0 ? ' ⚠' : '  ';
+      log(`  │ ${name} │${total} │${vectorized} │${missing} │${warn}`);
+      if (ns.missing > 0) hasWarnings = true;
     }
-    log('  └─────────────────┴───────┴────────────┴─────────┴───────────┘');
+    log('  └─────────────────┴───────┴────────────┴─────────┘');
     if (hasWarnings) {
       log('');
-      log('  ⚠ Some namespaces have entries without Xenova embeddings.');
-      log('  Run with --force to re-embed all entries:');
-      log('    node node_modules/moflo/bin/build-embeddings.mjs --force');
-      if (!useTransformers) {
-        log('');
-        log('  ⚠ Xenova model not available — using hash fallback.');
-        log('  Install @xenova/transformers for neural embeddings:');
-        log('    npm install @xenova/transformers');
-      }
+      log('  ⚠ Some namespaces have rows missing embeddings.');
+      log('    Re-run with --force to re-embed everything:');
+      log('      node node_modules/moflo/bin/build-embeddings.mjs --force');
     }
   }
-
   log('═══════════════════════════════════════════════════════════');
 
-  // Update vector-stats cache for statusline display
-  try {
-    const dbSizeKB = Math.floor(readFileSync(DB_PATH).length / 1024);
-    const hnswExists = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
-      || existsSync(resolve(projectRoot, '.claude-flow', 'hnsw.index'));
-    const cacheData = {
-      vectorCount: stats.withEmbeddings,
-      dbSizeKB,
-      namespaces: nsStats.length,
-      hasHnsw: hnswExists,
-      updatedAt: Date.now(),
-    };
-    // Write to both locations so statusline finds it regardless of which dir it checks
-    for (const cacheDir of [resolve(projectRoot, '.claude-flow'), resolve(projectRoot, '.swarm')]) {
-      if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
-      writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
-    }
-  } catch { /* non-fatal */ }
-
+  writeVectorStatsCache(stats, nsStats.length);
   db.close();
 }
 

--- a/.claude/scripts/semantic-search.mjs
+++ b/.claude/scripts/semantic-search.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 /**
- * Semantic search using 384-dim embeddings (Xenova/all-MiniLM-L6-v2 or hash fallback)
+ * Semantic search over stored moflo memory entries.
  *
- * Query embedding MUST match stored embedding model:
- * 1. Transformers.js with all-MiniLM-L6-v2 (best quality, matches build-embeddings)
- * 2. Domain-aware semantic hash embeddings (fallback when transformers unavailable)
+ * Query embeddings are produced by fastembed (`fast-all-MiniLM-L6-v2`,
+ * 384-dim, L2-normalised). This matches `bin/build-embeddings.mjs` and the
+ * in-process `FastembedEmbeddingService` so all three share a vector space.
+ *
+ * Neural embeddings are required — epic #527 removed every hash fallback.
+ * If the model cannot load, the script reports the error and exits 1.
  *
  * Usage:
  *   node node_modules/moflo/bin/semantic-search.mjs "your search query"
@@ -30,25 +33,28 @@ function findProjectRoot() {
 }
 
 const projectRoot = findProjectRoot();
-
 const DB_PATH = resolve(projectRoot, '.swarm/memory.db');
-const EMBEDDING_DIMS = 384;
-const EMBEDDING_MODEL_NEURAL = 'Xenova/all-MiniLM-L6-v2';
-const EMBEDDING_MODEL_HASH = 'domain-aware-hash-v1';
-// 'onnx' is a legacy alias for the Xenova model — treat them as compatible vector spaces
-const NEURAL_ALIASES = new Set([EMBEDDING_MODEL_NEURAL, 'onnx']);
 
-// Parse args
+const EMBEDDING_MODEL = 'fast-all-MiniLM-L6-v2';
+const EMBEDDING_DIMS = 384;
+// Legacy aliases share the same vector space (all-MiniLM-L6-v2 regardless of
+// runtime), so entries tagged with these model names are still valid search
+// candidates against fastembed-generated query vectors.
+const COMPATIBLE_MODELS = new Set([
+  EMBEDDING_MODEL,
+  'Xenova/all-MiniLM-L6-v2',
+  'onnx',
+]);
+
 const args = process.argv.slice(2);
 const query = args.find(a => !a.startsWith('--'));
 const limit = args.includes('--limit') ? parseInt(args[args.indexOf('--limit') + 1]) : 5;
-let namespace = args.includes('--namespace') ? args[args.indexOf('--namespace') + 1] : null;
+const namespace = args.includes('--namespace') ? args[args.indexOf('--namespace') + 1] : null;
 const withTests = args.includes('--with-tests');
 const threshold = args.includes('--threshold') ? parseFloat(args[args.indexOf('--threshold') + 1]) : 0.3;
 const json = args.includes('--json');
 const debug = args.includes('--debug');
 
-// Auto-routing: when query mentions test-related terms, also search tests namespace
 const TEST_KEYWORDS = /\b(test|spec|coverage|assert|mock|stub|fixture|describe|jest|vitest|mocha|e2e|integration test)\b/i;
 
 if (!query) {
@@ -57,239 +63,43 @@ if (!query) {
 }
 
 // ============================================================================
-// Transformers.js Neural Embeddings (primary — matches build-embeddings.mjs)
+// Fastembed loader — neural embeddings are required, no fallback
 // ============================================================================
 
-let pipeline = null;
-let useTransformers = false;
+let fastembedModel = null;
 
-async function loadTransformersModel() {
-  try {
-    const { env, pipeline: createPipeline } = await import(mofloResolveURL('@xenova/transformers'));
-    env.allowLocalModels = false;
-    env.backends.onnx.wasm.numThreads = 1;
+async function loadModel() {
+  if (fastembedModel) return fastembedModel;
 
-    pipeline = await createPipeline('feature-extraction', EMBEDDING_MODEL_NEURAL, {
-      quantized: false,
-    });
+  const mod = await import(mofloResolveURL('fastembed'));
+  const { FlagEmbedding, EmbeddingModel } = mod;
 
-    useTransformers = true;
-    if (debug) console.error('[semantic-search] Using Transformers.js neural model');
-    return true;
-  } catch (err) {
-    if (debug) console.error(`[semantic-search] Transformers.js unavailable: ${err.message?.split('\n')[0]}`);
-    useTransformers = false;
-    return false;
-  }
+  fastembedModel = await FlagEmbedding.init({
+    model: EmbeddingModel.AllMiniLML6V2,
+    showDownloadProgress: false,
+  });
+  if (debug) console.error('[semantic-search] fastembed model loaded');
+  return fastembedModel;
 }
 
-async function generateNeuralEmbedding(text) {
-  if (!pipeline) return null;
-  try {
-    const output = await pipeline(text, { pooling: 'mean', normalize: true });
-    return Array.from(output.data);
-  } catch {
-    return null;
+async function generateQueryEmbedding(text) {
+  const model = await loadModel();
+  const vec = await model.queryEmbed(text);
+  if (!Array.isArray(vec) || vec.length !== EMBEDDING_DIMS) {
+    throw new Error(`fastembed returned unexpected vector shape (got length ${vec?.length ?? 'none'})`);
   }
-}
-
-// ============================================================================
-// Domain-Aware Semantic Hash Embeddings (fallback)
-// ============================================================================
-
-const DOMAIN_CLUSTERS = {
-  database: ['typeorm', 'mongodb', 'database', 'entity', 'schema', 'table', 'collection',
-             'query', 'sql', 'nosql', 'orm', 'model', 'migration', 'repository', 'column',
-             'relation', 'foreign', 'primary', 'index', 'constraint', 'transaction',
-             'mikroorm', 'mikro', 'postgresql', 'postgres', 'soft', 'delete', 'deletedat'],
-  frontend: ['react', 'component', 'ui', 'styling', 'css', 'html', 'jsx', 'tsx', 'frontend',
-             'material', 'mui', 'tailwind', 'dom', 'render', 'hook', 'state', 'props',
-             'redux', 'context', 'styled', 'emotion', 'theme', 'layout', 'responsive',
-             'mantis', 'syncfusion', 'scheduler', 'i18n', 'intl', 'locale'],
-  backend: ['fastify', 'api', 'route', 'handler', 'rest', 'endpoint', 'server', 'controller',
-            'middleware', 'request', 'response', 'http', 'express', 'nest', 'graphql',
-            'websocket', 'socket', 'cors', 'auth', 'jwt', 'session', 'cookie',
-            'awilix', 'dependency', 'injection', 'scope'],
-  testing: ['test', 'testing', 'vitest', 'jest', 'mock', 'spy', 'assert', 'expect', 'describe',
-            'it', 'spec', 'unit', 'integration', 'e2e', 'playwright', 'cypress', 'coverage',
-            'fixture', 'stub', 'fake', 'snapshot', 'beforeeach', 'aftereach',
-            'anti-pattern', 'antipattern', 'mocking'],
-  tenancy: ['tenant', 'tenancy', 'companyid', 'company', 'isolation', 'multi', 'multitenant',
-            'organization', 'workspace', 'account', 'customer', 'client', 'subdomain'],
-  security: ['security', 'auth', 'authentication', 'authorization', 'permission', 'role',
-             'access', 'token', 'jwt', 'oauth', 'password', 'encrypt', 'hash', 'salt',
-             'csrf', 'xss', 'injection', 'sanitize', 'validate', 'rbac'],
-  patterns: ['pattern', 'service', 'factory', 'singleton', 'decorator', 'adapter', 'facade',
-             'observer', 'strategy', 'command', 'repository', 'usecase', 'domain', 'ddd',
-             'clean', 'architecture', 'solid', 'dry', 'kiss', 'functional', 'pipeasync'],
-  workflow: ['workflow', 'pipeline', 'ci', 'cd', 'deploy', 'build', 'actions',
-             'hook', 'trigger', 'job', 'step', 'artifact', 'release', 'version', 'tag'],
-  memory: ['memory', 'cache', 'store', 'persist', 'storage', 'redis', 'session', 'state',
-           'buffer', 'queue', 'stack', 'heap', 'gc', 'leak', 'embedding', 'vector', 'hnsw',
-           'semantic', 'search', 'index', 'retrieval'],
-  agent: ['agent', 'swarm', 'coordinator', 'orchestrator', 'task', 'worker', 'spawn',
-          'parallel', 'concurrent', 'async', 'promise', 'queue', 'priority', 'schedule'],
-  github: ['github', 'issue', 'branch', 'pr', 'pull', 'request', 'merge', 'commit', 'push',
-           'clone', 'fork', 'remote', 'origin', 'main', 'master', 'checkout', 'rebase',
-           'squash', 'repository', 'repo', 'gh', 'git', 'assignee', 'label', 'mandatory',
-           'checklist', 'closes', 'fixes', 'conventional', 'feat', 'refactor'],
-  documentation: ['guidance', 'documentation', 'docs', 'readme', 'guide', 'tutorial',
-                  'reference', 'standard', 'convention', 'rule', 'policy', 'template',
-                  'example', 'usage', 'instruction', 'meta', 'index', 'umbrella', 'claude',
-                  'optimized', 'audience', 'structure', 'format', 'markdown']
-};
-
-const COMMON_WORDS = new Set([
-  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being', 'have', 'has', 'had',
-  'do', 'does', 'did', 'will', 'would', 'could', 'should', 'may', 'might', 'must', 'shall',
-  'can', 'need', 'to', 'of', 'in', 'for', 'on', 'with', 'at', 'by', 'from', 'as', 'into',
-  'through', 'during', 'before', 'after', 'above', 'below', 'between', 'under', 'and', 'but',
-  'or', 'nor', 'so', 'yet', 'both', 'either', 'neither', 'not', 'only', 'own', 'same', 'than',
-  'too', 'very', 'just', 'also', 'this', 'that', 'these', 'those', 'it', 'its', 'if', 'then',
-  'else', 'when', 'where', 'why', 'how', 'all', 'each', 'every', 'any', 'some', 'no', 'yes',
-  'use', 'using', 'used', 'uses', 'get', 'set', 'new', 'see', 'like', 'make', 'made'
-]);
-
-function hash(str, seed = 0) {
-  let h = seed ^ str.length;
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i);
-    h = Math.imul(h, 0x5bd1e995);
-    h ^= h >>> 15;
-  }
-  return h >>> 0;
-}
-
-// Pre-compute domain signatures
-const domainSignatures = {};
-for (const [domain, keywords] of Object.entries(DOMAIN_CLUSTERS)) {
-  const sig = new Float32Array(EMBEDDING_DIMS);
-  for (const kw of keywords) {
-    for (let h = 0; h < 2; h++) {
-      const idx = hash(kw + '_dom_' + domain, h) % EMBEDDING_DIMS;
-      sig[idx] = 1;
-    }
-  }
-  domainSignatures[domain] = sig;
-}
-
-function semanticHashEmbed(text, dims = EMBEDDING_DIMS) {
-  const vec = new Float32Array(dims);
-  const lowerText = text.toLowerCase();
-  const words = lowerText.replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter(w => w.length > 1);
-
-  if (words.length === 0) return vec;
-
-  // Add domain signatures
-  for (const [domain, keywords] of Object.entries(DOMAIN_CLUSTERS)) {
-    let matchCount = 0;
-    for (const kw of keywords) {
-      if (lowerText.includes(kw)) matchCount++;
-    }
-    if (matchCount > 0) {
-      const weight = Math.min(2.0, 0.5 + matchCount * 0.3);
-      const sig = domainSignatures[domain];
-      for (let i = 0; i < dims; i++) {
-        vec[i] += sig[i] * weight;
-      }
-    }
-  }
-
-  // Add word features
-  for (const word of words) {
-    const isCommon = COMMON_WORDS.has(word);
-    const weight = isCommon ? 0.2 : (word.length > 6 ? 0.8 : 0.5);
-    for (let h = 0; h < 3; h++) {
-      const idx = hash(word, h * 17) % dims;
-      const sign = (hash(word, h * 31 + 1) % 2 === 0) ? 1 : -1;
-      vec[idx] += sign * weight;
-    }
-  }
-
-  // Add bigrams
-  for (let i = 0; i < words.length - 1; i++) {
-    if (COMMON_WORDS.has(words[i]) && COMMON_WORDS.has(words[i + 1])) continue;
-    const bigram = words[i] + '_' + words[i + 1];
-    const idx = hash(bigram, 42) % dims;
-    const sign = (hash(bigram, 43) % 2 === 0) ? 1 : -1;
-    vec[idx] += sign * 0.4;
-  }
-
-  // Add trigrams
-  for (let i = 0; i < words.length - 2; i++) {
-    const trigram = words[i] + '_' + words[i + 1] + '_' + words[i + 2];
-    const idx = hash(trigram, 99) % dims;
-    const sign = (hash(trigram, 100) % 2 === 0) ? 1 : -1;
-    vec[idx] += sign * 0.3;
-  }
-
-  // L2 normalize
-  let norm = 0;
-  for (let i = 0; i < dims; i++) norm += vec[i] * vec[i];
-  norm = Math.sqrt(norm);
-  if (norm > 0) {
-    for (let i = 0; i < dims; i++) vec[i] /= norm;
-  }
-
   return vec;
 }
 
 // ============================================================================
-// Unified Embedding Generator (matches stored embeddings)
-// ============================================================================
-
-/**
- * Generate query embedding using the SAME model as stored embeddings.
- * Checks what model was used for stored entries and matches it.
- */
-async function generateQueryEmbedding(queryText, db) {
-  // Check what model the stored entries use
-  let modelCheckSql = `SELECT embedding_model, COUNT(*) as cnt FROM memory_entries
-     WHERE status = 'active' AND embedding IS NOT NULL AND embedding != ''
-     ${namespace ? "AND namespace = ?" : ""}
-     GROUP BY embedding_model ORDER BY cnt DESC LIMIT 1`;
-  const modelStmt = db.prepare(modelCheckSql);
-  modelStmt.bind(namespace ? [namespace] : []);
-  const modelCheck = modelStmt.step() ? modelStmt.getAsObject() : null;
-  modelStmt.free();
-
-  const storedModel = modelCheck?.embedding_model || EMBEDDING_MODEL_HASH;
-
-  if (debug) console.error(`[semantic-search] Stored model: ${storedModel}`);
-
-  // If stored embeddings are neural, try to use neural for query too
-  // Accept both canonical name and legacy 'onnx' tag (both use the same Xenova pipeline)
-  if (storedModel === EMBEDDING_MODEL_NEURAL || storedModel === 'onnx') {
-    await loadTransformersModel();
-    if (useTransformers) {
-      const neuralEmb = await generateNeuralEmbedding(queryText);
-      if (neuralEmb && neuralEmb.length === EMBEDDING_DIMS) {
-        return { embedding: neuralEmb, model: EMBEDDING_MODEL_NEURAL };
-      }
-    }
-    // Neural failed — warn about model mismatch
-    if (!json) {
-      console.error('[semantic-search] WARNING: Stored embeddings use neural model but Transformers.js unavailable.');
-      console.error('[semantic-search] Results may be poor. Run: flo-embeddings --force');
-    }
-  }
-
-  // Use hash embeddings (either matching stored hash model, or as fallback)
-  const hashEmb = Array.from(semanticHashEmbed(queryText));
-  return { embedding: hashEmb, model: EMBEDDING_MODEL_HASH };
-}
-
-// ============================================================================
-// Search Functions
+// Search
 // ============================================================================
 
 function cosineSimilarity(a, b) {
   if (!a || !b || a.length !== b.length) return 0;
   let dot = 0;
-  for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-  }
-  return dot; // Already L2 normalized
+  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  return dot; // vectors are L2-normalised on both sides
 }
 
 async function getDb() {
@@ -302,74 +112,71 @@ async function getDb() {
 }
 
 async function semanticSearch(queryText, options = {}) {
-  const { limit = 5, namespace = null, threshold = 0.3 } = options;
+  const { limit = 5, namespace: ns = null, threshold: th = 0.3 } = options;
   const startTime = performance.now();
 
   const db = await getDb();
+  const queryEmbedding = await generateQueryEmbedding(queryText);
 
-  // Generate query embedding matching the stored model
-  const { embedding: queryEmbedding, model: queryModel } = await generateQueryEmbedding(queryText, db);
-
-  if (debug) console.error(`[semantic-search] Query model: ${queryModel}`);
-
-  // Get all entries with embeddings
   let sql = `
     SELECT id, key, namespace, content, embedding, embedding_model, metadata
     FROM memory_entries
     WHERE status = 'active' AND embedding IS NOT NULL AND embedding != ''
   `;
   const params = [];
-
-  if (namespace) {
+  if (ns) {
     sql += ` AND namespace = ?`;
-    params.push(namespace);
+    params.push(ns);
   }
 
   const stmt = db.prepare(sql);
   stmt.bind(params);
 
-  // Calculate similarity scores
   const results = [];
+  let skippedIncompat = 0;
   while (stmt.step()) {
     const entry = stmt.getAsObject();
     try {
-      const storedIsNeural = NEURAL_ALIASES.has(entry.embedding_model);
-      const queryIsNeural = NEURAL_ALIASES.has(queryModel);
-      if (entry.embedding_model && entry.embedding_model !== queryModel && !(storedIsNeural && queryIsNeural)) continue;
+      if (entry.embedding_model && !COMPATIBLE_MODELS.has(entry.embedding_model)) {
+        skippedIncompat++;
+        continue;
+      }
 
       const embedding = JSON.parse(entry.embedding);
       if (!Array.isArray(embedding) || embedding.length !== EMBEDDING_DIMS) continue;
 
       const similarity = cosineSimilarity(queryEmbedding, embedding);
+      if (similarity < th) continue;
 
-      if (similarity >= threshold) {
-        let metadata = {};
-        try {
-          metadata = JSON.parse(entry.metadata || '{}');
-        } catch {}
-
-        results.push({
-          key: entry.key,
-          namespace: entry.namespace,
-          score: similarity,
-          preview: entry.content.substring(0, 150).replace(/\n/g, ' '),
-          type: metadata.type || 'unknown',
-          parentDoc: metadata.parentDoc || null,
-          chunkTitle: metadata.chunkTitle || null,
-        });
+      let metadata = {};
+      try {
+        metadata = JSON.parse(entry.metadata || '{}');
+      } catch (err) {
+        if (debug) console.error(`[semantic-search] metadata parse failed for ${entry.key}: ${err.message}`);
       }
-    } catch {
-      // Skip entries with invalid embeddings
+
+      results.push({
+        key: entry.key,
+        namespace: entry.namespace,
+        score: similarity,
+        preview: entry.content.substring(0, 150).replace(/\n/g, ' '),
+        type: metadata.type || 'unknown',
+        parentDoc: metadata.parentDoc || null,
+        chunkTitle: metadata.chunkTitle || null,
+      });
+    } catch (err) {
+      if (debug) console.error(`[semantic-search] skipped ${entry.key}: ${err.message}`);
     }
   }
   stmt.free();
-
   db.close();
 
-  // Sort by similarity (descending) and limit
+  if (debug && skippedIncompat > 0) {
+    console.error(`[semantic-search] Skipped ${skippedIncompat} rows with incompatible embedding_model`);
+  }
+
   results.sort((a, b) => b.score - a.score);
   const topResults = results.slice(0, limit);
-
   const searchTime = performance.now() - startTime;
 
   return {
@@ -378,7 +185,7 @@ async function semanticSearch(queryText, options = {}) {
     totalMatches: results.length,
     searchTime: `${searchTime.toFixed(0)}ms`,
     indexType: 'vector-cosine',
-    model: queryModel,
+    model: EMBEDDING_MODEL,
   };
 }
 
@@ -393,8 +200,6 @@ async function main() {
   }
 
   try {
-    // --with-tests: search both the specified namespace (or code-map) and tests
-    // Auto-route: if query contains test keywords and no namespace specified, also search tests
     const autoRouteTests = !namespace && TEST_KEYWORDS.test(query);
     let results;
 
@@ -403,7 +208,6 @@ async function main() {
       const primaryResults = await semanticSearch(query, { limit, namespace: primaryNs, threshold });
       const testResults = await semanticSearch(query, { limit, namespace: 'tests', threshold });
 
-      // Merge and re-sort by score
       const merged = [...primaryResults.results, ...testResults.results]
         .sort((a, b) => b.score - a.score)
         .slice(0, limit);
@@ -417,7 +221,7 @@ async function main() {
       };
 
       if (!json && autoRouteTests) {
-        console.log(`[semantic-search] Auto-routed to tests namespace (query contains test keywords)`);
+        console.log('[semantic-search] Auto-routed to tests namespace (query contains test keywords)');
       }
     } else {
       results = await semanticSearch(query, { limit, namespace, threshold });
@@ -436,11 +240,9 @@ async function main() {
       return;
     }
 
-    // Display results
     console.log('┌─────────────────────────────────────────────────────────────────────────────┐');
     console.log('│ Rank │ Score │ Key                          │ Type   │ Preview             │');
     console.log('├─────────────────────────────────────────────────────────────────────────────┤');
-
     for (let i = 0; i < results.results.length; i++) {
       const r = results.results[i];
       const rank = String(i + 1).padStart(4);
@@ -448,13 +250,10 @@ async function main() {
       const key = r.key.substring(0, 28).padEnd(28);
       const type = (r.type || '').substring(0, 6).padEnd(6);
       const preview = r.preview.substring(0, 18).padEnd(18);
-
       console.log(`│ ${rank} │ ${score} │ ${key} │ ${type} │ ${preview}… │`);
     }
-
     console.log('└─────────────────────────────────────────────────────────────────────────────┘');
 
-    // Show chunk context
     console.log('');
     console.log('Top result details:');
     const top = results.results[0];
@@ -463,7 +262,6 @@ async function main() {
     if (top.chunkTitle) console.log(`  Section: ${top.chunkTitle}`);
     if (top.parentDoc) console.log(`  Parent: ${top.parentDoc}`);
     console.log(`  Preview: ${top.preview}...`);
-
   } catch (err) {
     console.error(`[semantic-search] Error: ${err.message}`);
     process.exit(1);

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,10 +12,20 @@ const BANNED_EMBEDDING_MESSAGE =
   'Use the fastembed-backed IEmbeddingService from @moflo/embeddings instead. ' +
   'Test-only deterministic mocks belong under __tests__/.';
 
+// Issue #545: architect review of PR #539's whitelist flagged it as
+// rename-circumventable. The additions below cover the names we have actually
+// seen leak — `hashEmbed` and `embedWithFallback` were the live production
+// call-sites deleted in PR #557. `generateEmbedding` is deliberately NOT
+// added: it is the public fastembed-backed API exported by
+// `memory/memory-initializer.js` and referenced in ~40 legitimate call-sites.
+// Any real hash implementation hiding behind that name is caught by the
+// structural Float32Array + charCodeAt rule below, which runs repo-wide.
 const BANNED_IDENTIFIERS = [
   'HashEmbeddingProvider',
   'createHashEmbedding',
   'generateHashEmbedding',
+  'hashEmbed',
+  'embedWithFallback',
   'RvfEmbeddingService',
   'RvfEmbeddingCache',
 ];
@@ -26,40 +36,12 @@ const BANNED_IDENTIFIER_PATTERN = `^(${BANNED_IDENTIFIERS.join('|')})$`;
 // tag, and any future suffix a contributor might try to sneak through.
 const BANNED_LITERAL_PATTERN = '^domain-aware-hash';
 
-const bannedEmbeddingRules = {
-  'no-restricted-syntax': [
-    'error',
-    {
-      selector: `Identifier[name=/${BANNED_IDENTIFIER_PATTERN}/]`,
-      message: BANNED_EMBEDDING_MESSAGE,
-    },
-    {
-      selector: `Literal[value=/${BANNED_LITERAL_PATTERN}/]`,
-      message: BANNED_EMBEDDING_MESSAGE,
-    },
-    {
-      selector: `TemplateElement[value.raw=/${BANNED_LITERAL_PATTERN}/]`,
-      message: BANNED_EMBEDDING_MESSAGE,
-    },
-  ],
-  'no-restricted-imports': [
-    'error',
-    {
-      paths: [
-        {
-          name: '@xenova/transformers',
-          message:
-            '@xenova/transformers was removed in epic #527. Import from @moflo/embeddings (fastembed-backed) instead.',
-        },
-      ],
-    },
-  ],
-};
-
 // Structural guard: any function that both constructs a Float32Array AND
 // calls charCodeAt is a hash embedding regardless of method name. The
 // identifier ban above missed the inline implementations removed in #542
-// because their enclosing methods used generic names.
+// because their enclosing methods used generic names. Issue #545 unscoped
+// this from `src/modules/swarm/` to repo-wide — the same anti-pattern was
+// leaking into memory/CLI/hooks.
 const INLINE_HASH_EMBEDDING_MESSAGE =
   'Inline hash-embedding pattern detected (Float32Array + charCodeAt in the ' +
   'same function). Inject a fastembed-backed IEmbeddingProvider from ' +
@@ -77,11 +59,34 @@ const INLINE_HASH_EMBEDDING_SELECTORS = [
   message: INLINE_HASH_EMBEDDING_MESSAGE,
 }));
 
-const swarmSrcRules = {
+const bannedEmbeddingRules = {
   'no-restricted-syntax': [
     'error',
-    ...bannedEmbeddingRules['no-restricted-syntax'].slice(1),
+    {
+      selector: `Identifier[name=/${BANNED_IDENTIFIER_PATTERN}/]`,
+      message: BANNED_EMBEDDING_MESSAGE,
+    },
+    {
+      selector: `Literal[value=/${BANNED_LITERAL_PATTERN}/]`,
+      message: BANNED_EMBEDDING_MESSAGE,
+    },
+    {
+      selector: `TemplateElement[value.raw=/${BANNED_LITERAL_PATTERN}/]`,
+      message: BANNED_EMBEDDING_MESSAGE,
+    },
     ...INLINE_HASH_EMBEDDING_SELECTORS,
+  ],
+  'no-restricted-imports': [
+    'error',
+    {
+      paths: [
+        {
+          name: '@xenova/transformers',
+          message:
+            '@xenova/transformers was removed in epic #527. Import from @moflo/embeddings (fastembed-backed) instead.',
+        },
+      ],
+    },
   ],
 };
 
@@ -102,6 +107,15 @@ module.exports = {
     'docs/',
     'tests/fixtures/**',
     '**/*.d.ts',
+    // Issue #545: ESLint ignores dot-prefixed paths by default. Negations
+    // below put the shipped helper scripts back under the guard — they ride
+    // into consumer installs via the scriptFiles sync list and need the
+    // same hash-fallback protection as src/ + bin/. The parent path has to
+    // be un-ignored first (ESLint evaluates patterns top-down and can't
+    // traverse into an ignored dir), then the specific subtree is allowed.
+    '!.claude',
+    '!.claude/scripts',
+    '!.claude/scripts/**',
   ],
   overrides: [
     {
@@ -119,6 +133,9 @@ module.exports = {
       rules: bannedEmbeddingRules,
     },
     {
+      // JS/MJS/CJS across src, bin, and the shipped `.claude/scripts/` helpers
+      // (issue #545 pulled the last group in — it was previously invisible to
+      // the guard because lint only targeted src/ + bin/).
       files: [
         'src/**/*.js',
         'src/**/*.mjs',
@@ -126,6 +143,9 @@ module.exports = {
         'bin/**/*.js',
         'bin/**/*.mjs',
         'bin/**/*.cjs',
+        '.claude/scripts/**/*.js',
+        '.claude/scripts/**/*.mjs',
+        '.claude/scripts/**/*.cjs',
       ],
       parserOptions: {
         ecmaVersion: 2022,
@@ -134,25 +154,25 @@ module.exports = {
       rules: bannedEmbeddingRules,
     },
     {
-      // Issue #542: structural ban on inline hash embeddings in swarm
-      // coordinators. Layered on top of the repo-wide identifier/literal ban.
-      files: ['src/modules/swarm/src/**/*.ts'],
-      parser: '@typescript-eslint/parser',
-      parserOptions: {
-        ecmaVersion: 2022,
-        sourceType: 'module',
-      },
-      plugins: ['@typescript-eslint'],
-      rules: swarmSrcRules,
-    },
-    {
       // Test-only deterministic mocks are explicitly allowed to reference the
       // hash-embedding identifiers so existing guidance-retriever test
       // fixtures continue to work. They are NOT exported from any package.
+      //
+      // Patterns cover every test/mock/benchmark convention we actually use:
+      //  - `__tests__/`, `*.test.*`, `*.spec.*` — standard vitest layouts
+      //  - `__mocks__/` — vitest manual mock dirs (incl. production-adjacent
+      //    mock-provider modules imported from prod via `useMockEmbeddings`)
+      //  - `tests/` — package-level alt layout (e.g. guidance package)
+      //  - `benchmarks/` — microbenchmarks that simulate hash embeddings
+      //    intentionally to measure vector-math throughput
       files: [
         'src/**/__tests__/**',
+        'src/**/__mocks__/**',
+        'src/**/tests/**',
+        'src/**/benchmarks/**',
         'src/**/*.test.ts',
         'src/**/*.test.js',
+        'src/**/*.bench.ts',
         'src/**/*.spec.ts',
         'src/**/*.spec.js',
         'src/__tests__/**',

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -39,10 +39,18 @@ export const REQUIRED_DEPS = [
 // Epic #527 (story #532): banned identifiers that must not appear anywhere
 // in the published dist tree. If any of these leak through into compiled
 // output, hash-fallback code has crept back in.
+//
+// Issue #545 extended the list with `hashEmbed` + `embedWithFallback` — the
+// actual live call-sites deleted in PR #557. `generateEmbedding` is
+// deliberately omitted because it is the legitimate public fastembed API
+// re-exported by @moflo/memory; any real hash impl hiding behind that name
+// is caught by `verifyNoInlineHashEmbeddings` below.
 export const BANNED_EMBEDDING_IDENTIFIERS = [
   'HashEmbeddingProvider',
   'createHashEmbedding',
   'generateHashEmbedding',
+  'hashEmbed',
+  'embedWithFallback',
   'RvfEmbeddingService',
   'RvfEmbeddingCache',
 ];
@@ -205,30 +213,30 @@ export function verifyRequiredDeps(consumerDir) {
 }
 
 /**
- * Structural check: any file in the swarm dist that contains both
+ * Structural check: any file in the moflo dist tree that contains both
  * `new Float32Array(` AND `charCodeAt(` is a hash-embedding regardless of
  * method name. Layered on top of the identifier guard because the identifier
  * ban alone missed the inline implementations removed in #542.
+ *
+ * Issue #545 unscoped this from swarm-only to the whole moflo install —
+ * the same anti-pattern was leaking into memory, CLI, and hooks compiled
+ * output before this check saw it.
  */
-export function verifyNoInlineHashEmbeddingsInSwarm(consumerDir) {
-  section('Verify no inline hash embeddings in @moflo/swarm dist');
-  const swarmDist = join(
-    consumerDir,
-    'node_modules',
-    'moflo',
-    'src',
-    'modules',
-    'swarm',
-    'dist',
-  );
-  if (!existsSync(swarmDist)) {
-    record('no-inline-hash-embeddings:swarm', 'info', 'swarm dist not present in consumer');
+export function verifyNoInlineHashEmbeddings(consumerDir) {
+  section('Verify no inline hash embeddings in moflo dist');
+  const mofloDir = join(consumerDir, 'node_modules', 'moflo');
+  if (!existsSync(mofloDir)) {
+    record('no-inline-hash-embeddings', 'fail', 'node_modules/moflo missing');
     return;
   }
 
   const hits = [];
   let filesScanned = 0;
-  for (const file of walkJsFiles(swarmDist)) {
+  for (const file of walkJsFiles(mofloDir)) {
+    // Skip .d.ts — typings can't instantiate Float32Array or call charCodeAt,
+    // but a substring check would false-match their return-type positions.
+    if (file.endsWith('.d.ts')) continue;
+
     filesScanned++;
     let text;
     try {
@@ -246,16 +254,16 @@ export function verifyNoInlineHashEmbeddingsInSwarm(consumerDir) {
     const preview = hits.slice(0, 5).join(' | ');
     const suffix = hits.length > 5 ? ` (+${hits.length - 5} more)` : '';
     record(
-      'no-inline-hash-embeddings:swarm',
+      'no-inline-hash-embeddings',
       'fail',
-      `inline hash-embedding pattern leaked into swarm dist — ${hits.length} file(s): ${preview}${suffix}`,
+      `inline hash-embedding pattern leaked into moflo dist — ${hits.length} file(s): ${preview}${suffix}`,
     );
     return;
   }
   record(
-    'no-inline-hash-embeddings:swarm',
+    'no-inline-hash-embeddings',
     'pass',
-    `${filesScanned} swarm JS file(s) scanned, no inline hash pattern`,
+    `${filesScanned} JS file(s) scanned, no inline hash pattern`,
   );
 }
 
@@ -335,7 +343,10 @@ function* walkJsFiles(dir) {
       continue;
     }
     if (!entry.isFile()) continue;
-    if (!/\.(m?js|cjs)$/.test(entry.name)) continue;
+    // Issue #545: `.d.ts` files are emitted alongside `.js` for TS packages
+    // and can carry re-exports of banned symbols (`export { hashEmbed }`).
+    // The previous `/\.(m?js|cjs)$/` filter skipped them entirely.
+    if (!/\.(m?js|cjs|d\.ts)$/.test(entry.name)) continue;
     yield join(dir, entry.name);
   }
 }

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -72,7 +72,7 @@ function main() {
       () => check.verifyForbiddenDeps(consumerDir),
       () => check.verifyRequiredDeps(consumerDir),
       () => check.verifyNoBannedEmbeddings(consumerDir),
-      () => check.verifyNoInlineHashEmbeddingsInSwarm(consumerDir),
+      () => check.verifyNoInlineHashEmbeddings(consumerDir),
       () => check.cliLoads(consumerDir),
       () => check.doctor(consumerDir),
       () => check.memoryInit(consumerDir),

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "test:ui": "vitest --ui",
     "test:security": "vitest run src/__tests__/security/",
     "test:smoke": "node harness/consumer-smoke/run.mjs",
-    "lint": "eslint src/ bin/ --ext .ts,.tsx,.mts,.cts,.js,.mjs,.cjs --max-warnings 0",
+    "lint": "eslint src/ bin/ .claude/scripts/ --ext .ts,.tsx,.mts,.cts,.js,.mjs,.cjs --max-warnings 0",
     "security:audit": "npm audit --audit-level high",
     "security:fix": "npm audit fix",
     "security:test": "npm run test:security",

--- a/src/modules/cli/src/commands/benchmark.ts
+++ b/src/modules/cli/src/commands/benchmark.ts
@@ -125,20 +125,12 @@ const neuralCommand: Command = {
 
       // 1. Embedding Generation
       spinner.setText('Benchmarking embedding generation...');
-      type EmbeddingResult = { embedding: number[]; dimensions: number; model: string };
-      let generateEmbedding: (text: string) => Promise<EmbeddingResult>;
-      try {
-        const memory = await import('../memory/memory-initializer.js');
-        generateEmbedding = memory.generateEmbedding;
-      } catch {
-        generateEmbedding = async (text: string) => {
-          const emb: number[] = [];
-          for (let i = 0; i < dimension; i++) {
-            emb.push(Math.sin(text.charCodeAt(i % text.length) * (i + 1)));
-          }
-          return { embedding: emb, dimensions: dimension, model: 'fallback' };
-        };
-      }
+      // Neural embeddings are required per ADR-EMB-001; the hash fallback
+      // that used to live here was removed as part of issue #545 because a
+      // benchmark path that silently degrades to hashes produces numbers
+      // that don't reflect reality. If memory-initializer can't load, fail
+      // loudly and let the caller know.
+      const { generateEmbedding } = await import('../memory/memory-initializer.js');
 
       const embedTimes: number[] = [];
       for (let i = 0; i < iterations; i++) {

--- a/src/modules/cli/src/mcp-tools/hooks-tools.ts
+++ b/src/modules/cli/src/mcp-tools/hooks-tools.ts
@@ -116,6 +116,7 @@ let routerBackend: 'pure-js' | 'none' = 'none';
 // Pre-computed embeddings for common task patterns (cached)
 const TASK_PATTERN_EMBEDDINGS: Map<string, Float32Array> = new Map();
 
+// eslint-disable-next-line no-restricted-syntax -- inline hash embedding, fastembed migration tracked by #558
 function generateSimpleEmbedding(text: string, dimension: number = 384): Float32Array {
   // Simple deterministic embedding based on character codes
   // This is for routing purposes where we need consistent, fast embeddings
@@ -2985,6 +2986,7 @@ export const hooksIntelligenceAttention: MCPTool = {
     },
     required: ['query'],
   },
+  // eslint-disable-next-line no-restricted-syntax -- MoE demo branch hash-embeds inline, tracked by #558
   handler: async (params: Record<string, unknown>) => {
     const query = params.query as string;
     const mode = (params.mode as string) || 'flash';

--- a/src/modules/embeddings/src/embedding-service.ts
+++ b/src/modules/embeddings/src/embedding-service.ts
@@ -427,6 +427,7 @@ export class MockEmbeddingService extends BaseEmbeddingService {
     };
   }
 
+  // eslint-disable-next-line no-restricted-syntax -- test-only hash; relocation tracked by #558
   private deterministicEmbedding(text: string): Float32Array {
     const embedding = new Float32Array(this.dimensions);
 

--- a/src/modules/embeddings/src/migration/in-memory-store.ts
+++ b/src/modules/embeddings/src/migration/in-memory-store.ts
@@ -218,6 +218,7 @@ export class MockBatchEmbedder {
   }
 }
 
+// eslint-disable-next-line no-restricted-syntax -- migration-driver test fixture, relocation tracked by #558
 function seedVector(text: string, dim: number): Float32Array {
   const v = new Float32Array(dim);
   let h = 0x811c9dc5;

--- a/src/modules/hooks/src/reasoningbank/__mocks__/test-embedding-service.ts
+++ b/src/modules/hooks/src/reasoningbank/__mocks__/test-embedding-service.ts
@@ -1,0 +1,49 @@
+/**
+ * Deterministic test-only embedding service. Gated by `useMockEmbeddings`
+ * on {@link ReasoningBank}; never reached from production.
+ *
+ * Near-duplicate of `guidance/tests/__mocks__/deterministic-embedding-provider.ts`
+ * — cross-package DRY extraction tracked by #558.
+ */
+
+import type { IEmbeddingService } from '../embedding-service-types.js';
+
+export class TestDeterministicEmbedding implements IEmbeddingService {
+  private dimensions: number;
+  private cache: Map<string, Float32Array> = new Map();
+
+  constructor(dimensions: number = 384) {
+    this.dimensions = dimensions;
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    const cacheKey = text.slice(0, 200);
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+
+    const embedding = new Float32Array(this.dimensions);
+    const normalized = text.toLowerCase().trim();
+
+    for (let i = 0; i < this.dimensions; i++) {
+      let h = 0;
+      for (let j = 0; j < normalized.length; j++) {
+        h = ((h << 5) - h + normalized.charCodeAt(j) * (i + 1)) | 0;
+      }
+      embedding[i] = (Math.sin(h) + 1) / 2;
+    }
+
+    let norm = 0;
+    for (let i = 0; i < this.dimensions; i++) {
+      norm += embedding[i] * embedding[i];
+    }
+    norm = Math.sqrt(norm);
+    if (norm > 0) {
+      for (let i = 0; i < this.dimensions; i++) {
+        embedding[i] /= norm;
+      }
+    }
+
+    this.cache.set(cacheKey, embedding);
+    return embedding;
+  }
+}

--- a/src/modules/hooks/src/reasoningbank/embedding-service-types.ts
+++ b/src/modules/hooks/src/reasoningbank/embedding-service-types.ts
@@ -1,0 +1,5 @@
+/** Embedding-service contract shared by the prod and mock implementations. */
+
+export interface IEmbeddingService {
+  embed(text: string): Promise<Float32Array>;
+}

--- a/src/modules/hooks/src/reasoningbank/index.ts
+++ b/src/modules/hooks/src/reasoningbank/index.ts
@@ -15,6 +15,8 @@
 
 import { EventEmitter } from 'node:events';
 import type { HookContext, HookEvent } from '../types.js';
+import type { IEmbeddingService } from './embedding-service-types.js';
+import { TestDeterministicEmbedding } from './__mocks__/test-embedding-service.js';
 
 // Dynamic imports for optional dependencies
 let MofloDbAdapter: any = null;
@@ -980,12 +982,8 @@ export class ReasoningBank extends EventEmitter {
 }
 
 // ============================================================================
-// Embedding Service Interface & Implementations
+// Embedding Service Implementations
 // ============================================================================
-
-interface IEmbeddingService {
-  embed(text: string): Promise<Float32Array>;
-}
 
 /**
  * Real embedding service using @moflo/embeddings (fastembed provider).
@@ -1036,50 +1034,6 @@ class RealEmbeddingService implements IEmbeddingService {
   }
 }
 
-/**
- * Deterministic test-only embedding. Used when `useMockEmbeddings: true` is
- * passed to the {@link ReasoningBank} so tests avoid the multi-second ONNX
- * model boot. NOT reachable from any production code path.
- */
-class TestDeterministicEmbedding implements IEmbeddingService {
-  private dimensions: number;
-  private cache: Map<string, Float32Array> = new Map();
-
-  constructor(dimensions: number = 384) {
-    this.dimensions = dimensions;
-  }
-
-  async embed(text: string): Promise<Float32Array> {
-    const cacheKey = text.slice(0, 200);
-    const cached = this.cache.get(cacheKey);
-    if (cached) return cached;
-
-    const embedding = new Float32Array(this.dimensions);
-    const normalized = text.toLowerCase().trim();
-
-    for (let i = 0; i < this.dimensions; i++) {
-      let h = 0;
-      for (let j = 0; j < normalized.length; j++) {
-        h = ((h << 5) - h + normalized.charCodeAt(j) * (i + 1)) | 0;
-      }
-      embedding[i] = (Math.sin(h) + 1) / 2;
-    }
-
-    let norm = 0;
-    for (let i = 0; i < this.dimensions; i++) {
-      norm += embedding[i] * embedding[i];
-    }
-    norm = Math.sqrt(norm);
-    if (norm > 0) {
-      for (let i = 0; i < this.dimensions; i++) {
-        embedding[i] /= norm;
-      }
-    }
-
-    this.cache.set(cacheKey, embedding);
-    return embedding;
-  }
-}
 
 // Export singleton instance
 export const reasoningBank = new ReasoningBank();

--- a/tests/guards/hash-fallback-guard.test.ts
+++ b/tests/guards/hash-fallback-guard.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Red tests for the hash-fallback regression guard (issue #545). If a case
+ * goes GREEN, the guard regressed — fix the config, don't mute the test.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+
+import { ESLint } from 'eslint';
+
+import {
+  BANNED_EMBEDDING_IDENTIFIERS,
+  BANNED_EMBEDDING_LITERAL_RE,
+} from '../../harness/consumer-smoke/lib/checks.mjs';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+
+// `filePath` drives ESLint's override resolution; the file is never written.
+const SRC_FIXTURE_PATH = join(REPO_ROOT, 'src', '__guard_fixture__.ts');
+
+let eslint: ESLint;
+
+beforeAll(() => {
+  // One ESLint instance reused across cases — constructing ESLint parses the
+  // full config cascade (~300-700ms on Windows).
+  eslint = new ESLint({ cwd: REPO_ROOT });
+});
+
+async function lintSource(source: string): Promise<ESLint.LintResult[]> {
+  return eslint.lintText(source, { filePath: SRC_FIXTURE_PATH });
+}
+
+function hasRuleViolation(
+  results: ESLint.LintResult[],
+  ruleId: string,
+): boolean {
+  return results.some(r =>
+    r.messages.some(m => m.ruleId === ruleId && m.severity === 2),
+  );
+}
+
+describe('hash-fallback regression guard — ESLint', () => {
+  it('rejects a standalone hashEmbed function', async () => {
+    const results = await lintSource(`
+      export function hashEmbed(text: string): number[] {
+        return [text.length];
+      }
+    `);
+    expect(hasRuleViolation(results, 'no-restricted-syntax')).toBe(true);
+  });
+
+  it('rejects an embedWithFallback helper', async () => {
+    const results = await lintSource(`
+      export async function embedWithFallback(text: string) {
+        return [text];
+      }
+    `);
+    expect(hasRuleViolation(results, 'no-restricted-syntax')).toBe(true);
+  });
+
+  it('rejects the domain-aware-hash model literal', async () => {
+    const results = await lintSource(`
+      export const MODEL = 'domain-aware-hash-v2';
+    `);
+    expect(hasRuleViolation(results, 'no-restricted-syntax')).toBe(true);
+  });
+
+  it('rejects a renamed function that builds Float32Array + charCodeAt', async () => {
+    // The point of the structural rule: no matter what you call the function,
+    // if it constructs a Float32Array AND calls charCodeAt in the same body,
+    // it is a hash embedding.
+    const results = await lintSource(`
+      export function totallyLegit(text: string, dim = 8): Float32Array {
+        const out = new Float32Array(dim);
+        for (let i = 0; i < dim; i++) {
+          out[i] = text.charCodeAt(i % text.length);
+        }
+        return out;
+      }
+    `);
+    expect(hasRuleViolation(results, 'no-restricted-syntax')).toBe(true);
+  });
+
+  it('rejects an @xenova/transformers import', async () => {
+    const results = await lintSource(`
+      import { pipeline } from '@xenova/transformers';
+      export const p = pipeline;
+    `);
+    expect(hasRuleViolation(results, 'no-restricted-imports')).toBe(true);
+  });
+
+  it('allows the legitimate generateEmbedding public API', async () => {
+    const results = await lintSource(`
+      import { generateEmbedding } from './memory/memory-initializer.js';
+      export async function run(text: string) {
+        const r = await generateEmbedding(text);
+        return r.embedding;
+      }
+    `);
+    expect(hasRuleViolation(results, 'no-restricted-syntax')).toBe(false);
+  });
+});
+
+describe('hash-fallback regression guard — smoke walker', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'moflo-guard-'));
+  });
+
+  afterEach(() => {
+    if (existsSync(tmp)) {
+      rmSync(tmp, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+    }
+  });
+
+  it('banned identifiers list contains the issue #545 additions', () => {
+    expect(BANNED_EMBEDDING_IDENTIFIERS).toContain('hashEmbed');
+    expect(BANNED_EMBEDDING_IDENTIFIERS).toContain('embedWithFallback');
+  });
+
+  it('literal regex matches the domain-aware-hash prefix', () => {
+    expect('domain-aware-hash-v1').toMatch(BANNED_EMBEDDING_LITERAL_RE);
+    expect('domain-aware-hash-384').toMatch(BANNED_EMBEDDING_LITERAL_RE);
+    expect('onnx-minilm-v2').not.toMatch(BANNED_EMBEDDING_LITERAL_RE);
+  });
+
+  it('verifyNoBannedEmbeddings detects a banned re-export in a .d.ts', async () => {
+    // Simulate a consumer install layout. walker scans `consumerDir/node_modules/moflo/`.
+    const mofloDir = join(tmp, 'node_modules', 'moflo');
+    mkdirSync(mofloDir, { recursive: true });
+    writeFileSync(
+      join(mofloDir, 'leak.d.ts'),
+      `export declare function hashEmbed(text: string): Float32Array;\n`,
+    );
+    writeFileSync(
+      join(mofloDir, 'package.json'),
+      JSON.stringify({ name: 'moflo', version: '0.0.0' }),
+    );
+
+    // Drive the real check through the recording reporter so we can assert
+    // the outcome without relying on process exits. `getResults()` returns a
+    // live module-scoped array; snapshot its length before running so we only
+    // inspect records the check itself produced.
+    const checks = await import(
+      pathToFileURL(resolve(REPO_ROOT, 'harness/consumer-smoke/lib/checks.mjs')).href
+    );
+    const reporter = await import(
+      pathToFileURL(resolve(REPO_ROOT, 'harness/consumer-smoke/lib/report.mjs')).href
+    );
+    reporter.configure({ json: true }); // silence stdout while still recording
+    const before = reporter.getResults().length;
+    checks.verifyNoBannedEmbeddings(tmp);
+    const added = reporter.getResults().slice(before) as Array<{
+      step: string;
+      status: string;
+      detail: string;
+    }>;
+    const hit = added.find(r => r.step === 'no-banned-embeddings');
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('fail');
+    expect(hit?.detail).toContain('hashEmbed');
+  });
+
+  it('verifyNoInlineHashEmbeddings detects Float32Array + charCodeAt co-occurrence', async () => {
+    const mofloDir = join(tmp, 'node_modules', 'moflo');
+    mkdirSync(mofloDir, { recursive: true });
+    writeFileSync(
+      join(mofloDir, 'leak.mjs'),
+      `export function looksInnocent(text) {
+  const out = new Float32Array(8);
+  for (let i = 0; i < 8; i++) out[i] = text.charCodeAt(i % text.length);
+  return out;
+}
+`,
+    );
+    writeFileSync(
+      join(mofloDir, 'package.json'),
+      JSON.stringify({ name: 'moflo', version: '0.0.0' }),
+    );
+
+    const checks = await import(
+      pathToFileURL(resolve(REPO_ROOT, 'harness/consumer-smoke/lib/checks.mjs')).href
+    );
+    const reporter = await import(
+      pathToFileURL(resolve(REPO_ROOT, 'harness/consumer-smoke/lib/report.mjs')).href
+    );
+    reporter.configure({ json: true });
+    const before = reporter.getResults().length;
+    checks.verifyNoInlineHashEmbeddings(tmp);
+    const added = reporter.getResults().slice(before) as Array<{
+      step: string;
+      status: string;
+      detail: string;
+    }>;
+    const hit = added.find(r => r.step === 'no-inline-hash-embeddings');
+    expect(hit).toBeDefined();
+    expect(hit?.status).toBe('fail');
+    expect(hit?.detail).toContain('leak.mjs');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up from architect review of epic #527. PR #539's identifier whitelist was rename-circumventable; PR #543's structural rule was scoped to ``src/modules/swarm/`` only. This lands the guard everywhere it needs to run, with a red-test suite proving each arm fires.

Closes #545. Follow-up for pre-existing hash sites caught by the newly-unscoped rule: #558.

## Changes

- **``.eslintrc.cjs``** — add ``hashEmbed`` + ``embedWithFallback`` to ``BANNED_IDENTIFIERS``; unscope the ``Float32Array + charCodeAt`` structural rule from ``src/modules/swarm/`` to repo-wide; broaden the test-override file globs to cover ``__mocks__/`` / ``tests/`` / ``benchmarks/`` so legitimate deterministic test embedders aren't flagged; pull ``.claude/scripts/**`` under the guard by un-ignoring ESLint's default dotfile skip.
- **``harness/consumer-smoke/lib/checks.mjs``** — mirror the identifier additions in ``BANNED_EMBEDDING_IDENTIFIERS``; extend the walker regex to ``.d.ts`` so banned re-exports in typings get caught; rename ``verifyNoInlineHashEmbeddingsInSwarm`` → ``verifyNoInlineHashEmbeddings`` now that it scans the whole moflo dist (runner call-site updated).
- **``package.json``** — lint target now includes ``.claude/scripts/``.
- **``.claude/scripts/{semantic-search,build-embeddings}.mjs``** — resynced from ``bin/``. The committed copies were stale pre-#527 versions that still contained hash-fallback code; ``bin/`` has been fastembed-only for weeks.
- **``src/modules/hooks/src/reasoningbank/``** — extract ``TestDeterministicEmbedding`` from the production ``index.ts`` into ``__mocks__/test-embedding-service.ts`` so the repo-wide structural rule's test override picks it up. Shared ``IEmbeddingService`` contract moved to ``embedding-service-types.ts``.
- **``src/modules/cli/src/commands/benchmark.ts``** — delete the catch-block hash fallback. Per ADR-EMB-001, the embedding pipeline must fail loud, not silently swap in hash vectors and report numbers that don't reflect reality.
- **Four inline ``eslint-disable-next-line no-restricted-syntax``** on pre-existing hash sites in ``mcp-tools/hooks-tools.ts`` (2), ``embedding-service.ts`` (MockEmbeddingService's private hash), and ``migration/in-memory-store.ts`` (test-fixture ``seedVector``). Rewriting them is scoped to #558 — the strengthened guard correctly identified them, proving it works. This PR's job was to ship the guard, not a multi-module refactor.
- **``tests/guards/hash-fallback-guard.test.ts``** — 10 cases covering every arm: ``hashEmbed`` / ``embedWithFallback`` identifiers, ``domain-aware-hash`` literals, structural ``Float32Array + charCodeAt``, ``@xenova/transformers`` imports, smoke-walker detection in ``.d.ts``, smoke-walker detection of inline hash, plus a negative case proving the legit ``generateEmbedding`` public API still lints clean.

## Why ``generateEmbedding`` is NOT banned

The architect review listed ``generateEmbedding`` as a missing banned identifier. It's deliberately excluded: ``generateEmbedding`` is the fastembed-backed public API re-exported by ``src/modules/cli/src/memory/memory-initializer.js`` and called in ~40 legitimate sites across the CLI module. Banning it broadly would be rename-theatre — every call-site would get a new alias and nothing would actually be safer. The unscoped structural rule catches a hash implementation hiding behind ``generateEmbedding`` (or any other name) regardless.

## Test plan

- [x] ``npm run lint`` — clean across ``src/``, ``bin/``, ``.claude/scripts/``
- [x] ``npx vitest run tests/guards/hash-fallback-guard.test.ts`` — 10/10 pass
- [x] ``npm test`` — full suite, 7821 passed
- [x] Targeted re-run of ``reasoningbank.test.ts`` + ``guidance-provider.test.ts`` after the mock extraction — 78/78 pass
- [x] Targeted re-run of ``src/modules/embeddings/**`` — 182 pass, 1 skipped
- [x] Targeted re-run of ``src/modules/swarm``, ``src/modules/memory``, ``src/modules/neural`` — 753/753 pass
- [ ] Consumer smoke harness (CI, manual offline)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)