### PR TITLE
fix(embeddings): wire migration to session-start + fix v3 schema mismatch

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -399,6 +399,36 @@ try {
   }
 } catch { /* non-fatal — flo still works via npx */ }
 
+// ── 3e. Foreground embeddings migration (visible UX) ───────────────────────
+// Run the embeddings-version migration synchronously with piped stdio BEFORE
+// we fire off background tasks, so the UpgradeRenderer's TTY bar / non-TTY
+// status lines reach the user. Returns fast when no DB exists, the schema
+// predates v3, or the stored version is already current — so the happy-path
+// cost on every session start is a few ms of probe work.
+try {
+  const migrationPaths = [
+    resolve(projectRoot, 'node_modules/moflo/src/modules/cli/dist/src/services/embeddings-migration.js'),
+    resolve(projectRoot, 'src/modules/cli/dist/src/services/embeddings-migration.js'),
+  ];
+  const migrationPath = migrationPaths.find((p) => existsSync(p));
+  if (migrationPath) {
+    const mod = await import(`file://${migrationPath.replace(/\\/g, '/')}`);
+    if (typeof mod.runEmbeddingsMigrationIfNeeded === 'function') {
+      await mod.runEmbeddingsMigrationIfNeeded({
+        out: process.stderr,
+        isTTY: Boolean(process.stderr.isTTY),
+      });
+    }
+  }
+} catch (err) {
+  // Non-fatal — a failed/aborted migration must not block session start. The
+  // driver persists its cursor so the next session picks up where we left off.
+  try {
+    const msg = err && err.message ? err.message : String(err);
+    process.stderr.write(`embeddings migration check skipped: ${msg}\n`);
+  } catch { /* writing the failure itself must not throw */ }
+}
+
 // ── 4. Spawn background tasks ───────────────────────────────────────────────
 const localCli = resolve(projectRoot, 'node_modules/moflo/src/modules/cli/bin/cli.js');
 const hasLocalCli = existsSync(localCli);

--- a/src/modules/cli/__tests__/services/embeddings-migration.test.ts
+++ b/src/modules/cli/__tests__/services/embeddings-migration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for `runEmbeddingsMigrationIfNeeded`.
+ *
+ * Covers the probe behaviour added for #547 — specifically that the migration
+ * only runs against DBs whose `memory_entries` table carries every column the
+ * driver reads or writes. A DB with just `embedding` but no `content` or
+ * `embedding_dimensions` used to pass the old probe and then throw mid-run.
+ */
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runEmbeddingsMigrationIfNeeded } from '../../src/services/embeddings-migration.js';
+
+type SqlJsDb = {
+  run(sql: string, params?: unknown[]): void;
+  export(): Uint8Array;
+  close(): void;
+};
+type SqlJsStatic = { Database: new (data?: Uint8Array) => SqlJsDb };
+
+let SQL: SqlJsStatic;
+
+beforeAll(async () => {
+  const initSqlJs = (await import('sql.js')).default;
+  SQL = (await initSqlJs()) as SqlJsStatic;
+});
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true });
+    } catch {
+      /* non-fatal — Windows occasionally holds file handles */
+    }
+  }
+});
+
+async function makeTmpDb(schema: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moflo-migration-'));
+  tmpDirs.push(dir);
+  const dbPath = join(dir, 'memory.db');
+  const db = new SQL.Database();
+  db.run(schema);
+  const bytes = db.export();
+  db.close();
+  await writeFile(dbPath, Buffer.from(bytes));
+  return dbPath;
+}
+
+describe('runEmbeddingsMigrationIfNeeded', () => {
+  it('returns false when the DB file does not exist', async () => {
+    const ran = await runEmbeddingsMigrationIfNeeded({
+      dbPath: join(tmpdir(), 'moflo-missing-', 'nope.db'),
+    });
+    expect(ran).toBe(false);
+  });
+
+  it('returns false for a DB lacking the v3 `content` column', async () => {
+    // Legacy schema: had `value` instead of `content`. The old probe only
+    // checked `embedding` and passed — then crashed on SELECT value. Now
+    // the probe requires the full v3 column set, so we skip cleanly.
+    const dbPath = await makeTmpDb(`
+      CREATE TABLE memory_entries (
+        id TEXT PRIMARY KEY,
+        key TEXT,
+        value TEXT,
+        embedding BLOB,
+        dimensions INTEGER
+      );
+    `);
+    expect(existsSync(dbPath)).toBe(true);
+    const ran = await runEmbeddingsMigrationIfNeeded({ dbPath });
+    expect(ran).toBe(false);
+  });
+
+  it('returns false for a DB lacking embedding_dimensions', async () => {
+    const dbPath = await makeTmpDb(`
+      CREATE TABLE memory_entries (
+        id TEXT PRIMARY KEY,
+        key TEXT,
+        content TEXT NOT NULL,
+        embedding TEXT
+      );
+    `);
+    const ran = await runEmbeddingsMigrationIfNeeded({ dbPath });
+    expect(ran).toBe(false);
+  });
+
+  it('returns false when no memory_entries table exists at all', async () => {
+    const dbPath = await makeTmpDb(`
+      CREATE TABLE unrelated (id TEXT PRIMARY KEY, value TEXT);
+    `);
+    const ran = await runEmbeddingsMigrationIfNeeded({ dbPath });
+    expect(ran).toBe(false);
+  });
+});

--- a/src/modules/cli/__tests__/services/sqljs-migration-store-v3.test.ts
+++ b/src/modules/cli/__tests__/services/sqljs-migration-store-v3.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Integration test — SqlJsMemoryEntriesStore against the real `MEMORY_SCHEMA_V3`
+ *
+ * Issue #547: the previous store adapter queried `value` and wrote
+ * `dimensions` / `Buffer` BLOB, but v3 schema uses `content`,
+ * `embedding_dimensions`, and JSON TEXT. The probe guard in
+ * `embeddings-migration.ts` passed because the `embedding` column does exist,
+ * so migrations ran and threw at runtime. This test runs the full driver
+ * against a DB built from the exact schema constant that production uses,
+ * so schema drift is caught at test time.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import {
+  EMBEDDINGS_VERSION,
+  MockBatchEmbedder,
+  migrateStore,
+} from '../../../embeddings/src/migration/index.js';
+import { SqlJsMemoryEntriesStore } from '../../src/services/sqljs-migration-store.js';
+import { MEMORY_SCHEMA_V3 } from '../../src/memory/memory-initializer.js';
+
+// ── sql.js bootstrap ────────────────────────────────────────────────────────
+type SqlJsStatic = {
+  Database: new (data?: Uint8Array) => SqlJsDb;
+};
+type SqlJsDb = {
+  prepare(sql: string): {
+    bind(params: unknown[]): boolean;
+    step(): boolean;
+    get(): unknown[];
+    getAsObject(): Record<string, unknown>;
+    free(): void;
+    run(params?: unknown[]): void;
+  };
+  run(sql: string, params?: unknown[]): void;
+  exec(sql: string): Array<{ columns: string[]; values: unknown[][] }>;
+  close(): void;
+};
+
+let SQL: SqlJsStatic;
+
+beforeAll(async () => {
+  const initSqlJs = (await import('sql.js')).default;
+  SQL = (await initSqlJs()) as SqlJsStatic;
+});
+
+function freshV3Db(): SqlJsDb {
+  const db = new SQL.Database();
+  // Apply the real production schema. If this DDL ever changes in a way that
+  // breaks the migration store, this test fails loud.
+  db.run(MEMORY_SCHEMA_V3);
+  return db;
+}
+
+function insertEntry(db: SqlJsDb, id: string, content: string): void {
+  db.run(
+    `INSERT INTO memory_entries (id, key, content) VALUES (?, ?, ?)`,
+    [id, `k-${id}`, content],
+  );
+}
+
+function selectEmbeddingRow(
+  db: SqlJsDb,
+  id: string,
+): { embedding: string | null; dims: number | null } {
+  const res = db.exec(
+    `SELECT embedding, embedding_dimensions FROM memory_entries WHERE id = '${id.replace(/'/g, "''")}'`,
+  );
+  const row = res[0]?.values[0];
+  if (!row) return { embedding: null, dims: null };
+  return {
+    embedding: row[0] === null ? null : String(row[0]),
+    dims: row[1] === null ? null : Number(row[1]),
+  };
+}
+
+describe('SqlJsMemoryEntriesStore against MEMORY_SCHEMA_V3', () => {
+  it('counts rows using the v3 `content` column, not the defunct `value`', async () => {
+    const db = freshV3Db();
+    insertEntry(db, 'a', 'hello world');
+    insertEntry(db, 'b', 'goodbye');
+    // An empty content row must not be counted — matches iteration behaviour.
+    db.run(
+      `INSERT INTO memory_entries (id, key, content) VALUES ('empty', 'k-empty', '')`,
+    );
+
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db');
+    expect(await store.countItems()).toBe(2);
+    db.close();
+  });
+
+  it('iterItems pulls sourceText from the v3 `content` column', async () => {
+    const db = freshV3Db();
+    insertEntry(db, 'a', 'alpha');
+    insertEntry(db, 'b', 'beta');
+
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db');
+    const rows = await store.iterItems(null, 10);
+    expect(rows.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(rows.map((r) => r.sourceText)).toEqual(['alpha', 'beta']);
+    db.close();
+  });
+
+  it('updateBatch writes JSON embeddings and embedding_dimensions', async () => {
+    const db = freshV3Db();
+    insertEntry(db, 'a', 'hello');
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db');
+
+    const emb = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    await store.updateBatch([{ id: 'a', embedding: emb }]);
+
+    const { embedding, dims } = selectEmbeddingRow(db, 'a');
+    expect(dims).toBe(4);
+    // Must be JSON text (parseable as number[]) — the production `embeddings
+    // search` path does JSON.parse on this column, so BLOB would crash it.
+    expect(typeof embedding).toBe('string');
+    const parsed = JSON.parse(embedding!);
+    expect(parsed).toHaveLength(4);
+    expect(parsed[0]).toBeCloseTo(0.1, 6);
+    expect(parsed[3]).toBeCloseTo(0.4, 6);
+    db.close();
+  });
+
+  it('end-to-end: migrateStore re-embeds every row in a v3 DB', async () => {
+    const db = freshV3Db();
+    for (let i = 0; i < 5; i++) {
+      insertEntry(db, `id-${i}`, `item-${i}`);
+    }
+
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db');
+    const embedder = new MockBatchEmbedder(8);
+
+    const result = await migrateStore({ store, embedder, batchSize: 2 });
+
+    expect(result.success).toBe(true);
+    expect(result.itemsMigrated).toBe(5);
+    expect(result.versionBumped).toBe(true);
+    expect(await store.getVersion()).toBe(EMBEDDINGS_VERSION);
+
+    // Every row has a JSON embedding of the expected dimension.
+    for (let i = 0; i < 5; i++) {
+      const { embedding, dims } = selectEmbeddingRow(db, `id-${i}`);
+      expect(dims).toBe(8);
+      const parsed = JSON.parse(embedding!) as number[];
+      expect(parsed).toHaveLength(8);
+    }
+    db.close();
+  });
+
+  it('cursor round-trips through migration_cursor (resume-safety)', async () => {
+    const db = freshV3Db();
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db');
+
+    expect(await store.loadCursor()).toBeNull();
+
+    await store.saveCursor({
+      storeId: store.storeId,
+      lastProcessedId: 'id-0042',
+      itemsDone: 42,
+      itemsTotal: 100,
+      startedAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_500,
+    });
+
+    const loaded = await store.loadCursor();
+    expect(loaded?.itemsDone).toBe(42);
+    expect(loaded?.lastProcessedId).toBe('id-0042');
+
+    await store.clearCursor();
+    expect(await store.loadCursor()).toBeNull();
+    db.close();
+  });
+
+  it('setVersion/getVersion round-trip via shared metadata table', async () => {
+    const db = freshV3Db();
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db');
+
+    expect(await store.getVersion()).toBeNull();
+    await store.setVersion(7);
+    expect(await store.getVersion()).toBe(7);
+    // Upserts, never duplicates.
+    await store.setVersion(9);
+    expect(await store.getVersion()).toBe(9);
+    db.close();
+  });
+});

--- a/src/modules/cli/src/commands/embeddings.ts
+++ b/src/modules/cli/src/commands/embeddings.ts
@@ -16,6 +16,7 @@
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { mofloImport } from '../services/moflo-require.js';
+import { runEmbeddingsMigrationIfNeeded } from '../services/embeddings-migration.js';
 
 // Dynamic imports for embeddings package (optional — may not be installed)
 async function getEmbeddings() {
@@ -23,120 +24,6 @@ async function getEmbeddings() {
     return await import('@moflo/embeddings');
   } catch {
     return null;
-  }
-}
-
-/**
- * Run the embeddings-version upgrade on the given DB when its stored version
- * is below the current runtime version. Safe to call on every session start
- * — returns fast when the DB is already up-to-date or when @moflo/embeddings
- * isn't installed.
- *
- * The story-2 driver (`runUpgrade`) and story-3 UX are wired here. The
- * concrete `MigrationStore` adapter for moflo's memory.db schema lives in
- * `services/sqljs-migration-store.ts`.
- */
-async function runEmbeddingsMigrationIfNeeded(options: {
-  dbPath?: string;
-  verbose?: boolean;
-}): Promise<boolean> {
-  const fs = await import('fs');
-  const path = await import('path');
-
-  const dbPath = path.resolve(options.dbPath ?? path.join(process.cwd(), '.swarm', 'memory.db'));
-  if (!fs.existsSync(dbPath)) return false;
-
-  const embeddings = await getEmbeddings();
-  if (!embeddings) return false;
-
-  const initSqlJs = (await mofloImport('sql.js'))?.default;
-  if (!initSqlJs) return false;
-
-  const SQL = await initSqlJs();
-  const buffer = fs.readFileSync(dbPath);
-  const db = new SQL.Database(buffer);
-
-  // Quick probe: does this DB carry embedding data at all? If not, skip.
-  const hasEmbeddingsTable = tableHasColumn(db, 'memory_entries', 'embedding');
-  if (!hasEmbeddingsTable) {
-    db.close();
-    return false;
-  }
-
-  const { SqlJsMemoryEntriesStore } = await import(
-    '../services/sqljs-migration-store.js'
-  );
-  const store = new SqlJsMemoryEntriesStore(db, path.basename(dbPath));
-
-  const currentVersion = await store.getVersion();
-  const targetVersion = (embeddings as { EMBEDDINGS_VERSION: number }).EMBEDDINGS_VERSION;
-  if (currentVersion !== null && currentVersion >= targetVersion) {
-    db.close();
-    return false;
-  }
-
-  const service = (embeddings as {
-    createEmbeddingService: (c: unknown) => {
-      embedBatch(texts: string[]): Promise<{ embeddings: Array<Float32Array | number[]> }>;
-    };
-  }).createEmbeddingService({
-    provider: 'fastembed',
-    dimensions: 384,
-  });
-
-  const runUpgrade = (embeddings as {
-    runUpgrade: (opts: unknown) => Promise<{ status: string; errors: readonly string[] }>;
-  }).runUpgrade;
-
-  const summary = await runUpgrade({
-    plan: {
-      steps: [
-        {
-          label: 'Re-index memory so search can find things again',
-          store,
-          embedder: {
-            async embedBatch(texts: string[]): Promise<Float32Array[]> {
-              const result = await service.embedBatch(texts);
-              return result.embeddings.map(vec =>
-                vec instanceof Float32Array ? vec : new Float32Array(vec),
-              );
-            },
-          },
-        },
-      ],
-    },
-  });
-
-  if (summary.status === 'completed') {
-    const exported = db.export();
-    fs.writeFileSync(dbPath, Buffer.from(exported));
-  }
-  db.close();
-
-  return summary.status === 'completed';
-}
-
-/** Return true if the given table has the given column. */
-function tableHasColumn(db: unknown, table: string, column: string): boolean {
-  try {
-    const stmt = (db as { prepare(sql: string): {
-      step(): boolean;
-      get(): unknown[];
-      free(): void;
-    } }).prepare(`PRAGMA table_info(${JSON.stringify(table).slice(1, -1)})`);
-    let hit = false;
-    while (stmt.step()) {
-      const row = stmt.get();
-      // PRAGMA table_info returns [cid, name, type, notnull, dflt_value, pk]
-      if (Array.isArray(row) && row[1] === column) {
-        hit = true;
-        break;
-      }
-    }
-    stmt.free();
-    return hit;
-  } catch {
-    return false;
   }
 }
 
@@ -766,6 +653,19 @@ const indexCommand: Command = {
   },
 };
 
+// Call the migration service, turning any failure into a warning instead of an
+// exit code. Used from both the "config already exists" and normal init paths
+// so the error surface stays consistent.
+async function safelyRunEmbeddingsMigration(dbPath?: string): Promise<boolean> {
+  try {
+    return await runEmbeddingsMigrationIfNeeded(dbPath ? { dbPath } : {});
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    output.printWarning(`Embeddings migration check failed: ${msg}`);
+    return false;
+  }
+}
+
 // Init subcommand - Initialize ONNX models and hyperbolic config
 const initCommand: Command = {
   name: 'init',
@@ -812,13 +712,19 @@ const initCommand: Command = {
       const modelDir = path.join(configDir, 'models');
       const configPath = path.join(configDir, 'embeddings.json');
 
-      // Check for existing config
-      if (fs.existsSync(configPath) && !force) {
-        output.printWarning('Embeddings already initialized');
-        output.printInfo(`Config exists: ${configPath}`);
-        output.writeln();
-        output.writeln(output.dim('Use --force to overwrite existing configuration'));
-        return { success: false, exitCode: 1 };
+      // Second-session path: config already exists. Skip download / rewrite,
+      // but still run the migration check so users upgrading moflo mid-project
+      // get their embeddings re-indexed. Migration is idempotent, resumable,
+      // and fast when already at target version.
+      const configAlreadyExisted = fs.existsSync(configPath);
+      if (configAlreadyExisted && !force) {
+        output.printInfo(`Embeddings config already present: ${configPath}`);
+        output.writeln(output.dim('Checking if memory DBs need re-embedding...'));
+        const ran = await safelyRunEmbeddingsMigration();
+        if (ran) {
+          output.printSuccess('Memory DB re-embedded to current version');
+        }
+        return { success: true, data: { reused: true, configPath } };
       }
 
       const spinner = output.createSpinner({ text: 'Initializing...', spinner: 'dots' });
@@ -876,12 +782,7 @@ const initCommand: Command = {
       // Auto-migrate existing memory DBs whose embeddings_version < current. The
       // migration driver is resumable and idempotent, so running it on every
       // init is safe and keeps upgrades seamless — no separate command required.
-      try {
-        await runEmbeddingsMigrationIfNeeded({ verbose: false });
-      } catch (migrationError) {
-        const msg = migrationError instanceof Error ? migrationError.message : String(migrationError);
-        output.printWarning(`Embeddings migration check failed: ${msg}`);
-      }
+      await safelyRunEmbeddingsMigration();
 
       output.writeln();
       output.printTable({
@@ -1814,9 +1715,8 @@ const migrateCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const dbPath = (ctx.flags.db as string) || '.swarm/memory.db';
-    const verbose = ctx.flags.verbose === true;
     try {
-      const ran = await runEmbeddingsMigrationIfNeeded({ dbPath, verbose });
+      const ran = await runEmbeddingsMigrationIfNeeded({ dbPath });
       return { success: true, data: { ran } };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/src/modules/cli/src/services/embeddings-migration.ts
+++ b/src/modules/cli/src/services/embeddings-migration.ts
@@ -1,0 +1,159 @@
+/**
+ * Idempotent embeddings-version migration for moflo's memory.db.
+ *
+ * Runs the story-2 driver (`runUpgrade`) with the story-3 UX on any DB whose
+ * stored `embeddings_version` is below the current runtime version. Safe to
+ * call on every session start — returns fast when the DB is already
+ * up-to-date or when `@moflo/embeddings` / `sql.js` aren't installed.
+ *
+ * Lives in `services/` so it has no dependency on the CLI command machinery.
+ * That lets `bin/session-start-launcher.mjs` dynamic-import it and run the
+ * migration in foreground with piped stdio — so the renderer's TTY bar /
+ * non-TTY status lines actually reach the user.
+ *
+ * @module @moflo/cli/services/embeddings-migration
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { mofloImport } from './moflo-require.js';
+
+export interface RunEmbeddingsMigrationOptions {
+  /** Path to the memory DB. Defaults to `<cwd>/.swarm/memory.db`. */
+  dbPath?: string;
+  /** Output stream for the renderer. Defaults to `process.stderr`. */
+  out?: NodeJS.WritableStream & { isTTY?: boolean };
+  /** Force TTY mode regardless of `out.isTTY`. */
+  isTTY?: boolean;
+}
+
+/**
+ * Run the migration if and only if it's needed.
+ *
+ * Returns `true` when the driver completed with status `'completed'` and
+ * wrote the new embeddings back to the DB file. Returns `false` in every
+ * other case — no DB found, embeddings package missing, DB schema lacks
+ * embedding columns, already at target version, or the driver aborted /
+ * failed mid-run. Errors propagate to the caller.
+ */
+export async function runEmbeddingsMigrationIfNeeded(
+  options: RunEmbeddingsMigrationOptions = {},
+): Promise<boolean> {
+  const fs = await import('fs');
+  const path = await import('path');
+
+  const dbPath = path.resolve(
+    options.dbPath ?? path.join(process.cwd(), '.swarm', 'memory.db'),
+  );
+  if (!fs.existsSync(dbPath)) return false;
+
+  let embeddings: unknown;
+  try {
+    embeddings = await import('@moflo/embeddings');
+  } catch {
+    return false;
+  }
+
+  const initSqlJs = (await mofloImport('sql.js'))?.default;
+  if (!initSqlJs) return false;
+
+  const SQL = await initSqlJs();
+  const buffer = fs.readFileSync(dbPath);
+  const db = new SQL.Database(buffer);
+
+  try {
+    // Probe: only migrate DBs that carry the v3 memory_entries schema. The
+    // old `embedding` column alone isn't enough — the migration writes back
+    // `content` and `embedding_dimensions`, so those must exist too, or the
+    // SELECT / UPDATE will throw at runtime.
+    if (!hasV3MemorySchema(db)) {
+      return false;
+    }
+
+    const { SqlJsMemoryEntriesStore } = await import('./sqljs-migration-store.js');
+    const store = new SqlJsMemoryEntriesStore(db, path.basename(dbPath));
+
+    const currentVersion = await store.getVersion();
+    const targetVersion = (embeddings as { EMBEDDINGS_VERSION: number }).EMBEDDINGS_VERSION;
+    if (currentVersion !== null && currentVersion >= targetVersion) {
+      return false;
+    }
+
+    const service = (embeddings as {
+      createEmbeddingService: (c: unknown) => {
+        embedBatch(texts: string[]): Promise<{ embeddings: Array<Float32Array | number[]> }>;
+      };
+    }).createEmbeddingService({
+      provider: 'fastembed',
+      dimensions: 384,
+    });
+
+    const runUpgrade = (embeddings as {
+      runUpgrade: (opts: unknown) => Promise<{ status: string; errors: readonly string[] }>;
+    }).runUpgrade;
+
+    const out = options.out ?? process.stderr;
+    const isTTY = options.isTTY ?? (out as { isTTY?: boolean }).isTTY ?? false;
+
+    const summary = await runUpgrade({
+      out,
+      isTTY,
+      plan: {
+        steps: [
+          {
+            label: 'Re-index memory so search can find things again',
+            store,
+            embedder: {
+              async embedBatch(texts: string[]): Promise<Float32Array[]> {
+                const result = await service.embedBatch(texts);
+                return result.embeddings.map((vec) =>
+                  vec instanceof Float32Array ? vec : new Float32Array(vec),
+                );
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    if (summary.status === 'completed') {
+      const exported = db.export();
+      fs.writeFileSync(dbPath, Buffer.from(exported));
+      return true;
+    }
+
+    return false;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * V3 memory schema probe. Checks that every column the migration touches
+ * exists on `memory_entries`. If any is missing, the DB is from an older or
+ * unrelated schema and we skip — not our table to rewrite.
+ */
+function hasV3MemorySchema(db: unknown): boolean {
+  const required = ['id', 'content', 'embedding', 'embedding_dimensions'];
+  try {
+    const stmt = (db as {
+      prepare(sql: string): {
+        step(): boolean;
+        get(): unknown[];
+        free(): void;
+      };
+    }).prepare(`PRAGMA table_info(memory_entries)`);
+    const present = new Set<string>();
+    while (stmt.step()) {
+      const row = stmt.get();
+      // PRAGMA table_info returns [cid, name, type, notnull, dflt_value, pk]
+      if (Array.isArray(row) && typeof row[1] === 'string') {
+        present.add(row[1]);
+      }
+    }
+    stmt.free();
+    return required.every((col) => present.has(col));
+  } catch {
+    return false;
+  }
+}

--- a/src/modules/cli/src/services/sqljs-migration-store.ts
+++ b/src/modules/cli/src/services/sqljs-migration-store.ts
@@ -6,13 +6,17 @@
  * table, re-embed the source text with the new neural model, and write the
  * updated vectors back transactionally.
  *
- * Schema assumptions (matches moflo's memory-initializer):
- *   CREATE TABLE memory_entries (id TEXT PRIMARY KEY, key TEXT, value TEXT,
- *                                embedding BLOB, dimensions INTEGER, ...);
- *   CREATE TABLE migration_cursor (store_id TEXT PRIMARY KEY, last_id TEXT,
- *                                  items_done INTEGER, items_total INTEGER,
- *                                  started_at INTEGER, updated_at INTEGER);
- *   CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+ * Schema assumptions — matches MEMORY_SCHEMA_V3 in
+ * `src/modules/cli/src/memory/memory-initializer.ts`:
+ *   CREATE TABLE memory_entries (
+ *     id TEXT PRIMARY KEY, key TEXT NOT NULL,
+ *     content TEXT NOT NULL,
+ *     embedding TEXT,              -- JSON-encoded Float32 array
+ *     embedding_dimensions INTEGER,
+ *     ...
+ *   );
+ *   CREATE TABLE migration_cursor (...);
+ *   CREATE TABLE metadata (...);
  *
  * Tables are created lazily if missing so the adapter works on older DBs.
  */
@@ -71,7 +75,7 @@ export class SqlJsMemoryEntriesStore {
 
   async countItems(): Promise<number> {
     const stmt = this.db.prepare(
-      `SELECT COUNT(*) AS n FROM memory_entries WHERE value IS NOT NULL AND length(value) > 0`,
+      `SELECT COUNT(*) AS n FROM memory_entries WHERE content IS NOT NULL AND length(content) > 0`,
     );
     try {
       if (stmt.step()) {
@@ -86,11 +90,11 @@ export class SqlJsMemoryEntriesStore {
 
   async iterItems(afterId: string | null, limit: number): Promise<MigrationItemRow[]> {
     const sql = afterId === null
-      ? `SELECT id, value FROM memory_entries
-         WHERE value IS NOT NULL AND length(value) > 0
+      ? `SELECT id, content FROM memory_entries
+         WHERE content IS NOT NULL AND length(content) > 0
          ORDER BY id ASC LIMIT ?`
-      : `SELECT id, value FROM memory_entries
-         WHERE value IS NOT NULL AND length(value) > 0 AND id > ?
+      : `SELECT id, content FROM memory_entries
+         WHERE content IS NOT NULL AND length(content) > 0 AND id > ?
          ORDER BY id ASC LIMIT ?`;
 
     const stmt = this.db.prepare(sql);
@@ -99,7 +103,7 @@ export class SqlJsMemoryEntriesStore {
       const out: MigrationItemRow[] = [];
       while (stmt.step()) {
         const row = stmt.getAsObject();
-        out.push({ id: String(row.id), sourceText: String(row.value ?? '') });
+        out.push({ id: String(row.id), sourceText: String(row.content ?? '') });
       }
       return out;
     } finally {
@@ -109,13 +113,16 @@ export class SqlJsMemoryEntriesStore {
 
   async updateBatch(updates: readonly { id: string; embedding: Float32Array }[]): Promise<void> {
     if (updates.length === 0) return;
+    // Embeddings are stored as JSON text in MEMORY_SCHEMA_V3's `embedding TEXT`
+    // column — matches how `memory-initializer.ts` and `commands/memory.ts`
+    // write them so `embeddings search` can JSON.parse() the result.
     const stmt = this.db.prepare(
-      `UPDATE memory_entries SET embedding = ?, dimensions = ? WHERE id = ?`,
+      `UPDATE memory_entries SET embedding = ?, embedding_dimensions = ? WHERE id = ?`,
     );
     try {
       for (const { id, embedding } of updates) {
-        const buf = Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength);
-        stmt.run([buf, embedding.length, id]);
+        const json = JSON.stringify(Array.from(embedding));
+        stmt.run([json, embedding.length, id]);
       }
     } finally {
       stmt.free();


### PR DESCRIPTION
## Summary

Three stacked defects blocked EPIC #527 AC #5 — the Story #530 UX layer never reached users. This PR fixes all three plus a related BLOB/JSON encoding bug surfaced while auditing the store.

1. **Foreground wiring** — `bin/session-start-launcher.mjs` now calls `runEmbeddingsMigrationIfNeeded` synchronously with `process.stderr` inherited, so the `UpgradeRenderer` TTY bar and non-TTY status lines actually reach the user. Previously the only auto-trigger was a detached `embeddings init` spawn with `stdio: 'ignore'`.
2. **Second-session bailout** — `embeddings init` no longer returns `exitCode: 1` when config already exists. Users upgrading moflo mid-project get their memory DB re-indexed automatically.
3. **Schema mismatch** — `SqlJsMemoryEntriesStore` used the legacy `value` / `dimensions` / `BLOB` shape. Rewired to match production `MEMORY_SCHEMA_V3`: `content` / `embedding_dimensions` / JSON TEXT. The schema probe is tightened to require the full v3 column set, so older/unrelated DBs are skipped cleanly instead of passing the old `tableHasColumn('embedding')` check and throwing mid-run.

## Changes

- Extract `runEmbeddingsMigrationIfNeeded` into `src/modules/cli/src/services/embeddings-migration.ts` so the launcher can dynamic-import it without pulling the CLI command machinery.
- Launcher foreground block wraps the call in a try/catch that writes to `process.stderr` — a failed/aborted migration must never block session start (driver persists its cursor, next session resumes).
- `embeddings init` reuses a shared `safelyRunEmbeddingsMigration` helper across both the config-exists and normal init paths.
- `SqlJsMemoryEntriesStore.updateBatch` now writes `JSON.stringify(Array.from(embedding))` to match how `memory-initializer.ts` / `commands/memory.ts` write embeddings — `embeddings search` can JSON.parse the result.
- Dropped unused `verbose` option from `RunEmbeddingsMigrationOptions`.

## Tests

Added to `src/modules/cli/__tests__/services/`:

- `sqljs-migration-store-v3.test.ts` — 6 tests. Builds a DB from the actual `MEMORY_SCHEMA_V3` constant so any future schema drift fails loud. Covers `countItems`, `iterItems`, `updateBatch` (asserts JSON parses, dims match), full `migrateStore` end-to-end, cursor round-trip, and `setVersion`/`getVersion`.
- `embeddings-migration.test.ts` — 4 tests. Covers the tightened probe: legacy-schema DB (`value`/`dimensions`), DB missing `embedding_dimensions`, DB with no `memory_entries`, and missing file.

TTY + non-TTY renderer paths are already exercised by the existing `upgrade-renderer.test.ts` suite (Story #530).

## Test plan

- [x] `npx vitest run src/modules/cli/__tests__/services/sqljs-migration-store-v3.test.ts src/modules/cli/__tests__/services/embeddings-migration.test.ts` — 10/10 pass
- [x] `npx vitest run src/modules/cli/__tests__/services/ src/modules/embeddings/__tests__/migration/` — 351/351 pass
- [x] Full repo `npm test` — 7836/0 pass, isolation batch 481/0 pass
- [x] `npm run build` clean in `src/modules/cli`
- [ ] Smoke check on a real v3 DB with `embeddings_version < EMBEDDINGS_VERSION` and observe foreground UX lines during session start (manual)
- [ ] Smoke check migration resume after SIGINT on Linux + macOS + Windows (manual)

Closes #547
Parent: #527

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)