### PR TITLE
fix(embeddings): atomic memory.db write during migration (#548)

### DIFF
--- a/src/modules/cli/__tests__/services/atomic-file-write.test.ts
+++ b/src/modules/cli/__tests__/services/atomic-file-write.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for `atomicWriteFileSync` — the temp-file + rename helper that
+ * protects DB/config files from mid-write corruption (#548).
+ *
+ * Covers the three failure modes a real SIGINT mid-write can produce:
+ *   1. write itself throws (e.g. ENOSPC) — original intact, temp cleaned up
+ *   2. rename throws (e.g. EACCES, EPERM) — original intact, temp cleaned up
+ *   3. both writes succeed — new content on target, no temp left behind
+ *
+ * Failure-path cases inject a fake fs (ESM doesn't let us spy on `node:fs`
+ * exports), while happy-path cases use the real filesystem under `os.tmpdir()`.
+ *
+ * Cross-platform: stays on `node:fs` sync APIs and `os.tmpdir()` per
+ * `feedback_cross_platform_mandatory`.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  readFileSync,
+  existsSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  atomicWriteFileSync,
+  type AtomicWriteFs,
+} from '../../src/services/atomic-file-write.js';
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* Windows sometimes holds file handles briefly — non-fatal for tests */
+    }
+  }
+});
+
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'moflo-atomic-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+describe('atomicWriteFileSync (real fs)', () => {
+  it('writes new content to the target path', () => {
+    const dir = makeTmpDir();
+    const target = join(dir, 'data.bin');
+
+    atomicWriteFileSync(target, Buffer.from('hello'));
+
+    expect(readFileSync(target, 'utf8')).toBe('hello');
+    expect(existsSync(`${target}.tmp`)).toBe(false);
+  });
+
+  it('replaces existing target content atomically', () => {
+    const dir = makeTmpDir();
+    const target = join(dir, 'data.bin');
+    writeFileSync(target, 'original');
+
+    atomicWriteFileSync(target, Buffer.from('replaced'));
+
+    expect(readFileSync(target, 'utf8')).toBe('replaced');
+    expect(existsSync(`${target}.tmp`)).toBe(false);
+  });
+});
+
+describe('atomicWriteFileSync (injected fs)', () => {
+  it('leaves original intact and cleans up temp when writeFileSync throws mid-write', () => {
+    const dir = makeTmpDir();
+    const target = join(dir, 'data.bin');
+    writeFileSync(target, 'original');
+
+    // Simulate SIGINT: the syscall starts, a partial temp file materialises,
+    // then the process is interrupted. Cleanup must remove the partial temp.
+    const fs: AtomicWriteFs = {
+      writeFileSync: (p, d) => {
+        writeFileSync(p, d);
+        throw new Error('EINTR: interrupted system call');
+      },
+      renameSync,
+      unlinkSync,
+    };
+
+    expect(() => atomicWriteFileSync(target, Buffer.from('replaced'), fs)).toThrow(
+      /EINTR/,
+    );
+    expect(readFileSync(target, 'utf8')).toBe('original');
+    expect(existsSync(`${target}.tmp`)).toBe(false);
+  });
+
+  it('leaves original intact and cleans up temp when renameSync throws', () => {
+    const dir = makeTmpDir();
+    const target = join(dir, 'data.bin');
+    writeFileSync(target, 'original');
+
+    const fs: AtomicWriteFs = {
+      writeFileSync,
+      renameSync: () => {
+        throw new Error('EPERM: operation not permitted');
+      },
+      unlinkSync,
+    };
+
+    expect(() => atomicWriteFileSync(target, Buffer.from('replaced'), fs)).toThrow(
+      /EPERM/,
+    );
+    expect(readFileSync(target, 'utf8')).toBe('original');
+    expect(existsSync(`${target}.tmp`)).toBe(false);
+  });
+
+  it('tolerates missing temp when writeFileSync errors before creating it', () => {
+    // ENOSPC-style failure: the temp never got written. Cleanup must not
+    // re-throw ENOENT, otherwise the real write error would be masked.
+    const dir = makeTmpDir();
+    const target = join(dir, 'data.bin');
+    writeFileSync(target, 'original');
+
+    const fs: AtomicWriteFs = {
+      writeFileSync: () => {
+        throw new Error('ENOSPC: no space left on device');
+      },
+      renameSync,
+      unlinkSync,
+    };
+
+    expect(() => atomicWriteFileSync(target, Buffer.from('replaced'), fs)).toThrow(
+      /ENOSPC/,
+    );
+    expect(readFileSync(target, 'utf8')).toBe('original');
+    expect(existsSync(`${target}.tmp`)).toBe(false);
+  });
+
+  it('does not mask the original error if cleanup itself throws', () => {
+    // If the temp cleanup fails too (unlikely but possible), the primary
+    // write/rename error is still what surfaces. This is the contract —
+    // cleanup failures must never shadow the real cause.
+    const fs: AtomicWriteFs = {
+      writeFileSync: () => {
+        throw new Error('EACCES: permission denied');
+      },
+      renameSync,
+      unlinkSync: () => {
+        throw new Error('cleanup exploded');
+      },
+    };
+
+    expect(() => atomicWriteFileSync('/irrelevant', Buffer.from('x'), fs)).toThrow(
+      /EACCES/,
+    );
+  });
+});

--- a/src/modules/cli/src/services/atomic-file-write.ts
+++ b/src/modules/cli/src/services/atomic-file-write.ts
@@ -1,0 +1,45 @@
+/**
+ * Atomic filesystem writes for files that must not be left corrupted if the
+ * process is interrupted mid-write (SIGINT, power loss, ENOSPC).
+ *
+ * Pattern: write to `<target>.tmp`, then rename onto `target`.
+ *   - `fs.renameSync` is atomic on POSIX.
+ *   - On Windows, Node maps it to `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`,
+ *     which replaces the destination near-atomically — concurrent readers
+ *     always observe either the old file or the new, never a truncated one.
+ *
+ * On any failure, the temp file is best-effort removed and the original
+ * `target` stays intact. The underlying error is always re-thrown.
+ *
+ * `fs` is injectable so the interrupt-mid-write paths can be exercised in
+ * unit tests without depending on ESM-unfriendly module spies.
+ *
+ * @module @moflo/cli/services/atomic-file-write
+ */
+
+import * as realFs from 'node:fs';
+
+export interface AtomicWriteFs {
+  writeFileSync: typeof realFs.writeFileSync;
+  renameSync: typeof realFs.renameSync;
+  unlinkSync: typeof realFs.unlinkSync;
+}
+
+export function atomicWriteFileSync(
+  targetPath: string,
+  data: Buffer | Uint8Array | string,
+  fs: AtomicWriteFs = realFs,
+): void {
+  const tmpPath = `${targetPath}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, data);
+    fs.renameSync(tmpPath, targetPath);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      /* best-effort cleanup — temp may not exist if writeFileSync failed early */
+    }
+    throw err;
+  }
+}

--- a/src/modules/cli/src/services/embeddings-migration.ts
+++ b/src/modules/cli/src/services/embeddings-migration.ts
@@ -17,6 +17,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { mofloImport } from './moflo-require.js';
+import { atomicWriteFileSync } from './atomic-file-write.js';
 
 export interface RunEmbeddingsMigrationOptions {
   /** Path to the memory DB. Defaults to `<cwd>/.swarm/memory.db`. */
@@ -117,8 +118,10 @@ export async function runEmbeddingsMigrationIfNeeded(
     });
 
     if (summary.status === 'completed') {
-      const exported = db.export();
-      fs.writeFileSync(dbPath, Buffer.from(exported));
+      // `db.export()` returns a Uint8Array; `writeFileSync` accepts it directly,
+      // so no Buffer.from() copy. Atomic temp-file + rename so SIGINT mid-write
+      // cannot truncate memory.db — see atomic-file-write.ts.
+      atomicWriteFileSync(dbPath, db.export());
       return true;
     }
 


### PR DESCRIPTION
## Summary
- SIGINT mid-write in `runEmbeddingsMigrationIfNeeded` could truncate `.swarm/memory.db` — the rewrite on line 121 was a direct `fs.writeFileSync(dbPath, Buffer.from(exported))` with no temp-file / rollback
- New `atomicWriteFileSync(target, data, fs?)` helper at `src/modules/cli/src/services/atomic-file-write.ts`: write to `<target>.tmp`, then `fs.renameSync` onto `target`. On any failure the temp file is best-effort unlinked and the original error re-thrown, so the original DB stays intact
- Call-site passes `db.export()` (Uint8Array) directly — dropping the `Buffer.from(exported)` copy saves a full DB-sized allocation

## Cross-platform
- `fs.renameSync` is atomic on POSIX
- On Windows, Node maps it to `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)` — concurrent readers see either the old file or the new, never a truncated one

## Testability note
ESM does not allow `vi.spyOn(fs, 'writeFileSync')` — `node:fs` exports aren't configurable. The helper therefore accepts an optional `AtomicWriteFs` (writeFileSync / renameSync / unlinkSync) so failure-mode tests can inject a fake fs without ESM namespace hacking.

## Test plan
- [x] 6 new tests in `src/modules/cli/__tests__/services/atomic-file-write.test.ts`:
  - real fs: happy path + replace existing target
  - injected fs: writeFileSync throws mid-write (EINTR) + leaves partial temp → cleaned up, original intact
  - injected fs: renameSync throws (EPERM) → temp cleaned up, original intact
  - injected fs: writeFileSync errors before creating temp (ENOSPC) → ENOENT from cleanup is swallowed, primary error surfaces
  - injected fs: cleanup itself throws → primary EACCES still surfaces (cleanup must not mask)
- [x] Full `@moflo/cli` suite green: 2028 passed, 11 skipped, 0 failures
- [x] `embeddings-migration.test.ts` (existing 4 tests) still passing

Closes #548
Parent: #527

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)