### PR TITLE
docs(embeddings): purge stale @xenova refs + fastembed air-gapped runbook (#550)

### DIFF
--- a/.claude/guidance/shipped/moflo-core-guidance.md
+++ b/.claude/guidance/shipped/moflo-core-guidance.md
@@ -644,7 +644,7 @@ All code changes MUST work on Windows, macOS, and Linux. Follow these rules:
 | Low search quality | Guidance docs missing `**Purpose:**` lines or generic headings | Follow guidance optimization rules in `guidance-memory-strategy.md` |
 | Session start slow | All three indexers running | Set `auto_index.code_map: false` in `moflo.yaml` if code map not needed |
 | Status line not showing | `statusline.cjs` error or `status_line.enabled: false` | Run `node .claude/helpers/statusline.cjs` to test, check `moflo.yaml` |
-| Embeddings falling back to hash | Transformers.js not available | Install `@xenova/transformers` — moflo includes it but some environments strip it |
+| Embeddings fail on first run (offline / air-gapped) | `fastembed` model cache missing | Pre-populate `~/.cache/fastembed` or set `FASTEMBED_CACHE` to a pre-baked cache dir — see `docs/modules/embeddings.md` "Sandbox & air-gapped first-run" |
 | `flo` command not found | Not in PATH | Use `npx flo` or `node node_modules/moflo/bin/index-guidance.mjs` |
 | Bundled guidance not indexed | Running inside moflo repo (same dir) | Bundled guidance only indexes when installed as a dependency in a different project |
 

--- a/.claude/guidance/shipped/moflo-memory-strategy.md
+++ b/.claude/guidance/shipped/moflo-memory-strategy.md
@@ -105,42 +105,28 @@ ASCII boxes, excessive emoji, rhetorical questions, and motivational text all wa
 
 ## Embedding Strategy
 
-### Embedding Models
+### Embedding Model
 
-| Model | Quality | Speed | When Used |
-|-------|---------|-------|-----------|
-| `Xenova/all-MiniLM-L6-v2` | High (true semantic) | ~3s for 1000 entries | Primary — `build-embeddings.mjs` uses this |
-| `domain-aware-hash-v1` | Good (domain clustering) | <1s for 1000 entries | Fallback when Transformers.js unavailable |
+| Model | Runtime | Speed | Notes |
+|-------|---------|-------|-------|
+| `fast-all-MiniLM-L6-v2` | `fastembed` (native ONNX + Rust tokenizer) | ~3s for 1000 entries | The only supported model — neural embeddings are mandatory (ADR-EMB-001) |
 
-**Neural embeddings (Xenova/all-MiniLM-L6-v2):**
-- Uses `@xenova/transformers` with ONNX WASM runtime
+**Neural embeddings (fast-all-MiniLM-L6-v2):**
+- Uses the `fastembed` npm package (Qdrant's embeddings-only ONNX client)
 - 384-dimensional vectors, L2-normalized
 - True semantic understanding — "soft delete" matches "mark as deleted" without keyword overlap
-- Loaded lazily on first use, cached for subsequent queries
+- Model auto-downloads to `~/.cache/fastembed` on first use; cached for subsequent queries
+- For offline / air-gapped / sandboxed runs, pre-populate the cache or set `FASTEMBED_CACHE` — see `docs/modules/embeddings.md` "Sandbox & air-gapped first-run"
 
-**Domain-aware hash embeddings (fallback):**
-- Custom SimHash-style algorithm with 12 domain clusters
-- Multi-position hashing with bigram/trigram features
-- Good at keyword-level matching but misses semantic paraphrases
-- No external dependencies — always available
+**Legacy-compatible model names:** Entries embedded by earlier moflo versions may be tagged `Xenova/all-MiniLM-L6-v2` or `onnx`. These share the same vector space as `fast-all-MiniLM-L6-v2`, so search treats them as compatible (`semantic-search.mjs` `COMPATIBLE_MODELS`).
+
+**No hash fallback.** Epic #527 removed every hash-embedding path. If the `fastembed` model cannot load, memory operations fail loudly rather than silently degrading to FNV-1a pseudo-vectors. See [ADR-EMB-001](../../../src/modules/embeddings/docs/adrs/ADR-EMB-001-neural-embeddings-mandatory.md).
 
 ### The Embedding Alignment Problem
 
 **Critical rule:** Query embeddings MUST match stored embeddings. Computing cosine similarity between vectors from different models produces meaningless scores.
 
-Both the search scripts and the MCP memory tools auto-detect the stored embedding model and generate matching query vectors. Search also filters out entries with mismatched `embedding_model`.
-
-### Domain Cluster Tuning
-
-The hash fallback's domain clusters can be extended with project-specific terms:
-
-| Cluster | Example Terms |
-|---------|--------------|
-| `database` | your ORM, database engine, schema terms |
-| `frontend` | UI framework, component library terms |
-| `backend` | DI container, API framework terms |
-| `testing` | test framework, assertion library terms |
-| `security` | auth system, permission model terms |
+Both the search scripts and the MCP memory tools use `fastembed` for query vectors and filter stored entries by `embedding_model` (via the legacy-compatible alias list above), so a mixed-version database remains coherent.
 
 ---
 

--- a/.claude/scripts/generate-code-map.mjs
+++ b/.claude/scripts/generate-code-map.mjs
@@ -925,7 +925,7 @@ async function main() {
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   log(`Done in ${elapsed}s — ${allChunks.length} chunks written to code-map namespace`);
 
-  // 7. Generate embeddings inline (not detached — ensures Xenova runs reliably)
+  // 7. Generate embeddings inline (not detached — ensures fastembed runs reliably)
   if (!skipEmbeddings) {
     await runEmbeddings();
   }

--- a/bin/generate-code-map.mjs
+++ b/bin/generate-code-map.mjs
@@ -925,7 +925,7 @@ async function main() {
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   log(`Done in ${elapsed}s — ${allChunks.length} chunks written to code-map namespace`);
 
-  // 7. Generate embeddings inline (not detached — ensures Xenova runs reliably)
+  // 7. Generate embeddings inline (not detached — ensures fastembed runs reliably)
   if (!skipEmbeddings) {
     await runEmbeddings();
   }

--- a/docs/memory-stack-decision-memo.md
+++ b/docs/memory-stack-decision-memo.md
@@ -1,6 +1,9 @@
 # Decision memo: agentdb removal (epic #464)
+
+> **Historical — pre-epic #527 (2026-04-22).** This memo captured the agentdb-removal decision before epic #527 landed. The "three-tier fallback `agentic-flow → @xenova/transformers → mock`" described below is no longer the live architecture: epic #527 removed every hash/mock fallback and swapped `@xenova/transformers` for `fastembed`. Kept as the point-in-time record of the Option-B decision. See [ADR-EMB-001](../src/modules/embeddings/docs/adrs/ADR-EMB-001-neural-embeddings-mandatory.md) for the current embedding architecture.
+
 Date: 2026-04-20
-Status: **pending user decision**
+Status: **shipped — agentdb removed in 4.8.80, `@xenova/transformers` replaced in #527**
 Research gates: Gate 1 ✅, Gate 2 ✅, Gate 3 ✅
 
 ## TL;DR


### PR DESCRIPTION
## Summary

Follow-up from EPIC #527 architect review. Cleans up the remaining stale `@xenova/transformers` references that survived the epic #527 rewrite (fastembed swap + hash-fallback removal) and confirms the air-gapped preload runbook is already in place.

## Changes

- **`docs/memory-stack-decision-memo.md`** — add historical banner pointing to ADR-EMB-001 (sibling `migration.md` and `audit-neural-hooks.md` already had this banner)
- **`.claude/guidance/shipped/moflo-core-guidance.md`** — replace troubleshooting row advising users to install `@xenova/transformers` with one pointing at fastembed's offline / air-gapped workflow
- **`.claude/guidance/shipped/moflo-memory-strategy.md`** — rewrite the *Embedding Models* section to reflect fastembed as the mandatory neural backing (hash fallback removed in #527), cross-reference ADR-EMB-001, and note the legacy-compatible model-name aliases (`Xenova/all-MiniLM-L6-v2`, `onnx`) that keep mixed-version databases searchable
- **`.claude/scripts/generate-code-map.mjs` + `bin/generate-code-map.mjs`** — update the stale "ensures Xenova runs reliably" comment to `fastembed`

## Acceptance criteria

- [x] `.claude/scripts/semantic-search.mjs` + `build-embeddings.mjs` use fastembed (already rewritten in #527 — the issue body referenced pre-#527 line numbers)
- [x] `docs/memory-stack-*.md` all carry a historical banner pointing at ADR-EMB-001
- [x] `docs/modules/embeddings.md` has an "Air-gapped install" section ("Sandbox & air-gapped first-run", lines 361–379) — already present
- [x] `grep -ri "@xenova/transformers" src/ package.json src/modules/*/package.json .claude/` returns only `src/modules/embeddings/docs/adrs/ADR-EMB-001-neural-embeddings-mandatory.md`, which is the ADR that documents the removal decision and legitimately retains references

## Testing

- [x] `npm run lint` — clean (0 warnings, max-warnings 0)
- [x] `npx vitest run tests/guards/` — 10/10 pass (includes the no-restricted-imports guard for `@xenova/transformers`)
- [x] Manual review of diff — docs-only, no runtime paths touched

Closes #550

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)