### PR TITLE
fix(embeddings): friendly formatting for model-load failures (#553)

### DIFF
--- a/src/modules/cli/__tests__/services/embedding-errors.test.ts
+++ b/src/modules/cli/__tests__/services/embedding-errors.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the friendly embedding-error formatter (#553).
+ *
+ * Covers each mapped error code path (network, cache permission, corrupted
+ * download, missing package, generic) and the verbose gate that hides the
+ * raw message + stack behind `--verbose` / `DEBUG=moflo:*`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  classifyEmbeddingError,
+  formatEmbeddingError,
+  isVerboseEmbeddingErrors,
+} from '../../src/memory/embedding-errors.js';
+
+describe('embedding-errors: classifyEmbeddingError', () => {
+  it('classifies ENETUNREACH by errno code as network', () => {
+    const err = Object.assign(new Error('boom'), { code: 'ENETUNREACH' });
+    expect(classifyEmbeddingError(err).code).toBe('network');
+  });
+
+  it('classifies ENOTFOUND / getaddrinfo in the message as network', () => {
+    const err = new Error('getaddrinfo ENOTFOUND huggingface.co');
+    expect(classifyEmbeddingError(err).code).toBe('network');
+  });
+
+  it('classifies wrapped fastembed network failure via cause chain', () => {
+    const root = Object.assign(new Error('network unreachable'), { code: 'ENETUNREACH' });
+    const wrapped = new Error('Failed to initialize fastembed: network unreachable');
+    (wrapped as Error & { cause?: unknown }).cause = root;
+    expect(classifyEmbeddingError(wrapped).code).toBe('network');
+  });
+
+  it('classifies EACCES by errno code as cache-permission', () => {
+    const err = Object.assign(new Error('permission'), { code: 'EACCES' });
+    expect(classifyEmbeddingError(err).code).toBe('cache-permission');
+  });
+
+  it('classifies "permission denied" in message as cache-permission', () => {
+    const err = new Error('mkdir /home/x/.cache/fastembed: permission denied');
+    expect(classifyEmbeddingError(err).code).toBe('cache-permission');
+  });
+
+  it('classifies corrupted / size-mismatch downloads as cache-corrupted', () => {
+    const cases = [
+      'checksum mismatch for model.onnx',
+      'unexpected end of file while reading model',
+      'corrupted gzip stream',
+      'invalid onnx model signature',
+    ];
+    for (const msg of cases) {
+      expect(classifyEmbeddingError(new Error(msg)).code).toBe('cache-corrupted');
+    }
+  });
+
+  it('classifies missing @moflo/embeddings package', () => {
+    const err = new Error(
+      '@moflo/embeddings is not installed. Neural embeddings are required — the hash fallback was removed in epic #527.',
+    );
+    expect(classifyEmbeddingError(err).code).toBe('missing-package');
+  });
+
+  it('falls through to generic when nothing matches', () => {
+    const err = new Error('something weird happened inside ONNX runtime');
+    expect(classifyEmbeddingError(err).code).toBe('generic');
+  });
+
+  it('handles non-Error inputs (strings, plain objects)', () => {
+    expect(classifyEmbeddingError('ENETUNREACH').code).toBe('network');
+    expect(classifyEmbeddingError({ code: 'EACCES' }).code).toBe('cache-permission');
+    expect(classifyEmbeddingError(null).code).toBe('generic');
+  });
+});
+
+describe('embedding-errors: formatEmbeddingError default (non-verbose)', () => {
+  const originalDebug = process.env.DEBUG;
+  beforeEach(() => {
+    delete process.env.DEBUG;
+  });
+  afterEach(() => {
+    if (originalDebug === undefined) delete process.env.DEBUG;
+    else process.env.DEBUG = originalDebug;
+  });
+
+  it('hides stack trace and raw message by default', () => {
+    const err = new Error('getaddrinfo ENOTFOUND huggingface.co');
+    const formatted = formatEmbeddingError(err);
+    expect(formatted).not.toContain('getaddrinfo ENOTFOUND');
+    expect(formatted).not.toContain('Underlying error:');
+    expect(formatted).not.toMatch(/\s+at\s+/);
+  });
+
+  it('renders the plain-English message + next step for network failures', () => {
+    const err = Object.assign(new Error('ENETUNREACH'), { code: 'ENETUNREACH' });
+    const formatted = formatEmbeddingError(err);
+    expect(formatted).toContain("Couldn't reach the model server");
+    expect(formatted).toContain('flo doctor');
+  });
+
+  it('renders the plain-English message + next step for cache-permission failures', () => {
+    const err = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    const formatted = formatEmbeddingError(err);
+    expect(formatted).toContain("Couldn't write the embedding model cache");
+    expect(formatted).toContain('~/.cache/fastembed');
+    expect(formatted).toContain('FASTEMBED_CACHE');
+  });
+
+  it('renders the delete-cache next step for corrupted downloads', () => {
+    const err = new Error('size mismatch while reading model.onnx');
+    const formatted = formatEmbeddingError(err);
+    expect(formatted).toContain('corrupted');
+    expect(formatted).toContain('Delete `~/.cache/fastembed`');
+  });
+
+  it('renders a generic next step when classification is unclear', () => {
+    const err = new Error('something weird happened');
+    const formatted = formatEmbeddingError(err);
+    expect(formatted).toContain("Couldn't load the neural embedding model");
+    expect(formatted).toContain('--verbose');
+  });
+});
+
+describe('embedding-errors: formatEmbeddingError verbose gate', () => {
+  const originalDebug = process.env.DEBUG;
+  beforeEach(() => {
+    delete process.env.DEBUG;
+  });
+  afterEach(() => {
+    if (originalDebug === undefined) delete process.env.DEBUG;
+    else process.env.DEBUG = originalDebug;
+  });
+
+  it('includes the raw message when verbose=true', () => {
+    const err = new Error('getaddrinfo ENOTFOUND huggingface.co');
+    const formatted = formatEmbeddingError(err, { verbose: true });
+    expect(formatted).toContain('Underlying error: getaddrinfo ENOTFOUND huggingface.co');
+  });
+
+  it('includes the stack trace when verbose=true', () => {
+    const err = new Error('boom');
+    const formatted = formatEmbeddingError(err, { verbose: true });
+    expect(formatted).toMatch(/Error: boom[\s\S]*at\s+/);
+  });
+
+  it('activates verbose when DEBUG is the moflo namespace', () => {
+    process.env.DEBUG = 'moflo:memory';
+    expect(isVerboseEmbeddingErrors()).toBe(true);
+    const err = new Error('boom');
+    expect(formatEmbeddingError(err)).toContain('Underlying error:');
+  });
+
+  it('activates verbose when DEBUG is the wildcard "*"', () => {
+    process.env.DEBUG = '*';
+    expect(isVerboseEmbeddingErrors()).toBe(true);
+  });
+
+  it('activates verbose when DEBUG has comma-separated namespaces including moflo', () => {
+    process.env.DEBUG = 'express,moflo,other';
+    expect(isVerboseEmbeddingErrors()).toBe(true);
+  });
+
+  it('stays non-verbose when DEBUG is an unrelated namespace', () => {
+    process.env.DEBUG = 'other:thing';
+    expect(isVerboseEmbeddingErrors()).toBe(false);
+  });
+
+  it('stays non-verbose when DEBUG contains a literal "*" inside another string', () => {
+    process.env.DEBUG = 'foo*bar';
+    expect(isVerboseEmbeddingErrors()).toBe(false);
+  });
+
+  it('stays non-verbose when DEBUG contains "moflo" as a substring (not a namespace)', () => {
+    process.env.DEBUG = 'xmoflo';
+    expect(isVerboseEmbeddingErrors()).toBe(false);
+  });
+});

--- a/src/modules/cli/src/memory/embedding-errors.ts
+++ b/src/modules/cli/src/memory/embedding-errors.ts
@@ -1,0 +1,142 @@
+/**
+ * Friendly formatting for neural-embedding load/inference failures.
+ *
+ * Classifies the raw error surfaced by `@moflo/embeddings` / `fastembed`
+ * (network, cache-permission, corrupted download, generic) and renders a
+ * plain-English message with a concrete next step. Stack + raw text are
+ * withheld unless verbose output is enabled via `--verbose` or
+ * `DEBUG=moflo` / `DEBUG=moflo:*` / `DEBUG=*`.
+ *
+ * Failure still propagates — this is formatting, not recovery (#553, AC #6).
+ */
+
+export type EmbeddingErrorCode =
+  | 'network'
+  | 'cache-permission'
+  | 'cache-corrupted'
+  | 'missing-package'
+  | 'generic';
+
+export interface EmbeddingErrorDetails {
+  code: EmbeddingErrorCode;
+  message: string;
+  nextStep: string;
+  rawMessage: string;
+  stack?: string;
+}
+
+const CACHE_HINT = '`~/.cache/fastembed` (or `$FASTEMBED_CACHE` if set)';
+
+const NETWORK_RE =
+  /\b(ENETUNREACH|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|EHOSTUNREACH|EHOSTDOWN|getaddrinfo|failed to (?:fetch|download)|network\s+(?:is\s+)?unreachable)\b/i;
+const PERMISSION_RE = /\b(EACCES|EPERM|EROFS|permission denied|read[- ]only file system)\b/i;
+const CORRUPTED_RE =
+  /(corrupt(?:ed)?|checksum|size[ _]?mismatch|unexpected (?:byte|end)|truncat(?:ed|ion)|invalid (?:gzip|zip|onnx|model))/i;
+
+function getErrnoCode(err: unknown, depth = 0): string | undefined {
+  if (!err || typeof err !== 'object' || depth > 5) return undefined;
+  const e = err as { code?: unknown; cause?: unknown };
+  if (typeof e.code === 'string') return e.code;
+  if (e.cause) return getErrnoCode(e.cause, depth + 1);
+  return undefined;
+}
+
+function getRawMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function getStack(err: unknown): string | undefined {
+  if (err instanceof Error && typeof err.stack === 'string') return err.stack;
+  return undefined;
+}
+
+export function classifyEmbeddingError(err: unknown): EmbeddingErrorDetails {
+  const rawMessage = getRawMessage(err);
+  const stack = getStack(err);
+  const code = getErrnoCode(err) ?? '';
+
+  if (/@moflo\/embeddings is not installed/i.test(rawMessage)) {
+    return {
+      code: 'missing-package',
+      message: 'Neural embeddings package is not installed.',
+      nextStep:
+        'Install it with `npm install @moflo/embeddings`, or run `flo doctor --fix` to repair the environment.',
+      rawMessage,
+      stack,
+    };
+  }
+
+  if (NETWORK_RE.test(code) || NETWORK_RE.test(rawMessage)) {
+    return {
+      code: 'network',
+      message: "Couldn't reach the model server to download the embedding model.",
+      nextStep: 'Check your network connection, or run `flo doctor` to diagnose.',
+      rawMessage,
+      stack,
+    };
+  }
+
+  if (PERMISSION_RE.test(code) || PERMISSION_RE.test(rawMessage)) {
+    return {
+      code: 'cache-permission',
+      message: "Couldn't write the embedding model cache.",
+      nextStep: `Check permissions on ${CACHE_HINT}.`,
+      rawMessage,
+      stack,
+    };
+  }
+
+  if (CORRUPTED_RE.test(rawMessage)) {
+    return {
+      code: 'cache-corrupted',
+      message: 'The embedding model cache looks corrupted.',
+      nextStep: `Delete ${CACHE_HINT} and retry. \`flo doctor --fix\` can do this for you.`,
+      rawMessage,
+      stack,
+    };
+  }
+
+  return {
+    code: 'generic',
+    message: "Couldn't load the neural embedding model.",
+    nextStep: 'Run `flo doctor` to diagnose, or re-run with `--verbose` for the underlying error.',
+    rawMessage,
+    stack,
+  };
+}
+
+/**
+ * Verbose is on when the caller passes `verbose: true`, or when `DEBUG`
+ * contains a standalone `*` or a `moflo` namespace (comma-separated, matching
+ * the `debug` package convention).
+ */
+export function isVerboseEmbeddingErrors(opts?: { verbose?: boolean }): boolean {
+  if (opts?.verbose) return true;
+  const debug = process.env.DEBUG;
+  if (!debug) return false;
+  return debug.split(',').some(part => {
+    const ns = part.trim();
+    return ns === '*' || /^moflo(?::|$)/i.test(ns);
+  });
+}
+
+export function formatEmbeddingError(
+  err: unknown,
+  opts?: { verbose?: boolean },
+): string {
+  const details = classifyEmbeddingError(err);
+  const lines = [details.message, details.nextStep];
+
+  if (isVerboseEmbeddingErrors(opts)) {
+    lines.push('', `Underlying error: ${details.rawMessage}`);
+    if (details.stack) lines.push(details.stack);
+  }
+
+  return lines.join('\n');
+}

--- a/src/modules/cli/src/memory/memory-initializer.ts
+++ b/src/modules/cli/src/memory/memory-initializer.ts
@@ -12,6 +12,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { mofloImport, importMofloMemory } from '../services/moflo-require.js';
+import { formatEmbeddingError } from './embedding-errors.js';
 
 /**
  * Write vector-stats.json cache for the statusline (no subprocess needed).
@@ -1616,10 +1617,7 @@ export async function generateEmbedding(text: string): Promise<{
   if (!embeddingModelState?.loaded) {
     const load = await loadEmbeddingModel();
     if (!load.success) {
-      throw new Error(
-        `Embedding model not available: ${load.error ?? 'unknown error'}. ` +
-          `Neural embeddings are required (epic #527).`,
-      );
+      throw new Error(formatEmbeddingError(load.error ?? 'unknown error'));
     }
   }
 
@@ -1632,7 +1630,12 @@ export async function generateEmbedding(text: string): Promise<{
     );
   }
 
-  const result = await state.service.embed(text);
+  let result: { embedding: Float32Array | number[] };
+  try {
+    result = await state.service.embed(text);
+  } catch (err) {
+    throw new Error(formatEmbeddingError(err));
+  }
   const embedding = Array.from(result.embedding as Float32Array | number[]);
   return {
     embedding,


### PR DESCRIPTION
## Summary

Follow-up from architect review of epic #527 (AC #6). Network/cache errors from `@moflo/embeddings` / `fastembed` previously surfaced as string-concatenated stack traces — e.g. a raw `getaddrinfo ENETUNREACH` line in the user's face. This routes the two failure points in `generateEmbedding()` through a dedicated formatter that maps common codes to plain-English messages with a concrete next step.

Error still fails hard — this is formatting, not recovery.

## Changes

- **New**: `src/modules/cli/src/memory/embedding-errors.ts` — `classifyEmbeddingError` + `formatEmbeddingError` + `isVerboseEmbeddingErrors`. Regex-driven classification over `err.code`, the raw message, and the `err.cause` chain (depth-guarded).
- **Wired in** at `memory-initializer.ts:1619` (load-fail throw) and the `state.service.embed(text)` call (~line 1635, now in a try/catch that re-throws with the formatted message).
- **New tests**: `src/modules/cli/__tests__/services/embedding-errors.test.ts` — 21 tests covering every code path + the verbose gate (including `DEBUG=foo*bar` and `DEBUG=xmoflo` non-matches).

### Mapped errors

| Error | Friendly message | Next step |
|---|---|---|
| `ENETUNREACH` / `ENOTFOUND` / `getaddrinfo` / "failed to fetch" | Couldn't reach the model server... | Check network, or run `flo doctor` |
| `EACCES` / `EPERM` / "permission denied" | Couldn't write the embedding model cache... | Check permissions on `~/.cache/fastembed` |
| `checksum` / `size mismatch` / `truncated` / `invalid onnx` | Model cache looks corrupted... | Delete `~/.cache/fastembed` and retry; `flo doctor --fix` can do it |
| `@moflo/embeddings is not installed` | Package not installed... | `npm install @moflo/embeddings` or `flo doctor --fix` |
| anything else | Couldn't load the neural embedding model... | `flo doctor` or `--verbose` for the underlying error |

### Verbose gate

Honors `{verbose:true}` opt OR `DEBUG` containing standalone `*` or a `moflo` namespace (comma-split per the `debug` package convention). Adds `Underlying error: <raw>` + stack only when verbose.

## Testing
- [x] Unit tests for each error code path (21 tests, all pass)
- [x] Verbose gate tested: explicit opt, `DEBUG=moflo`, `DEBUG=moflo:memory`, `DEBUG=*`, comma-separated lists, and negative cases (`DEBUG=foo*bar`, `DEBUG=xmoflo`)
- [x] Existing `memory-initializer.test.ts` passes (17 tests)
- [x] Full `cli/__tests__/services/` suite passes (305 tests)
- [x] Typecheck clean

Closes #553

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)