### PR TITLE
test(embeddings): add init-failure negative tests for FastembedEmbeddingService

### DIFF
--- a/src/modules/embeddings/__tests__/fastembed-embedding-service.test.ts
+++ b/src/modules/embeddings/__tests__/fastembed-embedding-service.test.ts
@@ -139,6 +139,53 @@ describe('FastembedEmbeddingService', () => {
     });
   });
 
+  describe('init failure', () => {
+    it('surfaces the inner cause when loadModule throws', async () => {
+      const failingLoad = async () => {
+        throw new Error('cache write denied');
+      };
+      const service = new FastembedEmbeddingService(
+        { provider: 'fastembed' },
+        { loadModule: failingLoad },
+      );
+
+      await expect(service.embed('x')).rejects.toThrow(
+        /Failed to initialize fastembed:.*cache write denied/,
+      );
+    });
+
+    it('rejects both embed() and embedBatch() when init failed', async () => {
+      const failingLoad = async () => {
+        throw new Error('model file missing');
+      };
+      const service = new FastembedEmbeddingService(
+        { provider: 'fastembed' },
+        { loadModule: failingLoad },
+      );
+
+      await expect(service.embed('x')).rejects.toThrow(/model file missing/);
+      await expect(service.embedBatch(['a', 'b'])).rejects.toThrow(/model file missing/);
+    });
+
+    it('recovers on retry when the loader succeeds the second time', async () => {
+      const flakyLoad = vi
+        .fn<() => Promise<FastembedModule>>()
+        .mockRejectedValueOnce(new Error('transient network'))
+        .mockImplementation(loadModule);
+      const service = new FastembedEmbeddingService(
+        { provider: 'fastembed' },
+        { loadModule: flakyLoad },
+      );
+
+      await expect(service.embed('x')).rejects.toThrow(/transient network/);
+
+      const result = await service.embed('x');
+      expect(result.embedding).toBeInstanceOf(Float32Array);
+      expect(result.embedding.length).toBe(DIM);
+      expect(flakyLoad).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('single embed', () => {
     it('returns Float32Array of length 384', async () => {
       const service = new FastembedEmbeddingService({ provider: 'fastembed' }, { loadModule });


### PR DESCRIPTION
## Summary
- Adds `describe('init failure', ...)` block to `fastembed-embedding-service.test.ts` with 3 negative tests covering the AC #6 hard-error path from EPIC #527.
- No production code changes — the existing `initialize()` implementation already satisfied the spec; the gap was pure test coverage.

## Changes
- **Test 1** — `loadModule` throws; `embed()` rejects with an Error whose message contains both the `Failed to initialize fastembed:` wrapper prefix and the inner cause.
- **Test 2** — after a failed init, both `embed()` and `embedBatch()` reject. No silent fallback path.
- **Test 3** — transient failure is recoverable: `vi.fn().mockRejectedValueOnce(err).mockImplementation(loadModule)` reuses the `beforeEach` loader closure. First call rejects, second call succeeds, loader invoked exactly twice.

## Testing
- [x] Unit tests pass — `npm test` in `src/modules/embeddings` passes all 172 tests (1 skipped integration gate).
- [x] /simplify applied — refactored test 3 to reuse the `beforeEach` `loadModule` closure instead of rebuilding the module-shape literal.
- [x] No production code touched — change is test-only.

Closes #554

Refs #527 (embeddings epic architect review follow-up)