### PR TITLE
fix(hive-mind): walk-up resolver replaces broken ../../../../modules paths (#556)

### DIFF
--- a/src/modules/cli/__tests__/mcp-tools-deep.test.ts
+++ b/src/modules/cli/__tests__/mcp-tools-deep.test.ts
@@ -17,12 +17,20 @@ import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 // Mock setup - must be before imports
 // ============================================================================
 
-// Mock fs to prevent actual file I/O during tests
-vi.mock('node:fs', () => {
+// Mock fs writes to prevent test side effects on disk. `existsSync` and
+// `readFileSync` fall through to real fs so legitimate resolvers (e.g.
+// locateMofloModuleDist walking up to src/modules/swarm/dist/) keep working.
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   const memStore = new Map<string, string>();
   return {
-    existsSync: vi.fn((p: string) => memStore.has(p)),
-    readFileSync: vi.fn((p: string) => memStore.get(p) || '{}'),
+    ...actual,
+    existsSync: vi.fn((p: string) => memStore.has(p) || actual.existsSync(p)),
+    readFileSync: vi.fn((p: string, ...rest: unknown[]) =>
+      memStore.has(p)
+        ? memStore.get(p) as string
+        : (actual.readFileSync as (...args: unknown[]) => string | Buffer)(p, ...rest)
+    ),
     writeFileSync: vi.fn((p: string, d: string) => memStore.set(p, d)),
     mkdirSync: vi.fn(),
     readdirSync: vi.fn(() => []),
@@ -31,11 +39,17 @@ vi.mock('node:fs', () => {
   };
 });
 
-vi.mock('fs', () => {
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
   const memStore = new Map<string, string>();
   return {
-    existsSync: vi.fn((p: string) => memStore.has(p)),
-    readFileSync: vi.fn((p: string) => memStore.get(p) || '{}'),
+    ...actual,
+    existsSync: vi.fn((p: string) => memStore.has(p) || actual.existsSync(p)),
+    readFileSync: vi.fn((p: string, ...rest: unknown[]) =>
+      memStore.has(p)
+        ? memStore.get(p) as string
+        : (actual.readFileSync as (...args: unknown[]) => string | Buffer)(p, ...rest)
+    ),
     writeFileSync: vi.fn((p: string, d: string) => memStore.set(p, d)),
     mkdirSync: vi.fn(),
     readdirSync: vi.fn(() => []),

--- a/src/modules/cli/__tests__/services/moflo-require.test.ts
+++ b/src/modules/cli/__tests__/services/moflo-require.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'os';
 
 import {
   importMofloMemory,
+  locateMofloModuleDist,
   _resetMofloMemoryCacheForTest,
 } from '../../src/services/moflo-require.js';
 
@@ -94,5 +95,64 @@ describe('importMofloMemory (walk-up resolver)', () => {
     // If this resolved to a native Windows path instead of file:// URL,
     // import() would have thrown — the fact that we got a module back
     // proves pathToFileURL conversion is in place.
+  });
+});
+
+describe('locateMofloModuleDist (regression guard for #556)', () => {
+  beforeEach(() => {
+    _resetMofloMemoryCacheForTest();
+  });
+
+  it('resolves @moflo/swarm message-bus from inside the cli package', () => {
+    const url = locateMofloModuleDist('swarm', 'message-bus/index.js');
+    expect(url).not.toBeNull();
+    expect(url).toMatch(/^file:\/\//);
+  });
+
+  it('never emits a path containing "modules/modules" (double-modules bug)', () => {
+    // Issue #556: mcp__moflo__hive-mind_init failed because a hand-built
+    // `../../../../modules/swarm/...` string walked up past `src/modules/` and
+    // then re-appended `modules/`, producing `src/modules/modules/swarm/...`.
+    // The resolver must never produce that shape on any platform.
+    const swarmUrl = locateMofloModuleDist('swarm', 'message-bus/index.js');
+    const memoryUrl = locateMofloModuleDist('memory', 'index.js');
+    for (const url of [swarmUrl, memoryUrl]) {
+      expect(url).not.toBeNull();
+      // Check both URL and decoded-path forms — pathToFileURL percent-encodes
+      // some characters on Windows, so we verify both shapes.
+      expect(url!).not.toMatch(/[\\/]modules[\\/]modules[\\/]/);
+      expect(url!).not.toMatch(/\/modules\/modules\//);
+    }
+  });
+
+  it('returns null for a non-existent package (no silent success)', () => {
+    const url = locateMofloModuleDist('definitely-not-a-real-package', 'index.js');
+    expect(url).toBeNull();
+  });
+
+  it('is cached per (pkg, rel) key so repeat calls are cheap', () => {
+    const a = locateMofloModuleDist('swarm', 'message-bus/index.js');
+    const b = locateMofloModuleDist('swarm', 'message-bus/index.js');
+    expect(a).toBe(b);
+  });
+});
+
+describe('hive-mind-tools path resolution (regression for #556)', () => {
+  it('hive-mind_init succeeds (no "Cannot find module" error)', async () => {
+    _resetMofloMemoryCacheForTest();
+    const { hiveMindTools } = await import('../../src/mcp-tools/hive-mind-tools.js');
+    const initTool = hiveMindTools.find(t => t.name === 'hive-mind_init');
+    expect(initTool).toBeDefined();
+
+    const result = await initTool!.handler({ topology: 'hierarchical', queenId: 'test-queen' });
+    expect(result).toMatchObject({
+      success: true,
+      topology: 'hierarchical',
+      status: 'initialized',
+    });
+
+    // Clean up so other tests get a fresh hive
+    const shutdownTool = hiveMindTools.find(t => t.name === 'hive-mind_shutdown');
+    await shutdownTool!.handler({ graceful: true, force: true });
   });
 });

--- a/src/modules/cli/src/mcp-tools/hive-mind-tools.ts
+++ b/src/modules/cli/src/mcp-tools/hive-mind-tools.ts
@@ -10,6 +10,7 @@
  */
 
 import type { MCPTool } from './types.js';
+import { locateMofloModuleDist } from '../services/moflo-require.js';
 
 // Namespace constants — avoids hardcoded strings scattered across handlers
 const HIVE_NS = 'hive-mind' as const;
@@ -19,15 +20,57 @@ const CONSENSUS_TTL_MS = 600_000;
 
 // ===== Lazy-loaded dependencies (avoid eager import of heavy modules) =====
 
-// Use `any` for lazy-loaded singletons to avoid cross-package import type issues
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _messageBus: any = null;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _writeThroughAdapter: any = null;
+// Structural typing of the swarm runtime shapes we use. Defined locally to
+// avoid a hard `@moflo/swarm` type dep — see feedback_no_fixed_depth_paths and
+// the walk-up resolver that locates the built artifact at runtime.
+interface MessageBusInstance {
+  initialize(): Promise<void>;
+  subscribe(id: string, cb: () => void, opts: { namespace: string }): void;
+  unsubscribe(id: string): void;
+  sendUnified(msg: Record<string, unknown>): Promise<string>;
+  broadcastUnified(msg: Record<string, unknown>): Promise<string>;
+  getStats(): { totalMessages: number; messagesPerSecond: number; queueDepth: number; activeNamespaces: number };
+}
+interface MessageBusCtor {
+  new (opts: { processingIntervalMs: number; reaperIntervalMs: number }): MessageBusInstance;
+}
 
-async function getMessageBus() {
+interface WriteThroughAdapterInstance {
+  attach(): void;
+  detach(): void;
+  clearNamespace(ns: string): Promise<void>;
+  getStats(): { written: number; errors: number; reaped: number };
+}
+interface WriteThroughAdapterCtor {
+  new (
+    bus: MessageBusInstance,
+    opts: { enabled: boolean; namespaces: readonly string[] },
+    memStore: (opts: Record<string, unknown>) => Promise<{ success: boolean; id: string; error?: string }>,
+    memOps: {
+      deleteEntry?: (opts: Record<string, unknown>) => Promise<{ success: boolean; error?: string }>;
+      listEntries?: (opts: Record<string, unknown>) => Promise<{ entries: Array<{ key: string; metadata?: Record<string, unknown> }> }>;
+    },
+  ): WriteThroughAdapterInstance;
+}
+
+let _messageBus: MessageBusInstance | null = null;
+let _writeThroughAdapter: WriteThroughAdapterInstance | null = null;
+
+async function importSwarmArtifact(relFromDist: string): Promise<Record<string, unknown>> {
+  const url = locateMofloModuleDist('swarm', relFromDist);
+  if (!url) {
+    throw new Error(
+      `@moflo/swarm artifact not found: src/modules/swarm/dist/${relFromDist}. ` +
+      `Run 'npm run build' to compile the swarm package.`
+    );
+  }
+  return import(url) as Promise<Record<string, unknown>>;
+}
+
+async function getMessageBus(): Promise<MessageBusInstance> {
   if (_messageBus) return _messageBus;
-  const { MessageBus } = await import('../../../../modules/swarm/dist/message-bus/index.js');
+  const mod = await importSwarmArtifact('message-bus/index.js');
+  const MessageBus = mod.MessageBus as MessageBusCtor;
   _messageBus = new MessageBus({
     processingIntervalMs: 50,
     reaperIntervalMs: 60_000,
@@ -36,11 +79,12 @@ async function getMessageBus() {
   return _messageBus;
 }
 
-async function getWriteThroughAdapter() {
+async function getWriteThroughAdapter(): Promise<WriteThroughAdapterInstance> {
   if (_writeThroughAdapter) return _writeThroughAdapter;
 
   const bus = await getMessageBus();
-  const { WriteThroughAdapter } = await import('../../../../modules/swarm/dist/message-bus/write-through-adapter.js');
+  const mod = await importSwarmArtifact('message-bus/write-through-adapter.js');
+  const WriteThroughAdapter = mod.WriteThroughAdapter as WriteThroughAdapterCtor;
 
   // Lazy-load memory functions
   let memStore: ((opts: Record<string, unknown>) => Promise<{ success: boolean; id: string; error?: string }>) | null = null;

--- a/src/modules/cli/src/services/moflo-require.ts
+++ b/src/modules/cli/src/services/moflo-require.ts
@@ -93,37 +93,73 @@ export function mofloResolve(specifier: string): string | null {
 }
 
 /**
- * Locate `src/modules/memory/dist/index.js` by walking up from this file's
- * directory until the path resolves. Layout-invariant across:
- *   - dev source (cli/src/services/)
- *   - built output (cli/dist/src/services/)
- *   - installed package (node_modules/moflo/src/modules/cli/dist/src/services/)
- *   - Windows and POSIX (path.join/dirname are platform-aware)
- *
- * Returns a file:// URL for ESM `import()`, or null if memory isn't built.
+ * Internal moflo packages whose built artifacts can be resolved via walk-up.
+ * Union rather than free string: catches typos at the call site and documents
+ * the intended consumers.
  */
-let cachedMemoryUrl: string | null | undefined;
+export type MofloInternalPackage =
+  | 'memory'
+  | 'swarm'
+  | 'hooks'
+  | 'embeddings'
+  | 'guidance'
+  | 'neural'
+  | 'security'
+  | 'shared'
+  | 'spells'
+  | 'plugins';
 
-function locateMofloMemoryDist(): string | null {
-  if (cachedMemoryUrl !== undefined) return cachedMemoryUrl;
+/**
+ * Locate a built artifact inside `src/modules/<pkg>/dist/<relFromDist>` by
+ * walking up from this file's directory until the path resolves. Layout- and
+ * platform-invariant across:
+ *   - dev source (<caller>/src/...)
+ *   - built output (<caller>/dist/src/...)
+ *   - installed package (node_modules/moflo/src/modules/<caller>/dist/src/...)
+ *   - Windows and POSIX (`path.join`/`dirname` are platform-aware,
+ *     `pathToFileURL` emits valid `file://` URLs on both)
+ *
+ * Consolidates the walk-up logic so callers can't construct brittle
+ * `../../../../` strings that silently point at the wrong package when the
+ * source/dist depth changes (see feedback_no_fixed_depth_paths).
+ *
+ * Returns a `file://` URL suitable for ESM `import()`, or `null` if the
+ * artifact isn't on disk (package not built / missing from install).
+ */
+const moduleDistUrlCache = new Map<string, string | null>();
+
+// Walk cap: the deepest real install is roughly
+// `<consumer>/node_modules/moflo/src/modules/<pkg>/dist/src/<...>` ≈ 8 hops up
+// to the moflo root. 12 gives comfortable headroom for worktree and monorepo
+// layouts without risking an unbounded loop at filesystem root.
+const MAX_WALK_DEPTH = 12;
+
+export function locateMofloModuleDist(pkg: MofloInternalPackage, relFromDist: string): string | null {
+  const cacheKey = `${pkg}::${relFromDist}`;
+  const cached = moduleDistUrlCache.get(cacheKey);
+  if (cached !== undefined) return cached;
 
   let dir = dirname(fileURLToPath(import.meta.url));
-  const rel = join('src', 'modules', 'memory', 'dist', 'index.js');
+  const rel = join('src', 'modules', pkg, 'dist', relFromDist);
 
-  // 12 levels is far more than any real moflo install depth
-  for (let i = 0; i < 12; i++) {
+  for (let i = 0; i < MAX_WALK_DEPTH; i++) {
     const candidate = join(dir, rel);
     if (existsSync(candidate)) {
-      cachedMemoryUrl = pathToFileURL(candidate).href;
-      return cachedMemoryUrl;
+      const url = pathToFileURL(candidate).href;
+      moduleDistUrlCache.set(cacheKey, url);
+      return url;
     }
     const parent = dirname(dir);
     if (parent === dir) break; // filesystem root
     dir = parent;
   }
 
-  cachedMemoryUrl = null;
+  moduleDistUrlCache.set(cacheKey, null);
   return null;
+}
+
+function locateMofloMemoryDist(): string | null {
+  return locateMofloModuleDist('memory', 'index.js');
 }
 
 /**
@@ -151,5 +187,5 @@ export async function importMofloMemory(): Promise<any | null> {
 
 // Test-only: reset the cache between unit tests that mutate the filesystem.
 export function _resetMofloMemoryCacheForTest(): void {
-  cachedMemoryUrl = undefined;
+  moduleDistUrlCache.clear();
 }

--- a/src/modules/hooks/__tests__/swarm-path-resolution.test.ts
+++ b/src/modules/hooks/__tests__/swarm-path-resolution.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression tests for issue #556.
+ *
+ * The previous hand-built `../../../../modules/swarm/dist/...` string walked
+ * up past `src/modules/` and then re-appended `modules/`, producing
+ * `src/modules/modules/swarm/...` — which fails to resolve on every platform.
+ * These tests pin the fix so the broken shape can't come back.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { locateSwarmArtifact } from '../src/swarm/index.js';
+
+describe('hooks/swarm locateSwarmArtifact (regression #556)', () => {
+  it('resolves @moflo/swarm MessageBus from inside the hooks package', () => {
+    const url = locateSwarmArtifact('message-bus/message-bus.js');
+    expect(url).not.toBeNull();
+    expect(url).toMatch(/^file:\/\//);
+  });
+
+  it('never emits a path containing "modules/modules"', () => {
+    const url = locateSwarmArtifact('message-bus/message-bus.js');
+    expect(url).not.toBeNull();
+    // Platform-agnostic: both separators covered.
+    expect(url!).not.toMatch(/[\\/]modules[\\/]modules[\\/]/);
+    expect(url!).not.toMatch(/\/modules\/modules\//);
+  });
+
+  it('returns null when the artifact is missing (no silent success)', () => {
+    const url = locateSwarmArtifact('does-not-exist/definitely-not.js');
+    expect(url).toBeNull();
+  });
+});

--- a/src/modules/hooks/src/swarm/index.ts
+++ b/src/modules/hooks/src/swarm/index.ts
@@ -11,6 +11,9 @@
  */
 
 import { EventEmitter } from 'node:events';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { reasoningBank, type GuidancePattern } from '../reasoningbank/index.js';
 import type {
   IMessageBus,
@@ -19,31 +22,57 @@ import type {
   MessageFilter,
 } from '../../../../modules/swarm/src/types.js';
 
-// Lazy-load MessageBus to avoid hard dependency on swarm package at import time.
-// The swarm package compiles to dist/ but hooks references src/ paths — lazy
-// import avoids the broken path at module evaluation time.
-async function loadMessageBus(): Promise<new () => IMessageBus> {
-  try {
-    // Try dist first (correct compiled output)
-    const mod = await import('../../../../modules/swarm/dist/message-bus/message-bus.js');
-    return mod.MessageBus;
-  } catch {
-    try {
-      // Fallback: src path (may have pre-compiled .js)
-      const mod = await import('../../../../modules/swarm/src/message-bus/message-bus.js');
-      return mod.MessageBus;
-    } catch {
-      // Final fallback: no-op message bus
-      const NoopMessageBus = class {
-        async initialize() {}
-        async shutdown() {}
-        async publish() {}
-        subscribe() { return () => {}; }
-        getMessages() { return []; }
-      };
-      return NoopMessageBus as unknown as new () => IMessageBus;
-    }
+/**
+ * Walk up from this file to find `src/modules/swarm/dist/<rel>`. Layout- and
+ * platform-invariant — works from source, built, and installed contexts on
+ * Windows/Linux/macOS. Mirrors `locateMofloModuleDist` in @moflo/cli
+ * (feedback_no_fixed_depth_paths: never use fixed ../ counts to cross
+ * moflo packages).
+ */
+export function locateSwarmArtifact(relFromDist: string): string | null {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  const rel = join('src', 'modules', 'swarm', 'dist', relFromDist);
+  for (let i = 0; i < 12; i++) {
+    const candidate = join(dir, rel);
+    if (existsSync(candidate)) return pathToFileURL(candidate).href;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
+  return null;
+}
+
+// Lazy-load MessageBus: the swarm package is a runtime peer and may not be
+// built in every consumer install. On failure we fall back to a no-op bus so
+// hooks keep functioning; the failure is logged (feedback_no_silent_failures)
+// rather than swallowed.
+async function loadMessageBus(): Promise<new () => IMessageBus> {
+  const url = locateSwarmArtifact('message-bus/message-bus.js');
+  if (url) {
+    try {
+      const mod = await import(url);
+      return mod.MessageBus;
+    } catch (err) {
+      console.warn(
+        `[moflo/hooks] Failed to load @moflo/swarm MessageBus from ${url}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  } else {
+    console.warn(
+      '[moflo/hooks] @moflo/swarm MessageBus not built — using no-op bus. ' +
+      'Run `npm run build` to enable swarm coordination.',
+    );
+  }
+  // No-op fallback — hooks continue to work without cross-agent messaging.
+  const NoopMessageBus = class {
+    async initialize() {}
+    async shutdown() {}
+    async publish() {}
+    subscribe() { return () => {}; }
+    getMessages() { return []; }
+  };
+  return NoopMessageBus as unknown as new () => IMessageBus;
 }
 
 // ============================================================================

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,10 @@ export const isolationTests = [
   'src/modules/spells/__tests__/prerequisites-resolve.test.ts',
   'src/modules/spells/__tests__/prerequisites-integration.test.ts',
   'tests/bin/gate-helpers.test.ts',
+  // Spawn/kill timing sensitive — `getActive returns only alive processes`
+  // intermittently observes the child before it's reaped on Windows maxForks=2.
+  // Passes in isolation; add here rather than retry-in-place.
+  'tests/bin/process-manager.test.ts',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- `mcp__moflo__hive-mind_init` threw `Cannot find module src/modules/modules/swarm/...` at runtime because hand-built `../../../../modules/swarm/dist/...` strings walked up 4 levels to `src/modules/` and then re-appended `modules/swarm/...`, doubling the segment.
- Source-tree tests hid the bug: from `cli/src/mcp-tools/`, 4 levels up happens to reach `src/`, so the same string resolves correctly. Only the `dist/` build shipped to users was broken.
- Introduces `locateMofloModuleDist(pkg, rel)` in `cli/services/moflo-require.ts` — walks up from `import.meta.url` looking for `src/modules/<pkg>/dist/<rel>`, returns a `file://` URL or null. Platform-invariant, cached per `(pkg, rel)`, typed on a `MofloInternalPackage` union.
- Same bug was present (and silently swallowed by a no-op fallback) in `hooks/swarm/index.ts`; fixed there too. Failures now log instead of silently degrading to a stub MessageBus.
- `mcp-tools-deep.test.ts` globally mocked `fs` in a way that returned `false` for every real path — defeating any honest resolver. Reads now fall through to real fs via `vi.importActual + spread` while writes stay stubbed.
- Added regression tests asserting no path containing `modules/modules` can be emitted; added end-to-end `hive-mind_init` invocation against the real walk-up.
- Moved `tests/bin/process-manager.test.ts` to the isolation list — passes alone, races on Windows maxForks=2 under full-suite load.

### Acceptance criteria (from #556)

- [x] `mcp__moflo__hive-mind_init` succeeds with hierarchical topology (covered by new e2e test)
- [x] `hive-mind_spawn`, `hive-mind_status`, `hive-mind_consensus` all route through the same fixed resolver
- [x] Path resolution uses a standard anchor helper (`locateMofloModuleDist`), not string concatenation

## Test plan

- [x] New `moflo-require.test.ts` cases pass — walk-up resolves `@moflo/swarm` and `@moflo/memory` dists; verifies no `modules/modules/` shape is ever emitted; returns null for missing packages; caches per `(pkg, rel)`.
- [x] New `swarm-path-resolution.test.ts` in hooks pins the same invariants for the hooks-side helper.
- [x] New e2e: `hive-mind_init` handler runs end-to-end without `Cannot find module` (was previously only green by accident in source-tree tests).
- [x] `mcp-tools-deep.test.ts` still green after the fs-mock fall-through refactor (105/105).
- [x] Full suite: 7896 passed, 0 failed (was 5 failing on main; 2 fixed by this change, 3 were flaky on Windows and tackled via isolation-list entry).
- [x] `npm run lint` clean.
- [x] `npm run build` clean.

## Out of scope (follow-ups)

- `src/modules/cli/src/mcp-tools/spell-tools.ts` (~L709-718) has four more `../../../../modules/spells/src/...` dynamic imports with the same brittle pattern. Not exercised by the #556 repro but worth its own PR.

Closes #556

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)