### PR TITLE
fix(spells): walk-up resolver for spell-tools + grimoire-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ src/modules/*/package-lock.json
 
 # MoFlo state (gitignored)
 .claude-epic/
+
+# Local runtime cache
+local_cache/

--- a/src/modules/cli/__tests__/services/moflo-require.test.ts
+++ b/src/modules/cli/__tests__/services/moflo-require.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'os';
 import {
   importMofloMemory,
   locateMofloModuleDist,
+  locateMofloModulePath,
   _resetMofloMemoryCacheForTest,
 } from '../../src/services/moflo-require.js';
 
@@ -133,6 +134,37 @@ describe('locateMofloModuleDist (regression guard for #556)', () => {
   it('is cached per (pkg, rel) key so repeat calls are cheap', () => {
     const a = locateMofloModuleDist('swarm', 'message-bus/index.js');
     const b = locateMofloModuleDist('swarm', 'message-bus/index.js');
+    expect(a).toBe(b);
+  });
+});
+
+describe('locateMofloModulePath (non-dist subpaths)', () => {
+  beforeEach(() => {
+    _resetMofloMemoryCacheForTest();
+  });
+
+  it('returns null for a non-existent subpath (no silent success)', () => {
+    const result = locateMofloModulePath('spells', 'definitely-not-a-real-subdir');
+    expect(result).toBeNull();
+  });
+
+  it('resolves an existing non-dist subpath (e.g. package.json)', () => {
+    // Every moflo package has a package.json — use it as a stable marker.
+    const result = locateMofloModulePath('spells', 'package.json');
+    expect(result).not.toBeNull();
+    expect(existsSync(result!)).toBe(true);
+    expect(result!).toMatch(/[\\/]src[\\/]modules[\\/]spells[\\/]package\.json$/);
+  });
+
+  it('never emits a "modules/modules" path shape', () => {
+    const result = locateMofloModulePath('spells', 'package.json');
+    expect(result).not.toBeNull();
+    expect(result!).not.toMatch(/[\\/]modules[\\/]modules[\\/]/);
+  });
+
+  it('is cached per (pkg, rel) key', () => {
+    const a = locateMofloModulePath('spells', 'package.json');
+    const b = locateMofloModulePath('spells', 'package.json');
     expect(a).toBe(b);
   });
 });

--- a/src/modules/cli/src/mcp-tools/spell-tools.ts
+++ b/src/modules/cli/src/mcp-tools/spell-tools.ts
@@ -19,6 +19,7 @@ import {
 } from '../services/engine-loader.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { buildGrimoire } from '../services/grimoire-builder.js';
+import { locateMofloModuleDist } from '../services/moflo-require.js';
 
 
 // ============================================================================
@@ -60,6 +61,55 @@ interface TrackedSpell {
 
 const MAX_TRACKED = 100;
 const trackedSpells = new Map<string, TrackedSpell>();
+
+// ============================================================================
+// @moflo/spells artifact loading
+//
+// Depth-invariant alternative to brittle '../../../../modules/spells/...'
+// relative imports. Those strings happened to resolve in the source tree and
+// blew up in the shipped dist layout (see PR #556 for the same class of bug
+// in hive-mind-tools). locateMofloModuleDist walks up from import.meta.url
+// to find src/modules/spells/dist/<rel> regardless of caller depth.
+// ============================================================================
+
+interface StepCommand {
+  readonly type: string;
+}
+type StepCommandSource = 'npm' | 'built-in' | 'user';
+interface StepCommandRegistryInstance {
+  register(command: StepCommand, source?: StepCommandSource): void;
+}
+interface StepCommandRegistryCtor {
+  new (): StepCommandRegistryInstance;
+}
+interface SpellPermissionReport {
+  permissionHash: string;
+  overallRisk: string;
+}
+
+interface PermissionAcceptanceModule {
+  recordAcceptance(projectRoot: string, spellIdentifier: string, permissionHash: string): Promise<void>;
+}
+interface PermissionDisclosureModule {
+  analyzeSpellPermissions(definition: SpellDefinition, registry: StepCommandRegistryInstance): SpellPermissionReport;
+}
+interface StepCommandRegistryModule {
+  StepCommandRegistry: StepCommandRegistryCtor;
+}
+interface BuiltinCommandsModule {
+  builtinCommands: readonly StepCommand[];
+}
+
+async function importSpellsArtifact<T>(relFromDist: string): Promise<T> {
+  const url = locateMofloModuleDist('spells', relFromDist);
+  if (!url) {
+    throw new Error(
+      `@moflo/spells artifact not found: src/modules/spells/dist/${relFromDist}. ` +
+      `Run 'npm run build' to compile the spells package.`
+    );
+  }
+  return import(url) as Promise<T>;
+}
 
 function evictOldest(): void {
   if (trackedSpells.size <= MAX_TRACKED) return;
@@ -704,18 +754,20 @@ export const spellTools: MCPTool[] = [
     handler: async (input) => {
       const spellName = input.name as string;
 
-      // Dynamically import to avoid circular deps with the spell engine
-      const { recordAcceptance } = await import(
-        '../../../../modules/spells/src/core/permission-acceptance.js'
+      // Load via depth-invariant walk-up (PR #556 pattern) — relative
+      // ../../../../ strings silently point at the wrong dir under the dist
+      // layout that ships to consumers.
+      const { recordAcceptance } = await importSpellsArtifact<PermissionAcceptanceModule>(
+        'core/permission-acceptance.js'
       );
-      const { analyzeSpellPermissions } = await import(
-        '../../../../modules/spells/src/core/permission-disclosure.js'
+      const { analyzeSpellPermissions } = await importSpellsArtifact<PermissionDisclosureModule>(
+        'core/permission-disclosure.js'
       );
-      const { StepCommandRegistry } = await import(
-        '../../../../modules/spells/src/core/step-command-registry.js'
+      const { StepCommandRegistry } = await importSpellsArtifact<StepCommandRegistryModule>(
+        'core/step-command-registry.js'
       );
-      const { builtinCommands } = await import(
-        '../../../../modules/spells/src/commands/index.js'
+      const { builtinCommands } = await importSpellsArtifact<BuiltinCommandsModule>(
+        'commands/index.js'
       );
 
       const projectRoot = findProjectRoot();

--- a/src/modules/cli/src/services/grimoire-builder.ts
+++ b/src/modules/cli/src/services/grimoire-builder.ts
@@ -7,26 +7,29 @@
  * set of spells under the same precedence rules.
  */
 
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import type { Grimoire } from '../../../../modules/spells/src/registry/spell-registry.js';
 import { loadMofloConfig } from '../config/moflo-config.js';
 import { loadSpellEngine, type EngineModule } from './engine-loader.js';
+import { locateMofloModulePath } from './moflo-require.js';
 
 /**
  * Resolve the shipped + user spell directories for a project.
  *
- * `shippedDir` defaults to the bundled `modules/spells/definitions` folder
- * relative to this file, so it keeps working in both source and dist layouts
- * per `feedback_consumer_path_resolution` (always anchored to `import.meta.url`).
+ * `shippedDir` defaults to the bundled `src/modules/spells/definitions` folder,
+ * resolved via a depth-invariant walk-up (layout-safe across source, dist, and
+ * installed-under-consumer's-node_modules/moflo/). The prior fixed-depth
+ * `../../../../modules/spells/definitions` string silently pointed at the
+ * wrong directory from the compiled `dist/src/services/` location — same class
+ * of bug as PR #556.
+ *
+ * Returns an empty string when the shipped dir isn't present on disk (e.g.
+ * pre-built source tree); the loader treats missing dirs as a no-op.
  */
 export function resolveSpellDirs(projectRoot: string): { shippedDir: string; userDirs: string[] } {
   const config = loadMofloConfig(projectRoot);
 
-  const defaultShippedDir = resolve(
-    dirname(fileURLToPath(import.meta.url)),
-    '../../../../modules/spells/definitions',
-  );
+  const defaultShippedDir = locateMofloModulePath('spells', 'definitions') ?? '';
   const shippedDir = config.spells.shippedDir
     ? resolve(projectRoot, config.spells.shippedDir)
     : defaultShippedDir;

--- a/src/modules/cli/src/services/moflo-require.ts
+++ b/src/modules/cli/src/services/moflo-require.ts
@@ -163,6 +163,44 @@ function locateMofloMemoryDist(): string | null {
 }
 
 /**
+ * Locate a filesystem path inside `src/modules/<pkg>/<rel>` (not limited to
+ * `dist/`) by the same walk-up strategy as locateMofloModuleDist. Useful for
+ * non-built data folders shipped alongside the module — e.g. spell YAML
+ * definitions, template assets, etc.
+ *
+ * Cross-platform: `path.join` handles separators on POSIX and Windows;
+ * `existsSync` returns the same answer in all environments. Works whether
+ * moflo is running from dev source, its own dist, or installed under a
+ * consumer's `node_modules/moflo/`.
+ *
+ * Returns the absolute filesystem path, or null if not found.
+ */
+const moduleSubpathCache = new Map<string, string | null>();
+
+export function locateMofloModulePath(pkg: MofloInternalPackage, rel: string): string | null {
+  const cacheKey = `${pkg}::${rel}`;
+  const cached = moduleSubpathCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  let dir = dirname(fileURLToPath(import.meta.url));
+  const relPath = join('src', 'modules', pkg, rel);
+
+  for (let i = 0; i < MAX_WALK_DEPTH; i++) {
+    const candidate = join(dir, relPath);
+    if (existsSync(candidate)) {
+      moduleSubpathCache.set(cacheKey, candidate);
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  moduleSubpathCache.set(cacheKey, null);
+  return null;
+}
+
+/**
  * Import `@moflo/memory` from within a moflo source module.
  *
  * The root `moflo` package ships @moflo/memory as a source folder rather than
@@ -185,7 +223,8 @@ export async function importMofloMemory(): Promise<any | null> {
   }
 }
 
-// Test-only: reset the cache between unit tests that mutate the filesystem.
+// Test-only: reset the caches between unit tests that mutate the filesystem.
 export function _resetMofloMemoryCacheForTest(): void {
   moduleDistUrlCache.clear();
+  moduleSubpathCache.clear();
 }


### PR DESCRIPTION
## Summary

- Two more instances of the PR #556 class of bug: hand-built `../../../../modules/spells/...` runtime paths that *happened* to resolve in the source tree but silently pointed at the wrong directory from the shipped `dist/` layout. Same silent-runtime-failure-in-consumer-installs pattern, same fix.
- Adds `locateMofloModulePath(pkg, rel)` helper alongside the existing `locateMofloModuleDist(...)` for non-dist subpaths (shipped spell YAML definitions, template assets, etc.).
- Filed #575 as the follow-up for a systematic audit of remaining fixed-depth paths + cross-platform / installed-layout verification.

## What changed

- `spell-tools.ts` — four dynamic imports in the `spell_accept` handler (permission-acceptance, permission-disclosure, step-command-registry, commands/index) now route through a typed `importSpellsArtifact<T>()` backed by `locateMofloModuleDist('spells', ...)`.
- `grimoire-builder.ts` — default `shippedDir` for shipped spell YAML definitions now uses `locateMofloModulePath('spells', 'definitions')` instead of the fixed-depth string.
- `moflo-require.ts` — new `locateMofloModulePath(pkg, rel)` helper with its own cache, sharing the `MAX_WALK_DEPTH` walk strategy.
- `moflo-require.test.ts` — 4 new regression tests for the new helper.
- `.gitignore` — `local_cache/` added under the MoFlo-state block.

## Why these are bugs, not cleanup

Identical pattern to #556. From `src/modules/cli/src/.../*.ts` four levels up is `src/`, so `src/modules/spells/...` resolves in the source tree used by tests. From the shipped `src/modules/cli/dist/src/.../*.js` four levels up is `src/modules/cli/`, so the same string resolves to `src/modules/cli/modules/spells/...` which doesn't exist. Consumer installs would fail at runtime with `ENOENT`.

The remaining `import type { ... } from '../../../../modules/spells/src/...'` lines in `engine-loader.ts` and `grimoire-builder.ts:12` are intentionally left alone — `import type` is erased at compile time, TS resolves them against the `.ts` source tree (consistent depth), and any break would be loud at build time rather than silent at runtime. #575 tracks the broader audit.

## Test plan

- [x] `npm run build` in `src/modules/cli` — clean
- [x] `npx vitest run src/modules/cli/__tests__/services/moflo-require.test.ts` — 13/13 pass (includes the new 4)
- [x] `npx vitest run src/modules/cli/__tests__/mcp-tools-deep.test.ts` — 105/105 pass
- [x] `npx vitest run --config vitest.isolation.config.ts src/modules/cli/__tests__/spell-tools-engine.test.ts` — 25/25 pass
- [x] Full `node scripts/test-runner.mjs` (parallel + isolation) — 7900/7900 pass, 0 failed
- [x] ESLint clean on changed files
- [ ] Verified on Windows (this branch was authored on Windows 11)
- [ ] #575 tracks the installed-layout + Linux/macOS smoke verification

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)