### PR TITLE
test(cli): pretrain benchmark hash-embedding regression guard (#560)

### DIFF
--- a/src/modules/cli/__tests__/pretrain-no-hash-embeddings.test.ts
+++ b/src/modules/cli/__tests__/pretrain-no-hash-embeddings.test.ts
@@ -1,0 +1,84 @@
+// Regression guard for issue #560 — `moflo benchmark pretrain` must measure
+// the real fastembed embedder, never an inline charCodeAt+Math.sin hash.
+//
+// The repo-wide ESLint structural rule in .eslintrc.cjs deliberately exempts
+// benchmarks/ paths (benchmarks legitimately compute synthetic vectors for
+// math throughput). That exemption is how the hash implementations originally
+// landed in benchmarkEmbeddingGeneration + benchmarkPretrainPipeline and
+// shipped under a user-visible "Embedding Generation: N ops/sec" label.
+//
+// Consumer-smoke's verifyNoInlineHashEmbeddings catches this at dist time,
+// but that only runs per-PR; this fast unit-level guard fails immediately if
+// the pattern is reintroduced.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const PRETRAIN_SRC = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'src',
+  'benchmarks',
+  'pretrain',
+  'index.ts',
+);
+
+// Matches `function NAME(`, `async function NAME(`, and optionally-prefixed
+// `export` variants — so dropping `export` or `async` during a refactor still
+// lets the guard find the body instead of silently passing as "function gone".
+function extractFunctionBody(source: string, name: string): string {
+  const header = new RegExp(
+    `(?:export\\s+)?(?:async\\s+)?function\\s+${name}\\s*\\(`,
+  ).exec(source);
+  if (!header) throw new Error(`function ${name} not found in pretrain/index.ts`);
+  const openBrace = source.indexOf('{', header.index + header[0].length);
+  if (openBrace === -1) throw new Error(`function ${name} has no body`);
+
+  let depth = 1;
+  for (let i = openBrace + 1; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(openBrace, i + 1);
+    }
+  }
+  throw new Error(`function ${name} body is unbalanced`);
+}
+
+describe('pretrain benchmark hash-embedding regression guard (#560)', () => {
+  const source = readFileSync(PRETRAIN_SRC, 'utf8');
+  const embeddingGenBody = extractFunctionBody(source, 'benchmarkEmbeddingGeneration');
+  const pipelineBody = extractFunctionBody(source, 'benchmarkPretrainPipeline');
+
+  const cases: Array<[string, string]> = [
+    ['benchmarkEmbeddingGeneration', embeddingGenBody],
+    ['benchmarkPretrainPipeline', pipelineBody],
+  ];
+
+  for (const [fn, body] of cases) {
+    it(`${fn} contains no inline hash-embedding pattern`, () => {
+      // These two functions are embedding benchmarks — charCodeAt in their
+      // body is never legitimate, so a bare presence check is the right gate.
+      expect(body).not.toMatch(/\bcharCodeAt\s*\(/);
+      // Catches FNV `hash / 0xffffffff` even if charCodeAt gets renamed.
+      expect(body).not.toMatch(/\/\s*0x[fF]{8}\b/);
+    });
+  }
+
+  it('benchmarkEmbeddingGeneration exercises the real IEmbeddingService', () => {
+    // Route through the production factory; a renamed local fallback
+    // (e.g. an inline `generateEmbedding`) would fail these assertions.
+    expect(embeddingGenBody).toMatch(/createEmbeddingService\s*\(/);
+    expect(embeddingGenBody).toMatch(/['"]fastembed['"]/);
+    expect(embeddingGenBody).toMatch(/service\.embed\(/);
+  });
+
+  it('benchmarkPretrainPipeline uses synthetic random vectors, not hash-derived ones', () => {
+    // Math.random is obviously synthetic; Math.sin(charCodeAt) looks real and
+    // misled users about `moflo benchmark pretrain` throughput in #560.
+    expect(pipelineBody).toMatch(/Math\.random\s*\(/);
+  });
+});

--- a/src/modules/embeddings/docs/audits/2026-04-23-float32array-producers.md
+++ b/src/modules/embeddings/docs/audits/2026-04-23-float32array-producers.md
@@ -10,7 +10,7 @@
 **Related:**
 - Epic #527 — "Hard-require neural embeddings; remove all hash fallbacks"
 - Issue #558 — "Purge remaining inline hash embeddings caught by unscoped guard"
-- Issue #560 — "Pretrain benchmark ships hash-based embeddings" (audit follow-up)
+- Issue #560 — "Pretrain benchmark ships hash-based embeddings" (resolved in PR #565; regression guard added under `src/modules/cli/__tests__/pretrain-no-hash-embeddings.test.ts`)
 - ADR-EMB-001 — Neural embeddings mandatory
 
 ## Methodology
@@ -36,16 +36,18 @@
 
 | Category | Files | Notes |
 |---|---|---|
-| PROVIDER | 12 | All reached via constructor/DI; none ambient. |
+| PROVIDER | 13 | All reached via constructor/DI; none ambient. `benchmarkEmbeddingGeneration` now routes through `createEmbeddingService` (#560, PR #565). |
 | STORAGE / DESERIALIZATION | 6 | Reconstitute provider output; safe. |
-| NON-SEMANTIC | 34+ | RL, LoRA, attention, optimiser state, math helpers. |
+| NON-SEMANTIC | 35+ | RL, LoRA, attention, optimiser state, math helpers. Now includes `benchmarkPretrainPipeline`'s `Math.random` fixture vectors (pipeline-wiring measurement, not a text→vector; #560). |
 | NEEDS-FIX (tracked in #558) | 4 | `eslint-disable` with `tracked by #558`. |
-| **NEEDS-FIX (new, not in #558)** | **1 file / 2 sites** | `benchmarks/pretrain/index.ts` — tracked as #560. |
+| **NEEDS-FIX (new, not in #558)** | **0** | `benchmarks/pretrain/index.ts` was promoted to PROVIDER + NON-SEMANTIC in PR #565 (issue #560). |
 
 Net result: the name-based guard already caught everything #558 tracks. The
 structural guard (`Float32Array + charCodeAt`) missed two hash-embedding sites
 inside `src/modules/cli/src/benchmarks/pretrain/index.ts` because the rule exempts
-paths under `benchmarks/`. These are filed as a new follow-up.
+paths under `benchmarks/`. Those were fixed in PR #565 and are now covered by a
+dedicated `__tests__/` regression guard (`pretrain-no-hash-embeddings.test.ts`)
+that is NOT subject to the `benchmarks/` exemption.
 
 ## PROVIDER — Flows through `IEmbeddingProvider`
 
@@ -63,6 +65,7 @@ paths under `benchmarks/`. These are filed as a new follow-up.
 | `src/modules/swarm/src/attention-coordinator.ts:829,889,897,891` | Same pattern — prefers caller-supplied vector, otherwise delegates to `this.embeddingProvider.embed`. | PR #543. |
 | `src/modules/hooks/src/reasoningbank/index.ts:862-868,1022-1028` | `ensureEmbedding()` calls the injected `embeddingService`. | Constructor-injected. |
 | `src/modules/cli/src/commands/embeddings.ts` | CLI wrapper over provider results. | Same DI path. |
+| `src/modules/cli/src/benchmarks/pretrain/index.ts:290-313` (`benchmarkEmbeddingGeneration`) | `createEmbeddingService({ provider: 'fastembed' })` + `service.embed(...)`. | Shipped via `moflo benchmark pretrain`; the reported number now reflects real fastembed throughput (#560, PR #565). |
 
 ## STORAGE / DESERIALIZATION — Reconstitutes prior provider output
 
@@ -105,6 +108,11 @@ Grouped by concern for readability.
 | `src/modules/cli/src/services/training-utils.ts:32-69,186-190` | Adam optimiser `m`/`v`, contrastive-loss gradient buffer. |
 | `src/modules/cli/src/services/movector-training.ts:128,233` | MoE expert-weight init, synthetic gradient for reward-shaped adaptation. |
 
+### Benchmark fixtures (pipeline-wiring measurement, not text→vector)
+| File | What the `Float32Array` holds |
+|---|---|
+| `src/modules/cli/src/benchmarks/pretrain/index.ts:421-430` (`benchmarkPretrainPipeline`) | Random fixture vectors used to time index construction and pattern extraction. The embedder itself is covered by `benchmarkEmbeddingGeneration` in the PROVIDER table; this helper deliberately uses `Math.random` so it cannot be mistaken for a real embedding (#560, PR #565). |
+
 ### Test-only paths NOT classified
 
 Skipped per audit scope. Listed here only so the audit is demonstrably complete.
@@ -129,26 +137,31 @@ All four carry `// eslint-disable-next-line no-restricted-syntax -- … tracked 
 
 This audit does **not** duplicate those into fresh issues — #558 is their owner.
 
-### #560 — NEW, not in #558
+### #560 — RESOLVED (PR #565)
 
-**Files:**
-- `src/modules/cli/src/benchmarks/pretrain/index.ts:290-312` — `benchmarkEmbeddingGeneration` builds a 384-dim vector from `text.charCodeAt` + `Math.sin`.
-- `src/modules/cli/src/benchmarks/pretrain/index.ts:432-465` — `benchmarkPretrainPipeline` generates 50 file embeddings via `Math.sin(file.path.charCodeAt(...))`.
+**Sites (original):**
+- `src/modules/cli/src/benchmarks/pretrain/index.ts:290-312` — `benchmarkEmbeddingGeneration` built a 384-dim vector from `text.charCodeAt` + `Math.sin`.
+- `src/modules/cli/src/benchmarks/pretrain/index.ts:432-465` — `benchmarkPretrainPipeline` generated 50 file embeddings via `Math.sin(file.path.charCodeAt(...))`.
 
 **Why the guard missed it:** the `no-restricted-syntax` structural rule exempts
 `benchmarks/` paths because benchmarks routinely compute synthetic vectors.
-These two functions however are imported from `src/modules/cli/src/commands/benchmark.ts`
-and are invoked by the user-facing `moflo benchmark` command — so `npm i moflo` ships
-them, and users see "Embedding Generation: N ops/sec" numbers that measure a
+These two functions however were imported from `src/modules/cli/src/commands/benchmark.ts`
+and are invoked by the user-facing `moflo benchmark` command — so `npm i moflo` shipped
+them, and users saw "Embedding Generation: N ops/sec" numbers that measured a
 hash function, not the real fastembed pipeline.
 
-**Recommendation:** either
-1. measure the real `IEmbeddingService` (integrity fix, preferred), or
-2. rename the reported label to `Hash Embedding Baseline (synthetic)` to
-   prevent misleading users, and move the synthetic helper under
-   `__tests__/` or `benchmarks/` where the lint exemption is justified.
+**Fix (option 1 — integrity):**
+- `benchmarkEmbeddingGeneration` now calls `createEmbeddingService({ provider: 'fastembed' }).embed(...)`. The reported throughput is real fastembed.
+- `benchmarkPretrainPipeline` keeps synthetic fixture vectors (its point is to time index/pattern wiring, not the embedder) but uses `Math.random` — an obviously synthetic generator that cannot be mistaken for a real embedding.
 
-Tracked as issue #560.
+**Why a new guard was required after PR #565:** the repo-wide ESLint structural
+rule still exempts `src/**/benchmarks/**`, so a future PR could re-introduce
+`charCodeAt` + `Math.sin` here and lint would stay green. Consumer-smoke's
+`verifyNoInlineHashEmbeddings` catches it at dist time but only on PR CI.
+The regression is now also gated by
+`src/modules/cli/__tests__/pretrain-no-hash-embeddings.test.ts`, which runs
+in the normal unit suite and is NOT subject to the `benchmarks/` exemption
+because it lives under `__tests__/`.
 
 ## Confidence
 
@@ -156,8 +169,9 @@ Tracked as issue #560.
   classified — spot-checked every file listed in the grep index before writing
   this document.
 - High confidence that no production hash-embedding path remains outside
-  `hooks-tools.ts` (tracked by #558) and `benchmarks/pretrain/index.ts`
-  (tracked by the new companion issue).
+  `hooks-tools.ts` (tracked by #558). `benchmarks/pretrain/index.ts` was fixed
+  in PR #565 and is guarded at unit-test time by
+  `pretrain-no-hash-embeddings.test.ts` (outside the `benchmarks/` ESLint exemption).
 - Moderate confidence that `neural/src/{reasoning-bank,reasoningbank-adapter,pattern-learner}.ts`'s
   `computePatternEmbedding` variants are truly non-semantic — they average
   `step.stateAfter` vectors which originate as RL state, not text embeddings.


### PR DESCRIPTION
## Summary

Closes #560. The code fix already shipped in PR #565 — `benchmarkEmbeddingGeneration` now routes through `createEmbeddingService({ provider: 'fastembed' })` and `benchmarkPretrainPipeline` uses `Math.random` for its fixture vectors. This PR adds the two remaining acceptance-criteria items: the regression guard test and the audit-doc update.

## Why a dedicated `__tests__/` guard

The repo-wide ESLint structural rule in `.eslintrc.cjs` (Float32Array + charCodeAt co-occurrence in a single function) explicitly exempts `src/**/benchmarks/**` — benchmarks legitimately compute synthetic vectors for math throughput. That exemption is how the hash embeddings originally landed in the pretrain benchmark and shipped under a user-visible "Embedding Generation: N ops/sec" label. Consumer-smoke's `verifyNoInlineHashEmbeddings` at `harness/consumer-smoke/lib/checks.mjs` catches it at dist time, but only on PR CI. The new `__tests__/` guard fires immediately in the normal unit suite and is not subject to the `benchmarks/` exemption.

## Changes

- `src/modules/cli/__tests__/pretrain-no-hash-embeddings.test.ts` — new regression guard. Reads the source file and asserts, per-function:
  - `benchmarkEmbeddingGeneration` + `benchmarkPretrainPipeline` contain no `charCodeAt(` or FNV `/ 0xffffffff`.
  - `benchmarkEmbeddingGeneration` still references `createEmbeddingService` + `'fastembed'` + `service.embed(`.
  - `benchmarkPretrainPipeline` still uses `Math.random`.
- `src/modules/embeddings/docs/audits/2026-04-23-float32array-producers.md` — move the two sites out of NEEDS-FIX: `benchmarkEmbeddingGeneration` → PROVIDER table; `benchmarkPretrainPipeline` → new "Benchmark fixtures (pipeline-wiring measurement, not text→vector)" subsection under NON-SEMANTIC. Confidence line and header references updated.

## Test plan

- [x] `npx vitest run src/modules/cli/__tests__/pretrain-no-hash-embeddings.test.ts` — 4/4 pass
- [x] `npx vitest run src/modules/cli/__tests__/` — 2063 pass / 11 skipped (59 files)
- [x] `npx vitest run src/modules/embeddings/ tests/guards/` — 198 pass / 1 skipped (12 files)
- [ ] Manual: confirm `moflo benchmark pretrain` output still reports real fastembed throughput

## Acceptance criteria (from #560)

- [x] `benchmarkEmbeddingGeneration` calls the real `IEmbeddingService` — shipped in PR #565
- [x] `benchmarkPretrainPipeline` no inline `Math.sin(charCodeAt)` — shipped in PR #565
- [x] `moflo benchmark` output no longer reports a hash-function's throughput — shipped in PR #565
- [x] A smoke test under `__tests__/` fails if either function is reintroduced with `charCodeAt` + `Math.sin` — **this PR**
- [x] Audit document updated to move sites out of NEEDS-FIX — **this PR**

Closes #560

Co-Authored-By: moflo <noreply@motailz.com>