### PR TITLE
refactor(shared): relocate atomicWriteFileSync for cross-package reuse

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -36,6 +36,26 @@ const BANNED_IDENTIFIER_PATTERN = `^(${BANNED_IDENTIFIERS.join('|')})$`;
 // tag, and any future suffix a contributor might try to sneak through.
 const BANNED_LITERAL_PATTERN = '^domain-aware-hash';
 
+// Issue #564: Flag raw `fs.writeFileSync(path, <anything>.export())` and
+// `writeFileSync(path, Buffer.from(<anything>.export()))` patterns. The
+// `:has(...)` guard scopes the rule to writeFileSync calls whose argument
+// tree contains a `.export()` call — the signature of a sql.js DB write.
+// The canonical `atomicWriteFileSync` helper never nests a `.export()` under
+// its own internal writeFileSync, so it doesn't self-trigger.
+const RAW_DB_WRITE_MESSAGE =
+  'Raw fs.writeFileSync(path, db.export()) is not atomic — SIGINT mid-write ' +
+  'can truncate the DB file. Use atomicWriteFileSync from @moflo/shared ' +
+  '(see #564 / #548).';
+
+const RAW_DB_WRITE_SELECTORS = [
+  {
+    selector:
+      "CallExpression[callee.property.name='writeFileSync']" +
+      ":has(CallExpression[callee.property.name='export'])",
+    message: RAW_DB_WRITE_MESSAGE,
+  },
+];
+
 // Structural guard: any function that both constructs a Float32Array AND
 // calls charCodeAt is a hash embedding regardless of method name. The
 // identifier ban above missed the inline implementations removed in #542
@@ -75,6 +95,7 @@ const bannedEmbeddingRules = {
       message: BANNED_EMBEDDING_MESSAGE,
     },
     ...INLINE_HASH_EMBEDDING_SELECTORS,
+    ...RAW_DB_WRITE_SELECTORS,
   ],
   'no-restricted-imports': [
     'error',

--- a/src/modules/cli/src/commands/memory.ts
+++ b/src/modules/cli/src/commands/memory.ts
@@ -12,6 +12,7 @@ import { output } from '../output.js';
 import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { mofloImport } from '../services/moflo-require.js';
+import { atomicWriteFileSync } from '../services/atomic-file-write.js';
 
 // Memory backends
 const BACKENDS = [
@@ -1520,8 +1521,7 @@ async function openDb(cwd: string): Promise<{ db: any; dbPath: string; SQL: any 
 }
 
 function saveAndCloseDb(db: any, dbPath: string): void {
-  const data = db.export();
-  fs.writeFileSync(dbPath, Buffer.from(data));
+  atomicWriteFileSync(dbPath, db.export());
   db.close();
 }
 
@@ -2208,11 +2208,8 @@ const rebuildIndexCommand: Command = {
         failed++;
       }
 
-      // Batch save every BATCH_SIZE entries
       if ((i + 1) % BATCH_SIZE === 0) {
-        const fs = await import('fs');
-        const data = db.export();
-        fs.writeFileSync(dbPath, Buffer.from(data));
+        atomicWriteFileSync(dbPath, db.export());
       }
     }
 

--- a/src/modules/cli/src/memory/bridge-core.ts
+++ b/src/modules/cli/src/memory/bridge-core.ts
@@ -8,6 +8,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
+import { atomicWriteFileSync } from '../services/atomic-file-write.js';
 
 // When run via npx, CWD may be node_modules/moflo — walk up to find actual project
 let _projectRoot: string | undefined;
@@ -176,9 +177,8 @@ export function persistBridgeDb(db: any, dbPath?: string): void {
     : path.join(getProjectRoot(), '.swarm', 'memory.db');
   if (target === ':memory:') return;
   try {
-    const data = db.export();
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, Buffer.from(data));
+    atomicWriteFileSync(target, db.export());
   } catch (err) {
     logBridgeError('bridge persist failed', err);
   }

--- a/src/modules/cli/src/memory/memory-initializer.ts
+++ b/src/modules/cli/src/memory/memory-initializer.ts
@@ -12,6 +12,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { mofloImport, importMofloMemory } from '../services/moflo-require.js';
+import { atomicWriteFileSync } from '../services/atomic-file-write.js';
 import { formatEmbeddingError } from './embedding-errors.js';
 
 /**
@@ -1036,9 +1037,7 @@ export async function ensureSchemaColumns(dbPath: string): Promise<{
     }
 
     if (modified) {
-      // Save updated database
-      const data = db.export();
-      fs.writeFileSync(dbPath, Buffer.from(data));
+      atomicWriteFileSync(dbPath, db.export());
     }
 
     db.close();
@@ -1477,9 +1476,7 @@ export async function applyTemporalDecay(dbPath?: string): Promise<{
 
     const changes = db.getRowsModified();
 
-    // Save
-    const data = db.export();
-    fs.writeFileSync(path_, Buffer.from(data));
+    atomicWriteFileSync(path_, db.export());
     db.close();
 
     return {
@@ -1888,9 +1885,7 @@ export async function verifyMemoryInit(dbPath: string, options?: {
     // Cleanup test entry
     db.run(`DELETE FROM memory_entries WHERE id = ?`, [testId]);
 
-    // Save changes
-    const data = db.export();
-    fs.writeFileSync(dbPath, Buffer.from(data));
+    atomicWriteFileSync(dbPath, db.export());
     db.close();
 
     const passed = tests.filter(t => t.passed).length;
@@ -2022,9 +2017,7 @@ export async function storeEntry(options: {
       ttl ? now + (ttl * 1000) : null
     ]);
 
-    // Save
-    const data = db.export();
-    fs.writeFileSync(dbPath, Buffer.from(data));
+    atomicWriteFileSync(dbPath, db.export());
 
     // Query exact stats while DB is still open
     let vecCount = 0, nsCount = 0;
@@ -2423,9 +2416,7 @@ export async function getEntry(options: {
       WHERE id = '${String(id).replace(/'/g, "''")}'
     `);
 
-    // Save updated database
-    const data = db.export();
-    fs.writeFileSync(dbPath, Buffer.from(data));
+    atomicWriteFileSync(dbPath, db.export());
 
     db.close();
 
@@ -2553,9 +2544,7 @@ export async function deleteEntry(options: {
     const countResult = db.exec(`SELECT COUNT(*) FROM memory_entries WHERE status = 'active'`);
     const remainingEntries = countResult[0]?.values?.[0]?.[0] as number || 0;
 
-    // Save updated database
-    const data = db.export();
-    fs.writeFileSync(dbPath, Buffer.from(data));
+    atomicWriteFileSync(dbPath, db.export());
 
     db.close();
 

--- a/src/modules/cli/src/services/atomic-file-write.ts
+++ b/src/modules/cli/src/services/atomic-file-write.ts
@@ -1,45 +1,55 @@
 /**
- * Atomic filesystem writes for files that must not be left corrupted if the
- * process is interrupted mid-write (SIGINT, power loss, ENOSPC).
+ * Sync re-export of `@moflo/shared/utils/atomic-file-write` (#564).
  *
- * Pattern: write to `<target>.tmp`, then rename onto `target`.
- *   - `fs.renameSync` is atomic on POSIX.
- *   - On Windows, Node maps it to `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`,
- *     which replaces the destination near-atomically — concurrent readers
- *     always observe either the old file or the new, never a truncated one.
+ * The canonical helper lives in `@moflo/shared` so that `embeddings`, `memory`,
+ * and `shared` itself can share it. Bare `import from '@moflo/shared'` does NOT
+ * resolve at runtime in this monorepo because cross-package symlinks aren't
+ * shipped in the published `moflo` tarball. Instead we reuse the existing
+ * walk-up resolver (`locateMofloModulePath`) to find the compiled JS file on
+ * disk and `createRequire` to sync-load it — the same pattern `doctor.ts` uses
+ * to reach `@moflo/neural`.
  *
- * On any failure, the temp file is best-effort removed and the original
- * `target` stays intact. The underlying error is always re-thrown.
- *
- * `fs` is injectable so the interrupt-mid-write paths can be exercised in
- * unit tests without depending on ESM-unfriendly module spies.
+ * The shared module is loaded lazily on first call rather than at import time
+ * so tests that mock `./moflo-require.js` (for other, unrelated reasons)
+ * aren't forced to re-export `locateMofloModulePath`. Keeping the load lazy
+ * also means cli modules that import this shim but never actually call the
+ * helper don't pay the walk-up cost.
  *
  * @module @moflo/cli/services/atomic-file-write
  */
 
-import * as realFs from 'node:fs';
+import { createRequire } from 'node:module';
+import { locateMofloModulePath } from './moflo-require.js';
 
-export interface AtomicWriteFs {
-  writeFileSync: typeof realFs.writeFileSync;
-  renameSync: typeof realFs.renameSync;
-  unlinkSync: typeof realFs.unlinkSync;
-}
+// Type-only import — erased at runtime. Pulls types via TS project reference
+// to `@moflo/shared`, so callers get full type inference from the canonical
+// source without needing a runtime dependency edge.
+import type {
+  atomicWriteFileSync as AtomicWriteFileSyncFn,
+  AtomicWriteFs as AtomicWriteFsType,
+} from '../../../shared/src/utils/atomic-file-write.js';
 
-export function atomicWriteFileSync(
-  targetPath: string,
-  data: Buffer | Uint8Array | string,
-  fs: AtomicWriteFs = realFs,
-): void {
-  const tmpPath = `${targetPath}.tmp`;
-  try {
-    fs.writeFileSync(tmpPath, data);
-    fs.renameSync(tmpPath, targetPath);
-  } catch (err) {
-    try {
-      fs.unlinkSync(tmpPath);
-    } catch {
-      /* best-effort cleanup — temp may not exist if writeFileSync failed early */
-    }
-    throw err;
+export type AtomicWriteFs = AtomicWriteFsType;
+
+let cached: typeof AtomicWriteFileSyncFn | null = null;
+
+function loadShared(): typeof AtomicWriteFileSyncFn {
+  if (cached) return cached;
+  const sharedPath = locateMofloModulePath('shared', 'dist/utils/atomic-file-write.js');
+  if (!sharedPath) {
+    throw new Error(
+      '@moflo/shared utils/atomic-file-write.js not found on disk. ' +
+        'Build @moflo/shared first (`npm run build` or `tsc -b`).',
+    );
   }
+  const req = createRequire(import.meta.url);
+  const shared = req(sharedPath) as { atomicWriteFileSync: typeof AtomicWriteFileSyncFn };
+  cached = shared.atomicWriteFileSync;
+  return cached;
 }
+
+export const atomicWriteFileSync: typeof AtomicWriteFileSyncFn = (
+  targetPath,
+  data,
+  fs,
+) => loadShared()(targetPath, data, fs);

--- a/src/modules/cli/src/services/learning-service.ts
+++ b/src/modules/cli/src/services/learning-service.ts
@@ -13,9 +13,10 @@
  * - HNSW indexing for fast similarity search
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { mofloImport } from './moflo-require.js';
+import { atomicWriteFileSync } from './atomic-file-write.js';
 import {
   createNeuralEmbeddingProvider,
   type NeuralEmbeddingProvider,
@@ -628,8 +629,7 @@ export class LearningService {
    */
   save(): void {
     if (!this.db) return;
-    const data = this.db.export();
-    writeFileSync(this.dbPath, Buffer.from(data));
+    atomicWriteFileSync(this.dbPath, this.db.export());
     this.dirty = false;
   }
 

--- a/src/modules/embeddings/src/persistent-cache.ts
+++ b/src/modules/embeddings/src/persistent-cache.ts
@@ -10,8 +10,9 @@
  * - Lazy initialization (no startup cost if not used)
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { dirname } from 'path';
+import { atomicWriteFileSync } from './utils/atomic-file-write.js';
 
 // Use 'any' for sql.js types to avoid complex typing issues
 // sql.js has its own types but they don't always match perfectly
@@ -178,9 +179,7 @@ export class PersistentEmbeddingCache {
     if (!this.db) return;
 
     try {
-      const data = this.db.export();
-      const buffer = Buffer.from(data);
-      writeFileSync(this.dbPath, buffer);
+      atomicWriteFileSync(this.dbPath, this.db.export());
       this.dirty = false;
     } catch (error) {
       console.error('[persistent-cache] Save error:', error);

--- a/src/modules/embeddings/src/utils/atomic-file-write.ts
+++ b/src/modules/embeddings/src/utils/atomic-file-write.ts
@@ -1,0 +1,65 @@
+/**
+ * Sync re-export of `@moflo/shared/utils/atomic-file-write` (#564).
+ *
+ * Mirrors the pattern used by the cli shim at
+ * `@moflo/cli/services/atomic-file-write`: lazy-load the canonical helper via
+ * a filesystem walk-up, because bare `@moflo/shared` doesn't resolve in the
+ * published moflo tree (no cross-package symlinks) and fixed-depth relative
+ * paths into `shared/dist/` leak shared's build layout into embeddings source
+ * — exactly the anti-pattern `feedback_no_fixed_depth_paths` warns about.
+ *
+ * The walk-up is inlined here rather than imported from a shared resolver
+ * because the resolver itself would need cross-package resolution to reach.
+ *
+ * @module @moflo/embeddings/utils/atomic-file-write
+ */
+
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import type {
+  atomicWriteFileSync as AtomicWriteFileSyncFn,
+  AtomicWriteFs as AtomicWriteFsType,
+} from '../../../shared/src/utils/atomic-file-write.js';
+
+export type AtomicWriteFs = AtomicWriteFsType;
+
+const MAX_WALK_DEPTH = 12;
+
+function locateSharedAtomicWriteJs(): string | null {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  const rel = join('src', 'modules', 'shared', 'dist', 'utils', 'atomic-file-write.js');
+  for (let i = 0; i < MAX_WALK_DEPTH; i++) {
+    const candidate = join(dir, rel);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+let cached: typeof AtomicWriteFileSyncFn | null = null;
+
+function loadShared(): typeof AtomicWriteFileSyncFn {
+  if (cached) return cached;
+  const sharedPath = locateSharedAtomicWriteJs();
+  if (!sharedPath) {
+    throw new Error(
+      '@moflo/shared utils/atomic-file-write.js not found on disk. ' +
+        'Build @moflo/shared first (`npm run build` or `tsc -b`).',
+    );
+  }
+  const req = createRequire(import.meta.url);
+  const shared = req(sharedPath) as { atomicWriteFileSync: typeof AtomicWriteFileSyncFn };
+  cached = shared.atomicWriteFileSync;
+  return cached;
+}
+
+export const atomicWriteFileSync: typeof AtomicWriteFileSyncFn = (
+  targetPath,
+  data,
+  fs,
+) => loadShared()(targetPath, data, fs);

--- a/src/modules/embeddings/tsconfig.json
+++ b/src/modules/embeddings/tsconfig.json
@@ -5,5 +5,8 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../shared" }
+  ]
 }

--- a/src/modules/memory/src/rvf-migration.ts
+++ b/src/modules/memory/src/rvf-migration.ts
@@ -3,7 +3,7 @@
  * formats (JSON files, sql.js / better-sqlite3 databases).
  * @module @moflo/memory/rvf-migration
  */
-import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, rename, unlink, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { RvfBackend } from './rvf-backend.js';
@@ -84,13 +84,28 @@ async function ensureDir(filePath: string): Promise<void> {
   if (!existsSync(dir)) await mkdir(dir, { recursive: true });
 }
 
+// Local async helper — exempt from the shared `atomicWriteFileSync` migration
+// in #564 because the migrator runs in an async streaming context and adding
+// sync writes inside the per-entry loop would block the event loop during
+// large migrations. Mirrors the shared helper's temp-file + rename semantics
+// with the addition of a timestamp suffix for concurrent-write isolation and
+// best-effort cleanup on rename failure (restored with this change — PR #564).
 async function atomicWrite(targetPath: string, data: string | Buffer): Promise<void> {
   validateMigrationPath(targetPath);
   const abs = resolve(targetPath);
   const tmp = abs + '.tmp.' + Date.now();
   await ensureDir(abs);
   await writeFile(tmp, data, typeof data === 'string' ? 'utf-8' : undefined);
-  await rename(tmp, abs);
+  try {
+    await rename(tmp, abs);
+  } catch (err) {
+    try {
+      await unlink(tmp);
+    } catch {
+      /* best-effort cleanup — tmp may already be gone */
+    }
+    throw err;
+  }
 }
 
 function mkResult(

--- a/src/modules/shared/__tests__/utils/atomic-file-write.test.ts
+++ b/src/modules/shared/__tests__/utils/atomic-file-write.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for `atomicWriteFileSync` — the temp-file + rename helper that
- * protects DB/config files from mid-write corruption (#548).
+ * protects DB/config files from mid-write corruption (#548, #564).
  *
  * Covers the three failure modes a real SIGINT mid-write can produce:
  *   1. write itself throws (e.g. ENOSPC) — original intact, temp cleaned up
@@ -30,7 +30,7 @@ import { join } from 'node:path';
 import {
   atomicWriteFileSync,
   type AtomicWriteFs,
-} from '../../src/services/atomic-file-write.js';
+} from '../../src/utils/atomic-file-write.js';
 
 const tmpDirs: string[] = [];
 afterEach(() => {
@@ -70,6 +70,21 @@ describe('atomicWriteFileSync (real fs)', () => {
 
     expect(readFileSync(target, 'utf8')).toBe('replaced');
     expect(existsSync(`${target}.tmp`)).toBe(false);
+  });
+
+  it('accepts a Uint8Array directly without Buffer.from wrapping (#564)', () => {
+    // db.export() returns a Uint8Array — the helper must accept it as-is
+    // so callers don't need a Buffer.from(...) copy.
+    const dir = makeTmpDir();
+    const target = join(dir, 'data.bin');
+    const payload = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+
+    atomicWriteFileSync(target, payload);
+
+    const read = readFileSync(target);
+    expect(read.length).toBe(4);
+    expect(read[0]).toBe(0xde);
+    expect(read[3]).toBe(0xef);
   });
 });
 

--- a/src/modules/shared/src/events/rvf-event-log.ts
+++ b/src/modules/shared/src/events/rvf-event-log.ts
@@ -16,8 +16,9 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, renameSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, appendFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-file-write.js';
 import type { DomainEvent } from './domain-events.js';
 
 // Re-export shared interfaces so consumers do not need to import event-store.ts
@@ -108,9 +109,7 @@ export class RvfEventLog extends EventEmitter {
         this.indexEvent(event);
       });
     } else {
-      const tmpLog = this.config.logPath + '.tmp';
-      writeFileSync(tmpLog, MAGIC);
-      renameSync(tmpLog, this.config.logPath);
+      atomicWriteFileSync(this.config.logPath, MAGIC);
     }
 
     // --- snapshots file ---
@@ -120,9 +119,7 @@ export class RvfEventLog extends EventEmitter {
         this.snapshots.set(snap.aggregateId, snap);
       });
     } else {
-      const tmpSnap = this.snapshotPath + '.tmp';
-      writeFileSync(tmpSnap, MAGIC);
-      renameSync(tmpSnap, this.snapshotPath);
+      atomicWriteFileSync(this.snapshotPath, MAGIC);
     }
 
     this.initialized = true;

--- a/src/modules/shared/src/index.ts
+++ b/src/modules/shared/src/index.ts
@@ -198,3 +198,9 @@ export * from './services/index.js';
 // Platform Utilities
 // =============================================================================
 export { IS_WINDOWS, NULL_DEVICE, silenceStderr, getShell, escapeShellArg } from './utils/platform.js';
+
+// =============================================================================
+// Atomic File Write (shared by cli, embeddings, memory, shared itself — #564)
+// =============================================================================
+export { atomicWriteFileSync } from './utils/atomic-file-write.js';
+export type { AtomicWriteFs } from './utils/atomic-file-write.js';

--- a/src/modules/shared/src/utils/atomic-file-write.ts
+++ b/src/modules/shared/src/utils/atomic-file-write.ts
@@ -1,0 +1,45 @@
+/**
+ * Atomic filesystem writes for files that must not be left corrupted if the
+ * process is interrupted mid-write (SIGINT, power loss, ENOSPC).
+ *
+ * Pattern: write to `<target>.tmp`, then rename onto `target`.
+ *   - `fs.renameSync` is atomic on POSIX.
+ *   - On Windows, Node maps it to `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`,
+ *     which replaces the destination near-atomically — concurrent readers
+ *     always observe either the old file or the new, never a truncated one.
+ *
+ * On any failure, the temp file is best-effort removed and the original
+ * `target` stays intact. The underlying error is always re-thrown.
+ *
+ * `fs` is injectable so the interrupt-mid-write paths can be exercised in
+ * unit tests without depending on ESM-unfriendly module spies.
+ *
+ * @module @moflo/shared/utils/atomic-file-write
+ */
+
+import * as realFs from 'node:fs';
+
+export interface AtomicWriteFs {
+  writeFileSync: typeof realFs.writeFileSync;
+  renameSync: typeof realFs.renameSync;
+  unlinkSync: typeof realFs.unlinkSync;
+}
+
+export function atomicWriteFileSync(
+  targetPath: string,
+  data: Buffer | Uint8Array | string,
+  fs: AtomicWriteFs = realFs,
+): void {
+  const tmpPath = `${targetPath}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, data);
+    fs.renameSync(tmpPath, targetPath);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      /* best-effort cleanup — temp may not exist if writeFileSync failed early */
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- Relocates the atomic temp-file + rename helper from `@moflo/cli` to `@moflo/shared` so `embeddings`, `memory`, and `shared` itself can all reach it.
- Migrates 10 sql.js DB persist sites (8 from the ticket + 2 found during review) from `fs.writeFileSync(path, Buffer.from(db.export()))` to `atomicWriteFileSync(path, db.export())` — crash-safe and drops a full DB-sized `Buffer.from()` copy per write.
- Adds an ESLint guard against regressions.

Closes #564

## Changes
- **New canonical helper**: `src/modules/shared/src/utils/atomic-file-write.ts` (moved verbatim from cli + one new test for the Uint8Array path).
- **Cross-package shims** (lazy walk-up + `createRequire`): `cli/services/atomic-file-write.ts` (uses existing `locateMofloModulePath`); `embeddings/src/utils/atomic-file-write.ts` (inlines a minimal walk-up, mirroring the cli pattern). Bare `import from '@moflo/shared'` doesn't resolve at runtime because cross-package symlinks aren't shipped in the published moflo tarball.
- **Migrated sites**: `cli/commands/memory.ts` (2), `cli/services/learning-service.ts`, `cli/memory/bridge-core.ts` (hot path on every memory mutation), `cli/memory/memory-initializer.ts` (6 sites), `embeddings/src/persistent-cache.ts`, `shared/events/rvf-event-log.ts` (also fixes the previously-orphaned `.tmp` on rename failure).
- **Exempt with justification**: `memory/src/rvf-migration.ts` keeps its local async `atomicWrite` (migrator streams through large files; a sync helper would block the event loop). Added best-effort `unlink` on rename failure to match the shared helper's cleanup contract.
- **Regression guard**: `.eslintrc.cjs` adds an AST selector that flags any `fs.writeFileSync(path, ...db.export()...)` tree — the shared helper's internal `writeFileSync` doesn't self-trigger because its argument tree never contains `.export()`.

## Test plan
- [x] 7 unit tests for the shared helper pass (including a new Uint8Array test)
- [x] Full vitest suite: 7905 tests pass, 0 failures (including isolation batch)
- [x] `npm run lint` clean — no warnings
- [x] `npm run test:smoke` — 30/30 consumer smoke checks pass
- [x] Manual ESLint-rule verification: fixture with `fs.writeFileSync(path, db.export())` and `fs.writeFileSync(path, Buffer.from(db.export()))` both flagged
- [ ] Manual SIGINT mid-write integration test — deferred (contract is already covered by the 7 unit tests with injected fs; all 10 call sites now share the exact same helper)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)