### PR TITLE
ci(sandbox): automate ghcr image publish on docker/sandbox/** changes (#566)

### DIFF
--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -1,0 +1,89 @@
+name: Publish sandbox image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/sandbox/**'
+      - '.github/workflows/sandbox-image.yml'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Custom tag override (omit for default: :latest + :sha-<short> on main, :preview-<branch> elsewhere)'
+        required: false
+        type: string
+
+env:
+  IMAGE: ghcr.io/eric-cielo/moflo-sandbox
+
+# Don't cancel in-flight publishes — a mid-push abort can leave partial manifests
+# on the registry. ci.yml uses cancel-in-progress: true because PR builds are
+# idempotent; publishes are not.
+concurrency:
+  group: sandbox-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build & push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: docker/sandbox
+          sparse-checkout-cone-mode: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tagging rules:
+      #   push to main                                -> :latest + :sha-<short>
+      #   workflow_dispatch on main (no tag input)    -> :latest + :sha-<short>
+      #   workflow_dispatch with `tag` input          -> that tag only (never touches :latest)
+      #   workflow_dispatch on non-main (no tag)      -> :preview-<sanitized-branch>
+      - name: Compute tags
+        id: tags
+        env:
+          CUSTOM_TAG: ${{ github.event.inputs.tag }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          short_sha=$(git rev-parse --short HEAD)
+          safe_ref=${REF_NAME//\//-}
+          tags=()
+          if [ -n "${CUSTOM_TAG:-}" ]; then
+            tags+=("${IMAGE}:${CUSTOM_TAG}")
+          elif [ "$REF" = "refs/heads/main" ]; then
+            tags+=("${IMAGE}:latest" "${IMAGE}:sha-${short_sha}")
+          else
+            tags+=("${IMAGE}:preview-${safe_ref}")
+          fi
+          {
+            echo "tags<<EOF"
+            printf "%s\n" "${tags[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/sandbox
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=moflo-sandbox
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -9,8 +9,13 @@
 # Published to: ghcr.io/eric-cielo/moflo-sandbox
 #
 # Rebuild:
-#   docker build -t ghcr.io/eric-cielo/moflo-sandbox:latest docker/sandbox/
-#   docker push ghcr.io/eric-cielo/moflo-sandbox:latest
+#   Automated — pushes to `main` that touch `docker/sandbox/**` rebuild and
+#   publish `:latest` + `:sha-<short>` via `.github/workflows/sandbox-image.yml`.
+#   Manual `workflow_dispatch` can publish preview tags from any branch.
+#
+#   Local testing only:
+#     docker build -t ghcr.io/eric-cielo/moflo-sandbox:latest docker/sandbox/
+#     docker push ghcr.io/eric-cielo/moflo-sandbox:latest
 
 FROM node:20-bookworm
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sandbox-image.yml` that rebuilds and pushes `ghcr.io/eric-cielo/moflo-sandbox` on every push to `main` that touches `docker/sandbox/**`, plus `workflow_dispatch` for manual/preview pushes.
- Updates `docker/sandbox/Dockerfile` header to document the automated workflow (keeps manual `docker build && push` as a local-testing note).
- First run after merge delivers the baked-fastembed-cache image from #549 to consumers, unblocking real-world delivery of the sandbox cache fix.

## Tagging rules

| Trigger | Tags |
|---|---|
| push to main (docker/sandbox/** changed) | `:latest` + `:sha-<short>` |
| workflow_dispatch on main, no `tag` input | `:latest` + `:sha-<short>` |
| workflow_dispatch with `tag` input | that tag only (never touches `:latest`) |
| workflow_dispatch on non-main, no `tag` input | `:preview-<sanitized-branch>` |

## Changes

- **NEW** `.github/workflows/sandbox-image.yml` — buildx + ghcr login + bash tag-computation step + `docker/build-push-action@v6` with GHA layer cache and inline OCI labels. `permissions: { contents: read, packages: write }`, `cancel-in-progress: false` to protect in-flight pushes, `sparse-checkout: docker/sandbox` to trim runner setup.
- **MOD** `docker/sandbox/Dockerfile` — header comment now points to the automated workflow; manual commands kept as "Local testing only".

## Design notes

- **Tag logic in bash, not `docker/metadata-action`.** The four interlocking rules (custom input overrides main-branch defaults; preview on non-main) are clearer as `if/elif/else` than as mutually-exclusive `enable=` expressions. `type=ref,event=branch` also does not fire on `workflow_dispatch`, which would force a workaround.
- **Injection-safe shell.** `CUSTOM_TAG`, `REF`, `REF_NAME` pass through `env:` — never interpolated into `run:` with `${{ }}`.
- **`cancel-in-progress: false`** (explicit comment) — diverges from `ci.yml` deliberately; publishes are not idempotent mid-push.

## Testing

- [x] YAML parses via `js-yaml`
- [x] `actionlint` (rhysd/actionlint docker) — clean, exit 0
- [x] Tag computation simulated locally for all 5 scenarios (push-to-main, dispatch-on-main no/with tag, dispatch-on-feature no/with tag) — produces correct tags, slash in branch names sanitized
- [ ] **Real validation lands after merge** — the first run on merge rebuilds and pushes `:latest` (picking up #549's baked cache). Manual workflow_dispatch from a branch will exercise the preview-tag path.

## Follow-up

- #579 — image name `ghcr.io/eric-cielo/moflo-sandbox` is duplicated across `Dockerfile` header, this workflow's `env.IMAGE`, and `platform-sandbox.ts:67`. Drift risk; separate issue.

Closes #566
Parent: #527 (embeddings epic), unblocks real-world delivery of #549

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)