### PR TITLE
fix(paths): audit + standing guard for fixed-depth modules paths (#575)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,10 +1,15 @@
 /**
- * Hash-embedding regression guard (epic #527, story #532).
+ * Cross-cutting source guards.
  *
- * Story 4 (#531) deleted every hash-embedding code path from moflo. This
- * config installs a standing guard so no future PR can silently reintroduce
- * one. The one rule below is the entire point of this file — do not add
- * unrelated lint rules here without a separate discussion.
+ * Originated as the hash-embedding regression guard (epic #527, story #532)
+ * and now hosts the small set of structural rules that protect consumer
+ * installs from silent regressions:
+ *   - Hash-embedding identifiers + inline patterns (epic #527 / #545)
+ *   - Raw `writeFileSync(path, db.export())` non-atomic DB writes (#564)
+ *   - Fixed-depth `../../../../modules/<pkg>/...` runtime/type paths (#575)
+ *
+ * Each rule cluster has its own selectors block — keep new clusters
+ * similarly delineated so the file stays scannable.
  */
 
 const BANNED_EMBEDDING_MESSAGE =
@@ -56,6 +61,30 @@ const RAW_DB_WRITE_SELECTORS = [
   },
 ];
 
+// Issue #575 / feedback_no_fixed_depth_paths: ban 4+ deep `../` chains that
+// cross a moflo package boundary. Source vs dist depths differ — these
+// strings silently resolve to the wrong dir under installed and dev layouts.
+const FIXED_DEPTH_MODULES_MESSAGE =
+  'Fixed-depth `../../../../modules/<pkg>/...` paths break under installed ' +
+  'and dev layouts because source/dist depths differ. Use ' +
+  '`locateMofloModuleDist`/`locateMofloModulePath` from ' +
+  '`services/moflo-require.js` (or the in-package equivalent) instead.';
+
+// Slashes wrapped in character classes so the trailing `/` doesn't terminate
+// the outer regex literal in the esquery selector.
+const FIXED_DEPTH_MODULES_PATTERN = '(\\.\\.[/\\\\]){4,}modules[/\\\\]';
+
+const FIXED_DEPTH_MODULES_SELECTORS = [
+  {
+    selector: `Literal[value=/${FIXED_DEPTH_MODULES_PATTERN}/]`,
+    message: FIXED_DEPTH_MODULES_MESSAGE,
+  },
+  {
+    selector: `TemplateElement[value.raw=/${FIXED_DEPTH_MODULES_PATTERN}/]`,
+    message: FIXED_DEPTH_MODULES_MESSAGE,
+  },
+];
+
 // Structural guard: any function that both constructs a Float32Array AND
 // calls charCodeAt is a hash embedding regardless of method name. The
 // identifier ban above missed the inline implementations removed in #542
@@ -96,6 +125,7 @@ const bannedEmbeddingRules = {
     },
     ...INLINE_HASH_EMBEDDING_SELECTORS,
     ...RAW_DB_WRITE_SELECTORS,
+    ...FIXED_DEPTH_MODULES_SELECTORS,
   ],
   'no-restricted-imports': [
     'error',

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -7,7 +7,7 @@
 import { existsSync, mkdirSync, writeFileSync, readdirSync, rmSync, statSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
-import { run, runNode, flo, NPM_CMD } from './proc.mjs';
+import { run, runNode, flo, NPM_CMD, getStderrSamples } from './proc.mjs';
 import { section, record, recordExit, log } from './report.mjs';
 import { findOrphans } from '../../../scripts/clean-dist.mjs';
 import { findOrtPackages } from '../../../scripts/prune-native-binaries.mjs';
@@ -742,6 +742,50 @@ function folderSize(dir) {
     else total += s.size;
   }
   return total;
+}
+
+/**
+ * Issue #575: scan captured stderr from every subprocess for `Cannot find
+ * module` / `ENOENT` lines — exit-zero commands can still emit those from
+ * optional dynamic imports, hiding the path regressions this audit guards.
+ */
+export function verifyNoPathResolutionErrors() {
+  section('Path resolution stderr scan (issue #575)');
+  const samples = getStderrSamples();
+  const offenders = [];
+
+  const CANNOT_FIND_RE = /Cannot find module ['"]([^'"]+)['"]/g;
+  const ENOENT_RE = /ENOENT[^\n]*['"]([^'"]+\.(?:js|mjs|cjs|ts|json))['"]/g;
+
+  for (const { label, stderr } of samples) {
+    let m;
+    CANNOT_FIND_RE.lastIndex = 0;
+    while ((m = CANNOT_FIND_RE.exec(stderr)) !== null) {
+      offenders.push({ label, kind: 'cannot-find-module', target: m[1] });
+    }
+    ENOENT_RE.lastIndex = 0;
+    while ((m = ENOENT_RE.exec(stderr)) !== null) {
+      offenders.push({ label, kind: 'enoent', target: m[1] });
+    }
+  }
+
+  if (offenders.length === 0) {
+    record('path-resolution-stderr', 'pass', `${samples.length} subprocess(es) clean`);
+    return;
+  }
+
+  const byTarget = new Map();
+  for (const o of offenders) {
+    if (!byTarget.has(o.target)) byTarget.set(o.target, []);
+    byTarget.get(o.target).push(`${o.label}(${o.kind})`);
+  }
+  for (const [target, sites] of byTarget) {
+    record(
+      `path-resolution:${target.slice(0, 80)}`,
+      'fail',
+      `seen in: ${[...new Set(sites)].slice(0, 4).join(', ')}`,
+    );
+  }
 }
 
 export function stopConsumerDaemon(consumerDir) {

--- a/harness/consumer-smoke/lib/proc.mjs
+++ b/harness/consumer-smoke/lib/proc.mjs
@@ -16,6 +16,15 @@ export const NPM_CMD = IS_WIN ? 'npm.cmd' : 'npm';
 let verbose = false;
 export function configure({ verbose: v }) { verbose = !!v; }
 
+// Issue #575: stderr from every subprocess is sampled so a final pass can
+// detect `Cannot find module ...` leaks that exit-zero commands hide.
+const stderrSamples = [];
+export function recordSample(label, stderr) {
+  if (stderr && stderr.length > 0) stderrSamples.push({ label, stderr });
+}
+export function getStderrSamples() { return stderrSamples; }
+export function clearStderrSamples() { stderrSamples.length = 0; }
+
 function quoteWin(arg) {
   const s = String(arg);
   return /[\s"&|<>^%]/.test(s) ? `"${s.replace(/"/g, '\\"')}"` : s;
@@ -35,10 +44,13 @@ export function run(cmd, args, runOpts = {}) {
   const result = needsShell
     ? spawnSync([cmd, ...args.map(quoteWin)].join(' '), { ...spawnOpts, shell: true })
     : spawnSync(cmd, args, { ...spawnOpts, shell: false });
+  const stderr = result.stderr || '';
+  const label = `${cmd.split(/[\\/]/).pop()}${args[0] ? ` ${args[0]}` : ''}`.slice(0, 60);
+  recordSample(label, stderr);
   return {
     code: result.status,
     stdout: result.stdout || '',
-    stderr: result.stderr || '',
+    stderr,
     error: result.error,
   };
 }

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -87,6 +87,8 @@ function main() {
       () => check.installSurface(consumerDir),
       () => check.verifyPrunedBinaries(consumerDir),
       () => check.verifyTokenizerSubpackage(consumerDir),
+      // Issue #575: must run LAST so it sees stderr from every preceding check.
+      () => check.verifyNoPathResolutionErrors(),
     ];
     for (const fn of checks) {
       try { fn(); } catch (err) {

--- a/src/modules/cli/__tests__/services/moflo-require.test.ts
+++ b/src/modules/cli/__tests__/services/moflo-require.test.ts
@@ -8,6 +8,7 @@ import {
   importMofloMemory,
   locateMofloModuleDist,
   locateMofloModulePath,
+  locateMofloRootPath,
   _resetMofloMemoryCacheForTest,
 } from '../../src/services/moflo-require.js';
 
@@ -165,6 +166,37 @@ describe('locateMofloModulePath (non-dist subpaths)', () => {
   it('is cached per (pkg, rel) key', () => {
     const a = locateMofloModulePath('spells', 'package.json');
     const b = locateMofloModulePath('spells', 'package.json');
+    expect(a).toBe(b);
+  });
+});
+
+describe('locateMofloRootPath (root-level shipped files — issue #575)', () => {
+  beforeEach(() => {
+    _resetMofloMemoryCacheForTest();
+  });
+
+  it('resolves the moflo root README.md (a stable root-level file)', () => {
+    const result = locateMofloRootPath('README.md');
+    expect(result).not.toBeNull();
+    expect(existsSync(result!)).toBe(true);
+    // Must end at the actual file, not a `src/modules/<pkg>/README.md` sibling.
+    expect(result!).not.toMatch(/[\\/]src[\\/]modules[\\/]/);
+  });
+
+  it('returns null for a non-existent root file (no silent success)', () => {
+    const result = locateMofloRootPath('definitely-not-a-real-file.txt');
+    expect(result).toBeNull();
+  });
+
+  it('resolves nested root subpaths (e.g. scripts/clean-dist.mjs)', () => {
+    const result = locateMofloRootPath(join('scripts', 'clean-dist.mjs'));
+    expect(result).not.toBeNull();
+    expect(existsSync(result!)).toBe(true);
+  });
+
+  it('is cached per `rel` key', () => {
+    const a = locateMofloRootPath('README.md');
+    const b = locateMofloRootPath('README.md');
     expect(a).toBe(b);
   });
 });

--- a/src/modules/cli/src/appliance/rvfa-builder.ts
+++ b/src/modules/cli/src/appliance/rvfa-builder.ts
@@ -9,11 +9,13 @@ import {
   createHash, scryptSync, randomBytes, createCipheriv, createDecipheriv,
 } from 'node:crypto';
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { execSync } from 'node:child_process';
 import {
   RvfaWriter, type RvfaHeader, type RvfaBootConfig, type RvfaModelConfig,
 } from './rvfa-format.js';
+import { locateMofloRootPath } from '../services/moflo-require.js';
+import { VERSION } from '../version.js';
 
 // ── Public Interfaces ────────────────────────────────────────
 
@@ -109,7 +111,7 @@ export class RvfaBuilder {
       arch: options.arch || 'x86_64',
       profile: options.profile,
       output: resolve(options.output),
-      rufloVersion: options.rufloVersion || detectRufloVersion(),
+      rufloVersion: options.rufloVersion || VERSION,
       models: options.models ?? defaultModelsForProfile(options.profile),
       apiKeys: options.apiKeys ?? '',
       verbose: options.verbose ?? false,
@@ -282,10 +284,12 @@ export class RvfaBuilder {
   }
 
   private buildVerifySection(): Buffer {
-    const scriptPath = resolve(dirname(new URL(import.meta.url).pathname), '../../../../scripts/verify-appliance.sh');
+    // Walk up to moflo root for the bundled verify script — see issue #575
+    // (prior `new URL().pathname` was Windows-broken and the depth was wrong).
+    const scriptPath = locateMofloRootPath(join('scripts', 'verify-appliance.sh'));
     let script: Buffer;
 
-    if (existsSync(scriptPath)) {
+    if (scriptPath && existsSync(scriptPath)) {
       script = readFileSync(scriptPath);
       this.log(`    Bundled verify-appliance.sh (${fmtBytes(script.length)})`);
     } else {
@@ -362,14 +366,6 @@ function parseEnvFile(content: string): Record<string, string> {
     if (k) result[k] = v;
   }
   return result;
-}
-
-function detectRufloVersion(): string {
-  try {
-    const p = resolve(dirname(new URL(import.meta.url).pathname), '../../package.json');
-    if (existsSync(p)) return JSON.parse(readFileSync(p, 'utf-8')).version ?? '3.5.0';
-  } catch { /* ignore */ }
-  return '3.5.0';
 }
 
 function defaultModelsForProfile(profile: string): string[] {

--- a/src/modules/cli/src/commands/doctor.ts
+++ b/src/modules/cli/src/commands/doctor.ts
@@ -26,6 +26,7 @@ import {
   getMofloRoot,
 } from './doctor-checks-deep.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
+import { locateMofloModuleDist } from '../services/moflo-require.js';
 
 // Promisified exec with proper shell and env inheritance for cross-platform support
 const execAsync = promisify(exec);
@@ -868,9 +869,19 @@ async function checkMemoryPatterns(_namespace: string): Promise<number> {
 // Exercises each component with a lightweight functional test rather than just checking "loaded".
 async function checkIntelligence(): Promise<HealthCheck> {
   try {
+    // Walk-up resolve avoids fixed-depth `../` strings that break under dev
+    // (.ts via tsx) where depth differs from compiled output — issue #575.
+    const neuralUrl = locateMofloModuleDist('neural', 'index.js');
+    if (!neuralUrl) {
+      return {
+        name: 'Intelligence',
+        status: 'warn',
+        message: 'Neural module not built — run `npm run build` to enable intelligence checks',
+        fix: 'npm run build',
+      };
+    }
     // @ts-ignore — neural is not in tsconfig project references but is available at runtime
-    // Import neural module — path is relative to compiled output at dist/src/commands/
-    const neural = await import('../../../../neural/dist/index.js');
+    const neural = await import(neuralUrl);
     const results: string[] = [];
     const failures: string[] = [];
 

--- a/src/modules/cli/src/services/engine-loader.ts
+++ b/src/modules/cli/src/services/engine-loader.ts
@@ -17,21 +17,21 @@ import type {
   PreflightWarning,
   PreflightWarningDecision,
   PreflightWarningHandler,
-} from '../../../../modules/spells/src/types/runner.types.js';
+} from '../../../spells/src/types/runner.types.js';
 import type {
   SpellDefinition,
-} from '../../../../modules/spells/src/types/spell-definition.types.js';
+} from '../../../spells/src/types/spell-definition.types.js';
 import type {
   Grimoire,
   RegistryOptions,
-} from '../../../../modules/spells/src/registry/spell-registry.js';
-import type { SandboxConfig } from '../../../../modules/spells/src/core/platform-sandbox.js';
+} from '../../../spells/src/registry/spell-registry.js';
+import type { SandboxConfig } from '../../../spells/src/core/platform-sandbox.js';
 import type {
   SpellScheduler,
   SpellExecutor,
-} from '../../../../modules/spells/src/scheduler/scheduler.js';
-import type { SchedulerOptions } from '../../../../modules/spells/src/scheduler/schedule.types.js';
-import type { MemoryAccessor } from '../../../../modules/spells/src/types/step-command.types.js';
+} from '../../../spells/src/scheduler/scheduler.js';
+import type { SchedulerOptions } from '../../../spells/src/scheduler/schedule.types.js';
+import type { MemoryAccessor } from '../../../spells/src/types/step-command.types.js';
 
 // Re-export spell types so consumers import from engine-loader (single boundary).
 export type { SpellResult };

--- a/src/modules/cli/src/services/grimoire-builder.ts
+++ b/src/modules/cli/src/services/grimoire-builder.ts
@@ -8,7 +8,7 @@
  */
 
 import { resolve } from 'node:path';
-import type { Grimoire } from '../../../../modules/spells/src/registry/spell-registry.js';
+import type { Grimoire } from '../../../spells/src/registry/spell-registry.js';
 import { loadMofloConfig } from '../config/moflo-config.js';
 import { loadSpellEngine, type EngineModule } from './engine-loader.js';
 import { locateMofloModulePath } from './moflo-require.js';
@@ -19,9 +19,9 @@ import { locateMofloModulePath } from './moflo-require.js';
  * `shippedDir` defaults to the bundled `src/modules/spells/definitions` folder,
  * resolved via a depth-invariant walk-up (layout-safe across source, dist, and
  * installed-under-consumer's-node_modules/moflo/). The prior fixed-depth
- * `../../../../modules/spells/definitions` string silently pointed at the
- * wrong directory from the compiled `dist/src/services/` location — same class
- * of bug as PR #556.
+ * Previous fixed-depth `../../../../modules/spells/definitions` string silently
+ * pointed at the wrong directory from the compiled `dist/src/services/`
+ * location — same class of bug as PR #556 (issue #575).
  *
  * Returns an empty string when the shipped dir isn't present on disk (e.g.
  * pre-built source tree); the loader treats missing dirs as a no-op.

--- a/src/modules/cli/src/services/moflo-require.ts
+++ b/src/modules/cli/src/services/moflo-require.ts
@@ -107,7 +107,8 @@ export type MofloInternalPackage =
   | 'security'
   | 'shared'
   | 'spells'
-  | 'plugins';
+  | 'plugins'
+  | 'cli';
 
 /**
  * Locate a built artifact inside `src/modules/<pkg>/dist/<relFromDist>` by
@@ -126,36 +127,41 @@ export type MofloInternalPackage =
  * Returns a `file://` URL suitable for ESM `import()`, or `null` if the
  * artifact isn't on disk (package not built / missing from install).
  */
-const moduleDistUrlCache = new Map<string, string | null>();
-
-// Walk cap: the deepest real install is roughly
-// `<consumer>/node_modules/moflo/src/modules/<pkg>/dist/src/<...>` ≈ 8 hops up
-// to the moflo root. 12 gives comfortable headroom for worktree and monorepo
-// layouts without risking an unbounded loop at filesystem root.
+// Walk cap: deepest real install is `<consumer>/node_modules/moflo/src/modules/<pkg>/dist/src/<...>`
+// ≈ 8 hops to the moflo root. 12 gives headroom for worktree/monorepo layouts.
 const MAX_WALK_DEPTH = 12;
 
-export function locateMofloModuleDist(pkg: MofloInternalPackage, relFromDist: string): string | null {
-  const cacheKey = `${pkg}::${relFromDist}`;
-  const cached = moduleDistUrlCache.get(cacheKey);
-  if (cached !== undefined) return cached;
-
+// Walk up from this file's dir, returning the first non-null `test(dir)` result.
+function walkUpFromSelf<T>(test: (dir: string) => T | null): T | null {
   let dir = dirname(fileURLToPath(import.meta.url));
-  const rel = join('src', 'modules', pkg, 'dist', relFromDist);
-
   for (let i = 0; i < MAX_WALK_DEPTH; i++) {
-    const candidate = join(dir, rel);
-    if (existsSync(candidate)) {
-      const url = pathToFileURL(candidate).href;
-      moduleDistUrlCache.set(cacheKey, url);
-      return url;
-    }
+    const hit = test(dir);
+    if (hit !== null) return hit;
     const parent = dirname(dir);
-    if (parent === dir) break; // filesystem root
+    if (parent === dir) return null;
     dir = parent;
   }
-
-  moduleDistUrlCache.set(cacheKey, null);
   return null;
+}
+
+function memoize<T>(cache: Map<string, T | null>, key: string, compute: () => T | null): T | null {
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+  const result = compute();
+  cache.set(key, result);
+  return result;
+}
+
+const moduleDistUrlCache = new Map<string, string | null>();
+
+export function locateMofloModuleDist(pkg: MofloInternalPackage, relFromDist: string): string | null {
+  return memoize(moduleDistUrlCache, `${pkg}::${relFromDist}`, () => {
+    const rel = join('src', 'modules', pkg, 'dist', relFromDist);
+    return walkUpFromSelf(dir => {
+      const candidate = join(dir, rel);
+      return existsSync(candidate) ? pathToFileURL(candidate).href : null;
+    });
+  });
 }
 
 function locateMofloMemoryDist(): string | null {
@@ -164,40 +170,19 @@ function locateMofloMemoryDist(): string | null {
 
 /**
  * Locate a filesystem path inside `src/modules/<pkg>/<rel>` (not limited to
- * `dist/`) by the same walk-up strategy as locateMofloModuleDist. Useful for
- * non-built data folders shipped alongside the module — e.g. spell YAML
- * definitions, template assets, etc.
- *
- * Cross-platform: `path.join` handles separators on POSIX and Windows;
- * `existsSync` returns the same answer in all environments. Works whether
- * moflo is running from dev source, its own dist, or installed under a
- * consumer's `node_modules/moflo/`.
- *
- * Returns the absolute filesystem path, or null if not found.
+ * `dist/`). Useful for non-built data folders shipped alongside the module
+ * — e.g. spell YAML definitions, template assets.
  */
 const moduleSubpathCache = new Map<string, string | null>();
 
 export function locateMofloModulePath(pkg: MofloInternalPackage, rel: string): string | null {
-  const cacheKey = `${pkg}::${rel}`;
-  const cached = moduleSubpathCache.get(cacheKey);
-  if (cached !== undefined) return cached;
-
-  let dir = dirname(fileURLToPath(import.meta.url));
-  const relPath = join('src', 'modules', pkg, rel);
-
-  for (let i = 0; i < MAX_WALK_DEPTH; i++) {
-    const candidate = join(dir, relPath);
-    if (existsSync(candidate)) {
-      moduleSubpathCache.set(cacheKey, candidate);
-      return candidate;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-
-  moduleSubpathCache.set(cacheKey, null);
-  return null;
+  return memoize(moduleSubpathCache, `${pkg}::${rel}`, () => {
+    const relPath = join('src', 'modules', pkg, rel);
+    return walkUpFromSelf(dir => {
+      const candidate = join(dir, relPath);
+      return existsSync(candidate) ? candidate : null;
+    });
+  });
 }
 
 /**
@@ -223,8 +208,29 @@ export async function importMofloMemory(): Promise<any | null> {
   }
 }
 
+/**
+ * Walk up to the moflo monorepo / installed-package root and join `rel`.
+ *
+ * "Moflo root" is the first ancestor directory that contains a `src/modules/`
+ * subtree — true for both the dev source tree (repo root) and an installed
+ * tree (`node_modules/moflo/`). Use for files shipped at the root of moflo
+ * (e.g. `scripts/*.sh`); the package walk-ups only see `src/modules/<pkg>/`.
+ */
+const rootPathCache = new Map<string, string | null>();
+
+export function locateMofloRootPath(rel: string): string | null {
+  return memoize(rootPathCache, rel, () =>
+    walkUpFromSelf(dir => {
+      if (!existsSync(join(dir, 'src', 'modules'))) return null;
+      const candidate = join(dir, rel);
+      return existsSync(candidate) ? candidate : null;
+    }),
+  );
+}
+
 // Test-only: reset the caches between unit tests that mutate the filesystem.
 export function _resetMofloMemoryCacheForTest(): void {
   moduleDistUrlCache.clear();
   moduleSubpathCache.clear();
+  rootPathCache.clear();
 }

--- a/src/modules/hooks/src/swarm/index.ts
+++ b/src/modules/hooks/src/swarm/index.ts
@@ -20,7 +20,7 @@ import type {
   Message,
   MessageType,
   MessageFilter,
-} from '../../../../modules/swarm/src/types.js';
+} from '../../../swarm/src/types.js';
 
 /**
  * Walk up from this file to find `src/modules/swarm/dist/<rel>`. Layout- and


### PR DESCRIPTION
## Summary

Comprehensive followup to #556 / #574. Eliminates the remaining hand-counted `../../../../modules/<pkg>/...` paths that silently resolve to the wrong directory under different deployment shapes (dev source vs compiled dist vs installed `node_modules/moflo/`), and installs a standing ESLint + smoke-harness guard so the bug class can't sneak back in.

## Runtime fixes

- **`doctor.ts:checkIntelligence`** — was importing `@moflo/neural` via a fixed-depth string that failed under `tsx` dev runs. Now uses `locateMofloModuleDist('neural', 'index.js')`.
- **`rvfa-builder.ts:buildVerifySection`** — `new URL(import.meta.url).pathname` was Windows-broken (returns `/C:/...`) AND the `../../../../scripts/` depth resolved to a non-existent directory in every layout, so this branch was never hit (silently fell back to the inline stub). Now resolves via `locateMofloRootPath('scripts/verify-appliance.sh')`.
- **`rvfa-builder.ts:detectRufloVersion`** — replaced runtime walk-up + `JSON.parse(package.json)` with the existing build-time `VERSION` constant from `version.ts` (auto-synced by `sync-version.mjs`). Bonus: under installed layout the old code would have returned `@moflo/cli`'s version instead of the published `moflo` root version.

## Type-only normalization

- `engine-loader.ts` (8 imports), `grimoire-builder.ts` (1), `hooks/src/swarm/index.ts` (1) — switched from `'../../../../modules/<pkg>/...'` to depth-3 `'../../../<pkg>/...'` (matches existing `daemon-spell-executor.ts` pattern). Erased at compile-time so runtime behavior is unchanged, but they now satisfy the new lint rule.

## New helpers (`services/moflo-require.ts`)

- `locateMofloRootPath(rel)` — for files shipped at the moflo root (e.g. `scripts/*.sh`); the existing `locateMofloModuleDist` / `locateMofloModulePath` only see `src/modules/<pkg>/...`.
- Internal `walkUpFromSelf(test)` + `memoize(cache, key, compute)` — unify the (formerly four) walk-up + cache loops into one shape per call site.

## Standing guards

- **ESLint** — new `no-restricted-syntax` selector blocks `(\.\.[/\]){4,}modules[/\]` literals + template elements (slashes wrapped in character classes so the trailing `/` doesn't terminate the regex literal).
- **Smoke harness** — `harness/consumer-smoke/lib/proc.mjs` samples stderr from every subprocess; new `verifyNoPathResolutionErrors` check runs last, scans for `Cannot find module` and `ENOENT.*\.(js|mjs|cjs|json|ts)`, and fails groupwise so the same broken path across multiple subprocesses surfaces once with all call-sites.

## Test plan

- [x] `npm run lint` — clean across `src/`, `bin/`, `.claude/scripts/` with `--max-warnings 0`
- [x] `npm run build` — full TypeScript build clean
- [x] `npm test` — 7909 tests pass (4 new cases in `moflo-require.test.ts` for `locateMofloRootPath`)
- [x] Type-only fixed-depth imports verified erased at compile (no runtime behavior change)
- [ ] `node harness/consumer-smoke/run.mjs` — run on Linux/macOS/Windows post-merge to verify the new `verifyNoPathResolutionErrors` check is exercised against a real install

Closes #575

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)