### PR TITLE
refactor(arch): ADR + dependency graph for @moflo/* workspace collapse

### DIFF
--- a/docs/adr/0001-collapse-moflo-workspace-packages.md
+++ b/docs/adr/0001-collapse-moflo-workspace-packages.md
@@ -1,0 +1,128 @@
+# ADR-0001 — Collapse `@moflo/*` Workspace Packages into a Single `moflo` Package
+
+- **Status:** Accepted
+- **Date:** 2026-04-24
+- **Related:** Workspace-collapse epic (TBD link), issue #584, `feedback_no_fixed_depth_paths.md`, `feedback_no_stale_docs.md`, `feedback_optional_deps_gotcha.md`
+- **Foundation artifacts:** [`collapse-deps.json`](./collapse-deps.json), [`collapse-deps.md`](./collapse-deps.md)
+
+## Context
+
+`moflo` is shipped on npm as a single package, but the source is laid out as a **14-package workspace** under `src/modules/<pkg>/`. Each package has its own `package.json` declaring `"name": "@moflo/<pkg>"`, its own `tsconfig.json`, and its own `dist/` build output. The 14 packages are:
+
+`aidefence`, `claims`, `cli`, `embeddings`, `guidance`, `hooks`, `memory`, `neural`, `plugins`, `security`, `shared`, `spells`, `swarm`, `testing`.
+
+The published tarball (`npm pack`) bundles only **11** of these (cli, embeddings, guidance, hooks, memory, neural, plugins, security, shared, spells, swarm). The remaining three — `aidefence`, `claims`, `testing` — publish as their own separate npm packages and are pulled in via `optionalDependencies` from `@moflo/cli`.
+
+### What goes wrong with this layout
+
+1. **Bare `@moflo/X` specifiers don't resolve in consumer installs.** When a user runs `npx moflo` from their own project, Node resolves `import '@moflo/memory'` against the consumer's `node_modules/`, not moflo's. Consumer projects don't have `@moflo/memory` installed (it ships _inside_ `node_modules/moflo/src/modules/memory/dist/`), so resolution fails. We worked around this with `mofloImport()` and `locateMofloModuleDist()` (`src/modules/cli/src/services/moflo-require.ts`) — a `createRequire`-anchored helper that walks up to find the right `dist/` folder. That helper now has 11 call sites and a 12-deep walk cap with caching. It exists purely because the workspace layout doesn't match the shipping reality.
+
+2. **Cross-package relative paths leak build layout.** Where the import-string workaround is inconvenient, modules use literal `../../../shared/dist/utils/atomic-file-write.js` paths (e.g. `src/modules/embeddings/src/utils/atomic-file-write.ts`). Those break the moment source/dist depth changes, which is why `feedback_no_fixed_depth_paths.md` and PR #581 added a guard. The guard is symptom-treatment for layout that shouldn't exist.
+
+3. **Build coordination tax.** Every module has its own `tsconfig.json`, `vitest.config.ts`, and build script. `tsc -b` orchestrates project references; one missing reference and a cross-package edit silently uses stale `dist/` output. New contributors hit this immediately.
+
+4. **Versioning theatre.** Module package.json files declare `"@moflo/memory": "^3.0.0-alpha.2"` peer/optional deps even though the version is a fiction — only the root `moflo` package is published, and its single `version` field is what consumers see. Internal version drift can't actually mean anything because consumers always get the matching set in one tarball.
+
+5. **No real spin-off path anyway.** The original justification for the workspace layout was theoretical: "we might publish individual packages later." The project owner has confirmed this is **not a goal** for moflo. We're paying the workspace tax for an option we don't intend to exercise.
+
+### Dependency graph snapshot
+
+From [`collapse-deps.md`](./collapse-deps.md):
+
+- **Leaves (zero outbound `@moflo/*` imports):** `aidefence`, `claims`, `embeddings`, `plugins`, `security`, `shared`, `spells`, `swarm` (8/14)
+- **Mid-tier:** `neural` → `memory`; `guidance` → `embeddings`, `hooks`; `hooks` → `embeddings`, `memory`, `security`; `testing` → `memory`, `shared`, `swarm`
+- **Trunk:** `cli` (outbound 9), `memory` (inbound 4), `embeddings` (inbound 4)
+- **Cycle:** `memory ↔ neural` (both edges are guarded dynamic imports — disappears on collapse)
+
+The graph is identical between TypeScript source and compiled `dist/` output. The published tarball preserves the same edges but is missing three packages (the optional add-ons).
+
+## Decision
+
+**Collapse all 14 `@moflo/*` workspace packages into the single root `moflo` package.**
+
+Concretely:
+
+1. Move every `src/modules/<pkg>/src/*` tree into a single source tree under the root `moflo` package — final layout TBD by the per-module stories, but the constraint is "no internal `@moflo/*` import strings remain."
+2. Delete the per-module `package.json`, `tsconfig.json`, and `vitest.config.ts` files. One root build, one root test run.
+3. Replace all `from '@moflo/X'` and `import('@moflo/X')` with relative imports that don't need the moflo-require walk-up.
+4. Delete `src/modules/cli/src/services/moflo-require.ts` and its 11 call sites. Replace `mofloImport`/`locateMofloModuleDist`/`requireMofloOrWarn` with direct relative imports.
+5. Delete `feedback_no_fixed_depth_paths.md`'s ESLint guard (the rule is moot once there's only one package depth).
+6. Resolve the three optional add-ons (`aidefence`, `claims`, `testing`) per the recommendations in [`collapse-deps.md`](./collapse-deps.md) — inline, keep separate with explicit lazy-load, or drop. Each is a per-module story.
+
+The collapse runs **leaves first** per the topological order in [`collapse-deps.md`](./collapse-deps.md), so each step's existing `@moflo/*` imports become trivially local by the time it's touched.
+
+## Alternatives considered
+
+### A. Keep the workspace + use `bundledDependencies`
+
+Declare each `@moflo/X` as a real npm dependency and let `npm pack` bundle them via `bundledDependencies`. This would fix the consumer-resolution problem (the packages would actually be in `node_modules/moflo/node_modules/@moflo/X/`) without touching source.
+
+**Rejected** because:
+
+- It doubles the install footprint — every package gets its own `node_modules/` copy of any shared transitive deps.
+- The version-drift theatre stays. Each `@moflo/X/package.json` still declares versions that don't matter.
+- `npm pack` with bundled deps is fragile across npm/pnpm/yarn — we'd be debugging packager edge cases instead of writing code.
+- The build coordination tax (per-module tsconfig, per-module vitest) is unchanged.
+
+### B. Keep the layout, ban `@moflo/*` strings, allow only relative paths
+
+Delete the moflo-require helper, mandate `../../<other-pkg>/src/...` everywhere, and rely on the existing ESLint rule from #581 to enforce no fixed-depth paths via a stable-marker walk-up.
+
+**Rejected** because:
+
+- It enshrines exactly the cross-package coupling we want to eliminate, just under different syntax.
+- The 14 separate `tsconfig.json` files still need project references and stale-build coordination.
+- Per-module test runners still split CI into 14 sub-jobs.
+- We end up with one package's source code reaching across ten directory boundaries to import from another — strictly worse readability than a single tree.
+
+### C. Status quo (do nothing)
+
+**Rejected** because the cost is paid every release: see PR #582 (sandbox image-name drift), PR #575 / #581 (fixed-depth path audit), the ongoing `mofloImport` retrofit. Each is real work driven by the layout. Removing the layout removes the recurring tax.
+
+## Consequences
+
+### Positive
+
+- One `package.json`, one `tsconfig.json`, one test runner, one build. CI gets simpler; new-contributor ramp shortens dramatically.
+- The moflo-require helper, the fixed-depth-path ESLint rule, and the `clean-dist` orphan checker either disappear or shrink to thin shells.
+- Internal refactors stop tripping over package boundaries. Renaming a function in `shared` doesn't require coordinating four `@moflo/X/package.json` version bumps.
+- Consumer surface stays identical — `moflo` on npm continues to be the single shipping name.
+- The 14-package illusion goes away. Anyone reading the source can trust that the layout matches reality.
+
+### Negative / cost
+
+- Lose the (theoretical, never-exercised) ability to publish individual `@moflo/X` packages on npm. The project owner has explicitly declared this a non-goal.
+- One-shot churn: every internal import string gets rewritten. The collapse epic is sized accordingly.
+- Test files currently scoped per-package run together once collapsed — global test setup needs review for shared state. (Mitigated by current `vitest.config.ts isolationTests` mechanism, which already handles this for the cross-package tests we have.)
+- IDE workspace folders that pin to `src/modules/<pkg>/` will need re-pinning. One-time, low-effort.
+
+### Risks and mitigations
+
+- **Risk:** test runner picks up cross-test pollution that was previously hidden by per-package isolation. **Mitigation:** `vitest.config.ts` has the `isolationTests` list (`feedback_vitest_isolation_list.md`); audit during the collapse and extend as needed.
+- **Risk:** something downstream depends on `@moflo/<pkg>` as an importable string (e.g., a plugin loaded via `import('@moflo/X')`). **Mitigation:** the dependency graph artifact catches every such reference; the collapse stories must address each. The plugin-store registry advertises `@moflo/security`, `@moflo/claims`, etc. — those entries will be revisited as part of the optional-add-on resolution.
+- **Risk:** the three optional add-ons (`aidefence`, `claims`, `testing`) are out of the tarball today; collapsing them in changes that. **Mitigation:** the decision is per-package and tracked in the epic. Each can independently inline / stay-separate / drop.
+
+## Migration plan
+
+The per-module stories in the workspace-collapse epic each:
+
+1. Pick the next package by topological order (leaves first; see [`collapse-deps.md`](./collapse-deps.md)).
+2. Move that package's `src/` tree into the unified layout.
+3. Rewrite all import strings that pointed at it to use the new relative path.
+4. Delete the package's own `package.json`, `tsconfig.json`, `vitest.config.ts`.
+5. Update any moflo-require call sites that referenced it.
+6. Run the full test suite + smoke harness; fix anything broken.
+7. Open a PR for that single package's collapse.
+
+The epic completes when all 14 packages are merged, the moflo-require helper is deleted, and the `files` array in the root `package.json` no longer enumerates per-module dist paths.
+
+## Verification
+
+The dependency graph in [`collapse-deps.json`](./collapse-deps.json) is the source of truth for "is this collapse complete?" After each story merges:
+
+```bash
+node scripts/analyze-collapse-deps.mjs --src --json /tmp/post-merge.json
+jq '.adjacency | to_entries | map(select(.value | length > 0))' /tmp/post-merge.json
+```
+
+When that command returns `[]` and `jq '.rootRefs | length' /tmp/post-merge.json` returns `0`, the workspace collapse is done.

--- a/docs/adr/collapse-deps.json
+++ b/docs/adr/collapse-deps.json
@@ -1,0 +1,77 @@
+{
+  "packages": [
+    "aidefence",
+    "claims",
+    "cli",
+    "embeddings",
+    "guidance",
+    "hooks",
+    "memory",
+    "neural",
+    "plugins",
+    "security",
+    "shared",
+    "spells",
+    "swarm",
+    "testing"
+  ],
+  "adjacency": {
+    "aidefence": [],
+    "claims": [],
+    "cli": [
+      "aidefence",
+      "claims",
+      "embeddings",
+      "memory",
+      "neural",
+      "plugins",
+      "security",
+      "shared",
+      "testing"
+    ],
+    "embeddings": [],
+    "guidance": [
+      "embeddings",
+      "hooks"
+    ],
+    "hooks": [
+      "embeddings",
+      "memory",
+      "security"
+    ],
+    "memory": [
+      "embeddings",
+      "neural"
+    ],
+    "neural": [
+      "memory"
+    ],
+    "plugins": [],
+    "security": [],
+    "shared": [],
+    "spells": [],
+    "swarm": [],
+    "testing": [
+      "memory",
+      "shared",
+      "swarm"
+    ]
+  },
+  "rootRefs": [
+    "cli",
+    "memory",
+    "neural",
+    "security",
+    "shared",
+    "swarm",
+    "testing"
+  ],
+  "cycles": [
+    [
+      "memory",
+      "neural"
+    ]
+  ],
+  "files": 1016,
+  "generatedAt": "2026-04-25T01:01:02Z"
+}

--- a/docs/adr/collapse-deps.md
+++ b/docs/adr/collapse-deps.md
@@ -1,0 +1,140 @@
+# `@moflo/*` Workspace Collapse — Dependency Graph
+
+Foundation artifact for the workspace-collapse epic. Companion to [`0001-collapse-moflo-workspace-packages.md`](./0001-collapse-moflo-workspace-packages.md) and machine-readable [`collapse-deps.json`](./collapse-deps.json).
+
+> This file is **hand-curated narrative**. Numeric facts (adjacency, inbound/outbound counts, cycles) come from `scripts/analyze-collapse-deps.mjs`; reproduce them with the commands at the bottom and reconcile any divergence before merging.
+
+The scanner walks three trees and produces the same edges in each:
+
+| Tree | Files | Notes |
+|------|-------|-------|
+| `src/**/*.ts` (source) | 1016 | Reference adjacency (canonical) |
+| `src/modules/*/dist/**/*.js` (compiled) | 651 | Identical adjacency to source — TypeScript build preserves edges |
+| `npm pack` tarball (consumer surface) | 602 | Same edges, but only 11 of 14 packages ship inside the tarball |
+
+The scanner strips `/* ... */` and `// ...` comments before matching `'@moflo/<pkg>'` so JSDoc mentions don't contaminate the graph. Both `from '@moflo/X'` and `import('@moflo/X')` are included, plus string-form references inside `mofloImport(...)` / `requireMofloOrWarn(...)` (the moflo-require helpers used to dodge consumer-project resolution).
+
+## Adjacency list
+
+Each row lists the `@moflo/*` packages a given module imports.
+
+| Package | Outbound | Inbound | Imports |
+|---------|----------|---------|---------|
+| `aidefence` | 0 | 1 | _leaf_ |
+| `claims` | 0 | 1 | _leaf_ |
+| `cli` | 9 | 0 | `aidefence`, `claims`, `embeddings`, `memory`, `neural`, `plugins`, `security`, `shared`, `testing` |
+| `embeddings` | 0 | 4 | _leaf_ |
+| `guidance` | 2 | 0 | `embeddings`, `hooks` |
+| `hooks` | 3 | 1 | `embeddings`, `memory`, `security` |
+| `memory` | 2 | 4 | `embeddings`, `neural` |
+| `neural` | 1 | 2 | `memory` |
+| `plugins` | 0 | 1 | _leaf_ |
+| `security` | 0 | 2 | _leaf_ |
+| `shared` | 0 | 2 | _leaf_ |
+| `spells` | 0 | 0 | _leaf, isolated_ |
+| `swarm` | 0 | 1 | _leaf_ |
+| `testing` | 3 | 1 | `memory`, `shared`, `swarm` |
+
+## Leaves (zero outbound `@moflo/*` imports — collapse first)
+
+These have no relative paths to other moflo packages to rewrite, so they merge cleanly:
+
+- `@moflo/aidefence` _(separately published, not in moflo tarball)_
+- `@moflo/claims` _(separately published, not in moflo tarball)_
+- `@moflo/embeddings`
+- `@moflo/plugins`
+- `@moflo/security`
+- `@moflo/shared`
+- `@moflo/spells` _(also zero inbound — fully isolated)_
+- `@moflo/swarm`
+
+`@moflo/embeddings` is technically a leaf in the package-import graph, but it _does_ reach into `@moflo/shared` via a runtime filesystem walk-up to `../../../shared/dist/utils/atomic-file-write.js` (`src/modules/embeddings/src/utils/atomic-file-write.ts`). After collapse, that walk-up becomes a normal local import — strictly an improvement.
+
+## Mid-tier (one level of fan-in or fan-out)
+
+Collapse after leaves; each has a single dependency edge to rewrite:
+
+- `@moflo/neural` → `memory`
+- `@moflo/guidance` → `embeddings`, `hooks`
+- `@moflo/hooks` → `embeddings`, `memory`, `security`
+- `@moflo/testing` → `memory`, `shared`, `swarm` _(separately published)_
+
+## Trunk (highest fan-in / fan-out — collapse last)
+
+- `@moflo/cli` — outbound 9, inbound 0. CLI is the ultimate consumer; flipping it changes every command surface. By the time everything else has collapsed, all of cli's `@moflo/*` imports become local.
+- `@moflo/memory` — inbound 4 (cli, hooks, neural, testing). Touching memory's package boundary affects four call-site groups.
+- `@moflo/embeddings` — inbound 4 (cli, guidance, hooks, memory). Already a leaf; the inbound count just means the rewrite is broad but mechanical.
+
+## Cycles
+
+There is one cycle (also recorded under `cycles` in `collapse-deps.json`):
+
+```
+memory → neural (src/modules/memory/src/learning-bridge.ts:420)
+neural → memory (src/modules/neural/src/reasoning-bank.ts:45)
+```
+
+Both edges are dynamic `await import(...)` guarded by try/catch — the runtime contract is "the other module is optional; degrade gracefully if absent." The cycle only exists at the package boundary; collapse removes it because both files end up in the same compilation unit.
+
+## Topological collapse order (recommended)
+
+After leaves and mid-tier are merged, the trunk falls in last. This ordering minimises work-in-progress: each step's `@moflo/*` imports are already local by the time we touch it.
+
+1. `@moflo/aidefence` _(leaf, optional add-on)_
+2. `@moflo/claims` _(leaf, optional add-on)_
+3. `@moflo/embeddings` _(leaf)_
+4. `@moflo/plugins` _(leaf)_
+5. `@moflo/security` _(leaf)_
+6. `@moflo/shared` _(leaf)_
+7. `@moflo/spells` _(leaf, isolated)_
+8. `@moflo/swarm` _(leaf)_
+9. `@moflo/neural` _(after memory or in same step due to cycle)_
+10. `@moflo/memory` _(after neural)_
+11. `@moflo/hooks`
+12. `@moflo/guidance`
+13. `@moflo/testing`
+14. `@moflo/cli` _(trunk — last)_
+
+Steps 9–10 must move together because of the dynamic-import cycle.
+
+## Consumer-surface caveat (the published tarball)
+
+`npm pack` only ships **11** of the 14 packages — `aidefence`, `claims`, and `testing` are deliberately excluded from `package.json#files`. They publish as their own npm packages.
+
+`@moflo/cli` (which DOES ship in the tarball) keeps live import strings to all three:
+
+| Site | Form | Behaviour when missing |
+|------|------|------------------------|
+| `src/modules/cli/src/mcp-tools/security-tools.ts` | `await import('@moflo/aidefence')` | Throws `AIDefence package not available. Install with: npm install @moflo/aidefence` |
+| `src/modules/cli/src/commands/security.js` | `await import('@moflo/aidefence')` | Same error path |
+| `src/modules/cli/src/mcp-tools/auto-install.ts` | Registry entry | Surfaces in interactive install prompt |
+| `src/modules/cli/src/update/checker.ts` | List of moflo packages | Skipped if not installed |
+| `src/modules/cli/src/plugins/store/discovery.ts` | Featured/official catalogue | Listing-only, no runtime resolve |
+| `src/modules/cli/package.json#optionalDependencies` | `"@moflo/aidefence": "file:../aidefence"` | Soft-fails npm-install; consumers must `npm i @moflo/aidefence` separately |
+
+**Implication for the collapse epic:** these "optional add-on" references must be converted to one of three end states by the per-module stories:
+
+1. **Inline** — pull aidefence/claims/testing into the root `moflo` package and remove the optional-dependency machinery (loses the "install only what you need" affordance).
+2. **Keep separate** — leave aidefence/claims/testing as standalone npm packages but rewrite cli's references to use the established lazy-load pattern (today's behaviour, just made explicit).
+3. **Drop** — remove the optional features entirely if they're underused.
+
+The choice is per-package and out of scope for this artifact; the dependency graph just records that the references exist and ship live in the cli.
+
+## Reproducing this artifact
+
+```bash
+# Source tree (canonical) — regenerates collapse-deps.json
+node scripts/analyze-collapse-deps.mjs --src --json docs/adr/collapse-deps.json
+
+# Compiled dist (parity check)
+npm run build
+node scripts/analyze-collapse-deps.mjs --dist --json /tmp/dist.json
+diff <(jq .adjacency docs/adr/collapse-deps.json) <(jq .adjacency /tmp/dist.json)
+
+# Published tarball (consumer surface)
+npm pack --pack-destination /tmp
+mkdir -p /tmp/moflo-pack && tar -xzf /tmp/moflo-*.tgz -C /tmp/moflo-pack
+node scripts/analyze-collapse-deps.mjs --tarball /tmp/moflo-pack/package --json /tmp/tarball.json
+```
+
+If the regenerated `collapse-deps.json` adjacency differs from this file's tables, treat the JSON as truth and update the tables here.

--- a/scripts/analyze-collapse-deps.mjs
+++ b/scripts/analyze-collapse-deps.mjs
@@ -1,0 +1,408 @@
+#!/usr/bin/env node
+// Static dependency-graph scanner for @moflo/* imports.
+//
+// Scans a tree (default: src/modules + bin + src/index.ts) for every
+// `@moflo/<pkg>` reference — static `from`, dynamic `import()`, `require()`,
+// and string-only references inside `mofloImport(...)` / `requireMofloOrWarn(...)`.
+// Each hit is mapped to the *source* package (which `src/modules/<pkg>/` it
+// lives in) so we get an adjacency list `{ source: [target, ...] }`.
+//
+// Modes:
+//   --src             scan src/modules/**/*.ts (excluding tests, dist, .d.ts)
+//   --dist            scan src/modules/**/dist/**/*.js (shipped artifacts)
+//   --tarball <dir>   scan an extracted `npm pack` tarball
+//
+// Output:
+//   --json <file>     write adjacency list JSON
+//   --md   <file>     write human-readable summary
+//   (no flag)         pretty-print to stdout
+
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { join, relative, sep } from 'path';
+
+const KNOWN_PACKAGES = [
+  'aidefence', 'claims', 'cli', 'embeddings', 'guidance', 'hooks',
+  'memory', 'neural', 'plugins', 'security', 'shared', 'spells',
+  'swarm', 'testing',
+];
+
+const MODES = {
+  src: { label: 'TypeScript source tree' },
+  dist: { label: 'compiled `dist/` artifacts' },
+  tarball: { label: 'extracted `npm pack` tarball' },
+};
+
+function parseArgs(argv) {
+  const args = { mode: 'src', json: null, md: null, root: process.cwd(), tarball: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--src') args.mode = 'src';
+    else if (a === '--dist') args.mode = 'dist';
+    else if (a === '--tarball') { args.mode = 'tarball'; args.tarball = argv[++i]; }
+    else if (a === '--json') args.json = argv[++i];
+    else if (a === '--md') args.md = argv[++i];
+    else if (a === '--root') args.root = argv[++i];
+  }
+  return args;
+}
+
+function* walk(dir, accept) {
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); }
+  catch { return; }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      yield* walk(full, accept);
+    } else if (entry.isFile() && accept(full)) {
+      yield full;
+    }
+  }
+}
+
+// Returns either a package name from KNOWN_PACKAGES, or null when the file
+// lives outside any module (root-level files like bin/, src/index.ts).
+function ownerPackage(absPath, repoRoot) {
+  const rel = relative(repoRoot, absPath).split(sep);
+  const idx = rel.findIndex(p => p === 'modules');
+  if (idx >= 0 && rel[idx - 1] === 'src' && rel[idx + 1]) {
+    const pkg = rel[idx + 1];
+    if (KNOWN_PACKAGES.includes(pkg)) return pkg;
+  }
+  // Tarball layout: package/src/modules/<pkg>/...
+  const pkgIdx = rel.findIndex(p => p === 'package');
+  if (pkgIdx >= 0) {
+    const subIdx = rel.indexOf('modules', pkgIdx);
+    if (subIdx > pkgIdx && rel[subIdx + 1] && KNOWN_PACKAGES.includes(rel[subIdx + 1])) {
+      return rel[subIdx + 1];
+    }
+  }
+  return null;
+}
+
+// We use a single regex with alternation rather than an AST walk because:
+//   - tarballs ship .js without sourcemaps; AST parsing them is brittle
+//   - the moflo-require helper takes the package as a *string* argument
+//     (`mofloImport('@moflo/memory')`), which an AST walker would miss
+//     unless taught about each helper.
+const MOFLO_REF = /['"`]@moflo\/([a-z0-9-]+)['"`]/g;
+
+// Strip /* ... */ block comments and // ... line comments, but keep string and
+// template-literal contents verbatim — those are where the import strings we
+// care about live. JSDoc references like `` `@moflo/cli` `` inside prose would
+// otherwise show up as false-positive edges in the graph.
+function stripComments(src) {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (c === '/' && next === '*') {
+      const end = src.indexOf('*/', i + 2);
+      if (end === -1) break;
+      i = end + 2;
+    } else if (c === '/' && next === '/') {
+      const end = src.indexOf('\n', i + 2);
+      if (end === -1) break;
+      i = end;
+    } else if (c === '"' || c === "'" || c === '`') {
+      i = consumeStringLike(src, i, c, out, s => { out = s; });
+    } else {
+      out += c;
+      i++;
+    }
+  }
+  return out;
+}
+
+// Consume a string/template literal starting at `i` (whose opening quote is
+// `quote`), append its full text to `out` via `setOut`, and return the index
+// just past the closing quote. Inside a template `${...}` expression, recurse
+// into nested string-likes so that braces inside `'}'` etc. don't desync the
+// brace-depth counter.
+function consumeStringLike(src, i, quote, outInit, setOut) {
+  let out = outInit + src[i];
+  i++;
+  while (i < src.length && src[i] !== quote) {
+    if (src[i] === '\\') {
+      out += src[i] + (src[i + 1] || '');
+      i += 2;
+      continue;
+    }
+    if (quote === '`' && src[i] === '$' && src[i + 1] === '{') {
+      out += '${';
+      i += 2;
+      let depth = 1;
+      while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === '"' || ch === "'" || ch === '`') {
+          let inner = '';
+          i = consumeStringLike(src, i, ch, '', s => { inner = s; });
+          out += inner;
+          continue;
+        }
+        if (ch === '{') depth++;
+        else if (ch === '}') { depth--; if (depth === 0) break; }
+        out += ch;
+        i++;
+      }
+      out += '}';
+      i++;
+      continue;
+    }
+    out += src[i++];
+  }
+  if (i < src.length) { out += src[i]; i++; }
+  setOut(out);
+  return i;
+}
+
+function scanFile(absPath) {
+  const src = stripComments(readFileSync(absPath, 'utf8'));
+  const refs = new Set();
+  for (const match of src.matchAll(MOFLO_REF)) {
+    const pkg = match[1];
+    if (KNOWN_PACKAGES.includes(pkg)) refs.add(pkg);
+  }
+  return refs;
+}
+
+function buildGraph({ mode, root, tarball }) {
+  const graph = Object.fromEntries(KNOWN_PACKAGES.map(p => [p, new Set()]));
+  const rootRefs = new Set();
+
+  let scanRoot;
+  let accept;
+  if (mode === 'src') {
+    scanRoot = root;
+    accept = full => {
+      if (full.includes(`${sep}node_modules${sep}`)) return false;
+      if (full.includes(`${sep}dist${sep}`)) return false;
+      if (full.endsWith('.d.ts')) return false;
+      return /\.(ts|tsx|mts|cts|mjs|js)$/.test(full);
+    };
+  } else if (mode === 'dist') {
+    scanRoot = join(root, 'src', 'modules');
+    accept = full => {
+      if (full.includes(`${sep}node_modules${sep}`)) return false;
+      if (!full.includes(`${sep}dist${sep}`)) return false;
+      if (full.endsWith('.d.ts')) return false;
+      return /\.(js|mjs|cjs)$/.test(full);
+    };
+  } else if (mode === 'tarball') {
+    if (!tarball || !existsSync(tarball)) {
+      throw new Error(`Tarball directory not found: ${tarball}`);
+    }
+    scanRoot = tarball;
+    accept = full => {
+      if (full.endsWith('.d.ts')) return false;
+      return /\.(js|mjs|cjs)$/.test(full);
+    };
+  } else {
+    throw new Error(`Unknown mode: ${mode}`);
+  }
+
+  let scannedFiles = 0;
+  for (const file of walk(scanRoot, accept)) {
+    scannedFiles++;
+    const owner = ownerPackage(file, root);
+    const target = owner === null ? rootRefs : graph[owner];
+    for (const ref of scanFile(file)) {
+      if (ref !== owner) target.add(ref);
+    }
+  }
+
+  return {
+    files: scannedFiles,
+    graph: Object.fromEntries(
+      KNOWN_PACKAGES.map(p => [p, [...graph[p]].sort()]),
+    ),
+    rootRefs: [...rootRefs].sort(),
+  };
+}
+
+function topoSort(graph) {
+  const order = [];
+  const remaining = new Set(KNOWN_PACKAGES);
+  while (remaining.size > 0) {
+    const ready = [...remaining]
+      .filter(n => graph[n].every(d => !remaining.has(d)))
+      .sort();
+    if (ready.length === 0) {
+      const stuck = [...remaining].sort();
+      order.push(`<cycle:${stuck.join(',')}>`);
+      break;
+    }
+    for (const n of ready) {
+      order.push(n);
+      remaining.delete(n);
+    }
+  }
+  return order;
+}
+
+// Strongly-connected-components (Tarjan) over the package graph. Returns the
+// non-trivial SCCs (size >= 2) so the JSON output can record cycles as data.
+function findCycles(graph) {
+  let index = 0;
+  const stack = [];
+  const onStack = new Set();
+  const indices = new Map();
+  const lowlinks = new Map();
+  const cycles = [];
+
+  function strongConnect(v) {
+    indices.set(v, index);
+    lowlinks.set(v, index);
+    index++;
+    stack.push(v);
+    onStack.add(v);
+    for (const w of graph[v] || []) {
+      if (!indices.has(w)) {
+        strongConnect(w);
+        lowlinks.set(v, Math.min(lowlinks.get(v), lowlinks.get(w)));
+      } else if (onStack.has(w)) {
+        lowlinks.set(v, Math.min(lowlinks.get(v), indices.get(w)));
+      }
+    }
+    if (lowlinks.get(v) === indices.get(v)) {
+      const component = [];
+      let w;
+      do {
+        w = stack.pop();
+        onStack.delete(w);
+        component.push(w);
+      } while (w !== v);
+      if (component.length >= 2) cycles.push(component.sort());
+    }
+  }
+
+  for (const n of KNOWN_PACKAGES) if (!indices.has(n)) strongConnect(n);
+  return cycles;
+}
+
+function classify(graph) {
+  const inboundCount = Object.fromEntries(KNOWN_PACKAGES.map(n => [n, 0]));
+  for (const n of KNOWN_PACKAGES) {
+    for (const dep of graph[n]) {
+      if (dep in inboundCount) inboundCount[dep]++;
+    }
+  }
+  const leaves = KNOWN_PACKAGES.filter(n => graph[n].length === 0).sort();
+  const trunk = KNOWN_PACKAGES.filter(n => inboundCount[n] >= 3).sort();
+  const earlyCollapse = KNOWN_PACKAGES
+    .filter(n => graph[n].length <= 1 && !trunk.includes(n))
+    .sort();
+  return { inboundCount, leaves, trunk, earlyCollapse };
+}
+
+function renderJson(result, outFile) {
+  const payload = {
+    packages: KNOWN_PACKAGES,
+    adjacency: result.graph,
+    rootRefs: result.rootRefs,
+    cycles: findCycles(result.graph),
+    files: result.files,
+    generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+  };
+  writeFileSync(outFile, JSON.stringify(payload, null, 2) + '\n');
+}
+
+function renderList(items, formatter, emptyText) {
+  if (items.length === 0) return [emptyText];
+  return items.map(formatter);
+}
+
+function renderMd(result, mode, outFile) {
+  const { graph, rootRefs } = result;
+  const { inboundCount, leaves, trunk, earlyCollapse } = classify(graph);
+  const order = topoSort(graph);
+  const sourceLabel = MODES[mode].label;
+
+  const lines = [];
+  lines.push('# `@moflo/*` Workspace Collapse — Dependency Graph');
+  lines.push('');
+  lines.push(`Generated by \`scripts/analyze-collapse-deps.mjs --${mode}\` against the **${sourceLabel}**.`);
+  lines.push('');
+  lines.push(`Files scanned: **${result.files}**.`);
+  lines.push('');
+  lines.push('## Adjacency list');
+  lines.push('');
+  lines.push('Each row lists the `@moflo/*` packages a given module imports (static `from`, dynamic `import()`, or string-arg `mofloImport`).');
+  lines.push('');
+  lines.push('| Package | Outbound count | Imports |');
+  lines.push('|---------|----------------|---------|');
+  for (const pkg of KNOWN_PACKAGES) {
+    const deps = graph[pkg];
+    lines.push(`| \`${pkg}\` | ${deps.length} | ${deps.length ? deps.map(d => `\`${d}\``).join(', ') : '—'} |`);
+  }
+  lines.push('');
+  lines.push('## Inbound count (how many other packages import this one)');
+  lines.push('');
+  lines.push('| Package | Inbound count |');
+  lines.push('|---------|---------------|');
+  for (const pkg of KNOWN_PACKAGES) {
+    lines.push(`| \`${pkg}\` | ${inboundCount[pkg]} |`);
+  }
+  lines.push('');
+  lines.push('## Leaves (zero outbound `@moflo/*` imports)');
+  lines.push('');
+  lines.push('Safe to merge first — no relative paths to other moflo packages will need rewriting.');
+  lines.push('');
+  lines.push(...renderList(leaves, p => `- \`@moflo/${p}\``, '_(none)_'));
+  lines.push('');
+  lines.push('## Early-collapse candidates (outbound ≤ 1, not trunk)');
+  lines.push('');
+  lines.push('After leaves, collapse these next — single relative-path rewrite each.');
+  lines.push('');
+  lines.push(...renderList(
+    earlyCollapse,
+    p => `- \`@moflo/${p}\` → ${graph[p].length ? graph[p].map(d => `\`${d}\``).join(', ') : '_leaf_'}`,
+    '_(none)_',
+  ));
+  lines.push('');
+  lines.push('## Trunk (≥ 3 inbound)');
+  lines.push('');
+  lines.push('Collapse last — these are widely depended on, so flipping them changes many call sites.');
+  lines.push('');
+  lines.push(...renderList(trunk, p => `- \`@moflo/${p}\` (inbound = ${inboundCount[p]})`, '_(none)_'));
+  lines.push('');
+  lines.push('## Topological collapse order (leaves first)');
+  lines.push('');
+  lines.push('Recommended merge order. Each subsequent step has all of its dependencies already merged into the root package, so its own internal `@moflo/*` imports become local relative paths.');
+  lines.push('');
+  for (let i = 0; i < order.length; i++) {
+    lines.push(`${i + 1}. \`@moflo/${order[i]}\``);
+  }
+  lines.push('');
+  if (rootRefs.length > 0) {
+    lines.push('## Root-level references');
+    lines.push('');
+    lines.push('Files outside `src/modules/` (e.g. `bin/`, `src/index.ts`, `scripts/`) that reference `@moflo/*`. After collapse, these become local imports.');
+    lines.push('');
+    for (const p of rootRefs) lines.push(`- \`@moflo/${p}\``);
+    lines.push('');
+  }
+
+  writeFileSync(outFile, lines.join('\n'));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = buildGraph(args);
+
+  if (args.json) renderJson(result, args.json);
+  if (args.md) renderMd(result, args.mode, args.md);
+
+  if (!args.json && !args.md) {
+    console.log(JSON.stringify(result.graph, null, 2));
+  } else {
+    console.log(`Mode: ${args.mode}`);
+    console.log(`Scanned ${result.files} files`);
+    if (args.json) console.log(`JSON → ${args.json}`);
+    if (args.md) console.log(`MD   → ${args.md}`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Foundation artifacts for the workspace-collapse epic. Closes #584.

- `docs/adr/0001-collapse-moflo-workspace-packages.md` — ADR documenting the decision to collapse the 14 `@moflo/*` workspace packages into the single root `moflo` package (current state, decision, alternatives, consequences, migration plan).
- `docs/adr/collapse-deps.json` — machine-readable adjacency list, root-level refs, and cycle data (Tarjan SCC). Regenerable from the scanner.
- `docs/adr/collapse-deps.md` — human-readable narrative covering leaves, mid-tier, trunk, topological collapse order, and the consumer-surface caveat.
- `scripts/analyze-collapse-deps.mjs` — the regenerable scanner. `--src` / `--dist` / `--tarball` modes; strips JS comments before regex; handles nested string-likes inside template-expression braces.

## Key findings

| | |
|--|--|
| Leaves (8) | `aidefence`, `claims`, `embeddings`, `plugins`, `security`, `shared`, `spells`, `swarm` |
| Trunk | `cli` (outbound 9, inbound 0); `memory` & `embeddings` (each inbound 4) |
| Cycle | `memory ↔ neural` — both edges are guarded dynamic `import()`, disappears on collapse |
| Tarball gap | `aidefence`, `claims`, `testing` ship as separate npm packages — but `cli` keeps live `import('@moflo/<pkg>')` strings to all three (handled via try/catch + clear error messaging today) |

Source-tree, compiled-`dist/`, and extracted-tarball scans produce **identical** adjacency.

## Test plan

- [x] `node scripts/analyze-collapse-deps.mjs --src --json docs/adr/collapse-deps.json` regenerates the committed file with no diff
- [x] `--dist` and `--tarball` modes produce the same adjacency as `--src`
- [x] Smoke fixture verifies comment-stripper rejects JSDoc-prose mentions and handles nested string-likes inside `${...}` expressions
- [x] Tarjan SCC correctly identifies the single `memory↔neural` cycle
- [x] All 14 packages from acceptance criteria appear as adjacency keys

## Out of scope

Per the issue, the per-module collapse work is tracked under separate stories in the workspace-collapse epic. This PR ships the decision and the data the stories will consume.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)