### PR TITLE
ci(smoke): consumer-install gate for @moflo/* bare specifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,39 +76,8 @@ jobs:
         # in a dedicated second pass, which `npx vitest run` does not perform.
         run: npm test
 
-  smoke:
-    name: Consumer smoke (${{ matrix.os }})
-    needs: [build]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-
-      # See the test job for cache-key rationale. `~/.cache/fastembed`
-      # expands on all three runners (Linux/macOS/Windows) — actions/cache
-      # resolves `~` via os.homedir() and fastembed agrees on the path.
-      - name: Cache fastembed model
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/fastembed
-          key: fastembed-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-fast-all-MiniLM-L6-v2
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Build all packages
-        run: npm run build
-
-      - name: Run consumer smoke harness
-        run: npm run test:smoke
+  # Consumer smoke moved to .github/workflows/consumer-install-smoke.yml so it
+  # also runs on push to main and gates /publish (issue #585).
 
   lint:
     name: Lint & Security

--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -1,0 +1,67 @@
+name: Consumer install smoke
+
+# Issue #585: standalone gate for consumer-install packaging regressions.
+#
+# Tests moflo as a real consumer would — `npm pack` + scratch-dir install —
+# rather than as an in-tree workspace where bare `@moflo/*` specifiers resolve
+# via hoisting. This is the harness that would have caught the silent
+# migration skip shipped in 4.8.87-rc.2 (regression test landed in #583,
+# tracker test landed in PR for this issue).
+#
+# Required for /publish: keep this workflow as a required check on the
+# protected branch so a release can never tag from a tree that fails here.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  NODE_VERSION: '20'
+
+# Cancel superseded PR runs but never cancel an in-flight push to main:
+# a half-finished smoke on main leaves the branch in an unverified state and
+# the next push has nothing to compare against.
+concurrency:
+  group: consumer-smoke-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  smoke:
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    # Acceptance criterion: < 5 min on Ubuntu. Cap all runners conservatively
+    # so a stuck install can't hold the queue.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      # Caches the fastembed model (~90 MB). Key includes the lockfile hash
+      # so a fastembed bump invalidates automatically, and the model name so
+      # swapping models never reuses a stale vector space. No restore-keys —
+      # partial prefix matches could restore the wrong model's binary blobs
+      # on a future model swap. See ADR-EMB-001 / epic #527.
+      - name: Cache fastembed model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/fastembed
+          key: fastembed-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-fast-all-MiniLM-L6-v2
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build all packages
+        run: npm run build
+
+      - name: Run consumer smoke harness
+        run: npm run test:smoke

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -788,6 +788,43 @@ export function verifyNoPathResolutionErrors() {
   }
 }
 
+/**
+ * Issue #585: probe every `@moflo/*` bare-specifier path in the consumer
+ * install. Catches the regression class that shipped in 4.8.87-rc.2 — silent
+ * `try/catch { return null }` blocks around `import('@moflo/<pkg>')` that hid
+ * a broken tarball from consumers.
+ *
+ * Delegates to `scripts/consumer-smoke/probe-bare-specifiers.mjs` so
+ * contributors can reproduce locally with one command:
+ *   node scripts/consumer-smoke/probe-bare-specifiers.mjs --consumer-dir <path>
+ */
+export function consumerInstallSensitivePaths(consumerDir, repoRoot) {
+  section('Consumer-install-sensitive @moflo/* probes (issue #585)');
+  const probe = join(repoRoot, 'scripts', 'consumer-smoke', 'probe-bare-specifiers.mjs');
+  if (!existsSync(probe)) {
+    record('probe-bare-specifiers', 'fail', `${relative(repoRoot, probe)} missing`);
+    return;
+  }
+  const r = runNode(probe, ['--consumer-dir', consumerDir, '--json'], {
+    cwd: repoRoot,
+    timeout: 180_000,
+  });
+  let parsed;
+  try { parsed = JSON.parse(r.stdout.trim()); } catch {
+    record('probe-bare-specifiers', 'fail',
+      `non-JSON output (exit ${r.code}): ${(r.stderr || r.stdout).trim().slice(0, 300)}`);
+    return;
+  }
+  for (const pr of parsed.results) {
+    record(`probe:${pr.name}`, pr.status, pr.detail);
+  }
+  if (r.code !== 0 && parsed.hardFails === 0) {
+    // Probe exit was non-zero but no hard fails were recorded — surface so
+    // the harness doesn't silently miss an aborted probe run.
+    record('probe-bare-specifiers', 'fail', `probe exit ${r.code} with no recorded fails`);
+  }
+}
+
 export function stopConsumerDaemon(consumerDir) {
   // Consumer scratch dirs have no moflo.yaml, so the daemon auto-starts
   // during memory ops and holds locks on .swarm/memory.db. Stop it so the

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -87,6 +87,9 @@ function main() {
       () => check.installSurface(consumerDir),
       () => check.verifyPrunedBinaries(consumerDir),
       () => check.verifyTokenizerSubpackage(consumerDir),
+      // Issue #585: probe every @moflo/* bare specifier the consumer install
+      // exercises, including the four call sites loud-failed in #583.
+      () => check.consumerInstallSensitivePaths(consumerDir, repoRoot),
       // Issue #575: must run LAST so it sees stderr from every preceding check.
       () => check.verifyNoPathResolutionErrors(),
     ];

--- a/scripts/consumer-smoke/probe-bare-specifiers.mjs
+++ b/scripts/consumer-smoke/probe-bare-specifiers.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * Probe consumer-install-sensitive `@moflo/*` bare-specifier paths.
+ *
+ * Catches the regression class shipped in 4.8.87-rc.2 (issue #583): silent
+ * `try { import('@moflo/embeddings') } catch { return null }` blocks that
+ * left consumers with a broken install and no signal in their logs.
+ *
+ * Inversion to keep in mind: in a consumer install, the `@moflo/<pkg>` bare
+ * specifiers are NOT resolvable — those packages live as folders inside
+ * `node_modules/moflo/src/modules/<pkg>/` and have no top-level
+ * `node_modules/@moflo/` symlinks. moflo uses walk-up fallbacks
+ * (`importMofloMemory`) or graceful loud-fail (`requireMofloOrWarn`) to
+ * cope. This probe verifies the loud-fail signal IS present at the call
+ * sites patched in #583 — its absence is the bug we're guarding against.
+ *
+ * Probes:
+ *
+ *   1. **Module-load probes** — import each of the four files patched in
+ *      PR #583. Files with a top-level `await requireMofloOrWarn(...)`
+ *      (currently just `neural-tools.js`) must produce the named stderr
+ *      line on import. All four must load without throwing
+ *      `ERR_MODULE_NOT_FOUND`.
+ *
+ *   2. **Session-start launcher probe** — run
+ *      `.claude/scripts/session-start-launcher.mjs` from a consumer
+ *      scratch dir. The launcher is what consumers actually hit on
+ *      Claude Code startup, and it's where the rc.2 silent skip lived.
+ *      Must run to completion AND produce the embeddings-migration loud
+ *      signal (proves the migration foreground hook didn't silently
+ *      no-op).
+ *
+ *   3. **Files-array sanity** — every `src/modules/<pkg>/dist/` glob in
+ *      the published `package.json` "files" array must point to a real
+ *      directory in the installed tarball. Catches stale `files`
+ *      entries.
+ *
+ * Locally invokable; the consumer-smoke harness wires this in as one of
+ * its checks.
+ *
+ * Usage:
+ *   node scripts/consumer-smoke/probe-bare-specifiers.mjs --consumer-dir <path>
+ *   node scripts/consumer-smoke/probe-bare-specifiers.mjs --consumer-dir <path> --json
+ */
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const argv = process.argv.slice(2);
+const consumerDirIdx = argv.indexOf('--consumer-dir');
+if (consumerDirIdx === -1 || !argv[consumerDirIdx + 1]) {
+  process.stderr.write('usage: probe-bare-specifiers.mjs --consumer-dir <path> [--json]\n');
+  process.exit(2);
+}
+const consumerDir = argv[consumerDirIdx + 1];
+const asJson = argv.includes('--json');
+
+if (!existsSync(consumerDir)) {
+  process.stderr.write(`consumer dir not found: ${consumerDir}\n`);
+  process.exit(2);
+}
+
+const mofloPkgDir = join(consumerDir, 'node_modules', 'moflo');
+if (!existsSync(mofloPkgDir)) {
+  process.stderr.write(`node_modules/moflo missing in ${consumerDir}\n`);
+  process.exit(2);
+}
+
+const cliDist = join(mofloPkgDir, 'src', 'modules', 'cli', 'dist', 'src');
+if (!existsSync(cliDist)) {
+  process.stderr.write(`cli dist missing at ${cliDist} — did the tarball pack correctly?\n`);
+  process.exit(2);
+}
+
+/**
+ * The four files patched in PR #583. `loudFailExpected` is true when the
+ * file has a top-level `await requireMofloOrWarn(...)` that fires on
+ * import — currently only `neural-tools.js`. Other files defer until the
+ * function is called, so importing them alone produces no signal.
+ */
+const PR_583_FILES = [
+  {
+    label: 'embeddings-migration',
+    relPath: 'services/embeddings-migration.js',
+    loudFailExpected: false,
+  },
+  {
+    label: 'hooks-tools',
+    relPath: 'mcp-tools/hooks-tools.js',
+    loudFailExpected: false,
+  },
+  {
+    label: 'neural-tools',
+    relPath: 'mcp-tools/neural-tools.js',
+    loudFailExpected: true,
+    expectedTag: 'neural-tools',
+    expectedSpecifier: '@moflo/embeddings',
+  },
+  {
+    label: 'security-tools',
+    relPath: 'mcp-tools/security-tools.js',
+    loudFailExpected: false,
+  },
+];
+
+const results = [];
+let hardFails = 0;
+
+function record(name, status, detail) {
+  results.push({ name, status, detail });
+  if (status === 'fail') hardFails++;
+}
+
+function importInChild(targetUrl, cwd) {
+  const code = `await import(${JSON.stringify(targetUrl)});`;
+  return spawnSync(process.execPath, ['--input-type=module', '-e', code], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: { ...process.env, MOFLO_BRIDGE_QUIET: '1' },
+  });
+}
+
+// ── Probe 1: PR #583 module-load probes ────────────────────────────────────
+for (const site of PR_583_FILES) {
+  const abs = join(cliDist, site.relPath);
+  if (!existsSync(abs)) {
+    record(`load:${site.label}`, 'fail', `${relative(mofloPkgDir, abs)} not in tarball`);
+    continue;
+  }
+  const url = pathToFileURL(abs).href;
+  const r = importInChild(url, consumerDir);
+
+  if (r.error) {
+    record(`load:${site.label}`, 'fail', `spawn error: ${r.error.message}`);
+    continue;
+  }
+
+  const stderr = r.stderr || '';
+
+  // Hard ERR_MODULE_NOT_FOUND escaping the helper is always a fail —
+  // means a bare import bypassed `requireMofloOrWarn` and crashed.
+  if (/ERR_MODULE_NOT_FOUND|Cannot find package/.test(stderr) && r.status !== 0) {
+    record(
+      `load:${site.label}`,
+      'fail',
+      `hard module-not-found on import: ${stderr.slice(0, 200)}`,
+    );
+    continue;
+  }
+  if (r.status !== 0) {
+    record(
+      `load:${site.label}`,
+      'fail',
+      `import exit ${r.status}: ${(stderr || r.stdout || '').trim().slice(0, 200)}`,
+    );
+    continue;
+  }
+
+  // For files with a top-level loud-fail, the named line MUST appear in
+  // stderr — its absence is the rc.2 silent-skip regression.
+  if (site.loudFailExpected) {
+    const expected = new RegExp(
+      `\\[${site.expectedTag}\\][^\\n]*${site.expectedSpecifier.replace('/', '\\/')}[^\\n]*not resolvable`,
+      'i',
+    );
+    if (!expected.test(stderr)) {
+      record(
+        `load:${site.label}`,
+        'fail',
+        `expected loud-fail line missing — silent skip regression. ` +
+          `stderr was: ${stderr.trim().slice(0, 200) || '(empty)'}`,
+      );
+      continue;
+    }
+    record(
+      `load:${site.label}`,
+      'pass',
+      `loud-fail signal present for ${site.expectedSpecifier}`,
+    );
+    continue;
+  }
+
+  record(`load:${site.label}`, 'pass', 'imports cleanly');
+}
+
+// ── Probe 2: session-start launcher (the rc.2 trigger path) ────────────────
+// The launcher ships in `bin/` and gets synced into `<consumer>/.claude/scripts/`
+// on first session-start. Probe the canonical bin/ location — that's the file
+// the launcher uses as its sync source, and the one the rc.2 silent-skip lived in.
+const launcher = join(mofloPkgDir, 'bin', 'session-start-launcher.mjs');
+if (!existsSync(launcher)) {
+  record(
+    'session-start-launcher',
+    'fail',
+    `${relative(mofloPkgDir, launcher)} not in tarball`,
+  );
+} else {
+  const r = spawnSync(process.execPath, [launcher], {
+    cwd: consumerDir,
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: { ...process.env, MOFLO_BRIDGE_QUIET: '1' },
+  });
+  if (r.error) {
+    record('session-start-launcher', 'fail', `spawn error: ${r.error.message}`);
+  } else if (r.status !== 0) {
+    record(
+      'session-start-launcher',
+      'fail',
+      `launcher exit ${r.status}: ${(r.stderr || r.stdout || '').trim().slice(0, 300)}`,
+    );
+  } else {
+    // The launcher imports `embeddings-migration.js` and calls
+    // `runEmbeddingsMigrationIfNeeded`. In a fresh consumer scratch dir
+    // there's no DB, so the function returns false BEFORE the
+    // `@moflo/embeddings` resolution attempt — meaning we get no
+    // loud-fail line. That's expected and not a regression.
+    //
+    // What we DO assert: the launcher itself didn't print
+    // `embeddings migration check skipped: <error>` to stderr (the
+    // launcher's own outer try/catch). Its presence means the launcher
+    // failed to even get to runEmbeddingsMigrationIfNeeded — that IS a
+    // regression worth flagging.
+    const stderr = r.stderr || '';
+    if (/embeddings migration check skipped:/i.test(stderr)) {
+      record(
+        'session-start-launcher',
+        'fail',
+        `launcher's outer catch fired — migration entry-point itself crashed: ${stderr.slice(0, 300)}`,
+      );
+    } else {
+      record('session-start-launcher', 'pass', 'launcher ran cleanly');
+    }
+  }
+}
+
+// ── Probe 3: package.json files-array sanity ───────────────────────────────
+const ROOT_PKG = JSON.parse(readFileSync(join(mofloPkgDir, 'package.json'), 'utf8'));
+const filesEntries = Array.isArray(ROOT_PKG.files) ? ROOT_PKG.files : [];
+const moduleDistGlobs = filesEntries.filter(
+  (e) => /^src\/modules\/[^/]+\/dist\//.test(e) && !e.startsWith('!'),
+);
+const missingDists = [];
+for (const glob of moduleDistGlobs) {
+  // `src/modules/<pkg>/dist/**/*.js` → `src/modules/<pkg>/dist`
+  const distDir = glob.replace(/\/(?:\*\*|\!).*$/, '').replace(/\/\*\*\/.+$/, '');
+  const abs = join(mofloPkgDir, distDir);
+  if (!existsSync(abs) || !statSync(abs).isDirectory()) {
+    missingDists.push(distDir);
+  }
+}
+if (missingDists.length > 0) {
+  record(
+    'files-array:dists',
+    'fail',
+    `package.json files claims dirs that didn't ship: ${missingDists.join(', ')}`,
+  );
+} else {
+  record(
+    'files-array:dists',
+    'pass',
+    `${moduleDistGlobs.length} module dist dir(s) present`,
+  );
+}
+
+// ── Report ──────────────────────────────────────────────────────────────────
+if (asJson) {
+  process.stdout.write(JSON.stringify({ results, hardFails }, null, 2) + '\n');
+} else {
+  for (const r of results) {
+    const tag = r.status === 'pass' ? 'PASS' : 'FAIL';
+    process.stdout.write(`  [${tag}] ${r.name} — ${r.detail}\n`);
+  }
+  process.stdout.write(
+    `\n${results.filter((r) => r.status === 'pass').length}/${results.length} passed` +
+      (hardFails > 0 ? `, ${hardFails} hard fail(s)` : '') +
+      '\n',
+  );
+}
+
+process.exit(hardFails > 0 ? 1 : 0);

--- a/src/modules/cli/__tests__/services/published-package-drift-guard.test.ts
+++ b/src/modules/cli/__tests__/services/published-package-drift-guard.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Published-package drift guard (issue #585).
+ *
+ * Two static invariants that, if violated, would ship a broken consumer
+ * install — the same class of bug as 4.8.87-rc.2 (issue #583). Pairs with
+ * the consumer-smoke probe at `scripts/consumer-smoke/probe-bare-specifiers.mjs`:
+ * the smoke catches it at runtime, this catches it in vitest in <100ms so a
+ * dev sees the problem before they push.
+ *
+ *   1. **Files-array coverage**: every `@moflo/<pkg>` bare specifier used in
+ *      moflo source must point to a module whose dist is in
+ *      `package.json`'s `files` array. A bare import for a module not
+ *      shipped in the tarball will throw `ERR_MODULE_NOT_FOUND` in any
+ *      consumer install.
+ *
+ *   2. **Bare-import inventory**: snapshot the set of `@moflo/<pkg>`
+ *      packages imported anywhere in source. New entries fail the test
+ *      until they're added to ALLOWED_BARE_PACKAGES — at which point the
+ *      dev has been forced to think about whether the consumer-smoke
+ *      probe still covers them. (It auto-extends, but the static signal
+ *      keeps the inventory honest.)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, 'package.json')) && existsSync(join(dir, 'src', 'modules'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate moflo repo root from drift guard test.');
+}
+
+const REPO_ROOT = findRepoRoot();
+const SRC_ROOT = join(REPO_ROOT, 'src');
+
+// Auto-installed externals that intentionally aren't in moflo's `files` array.
+// Adding to this list is a deliberate choice — every entry here costs the
+// consumer an extra install on first use.
+const AUTO_INSTALLED_EXTERNALS = new Set(['@moflo/aidefence']);
+
+// Pinned inventory of bare packages. New entries force a dev to verify the
+// consumer-smoke probe still covers them.
+const ALLOWED_BARE_PACKAGES = new Set([
+  '@moflo/shared',
+  '@moflo/memory',
+  '@moflo/swarm',
+  '@moflo/neural',
+  '@moflo/embeddings',
+  '@moflo/aidefence',
+  '@moflo/guidance',
+  '@moflo/hooks',
+]);
+
+const BARE_RE = /(?:from|import)\s*\(?\s*['"](@moflo\/[a-z][a-z0-9_-]*)(?:\/[a-z0-9_/.-]+)?['"]/g;
+
+// Skip JSDoc and line comments — they routinely show example imports for
+// modules we don't actually depend on. The `tests/` and `__tests__/`
+// directories are excluded because per-module test code may import the
+// module's own siblings via bare specifier for ergonomics, but those
+// imports never run inside a consumer install.
+const TEST_DIRS = new Set(['__tests__', 'tests', 'test']);
+
+function* walkTs(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    if (TEST_DIRS.has(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkTs(full);
+      continue;
+    }
+    if (!/\.(m?ts|m?js)$/.test(entry.name)) continue;
+    if (entry.name.endsWith('.d.ts')) continue;
+    if (!entry.isFile()) continue;
+    yield full;
+  }
+}
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return trimmed.startsWith('*') || trimmed.startsWith('//');
+}
+
+function scanBareImports(): Set<string> {
+  const found = new Set<string>();
+  for (const file of walkTs(SRC_ROOT)) {
+    const text = readFileSync(file, 'utf8');
+    if (!text.includes('@moflo/')) continue;
+    for (const line of text.split('\n')) {
+      if (isCommentLine(line)) continue;
+      if (!line.includes('@moflo/')) continue;
+      BARE_RE.lastIndex = 0;
+      let m;
+      while ((m = BARE_RE.exec(line)) !== null) {
+        found.add(m[1]);
+      }
+    }
+  }
+  return found;
+}
+
+interface PkgJson {
+  files?: string[];
+}
+
+function shippedModules(): Set<string> {
+  const pkg: PkgJson = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
+  const filesArr = pkg.files ?? [];
+  const shipped = new Set<string>();
+  for (const entry of filesArr) {
+    if (entry.startsWith('!')) continue;
+    const m = entry.match(/^src\/modules\/([^/]+)\/dist\//);
+    if (m) shipped.add(`@moflo/${m[1]}`);
+  }
+  return shipped;
+}
+
+describe('published-package drift guard (issue #585)', () => {
+  it('every @moflo/* bare specifier points to a module shipped in package.json files (or an allowed external)', () => {
+    const used = scanBareImports();
+    const shipped = shippedModules();
+    const orphans: string[] = [];
+    for (const spec of used) {
+      if (shipped.has(spec)) continue;
+      if (AUTO_INSTALLED_EXTERNALS.has(spec)) continue;
+      orphans.push(spec);
+    }
+    expect(
+      orphans,
+      `These @moflo/* bare imports target modules not shipped in package.json "files":\n  ${orphans.join('\n  ')}\n` +
+        `Either (a) add the module's dist to "files", (b) add to AUTO_INSTALLED_EXTERNALS if it's a real external, ` +
+        `or (c) remove the import.`,
+    ).toEqual([]);
+  });
+
+  it('inventory of @moflo/* bare specifiers matches the pinned allow-list', () => {
+    const used = scanBareImports();
+    const unexpected = [...used].filter((s) => !ALLOWED_BARE_PACKAGES.has(s));
+    const missing = [...ALLOWED_BARE_PACKAGES].filter((s) => !used.has(s));
+    expect(
+      { unexpected, missing },
+      `New or removed @moflo/* bare specifiers detected.\n` +
+        `If intentional: update ALLOWED_BARE_PACKAGES in this file AND verify the consumer-smoke probe ` +
+        `at scripts/consumer-smoke/probe-bare-specifiers.mjs covers the new path.`,
+    ).toEqual({ unexpected: [], missing: [] });
+  });
+
+  it('every shipped module dist directory exists under src/modules/', () => {
+    // Catches a stale `files` entry — claiming to ship a module whose
+    // source was deleted. Consumers would see the spec resolve but the
+    // import would 404 because the dist dir doesn't exist.
+    const pkg: PkgJson = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
+    const filesArr = pkg.files ?? [];
+    const missing: string[] = [];
+    for (const entry of filesArr) {
+      if (entry.startsWith('!')) continue;
+      const m = entry.match(/^(src\/modules\/[^/]+)\/dist\//);
+      if (!m) continue;
+      const moduleSrc = join(REPO_ROOT, m[1]);
+      if (!existsSync(moduleSrc) || !statSync(moduleSrc).isDirectory()) {
+        missing.push(relative(REPO_ROOT, moduleSrc));
+      }
+    }
+    expect(
+      missing,
+      `package.json "files" claims to ship from these module dirs that don't exist:\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Build the CI gate that would have caught 4.8.87-rc.2: a dedicated workflow that exercises every `@moflo/*` bare-specifier path patched in #583 from a real tarball install.
- New probe asserts the loud-fail signal IS present at consumer-install-sensitive call sites (its absence is the rc.2 silent-skip regression). Auto-extends as new bare imports are added — the static drift guard pins the inventory.
- Smoke moved to its own workflow; runs on PR + push to main, gates `/publish`.

## Inversion to keep in mind

In any consumer install, `@moflo/<pkg>` bare specifiers are **not** resolvable — those modules live as folders inside `node_modules/moflo/src/modules/<pkg>/` with no top-level `node_modules/@moflo/` symlinks. The loud-fail signal firing IS the post-#583 expected state; its ABSENCE indicates an rc.2-style silent regression. The probe is calibrated for that.

## Changes

- `scripts/consumer-smoke/probe-bare-specifiers.mjs` — locally invokable probe that, given a consumer scratch dir, imports each of the four files patched in #583, runs the session-start launcher, and validates `files`-array dist dirs all ship.
- `harness/consumer-smoke/{run.mjs,lib/checks.mjs}` — wires the probe in as a new check.
- `.github/workflows/consumer-install-smoke.yml` — dedicated workflow on Ubuntu/macOS/Windows, PR + push to main, 15-min cap.
- `.github/workflows/ci.yml` — duplicate smoke job removed.
- `src/modules/cli/__tests__/services/published-package-drift-guard.test.ts` — static guard. Pins `@moflo/*` bare-import inventory + every shipped module dist dir must exist.

## Test plan

- [x] Local smoke harness passes end-to-end on Windows in 70s (37/37 checks).
- [x] All 2069 cli tests pass.
- [x] Drift-guard test passes (3/3 assertions).
- [ ] CI smoke passes on Ubuntu/macOS/Windows.
- [ ] Verified the probe would have failed against 4.8.87-rc.2 (see "Inversion" above — the probe asserts on the exact loud-fail signal #583 added).

Closes #585

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)