### PR TITLE
test: add 19 Windows fork-contention flakies to vitest isolationTests (#617)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,31 @@ export const isolationTests = [
   // maxForks=2 and pushes neighboring tests over their timeouts. Cached
   // runs are <2 s but the cache-cold path is the one CI exercises.
   'src/modules/cli/__tests__/embeddings/fastembed-inline-integration.test.ts',
+  // Issue #617 — full-suite Windows fork contention triage. Across 4
+  // back-to-back `npm test` runs the failure set varied 31/41/42/49 with
+  // wildly different members; every file below was verified to pass in
+  // isolation (and the three that needed individual re-verification —
+  // doctor-sandbox-tier, pause-resume, runner-bridge — pass cleanly when
+  // run alone, but exceed 5 s timeouts when batched even sequentially).
+  'src/modules/cli/__tests__/cli.test.ts',
+  'src/modules/cli/__tests__/doctor-sandbox-tier.test.ts',
+  'src/modules/cli/__tests__/mcp-tools-deep.test.ts',
+  'src/modules/cli/__tests__/services/moflo-require.test.ts',
+  'src/modules/guidance/tests/persistence.test.ts',
+  'src/modules/hooks/__tests__/workers.test.ts',
+  'src/modules/shared/src/hooks/verify-exports.test.ts',
+  'src/modules/spells/__tests__/built-in-commands.test.ts',
+  'src/modules/spells/__tests__/moflo-levels.test.ts',
+  'src/modules/spells/__tests__/parallel-integration.test.ts',
+  'src/modules/spells/__tests__/pause-resume.test.ts',
+  'src/modules/spells/__tests__/preflight-severity.test.ts',
+  'src/modules/spells/__tests__/runner-bridge.test.ts',
+  'src/modules/spells/__tests__/runner.test.ts',
+  'src/modules/spells/__tests__/tool-registry.test.ts',
+  'tests/bin/bin-scripts.test.ts',
+  'tests/guards/hash-fallback-guard.test.ts',
+  'tests/hive-mind-messagebus.test.ts',
+  'tests/issue-fixes.test.ts',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Triaged and added 19 confirmed-flaky test files to `vitest.config.ts:isolationTests` so they run sequentially in pass 2 instead of competing for resources under `maxForks=2` on Windows. After the change, three consecutive `npm test` runs produce identical results — only the documented #618 LearningBridge benchmark failures remain.

## Triage method

1. Ran `npm test` 4 times on `main` — observed 31/41/42/49 failures with wildly different members.
2. Built the union of failing files (20 unique files across the runs).
3. Ran the union sequentially under `vitest.isolation.config.ts` (`maxForks: 1`). 16 passed clean; 3 stragglers (`doctor-sandbox-tier`, `pause-resume`, `runner-bridge`) failed even batched-sequential.
4. Re-ran each straggler individually — all 3 passed alone, confirming flakiness rather than real failure.
5. Documented out-of-scope failure (`memory/src/benchmark.test.ts` — real LearningBridge perf miss) is tracked under #618; not added here.

## Changes

- `vitest.config.ts`: appended 19 entries with one comment block referencing #617 (no other edits)

## Files added to `isolationTests`

- `src/modules/cli/__tests__/cli.test.ts`
- `src/modules/cli/__tests__/doctor-sandbox-tier.test.ts`
- `src/modules/cli/__tests__/mcp-tools-deep.test.ts`
- `src/modules/cli/__tests__/services/moflo-require.test.ts`
- `src/modules/guidance/tests/persistence.test.ts`
- `src/modules/hooks/__tests__/workers.test.ts`
- `src/modules/shared/src/hooks/verify-exports.test.ts`
- `src/modules/spells/__tests__/built-in-commands.test.ts`
- `src/modules/spells/__tests__/moflo-levels.test.ts`
- `src/modules/spells/__tests__/parallel-integration.test.ts`
- `src/modules/spells/__tests__/pause-resume.test.ts`
- `src/modules/spells/__tests__/preflight-severity.test.ts`
- `src/modules/spells/__tests__/runner-bridge.test.ts`
- `src/modules/spells/__tests__/runner.test.ts`
- `src/modules/spells/__tests__/tool-registry.test.ts`
- `tests/bin/bin-scripts.test.ts`
- `tests/guards/hash-fallback-guard.test.ts`
- `tests/hive-mind-messagebus.test.ts`
- `tests/issue-fixes.test.ts`

## Test plan

- [x] 4 baseline `npm test` runs to capture flaky union
- [x] Union verified passing under `vitest.isolation.config.ts` (16 immediate, 3 individually)
- [x] All 19 path entries verified to exist on disk; no duplicates with existing list
- [x] 3 consecutive post-fix `npm test` runs — identical results, only #618 benchmark failures remain
- [x] /simplify checks (path validity, duplicates) clean for the config-only change

Closes #617

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)