### PR TITLE
fix(daemon): epic #629 — eliminate session-start CPU saturation

### DIFF
--- a/.claude/scripts/hooks.mjs
+++ b/.claude/scripts/hooks.mjs
@@ -24,6 +24,7 @@ import { existsSync, appendFileSync, readFileSync, writeFileSync, mkdirSync, sta
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createProcessManager } from './lib/process-manager.mjs';
+import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -560,13 +561,19 @@ function touchSpawnStamp() {
 
 // Run daemon start in background (non-blocking) — skip if already running
 function runDaemonStartBackground() {
-  // 1. Check if a live daemon already holds the lock
+  // 1. Honor user opt-out via .claude/settings.json claudeFlow.daemon.autoStart
+  if (!shouldDaemonAutoStart(projectRoot)) {
+    log('info', 'Daemon autoStart disabled in settings, skipping');
+    return;
+  }
+
+  // 2. Check if a live daemon already holds the lock
   if (isDaemonLockHeld()) {
     log('info', 'Daemon already running (lock held), skipping start');
     return;
   }
 
-  // 2. Debounce: skip if we spawned recently (prevents thundering herd)
+  // 3. Debounce: skip if we spawned recently (prevents thundering herd)
   if (isDaemonSpawnRecent()) {
     log('info', 'Daemon spawn debounced (recent attempt), skipping');
     return;
@@ -578,7 +585,7 @@ function runDaemonStartBackground() {
     return;
   }
 
-  // 3. Write stamp BEFORE spawning so concurrent callers see it immediately
+  // 4. Write stamp BEFORE spawning so concurrent callers see it immediately
   touchSpawnStamp();
 
   spawnWindowless('node', [localCli, 'daemon', 'start', '--quiet'], 'daemon');

--- a/.claude/scripts/lib/daemon-config.mjs
+++ b/.claude/scripts/lib/daemon-config.mjs
@@ -1,0 +1,19 @@
+// Daemon spawn-gate for bin/ scripts. Reads .claude/settings.json — the
+// Claude-Code-facing surface. moflo.yaml's daemon.auto_start is a separate
+// parallel gate honored by src/cli/index.ts maybeAutoStartDaemon.
+
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Default-true on missing file, missing key, or malformed JSON so a broken
+// config can't silently disable the daemon.
+export function shouldDaemonAutoStart(projectRoot) {
+  try {
+    const settingsPath = resolve(projectRoot, '.claude', 'settings.json');
+    if (!existsSync(settingsPath)) return true;
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    return settings?.claudeFlow?.daemon?.autoStart !== false;
+  } catch {
+    return true;
+  }
+}

--- a/.claude/scripts/lib/process-manager.mjs
+++ b/.claude/scripts/lib/process-manager.mjs
@@ -56,7 +56,8 @@ function lockPath(root) {
   return resolve(root, '.claude-flow', 'spawn.lock');
 }
 
-function readRegistry(root) {
+/** Raw read — returns whatever's on disk without filtering or rewriting. */
+function readRegistryRaw(root) {
   const p = registryPath(root);
   if (!existsSync(p)) return [];
   try {
@@ -65,6 +66,22 @@ function readRegistry(root) {
   } catch {
     return [];
   }
+}
+
+/**
+ * Default read — auto-prunes dead PIDs and rewrites the file when stale
+ * entries are detected. Catches the "abnormal session termination" case
+ * (Claude killed via task manager, OS reboot, hard crash) where session-end
+ * never ran and the registry would otherwise grow unboundedly. Rewrite is
+ * skipped when nothing changed so steady-state reads stay cheap.
+ */
+function readRegistry(root) {
+  const raw = readRegistryRaw(root);
+  const live = raw.filter(e => e && typeof e.pid === 'number' && isAlive(e.pid));
+  if (live.length !== raw.length) {
+    try { writeRegistry(root, live); } catch { /* non-fatal */ }
+  }
+  return live;
 }
 
 /** Atomic write: write to tmp file then rename to avoid torn reads. */
@@ -191,7 +208,9 @@ export function createProcessManager(root) {
      * @returns {{ killed: number, total: number }}
      */
     killAll() {
-      const entries = readRegistry(projectRoot);
+      // Use raw read so `total` reflects every on-disk entry — including
+      // dead ones we'd otherwise skip silently. Matches the prior contract.
+      const entries = readRegistryRaw(projectRoot);
       let killed = 0;
 
       for (const entry of entries) {
@@ -227,7 +246,9 @@ export function createProcessManager(root) {
      * @returns {{ pruned: number, remaining: number }}
      */
     prune() {
-      const entries = readRegistry(projectRoot);
+      // Use raw read so the pruned count reflects what was on disk, not
+      // what the auto-pruning readRegistry would have already cleaned up.
+      const entries = readRegistryRaw(projectRoot);
       const alive = entries.filter(e => isAlive(e.pid));
       writeRegistry(projectRoot, alive);
       return { pruned: entries.length - alive.length, remaining: alive.length };

--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -24,6 +24,7 @@ import { existsSync, appendFileSync, readFileSync, writeFileSync, mkdirSync, sta
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createProcessManager } from './lib/process-manager.mjs';
+import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -560,13 +561,19 @@ function touchSpawnStamp() {
 
 // Run daemon start in background (non-blocking) — skip if already running
 function runDaemonStartBackground() {
-  // 1. Check if a live daemon already holds the lock
+  // 1. Honor user opt-out via .claude/settings.json claudeFlow.daemon.autoStart
+  if (!shouldDaemonAutoStart(projectRoot)) {
+    log('info', 'Daemon autoStart disabled in settings, skipping');
+    return;
+  }
+
+  // 2. Check if a live daemon already holds the lock
   if (isDaemonLockHeld()) {
     log('info', 'Daemon already running (lock held), skipping start');
     return;
   }
 
-  // 2. Debounce: skip if we spawned recently (prevents thundering herd)
+  // 3. Debounce: skip if we spawned recently (prevents thundering herd)
   if (isDaemonSpawnRecent()) {
     log('info', 'Daemon spawn debounced (recent attempt), skipping');
     return;
@@ -578,7 +585,7 @@ function runDaemonStartBackground() {
     return;
   }
 
-  // 3. Write stamp BEFORE spawning so concurrent callers see it immediately
+  // 4. Write stamp BEFORE spawning so concurrent callers see it immediately
   touchSpawnStamp();
 
   spawnWindowless('node', [localCli, 'daemon', 'start', '--quiet'], 'daemon');

--- a/bin/lib/daemon-config.mjs
+++ b/bin/lib/daemon-config.mjs
@@ -1,27 +1,12 @@
-/**
- * Daemon spawn-gate config reader for bin/ scripts.
- *
- * Mirrors the TypeScript `daemon.auto_start` behavior in src/cli/index.ts but
- * reads from .claude/settings.json (claudeFlow.daemon.autoStart) — that's the
- * Claude-Code-facing setting and the one the SessionStart hook surface
- * documents to users. moflo.yaml's daemon.auto_start is a separate, parallel
- * gate honored by the CLI's `maybeAutoStartDaemon`.
- */
+// Daemon spawn-gate for bin/ scripts. Reads .claude/settings.json — the
+// Claude-Code-facing surface. moflo.yaml's daemon.auto_start is a separate
+// parallel gate honored by src/cli/index.ts maybeAutoStartDaemon.
 
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 
-/**
- * Returns true if the daemon should auto-start at session-start.
- *
- * Default is `true` (preserves prior behavior). Returns `false` only when
- * `.claude/settings.json` has `claudeFlow.daemon.autoStart === false`.
- * Missing file, missing key, or malformed JSON all default to `true` so a
- * broken config can't silently disable the daemon.
- *
- * @param {string} projectRoot - Absolute path to the project root.
- * @returns {boolean}
- */
+// Default-true on missing file, missing key, or malformed JSON so a broken
+// config can't silently disable the daemon.
 export function shouldDaemonAutoStart(projectRoot) {
   try {
     const settingsPath = resolve(projectRoot, '.claude', 'settings.json');

--- a/bin/lib/daemon-config.mjs
+++ b/bin/lib/daemon-config.mjs
@@ -1,0 +1,34 @@
+/**
+ * Daemon spawn-gate config reader for bin/ scripts.
+ *
+ * Mirrors the TypeScript `daemon.auto_start` behavior in src/cli/index.ts but
+ * reads from .claude/settings.json (claudeFlow.daemon.autoStart) — that's the
+ * Claude-Code-facing setting and the one the SessionStart hook surface
+ * documents to users. moflo.yaml's daemon.auto_start is a separate, parallel
+ * gate honored by the CLI's `maybeAutoStartDaemon`.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Returns true if the daemon should auto-start at session-start.
+ *
+ * Default is `true` (preserves prior behavior). Returns `false` only when
+ * `.claude/settings.json` has `claudeFlow.daemon.autoStart === false`.
+ * Missing file, missing key, or malformed JSON all default to `true` so a
+ * broken config can't silently disable the daemon.
+ *
+ * @param {string} projectRoot - Absolute path to the project root.
+ * @returns {boolean}
+ */
+export function shouldDaemonAutoStart(projectRoot) {
+  try {
+    const settingsPath = resolve(projectRoot, '.claude', 'settings.json');
+    if (!existsSync(settingsPath)) return true;
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    return settings?.claudeFlow?.daemon?.autoStart !== false;
+  } catch {
+    return true;
+  }
+}

--- a/bin/lib/process-manager.mjs
+++ b/bin/lib/process-manager.mjs
@@ -56,7 +56,8 @@ function lockPath(root) {
   return resolve(root, '.claude-flow', 'spawn.lock');
 }
 
-function readRegistry(root) {
+/** Raw read — returns whatever's on disk without filtering or rewriting. */
+function readRegistryRaw(root) {
   const p = registryPath(root);
   if (!existsSync(p)) return [];
   try {
@@ -65,6 +66,22 @@ function readRegistry(root) {
   } catch {
     return [];
   }
+}
+
+/**
+ * Default read — auto-prunes dead PIDs and rewrites the file when stale
+ * entries are detected. Catches the "abnormal session termination" case
+ * (Claude killed via task manager, OS reboot, hard crash) where session-end
+ * never ran and the registry would otherwise grow unboundedly. Rewrite is
+ * skipped when nothing changed so steady-state reads stay cheap.
+ */
+function readRegistry(root) {
+  const raw = readRegistryRaw(root);
+  const live = raw.filter(e => e && typeof e.pid === 'number' && isAlive(e.pid));
+  if (live.length !== raw.length) {
+    try { writeRegistry(root, live); } catch { /* non-fatal */ }
+  }
+  return live;
 }
 
 /** Atomic write: write to tmp file then rename to avoid torn reads. */
@@ -191,7 +208,9 @@ export function createProcessManager(root) {
      * @returns {{ killed: number, total: number }}
      */
     killAll() {
-      const entries = readRegistry(projectRoot);
+      // Use raw read so `total` reflects every on-disk entry — including
+      // dead ones we'd otherwise skip silently. Matches the prior contract.
+      const entries = readRegistryRaw(projectRoot);
       let killed = 0;
 
       for (const entry of entries) {
@@ -227,7 +246,9 @@ export function createProcessManager(root) {
      * @returns {{ pruned: number, remaining: number }}
      */
     prune() {
-      const entries = readRegistry(projectRoot);
+      // Use raw read so the pruned count reflects what was on disk, not
+      // what the auto-pruning readRegistry would have already cleaned up.
+      const entries = readRegistryRaw(projectRoot);
       const alive = entries.filter(e => isAlive(e.pid));
       writeRegistry(projectRoot, alive);
       return { pruned: entries.length - alive.length, remaining: alive.length };

--- a/src/cli/__tests__/cross-platform.test.ts
+++ b/src/cli/__tests__/cross-platform.test.ts
@@ -455,6 +455,32 @@ describe('bin and .claude/scripts file sync', () => {
 
     expect(binSrc).toBe(helpersSrc);
   });
+
+  it('hooks.mjs should be in sync between bin/ and .claude/scripts/', () => {
+    const binSrc = readFileSync(
+      join(__dirname, '..', '..', '..', 'bin', 'hooks.mjs'),
+      'utf-8'
+    );
+    const scriptsSrc = readFileSync(
+      join(__dirname, '..', '..', '..', '.claude', 'scripts', 'hooks.mjs'),
+      'utf-8'
+    );
+
+    expect(binSrc).toBe(scriptsSrc);
+  });
+
+  it('daemon-config.mjs should be in sync between bin/ and .claude/scripts/', () => {
+    const binSrc = readFileSync(
+      join(__dirname, '..', '..', '..', 'bin', 'lib', 'daemon-config.mjs'),
+      'utf-8'
+    );
+    const scriptsSrc = readFileSync(
+      join(__dirname, '..', '..', '..', '.claude', 'scripts', 'lib', 'daemon-config.mjs'),
+      'utf-8'
+    );
+
+    expect(binSrc).toBe(scriptsSrc);
+  });
 });
 
 // ============================================================================

--- a/src/cli/__tests__/services/worker-daemon.test.ts
+++ b/src/cli/__tests__/services/worker-daemon.test.ts
@@ -78,6 +78,27 @@ describe('WorkerDaemon', () => {
       expect(typeof daemon.on).toBe('function');
       expect(typeof daemon.emit).toBe('function');
     });
+
+    it('default registry has audit worker disabled (#633)', () => {
+      // No explicit workers config — falls through to DEFAULT_WORKERS
+      const defaultDaemon = new WorkerDaemon('/tmp/test-default', { autoStart: false });
+      const audit = defaultDaemon.getStatus().config.workers.find(w => w.type === 'audit');
+      expect(audit).toBeDefined();
+      expect(audit?.enabled).toBe(false);
+    });
+
+    it('default registry keeps non-audit workers enabled', () => {
+      const defaultDaemon = new WorkerDaemon('/tmp/test-default-others', { autoStart: false });
+      const workers = defaultDaemon.getStatus().config.workers;
+      const map = workers.find(w => w.type === 'map');
+      const optimize = workers.find(w => w.type === 'optimize');
+      const consolidate = workers.find(w => w.type === 'consolidate');
+      const testgaps = workers.find(w => w.type === 'testgaps');
+      expect(map?.enabled).toBe(true);
+      expect(optimize?.enabled).toBe(true);
+      expect(consolidate?.enabled).toBe(true);
+      expect(testgaps?.enabled).toBe(true);
+    });
   });
 
   // ===========================================================================

--- a/src/cli/__tests__/shared/utils/atomic-file-write.test.ts
+++ b/src/cli/__tests__/shared/utils/atomic-file-write.test.ts
@@ -86,6 +86,34 @@ describe('atomicWriteFileSync (real fs)', () => {
     expect(read[0]).toBe(0xde);
     expect(read[3]).toBe(0xef);
   });
+
+  it('uses a process-unique temp path (#635) — concurrent writers cannot clobber tmp', async () => {
+    // 50 concurrent writers within the same process race for the same target.
+    // Each writes a complete, parseable JSON payload tagged with its writer ID.
+    // The destination must always end up with EXACTLY ONE writer's full payload —
+    // never a corrupted mix or partial JSON.
+    const dir = makeTmpDir();
+    const target = join(dir, 'concurrent.json');
+
+    const writers = Array.from({ length: 50 }, (_, i) =>
+      Promise.resolve().then(() => {
+        try {
+          atomicWriteFileSync(target, JSON.stringify({ writer: i, payload: 'x'.repeat(2048) }));
+        } catch {
+          /* rename-race losers throw; that's expected last-writer-wins behavior */
+        }
+      }),
+    );
+    await Promise.all(writers);
+
+    const final = readFileSync(target, 'utf8');
+    // Always parseable — proves no torn write.
+    const parsed = JSON.parse(final);
+    expect(typeof parsed.writer).toBe('number');
+    expect(parsed.writer).toBeGreaterThanOrEqual(0);
+    expect(parsed.writer).toBeLessThan(50);
+    expect(parsed.payload).toBe('x'.repeat(2048));
+  });
 });
 
 describe('atomicWriteFileSync (injected fs)', () => {

--- a/src/cli/__tests__/shared/utils/atomic-file-write.test.ts
+++ b/src/cli/__tests__/shared/utils/atomic-file-write.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   mkdtempSync,
   readFileSync,
+  readdirSync,
   existsSync,
   writeFileSync,
   renameSync,
@@ -87,11 +88,10 @@ describe('atomicWriteFileSync (real fs)', () => {
     expect(read[3]).toBe(0xef);
   });
 
-  it('uses a process-unique temp path (#635) — concurrent writers cannot clobber tmp', async () => {
-    // 50 concurrent writers within the same process race for the same target.
-    // Each writes a complete, parseable JSON payload tagged with its writer ID.
-    // The destination must always end up with EXACTLY ONE writer's full payload —
-    // never a corrupted mix or partial JSON.
+  it('uses a process-unique temp path so concurrent writers cannot clobber tmp', async () => {
+    // 50 concurrent writers race for the same target. Each writes a complete
+    // parseable JSON payload tagged with its writer ID. The destination must
+    // always end up with exactly one writer's full payload — never a mix.
     const dir = makeTmpDir();
     const target = join(dir, 'concurrent.json');
 
@@ -100,19 +100,22 @@ describe('atomicWriteFileSync (real fs)', () => {
         try {
           atomicWriteFileSync(target, JSON.stringify({ writer: i, payload: 'x'.repeat(2048) }));
         } catch {
-          /* rename-race losers throw; that's expected last-writer-wins behavior */
+          /* rename-race losers throw; expected under last-writer-wins semantics */
         }
       }),
     );
     await Promise.all(writers);
 
-    const final = readFileSync(target, 'utf8');
-    // Always parseable — proves no torn write.
-    const parsed = JSON.parse(final);
+    const parsed = JSON.parse(readFileSync(target, 'utf8'));
     expect(typeof parsed.writer).toBe('number');
     expect(parsed.writer).toBeGreaterThanOrEqual(0);
     expect(parsed.writer).toBeLessThan(50);
     expect(parsed.payload).toBe('x'.repeat(2048));
+
+    // No leftover .tmp.* files — the helper either renamed them or unlinked
+    // them on failure. Stale tmp files would silently leak disk over time.
+    const stragglers = readdirSync(dir).filter(f => f.startsWith('concurrent.json.tmp.'));
+    expect(stragglers).toEqual([]);
   });
 });
 

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -115,9 +115,12 @@ export function generateSettings(options: InitOptions): object {
     },
     daemon: {
       autoStart: true,
+      // Note: this list is documentation for the user — the daemon's actual
+      // worker registry lives in src/cli/services/worker-daemon.ts DEFAULT_WORKERS.
+      // 'audit' is intentionally absent here because it's default-disabled
+      // pending the perf fix in #631.
       workers: [
         'map',           // Codebase mapping
-        'audit',         // Security auditing (critical priority)
         'optimize',      // Performance optimization (high priority)
         'consolidate',   // Memory consolidation
         'testgaps',      // Test coverage gaps

--- a/src/cli/services/spell-gate.ts
+++ b/src/cli/services/spell-gate.ts
@@ -142,14 +142,10 @@ export class GateService {
   writeState(state: GateState): void {
     try {
       fs.mkdirSync(path.dirname(this.stateFilePath), { recursive: true });
-      // Atomic write — concurrent gate hooks fire as separate node processes
-      // and used to produce torn JSON when they raced on naked writeFileSync
-      // (#629/#635). atomicWriteFileSync uses a process-unique temp path +
-      // rename so the destination always reflects exactly one writer's data.
+      // Atomic write so concurrent gate-hook processes never produce torn JSON.
       atomicWriteFileSync(this.stateFilePath, JSON.stringify(state, null, 2));
     } catch {
-      // Non-fatal — last-writer-wins semantics; some updates may be lost
-      // under contention but the file is never corrupted.
+      // Non-fatal — last-writer-wins; updates may be lost, never corrupted.
     }
   }
 

--- a/src/cli/services/spell-gate.ts
+++ b/src/cli/services/spell-gate.ts
@@ -18,6 +18,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { atomicWriteFileSync } from './atomic-file-write.js';
 import { loadMofloConfig } from '../config/moflo-config.js';
 
 // ============================================================================
@@ -141,9 +142,14 @@ export class GateService {
   writeState(state: GateState): void {
     try {
       fs.mkdirSync(path.dirname(this.stateFilePath), { recursive: true });
-      fs.writeFileSync(this.stateFilePath, JSON.stringify(state, null, 2));
+      // Atomic write — concurrent gate hooks fire as separate node processes
+      // and used to produce torn JSON when they raced on naked writeFileSync
+      // (#629/#635). atomicWriteFileSync uses a process-unique temp path +
+      // rename so the destination always reflects exactly one writer's data.
+      atomicWriteFileSync(this.stateFilePath, JSON.stringify(state, null, 2));
     } catch {
-      // Non-fatal
+      // Non-fatal — last-writer-wins semantics; some updates may be lost
+      // under contention but the file is never corrupted.
     }
   }
 

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -12,6 +12,7 @@
 
 import { EventEmitter } from 'events';
 import { existsSync, mkdirSync, writeFileSync, readFileSync, appendFileSync } from 'fs';
+import { atomicWriteFileSync } from './atomic-file-write.js';
 import { cpus } from 'os';
 import { join } from 'path';
 import {
@@ -1089,7 +1090,9 @@ export class WorkerDaemon extends EventEmitter {
     };
 
     try {
-      writeFileSync(this.config.stateFile, JSON.stringify(state, null, 2));
+      // Atomic write protects daemon-state.json from corruption when the
+      // daemon is force-killed mid-write (#635).
+      atomicWriteFileSync(this.config.stateFile, JSON.stringify(state, null, 2));
     } catch (error) {
       this.log('error', `Failed to save state: ${error}`);
     }

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -99,7 +99,10 @@ interface WorkerConfigInternal extends WorkerConfig {
 // Default worker configurations with improved intervals (P0 fix: map 5min -> 15min)
 const DEFAULT_WORKERS: WorkerConfigInternal[] = [
   { type: 'map', intervalMs: 15 * 60 * 1000, offsetMs: 0, priority: 'normal', description: 'Codebase mapping', enabled: true },
-  { type: 'audit', intervalMs: 10 * 60 * 1000, offsetMs: 2 * 60 * 1000, priority: 'critical', description: 'Security analysis', enabled: true },
+  // Default-disabled until the perf regression in #631 is remediated. The
+  // worker averages 238 s/run on real installs, saturating cores back-to-back
+  // when scheduled at the 10-minute interval. Re-enable here when #631 ships.
+  { type: 'audit', intervalMs: 10 * 60 * 1000, offsetMs: 2 * 60 * 1000, priority: 'critical', description: 'Security analysis', enabled: false },
   { type: 'optimize', intervalMs: 15 * 60 * 1000, offsetMs: 4 * 60 * 1000, priority: 'high', description: 'Performance optimization', enabled: true },
   { type: 'consolidate', intervalMs: 30 * 60 * 1000, offsetMs: 6 * 60 * 1000, priority: 'low', description: 'Memory consolidation', enabled: true },
   { type: 'testgaps', intervalMs: 20 * 60 * 1000, offsetMs: 8 * 60 * 1000, priority: 'normal', description: 'Test coverage analysis', enabled: true },
@@ -457,10 +460,16 @@ export class WorkerDaemon extends EventEmitter {
     this.emit('started', { pid: process.pid, startedAt: this.startedAt });
 
     // Schedule all enabled workers
+    const skipped: string[] = [];
     for (const workerConfig of this.config.workers) {
       if (workerConfig.enabled) {
         this.scheduleWorker(workerConfig);
+      } else {
+        skipped.push(workerConfig.type);
       }
+    }
+    if (skipped.length > 0) {
+      this.log('info', `Skipping disabled workers: ${skipped.join(', ')} (audit is default-off pending #631)`);
     }
 
     if (this.scheduler && !this.scheduler.isRunning) {

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -470,7 +470,7 @@ export class WorkerDaemon extends EventEmitter {
       }
     }
     if (skipped.length > 0) {
-      this.log('info', `Skipping disabled workers: ${skipped.join(', ')} (audit is default-off pending #631)`);
+      this.log('info', `Skipping disabled workers: ${skipped.join(', ')}`);
     }
 
     if (this.scheduler && !this.scheduler.isRunning) {
@@ -1090,8 +1090,7 @@ export class WorkerDaemon extends EventEmitter {
     };
 
     try {
-      // Atomic write protects daemon-state.json from corruption when the
-      // daemon is force-killed mid-write (#635).
+      // Atomic write so a force-kill mid-write can't leave partial JSON behind.
       atomicWriteFileSync(this.config.stateFile, JSON.stringify(state, null, 2));
     } catch (error) {
       this.log('error', `Failed to save state: ${error}`);

--- a/src/cli/shared/utils/atomic-file-write.ts
+++ b/src/cli/shared/utils/atomic-file-write.ts
@@ -1,12 +1,19 @@
 /**
  * Atomic filesystem writes for files that must not be left corrupted if the
- * process is interrupted mid-write (SIGINT, power loss, ENOSPC).
+ * process is interrupted mid-write (SIGINT, power loss, ENOSPC) or if multiple
+ * processes write to the same target concurrently.
  *
- * Pattern: write to `<target>.tmp`, then rename onto `target`.
+ * Pattern: write to a process-unique temp path `<target>.tmp.<pid>.<rand>`,
+ * then rename onto `target`.
  *   - `fs.renameSync` is atomic on POSIX.
  *   - On Windows, Node maps it to `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`,
  *     which replaces the destination near-atomically — concurrent readers
  *     always observe either the old file or the new, never a truncated one.
+ *   - The unique temp path means concurrent writers can't clobber each other's
+ *     in-flight bytes (#635). Last-writer-wins semantics: each rename is fully
+ *     atomic, so the destination always reflects exactly one writer's data.
+ *     Updates from earlier writers may be lost — that's a separate concern
+ *     requiring read-modify-write under a file lock.
  *
  * On any failure, the temp file is best-effort removed and the original
  * `target` stays intact. The underlying error is always re-thrown.
@@ -30,7 +37,7 @@ export function atomicWriteFileSync(
   data: Buffer | Uint8Array | string,
   fs: AtomicWriteFs = realFs,
 ): void {
-  const tmpPath = `${targetPath}.tmp`;
+  const tmpPath = `${targetPath}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 8)}`;
   try {
     fs.writeFileSync(tmpPath, data);
     fs.renameSync(tmpPath, targetPath);

--- a/tests/bin/_helpers.ts
+++ b/tests/bin/_helpers.ts
@@ -1,0 +1,15 @@
+import { mkdirSync, rmSync } from 'fs';
+import { resolve } from 'path';
+
+export function makeTempRoot(label: string): string {
+  const root = resolve(
+    __dirname,
+    `../../.testoutput/.test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(root, { recursive: true });
+  return root;
+}
+
+export function cleanTempRoot(root: string): void {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* ok */ }
+}

--- a/tests/bin/daemon-config.test.ts
+++ b/tests/bin/daemon-config.test.ts
@@ -1,38 +1,12 @@
-/**
- * Tests for bin/lib/daemon-config.mjs — the SessionStart spawn gate that
- * honors .claude/settings.json claudeFlow.daemon.autoStart.
- *
- * Story #632 / epic #629.
- */
-
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { writeFileSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
+import { makeTempRoot, cleanTempRoot } from './_helpers.js';
 
 const helperUrl =
   'file://' +
   resolve(__dirname, '../../bin/lib/daemon-config.mjs').replace(/\\/g, '/');
 const { shouldDaemonAutoStart } = await import(helperUrl);
-
-function makeTempRoot(): string {
-  const root = resolve(
-    __dirname,
-    '../../.testoutput/.test-daemon-config-' +
-      Date.now() +
-      '-' +
-      Math.random().toString(36).slice(2, 8),
-  );
-  mkdirSync(root, { recursive: true });
-  return root;
-}
-
-function cleanTempRoot(root: string) {
-  try {
-    rmSync(root, { recursive: true, force: true });
-  } catch {
-    /* ok */
-  }
-}
 
 function writeSettings(root: string, settings: unknown) {
   const dir = resolve(root, '.claude');
@@ -44,7 +18,7 @@ describe('shouldDaemonAutoStart', () => {
   let root: string;
 
   beforeEach(() => {
-    root = makeTempRoot();
+    root = makeTempRoot('daemon-config');
   });
   afterEach(() => cleanTempRoot(root));
 

--- a/tests/bin/daemon-config.test.ts
+++ b/tests/bin/daemon-config.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for bin/lib/daemon-config.mjs — the SessionStart spawn gate that
+ * honors .claude/settings.json claudeFlow.daemon.autoStart.
+ *
+ * Story #632 / epic #629.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { resolve } from 'path';
+
+const helperUrl =
+  'file://' +
+  resolve(__dirname, '../../bin/lib/daemon-config.mjs').replace(/\\/g, '/');
+const { shouldDaemonAutoStart } = await import(helperUrl);
+
+function makeTempRoot(): string {
+  const root = resolve(
+    __dirname,
+    '../../.testoutput/.test-daemon-config-' +
+      Date.now() +
+      '-' +
+      Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* ok */
+  }
+}
+
+function writeSettings(root: string, settings: unknown) {
+  const dir = resolve(root, '.claude');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(resolve(dir, 'settings.json'), JSON.stringify(settings));
+}
+
+describe('shouldDaemonAutoStart', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeTempRoot();
+  });
+  afterEach(() => cleanTempRoot(root));
+
+  it('returns true when .claude/settings.json is missing (preserves prior behavior)', () => {
+    expect(shouldDaemonAutoStart(root)).toBe(true);
+  });
+
+  it('returns true when settings.json has no claudeFlow block', () => {
+    writeSettings(root, { hooks: {} });
+    expect(shouldDaemonAutoStart(root)).toBe(true);
+  });
+
+  it('returns true when claudeFlow.daemon block is absent', () => {
+    writeSettings(root, { claudeFlow: { version: '3.0.0' } });
+    expect(shouldDaemonAutoStart(root)).toBe(true);
+  });
+
+  it('returns true when claudeFlow.daemon.autoStart key is absent', () => {
+    writeSettings(root, { claudeFlow: { daemon: { workers: ['map'] } } });
+    expect(shouldDaemonAutoStart(root)).toBe(true);
+  });
+
+  it('returns true when claudeFlow.daemon.autoStart === true', () => {
+    writeSettings(root, { claudeFlow: { daemon: { autoStart: true } } });
+    expect(shouldDaemonAutoStart(root)).toBe(true);
+  });
+
+  it('returns false when claudeFlow.daemon.autoStart === false', () => {
+    writeSettings(root, { claudeFlow: { daemon: { autoStart: false } } });
+    expect(shouldDaemonAutoStart(root)).toBe(false);
+  });
+
+  it('returns true on malformed JSON (does not silently disable the daemon)', () => {
+    const dir = resolve(root, '.claude');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, 'settings.json'), '{this is not valid json');
+    expect(shouldDaemonAutoStart(root)).toBe(true);
+  });
+
+  it('treats truthy non-boolean values as enabled (only explicit false disables)', () => {
+    writeSettings(root, { claudeFlow: { daemon: { autoStart: 'yes' } } });
+    expect(shouldDaemonAutoStart(root)).toBe(true);
+  });
+
+  it('treats null autoStart as enabled (matches "absent" semantics)', () => {
+    writeSettings(root, { claudeFlow: { daemon: { autoStart: null } } });
+    expect(shouldDaemonAutoStart(root)).toBe(true);
+  });
+});

--- a/tests/bin/process-manager.test.ts
+++ b/tests/bin/process-manager.test.ts
@@ -189,6 +189,29 @@ describe('getActive() and prune()', () => {
     expect(result.pruned).toBe(1);
     expect(result.remaining).toBe(0);
   });
+
+  it('getActive auto-prunes the file when stale entries are present (#634)', () => {
+    // Seed registry with two dead PIDs and one live PID.
+    writeFileSync(
+      join(root, '.claude-flow', 'background-pids.json'),
+      JSON.stringify([
+        { pid: 99999998, label: 'ghost-a', cmd: 'node -e ...', startedAt: new Date().toISOString() },
+        { pid: process.pid, label: 'parent-test', cmd: 'vitest', startedAt: new Date().toISOString() },
+        { pid: 99999999, label: 'ghost-b', cmd: 'node -e ...', startedAt: new Date().toISOString() },
+      ]),
+    );
+
+    const active = runPM(root, `return pm.getActive();`);
+    expect(active.length).toBe(1);
+    expect(active[0].label).toBe('parent-test');
+
+    // Critical assertion: the file on disk was rewritten with the live subset.
+    // This proves we're not leaving stale entries to accumulate across sessions
+    // when session-end didn't fire (abnormal termination).
+    const onDisk = JSON.parse(readFileSync(join(root, '.claude-flow', 'background-pids.json'), 'utf-8'));
+    expect(onDisk).toHaveLength(1);
+    expect(onDisk[0].label).toBe('parent-test');
+  });
 });
 
 describe('lock guard', () => {

--- a/tests/bin/yaml-upgrader.test.ts
+++ b/tests/bin/yaml-upgrader.test.ts
@@ -6,8 +6,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
+import { makeTempRoot, cleanTempRoot } from './_helpers.js';
 
 // Dynamic import so Vitest can resolve the .mjs from this .ts test file.
 const upgraderUrl = 'file://' + resolve(__dirname, '../../bin/lib/yaml-upgrader.mjs').replace(/\\/g, '/');
@@ -18,22 +19,12 @@ const {
   ensureYamlSections,
 } = await import(upgraderUrl);
 
-function makeTempRoot(): string {
-  const root = resolve(__dirname, '../../.testoutput/.test-yaml-upgrader-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
-  mkdirSync(root, { recursive: true });
-  return root;
-}
-
-function cleanTempRoot(root: string) {
-  try { rmSync(root, { recursive: true, force: true }); } catch { /* ok */ }
-}
-
 describe('yaml-upgrader', () => {
   let root: string;
   let yamlPath: string;
 
   beforeEach(() => {
-    root = makeTempRoot();
+    root = makeTempRoot('yaml-upgrader');
     yamlPath = resolve(root, 'moflo.yaml');
   });
   afterEach(() => cleanTempRoot(root));


### PR DESCRIPTION
## Summary

Epic #629 — four story commits on a shared branch that together eliminate the session-start CPU saturation users hit when opening Claude Code in a moflo project. Plus one simplify pass after the four stories.

## Stories included

- **#632** — fix(daemon): honor `claudeFlow.daemon.autoStart` in session-start spawn path
- **#633** — fix(daemon): default-disable audit worker until perf regression is remediated *(temporary workaround; revert checklist in #631)*
- **#634** — fix(daemon): auto-prune dead PIDs from `background-pids.json` on read
- **#635** — fix(gates): atomic write for `.claude/workflow-state.json` to prevent torn writes

## Why

Per #629 diagnostic data: the audit worker averaged 238 s/run on a 600 s interval at `priority: critical`, queuing back-to-back and saturating ~6.5 cores indefinitely. The session-start hook spawned the daemon unconditionally — there was no user-facing kill-switch. Concurrent gate-hook processes were producing torn JSON in `workflow-state.json`. Stale PIDs accumulated in `background-pids.json` whenever Claude was killed abnormally.

Combined effect: opening Claude Code in a moflo project pegged CPU and made the editor appear hung.

## How

Each story is one commit, scoped narrowly:

| Commit | Story | Surface |
|--------|-------|---------|
| `9eba1c5` | #632 | New `bin/lib/daemon-config.mjs` helper; `runDaemonStartBackground` early-returns when `claudeFlow.daemon.autoStart === false` |
| `01ed3e0` | #633 | `DEFAULT_WORKERS[audit].enabled = false` in `worker-daemon.ts:102`; cosmetic worker list updated; `start()` logs skipped workers |
| `92f4a85` | #634 | Split `readRegistry` → `readRegistryRaw` (pure read, used by `prune`/`killAll` for return-contract counts) + `readRegistry` (auto-prunes + atomically rewrites file when stale entries detected) |
| `125f8c3` | #635 | Shared helper `atomic-file-write.ts` upgraded to `<target>.tmp.<pid>.<rand>` so concurrent writers don't clobber each other's tmp; `GateService.writeState` and `WorkerDaemon.saveState` migrated to the helper |
| `30ac09a` | — | /simplify pass: trim doc bloat, extract `tests/bin/_helpers.ts`, drop task-rotting log text, add cleanup assertion to concurrent stress test |

## Tests

All green:

- `tests/bin/` — 42 parallel + 41 isolation passes (process-manager, daemon-config, yaml-upgrader, bin-scripts, lib-sync, install-manifest, gate-helpers, index-tests)
- `src/cli/__tests__/services/worker-daemon.test.ts` — 14 (added 2 for default-disabled audit)
- `src/cli/__tests__/shared/utils/atomic-file-write.test.ts` — 8 (added concurrent 50-writer stress test asserting parseable destination + no `.tmp.*` stragglers)
- `src/cli/__tests__/daemon-dashboard.test.ts` — 34
- `src/cli/__tests__/commands-untested.test.ts` — 70

`tsc -b --noEmit` clean.

## Test plan

- [x] Unit tests pass (touched files + their immediate neighbors)
- [x] Concurrent-writer stress test for atomic-file-write
- [x] Auto-prune regression test for background-pids registry
- [x] /simplify pass complete; re-tests green
- [ ] Manual smoke: open Claude Code in a fresh moflo project, observe daemon respects `claudeFlow.daemon.autoStart: false`, observe audit worker absent from `daemon-state.json`
- [ ] Manual smoke: rapid-fire gate hooks (Glob + Grep + Read in parallel from Claude) don't produce torn `workflow-state.json`

## Workaround tracking

Story #633 ships a temporary default-disable for the audit worker. The actual perf fix lives in **#631**, which has an explicit `## Workaround removal checklist` enumerating the exact lines to flip back when remediated. Cross-referenced in a comment on #633. Won't get forgotten.

While tracing #631 I also noticed the `security-audit.json` output is **never read** by any command, UI surface, or other worker — the audit findings are a dead letter today even when the worker runs successfully. Documented in a comment on #631 so whoever picks up the perf work also designs a surfacing path.

## Out of scope

- **#636** — Upgrade-UX gap (no warning before SessionStart mutations). Filed as a separate issue per user direction; design pass needed before implementation.
- **#631** — Audit worker root-cause perf investigation + per-worker runtime cap. Tracks the actual remediation; this PR ships the symptom mitigation only.

Closes #629
Closes #632
Closes #633
Closes #634
Closes #635