### PR TITLE
refactor(types): purge stale @moflo/* ambient declarations (#603)

### DIFF
--- a/src/cli/types/optional-modules.d.ts
+++ b/src/cli/types/optional-modules.d.ts
@@ -7,8 +7,6 @@
  * hoisted node_modules are not available.
  */
 
-declare module '@moflo/mcp';
-declare module '@moflo/memory';
 declare module '@noble/ed25519';
 
 declare module 'pg' {


### PR DESCRIPTION
## Summary

Deletes 2 stale ambient module declarations (`@moflo/mcp`, `@moflo/memory`) from `src/cli/types/optional-modules.d.ts`. Both packages were collapsed by epic #586; nothing in `src/` imports either bare specifier.

## Why this PR is a 2-line change instead of #603's original scope

Post-collapse audit overturned the ticket's premise. See [#603 body](https://github.com/eric-cielo/moflo/issues/603) and the explanatory comment for full context, but in short:

- **`moflo-require.ts` stays.** All 16 callers use `mofloImport('sql.js')` to resolve moflo's own non-`@moflo/*` npm deps from moflo's `node_modules` under `npx`-in-consumer — exactly the pattern from `feedback_consumer_path_resolution`. Walk-up helpers in the same file (`findMofloPackageRoot` / `locateMofloModuleDist` / etc.) are the canonical anchor for moflo asset resolution post-#602.
- **`bundledDependencies` already absent.** Verified across all `package.json` files in the repo, both spellings (`bundle*` / `bundled*`). Nothing to remove.
- **`optional-modules.d.ts` only partially stale.** Real optional npm deps (`@noble/ed25519`, `pg`) kept.

## Side artifacts found during audit (filed separately, not in this PR)

- #641 — `src/__tests__/appliance/rvfa-distribution.test.ts` imports from non-existent `../../@moflo/cli/src/...` post-collapse
- #642 — flaky test runner (cold-run reported 4 fails, 2 retries clean; failure ids not surfaced by current runner output)

Same-PR doc cleanup: epic #586 body checklist updated to reflect that #594–#602 are all CLOSED.

## Changes

- `src/cli/types/optional-modules.d.ts`: -2 lines (removed `@moflo/mcp` + `@moflo/memory` ambient declarations).

## Testing

- [x] `tsc -b` — clean, no new TS2307
- [x] Full test suite — 6654 pass, 0 fail (after one cold-run flake — see #642)
- [x] #585 consumer-install smoke — 37/37 pass
- [x] /simplify gate — confirmed no-op (pure deletion of dead declarations, nothing to simplify)

Closes #603
Refs #586