### PR TITLE
chore(settings): disable daemon autoStart, drop audit worker

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -301,10 +301,9 @@
       "enabled": true
     },
     "daemon": {
-      "autoStart": true,
+      "autoStart": false,
       "workers": [
         "map",
-        "audit",
         "optimize",
         "consolidate",
         "testgaps",


### PR DESCRIPTION
## Summary
- Set `daemon.autoStart` to `false` in `.claude/settings.json`
- Remove `audit` from the daemon workers list

## Test plan
- [ ] Reload Claude Code session and confirm daemon does not auto-start
- [ ] Confirm remaining workers (map, optimize, consolidate, testgaps, ...) still register when daemon is started manually

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)