### PR TITLE
fix(memory): stop clobbering vector-stats.json with 0 (#639)

### DIFF
--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -19,16 +19,17 @@ import { HnswLite } from './hnsw-lite.js';
 
 /**
  * Write vector-stats.json cache for the statusline (no subprocess needed).
- * Called after memory store/delete to keep the cache fresh.
+ * Called after memory store in the raw-sql.js fallback path. The bridge path
+ * goes through refreshVectorStatsCache() in bridge-core.ts instead.
  * @param dbPath - path to the SQLite database file
- * @param stats  - optional exact counts from a db query already in progress
+ * @param stats  - exact counts from a db query already in progress (required —
+ *                 making this optional caused issue #639 by silently writing 0)
  */
-function writeVectorStatsCache(dbPath: string, stats?: { vectorCount: number; namespaces: number }): void {
+function writeVectorStatsCache(dbPath: string, stats: { vectorCount: number; namespaces: number }): void {
   try {
     const fileStat = fs.statSync(dbPath);
     const dbSizeKB = Math.floor(fileStat.size / 1024);
-    const vectorCount = stats?.vectorCount ?? 0;
-    const namespaces = stats?.namespaces ?? 0;
+    const { vectorCount, namespaces } = stats;
 
     // Check HNSW index presence
     const dbDir = path.dirname(dbPath);
@@ -1910,17 +1911,14 @@ export async function storeEntry(options: {
   embedding?: { dimensions: number; model: string };
   error?: string;
 }> {
-  // ADR-053: Try AgentDB v3 bridge first
+  // ADR-053: Try AgentDB v3 bridge first. The bridge calls
+  // refreshVectorStatsCache() itself (bridge-entries.ts:191) — a second
+  // write here was redundant and previously clobbered the correct count
+  // with 0 (#639).
   const bridge = await getBridge();
   if (bridge) {
     const bridgeResult = await bridge.bridgeStoreEntry(options);
-    if (bridgeResult) {
-      // Update statusline cache after successful bridge store
-      const swarmDir = path.join(process.cwd(), '.swarm');
-      const dbFile = options.dbPath || path.join(swarmDir, 'memory.db');
-      writeVectorStatsCache(dbFile);
-      return bridgeResult;
-    }
+    if (bridgeResult) return bridgeResult;
   }
 
   // Fallback: raw sql.js


### PR DESCRIPTION
## Summary

Fixes Bug 2 from #639 — the statusline reporting `Vectors ●0` despite the DB having thousands of embedded rows.

## Root cause

`storeEntry`'s AgentDB v3 bridge fast path called `writeVectorStatsCache(dbFile)` *after* `bridge.bridgeStoreEntry` had already updated the cache via `refreshVectorStatsCache()` (`bridge-entries.ts:191`). The redundant local call passed no stats; the local helper had `stats?` optional and defaulted `vectorCount`/`namespaces` to `0`. So every memory store via the bridge overwrote the correct value with `{vectorCount: 0}`.

That matches the user-visible flip:
- right after the indexer / refreshVectorStatsCache wrote: real count
- right after any memory_store: 0

## Fix

1. Delete the redundant call in `storeEntry`'s bridge path.
2. Make `stats` *required* on the local `writeVectorStatsCache`. The silent default-to-0 was the antipattern that allowed this; making it a TS compile error guards re-introduction.

## Diff

```
src/cli/memory/memory-initializer.ts | 24 ++++++++++--------------
1 file changed, 11 insertions(+), 13 deletions(-)
```

## Out of scope (still in #639)

- **Bug 1** — invisible upgrade UX (launcher's stderr is `stdio: 'ignore'`d by SessionStart). That needs broader work tracked in #636.
- **Daemon spam** — `[neural-tools] @moflo/embeddings not resolvable …` is a separate code path that survived the collapse with a stale `moflo-require` call.

Both will be tracked under #639 separately or rolled into related issues.

## Validation

- `npm run build` clean
- `npx tsc --noEmit` clean
- Full vitest suite: 6654 passed, 0 failed
- Live evidence on this machine before fix: `.claude-flow/vector-stats.json` says `vectorCount: 0`, DB query says **4,257** active embedded rows
- After this fix lands and is reinstalled, the next memory_store will let `refreshVectorStatsCache` write the real count and won't be clobbered

## Test plan

- [x] Build passes
- [x] Type-check passes
- [x] Full test suite passes (6654/6654)
- [ ] After publish + reinstall locally, statusline reflects actual DB count and stays correct across memory_store operations

Closes part of #639