### PR TITLE
fix(launcher): recycle stale daemon on moflo version change (#639)

### DIFF
--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -222,6 +222,42 @@ try {
         }
       }
 
+      // Recycle the running daemon — its in-process module cache holds the
+      // previous moflo image. After an upgrade that cache is stale, which
+      // shows up as warnings from removed code paths (e.g. the
+      // `[neural-tools] @moflo/embeddings not resolvable` spam from #639,
+      // emitted by pre-#592 collapse code that no longer exists in source)
+      // and means freshly-disabled workers keep running.
+      //
+      // Recycle = stop old + start new. We kill the lock-recorded PID,
+      // remove the lock, then fire a fresh daemon so the user keeps the
+      // functionality they had. `daemon.autoStart` only governs the
+      // cold-start case (no daemon existed); here a daemon was actually
+      // running, so replacing it with a current-code copy is the desired
+      // behaviour regardless of that flag.
+      try {
+        const lockFile = resolve(projectRoot, '.claude-flow', 'daemon.lock');
+        if (existsSync(lockFile)) {
+          let stalePid = null;
+          try {
+            const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
+            if (typeof lock?.pid === 'number' && lock.pid > 0) stalePid = lock.pid;
+          } catch { /* malformed lock — fall through to unlink */ }
+          if (stalePid !== null) {
+            try { process.kill(stalePid, 'SIGTERM'); } catch { /* already dead */ }
+          }
+          try { unlinkSync(lockFile); } catch { /* non-fatal */ }
+          // Respawn only if a live daemon was actually recorded — no point
+          // starting one when there wasn't one before.
+          if (stalePid !== null) {
+            const localCliPath = resolve(binDir, 'cli.js');
+            if (existsSync(localCliPath)) {
+              fireAndForget('node', [localCliPath, 'daemon', 'start', '--quiet'], 'daemon-recycle');
+            }
+          }
+        }
+      } catch { /* non-fatal — daemon recycle is best-effort */ }
+
       // Write updated manifest + version stamp
       try {
         const cfDir = resolve(projectRoot, '.claude-flow');

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -222,6 +222,42 @@ try {
         }
       }
 
+      // Recycle the running daemon — its in-process module cache holds the
+      // previous moflo image. After an upgrade that cache is stale, which
+      // shows up as warnings from removed code paths (e.g. the
+      // `[neural-tools] @moflo/embeddings not resolvable` spam from #639,
+      // emitted by pre-#592 collapse code that no longer exists in source)
+      // and means freshly-disabled workers keep running.
+      //
+      // Recycle = stop old + start new. We kill the lock-recorded PID,
+      // remove the lock, then fire a fresh daemon so the user keeps the
+      // functionality they had. `daemon.autoStart` only governs the
+      // cold-start case (no daemon existed); here a daemon was actually
+      // running, so replacing it with a current-code copy is the desired
+      // behaviour regardless of that flag.
+      try {
+        const lockFile = resolve(projectRoot, '.claude-flow', 'daemon.lock');
+        if (existsSync(lockFile)) {
+          let stalePid = null;
+          try {
+            const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
+            if (typeof lock?.pid === 'number' && lock.pid > 0) stalePid = lock.pid;
+          } catch { /* malformed lock — fall through to unlink */ }
+          if (stalePid !== null) {
+            try { process.kill(stalePid, 'SIGTERM'); } catch { /* already dead */ }
+          }
+          try { unlinkSync(lockFile); } catch { /* non-fatal */ }
+          // Respawn only if a live daemon was actually recorded — no point
+          // starting one when there wasn't one before.
+          if (stalePid !== null) {
+            const localCliPath = resolve(binDir, 'cli.js');
+            if (existsSync(localCliPath)) {
+              fireAndForget('node', [localCliPath, 'daemon', 'start', '--quiet'], 'daemon-recycle');
+            }
+          }
+        }
+      } catch { /* non-fatal — daemon recycle is best-effort */ }
+
       // Write updated manifest + version stamp
       try {
         const cfDir = resolve(projectRoot, '.claude-flow');


### PR DESCRIPTION
## Summary

Fixes the **daemon spam** observation in #639 — the `[neural-tools] @moflo/embeddings not resolvable` lines that keep appearing in `daemon.log` despite the offending code being gone from source.

Same root cause kept PR #644's `audit` worker disable from taking effect: the daemon was loaded with the old worker config and never recycled.

## Root cause

A long-running daemon holds an in-process snapshot of `node_modules/moflo` code. After a moflo upgrade that snapshot is stale — removed code paths keep firing, freshly-disabled workers keep running, and changes to `.claude/settings.json` only land for workers that get scheduled fresh.

## Fix

Extend the launcher's existing version-change block (`bin/session-start-launcher.mjs`, mirrored to `.claude/scripts/session-start-launcher.mjs`) to:

1. Read the PID from `.claude-flow/daemon.lock`
2. SIGTERM it
3. Remove the lock
4. **Fire a fresh daemon** via the existing `fireAndForget` helper — only if a live daemon was actually recorded

Recycle = stop old + start new. `daemon.autoStart` governs the cold-start case (no daemon existed); the recycle path is a different scenario and respawns regardless so the user keeps the functionality they had, just with current code.

## Why both files

`bin/session-start-launcher.mjs` is the canonical copy that ships in the tarball. `.claude/scripts/session-start-launcher.mjs` is the dogfood mirror that the moflo project itself runs at session start. Both are git-tracked; both need the change to keep behaviour aligned (`feedback_scriptfiles_sync.md`).

## Out of scope

#639 also flags **Bug 1** (invisible upgrade UX — the launcher writes the embeddings-migration progress to a stderr that isn't surfaced to the user). That depends on Claude Code's SessionStart hook stdio handling and is broader UX work tracked under #636. Not addressed here.

## Validation

- `node --check` clean on both launcher copies
- `npm run build` clean
- `npx tsc --noEmit` clean
- Full vitest suite: 6654 passed, 0 failed
- Live evidence on this machine: stale daemon (PID 15876, started 9h ago) was emitting the `@moflo/embeddings not resolvable` spam every cycle. After SIGTERM + lock removal, the spam stopped immediately.

## Test plan

- [x] Build + type-check
- [x] Full test suite
- [ ] After publish + reinstall, confirm next session-start kills any stale daemon and respawns it cleanly with the new code

Closes part of #639