### PR TITLE
Epic #648: embeddings mixed-model cleanup (3 stories)

### DIFF
--- a/src/cli/__tests__/bridge-entries.test.ts
+++ b/src/cli/__tests__/bridge-entries.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for bridge-entries `bridgeStoreEntry` — covers the #649 fix:
+ *  - reads the actual model name from the bridge embedder (no hardcoded
+ *    'Xenova/all-MiniLM-L6-v2')
+ *  - returns success: false on embed failure (no silent null insertion)
+ *  - intentional opt-out (generateEmbeddingFlag=false) tags the row 'none',
+ *    not the schema default 'local', so the audit trail distinguishes
+ *    intentional skips from failures.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import {
+  setBridgeEmbedderForTest,
+  _resetBridgeEmbedderCacheForTest,
+  type BridgeEmbedder,
+} from '../memory/bridge-embedder.js';
+import { bridgeStoreEntry } from '../memory/bridge-entries.js';
+import { _resetProjectRootForTest, execRows, getDb } from '../memory/bridge-core.js';
+import { shutdownBridge, getControllerRegistry } from '../memory/memory-bridge.js';
+
+let tmpDir: string;
+let dbPath: string;
+let originalCwd: string;
+
+// Local stub instead of MockEmbeddingService (src/cli/embeddings/__tests__/mocks/)
+// because we exercise the BridgeEmbedder contract — narrower than IEmbeddingService
+// and supports failure injection directly.
+class StubEmbedder implements BridgeEmbedder {
+  readonly model: string;
+  readonly dimensions: number;
+  private vector: Float32Array | null;
+  private failure: Error | null;
+
+  constructor(opts: {
+    model?: string;
+    dimensions?: number;
+    vector?: Float32Array | null;
+    failure?: Error | null;
+  } = {}) {
+    this.model = opts.model ?? 'stub-embedder-v1';
+    this.dimensions = opts.dimensions ?? 384;
+    this.vector = opts.vector ?? new Float32Array(this.dimensions).fill(0.1);
+    this.failure = opts.failure ?? null;
+  }
+
+  async embed(_text: string): Promise<Float32Array> {
+    if (this.failure) throw this.failure;
+    if (!this.vector) throw new Error('stub: no vector and no failure configured');
+    return this.vector;
+  }
+}
+
+beforeEach(async () => {
+  originalCwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-bridge-entries-'));
+  fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
+  // Bridge resolves project root from cwd for ancillary paths
+  // (.claude-flow/vector-stats.json). Isolate so tests don't clobber the
+  // host project's stats cache.
+  process.chdir(tmpDir);
+  // Bridge caches project root at module level — reset so it picks up tmpDir.
+  _resetProjectRootForTest();
+  dbPath = path.join(tmpDir, '.swarm', 'memory.db');
+  // Make sure no leftover bridge singleton points at a stale dbPath
+  await shutdownBridge();
+});
+
+afterEach(async () => {
+  setBridgeEmbedderForTest(null);
+  _resetBridgeEmbedderCacheForTest();
+  await shutdownBridge();
+  vi.restoreAllMocks();
+  process.chdir(originalCwd);
+  _resetProjectRootForTest();
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+async function readRows(sql: string, params?: unknown[]): Promise<Record<string, unknown>[]> {
+  const reg = await getControllerRegistry(dbPath);
+  if (!reg) throw new Error('test bridge registry unavailable');
+  const ctx = getDb(reg);
+  if (!ctx) throw new Error('test bridge db ctx unavailable');
+  return execRows(ctx.db, sql, params);
+}
+
+describe('bridgeStoreEntry — embed failure surfacing (#649)', () => {
+  it('returns success:false with error message when the embedder throws', async () => {
+    setBridgeEmbedderForTest(
+      new StubEmbedder({ failure: new Error('synthetic embed failure') }),
+    );
+
+    const result = await bridgeStoreEntry({
+      key: 'k1',
+      value: 'some content',
+      namespace: 'test',
+      dbPath,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.success).toBe(false);
+    expect(result?.error).toContain('embedding generation failed');
+    expect(result?.error).toContain('synthetic embed failure');
+    const rows = await readRows('SELECT id FROM memory_entries WHERE key = ?', ['k1']);
+    expect(rows).toHaveLength(0);
+  });
+
+});
+
+describe('bridgeStoreEntry — model name passthrough (#649)', () => {
+  it("tags inserted rows with the embedder's reported model, not 'Xenova/all-MiniLM-L6-v2'", async () => {
+    setBridgeEmbedderForTest(
+      new StubEmbedder({ model: 'custom-test-model-v2', dimensions: 384 }),
+    );
+
+    const result = await bridgeStoreEntry({
+      key: 'k-model',
+      value: 'content',
+      namespace: 'test',
+      dbPath,
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.embedding?.model).toBe('custom-test-model-v2');
+
+    const rows = await readRows(
+      'SELECT embedding_model FROM memory_entries WHERE key = ?',
+      ['k-model'],
+    );
+    expect(rows[0]?.embedding_model).toBe('custom-test-model-v2');
+    expect(rows[0]?.embedding_model).not.toBe('Xenova/all-MiniLM-L6-v2');
+  });
+});
+
+describe('bridgeStoreEntry — opt-out path (#649)', () => {
+  it("tags rows with 'none' when caller passes generateEmbeddingFlag=false", async () => {
+    setBridgeEmbedderForTest(new StubEmbedder()); // present but won't be called
+
+    const result = await bridgeStoreEntry({
+      key: 'k-opt-out',
+      value: 'content',
+      namespace: 'test',
+      generateEmbeddingFlag: false,
+      dbPath,
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.embedding).toBeUndefined();
+
+    const rows = await readRows(
+      'SELECT embedding, embedding_model FROM memory_entries WHERE key = ?',
+      ['k-opt-out'],
+    );
+    expect(rows[0]?.embedding).toBeNull();
+    expect(rows[0]?.embedding_model).toBe('none');
+    expect(rows[0]?.embedding_model).not.toBe('local');
+  });
+});
+
+describe('refreshVectorStatsCache — missing counter (#649)', () => {
+  it('writes a `missing` field for active rows with NULL embedding', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'fast-all-MiniLM-L6-v2' }));
+
+    // Insert one healthy row (with embedding) and two opt-out rows (without)
+    await bridgeStoreEntry({ key: 'healthy', value: 'h', namespace: 'test', dbPath });
+    await bridgeStoreEntry({
+      key: 'skipped-1', value: 's1', namespace: 'test',
+      generateEmbeddingFlag: false, dbPath,
+    });
+    await bridgeStoreEntry({
+      key: 'skipped-2', value: 's2', namespace: 'test',
+      generateEmbeddingFlag: false, dbPath,
+    });
+
+    // Fire the cache refresh explicitly so we don't race the bridge's own
+    // post-store call.
+    const { refreshVectorStatsCache } = await import('../memory/bridge-core.js');
+    refreshVectorStatsCache(dbPath);
+
+    const statsPath = path.join(tmpDir, '.claude-flow', 'vector-stats.json');
+    expect(fs.existsSync(statsPath)).toBe(true);
+    const stats = JSON.parse(fs.readFileSync(statsPath, 'utf-8'));
+    expect(stats.vectorCount).toBe(1);
+    expect(stats.missing).toBe(2);
+  });
+});

--- a/src/cli/__tests__/commands/doctor-embedding-hygiene.test.ts
+++ b/src/cli/__tests__/commands/doctor-embedding-hygiene.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the #651 doctor embedding-hygiene check. The check is the
+ * automatic regression catcher for the three #648 failure modes:
+ *  - banned `domain-aware-hash%` rows
+ *  - silent-failure marker (`local` + null embedding)
+ *  - mixed neural models in the active set
+ *
+ * Each test seeds a fresh memory.db with one specific failure mode and
+ * asserts the check both flags it and lets a clean DB pass.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { checkEmbeddingHygiene } from '../../commands/doctor-embedding-hygiene.js';
+import { CANONICAL_EMBEDDING_MODEL } from '../../embeddings/migration/types.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+
+type SqlJsDb = {
+  run(sql: string, params?: unknown[]): void;
+  export(): Uint8Array;
+  close(): void;
+};
+type SqlJsStatic = { Database: new (data?: Uint8Array) => SqlJsDb };
+
+let SQL: SqlJsStatic;
+let originalCwd: string;
+let tmpDir: string;
+
+beforeAll(async () => {
+  const initSqlJs = (await import('sql.js')).default;
+  SQL = (await initSqlJs()) as SqlJsStatic;
+});
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = mkdtempSync(join(tmpdir(), 'moflo-hygiene-'));
+  // checkEmbeddingHygiene resolves memory.db relative to cwd — isolate.
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+function seedDb(setup: (db: SqlJsDb) => void): void {
+  const db = new SQL.Database();
+  db.run(MEMORY_SCHEMA_V3);
+  setup(db);
+  const bytes = db.export();
+  db.close();
+  const swarmDir = join(tmpDir, '.swarm');
+  mkdirSync(swarmDir, { recursive: true });
+  writeFileSync(join(swarmDir, 'memory.db'), Buffer.from(bytes));
+}
+
+function insert(
+  db: SqlJsDb,
+  id: string,
+  model: string | null,
+  hasEmbedding: boolean,
+): void {
+  const embedding = hasEmbedding ? JSON.stringify([0.1, 0.2]) : null;
+  if (model === null) {
+    db.run(
+      `INSERT INTO memory_entries (id, key, content, embedding) VALUES (?, ?, ?, ?)`,
+      [id, `k-${id}`, `content-${id}`, embedding],
+    );
+  } else {
+    db.run(
+      `INSERT INTO memory_entries (id, key, content, embedding, embedding_model)
+       VALUES (?, ?, ?, ?, ?)`,
+      [id, `k-${id}`, `content-${id}`, embedding, model],
+    );
+  }
+}
+
+describe('checkEmbeddingHygiene (#651)', () => {
+  it('passes when no memory database exists', async () => {
+    const result = await checkEmbeddingHygiene();
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('No memory database');
+  });
+
+  it('passes on a clean DB with all rows on the canonical model', async () => {
+    seedDb((db) => {
+      insert(db, 'a', CANONICAL_EMBEDDING_MODEL, true);
+      insert(db, 'b', CANONICAL_EMBEDDING_MODEL, true);
+    });
+
+    const result = await checkEmbeddingHygiene();
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain(CANONICAL_EMBEDDING_MODEL);
+    expect(result.message).toContain('no residue');
+  });
+
+  it("warns on banned 'domain-aware-hash%' rows", async () => {
+    seedDb((db) => {
+      insert(db, 'a', CANONICAL_EMBEDDING_MODEL, true);
+      insert(db, 'b', 'domain-aware-hash-v1', true);
+      insert(db, 'c', 'domain-aware-hash-384', true);
+    });
+
+    const result = await checkEmbeddingHygiene();
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('banned hash model');
+    expect(result.message).toContain('domain-aware-hash-v1=1');
+    expect(result.message).toContain('domain-aware-hash-384=1');
+    expect(result.fix).toContain('embeddings init');
+  });
+
+  it("warns on the silent-failure marker (model='local' + embedding NULL)", async () => {
+    seedDb((db) => {
+      insert(db, 'a', CANONICAL_EMBEDDING_MODEL, true);
+      insert(db, 'b', 'local', false);
+      insert(db, 'c', 'local', false);
+    });
+
+    const result = await checkEmbeddingHygiene();
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain("embedding_model='local'");
+    expect(result.message).toContain('AND embedding IS NULL');
+  });
+
+  it('warns when more than one neural model is present in the active set', async () => {
+    seedDb((db) => {
+      insert(db, 'a', CANONICAL_EMBEDDING_MODEL, true);
+      insert(db, 'b', 'Xenova/all-MiniLM-L6-v2', true);
+      insert(db, 'c', 'fastembed/all-MiniLM-L6-v2', true);
+    });
+
+    const result = await checkEmbeddingHygiene();
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('mixed neural models');
+    expect(result.message).toContain('Xenova/all-MiniLM-L6-v2');
+    expect(result.message).toContain('fastembed/all-MiniLM-L6-v2');
+  });
+
+  it('warns on multiple issues simultaneously without crashing', async () => {
+    seedDb((db) => {
+      insert(db, 'a', CANONICAL_EMBEDDING_MODEL, true);
+      insert(db, 'b', 'Xenova/all-MiniLM-L6-v2', true);
+      insert(db, 'c', 'domain-aware-hash-v1', true);
+      insert(db, 'd', 'local', false);
+    });
+
+    const result = await checkEmbeddingHygiene();
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('banned hash model');
+    expect(result.message).toContain("embedding_model='local'");
+    expect(result.message).toContain('mixed neural models');
+  });
+
+  it('passes (does not warn) when only sentinels are present alongside the canonical model', async () => {
+    // 'none' (Story-1 opt-out tag) and 'local'-with-vector are sentinels
+    // that should NOT trigger the silent-failure check (the marker is
+    // specifically local+null, not local-with-content).
+    seedDb((db) => {
+      insert(db, 'a', CANONICAL_EMBEDDING_MODEL, true);
+      insert(db, 'b', 'none', false);
+      insert(db, 'c', 'local', true);
+    });
+
+    const result = await checkEmbeddingHygiene();
+    expect(result.status).toBe('pass');
+  });
+
+  it('ignores soft-deleted rows (status != active)', async () => {
+    seedDb((db) => {
+      insert(db, 'a', CANONICAL_EMBEDDING_MODEL, true);
+      // Banned row, but soft-deleted — should not trigger warning.
+      db.run(
+        `INSERT INTO memory_entries (id, key, content, embedding, embedding_model, status)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        ['banned-deleted', 'k-banned', 'c', JSON.stringify([0.1]), 'domain-aware-hash-v1', 'deleted'],
+      );
+    });
+
+    const result = await checkEmbeddingHygiene();
+    expect(result.status).toBe('pass');
+  });
+});

--- a/src/cli/__tests__/services/embeddings-migration.test.ts
+++ b/src/cli/__tests__/services/embeddings-migration.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { runEmbeddingsMigrationIfNeeded } from '../../services/embeddings-migration.js';
+import { CANONICAL_EMBEDDING_MODEL } from '../../embeddings/migration/types.js';
 
 type SqlJsDb = {
   run(sql: string, params?: unknown[]): void;
@@ -98,5 +99,78 @@ describe('runEmbeddingsMigrationIfNeeded', () => {
     `);
     const ran = await runEmbeddingsMigrationIfNeeded({ dbPath });
     expect(ran).toBe(false);
+  });
+});
+
+// ── Story 2 / #650: eligibility-aware short-circuit ──────────────────────────
+// These tests exercise the orchestrator's "should we run?" logic without
+// touching fastembed — when there are no eligible rows the orchestrator
+// short-circuits before constructing an embedder. The end-to-end repair
+// behavior is covered at the store layer in sqljs-migration-store-v3.test.ts.
+
+describe('runEmbeddingsMigrationIfNeeded — eligibility short-circuit (#650)', () => {
+  /** Apply MEMORY_SCHEMA_V3 to a fresh in-memory DB, then export to disk. */
+  async function makeV3Db(setup?: (db: SqlJsDb & { exec(sql: string): unknown }) => void): Promise<string> {
+    const { MEMORY_SCHEMA_V3 } = await import('../../memory/memory-initializer.js');
+    const dir = await mkdtemp(join(tmpdir(), 'moflo-migration-elig-'));
+    tmpDirs.push(dir);
+    const dbPath = join(dir, 'memory.db');
+    const db = new SQL.Database() as SqlJsDb & { exec(sql: string): unknown };
+    db.run(MEMORY_SCHEMA_V3);
+    if (setup) setup(db);
+    const bytes = db.export();
+    db.close();
+    await writeFile(dbPath, Buffer.from(bytes));
+    return dbPath;
+  }
+
+  async function readVersion(dbPath: string): Promise<number | null> {
+    const { readFile } = await import('node:fs/promises');
+    const bytes = await readFile(dbPath);
+    const db = new SQL.Database(bytes) as SqlJsDb & {
+      exec(sql: string): Array<{ columns: string[]; values: unknown[][] }>;
+    };
+    try {
+      const res = db.exec(`SELECT value FROM metadata WHERE key='embeddings_version'`);
+      const row = res[0]?.values[0];
+      return row ? Number(row[0]) : null;
+    } finally {
+      db.close();
+    }
+  }
+
+  // Use the canonical constant so a rename ripples through automatically.
+  const TARGET_MODEL = CANONICAL_EMBEDDING_MODEL;
+
+  /** No-op WritableStream for test runs so the renderer doesn't dirty output. */
+  const silentOut = {
+    write: () => true,
+    isTTY: false,
+  } as unknown as NodeJS.WritableStream & { isTTY?: boolean };
+
+  it('runs the driver on a fresh DB and bumps version to v2 with zero items', async () => {
+    const dbPath = await makeV3Db();
+    const ran = await runEmbeddingsMigrationIfNeeded({ dbPath, out: silentOut });
+    // Fresh DB had no version stamp → short-circuit doesn't fire → driver
+    // runs, sees 0 items, bumps version, exits success. The orchestrator
+    // returns true because the driver completed.
+    expect(ran).toBe(true);
+    expect(await readVersion(dbPath)).toBe(2);
+  });
+
+  it('skips a v2-stamped DB whose rows are all on the target model', async () => {
+    const dbPath = await makeV3Db((db) => {
+      db.run(
+        `INSERT INTO memory_entries (id, key, content, embedding, embedding_dimensions, embedding_model)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        ['a', 'k-a', 'content-a', JSON.stringify([0.1, 0.2]), 2, TARGET_MODEL],
+      );
+      db.run(
+        `INSERT INTO metadata (key, value) VALUES ('embeddings_version', '2')`,
+      );
+    });
+    const ran = await runEmbeddingsMigrationIfNeeded({ dbPath });
+    expect(ran).toBe(false); // clean DB — short-circuit before driver loads
+    expect(await readVersion(dbPath)).toBe(2);
   });
 });

--- a/src/cli/__tests__/services/sqljs-migration-store-v3.test.ts
+++ b/src/cli/__tests__/services/sqljs-migration-store-v3.test.ts
@@ -16,6 +16,7 @@ import {
   EMBEDDINGS_VERSION,
   migrateStore,
 } from '../../embeddings/migration/index.js';
+import { CANONICAL_EMBEDDING_MODEL } from '../../embeddings/migration/types.js';
 import { MockBatchEmbedder } from '../../embeddings/__tests__/migration/mock-batch-embedder.js';
 import { SqlJsMemoryEntriesStore } from '../../services/sqljs-migration-store.js';
 import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
@@ -182,6 +183,168 @@ describe('SqlJsMemoryEntriesStore against MEMORY_SCHEMA_V3', () => {
     // Upserts, never duplicates.
     await store.setVersion(9);
     expect(await store.getVersion()).toBe(9);
+    db.close();
+  });
+});
+
+describe('SqlJsMemoryEntriesStore — eligibility-aware repair (#650)', () => {
+  // Use the canonical constant so a rename in embeddings/migration/types.ts
+  // ripples through every test reference automatically. The store's contract
+  // is "tag rows with whatever the orchestrator passes" — testing identity is
+  // fine here; testing the producer-consumer chain happens in the e2e test
+  // below where MockBatchEmbedder rewrites everything.
+  const TARGET_MODEL = CANONICAL_EMBEDDING_MODEL;
+
+  function insertWithModel(
+    db: SqlJsDb,
+    id: string,
+    content: string,
+    model: string | null,
+  ): void {
+    if (model === null) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, content) VALUES (?, ?, ?)`,
+        [id, `k-${id}`, content],
+      );
+    } else {
+      db.run(
+        `INSERT INTO memory_entries (id, key, content, embedding_model)
+         VALUES (?, ?, ?, ?)`,
+        [id, `k-${id}`, content, model],
+      );
+    }
+  }
+
+  function selectModelRow(
+    db: SqlJsDb,
+    id: string,
+  ): { model: string | null; dims: number | null } {
+    const res = db.exec(
+      `SELECT embedding_model, embedding_dimensions FROM memory_entries WHERE id = '${id.replace(/'/g, "''")}'`,
+    );
+    const row = res[0]?.values[0];
+    if (!row) return { model: null, dims: null };
+    return {
+      model: row[0] === null ? null : String(row[0]),
+      dims: row[1] === null ? null : Number(row[1]),
+    };
+  }
+
+  it('countItems excludes rows already on the target model', async () => {
+    const db = freshV3Db();
+    insertWithModel(db, 'on-target-1', 'a', TARGET_MODEL);
+    insertWithModel(db, 'on-target-2', 'b', TARGET_MODEL);
+    insertWithModel(db, 'xenova', 'c', 'Xenova/all-MiniLM-L6-v2');
+    insertWithModel(db, 'hash', 'd', 'domain-aware-hash-v1');
+    insertWithModel(db, 'null-model', 'e', null); // schema default 'local'
+
+    const repair = new SqlJsMemoryEntriesStore(db, 'memory.db', {
+      targetModel: TARGET_MODEL,
+    });
+    // 3 ineligible: xenova + hash + null-model. The two on-target rows are
+    // filtered out — short-circuit candidates for the orchestrator.
+    expect(await repair.countItems()).toBe(3);
+
+    // Without targetModel the legacy "every content row" semantics still apply.
+    const legacy = new SqlJsMemoryEntriesStore(db, 'memory.db');
+    expect(await legacy.countItems()).toBe(5);
+    db.close();
+  });
+
+  it('hasIneligibleRows is the bounded probe used by the session-start short-circuit', async () => {
+    const db = freshV3Db();
+    insertWithModel(db, 'on', 'a', TARGET_MODEL);
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db', { targetModel: TARGET_MODEL });
+
+    expect(await store.hasIneligibleRows()).toBe(false);
+
+    // Add one row tagged with a banned legacy model — probe trips immediately.
+    insertWithModel(db, 'off', 'b', 'domain-aware-hash-v1');
+    expect(await store.hasIneligibleRows()).toBe(true);
+
+    // Stores constructed without targetModel never report ineligible rows —
+    // the contract is that legacy callers don't get the new repair behavior.
+    const legacy = new SqlJsMemoryEntriesStore(db, 'memory.db');
+    expect(await legacy.hasIneligibleRows()).toBe(false);
+    db.close();
+  });
+
+  it('iterItems yields only ineligible rows when targetModel is set', async () => {
+    const db = freshV3Db();
+    insertWithModel(db, 'a-on', 'a', TARGET_MODEL);
+    insertWithModel(db, 'b-off', 'b', 'Xenova/all-MiniLM-L6-v2');
+    insertWithModel(db, 'c-on', 'c', TARGET_MODEL);
+    insertWithModel(db, 'd-off', 'd', null);
+
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db', {
+      targetModel: TARGET_MODEL,
+    });
+    const rows = await store.iterItems(null, 100);
+    expect(rows.map((r) => r.id)).toEqual(['b-off', 'd-off']);
+
+    // Cursor pagination still works against the filtered set.
+    const tail = await store.iterItems('b-off', 100);
+    expect(tail.map((r) => r.id)).toEqual(['d-off']);
+    db.close();
+  });
+
+  it('updateBatch re-tags embedding_model when targetModel is set', async () => {
+    const db = freshV3Db();
+    insertWithModel(db, 'x', 'content', 'Xenova/all-MiniLM-L6-v2');
+
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db', {
+      targetModel: TARGET_MODEL,
+    });
+    await store.updateBatch([{ id: 'x', embedding: new Float32Array(8).fill(0.5) }]);
+
+    const { model, dims } = selectModelRow(db, 'x');
+    expect(model).toBe(TARGET_MODEL);
+    expect(dims).toBe(8);
+    db.close();
+  });
+
+  it('updateBatch leaves embedding_model untouched when targetModel is unset (legacy)', async () => {
+    const db = freshV3Db();
+    insertWithModel(db, 'x', 'content', 'Xenova/all-MiniLM-L6-v2');
+
+    const legacy = new SqlJsMemoryEntriesStore(db, 'memory.db');
+    await legacy.updateBatch([{ id: 'x', embedding: new Float32Array(8).fill(0.5) }]);
+
+    // Backward-compat: legacy store does not re-tag — model column is preserved.
+    const { model, dims } = selectModelRow(db, 'x');
+    expect(model).toBe('Xenova/all-MiniLM-L6-v2');
+    expect(dims).toBe(8);
+    db.close();
+  });
+
+  it('end-to-end repair: mixed-model DB converges to all rows on target', async () => {
+    const db = freshV3Db();
+    insertWithModel(db, 'on', 'on-target', TARGET_MODEL);
+    insertWithModel(db, 'xenova', 'xen', 'Xenova/all-MiniLM-L6-v2');
+    insertWithModel(db, 'hash', 'h', 'domain-aware-hash-v1');
+    insertWithModel(db, 'null-model', 'n', null);
+
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db', {
+      targetModel: TARGET_MODEL,
+    });
+    const embedder = new MockBatchEmbedder(8);
+
+    const result = await migrateStore({ store, embedder, batchSize: 2 });
+    expect(result.success).toBe(true);
+    expect(result.itemsMigrated).toBe(3); // only the three ineligibles
+
+    // Post-condition: every row is on the target model.
+    const res = db.exec(
+      `SELECT embedding_model, COUNT(*) AS n FROM memory_entries GROUP BY embedding_model`,
+    );
+    const grouped = (res[0]?.values ?? []).map((r) => ({
+      model: String(r[0]),
+      count: Number(r[1]),
+    }));
+    expect(grouped).toEqual([{ model: TARGET_MODEL, count: 4 }]);
+
+    // Eligibility filter has zero work left — the next call short-circuits.
+    expect(await store.countItems()).toBe(0);
     db.close();
   });
 });

--- a/src/cli/commands/doctor-embedding-hygiene.ts
+++ b/src/cli/commands/doctor-embedding-hygiene.ts
@@ -1,0 +1,230 @@
+/**
+ * Embedding hygiene doctor check (#651) — catches the three regressions
+ * documented in #648:
+ *
+ *   1. Banned hash-tagged rows (`embedding_model LIKE 'domain-aware-hash%'`).
+ *      ADR-EMB-001 retires the hash fallback; surviving rows are residue
+ *      from a pre-ban moflo install.
+ *   2. Silent-failure marker (`embedding_model = 'local' AND embedding IS
+ *      NULL`). Pre-#649 this was the schema default for null-embedded rows
+ *      that should never have been inserted; #651 doctor surfaces them so
+ *      they don't accumulate again.
+ *   3. Mixed-model active set — more than one neural model present at the
+ *      same time. Cosine similarity is meaningful within an embedding
+ *      space, not across them, so search precision degrades when the table
+ *      mixes (e.g.) `Xenova/all-MiniLM-L6-v2` and `fast-all-MiniLM-L6-v2`
+ *      vectors. The Story-2 self-healing migration converges every active
+ *      row on the canonical label; this check verifies it actually did.
+ *
+ * Lives next to the doctor command rather than in `doctor.ts` to keep that
+ * file under the 500-line decomposition target.
+ *
+ * @module cli/commands/doctor-embedding-hygiene
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+import { CANONICAL_EMBEDDING_MODEL } from '../embeddings/migration/types.js';
+import { mofloImport } from '../services/moflo-require.js';
+
+export interface HealthCheck {
+  name: string;
+  status: 'pass' | 'warn' | 'fail';
+  message: string;
+  fix?: string;
+}
+
+/**
+ * Known neural-model labels that all share the all-MiniLM-L6-v2 384-dim
+ * vector space. The Story-2 migration retags any of these to the
+ * canonical label; presence of more than one indicates incomplete
+ * convergence.
+ */
+const KNOWN_NEURAL_LABELS: ReadonlySet<string> = new Set([
+  CANONICAL_EMBEDDING_MODEL,
+  'fastembed/all-MiniLM-L6-v2',
+  'Xenova/all-MiniLM-L6-v2',
+]);
+
+/** Non-neural sentinels that don't count toward the mixed-model check. */
+const SENTINEL_LABELS: ReadonlySet<string> = new Set(['none', 'local']);
+
+interface ModelGroup {
+  model: string;
+  count: number;
+  hasNullEmbedding: boolean;
+}
+
+/**
+ * Scan the bridge memory.db for the three #648 regression markers. Pass when
+ * either no DB exists yet, or every active row is on the canonical model
+ * with no banned/null-failure residue.
+ */
+export async function checkEmbeddingHygiene(): Promise<HealthCheck> {
+  const dbPath = resolveMemoryDb();
+  if (dbPath === null) {
+    // Nothing to scan — checkEmbeddings already reports the missing DB.
+    return {
+      name: 'Embedding hygiene',
+      status: 'pass',
+      message: 'No memory database — nothing to check',
+    };
+  }
+
+  const groups = await loadModelGroups(dbPath);
+  if (groups === null) {
+    return {
+      name: 'Embedding hygiene',
+      status: 'pass',
+      message: 'Cannot inspect memory DB (sql.js not available)',
+    };
+  }
+  if (groups.length === 0) {
+    return {
+      name: 'Embedding hygiene',
+      status: 'pass',
+      message: 'No active rows — nothing to check',
+    };
+  }
+
+  const issues: string[] = [];
+
+  // (1) Banned hash-tagged rows.
+  const banned = groups.filter((g) => g.model.startsWith('domain-aware-hash'));
+  const bannedTotal = banned.reduce((sum, g) => sum + g.count, 0);
+  if (bannedTotal > 0) {
+    const detail = banned
+      .map((g) => `${g.model}=${g.count}`)
+      .join(', ');
+    issues.push(`${bannedTotal} row(s) tagged with banned hash model (${detail})`);
+  }
+
+  // (2) Silent-failure marker — local + NULL embedding.
+  const localNull = groups.find((g) => g.model === 'local' && g.hasNullEmbedding);
+  if (localNull && localNull.count > 0) {
+    issues.push(
+      `${localNull.count} row(s) with embedding_model='local' AND embedding IS NULL ` +
+        '(silent producer failure marker — see #649)',
+    );
+  }
+
+  // (3) Mixed neural models.
+  const neuralPresent = groups
+    .filter((g) => KNOWN_NEURAL_LABELS.has(g.model))
+    .map((g) => g.model);
+  if (neuralPresent.length > 1) {
+    const detail = groups
+      .filter((g) => KNOWN_NEURAL_LABELS.has(g.model))
+      .map((g) => `${g.model}=${g.count}`)
+      .join(', ');
+    issues.push(`mixed neural models present (${detail}) — cosine search precision degrades`);
+  }
+
+  // (4) Unknown labels (not target, not legacy-neural, not sentinel) —
+  // surface but don't elevate to warn unless the count is non-trivial. New
+  // legitimate models will land here too; this is defense in depth, not a
+  // strict invariant.
+  const unknown = groups.filter(
+    (g) => !KNOWN_NEURAL_LABELS.has(g.model) &&
+      !SENTINEL_LABELS.has(g.model) &&
+      !g.model.startsWith('domain-aware-hash'),
+  );
+  if (unknown.length > 0) {
+    const total = unknown.reduce((sum, g) => sum + g.count, 0);
+    const detail = unknown.map((g) => `${g.model}=${g.count}`).join(', ');
+    issues.push(`${total} row(s) with unrecognised embedding_model (${detail})`);
+  }
+
+  if (issues.length === 0) {
+    const onTarget = groups.find((g) => g.model === CANONICAL_EMBEDDING_MODEL)?.count ?? 0;
+    return {
+      name: 'Embedding hygiene',
+      status: 'pass',
+      message: `${onTarget} row(s) on ${CANONICAL_EMBEDDING_MODEL}, no residue`,
+    };
+  }
+
+  return {
+    name: 'Embedding hygiene',
+    status: 'warn',
+    message: issues.join('; '),
+    fix: 'npx moflo embeddings init  # runs the self-healing repair migration',
+  };
+}
+
+function resolveMemoryDb(): string | null {
+  const candidates = [
+    join(process.cwd(), '.swarm', 'memory.db'),
+    join(process.cwd(), '.claude-flow', 'memory.db'),
+    join(process.cwd(), 'data', 'memory.db'),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+async function loadModelGroups(dbPath: string): Promise<ModelGroup[] | null> {
+  const fs = await import('fs');
+  let initSqlJs: any;
+  try {
+    initSqlJs = (await mofloImport('sql.js'))?.default;
+  } catch {
+    return null;
+  }
+  if (!initSqlJs) return null;
+
+  let db: any;
+  try {
+    const SQL = await initSqlJs();
+    const buffer = fs.readFileSync(dbPath);
+    db = new SQL.Database(buffer);
+  } catch {
+    return null;
+  }
+
+  try {
+    // Probe for the v3 schema columns this check reads. If memory_entries
+    // doesn't exist or lacks embedding_model, treat it as "nothing to check"
+    // rather than fail — older DBs predate #648.
+    let hasSchema = false;
+    try {
+      const stmt = db.prepare(`PRAGMA table_info(memory_entries)`);
+      const cols = new Set<string>();
+      while (stmt.step()) {
+        const row = stmt.get();
+        if (Array.isArray(row) && typeof row[1] === 'string') cols.add(row[1]);
+      }
+      stmt.free();
+      hasSchema = ['embedding', 'embedding_model', 'status'].every((c) => cols.has(c));
+    } catch {
+      hasSchema = false;
+    }
+    if (!hasSchema) return [];
+
+    const groups: ModelGroup[] = [];
+    const result = db.exec(
+      `SELECT
+         COALESCE(embedding_model, 'NULL') AS model,
+         COUNT(*) AS n,
+         SUM(CASE WHEN embedding IS NULL THEN 1 ELSE 0 END) AS null_count
+       FROM memory_entries
+       WHERE status = 'active'
+       GROUP BY model`,
+    );
+    if (!result || result.length === 0) return [];
+    const rows = result[0]?.values ?? [];
+    for (const row of rows) {
+      groups.push({
+        model: String(row[0]),
+        count: Number(row[1]),
+        hasNullEmbedding: Number(row[2]) > 0,
+      });
+    }
+    return groups;
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -25,6 +25,7 @@ import {
   checkMofloDbBridge,
   getMofloRoot,
 } from './doctor-checks-deep.js';
+import { checkEmbeddingHygiene } from './doctor-embedding-hygiene.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 
 // Promisified exec with proper shell and env inheritance for cross-platform support
@@ -1441,6 +1442,7 @@ export const doctorCommand: Command = {
       checkDaemonStatus,
       checkMemoryDatabase,
       checkEmbeddings,
+      checkEmbeddingHygiene,
       checkTestDirs,
       checkMcpServers,
       checkDiskSpace,
@@ -1471,6 +1473,8 @@ export const doctorCommand: Command = {
       'daemon': checkDaemonStatus,
       'memory': checkMemoryDatabase,
       'embeddings': checkEmbeddings,
+      'embedding-hygiene': checkEmbeddingHygiene,
+      'hygiene': checkEmbeddingHygiene,
       'git': checkGit,
       'mcp': checkMcpServers,
       'disk': checkDiskSpace,

--- a/src/cli/embeddings/migration/migrate-store.ts
+++ b/src/cli/embeddings/migration/migrate-store.ts
@@ -6,6 +6,15 @@
  * bumps the store's `embeddings_version` marker to {@link EMBEDDINGS_VERSION}
  * only once the final batch commits.
  *
+ * **Eligibility is the store's contract, not the driver's.** The driver
+ * iterates whatever `store.iterItems()` yields. Modern stores
+ * (`SqlJsMemoryEntriesStore` with `targetModel` set, post-#650) filter to
+ * rows whose `embedding_model` does not match the target — so a partially-
+ * migrated DB self-heals on the next call instead of trusting the
+ * `embeddings_version` stamp. Stores that omit `targetModel` keep the legacy
+ * "blanket re-embed every row with content" semantics for callers that
+ * pre-date the eligibility filter.
+ *
  * Semantics:
  *   - Resumable: persists a cursor per store; a second call with the same
  *     arguments after an abort picks up exactly where the previous call left

--- a/src/cli/embeddings/migration/types.ts
+++ b/src/cli/embeddings/migration/types.ts
@@ -19,6 +19,21 @@
 export const EMBEDDINGS_VERSION = 2 as const;
 
 /**
+ * Canonical model label written into `memory_entries.embedding_model` by every
+ * code path that produces a vector for moflo's memory.db — the bridge embedder
+ * (`bridgeStoreEntry`), the migration store (`SqlJsMemoryEntriesStore` repair
+ * mode), and the indexer (`bin/build-embeddings.mjs`). Centralized here so
+ * `services/`, `memory/`, `embeddings/`, and `bin/` cannot drift; the
+ * pre-#650 mix of `'Xenova/all-MiniLM-L6-v2'`, `'fastembed/all-MiniLM-L6-v2'`,
+ * `'fast-all-MiniLM-L6-v2'`, `'local'`, and `'domain-aware-hash-v1'` was the
+ * exact failure mode #648 documented.
+ */
+export const CANONICAL_EMBEDDING_MODEL = 'fast-all-MiniLM-L6-v2';
+
+/** Vector dimension every CANONICAL_EMBEDDING_MODEL embedder must produce. */
+export const CANONICAL_EMBEDDING_DIMENSIONS = 384;
+
+/**
  * A single item in a store that carries an embedding derived from source text.
  */
 export interface MigrationItem {

--- a/src/cli/memory/bridge-core.ts
+++ b/src/cli/memory/bridge-core.ts
@@ -12,6 +12,16 @@ import { atomicWriteFileSync } from '../services/atomic-file-write.js';
 
 // When run via npx, CWD may be node_modules/moflo — walk up to find actual project
 let _projectRoot: string | undefined;
+
+/**
+ * Reset the cached project root. Tests that change `process.cwd()` or
+ * `process.env.CLAUDE_PROJECT_DIR` between cases must call this to avoid
+ * leaking state across tests.
+ */
+export function _resetProjectRootForTest(): void {
+  _projectRoot = undefined;
+}
+
 function getProjectRoot(): string {
   if (_projectRoot) return _projectRoot;
   if (process.env.CLAUDE_PROJECT_DIR) {
@@ -282,6 +292,42 @@ export function cosineSim(a: number[], b: number[]): number {
   return mag === 0 ? 0 : dot / mag;
 }
 
+/** Stats payload that goes into `.claude-flow/vector-stats.json`. */
+export interface VectorStatsPayload {
+  vectorCount: number;
+  missing: number;
+  dbSizeKB: number;
+  namespaces: number;
+  hasHnsw: boolean;
+}
+
+/**
+ * Single source of truth for the on-disk vector-stats.json shape. Both the
+ * bridge path (refreshVectorStatsCache, this module) and the raw-sql.js
+ * fallback (writeVectorStatsCache, memory-initializer.ts) call this so the
+ * field order and key set never drift. Issue #639 was caused by exactly that
+ * kind of dual-writer divergence.
+ */
+export function writeVectorStatsJson(rootDir: string, stats: VectorStatsPayload): void {
+  const cacheDir = path.join(rootDir, '.claude-flow');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(cacheDir, 'vector-stats.json'),
+    JSON.stringify({ ...stats, updatedAt: Date.now() }),
+  );
+}
+
+/** Probe both legacy locations for an HNSW index sidecar file. */
+function detectHnswIndex(rootDir: string): boolean {
+  for (const p of [
+    path.join(rootDir, '.swarm', 'hnsw.index'),
+    path.join(rootDir, '.claude-flow', 'hnsw.index'),
+  ]) {
+    try { fs.statSync(p); return true; } catch { /* nope */ }
+  }
+  return false;
+}
+
 /**
  * Write vector-stats.json cache file used by the statusline. Runs
  * synchronously — only fires when the registry is already resolved, so
@@ -298,18 +344,31 @@ export function refreshVectorStatsCache(dbPathOverride?: string): void {
     let vectorCount = 0;
     let namespaces = 0;
     let dbSizeKB = 0;
-    let hasHnsw = false;
+    let missing = 0;
 
     try {
-      const countRow = ctx.db.prepare(
-        'SELECT COUNT(*) as c FROM memory_entries WHERE status = ? AND embedding IS NOT NULL',
-      ).get('active') as { c: number } | undefined;
-      vectorCount = countRow?.c ?? 0;
+      // sql.js Statement.get() returns positional arrays — read with execRows()
+      // (which wraps db.exec()) to get column-keyed objects. Pre-#649 these
+      // reads happened to never fire (the bridge embedder was always missing
+      // so bridgeStoreEntry never reached this call), and when fixed they
+      // would have clobbered vector-stats.json with zeros via .get().
+      const [countRow] = execRows(
+        ctx.db,
+        "SELECT COUNT(*) as c FROM memory_entries WHERE status = 'active' AND embedding IS NOT NULL",
+      );
+      vectorCount = Number(countRow?.c ?? 0);
 
-      const nsRow = ctx.db.prepare(
-        'SELECT COUNT(DISTINCT namespace) as n FROM memory_entries WHERE status = ?',
-      ).get('active') as { n: number } | undefined;
-      namespaces = nsRow?.n ?? 0;
+      const [nsRow] = execRows(
+        ctx.db,
+        "SELECT COUNT(DISTINCT namespace) as n FROM memory_entries WHERE status = 'active'",
+      );
+      namespaces = Number(nsRow?.n ?? 0);
+
+      const [missingRow] = execRows(
+        ctx.db,
+        "SELECT COUNT(*) as c FROM memory_entries WHERE status = 'active' AND embedding IS NULL",
+      );
+      missing = Number(missingRow?.c ?? 0);
     } catch {
       // Table may not exist yet
     }
@@ -321,20 +380,13 @@ export function refreshVectorStatsCache(dbPathOverride?: string): void {
     } catch { /* file may not exist */ }
 
     const root = getProjectRoot();
-    const hnswPaths = [
-      path.join(root, '.swarm', 'hnsw.index'),
-      path.join(root, '.claude-flow', 'hnsw.index'),
-    ];
-    for (const p of hnswPaths) {
-      try { fs.statSync(p); hasHnsw = true; break; } catch { /* nope */ }
-    }
-
-    const cacheDir = path.join(root, '.claude-flow');
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(cacheDir, 'vector-stats.json'),
-      JSON.stringify({ vectorCount, dbSizeKB, namespaces, hasHnsw, updatedAt: Date.now() }),
-    );
+    writeVectorStatsJson(root, {
+      vectorCount,
+      missing,
+      dbSizeKB,
+      namespaces,
+      hasHnsw: detectHnswIndex(root),
+    });
   } catch {
     // Non-fatal — statusline falls back to file size estimate
   }

--- a/src/cli/memory/bridge-embedder.ts
+++ b/src/cli/memory/bridge-embedder.ts
@@ -20,12 +20,21 @@
 
 import { createEmbeddingService } from '../embeddings/index.js';
 import type { IEmbeddingService } from '../embeddings/types.js';
+import {
+  CANONICAL_EMBEDDING_DIMENSIONS,
+  CANONICAL_EMBEDDING_MODEL,
+} from '../embeddings/migration/types.js';
 
-/** Canonical model label written into `memory_entries.embedding_model`. */
-export const BRIDGE_EMBEDDING_MODEL = 'fast-all-MiniLM-L6-v2';
+/**
+ * Canonical model label written into `memory_entries.embedding_model`.
+ * Aliased from {@link CANONICAL_EMBEDDING_MODEL} for backward compatibility
+ * with bridge-side callers; new code in `services/` and `embeddings/` should
+ * import the canonical name directly to avoid sideways `memory/` coupling.
+ */
+export const BRIDGE_EMBEDDING_MODEL = CANONICAL_EMBEDDING_MODEL;
 
 /** Canonical embedding dimension count for the bridge embedder. */
-export const BRIDGE_EMBEDDING_DIMENSIONS = 384;
+export const BRIDGE_EMBEDDING_DIMENSIONS = CANONICAL_EMBEDDING_DIMENSIONS;
 
 /**
  * `embedding_model` value for rows where the caller intentionally skipped

--- a/src/cli/memory/bridge-embedder.ts
+++ b/src/cli/memory/bridge-embedder.ts
@@ -1,0 +1,115 @@
+/**
+ * Bridge embedder — single source of truth for embedding generation
+ * inside the sql.js bridge path (`bridgeStoreEntry`, `bridgeGenerateEmbedding`,
+ * `bridgeAddToHNSW`).
+ *
+ * Pre-#648 the bridge read `ctx.mofloDb.embedder`, which is undefined on the
+ * `SqlJsHandle` shape — every "successful embed" branch was unreachable, so
+ * every store inserted a null-embedded row tagged with the schema default
+ * (`'local'`). The successful-path label (`'Xenova/all-MiniLM-L6-v2'`) was
+ * dead code. See issue #648 / story #649.
+ *
+ * This module owns the lazily-initialized `FastembedEmbeddingService` and
+ * exposes the canonical model label (`'fast-all-MiniLM-L6-v2'`) so every
+ * write path tags rows the same way the indexer (`bin/build-embeddings.mjs`)
+ * does. Failures throw — never silently degrade.
+ *
+ * @module v3/cli/bridge-embedder
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { createEmbeddingService } from '../embeddings/index.js';
+import type { IEmbeddingService } from '../embeddings/types.js';
+
+/** Canonical model label written into `memory_entries.embedding_model`. */
+export const BRIDGE_EMBEDDING_MODEL = 'fast-all-MiniLM-L6-v2';
+
+/** Canonical embedding dimension count for the bridge embedder. */
+export const BRIDGE_EMBEDDING_DIMENSIONS = 384;
+
+/**
+ * `embedding_model` value for rows where the caller intentionally skipped
+ * embedding generation (e.g. `generateEmbeddingFlag: false`). Distinct from
+ * the schema default `'local'`, which #649 retired as ambiguous — the doctor
+ * check in #651 needs this clean separation to tell intentional skips from
+ * silent failures.
+ */
+export const EMBEDDING_MODEL_OPT_OUT = 'none';
+
+/**
+ * The legacy schema default for `memory_entries.embedding_model`. New rows
+ * should never be tagged with this value — exported only so audits and the
+ * #651 doctor check can detect pre-fix residue without re-typing the literal.
+ */
+export const EMBEDDING_MODEL_LEGACY_DEFAULT = 'local';
+
+/**
+ * Minimal contract the bridge needs from an embedder. Tests inject a stub
+ * via `setBridgeEmbedderForTest`. `embed()` MUST throw on failure — silent
+ * `null` returns are what story #649 is fixing.
+ */
+export interface BridgeEmbedder {
+  readonly model: string;
+  readonly dimensions: number;
+  embed(text: string): Promise<Float32Array>;
+}
+
+let cachedEmbedder: BridgeEmbedder | null = null;
+let testOverride: BridgeEmbedder | null = null;
+
+class LazyFastembedBridgeEmbedder implements BridgeEmbedder {
+  readonly model = BRIDGE_EMBEDDING_MODEL;
+  readonly dimensions = BRIDGE_EMBEDDING_DIMENSIONS;
+
+  private service: IEmbeddingService | null = null;
+
+  private getService(): IEmbeddingService {
+    if (!this.service) {
+      this.service = createEmbeddingService({
+        provider: 'fastembed',
+        dimensions: BRIDGE_EMBEDDING_DIMENSIONS,
+      });
+    }
+    return this.service;
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    const result = await this.getService().embed(text);
+    const raw = (result as { embedding: Float32Array | number[] }).embedding;
+    const vector = raw instanceof Float32Array ? raw : new Float32Array(raw);
+    if (vector.length !== this.dimensions) {
+      throw new Error(
+        `bridge embedder produced ${vector.length}-dim vector, expected ${this.dimensions}`,
+      );
+    }
+    return vector;
+  }
+}
+
+/**
+ * Resolve the bridge embedder. Returns the test override if one was
+ * installed via `setBridgeEmbedderForTest`, otherwise the lazily-built
+ * fastembed singleton.
+ */
+export function getBridgeEmbedder(): BridgeEmbedder {
+  if (testOverride) return testOverride;
+  if (!cachedEmbedder) cachedEmbedder = new LazyFastembedBridgeEmbedder();
+  return cachedEmbedder;
+}
+
+/**
+ * Install a stub embedder for tests. Pass `null` to clear and fall back to
+ * the production fastembed implementation.
+ */
+export function setBridgeEmbedderForTest(impl: BridgeEmbedder | null): void {
+  testOverride = impl;
+}
+
+/**
+ * Drop the cached production embedder — exposed so tests that exercised
+ * the real fastembed path can reset it without leaking state into the next
+ * test.
+ */
+export function _resetBridgeEmbedderCacheForTest(): void {
+  cachedEmbedder = null;
+}

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -9,6 +9,7 @@
  */
 
 import { cosineSim, execRows, generateId, persistBridgeDb, refreshVectorStatsCache, withDb } from './bridge-core.js';
+import { EMBEDDING_MODEL_OPT_OUT, getBridgeEmbedder } from './bridge-embedder.js';
 
 function makeEntryCacheKey(namespace: string, key: string): string {
   const safeNs = String(namespace).replace(/:/g, '_');
@@ -141,21 +142,19 @@ export async function bridgeStoreEntry(options: {
 
     let embeddingJson: string | null = null;
     let dimensions = 0;
-    let model = 'local';
+    let model: string = EMBEDDING_MODEL_OPT_OUT;
 
-    if (options.generateEmbeddingFlag !== false && value.length > 0) {
+    const wantsEmbedding = options.generateEmbeddingFlag !== false && value.length > 0;
+    if (wantsEmbedding) {
+      const embedder = getBridgeEmbedder();
       try {
-        const embedder = ctx.mofloDb.embedder;
-        if (embedder) {
-          const emb = await embedder.embed(value);
-          if (emb) {
-            embeddingJson = JSON.stringify(Array.from(emb));
-            dimensions = emb.length;
-            model = 'Xenova/all-MiniLM-L6-v2';
-          }
-        }
-      } catch {
-        // Embedding failed — store without
+        const vector = await embedder.embed(value);
+        embeddingJson = JSON.stringify(Array.from(vector));
+        dimensions = vector.length;
+        model = embedder.model;
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        return { success: false, id, error: `embedding generation failed: ${reason}` };
       }
     }
 

--- a/src/cli/memory/memory-bridge.ts
+++ b/src/cli/memory/memory-bridge.ts
@@ -22,6 +22,10 @@ import {
   bridgeSearchEntries,
   bridgeStoreEntry,
 } from './bridge-entries.js';
+import {
+  BRIDGE_EMBEDDING_MODEL,
+  getBridgeEmbedder,
+} from './bridge-embedder.js';
 
 // ===== Re-exports: primitives =====
 
@@ -53,22 +57,17 @@ export async function bridgeGenerateEmbedding(
   const registry = await getRegistry(dbPath);
   if (!registry) return null;
 
-  try {
-    const mofloDb = registry.getMofloDb();
-    const embedder = mofloDb?.embedder;
-    if (!embedder) return null;
-
-    const emb = await embedder.embed(text);
-    if (!emb) return null;
-
-    return {
-      embedding: Array.from(emb),
-      dimensions: emb.length,
-      model: 'Xenova/all-MiniLM-L6-v2',
-    };
-  } catch {
-    return null;
-  }
+  // Pre-#648 this read `mofloDb.embedder`, which never exists on a SqlJsHandle —
+  // the path always returned null and silently fell through to the
+  // memory-initializer fastembed path. Wired through bridge-embedder so the
+  // bridge does the work directly and tags results with the canonical model.
+  const embedder = getBridgeEmbedder();
+  const vector = await embedder.embed(text);
+  return {
+    embedding: Array.from(vector),
+    dimensions: vector.length,
+    model: embedder.model,
+  };
 }
 
 export async function bridgeLoadEmbeddingModel(
@@ -83,23 +82,17 @@ export async function bridgeLoadEmbeddingModel(
   const registry = await getRegistry(dbPath);
   if (!registry) return null;
 
-  try {
-    const mofloDb = registry.getMofloDb();
-    const embedder = mofloDb?.embedder;
-    if (!embedder) return null;
-
-    const test = await embedder.embed('test');
-    if (!test) return null;
-
-    return {
-      success: true,
-      dimensions: test.length,
-      modelName: 'Xenova/all-MiniLM-L6-v2',
-      loadTime: Date.now() - startTime,
-    };
-  } catch {
-    return null;
-  }
+  // Probe the embedder so callers see real load failure rather than a stale
+  // cached "available" — embed() lazily initializes fastembed and throws on
+  // model-load failure (per #648 acceptance: no silent fallback).
+  const embedder = getBridgeEmbedder();
+  const probe = await embedder.embed('moflo bridge embedder probe');
+  return {
+    success: true,
+    dimensions: probe.length,
+    modelName: embedder.model,
+    loadTime: Date.now() - startTime,
+  };
 }
 
 // ===== HNSW bridge =====
@@ -195,15 +188,18 @@ export async function bridgeAddToHNSW(
   return withDb(dbPath, async (ctx) => {
     const now = Date.now();
     const embeddingJson = JSON.stringify(embedding);
+    // Bridge-produced vectors come from getBridgeEmbedder() (fastembed, 384-dim).
+    // Pre-#648 this column was hardcoded to 'Xenova/all-MiniLM-L6-v2' which
+    // misrepresented the producing model — fixed to the canonical bridge label.
     ctx.db.prepare(`
       INSERT OR REPLACE INTO memory_entries (
         id, key, namespace, content, type,
         embedding, embedding_dimensions, embedding_model,
         created_at, updated_at, status
-      ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, 'Xenova/all-MiniLM-L6-v2', ?, ?, 'active')
+      ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, 'active')
     `).run([
       id, entry.key, entry.namespace, entry.content,
-      embeddingJson, embedding.length,
+      embeddingJson, embedding.length, BRIDGE_EMBEDDING_MODEL,
       now, now,
     ]);
     persistBridgeDb(ctx.db, dbPath);

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -16,6 +16,8 @@ import { atomicWriteFileSync } from '../services/atomic-file-write.js';
 import { formatEmbeddingError } from './embedding-errors.js';
 import { createEmbeddingService } from '../embeddings/index.js';
 import { HnswLite } from './hnsw-lite.js';
+import { EMBEDDING_MODEL_OPT_OUT } from './bridge-embedder.js';
+import { writeVectorStatsJson } from './bridge-core.js';
 
 /**
  * Write vector-stats.json cache for the statusline (no subprocess needed).
@@ -25,13 +27,15 @@ import { HnswLite } from './hnsw-lite.js';
  * @param stats  - exact counts from a db query already in progress (required —
  *                 making this optional caused issue #639 by silently writing 0)
  */
-function writeVectorStatsCache(dbPath: string, stats: { vectorCount: number; namespaces: number }): void {
+function writeVectorStatsCache(
+  dbPath: string,
+  stats: { vectorCount: number; namespaces: number; missing?: number },
+): void {
   try {
     const fileStat = fs.statSync(dbPath);
     const dbSizeKB = Math.floor(fileStat.size / 1024);
-    const { vectorCount, namespaces } = stats;
+    const { vectorCount, namespaces, missing = 0 } = stats;
 
-    // Check HNSW index presence
     const dbDir = path.dirname(dbPath);
     const projectDir = path.dirname(dbDir); // .swarm -> project root
     let hasHnsw = false;
@@ -42,13 +46,7 @@ function writeVectorStatsCache(dbPath: string, stats: { vectorCount: number; nam
       try { fs.statSync(p); hasHnsw = true; break; } catch { /* nope */ }
     }
 
-    // Write to .claude-flow dir next to the .swarm dir
-    const cacheDir = path.join(projectDir, '.claude-flow');
-    if (!fs.existsSync(cacheDir)) fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(cacheDir, 'vector-stats.json'),
-      JSON.stringify({ vectorCount, dbSizeKB, namespaces, hasHnsw, updatedAt: Date.now() })
-    );
+    writeVectorStatsJson(projectDir, { vectorCount, missing, dbSizeKB, namespaces, hasHnsw });
   } catch { /* Non-fatal */ }
 }
 
@@ -1953,10 +1951,13 @@ export async function storeEntry(options: {
     const id = `entry_${Date.now()}_${Math.random().toString(36).substring(7)}`;
     const now = Date.now();
 
-    // Generate embedding if requested
+    // generateEmbedding() throws on embed failure; the outer try/catch returns
+    // success:false rather than inserting a null-embedded row. Opt-out rows
+    // (generateEmbeddingFlag=false) are tagged EMBEDDING_MODEL_OPT_OUT — see
+    // the constant's docstring in bridge-embedder.ts for the rationale.
     let embeddingJson: string | null = null;
     let embeddingDimensions: number | null = null;
-    let embeddingModel: string | null = null;
+    let embeddingModel: string = EMBEDDING_MODEL_OPT_OUT;
 
     if (generateEmbeddingFlag && value.length > 0) {
       const embResult = await generateEmbedding(value);
@@ -1995,13 +1996,17 @@ export async function storeEntry(options: {
 
     atomicWriteFileSync(dbPath, db.export());
 
-    // Query exact stats while DB is still open
-    let vecCount = 0, nsCount = 0;
+    // Query exact stats while DB is still open. `missing` is the active-rows-
+    // with-NULL-embedding count, surfaced via vector-stats.json so the
+    // statusline can warn on coverage holes (#648 / #649).
+    let vecCount = 0, nsCount = 0, missingCount = 0;
     try {
       const vc = db.exec("SELECT COUNT(*) FROM memory_entries WHERE status='active' AND embedding IS NOT NULL");
       vecCount = vc[0]?.values?.[0]?.[0] as number ?? 0;
       const nc = db.exec("SELECT COUNT(DISTINCT namespace) FROM memory_entries WHERE status='active'");
       nsCount = nc[0]?.values?.[0]?.[0] as number ?? 0;
+      const mc = db.exec("SELECT COUNT(*) FROM memory_entries WHERE status='active' AND embedding IS NULL");
+      missingCount = mc[0]?.values?.[0]?.[0] as number ?? 0;
     } catch { /* table may not have status column in older DBs */ }
 
     db.close();
@@ -2018,7 +2023,7 @@ export async function storeEntry(options: {
     }
 
     // Update statusline cache with exact counts
-    writeVectorStatsCache(dbPath, { vectorCount: vecCount, namespaces: nsCount });
+    writeVectorStatsCache(dbPath, { vectorCount: vecCount, namespaces: nsCount, missing: missingCount });
 
     return {
       success: true,

--- a/src/cli/services/embeddings-migration.ts
+++ b/src/cli/services/embeddings-migration.ts
@@ -2,9 +2,10 @@
  * Idempotent embeddings-version migration for moflo's memory.db.
  *
  * Runs the story-2 driver (`runUpgrade`) with the story-3 UX on any DB whose
- * stored `embeddings_version` is below the current runtime version. Safe to
- * call on every session start — returns fast when the DB is already
- * up-to-date or when `sql.js` isn't available.
+ * stored `embeddings_version` is below the current runtime version OR whose
+ * active rows include any non-target `embedding_model` (#650 — repair mode).
+ * Safe to call on every session start — returns fast when the DB is fully
+ * on-target, when sql.js isn't available, or when the schema is too old.
  *
  * Lives in `services/` so it has no dependency on the CLI command machinery.
  * That lets `bin/session-start-launcher.mjs` dynamic-import it and run the
@@ -21,7 +22,10 @@ import { atomicWriteFileSync } from './atomic-file-write.js';
 // EMBEDDINGS_VERSION is a number constant in a leaf types module — pulling it
 // eagerly is cheap. The heavy imports (fastembed wrapper, upgrade renderer,
 // etc.) stay deferred behind the early returns so session-start stays fast.
-import { EMBEDDINGS_VERSION } from '../embeddings/migration/types.js';
+import {
+  CANONICAL_EMBEDDING_MODEL,
+  EMBEDDINGS_VERSION,
+} from '../embeddings/migration/types.js';
 
 export interface RunEmbeddingsMigrationOptions {
   /** Path to the memory DB. Defaults to `<cwd>/.swarm/memory.db`. */
@@ -69,11 +73,28 @@ export async function runEmbeddingsMigrationIfNeeded(
     }
 
     const { SqlJsMemoryEntriesStore } = await import('./sqljs-migration-store.js');
-    const store = new SqlJsMemoryEntriesStore(db, path.basename(dbPath));
+    // `targetModel` makes the store filter rows by `embedding_model != target`
+    // and re-tag them on update. Combined with the version + eligibility probe
+    // below this turns the migration into a self-healing pass — no separate
+    // "repair" command needed for #648's surviving Xenova / hash / 'local'
+    // residue. See the constructor's docstring for full semantics.
+    const store = new SqlJsMemoryEntriesStore(db, path.basename(dbPath), {
+      targetModel: CANONICAL_EMBEDDING_MODEL,
+    });
 
+    // Two-stage probe — keep session-start cost flat regardless of DB size.
+    //
+    //   1. `getVersion()` — single-row metadata SELECT, sub-millisecond.
+    //   2. `hasIneligibleRows()` — `SELECT 1 ... LIMIT 1` against
+    //      `memory_entries`, bounded regardless of row count.
+    //
+    // The clean common case (v2 stamped, all rows on target) costs both
+    // probes plus zero work. The migrate-store driver bumps the version on
+    // a successful 0-item run — so a fresh DB or a stale-stamp DB falls
+    // through naturally without a special-case write here.
     const currentVersion = await store.getVersion();
     if (currentVersion !== null && currentVersion >= EMBEDDINGS_VERSION) {
-      return false;
+      if (!(await store.hasIneligibleRows())) return false;
     }
 
     const { createEmbeddingService, runUpgrade } = await import('../embeddings/index.js');

--- a/src/cli/services/sqljs-migration-store.ts
+++ b/src/cli/services/sqljs-migration-store.ts
@@ -45,12 +45,47 @@ export interface MigrationItemRow {
   sourceText: string;
 }
 
+/** Optional store-wide configuration; legacy callers can omit. */
+export interface SqlJsMemoryEntriesStoreOptions {
+  /**
+   * Canonical model label this migration produces (e.g.
+   * `'fast-all-MiniLM-L6-v2'`). When set:
+   *   - `countItems()` and `iterItems()` only return rows whose
+   *     `embedding_model` differs from `targetModel` (or is NULL). This
+   *     turns the migration into a self-healing pass: completed rows are
+   *     filtered out, surviving non-target rows (Xenova-tagged,
+   *     domain-aware-hash-*, NULL/'local' residue from #649's silent
+   *     failures, etc.) are re-embedded.
+   *   - `updateBatch()` writes `embedding_model = targetModel` alongside
+   *     the new vector, so the post-migration label faithfully describes
+   *     the producing embedder. Pre-#650 the column was untouched, which
+   *     is how the live DB ended up with non-target rows surviving past
+   *     a successful v2 stamp.
+   *
+   * Omit for the legacy "blanket re-embed without re-tagging" semantics
+   * still used by the existing tests.
+   */
+  targetModel?: string;
+}
+
+// SQL fragment shared by countItems / iterItems / hasIneligibleRows when the
+// store has a configured `targetModel`. Centralized so the eligibility rule
+// stays consistent across read paths — drift here re-opens #648's failure
+// mode where some queries treat a row as "done" while others don't.
+const ELIGIBILITY_AND_CLAUSE = 'AND (embedding_model IS NULL OR embedding_model != ?)';
+
 export class SqlJsMemoryEntriesStore {
   readonly storeId: string;
   private inTransaction = false;
+  private readonly targetModel: string | null;
 
-  constructor(private readonly db: SqlJsDatabase, dbFileName: string) {
+  constructor(
+    private readonly db: SqlJsDatabase,
+    dbFileName: string,
+    options: SqlJsMemoryEntriesStoreOptions = {},
+  ) {
     this.storeId = `${dbFileName}:memory_entries`;
+    this.targetModel = options.targetModel ?? null;
     this.ensureTables();
   }
 
@@ -73,11 +108,18 @@ export class SqlJsMemoryEntriesStore {
     `);
   }
 
+  /**
+   * Count rows the migration would touch. When `targetModel` is set this
+   * is the count of rows NOT yet on the target — so a clean DB returns 0
+   * and the migration short-circuits.
+   */
   async countItems(): Promise<number> {
-    const stmt = this.db.prepare(
-      `SELECT COUNT(*) AS n FROM memory_entries WHERE content IS NOT NULL AND length(content) > 0`,
-    );
+    const baseSql = `SELECT COUNT(*) AS n FROM memory_entries
+                     WHERE content IS NOT NULL AND length(content) > 0`;
+    const sql = this.targetModel === null ? baseSql : `${baseSql} ${ELIGIBILITY_AND_CLAUSE}`;
+    const stmt = this.db.prepare(sql);
     try {
+      if (this.targetModel !== null) stmt.bind([this.targetModel]);
       if (stmt.step()) {
         const row = stmt.getAsObject();
         return Number(row.n ?? 0);
@@ -88,18 +130,53 @@ export class SqlJsMemoryEntriesStore {
     }
   }
 
+  /**
+   * Bounded eligibility probe — `LIMIT 1` exits as soon as one ineligible row
+   * is found. Used by the orchestrator's session-start short-circuit so the
+   * "v2 stamped, all rows on target" common case doesn't pay for a full
+   * COUNT(*). Returns false (no work needed) when called on a store with no
+   * `targetModel` configured.
+   */
+  async hasIneligibleRows(): Promise<boolean> {
+    if (this.targetModel === null) return false;
+    const stmt = this.db.prepare(
+      `SELECT 1 FROM memory_entries
+       WHERE content IS NOT NULL AND length(content) > 0 ${ELIGIBILITY_AND_CLAUSE}
+       LIMIT 1`,
+    );
+    try {
+      stmt.bind([this.targetModel]);
+      return stmt.step();
+    } finally {
+      stmt.free();
+    }
+  }
+
+  /**
+   * Iterate rows the migration should re-embed. With `targetModel` set,
+   * already-target rows are filtered out — interrupted runs naturally
+   * resume only on stragglers, and a finished run yields no rows at all.
+   */
   async iterItems(afterId: string | null, limit: number): Promise<MigrationItemRow[]> {
+    const eligibilityClause = this.targetModel === null ? '' : ELIGIBILITY_AND_CLAUSE;
+
     const sql = afterId === null
       ? `SELECT id, content FROM memory_entries
          WHERE content IS NOT NULL AND length(content) > 0
+           ${eligibilityClause}
          ORDER BY id ASC LIMIT ?`
       : `SELECT id, content FROM memory_entries
          WHERE content IS NOT NULL AND length(content) > 0 AND id > ?
+           ${eligibilityClause}
          ORDER BY id ASC LIMIT ?`;
 
     const stmt = this.db.prepare(sql);
     try {
-      stmt.bind(afterId === null ? [limit] : [afterId, limit]);
+      const params: unknown[] = [];
+      if (afterId !== null) params.push(afterId);
+      if (this.targetModel !== null) params.push(this.targetModel);
+      params.push(limit);
+      stmt.bind(params);
       const out: MigrationItemRow[] = [];
       while (stmt.step()) {
         const row = stmt.getAsObject();
@@ -116,13 +193,27 @@ export class SqlJsMemoryEntriesStore {
     // Embeddings are stored as JSON text in MEMORY_SCHEMA_V3's `embedding TEXT`
     // column — matches how `memory-initializer.ts` and `commands/memory.ts`
     // write them so `embeddings search` can JSON.parse() the result.
-    const stmt = this.db.prepare(
-      `UPDATE memory_entries SET embedding = ?, embedding_dimensions = ? WHERE id = ?`,
-    );
+    //
+    // When `targetModel` is configured the UPDATE also re-tags the row so
+    // post-migration `embedding_model` faithfully describes the producing
+    // embedder. Pre-#650 the column was left untouched, which let
+    // mixed-model rows survive past a successful v2 stamp.
+    const stmt = this.targetModel === null
+      ? this.db.prepare(
+          `UPDATE memory_entries SET embedding = ?, embedding_dimensions = ? WHERE id = ?`,
+        )
+      : this.db.prepare(
+          `UPDATE memory_entries
+           SET embedding = ?, embedding_dimensions = ?, embedding_model = ?
+           WHERE id = ?`,
+        );
     try {
       for (const { id, embedding } of updates) {
         const json = JSON.stringify(Array.from(embedding));
-        stmt.run([json, embedding.length, id]);
+        const params = this.targetModel === null
+          ? [json, embedding.length, id]
+          : [json, embedding.length, this.targetModel, id];
+        stmt.run(params);
       }
     } finally {
       stmt.free();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -72,6 +72,10 @@ export const isolationTests = [
   'tests/guards/hash-fallback-guard.test.ts',
   'tests/hive-mind-messagebus.test.ts',
   'tests/issue-fixes.test.ts',
+  // process.chdir + bridge singleton reset per test — racy under parallel
+  // forks because cwd is process-global and the registry singleton is
+  // module-shared.
+  'src/cli/__tests__/bridge-entries.test.ts',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Closes the three bugs documented in #648 across three commits on a shared epic branch (single-branch strategy):

- **#649** producer fix — `bridgeStoreEntry` no longer reads the always-undefined `mofloDb.embedder`; routes through a singleton `LazyFastembedBridgeEmbedder`, fails loudly on embed errors, tags rows with the canonical model name. Same dead-path repair in `bridgeGenerateEmbedding` / `bridgeLoadEmbeddingModel` / `bridgeAddToHNSW`. Fixed a latent sql.js `.get()` bug in `refreshVectorStatsCache` that would have re-triggered #639's clobber-with-zero failure mode the moment the embedder started working. Added `missing` counter to `vector-stats.json` so the statusline can warn on coverage holes.
- **#650** self-healing migration — `SqlJsMemoryEntriesStore` takes a `targetModel` option; `countItems` / `iterItems` filter by `embedding_model != target` and `updateBatch` re-tags rows. Orchestrator does a two-stage probe (`getVersion` then `LIMIT 1` ineligibility) so the clean-DB session-start cost stays sub-millisecond regardless of row count. Pre-#650 the v2 stamp short-circuited the migration even when ~2k non-target rows survived; now the migration is naturally repair-aware.
- **#651** doctor regression catcher — new `embedding-hygiene` check warns on banned `domain-aware-hash%` rows, the silent-failure marker (`local`+NULL), and mixed neural models. Auto-prevents future re-introduction.

Constants centralized in `embeddings/migration/types.ts` (`CANONICAL_EMBEDDING_MODEL`, `CANONICAL_EMBEDDING_DIMENSIONS`); `memory/bridge-embedder.ts` re-exports for backward compat. Shared `writeVectorStatsJson` helper kills the dual-writer drift mode behind #639.

## Test plan

- [x] `npm test` — 6684 / 6684 passing (was 6673 before the epic; +11 net new)
- [x] Story 1 simplify pass complete — extracted shared writer, sentinel constants, dropped redundant dimension check
- [x] Story 2 simplify pass complete — relocated canonical constant, extracted SQL fragment, deleted unused `hasTargetModel`, swapped full COUNT(\*) for `LIMIT 1` probe to keep session-start hot path bounded
- [x] Story 3 simplify pass complete — replaced gratuitous `require()` with proper import in test
- [x] Filed follow-up #652 for a latent test-runner parser bug discovered while wiring the hygiene test (apostrophes in `//` comments inside `isolationTests` array break the regex parser, hiding ~26 silently-failing tests). Out of scope for this PR.

## Verification on this dogfood DB

After consumer install, on next session-start the self-healing migration will repair the ~2k surviving non-target rows. Doctor's hygiene check will then report `0 row(s) with banned hash model, 0 with silent-failure marker, on canonical model only`.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)