### PR TITLE
fix(tests): repoint rvfa-distribution.test.ts imports to post-collapse path

### DIFF
--- a/src/__tests__/appliance/rvfa-distribution.test.ts
+++ b/src/__tests__/appliance/rvfa-distribution.test.ts
@@ -15,12 +15,12 @@ import {
   RvfaPublisher,
   type RvfpHeader,
   type CreatePatchOptions,
-} from '../../@moflo/cli/src/appliance/rvfa-distribution.js';
+} from '../../cli/appliance/rvfa-distribution.js';
 import {
   RvfaWriter,
   RvfaReader,
   createDefaultHeader,
-} from '../../@moflo/cli/src/appliance/rvfa-format.js';
+} from '../../cli/appliance/rvfa-format.js';
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

- Repointed two stale `@moflo/cli` imports in `src/__tests__/appliance/rvfa-distribution.test.ts` to the post-collapse `src/cli/appliance/` location (epic #586 / story #602 inlined the workspace package).
- Updated docstring run-command path from the equally stale `v3/__tests__/...` to `src/__tests__/...`.
- All 28 tests pass via `npx tsx --test`.

The appliance directory is excluded from vitest in `vitest.config.ts` (uses `node:test` + needs native bindings), which is why this stale-import breakage never surfaced in CI.

## Out of scope

Four sibling test files in the same directory (`gguf-engine`, `rvfa-builder`, `rvfa-format`, `rvfa-signing`) have the same class of breakage with a different stale prefix (`../../modules/cli/...`). #641's body strictly bounded scope to `@moflo/cli` references, so those are tracked in follow-up #654 rather than folded in here.

## Test plan

- [x] `npx tsx --test src/__tests__/appliance/rvfa-distribution.test.ts` → 28/28 passing
- [x] `tsc --noEmit` clean for the touched file
- [x] `grep -rn '@moflo/cli' src/__tests__/` returns zero hits

Closes #641

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)