### PR TITLE
fix(test-runner): strip comments before parsing isolationTests array (#652)

### DIFF
--- a/scripts/load-isolation-tests.d.ts
+++ b/scripts/load-isolation-tests.d.ts
@@ -1,0 +1,2 @@
+export function parseIsolationTests(configSource: string): string[];
+export function loadIsolationTests(configPath: string): string[];

--- a/scripts/load-isolation-tests.mjs
+++ b/scripts/load-isolation-tests.mjs
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs';
+
+// Strip comments before scanning for quoted strings — apostrophes inside
+// `//` comments would otherwise throw quote pairing off and silently drop
+// later entries. Contract: entries are simple test path string literals
+// (no escaped quotes); a literal like `'it\'s'` would still mis-tokenize.
+export function parseIsolationTests(configSource) {
+  const match = configSource.match(/export\s+const\s+isolationTests\s*=\s*\[([\s\S]*?)\];/);
+  if (!match) return [];
+  const body = match[1]
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+  const entries = [];
+  for (const m of body.matchAll(/'([^']+)'|"([^"]+)"/g)) {
+    entries.push(m[1] || m[2]);
+  }
+  return entries;
+}
+
+export function loadIsolationTests(configPath) {
+  try {
+    return parseIsolationTests(readFileSync(configPath, 'utf-8'));
+  } catch (err) {
+    console.error(`[test-runner] failed to load isolation tests from ${configPath}: ${err.message}`);
+    return [];
+  }
+}

--- a/scripts/test-runner.mjs
+++ b/scripts/test-runner.mjs
@@ -15,6 +15,7 @@ import { spawn } from 'child_process';
 import { readFileSync, unlinkSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { loadIsolationTests } from './load-isolation-tests.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -22,26 +23,6 @@ const jsonFile = resolve(root, '.vitest-results.json');
 const vitestBin = resolve(root, 'node_modules/vitest/vitest.mjs');
 const isolationConfig = resolve(root, 'vitest.isolation.config.ts');
 const env = { ...process.env, NODE_OPTIONS: '--max-old-space-size=8192' };
-
-/**
- * Load isolation test list from vitest.config.ts at runtime.
- * Reads the exported array via regex since it's a .ts file.
- */
-function loadIsolationTests() {
-  try {
-    const raw = readFileSync(resolve(root, 'vitest.config.ts'), 'utf-8');
-    const match = raw.match(/export\s+const\s+isolationTests\s*=\s*\[([\s\S]*?)\];/);
-    if (!match) return [];
-    // Extract quoted strings from the array literal
-    const entries = [];
-    for (const m of match[1].matchAll(/'([^']+)'|"([^"]+)"/g)) {
-      entries.push(m[1] || m[2]);
-    }
-    return entries;
-  } catch {
-    return [];
-  }
-}
 
 /** Run vitest with given args, return { code, passed, failed } */
 function runVitest(args, { config } = {}) {
@@ -80,7 +61,7 @@ function cleanup() {
 }
 
 async function main() {
-  const isolationTests = loadIsolationTests();
+  const isolationTests = loadIsolationTests(resolve(root, 'vitest.config.ts'));
 
   // ── Pass 1: Main parallel suite ──
   console.log('\n━━ Pass 1: Parallel suite ━━\n');

--- a/src/cli/__tests__/doctor-sandbox-tier.test.ts
+++ b/src/cli/__tests__/doctor-sandbox-tier.test.ts
@@ -16,7 +16,7 @@ import {
   detectSandboxCapability,
   resetSandboxCache,
   type SandboxCapability,
-} from '../../spells/src/core/platform-sandbox.js';
+} from '../spells/core/platform-sandbox.js';
 
 describe('doctor sandbox tier diagnostic', { timeout: 15_000 }, () => {
   afterEach(() => {

--- a/src/cli/__tests__/hooks/statusline/statusline-collision.test.ts
+++ b/src/cli/__tests__/hooks/statusline/statusline-collision.test.ts
@@ -77,7 +77,7 @@ function isCollisionZoneClear(line: string): boolean {
 }
 
 describe('Statusline Collision Zone Avoidance', () => {
-  it('should have clear collision zone in safe multi-line output', { timeout: 15_000 }, async () => {
+  it('should have clear collision zone in safe multi-line output', async () => {
     // Import dynamically to avoid build issues
     const { StatuslineGenerator } = await import('../../../hooks/statusline/index.js');
 
@@ -99,7 +99,7 @@ describe('Statusline Collision Zone Avoidance', () => {
     }
   });
 
-  it('should produce single-line output when requested', { timeout: 15_000 }, async () => {
+  it('should produce single-line output when requested', async () => {
     const { StatuslineGenerator } = await import('../../../hooks/statusline/index.js');
 
     const generator = new StatuslineGenerator();
@@ -113,7 +113,7 @@ describe('Statusline Collision Zone Avoidance', () => {
     expect(output.includes('\n')).toBe(false);
   });
 
-  it('should have padding in the collision line', { timeout: 15_000 }, async () => {
+  it('should have padding in the collision line', async () => {
     const { StatuslineGenerator } = await import('../../../hooks/statusline/index.js');
 
     const generator = new StatuslineGenerator();
@@ -144,7 +144,7 @@ describe('Statusline Collision Zone Avoidance', () => {
 });
 
 describe('Statusline Output Modes', () => {
-  it('should support all output modes', { timeout: 15_000 }, async () => {
+  it('should support all output modes', async () => {
     const { StatuslineGenerator } = await import('../../../hooks/statusline/index.js');
 
     const generator = new StatuslineGenerator();

--- a/tests/bin/bin-scripts.test.ts
+++ b/tests/bin/bin-scripts.test.ts
@@ -19,9 +19,12 @@ const BIN = resolve(__dirname, '../../bin');
 /** Run `node --check <file>` and return whether it succeeded. */
 function syntaxCheck(file: string): { ok: boolean; error?: string } {
   try {
+    // Spawning `node --check` under cumulative isolation-batch load can
+    // exceed a tight 5 s ceiling on Windows; the check itself is fast,
+    // it's just the child-process spin-up that's contended.
     execFileSync('node', ['--check', file], {
       encoding: 'utf-8',
-      timeout: 5000,
+      timeout: 30_000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     return { ok: true };

--- a/tests/bin/load-isolation-tests.test.ts
+++ b/tests/bin/load-isolation-tests.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { parseIsolationTests, loadIsolationTests } from '../../scripts/load-isolation-tests.mjs';
+import { makeTempRoot, cleanTempRoot } from './_helpers';
+
+describe('parseIsolationTests', () => {
+  it('returns paths from a clean array', () => {
+    const src = `
+export const isolationTests = [
+  'a.test.ts',
+  'b.test.ts',
+];
+`;
+    expect(parseIsolationTests(src)).toEqual(['a.test.ts', 'b.test.ts']);
+  });
+
+  it('keeps later paths when a // comment contains an apostrophe', () => {
+    const src = `
+export const isolationTests = [
+  'before.test.ts',
+  // it's tricky — comment with apostrophe
+  'after.test.ts',
+  // doesn't break anymore
+  'final.test.ts',
+];
+`;
+    expect(parseIsolationTests(src)).toEqual([
+      'before.test.ts',
+      'after.test.ts',
+      'final.test.ts',
+    ]);
+  });
+
+  it('strips /* */ block comments before extracting paths', () => {
+    const src = `
+export const isolationTests = [
+  'one.test.ts',
+  /* it's a block comment with apostrophes */
+  'two.test.ts',
+];
+`;
+    expect(parseIsolationTests(src)).toEqual(['one.test.ts', 'two.test.ts']);
+  });
+
+  it('supports double-quoted entries', () => {
+    const src = `
+export const isolationTests = [
+  "double.test.ts",
+  'single.test.ts',
+];
+`;
+    expect(parseIsolationTests(src)).toEqual(['double.test.ts', 'single.test.ts']);
+  });
+
+  it('returns [] when the export is missing', () => {
+    expect(parseIsolationTests('// no array here\n')).toEqual([]);
+  });
+
+  it('returns the canonical full list from the real vitest.config.ts', () => {
+    const root = resolve(__dirname, '..', '..');
+    const entries = loadIsolationTests(resolve(root, 'vitest.config.ts'));
+    expect(entries.length).toBeGreaterThanOrEqual(40);
+    for (const path of entries) {
+      expect(path).toMatch(/\.test\.ts$/);
+      expect(path.length).toBeLessThan(120);
+    }
+  });
+});
+
+describe('loadIsolationTests', () => {
+  it('reads from a file path and parses correctly', () => {
+    const tmpDir = makeTempRoot('load-isolation');
+    try {
+      const fixture = resolve(tmpDir, 'vitest.config.ts');
+      writeFileSync(fixture, `
+export const isolationTests = [
+  'x.test.ts', // it's fine
+  'y.test.ts',
+];
+`);
+      expect(loadIsolationTests(fixture)).toEqual(['x.test.ts', 'y.test.ts']);
+    } finally {
+      cleanTempRoot(tmpDir);
+    }
+  });
+
+  it('returns [] when the file does not exist', () => {
+    expect(loadIsolationTests(resolve(__dirname, '__never_exists__', 'nope.ts'))).toEqual([]);
+  });
+});

--- a/tests/bin/process-manager.test.ts
+++ b/tests/bin/process-manager.test.ts
@@ -167,8 +167,10 @@ describe('getActive() and prune()', () => {
       return true;
     `);
 
-    // Wait for the short-lived one to exit
-    try { execFileSync('node', ['-e', 'setTimeout(()=>{},500)'], { timeout: 2000 }); } catch { /* ok */ }
+    // Wait for the short-lived one to exit. Bumped from 500 ms because
+    // under cumulative isolation-batch load the OS reaper can lag and
+    // getActive() still observes the not-yet-reaped child PID.
+    try { execFileSync('node', ['-e', 'setTimeout(()=>{},2000)'], { timeout: 5000 }); } catch { /* ok */ }
 
     const active = runPM(root, `return pm.getActive();`);
     expect(active.length).toBe(1);

--- a/tests/issue-fixes.test.ts
+++ b/tests/issue-fixes.test.ts
@@ -14,7 +14,6 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 const rootPkgPath = resolve(__dirname, '../package.json');
-const cliPkgPath = resolve(__dirname, '../src/cli/package.json');
 const versionTsPath = resolve(__dirname, '../src/cli/version.ts');
 
 describe('#74 — CLI version sync', () => {
@@ -27,12 +26,6 @@ describe('#74 — CLI version sync', () => {
     const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
     const content = readFileSync(versionTsPath, 'utf-8');
     expect(content).toContain(`'${rootPkg.version}'`);
-  });
-
-  it('CLI package.json matches root package.json version', () => {
-    const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
-    const cliPkg = JSON.parse(readFileSync(cliPkgPath, 'utf-8'));
-    expect(cliPkg.version).toBe(rootPkg.version);
   });
 
   it('root package.json has prebuild script that syncs version', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,6 +76,10 @@ export const isolationTests = [
   // forks because cwd is process-global and the registry singleton is
   // module-shared.
   'src/cli/__tests__/bridge-entries.test.ts',
+  // performance/timing assertions (initialize<500ms, shutdown<100ms, access
+  // overhead<threshold) bust under Windows parallel-fork contention; whole
+  // file passes <200ms in isolation.
+  'src/cli/memory/controller-registry.test.ts',
 ];
 
 export default defineConfig({

--- a/vitest.isolation.config.ts
+++ b/vitest.isolation.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from 'vitest/config';
 /**
  * Minimal vitest config for isolation tests.
  * No exclude list — the test-runner passes specific files to run.
+ *
+ * testTimeout is bumped here because the isolation batch runs ~40 heavy
+ * test files sequentially in one fork (maxForks:1). Tests that finish in
+ * 1–2 s alone can still take 10–15 s under cumulative fork pressure
+ * (transform cache, dynamic imports, GC). The default 5 s is not enough.
  */
 export default defineConfig({
   test: {
@@ -10,5 +15,6 @@ export default defineConfig({
     execArgv: ['--max-old-space-size=12288'],
     maxForks: 1,
     minForks: 1,
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary

The `loadIsolationTests` parser in `scripts/test-runner.mjs` used a naive
`'([^']+)'` regex to extract test paths from `vitest.config.ts`'s
`isolationTests` array. Apostrophes inside `//` comments threw the
quote-pairing off, silently dropping ~22 of 42 entries — those isolation
tests were skipped on every `npm test` run.

## Changes

- **Parser fix**: extract `parseIsolationTests` + `loadIsolationTests`
  into `scripts/load-isolation-tests.mjs`. Strip `/* */` block comments
  and `//` line comments before scanning for quoted strings. Add `.d.ts`
  for type-checked imports. Log to stderr on read failure (no silent
  catch).
- **Parser tests**: `tests/bin/load-isolation-tests.test.ts` covers
  apostrophe-in-comment, block comments, double quotes, missing array,
  and the real `vitest.config.ts` (≥40 entries, all `*.test.ts`).
- **Stale workspace-collapse refs surfaced** by previously-skipped tests
  now running again:
  - `src/cli/__tests__/doctor-sandbox-tier.test.ts` import path
    `../../spells/src/core/platform-sandbox.js` → `../spells/core/platform-sandbox.js`
  - `tests/issue-fixes.test.ts`: drop obsolete `src/cli/package.json`
    assertion (file removed in epic #586 collapse)
- **Cumulative-load fork-pressure mitigations** for the now-correctly-running
  42-file isolation batch:
  - `vitest.isolation.config.ts`: `testTimeout: 30_000` (default 5s
    busts under maxForks:1 cumulative load)
  - `statusline-collision.test.ts`: drop redundant per-test
    `{ timeout: 15_000 }` overrides — per-test beats config
  - `tests/bin/bin-scripts.test.ts`: `node --check` execFileSync ceiling
    5s → 30s
  - `tests/bin/process-manager.test.ts`: spawn-reap wait 500ms → 2000ms
  - `vitest.config.ts`: isolate `src/cli/memory/controller-registry.test.ts`
    (timing-sensitive performance assertions)

## Test plan

- [x] Parser unit tests pass (8/8) — covers apostrophe, block comments, missing array, real config
- [x] `npm test` green: 7218/7218 passed across 3 consecutive runs
- [x] `/simplify` pass cleared review findings (reuse `_helpers.ts`, drop `@ts-expect-error` via `.d.ts`, log on parse failure)

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)