### PR TITLE
fix(tests): repair appliance test imports broken by workspace-collapse

### DIFF
--- a/src/__tests__/appliance/gguf-engine.test.ts
+++ b/src/__tests__/appliance/gguf-engine.test.ts
@@ -2,7 +2,7 @@
  * GGUF inference engine tests.
  *
  * Uses the Node.js built-in test runner (node:test).
- * Run: npx tsx --test v3/__tests__/appliance/gguf-engine.test.ts
+ * Run: npx tsx --test src/__tests__/appliance/gguf-engine.test.ts
  */
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
@@ -15,7 +15,7 @@ import {
   parseGgufHeader,
   GgufEngine,
   type GgufMetadata,
-} from '../../modules/cli/src/appliance/gguf-engine.js';
+} from '../../cli/appliance/gguf-engine.js';
 
 // ---------------------------------------------------------------------------
 // GGUF Binary Helpers

--- a/src/__tests__/appliance/rvfa-builder.test.ts
+++ b/src/__tests__/appliance/rvfa-builder.test.ts
@@ -2,7 +2,7 @@
  * RVFA Builder pipeline tests.
  *
  * Uses the Node.js built-in test runner (node:test).
- * Run: npx tsx --test v3/__tests__/appliance/rvfa-builder.test.ts
+ * Run: npx tsx --test src/__tests__/appliance/rvfa-builder.test.ts
  */
 
 import { describe, it, afterEach } from 'node:test';
@@ -14,8 +14,8 @@ import {
   RvfaBuilder,
   encryptApiKeys,
   decryptApiKeys,
-} from '../../modules/cli/src/appliance/rvfa-builder.js';
-import { RvfaReader } from '../../modules/cli/src/appliance/rvfa-format.js';
+} from '../../cli/appliance/rvfa-builder.js';
+import { RvfaReader } from '../../cli/appliance/rvfa-format.js';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/__tests__/appliance/rvfa-distribution.test.ts
+++ b/src/__tests__/appliance/rvfa-distribution.test.ts
@@ -2,7 +2,7 @@
  * RVFA Distribution & Hot-Patch module tests.
  *
  * Uses the Node.js built-in test runner (node:test).
- * Run: npx tsx --test v3/__tests__/appliance/rvfa-distribution.test.ts
+ * Run: npx tsx --test src/__tests__/appliance/rvfa-distribution.test.ts
  */
 
 import { describe, it, afterEach } from 'node:test';

--- a/src/__tests__/appliance/rvfa-format.test.ts
+++ b/src/__tests__/appliance/rvfa-format.test.ts
@@ -2,7 +2,7 @@
  * RVFA binary format tests.
  *
  * Uses the Node.js built-in test runner (node:test).
- * Run: npx tsx --test v3/__tests__/appliance/rvfa-format.test.ts
+ * Run: npx tsx --test src/__tests__/appliance/rvfa-format.test.ts
  */
 
 import { describe, it, beforeEach } from 'node:test';
@@ -16,7 +16,7 @@ import {
   validateHeader,
   RVFA_MAGIC,
   RVFA_VERSION,
-} from '../../modules/cli/src/appliance/rvfa-format.js';
+} from '../../cli/appliance/rvfa-format.js';
 
 // -- Helpers ------------------------------------------------------------------
 

--- a/src/__tests__/appliance/rvfa-signing.test.ts
+++ b/src/__tests__/appliance/rvfa-signing.test.ts
@@ -2,7 +2,7 @@
  * RVFA Ed25519 signing module tests.
  *
  * Uses the Node.js built-in test runner (node:test).
- * Run: npx tsx --test v3/__tests__/appliance/rvfa-signing.test.ts
+ * Run: npx tsx --test src/__tests__/appliance/rvfa-signing.test.ts
  */
 
 import { describe, it, afterEach } from 'node:test';
@@ -17,12 +17,12 @@ import {
   RvfaSigner,
   RvfaVerifier,
   type RvfaKeyPair,
-} from '../../modules/cli/src/appliance/rvfa-signing.js';
+} from '../../cli/appliance/rvfa-signing.js';
 import {
   RvfaWriter,
   RvfaReader,
   createDefaultHeader,
-} from '../../modules/cli/src/appliance/rvfa-format.js';
+} from '../../cli/appliance/rvfa-format.js';
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

Four `src/__tests__/appliance/` test files have imported from `../../modules/cli/src/appliance/` since workspace-collapse epic #586 — but `src/modules/` no longer exists. The shipped source lives at `src/cli/appliance/`. The dir is excluded from vitest (these use `node:test`), so the breakage didn't surface in CI.

## Changes

- Update imports in 4 test files (`gguf-engine`, `rvfa-builder`, `rvfa-format`, `rvfa-signing`) from `../../modules/cli/src/appliance/<x>.js` to `../../cli/appliance/<x>.js`.
- Update stale `v3/__tests__/...` run-instructions in 5 docstrings (the four above plus `rvfa-distribution`) to `src/__tests__/...`.

## Out of scope (filed separately)

`rvfa-distribution.test.ts` still imports from `../../@moflo/cli/src/appliance/...` — a third stale prefix #641 missed. Will file as a follow-up rather than expanding this issue's scope.

## Testing

- [x] `npx tsx --test src/__tests__/appliance/gguf-engine.test.ts` — 26/26 pass
- [x] `npx tsx --test src/__tests__/appliance/rvfa-builder.test.ts` — 15/15 pass
- [x] `npx tsx --test src/__tests__/appliance/rvfa-format.test.ts` — 44/44 pass
- [x] `npx tsx --test src/__tests__/appliance/rvfa-signing.test.ts` — 21/21 pass
- [x] `grep -rn 'modules/cli' src/__tests__/` returns zero hits
- [x] `grep -rn 'v3/__tests__' src/__tests__/appliance/` returns zero hits

Closes #654