### PR TITLE
fix(hooks-tools): upsert pretrain patterns to silence UNIQUE flood (#658)

### DIFF
--- a/src/cli/mcp-tools/hooks-tools.ts
+++ b/src/cli/mcp-tools/hooks-tools.ts
@@ -42,6 +42,7 @@ let storeEntryFn: ((options: {
   generateEmbeddingFlag?: boolean;
   tags?: string[];
   ttl?: number;
+  upsert?: boolean;
 }) => Promise<{
   success: boolean;
   id: string;
@@ -1712,6 +1713,9 @@ export const hooksPretrain: MCPTool = {
             namespace: 'patterns',
             generateEmbeddingFlag: true,
             tags: [pattern.type, 'pretrain', `depth-${depth}`],
+            // Pretrain keys are deterministic content hashes — re-running on a
+            // seeded DB must refresh, not throw UNIQUE(namespace, key) (#658).
+            upsert: true,
           });
           patternsStored++;
         } catch {


### PR DESCRIPTION
## Summary

- Pretrain stores patterns under deterministic content-hash keys (`pattern-${type}-${hash}`); re-running on a seeded `.swarm/memory.db` hit `UNIQUE(namespace, key)` and the bridge logged ~80 lines to stderr per session-start auto-pretrain
- Pass `upsert: true` (already supported by `bridgeStoreEntry` / `storeEntry`) so re-runs refresh instead of erroring
- Update the lazy-loaded `storeEntryFn` type to include `upsert?: boolean` (was silently being dropped)

## Changes

- `src/cli/mcp-tools/hooks-tools.ts`: add `upsert?: boolean` to lazy-loaded store type; pass `upsert: true` in pretrain distill loop with a comment explaining why

## Testing

- [x] Verified zero `UNIQUE constraint` stderr lines: `npx vitest run tests/issue-fixes.test.ts -t "session-start auto-pretrain" --config vitest.isolation.config.ts --reporter=verbose 2>&1 | grep -c "UNIQUE constraint"` → `0` (was `58+`)
- [x] `tests/issue-fixes.test.ts` — 10/10 pass
- [x] Pretrain + bridge-entries focused tests — 11/11 pass
- [x] Full suite: 7217 passed; 3 pre-existing isolation-batch flakes (process-manager, gate-helpers, persistence — all pass individually, tracked under #642, unrelated to this change)

## Acceptance Criteria

- [x] No `UNIQUE constraint` stderr lines from this test on a clean run
- [x] Underlying root cause fixed (not silenced) — bridge `INSERT OR REPLACE` engaged via `upsert: true`
- [x] `npm test` stderr is meaningfully cleaner

Closes #658