### PR TITLE
chore(ci): bump Node to 22 (LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -18,7 +18,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 # Cancel superseded PR runs but never cancel an in-flight push to main:
 # a half-finished smoke on main leaves the branch in an unverified state and

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "vitest": "^4.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump CI workflows (ci.yml, consumer-install-smoke.yml) from Node 20 to Node 22 — Node 20 EOLs this month.
- Bump `package.json` engines from `>=20.0.0` to `>=22.0.0` so consumers get the same signal.

## Test plan
- [ ] CI workflow runs green on Node 22
- [ ] Consumer-install smoke passes on all three OSes (ubuntu/macos/windows)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)