### PR TITLE
fix(test-runner): always log failed test ids in summary (#642)

### DIFF
--- a/scripts/test-runner-failures.mjs
+++ b/scripts/test-runner-failures.mjs
@@ -1,0 +1,39 @@
+/**
+ * Failure-extraction helpers for the test-runner wrapper.
+ *
+ * Lives in its own module so tests can import without triggering the
+ * runner's top-level main() side effect.
+ */
+
+/** Pull failed test ids out of vitest's JSON results so the summary line
+ *  still names them when the default reporter's output has scrolled past
+ *  in a tail buffer. Without this, a transient flake leaves zero forensic
+ *  trace once `.vitest-results.json` gets clobbered by the next run (#642). */
+export function extractFailures(results) {
+  const failures = [];
+  const testFiles = results?.testResults || [];
+  for (const file of testFiles) {
+    const fileName = file.name || '(unknown file)';
+    const assertions = file.assertionResults || [];
+    const failedAssertions = assertions.filter((a) => a.status === 'failed');
+    for (const a of failedAssertions) {
+      failures.push({ file: fileName, name: a.fullName || a.title || '(unnamed)' });
+    }
+    if (failedAssertions.length === 0 && file.status === 'failed') {
+      // File-level failure with no per-assertion record (import error, setup
+      // hook crash, suite-level throw). Surface the file so the operator can
+      // re-run it directly.
+      failures.push({ file: fileName, name: '(file-level failure: import / setup / suite hook)' });
+    }
+  }
+  return failures;
+}
+
+export function printFailures(label, failures, log = console.log) {
+  if (failures.length === 0) return;
+  log(`\n  Failed in ${label}:`);
+  for (const f of failures) {
+    log(`    ✗ ${f.file}`);
+    log(`        ${f.name}`);
+  }
+}

--- a/scripts/test-runner.mjs
+++ b/scripts/test-runner.mjs
@@ -16,6 +16,7 @@ import { readFileSync, unlinkSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { loadIsolationTests } from './load-isolation-tests.mjs';
+import { extractFailures, printFailures } from './test-runner-failures.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -24,7 +25,7 @@ const vitestBin = resolve(root, 'node_modules/vitest/vitest.mjs');
 const isolationConfig = resolve(root, 'vitest.isolation.config.ts');
 const env = { ...process.env, NODE_OPTIONS: '--max-old-space-size=8192' };
 
-/** Run vitest with given args, return { code, passed, failed } */
+/** Run vitest with given args, return { code, passed, failed, failures } */
 function runVitest(args, { config } = {}) {
   const finalArgs = [vitestBin, ...args];
   if (config) finalArgs.push('--config', config);
@@ -39,19 +40,21 @@ function runVitest(args, { config } = {}) {
     child.on('close', (code) => {
       let passed = 0;
       let failed = 0;
+      let failures = [];
 
       try {
         const raw = readFileSync(jsonFile, 'utf-8');
         const results = JSON.parse(raw);
         failed = (results.numFailedTests || 0) + (results.numFailedTestSuites || 0);
         passed = results.numPassedTests || 0;
+        failures = extractFailures(results);
       } catch {
         // JSON missing — treat non-zero exit as failure
         if (code !== 0) failed = 1;
       }
 
       cleanup();
-      resolve({ code, passed, failed });
+      resolve({ code, passed, failed, failures });
     });
   });
 }
@@ -74,9 +77,11 @@ async function main() {
 
   let totalPassed = main.passed;
   let totalFailed = main.failed;
+  const allFailures = [...main.failures];
 
   if (main.failed > 0) {
     console.log(`\n✗ Parallel suite: ${main.failed} failure(s)`);
+    printFailures('parallel suite', main.failures);
   } else {
     console.log(`\n✓ Parallel suite: ${main.passed} tests passed`);
   }
@@ -107,9 +112,11 @@ async function main() {
 
     totalPassed += result.passed;
     totalFailed += result.failed;
+    allFailures.push(...result.failures);
 
     if (result.failed > 0) {
       console.log(`\n✗ Isolation batch: ${result.failed} failure(s)`);
+      printFailures('isolation batch', result.failures);
     } else {
       console.log(`\n✓ Isolation batch: ${result.passed} tests passed`);
     }
@@ -121,6 +128,7 @@ async function main() {
   console.log(`  Total failed: ${totalFailed}`);
 
   if (totalFailed > 0) {
+    printFailures('full run', allFailures);
     console.log('\n✗ Tests failed');
     process.exit(1);
   }

--- a/tests/bin/test-runner-failures.test.ts
+++ b/tests/bin/test-runner-failures.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for scripts/test-runner-failures.mjs
+ *
+ * Covers the failure-extraction logic that #642 relies on so a flake
+ * always names the responsible test file/name in the summary, even when
+ * vitest's default reporter output has scrolled past in a tail buffer.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { extractFailures, printFailures } from '../../scripts/test-runner-failures.mjs';
+
+describe('extractFailures', () => {
+  it('returns [] for an empty / clean run', () => {
+    expect(extractFailures({ testResults: [] })).toEqual([]);
+    expect(extractFailures({})).toEqual([]);
+    expect(extractFailures(null)).toEqual([]);
+    expect(extractFailures(undefined)).toEqual([]);
+  });
+
+  it('returns [] when every assertion passed', () => {
+    const results = {
+      testResults: [
+        {
+          name: '/abs/path/foo.test.ts',
+          status: 'passed',
+          assertionResults: [
+            { title: 'a', status: 'passed' },
+            { title: 'b', status: 'passed' },
+          ],
+        },
+      ],
+    };
+    expect(extractFailures(results)).toEqual([]);
+  });
+
+  it('captures one entry per failed assertion with file + fullName', () => {
+    const results = {
+      testResults: [
+        {
+          name: '/abs/path/foo.test.ts',
+          status: 'failed',
+          assertionResults: [
+            { fullName: 'foo > a', title: 'a', status: 'passed' },
+            { fullName: 'foo > b', title: 'b', status: 'failed' },
+            { fullName: 'foo > c', title: 'c', status: 'failed' },
+          ],
+        },
+        {
+          name: '/abs/path/bar.test.ts',
+          status: 'failed',
+          assertionResults: [
+            { fullName: 'bar > x', title: 'x', status: 'failed' },
+          ],
+        },
+      ],
+    };
+    expect(extractFailures(results)).toEqual([
+      { file: '/abs/path/foo.test.ts', name: 'foo > b' },
+      { file: '/abs/path/foo.test.ts', name: 'foo > c' },
+      { file: '/abs/path/bar.test.ts', name: 'bar > x' },
+    ]);
+  });
+
+  it('falls back to title when fullName is missing', () => {
+    const results = {
+      testResults: [
+        {
+          name: '/abs/path/foo.test.ts',
+          status: 'failed',
+          assertionResults: [{ title: 'just-title', status: 'failed' }],
+        },
+      ],
+    };
+    expect(extractFailures(results)).toEqual([
+      { file: '/abs/path/foo.test.ts', name: 'just-title' },
+    ]);
+  });
+
+  it('records a file-level failure when status=failed but no assertion failed', () => {
+    // Import error / setup hook crash — vitest reports the file as failed
+    // without per-assertion failure records.
+    const results = {
+      testResults: [
+        {
+          name: '/abs/path/broken.test.ts',
+          status: 'failed',
+          assertionResults: [],
+        },
+      ],
+    };
+    const out = extractFailures(results);
+    expect(out).toHaveLength(1);
+    expect(out[0].file).toBe('/abs/path/broken.test.ts');
+    expect(out[0].name).toMatch(/file-level failure/);
+  });
+
+  it('handles a missing file name defensively', () => {
+    const results = {
+      testResults: [
+        { status: 'failed', assertionResults: [{ title: 't', status: 'failed' }] },
+      ],
+    };
+    expect(extractFailures(results)).toEqual([
+      { file: '(unknown file)', name: 't' },
+    ]);
+  });
+});
+
+describe('printFailures', () => {
+  it('writes nothing when the failure list is empty', () => {
+    const log = vi.fn();
+    printFailures('parallel suite', [], log);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('emits a header plus two lines per failure (file + name)', () => {
+    const log = vi.fn();
+    printFailures('parallel suite', [
+      { file: '/abs/foo.test.ts', name: 'foo > b' },
+      { file: '/abs/bar.test.ts', name: 'bar > x' },
+    ], log);
+
+    // 1 header + 2 lines per failure
+    expect(log).toHaveBeenCalledTimes(1 + 2 * 2);
+    const calls = log.mock.calls.map((c) => c[0]);
+    expect(calls[0]).toMatch(/parallel suite/);
+    expect(calls.join('\n')).toContain('/abs/foo.test.ts');
+    expect(calls.join('\n')).toContain('foo > b');
+    expect(calls.join('\n')).toContain('/abs/bar.test.ts');
+    expect(calls.join('\n')).toContain('bar > x');
+  });
+});


### PR DESCRIPTION
## Summary

- Parse vitest JSON results into `{file, name}` failure list and print it under each pass plus once more in the final `━━ Summary ━━` block.
- Helpers (`extractFailures`, `printFailures`) extracted to `scripts/test-runner-failures.mjs` so they're unit-testable without triggering the runner's top-level `main()` side effect.
- Adds 8 vitest cases covering the extraction shape, fullName/title fallback, file-level failures, defensive missing-name handling, and `printFailures` injection seam.

## Why

Per the issue: a 4-test cold-run flake left zero forensic trace because (a) the default reporter's inline failure detail scrolled past in a tail buffer and (b) `.vitest-results.json` was clobbered by the next run. The runner counted failures from JSON but never extracted the test names. After this change, even if a flake repeats, the failed test ids are pinned at the bottom of the run output where the captured tail buffer always shows them.

## Acceptance criteria from #642

- [ ] Reproduce the cold-run flake — *not in scope here; not reproducible on demand*
- [ ] Identify failing test ids on cold run — *unblocked: when the next flake hits, ids will be in the run output*
- [ ] Fix flakiness at its source — *deferred until ids are captured (this PR enables that)*
- [x] **Test runner always logs failed test ids visibly** — done

## Test plan

- [x] `npx vitest run tests/bin/test-runner-failures.test.ts` — 8/8 pass
- [x] `npx vitest run tests/bin/` — 58/58 pass
- [x] `npm test` (full suite) — 7239/7239 pass; new logging path wired but no failures to print this run

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)