### PR TITLE
fix(daemon): cancel in-flight worker logic on timeout/disable (#669)

### DIFF
--- a/src/cli/__tests__/services/headless-worker-executor-abort.test.ts
+++ b/src/cli/__tests__/services/headless-worker-executor-abort.test.ts
@@ -1,0 +1,91 @@
+/**
+ * HeadlessWorkerExecutor — AbortSignal kill path (#669)
+ *
+ * Focused tests for the new signal-aware execute() so a worker disabled or
+ * timed-out mid-flight actually kills the spawned `claude` child instead of
+ * letting it run to natural completion.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import type { ChildProcess } from 'child_process';
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execSync: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue(''),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+}));
+
+vi.mock('glob', () => ({
+  glob: vi.fn().mockResolvedValue([]),
+  globSync: vi.fn().mockReturnValue([]),
+}));
+
+import { spawn, execSync } from 'child_process';
+import {
+  HeadlessWorkerExecutor,
+  HEADLESS_WORKER_CONFIGS,
+} from '../../services/headless-worker-executor.js';
+
+/** Build a stub ChildProcess that records kill invocations. */
+function makeStubChild(): ChildProcess & { kill: ReturnType<typeof vi.fn> } {
+  const ee = new EventEmitter() as ChildProcess & { kill: ReturnType<typeof vi.fn>; killed: boolean };
+  ee.stdout = new EventEmitter() as NodeJS.ReadableStream;
+  ee.stderr = new EventEmitter() as NodeJS.ReadableStream;
+  ee.killed = false;
+  ee.kill = vi.fn().mockImplementation(() => {
+    ee.killed = true;
+    // Simulate the OS reaping the child: emit close so the executor's
+    // close handler fires and resolves cleanly.
+    setImmediate(() => ee.emit('close', 143));
+    return true;
+  });
+  return ee;
+}
+
+describe('HeadlessWorkerExecutor abort-on-signal (#669)', () => {
+  let executor: HeadlessWorkerExecutor;
+
+  beforeEach(() => {
+    // Treat `claude --version` as available so isAvailable() short-circuits true.
+    // execSync is called with encoding: 'utf-8' so it returns a string, not a Buffer.
+    (execSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue('1.2.3');
+    executor = new HeadlessWorkerExecutor('/tmp/test-headless', { maxConcurrent: 1 });
+    // Suppress 'error' event throws — emit('error', ...) on EventEmitter without
+    // a listener becomes an unhandled rejection. We assert via the resolved
+    // Promise instead.
+    executor.on('error', () => { /* swallow */ });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('kills the spawned child when the AbortSignal fires', async () => {
+    const child = makeStubChild();
+    (spawn as unknown as ReturnType<typeof vi.fn>).mockReturnValue(child);
+
+    const workerType = Object.keys(HEADLESS_WORKER_CONFIGS)[0] as keyof typeof HEADLESS_WORKER_CONFIGS;
+    const controller = new AbortController();
+
+    const resultPromise = executor.execute(workerType, undefined, controller.signal);
+
+    // Wait a tick so executeClaudeCode has installed its abort listener.
+    await new Promise((r) => setImmediate(r));
+    expect(child.kill).not.toHaveBeenCalled();
+
+    controller.abort();
+    const result = await resultPromise;
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/aborted/i);
+  });
+});

--- a/src/cli/__tests__/services/worker-daemon-cancellation.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-cancellation.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Worker Daemon — Mid-Flight Cancellation (#669)
+ *
+ * Verifies that an in-flight worker run can be interrupted both by the
+ * runWithTimeout timer firing AND by setWorkerEnabled(type, false), instead
+ * of running to natural completion (the pre-#669 behaviour, which kept a
+ * timed-out headless child consuming CPU + tokens for up to its own
+ * internal timeout).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn().mockImplementation((filePath: string) => {
+      if (typeof filePath === 'string' && (filePath.includes('daemon-state.json') || filePath.includes('config.json'))) {
+        return '{}';
+      }
+      throw new Error('ENOENT');
+    }),
+    appendFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../../services/headless-worker-executor.js', () => ({
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
+    isAvailable: vi.fn().mockResolvedValue(false),
+    on: vi.fn(),
+  })),
+  HEADLESS_WORKER_TYPES: [],
+  HEADLESS_WORKER_CONFIGS: {},
+  isHeadlessWorker: vi.fn().mockReturnValue(false),
+}));
+
+const originalOn = process.on.bind(process);
+vi.spyOn(process, 'on').mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+  if (['SIGTERM', 'SIGINT', 'SIGHUP'].includes(event)) return process;
+  return originalOn(event, handler);
+});
+
+import { WorkerDaemon } from '../../services/worker-daemon.js';
+import type { DaemonConfig } from '../../services/worker-daemon.js';
+
+function buildDaemon(extra: Partial<DaemonConfig> = {}): WorkerDaemon {
+  return new WorkerDaemon('/tmp/test-cancel', {
+    autoStart: false,
+    workers: [
+      { type: 'map', intervalMs: 1000, priority: 'normal', description: 'test', enabled: true },
+    ],
+    ...extra,
+  });
+}
+
+/**
+ * Spy on `runWorkerLogic` and capture the AbortSignal it was called with,
+ * holding the run open until the test resolves it. This is the seam #669's
+ * acceptance criteria call out: a stub that observes the signal asserts it
+ * fires on timeout and on disable.
+ */
+function captureSignalAndHang(daemon: WorkerDaemon): {
+  signalReady: Promise<AbortSignal>;
+  finishRun: () => void;
+} {
+  let resolveSignal!: (s: AbortSignal) => void;
+  const signalReady = new Promise<AbortSignal>((r) => { resolveSignal = r; });
+  let finishRun!: () => void;
+  const runDone = new Promise<void>((r) => { finishRun = r; });
+
+  vi.spyOn(
+    daemon as unknown as { runWorkerLogic: (cfg: unknown, signal?: AbortSignal) => Promise<unknown> },
+    'runWorkerLogic',
+  ).mockImplementation(async (_cfg, signal) => {
+    if (signal) resolveSignal(signal);
+    await runDone;
+    return { ok: true };
+  });
+
+  return { signalReady, finishRun };
+}
+
+describe('WorkerDaemon mid-flight cancellation (#669)', () => {
+  let daemon: WorkerDaemon;
+
+  afterEach(async () => {
+    if (daemon) await daemon.stop();
+    vi.restoreAllMocks();
+  });
+
+  describe('runWithTimeout aborts the signal on timeout', () => {
+    beforeEach(() => {
+      daemon = buildDaemon({ workerTimeoutMs: 50 });
+    });
+
+    it('signal becomes aborted when the run exceeds workerTimeoutMs', async () => {
+      const { signalReady, finishRun } = captureSignalAndHang(daemon);
+
+      const triggerPromise = daemon.triggerWorker('map');
+
+      const signal = await signalReady;
+      expect(signal.aborted).toBe(false);
+
+      const result = await triggerPromise;
+      expect(signal.aborted).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/timed out/i);
+
+      finishRun();
+    });
+  });
+
+  describe('setWorkerEnabled(type, false) aborts the signal mid-flight', () => {
+    beforeEach(() => {
+      // Generous timeout so disable wins the race, not the timer.
+      daemon = buildDaemon({ workerTimeoutMs: 10_000 });
+    });
+
+    it('signal becomes aborted when the worker is disabled while running', async () => {
+      const { signalReady, finishRun } = captureSignalAndHang(daemon);
+
+      const triggerPromise = daemon.triggerWorker('map');
+
+      const signal = await signalReady;
+      expect(signal.aborted).toBe(false);
+
+      daemon.setWorkerEnabled('map', false);
+      expect(signal.aborted).toBe(true);
+
+      finishRun();
+      const result = await triggerPromise;
+      // The local-mode mock resolves cleanly; the meaningful assertion is
+      // that the signal already fired (above), which is what callers like
+      // HeadlessWorkerExecutor observe to kill their child process.
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/cli/services/headless-worker-executor.ts
+++ b/src/cli/services/headless-worker-executor.ts
@@ -205,6 +205,7 @@ interface PoolEntry {
 interface QueueEntry {
   workerType: HeadlessWorkerType;
   config?: Partial<HeadlessOptions>;
+  signal?: AbortSignal;
   resolve: (result: HeadlessExecutionResult) => void;
   reject: (error: Error) => void;
   queuedAt: Date;
@@ -699,10 +700,15 @@ export class HeadlessWorkerExecutor extends EventEmitter {
 
   /**
    * Execute a headless worker
+   *
+   * `signal` aborts the spawned Claude Code child on .abort() so a worker
+   * disabled or timed-out mid-flight stops consuming CPU + tokens instead
+   * of running to natural completion (#669).
    */
   async execute(
     workerType: HeadlessWorkerType,
-    configOverrides?: Partial<HeadlessOptions>
+    configOverrides?: Partial<HeadlessOptions>,
+    signal?: AbortSignal,
   ): Promise<HeadlessExecutionResult> {
     const baseConfig = HEADLESS_WORKER_CONFIGS[workerType];
     if (!baseConfig) {
@@ -724,11 +730,20 @@ export class HeadlessWorkerExecutor extends EventEmitter {
     if (this.processPool.size >= this.config.maxConcurrent) {
       // Queue the request
       return new Promise((resolve, reject) => {
+        // Wrap resolve/reject so we always remove the abort listener once the
+        // entry settles — without this, a long-lived caller signal accumulates
+        // one listener per dispatched run.
+        let onAbort: (() => void) | null = null;
+        const detach = () => {
+          if (onAbort && signal) signal.removeEventListener('abort', onAbort);
+          onAbort = null;
+        };
         const entry: QueueEntry = {
           workerType,
           config: configOverrides,
-          resolve,
-          reject,
+          signal,
+          resolve: (r) => { detach(); resolve(r); },
+          reject: (e) => { detach(); reject(e); },
           queuedAt: new Date(),
         };
         this.pendingQueue.push(entry);
@@ -736,11 +751,22 @@ export class HeadlessWorkerExecutor extends EventEmitter {
           workerType,
           queuePosition: this.pendingQueue.length,
         });
+
+        // Drop from queue immediately if aborted before a slot opens.
+        if (signal) {
+          onAbort = () => {
+            const idx = this.pendingQueue.indexOf(entry);
+            if (idx >= 0) this.pendingQueue.splice(idx, 1);
+            entry.reject(new Error('Headless execution aborted while queued'));
+          };
+          if (signal.aborted) onAbort();
+          else signal.addEventListener('abort', onAbort, { once: true });
+        }
       });
     }
 
     // Execute immediately
-    return this.executeInternal(workerType, configOverrides);
+    return this.executeInternal(workerType, configOverrides, signal);
   }
 
   /**
@@ -853,6 +879,18 @@ export class HeadlessWorkerExecutor extends EventEmitter {
   // ============================================
 
   /**
+   * SIGTERM the child, then SIGKILL after 5s if it hasn't exited. Used by
+   * both the per-execution timeout and the abort-signal handler so the kill
+   * escalation lives in one place.
+   */
+  private killChildWithGracePeriod(child: import('child_process').ChildProcess): void {
+    child.kill('SIGTERM');
+    setTimeout(() => {
+      if (!child.killed) child.kill('SIGKILL');
+    }, 5000);
+  }
+
+  /**
    * Ensure log directory exists
    */
   private ensureLogDir(): void {
@@ -870,7 +908,8 @@ export class HeadlessWorkerExecutor extends EventEmitter {
    */
   private async executeInternal(
     workerType: HeadlessWorkerType,
-    configOverrides?: Partial<HeadlessOptions>
+    configOverrides?: Partial<HeadlessOptions>,
+    signal?: AbortSignal,
   ): Promise<HeadlessExecutionResult> {
     const baseConfig = HEADLESS_WORKER_CONFIGS[workerType];
     const headless = { ...baseConfig.headless!, ...configOverrides };
@@ -897,6 +936,7 @@ export class HeadlessWorkerExecutor extends EventEmitter {
         timeoutMs: headless.timeoutMs || this.config.defaultTimeoutMs,
         executionId,
         workerType,
+        signal,
       });
 
       // Parse output based on format
@@ -953,7 +993,7 @@ export class HeadlessWorkerExecutor extends EventEmitter {
       const next = this.pendingQueue.shift();
       if (!next) break;
 
-      this.executeInternal(next.workerType, next.config)
+      this.executeInternal(next.workerType, next.config, next.signal)
         .then(next.resolve)
         .catch(next.reject);
     }
@@ -1152,6 +1192,7 @@ Analyze the above codebase context and provide your response following the forma
       timeoutMs: number;
       executionId: string;
       workerType: HeadlessWorkerType;
+      signal?: AbortSignal;
     }
   ): Promise<{ success: boolean; output: string; tokensUsed?: number; error?: string }> {
     return new Promise((resolve) => {
@@ -1175,13 +1216,7 @@ Analyze the above codebase context and provide your response following the forma
       // Setup timeout
       const timeoutHandle = setTimeout(() => {
         if (this.processPool.has(options.executionId)) {
-          child.kill('SIGTERM');
-          // Give it a moment to terminate gracefully
-          setTimeout(() => {
-            if (!child.killed) {
-              child.kill('SIGKILL');
-            }
-          }, 5000);
+          this.killChildWithGracePeriod(child);
         }
       }, options.timeoutMs);
 
@@ -1247,6 +1282,35 @@ Analyze the above codebase context and provide your response following the forma
           error: error.message,
         });
       });
+
+      // Kill the child process if the caller aborts (e.g. setWorkerEnabled(false)
+      // mid-flight, or runWithTimeout firing in WorkerDaemon). Without this the
+      // child runs to natural completion, holding handles + burning tokens for
+      // up to its own internal timeout (#669).
+      if (options.signal) {
+        const signal = options.signal;
+        const onAbort = () => {
+          if (resolved) return;
+          resolved = true;
+          this.killChildWithGracePeriod(child);
+          cleanup();
+          resolve({
+            success: false,
+            output: stdout || stderr,
+            error: 'Execution aborted',
+          });
+        };
+        if (signal.aborted) {
+          onAbort();
+        } else {
+          signal.addEventListener('abort', onAbort, { once: true });
+          // Drop the listener on normal completion so a long-lived caller
+          // signal (e.g. a swarm-wide cancel token) doesn't accumulate one
+          // listener per dispatched run.
+          child.once('close', () => signal.removeEventListener('abort', onAbort));
+          child.once('error', () => signal.removeEventListener('abort', onAbort));
+        }
+      }
 
       // Handle timeout
       setTimeout(() => {

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -62,6 +62,10 @@ interface WorkerState {
   lastDurationMs?: number;
   consecutiveOverruns: number;
   disabledByOverrun?: boolean;
+  // Set while the worker is in-flight so setWorkerEnabled(false) and the
+  // workerTimeout in runWithTimeout can interrupt the run instead of letting
+  // it consume CPU/tokens to natural completion (#669).
+  abortController?: AbortController;
 }
 
 interface WorkerResult {
@@ -725,7 +729,11 @@ export class WorkerDaemon extends EventEmitter {
     const workerId = `${workerConfig.type}_${Date.now()}`;
     const startTime = Date.now();
 
-    // Track running worker
+    // The controller is parked on shared state so setWorkerEnabled(false) can
+    // interrupt this in-flight run; runWithTimeout also aborts it on timeout
+    // so the headless child gets killed instead of running to completion (#669).
+    const controller = new AbortController();
+    state.abortController = controller;
     this.runningWorkers.add(workerConfig.type);
     state.isRunning = true;
     this.emit('worker:start', { workerId, type: workerConfig.type });
@@ -734,9 +742,10 @@ export class WorkerDaemon extends EventEmitter {
     try {
       // Execute worker logic with timeout (P1 fix)
       const output = await this.runWithTimeout(
-        () => this.runWorkerLogic(workerConfig),
+        (signal) => this.runWorkerLogic(workerConfig, signal),
         this.config.workerTimeoutMs,
-        `Worker ${workerConfig.type} timed out after ${this.config.workerTimeoutMs / 1000}s`
+        `Worker ${workerConfig.type} timed out after ${this.config.workerTimeoutMs / 1000}s`,
+        controller,
       );
       const durationMs = Date.now() - startTime;
 
@@ -787,25 +796,30 @@ export class WorkerDaemon extends EventEmitter {
       return result;
     } finally {
       // Remove from running set and process queue
+      state.abortController = undefined;
       this.runningWorkers.delete(workerConfig.type);
       this.processPendingWorkers();
     }
   }
 
   /**
-   * Run a function with timeout (P1 fix)
+   * Run a function with timeout (P1 fix). Aborts `controller` on timeout so
+   * the underlying work — headless child process in particular — actually
+   * stops instead of running to natural completion after we reject (#669).
    */
   private async runWithTimeout<T>(
-    fn: () => Promise<T>,
+    fn: (signal: AbortSignal) => Promise<T>,
     timeoutMs: number,
-    timeoutMessage: string
+    timeoutMessage: string,
+    controller: AbortController,
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
+        controller.abort();
         reject(new Error(timeoutMessage));
       }, timeoutMs);
 
-      fn()
+      fn(controller.signal)
         .then((result) => {
           clearTimeout(timer);
           resolve(result);
@@ -818,14 +832,16 @@ export class WorkerDaemon extends EventEmitter {
   }
 
   /**
-   * Run the actual worker logic
+   * Run the actual worker logic. `signal` is propagated to the headless
+   * executor so an abort kills the spawned Claude Code child (#669); local
+   * fallbacks ignore it — they're cheap and wall-bounded already.
    */
-  private async runWorkerLogic(workerConfig: WorkerConfig): Promise<unknown> {
+  private async runWorkerLogic(workerConfig: WorkerConfig, signal?: AbortSignal): Promise<unknown> {
     // Check if this is a headless worker type and headless execution is available
     if (isHeadlessWorker(workerConfig.type) && this.headlessAvailable && this.headlessExecutor) {
       try {
         this.log('info', `Running ${workerConfig.type} in headless mode (Claude Code AI)`);
-        const result = await this.headlessExecutor.execute(workerConfig.type as HeadlessWorkerType);
+        const result = await this.headlessExecutor.execute(workerConfig.type as HeadlessWorkerType, undefined, signal);
         return {
           mode: 'headless',
           ...result,
@@ -1129,6 +1145,10 @@ export class WorkerDaemon extends EventEmitter {
           clearTimeout(timer);
           this.timers.delete(type);
         }
+        // Interrupt any in-flight run so disable means "stop now" instead of
+        // "stop after this run finishes naturally" (up to workerTimeoutMs of
+        // continued CPU + tokens for headless workers — #669).
+        this.workers.get(type)?.abortController?.abort();
       }
 
       this.saveState();
@@ -1143,14 +1163,18 @@ export class WorkerDaemon extends EventEmitter {
       running: this.running,
       startedAt: this.startedAt?.toISOString(),
       workers: Object.fromEntries(
-        Array.from(this.workers.entries()).map(([type, state]) => [
-          type,
-          {
-            ...state,
-            lastRun: state.lastRun?.toISOString(),
-            nextRun: state.nextRun?.toISOString(),
-          }
-        ])
+        Array.from(this.workers.entries()).map(([type, state]) => {
+          // abortController is a runtime handle — drop from serialized state.
+          const { abortController: _ac, ...persisted } = state;
+          return [
+            type,
+            {
+              ...persisted,
+              lastRun: state.lastRun?.toISOString(),
+              nextRun: state.nextRun?.toISOString(),
+            },
+          ];
+        })
       ),
       config: {
         ...this.config,


### PR DESCRIPTION
## Summary

Wires an `AbortController` through `executeWorker → runWithTimeout → runWorkerLogic → HeadlessWorkerExecutor.execute → executeClaudeCode` so a worker timeout *or* `setWorkerEnabled(type, false)` actually interrupts the in-flight run instead of leaving it to finish naturally — including killing the spawned Claude Code child for headless workers, which previously kept consuming CPU + tokens for up to `workerTimeoutMs` after the rejection.

## Changes

- `WorkerState.abortController` parked during `executeWorker`'s try; cleared in `finally`.
- `runWithTimeout` now creates the signal, passes it to `fn`, and aborts on timeout in addition to rejecting.
- `runWorkerLogic` accepts an optional `signal` and forwards it to `HeadlessWorkerExecutor.execute`.
- `setWorkerEnabled(type, false)` calls `state.abortController?.abort()` on the in-flight run.
- `HeadlessWorkerExecutor.executeClaudeCode` registers an abort listener that kills the spawned child via `SIGTERM` + 5s `SIGKILL` escalation; queue-path entries reject with "aborted while queued" when their signal fires before a slot opens.
- `killChildWithGracePeriod` helper extracted so the kill escalation lives in one place — used by both the existing timeout path and the new abort path (was duplicated inline before).
- Abort listeners on caller signals are detached on normal completion (close/error) so a long-lived swarm-wide cancel token doesn't accumulate one listener per dispatch.
- `saveState` destructures `abortController` out before serializing — runtime handle isn't JSON-meaningful.

## Testing

- [x] Unit: `worker-daemon-cancellation.test.ts` — stubbed `runWorkerLogic` observes the signal and asserts it fires on **both** timeout (`workerTimeoutMs: 50`) and `setWorkerEnabled('map', false)`.
- [x] Unit: `headless-worker-executor-abort.test.ts` — spawn mock observes `child.kill('SIGTERM')` when the AbortSignal fires.
- [x] Existing tests pass (97 in worker-daemon + headless-executor unit suites).
- [x] Full suite: `node scripts/test-runner.mjs` clean — 7242 passed, 0 failed.

Closes #669

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)