### PR TITLE
fix(daemon): stop WorkerDaemon listener leak; share attach/detach helper

### DIFF
--- a/src/cli/__tests__/services/worker-daemon-listener-cleanup.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-listener-cleanup.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Worker Daemon — Signal + Emitter Listener Cleanup (#667)
+ *
+ * Verifies that WorkerDaemon.stop() detaches the SIGTERM/SIGINT/SIGHUP
+ * handlers it registered in the constructor and clears its own EventEmitter
+ * subscribers, so repeated construction (in tests + smoke harnesses) does
+ * not accumulate listeners and trip MaxListenersExceededWarning.
+ *
+ * Unlike the other worker-daemon test files, this one deliberately does NOT
+ * mock process.on — the assertions are about real listener counts on the
+ * process object.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn().mockImplementation((filePath: string) => {
+      if (typeof filePath === 'string' && (filePath.includes('daemon-state.json') || filePath.includes('config.json'))) {
+        return '{}';
+      }
+      throw new Error('ENOENT');
+    }),
+    appendFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../../services/headless-worker-executor.js', () => ({
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
+    isAvailable: vi.fn().mockResolvedValue(false),
+    on: vi.fn(),
+  })),
+  HEADLESS_WORKER_TYPES: [],
+  HEADLESS_WORKER_CONFIGS: {},
+  isHeadlessWorker: vi.fn().mockReturnValue(false),
+}));
+
+import { WorkerDaemon, getDaemon, stopDaemon } from '../../services/worker-daemon.js';
+
+const SIGNALS = ['SIGTERM', 'SIGINT', 'SIGHUP'] as const;
+
+function snapshotSignalCounts(): Record<typeof SIGNALS[number], number> {
+  return {
+    SIGTERM: process.listenerCount('SIGTERM'),
+    SIGINT: process.listenerCount('SIGINT'),
+    SIGHUP: process.listenerCount('SIGHUP'),
+  };
+}
+
+function buildDaemon(): WorkerDaemon {
+  return new WorkerDaemon('/tmp/test-listener-cleanup', {
+    autoStart: false,
+    workers: [
+      { type: 'map', intervalMs: 1000, priority: 'normal', description: 'test', enabled: true },
+    ],
+  });
+}
+
+describe('WorkerDaemon listener cleanup (#667)', () => {
+  let baseline: Record<typeof SIGNALS[number], number>;
+
+  beforeEach(() => {
+    baseline = snapshotSignalCounts();
+  });
+
+  afterEach(() => {
+    // Defensive: ensure no stray listeners survive a failing assertion.
+    for (const sig of SIGNALS) {
+      const current = process.listenerCount(sig);
+      if (current > baseline[sig]) {
+        process.removeAllListeners(sig);
+      }
+    }
+  });
+
+  it('constructor adds one handler to each of SIGTERM, SIGINT, SIGHUP', () => {
+    const daemon = buildDaemon();
+    const after = snapshotSignalCounts();
+    for (const sig of SIGNALS) {
+      expect(after[sig]).toBe(baseline[sig] + 1);
+    }
+    return daemon.stop();
+  });
+
+  it('stop() removes the signal handlers it registered (without start)', async () => {
+    const daemon = buildDaemon();
+    await daemon.stop();
+    const after = snapshotSignalCounts();
+    for (const sig of SIGNALS) {
+      expect(after[sig]).toBe(baseline[sig]);
+    }
+  });
+
+  it('stop() removes the signal handlers after start()', async () => {
+    const daemon = buildDaemon();
+    await daemon.start();
+    await daemon.stop();
+    const after = snapshotSignalCounts();
+    for (const sig of SIGNALS) {
+      expect(after[sig]).toBe(baseline[sig]);
+    }
+  });
+
+  it('stop() clears the daemon EventEmitter listeners', async () => {
+    const daemon = buildDaemon();
+    daemon.on('worker:complete', () => {});
+    daemon.on('worker:start', () => {});
+    daemon.on('worker:deferred', () => {});
+    daemon.on('worker:disabled-overrun', () => {});
+
+    expect(daemon.listenerCount('worker:complete')).toBe(1);
+    expect(daemon.listenerCount('worker:start')).toBe(1);
+    expect(daemon.listenerCount('worker:deferred')).toBe(1);
+    expect(daemon.listenerCount('worker:disabled-overrun')).toBe(1);
+
+    await daemon.stop();
+
+    expect(daemon.listenerCount('worker:complete')).toBe(0);
+    expect(daemon.listenerCount('worker:start')).toBe(0);
+    expect(daemon.listenerCount('worker:deferred')).toBe(0);
+    expect(daemon.listenerCount('worker:disabled-overrun')).toBe(0);
+  });
+
+  it('stop() is idempotent: second call does not throw or double-remove', async () => {
+    const daemon = buildDaemon();
+    await daemon.stop();
+    const afterFirst = snapshotSignalCounts();
+
+    await expect(daemon.stop()).resolves.not.toThrow();
+
+    const afterSecond = snapshotSignalCounts();
+    for (const sig of SIGNALS) {
+      expect(afterSecond[sig]).toBe(afterFirst[sig]);
+      expect(afterSecond[sig]).toBe(baseline[sig]);
+    }
+  });
+
+  it('terminal events still fire to subscribers before the emitter is cleared', async () => {
+    const daemon = buildDaemon();
+    await daemon.start();
+
+    const stoppedSpy = vi.fn();
+    daemon.on('stopped', stoppedSpy);
+
+    await daemon.stop();
+    expect(stoppedSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stopDaemon() releases the singleton so the next getDaemon() returns a fresh instance', async () => {
+    const first = getDaemon('/tmp/test-singleton', { autoStart: false });
+    await stopDaemon();
+    const second = getDaemon('/tmp/test-singleton', { autoStart: false });
+    expect(second).not.toBe(first);
+    await stopDaemon();
+  });
+
+  it('many constructions + stops do not leak listeners (the regression scenario)', async () => {
+    // The original bug fired MaxListenersExceededWarning at 11 listeners.
+    // Construct 20 daemons in sequence — each pair (new + stop) must net to
+    // zero listener delta.
+    for (let i = 0; i < 20; i++) {
+      const daemon = buildDaemon();
+      await daemon.stop();
+    }
+    const after = snapshotSignalCounts();
+    for (const sig of SIGNALS) {
+      expect(after[sig]).toBe(baseline[sig]);
+    }
+  });
+});

--- a/src/cli/__tests__/shared/resilience/signal-handlers.test.ts
+++ b/src/cli/__tests__/shared/resilience/signal-handlers.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the shared signal-handler attach/detach utility (#667 follow-up).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  SHUTDOWN_SIGNALS,
+  attachSignalHandlers,
+} from '../../../shared/resilience/signal-handlers.js';
+
+function snapshot(): Record<typeof SHUTDOWN_SIGNALS[number], number> {
+  return {
+    SIGTERM: process.listenerCount('SIGTERM'),
+    SIGINT: process.listenerCount('SIGINT'),
+    SIGHUP: process.listenerCount('SIGHUP'),
+  };
+}
+
+describe('attachSignalHandlers', () => {
+  let baseline: ReturnType<typeof snapshot>;
+
+  beforeEach(() => {
+    baseline = snapshot();
+  });
+
+  it('registers the handler on the default SHUTDOWN_SIGNALS', () => {
+    const detach = attachSignalHandlers(() => {});
+    const after = snapshot();
+    for (const sig of SHUTDOWN_SIGNALS) {
+      expect(after[sig]).toBe(baseline[sig] + 1);
+    }
+    detach();
+  });
+
+  it('returned detach removes the listeners', () => {
+    const detach = attachSignalHandlers(() => {});
+    detach();
+    const after = snapshot();
+    for (const sig of SHUTDOWN_SIGNALS) {
+      expect(after[sig]).toBe(baseline[sig]);
+    }
+  });
+
+  it('detach is idempotent', () => {
+    const detach = attachSignalHandlers(() => {});
+    detach();
+    expect(() => detach()).not.toThrow();
+    const after = snapshot();
+    for (const sig of SHUTDOWN_SIGNALS) {
+      expect(after[sig]).toBe(baseline[sig]);
+    }
+  });
+
+  it('honors a custom signals list', () => {
+    const detach = attachSignalHandlers(() => {}, ['SIGINT']);
+    const after = snapshot();
+    expect(after.SIGINT).toBe(baseline.SIGINT + 1);
+    expect(after.SIGTERM).toBe(baseline.SIGTERM);
+    expect(after.SIGHUP).toBe(baseline.SIGHUP);
+    detach();
+  });
+
+  it('many attach/detach cycles do not leak', () => {
+    for (let i = 0; i < 25; i++) {
+      const detach = attachSignalHandlers(() => {});
+      detach();
+    }
+    const after = snapshot();
+    for (const sig of SHUTDOWN_SIGNALS) {
+      expect(after[sig]).toBe(baseline[sig]);
+    }
+  });
+
+  it('registers the same handler reference on every signal', () => {
+    const handler: NodeJS.SignalsListener = () => {};
+    const detach = attachSignalHandlers(handler);
+    for (const sig of SHUTDOWN_SIGNALS) {
+      expect(process.listeners(sig)).toContain(handler);
+    }
+    detach();
+    for (const sig of SHUTDOWN_SIGNALS) {
+      expect(process.listeners(sig)).not.toContain(handler);
+    }
+  });
+});

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -6,6 +6,7 @@
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { WorkerDaemon, getDaemon, startDaemon, stopDaemon, type WorkerType, type DaemonConfig } from '../services/worker-daemon.js';
+import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import { acquireDaemonLock, releaseDaemonLock, getDaemonLockHolder, transferDaemonLock, lockPath } from '../services/daemon-lock.js';
 import { installDaemonService, uninstallDaemonService, isDaemonInstalled } from '../services/daemon-service.js';
 import { startDashboard, createDashboardMemoryAccessor, DEFAULT_DASHBOARD_PORT, type DashboardHandle } from '../services/daemon-dashboard.js';
@@ -115,8 +116,7 @@ const startCommand: Command = {
         releaseDaemonLock(projectRoot, process.pid, true);
       };
       process.on('exit', cleanup);
-      process.on('SIGINT', () => { cleanup(); process.exit(0); });
-      process.on('SIGTERM', () => { cleanup(); process.exit(0); });
+      attachSignalHandlers(() => { cleanup(); process.exit(0); }, ['SIGINT', 'SIGTERM']);
       // Ignore SIGHUP on macOS/Linux — prevents daemon death when terminal closes (#1283)
       if (process.platform !== 'win32') {
         process.on('SIGHUP', () => { /* ignore — keep running */ });

--- a/src/cli/commands/hive-mind.ts
+++ b/src/cli/commands/hive-mind.ts
@@ -10,6 +10,7 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
+import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import { spawn as childSpawn, execSync } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
@@ -311,14 +312,11 @@ async function spawnClaudeCodeInstance(
         process.exit(0);
       };
 
-      process.on('SIGINT', sigintHandler);
-      process.on('SIGTERM', sigintHandler);
+      const detachSignals = attachSignalHandlers(sigintHandler, ['SIGINT', 'SIGTERM']);
 
       // Handle process exit
       claudeProcess.on('exit', (code) => {
-        // Clean up signal handlers
-        process.removeListener('SIGINT', sigintHandler);
-        process.removeListener('SIGTERM', sigintHandler);
+        detachSignals();
 
         if (code === 0) {
           output.writeln();

--- a/src/cli/embeddings/migration/upgrade-coordinator.ts
+++ b/src/cli/embeddings/migration/upgrade-coordinator.ts
@@ -17,6 +17,7 @@
  */
 
 import { migrateStore } from './migrate-store.js';
+import { attachSignalHandlers } from '../../shared/resilience/signal-handlers.js';
 import type {
   MigrationEmbedder,
   MigrationProgress,
@@ -131,10 +132,9 @@ export async function runUpgrade(options: UpgradeCoordinatorOptions): Promise<Up
     }
   }
 
-  let sigintListener: (() => void) | null = null;
+  let detachSigint: (() => void) | null = null;
   if (options.installSigintHandler !== false) {
-    sigintListener = () => abortAll('SIGINT');
-    process.on('SIGINT', sigintListener);
+    detachSigint = attachSignalHandlers(() => abortAll('SIGINT'), ['SIGINT']);
   }
 
   const startedAt = now();
@@ -190,7 +190,7 @@ export async function runUpgrade(options: UpgradeCoordinatorOptions): Promise<Up
       renderer.complete(totalMigrated, now() - startedAt);
     }
   } finally {
-    if (sigintListener) process.off('SIGINT', sigintListener);
+    detachSigint?.();
     if (externalAbortListener && externalSignal) {
       externalSignal.removeEventListener('abort', externalAbortListener);
     }

--- a/src/cli/runtime/headless.ts
+++ b/src/cli/runtime/headless.ts
@@ -17,6 +17,7 @@
 
 import { HeadlessWorkerExecutor, HEADLESS_WORKER_TYPES, type HeadlessWorkerType } from '../services/headless-worker-executor.js';
 import { WorkerDaemon, getDaemon, startDaemon, stopDaemon } from '../services/worker-daemon.js';
+import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import {
   initializeIntelligence,
   benchmarkAdaptation,
@@ -173,18 +174,11 @@ async function runDaemon(): Promise<void> {
   console.log('[Headless] Daemon started');
   console.log('[Headless] Press Ctrl+C to stop');
 
-  // Handle shutdown
-  process.on('SIGINT', async () => {
-    console.log('\n[Headless] Shutting down daemon...');
+  attachSignalHandlers(async (sig) => {
+    console.log(`\n[Headless] Received ${sig}, shutting down daemon...`);
     await stopDaemon();
     process.exit(0);
-  });
-
-  process.on('SIGTERM', async () => {
-    console.log('\n[Headless] Received SIGTERM, shutting down...');
-    await stopDaemon();
-    process.exit(0);
-  });
+  }, ['SIGINT', 'SIGTERM']);
 
   // Keep process running
   await new Promise(() => {});

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -28,6 +28,7 @@ import type {
   SchedulerEvent,
 } from '../spells/scheduler/scheduler.js';
 import { withTimeout } from '../shared/resilience/retry.js';
+import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import { calculateDelay } from '../production/retry.js';
 import { CircuitBreaker } from '../production/circuit-breaker.js';
 
@@ -166,6 +167,17 @@ export class WorkerDaemon extends EventEmitter {
   // Injectable OS provider for testing (avoids ESM module namespace issues)
   private _osProvider?: { loadavg: () => number[]; totalmem: () => number; freemem: () => number };
 
+  // Detach callback returned by attachSignalHandlers; calling it removes the
+  // SIGTERM/SIGINT/SIGHUP handlers this daemon registered. Without this,
+  // every `new WorkerDaemon()` permanently bumps those listener counts and
+  // eventually trips MaxListenersExceededWarning.
+  private _detachShutdownHandlers?: () => void;
+
+  // Detach callbacks for the listeners forwarded from the headless executor.
+  // Mirrors the unsubScheduler pattern so stop() can release the executor's
+  // hold on this daemon's `this`.
+  private _detachHeadlessForwarders: Array<() => void> = [];
+
   constructor(projectRoot: string, config?: Partial<DaemonConfig>) {
     super();
     this.projectRoot = projectRoot;
@@ -237,22 +249,21 @@ export class WorkerDaemon extends EventEmitter {
       if (this.headlessAvailable) {
         this.log('info', 'Claude Code headless mode available - AI workers enabled');
 
-        // Forward headless executor events
-        this.headlessExecutor.on('execution:start', (data) => {
-          this.emit('headless:start', data);
-        });
-
-        this.headlessExecutor.on('execution:complete', (data) => {
-          this.emit('headless:complete', data);
-        });
-
-        this.headlessExecutor.on('execution:error', (data) => {
-          this.emit('headless:error', data);
-        });
-
-        this.headlessExecutor.on('output', (data) => {
-          this.emit('headless:output', data);
-        });
+        // Forward headless executor events. Track detach callbacks so stop()
+        // can release the executor's hold on `this` instead of leaving the
+        // forwarder closures alive on the executor's emitter.
+        const executor = this.headlessExecutor;
+        const forwards: Array<[string, string]> = [
+          ['execution:start', 'headless:start'],
+          ['execution:complete', 'headless:complete'],
+          ['execution:error', 'headless:error'],
+          ['output', 'headless:output'],
+        ];
+        for (const [src, dst] of forwards) {
+          const forwarder = (data: unknown) => { this.emit(dst, data); };
+          executor.on(src, forwarder);
+          this._detachHeadlessForwarders.push(() => executor.removeListener(src, forwarder));
+        }
       } else {
         this.log('info', 'Claude Code not found - AI workers will run in local fallback mode');
       }
@@ -344,15 +355,17 @@ export class WorkerDaemon extends EventEmitter {
    * Setup graceful shutdown handlers
    */
   private setupShutdownHandlers(): void {
-    const shutdown = async () => {
+    this._detachShutdownHandlers = attachSignalHandlers(async () => {
       this.log('info', 'Received shutdown signal, stopping daemon...');
       await this.stop();
       process.exit(0);
-    };
+    });
+  }
 
-    process.on('SIGTERM', shutdown);
-    process.on('SIGINT', shutdown);
-    process.on('SIGHUP', shutdown);
+  /** Idempotent: clears `_detachShutdownHandlers` so a second call is a no-op. */
+  private removeShutdownHandlers(): void {
+    this._detachShutdownHandlers?.();
+    this._detachShutdownHandlers = undefined;
   }
 
   /**
@@ -537,6 +550,12 @@ export class WorkerDaemon extends EventEmitter {
   async stop(): Promise<void> {
     if (!this.running) {
       this.emit('warning', 'Daemon not running');
+      // Constructor registered signal handlers and headless-forwarders before
+      // start() was ever called, so stop()-without-start must still tear them
+      // down.
+      this.removeShutdownHandlers();
+      this.detachHeadlessForwarders();
+      this.removeAllListeners();
       return;
     }
 
@@ -562,6 +581,19 @@ export class WorkerDaemon extends EventEmitter {
     this.saveState();
     this.emit('stopped', { stoppedAt: new Date() });
     this.log('info', 'Daemon stopped');
+
+    // Tear down last so subscribers still observe the terminal events above.
+    this.removeShutdownHandlers();
+    this.detachHeadlessForwarders();
+    this.removeAllListeners();
+  }
+
+  /** Idempotent: drains the detach-callback list. */
+  private detachHeadlessForwarders(): void {
+    while (this._detachHeadlessForwarders.length > 0) {
+      const detach = this._detachHeadlessForwarders.pop();
+      detach?.();
+    }
   }
 
   /**
@@ -1279,11 +1311,14 @@ export async function startDaemon(projectRoot: string, config?: Partial<DaemonCo
 }
 
 /**
- * Stop daemon
+ * Stop daemon. Releases the singleton so a subsequent getDaemon() builds a
+ * fresh instance instead of handing back a torn-down zombie whose listeners
+ * have all been removed.
  */
 export async function stopDaemon(): Promise<void> {
   if (daemonInstance) {
     await daemonInstance.stop();
+    daemonInstance = null;
   }
 }
 

--- a/src/cli/shared/resilience/index.ts
+++ b/src/cli/shared/resilience/index.ts
@@ -24,3 +24,7 @@ export type { RateLimiter, RateLimiterOptions, RateLimitResult } from './rate-li
 // Bulkhead
 export { Bulkhead } from './bulkhead.js';
 export type { BulkheadOptions, BulkheadStats } from './bulkhead.js';
+
+// Signal handlers
+export { SHUTDOWN_SIGNALS, attachSignalHandlers } from './signal-handlers.js';
+export type { ShutdownSignal } from './signal-handlers.js';

--- a/src/cli/shared/resilience/signal-handlers.ts
+++ b/src/cli/shared/resilience/signal-handlers.ts
@@ -1,0 +1,35 @@
+/**
+ * Process signal handler attach/detach utility.
+ *
+ * Centralises the capture-handler-then-removeListener idiom that was
+ * reimplemented across worker-daemon, hive-mind, headless runtime, daemon
+ * command, upgrade coordinator, etc. — each subtly different, several missing
+ * the detach side, which leaked listeners and tripped MaxListenersExceededWarning
+ * across repeated test instantiations (#667).
+ */
+
+export const SHUTDOWN_SIGNALS = ['SIGTERM', 'SIGINT', 'SIGHUP'] as const;
+export type ShutdownSignal = (typeof SHUTDOWN_SIGNALS)[number];
+
+/**
+ * Register the same handler on each of `signals`. Returns a detach function
+ * that removes them; the detach is idempotent so callers can defensively call
+ * it from multiple cleanup paths (e.g. both `try/finally` and a stop() method).
+ */
+export function attachSignalHandlers(
+  handler: NodeJS.SignalsListener,
+  signals: readonly NodeJS.Signals[] = SHUTDOWN_SIGNALS,
+): () => void {
+  for (const sig of signals) {
+    process.on(sig, handler);
+  }
+
+  let detached = false;
+  return () => {
+    if (detached) return;
+    detached = true;
+    for (const sig of signals) {
+      process.removeListener(sig, handler);
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- Capture SIGTERM/SIGINT/SIGHUP handler reference and clear it (plus self-emitter listeners) in `WorkerDaemon.stop()`. Idempotent — safe across repeated calls and a stop() on a constructed-but-not-started daemon.
- Extract `attachSignalHandlers(handler, signals?)` into `src/cli/shared/resilience/signal-handlers.ts` (returns idempotent detach). Migrate 5 sites that each reimplemented this pattern with subtle variations: `worker-daemon`, `runtime/headless`, `commands/daemon`, `commands/hive-mind`, `embeddings/migration/upgrade-coordinator`.
- Two adjacent fixes uncovered by /simplify review:
  - `stopDaemon()` now nulls the module-level singleton so the next `getDaemon()` builds a fresh daemon instead of returning a torn-down zombie.
  - `HeadlessExecutor` forwarder listeners are tracked and detached on `stop()`.

## Changes

- `src/cli/services/worker-daemon.ts` — listener cleanup in `stop()`, headless forwarder detach, singleton reset.
- `src/cli/shared/resilience/signal-handlers.ts` — new shared utility with barrel export.
- `src/cli/runtime/headless.ts`, `src/cli/commands/daemon.ts`, `src/cli/commands/hive-mind.ts`, `src/cli/embeddings/migration/upgrade-coordinator.ts` — migrated to use the utility.
- `src/cli/__tests__/services/worker-daemon-listener-cleanup.test.ts` — 8 regression tests including the 20-construct-then-stop scenario that originally tripped the warning.
- `src/cli/__tests__/shared/resilience/signal-handlers.test.ts` — 6 tests for the new utility.

## Testing

- [x] Unit tests pass (14 new tests across the two new files)
- [x] Full vitest suite: **7256 passing**, 0 failing
- [x] No `MaxListenersExceededWarning` in worker-daemon test stderr
- [x] `npm run build` clean
- [x] ESLint clean on all changed files

Closes #667