### PR TITLE
fix(daemon): update averageDurationMs on worker failures (#666)

### DIFF
--- a/src/cli/__tests__/services/worker-daemon-average-duration.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-average-duration.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Worker Daemon — averageDurationMs across mixed success/failure runs (#666)
+ *
+ * Pre-fix: the success branch updated averageDurationMs but the failure
+ * branch did not, while both branches incremented runCount, so the displayed
+ * average drifted low whenever a worker had any failures. Both branches now
+ * funnel through finalizeRun(), so the average stays correct regardless of
+ * outcome mix.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn().mockImplementation((filePath: string) => {
+      if (typeof filePath === 'string' && (filePath.includes('daemon-state.json') || filePath.includes('config.json'))) {
+        return '{}';
+      }
+      throw new Error('ENOENT');
+    }),
+    appendFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../../services/headless-worker-executor.js', () => ({
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
+    isAvailable: vi.fn().mockResolvedValue(false),
+    on: vi.fn(),
+  })),
+  HEADLESS_WORKER_TYPES: [],
+  HEADLESS_WORKER_CONFIGS: {},
+  isHeadlessWorker: vi.fn().mockReturnValue(false),
+}));
+
+const originalOn = process.on.bind(process);
+vi.spyOn(process, 'on').mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+  if (['SIGTERM', 'SIGINT', 'SIGHUP'].includes(event)) return process;
+  return originalOn(event, handler);
+});
+
+import { WorkerDaemon } from '../../services/worker-daemon.js';
+
+describe('WorkerDaemon averageDurationMs (#666)', () => {
+  let daemon: WorkerDaemon;
+  let synthNow: number;
+  let nowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    synthNow = 1_700_000_000_000;
+    nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => synthNow);
+
+    daemon = new WorkerDaemon('/tmp/test-avg-duration', {
+      autoStart: false,
+      workers: [
+        { type: 'map', intervalMs: 60_000, priority: 'normal', description: 'test', enabled: true },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    nowSpy.mockRestore();
+    vi.restoreAllMocks();
+    await daemon.stop();
+  });
+
+  /**
+   * Drive a single triggerWorker run with a precise observed duration.
+   *
+   * executeWorker reads `startTime = Date.now()` before awaiting
+   * runWorkerLogic, then `durationMs = Date.now() - startTime` after. We
+   * advance the synth clock from inside the runWorkerLogic stub so the
+   * observed duration is exactly `durationMs`, regardless of any other
+   * Date.now() calls in the path (workerId, circuit breaker, lastRun).
+   */
+  async function runOnce(durationMs: number, outcome: 'ok' | 'fail'): Promise<void> {
+    vi.spyOn(
+      daemon as unknown as { runWorkerLogic: () => Promise<unknown> },
+      'runWorkerLogic',
+    ).mockImplementationOnce(async () => {
+      synthNow += durationMs;
+      if (outcome === 'fail') throw new Error('synthetic failure');
+      return { ok: true };
+    });
+    await daemon.triggerWorker('map');
+  }
+
+  it('averageDurationMs equals arithmetic mean across mixed success and failure runs', async () => {
+    for (let i = 0; i < 90; i++) await runOnce(1000, 'ok');
+    for (let i = 0; i < 10; i++) await runOnce(5000, 'fail');
+
+    const state = daemon.getStatus().workers.get('map')!;
+    expect(state.runCount).toBe(100);
+    expect(state.successCount).toBe(90);
+    expect(state.failureCount).toBe(10);
+    const expectedMean = (90 * 1000 + 10 * 5000) / 100;
+    expect(state.averageDurationMs).toBeCloseTo(expectedMean, 5);
+  });
+
+  it('averageDurationMs updates on a failure-only sequence (no success ever runs)', async () => {
+    for (const d of [200, 400, 600]) await runOnce(d, 'fail');
+
+    const state = daemon.getStatus().workers.get('map')!;
+    expect(state.runCount).toBe(3);
+    expect(state.failureCount).toBe(3);
+    expect(state.successCount).toBe(0);
+    expect(state.averageDurationMs).toBeCloseTo((200 + 400 + 600) / 3, 5);
+  });
+});

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -786,6 +786,26 @@ export class WorkerDaemon extends EventEmitter {
   }
 
   /**
+   * Finalize a worker run (shared by success and failure paths). Keeps both
+   * branches' state updates aligned — previously the success branch updated
+   * averageDurationMs but the failure branch did not, while both incremented
+   * runCount, so the displayed average drifted low whenever a worker failed
+   * (#666).
+   */
+  private finalizeRun(
+    workerConfig: WorkerConfig,
+    state: WorkerState,
+    durationMs: number,
+  ): void {
+    state.runCount++;
+    state.lastRun = new Date();
+    state.averageDurationMs =
+      (state.averageDurationMs * (state.runCount - 1) + durationMs) / state.runCount;
+    state.isRunning = false;
+    this.evaluateOverrun(workerConfig, state, durationMs);
+  }
+
+  /**
    * Execute a worker with concurrency control (P0 fix)
    */
   private async executeWorkerWithConcurrencyControl(workerConfig: WorkerConfig): Promise<WorkerResult | null> {
@@ -841,13 +861,8 @@ export class WorkerDaemon extends EventEmitter {
       );
       const durationMs = Date.now() - startTime;
 
-      // Update state
-      state.runCount++;
       state.successCount++;
-      state.lastRun = new Date();
-      state.averageDurationMs = (state.averageDurationMs * (state.runCount - 1) + durationMs) / state.runCount;
-      state.isRunning = false;
-      this.evaluateOverrun(workerConfig, state, durationMs);
+      this.finalizeRun(workerConfig, state, durationMs);
 
       const result: WorkerResult = {
         workerId,
@@ -866,11 +881,8 @@ export class WorkerDaemon extends EventEmitter {
     } catch (error) {
       const durationMs = Date.now() - startTime;
 
-      state.runCount++;
       state.failureCount++;
-      state.lastRun = new Date();
-      state.isRunning = false;
-      this.evaluateOverrun(workerConfig, state, durationMs);
+      this.finalizeRun(workerConfig, state, durationMs);
 
       const result: WorkerResult = {
         workerId,


### PR DESCRIPTION
## Summary

`executeWorker` incremented `state.runCount` in both the success and catch branches, but only updated `state.averageDurationMs` in the success branch — so the displayed mean drifted low whenever a worker had any failures. The reported example: 90 successes @ 1s + 10 failures @ 5s rendered as **0.9 s** instead of the real **1.4 s**.

## Changes

- New private `finalizeRun(workerConfig, state, durationMs)` helper that owns all shared post-run state mutations: `runCount++`, `lastRun`, `averageDurationMs`, `isRunning=false`, `evaluateOverrun(...)`.
- Both branches in `executeWorker` now call `finalizeRun`; only `successCount++` / `failureCount++` stay inline. Removes the copy-paste between the two branches that the `/simplify` reviewer also flagged on PR #665.
- New test `worker-daemon-average-duration.test.ts` covering:
  - Mixed mean (90 ok @ 1000 ms + 10 fail @ 5000 ms → 1400 ms exactly).
  - Failure-only sequence (pre-fix this stuck `averageDurationMs` at 0 forever).

## Test plan

- [x] `npx vitest run src/cli/__tests__/services/worker-daemon` — 6 files / 48 tests pass.
- [x] New mixed-outcome and failure-only assertions both fail against the pre-fix code and pass after.
- [x] `/simplify` pass on the diff.

Closes #666