### PR TITLE
test(worker-daemon): use function-keyword mock for HeadlessWorkerExecutor (#660)

### DIFF
--- a/src/cli/__tests__/services/worker-daemon-average-duration.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-average-duration.test.ts
@@ -28,10 +28,12 @@ vi.mock('fs', async () => {
 });
 
 vi.mock('../../services/headless-worker-executor.js', () => ({
-  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
-    isAvailable: vi.fn().mockResolvedValue(false),
-    on: vi.fn(),
-  })),
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(function () {
+    return {
+      isAvailable: vi.fn().mockResolvedValue(false),
+      on: vi.fn(),
+    };
+  }),
   HEADLESS_WORKER_TYPES: [],
   HEADLESS_WORKER_CONFIGS: {},
   isHeadlessWorker: vi.fn().mockReturnValue(false),

--- a/src/cli/__tests__/services/worker-daemon-cancellation.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-cancellation.test.ts
@@ -28,10 +28,12 @@ vi.mock('fs', async () => {
 });
 
 vi.mock('../../services/headless-worker-executor.js', () => ({
-  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
-    isAvailable: vi.fn().mockResolvedValue(false),
-    on: vi.fn(),
-  })),
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(function () {
+    return {
+      isAvailable: vi.fn().mockResolvedValue(false),
+      on: vi.fn(),
+    };
+  }),
   HEADLESS_WORKER_TYPES: [],
   HEADLESS_WORKER_CONFIGS: {},
   isHeadlessWorker: vi.fn().mockReturnValue(false),

--- a/src/cli/__tests__/services/worker-daemon-listener-cleanup.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-listener-cleanup.test.ts
@@ -31,10 +31,12 @@ vi.mock('fs', async () => {
 });
 
 vi.mock('../../services/headless-worker-executor.js', () => ({
-  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
-    isAvailable: vi.fn().mockResolvedValue(false),
-    on: vi.fn(),
-  })),
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(function () {
+    return {
+      isAvailable: vi.fn().mockResolvedValue(false),
+      on: vi.fn(),
+    };
+  }),
   HEADLESS_WORKER_TYPES: [],
   HEADLESS_WORKER_CONFIGS: {},
   isHeadlessWorker: vi.fn().mockReturnValue(false),

--- a/src/cli/__tests__/services/worker-daemon-overrun.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-overrun.test.ts
@@ -27,10 +27,12 @@ vi.mock('fs', async () => {
 });
 
 vi.mock('../../services/headless-worker-executor.js', () => ({
-  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
-    isAvailable: vi.fn().mockResolvedValue(false),
-    on: vi.fn(),
-  })),
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(function () {
+    return {
+      isAvailable: vi.fn().mockResolvedValue(false),
+      on: vi.fn(),
+    };
+  }),
   HEADLESS_WORKER_TYPES: [],
   HEADLESS_WORKER_CONFIGS: {},
   isHeadlessWorker: vi.fn().mockReturnValue(false),

--- a/src/cli/__tests__/services/worker-daemon-scheduler.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-scheduler.test.ts
@@ -27,10 +27,12 @@ vi.mock('fs', async () => {
 });
 
 vi.mock('../../services/headless-worker-executor.js', () => ({
-  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
-    isAvailable: vi.fn().mockResolvedValue(false),
-    on: vi.fn(),
-  })),
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(function () {
+    return {
+      isAvailable: vi.fn().mockResolvedValue(false),
+      on: vi.fn(),
+    };
+  }),
   HEADLESS_WORKER_TYPES: [],
   HEADLESS_WORKER_CONFIGS: {},
   isHeadlessWorker: vi.fn().mockReturnValue(false),

--- a/src/cli/__tests__/services/worker-daemon.test.ts
+++ b/src/cli/__tests__/services/worker-daemon.test.ts
@@ -30,10 +30,12 @@ vi.mock('fs', async () => {
 
 // Mock the headless executor so constructor doesn't spawn processes
 vi.mock('../../services/headless-worker-executor.js', () => ({
-  HeadlessWorkerExecutor: vi.fn().mockImplementation(() => ({
-    isAvailable: vi.fn().mockResolvedValue(false),
-    on: vi.fn(),
-  })),
+  HeadlessWorkerExecutor: vi.fn().mockImplementation(function () {
+    return {
+      isAvailable: vi.fn().mockResolvedValue(false),
+      on: vi.fn(),
+    };
+  }),
   HEADLESS_WORKER_TYPES: [],
   HEADLESS_WORKER_CONFIGS: {},
   isHeadlessWorker: vi.fn().mockReturnValue(false),


### PR DESCRIPTION
## Summary

- Convert `vi.fn().mockImplementation(() => ({...}))` → `function () { return {...}; }` for the `HeadlessWorkerExecutor` mock in 6 worker-daemon test files.
- Eliminates the `[vitest] The vi.fn() mock did not use 'function' or 'class'` warning that floods stderr during `npm test` (~20+ lines per run).
- Behavior is preserved 1:1; matches existing pattern at `src/cli/__tests__/services/daemon-scheduler-bootstrap.test.ts:21`.

## Why

Vitest 4 routes `new`-invoked mocks through `Reflect.construct(impl, args, new.target)` (see `node_modules/@vitest/spy/dist/index.js:308`). Arrow functions can't be constructed, so `Reflect.construct` throws `TypeError: ... is not a constructor` and emits the warning. The error was previously swallowed by `WorkerDaemon.initHeadlessExecutor()`'s `.catch()` handler, so tests passed while stderr filled with warnings.

## Files

- `src/cli/__tests__/services/worker-daemon.test.ts`
- `src/cli/__tests__/services/worker-daemon-scheduler.test.ts`
- `src/cli/__tests__/services/worker-daemon-cancellation.test.ts`
- `src/cli/__tests__/services/worker-daemon-listener-cleanup.test.ts`
- `src/cli/__tests__/services/worker-daemon-average-duration.test.ts`
- `src/cli/__tests__/services/worker-daemon-overrun.test.ts`

The issue listed two files as a sample; an audit of the codebase surfaced four more with the identical pattern — all fixed.

## Test plan

- [x] `npm test` passes (7256 tests, 0 fail)
- [x] Zero `[vitest] The vi.fn() mock did not use` lines in `npm test` output (was 20+)
- [x] Affected daemon test files all pass with the new mock form
- [x] No source code changes — only test mock plumbing

Closes #660

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)