### PR TITLE
fix(neural): drop perf-target theatre — warns, JSDoc, test titles (#659)

### DIFF
--- a/src/cli/__tests__/neural/README.md
+++ b/src/cli/__tests__/neural/README.md
@@ -16,14 +16,14 @@ Tests for SONA Learning Engine (pure TypeScript implementation):
 
 **Learning from Trajectories (5 tests)**
 - Learning from complete trajectory
-- Performance target validation (<0.05ms)
+- Learning completion smoke check
 - Handling empty trajectories
 - Multi-step trajectory learning
 - Learning time tracking
 
 **Adaptation (6 tests)**
 - Behavior adaptation based on context
-- Performance target validation (<0.1ms)
+- Adaptation completion smoke check
 - Finding similar patterns
 - Route inference from patterns
 - Handling no patterns found
@@ -51,7 +51,7 @@ Tests for reinforcement learning algorithms:
 #### Q-Learning (8 tests)
 - Initialization
 - Q-value updates from trajectory
-- Performance target (<1ms)
+- Update completion smoke check
 - Exploration rate decay
 - Epsilon-greedy action selection
 - Q-value retrieval
@@ -73,7 +73,7 @@ Tests for reinforcement learning algorithms:
 - Initialization
 - Experience replay buffer
 - DQN update mechanism
-- Performance target (<10ms)
+- Update completion smoke check
 - Double DQN support
 - Epsilon-greedy action selection
 - Q-value retrieval
@@ -84,7 +84,7 @@ Tests for reinforcement learning algorithms:
 - Initialization
 - Experience collection
 - PPO update with clipping
-- Performance target (<10ms for small batches)
+- Update completion smoke check
 - GAE advantage computation
 - Policy action sampling
 - Multiple training epochs
@@ -95,7 +95,7 @@ Tests for reinforcement learning algorithms:
 - Trajectory buffer management
 - Incomplete trajectory handling
 - Training on buffered trajectories
-- Performance target (<10ms per batch)
+- Training completion smoke check
 - Return-conditioned action generation
 - Causal attention masking
 - Bounded trajectory buffer
@@ -159,22 +159,6 @@ Tests for pattern learning and ReasoningBank:
 - Pattern evolution event emission
 
 ---
-
-## Performance Targets
-
-All tests validate against these performance targets:
-
-| Operation | Target | Test Coverage |
-|-----------|--------|---------------|
-| SONA learn() | <0.05ms | ✓ |
-| SONA adapt() | <0.1ms | ✓ |
-| Q-Learning update | <1ms | ✓ |
-| SARSA update | <1ms | ✓ |
-| DQN update | <10ms | ✓ |
-| PPO update | <10ms | ✓ |
-| Decision Transformer train | <10ms | ✓ |
-| ReasoningBank retrieval | <10ms | ✓ |
-| ReasoningBank distillation | <10ms | ✓ |
 
 ## Running Tests
 

--- a/src/cli/__tests__/neural/algorithms.test.ts
+++ b/src/cli/__tests__/neural/algorithms.test.ts
@@ -7,8 +7,6 @@
  * - DQN
  * - PPO
  * - Decision Transformer
- *
- * Performance target: <10ms per update
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -71,14 +69,14 @@ describe('Q-Learning Algorithm', () => {
     expect(stats.qTableSize).toBeGreaterThan(0);
   });
 
-  it('should update under performance target (<1ms)', () => {
+  it('should complete update within 10ms (smoke check)', () => {
     const trajectory = createTestTrajectory(10);
 
     const startTime = performance.now();
     qlearning.update(trajectory);
     const elapsed = performance.now() - startTime;
 
-    expect(elapsed).toBeLessThan(10); // Reasonable target for small trajectories
+    expect(elapsed).toBeLessThan(10);
   });
 
   it('should decay exploration rate', () => {
@@ -281,7 +279,7 @@ describe('DQN Algorithm', () => {
     expect(result.epsilon).toBeGreaterThan(0);
   });
 
-  it('should update under performance target (<10ms)', () => {
+  it('should complete update within 500ms (smoke check)', () => {
     // Add experiences
     for (let i = 0; i < 5; i++) {
       dqn.addExperience(createTestTrajectory(10));
@@ -291,8 +289,6 @@ describe('DQN Algorithm', () => {
     dqn.update();
     const elapsed = performance.now() - startTime;
 
-    // Allow generous overhead for neural network in test environment
-    // (actual production target is <10ms, but tests run in CI may be slower)
     expect(elapsed).toBeLessThan(500);
   });
 
@@ -401,7 +397,7 @@ describe('PPO Algorithm', () => {
     expect(result.entropy).toBeGreaterThanOrEqual(0);
   });
 
-  it('should update under performance target (<10ms for small batches)', () => {
+  it('should complete update within 100ms (smoke check)', () => {
     const smallPPO = createPPO({
       miniBatchSize: 16,
       epochs: 1,
@@ -415,7 +411,7 @@ describe('PPO Algorithm', () => {
     smallPPO.update();
     const elapsed = performance.now() - startTime;
 
-    expect(elapsed).toBeLessThan(100); // Allow overhead for PPO complexity
+    expect(elapsed).toBeLessThan(100);
   });
 
   it('should compute GAE advantages', () => {
@@ -517,7 +513,7 @@ describe('Decision Transformer', () => {
     expect(result.accuracy).toBeLessThanOrEqual(1);
   });
 
-  it('should train under performance target (<10ms per batch)', () => {
+  it('should complete training within 100ms (smoke check)', () => {
     for (let i = 0; i < 3; i++) {
       dt.addTrajectory(createTestTrajectory(5));
     }
@@ -526,7 +522,7 @@ describe('Decision Transformer', () => {
     dt.train();
     const elapsed = performance.now() - startTime;
 
-    expect(elapsed).toBeLessThan(100); // Allow overhead for transformer
+    expect(elapsed).toBeLessThan(100);
   });
 
   it('should get action conditioned on target return', () => {

--- a/src/cli/__tests__/neural/patterns.test.ts
+++ b/src/cli/__tests__/neural/patterns.test.ts
@@ -6,8 +6,6 @@
  * - Memory distillation (4-step pipeline)
  * - Trajectory tracking and judgment
  * - Pattern evolution and consolidation
- *
- * Performance target: <10ms for learning operations
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';

--- a/src/cli/__tests__/neural/sona.test.ts
+++ b/src/cli/__tests__/neural/sona.test.ts
@@ -2,12 +2,7 @@
  * SONA Learning Engine Tests
  *
  * Tests for SONA integration with pure TypeScript SonaEngine.
- * Covers initialization, learning, adaptation, mode switching, and performance.
- *
- * Performance targets:
- * - learn(): <0.05ms
- * - adapt(): <0.1ms
- * - Full learning cycle: <10ms
+ * Covers initialization, learning, adaptation, and mode switching.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -155,7 +150,7 @@ describe('SONALearningEngine', () => {
       await expect(engine.learn(trajectory)).resolves.not.toThrow();
     });
 
-    it('should complete learning under performance target', async () => {
+    it('should complete learning within 50ms (smoke check)', async () => {
       const trajectory: Trajectory = {
         trajectoryId: 'perf-test',
         context: 'Performance test',
@@ -237,7 +232,7 @@ describe('SONALearningEngine', () => {
       expect(result.confidence).toBeLessThanOrEqual(1);
     });
 
-    it('should complete adaptation under performance target', async () => {
+    it('should complete adaptation within 50ms (smoke check)', async () => {
       const context: Context = {
         domain: 'code',
         queryEmbedding: new Float32Array(768).fill(0.5),

--- a/src/cli/neural/algorithms/a2c.ts
+++ b/src/cli/neural/algorithms/a2c.ts
@@ -6,8 +6,6 @@
  * - N-step returns
  * - Entropy regularization
  * - Advantage normalization
- *
- * Performance Target: <10ms per update step
  */
 
 import type {
@@ -131,11 +129,8 @@ export class A2CAlgorithm {
 
   /**
    * Perform A2C update
-   * Target: <10ms
    */
   update(): { policyLoss: number; valueLoss: number; entropy: number } {
-    const startTime = performance.now();
-
     if (this.buffer.length < this.config.nSteps) {
       return { policyLoss: 0, valueLoss: 0, entropy: 0 };
     }
@@ -201,11 +196,6 @@ export class A2CAlgorithm {
     this.avgPolicyLoss = totalPolicyLoss / this.buffer.length || 0;
     this.avgValueLoss = totalValueLoss / this.buffer.length || 0;
     this.avgEntropy = totalEntropy / this.buffer.length || 0;
-
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 10) {
-      console.warn(`A2C update exceeded target: ${elapsed.toFixed(2)}ms > 10ms`);
-    }
 
     return {
       policyLoss: this.avgPolicyLoss,

--- a/src/cli/neural/algorithms/curiosity.ts
+++ b/src/cli/neural/algorithms/curiosity.ts
@@ -6,8 +6,6 @@
  * - Random Network Distillation (RND)
  * - Forward and inverse dynamics models
  * - Exploration bonus generation
- *
- * Performance Target: <5ms per forward pass
  */
 
 import type { CuriosityConfig, Trajectory, TrajectoryStep } from '../types.js';
@@ -116,8 +114,6 @@ export class CuriosityModule {
     action: string,
     nextState: Float32Array
   ): number {
-    const startTime = performance.now();
-
     // Encode states to features
     const stateFeature = this.encodeState(state);
     const nextStateFeature = this.encodeState(nextState);
@@ -135,11 +131,6 @@ export class CuriosityModule {
     // Normalize intrinsic reward
     const intrinsic = this.normalizeIntrinsic(error);
 
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 5) {
-      console.warn(`ICM reward exceeded target: ${elapsed.toFixed(2)}ms > 5ms`);
-    }
-
     return intrinsic * this.config.intrinsicCoef;
   }
 
@@ -147,8 +138,6 @@ export class CuriosityModule {
    * Compute RND-based intrinsic reward
    */
   computeRNDReward(state: Float32Array): number {
-    const startTime = performance.now();
-
     // Target network output (fixed random features)
     const targetOutput = this.rndForward(state, this.rndTarget);
 
@@ -164,11 +153,6 @@ export class CuriosityModule {
     // Normalize
     const intrinsic = this.normalizeIntrinsic(error);
 
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 5) {
-      console.warn(`RND reward exceeded target: ${elapsed.toFixed(2)}ms > 5ms`);
-    }
-
     return intrinsic * this.config.intrinsicCoef;
   }
 
@@ -176,8 +160,6 @@ export class CuriosityModule {
    * Update curiosity models from trajectory
    */
   update(trajectory: Trajectory): { forwardLoss: number; inverseLoss: number } {
-    const startTime = performance.now();
-
     if (trajectory.steps.length < 2) {
       return { forwardLoss: 0, inverseLoss: 0 };
     }
@@ -213,11 +195,6 @@ export class CuriosityModule {
     this.updateCount++;
     this.avgForwardLoss = count > 0 ? totalForwardLoss / count : 0;
     this.avgInverseLoss = count > 0 ? totalInverseLoss / count : 0;
-
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 10) {
-      console.warn(`Curiosity update exceeded target: ${elapsed.toFixed(2)}ms > 10ms`);
-    }
 
     return {
       forwardLoss: this.avgForwardLoss,

--- a/src/cli/neural/algorithms/decision-transformer.ts
+++ b/src/cli/neural/algorithms/decision-transformer.ts
@@ -6,8 +6,6 @@
  * - Return-conditioned generation
  * - Causal transformer attention
  * - Offline RL from trajectories
- *
- * Performance Target: <10ms per forward pass
  */
 
 import type {
@@ -125,11 +123,8 @@ export class DecisionTransformer {
 
   /**
    * Train on buffered trajectories
-   * Target: <10ms per batch
    */
   train(): { loss: number; accuracy: number } {
-    const startTime = performance.now();
-
     if (this.trajectoryBuffer.length === 0) {
       return { loss: 0, accuracy: 0 };
     }
@@ -179,11 +174,6 @@ export class DecisionTransformer {
 
     this.updateCount++;
     this.avgLoss = total > 0 ? totalLoss / total : 0;
-
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 10) {
-      console.warn(`DT training exceeded target: ${elapsed.toFixed(2)}ms > 10ms`);
-    }
 
     return {
       loss: this.avgLoss,

--- a/src/cli/neural/algorithms/dqn.ts
+++ b/src/cli/neural/algorithms/dqn.ts
@@ -7,8 +7,6 @@
  * - Double DQN (optional)
  * - Dueling architecture (optional)
  * - Epsilon-greedy exploration
- *
- * Performance Target: <10ms per update step
  */
 
 import type {
@@ -118,11 +116,8 @@ export class DQNAlgorithm {
 
   /**
    * Perform DQN update
-   * Target: <10ms
    */
   update(): { loss: number; epsilon: number } {
-    const startTime = performance.now();
-
     if (this.buffer.length < this.config.miniBatchSize) {
       return { loss: 0, epsilon: this.epsilon };
     }
@@ -183,11 +178,6 @@ export class DQNAlgorithm {
 
     this.updateCount++;
     this.avgLoss = totalLoss / batch.length;
-
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 10) {
-      console.warn(`DQN update exceeded target: ${elapsed.toFixed(2)}ms > 10ms`);
-    }
 
     return {
       loss: this.avgLoss,

--- a/src/cli/neural/algorithms/ppo.ts
+++ b/src/cli/neural/algorithms/ppo.ts
@@ -6,8 +6,6 @@
  * - GAE (Generalized Advantage Estimation)
  * - Value function clipping
  * - Entropy bonus
- *
- * Performance Target: <10ms per update step
  */
 
 import type {
@@ -127,11 +125,8 @@ export class PPOAlgorithm {
 
   /**
    * Perform PPO update
-   * Target: <10ms
    */
   update(): { policyLoss: number; valueLoss: number; entropy: number } {
-    const startTime = performance.now();
-
     if (this.buffer.length < this.config.miniBatchSize) {
       return { policyLoss: 0, valueLoss: 0, entropy: 0 };
     }
@@ -182,11 +177,6 @@ export class PPOAlgorithm {
     // Clear buffer
     this.buffer = [];
     this.updateCount++;
-
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 10) {
-      console.warn(`PPO update exceeded target: ${elapsed.toFixed(2)}ms > 10ms`);
-    }
 
     return {
       policyLoss: numUpdates > 0 ? totalPolicyLoss / numUpdates : 0,

--- a/src/cli/neural/algorithms/q-learning.ts
+++ b/src/cli/neural/algorithms/q-learning.ts
@@ -8,7 +8,6 @@
  * - Experience replay
  *
  * Suitable for smaller state spaces or discretized environments.
- * Performance Target: <1ms per update
  */
 
 import type { Trajectory, RLConfig } from '../types.js';
@@ -87,8 +86,6 @@ export class QLearning {
    * Update Q-values from trajectory
    */
   update(trajectory: Trajectory): { tdError: number } {
-    const startTime = performance.now();
-
     if (trajectory.steps.length === 0) {
       return { tdError: 0 };
     }
@@ -155,11 +152,6 @@ export class QLearning {
 
     this.updateCount++;
     this.avgTDError = totalTDError / trajectory.steps.length;
-
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 1) {
-      console.warn(`Q-learning update exceeded target: ${elapsed.toFixed(2)}ms > 1ms`);
-    }
 
     return { tdError: this.avgTDError };
   }

--- a/src/cli/neural/algorithms/sarsa.ts
+++ b/src/cli/neural/algorithms/sarsa.ts
@@ -6,8 +6,6 @@
  * - State hashing for continuous states
  * - Expected SARSA variant (optional)
  * - Eligibility traces (SARSA-lambda)
- *
- * Performance Target: <1ms per update
  */
 
 import type { Trajectory, RLConfig } from '../types.js';
@@ -88,8 +86,6 @@ export class SARSAAlgorithm {
    * Update Q-values from trajectory using SARSA
    */
   update(trajectory: Trajectory): { tdError: number } {
-    const startTime = performance.now();
-
     if (trajectory.steps.length < 2) {
       return { tdError: 0 };
     }
@@ -166,11 +162,6 @@ export class SARSAAlgorithm {
 
     this.updateCount++;
     this.avgTDError = totalTDError / trajectory.steps.length;
-
-    const elapsed = performance.now() - startTime;
-    if (elapsed > 1) {
-      console.warn(`SARSA update exceeded target: ${elapsed.toFixed(2)}ms > 1ms`);
-    }
 
     return { tdError: this.avgTDError };
   }

--- a/src/cli/neural/index.ts
+++ b/src/cli/neural/index.ts
@@ -4,11 +4,6 @@
  * Complete neural learning module with SONA learning modes,
  * ReasoningBank integration, pattern learning, and RL algorithms.
  *
- * Performance Targets:
- * - SONA adaptation: <0.05ms
- * - Pattern matching: <1ms
- * - Learning step: <10ms
- *
  * @module moflo/cli/neural
  */
 

--- a/src/cli/neural/modes/real-time.ts
+++ b/src/cli/neural/modes/real-time.ts
@@ -57,7 +57,6 @@ export class RealTimeMode extends BaseModeImplementation {
 
   /**
    * Find patterns using cached similarity search
-   * Target: <1ms for k=3
    */
   async findPatterns(
     embedding: Float32Array,
@@ -118,7 +117,6 @@ export class RealTimeMode extends BaseModeImplementation {
 
   /**
    * Fast learning using Micro-LoRA updates
-   * Target: <10ms per batch
    */
   async learn(
     trajectories: Trajectory[],
@@ -151,7 +149,6 @@ export class RealTimeMode extends BaseModeImplementation {
 
   /**
    * Apply LoRA with minimal overhead
-   * Target: <0.05ms
    */
   async applyLoRA(
     input: Float32Array,

--- a/src/cli/neural/pattern-learner.ts
+++ b/src/cli/neural/pattern-learner.ts
@@ -3,11 +3,6 @@
  *
  * Implements pattern extraction, matching, and evolution for
  * continuous learning from agent experiences.
- *
- * Performance Targets:
- * - Pattern matching: <1ms
- * - Pattern extraction: <5ms
- * - Evolution step: <2ms
  */
 
 import type {
@@ -98,7 +93,6 @@ export class PatternLearner {
 
   /**
    * Find matching patterns for a query embedding
-   * Target: <1ms
    */
   findMatches(queryEmbedding: Float32Array, k: number = 3): PatternMatch[] {
     const startTime = performance.now();
@@ -141,11 +135,6 @@ export class PatternLearner {
     this.matchCount++;
     this.totalMatchTime += elapsed;
 
-    // Warn if over target
-    if (elapsed > 1) {
-      console.warn(`Pattern matching exceeded target: ${elapsed.toFixed(2)}ms > 1ms`);
-    }
-
     return result;
   }
 
@@ -163,7 +152,6 @@ export class PatternLearner {
 
   /**
    * Extract a pattern from a trajectory
-   * Target: <5ms
    */
   extractPattern(trajectory: Trajectory, memory?: DistilledMemory): Pattern | null {
     const startTime = performance.now();
@@ -246,7 +234,6 @@ export class PatternLearner {
 
   /**
    * Evolve a pattern based on new experience
-   * Target: <2ms
    */
   evolvePattern(patternId: string, quality: number, context?: string): void {
     const startTime = performance.now();

--- a/src/cli/neural/reasoning-bank.ts
+++ b/src/cli/neural/reasoning-bank.ts
@@ -7,11 +7,6 @@
  * 3. DISTILL - Extract strategy memories from trajectories
  * 4. CONSOLIDATE - Dedup, detect contradictions, prune old patterns
  *
- * Performance Targets:
- * - Retrieval: <10ms with MofloDb HNSW (150x faster than brute-force)
- * - Learning step: <10ms
- * - Consolidation: <100ms
- *
  * @module reasoning-bank
  */
 

--- a/src/cli/neural/reasoningbank-adapter.ts
+++ b/src/cli/neural/reasoningbank-adapter.ts
@@ -8,12 +8,6 @@
  * - Pattern consolidation with deduplication and pruning
  *
  * Based on Algorithm 3 & 4 from ReasoningBank paper.
- *
- * Performance Targets:
- * - Pattern retrieval: <5ms
- * - Verdict judgment: <10ms
- * - Memory distillation: <50ms
- * - Consolidation: <100ms
  */
 
 import type {

--- a/src/cli/neural/sona-integration.ts
+++ b/src/cli/neural/sona-integration.ts
@@ -4,7 +4,6 @@
  * Pure TypeScript SONA engine with:
  * - Trajectory tracking and verdict judgment
  * - Pattern extraction and memory distillation
- * - Sub-0.05ms learning performance target
  * - Clean TypeScript API with proper types
  *
  * @module sona-integration
@@ -139,11 +138,6 @@ function modeToConfig(mode: SONAMode, modeConfig: SONAModeConfig): JsSonaConfig 
 
 /**
  * SONA Learning Engine - wraps pure TS SonaEngine for V3 usage
- *
- * Performance targets:
- * - learn(): <0.05ms
- * - adapt(): <0.1ms
- * - Full learning cycle: <10ms
  */
 export class SONALearningEngine {
   private engine: SonaEngine;
@@ -162,8 +156,6 @@ export class SONALearningEngine {
 
   /**
    * Learn from a trajectory
-   *
-   * Performance target: <0.05ms
    *
    * @param trajectory - Trajectory to learn from
    */

--- a/src/cli/neural/sona-manager.ts
+++ b/src/cli/neural/sona-manager.ts
@@ -3,11 +3,6 @@
  *
  * Manages learning modes and provides adaptive optimization for agent tasks.
  *
- * Performance Targets:
- * - Adaptation: <0.05ms
- * - Pattern retrieval: <1ms
- * - Learning step: <10ms
- *
  * Supported Modes:
  * - real-time: Sub-millisecond adaptation (2200 ops/sec)
  * - balanced: General purpose (+25% quality)
@@ -468,8 +463,6 @@ export class SONAManager {
     input: Float32Array,
     domain?: string
   ): Promise<Float32Array> {
-    const startTime = performance.now();
-
     // Get relevant LoRA weights
     const weights = domain
       ? this.loraWeights.get(domain)
@@ -477,13 +470,6 @@ export class SONAManager {
 
     // Apply adaptations via mode implementation
     const output = await this.modeImpl.applyLoRA(input, weights);
-
-    const latency = performance.now() - startTime;
-
-    // Verify performance target
-    if (latency > 0.05 && this.currentMode !== 'research' && this.currentMode !== 'batch') {
-      console.warn(`SONA adaptation exceeded target: ${latency.toFixed(3)}ms > 0.05ms`);
-    }
 
     return output;
   }

--- a/src/cli/neural/types.ts
+++ b/src/cli/neural/types.ts
@@ -1,11 +1,6 @@
 /**
  * V3 Neural/Learning System Types
  * Core type definitions for SONA learning modes and ReasoningBank integration
- *
- * Performance Targets:
- * - SONA adaptation: <0.05ms
- * - Pattern matching: <1ms
- * - Learning step: <10ms
  */
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The neural module shipped aspirational performance targets that nothing enforced. Per `feedback_no_stale_docs.md` + broken-window discipline, this PR sweeps all three forms in one shot.

- **Library theatre**: `console.warn(...exceeded target...)` blocks fired from inside hot-path `update()`/`train()` methods on every call when an arbitrary self-target was missed. They polluted consumer stderr, didn't fail anything, and provided zero useful telemetry. Removed from 9 files (`q-learning.ts`, `sarsa.ts`, `dqn.ts`, `ppo.ts`, `a2c.ts`, `decision-transformer.ts`, `curiosity.ts` ×3, `sona-manager.ts`, `pattern-learner.ts`).
- **Lying test titles**: 6 tests had titles like `'should update under performance target (<10ms)'` paired with assertions an order of magnitude looser (`<500ms` / `<100ms` / `<50ms`). Renamed to honest `'should complete update within Nms (smoke check)'` matching the actual bound.
- **Orphan JSDoc**: `* Performance Target: <Xms` / `* Target: <Xms` headers throughout `src/cli/neural/**` and the test tree (15+ locations) — same theatre, just in comment form. Swept.
- **Misleading README table**: `__tests__/neural/README.md` shipped a Performance Targets table claiming all numbers were validated. Removed.

Going with **option 2 (demote)** from the issue. Targets earned by measurement, not aspiration — and the current numbers are aspiration. Removing theatre is more honest than rubber-stamping false enforcement.

## Changes

- 19 files changed, 16 insertions(+), 182 deletions(-)
- Pure deletion of dead/misleading code; no behavior changes
- Removed dead `startTime` / `elapsed` locals that only fed the deleted warns
- `pattern-learner.ts` keeps `elapsed` because it legitimately accumulates `totalMatchTime` (exposed via `getStats().avgMatchTimeMs`)

## Testing
- [x] `npm run build` — clean (no unused-var errors from removed `startTime`)
- [x] `npx vitest run src/cli/__tests__/neural/` — 108/108 pass
- [x] `npm test` — 7256 passed, 0 failed (full suite clean)
- [x] `grep "exceeded target" src/cli/` — zero matches
- [x] `grep "Performance Target\|Performance target" src/cli/neural/` — zero matches in source; remaining hits are unrelated config UI flags in `hooks/`

## Acceptance Criteria
- [x] No `exceeded target` strings remain in `src/cli/neural/**`
- [x] No `exceeded target` stderr lines on a clean `npm test` run
- [x] Test titles in `algorithms.test.ts` and `sona.test.ts` match the bounds the assertions actually enforce
- [x] No test claims a "performance target" budget it doesn't enforce
- [x] `__tests__/neural/README.md` does not claim aspirational targets are validated
- [x] All affected unit tests still pass

Closes #659