### PR TITLE
cleanup(smoke): re-baseline install-size budget post-workspace-collapse (#605)

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -42,7 +42,7 @@ Follow docs/BUILD.md exactly. Every step must succeed before proceeding to the n
 npm run build
 ```
 
-This syncs the version to `src/cli/version.ts` and `src/cli/package.json` via the `version` lifecycle script, then compiles all TypeScript.
+This syncs the version to `src/cli/version.ts` via the `version` lifecycle script, then compiles all TypeScript.
 
 **Must exit 0.** If it fails, stop and fix the build error.
 
@@ -67,7 +67,7 @@ All checks must pass (warnings are acceptable on Windows for sandbox tier). If d
 Commit the version bump files:
 
 ```bash
-git add package.json package-lock.json src/cli/package.json src/cli/version.ts
+git add package.json package-lock.json src/cli/version.ts
 git commit -m "chore: bump version to <new-version>"
 git push origin main
 ```
@@ -161,4 +161,4 @@ Installed:  moflo@<new-version> (devDependency)
 - Never use `--force` on npm publish
 - Never install moflo globally — it is always a local devDependency
 - If any step fails, stop and fix the issue before proceeding — do not skip steps
-- The `prepublishOnly` script in package.json runs `check-version-sync.mjs && npm run build` automatically, so npm publish will fail-fast if versions are out of sync
+- The `prepublishOnly` script in package.json runs `npm run build` automatically, so npm publish will fail-fast on any TypeScript or asset-bundling error

--- a/harness/consumer-smoke/README.md
+++ b/harness/consumer-smoke/README.md
@@ -22,7 +22,8 @@ Takes ~30–60 seconds; most of it is `npm install` in the scratch consumer.
 |-------|------|----------|
 | Pack | `pack` | `npm pack` produces a tarball |
 | Install | `install` | Tarball installs cleanly into a scratch consumer |
-| Forbidden deps | `forbidden-deps` | `node_modules` + full dep tree free of `agentdb`, `agentic-flow`, `@ruvector/*`, `ruvector`, `onnxruntime-node` |
+| Forbidden deps | `forbidden-deps` | `node_modules` + full dep tree free of `agentdb`, `agentic-flow`, `@ruvector/*`, `ruvector`, `@xenova/transformers`, `fastembed` |
+| Required deps | `required-deps` | `onnxruntime-node` and `@anush008/tokenizers` are present (embedding stack intact) |
 | CLI | `cli-version` | `flo --version` reports a semver |
 | CLI | `doctor` | `flo doctor --json` runs (exit 0 or 1) |
 | Memory | `memory-init` | `flo memory init` initializes the sql.js+HNSW store |
@@ -34,7 +35,7 @@ Takes ~30–60 seconds; most of it is `npm install` in the scratch consumer.
 | Hooks | `hooks-list / pre-task / post-edit` | Hook commands succeed end-to-end |
 | Skill | `flo-skill` | `.claude/skills/fl/SKILL.md` ships inside the package |
 | Invariants | `no-stray-rvf`, `no-agentdb-rvf` | No surprise `.rvf` files at consumer root |
-| Surface | `moflo-install-size` | Enforces installed size budget (warn > 100 MB, fail > 120 MB) |
+| Surface | `moflo-install-size` | Enforces installed size budget (warn > 95 MB, fail > 110 MB) |
 
 ## Exit codes
 
@@ -44,12 +45,9 @@ Takes ~30–60 seconds; most of it is `npm install` in the scratch consumer.
 
 ## Known regressions (WARN, do not block)
 
-Some forbidden deps still leak through pending a dedicated fix. These are
-tracked in `lib/checks.mjs` under `KNOWN_FORBIDDEN_REGRESSIONS` with a link to
-the issue. Trim entries as fixes ship:
-
-- `onnxruntime-node` — transitive of `@xenova/transformers@2.17.2`
-  (in moflo's optionalDependencies). Blocks epic #501 Story 1 ship.
+`KNOWN_FORBIDDEN_REGRESSIONS` in `lib/checks.mjs` lists forbidden deps that
+still leak through pending a dedicated fix. Currently empty — every entry on
+the `FORBIDDEN_DEPS` list is a hard fail.
 
 ## Cross-platform
 
@@ -87,9 +85,9 @@ merge.
 ## Environment variables
 
 - `MOFLO_INSTALL_SIZE_WARN_MB` — Override the install-size warn threshold
-  (default: 100 MB). Non-positive or non-numeric values fall back to the default.
+  (default: 95 MB). Non-positive or non-numeric values fall back to the default.
 - `MOFLO_INSTALL_SIZE_MAX_MB` — Override the install-size fail threshold
-  (default: 120 MB). Use deliberately (e.g. a model bump) and land the new
+  (default: 110 MB). Use deliberately (e.g. a model bump) and land the new
   ceiling in the same PR as a README note so the budget stays a real contract.
 
 ## When to run

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -581,10 +581,14 @@ export function consumerInvariants(consumerDir) {
   }
 }
 
-// Defaults headroom over the README's ~80 MB post-prune claim.
+// Re-baselined post-workspace-collapse (#605, epic #586): consumer install
+// measured at ~83 MB on Windows (moflo pkg 10 MB + ORT/tokenizers/sql.js).
+// Warn ≈ +15% headroom, fail ≈ +33% headroom — same ratios as the prior
+// 100/120 budget held against an ~80 MB anchor, just tightened to the
+// current floor so a regression is caught before the budget creeps.
 // Override via MOFLO_INSTALL_SIZE_{WARN,MAX}_MB (see harness README).
-const INSTALL_SIZE_WARN_MB_DEFAULT = 100;
-const INSTALL_SIZE_MAX_MB_DEFAULT = 120;
+const INSTALL_SIZE_WARN_MB_DEFAULT = 95;
+const INSTALL_SIZE_MAX_MB_DEFAULT = 110;
 
 function readEnvMb(name, fallback) {
   const raw = process.env[name];

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -51,11 +51,14 @@ function baseEnv(projectDir: string): Record<string, string> {
   };
 }
 
-/** Run gate.cjs with a subcommand and env vars. Returns { stdout, stderr, exitCode }. */
+/** Run gate.cjs with a subcommand and env vars. Returns { stdout, stderr, exitCode }.
+ *  Timeout is generous because under isolation-batch contention (Windows in
+ *  particular) `node + load gate.cjs` can take well over the 5 s the test
+ *  used to allow; the test measures behavior, not speed. */
 function runGate(command: string, env: Record<string, string>): { stdout: string; stderr: string; exitCode: number } {
   try {
     const stdout = execFileSync('node', [GATE, command], {
-      env, encoding: 'utf-8', timeout: 5000,
+      env, encoding: 'utf-8', timeout: 30000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     return { stdout, stderr: '', exitCode: 0 };
@@ -99,11 +102,12 @@ function runEsmWithStdin(
     proc.stdin.write(JSON.stringify(stdinJson));
     proc.stdin.end();
 
-    // Safety timeout
+    // Safety timeout — generous so isolation-batch contention can't false-fail
+    // a behavior test (paired with the 30 s runGate budget above).
     setTimeout(() => {
       try { proc.kill(); } catch {}
       resolve({ stdout, stderr, exitCode: -1 });
-    }, 8000);
+    }, 30000);
   });
 }
 

--- a/tests/bin/process-manager.test.ts
+++ b/tests/bin/process-manager.test.ts
@@ -113,14 +113,17 @@ describe('spawn()', () => {
       return { pid: r.pid };
     `);
 
-    // Wait a moment for it to exit
-    try { execFileSync('node', ['-e', 'setTimeout(()=>{},500)'], { timeout: 2000 }); } catch { /* ok */ }
-
-    // Respawn with same label should succeed (not skipped)
+    // Poll getActive until the OS reaper clears the previous PID, then respawn.
+    // Same fix as the `getActive returns only alive processes` test above —
+    // any fixed sleep is wrong by construction (#672 leaked at 500 ms and 2 s).
     const r2 = runPM(root, `
+      const deadline = Date.now() + 20000;
+      while (pm.getActive().some((p) => p.label === 'short-lived') && Date.now() < deadline) {
+        await new Promise((res) => setTimeout(res, 100));
+      }
       const r = pm.spawn('node', ['-e', 'setTimeout(()=>{},60000)'], 'short-lived');
       return { pid: r.pid, skipped: r.skipped };
-    `);
+    `, 30000);
     expect(r2.skipped).toBe(false);
     expect(r2.pid).not.toBe(r1.pid);
 


### PR DESCRIPTION
## Summary

Re-baseline the consumer install-size gate to reflect the post-collapse footprint, plus three adjacent stale-doc fixes that surfaced during the pipeline audit. Also includes the de-flaking of two pre-existing bin/ tests that flipped between runs (#684, fixed in this PR).

| | Before | After |
|---|---:|---:|
| Warn threshold | 100 MB | **95 MB** |
| Fail threshold | 120 MB | **110 MB** |
| Headroom over current ~83 MB | 21% / 45% | 15% / 33% |

## Changes

### Install-size budget rebaseline (#605)

- `harness/consumer-smoke/lib/checks.mjs` — `INSTALL_SIZE_WARN_MB_DEFAULT` 100 → 95, `INSTALL_SIZE_MAX_MB_DEFAULT` 120 → 110, comment now describes the ratio derivation instead of anchoring on a stale README number.
- `harness/consumer-smoke/README.md`:
  - `forbidden-deps` row corrected — `onnxruntime-node` moved out (it's in `REQUIRED_DEPS` since #613) and `@xenova/transformers` + `fastembed` listed accurately. Added a `required-deps` row.
  - "Known regressions" section was fully obsolete (`KNOWN_FORBIDDEN_REGRESSIONS` is an empty Set). Replaced with a one-liner.
  - Env-var defaults updated to match new thresholds.
- `.claude/skills/publish/SKILL.md` — three stale references removed: `src/cli/package.json` (file doesn't exist), `scripts/check-version-sync.mjs` (script doesn't exist), and `prepublishOnly` claim that mentioned both.

### bin/ test de-flake (#684 — bundled because both flakes blocked verification of the rebaseline)

- `tests/bin/process-manager.test.ts` — replaced fixed `setTimeout(500)` wait-for-OS-reaper with the same `getActive()` polling pattern the file already uses for the analogous `getActive returns only alive processes` test (L172-173 has the standing comment about why fixed sleeps are wrong by construction; the respawn test was missed in #672's fix).
- `tests/bin/gate-helpers.test.ts` — bumped `runGate` `execFileSync` timeout from 5 s to 30 s, and `runEsmWithStdin` safety timeout from 8 s to 30 s. These tests measure behavior, not speed; under isolation-batch load on Windows the 5 s budget for `node + load gate.cjs` was getting eaten and surfacing as `exitCode 1` (ETIMEDOUT) masquerading as the expected behavior failure (e.g. "exempts CLAUDE.md from read gate" expected 0, got 1).

## Pipeline audit (zero changes needed)

- No `scripts/release/` directory exists; publish flow lives in `package.json` `prepublishOnly` + the `/publish` skill.
- CI workflows (`ci.yml`, `consumer-install-smoke.yml`, `sandbox-image.yml`) reference no workspace manifests — PR #680 already purged residue and added the 5-invariant drift guard.
- `npm pack --dry-run` produces a clean 1370-file / 9.98 MB-unpacked tarball with **zero stale paths** (no `src/modules/`, no `@moflo/*`, no `packages/`).
- `package.json` `files` array references no deleted module paths.

## Acceptance criteria (#605)

- [x] `npm publish --dry-run` produces the same tarball contents as today (verified — 1370 files, no stale paths).
- [x] Install-size budget threshold updated to reflect post-collapse footprint.
- [x] No publish-pipeline step references workspace manifests.
- [x] #568 install-size monitoring updated and passing.

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:smoke` — 37 passed / 0 failed / 0 warn; `moflo-install-size` reports `[PASS] 82.8 MB total (moflo pkg 10.0 MB; warn > 95 MB, fail > 110 MB)`
- [x] `npm test` — **three consecutive clean runs** (7256 passed / 0 failed each) after the de-flake fix; pre-fix runs hit different bin/ test failures across runs.
- [ ] CI smoke matrix (ubuntu / macos / windows) passes on this PR

## Follow-ups filed

- **#683** — investigate the 1.4 MB unpacked-tarball spike between `moflo@4.8.85` (9.07 MB) and `moflo@4.8.87` (10.46 MB). The collapse was net-neutral on tarball size; the spike comes from new `dist/src/cli/movector/` + hooks/tools growth + epic #648.

Closes #605
Closes #684
Parent: #586