### PR TITLE
docs(687): restore docs/modules/cli.md as post-collapse pointer/index

### DIFF
--- a/docs/modules/cli.md
+++ b/docs/modules/cli.md
@@ -1,0 +1,35 @@
+# cli
+
+> **Single-package home — there is no `@moflo/cli` workspace package.**
+> After [ADR-0001](../adr/0001-collapse-moflo-workspace-packages.md) (epic [#586](https://github.com/eric-cielo/moflo/issues/586), final story [#602](https://github.com/eric-cielo/moflo/issues/602)), `src/cli/` is the entire `moflo` source tree. This file is the index for the sibling per-subsystem docs in this directory.
+
+For the authoritative layout of `src/cli/`, see [src/cli/CLAUDE.md](../../src/cli/CLAUDE.md).
+
+## Collapsed ex-`@moflo/*` subsystems
+
+Each of these used to be a workspace package; all are now inlined under `src/cli/<area>/` and ship inside the single `moflo` tarball.
+
+- [aidefence.md](aidefence.md) — AI manipulation defense (`src/cli/aidefence/`)
+- [embeddings.md](embeddings.md) — fastembed neural embeddings (`src/cli/embeddings/`)
+- [guidance.md](guidance.md) — long-horizon governance (`src/cli/guidance/`)
+- [hooks.md](hooks.md) — hook registry, daemons, statusline, workers (`src/cli/hooks/`)
+- [memory.md](memory.md) — MofloDb adapter, HNSW, learning bridge (`src/cli/memory/`)
+- [neural.md](neural.md) — SONA, ReasoningBank, RL algorithms (`src/cli/neural/`)
+- [security.md](security.md) — deleted as dead code in [#594](https://github.com/eric-cielo/moflo/issues/594)
+- [shared.md](shared.md) — shared types / utilities (`src/cli/shared/`)
+- [spells.md](spells.md) — spell engine (`src/cli/spells/`)
+- [swarm.md](swarm.md) — coordination engine (`src/cli/swarm/`)
+
+## Subtrees that were never workspace packages
+
+These have always lived at the root of the cli source tree and have no per-subsystem doc — see `src/cli/CLAUDE.md` for the layout summary, or read the sources directly.
+
+- `commands/` — 40+ CLI commands (`flo doctor`, `flo memory`, `flo spell`, `flo hooks`, …)
+- `init/` — `flo init` wizard, `claudemd-generator`, settings, MCP config
+- `mcp-server.ts`, `mcp-client.ts`, `mcp-tools/` — MCP entry points and tool definitions
+- `plugins/` — plugin discovery and store
+- `services/` — `engine-loader`, `grimoire-builder`, `findProjectRoot`, path anchors
+
+## Binary entry
+
+`bin/cli.js` proxies to compiled `dist/src/cli/index.js`. The `flo`, `moflo`, and `claude-flow` aliases all point at the same entry.


### PR DESCRIPTION
## Summary

PR #686 (closing #606) deleted `docs/modules/cli.md` outright as a stale 452-line pre-collapse README dump. Correct in spirit but wrong in shape — the deletion left three real gaps:

1. **Symmetry break.** `docs/modules/` has 10 sibling pointers (aidefence, embeddings, guidance, hooks, memory, neural, security, shared, spells, swarm) but no overview / landing for the directory.
2. **No coverage of always-was-cli subtrees.** `commands/`, `init/`, `mcp-tools/`, `mcp-server.ts`, `services/`, `plugins/` were never workspace packages and don't have a per-subsystem doc — but should still appear in a discoverable index.
3. **404 risk** for old GitHub issue / commit links that referenced `docs/modules/cli.md`.

Restore as a 35-line thin pointer matching the shape of the other `docs/modules/*.md` files: explicit "no `@moflo/cli` workspace package exists" framing, links to ADR-0001 and `src/cli/CLAUDE.md` for the authoritative layout, indexes all 10 sibling subsystem docs, and enumerates the never-was-a-package subtrees so the directory's TOC is honest.

## Test plan

- [x] `src/cli/__tests__/services/published-package-drift-guard.test.ts` — 5/5 pass (the `@moflo/cli` mention follows the "no longer exists" historical-marker idiom that the test's `HISTORICAL_MARKERS` regex allows)
- [x] Listed subtrees verified to exist on disk: `commands/`, `init/`, `mcp-client.ts`, `mcp-server.ts`, `mcp-tools/`, `plugins/`, `services/`
- [x] Every sibling `docs/modules/*.md` link resolves
- [x] File is 35 lines (under the < 60-line AC budget)

Closes #687

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)