### PR TITLE
perf(security-tools): parallelize aidefence_analyze fan-out

### DIFF
--- a/src/cli/__tests__/security-tools-concurrency.test.ts
+++ b/src/cli/__tests__/security-tools-concurrency.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Concurrency test for security MCP handler.
+ *
+ * Guards the perf fix from #607: aidefence_analyze must run getBestMitigation
+ * lookups in parallel, not sequentially.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../mcp-tools/aidefence-moflodb-store.js', () => ({
+  tryCreateMofloDbStore: vi.fn(async () => null),
+}));
+
+const mockDetect = vi.fn();
+const mockGetBestMitigation = vi.fn();
+const mockSearchSimilarThreats = vi.fn(async () => []);
+
+vi.mock('../aidefence/index.js', () => ({
+  createAIDefence: vi.fn(() => ({
+    detect: mockDetect,
+    getBestMitigation: mockGetBestMitigation,
+    searchSimilarThreats: mockSearchSimilarThreats,
+  })),
+}));
+
+import { securityTools } from '../mcp-tools/security-tools.js';
+
+const aidefenceAnalyzeTool = securityTools.find(t => t.name === 'aidefence_analyze');
+
+describe('aidefence_analyze concurrency', () => {
+  beforeEach(() => {
+    mockDetect.mockReset();
+    mockGetBestMitigation.mockReset();
+    mockSearchSimilarThreats.mockClear();
+  });
+
+  it('runs getBestMitigation lookups in parallel', async () => {
+    expect(aidefenceAnalyzeTool).toBeDefined();
+    const threatTypes = [
+      'prompt_injection',
+      'jailbreak',
+      'data_exfiltration',
+      'context_manipulation',
+      'social_engineering',
+    ];
+    const threats = threatTypes.map(type => ({
+      type,
+      severity: 'high',
+      confidence: 0.9,
+      description: 'test',
+    }));
+    mockDetect.mockResolvedValue({
+      safe: false,
+      threats,
+      piiFound: false,
+      detectionTimeMs: 1,
+    });
+    const delayMs = 50;
+    mockGetBestMitigation.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      return { strategy: 'block', effectiveness: 0.9 };
+    });
+
+    const start = performance.now();
+    const result = await aidefenceAnalyzeTool!.handler({ input: 'test', searchSimilar: false });
+    const elapsed = performance.now() - start;
+
+    // Sequential would be 5 × 50ms = 250ms; parallel should land near 50ms.
+    // Use a generous bound (half of sequential) to keep this stable on busy CI.
+    expect(elapsed).toBeLessThan((threatTypes.length * delayMs) / 2);
+
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+    expect(payload.mitigations).toHaveLength(threatTypes.length);
+    expect(payload.mitigations.map((m: { threatType: string }) => m.threatType)).toEqual(threatTypes);
+  });
+
+  it('filters out threats with no available mitigation', async () => {
+    mockDetect.mockResolvedValue({
+      safe: false,
+      threats: [
+        { type: 'prompt_injection', severity: 'high', confidence: 0.9, description: '' },
+        { type: 'jailbreak', severity: 'high', confidence: 0.9, description: '' },
+        { type: 'social_engineering', severity: 'high', confidence: 0.9, description: '' },
+      ],
+      piiFound: false,
+      detectionTimeMs: 1,
+    });
+    mockGetBestMitigation.mockImplementation(async (type: string) => {
+      if (type === 'jailbreak') return null;
+      return { strategy: 'block', effectiveness: 0.8 };
+    });
+
+    const result = await aidefenceAnalyzeTool!.handler({ input: 'test', searchSimilar: false });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(payload.mitigations).toHaveLength(2);
+    expect(payload.mitigations.map((m: { threatType: string }) => m.threatType)).toEqual([
+      'prompt_injection',
+      'social_engineering',
+    ]);
+  });
+});

--- a/src/cli/mcp-tools/security-tools.ts
+++ b/src/cli/mcp-tools/security-tools.ts
@@ -144,37 +144,33 @@ const aidefenceAnalyzeTool: MCPTool = {
       const defender = await getAIDefence();
       const result = await defender.detect(input);
 
+      // Mitigation lookups and similar-threat search share no data dependency,
+      // so fan them out together (#607).
+      const [mitigations, similar] = await Promise.all([
+        Promise.all(
+          result.threats.map(async (threat) => {
+            const mitigation = await defender.getBestMitigation(
+              threat.type as Parameters<typeof defender.getBestMitigation>[0]
+            );
+            return mitigation
+              ? { threatType: threat.type, strategy: mitigation.strategy, effectiveness: mitigation.effectiveness }
+              : null;
+          })
+        ),
+        searchSimilar ? defender.searchSimilarThreats(input, { k }) : Promise.resolve([]),
+      ]);
+
       const analysis: Record<string, unknown> = {
         detection: {
           safe: result.safe,
           threats: result.threats,
           piiFound: result.piiFound,
         },
-        mitigations: [] as Array<{ threatType: string; strategy: string; effectiveness: number }>,
-        similarPatterns: [] as Array<unknown>,
+        mitigations: mitigations.filter((m): m is NonNullable<typeof m> => m !== null),
+        similarPatterns: searchSimilar
+          ? similar.map(p => ({ pattern: p.pattern, type: p.type, effectiveness: p.effectiveness }))
+          : [],
       };
-
-      // Get mitigations for detected threats
-      for (const threat of result.threats) {
-        const mitigation = await defender.getBestMitigation(threat.type as Parameters<typeof defender.getBestMitigation>[0]);
-        if (mitigation) {
-          (analysis.mitigations as Array<unknown>).push({
-            threatType: threat.type,
-            strategy: mitigation.strategy,
-            effectiveness: mitigation.effectiveness,
-          });
-        }
-      }
-
-      // Search similar patterns
-      if (searchSimilar) {
-        const similar = await defender.searchSimilarThreats(input, { k });
-        analysis.similarPatterns = similar.map(p => ({
-          pattern: p.pattern,
-          type: p.type,
-          effectiveness: p.effectiveness,
-        }));
-      }
 
       return {
         content: [{


### PR DESCRIPTION
## Summary

- Replace sequential `for…of` over `result.threats` in `aidefence_analyze` with `Promise.all`, so N mitigation lookups run concurrently.
- Hoist `searchSimilarThreats` into the same fan-out — independent of mitigations.
- Drop the empty-array stub init for `analysis.mitigations` / `analysis.similarPatterns`; assign filtered results directly.

## Why

`getBestMitigation()` round-trips the learning service / vector store. With N detected threats the handler waited N × round-trip + 1 similar-search serially.

## Changes

- `src/cli/mcp-tools/security-tools.ts` — single `Promise.all` for both fan-outs.
- `src/cli/__tests__/security-tools-concurrency.test.ts` — vi.mock 50ms delay on `getBestMitigation`, assert handler completes in well under N × 50ms; second case verifies null-mitigation filtering preserves order.

## Testing

- [x] New concurrency test passes (`security-tools-concurrency.test.ts` — 2 tests)
- [x] aidefence-integration suite passes (no behavior change)
- [x] mcp-tools-deep schema suite passes
- [x] Full repo suite: 7254 passed / 0 failed
- [x] `tsc` clean

Closes #607