### PR TITLE
fix(683): drop .d.ts from npm tarball — restore prior shrink

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "files": [
     "bin/**",
     "dist/src/cli/**/*.js",
-    "dist/src/cli/**/*.d.ts",
     "dist/src/cli/**/*.yaml",
     "!dist/**/*.map",
     "src/cli/agents/**",


### PR DESCRIPTION
## Summary
- Removes `dist/src/cli/**/*.d.ts` from `package.json` `files` array.
- Restores the explicit decision in 085c092bc (April 2026) silently reverted by the workspace-collapse refactor (PR #628, commit 0435fd0ed).
- Brings the tarball below the 4.8.85 baseline.

## Findings
The `+1.39 MB / +556 files` jump in moflo@4.8.87 (#683) is entirely `.d.ts` declaration files re-introduced when the `files` array was reshaped during workspace collapse. 4.8.86 shipped **0** `.d.ts`; 4.8.87 shipped **551** at 2.58 MB. moflo is consumed as a CLI devDependency — declarations are not referenced by consumer code.

## Result (`npm pack --dry-run`)

| | files | unpacked |
|---|---|---|
| 4.8.85 / 4.8.86 | 810 | 9.07 MB |
| 4.8.87 (current) | 1366 | 10.46 MB |
| **This PR** | **817** | **8.45 MB** |

`.d.ts` count in tarball: 551 → 0. Consumer install: 83 MB → 81.3 MB. tsc still emits .d.ts locally for incremental builds / IDE — they just no longer ship.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 7254 passed / 0 failed
- [x] `npm run test:smoke` — 37 passed / 0 failed (consumer probes load moflo internals via `.js`, not types)
- [x] `npm run build` clean
- [x] `npm pack --dry-run` shows 0 `.d.ts` and 8.45 MB unpacked

## Followups
Filed #690 covering two unrelated easy wins surfaced during the post-fix pass (v3-* skill ship policy, stale `SKILLS_MAP` entries in `init/executor.ts`).

Closes #683