### PR TITLE
fix(697): replace broken callMCPTool stop path with PID-file shutdown

### DIFF
--- a/src/cli/__tests__/p1-commands.test.ts
+++ b/src/cli/__tests__/p1-commands.test.ts
@@ -60,26 +60,9 @@ vi.mock('../mcp-client.js', () => ({
       };
     }
 
-    if (toolName === 'swarm_stop') {
-      return { stopped: true, stoppedAt: new Date().toISOString() };
-    }
-
     // MCP tools
-    if (toolName === 'mcp_start') {
-      return {
-        serverId: 'mcp-mock-123',
-        port: input.port || 3000,
-        transport: input.transport || 'stdio',
-        startedAt: new Date().toISOString()
-      };
-    }
-
     if (toolName === 'mcp_status') {
       return { running: true, port: 3000, transport: 'stdio' };
-    }
-
-    if (toolName === 'mcp_stop') {
-      return { stopped: true };
     }
 
     // Memory tools
@@ -558,14 +541,119 @@ describe('Start Command', () => {
   });
 
   describe('start stop', () => {
-    it('should stop system', async () => {
+    // Helper: simulate a daemon.pid file containing the given pid string.
+    // Other reads (config.yaml) keep returning the default YAML.
+    const mockDaemonPidFile = (pid: string) => {
+      vi.mocked(fs.readFileSync).mockImplementation((p) =>
+        String(p).includes('daemon.pid')
+          ? pid
+          : 'version: 3.0.0\nswarm:\n  topology: mesh'
+      );
+    };
+
+    // Helper: simulate no daemon.pid file (readFileSync throws ENOENT).
+    const mockNoDaemonPidFile = () => {
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (String(p).includes('daemon.pid')) {
+          const err = new Error('ENOENT') as NodeJS.ErrnoException;
+          err.code = 'ENOENT';
+          throw err;
+        }
+        return 'version: 3.0.0\nswarm:\n  topology: mesh';
+      });
+    };
+
+    const spyOnKill = (impl: NodeJS.Process['kill']) =>
+      vi.spyOn(process, 'kill').mockImplementation(impl);
+
+    it('should stop system when no daemon is running', async () => {
+      mockNoDaemonPidFile();
       ctx.flags = { force: true, _: [] };
 
       const stopCmd = startCommand.subcommands?.find(c => c.name === 'stop');
       const result = await stopCmd!.action!(ctx);
 
       expect(result.success).toBe(true);
-      expect(result.data).toHaveProperty('stopped', true);
+      expect(result.data).toMatchObject({
+        stopped: true,
+        daemonWasRunning: false,
+        signaledPid: null
+      });
+    });
+
+    it('should not call any MCP tool during stop (regression for #697)', async () => {
+      mockNoDaemonPidFile();
+      const { callMCPTool } = await import('../mcp-client.js');
+      vi.mocked(callMCPTool).mockClear();
+      ctx.flags = { force: true, _: [] };
+
+      const stopCmd = startCommand.subcommands?.find(c => c.name === 'stop');
+      await stopCmd!.action!(ctx);
+
+      expect(callMCPTool).not.toHaveBeenCalled();
+    });
+
+    it('should signal the daemon and remove the PID file when one exists', async () => {
+      mockDaemonPidFile('12345');
+      const killSpy = spyOnKill((() => true) as NodeJS.Process['kill']);
+      ctx.flags = { force: false, _: [] };
+
+      try {
+        const stopCmd = startCommand.subcommands?.find(c => c.name === 'stop');
+        const result = await stopCmd!.action!(ctx);
+
+        expect(result.success).toBe(true);
+        expect(killSpy).toHaveBeenCalledWith(12345, 'SIGTERM');
+        expect(fs.unlinkSync).toHaveBeenCalled();
+        expect(result.data).toMatchObject({
+          stopped: true,
+          daemonWasRunning: true,
+          signaledPid: 12345
+        });
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
+    it('should send SIGKILL when --force is passed', async () => {
+      mockDaemonPidFile('54321');
+      const killSpy = spyOnKill((() => true) as NodeJS.Process['kill']);
+      ctx.flags = { force: true, _: [] };
+
+      try {
+        const stopCmd = startCommand.subcommands?.find(c => c.name === 'stop');
+        await stopCmd!.action!(ctx);
+
+        expect(killSpy).toHaveBeenCalledWith(54321, 'SIGKILL');
+      } finally {
+        killSpy.mockRestore();
+      }
+    });
+
+    it('should treat ESRCH (no such process) as benign', async () => {
+      mockDaemonPidFile('99999');
+      const killSpy = spyOnKill((() => {
+        const err = new Error('No such process') as NodeJS.ErrnoException;
+        err.code = 'ESRCH';
+        throw err;
+      }) as NodeJS.Process['kill']);
+      ctx.flags = { force: false, _: [] };
+
+      try {
+        const stopCmd = startCommand.subcommands?.find(c => c.name === 'stop');
+        const result = await stopCmd!.action!(ctx);
+
+        // Stale PID file is treated as "daemon already exited" — still cleans up.
+        expect(result.success).toBe(true);
+        expect(fs.unlinkSync).toHaveBeenCalled();
+        expect(result.data).toMatchObject({
+          stopped: true,
+          daemonWasRunning: true,
+          signaledPid: null
+        });
+      } finally {
+        killSpy.mockRestore();
+      }
     });
   });
 

--- a/src/cli/__tests__/tool-names.test.ts
+++ b/src/cli/__tests__/tool-names.test.ts
@@ -43,11 +43,6 @@ describe('MCP Tool Name Constants', () => {
     expect(toolNames.TOOL_HIVE_MIND_MEMORY).toBe('hive-mind_memory');
   });
 
-  it('exports infrastructure tool names', () => {
-    expect(toolNames.TOOL_MCP_STOP).toBe('mcp_stop');
-    expect(toolNames.TOOL_SWARM_STOP).toBe('swarm_stop');
-  });
-
   it('all exports are strings', () => {
     for (const [key, value] of Object.entries(toolNames)) {
       expect(typeof value).toBe('string');

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -133,32 +133,12 @@ const startAction = async (ctx: CommandContext): Promise<CommandResult> => {
 
     spinner.succeed(`Swarm initialized (${finalTopology})`);
 
-    // Step 2: Start MCP server if configured (stdio only)
-    let mcpResult: Record<string, unknown> | null = null;
+    // Step 2: Note MCP server lifecycle is external
+    // The MCP server is launched directly by Claude Code (or via `flo mcp serve`)
+    // as a stdio subprocess — there is no `mcp_start` MCP tool. This `flo start`
+    // command does not own that process's lifecycle.
     if (autoStartMcp) {
-      spinner.setText('Starting MCP server...');
-      spinner.start();
-
-      try {
-        mcpResult = await callMCPTool<{
-          serverId: string;
-          transport: string;
-          startedAt: string;
-        }>('mcp_start', {
-          transport: mcpConfig.transportType || 'stdio',
-          tools: mcpConfig.tools || ['agent', 'swarm', 'memory', 'task']
-        });
-
-        spinner.succeed('MCP server started (stdio)');
-      } catch (error) {
-        spinner.fail('MCP server failed to start');
-        output.printWarning(
-          error instanceof MCPClientError
-            ? error.message
-            : String(error)
-        );
-        // Continue without MCP
-      }
+      spinner.succeed('MCP server (stdio) is launched separately by the host');
     }
 
     // Step 3: Run health check
@@ -240,9 +220,7 @@ const startAction = async (ctx: CommandContext): Promise<CommandResult> => {
       swarmId: swarmResult.swarmId,
       topology: finalTopology,
       maxAgents,
-      mcp: mcpResult ? {
-        transport: mcpConfig.transportType || 'stdio'
-      } : null,
+      mcp: autoStartMcp ? { transport: mcpConfig.transportType || 'stdio' } : null,
       health: healthResult.status,
       daemon,
       startedAt: new Date().toISOString()
@@ -307,41 +285,76 @@ const stopCommand: Command = {
     spinner.start();
 
     try {
-      // Stop MCP server
-      spinner.setText('Stopping MCP server...');
-      try {
-        await callMCPTool('mcp_stop', { graceful: !force, timeout });
-        spinner.succeed('MCP server stopped');
-      } catch {
-        spinner.fail('MCP server was not running');
-      }
-
-      // Stop swarm
-      spinner.setText('Stopping swarm...');
-      spinner.start();
-      try {
-        await callMCPTool('swarm_stop', {
-          graceful: !force,
-          timeout,
-          saveState: true
-        });
-        spinner.succeed('Swarm stopped');
-      } catch {
-        spinner.fail('Swarm was not running');
-      }
-
-      // Clean up daemon PID
+      // The stop mechanism is daemon-PID-file deletion. The daemon's keep-alive
+      // interval (set up in startAction) polls for the PID file and exits when
+      // it's gone. There are no `mcp_stop` or `swarm_stop` MCP tools — the MCP
+      // server is a stdio subprocess of the host (Claude Code) and the swarm
+      // is in-memory orchestration with no separate process to terminate.
       const daemonPidPath = path.join(ctx.cwd, '.claude-flow', 'daemon.pid');
-      if (fs.existsSync(daemonPidPath)) {
-        fs.unlinkSync(daemonPidPath);
+      const signal: NodeJS.Signals = force ? 'SIGKILL' : 'SIGTERM';
+
+      let pidStr: string;
+      try {
+        pidStr = fs.readFileSync(daemonPidPath, 'utf-8').trim();
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          spinner.succeed('No running daemon found (nothing to stop)');
+          output.writeln();
+          output.printSuccess('MoFlo stopped successfully');
+          return {
+            success: true,
+            data: {
+              stopped: true,
+              force,
+              daemonWasRunning: false,
+              signaledPid: null,
+              stoppedAt: new Date().toISOString()
+            }
+          };
+        }
+        throw err;
       }
+
+      spinner.setText('Stopping daemon...');
+      const pid = Number.parseInt(pidStr, 10);
+      let signaledPid: number | null = null;
+      let pidValid = Number.isFinite(pid) && pid > 0;
+
+      if (pidValid) {
+        try {
+          process.kill(pid, signal);
+          signaledPid = pid;
+        } catch (err) {
+          // ESRCH = no such process; benign (daemon already exited).
+          // Anything else (EPERM, EINVAL) is a real failure.
+          if ((err as NodeJS.ErrnoException).code !== 'ESRCH') throw err;
+        }
+      }
+
+      fs.unlinkSync(daemonPidPath);
+
+      let stopMessage: string;
+      if (signaledPid !== null) {
+        stopMessage = `Daemon signaled (pid ${signaledPid}) and PID file removed`;
+      } else if (!pidValid) {
+        stopMessage = 'PID file was malformed; removed';
+      } else {
+        stopMessage = 'PID file removed (daemon process already exited)';
+      }
+      spinner.succeed(stopMessage);
 
       output.writeln();
       output.printSuccess('MoFlo stopped successfully');
 
       return {
         success: true,
-        data: { stopped: true, force, stoppedAt: new Date().toISOString() }
+        data: {
+          stopped: true,
+          force,
+          daemonWasRunning: true,
+          signaledPid,
+          stoppedAt: new Date().toISOString()
+        }
       };
     } catch (error) {
       spinner.fail('Stop failed');

--- a/src/cli/mcp-tools/tool-names.ts
+++ b/src/cli/mcp-tools/tool-names.ts
@@ -36,7 +36,3 @@ export const TOOL_HIVE_MIND_MEMORY = 'hive-mind_memory' as const;
 // Hooks tools
 export const TOOL_HOOKS_INTELLIGENCE_RESET = 'hooks_intelligence-reset' as const;
 export const TOOL_HOOKS_MODEL_OUTCOME = 'hooks_model-outcome' as const;
-
-// Infrastructure tools
-export const TOOL_MCP_STOP = 'mcp_stop' as const;
-export const TOOL_SWARM_STOP = 'swarm_stop' as const;


### PR DESCRIPTION
## Summary

- `start.ts` called three MCP tools that were never registered (`mcp_start`, `mcp_stop`, `swarm_stop`). The two stop calls were wrapped in silent catches and always reported \"was not running\" regardless of state.
- Replaces the bogus tool calls with the actual daemon-stop mechanism: read `.claude-flow/daemon.pid`, send `SIGTERM` (or `SIGKILL` with `--force`), tolerate `ESRCH`, delete the PID file.
- Removes stale `TOOL_MCP_STOP` / `TOOL_SWARM_STOP` constants and dead mocks in `p1-commands.test.ts`.

## Why this happened

Surfaced during the #693 / #696 MCP audit. The `mcp_stop` / `swarm_stop` / `mcp_start` names existed only in `start.ts` call sites, `tool-names.ts` constants, and test mocks — never as registered tools. The catches swallowed every \"tool not found\" error so the bug was invisible.

## Changes

- **`src/cli/commands/start.ts`** — `startAction`: dropped the `mcp_start` block (the MCP server is a stdio subprocess of the host, not something this command can launch). `stopCommand`: replaced `callMCPTool('mcp_stop')` and `callMCPTool('swarm_stop')` with `process.kill(pid, signal)` against the daemon PID. Single `readFileSync` + ENOENT catch (no TOCTOU).
- **`src/cli/mcp-tools/tool-names.ts`** — deleted `TOOL_MCP_STOP` and `TOOL_SWARM_STOP`.
- **`src/cli/__tests__/tool-names.test.ts`** — removed assertion block for the deleted constants.
- **`src/cli/__tests__/p1-commands.test.ts`** — removed dead mocks for `mcp_start` / `mcp_stop` / `swarm_stop`. Added 4 regression tests:
  - no-daemon path returns success
  - regression guard: stop never calls any MCP tool (#697)
  - PID file present → `SIGTERM` + file deleted
  - `--force` → `SIGKILL`
  - `ESRCH` (stale PID) treated as benign cleanup

## Acceptance criteria (from #697)

- [x] Stop path actually shuts down the daemon — by direct `process.kill` against the stored PID, not by calling non-existent tools
- [x] Silent catches removed (`feedback_no_silent_failures.md` compliant)
- [x] Stale `TOOL_MCP_STOP` and `TOOL_SWARM_STOP` constants removed
- [x] Tests added that verify the stop path actually shuts down the relevant subsystems

## Out of scope (worth follow-ups)

- The repo has 4 places that hardcode `'.claude-flow/daemon.pid'` and 2 different PID-file formats (`start.ts` writes a bare integer; `process.ts` writes JSON). Should be unified, but expanding scope here would be churn. Recommend a follow-up issue.
- Followup #698 (docs drift) and #699 (`.claude-flow/` → `.moflo/`) still apply.

## Testing

- [x] Unit + integration tests pass (`npm test`: 7240 passed, 0 failed)
- [x] Build passes (`npm run build`)
- [x] /simplify run on changed code; reuse + quality + efficiency review applied
- [x] Manual verification of stop behavior: with no daemon running → \"No running daemon found\"; with PID file present → SIGTERM sent, file removed

Closes #697

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)