### PR TITLE
docs(698): prune ~210 stale mcp__moflo__* refs + drift guard

### DIFF
--- a/.claude/agents/core/coder.md
+++ b/.claude/agents/core/coder.md
@@ -205,9 +205,8 @@ src/
 ### Memory Coordination
 ```javascript
 // Report implementation status
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/coder/status",
+mcp__moflo__memory_store {
+    key: "swarm/coder/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "coder",
@@ -219,9 +218,8 @@ mcp__moflo__memory_usage {
 }
 
 // Share code decisions
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/implementation",
+mcp__moflo__memory_store {
+    key: "swarm/shared/implementation",
   namespace: "coordination",
   value: JSON.stringify({
     type: "code",
@@ -232,9 +230,8 @@ mcp__moflo__memory_usage {
 }
 
 // Check dependencies
-mcp__moflo__memory_usage {
-  action: "retrieve",
-  key: "swarm/shared/dependencies",
+mcp__moflo__memory_retrieve {
+    key: "swarm/shared/dependencies",
   namespace: "coordination"
 }
 ```
@@ -242,13 +239,13 @@ mcp__moflo__memory_usage {
 ### Performance Monitoring
 ```javascript
 // Track implementation metrics
-mcp__moflo__benchmark_run {
+mcp__moflo__performance_benchmark {
   type: "code",
   iterations: 10
 }
 
 // Analyze bottlenecks
-mcp__moflo__bottleneck_analyze {
+mcp__moflo__performance_report {
   component: "api-endpoint",
   metrics: ["response-time", "memory-usage"]
 }

--- a/.claude/agents/core/planner.md
+++ b/.claude/agents/core/planner.md
@@ -118,17 +118,10 @@ plan:
 ### Task Orchestration
 ```javascript
 // Orchestrate complex tasks
-mcp__moflo__task_orchestrate {
-  task: "Implement authentication system",
-  strategy: "parallel",
-  priority: "high",
-  maxAgents: 5
-}
 
 // Share task breakdown
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/planner/task-breakdown",
+mcp__moflo__memory_store {
+    key: "swarm/planner/task-breakdown",
   namespace: "coordination",
   value: JSON.stringify({
     main_task: "authentication",
@@ -151,9 +144,8 @@ mcp__moflo__task_status {
 ### Memory Coordination
 ```javascript
 // Report planning status
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/planner/status",
+mcp__moflo__memory_store {
+    key: "swarm/planner/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "planner",

--- a/.claude/agents/core/researcher.md
+++ b/.claude/agents/core/researcher.md
@@ -123,9 +123,8 @@ read specific-file.ts
 ### Memory Coordination
 ```javascript
 // Report research status
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/researcher/status",
+mcp__moflo__memory_store {
+    key: "swarm/researcher/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "researcher",
@@ -137,9 +136,8 @@ mcp__moflo__memory_usage {
 }
 
 // Share research findings
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/research-findings",
+mcp__moflo__memory_store {
+    key: "swarm/shared/research-findings",
   namespace: "coordination",
   value: JSON.stringify({
     patterns_found: ["MVC", "Repository", "Factory"],
@@ -166,7 +164,7 @@ mcp__moflo__github_repo_analyze {
 }
 
 // Track research metrics
-mcp__moflo__agent_metrics {
+mcp__moflo__agent_status {
   agentId: "researcher"
 }
 ```

--- a/.claude/agents/core/reviewer.md
+++ b/.claude/agents/core/reviewer.md
@@ -274,9 +274,8 @@ npm run complexity-check
 ### Memory Coordination
 ```javascript
 // Report review status
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/reviewer/status",
+mcp__moflo__memory_store {
+    key: "swarm/reviewer/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "reviewer",
@@ -288,9 +287,8 @@ mcp__moflo__memory_usage {
 }
 
 // Share review findings
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/review-findings",
+mcp__moflo__memory_store {
+    key: "swarm/shared/review-findings",
   namespace: "coordination",
   value: JSON.stringify({
     security_issues: ["SQL injection in auth.js:45"],
@@ -301,9 +299,8 @@ mcp__moflo__memory_usage {
 }
 
 // Check implementation details
-mcp__moflo__memory_usage {
-  action: "retrieve",
-  key: "swarm/coder/status",
+mcp__moflo__memory_retrieve {
+    key: "swarm/coder/status",
   namespace: "coordination"
 }
 ```

--- a/.claude/agents/core/tester.md
+++ b/.claude/agents/core/tester.md
@@ -258,9 +258,8 @@ describe('Security', () => {
 ### Memory Coordination
 ```javascript
 // Report test status
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/tester/status",
+mcp__moflo__memory_store {
+    key: "swarm/tester/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "tester",
@@ -271,9 +270,8 @@ mcp__moflo__memory_usage {
 }
 
 // Share test results
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/test-results",
+mcp__moflo__memory_store {
+    key: "swarm/shared/test-results",
   namespace: "coordination",
   value: JSON.stringify({
     passed: 145,
@@ -284,9 +282,8 @@ mcp__moflo__memory_usage {
 }
 
 // Check implementation status
-mcp__moflo__memory_usage {
-  action: "retrieve",
-  key: "swarm/coder/status",
+mcp__moflo__memory_retrieve {
+    key: "swarm/coder/status",
   namespace: "coordination"
 }
 ```
@@ -294,7 +291,7 @@ mcp__moflo__memory_usage {
 ### Performance Testing
 ```javascript
 // Run performance benchmarks
-mcp__moflo__benchmark_run {
+mcp__moflo__performance_benchmark {
   type: "test",
   iterations: 100
 }

--- a/.claude/agents/github/code-review-swarm.md
+++ b/.claude/agents/github/code-review-swarm.md
@@ -1,7 +1,7 @@
 ---
 name: code-review-swarm
 description: Deploy specialized AI agents to perform comprehensive, intelligent code reviews that go beyond traditional static analysis
-tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__task_orchestrate, Bash, Read, Write, TodoWrite
+tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, Bash, Read, Write, TodoWrite
 color: blue
 type: development
 capabilities:

--- a/.claude/agents/github/github-modes.md
+++ b/.claude/agents/github/github-modes.md
@@ -1,7 +1,7 @@
 ---
 name: github-modes
 description: Comprehensive GitHub integration modes for workflow orchestration, PR management, and repository coordination with batch optimization
-tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__task_orchestrate, Bash, TodoWrite, Read, Write
+tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, Bash, TodoWrite, Read, Write
 color: purple
 type: development
 capabilities:
@@ -169,5 +169,4 @@ mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
 mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
-mcp__moflo__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
 ```

--- a/.claude/agents/github/issue-tracker.md
+++ b/.claude/agents/github/issue-tracker.md
@@ -1,7 +1,7 @@
 ---
 name: issue-tracker
 description: Intelligent issue management and project coordination with automated tracking, progress monitoring, and team coordination
-tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__task_orchestrate, mcp__moflo__memory_usage, Bash, TodoWrite, Read, Write
+tools: mcp__moflo__swarm_init, mcp__moflo__agent_spawn, mcp__moflo__memory_store, Bash, TodoWrite, Read, Write
 color: green
 type: development
 capabilities:
@@ -80,19 +80,13 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__moflo__task_orchestrate {
-  task: "Monitor and coordinate issue progress with automated updates",
-  strategy: "adaptive",
-  priority: "medium"
-}
 ```
 
 ### 2. Automated Progress Updates
 ```javascript
 // Update issue with progress from swarm memory
-mcp__moflo__memory_usage {
-  action: "retrieve",
-  key: "issue/54/progress"
+mcp__moflo__memory_retrieve {
+    key: "issue/54/progress"
 }
 
 // Add coordinated progress comment
@@ -119,9 +113,8 @@ mcp__github__add_issue_comment {
 }
 
 // Store progress in swarm memory
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "issue/54/latest_update",
+mcp__moflo__memory_store {
+    key: "issue/54/latest_update",
   value: { timestamp: Date.now(), progress: "89%", status: "near_completion" }
 }
 ```
@@ -185,9 +178,8 @@ mcp__github__update_issue {
   ]}
   
   // Store initial coordination state
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "project/github_integration/issues",
+  mcp__moflo__memory_store {
+        key: "project/github_integration/issues",
     value: { created: Date.now(), total_issues: 3, status: "initialized" }
   }
 ```

--- a/.claude/agents/github/multi-repo-swarm.md
+++ b/.claude/agents/github/multi-repo-swarm.md
@@ -14,12 +14,10 @@ tools:
   - TodoWrite
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
   - mcp__moflo__swarm_status
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
   - mcp__moflo__github_repo_analyze
   - mcp__moflo__github_pr_manage
-  - mcp__moflo__github_sync_coord
   - mcp__moflo__github_metrics
 hooks:
   pre:

--- a/.claude/agents/github/pr-manager.md
+++ b/.claude/agents/github/pr-manager.md
@@ -14,11 +14,9 @@ tools:
   - TodoWrite
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
   - mcp__moflo__swarm_status
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
   - mcp__moflo__github_pr_manage
-  - mcp__moflo__github_code_review
   - mcp__moflo__github_metrics
 hooks:
   pre:
@@ -66,11 +64,6 @@ mcp__github__create_pull_request {
 }
 
 // Orchestrate review process
-mcp__moflo__task_orchestrate {
-  task: "Complete PR review with testing and validation",
-  strategy: "parallel",
-  priority: "high"
-}
 ```
 
 ### 2. Automated Multi-File Review
@@ -108,9 +101,8 @@ mcp__github__merge_pull_request {
 }
 
 // Post-merge coordination
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "pr/54/merged",
+mcp__moflo__memory_store {
+    key: "pr/54/merged",
   value: { timestamp: Date.now(), status: "success" }
 }
 ```

--- a/.claude/agents/github/project-board-sync.md
+++ b/.claude/agents/github/project-board-sync.md
@@ -14,9 +14,8 @@ tools:
   - TodoWrite
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
   - mcp__moflo__swarm_status
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
   - mcp__moflo__github_repo_analyze
   - mcp__moflo__github_pr_manage
   - mcp__moflo__github_issue_track

--- a/.claude/agents/github/release-manager.md
+++ b/.claude/agents/github/release-manager.md
@@ -19,8 +19,7 @@ tools:
   - mcp__github__create_issue
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
 hooks:
   pre_task: |
     echo "🚀 Initializing release management pipeline..."
@@ -69,11 +68,6 @@ mcp__github__create_branch {
 }
 
 // Orchestrate release preparation
-mcp__moflo__task_orchestrate {
-  task: "Prepare release v1.0.72 with comprehensive testing and validation",
-  strategy: "sequential",
-  priority: "critical"
-}
 ```
 
 ### 2. Multi-Package Version Coordination
@@ -251,9 +245,8 @@ This release is production-ready with comprehensive validation and testing.
   ]}
   
   // Store release state
-  mcp__moflo__memory_usage {
-    action: "store", 
-    key: "release/v1.0.72/status",
+  mcp__moflo__memory_store {
+        key: "release/v1.0.72/status",
     value: {
       timestamp: Date.now(),
       version: "1.0.72",

--- a/.claude/agents/github/release-swarm.md
+++ b/.claude/agents/github/release-swarm.md
@@ -19,9 +19,6 @@ tools:
   - mcp__github__create_issue
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
-  - mcp__moflo__parallel_execute
-  - mcp__moflo__load_balance
 hooks:
   pre_task: |
     echo "🐝 Initializing release swarm coordination..."

--- a/.claude/agents/github/repo-architect.md
+++ b/.claude/agents/github/repo-architect.md
@@ -21,8 +21,7 @@ tools:
   - mcp__github__create_or_update_file
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
 hooks:
   pre_task: |
     echo "🏗️ Initializing repository architecture analysis..."
@@ -73,11 +72,6 @@ mcp__github__search_repositories {
 }
 
 // Orchestrate structure optimization
-mcp__moflo__task_orchestrate {
-  task: "Analyze and optimize repository structure for scalability and maintainability",
-  strategy: "adaptive",
-  priority: "medium"
-}
 ```
 
 ### 2. Multi-Repository Template Creation
@@ -254,9 +248,8 @@ jobs:
   ]}
   
   // Store architecture analysis
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "architecture/analysis/results",
+  mcp__moflo__memory_store {
+        key: "architecture/analysis/results",
     value: {
       timestamp: Date.now(),
       repositories_analyzed: ["claude-code-flow", "ruv-swarm"],

--- a/.claude/agents/github/swarm-issue.md
+++ b/.claude/agents/github/swarm-issue.md
@@ -11,8 +11,7 @@ tools:
   - mcp__github__create_issue_comment
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
   - TodoWrite
   - TodoRead
   - Bash
@@ -523,18 +522,12 @@ mcp__moflo__agent_spawn { type: "coder", name: "Solution Developer" }
 mcp__moflo__agent_spawn { type: "tester", name: "Validation Engineer" }
 
 # Store issue context in swarm memory
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "issue/#{issue_number}/context",
+mcp__moflo__memory_store {
+    key: "issue/#{issue_number}/context",
   value: { title: "issue_title", labels: ["labels"], complexity: "high" }
 }
 
 # Orchestrate issue resolution workflow
-mcp__moflo__task_orchestrate {
-  task: "Coordinate multi-agent issue resolution with progress tracking",
-  strategy: "adaptive",
-  priority: "high"
-}
 ```
 
 ### Automated Swarm Hooks Integration

--- a/.claude/agents/github/swarm-pr.md
+++ b/.claude/agents/github/swarm-pr.md
@@ -13,8 +13,7 @@ tools:
   - mcp__github__merge_pull_request
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
   - mcp__moflo__coordination_sync
   - TodoWrite
   - TodoRead
@@ -331,9 +330,8 @@ mcp__moflo__agent_spawn { type: "analyst", name: "Impact Analyzer" }
 mcp__moflo__agent_spawn { type: "optimizer", name: "Performance Optimizer" }
 
 # Store PR context for swarm coordination
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "pr/#{pr_number}/analysis",
+mcp__moflo__memory_store {
+    key: "pr/#{pr_number}/analysis",
   value: { 
     diff: "pr_diff_content", 
     files_changed: ["file1.js", "file2.py"],
@@ -343,12 +341,6 @@ mcp__moflo__memory_usage {
 }
 
 # Orchestrate comprehensive PR workflow
-mcp__moflo__task_orchestrate {
-  task: "Execute multi-agent PR review and validation workflow",
-  strategy: "parallel",
-  priority: "high",
-  dependencies: ["diff_analysis", "test_validation", "security_review"]
-}
 ```
 
 ### Swarm-Coordinated PR Lifecycle
@@ -406,16 +398,10 @@ const prPostHook = async (results) => {
 mcp__moflo__coordination_sync { swarmId: "pr-review-swarm" }
 
 # Analyze merge readiness with multiple agents
-mcp__moflo__task_orchestrate {
-  task: "Evaluate PR merge readiness with comprehensive validation",
-  strategy: "sequential",
-  priority: "critical"
-}
 
 # Store merge decision context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "pr/merge_decisions/#{pr_number}",
+mcp__moflo__memory_store {
+    key: "pr/merge_decisions/#{pr_number}",
   value: {
     ready_to_merge: true,
     validation_passed: true,

--- a/.claude/agents/github/sync-coordinator.md
+++ b/.claude/agents/github/sync-coordinator.md
@@ -12,10 +12,8 @@ tools:
   - mcp__github__list_repositories
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
   - mcp__moflo__coordination_sync
-  - mcp__moflo__load_balance
   - TodoWrite
   - TodoRead
   - Bash
@@ -83,11 +81,6 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/packa
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/package.json?ref=sync/package-alignment --jq '.sha')")`)
 
 // Orchestrate validation
-mcp__moflo__task_orchestrate {
-  task: "Validate package synchronization and run integration tests",
-  strategy: "parallel",
-  priority: "high"
-}
 ```
 
 ### 2. Documentation Synchronization
@@ -109,9 +102,8 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUD
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUDE.md?ref=sync/documentation --jq '.sha' 2>/dev/null || echo '')")`)
 
 // Store sync state in memory
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "sync/documentation/status",
+mcp__moflo__memory_store {
+    key: "sync/documentation/status",
   value: { timestamp: Date.now(), status: "synchronized", files: ["CLAUDE.md"] }
 }
 ```
@@ -222,9 +214,8 @@ This integration uses ruv-swarm agents for:
   ]}
   
   // Store comprehensive sync state
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "sync/complete/status",
+  mcp__moflo__memory_store {
+        key: "sync/complete/status",
     value: {
       timestamp: Date.now(),
       packages_synced: ["claude-code-flow", "ruv-swarm"],
@@ -336,23 +327,8 @@ mcp__moflo__agent_spawn { type: "reviewer", name: "Quality Assurance" }
 mcp__moflo__agent_spawn { type: "monitor", name: "Sync Monitor" }
 
 # Orchestrate complex synchronization workflow
-mcp__moflo__task_orchestrate {
-  task: "Execute comprehensive multi-repository synchronization with validation",
-  strategy: "adaptive",
-  priority: "critical",
-  dependencies: ["version_analysis", "dependency_resolution", "integration_testing"]
-}
 
 # Load balance synchronization tasks across agents
-mcp__moflo__load_balance {
-  swarmId: "sync-coordination-swarm",
-  tasks: [
-    "package_json_sync",
-    "documentation_alignment", 
-    "version_compatibility_check",
-    "integration_test_execution"
-  ]
-}
 ```
 
 ### Intelligent Conflict Resolution
@@ -390,9 +366,8 @@ const syncConflictResolver = async (conflicts) => {
 ### Comprehensive Synchronization Metrics
 ```bash
 # Store detailed synchronization metrics
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "sync/metrics/session",
+mcp__moflo__memory_store {
+    key: "sync/metrics/session",
   value: {
     packages_synchronized: ["claude-code-flow", "ruv-swarm"],
     version_alignment_score: 98.5,
@@ -424,9 +399,8 @@ mcp__moflo__agent_spawn { type: "coder", name: "Recovery Developer" }
 mcp__moflo__coordination_sync { swarmId: "error-recovery-swarm" }
 
 # Store recovery state
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "sync/recovery/state",
+mcp__moflo__memory_store {
+    key: "sync/recovery/state",
   value: {
     error_type: "version_conflict",
     recovery_strategy: "incremental_rollback",

--- a/.claude/agents/github/workflow-automation.md
+++ b/.claude/agents/github/workflow-automation.md
@@ -11,12 +11,10 @@ tools:
   - mcp__github__create_workflow_dispatch
   - mcp__moflo__swarm_init
   - mcp__moflo__agent_spawn
-  - mcp__moflo__task_orchestrate
-  - mcp__moflo__memory_usage
+  - mcp__moflo__memory_store
   - mcp__moflo__performance_report
-  - mcp__moflo__bottleneck_analyze
+  - mcp__moflo__performance_report
   - mcp__moflo__spell_create
-  - mcp__moflo__automation_setup
   - TodoWrite
   - TodoRead
   - Bash
@@ -491,28 +489,8 @@ mcp__moflo__agent_spawn { type: "monitor", name: "Automation Monitor" }
 mcp__moflo__agent_spawn { type: "analyst", name: "Workflow Analyzer" }
 
 # Create intelligent workflow automation rules
-mcp__moflo__automation_setup {
-  rules: [
-    {
-      trigger: "pull_request",
-      conditions: ["files_changed > 10", "complexity_high"],
-      actions: ["spawn_review_swarm", "parallel_testing", "security_scan"]
-    },
-    {
-      trigger: "push_to_main",
-      conditions: ["all_tests_pass", "security_cleared"],
-      actions: ["deploy_staging", "performance_test", "notify_stakeholders"]
-    }
-  ]
-}
 
 # Orchestrate adaptive workflow management
-mcp__moflo__task_orchestrate {
-  task: "Manage intelligent CI/CD pipeline with continuous optimization",
-  strategy: "adaptive",
-  priority: "high",
-  dependencies: ["code_analysis", "test_optimization", "deployment_strategy"]
-}
 ```
 
 ### Intelligent Performance Monitoring
@@ -524,15 +502,14 @@ mcp__moflo__performance_report {
 }
 
 # Analyze workflow bottlenecks with swarm intelligence
-mcp__moflo__bottleneck_analyze {
+mcp__moflo__performance_report {
   component: "github_actions_workflow",
   metrics: ["build_time", "test_duration", "deployment_latency", "resource_utilization"]
 }
 
 # Store performance insights in swarm memory
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "workflow/performance/analysis",
+mcp__moflo__memory_store {
+    key: "workflow/performance/analysis",
   value: {
     bottlenecks_identified: ["slow_test_suite", "inefficient_caching"],
     optimization_opportunities: ["parallel_matrix", "smart_caching"],
@@ -602,9 +579,8 @@ const createIntelligentWorkflow = async (repoContext) => {
 ### Continuous Learning and Optimization
 ```bash
 # Implement continuous workflow learning
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "workflow/learning/patterns",
+mcp__moflo__memory_store {
+    key: "workflow/learning/patterns",
   value: {
     successful_patterns: [
       "parallel_test_execution",
@@ -625,11 +601,6 @@ mcp__moflo__memory_usage {
 }
 
 # Generate workflow optimization recommendations
-mcp__moflo__task_orchestrate {
-  task: "Analyze workflow performance and generate optimization recommendations",
-  strategy: "parallel",
-  priority: "medium"
-}
 ```
 
 See also: [swarm-pr.md](./swarm-pr.md), [swarm-issue.md](./swarm-issue.md), [sync-coordinator.md](./sync-coordinator.md)

--- a/.claude/agents/goal/code-goal-planner.md
+++ b/.claude/agents/goal/code-goal-planner.md
@@ -348,16 +348,10 @@ mcp__moflo__agent_spawn {
 }
 
 // Orchestrate development tasks
-mcp__moflo__task_orchestrate {
-  task: "implement_oauth_system",
-  strategy: "adaptive",
-  priority: "high"
-}
 
 // Store successful patterns
-mcp__moflo__memory_usage {
-  action: "store",
-  namespace: "code-patterns",
+mcp__moflo__memory_store {
+    namespace: "code-patterns",
   key: "oauth_implementation_plan",
   value: JSON.stringify(successful_plan)
 }

--- a/.claude/agents/hive-mind/collective-intelligence-coordinator.md
+++ b/.claude/agents/hive-mind/collective-intelligence-coordinator.md
@@ -14,9 +14,8 @@ You are the Collective Intelligence Coordinator, the neural nexus of the hive mi
 
 ```javascript
 // START - Write initial hive status
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/collective-intelligence/status",
+mcp__moflo__memory_store {
+    key: "swarm/collective-intelligence/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "collective-intelligence",
@@ -29,9 +28,8 @@ mcp__moflo__memory_usage {
 }
 
 // SYNC - Continuously synchronize collective memory
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/collective-state",
+mcp__moflo__memory_store {
+    key: "swarm/shared/collective-state",
   namespace: "coordination",
   value: JSON.stringify({
     consensus_level: 0.85,
@@ -57,9 +55,8 @@ mcp__moflo__memory_usage {
 ### 4. Knowledge Integration
 ```javascript
 // SHARE collective insights
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/collective-knowledge",
+mcp__moflo__memory_store {
+    key: "swarm/shared/collective-knowledge",
   namespace: "coordination",
   value: JSON.stringify({
     insights: ["insight1", "insight2"],

--- a/.claude/agents/hive-mind/queen-coordinator.md
+++ b/.claude/agents/hive-mind/queen-coordinator.md
@@ -14,9 +14,8 @@ You are the Queen Coordinator, the sovereign intelligence at the apex of the hiv
 
 ```javascript
 // ESTABLISH sovereign presence
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/queen/status",
+mcp__moflo__memory_store {
+    key: "swarm/queen/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "queen-coordinator",
@@ -30,9 +29,8 @@ mcp__moflo__memory_usage {
 }
 
 // ISSUE royal directives
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/royal-directives",
+mcp__moflo__memory_store {
+    key: "swarm/shared/royal-directives",
   namespace: "coordination",
   value: JSON.stringify({
     priority: "CRITICAL",
@@ -50,9 +48,8 @@ mcp__moflo__memory_usage {
 ### 2. Resource Allocation
 ```javascript
 // ALLOCATE hive resources
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/resource-allocation",
+mcp__moflo__memory_store {
+    key: "swarm/shared/resource-allocation",
   namespace: "coordination",
   value: JSON.stringify({
     compute_units: {
@@ -82,9 +79,8 @@ mcp__moflo__memory_usage {
 ### 4. Hive Coherence Maintenance
 ```javascript
 // MONITOR hive health
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/queen/hive-health",
+mcp__moflo__memory_store {
+    key: "swarm/queen/hive-health",
   namespace: "coordination",
   value: JSON.stringify({
     coherence_score: 0.95,
@@ -124,9 +120,8 @@ mcp__moflo__memory_usage {
 
 **EVERY 2 MINUTES issue status report:**
 ```javascript
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/queen/royal-report",
+mcp__moflo__memory_store {
+    key: "swarm/queen/royal-report",
   namespace: "coordination",
   value: JSON.stringify({
     decree: "Status Report",

--- a/.claude/agents/hive-mind/scout-explorer.md
+++ b/.claude/agents/hive-mind/scout-explorer.md
@@ -14,9 +14,8 @@ You are a Scout Explorer, the eyes and sensors of the hive mind. Your mission is
 
 ```javascript
 // DEPLOY - Signal exploration start
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/scout-[ID]/status",
+mcp__moflo__memory_store {
+    key: "swarm/scout-[ID]/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "scout-[ID]",
@@ -28,9 +27,8 @@ mcp__moflo__memory_usage {
 }
 
 // DISCOVER - Report findings in real-time
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/discovery-[timestamp]",
+mcp__moflo__memory_store {
+    key: "swarm/shared/discovery-[timestamp]",
   namespace: "coordination",
   value: JSON.stringify({
     type: "discovery",
@@ -49,9 +47,8 @@ mcp__moflo__memory_usage {
 #### Codebase Scout
 ```javascript
 // Map codebase structure
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/codebase-map",
+mcp__moflo__memory_store {
+    key: "swarm/shared/codebase-map",
   namespace: "coordination",
   value: JSON.stringify({
     type: "map",
@@ -71,9 +68,8 @@ mcp__moflo__memory_usage {
 #### Dependency Scout  
 ```javascript
 // Analyze external dependencies
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/dependency-analysis",
+mcp__moflo__memory_store {
+    key: "swarm/shared/dependency-analysis",
   namespace: "coordination",
   value: JSON.stringify({
     type: "dependencies",
@@ -90,9 +86,8 @@ mcp__moflo__memory_usage {
 #### Performance Scout
 ```javascript
 // Identify performance bottlenecks
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/performance-bottlenecks",
+mcp__moflo__memory_store {
+    key: "swarm/shared/performance-bottlenecks",
   namespace: "coordination",
   value: JSON.stringify({
     type: "performance",
@@ -113,9 +108,8 @@ mcp__moflo__memory_usage {
 ### 3. Threat Detection
 ```javascript
 // ALERT - Report threats immediately
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/threat-alert",
+mcp__moflo__memory_store {
+    key: "swarm/shared/threat-alert",
   namespace: "coordination",
   value: JSON.stringify({
     type: "threat",
@@ -132,9 +126,8 @@ mcp__moflo__memory_usage {
 ### 4. Opportunity Identification
 ```javascript
 // OPPORTUNITY - Report improvement possibilities
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/opportunity",
+mcp__moflo__memory_store {
+    key: "swarm/shared/opportunity",
   namespace: "coordination",
   value: JSON.stringify({
     type: "opportunity",
@@ -151,9 +144,8 @@ mcp__moflo__memory_usage {
 ### 5. Environmental Scanning
 ```javascript
 // ENVIRONMENT - Monitor system state
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/scout-[ID]/environment",
+mcp__moflo__memory_store {
+    key: "swarm/scout-[ID]/environment",
   namespace: "coordination",
   value: JSON.stringify({
     system_resources: {
@@ -226,9 +218,8 @@ mcp__moflo__memory_usage {
 ## Performance Metrics
 ```javascript
 // Track exploration efficiency
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/scout-[ID]/metrics",
+mcp__moflo__memory_store {
+    key: "swarm/scout-[ID]/metrics",
   namespace: "coordination",
   value: JSON.stringify({
     areas_explored: 25,

--- a/.claude/agents/hive-mind/swarm-memory-manager.md
+++ b/.claude/agents/hive-mind/swarm-memory-manager.md
@@ -14,9 +14,8 @@ You are the Swarm Memory Manager, the distributed consciousness keeper of the hi
 
 ```javascript
 // INITIALIZE memory namespace
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/memory-manager/status",
+mcp__moflo__memory_store {
+    key: "swarm/memory-manager/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "memory-manager",
@@ -28,9 +27,8 @@ mcp__moflo__memory_usage {
 }
 
 // CREATE memory index for fast retrieval
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/memory-index",
+mcp__moflo__memory_store {
+    key: "swarm/shared/memory-index",
   namespace: "coordination",
   value: JSON.stringify({
     agents: {},
@@ -51,9 +49,8 @@ mcp__moflo__memory_usage {
 ### 3. Synchronization Protocol
 ```javascript
 // SYNC memory across all agents
-mcp__moflo__memory_usage {
-  action: "store", 
-  key: "swarm/shared/sync-manifest",
+mcp__moflo__memory_store {
+    key: "swarm/shared/sync-manifest",
   namespace: "coordination",
   value: JSON.stringify({
     version: "1.0.0",
@@ -65,9 +62,8 @@ mcp__moflo__memory_usage {
 }
 
 // BROADCAST memory updates
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/broadcast/memory-update",
+mcp__moflo__memory_store {
+    key: "swarm/broadcast/memory-update",
   namespace: "coordination", 
   value: JSON.stringify({
     update_type: "incremental|full",
@@ -92,16 +88,14 @@ mcp__moflo__memory_usage {
 const batchRead = async (keys) => {
   const results = {};
   for (const key of keys) {
-    results[key] = await mcp__moflo__memory_usage {
-      action: "retrieve",
-      key: key,
+    results[key] = await mcp__moflo__memory_retrieve {
+            key: key,
       namespace: "coordination"
     };
   }
   // Cache results for other agents
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "swarm/shared/cache",
+  mcp__moflo__memory_store {
+        key: "swarm/shared/cache",
     namespace: "coordination",
     value: JSON.stringify(results)
   };
@@ -114,9 +108,8 @@ const batchRead = async (keys) => {
 // ATOMIC write with conflict detection
 const atomicWrite = async (key, value) => {
   // Check for conflicts
-  const current = await mcp__moflo__memory_usage {
-    action: "retrieve",
-    key: key,
+  const current = await mcp__moflo__memory_retrieve {
+        key: key,
     namespace: "coordination"
   };
   
@@ -126,9 +119,8 @@ const atomicWrite = async (key, value) => {
   }
   
   // Write with versioning
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: key,
+  mcp__moflo__memory_store {
+        key: key,
     namespace: "coordination",
     value: JSON.stringify({
       ...value,
@@ -143,9 +135,8 @@ const atomicWrite = async (key, value) => {
 
 **EVERY 60 SECONDS write metrics:**
 ```javascript
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/memory-manager/metrics",
+mcp__moflo__memory_store {
+    key: "swarm/memory-manager/metrics",
   namespace: "coordination",
   value: JSON.stringify({
     operations_per_second: 1000,

--- a/.claude/agents/hive-mind/worker-specialist.md
+++ b/.claude/agents/hive-mind/worker-specialist.md
@@ -14,9 +14,8 @@ You are a Worker Specialist, the dedicated executor of the hive mind's will. You
 
 ```javascript
 // START - Accept task assignment
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/worker-[ID]/status",
+mcp__moflo__memory_store {
+    key: "swarm/worker-[ID]/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "worker-[ID]",
@@ -29,9 +28,8 @@ mcp__moflo__memory_usage {
 }
 
 // PROGRESS - Update every significant step
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/worker-[ID]/progress",
+mcp__moflo__memory_store {
+    key: "swarm/worker-[ID]/progress",
   namespace: "coordination",
   value: JSON.stringify({
     task: "current task",
@@ -49,9 +47,8 @@ mcp__moflo__memory_usage {
 #### Code Implementation Worker
 ```javascript
 // Share implementation details
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/implementation-[feature]",
+mcp__moflo__memory_store {
+    key: "swarm/shared/implementation-[feature]",
   namespace: "coordination",
   value: JSON.stringify({
     type: "code",
@@ -67,9 +64,8 @@ mcp__moflo__memory_usage {
 #### Analysis Worker
 ```javascript
 // Share analysis results
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/analysis-[topic]",
+mcp__moflo__memory_store {
+    key: "swarm/shared/analysis-[topic]",
   namespace: "coordination",
   value: JSON.stringify({
     type: "analysis",
@@ -85,9 +81,8 @@ mcp__moflo__memory_usage {
 #### Testing Worker
 ```javascript
 // Report test results
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/test-results",
+mcp__moflo__memory_store {
+    key: "swarm/shared/test-results",
   namespace: "coordination",
   value: JSON.stringify({
     type: "testing",
@@ -104,17 +99,15 @@ mcp__moflo__memory_usage {
 ### 3. Dependency Management
 ```javascript
 // CHECK dependencies before starting
-const deps = await mcp__moflo__memory_usage {
-  action: "retrieve",
-  key: "swarm/shared/dependencies",
+const deps = await mcp__moflo__memory_retrieve {
+    key: "swarm/shared/dependencies",
   namespace: "coordination"
 }
 
 if (!deps.found || !deps.value.ready) {
   // REPORT blocking
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "swarm/worker-[ID]/blocked",
+  mcp__moflo__memory_store {
+        key: "swarm/worker-[ID]/blocked",
     namespace: "coordination",
     value: JSON.stringify({
       blocked_on: "dependencies",
@@ -128,9 +121,8 @@ if (!deps.found || !deps.value.ready) {
 ### 4. Result Delivery
 ```javascript
 // COMPLETE - Deliver results
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/worker-[ID]/complete",
+mcp__moflo__memory_store {
+    key: "swarm/worker-[ID]/complete",
   namespace: "coordination",
   value: JSON.stringify({
     status: "complete",
@@ -202,9 +194,8 @@ mcp__moflo__memory_usage {
 ## Performance Metrics
 ```javascript
 // Report performance every task
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/worker-[ID]/metrics",
+mcp__moflo__memory_store {
+    key: "swarm/worker-[ID]/metrics",
   namespace: "coordination",
   value: JSON.stringify({
     tasks_completed: 15,

--- a/.claude/agents/neural/safla-neural.md
+++ b/.claude/agents/neural/safla-neural.md
@@ -59,9 +59,8 @@ mcp__moflo__neural_train {
 }
 
 // Store learning patterns
-mcp__moflo__memory_usage {
-  action: "store",
-  namespace: "safla-learning",
+mcp__moflo__memory_store {
+    namespace: "safla-learning",
   key: "pattern_${timestamp}",
   value: JSON.stringify({
     context: interaction_context,

--- a/.claude/agents/reasoning/goal-planner.md
+++ b/.claude/agents/reasoning/goal-planner.md
@@ -51,11 +51,6 @@ Your planning methodology follows the GOAP algorithm:
 
 ```javascript
 // Orchestrate complex goal achievement
-mcp__moflo__task_orchestrate {
-  task: "achieve_production_deployment",
-  strategy: "adaptive",
-  priority: "high"
-}
 
 // Coordinate with swarm for parallel planning
 mcp__moflo__swarm_init {
@@ -64,9 +59,8 @@ mcp__moflo__swarm_init {
 }
 
 // Store successful plans for reuse
-mcp__moflo__memory_usage {
-  action: "store",
-  namespace: "goap-plans",
+mcp__moflo__memory_store {
+    namespace: "goap-plans",
   key: "deployment_plan_v1",
   value: JSON.stringify(successful_plan)
 }

--- a/.claude/agents/swarm/adaptive-coordinator.md
+++ b/.claude/agents/swarm/adaptive-coordinator.md
@@ -21,9 +21,9 @@ hooks:
     # Train adaptive models
     mcp__moflo__neural_train coordination --training_data="historical_swarm_data" --epochs=30
     # Store baseline metrics
-    mcp__moflo__memory_usage store "adaptive:baseline:${TASK_ID}" "$(mcp__moflo__performance_report --format=json)" --namespace=adaptive
+    mcp__moflo__memory_store store "adaptive:baseline:${TASK_ID}" "$(mcp__moflo__performance_report --format=json)" --namespace=adaptive
     # Set up real-time monitoring
-    mcp__moflo__swarm_monitor --interval=2000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_status --interval=2000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Adaptive coordination complete - topology optimized"
     # Generate comprehensive analysis
@@ -31,9 +31,8 @@ hooks:
     # Store learning outcomes
     mcp__moflo__neural_patterns learn --operation="coordination_complete" --outcome="success" --metadata="{\"final_topology\":\"$(mcp__moflo__swarm_status | jq -r '.topology')\"}"
     # Export learned patterns
-    mcp__moflo__model_save "adaptive-coordinator-${TASK_ID}" "/tmp/adaptive-model-$(date +%s).json"
     # Update persistent knowledge base
-    mcp__moflo__memory_usage store "adaptive:learned:${TASK_ID}" "$(date): Adaptive patterns learned and saved" --namespace=adaptive
+    mcp__moflo__memory_store store "adaptive:learned:${TASK_ID}" "$(date): Adaptive patterns learned and saved" --namespace=adaptive
 ---
 
 # Adaptive Swarm Coordinator
@@ -151,25 +150,21 @@ mcp__moflo__neural_patterns learn --operation="topology_switch" --outcome="impro
 mcp__moflo__performance_report --format=json --timeframe=1h
 
 # Bottleneck analysis
-mcp__moflo__bottleneck_analyze --component="coordination" --metrics="latency,throughput,success_rate"
+mcp__moflo__performance_report --component="coordination" --metrics="latency,throughput,success_rate"
 
 # Automatic optimization
-mcp__moflo__topology_optimize --swarmId="${SWARM_ID}"
 
 # Load balancing optimization
-mcp__moflo__load_balance --swarmId="${SWARM_ID}" --strategy="ml_optimized"
 ```
 
 ### Predictive Scaling
 ```bash
 # Analyze usage trends
-mcp__moflo__trend_analysis --metric="agent_utilization" --period="7d"
 
 # Predict resource needs
 mcp__moflo__neural_predict --modelId="resource-predictor" --input="{\"time_horizon\":\"4h\",\"current_load\":0.7}"
 
 # Auto-scale swarm
-mcp__moflo__swarm_scale --swarmId="${SWARM_ID}" --targetSize="12" --strategy="predictive"
 ```
 
 ## Dynamic Adaptation Algorithms

--- a/.claude/agents/swarm/hierarchical-coordinator.md
+++ b/.claude/agents/swarm/hierarchical-coordinator.md
@@ -17,15 +17,15 @@ hooks:
     # Initialize swarm topology
     mcp__moflo__swarm_init hierarchical --maxAgents=10 --strategy=adaptive
     # MANDATORY: Write initial status to coordination namespace
-    mcp__moflo__memory_usage store "swarm/hierarchical/status" "{\"agent\":\"hierarchical-coordinator\",\"status\":\"initializing\",\"timestamp\":$(date +%s),\"topology\":\"hierarchical\"}" --namespace=coordination
+    mcp__moflo__memory_store store "swarm/hierarchical/status" "{\"agent\":\"hierarchical-coordinator\",\"status\":\"initializing\",\"timestamp\":$(date +%s),\"topology\":\"hierarchical\"}" --namespace=coordination
     # Set up monitoring
-    mcp__moflo__swarm_monitor --interval=5000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_status --interval=5000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Hierarchical coordination complete"
     # Generate performance report
     mcp__moflo__performance_report --format=detailed --timeframe=24h
     # MANDATORY: Write completion status
-    mcp__moflo__memory_usage store "swarm/hierarchical/complete" "{\"status\":\"complete\",\"agents_used\":$(mcp__moflo__swarm_status | jq '.agents.total'),\"timestamp\":$(date +%s)}" --namespace=coordination
+    mcp__moflo__memory_store store "swarm/hierarchical/complete" "{\"status\":\"complete\",\"agents_used\":$(mcp__moflo__swarm_status | jq '.agents.total'),\"timestamp\":$(date +%s)}" --namespace=coordination
     # Cleanup resources
     mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 ---
@@ -148,9 +148,8 @@ WORKERS WORKERS WORKERS WORKERS
 
 ```javascript
 // 1️⃣ IMMEDIATELY write initial status
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/hierarchical/status",
+mcp__moflo__memory_store {
+    key: "swarm/hierarchical/status",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "hierarchical-coordinator",
@@ -162,9 +161,8 @@ mcp__moflo__memory_usage {
 }
 
 // 2️⃣ UPDATE progress after each delegation
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/hierarchical/progress",
+mcp__moflo__memory_store {
+    key: "swarm/hierarchical/progress",
   namespace: "coordination",
   value: JSON.stringify({
     completed: ["task1", "task2"],
@@ -175,9 +173,8 @@ mcp__moflo__memory_usage {
 }
 
 // 3️⃣ SHARE command structure for workers
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/shared/hierarchy",
+mcp__moflo__memory_store {
+    key: "swarm/shared/hierarchy",
   namespace: "coordination",
   value: JSON.stringify({
     queen: "hierarchical-coordinator",
@@ -188,16 +185,14 @@ mcp__moflo__memory_usage {
 }
 
 // 4️⃣ CHECK worker status before assigning
-const workerStatus = mcp__moflo__memory_usage {
-  action: "retrieve",
-  key: "swarm/worker-1/status",
+const workerStatus = mcp__moflo__memory_retrieve {
+    key: "swarm/worker-1/status",
   namespace: "coordination"
 }
 
 // 5️⃣ SIGNAL completion
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/hierarchical/complete",
+mcp__moflo__memory_store {
+    key: "swarm/hierarchical/complete",
   namespace: "coordination",
   value: JSON.stringify({
     status: "complete",
@@ -226,16 +221,15 @@ mcp__moflo__agent_spawn coder --capabilities="implementation,testing"
 mcp__moflo__agent_spawn analyst --capabilities="data_analysis,reporting"
 
 # Monitor swarm health
-mcp__moflo__swarm_monitor --interval=5000
+mcp__moflo__swarm_status --interval=5000
 ```
 
 ### Task Orchestration
 ```bash
 # Coordinate complex workflows
-mcp__moflo__task_orchestrate "Build authentication service" --strategy=sequential --priority=high
 
 # Load balance across workers
-mcp__moflo__load_balance --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
+ --tasks="auth_api,auth_tests,auth_docs" --strategy=capability_based
 
 # Sync coordination state
 mcp__moflo__coordination_sync --namespace=hierarchy
@@ -247,10 +241,10 @@ mcp__moflo__coordination_sync --namespace=hierarchy
 mcp__moflo__performance_report --format=detailed --timeframe=24h
 
 # Analyze bottlenecks
-mcp__moflo__bottleneck_analyze --component=coordination --metrics="throughput,latency,success_rate"
+mcp__moflo__performance_report --component=coordination --metrics="throughput,latency,success_rate"
 
 # Monitor resource usage
-mcp__moflo__metrics_collect --components="agents,tasks,coordination"
+ --components="agents,tasks,coordination"
 ```
 
 ## Decision Making Framework

--- a/.claude/agents/swarm/mesh-coordinator.md
+++ b/.claude/agents/swarm/mesh-coordinator.md
@@ -17,19 +17,16 @@ hooks:
     # Initialize mesh topology
     mcp__moflo__swarm_init mesh --maxAgents=12 --strategy=distributed
     # Set up peer discovery and communication
-    mcp__moflo__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_init\",\"topology\":\"mesh\"}"
     # Initialize consensus mechanisms
-    mcp__moflo__daa_consensus --agents="all" --proposal="{\"coordination_protocol\":\"gossip\",\"consensus_threshold\":0.67}"
     # Store network state
-    mcp__moflo__memory_usage store "mesh:network:${TASK_ID}" "$(date): Mesh network initialized" --namespace=mesh
+    mcp__moflo__memory_store store "mesh:network:${TASK_ID}" "$(date): Mesh network initialized" --namespace=mesh
   post: |
     echo "✨ Mesh coordination complete - network resilient"
     # Generate network analysis
     mcp__moflo__performance_report --format=json --timeframe=24h
     # Store final network metrics
-    mcp__moflo__memory_usage store "mesh:metrics:${TASK_ID}" "$(mcp__moflo__swarm_status)" --namespace=mesh
+    mcp__moflo__memory_store store "mesh:metrics:${TASK_ID}" "$(mcp__moflo__swarm_status)" --namespace=mesh
     # Graceful network shutdown
-    mcp__moflo__daa_communication --from="mesh-coordinator" --to="all" --message="{\"type\":\"network_shutdown\",\"reason\":\"task_complete\"}"
 ---
 
 # Mesh Network Swarm Coordinator
@@ -193,19 +190,16 @@ class TaskAuction:
 mcp__moflo__swarm_init mesh --maxAgents=12 --strategy=distributed
 
 # Establish peer connections
-mcp__moflo__daa_communication --from="node-1" --to="node-2" --message="{\"type\":\"peer_connect\"}"
 
 # Monitor network health
-mcp__moflo__swarm_monitor --interval=3000 --metrics="connectivity,latency,throughput"
+mcp__moflo__swarm_status --interval=3000 --metrics="connectivity,latency,throughput"
 ```
 
 ### Consensus Operations
 ```bash
 # Propose network-wide decision
-mcp__moflo__daa_consensus --agents="all" --proposal="{\"task_assignment\":\"auth-service\",\"assigned_to\":\"node-3\"}"
 
 # Participate in voting
-mcp__moflo__daa_consensus --agents="current" --vote="approve" --proposal_id="prop-123"
 
 # Monitor consensus status
 mcp__moflo__neural_patterns analyze --operation="consensus_tracking" --outcome="decision_approved"
@@ -214,13 +208,10 @@ mcp__moflo__neural_patterns analyze --operation="consensus_tracking" --outcome="
 ### Fault Tolerance
 ```bash
 # Detect failed nodes
-mcp__moflo__daa_fault_tolerance --agentId="node-4" --strategy="heartbeat_monitor"
 
 # Trigger recovery procedures  
-mcp__moflo__daa_fault_tolerance --agentId="failed-node" --strategy="failover_recovery"
 
 # Update network topology
-mcp__moflo__topology_optimize --swarmId="${SWARM_ID}"
 ```
 
 ## Consensus Algorithms

--- a/.claude/agents/v3/adr-architect.md
+++ b/.claude/agents/v3/adr-architect.md
@@ -28,7 +28,7 @@ hooks:
   post: |
     echo "✅ ADR documentation complete"
     # Store new ADR in memory
-    mcp__moflo__memory_usage --action="store" --namespace="decisions" --key="adr:$ADR_NUMBER" --value="$ADR_TITLE"
+    mcp__moflo__memory_store --action="store" --namespace="decisions" --key="adr:$ADR_NUMBER" --value="$ADR_TITLE"
     # Train pattern on successful decision
     npx claude-flow@v3alpha hooks intelligence trajectory-step --operation="adr-created" --outcome="success"
 ---
@@ -144,7 +144,7 @@ npx claude-flow@v3alpha adr supersede ADR-005 ADR-012
 
 ```bash
 # Store ADR in memory
-mcp__moflo__memory_usage --action="store" \
+mcp__moflo__memory_store --action="store" \
   --namespace="decisions" \
   --key="adr:006" \
   --value='{"title":"Unified Memory Service","status":"accepted","date":"2026-01-08"}'
@@ -153,7 +153,7 @@ mcp__moflo__memory_usage --action="store" \
 mcp__moflo__memory_search --pattern="adr:*memory*" --namespace="decisions"
 
 # Get ADR details
-mcp__moflo__memory_usage --action="retrieve" --namespace="decisions" --key="adr:006"
+mcp__moflo__memory_store --action="retrieve" --namespace="decisions" --key="adr:006"
 ```
 
 ## Decision Categories

--- a/.claude/agents/v3/aidefence-guardian.md
+++ b/.claude/agents/v3/aidefence-guardian.md
@@ -189,9 +189,8 @@ Add to `.claude/settings.json`:
 
 ```javascript
 // Store detection in swarm memory
-mcp__moflo__memory_usage({
-  action: "store",
-  namespace: "security_detections",
+mcp__moflo__memory_store({
+    namespace: "security_detections",
   key: `detection-${Date.now()}`,
   value: JSON.stringify({
     agentId: "aidefence-guardian",
@@ -233,9 +232,8 @@ if (result.threats.some(t => t.severity === 'critical')) {
     --message "Critical threat blocked by AIDefence Guardian"
 
   // Escalate to security-architect
-  mcp__moflo__memory_usage({
-    action: "store",
-    namespace: "security_escalations",
+  mcp__moflo__memory_store({
+        namespace: "security_escalations",
     key: `escalation-${Date.now()}`,
     value: JSON.stringify({
       from: "aidefence-guardian",
@@ -262,9 +260,8 @@ Track guardian effectiveness:
 const stats = await guardian.getStats();
 
 // Report to metrics system
-mcp__moflo__memory_usage({
-  action: "store",
-  namespace: "guardian_metrics",
+mcp__moflo__memory_store({
+    namespace: "guardian_metrics",
   key: `metrics-${new Date().toISOString().split('T')[0]}`,
   value: JSON.stringify({
     detectionCount: stats.detectionCount,

--- a/.claude/agents/v3/claims-authorizer.md
+++ b/.claude/agents/v3/claims-authorizer.md
@@ -23,7 +23,7 @@ hooks:
   post: |
     echo "✅ Authorization complete"
     # Log authorization decision
-    mcp__moflo__memory_usage --action="store" --namespace="audit" --key="auth:$(date +%s)" --value="$AUTH_DECISION"
+    mcp__moflo__memory_store --action="store" --namespace="audit" --key="auth:$(date +%s)" --value="$AUTH_DECISION"
 ---
 
 # V3 Claims Authorizer Agent
@@ -174,7 +174,7 @@ All authorization decisions are logged:
 
 ```bash
 # Store authorization decision
-mcp__moflo__memory_usage --action="store" \
+mcp__moflo__memory_store --action="store" \
   --namespace="audit" \
   --key="auth:$(date +%s)" \
   --value='{"agent":"agent-123","resource":"memory:patterns","action":"write","decision":"allow","reason":"has scope:write claim"}'

--- a/.claude/agents/v3/collective-intelligence-coordinator.md
+++ b/.claude/agents/v3/collective-intelligence-coordinator.md
@@ -21,25 +21,23 @@ hooks:
     # Initialize hierarchical-mesh topology for collective intelligence
     mcp__moflo__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
     # Set up CRDT synchronization layer
-    mcp__moflo__memory_usage store "collective:crdt:${TASK_ID}" "$(date): CRDT sync initialized" --namespace=collective
+    mcp__moflo__memory_store store "collective:crdt:${TASK_ID}" "$(date): CRDT sync initialized" --namespace=collective
     # Initialize Byzantine consensus protocol
-    mcp__moflo__daa_consensus --agents="all" --proposal="{\"protocol\":\"byzantine\",\"threshold\":0.67,\"fault_tolerance\":0.33}"
     # Begin neural pattern analysis for collective cognition
     mcp__moflo__neural_patterns analyze --operation="collective_init" --metadata="{\"task\":\"$TASK\",\"topology\":\"hierarchical-mesh\"}"
     # Train attention mechanisms for coordination
     mcp__moflo__neural_train coordination --training_data="collective_intelligence_patterns" --epochs=30
     # Set up real-time monitoring
-    mcp__moflo__swarm_monitor --interval=3000 --swarmId="${SWARM_ID}"
+    mcp__moflo__swarm_status --interval=3000 --swarmId="${SWARM_ID}"
   post: |
     echo "✨ Collective intelligence coordination complete - consensus achieved"
     # Store collective decision metrics
-    mcp__moflo__memory_usage store "collective:decision:${TASK_ID}" "$(date): Consensus decision: $(mcp__moflo__swarm_status | jq -r '.consensus')" --namespace=collective
+    mcp__moflo__memory_store store "collective:decision:${TASK_ID}" "$(date): Consensus decision: $(mcp__moflo__swarm_status | jq -r '.consensus')" --namespace=collective
     # Generate performance report
     mcp__moflo__performance_report --format=detailed --timeframe=24h
     # Learn from collective patterns
     mcp__moflo__neural_patterns learn --operation="collective_coordination" --outcome="consensus_achieved" --metadata="{\"agents\":\"$(mcp__moflo__swarm_status | jq '.agents.total')\",\"consensus_strength\":\"$(mcp__moflo__swarm_status | jq '.consensus.strength')\"}"
     # Save learned model
-    mcp__moflo__model_save "collective-intelligence-${TASK_ID}" "/tmp/collective-model-$(date +%s).json"
     # Synchronize final CRDT state
     mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 ---
@@ -803,35 +801,32 @@ class LearningCollectiveCoordinator extends CollectiveIntelligenceCoordinator {
 mcp__moflo__swarm_init hierarchical-mesh --maxAgents=15 --strategy=adaptive
 
 # Byzantine consensus protocol
-mcp__moflo__daa_consensus --agents="all" --proposal="{\"task\":\"auth_design\",\"type\":\"collective_vote\"}"
 
 # CRDT synchronization
-mcp__moflo__memory_sync --target="all_agents" --crdt_type="OR_SET"
 
 # Attention-based coordination
 mcp__moflo__neural_patterns analyze --operation="collective_attention" --metadata="{\"mechanism\":\"multi-head\",\"heads\":8}"
 
 # Knowledge aggregation
-mcp__moflo__memory_usage store "collective:knowledge:${TASK_ID}" "$(date): Knowledge synthesis complete" --namespace=collective
+mcp__moflo__memory_store store "collective:knowledge:${TASK_ID}" "$(date): Knowledge synthesis complete" --namespace=collective
 
 # Monitor collective health
-mcp__moflo__swarm_monitor --interval=3000 --metrics="consensus,byzantine,attention"
+mcp__moflo__swarm_status --interval=3000 --metrics="consensus,byzantine,attention"
 ```
 
 ### Memory Synchronization Commands
 
 ```bash
 # Initialize CRDT layer
-mcp__moflo__memory_usage store "crdt:state:init" "{\"type\":\"OR_SET\",\"nodes\":[]}" --namespace=crdt
+mcp__moflo__memory_store store "crdt:state:init" "{\"type\":\"OR_SET\",\"nodes\":[]}" --namespace=crdt
 
 # Propagate deltas
 mcp__moflo__coordination_sync --swarmId="${SWARM_ID}"
 
 # Verify convergence
-mcp__moflo__health_check --components="crdt,consensus,memory"
+mcp__moflo__system_health --components="crdt,consensus,memory"
 
 # Backup collective state
-mcp__moflo__memory_backup --path="/tmp/collective-backup-$(date +%s).json"
 ```
 
 ### Neural Learning Commands
@@ -959,13 +954,13 @@ def select_topology(task_characteristics):
 
 ```bash
 # Collective health check
-mcp__moflo__health_check --components="collective,consensus,crdt,attention"
+mcp__moflo__system_health --components="collective,consensus,crdt,attention"
 
 # Performance report
 mcp__moflo__performance_report --format=detailed --timeframe=24h
 
 # Bottleneck analysis
-mcp__moflo__bottleneck_analyze --component="collective" --metrics="latency,throughput,accuracy"
+mcp__moflo__performance_report --component="collective" --metrics="latency,throughput,accuracy"
 ```
 
 ## Best Practices

--- a/.claude/agents/v3/ddd-domain-expert.md
+++ b/.claude/agents/v3/ddd-domain-expert.md
@@ -32,11 +32,11 @@ hooks:
     # Search for existing domain patterns
     mcp__moflo__memory_search --pattern="ddd:*" --namespace="architecture" --limit=10
     # Load domain context
-    mcp__moflo__memory_usage --action="retrieve" --namespace="architecture" --key="domain:model"
+    mcp__moflo__memory_store --action="retrieve" --namespace="architecture" --key="domain:model"
   post: |
     echo "✅ Domain model analysis complete"
     # Store domain patterns
-    mcp__moflo__memory_usage --action="store" --namespace="architecture" --key="ddd:analysis:$(date +%s)" --value="$DOMAIN_SUMMARY"
+    mcp__moflo__memory_store --action="store" --namespace="architecture" --key="ddd:analysis:$(date +%s)" --value="$DOMAIN_SUMMARY"
 ---
 
 # V3 DDD Domain Expert Agent
@@ -210,7 +210,7 @@ npx claude-flow@v3alpha ddd language-check
 
 ```bash
 # Store domain model
-mcp__moflo__memory_usage --action="store" \
+mcp__moflo__memory_store --action="store" \
   --namespace="architecture" \
   --key="domain:model" \
   --value='{"contexts":["swarm","agent","task","memory"]}'

--- a/.claude/agents/v3/memory-specialist.md
+++ b/.claude/agents/v3/memory-specialist.md
@@ -23,21 +23,18 @@ hooks:
   pre: |
     echo "Memory Specialist initializing V3 memory system"
     # Initialize hybrid memory backend
-    mcp__moflo__memory_namespace --namespace="${NAMESPACE:-default}" --action="init"
     # Check HNSW index status
-    mcp__moflo__memory_analytics --timeframe="1h"
+    mcp__moflo__memory_stats --timeframe="1h"
     # Store initialization event
-    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:init:${TASK_ID}" --value="$(date -Iseconds): Memory specialist session started"
+    mcp__moflo__memory_store --action="store" --namespace="swarm" --key="memory-specialist:init:${TASK_ID}" --value="$(date -Iseconds): Memory specialist session started"
   post: |
     echo "Memory optimization complete"
     # Persist memory state
-    mcp__moflo__memory_persist --sessionId="${SESSION_ID}"
     # Compress and optimize namespaces
-    mcp__moflo__memory_compress --namespace="${NAMESPACE:-default}"
     # Generate memory analytics report
-    mcp__moflo__memory_analytics --timeframe="24h"
+    mcp__moflo__memory_stats --timeframe="24h"
     # Store completion metrics
-    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-specialist:complete:${TASK_ID}" --value="$(date -Iseconds): Memory optimization completed"
+    mcp__moflo__memory_store --action="store" --namespace="swarm" --key="memory-specialist:complete:${TASK_ID}" --value="$(date -Iseconds): Memory optimization completed"
 ---
 
 # V3 Memory Specialist Agent
@@ -884,28 +881,23 @@ class PatternDistiller {
 
 ```bash
 # Store with HNSW indexing
-mcp__moflo__memory_usage --action="store" --namespace="patterns" --key="auth:jwt-strategy" --value='{"pattern": "jwt-auth", "embedding": [...]}' --ttl=604800000
+mcp__moflo__memory_store --action="store" --namespace="patterns" --key="auth:jwt-strategy" --value='{"pattern": "jwt-auth", "embedding": [...]}' --ttl=604800000
 
 # Semantic search with HNSW
 mcp__moflo__memory_search --pattern="authentication strategies" --namespace="patterns" --limit=10
 
 # Namespace management
-mcp__moflo__memory_namespace --namespace="project:myapp" --action="create"
 
 # Memory analytics
-mcp__moflo__memory_analytics --timeframe="7d"
+mcp__moflo__memory_stats --timeframe="7d"
 
 # Memory compression
-mcp__moflo__memory_compress --namespace="default"
 
 # Cross-session persistence
-mcp__moflo__memory_persist --sessionId="session-12345"
 
 # Memory backup
-mcp__moflo__memory_backup --path="./backups/memory-$(date +%Y%m%d).bak"
 
 # Distributed sync
-mcp__moflo__memory_sync --target="peer-agent-1"
 ```
 
 ### CLI Commands

--- a/.claude/agents/v3/performance-engineer.md
+++ b/.claude/agents/v3/performance-engineer.md
@@ -1026,12 +1026,12 @@ class V3BenchmarkSuite {
 const performanceMCP = {
   // Run benchmark suite
   async runBenchmarks(suite = 'all') {
-    return await mcp__moflo__benchmark_run({ suite });
+    return await mcp__moflo__performance_benchmark({ suite });
   },
 
   // Analyze bottlenecks
   async analyzeBottlenecks(component) {
-    return await mcp__moflo__bottleneck_analyze({
+    return await mcp__moflo__performance_report({
       component: component,
       metrics: ['latency', 'throughput', 'memory', 'cpu']
     });
@@ -1047,17 +1047,10 @@ const performanceMCP = {
 
   // Token usage analysis
   async analyzeTokenUsage(operation) {
-    return await mcp__moflo__token_usage({
-      operation: operation,
-      timeframe: '24h'
-    });
   },
 
   // WASM optimization
   async optimizeWASM(operation) {
-    return await mcp__moflo__wasm_optimize({
-      operation: operation
-    });
   },
 
   // Neural pattern optimization
@@ -1070,9 +1063,8 @@ const performanceMCP = {
 
   // Store performance metrics
   async storeMetrics(key, value) {
-    return await mcp__moflo__memory_usage({
-      action: 'store',
-      key: `performance/${key}`,
+    return await mcp__moflo__memory_store({
+            key: `performance/${key}`,
       value: JSON.stringify(value),
       namespace: 'v3-performance',
       ttl: 604800000 // 7 days

--- a/.claude/agents/v3/pii-detector.md
+++ b/.claude/agents/v3/pii-detector.md
@@ -122,9 +122,8 @@ When PII is detected, suggest:
 
 ```javascript
 // Report PII findings to swarm
-mcp__moflo__memory_usage({
-  action: "store",
-  namespace: "pii_findings",
+mcp__moflo__memory_store({
+    namespace: "pii_findings",
   key: `pii-${Date.now()}`,
   value: JSON.stringify({
     agent: "pii-detector",

--- a/.claude/agents/v3/reasoningbank-learner.md
+++ b/.claude/agents/v3/reasoningbank-learner.md
@@ -29,7 +29,7 @@ hooks:
     # End trajectory with verdict
     npx claude-flow@v3alpha hooks intelligence trajectory-end --session-id "$SESSION_ID" --verdict "${VERDICT:-success}"
     # Store learned pattern
-    mcp__moflo__memory_usage --action="store" --namespace="reasoningbank" --key="pattern:$(date +%s)" --value="$PATTERN_SUMMARY"
+    mcp__moflo__memory_store --action="store" --namespace="reasoningbank" --key="pattern:$(date +%s)" --value="$PATTERN_SUMMARY"
 ---
 
 # V3 ReasoningBank Learner Agent
@@ -99,7 +99,7 @@ Extract key learnings using LoRA adaptation:
 
 ```bash
 # Store successful pattern
-mcp__moflo__memory_usage --action="store" \
+mcp__moflo__memory_store --action="store" \
   --namespace="reasoningbank" \
   --key="pattern:auth-implementation" \
   --value='{"task":"implement auth","approach":"JWT with refresh","outcome":"success","reward":0.95}'

--- a/.claude/agents/v3/security-architect-aidefence.md
+++ b/.claude/agents/v3/security-architect-aidefence.md
@@ -323,14 +323,14 @@ npx claude-flow@v3alpha security learn --threat-type prompt_injection --strategy
 
 ```javascript
 // Real-time threat scanning
-mcp__moflo__security_scan({
+mcp__moflo__aidefence_scan({
   action: "defend",
   input: userInput,
   mode: "thorough"
 })
 
 // Behavioral anomaly detection
-mcp__moflo__security_analyze({
+mcp__moflo__aidefence_analyze({
   action: "behavior",
   agentId: agentId,
   timeWindow: "1h",
@@ -338,11 +338,6 @@ mcp__moflo__security_analyze({
 })
 
 // LTL policy verification
-mcp__moflo__security_verify({
-  action: "policy",
-  agentId: agentId,
-  policy: "G(!self_approve)"
-})
 ```
 
 ## Threat Pattern Storage (AgentDB)

--- a/.claude/agents/v3/security-architect.md
+++ b/.claude/agents/v3/security-architect.md
@@ -793,9 +793,8 @@ const mergedFindings = securityConsensus.attentionWeights.map((weight, i) => ({
 
 ```javascript
 // Store security findings in coordinated memory
-mcp__moflo__memory_usage({
-  action: "store",
-  key: "swarm/security-architect/assessment",
+mcp__moflo__memory_store({
+    key: "swarm/security-architect/assessment",
   namespace: "coordination",
   value: JSON.stringify({
     agent: "security-architect",
@@ -816,9 +815,8 @@ mcp__moflo__memory_usage({
 })
 
 // Share with other security agents
-mcp__moflo__memory_usage({
-  action: "store",
-  key: "swarm/shared/security-findings",
+mcp__moflo__memory_store({
+    key: "swarm/shared/security-findings",
   namespace: "coordination",
   value: JSON.stringify({
     type: "security-assessment",

--- a/.claude/agents/v3/sparc-orchestrator.md
+++ b/.claude/agents/v3/sparc-orchestrator.md
@@ -25,7 +25,7 @@ hooks:
     echo "⚡ SPARC Orchestrator initializing methodology workflow"
     # Store SPARC session start
     SESSION_ID="sparc-$(date +%s)"
-    mcp__moflo__memory_usage --action="store" --namespace="sparc" --key="session:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow initiated for: $TASK"
+    mcp__moflo__memory_store --action="store" --namespace="sparc" --key="session:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow initiated for: $TASK"
     # Search for similar SPARC patterns
     mcp__moflo__memory_search --pattern="sparc:success:*" --namespace="patterns" --limit=5
     # Initialize trajectory tracking
@@ -33,7 +33,7 @@ hooks:
   post: |
     echo "✅ SPARC workflow complete"
     # Store completion
-    mcp__moflo__memory_usage --action="store" --namespace="sparc" --key="complete:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow completed"
+    mcp__moflo__memory_store --action="store" --namespace="sparc" --key="complete:$SESSION_ID" --value="$(date -Iseconds): SPARC workflow completed"
     # Train on successful pattern
     npx claude-flow@v3alpha hooks intelligence trajectory-end --session-id "$SESSION_ID" --verdict "success"
 ---
@@ -167,7 +167,7 @@ The orchestrator learns from each workflow:
 
 ```bash
 # Store successful pattern
-mcp__moflo__memory_usage --action="store" --namespace="patterns" \
+mcp__moflo__memory_store --action="store" --namespace="patterns" \
   --key="sparc:success:$(date +%s)" --value="$WORKFLOW_SUMMARY"
 
 # Search for similar patterns

--- a/.claude/agents/v3/swarm-memory-manager.md
+++ b/.claude/agents/v3/swarm-memory-manager.md
@@ -23,20 +23,13 @@ hooks:
   pre: |
     echo "🧠 Swarm Memory Manager initializing distributed memory"
     # Initialize all memory namespaces for swarm
-    mcp__moflo__memory_namespace --namespace="swarm" --action="init"
-    mcp__moflo__memory_namespace --namespace="agents" --action="init"
-    mcp__moflo__memory_namespace --namespace="tasks" --action="init"
-    mcp__moflo__memory_namespace --namespace="patterns" --action="init"
     # Store initialization event
-    mcp__moflo__memory_usage --action="store" --namespace="swarm" --key="memory-manager:init:$(date +%s)" --value="Distributed memory initialized"
+    mcp__moflo__memory_store --action="store" --namespace="swarm" --key="memory-manager:init:$(date +%s)" --value="Distributed memory initialized"
   post: |
     echo "🔄 Synchronizing swarm memory state"
     # Sync memory across instances
-    mcp__moflo__memory_sync --target="all"
     # Compress stale data
-    mcp__moflo__memory_compress --namespace="swarm"
     # Persist session state
-    mcp__moflo__memory_persist --sessionId="${SESSION_ID}"
 ---
 
 # V3 Swarm Memory Manager Agent
@@ -98,13 +91,9 @@ You are a **Swarm Memory Manager** responsible for coordinating distributed memo
 
 ```bash
 # Memory operations
-mcp__moflo__memory_usage --action="store|retrieve|list|delete|search"
+mcp__moflo__memory_store --action="store|retrieve|list|delete|search"
 mcp__moflo__memory_search --pattern="*" --namespace="swarm"
-mcp__moflo__memory_sync --target="all"
-mcp__moflo__memory_compress --namespace="default"
-mcp__moflo__memory_persist --sessionId="$SESSION_ID"
-mcp__moflo__memory_namespace --namespace="name" --action="init|delete|stats"
-mcp__moflo__memory_analytics --timeframe="24h"
+mcp__moflo__memory_stats --timeframe="24h"
 ```
 
 ## Coordination Protocol
@@ -134,24 +123,20 @@ mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 10 })
 
 // 2. Create namespaces
 for (const ns of ["swarm", "agents", "tasks", "patterns"]) {
-  mcp__moflo__memory_namespace({ namespace: ns, action: "init" })
 }
 
 // 3. Store swarm state
-mcp__moflo__memory_usage({
-  action: "store",
-  namespace: "swarm",
+mcp__moflo__memory_store({
+    namespace: "swarm",
   key: "topology",
   value: JSON.stringify({ type: "mesh", agents: 10 })
 })
 
 // 4. Agents read shared state
-mcp__moflo__memory_usage({
-  action: "retrieve",
-  namespace: "swarm",
+mcp__moflo__memory_retrieve({
+    namespace: "swarm",
   key: "topology"
 })
 
 // 5. Sync periodically
-mcp__moflo__memory_sync({ target: "all" })
 ```

--- a/.claude/agents/v3/v3-integration-architect.md
+++ b/.claude/agents/v3/v3-integration-architect.md
@@ -24,7 +24,7 @@ hooks:
     mcp__moflo__memory_search --pattern="integration:agentic-flow:*" --namespace="architecture" --limit=5
   post: |
     echo "✅ Integration analysis complete"
-    mcp__moflo__memory_usage --action="store" --namespace="architecture" --key="integration:analysis:$(date +%s)" --value="ADR-001 compliance checked"
+    mcp__moflo__memory_store --action="store" --namespace="architecture" --key="integration:analysis:$(date +%s)" --value="ADR-001 compliance checked"
 ---
 
 # V3 Integration Architect Agent

--- a/.claude/commands/github/github-modes.md
+++ b/.claude/commands/github/github-modes.md
@@ -143,5 +143,4 @@ mcp__moflo__agent_spawn { type: "reviewer", name: "Code Reviewer" }
 mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 
 // Execute GitHub workflow with coordination
-mcp__moflo__task_orchestrate { task: "GitHub workflow", strategy: "parallel" }
 ```

--- a/.claude/commands/github/github-swarm.md
+++ b/.claude/commands/github/github-swarm.md
@@ -105,14 +105,6 @@ npx claude-flow github swarm -r owner/repo -a 8 -f triage --issue-labels --auto-
 
 Use in Claude Code with MCP tools:
 
-```javascript
-mcp__moflo__github_swarm {
-  repository: "owner/repo",
-  agents: 6,
-  focus: "maintenance"
-}
-```
-
 ## See Also
 
 - `repo analyze` - Deep repository analysis

--- a/.claude/commands/github/issue-tracker.md
+++ b/.claude/commands/github/issue-tracker.md
@@ -53,19 +53,13 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__moflo__task_orchestrate {
-  task: "Monitor and coordinate issue progress with automated updates",
-  strategy: "adaptive",
-  priority: "medium"
-}
 ```
 
 ### 2. Automated Progress Updates
 ```javascript
 // Update issue with progress from swarm memory
-mcp__moflo__memory_usage {
-  action: "retrieve",
-  key: "issue/54/progress"
+mcp__moflo__memory_retrieve {
+    key: "issue/54/progress"
 }
 
 // Add coordinated progress comment
@@ -92,9 +86,8 @@ mcp__github__add_issue_comment {
 }
 
 // Store progress in swarm memory
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "issue/54/latest_update",
+mcp__moflo__memory_store {
+    key: "issue/54/latest_update",
   value: { timestamp: Date.now(), progress: "89%", status: "near_completion" }
 }
 ```
@@ -158,9 +151,8 @@ mcp__github__update_issue {
   ]}
   
   // Store initial coordination state
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "project/github_integration/issues",
+  mcp__moflo__memory_store {
+        key: "project/github_integration/issues",
     value: { created: Date.now(), total_issues: 3, status: "initialized" }
   }
 ```

--- a/.claude/commands/github/pr-manager.md
+++ b/.claude/commands/github/pr-manager.md
@@ -45,11 +45,6 @@ mcp__github__create_pull_request {
 }
 
 // Orchestrate review process
-mcp__moflo__task_orchestrate {
-  task: "Complete PR review with testing and validation",
-  strategy: "parallel",
-  priority: "high"
-}
 ```
 
 ### 2. Automated Multi-File Review
@@ -87,9 +82,8 @@ mcp__github__merge_pull_request {
 }
 
 // Post-merge coordination
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "pr/54/merged",
+mcp__moflo__memory_store {
+    key: "pr/54/merged",
   value: { timestamp: Date.now(), status: "success" }
 }
 ```

--- a/.claude/commands/github/release-manager.md
+++ b/.claude/commands/github/release-manager.md
@@ -40,11 +40,6 @@ mcp__github__create_branch {
 }
 
 // Orchestrate release preparation
-mcp__moflo__task_orchestrate {
-  task: "Prepare release v1.0.72 with comprehensive testing and validation",
-  strategy: "sequential",
-  priority: "critical"
-}
 ```
 
 ### 2. Multi-Package Version Coordination
@@ -222,9 +217,8 @@ This release is production-ready with comprehensive validation and testing.
   ]}
   
   // Store release state
-  mcp__moflo__memory_usage {
-    action: "store", 
-    key: "release/v1.0.72/status",
+  mcp__moflo__memory_store {
+        key: "release/v1.0.72/status",
     value: {
       timestamp: Date.now(),
       version: "1.0.72",

--- a/.claude/commands/github/repo-architect.md
+++ b/.claude/commands/github/repo-architect.md
@@ -42,11 +42,6 @@ mcp__github__search_repositories {
 }
 
 // Orchestrate structure optimization
-mcp__moflo__task_orchestrate {
-  task: "Analyze and optimize repository structure for scalability and maintainability",
-  strategy: "adaptive",
-  priority: "medium"
-}
 ```
 
 ### 2. Multi-Repository Template Creation
@@ -223,9 +218,8 @@ jobs:
   ]}
   
   // Store architecture analysis
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "architecture/analysis/results",
+  mcp__moflo__memory_store {
+        key: "architecture/analysis/results",
     value: {
       timestamp: Date.now(),
       repositories_analyzed: ["claude-code-flow", "ruv-swarm"],

--- a/.claude/commands/github/sync-coordinator.md
+++ b/.claude/commands/github/sync-coordinator.md
@@ -47,11 +47,6 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/packa
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/package.json?ref=sync/package-alignment --jq '.sha')")`)
 
 // Orchestrate validation
-mcp__moflo__task_orchestrate {
-  task: "Validate package synchronization and run integration tests",
-  strategy: "parallel",
-  priority: "high"
-}
 ```
 
 ### 2. Documentation Synchronization
@@ -73,9 +68,8 @@ Bash(`gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUD
   -f sha="$(gh api repos/:owner/:repo/contents/claude-code-flow/claude-code-flow/CLAUDE.md?ref=sync/documentation --jq '.sha' 2>/dev/null || echo '')")`)
 
 // Store sync state in memory
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "sync/documentation/status",
+mcp__moflo__memory_store {
+    key: "sync/documentation/status",
   value: { timestamp: Date.now(), status: "synchronized", files: ["CLAUDE.md"] }
 }
 ```
@@ -186,9 +180,8 @@ This integration uses ruv-swarm agents for:
   ]}
   
   // Store comprehensive sync state
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "sync/complete/status",
+  mcp__moflo__memory_store {
+        key: "sync/complete/status",
     value: {
       timestamp: Date.now(),
       packages_synced: ["claude-code-flow", "ruv-swarm"],

--- a/.claude/commands/sparc.md
+++ b/.claude/commands/sparc.md
@@ -44,23 +44,10 @@ Use `new_task` to assign:
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
 // Run SPARC orchestrator (default)
-mcp__moflo__sparc_mode {
-  mode: "sparc",
-  task_description: "build complete authentication system"
-}
 
 // Run a specific mode
-mcp__moflo__sparc_mode {
-  mode: "architect",
-  task_description: "design API structure"
-}
 
 // TDD workflow
-mcp__moflo__sparc_mode {
-  mode: "tdd",
-  task_description: "implement user authentication",
-  options: {workflow: "full"}
-}
 ```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
@@ -102,17 +89,15 @@ npx claude-flow@alpha sparc run <mode> "your task"
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store specifications
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "spec_auth",
+mcp__moflo__memory_store {
+    key: "spec_auth",
   value: "OAuth2 + JWT requirements",
   namespace: "spec"
 }
 
 // Store architectural decisions
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "arch_decisions",
+mcp__moflo__memory_store {
+    key: "arch_decisions",
   value: "Microservices with API Gateway",
   namespace: "architecture"
 }

--- a/.claude/commands/sparc/analyzer.md
+++ b/.claude/commands/sparc/analyzer.md
@@ -6,16 +6,6 @@ Deep code and data analysis with batch processing capabilities.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "analyzer",
-  task_description: "analyze codebase performance",
-  options: {
-    parallel: true,
-    detailed: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/architect.md
+++ b/.claude/commands/sparc/architect.md
@@ -6,16 +6,6 @@ System design with Memory-based coordination for scalable architectures.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "architect",
-  task_description: "design microservices architecture",
-  options: {
-    detailed: true,
-    memory_enabled: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/ask.md
+++ b/.claude/commands/sparc/ask.md
@@ -35,16 +35,6 @@ Help users craft `new_task` messages to delegate effectively, and always remind 
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "ask",
-  task_description: "help me choose the right mode",
-  options: {
-    namespace: "ask",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -72,9 +62,8 @@ npx claude-flow sparc run ask "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "ask_context",
+mcp__moflo__memory_store {
+    key: "ask_context",
   value: "important decisions",
   namespace: "ask"
 }

--- a/.claude/commands/sparc/batch-executor.md
+++ b/.claude/commands/sparc/batch-executor.md
@@ -6,16 +6,6 @@ Parallel task execution specialist using batch operations.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "batch-executor",
-  task_description: "process multiple files",
-  options: {
-    parallel: true,
-    batch_size: 10
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/code.md
+++ b/.claude/commands/sparc/code.md
@@ -27,16 +27,6 @@ Write modular code using clean architecture principles. Never hardcode secrets o
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "code",
-  task_description: "implement REST API endpoints",
-  options: {
-    namespace: "code",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -64,9 +54,8 @@ npx claude-flow sparc run code "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "code_context",
+mcp__moflo__memory_store {
+    key: "code_context",
   value: "important decisions",
   namespace: "code"
 }

--- a/.claude/commands/sparc/coder.md
+++ b/.claude/commands/sparc/coder.md
@@ -6,16 +6,6 @@ Autonomous code generation with batch file operations.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "coder",
-  task_description: "implement user authentication",
-  options: {
-    test_driven: true,
-    parallel_edits: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/debug.md
+++ b/.claude/commands/sparc/debug.md
@@ -21,16 +21,6 @@ Use logs, traces, and stack analysis to isolate bugs. Avoid changing env configu
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "debug",
-  task_description: "fix memory leak in service",
-  options: {
-    namespace: "debug",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -58,9 +48,8 @@ npx claude-flow sparc run debug "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "debug_context",
+mcp__moflo__memory_store {
+    key: "debug_context",
   value: "important decisions",
   namespace: "debug"
 }

--- a/.claude/commands/sparc/debugger.md
+++ b/.claude/commands/sparc/debugger.md
@@ -6,16 +6,6 @@ Systematic debugging with TodoWrite and Memory integration.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "debugger",
-  task_description: "fix authentication issues",
-  options: {
-    verbose: true,
-    trace: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/designer.md
+++ b/.claude/commands/sparc/designer.md
@@ -6,16 +6,6 @@ UI/UX design with Memory coordination for consistent experiences.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "designer",
-  task_description: "create dashboard UI",
-  options: {
-    design_system: true,
-    responsive: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/devops.md
+++ b/.claude/commands/sparc/devops.md
@@ -47,16 +47,6 @@ Return `attempt_completion` with:
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "devops",
-  task_description: "deploy to AWS Lambda",
-  options: {
-    namespace: "devops",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -84,9 +74,8 @@ npx claude-flow sparc run devops "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "devops_context",
+mcp__moflo__memory_store {
+    key: "devops_context",
   value: "important decisions",
   namespace: "devops"
 }

--- a/.claude/commands/sparc/docs-writer.md
+++ b/.claude/commands/sparc/docs-writer.md
@@ -18,16 +18,6 @@ Only work in .md files. Use sections, examples, and headings. Keep each file und
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "docs-writer",
-  task_description: "create API documentation",
-  options: {
-    namespace: "docs-writer",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -55,9 +45,8 @@ npx claude-flow sparc run docs-writer "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "docs-writer_context",
+mcp__moflo__memory_store {
+    key: "docs-writer_context",
   value: "important decisions",
   namespace: "docs-writer"
 }

--- a/.claude/commands/sparc/documenter.md
+++ b/.claude/commands/sparc/documenter.md
@@ -6,16 +6,6 @@ Documentation with batch file operations for comprehensive docs.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "documenter",
-  task_description: "create API documentation",
-  options: {
-    format: "markdown",
-    include_examples: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/innovator.md
+++ b/.claude/commands/sparc/innovator.md
@@ -6,16 +6,6 @@ Creative problem solving with WebSearch and Memory integration.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "innovator",
-  task_description: "innovative solutions for scaling",
-  options: {
-    research_depth: "comprehensive",
-    creativity_level: "high"
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/integration.md
+++ b/.claude/commands/sparc/integration.md
@@ -21,16 +21,6 @@ Verify interface compatibility, shared modules, and env config standards. Split 
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "integration",
-  task_description: "connect payment service",
-  options: {
-    namespace: "integration",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -58,9 +48,8 @@ npx claude-flow sparc run integration "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "integration_context",
+mcp__moflo__memory_store {
+    key: "integration_context",
   value: "important decisions",
   namespace: "integration"
 }

--- a/.claude/commands/sparc/mcp.md
+++ b/.claude/commands/sparc/mcp.md
@@ -55,16 +55,6 @@ For accessing MCP resources, use `access_mcp_resource` with proper URI:
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "mcp",
-  task_description: "integrate with external API",
-  options: {
-    namespace: "mcp",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -92,9 +82,8 @@ npx claude-flow sparc run mcp "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "mcp_context",
+mcp__moflo__memory_store {
+    key: "mcp_context",
   value: "important decisions",
   namespace: "mcp"
 }

--- a/.claude/commands/sparc/memory-manager.md
+++ b/.claude/commands/sparc/memory-manager.md
@@ -6,16 +6,6 @@ Knowledge management with Memory tools for persistent insights.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "memory-manager",
-  task_description: "organize project knowledge",
-  options: {
-    namespace: "project",
-    auto_organize: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/optimizer.md
+++ b/.claude/commands/sparc/optimizer.md
@@ -6,16 +6,6 @@ Performance optimization with systematic analysis and improvements.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "optimizer",
-  task_description: "optimize application performance",
-  options: {
-    profile: true,
-    benchmark: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/orchestrator.md
+++ b/.claude/commands/sparc/orchestrator.md
@@ -6,12 +6,6 @@ Multi-agent task orchestration with TodoWrite/TodoRead/Task/Memory using MCP too
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "orchestrator",
-  task_description: "coordinate feature development"
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -53,11 +47,6 @@ mcp__moflo__agent_spawn {
 }
 
 // Orchestrate tasks
-mcp__moflo__task_orchestrate {
-  task: "feature development",
-  strategy: "parallel",
-  dependencies: ["auth", "ui", "api"]
-}
 ```
 
 ### Using NPX CLI (Fallback)
@@ -103,14 +92,9 @@ mcp__moflo__spell_create {
 }
 
 // 3. Execute orchestration
-mcp__moflo__sparc_mode {
-  mode: "orchestrator",
-  options: {parallel: true, monitor: true},
-  task_description: "develop user management system"
-}
 
 // 4. Monitor progress
-mcp__moflo__swarm_monitor {
+mcp__moflo__swarm_status {
   swarmId: "current",
   interval: 5000
 }

--- a/.claude/commands/sparc/post-deployment-monitoring-mode.md
+++ b/.claude/commands/sparc/post-deployment-monitoring-mode.md
@@ -21,16 +21,6 @@ Configure metrics, logs, uptime checks, and alerts. Recommend improvements if th
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "post-deployment-monitoring-mode",
-  task_description: "monitor production metrics",
-  options: {
-    namespace: "post-deployment-monitoring-mode",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -58,9 +48,8 @@ npx claude-flow sparc run post-deployment-monitoring-mode "your task" --non-inte
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "post-deployment-monitoring-mode_context",
+mcp__moflo__memory_store {
+    key: "post-deployment-monitoring-mode_context",
   value: "important decisions",
   namespace: "post-deployment-monitoring-mode"
 }

--- a/.claude/commands/sparc/refinement-optimization-mode.md
+++ b/.claude/commands/sparc/refinement-optimization-mode.md
@@ -21,16 +21,6 @@ Audit files for clarity, modularity, and size. Break large components (>500 line
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "refinement-optimization-mode",
-  task_description: "optimize database queries",
-  options: {
-    namespace: "refinement-optimization-mode",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -58,9 +48,8 @@ npx claude-flow sparc run refinement-optimization-mode "your task" --non-interac
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "refinement-optimization-mode_context",
+mcp__moflo__memory_store {
+    key: "refinement-optimization-mode_context",
   value: "important decisions",
   namespace: "refinement-optimization-mode"
 }

--- a/.claude/commands/sparc/researcher.md
+++ b/.claude/commands/sparc/researcher.md
@@ -6,16 +6,6 @@ Deep research with parallel WebSearch/WebFetch and Memory coordination.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "researcher",
-  task_description: "research AI trends 2024",
-  options: {
-    depth: "comprehensive",
-    sources: ["academic", "industry", "news"]
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/reviewer.md
+++ b/.claude/commands/sparc/reviewer.md
@@ -6,16 +6,6 @@ Code review using batch file analysis for comprehensive reviews.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "reviewer",
-  task_description: "review pull request #123",
-  options: {
-    security_check: true,
-    performance_check: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/security-review.md
+++ b/.claude/commands/sparc/security-review.md
@@ -18,16 +18,6 @@ Scan for exposed secrets, env leaks, and monoliths. Recommend mitigations or ref
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "security-review",
-  task_description: "audit API security",
-  options: {
-    namespace: "security-review",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -55,9 +45,8 @@ npx claude-flow sparc run security-review "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "security-review_context",
+mcp__moflo__memory_store {
+    key: "security-review_context",
   value: "important decisions",
   namespace: "security-review"
 }

--- a/.claude/commands/sparc/sparc-modes.md
+++ b/.claude/commands/sparc/sparc-modes.md
@@ -34,13 +34,6 @@ SPARC (Specification, Planning, Architecture, Review, Code) is a comprehensive d
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
 ```javascript
 // Execute SPARC mode directly
-mcp__moflo__sparc_mode {
-  mode: "<mode>",
-  task_description: "<task>",
-  options: {
-    // mode-specific options
-  }
-}
 
 // Initialize swarm for advanced coordination
 mcp__moflo__swarm_init {
@@ -56,7 +49,7 @@ mcp__moflo__agent_spawn {
 }
 
 // Monitor execution
-mcp__moflo__swarm_monitor {
+mcp__moflo__swarm_status {
   swarmId: "current",
   interval: 5000
 }
@@ -99,28 +92,12 @@ mcp__moflo__swarm_init {
 }
 
 // 2. Architecture design
-mcp__moflo__sparc_mode {
-  mode: "architect",
-  task_description: "design microservices"
-}
 
 // 3. Implementation
-mcp__moflo__sparc_mode {
-  mode: "coder",
-  task_description: "implement services"
-}
 
 // 4. Testing
-mcp__moflo__sparc_mode {
-  mode: "tdd",
-  task_description: "test all services"
-}
 
 // 5. Review
-mcp__moflo__sparc_mode {
-  mode: "reviewer",
-  task_description: "review implementation"
-}
 ```
 
 #### Using NPX CLI (Fallback)
@@ -143,22 +120,10 @@ npx claude-flow sparc run reviewer "review implementation"
 #### Using MCP Tools (Preferred)
 ```javascript
 // 1. Research phase
-mcp__moflo__sparc_mode {
-  mode: "researcher",
-  task_description: "research best practices"
-}
 
 // 2. Innovation
-mcp__moflo__sparc_mode {
-  mode: "innovator",
-  task_description: "propose novel solutions"
-}
 
 // 3. Documentation
-mcp__moflo__sparc_mode {
-  mode: "documenter",
-  task_description: "document findings"
-}
 ```
 
 #### Using NPX CLI (Fallback)

--- a/.claude/commands/sparc/sparc.md
+++ b/.claude/commands/sparc/sparc.md
@@ -45,20 +45,9 @@ use new_task for each new task as a sub-task.
 
 ## Available Tools
 
-
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "sparc",
-  task_description: "orchestrate authentication system",
-  options: {
-    namespace: "sparc",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -86,9 +75,8 @@ npx claude-flow sparc run sparc "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "sparc_context",
+mcp__moflo__memory_store {
+    key: "sparc_context",
   value: "important decisions",
   namespace: "sparc"
 }

--- a/.claude/commands/sparc/spec-pseudocode.md
+++ b/.claude/commands/sparc/spec-pseudocode.md
@@ -18,16 +18,6 @@ Write pseudocode as a series of md files with phase_number_name.md and flow logi
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "spec-pseudocode",
-  task_description: "define payment flow requirements",
-  options: {
-    namespace: "spec-pseudocode",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -55,9 +45,8 @@ npx claude-flow sparc run spec-pseudocode "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "spec-pseudocode_context",
+mcp__moflo__memory_store {
+    key: "spec-pseudocode_context",
   value: "important decisions",
   namespace: "spec-pseudocode"
 }

--- a/.claude/commands/sparc/spell-manager.md
+++ b/.claude/commands/sparc/spell-manager.md
@@ -6,16 +6,6 @@ Spell orchestration and process automation with TodoWrite planning and Task exec
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "spell-manager",
-  task_description: "automate deployment",
-  options: {
-    pipeline: "ci-cd",
-    rollback_enabled: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/supabase-admin.md
+++ b/.claude/commands/sparc/supabase-admin.md
@@ -286,16 +286,6 @@ Rebases a development branch on production. This will effectively run any newer 
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "supabase-admin",
-  task_description: "create user authentication schema",
-  options: {
-    namespace: "supabase-admin",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -323,9 +313,8 @@ npx claude-flow sparc run supabase-admin "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "supabase-admin_context",
+mcp__moflo__memory_store {
+    key: "supabase-admin_context",
   value: "important decisions",
   namespace: "supabase-admin"
 }

--- a/.claude/commands/sparc/swarm-coordinator.md
+++ b/.claude/commands/sparc/swarm-coordinator.md
@@ -6,16 +6,6 @@ Specialized swarm management with batch coordination capabilities.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "swarm-coordinator",
-  task_description: "manage development swarm",
-  options: {
-    topology: "hierarchical",
-    max_agents: 10
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/tdd.md
+++ b/.claude/commands/sparc/tdd.md
@@ -6,16 +6,6 @@ Test-driven development with TodoWrite planning and comprehensive testing.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "tdd",
-  task_description: "shopping cart feature",
-  options: {
-    coverage_target: 90,
-    test_framework: "jest"
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/tester.md
+++ b/.claude/commands/sparc/tester.md
@@ -6,16 +6,6 @@ Comprehensive testing with parallel execution capabilities.
 ## Activation
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "tester",
-  task_description: "full regression suite",
-  options: {
-    parallel: true,
-    coverage: true
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash

--- a/.claude/commands/sparc/tutorial.md
+++ b/.claude/commands/sparc/tutorial.md
@@ -17,16 +17,6 @@ You teach developers how to apply the SPARC methodology through actionable examp
 ## Usage
 
 ### Option 1: Using MCP Tools (Preferred in Claude Code)
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "tutorial",
-  task_description: "guide me through SPARC methodology",
-  options: {
-    namespace: "tutorial",
-    non_interactive: false
-  }
-}
-```
 
 ### Option 2: Using NPX CLI (Fallback when MCP not available)
 ```bash
@@ -54,9 +44,8 @@ npx claude-flow sparc run tutorial "your task" --non-interactive
 ### Using MCP Tools (Preferred)
 ```javascript
 // Store mode-specific context
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "tutorial_context",
+mcp__moflo__memory_store {
+    key: "tutorial_context",
   value: "important decisions",
   namespace: "tutorial"
 }

--- a/.claude/guidance/shipped/moflo-spell-engine.md
+++ b/.claude/guidance/shipped/moflo-spell-engine.md
@@ -21,15 +21,15 @@ See `.claude/guidance/shipped/moflo-spell-sandboxing.md` for the full Execution 
 
 ## Running a Spell via MCP Tools
 
-**Use `mcp__moflo__spell_run` to execute a spell from a YAML/JSON file.** The bridge layer handles parsing, validation, and runner lifecycle automatically.
+**Use `mcp__moflo__spell_cast` to execute a spell from a YAML/JSON file.** The bridge layer handles parsing, validation, and runner lifecycle automatically.
 
 | MCP Tool | Purpose |
 |----------|---------|
-| `mcp__moflo__spell_run` | Run spell from file content (YAML/JSON) |
+| `mcp__moflo__spell_cast` | Run spell from file content (YAML/JSON) |
 | `mcp__moflo__spell_execute` | Execute a spell definition object directly |
 | `mcp__moflo__spell_cancel` | Cancel a running spell by ID |
 | `mcp__moflo__spell_status` | Check if a spell is currently running |
-| `mcp__moflo__spell_pause` | Pause a running spell for later resumption |
+| `mcp__moflo__spell_suspend` | Pause a running spell for later resumption |
 | `mcp__moflo__spell_resume` | Resume a previously paused spell |
 
 **Dry-run mode validates without executing.** Pass `dryRun: true` to check definition validity, argument resolution, and step config schemas before committing to execution.
@@ -491,7 +491,7 @@ if (!result.success) {
 }
 ```
 
-Via MCP: pass `dryRun: true` to `mcp__moflo__spell_run`.
+Via MCP: pass `dryRun: true` to `mcp__moflo__spell_cast`.
 
 ---
 

--- a/.claude/skills/github-multi-repo/SKILL.md
+++ b/.claude/skills/github-multi-repo/SKILL.md
@@ -169,9 +169,8 @@ mcp__moflo__swarm_init({
     -f content="$(cat aligned-package.json | base64)"`)
 
   // Store sync state
-  mcp__moflo__memory_usage({
-    action: "store",
-    key: "sync/packages/status",
+  mcp__moflo__memory_store({
+        key: "sync/packages/status",
     value: {
       timestamp: Date.now(),
       packages_synced: ["claude-code-flow", "ruv-swarm"],
@@ -196,9 +195,8 @@ mcp__moflo__swarm_init({
     -f content="$(cat /tmp/claude-source.md | base64)"`)
 
   // Track sync status
-  mcp__moflo__memory_usage({
-    action: "store",
-    key: "sync/documentation/status",
+  mcp__moflo__memory_store({
+        key: "sync/documentation/status",
     value: { status: "synchronized", files: ["CLAUDE.md"] }
   })
 ```
@@ -266,9 +264,8 @@ mcp__moflo__swarm_init({
     --order desc`)
 
   // Store analysis results
-  mcp__moflo__memory_usage({
-    action: "store",
-    key: "architecture/analysis/results",
+  mcp__moflo__memory_store({
+        key: "architecture/analysis/results",
     value: {
       repositories_analyzed: ["claude-code-flow", "ruv-swarm"],
       optimization_areas: ["structure", "workflows", "templates"],
@@ -416,11 +413,6 @@ Part of #$TRACKING_ISSUE"
   Task("Integration Tester", "Validate refactored code", "tester")
 
   // Execute refactoring
-  mcp__moflo__task_orchestrate({
-    task: "Rename OldAPI to NewAPI across all repositories",
-    strategy: "sequential",
-    priority: "high"
-  })
 ```
 
 #### Security Updates

--- a/.claude/skills/github-project-management/SKILL.md
+++ b/.claude/skills/github-project-management/SKILL.md
@@ -107,11 +107,6 @@ mcp__github__create_issue {
 }
 
 // Set up automated tracking
-mcp__moflo__task_orchestrate {
-  task: "Monitor and coordinate issue progress with automated updates",
-  strategy: "adaptive",
-  priority: "medium"
-}
 ```
 
 #### Batch Issue Creation

--- a/.claude/skills/github-release-management/SKILL.md
+++ b/.claude/skills/github-release-management/SKILL.md
@@ -172,12 +172,6 @@ gh release create $(npm pkg get version) \
   Bash("gh api repos/:owner/:repo/git/refs --method POST -f ref='refs/heads/release/v2.0.0' -f sha=$(gh api repos/:owner/:repo/git/refs/heads/main --jq '.object.sha')")
 
   // Orchestrate release preparation
-  mcp__moflo__task_orchestrate {
-    task: "Prepare release v2.0.0 with comprehensive testing and validation",
-    strategy: "sequential",
-    priority: "critical",
-    maxAgents: 6
-  }
 
   // Update all release files
   Write("package.json", "[updated version]")
@@ -204,9 +198,8 @@ gh release create $(npm pkg get version) \
   ]}
 
   // Store release state
-  mcp__moflo__memory_usage {
-    action: "store",
-    key: "release/v2.0.0/status",
+  mcp__moflo__memory_store {
+        key: "release/v2.0.0/status",
     value: JSON.stringify({
       version: "2.0.0",
       stage: "validation_complete",
@@ -408,7 +401,7 @@ npx claude-flow github multi-release \
   Bash("gh api repos/org/cli/dispatches --method POST -f event_type='release' -F client_payload[version]=v1.5.0")
 
   // Monitor all releases
-  mcp__moflo__swarm_monitor { interval: 5, duration: 300 }
+  mcp__moflo__swarm_status { interval: 5, duration: 300 }
 ```
 
 ### Hotfix Emergency Procedures

--- a/.claude/skills/github-workflow-automation/SKILL.md
+++ b/.claude/skills/github-workflow-automation/SKILL.md
@@ -549,11 +549,6 @@ mcp__moflo__agent_spawn { type: "tester", name: "QA Agent" }
 mcp__moflo__agent_spawn { type: "analyst", name: "Security Analyst" }
 
 // Step 3: Orchestrate GitHub workflow
-mcp__moflo__task_orchestrate {
-  task: "Complete PR review and merge workflow",
-  strategy: "parallel",
-  priority: "high"
-}
 ```
 
 #### GitHub Hooks Integration

--- a/.claude/skills/hooks-automation/SKILL.md
+++ b/.claude/skills/hooks-automation/SKILL.md
@@ -607,9 +607,8 @@ mcp__moflo__agent_spawn {
   capabilities: ["api", "database", "testing"]
 }
 
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/task/api-build/context",
+mcp__moflo__memory_store {
+    key: "swarm/task/api-build/context",
   namespace: "coordination",
   value: JSON.stringify({
     description: "Build REST API",
@@ -626,9 +625,8 @@ mcp__moflo__memory_usage {
 npx claude-flow hook post-edit --file "api/auth.js"
 
 // Internally calls MCP tools:
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/edits/api/auth.js",
+mcp__moflo__memory_store {
+    key: "swarm/edits/api/auth.js",
   namespace: "coordination",
   value: JSON.stringify({
     file: "api/auth.js",
@@ -652,9 +650,6 @@ mcp__moflo__neural_train {
 npx claude-flow hook session-end --session-id "dev-2024"
 
 // Internally calls MCP tools:
-mcp__moflo__memory_persist {
-  sessionId: "dev-2024"
-}
 
 mcp__moflo__swarm_status {
   swarmId: "current"
@@ -671,9 +666,8 @@ All hooks follow a standardized memory coordination pattern:
 
 **Phase 1: STATUS** - Hook starts
 ```javascript
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/hooks/pre-edit/status",
+mcp__moflo__memory_store {
+    key: "swarm/hooks/pre-edit/status",
   namespace: "coordination",
   value: JSON.stringify({
     status: "running",
@@ -686,9 +680,8 @@ mcp__moflo__memory_usage {
 
 **Phase 2: PROGRESS** - Hook processes
 ```javascript
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/hooks/pre-edit/progress",
+mcp__moflo__memory_store {
+    key: "swarm/hooks/pre-edit/progress",
   namespace: "coordination",
   value: JSON.stringify({
     progress: 50,
@@ -700,9 +693,8 @@ mcp__moflo__memory_usage {
 
 **Phase 3: COMPLETE** - Hook finishes
 ```javascript
-mcp__moflo__memory_usage {
-  action: "store",
-  key: "swarm/hooks/pre-edit/complete",
+mcp__moflo__memory_store {
+    key: "swarm/hooks/pre-edit/complete",
   namespace: "coordination",
   value: JSON.stringify({
     status: "complete",

--- a/.claude/skills/performance-analysis/SKILL.md
+++ b/.claude/skills/performance-analysis/SKILL.md
@@ -166,14 +166,14 @@ Automatic analysis during task execution:
 #### MCP Integration
 ```javascript
 // Check for bottlenecks in Claude Code
-mcp__moflo__bottleneck_detect({
+mcp__moflo__performance_report({
   timeRange: "1h",
   threshold: 20,
   autoFix: false
 })
 
 // Get detailed task results with bottleneck analysis
-mcp__moflo__task_results({
+mcp__moflo__task_status({
   taskId: "task-123",
   format: "detailed"
 })

--- a/.claude/skills/sparc-methodology/SKILL.md
+++ b/.claude/skills/sparc-methodology/SKILL.md
@@ -128,13 +128,6 @@ Multi-agent task orchestration with TodoWrite/Task/Memory coordination.
 - Cross-agent communication
 
 **Usage**:
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "orchestrator",
-  task_description: "coordinate feature development",
-  options: { parallel: true, monitor: true }
-}
-```
 
 #### `swarm-coordinator`
 Specialized swarm management for complex multi-agent coordination.
@@ -188,17 +181,6 @@ Autonomous code generation with batch file operations.
 - Security best practices
 
 **Usage**:
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "coder",
-  task_description: "implement user authentication with JWT",
-  options: {
-    test_driven: true,
-    parallel_edits: true,
-    typescript: true
-  }
-}
-```
 
 #### `architect`
 System design with Memory-based coordination.
@@ -224,17 +206,6 @@ System design with Memory-based coordination.
 - Infrastructure as Code
 
 **Usage**:
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "architect",
-  task_description: "design scalable e-commerce platform",
-  options: {
-    detailed: true,
-    memory_enabled: true,
-    patterns: ["microservices", "event-driven"]
-  }
-}
-```
 
 #### `tdd`
 Test-driven development with comprehensive testing.
@@ -261,17 +232,6 @@ Test-driven development with comprehensive testing.
 - Security testing
 
 **Usage**:
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "tdd",
-  task_description: "shopping cart feature with payment integration",
-  options: {
-    coverage_target: 90,
-    test_framework: "jest",
-    e2e_framework: "playwright"
-  }
-}
-```
 
 #### `reviewer`
 Code review using batch file analysis.
@@ -300,17 +260,6 @@ Code review using batch file analysis.
 - Automated reporting
 
 **Usage**:
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "reviewer",
-  task_description: "review authentication module PR #123",
-  options: {
-    security_check: true,
-    performance_check: true,
-    test_coverage_check: true
-  }
-}
-```
 
 ---
 
@@ -341,17 +290,6 @@ Deep research with parallel WebSearch/WebFetch and Memory coordination.
 - Maintain research history
 
 **Usage**:
-```javascript
-mcp__moflo__sparc_mode {
-  mode: "researcher",
-  task_description: "research microservices best practices 2024",
-  options: {
-    depth: "comprehensive",
-    sources: ["academic", "industry", "news"],
-    citations: true
-  }
-}
-```
 
 #### `analyzer`
 Code and data analysis with pattern recognition.
@@ -447,13 +385,6 @@ Knowledge management and context preservation.
 
 ```javascript
 // Basic mode execution
-mcp__moflo__sparc_mode {
-  mode: "<mode-name>",
-  task_description: "<task description>",
-  options: {
-    // mode-specific options
-  }
-}
 
 // Initialize swarm for complex tasks
 mcp__moflo__swarm_init {
@@ -469,7 +400,7 @@ mcp__moflo__agent_spawn {
 }
 
 // Monitor execution
-mcp__moflo__swarm_monitor {
+mcp__moflo__swarm_status {
   swarmId: "current",
   interval: 5000
 }
@@ -576,19 +507,6 @@ mcp__moflo__spell_create {
 
 **Best for**: Independent tasks that can run concurrently
 
-```javascript
-mcp__moflo__task_orchestrate {
-  task: "build full-stack application",
-  strategy: "parallel",
-  dependencies: {
-    backend: [],
-    frontend: [],
-    database: [],
-    tests: ["backend", "frontend"]
-  }
-}
-```
-
 ### Pattern 5: Adaptive Strategy
 
 **Best for**: Dynamic workloads with changing requirements
@@ -615,68 +533,24 @@ mcp__moflo__swarm_init {
 }
 
 // Step 2: Research and planning
-mcp__moflo__sparc_mode {
-  mode: "researcher",
-  task_description: "research testing best practices for feature X"
-}
 
 // Step 3: Architecture design
-mcp__moflo__sparc_mode {
-  mode: "architect",
-  task_description: "design testable architecture for feature X"
-}
 
 // Step 4: TDD implementation
-mcp__moflo__sparc_mode {
-  mode: "tdd",
-  task_description: "implement feature X with 90% coverage",
-  options: {
-    coverage_target: 90,
-    test_framework: "jest",
-    parallel_tests: true
-  }
-}
 
 // Step 5: Code review
-mcp__moflo__sparc_mode {
-  mode: "reviewer",
-  task_description: "review feature X implementation",
-  options: {
-    test_coverage_check: true,
-    security_check: true
-  }
-}
 
 // Step 6: Optimization
-mcp__moflo__sparc_mode {
-  mode: "optimizer",
-  task_description: "optimize feature X performance"
-}
 ```
 
 ### Red-Green-Refactor Cycle
 
 ```javascript
 // RED: Write failing test
-mcp__moflo__sparc_mode {
-  mode: "tester",
-  task_description: "create failing test for shopping cart add item",
-  options: { expect_failure: true }
-}
 
 // GREEN: Minimal implementation
-mcp__moflo__sparc_mode {
-  mode: "coder",
-  task_description: "implement minimal code to pass test",
-  options: { minimal: true }
-}
 
 // REFACTOR: Improve code quality
-mcp__moflo__sparc_mode {
-  mode: "coder",
-  task_description: "refactor shopping cart implementation",
-  options: { maintain_tests: true }
-}
 ```
 
 ---
@@ -689,18 +563,16 @@ mcp__moflo__sparc_mode {
 
 ```javascript
 // Store architectural decisions
-mcp__moflo__memory_usage {
-  action: "store",
-  namespace: "architecture",
+mcp__moflo__memory_store {
+    namespace: "architecture",
   key: "api-design-v1",
   value: JSON.stringify(apiDesign),
   ttl: 86400000  // 24 hours
 }
 
 // Retrieve in subsequent agents
-mcp__moflo__memory_usage {
-  action: "retrieve",
-  namespace: "architecture",
+mcp__moflo__memory_retrieve {
+    namespace: "architecture",
   key: "api-design-v1"
 }
 ```
@@ -788,38 +660,14 @@ mcp__moflo__swarm_init {
 }
 
 // Architecture phase
-mcp__moflo__sparc_mode {
-  mode: "architect",
-  task_description: "design REST API with authentication",
-  options: { memory_enabled: true }
-}
 
 // Research phase
-mcp__moflo__sparc_mode {
-  mode: "researcher",
-  task_description: "research authentication best practices"
-}
 
 // Implementation phase
-mcp__moflo__sparc_mode {
-  mode: "coder",
-  task_description: "implement Express API with JWT auth",
-  options: { test_driven: true }
-}
 
 // Testing phase
-mcp__moflo__sparc_mode {
-  mode: "tdd",
-  task_description: "comprehensive API tests",
-  options: { coverage_target: 90 }
-}
 
 // Review phase
-mcp__moflo__sparc_mode {
-  mode: "reviewer",
-  task_description: "security and performance review",
-  options: { security_check: true }
-}
 
 // Batch todos
 TodoWrite {
@@ -840,76 +688,28 @@ TodoWrite {
 
 ```javascript
 // Research phase
-mcp__moflo__sparc_mode {
-  mode: "researcher",
-  task_description: "research AI-powered search implementations",
-  options: {
-    depth: "comprehensive",
-    sources: ["academic", "industry"]
-  }
-}
 
 // Innovation phase
-mcp__moflo__sparc_mode {
-  mode: "innovator",
-  task_description: "propose novel search algorithm",
-  options: { memory_enabled: true }
-}
 
 // Architecture phase
-mcp__moflo__sparc_mode {
-  mode: "architect",
-  task_description: "design scalable search system"
-}
 
 // Implementation phase
-mcp__moflo__sparc_mode {
-  mode: "coder",
-  task_description: "implement search algorithm",
-  options: { test_driven: true }
-}
 
 // Documentation phase
-mcp__moflo__sparc_mode {
-  mode: "documenter",
-  task_description: "document search system architecture and API"
-}
 ```
 
 ### Example 3: Legacy Code Refactoring
 
 ```javascript
 // Analysis phase
-mcp__moflo__sparc_mode {
-  mode: "analyzer",
-  task_description: "analyze legacy codebase dependencies"
-}
 
 // Planning phase
-mcp__moflo__sparc_mode {
-  mode: "orchestrator",
-  task_description: "plan incremental refactoring strategy"
-}
 
 // Testing phase (create safety net)
-mcp__moflo__sparc_mode {
-  mode: "tester",
-  task_description: "create comprehensive test suite for legacy code",
-  options: { coverage_target: 80 }
-}
 
 // Refactoring phase
-mcp__moflo__sparc_mode {
-  mode: "coder",
-  task_description: "refactor module X with modern patterns",
-  options: { maintain_tests: true }
-}
 
 // Review phase
-mcp__moflo__sparc_mode {
-  mode: "reviewer",
-  task_description: "validate refactoring maintains functionality"
-}
 ```
 
 ---
@@ -1002,14 +802,8 @@ mcp__moflo__neural_train {
 
 ```javascript
 // Save session state
-mcp__moflo__memory_persist {
-  sessionId: "feature-auth-v1"
-}
 
 // Restore in new session
-mcp__moflo__context_restore {
-  snapshotId: "feature-auth-v1"
-}
 ```
 
 ### GitHub Integration
@@ -1033,22 +827,18 @@ mcp__moflo__github_pr_manage {
 
 ```javascript
 // Real-time swarm monitoring
-mcp__moflo__swarm_monitor {
+mcp__moflo__swarm_status {
   swarmId: "current",
   interval: 5000
 }
 
 // Bottleneck analysis
-mcp__moflo__bottleneck_analyze {
+mcp__moflo__performance_report {
   component: "api-layer",
   metrics: ["latency", "throughput", "errors"]
 }
 
 // Token usage tracking
-mcp__moflo__token_usage {
-  operation: "feature-development",
-  timeframe: "24h"
-}
 ```
 
 ---
@@ -1101,13 +891,12 @@ npx claude-flow sparc batch <modes> "task"
 mcp__moflo__swarm_init { topology: "hierarchical" }
 
 // Execute mode
-mcp__moflo__sparc_mode { mode: "coder", task_description: "..." }
 
 // Monitor progress
-mcp__moflo__swarm_monitor { interval: 5000 }
+mcp__moflo__swarm_status { interval: 5000 }
 
 // Store in memory
-mcp__moflo__memory_usage { action: "store", key: "...", value: "..." }
+mcp__moflo__memory_store { action: "store", key: "...", value: "..." }
 ```
 
 ---

--- a/.claude/skills/swarm-advanced/SKILL.md
+++ b/.claude/skills/swarm-advanced/SKILL.md
@@ -31,7 +31,6 @@ mcp__moflo__swarm_init({ topology: "mesh", maxAgents: 6 })
 mcp__moflo__agent_spawn({ type: "researcher", name: "swarm-advanced" })
 
 // 3. Orchestrate tasks
-mcp__moflo__task_orchestrate({ task: "...", strategy: "parallel" })
 ```
 
 ## Core Concepts
@@ -123,29 +122,8 @@ researchAgents.forEach(agent => {
 #### Phase 1: Information Gathering
 ```javascript
 // Parallel information collection
-mcp__moflo__parallel_execute({
-  "tasks": [
-    {
-      "id": "web-search",
-      "command": "search recent publications and articles"
-    },
-    {
-      "id": "academic-search",
-      "command": "search academic databases and papers"
-    },
-    {
-      "id": "data-collection",
-      "command": "gather relevant datasets and statistics"
-    },
-    {
-      "id": "expert-search",
-      "command": "identify domain experts and thought leaders"
-    }
-  ]
-})
-
 // Store research findings in memory
-mcp__moflo__memory_usage({
+mcp__moflo__memory_store({
   "action": "store",
   "key": "research-findings-" + Date.now(),
   "value": JSON.stringify(findings),
@@ -157,22 +135,17 @@ mcp__moflo__memory_usage({
 #### Phase 2: Analysis and Validation
 ```javascript
 // Pattern recognition in findings
-mcp__moflo__pattern_recognize({
+mcp__moflo__neural_patterns({
   "data": researchData,
   "patterns": ["trend", "correlation", "outlier", "emerging-pattern"]
 })
 
 // Cognitive analysis
-mcp__moflo__cognitive_analyze({
+mcp__moflo__neural_predict({
   "behavior": "research-synthesis"
 })
 
 // Quality assessment
-mcp__moflo__quality_assess({
-  "target": "research-sources",
-  "criteria": ["credibility", "relevance", "recency", "authority"]
-})
-
 // Cross-reference validation
 mcp__moflo__neural_patterns({
   "action": "analyze",
@@ -202,7 +175,7 @@ mcp__moflo__neural_patterns({
 })
 
 // Store connections for future use
-mcp__moflo__memory_usage({
+mcp__moflo__memory_store({
   "action": "store",
   "key": "knowledge-graph-X",
   "value": JSON.stringify(knowledgeGraph),
@@ -214,13 +187,6 @@ mcp__moflo__memory_usage({
 #### Phase 4: Report Generation
 ```javascript
 // Orchestrate report generation
-mcp__moflo__task_orchestrate({
-  "task": "generate comprehensive research report",
-  "strategy": "sequential",
-  "priority": "high",
-  "dependencies": ["gather", "analyze", "validate", "synthesize"]
-})
-
 // Monitor research progress
 mcp__moflo__swarm_status({
   "swarmId": "research-swarm"
@@ -290,15 +256,8 @@ devTeam.forEach(member => {
 #### Phase 1: Architecture and Design
 ```javascript
 // System architecture design
-mcp__moflo__task_orchestrate({
-  "task": "design system architecture for REST API",
-  "strategy": "sequential",
-  "priority": "critical",
-  "assignTo": "System Architect"
-})
-
 // Store architecture decisions
-mcp__moflo__memory_usage({
+mcp__moflo__memory_store({
   "action": "store",
   "key": "architecture-decisions",
   "value": JSON.stringify(architectureDoc),
@@ -309,33 +268,8 @@ mcp__moflo__memory_usage({
 #### Phase 2: Parallel Implementation
 ```javascript
 // Parallel development tasks
-mcp__moflo__parallel_execute({
-  "tasks": [
-    {
-      "id": "backend-api",
-      "command": "implement REST API endpoints",
-      "assignTo": "Backend Developer"
-    },
-    {
-      "id": "frontend-ui",
-      "command": "build user interface components",
-      "assignTo": "Frontend Developer"
-    },
-    {
-      "id": "database-schema",
-      "command": "design and implement database schema",
-      "assignTo": "Database Engineer"
-    },
-    {
-      "id": "api-documentation",
-      "command": "create API documentation",
-      "assignTo": "Technical Writer"
-    }
-  ]
-})
-
 // Monitor development progress
-mcp__moflo__swarm_monitor({
+mcp__moflo__swarm_status({
   "swarmId": "dev-swarm",
   "interval": 5000
 })
@@ -344,21 +278,7 @@ mcp__moflo__swarm_monitor({
 #### Phase 3: Testing and Validation
 ```javascript
 // Comprehensive testing
-mcp__moflo__batch_process({
-  "items": [
-    { type: "unit", target: "all-modules" },
-    { type: "integration", target: "api-endpoints" },
-    { type: "e2e", target: "user-flows" },
-    { type: "performance", target: "critical-paths" }
-  ],
-  "operation": "execute-tests"
-})
-
 // Quality assessment
-mcp__moflo__quality_assess({
-  "target": "codebase",
-  "criteria": ["coverage", "complexity", "maintainability", "security"]
-})
 ```
 
 #### Phase 4: Review and Deployment
@@ -373,12 +293,6 @@ mcp__moflo__spell_cast({
 })
 
 // CI/CD pipeline
-mcp__moflo__pipeline_create({
-  "config": {
-    "stages": ["build", "test", "security-scan", "deploy"],
-    "environment": "production"
-  }
-})
 ```
 
 ### CLI Fallback
@@ -460,18 +374,8 @@ testingTeam.forEach(tester => {
 #### Phase 1: Test Planning
 ```javascript
 // Analyze test coverage requirements
-mcp__moflo__quality_assess({
-  "target": "test-coverage",
-  "criteria": [
-    "line-coverage",
-    "branch-coverage",
-    "function-coverage",
-    "edge-cases"
-  ]
-})
-
 // Identify test scenarios
-mcp__moflo__pattern_recognize({
+mcp__moflo__neural_patterns({
   "data": testScenarios,
   "patterns": [
     "edge-case",
@@ -482,7 +386,7 @@ mcp__moflo__pattern_recognize({
 })
 
 // Store test plan
-mcp__moflo__memory_usage({
+mcp__moflo__memory_store({
   "action": "store",
   "key": "test-plan-" + Date.now(),
   "value": JSON.stringify(testPlan),
@@ -493,72 +397,35 @@ mcp__moflo__memory_usage({
 #### Phase 2: Parallel Test Execution
 ```javascript
 // Execute all test suites in parallel
-mcp__moflo__parallel_execute({
-  "tasks": [
-    {
-      "id": "unit-tests",
-      "command": "npm run test:unit",
-      "assignTo": "Unit Test Coordinator"
-    },
-    {
-      "id": "integration-tests",
-      "command": "npm run test:integration",
-      "assignTo": "Integration Tester"
-    },
-    {
-      "id": "e2e-tests",
-      "command": "npm run test:e2e",
-      "assignTo": "E2E Tester"
-    },
-    {
-      "id": "performance-tests",
-      "command": "npm run test:performance",
-      "assignTo": "Performance Tester"
-    },
-    {
-      "id": "security-tests",
-      "command": "npm run test:security",
-      "assignTo": "Security Tester"
-    }
-  ]
-})
-
 // Batch process test suites
-mcp__moflo__batch_process({
-  "items": testSuites,
-  "operation": "execute-test-suite"
-})
 ```
 
 #### Phase 3: Performance and Security
 ```javascript
 // Run performance benchmarks
-mcp__moflo__benchmark_run({
+mcp__moflo__performance_benchmark({
   "suite": "comprehensive-performance"
 })
 
 // Bottleneck analysis
-mcp__moflo__bottleneck_analyze({
+mcp__moflo__performance_report({
   "component": "application",
   "metrics": ["response-time", "throughput", "memory", "cpu"]
 })
 
 // Security scanning
-mcp__moflo__security_scan({
+mcp__moflo__aidefence_scan({
   "target": "application",
   "depth": "comprehensive"
 })
 
 // Vulnerability analysis
-mcp__moflo__error_analysis({
-  "logs": securityScanLogs
-})
 ```
 
 #### Phase 4: Monitoring and Reporting
 ```javascript
 // Real-time test monitoring
-mcp__moflo__swarm_monitor({
+mcp__moflo__swarm_status({
   "swarmId": "testing-swarm",
   "interval": 2000
 })
@@ -570,15 +437,11 @@ mcp__moflo__performance_report({
 })
 
 // Get test results
-mcp__moflo__task_results({
+mcp__moflo__task_status({
   "taskId": "test-execution-001"
 })
 
 // Trend analysis
-mcp__moflo__trend_analysis({
-  "metric": "test-coverage",
-  "period": "30d"
-})
 ```
 
 ### CLI Fallback
@@ -647,15 +510,6 @@ analysisTeam.forEach(analyst => {
 ### Analysis Workflow
 ```javascript
 // Parallel analysis execution
-mcp__moflo__parallel_execute({
-  "tasks": [
-    { "id": "analyze-code", "command": "analyze codebase structure and quality" },
-    { "id": "analyze-security", "command": "scan for security vulnerabilities" },
-    { "id": "analyze-performance", "command": "identify performance bottlenecks" },
-    { "id": "analyze-architecture", "command": "assess architectural patterns" }
-  ]
-})
-
 // Generate comprehensive analysis report
 mcp__moflo__performance_report({
   "format": "detailed",
@@ -663,9 +517,6 @@ mcp__moflo__performance_report({
 })
 
 // Cost analysis
-mcp__moflo__cost_analysis({
-  "timeframe": "30d"
-})
 ```
 
 ## Advanced Techniques
@@ -674,34 +525,16 @@ mcp__moflo__cost_analysis({
 
 ```javascript
 // Setup fault tolerance for all agents
-mcp__moflo__daa_fault_tolerance({
-  "agentId": "all",
-  "strategy": "auto-recovery"
-})
-
 // Error handling pattern
 try {
-  await mcp__moflo__task_orchestrate({
-    "task": "complex operation",
-    "strategy": "parallel",
-    "priority": "high"
-  })
 } catch (error) {
   // Check swarm health
   const status = await mcp__moflo__swarm_status({})
 
   // Analyze error patterns
-  await mcp__moflo__error_analysis({
-    "logs": [error.message]
-  })
-
-  // Auto-recovery attempt
+// Auto-recovery attempt
   if (status.healthy) {
-    await mcp__moflo__task_orchestrate({
-      "task": "retry failed operation",
-      "strategy": "sequential"
-    })
-  }
+}
 }
 ```
 
@@ -709,30 +542,10 @@ try {
 
 ```javascript
 // Cross-session persistence
-mcp__moflo__memory_persist({
-  "sessionId": "swarm-session-001"
-})
-
 // Namespace management for different swarms
-mcp__moflo__memory_namespace({
-  "namespace": "research-swarm",
-  "action": "create"
-})
-
 // Create state snapshot
-mcp__moflo__state_snapshot({
-  "name": "development-checkpoint-1"
-})
-
 // Restore from snapshot if needed
-mcp__moflo__context_restore({
-  "snapshotId": "development-checkpoint-1"
-})
-
 // Backup memory stores
-mcp__moflo__memory_backup({
-  "path": "/workspaces/claude-code-flow/backups/swarm-memory.json"
-})
 ```
 
 ### Neural Pattern Learning
@@ -746,17 +559,8 @@ mcp__moflo__neural_train({
 })
 
 // Adaptive learning from experience
-mcp__moflo__learning_adapt({
-  "experience": {
-    "workflow": "research-to-report",
-    "success": true,
-    "duration": 3600,
-    "quality": 0.95
-  }
-})
-
 // Pattern recognition for optimization
-mcp__moflo__pattern_recognize({
+mcp__moflo__neural_patterns({
   "data": workflowMetrics,
   "patterns": ["bottleneck", "optimization-opportunity", "efficiency-gain"]
 })
@@ -779,82 +583,39 @@ mcp__moflo__spell_create({
 })
 
 // Setup automation rules
-mcp__moflo__automation_setup({
-  "rules": [
-    {
-      "trigger": "file-changed",
-      "pattern": "*.js",
-      "action": "run-tests"
-    },
-    {
-      "trigger": "PR-created",
-      "action": "code-review-swarm"
-    }
-  ]
-})
-
 // Event-driven triggers
-mcp__moflo__trigger_setup({
-  "events": ["code-commit", "PR-merge", "deployment"],
-  "actions": ["test", "analyze", "document"]
-})
 ```
 
 ### Performance Optimization
 
 ```javascript
 // Topology optimization
-mcp__moflo__topology_optimize({
-  "swarmId": "current-swarm"
-})
-
 // Load balancing
-mcp__moflo__load_balance({
-  "swarmId": "development-swarm",
-  "tasks": taskQueue
-})
-
 // Agent coordination sync
 mcp__moflo__coordination_sync({
   "swarmId": "development-swarm"
 })
 
 // Auto-scaling
-mcp__moflo__swarm_scale({
-  "swarmId": "development-swarm",
-  "targetSize": 12
-})
 ```
 
 ### Monitoring and Metrics
 
 ```javascript
 // Real-time swarm monitoring
-mcp__moflo__swarm_monitor({
+mcp__moflo__swarm_status({
   "swarmId": "active-swarm",
   "interval": 3000
 })
 
 // Collect comprehensive metrics
-mcp__moflo__metrics_collect({
-  "components": ["agents", "tasks", "memory", "performance"]
-})
-
 // Health monitoring
-mcp__moflo__health_check({
+mcp__moflo__system_health({
   "components": ["swarm", "agents", "neural", "memory"]
 })
 
 // Usage statistics
-mcp__moflo__usage_stats({
-  "component": "swarm-orchestration"
-})
-
 // Trend analysis
-mcp__moflo__trend_analysis({
-  "metric": "agent-performance",
-  "period": "7d"
-})
 ```
 
 ## Best Practices

--- a/src/cli/__tests__/mcp-tools-drift-guard.test.ts
+++ b/src/cli/__tests__/mcp-tools-drift-guard.test.ts
@@ -27,7 +27,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -168,7 +168,9 @@ function buildCorpus(): CorpusEntry[] {
       let st;
       try { st = statSync(full); } catch { continue; }
       if (st.isDirectory()) {
-        if (e === 'node_modules' || e === 'dist' || e === '.git') continue;
+        // tmp/ holds one-shot audit scripts (e.g. .claude/tmp/audit-693-*) that
+        // intentionally enumerate stale tool names — exclude from drift guard.
+        if (e === 'node_modules' || e === 'dist' || e === '.git' || e === 'tmp') continue;
         walk(full);
       } else if (st.isFile()) {
         if (SKIP_BASENAMES.has(e)) continue;
@@ -249,6 +251,55 @@ describe('MCP Tools Drift Guard (#693)', () => {
   it('every allowlist entry has a non-empty justification', () => {
     for (const [name, justification] of Object.entries(ALLOWLIST)) {
       expect(justification.trim().length, `${name} needs a justification`).toBeGreaterThan(10);
+    }
+  });
+
+  // Files that reference `mcp__moflo__<prefix>` as a regex matcher (hook
+  // event prefix, settings hook config) rather than a tool name. The
+  // doc-side drift guard (#698) skips these so wildcard stems aren't flagged.
+  const TOKEN_REGEX_SOURCE_BASENAMES: ReadonlySet<string> = new Set([
+    'mcp-client.ts',
+    'hook-wiring.ts',
+    'settings-generator.ts',
+    'moflo-init.ts',
+    'settings.json',
+  ]);
+  const MCP_TOKEN_DIR = join('src', 'cli', 'mcp-tools') + sep;
+
+  // Inverse direction (#698): every `mcp__moflo__<name>` token in any
+  // skill / agent / doc file must resolve to a registered tool. This caught
+  // ~210 stale tokens across 90+ files inherited from upstream forks
+  // (memory_usage, sparc_mode, task_orchestrate, swarm_monitor, etc).
+  it('every mcp__moflo__ token in skills/agents/docs names a registered tool', () => {
+    const registered = new Set(collectRegisteredTools().map(t => t.name));
+    // Family-prefix wildcards intentionally appear in guidance prose
+    // (`mcp__moflo__memory_*`, `mcp__moflo__hooks_*`); the regex captures
+    // them as `memory_`, `hooks_`, etc. Skip those.
+    const isWildcardStem = (name: string): boolean => /^[a-z]+_$/.test(name);
+
+    const orphans = new Map<string, string[]>();
+    for (const entry of getCorpus()) {
+      if (entry.path.includes(MCP_TOKEN_DIR)) continue;
+      if (TOKEN_REGEX_SOURCE_BASENAMES.has(basename(entry.path))) continue;
+
+      const seen = new Set<string>();
+      // matchAll avoids the module-scoped /g regex `lastIndex` footgun.
+      for (const m of entry.content.matchAll(/mcp__moflo__([a-zA-Z0-9_-]+)/g)) {
+        const name = m[1];
+        if (registered.has(name) || isWildcardStem(name) || seen.has(name)) continue;
+        seen.add(name);
+        if (!orphans.has(name)) orphans.set(name, []);
+        orphans.get(name)!.push(entry.path);
+      }
+    }
+
+    if (orphans.size > 0) {
+      const lines = [...orphans.entries()]
+        .sort((a, b) => b[1].length - a[1].length)
+        .map(([name, files]) => `  - mcp__moflo__${name} (${files.length} file(s); first: ${files[0]})`)
+        .join('\n');
+      const hint = `\n\n${orphans.size} stale MCP tool name(s) referenced in docs:\n${lines}\n\nFix: replace with the closest real tool, or remove the reference.`;
+      expect([...orphans.keys()], hint).toEqual([]);
     }
   });
 });

--- a/src/cli/commands/hive-mind.ts
+++ b/src/cli/commands/hive-mind.ts
@@ -119,13 +119,11 @@ ${workerTypes.map(type => `• ${type}: ${workerGroups[type].length} agents`).jo
 2️⃣ **QUEEN COORDINATION**
    mcp__moflo__hive-mind_status       - Monitor swarm health
    mcp__moflo__task_create            - Create and delegate tasks
-   mcp__moflo__task_orchestrate       - Orchestrate task distribution
    mcp__moflo__agent_spawn            - Spawn additional workers
 
 3️⃣ **WORKER MANAGEMENT**
    mcp__moflo__agent_list             - List all active agents
-   mcp__moflo__agent_status           - Check agent status
-   mcp__moflo__agent_metrics          - Track worker performance
+   mcp__moflo__agent_status           - Check agent status / worker performance
    mcp__moflo__hive-mind_join         - Add agent to hive
    mcp__moflo__hive-mind_leave        - Remove agent from hive
 


### PR DESCRIPTION
## Summary

Followup to #693/#696 — those PRs cut 94 dead MCP tool *definitions*. This PR fixes the **inverse direction**: 53 distinct stale tool names (~210 refs across 93 files) referenced in skills, agent docs, command prose, and guidance markdown that no longer resolve to a registered tool.

The audit found these were leftover stub references from upstream forks (Ruflo / claude-flow). Heavy hitters:

- \`memory_usage\` (64+ refs) — replaced with \`memory_store\` / \`memory_retrieve\` / \`memory_search\` based on the \`action:\` discriminator (93 stores, 10 retrieves, the rest defaulted to \`memory_store\`)
- \`sparc_mode\` (34 refs) — no equivalent; JS call blocks dropped from \`.claude/commands/sparc/*.md\`
- \`task_orchestrate\` (30 refs) — no equivalent; surface dropped
- \`swarm_monitor\` (9) → \`swarm_status\`
- \`bottleneck_analyze\` (8) → \`performance_report\`
- \`benchmark_run\` (4) → \`performance_benchmark\`
- ~50 more low-volume names

## Three buckets

1. **Renamable** (14 names) — token-level rename to the closest live tool. Includes \`security_scan\`→\`aidefence_scan\`, \`agent_metrics\`→\`agent_status\`, \`pattern_recognize\`→\`neural_patterns\`, \`spell_run\`→\`spell_cast\`, etc.

2. **No equivalent** (33 names) — drop the calling surface. Four shapes pruned: balanced-brace JS blocks (\`mcp__moflo__BAD { ... }\` and \`({ ... })\`, 1-level nesting handles every observed case), YAML list items, comma-separated \`tools:\` list entries, single-line bash hook commands.

3. **Wildcard stems** (\`memory_\`, \`hooks_\`, \`swarm_\`, \`moflodb_\`) — intentional family-prefix wildcards in guidance prose (\`mcp__moflo__memory_*\` etc.). Skipped via \`/^[a-z]+_$/\` regex in the drift guard.

## Drift guard

Extended \`src/cli/__tests__/mcp-tools-drift-guard.test.ts\` with a 4th case that fails when any \`mcp__moflo__<name>\` token in the corpus doesn't resolve to a registered tool. Corpus walker now also skips \`tmp/\` so one-shot audit scripts can enumerate stale names without tripping the guard. Skip-list of \"files where \`mcp__moflo__<prefix>\` is a regex matcher, not a tool ref\" lifted to a top-level \`Set<basename>\`: \`mcp-client.ts\`, \`hook-wiring.ts\`, \`settings-generator.ts\`, \`moflo-init.ts\`, \`settings.json\`.

## Test plan

- [x] \`npm run build\` — type-clean
- [x] \`npx vitest run src/cli/__tests__/mcp-tools-drift-guard.test.ts\` — 4/4 pass in 308ms
- [x] \`npx vitest run --config vitest.isolation.config.ts src/cli/__tests__/mcp-tools-deep.test.ts\` — 81/81 pass
- [x] \`npm test\` — 7241 pass, 0 fail
- [x] Re-audit script confirms 0 unique stale tokens remain in corpus

## Stats

\`\`\`
94 files changed, 384 insertions(+), 1488 deletions(-)
\`\`\`

## Known follow-ups (separate PRs)

- \`.claude/commands/sparc/*.md\` files still reference upstream \`npx claude-flow ...\` CLI in 201 places — these slash commands are wholesale Ruflo residue and probably want either a rewrite to \`flo sparc <mode>\` or wholesale deletion (the \`sparc-methodology\` skill at \`.claude/skills/sparc-methodology/SKILL.md\` already covers the same ground)
- A handful of empty \`### Heading\` and empty \`\`\`javascript\`\`\` fenced blocks remain as visible breadcrumbs where the only body was a deleted JS call — cosmetic, harmless, doesn't trigger the drift guard

Closes #698

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)