### PR TITLE
refactor(701): extract shared json-store helper for mcp-tools

### DIFF
--- a/src/cli/__tests__/mcp-tools-json-store.test.ts
+++ b/src/cli/__tests__/mcp-tools-json-store.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the shared JSON-store helper used by the trimmed MCP tool surfaces.
+ * Anchors all I/O at `<cwd>/.moflo/<subdir>/<file>`, so each test runs in its
+ * own tmpdir to avoid polluting the real `.moflo/`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { createJsonStore } from '../mcp-tools/json-store.js';
+
+interface Sample {
+  greeting: string;
+  count: number;
+}
+
+describe('createJsonStore', () => {
+  let originalCwd: string;
+  let tmp: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmp = mkdtempSync(join(tmpdir(), 'moflo-json-store-'));
+    process.chdir(tmp);
+    storePath = join(tmp, '.moflo', 'sample', 'data.json');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns defaults() when the backing file is missing', () => {
+    const store = createJsonStore<Sample>({
+      subdir: 'sample',
+      file: 'data.json',
+      defaults: () => ({ greeting: 'hello', count: 0 }),
+    });
+
+    expect(store.load()).toEqual({ greeting: 'hello', count: 0 });
+  });
+
+  it('round-trips values through save/load', () => {
+    const store = createJsonStore<Sample>({
+      subdir: 'sample',
+      file: 'data.json',
+      defaults: () => ({ greeting: 'hello', count: 0 }),
+    });
+
+    store.save({ greeting: 'hi', count: 7 });
+
+    expect(existsSync(storePath)).toBe(true);
+    expect(store.load()).toEqual({ greeting: 'hi', count: 7 });
+  });
+
+  it('falls back to defaults() on malformed JSON', () => {
+    const store = createJsonStore<Sample>({
+      subdir: 'sample',
+      file: 'data.json',
+      defaults: () => ({ greeting: 'fallback', count: -1 }),
+    });
+
+    mkdirSync(join(tmp, '.moflo', 'sample'), { recursive: true });
+    writeFileSync(storePath, '{not valid json', 'utf-8');
+
+    expect(store.load()).toEqual({ greeting: 'fallback', count: -1 });
+  });
+
+  it('creates the parent directory tree on save', () => {
+    const store = createJsonStore<Sample>({
+      subdir: 'deeply/nested/sample',
+      file: 'data.json',
+      defaults: () => ({ greeting: 'hello', count: 0 }),
+    });
+
+    expect(existsSync(join(tmp, '.moflo', 'deeply'))).toBe(false);
+
+    store.save({ greeting: 'hi', count: 1 });
+
+    expect(existsSync(join(tmp, '.moflo', 'deeply', 'nested', 'sample', 'data.json'))).toBe(true);
+  });
+
+  it('calls defaults() per load() — fresh values on each miss', () => {
+    let callCount = 0;
+    const store = createJsonStore<{ id: number }>({
+      subdir: 'sample',
+      file: 'data.json',
+      defaults: () => ({ id: ++callCount }),
+    });
+
+    expect(store.load().id).toBe(1);
+    expect(store.load().id).toBe(2);
+    expect(store.load().id).toBe(3);
+  });
+
+  it('writes pretty-printed JSON', () => {
+    const store = createJsonStore<Sample>({
+      subdir: 'sample',
+      file: 'data.json',
+      defaults: () => ({ greeting: 'hello', count: 0 }),
+    });
+
+    store.save({ greeting: 'hi', count: 7 });
+
+    const raw = readFileSync(storePath, 'utf-8');
+    expect(raw).toContain('\n');
+    expect(raw).toContain('  "greeting"');
+  });
+
+  it('surfaces I/O errors other than ENOENT', () => {
+    // mkdir at the file path → readFileSync throws EISDIR on every platform,
+    // exercising the "not ENOENT, not SyntaxError" branch.
+    mkdirSync(join(tmp, '.moflo', 'sample'), { recursive: true });
+    mkdirSync(storePath);
+
+    const store = createJsonStore<Sample>({
+      subdir: 'sample',
+      file: 'data.json',
+      defaults: () => ({ greeting: 'fallback', count: -1 }),
+    });
+
+    expect(() => store.load()).toThrow();
+  });
+});

--- a/src/cli/mcp-tools/coordination-tools.ts
+++ b/src/cli/mcp-tools/coordination-tools.ts
@@ -7,13 +7,7 @@
  */
 
 import type { MCPTool } from './types.js';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
-
-// Storage paths
-const COORD_DIR = 'coordination';
-const COORD_FILE = 'store.json';
+import { createJsonStore } from './json-store.js';
 
 interface SyncState {
   lastSync: string;
@@ -28,31 +22,10 @@ interface CoordinationStore {
   version: string;
 }
 
-function getCoordDir(): string {
-  return join(process.cwd(), STORAGE_DIR, COORD_DIR);
-}
-
-function getCoordPath(): string {
-  return join(getCoordDir(), COORD_FILE);
-}
-
-function ensureCoordDir(): void {
-  const dir = getCoordDir();
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-}
-
-function loadCoordStore(): CoordinationStore {
-  try {
-    const path = getCoordPath();
-    if (existsSync(path)) {
-      return JSON.parse(readFileSync(path, 'utf-8'));
-    }
-  } catch {
-    // Return default store
-  }
-  return {
+const store = createJsonStore<CoordinationStore>({
+  subdir: 'coordination',
+  file: 'store.json',
+  defaults: () => ({
     sync: {
       lastSync: new Date().toISOString(),
       syncCount: 0,
@@ -61,13 +34,8 @@ function loadCoordStore(): CoordinationStore {
     },
     nodes: {},
     version: '3.0.0',
-  };
-}
-
-function saveCoordStore(store: CoordinationStore): void {
-  ensureCoordDir();
-  writeFileSync(getCoordPath(), JSON.stringify(store, null, 2), 'utf-8');
-}
+  }),
+});
 
 export const coordinationTools: MCPTool[] = [
   {
@@ -83,46 +51,46 @@ export const coordinationTools: MCPTool[] = [
       },
     },
     handler: async (input) => {
-      const store = loadCoordStore();
+      const state = store.load();
       const action = (input.action as string) || 'status';
 
       if (action === 'status') {
-        const timeSinceSync = Date.now() - new Date(store.sync.lastSync).getTime();
+        const timeSinceSync = Date.now() - new Date(state.sync.lastSync).getTime();
 
         return {
           success: true,
-          sync: store.sync,
+          sync: state.sync,
           timeSinceSync: `${Math.floor(timeSinceSync / 1000)}s`,
-          status: store.sync.conflicts > 0 ? 'conflicts' : store.sync.pendingChanges > 0 ? 'pending' : 'synced',
+          status: state.sync.conflicts > 0 ? 'conflicts' : state.sync.pendingChanges > 0 ? 'pending' : 'synced',
         };
       }
 
       if (action === 'trigger') {
-        store.sync.syncCount++;
-        store.sync.lastSync = new Date().toISOString();
-        store.sync.pendingChanges = 0;
+        state.sync.syncCount++;
+        state.sync.lastSync = new Date().toISOString();
+        state.sync.pendingChanges = 0;
 
         // Simulate sync
         await new Promise(resolve => setTimeout(resolve, 50));
 
-        saveCoordStore(store);
+        store.save(state);
 
         return {
           success: true,
           action: 'synchronized',
-          syncCount: store.sync.syncCount,
-          syncedAt: store.sync.lastSync,
-          nodesSync: Object.keys(store.nodes).length,
+          syncCount: state.sync.syncCount,
+          syncedAt: state.sync.lastSync,
+          nodesSync: Object.keys(state.nodes).length,
         };
       }
 
       if (action === 'resolve') {
         const strategy = (input.conflictResolution as string) || 'latest';
 
-        if (store.sync.conflicts > 0) {
-          const resolved = store.sync.conflicts;
-          store.sync.conflicts = 0;
-          saveCoordStore(store);
+        if (state.sync.conflicts > 0) {
+          const resolved = state.sync.conflicts;
+          state.sync.conflicts = 0;
+          store.save(state);
 
           return {
             success: true,

--- a/src/cli/mcp-tools/json-store.ts
+++ b/src/cli/mcp-tools/json-store.ts
@@ -1,0 +1,54 @@
+/**
+ * Tiny JSON-on-disk store shared by the trimmed MCP-tool surfaces
+ * (`coordination-tools`, `system-tools`, `performance-tools`).
+ *
+ * Anchors files at `<cwd>/.moflo/<subdir>/<file>` via {@link mofloDir}. On a
+ * missing file or syntactically-malformed JSON, `load()` falls back to
+ * `defaults()` so first-run callers never crash. Any other I/O failure
+ * (EACCES, EISDIR, etc.) is surfaced — silent recovery there would
+ * masquerade as a clean first-run and discard real on-disk state.
+ *
+ * Intentionally minimal: no locking, no caching, no schema validation.
+ * Each consumer keeps its own typed shape; this is just persistence.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { mofloDir } from '../services/moflo-paths.js';
+
+export interface JsonStoreOptions<T> {
+  subdir: string;
+  file: string;
+  defaults: () => T;
+}
+
+export interface JsonStore<T> {
+  load(): T;
+  save(value: T): void;
+}
+
+export function createJsonStore<T>(opts: JsonStoreOptions<T>): JsonStore<T> {
+  const path = (): string => join(mofloDir(process.cwd()), opts.subdir, opts.file);
+
+  return {
+    load(): T {
+      let raw: string;
+      try {
+        raw = readFileSync(path(), 'utf-8');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return opts.defaults();
+        throw err;
+      }
+      try {
+        return JSON.parse(raw) as T;
+      } catch (err) {
+        if (err instanceof SyntaxError) return opts.defaults();
+        throw err;
+      }
+    },
+    save(value: T): void {
+      const p = path();
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, JSON.stringify(value, null, 2), 'utf-8');
+    },
+  };
+}

--- a/src/cli/mcp-tools/performance-tools.ts
+++ b/src/cli/mcp-tools/performance-tools.ts
@@ -11,14 +11,8 @@
  */
 
 import type { MCPTool } from './types.js';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import * as os from 'node:os';
-import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
-
-// Storage paths
-const PERF_DIR = 'performance';
-const METRICS_FILE = 'metrics.json';
+import { createJsonStore } from './json-store.js';
 
 interface PerfMetrics {
   timestamp: string;
@@ -48,37 +42,11 @@ interface PerfStore {
   version: string;
 }
 
-function getPerfDir(): string {
-  return join(process.cwd(), STORAGE_DIR, PERF_DIR);
-}
-
-function getPerfPath(): string {
-  return join(getPerfDir(), METRICS_FILE);
-}
-
-function ensurePerfDir(): void {
-  const dir = getPerfDir();
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-}
-
-function loadPerfStore(): PerfStore {
-  try {
-    const path = getPerfPath();
-    if (existsSync(path)) {
-      return JSON.parse(readFileSync(path, 'utf-8'));
-    }
-  } catch {
-    // Return empty store
-  }
-  return { metrics: [], benchmarks: {}, version: '3.0.0' };
-}
-
-function savePerfStore(store: PerfStore): void {
-  ensurePerfDir();
-  writeFileSync(getPerfPath(), JSON.stringify(store, null, 2), 'utf-8');
-}
+const store = createJsonStore<PerfStore>({
+  subdir: 'performance',
+  file: 'metrics.json',
+  defaults: () => ({ metrics: [], benchmarks: {}, version: '3.0.0' }),
+});
 
 export const performanceTools: MCPTool[] = [
   {
@@ -94,7 +62,7 @@ export const performanceTools: MCPTool[] = [
       },
     },
     handler: async (input) => {
-      const store = loadPerfStore();
+      const state = store.load();
       const format = (input.format as string) || 'summary';
 
       // Get REAL system metrics via Node.js APIs
@@ -117,24 +85,24 @@ export const performanceTools: MCPTool[] = [
           heap: Math.round(memUsage.heapUsed / 1024 / 1024),
         },
         latency: {
-          avg: store.metrics.length > 0 ? store.metrics.slice(-10).reduce((s, m) => s + m.latency.avg, 0) / Math.min(store.metrics.length, 10) : 50,
-          p50: store.metrics.length > 0 ? store.metrics.slice(-10).reduce((s, m) => s + m.latency.p50, 0) / Math.min(store.metrics.length, 10) : 40,
-          p95: store.metrics.length > 0 ? store.metrics.slice(-10).reduce((s, m) => s + m.latency.p95, 0) / Math.min(store.metrics.length, 10) : 100,
-          p99: store.metrics.length > 0 ? store.metrics.slice(-10).reduce((s, m) => s + m.latency.p99, 0) / Math.min(store.metrics.length, 10) : 200,
+          avg: state.metrics.length > 0 ? state.metrics.slice(-10).reduce((s, m) => s + m.latency.avg, 0) / Math.min(state.metrics.length, 10) : 50,
+          p50: state.metrics.length > 0 ? state.metrics.slice(-10).reduce((s, m) => s + m.latency.p50, 0) / Math.min(state.metrics.length, 10) : 40,
+          p95: state.metrics.length > 0 ? state.metrics.slice(-10).reduce((s, m) => s + m.latency.p95, 0) / Math.min(state.metrics.length, 10) : 100,
+          p99: state.metrics.length > 0 ? state.metrics.slice(-10).reduce((s, m) => s + m.latency.p99, 0) / Math.min(state.metrics.length, 10) : 200,
         },
         throughput: {
-          requests: store.metrics.length > 0 ? store.metrics[store.metrics.length - 1].throughput.requests + 1 : 1,
-          operations: store.metrics.length > 0 ? store.metrics[store.metrics.length - 1].throughput.operations + 10 : 10,
+          requests: state.metrics.length > 0 ? state.metrics[state.metrics.length - 1].throughput.requests + 1 : 1,
+          operations: state.metrics.length > 0 ? state.metrics[state.metrics.length - 1].throughput.operations + 10 : 10,
         },
         errors: { count: 0, rate: 0 },
       };
 
-      store.metrics.push(currentMetrics);
+      state.metrics.push(currentMetrics);
       // Keep last 100 metrics
-      if (store.metrics.length > 100) {
-        store.metrics = store.metrics.slice(-100);
+      if (state.metrics.length > 100) {
+        state.metrics = state.metrics.slice(-100);
       }
-      savePerfStore(store);
+      store.save(state);
 
       if (format === 'summary') {
         return {
@@ -151,7 +119,7 @@ export const performanceTools: MCPTool[] = [
       }
 
       // Calculate trends from history
-      const history = store.metrics.slice(-10);
+      const history = state.metrics.slice(-10);
       const cpuTrend = history.length >= 2
         ? (history[history.length - 1].cpu.usage > history[0].cpu.usage ? 'increasing' : 'stable')
         : 'stable';
@@ -196,7 +164,7 @@ export const performanceTools: MCPTool[] = [
       },
     },
     handler: async (input) => {
-      const store = loadPerfStore();
+      const state = store.load();
       const suite = (input.suite as string) || 'all';
       const iterations = (input.iterations as number) || 100;
       const warmup = input.warmup !== false;
@@ -277,7 +245,7 @@ export const performanceTools: MCPTool[] = [
             createdAt: new Date().toISOString(),
           };
 
-          store.benchmarks[id] = result;
+          state.benchmarks[id] = result;
 
           results.push({
             name: suiteName,
@@ -289,10 +257,10 @@ export const performanceTools: MCPTool[] = [
         }
       }
 
-      savePerfStore(store);
+      store.save(state);
 
       // Calculate comparison vs previous benchmarks
-      const allBenchmarks = Object.values(store.benchmarks);
+      const allBenchmarks = Object.values(state.benchmarks);
       const previousBenchmarks = allBenchmarks
         .filter(b => suitesToRun.includes(b.name) && b.createdAt < results[0]?.name)
         .slice(-suitesToRun.length);

--- a/src/cli/mcp-tools/system-tools.ts
+++ b/src/cli/mcp-tools/system-tools.ts
@@ -9,13 +9,7 @@
  */
 
 import type { MCPTool } from './types.js';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
-
-// Storage paths
-const SYSTEM_DIR = 'system';
-const METRICS_FILE = 'metrics.json';
+import { createJsonStore } from './json-store.js';
 
 interface SystemMetrics {
   startTime: string;
@@ -29,31 +23,10 @@ interface SystemMetrics {
   requests: { total: number; success: number; errors: number };
 }
 
-function getSystemDir(): string {
-  return join(process.cwd(), STORAGE_DIR, SYSTEM_DIR);
-}
-
-function getMetricsPath(): string {
-  return join(getSystemDir(), METRICS_FILE);
-}
-
-function ensureSystemDir(): void {
-  const dir = getSystemDir();
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-}
-
-function loadMetrics(): SystemMetrics {
-  try {
-    const path = getMetricsPath();
-    if (existsSync(path)) {
-      return JSON.parse(readFileSync(path, 'utf-8'));
-    }
-  } catch {
-    // Return default metrics
-  }
-  return {
+const store = createJsonStore<SystemMetrics>({
+  subdir: 'system',
+  file: 'metrics.json',
+  defaults: () => ({
     startTime: new Date().toISOString(),
     lastCheck: new Date().toISOString(),
     uptime: 0,
@@ -63,14 +36,8 @@ function loadMetrics(): SystemMetrics {
     agents: { active: 0, total: 0 },
     tasks: { pending: 0, completed: 0, failed: 0 },
     requests: { total: 0, success: 0, errors: 0 },
-  };
-}
-
-function saveMetrics(metrics: SystemMetrics): void {
-  ensureSystemDir();
-  metrics.lastCheck = new Date().toISOString();
-  writeFileSync(getMetricsPath(), JSON.stringify(metrics, null, 2), 'utf-8');
-}
+  }),
+});
 
 export const systemTools: MCPTool[] = [
   {
@@ -86,7 +53,7 @@ export const systemTools: MCPTool[] = [
       },
     },
     handler: async (input) => {
-      const metrics = loadMetrics();
+      const metrics = store.load();
       const checks: Array<{ name: string; status: string; latency: number; message?: string }> = [];
 
       // Core checks
@@ -140,7 +107,8 @@ export const systemTools: MCPTool[] = [
 
       // Update metrics
       metrics.health = overallHealth;
-      saveMetrics(metrics);
+      metrics.lastCheck = new Date().toISOString();
+      store.save(metrics);
 
       return {
         overall: overallHealth >= 0.8 ? 'healthy' : overallHealth >= 0.5 ? 'degraded' : 'unhealthy',


### PR DESCRIPTION
## Summary

Three trimmed `*-tools.ts` files shared near-identical `getXDir / getXPath / ensureXDir / loadXStore / saveXStore` boilerplate (~40 lines each) for `.moflo/<subdir>/<file>.json` persistence. Extract a shared helper.

- New helper: `src/cli/mcp-tools/json-store.ts` — `createJsonStore<T>({ subdir, file, defaults })` returning `{ load(), save(value) }`. Anchors at `mofloDir(process.cwd())`.
- Migrated: `coordination-tools.ts`, `system-tools.ts`, `performance-tools.ts`.
- Net: ~96 lines of boilerplate gone.

## Changes

- `load()` returns `defaults()` on **ENOENT** or **SyntaxError** only. Any other I/O error (EACCES, EISDIR, etc.) propagates — silent recovery there would masquerade as a first-run and discard real on-disk state, contradicting the project's no-silent-failures rule.
- `defaults` is a factory called per miss, so values like `new Date().toISOString()` stay fresh.
- Anchors via `mofloDir()` (services/moflo-paths.ts) rather than inlining `join(process.cwd(), '.moflo', ...)`.
- `system-tools.ts` previously stamped `metrics.lastCheck = new Date().toISOString()` inside `saveMetrics()`; that domain mutation moved to the call site (the helper is generic, doesn't know schemas).
- `performance-tools.ts` handlers had a local `const store = loadPerfStore()` that would shadow the new module-level `store`; renamed local to `state`. Same convention in coordination-tools.

## Testing

- [x] New unit tests in `src/cli/__tests__/mcp-tools-json-store.test.ts` cover: missing file → defaults, round-trip, malformed JSON → defaults, nested mkdir on save, defaults() called per miss, pretty-print, **non-ENOENT errors propagate** (EISDIR via mkdir-at-file-path, cross-platform).
- [x] Existing `mcp-tools-deep` (72 tests) and `mcp-tools-drift-guard` (4 tests) green — no consumer-visible behaviour change.
- [x] `npx tsc --noEmit` clean.

## Out of scope (filed/flagged separately)

- `src/cli/mcp-tools/hive-mind-tools.ts:189-208` has the same pattern — eligible for a follow-up migration.
- `src/cli/mcp-tools/session-tools.ts:33-66` is a per-session-id-files variant; needs a different abstraction.
- `performance-tools.ts:265` filters on `b.createdAt < results[0]?.name` (ISO timestamp vs. benchmark-name string — always false). Pre-existing dead comparison surfaced by the diff; not touched here.

Closes #701