### PR TITLE
cleanup(714): retire .swarm/vector-stats.json parallel write

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -492,22 +492,18 @@ function getAgentDBStats() {
   let hasHnsw = false;
 
   // Read cached stats (written by memory store/embed/rebuild commands).
-  // `.moflo/` is the canonical post-#699 location; `.swarm/` is a parallel
-  // copy that build-embeddings.mjs writes for legacy compatibility. First
-  // valid read wins — order is post-rename canonical first, then legacy.
-  const cachePaths = [
-    path.join(CWD, '.moflo', 'vector-stats.json'),
-    path.join(CWD, '.swarm', 'vector-stats.json'),
-  ];
-  for (const cp of cachePaths) {
-    const cached = readJSON(cp);
-    if (cached && typeof cached.vectorCount === 'number') {
-      vectorCount = cached.vectorCount;
-      dbSizeKB = cached.dbSizeKB || 0;
-      namespaces = cached.namespaces || 0;
-      hasHnsw = cached.hasHnsw || false;
-      return { vectorCount, dbSizeKB, namespaces, hasHnsw };
-    }
+  // `.moflo/` is the canonical location post-#699; the `.swarm/` parallel
+  // write was retired in #714 because every writer (bridge-core,
+  // memory-initializer, build-embeddings) now writes here, so the legacy
+  // fallback can only ever be stale — exactly the divergence trap that
+  // produced #639.
+  const cached = readJSON(path.join(CWD, '.moflo', 'vector-stats.json'));
+  if (cached && typeof cached.vectorCount === 'number') {
+    vectorCount = cached.vectorCount;
+    dbSizeKB = cached.dbSizeKB || 0;
+    namespaces = cached.namespaces || 0;
+    hasHnsw = cached.hasHnsw || false;
+    return { vectorCount, dbSizeKB, namespaces, hasHnsw };
   }
 
   // Fallback: estimate from DB file size (no subprocess)

--- a/.claude/scripts/build-embeddings.mjs
+++ b/.claude/scripts/build-embeddings.mjs
@@ -185,10 +185,9 @@ function writeVectorStatsCache(stats, nsCount) {
       hasHnsw: hnswExists,
       updatedAt: Date.now(),
     };
-    for (const cacheDir of [resolve(projectRoot, '.moflo'), resolve(projectRoot, '.swarm')]) {
-      if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
-      writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
-    }
+    const cacheDir = resolve(projectRoot, '.moflo');
+    if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
   } catch (err) {
     debug(`vector-stats cache write failed (non-fatal): ${err.message}`);
   }

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -402,6 +402,16 @@ try {
   }
 } catch { /* non-fatal */ }
 
+// ── 3b-714. Retire legacy `.swarm/vector-stats.json` parallel write (#714) ─
+// `.moflo/vector-stats.json` is canonical post-#699; pre-#714 builds also
+// wrote a copy under `.swarm/` for a "legacy compatibility" reader that no
+// longer exists. The leftover file can only ever be stale, so delete it on
+// session start. Unconditional unlink — the catch absorbs ENOENT once the
+// file is gone, so this is idempotent without a stat probe.
+try {
+  unlinkSync(resolve(projectRoot, '.swarm', 'vector-stats.json'));
+} catch { /* non-fatal — ENOENT once removed, EACCES on Windows AV holds */ }
+
 // ── 3c. Clean up double-prefixed guidance files from pre-4.8.45 upgrade ─────
 // Before 4.8.45, session-start dynamically prepended "moflo-" to shipped filenames.
 // When upgrading to 4.8.45+ (where files already have the prefix), the old in-memory

--- a/bin/build-embeddings.mjs
+++ b/bin/build-embeddings.mjs
@@ -185,10 +185,9 @@ function writeVectorStatsCache(stats, nsCount) {
       hasHnsw: hnswExists,
       updatedAt: Date.now(),
     };
-    for (const cacheDir of [resolve(projectRoot, '.moflo'), resolve(projectRoot, '.swarm')]) {
-      if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
-      writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
-    }
+    const cacheDir = resolve(projectRoot, '.moflo');
+    if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
   } catch (err) {
     debug(`vector-stats cache write failed (non-fatal): ${err.message}`);
   }

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -451,6 +451,16 @@ try {
   }
 } catch { /* non-fatal */ }
 
+// ── 3b-714. Retire legacy `.swarm/vector-stats.json` parallel write (#714) ─
+// `.moflo/vector-stats.json` is canonical post-#699; pre-#714 builds also
+// wrote a copy under `.swarm/` for a "legacy compatibility" reader that no
+// longer exists. The leftover file can only ever be stale, so delete it on
+// session start. Unconditional unlink — the catch absorbs ENOENT once the
+// file is gone, so this is idempotent without a stat probe.
+try {
+  unlinkSync(resolve(projectRoot, '.swarm', 'vector-stats.json'));
+} catch { /* non-fatal — ENOENT once removed, EACCES on Windows AV holds */ }
+
 // ── 3c. Clean up double-prefixed guidance files from pre-4.8.45 upgrade ─────
 // Before 4.8.45, session-start dynamically prepended "moflo-" to shipped filenames.
 // When upgrading to 4.8.45+ (where files already have the prefix), the old in-memory

--- a/src/cli/__tests__/statusline-paths.test.ts
+++ b/src/cli/__tests__/statusline-paths.test.ts
@@ -1,16 +1,16 @@
 /**
- * Path-hygiene test for the deployed `.claude/helpers/statusline.cjs` (#639).
+ * Path-hygiene test for the deployed `.claude/helpers/statusline.cjs`.
  *
- * The migration commit that renamed runtime state from `.claude-flow/` to
- * `.moflo/` (PR #706) missed this file. The bug was that statusline read
- * `.claude-flow/vector-stats.json` (legacy) before `.moflo/vector-stats.json`
- * (canonical), so when a different writer left a stale `vectorCount: 0` in
- * the legacy path the statusline displayed `Vectors ●0` despite the live DB
- * having thousands of embedded rows.
+ * Two regression bands are guarded here:
  *
- * This test guards against the file regressing: it must contain zero
- * `.claude-flow/` references and must read the `.moflo/` cache before the
- * `.swarm/` fallback.
+ * 1. #639 / #706 — the rename from `.claude-flow/` to `.moflo/` must stay
+ *    complete. A `.claude-flow/` reference creeping back in would resurface
+ *    the original bug where stale legacy files masked the canonical count.
+ *
+ * 2. #714 — the `.swarm/vector-stats.json` parallel read was retired now
+ *    that every writer (bridge-core, memory-initializer, build-embeddings)
+ *    targets `.moflo/` only. A `.swarm/vector-stats.json` reference creeping
+ *    back in would re-introduce the divergence trap that produced #639.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -18,19 +18,16 @@ import { resolve } from 'node:path';
 
 const STATUSLINE = resolve(__dirname, '../../../.claude/helpers/statusline.cjs');
 
-describe('.claude/helpers/statusline.cjs — post-#699 path hygiene (#639)', () => {
+describe('.claude/helpers/statusline.cjs — vector-stats path hygiene', () => {
   const source = readFileSync(STATUSLINE, 'utf-8');
 
-  it('contains zero `.claude-flow/` path references', () => {
+  it('contains zero `.claude-flow/` path references (#639/#706)', () => {
     const matches = source.match(/\.claude-flow\b/g) ?? [];
     expect(matches).toHaveLength(0);
   });
 
-  it('reads the `.moflo/vector-stats.json` cache before the `.swarm/` fallback', () => {
-    const mofloIdx = source.indexOf("'.moflo', 'vector-stats.json'");
-    const swarmIdx = source.indexOf("'.swarm', 'vector-stats.json'");
-    expect(mofloIdx).toBeGreaterThanOrEqual(0);
-    expect(swarmIdx).toBeGreaterThanOrEqual(0);
-    expect(mofloIdx).toBeLessThan(swarmIdx);
+  it('reads `.moflo/vector-stats.json` and never `.swarm/vector-stats.json` (#714)', () => {
+    expect(source).toContain("'.moflo', 'vector-stats.json'");
+    expect(source).not.toContain("'.swarm', 'vector-stats.json'");
   });
 });


### PR DESCRIPTION
## Summary

Retire the `.swarm/vector-stats.json` parallel write left over from the #699 `.claude-flow/` → `.moflo/` rename. Two writers (build-embeddings + statusline reader) created a divergence trap that already produced #639 once — this PR collapses to a single `.moflo/` writer/reader and adds a one-time cleanup of the legacy file.

## Changes

- `bin/build-embeddings.mjs` (+ synced `.claude/scripts/` copy) — single `.moflo/` write instead of dual loop
- `.claude/helpers/statusline.cjs` — single-path read, comment explains why the fallback was retired
- `bin/session-start-launcher.mjs` (+ synced `.claude/scripts/` copy) — unconditional one-time `unlinkSync('.swarm/vector-stats.json')` (catch absorbs ENOENT — idempotent without TOCTOU stat)
- `src/cli/__tests__/statusline-paths.test.ts` — stronger assertion: `not.toContain('.swarm/vector-stats.json')` instead of "moflo-before-swarm" ordering

## Out of scope

- `.swarm/memory.db` (sql.js DB lives there post-#699)
- `.swarm/hnsw.index` (separate cleanup if any)

## Testing

- [x] `statusline-paths.test.ts` (2 tests) — green, both bands (#639/#706 and #714) covered
- [x] `bridge-vector-stats-anti-clobber.test.ts` (2 tests) — green via isolation config
- [x] `bridge-entries.test.ts` (4 tests) — green via isolation config
- [x] `doctor-stale-vector-stats.test.ts` (4 tests) — green
- [x] `tests/doctor-command.test.ts` (7 tests) — green
- [x] `tsc --noEmit` — clean

## Follow-up

#719 — route build-embeddings.mjs through `writeVectorStatsJson` (bridge-core.ts) to unify the payload shape (currently inlines, drops the `missing` field).

Closes #714