### PR TITLE
feat(716): surface every SessionStart launcher mutation to stdout

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -31,6 +31,21 @@ function findProjectRoot() {
 
 const projectRoot = findProjectRoot();
 
+// Visible mutation reporter (#716). Claude Code's SessionStart hook captures
+// stdout as `additionalContext`, so each line here surfaces to Claude — and
+// through it to the user — explaining what the launcher just changed. Keep
+// silent fast-path: only call this when something actually mutated.
+function emitMutation(action, details) {
+  try {
+    const tail = details ? ` (${details})` : '';
+    process.stdout.write(`moflo: ${action}${tail}\n`);
+  } catch {
+    // Writing must never throw — a broken stdout would block session start.
+  }
+}
+
+const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
 // ── 0. LEGACY state migration (#699) ─────────────────────────────────────────
 // Consumers upgrading from older moflo builds (inherited from upstream Ruflo)
 // get a one-time auto-migration of LEGACY `.claude-flow/` → `.moflo/` so claim
@@ -38,7 +53,10 @@ const projectRoot = findProjectRoot();
 // The migration helper is idempotent — see bin/lib/moflo-paths.mjs for the
 // algorithm. LEGACY: no-ops once `.claude-flow/` is gone.
 try {
-  migrateClaudeFlowToMoflo(projectRoot);
+  const cfMigration = migrateClaudeFlowToMoflo(projectRoot);
+  if (cfMigration?.migrated) {
+    emitMutation('migrated runtime state to .moflo/', 'from legacy .claude-flow/'); // LEGACY
+  }
 } catch {
   // Non-fatal — anything left behind by the migration just means it runs
   // again next session. Better to keep launching than to block on it.
@@ -70,7 +88,7 @@ function fireAndForget(cmd, args, label) {
 // failure mode (no lock, dead PID, missing CLI) is silently absorbed — the
 // recycle is best-effort and must never block session start.
 function recycleDaemon(lockFile, label) {
-  if (!existsSync(lockFile)) return;
+  if (!existsSync(lockFile)) return false;
   let stalePid = null;
   try {
     const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
@@ -87,7 +105,9 @@ function recycleDaemon(lockFile, label) {
     if (existsSync(localCliPath)) {
       fireAndForget('node', [localCliPath, 'daemon', 'start', '--quiet'], label);
     }
+    return true;
   }
+  return false;
 }
 
 // ── 2. Reset workflow state for new session ──────────────────────────────────
@@ -146,6 +166,14 @@ try {
     } catch { /* no manifest yet — version check handles first install */ }
 
     if (installedVersion !== cachedVersion || manifestDrifted) {
+      if (installedVersion !== cachedVersion) {
+        emitMutation(
+          'upgraded',
+          cachedVersion ? `${cachedVersion} → ${installedVersion}` : `installed ${installedVersion}`,
+        );
+      } else {
+        emitMutation('repaired stale install', 'manifest drift detected');
+      }
       const binDir = resolve(projectRoot, 'node_modules/moflo/bin');
 
       // ── Manifest-based auto-update ──────────────────────────────────────
@@ -256,14 +284,23 @@ try {
       // ── Clean up files we installed previously but no longer ship ──
       // Only remove files that are in the OLD manifest but NOT in the new one.
       // This ensures we never delete user-created or runtime-generated files.
+      let removedFiles = 0;
       if (previousManifest.length > 0) {
         const currentSet = new Set(currentManifest);
         for (const rel of previousManifest) {
           if (!currentSet.has(rel)) {
             const abs = resolve(projectRoot, rel);
-            try { if (existsSync(abs)) unlinkSync(abs); } catch { /* non-fatal */ }
+            try {
+              if (existsSync(abs)) {
+                unlinkSync(abs);
+                removedFiles++;
+              }
+            } catch { /* non-fatal */ }
           }
         }
+      }
+      if (removedFiles > 0) {
+        emitMutation('cleaned up retired files', `${removedFiles} removed`);
       }
 
       // Recycle the running daemon — its in-process module cache holds the
@@ -277,7 +314,9 @@ try {
       // existed); here a daemon was actually running, so replacing it with a
       // current-code copy is the desired behaviour regardless of that flag.
       try {
-        recycleDaemon(resolve(projectRoot, '.moflo', 'daemon.lock'), 'daemon-recycle');
+        if (recycleDaemon(resolve(projectRoot, '.moflo', 'daemon.lock'), 'daemon-recycle')) {
+          emitMutation('recycled daemon', 'load fresh moflo code');
+        }
       } catch { /* non-fatal — daemon recycle is best-effort */ }
 
       // Write updated manifest + version stamp
@@ -329,7 +368,9 @@ try {
       if (typeof lock?.startedAt === 'number') daemonStartedAt = lock.startedAt;
     } catch { /* corrupt lock — fall through, recycleDaemon will unlink it */ }
     if (daemonStartedAt > 0 && (installedAt - daemonStartedAt) > STALE_DAEMON_MTIME_SKEW_MS) {
-      recycleDaemon(lockFile, 'daemon-stale-recycle');
+      if (recycleDaemon(lockFile, 'daemon-stale-recycle')) {
+        emitMutation('recycled stale daemon', 'predates current install');
+      }
     }
   }
 } catch { /* non-fatal — best-effort stale-daemon detection */ }
@@ -343,6 +384,7 @@ try {
   if (existsSync(settingsPath)) {
     const raw = readFileSync(settingsPath, 'utf-8');
     let dirty = false;
+    const settingsChanges = [];
     const settings = JSON.parse(raw);
 
     // 3a-i. Remove stale PATH override (${PATH} isn't expanded by Claude Code,
@@ -351,6 +393,7 @@ try {
     if (settings.env.PATH) {
       delete settings.env.PATH;
       dirty = true;
+      settingsChanges.push('removed stale PATH override');
     }
 
     // 3a-ii. Replace npx flo hook commands with direct node helper invocations
@@ -382,6 +425,7 @@ try {
 
     const migrationMap = new Map(hookMigrations.map(m => [m.from, m.to]));
 
+    let migratedHookCount = 0;
     function migrateHooks(hookGroups) {
       if (!Array.isArray(hookGroups)) return;
       for (const group of hookGroups) {
@@ -390,6 +434,7 @@ try {
           if (hook.command && migrationMap.has(hook.command)) {
             hook.command = migrationMap.get(hook.command);
             dirty = true;
+            migratedHookCount++;
           }
         }
       }
@@ -400,6 +445,9 @@ try {
         migrateHooks(settings.hooks[eventName]);
       }
     }
+    if (migratedHookCount > 0) {
+      settingsChanges.push(`rewrote ${plural(migratedHookCount, 'npx hook command')}`);
+    }
 
     // 3a-iii. Ensure statusLine is wired (statusline.cjs is synced by step 3
     // but settings.json may lack the config block, so the status line never appears)
@@ -409,6 +457,7 @@ try {
         command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/statusline.cjs" --compact',
       };
       dirty = true;
+      settingsChanges.push('added statusLine');
     }
 
     // 3a-iv. Repair missing required hook wirings (same logic as doctor --fix
@@ -422,12 +471,16 @@ try {
       if (hwPath) {
         const { repairHookWiring } = await import(`file://${hwPath.replace(/\\/g, '/')}`);
         const { repaired } = repairHookWiring(settings);
-        if (repaired.length > 0) dirty = true;
+        if (repaired.length > 0) {
+          dirty = true;
+          settingsChanges.push(`repaired ${plural(repaired.length, 'hook wiring')}`);
+        }
       }
     } catch { /* non-fatal — doctor can still fix later */ }
 
     if (dirty) {
       writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+      emitMutation('updated .claude/settings.json', settingsChanges.join(', '));
     }
   }
 } catch { /* non-fatal — stale hooks won't block session, just emit warnings */ }
@@ -438,6 +491,7 @@ try {
   const guidanceDir = resolve(projectRoot, '.claude/guidance');
   const shippedDir = resolve(projectRoot, 'node_modules/moflo/.claude/guidance/shipped');
   if (existsSync(shippedDir)) {
+    let restoredGuidance = 0;
     const shippedFiles = readdirSync(shippedDir).filter(f => f.endsWith('.md'));
     for (const file of shippedFiles) {
       const dest = resolve(guidanceDir, file);
@@ -446,7 +500,11 @@ try {
         const header = `<!-- AUTO-GENERATED by moflo session-start. Do not edit — changes will be overwritten. -->\n<!-- Source: node_modules/moflo/.claude/guidance/shipped/${file} -->\n\n`;
         const content = readFileSync(resolve(shippedDir, file), 'utf-8');
         writeFileSync(dest, header + content);
+        restoredGuidance++;
       }
+    }
+    if (restoredGuidance > 0) {
+      emitMutation('restored missing guidance files', `${restoredGuidance} restored`);
     }
   }
 } catch { /* non-fatal */ }
@@ -455,10 +513,12 @@ try {
 // `.moflo/vector-stats.json` is canonical post-#699; pre-#714 builds also
 // wrote a copy under `.swarm/` for a "legacy compatibility" reader that no
 // longer exists. The leftover file can only ever be stale, so delete it on
-// session start. Unconditional unlink — the catch absorbs ENOENT once the
-// file is gone, so this is idempotent without a stat probe.
+// session start. Unconditional unlinkSync — ENOENT (the hot path) lands in
+// catch and stays silent, while a successful unlink reaches the emit on the
+// rare cleanup path (#716). Avoids an extra existsSync stat per session.
 try {
   unlinkSync(resolve(projectRoot, '.swarm', 'vector-stats.json'));
+  emitMutation('removed legacy .swarm/vector-stats.json');
 } catch { /* non-fatal — ENOENT once removed, EACCES on Windows AV holds */ }
 
 // ── 3c. Clean up double-prefixed guidance files from pre-4.8.45 upgrade ─────
@@ -468,10 +528,17 @@ try {
 try {
   const guidanceDir = resolve(projectRoot, '.claude/guidance');
   if (existsSync(guidanceDir)) {
+    let removedDoubles = 0;
     for (const file of readdirSync(guidanceDir)) {
       if ((file.startsWith('moflo-moflo-') || file === 'moflo-moflo.md' || file === 'moflo.md') && file.endsWith('.md')) {
-        try { unlinkSync(resolve(guidanceDir, file)); } catch { /* non-fatal */ }
+        try {
+          unlinkSync(resolve(guidanceDir, file));
+          removedDoubles++;
+        } catch { /* non-fatal */ }
       }
+    }
+    if (removedDoubles > 0) {
+      emitMutation('removed legacy double-prefixed guidance files', `${removedDoubles} removed`);
     }
   }
 } catch { /* non-fatal */ }
@@ -491,7 +558,13 @@ try {
   const mofloYaml = resolve(projectRoot, 'moflo.yaml');
   if (upgraderPath && existsSync(mofloYaml)) {
     const { ensureYamlSections } = await import(`file://${upgraderPath.replace(/\\/g, '/')}`);
-    ensureYamlSections(mofloYaml);
+    const appended = ensureYamlSections(mofloYaml);
+    if (Array.isArray(appended) && appended.length > 0) {
+      emitMutation(
+        'updated moflo.yaml',
+        `appended ${plural(appended.length, 'section')}: ${appended.join(', ')}`,
+      );
+    }
   }
 } catch { /* non-fatal — yaml stays as-is, user can still edit manually */ }
 
@@ -504,7 +577,10 @@ try {
   const shimPath = existsSync(shimLib) ? shimLib : existsSync(localShimLib) ? localShimLib : null;
   if (shimPath) {
     const { installGlobalShim } = await import(`file://${shimPath.replace(/\\/g, '/')}`);
-    installGlobalShim({ silent: true });
+    const shimResult = installGlobalShim({ silent: true });
+    if (shimResult?.installed) {
+      emitMutation('installed global flo shim', 'bare `flo` now resolves to project install');
+    }
   }
 } catch { /* non-fatal — flo still works via npx */ }
 
@@ -533,18 +609,10 @@ try {
         out: process.stderr,
         isTTY: Boolean(process.stderr.isTTY),
         onMigrationStart: () => {
-          try {
-            process.stdout.write(
-              'moflo: re-indexing memory store (this may take 30-60s on first run after upgrade)...\n',
-            );
-          } catch { /* writing must never throw */ }
+          emitMutation('re-indexing memory store', 'this may take 30-60s on first run after upgrade');
         },
         onMigrationComplete: (rowsEmbedded) => {
-          try {
-            process.stdout.write(
-              `moflo: memory re-indexed (${rowsEmbedded} rows re-embedded). Search is back.\n`,
-            );
-          } catch { /* writing must never throw */ }
+          emitMutation('memory re-indexed', `${plural(rowsEmbedded, 'row')} re-embedded — search is back`);
         },
       });
     }

--- a/src/cli/__tests__/pretrain-integration.test.ts
+++ b/src/cli/__tests__/pretrain-integration.test.ts
@@ -54,6 +54,16 @@ describe('pretrain handler fileTypes parameter', () => {
     try {
       const mod = await import('../mcp-tools/hooks-tools.js');
       hooksPretrain = mod.hooksPretrain;
+      // Warm the handler's lazy import chain so the first `it` doesn't pay the
+      // cold-start cost. Under full-suite parallel load this initialization
+      // can balloon past the per-test 5s budget; warming once in beforeAll
+      // amortizes it. Args mirror the first test so the same code path is
+      // exercised. (#716 — was the only remaining full-suite flake.)
+      await hooksPretrain.handler({
+        path: '/tmp/nonexistent',
+        depth: 'shallow',
+        fileTypes: ['ts'],
+      });
     } catch {
       // Module may fail to fully load in test env — that's ok,
       // the unit tests above cover the logic extraction

--- a/src/cli/__tests__/spells/preflights.test.ts
+++ b/src/cli/__tests__/spells/preflights.test.ts
@@ -162,28 +162,34 @@ describe('checkPreflights', () => {
   });
 
   it('runs checks in parallel', async () => {
+    // Verify parallelism by observing concurrent in-flight execution rather
+    // than wall-clock timing. Wall-clock `total < 2x sequential` assertions
+    // were flaky on Windows under full-suite parallel-worker contention,
+    // where event-loop scheduling can stretch a 40ms timeout past 75ms even
+    // when the checks did run concurrently.
     const registry = new StepCommandRegistry();
-    const delays: number[] = [];
-    const makeSlow = (name: string, ms: number): PreflightCheck => ({
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const makeChecker = (name: string): PreflightCheck => ({
       name,
       check: async () => {
-        const started = Date.now();
-        await new Promise(r => setTimeout(r, ms));
-        delays.push(Date.now() - started);
+        inFlight++;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
         return { passed: true };
       },
     });
-    registry.register(makeCommand('github', [makeSlow('a', 40), makeSlow('b', 40)]));
+    registry.register(makeCommand('github', [makeChecker('a'), makeChecker('b'), makeChecker('c')]));
 
     const spell: SpellDefinition = {
       name: 'test',
       steps: [step('s1', 'github', {})],
     };
-    const start = Date.now();
     await checkPreflights(collectPreflights(spell, registry, { args: {} }));
-    const total = Date.now() - start;
-    // Sequential would be ~80ms, parallel ~40ms. Allow slack.
-    expect(total).toBeLessThan(75);
+    // If checks ran sequentially the peak would be 1; parallel execution
+    // requires at least 2 simultaneously in-flight.
+    expect(peakInFlight).toBeGreaterThan(1);
   });
 });
 

--- a/tests/bin/launcher-visibility.test.ts
+++ b/tests/bin/launcher-visibility.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for the SessionStart launcher's visible-mutation reporting (#716).
+ *
+ * The launcher does several mutating operations on session start (legacy
+ * runtime-state migration, settings.json rewrites, moflo.yaml section append,
+ * stale-file cleanup, daemon recycle, …). After PR #711 the embeddings
+ * migration writes a user-visible one-liner to stdout; #716 extends that
+ * pattern to every other mutation surface.
+ *
+ * These tests spawn the actual launcher in an isolated temp directory and
+ * assert stdout. Each scenario stages just enough state to trigger one
+ * mutation, then asserts:
+ *   - the expected `moflo: <action> (<details>)` line appears on stdout
+ *   - the silent fast-path is preserved when nothing has actually changed
+ *
+ * The launcher swallows all errors internally and exits cleanly, so the
+ * tests don't need to mock node_modules/moflo — missing optional
+ * dependencies just cause those code paths to silently no-op, which is the
+ * exact behavior we want to verify.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { copyFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { resolve, join } from 'path';
+
+const LAUNCHER = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+const REPO_ROOT = resolve(__dirname, '../..');
+
+function makeTempRoot(): string {
+  const root = resolve(
+    __dirname,
+    '../../.testoutput/.test-launcher-vis-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(root, { recursive: true });
+  // package.json is the project-root marker the launcher walks up to find
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'launcher-test', version: '0.0.0' }));
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows occasionally holds handles — non-fatal for tests */
+  }
+}
+
+function runLauncher(cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync('node', [LAUNCHER], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status };
+}
+
+function mutationLines(stdout: string): string[] {
+  return stdout.split('\n').filter((line) => line.startsWith('moflo:'));
+}
+
+describe('session-start-launcher — visible mutation reporter (#716)', () => {
+  let root: string;
+  beforeEach(() => {
+    root = makeTempRoot();
+  });
+  afterEach(() => {
+    cleanTempRoot(root);
+  });
+
+  it('emits no mutation lines on the silent fast-path (nothing to migrate)', () => {
+    // Bare temp project: no .claude-flow/, no .swarm/, no settings.json, no moflo.yaml,
+    // no node_modules/moflo. Every mutation surface should no-op silently.
+    const { stdout } = runLauncher(root);
+    expect(mutationLines(stdout)).toEqual([]);
+  });
+
+  it('reports `.claude-flow/` → `.moflo/` runtime-state migration', () => {
+    // Stage a legacy runtime-state directory with a single file. The launcher's
+    // step 0 calls migrateClaudeFlowToMoflo() which renames to .moflo/.
+    mkdirSync(join(root, '.claude-flow'), { recursive: true });
+    writeFileSync(join(root, '.claude-flow', 'metrics.json'), '{}');
+
+    const { stdout } = runLauncher(root);
+    const lines = mutationLines(stdout);
+
+    expect(lines).toContain('moflo: migrated runtime state to .moflo/ (from legacy .claude-flow/)');
+    // The migration actually moved the file
+    expect(existsSync(join(root, '.moflo', 'metrics.json'))).toBe(true);
+    expect(existsSync(join(root, '.claude-flow', 'metrics.json'))).toBe(false);
+  });
+
+  it('reports legacy `.swarm/vector-stats.json` removal exactly once', () => {
+    mkdirSync(join(root, '.swarm'), { recursive: true });
+    writeFileSync(join(root, '.swarm', 'vector-stats.json'), '{"stale":true}');
+
+    const first = runLauncher(root);
+    expect(mutationLines(first.stdout)).toContain('moflo: removed legacy .swarm/vector-stats.json');
+    expect(existsSync(join(root, '.swarm', 'vector-stats.json'))).toBe(false);
+
+    // Idempotent silent fast-path: second run sees nothing to remove → no line.
+    const second = runLauncher(root);
+    expect(mutationLines(second.stdout)).not.toContain(
+      'moflo: removed legacy .swarm/vector-stats.json',
+    );
+  });
+
+  it('reports double-prefixed guidance file cleanup', () => {
+    const guidanceDir = join(root, '.claude/guidance');
+    mkdirSync(guidanceDir, { recursive: true });
+    writeFileSync(join(guidanceDir, 'moflo-moflo-core-guidance.md'), '# stale\n');
+    writeFileSync(join(guidanceDir, 'moflo-moflo.md'), '# stale\n');
+    // A real file that must NOT be touched — sanity check that we only delete the doubles
+    writeFileSync(join(guidanceDir, 'moflo-real.md'), '# real\n');
+
+    const { stdout } = runLauncher(root);
+    const lines = mutationLines(stdout);
+
+    expect(
+      lines.some((l) => l.startsWith('moflo: removed legacy double-prefixed guidance files')),
+    ).toBe(true);
+    expect(existsSync(join(guidanceDir, 'moflo-moflo-core-guidance.md'))).toBe(false);
+    expect(existsSync(join(guidanceDir, 'moflo-moflo.md'))).toBe(false);
+    expect(existsSync(join(guidanceDir, 'moflo-real.md'))).toBe(true);
+  });
+
+  it('reports moflo.yaml section append', () => {
+    // The launcher loads bin/lib/yaml-upgrader.mjs relative to projectRoot, so
+    // we stage a copy under the temp root for the upgrader path to resolve.
+    mkdirSync(join(root, 'bin', 'lib'), { recursive: true });
+    copyFileSync(
+      resolve(REPO_ROOT, 'bin/lib/yaml-upgrader.mjs'),
+      join(root, 'bin/lib/yaml-upgrader.mjs'),
+    );
+    // moflo.yaml without `sandbox:` — yaml-upgrader will append it.
+    writeFileSync(join(root, 'moflo.yaml'), 'project:\n  name: test\n');
+
+    const { stdout } = runLauncher(root);
+    const lines = mutationLines(stdout);
+
+    expect(lines.some((l) => l.startsWith('moflo: updated moflo.yaml'))).toBe(true);
+    expect(lines.find((l) => l.startsWith('moflo: updated moflo.yaml'))).toContain('sandbox');
+  });
+
+  it('reports settings.json mutations when stale entries are rewritten', () => {
+    const claudeDir = join(root, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    // Stage a settings.json with multiple stale entries: PATH override, an
+    // npx-flo hook, and a missing statusLine. Each one trips a separate
+    // settingsChanges entry and they share the single emit line.
+    writeFileSync(
+      join(claudeDir, 'settings.json'),
+      JSON.stringify(
+        {
+          env: { PATH: '${PATH}:/somewhere' },
+          hooks: {
+            PreToolUse: [
+              { hooks: [{ command: 'npx flo hooks pre-edit' }] },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const { stdout } = runLauncher(root);
+    const lines = mutationLines(stdout);
+
+    const settingsLine = lines.find((l) => l.startsWith('moflo: updated .claude/settings.json'));
+    expect(settingsLine).toBeDefined();
+    expect(settingsLine).toContain('removed stale PATH override');
+    expect(settingsLine).toContain('rewrote 1 npx hook command');
+    expect(settingsLine).toContain('added statusLine');
+  });
+
+  it('does not emit a settings line when settings.json is already current', () => {
+    const claudeDir = join(root, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    // Settings already has the expected statusLine and no stale entries.
+    writeFileSync(
+      join(claudeDir, 'settings.json'),
+      JSON.stringify(
+        {
+          statusLine: {
+            type: 'command',
+            command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/statusline.cjs" --compact',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const { stdout } = runLauncher(root);
+    const lines = mutationLines(stdout);
+    expect(lines.some((l) => l.startsWith('moflo: updated .claude/settings.json'))).toBe(false);
+  });
+
+  it('every emitted line matches the `moflo: <action> (<details>?)` format', () => {
+    // Trigger several mutations at once to assert the format invariant.
+    mkdirSync(join(root, '.claude-flow'), { recursive: true });
+    writeFileSync(join(root, '.claude-flow', 'x.json'), '{}');
+    mkdirSync(join(root, '.swarm'), { recursive: true });
+    writeFileSync(join(root, '.swarm', 'vector-stats.json'), '{}');
+    writeFileSync(join(root, 'moflo.yaml'), 'project:\n  name: t\n');
+
+    const { stdout } = runLauncher(root);
+    const lines = mutationLines(stdout);
+
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      // `moflo: <action>` minimum, optional ` (<details>)` suffix
+      expect(line).toMatch(/^moflo: [^()][^(]*( \([^)]+\))?$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

PR #711 made the embeddings-migration UX visible. Issue #716 calls out that the launcher does several **other** silent mutations every SessionStart — runtime-state migration, scripts/helpers sync, settings.json rewrites, daemon recycling, manifest cleanup, etc. — and users have no signal moflo did them.

This extends the post-#711 pattern to every silent mutation surface: a single `emitMutation(action, details?)` helper writes `moflo: <action> (<details>)` to stdout, but **only when something actually changed**. The silent fast-path stays silent.

## Changes

- New `emitMutation()` + `plural()` helpers in `bin/session-start-launcher.mjs`
- `recycleDaemon()` now returns boolean so callers can emit on real recycles
- Surfaces wired up:
  - migrated runtime state to .moflo/ (from legacy .claude-flow/)
  - upgraded vX → vY  /  repaired stale install (manifest drift)
  - cleaned up retired files
  - recycled daemon  /  recycled stale daemon
  - updated .claude/settings.json (per-change detail: PATH, hook commands, statusLine, hook wirings)
  - restored missing guidance files
  - removed legacy .swarm/vector-stats.json
  - removed legacy double-prefixed guidance files
  - updated moflo.yaml (sections appended)
  - installed global flo shim
- Existing post-#711 embeddings-migration callbacks migrated onto the shared `emitMutation()` for DRY

## Side fixes (full-suite stability)

Two pre-existing flakes surfaced while verifying — fixed at the source per the broken-window rule, not parked:
- `pretrain-integration.test.ts`: warm the handler's lazy import chain in `beforeAll` so the first `it` doesn't pay cold-start cost under Windows worker contention
- `preflights.test.ts`: replace wall-clock `total < 75ms` with peak-in-flight counter — observes parallelism directly

## Testing

- [x] New `tests/bin/launcher-visibility.test.ts` — spawns the actual launcher in an isolated temp dir, asserts stdout for each mutation type plus the silent fast-path and the `moflo: <action> (<details>?)` format invariant (8 tests)
- [x] All pre-existing launcher tests still pass (bin-scripts, settings-statusline, embeddings-migration-callbacks, install-manifest, lib-sync, yaml-upgrader, daemon-config)
- [x] Full suite: 7271/0 — verified across two consecutive runs
- [x] Drift-guard: added explicit `LEGACY` marker to the line that references `.claude-flow/`

Closes #716