### PR TITLE
refactor(719): route bin/build-embeddings.mjs through writeVectorStatsJson

### DIFF
--- a/.claude/scripts/build-embeddings.mjs
+++ b/.claude/scripts/build-embeddings.mjs
@@ -16,11 +16,13 @@
  *   flo-embeddings --namespace guidance                       # scope to one namespace
  */
 
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { mofloResolveURL, mofloInternalURL } from './lib/moflo-resolve.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 const FASTEMBED_INLINE = 'dist/src/cli/embeddings/fastembed-inline/index.js';
+const BRIDGE_CORE = 'dist/src/cli/memory/bridge-core.js';
+const { writeVectorStatsJson } = await import(mofloInternalURL(BRIDGE_CORE));
 
 function findProjectRoot() {
   let dir = process.cwd();
@@ -173,21 +175,23 @@ function getEmbeddingStats(db) {
   };
 }
 
-function writeVectorStatsCache(stats, nsCount) {
+// Thin wrapper around bridge-core's writeVectorStatsJson — keeps the on-disk
+// payload shape (including the `missing` field doctor reads in #639) in lockstep
+// with the bridge writer. Aggregates `missing` from namespace stats so doctor's
+// stale-vector-stats check still sees a populated count after this script runs.
+function writeVectorStatsCache(stats, nsStats) {
   try {
     const dbSizeKB = Math.floor(readFileSync(DB_PATH).length / 1024);
-    const hnswExists = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
+    const hasHnsw = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
       || existsSync(resolve(projectRoot, '.moflo', 'hnsw.index'));
-    const cacheData = {
+    const missing = nsStats.reduce((sum, ns) => sum + (ns.missing || 0), 0);
+    writeVectorStatsJson(projectRoot, {
       vectorCount: stats.withEmbeddings,
+      missing,
       dbSizeKB,
-      namespaces: nsCount,
-      hasHnsw: hnswExists,
-      updatedAt: Date.now(),
-    };
-    const cacheDir = resolve(projectRoot, '.moflo');
-    if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
-    writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
+      namespaces: nsStats.length,
+      hasHnsw,
+    });
   } catch (err) {
     debug(`vector-stats cache write failed (non-fatal): ${err.message}`);
   }
@@ -211,7 +215,7 @@ async function main() {
     log('All entries already have embeddings');
     const stats = getEmbeddingStats(db);
     log(`Total: ${stats.withEmbeddings}/${stats.total} entries embedded`);
-    writeVectorStatsCache(stats, getNamespaceStats(db).length);
+    writeVectorStatsCache(stats, getNamespaceStats(db));
     db.close();
     return;
   }
@@ -315,7 +319,7 @@ async function main() {
   }
   log('═══════════════════════════════════════════════════════════');
 
-  writeVectorStatsCache(stats, nsStats.length);
+  writeVectorStatsCache(stats, nsStats);
   db.close();
 }
 

--- a/bin/build-embeddings.mjs
+++ b/bin/build-embeddings.mjs
@@ -16,11 +16,13 @@
  *   flo-embeddings --namespace guidance                       # scope to one namespace
  */
 
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { mofloResolveURL, mofloInternalURL } from './lib/moflo-resolve.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 const FASTEMBED_INLINE = 'dist/src/cli/embeddings/fastembed-inline/index.js';
+const BRIDGE_CORE = 'dist/src/cli/memory/bridge-core.js';
+const { writeVectorStatsJson } = await import(mofloInternalURL(BRIDGE_CORE));
 
 function findProjectRoot() {
   let dir = process.cwd();
@@ -173,21 +175,23 @@ function getEmbeddingStats(db) {
   };
 }
 
-function writeVectorStatsCache(stats, nsCount) {
+// Thin wrapper around bridge-core's writeVectorStatsJson — keeps the on-disk
+// payload shape (including the `missing` field doctor reads in #639) in lockstep
+// with the bridge writer. Aggregates `missing` from namespace stats so doctor's
+// stale-vector-stats check still sees a populated count after this script runs.
+function writeVectorStatsCache(stats, nsStats) {
   try {
     const dbSizeKB = Math.floor(readFileSync(DB_PATH).length / 1024);
-    const hnswExists = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
+    const hasHnsw = existsSync(resolve(projectRoot, '.swarm', 'hnsw.index'))
       || existsSync(resolve(projectRoot, '.moflo', 'hnsw.index'));
-    const cacheData = {
+    const missing = nsStats.reduce((sum, ns) => sum + (ns.missing || 0), 0);
+    writeVectorStatsJson(projectRoot, {
       vectorCount: stats.withEmbeddings,
+      missing,
       dbSizeKB,
-      namespaces: nsCount,
-      hasHnsw: hnswExists,
-      updatedAt: Date.now(),
-    };
-    const cacheDir = resolve(projectRoot, '.moflo');
-    if (!existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
-    writeFileSync(resolve(cacheDir, 'vector-stats.json'), JSON.stringify(cacheData));
+      namespaces: nsStats.length,
+      hasHnsw,
+    });
   } catch (err) {
     debug(`vector-stats cache write failed (non-fatal): ${err.message}`);
   }
@@ -211,7 +215,7 @@ async function main() {
     log('All entries already have embeddings');
     const stats = getEmbeddingStats(db);
     log(`Total: ${stats.withEmbeddings}/${stats.total} entries embedded`);
-    writeVectorStatsCache(stats, getNamespaceStats(db).length);
+    writeVectorStatsCache(stats, getNamespaceStats(db));
     db.close();
     return;
   }
@@ -315,7 +319,7 @@ async function main() {
   }
   log('═══════════════════════════════════════════════════════════');
 
-  writeVectorStatsCache(stats, nsStats.length);
+  writeVectorStatsCache(stats, nsStats);
   db.close();
 }
 

--- a/tests/bin/bin-scripts.test.ts
+++ b/tests/bin/bin-scripts.test.ts
@@ -83,6 +83,18 @@ describe('bin/build-embeddings.mjs', () => {
     const result = syntaxCheck(file);
     expect(result.ok).toBe(true);
   });
+
+  // #719 — vector-stats.json payload must stay in lockstep with the bridge
+  // writer. Routing through writeVectorStatsJson is the only way the doctor's
+  // `missing` field (#639) survives a build-embeddings run.
+  it('routes vector-stats writes through bridge-core writeVectorStatsJson', async () => {
+    const { readFileSync } = await import('fs');
+    const src = readFileSync(file, 'utf-8');
+    expect(src).toMatch(/writeVectorStatsJson/);
+    expect(src).toMatch(/dist\/src\/cli\/memory\/bridge-core\.js/);
+    // No bypass via direct write to vector-stats.json
+    expect(src).not.toMatch(/vector-stats\.json['"]\s*,\s*JSON\.stringify/);
+  });
 });
 
 describe('bin/index-guidance.mjs', () => {


### PR DESCRIPTION
## Summary

- Replaces the inlined `writeVectorStatsCache()` in `bin/build-embeddings.mjs` with a thin wrapper that delegates to `writeVectorStatsJson()` from `src/cli/memory/bridge-core.ts` — the same single-source-of-truth helper the bridge already uses.
- Restores the `missing` field on the payload (active rows with NULL embedding) so doctor's stale-vector-stats check (#639) keeps working when `build-embeddings` runs last.
- Mirrors the change to `.claude/scripts/build-embeddings.mjs` (auto-synced consumer copy).

## Why

After #714 retired the `.swarm/vector-stats.json` parallel write, every writer was supposed to route through the centralized helper. `bin/build-embeddings.mjs:176-194` still hand-rolled its own serialization — exactly the dual-writer divergence that originally caused #639. The helper writes `missing`; the inline copy didn't.

## Changes

- `bin/build-embeddings.mjs` — load `writeVectorStatsJson` via `mofloInternalURL('dist/src/cli/memory/bridge-core.js')` (matches the existing `FASTEMBED_INLINE` pattern in the same file), aggregate `missing` from `getNamespaceStats()` rows, drop manual `mkdirSync` + `writeFileSync` of `vector-stats.json`, drop the `updatedAt` field (the helper sets it itself).
- `.claude/scripts/build-embeddings.mjs` — identical sync.
- `tests/bin/bin-scripts.test.ts` — adds a static regression test that asserts the bin file imports `writeVectorStatsJson` from the bridge-core dist path AND contains no direct `vector-stats.json` `writeFileSync` bypass.

## Out of Scope (per issue)

- `LEGACY_SWARM_DIR` constant — `.swarm/` is not legacy, only the vector-stats.json under it was.
- Exporting `detectHnswIndex` from `bridge-core.ts` — the `.swarm/hnsw.index || .moflo/hnsw.index` probe duplicates lines 321-329 of bridge-core but is a separate concern.

## Testing

- [x] `npm test` — full suite green (7271 passed)
- [x] `npm run lint` — clean
- [x] New regression test passes (bin-scripts.test.ts now has 11 tests, was 10)
- [x] `npm run build` — clean

Closes #719

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)