### PR TITLE
feat(636): user-visible upgrade-UX notice via statusline

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -599,6 +599,34 @@ function getIntegrationStatus() {
   return { mcpServers, hasDatabase, hasApi };
 }
 
+// Upgrade notice (#636) — written by the session-start launcher; null when missing, expired, or malformed.
+function getUpgradeNotice() {
+  const data = readJSON(path.join(CWD, '.moflo', 'upgrade-notice.json'));
+  if (!data || typeof data !== 'object') return null;
+  const expiresAt = data.expiresAt ? new Date(data.expiresAt).getTime() : 0;
+  if (!expiresAt || Date.now() > expiresAt) return null;
+  return {
+    kind: data.kind === 'repair' ? 'repair' : 'upgrade',
+    from: typeof data.from === 'string' ? data.from : '',
+    to: typeof data.to === 'string' ? data.to : '',
+    changes: typeof data.changes === 'number' && data.changes > 0 ? data.changes : 0,
+  };
+}
+
+function formatUpgradeNoticeSegment(notice) {
+  if (!notice) return '';
+  const changesPart = notice.changes > 0
+    ? ` ${c.dim}(${notice.changes} ${notice.changes === 1 ? 'change' : 'changes'})${c.reset}`
+    : '';
+  if (notice.kind === 'repair') {
+    return `${c.brightYellow}📦 install repaired${c.reset}${changesPart}`;
+  }
+  const versions = notice.from && notice.to
+    ? `${notice.from} → ${notice.to}`
+    : (notice.to || 'upgraded');
+  return `${c.brightYellow}📦 ${versions}${c.reset}${changesPart}`;
+}
+
 // Session stats (pure file reads)
 function getSessionStats() {
   for (const p of ['.moflo/session.json', '.claude/session.json']) {
@@ -621,6 +649,11 @@ function progressBar(current, total) {
   return '[' + '\u25CF'.repeat(filled) + '\u25CB'.repeat(width - filled) + ']';
 }
 
+function pushUpgradeNoticeSegment(target) {
+  const notice = getUpgradeNotice();
+  if (notice) target.push(formatUpgradeNoticeSegment(notice));
+}
+
 // Single-line statusline for Claude Code's status bar
 function generateStatusline() {
   const git = getGitInfo();
@@ -637,6 +670,8 @@ function generateStatusline() {
 
   // Branding (always shown when enabled)
   parts.push(`${c.bold}${c.brightPurple}\u258A ${SL_CONFIG.branding}${c.reset}`);
+
+  pushUpgradeNoticeSegment(parts);
 
   // User + swarm indicator
   const dot = swarm.coordinationActive ? `${c.brightGreen}\u25CF${c.reset}` : `${c.brightCyan}\u25CF${c.reset}`;
@@ -721,6 +756,7 @@ function generateDashboard() {
     header += `  ${c.dim}\u2502${c.reset}  ${c.cyan}\u23F1 ${session.duration}${c.reset}`;
   }
   lines.push(header);
+  pushUpgradeNoticeSegment(lines);
 
   // Separator
   lines.push(`${c.dim}${'─'.repeat(53)}${c.reset}`);
@@ -796,6 +832,7 @@ function generateCompactDashboard() {
     header += `  ${c.dim}\u2502${c.reset}  ${c.cyan}\u23F1 ${session.duration}${c.reset}`;
   }
   lines.push(header);
+  pushUpgradeNoticeSegment(lines);
 
   // Combined swarm + agentdb + mcp line
   const segments = [];
@@ -845,6 +882,7 @@ function generateJSON() {
     agentdb: getAgentDBStats(),
     tests: getTestStats(),
     git: { modified: git.modified, untracked: git.untracked, staged: git.staged, ahead: git.ahead, behind: git.behind },
+    upgradeNotice: getUpgradeNotice(),
     lastUpdated: new Date().toISOString(),
   };
 }

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -35,7 +35,13 @@ const projectRoot = findProjectRoot();
 // stdout as `additionalContext`, so each line here surfaces to Claude — and
 // through it to the user — explaining what the launcher just changed. Keep
 // silent fast-path: only call this when something actually mutated.
+//
+// `mutationCount` is read by the post-spawn notice writer (#636) so the
+// statusline notice + the closing "starting background tasks" line both
+// know whether anything actually fired this session.
+let mutationCount = 0;
 function emitMutation(action, details) {
+  mutationCount++;
   try {
     const tail = details ? ` (${details})` : '';
     process.stdout.write(`moflo: ${action}${tail}\n`);
@@ -45,6 +51,10 @@ function emitMutation(action, details) {
 }
 
 const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+// Captured inside the upgrade/drift branch so the post-spawn notice writer
+// can persist `.moflo/upgrade-notice.json` for the statusline (#636).
+let upgradeNoticeContext = null;
 
 // ── 0. LEGACY state migration (#699) ─────────────────────────────────────────
 // Consumers upgrading from older moflo builds (inherited from upstream Ruflo)
@@ -167,11 +177,21 @@ try {
 
     if (installedVersion !== cachedVersion || manifestDrifted) {
       if (installedVersion !== cachedVersion) {
+        upgradeNoticeContext = {
+          kind: 'upgrade',
+          from: cachedVersion || null,
+          to: installedVersion,
+        };
         emitMutation(
           'upgraded',
           cachedVersion ? `${cachedVersion} → ${installedVersion}` : `installed ${installedVersion}`,
         );
       } else {
+        upgradeNoticeContext = {
+          kind: 'repair',
+          from: installedVersion,
+          to: installedVersion,
+        };
         emitMutation('repaired stale install', 'manifest drift detected');
       }
       const binDir = resolve(projectRoot, 'node_modules/moflo/bin');
@@ -624,6 +644,48 @@ try {
     const msg = err && err.message ? err.message : String(err);
     process.stderr.write(`embeddings migration check skipped: ${msg}\n`);
   } catch { /* writing the failure itself must not throw */ }
+}
+
+// ── 3f. Persist upgrade notice for statusline (#636) ────────────────────────
+// When this session bumped the version stamp or repaired manifest drift, write
+// a transient `.moflo/upgrade-notice.json` so the statusline can show a
+// leading user-visible segment (`📦 vX → vY (N changes)`). The file expires
+// via TTL — statusline silently ignores it after `expiresAt`. The next
+// upgrade overwrites the file, so no manual cleanup is needed.
+//
+// Stdout emits go to Claude's `additionalContext` (collapsed by default in
+// the system reminder); this notice surfaces the same information directly
+// in the user's UI. Together they close the "Claude appears hung and CPU
+// spikes" gap from #629 — the user always knows when an upgrade procedure
+// just ran.
+const UPGRADE_NOTICE_TTL_MS = 60 * 60 * 1000; // 1 hour
+if (upgradeNoticeContext && mutationCount > 0) {
+  try {
+    const cfDir = resolve(projectRoot, '.moflo');
+    if (!existsSync(cfDir)) mkdirSync(cfDir, { recursive: true });
+    const now = Date.now();
+    const notice = {
+      kind: upgradeNoticeContext.kind,
+      from: upgradeNoticeContext.from,
+      to: upgradeNoticeContext.to,
+      at: new Date(now).toISOString(),
+      expiresAt: new Date(now + UPGRADE_NOTICE_TTL_MS).toISOString(),
+      changes: mutationCount,
+    };
+    writeFileSync(
+      resolve(cfDir, 'upgrade-notice.json'),
+      JSON.stringify(notice, null, 2),
+    );
+  } catch { /* non-fatal — statusline just won't show the segment */ }
+}
+
+// Bypasses emitMutation — framing, not a mutation, so it must not inflate the count.
+if (mutationCount > 0) {
+  try {
+    process.stdout.write(
+      'moflo: starting background tasks (daemon, indexer, pretrain — CPU may briefly spike)\n',
+    );
+  } catch { /* non-fatal */ }
 }
 
 // ── 4. Spawn background tasks ───────────────────────────────────────────────

--- a/src/cli/__tests__/statusline-upgrade-notice.test.ts
+++ b/src/cli/__tests__/statusline-upgrade-notice.test.ts
@@ -1,0 +1,158 @@
+// Statusline upgrade-notice tests (#636) — covers TTL + render across the
+// .moflo/upgrade-notice.json sidecar that session-start writes after an upgrade.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const STATUSLINE = resolve(__dirname, '../../../.claude/helpers/statusline.cjs');
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+}
+
+function makeTempRoot(): string {
+  const root = resolve(
+    REPO_ROOT,
+    '.testoutput',
+    '.test-statusline-notice-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'sl-test', version: '0.0.0' }));
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows occasionally holds handles — non-fatal */
+  }
+}
+
+function runStatusline(cwd: string, args: string[] = ['--json-compact']): RunResult {
+  const result = spawnSync('node', [STATUSLINE, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 15_000,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: cwd, CI: '1' },
+    input: '',
+  });
+  return {
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    status: result.status,
+  };
+}
+
+function writeNotice(root: string, body: unknown) {
+  const dir = join(root, '.moflo');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'upgrade-notice.json'), JSON.stringify(body, null, 2));
+}
+
+describe('statusline upgrade-notice (#636)', () => {
+  let root: string;
+  beforeEach(() => {
+    root = makeTempRoot();
+  });
+  afterEach(() => {
+    cleanTempRoot(root);
+  });
+
+  it('exposes an active notice within TTL via JSON output', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now - 60_000).toISOString(),
+      expiresAt: new Date(now + 30 * 60_000).toISOString(),
+      changes: 3,
+    });
+
+    const { stdout, status } = runStatusline(root);
+    expect(status).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toEqual({
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      changes: 3,
+    });
+  });
+
+  it('omits an expired notice (past expiresAt)', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now - 2 * 60 * 60_000).toISOString(),
+      expiresAt: new Date(now - 60 * 60_000).toISOString(),
+      changes: 3,
+    });
+
+    const { stdout } = runStatusline(root);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toBeNull();
+  });
+
+  it('omits the segment when no notice file exists (fast path)', () => {
+    const { stdout } = runStatusline(root);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toBeNull();
+  });
+
+  it('tolerates a malformed notice file without crashing', () => {
+    const dir = join(root, '.moflo');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'upgrade-notice.json'), '{ this is not json');
+
+    const { stdout, status } = runStatusline(root);
+    expect(status).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toBeNull();
+  });
+
+  it('renders a leading segment with version delta in compact-dashboard output', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now).toISOString(),
+      expiresAt: new Date(now + 30 * 60_000).toISOString(),
+      changes: 3,
+    });
+
+    const { stdout } = runStatusline(root, ['--compact']);
+    // ANSI escapes are present — strip them before asserting.
+    // eslint-disable-next-line no-control-regex
+    const plain = stdout.replace(/\x1B\[[0-9;]*m/g, '');
+    expect(plain).toContain('4.8.79 → 4.8.80');
+    expect(plain).toContain('3 changes');
+  });
+
+  it('renders a "repair" notice with the expected wording', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      kind: 'repair',
+      from: '4.8.80',
+      to: '4.8.80',
+      at: new Date(now).toISOString(),
+      expiresAt: new Date(now + 30 * 60_000).toISOString(),
+      changes: 1,
+    });
+
+    const { stdout } = runStatusline(root, ['--compact']);
+    // eslint-disable-next-line no-control-regex
+    const plain = stdout.replace(/\x1B\[[0-9;]*m/g, '');
+    expect(plain).toContain('install repaired');
+    expect(plain).toContain('1 change');
+    expect(plain).not.toContain('1 changes');
+  });
+});

--- a/tests/bin/launcher-visibility.test.ts
+++ b/tests/bin/launcher-visibility.test.ts
@@ -1,11 +1,13 @@
 /**
- * Tests for the SessionStart launcher's visible-mutation reporting (#716).
+ * Tests for the SessionStart launcher's visible-mutation reporting (#716)
+ * and the user-visible upgrade-notice surface (#636).
  *
  * The launcher does several mutating operations on session start (legacy
  * runtime-state migration, settings.json rewrites, moflo.yaml section append,
  * stale-file cleanup, daemon recycle, …). After PR #711 the embeddings
  * migration writes a user-visible one-liner to stdout; #716 extends that
- * pattern to every other mutation surface.
+ * pattern to every other mutation surface; #636 adds a `.moflo/upgrade-notice.json`
+ * sidecar that the statusline reads to show a leading UI segment.
  *
  * These tests spawn the actual launcher in an isolated temp directory and
  * assert stdout. Each scenario stages just enough state to trigger one
@@ -19,7 +21,7 @@
  * exact behavior we want to verify.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { copyFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { resolve, join } from 'path';
 
@@ -212,5 +214,97 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
       // `moflo: <action>` minimum, optional ` (<details>)` suffix
       expect(line).toMatch(/^moflo: [^()][^(]*( \([^)]+\))?$/);
     }
+  });
+
+  it('emits closing "starting background tasks" line only when something fired', () => {
+    // Bare temp project — silent fast-path, no tasks line.
+    const silent = runLauncher(root);
+    expect(silent.stdout).not.toContain('moflo: starting background tasks');
+
+    // Stage a real mutation so the launcher fires at least once.
+    mkdirSync(join(root, '.swarm'), { recursive: true });
+    writeFileSync(join(root, '.swarm', 'vector-stats.json'), '{}');
+
+    const noisy = runLauncher(root);
+    expect(noisy.stdout).toContain('moflo: starting background tasks');
+    // The line is informational framing — must not match the mutation regex
+    // because it explains what's about to start, not what just happened.
+    expect(
+      noisy.stdout
+        .split('\n')
+        .find((l) => l.startsWith('moflo: starting background tasks')),
+    ).toContain('CPU may briefly spike');
+  });
+
+  it('writes .moflo/upgrade-notice.json with kind=upgrade on a version bump (#636)', () => {
+    // Stage `node_modules/moflo/package.json` at v9.9.9 and a prior cached
+    // version at v9.9.8 so the launcher takes the version-bump branch.
+    mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
+    writeFileSync(
+      join(root, 'node_modules', 'moflo', 'package.json'),
+      JSON.stringify({ name: 'moflo', version: '9.9.9' }),
+    );
+    mkdirSync(join(root, '.moflo'), { recursive: true });
+    writeFileSync(join(root, '.moflo', 'moflo-version'), '9.9.8');
+
+    const { stdout } = runLauncher(root);
+    expect(stdout).toContain('moflo: upgraded (9.9.8 → 9.9.9)');
+
+    const noticePath = join(root, '.moflo', 'upgrade-notice.json');
+    expect(existsSync(noticePath)).toBe(true);
+
+    const notice = JSON.parse(readFileSync(noticePath, 'utf-8'));
+    expect(notice.kind).toBe('upgrade');
+    expect(notice.from).toBe('9.9.8');
+    expect(notice.to).toBe('9.9.9');
+    expect(typeof notice.at).toBe('string');
+    expect(typeof notice.expiresAt).toBe('string');
+    expect(new Date(notice.expiresAt).getTime()).toBeGreaterThan(
+      new Date(notice.at).getTime(),
+    );
+    expect(notice.changes).toBeGreaterThan(0);
+  });
+
+  it('does NOT write upgrade-notice.json on the silent fast-path', () => {
+    // No node_modules/moflo, no version mismatch, no mutations — the notice
+    // must not be created.
+    const noticePath = join(root, '.moflo', 'upgrade-notice.json');
+    expect(existsSync(noticePath)).toBe(false);
+
+    runLauncher(root);
+    expect(existsSync(noticePath)).toBe(false);
+  });
+
+  it('overwrites a stale upgrade-notice.json on a subsequent upgrade', () => {
+    // Pre-seed with a notice from a prior upgrade.
+    mkdirSync(join(root, '.moflo'), { recursive: true });
+    const noticePath = join(root, '.moflo', 'upgrade-notice.json');
+    writeFileSync(
+      noticePath,
+      JSON.stringify({
+        kind: 'upgrade',
+        from: '1.0.0',
+        to: '1.0.1',
+        at: '2020-01-01T00:00:00.000Z',
+        expiresAt: '2020-01-01T01:00:00.000Z',
+        changes: 99,
+      }),
+    );
+
+    // Now stage a fresh upgrade that the launcher should record.
+    mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
+    writeFileSync(
+      join(root, 'node_modules', 'moflo', 'package.json'),
+      JSON.stringify({ name: 'moflo', version: '9.9.9' }),
+    );
+    writeFileSync(join(root, '.moflo', 'moflo-version'), '9.9.8');
+
+    runLauncher(root);
+
+    const updated = JSON.parse(readFileSync(noticePath, 'utf-8'));
+    expect(updated.from).toBe('9.9.8');
+    expect(updated.to).toBe('9.9.9');
+    expect(updated.changes).toBeGreaterThan(0);
+    expect(updated.changes).not.toBe(99);
   });
 });


### PR DESCRIPTION
## Summary

Closes the user-visible-surface gap from #629 — Claude appears hung + CPU spikes during a SessionStart upgrade procedure with no signal anything is happening. #716 made every mutation emit `moflo: <action>` to stdout, which lands in Claude's `additionalContext` (collapsed by default in the system reminder). This PR adds the missing UI surface so the user sees the upgrade *in their statusline*.

Mandatory upgrade — no confirm, no skip, no defer. Pure notification.

## Changes

- **Launcher** (`bin/session-start-launcher.mjs`)
  - Tracks `mutationCount` (incremented inside `emitMutation`) and `upgradeNoticeContext` (set in the version-bump / manifest-drift branch)
  - Step 3f: writes `.moflo/upgrade-notice.json` (`{ kind, from, to, at, expiresAt, changes }`) with 1h TTL when an upgrade fires AND ≥1 mutation occurred. Next upgrade overwrites — no manual cleanup
  - Closing emit: `moflo: starting background tasks (daemon, indexer, pretrain — CPU may briefly spike)` before the fire-and-forget spawn, gated on `mutationCount > 0`. Bypasses `emitMutation` (framing, not a mutation)

- **Statusline** (`.claude/helpers/statusline.cjs`)
  - `getUpgradeNotice()` — reads + TTL-checks + sanitizes
  - `formatUpgradeNoticeSegment()` — renders `📦 4.8.79 → 4.8.80 (3 changes)` (or `📦 install repaired (1 change)` for `kind: 'repair'`)
  - `pushUpgradeNoticeSegment(target)` — single helper used by `generateStatusline`, `generateDashboard`, `generateCompactDashboard` (DRY)
  - `generateJSON` adds `upgradeNotice` field for programmatic consumers

## Test plan

- [x] `tests/bin/launcher-visibility.test.ts` extended (4 new cases)
  - closing background-tasks line fires only on noisy path
  - notice file written with `kind=upgrade` on version bump
  - silent fast-path leaves no notice file
  - subsequent upgrade overwrites stale notice
- [x] New `src/cli/__tests__/statusline-upgrade-notice.test.ts` (6 cases)
  - active notice within TTL exposed via JSON
  - expired notice (past `expiresAt`) omitted
  - missing notice file → null
  - malformed JSON tolerated, no crash
  - leading segment renders in compact-dashboard with version delta
  - `kind: 'repair'` wording + singular pluralization
- [x] Full suite: 7282 passed / 0 failed (broken-window clean)
- [ ] Manual UI verification after publish + reinstall (will validate the symbol post-merge)

Closes #636

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)