### PR TITLE
ci: force bundled JS actions onto Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
 
 env:
   NODE_VERSION: '22'
+  # Forces bundled JS actions (checkout, setup-node, cache, etc.) to run on
+  # Node 24 instead of their pinned Node 20 runtime. Silences the GitHub-wide
+  # Node 20 deprecation warning ahead of the 2026-06-02 forced cutover.
+  # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -19,6 +19,11 @@ on:
 
 env:
   NODE_VERSION: '22'
+  # Forces bundled JS actions (checkout, setup-node, cache, etc.) to run on
+  # Node 24 instead of their pinned Node 20 runtime. Silences the GitHub-wide
+  # Node 20 deprecation warning ahead of the 2026-06-02 forced cutover.
+  # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # Cancel superseded PR runs but never cancel an in-flight push to main:
 # a half-finished smoke on main leaves the branch in an unverified state and

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -15,6 +15,11 @@ on:
 
 env:
   IMAGE: ghcr.io/eric-cielo/moflo-sandbox
+  # Forces bundled JS actions (checkout, etc.) to run on Node 24 instead of
+  # their pinned Node 20 runtime. Silences the Node 20 deprecation warning
+  # ahead of the 2026-06-02 forced cutover.
+  # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # Don't cancel in-flight publishes — a mid-push abort can leave partial manifests
 # on the registry. ci.yml uses cancel-in-progress: true because PR builds are


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the workflow `env:` of `ci.yml`, `consumer-install-smoke.yml`, and `sandbox-image.yml`.
- Silences the GitHub-wide Node 20 deprecation warning produced by the bundled JS runtime in `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/cache@v4`.
- `NODE_VERSION` stays at `'22'` — that controls our workflow steps, which we still want to support on 22.

## Why this works
The deprecation warning is about each action's *internal* JS runtime (Node 20 bundled with v4 actions), not the Node version our steps use. `node-version: '22'` on `setup-node` has no effect on the action's own runtime. The env var is GitHub's documented opt-in to force Node 24 for all bundled JS actions ahead of the 2026-06-02 forced cutover.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Test plan
- [ ] CI green on this PR
- [ ] Verify Node 20 deprecation warning no longer appears on the run summary

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)