### PR TITLE
fix(738): upgrade notice clears after work completes

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -602,13 +602,18 @@ function getIntegrationStatus() {
   return { mcpServers, hasDatabase, hasApi };
 }
 
-// Upgrade notice (#636) — written by the session-start launcher; null when missing, expired, or malformed.
+// Upgrade notice (#636, #738) — written by the session-start launcher; null
+// when missing, expired, or malformed. The launcher writes status='in-progress'
+// while upgrade work is running, then deletes the file when done — so a
+// 'complete' status only ever shows up here for legacy notice files left by
+// pre-#738 launchers.
 function getUpgradeNotice() {
   const data = readJSON(path.join(CWD, '.moflo', 'upgrade-notice.json'));
   if (!data || typeof data !== 'object') return null;
   const expiresAt = data.expiresAt ? new Date(data.expiresAt).getTime() : 0;
   if (!expiresAt || Date.now() > expiresAt) return null;
   return {
+    status: data.status === 'in-progress' ? 'in-progress' : 'complete',
     kind: data.kind === 'repair' ? 'repair' : 'upgrade',
     from: typeof data.from === 'string' ? data.from : '',
     to: typeof data.to === 'string' ? data.to : '',
@@ -618,16 +623,19 @@ function getUpgradeNotice() {
 
 function formatUpgradeNoticeSegment(notice) {
   if (!notice) return '';
-  const changesPart = notice.changes > 0
-    ? ` ${c.dim}(${notice.changes} ${notice.changes === 1 ? 'change' : 'changes'})${c.reset}`
-    : '';
+  let suffix = '';
+  if (notice.status === 'in-progress') {
+    suffix = ` ${c.dim}(updating…)${c.reset}`;
+  } else if (notice.changes > 0) {
+    suffix = ` ${c.dim}(${notice.changes} ${notice.changes === 1 ? 'change' : 'changes'})${c.reset}`;
+  }
   if (notice.kind === 'repair') {
-    return `${c.brightYellow}📦 install repaired${c.reset}${changesPart}`;
+    return `${c.brightYellow}📦 install repaired${c.reset}${suffix}`;
   }
   const versions = notice.from && notice.to
     ? `${notice.from} → ${notice.to}`
     : (notice.to || 'upgraded');
-  return `${c.brightYellow}📦 ${versions}${c.reset}${changesPart}`;
+  return `${c.brightYellow}📦 ${versions}${c.reset}${suffix}`;
 }
 
 // Session stats (pure file reads)
@@ -671,10 +679,13 @@ function generateStatusline() {
 
   const parts = [];
 
+  // Upgrade notice \u2014 leading position so it reads as a transient banner
+  // rather than a permanent column (#738). Only renders during the upgrade
+  // window; the launcher deletes the notice file after work completes.
+  pushUpgradeNoticeSegment(parts);
+
   // Branding (always shown when enabled)
   parts.push(`${c.bold}${c.brightPurple}\u258A ${SL_CONFIG.branding}${c.reset}`);
-
-  pushUpgradeNoticeSegment(parts);
 
   // User + swarm indicator
   const dot = swarm.coordinationActive ? `${c.brightGreen}\u25CF${c.reset}` : `${c.brightCyan}\u25CF${c.reset}`;
@@ -758,8 +769,9 @@ function generateDashboard() {
   if (SL_CONFIG.show_session && session.duration) {
     header += `  ${c.dim}\u2502${c.reset}  ${c.cyan}\u23F1 ${session.duration}${c.reset}`;
   }
-  lines.push(header);
+  // Upgrade notice \u2014 leading line so it reads as a transient banner (#738).
   pushUpgradeNoticeSegment(lines);
+  lines.push(header);
 
   // Separator
   lines.push(`${c.dim}${'─'.repeat(53)}${c.reset}`);
@@ -834,8 +846,9 @@ function generateCompactDashboard() {
   if (SL_CONFIG.show_session && session.duration) {
     header += `  ${c.dim}\u2502${c.reset}  ${c.cyan}\u23F1 ${session.duration}${c.reset}`;
   }
-  lines.push(header);
+  // Upgrade notice \u2014 leading line so it reads as a transient banner (#738).
   pushUpgradeNoticeSegment(lines);
+  lines.push(header);
 
   // Combined swarm + agentdb + mcp line
   const segments = [];

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -9,9 +9,9 @@
 
 import { spawn } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
-import { resolve, dirname } from 'path';
+import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { migrateClaudeFlowToMoflo, migrateMemoryDbToMoflo } from './lib/moflo-paths.mjs';
+import { migrateClaudeFlowToMoflo, migrateMemoryDbToMoflo, mofloDir } from './lib/moflo-paths.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -55,6 +55,36 @@ const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
 // Captured inside the upgrade/drift branch so the post-spawn notice writer
 // can persist `.moflo/upgrade-notice.json` for the statusline (#636).
 let upgradeNoticeContext = null;
+
+// 5-min TTL is a safety net for zombie launchers (statusline ignores past-TTL
+// files). The launcher deletes the notice when upgrade work finishes — no
+// "complete" state lingers, see #738.
+const UPGRADE_NOTICE_INPROGRESS_TTL_MS = 5 * 60 * 1000;
+const UPGRADE_NOTICE_PATH = () => join(mofloDir(projectRoot), 'upgrade-notice.json');
+
+function writeInProgressUpgradeNotice() {
+  if (!upgradeNoticeContext) return;
+  try {
+    mkdirSync(mofloDir(projectRoot), { recursive: true });
+    const now = Date.now();
+    const notice = {
+      status: 'in-progress',
+      kind: upgradeNoticeContext.kind,
+      from: upgradeNoticeContext.from,
+      to: upgradeNoticeContext.to,
+      at: new Date(now).toISOString(),
+      expiresAt: new Date(now + UPGRADE_NOTICE_INPROGRESS_TTL_MS).toISOString(),
+      changes: 0,
+    };
+    writeFileSync(UPGRADE_NOTICE_PATH(), JSON.stringify(notice, null, 2));
+  } catch { /* non-fatal — statusline just won't show the segment */ }
+}
+
+function clearUpgradeNotice() {
+  try {
+    unlinkSync(UPGRADE_NOTICE_PATH());
+  } catch { /* non-fatal — already gone or never existed */ }
+}
 
 // ── 0. LEGACY state migration (#699) ─────────────────────────────────────────
 // Consumers upgrading from older moflo builds (inherited from upstream Ruflo)
@@ -213,6 +243,11 @@ try {
         };
         emitMutation('repaired stale install', 'manifest drift detected');
       }
+      // Surface a transient "(updating…)" badge in the statusline before the
+      // long-running upgrade work (manifest sync, daemon recycle, embeddings
+      // migration). See #738 — the launcher clears this file after work
+      // completes, so the badge naturally disappears once the user is unblocked.
+      writeInProgressUpgradeNotice();
       const binDir = resolve(projectRoot, 'node_modules/moflo/bin');
 
       // ── Manifest-based auto-update ──────────────────────────────────────
@@ -695,37 +730,12 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
-// ── 3f. Persist upgrade notice for statusline (#636) ────────────────────────
-// When this session bumped the version stamp or repaired manifest drift, write
-// a transient `.moflo/upgrade-notice.json` so the statusline can show a
-// leading user-visible segment (`📦 vX → vY (N changes)`). The file expires
-// via TTL — statusline silently ignores it after `expiresAt`. The next
-// upgrade overwrites the file, so no manual cleanup is needed.
-//
-// Stdout emits go to Claude's `additionalContext` (collapsed by default in
-// the system reminder); this notice surfaces the same information directly
-// in the user's UI. Together they close the "Claude appears hung and CPU
-// spikes" gap from #629 — the user always knows when an upgrade procedure
-// just ran.
-const UPGRADE_NOTICE_TTL_MS = 60 * 60 * 1000; // 1 hour
-if (upgradeNoticeContext && mutationCount > 0) {
-  try {
-    const cfDir = resolve(projectRoot, '.moflo');
-    if (!existsSync(cfDir)) mkdirSync(cfDir, { recursive: true });
-    const now = Date.now();
-    const notice = {
-      kind: upgradeNoticeContext.kind,
-      from: upgradeNoticeContext.from,
-      to: upgradeNoticeContext.to,
-      at: new Date(now).toISOString(),
-      expiresAt: new Date(now + UPGRADE_NOTICE_TTL_MS).toISOString(),
-      changes: mutationCount,
-    };
-    writeFileSync(
-      resolve(cfDir, 'upgrade-notice.json'),
-      JSON.stringify(notice, null, 2),
-    );
-  } catch { /* non-fatal — statusline just won't show the segment */ }
+// ── 3f. Clear the in-progress upgrade notice (#636, #738) ───────────────────
+// Upgrade work is finished; drop the notice so the statusline badge disappears
+// immediately. Change summary is already in stdout emits (Claude's
+// `additionalContext`); a lingering "you upgraded a while ago" badge is noise.
+if (upgradeNoticeContext) {
+  clearUpgradeNotice();
 }
 
 // Bypasses emitMutation — framing, not a mutation, so it must not inflate the count.

--- a/src/cli/__tests__/statusline-upgrade-notice.test.ts
+++ b/src/cli/__tests__/statusline-upgrade-notice.test.ts
@@ -63,7 +63,9 @@ describe('statusline upgrade-notice (#636)', () => {
     cleanTempRoot(root);
   });
 
-  it('exposes an active notice within TTL via JSON output', () => {
+  it('exposes a legacy "complete" notice within TTL via JSON output', () => {
+    // No `status` field — exercises the legacy fall-through path so a stale
+    // notice from a pre-#738 launcher still renders sensibly until it expires.
     const now = Date.now();
     writeNotice(root, {
       kind: 'upgrade',
@@ -78,11 +80,60 @@ describe('statusline upgrade-notice (#636)', () => {
     expect(status).toBe(0);
     const json = JSON.parse(stdout);
     expect(json.upgradeNotice).toEqual({
+      status: 'complete',
       kind: 'upgrade',
       from: '4.8.79',
       to: '4.8.80',
       changes: 3,
     });
+  });
+
+  it('exposes an in-progress notice with an updating… indicator', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      status: 'in-progress',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now - 5_000).toISOString(),
+      expiresAt: new Date(now + 5 * 60_000).toISOString(),
+      changes: 0,
+    });
+
+    const { stdout, status } = runStatusline(root);
+    expect(status).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toEqual({
+      status: 'in-progress',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      changes: 0,
+    });
+
+    const compact = runStatusline(root, ['--compact']);
+    // eslint-disable-next-line no-control-regex
+    const plain = compact.stdout.replace(/\x1B\[[0-9;]*m/g, '');
+    expect(plain).toContain('4.8.79 → 4.8.80');
+    expect(plain).toContain('updating');
+    expect(plain).not.toContain('changes');
+  });
+
+  it('omits an in-progress notice past its TTL (zombie launcher safety)', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      status: 'in-progress',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now - 10 * 60_000).toISOString(),
+      expiresAt: new Date(now - 5 * 60_000).toISOString(),
+      changes: 0,
+    });
+
+    const { stdout } = runStatusline(root);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toBeNull();
   });
 
   it('omits an expired notice (past expiresAt)', () => {

--- a/tests/bin/launcher-visibility.test.ts
+++ b/tests/bin/launcher-visibility.test.ts
@@ -236,9 +236,12 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     ).toContain('CPU may briefly spike');
   });
 
-  it('writes .moflo/upgrade-notice.json with kind=upgrade on a version bump (#636)', () => {
+  it('clears upgrade-notice.json after completing a version-bump upgrade (#636, #738)', () => {
     // Stage `node_modules/moflo/package.json` at v9.9.9 and a prior cached
     // version at v9.9.8 so the launcher takes the version-bump branch.
+    // The launcher writes an in-progress notice while upgrade work is running
+    // and DELETES the file when work completes — so the badge disappears once
+    // the user is unblocked instead of lingering for an hour (#738).
     mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
     writeFileSync(
       join(root, 'node_modules', 'moflo', 'package.json'),
@@ -250,19 +253,9 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     const { stdout } = runLauncher(root);
     expect(stdout).toContain('moflo: upgraded (9.9.8 → 9.9.9)');
 
+    // After the launcher exits, the notice file must be GONE (#738 AC).
     const noticePath = join(root, '.moflo', 'upgrade-notice.json');
-    expect(existsSync(noticePath)).toBe(true);
-
-    const notice = JSON.parse(readFileSync(noticePath, 'utf-8'));
-    expect(notice.kind).toBe('upgrade');
-    expect(notice.from).toBe('9.9.8');
-    expect(notice.to).toBe('9.9.9');
-    expect(typeof notice.at).toBe('string');
-    expect(typeof notice.expiresAt).toBe('string');
-    expect(new Date(notice.expiresAt).getTime()).toBeGreaterThan(
-      new Date(notice.at).getTime(),
-    );
-    expect(notice.changes).toBeGreaterThan(0);
+    expect(existsSync(noticePath)).toBe(false);
   });
 
   it('does NOT write upgrade-notice.json on the silent fast-path', () => {
@@ -275,8 +268,9 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     expect(existsSync(noticePath)).toBe(false);
   });
 
-  it('overwrites a stale upgrade-notice.json on a subsequent upgrade', () => {
-    // Pre-seed with a notice from a prior upgrade.
+  it('clears a stale upgrade-notice.json on a subsequent upgrade (#738)', () => {
+    // Pre-seed with a stale notice from a prior upgrade. After this session's
+    // upgrade work completes the launcher must delete it — no lingering badge.
     mkdirSync(join(root, '.moflo'), { recursive: true });
     const noticePath = join(root, '.moflo', 'upgrade-notice.json');
     writeFileSync(
@@ -291,7 +285,7 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
       }),
     );
 
-    // Now stage a fresh upgrade that the launcher should record.
+    // Stage a fresh upgrade that the launcher should process and clean up.
     mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
     writeFileSync(
       join(root, 'node_modules', 'moflo', 'package.json'),
@@ -301,10 +295,6 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
 
     runLauncher(root);
 
-    const updated = JSON.parse(readFileSync(noticePath, 'utf-8'));
-    expect(updated.from).toBe('9.9.8');
-    expect(updated.to).toBe('9.9.9');
-    expect(updated.changes).toBeGreaterThan(0);
-    expect(updated.changes).not.toBe(99);
+    expect(existsSync(noticePath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The session-start launcher previously wrote `.moflo/upgrade-notice.json` with a 1-hour TTL **after** upgrade work finished, turning a transient signal into a permanent statusline column. During the 30–60s embeddings migration the user also had no visual cue that work was still in flight.

## Changes

- **`bin/session-start-launcher.mjs`** — Adds `writeInProgressUpgradeNotice()` (called right after `upgradeNoticeContext` is set, before the long-running work) and `clearUpgradeNotice()` (called at the end of section 3f, replacing the prior 1-hour TTL writer). Uses `mofloDir(projectRoot)` from `bin/lib/moflo-paths.mjs` for path canonicalization. The in-progress notice carries a 5-min TTL as a zombie-launcher safety net.
- **`.claude/helpers/statusline.cjs`** — `getUpgradeNotice()` now exposes a `status` field (defaults to `"complete"` for legacy notice files); `formatUpgradeNoticeSegment()` renders `(updating…)` for `status === "in-progress"`. `pushUpgradeNoticeSegment()` moved to leading position in single-line, dashboard, and compact-dashboard outputs so the badge reads as a transient banner rather than a buried column.
- **Tests** — `statusline-upgrade-notice.test.ts` gains in-progress + zombie-TTL coverage and updates the legacy-fallback test to assert the new shape. `launcher-visibility.test.ts` updates assertions: after the launcher exits, the notice file must be **gone**, not present-with-correct-content.

## Acceptance Criteria (#738)

- [x] Upgrade notice clears once the launcher finishes (file deleted in section 3f).
- [x] During the active upgrade window, the notice includes an `(updating…)` indicator.
- [x] Placement moved to leading position (transient banner, not a permanent column).
- [x] Tests cover the lifecycle: in-progress visible during upgrade → notice removed after completion.

## Testing

- [x] `npx vitest run src/cli/__tests__/statusline-upgrade-notice.test.ts tests/bin/launcher-visibility.test.ts` — 20/20 pass
- [x] Full vitest suite — 6452 tests pass, 16 skipped (no regressions)
- [x] `npx eslint bin/session-start-launcher.mjs --max-warnings 0` clean
- [x] `npx tsc --noEmit -p tsconfig.json` clean

Closes #738

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)