### PR TITLE
fix(729): skip embeddings for ephemeral namespaces + purge legacy rows

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -730,6 +730,38 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
+// ── 3e-729. Purge ephemeral-namespace rows (#729) ───────────────────────────
+// Four namespaces (hive-mind, tasklist, epic-state, test-bridge-fix) store
+// internal moflo run-tracking — never user knowledge — and were polluting the
+// embeddings index. Going forward, writes to those namespaces skip embedding
+// generation (see EPHEMERAL_NAMESPACES in memory/bridge-embedder.ts); existing
+// rows from prior versions get hard-deleted here. Idempotent — returns
+// `purged: 0` once the DB is clean. Runs BEFORE background MCP/daemon spawn
+// so the foreground sql.js write isn't overwritten by a concurrent flush.
+try {
+  const purgePaths = [
+    resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/ephemeral-namespace-purge.js'),
+    resolve(projectRoot, 'dist/src/cli/services/ephemeral-namespace-purge.js'),
+  ];
+  const purgePath = purgePaths.find((p) => existsSync(p));
+  if (purgePath) {
+    const { purgeEphemeralNamespaces } = await import(`file://${purgePath.replace(/\\/g, '/')}`);
+    const result = await purgeEphemeralNamespaces();
+    if (result?.purged > 0) {
+      emitMutation(
+        'pruned ephemeral namespace rows',
+        `${plural(result.purged, 'row')} from internal run-tracking`,
+      );
+    }
+  }
+} catch (err) {
+  // Non-fatal — leftover rows just sit until the next session retries.
+  try {
+    const msg = err && err.message ? err.message : String(err);
+    process.stderr.write(`ephemeral-namespace purge skipped: ${msg}\n`);
+  } catch { /* writing the failure itself must not throw */ }
+}
+
 // ── 3f. Clear the in-progress upgrade notice (#636, #738) ───────────────────
 // Upgrade work is finished; drop the notice so the statusline badge disappears
 // immediately. Change summary is already in stdout emits (Claude's

--- a/src/cli/__tests__/bridge-entries.test.ts
+++ b/src/cli/__tests__/bridge-entries.test.ts
@@ -163,6 +163,82 @@ describe('bridgeStoreEntry — opt-out path (#649)', () => {
   });
 });
 
+describe('bridgeStoreEntry — ephemeral namespace skip (#729)', () => {
+  it.each([
+    ['hive-mind'],
+    ['tasklist'],
+    ['epic-state'],
+    ['test-bridge-fix'],
+  ])("namespace=%s — writes embedding=NULL and embedding_model=NULL even when generateEmbeddingFlag is true", async (namespace) => {
+    // Stub embedder is installed but must NOT be called for ephemeral writes.
+    const embedSpy = vi.fn(async () => new Float32Array(384).fill(0.1));
+    setBridgeEmbedderForTest({
+      model: 'should-not-be-used',
+      dimensions: 384,
+      embed: embedSpy,
+    });
+
+    const result = await bridgeStoreEntry({
+      key: 'k-ephemeral',
+      value: 'run-tracking content',
+      namespace,
+      dbPath,
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.embedding).toBeUndefined();
+    expect(embedSpy).not.toHaveBeenCalled();
+
+    const rows = await readRows(
+      'SELECT embedding, embedding_model, embedding_dimensions FROM memory_entries WHERE key = ?',
+      ['k-ephemeral'],
+    );
+    expect(rows[0]?.embedding).toBeNull();
+    expect(rows[0]?.embedding_model).toBeNull();
+    expect(rows[0]?.embedding_dimensions).toBeNull();
+  });
+
+  it('drops precomputed embeddings for ephemeral namespaces (no smuggling)', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'fast-all-MiniLM-L6-v2' }));
+
+    const result = await bridgeStoreEntry({
+      key: 'k-precomp',
+      value: 'spell record',
+      namespace: 'tasklist',
+      precomputedEmbedding: new Float32Array(384).fill(0.42),
+      dbPath,
+    });
+
+    expect(result?.success).toBe(true);
+    const rows = await readRows(
+      'SELECT embedding, embedding_model FROM memory_entries WHERE key = ?',
+      ['k-precomp'],
+    );
+    expect(rows[0]?.embedding).toBeNull();
+    expect(rows[0]?.embedding_model).toBeNull();
+  });
+
+  it('non-ephemeral namespaces still get embedded normally', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'fast-all-MiniLM-L6-v2' }));
+
+    const result = await bridgeStoreEntry({
+      key: 'k-knowledge',
+      value: 'a real knowledge entry',
+      namespace: 'knowledge',
+      dbPath,
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.embedding?.model).toBe('fast-all-MiniLM-L6-v2');
+    const rows = await readRows(
+      'SELECT embedding, embedding_model FROM memory_entries WHERE key = ?',
+      ['k-knowledge'],
+    );
+    expect(rows[0]?.embedding).not.toBeNull();
+    expect(rows[0]?.embedding_model).toBe('fast-all-MiniLM-L6-v2');
+  });
+});
+
 describe('refreshVectorStatsCache — missing counter (#649)', () => {
   it('writes a `missing` field for active rows with NULL embedding', async () => {
     setBridgeEmbedderForTest(new StubEmbedder({ model: 'fast-all-MiniLM-L6-v2' }));

--- a/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
+++ b/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the #729 ephemeral-namespace purge service.
+ *
+ * Covers:
+ *  - Hard-deletes rows from each of the four ephemeral namespaces
+ *    (hive-mind, tasklist, epic-state, test-bridge-fix)
+ *  - Preserves rows in unrelated namespaces (knowledge, patterns, etc.)
+ *  - Idempotent: clean DB returns purged: 0 and does not rewrite the file
+ *  - Skips DBs that lack memory_entries
+ *  - Returns purged: 0 when the DB does not exist
+ */
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { purgeEphemeralNamespaces } from '../../services/ephemeral-namespace-purge.js';
+import { EPHEMERAL_NAMESPACES } from '../../memory/bridge-embedder.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+
+type SqlJsDb = {
+  run(sql: string, params?: unknown[]): void;
+  exec(sql: string): Array<{ values: unknown[][] }>;
+  export(): Uint8Array;
+  close(): void;
+};
+type SqlJsStatic = { Database: new (data?: Uint8Array) => SqlJsDb };
+
+let SQL: SqlJsStatic;
+
+beforeAll(async () => {
+  const initSqlJs = (await import('sql.js')).default;
+  SQL = (await initSqlJs()) as SqlJsStatic;
+});
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true });
+    } catch {
+      /* non-fatal — Windows occasionally holds file handles */
+    }
+  }
+});
+
+async function makeTmpDb(setup: (db: SqlJsDb) => void): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moflo-eph-purge-'));
+  tmpDirs.push(dir);
+  const dbPath = join(dir, 'memory.db');
+  const db = new SQL.Database();
+  db.run(MEMORY_SCHEMA_V3);
+  setup(db);
+  const bytes = db.export();
+  db.close();
+  await writeFile(dbPath, Buffer.from(bytes));
+  return dbPath;
+}
+
+function countByNamespace(dbBytes: Uint8Array, namespace: string): number {
+  const db = new SQL.Database(dbBytes);
+  try {
+    const stmt = `SELECT COUNT(*) FROM memory_entries WHERE namespace = '${namespace}'`;
+    const rows = db.exec(stmt);
+    return Number(rows[0]?.values?.[0]?.[0] ?? 0);
+  } finally {
+    db.close();
+  }
+}
+
+describe('purgeEphemeralNamespaces (#729)', () => {
+  it('returns purged: 0 when the DB file does not exist', async () => {
+    const result = await purgeEphemeralNamespaces({
+      dbPath: join(tmpdir(), 'moflo-missing-729', 'nope.db'),
+    });
+    expect(result).toEqual({ purged: 0 });
+  });
+
+  it('hard-deletes rows from every ephemeral namespace and preserves others', async () => {
+    const dbPath = await makeTmpDb((db) => {
+      let n = 0;
+      const insert = (id: string, ns: string, content: string) =>
+        db.run(
+          `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+          [id, `k-${id}`, ns, content],
+        );
+
+      // 2 rows per ephemeral namespace
+      for (const ns of EPHEMERAL_NAMESPACES) {
+        insert(`${ns}-${++n}`, ns, `ephemeral-${ns}-1`);
+        insert(`${ns}-${++n}`, ns, `ephemeral-${ns}-2`);
+      }
+
+      // Untouchable: 3 rows in real namespaces with valid content
+      insert('keep-1', 'knowledge', 'real user knowledge');
+      insert('keep-2', 'patterns', 'a learned pattern');
+      insert('keep-3', 'guidance', 'guidance entry');
+    });
+
+    const result = await purgeEphemeralNamespaces({ dbPath });
+    expect(result.purged).toBe(EPHEMERAL_NAMESPACES.size * 2);
+
+    const after = await readFile(dbPath);
+    for (const ns of EPHEMERAL_NAMESPACES) {
+      expect(countByNamespace(after, ns)).toBe(0);
+    }
+    expect(countByNamespace(after, 'knowledge')).toBe(1);
+    expect(countByNamespace(after, 'patterns')).toBe(1);
+    expect(countByNamespace(after, 'guidance')).toBe(1);
+  });
+
+  it('is idempotent: a clean DB returns purged: 0 without writing', async () => {
+    const dbPath = await makeTmpDb((db) => {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+        ['live', 'k', 'patterns', 'c'],
+      );
+    });
+
+    const before = await readFile(dbPath);
+    const result = await purgeEphemeralNamespaces({ dbPath });
+    expect(result).toEqual({ purged: 0 });
+
+    // No write means the file bytes are unchanged.
+    const after = await readFile(dbPath);
+    expect(Buffer.compare(before, after)).toBe(0);
+  });
+
+  it('running twice in succession is a no-op on the second pass', async () => {
+    const dbPath = await makeTmpDb((db) => {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+        ['t1', 'k1', 'tasklist', 'sp-foo'],
+      );
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+        ['t2', 'k2', 'epic-state', 'epic-7'],
+      );
+    });
+
+    const first = await purgeEphemeralNamespaces({ dbPath });
+    expect(first.purged).toBe(2);
+
+    const second = await purgeEphemeralNamespaces({ dbPath });
+    expect(second.purged).toBe(0);
+  });
+
+  it('skips DBs that lack a memory_entries table', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'moflo-eph-purge-other-'));
+    tmpDirs.push(dir);
+    const dbPath = join(dir, 'something.db');
+    const db = new SQL.Database();
+    db.run(`CREATE TABLE other_table (id TEXT PRIMARY KEY);`);
+    const bytes = db.export();
+    db.close();
+    await writeFile(dbPath, Buffer.from(bytes));
+
+    const result = await purgeEphemeralNamespaces({ dbPath });
+    expect(result).toEqual({ purged: 0 });
+  });
+});
+
+describe('EPHEMERAL_NAMESPACES (#729)', () => {
+  it('contains exactly the four documented namespaces', () => {
+    expect(Array.from(EPHEMERAL_NAMESPACES).sort()).toEqual(
+      ['epic-state', 'hive-mind', 'tasklist', 'test-bridge-fix'],
+    );
+  });
+});

--- a/src/cli/memory/bridge-embedder.ts
+++ b/src/cli/memory/bridge-embedder.ts
@@ -54,6 +54,28 @@ export const EMBEDDING_MODEL_OPT_OUT = 'none';
 export const EMBEDDING_MODEL_LEGACY_DEFAULT = 'local';
 
 /**
+ * Namespaces that store internal moflo run-tracking, never user knowledge.
+ * Writes here skip embedding generation entirely — both `embedding` and
+ * `embedding_model` land as NULL, distinct from the opt-out path which still
+ * tags rows with `'none'`. Existing rows in these namespaces are hard-deleted
+ * on upgrade by `services/ephemeral-namespace-purge.ts`.
+ *
+ * Members:
+ * - `hive-mind`     — MCP broadcast traffic (msg:*, agent_join, consensus_propose)
+ * - `tasklist`      — Spell run records (sp-*) written by spells/core/runner.ts + daemon-dashboard.ts
+ * - `epic-state`    — Epic progress (epic-N, story-M) written by commands/epic.ts
+ * - `test-bridge-fix` — Single 2026-04-23 row left over from a one-off test
+ *
+ * See story #729 for the source-trace and rationale.
+ */
+export const EPHEMERAL_NAMESPACES: ReadonlySet<string> = new Set([
+  'hive-mind',
+  'tasklist',
+  'epic-state',
+  'test-bridge-fix',
+]);
+
+/**
  * Minimal contract the bridge needs from an embedder. Tests inject a stub
  * via `setBridgeEmbedderForTest`. `embed()` MUST throw on failure — silent
  * `null` returns are what story #649 is fixing.
@@ -126,14 +148,35 @@ class LazyFastembedBridgeEmbedder implements BridgeEmbedder {
  */
 export type ResolvedEmbedding =
   | { ok: true; json: string; dimensions: number; model: string }
-  | { ok: true; json: null; dimensions: 0; model: string }
+  | { ok: true; json: null; dimensions: 0; model: string | null }
   | { ok: false; reason: string };
+
+/**
+ * Build the `embedding` field of a store-entry response from a resolved
+ * embedding. Returns `undefined` for skip paths (opt-out and ephemeral) so
+ * the caller can pass it straight through.
+ */
+export function embeddingResponseFrom(
+  resolved: Extract<ResolvedEmbedding, { ok: true }>,
+): { dimensions: number; model: string } | undefined {
+  // json !== null narrows to the embedded variant where model is `string`.
+  return resolved.json !== null
+    ? { dimensions: resolved.dimensions, model: resolved.model }
+    : undefined;
+}
 
 export async function resolveBridgeEmbedding(
   value: string,
   precomputed: Float32Array | number[] | undefined,
   generateEmbeddingFlag: boolean | undefined,
+  namespace?: string,
 ): Promise<ResolvedEmbedding> {
+  // Ephemeral namespaces (run-tracking, never user knowledge) skip embeddings
+  // unconditionally — even precomputed vectors are dropped. Result row has
+  // `embedding IS NULL` and `embedding_model IS NULL`. See #729.
+  if (namespace && EPHEMERAL_NAMESPACES.has(namespace)) {
+    return { ok: true, json: null, dimensions: 0, model: null };
+  }
   const wantsEmbedding = generateEmbeddingFlag !== false && value.length > 0;
   if (!wantsEmbedding) {
     return { ok: true, json: null, dimensions: 0, model: EMBEDDING_MODEL_OPT_OUT };

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -9,7 +9,7 @@
  */
 
 import { cosineSim, execRows, generateId, persistBridgeDb, refreshVectorStatsCache, withDb } from './bridge-core.js';
-import { resolveBridgeEmbedding } from './bridge-embedder.js';
+import { embeddingResponseFrom, resolveBridgeEmbedding } from './bridge-embedder.js';
 
 function makeEntryCacheKey(namespace: string, key: string): string {
   const safeNs = String(namespace).replace(/:/g, '_');
@@ -146,13 +146,12 @@ export async function bridgeStoreEntry(options: {
       return { success: false, id, error: `MutationGuard rejected: ${guardResult.reason}` };
     }
 
-    const resolved = await resolveBridgeEmbedding(value, options.precomputedEmbedding, options.generateEmbeddingFlag);
+    const resolved = await resolveBridgeEmbedding(value, options.precomputedEmbedding, options.generateEmbeddingFlag, namespace);
     if (!resolved.ok) {
       return { success: false, id, error: `embedding generation failed: ${resolved.reason}` };
     }
-    const embeddingJson = resolved.json;
-    const dimensions = resolved.dimensions;
-    const model = resolved.model;
+    const { json: embeddingJson, dimensions, model } = resolved;
+    const embeddingResponse = embeddingResponseFrom(resolved);
 
     const insertSql = options.upsert
       ? `INSERT OR REPLACE INTO memory_entries (
@@ -188,7 +187,7 @@ export async function bridgeStoreEntry(options: {
     return {
       success: true,
       id,
-      embedding: embeddingJson ? { dimensions, model } : undefined,
+      embedding: embeddingResponse,
       guarded: true,
       cached: true,
       attested: true,
@@ -250,12 +249,13 @@ export async function bridgeStoreEntries(items: Array<{
       const id = generateId('entry');
       const now = Date.now();
 
-      const resolved = await resolveBridgeEmbedding(value, opts.precomputedEmbedding, opts.generateEmbeddingFlag);
+      const resolved = await resolveBridgeEmbedding(value, opts.precomputedEmbedding, opts.generateEmbeddingFlag, namespace);
       if (!resolved.ok) {
         results.push({ success: false, id, error: `embedding generation failed: ${resolved.reason}` });
         continue;
       }
       const { json: embeddingJson, dimensions, model } = resolved;
+      const embeddingResponse = embeddingResponseFrom(resolved);
 
       const insertSql = opts.upsert
         ? `INSERT OR REPLACE INTO memory_entries (
@@ -294,7 +294,7 @@ export async function bridgeStoreEntries(items: Array<{
       results.push({
         success: true,
         id,
-        embedding: embeddingJson ? { dimensions, model } : undefined,
+        embedding: embeddingResponse,
       });
     }
 

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -15,7 +15,7 @@ import { mofloImport } from '../services/moflo-require.js';
 import { atomicWriteFileSync } from '../services/atomic-file-write.js';
 import { formatEmbeddingError } from './embedding-errors.js';
 import { HnswLite } from './hnsw-lite.js';
-import { EMBEDDING_MODEL_OPT_OUT, getBridgeEmbedder } from './bridge-embedder.js';
+import { EMBEDDING_MODEL_OPT_OUT, EPHEMERAL_NAMESPACES, getBridgeEmbedder } from './bridge-embedder.js';
 import { toFloat32 } from './controllers/_shared.js';
 import { writeVectorStatsJson } from './bridge-core.js';
 import {
@@ -1959,11 +1959,15 @@ export async function storeEntry(options: {
     // success:false rather than inserting a null-embedded row. Opt-out rows
     // (generateEmbeddingFlag=false) are tagged EMBEDDING_MODEL_OPT_OUT — see
     // the constant's docstring in bridge-embedder.ts for the rationale.
+    // Ephemeral namespaces (#729) skip embedding entirely AND tag model NULL.
     let embeddingJson: string | null = null;
     let embeddingDimensions: number | null = null;
-    let embeddingModel: string = EMBEDDING_MODEL_OPT_OUT;
+    let embeddingModel: string | null = EMBEDDING_MODEL_OPT_OUT;
 
-    if (generateEmbeddingFlag && value.length > 0) {
+    const isEphemeralNs = EPHEMERAL_NAMESPACES.has(namespace);
+    if (isEphemeralNs) {
+      embeddingModel = null;
+    } else if (generateEmbeddingFlag && value.length > 0) {
       if (options.precomputedEmbedding) {
         // Tag with the bridge embedder's canonical model so precomputed rows
         // are indistinguishable from live single-embed rows downstream.

--- a/src/cli/services/ephemeral-namespace-purge.ts
+++ b/src/cli/services/ephemeral-namespace-purge.ts
@@ -1,0 +1,97 @@
+/**
+ * Idempotent ephemeral-namespace purge for moflo's memory DB (`.moflo/moflo.db`).
+ *
+ * Story #729 retired four namespaces from the persistent memory layer because
+ * they store internal moflo run-tracking — not user knowledge — and embedding
+ * them polluted the search index:
+ *
+ *  - `hive-mind`        (MCP broadcast traffic)
+ *  - `tasklist`         (spell run records)
+ *  - `epic-state`       (epic progress tracking)
+ *  - `test-bridge-fix`  (single-row leftover from a one-off test)
+ *
+ * This service hard-deletes any rows in those namespaces left over from prior
+ * moflo versions, then VACUUMs to reclaim disk. Future writes to these
+ * namespaces still land in the DB — but skip embedding generation entirely
+ * (see {@link EPHEMERAL_NAMESPACES} in `memory/bridge-embedder.ts`).
+ *
+ * Lives in `services/` so it has no dependency on the CLI command machinery.
+ * That lets `bin/session-start-launcher.mjs` dynamic-import it and run the
+ * purge in foreground BEFORE long-lived sql.js consumers (MCP server, daemon)
+ * open the DB — sql.js dumps the whole snapshot on every flush and would
+ * otherwise clobber our cleanup (see #727's clobber-hazard analysis).
+ *
+ * @module cli/services/ephemeral-namespace-purge
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { EPHEMERAL_NAMESPACES } from '../memory/bridge-embedder.js';
+import { mofloImport } from './moflo-require.js';
+import { atomicWriteFileSync } from './atomic-file-write.js';
+import { memoryDbPath } from './moflo-paths.js';
+
+export interface PurgeEphemeralNamespacesOptions {
+  /** Path to the memory DB. Defaults to `<cwd>/.moflo/moflo.db`. */
+  dbPath?: string;
+}
+
+export interface PurgeEphemeralNamespacesResult {
+  /** Number of rows hard-deleted across all ephemeral namespaces. 0 when nothing to purge. */
+  purged: number;
+}
+
+/**
+ * Hard-delete every row whose namespace is in {@link EPHEMERAL_NAMESPACES}
+ * and VACUUM. Returns `{ purged: 0 }` on the happy path: no DB, sql.js
+ * unavailable, schema lacks `memory_entries`, or no ephemeral rows present.
+ * Errors propagate to the caller (the launcher absorbs them so a failed
+ * purge never blocks session start).
+ */
+export async function purgeEphemeralNamespaces(
+  options: PurgeEphemeralNamespacesOptions = {},
+): Promise<PurgeEphemeralNamespacesResult> {
+  const fs = await import('fs');
+  const path = await import('path');
+
+  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(process.cwd()));
+  if (!fs.existsSync(dbPath)) return { purged: 0 };
+
+  const initSqlJs = (await mofloImport('sql.js'))?.default;
+  if (!initSqlJs) return { purged: 0 };
+
+  const SQL = await initSqlJs();
+  const buffer = fs.readFileSync(dbPath);
+  const db = new SQL.Database(buffer);
+
+  try {
+    // Probe: schema must carry `memory_entries`. Older / non-moflo DBs are
+    // a no-op so we don't VACUUM unrelated SQLite files.
+    const probe = db.exec(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_entries' LIMIT 1`,
+    );
+    if (!probe[0]?.values?.[0]) return { purged: 0 };
+
+    const namespaces = Array.from(EPHEMERAL_NAMESPACES);
+    const placeholders = namespaces.map(() => '?').join(', ');
+
+    // Single-scan delete + rowsModified: skips a redundant COUNT pass on dirty
+    // DBs and avoids the prepare/bind/step/free overhead on clean ones. VACUUM
+    // (and the disk write) only run when something was actually deleted.
+    db.run(
+      `DELETE FROM memory_entries WHERE namespace IN (${placeholders})`,
+      namespaces,
+    );
+    const purged = db.getRowsModified?.() ?? 0;
+    if (purged === 0) return { purged: 0 };
+
+    // VACUUM has to run outside any open transaction; sql.js auto-commits
+    // each `db.run`, so this is safe to chain.
+    db.run('VACUUM');
+
+    atomicWriteFileSync(dbPath, db.export());
+    return { purged };
+  } finally {
+    db.close();
+  }
+}

--- a/src/cli/transfer/storage/gcs.ts
+++ b/src/cli/transfer/storage/gcs.ts
@@ -48,12 +48,21 @@ export function getGCSConfig(): GCSConfig | null {
   };
 }
 
+// Bound the subprocess so a slow / hung gcloud spawn doesn't stretch test
+// timeouts (or session-start probes) indefinitely. gcloud responds in ~100ms
+// when present; 5s is generous for a contended CI runner.
+const GCLOUD_PROBE_TIMEOUT_MS = 5_000;
+
 /**
  * Check if gcloud CLI is available
  */
 export function isGCloudAvailable(): boolean {
   try {
-    execSync('gcloud --version', { stdio: 'pipe', windowsHide: true });
+    execSync('gcloud --version', {
+      stdio: 'pipe',
+      windowsHide: true,
+      timeout: GCLOUD_PROBE_TIMEOUT_MS,
+    });
     return true;
   } catch {
     return false;
@@ -65,7 +74,11 @@ export function isGCloudAvailable(): boolean {
  */
 export async function isGCloudAuthenticated(): Promise<boolean> {
   try {
-    execSync('gcloud auth print-access-token', { stdio: 'pipe', windowsHide: true });
+    execSync('gcloud auth print-access-token', {
+      stdio: 'pipe',
+      windowsHide: true,
+      timeout: GCLOUD_PROBE_TIMEOUT_MS,
+    });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Story #729 of epic #726 (Memory DB hygiene). Four namespaces store internal moflo run-tracking — never user knowledge — and were polluting the embeddings index:

| Namespace | Source writer | What it stores |
|---|---|---|
| `hive-mind` | `mcp-tools/hive-mind-tools.ts` | MCP broadcast traffic |
| `tasklist` | `spells/core/runner.ts`, `services/daemon-dashboard.ts` | Spell run records |
| `epic-state` | `commands/epic.ts` | Epic progress (`epic-N`, `story-M`) |
| `test-bridge-fix` | (no current writer) | Single 2026-04-23 row from a one-off test |

Going forward, writes to those namespaces skip embedding generation entirely — `embedding` and `embedding_model` both land as NULL (distinct from the opt-out path which tags `model='''none''`). Existing rows from prior versions get hard-deleted on session start by a new idempotent purge service.

## Changes

- **`memory/bridge-embedder.ts`** — `EPHEMERAL_NAMESPACES` single source of truth. `resolveBridgeEmbedding()` takes optional `namespace`; ephemeral check is the FIRST branch and drops even precomputed vectors. Added `embeddingResponseFrom(resolved)` helper to unify the response-narrowing in both bridge store paths.
- **`memory/bridge-entries.ts`** — both `bridgeStoreEntry` and `bridgeStoreEntries` now thread namespace into the resolver and use `embeddingResponseFrom()`.
- **`memory/memory-initializer.ts`** — legacy sql.js fallback honors the same skip-list; explicit-NULL binding overrides the schema default `'''local'''`.
- **`services/ephemeral-namespace-purge.ts`** (new) — DELETE-then-`getRowsModified()`, VACUUM only when rows changed. Mirrors `soft-delete-purge.ts` (#728).
- **`bin/session-start-launcher.mjs`** — step 3e-729 wired right after 3e-728. Idempotent — runs every session, no-ops once clean.

## Acceptance criteria

- [x] New rows in any of the 4 namespaces have `embedding IS NULL` and `embedding_model IS NULL`
- [x] After upgrade, `SELECT COUNT(*) FROM memory_entries WHERE namespace IN (...)` returns 0
- [x] Spell + epic + dashboard reads still function (write succeeds, search across `*` namespaces still works)
- [x] Test coverage for skip-list + upgrade-purge

> Note: gating story #736 (populated-consumer smoke profile) is still OPEN. The purge logic here is itself idempotent and tested, but the broader epic-#726 safety harness in #736 is the right gate before publishing this branch as part of `4.9.0`.

## Test plan

- [x] `npm test` — 7317/7317 passing (40 parallel files + isolation batch)
- [x] Embedder skip path: `it.each` per ephemeral namespace asserts NULL/NULL on insert; precomputed vector path also drops embeddings
- [x] Non-ephemeral namespaces still embed normally (regression guard)
- [x] Purge service: hard-delete-only-ephemeral, idempotent (clean DB does not rewrite file), no-op on second pass, skips DBs without `memory_entries`
- [x] `EPHEMERAL_NAMESPACES` set membership locked to the 4 documented namespaces
- [ ] Manual: install in a populated consumer + watch session-start emit `pruned ephemeral namespace rows (N rows from internal run-tracking)` once

Closes #729

Co-Authored-By: Claude <noreply@anthropic.com>