### PR TITLE
fix(indexer): use memory rebuild-index in index-all (#731)

### DIFF
--- a/bin/index-all.mjs
+++ b/bin/index-all.mjs
@@ -219,7 +219,7 @@ async function main() {
 
   // 7. HNSW rebuild — MUST run last, after all writes are committed (#81)
   if (localCli) {
-    await runStep('hnsw-rebuild', 'node', [localCli, 'memory', 'rebuild', '--force']);
+    await runStep('hnsw-rebuild', 'node', [localCli, 'memory', 'rebuild-index', '--force']);
   } else {
     log('SKIP  hnsw-rebuild (CLI not found)');
   }

--- a/tests/bin/session-start-embedding-race.test.ts
+++ b/tests/bin/session-start-embedding-race.test.ts
@@ -91,6 +91,19 @@ describe('bin/index-all.mjs runStep timeout (#744)', () => {
   });
 });
 
+describe('bin/index-all.mjs hnsw-rebuild subcommand (#731)', () => {
+  const file = resolve(BIN, 'index-all.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('invokes `memory rebuild-index`, not the non-existent `memory rebuild`', () => {
+    // The CLI registers `rebuild-index`. Passing `rebuild` prints help and
+    // exits 0, so the chain reports DONE while no rebuild happens — silent
+    // failure on every session-start.
+    expect(src).toMatch(/['"]memory['"]\s*,\s*['"]rebuild-index['"]/);
+    expect(src).not.toMatch(/['"]memory['"]\s*,\s*['"]rebuild['"]\s*,/);
+  });
+});
+
 describe('runStep behavioural smoke — kills slow children on timeout', () => {
   // Fabricate a tiny child script that sleeps longer than the timeout, run
   // it through a stripped-down clone of runStep, and assert the child PID is


### PR DESCRIPTION
## Summary
- `bin/index-all.mjs` invoked `memory rebuild`, but the registered subcommand is `memory rebuild-index`. The memory dispatcher prints help and exits `0` on unknown subcommands, so `hnsw-rebuild` reported DONE while the rebuild silently no-op'd on every session-start.
- One-line fix in the `runStep` argv. Added a source-invariant regression test in `tests/bin/session-start-embedding-race.test.ts` that pins the literal subcommand string and forbids the bare `'rebuild',` form.

## Changes
- `bin/index-all.mjs:222` — `'memory', 'rebuild', '--force'` → `'memory', 'rebuild-index', '--force'`
- `tests/bin/session-start-embedding-race.test.ts` — new `describe('bin/index-all.mjs hnsw-rebuild subcommand (#731)')` block with two assertions

## Testing
- [x] `npx vitest run tests/bin/session-start-embedding-race.test.ts` — 9/9 pass
- [x] `npx vitest run tests/bin/` — 111/111 pass across 11 files
- [x] Verified silent-failure behaviour: `node bin/cli.js memory rebuild --force` exits 0 with help text (the bug)
- [ ] Manual: confirm next session-start runs an actual rebuild (waits on epic #726 task H landing `.moflo/hnsw.index`)

Closes #731