### PR TITLE
fix(732): drop dead explicit-download path from embeddings init

### DIFF
--- a/src/cli/__tests__/commands/embeddings-init-inline.test.ts
+++ b/src/cli/__tests__/commands/embeddings-init-inline.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression tests for #732. The `embeddings init` and `embeddings models -d`
+ * actions used to call `embeddings.downloadEmbeddingModel()`, which throws
+ * unconditionally because the fastembed-inline runtime auto-fetches on first
+ * use. The init command treated the throw as fatal, surfacing
+ * `[ERROR] Initialization failed: Explicit model downloads are not supported`
+ * to consumers running `doctor --fix`, manual `embeddings init`, or
+ * `embeddings models -d <id>`.
+ *
+ * The fix removes the explicit-download path entirely and lets the runtime
+ * fetch on first use. These tests pin that behaviour.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { initCommand, modelsCommand } from '../../commands/embeddings.js';
+import type { CommandContext, ParsedFlags } from '../../types.js';
+
+function makeCtx(flags: ParsedFlags): CommandContext {
+  return {
+    args: [],
+    flags,
+    cwd: process.cwd(),
+    interactive: false,
+  };
+}
+
+describe('embeddings init — inline runtime auto-fetch (#732)', () => {
+  let originalCwd: string;
+  let tmp: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmp = mkdtempSync(join(tmpdir(), 'moflo-embeddings-init-'));
+    process.chdir(tmp);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('default flags (download=true) succeed without throwing', async () => {
+    const result = await initCommand.action!(makeCtx({}));
+    expect(result.success).toBe(true);
+    const cfg = JSON.parse(readFileSync(join(tmp, '.moflo', 'embeddings.json'), 'utf-8'));
+    expect(cfg.model).toBe('all-MiniLM-L6-v2');
+  });
+
+  it('--force over an existing config rewrites and succeeds', async () => {
+    await initCommand.action!(makeCtx({}));
+    expect(existsSync(join(tmp, '.moflo', 'embeddings.json'))).toBe(true);
+
+    const result = await initCommand.action!(makeCtx({ force: true, model: 'all-mpnet-base-v2' }));
+    expect(result.success).toBe(true);
+    const cfg = JSON.parse(readFileSync(join(tmp, '.moflo', 'embeddings.json'), 'utf-8'));
+    expect(cfg.model).toBe('all-mpnet-base-v2');
+    expect(cfg.dimension).toBe(768);
+  });
+
+  it('--no-download still succeeds (back-compat)', async () => {
+    const result = await initCommand.action!(makeCtx({ download: false }));
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('embeddings models -d — inline runtime auto-fetch (#732)', () => {
+  it('returns success with a friendly auto-fetch message', async () => {
+    const result = await modelsCommand.action!(makeCtx({ download: 'all-MiniLM-L6-v2' }));
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('downloadEmbeddingModel removed (#732 drift guard)', () => {
+  it('is no longer exported from embeddings/index', async () => {
+    const mod = await import('../../embeddings/index.js') as Record<string, unknown>;
+    expect(mod.downloadEmbeddingModel).toBeUndefined();
+  });
+
+  it('is not referenced anywhere in src/', () => {
+    // Pure-fs scan matching the established drift-guard pattern in
+    // services/published-package-drift-guard.test.ts (no shell-out, no git
+    // dependency, cross-platform).
+    const repoRoot = findRepoRoot();
+    const offenders: string[] = [];
+    for (const file of walkSrc(join(repoRoot, 'src'))) {
+      const text = readFileSync(file, 'utf-8');
+      if (text.includes('downloadEmbeddingModel')) {
+        offenders.push(file.replace(repoRoot, '').replace(/\\/g, '/'));
+      }
+    }
+    expect(offenders, 'downloadEmbeddingModel must have zero src references').toEqual([]);
+  });
+});
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, 'package.json')) && existsSync(join(dir, 'src', 'cli'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate moflo repo root from drift guard test.');
+}
+
+function* walkSrc(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '__tests__') continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkSrc(full);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!/\.(m?ts|m?js)$/.test(entry.name)) continue;
+    if (entry.name.endsWith('.d.ts')) continue;
+    if (statSync(full).size > 5_000_000) continue;
+    yield full;
+  }
+}

--- a/src/cli/commands/embeddings.ts
+++ b/src/cli/commands/embeddings.ts
@@ -662,7 +662,7 @@ async function safelyRunEmbeddingsMigration(dbPath?: string): Promise<boolean> {
 }
 
 // Init subcommand - Initialize ONNX models and hyperbolic config
-const initCommand: Command = {
+export const initCommand: Command = {
   name: 'init',
   description: 'Initialize embedding subsystem with ONNX model and hyperbolic config',
   options: [
@@ -683,7 +683,6 @@ const initCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const model = ctx.flags.model as string || 'all-MiniLM-L6-v2';
     const hyperbolic = ctx.flags.hyperbolic !== false;
-    const download = ctx.flags.download !== false;
     const force = ctx.flags.force === true;
 
     // Parse curvature - handle both kebab-case and direct value
@@ -702,9 +701,7 @@ const initCommand: Command = {
       const fs = await import('fs');
       const path = await import('path');
 
-      // Create directories
       const configDir = path.join(process.cwd(), '.moflo');
-      const modelDir = path.join(configDir, 'models');
       const configPath = path.join(configDir, 'embeddings.json');
 
       // Second-session path: config already exists. Skip download / rewrite,
@@ -728,24 +725,15 @@ const initCommand: Command = {
       if (!fs.existsSync(configDir)) {
         fs.mkdirSync(configDir, { recursive: true });
       }
-      if (!fs.existsSync(modelDir)) {
-        fs.mkdirSync(modelDir, { recursive: true });
-      }
 
-      // Download model if requested
-      if (download) {
-        spinner.setText(`Downloading ONNX model: ${model}...`);
-        await embeddings.downloadEmbeddingModel(model, modelDir, (p) => {
-          spinner.setText(`Downloading ${model}... ${p.percent.toFixed(0)}%`);
-        });
-      }
-
-      // Write embeddings config
+      // The fastembed-inline runtime fetches the model on first use, so the
+      // legacy explicit-download step has been removed. The `--download` /
+      // `--no-download` flag is still accepted for back-compat with existing
+      // callers (e.g. `npx moflo embeddings init --no-download` in init.ts).
       spinner.setText('Writing configuration...');
       const dimension = model.includes('mpnet') ? 768 : 384;
       const config = {
         model,
-        modelPath: modelDir,
         dimension,
         cacheSize,
         hyperbolic: {
@@ -783,7 +771,7 @@ const initCommand: Command = {
           { setting: 'Cache Size', value: String(cacheSize) + ' entries' },
           { setting: 'Hyperbolic', value: hyperbolic ? `${output.success('Enabled')} (c=${curvature})` : output.dim('Disabled') },
           { setting: 'Neural Substrate', value: output.success('Enabled') },
-          { setting: 'Model Path', value: modelDir },
+          { setting: 'Model Cache', value: output.dim('managed by fastembed-inline') },
           { setting: 'Config', value: configPath },
         ],
       });
@@ -1214,7 +1202,7 @@ const neuralCommand: Command = {
 };
 
 // Models subcommand
-const modelsCommand: Command = {
+export const modelsCommand: Command = {
   name: 'models',
   description: 'List and download embedding models',
   options: [
@@ -1233,18 +1221,12 @@ const modelsCommand: Command = {
     output.writeln(output.dim('─'.repeat(60)));
 
     if (download) {
-      const spinner = output.createSpinner({ text: `Downloading ${download}...`, spinner: 'dots' });
-      spinner.start();
-
-      try {
-        await embeddings.downloadEmbeddingModel(download, '.models', (p) => {
-          spinner.setText(`Downloading ${download}... ${p.percent.toFixed(1)}%`);
-        });
-        spinner.succeed(`Downloaded ${download}`);
-      } catch (err) {
-        spinner.fail(`Failed to download: ${err}`);
-        return { success: false, exitCode: 1 };
-      }
+      // fastembed-inline auto-fetches on first use; explicit downloads are a
+      // no-op in the current build. Keep the flag working as documented but
+      // avoid surfacing a false-positive error.
+      output.printInfo(
+        `Model "${download}" will be fetched on first use (fastembed-inline runtime).`,
+      );
       return { success: true };
     }
 

--- a/src/cli/embeddings/index.ts
+++ b/src/cli/embeddings/index.ts
@@ -138,7 +138,6 @@ export {
   createNeuralService,
   isNeuralAvailable,
   listEmbeddingModels,
-  downloadEmbeddingModel,
   type DriftResult,
   type MemoryEntry,
   type AgentState,

--- a/src/cli/embeddings/neural-integration.ts
+++ b/src/cli/embeddings/neural-integration.ts
@@ -140,18 +140,3 @@ export async function listEmbeddingModels(): Promise<Array<{
   ];
 }
 
-/**
- * The old `downloadModel` path (via `agentic-flow/embeddings`) is no longer
- * available. Neural models are fetched on-demand by `FastembedEmbeddingService`
- * through the upstream `fastembed` package itself.
- */
-export async function downloadEmbeddingModel(
-  _modelId: string,
-  _targetDir?: string,
-  _onProgress?: (progress: { percent: number; bytesDownloaded: number; totalBytes: number }) => void,
-): Promise<string> {
-  throw new Error(
-    'Explicit model downloads are not supported in this build. The ' +
-      'fastembed runtime fetches its model automatically on first use.',
-  );
-}


### PR DESCRIPTION
## Summary

`embeddings init` and `embeddings models -d` called `downloadEmbeddingModel()`, which threw unconditionally because the fastembed-inline runtime auto-fetches on first use. The init command treated the throw as fatal and surfaced `[ERROR] Initialization failed: Explicit model downloads…` to anyone running `doctor --fix` (`doctor.ts:680`), manual `embeddings init`, or `embeddings models -d`.

The original session-start symptom in #732 was already eliminated by #744 (no more spawn from `hooks.mjs session-start`). This PR fixes the latent helper bug that #744 worked around.

## Changes

- `src/cli/commands/embeddings.ts` — drop both `downloadEmbeddingModel` call sites. Init now skips the dead `mkdirSync(modelDir)`, the stale `modelPath` in the persisted config, and the misleading "Model Path" row in the success table. `models -d` returns success with a friendly auto-fetch message. Export `initCommand` / `modelsCommand` for testability.
- `src/cli/embeddings/neural-integration.ts` — delete the always-throwing helper.
- `src/cli/embeddings/index.ts` — drop the export.
- `src/cli/__tests__/commands/embeddings-init-inline.test.ts` — new regression suite covering the three live triggers plus a pure-fs drift guard (matches `services/published-package-drift-guard.test.ts` — no `git grep` shell-out, so it stays cross-platform).

The `--download` / `--no-download` flag stays in the options array so existing callers (`init.ts` passes `--no-download`) keep working.

## Testing

- [x] New regression suite (6 tests) passes
- [x] Full test suite: `npm test` — 7362 passed, 0 failed
- [x] Type check clean (`tsc --noEmit`)
- [x] Manual: `npx moflo embeddings init --force` exits 0 with no `[ERROR]` line

Closes #732