### PR TITLE
fix(734): real HNSW sidecar persistence — graph + neighbors round-trip

### DIFF
--- a/.claude/scripts/build-embeddings.mjs
+++ b/.claude/scripts/build-embeddings.mjs
@@ -16,14 +16,16 @@
  *   flo-embeddings --namespace guidance                       # scope to one namespace
  */
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { mofloResolveURL, mofloInternalURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, hnswIndexPath } from './lib/moflo-paths.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 const FASTEMBED_INLINE = 'dist/src/cli/embeddings/fastembed-inline/index.js';
 const BRIDGE_CORE = 'dist/src/cli/memory/bridge-core.js';
+const HNSW_PERSISTENCE = 'dist/src/cli/memory/hnsw-persistence.js';
 const { writeVectorStatsJson } = await import(mofloInternalURL(BRIDGE_CORE));
+const { buildAndWriteHnswSidecar } = await import(mofloInternalURL(HNSW_PERSISTENCE));
 
 function findProjectRoot() {
   let dir = process.cwd();
@@ -262,15 +264,6 @@ async function main() {
 
   if (embedded > 0) {
     saveDb(db);
-    for (const p of [
-      hnswIndexPath(projectRoot),
-      resolve(projectRoot, '.moflo', 'hnsw.metadata.json'),
-    ]) {
-      if (existsSync(p)) {
-        unlinkSync(p);
-        log(`Deleted stale HNSW index: ${p}`);
-      }
-    }
   }
 
   const stats = getEmbeddingStats(db);
@@ -321,6 +314,20 @@ async function main() {
 
   writeVectorStatsCache(stats, nsStats);
   db.close();
+
+  // Rebuild + persist the HNSW sidecar so cold-start memory searches skip
+  // the SQL→graph rebuild. Failure here exits non-zero — index-all.mjs and
+  // any caller of this script depend on the sidecar landing on disk.
+  if (stats.withEmbeddings > 0) {
+    log('Building HNSW sidecar...');
+    const result = await buildAndWriteHnswSidecar(DB_PATH, projectRoot, {
+      dimensions: EMBEDDING_DIMS,
+    });
+    log(`HNSW sidecar: ${result.vectorCount} vectors → ${result.sidecarPath} (${(result.bytes / 1024).toFixed(1)} KB)`);
+    if (!existsSync(result.sidecarPath)) {
+      throw new Error(`HNSW sidecar missing after write: ${result.sidecarPath}`);
+    }
+  }
 }
 
 main().catch(err => {

--- a/.claude/scripts/index-all.mjs
+++ b/.claude/scripts/index-all.mjs
@@ -14,6 +14,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn, spawnSync } from 'child_process';
 import { platform } from 'os';
+import { hnswIndexPath } from './lib/moflo-paths.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -217,15 +218,32 @@ async function main() {
     log('SKIP  build-embeddings (script not found)');
   }
 
-  // 7. HNSW rebuild — MUST run last, after all writes are committed (#81)
+  // 7. HNSW rebuild — MUST run last, after all writes are committed (#81).
+  //    rebuild-index now also writes the binary HNSW sidecar at
+  //    .moflo/hnsw.index, which can take longer than the default 120s on a
+  //    populated consumer DB — match build-embeddings' 300s budget.
+  let hnswOk = true;
   if (localCli) {
-    await runStep('hnsw-rebuild', 'node', [localCli, 'memory', 'rebuild', '--force']);
+    const ok = await runStep('hnsw-rebuild', 'node', [localCli, 'memory', 'rebuild-index', '--force'], 300_000);
+    if (ok) {
+      const sidecar = hnswIndexPath(projectRoot);
+      if (!existsSync(sidecar)) {
+        // Loud failure: missing sidecar means cold-start memory search
+        // silently rebuilds from SQL on every consumer process — the exact
+        // regression this guard exists to surface.
+        log(`FAIL  hnsw-rebuild post-check: sidecar missing at ${sidecar}`);
+        hnswOk = false;
+      }
+    } else {
+      hnswOk = false;
+    }
   } else {
     log('SKIP  hnsw-rebuild (CLI not found)');
   }
 
   const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   log(`Sequential indexing chain complete (${totalElapsed}s)`);
+  if (!hnswOk) process.exit(1);
 }
 
 main().catch(err => {

--- a/.npmignore
+++ b/.npmignore
@@ -24,7 +24,6 @@
 **/*.db-shm
 **/*.db-wal
 **/hnsw.index
-**/hnsw.metadata.json
 
 # IDE/Editor
 .vscode/

--- a/bin/build-embeddings.mjs
+++ b/bin/build-embeddings.mjs
@@ -16,14 +16,16 @@
  *   flo-embeddings --namespace guidance                       # scope to one namespace
  */
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { mofloResolveURL, mofloInternalURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, hnswIndexPath } from './lib/moflo-paths.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 const FASTEMBED_INLINE = 'dist/src/cli/embeddings/fastembed-inline/index.js';
 const BRIDGE_CORE = 'dist/src/cli/memory/bridge-core.js';
+const HNSW_PERSISTENCE = 'dist/src/cli/memory/hnsw-persistence.js';
 const { writeVectorStatsJson } = await import(mofloInternalURL(BRIDGE_CORE));
+const { buildAndWriteHnswSidecar } = await import(mofloInternalURL(HNSW_PERSISTENCE));
 
 function findProjectRoot() {
   let dir = process.cwd();
@@ -262,15 +264,6 @@ async function main() {
 
   if (embedded > 0) {
     saveDb(db);
-    for (const p of [
-      hnswIndexPath(projectRoot),
-      resolve(projectRoot, '.moflo', 'hnsw.metadata.json'),
-    ]) {
-      if (existsSync(p)) {
-        unlinkSync(p);
-        log(`Deleted stale HNSW index: ${p}`);
-      }
-    }
   }
 
   const stats = getEmbeddingStats(db);
@@ -321,6 +314,20 @@ async function main() {
 
   writeVectorStatsCache(stats, nsStats);
   db.close();
+
+  // Rebuild + persist the HNSW sidecar so cold-start memory searches skip
+  // the SQL→graph rebuild. Failure here exits non-zero — index-all.mjs and
+  // any caller of this script depend on the sidecar landing on disk.
+  if (stats.withEmbeddings > 0) {
+    log('Building HNSW sidecar...');
+    const result = await buildAndWriteHnswSidecar(DB_PATH, projectRoot, {
+      dimensions: EMBEDDING_DIMS,
+    });
+    log(`HNSW sidecar: ${result.vectorCount} vectors → ${result.sidecarPath} (${(result.bytes / 1024).toFixed(1)} KB)`);
+    if (!existsSync(result.sidecarPath)) {
+      throw new Error(`HNSW sidecar missing after write: ${result.sidecarPath}`);
+    }
+  }
 }
 
 main().catch(err => {

--- a/bin/index-all.mjs
+++ b/bin/index-all.mjs
@@ -14,6 +14,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn, spawnSync } from 'child_process';
 import { platform } from 'os';
+import { hnswIndexPath } from './lib/moflo-paths.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -217,15 +218,32 @@ async function main() {
     log('SKIP  build-embeddings (script not found)');
   }
 
-  // 7. HNSW rebuild — MUST run last, after all writes are committed (#81)
+  // 7. HNSW rebuild — MUST run last, after all writes are committed (#81).
+  //    rebuild-index now also writes the binary HNSW sidecar at
+  //    .moflo/hnsw.index, which can take longer than the default 120s on a
+  //    populated consumer DB — match build-embeddings' 300s budget.
+  let hnswOk = true;
   if (localCli) {
-    await runStep('hnsw-rebuild', 'node', [localCli, 'memory', 'rebuild-index', '--force']);
+    const ok = await runStep('hnsw-rebuild', 'node', [localCli, 'memory', 'rebuild-index', '--force'], 300_000);
+    if (ok) {
+      const sidecar = hnswIndexPath(projectRoot);
+      if (!existsSync(sidecar)) {
+        // Loud failure: missing sidecar means cold-start memory search
+        // silently rebuilds from SQL on every consumer process — the exact
+        // regression this guard exists to surface.
+        log(`FAIL  hnsw-rebuild post-check: sidecar missing at ${sidecar}`);
+        hnswOk = false;
+      }
+    } else {
+      hnswOk = false;
+    }
   } else {
     log('SKIP  hnsw-rebuild (CLI not found)');
   }
 
   const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   log(`Sequential indexing chain complete (${totalElapsed}s)`);
+  if (!hnswOk) process.exit(1);
 }
 
 main().catch(err => {

--- a/src/cli/__tests__/memory/hnsw-lite-serialize.test.ts
+++ b/src/cli/__tests__/memory/hnsw-lite-serialize.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Round-trip + format-validation tests for HnswLite serialize/load (#734).
+ *
+ * The graph (vectors + neighbor adjacency) round-trips byte-for-byte and
+ * search results must be identical before and after a serialize→load cycle.
+ * Negative tests assert the format gates (magic, version, size) so corrupted
+ * sidecars surface a clear error rather than silently degrading.
+ */
+import { describe, it, expect } from 'vitest';
+import { HnswLite } from '../../memory/hnsw-lite.js';
+
+function rng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+function buildIndex(rows: number, dim: number, seed = 1): HnswLite {
+  const rand = rng(seed);
+  const idx = new HnswLite(dim, 16, 200, 'cosine');
+  for (let i = 0; i < rows; i++) {
+    const v = new Float32Array(dim);
+    for (let j = 0; j < dim; j++) v[j] = rand() * 2 - 1;
+    idx.add(`row-${i.toString().padStart(4, '0')}-uuid-${seed}`, v);
+  }
+  return idx;
+}
+
+describe('HnswLite serialize / load', () => {
+  it('round-trips a small index exactly (size + neighbors + vectors)', () => {
+    const original = buildIndex(50, 32);
+    const buf = original.serialize();
+    const loaded = HnswLite.load(buf);
+
+    expect(loaded.size).toBe(original.size);
+
+    // Same search results for 10 random queries.
+    const rand = rng(99);
+    for (let q = 0; q < 10; q++) {
+      const query = new Float32Array(32);
+      for (let j = 0; j < 32; j++) query[j] = rand() * 2 - 1;
+      const a = original.search(query, 5);
+      const b = loaded.search(query, 5);
+      expect(b.map(r => r.id)).toEqual(a.map(r => r.id));
+      for (let i = 0; i < a.length; i++) {
+        expect(b[i].score).toBeCloseTo(a[i].score, 6);
+      }
+    }
+  });
+
+  it('round-trips at realistic dim=384 with 200 vectors', () => {
+    const original = buildIndex(200, 384, 7);
+    const loaded = HnswLite.load(original.serialize());
+
+    const rand = rng(123);
+    for (let q = 0; q < 20; q++) {
+      const query = new Float32Array(384);
+      for (let j = 0; j < 384; j++) query[j] = rand() * 2 - 1;
+      const a = original.search(query, 8);
+      const b = loaded.search(query, 8);
+      expect(b.map(r => r.id)).toEqual(a.map(r => r.id));
+    }
+  });
+
+  it('round-trips an empty index', () => {
+    const empty = new HnswLite(384, 16, 200, 'cosine');
+    const loaded = HnswLite.load(empty.serialize());
+    expect(loaded.size).toBe(0);
+    expect(loaded.search(new Float32Array(384), 5)).toEqual([]);
+  });
+
+  it('preserves the configured metric across a round-trip', () => {
+    const dot = new HnswLite(8, 4, 50, 'dot');
+    dot.add('a', new Float32Array([1, 0, 0, 0, 0, 0, 0, 0]));
+    dot.add('b', new Float32Array([0, 1, 0, 0, 0, 0, 0, 0]));
+    const loaded = HnswLite.load(dot.serialize());
+    // Dot of [1,0,...] with itself is 1; with [0,1,...] is 0.
+    const r = loaded.search(new Float32Array([1, 0, 0, 0, 0, 0, 0, 0]), 2);
+    expect(r[0].id).toBe('a');
+    expect(r[0].score).toBeCloseTo(1, 6);
+    expect(r[1].score).toBeCloseTo(0, 6);
+  });
+
+  it('rejects a buffer with wrong magic', () => {
+    const bad = Buffer.alloc(64);
+    bad.write('NOTMAGIC', 0, 'ascii');
+    expect(() => HnswLite.load(bad)).toThrow(/bad magic/);
+  });
+
+  it('rejects a buffer smaller than the header', () => {
+    expect(() => HnswLite.load(Buffer.alloc(8))).toThrow(/too small/);
+  });
+
+  it('rejects an unknown version', () => {
+    const buf = buildIndex(3, 8).serialize();
+    buf.writeUInt8(99, 8);
+    expect(() => HnswLite.load(buf)).toThrow(/unsupported version/);
+  });
+
+  it('rejects a truncated buffer', () => {
+    const buf = buildIndex(3, 8).serialize();
+    expect(() => HnswLite.load(buf.subarray(0, buf.length - 4))).toThrow(/size mismatch/);
+  });
+
+  it('rejects a JSON section that does not match vectorCount', () => {
+    const idx = buildIndex(3, 8);
+    const buf = idx.serialize();
+    // Rewrite vectorCount (offset 24) to 2 — header now says 2 but JSON has 3.
+    buf.writeUInt32LE(2, 24);
+    expect(() => HnswLite.load(buf)).toThrow(/size mismatch|arity mismatch/);
+  });
+});

--- a/src/cli/__tests__/memory/hnsw-persistence.test.ts
+++ b/src/cli/__tests__/memory/hnsw-persistence.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration + source-invariant tests for the HNSW sidecar persistence
+ * layer (#734). Together they enforce:
+ *
+ *   1. Round-trip: build a graph from a seeded sql.js DB → write the sidecar →
+ *      load it back → search results match.
+ *   2. Cold-start optimisation: tryLoadHnswSidecar() returns a populated
+ *      HnswLite without ever reading the embedding column.
+ *   3. Phantom-sidecar removal: the dead `unlinkSync(.../hnsw.index)` block
+ *      and `hnsw.metadata.json` references that #734 deleted from
+ *      build-embeddings.mjs and memory-initializer.ts stay deleted.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  buildAndWriteHnswSidecar,
+  tryLoadHnswSidecar,
+} from '../../memory/hnsw-persistence.js';
+import { hnswIndexPath, MOFLO_DIR, MEMORY_DB_FILE } from '../../services/moflo-paths.js';
+import { mofloImport } from '../../services/moflo-require.js';
+
+const DIM = 8;
+const ROW_COUNT = 12;
+
+async function seedDb(dbPath: string): Promise<string[]> {
+  const sqlJsModule = await mofloImport('sql.js');
+  if (!sqlJsModule) throw new Error('sql.js not available');
+  const SQL = await (sqlJsModule as { default: () => Promise<unknown> }).default() as {
+    Database: new () => {
+      run: (sql: string, params?: unknown[]) => void;
+      export: () => Uint8Array;
+      close: () => void;
+    };
+  };
+  const db = new SQL.Database();
+
+  db.run(`CREATE TABLE memory_entries (
+    id TEXT PRIMARY KEY,
+    key TEXT,
+    namespace TEXT,
+    content TEXT,
+    embedding TEXT,
+    status TEXT
+  )`);
+
+  const ids: string[] = [];
+  for (let i = 0; i < ROW_COUNT; i++) {
+    const id = `row-${i.toString().padStart(3, '0')}`;
+    ids.push(id);
+    const vec = Array.from({ length: DIM }, (_, j) => Math.sin(i * 0.7 + j * 0.3));
+    db.run(
+      `INSERT INTO memory_entries (id, key, namespace, content, embedding, status)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [id, `key-${i}`, 'patterns', `content ${i}`, JSON.stringify(vec), 'active'],
+    );
+  }
+
+  // Mix in one entry with no embedding (must be ignored by buildAndWriteHnswSidecar).
+  db.run(
+    `INSERT INTO memory_entries (id, key, namespace, content, embedding, status)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    ['row-no-embedding', 'no-embed', 'patterns', 'skipped', null, 'active'],
+  );
+
+  fs.writeFileSync(dbPath, Buffer.from(db.export()));
+  db.close();
+  return ids;
+}
+
+describe('hnsw-persistence — buildAndWriteHnswSidecar', () => {
+  let tmp: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-734-'));
+    fs.mkdirSync(path.join(tmp, MOFLO_DIR));
+    dbPath = path.join(tmp, MOFLO_DIR, MEMORY_DB_FILE);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('writes a sidecar at .moflo/hnsw.index containing every embedded row', async () => {
+    await seedDb(dbPath);
+
+    const result = await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+    expect(result.sidecarPath).toBe(hnswIndexPath(tmp));
+    expect(result.vectorCount).toBe(ROW_COUNT); // null-embedding row excluded
+    expect(fs.existsSync(result.sidecarPath)).toBe(true);
+    expect(fs.statSync(result.sidecarPath).size).toBe(result.bytes);
+  });
+
+  it('round-trips: tryLoadHnswSidecar returns a populated HnswLite that searches correctly', async () => {
+    const ids = await seedDb(dbPath);
+    await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+    const loaded = tryLoadHnswSidecar(tmp);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.size).toBe(ROW_COUNT);
+
+    // Query with the exact embedding of row 5 — top hit must be row 5.
+    const queryVec = new Float32Array(
+      Array.from({ length: DIM }, (_, j) => Math.sin(5 * 0.7 + j * 0.3)),
+    );
+    const hits = loaded!.search(queryVec, 3);
+    expect(hits[0].id).toBe(ids[5]);
+  });
+
+  it('returns null when the sidecar is missing', () => {
+    expect(tryLoadHnswSidecar(tmp)).toBeNull();
+  });
+
+  it('returns null and warns when the sidecar is corrupt', () => {
+    fs.writeFileSync(hnswIndexPath(tmp), Buffer.from('NOTAVALIDFILE'));
+    // Suppress the warn output for the duration of the test.
+    const original = console.warn;
+    console.warn = () => {};
+    try {
+      expect(tryLoadHnswSidecar(tmp)).toBeNull();
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  it('throws when the source DB is missing — fail-loud guarantee', async () => {
+    await expect(
+      buildAndWriteHnswSidecar(path.join(tmp, 'nope.db'), tmp, { dimensions: DIM }),
+    ).rejects.toThrow(/db not found/);
+  });
+
+  it('atomic rename: a fresh write replaces an older sidecar without leaving a tmp file', async () => {
+    await seedDb(dbPath);
+    fs.writeFileSync(hnswIndexPath(tmp), Buffer.from('stale'));
+    await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+    const remaining = fs.readdirSync(path.join(tmp, MOFLO_DIR));
+    // No `*.tmp` orphans from atomicWriteFileSync.
+    expect(remaining.filter(f => f.endsWith('.tmp'))).toEqual([]);
+    expect(remaining).toContain('hnsw.index');
+  });
+});
+
+describe('hnsw-persistence — source-level invariants (regression guard)', () => {
+  it('build-embeddings.mjs no longer unlink-syncs hnsw.index or references hnsw.metadata.json', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const file = path.join(repoRoot, 'bin', 'build-embeddings.mjs');
+    if (!fs.existsSync(file)) return; // not present in some packaging contexts
+    const text = fs.readFileSync(file, 'utf-8');
+    expect(text).not.toMatch(/unlinkSync\([^)]*hnsw\.index/);
+    expect(text).not.toMatch(/hnsw\.metadata\.json/);
+  });
+
+  it('memory-initializer.ts no longer reads or writes hnsw.metadata.json', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const file = path.join(repoRoot, 'src', 'cli', 'memory', 'memory-initializer.ts');
+    if (!fs.existsSync(file)) return;
+    const text = fs.readFileSync(file, 'utf-8');
+    expect(text).not.toMatch(/hnsw\.metadata\.json/);
+    expect(text).not.toMatch(/saveHNSWMetadata/);
+  });
+
+  it('index-all.mjs has the post-condition existsSync check after hnsw-rebuild', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const file = path.join(repoRoot, 'bin', 'index-all.mjs');
+    if (!fs.existsSync(file)) return;
+    const text = fs.readFileSync(file, 'utf-8');
+    expect(text).toMatch(/hnsw-rebuild post-check/);
+    expect(text).toMatch(/hnswIndexPath\(projectRoot\)/);
+  });
+});

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -2162,6 +2162,28 @@ const rebuildIndexCommand: Command = {
     while (stmt.step()) entries.push(stmt.getAsObject() as any);
     stmt.free();
 
+    // Atomic write + post-condition check shared by both code paths below
+    // (no-work-needed early return and post-embedding completion). Throws
+    // are caught here to surface a clean CommandResult; the index-all.mjs
+    // hnsw-rebuild step relies on the non-zero exit when this fails.
+    const writeSidecarOrFail = async (showBytes: boolean): Promise<CommandResult | null> => {
+      const { buildAndWriteHnswSidecar } = await import('../memory/hnsw-persistence.js');
+      try {
+        const result = await buildAndWriteHnswSidecar(dbPath, cwd);
+        const tail = showBytes ? ` (${(result.bytes / 1024).toFixed(1)} KB)` : '';
+        output.writeln(`  HNSW sidecar:    ${result.vectorCount} vectors → ${result.sidecarPath}${tail}`);
+        if (!fs.existsSync(result.sidecarPath)) {
+          output.printError(`HNSW sidecar missing after write: ${result.sidecarPath}`);
+          return { success: false, exitCode: 1 };
+        }
+        return null;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        output.printError(`HNSW sidecar write failed: ${msg}`);
+        return { success: false, exitCode: 1 };
+      }
+    };
+
     if (entries.length === 0) {
       // Show stats
       const totalStmt = db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active'`);
@@ -2174,6 +2196,15 @@ const rebuildIndexCommand: Command = {
 
       output.printSuccess(`All entries already have embeddings (${withEmbed}/${total})`);
       db.close();
+
+      // Refresh the HNSW sidecar even on the no-work path so a consumer
+      // that upgrades to this release with embeddings already current
+      // still gets the cold-start speedup.
+      if (withEmbed > 0) {
+        const fail = await writeSidecarOrFail(false);
+        if (fail) return fail;
+      }
+
       return { success: true };
     }
 
@@ -2236,6 +2267,14 @@ const rebuildIndexCommand: Command = {
     output.writeln(`  Failed:          ${failed} entries`);
     output.writeln(`  Time:            ${totalTime}s`);
     output.writeln(`  Total coverage:  ${withEmbed2}/${total2} entries`);
+
+    // Build + persist the HNSW sidecar so cold-start memory searches
+    // skip the full SQL→graph rebuild. Failure is fatal — bin/index-all.mjs
+    // and any caller of this command depend on the sidecar landing on disk.
+    if (withEmbed2 > 0) {
+      const fail = await writeSidecarOrFail(true);
+      if (fail) return fail;
+    }
 
     return { success: failed === 0, exitCode: failed > 0 ? 1 : 0 };
   }

--- a/src/cli/memory/controllers/_shared.ts
+++ b/src/cli/memory/controllers/_shared.ts
@@ -18,6 +18,24 @@ export function toFloat32(vec: Float32Array | number[]): Float32Array {
 }
 
 /**
+ * Parse a JSON-serialised number[] from the legacy `memory_entries.embedding`
+ * TEXT column (as written by the sql.js path) into a Float32Array. Returns
+ * null on missing/empty input or any parse failure — the source-of-truth
+ * dance happens elsewhere; this helper just normalises the read.
+ */
+export function parseEmbeddingJson(value: unknown): Float32Array | null {
+  if (typeof value !== 'string' || value === '') return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  return Float32Array.from(parsed as number[]);
+}
+
+/**
  * Serialize a vector to a BLOB suitable for sql.js storage. Returns null
  * when no vector is supplied so callers can persist `NULL`.
  */

--- a/src/cli/memory/hnsw-lite.ts
+++ b/src/cli/memory/hnsw-lite.ts
@@ -3,19 +3,27 @@ export interface HnswSearchResult {
   score: number;
 }
 
+export type HnswMetric = 'cosine' | 'dot' | 'euclidean';
+const METRICS: readonly HnswMetric[] = ['cosine', 'dot', 'euclidean'];
+
+const SERIAL_MAGIC = Buffer.from('MFLOHNSW', 'ascii');
+const SERIAL_VERSION = 1;
+const SERIAL_HEADER_BYTES = 32;
+const SERIAL_FLOAT_BYTES = 4;
+
 export class HnswLite {
   private vectors = new Map<string, Float32Array>();
   private neighbors = new Map<string, Set<string>>();
   private readonly dimensions: number;
   private readonly maxNeighbors: number;
   private readonly efConstruction: number;
-  private readonly metric: string;
+  private readonly metric: HnswMetric;
 
-  constructor(dimensions: number, m: number, efConstruction: number, metric: string) {
+  constructor(dimensions: number, m: number, efConstruction: number, metric: HnswMetric | string) {
     this.dimensions = dimensions;
     this.maxNeighbors = m;
     this.efConstruction = efConstruction;
-    this.metric = metric;
+    this.metric = METRICS.includes(metric as HnswMetric) ? (metric as HnswMetric) : 'cosine';
   }
 
   get size(): number {
@@ -111,6 +119,151 @@ export class HnswLite {
     }
 
     return filtered.slice(0, k);
+  }
+
+  /**
+   * Serialize the in-memory graph (vectors + neighbor adjacency) to a Buffer
+   * suitable for atomic write to `.moflo/hnsw.index`. Format:
+   *
+   *   bytes  0-7   "MFLOHNSW" magic
+   *   byte   8     version (u8)
+   *   byte   9     metric code (0 cosine, 1 dot, 2 euclidean)
+   *   bytes 10-11  reserved
+   *   bytes 12-15  dimensions (u32 LE)
+   *   bytes 16-19  maxNeighbors / m (u32 LE)
+   *   bytes 20-23  efConstruction (u32 LE)
+   *   bytes 24-27  vectorCount (u32 LE)
+   *   bytes 28-31  json section length (u32 LE)
+   *   bytes 32..   UTF-8 JSON `{ids: string[], neighbors: number[][]}`
+   *                — `ids[i]` is the entry id at position i
+   *                — `neighbors[i]` lists indices into `ids[]` (not the strings themselves)
+   *   then         vectorCount × dimensions × 4 bytes, Float32 LE, in `ids[]` order
+   *
+   * Indexed-by-position neighbors keep the JSON small even when ids are UUIDs.
+   */
+  serialize(): Buffer {
+    const ids = Array.from(this.vectors.keys());
+    const idxOf = new Map<string, number>();
+    for (let i = 0; i < ids.length; i++) idxOf.set(ids[i], i);
+
+    const neighborIdx: number[][] = ids.map(id => {
+      const set = this.neighbors.get(id);
+      if (!set) return [];
+      const out: number[] = [];
+      for (const nId of set) {
+        const i = idxOf.get(nId);
+        if (i !== undefined) out.push(i);
+      }
+      return out;
+    });
+
+    const json = JSON.stringify({ ids, neighbors: neighborIdx });
+    const jsonBuf = Buffer.from(json, 'utf-8');
+    const vectorBytes = ids.length * this.dimensions * SERIAL_FLOAT_BYTES;
+    const out = Buffer.alloc(SERIAL_HEADER_BYTES + jsonBuf.length + vectorBytes);
+
+    SERIAL_MAGIC.copy(out, 0);
+    out.writeUInt8(SERIAL_VERSION, 8);
+    out.writeUInt8(METRICS.indexOf(this.metric), 9);
+    // bytes 10-11 reserved (zero-filled by alloc)
+    out.writeUInt32LE(this.dimensions, 12);
+    out.writeUInt32LE(this.maxNeighbors, 16);
+    out.writeUInt32LE(this.efConstruction, 20);
+    out.writeUInt32LE(ids.length, 24);
+    out.writeUInt32LE(jsonBuf.length, 28);
+    jsonBuf.copy(out, SERIAL_HEADER_BYTES);
+
+    // Bulk-copy the vector block — Float32Array shares memory with its
+    // backing ArrayBuffer, so a single `Buffer.copy` per vector beats
+    // 1.15M scalar writeFloatLE calls (3k × 384) on a typical consumer.
+    let offset = SERIAL_HEADER_BYTES + jsonBuf.length;
+    const vecBytes = this.dimensions * SERIAL_FLOAT_BYTES;
+    for (const id of ids) {
+      const vec = this.vectors.get(id)!;
+      const srcView = Buffer.from(vec.buffer, vec.byteOffset, vecBytes);
+      srcView.copy(out, offset);
+      offset += vecBytes;
+    }
+    return out;
+  }
+
+  /**
+   * Reconstruct an HnswLite from a serialize() buffer. Throws on bad magic,
+   * unknown version, or truncated payload — callers should catch and fall
+   * back to rebuilding from the source-of-truth (SQL embedding column).
+   */
+  static load(buf: Buffer): HnswLite {
+    if (buf.length < SERIAL_HEADER_BYTES) {
+      throw new Error(`HnswLite.load: buffer too small (${buf.length} < ${SERIAL_HEADER_BYTES})`);
+    }
+    if (buf.compare(SERIAL_MAGIC, 0, SERIAL_MAGIC.length, 0, SERIAL_MAGIC.length) !== 0) {
+      throw new Error(`HnswLite.load: bad magic, expected MFLOHNSW`);
+    }
+    const version = buf.readUInt8(8);
+    if (version !== SERIAL_VERSION) {
+      throw new Error(`HnswLite.load: unsupported version ${version} (expected ${SERIAL_VERSION})`);
+    }
+    const metricCode = buf.readUInt8(9);
+    const metric = METRICS[metricCode];
+    if (!metric) {
+      throw new Error(`HnswLite.load: unknown metric code ${metricCode}`);
+    }
+    const dimensions = buf.readUInt32LE(12);
+    const m = buf.readUInt32LE(16);
+    const efConstruction = buf.readUInt32LE(20);
+    const vectorCount = buf.readUInt32LE(24);
+    const jsonLen = buf.readUInt32LE(28);
+
+    const expectedSize =
+      SERIAL_HEADER_BYTES + jsonLen + vectorCount * dimensions * SERIAL_FLOAT_BYTES;
+    if (buf.length !== expectedSize) {
+      throw new Error(
+        `HnswLite.load: size mismatch (have ${buf.length}, expected ${expectedSize})`,
+      );
+    }
+
+    const json = buf.toString('utf-8', SERIAL_HEADER_BYTES, SERIAL_HEADER_BYTES + jsonLen);
+    let parsed: { ids: string[]; neighbors: number[][] };
+    try {
+      parsed = JSON.parse(json);
+    } catch (err) {
+      throw new Error(`HnswLite.load: malformed JSON section — ${(err as Error).message}`);
+    }
+    if (!Array.isArray(parsed.ids) || !Array.isArray(parsed.neighbors)) {
+      throw new Error(`HnswLite.load: JSON missing ids[] or neighbors[]`);
+    }
+    if (parsed.ids.length !== vectorCount || parsed.neighbors.length !== vectorCount) {
+      throw new Error(
+        `HnswLite.load: JSON arity mismatch (ids=${parsed.ids.length}, neighbors=${parsed.neighbors.length}, expected ${vectorCount})`,
+      );
+    }
+
+    const inst = new HnswLite(dimensions, m, efConstruction, metric);
+    // Bulk-decode floats: each vector is `dim × 4` contiguous LE bytes.
+    // We can't view-into-place because the JSON section is variable
+    // length — `SERIAL_HEADER_BYTES + jsonLen` rarely lands on a 4-byte
+    // boundary, and Float32Array views require aligned start offsets.
+    // Allocate the typed array first (always aligned) and memcpy bytes
+    // into its backing buffer. One copy per vector vs. `dim` scalar
+    // readFloatLE calls. Hot path — every cold-start memory search lands
+    // here.
+    const vecBytes = dimensions * SERIAL_FLOAT_BYTES;
+    let offset = SERIAL_HEADER_BYTES + jsonLen;
+    for (let i = 0; i < vectorCount; i++) {
+      const vec = new Float32Array(dimensions);
+      Buffer.from(vec.buffer).set(buf.subarray(offset, offset + vecBytes));
+      inst.vectors.set(parsed.ids[i], vec);
+      offset += vecBytes;
+    }
+    for (let i = 0; i < vectorCount; i++) {
+      const nSet = new Set<string>();
+      for (const nIdx of parsed.neighbors[i]) {
+        const nId = parsed.ids[nIdx];
+        if (nId !== undefined) nSet.add(nId);
+      }
+      inst.neighbors.set(parsed.ids[i], nSet);
+    }
+    return inst;
   }
 
   private bruteForce(query: Float32Array, k: number, threshold?: number): HnswSearchResult[] {

--- a/src/cli/memory/hnsw-persistence.ts
+++ b/src/cli/memory/hnsw-persistence.ts
@@ -1,0 +1,135 @@
+/**
+ * HNSW sidecar persistence helper (#734).
+ *
+ * Builds an in-memory `HnswLite` graph from the source-of-truth embedding
+ * column in `.moflo/moflo.db` and atomically writes it to
+ * `.moflo/hnsw.index`. Used by `memory rebuild-index`, `bin/build-embeddings.mjs`,
+ * and any other writer that needs to refresh the sidecar after embeddings
+ * change.
+ *
+ * Cold-start readers (`getHNSWIndex()` in memory-initializer.ts) call
+ * `tryLoadHnswSidecar()` to skip the SQL-rebuild path entirely when the
+ * sidecar exists and is well-formed.
+ *
+ * The sidecar binary format is owned by `HnswLite.serialize()` /
+ * `HnswLite.load()` — see hnsw-lite.ts.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { mofloImport } from '../services/moflo-require.js';
+import { atomicWriteFileSync } from '../services/atomic-file-write.js';
+import { HnswLite } from './hnsw-lite.js';
+import { parseEmbeddingJson } from './controllers/_shared.js';
+import { hnswIndexPath } from '../services/moflo-paths.js';
+
+export interface HnswBuildOptions {
+  /** Override embedding dimensions. Defaults to 384 (matches fast-all-MiniLM-L6-v2). */
+  dimensions?: number;
+  /** HnswLite m parameter. Defaults to 16. */
+  m?: number;
+  /** HnswLite efConstruction parameter. Defaults to 200. */
+  efConstruction?: number;
+  /** Distance metric. Defaults to 'cosine'. */
+  metric?: 'cosine' | 'dot' | 'euclidean';
+}
+
+export interface HnswBuildResult {
+  /** Path the sidecar was written to. */
+  sidecarPath: string;
+  /** Number of vectors persisted. */
+  vectorCount: number;
+  /** Bytes written. */
+  bytes: number;
+}
+
+/**
+ * Build an HnswLite from every active row in `dbPath` that has an embedding,
+ * then atomically write the sidecar to `<projectRoot>/.moflo/hnsw.index`.
+ *
+ * Throws on any failure — write errors, dimension mismatches, or empty
+ * indexes. Callers (rebuild-index, build-embeddings.mjs, index-all.mjs)
+ * use the throw to fail loudly, which is the explicit guardrail in #734.
+ */
+export async function buildAndWriteHnswSidecar(
+  dbPath: string,
+  projectRoot: string,
+  options: HnswBuildOptions = {},
+): Promise<HnswBuildResult> {
+  const dimensions = options.dimensions ?? 384;
+  const m = options.m ?? 16;
+  const efConstruction = options.efConstruction ?? 200;
+  const metric = options.metric ?? 'cosine';
+
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`buildAndWriteHnswSidecar: db not found at ${dbPath}`);
+  }
+
+  const sqlJsModule = await mofloImport('sql.js');
+  if (!sqlJsModule) {
+    throw new Error(`buildAndWriteHnswSidecar: sql.js not available`);
+  }
+  const SQL = await sqlJsModule.default();
+  const buf = fs.readFileSync(dbPath);
+  const db = new SQL.Database(buf) as {
+    exec: (sql: string) => Array<{ values: unknown[][] }>;
+    close: () => void;
+  };
+
+  const hnsw = new HnswLite(dimensions, m, efConstruction, metric);
+  let skipped = 0;
+
+  try {
+    const rows = db.exec(
+      `SELECT id, embedding FROM memory_entries
+       WHERE status = 'active' AND embedding IS NOT NULL AND embedding != ''`,
+    );
+    const values = rows[0]?.values ?? [];
+    for (const row of values) {
+      const [id, embeddingJson] = row as [string, unknown];
+      const vec = parseEmbeddingJson(embeddingJson);
+      if (!vec || vec.length !== dimensions) {
+        skipped++;
+        continue;
+      }
+      hnsw.add(String(id), vec);
+    }
+  } finally {
+    db.close();
+  }
+
+  if (skipped > 0) {
+    console.warn(`[hnsw-persistence] skipped ${skipped} rows with malformed or wrong-dimension embeddings`);
+  }
+
+  const sidecarPath = hnswIndexPath(projectRoot);
+  fs.mkdirSync(path.dirname(sidecarPath), { recursive: true });
+  const out = hnsw.serialize();
+  atomicWriteFileSync(sidecarPath, out);
+
+  return { sidecarPath, vectorCount: hnsw.size, bytes: out.length };
+}
+
+/**
+ * Load `<projectRoot>/.moflo/hnsw.index` if present and well-formed. Returns
+ * null on missing file or any parse error — callers fall back to rebuilding
+ * the graph from SQL. Logs format errors via console.warn so corruption is
+ * visible without surfacing a hard failure to interactive callers.
+ */
+export function tryLoadHnswSidecar(projectRoot: string): HnswLite | null {
+  const sidecarPath = hnswIndexPath(projectRoot);
+  if (!fs.existsSync(sidecarPath)) return null;
+  let buf: Buffer;
+  try {
+    buf = fs.readFileSync(sidecarPath);
+  } catch (err) {
+    console.warn(`[hnsw-persistence] read failed for ${sidecarPath}: ${(err as Error).message}`);
+    return null;
+  }
+  try {
+    return HnswLite.load(buf);
+  } catch (err) {
+    console.warn(`[hnsw-persistence] load failed for ${sidecarPath}: ${(err as Error).message} — will rebuild from SQL`);
+    return null;
+  }
+}

--- a/src/cli/memory/index.ts
+++ b/src/cli/memory/index.ts
@@ -195,6 +195,8 @@ export { RvfBackend } from './rvf-backend.js';
 export type { RvfBackendConfig } from './rvf-backend.js';
 export { HnswLite, cosineSimilarity } from './hnsw-lite.js';
 export type { HnswSearchResult } from './hnsw-lite.js';
+export { buildAndWriteHnswSidecar, tryLoadHnswSidecar } from './hnsw-persistence.js';
+export type { HnswBuildOptions, HnswBuildResult } from './hnsw-persistence.js';
 export { HNSWIndex } from './hnsw-index.js';
 export { CacheManager, TieredCacheManager } from './cache-manager.js';
 export { QueryBuilder, query, QueryTemplates } from './query-builder.js';

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -15,8 +15,9 @@ import { mofloImport } from '../services/moflo-require.js';
 import { atomicWriteFileSync } from '../services/atomic-file-write.js';
 import { formatEmbeddingError } from './embedding-errors.js';
 import { HnswLite } from './hnsw-lite.js';
+import { tryLoadHnswSidecar } from './hnsw-persistence.js';
 import { EMBEDDING_MODEL_OPT_OUT, EPHEMERAL_NAMESPACES, getBridgeEmbedder } from './bridge-embedder.js';
-import { toFloat32 } from './controllers/_shared.js';
+import { parseEmbeddingJson, toFloat32 } from './controllers/_shared.js';
 import { writeVectorStatsJson } from './bridge-core.js';
 import {
   MOFLO_DIR,
@@ -419,10 +420,15 @@ export async function getHNSWIndex(options?: {
     if (!fs.existsSync(dbDir)) {
       fs.mkdirSync(dbDir, { recursive: true });
     }
-    const metadataPath = path.join(dbDir, 'hnsw.metadata.json');
+    const projectRoot = path.dirname(dbDir);
 
-    // Create HnswLite index and wrap it with the expected db interface
-    const hnsw = new HnswLite(dimensions, 16, 200, 'cosine');
+    // Try the binary sidecar first — graph + neighbors round-trip exactly,
+    // so the cold-start cost drops to one readFileSync + slice. Fall back
+    // to SQL-rebuild only when the sidecar is missing or malformed.
+    const loadedFromSidecar = options?.forceRebuild ? null : tryLoadHnswSidecar(projectRoot);
+    const hnsw = loadedFromSidecar ?? new HnswLite(dimensions, 16, 200, 'cosine');
+    const sidecarLoaded = loadedFromSidecar !== null;
+
     const db = {
       insert: async (entry: { id: string; vector: Float32Array }) => {
         hnsw.add(entry.id, entry.vector);
@@ -433,19 +439,7 @@ export async function getHNSWIndex(options?: {
       len: async () => hnsw.size,
     };
 
-    // Load metadata (entry info) if exists
     const entries = new Map<string, HNSWEntry>();
-    if (fs.existsSync(metadataPath)) {
-      try {
-        const metadataJson = fs.readFileSync(metadataPath, 'utf-8');
-        const metadata = JSON.parse(metadataJson) as Array<[string, HNSWEntry]>;
-        for (const [key, value] of metadata) {
-          entries.set(key, value);
-        }
-      } catch {
-        // Metadata load failed, will rebuild
-      }
-    }
 
     hnswIndex = {
       db,
@@ -454,6 +448,14 @@ export async function getHNSWIndex(options?: {
       initialized: false
     };
 
+    // Always populate the entries metadata from SQL — `key/namespace/content`
+    // is the source of truth there, and the sidecar only stores vectors +
+    // adjacency. When the sidecar IS loaded we skip the per-row JSON.parse
+    // of the embedding column, which is the expensive part on a populated
+    // consumer DB.
+    const SELECT_WITH_EMBEDDING = `id, key, namespace, content, embedding`;
+    const SELECT_METADATA_ONLY = `id, key, namespace, content`;
+
     if (fs.existsSync(dbPath)) {
       try {
         const initSqlJs = (await mofloImport('sql.js')).default;
@@ -461,72 +463,61 @@ export async function getHNSWIndex(options?: {
         const fileBuffer = fs.readFileSync(dbPath);
         const sqlDb = new SQL.Database(fileBuffer);
 
-        // Load all entries with embeddings
+        const cols = sidecarLoaded ? SELECT_METADATA_ONLY : SELECT_WITH_EMBEDDING;
         const result = sqlDb.exec(`
-          SELECT id, key, namespace, content, embedding
+          SELECT ${cols}
           FROM memory_entries
           WHERE status = 'active' AND embedding IS NOT NULL
           LIMIT 10000
         `);
 
+        let parseSkipped = 0;
         if (result[0]?.values) {
           for (const row of result[0].values) {
-            const [id, key, ns, content, embeddingJson] = row as [string, string, string, string, string];
-            if (embeddingJson) {
-              try {
-                const embedding = JSON.parse(embeddingJson) as number[];
-                const vector = new Float32Array(embedding);
+            const [id, key, ns, content, embeddingJson] = row as [string, string, string, string, string?];
 
-                await db.insert({
-                  id: String(id),
-                  vector
-                });
-
-                hnswIndex.entries.set(String(id), {
-                  id: String(id),
-                  key: key || String(id),
-                  namespace: ns || 'default',
-                  content: content || ''
-                });
-              } catch {
-                // Skip invalid embeddings
+            if (!sidecarLoaded) {
+              const vec = parseEmbeddingJson(embeddingJson);
+              if (!vec) {
+                parseSkipped++;
+                continue;
               }
+              await db.insert({ id: String(id), vector: vec });
             }
+
+            hnswIndex.entries.set(String(id), {
+              id: String(id),
+              key: key || String(id),
+              namespace: ns || 'default',
+              content: content || ''
+            });
           }
+        }
+        if (parseSkipped > 0) {
+          console.warn(`[memory-initializer] skipped ${parseSkipped} rows with malformed embeddings`);
         }
 
         sqlDb.close();
-      } catch {
-        // SQLite load failed, start with empty index
+      } catch (err) {
+        console.warn(`[memory-initializer] SQL load failed, starting empty: ${(err as Error).message}`);
       }
     }
 
     hnswIndex.initialized = true;
     hnswInitializing = false;
     return hnswIndex;
-  } catch {
+  } catch (err) {
+    console.warn(`[memory-initializer] getHNSWIndex failed: ${(err as Error).message}`);
     hnswInitializing = false;
     return null;
   }
 }
 
 /**
- * Save HNSW metadata to disk for persistence
- */
-function saveHNSWMetadata(): void {
-  if (!hnswIndex?.entries) return;
-
-  try {
-    const metadataPath = path.join(path.dirname(memoryDbPath(process.cwd())), 'hnsw.metadata.json');
-    const metadata = Array.from(hnswIndex.entries.entries());
-    fs.writeFileSync(metadataPath, JSON.stringify(metadata));
-  } catch {
-    // Silently fail - metadata save is best-effort
-  }
-}
-
-/**
- * Add entry to HNSW index (with automatic persistence)
+ * Add entry to HNSW index. Live-adds stay in-memory until the next
+ * `memory rebuild-index` run rebuilds the binary sidecar at
+ * `.moflo/hnsw.index`. The sql.js `embedding` column is the source of
+ * truth across process boundaries.
  */
 export async function addToHNSWIndex(
   id: string,
@@ -550,9 +541,6 @@ export async function addToHNSWIndex(
       vector
     });
     index.entries.set(id, entry);
-
-    // Save metadata for persistence (debounced would be better for high-volume)
-    saveHNSWMetadata();
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

`HnswLite` previously had no save/load API and `.moflo/hnsw.index` was a phantom path: `bridge-core` checked `existsSync` against it, `build-embeddings.mjs` unlinked it "to invalidate stale state," but no code ever wrote it. `vector-stats.hasHnsw` was permanently `false`, and every Node cold start rebuilt the in-memory graph from the SQL `embedding` column — the bulk of the multi-minute "Memory upgrade complete" lag visible in consumers.

This change makes the sidecar real.

## Changes

- **`HnswLite.serialize()` / `static load(buf)`** — binary format: 32-byte header (magic `MFLOHNSW`, u8 version, u8 metric code, u32 dim/m/efC/vectorCount/jsonLen) + JSON `{ids, neighbors as int indices into ids[]}` + packed Float32 LE vector block. Load decodes via per-vector `new Float32Array(dim)` + `Buffer.from(vec.buffer).set(buf.subarray(...))` — bulk memcpy, alignment-safe, hot path.
- **`src/cli/memory/hnsw-persistence.ts` (new)** — `buildAndWriteHnswSidecar(dbPath, projectRoot)` opens sql.js, reads embedded rows, `atomicWriteFileSync`s the sidecar. `tryLoadHnswSidecar(projectRoot)` returns an `HnswLite` or `null`.
- **`memory rebuild-index` + `bin/build-embeddings.mjs`** both invoke the writer after their embed pass. Failure is fatal — the sidecar must land on disk for the chain to report DONE.
- **`bin/index-all.mjs`** `hnsw-rebuild` step bumped to 300s (matches sibling `build-embeddings` budget) and gained an `existsSync` post-check that triggers `process.exit(1)` on miss.
- **`getHNSWIndex()`** in `memory-initializer.ts` tries the sidecar first; when loaded, the SQL pass fetches metadata columns only (no embedding column), eliminating the per-row `JSON.parse` that dominated cold-start cost on populated consumers.
- **Phantom-sidecar dead code removed** — `unlinkSync` block in `bin/build-embeddings.mjs`, `saveHNSWMetadata` + `hnsw.metadata.json` reads in `memory-initializer.ts`, `.npmignore` line for the phantom file.
- **`parseEmbeddingJson` helper** added to `controllers/_shared.ts` so `hnsw-persistence` and `memory-initializer` share one parser.

## Test plan

- [x] Unit: `HnswLite.serialize`/`load` round-trip with random + realistic-dim vectors, empty index, metric preservation, all four format-validation negatives (bad magic, undersized buffer, unknown version, truncated payload, arity mismatch).
- [x] Integration: seeded sql.js DB → `buildAndWriteHnswSidecar` → `tryLoadHnswSidecar` round-trip with exact-match top hit; missing DB → throws; corrupt sidecar → returns null; atomic rename leaves no `*.tmp` orphans.
- [x] Source invariants: `bin/build-embeddings.mjs` no longer `unlinkSync`s `hnsw.index`; `memory-initializer.ts` no longer reads/writes `hnsw.metadata.json` and no longer references `saveHNSWMetadata`; `bin/index-all.mjs` has the post-check + `hnswIndexPath(projectRoot)` reference.
- [x] Full suite: 7380 tests pass, type-check clean.
- [ ] Manual: cold-start consumer search after sidecar exists — to be verified post-merge in a real consumer; the size of this consumer's DB is well-suited as the canary.

## Companion epic

Part of #726 (Memory DB hygiene). The original ticket framed this as "rebuild-index reports DONE but produces no sidecar — the persistence step is failing silently." Verification during /flo 734 showed there *was* no persistence step at all; ticket body has been rewritten to reflect the real fix scope (A+B per discussion).

Closes #734

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)