### PR TITLE
fix(735): finish .claude-flow/ removal — Phase 1 + Phase 2 migration

### DIFF
--- a/.claude/helpers/auto-memory-hook.mjs
+++ b/.claude/helpers/auto-memory-hook.mjs
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const PROJECT_ROOT = join(__dirname, '../..');
-const DATA_DIR = join(PROJECT_ROOT, '.claude-flow', 'data');
+const DATA_DIR = join(PROJECT_ROOT, '.moflo', 'data');
 const STORE_PATH = join(DATA_DIR, 'auto-memory-store.json');
 
 const DIM = '\x1b[2m';

--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -11,11 +11,11 @@ const path = require('path');
 const os = require('os');
 
 const PROJECT_ROOT = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
-const DATA_DIR = path.join(PROJECT_ROOT, '.claude-flow', 'data');
+const DATA_DIR = path.join(PROJECT_ROOT, '.moflo', 'data');
 const STORE_PATH = path.join(DATA_DIR, 'auto-memory-store.json');
 const RANKED_PATH = path.join(DATA_DIR, 'ranked-context.json');
 const PENDING_PATH = path.join(DATA_DIR, 'pending-insights.jsonl');
-const SESSION_DIR = path.join(PROJECT_ROOT, '.claude-flow', 'sessions');
+const SESSION_DIR = path.join(PROJECT_ROOT, '.moflo', 'sessions');
 const SESSION_FILE = path.join(SESSION_DIR, 'current.json');
 
 function ensureDir(dir) {
@@ -55,7 +55,7 @@ function bootstrapFromMemoryFiles() {
   var entries = [];
   var candidates = [
     path.join(os.homedir(), ".claude", "projects"),
-    path.join(PROJECT_ROOT, ".claude-flow", "memory"),
+    path.join(PROJECT_ROOT, ".moflo", "memory"),
     path.join(PROJECT_ROOT, ".claude", "memory"),
   ];
   for (var i = 0; i < candidates.length; i++) {

--- a/bin/lib/moflo-paths.mjs
+++ b/bin/lib/moflo-paths.mjs
@@ -21,6 +21,7 @@ import {
   rmdirSync,
   statSync,
   unlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 
@@ -74,7 +75,9 @@ export function memoryDbCandidatePaths(projectRoot) {
  * One-time migration of `.claude-flow/` → `.moflo/`. Idempotent — safe to call
  * on every session start. See moflo-paths.ts for the full contract.
  *
- * Returns `{ migrated, reason? }`.
+ * Returns `{ migrated, reason?, movedCount?, collisions? }`. The launcher
+ * uses `movedCount` for the "migrated N files" message and `collisions` to
+ * warn about subdirs (e.g. models/) that exist in both locations.
  */
 export function migrateClaudeFlowToMoflo(projectRoot) {
   const legacy = legacyClaudeFlowDir(projectRoot);
@@ -83,8 +86,11 @@ export function migrateClaudeFlowToMoflo(projectRoot) {
   if (!existsSync(legacy)) return { migrated: false, reason: 'no-legacy' };
 
   if (!existsSync(target)) {
+    let movedCount = 0;
+    try { movedCount = readdirSync(legacy).length; } catch { /* count is cosmetic */ }
     renameSync(legacy, target);
-    return { migrated: true };
+    rewriteEmbeddingsModelPath(projectRoot);
+    return { migrated: true, movedCount };
   }
 
   let entries;
@@ -95,12 +101,18 @@ export function migrateClaudeFlowToMoflo(projectRoot) {
   }
 
   let moved = 0;
+  let modelsMoved = false;
+  const collisions = [];
   for (const name of entries) {
     const dst = join(target, name);
-    if (existsSync(dst)) continue;
+    if (existsSync(dst)) {
+      collisions.push(name);
+      continue;
+    }
     try {
       renameSync(join(legacy, name), dst);
       moved++;
+      if (name === 'models') modelsMoved = true;
     } catch {
       // Best-effort — single failed move shouldn't abort the rest.
     }
@@ -112,7 +124,44 @@ export function migrateClaudeFlowToMoflo(projectRoot) {
     // Non-fatal — leftover legacy dir means migration runs next time.
   }
 
-  return moved > 0 ? { migrated: true } : { migrated: false, reason: 'merged-nothing' };
+  if (modelsMoved) rewriteEmbeddingsModelPath(projectRoot);
+
+  if (moved === 0) {
+    return { migrated: false, reason: 'merged-nothing', movedCount: 0, collisions };
+  }
+  return { migrated: true, movedCount: moved, collisions };
+}
+
+/**
+ * Rewrite `.moflo/embeddings.json:modelPath` if it still references the
+ * legacy `.claude-flow/` location (#735). Best-effort: file-not-present,
+ * malformed JSON, missing field, or already-correct path → silent no-op.
+ * Mirrors the TS twin in src/cli/services/moflo-paths.ts. Uses tmp+rename
+ * so SIGINT mid-flush can't leave embeddings.json truncated.
+ */
+export function rewriteEmbeddingsModelPath(projectRoot) {
+  const cfgPath = join(projectRoot, MOFLO_DIR, 'embeddings.json');
+
+  let raw;
+  try { raw = readFileSync(cfgPath, 'utf8'); } catch { return false; }
+
+  let cfg;
+  try { cfg = JSON.parse(raw); } catch { return false; }
+
+  if (typeof cfg.modelPath !== 'string') return false;
+  if (!cfg.modelPath.includes(LEGACY_CLAUDE_FLOW_DIR)) return false;
+
+  cfg.modelPath = cfg.modelPath.split(LEGACY_CLAUDE_FLOW_DIR).join(MOFLO_DIR);
+
+  const tmpPath = `${cfgPath}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 8)}`;
+  try {
+    writeFileSync(tmpPath, JSON.stringify(cfg, null, 2));
+    renameSync(tmpPath, cfgPath);
+    return true;
+  } catch {
+    try { unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
+    return false;
+  }
 }
 
 const SQLITE_MAGIC_HEADER = Buffer.from('SQLite format 3\0', 'utf8');

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -106,16 +106,32 @@ try {
   unlinkSync(join(mofloDir(projectRoot), 'upgrade-notice.json'));
 } catch { /* non-fatal — file usually doesn't exist */ }
 
-// ── 0. LEGACY state migration (#699) ─────────────────────────────────────────
+// ── 0. LEGACY state migration (#699, #735) ──────────────────────────────────
 // Consumers upgrading from older moflo builds (inherited from upstream Ruflo)
 // get a one-time auto-migration of LEGACY `.claude-flow/` → `.moflo/` so claim
-// files, daemon state, metrics, and the version stamp survive the rename.
+// files, models cache, metrics, and the version stamp survive the rename.
 // The migration helper is idempotent — see bin/lib/moflo-paths.mjs for the
-// algorithm. LEGACY: no-ops once `.claude-flow/` is gone.
+// algorithm.
+//
+// Staged removal contract (#735):
+//   1. THIS release ships Phase 1 (writers redirected to `.moflo/`) + Phase 2 // LEGACY
+//      (this migration call moves stragglers + warns on collisions).
+//   2. The release AFTER Phase 1 is steady-state should hard-delete any
+//      remaining empty `.claude-flow/` directory — until then, the helper // LEGACY
+//      drops the dir naturally once everything's been moved.
+// LEGACY: every emit below stops firing once `.claude-flow/` is gone.
 try {
   const cfMigration = migrateClaudeFlowToMoflo(projectRoot);
   if (cfMigration?.migrated) {
-    emitMutation('migrated runtime state to .moflo/', 'from legacy .claude-flow/'); // LEGACY
+    const count = cfMigration.movedCount ?? 0;
+    emitMutation(`migrated ${plural(count, 'entry')} from legacy .claude-flow/`); // LEGACY
+  }
+  // Surface collisions so users notice that BOTH locations now hold the same
+  // subdir name (most often `models/` after a partial pre-#735 migration).
+  // Manual cleanup is needed — moflo refuses to silently choose.
+  if ((cfMigration?.collisions?.length ?? 0) > 0) {
+    const collisionMsg = 'kept legacy .claude-flow/ entries to avoid clobbering .moflo/'; // LEGACY
+    emitMutation(collisionMsg, `collisions: ${cfMigration.collisions.join(', ')}`);
   }
 } catch {
   // Non-fatal — anything left behind by the migration just means it runs

--- a/src/cli/__tests__/services/moflo-paths-migration.test.ts
+++ b/src/cli/__tests__/services/moflo-paths-migration.test.ts
@@ -28,6 +28,7 @@ import {
   migrateClaudeFlowToMoflo,
   migrateMemoryDbToMoflo,
   mofloDir,
+  rewriteEmbeddingsModelPath,
 } from '../../services/moflo-paths.js';
 
 // SQLite header magic — `migrateMemoryDbToMoflo` rejects copies that don't
@@ -71,6 +72,8 @@ describe('migrateClaudeFlowToMoflo (#699)', () => {
       const result = migrateClaudeFlowToMoflo(root);
 
       expect(result.migrated).toBe(true);
+      // Top-level entries: claims/ + daemon.lock = 2
+      expect(result.movedCount).toBe(2);
       expect(existsSync(legacy)).toBe(false);
       expect(readFileSync(join(mofloDir(root), 'claims', 'claim.json'), 'utf8')).toBe('{"id":"abc"}');
       expect(readFileSync(join(mofloDir(root), 'daemon.lock'), 'utf8')).toBe('{"pid":123}');
@@ -151,10 +154,170 @@ describe('migrateClaudeFlowToMoflo (#699)', () => {
       writeFileSync(join(legacy, 'collide.json'), 'old');
       writeFileSync(join(target, 'collide.json'), 'new');
 
-      migrateClaudeFlowToMoflo(root);
+      const result = migrateClaudeFlowToMoflo(root);
 
       expect(existsSync(legacy)).toBe(true);
       expect(readdirSync(legacy)).toEqual(['collide.json']);
+      // #735: surface collisions so the launcher can warn the user instead
+      // of silently choosing one side.
+      expect(result.collisions).toEqual(['collide.json']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // #735: model cache must survive migration so consumers don't re-download
+  // multi-MB ONNX bytes over a slow connection.
+  it('preserves .claude-flow/models/ as .moflo/models/ via merge path', () => {
+    const root = mkRoot();
+    try {
+      const legacy = legacyClaudeFlowDir(root);
+      const target = mofloDir(root);
+      // Pre-existing target forces the merge path (not the wholesale rename).
+      mkdirSync(target);
+      writeFileSync(join(target, 'placeholder'), 'x');
+      mkdirSync(join(legacy, 'models'), { recursive: true });
+      writeFileSync(join(legacy, 'models', 'model.onnx'), 'fake-onnx-bytes');
+
+      const result = migrateClaudeFlowToMoflo(root);
+
+      expect(result.migrated).toBe(true);
+      expect(result.collisions).toEqual([]);
+      expect(readFileSync(join(target, 'models', 'model.onnx'), 'utf8')).toBe('fake-onnx-bytes');
+      expect(existsSync(join(legacy, 'models'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // #735: when models/ exists in BOTH locations, never silently choose —
+  // surface the collision so the user can manually decide.
+  it('warns via collisions when models/ exists in both .claude-flow/ and .moflo/', () => {
+    const root = mkRoot();
+    try {
+      const legacy = legacyClaudeFlowDir(root);
+      const target = mofloDir(root);
+      mkdirSync(join(legacy, 'models'), { recursive: true });
+      writeFileSync(join(legacy, 'models', 'old.onnx'), 'old-bytes');
+      mkdirSync(join(target, 'models'), { recursive: true });
+      writeFileSync(join(target, 'models', 'new.onnx'), 'new-bytes');
+
+      const result = migrateClaudeFlowToMoflo(root);
+
+      expect(result.collisions).toContain('models');
+      // Both copies preserved — neither side touched.
+      expect(readFileSync(join(legacy, 'models', 'old.onnx'), 'utf8')).toBe('old-bytes');
+      expect(readFileSync(join(target, 'models', 'new.onnx'), 'utf8')).toBe('new-bytes');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // #735: when models/ relocates, the embeddings.json modelPath baked in
+  // pre-migration must be rewritten to point at the new location.
+  it('rewrites embeddings.json:modelPath when models/ moves via wholesale rename', () => {
+    const root = mkRoot();
+    try {
+      const legacy = legacyClaudeFlowDir(root);
+      mkdirSync(join(legacy, 'models'), { recursive: true });
+      writeFileSync(join(legacy, 'models', 'model.onnx'), 'bytes');
+      // Pre-migration embeddings.json lives inside the legacy dir, so the
+      // wholesale rename brings it along with a stale modelPath baked in.
+      writeFileSync(
+        join(legacy, 'embeddings.json'),
+        JSON.stringify({ modelPath: `/abs/path/${LEGACY_CLAUDE_FLOW_DIR}/models/model.onnx` }),
+      );
+
+      const result = migrateClaudeFlowToMoflo(root);
+      expect(result.migrated).toBe(true);
+
+      const cfg = JSON.parse(readFileSync(join(mofloDir(root), 'embeddings.json'), 'utf8'));
+      expect(cfg.modelPath).toBe(`/abs/path/${MOFLO_DIR}/models/model.onnx`);
+      expect(cfg.modelPath).not.toContain(LEGACY_CLAUDE_FLOW_DIR);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rewrites embeddings.json:modelPath when models/ moves via merge path', () => {
+    const root = mkRoot();
+    try {
+      const legacy = legacyClaudeFlowDir(root);
+      const target = mofloDir(root);
+      mkdirSync(target);
+      // Stale config already at canonical location pointing at legacy.
+      writeFileSync(
+        join(target, 'embeddings.json'),
+        JSON.stringify({ modelPath: `C:\\\\proj\\\\${LEGACY_CLAUDE_FLOW_DIR}\\\\models` }),
+      );
+      mkdirSync(join(legacy, 'models'), { recursive: true });
+      writeFileSync(join(legacy, 'models', 'model.onnx'), 'bytes');
+
+      migrateClaudeFlowToMoflo(root);
+
+      const cfg = JSON.parse(readFileSync(join(target, 'embeddings.json'), 'utf8'));
+      expect(cfg.modelPath).not.toContain(LEGACY_CLAUDE_FLOW_DIR);
+      expect(cfg.modelPath).toContain(MOFLO_DIR);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('rewriteEmbeddingsModelPath (#735)', () => {
+  it('returns false when embeddings.json does not exist', () => {
+    const root = mkRoot();
+    try {
+      expect(rewriteEmbeddingsModelPath(root)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false when modelPath does not reference legacy', () => {
+    const root = mkRoot();
+    try {
+      mkdirSync(mofloDir(root), { recursive: true });
+      writeFileSync(
+        join(mofloDir(root), 'embeddings.json'),
+        JSON.stringify({ modelPath: '/already/correct/.moflo/models' }),
+      );
+      expect(rewriteEmbeddingsModelPath(root)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('survives malformed JSON without throwing', () => {
+    const root = mkRoot();
+    try {
+      mkdirSync(mofloDir(root), { recursive: true });
+      writeFileSync(join(mofloDir(root), 'embeddings.json'), '{ not valid json');
+      expect(rewriteEmbeddingsModelPath(root)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves other fields when rewriting modelPath', () => {
+    const root = mkRoot();
+    try {
+      mkdirSync(mofloDir(root), { recursive: true });
+      writeFileSync(
+        join(mofloDir(root), 'embeddings.json'),
+        JSON.stringify({
+          modelPath: `/x/${LEGACY_CLAUDE_FLOW_DIR}/models`,
+          dimensions: 384,
+          provider: 'fastembed',
+        }),
+      );
+
+      expect(rewriteEmbeddingsModelPath(root)).toBe(true);
+
+      const cfg = JSON.parse(readFileSync(join(mofloDir(root), 'embeddings.json'), 'utf8'));
+      expect(cfg.modelPath).toBe(`/x/${MOFLO_DIR}/models`);
+      expect(cfg.dimensions).toBe(384);
+      expect(cfg.provider).toBe('fastembed');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/services/published-package-drift-guard.test.ts
+++ b/src/cli/__tests__/services/published-package-drift-guard.test.ts
@@ -224,6 +224,7 @@ describe('published-package drift guard (issue #585)', () => {
       join(REPO_ROOT, 'bin'),
       join(REPO_ROOT, 'scripts'),
       join(REPO_ROOT, '.claude', 'guidance', 'shipped'),
+      join(REPO_ROOT, '.claude', 'helpers'), // shipped (#735): writers here re-create `.claude-flow/`
       join(REPO_ROOT, '.claude', 'skills'),
     ];
     const CLAUDE_FLOW_RE = /\.claude-flow/;

--- a/src/cli/services/moflo-paths.ts
+++ b/src/cli/services/moflo-paths.ts
@@ -31,6 +31,7 @@ import {
   unlinkSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 
 export const MOFLO_DIR = '.moflo';
 /** Canonical memory DB filename (post-#727). Lives at `<root>/.moflo/moflo.db`. */
@@ -104,6 +105,14 @@ export interface MigrationResult {
   migrated: boolean;
   /** Diagnostic string for "why didn't this migrate" — `no-legacy`, `legacy-unreadable`, `merged-nothing`. Absent on success. */
   reason?: string;
+  /** Number of legacy entries actually relocated to `.moflo/` this call. */
+  movedCount?: number;
+  /**
+   * Names left behind in `.claude-flow/` because the same name already
+   * existed in `.moflo/`. Surfaced so the launcher can warn the user that
+   * BOTH copies exist (per #735: never silently choose).
+   */
+  collisions?: string[];
 }
 
 /**
@@ -112,8 +121,13 @@ export interface MigrationResult {
  * - Legacy missing → no-op (the steady state after first run).
  * - Legacy present + target missing → atomic rename (preserves mtimes).
  * - Both present → merge: target wins on collision, leaving the colliding
- *   entry behind in legacy/ so a future run can retry. Drops the legacy dir
- *   if everything moved cleanly.
+ *   entry behind in legacy/ so the launcher can warn and a future run can
+ *   retry. Drops the legacy dir if everything moved cleanly.
+ *
+ * When the models cache moves (legacy `.claude-flow/models/` lands at
+ * `.moflo/models/`), `.moflo/embeddings.json:modelPath` is rewritten in the
+ * same call so the next embedder run finds the relocated ONNX bytes instead
+ * of re-downloading multi-MB binaries (#735).
  *
  * Idempotent and safe to call from session start.
  */
@@ -124,8 +138,13 @@ export function migrateClaudeFlowToMoflo(projectRoot: string): MigrationResult {
   if (!existsSync(legacy)) return { migrated: false, reason: 'no-legacy' };
 
   if (!existsSync(target)) {
+    // Wholesale rename — count what's about to move so the launcher can
+    // report `migrated N files` instead of opaque "migrated runtime state".
+    let movedCount = 0;
+    try { movedCount = readdirSync(legacy).length; } catch { /* count is cosmetic */ }
     renameSync(legacy, target);
-    return { migrated: true };
+    rewriteEmbeddingsModelPath(projectRoot);
+    return { migrated: true, movedCount };
   }
 
   let entries: string[];
@@ -136,12 +155,18 @@ export function migrateClaudeFlowToMoflo(projectRoot: string): MigrationResult {
   }
 
   let moved = 0;
+  let modelsMoved = false;
+  const collisions: string[] = [];
   for (const name of entries) {
     const dst = join(target, name);
-    if (existsSync(dst)) continue; // target wins — newer state preferred
+    if (existsSync(dst)) {
+      collisions.push(name); // target wins — but the launcher must warn
+      continue;
+    }
     try {
       renameSync(join(legacy, name), dst);
       moved++;
+      if (name === 'models') modelsMoved = true;
     } catch {
       // Best-effort merge — a failed move on one entry shouldn't abort the rest.
     }
@@ -154,7 +179,46 @@ export function migrateClaudeFlowToMoflo(projectRoot: string): MigrationResult {
     // Non-fatal — leftover legacy dir just means migration runs next time.
   }
 
-  return moved > 0 ? { migrated: true } : { migrated: false, reason: 'merged-nothing' };
+  if (modelsMoved) rewriteEmbeddingsModelPath(projectRoot);
+
+  if (moved === 0) {
+    return { migrated: false, reason: 'merged-nothing', movedCount: 0, collisions };
+  }
+  return { migrated: true, movedCount: moved, collisions };
+}
+
+/**
+ * Rewrite `.moflo/embeddings.json:modelPath` if it still references the
+ * legacy `.claude-flow/` location. Called after a models/ relocation so the
+ * stale path doesn't force a multi-MB re-download (#735).
+ *
+ * Best-effort: file-not-present, malformed JSON, missing `modelPath`, or
+ * already-correct path are all silent no-ops. Returns true only when the
+ * file was actually rewritten. Uses atomicWriteFileSync so a SIGINT mid-flush
+ * can't truncate embeddings.json and break every subsequent embedder run.
+ */
+export function rewriteEmbeddingsModelPath(projectRoot: string): boolean {
+  const cfgPath = join(projectRoot, MOFLO_DIR, 'embeddings.json');
+
+  let raw: string;
+  try { raw = readFileSync(cfgPath, 'utf8'); } catch { return false; }
+
+  let cfg: { modelPath?: string };
+  try { cfg = JSON.parse(raw); } catch { return false; }
+
+  if (typeof cfg.modelPath !== 'string') return false;
+  if (!cfg.modelPath.includes(LEGACY_CLAUDE_FLOW_DIR)) return false;
+
+  // split-join handles every occurrence and works with both `/` and `\\`
+  // (escaped) forms in JSON-encoded Windows paths.
+  cfg.modelPath = cfg.modelPath.split(LEGACY_CLAUDE_FLOW_DIR).join(MOFLO_DIR);
+
+  try {
+    atomicWriteFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export interface DbMigrationResult {

--- a/tests/bin/launcher-visibility.test.ts
+++ b/tests/bin/launcher-visibility.test.ts
@@ -85,10 +85,41 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     const { stdout } = runLauncher(root);
     const lines = mutationLines(stdout);
 
-    expect(lines).toContain('moflo: migrated runtime state to .moflo/ (from legacy .claude-flow/)');
+    // #735: message includes entry count instead of opaque "runtime state".
+    expect(lines).toContain('moflo: migrated 1 entry from legacy .claude-flow/');
     // The migration actually moved the file
     expect(existsSync(join(root, '.moflo', 'metrics.json'))).toBe(true);
     expect(existsSync(join(root, '.claude-flow', 'metrics.json'))).toBe(false);
+  });
+
+  it('warns about collisions when both .claude-flow/ and .moflo/ have the same subdir (#735)', () => {
+    // Pre-existing target forces the merge path. `models/` collision is the
+    // motivating case from #735 — never silently choose, surface to user.
+    mkdirSync(join(root, '.moflo', 'models'), { recursive: true });
+    writeFileSync(join(root, '.moflo', 'models', 'new.onnx'), 'new');
+    mkdirSync(join(root, '.claude-flow', 'models'), { recursive: true });
+    writeFileSync(join(root, '.claude-flow', 'models', 'old.onnx'), 'old');
+
+    const { stdout } = runLauncher(root);
+    const lines = mutationLines(stdout);
+
+    const collisionLine = lines.find((l) =>
+      l.startsWith('moflo: kept legacy .claude-flow/ entries to avoid clobbering .moflo/'),
+    );
+    expect(collisionLine).toBeDefined();
+    expect(collisionLine).toContain('models');
+    // Both copies preserved.
+    expect(existsSync(join(root, '.claude-flow', 'models', 'old.onnx'))).toBe(true);
+    expect(existsSync(join(root, '.moflo', 'models', 'new.onnx'))).toBe(true);
+  });
+
+  it('does not emit a migration line on the silent fast-path when .claude-flow/ is absent (#735)', () => {
+    // No .claude-flow/ present — every migration-related line MUST stay quiet
+    // so it stops inflating mutationCount on every session-start.
+    const { stdout } = runLauncher(root);
+    const lines = mutationLines(stdout);
+    expect(lines.find((l) => l.includes('migrated') && l.includes('.claude-flow/'))).toBeUndefined();
+    expect(lines.find((l) => l.includes('kept legacy .claude-flow/'))).toBeUndefined();
   });
 
   it('reports legacy `.swarm/vector-stats.json` removal exactly once', () => {


### PR DESCRIPTION
## Summary

Finishes the `.claude-flow/` → `.moflo/` migration started in #706. Story under epic #726.

- **Phase 1 (writers)**: redirect the two remaining source-tree writers (`.claude/helpers/intelligence.cjs` and `auto-memory-hook.mjs`) and add `.claude/helpers/` to the drift-guard SCAN_ROOTS so this cannot regress.
- **Phase 2 (preserving migration)**: `migrateClaudeFlowToMoflo` now reports `{movedCount, collisions}`. Launcher emits `migrated N entries from legacy .claude-flow/` (with a real count) and warns when subdirs collide between the two locations instead of silently choosing. When `models/` actually relocates, `.moflo/embeddings.json:modelPath` is rewritten atomically so the next embedder run finds the relocated ONNX bytes — no multi-MB re-download.
- **Phase 3 (hard-delete)**: deliberately deferred to the next release per the staged-removal contract documented inline in `bin/session-start-launcher.mjs`.

## Why the drift guard missed this

The `published-package-drift-guard` test scans `src/cli`, `bin`, `scripts`, `.claude/guidance/shipped`, and `.claude/skills` — but `.claude/helpers/` was never in the list, even though those files ship with the package and run on every consumer's session start. They were silently re-creating `.claude-flow/data/` and `.claude-flow/sessions/` on every session, which is why the legacy directory kept coming back.

## Acceptance criteria

- [x] No source-tree code writes to `.claude-flow/` after Phase 1 (drift guard now scans `.claude/helpers/` too)
- [x] Consumer with legacy `.claude-flow/models/` ends up with `.moflo/models/`
- [x] Consumer with legacy `.claude-flow/data/` has its contents preserved at `.moflo/data/`
- [x] `.moflo/embeddings.json:modelPath` rewritten when models relocate (atomic write)
- [x] Mutation message uses real count, fires only when `.claude-flow/` actually present
- [x] Collision case logs a warning and keeps both — never silently chooses
- [x] Phase 3 staged removal documented in launcher comment

## Test plan

- [x] All 7390 tests pass (full `npm test` after every change)
- [x] New tests in `moflo-paths-migration.test.ts` cover: movedCount return, collision tracking, models/ preservation via merge path, both-models warning, embeddings.json modelPath rewrite via wholesale rename + merge path, malformed-JSON tolerance, field preservation
- [x] `launcher-visibility.test.ts` covers: new "migrated N entries" message, collision warning, silent fast-path when `.claude-flow/` absent
- [x] `published-package-drift-guard.test.ts` enforces no `.claude-flow/` in `.claude/helpers/` going forward
- [ ] Manual smoke gated on epic #736 populated-consumer profile

Closes #735

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)