### PR TITLE
fix(750): hard-delete `knowledge` namespace residue + purge stale doc refs

### DIFF
--- a/.claude/skills/hive-mind-advanced/SKILL.md
+++ b/.claude/skills/hive-mind-advanced/SKILL.md
@@ -158,11 +158,11 @@ const decision = await hiveMind.buildConsensus(
 await memory.store('api-patterns', {
   rest: { pros: [...], cons: [...] },
   graphql: { pros: [...], cons: [...] }
-}, 'knowledge', { confidence: 0.95 });
+}, 'learnings', { confidence: 0.95 });
 ```
 
 **Memory Types**
-- `knowledge`: Permanent insights (no TTL)
+- `learnings`: Permanent insights (no TTL) — `knowledge` is a deprecated alias
 - `context`: Session context (1 hour TTL)
 - `task`: Task-specific data (30 min TTL)
 - `result`: Execution results (permanent, compressed)
@@ -176,7 +176,7 @@ await memory.store('api-patterns', {
 ```javascript
 // Search memory by pattern
 const results = await memory.search('api*', {
-  type: 'knowledge',
+  type: 'learnings',
   minConfidence: 0.8,
   limit: 50
 });
@@ -404,7 +404,7 @@ await memory.store('auth-pattern', {
   pros: ['Stateless', 'Scalable'],
   cons: ['Token size', 'Revocation complexity'],
   implementation: {...}
-}, 'knowledge', { confidence: 0.95 });
+}, 'learnings', { confidence: 0.95 });
 ```
 
 **Build Associations**

--- a/.claude/skills/memory-patterns/SKILL.md
+++ b/.claude/skills/memory-patterns/SKILL.md
@@ -21,7 +21,7 @@ Three things to know:
 
 2. **CLI** — `flo-search "<query>" --namespace <ns>` for quick semantic lookup from the shell.
 
-3. **Namespaces** — namespace + key is the unique identity. Default namespaces shipped by moflo: `knowledge`, `patterns`, `guidance`, `code-map`. Create your own for application memory (e.g. `app:sessions`, `app:users`).
+3. **Namespaces** — namespace + key is the unique identity. Default namespaces shipped by moflo: `learnings`, `patterns`, `guidance`, `code-map`. (`knowledge` is a deprecated alias — writes are transparently redirected to `learnings`.) Create your own for application memory (e.g. `app:sessions`, `app:users`).
 
 ## Pattern 1: Session Memory
 
@@ -50,7 +50,7 @@ Facts that should survive any session and be findable by meaning, not exact key:
 
 ```typescript
 await mcp.memory_store({
-  namespace: 'knowledge',
+  namespace: 'learnings',
   key: 'auth:session-token-rotation',
   value: 'Session tokens are rotated every 15 minutes by the auth middleware. Refresh happens transparently on the client.',
   tags: ['auth', 'security'],
@@ -59,7 +59,7 @@ await mcp.memory_store({
 
 // Retrieval: semantic, not keyword
 const hits = await mcp.memory_search({
-  namespace: 'knowledge',
+  namespace: 'learnings',
   query: 'how do auth tokens refresh?',
   limit: 5,
   threshold: 0.4,

--- a/.claude/skills/vector-search/SKILL.md
+++ b/.claude/skills/vector-search/SKILL.md
@@ -9,7 +9,7 @@ Semantic search over your own documents, backed by moflo's HNSW index in `.swarm
 
 ## When to Use This vs `memory-patterns`
 
-- **`memory-patterns`** — structured, namespaced memory you own (sessions, knowledge, patterns). Keys matter. Entries are conceptual units.
+- **`memory-patterns`** — structured, namespaced memory you own (sessions, learnings, patterns). Keys matter. Entries are conceptual units.
 - **This skill (`vector-search`)** — search over documents you've ingested for retrieval. Entries are content chunks. Keys are just stable IDs for dedupe.
 
 Both use the same index; the difference is how you chunk and what you put in the `value` field.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ This project uses [MoFlo](https://github.com/eric-cielo/moflo) for AI-assisted d
 
 ### FIRST ACTION ON EVERY PROMPT: Search Memory
 
-MUST call `mcp__moflo__memory_search` BEFORE any Glob/Grep/Read/file exploration. Namespaces: `guidance`+`patterns` every prompt; `code-map` when navigating code. When the user says "remember this": `mcp__moflo__memory_store` with namespace `knowledge`.
+MUST call `mcp__moflo__memory_search` BEFORE any Glob/Grep/Read/file exploration. Namespaces: `guidance`+`patterns`+`learnings` every prompt; `code-map` when navigating code. When the user says "remember this": `mcp__moflo__memory_store` with namespace `learnings`.
 
 ### Spell Gates (enforced automatically)
 

--- a/bin/migrations/knowledge-purge.mjs
+++ b/bin/migrations/knowledge-purge.mjs
@@ -1,0 +1,107 @@
+/**
+ * Migration: hard-delete every legacy `knowledge`-namespace row whose
+ * counterpart now exists in `learnings` (tagged `migratedFrom:knowledge`).
+ *
+ * Runs AFTER `knowledge-to-learnings` (manifest gate). For each `knowledge`
+ * row (active or archived):
+ *   - counterpart present  → hard-delete
+ *   - counterpart missing  → skip with stderr warning (defensive — should
+ *     not happen post-`knowledge-to-learnings`; existing consumers stuck on
+ *     the active-only v1 will see this for archived rows the original missed)
+ *
+ * The deprecated-alias soft-redirect at `storeEntry` stays — any caller still
+ * passing `namespace: 'knowledge'` writes lands transparently in `learnings`.
+ *
+ * @module bin/migrations/knowledge-purge
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { mofloResolveURL } from '../lib/moflo-resolve.mjs';
+import { memoryDbPath } from '../lib/moflo-paths.mjs';
+import { hasMigrationRun } from '../lib/migrations.mjs';
+import { MIGRATED_FROM_KNOWLEDGE } from './lib/markers.mjs';
+
+export const name = 'knowledge-purge';
+// Explicit ordering puts this after `knowledge-to-learnings` (default order=0)
+// in the runner's queue so a single session-start completes the pipeline. The
+// manifest gate inside `run()` is the cross-session safety net: if the
+// consolidation copy errored mid-run, the manifest is unstamped and we defer
+// the purge until a future session lands the copy successfully.
+export const order = 10;
+
+/**
+ * @param {string} projectRoot
+ * @returns {Promise<{purged:number, skipped:number}>}
+ */
+export async function run(projectRoot) {
+  // Manifest gate: only run after the consolidation copy completed. Throwing
+  // (rather than returning {skipped:true}) keeps the manifest unstamped so
+  // we retry next session — the runner records done only on resolved returns.
+  if (!hasMigrationRun(projectRoot, 'knowledge-to-learnings')) {
+    throw new Error('knowledge-to-learnings has not yet completed; will retry next session');
+  }
+
+  const dbPath = memoryDbPath(projectRoot);
+  if (!existsSync(dbPath)) return { purged: 0, skipped: 0 };
+
+  // Lazy-load sql.js — keeps the manifest-stamped no-op path off the WASM
+  // init cost (~30ms cold).
+  const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(readFileSync(dbPath));
+
+  const knowledgeStmt = db.prepare(
+    `SELECT id, key, status FROM memory_entries
+     WHERE namespace = 'knowledge' AND status IN ('active','archived')`,
+  );
+  const knowledgeRows = [];
+  while (knowledgeStmt.step()) knowledgeRows.push(knowledgeStmt.getAsObject());
+  knowledgeStmt.free();
+
+  if (knowledgeRows.length === 0) {
+    db.close();
+    return { purged: 0, skipped: 0 };
+  }
+
+  // tags is a JSON-encoded array string — LIKE on the substring is enough to
+  // confirm the migratedFrom:knowledge marker without parsing every row. The
+  // marker is a JS-defined constant, not user input, so inlining via template
+  // literal avoids sql.js's two-step prepare+bind for a single-shot read.
+  const counterpartStmt = db.prepare(
+    `SELECT key FROM memory_entries
+     WHERE namespace = 'learnings'
+       AND status IN ('active','archived')
+       AND tags LIKE '%${MIGRATED_FROM_KNOWLEDGE}%'`,
+  );
+  const migratedKeys = new Set();
+  while (counterpartStmt.step()) migratedKeys.add(String(counterpartStmt.getAsObject().key));
+  counterpartStmt.free();
+
+  const deleteStmt = db.prepare(`DELETE FROM memory_entries WHERE id = ?`);
+
+  let purged = 0;
+  let skipped = 0;
+  try {
+    for (const row of knowledgeRows) {
+      const key = String(row.key);
+      if (!migratedKeys.has(key)) {
+        skipped++;
+        // One-line stderr warning per ticket — defensive, should not fire on
+        // a healthy DB. archived-row orphans on consumers stuck on v1 surface
+        // here so the user has a paper trail.
+        process.stderr.write(
+          `[migrations]   knowledge-purge: skipping orphan key="${key}" status=${row.status} (no ${MIGRATED_FROM_KNOWLEDGE} counterpart)\n`,
+        );
+        continue;
+      }
+      deleteStmt.run([row.id]);
+      purged++;
+    }
+  } finally {
+    deleteStmt.free();
+  }
+
+  if (purged > 0) writeFileSync(dbPath, Buffer.from(db.export()));
+  db.close();
+  return { purged, skipped };
+}

--- a/bin/migrations/knowledge-to-learnings.mjs
+++ b/bin/migrations/knowledge-to-learnings.mjs
@@ -1,10 +1,11 @@
 /**
- * Migration: copy every active row from the deprecated `knowledge` namespace
- * into `learnings`, tagging with `source:user`, `locked`, `migratedFrom:knowledge`
- * so future decay/prune leaves them alone.
+ * Migration: copy every row (active + archived) from the deprecated `knowledge`
+ * namespace into `learnings`, tagging with `source:user`, `locked`,
+ * `migratedFrom:knowledge` so future decay/prune leaves them alone. Archived
+ * rows preserve their `status='archived'` on the learnings side.
  *
- * Original `knowledge` rows are preserved (the standing rule against renaming
- * core namespaces forbids deletion); they're just no longer the canonical home.
+ * Source `knowledge` rows are preserved here; the follow-on `knowledge-purge`
+ * migration hard-deletes them once their counterpart is confirmed.
  *
  * @module bin/migrations/knowledge-to-learnings
  */
@@ -14,8 +15,7 @@ import { writeFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { mofloResolveURL } from '../lib/moflo-resolve.mjs';
 import { memoryDbPath } from '../lib/moflo-paths.mjs';
-
-const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
+import { MIGRATED_FROM_KNOWLEDGE } from './lib/markers.mjs';
 
 export const name = 'knowledge-to-learnings';
 
@@ -24,7 +24,7 @@ function generateId() {
 }
 
 function mergeTags(originalJson) {
-  const additions = ['source:user', 'locked', 'migratedFrom:knowledge'];
+  const additions = ['source:user', 'locked', MIGRATED_FROM_KNOWLEDGE];
   let original = [];
   try {
     const parsed = JSON.parse(originalJson || '[]');
@@ -38,20 +38,25 @@ function mergeTags(originalJson) {
 /**
  * @param {string} projectRoot
  * @returns {Promise<{rowsMigrated:number, rowsSkipped:number}>}
+ *   `rowsMigrated` counts both active and archived inserts. `rowsSkipped`
+ *   counts (key, status) pairs that already had a learnings counterpart.
  */
 export async function run(projectRoot) {
   const dbPath = memoryDbPath(projectRoot);
   if (!existsSync(dbPath)) return { rowsMigrated: 0, rowsSkipped: 0 };
 
+  // Lazy-load sql.js — top-level await would pay ~30ms WASM init even on the
+  // no-op fast-path where the manifest already records this migration as done.
+  const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
   const SQL = await initSqlJs();
   const db = new SQL.Database(readFileSync(dbPath));
 
   const sourceStmt = db.prepare(
     `SELECT id, key, content, type, metadata, tags, embedding, embedding_dimensions,
             embedding_model, owner_id, created_at, updated_at, expires_at,
-            last_accessed_at, access_count
+            last_accessed_at, access_count, status
      FROM memory_entries
-     WHERE namespace = 'knowledge' AND status = 'active'`,
+     WHERE namespace = 'knowledge' AND status IN ('active','archived')`,
   );
   const rows = [];
   while (sourceStmt.step()) rows.push(sourceStmt.getAsObject());
@@ -63,10 +68,15 @@ export async function run(projectRoot) {
   }
 
   const existingStmt = db.prepare(
-    `SELECT key FROM memory_entries WHERE namespace = 'learnings' AND status = 'active'`,
+    `SELECT key, status FROM memory_entries WHERE namespace = 'learnings' AND status IN ('active','archived')`,
   );
-  const existingKeys = new Set();
-  while (existingStmt.step()) existingKeys.add(String(existingStmt.getAsObject().key));
+  // key|status pairs — a knowledge row's archived counterpart shouldn't block
+  // copying its active version (and vice-versa) so we key by both fields.
+  const existingPairs = new Set();
+  while (existingStmt.step()) {
+    const r = existingStmt.getAsObject();
+    existingPairs.add(`${String(r.key)}|${String(r.status)}`);
+  }
   existingStmt.free();
 
   const insertStmt = db.prepare(`
@@ -74,7 +84,7 @@ export async function run(projectRoot) {
       (id, key, namespace, content, type, embedding, embedding_model, embedding_dimensions,
        tags, metadata, owner_id, created_at, updated_at, expires_at,
        last_accessed_at, access_count, status)
-    VALUES (?, ?, 'learnings', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+    VALUES (?, ?, 'learnings', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   let migrated = 0;
@@ -82,7 +92,8 @@ export async function run(projectRoot) {
   try {
     for (const row of rows) {
       const key = String(row.key);
-      if (existingKeys.has(key)) { skipped++; continue; }
+      const status = String(row.status ?? 'active');
+      if (existingPairs.has(`${key}|${status}`)) { skipped++; continue; }
 
       insertStmt.run([
         generateId(),
@@ -100,6 +111,7 @@ export async function run(projectRoot) {
         row.expires_at ?? null,
         row.last_accessed_at ?? null,
         row.access_count ?? 0,
+        status,
       ]);
       migrated++;
     }

--- a/bin/migrations/lib/markers.mjs
+++ b/bin/migrations/lib/markers.mjs
@@ -1,0 +1,11 @@
+/**
+ * Shared tag markers used across the knowledge → learnings migration pipeline.
+ *
+ * @module bin/migrations/lib/markers
+ */
+
+/** Tag stamped on every learnings row that was migrated from the deprecated
+ *  knowledge namespace. The purge migration uses this to confirm a counterpart
+ *  exists before hard-deleting the source row, so a typo here silently breaks
+ *  the entire pipeline. */
+export const MIGRATED_FROM_KNOWLEDGE = 'migratedFrom:knowledge';

--- a/bin/run-migrations.mjs
+++ b/bin/run-migrations.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Migration runner — consults the per-project manifest and runs only
- * migrations that haven't already been recorded. Fast-paths to a no-op (~5ms)
- * when nothing is unmet, so it's safe to fire on every session start.
+ * migrations that haven't already been recorded. Fast-paths to a no-op when
+ * nothing is unmet (cost = node startup + ESM graph; sub-100ms on warm fs),
+ * so it's safe to fire on every session start.
  *
  * Migrations live under `bin/migrations/` and each module exports:
  *   export const name = '<unique-id>';
@@ -77,6 +78,16 @@ async function loadMigrations() {
       debug(`SKIP ${f} — load error: ${err.message}`);
     }
   }
+  // Stable order: by `order` (default 0) ascending, then by `name`. A
+  // migration that depends on another should `export const order = N` with N
+  // larger than the dep's. readdirSync is filesystem-dependent across OSes,
+  // so explicit ordering is the only portable way to express dependencies.
+  loaded.sort((a, b) => {
+    const ao = typeof a.order === 'number' ? a.order : 0;
+    const bo = typeof b.order === 'number' ? b.order : 0;
+    if (ao !== bo) return ao - bo;
+    return a.name.localeCompare(b.name);
+  });
   return loaded;
 }
 

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -7,7 +7,7 @@
  * Invoked by: node .claude/scripts/session-start-launcher.mjs
  */
 
-import { spawn } from 'child_process';
+import { spawn, execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -880,16 +880,70 @@ if (existsSync(hooksScript)) {
 }
 
 // Migration runner — consults `.moflo/migrations.json` and runs only
-// migrations that haven't been recorded. Single spawn, fast-paths to a
-// no-op when the manifest is current, so safe to fire every session.
+// migrations that haven't been recorded. Fast-paths to a no-op when the
+// manifest is current; the runner module loads with lazy sql.js init in
+// each migration, so a stamped session pays only node startup + ESM graph.
 //
 // Prefer the npm-package path so first-install consumers run unmet
 // migrations without waiting for a script-sync round-trip.
+//
+// Run synchronously (capture stdout) so each completed migration surfaces
+// through emitMutation — Claude's session-start hook captures launcher
+// stdout and that's the only channel that reaches the user.
 const runMigrationsPkg = resolve(projectRoot, 'node_modules/moflo/bin/run-migrations.mjs');
 const runMigrationsMirror = resolve(projectRoot, '.claude/scripts/run-migrations.mjs');
 const runMigrations = existsSync(runMigrationsPkg) ? runMigrationsPkg : runMigrationsMirror;
 if (existsSync(runMigrations)) {
-  fireAndForget('node', [runMigrations], 'migration runner');
+  runMigrationsAndAnnounce(runMigrations);
+}
+
+function runMigrationsAndAnnounce(runnerPath) {
+  let raw;
+  try {
+    raw = execFileSync('node', [runnerPath], {
+      cwd: projectRoot,
+      timeout: 30_000,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+  } catch (err) {
+    // Migrations are best-effort — a failure here must never block session
+    // start. But silent swallowing hides hangs (30s timeout) and corrupted
+    // DBs from the user, so leave a stderr crumb.
+    process.stderr.write(`moflo: migration runner failed (${err.code || err.message}); will retry next session\n`);
+    return;
+  }
+
+  const labels = {
+    'knowledge-to-learnings': 'consolidated knowledge → learnings',
+    'knowledge-purge': 'removed legacy knowledge namespace rows',
+  };
+
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\[migrations\]\s+([\w-]+):\s+done\s+in\s+\d+ms\s*(.*)$/);
+    if (!m) continue;
+    const migrationName = m[1];
+    let parsed = null;
+    try { parsed = m[2] ? JSON.parse(m[2]) : null; } catch { parsed = null; }
+
+    // Silent fast-path: don't announce zero-work runs (no point telling the
+    // user the launcher did nothing). If every numeric detail field is 0,
+    // skip the emit. Stamped migrations don't even reach this loop because
+    // the runner short-circuits via the manifest.
+    if (parsed) {
+      const nums = Object.values(parsed).filter((v) => typeof v === 'number');
+      if (nums.length > 0 && nums.every((v) => v === 0)) continue;
+    }
+
+    let detail = '';
+    if (parsed) {
+      if (typeof parsed.purged === 'number') detail = `${parsed.purged} ${parsed.purged === 1 ? 'row' : 'rows'}`;
+      else if (typeof parsed.rowsMigrated === 'number') detail = `${parsed.rowsMigrated} ${parsed.rowsMigrated === 1 ? 'entry' : 'entries'}`;
+    }
+
+    const label = labels[migrationName] || `migration ${migrationName}`;
+    emitMutation(label, detail);
+  }
 }
 
 // Patches are now baked into moflo@4.0.0 source — no runtime patching needed.

--- a/harness/consumer-smoke/lib/populated.mjs
+++ b/harness/consumer-smoke/lib/populated.mjs
@@ -29,6 +29,7 @@ import {
   hnswIndexPath,
   legacyHnswIndexPath,
 } from '../../../bin/lib/moflo-paths.mjs';
+import { MIGRATED_FROM_KNOWLEDGE } from '../../../bin/migrations/lib/markers.mjs';
 
 const ACTIVE_NAMESPACES = ['guidance', 'patterns', 'code-map', 'tests', 'knowledge', 'learnings', 'default'];
 const EPHEMERAL_NAMESPACES = ['hive-mind', 'tasklist', 'epic-state', 'test-bridge-fix'];
@@ -210,7 +211,7 @@ function inspectPostStateDb(consumerDir) {
 const { readFileSync } = await import('node:fs');
 const SQL = await sqlInit();
 const db = new SQL.Database(readFileSync(${JSON.stringify(dbPath)}));
-const out = { byNamespaceStatus: {}, integrity: null, ids: [], hasEmbedding: 0 };
+const out = { byNamespaceStatus: {}, integrity: null, ids: [], hasEmbedding: 0, migratedLearnings: { byStatus: {}, withEmbedding: 0, sampleKeys: [] } };
 const res = db.exec("SELECT namespace, status, COUNT(*) FROM memory_entries GROUP BY namespace, status");
 if (res[0]) {
   for (const row of res[0].values) out.byNamespaceStatus[row[0]+'/'+row[1]] = row[2];
@@ -221,6 +222,15 @@ const embRes = db.exec("SELECT COUNT(*) FROM memory_entries WHERE embedding IS N
 if (embRes[0]) out.hasEmbedding = embRes[0].values[0][0];
 const intRes = db.exec("PRAGMA integrity_check");
 if (intRes[0]) out.integrity = intRes[0].values[0][0];
+const migMarker = ${JSON.stringify(`%${MIGRATED_FROM_KNOWLEDGE}%`)};
+const migRes = db.exec("SELECT status, COUNT(*) FROM memory_entries WHERE namespace='learnings' AND tags LIKE '" + migMarker + "' GROUP BY status");
+if (migRes[0]) {
+  for (const row of migRes[0].values) out.migratedLearnings.byStatus[row[0]] = row[1];
+}
+const migEmbRes = db.exec("SELECT COUNT(*) FROM memory_entries WHERE namespace='learnings' AND tags LIKE '" + migMarker + "' AND embedding IS NOT NULL AND embedding != ''");
+if (migEmbRes[0]) out.migratedLearnings.withEmbedding = migEmbRes[0].values[0][0];
+const sampleRes = db.exec("SELECT key FROM memory_entries WHERE namespace='learnings' AND tags LIKE '" + migMarker + "' LIMIT 5");
+if (sampleRes[0]) out.migratedLearnings.sampleKeys = sampleRes[0].values.map(r => r[0]);
 db.close();
 emit(out);
 `);
@@ -245,7 +255,12 @@ function inspectInstalledEphemeralNamespaces(consumerDir) {
 }
 
 function assertActiveRowsPreserved(snapshot, expectedRows) {
-  const expected = expectedRows.filter(r => r.status === 'active' && ACTIVE_NAMESPACES.includes(r.namespace));
+  // `knowledge` is excluded — story #750 hard-deletes those rows after copying
+  // them to `learnings`. Survival is asserted on the migrated counterpart in
+  // assertKnowledgeMigratedToLearnings instead.
+  const expected = expectedRows.filter(
+    r => r.status === 'active' && ACTIVE_NAMESPACES.includes(r.namespace) && r.namespace !== 'knowledge',
+  );
   const presentIds = new Set(snapshot.ids);
   const missing = expected.filter(r => !presentIds.has(r.id));
   if (missing.length === 0) {
@@ -260,13 +275,50 @@ function assertActiveRowsPreserved(snapshot, expectedRows) {
   );
 }
 
-function assertArchivedRowsPreserved(snapshot) {
-  const archivedCount = snapshot.byNamespaceStatus['knowledge/archived'] ?? 0;
-  if (archivedCount >= ARCHIVED_ROW_COUNT) {
-    record('populated:archived-preserved', 'pass', `${archivedCount} archived rows survive`);
-  } else {
-    record('populated:archived-preserved', 'fail', `expected ≥ ${ARCHIVED_ROW_COUNT} archived rows, got ${archivedCount}`);
+function assertKnowledgePurged(snapshot) {
+  // Story #750: every active+archived knowledge row should be hard-deleted
+  // after the consolidation→purge migration pipeline.
+  const offenders = [];
+  for (const status of ['active', 'archived']) {
+    const count = snapshot.byNamespaceStatus[`knowledge/${status}`] ?? 0;
+    if (count > 0) offenders.push(`${status}=${count}`);
   }
+  if (offenders.length === 0) {
+    record('populated:knowledge-purged', 'pass', 'no legacy knowledge rows remain (#750)');
+  } else {
+    record('populated:knowledge-purged', 'fail', `legacy knowledge rows leaked through #750 purge: ${offenders.join(', ')}`);
+  }
+}
+
+function assertKnowledgeMigratedToLearnings(snapshot) {
+  // Every knowledge row should re-surface as a `learnings` row carrying the
+  // `migratedFrom:knowledge` tag with status preserved (active stays active,
+  // archived stays archived) and its embedding intact.
+  const expectedActive = ROWS_PER_ACTIVE_NAMESPACE; // 20 from buildSeedPlan
+  const expectedArchived = ARCHIVED_ROW_COUNT; // 3
+  const expectedTotal = expectedActive + expectedArchived;
+  const got = snapshot.migratedLearnings ?? { byStatus: {}, withEmbedding: 0, sampleKeys: [] };
+  const gotActive = got.byStatus.active ?? 0;
+  const gotArchived = got.byStatus.archived ?? 0;
+  const gotTotal = gotActive + gotArchived;
+
+  if (gotTotal < expectedTotal) {
+    record('populated:knowledge-migrated', 'fail',
+      `expected ≥ ${expectedTotal} migratedFrom:knowledge learnings rows, got ${gotTotal} (active=${gotActive}, archived=${gotArchived})`);
+    return;
+  }
+  if (gotArchived < expectedArchived) {
+    record('populated:knowledge-migrated', 'fail',
+      `archived status not preserved on migrated rows: expected ≥ ${expectedArchived}, got ${gotArchived}`);
+    return;
+  }
+  if (got.withEmbedding < expectedTotal) {
+    record('populated:knowledge-migrated', 'fail',
+      `embeddings dropped on migrated rows: ${got.withEmbedding}/${expectedTotal} retained`);
+    return;
+  }
+  record('populated:knowledge-migrated', 'pass',
+    `${gotTotal} learnings rows tagged migratedFrom:knowledge (active=${gotActive}, archived=${gotArchived}, with-embedding=${got.withEmbedding})`);
 }
 
 function assertDeletedRowsPurged(snapshot) {
@@ -381,6 +433,8 @@ function assertLauncherAnnouncements(stdout) {
     { fragment: 'relocated memory db', label: 'announce-db-relocation' },
     { fragment: 'soft-deleted', label: 'announce-softdelete-purge' },
     { fragment: 'ephemeral namespace', label: 'announce-ephemeral-purge' },
+    { fragment: 'consolidated knowledge', label: 'announce-knowledge-consolidation' },
+    { fragment: 'removed legacy knowledge', label: 'announce-knowledge-purge' },
   ];
   for (const e of expected) {
     if (stdout.includes(e.fragment)) {
@@ -576,7 +630,8 @@ export async function runPopulatedConsumerProfile(consumerDir) {
     record('populated:post-state-snapshot', 'fail', `${MOFLO_DIR}/${MEMORY_DB_FILE} inspect probe failed`);
   } else {
     assertActiveRowsPreserved(snapshot, rows);
-    assertArchivedRowsPreserved(snapshot);
+    assertKnowledgePurged(snapshot);
+    assertKnowledgeMigratedToLearnings(snapshot);
     assertDeletedRowsPurged(snapshot);
     assertEphemeralRowsPurged(snapshot);
     assertIntegrity(snapshot);

--- a/src/cli/__tests__/services/knowledge-purge-migration.test.ts
+++ b/src/cli/__tests__/services/knowledge-purge-migration.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the `knowledge-purge` migration (story #750).
+ *
+ * Drives `bin/migrations/knowledge-purge.mjs` against fixture sql.js DBs
+ * to verify:
+ *   - manifest gate (defers when `knowledge-to-learnings` hasn't run)
+ *   - hard-deletes active+archived knowledge rows whose `migratedFrom:knowledge`
+ *     counterpart exists in `learnings`
+ *   - skips orphans with a stderr warning
+ *   - is idempotent on a second pass
+ *
+ * Co-tests `knowledge-to-learnings` because the two migrations form one
+ * pipeline — verifying purge alone is brittle without the upstream copy.
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { run as knowledgeToLearningsRun, name as knowledgeToLearningsName }
+  from '../../../../bin/migrations/knowledge-to-learnings.mjs';
+import { markMigrationDone } from '../../../../bin/lib/migrations.mjs';
+import { MIGRATED_FROM_KNOWLEDGE } from '../../../../bin/migrations/lib/markers.mjs';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+
+type SqlJsDb = {
+  run(sql: string, params?: unknown[]): void;
+  exec(sql: string): Array<{ values: unknown[][]; columns: string[] }>;
+  export(): Uint8Array;
+  close(): void;
+};
+type SqlJsStatic = { Database: new (data?: Uint8Array) => SqlJsDb };
+
+let SQL: SqlJsStatic;
+
+beforeAll(async () => {
+  const initSqlJs = (await import('sql.js')).default;
+  SQL = (await initSqlJs()) as SqlJsStatic;
+});
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true });
+    } catch {
+      /* non-fatal — Windows occasionally holds file handles */
+    }
+  }
+});
+
+interface SeedRow {
+  id: string;
+  key: string;
+  namespace: string;
+  content: string;
+  status: 'active' | 'archived' | 'deleted';
+  tags?: string[];
+  embedding?: string;
+}
+
+async function makeProject(rows: SeedRow[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moflo-knowledge-purge-'));
+  tmpDirs.push(dir);
+  await mkdir(join(dir, '.moflo'), { recursive: true });
+
+  const db = new SQL.Database();
+  // Production schema — drift here is caught loud rather than silently
+  // letting the migration pass against a stale fixture.
+  db.run(MEMORY_SCHEMA_V3);
+  for (const r of rows) {
+    db.run(
+      `INSERT INTO memory_entries (id, key, namespace, content, status, tags, embedding, embedding_dimensions)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        r.id,
+        r.key,
+        r.namespace,
+        r.content,
+        r.status,
+        JSON.stringify(r.tags ?? []),
+        r.embedding ?? null,
+        r.embedding ? 384 : null,
+      ],
+    );
+  }
+  const buf = Buffer.from(db.export());
+  db.close();
+  writeFileSync(join(dir, '.moflo', 'moflo.db'), buf);
+  return dir;
+}
+
+function readDb(dir: string): SqlJsDb {
+  const buf = readFileSync(join(dir, '.moflo', 'moflo.db'));
+  return new SQL.Database(buf);
+}
+
+function rowsByNamespaceStatus(dir: string): Record<string, number> {
+  const db = readDb(dir);
+  const res = db.exec(
+    `SELECT namespace, status, COUNT(*) FROM memory_entries GROUP BY namespace, status`,
+  );
+  const out: Record<string, number> = {};
+  for (const row of res[0]?.values ?? []) out[`${row[0]}/${row[1]}`] = Number(row[2]);
+  db.close();
+  return out;
+}
+
+// Importing knowledge-purge.mjs via a `new URL(...)` so the ESM resolver
+// resolves it relative to this file regardless of cwd. Module is cached
+// after first import — the gate logic reads the manifest fresh each call,
+// so the cache is invariant-safe across tests.
+async function importPurge() {
+  return await import(new URL('../../../../bin/migrations/knowledge-purge.mjs', import.meta.url).href);
+}
+
+describe('knowledge-purge migration', () => {
+  it('throws when knowledge-to-learnings has not yet completed (manifest gate)', async () => {
+    const dir = await makeProject([
+      { id: 'k1', key: 'a', namespace: 'knowledge', content: 'x', status: 'active' },
+    ]);
+
+    const purge = await importPurge();
+    await expect(purge.run(dir)).rejects.toThrow(/knowledge-to-learnings/);
+
+    const counts = rowsByNamespaceStatus(dir);
+    expect(counts['knowledge/active']).toBe(1);
+  });
+
+  it('hard-deletes active+archived knowledge rows whose migrated counterpart exists', async () => {
+    const seed: SeedRow[] = [];
+    for (let i = 0; i < 5; i++) {
+      seed.push({
+        id: `k-active-${i}`, key: `key-${i}`, namespace: 'knowledge',
+        content: `content ${i}`, status: 'active', embedding: '[0.1]',
+      });
+    }
+    for (let i = 0; i < 3; i++) {
+      seed.push({
+        id: `k-archived-${i}`, key: `archived-${i}`, namespace: 'knowledge',
+        content: `archived ${i}`, status: 'archived', embedding: '[0.2]',
+      });
+    }
+    const dir = await makeProject(seed);
+
+    // Run the consolidation copy first — it stamps migratedFrom:knowledge tags
+    // on every counterpart.
+    const copyResult = await knowledgeToLearningsRun(dir);
+    expect(copyResult.rowsMigrated).toBe(8);
+    markMigrationDone(dir, knowledgeToLearningsName);
+
+    const purge = await importPurge();
+    const result = await purge.run(dir);
+    expect(result.purged).toBe(8);
+    expect(result.skipped).toBe(0);
+
+    const counts = rowsByNamespaceStatus(dir);
+    expect(counts['knowledge/active'] ?? 0).toBe(0);
+    expect(counts['knowledge/archived'] ?? 0).toBe(0);
+    expect(counts['learnings/active']).toBe(5);
+    expect(counts['learnings/archived']).toBe(3);
+  });
+
+  it('skips orphan knowledge rows (no migratedFrom:knowledge counterpart)', async () => {
+    const dir = await makeProject([
+      // Will be purged — has counterpart
+      { id: 'k1', key: 'has-counterpart', namespace: 'knowledge', content: 'x', status: 'active' },
+      // Truly orphan — has a learnings row but missing the tag
+      { id: 'k2', key: 'untagged-counterpart', namespace: 'knowledge', content: 'y', status: 'active' },
+      { id: 'l2', key: 'untagged-counterpart', namespace: 'learnings', content: 'y', status: 'active', tags: ['random'] },
+      // Truly orphan — no learnings row at all
+      { id: 'k3', key: 'no-counterpart', namespace: 'knowledge', content: 'z', status: 'active' },
+    ]);
+
+    // Stamp the gate manifest, then add a synthetic counterpart for k1 only.
+    const db = readDb(dir);
+    db.run(
+      `INSERT INTO memory_entries (id, key, namespace, content, status, tags)
+       VALUES ('l1', 'has-counterpart', 'learnings', 'x', 'active', ?)`,
+      [JSON.stringify([MIGRATED_FROM_KNOWLEDGE, 'source:user', 'locked'])],
+    );
+    writeFileSync(join(dir, '.moflo', 'moflo.db'), Buffer.from(db.export()));
+    db.close();
+    markMigrationDone(dir, knowledgeToLearningsName);
+
+    // Capture stderr so we can verify the orphan-skip warning fires.
+    const stderrChunks: string[] = [];
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderrChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString());
+      return true;
+    });
+
+    let result;
+    try {
+      const purge = await importPurge();
+      result = await purge.run(dir);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+
+    expect(result.purged).toBe(1);
+    expect(result.skipped).toBe(2);
+
+    const counts = rowsByNamespaceStatus(dir);
+    expect(counts['knowledge/active']).toBe(2); // two orphans survived
+
+    const warnings = stderrChunks.join('').split('\n').filter(l => l.includes('skipping orphan'));
+    expect(warnings.length).toBe(2);
+    expect(warnings.some(w => w.includes('untagged-counterpart'))).toBe(true);
+    expect(warnings.some(w => w.includes('no-counterpart'))).toBe(true);
+  });
+
+  it('is idempotent — second invocation reports zero work', async () => {
+    const dir = await makeProject([
+      { id: 'k1', key: 'a', namespace: 'knowledge', content: 'x', status: 'active' },
+      { id: 'k2', key: 'b', namespace: 'knowledge', content: 'y', status: 'archived' },
+    ]);
+    await knowledgeToLearningsRun(dir);
+    markMigrationDone(dir, knowledgeToLearningsName);
+
+    const purge = await importPurge();
+    const first = await purge.run(dir);
+    expect(first.purged).toBe(2);
+
+    const second = await purge.run(dir);
+    expect(second.purged).toBe(0);
+    expect(second.skipped).toBe(0);
+  });
+
+  it('returns purged:0 when there are no knowledge rows to begin with', async () => {
+    const dir = await makeProject([
+      { id: 'p1', key: 'unrelated', namespace: 'patterns', content: 'x', status: 'active' },
+    ]);
+    markMigrationDone(dir, knowledgeToLearningsName);
+
+    const purge = await importPurge();
+    const result = await purge.run(dir);
+    expect(result.purged).toBe(0);
+    expect(result.skipped).toBe(0);
+  });
+
+  it('handles missing DB file as a clean no-op', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'moflo-knowledge-purge-empty-'));
+    tmpDirs.push(dir);
+    await mkdir(join(dir, '.moflo'), { recursive: true });
+    markMigrationDone(dir, knowledgeToLearningsName);
+
+    const purge = await importPurge();
+    const result = await purge.run(dir);
+    expect(result).toEqual({ purged: 0, skipped: 0 });
+  });
+});

--- a/src/cli/services/spell-gate.ts
+++ b/src/cli/services/spell-gate.ts
@@ -465,7 +465,7 @@ export function processGateCommand(command: string, env: Record<string, string |
         console.log('Pre-Compact Guidance:');
         console.log('IMPORTANT: Before compacting, preserve key context:');
         console.log('   - Check CLAUDE.md for project rules and architecture');
-        console.log('   - Memory namespaces: guidance, code-map, patterns, knowledge');
+        console.log('   - Memory namespaces: guidance, code-map, patterns, learnings');
         console.log('   - Use memory search to recover context after compact');
         console.log('   - Batch all operations in single messages (GOLDEN RULE)');
         process.exit(0);


### PR DESCRIPTION
## Summary
- Adds `bin/migrations/knowledge-purge.mjs` that hard-deletes legacy `knowledge` namespace rows (active + archived) once their `migratedFrom:knowledge` counterpart is confirmed in `learnings`. Manifest-gated + `order = 10` so the chain finishes in one session-start.
- Extends `knowledge-to-learnings.mjs` to also copy archived rows with status preserved, keyed on `(key, status)`.
- Replaces the launcher's fire-and-forget migration spawn with a sync run that surfaces each completed migration through `emitMutation` — Claude's session-start additionalContext now shows "consolidated knowledge → learnings" and "removed legacy knowledge namespace rows".
- Purges every stale doc reference that still steered writes to `knowledge`: root `CLAUDE.md`, three `SKILL.md` files, and the `spell-gate.ts` log message. The deprecated-alias soft-redirect at `storeEntry` stays — covered by the existing `knowledge-alias.test.ts`.
- Adds explicit `order` field support to `bin/run-migrations.mjs` (with name as tiebreaker) — the portable way to express migration dependencies given `readdirSync`'s filesystem-dependent order.

## Changes
- `bin/migrations/knowledge-purge.mjs` (new)
- `bin/migrations/knowledge-to-learnings.mjs` — handles archived rows
- `bin/migrations/lib/markers.mjs` (new) — `MIGRATED_FROM_KNOWLEDGE` constant shared across migrations, harness, tests
- `bin/run-migrations.mjs` — `order`-aware migration sort
- `bin/session-start-launcher.mjs` — sync migration run + stdout-parser → emitMutation; stderr crumb on runner failure
- `harness/consumer-smoke/lib/populated.mjs` — new assertions for knowledge purge + counterpart survival, new launcher-announcement assertions
- `src/cli/__tests__/services/knowledge-purge-migration.test.ts` (new) — gate, happy path, orphan-skip-with-warn, idempotency, no-op
- `CLAUDE.md`, `.claude/skills/{hive-mind-advanced,memory-patterns,vector-search}/SKILL.md`, `src/cli/services/spell-gate.ts` — stale `knowledge` references replaced with `learnings`

## Perf
sql.js init moved inside `run()` in both migrations — top-level `await import('sql.js')` paid ~30ms WASM init even when the manifest fast-paths the migration. Stamped no-op now stays cheap.

## Test plan
- [x] Unit: `knowledge-purge-migration.test.ts` (6 tests, covers gate / happy / orphan / idempotency / no-op / missing-DB)
- [x] Unit: existing `knowledge-alias.test.ts`, `ephemeral-namespace-purge.test.ts`, `soft-delete-purge.test.ts` still pass
- [x] Full vitest suite: 7396 passed / 0 failed (parallel + isolation)
- [x] `npm run test:smoke:populated`: 27/27 — including new `populated:knowledge-purged`, `populated:knowledge-migrated` (23 rows: active=20, archived=3, with-embedding=23), `populated:announce-knowledge-consolidation`, `populated:announce-knowledge-purge`
- [x] `npm run lint`: clean
- [x] `npm run build`: clean

Closes #750

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)