### PR TITLE
docs(753): cut YAML-driven epic claims from README + regression gate

### DIFF
--- a/.claude/skills/fl/epic.md
+++ b/.claude/skills/fl/epic.md
@@ -25,15 +25,14 @@ Detection uses `isEpicIssue()` from `src/cli/epic/detection.ts`.
 
 Strategy is determined by (in priority order):
 1. CLI flag: `--strategy auto-merge`
-2. Feature definition: `strategy` field in YAML
-3. Config: `epic.default_strategy` in `moflo.yaml`
-4. Default: `single-branch`
+2. Config: `epic.default_strategy` in `moflo.yaml`
+3. Default: `single-branch`
 
 ## How It Works
 
 The `flo epic run` command:
 1. Fetches the epic issue and validates it
-2. Extracts and orders stories (topological sort for dependencies)
+2. Extracts stories from the issue body (checklists, numbered refs, `## Stories` / `## Tasks` sections) in document order
 3. Loads the appropriate spell YAML template
 4. Runs via the spell engine (SpellRunner)
 5. The spell template handles branch creation, story iteration, PR creation, and checklist tracking

--- a/README.md
+++ b/README.md
@@ -290,53 +290,24 @@ For simple epics with independent stories, `/flo <epic>` is all you need. For co
 
 ### Feature Orchestration (`flo epic`)
 
-`flo epic` is the robust epic runner — it adds persistent state, resume from failure, and auto-merge between stories on top of `/flo`. It accepts either a GitHub issue number or a YAML file:
+`flo epic` is the robust epic runner — it adds persistent state, resume from failure, and per-story auto-merge on top of `/flo`. It takes a GitHub epic issue number:
 
 ```bash
-# From a GitHub epic (auto-detects stories)
-flo epic run 42                        # Fetch epic #42, run all stories sequentially
-flo epic run 42 --dry-run              # Preview execution plan without running
-flo epic run 42 --no-merge             # Skip auto-merge between stories
-
-# From a YAML definition (explicit dependencies)
-flo epic run feature.yaml              # Execute stories in dependency order
-flo epic run feature.yaml --dry-run    # Show execution plan
-flo epic run feature.yaml --verbose    # Stream Claude output to terminal
-
-# State management
-flo epic status epic-42                # Check progress (which stories passed/failed)
-flo epic reset epic-42                 # Reset state for re-run
+flo epic run 42                            # Fetch epic #42, run all stories sequentially
+flo epic run 42 --dry-run                  # Preview execution plan without running
+flo epic run 42 --strategy auto-merge      # Per-story PRs with auto-merge between stories
+flo epic status 42                         # Check progress (which stories passed/failed)
+flo epic reset 42                          # Reset state for re-run
 ```
 
-When given an issue number, `flo epic` fetches the epic from GitHub, extracts child stories from checklists and numbered references, then runs each through `/flo` with state tracking. If a story fails, you can fix the issue and `flo epic run 42` again — it resumes from where it left off, skipping already-passed stories.
-
-For features with inter-story dependencies (story B requires story A to be merged first), use a YAML definition:
-
-```yaml
-feature:
-  id: my-feature
-  name: "My Feature"
-  repository: /path/to/project
-  base_branch: main
-
-  stories:
-    - id: story-1
-      name: "Entity and service"
-      issue: 101
-
-    - id: story-2
-      name: "Routes and tests"
-      issue: 102
-      depends_on: [story-1]
-```
+`flo epic` fetches the epic from GitHub, extracts child stories from checklists, numbered references, and `## Stories` / `## Tasks` sections, then runs each through `/flo` with state tracking. If a story fails, you can fix the issue and `flo epic run 42` again — it resumes from where it left off, skipping already-passed stories.
 
 | | `/flo <epic>` | `flo epic run <epic>` |
 |---|---|---|
 | **State tracking** | No | Yes (`epic-state` memory namespace) |
 | **Resume from failure** | No | Yes (skips passed stories) |
-| **Auto-merge PRs** | No | Yes (between stories) |
+| **Auto-merge PRs** | No | Yes (`--strategy auto-merge`) |
 | **Dry-run preview** | No | Yes |
-| **Dependency ordering** | No (top-to-bottom) | Yes (YAML only, topological sort) |
 
 ## Spells
 
@@ -474,7 +445,7 @@ flo epic status 42                       # Check progress
 flo epic reset 42                        # Reset state for re-run
 ```
 
-For features with inter-story dependencies, define them in a YAML file with `depends_on` fields for topological ordering. See the [Epic handling](#epic-handling) section above for detection criteria and the full comparison between `/flo <epic>` and `flo epic run`.
+See the [Epic handling](#epic-handling) section above for detection criteria and the comparison between `/flo <epic>` and `flo epic run`.
 
 ## Commands
 

--- a/tests/epic-command.test.ts
+++ b/tests/epic-command.test.ts
@@ -4,6 +4,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '..');
 
 describe('epic command structure', () => {
   let epicCommand: any;
@@ -373,5 +377,21 @@ describe('epic resume support', () => {
       }
     }
     expect(completed).toEqual(new Set([10, 11]));
+  });
+});
+
+describe('README accuracy: YAML-driven epic execution (#753)', () => {
+  // #753: runEpic rejects non-numeric input, so README must not advertise YAML-driven mode.
+
+  const README = readFileSync(resolve(REPO_ROOT, 'README.md'), 'utf-8');
+
+  it('does not advertise `flo epic run <file>.yaml`', () => {
+    expect(README).not.toMatch(/flo epic run [^\s`]+\.ya?ml/i);
+  });
+
+  it('does not claim a YAML-driven dependency-ordering capability', () => {
+    // extractStories() never populates depends_on, so the topological-sort
+    // / dependency-ordering pitch is currently false in any phrasing.
+    expect(README).not.toMatch(/YAML[^.\n]{0,40}(topological|dependency ordering)/i);
   });
 });


### PR DESCRIPTION
## Summary

`flo epic run feature.yaml` is documented in the README as a first-class feature with concrete examples and a YAML schema, but `src/cli/commands/epic.ts:55-58` rejects any non-numeric source with `Expected issue number, got: "<source>"`. Per the issue's own acceptance criteria — and given the implementation cost (spell-template forking or invasive mode-flag conditionals on `single-branch.yaml` / `auto-merge.yaml`) and the absence of documented user demand — this PR takes the cut-the-docs path.

## Changes

- **`README.md`** — remove the "From a YAML definition" example block, the `feature.yaml` schema, and the "Dependency ordering | Yes (YAML only, topological sort)" comparison row. Tighten the remaining example block to flags that actually work (`--strategy auto-merge`, `--dry-run`). Add `## Stories` / `## Tasks` to the extraction list (matches `detection.ts:81-89`).
- **`.claude/skills/fl/epic.md`** — drop the "Feature definition: strategy field in YAML" priority entry and the "topological sort for dependencies" claim. `extractStories` never populates `depends_on`, so the GH-issue path runs in document order.
- **`tests/epic-command.test.ts`** — add two regression assertions that fail if the YAML claims reappear. Use repo-convention `resolve(__dirname, '..')` for repo-root.

Type infrastructure (`FeatureDefinition`, `StoryDefinition.depends_on`, `resolveExecutionOrder`) stays in `src/cli/epic/` as scaffold for a future YAML implementation — not actively wrong, just unwired.

## Why cut, not implement

1. Spell templates `single-branch.yaml` / `auto-merge.yaml` are heavily coupled to a numeric `epic_number`: step `check-off-story` does `gh issue view $EPIC` to flip checkboxes on an epic body that doesn't exist in YAML mode, and `create-pr` body uses `Closes #{epic_number}` referencing a GH issue YAML mode doesn't have. Implementing requires fork+duplicate (DRY violation) or a mode-flag with conditional steps through both templates.
2. `depends_on` is dead code on the GH path anyway — `extractStories` (`detection.ts:57-92`) only pulls flat `#NNN` references, so `resolveExecutionOrder` always emits trivial doc-order. The "Yes (YAML only, topological sort)" cell was technically accurate but moot.
3. No documented user demand — surfaced by README audit in #751, not user pain.
4. The acceptance criteria explicitly accepts this path.

## Follow-ups

- #760 — `--no-merge` and `--verbose` flag drift on `flo epic run` (also caught while fixing this)
- #761 — implement YAML-driven epic mode if real demand surfaces

## Testing

- [x] 85/85 epic tests pass (`epic-command.test.ts`, `epic-detection.test.ts`, `epic-spells.test.ts`)
- [x] 2 new regression tests covering the deleted README phrasings (would fail if reverted)
- [x] Manual eyeball: README renders cleanly, no orphaned cross-refs to YAML examples

Closes #753