### PR TITLE
fix(756): static import for cron-parser + strict validation always-on

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -431,6 +431,53 @@ export function memoryCrud(consumerDir) {
   recordExit('memory-delete', flo(consumerDir, ['memory', 'delete', '-k', key, '--namespace', 'smoke']));
 }
 
+/**
+ * Issue #756: `flo spell schedule create --cron <invalid>` must fail strict
+ * validation in a consumer install. Regression catches the
+ * fixed-depth-`../../../../spells/dist/...` import that silently fell back to
+ * a permissive regex when the path resolved to nothing in node_modules layouts.
+ *
+ * "Strict" here means the cron-parser is actually loaded and rejects garbage
+ * — not just that the timing-options arity check trips first. We assert
+ * non-zero exit AND a clear error message, but we DO NOT assert "Invalid
+ * schedule" verbatim because output formatting is allowed to evolve.
+ */
+export function spellScheduleStrictCron(consumerDir) {
+  section('Spell schedule strict cron validation (issue #756)');
+
+  const r = flo(
+    consumerDir,
+    ['spell', 'schedule', 'create', '-n', 'smoke-756', '--cron', 'a b c d e'],
+    { timeout: 60_000 },
+  );
+
+  if (r.code === 0) {
+    record(
+      'spell-schedule-strict-cron',
+      'fail',
+      `garbage cron 'a b c d e' was accepted (exit 0) — strict validator is not loading; ` +
+        `stdout: ${r.stdout.trim().slice(0, 200)}`,
+    );
+    return;
+  }
+
+  // Confirm the rejection mentions the cron field, not e.g. a missing-name
+  // error or some unrelated crash. Both stdout and stderr are scanned because
+  // `output.printError` writes to either depending on TTY detection.
+  const combined = `${r.stdout}\n${r.stderr}`;
+  if (!/cron|Invalid schedule/i.test(combined)) {
+    record(
+      'spell-schedule-strict-cron',
+      'fail',
+      `non-zero exit ${r.code} but no cron-rejection message; ` +
+        `output: ${combined.trim().slice(0, 200)}`,
+    );
+    return;
+  }
+
+  record('spell-schedule-strict-cron', 'pass', `rejected with exit ${r.code}`);
+}
+
 export function spellList(consumerDir) {
   section('Spell engine');
   // Issue #755: shipped grimoire must contain the epic spells out of the box.

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -78,6 +78,7 @@ function main() {
       () => check.memoryInit(consumerDir),
       () => check.memoryCrud(consumerDir),
       () => check.spellList(consumerDir),
+      () => check.spellScheduleStrictCron(consumerDir),
       () => check.mcpTools(consumerDir),
       () => check.moflodbBridge(consumerDir),
       () => check.floSearch(consumerDir),

--- a/src/cli/__tests__/commands/spell-schedule.test.ts
+++ b/src/cli/__tests__/commands/spell-schedule.test.ts
@@ -161,6 +161,19 @@ describe('spell schedule command', () => {
       expect(result.success).toBe(false);
     });
 
+    // Issue #756: if this fails, the fixed-depth-import regression is back —
+    // the strict cron-parser is no longer loading and validation has fallen
+    // through to the old permissive shape-only check.
+    it('should reject 5-field garbage cron via strict parser', async () => {
+      const result = await createCmd().action!(makeCtx({
+        flags: { _: [], name: 'audit', cron: 'a b c d e' },
+      })) as CommandResult;
+
+      expect(result.success).toBe(false);
+      // mcp_memory_store must NOT have been called for an invalid cron.
+      expect(mockCallMCP).not.toHaveBeenCalled();
+    });
+
     it('should reject invalid interval format', async () => {
       const result = await createCmd().action!(makeCtx({
         flags: { _: [], name: 'audit', interval: 'bad' },

--- a/src/cli/commands/spell-schedule.ts
+++ b/src/cli/commands/spell-schedule.ts
@@ -17,25 +17,9 @@ import { callMCPTool } from '../mcp-client.js';
 import { TOOL_MEMORY_STORE, TOOL_MEMORY_LIST, TOOL_MEMORY_RETRIEVE } from '../mcp-tools/tool-names.js';
 import { handleMCPError } from '../services/cli-formatters.js';
 import { ensureDaemonForScheduling } from '../services/daemon-readiness.js';
+import { validateSchedule, computeNextRun } from '../spells/scheduler/cron-parser.js';
 
 const NAMESPACE_SCHEDULES = 'scheduled-spells';
-
-// Cached scheduler utils — resolved once on first call
-let _schedulerUtils: Record<string, Function> | null | undefined;
-
-async function getSchedulerUtils() {
-  if (_schedulerUtils !== undefined) return _schedulerUtils;
-  try {
-    const { dirname, join } = await import('path');
-    const { fileURLToPath, pathToFileURL } = await import('url');
-    const here = dirname(fileURLToPath(import.meta.url));
-    const cronParserPath = join(here, '..', '..', '..', '..', 'spells', 'dist', 'scheduler', 'cron-parser.js');
-    _schedulerUtils = await import(pathToFileURL(cronParserPath).href);
-  } catch {
-    _schedulerUtils = null;
-  }
-  return _schedulerUtils;
-}
 
 // ── Schedule Create ───────────────────────────────────────────────────────────
 
@@ -74,47 +58,18 @@ const createCommand: Command = {
       return { success: false, exitCode: 1 };
     }
 
-    const utils = await getSchedulerUtils();
     const now = Date.now();
-    let nextRunAt: number;
-
-    if (utils) {
-      const validation = utils.validateSchedule({ cron, interval, at });
-      if (!validation.valid) {
-        output.printError(`Invalid schedule: ${validation.errors.map((e: { message: string }) => e.message).join(', ')}`);
-        return { success: false, exitCode: 1 };
-      }
-      const computed = utils.computeNextRun({ cron, interval, at }, now);
-      if (computed === null) {
-        output.printError('Could not compute next run time from the provided schedule');
-        return { success: false, exitCode: 1 };
-      }
-      nextRunAt = computed;
-    } else {
-      // Fallback: basic validation if spells package unavailable
-      if (cron && !/^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/.test(cron.trim())) {
-        output.printError('Invalid cron expression: must be 5 fields (minute hour day month weekday)');
-        return { success: false, exitCode: 1 };
-      }
-      if (interval && !/^\d+[smhd]$/.test(interval.trim())) {
-        output.printError('Invalid interval: use format like "30m", "6h", "1d", "90s"');
-        return { success: false, exitCode: 1 };
-      }
-      if (at && isNaN(Date.parse(at))) {
-        output.printError('Invalid datetime: use ISO 8601 format (e.g., 2026-04-01T09:00:00Z)');
-        return { success: false, exitCode: 1 };
-      }
-      // Approximate next run for fallback path
-      if (interval) {
-        const match = interval.trim().match(/^(\d+)([smhd])$/)!;
-        const mult: Record<string, number> = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 };
-        nextRunAt = now + (Number(match[1]) * mult[match[2]]);
-      } else if (at) {
-        nextRunAt = Date.parse(at);
-      } else {
-        nextRunAt = now + 60_000;
-      }
+    const validation = validateSchedule({ cron, interval, at }, 'schedule');
+    if (validation.length > 0) {
+      output.printError(`Invalid schedule: ${validation.map(e => e.message).join(', ')}`);
+      return { success: false, exitCode: 1 };
     }
+    const computed = computeNextRun({ cron, interval, at }, now);
+    if (computed === null) {
+      output.printError('Could not compute next run time from the provided schedule');
+      return { success: false, exitCode: 1 };
+    }
+    const nextRunAt = computed;
 
     // Daemon readiness check (lazy — only on schedule creation)
     const projectRoot = ctx.cwd || process.cwd();


### PR DESCRIPTION
## Summary

- `spell-schedule.ts:32` had a fixed-depth `'..','..','..','..','spells','dist','scheduler','cron-parser.js'` dynamic import — a pre-#586-workspace-collapse layout that resolved to nothing in source, dist, or consumer node_modules. The silent catch dropped strict validation onto a permissive `\S+ \S+ \S+ \S+ \S+` regex, so 5-field garbage was accepted.
- After #586 collapsed `@moflo/spells` into `src/cli/spells/`, the cron-parser is a sibling subdir — replaced the dynamic load with a plain static ESM import `from '../spells/scheduler/cron-parser.js'`. Removed the entire fallback block (and the broken `validation.valid`/`.errors` access; `validateSchedule` returns `ValidationError[]`).
- Bonus: the in-tree `getSchedulerUtils` cache + `try/catch dynamic import` async hop on the schedule hot path is gone.

## Changes

- `src/cli/commands/spell-schedule.ts` — static `import { validateSchedule, computeNextRun }`, drop `getSchedulerUtils` and the permissive fallback.
- `src/cli/__tests__/commands/spell-schedule.test.ts` — new test asserts 5-field garbage `'a b c d e'` is rejected and `mcp_memory_store` is not called.
- `harness/consumer-smoke/lib/checks.mjs` + `run.mjs` — new `spellScheduleStrictCron` check runs `flo spell schedule create -n smoke-756 --cron 'a b c d e'` against the installed moflo and asserts non-zero exit + cron-rejection message in output.

## Acceptance Criteria

- [x] `spell-schedule.ts` imports the cron-parser via a stable in-tree path (`../spells/scheduler/cron-parser.js`) — no fixed-depth/anchor dance needed inside the package
- [x] Strict cron validation runs in consumer installs (not just the dev tree)
- [x] Consumer-smoke harness covers `flo spell schedule create --cron <expr>` rejecting an invalid expression

## Test Plan

- [x] Unit: `npx vitest run src/cli/__tests__/commands/spell-schedule.test.ts` — 17 passed (incl. new strict-parser test)
- [x] Unit: `npx vitest run src/cli/__tests__/spells/scheduler.test.ts` — 83 passed
- [x] Lint: `npm run lint` clean (path-safety ESLint guard happy with the relative import)
- [x] Build: `npm run build` clean (tsc resolved the new import)
- [x] Full suite: `npm test` — 7404 passed, 0 failed
- [ ] Consumer-smoke runs in CI on this PR (covers ubuntu/macos/windows)

Closes #756

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)