### PR TITLE
fix(757): drop dead status_line.show_agentdb config key

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -51,7 +51,6 @@ function loadStatusLineConfig() {
     show_mcp: true,
     show_security: true,
     show_adrs: true,
-    show_agentdb: true,
     show_tests: true,
     mode: 'compact',
   };
@@ -785,28 +784,18 @@ function generateDashboard() {
     );
   }
 
-  // AgentDB + MCP line (if either enabled)
-  if (SL_CONFIG.show_agentdb || SL_CONFIG.show_mcp) {
+  // MCP line
+  if (SL_CONFIG.show_mcp) {
     const parts = [];
-    if (SL_CONFIG.show_agentdb) {
-      const agentdb = getAgentDBStats();
-      const hnswInd = agentdb.hasHnsw ? `${c.brightGreen}\u26A1${c.reset}` : '';
-      const sizeDisp = agentdb.dbSizeKB >= 1024 ? `${(agentdb.dbSizeKB / 1024).toFixed(1)}MB` : `${agentdb.dbSizeKB}KB`;
-      const vectorColor = agentdb.vectorCount > 0 ? c.brightGreen : c.dim;
-      parts.push(`${c.cyan}Vectors${c.reset} ${vectorColor}\u25CF${agentdb.vectorCount}${hnswInd}${c.reset}`);
-      parts.push(`${c.cyan}Size${c.reset} ${c.brightWhite}${sizeDisp}${c.reset}`);
+    const integration = getIntegrationStatus();
+    if (integration.mcpServers.total > 0) {
+      const mcpCol = integration.mcpServers.enabled === integration.mcpServers.total ? c.brightGreen :
+                     integration.mcpServers.enabled > 0 ? c.brightYellow : c.red;
+      parts.push(`${c.cyan}MCP${c.reset} ${mcpCol}\u25CF${integration.mcpServers.enabled}/${integration.mcpServers.total}${c.reset}`);
     }
-    if (SL_CONFIG.show_mcp) {
-      const integration = getIntegrationStatus();
-      if (integration.mcpServers.total > 0) {
-        const mcpCol = integration.mcpServers.enabled === integration.mcpServers.total ? c.brightGreen :
-                       integration.mcpServers.enabled > 0 ? c.brightYellow : c.red;
-        parts.push(`${c.cyan}MCP${c.reset} ${mcpCol}\u25CF${integration.mcpServers.enabled}/${integration.mcpServers.total}${c.reset}`);
-      }
-      if (integration.hasDatabase) parts.push(`${c.brightGreen}\u25C6${c.reset}DB`);
-    }
+    if (integration.hasDatabase) parts.push(`${c.brightGreen}\u25C6${c.reset}DB`);
     if (parts.length > 0) {
-      lines.push(`${c.brightCyan}\uD83D\uDCCA AgentDB${c.reset}    ${parts.join(`  ${c.dim}\u2502${c.reset}  `)}`);
+      lines.push(`${c.brightCyan}\uD83D\uDCCA MCP${c.reset}  ${parts.join(`  ${c.dim}\u2502${c.reset}  `)}`);
     }
   }
 
@@ -846,7 +835,7 @@ function generateCompactDashboard() {
   pushUpgradeNoticeSegment(lines);
   lines.push(header);
 
-  // Combined swarm + agentdb + mcp line
+  // Combined swarm + mcp line
   const segments = [];
   if (SL_CONFIG.show_swarm) {
     const swarm = getSwarmStatus();
@@ -854,15 +843,6 @@ function generateCompactDashboard() {
     const agentsColor = swarm.activeAgents > 0 ? c.brightGreen : c.red;
     segments.push(
       `${c.brightYellow}\uD83E\uDD16${c.reset} ${swarmInd}[${agentsColor}${swarm.activeAgents}${c.reset}/${c.brightWhite}${swarm.maxAgents}${c.reset}]`
-    );
-  }
-  if (SL_CONFIG.show_agentdb) {
-    const agentdb = getAgentDBStats();
-    const hnswInd = agentdb.hasHnsw ? `\u26A1` : '';
-    const sizeDisp = agentdb.dbSizeKB >= 1024 ? `${(agentdb.dbSizeKB / 1024).toFixed(1)}MB` : `${agentdb.dbSizeKB}KB`;
-    const vectorColor = agentdb.vectorCount > 0 ? c.brightGreen : c.dim;
-    segments.push(
-      `${c.brightCyan}\uD83D\uDCCA${c.reset} ${vectorColor}${agentdb.vectorCount}${hnswInd}${c.reset} ${c.dim}(${sizeDisp})${c.reset}`
     );
   }
   if (SL_CONFIG.show_mcp) {

--- a/moflo.yaml
+++ b/moflo.yaml
@@ -75,7 +75,6 @@ status_line:
   show_git: true
   show_session: true
   show_swarm: true
-  show_agentdb: true
   show_mcp: true
 
 # Model preferences (haiku, sonnet, opus)

--- a/src/cli/__tests__/moflo-config-status-line.test.ts
+++ b/src/cli/__tests__/moflo-config-status-line.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression test for issue #757 — `status_line.show_agentdb` was dead config
+ * after agentdb was removed in 4.8.80. This guards against re-adding it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadMofloConfig, type MofloConfig } from '../config/moflo-config.js';
+
+// Compile-time guard: the type itself must not expose show_agentdb.
+type _NoShowAgentdb = 'show_agentdb' extends keyof MofloConfig['status_line']
+  ? never
+  : true;
+const _typeGuard: _NoShowAgentdb = true;
+void _typeGuard;
+
+describe('moflo-config: status_line.show_agentdb is dropped (#757)', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'moflo-config-statusline-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('default config has no show_agentdb key', () => {
+    const config = loadMofloConfig(root);
+    expect(config.status_line).not.toHaveProperty('show_agentdb');
+  });
+
+  it('ignores show_agentdb when present in moflo.yaml', async () => {
+    await writeFile(
+      join(root, 'moflo.yaml'),
+      'status_line:\n  show_agentdb: true\n  show_swarm: false\n',
+    );
+    const config = loadMofloConfig(root);
+    expect(config.status_line).not.toHaveProperty('show_agentdb');
+    expect(config.status_line.show_swarm).toBe(false);
+  });
+});

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -122,7 +122,6 @@ export interface MofloConfig {
     show_mcp: boolean;
     show_security: boolean;
     show_adrs: boolean;
-    show_agentdb: boolean;
     show_tests: boolean;
     mode: 'single-line' | 'dashboard';
   };
@@ -221,7 +220,6 @@ const DEFAULT_CONFIG: MofloConfig = {
     show_mcp: true,
     show_security: true,
     show_adrs: true,
-    show_agentdb: true,
     show_tests: true,
     mode: 'single-line',
   },
@@ -370,7 +368,6 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
       show_mcp: raw.status_line?.show_mcp ?? raw.statusLine?.showMcp ?? DEFAULT_CONFIG.status_line.show_mcp,
       show_security: raw.status_line?.show_security ?? raw.statusLine?.showSecurity ?? DEFAULT_CONFIG.status_line.show_security,
       show_adrs: raw.status_line?.show_adrs ?? raw.statusLine?.showAdrs ?? DEFAULT_CONFIG.status_line.show_adrs,
-      show_agentdb: raw.status_line?.show_agentdb ?? raw.statusLine?.showAgentdb ?? DEFAULT_CONFIG.status_line.show_agentdb,
       show_tests: raw.status_line?.show_tests ?? raw.statusLine?.showTests ?? DEFAULT_CONFIG.status_line.show_tests,
       mode: raw.status_line?.mode ?? raw.statusLine?.mode ?? DEFAULT_CONFIG.status_line.mode,
     },
@@ -569,7 +566,6 @@ status_line:
   show_mcp: true                  # MCP server count
   show_security: true             # CVE/security status (dashboard only)
   show_adrs: true                 # ADR compliance (dashboard only)
-  show_agentdb: true              # AgentDB vectors/size (dashboard only)
   show_tests: true                # Test file count (dashboard only)
   mode: single-line              # single-line (default) or dashboard (multi-line)
 `;

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -419,7 +419,6 @@ status_line:
   show_git: true
   show_session: true
   show_swarm: true
-  show_agentdb: true
   show_mcp: true
 
 # Model preferences (haiku, sonnet, opus)


### PR DESCRIPTION
## Summary

- Remove dead `status_line.show_agentdb` config key — agentdb was fully removed in moflo 4.8.80 (`project_agentdb_removal.md`), so flipping the key has had no effect since.
- Eight surfaces purged: `MofloConfig` type, `DEFAULT_CONFIG`, `mergeConfig` parser, generated yaml example inside `moflo-config.ts`, `init/moflo-init.ts` yaml template, root `moflo.yaml`, and the `.claude/helpers/statusline.cjs` default + 3 renderer branches that read it.
- Re-label the dashboard "📊 AgentDB" header to "📊 MCP" (the line now only renders MCP info) and tighten its column padding to match `🤖 Swarm`.

## Changes

- `src/cli/config/moflo-config.ts` — drop key from interface, DEFAULT_CONFIG, mergeConfig parser, and the example yaml emitted by `generateMofloConfig`.
- `src/cli/init/moflo-init.ts` + root `moflo.yaml` — drop the line from the user-facing yaml templates.
- `.claude/helpers/statusline.cjs` — drop default + 3 renderer branches; rename "AgentDB" header to "MCP"; collapse the now-redundant inner `if (show_mcp)` guard.
- `src/cli/__tests__/moflo-config-status-line.test.ts` — new regression test: compile-time conditional-type guard + runtime assertions that `loadMofloConfig` ignores the key when present in user yaml.

## Out of scope (follow-up worth filing)

- `getAgentDBStats()` in `statusline.cjs` is still alive — it reads `.moflo/vector-stats.json` (moflo's own vector store) and powers `intelligencePct` + the JSON `agentdb` field. Legacy name is misleading but renaming the JSON field would be a schema break for `--json` consumers; leave for a deprecation cycle.

## Testing

- [x] `npm run build` — clean
- [x] `npm test` — 7406 passed, 11 skipped, 0 failed
- [x] New regression test (2 cases, both pass)
- [x] Smoke: `node .claude/helpers/statusline.cjs` in `--json`, `--compact`, `--dashboard` modes — all render cleanly with the key absent

Closes #757

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)