### PR TITLE
fix(763): surface loop-iteration step output under flo epic --verbose

### DIFF
--- a/src/cli/__tests__/spells/runner.test.ts
+++ b/src/cli/__tests__/spells/runner.test.ts
@@ -1176,6 +1176,44 @@ describe('SpellCaster — loop iteration', () => {
     // Duration must include iteration time (~100ms for 2 items x 50ms each)
     expect(loopStep.duration).toBeGreaterThanOrEqual(DELAY_MS * 2 * 0.8);
   });
+
+  // iterationOutputs must reach onStepComplete observers via result.output.data,
+  // not only via the variables map — observers don't have access to the latter.
+  it('should expose iterationOutputs on the loop step result.output.data via onStepComplete', async () => {
+    registry.register(createLoopCommand(['a', 'b']));
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (_config, ctx) => ({
+        success: true,
+        data: { stdout: `out-${ctx.variables['item']}`, stderr: '' },
+        duration: 1,
+      }),
+    }));
+
+    const definition = simpleSpell([
+      {
+        id: 'loop1', type: 'loop', config: {}, output: 'loop1',
+        steps: [{ id: 'nested', type: 'nested', config: {} }],
+      },
+    ]);
+
+    const observed: Array<Record<string, unknown> | undefined> = [];
+    await runner.run(definition, {}, {
+      onStepComplete: (sr) => {
+        if (sr.stepId === 'loop1') {
+          observed.push(sr.output?.data as Record<string, unknown> | undefined);
+        }
+      },
+    });
+
+    expect(observed).toHaveLength(1);
+    const data = observed[0]!;
+    const iterOutputs = data.iterationOutputs as Array<Record<string, unknown>>;
+    expect(iterOutputs).toBeDefined();
+    expect(iterOutputs).toHaveLength(2);
+    expect((iterOutputs[0].nested as Record<string, unknown>).stdout).toBe('out-a');
+    expect((iterOutputs[1].nested as Record<string, unknown>).stdout).toBe('out-b');
+  });
 });
 
 // ============================================================================
@@ -1221,5 +1259,43 @@ describe('SpellCaster — parallel step duration', () => {
     const parStep = result.steps.find(s => s.stepId === 'par1')!;
     // Parallel steps run concurrently, so duration >= one delay, not zero
     expect(parStep.duration).toBeGreaterThanOrEqual(DELAY_MS * 0.8);
+  });
+
+  // Same invariant as the loop test above — onStepComplete must see stepOutputs.
+  it('should expose stepOutputs on the parallel step result.output.data via onStepComplete', async () => {
+    registry.register(createParallelCommand());
+    registry.register(createMockCommand({
+      type: 'nested',
+      execute: async (config) => ({
+        success: true,
+        data: { stdout: `out-${(config as { tag?: string }).tag ?? '?'}`, stderr: '' },
+        duration: 1,
+      }),
+    }));
+
+    const definition = simpleSpell([
+      {
+        id: 'par1', type: 'parallel', config: {}, output: 'par1',
+        steps: [
+          { id: 'a', type: 'nested', config: { tag: 'a' } },
+          { id: 'b', type: 'nested', config: { tag: 'b' } },
+        ],
+      },
+    ]);
+
+    const observed: Array<Record<string, unknown> | undefined> = [];
+    await runner.run(definition, {}, {
+      onStepComplete: (sr) => {
+        if (sr.stepId === 'par1') {
+          observed.push(sr.output?.data as Record<string, unknown> | undefined);
+        }
+      },
+    });
+
+    expect(observed).toHaveLength(1);
+    const stepOutputs = observed[0]!.stepOutputs as Record<string, Record<string, unknown>>;
+    expect(stepOutputs).toBeDefined();
+    expect(stepOutputs.a.stdout).toBe('out-a');
+    expect(stepOutputs.b.stdout).toBe('out-b');
   });
 });

--- a/src/cli/commands/epic.ts
+++ b/src/cli/commands/epic.ts
@@ -238,17 +238,7 @@ async function runEpic(
         // --verbose: echo captured bash stdout/stderr after the step completes.
         // (Not real-time streaming — the spell engine captures stdio.)
         if (verbose) {
-          const data = stepResult.output?.data as { stdout?: string; stderr?: string } | undefined;
-          if (data?.stdout) {
-            for (const line of data.stdout.split(/\r?\n/)) {
-              if (line) console.log(`[epic]   │ ${line}`);
-            }
-          }
-          if (data?.stderr) {
-            for (const line of data.stderr.split(/\r?\n/)) {
-              if (line) console.log(`[epic]   │ (stderr) ${line}`);
-            }
-          }
+          echoStepOutput(stepResult.output?.data as Record<string, unknown> | undefined, '');
         }
       },
       onPreflightWarnings: isInteractive() ? resolvePreflightWarningsInteractively : undefined,
@@ -315,6 +305,51 @@ async function runEpic(
       console.error(error.stack);
     }
     return { success: false, message: buildFailureSummary(error.message) };
+  }
+}
+
+// ============================================================================
+// --verbose output echo
+// ============================================================================
+
+function echoStream(stream: string, indent: string, kind: 'stdout' | 'stderr'): void {
+  for (const line of stream.split(/\r?\n/)) {
+    if (line) {
+      const prefix = kind === 'stderr' ? '(stderr) ' : '';
+      console.log(`[epic] ${indent}│ ${prefix}${line}`);
+    }
+  }
+}
+
+function echoStepOutput(data: Record<string, unknown> | undefined, indent: string): void {
+  if (!data) return;
+
+  const stdout = typeof data.stdout === 'string' ? data.stdout : undefined;
+  const stderr = typeof data.stderr === 'string' ? data.stderr : undefined;
+  if (stdout) echoStream(stdout, indent, 'stdout');
+  if (stderr) echoStream(stderr, indent, 'stderr');
+
+  // Loop step: walk each iteration's nested-step outputs.
+  const iterationOutputs = data.iterationOutputs;
+  if (Array.isArray(iterationOutputs)) {
+    for (let i = 0; i < iterationOutputs.length; i++) {
+      const iter = iterationOutputs[i];
+      if (!iter || typeof iter !== 'object') continue;
+      console.log(`[epic] ${indent}├─ iteration ${i + 1}/${iterationOutputs.length}`);
+      for (const [stepId, stepData] of Object.entries(iter as Record<string, unknown>)) {
+        console.log(`[epic] ${indent}│  ├─ ${stepId}`);
+        echoStepOutput(stepData as Record<string, unknown> | undefined, indent + '│  │  ');
+      }
+    }
+  }
+
+  // Parallel step: walk each branch's output.
+  const stepOutputs = data.stepOutputs;
+  if (stepOutputs && typeof stepOutputs === 'object' && !Array.isArray(stepOutputs)) {
+    for (const [stepId, stepData] of Object.entries(stepOutputs as Record<string, unknown>)) {
+      console.log(`[epic] ${indent}├─ ${stepId}`);
+      echoStepOutput(stepData as Record<string, unknown> | undefined, indent + '│  ');
+    }
   }
 }
 

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -314,9 +314,17 @@ export class SpellCaster {
             step, result.output, state.variables, errors, state.options.signal,
             (nested, s) => this.runStep(nested, state, s),
           );
-          result = { ...result, duration: result.duration + (Date.now() - loopStart) };
+          // onStepComplete observers see only result.output.data — they cannot
+          // reach the variables map, so iterationOutputs must be embedded here
+          // or per-iteration output is invisible to verbose handlers.
+          const stepOut = result.output as StepOutput;
+          const loopData = { ...stepOut.data, iterationOutputs: loopResult.outputs };
+          result = {
+            ...result,
+            duration: result.duration + (Date.now() - loopStart),
+            output: { ...stepOut, data: loopData },
+          };
           stepResults[resultIdx] = result;
-          const loopData = { ...(result.output as StepOutput).data, iterationOutputs: loopResult.outputs };
           if (step.output) variables[step.output] = loopData;
           variables[step.id] = loopData;
 
@@ -333,9 +341,15 @@ export class SpellCaster {
             step, result.output as StepOutput, state.variables, errors, state.options.signal,
             (nested, s) => this.runStep(nested, state, s),
           );
-          result = { ...result, duration: result.duration + (Date.now() - parallelStart) };
+          // Same invariant as the loop branch above.
+          const stepOut = result.output as StepOutput;
+          const parallelData = { ...stepOut.data, stepOutputs: parallelResult.outputs };
+          result = {
+            ...result,
+            duration: result.duration + (Date.now() - parallelStart),
+            output: { ...stepOut, data: parallelData },
+          };
           stepResults[resultIdx] = result;
-          const parallelData = { ...(result.output as StepOutput).data, stepOutputs: parallelResult.outputs };
           if (step.output) variables[step.output] = parallelData;
           variables[step.id] = parallelData;
 


### PR DESCRIPTION
## Summary

- `src/cli/spells/core/runner.ts` — embed `iterationOutputs` (loop) and `stepOutputs` (parallel) onto `result.output.data` so `onStepComplete` observers see iteration data without needing access to the variables map
- `src/cli/commands/epic.ts` — extracted recursive `echoStepOutput` helper that walks `iterationOutputs` / `stepOutputs` and prints each nested bash step's stdout/stderr indented under the parent (`├─ iteration 1/N`, `│  ├─ implement-story`, then captured streams)
- Two regression tests in `src/cli/__tests__/spells/runner.test.ts` asserting the loop and parallel parent step's `result.output.data` carries iteration outputs through `onStepComplete`

## Why

#754 shipped `flo epic run --verbose` for top-level steps, but the actual `claude -p ...` invocation lives inside the `process-stories` loop in both epic spell templates. Per-story output was invisible — the verbose flag was effectively useless for the most interesting work.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 7420/7420 passing
- [x] Targeted: runner.test.ts under isolation config — 48/48 (including 2 new regressions)
- [x] Targeted: loop-executor + parallel-executor + epic-command + epic-detection — 62/62

Closes #763

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)