### PR TITLE
fix(768): scope short-flag aliases to deeply-nested + lazy-loaded commands

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -445,11 +445,9 @@ export function memoryCrud(consumerDir) {
 export function spellScheduleStrictCron(consumerDir) {
   section('Spell schedule strict cron validation (issue #756)');
 
-  // Use --name long form: deeply-nested subcommands' short flags don't
-  // scope correctly under lazy-loaded commands (see follow-up issue).
   const r = flo(
     consumerDir,
-    ['spell', 'schedule', 'create', '--name', 'smoke-756', '--cron', 'a b c d e'],
+    ['spell', 'schedule', 'create', '-n', 'smoke-756', '--cron', 'a b c d e'],
     { timeout: 60_000 },
   );
 

--- a/src/cli/__tests__/parser.test.ts
+++ b/src/cli/__tests__/parser.test.ts
@@ -255,6 +255,32 @@ describe('CommandParser', () => {
       const result = parser.parse(['task', 'run', '-t', '5000']);
       expect(result.flags.timeout).toBe(5000);
     });
+
+    // 3-level subcommand short flags must be in scope: `spell schedule create -n foo`
+    // would otherwise alias `-n` to whichever globally-registered command claimed it.
+    // The sibling `guidance` command intentionally claims -n for --max-shards to
+    // exercise the real collision the original bug surfaced.
+    it('should resolve short flags from a 3-level nested subcommand', () => {
+      const leaf: Command = {
+        name: 'create',
+        description: 'Create',
+        options: [{ name: 'name', short: 'n', type: 'string', description: 'Name' }],
+      };
+      const mid: Command = { name: 'schedule', description: 'Schedule', subcommands: [leaf] };
+      const top: Command = { name: 'spell', description: 'Spell', subcommands: [mid] };
+      const sibling: Command = {
+        name: 'guidance',
+        description: 'Guidance',
+        options: [{ name: 'max-shards', short: 'n', type: 'number', description: 'Shards' }],
+      };
+      parser.registerCommand(top);
+      parser.registerCommand(sibling);
+
+      const result = parser.parse(['spell', 'schedule', 'create', '-n', 'audit']);
+      expect(result.flags.name).toBe('audit');
+      expect(result.flags.maxShards).toBeUndefined();
+      expect(result.command).toEqual(['spell', 'schedule', 'create']);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -80,8 +80,8 @@ export class CLI {
   async run(args: string[] = process.argv.slice(2)): Promise<void> {
     try {
       // Parse arguments
-      const parseResult = this.parser.parse(args);
-      const { command: commandPath, flags, positional } = parseResult;
+      let parseResult = this.parser.parse(args);
+      let { command: commandPath, flags, positional } = parseResult;
 
       // Handle global flags
       if (flags.version || flags.V) {
@@ -158,6 +158,17 @@ export class CLI {
       // If not found in sync registry, try lazy loading
       if (!command && hasCommand(commandName)) {
         command = await getCommandAsync(commandName);
+        if (command) {
+          // The first parse happened without knowledge of this command's
+          // subcommand tree, so scoped short-flag aliases for any nested
+          // subcommand options weren't applied — and a globally-registered
+          // command's `-x` would have hijacked the value. Register the
+          // newly-loaded command and re-parse so flags reflect the leaf
+          // command's options.
+          this.parser.registerCommand(command);
+          parseResult = this.parser.parse(args);
+          ({ command: commandPath, flags, positional } = parseResult);
+        }
       }
 
       if (!command) {

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -128,22 +128,24 @@ export class CommandParser {
       raw: [...args]
     };
 
-    // Pass 1: Identify command and subcommand (skip flags)
-    let resolvedCmd: Command | undefined;
-    let resolvedSub: Command | undefined;
+    // Pass 1: Walk positional args to resolve the command chain to its deepest
+    // matching node. The scoped-alias map needs to know the leaf command —
+    // otherwise short flags from arbitrarily deep subcommands collide with
+    // identically-named flags on shallower commands (e.g. spell→schedule→create
+    // -n vs guidance -n).
+    const chain: Command[] = [];
     for (const arg of args) {
       if (arg.startsWith('-')) continue;
-      if (!resolvedCmd && this.commands.has(arg)) {
-        resolvedCmd = this.commands.get(arg);
-      } else if (resolvedCmd && !resolvedSub && resolvedCmd.subcommands) {
-        resolvedSub = resolvedCmd.subcommands.find(sc => sc.name === arg || sc.aliases?.includes(arg));
-      }
+      const next = chain.length === 0
+        ? this.commands.get(arg)
+        : this.findSubcommand(chain[chain.length - 1], arg);
+      if (!next) break;
+      chain.push(next);
     }
 
-    // Pass 2: Build aliases scoped to the resolved subcommand
-    // Subcommand-specific aliases take priority over global ones
-    const aliases = this.buildScopedAliases(resolvedSub || resolvedCmd);
-    const booleanFlags = this.getScopedBooleanFlags(resolvedSub || resolvedCmd);
+    const deepestCmd = chain[chain.length - 1];
+    const aliases = this.buildScopedAliases(deepestCmd);
+    const booleanFlags = this.getScopedBooleanFlags(deepestCmd);
 
     let i = 0;
     let parsingFlags = true;
@@ -170,38 +172,16 @@ export class CommandParser {
 
       // Handle positional arguments
       if (result.command.length === 0 && this.commands.has(arg)) {
-        // This is a command
+        // This is a command — walk its subcommand chain greedily.
         result.command.push(arg);
-
-        // Check for subcommand (level 1)
-        const cmd = this.commands.get(arg);
-        if (cmd?.subcommands && i + 1 < args.length) {
+        let current: Command | undefined = this.commands.get(arg);
+        while (current && i + 1 < args.length) {
           const nextArg = args[i + 1];
-          const subCmd = cmd.subcommands.find(sc => sc.name === nextArg || sc.aliases?.includes(nextArg));
-          if (subCmd) {
-            result.command.push(nextArg);
-            i++;
-
-            // Check for nested subcommand (level 2)
-            if (subCmd.subcommands && i + 1 < args.length) {
-              const nestedArg = args[i + 1];
-              const nestedCmd = subCmd.subcommands.find(sc => sc.name === nestedArg || sc.aliases?.includes(nestedArg));
-              if (nestedCmd) {
-                result.command.push(nestedArg);
-                i++;
-
-                // Check for deeply nested subcommand (level 3)
-                if (nestedCmd.subcommands && i + 1 < args.length) {
-                  const deepArg = args[i + 1];
-                  const deepCmd = nestedCmd.subcommands.find(sc => sc.name === deepArg || sc.aliases?.includes(deepArg));
-                  if (deepCmd) {
-                    result.command.push(deepArg);
-                    i++;
-                  }
-                }
-              }
-            }
-          }
+          const sub = this.findSubcommand(current, nextArg);
+          if (!sub) break;
+          result.command.push(nextArg);
+          i++;
+          current = sub;
         }
       } else {
         // Positional argument
@@ -216,6 +196,10 @@ export class CommandParser {
     this.applyDefaults(result.flags);
 
     return result;
+  }
+
+  private findSubcommand(parent: Command | undefined, name: string): Command | undefined {
+    return parent?.subcommands?.find(sc => sc.name === name || sc.aliases?.includes(name));
   }
 
   private parseFlag(


### PR DESCRIPTION
## Summary

Two interacting bugs caused \`flo spell schedule create -n NAME --cron …\` to fail with \`[ERROR] Required option missing: --name\`:

1. **Parser depth ceiling.** Pass 1 only descended 2 levels of subcommand resolution, so for 3-level commands like \`spell schedule create\`, the leaf command's options were absent from the scoped-alias map. \`-n\` then aliased to whichever globally-registered command claimed it (\`guidance --max-shards\` in this case).
2. **Lazy-loaded commands.** \`spell\` isn't in the eager \`commands\` array — it's resolved via \`getCommandAsync\` after the first \`parse()\`. Even with arbitrary-depth resolution, the command's subtree was invisible at parse time.

## Fix

- \`src/cli/parser.ts\` — replace fixed-depth chain (\`resolvedCmd\`/\`Sub\`/\`Nested\`) with a greedy while-loop walk via a shared \`findSubcommand\` helper. Pass 2's 4-deep nested if-blocks for \`command\`-path emission collapse to the same loop. Handles arbitrary nesting depth and dedupes the \`subcommands.find(sc => sc.name === arg || sc.aliases?.includes(arg))\` pattern that was repeated 5× in this file.
- \`src/cli/index.ts\` — after \`getCommandAsync\` resolves, \`registerCommand\` the new command on the parser and re-parse args so scoped aliases see the full tree.
- \`harness/consumer-smoke/lib/checks.mjs\` — revert the \`--name\` workaround that was pointing at this issue. Smoke now exercises \`-n\` end-to-end.
- \`src/cli/__tests__/parser.test.ts\` — regression test pinning the 3-level scoped-alias path. Registers a sibling command claiming \`-n\` so the test genuinely fails against the old fixed-depth code, not just trivially passes.

## Test plan

- [x] Live repro: \`node bin/cli.js spell schedule create -n smoke-test --cron \"a b c d e\"\` now reports \`Invalid schedule: invalid cron expression\` (previously: \`Required option missing: --name\`)
- [x] Valid cron: \`node bin/cli.js spell schedule create -n audit --cron \"0 9 * * *\"\` succeeds
- [x] Spell help unaffected: \`node bin/cli.js spell --help\` works
- [x] Guidance unaffected: \`node bin/cli.js guidance --max-shards 3\` works (no -n collision)
- [x] \`npm run build\` clean
- [x] \`npm test\` — 7421/7421 passing
- [x] Targeted: parser.test.ts (49/49 incl. new regression), cli.test.ts isolation (32/32)

Closes #768

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)