### PR TITLE
fix(774): dry-run validator registers top-level step.id; resolveVariable short-circuits on _dryRun sentinel

### DIFF
--- a/src/cli/__tests__/spells/dry-run-validator.test.ts
+++ b/src/cli/__tests__/spells/dry-run-validator.test.ts
@@ -244,7 +244,34 @@ describe('dryRunValidate', () => {
 
     // After step 'a' with output 'stepAOutput', the variable should be set for step 'b'
     expect(capturedVars[1]).toHaveProperty('stepAOutput', { _dryRun: true });
+    // step.id is also registered so forward `{a.<deep>}` refs interpolate (#774)
+    expect(capturedVars[1]).toHaveProperty('a', { _dryRun: true });
     expect(result.valid).toBe(true);
+  });
+
+  it('should resolve forward step.id deep-path refs under dry-run (#774)', async () => {
+    // A 2-step spell where step 2 references `{step1.stdout}` — step 1 has
+    // no explicit `output:` field, mirroring the epic-single-branch.yaml
+    // case that broke `flo epic --dry-run`.
+    const registry = new StepCommandRegistry();
+    registry.register(makeCommand());
+
+    const definition = makeDefinition([
+      makeStep({ id: 'step1', config: { msg: 'hello' } }),
+      makeStep({ id: 'step2', config: { body: 'prefix {step1.stdout} suffix' } }),
+    ]);
+
+    const result = await dryRunValidate(
+      definition, {}, validDefResult, defaultOptions, registry, buildContextFactory(),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.steps[1].validationResult.valid).toBe(true);
+    // The interpolated config should contain the dry-run placeholder string,
+    // not throw "Variable interpolation failed".
+    expect(result.steps[1].interpolatedConfig).toMatchObject({
+      body: expect.stringContaining('_dryRun_placeholder'),
+    });
   });
 
   it.each(['parallel', 'loop'] as const)(

--- a/src/cli/spells/core/dry-run-validator.ts
+++ b/src/cli/spells/core/dry-run-validator.ts
@@ -164,8 +164,9 @@ export async function dryRunValidate(
     const report = await dryRunValidateStep(step, `steps[${i}]`, context, env);
     stepReports.push(report);
 
-    if (step.output && report.validationResult.valid) {
-      variables[step.output] = { _dryRun: true };
+    if (report.validationResult.valid) {
+      if (step.output) variables[step.output] = { _dryRun: true };
+      variables[step.id] = { _dryRun: true };
     }
 
     // Validate nested steps for parallel and loop blocks (#247, #252)

--- a/src/cli/spells/core/interpolation.ts
+++ b/src/cli/spells/core/interpolation.ts
@@ -58,6 +58,13 @@ function resolveVariable(path: string, context: CastingContext): unknown {
       value = undefined;
       break;
     }
+    // Dry-run sentinel: dry-run-validator stores `{ _dryRun: true }` in
+    // place of unknown step outputs. Any further nested access (e.g.
+    // `{stepId.stdout}`) resolves to a placeholder so spells with forward
+    // step-output refs validate cleanly without runtime data.
+    if ((value as Record<string, unknown>)._dryRun === true) {
+      return '_dryRun_placeholder';
+    }
     value = (value as Record<string, unknown>)[segment];
   }
   if (value !== undefined) return value;


### PR DESCRIPTION
## Summary

- `dry-run-validator.ts`: register `variables[step.id]` after a successful top-level step (mirroring the existing nested-block behavior and matching runner.ts:308 at runtime).
- `interpolation.ts`: `resolveVariable` short-circuits when walking past a `{ _dryRun: true }` sentinel and returns the placeholder string `_dryRun_placeholder`. Without this, deep-path refs like `{step1.stdout}` walk into the marker and resolve to undefined, throwing "Variable interpolation failed".
- Regression test added: a 2-step spell where step 2 references `{step1.stdout}` (no explicit `output:`) validates clean under `dryRunValidate`.

The issue body proposed only the first half — without the resolveVariable short-circuit, `flo epic 287 --dry-run` still failed because the runtime stored object had a `.stdout` field that the dry-run marker did not.

Closes #774

## Test plan
- [x] `npx flo epic 287 --dry-run` reports `Dry-run: spell is valid` (was: `steps[5].config: Variable interpolation failed`)
- [x] `npx vitest run src/cli/__tests__/spells/dry-run-validator.test.ts` — 14 passed (was 13)
- [x] `npx vitest run src/cli/__tests__/spells/interpolation.test.ts` — 23 passed (no regression)
- [x] `npm test` — 7422 passed

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)