### PR TITLE
fix(776): preserve multi-line PR/issue bodies on Windows via execFile argv

### DIFF
--- a/src/cli/__tests__/spells/github-cli-tool.test.ts
+++ b/src/cli/__tests__/spells/github-cli-tool.test.ts
@@ -9,14 +9,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { githubCliConnector, validateGitHubAction, VALID_ACTIONS } from '../../spells/connectors/github-cli.js';
 
 // ============================================================================
-// Mock child_process (exec + execFile for prerequisite-checker)
+// Mock child_process — exec + execFile
 // ============================================================================
 
 type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
 
 let mockExecResult: { stdout: string; stderr: string; exitCode: number } = {
   stdout: '', stderr: '', exitCode: 0,
 };
+
+interface CapturedCall {
+  file: string;
+  args: string[];
+}
+const capturedExecFileCalls: CapturedCall[] = [];
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
@@ -36,11 +43,35 @@ vi.mock('node:child_process', async (importOriginal) => {
       });
       return child;
     },
+    // execFile has overloads with and without an `options` arg. The
+    // callback is always the last argument; everything before is positional.
+    execFile: (file: string, args: string[], optsOrCb: unknown, maybeCb?: ExecFileCallback) => {
+      const callback = (typeof optsOrCb === 'function' ? optsOrCb : maybeCb) as ExecFileCallback;
+      capturedExecFileCalls.push({ file, args: [...args] });
+      const child = {
+        exitCode: mockExecResult.exitCode,
+        kill: vi.fn(),
+      };
+      if (typeof callback === 'function') {
+        process.nextTick(() => {
+          callback(
+            mockExecResult.exitCode !== 0 ? new Error('command failed') : null,
+            mockExecResult.stdout,
+            mockExecResult.stderr,
+          );
+        });
+      }
+      return child;
+    },
   };
 });
 
 function setMockResult(stdout: string, exitCode = 0, stderr = '') {
   mockExecResult = { stdout, stderr, exitCode };
+}
+
+function lastExecFileCall(): CapturedCall | undefined {
+  return capturedExecFileCalls[capturedExecFileCalls.length - 1];
 }
 
 // ============================================================================
@@ -151,6 +182,7 @@ describe('githubCliConnector — validateGitHubAction', () => {
 describe('githubCliConnector — execute', () => {
   beforeEach(() => {
     setMockResult('', 0);
+    capturedExecFileCalls.length = 0;
   });
 
   afterEach(() => {
@@ -239,5 +271,64 @@ describe('githubCliConnector — execute', () => {
     const output = await githubCliConnector.execute('issue-fetch', {});
     expect(output.success).toBe(false);
     expect(output.error).toContain('issue number');
+  });
+});
+
+// ============================================================================
+// Multi-line bodies must pass through argv verbatim (no shell escaping)
+// ============================================================================
+
+describe('githubCliConnector — multi-line body integrity', () => {
+  beforeEach(() => {
+    setMockResult('', 0);
+    capturedExecFileCalls.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const multiLineBody = '## Epic #287\n\nConsolidated PR for all stories.\n\nCloses #284 Closes #285 Closes #286 Closes #287';
+
+  it('pr-create passes multi-line body verbatim as a single argv element', async () => {
+    setMockResult('https://github.com/org/repo/pull/99');
+    await githubCliConnector.execute('pr-create', { title: 'feat: epic #287', body: multiLineBody });
+
+    const call = lastExecFileCall();
+    expect(call).toBeDefined();
+    expect(call!.file).toBe('gh');
+    const bodyIdx = call!.args.indexOf('--body');
+    expect(bodyIdx).toBeGreaterThan(-1);
+    expect(call!.args[bodyIdx + 1]).toBe(multiLineBody);
+  });
+
+  it('issue-edit passes multi-line body verbatim', async () => {
+    setMockResult('');
+    await githubCliConnector.execute('issue-edit', { issue: 287, body: multiLineBody });
+
+    const call = lastExecFileCall();
+    expect(call).toBeDefined();
+    const bodyIdx = call!.args.indexOf('--body');
+    expect(call!.args[bodyIdx + 1]).toBe(multiLineBody);
+  });
+
+  it('comment passes multi-line body verbatim', async () => {
+    setMockResult('');
+    await githubCliConnector.execute('comment', { issue: 287, body: multiLineBody });
+
+    const call = lastExecFileCall();
+    expect(call).toBeDefined();
+    const bodyIdx = call!.args.indexOf('--body');
+    expect(call!.args[bodyIdx + 1]).toBe(multiLineBody);
+  });
+
+  it('does not invoke a shell — arguments containing shell metacharacters are not interpreted', async () => {
+    setMockResult('https://github.com/org/repo/pull/100');
+    const trickyBody = 'line1\n& whoami\n| cat\n"quoted" $VAR `subshell`';
+    await githubCliConnector.execute('pr-create', { title: 'test', body: trickyBody });
+
+    const call = lastExecFileCall();
+    const bodyIdx = call!.args.indexOf('--body');
+    expect(call!.args[bodyIdx + 1]).toBe(trickyBody);
   });
 });

--- a/src/cli/__tests__/spells/github-command.test.ts
+++ b/src/cli/__tests__/spells/github-command.test.ts
@@ -16,6 +16,7 @@ import { ALLOW_ALL_GATEWAY } from './helpers.js';
 // ============================================================================
 
 type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
 
 let mockExecResult: { stdout: string; stderr: string; exitCode: number } = {
   stdout: '', stderr: '', exitCode: 0,
@@ -37,6 +38,23 @@ vi.mock('node:child_process', async (importOriginal) => {
           mockExecResult.stderr,
         );
       });
+      return child;
+    },
+    execFile: (_file: string, _args: string[], optsOrCb: unknown, maybeCb?: ExecFileCallback) => {
+      const callback = (typeof optsOrCb === 'function' ? optsOrCb : maybeCb) as ExecFileCallback;
+      const child = {
+        exitCode: mockExecResult.exitCode,
+        kill: vi.fn(),
+      };
+      if (typeof callback === 'function') {
+        process.nextTick(() => {
+          callback(
+            mockExecResult.exitCode !== 0 ? new Error('command failed') : null,
+            mockExecResult.stdout,
+            mockExecResult.stderr,
+          );
+        });
+      }
       return child;
     },
   };

--- a/src/cli/spells/commands/github-command.ts
+++ b/src/cli/spells/commands/github-command.ts
@@ -23,8 +23,7 @@ import type {
 import { interpolateString } from '../core/interpolation.js';
 import { commandExists } from '../core/prerequisite-checker.js';
 import {
-  execAsync,
-  escapeShellArg,
+  execFileAsync,
   validateGitHubAction,
   githubCliConnector,
   VALID_ACTIONS,
@@ -68,7 +67,7 @@ const githubPrerequisites: readonly Prerequisite[] = [
     name: 'gh-auth',
     check: async () => {
       try {
-        const result = await execAsync('gh auth status', 5000);
+        const result = await execFileAsync('gh', ['auth', 'status'], 5000);
         return result.exitCode === 0;
       } catch {
         return false;
@@ -91,7 +90,7 @@ const githubPreflights: readonly PreflightCheck<GitHubStepConfig>[] = [
       if (typeof config.issue !== 'number') return { passed: true };
       // Skip for create-type actions that don't require the issue to exist.
       if (config.action === 'issue-edit' || config.action === 'issue-fetch' || config.action === 'comment' || config.action === 'label') {
-        const result = await execAsync(`gh issue view ${config.issue} --json number`, 5000);
+        const result = await execFileAsync('gh', ['issue', 'view', String(config.issue), '--json', 'number'], 5000);
         if (result.exitCode === 0) return { passed: true };
         return { passed: false, reason: `issue #${config.issue} not found or not accessible` };
       }
@@ -103,7 +102,7 @@ const githubPreflights: readonly PreflightCheck<GitHubStepConfig>[] = [
     check: async (config) => {
       if (typeof config.pr !== 'number') return { passed: true };
       if (config.action === 'pr-merge' || config.action === 'pr-find') {
-        const result = await execAsync(`gh pr view ${config.pr} --json number`, 5000);
+        const result = await execFileAsync('gh', ['pr', 'view', String(config.pr), '--json', 'number'], 5000);
         if (result.exitCode === 0) return { passed: true };
         return { passed: false, reason: `PR #${config.pr} not found or not accessible` };
       }
@@ -210,7 +209,7 @@ export const githubCommand: StepCommand<GitHubStepConfig> = {
   async rollback(config: GitHubStepConfig): Promise<void> {
     if (config.action !== 'pr-create') return;
     if (config.head) {
-      await execAsync(`gh pr close ${escapeShellArg(config.head)}`);
+      await execFileAsync('gh', ['pr', 'close', config.head]);
     }
   },
 };

--- a/src/cli/spells/connectors/github-cli.ts
+++ b/src/cli/spells/connectors/github-cli.ts
@@ -11,10 +11,9 @@
 
 import type { SpellConnector, ConnectorAction, ConnectorOutput } from '../types/spell-connector.types.js';
 import { commandExists } from '../core/prerequisite-checker.js';
-import { execAsync, escapeShellArg } from '../core/shell.js';
+import { execFileAsync } from '../core/shell.js';
 
-// Re-export shell utilities for consumers that imported from here
-export { execAsync, escapeShellArg, type ExecResult } from '../core/shell.js';
+export { execFileAsync, type ExecResult } from '../core/shell.js';
 
 // ============================================================================
 // Types
@@ -44,30 +43,30 @@ const VALID_MERGE_METHODS = ['squash', 'merge', 'rebase'] as const;
 async function executeIssueFetch(params: Record<string, unknown>, start: number): Promise<ConnectorOutput> {
   const issue = params.issue as number;
   const fields = (params.fields as string[])?.join(',') || 'number,title,body,labels,state,assignees';
-  const result = await execAsync(`gh issue view ${issue} --json ${fields}`);
+  const result = await execFileAsync('gh', ['issue', 'view', String(issue), '--json', fields]);
   if (result.exitCode !== 0) {
     return { success: false, data: {}, error: result.stderr || `Failed to fetch issue #${issue}`, duration: Date.now() - start };
   }
   return { success: true, data: JSON.parse(result.stdout), duration: Date.now() - start };
 }
 
-function appendLabelArgs(args: string[], labels: { add?: string[]; remove?: string[] } | undefined): void {
+function appendLabelArgv(argv: string[], labels: { add?: string[]; remove?: string[] } | undefined): void {
   if (labels?.add) {
-    for (const l of labels.add) args.push(`--add-label ${escapeShellArg(l)}`);
+    for (const l of labels.add) argv.push('--add-label', l);
   }
   if (labels?.remove) {
-    for (const l of labels.remove) args.push(`--remove-label ${escapeShellArg(l)}`);
+    for (const l of labels.remove) argv.push('--remove-label', l);
   }
 }
 
 async function executeIssueEdit(params: Record<string, unknown>, start: number): Promise<ConnectorOutput> {
   const issue = params.issue as number;
-  const args: string[] = [`gh issue edit ${issue}`];
-  if (params.title) args.push(`--title ${escapeShellArg(params.title as string)}`);
-  if (params.body) args.push(`--body ${escapeShellArg(params.body as string)}`);
-  appendLabelArgs(args, params.labels as { add?: string[]; remove?: string[] } | undefined);
+  const argv: string[] = ['issue', 'edit', String(issue)];
+  if (params.title) argv.push('--title', params.title as string);
+  if (params.body) argv.push('--body', params.body as string);
+  appendLabelArgv(argv, params.labels as { add?: string[]; remove?: string[] } | undefined);
 
-  const result = await execAsync(args.join(' '));
+  const result = await execFileAsync('gh', argv);
   if (result.exitCode !== 0) {
     return { success: false, data: {}, error: result.stderr || `Failed to edit issue #${issue}`, duration: Date.now() - start };
   }
@@ -75,22 +74,21 @@ async function executeIssueEdit(params: Record<string, unknown>, start: number):
 }
 
 async function executePrCreate(params: Record<string, unknown>, start: number): Promise<ConnectorOutput> {
-  const args: string[] = ['gh pr create'];
-  args.push(`--title ${escapeShellArg(params.title as string)}`);
-  if (params.body) args.push(`--body ${escapeShellArg(params.body as string)}`);
-  if (params.base) args.push(`--base ${escapeShellArg(params.base as string)}`);
-  if (params.head) args.push(`--head ${escapeShellArg(params.head as string)}`);
+  const argv: string[] = ['pr', 'create', '--title', params.title as string];
+  if (params.body) argv.push('--body', params.body as string);
+  if (params.base) argv.push('--base', params.base as string);
+  if (params.head) argv.push('--head', params.head as string);
   const labels = params.labels as { add?: string[] } | undefined;
   if (labels?.add) {
-    for (const l of labels.add) args.push(`--label ${escapeShellArg(l)}`);
+    for (const l of labels.add) argv.push('--label', l);
   }
 
-  const result = await execAsync(args.join(' '), 60000);
+  const result = await execFileAsync('gh', argv, 60000);
   if (result.exitCode !== 0) {
     return { success: false, data: {}, error: result.stderr || 'Failed to create PR', duration: Date.now() - start };
   }
 
-  const prUrl = result.stdout.trim();
+  const prUrl = result.stdout;
   const prNumber = parseInt(prUrl.match(/\/pull\/(\d+)/)?.[1] ?? '0', 10);
   return { success: true, data: { prUrl, prNumber }, duration: Date.now() - start };
 }
@@ -98,12 +96,11 @@ async function executePrCreate(params: Record<string, unknown>, start: number): 
 async function executePrMerge(params: Record<string, unknown>, start: number): Promise<ConnectorOutput> {
   const prRef = (params.pr ?? params.issue) as number;
   const mergeMethod = (params.mergeMethod as string) ?? 'squash';
-  const args: string[] = [`gh pr merge ${prRef}`];
-  args.push(`--${mergeMethod}`);
-  if (params.deleteBranch !== false) args.push('--delete-branch');
-  if (params.admin) args.push('--admin');
+  const argv: string[] = ['pr', 'merge', String(prRef), `--${mergeMethod}`];
+  if (params.deleteBranch !== false) argv.push('--delete-branch');
+  if (params.admin) argv.push('--admin');
 
-  const result = await execAsync(args.join(' '), 60000);
+  const result = await execFileAsync('gh', argv, 60000);
   if (result.exitCode !== 0) {
     return { success: false, data: {}, error: result.stderr || `Failed to merge PR #${prRef}`, duration: Date.now() - start };
   }
@@ -111,14 +108,14 @@ async function executePrMerge(params: Record<string, unknown>, start: number): P
 }
 
 async function executePrFind(params: Record<string, unknown>, start: number): Promise<ConnectorOutput> {
-  let cmd: string;
+  const argv: string[] = ['pr', 'list'];
   if (params.head) {
-    cmd = `gh pr list --head ${escapeShellArg(params.head as string)} --json number,title,state,url --limit 1`;
+    argv.push('--head', params.head as string, '--json', 'number,title,state,url', '--limit', '1');
   } else {
-    cmd = `gh pr list --search ${escapeShellArg(params.search as string)} --json number,title,state,url --limit 10`;
+    argv.push('--search', params.search as string, '--json', 'number,title,state,url', '--limit', '10');
   }
 
-  const result = await execAsync(cmd);
+  const result = await execFileAsync('gh', argv);
   if (result.exitCode !== 0) {
     return { success: false, data: {}, error: result.stderr || 'Failed to find PR', duration: Date.now() - start };
   }
@@ -129,10 +126,10 @@ async function executePrFind(params: Record<string, unknown>, start: number): Pr
 
 async function executeLabel(params: Record<string, unknown>, start: number): Promise<ConnectorOutput> {
   const ref = (params.issue ?? params.pr) as number;
-  const args: string[] = [`gh issue edit ${ref}`];
-  appendLabelArgs(args, params.labels as { add?: string[]; remove?: string[] } | undefined);
+  const argv: string[] = ['issue', 'edit', String(ref)];
+  appendLabelArgv(argv, params.labels as { add?: string[]; remove?: string[] } | undefined);
 
-  const result = await execAsync(args.join(' '));
+  const result = await execFileAsync('gh', argv);
   if (result.exitCode !== 0) {
     return { success: false, data: {}, error: result.stderr || `Failed to update labels for #${ref}`, duration: Date.now() - start };
   }
@@ -143,7 +140,7 @@ async function executeLabel(params: Record<string, unknown>, start: number): Pro
 async function executeComment(params: Record<string, unknown>, start: number): Promise<ConnectorOutput> {
   const ref = (params.issue ?? params.pr) as number;
   const body = params.body as string;
-  const result = await execAsync(`gh issue comment ${ref} --body ${escapeShellArg(body)}`);
+  const result = await execFileAsync('gh', ['issue', 'comment', String(ref), '--body', body]);
   if (result.exitCode !== 0) {
     return { success: false, data: {}, error: result.stderr || `Failed to comment on #${ref}`, duration: Date.now() - start };
   }
@@ -151,7 +148,7 @@ async function executeComment(params: Record<string, unknown>, start: number): P
 }
 
 async function executeRepoInfo(start: number): Promise<ConnectorOutput> {
-  const result = await execAsync('gh repo view --json name,owner,url,defaultBranchRef,description');
+  const result = await execFileAsync('gh', ['repo', 'view', '--json', 'name,owner,url,defaultBranchRef,description']);
   if (result.exitCode !== 0) {
     return { success: false, data: {}, error: result.stderr || 'Failed to get repo info', duration: Date.now() - start };
   }
@@ -329,7 +326,7 @@ export const githubCliConnector: SpellConnector = {
     if (!ghInstalled) {
       throw new Error('GitHub CLI (gh) is not installed. Install from https://cli.github.com');
     }
-    const authResult = await execAsync('gh auth status', 5000);
+    const authResult = await execFileAsync('gh', ['auth', 'status'], 5000);
     if (authResult.exitCode !== 0) {
       throw new Error('GitHub CLI is not authenticated. Run: gh auth login');
     }

--- a/src/cli/spells/core/shell.ts
+++ b/src/cli/spells/core/shell.ts
@@ -6,7 +6,7 @@
  * that need CLI execution.
  */
 
-import { exec } from 'node:child_process';
+import { exec, execFile } from 'node:child_process';
 
 // ============================================================================
 // Types
@@ -38,6 +38,34 @@ export function execAsync(command: string, timeout = 30000): Promise<ExecResult>
         exitCode: child.exitCode ?? (error ? 1 : 0),
       });
     });
+  });
+}
+
+/**
+ * Spawn a binary with an argv array — no shell, no escaping required.
+ * Use this whenever an argument may contain newlines, quotes, or other
+ * shell metacharacters. cmd.exe treats embedded `\n` in shell-mode
+ * strings as a command separator regardless of quoting, so any gh/git
+ * command that carries a multi-line body must go through this path.
+ */
+export function execFileAsync(
+  file: string,
+  args: readonly string[],
+  timeout = 30000,
+): Promise<ExecResult> {
+  return new Promise((resolve) => {
+    const child = execFile(
+      file,
+      args,
+      { timeout, windowsHide: true, encoding: 'utf8' },
+      (error, stdout, stderr) => {
+        resolve({
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+          exitCode: child.exitCode ?? (error ? 1 : 0),
+        });
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
- Switch all `gh` CLI invocations in the spell engine from shell-mode `exec(joinedString)` to argv-mode `execFile('gh', argv)`. cmd.exe truncates multi-line `--body` values at the first newline regardless of quoting, so bypassing the shell is the only correct cross-platform fix.
- Add `execFileAsync(file, args[], timeout)` to `spells/core/shell.ts` mirroring the never-throws contract of `execAsync`.
- Migrate `github-cli` connector (8 actions), `github` step preflights, and PR-create rollback to argv form. Drop dead `execAsync`/`escapeShellArg` re-exports from the connector.

## Why
Surfaced when epic PR #775 (issue #287 retest) lost its `Closes #284 Closes #285 Closes #286 Closes #287` tail. PR body became just `## Epic #287` — everything after the first `\n` was dropped because `escapeShellArg` only quotes against spaces/quotes, not newlines, and `exec` routes through cmd.exe which treats `\n` as a command separator. Consequence: epic issue does not auto-close on PR merge.

## Test plan
- [x] Connector tests: `npx vitest run src/cli/__tests__/spells/github-cli-tool.test.ts src/cli/__tests__/spells/github-command.test.ts` — 59 pass, including new regression tests:
  - `pr-create` argv contains multi-line body verbatim
  - `issue-edit` argv contains multi-line body verbatim
  - `comment` argv contains multi-line body verbatim
  - body containing `&`, `|`, `\$VAR`, backticks passes through uninterpreted
- [x] Full spells suite: `npx vitest run src/cli/__tests__/spells` — 1003/1003 pass
- [x] Full test suite: `npm test` — 7426/7426 pass, 0 fail
- [x] `npm run build` — clean

Closes #776

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)