### PR TITLE
fix(787): migrate CLI flag reads to camelCase + ESLint guard

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,7 @@
  *   - Fixed-depth `../../../../modules/<pkg>/...` runtime/type paths (#575)
  *   - `path.resolve|join(<anchor>, '..', '..', ...)` traversal that bakes in
  *     fragile dist/source depth assumptions (#781 / #782 — use mofloPath())
+ *   - `ctx.flags['kebab-case']` reads — parser stores camelCase only (#787)
  *
  * Each rule cluster has its own selectors block — keep new clusters
  * similarly delineated so the file stays scannable.
@@ -171,6 +172,41 @@ const SILENT_WARN_CATCH_SELECTORS = [
   },
 ];
 
+// Issue #787: ban `ctx.flags['kebab-case']` (and bare `flags['kebab-case']`)
+// reads. The parser at src/cli/parser.ts normalises every flag name from
+// kebab-case to camelCase before storing in ctx.flags, so the dashed lookup
+// is always undefined — silently disabling the flag instead of failing loud.
+// Hit during epic #781 when `--allow-warn` did nothing across CI runs because
+// it was being read as `ctx.flags['allow-warn']` instead of `ctx.flags.allowWarn`.
+//
+// Selector matches a MemberExpression whose .property is a string literal
+// containing a hyphen (the kebab marker), and whose .object's .property name
+// is `flags`. That covers `ctx.flags['x-y']`, `result.flags['x-y']`, and the
+// destructured `const { flags } = ctx; flags['x-y']` form.
+//
+// Allowed: camelCase string-key access (`ctx.flags['someKey']`) — useful when
+// the flag name is dynamic or when reserved-word keys force bracket notation.
+const KEBAB_FLAG_READ_MESSAGE =
+  'ctx.flags["<kebab-case>"] is always undefined — the parser normalises ' +
+  'kebab-case flag names to camelCase before storing (#787). Read as ' +
+  'ctx.flags.<camelCase> instead (e.g. `ctx.flags.allowWarn`, not ' +
+  '`ctx.flags["allow-warn"]`).';
+
+const KEBAB_FLAG_READ_SELECTORS = [
+  {
+    selector:
+      `MemberExpression[computed=true][object.property.name='flags']` +
+      `[property.type='Literal'][property.value=/-/]`,
+    message: KEBAB_FLAG_READ_MESSAGE,
+  },
+  {
+    selector:
+      `MemberExpression[computed=true][object.name='flags']` +
+      `[property.type='Literal'][property.value=/-/]`,
+    message: KEBAB_FLAG_READ_MESSAGE,
+  },
+];
+
 // Structural guard: any function that both constructs a Float32Array AND
 // calls charCodeAt is a hash embedding regardless of method name. The
 // identifier ban above missed the inline implementations removed in #542
@@ -214,6 +250,7 @@ const bannedEmbeddingRules = {
     ...FIXED_DEPTH_MODULES_SELECTORS,
     ...PATH_TRAVERSAL_SELECTORS,
     ...SILENT_WARN_CATCH_SELECTORS,
+    ...KEBAB_FLAG_READ_SELECTORS,
   ],
   'no-restricted-imports': [
     'error',
@@ -311,6 +348,7 @@ module.exports = {
           ...FIXED_DEPTH_MODULES_SELECTORS,
           ...PATH_TRAVERSAL_SELECTORS,
           ...SILENT_WARN_CATCH_SELECTORS,
+          ...KEBAB_FLAG_READ_SELECTORS,
         ],
       },
     },
@@ -341,6 +379,7 @@ module.exports = {
           ...RAW_DB_WRITE_SELECTORS,
           ...FIXED_DEPTH_MODULES_SELECTORS,
           ...SILENT_WARN_CATCH_SELECTORS,
+          ...KEBAB_FLAG_READ_SELECTORS,
         ],
       },
     },

--- a/src/cli/__tests__/p1-commands.test.ts
+++ b/src/cli/__tests__/p1-commands.test.ts
@@ -529,7 +529,7 @@ describe('Start Command', () => {
     });
 
     it('should skip MCP server when requested', async () => {
-      ctx.flags = { 'skip-mcp': true, _: [] };
+      ctx.flags = { skipMcp: true, _: [] };
 
       const result = await startCommand.action!(ctx);
 
@@ -709,7 +709,7 @@ describe('Status Command', () => {
     });
 
     it('should perform health check', async () => { // Skip: requires live MCP context
-      ctx.flags = { 'health-check': true, _: [] };
+      ctx.flags = { healthCheck: true, _: [] };
 
       const result = await statusCommand.action!(ctx);
 

--- a/src/cli/__tests__/parser.test.ts
+++ b/src/cli/__tests__/parser.test.ts
@@ -113,10 +113,7 @@ describe('CommandParser', () => {
   // normalizeKey (kebab-case to camelCase)
   // -------------------------------------------------------------------------
   describe('key normalization', () => {
-    // The kebab-undefined assertion (#787) is paired with the camelCase
-    // assertion: the parser stores ONE shape, not both. ~91 call-sites silently
-    // read the kebab form and got undefined — anything re-introducing a kebab
-    // key here would resurrect that bug class.
+    // #787: parser stores camelCase only, never the kebab form.
     it('should convert kebab-case keys to camelCase and not store the kebab form', () => {
       const result = parser.parse(['--some-long-flag=yes']);
       expect(result.flags.someLongFlag).toBe('yes');

--- a/src/cli/__tests__/parser.test.ts
+++ b/src/cli/__tests__/parser.test.ts
@@ -113,14 +113,25 @@ describe('CommandParser', () => {
   // normalizeKey (kebab-case to camelCase)
   // -------------------------------------------------------------------------
   describe('key normalization', () => {
-    it('should convert kebab-case keys to camelCase', () => {
+    // The kebab-undefined assertion (#787) is paired with the camelCase
+    // assertion: the parser stores ONE shape, not both. ~91 call-sites silently
+    // read the kebab form and got undefined — anything re-introducing a kebab
+    // key here would resurrect that bug class.
+    it('should convert kebab-case keys to camelCase and not store the kebab form', () => {
       const result = parser.parse(['--some-long-flag=yes']);
       expect(result.flags.someLongFlag).toBe('yes');
+      expect(result.flags['some-long-flag']).toBeUndefined();
     });
 
     it('should leave simple keys unchanged', () => {
       const result = parser.parse(['--simple=val']);
       expect(result.flags.simple).toBe('val');
+    });
+
+    it('should normalise --no-<kebab> to camelCase=false (#787)', () => {
+      const result = parser.parse(['--no-some-feature']);
+      expect(result.flags['no-some-feature']).toBeUndefined();
+      expect(result.flags.someFeature).toBe(false);
     });
   });
 

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -1537,7 +1537,7 @@ const modulesCommand: Command = {
     const targetDir = ctx.args[0] || ctx.cwd;
     const outputFile = ctx.flags.output as string | undefined;
     const format = (ctx.flags.format as string) || 'text';
-    const minSize = (ctx.flags['min-size'] as number) || 2;
+    const minSize = (ctx.flags.minSize as number) || 2;
 
     output.printInfo(`Detecting module communities in: ${output.highlight(targetDir)}`);
     output.writeln();

--- a/src/cli/commands/appliance-advanced.ts
+++ b/src/cli/commands/appliance-advanced.ts
@@ -52,8 +52,8 @@ export const signCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const file = ctx.flags.file as string;
     const keyPath = ctx.flags.key as string | undefined;
-    const genKeys = ctx.flags['generate-keys'] as boolean;
-    const keyDir = ctx.flags['key-dir'] as string || '.rvfa-keys';
+    const genKeys = ctx.flags.generateKeys as boolean;
+    const keyDir = ctx.flags.keyDir as string || '.rvfa-keys';
     const signer = ctx.flags.signer as string | undefined;
     if (!file) return fail('--file is required');
 
@@ -191,14 +191,14 @@ export const updateAppCommand: Command = {
       }
 
       let pubKey: Buffer | undefined;
-      if (ctx.flags['public-key']) {
-        const pkPath = ctx.flags['public-key'] as string;
+      if (ctx.flags.publicKey) {
+        const pkPath = ctx.flags.publicKey as string;
         if (!(await requireFile(pkPath))) return { success: false, exitCode: 1 };
         pubKey = fs.readFileSync(pkPath);
       }
 
       const result = await dist.RvfaPatcher.applyPatch(file, patchBuf, {
-        backup: !(ctx.flags['no-backup'] as boolean),
+        backup: !(ctx.flags.noBackup as boolean),
         verify: true,
         publicKey: pubKey,
       });

--- a/src/cli/commands/appliance.ts
+++ b/src/cli/commands/appliance.ts
@@ -93,7 +93,7 @@ const buildCommand: Command = {
     const outputPath = ctx.flags.output as string || 'ruflo.rvf';
     const arch = ctx.flags.arch as string || 'x86_64';
     const models = ctx.flags.models as string[] || [];
-    const apiKeysPath = ctx.flags['api-keys'] as string | undefined;
+    const apiKeysPath = ctx.flags.apiKeys as string | undefined;
 
     header('RVFA Appliance Builder');
     output.printInfo(`Profile:  ${output.highlight(profile)}`);

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -43,8 +43,8 @@ const startCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const quiet = ctx.flags.quiet as boolean;
     const foreground = ctx.flags.foreground as boolean;
-    const noDashboard = ctx.flags['no-dashboard'] as boolean;
-    const rawDashboardPort = ctx.flags['dashboard-port'] as string | undefined;
+    const noDashboard = ctx.flags.noDashboard as boolean;
+    const rawDashboardPort = ctx.flags.dashboardPort as string | undefined;
     const projectRoot = process.cwd();
     const isDaemonProcess = process.env.CLAUDE_FLOW_DAEMON === '1';
 
@@ -61,8 +61,8 @@ const startCommand: Command = {
 
     // Parse resource threshold overrides from CLI flags
     const config: Partial<DaemonConfig> = {};
-    const rawMaxCpu = ctx.flags['max-cpu-load'] as string | undefined;
-    const rawMinMem = ctx.flags['min-free-memory'] as string | undefined;
+    const rawMaxCpu = ctx.flags.maxCpuLoad as string | undefined;
+    const rawMinMem = ctx.flags.minFreeMemory as string | undefined;
 
     // Strict numeric pattern to prevent command injection when forwarding to subprocess (S1)
     const NUMERIC_RE = /^\d+(\.\d+)?$/;
@@ -549,7 +549,7 @@ const statusCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const verbose = ctx.flags.verbose as boolean;
-    const showModes = ctx.flags['show-modes'] as boolean;
+    const showModes = ctx.flags.showModes as boolean;
     const projectRoot = process.cwd();
 
     try {

--- a/src/cli/commands/deployment.ts
+++ b/src/cli/commands/deployment.ts
@@ -26,7 +26,7 @@ const deployCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const env = ctx.flags.env as string || 'staging';
     const version = ctx.flags.version as string || 'latest';
-    const dryRun = ctx.flags['dry-run'] as boolean;
+    const dryRun = ctx.flags.dryRun as boolean;
 
     output.writeln();
     output.writeln(output.bold(`Deployment: ${env.toUpperCase()}`));

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1310,7 +1310,7 @@ export const doctorCommand: Command = {
     const autoInstall = ctx.flags.install as boolean;
     const component = ctx.flags.component as string;
     const verbose = ctx.flags.verbose as boolean;
-    const killZombies = ctx.flags['kill-zombies'] as boolean;
+    const killZombies = ctx.flags.killZombies as boolean;
     const strict = ctx.flags.strict as boolean;
     // Parser normalises kebab-case flag names to camelCase: `--allow-warn`
     // arrives as `ctx.flags.allowWarn`. Reading the dashed form returns

--- a/src/cli/commands/embeddings.ts
+++ b/src/cli/commands/embeddings.ts
@@ -124,7 +124,7 @@ const searchCommand: Command = {
     const namespace = ctx.flags.collection as string || 'default';
     const limit = parseInt(ctx.flags.limit as string || '10', 10);
     const threshold = parseFloat(ctx.flags.threshold as string || '0.5');
-    const dbPath = ctx.flags['db-path'] as string || memoryDbPath(process.cwd());
+    const dbPath = ctx.flags.dbPath as string || memoryDbPath(process.cwd());
 
     if (!query) {
       output.printError('Query is required');
@@ -410,7 +410,7 @@ const collectionsCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const action = ctx.flags.action as string || 'list';
-    const dbPath = ctx.flags['db-path'] as string || memoryDbPath(process.cwd());
+    const dbPath = ctx.flags.dbPath as string || memoryDbPath(process.cwd());
 
     output.writeln();
     output.writeln(output.bold('Embedding Collections (Namespaces)'));
@@ -531,7 +531,7 @@ const indexCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const action = ctx.flags.action as string || 'status';
     const collection = ctx.flags.collection as string;
-    const efConstruction = parseInt(ctx.flags['ef-construction'] as string || '200', 10);
+    const efConstruction = parseInt(ctx.flags.efConstruction as string || '200', 10);
     const m = parseInt(ctx.flags.m as string || '16', 10);
 
     output.writeln();
@@ -685,12 +685,10 @@ export const initCommand: Command = {
     const hyperbolic = ctx.flags.hyperbolic !== false;
     const force = ctx.flags.force === true;
 
-    // Parse curvature - handle both kebab-case and direct value
     const curvatureRaw = ctx.flags.curvature as string || '-1';
     const curvature = parseFloat(curvatureRaw);
 
-    // Parse cache-size - check both kebab-case and camelCase
-    const cacheSizeRaw = (ctx.flags['cache-size'] || ctx.flags.cacheSize || '256') as string;
+    const cacheSizeRaw = (ctx.flags.cacheSize || '256') as string;
     const cacheSize = parseInt(cacheSizeRaw, 10);
 
     output.writeln();
@@ -858,7 +856,7 @@ const chunkCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const text = ctx.flags.text as string || '';
-    const maxSize = parseInt(ctx.flags['max-size'] as string || '512', 10);
+    const maxSize = parseInt(ctx.flags.maxSize as string || '512', 10);
     const overlap = parseInt(ctx.flags.overlap as string || '50', 10);
     const strategy = ctx.flags.strategy as string || 'sentence';
 
@@ -1061,9 +1059,9 @@ const neuralCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const feature = ctx.flags.feature as string || 'all';
     const init = ctx.flags.init as boolean;
-    const driftThreshold = parseFloat((ctx.flags['drift-threshold'] || ctx.flags.driftThreshold || '0.3') as string);
-    const decayRate = parseFloat((ctx.flags['decay-rate'] || ctx.flags.decayRate || '0.01') as string);
-    const consolidationInterval = parseInt((ctx.flags['consolidation-interval'] || ctx.flags.consolidationInterval || '60000') as string, 10);
+    const driftThreshold = parseFloat((ctx.flags.driftThreshold || '0.3') as string);
+    const decayRate = parseFloat((ctx.flags.decayRate || '0.01') as string);
+    const consolidationInterval = parseInt((ctx.flags.consolidationInterval || '60000') as string, 10);
 
     output.writeln();
     output.writeln(output.bold('Neural Embedding Substrate (MoVector)'));
@@ -1275,7 +1273,7 @@ const cacheCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const action = ctx.flags.action as string || 'stats';
-    const dbPath = ctx.flags['db-path'] as string || '.cache/embeddings.db';
+    const dbPath = ctx.flags.dbPath as string || '.cache/embeddings.db';
 
     output.writeln();
     output.writeln(output.bold('Embedding Cache'));
@@ -1495,7 +1493,7 @@ const benchmarkCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const iterations = parseInt(ctx.flags.iterations as string || '10', 10);
-    const batchSize = parseInt(ctx.flags['batch-size'] as string || '5', 10);
+    const batchSize = parseInt(ctx.flags.batchSize as string || '5', 10);
     const full = ctx.flags.full === true;
 
     output.writeln();

--- a/src/cli/commands/epic.ts
+++ b/src/cli/commands/epic.ts
@@ -574,8 +574,8 @@ const epicCommand: Command = {
         if (!source) {
           return { success: false, message: 'Usage: flo epic <issue-number> [--strategy] [--no-merge] [--verbose] [--dry-run]' };
         }
-        const dryRun = ctx.flags['dry-run'] === true || ctx.flags['dryRun'] === true;
-        const noMerge = ctx.flags['no-merge'] === true || ctx.flags['noMerge'] === true;
+        const dryRun = ctx.flags.dryRun === true;
+        const noMerge = ctx.flags.noMerge === true;
         const verbose = ctx.flags['verbose'] === true;
         const strategyFlag = ctx.flags['strategy'] as string | undefined;
         let strategy: EpicStrategy = 'single-branch';

--- a/src/cli/commands/github.ts
+++ b/src/cli/commands/github.ts
@@ -244,7 +244,7 @@ const ciCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const force = ctx.flags.force as boolean;
-    const dryRun = (ctx.flags['dry-run'] || ctx.flags.dryRun) as boolean;
+    const dryRun = ctx.flags.dryRun as boolean;
     const cwd = ctx.cwd;
 
     const config = readProjectConfig(cwd);
@@ -299,11 +299,11 @@ const settingsCommand: Command = {
     { command: 'flo github settings --skip-protection', description: 'Only apply repo-level settings' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const dryRun = (ctx.flags['dry-run'] || ctx.flags.dryRun) as boolean;
-    const skipProtection = (ctx.flags['skip-protection'] || ctx.flags.skipProtection) as boolean;
-    const skipRepo = (ctx.flags['skip-repo'] || ctx.flags.skipRepo) as boolean;
-    const requiredReviews = parseInt((ctx.flags['required-reviews'] || ctx.flags.requiredReviews) as string || '1', 10);
-    const requireCi = (ctx.flags['require-ci'] ?? ctx.flags.requireCi ?? true) as boolean;
+    const dryRun = ctx.flags.dryRun as boolean;
+    const skipProtection = ctx.flags.skipProtection as boolean;
+    const skipRepo = ctx.flags.skipRepo as boolean;
+    const requiredReviews = parseInt(ctx.flags.requiredReviews as string || '1', 10);
+    const requireCi = (ctx.flags.requireCi ?? true) as boolean;
     const cwd = ctx.cwd;
 
     if (!ghAvailable()) {
@@ -487,8 +487,8 @@ const setupCommand: Command = {
     { command: 'flo github setup --skip-ci', description: 'Only apply repo settings' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const dryRun = (ctx.flags['dry-run'] || ctx.flags.dryRun) as boolean;
-    const skipCi = (ctx.flags['skip-ci'] || ctx.flags.skipCi) as boolean;
+    const dryRun = ctx.flags.dryRun as boolean;
+    const skipCi = ctx.flags.skipCi as boolean;
 
     output.writeln();
     output.writeln(output.bold('GitHub Project Setup'));

--- a/src/cli/commands/guidance.ts
+++ b/src/cli/commands/guidance.ts
@@ -106,7 +106,7 @@ const retrieveCommand: Command = {
     const task = ctx.flags.task as string;
     const rootPath = ctx.flags.root as string || './CLAUDE.md';
     const localPath = ctx.flags.local as string | undefined;
-    const maxShards = parseInt(ctx.flags['max-shards'] as string || '5', 10);
+    const maxShards = parseInt(ctx.flags.maxShards as string || '5', 10);
     const intentOverride = ctx.flags.intent as string | undefined;
     const jsonOutput = ctx.flags.json === true;
 
@@ -358,9 +358,9 @@ const optimizeCommand: Command = {
     const rootPath = ctx.flags.root as string || './CLAUDE.md';
     const localPath = ctx.flags.local as string | undefined;
     const applyChanges = ctx.flags.apply === true;
-    const contextSize = (ctx.flags['context-size'] as string || 'standard') as 'compact' | 'standard' | 'full';
-    const targetScore = parseInt(ctx.flags['target-score'] as string || '90', 10);
-    const maxIterations = parseInt(ctx.flags['max-iterations'] as string || '5', 10);
+    const contextSize = (ctx.flags.contextSize as string || 'standard') as 'compact' | 'standard' | 'full';
+    const targetScore = parseInt(ctx.flags.targetScore as string || '90', 10);
+    const maxIterations = parseInt(ctx.flags.maxIterations as string || '5', 10);
     const jsonOutput = ctx.flags.json === true;
 
     output.writeln();
@@ -472,10 +472,10 @@ const abTestCommand: Command = {
     { command: 'claude-flow guidance ab-test --json', description: 'Output full report as JSON' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const configAPath = ctx.flags['config-a'] as string | undefined;
-    const configBPath = ctx.flags['config-b'] as string || './CLAUDE.md';
+    const configAPath = ctx.flags.configA as string | undefined;
+    const configBPath = ctx.flags.configB as string || './CLAUDE.md';
     const tasksPath = ctx.flags.tasks as string | undefined;
-    const workDir = ctx.flags['work-dir'] as string | undefined;
+    const workDir = ctx.flags.workDir as string | undefined;
     const jsonOutput = ctx.flags.json === true;
 
     output.writeln();

--- a/src/cli/commands/hive-mind.ts
+++ b/src/cli/commands/hive-mind.ts
@@ -248,14 +248,14 @@ async function spawnClaudeCodeInstance(
       output.writeln(output.dim('Falling back to displaying instructions...'));
     }
 
-    const dryRun = flags.dryRun || flags['dry-run'];
+    const dryRun = flags.dryRun;
 
     if (claudeAvailable && !dryRun) {
       // Build arguments - flags first, then prompt
       const claudeArgs: string[] = [];
 
       // Check for non-interactive mode
-      const isNonInteractive = flags['non-interactive'] || flags.nonInteractive;
+      const isNonInteractive = flags.nonInteractive;
       if (isNonInteractive) {
         claudeArgs.push('-p'); // Print mode
         claudeArgs.push('--output-format', 'stream-json');
@@ -268,9 +268,9 @@ async function spawnClaudeCodeInstance(
       // explicitly set to 'autonomous' via flag. Non-interactive mode is
       // required for headless execution, so --dangerously-skip-permissions
       // is always included — but --allowedTools restricts the blast radius.
-      const noAutoPerms = flags['no-auto-permissions'];
+      const noAutoPerms = flags.noAutoPermissions;
       if (!noAutoPerms) {
-        const permLevel = (flags['permission-level'] as string) ?? 'elevated';
+        const permLevel = (flags.permissionLevel as string) ?? 'elevated';
         const resolved = resolvePermissions(permLevel);
         claudeArgs.push(...resolved.cliArgs);
       }
@@ -446,9 +446,9 @@ const initCommand: Command = {
     const config = {
       topology: topology || 'hierarchical-mesh',
       consensus: consensus || 'byzantine',
-      maxAgents: (ctx.flags.maxAgents ?? ctx.flags['max-agents']) as number || 15,
+      maxAgents: ctx.flags.maxAgents as number || 15,
       persist: ctx.flags.persist as boolean,
-      memoryBackend: (ctx.flags.memoryBackend ?? ctx.flags['memory-backend']) as string || 'hybrid'
+      memoryBackend: ctx.flags.memoryBackend as string || 'hybrid'
     };
 
     output.writeln();
@@ -1092,7 +1092,7 @@ const joinCommand: Command = {
     { name: 'role', short: 'r', description: 'Agent role (worker, specialist, scout)', type: 'string', default: 'worker' }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const agentId = ctx.args[0] || ctx.flags['agent-id'] as string || ctx.flags.agentId as string;
+    const agentId = ctx.args[0] || ctx.flags.agentId as string;
     if (!agentId) {
       output.printError('Agent ID is required. Use --agent-id or -a flag, or provide as argument.');
       return { success: false, exitCode: 1 };
@@ -1112,7 +1112,7 @@ const leaveCommand: Command = {
   description: 'Remove an agent from the hive mind',
   options: [{ name: 'agent-id', short: 'a', description: 'Agent ID to remove', type: 'string' }],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const agentId = ctx.args[0] || ctx.flags['agent-id'] as string || ctx.flags.agentId as string;
+    const agentId = ctx.args[0] || ctx.flags.agentId as string;
     if (!agentId) { output.printError('Agent ID required.'); return { success: false, exitCode: 1 }; }
     try {
       const result = await callMCPTool<{ success: boolean; agentId: string; remainingWorkers: number; error?: string }>('hive-mind_leave', { agentId });

--- a/src/cli/commands/hooks.ts
+++ b/src/cli/commands/hooks.ts
@@ -708,9 +708,9 @@ const pretrainCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const repoPath = ctx.flags.path as string || '.';
     const depth = ctx.flags.depth as string || 'medium';
-    const withEmbeddings = ctx.flags['with-embeddings'] !== false && ctx.flags.withEmbeddings !== false;
-    const embeddingModel = (ctx.flags['embedding-model'] || ctx.flags.embeddingModel || 'all-MiniLM-L6-v2') as string;
-    const fileTypes = (ctx.flags['file-types'] || ctx.flags.fileTypes || 'ts,js,py,md,json') as string;
+    const withEmbeddings = ctx.flags.withEmbeddings !== false;
+    const embeddingModel = (ctx.flags.embeddingModel || 'all-MiniLM-L6-v2') as string;
+    const fileTypes = (ctx.flags.fileTypes || 'ts,js,py,md,json') as string;
 
     output.writeln();
     output.writeln(output.bold('Pretraining Intelligence (4-Step Pipeline + Embeddings)'));
@@ -2415,9 +2415,9 @@ const workerDetectCommand: Command = {
     { command: 'claude-flow hooks worker detect -p "security audit" --auto-dispatch', description: 'Detect and dispatch' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const prompt = ctx.flags['prompt'] as string;
-    const autoDispatch = ctx.flags['auto-dispatch'] as boolean;
-    const minConfidence = parseFloat(ctx.flags['min-confidence'] as string || '0.5');
+    const prompt = ctx.flags.prompt as string;
+    const autoDispatch = ctx.flags.autoDispatch as boolean;
+    const minConfidence = parseFloat(ctx.flags.minConfidence as string || '0.5');
 
     if (!prompt) {
       output.printError('--prompt is required');
@@ -2577,7 +2577,7 @@ const coverageRouteCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const task = ctx.args[0] || ctx.flags.task as string;
     const threshold = ctx.flags.threshold as number || 80;
-    const useNativeBackend = !ctx.flags['no-movector'];
+    const useNativeBackend = !ctx.flags.noMovector;
 
     if (!task) {
       output.printError('Task description is required. Use --task or -t flag.');
@@ -2843,8 +2843,8 @@ const coverageGapsCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const threshold = ctx.flags.threshold as number || 80;
-    const groupByAgent = ctx.flags['group-by-agent'] !== false;
-    const criticalOnly = ctx.flags['critical-only'] as boolean || false;
+    const groupByAgent = ctx.flags.groupByAgent !== false;
+    const criticalOnly = ctx.flags.criticalOnly as boolean || false;
 
     const spinner = output.createSpinner({ text: 'Analyzing project coverage gaps...' });
     spinner.start();
@@ -3411,7 +3411,7 @@ const statuslineCommand: Command = {
     }
 
     // Full colored output
-    const noColor = ctx.flags['no-color'] || ctx.flags.noColor;
+    const noColor = ctx.flags.noColor;
     const c = noColor ? {
       reset: '', bold: '', dim: '', red: '', green: '', yellow: '', blue: '',
       purple: '', cyan: '', brightRed: '', brightGreen: '', brightYellow: '',
@@ -3807,8 +3807,8 @@ const modelRouteCommand: Command = {
       }>('hooks_model-route', {
         task,
         context: ctx.flags.context,
-        preferCost: ctx.flags['prefer-cost'],
-        preferQuality: ctx.flags['prefer-quality'],
+        preferCost: ctx.flags.preferCost,
+        preferQuality: ctx.flags.preferQuality,
       });
 
       if (ctx.flags.format === 'json') {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -33,8 +33,8 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
   const force = ctx.flags.force as boolean;
   const minimal = ctx.flags.minimal as boolean;
   const full = ctx.flags.full as boolean;
-  const skipClaude = ctx.flags['skip-claude'] as boolean;
-  const onlyClaude = ctx.flags['only-claude'] as boolean;
+  const skipClaude = ctx.flags.skipClaude as boolean;
+  const onlyClaude = ctx.flags.onlyClaude as boolean;
   const cwd = ctx.cwd;
 
   // ── MoFlo Project Setup ────────────────────────────────────────────
@@ -179,8 +179,8 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
     }
 
     // Handle --start-all or --start-daemon
-    const startAll = ctx.flags['start-all'] || ctx.flags.startAll;
-    const startDaemon = ctx.flags['start-daemon'] || ctx.flags.startDaemon || startAll;
+    const startAll = ctx.flags.startAll;
+    const startDaemon = ctx.flags.startDaemon || startAll;
 
     if (startDaemon || startAll) {
       output.writeln();
@@ -278,8 +278,8 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
     }
 
     // Handle --with-embeddings
-    const withEmbeddings = ctx.flags['with-embeddings'] || ctx.flags.withEmbeddings;
-    const embeddingModel = (ctx.flags['embedding-model'] || ctx.flags.embeddingModel || 'all-MiniLM-L6-v2') as string;
+    const withEmbeddings = ctx.flags.withEmbeddings;
+    const embeddingModel = (ctx.flags.embeddingModel || 'all-MiniLM-L6-v2') as string;
 
     if (withEmbeddings) {
       output.writeln();
@@ -751,7 +751,7 @@ const upgradeCommand: Command = {
     },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const addMissing = (ctx.flags['add-missing'] || ctx.flags.addMissing) as boolean;
+    const addMissing = ctx.flags.addMissing as boolean;
     const upgradeSettings = (ctx.flags.settings) as boolean;
 
     output.writeln();

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -298,7 +298,7 @@ const searchCommand: Command = {
     const limit = ctx.flags.limit as number || 10;
     const threshold = ctx.flags.threshold as number || 0.3;
     const searchType = ctx.flags.type as string || 'semantic';
-    const buildHnsw = (ctx.flags['build-hnsw'] || ctx.flags.buildHnsw) as boolean;
+    const buildHnsw = ctx.flags.buildHnsw as boolean;
 
     if (!query) {
       output.printError('Query is required. Use --query or -q');
@@ -1832,7 +1832,7 @@ const indexGuidanceCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const forceReindex = ctx.flags.force as boolean;
     const specificFile = ctx.flags.file as string | undefined;
-    const skipEmbeddings = ctx.flags['no-embeddings'] as boolean;
+    const skipEmbeddings = ctx.flags.noEmbeddings as boolean;
     const overlapPercent = (ctx.flags.overlap as number) || DEFAULT_OVERLAP_PERCENT;
     const NAMESPACE = 'guidance';
 
@@ -2448,7 +2448,7 @@ const codeMapCommand: Command = {
     const forceRegen = ctx.flags.force as boolean;
     const verbose = ctx.flags.verbose as boolean;
     const statsOnly = ctx.flags.stats as boolean;
-    const skipEmbeddings = ctx.flags['no-embeddings'] as boolean;
+    const skipEmbeddings = ctx.flags.noEmbeddings as boolean;
     const NAMESPACE = 'code-map';
 
     const fs = await import('fs');
@@ -2797,9 +2797,9 @@ const refreshCommand: Command = {
     { command: 'flo memory refresh --skip-code-map', description: 'Reindex guidance only + vacuum' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const skipGuidance = ctx.flags['skip-guidance'] as boolean;
-    const skipCodeMap = ctx.flags['skip-code-map'] as boolean;
-    const skipCleanup = ctx.flags['skip-cleanup'] as boolean;
+    const skipGuidance = ctx.flags.skipGuidance as boolean;
+    const skipCodeMap = ctx.flags.skipCodeMap as boolean;
+    const skipCleanup = ctx.flags.skipCleanup as boolean;
 
     output.writeln();
     output.writeln(output.bold('MoFlo Memory Refresh'));

--- a/src/cli/commands/neural.ts
+++ b/src/cli/commands/neural.ts
@@ -36,8 +36,8 @@ const trainCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const patternType = ctx.flags.pattern as string || 'coordination';
     const epochs = parseInt(ctx.flags.epochs as string || '50', 10);
-    const learningRate = parseFloat(ctx.flags['learning-rate'] as string || '0.01');
-    const batchSize = parseInt(ctx.flags['batch-size'] as string || '32', 10);
+    const learningRate = parseFloat(ctx.flags.learningRate as string || '0.01');
+    const batchSize = parseInt(ctx.flags.batchSize as string || '32', 10);
     const dim = Math.min(parseInt(ctx.flags.dim as string || '256', 10), 256);
     const useWasm = ctx.flags.wasm !== false;
     const useFlash = ctx.flags.flash !== false;
@@ -942,7 +942,7 @@ const exportCommand: Command = {
     const outputFile = ctx.flags.output as string | undefined;
     const pinToIpfs = ctx.flags.ipfs as boolean;
     const signExport = ctx.flags.sign !== false;
-    const stripPii = ctx.flags['strip-pii'] !== false;
+    const stripPii = ctx.flags.stripPii !== false;
     const customName = ctx.flags.name as string;
 
     output.writeln();

--- a/src/cli/commands/process.ts
+++ b/src/cli/commands/process.ts
@@ -89,8 +89,8 @@ const daemonCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const action = (ctx.flags?.action as string) || 'status';
     const port = (ctx.flags?.port as number) || 3847;
-    const pidFile = (ctx.flags?.['pid-file'] as string) || '.moflo/daemon.pid';
-    const logFile = (ctx.flags?.['log-file'] as string) || '.moflo/daemon.log';
+    const pidFile = (ctx.flags?.pidFile as string) || '.moflo/daemon.pid';
+    const logFile = (ctx.flags?.logFile as string) || '.moflo/daemon.log';
     const detach = ctx.flags?.detach !== false;
 
     // Check existing daemon state from PID file

--- a/src/cli/commands/route.ts
+++ b/src/cli/commands/route.ts
@@ -417,7 +417,7 @@ const feedbackCommand: Command = {
     const taskDescription = ctx.flags.task as string;
     const agentId = ctx.flags.agent as string;
     const reward = ctx.flags.reward as number;
-    const nextTask = ctx.flags['next-task'] as string | undefined;
+    const nextTask = ctx.flags.nextTask as string | undefined;
 
     if (!taskDescription || !agentId) {
       output.printError('Task description and agent are required');

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -212,9 +212,9 @@ const saveCommand: Command = {
       }>('session_save', {
         name: sessionName,
         description,
-        includeMemory: ctx.flags['include-memory'] !== false,
-        includeAgents: ctx.flags['include-agents'] !== false,
-        includeTasks: ctx.flags['include-tasks'] !== false
+        includeMemory: ctx.flags.includeMemory !== false,
+        includeAgents: ctx.flags.includeAgents !== false,
+        includeTasks: ctx.flags.includeTasks !== false
       });
 
       spinner.succeed('Session saved');
@@ -346,9 +346,9 @@ const restoreCommand: Command = {
 
     try {
       // Determine what to restore
-      const restoreMemory = !ctx.flags['agents-only'] && !ctx.flags['tasks-only'];
-      const restoreAgents = !ctx.flags['memory-only'] && !ctx.flags['tasks-only'];
-      const restoreTasks = !ctx.flags['memory-only'] && !ctx.flags['agents-only'];
+      const restoreMemory = !ctx.flags.agentsOnly && !ctx.flags.tasksOnly;
+      const restoreAgents = !ctx.flags.memoryOnly && !ctx.flags.tasksOnly;
+      const restoreTasks = !ctx.flags.memoryOnly && !ctx.flags.agentsOnly;
 
       const result = await callMCPTool<{
         sessionId: string;
@@ -548,7 +548,7 @@ const exportCommand: Command = {
         };
       }>('session_export', {
         sessionId,
-        includeMemory: ctx.flags['include-memory'] !== false
+        includeMemory: ctx.flags.includeMemory !== false
       });
 
       // Format output

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -89,7 +89,7 @@ function loadConfig(cwd: string): Record<string, unknown> | null {
 const startAction = async (ctx: CommandContext): Promise<CommandResult> => {
   const daemon = ctx.flags.daemon as boolean;
   const topology = (ctx.flags.topology as string) || DEFAULT_TOPOLOGY;
-  const skipMcp = ctx.flags['skip-mcp'] as boolean;
+  const skipMcp = ctx.flags.skipMcp as boolean;
   const cwd = ctx.cwd;
 
   // Check initialization

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -332,7 +332,7 @@ function formatHealth(health: string): string {
 const statusAction = async (ctx: CommandContext): Promise<CommandResult> => {
   const watch = ctx.flags.watch as boolean;
   const interval = (ctx.flags.interval as number) || DEFAULT_WATCH_INTERVAL / 1000;
-  const healthCheck = ctx.flags['health-check'] as boolean;
+  const healthCheck = ctx.flags.healthCheck as boolean;
   const cwd = ctx.cwd;
 
   // Check initialization

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -694,7 +694,7 @@ const retryCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const taskId = ctx.args[0];
-    const resetState = ctx.flags['reset-state'] as boolean;
+    const resetState = ctx.flags.resetState as boolean;
 
     if (!taskId) {
       output.printError('Task ID is required');

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -150,7 +150,7 @@ const allCommand: Command = {
         autoUpdate: {
           patch: true,
           minor: true,
-          major: flags['include-major'] as boolean || false,
+          major: flags.includeMajor as boolean || false,
         },
       };
 
@@ -175,19 +175,19 @@ const allCommand: Command = {
       const updateResults = await executeMultipleUpdates(
         results,
         installedPackages,
-        flags['dry-run'] as boolean
+        flags.dryRun as boolean
       );
 
       const successful = updateResults.filter((r) => r.success);
       const failed = updateResults.filter((r) => !r.success);
 
       output.writeln();
-      output.writeln(output.highlight(flags['dry-run'] ? '═══ Dry Run - Would Update ═══' : '═══ Update Results ═══'));
+      output.writeln(output.highlight(flags.dryRun ? '═══ Dry Run - Would Update ═══' : '═══ Update Results ═══'));
       output.writeln();
 
       if (successful.length > 0) {
         output.printSuccess(
-          `${successful.length} package(s) ${flags['dry-run'] ? 'would be ' : ''}updated:`
+          `${successful.length} package(s) ${flags.dryRun ? 'would be ' : ''}updated:`
         );
         for (const r of successful) {
           output.writeln(`  ${output.success('✓')} ${r.package}@${r.version}`);

--- a/tests/epic-command.test.ts
+++ b/tests/epic-command.test.ts
@@ -66,7 +66,7 @@ describe('epic command structure', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const result = await epicCommand.action({
       args: ['run', '42'],
-      flags: { 'no-merge': true, strategy: 'auto-merge' },
+      flags: { noMerge: true, strategy: 'auto-merge' },
     });
     expect(result.success).toBe(false);
     expect(result.message).toContain('--no-merge cannot be combined with --strategy auto-merge');


### PR DESCRIPTION
## Summary

The CLI parser (`src/cli/parser.ts:283-286`) normalises every flag name from kebab-case to camelCase before storing in `ctx.flags`. ~93 sites across 21 command files were reading `ctx.flags['kebab-case']` instead of `ctx.flags.camelCase` — the dashed lookup is always `undefined`, so the flag silently does nothing. Hit during epic #781 (PR #786) when `--allow-warn` silently disabled the entire smoke allowlist on every CI run.

This change makes the bug class structurally extinct.

## Changes

- **Mass migration** — every `ctx.flags['<kebab>']` and bare `flags['<kebab>']` read converted to camelCase across 21 files (~93 sites). Hedge expressions like `(flags['kebab'] || flags.camelCase)` collapse to a single camelCase read since the kebab branch was always undefined.
- **ESLint rule** — `KEBAB_FLAG_READ_SELECTORS` in `.eslintrc.cjs` bans computed `flags['<kebab>']` reads via `no-restricted-syntax`, added to all three rule blocks so it applies repo-wide. Caught 2 sites in `process.ts` I missed in the initial sweep.
- **Regression tests** — `parser.test.ts` asserts both `flags.someLongFlag === 'yes'` AND `flags['some-long-flag'] === undefined` for the same parse, plus a `--no-<kebab>` parsing test.
- **Test fixes** — `p1-commands.test.ts` and `tests/epic-command.test.ts` were silently passing kebab keys the parser would never produce; updated to camelCase. The migration revealed they were paired with the bug.

## Out of scope

The deeper `--no-X` parser bug remains: parser strips `no-` and stores `flags.X = false`, so `noDashboard` / `noBackup` / `noMovector` / `noColor` / `noEmbeddings` / `noMerge` / `noAutoPermissions` reads are still broken the same way the kebab reads were. Mechanical migration is faithful to the original buggy-but-stable behavior; semantic fix tracked separately.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Full `npm test` — 7,435 passed, 0 failed
- [x] New parser regression tests assert kebab keys are NEVER stored

Closes #787