### PR TITLE
chore(788): sync .claude/scripts/ mirror to moflo@4.9.0-rc.12

### DIFF
--- a/.claude/scripts/lib/moflo-paths.mjs
+++ b/.claude/scripts/lib/moflo-paths.mjs
@@ -21,6 +21,7 @@ import {
   rmdirSync,
   statSync,
   unlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 
@@ -74,7 +75,9 @@ export function memoryDbCandidatePaths(projectRoot) {
  * One-time migration of `.claude-flow/` → `.moflo/`. Idempotent — safe to call
  * on every session start. See moflo-paths.ts for the full contract.
  *
- * Returns `{ migrated, reason? }`.
+ * Returns `{ migrated, reason?, movedCount?, collisions? }`. The launcher
+ * uses `movedCount` for the "migrated N files" message and `collisions` to
+ * warn about subdirs (e.g. models/) that exist in both locations.
  */
 export function migrateClaudeFlowToMoflo(projectRoot) {
   const legacy = legacyClaudeFlowDir(projectRoot);
@@ -83,8 +86,11 @@ export function migrateClaudeFlowToMoflo(projectRoot) {
   if (!existsSync(legacy)) return { migrated: false, reason: 'no-legacy' };
 
   if (!existsSync(target)) {
+    let movedCount = 0;
+    try { movedCount = readdirSync(legacy).length; } catch { /* count is cosmetic */ }
     renameSync(legacy, target);
-    return { migrated: true };
+    rewriteEmbeddingsModelPath(projectRoot);
+    return { migrated: true, movedCount };
   }
 
   let entries;
@@ -95,12 +101,18 @@ export function migrateClaudeFlowToMoflo(projectRoot) {
   }
 
   let moved = 0;
+  let modelsMoved = false;
+  const collisions = [];
   for (const name of entries) {
     const dst = join(target, name);
-    if (existsSync(dst)) continue;
+    if (existsSync(dst)) {
+      collisions.push(name);
+      continue;
+    }
     try {
       renameSync(join(legacy, name), dst);
       moved++;
+      if (name === 'models') modelsMoved = true;
     } catch {
       // Best-effort — single failed move shouldn't abort the rest.
     }
@@ -112,7 +124,44 @@ export function migrateClaudeFlowToMoflo(projectRoot) {
     // Non-fatal — leftover legacy dir means migration runs next time.
   }
 
-  return moved > 0 ? { migrated: true } : { migrated: false, reason: 'merged-nothing' };
+  if (modelsMoved) rewriteEmbeddingsModelPath(projectRoot);
+
+  if (moved === 0) {
+    return { migrated: false, reason: 'merged-nothing', movedCount: 0, collisions };
+  }
+  return { migrated: true, movedCount: moved, collisions };
+}
+
+/**
+ * Rewrite `.moflo/embeddings.json:modelPath` if it still references the
+ * legacy `.claude-flow/` location (#735). Best-effort: file-not-present,
+ * malformed JSON, missing field, or already-correct path → silent no-op.
+ * Mirrors the TS twin in src/cli/services/moflo-paths.ts. Uses tmp+rename
+ * so SIGINT mid-flush can't leave embeddings.json truncated.
+ */
+export function rewriteEmbeddingsModelPath(projectRoot) {
+  const cfgPath = join(projectRoot, MOFLO_DIR, 'embeddings.json');
+
+  let raw;
+  try { raw = readFileSync(cfgPath, 'utf8'); } catch { return false; }
+
+  let cfg;
+  try { cfg = JSON.parse(raw); } catch { return false; }
+
+  if (typeof cfg.modelPath !== 'string') return false;
+  if (!cfg.modelPath.includes(LEGACY_CLAUDE_FLOW_DIR)) return false;
+
+  cfg.modelPath = cfg.modelPath.split(LEGACY_CLAUDE_FLOW_DIR).join(MOFLO_DIR);
+
+  const tmpPath = `${cfgPath}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 8)}`;
+  try {
+    writeFileSync(tmpPath, JSON.stringify(cfg, null, 2));
+    renameSync(tmpPath, cfgPath);
+    return true;
+  } catch {
+    try { unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
+    return false;
+  }
 }
 
 const SQLITE_MAGIC_HEADER = Buffer.from('SQLite format 3\0', 'utf8');

--- a/.claude/scripts/migrations/knowledge-purge.mjs
+++ b/.claude/scripts/migrations/knowledge-purge.mjs
@@ -1,0 +1,107 @@
+/**
+ * Migration: hard-delete every legacy `knowledge`-namespace row whose
+ * counterpart now exists in `learnings` (tagged `migratedFrom:knowledge`).
+ *
+ * Runs AFTER `knowledge-to-learnings` (manifest gate). For each `knowledge`
+ * row (active or archived):
+ *   - counterpart present  → hard-delete
+ *   - counterpart missing  → skip with stderr warning (defensive — should
+ *     not happen post-`knowledge-to-learnings`; existing consumers stuck on
+ *     the active-only v1 will see this for archived rows the original missed)
+ *
+ * The deprecated-alias soft-redirect at `storeEntry` stays — any caller still
+ * passing `namespace: 'knowledge'` writes lands transparently in `learnings`.
+ *
+ * @module bin/migrations/knowledge-purge
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { mofloResolveURL } from '../lib/moflo-resolve.mjs';
+import { memoryDbPath } from '../lib/moflo-paths.mjs';
+import { hasMigrationRun } from '../lib/migrations.mjs';
+import { MIGRATED_FROM_KNOWLEDGE } from './lib/markers.mjs';
+
+export const name = 'knowledge-purge';
+// Explicit ordering puts this after `knowledge-to-learnings` (default order=0)
+// in the runner's queue so a single session-start completes the pipeline. The
+// manifest gate inside `run()` is the cross-session safety net: if the
+// consolidation copy errored mid-run, the manifest is unstamped and we defer
+// the purge until a future session lands the copy successfully.
+export const order = 10;
+
+/**
+ * @param {string} projectRoot
+ * @returns {Promise<{purged:number, skipped:number}>}
+ */
+export async function run(projectRoot) {
+  // Manifest gate: only run after the consolidation copy completed. Throwing
+  // (rather than returning {skipped:true}) keeps the manifest unstamped so
+  // we retry next session — the runner records done only on resolved returns.
+  if (!hasMigrationRun(projectRoot, 'knowledge-to-learnings')) {
+    throw new Error('knowledge-to-learnings has not yet completed; will retry next session');
+  }
+
+  const dbPath = memoryDbPath(projectRoot);
+  if (!existsSync(dbPath)) return { purged: 0, skipped: 0 };
+
+  // Lazy-load sql.js — keeps the manifest-stamped no-op path off the WASM
+  // init cost (~30ms cold).
+  const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(readFileSync(dbPath));
+
+  const knowledgeStmt = db.prepare(
+    `SELECT id, key, status FROM memory_entries
+     WHERE namespace = 'knowledge' AND status IN ('active','archived')`,
+  );
+  const knowledgeRows = [];
+  while (knowledgeStmt.step()) knowledgeRows.push(knowledgeStmt.getAsObject());
+  knowledgeStmt.free();
+
+  if (knowledgeRows.length === 0) {
+    db.close();
+    return { purged: 0, skipped: 0 };
+  }
+
+  // tags is a JSON-encoded array string — LIKE on the substring is enough to
+  // confirm the migratedFrom:knowledge marker without parsing every row. The
+  // marker is a JS-defined constant, not user input, so inlining via template
+  // literal avoids sql.js's two-step prepare+bind for a single-shot read.
+  const counterpartStmt = db.prepare(
+    `SELECT key FROM memory_entries
+     WHERE namespace = 'learnings'
+       AND status IN ('active','archived')
+       AND tags LIKE '%${MIGRATED_FROM_KNOWLEDGE}%'`,
+  );
+  const migratedKeys = new Set();
+  while (counterpartStmt.step()) migratedKeys.add(String(counterpartStmt.getAsObject().key));
+  counterpartStmt.free();
+
+  const deleteStmt = db.prepare(`DELETE FROM memory_entries WHERE id = ?`);
+
+  let purged = 0;
+  let skipped = 0;
+  try {
+    for (const row of knowledgeRows) {
+      const key = String(row.key);
+      if (!migratedKeys.has(key)) {
+        skipped++;
+        // One-line stderr warning per ticket — defensive, should not fire on
+        // a healthy DB. archived-row orphans on consumers stuck on v1 surface
+        // here so the user has a paper trail.
+        process.stderr.write(
+          `[migrations]   knowledge-purge: skipping orphan key="${key}" status=${row.status} (no ${MIGRATED_FROM_KNOWLEDGE} counterpart)\n`,
+        );
+        continue;
+      }
+      deleteStmt.run([row.id]);
+      purged++;
+    }
+  } finally {
+    deleteStmt.free();
+  }
+
+  if (purged > 0) writeFileSync(dbPath, Buffer.from(db.export()));
+  db.close();
+  return { purged, skipped };
+}

--- a/.claude/scripts/migrations/knowledge-to-learnings.mjs
+++ b/.claude/scripts/migrations/knowledge-to-learnings.mjs
@@ -1,10 +1,11 @@
 /**
- * Migration: copy every active row from the deprecated `knowledge` namespace
- * into `learnings`, tagging with `source:user`, `locked`, `migratedFrom:knowledge`
- * so future decay/prune leaves them alone.
+ * Migration: copy every row (active + archived) from the deprecated `knowledge`
+ * namespace into `learnings`, tagging with `source:user`, `locked`,
+ * `migratedFrom:knowledge` so future decay/prune leaves them alone. Archived
+ * rows preserve their `status='archived'` on the learnings side.
  *
- * Original `knowledge` rows are preserved (the standing rule against renaming
- * core namespaces forbids deletion); they're just no longer the canonical home.
+ * Source `knowledge` rows are preserved here; the follow-on `knowledge-purge`
+ * migration hard-deletes them once their counterpart is confirmed.
  *
  * @module bin/migrations/knowledge-to-learnings
  */
@@ -14,8 +15,7 @@ import { writeFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { mofloResolveURL } from '../lib/moflo-resolve.mjs';
 import { memoryDbPath } from '../lib/moflo-paths.mjs';
-
-const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
+import { MIGRATED_FROM_KNOWLEDGE } from './lib/markers.mjs';
 
 export const name = 'knowledge-to-learnings';
 
@@ -24,7 +24,7 @@ function generateId() {
 }
 
 function mergeTags(originalJson) {
-  const additions = ['source:user', 'locked', 'migratedFrom:knowledge'];
+  const additions = ['source:user', 'locked', MIGRATED_FROM_KNOWLEDGE];
   let original = [];
   try {
     const parsed = JSON.parse(originalJson || '[]');
@@ -38,20 +38,25 @@ function mergeTags(originalJson) {
 /**
  * @param {string} projectRoot
  * @returns {Promise<{rowsMigrated:number, rowsSkipped:number}>}
+ *   `rowsMigrated` counts both active and archived inserts. `rowsSkipped`
+ *   counts (key, status) pairs that already had a learnings counterpart.
  */
 export async function run(projectRoot) {
   const dbPath = memoryDbPath(projectRoot);
   if (!existsSync(dbPath)) return { rowsMigrated: 0, rowsSkipped: 0 };
 
+  // Lazy-load sql.js — top-level await would pay ~30ms WASM init even on the
+  // no-op fast-path where the manifest already records this migration as done.
+  const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
   const SQL = await initSqlJs();
   const db = new SQL.Database(readFileSync(dbPath));
 
   const sourceStmt = db.prepare(
     `SELECT id, key, content, type, metadata, tags, embedding, embedding_dimensions,
             embedding_model, owner_id, created_at, updated_at, expires_at,
-            last_accessed_at, access_count
+            last_accessed_at, access_count, status
      FROM memory_entries
-     WHERE namespace = 'knowledge' AND status = 'active'`,
+     WHERE namespace = 'knowledge' AND status IN ('active','archived')`,
   );
   const rows = [];
   while (sourceStmt.step()) rows.push(sourceStmt.getAsObject());
@@ -63,10 +68,15 @@ export async function run(projectRoot) {
   }
 
   const existingStmt = db.prepare(
-    `SELECT key FROM memory_entries WHERE namespace = 'learnings' AND status = 'active'`,
+    `SELECT key, status FROM memory_entries WHERE namespace = 'learnings' AND status IN ('active','archived')`,
   );
-  const existingKeys = new Set();
-  while (existingStmt.step()) existingKeys.add(String(existingStmt.getAsObject().key));
+  // key|status pairs — a knowledge row's archived counterpart shouldn't block
+  // copying its active version (and vice-versa) so we key by both fields.
+  const existingPairs = new Set();
+  while (existingStmt.step()) {
+    const r = existingStmt.getAsObject();
+    existingPairs.add(`${String(r.key)}|${String(r.status)}`);
+  }
   existingStmt.free();
 
   const insertStmt = db.prepare(`
@@ -74,7 +84,7 @@ export async function run(projectRoot) {
       (id, key, namespace, content, type, embedding, embedding_model, embedding_dimensions,
        tags, metadata, owner_id, created_at, updated_at, expires_at,
        last_accessed_at, access_count, status)
-    VALUES (?, ?, 'learnings', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+    VALUES (?, ?, 'learnings', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   let migrated = 0;
@@ -82,7 +92,8 @@ export async function run(projectRoot) {
   try {
     for (const row of rows) {
       const key = String(row.key);
-      if (existingKeys.has(key)) { skipped++; continue; }
+      const status = String(row.status ?? 'active');
+      if (existingPairs.has(`${key}|${status}`)) { skipped++; continue; }
 
       insertStmt.run([
         generateId(),
@@ -100,6 +111,7 @@ export async function run(projectRoot) {
         row.expires_at ?? null,
         row.last_accessed_at ?? null,
         row.access_count ?? 0,
+        status,
       ]);
       migrated++;
     }

--- a/.claude/scripts/migrations/lib/markers.mjs
+++ b/.claude/scripts/migrations/lib/markers.mjs
@@ -1,0 +1,11 @@
+/**
+ * Shared tag markers used across the knowledge → learnings migration pipeline.
+ *
+ * @module bin/migrations/lib/markers
+ */
+
+/** Tag stamped on every learnings row that was migrated from the deprecated
+ *  knowledge namespace. The purge migration uses this to confirm a counterpart
+ *  exists before hard-deleting the source row, so a typo here silently breaks
+ *  the entire pipeline. */
+export const MIGRATED_FROM_KNOWLEDGE = 'migratedFrom:knowledge';

--- a/.claude/scripts/run-migrations.mjs
+++ b/.claude/scripts/run-migrations.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Migration runner — consults the per-project manifest and runs only
- * migrations that haven't already been recorded. Fast-paths to a no-op (~5ms)
- * when nothing is unmet, so it's safe to fire on every session start.
+ * migrations that haven't already been recorded. Fast-paths to a no-op when
+ * nothing is unmet (cost = node startup + ESM graph; sub-100ms on warm fs),
+ * so it's safe to fire on every session start.
  *
  * Migrations live under `bin/migrations/` and each module exports:
  *   export const name = '<unique-id>';
@@ -77,6 +78,16 @@ async function loadMigrations() {
       debug(`SKIP ${f} — load error: ${err.message}`);
     }
   }
+  // Stable order: by `order` (default 0) ascending, then by `name`. A
+  // migration that depends on another should `export const order = N` with N
+  // larger than the dep's. readdirSync is filesystem-dependent across OSes,
+  // so explicit ordering is the only portable way to express dependencies.
+  loaded.sort((a, b) => {
+    const ao = typeof a.order === 'number' ? a.order : 0;
+    const bo = typeof b.order === 'number' ? b.order : 0;
+    if (ao !== bo) return ao - bo;
+    return a.name.localeCompare(b.name);
+  });
   return loaded;
 }
 

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -7,7 +7,7 @@
  * Invoked by: node .claude/scripts/session-start-launcher.mjs
  */
 
-import { spawn } from 'child_process';
+import { spawn, execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -106,16 +106,32 @@ try {
   unlinkSync(join(mofloDir(projectRoot), 'upgrade-notice.json'));
 } catch { /* non-fatal — file usually doesn't exist */ }
 
-// ── 0. LEGACY state migration (#699) ─────────────────────────────────────────
+// ── 0. LEGACY state migration (#699, #735) ──────────────────────────────────
 // Consumers upgrading from older moflo builds (inherited from upstream Ruflo)
 // get a one-time auto-migration of LEGACY `.claude-flow/` → `.moflo/` so claim
-// files, daemon state, metrics, and the version stamp survive the rename.
+// files, models cache, metrics, and the version stamp survive the rename.
 // The migration helper is idempotent — see bin/lib/moflo-paths.mjs for the
-// algorithm. LEGACY: no-ops once `.claude-flow/` is gone.
+// algorithm.
+//
+// Staged removal contract (#735):
+//   1. THIS release ships Phase 1 (writers redirected to `.moflo/`) + Phase 2 // LEGACY
+//      (this migration call moves stragglers + warns on collisions).
+//   2. The release AFTER Phase 1 is steady-state should hard-delete any
+//      remaining empty `.claude-flow/` directory — until then, the helper // LEGACY
+//      drops the dir naturally once everything's been moved.
+// LEGACY: every emit below stops firing once `.claude-flow/` is gone.
 try {
   const cfMigration = migrateClaudeFlowToMoflo(projectRoot);
   if (cfMigration?.migrated) {
-    emitMutation('migrated runtime state to .moflo/', 'from legacy .claude-flow/'); // LEGACY
+    const count = cfMigration.movedCount ?? 0;
+    emitMutation(`migrated ${plural(count, 'entry')} from legacy .claude-flow/`); // LEGACY
+  }
+  // Surface collisions so users notice that BOTH locations now hold the same
+  // subdir name (most often `models/` after a partial pre-#735 migration).
+  // Manual cleanup is needed — moflo refuses to silently choose.
+  if ((cfMigration?.collisions?.length ?? 0) > 0) {
+    const collisionMsg = 'kept legacy .claude-flow/ entries to avoid clobbering .moflo/'; // LEGACY
+    emitMutation(collisionMsg, `collisions: ${cfMigration.collisions.join(', ')}`);
   }
 } catch {
   // Non-fatal — anything left behind by the migration just means it runs
@@ -355,15 +371,27 @@ try {
           }
         }
 
-        // Sync migrations/ subdirectory. run-migrations.mjs imports each
-        // module by directory walk — without this the runner finds no
-        // migrations on a script-synced consumer.
+        // Sync migrations/ subdirectory recursively. The migration scripts
+        // import shared helpers from `./lib/markers.mjs` — a flat readdir
+        // dropped that subdir, leaving consumers with broken imports (#777).
         const migrationsSrcDir = resolve(binDir, 'migrations');
         const migrationsDestDir = resolve(scriptsDir, 'migrations');
         if (existsSync(migrationsSrcDir)) {
           if (!existsSync(migrationsDestDir)) mkdirSync(migrationsDestDir, { recursive: true });
-          for (const file of readdirSync(migrationsSrcDir)) {
-            syncFile(resolve(migrationsSrcDir, file), resolve(migrationsDestDir, file), `.claude/scripts/migrations/${file}`);
+          let migrationEntries;
+          try {
+            migrationEntries = readdirSync(migrationsSrcDir, { recursive: true, withFileTypes: true });
+          } catch {
+            migrationEntries = [];
+          }
+          for (const entry of migrationEntries) {
+            if (!entry.isFile()) continue;
+            const parent = entry.parentPath || entry.path || migrationsSrcDir;
+            const absSrc = resolve(parent, entry.name);
+            const rel = absSrc.slice(migrationsSrcDir.length + 1).split(/[\\/]/).join('/');
+            const absDest = resolve(migrationsDestDir, rel);
+            try { mkdirSync(dirname(absDest), { recursive: true }); } catch { /* non-fatal */ }
+            syncFile(absSrc, absDest, `.claude/scripts/migrations/${rel}`);
           }
         }
       }
@@ -864,16 +892,70 @@ if (existsSync(hooksScript)) {
 }
 
 // Migration runner — consults `.moflo/migrations.json` and runs only
-// migrations that haven't been recorded. Single spawn, fast-paths to a
-// no-op when the manifest is current, so safe to fire every session.
+// migrations that haven't been recorded. Fast-paths to a no-op when the
+// manifest is current; the runner module loads with lazy sql.js init in
+// each migration, so a stamped session pays only node startup + ESM graph.
 //
 // Prefer the npm-package path so first-install consumers run unmet
 // migrations without waiting for a script-sync round-trip.
+//
+// Run synchronously (capture stdout) so each completed migration surfaces
+// through emitMutation — Claude's session-start hook captures launcher
+// stdout and that's the only channel that reaches the user.
 const runMigrationsPkg = resolve(projectRoot, 'node_modules/moflo/bin/run-migrations.mjs');
 const runMigrationsMirror = resolve(projectRoot, '.claude/scripts/run-migrations.mjs');
 const runMigrations = existsSync(runMigrationsPkg) ? runMigrationsPkg : runMigrationsMirror;
 if (existsSync(runMigrations)) {
-  fireAndForget('node', [runMigrations], 'migration runner');
+  runMigrationsAndAnnounce(runMigrations);
+}
+
+function runMigrationsAndAnnounce(runnerPath) {
+  let raw;
+  try {
+    raw = execFileSync('node', [runnerPath], {
+      cwd: projectRoot,
+      timeout: 30_000,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+  } catch (err) {
+    // Migrations are best-effort — a failure here must never block session
+    // start. But silent swallowing hides hangs (30s timeout) and corrupted
+    // DBs from the user, so leave a stderr crumb.
+    process.stderr.write(`moflo: migration runner failed (${err.code || err.message}); will retry next session\n`);
+    return;
+  }
+
+  const labels = {
+    'knowledge-to-learnings': 'consolidated knowledge → learnings',
+    'knowledge-purge': 'removed legacy knowledge namespace rows',
+  };
+
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\[migrations\]\s+([\w-]+):\s+done\s+in\s+\d+ms\s*(.*)$/);
+    if (!m) continue;
+    const migrationName = m[1];
+    let parsed = null;
+    try { parsed = m[2] ? JSON.parse(m[2]) : null; } catch { parsed = null; }
+
+    // Silent fast-path: don't announce zero-work runs (no point telling the
+    // user the launcher did nothing). If every numeric detail field is 0,
+    // skip the emit. Stamped migrations don't even reach this loop because
+    // the runner short-circuits via the manifest.
+    if (parsed) {
+      const nums = Object.values(parsed).filter((v) => typeof v === 'number');
+      if (nums.length > 0 && nums.every((v) => v === 0)) continue;
+    }
+
+    let detail = '';
+    if (parsed) {
+      if (typeof parsed.purged === 'number') detail = `${parsed.purged} ${parsed.purged === 1 ? 'row' : 'rows'}`;
+      else if (typeof parsed.rowsMigrated === 'number') detail = `${parsed.rowsMigrated} ${parsed.rowsMigrated === 1 ? 'entry' : 'entries'}`;
+    }
+
+    const label = labels[migrationName] || `migration ${migrationName}`;
+    emitMutation(label, detail);
+  }
 }
 
 // Patches are now baked into moflo@4.0.0 source — no runtime patching needed.


### PR DESCRIPTION
## Summary

- Closes #788. The 5 modified/untracked files in `.claude/scripts/` are byte-identical mirrors of `bin/` source already shipped in moflo@4.9.0-rc.12 (commit `f7a92f5fa feat(memory): consolidate knowledge → learnings + add migration runner`). The session-start launcher synced them on a previous boot but git never tracked them. Commit them so the next `/publish` runs on a clean tree.
- Adds the missing `.claude/scripts/migrations/lib/markers.mjs` mirror. The recursive sync logic from #777 only fires on version-stamp change or manifest drift, so the marker stays absent on stable installs even though the npm tarball ships it under `bin/migrations/lib/markers.mjs`.

## Why this is a no-op for runtime

- `bin/` source is unchanged.
- `node_modules/moflo/bin/run-migrations.mjs` is the preferred entry point and already had this content; the `.claude/scripts/` mirror is the fallback path only used if the npm install is gone.
- `.moflo/migrations.json` confirms both migrations have already run (rc.8) — no behavior change from this PR.

## Test plan
- [x] `npx eslint .claude/scripts/ --ext .mjs,.cjs --max-warnings 0` → clean
- [x] `npx vitest run knowledge-purge-migration moflo-paths-migration` → 33 passed
- [x] `diff bin/* .claude/scripts/*` for all 6 files → all empty (byte-identical)
- [x] `node .claude/scripts/run-migrations.mjs` → no-op (manifest already stamped)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)