### PR TITLE
refactor(789): migrate ~170 inline error-stringify sites to errorDetail()

### DIFF
--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 import { writeFile } from 'fs/promises';
 import { resolve } from 'path';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Dynamic import for AST analyzer
 async function getASTAnalyzer() {
@@ -646,7 +647,7 @@ const astCommand: Command = {
       return { success: true, data: { files: results, totals } };
     } catch (error) {
       spinner.stop();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       output.printError(`AST analysis failed: ${message}`);
       return { success: false, exitCode: 1 };
     }
@@ -825,7 +826,7 @@ const complexityAstCommand: Command = {
       return { success: true, data: { files: results, flaggedCount } };
     } catch (error) {
       spinner.stop();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       output.printError(`Complexity analysis failed: ${message}`);
       return { success: false, exitCode: 1 };
     }
@@ -990,7 +991,7 @@ const symbolsCommand: Command = {
       return { success: true, data: symbols };
     } catch (error) {
       spinner.stop();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       output.printError(`Symbol extraction failed: ${message}`);
       return { success: false, exitCode: 1 };
     }
@@ -1152,7 +1153,7 @@ const importsCommand: Command = {
       return { success: true, data: { imports: sortedImports } };
     } catch (error) {
       spinner.stop();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       output.printError(`Import analysis failed: ${message}`);
       return { success: false, exitCode: 1 };
     }
@@ -1491,7 +1492,7 @@ const boundariesCommand: Command = {
       return { success: true, data: result };
     } catch (error) {
       spinner.stop();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       output.printError(`Analysis failed: ${message}`);
       return { success: false, exitCode: 1 };
     }
@@ -1646,7 +1647,7 @@ const modulesCommand: Command = {
       return { success: true, data: result };
     } catch (error) {
       spinner.stop();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       output.printError(`Analysis failed: ${message}`);
       return { success: false, exitCode: 1 };
     }
@@ -1845,7 +1846,7 @@ const dependenciesCommand: Command = {
       return { success: true };
     } catch (error) {
       spinner.stop();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       output.printError(`Analysis failed: ${message}`);
       return { success: false, exitCode: 1 };
     }
@@ -1983,7 +1984,7 @@ const circularCommand: Command = {
       return { success: true, data: { cycles: filtered } };
     } catch (error) {
       spinner.stop();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       output.printError(`Analysis failed: ${message}`);
       return { success: false, exitCode: 1 };
     }

--- a/src/cli/commands/appliance-advanced.ts
+++ b/src/cli/commands/appliance-advanced.ts
@@ -5,16 +5,13 @@
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 function fmtSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
-function errMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 const fail = (msg: string, detail?: string): CommandResult => {
@@ -93,7 +90,7 @@ export const signCommand: Command = {
       output.printInfo(`Signature:   ${meta.signature.slice(0, 32)}...`);
       return { success: true, data: meta };
     } catch (err) {
-      return fail('Signing failed', errMsg(err));
+      return fail('Signing failed', errorDetail(err));
     }
   },
 };
@@ -131,7 +128,7 @@ export const publishCommand: Command = {
       output.printInfo(`Gateway: ${result.gatewayUrl}`);
       return { success: true, data: result };
     } catch (err) {
-      return fail('Publishing failed', errMsg(err));
+      return fail('Publishing failed', errorDetail(err));
     }
   },
 };
@@ -213,7 +210,7 @@ export const updateAppCommand: Command = {
       }
       return { success: result.success, exitCode: result.success ? 0 : 1, data: result };
     } catch (err) {
-      return fail('Update failed', errMsg(err));
+      return fail('Update failed', errorDetail(err));
     }
   },
 };

--- a/src/cli/commands/appliance.ts
+++ b/src/cli/commands/appliance.ts
@@ -6,6 +6,7 @@
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { signCommand, publishCommand, updateAppCommand } from './appliance-advanced.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 interface RvfaSection {
   id: string;
@@ -30,10 +31,6 @@ function fmtSize(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
-function errMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 const fail = (msg: string, detail?: string): CommandResult => {
@@ -137,7 +134,7 @@ const buildCommand: Command = {
       output.printInfo(`Total size: ${output.bold(fmtSize(result.totalSize))}  Duration: ${duration}s`);
       return { success: true, data: result };
     } catch (err) {
-      return fail('Build failed', errMsg(err));
+      return fail('Build failed', errorDetail(err));
     }
   },
 };
@@ -211,7 +208,7 @@ const inspectCommand: Command = {
       }
       return { success: true, data: hdr };
     } catch (err) {
-      return fail('Failed to inspect appliance', errMsg(err));
+      return fail('Failed to inspect appliance', errorDetail(err));
     }
   },
 };
@@ -279,7 +276,7 @@ const verifyCommand: Command = {
            : output.printError('Appliance verification failed');
       return { success: pass, exitCode: pass ? 0 : 1 };
     } catch (err) {
-      return fail('Verification failed', errMsg(err));
+      return fail('Verification failed', errorDetail(err));
     }
   },
 };
@@ -345,7 +342,7 @@ const extractCommand: Command = {
       }
       return { success: true };
     } catch (err) {
-      return fail('Extraction failed', errMsg(err));
+      return fail('Extraction failed', errorDetail(err));
     }
   },
 };
@@ -393,7 +390,7 @@ const runCommand: Command = {
       if (result.pid) output.printInfo(`PID: ${result.pid}`);
       return { success: true, data: result };
     } catch (err) {
-      return fail('Boot failed', errMsg(err));
+      return fail('Boot failed', errorDetail(err));
     }
   },
 };

--- a/src/cli/commands/benchmark.ts
+++ b/src/cli/commands/benchmark.ts
@@ -9,6 +9,7 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ============================================================================
 // Pretrain Benchmark Subcommand
@@ -70,7 +71,7 @@ const pretrainCommand: Command = {
           : `${results.results.filter(r => r.targetMet).length}/${results.results.length} targets met`,
       };
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err);
+      const errorMsg = errorDetail(err);
       output.writeln(output.error(`Benchmark failed: ${errorMsg}`));
       return {
         success: false,
@@ -248,7 +249,7 @@ const neuralCommand: Command = {
       };
     } catch (err) {
       spinner.stop();
-      const errorMsg = err instanceof Error ? err.message : String(err);
+      const errorMsg = errorDetail(err);
       output.writeln(output.error(`Neural benchmark failed: ${errorMsg}`));
       return {
         success: false,
@@ -376,7 +377,7 @@ const memoryCommand: Command = {
       return { success: true, message: 'Memory benchmarks complete' };
     } catch (err) {
       spinner.stop();
-      const errorMsg = err instanceof Error ? err.message : String(err);
+      const errorMsg = errorDetail(err);
       output.writeln(output.error(`Memory benchmark failed: ${errorMsg}`));
       return {
         success: false,

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -17,6 +17,7 @@ import type { SchedulerEvent } from '../spells/scheduler/scheduler.js';
 import { spawn, execFile, execFileSync } from 'child_process';
 import { join, resolve, isAbsolute } from 'path';
 import * as fs from 'fs';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Start daemon subcommand
 const startCommand: Command = {
@@ -201,7 +202,7 @@ const startCommand: Command = {
 
       return { success: true };
     } catch (error) {
-      output.printError(`Failed to start daemon: ${error instanceof Error ? error.message : String(error)}`);
+      output.printError(`Failed to start daemon: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   },
@@ -227,7 +228,7 @@ async function attachDaemonServices(
   try {
     memory = await createDashboardMemoryAccessor();
   } catch (err) {
-    logWarn(`Memory accessor unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    logWarn(`Memory accessor unavailable: ${errorDetail(err)}`);
     return { dashboard: null, memory: null };
   }
 
@@ -243,7 +244,7 @@ async function attachDaemonServices(
       });
       if (opts.verbose) output.printSuccess(`Dashboard: http://localhost:${dashboard.port}`);
     } catch (err) {
-      logWarn(`Dashboard failed to start: ${err instanceof Error ? err.message : String(err)}`);
+      logWarn(`Dashboard failed to start: ${errorDetail(err)}`);
     }
   }
 
@@ -266,7 +267,7 @@ async function attachDaemonServices(
     });
     if (opts.verbose) output.printSuccess('Spell scheduler attached');
   } catch (err) {
-    logWarn(`Spell scheduler not started: ${err instanceof Error ? err.message : String(err)}`);
+    logWarn(`Spell scheduler not started: ${errorDetail(err)}`);
   }
 
   return { dashboard, memory };
@@ -463,7 +464,7 @@ const stopCommand: Command = {
 
       return { success: true };
     } catch (error) {
-      output.printError(`Failed to stop daemon: ${error instanceof Error ? error.message : String(error)}`);
+      output.printError(`Failed to stop daemon: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   },
@@ -733,7 +734,7 @@ const triggerCommand: Command = {
 
       return { success: result.success, data: result };
     } catch (error) {
-      output.printError(`Failed to trigger worker: ${error instanceof Error ? error.message : String(error)}`);
+      output.printError(`Failed to trigger worker: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   },
@@ -768,7 +769,7 @@ const enableCommand: Command = {
 
       return { success: true };
     } catch (error) {
-      output.printError(`Failed to ${disable ? 'disable' : 'enable'} worker: ${error instanceof Error ? error.message : String(error)}`);
+      output.printError(`Failed to ${disable ? 'disable' : 'enable'} worker: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   },
@@ -803,7 +804,7 @@ const installCommand: Command = {
       return { success: result.success, exitCode: result.success ? 0 : 1 };
     } catch (error) {
       if (!quiet) {
-        output.printError(`Failed to install daemon service: ${error instanceof Error ? error.message : String(error)}`);
+        output.printError(`Failed to install daemon service: ${errorDetail(error)}`);
       }
       return { success: false, exitCode: 1 };
     }
@@ -838,7 +839,7 @@ const uninstallCommand: Command = {
       return { success: result.success, exitCode: result.success ? 0 : 1 };
     } catch (error) {
       if (!quiet) {
-        output.printError(`Failed to uninstall daemon service: ${error instanceof Error ? error.message : String(error)}`);
+        output.printError(`Failed to uninstall daemon service: ${errorDetail(error)}`);
       }
       return { success: false, exitCode: 1 };
     }

--- a/src/cli/commands/diagnose.ts
+++ b/src/cli/commands/diagnose.ts
@@ -13,6 +13,7 @@
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ---------------------------------------------------------------------------
 // Test harness types
@@ -40,7 +41,7 @@ async function timed(name: string, fn: () => Promise<{ status: 'pass' | 'fail' |
     const r = await fn();
     return { name, ...r, duration: performance.now() - t0 };
   } catch (err) {
-    return { name, status: 'fail', message: err instanceof Error ? err.message : String(err), duration: performance.now() - t0 };
+    return { name, status: 'fail', message: errorDetail(err), duration: performance.now() - t0 };
   }
 }
 
@@ -187,7 +188,7 @@ function testSwarmLifecycle(): DiagTest {
 
       return { status: 'pass', message: `Swarm ${swarmId} — init/spawn/status/stop OK` };
     } catch (err) {
-      return { status: 'fail', message: err instanceof Error ? err.message : String(err) };
+      return { status: 'fail', message: errorDetail(err) };
     }
   });
 }
@@ -230,7 +231,7 @@ function testHiveMindLifecycle(): DiagTest {
 
       return { status: 'pass', message: `Hive ${hiveId} — init/spawn/status/shutdown OK` };
     } catch (err) {
-      return { status: 'fail', message: err instanceof Error ? err.message : String(err) };
+      return { status: 'fail', message: errorDetail(err) };
     }
   });
 }
@@ -262,7 +263,7 @@ function testTaskLifecycle(): DiagTest {
 
       return { status: 'pass', message: `Task ${taskId} — create/list OK` };
     } catch (err) {
-      return { status: 'fail', message: err instanceof Error ? err.message : String(err) };
+      return { status: 'fail', message: errorDetail(err) };
     }
   });
 }
@@ -287,7 +288,7 @@ function testHooksRouting(): DiagTest {
       if (!agent) return { status: 'fail', message: 'No agent recommendation returned' };
       return { status: 'pass', message: `Routed to ${agent} (${confidence}% confidence)` };
     } catch (err) {
-      return { status: 'fail', message: err instanceof Error ? err.message : String(err) };
+      return { status: 'fail', message: errorDetail(err) };
     }
   });
 }
@@ -321,7 +322,7 @@ function testConfigShow(): DiagTest {
       }
       return { status: 'fail', message: 'No config file found' };
     } catch (err) {
-      return { status: 'fail', message: err instanceof Error ? err.message : String(err) };
+      return { status: 'fail', message: errorDetail(err) };
     }
   });
 }
@@ -342,7 +343,7 @@ function testInitIdempotency(): DiagTest {
       }
       return { status: 'pass', message: `${expected.length} artifacts verified` };
     } catch (err) {
-      return { status: 'fail', message: err instanceof Error ? err.message : String(err) };
+      return { status: 'fail', message: errorDetail(err) };
     }
   });
 }
@@ -365,7 +366,7 @@ function testNeuralStatus(): DiagTest {
       return { status: 'pass', message: `${active.length}/${components.length} components active` };
     } catch (err) {
       // Neural is optional — don't fail the whole suite
-      return { status: 'skip', message: `Neural not available: ${err instanceof Error ? err.message : String(err)}` };
+      return { status: 'skip', message: `Neural not available: ${errorDetail(err)}` };
     }
   });
 }
@@ -382,7 +383,7 @@ function testMcpParity(): DiagTest {
       }
       return { status: 'pass', message: `${found.length} memory tools registered` };
     } catch (err) {
-      return { status: 'fail', message: err instanceof Error ? err.message : String(err) };
+      return { status: 'fail', message: errorDetail(err) };
     }
   });
 }

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -135,7 +135,7 @@ export async function checkSubagentHealth(): Promise<HealthCheck> {
     const parts = ['spawn', statusOk ? 'status' : null, terminateOk ? 'terminate' : null].filter(Boolean);
     return { name: 'Subagent Health', status: 'pass', message: `Lifecycle OK (${parts.join(' → ')})` };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorDetail(err);
     return { name: 'Subagent Health', status: 'fail', message: `Agent lifecycle failed: ${msg}`, fix: 'npm run build' };
   }
 }
@@ -191,7 +191,7 @@ steps:
     const errMsg = result.errors?.map((e: { message: string }) => e.message).join('; ') || 'unknown error';
     return { name: 'Spell Execution', status: 'fail', message: `Probe failed: ${errMsg}`, fix: 'npm run build' };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorDetail(err);
     return { name: 'Spell Execution', status: 'fail', message: `Spell engine error: ${msg}`, fix: 'npm run build' };
   }
 }
@@ -219,7 +219,7 @@ export async function checkMcpToolInvocation(): Promise<HealthCheck> {
     } catch (importErr) {
       // MCP tools index may have circular init deps when loaded outside MCP server.
       // Module file exists — partial pass.
-      const msg = importErr instanceof Error ? importErr.message : String(importErr);
+      const msg = errorDetail(importErr);
       const short = msg.length > 80 ? msg.slice(0, 80) + '...' : msg;
       return { name: 'MCP Tool Invocation', status: 'warn', message: `Module found but import failed: ${short}`, fix: 'npm run build' };
     }
@@ -273,7 +273,7 @@ export async function checkMcpToolInvocation(): Promise<HealthCheck> {
       message: `${toolCount} tools loaded (${presentCategories.join(', ')})`,
     };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorDetail(err);
     return { name: 'MCP Tool Invocation', status: 'fail', message: `MCP tool loading failed: ${msg}`, fix: 'npm run build' };
   }
 }
@@ -301,7 +301,7 @@ export async function checkHookExecution(): Promise<HealthCheck> {
     } catch (importErr) {
       // Hooks module has deep dependency chain (swarm, memory, etc.) that may
       // not be fully compiled. Report partial success — module file exists.
-      const msg = importErr instanceof Error ? importErr.message : String(importErr);
+      const msg = errorDetail(importErr);
       const short = msg.length > 80 ? msg.slice(0, 80) + '...' : msg;
       return { name: 'Hook Execution', status: 'warn', message: `Module found but import failed: ${short}`, fix: 'npm run build' };
     }
@@ -337,7 +337,7 @@ export async function checkHookExecution(): Promise<HealthCheck> {
 
     return { name: 'Hook Execution', status: 'pass', message: parts.join(', ') };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorDetail(err);
     // Hook errors during doctor are non-fatal — the system may not have hooks configured
     if (msg.includes('No hooks registered') || msg.includes('not initialized')) {
       return { name: 'Hook Execution', status: 'pass', message: 'Executor loaded (no hooks registered)' };
@@ -412,7 +412,7 @@ export async function checkMcpSpellIntegration(): Promise<HealthCheck> {
       fix: 'Ensure spell-tools.ts imports from runner-bridge.ts',
     };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorDetail(err);
     return { name: 'MCP Spell Integration', status: 'fail', message: `MCP spell bridge error: ${msg}`, fix: 'npm run build' };
   }
 }
@@ -464,7 +464,7 @@ export async function checkMofloDbBridge(): Promise<HealthCheck> {
       message: `${controllers.length} controllers loaded`,
     };
   } catch (err) {
-    const msg = err instanceof Error ? err.message.split(/\r?\n/)[0] : String(err);
+    const msg = errorDetail(err, { firstLineOnly: true });
     return { name: 'MofloDb Bridge', status: 'fail', message: `check error: ${msg}`, fix: 'npm run build' };
   }
 }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -753,7 +753,7 @@ async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       }
       return success;
     } catch (e) {
-      output.writeln(output.warning(`  Fix failed: ${e instanceof Error ? e.message : String(e)}`));
+      output.writeln(output.warning(`  Fix failed: ${errorDetail(e)}`));
       return false;
     }
   }
@@ -1531,7 +1531,7 @@ export const doctorCommand: Command = {
             name: 'Sandbox Tier',
             status: 'warn',
             message: `sandboxing enabled but not ready (${cap.platform})`,
-            fix: err instanceof Error ? err.message : String(err),
+            fix: errorDetail(err),
           };
         }
       } catch (err) {

--- a/src/cli/commands/embeddings.ts
+++ b/src/cli/commands/embeddings.ts
@@ -19,6 +19,7 @@ import { mofloImport } from '../services/moflo-require.js';
 import { runEmbeddingsMigrationIfNeeded } from '../services/embeddings-migration.js';
 import { memoryDbPath, MEMORY_DB_FILE, MOFLO_DIR } from '../services/moflo-paths.js';
 import * as embeddings from '../embeddings/index.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 const DEFAULT_DB_PATH_FLAG = `${MOFLO_DIR}/${MEMORY_DB_FILE}`;
 
@@ -98,7 +99,7 @@ const generateCommand: Command = {
       return { success: true, data: result };
     } catch (error) {
       spinner.fail('Embedding generation failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -271,7 +272,7 @@ const searchCommand: Command = {
       return { success: true, data: topResults };
     } catch (error) {
       spinner.fail('Search failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -389,7 +390,7 @@ const compareCommand: Command = {
       return { success: true, data: { similarity, metric, embedTime } };
     } catch (error) {
       spinner.fail('Comparison failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -498,7 +499,7 @@ const collectionsCommand: Command = {
 
       return { success: true, data: collections };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -642,7 +643,7 @@ const indexCommand: Command = {
       output.printError(`Unknown action: ${action}`);
       return { success: false, exitCode: 1 };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -655,7 +656,7 @@ async function safelyRunEmbeddingsMigration(dbPath?: string): Promise<boolean> {
   try {
     return await runEmbeddingsMigrationIfNeeded(dbPath ? { dbPath } : {});
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorDetail(err);
     output.printWarning(`Embeddings migration check failed: ${msg}`);
     return false;
   }
@@ -796,7 +797,7 @@ export const initCommand: Command = {
 
       return { success: true, data: config };
     } catch (error) {
-      output.printError('Initialization failed: ' + (error instanceof Error ? error.message : String(error)));
+      output.printError('Initialization failed: ' + (errorDetail(error)));
       return { success: false, exitCode: 1 };
     }
   },
@@ -1472,7 +1473,7 @@ const warmupCommand: Command = {
       return { success: true, data: { loadTime, totalTime, dimensions: modelInfo.dimensions } };
     } catch (error) {
       spinner.fail('Warmup failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -1627,7 +1628,7 @@ const benchmarkCommand: Command = {
 
       return { success: true, data: { results, avgWarm, coldTime } };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -1655,7 +1656,7 @@ const migrateCommand: Command = {
       const ran = await runEmbeddingsMigrationIfNeeded({ dbPath });
       return { success: true, data: { ran } };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       output.printError(`Migration failed: ${msg}`);
       return { success: false, exitCode: 1 };
     }

--- a/src/cli/commands/github.ts
+++ b/src/cli/commands/github.ts
@@ -12,6 +12,7 @@ import { output } from '../output.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ============================================================================
 // Helpers
@@ -379,9 +380,9 @@ const settingsCommand: Command = {
           }
           applied.push(...batch.labels);
         } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e);
+          const msg = errorDetail(e, { firstLineOnly: true });
           for (const label of batch.labels) {
-            output.writeln(`  ${output.warning('⚠')} ${label} — ${msg.split(/\r?\n/)[0]}`);
+            output.writeln(`  ${output.warning('⚠')} ${label} — ${msg}`);
           }
           errors.push(...batch.labels);
         }
@@ -438,7 +439,7 @@ const settingsCommand: Command = {
           }
           applied.push(...protectionItems);
         } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e);
+          const msg = errorDetail(e);
           if (msg.includes('not found') || msg.includes('404')) {
             output.writeln(`  ${output.warning('⚠')} Branch protection requires GitHub Pro, Team, or Enterprise`);
           } else if (msg.includes('403')) {

--- a/src/cli/commands/guidance.ts
+++ b/src/cli/commands/guidance.ts
@@ -5,6 +5,7 @@
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // compile subcommand
 const compileCommand: Command = {
@@ -79,7 +80,7 @@ const compileCommand: Command = {
 
       return { success: true, data: bundle };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       output.writeln(output.error(`Compilation failed: ${msg}`));
       return { success: false, message: msg };
     }
@@ -178,7 +179,7 @@ const retrieveCommand: Command = {
 
       return { success: true, data: result };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       output.writeln(output.error(`Retrieval failed: ${msg}`));
       return { success: false, message: msg };
     }
@@ -270,7 +271,7 @@ const gatesCommand: Command = {
 
       return { success: true, data: results };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       output.writeln(output.error(`Gate evaluation failed: ${msg}`));
       return { success: false, message: msg };
     }
@@ -328,7 +329,7 @@ const statusCommand: Command = {
 
       return { success: true, data: statusData };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       output.writeln(output.error(`Status check failed: ${msg}`));
       return { success: false, message: msg };
     }
@@ -447,7 +448,7 @@ const optimizeCommand: Command = {
 
       return { success: true, data: result };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       output.writeln(output.error(`Optimization failed: ${msg}`));
       return { success: false, message: msg };
     }
@@ -569,7 +570,7 @@ const abTestCommand: Command = {
 
       return { success: true, data: report };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       output.writeln(output.error(`A/B benchmark failed: ${msg}`));
       return { success: false, message: msg };
     }

--- a/src/cli/commands/hive-mind.ts
+++ b/src/cli/commands/hive-mind.ts
@@ -14,6 +14,7 @@ import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import { spawn as childSpawn, execSync } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
+import { errorDetail } from '../shared/utils/error-detail.js';
 // Inline permission resolver to avoid cross-package runtime import
 // (cli rootDir:"." produces dist/src/ which breaks relative paths to spells/)
 const PERM_TOOLS: Record<string, readonly string[]> = {
@@ -358,7 +359,7 @@ async function spawnClaudeCodeInstance(
     }
   } catch (error) {
     spinner.fail('Failed to prepare Claude Code coordination');
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorMessage = errorDetail(error);
     output.printError(`Error: ${errorMessage}`);
 
     // Try to save prompt as fallback

--- a/src/cli/commands/hooks.ts
+++ b/src/cli/commands/hooks.ts
@@ -10,6 +10,7 @@ import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { storeCommand } from './transfer-store.js';
 import { memoryDbCandidatePaths } from '../services/moflo-paths.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Hook types
 const HOOK_TYPES = [
@@ -1661,7 +1662,7 @@ const sessionEndCommand: Command = {
 
       return { success: true, data: result };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       const isTimeout = msg.includes('timed out');
 
       if (isTimeout) {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -8,6 +8,7 @@ import { output } from '../output.js';
 import { confirm, select, multiSelect, input } from '../prompt.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { errorDetail } from '../shared/utils/error-detail.js';
 import {
   executeInit,
   executeUpgrade,
@@ -60,7 +61,7 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
     }
     output.writeln();
   } catch (e) {
-    output.printWarning(`MoFlo setup: ${e instanceof Error ? e.message : String(e)}`);
+    output.printWarning(`MoFlo setup: ${errorDetail(e)}`);
   }
   // ── End MoFlo Setup ────────────────────────────────────────────────
 
@@ -316,7 +317,7 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
     return { success: true, data: result };
   } catch (error) {
     spinner.fail('Initialization failed');
-    output.printError(`Failed to initialize: ${error instanceof Error ? error.message : String(error)}`);
+    output.printError(`Failed to initialize: ${errorDetail(error)}`);
     return { success: false, exitCode: 1 };
   }
 };
@@ -878,7 +879,7 @@ const upgradeCommand: Command = {
       return { success: true, data: result };
     } catch (error) {
       spinner.fail('Upgrade failed');
-      output.printError(`Failed to upgrade: ${error instanceof Error ? error.message : String(error)}`);
+      output.printError(`Failed to upgrade: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   },

--- a/src/cli/commands/issues.ts
+++ b/src/cli/commands/issues.ts
@@ -19,6 +19,7 @@
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { createClaimService, type Claimant, type ClaimStatus } from '../services/claim-service.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ============================================================================
 // Subcommands
@@ -214,7 +215,7 @@ const releaseCommand: Command = {
       output.printSuccess(`Released claim on issue ${issueId}`);
       return { success: true };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -267,7 +268,7 @@ const handoffCommand: Command = {
       output.printSuccess(`Handoff requested for issue ${issueId}`);
       return { success: true };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -321,7 +322,7 @@ const statusCommand: Command = {
 
       return { success: true, data: claim };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -13,6 +13,7 @@ import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { mofloImport } from '../services/moflo-require.js';
 import { atomicWriteFileSync } from '../services/atomic-file-write.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Memory backends
 const BACKENDS = [
@@ -1458,7 +1459,7 @@ const initMemoryCommand: Command = {
       };
     } catch (error) {
       spinner.fail('Initialization failed');
-      output.printError(`Failed to initialize memory: ${error instanceof Error ? error.message : String(error)}`);
+      output.printError(`Failed to initialize memory: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   }
@@ -2178,7 +2179,7 @@ const rebuildIndexCommand: Command = {
         }
         return null;
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = errorDetail(err);
         output.printError(`HNSW sidecar write failed: ${msg}`);
         return { success: false, exitCode: 1 };
       }
@@ -2828,7 +2829,7 @@ const refreshCommand: Command = {
         output.writeln(`${icon} ${name} ${output.dim(`(${durStr})`)}`);
       } catch (err) {
         const dur = performance.now() - stepStart;
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = errorDetail(err);
         steps.push({ name, status: 'fail', message: msg, duration: dur });
         output.writeln(`${output.error('✗')} ${name}: ${msg}`);
       }

--- a/src/cli/commands/neural.ts
+++ b/src/cli/commands/neural.ts
@@ -8,6 +8,7 @@
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { mofloImport, mofloResolve } from '../services/moflo-require.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Train subcommand - REAL WASM training with MoVector
 const trainCommand: Command = {
@@ -382,7 +383,7 @@ const trainCommand: Command = {
       };
     } catch (error) {
       spinner.fail('Training failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -544,7 +545,7 @@ const statusCommand: Command = {
       return { success: true, data: { stats, hnswStatus, adaptBench, modelInfo, trainingStats } };
     } catch (error) {
       spinner.fail('Failed to check neural systems');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -751,7 +752,7 @@ const predictCommand: Command = {
       return { success: true, data: { matches, searchTime } };
     } catch (error) {
       spinner.fail('Prediction failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -915,7 +916,7 @@ const optimizeCommand: Command = {
       return { success: true };
     } catch (error) {
       spinner.fail('Optimization failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -1145,7 +1146,7 @@ const exportCommand: Command = {
 
       return { success: true };
     } catch (error) {
-      spinner.fail(`Export failed: ${error instanceof Error ? error.message : String(error)}`);
+      spinner.fail(`Export failed: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   },
@@ -1286,7 +1287,7 @@ const listCommand: Command = {
 
       return { success: true };
     } catch (error) {
-      spinner.fail(`Failed to list models: ${error instanceof Error ? error.message : String(error)}`);
+      spinner.fail(`Failed to list models: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   },
@@ -1411,7 +1412,7 @@ const importCommand: Command = {
 
           output.writeln(output.success('Signature verified'));
         } catch (err) {
-          output.writeln(output.warning(`Signature verification skipped: ${err instanceof Error ? err.message : String(err)}`));
+          output.writeln(output.warning(`Signature verification skipped: ${errorDetail(err)}`));
         }
       }
 
@@ -1511,7 +1512,7 @@ const importCommand: Command = {
 
       return { success: true };
     } catch (error) {
-      spinner.fail(`Import failed: ${error instanceof Error ? error.message : String(error)}`);
+      spinner.fail(`Import failed: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   },
@@ -1640,7 +1641,7 @@ const benchmarkCommand: Command = {
       return { success: true, data: { results, loraAvg } };
     } catch (error) {
       spinner.fail('Benchmark failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },

--- a/src/cli/commands/progress.ts
+++ b/src/cli/commands/progress.ts
@@ -9,6 +9,7 @@
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 function progressBar(percent: number, width: number = 20): string {
   const filled = Math.round((percent / 100) * width);
@@ -203,7 +204,7 @@ const watchCommand: Command = {
           process.stdout.write(`\r${progressBar(currentProgress, 20)} ${output.dim(new Date().toLocaleTimeString())}`);
         }
       } catch (error) {
-        output.printError(`Check failed: ${error instanceof Error ? error.message : String(error)}`);
+        output.printError(`Check failed: ${errorDetail(error)}`);
       }
     };
 

--- a/src/cli/commands/route.ts
+++ b/src/cli/commands/route.ts
@@ -13,6 +13,7 @@
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 import {
   createQLearningRouter,
   isMovectorAvailable,
@@ -235,7 +236,7 @@ const routeTaskCommand: Command = {
       return { success: true, data: { agentId: result.route, result } };
     } catch (error) {
       spinner.fail('Routing failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -295,7 +296,7 @@ const listAgentsCommand: Command = {
 
       return { success: true, data: AGENT_TYPES };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -367,7 +368,7 @@ const statsCommand: Command = {
 
       return { success: true, data: { stats, backend: backendStatus } };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -450,7 +451,7 @@ const feedbackCommand: Command = {
 
       return { success: true, data: { tdError } };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -491,7 +492,7 @@ const resetCommand: Command = {
       output.printSuccess('Q-Learning router state has been reset');
       return { success: true };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -533,7 +534,7 @@ const exportCommand: Command = {
 
       return { success: true, data };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -575,7 +576,7 @@ const importCommand: Command = {
 
       return { success: true };
     } catch (error) {
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },
@@ -802,7 +803,7 @@ const coverageRouteCommand: Command = {
       return { success: true, data: routeResult };
     } catch (error) {
       spinner.fail('Coverage analysis failed');
-      output.printError(error instanceof Error ? error.message : String(error));
+      output.printError(errorDetail(error));
       return { success: false, exitCode: 1 };
     }
   },

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -9,6 +9,7 @@ import { confirm, select } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Default configuration
 const DEFAULT_TOPOLOGY = 'hierarchical-mesh';
@@ -358,7 +359,7 @@ const stopCommand: Command = {
       };
     } catch (error) {
       spinner.fail('Stop failed');
-      output.printError(`Failed to stop: ${error instanceof Error ? error.message : String(error)}`);
+      output.printError(`Failed to stop: ${errorDetail(error)}`);
       return { success: false, exitCode: 1 };
     }
   }

--- a/src/cli/embeddings/fastembed-embedding-service.ts
+++ b/src/cli/embeddings/fastembed-embedding-service.ts
@@ -19,6 +19,7 @@ import type {
   FastembedEmbeddingConfig,
 } from './types.js';
 import { BaseEmbeddingService } from './embedding-service.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 const DEFAULT_BATCH_SIZE = 32;
 
@@ -100,7 +101,7 @@ export class FastembedEmbeddingService extends BaseEmbeddingService {
         this.model = model;
         return model;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = errorDetail(error);
         throw new Error(`Failed to initialize fastembed: ${message}`);
       } finally {
         this.initPromise = null;
@@ -139,7 +140,7 @@ export class FastembedEmbeddingService extends BaseEmbeddingService {
         latencyMs,
       };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorDetail(error);
       this.emitEvent({ type: 'embed_error', text, error: message });
       throw new Error(`Fastembed embedding failed: ${message}`);
     }
@@ -174,7 +175,7 @@ export class FastembedEmbeddingService extends BaseEmbeddingService {
           }
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = errorDetail(error);
         throw new Error(`Fastembed batch embedding failed: ${message}`);
       }
 

--- a/src/cli/embeddings/migration/migrate-store.ts
+++ b/src/cli/embeddings/migration/migrate-store.ts
@@ -42,6 +42,7 @@ import {
   type MigrationProgress,
   type MigrationResult,
 } from './types.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 const DEFAULT_BATCH_SIZE = 32;
 const DEFAULT_MAX_RETRIES = 3;
@@ -280,7 +281,7 @@ async function attemptBatchOnce(ctx: CommitContext): Promise<AttemptOutcome> {
       throw inner;
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorDetail(err);
     return { ok: false, error: message };
   }
 }
@@ -297,7 +298,7 @@ async function safeRollback(
   try {
     await store.rollback();
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorDetail(err);
     errors.push(`[${store.storeId}] rollback failed: ${message}`);
   }
 }

--- a/src/cli/guidance/hooks.ts
+++ b/src/cli/guidance/hooks.ts
@@ -31,6 +31,7 @@ import type { HookRegistry } from '../hooks/index.js';
 import type { EnforcementGates } from './gates.js';
 import type { ShardRetriever } from './retriever.js';
 import type { RunLedger } from './ledger.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 import type {
   GateResult,
   GateDecision,
@@ -373,7 +374,7 @@ export class GuidanceHookProvider {
     } catch (error) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorDetail(error),
         message: 'Failed to retrieve guidance shards for task',
       };
     }
@@ -431,7 +432,7 @@ export class GuidanceHookProvider {
     } catch (error) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorDetail(error),
         message: `Failed to finalize run event for task "${taskId}"`,
       };
     }

--- a/src/cli/hooks/daemons/index.ts
+++ b/src/cli/hooks/daemons/index.ts
@@ -14,6 +14,7 @@ import type {
   DaemonStatus,
   DaemonManagerConfig,
 } from '../types.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 /**
  * Daemon instance
@@ -99,7 +100,7 @@ export class DaemonManager {
       await this.executeDaemonTask(name);
     } catch (error) {
       daemon.state.status = 'error';
-      daemon.state.error = error instanceof Error ? error.message : String(error);
+      daemon.state.error = errorDetail(error);
       throw error;
     }
   }
@@ -254,7 +255,7 @@ export class DaemonManager {
       this.restartCounts.set(name, 0);
     } catch (error) {
       daemon.state.failureCount++;
-      daemon.state.error = error instanceof Error ? error.message : String(error);
+      daemon.state.error = errorDetail(error);
 
       // Handle auto-restart
       if (this.config.autoRestart) {

--- a/src/cli/hooks/executor/index.ts
+++ b/src/cli/hooks/executor/index.ts
@@ -14,6 +14,7 @@ import type {
   HookEntry,
 } from '../types.js';
 import { HookRegistry, defaultRegistry } from '../registry/index.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 /**
  * Default execution options
@@ -98,7 +99,7 @@ export class HookExecutor {
       } catch (error) {
         result = {
           success: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: errorDetail(error),
         };
       }
 

--- a/src/cli/hooks/workers/index.ts
+++ b/src/cli/hooks/workers/index.ts
@@ -9,6 +9,7 @@ import { EventEmitter } from 'events';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 // ============================================================================
 // Security Constants
@@ -893,7 +894,7 @@ export class WorkerManager extends EventEmitter {
         worker: name,
         success: false,
         duration,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorDetail(error),
         timestamp: new Date(),
       };
 

--- a/src/cli/hooks/workers/session-hook.ts
+++ b/src/cli/hooks/workers/session-hook.ts
@@ -6,6 +6,7 @@
 
 import { WorkerManager, createWorkerManager } from './index.js';
 import * as path from 'path';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 // ============================================================================
 // Types
@@ -84,7 +85,7 @@ export async function onSessionStart(config: SessionHookConfig = {}): Promise<Se
     return {
       success: false,
       manager: createWorkerManager(projectRoot),
-      error: error instanceof Error ? error.message : String(error),
+      error: errorDetail(error),
     };
   }
 }

--- a/src/cli/init/executor.ts
+++ b/src/cli/init/executor.ts
@@ -30,6 +30,7 @@ import { generateClaudeMd } from './claudemd-generator.js';
 import { writeEnvrc } from './envrc-generator.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 import { locateMofloRootPath } from '../services/moflo-require.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 /**
  * Skills to copy based on configuration. Exported for integrity tests.
@@ -213,7 +214,7 @@ export async function executeInit(options: InitOptions): Promise<InitResult> {
 
   } catch (error) {
     result.success = false;
-    result.errors.push(error instanceof Error ? error.message : String(error));
+    result.errors.push(errorDetail(error));
   }
 
   return result;
@@ -671,7 +672,7 @@ export async function executeUpgrade(targetDir: string, _upgradeSettings = false
             'statusLine',
           ];
         } catch (settingsError) {
-          result.errors.push(`Settings merge failed: ${settingsError instanceof Error ? settingsError.message : String(settingsError)}`);
+          result.errors.push(`Settings merge failed: ${errorDetail(settingsError)}`);
         }
       } else {
         // Create new settings.json with defaults
@@ -739,7 +740,7 @@ export async function executeUpgrade(targetDir: string, _upgradeSettings = false
 
   } catch (error) {
     result.success = false;
-    result.errors.push(error instanceof Error ? error.message : String(error));
+    result.errors.push(errorDetail(error));
   }
 
   return result;
@@ -848,7 +849,7 @@ export async function executeUpgradeWithMissing(targetDir: string, _upgradeSetti
     }
 
   } catch (error) {
-    result.errors.push(`Add missing failed: ${error instanceof Error ? error.message : String(error)}`);
+    result.errors.push(`Add missing failed: ${errorDetail(error)}`);
   }
 
   return result;

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { locateMofloRootPath } from '../services/moflo-require.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Directories that walkers should never recurse into when discovering project
 // structure. The runtime state dirs (.swarm, .moflo) and other generated/
@@ -1012,7 +1013,7 @@ function installGlobalFloShim(root: string): MofloInitResult['steps'][0] {
     }
     return { name: 'global flo shim', status: 'skipped', detail: 'Already up to date' };
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = errorDetail(err);
     return { name: 'global flo shim', status: 'error', detail: msg };
   }
 }

--- a/src/cli/mcp-client.ts
+++ b/src/cli/mcp-client.ts
@@ -26,6 +26,7 @@ import { performanceTools } from './mcp-tools/performance-tools.js';
 import { githubTools } from './mcp-tools/github-tools.js';
 import { coordinationTools } from './mcp-tools/coordination-tools.js';
 import { moflodbTools } from './mcp-tools/moflodb-tools.js';
+import { errorDetail } from './shared/utils/error-detail.js';
 
 /**
  * MCP Tool Registry
@@ -119,7 +120,7 @@ export async function callMCPTool<T = unknown>(
   } catch (error) {
     // Wrap and re-throw with context
     throw new MCPClientError(
-      `Failed to execute MCP tool '${toolName}': ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to execute MCP tool '${toolName}': ${errorDetail(error)}`,
       toolName,
       error instanceof Error ? error : undefined
     );

--- a/src/cli/mcp-server.ts
+++ b/src/cli/mcp-server.ts
@@ -25,6 +25,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { errorDetail } from './shared/utils/error-detail.js';
 
 // ESM-compatible __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -343,7 +344,7 @@ export class MCPServerManager extends EventEmitter {
           } catch (error) {
             console.error(
               `[${new Date().toISOString()}] ERROR [claude-flow-mcp] Failed to parse message:`,
-              error instanceof Error ? error.message : String(error)
+              errorDetail(error)
             );
           }
         }

--- a/src/cli/mcp-tools/hooks-tools.ts
+++ b/src/cli/mcp-tools/hooks-tools.ts
@@ -6,6 +6,7 @@
 import { mkdirSync, writeFileSync, existsSync, readFileSync, statSync, readdirSync } from 'fs';
 import { dirname, join, resolve, extname } from 'path';
 import type { MCPTool } from './types.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Real vector search functions - lazy loaded to avoid circular imports
 let searchEntriesFn: ((options: {
@@ -26,7 +27,7 @@ async function getRealSearchFunction() {
       const { searchEntries } = await import('../memory/memory-initializer.js');
       searchEntriesFn = searchEntries;
     } catch (err) {
-      console.error('[hooks-tools] Failed to load memory-initializer searchEntries:', err instanceof Error ? err.message : String(err));
+      console.error('[hooks-tools] Failed to load memory-initializer searchEntries:', errorDetail(err));
       searchEntriesFn = null;
     }
   }
@@ -56,7 +57,7 @@ async function getRealStoreFunction() {
       const { storeEntry } = await import('../memory/memory-initializer.js');
       storeEntryFn = storeEntry;
     } catch (err) {
-      console.error('[hooks-tools] Failed to load memory-initializer storeEntry:', err instanceof Error ? err.message : String(err));
+      console.error('[hooks-tools] Failed to load memory-initializer storeEntry:', errorDetail(err));
       storeEntryFn = null;
     }
   }
@@ -1991,7 +1992,7 @@ export const hooksSessionStart: MCPTool = {
       } catch (error) {
         daemonStatus = {
           started: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: errorDetail(error),
         };
       }
     }
@@ -2337,7 +2338,7 @@ export const hooksPatternStore: MCPTool = {
             tags: [type, `confidence-${Math.round(confidence * 100)}`, 'reasoning-pattern'],
           });
         } catch (error) {
-          storeResult = { success: false, error: error instanceof Error ? error.message : String(error) };
+          storeResult = { success: false, error: errorDetail(error) };
         }
       }
     }

--- a/src/cli/mcp-tools/neural-tools.ts
+++ b/src/cli/mcp-tools/neural-tools.ts
@@ -14,6 +14,7 @@ import type { MCPTool } from './types.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Lazily resolved fastembed-backed embedder. The previous top-level `await`
 // blocked module evaluation on the fastembed model load (~1–3 s + model
@@ -44,7 +45,7 @@ async function getRealEmbeddings(): Promise<RealEmbeddings> {
       embeddingServiceName = service.provider;
     } catch (err) {
       process.stderr.write(
-        `[neural-tools] embeddings load failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        `[neural-tools] embeddings load failed: ${errorDetail(err)}\n`,
       );
       realEmbeddings = null;
     }

--- a/src/cli/mcp-tools/spell-tools.ts
+++ b/src/cli/mcp-tools/spell-tools.ts
@@ -19,6 +19,7 @@ import {
 } from '../services/engine-loader.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { buildGrimoire } from '../services/grimoire-builder.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 
 // ============================================================================
@@ -99,7 +100,7 @@ async function executeAndTrack(
   } catch (err) {
     tracked.status = SPELL_STATUS.FAILED;
     tracked.completedAt = new Date().toISOString();
-    return { spellId, error: errorMsg(err) };
+    return { spellId, error: errorDetail(err) };
   }
 }
 
@@ -135,11 +136,6 @@ export function invalidateRegistry(): void {
 // ============================================================================
 // Serialization helpers
 // ============================================================================
-
-/** Extract error message from an unknown catch value. */
-function errorMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
 
 /** Serialize a single step for MCP responses. */
 function serializeStep(s: SpellResult['steps'][number]) {
@@ -624,7 +620,7 @@ export const spellTools: MCPTool[] = [
           const entries = registry.list();
           return { action, templates: entries, total: entries.length };
         } catch (err) {
-          return { action, error: errorMsg(err) };
+          return { action, error: errorDetail(err) };
         }
       }
 
@@ -637,7 +633,7 @@ export const spellTools: MCPTool[] = [
           if (!info) return { action, error: `Spell not found in grimoire: ${query}` };
           return { action, ...info };
         } catch (err) {
-          return { action, error: errorMsg(err) };
+          return { action, error: errorDetail(err) };
         }
       }
 

--- a/src/cli/memory/bridge-core.ts
+++ b/src/cli/memory/bridge-core.ts
@@ -58,6 +58,7 @@ function getProjectRoot(): string {
 }
 
 import { ControllerRegistry } from './controller-registry.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 let registryPromise: Promise<any | null> | null = null;
 // Sync handle populated once the promise resolves. Lets sync callers
@@ -81,7 +82,7 @@ export function getBridgeLastError(): Error | null {
 
 function logBridgeError(context: string, err: unknown): void {
   if (process.env.MOFLO_BRIDGE_QUIET) return;
-  const msg = err instanceof Error ? err.message : String(err);
+  const msg = errorDetail(err);
   console.error(`[moflo] ${context}: ${msg}`);
 }
 

--- a/src/cli/memory/bridge-embedder.ts
+++ b/src/cli/memory/bridge-embedder.ts
@@ -25,6 +25,7 @@ import {
   CANONICAL_EMBEDDING_MODEL,
 } from '../embeddings/migration/types.js';
 import { toFloat32 } from './controllers/_shared.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 /**
  * Canonical model label written into `memory_entries.embedding_model`.
@@ -190,7 +191,7 @@ export async function resolveBridgeEmbedding(
     const vector = await embedder.embed(value);
     return { ok: true, json: JSON.stringify(Array.from(vector)), dimensions: vector.length, model: embedder.model };
   } catch (err) {
-    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    return { ok: false, reason: errorDetail(err) };
   }
 }
 

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -10,6 +10,7 @@
 
 import { cosineSim, execRows, generateId, persistBridgeDb, refreshVectorStatsCache, withDb } from './bridge-core.js';
 import { embeddingResponseFrom, resolveBridgeEmbedding } from './bridge-embedder.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 function makeEntryCacheKey(namespace: string, key: string): string {
   const safeNs = String(namespace).replace(/:/g, '_');
@@ -280,7 +281,7 @@ export async function bridgeStoreEntries(items: Array<{
           ttl ? now + (ttl * 1000) : null,
         ]);
       } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
+        const reason = errorDetail(err);
         results.push({ success: false, id, error: `insert failed: ${reason}` });
         continue;
       }

--- a/src/cli/memory/controller-registry.ts
+++ b/src/cli/memory/controller-registry.ts
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import type { IMemoryBackend } from './types.js';
 import { openSqlJsDatabase } from './sqljs-backend.js';
 import { CONTROLLER_SPECS } from './controller-specs.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 import type {
   ControllerName,
   ControllerSpec,
@@ -292,7 +293,7 @@ export class ControllerRegistry extends EventEmitter implements RegistryView {
       this.mofloDb = { database, close: async () => database.close() };
       this.emit('mofloDb:initialized');
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = errorDetail(error);
       this.emit('mofloDb:unavailable', { reason: msg.substring(0, 200) });
       this.mofloDb = null;
     }
@@ -349,7 +350,7 @@ export class ControllerRegistry extends EventEmitter implements RegistryView {
         });
       }
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = errorDetail(error);
       const initTimeMs = performance.now() - startTime;
       this.controllers.set(spec.name, {
         name: spec.name,

--- a/src/cli/memory/controllers/nightly-learner.ts
+++ b/src/cli/memory/controllers/nightly-learner.ts
@@ -19,6 +19,7 @@ import type { Reflexion } from './reflexion.js';
 import type { Skills } from './skills.js';
 import type { ControllerSpec } from '../controller-spec.js';
 import { hasMethod } from './_shared.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 export interface NightlyReport {
   consolidation?: ConsolidationReport;
@@ -74,7 +75,7 @@ export class NightlyLearner {
           memoriesForgotten: 0,
           workingPromoted: 0,
           timestamp: Date.now(),
-          error: err instanceof Error ? err.message : String(err),
+          error: errorDetail(err),
         };
       }
     }

--- a/src/cli/memory/ewc-consolidation.ts
+++ b/src/cli/memory/ewc-consolidation.ts
@@ -23,6 +23,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ============================================================================
 // Types
@@ -355,7 +356,7 @@ export class EWCConsolidator {
 
       return result;
     } catch (error) {
-      result.error = error instanceof Error ? error.message : String(error);
+      result.error = errorDetail(error);
       result.duration = performance.now() - startTime;
       return result;
     }

--- a/src/cli/memory/intelligence.ts
+++ b/src/cli/memory/intelligence.ts
@@ -14,6 +14,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ============================================================================
 // Persistence Configuration
@@ -562,7 +563,7 @@ export async function initializeIntelligence(config?: Partial<SonaConfig>): Prom
       success: false,
       sonaEnabled: false,
       reasoningBankEnabled: false,
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -19,6 +19,7 @@ import { tryLoadHnswSidecar } from './hnsw-persistence.js';
 import { EMBEDDING_MODEL_OPT_OUT, EPHEMERAL_NAMESPACES, getBridgeEmbedder } from './bridge-embedder.js';
 import { parseEmbeddingJson, toFloat32 } from './controllers/_shared.js';
 import { writeVectorStatsJson } from './bridge-core.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 import {
   MOFLO_DIR,
   hnswIndexPath,
@@ -1025,7 +1026,7 @@ export async function ensureSchemaColumns(dbPath: string): Promise<{
     return {
       success: false,
       columnsAdded,
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }
@@ -1354,7 +1355,7 @@ export async function initializeMemoryDatabase(options: {
         hnswIndexing: false,
         migrationTracking: false
       },
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }
@@ -1468,7 +1469,7 @@ export async function applyTemporalDecay(dbPath?: string): Promise<{
     return {
       success: false,
       patternsDecayed: 0,
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }
@@ -2052,7 +2053,7 @@ export async function storeEntry(options: {
     return {
       success: false,
       id: '',
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }
@@ -2223,7 +2224,7 @@ export async function searchEntries(options: {
       success: false,
       results: [],
       searchTime: Date.now() - startTime,
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }
@@ -2362,7 +2363,7 @@ export async function listEntries(options: {
       success: false,
       entries: [],
       total: 0,
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }
@@ -2478,7 +2479,7 @@ export async function getEntry(options: {
     return {
       success: false,
       found: false,
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }
@@ -2590,7 +2591,7 @@ export async function deleteEntry(options: {
       key,
       namespace,
       remainingEntries: 0,
-      error: error instanceof Error ? error.message : String(error)
+      error: errorDetail(error)
     };
   }
 }

--- a/src/cli/plugins/manager.ts
+++ b/src/cli/plugins/manager.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -203,7 +204,7 @@ export class PluginManager {
 
       return { success: true, plugin };
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = errorDetail(error);
       console.error(`[PluginManager] Failed to install ${packageName}:`, errorMsg);
       return { success: false, error: errorMsg };
     }
@@ -263,7 +264,7 @@ export class PluginManager {
 
       return { success: true, plugin };
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = errorDetail(error);
       console.error(`[PluginManager] Failed to install from local:`, errorMsg);
       return { success: false, error: errorMsg };
     }
@@ -306,7 +307,7 @@ export class PluginManager {
 
       return { success: true };
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = errorDetail(error);
       console.error(`[PluginManager] Failed to uninstall ${packageName}:`, errorMsg);
       return { success: false, error: errorMsg };
     }
@@ -471,7 +472,7 @@ export class PluginManager {
 
       return { success: true, plugin: existing };
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = errorDetail(error);
       return { success: false, error: errorMsg };
     }
   }

--- a/src/cli/runtime/headless.ts
+++ b/src/cli/runtime/headless.ts
@@ -18,6 +18,7 @@
 import { HeadlessWorkerExecutor, HEADLESS_WORKER_TYPES, type HeadlessWorkerType } from '../services/headless-worker-executor.js';
 import { WorkerDaemon, getDaemon, startDaemon, stopDaemon } from '../services/worker-daemon.js';
 import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 import {
   initializeIntelligence,
   benchmarkAdaptation,
@@ -334,7 +335,7 @@ async function main(): Promise<void> {
         break;
     }
   } catch (error) {
-    console.error('[Headless] Error:', error instanceof Error ? error.message : String(error));
+    console.error('[Headless] Error:', errorDetail(error));
     process.exit(1);
   }
 }

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -12,6 +12,7 @@ import type { WorkerDaemon } from './worker-daemon.js';
 import type { MemoryAccessor } from '../spells/types/step-command.types.js';
 import type { FloRunContext } from '../spells/types/runner.types.js';
 import type { SchedulerErrorCode } from '../spells/scheduler/scheduler.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ============================================================================
 // Types
@@ -393,7 +394,7 @@ async function handleRequest(
       sendJson(res, 404, { error: 'Not found' });
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorDetail(err);
     sendJson(res, 500, { error: 'Internal server error', message });
   }
 }
@@ -438,13 +439,13 @@ async function handleScheduleAction(
     // verb === 'run' — execute asynchronously so the response returns fast;
     // the UI polls history for completion.
     scheduler.runScheduleNow(scheduleId).catch(err => {
-      console.warn(`[dashboard] runScheduleNow(${scheduleId}) failed: ${err instanceof Error ? err.message : String(err)}`);
+      console.warn(`[dashboard] runScheduleNow(${scheduleId}) failed: ${errorDetail(err)}`);
     });
     sendJson(res, 202, { ok: true, id: scheduleId, accepted: true });
   } catch (err) {
     const code = getSchedulerErrorCode(err);
     const status = code === 'busy' ? 409 : code ? 404 : 500;
-    sendJson(res, status, { error: err instanceof Error ? err.message : String(err) });
+    sendJson(res, status, { error: errorDetail(err) });
   }
 }
 

--- a/src/cli/services/daemon-service.ts
+++ b/src/cli/services/daemon-service.ts
@@ -15,6 +15,7 @@ import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
 import { locateMofloCliBin } from './moflo-require.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -295,7 +296,7 @@ function installWindows(projectRoot: string, nodePath: string, cliPath: string):
     return {
       success: false,
       servicePath: null,
-      message: `Failed to create scheduled task: ${err instanceof Error ? err.message : String(err)}`,
+      message: `Failed to create scheduled task: ${errorDetail(err)}`,
     };
   }
 

--- a/src/cli/services/daemon-spell-executor.ts
+++ b/src/cli/services/daemon-spell-executor.ts
@@ -17,6 +17,7 @@ import type {
 import type { SpellResult, SpellErrorCode } from '../spells/types/runner.types.js';
 import type { SpellDefinition } from '../spells/types/spell-definition.types.js';
 import type { Grimoire } from '../spells/registry/spell-registry.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 import {
   loadSpellEngine,
   type EngineModule,
@@ -85,7 +86,7 @@ export class DaemonSpellExecutor implements SpellExecutor {
         // Cancellation is best-effort — the engine may have already finished.
         // Emit to stderr so daemon logs capture the case without disrupting
         // the poll loop or propagating the failure back to the scheduler.
-        console.warn(`[daemon-spell-executor] bridgeCancelSpell(${spellId}) failed: ${err instanceof Error ? err.message : String(err)}`);
+        console.warn(`[daemon-spell-executor] bridgeCancelSpell(${spellId}) failed: ${errorDetail(err)}`);
       }
     };
     if (signal?.aborted) onAbort();
@@ -104,7 +105,7 @@ export class DaemonSpellExecutor implements SpellExecutor {
       return failedResult(
         spellId,
         'STEP_EXECUTION_FAILED',
-        err instanceof Error ? err.message : String(err),
+        errorDetail(err),
       );
     } finally {
       signal?.removeEventListener('abort', onAbort);

--- a/src/cli/services/headless-worker-executor.ts
+++ b/src/cli/services/headless-worker-executor.ts
@@ -24,6 +24,7 @@ import { EventEmitter } from 'events';
 import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
 import type { WorkerType } from './worker-daemon.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ============================================
 // Type Definitions
@@ -967,7 +968,7 @@ export class HeadlessWorkerExecutor extends EventEmitter {
       this.emit('complete', executionResult);
       return executionResult;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = errorDetail(error);
       const executionResult = this.createErrorResult(workerType, errorMessage);
       executionResult.executionId = executionId;
       executionResult.durationMs = Date.now() - startTime;

--- a/src/cli/services/movector-training.ts
+++ b/src/cli/services/movector-training.ts
@@ -14,6 +14,7 @@
 
 import { createLoRAAdapter, type LoRAAdapter } from '../movector/lora-adapter.js';
 import { FlashAttention as PureTSFlashAttention } from '../movector/flash-attention.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 import {
   AdamWOptimizer,
   InfoNceLoss,
@@ -173,7 +174,7 @@ export async function initializeTraining(config: TrainingConfig = {}): Promise<{
     return {
       success: false,
       features,
-      error: error instanceof Error ? error.message : String(error),
+      error: errorDetail(error),
     };
   }
 }

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -32,6 +32,7 @@ import { withTimeout } from '../shared/resilience/retry.js';
 import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import { calculateDelay } from '../production/retry.js';
 import { CircuitBreaker } from '../production/circuit-breaker.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Worker types matching hooks-tools.ts
 export type WorkerType =
@@ -574,7 +575,7 @@ export class WorkerDaemon extends EventEmitter {
         await this.scheduler.stop();
         this.log('info', 'Spell scheduler stopped');
       } catch (err) {
-        this.log('warn', `Scheduler stop error: ${err instanceof Error ? err.message : String(err)}`);
+        this.log('warn', `Scheduler stop error: ${errorDetail(err)}`);
       }
     }
 
@@ -643,7 +644,7 @@ export class WorkerDaemon extends EventEmitter {
       try {
         await this.scheduler.stop();
       } catch (err) {
-        this.log('warn', `Scheduler stop during detach failed: ${err instanceof Error ? err.message : String(err)}`);
+        this.log('warn', `Scheduler stop during detach failed: ${errorDetail(err)}`);
       }
       this.scheduler = null;
     }
@@ -890,7 +891,7 @@ export class WorkerDaemon extends EventEmitter {
         type: workerConfig.type,
         success: false,
         durationMs,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorDetail(error),
         timestamp: new Date(),
       };
 
@@ -926,7 +927,7 @@ export class WorkerDaemon extends EventEmitter {
         this.log('warn', `Headless execution failed for ${workerConfig.type}, falling back to local mode`);
         this.emit('headless:fallback', {
           type: workerConfig.type,
-          error: error instanceof Error ? error.message : String(error),
+          error: errorDetail(error),
         });
         // Fall through to local execution
       }

--- a/src/cli/services/worker-queue.ts
+++ b/src/cli/services/worker-queue.ts
@@ -20,6 +20,7 @@
 import { EventEmitter } from 'events';
 import { randomUUID } from 'crypto';
 import type { HeadlessWorkerType, HeadlessExecutionResult, WorkerPriority } from './headless-worker-executor.js';
+import { errorDetail } from '../shared/utils/error-detail.js';
 
 // ============================================
 // Type Definitions
@@ -605,7 +606,7 @@ export class WorkerQueue extends EventEmitter {
             await new Promise(resolve => setTimeout(resolve, 1000));
           }
         } catch (error) {
-          this.emit('error', { error: error instanceof Error ? error.message : String(error) });
+          this.emit('error', { error: errorDetail(error) });
           // Wait before retrying to avoid tight error loop
           await new Promise(resolve => setTimeout(resolve, 5000));
         }
@@ -614,7 +615,7 @@ export class WorkerQueue extends EventEmitter {
 
     // Start processing
     processLoop().catch(error => {
-      this.emit('error', { error: error instanceof Error ? error.message : String(error) });
+      this.emit('error', { error: errorDetail(error) });
     });
   }
 
@@ -629,7 +630,7 @@ export class WorkerQueue extends EventEmitter {
       const result = await handler(task);
       await this.complete(task.id, result);
     } catch (error) {
-      await this.fail(task.id, error instanceof Error ? error.message : String(error));
+      await this.fail(task.id, errorDetail(error));
     }
   }
 

--- a/src/cli/shared/mcp/tool-registry.ts
+++ b/src/cli/shared/mcp/tool-registry.ts
@@ -15,6 +15,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { errorDetail } from '../utils/error-detail.js';
 import {
   MCPTool,
   JSONSchema,
@@ -403,7 +404,7 @@ export class ToolRegistry extends EventEmitter {
       return {
         content: [{
           type: 'text',
-          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          text: `Error: ${errorDetail(error)}`,
         }],
         isError: true,
       };

--- a/src/cli/shared/plugins/official/maestro-plugin.ts
+++ b/src/cli/shared/plugins/official/maestro-plugin.ts
@@ -9,6 +9,7 @@
 
 import type { ClaudeFlowPlugin, PluginContext, PluginConfig } from '../types.js';
 import { HookEvent, HookPriority, type TaskInfo, type ErrorInfo } from '../../hooks/index.js';
+import { errorDetail } from '../../utils/error-detail.js';
 
 /**
  * Maestro configuration
@@ -213,7 +214,7 @@ export class MaestroPlugin implements ClaudeFlowPlugin {
       spell.status = 'failed';
       errors.push({
         stepId: 'spell',
-        error: error instanceof Error ? error.message : String(error),
+        error: errorDetail(error),
       });
     } finally {
       this.activeSpells--;
@@ -414,7 +415,7 @@ export class MaestroPlugin implements ClaudeFlowPlugin {
       return { success: true, output: step.output };
     } catch (error) {
       step.status = 'failed';
-      step.error = error instanceof Error ? error.message : String(error);
+      step.error = errorDetail(error);
       step.completedAt = new Date();
 
       return { success: false, error: step.error };

--- a/src/cli/spells/commands/composite-command.ts
+++ b/src/cli/spells/commands/composite-command.ts
@@ -20,6 +20,7 @@ import type {
 } from '../types/step-command.types.js';
 import type { YamlStepDefinition, YamlInputDef, YamlAction } from '../loaders/yaml-step-loader.js';
 import { shellEscapeValue } from '../core/interpolation.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 export interface CompositeStepConfig extends StepConfig {
   readonly [key: string]: unknown;
@@ -73,7 +74,7 @@ export function createCompositeCommand(def: YamlStepDefinition): StepCommand<Com
             };
           }
         } catch (err) {
-          const errorMsg = err instanceof Error ? err.message : String(err);
+          const errorMsg = errorDetail(err);
           results.push({
             index: i,
             tool: action.tool,

--- a/src/cli/spells/connectors/http-tool.ts
+++ b/src/cli/spells/connectors/http-tool.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SpellConnector, ConnectorAction, ConnectorOutput } from '../types/spell-connector.types.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 // ============================================================================
 // Types
@@ -173,7 +174,7 @@ export const httpConnector: SpellConnector = {
       return {
         success: false,
         data: {},
-        error: err instanceof Error ? err.message : String(err),
+        error: errorDetail(err),
         duration: Date.now() - start,
       };
     }

--- a/src/cli/spells/connectors/imap.ts
+++ b/src/cli/spells/connectors/imap.ts
@@ -33,6 +33,7 @@ import {
   type InboxEmail,
 } from './local-outlook.js';
 import { loadOptional } from './shared/optional-import.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 const IMAP_INSTALL_MSG =
   "IMAP connector requires 'imapflow' and 'mailparser' to be installed. Run: npm i imapflow mailparser";
@@ -400,7 +401,7 @@ export function createImapConnector(): SpellConnector {
         return {
           success: false,
           data: {},
-          error: `imap: ${err instanceof Error ? err.message : String(err)}`,
+          error: `imap: ${errorDetail(err)}`,
           duration: Date.now() - start,
         };
       }

--- a/src/cli/spells/connectors/slack.ts
+++ b/src/cli/spells/connectors/slack.ts
@@ -18,6 +18,7 @@ import type {
   ConnectorAction,
   ConnectorOutput,
 } from '../types/spell-connector.types.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 // ============================================================================
 // Types
@@ -154,7 +155,7 @@ export function createSlackConnector(): SpellConnector {
         return {
           success: false,
           data: {},
-          error: err instanceof Error ? err.message : String(err),
+          error: errorDetail(err),
           duration: Date.now() - start,
         };
       }

--- a/src/cli/spells/core/connector-accessor.ts
+++ b/src/cli/spells/core/connector-accessor.ts
@@ -8,6 +8,7 @@
 
 import type { ConnectorAccessor, ConnectorView, ConnectorOutput, ConnectorCapability } from '../types/spell-connector.types.js';
 import type { SpellConnectorRegistry } from '../registry/connector-registry.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 export class ConnectorAccessorImpl implements ConnectorAccessor {
   private readonly initialized = new Set<string>();
@@ -58,7 +59,7 @@ export class ConnectorAccessorImpl implements ConnectorAccessor {
         return {
           success: false,
           data: {},
-          error: `Connector "${connectorName}" failed to initialize: ${err instanceof Error ? err.message : String(err)}`,
+          error: `Connector "${connectorName}" failed to initialize: ${errorDetail(err)}`,
         };
       }
     }

--- a/src/cli/spells/core/gated-connector-accessor.ts
+++ b/src/cli/spells/core/gated-connector-accessor.ts
@@ -8,6 +8,7 @@
 
 import type { ConnectorAccessor, ConnectorView, ConnectorOutput, ConnectorCapability } from '../types/spell-connector.types.js';
 import type { ICapabilityGateway } from './capability-gateway.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 export class GatedConnectorAccessor implements ConnectorAccessor {
   constructor(
@@ -35,7 +36,7 @@ export class GatedConnectorAccessor implements ConnectorAccessor {
       return {
         success: false,
         data: {},
-        error: `Connector "${connectorName}" blocked by capability gateway: ${err instanceof Error ? err.message : String(err)}`,
+        error: `Connector "${connectorName}" blocked by capability gateway: ${errorDetail(err)}`,
       };
     }
 

--- a/src/cli/spells/core/rollback-orchestrator.ts
+++ b/src/cli/spells/core/rollback-orchestrator.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types/runner.types.js';
 import type { StepDefinition } from '../types/spell-definition.types.js';
 import type { StepCommandRegistry } from './step-command-registry.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 export interface CompletedStep {
   step: StepDefinition;
@@ -49,7 +50,7 @@ export async function rollbackSteps(
         stepResults[idx] = {
           ...stepResults[idx],
           rollbackAttempted: true,
-          rollbackError: err instanceof Error ? err.message : String(err),
+          rollbackError: errorDetail(err),
         };
       }
     }

--- a/src/cli/spells/core/step-executor.ts
+++ b/src/cli/spells/core/step-executor.ts
@@ -34,6 +34,7 @@ import {
 import { executeWithTimeout } from './timeout-executor.js';
 import { CapabilityGateway } from './capability-gateway.js';
 import { GatedConnectorAccessor } from './gated-connector-accessor.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 const DEFAULT_STEP_TIMEOUT = 300_000; // 5 minutes
 
@@ -101,7 +102,7 @@ export async function executeSingleStep(
     interpolatedConfig = interpolateConfig(step.config as Record<string, unknown>, context);
   } catch (err) {
     return { stepId: step.id, stepType: step.type, status: 'failed',
-      error: `Variable interpolation failed: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Variable interpolation failed: ${errorDetail(err)}`,
       errorCode: 'STEP_EXECUTION_FAILED', duration: Date.now() - stepStart };
   }
 
@@ -152,7 +153,7 @@ export async function executeSingleStep(
     const isTimeout = err instanceof Error && err.message === 'Step timed out';
     return { stepId: step.id, stepType: step.type,
       status: isCancelled ? 'cancelled' : 'failed',
-      error: err instanceof Error ? err.message : String(err),
+      error: errorDetail(err),
       errorCode: isCancelled ? 'STEP_CANCELLED' : isTimeout ? 'STEP_TIMEOUT' : 'STEP_EXECUTION_FAILED',
       duration: Date.now() - stepStart };
   }
@@ -165,7 +166,7 @@ export async function executeSingleStep(
     if (command.rollback) {
       rollbackAttempted = true;
       try { await command.rollback(interpolatedConfig, context); }
-      catch (rbErr) { rollbackError = rbErr instanceof Error ? rbErr.message : String(rbErr); }
+      catch (rbErr) { rollbackError = errorDetail(rbErr); }
     }
     return { stepId: step.id, stepType: step.type, status: 'failed', output: maskedOutput,
       error: maskedOutput.error ?? 'Step execution returned failure',

--- a/src/cli/spells/factory/runner-factory.ts
+++ b/src/cli/spells/factory/runner-factory.ts
@@ -17,6 +17,7 @@ import { parseSpell } from '../schema/parser.js';
 import { validateSpellDefinition } from '../schema/validator.js';
 import { SpellConnectorRegistry } from '../registry/connector-registry.js';
 import { loadSandboxConfigFromProject } from '../core/platform-sandbox.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 // ============================================================================
 // Types
@@ -93,7 +94,7 @@ export async function runSpellFromContent(
       success: false,
       steps: [],
       outputs: {},
-      errors: [{ code: 'DEFINITION_VALIDATION_FAILED', message: `Parse error: ${err instanceof Error ? err.message : String(err)}` }],
+      errors: [{ code: 'DEFINITION_VALIDATION_FAILED', message: `Parse error: ${errorDetail(err)}` }],
       duration: 0,
       cancelled: false,
     };

--- a/src/cli/spells/loaders/definition-loader.ts
+++ b/src/cli/spells/loaders/definition-loader.ts
@@ -14,6 +14,7 @@ import { join, extname } from 'node:path';
 import { parseSpell } from '../schema/parser.js';
 import { validateSpellDefinition } from '../schema/validator.js';
 import type { SpellDefinition, ParsedSpell } from '../types/spell-definition.types.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 // ============================================================================
 // Types
@@ -136,7 +137,7 @@ function loadFromDirectory(
     } catch (err) {
       errors.push({
         file: filePath,
-        message: err instanceof Error ? err.message : String(err),
+        message: errorDetail(err),
       });
     }
   }

--- a/src/cli/spells/loaders/directory-step-loader.ts
+++ b/src/cli/spells/loaders/directory-step-loader.ts
@@ -17,6 +17,7 @@ import type { StepCommand } from '../types/step-command.types.js';
 
 const require = createRequire(import.meta.url);
 import { isYamlStepFile, loadYamlStep } from './yaml-step-loader.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 export interface DirectoryStepLoaderOptions {
   /** Directories to scan, in ascending priority order (last wins). */
@@ -101,7 +102,7 @@ function scanDirectory(
     } catch (err) {
       warnings.push({
         file: filePath,
-        message: err instanceof Error ? err.message : String(err),
+        message: errorDetail(err),
       });
     }
   }

--- a/src/cli/spells/loaders/npm-step-loader.ts
+++ b/src/cli/spells/loaders/npm-step-loader.ts
@@ -20,6 +20,7 @@ import { join, resolve } from 'node:path';
 import type { StepCommand } from '../types/step-command.types.js';
 import type { DiscoveredStep, DirectoryLoadWarning } from './directory-step-loader.js';
 import { isStepCommand } from './directory-step-loader.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 const NPM_STEP_PREFIX = 'moflo-step-';
 
@@ -61,7 +62,7 @@ export function loadStepsFromNpm(projectRoot: string): NpmLoadResult {
     } catch (err) {
       warnings.push({
         file: pkgDir,
-        message: err instanceof Error ? err.message : String(err),
+        message: errorDetail(err),
       });
     }
   }

--- a/src/cli/spells/registry/connector-registry.ts
+++ b/src/cli/spells/registry/connector-registry.ts
@@ -12,6 +12,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 import type {
   SpellConnector,
   ConnectorRegistryEntry,
@@ -183,7 +184,7 @@ export class SpellConnectorRegistry {
       } catch (err) {
         errors.push({
           file: candidate.file,
-          message: err instanceof Error ? err.message : String(err),
+          message: errorDetail(err),
         });
       }
     }
@@ -258,7 +259,7 @@ function discoverNpmConnectors(projectRoot: string): NpmConnectorDiscovery[] {
           ok: false,
           error: {
             file: pkgJsonPath,
-            message: err instanceof Error ? err.message : String(err),
+            message: errorDetail(err),
           },
         });
       }

--- a/src/cli/spells/scheduler/scheduler.ts
+++ b/src/cli/spells/scheduler/scheduler.ts
@@ -16,6 +16,7 @@ import type {
 } from './schedule.types.js';
 import { computeNextRun } from './cron-parser.js';
 import { compareMofloLevels } from '../core/capability-validator.js';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 // ============================================================================
 // Constants
@@ -505,7 +506,7 @@ export class SpellScheduler {
         ...initial,
         completedAt,
         success: false,
-        error: err instanceof Error ? err.message : String(err),
+        error: errorDetail(err),
         duration: completedAt - now,
       };
       await this.memory.write(NAMESPACE_EXECUTIONS, executionId, finalRecord);

--- a/src/cli/transfer/ipfs/client.ts
+++ b/src/cli/transfer/ipfs/client.ts
@@ -10,6 +10,7 @@
  */
 
 import * as crypto from 'crypto';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 /**
  * Available IPFS gateways in priority order
@@ -113,7 +114,7 @@ export async function resolveIPNS(
         return cid;
       }
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = errorDetail(error);
       console.warn(`[IPFS] Gateway ${gateway} failed: ${errorMsg}`);
       continue;
     }
@@ -168,7 +169,7 @@ export async function fetchFromIPFS<T>(
         console.warn(`[IPFS] Rate limited on ${gateway}, trying next...`);
       }
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = errorDetail(error);
       console.warn(`[IPFS] Gateway ${gateway} failed: ${errorMsg}`);
       continue;
     }

--- a/src/cli/transfer/serialization/cfp.ts
+++ b/src/cli/transfer/serialization/cfp.ts
@@ -5,6 +5,7 @@
 
 import type { CFPFormat, SerializationFormat, PatternCollection } from '../types.js';
 import * as crypto from 'crypto';
+import { errorDetail } from '../../shared/utils/error-detail.js';
 
 // Version info
 const CFP_VERSION = '1.0.0';
@@ -145,7 +146,7 @@ export function deserializeCFP(data: string | Buffer): CFPFormat {
   try {
     parsed = JSON.parse(str);
   } catch (e) {
-    throw new Error(`Invalid CFP file: ${e instanceof Error ? e.message : String(e)}`);
+    throw new Error(`Invalid CFP file: ${errorDetail(e)}`);
   }
 
   // Validate magic bytes


### PR DESCRIPTION
## Summary

Closes story 3 of epic #789. With this merged, all three stories close and #789 itself can close.

Mechanical migration: every canonical \`X instanceof Error ? X.message : String(X)\` site now calls \`errorDetail(X)\` from the existing helper at \`src/cli/shared/utils/error-detail.ts\` (adopted by \`doctor.ts\` in #785; epic body called this out as opportunistic / low-priority — knocking it out in one batch).

- **173 sites replaced** across **69 files**
- **67 new \`import { errorDetail } from '...'\` statements** added
- 3 trivial pass-through wrappers (\`errMsg\`, \`errorMsg\`) removed and inlined
- 2 firstLineOnly call sites cleaned up via \`errorDetail(e, { firstLineOnly: true })\`:
  - \`doctor-checks-deep.ts:467\`
  - \`github.ts:383-385\` (hoisted out of a per-label loop)

## Out of scope (intentional)

Variants with semantically different fallbacks were NOT migrated — they don't match the canonical pattern:
- \`: 'Unknown error'\` / \`: 'error'\` / \`: 'unknown error'\` (~36 sites)
- \`: new Error(String(error))\` form (need an Error object, not a string)

A reviewer agent flagged these as "marginally different fallback semantics, more truthful with errorDetail" — but converting them would change user-visible error messages, so they're left for case-by-case judgment.

## Behavior change

None measurable. \`errorDetail(e)\`'s implementation is byte-equivalent to the inline pattern: \`e instanceof Error ? e.message : String(e)\`. Hot-path review confirmed every replaced site is inside a \`catch\` block — exception construction dwarfs the function-call cost by orders of magnitude.

## Test plan

- [x] \`npx tsc --noEmit\` → clean
- [x] \`npx eslint src/cli --max-warnings 0\` → clean
- [x] \`npm run build\` → success
- [x] \`npm test\` → 7434 tests passed (no regressions)
- [x] \`grep -rEn '(\w+) instanceof Error \? \1\.message : String\(\1\)' src/cli\` → only matches the helper itself

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)