### PR TITLE
fix: sync SCRIPT_MAP across init/upgrade + README hook-count drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,16 +293,16 @@ For simple epics with independent stories, `/flo <epic>` is all you need. For co
 `flo epic` is the robust epic runner — it adds persistent state, resume from failure, and per-story auto-merge on top of `/flo`. It takes a GitHub epic issue number:
 
 ```bash
-flo epic run 42                            # Fetch epic #42, run all stories sequentially
-flo epic run 42 --dry-run                  # Preview execution plan without running
-flo epic run 42 --strategy auto-merge      # Per-story PRs with auto-merge between stories
+flo epic 42                                # Fetch epic #42, run all stories sequentially
+flo epic 42 --dry-run                      # Preview execution plan without running
+flo epic 42 --strategy auto-merge          # Per-story PRs with auto-merge between stories
 flo epic status 42                         # Check progress (which stories passed/failed)
 flo epic reset 42                          # Reset state for re-run
 ```
 
-`flo epic` fetches the epic from GitHub, extracts child stories from checklists, numbered references, and `## Stories` / `## Tasks` sections, then runs each through `/flo` with state tracking. If a story fails, you can fix the issue and `flo epic run 42` again — it resumes from where it left off, skipping already-passed stories.
+`flo epic` fetches the epic from GitHub, extracts child stories from checklists, numbered references, and `## Stories` / `## Tasks` sections, then runs each through `/flo` with state tracking. If a story fails, you can fix the issue and re-run `flo epic 42` — it resumes from where it left off, skipping already-passed stories. (`flo epic run 42` is an explicit alias for the same shorthand.)
 
-| | `/flo <epic>` | `flo epic run <epic>` |
+| | `/flo <epic>` | `flo epic <epic>` |
 |---|---|---|
 | **State tracking** | No | Yes (`epic-state` memory namespace) |
 | **Resume from failure** | No | Yes (skips passed stories) |
@@ -583,7 +583,7 @@ flo --version                    # Show version
 
 ### Hooks (enabled OOTB)
 
-Hooks are shell commands that Claude Code runs automatically at specific points in its lifecycle. MoFlo installs 20 hook bindings across 8 lifecycle events. You don't invoke these — they fire automatically.
+Hooks are shell commands that Claude Code runs automatically at specific points in its lifecycle. MoFlo installs 23 hook bindings across 8 lifecycle events. You don't invoke these — they fire automatically.
 
 | Hook Event | What fires | What it does | Enabled OOTB |
 |------------|-----------|-------------|:---:|
@@ -593,9 +593,12 @@ Hooks are shell commands that Claude Code runs automatically at specific points 
 | **PreToolUse: Bash** | `flo gate check-dangerous-command` | Safety check on shell commands | Yes |
 | **PreToolUse: Bash** | `flo gate check-before-pr` | Validates PR readiness before `gh pr create` | Yes |
 | **PostToolUse: Write/Edit** | `flo hooks post-edit` | Records edit outcome, optionally trains neural patterns | Yes |
+| **PostToolUse: Write/Edit** | `flo gate reset-edit-gates` | Resets edit-related gate state after the write completes | Yes |
 | **PostToolUse: Agent** | `flo hooks post-task` | Records task completion, feeds outcome into routing learner | Yes |
 | **PostToolUse: TaskCreate** | `flo gate record-task-created` | Records that a task was registered (clears TaskCreate gate) | Yes |
 | **PostToolUse: Bash** | `flo gate check-bash-memory` | Detects memory search commands in Bash (clears memory gate) | Yes |
+| **PostToolUse: Bash** | `flo gate record-test-run` | Records test runs from Bash for the test-output gate | Yes |
+| **PostToolUse: Skill** | `flo gate record-skill-run` | Records that a skill was invoked (clears skill-related gates) | Yes |
 | **PostToolUse: memory_search** | `flo gate record-memory-searched` | Records that memory was searched (clears memory-first gate) | Yes |
 | **PostToolUse: TaskUpdate** | `flo gate check-task-transition` | Validates task state transitions (prevents skipping states) | Yes |
 | **PostToolUse: memory_store** | `flo gate record-learnings-stored` | Records that learnings were persisted to memory | Yes |

--- a/src/cli/__tests__/init-copy-maps.test.ts
+++ b/src/cli/__tests__/init-copy-maps.test.ts
@@ -19,6 +19,7 @@ import * as os from 'os';
 import { executeInit, DEFAULT_INIT_OPTIONS } from '../init/index.js';
 import { SKILLS_MAP, AGENTS_MAP } from '../init/executor.js';
 import type { InitOptions } from '../init/types.js';
+import { findRepoRoot } from './_helpers/repo-walk.js';
 
 // ============================================================================
 // Runtime: executeInit doesn't crash on missing map keys
@@ -189,3 +190,31 @@ describe.each(['agents', 'skills'])(
     });
   },
 );
+
+// SCRIPT_MAP divergence guard — the shipped-script list lives in 3 production
+// sites that must agree (#777, #84, feedback_scriptfiles_sync.md).
+describe('shipped script lists agree across all sync sites', () => {
+  const repoRoot = findRepoRoot(import.meta.url);
+
+  function extractScripts(source: string, varName: string): string[] {
+    const re = new RegExp(`const\\s+${varName}[^=]*=\\s*[\\[{]([\\s\\S]*?)[\\]}];`, 'm');
+    const block = source.match(re)?.[1] ?? '';
+    return [...block.matchAll(/['"]([\w.-]+\.mjs)['"]/g)].map(m => m[1]).sort();
+  }
+
+  it('moflo-init.ts SCRIPT_MAP, executor.ts UPGRADE_SCRIPT_MAP, and session-start-launcher.mjs scriptFiles all contain the same files', () => {
+    const initSrc = fs.readFileSync(path.join(repoRoot, 'src/cli/init/moflo-init.ts'), 'utf-8');
+    const executorSrc = fs.readFileSync(path.join(repoRoot, 'src/cli/init/executor.ts'), 'utf-8');
+    const launcherSrc = fs.readFileSync(path.join(repoRoot, 'bin/session-start-launcher.mjs'), 'utf-8');
+
+    const init = extractScripts(initSrc, 'SCRIPT_MAP');
+    const upgrade = extractScripts(executorSrc, 'UPGRADE_SCRIPT_MAP');
+    const launcher = extractScripts(launcherSrc, 'scriptFiles');
+
+    // Guard against a regex break that returns [] from all 3 — would silently
+    // pass the parity check and let real drift through.
+    expect(init.length).toBeGreaterThan(0);
+    expect(init).toEqual(upgrade);
+    expect(init).toEqual(launcher);
+  });
+});

--- a/src/cli/init/executor.ts
+++ b/src/cli/init/executor.ts
@@ -459,24 +459,24 @@ export async function executeUpgrade(targetDir: string, _upgradeSettings = false
     // Must mirror the list in bin/session-start-launcher.mjs — divergence
     // here means the launcher's drift-repair will delete files this upgrade
     // didn't track, even though they ship in the package (#777).
-    const UPGRADE_SCRIPT_MAP: Record<string, string> = {
-      'hooks.mjs': 'hooks.mjs',
-      'session-start-launcher.mjs': 'session-start-launcher.mjs',
-      'index-guidance.mjs': 'index-guidance.mjs',
-      'build-embeddings.mjs': 'build-embeddings.mjs',
-      'generate-code-map.mjs': 'generate-code-map.mjs',
-      'semantic-search.mjs': 'semantic-search.mjs',
-      'index-tests.mjs': 'index-tests.mjs',
-      'index-patterns.mjs': 'index-patterns.mjs',
-      'index-all.mjs': 'index-all.mjs',
-      'setup-project.mjs': 'setup-project.mjs',
-      'run-migrations.mjs': 'run-migrations.mjs',
-    };
+    const UPGRADE_SCRIPT_MAP: string[] = [
+      'hooks.mjs',
+      'session-start-launcher.mjs',
+      'index-guidance.mjs',
+      'build-embeddings.mjs',
+      'generate-code-map.mjs',
+      'semantic-search.mjs',
+      'index-tests.mjs',
+      'index-patterns.mjs',
+      'index-all.mjs',
+      'setup-project.mjs',
+      'run-migrations.mjs',
+    ];
     const binDir = findMofloBinDir();
     if (binDir) {
-      for (const [destName, srcName] of Object.entries(UPGRADE_SCRIPT_MAP)) {
-        const srcPath = path.join(binDir, srcName);
-        const destPath = path.join(scriptsDir, destName);
+      for (const name of UPGRADE_SCRIPT_MAP) {
+        const srcPath = path.join(binDir, name);
+        const destPath = path.join(scriptsDir, name);
         if (!fs.existsSync(srcPath)) continue;
         try {
           const srcStat = fs.statSync(srcPath);
@@ -490,9 +490,9 @@ export async function executeUpgrade(targetDir: string, _upgradeSettings = false
             fs.copyFileSync(srcPath, destPath);
           }
           if (destExists) {
-            result.updated.push(`.claude/scripts/${destName}`);
+            result.updated.push(`.claude/scripts/${name}`);
           } else {
-            result.created.push(`.claude/scripts/${destName}`);
+            result.created.push(`.claude/scripts/${name}`);
           }
         } catch {
           // Non-fatal — skip individual script on error

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -786,15 +786,23 @@ ${MOFLO_MARKER_END}
 // Always overwrite to keep them in sync with the installed moflo version.
 // ============================================================================
 
-const SCRIPT_MAP: Record<string, string> = {
-  'hooks.mjs': 'hooks.mjs',
-  'session-start-launcher.mjs': 'session-start-launcher.mjs',
-  'index-guidance.mjs': 'index-guidance.mjs',
-  'build-embeddings.mjs': 'build-embeddings.mjs',
-  'generate-code-map.mjs': 'generate-code-map.mjs',
-  'semantic-search.mjs': 'semantic-search.mjs',
-  'index-tests.mjs': 'index-tests.mjs',
-};
+// Must mirror UPGRADE_SCRIPT_MAP in src/cli/init/executor.ts and the
+// scriptFiles array in bin/session-start-launcher.mjs — first-init drops any
+// script missing here, and the launcher's manifest cleanup later treats it as
+// orphan residue and deletes it (#777, feedback_scriptfiles_sync.md).
+const SCRIPT_MAP: string[] = [
+  'hooks.mjs',
+  'session-start-launcher.mjs',
+  'index-guidance.mjs',
+  'build-embeddings.mjs',
+  'generate-code-map.mjs',
+  'semantic-search.mjs',
+  'index-tests.mjs',
+  'index-patterns.mjs',
+  'index-all.mjs',
+  'setup-project.mjs',
+  'run-migrations.mjs',
+];
 
 function syncScripts(root: string, force?: boolean): MofloInitResult['steps'][0] {
   const scriptsDir = path.join(root, '.claude', 'scripts');
@@ -815,9 +823,9 @@ function syncScripts(root: string, force?: boolean): MofloInitResult['steps'][0]
   }
 
   let copied = 0;
-  for (const [dest, src] of Object.entries(SCRIPT_MAP)) {
-    const srcPath = path.join(binDir, src);
-    const destPath = path.join(scriptsDir, dest);
+  for (const name of SCRIPT_MAP) {
+    const srcPath = path.join(binDir, name);
+    const destPath = path.join(scriptsDir, name);
 
     if (!fs.existsSync(srcPath)) continue;
 

--- a/tests/init-test-dirs.test.ts
+++ b/tests/init-test-dirs.test.ts
@@ -67,7 +67,7 @@ describe('moflo-init.ts test directory support', () => {
     expect(content).toContain('discoverTestDirs(root)');
   });
 
-  it('SCRIPT_MAP includes index-tests.mjs', () => {
-    expect(content).toContain("'index-tests.mjs': 'index-tests.mjs'");
-  });
+  // SCRIPT_MAP membership is asserted strictly in init-copy-maps.test.ts
+  // ('shipped script lists agree across all sync sites'), which extracts the
+  // block and diffs all 3 sync sites — strictly stronger than a loose toContain.
 });


### PR DESCRIPTION
## Summary

Audit-driven fixes covering one consumer-impacting bug + README accuracy drift, plus simplify-pass cleanups.

### 1. `flo init` was missing 4 mirrored scripts (consumer-impacting)

The shipped-script list lives in 3 production sites that **must** agree (per `feedback_scriptfiles_sync.md`):

| Site | Entries before |
|---|---|
| `src/cli/init/moflo-init.ts` `SCRIPT_MAP` (first init) | **7** ⚠ |
| `src/cli/init/executor.ts` `UPGRADE_SCRIPT_MAP` (upgrade) | 11 ✓ |
| `bin/session-start-launcher.mjs` `scriptFiles` (launcher) | 11 ✓ |

Fresh `flo init` was mirroring only 7 scripts to `.claude/scripts/` — `index-patterns.mjs`, `index-all.mjs`, `setup-project.mjs`, `run-migrations.mjs` only landed after a subsequent moflo upgrade ran.

This PR brings `moflo-init.ts` to 11 entries and adds a static parity test in `init-copy-maps.test.ts` that diffs the three lists at parse time. Cross-language shared-module DRY (TS + `.mjs`) would have expanded scope; the test enforces parity at zero runtime cost, with a `length > 0` floor to catch a regex break.

### 2. Simplify-pass cleanups

- Collapsed `SCRIPT_MAP` and `UPGRADE_SCRIPT_MAP` from `Record<string, string>` to `string[]` — every entry was identity (`'foo.mjs': 'foo.mjs'`); the Record shape was over-engineered. Consumer loops simplify to `for (const name of ...)`.
- Removed redundant `'SCRIPT_MAP includes index-tests.mjs'` assertion in `tests/init-test-dirs.test.ts` — strictly subsumed by the new parity test, with a breadcrumb comment pointing at it.
- Switched the new test's `repoRoot` to `findRepoRoot(import.meta.url)` per `feedback_no_fixed_depth_paths.md`.
- Collapsed two near-duplicate regex extractors into one (`extractScripts`) — possible because all 3 lists are now arrays.

### 3. README hook count off-by-3

- Claimed "20 hook bindings across 8 lifecycle events" → actual is **23 bindings, 8 events** (`settings-generator.ts` emits 23 `type: 'command'` hook entries; the 24th is the statusline).
- Hook table was missing 3 rows: PostToolUse `reset-edit-gates`, `record-test-run`, `record-skill-run`.

### 4. Canonical `flo epic` syntax

- README mixed `flo epic 42` and `flo epic run 42`. Both work, but `epic.ts` treats the bare form as primary. Standardized on the bare form, mentioning `run` once as the explicit alias.

### Audit findings already accurate (no change needed)

- 9 bin entries ✓
- 12 task patterns ✓
- 28 parallel health checks ✓
- "100+ MCP tools" — actual count is 112 ✓
- All major path resolution uses `import.meta.url` / `mofloPath()` anchors ✓
- All shipped CLI commands documented in README exist ✓

## Test plan

- [x] `npx vitest run init-copy-maps + init-test-dirs` — 19/19 pass (incl. new divergence guard)
- [x] `npx vitest run init-copy-maps + auto-update` — 41/41 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 887 passed; one pre-existing unrelated failure in `sandbox-tier-integration.test.ts` (cache-reset non-determinism on Windows w/ Docker installed) flagged for separate triage

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)