### PR TITLE
fix(sandbox): bump detection timeouts so cold-start probes are deterministic

### DIFF
--- a/src/cli/spells/core/platform-sandbox.ts
+++ b/src/cli/spells/core/platform-sandbox.ts
@@ -154,10 +154,16 @@ function detectWindows(): SandboxCapability {
 // Helpers
 // ============================================================================
 
+// Detection runs once per process and is cached, so timeouts can be generous.
+// Cold-start `docker info` on Windows can take 5-10s on the named-pipe
+// handshake, so a tight budget would falsely report the daemon down.
+const BINARY_EXISTS_TIMEOUT_MS = 10_000;
+const DOCKER_DAEMON_TIMEOUT_MS = 15_000;
+
 function binaryExists(name: string): boolean {
   try {
     const cmd = platform() === 'win32' ? `where ${name}` : `which ${name}`;
-    execSync(cmd, { stdio: 'ignore', timeout: 5000 });
+    execSync(cmd, { stdio: 'ignore', timeout: BINARY_EXISTS_TIMEOUT_MS });
     return true;
   } catch {
     return false;
@@ -166,7 +172,7 @@ function binaryExists(name: string): boolean {
 
 function dockerDaemonRunning(): boolean {
   try {
-    execSync('docker info', { stdio: 'ignore', timeout: 4000 });
+    execSync('docker info', { stdio: 'ignore', timeout: DOCKER_DAEMON_TIMEOUT_MS });
     return true;
   } catch {
     return false;
@@ -319,7 +325,9 @@ function dockerImageExists(image: string): boolean {
   const cached = _imageExistsCache.get(image);
   if (cached !== undefined) return cached;
   try {
-    execSync(`docker image inspect ${escapeShellArg(image)}`, { stdio: 'ignore', timeout: 5000 });
+    // Same cold-start budget as `docker info` — both hit the Docker Desktop
+    // daemon over its named-pipe handshake. Result is cached per image.
+    execSync(`docker image inspect ${escapeShellArg(image)}`, { stdio: 'ignore', timeout: DOCKER_DAEMON_TIMEOUT_MS });
     _imageExistsCache.set(image, true);
     return true;
   } catch {


### PR DESCRIPTION
## Summary

Followup from PR #794's audit. `detectSandboxCapability()` was non-deterministic across consecutive calls on Windows under fork pressure.

## Root cause

`docker info`'s 4 s timeout was tighter than Docker Desktop's named-pipe handshake on cold start, especially under cumulative GC/fork pressure during the sequential isolation-batch test phase. Repro:

```
First probe:  execSync('docker info', {timeout: 4000}) → TIMEOUT → catch → {available: false}
Second probe: docker is now warm                       → 200ms   → ok    → {available: true}
```

The isolation-batch test `resetSandboxCache allows re-detection` (`src/cli/__tests__/spells/sandbox-tier-integration.test.ts:225`) asserts the two probes agree, so it reliably failed on dev machines with Docker installed.

## Fix

Detection is cached for process lifetime (`let _cached`), so a generous one-shot budget is correct:

| Call site | Before | After |
|---|---|---|
| `where`/`which <bin>` | 5 s | 10 s |
| `docker info` | 4 s | 15 s |
| `docker image inspect` | 5 s | 15 s (reuses `DOCKER_DAEMON_TIMEOUT_MS`) |

`dockerImageExists` was bumped too because it hits the same Docker Desktop RPC handshake as `docker info` — same cold-start failure mode, same fix. All three now route through named constants with a comment explaining the rationale.

## Why not reuse `commandExists()` from `prerequisite-checker.ts`?

That helper is async (`Promise<boolean>`) and timeout-less. Swapping `binaryExists()` for `commandExists()` would require cascading async through every consumer of `detectSandboxCapability()` (doctor checks, statusline, MCP tools). Out of scope for a timeout bug fix; flagged for a future cleanup pass.

## Test plan

- [x] Repro confirmed (4 s timeout was the cause)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run sandbox-tier-integration.test.ts --config vitest.isolation.config.ts` — 56/56 pass
- [x] `npm test` (full parallel + isolation batch) — **888 passed, 0 failed** — was 887/1 before this fix

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)