### PR TITLE
refactor(sandbox): make detection async, share commandExists + execFileAsync

### DIFF
--- a/src/cli/__tests__/doctor-sandbox-tier.test.ts
+++ b/src/cli/__tests__/doctor-sandbox-tier.test.ts
@@ -24,8 +24,8 @@ describe('doctor sandbox tier diagnostic', { timeout: 15_000 }, () => {
     vi.restoreAllMocks();
   });
 
-  it('detectSandboxCapability returns a valid SandboxCapability', () => {
-    const cap = detectSandboxCapability();
+  it('detectSandboxCapability returns a valid SandboxCapability', async () => {
+    const cap = await detectSandboxCapability();
 
     expect(cap).toHaveProperty('platform');
     expect(cap).toHaveProperty('available');
@@ -34,26 +34,26 @@ describe('doctor sandbox tier diagnostic', { timeout: 15_000 }, () => {
     expect(typeof cap.available).toBe('boolean');
   });
 
-  it('returns cached result on subsequent calls', () => {
-    const first = detectSandboxCapability();
-    const second = detectSandboxCapability();
+  it('returns cached result on subsequent calls', async () => {
+    const first = await detectSandboxCapability();
+    const second = await detectSandboxCapability();
 
     // Same reference — cached
     expect(first).toBe(second);
   });
 
-  it('resetSandboxCache clears the cache', () => {
-    const first = detectSandboxCapability();
+  it('resetSandboxCache clears the cache', async () => {
+    const first = await detectSandboxCapability();
     resetSandboxCache();
-    const second = detectSandboxCapability();
+    const second = await detectSandboxCapability();
 
     // Different reference after cache reset (though values may be equal)
     expect(first).not.toBe(second);
     expect(first).toEqual(second);
   });
 
-  it('capability fields match expected doctor output format', () => {
-    const cap = detectSandboxCapability();
+  it('capability fields match expected doctor output format', async () => {
+    const cap = await detectSandboxCapability();
 
     // Doctor check formats: `${cap.tool} (${cap.platform})` or `denylist only (${cap.platform})`
     if (cap.available) {
@@ -68,8 +68,8 @@ describe('doctor sandbox tier diagnostic', { timeout: 15_000 }, () => {
     }
   });
 
-  it('platform matches current OS', () => {
-    const cap = detectSandboxCapability();
+  it('platform matches current OS', async () => {
+    const cap = await detectSandboxCapability();
     expect(cap.platform).toBe(process.platform);
   });
 });

--- a/src/cli/__tests__/spells/platform-sandbox.test.ts
+++ b/src/cli/__tests__/spells/platform-sandbox.test.ts
@@ -2,12 +2,38 @@
  * Platform Sandbox Detection Tests
  *
  * Tests for OS-level sandbox detection and config resolution.
- * Uses mocking to test all platform paths without requiring actual OS tools.
+ * Mocks at three abstraction boundaries:
+ *   - `commandExists` (prerequisite-checker) — binary-on-PATH probes
+ *   - `execFileAsync`  (shell.ts)              — `docker info` / `docker image inspect`
+ *   - `spawn`          (child_process)         — `docker pull`
  *
  * @see https://github.com/eric-cielo/moflo/issues/409
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('node:os', () => ({
+  platform: vi.fn(() => 'linux'),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ''),
+}));
+
+vi.mock('../../spells/core/prerequisite-checker.js', () => ({
+  commandExists: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock('../../spells/core/shell.js', () => ({
+  execFileAsync: vi.fn(() => Promise.resolve({ stdout: '', stderr: '', exitCode: 0 })),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
 import {
   detectSandboxCapability,
   resetSandboxCache,
@@ -15,38 +41,55 @@ import {
   resolveEffectiveSandbox,
   formatSandboxLog,
   DEFAULT_SANDBOX_CONFIG,
-  type SandboxConfig,
 } from '../../spells/core/platform-sandbox.js';
-
-// ============================================================================
-// Mocks
-// ============================================================================
-
-vi.mock('node:os', () => ({
-  platform: vi.fn(() => 'linux'),
-}));
-
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
-  exec: vi.fn(),
-  spawn: vi.fn(),
-}));
-
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(() => false),
-}));
-
 import { platform } from 'node:os';
-import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { commandExists } from '../../spells/core/prerequisite-checker.js';
+import { execFileAsync } from '../../spells/core/shell.js';
+import { spawn } from 'node:child_process';
 
 const mockPlatform = vi.mocked(platform);
-const mockExecSync = vi.mocked(execSync);
 const mockExistsSync = vi.mocked(existsSync);
+const mockCommandExists = vi.mocked(commandExists);
+const mockExecFileAsync = vi.mocked(execFileAsync);
+const mockSpawn = vi.mocked(spawn);
+
+// ── Mock helpers ──────────────────────────────────────────────────────
+
+/** All `docker <args>` probes return exitCode 0 (success). */
+function dockerSuccess(): void {
+  mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+}
+
+/** All `docker <args>` probes return exitCode 1 (daemon down / not found). */
+function dockerFailure(): void {
+  mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '', exitCode: 1 });
+}
+
+/** Per-args dispatch: route specific docker probes to success/failure exit codes. */
+function dockerRouter(decide: (args: readonly string[]) => 0 | 1): void {
+  mockExecFileAsync.mockImplementation(async (_file, args) => ({
+    stdout: '', stderr: '', exitCode: decide(args),
+  }));
+}
+
+/** Make spawn() return a fake child that emits exit 0 next tick. */
+function spawnSuccess(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockSpawn.mockImplementation(((..._args: any[]) => {
+    const proc = new EventEmitter() as EventEmitter & { kill: () => boolean };
+    proc.kill = () => true;
+    setImmediate(() => proc.emit('exit', 0));
+    return proc as unknown as ReturnType<typeof spawn>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any);
+}
 
 beforeEach(() => {
   resetSandboxCache();
   vi.clearAllMocks();
+  mockCommandExists.mockResolvedValue(false);
+  dockerSuccess(); // benign default
 });
 
 // ============================================================================
@@ -54,151 +97,104 @@ beforeEach(() => {
 // ============================================================================
 
 describe('detectSandboxCapability', () => {
-
-  // ── macOS ──────────────────────────────────────────────────────────
-
   describe('macOS', () => {
-    beforeEach(() => {
-      mockPlatform.mockReturnValue('darwin');
-    });
+    beforeEach(() => mockPlatform.mockReturnValue('darwin'));
 
-    it('detects sandbox-exec when present', () => {
+    it('detects sandbox-exec when present', async () => {
       mockExistsSync.mockReturnValue(true);
-      const result = detectSandboxCapability();
+      const result = await detectSandboxCapability();
       expect(result).toEqual({
-        platform: 'darwin',
-        available: true,
-        tool: 'sandbox-exec',
-        overhead: 'low',
+        platform: 'darwin', available: true, tool: 'sandbox-exec', overhead: 'low',
       });
     });
 
-    it('returns unavailable when sandbox-exec is missing', () => {
+    it('returns unavailable when sandbox-exec is missing', async () => {
       mockExistsSync.mockReturnValue(false);
-      const result = detectSandboxCapability();
+      const result = await detectSandboxCapability();
       expect(result).toEqual({
-        platform: 'darwin',
-        available: false,
-        tool: null,
-        overhead: null,
+        platform: 'darwin', available: false, tool: null, overhead: null,
       });
     });
   });
-
-  // ── Linux ──────────────────────────────────────────────────────────
 
   describe('Linux', () => {
-    beforeEach(() => {
-      mockPlatform.mockReturnValue('linux');
-    });
+    beforeEach(() => mockPlatform.mockReturnValue('linux'));
 
-    it('detects bwrap when present', () => {
-      mockExecSync.mockReturnValue(Buffer.from('/usr/bin/bwrap'));
-      const result = detectSandboxCapability();
+    it('detects bwrap when present', async () => {
+      mockCommandExists.mockResolvedValue(true);
+      const result = await detectSandboxCapability();
       expect(result).toEqual({
-        platform: 'linux',
-        available: true,
-        tool: 'bwrap',
-        overhead: 'low',
+        platform: 'linux', available: true, tool: 'bwrap', overhead: 'low',
       });
     });
 
-    it('returns unavailable when bwrap is absent', () => {
-      mockExecSync.mockImplementation(() => { throw new Error('not found'); });
-      const result = detectSandboxCapability();
+    it('returns unavailable when bwrap is absent', async () => {
+      mockCommandExists.mockResolvedValue(false);
+      const result = await detectSandboxCapability();
       expect(result).toEqual({
-        platform: 'linux',
-        available: false,
-        tool: null,
-        overhead: null,
+        platform: 'linux', available: false, tool: null, overhead: null,
       });
     });
   });
-
-  // ── Windows ────────────────────────────────────────────────────────
 
   describe('Windows', () => {
-    beforeEach(() => {
-      mockPlatform.mockReturnValue('win32');
-    });
+    beforeEach(() => mockPlatform.mockReturnValue('win32'));
 
-    it('detects Docker Desktop when installed and daemon running', () => {
-      // First call: `where docker` succeeds
-      // Second call: `docker info` succeeds
-      mockExecSync.mockReturnValue(Buffer.from(''));
-      const result = detectSandboxCapability();
+    it('detects Docker Desktop when installed and daemon running', async () => {
+      mockCommandExists.mockResolvedValue(true); // docker on PATH
+      dockerSuccess(); // docker info ok
+      const result = await detectSandboxCapability();
       expect(result).toEqual({
-        platform: 'win32',
-        available: true,
-        tool: 'docker',
-        overhead: 'medium',
+        platform: 'win32', available: true, tool: 'docker', overhead: 'medium',
       });
     });
 
-    it('returns unavailable when docker binary not found', () => {
-      mockExecSync.mockImplementation(() => { throw new Error('not found'); });
-      const result = detectSandboxCapability();
+    it('returns unavailable when docker binary not found', async () => {
+      mockCommandExists.mockResolvedValue(false);
+      const result = await detectSandboxCapability();
       expect(result).toEqual({
-        platform: 'win32',
-        available: false,
-        tool: null,
-        overhead: null,
+        platform: 'win32', available: false, tool: null, overhead: null,
       });
     });
 
-    it('returns unavailable when docker daemon is not running', () => {
-      let callCount = 0;
-      mockExecSync.mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) return Buffer.from(''); // `where docker` OK
-        throw new Error('daemon not running'); // `docker info` fails
-      });
-      const result = detectSandboxCapability();
+    it('returns unavailable when docker daemon is not running', async () => {
+      mockCommandExists.mockResolvedValue(true);
+      dockerFailure(); // docker info errors
+      const result = await detectSandboxCapability();
       expect(result).toEqual({
-        platform: 'win32',
-        available: false,
-        tool: null,
-        overhead: null,
+        platform: 'win32', available: false, tool: null, overhead: null,
       });
     });
   });
 
-  // ── Unsupported platform ────────────────────────────────────────────
-
-  it('returns unavailable for unsupported platforms', () => {
+  it('returns unavailable for unsupported platforms', async () => {
     mockPlatform.mockReturnValue('freebsd' as NodeJS.Platform);
-    const result = detectSandboxCapability();
+    const result = await detectSandboxCapability();
     expect(result).toEqual({
-      platform: 'freebsd',
-      available: false,
-      tool: null,
-      overhead: null,
+      platform: 'freebsd', available: false, tool: null, overhead: null,
     });
   });
 
-  // ── Caching ─────────────────────────────────────────────────────────
-
-  it('caches the result for the process lifetime', () => {
+  it('caches the result for the process lifetime', async () => {
     mockPlatform.mockReturnValue('linux');
-    mockExecSync.mockReturnValue(Buffer.from('/usr/bin/bwrap'));
+    mockCommandExists.mockResolvedValue(true);
 
-    const first = detectSandboxCapability();
-    const second = detectSandboxCapability();
+    const first = await detectSandboxCapability();
+    const second = await detectSandboxCapability();
 
-    expect(first).toBe(second); // Same reference
-    // execSync called only for the first detection (which for linux)
-    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(mockCommandExists).toHaveBeenCalledTimes(1);
   });
 
-  it('resetSandboxCache allows re-detection', () => {
+  it('resetSandboxCache allows re-detection', async () => {
     mockPlatform.mockReturnValue('linux');
-    mockExecSync.mockReturnValue(Buffer.from('/usr/bin/bwrap'));
+    mockCommandExists.mockResolvedValue(true);
 
-    detectSandboxCapability();
+    await detectSandboxCapability();
     resetSandboxCache();
-    detectSandboxCapability();
+    await detectSandboxCapability();
 
-    expect(mockExecSync).toHaveBeenCalledTimes(2);
+    expect(mockCommandExists).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -235,153 +231,9 @@ describe('resolveSandboxConfig', () => {
 
   it('ignores non-boolean enabled values', () => {
     const config = resolveSandboxConfig({ enabled: 'yes' });
-    expect(config.enabled).toBe(false); // default (sandbox off unless opted in)
-  });
-});
-
-// ============================================================================
-// resolveEffectiveSandbox()
-// ============================================================================
-
-describe('resolveEffectiveSandbox', () => {
-  beforeEach(() => {
-    mockPlatform.mockReturnValue('linux');
-    mockExecSync.mockReturnValue(Buffer.from('/usr/bin/bwrap'));
+    expect(config.enabled).toBe(false);
   });
 
-  it('uses OS sandbox when available and config is auto', () => {
-    const effective = resolveEffectiveSandbox({ enabled: true, tier: 'auto' });
-    expect(effective.useOsSandbox).toBe(true);
-    expect(effective.capability.tool).toBe('bwrap');
-    expect(effective.displayStatus).toContain('bwrap');
-  });
-
-  it('disables OS sandbox when config.enabled is false', () => {
-    const effective = resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
-    expect(effective.useOsSandbox).toBe(false);
-    expect(effective.displayStatus).toContain('disabled');
-  });
-
-  it('disables OS sandbox when tier is denylist-only', () => {
-    const effective = resolveEffectiveSandbox({ enabled: true, tier: 'denylist-only' });
-    expect(effective.useOsSandbox).toBe(false);
-    expect(effective.displayStatus).toContain('disabled');
-  });
-
-  it('throws when tier is full but no sandbox available', () => {
-    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
-    expect(() => resolveEffectiveSandbox({ enabled: true, tier: 'full' })).toThrow(
-      /Sandbox tier "full" requires an OS sandbox/,
-    );
-  });
-
-  it('falls back gracefully when tier is auto and no sandbox available', () => {
-    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
-    const effective = resolveEffectiveSandbox({ enabled: true, tier: 'auto' });
-    expect(effective.useOsSandbox).toBe(false);
-    expect(effective.displayStatus).toContain('not available');
-  });
-
-  // ── Windows-specific Docker setup guidance ─────────────────────────
-
-  describe('Windows Docker setup errors', () => {
-    beforeEach(() => {
-      mockPlatform.mockReturnValue('win32');
-    });
-
-    it('throws friendly message when sandbox enabled but Docker not installed', () => {
-      // binaryExists(docker) returns false
-      mockExecSync.mockImplementation(() => { throw new Error('where: not found'); });
-
-      expect(() => resolveEffectiveSandbox({
-        enabled: true,
-        tier: 'auto',
-        dockerImage: 'node:20-bookworm',
-      })).toThrow(/Install Docker Desktop/);
-    });
-
-    it('throws friendly message when sandbox enabled but daemon not running', () => {
-      // binaryExists returns true, docker info throws
-      let call = 0;
-      mockExecSync.mockImplementation(() => {
-        call++;
-        if (call === 1) return Buffer.from(''); // where docker
-        throw new Error('daemon not running'); // docker info
-      });
-
-      expect(() => resolveEffectiveSandbox({
-        enabled: true,
-        tier: 'auto',
-        dockerImage: 'node:20-bookworm',
-      })).toThrow(/start Docker Desktop/i);
-    });
-
-    it('auto-defaults dockerImage to recommended image when not configured', () => {
-      // where docker ok, docker info ok, docker image inspect ok (auto-default image exists)
-      mockExecSync.mockReturnValue(Buffer.from(''));
-
-      const effective = resolveEffectiveSandbox({
-        enabled: true,
-        tier: 'auto',
-      });
-      expect(effective.useOsSandbox).toBe(true);
-      expect(effective.config.dockerImage).toBe('ghcr.io/eric-cielo/moflo-sandbox:latest');
-    });
-
-    it('auto-pulls image when configured but not present locally', () => {
-      // where docker ok, docker info ok, docker image inspect fails, docker pull ok
-      let call = 0;
-      mockExecSync.mockImplementation(() => {
-        call++;
-        if (call <= 2) return Buffer.from(''); // where + info
-        if (call === 3) throw new Error('No such image'); // docker image inspect
-        return Buffer.from(''); // docker pull succeeds
-      });
-
-      const effective = resolveEffectiveSandbox({
-        enabled: true,
-        tier: 'auto',
-        dockerImage: 'node:20-bookworm',
-      });
-      expect(effective.useOsSandbox).toBe(true);
-    });
-
-    it('succeeds when Docker ready, image configured and pulled', () => {
-      mockExecSync.mockReturnValue(Buffer.from(''));
-
-      const effective = resolveEffectiveSandbox({
-        enabled: true,
-        tier: 'auto',
-        dockerImage: 'node:20-bookworm',
-      });
-      expect(effective.useOsSandbox).toBe(true);
-      expect(effective.capability.tool).toBe('docker');
-      expect(effective.config.dockerImage).toBe('node:20-bookworm');
-    });
-
-    it('skips Docker checks when sandbox disabled', () => {
-      mockExecSync.mockImplementation(() => { throw new Error('no docker'); });
-
-      const effective = resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
-      expect(effective.useOsSandbox).toBe(false);
-      expect(effective.displayStatus).toContain('disabled');
-    });
-
-    it('skips Docker checks when tier is denylist-only', () => {
-      mockExecSync.mockImplementation(() => { throw new Error('no docker'); });
-
-      const effective = resolveEffectiveSandbox({ enabled: true, tier: 'denylist-only' });
-      expect(effective.useOsSandbox).toBe(false);
-      expect(effective.displayStatus).toContain('disabled');
-    });
-  });
-});
-
-// ============================================================================
-// resolveSandboxConfig — dockerImage handling
-// ============================================================================
-
-describe('resolveSandboxConfig', () => {
   it('picks up dockerImage from camelCase key', () => {
     const cfg = resolveSandboxConfig({ enabled: true, dockerImage: 'my:img' });
     expect(cfg.dockerImage).toBe('my:img');
@@ -404,20 +256,130 @@ describe('resolveSandboxConfig', () => {
 });
 
 // ============================================================================
+// resolveEffectiveSandbox()
+// ============================================================================
+
+describe('resolveEffectiveSandbox', () => {
+  beforeEach(() => {
+    mockPlatform.mockReturnValue('linux');
+    mockCommandExists.mockResolvedValue(true); // bwrap available
+  });
+
+  it('uses OS sandbox when available and config is auto', async () => {
+    const effective = await resolveEffectiveSandbox({ enabled: true, tier: 'auto' });
+    expect(effective.useOsSandbox).toBe(true);
+    expect(effective.capability.tool).toBe('bwrap');
+    expect(effective.displayStatus).toContain('bwrap');
+  });
+
+  it('disables OS sandbox when config.enabled is false', async () => {
+    const effective = await resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
+    expect(effective.useOsSandbox).toBe(false);
+    expect(effective.displayStatus).toContain('disabled');
+  });
+
+  it('disables OS sandbox when tier is denylist-only', async () => {
+    const effective = await resolveEffectiveSandbox({ enabled: true, tier: 'denylist-only' });
+    expect(effective.useOsSandbox).toBe(false);
+    expect(effective.displayStatus).toContain('disabled');
+  });
+
+  it('throws when tier is full but no sandbox available', async () => {
+    mockCommandExists.mockResolvedValue(false);
+    await expect(resolveEffectiveSandbox({ enabled: true, tier: 'full' })).rejects.toThrow(
+      /Sandbox tier "full" requires an OS sandbox/,
+    );
+  });
+
+  it('falls back gracefully when tier is auto and no sandbox available', async () => {
+    mockCommandExists.mockResolvedValue(false);
+    const effective = await resolveEffectiveSandbox({ enabled: true, tier: 'auto' });
+    expect(effective.useOsSandbox).toBe(false);
+    expect(effective.displayStatus).toContain('not available');
+  });
+
+  describe('Windows Docker setup errors', () => {
+    beforeEach(() => mockPlatform.mockReturnValue('win32'));
+
+    it('throws friendly message when sandbox enabled but Docker not installed', async () => {
+      mockCommandExists.mockResolvedValue(false); // docker missing
+      await expect(resolveEffectiveSandbox({
+        enabled: true, tier: 'auto', dockerImage: 'node:20-bookworm',
+      })).rejects.toThrow(/Install Docker Desktop/);
+    });
+
+    it('throws friendly message when sandbox enabled but daemon not running', async () => {
+      mockCommandExists.mockResolvedValue(true); // docker present
+      dockerFailure(); // info fails → daemon down
+      await expect(resolveEffectiveSandbox({
+        enabled: true, tier: 'auto', dockerImage: 'node:20-bookworm',
+      })).rejects.toThrow(/start Docker Desktop/i);
+    });
+
+    it('auto-defaults dockerImage to recommended image when not configured', async () => {
+      mockCommandExists.mockResolvedValue(true);
+      dockerSuccess(); // info + image inspect both succeed
+      const effective = await resolveEffectiveSandbox({ enabled: true, tier: 'auto' });
+      expect(effective.useOsSandbox).toBe(true);
+      expect(effective.config.dockerImage).toBe('ghcr.io/eric-cielo/moflo-sandbox:latest');
+    });
+
+    it('auto-pulls image when configured but not present locally', async () => {
+      mockCommandExists.mockResolvedValue(true);
+      // info ok; image inspect fails → triggers pull
+      dockerRouter((args) =>
+        args[0] === 'image' && args[1] === 'inspect' ? 1 : 0,
+      );
+      spawnSuccess();
+      const effective = await resolveEffectiveSandbox({
+        enabled: true, tier: 'auto', dockerImage: 'node:20-bookworm',
+      });
+      expect(effective.useOsSandbox).toBe(true);
+      expect(mockSpawn).toHaveBeenCalledWith('docker', ['pull', 'node:20-bookworm'], expect.objectContaining({ stdio: 'inherit' }));
+    });
+
+    it('succeeds when Docker ready, image configured and pulled', async () => {
+      mockCommandExists.mockResolvedValue(true);
+      dockerSuccess();
+      const effective = await resolveEffectiveSandbox({
+        enabled: true, tier: 'auto', dockerImage: 'node:20-bookworm',
+      });
+      expect(effective.useOsSandbox).toBe(true);
+      expect(effective.capability.tool).toBe('docker');
+      expect(effective.config.dockerImage).toBe('node:20-bookworm');
+    });
+
+    it('skips Docker checks when sandbox disabled', async () => {
+      mockCommandExists.mockResolvedValue(false);
+      const effective = await resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
+      expect(effective.useOsSandbox).toBe(false);
+      expect(effective.displayStatus).toContain('disabled');
+    });
+
+    it('skips Docker checks when tier is denylist-only', async () => {
+      mockCommandExists.mockResolvedValue(false);
+      const effective = await resolveEffectiveSandbox({ enabled: true, tier: 'denylist-only' });
+      expect(effective.useOsSandbox).toBe(false);
+      expect(effective.displayStatus).toContain('disabled');
+    });
+  });
+});
+
+// ============================================================================
 // formatSandboxLog()
 // ============================================================================
 
 describe('formatSandboxLog', () => {
-  it('formats the log message with [spell] prefix', () => {
+  it('formats the log message with [spell] prefix', async () => {
     mockPlatform.mockReturnValue('darwin');
     mockExistsSync.mockReturnValue(true);
-    const effective = resolveEffectiveSandbox({ enabled: true, tier: 'auto' });
+    const effective = await resolveEffectiveSandbox({ enabled: true, tier: 'auto' });
     const log = formatSandboxLog(effective);
     expect(log).toBe('[spell] OS sandbox: sandbox-exec (darwin)');
   });
 
-  it('formats disabled status', () => {
-    const effective = resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
+  it('formats disabled status', async () => {
+    const effective = await resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
     const log = formatSandboxLog(effective);
     expect(log).toBe('[spell] OS sandbox: disabled (denylist active)');
   });
@@ -429,17 +391,12 @@ describe('formatSandboxLog', () => {
 
 describe('denylist independence', () => {
   it('denylist runs regardless of sandbox enabled=false', () => {
-    // This test verifies the architectural guarantee: sandbox config
-    // only controls OS-level sandboxing, never the denylist.
     const config = resolveSandboxConfig({ enabled: false });
     expect(config.enabled).toBe(false);
-    // The denylist is enforced in bash-command.ts via checkDestructivePatterns,
-    // which has no dependency on SandboxConfig. This test documents the contract.
   });
 
   it('denylist runs regardless of sandbox tier=denylist-only', () => {
     const config = resolveSandboxConfig({ tier: 'denylist-only' });
     expect(config.tier).toBe('denylist-only');
-    // Same as above — denylist is always active, sandbox config is orthogonal.
   });
 });

--- a/src/cli/__tests__/spells/sandbox-tier-integration.test.ts
+++ b/src/cli/__tests__/spells/sandbox-tier-integration.test.ts
@@ -166,8 +166,8 @@ describe('denylist override via allowDestructive', () => {
 // ============================================================================
 
 describe('platform detection returns correct results', () => {
-  it('returns a valid SandboxCapability shape', () => {
-    const cap = detectSandboxCapability();
+  it('returns a valid SandboxCapability shape', async () => {
+    const cap = await detectSandboxCapability();
     expect(cap).toHaveProperty('platform');
     expect(cap).toHaveProperty('available');
     expect(cap).toHaveProperty('tool');
@@ -176,13 +176,13 @@ describe('platform detection returns correct results', () => {
     expect(typeof cap.available).toBe('boolean');
   });
 
-  it('matches the current OS platform', () => {
-    const cap = detectSandboxCapability();
+  it('matches the current OS platform', async () => {
+    const cap = await detectSandboxCapability();
     expect(cap.platform).toBe(platform());
   });
 
-  it.skipIf(!IS_MACOS)('macOS: detects sandbox-exec', () => {
-    const cap = detectSandboxCapability();
+  it.skipIf(!IS_MACOS)('macOS: detects sandbox-exec', async () => {
+    const cap = await detectSandboxCapability();
     // sandbox-exec is always present on macOS
     expect(cap.platform).toBe('darwin');
     expect(cap.available).toBe(true);
@@ -190,8 +190,8 @@ describe('platform detection returns correct results', () => {
     expect(cap.overhead).toBe('low');
   });
 
-  it.skipIf(!IS_LINUX)('Linux: detects bwrap if installed', () => {
-    const cap = detectSandboxCapability();
+  it.skipIf(!IS_LINUX)('Linux: detects bwrap if installed', async () => {
+    const cap = await detectSandboxCapability();
     expect(cap.platform).toBe('linux');
     // bwrap may or may not be installed; just validate the shape
     if (cap.available) {
@@ -203,8 +203,8 @@ describe('platform detection returns correct results', () => {
     }
   });
 
-  it.skipIf(!IS_WINDOWS)('Windows: detects Docker if available', () => {
-    const cap = detectSandboxCapability();
+  it.skipIf(!IS_WINDOWS)('Windows: detects Docker if available', async () => {
+    const cap = await detectSandboxCapability();
     expect(cap.platform).toBe('win32');
     if (cap.available) {
       expect(cap.tool).toBe('docker');
@@ -215,18 +215,18 @@ describe('platform detection returns correct results', () => {
     }
   });
 
-  it('caches detection result', () => {
+  it('caches detection result', async () => {
     resetSandboxCache();
-    const first = detectSandboxCapability();
-    const second = detectSandboxCapability();
+    const first = await detectSandboxCapability();
+    const second = await detectSandboxCapability();
     expect(first).toBe(second); // Same reference
   });
 
-  it('resetSandboxCache allows re-detection', () => {
+  it('resetSandboxCache allows re-detection', async () => {
     resetSandboxCache();
-    const first = detectSandboxCapability();
+    const first = await detectSandboxCapability();
     resetSandboxCache();
-    const second = detectSandboxCapability();
+    const second = await detectSandboxCapability();
     // Equal values but fresh object
     expect(second).toEqual(first);
     expect(second).not.toBe(first);
@@ -331,8 +331,8 @@ describe('graceful fallback when OS sandbox is unavailable', () => {
     vi.restoreAllMocks();
   });
 
-  it('auto tier falls back to denylist-only when no OS sandbox detected', () => {
-    const effective = resolveEffectiveSandbox(
+  it('auto tier falls back to denylist-only when no OS sandbox detected', async () => {
+    const effective = await resolveEffectiveSandbox(
       { enabled: true, tier: 'auto' },
       UNAVAILABLE_CAPABILITY,
     );
@@ -340,20 +340,20 @@ describe('graceful fallback when OS sandbox is unavailable', () => {
     expect(effective.displayStatus).toContain('not available');
   });
 
-  it('full tier throws when no OS sandbox is available', () => {
-    expect(() =>
+  it('full tier throws when no OS sandbox is available', async () => {
+    await expect(
       resolveEffectiveSandbox({ enabled: true, tier: 'full' }, UNAVAILABLE_CAPABILITY),
-    ).toThrow(/Sandbox tier "full" requires an OS sandbox/);
+    ).rejects.toThrow(/Sandbox tier "full" requires an OS sandbox/);
   });
 
-  it('denylist-only tier always skips OS sandbox', () => {
-    const effective = resolveEffectiveSandbox({ enabled: true, tier: 'denylist-only' });
+  it('denylist-only tier always skips OS sandbox', async () => {
+    const effective = await resolveEffectiveSandbox({ enabled: true, tier: 'denylist-only' });
     expect(effective.useOsSandbox).toBe(false);
     expect(effective.displayStatus).toContain('disabled');
   });
 
-  it('enabled: false disables OS sandbox', () => {
-    const effective = resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
+  it('enabled: false disables OS sandbox', async () => {
+    const effective = await resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
     expect(effective.useOsSandbox).toBe(false);
     expect(effective.displayStatus).toContain('disabled');
   });
@@ -365,8 +365,8 @@ describe('graceful fallback when OS sandbox is unavailable', () => {
     expect(result.error).toContain('Command blocked');
   });
 
-  it('formatSandboxLog produces correct output for all states', () => {
-    const disabledEffective = resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
+  it('formatSandboxLog produces correct output for all states', async () => {
+    const disabledEffective = await resolveEffectiveSandbox({ enabled: false, tier: 'auto' });
     const log = formatSandboxLog(disabledEffective);
     expect(log).toMatch(/^\[spell\] OS sandbox:/);
     expect(log).toContain('disabled');
@@ -457,7 +457,7 @@ describe('full pipeline: config through execution', () => {
     resetSandboxCache();
   });
 
-  it('resolveSandboxConfig → resolveEffectiveSandbox produces consistent state', () => {
+  it('resolveSandboxConfig → resolveEffectiveSandbox produces consistent state', async () => {
     // Pass explicit capabilities so this config-consistency test doesn't depend
     // on the host's real Docker/bwrap availability (Windows without Docker
     // Desktop running would otherwise hit the throw path).
@@ -469,18 +469,18 @@ describe('full pipeline: config through execution', () => {
     const availableCap = { platform: 'linux' as NodeJS.Platform, available: true, tool: 'bwrap', overhead: 'low' as const };
     const unavailableCap = { platform: 'linux' as NodeJS.Platform, available: false, tool: null, overhead: null };
 
-    const effectiveAvailable = resolveEffectiveSandbox(config, availableCap);
+    const effectiveAvailable = await resolveEffectiveSandbox(config, availableCap);
     expect(effectiveAvailable.config).toEqual(config);
     expect(effectiveAvailable.useOsSandbox).toBe(true);
 
-    const effectiveUnavailable = resolveEffectiveSandbox(config, unavailableCap);
+    const effectiveUnavailable = await resolveEffectiveSandbox(config, unavailableCap);
     expect(effectiveUnavailable.config).toEqual(config);
     expect(effectiveUnavailable.useOsSandbox).toBe(false);
   });
 
-  it('denylist-only config always results in useOsSandbox: false', () => {
+  it('denylist-only config always results in useOsSandbox: false', async () => {
     const config = resolveSandboxConfig({ enabled: true, tier: 'denylist-only' });
-    const effective = resolveEffectiveSandbox(config);
+    const effective = await resolveEffectiveSandbox(config);
     expect(effective.useOsSandbox).toBe(false);
   });
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1483,7 +1483,7 @@ export const doctorCommand: Command = {
           resolveEffectiveSandbox,
         } = await import('../spells/index.js');
 
-        const cap = detectSandboxCapability();
+        const cap = await detectSandboxCapability();
         const config = await loadSandboxConfigFromProject(process.cwd());
 
         // If sandboxing isn't enabled in moflo.yaml, just report capability.
@@ -1512,7 +1512,7 @@ export const doctorCommand: Command = {
 
         // Sandboxing is enabled — run the real resolver and surface any error.
         try {
-          const effective = resolveEffectiveSandbox(config);
+          const effective = await resolveEffectiveSandbox(config);
           if (effective.useOsSandbox) {
             const imageHint = effective.config.dockerImage ? `, ${effective.config.dockerImage}` : '';
             return {

--- a/src/cli/spells/core/platform-sandbox.ts
+++ b/src/cli/spells/core/platform-sandbox.ts
@@ -12,11 +12,12 @@
  * @see https://github.com/eric-cielo/moflo/issues/409
  */
 
-import { execSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { platform } from 'node:os';
 import { join } from 'node:path';
-import { escapeShellArg } from './shell.js';
+import { commandExists } from './prerequisite-checker.js';
+import { execFileAsync } from './shell.js';
 
 type YamlModule = { load: (s: string) => unknown; default?: { load: (s: string) => unknown } };
 
@@ -70,7 +71,16 @@ export const RECOMMENDED_DOCKER_IMAGE = 'ghcr.io/eric-cielo/moflo-sandbox:latest
 // Detection (cached)
 // ============================================================================
 
-let _cached: SandboxCapability | undefined;
+// Detection runs once per process and is cached, so timeouts can be generous.
+// Cold-start `docker info` on Windows can take 5-10s on the named-pipe
+// handshake, so a tight budget would falsely report the daemon down.
+const BINARY_EXISTS_TIMEOUT_MS = 10_000;
+const DOCKER_DAEMON_TIMEOUT_MS = 15_000;
+
+// Cache the in-flight Promise rather than the resolved value so concurrent
+// callers share one detection probe (avoids racing two `docker info` calls if
+// e.g. doctor and runner ask within the same tick).
+let _cachedDetection: Promise<SandboxCapability> | undefined;
 
 /**
  * Detect the available sandbox tool for the current platform.
@@ -78,19 +88,25 @@ let _cached: SandboxCapability | undefined;
  * Results are cached for the process lifetime — filesystem/daemon checks
  * are expensive and the answer doesn't change mid-process.
  */
-export function detectSandboxCapability(): SandboxCapability {
-  if (_cached) return _cached;
-  _cached = detectUncached();
-  return _cached;
+export function detectSandboxCapability(): Promise<SandboxCapability> {
+  if (!_cachedDetection) {
+    // Don't cache rejection — sticky failure across the process lifetime would
+    // be a hard-to-diagnose footgun if a caller ever surfaces an error.
+    _cachedDetection = detectUncached().catch((err) => {
+      _cachedDetection = undefined;
+      throw err;
+    });
+  }
+  return _cachedDetection;
 }
 
 /** Reset the cached result (for testing). */
 export function resetSandboxCache(): void {
-  _cached = undefined;
+  _cachedDetection = undefined;
   _imageExistsCache.clear();
 }
 
-function detectUncached(): SandboxCapability {
+async function detectUncached(): Promise<SandboxCapability> {
   const os = platform();
 
   if (os === 'darwin') {
@@ -121,8 +137,8 @@ function detectMacOS(): SandboxCapability {
 
 // ── Linux ──────────────────────────────────────────────────────────────
 
-function detectLinux(): SandboxCapability {
-  const available = binaryExists('bwrap');
+async function detectLinux(): Promise<SandboxCapability> {
+  const available = await commandExists('bwrap', { timeoutMs: BINARY_EXISTS_TIMEOUT_MS });
   return {
     platform: 'linux',
     available,
@@ -133,12 +149,12 @@ function detectLinux(): SandboxCapability {
 
 // ── Windows ────────────────────────────────────────────────────────────
 
-function detectWindows(): SandboxCapability {
-  if (!binaryExists('docker')) {
+async function detectWindows(): Promise<SandboxCapability> {
+  if (!(await commandExists('docker', { timeoutMs: BINARY_EXISTS_TIMEOUT_MS }))) {
     return { platform: 'win32', available: false, tool: null, overhead: null };
   }
 
-  if (!dockerDaemonRunning()) {
+  if (!(await dockerDaemonRunning())) {
     return { platform: 'win32', available: false, tool: null, overhead: null };
   }
 
@@ -154,30 +170,14 @@ function detectWindows(): SandboxCapability {
 // Helpers
 // ============================================================================
 
-// Detection runs once per process and is cached, so timeouts can be generous.
-// Cold-start `docker info` on Windows can take 5-10s on the named-pipe
-// handshake, so a tight budget would falsely report the daemon down.
-const BINARY_EXISTS_TIMEOUT_MS = 10_000;
-const DOCKER_DAEMON_TIMEOUT_MS = 15_000;
-
-function binaryExists(name: string): boolean {
-  try {
-    const cmd = platform() === 'win32' ? `where ${name}` : `which ${name}`;
-    execSync(cmd, { stdio: 'ignore', timeout: BINARY_EXISTS_TIMEOUT_MS });
-    return true;
-  } catch {
-    return false;
-  }
+// Single source of truth for docker probe outcome semantics — `execFileAsync`
+// from shell.ts never throws, so we branch on exitCode instead of try/catch.
+async function dockerProbe(args: readonly string[]): Promise<boolean> {
+  const { exitCode } = await execFileAsync('docker', args, DOCKER_DAEMON_TIMEOUT_MS);
+  return exitCode === 0;
 }
 
-function dockerDaemonRunning(): boolean {
-  try {
-    execSync('docker info', { stdio: 'ignore', timeout: DOCKER_DAEMON_TIMEOUT_MS });
-    return true;
-  } catch {
-    return false;
-  }
-}
+const dockerDaemonRunning = (): Promise<boolean> => dockerProbe(['info']);
 
 // ============================================================================
 // Config Resolution
@@ -258,17 +258,18 @@ export interface EffectiveSandbox {
  * @returns EffectiveSandbox — includes display status for spell-start logging.
  * @throws Error if tier is 'full' but no OS sandbox is available.
  */
-export function resolveEffectiveSandbox(
+export async function resolveEffectiveSandbox(
   config: SandboxConfig,
-  capability: SandboxCapability = detectSandboxCapability(),
-): EffectiveSandbox {
+  capability?: SandboxCapability,
+): Promise<EffectiveSandbox> {
+  const cap = capability ?? await detectSandboxCapability();
   let resolved = config;
 
   // Config disabled or tier is denylist-only => no OS sandbox
   if (!resolved.enabled || resolved.tier === 'denylist-only') {
     return {
       useOsSandbox: false,
-      capability,
+      capability: cap,
       config: resolved,
       displayStatus: `OS sandbox: disabled (denylist active)`,
     };
@@ -277,41 +278,41 @@ export function resolveEffectiveSandbox(
   // Windows: Docker is required for OS sandboxing. If Docker is available,
   // auto-default the image and auto-pull it on first use so the user doesn't
   // have to do manual setup. Only throw if Docker itself isn't installed/running.
-  if (capability.platform === 'win32') {
-    if (!capability.available) {
+  if (cap.platform === 'win32') {
+    if (!cap.available) {
       throw new Error(formatWindowsDockerNotReadyMessage());
     }
     const image = resolved.dockerImage || RECOMMENDED_DOCKER_IMAGE;
     if (!resolved.dockerImage) {
       resolved = { ...resolved, dockerImage: image };
     }
-    if (!dockerImageExists(image)) {
-      dockerPullImage(image);
+    if (!(await dockerImageExists(image))) {
+      await dockerPullImage(image);
     }
   }
 
   // tier: full — require OS sandbox on non-Windows platforms
-  if (resolved.tier === 'full' && !capability.available) {
+  if (resolved.tier === 'full' && !cap.available) {
     throw new Error(
-      `Sandbox tier "full" requires an OS sandbox but none was detected on ${capability.platform}. ` +
+      `Sandbox tier "full" requires an OS sandbox but none was detected on ${cap.platform}. ` +
       `Install bubblewrap (Linux) or set sandbox.tier to "auto".`,
     );
   }
 
-  if (!capability.available) {
+  if (!cap.available) {
     return {
       useOsSandbox: false,
-      capability,
+      capability: cap,
       config: resolved,
-      displayStatus: `OS sandbox: not available (${capability.platform})`,
+      displayStatus: `OS sandbox: not available (${cap.platform})`,
     };
   }
 
   return {
     useOsSandbox: true,
-    capability,
+    capability: cap,
     config: resolved,
-    displayStatus: `OS sandbox: ${capability.tool} (${capability.platform})`,
+    displayStatus: `OS sandbox: ${cap.tool} (${cap.platform})`,
   };
 }
 
@@ -321,39 +322,52 @@ const _imageExistsCache = new Map<string, boolean>();
  * Check whether a Docker image is available locally (already pulled).
  * Result is cached per image name for the process lifetime.
  */
-function dockerImageExists(image: string): boolean {
+async function dockerImageExists(image: string): Promise<boolean> {
   const cached = _imageExistsCache.get(image);
   if (cached !== undefined) return cached;
-  try {
-    // Same cold-start budget as `docker info` — both hit the Docker Desktop
-    // daemon over its named-pipe handshake. Result is cached per image.
-    execSync(`docker image inspect ${escapeShellArg(image)}`, { stdio: 'ignore', timeout: DOCKER_DAEMON_TIMEOUT_MS });
-    _imageExistsCache.set(image, true);
-    return true;
-  } catch {
-    return false;
-  }
+  // `dockerProbe` shares the cold-start timeout/error-swallow policy with
+  // `dockerDaemonRunning` — both hit the Docker Desktop named-pipe handshake.
+  // Only positive outcomes are cached: a missing image must re-probe after
+  // `dockerPullImage` populates the cache, so symmetric caching would break
+  // the pull-then-recheck flow.
+  const ok = await dockerProbe(['image', 'inspect', image]);
+  if (ok) _imageExistsCache.set(image, true);
+  return ok;
 }
 
 /**
  * Pull a Docker image, printing a one-time setup banner so the user knows
  * what's happening and why. Throws if the pull fails.
  */
-function dockerPullImage(image: string): void {
+async function dockerPullImage(image: string): Promise<void> {
   console.log(
     `[spell] One-time setup: pulling Docker image ${image} for sandboxing...\n` +
     `        This only happens once — Docker caches the image afterwards.`,
   );
+  // `spawn` (not execFileAsync) so the docker pull progress streams live to
+  // the user's terminal. execFileAsync buffers stdout, defeating the banner.
   try {
-    execSync(`docker pull ${escapeShellArg(image)}`, { stdio: 'inherit', timeout: 300_000 });
-    _imageExistsCache.set(image, true);
-    console.log(`[spell] Docker image ${image} is ready.`);
-  } catch {
+    await new Promise<void>((resolve, reject) => {
+      let timedOut = false;
+      const proc = spawn('docker', ['pull', image], { stdio: 'inherit' });
+      const timer = setTimeout(() => { timedOut = true; proc.kill('SIGTERM'); }, 300_000);
+      proc.on('error', (err) => { clearTimeout(timer); reject(err); });
+      proc.on('exit', (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve();
+        else if (timedOut) reject(new Error('docker pull timed out after 5 minutes'));
+        else reject(new Error(`docker pull exited with code ${code}`));
+      });
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `Failed to pull Docker image "${image}".\n\n` +
+      `Failed to pull Docker image "${image}": ${detail}\n\n` +
       'Make sure Docker Desktop is running and you have internet access, then try again.',
     );
   }
+  _imageExistsCache.set(image, true);
+  console.log(`[spell] Docker image ${image} is ready.`);
 }
 
 // ── Beginner-friendly setup messages (Windows) ──────────────────────────

--- a/src/cli/spells/core/prerequisite-checker.ts
+++ b/src/cli/spells/core/prerequisite-checker.ts
@@ -29,11 +29,16 @@ import { readLineFromStdin } from './stdin-reader.js';
 
 const execFileAsync = promisify(execFile);
 
-/** Check whether a CLI command is available on the system PATH. */
-export async function commandExists(cmd: string): Promise<boolean> {
+/**
+ * Check whether a CLI command is available on the system PATH.
+ *
+ * `timeoutMs` caps the lookup probe — important for callers that probe under
+ * fork/GC pressure where `where`/`which` can stall (see platform-sandbox).
+ */
+export async function commandExists(cmd: string, opts?: { timeoutMs?: number }): Promise<boolean> {
   try {
     const bin = process.platform === 'win32' ? 'where' : 'which';
-    await execFileAsync(bin, [cmd]);
+    await execFileAsync(bin, [cmd], opts?.timeoutMs ? { timeout: opts.timeoutMs } : undefined);
     return true;
   } catch {
     return false;

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -203,7 +203,7 @@ export class SpellCaster {
     let effectiveSandbox: EffectiveSandbox | undefined;
     try {
       const sandboxCfg = options.sandboxConfig ?? DEFAULT_SANDBOX_CONFIG;
-      effectiveSandbox = resolveEffectiveSandbox(sandboxCfg);
+      effectiveSandbox = await resolveEffectiveSandbox(sandboxCfg);
       console.log(formatSandboxLog(effectiveSandbox));
     } catch (err) {
       // tier: full but no sandbox available — fail the spell


### PR DESCRIPTION
## Summary

Followup to PR #795 — applies the deferred refactor that PR called out. Cascades `detectSandboxCapability()` and `resolveEffectiveSandbox()` to async, dropping bespoke duplicates in favor of the shared primitives.

## Production code

- **`binaryExists` deleted** — replaced with shared `commandExists` from `prerequisite-checker.ts` (extended with `{timeoutMs?}` option for cold-start scenarios).
- **`execSync('docker info')` / `execSync('docker image inspect')` deleted** — replaced with shared `execFileAsync` from `shell.ts`. Array args dodge shell quoting; `escapeShellArg` import dropped.
- **`dockerProbe(args)` extracted** — `dockerDaemonRunning` and `dockerImageExists` had identical try/await/catch wrappers. Single source of truth for the cold-start timeout + error-swallow policy.
- **Detection cache** — was `SandboxCapability | undefined`, now `Promise<SandboxCapability> | undefined`. Concurrent callers share one in-flight probe instead of racing two `docker info` calls. Self-heals on rejection (sticky failure across process lifetime would be a hard-to-diagnose footgun).
- **`dockerPullImage` improvements** — surfaces underlying error cause (per `feedback_no_silent_failures.md`), distinguishes timeout from non-zero exit code via a `timedOut` flag.
- **Consumers** — `doctor.ts` and `runner.ts` updated with `await`. Both were already inside async functions; cascade was clean.

## Test code

`platform-sandbox.test.ts` switches mock strategy from mocking `node:child_process.execSync` (no longer used by production) to mocking the three abstraction boundaries production now goes through:
- `commandExists` (prerequisite-checker.ts)
- `execFileAsync` (shell.ts)
- `spawn` (child_process — for docker pull)

The `Error|null` per-call routing was simplified to `exitCode 0|1` since `execFileAsync` never throws. `mockReturnValue(Buffer.from(''))` calls collapse to `mockResolvedValue({stdout, stderr, exitCode: 0})`.

`doctor-sandbox-tier.test.ts`, `sandbox-tier-integration.test.ts` — added `await` and switched `expect(() => fn()).toThrow()` patterns to `await expect(fn()).rejects.toThrow()`.

## What was deferred / skipped (and why)

- **Don't parallelize `detectWindows` probes** — sequential short-circuits cheap (`commandExists`) before slow (`docker info`). `Promise.all` would waste 15s on the no-Docker case.
- **No `spawnAsync` helper extracted** — `dockerPullImage` is the only spawn-with-timeout caller. Resist abstracting until a third caller appears.
- **No async-memoize helper extracted** — same reasoning, single caller.

## Test plan
- [x] `npx vitest platform-sandbox + doctor-sandbox-tier` — 41/41 pass
- [x] `npx vitest sandbox-tier-integration + runner-bridge` (isolation config) — 70/70 + 10 skipped
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` (full parallel + isolation batch) — **7434 passed, 0 failed**

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)