### PR TITLE
feat(statusline): post-upgrade "completed" notice + Embeddings rename

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -382,7 +382,7 @@ function getSwarmStatus() {
 function getSystemMetrics() {
   const memoryMB = Math.floor(process.memoryUsage().heapUsed / 1024 / 1024);
   const learning = getLearningStats();
-  const agentdb = getAgentDBStats();
+  const embeddings = getEmbeddingsStats();
 
   // Intelligence from learning.json
   const learningData = readJSON(path.join(CWD, '.moflo', 'metrics', 'learning.json'));
@@ -393,7 +393,7 @@ function getSystemMetrics() {
     intelligencePct = Math.min(100, Math.floor(learningData.intelligence.score));
   } else {
     const fromPatterns = learning.patterns > 0 ? Math.min(100, Math.floor(learning.patterns / 10)) : 0;
-    const fromVectors = agentdb.vectorCount > 0 ? Math.min(100, Math.floor(agentdb.vectorCount / 100)) : 0;
+    const fromVectors = embeddings.vectorCount > 0 ? Math.min(100, Math.floor(embeddings.vectorCount / 100)) : 0;
     intelligencePct = Math.max(fromPatterns, fromVectors);
   }
 
@@ -423,7 +423,7 @@ function getSystemMetrics() {
     subAgents = activityData.processes.estimated_agents;
   }
 
-  return { memoryMB, contextPct, intelligencePct, subAgents };
+  return { memoryMB, contextPct, intelligencePct, subAgents, embeddings };
 }
 
 // ADR status (count files only — don't read contents)
@@ -484,9 +484,9 @@ function getHooksStatus() {
   return { enabled, total };
 }
 
-// AgentDB stats — reads from cache file written by embedding/memory operations.
+// Embeddings stats — reads from cache file written by embedding/memory ops.
 // No subprocess spawning. Falls back to DB file size estimate if cache is missing.
-function getAgentDBStats() {
+function getEmbeddingsStats() {
   let vectorCount = 0;
   let dbSizeKB = 0;
   let namespaces = 0;
@@ -601,20 +601,25 @@ function getIntegrationStatus() {
   return { mcpServers, hasDatabase, hasApi };
 }
 
-// Upgrade notice (#636, #738, #743) — written by the session-start launcher
-// ONLY while upgrade work is in flight; the launcher deletes the file when
-// work completes. We render it strictly for status='in-progress' so a stale
-// notice (legacy "complete" file from pre-#738 launchers, zombie write from
-// an aborted launcher, future writer mistakes) cannot turn the statusline
-// segment into a permanent column. The launcher's section 0-pre also drops
-// any leftover file at session start as a second line of defence.
+// Upgrade notice (#636, #738, #743) — written by the session-start launcher.
+//   status='in-progress' — work is running; rendered with "(updating…)".
+//   status='completed'   — work just finished; short-TTL post-upgrade badge so
+//                          the user sees something on the very next render
+//                          (Claude Code only paints the statusline AFTER the
+//                          SessionStart hook returns, so the in-progress badge
+//                          has effectively zero visibility window).
+// Anything else is dropped (legacy "complete" pre-#738 files, zombie writes,
+// future writer mistakes) so a stale notice can never turn the segment into a
+// permanent column. Section 0-pre of the launcher also wipes any leftover at
+// session start as a second line of defence.
 function getUpgradeNotice() {
   const data = readJSON(path.join(CWD, '.moflo', 'upgrade-notice.json'));
   if (!data || typeof data !== 'object') return null;
-  if (data.status !== 'in-progress') return null;
+  if (data.status !== 'in-progress' && data.status !== 'completed') return null;
   const expiresAt = data.expiresAt ? new Date(data.expiresAt).getTime() : 0;
   if (!expiresAt || Date.now() > expiresAt) return null;
   return {
+    status: data.status,
     kind: data.kind === 'repair' ? 'repair' : 'upgrade',
     from: typeof data.from === 'string' ? data.from : '',
     to: typeof data.to === 'string' ? data.to : '',
@@ -623,14 +628,20 @@ function getUpgradeNotice() {
 
 function formatUpgradeNoticeSegment(notice) {
   if (!notice) return '';
-  const suffix = ` ${c.dim}(updating…)${c.reset}`;
+  const inFlight = notice.status === 'in-progress';
+  const suffix = inFlight ? ` ${c.dim}(updating…)${c.reset}` : '';
+  // Pick body text: repair > in-flight version range > completed "upgraded to"
+  // > bare "upgraded" fallback when no version is known.
+  let body;
   if (notice.kind === 'repair') {
-    return `${c.brightYellow}📦 install repaired${c.reset}${suffix}`;
+    body = 'install repaired';
+  } else if (inFlight) {
+    body = notice.from && notice.to ? `${notice.from} → ${notice.to}` : (notice.to || 'upgraded');
+  } else {
+    const target = notice.to || notice.from || '';
+    body = target ? `upgraded to ${target}` : 'upgraded';
   }
-  const versions = notice.from && notice.to
-    ? `${notice.from} → ${notice.to}`
-    : (notice.to || 'upgraded');
-  return `${c.brightYellow}📦 ${versions}${c.reset}${suffix}`;
+  return `${c.brightYellow}📦 ${body}${c.reset}${suffix}`;
 }
 
 // Session stats (pure file reads)
@@ -784,6 +795,25 @@ function generateDashboard() {
     );
   }
 
+  // Embeddings line \u2014 vector store stats from .moflo/vector-stats.json.
+  // Reuses `system.embeddings` (already computed by getSystemMetrics()) instead
+  // of re-probing the cache file on every render.
+  {
+    const vec = system.embeddings;
+    if (vec.vectorCount > 0) {
+      const hnswInd = vec.hasHnsw ? `${c.brightGreen}\u26A1${c.reset}` : '';
+      const sizeDisp = vec.dbSizeKB >= 1024 ? `${(vec.dbSizeKB / 1024).toFixed(1)}MB` : `${vec.dbSizeKB}KB`;
+      const eParts = [
+        `${c.cyan}Vectors${c.reset} ${c.brightGreen}\u25CF${vec.vectorCount}${c.reset}${hnswInd}`,
+        `${c.cyan}Size${c.reset} ${c.brightWhite}${sizeDisp}${c.reset}`,
+      ];
+      if (vec.namespaces > 0) {
+        eParts.push(`${c.cyan}NS${c.reset} ${c.brightWhite}${vec.namespaces}${c.reset}`);
+      }
+      lines.push(`${c.brightCyan}\uD83D\uDCCA Embeddings${c.reset}  ${eParts.join(`  ${c.dim}\u2502${c.reset}  `)}`);
+    }
+  }
+
   // MCP line
   if (SL_CONFIG.show_mcp) {
     const parts = [];
@@ -795,7 +825,7 @@ function generateDashboard() {
     }
     if (integration.hasDatabase) parts.push(`${c.brightGreen}\u25C6${c.reset}DB`);
     if (parts.length > 0) {
-      lines.push(`${c.brightCyan}\uD83D\uDCCA MCP${c.reset}  ${parts.join(`  ${c.dim}\u2502${c.reset}  `)}`);
+      lines.push(`${c.brightCyan}\uD83D\uDD0C MCP${c.reset}  ${parts.join(`  ${c.dim}\u2502${c.reset}  `)}`);
     }
   }
 
@@ -835,7 +865,7 @@ function generateCompactDashboard() {
   pushUpgradeNoticeSegment(lines);
   lines.push(header);
 
-  // Combined swarm + mcp line
+  // Combined swarm + embeddings + mcp line
   const segments = [];
   if (SL_CONFIG.show_swarm) {
     const swarm = getSwarmStatus();
@@ -844,6 +874,18 @@ function generateCompactDashboard() {
     segments.push(
       `${c.brightYellow}\uD83E\uDD16${c.reset} ${swarmInd}[${agentsColor}${swarm.activeAgents}${c.reset}/${c.brightWhite}${swarm.maxAgents}${c.reset}]`
     );
+  }
+  // Embeddings \u2014 always-on when vectorCount > 0; self-hides on a fresh install.
+  // Compact doesn't call getSystemMetrics() so this is the only probe per render.
+  {
+    const vec = getEmbeddingsStats();
+    if (vec.vectorCount > 0) {
+      const hnswInd = vec.hasHnsw ? '\u26A1' : '';
+      const sizeDisp = vec.dbSizeKB >= 1024 ? `${(vec.dbSizeKB / 1024).toFixed(1)}MB` : `${vec.dbSizeKB}KB`;
+      segments.push(
+        `${c.brightCyan}\uD83D\uDCCA${c.reset} ${c.brightGreen}${vec.vectorCount}${hnswInd}${c.reset} ${c.dim}(${sizeDisp})${c.reset}`
+      );
+    }
   }
   if (SL_CONFIG.show_mcp) {
     const integration = getIntegrationStatus();
@@ -863,15 +905,16 @@ function generateCompactDashboard() {
 // JSON output
 function generateJSON() {
   const git = getGitInfo();
+  const system = getSystemMetrics();
   return {
     user: { name: git.name, gitBranch: git.gitBranch, modelName: getModelName() },
     v3Progress: getV3Progress(),
     security: getSecurityStatus(),
     swarm: getSwarmStatus(),
-    system: getSystemMetrics(),
+    system,
     adrs: getADRStatus(),
     hooks: getHooksStatus(),
-    agentdb: getAgentDBStats(),
+    embeddings: system.embeddings,
     tests: getTestStats(),
     git: { modified: git.modified, untracked: git.untracked, staged: git.staged, ahead: git.ahead, behind: git.behind },
     upgradeNotice: getUpgradeNotice(),

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -63,33 +63,34 @@ let upgradeNoticeContext = null;
 let pendingVersionStampWrite = null;
 
 // 5-min TTL is a safety net for zombie launchers (statusline ignores past-TTL
-// files). The launcher deletes the notice when upgrade work finishes — no
-// "complete" state lingers, see #738.
+// files). The 2-min "completed" TTL lets the user see the post-upgrade badge
+// briefly in the next session render (Claude Code renders the statusline only
+// AFTER the SessionStart hook returns, so the in-progress badge has effectively
+// zero visibility window). The next session-start's section 0-pre wipes any
+// leftover, so a stale completed notice can't linger past one session.
 const UPGRADE_NOTICE_INPROGRESS_TTL_MS = 5 * 60 * 1000;
+const UPGRADE_NOTICE_COMPLETED_TTL_MS = 2 * 60 * 1000;
 const UPGRADE_NOTICE_PATH = () => join(mofloDir(projectRoot), 'upgrade-notice.json');
 
-function writeInProgressUpgradeNotice() {
+function writeUpgradeNotice(status) {
   if (!upgradeNoticeContext) return;
+  const ttlMs = status === 'completed'
+    ? UPGRADE_NOTICE_COMPLETED_TTL_MS
+    : UPGRADE_NOTICE_INPROGRESS_TTL_MS;
   try {
     mkdirSync(mofloDir(projectRoot), { recursive: true });
     const now = Date.now();
     const notice = {
-      status: 'in-progress',
+      status,
       kind: upgradeNoticeContext.kind,
       from: upgradeNoticeContext.from,
       to: upgradeNoticeContext.to,
       at: new Date(now).toISOString(),
-      expiresAt: new Date(now + UPGRADE_NOTICE_INPROGRESS_TTL_MS).toISOString(),
+      expiresAt: new Date(now + ttlMs).toISOString(),
       changes: 0,
     };
     writeFileSync(UPGRADE_NOTICE_PATH(), JSON.stringify(notice, null, 2));
   } catch { /* non-fatal — statusline just won't show the segment */ }
-}
-
-function clearUpgradeNotice() {
-  try {
-    unlinkSync(UPGRADE_NOTICE_PATH());
-  } catch { /* non-fatal — already gone or never existed */ }
 }
 
 // ── 0-pre. Drop any stale upgrade notice (#738, #743) ───────────────────────
@@ -313,9 +314,9 @@ try {
       }
       // Surface a transient "(updating…)" badge in the statusline before the
       // long-running upgrade work (manifest sync, daemon recycle, embeddings
-      // migration). See #738 — the launcher clears this file after work
-      // completes, so the badge naturally disappears once the user is unblocked.
-      writeInProgressUpgradeNotice();
+      // migration). See #738 — section 3f flips this to a 2-min "completed"
+      // badge once work finishes (TTL rationale at the constants above).
+      writeUpgradeNotice('in-progress');
       const binDir = resolve(projectRoot, 'node_modules/moflo/bin');
 
       // ── Manifest-based auto-update ──────────────────────────────────────
@@ -855,12 +856,11 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
-// ── 3f. Clear the in-progress upgrade notice (#636, #738) ───────────────────
-// Upgrade work is finished; drop the notice so the statusline badge disappears
-// immediately. Change summary is already in stdout emits (Claude's
-// `additionalContext`); a lingering "you upgraded a while ago" badge is noise.
+// ── 3f. Flip the upgrade notice to "completed" (#636, #738) ─────────────────
+// See the TTL rationale at the constants above for why we switch to a
+// short-TTL completed badge instead of clearing the file.
 if (upgradeNoticeContext) {
-  clearUpgradeNotice();
+  writeUpgradeNotice('completed');
 }
 
 // ── 3g. Commit deferred version stamp (#730) ────────────────────────────────

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -63,33 +63,34 @@ let upgradeNoticeContext = null;
 let pendingVersionStampWrite = null;
 
 // 5-min TTL is a safety net for zombie launchers (statusline ignores past-TTL
-// files). The launcher deletes the notice when upgrade work finishes — no
-// "complete" state lingers, see #738.
+// files). The 2-min "completed" TTL lets the user see the post-upgrade badge
+// briefly in the next session render (Claude Code renders the statusline only
+// AFTER the SessionStart hook returns, so the in-progress badge has effectively
+// zero visibility window). The next session-start's section 0-pre wipes any
+// leftover, so a stale completed notice can't linger past one session.
 const UPGRADE_NOTICE_INPROGRESS_TTL_MS = 5 * 60 * 1000;
+const UPGRADE_NOTICE_COMPLETED_TTL_MS = 2 * 60 * 1000;
 const UPGRADE_NOTICE_PATH = () => join(mofloDir(projectRoot), 'upgrade-notice.json');
 
-function writeInProgressUpgradeNotice() {
+function writeUpgradeNotice(status) {
   if (!upgradeNoticeContext) return;
+  const ttlMs = status === 'completed'
+    ? UPGRADE_NOTICE_COMPLETED_TTL_MS
+    : UPGRADE_NOTICE_INPROGRESS_TTL_MS;
   try {
     mkdirSync(mofloDir(projectRoot), { recursive: true });
     const now = Date.now();
     const notice = {
-      status: 'in-progress',
+      status,
       kind: upgradeNoticeContext.kind,
       from: upgradeNoticeContext.from,
       to: upgradeNoticeContext.to,
       at: new Date(now).toISOString(),
-      expiresAt: new Date(now + UPGRADE_NOTICE_INPROGRESS_TTL_MS).toISOString(),
+      expiresAt: new Date(now + ttlMs).toISOString(),
       changes: 0,
     };
     writeFileSync(UPGRADE_NOTICE_PATH(), JSON.stringify(notice, null, 2));
   } catch { /* non-fatal — statusline just won't show the segment */ }
-}
-
-function clearUpgradeNotice() {
-  try {
-    unlinkSync(UPGRADE_NOTICE_PATH());
-  } catch { /* non-fatal — already gone or never existed */ }
 }
 
 // ── 0-pre. Drop any stale upgrade notice (#738, #743) ───────────────────────
@@ -313,9 +314,9 @@ try {
       }
       // Surface a transient "(updating…)" badge in the statusline before the
       // long-running upgrade work (manifest sync, daemon recycle, embeddings
-      // migration). See #738 — the launcher clears this file after work
-      // completes, so the badge naturally disappears once the user is unblocked.
-      writeInProgressUpgradeNotice();
+      // migration). See #738 — section 3f flips this to a 2-min "completed"
+      // badge once work finishes (TTL rationale at the constants above).
+      writeUpgradeNotice('in-progress');
       const binDir = resolve(projectRoot, 'node_modules/moflo/bin');
 
       // ── Manifest-based auto-update ──────────────────────────────────────
@@ -855,12 +856,11 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
-// ── 3f. Clear the in-progress upgrade notice (#636, #738) ───────────────────
-// Upgrade work is finished; drop the notice so the statusline badge disappears
-// immediately. Change summary is already in stdout emits (Claude's
-// `additionalContext`); a lingering "you upgraded a while ago" badge is noise.
+// ── 3f. Flip the upgrade notice to "completed" (#636, #738) ─────────────────
+// See the TTL rationale at the constants above for why we switch to a
+// short-TTL completed badge instead of clearing the file.
 if (upgradeNoticeContext) {
-  clearUpgradeNotice();
+  writeUpgradeNotice('completed');
 }
 
 // ── 3g. Commit deferred version stamp (#730) ────────────────────────────────

--- a/src/cli/__tests__/statusline-upgrade-notice.test.ts
+++ b/src/cli/__tests__/statusline-upgrade-notice.test.ts
@@ -1,4 +1,4 @@
-// Statusline upgrade-notice tests (#636 → #738 → #743).
+// Statusline upgrade-notice tests (#636 → #738 → #743 → completed-state).
 //
 // Contract evolution:
 //   #636 — original feature: launcher writes notice after upgrade, statusline
@@ -6,13 +6,16 @@
 //   #738 — launcher writes status='in-progress' BEFORE upgrade work, deletes
 //          file when work completes; statusline still rendered legacy mode
 //          as a fallback.
-//   #743 — statusline now renders ONLY status='in-progress' notices. Stale
-//          legacy files (or any future bad writer) cannot turn the segment
-//          into a permanent column; the launcher's section 0-pre also drops
-//          any leftover file at session start as a second line of defence.
+//   #743 — statusline renders ONLY status='in-progress' notices. Stale legacy
+//          files cannot turn the segment into a permanent column.
+//   completed-state — section 3f writes status='completed' with 2-min TTL
+//          instead of deleting; gives the post-upgrade badge a real visibility
+//          window because Claude Code paints the statusline only AFTER the
+//          SessionStart hook returns. Section 0-pre still wipes any leftover
+//          at the next launcher run, capping lifetime at one session.
 //
-// These tests pin the #743 contract so a regression to "rendering complete
-// notices for an hour" can't slip back in unobserved.
+// These tests pin both the #743 stale-file rejection and the new completed
+// contract.
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
@@ -118,6 +121,7 @@ describe('statusline upgrade-notice (#636 / #738 / #743)', () => {
     expect(status).toBe(0);
     const json = JSON.parse(stdout);
     expect(json.upgradeNotice).toEqual({
+      status: 'in-progress',
       kind: 'upgrade',
       from: '4.8.79',
       to: '4.8.80',
@@ -199,5 +203,70 @@ describe('statusline upgrade-notice (#636 / #738 / #743)', () => {
     const plain = stdout.replace(/\x1B\[[0-9;]*m/g, '');
     expect(plain).toContain('install repaired');
     expect(plain).toContain('updating');
+  });
+
+  it('renders a completed upgrade notice without the updating… indicator', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      status: 'completed',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now - 1_000).toISOString(),
+      expiresAt: new Date(now + 2 * 60_000).toISOString(),
+      changes: 0,
+    });
+
+    const { stdout, status } = runStatusline(root);
+    expect(status).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toEqual({
+      status: 'completed',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+    });
+
+    const compact = runStatusline(root, ['--compact']);
+    // eslint-disable-next-line no-control-regex
+    const plain = compact.stdout.replace(/\x1B\[[0-9;]*m/g, '');
+    expect(plain).toContain('upgraded to 4.8.80');
+    expect(plain).not.toContain('updating');
+  });
+
+  it('omits a completed notice past its TTL', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      status: 'completed',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now - 10 * 60_000).toISOString(),
+      expiresAt: new Date(now - 5 * 60_000).toISOString(),
+      changes: 0,
+    });
+
+    const { stdout } = runStatusline(root);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toBeNull();
+  });
+
+  it('renders a completed "repair" notice without the updating… indicator', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      status: 'completed',
+      kind: 'repair',
+      from: '4.8.80',
+      to: '4.8.80',
+      at: new Date(now).toISOString(),
+      expiresAt: new Date(now + 2 * 60_000).toISOString(),
+      changes: 0,
+    });
+
+    const { stdout } = runStatusline(root, ['--compact']);
+    // eslint-disable-next-line no-control-regex
+    const plain = stdout.replace(/\x1B\[[0-9;]*m/g, '');
+    expect(plain).toContain('install repaired');
+    expect(plain).not.toContain('updating');
   });
 });

--- a/tests/bin/launcher-visibility.test.ts
+++ b/tests/bin/launcher-visibility.test.ts
@@ -267,14 +267,16 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     ).toContain('CPU may briefly spike');
   });
 
-  it('clears upgrade-notice.json + commits version stamp after a version-bump upgrade (#636, #738, #730)', () => {
+  it('writes a completed upgrade notice + commits version stamp after a version-bump upgrade (#636, #738, #730)', () => {
     // Stage `node_modules/moflo/package.json` at v9.9.9 and a prior cached
-    // version at v9.9.8 so the launcher takes the version-bump branch.
-    // The launcher writes an in-progress notice while upgrade work is running
-    // and DELETES the file when work completes — so the badge disappears once
-    // the user is unblocked instead of lingering for an hour (#738). After
-    // every other upgrade-work block runs the launcher commits the version
-    // stamp last (#730), so post-run state is: stamp = new version, notice gone.
+    // version at v9.9.8 so the launcher takes the version-bump branch. The
+    // launcher writes an in-progress notice while upgrade work is running and
+    // a status='completed' notice with 2-min TTL when work finishes — Claude
+    // Code paints the statusline only AFTER the SessionStart hook returns, so
+    // the in-flight badge has zero visibility window; the completed notice is
+    // what the user actually sees on the next render. After every other
+    // upgrade-work block runs the launcher commits the version stamp last
+    // (#730). Post-run state: stamp = new version, notice = completed.
     mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
     writeFileSync(
       join(root, 'node_modules', 'moflo', 'package.json'),
@@ -287,9 +289,17 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     const { stdout } = runLauncher(root);
     expect(stdout).toContain('moflo: upgraded (9.9.8 → 9.9.9)');
 
-    // After the launcher exits, the notice file must be GONE (#738 AC).
+    // After the launcher exits the notice must be a completed handoff —
+    // not the in-progress version (work is done) and not deleted (else the
+    // user never sees the post-upgrade badge).
     const noticePath = join(root, '.moflo', 'upgrade-notice.json');
-    expect(existsSync(noticePath)).toBe(false);
+    expect(existsSync(noticePath)).toBe(true);
+    const notice = JSON.parse(readFileSync(noticePath, 'utf-8'));
+    expect(notice.status).toBe('completed');
+    expect(notice.kind).toBe('upgrade');
+    expect(notice.from).toBe('9.9.8');
+    expect(notice.to).toBe('9.9.9');
+    expect(new Date(notice.expiresAt).getTime()).toBeGreaterThan(Date.now());
 
     // And the version stamp must reflect the new version (#730 AC).
     expect(readFileSync(stampPath, 'utf-8').trim()).toBe('9.9.9');
@@ -352,17 +362,23 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
     );
 
     // Next launcher detects the same upgrade and completes it cleanly: stamp
-    // bumped, notice cleared. This is the AC: "leaves the system without the
-    // new stamp, so the next launcher re-runs the upgrade detection".
+    // bumped, notice transitioned to status='completed'. This is the AC:
+    // "leaves the system without the new stamp, so the next launcher re-runs
+    // the upgrade detection".
     const second = runLauncher(root);
     expect(second.stdout).toContain('moflo: upgraded (9.9.8 → 9.9.9)');
     expect(readFileSync(stampPath, 'utf-8').trim()).toBe('9.9.9');
-    expect(existsSync(join(root, '.moflo', 'upgrade-notice.json'))).toBe(false);
+    const noticePath = join(root, '.moflo', 'upgrade-notice.json');
+    expect(existsSync(noticePath)).toBe(true);
+    const notice = JSON.parse(readFileSync(noticePath, 'utf-8'));
+    expect(notice.status).toBe('completed');
   });
 
-  it('clears a stale upgrade-notice.json on a subsequent upgrade (#738)', () => {
-    // Pre-seed with a stale notice from a prior upgrade. After this session's
-    // upgrade work completes the launcher must delete it — no lingering badge.
+  it('replaces a stale upgrade-notice.json with a fresh completed notice on a subsequent upgrade (#738)', () => {
+    // Pre-seed with a stale notice from a prior upgrade. Section 0-pre wipes
+    // it at session start; section 3f writes a fresh status='completed'
+    // notice for THIS session's upgrade. The pre-existing 1.0.0/1.0.1
+    // values must NOT survive — they'd point users at the wrong version.
     mkdirSync(join(root, '.moflo'), { recursive: true });
     const noticePath = join(root, '.moflo', 'upgrade-notice.json');
     writeFileSync(
@@ -387,7 +403,11 @@ describe('session-start-launcher — visible mutation reporter (#716)', () => {
 
     runLauncher(root);
 
-    expect(existsSync(noticePath)).toBe(false);
+    expect(existsSync(noticePath)).toBe(true);
+    const notice = JSON.parse(readFileSync(noticePath, 'utf-8'));
+    expect(notice.status).toBe('completed');
+    expect(notice.from).toBe('9.9.8');
+    expect(notice.to).toBe('9.9.9');
   });
 
   it('clears a stale upgrade-notice.json even when no upgrade fires this session (#743)', () => {


### PR DESCRIPTION
## Summary

The in-progress upgrade badge had effectively zero visibility window: Claude Code paints the statusline only **after** the SessionStart hook returns, by which point the launcher has already exited and cleared the notice. This switches section 3f to write a 2-min-TTL **"completed"** notice instead, so the user actually sees the post-upgrade badge on the next render.

```
Before: 📦 4.9.0-rc.13 → 4.9.0-rc.14 (updating…)   [never visible]
After:  📦 upgraded to 4.9.0-rc.14                  [visible ~2 min]
```

Section 0-pre of the next launcher run wipes any leftover so it can't linger across sessions.

## Bonus polish (same PR)

- **Rename `getAgentDBStats` → `getEmbeddingsStats`** (function + local var + JSON output key). Display label was already rebranded in #767; the function/JSON-key was the last bit of `AgentDB` drift after the agentdb removal in epic #586.
- **MCP icon** `📊` → `🔌` — less visual collision with the new Embeddings line.
- **Dedupe per-render probe** — `generateDashboard` and `generateJSON` were each calling `getEmbeddingsStats()` twice (once via `getSystemMetrics`, once directly). Now reuses `system.embeddings` from the first call.

## Simplify-pass cleanups

- Collapsed `writeInProgressUpgradeNotice` + `writeCompletedUpgradeNotice` into a single `writeUpgradeNotice(status)` — they were 13 of 16 lines identical.
- Deleted dead `clearUpgradeNotice()` — section 3f no longer calls it; only remaining unlinker is the inline one in section 0-pre.
- Refactored `formatUpgradeNoticeSegment` to single-return shape: pick body text via if/else cascade, append suffix once (was three intertwined returns).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Targeted tests (statusline-upgrade-notice + launcher-visibility) — **26/26**
- [x] Full suite (parallel + isolation batch) — **7437 passed, 0 failed**

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)