### PR TITLE
feat(799): lazy swarm coordinator singleton + CLAUDE.md regression guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,27 @@ flo doctor --fix                             # Health check
 ## Broken Window Theory (mandatory — moflo repo only)
 
 Zero tolerance for unresolved failures. Every failing test, every warning, every bug gets fixed before moving on — no exceptions by severity, no "probably flaky" without individual re-verification. If a test fails in the full suite, retest individually to distinguish real failures from flaky ones. If flaky, fix the flakiness itself (tight timeouts, resource contention, etc.) — don't just re-run and move on. A red signal is never acceptable as background noise.
+
+## ⛔ Protected functionality — swarm + hive-mind (mandatory)
+
+**Swarm and hive-mind are CRITICAL moflo product surface.** They are headline capabilities (`flo swarm`, `flo hive-mind`, MCP tools `swarm_*` / `agent_*` / `task_*` / `hive-mind_*`, queen/worker hierarchy, consensus). They MUST remain wired and functional across every refactor, migration, collapse, rename, and "cleanup".
+
+**Regression includes — not just deletion — but also:**
+- **Disconnection** — leaving infrastructure in place but reducing MCP handlers to stubs returning hardcoded literals (e.g. `{ swarmId: 'swarm-' + Date.now() }`, `{ agentCount: 0, taskCount: 0 }`, file-based JSON writes that bypass the coordinator). This is the silent failure mode that triggered epic #798.
+- **Stubbing / "simplification"** — replacing real coordinator calls with synthetic returns under "we'll wire it later".
+- **Migration drift** — completing one half of a migration (e.g. hive-mind to MessageBus) without the matching swarm/agent half.
+
+**Mandatory verification on any change to** `src/cli/mcp-tools/{swarm,agent,task,hive-mind}-tools.ts`, `src/cli/swarm/**`, `src/cli/commands/{swarm,agent,hive-mind}.ts`, or related MCP wiring:
+
+1. `agent_spawn` invokes `coordinator.spawnAgent(...)` — not a JSON store write
+2. `swarm_init` invokes `coordinator.initialize(...)` — not literal `swarm-${Date.now()}`
+3. `swarm_status` / `swarm_health` query the coordinator — not hardcoded values
+4. `task_*` invokes `coordinator.distributeTasks` / `executeTask` / `cancelTask`
+5. `hive-mind_*` routes through `MessageBus` + `WriteThroughAdapter` (Story #121); workers register with the shared coordinator
+6. End-to-end system tests at `tests/system/swarm-restoration-e2e.test.ts` exercise the wired path
+
+**If a refactor seems to require disconnecting handlers temporarily, STOP and surface it.** Load-bearing change requiring explicit owner sign-off — never an in-passing tidy-up. Default to preservation.
+
+**Cost of violation:** Epic #798 (10 stories) exists solely to repair this regression. The user described it as "costing critical time and money to repair when it NEVER should have been necessary." This rule is non-negotiable.
+
+See `feedback_swarm_hive_never_regress.md` in auto-memory for full detail.

--- a/src/cli/__tests__/swarm-coordinator-singleton.test.ts
+++ b/src/cli/__tests__/swarm-coordinator-singleton.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for the lazy swarm coordinator singleton (Story #799 / epic #798).
+ *
+ * Validates:
+ * - First call constructs and initializes a coordinator instance
+ * - Subsequent calls return the same instance (memoization)
+ * - Concurrent callers race-safe — share one in-flight init
+ * - `_resetSwarmCoordinatorForTest()` clears state for the next test
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetSwarmCoordinatorForTest,
+  getSwarmCoordinator,
+} from '../mcp-tools/swarm-coordinator-singleton.js';
+
+describe('swarm-coordinator-singleton', () => {
+  afterEach(() => {
+    _resetSwarmCoordinatorForTest();
+  });
+
+  it('returns the same instance across sequential calls', async () => {
+    const a = await getSwarmCoordinator();
+    const b = await getSwarmCoordinator();
+    expect(a).toBe(b);
+  });
+
+  it('returns a coordinator that has been initialized', async () => {
+    const coord = await getSwarmCoordinator();
+    // After initialize() the coordinator should respond to its public API.
+    expect(typeof coord.shutdown).toBe('function');
+    expect(typeof coord.getStatus).toBe('function');
+  });
+
+  it('shares one in-flight init across concurrent callers', async () => {
+    const [a, b, c] = await Promise.all([
+      getSwarmCoordinator(),
+      getSwarmCoordinator(),
+      getSwarmCoordinator(),
+    ]);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it('reset hook produces a fresh instance on the next call', async () => {
+    const first = await getSwarmCoordinator();
+    _resetSwarmCoordinatorForTest();
+    const second = await getSwarmCoordinator();
+    expect(second).not.toBe(first);
+  });
+});

--- a/src/cli/__tests__/swarm-coordinator-singleton.test.ts
+++ b/src/cli/__tests__/swarm-coordinator-singleton.test.ts
@@ -1,11 +1,5 @@
 /**
- * Tests for the lazy swarm coordinator singleton (Story #799 / epic #798).
- *
- * Validates:
- * - First call constructs and initializes a coordinator instance
- * - Subsequent calls return the same instance (memoization)
- * - Concurrent callers race-safe — share one in-flight init
- * - `_resetSwarmCoordinatorForTest()` clears state for the next test
+ * Tests for the lazy swarm coordinator singleton (#799 / epic #798).
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -15,8 +9,8 @@ import {
 } from '../mcp-tools/swarm-coordinator-singleton.js';
 
 describe('swarm-coordinator-singleton', () => {
-  afterEach(() => {
-    _resetSwarmCoordinatorForTest();
+  afterEach(async () => {
+    await _resetSwarmCoordinatorForTest();
   });
 
   it('returns the same instance across sequential calls', async () => {
@@ -27,7 +21,6 @@ describe('swarm-coordinator-singleton', () => {
 
   it('returns a coordinator that has been initialized', async () => {
     const coord = await getSwarmCoordinator();
-    // After initialize() the coordinator should respond to its public API.
     expect(typeof coord.shutdown).toBe('function');
     expect(typeof coord.getStatus).toBe('function');
   });
@@ -44,8 +37,14 @@ describe('swarm-coordinator-singleton', () => {
 
   it('reset hook produces a fresh instance on the next call', async () => {
     const first = await getSwarmCoordinator();
-    _resetSwarmCoordinatorForTest();
+    await _resetSwarmCoordinatorForTest();
     const second = await getSwarmCoordinator();
     expect(second).not.toBe(first);
+  });
+
+  it('throws when config is passed after initialization', async () => {
+    await getSwarmCoordinator();
+    await expect(getSwarmCoordinator({ topology: { type: 'mesh', maxAgents: 5 } } as never))
+      .rejects.toThrow(/config is honored only on the first call/);
   });
 });

--- a/src/cli/mcp-tools/swarm-coordinator-singleton.ts
+++ b/src/cli/mcp-tools/swarm-coordinator-singleton.ts
@@ -1,0 +1,72 @@
+/**
+ * Swarm Coordinator Singleton — lazy module-level instance for MCP tool handlers
+ *
+ * Story #799 (epic #798): MCP tool handlers (`agent_*`, `swarm_*`, `task_*`) need a
+ * shared `UnifiedSwarmCoordinator` to dispatch real lifecycle operations against.
+ * Mirrors the hive-mind-tools.ts:24-70 pattern (lazy MessageBus singleton).
+ *
+ * Why lazy: coordinator init spins up TopologyManager + MessageBus + ConsensusEngine
+ * + AgentPools (~tens of ms). If a session only calls memory_search, it should not
+ * pay that cost. First swarm/agent/task tool call triggers init; subsequent calls
+ * reuse the cached instance.
+ *
+ * Race-safety: an in-flight init promise is cached so concurrent callers share a
+ * single bootstrap rather than racing two coordinator constructions.
+ */
+
+import {
+  UnifiedSwarmCoordinator,
+  createUnifiedSwarmCoordinator,
+} from '../swarm/unified-coordinator.js';
+import type { CoordinatorConfig } from '../swarm/types.js';
+
+let _coordinator: UnifiedSwarmCoordinator | null = null;
+let _initPromise: Promise<UnifiedSwarmCoordinator> | null = null;
+
+/**
+ * Get the singleton swarm coordinator, lazy-initializing on first call.
+ *
+ * Concurrent callers receive the same in-flight initialization promise so that
+ * exactly one coordinator is constructed regardless of how many handlers race.
+ */
+export async function getSwarmCoordinator(
+  config?: Partial<CoordinatorConfig>,
+): Promise<UnifiedSwarmCoordinator> {
+  if (_coordinator) return _coordinator;
+  if (_initPromise) return _initPromise;
+
+  _initPromise = (async () => {
+    const coord = createUnifiedSwarmCoordinator(config);
+    await coord.initialize();
+    _coordinator = coord;
+    return coord;
+  })();
+
+  try {
+    return await _initPromise;
+  } finally {
+    // Clear the promise cache only once the result is settled. If init fails,
+    // the next call should be allowed to retry rather than re-await a failed promise.
+    if (!_coordinator) {
+      _initPromise = null;
+    }
+  }
+}
+
+/**
+ * Test-only reset hook. Resets the singleton state so each test gets a fresh
+ * coordinator. Not exported from `index.ts`; only callable from test files
+ * that import this module directly.
+ */
+export function _resetSwarmCoordinatorForTest(): void {
+  if (_coordinator) {
+    // Best-effort shutdown so tests don't leak background timers.
+    try {
+      void _coordinator.shutdown();
+    } catch {
+      // Swallow — test is tearing down anyway.
+    }
+  }
+  _coordinator = null;
+  _initPromise = null;
+}

--- a/src/cli/mcp-tools/swarm-coordinator-singleton.ts
+++ b/src/cli/mcp-tools/swarm-coordinator-singleton.ts
@@ -1,17 +1,8 @@
 /**
- * Swarm Coordinator Singleton — lazy module-level instance for MCP tool handlers
+ * Lazy singleton for UnifiedSwarmCoordinator.
  *
- * Story #799 (epic #798): MCP tool handlers (`agent_*`, `swarm_*`, `task_*`) need a
- * shared `UnifiedSwarmCoordinator` to dispatch real lifecycle operations against.
- * Mirrors the hive-mind-tools.ts:24-70 pattern (lazy MessageBus singleton).
- *
- * Why lazy: coordinator init spins up TopologyManager + MessageBus + ConsensusEngine
- * + AgentPools (~tens of ms). If a session only calls memory_search, it should not
- * pay that cost. First swarm/agent/task tool call triggers init; subsequent calls
- * reuse the cached instance.
- *
- * Race-safety: an in-flight init promise is cached so concurrent callers share a
- * single bootstrap rather than racing two coordinator constructions.
+ * Init cost (~tens of ms — TopologyManager + MessageBus + ConsensusEngine + AgentPools)
+ * is only paid on the first swarm/agent/task tool call, not on memory-search-only sessions.
  */
 
 import {
@@ -26,15 +17,25 @@ let _initPromise: Promise<UnifiedSwarmCoordinator> | null = null;
 /**
  * Get the singleton swarm coordinator, lazy-initializing on first call.
  *
- * Concurrent callers receive the same in-flight initialization promise so that
- * exactly one coordinator is constructed regardless of how many handlers race.
+ * `config` is honored only on the very first call. Passing config after the
+ * coordinator is already initialized is a misuse — it would silently be
+ * ignored, so we throw to surface it.
  */
 export async function getSwarmCoordinator(
   config?: Partial<CoordinatorConfig>,
 ): Promise<UnifiedSwarmCoordinator> {
-  if (_coordinator) return _coordinator;
+  if (_coordinator) {
+    if (config !== undefined) {
+      throw new Error(
+        'getSwarmCoordinator(config) called after initialization — config is honored only on the first call. Reset via _resetSwarmCoordinatorForTest() if you need to re-initialize.',
+      );
+    }
+    return _coordinator;
+  }
   if (_initPromise) return _initPromise;
 
+  // In-flight promise cache so concurrent callers share a single bootstrap
+  // rather than racing two coordinator constructions.
   _initPromise = (async () => {
     const coord = createUnifiedSwarmCoordinator(config);
     await coord.initialize();
@@ -45,28 +46,25 @@ export async function getSwarmCoordinator(
   try {
     return await _initPromise;
   } finally {
-    // Clear the promise cache only once the result is settled. If init fails,
-    // the next call should be allowed to retry rather than re-await a failed promise.
-    if (!_coordinator) {
-      _initPromise = null;
-    }
+    // Always clear so a failed init lets the next call retry.
+    _initPromise = null;
   }
 }
 
 /**
- * Test-only reset hook. Resets the singleton state so each test gets a fresh
- * coordinator. Not exported from `index.ts`; only callable from test files
- * that import this module directly.
+ * Test-only reset hook. Awaits shutdown so timers and listeners are torn down
+ * before the next test's coordinator boots — fire-and-forget would leak
+ * intervals across the suite.
  */
-export function _resetSwarmCoordinatorForTest(): void {
-  if (_coordinator) {
-    // Best-effort shutdown so tests don't leak background timers.
-    try {
-      void _coordinator.shutdown();
-    } catch {
-      // Swallow — test is tearing down anyway.
-    }
-  }
+export async function _resetSwarmCoordinatorForTest(): Promise<void> {
+  const coord = _coordinator;
   _coordinator = null;
   _initPromise = null;
+  if (coord) {
+    try {
+      await coord.shutdown();
+    } catch {
+      // Swallow: test teardown should not fail because shutdown raced.
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Foundation for swarm + hive-mind restoration epic #798 — Story 1 (#799). Module-level lazy `getSwarmCoordinator()` so future `agent_*`/`swarm_*`/`task_*` handlers can dispatch real coordinator operations. Plus elevation of the swarm/hive-mind protection rule into root CLAUDE.md so the regression that produced epic #798 cannot recur silently.

## What

- `src/cli/mcp-tools/swarm-coordinator-singleton.ts` — lazy `getSwarmCoordinator()`, race-safe in-flight promise cache, throws if `config` passed after init, async `_resetSwarmCoordinatorForTest()` that awaits shutdown
- `src/cli/__tests__/swarm-coordinator-singleton.test.ts` — 5 tests: sequential reuse, init shape, concurrent race, reset, throw-on-config-after-init
- `CLAUDE.md` — new "⛔ Protected functionality" section explicitly names disconnection / stubbing / "simplification to literals" as regressions equivalent to deletion. Mandatory verification checklist for any change touching `mcp-tools/{swarm,agent,task,hive-mind}-tools.ts`. Cross-references new `feedback_swarm_hive_never_regress.md` memory.

## Why this shape

Mirrors the proven `hive-mind-tools.ts:24-70` pattern (lazy MessageBus). Init is deferred to first call so `memory_search`-only sessions don't pay coordinator startup cost (TopologyManager + MessageBus + ConsensusEngine + AgentPools).

`/simplify` review-agent findings all addressed in-PR:
- CRITICAL — async shutdown so test teardown doesn't leak timers across the suite
- HIGH — config-after-init now throws instead of silently ignoring
- LOW — trimmed verbose file header

## No behavior change

Nothing imports the singleton yet. Stories 3+ (#801, #803, #805, #806, #807) wire it into the actual MCP handlers.

## Test plan

- [x] \`npm test\` — full suite green: **7442 passed / 0 failed** (+5 vs main)
- [x] \`npm run lint\` — clean (--max-warnings 0)
- [x] \`tsc --noEmit\` — clean
- [x] \`/simplify\` ran with 3 review agents; all findings fixed in-PR
- [x] Singleton 5/5 tests pass

Closes #799

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)