### PR TITLE
feat(800): centralize subagent bootstrap directive (single-source JSON)

### DIFF
--- a/.claude/helpers/subagent-bootstrap.json
+++ b/.claude/helpers/subagent-bootstrap.json
@@ -1,0 +1,3 @@
+{
+  "directive": "MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/shipped/moflo-subagents.md` protocol."
+}

--- a/.claude/helpers/subagent-start.cjs
+++ b/.claude/helpers/subagent-start.cjs
@@ -5,16 +5,52 @@
  *
  * Output format: JSON with additionalContext (Claude Code hook protocol).
  * Exit 0 = allow (SubagentStart cannot block).
+ *
+ * Source of truth: ./subagent-bootstrap.json (sibling). The TS export at
+ * `src/cli/services/subagent-bootstrap.ts` reads the same file so future
+ * agent_spawn surfaces (epic #798 stories 3 + 9) inject byte-identical text.
+ *
+ * Inline FALLBACK keeps the hook functional if the JSON sibling is ever
+ * missing — a SubagentStart that emits nothing leaves the memory-first gate
+ * un-announced and silently regresses subagent behavior.
  */
 'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Defense-in-depth copy of the canonical directive in subagent-bootstrap.json.
+// Kept as a single-line literal so the parity test in tests/bin/subagent-start.test.ts
+// can verify it matches the JSON via plain substring containment.
+const FALLBACK_DIRECTIVE = 'MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/shipped/moflo-subagents.md` protocol.';
+
+function loadDirective() {
+  const jsonPath = path.join(__dirname, 'subagent-bootstrap.json');
+  let raw;
+  try {
+    raw = fs.readFileSync(jsonPath, 'utf8');
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      process.stderr.write(`[subagent-start] read failed: ${err.message} — using inline fallback\n`);
+    }
+    return FALLBACK_DIRECTIVE;
+  }
+  try {
+    const data = JSON.parse(raw);
+    if (typeof data.directive === 'string' && data.directive.length > 0) {
+      return data.directive;
+    }
+    process.stderr.write('[subagent-start] subagent-bootstrap.json missing string `directive` — using inline fallback\n');
+  } catch (err) {
+    process.stderr.write(`[subagent-start] subagent-bootstrap.json parse failed: ${err.message} — using inline fallback\n`);
+  }
+  return FALLBACK_DIRECTIVE;
+}
 
 const output = {
   hookSpecificOutput: {
     hookEventName: 'SubagentStart',
-    additionalContext:
-      'MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). ' +
-      'The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. ' +
-      'After memory search, follow `.claude/guidance/shipped/moflo-subagents.md` protocol.',
+    additionalContext: loadDirective(),
   },
 };
 

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -416,7 +416,9 @@ try {
           resolve(projectRoot, 'node_modules/moflo/src/cli/.claude/helpers'),
         ];
         const sourceHelperFiles = [
-          'auto-memory-hook.mjs', 'statusline.cjs', 'intelligence.cjs', 'subagent-start.cjs', 'pre-commit', 'post-commit',
+          'auto-memory-hook.mjs', 'statusline.cjs', 'intelligence.cjs',
+          'subagent-start.cjs', 'subagent-bootstrap.json',
+          'pre-commit', 'post-commit',
         ];
         for (const file of sourceHelperFiles) {
           const dest = resolve(helpersDir, file);

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -416,7 +416,9 @@ try {
           resolve(projectRoot, 'node_modules/moflo/src/cli/.claude/helpers'),
         ];
         const sourceHelperFiles = [
-          'auto-memory-hook.mjs', 'statusline.cjs', 'intelligence.cjs', 'subagent-start.cjs', 'pre-commit', 'post-commit',
+          'auto-memory-hook.mjs', 'statusline.cjs', 'intelligence.cjs',
+          'subagent-start.cjs', 'subagent-bootstrap.json',
+          'pre-commit', 'post-commit',
         ];
         for (const file of sourceHelperFiles) {
           const dest = resolve(helpersDir, file);

--- a/src/cli/__tests__/services/subagent-bootstrap.test.ts
+++ b/src/cli/__tests__/services/subagent-bootstrap.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Subagent bootstrap directive parity test (story #800).
+ *
+ * The TS export `SUBAGENT_BOOTSTRAP_DIRECTIVE` is one of the consumers of
+ * `.claude/helpers/subagent-bootstrap.json` — the cjs SubagentStart hook is
+ * the other (covered by `tests/bin/subagent-start.test.ts`). Both paths
+ * must land on the same string; otherwise spawn surfaces drift apart and
+ * the "single source of truth" promise of story #800 breaks silently.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../../services/subagent-bootstrap.js';
+
+const REPO_ROOT = resolve(__dirname, '../../../..');
+const JSON_PATH = resolve(REPO_ROOT, '.claude/helpers/subagent-bootstrap.json');
+
+describe('SUBAGENT_BOOTSTRAP_DIRECTIVE', () => {
+  it('canonical JSON ships at .claude/helpers/subagent-bootstrap.json', () => {
+    expect(existsSync(JSON_PATH)).toBe(true);
+  });
+
+  it('matches subagent-bootstrap.json byte-for-byte', () => {
+    const json = JSON.parse(readFileSync(JSON_PATH, 'utf-8')) as { directive: string };
+    expect(SUBAGENT_BOOTSTRAP_DIRECTIVE).toBe(json.directive);
+  });
+
+  it('non-empty string', () => {
+    expect(typeof SUBAGENT_BOOTSTRAP_DIRECTIVE).toBe('string');
+    expect(SUBAGENT_BOOTSTRAP_DIRECTIVE.length).toBeGreaterThan(0);
+  });
+
+  it('names the load-bearing memory_search tool', () => {
+    expect(SUBAGENT_BOOTSTRAP_DIRECTIVE).toContain('mcp__moflo__memory_search');
+  });
+});

--- a/src/cli/services/index.ts
+++ b/src/cli/services/index.ts
@@ -90,6 +90,9 @@ export {
   type RepairResult,
 } from './hook-wiring.js';
 
+// Subagent Bootstrap Directive (single-source for SubagentStart + agent_spawn surfaces)
+export { SUBAGENT_BOOTSTRAP_DIRECTIVE } from './subagent-bootstrap.js';
+
 // Re-export types
 export type { default as WorkerDaemonType, DaemonConfig } from './worker-daemon.js';
 export type { default as HeadlessWorkerExecutorType } from './headless-worker-executor.js';

--- a/src/cli/services/subagent-bootstrap.ts
+++ b/src/cli/services/subagent-bootstrap.ts
@@ -1,0 +1,66 @@
+/**
+ * Single source of truth for the subagent memory-first directive.
+ *
+ * `.claude/helpers/subagent-bootstrap.json` at the moflo package root is the
+ * canonical directive string. The cjs SubagentStart hook
+ * (`.claude/helpers/subagent-start.cjs`) reads it via `__dirname`; this TS
+ * module reads the same file via `locateMofloRootPath` so every spawn surface
+ * — the hook today, `agent_spawn` after story #801, hive-mind worker
+ * registration after story #807 — injects byte-identical text.
+ *
+ * The inline FALLBACK below is intentionally a second copy of the string,
+ * required as defense-in-depth so a stale install missing the JSON file (or
+ * a partially-published tarball) cannot silently spawn agents without the
+ * memory-first directive. The parity test in
+ * `src/cli/__tests__/services/subagent-bootstrap.test.ts` pins the FALLBACK
+ * to the JSON at commit time so the two cannot drift unnoticed.
+ */
+import { readFileSync } from 'node:fs';
+import { locateMofloRootPath } from './moflo-require.js';
+
+const BOOTSTRAP_JSON_REL = '.claude/helpers/subagent-bootstrap.json';
+
+// Defense-in-depth copy of the canonical directive in subagent-bootstrap.json.
+// Kept as a single-line literal so the parity test can verify it matches the
+// JSON via plain substring containment.
+const FALLBACK_DIRECTIVE = 'MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/shipped/moflo-subagents.md` protocol.';
+
+function loadDirective(): string {
+  const jsonPath = locateMofloRootPath(BOOTSTRAP_JSON_REL);
+  if (!jsonPath) {
+    process.stderr.write(
+      `[subagent-bootstrap] ${BOOTSTRAP_JSON_REL} not found in moflo package — using inline fallback\n`,
+    );
+    return FALLBACK_DIRECTIVE;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(jsonPath, 'utf8');
+  } catch (err) {
+    process.stderr.write(
+      `[subagent-bootstrap] read failed: ${(err as Error).message} — using inline fallback\n`,
+    );
+    return FALLBACK_DIRECTIVE;
+  }
+  try {
+    const data = JSON.parse(raw) as { directive?: unknown };
+    if (typeof data.directive === 'string' && data.directive.length > 0) {
+      return data.directive;
+    }
+    process.stderr.write(
+      '[subagent-bootstrap] subagent-bootstrap.json missing string `directive` — using inline fallback\n',
+    );
+  } catch (err) {
+    process.stderr.write(
+      `[subagent-bootstrap] subagent-bootstrap.json parse failed: ${(err as Error).message} — using inline fallback\n`,
+    );
+  }
+  return FALLBACK_DIRECTIVE;
+}
+
+/**
+ * The canonical directive string injected into every subagent's bootstrap
+ * context. Resolved once at module load — the JSON file is shipped in the
+ * tarball and never rewritten at runtime, so caching is safe.
+ */
+export const SUBAGENT_BOOTSTRAP_DIRECTIVE: string = loadDirective();

--- a/tests/bin/subagent-start.test.ts
+++ b/tests/bin/subagent-start.test.ts
@@ -1,0 +1,70 @@
+/**
+ * SubagentStart hook parity tests (story #800).
+ *
+ * The SubagentStart hook injects a memory-first directive into every
+ * spawned subagent's bootstrap context. Story #800 moved the directive
+ * out of the cjs hook source and into a sibling JSON file so the TS spawn
+ * surfaces (epic #798 stories 3 + 9) can read the same canonical text.
+ * These tests pin two contracts:
+ *   1. The hook's emitted `additionalContext` matches the JSON byte-for-byte
+ *      — drift breaks the single-source-of-truth promise across consumers.
+ *   2. The cjs hook's inline FALLBACK string (defense-in-depth for a missing
+ *      JSON file) also matches the JSON. Without this, the fallback can rot
+ *      silently when the canonical directive is updated.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const HELPERS_DIR = resolve(__dirname, '../../.claude/helpers');
+const HOOK_PATH = resolve(HELPERS_DIR, 'subagent-start.cjs');
+const JSON_PATH = resolve(HELPERS_DIR, 'subagent-bootstrap.json');
+const TS_MODULE_PATH = resolve(__dirname, '../../src/cli/services/subagent-bootstrap.ts');
+
+interface HookOutput {
+  hookSpecificOutput?: {
+    hookEventName?: string;
+    additionalContext?: string;
+  };
+}
+
+describe('subagent-start.cjs', () => {
+  let hookOutput: HookOutput;
+  let canonicalDirective: string;
+
+  beforeAll(() => {
+    canonicalDirective = (JSON.parse(readFileSync(JSON_PATH, 'utf-8')) as { directive: string }).directive;
+    const stdout = execFileSync('node', [HOOK_PATH], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    hookOutput = JSON.parse(stdout) as HookOutput;
+  });
+
+  it('shipped sibling JSON exists', () => {
+    expect(existsSync(JSON_PATH)).toBe(true);
+  });
+
+  it('emits the SubagentStart hook envelope', () => {
+    expect(hookOutput.hookSpecificOutput?.hookEventName).toBe('SubagentStart');
+    expect(typeof hookOutput.hookSpecificOutput?.additionalContext).toBe('string');
+    expect(hookOutput.hookSpecificOutput?.additionalContext?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('additionalContext matches subagent-bootstrap.json byte-for-byte', () => {
+    expect(hookOutput.hookSpecificOutput?.additionalContext).toBe(canonicalDirective);
+  });
+
+  it('cjs FALLBACK literal matches the canonical directive', () => {
+    const cjsSource = readFileSync(HOOK_PATH, 'utf-8');
+    expect(cjsSource).toContain(canonicalDirective);
+  });
+
+  it('ts FALLBACK literal matches the canonical directive', () => {
+    const tsSource = readFileSync(TS_MODULE_PATH, 'utf-8');
+    expect(tsSource).toContain(canonicalDirective);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract the SubagentStart memory-first directive out of `.claude/helpers/subagent-start.cjs` and into the canonical `.claude/helpers/subagent-bootstrap.json` so future spawn surfaces (epic #798 stories 3 + 9) inject byte-identical text.
- Add `src/cli/services/subagent-bootstrap.ts` exporting `SUBAGENT_BOOTSTRAP_DIRECTIVE`, anchored on `locateMofloRootPath` (the documented helper for moflo-package-root files — respects `feedback_no_fixed_depth_paths`).
- Pin both surfaces to the JSON via parity tests; pin the defense-in-depth FALLBACK literals to the JSON via source-level substring containment so a stale install missing the JSON still injects matching text.
- Wire `subagent-bootstrap.json` into both copies of `session-start-launcher.mjs` (`sourceHelperFiles`) so consumer projects receive it on session-start sync.

## Drift surfaces (now impossible)
| Layer | Source |
|------|--------|
| Hook stdout (cjs) | reads sibling JSON via `__dirname` |
| TS export (epic #798 future agent_spawn / hive-mind) | reads same JSON via `locateMofloRootPath` |
| FALLBACK literals (defense-in-depth) | pinned to JSON at commit time by parity tests |

## Test plan
- [x] `tests/bin/subagent-start.test.ts` — child-process hook output matches JSON byte-for-byte; cjs + ts source files contain the canonical directive (FALLBACK parity)
- [x] `src/cli/__tests__/services/subagent-bootstrap.test.ts` — TS export matches JSON byte-for-byte
- [x] Full `npm test` (parallel + isolation): 7451 passing, 0 failing
- [x] Build clean (`tsc` no errors)

Closes #800
Part of epic #798

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)