### PR TITLE
feat(801): wire agent_spawn to UnifiedSwarmCoordinator

### DIFF
--- a/src/cli/__tests__/mcp-tools/agent-spawn.test.ts
+++ b/src/cli/__tests__/mcp-tools/agent-spawn.test.ts
@@ -1,13 +1,5 @@
 /**
- * Story #801 — `agent_spawn` wired to the live UnifiedSwarmCoordinator.
- *
- * Pins:
- *   - Spawn writes through the coordinator (not the JSON store)
- *   - Returned id matches the Ruflo-style regex and is reachable via
- *     `coordinator.getAgent(id)` in the same handler call
- *   - Response.bootstrap is byte-equal to the canonical directive (#800)
- *   - Whitelist + slug validation rejects without throwing
- *   - ADR-026 model routing preserved on the coordinator path
+ * `agent_spawn` wired to the live UnifiedSwarmCoordinator (story #801).
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -20,97 +12,94 @@ import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../../services/subagent-bootstrap.
 
 const ID_RE = /^agent-[a-z][a-z0-9-]*-[0-9a-f]{24}$/;
 
-function findSpawnTool() {
-  const tool = agentTools.find(t => t.name === 'agent_spawn');
-  if (!tool) throw new Error('agent_spawn tool missing from agentTools');
-  return tool;
+interface SpawnResult {
+  success: boolean;
+  agentId?: string;
+  agentType?: string;
+  domain?: string;
+  status?: string;
+  spawned?: boolean;
+  model?: string;
+  modelRoutedBy?: string;
+  bootstrap?: string;
+  error?: string;
 }
 
-describe('agent_spawn — coordinator-backed (story #801)', () => {
+async function spawn(input: Record<string, unknown>): Promise<SpawnResult> {
+  const tool = agentTools.find(t => t.name === 'agent_spawn');
+  if (!tool) throw new Error('agent_spawn tool missing from agentTools');
+  return (await tool.handler(input)) as SpawnResult;
+}
+
+describe('agent_spawn — coordinator-backed', () => {
   afterEach(async () => {
     await _resetSwarmCoordinatorForTest();
   });
 
   it('spawns a live agent reachable via coordinator.getAgent', async () => {
-    const tool = findSpawnTool();
-    const result = (await tool.handler({ agentType: 'coder' })) as Record<string, unknown>;
+    const result = await spawn({ agentType: 'coder' });
 
     expect(result.success).toBe(true);
-    expect(typeof result.agentId).toBe('string');
-    expect(result.agentId as string).toMatch(ID_RE);
+    expect(result.agentId).toBeDefined();
+    expect(result.agentId!).toMatch(ID_RE);
 
     const coord = await getSwarmCoordinator();
-    const live = coord.getAgent(result.agentId as string);
+    const live = coord.getAgent(result.agentId!);
     expect(live).toBeDefined();
     expect(live!.type).toBe('coder');
     expect(live!.status).toBe('idle');
   });
 
   it('embeds the canonical bootstrap directive byte-for-byte', async () => {
-    const tool = findSpawnTool();
-    const result = (await tool.handler({ agentType: 'researcher' })) as Record<string, unknown>;
+    const result = await spawn({ agentType: 'researcher' });
     expect(result.bootstrap).toBe(SUBAGENT_BOOTSTRAP_DIRECTIVE);
   });
 
   it('rejects unknown agent types without throwing', async () => {
-    const tool = findSpawnTool();
-    const result = (await tool.handler({ agentType: 'definitely-not-a-real-type' })) as Record<string, unknown>;
+    const result = await spawn({ agentType: 'definitely-not-a-real-type' });
     expect(result.success).toBe(false);
-    expect(typeof result.error).toBe('string');
-    expect(result.error as string).toMatch(/whitelist|allowed/i);
+    expect(result.error).toMatch(/whitelist|allowed/i);
   });
 
   it('rejects non-string agent types without throwing', async () => {
-    const tool = findSpawnTool();
-    const result = (await tool.handler({ agentType: 123 as unknown as string })) as Record<string, unknown>;
+    const result = await spawn({ agentType: 123 as unknown as string });
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
   });
 
   it('rejects malformed slugs (uppercase / punctuation)', async () => {
-    const tool = findSpawnTool();
     for (const bad of ['Coder', 'coder!', 'a b', '../traversal']) {
-      const result = (await tool.handler({ agentType: bad })) as Record<string, unknown>;
+      const result = await spawn({ agentType: bad });
       expect(result.success).toBe(false);
     }
   });
 
   it('honors explicit model selection (modelRoutedBy=explicit)', async () => {
-    const tool = findSpawnTool();
-    const result = (await tool.handler({
-      agentType: 'coder',
-      model: 'opus',
-    })) as Record<string, unknown>;
+    const result = await spawn({ agentType: 'coder', model: 'opus' });
     expect(result.success).toBe(true);
     expect(result.model).toBe('opus');
     expect(result.modelRoutedBy).toBe('explicit');
   });
 
   it('falls back to AGENT_TYPE_MODEL_DEFAULTS when no model/task supplied', async () => {
-    const tool = findSpawnTool();
-    const result = (await tool.handler({ agentType: 'architect' })) as Record<string, unknown>;
+    const result = await spawn({ agentType: 'architect' });
     expect(result.success).toBe(true);
     expect(result.model).toBe('opus');
     expect(result.modelRoutedBy).toBe('default');
   });
 
   it('passes domain through to the coordinator', async () => {
-    const tool = findSpawnTool();
-    const result = (await tool.handler({
-      agentType: 'tester',
-      domain: 'support',
-    })) as Record<string, unknown>;
+    const result = await spawn({ agentType: 'tester', domain: 'support' });
     expect(result.success).toBe(true);
     expect(result.domain).toBe('support');
   });
 
   it('generates collision-resistant ids across burst spawns', async () => {
-    const tool = findSpawnTool();
     const ids = new Set<string>();
     for (let i = 0; i < 25; i++) {
-      const result = (await tool.handler({ agentType: 'worker' })) as Record<string, unknown>;
+      const result = await spawn({ agentType: 'worker' });
       expect(result.success).toBe(true);
-      ids.add(result.agentId as string);
+      ids.add(result.agentId!);
     }
     expect(ids.size).toBe(25);
   });

--- a/src/cli/__tests__/mcp-tools/agent-spawn.test.ts
+++ b/src/cli/__tests__/mcp-tools/agent-spawn.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Story #801 — `agent_spawn` wired to the live UnifiedSwarmCoordinator.
+ *
+ * Pins:
+ *   - Spawn writes through the coordinator (not the JSON store)
+ *   - Returned id matches the Ruflo-style regex and is reachable via
+ *     `coordinator.getAgent(id)` in the same handler call
+ *   - Response.bootstrap is byte-equal to the canonical directive (#800)
+ *   - Whitelist + slug validation rejects without throwing
+ *   - ADR-026 model routing preserved on the coordinator path
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { agentTools } from '../../mcp-tools/agent-tools.js';
+import {
+  _resetSwarmCoordinatorForTest,
+  getSwarmCoordinator,
+} from '../../mcp-tools/swarm-coordinator-singleton.js';
+import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../../services/subagent-bootstrap.js';
+
+const ID_RE = /^agent-[a-z][a-z0-9-]*-[0-9a-f]{24}$/;
+
+function findSpawnTool() {
+  const tool = agentTools.find(t => t.name === 'agent_spawn');
+  if (!tool) throw new Error('agent_spawn tool missing from agentTools');
+  return tool;
+}
+
+describe('agent_spawn — coordinator-backed (story #801)', () => {
+  afterEach(async () => {
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('spawns a live agent reachable via coordinator.getAgent', async () => {
+    const tool = findSpawnTool();
+    const result = (await tool.handler({ agentType: 'coder' })) as Record<string, unknown>;
+
+    expect(result.success).toBe(true);
+    expect(typeof result.agentId).toBe('string');
+    expect(result.agentId as string).toMatch(ID_RE);
+
+    const coord = await getSwarmCoordinator();
+    const live = coord.getAgent(result.agentId as string);
+    expect(live).toBeDefined();
+    expect(live!.type).toBe('coder');
+    expect(live!.status).toBe('idle');
+  });
+
+  it('embeds the canonical bootstrap directive byte-for-byte', async () => {
+    const tool = findSpawnTool();
+    const result = (await tool.handler({ agentType: 'researcher' })) as Record<string, unknown>;
+    expect(result.bootstrap).toBe(SUBAGENT_BOOTSTRAP_DIRECTIVE);
+  });
+
+  it('rejects unknown agent types without throwing', async () => {
+    const tool = findSpawnTool();
+    const result = (await tool.handler({ agentType: 'definitely-not-a-real-type' })) as Record<string, unknown>;
+    expect(result.success).toBe(false);
+    expect(typeof result.error).toBe('string');
+    expect(result.error as string).toMatch(/whitelist|allowed/i);
+  });
+
+  it('rejects non-string agent types without throwing', async () => {
+    const tool = findSpawnTool();
+    const result = (await tool.handler({ agentType: 123 as unknown as string })) as Record<string, unknown>;
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects malformed slugs (uppercase / punctuation)', async () => {
+    const tool = findSpawnTool();
+    for (const bad of ['Coder', 'coder!', 'a b', '../traversal']) {
+      const result = (await tool.handler({ agentType: bad })) as Record<string, unknown>;
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it('honors explicit model selection (modelRoutedBy=explicit)', async () => {
+    const tool = findSpawnTool();
+    const result = (await tool.handler({
+      agentType: 'coder',
+      model: 'opus',
+    })) as Record<string, unknown>;
+    expect(result.success).toBe(true);
+    expect(result.model).toBe('opus');
+    expect(result.modelRoutedBy).toBe('explicit');
+  });
+
+  it('falls back to AGENT_TYPE_MODEL_DEFAULTS when no model/task supplied', async () => {
+    const tool = findSpawnTool();
+    const result = (await tool.handler({ agentType: 'architect' })) as Record<string, unknown>;
+    expect(result.success).toBe(true);
+    expect(result.model).toBe('opus');
+    expect(result.modelRoutedBy).toBe('default');
+  });
+
+  it('passes domain through to the coordinator', async () => {
+    const tool = findSpawnTool();
+    const result = (await tool.handler({
+      agentType: 'tester',
+      domain: 'support',
+    })) as Record<string, unknown>;
+    expect(result.success).toBe(true);
+    expect(result.domain).toBe('support');
+  });
+
+  it('generates collision-resistant ids across burst spawns', async () => {
+    const tool = findSpawnTool();
+    const ids = new Set<string>();
+    for (let i = 0; i < 25; i++) {
+      const result = (await tool.handler({ agentType: 'worker' })) as Record<string, unknown>;
+      expect(result.success).toBe(true);
+      ids.add(result.agentId as string);
+    }
+    expect(ids.size).toBe(25);
+  });
+});

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -99,7 +99,10 @@ export async function checkSubagentHealth(): Promise<HealthCheck> {
       metadata: { purpose: 'doctor-health-check' },
     }, {});
 
-    if (!spawnResult?.agentId || !['active', 'spawned'].includes(spawnResult.status)) {
+    // `idle` is the AgentState status returned by the live coordinator (post
+    // #801); `active`/`spawned` were the legacy literal returns. Accept all
+    // three — matches the status-check enum 13 lines below.
+    if (!spawnResult?.agentId || !['active', 'idle', 'spawned'].includes(spawnResult.status)) {
       return { name: 'Subagent Health', status: 'fail', message: `Spawn returned unexpected result: ${JSON.stringify(spawnResult)}` };
     }
 

--- a/src/cli/mcp-tools/agent-tools.ts
+++ b/src/cli/mcp-tools/agent-tools.ts
@@ -269,8 +269,6 @@ export const agentTools: MCPTool[] = [
       required: ['agentType'],
     },
     handler: async (input) => {
-      // Validation must return a response, not throw — `mcp-tools-deep`
-      // exercises bad input by passing a number and asserts no throw.
       const validation = validateAgentType(input.agentType);
       if (!validation.ok) {
         return {
@@ -290,8 +288,7 @@ export const agentTools: MCPTool[] = [
 
       const routingResult = await determineAgentModel(agentType, config, task);
 
-      // 24 hex chars of kernel entropy — Math.random().toString(36) was
-      // observably colliding under burst spawns.
+      // Math.random().toString(36) was observably colliding under burst spawns.
       const agentId = `agent-${agentType}-${randomBytes(12).toString('hex')}`;
 
       const capabilities = Array.isArray(config.capabilities)
@@ -303,8 +300,6 @@ export const agentTools: MCPTool[] = [
       try {
         spawned = await coordinator.spawnAgent({
           id: agentId,
-          // ALLOWED_AGENT_TYPES already gated the slug; coordinator's
-          // agentTypeToDomain falls back to `core` for non-canonical names.
           type: agentType as AgentType,
           name: (config.name as string) || agentId,
           capabilities,
@@ -325,9 +320,6 @@ export const agentTools: MCPTool[] = [
         };
       }
 
-      // `bootstrap` appears here AND in coordinator metadata: callers see it
-      // in the response, the coordinator persists it for downstream surfaces
-      // (hive-mind workers, etc.) that read AgentState directly.
       const response: Record<string, unknown> = {
         success: true,
         agentId: spawned.agentId,

--- a/src/cli/mcp-tools/agent-tools.ts
+++ b/src/cli/mcp-tools/agent-tools.ts
@@ -1,14 +1,20 @@
 /**
  * Agent MCP Tools for CLI
  *
- * Tool definitions for agent lifecycle management with file persistence.
- * Includes model routing integration for intelligent model selection.
+ * `agent_spawn` writes through the live UnifiedSwarmCoordinator. The other
+ * handlers still read from the JSON store — kept until they are migrated.
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import type { MCPTool } from './types.js';
 import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
+import { findProjectRoot } from '../services/project-root.js';
+import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../services/subagent-bootstrap.js';
+import { getSwarmCoordinator } from './swarm-coordinator-singleton.js';
+import type { AgentType } from '../swarm/types.js';
+import type { AgentDomain } from '../swarm/unified-coordinator.js';
 
 // Storage paths
 const AGENT_DIR = 'agents';
@@ -36,7 +42,10 @@ interface AgentStore {
 }
 
 function getAgentDir(): string {
-  return join(process.cwd(), STORAGE_DIR, AGENT_DIR);
+  // findProjectRoot() walks up to the consumer's package.json/.git, so the
+  // MCP server still locates `<consumer>/.moflo/agents/` when launched from
+  // a working directory that diverges from the user's project root.
+  return join(findProjectRoot(), STORAGE_DIR, AGENT_DIR);
 }
 
 function getAgentPath(): string {
@@ -66,6 +75,70 @@ function loadAgentStore(): AgentStore {
 function saveAgentStore(store: AgentStore): void {
   ensureAgentDir();
   writeFileSync(getAgentPath(), JSON.stringify(store, null, 2), 'utf-8');
+}
+
+// Coordinator's `agentTypeToDomain` falls through to `core` for unknown
+// types, so this whitelist is the only gating layer. The slug regex blocks
+// typos and shell-injection chars; the Set check pins the surface area to
+// the canonical AgentType union plus the shipped `.claude/agents/` slugs.
+
+// Pinning the canonical-13 portion to AgentType makes a TS error fire if the
+// union ever drifts ahead of the whitelist.
+const CANONICAL_AGENT_TYPES = [
+  'coordinator', 'researcher', 'coder', 'analyst', 'architect',
+  'tester', 'reviewer', 'optimizer', 'documenter', 'monitor',
+  'specialist', 'queen', 'worker',
+] as const satisfies readonly AgentType[];
+
+const ALLOWED_AGENT_TYPES: ReadonlySet<string> = new Set<string>([
+  ...CANONICAL_AGENT_TYPES,
+  // Shipped Claude Code agent definitions (.claude/agents/**)
+  'adaptive-coordinator', 'adr-architect', 'aidefence-guardian',
+  'analyze-code-quality', 'api-docs', 'arch-system-design',
+  'backend-dev', 'base-template-generator', 'benchmark-suite',
+  'byzantine-coordinator', 'cicd-engineer', 'claims-authorizer',
+  'claude-code-guide', 'code-analyzer', 'code-goal-planner',
+  'code-review-swarm', 'collective-intelligence-coordinator',
+  'crdt-synchronizer', 'data-ml-model', 'ddd-domain-expert',
+  'dev-backend-api', 'docs-api-openapi', 'general-purpose',
+  'github-modes', 'goal-planner', 'gossip-coordinator',
+  'hierarchical-coordinator', 'injection-analyst', 'issue-tracker',
+  'load-balancer', 'memory-specialist', 'mesh-coordinator',
+  'ml-developer', 'mobile-dev', 'multi-repo-swarm',
+  'ops-cicd-github', 'performance-benchmarker', 'performance-engineer',
+  'performance-monitor', 'pii-detector', 'planner',
+  'pr-manager', 'production-validator', 'project-board-sync',
+  'pseudocode', 'quorum-manager', 'queen-coordinator',
+  'raft-manager', 'reasoningbank-learner', 'refinement',
+  'release-manager', 'release-swarm', 'repo-architect',
+  'resource-allocator', 'safla-neural', 'scout-explorer',
+  'security-architect', 'security-architect-aidefence',
+  'security-auditor', 'security-manager', 'sona-learning-optimizer',
+  'sparc-orchestrator', 'spec-mobile-react-native', 'specification',
+  'swarm-issue', 'swarm-memory-manager', 'swarm-pr',
+  'sync-coordinator', 'system-architect', 'tdd-london-swarm',
+  'test-long-runner', 'topology-optimizer', 'v3-integration-architect',
+  'workflow-automation', 'worker-specialist',
+]);
+
+const AGENT_TYPE_SLUG_RE = /^[a-z][a-z0-9-]*$/;
+
+interface AgentTypeValidation {
+  ok: boolean;
+  error?: string;
+}
+
+function validateAgentType(value: unknown): AgentTypeValidation {
+  if (typeof value !== 'string' || value.length === 0) {
+    return { ok: false, error: 'agentType must be a non-empty string' };
+  }
+  if (!AGENT_TYPE_SLUG_RE.test(value)) {
+    return { ok: false, error: `agentType "${value}" must match ${AGENT_TYPE_SLUG_RE}` };
+  }
+  if (!ALLOWED_AGENT_TYPES.has(value)) {
+    return { ok: false, error: `agentType "${value}" is not in the allowed agent-type whitelist` };
+  }
+  return { ok: true };
 }
 
 // Default model mappings for agent types (can be overridden)
@@ -196,54 +269,78 @@ export const agentTools: MCPTool[] = [
       required: ['agentType'],
     },
     handler: async (input) => {
-      const store = loadAgentStore();
-      const agentId = (input.agentId as string) || `agent-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      // Validation must return a response, not throw — `mcp-tools-deep`
+      // exercises bad input by passing a number and asserts no throw.
+      const validation = validateAgentType(input.agentType);
+      if (!validation.ok) {
+        return {
+          success: false,
+          error: validation.error,
+          agentType: input.agentType,
+        };
+      }
       const agentType = input.agentType as string;
       const config = (input.config as Record<string, unknown>) || {};
 
-      // Add explicit model to config if provided
       if (input.model) {
         config.model = input.model;
       }
 
-      // Get task from either top-level or config (CLI passes it in config.task)
       const task = (input.task as string) || (config.task as string) || undefined;
 
-      // Determine model using ADR-026 3-tier routing logic
-      const routingResult = await determineAgentModel(
-        agentType,
-        config,
-        task
-      );
+      const routingResult = await determineAgentModel(agentType, config, task);
 
-      const agent: AgentRecord = {
-        agentId,
-        agentType,
-        status: 'idle',
-        health: 1.0,
-        taskCount: 0,
-        config,
-        createdAt: new Date().toISOString(),
-        domain: input.domain as string,
-        model: routingResult.model,
-        modelRoutedBy: routingResult.routedBy,
-      };
+      // 24 hex chars of kernel entropy — Math.random().toString(36) was
+      // observably colliding under burst spawns.
+      const agentId = `agent-${agentType}-${randomBytes(12).toString('hex')}`;
 
-      store.agents[agentId] = agent;
-      saveAgentStore(store);
+      const capabilities = Array.isArray(config.capabilities)
+        ? (config.capabilities as unknown[]).filter((c): c is string => typeof c === 'string')
+        : undefined;
 
-      // Include Agent Booster routing info if applicable
+      const coordinator = await getSwarmCoordinator();
+      let spawned: { agentId: string; domain: AgentDomain; status: string; spawned: boolean };
+      try {
+        spawned = await coordinator.spawnAgent({
+          id: agentId,
+          // ALLOWED_AGENT_TYPES already gated the slug; coordinator's
+          // agentTypeToDomain falls back to `core` for non-canonical names.
+          type: agentType as AgentType,
+          name: (config.name as string) || agentId,
+          capabilities,
+          domain: input.domain as AgentDomain | undefined,
+          metadata: {
+            ...(config as Record<string, unknown>),
+            model: routingResult.model,
+            modelRoutedBy: routingResult.routedBy,
+            bootstrap: SUBAGENT_BOOTSTRAP_DIRECTIVE,
+          },
+        });
+      } catch (err) {
+        return {
+          success: false,
+          agentId,
+          agentType,
+          error: (err as Error).message,
+        };
+      }
+
+      // `bootstrap` appears here AND in coordinator metadata: callers see it
+      // in the response, the coordinator persists it for downstream surfaces
+      // (hive-mind workers, etc.) that read AgentState directly.
       const response: Record<string, unknown> = {
         success: true,
-        agentId,
-        agentType: agent.agentType,
-        model: agent.model,
+        agentId: spawned.agentId,
+        agentType,
+        domain: spawned.domain,
+        status: spawned.status,
+        spawned: spawned.spawned,
+        model: routingResult.model,
         modelRoutedBy: routingResult.routedBy,
-        status: 'spawned',
-        createdAt: agent.createdAt,
+        bootstrap: SUBAGENT_BOOTSTRAP_DIRECTIVE,
+        createdAt: new Date().toISOString(),
       };
 
-      // Add Agent Booster info if task can skip LLM
       if (routingResult.canSkipLLM) {
         response.canSkipLLM = true;
         response.agentBoosterIntent = routingResult.agentBoosterIntent;

--- a/src/cli/swarm/types.ts
+++ b/src/cli/swarm/types.ts
@@ -725,7 +725,7 @@ export interface IUnifiedSwarmCoordinator {
   resume(): Promise<void>;
 
   // Agent management
-  registerAgent(agent: Omit<AgentState, 'id'>): Promise<string>;
+  registerAgent(agent: Omit<AgentState, 'id'>, options?: { id?: string }): Promise<string>;
   unregisterAgent(agentId: string): Promise<void>;
   getAgent(agentId: string): AgentState | undefined;
   getAllAgents(): AgentState[];

--- a/src/cli/swarm/unified-coordinator.ts
+++ b/src/cli/swarm/unified-coordinator.ts
@@ -1418,7 +1418,7 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
     options?: { id?: string },
   ): Promise<{ agentId: string; domain: AgentDomain }> {
     // First register the agent normally
-    const agentId = await this.registerAgent(agentData, { id: options?.id });
+    const agentId = await this.registerAgent(agentData, options);
 
     // Determine domain based on agent number
     const domain = this.getAgentDomain(agentNumber);

--- a/src/cli/swarm/unified-coordinator.ts
+++ b/src/cli/swarm/unified-coordinator.ts
@@ -297,7 +297,8 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
   // ===== AGENT MANAGEMENT =====
 
   async registerAgent(
-    agentData: Omit<AgentState, 'id'>
+    agentData: Omit<AgentState, 'id'>,
+    options?: { id?: string },
   ): Promise<string> {
     const startTime = performance.now();
 
@@ -305,9 +306,12 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       throw new Error(`Maximum agents (${this.config.maxAgents}) reached`);
     }
 
+    // MCP-tool spawn surfaces supply a pre-generated id so callers can
+    // log/return it before awaiting registration; internal callers omit it
+    // and get the legacy `agent_<swarmId>_<counter>` form.
     this.agentCounter++;
     const agentId: AgentId = {
-      id: `agent_${this.state.id.id}_${this.agentCounter}`,
+      id: options?.id ?? `agent_${this.state.id.id}_${this.agentCounter}`,
       swarmId: this.state.id.id,
       type: agentData.type,
       instance: this.agentCounter,
@@ -1410,10 +1414,11 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
    */
   async registerAgentWithDomain(
     agentData: Omit<AgentState, 'id'>,
-    agentNumber: number
+    agentNumber: number,
+    options?: { id?: string },
   ): Promise<{ agentId: string; domain: AgentDomain }> {
     // First register the agent normally
-    const agentId = await this.registerAgent(agentData);
+    const agentId = await this.registerAgent(agentData, { id: options?.id });
 
     // Determine domain based on agent number
     const domain = this.getAgentDomain(agentNumber);
@@ -1573,6 +1578,7 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
    * @returns Spawned agent ID and details
    */
   async spawnAgent(options: {
+    id?: string;
     type: AgentType;
     name?: string;
     capabilities?: string[];
@@ -1607,7 +1613,7 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
 
     if (options.agentNumber) {
       // Use provided agent number to determine domain
-      const result = await this.registerAgentWithDomain(agentData, options.agentNumber);
+      const result = await this.registerAgentWithDomain(agentData, options.agentNumber, { id: options.id });
       agentId = result.agentId;
       domain = result.domain;
     } else if (options.domain) {
@@ -1617,13 +1623,13 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
         .filter(([, d]) => d === options.domain)
         .length;
       const nextNumber = config?.agentNumbers[existingAgents] || config?.agentNumbers[0] || 1;
-      const result = await this.registerAgentWithDomain(agentData, nextNumber);
+      const result = await this.registerAgentWithDomain(agentData, nextNumber, { id: options.id });
       agentId = result.agentId;
       domain = result.domain;
     } else {
       // Auto-assign to most appropriate domain based on type
       domain = this.agentTypeToDomain(options.type);
-      agentId = await this.registerAgent(agentData);
+      agentId = await this.registerAgent(agentData, { id: options.id });
       this.agentDomainMap.set(agentId, domain);
     }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -105,6 +105,11 @@ export default defineConfig({
       '**/node_modules/**',
       '**/dist/**',
       '.git/**',
+      // Parallel-agent git worktrees check out a full source tree under
+      // `.claude/worktrees/<id>/`. Without this exclude, vitest globs the
+      // duplicate test files and they fail dist-resolution because each
+      // worktree has its own out-of-tree compiled output.
+      '.claude/worktrees/**',
       // Appliance tests — require native GGUF/RVFA bindings not installed
       'src/__tests__/appliance/**',
       // Context persistence hook — missing deps

--- a/vitest.isolation.config.ts
+++ b/vitest.isolation.config.ts
@@ -16,5 +16,14 @@ export default defineConfig({
     maxForks: 1,
     minForks: 1,
     testTimeout: 30_000,
+    // Same worktree exclude as the parallel config — vitest treats CLI file
+    // paths as patterns, so a relative isolation path can match the same
+    // file inside a `.claude/worktrees/<id>/` git worktree.
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '.git/**',
+      '.claude/worktrees/**',
+    ],
   },
 });


### PR DESCRIPTION
## Summary

Story 3 of epic #798 — replaces the JSON-store stub for `agent_spawn` with a live call to `UnifiedSwarmCoordinator.spawnAgent(...)`. Spawned agents are now real `AgentState` records reachable via `coordinator.getAgent(id)` in the same handler call. Builds on Story 1 (#809 lazy singleton) and Story 2 (#810 `SUBAGENT_BOOTSTRAP_DIRECTIVE`).

## What

- **`src/cli/mcp-tools/agent-tools.ts`** — rewritten `agent_spawn` handler with a slug-regex + whitelist gate. Canonical 13 entries use `as const satisfies readonly AgentType[]` so a TS error fires if the `AgentType` union drifts ahead of the whitelist. Invalid input returns `{ success: false, error }` instead of throwing — preserves the existing `mcp-tools-deep` contract.
- **`src/cli/swarm/unified-coordinator.ts`** + **`src/cli/swarm/types.ts`** — optional `{ id?: string }` threaded through `registerAgent` / `registerAgentWithDomain` / `spawnAgent` (and the `IUnifiedSwarmCoordinator` interface) so MCP-tool callers can supply Ruflo-style ids. Internal callers default to the legacy `agent_<swarmId>_<counter>` form.
- **`src/cli/__tests__/mcp-tools/agent-spawn.test.ts`** — 9 tests pinning live coordinator state, byte-equal bootstrap directive, validation behavior, model-routing preservation, and 25-spawn collision resistance.

## Side fixes

- **`agent-tools.ts:39`** — `process.cwd()` → `findProjectRoot()` so the JSON-store path still resolves correctly when the MCP server cwd diverges from the consumer's project root (per `feedback_consumer_path_resolution`). The JSON store stays put until #802 wires `agent_list` / `agent_terminate` / `agent_status` to the coordinator.
- **`vitest.config.ts` + `vitest.isolation.config.ts`** — exclude `.claude/worktrees/**`. Vitest was globbing duplicate test files inside parallel-agent worktrees and breaking dist resolution.

## Behavior

- `agent_spawn` invokes `coordinator.spawnAgent(...)`, not a JSON write
- Response includes `bootstrap` byte-equal to `SUBAGENT_BOOTSTRAP_DIRECTIVE` from #800 (also persisted into coordinator metadata for downstream surfaces like hive-mind workers)
- ID matches `/^agent-[a-z][a-z0-9-]*-[0-9a-f]{24}$/` (24 hex chars from `randomBytes(12)`)
- Invalid types rejected with structured error (no throw)
- ADR-026 model routing preserved verbatim — `mcp-tools-deep.test.ts` Agent Tools assertions unchanged

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean (`--max-warnings 0`)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — full suite green (7460/7460 passing)
- [x] New `agent-spawn.test.ts`: 9/9 passing
- [x] `mcp-tools-deep.test.ts`: existing Agent-Tools assertions still green
- [x] `swarm/coordinator.test.ts`: 11/11 passing (registerAgent's new option is backward-compatible)
- [x] `/simplify` ran four passes with three review agents each; high-value findings applied across separate commits (dead `agentId` fallback removed, `satisfies` drift-guard on canonical-13, narrative comments trimmed, typed test helper, interface alignment)

Closes #801
Part of epic #798

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)