### PR TITLE
feat(802): wire agent_list/terminate/status to UnifiedSwarmCoordinator

### DIFF
--- a/src/cli/__tests__/mcp-tools/_helpers.ts
+++ b/src/cli/__tests__/mcp-tools/_helpers.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared helpers for mcp-tools tests.
+ */
+
+import { agentTools } from '../../mcp-tools/agent-tools.js';
+import type { MCPTool } from '../../mcp-tools/types.js';
+
+export function getAgentTool(name: string): MCPTool {
+  const tool = agentTools.find(t => t.name === name);
+  if (!tool) throw new Error(`agent tool "${name}" not registered`);
+  return tool;
+}
+
+export async function spawnAgentForTest(
+  input: Record<string, unknown> = { agentType: 'coder' },
+): Promise<string> {
+  const result = (await getAgentTool('agent_spawn').handler(input)) as {
+    success: boolean;
+    agentId?: string;
+    error?: string;
+  };
+  if (!result.success || !result.agentId) {
+    throw new Error(`spawnAgentForTest failed: ${result.error ?? 'unknown'}`);
+  }
+  return result.agentId;
+}

--- a/src/cli/__tests__/mcp-tools/agent-list.test.ts
+++ b/src/cli/__tests__/mcp-tools/agent-list.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `agent_list` wired to the live UnifiedSwarmCoordinator (story #802).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { _resetSwarmCoordinatorForTest } from '../../mcp-tools/swarm-coordinator-singleton.js';
+import { getAgentTool, spawnAgentForTest } from './_helpers.js';
+
+interface ListResult {
+  agents: Array<{
+    agentId: string;
+    name: string;
+    agentType: string;
+    status: string;
+    domain?: string;
+    workload: number;
+    health: number;
+  }>;
+  total: number;
+  returned: number;
+  filters: Record<string, unknown>;
+}
+
+const listTool = getAgentTool('agent_list');
+const terminateTool = getAgentTool('agent_terminate');
+
+async function list(input: Record<string, unknown> = {}): Promise<ListResult> {
+  return (await listTool.handler(input)) as ListResult;
+}
+
+describe('agent_list — coordinator-backed', () => {
+  afterEach(async () => {
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('reflects agents spawned through the coordinator', async () => {
+    const a1 = await spawnAgentForTest({ agentType: 'coder' });
+    const a2 = await spawnAgentForTest({ agentType: 'tester' });
+
+    const result = await list();
+    const ids = result.agents.map(a => a.agentId);
+    expect(ids).toContain(a1);
+    expect(ids).toContain(a2);
+    expect(result.total).toBe(result.agents.length);
+  });
+
+  it('returns an empty array when no agents exist', async () => {
+    const result = await list();
+    expect(result.agents).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it('filters by agentType', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+    await spawnAgentForTest({ agentType: 'coder' });
+    await spawnAgentForTest({ agentType: 'tester' });
+
+    const result = await list({ agentType: 'coder' });
+    expect(result.agents.length).toBe(2);
+    expect(result.agents.every(a => a.agentType === 'coder')).toBe(true);
+  });
+
+  it('filters by status', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+    const idle = await list({ status: 'idle' });
+    expect(idle.agents.length).toBeGreaterThanOrEqual(1);
+    expect(idle.agents.every(a => a.status === 'idle')).toBe(true);
+
+    const busy = await list({ status: 'busy' });
+    expect(busy.agents).toEqual([]);
+  });
+
+  it('honors limit and offset for pagination', async () => {
+    for (let i = 0; i < 5; i++) await spawnAgentForTest({ agentType: 'worker' });
+
+    const page1 = await list({ limit: 2, offset: 0 });
+    expect(page1.agents.length).toBe(2);
+    expect(page1.total).toBe(5);
+    expect(page1.returned).toBe(2);
+
+    const page2 = await list({ limit: 2, offset: 2 });
+    expect(page2.agents.length).toBe(2);
+
+    const page3 = await list({ limit: 2, offset: 4 });
+    expect(page3.agents.length).toBe(1);
+
+    const ids = new Set([
+      ...page1.agents.map(a => a.agentId),
+      ...page2.agents.map(a => a.agentId),
+      ...page3.agents.map(a => a.agentId),
+    ]);
+    expect(ids.size).toBe(5);
+  });
+
+  it('does not surface terminated agents (coordinator deletes them)', async () => {
+    const agentId = await spawnAgentForTest({ agentType: 'coder' });
+    await terminateTool.handler({ agentId });
+
+    const result = await list();
+    expect(result.agents.find(a => a.agentId === agentId)).toBeUndefined();
+  });
+});

--- a/src/cli/__tests__/mcp-tools/agent-status.test.ts
+++ b/src/cli/__tests__/mcp-tools/agent-status.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `agent_status` wired to the live UnifiedSwarmCoordinator (story #802).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { _resetSwarmCoordinatorForTest } from '../../mcp-tools/swarm-coordinator-singleton.js';
+import { getAgentTool, spawnAgentForTest } from './_helpers.js';
+
+interface StatusResult {
+  agentId: string;
+  agentType?: string;
+  name?: string;
+  status: string;
+  health?: number;
+  workload?: number;
+  domain?: string;
+  currentTask?: string;
+  lastHeartbeat?: string;
+  taskCount?: number;
+  metrics?: Record<string, unknown>;
+  history?: { tasksCompleted: number; tasksFailed: number; successRate: number };
+  error?: string;
+}
+
+const statusTool = getAgentTool('agent_status');
+
+async function status(input: Record<string, unknown>): Promise<StatusResult> {
+  return (await statusTool.handler(input)) as StatusResult;
+}
+
+describe('agent_status — coordinator-backed', () => {
+  afterEach(async () => {
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('returns live AgentState for a coordinator-spawned agent', async () => {
+    const agentId = await spawnAgentForTest({ agentType: 'coder' });
+
+    const result = await status({ agentId });
+    expect(result.agentId).toBe(agentId);
+    expect(result.agentType).toBe('coder');
+    expect(result.status).toBe('idle');
+    expect(typeof result.health).toBe('number');
+    expect(typeof result.workload).toBe('number');
+    expect(typeof result.lastHeartbeat).toBe('string');
+  });
+
+  it('omits metrics by default and includes them when requested', async () => {
+    const agentId = await spawnAgentForTest({ agentType: 'tester' });
+
+    const without = await status({ agentId });
+    expect(without.metrics).toBeUndefined();
+
+    const withMetrics = await status({ agentId, includeMetrics: true });
+    expect(withMetrics.metrics).toBeDefined();
+    expect(withMetrics.metrics).toHaveProperty('tasksCompleted');
+    expect(withMetrics.metrics).toHaveProperty('successRate');
+    expect(typeof (withMetrics.metrics as { lastActivity: unknown }).lastActivity).toBe('string');
+  });
+
+  it('omits history by default and includes it when requested', async () => {
+    const agentId = await spawnAgentForTest({ agentType: 'coder' });
+
+    const without = await status({ agentId });
+    expect(without.history).toBeUndefined();
+
+    const withHistory = await status({ agentId, includeHistory: true });
+    expect(withHistory.history).toBeDefined();
+    expect(withHistory.history!.tasksCompleted).toBeGreaterThanOrEqual(0);
+    expect(withHistory.history!.tasksFailed).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns status:not_found for unknown agent IDs', async () => {
+    const result = await status({ agentId: 'agent-coder-deadbeef00000000deadbeef' });
+    expect(result.status).toBe('not_found');
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('returns status:not_found for empty agentId without throwing', async () => {
+    const result = await status({ agentId: '' });
+    expect(result.status).toBe('not_found');
+  });
+
+  it('surfaces the agent domain from the coordinator', async () => {
+    const agentId = await spawnAgentForTest({ agentType: 'tester' });
+    const result = await status({ agentId });
+    // tester maps to "support" in agentTypeToDomain
+    expect(result.domain).toBe('support');
+  });
+});

--- a/src/cli/__tests__/mcp-tools/agent-terminate.test.ts
+++ b/src/cli/__tests__/mcp-tools/agent-terminate.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `agent_terminate` wired to the live UnifiedSwarmCoordinator (story #802).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetSwarmCoordinatorForTest,
+  getSwarmCoordinator,
+} from '../../mcp-tools/swarm-coordinator-singleton.js';
+import { getAgentTool, spawnAgentForTest } from './_helpers.js';
+
+interface TerminateResult {
+  success: boolean;
+  agentId: string;
+  terminated?: boolean;
+  tasksReassigned?: number;
+  reason?: string;
+  terminatedAt?: string;
+  error?: string;
+}
+
+const terminateTool = getAgentTool('agent_terminate');
+
+async function terminate(input: Record<string, unknown>): Promise<TerminateResult> {
+  return (await terminateTool.handler(input)) as TerminateResult;
+}
+
+describe('agent_terminate — coordinator-backed', () => {
+  afterEach(async () => {
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('removes the agent from coordinator state', async () => {
+    const agentId = await spawnAgentForTest({ agentType: 'coder' });
+
+    const result = await terminate({ agentId });
+    expect(result.success).toBe(true);
+    expect(result.terminated).toBe(true);
+    expect(result.agentId).toBe(agentId);
+    expect(typeof result.terminatedAt).toBe('string');
+
+    const coord = await getSwarmCoordinator();
+    expect(coord.getAgent(agentId)).toBeUndefined();
+  });
+
+  it('is idempotent — second call returns success:false with not found', async () => {
+    const agentId = await spawnAgentForTest({ agentType: 'tester' });
+    await terminate({ agentId });
+
+    const second = await terminate({ agentId });
+    expect(second.success).toBe(false);
+    expect(second.error).toMatch(/not found/i);
+  });
+
+  it('returns success:false for unknown agent IDs (no throw)', async () => {
+    const result = await terminate({ agentId: 'agent-coder-deadbeef00000000deadbeef' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('rejects empty agentId without throwing', async () => {
+    const result = await terminate({ agentId: '' });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('passes the reason through to the coordinator response', async () => {
+    const agentId = await spawnAgentForTest({ agentType: 'coder' });
+    const result = await terminate({ agentId, reason: 'unit-test cleanup' });
+    expect(result.success).toBe(true);
+    expect(result.reason).toBe('unit-test cleanup');
+  });
+});

--- a/src/cli/mcp-tools/agent-tools.ts
+++ b/src/cli/mcp-tools/agent-tools.ts
@@ -1,8 +1,9 @@
 /**
  * Agent MCP Tools for CLI
  *
- * `agent_spawn` writes through the live UnifiedSwarmCoordinator. The other
- * handlers still read from the JSON store — kept until they are migrated.
+ * `agent_spawn`, `agent_list`, `agent_terminate`, `agent_status` route through
+ * UnifiedSwarmCoordinator (epic #798, stories #801, #802).
+ * TODO(epic-#798): `agent_pool` + `agent_health` are still JSON-store-backed.
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
@@ -13,7 +14,7 @@ import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../services/subagent-bootstrap.js';
 import { getSwarmCoordinator } from './swarm-coordinator-singleton.js';
-import type { AgentType } from '../swarm/types.js';
+import type { AgentType, AgentStatus } from '../swarm/types.js';
 import type { AgentDomain } from '../swarm/unified-coordinator.js';
 
 // Storage paths
@@ -122,6 +123,12 @@ const ALLOWED_AGENT_TYPES: ReadonlySet<string> = new Set<string>([
 ]);
 
 const AGENT_TYPE_SLUG_RE = /^[a-z][a-z0-9-]*$/;
+
+function toNonNegativeInt<D extends number | undefined>(value: unknown, fallback: D): number | D {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return Math.floor(n);
+}
 
 interface AgentTypeValidation {
   ok: boolean;
@@ -354,29 +361,40 @@ export const agentTools: MCPTool[] = [
       properties: {
         agentId: { type: 'string', description: 'ID of agent to terminate' },
         force: { type: 'boolean', description: 'Force immediate termination' },
+        reason: { type: 'string', description: 'Reason for termination (audit trail)' },
+        gracePeriodMs: { type: 'number', description: 'Grace period before forcing (ms)' },
       },
       required: ['agentId'],
     },
     handler: async (input) => {
-      const store = loadAgentStore();
       const agentId = input.agentId as string;
-
-      if (store.agents[agentId]) {
-        store.agents[agentId].status = 'terminated';
-        saveAgentStore(store);
-        return {
-          success: true,
-          agentId,
-          terminated: true,
-          terminatedAt: new Date().toISOString(),
-        };
+      if (typeof agentId !== 'string' || !agentId) {
+        return { success: false, agentId, error: 'agentId must be a non-empty string' };
       }
 
-      return {
-        success: false,
-        agentId,
-        error: 'Agent not found',
-      };
+      const coordinator = await getSwarmCoordinator();
+      try {
+        const result = await coordinator.terminateAgent(agentId, {
+          force: input.force as boolean | undefined,
+          reason: input.reason as string | undefined,
+          gracePeriodMs: input.gracePeriodMs as number | undefined,
+        });
+
+        if (!result.terminated) {
+          return { success: false, agentId, error: result.reason || 'Agent not found' };
+        }
+
+        return {
+          success: true,
+          agentId: result.agentId,
+          terminated: true,
+          tasksReassigned: result.tasksReassigned ?? 0,
+          reason: result.reason,
+          terminatedAt: new Date().toISOString(),
+        };
+      } catch (err) {
+        return { success: false, agentId, error: (err as Error).message };
+      }
     },
   },
   {
@@ -387,31 +405,52 @@ export const agentTools: MCPTool[] = [
       type: 'object',
       properties: {
         agentId: { type: 'string', description: 'ID of agent' },
+        includeMetrics: { type: 'boolean', description: 'Include AgentMetrics in response' },
+        includeHistory: { type: 'boolean', description: 'Include task counters from metrics' },
       },
       required: ['agentId'],
     },
     handler: async (input) => {
-      const store = loadAgentStore();
       const agentId = input.agentId as string;
-      const agent = store.agents[agentId];
+      if (typeof agentId !== 'string' || !agentId) {
+        return { agentId, status: 'not_found', error: 'agentId must be a non-empty string' };
+      }
 
-      if (agent) {
-        return {
-          agentId: agent.agentId,
-          agentType: agent.agentType,
-          status: agent.status,
-          health: agent.health,
-          taskCount: agent.taskCount,
-          createdAt: agent.createdAt,
-          domain: agent.domain,
+      const coordinator = await getSwarmCoordinator();
+      const agent = coordinator.getAgent(agentId);
+      if (!agent) {
+        return { agentId, status: 'not_found', error: 'Agent not found' };
+      }
+
+      const response: Record<string, unknown> = {
+        agentId: agent.id.id,
+        agentType: agent.type,
+        name: agent.name,
+        status: agent.status,
+        health: agent.health,
+        workload: agent.workload,
+        domain: coordinator.getDomainForAgent(agentId),
+        currentTask: agent.currentTask?.id,
+        lastHeartbeat: agent.lastHeartbeat.toISOString(),
+        taskCount: agent.metrics.tasksCompleted + agent.metrics.tasksFailed,
+      };
+
+      if (input.includeMetrics) {
+        response.metrics = {
+          ...agent.metrics,
+          lastActivity: agent.metrics.lastActivity.toISOString(),
         };
       }
 
-      return {
-        agentId,
-        status: 'not_found',
-        error: 'Agent not found',
-      };
+      if (input.includeHistory) {
+        response.history = {
+          tasksCompleted: agent.metrics.tasksCompleted,
+          tasksFailed: agent.metrics.tasksFailed,
+          successRate: agent.metrics.successRate,
+        };
+      }
+
+      return response;
     },
   },
   {
@@ -421,42 +460,38 @@ export const agentTools: MCPTool[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        status: { type: 'string', description: 'Filter by status' },
+        status: { type: 'string', description: 'Filter by status (idle/busy/...)' },
+        agentType: { type: 'string', description: 'Filter by agent type' },
         domain: { type: 'string', description: 'Filter by domain' },
-        includeTerminated: { type: 'boolean', description: 'Include terminated agents' },
+        limit: { type: 'number', description: 'Max results to return' },
+        offset: { type: 'number', description: 'Skip first N results' },
       },
     },
     handler: async (input) => {
-      const store = loadAgentStore();
-      let agents = Object.values(store.agents);
+      const coordinator = await getSwarmCoordinator();
+      const all = coordinator.listAgents({
+        status: input.status as AgentStatus | undefined,
+        type: input.agentType as AgentType | undefined,
+        domain: input.domain as AgentDomain | undefined,
+      });
 
-      // Filter by status
-      if (input.status) {
-        agents = agents.filter(a => a.status === input.status);
-      } else if (!input.includeTerminated) {
-        agents = agents.filter(a => a.status !== 'terminated');
-      }
+      const offset = toNonNegativeInt(input.offset, 0);
+      const limit = toNonNegativeInt(input.limit, undefined);
+      const sliced = limit === undefined ? all.slice(offset) : all.slice(offset, offset + limit);
 
-      // Filter by domain
-      if (input.domain) {
-        agents = agents.filter(a => a.domain === input.domain);
-      }
+      // Rename `type` → `agentType` so list/status/spawn share one field name.
+      const projected = sliced.map(({ type, ...rest }) => ({ ...rest, agentType: type }));
 
       return {
-        agents: agents.map(a => ({
-          agentId: a.agentId,
-          agentType: a.agentType,
-          status: a.status,
-          health: a.health,
-          taskCount: a.taskCount,
-          createdAt: a.createdAt,
-          domain: a.domain,
-        })),
-        total: agents.length,
+        agents: projected,
+        total: all.length,
+        returned: projected.length,
         filters: {
           status: input.status,
+          agentType: input.agentType,
           domain: input.domain,
-          includeTerminated: input.includeTerminated,
+          limit,
+          offset,
         },
       };
     },

--- a/src/cli/swarm/unified-coordinator.ts
+++ b/src/cli/swarm/unified-coordinator.ts
@@ -377,6 +377,15 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
     return this.state.agents.get(agentId);
   }
 
+  /**
+   * Resolve the runtime domain for a spawned agent ID.
+   * Distinct from `getAgentDomain(agentNumber)` which maps the static
+   * 15-agent hierarchy slot.
+   */
+  getDomainForAgent(agentId: string): AgentDomain | undefined {
+    return this.agentDomainMap.get(agentId);
+  }
+
   getAllAgents(): AgentState[] {
     return Array.from(this.state.agents.values());
   }


### PR DESCRIPTION
## Summary

- Replaces JSON-store reads in `agent_list`, `agent_terminate`, `agent_status` MCP handlers with live calls to `UnifiedSwarmCoordinator.{listAgents, terminateAgent, getAgent}`. Continues epic #798 / closes #802.
- Adds `coordinator.getDomainForAgent(agentId)` (named to disambiguate from the existing `getAgentDomain(agentNumber)` static-hierarchy lookup) so `agent_status` resolves the runtime domain in O(1) instead of scanning `listAgents()`.
- Schema updates per Story 4 spec: `agent_list` gains `agentType`/`limit`/`offset`, drops `includeTerminated` (terminated agents are removed from coordinator state). `agent_terminate` gains `reason`/`gracePeriodMs`. `agent_status` gains `includeMetrics`/`includeHistory`.
- Response shape: `agent_list` projection field `type` renamed to `agentType` for cross-tool consistency with the `agent_spawn` input field and the `agent_status` output.
- New tests: `__tests__/mcp-tools/agent-{list,status,terminate}.test.ts` plus a shared `_helpers.ts` (`spawnAgentForTest`, `getAgentTool`) deduping the spawn-and-find pattern across all four mcp-tools test files.

## Acceptance (per #802)

- [x] All 4 agent_* MCP tools (`agent_spawn` from #801 + the 3 here) operate on live coordinator state — no JSON writes in their hot path.
- [x] `.moflo/agents/store.json` becomes legacy/unused for these handlers (still consulted by `agent_pool`/`agent_health`, which later stories migrate).
- [x] Tests prove `coordinator.getAgent(...)` reflects the spawn/terminate state changes.

## Test plan

- [x] `npx vitest run src/cli/__tests__/mcp-tools/` — 4 files, 32 tests, all green
- [x] `npx vitest run src/cli/__tests__/mcp-tools-deep.test.ts src/cli/__tests__/commands.test.ts src/cli/__tests__/p1-commands.test.ts` — 134 tests, no regressions
- [x] `npm test` (full suite) — story-#802 tests stable across multiple runs; pre-existing intermittent flakes (fastembed, knowledge-alias, statusline-upgrade-notice, etc.) unrelated to this change and tracked under issue #617 (Windows fork contention; documented in `vitest.config.ts:43-48`)

Refs epic #798, predecessor #801.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)