### PR TITLE
feat(804): swarm_scale MCP tool wired to UnifiedSwarmCoordinator

### DIFF
--- a/.claude/skills/swarm-advanced/SKILL.md
+++ b/.claude/skills/swarm-advanced/SKILL.md
@@ -33,6 +33,34 @@ mcp__moflo__agent_spawn({ type: "researcher", name: "swarm-advanced" })
 // 3. Orchestrate tasks
 ```
 
+### Dynamic Scaling
+Use `mcp__moflo__swarm_scale` to grow or shrink the agent pool to a target size
+without re-initializing the swarm. Three strategies are available:
+
+```javascript
+// Burst-spawn 8 workers all at once (load test, big batch)
+mcp__moflo__swarm_scale({
+  targetAgents: 8,
+  scaleStrategy: "immediate",
+  agentTypes: ["worker"],
+  reason: "load-test ramp"
+})
+
+// Rate-limited ramp (1 agent / 200ms) — gentler on the coordinator
+mcp__moflo__swarm_scale({
+  targetAgents: 12,
+  scaleStrategy: "gradual",
+  agentTypes: ["coder", "tester"]
+})
+
+// Adaptive: chunks scale with current coordinator load
+mcp__moflo__swarm_scale({ targetAgents: 4, scaleStrategy: "adaptive" })
+```
+
+The tool returns `{ previousAgents, currentAgents, scalingStatus, addedAgents,
+removedAgents }` so callers can verify the swarm reached the target. Scale-down
+prefers idle agents first, then oldest by heartbeat.
+
 ## Core Concepts
 
 ### Swarm Topologies

--- a/src/cli/__tests__/mcp-tools/swarm-scale.test.ts
+++ b/src/cli/__tests__/mcp-tools/swarm-scale.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `swarm_scale` wired to the live UnifiedSwarmCoordinator (story #804).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetSwarmCoordinatorForTest,
+  getSwarmCoordinator,
+} from '../../mcp-tools/swarm-coordinator-singleton.js';
+import { getSwarmTool, spawnAgentForTest } from './_helpers.js';
+
+interface ScaleResult {
+  swarmId: string;
+  previousAgents: number;
+  targetAgents: number;
+  currentAgents: number;
+  scalingStatus: 'completed' | 'in-progress' | 'failed';
+  scaleStrategy: 'gradual' | 'immediate' | 'adaptive';
+  scaledAt: string;
+  addedAgents?: string[];
+  removedAgents?: string[];
+  reason?: string;
+  error?: string;
+}
+
+async function callInit(input: Record<string, unknown> = {}) {
+  return getSwarmTool('swarm_init').handler(input);
+}
+
+async function callScale(input: Record<string, unknown>): Promise<ScaleResult> {
+  return (await getSwarmTool('swarm_scale').handler(input)) as ScaleResult;
+}
+
+describe('swarm_scale — coordinator-backed', () => {
+  afterEach(async () => {
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('scales up from zero, calling coordinator.spawnAgent for each new agent', async () => {
+    await callInit({ topology: 'mesh' });
+
+    const result = await callScale({
+      targetAgents: 3,
+      scaleStrategy: 'immediate',
+      agentTypes: ['worker'],
+    });
+
+    expect(result.scalingStatus).toBe('completed');
+    expect(result.previousAgents).toBe(0);
+    expect(result.currentAgents).toBe(3);
+    expect(result.addedAgents).toBeDefined();
+    expect(result.addedAgents!.length).toBe(3);
+    expect(result.removedAgents).toBeUndefined();
+
+    // All spawned agents are reachable through the coordinator — no JSON-store stub.
+    const coord = await getSwarmCoordinator();
+    for (const id of result.addedAgents!) {
+      const live = coord.getAgent(id);
+      expect(live, `agent ${id} should be reachable via coordinator`).toBeDefined();
+      expect(live!.type).toBe('worker');
+    }
+  });
+
+  it('scales down via coordinator.terminateAgent (idle agents first)', async () => {
+    await callInit();
+    await spawnAgentForTest({ agentType: 'worker' });
+    await spawnAgentForTest({ agentType: 'worker' });
+    await spawnAgentForTest({ agentType: 'worker' });
+
+    const result = await callScale({
+      targetAgents: 1,
+      scaleStrategy: 'immediate',
+      reason: 'integration-test scale-down',
+    });
+
+    expect(result.scalingStatus).toBe('completed');
+    expect(result.previousAgents).toBe(3);
+    expect(result.currentAgents).toBe(1);
+    expect(result.removedAgents).toBeDefined();
+    expect(result.removedAgents!.length).toBe(2);
+    expect(result.addedAgents).toBeUndefined();
+    expect(result.reason).toBe('integration-test scale-down');
+
+    const coord = await getSwarmCoordinator();
+    const live = coord.getAllAgents().filter(a => a.status !== 'terminated');
+    expect(live.length).toBe(1);
+  });
+
+  it('respects gradual rate-limiting (≥ 200ms per inter-agent gap)', async () => {
+    await callInit();
+
+    const start = Date.now();
+    const result = await callScale({
+      targetAgents: 3,
+      scaleStrategy: 'gradual',
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result.scalingStatus).toBe('completed');
+    expect(result.currentAgents).toBe(3);
+    // 3 spawns ⇒ 2 inter-agent gaps × 200 ms = ≥ 400 ms (loosened to 380 to
+    // tolerate timer jitter on slow CI; spawn time itself adds further headroom).
+    expect(elapsed).toBeGreaterThanOrEqual(380);
+  });
+
+  it('is idempotent at target — no spawn/terminate when already there', async () => {
+    await callInit();
+    await spawnAgentForTest({ agentType: 'worker' });
+    await spawnAgentForTest({ agentType: 'worker' });
+
+    const result = await callScale({ targetAgents: 2, scaleStrategy: 'immediate' });
+
+    expect(result.scalingStatus).toBe('completed');
+    expect(result.previousAgents).toBe(2);
+    expect(result.currentAgents).toBe(2);
+    expect(result.addedAgents).toBeUndefined();
+    expect(result.removedAgents).toBeUndefined();
+  });
+
+  it('round-robins agentTypes when scaling up', async () => {
+    await callInit();
+    const result = await callScale({
+      targetAgents: 4,
+      scaleStrategy: 'immediate',
+      agentTypes: ['coder', 'tester'],
+    });
+    expect(result.scalingStatus).toBe('completed');
+
+    const coord = await getSwarmCoordinator();
+    const types = result.addedAgents!.map(id => coord.getAgent(id)!.type).sort();
+    expect(types).toEqual(['coder', 'coder', 'tester', 'tester']);
+  });
+
+  it('rejects targetAgents below 1 without throwing', async () => {
+    await callInit();
+    const result = await callScale({ targetAgents: 0 });
+    expect(result.scalingStatus).toBe('failed');
+    expect(result.error).toMatch(/targetAgents/);
+  });
+
+  it('rejects targetAgents above the 1000 cap', async () => {
+    await callInit();
+    const result = await callScale({ targetAgents: 1001 });
+    expect(result.scalingStatus).toBe('failed');
+    expect(result.error).toMatch(/1000/);
+  });
+
+  it('rejects an unknown scaleStrategy', async () => {
+    await callInit();
+    const result = await callScale({ targetAgents: 1, scaleStrategy: 'turbo' });
+    expect(result.scalingStatus).toBe('failed');
+    expect(result.error).toMatch(/scaleStrategy/);
+  });
+
+  it('rejects unknown agent types via the shared whitelist', async () => {
+    await callInit();
+    const result = await callScale({
+      targetAgents: 2,
+      agentTypes: ['definitely-not-a-real-type'],
+    });
+    expect(result.scalingStatus).toBe('failed');
+    expect(result.error).toMatch(/whitelist|allowed|agentTypes/i);
+  });
+
+  it('records scaledAt as ISO timestamp and echoes the chosen strategy', async () => {
+    await callInit();
+    const result = await callScale({ targetAgents: 1, scaleStrategy: 'adaptive' });
+    expect(result.scaleStrategy).toBe('adaptive');
+    expect(() => new Date(result.scaledAt).toISOString()).not.toThrow();
+  });
+});

--- a/src/cli/mcp-tools/agent-tools.ts
+++ b/src/cli/mcp-tools/agent-tools.ts
@@ -130,12 +130,12 @@ function toNonNegativeInt<D extends number | undefined>(value: unknown, fallback
   return Math.floor(n);
 }
 
-interface AgentTypeValidation {
+export interface AgentTypeValidation {
   ok: boolean;
   error?: string;
 }
 
-function validateAgentType(value: unknown): AgentTypeValidation {
+export function validateAgentType(value: unknown): AgentTypeValidation {
   if (typeof value !== 'string' || value.length === 0) {
     return { ok: false, error: 'agentType must be a non-empty string' };
   }

--- a/src/cli/mcp-tools/swarm-scale-handler.ts
+++ b/src/cli/mcp-tools/swarm-scale-handler.ts
@@ -1,6 +1,8 @@
 /**
- * `swarm_scale` MCP tool — strategy-aware scaling routed through
- * UnifiedSwarmCoordinator (epic #798, story #804).
+ * `swarm_scale` MCP tool handler — strategy-aware scaling routed through
+ * UnifiedSwarmCoordinator (epic #798, story #804). The MCPTool registration
+ * lives in `./swarm-tools.ts` so the drift-guard regex (#693) sees the
+ * `name: 'swarm_scale'` literal in the file `mcp-client.ts` imports.
  *
  * Three strategies:
  *   - `immediate`: sequential awaits with no inter-op delay
@@ -207,7 +209,7 @@ export async function scaleHandler(input: Record<string, unknown>): Promise<Scal
       scalingStatus: 'completed',
       scaleStrategy: strategy,
       scaledAt,
-      reason,
+      ...(reason !== undefined ? { reason } : {}),
     };
   }
 
@@ -242,14 +244,17 @@ export async function scaleHandler(input: Record<string, unknown>): Promise<Scal
   }
 
   // Roll back partial scale-up on failure: agents we just spawned are owners
-  // we silently leaked otherwise. Best-effort terminate; rollback errors are
-  // recorded but don't override the original opError.
+  // we silently leaked otherwise. Splice out so the result-shape spread below
+  // omits them — the contract is "rolled-back agents are reported as if they
+  // never existed", which matches scalingStatus: 'failed'.
   if (opError && delta > 0 && addedAgents.length > 0) {
-    for (const id of addedAgents.splice(0)) {
+    const toRollback = addedAgents.splice(0);
+    for (const id of toRollback) {
       try {
         await coordinator.terminateAgent(id, { reason: 'swarm_scale rollback', force: true });
       } catch {
-        // Rollback best-effort — surfacing the original error is more useful.
+        // Best-effort — surfacing the original error is more useful than
+        // a noisier composite.
       }
     }
   }
@@ -271,7 +276,7 @@ export async function scaleHandler(input: Record<string, unknown>): Promise<Scal
     scaledAt,
     ...(addedAgents.length > 0 ? { addedAgents } : {}),
     ...(removedAgents.length > 0 ? { removedAgents } : {}),
-    reason,
+    ...(reason !== undefined ? { reason } : {}),
     ...(opError ? { error: opError.message } : {}),
   };
 }

--- a/src/cli/mcp-tools/swarm-scale.ts
+++ b/src/cli/mcp-tools/swarm-scale.ts
@@ -1,0 +1,277 @@
+/**
+ * `swarm_scale` MCP tool — strategy-aware scaling routed through
+ * UnifiedSwarmCoordinator (epic #798, story #804).
+ *
+ * Three strategies:
+ *   - `immediate`: sequential awaits with no inter-op delay
+ *   - `gradual`:   sequential awaits with 200ms between operations
+ *   - `adaptive`:  chunked, where chunk size shrinks under coordinator load
+ *
+ * On scale-up failure the partial fleet is rolled back so callers don't end
+ * up owning agents they didn't ask for.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { getSwarmCoordinator } from './swarm-coordinator-singleton.js';
+import { validateAgentType } from './agent-tools.js';
+import type { AgentState, AgentType } from '../swarm/types.js';
+import type { UnifiedSwarmCoordinator } from '../swarm/unified-coordinator.js';
+
+export type ScaleStrategy = 'gradual' | 'immediate' | 'adaptive';
+
+export const SCALE_STRATEGIES: readonly ScaleStrategy[] = ['gradual', 'immediate', 'adaptive'];
+
+export const TARGET_AGENTS_MIN = 1;
+export const TARGET_AGENTS_MAX = 1000;
+
+// Ticket #804: gradual strategy is "1 agent per 200ms".
+const GRADUAL_INTERVAL_MS = 200;
+
+// Adaptive chunking: spawns/terminates per chunk when coordinator is light vs busy.
+// Utilization = busy / live agents. < 0.5 → light load → larger chunks.
+const ADAPTIVE_CHUNK_LIGHT = 10;
+const ADAPTIVE_CHUNK_BUSY = 3;
+const ADAPTIVE_INTERCHUNK_MS = 50;
+const ADAPTIVE_LIGHT_THRESHOLD = 0.5;
+
+const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
+
+const isScaleStrategy = (value: unknown): value is ScaleStrategy =>
+  typeof value === 'string' && (SCALE_STRATEGIES as readonly string[]).includes(value);
+
+function liveAgents(coordinator: UnifiedSwarmCoordinator): AgentState[] {
+  return coordinator.getAllAgents().filter(a => a.status !== 'terminated');
+}
+
+function pickAgentType(agentTypes: string[] | undefined, index: number): string {
+  if (!agentTypes || agentTypes.length === 0) return 'worker';
+  return agentTypes[index % agentTypes.length];
+}
+
+function selectAgentsToTerminate(
+  candidates: AgentState[],
+  count: number,
+  agentTypes: string[] | undefined,
+): AgentState[] {
+  let pool = candidates;
+  if (agentTypes && agentTypes.length > 0) {
+    const set = new Set(agentTypes);
+    pool = pool.filter(a => set.has(a.type));
+  }
+  // Idle first (cheap to terminate — no grace period). Within a status bucket,
+  // oldest heartbeat first so we drain dormant agents before fresh ones.
+  const sorted = [...pool].sort((a, b) => {
+    if (a.status === 'idle' && b.status !== 'idle') return -1;
+    if (b.status === 'idle' && a.status !== 'idle') return 1;
+    return a.lastHeartbeat.getTime() - b.lastHeartbeat.getTime();
+  });
+  return sorted.slice(0, count);
+}
+
+function utilizationOf(coordinator: UnifiedSwarmCoordinator): number {
+  let total = 0;
+  let busy = 0;
+  for (const agent of coordinator.getAllAgents()) {
+    if (agent.status === 'terminated') continue;
+    total++;
+    if (agent.status === 'busy') busy++;
+  }
+  return total === 0 ? 0 : busy / total;
+}
+
+async function executeWithStrategy(
+  strategy: ScaleStrategy,
+  count: number,
+  utilizationProvider: () => number,
+  fn: (index: number) => Promise<void>,
+): Promise<void> {
+  if (strategy === 'immediate') {
+    for (let i = 0; i < count; i++) await fn(i);
+    return;
+  }
+
+  if (strategy === 'gradual') {
+    for (let i = 0; i < count; i++) {
+      await fn(i);
+      if (i < count - 1) await sleep(GRADUAL_INTERVAL_MS);
+    }
+    return;
+  }
+
+  // adaptive: chunk size adapts to coordinator load between chunks.
+  let i = 0;
+  while (i < count) {
+    const utilization = utilizationProvider();
+    const chunk = utilization < ADAPTIVE_LIGHT_THRESHOLD ? ADAPTIVE_CHUNK_LIGHT : ADAPTIVE_CHUNK_BUSY;
+    const end = Math.min(i + chunk, count);
+    for (let j = i; j < end; j++) await fn(j);
+    i = end;
+    if (i < count) await sleep(ADAPTIVE_INTERCHUNK_MS);
+  }
+}
+
+interface ScaleResult {
+  swarmId: string;
+  previousAgents: number;
+  targetAgents: number;
+  currentAgents: number;
+  scalingStatus: 'completed' | 'in-progress' | 'failed';
+  scaleStrategy: ScaleStrategy;
+  scaledAt: string;
+  addedAgents?: string[];
+  removedAgents?: string[];
+  reason?: string;
+  error?: string;
+}
+
+interface FailureContext {
+  scaledAt: string;
+  scaleStrategy: ScaleStrategy;
+  reason?: string;
+}
+
+function failure(error: string, ctx: FailureContext, partial?: Partial<ScaleResult>): ScaleResult {
+  return {
+    swarmId: '',
+    previousAgents: 0,
+    targetAgents: 0,
+    currentAgents: 0,
+    scalingStatus: 'failed',
+    scaleStrategy: ctx.scaleStrategy,
+    scaledAt: ctx.scaledAt,
+    reason: ctx.reason,
+    error,
+    ...partial,
+  };
+}
+
+export async function scaleHandler(input: Record<string, unknown>): Promise<ScaleResult> {
+  const scaledAt = new Date().toISOString();
+  const reason = input.reason as string | undefined;
+
+  const strategyInput = input.scaleStrategy ?? 'gradual';
+  if (!isScaleStrategy(strategyInput)) {
+    return failure(
+      `scaleStrategy "${String(strategyInput)}" must be one of ${SCALE_STRATEGIES.join(', ')}`,
+      { scaledAt, scaleStrategy: 'gradual', reason },
+    );
+  }
+  const strategy: ScaleStrategy = strategyInput;
+
+  const ctx: FailureContext = { scaledAt, scaleStrategy: strategy, reason };
+
+  const targetRaw = input.targetAgents;
+  const targetAgents = typeof targetRaw === 'number' ? targetRaw : Number(targetRaw);
+  if (
+    !Number.isFinite(targetAgents) ||
+    !Number.isInteger(targetAgents) ||
+    targetAgents < TARGET_AGENTS_MIN ||
+    targetAgents > TARGET_AGENTS_MAX
+  ) {
+    return failure(
+      `targetAgents must be an integer between ${TARGET_AGENTS_MIN} and ${TARGET_AGENTS_MAX}`,
+      ctx,
+      { targetAgents: Number.isFinite(targetAgents) ? targetAgents : 0 },
+    );
+  }
+
+  const agentTypesRaw = input.agentTypes;
+  let agentTypes: string[] | undefined;
+  if (agentTypesRaw !== undefined) {
+    if (!Array.isArray(agentTypesRaw)) {
+      return failure('agentTypes must be an array of strings', ctx, { targetAgents });
+    }
+    const validated: string[] = [];
+    for (const t of agentTypesRaw) {
+      const v = validateAgentType(t);
+      if (!v.ok) {
+        return failure(`agentTypes: ${v.error}`, ctx, { targetAgents });
+      }
+      validated.push(t as string);
+    }
+    agentTypes = validated;
+  }
+
+  const coordinator = await getSwarmCoordinator();
+  const swarmId = coordinator.getState().id.id;
+  const liveBefore = liveAgents(coordinator);
+  const previousAgents = liveBefore.length;
+  const delta = targetAgents - previousAgents;
+
+  if (delta === 0) {
+    return {
+      swarmId,
+      previousAgents,
+      targetAgents,
+      currentAgents: previousAgents,
+      scalingStatus: 'completed',
+      scaleStrategy: strategy,
+      scaledAt,
+      reason,
+    };
+  }
+
+  const addedAgents: string[] = [];
+  const removedAgents: string[] = [];
+  let opError: Error | undefined;
+
+  const utilizationProvider = (): number => utilizationOf(coordinator);
+
+  try {
+    if (delta > 0) {
+      await executeWithStrategy(strategy, delta, utilizationProvider, async (i) => {
+        const agentType = pickAgentType(agentTypes, i);
+        const agentId = `agent-scaled-${agentType}-${randomBytes(6).toString('hex')}`;
+        const spawned = await coordinator.spawnAgent({
+          id: agentId,
+          type: agentType as AgentType,
+          metadata: { scaledAt, scaleStrategy: strategy, scaleIndex: i, scaleReason: reason },
+        });
+        addedAgents.push(spawned.agentId);
+      });
+    } else {
+      const targetsToTerminate = selectAgentsToTerminate(liveBefore, -delta, agentTypes);
+      await executeWithStrategy(strategy, targetsToTerminate.length, utilizationProvider, async (i) => {
+        const target = targetsToTerminate[i];
+        const result = await coordinator.terminateAgent(target.id.id, { reason: reason ?? 'swarm_scale' });
+        if (result.terminated) removedAgents.push(result.agentId);
+      });
+    }
+  } catch (err) {
+    opError = err as Error;
+  }
+
+  // Roll back partial scale-up on failure: agents we just spawned are owners
+  // we silently leaked otherwise. Best-effort terminate; rollback errors are
+  // recorded but don't override the original opError.
+  if (opError && delta > 0 && addedAgents.length > 0) {
+    for (const id of addedAgents.splice(0)) {
+      try {
+        await coordinator.terminateAgent(id, { reason: 'swarm_scale rollback', force: true });
+      } catch {
+        // Rollback best-effort — surfacing the original error is more useful.
+      }
+    }
+  }
+
+  const currentAgents = liveAgents(coordinator).length;
+  const scalingStatus: ScaleResult['scalingStatus'] = opError
+    ? 'failed'
+    : currentAgents === targetAgents
+      ? 'completed'
+      : 'in-progress';
+
+  return {
+    swarmId,
+    previousAgents,
+    targetAgents,
+    currentAgents,
+    scalingStatus,
+    scaleStrategy: strategy,
+    scaledAt,
+    ...(addedAgents.length > 0 ? { addedAgents } : {}),
+    ...(removedAgents.length > 0 ? { removedAgents } : {}),
+    reason,
+    ...(opError ? { error: opError.message } : {}),
+  };
+}

--- a/src/cli/mcp-tools/swarm-tools.ts
+++ b/src/cli/mcp-tools/swarm-tools.ts
@@ -3,6 +3,7 @@
  *
  * `swarm_init`, `swarm_status`, `swarm_health` route through
  * UnifiedSwarmCoordinator (epic #798, story #803).
+ * `swarm_scale` lives in `./swarm-scale.ts` (epic #798, story #804).
  */
 
 import { existsSync } from 'node:fs';
@@ -12,6 +13,12 @@ import {
   getSwarmCoordinator,
   isSwarmCoordinatorInitialized,
 } from './swarm-coordinator-singleton.js';
+import {
+  scaleHandler,
+  SCALE_STRATEGIES,
+  TARGET_AGENTS_MIN,
+  TARGET_AGENTS_MAX,
+} from './swarm-scale.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { MOFLO_DIR } from '../services/moflo-paths.js';
 import type {
@@ -276,5 +283,37 @@ export const swarmTools: MCPTool[] = [
         checkedAt: new Date().toISOString(),
       };
     },
+  },
+  {
+    name: 'swarm_scale',
+    description: 'Scale swarm agents up or down with gradual / immediate / adaptive strategy',
+    category: 'swarm',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        targetAgents: {
+          type: 'number',
+          description: `Target number of non-terminated agents (${TARGET_AGENTS_MIN}-${TARGET_AGENTS_MAX})`,
+          minimum: TARGET_AGENTS_MIN,
+          maximum: TARGET_AGENTS_MAX,
+        },
+        scaleStrategy: {
+          type: 'string',
+          enum: [...SCALE_STRATEGIES],
+          description: 'Scaling strategy (default: gradual)',
+        },
+        agentTypes: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Agent types to spawn (round-robin) and to restrict scale-down candidates to. Defaults to ["worker"].',
+        },
+        reason: {
+          type: 'string',
+          description: 'Reason for scaling (audit trail)',
+        },
+      },
+      required: ['targetAgents'],
+    },
+    handler: async (input) => scaleHandler(input),
   },
 ];

--- a/src/cli/mcp-tools/swarm-tools.ts
+++ b/src/cli/mcp-tools/swarm-tools.ts
@@ -3,7 +3,8 @@
  *
  * `swarm_init`, `swarm_status`, `swarm_health` route through
  * UnifiedSwarmCoordinator (epic #798, story #803).
- * `swarm_scale` lives in `./swarm-scale.ts` (epic #798, story #804).
+ * `swarm_scale` handler logic lives in `./swarm-scale-handler.ts`
+ * (epic #798, story #804).
  */
 
 import { existsSync } from 'node:fs';
@@ -18,7 +19,7 @@ import {
   SCALE_STRATEGIES,
   TARGET_AGENTS_MIN,
   TARGET_AGENTS_MAX,
-} from './swarm-scale.js';
+} from './swarm-scale-handler.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { MOFLO_DIR } from '../services/moflo-paths.js';
 import type {


### PR DESCRIPTION
## Summary

Adds the missing `swarm_scale` MCP tool (epic #798, story #804). Routes through `coordinator.spawnAgent` / `coordinator.terminateAgent` — no JSON-store stubs, no `Date.now()` placeholders — completing the swarm-side coverage of the protected-functionality verification list in CLAUDE.md.

## Behaviour

| Strategy | Pacing |
|----------|--------|
| `immediate` | Sequential awaits, no inter-op delay |
| `gradual` | Sequential awaits, 200 ms between operations |
| `adaptive` | Chunked: 10 under light load, 3 under busy load; chunk size re-sampled via single-pass utilization scan |

Scale-down prefers idle agents (no grace period), then oldest by `lastHeartbeat`. Optional `agentTypes` round-robins on spawn and restricts the candidate pool on terminate. Partial scale-up failures roll back agents we already added (best-effort, force-terminated) so callers don't silently inherit a leaked fleet.

## Changes

- `src/cli/mcp-tools/swarm-scale-handler.ts` (new) — handler + helpers (`executeWithStrategy`, `utilizationOf`, `selectAgentsToTerminate`, `failure` builder).
- `src/cli/mcp-tools/swarm-tools.ts` — registers the `MCPTool` literal so the drift-guard regex (#693) sees `name: 'swarm_scale'`.
- `src/cli/mcp-tools/agent-tools.ts` — exports `validateAgentType` so the new handler reuses the canonical agent-type whitelist instead of duplicating it.
- `.claude/skills/swarm-advanced/SKILL.md` — Dynamic Scaling subsection (also the drift-guard's "real consumer" hit).
- `src/cli/__tests__/mcp-tools/swarm-scale.test.ts` (new) — 10 tests.

## Testing

- [x] swarm-scale unit tests (10/10): scale up/down, gradual rate (>= 380 ms for 3 spawns), idempotency at target, round-robin agent types, validation rejections (range, strategy, type whitelist).
- [x] All `mcp-tools/*` tests pass (56/56).
- [x] Drift guard #693 passes — tool has a documented consumer; no stale tokens.
- [x] `npm run build` — clean.
- [x] `npm test` — only unrelated pre-existing flake (issue #813: corrupt local fastembed `model.onnx` cache).
- [ ] Manual MCP smoke — would require a live MCP harness; covered by handler-level tests instead.

Closes #804