### PR TITLE
feat(805): task_* family wiring (7 MCP tools)

### DIFF
--- a/.claude/skills/swarm-advanced/SKILL.md
+++ b/.claude/skills/swarm-advanced/SKILL.md
@@ -61,6 +61,55 @@ The tool returns `{ previousAgents, currentAgents, scalingStatus, addedAgents,
 removedAgents }` so callers can verify the swarm reached the target. Scale-down
 prefers idle agents first, then oldest by heartbeat.
 
+### Task Orchestration
+
+The `task_*` family talks to the same UnifiedSwarmCoordinator that
+`swarm_init` / `agent_spawn` use, so tasks created here flow through the
+same scoring scheduler that load-balances across idle agents.
+
+```javascript
+// Single task — coordinator picks the lowest-workload agent automatically
+mcp__moflo__task_create({
+  type: "coding",
+  description: "Implement OAuth refresh flow",
+  priority: "high"
+})
+
+// Direct dispatch to a known agent (skip the scheduler)
+mcp__moflo__task_assign({
+  taskId: "task_swarm-…_3",
+  agentId: "agent-coder-…"
+})
+
+// Domain-routed dispatch (queen / security / core / integration / support)
+mcp__moflo__task_assign({
+  taskId: "task_swarm-…_4",
+  domain: "security"
+})
+
+// Submit a batch — load-balanced across available agents in one call.
+// 5 tasks across 3 idle agents → no agent ends up with more than 2.
+mcp__moflo__task_orchestrate({
+  tasks: [
+    { type: "coding", description: "endpoint A" },
+    { type: "coding", description: "endpoint B" },
+    { type: "testing", description: "tests for A" },
+    { type: "testing", description: "tests for B" },
+    { type: "review",  description: "PR review" }
+  ]
+})
+
+// Mark a task done and record its outcome
+mcp__moflo__task_complete({
+  taskId: "task_swarm-…_3",
+  result: { ok: true, summary: "merged in PR #842" }
+})
+```
+
+`task_orchestrate` returns `{ submitted, assigned, queued, rejected, tasks,
+errors }` — `assigned` is the count whose agents accepted them on submit;
+the rest are queued and will be picked up as agents go idle.
+
 ## Core Concepts
 
 ### Swarm Topologies

--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ hive-mind-prompt-*.txt
 # Ephemeral / test artifacts
 .claude/projects/
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 **/workflow-state.json
 *.rvf
 .vitest-results.json

--- a/src/cli/__tests__/mcp-tools-deep.test.ts
+++ b/src/cli/__tests__/mcp-tools-deep.test.ts
@@ -465,10 +465,13 @@ describe('MCP Tools Deep Test Suite', () => {
   describe('Task Tools - Handler Invocation', () => {
     it('task_create creates a task', async () => {
       const tool = taskTools.find(t => t.name === 'task_create')!;
-      const result: any = await tool.handler({ type: 'feature', description: 'Test task' });
+      // Story #805: task_create is now wired to UnifiedSwarmCoordinator,
+      // which restricts `type` to the TaskType union (no 'feature' alias).
+      // Status is 'queued' when no agents exist (or 'assigned' if one does).
+      const result: any = await tool.handler({ type: 'coding', description: 'Test task' });
       expect(result.taskId).toBeDefined();
-      expect(result.type).toBe('feature');
-      expect(result.status).toBe('pending');
+      expect(result.type).toBe('coding');
+      expect(['queued', 'assigned']).toContain(result.status);
     });
 
     it('task_list returns tasks array', async () => {
@@ -757,10 +760,12 @@ describe('MCP Tools Deep Test Suite', () => {
 
     it('task_create returns taskId and status', async () => {
       const tool = taskTools.find(t => t.name === 'task_create')!;
-      const result: any = await tool.handler({ type: 'bugfix', description: 'Fix the bug' });
+      // Story #805: see note above — type union no longer includes 'bugfix';
+      // status is 'queued' (no agents) or 'assigned' (auto-scheduled).
+      const result: any = await tool.handler({ type: 'coding', description: 'Fix the bug' });
       expect(result.taskId).toBeDefined();
       expect(typeof result.taskId).toBe('string');
-      expect(result.status).toBe('pending');
+      expect(['queued', 'assigned']).toContain(result.status);
     });
 
     it('swarm_init returns success and swarmId', async () => {

--- a/src/cli/__tests__/mcp-tools-deep.test.ts
+++ b/src/cli/__tests__/mcp-tools-deep.test.ts
@@ -465,9 +465,8 @@ describe('MCP Tools Deep Test Suite', () => {
   describe('Task Tools - Handler Invocation', () => {
     it('task_create creates a task', async () => {
       const tool = taskTools.find(t => t.name === 'task_create')!;
-      // Story #805: task_create is now wired to UnifiedSwarmCoordinator,
-      // which restricts `type` to the TaskType union (no 'feature' alias).
-      // Status is 'queued' when no agents exist (or 'assigned' if one does).
+      // `type` is the TaskType union; status is 'queued' (no idle agent)
+      // or 'assigned' (auto-scheduler picked one).
       const result: any = await tool.handler({ type: 'coding', description: 'Test task' });
       expect(result.taskId).toBeDefined();
       expect(result.type).toBe('coding');
@@ -760,8 +759,6 @@ describe('MCP Tools Deep Test Suite', () => {
 
     it('task_create returns taskId and status', async () => {
       const tool = taskTools.find(t => t.name === 'task_create')!;
-      // Story #805: see note above — type union no longer includes 'bugfix';
-      // status is 'queued' (no agents) or 'assigned' (auto-scheduled).
       const result: any = await tool.handler({ type: 'coding', description: 'Fix the bug' });
       expect(result.taskId).toBeDefined();
       expect(typeof result.taskId).toBe('string');

--- a/src/cli/__tests__/mcp-tools/_helpers.ts
+++ b/src/cli/__tests__/mcp-tools/_helpers.ts
@@ -4,6 +4,7 @@
 
 import { agentTools } from '../../mcp-tools/agent-tools.js';
 import { swarmTools } from '../../mcp-tools/swarm-tools.js';
+import { taskTools } from '../../mcp-tools/task-tools.js';
 import type { MCPTool } from '../../mcp-tools/types.js';
 
 export function getAgentTool(name: string): MCPTool {
@@ -15,6 +16,12 @@ export function getAgentTool(name: string): MCPTool {
 export function getSwarmTool(name: string): MCPTool {
   const tool = swarmTools.find(t => t.name === name);
   if (!tool) throw new Error(`swarm tool "${name}" not registered`);
+  return tool;
+}
+
+export function getTaskTool(name: string): MCPTool {
+  const tool = taskTools.find(t => t.name === name);
+  if (!tool) throw new Error(`task tool "${name}" not registered`);
   return tool;
 }
 

--- a/src/cli/__tests__/mcp-tools/task-orchestrate.test.ts
+++ b/src/cli/__tests__/mcp-tools/task-orchestrate.test.ts
@@ -1,11 +1,10 @@
 /**
- * `task_orchestrate` load-balanced multi-task distribution (story #805).
+ * `task_orchestrate` load-balanced multi-task distribution.
  *
- * Acceptance bar from issue #805: "Load balancing observable: 5 tasks across
- * 3 agents → no agent gets >2." That hinges on the coordinator's
- * `assignTask` scoring heuristic (workload-aware), not on this MCP shim.
- * These tests pin the contract so future scheduler refactors don't silently
- * regress fairness.
+ * Acceptance bar: "5 tasks across 3 agents → no agent gets more than 2."
+ * That hinges on the coordinator's `assignTask` scoring heuristic
+ * (workload-aware), not on this MCP shim. These tests pin the contract so
+ * future scheduler refactors don't silently regress fairness.
  */
 
 import { afterEach, describe, expect, it } from 'vitest';

--- a/src/cli/__tests__/mcp-tools/task-orchestrate.test.ts
+++ b/src/cli/__tests__/mcp-tools/task-orchestrate.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `task_orchestrate` load-balanced multi-task distribution (story #805).
+ *
+ * Acceptance bar from issue #805: "Load balancing observable: 5 tasks across
+ * 3 agents → no agent gets >2." That hinges on the coordinator's
+ * `assignTask` scoring heuristic (workload-aware), not on this MCP shim.
+ * These tests pin the contract so future scheduler refactors don't silently
+ * regress fairness.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetSwarmCoordinatorForTest,
+  getSwarmCoordinator,
+} from '../../mcp-tools/swarm-coordinator-singleton.js';
+import { getTaskTool, spawnAgentForTest } from './_helpers.js';
+
+interface OrchestrateResult {
+  success: boolean;
+  submitted: number;
+  assigned: number;
+  queued: number;
+  rejected: number;
+  tasks: Array<{
+    taskId: string;
+    type: string;
+    status: string;
+    assignedTo: string[];
+  }>;
+  errors: Array<{ index: number; error: string }>;
+}
+
+const orchestrateTool = getTaskTool('task_orchestrate');
+
+async function orchestrate(input: Record<string, unknown>): Promise<OrchestrateResult> {
+  return (await orchestrateTool.handler(input)) as OrchestrateResult;
+}
+
+describe('task_orchestrate — load-balanced submission', () => {
+  afterEach(async () => {
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('5 tasks across 3 agents: no agent receives more than 2 — and tasks beyond capacity queue', async () => {
+    // 3 worker agents — coordinator's `assignTask` will score-balance, picking
+    // the lowest-workload idle agent on each new submit. Once an agent goes
+    // 'busy' it falls out of `getAvailableAgents()`, so subsequent submits
+    // must spread across remaining idle agents until all are busy, then queue.
+    const agents = [
+      await spawnAgentForTest({ agentType: 'coder' }),
+      await spawnAgentForTest({ agentType: 'coder' }),
+      await spawnAgentForTest({ agentType: 'coder' }),
+    ];
+
+    const result = await orchestrate({
+      tasks: Array.from({ length: 5 }).map((_, i) => ({
+        type: 'coding',
+        description: `task-${i}`,
+        priority: 'normal',
+      })),
+    });
+
+    expect(result.submitted).toBe(5);
+    expect(result.rejected).toBe(0);
+
+    // Count tasks-per-agent across the FIRST assignment of each task.
+    const counts = new Map<string, number>(agents.map(a => [a, 0]));
+    for (const t of result.tasks) {
+      if (t.assignedTo.length > 0) {
+        const agent = t.assignedTo[0];
+        counts.set(agent, (counts.get(agent) ?? 0) + 1);
+      }
+    }
+
+    // Every assigned count must be ≤ 2 — that's the AC for no-agent-overload.
+    for (const [agent, count] of counts) {
+      expect(count, `agent ${agent} got ${count} tasks (max 2)`).toBeLessThanOrEqual(2);
+    }
+
+    // 3 agents × 1 concurrent task each = 3 assigned, 2 queued.
+    expect(result.assigned).toBe(3);
+    expect(result.queued).toBe(2);
+  });
+
+  it('honors per-task type/priority overrides without bleeding state', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+    await spawnAgentForTest({ agentType: 'researcher' });
+
+    const result = await orchestrate({
+      tasks: [
+        { type: 'coding', description: 'high-prio', priority: 'critical' },
+        { type: 'research', description: 'normal', priority: 'normal' },
+      ],
+    });
+
+    expect(result.submitted).toBe(2);
+    expect(result.tasks[0].type).toBe('coding');
+    expect(result.tasks[1].type).toBe('research');
+
+    const coord = await getSwarmCoordinator();
+    const live0 = coord.getTask(result.tasks[0].taskId);
+    const live1 = coord.getTask(result.tasks[1].taskId);
+    expect(live0?.priority).toBe('critical');
+    expect(live1?.priority).toBe('normal');
+  });
+
+  it('rejects bad-shaped tasks individually and continues with valid ones', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+
+    const result = await orchestrate({
+      tasks: [
+        { type: 'coding', description: 'good' },
+        { type: 'sandwich', description: 'bad-type' },
+        { description: 'no-type-at-all' },
+        { type: 'coding', description: 'also-good' },
+      ],
+    });
+
+    expect(result.submitted).toBe(2);
+    expect(result.rejected).toBe(2);
+    expect(result.errors.length).toBe(2);
+    expect(result.errors[0].index).toBe(1);
+    expect(result.errors[1].index).toBe(2);
+    expect(result.success).toBe(false); // any rejection flips success
+  });
+
+  it('rejects empty or non-array tasks input', async () => {
+    const empty = await orchestrate({ tasks: [] });
+    expect(empty.success).toBe(false);
+
+    const notArray = await orchestrate({ tasks: 'not-an-array' as unknown as object[] });
+    expect(notArray.success).toBe(false);
+  });
+
+  it('persists every submitted task in the coordinator (not a JSON store)', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+
+    const result = await orchestrate({
+      tasks: [
+        { type: 'coding', description: 'one' },
+        { type: 'coding', description: 'two' },
+      ],
+    });
+    expect(result.submitted).toBe(2);
+
+    const coord = await getSwarmCoordinator();
+    for (const t of result.tasks) {
+      const live = coord.getTask(t.taskId);
+      expect(live, `task ${t.taskId} should be persisted in coordinator`).toBeDefined();
+    }
+  });
+});

--- a/src/cli/__tests__/mcp-tools/task-pipeline.test.ts
+++ b/src/cli/__tests__/mcp-tools/task-pipeline.test.ts
@@ -1,9 +1,7 @@
 /**
- * `task_*` family wired to UnifiedSwarmCoordinator (story #805).
- *
- * Covers the create → assign → status → complete → cancel pipeline. The
- * companion `task-orchestrate.test.ts` covers load-balanced multi-task
- * distribution across agents.
+ * `task_*` family backed by UnifiedSwarmCoordinator: create → assign →
+ * status → complete → cancel pipeline. Load-balanced batch dispatch is
+ * covered separately in `task-orchestrate.test.ts`.
  */
 
 import { afterEach, describe, expect, it } from 'vitest';

--- a/src/cli/__tests__/mcp-tools/task-pipeline.test.ts
+++ b/src/cli/__tests__/mcp-tools/task-pipeline.test.ts
@@ -1,0 +1,343 @@
+/**
+ * `task_*` family wired to UnifiedSwarmCoordinator (story #805).
+ *
+ * Covers the create → assign → status → complete → cancel pipeline. The
+ * companion `task-orchestrate.test.ts` covers load-balanced multi-task
+ * distribution across agents.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  _resetSwarmCoordinatorForTest,
+  getSwarmCoordinator,
+} from '../../mcp-tools/swarm-coordinator-singleton.js';
+import { getTaskTool, spawnAgentForTest } from './_helpers.js';
+
+interface TaskShape {
+  taskId: string;
+  type: string;
+  name: string;
+  description: string;
+  priority: string;
+  status: string;
+  progress: number;
+  assignedTo: string[];
+  tags: string[];
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  result?: unknown;
+}
+
+interface CreateResult extends TaskShape {
+  success: boolean;
+  error?: string;
+}
+
+interface AssignResult {
+  success: boolean;
+  taskId: string;
+  agentId?: string;
+  domain?: string;
+  assignmentMode?: 'direct' | 'domain';
+  queued?: boolean;
+  error?: string;
+  reason?: string;
+}
+
+interface CompleteResult {
+  success: boolean;
+  taskId: string;
+  status?: string;
+  completedAt?: string;
+  result?: unknown;
+  error?: string;
+}
+
+interface CancelResult {
+  success: boolean;
+  taskId: string;
+  status?: string;
+  cancelledAt?: string;
+  reason?: string;
+  error?: string;
+}
+
+interface ListResult {
+  tasks: TaskShape[];
+  total: number;
+  returned: number;
+  filters: Record<string, unknown>;
+}
+
+const createTool = getTaskTool('task_create');
+const assignTool = getTaskTool('task_assign');
+const statusTool = getTaskTool('task_status');
+const listTool = getTaskTool('task_list');
+const completeTool = getTaskTool('task_complete');
+const cancelTool = getTaskTool('task_cancel');
+
+async function create(input: Record<string, unknown>): Promise<CreateResult> {
+  return (await createTool.handler(input)) as CreateResult;
+}
+
+async function assign(input: Record<string, unknown>): Promise<AssignResult> {
+  return (await assignTool.handler(input)) as AssignResult;
+}
+
+async function status(input: Record<string, unknown>): Promise<TaskShape & { error?: string }> {
+  return (await statusTool.handler(input)) as TaskShape & { error?: string };
+}
+
+async function list(input: Record<string, unknown> = {}): Promise<ListResult> {
+  return (await listTool.handler(input)) as ListResult;
+}
+
+async function complete(input: Record<string, unknown>): Promise<CompleteResult> {
+  return (await completeTool.handler(input)) as CompleteResult;
+}
+
+async function cancel(input: Record<string, unknown>): Promise<CancelResult> {
+  return (await cancelTool.handler(input)) as CancelResult;
+}
+
+describe('task_* pipeline — coordinator-backed', () => {
+  afterEach(async () => {
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('runs create → status → complete end-to-end via the coordinator', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+
+    const created = await create({
+      type: 'coding',
+      description: 'Implement the thing',
+    });
+    expect(created.success).toBe(true);
+    expect(created.taskId).toMatch(/^task_/);
+    // submitTask immediately auto-assigns when an idle agent is available.
+    expect(created.status).toBe('assigned');
+    expect(created.assignedTo.length).toBe(1);
+
+    // The task is reachable through the live coordinator — not a JSON store.
+    const coord = await getSwarmCoordinator();
+    expect(coord.getTask(created.taskId)).toBeDefined();
+
+    const stat = await status({ taskId: created.taskId });
+    expect(stat.status).toBe('assigned');
+    expect(stat.taskId).toBe(created.taskId);
+
+    const completed = await complete({
+      taskId: created.taskId,
+      result: { ok: true, summary: 'done' },
+    });
+    expect(completed.success).toBe(true);
+    expect(completed.status).toBe('completed');
+    expect(completed.result).toEqual({ ok: true, summary: 'done' });
+
+    // Coordinator metrics moved
+    expect(coord.getMetrics().completedTasks).toBe(1);
+  });
+
+  it('queues a task when no agents are available', async () => {
+    const created = await create({
+      type: 'research',
+      description: 'No agents yet',
+    });
+    expect(created.success).toBe(true);
+    expect(created.status).toBe('queued');
+    expect(created.assignedTo).toEqual([]);
+  });
+
+  it('rejects missing or invalid type/description without throwing', async () => {
+    const noType = await create({ description: 'x' });
+    expect(noType.success).toBe(false);
+    expect(noType.error).toMatch(/type/);
+
+    const badType = await create({ type: 'sandwich-making', description: 'x' });
+    expect(badType.success).toBe(false);
+
+    const noDesc = await create({ type: 'coding' });
+    expect(noDesc.success).toBe(false);
+    expect(noDesc.error).toMatch(/description/);
+
+    const badPriority = await create({
+      type: 'coding',
+      description: 'x',
+      priority: 'extreme',
+    });
+    expect(badPriority.success).toBe(false);
+    expect(badPriority.error).toMatch(/priority/);
+  });
+
+  it('task_assign honors direct agentId targeting', async () => {
+    const a1 = await spawnAgentForTest({ agentType: 'coder' });
+    const a2 = await spawnAgentForTest({ agentType: 'tester' });
+
+    // Spawn one extra agent so the auto-scheduler doesn't pin the new task to
+    // the only idle agent we want to test against.
+    void a1;
+
+    const created = await create({ type: 'testing', description: 'Run tests' });
+    expect(created.success).toBe(true);
+
+    // First, cancel auto-assignment so we can re-target manually.
+    await cancel({ taskId: created.taskId });
+
+    // Re-create a fresh task to test direct assignment.
+    const fresh = await create({ type: 'testing', description: 'Round 2' });
+    const result = await assign({ taskId: fresh.taskId, agentId: a2 });
+    // Direct re-assignment is allowed even if scheduler already picked.
+    expect(result.success).toBe(true);
+    expect(result.assignmentMode).toBe('direct');
+    expect(result.agentId).toBe(a2);
+
+    const coord = await getSwarmCoordinator();
+    const live = coord.getTask(fresh.taskId);
+    expect(live?.assignedTo?.id).toBe(a2);
+  });
+
+  it('task_assign rejects when neither agentId nor domain is provided', async () => {
+    const created = await create({ type: 'coding', description: 'x' });
+    const result = await assign({ taskId: created.taskId });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/agentId.*domain/);
+  });
+
+  it('task_assign rejects an unknown agentId', async () => {
+    const created = await create({ type: 'coding', description: 'x' });
+    const result = await assign({ taskId: created.taskId, agentId: 'agent-ghost' });
+    expect(result.success).toBe(false);
+    // Handler surfaces the coordinator's reason as `error` to match the
+    // shape of agent_terminate / agent_status.
+    expect(result.error).toBe('agent_not_found');
+  });
+
+  it('task_assign routes through a domain pool when domain is specified', async () => {
+    const created = await create({ type: 'analysis', description: 'Domain dispatch' });
+    const result = await assign({ taskId: created.taskId, domain: 'security' });
+
+    // Domain pools auto-scale up to maxSize on acquire; first dispatch creates
+    // a pooled agent. We assert the contract: domain-mode returns success and
+    // either an agentId (assigned) or queued=true (pool exhausted).
+    expect(result.success).toBe(true);
+    expect(result.assignmentMode).toBe('domain');
+    if (result.agentId) {
+      const coord = await getSwarmCoordinator();
+      const live = coord.getTask(created.taskId);
+      expect(live?.assignedTo?.id).toBe(result.agentId);
+    } else {
+      expect(result.queued).toBe(true);
+    }
+  });
+
+  it('task_assign rejects an unknown domain string', async () => {
+    const created = await create({ type: 'coding', description: 'x' });
+    const result = await assign({ taskId: created.taskId, domain: 'sandwich-domain' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/domain/);
+  });
+
+  it('task_list filters by status, type, priority, and assignedTo', async () => {
+    const agent = await spawnAgentForTest({ agentType: 'coder' });
+
+    const t1 = await create({ type: 'coding', description: 'A', priority: 'high' });
+    const t2 = await create({ type: 'research', description: 'B', priority: 'low' });
+    void t2;
+
+    // Status filter — t1 was auto-assigned, t2 queued (no researcher agent).
+    const assigned = await list({ status: 'assigned' });
+    expect(assigned.tasks.find(t => t.taskId === t1.taskId)).toBeDefined();
+
+    const queued = await list({ status: 'queued' });
+    expect(queued.tasks.length).toBeGreaterThanOrEqual(1);
+    expect(queued.tasks.every(t => t.status === 'queued')).toBe(true);
+
+    // Type filter
+    const byType = await list({ type: 'research' });
+    expect(byType.tasks.every(t => t.type === 'research')).toBe(true);
+
+    // Priority filter
+    const byPriority = await list({ priority: 'high' });
+    expect(byPriority.tasks.every(t => t.priority === 'high')).toBe(true);
+
+    // assignedTo filter
+    const byAgent = await list({ assignedTo: agent });
+    expect(byAgent.tasks.every(t => t.assignedTo.includes(agent))).toBe(true);
+  });
+
+  it('task_list paginates with limit/offset and reports total', async () => {
+    for (let i = 0; i < 5; i++) {
+      await create({ type: 'coding', description: `task-${i}` });
+    }
+    const page1 = await list({ limit: 2, offset: 0 });
+    expect(page1.tasks.length).toBe(2);
+    expect(page1.total).toBeGreaterThanOrEqual(5);
+    expect(page1.returned).toBe(2);
+
+    const page2 = await list({ limit: 2, offset: 2 });
+    expect(page2.tasks.length).toBe(2);
+
+    // No overlap between pages
+    const ids1 = page1.tasks.map(t => t.taskId);
+    const ids2 = page2.tasks.map(t => t.taskId);
+    expect(ids1.some(id => ids2.includes(id))).toBe(false);
+  });
+
+  it('task_list supports comma-separated status filter', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+    const created = await create({ type: 'coding', description: 'A' });
+    await complete({ taskId: created.taskId });
+
+    await create({ type: 'research', description: 'B' }); // queued
+
+    const result = await list({ status: 'completed,queued' });
+    const statuses = new Set(result.tasks.map(t => t.status));
+    expect([...statuses].every(s => s === 'completed' || s === 'queued')).toBe(true);
+  });
+
+  it('task_complete returns not-found when the task does not exist', async () => {
+    const result = await complete({ taskId: 'task-ghost' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found|not_found/);
+  });
+
+  it('task_complete is idempotent on already-completed tasks', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+    const created = await create({ type: 'coding', description: 'x' });
+    await complete({ taskId: created.taskId, result: { v: 1 } });
+    const second = await complete({ taskId: created.taskId, result: { v: 2 } });
+    expect(second.success).toBe(true);
+
+    // Output from the first complete should be preserved (no overwrite).
+    const stat = await status({ taskId: created.taskId });
+    expect(stat.result).toEqual({ v: 1 });
+  });
+
+  it('task_cancel transitions to cancelled and records timestamp', async () => {
+    await spawnAgentForTest({ agentType: 'coder' });
+    const created = await create({ type: 'coding', description: 'will-cancel' });
+    const result = await cancel({ taskId: created.taskId, reason: 'changed-my-mind' });
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('cancelled');
+    expect(result.reason).toBe('changed-my-mind');
+    expect(() => new Date(result.cancelledAt!).toISOString()).not.toThrow();
+
+    const stat = await status({ taskId: created.taskId });
+    expect(stat.status).toBe('cancelled');
+  });
+
+  it('task_cancel returns not-found for unknown task ids', async () => {
+    const result = await cancel({ taskId: 'task-ghost' });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found|not_found/);
+  });
+
+  it('rejects malformed taskId on every read/write tool', async () => {
+    expect((await status({ taskId: '' })).error).toBeDefined();
+    expect((await complete({ taskId: '' })).error).toBeDefined();
+    expect((await cancel({ taskId: '' })).error).toBeDefined();
+    expect((await assign({ taskId: '' })).error).toBeDefined();
+  });
+});

--- a/src/cli/mcp-tools/agent-tools.ts
+++ b/src/cli/mcp-tools/agent-tools.ts
@@ -124,7 +124,7 @@ const ALLOWED_AGENT_TYPES: ReadonlySet<string> = new Set<string>([
 
 const AGENT_TYPE_SLUG_RE = /^[a-z][a-z0-9-]*$/;
 
-function toNonNegativeInt<D extends number | undefined>(value: unknown, fallback: D): number | D {
+export function toNonNegativeInt<D extends number | undefined>(value: unknown, fallback: D): number | D {
   const n = Number(value);
   if (!Number.isFinite(n) || n < 0) return fallback;
   return Math.floor(n);

--- a/src/cli/mcp-tools/task-tools.ts
+++ b/src/cli/mcp-tools/task-tools.ts
@@ -1,123 +1,210 @@
 /**
- * Task MCP Tools for CLI
- *
- * Tool definitions for task management with file persistence.
+ * Task MCP tool surface backed by UnifiedSwarmCoordinator.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import type { MCPTool } from './types.js';
-import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
+import { getSwarmCoordinator } from './swarm-coordinator-singleton.js';
+import { toNonNegativeInt } from './agent-tools.js';
+import type {
+  TaskDefinition,
+  TaskPriority,
+  TaskStatus,
+  TaskType,
+} from '../swarm/types.js';
+import type { AgentDomain } from '../swarm/unified-coordinator.js';
 
-// Storage paths
-const TASK_DIR = 'tasks';
-const TASK_FILE = 'store.json';
+const TASK_TYPES: ReadonlySet<TaskType> = new Set([
+  'research', 'analysis', 'coding', 'testing', 'review',
+  'documentation', 'coordination', 'consensus', 'custom',
+]);
 
-interface TaskRecord {
+const TASK_PRIORITIES: ReadonlySet<TaskPriority> = new Set([
+  'critical', 'high', 'normal', 'low', 'background',
+]);
+
+const TASK_STATUSES: ReadonlySet<TaskStatus> = new Set([
+  'created', 'queued', 'assigned', 'running', 'paused',
+  'completed', 'failed', 'cancelled', 'timeout',
+]);
+
+const AGENT_DOMAINS: ReadonlySet<AgentDomain> = new Set([
+  'queen', 'security', 'core', 'integration', 'support',
+]);
+
+// Pin the projection's timeout default rather than reading
+// coordinator.config.taskTimeoutMs so the MCP-side shape stays stable across
+// coordinator re-config.
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_RETRIES = 3;
+
+const PROGRESS_BY_STATUS: Record<TaskStatus, number> = {
+  created: 0,
+  queued: 0,
+  assigned: 10,
+  running: 50,
+  paused: 50,
+  completed: 100,
+  failed: 0,
+  cancelled: 0,
+  timeout: 0,
+};
+
+interface TaskIdValidation {
+  ok: boolean;
   taskId: string;
-  type: string;
+  error?: string;
+}
+
+function validateTaskId(input: Record<string, unknown>): TaskIdValidation {
+  const taskId = input.taskId as string;
+  if (typeof taskId !== 'string' || !taskId) {
+    return { ok: false, taskId: taskId ?? '', error: 'taskId must be a non-empty string' };
+  }
+  return { ok: true, taskId };
+}
+
+interface TaskShape {
+  taskId: string;
+  type: TaskType;
+  name: string;
   description: string;
-  priority: 'low' | 'normal' | 'high' | 'critical';
-  status: 'pending' | 'in_progress' | 'completed' | 'failed' | 'cancelled';
+  priority: TaskPriority;
+  status: TaskStatus;
   progress: number;
   assignedTo: string[];
   tags: string[];
   createdAt: string;
   startedAt: string | null;
   completedAt: string | null;
-  result?: Record<string, unknown>;
+  result?: unknown;
 }
 
-interface TaskStore {
-  tasks: Record<string, TaskRecord>;
-  version: string;
+function projectTask(task: TaskDefinition): TaskShape {
+  // Coordinator has no numeric progress; derive from status so the MCP shape
+  // matches what the legacy JSON-store API exposed.
+  const tags = Array.isArray(task.metadata?.tags)
+    ? (task.metadata.tags as unknown[]).filter((t): t is string => typeof t === 'string')
+    : [];
+
+  return {
+    taskId: task.id.id,
+    type: task.type,
+    name: task.name,
+    description: task.description,
+    priority: task.priority,
+    status: task.status,
+    progress: PROGRESS_BY_STATUS[task.status] ?? 0,
+    assignedTo: task.assignedTo ? [task.assignedTo.id] : [],
+    tags,
+    createdAt: task.createdAt.toISOString(),
+    startedAt: task.startedAt ? task.startedAt.toISOString() : null,
+    completedAt: task.completedAt ? task.completedAt.toISOString() : null,
+    result: task.output,
+  };
 }
 
-function getTaskDir(): string {
-  return join(process.cwd(), STORAGE_DIR, TASK_DIR);
-}
-
-function getTaskPath(): string {
-  return join(getTaskDir(), TASK_FILE);
-}
-
-function ensureTaskDir(): void {
-  const dir = getTaskDir();
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+function buildTaskInput(input: Record<string, unknown>): {
+  ok: true;
+  task: Omit<TaskDefinition, 'id' | 'status' | 'createdAt'>;
+} | { ok: false; error: string } {
+  const type = input.type as string;
+  if (!type || !TASK_TYPES.has(type as TaskType)) {
+    return {
+      ok: false,
+      error: `type must be one of: ${[...TASK_TYPES].join(', ')}`,
+    };
   }
-}
 
-function loadTaskStore(): TaskStore {
-  try {
-    const path = getTaskPath();
-    if (existsSync(path)) {
-      const data = readFileSync(path, 'utf-8');
-      return JSON.parse(data);
-    }
-  } catch {
-    // Return empty store on error
+  const description = input.description as string;
+  if (typeof description !== 'string' || description.length === 0) {
+    return { ok: false, error: 'description must be a non-empty string' };
   }
-  return { tasks: {}, version: '3.0.0' };
-}
 
-function saveTaskStore(store: TaskStore): void {
-  ensureTaskDir();
-  writeFileSync(getTaskPath(), JSON.stringify(store, null, 2), 'utf-8');
+  const priorityRaw = (input.priority as string) || 'normal';
+  if (!TASK_PRIORITIES.has(priorityRaw as TaskPriority)) {
+    return {
+      ok: false,
+      error: `priority must be one of: ${[...TASK_PRIORITIES].join(', ')}`,
+    };
+  }
+
+  const tags = Array.isArray(input.tags)
+    ? (input.tags as unknown[]).filter((t): t is string => typeof t === 'string')
+    : [];
+
+  const name = (input.name as string) || `${type}-${randomBytes(4).toString('hex')}`;
+  const timeoutMs = typeof input.timeoutMs === 'number' && input.timeoutMs > 0
+    ? input.timeoutMs
+    : DEFAULT_TIMEOUT_MS;
+  const maxRetries = typeof input.maxRetries === 'number' && input.maxRetries >= 0
+    ? Math.floor(input.maxRetries)
+    : DEFAULT_MAX_RETRIES;
+
+  return {
+    ok: true,
+    task: {
+      type: type as TaskType,
+      name,
+      description,
+      priority: priorityRaw as TaskPriority,
+      dependencies: [],
+      input: input.input ?? null,
+      timeoutMs,
+      retries: 0,
+      maxRetries,
+      metadata: {
+        tags,
+        ...(input.metadata && typeof input.metadata === 'object'
+          ? input.metadata as Record<string, unknown>
+          : {}),
+      },
+    },
+  };
 }
 
 export const taskTools: MCPTool[] = [
   {
     name: 'task_create',
-    description: 'Create a new task',
+    description: 'Create a new task and submit it to the coordinator',
     category: 'task',
     inputSchema: {
       type: 'object',
       properties: {
-        type: { type: 'string', description: 'Task type (feature, bugfix, research, refactor)' },
+        type: { type: 'string', description: `Task type (${[...TASK_TYPES].join(' | ')})` },
+        name: { type: 'string', description: 'Optional human-readable name' },
         description: { type: 'string', description: 'Task description' },
-        priority: { type: 'string', description: 'Task priority (low, normal, high, critical)' },
-        assignTo: { type: 'array', items: { type: 'string' }, description: 'Agent IDs to assign' },
+        priority: { type: 'string', description: `Task priority (${[...TASK_PRIORITIES].join(' | ')})` },
         tags: { type: 'array', items: { type: 'string' }, description: 'Task tags' },
+        timeoutMs: { type: 'number', description: 'Task timeout (ms)' },
+        maxRetries: { type: 'number', description: 'Max retry attempts' },
+        input: { description: 'Task input payload (any shape)' },
+        metadata: { type: 'object', description: 'Additional metadata merged into task.metadata' },
       },
       required: ['type', 'description'],
     },
     handler: async (input) => {
-      const store = loadTaskStore();
-      const taskId = `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const built = buildTaskInput(input);
+      if (!built.ok) {
+        return { success: false, error: built.error };
+      }
 
-      const task: TaskRecord = {
-        taskId,
-        type: input.type as string,
-        description: input.description as string,
-        priority: (input.priority as TaskRecord['priority']) || 'normal',
-        status: 'pending',
-        progress: 0,
-        assignedTo: (input.assignTo as string[]) || [],
-        tags: (input.tags as string[]) || [],
-        createdAt: new Date().toISOString(),
-        startedAt: null,
-        completedAt: null,
-      };
-
-      store.tasks[taskId] = task;
-      saveTaskStore(store);
-
-      return {
-        taskId,
-        type: task.type,
-        description: task.description,
-        priority: task.priority,
-        status: task.status,
-        createdAt: task.createdAt,
-        assignedTo: task.assignedTo,
-        tags: task.tags,
-      };
+      const coordinator = await getSwarmCoordinator();
+      try {
+        const taskId = await coordinator.submitTask(built.task);
+        const task = coordinator.getTask(taskId);
+        if (!task) {
+          return { success: false, error: 'Task creation succeeded but task not found' };
+        }
+        return { success: true, ...projectTask(task) };
+      } catch (err) {
+        return { success: false, error: (err as Error).message };
+      }
     },
   },
   {
     name: 'task_status',
-    description: 'Get task status',
+    description: 'Get task status from the coordinator',
     category: 'task',
     inputSchema: {
       type: 'object',
@@ -127,54 +214,36 @@ export const taskTools: MCPTool[] = [
       required: ['taskId'],
     },
     handler: async (input) => {
-      const store = loadTaskStore();
-      const taskId = input.taskId as string;
-      const task = store.tasks[taskId];
-
-      if (task) {
-        return {
-          taskId: task.taskId,
-          type: task.type,
-          description: task.description,
-          status: task.status,
-          progress: task.progress,
-          priority: task.priority,
-          assignedTo: task.assignedTo,
-          tags: task.tags,
-          createdAt: task.createdAt,
-          startedAt: task.startedAt,
-          completedAt: task.completedAt,
-        };
+      const v = validateTaskId(input);
+      if (!v.ok) return { taskId: v.taskId, status: 'not_found', error: v.error };
+      const coordinator = await getSwarmCoordinator();
+      const task = coordinator.getTask(v.taskId);
+      if (!task) {
+        return { taskId: v.taskId, status: 'not_found', error: 'task_not_found' };
       }
-
-      return {
-        taskId,
-        status: 'not_found',
-        error: 'Task not found',
-      };
+      return projectTask(task);
     },
   },
   {
     name: 'task_list',
-    description: 'List all tasks',
+    description: 'List tasks with filters',
     category: 'task',
     inputSchema: {
       type: 'object',
       properties: {
-        status: { type: 'string', description: 'Filter by status' },
-        type: { type: 'string', description: 'Filter by type' },
-        assignedTo: { type: 'string', description: 'Filter by assigned agent' },
+        status: { type: 'string', description: 'Filter by status (comma-separated for multiple)' },
+        type: { type: 'string', description: 'Filter by task type' },
+        assignedTo: { type: 'string', description: 'Filter by assigned agent ID' },
         priority: { type: 'string', description: 'Filter by priority' },
-        limit: { type: 'number', description: 'Max tasks to return' },
+        limit: { type: 'number', description: 'Max tasks to return (default 50)' },
+        offset: { type: 'number', description: 'Skip first N results' },
       },
     },
     handler: async (input) => {
-      const store = loadTaskStore();
-      let tasks = Object.values(store.tasks);
+      const coordinator = await getSwarmCoordinator();
+      let tasks = coordinator.getAllTasks();
 
-      // Apply filters
       if (input.status) {
-        // Support comma-separated status values
         const statuses = (input.status as string).split(',').map(s => s.trim());
         tasks = tasks.filter(t => statuses.includes(t.status));
       }
@@ -182,116 +251,188 @@ export const taskTools: MCPTool[] = [
         tasks = tasks.filter(t => t.type === input.type);
       }
       if (input.assignedTo) {
-        tasks = tasks.filter(t => t.assignedTo.includes(input.assignedTo as string));
+        tasks = tasks.filter(t => t.assignedTo?.id === input.assignedTo);
       }
       if (input.priority) {
         tasks = tasks.filter(t => t.priority === input.priority);
       }
 
-      // Sort by creation date (newest first)
-      tasks.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      tasks.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 
-      // Apply limit
-      const limit = (input.limit as number) || 50;
-      tasks = tasks.slice(0, limit);
+      const total = tasks.length;
+      const offset = toNonNegativeInt(input.offset, 0);
+      const limitInput = toNonNegativeInt(input.limit, undefined);
+      const limit = limitInput && limitInput > 0 ? limitInput : 50;
+      const sliced = tasks.slice(offset, offset + limit);
 
       return {
-        tasks: tasks.map(t => ({
-          taskId: t.taskId,
-          type: t.type,
-          description: t.description,
-          status: t.status,
-          progress: t.progress,
-          priority: t.priority,
-          assignedTo: t.assignedTo,
-          createdAt: t.createdAt,
-        })),
-        total: tasks.length,
+        tasks: sliced.map(projectTask),
+        total,
+        returned: sliced.length,
         filters: {
           status: input.status,
           type: input.type,
           assignedTo: input.assignedTo,
           priority: input.priority,
+          limit,
+          offset,
         },
       };
     },
   },
   {
     name: 'task_complete',
-    description: 'Mark task as complete',
+    description: 'Mark a task as completed and record its result',
     category: 'task',
     inputSchema: {
       type: 'object',
       properties: {
         taskId: { type: 'string', description: 'Task ID' },
-        result: { type: 'object', description: 'Task result data' },
+        result: { description: 'Task result payload (any shape)' },
       },
       required: ['taskId'],
     },
     handler: async (input) => {
-      const store = loadTaskStore();
-      const taskId = input.taskId as string;
-      const task = store.tasks[taskId];
-
-      if (task) {
-        task.status = 'completed';
-        task.progress = 100;
-        task.completedAt = new Date().toISOString();
-        task.result = (input.result as Record<string, unknown>) || {};
-        saveTaskStore(store);
-
-        return {
-          taskId: task.taskId,
-          status: task.status,
-          completedAt: task.completedAt,
-          result: task.result,
-        };
+      const v = validateTaskId(input);
+      if (!v.ok) return { success: false, taskId: v.taskId, error: v.error };
+      const coordinator = await getSwarmCoordinator();
+      const outcome = await coordinator.completeTask(v.taskId, input.result);
+      if (!outcome.completed) {
+        return { success: false, taskId: v.taskId, error: outcome.reason };
       }
-
+      const task = coordinator.getTask(v.taskId);
       return {
-        taskId,
-        status: 'not_found',
-        error: 'Task not found',
+        success: true,
+        taskId: v.taskId,
+        status: task?.status ?? 'completed',
+        completedAt: task?.completedAt?.toISOString() ?? new Date().toISOString(),
+        result: task?.output,
       };
     },
   },
   {
     name: 'task_assign',
-    description: 'Assign a task to one or more agents',
+    description: 'Assign a task to a specific agent or to a domain pool',
     category: 'task',
     inputSchema: {
       type: 'object',
       properties: {
         taskId: { type: 'string', description: 'Task ID to assign' },
-        agentIds: { type: 'array', items: { type: 'string' }, description: 'Agent IDs to assign' },
-        unassign: { type: 'boolean', description: 'Unassign all agents from task' },
+        agentId: { type: 'string', description: 'Agent ID for direct assignment' },
+        domain: { type: 'string', description: `Domain to assign through (${[...AGENT_DOMAINS].join(' | ')})` },
       },
       required: ['taskId'],
     },
     handler: async (input) => {
-      const store = loadTaskStore();
-      const taskId = input.taskId as string;
-      const task = store.tasks[taskId];
+      const v = validateTaskId(input);
+      if (!v.ok) return { success: false, taskId: v.taskId, error: v.error };
+      const coordinator = await getSwarmCoordinator();
 
-      if (!task) {
-        return { taskId, error: 'Task not found' };
+      const agentId = input.agentId as string | undefined;
+      const domain = input.domain as string | undefined;
+
+      if (!agentId && !domain) {
+        return { success: false, taskId: v.taskId, error: 'Either agentId or domain must be provided' };
+      }
+      if (agentId && domain) {
+        return { success: false, taskId: v.taskId, error: 'Provide agentId or domain, not both' };
       }
 
-      const previouslyAssigned = [...task.assignedTo];
+      try {
+        if (agentId) {
+          const result = await coordinator.assignTaskToAgent(v.taskId, agentId);
+          if (!result.assigned) {
+            return { success: false, taskId: v.taskId, agentId, error: result.reason };
+          }
+          return { success: true, taskId: v.taskId, agentId, assignmentMode: 'direct' };
+        }
 
-      if (input.unassign) {
-        task.assignedTo = [];
-      } else {
-        const agentIds = (input.agentIds as string[]) || [];
-        task.assignedTo = agentIds;
+        if (!AGENT_DOMAINS.has(domain as AgentDomain)) {
+          return {
+            success: false,
+            taskId: v.taskId,
+            error: `domain must be one of: ${[...AGENT_DOMAINS].join(', ')}`,
+          };
+        }
+        const assignedAgent = await coordinator.assignTaskToDomain(v.taskId, domain as AgentDomain);
+        if (!assignedAgent) {
+          return {
+            success: true,
+            taskId: v.taskId,
+            domain,
+            assignmentMode: 'domain',
+            queued: true,
+            reason: 'no_available_agents',
+          };
+        }
+        return {
+          success: true,
+          taskId: v.taskId,
+          domain,
+          agentId: assignedAgent,
+          assignmentMode: 'domain',
+        };
+      } catch (err) {
+        return { success: false, taskId: v.taskId, error: (err as Error).message };
+      }
+    },
+  },
+  {
+    name: 'task_orchestrate',
+    description: 'Submit multiple tasks in one call; load-balanced across available agents',
+    category: 'task',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tasks: {
+          type: 'array',
+          description: 'Array of task definitions (same shape as task_create input)',
+          items: { type: 'object' },
+        },
+      },
+      required: ['tasks'],
+    },
+    handler: async (input) => {
+      const tasks = input.tasks;
+      if (!Array.isArray(tasks) || tasks.length === 0) {
+        return { success: false, error: 'tasks must be a non-empty array' };
       }
 
-      saveTaskStore(store);
+      const coordinator = await getSwarmCoordinator();
+      const accepted: TaskShape[] = [];
+      const rejected: Array<{ index: number; error: string }> = [];
+
+      // Sequential on purpose: coordinator's `assignTask` reads
+      // `getAvailableAgents()` then awaits a `messageBus.send` before flipping
+      // the chosen agent to 'busy'. Parallelizing this loop with Promise.all
+      // lets two submits observe the same idle agent and break the
+      // load-balancing AC ("5 tasks across 3 agents → no agent gets >2").
+      for (let i = 0; i < tasks.length; i++) {
+        const built = buildTaskInput(tasks[i] as Record<string, unknown>);
+        if (!built.ok) {
+          rejected.push({ index: i, error: built.error });
+          continue;
+        }
+        try {
+          const taskId = await coordinator.submitTask(built.task);
+          const task = coordinator.getTask(taskId);
+          if (task) accepted.push(projectTask(task));
+        } catch (err) {
+          rejected.push({ index: i, error: (err as Error).message });
+        }
+      }
+
+      const assignedCount = accepted.filter(t => t.assignedTo.length > 0).length;
+      const queuedCount = accepted.length - assignedCount;
 
       return {
-        taskId: task.taskId,
-        assignedTo: task.assignedTo,
-        previouslyAssigned,
+        success: rejected.length === 0,
+        submitted: accepted.length,
+        assigned: assignedCount,
+        queued: queuedCount,
+        rejected: rejected.length,
+        tasks: accepted,
+        errors: rejected,
       };
     },
   },
@@ -308,29 +449,29 @@ export const taskTools: MCPTool[] = [
       required: ['taskId'],
     },
     handler: async (input) => {
-      const store = loadTaskStore();
-      const taskId = input.taskId as string;
-      const task = store.tasks[taskId];
-
-      if (task) {
-        task.status = 'cancelled';
-        task.completedAt = new Date().toISOString();
-        task.result = { cancelReason: input.reason || 'Cancelled by user' };
-        saveTaskStore(store);
-
+      const v = validateTaskId(input);
+      if (!v.ok) return { success: false, taskId: v.taskId, error: v.error };
+      const coordinator = await getSwarmCoordinator();
+      const before = coordinator.getTask(v.taskId);
+      if (!before) {
+        return { success: false, taskId: v.taskId, error: 'task_not_found' };
+      }
+      try {
+        await coordinator.cancelTask(v.taskId);
+        const after = coordinator.getTask(v.taskId);
         return {
           success: true,
-          taskId: task.taskId,
-          status: task.status,
-          cancelledAt: task.completedAt,
+          taskId: v.taskId,
+          status: after?.status ?? 'cancelled',
+          cancelledAt: after?.completedAt?.toISOString() ?? new Date().toISOString(),
+          reason: (input.reason as string) || 'Cancelled by user',
         };
+      } catch (err) {
+        return { success: false, taskId: v.taskId, error: (err as Error).message };
       }
-
-      return {
-        success: false,
-        taskId,
-        error: 'Task not found',
-      };
     },
   },
 ];
+
+// Validation helpers exported for test reuse.
+export { TASK_TYPES, TASK_PRIORITIES, TASK_STATUSES, AGENT_DOMAINS };

--- a/src/cli/swarm/unified-coordinator.ts
+++ b/src/cli/swarm/unified-coordinator.ts
@@ -471,11 +471,103 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
     }
 
     task.status = 'cancelled';
+    task.completedAt = new Date();
 
     this.emitEvent('task.failed', {
       taskId,
       reason: 'cancelled',
     });
+  }
+
+  /**
+   * Public companion to the bus-driven `handleTaskComplete` path: lets a
+   * caller without a reporting agent finalize a task. Idempotent on
+   * already-completed tasks.
+   */
+  async completeTask(
+    taskId: string,
+    output?: unknown,
+  ): Promise<{ completed: boolean; reason?: string }> {
+    const task = this.state.tasks.get(taskId);
+    if (!task) {
+      return { completed: false, reason: 'task_not_found' };
+    }
+    if (task.status === 'completed') {
+      return { completed: true, reason: 'already_completed' };
+    }
+
+    task.status = 'completed';
+    task.output = output;
+    task.completedAt = new Date();
+
+    if (task.assignedTo) {
+      const agent = this.state.agents.get(task.assignedTo.id);
+      if (agent) {
+        agent.status = 'idle';
+        agent.currentTask = undefined;
+        agent.metrics.tasksCompleted++;
+      }
+    }
+
+    this.state.metrics.completedTasks++;
+
+    if (task.startedAt) {
+      const duration = task.completedAt.getTime() - task.startedAt.getTime();
+      this.state.metrics.avgTaskDurationMs =
+        (this.state.metrics.avgTaskDurationMs * 0.9) + (duration * 0.1);
+    }
+
+    this.emitEvent('task.completed', {
+      taskId,
+      agentId: task.assignedTo?.id,
+      result: output,
+    });
+
+    return { completed: true };
+  }
+
+  /**
+   * Direct-target counterpart to the auto-scheduler `assignTask` and the
+   * domain-routed `assignTaskToDomain`: caller already knows the agent.
+   * Re-assignment releases the previously assigned agent if any.
+   */
+  async assignTaskToAgent(
+    taskId: string,
+    agentId: string,
+  ): Promise<{ assigned: boolean; reason?: string }> {
+    const task = this.state.tasks.get(taskId);
+    if (!task) return { assigned: false, reason: 'task_not_found' };
+
+    const agent = this.state.agents.get(agentId);
+    if (!agent) return { assigned: false, reason: 'agent_not_found' };
+    if (agent.status === 'terminated') return { assigned: false, reason: 'agent_terminated' };
+
+    if (task.assignedTo && task.assignedTo.id !== agentId) {
+      const previous = this.state.agents.get(task.assignedTo.id);
+      if (previous) {
+        previous.status = 'idle';
+        previous.currentTask = undefined;
+      }
+    }
+
+    task.assignedTo = agent.id;
+    task.status = 'assigned';
+    task.startedAt = task.startedAt ?? new Date();
+    agent.status = 'busy';
+    agent.currentTask = task.id;
+
+    await this.messageBus.send({
+      type: 'task_assign',
+      from: this.state.id.id,
+      to: agent.id.id,
+      payload: { task },
+      priority: this.mapTaskPriorityToMessagePriority(task.priority),
+      requiresAck: true,
+      ttlMs: this.config.taskTimeoutMs,
+    });
+
+    this.emitEvent('task.assigned', { taskId, agentId });
+    return { assigned: true };
   }
 
   getTask(taskId: string): TaskDefinition | undefined {
@@ -868,7 +960,7 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
 
     switch (message.type) {
       case 'task_complete':
-        this.handleTaskComplete(agentId, message.payload as { taskId: string; result: unknown });
+        void this.handleTaskComplete(agentId, message.payload as { taskId: string; result: unknown });
         break;
       case 'task_fail':
         this.handleTaskFail(agentId, message.payload as { taskId: string; error: string });
@@ -882,34 +974,14 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
     }
   }
 
-  private handleTaskComplete(agentId: string, data: { taskId: string; result: unknown }): void {
-    const task = this.state.tasks.get(data.taskId);
-    const agent = this.state.agents.get(agentId);
-
-    if (task && agent) {
-      task.status = 'completed';
-      task.output = data.result;
-      task.completedAt = new Date();
-
-      agent.status = 'idle';
-      agent.currentTask = undefined;
-      agent.metrics.tasksCompleted++;
-
-      this.state.metrics.completedTasks++;
-
-      // Update average task duration
-      if (task.startedAt) {
-        const duration = task.completedAt.getTime() - task.startedAt.getTime();
-        this.state.metrics.avgTaskDurationMs =
-          (this.state.metrics.avgTaskDurationMs * 0.9) + (duration * 0.1);
-      }
-
-      this.emitEvent('task.completed', {
-        taskId: data.taskId,
-        agentId,
-        result: data.result,
-      });
-    }
+  private async handleTaskComplete(
+    agentId: string,
+    data: { taskId: string; result: unknown },
+  ): Promise<void> {
+    // Bus path: only finalize if the reporting agent is known. `completeTask`
+    // is permissive (operates without an assigned agent), so guard here.
+    if (!this.state.agents.has(agentId)) return;
+    await this.completeTask(data.taskId, data.result);
   }
 
   private handleTaskFail(agentId: string, data: { taskId: string; error: string }): void {

--- a/src/cli/swarm/unified-coordinator.ts
+++ b/src/cli/swarm/unified-coordinator.ts
@@ -550,6 +550,17 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       }
     }
 
+    await this.bindTaskToAgent(task, agent);
+    return { assigned: true };
+  }
+
+  /**
+   * Mutate task + agent into the 'assigned/busy' pair and notify the agent
+   * via the message bus. Shared by `assignTask` (auto-scheduler) and
+   * `assignTaskToAgent` (direct caller). Caller is responsible for any
+   * pre-checks (capacity, prior-agent release, domain bookkeeping).
+   */
+  private async bindTaskToAgent(task: TaskDefinition, agent: AgentState): Promise<void> {
     task.assignedTo = agent.id;
     task.status = 'assigned';
     task.startedAt = task.startedAt ?? new Date();
@@ -566,8 +577,10 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       ttlMs: this.config.taskTimeoutMs,
     });
 
-    this.emitEvent('task.assigned', { taskId, agentId });
-    return { assigned: true };
+    this.emitEvent('task.assigned', {
+      taskId: task.id.id,
+      agentId: agent.id.id,
+    });
   }
 
   getTask(taskId: string): TaskDefinition | undefined {
@@ -865,28 +878,7 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       return undefined;
     }
 
-    // Assign task
-    task.assignedTo = bestAgent.id;
-    task.status = 'assigned';
-    bestAgent.status = 'busy';
-    bestAgent.currentTask = task.id;
-
-    // Notify agent via message bus
-    await this.messageBus.send({
-      type: 'task_assign',
-      from: this.state.id.id,
-      to: bestAgent.id.id,
-      payload: { task },
-      priority: this.mapTaskPriorityToMessagePriority(task.priority),
-      requiresAck: true,
-      ttlMs: this.config.taskTimeoutMs,
-    });
-
-    this.emitEvent('task.assigned', {
-      taskId: task.id.id,
-      agentId: bestAgent.id.id,
-    });
-
+    await this.bindTaskToAgent(task, bestAgent);
     return bestAgent;
   }
 


### PR DESCRIPTION
## Summary

Story 7 of [epic #798](https://github.com/eric-cielo/moflo/issues/798) — wires the `task_*` MCP tool family to `UnifiedSwarmCoordinator`, replacing the JSON-store stubs in `<root>/.moflo/tasks/`. `task_orchestrate` is new (Ruflo parity).

- **`task_create`** → `coordinator.submitTask` (auto-scoring scheduler)
- **`task_assign`** → `coordinator.assignTaskToAgent` (direct agentId) or `assignTaskToDomain` (domain pool)
- **`task_orchestrate`** → batch submit, sequential by design (see below)
- **`task_complete`** → new public `coordinator.completeTask(taskId, output?)`
- **`task_status`** / **`task_list`** → coordinator queries, not file reads
- **`task_cancel`** → `coordinator.cancelTask` (now records `completedAt`)

## Coordinator changes

- New public `completeTask(taskId, output?)` — finalize tasks for callers without a reporting agent (e.g. MCP). Idempotent on already-completed.
- New public `assignTaskToAgent(taskId, agentId)` — direct-target assignment with prior-agent release.
- Private `handleTaskComplete` (bus path) now delegates to `completeTask` (DRY).
- Private `bindTaskToAgent` shared by the auto-scheduler and the direct-target paths.

## Why `task_orchestrate` is sequential

`coordinator.submitTask → assignTask` reads `getAvailableAgents()` then awaits a `messageBus.send` before flipping the chosen agent to `'busy'`. Parallelizing the orchestrate loop with `Promise.all` would let two submits observe the same idle agent and break the AC ("5 tasks across 3 agents → no agent gets >2"). Comment in code protects future refactors.

## Tests

- `src/cli/__tests__/mcp-tools/task-pipeline.test.ts` — 16 tests covering create → assign → status → complete → cancel.
- `src/cli/__tests__/mcp-tools/task-orchestrate.test.ts` — 5 tests including the AC's load-balanced spread.
- Updated 2 stale assertions in `mcp-tools-deep.test.ts` (old stub used `'feature'`/`'pending'` which aren't in the `TaskType` / `TaskStatus` unions).
- `task_orchestrate` documented in `.claude/skills/swarm-advanced/SKILL.md` to satisfy the drift guard.

Promoted `toNonNegativeInt` from `agent-tools.ts` to a shared export and reused in `task_list` pagination.

## Test plan

- [x] `npx vitest run src/cli/__tests__/mcp-tools/` — 73/73 pass
- [x] `npx vitest run src/cli/__tests__/swarm/` — 193/193 pass
- [x] `npx vitest run src/cli/__tests__/mcp-tools-drift-guard.test.ts` — 4/4 pass
- [x] `npm run build` — clean

Closes #805.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)