### PR TITLE
ci: bump checkout/setup-node/cache to v5 (native Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,6 @@ on:
 
 env:
   NODE_VERSION: '22'
-  # Forces bundled JS actions (checkout, setup-node, cache, etc.) to run on
-  # Node 24 instead of their pinned Node 20 runtime. Silences the GitHub-wide
-  # Node 20 deprecation warning ahead of the 2026-06-02 forced cutover.
-  # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -21,9 +16,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -48,9 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -63,7 +58,7 @@ jobs:
       # download, exactly what the cache exists to amortize.
       # See ADR-EMB-001 and epic #527.
       - name: Cache fastembed model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/fastembed
           key: fastembed-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-fast-all-MiniLM-L6-v2
@@ -88,9 +83,9 @@ jobs:
     name: Lint & Security
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -19,11 +19,6 @@ on:
 
 env:
   NODE_VERSION: '22'
-  # Forces bundled JS actions (checkout, setup-node, cache, etc.) to run on
-  # Node 24 instead of their pinned Node 20 runtime. Silences the GitHub-wide
-  # Node 20 deprecation warning ahead of the 2026-06-02 forced cutover.
-  # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # Cancel superseded PR runs but never cancel an in-flight push to main:
 # a half-finished smoke on main leaves the branch in an unverified state and
@@ -44,9 +39,9 @@ jobs:
     # so a stuck install can't hold the queue.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -57,7 +52,7 @@ jobs:
       # partial prefix matches could restore the wrong model's binary blobs
       # on a future model swap. See ADR-EMB-001 / epic #527.
       - name: Cache fastembed model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/fastembed
           key: fastembed-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-fast-all-MiniLM-L6-v2

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -15,11 +15,6 @@ on:
 
 env:
   IMAGE: ghcr.io/eric-cielo/moflo-sandbox
-  # Forces bundled JS actions (checkout, etc.) to run on Node 24 instead of
-  # their pinned Node 20 runtime. Silences the Node 20 deprecation warning
-  # ahead of the 2026-06-02 forced cutover.
-  # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # Don't cancel in-flight publishes — a mid-push abort can leave partial manifests
 # on the registry. ci.yml uses cancel-in-progress: true because PR builds are
@@ -36,7 +31,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
           sparse-checkout: docker/sandbox


### PR DESCRIPTION
## Summary

Third attempt at silencing the Node 20 deprecation warning that fires at the end of every job on ubuntu/macos/windows. Previous two missed the actual mechanism:

- **Attempt 1 (#671)** bumped `NODE_VERSION` to 22 — wrong layer (that's the runtime *user code* runs on, not the bundled JS-action runtime).
- **Attempt 2 (#725)** added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`. That env var DOES upgrade the actions to Node 24 at runtime, but [actions/runner#4295](https://github.com/actions/runner/issues/4295) is an open bug: the end-of-job deprecation annotation iterates the deprecated-actions list (built from declared `using: node20`) BEFORE the version-upgrade check runs, so the warning still fires misleadingly even though execution is on Node 24. A runtime workaround cannot silence a static-analysis warning.

**Real fix** — bump to action versions that natively declare `using: node24`, removing the actions from the deprecated list entirely:

| Action | Old | New | First Node 24 release |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | [v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0) |
| `actions/setup-node` | v4 | v5 | [v5.0.0](https://github.com/actions/setup-node/releases/tag/v5.0.0) |
| `actions/cache` | v4 | v5 | [v5.0.0](https://github.com/actions/cache/releases/tag/v5.0.0) |

Also drops the now-redundant `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env block (and its 4-line explanatory comment) from all three workflows.

Affected workflows: `ci.yml`, `sandbox-image.yml`, `consumer-install-smoke.yml` (the matrix that fans out to ubuntu/windows/macos — where the user observed the warning).

## Test plan

- [ ] CI green on this PR
- [ ] No "Node.js 20 is deprecated" annotation at the end of any job (build / test / lint)
- [ ] consumer-install-smoke passes on all three OSes (ubuntu/macos/windows) with no deprecation annotation
- [ ] sandbox-image build succeeds on push to main (post-merge verification)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)