### PR TITLE
feat(806): write-through persistence for swarm coordinator

### DIFF
--- a/src/cli/__tests__/swarm/persistence.test.ts
+++ b/src/cli/__tests__/swarm/persistence.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Story #806 — Swarm restart persistence.
+ *
+ * Verifies that agents/topology survive `_resetSwarmCoordinatorForTest()`
+ * (the test analogue of an MCP-server restart) when an in-memory persistence
+ * backend is wired into the singleton.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetSwarmCoordinatorForTest,
+  _setSwarmPersistenceForTest,
+  getSwarmCoordinator,
+} from '../../mcp-tools/swarm-coordinator-singleton.js';
+import { agentTools } from '../../mcp-tools/agent-tools.js';
+import {
+  SWARM_AGENTS_NS,
+  SWARM_TOPOLOGY_NS,
+  SwarmPersistence,
+  type SwarmMemoryFns,
+} from '../../swarm/swarm-persistence.js';
+
+interface FakeRow {
+  key: string;
+  namespace: string;
+  content: string;
+}
+
+/**
+ * sql.js-free fake persistence backend. Captures every storeEntry/deleteEntry
+ * call across coordinator boots so tests can assert the same writes that
+ * would have hit moflo.db in production.
+ */
+function createInMemoryFns(): { fns: SwarmMemoryFns; rows: Map<string, FakeRow> } {
+  const rows = new Map<string, FakeRow>();
+  const compositeKey = (namespace: string, key: string) => `${namespace}::${key}`;
+
+  const fns: SwarmMemoryFns = {
+    async storeEntry(opts) {
+      rows.set(compositeKey(opts.namespace, opts.key), {
+        key: opts.key,
+        namespace: opts.namespace,
+        content: opts.value,
+      });
+      return { success: true, id: `id_${rows.size}` };
+    },
+    async getEntry(opts) {
+      const ns = opts.namespace ?? 'default';
+      const row = rows.get(compositeKey(ns, opts.key));
+      if (!row) return { success: true, found: false };
+      return { success: true, found: true, entry: { content: row.content } };
+    },
+    async listEntries(opts) {
+      const ns = opts.namespace;
+      const entries = ns
+        ? Array.from(rows.values()).filter(r => r.namespace === ns)
+        : Array.from(rows.values());
+      return {
+        success: true,
+        entries: entries.map(r => ({ key: r.key })),
+        total: entries.length,
+      };
+    },
+    async deleteEntry(opts) {
+      const ns = opts.namespace ?? 'default';
+      const existed = rows.delete(compositeKey(ns, opts.key));
+      return { success: true, deleted: existed };
+    },
+  };
+
+  return { fns, rows };
+}
+
+function getAgentTool(name: string) {
+  const tool = agentTools.find(t => t.name === name);
+  if (!tool) throw new Error(`agent tool "${name}" not registered`);
+  return tool;
+}
+
+describe('Swarm restart persistence (story #806)', () => {
+  let backend: ReturnType<typeof createInMemoryFns>;
+
+  beforeEach(() => {
+    backend = createInMemoryFns();
+    _setSwarmPersistenceForTest(new SwarmPersistence(backend.fns));
+  });
+
+  afterEach(async () => {
+    _setSwarmPersistenceForTest(null);
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('writes spawned agents into the swarm-agents namespace', async () => {
+    const spawn = getAgentTool('agent_spawn');
+    const result = (await spawn.handler({ agentType: 'coder' })) as { success: boolean; agentId: string };
+    expect(result.success).toBe(true);
+
+    const agentRows = Array.from(backend.rows.values()).filter(r => r.namespace === SWARM_AGENTS_NS);
+    expect(agentRows.length).toBe(1);
+    expect(agentRows[0].key).toBe(`agent:${result.agentId}`);
+
+    const parsed = JSON.parse(agentRows[0].content);
+    expect(parsed.id).toBe(result.agentId);
+    expect(parsed.type).toBe('coder');
+    expect(parsed.domain).toBe('core');
+  });
+
+  it('restarts spawn → reset → re-init and recovers both agents', async () => {
+    const spawn = getAgentTool('agent_spawn');
+    const list = getAgentTool('agent_list');
+
+    const a1 = (await spawn.handler({ agentType: 'coder' })) as { agentId: string };
+    const a2 = (await spawn.handler({ agentType: 'researcher' })) as { agentId: string };
+    expect(a1.agentId).toBeTruthy();
+    expect(a2.agentId).toBeTruthy();
+
+    // Sanity: both rows are persisted before we kill the coordinator.
+    const before = Array.from(backend.rows.values()).filter(r => r.namespace === SWARM_AGENTS_NS);
+    expect(before.length).toBe(2);
+
+    // Simulate MCP-server restart — drop the in-memory coordinator and re-boot.
+    await _resetSwarmCoordinatorForTest();
+
+    const listed = (await list.handler({})) as {
+      agents: Array<{ agentId: string; agentType: string }>;
+      total: number;
+    };
+
+    expect(listed.total).toBe(2);
+    const ids = listed.agents.map(a => a.agentId).sort();
+    expect(ids).toEqual([a1.agentId, a2.agentId].sort());
+    const types = listed.agents.map(a => a.agentType).sort();
+    expect(types).toEqual(['coder', 'researcher']);
+  });
+
+  it('removes terminated agents from the persisted set', async () => {
+    const spawn = getAgentTool('agent_spawn');
+    const terminate = getAgentTool('agent_terminate');
+
+    const a1 = (await spawn.handler({ agentType: 'tester' })) as { agentId: string };
+    const a2 = (await spawn.handler({ agentType: 'reviewer' })) as { agentId: string };
+
+    const term = (await terminate.handler({ agentId: a1.agentId, force: true })) as {
+      success: boolean;
+    };
+    expect(term.success).toBe(true);
+
+    const remaining = Array.from(backend.rows.values()).filter(r => r.namespace === SWARM_AGENTS_NS);
+    expect(remaining.length).toBe(1);
+    expect(remaining[0].key).toBe(`agent:${a2.agentId}`);
+
+    await _resetSwarmCoordinatorForTest();
+
+    const list = getAgentTool('agent_list');
+    const listed = (await list.handler({})) as { agents: Array<{ agentId: string }>; total: number };
+    expect(listed.total).toBe(1);
+    expect(listed.agents[0].agentId).toBe(a2.agentId);
+  });
+
+  it('persists a topology snapshot under swarm-topology', async () => {
+    const spawn = getAgentTool('agent_spawn');
+    await spawn.handler({ agentType: 'coder' });
+    await spawn.handler({ agentType: 'reviewer' });
+
+    // Topology writes are microtask-debounced + fire-and-forget; yield until
+    // a row appears (capped) so the test isn't racing the write.
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const hasRow = Array.from(backend.rows.values()).some(
+        r => r.namespace === SWARM_TOPOLOGY_NS,
+      );
+      if (hasRow) break;
+      await new Promise(resolve => setTimeout(resolve, 5));
+    }
+
+    const topologyRows = Array.from(backend.rows.values()).filter(
+      r => r.namespace === SWARM_TOPOLOGY_NS,
+    );
+    expect(topologyRows.length).toBeGreaterThan(0);
+    const snapshot = JSON.parse(topologyRows[0].content);
+    expect(snapshot.type).toBeDefined();
+    expect(snapshot.nodeCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('runs cleanly when no persistence backend is wired', async () => {
+    // Override path: explicitly clear and re-boot. With the test-only override
+    // null'd and no real memory backend in this isolated process, the
+    // coordinator must still spawn agents in-memory.
+    _setSwarmPersistenceForTest(null);
+    await _resetSwarmCoordinatorForTest();
+
+    // Directly drive the coordinator (bypass MCP path so the singleton can't
+    // re-attach the test fake from a previous turn).
+    const coord = await getSwarmCoordinator();
+    const spawned = await coord.spawnAgent({ type: 'worker' });
+    expect(spawned.spawned).toBe(true);
+    expect(coord.getAgent(spawned.agentId)).toBeDefined();
+  });
+});

--- a/src/cli/mcp-tools/swarm-coordinator-singleton.ts
+++ b/src/cli/mcp-tools/swarm-coordinator-singleton.ts
@@ -10,9 +10,17 @@ import {
   createUnifiedSwarmCoordinator,
 } from '../swarm/unified-coordinator.js';
 import type { CoordinatorConfig } from '../swarm/types.js';
+import { SwarmPersistence, type SwarmMemoryFns } from '../swarm/swarm-persistence.js';
 
 let _coordinator: UnifiedSwarmCoordinator | null = null;
 let _initPromise: Promise<UnifiedSwarmCoordinator> | null = null;
+
+/**
+ * Test-only override for the persistence backend. When set, replaces the
+ * memory-initializer-backed persistence on the next coordinator boot. Lets
+ * tests inject an in-memory fake without touching sql.js or process.cwd.
+ */
+let _persistenceOverride: SwarmPersistence | null = null;
 
 /**
  * Get the singleton swarm coordinator, lazy-initializing on first call.
@@ -39,6 +47,21 @@ export async function getSwarmCoordinator(
   _initPromise = (async () => {
     const coord = createUnifiedSwarmCoordinator(config);
     await coord.initialize();
+
+    // Story #806 — write-through persistence + restart hydration.
+    // attachPersistence() and the hydrate are best-effort: a missing memory
+    // backend logs nothing and leaves the coordinator running in-memory only.
+    const persistence = _persistenceOverride ?? (await loadPersistence());
+    if (persistence) {
+      coord.attachPersistence(persistence);
+      try {
+        await coord.hydrateFromPersistence();
+      } catch {
+        // Hydration failures must not block coordinator boot — restart-recovery
+        // is opportunistic durability, not a hard precondition.
+      }
+    }
+
     _coordinator = coord;
     return coord;
   })();
@@ -61,6 +84,14 @@ export function isSwarmCoordinatorInitialized(): boolean {
 }
 
 /**
+ * Test-only persistence override. Pass `null` to clear. Must be called before
+ * the next `getSwarmCoordinator()` to take effect on that boot.
+ */
+export function _setSwarmPersistenceForTest(p: SwarmPersistence | null): void {
+  _persistenceOverride = p;
+}
+
+/**
  * Test-only reset hook. Awaits shutdown so timers and listeners are torn down
  * before the next test's coordinator boots — fire-and-forget would leak
  * intervals across the suite.
@@ -75,5 +106,29 @@ export async function _resetSwarmCoordinatorForTest(): Promise<void> {
     } catch {
       // Swallow: test teardown should not fail because shutdown raced.
     }
+  }
+}
+
+async function loadPersistence(): Promise<SwarmPersistence | undefined> {
+  // Tests opt in via `_setSwarmPersistenceForTest`. Auto-loading the
+  // memory-initializer in test contexts pulls in sql.js + the dogfood DB and
+  // adds multi-second boot latency to every singleton-using test. Skip it.
+  if (process.env.VITEST || process.env.NODE_ENV === 'test') {
+    return undefined;
+  }
+
+  try {
+    const mem = await import('../memory/memory-initializer.js');
+    const fns: SwarmMemoryFns = {
+      storeEntry: mem.storeEntry as SwarmMemoryFns['storeEntry'],
+      getEntry: mem.getEntry as SwarmMemoryFns['getEntry'],
+      listEntries: mem.listEntries as SwarmMemoryFns['listEntries'],
+      deleteEntry: mem.deleteEntry as SwarmMemoryFns['deleteEntry'],
+    };
+    return new SwarmPersistence(fns);
+  } catch {
+    // Memory backend not available in this process — skip persistence rather
+    // than crash. Mirrors hive-mind-tools' write-through fallback.
+    return undefined;
   }
 }

--- a/src/cli/swarm/swarm-persistence.ts
+++ b/src/cli/swarm/swarm-persistence.ts
@@ -1,0 +1,231 @@
+/**
+ * Swarm Persistence Layer (Story #806 — Epic #798)
+ *
+ * Continues the Story #121 hive-mind pattern: writes coordinator state through
+ * to moflo.db so the swarm survives MCP-server restart. Decoupled from the
+ * coordinator via dependency injection so tests can substitute an in-memory
+ * fake without touching sql.js.
+ */
+
+import type {
+  AgentCapabilities,
+  AgentMetrics,
+  AgentState,
+  AgentStatus,
+  AgentType,
+  ConsensusResult,
+  TopologyState,
+} from './types.js';
+import type { AgentDomain } from './unified-coordinator.js';
+
+export const SWARM_AGENTS_NS = 'swarm-agents' as const;
+export const SWARM_TOPOLOGY_NS = 'swarm-topology' as const;
+export const SWARM_CONSENSUS_NS = 'swarm-consensus' as const;
+
+const AGENT_KEY_PREFIX = 'agent:';
+const PROPOSAL_KEY_PREFIX = 'proposal:';
+const TOPOLOGY_KEY = 'current';
+
+/** Memory-DB primitives the coordinator needs. Mirrors memory-initializer.ts. */
+export interface SwarmMemoryFns {
+  storeEntry: (opts: {
+    key: string;
+    value: string;
+    namespace: string;
+    tags?: string[];
+    upsert?: boolean;
+    generateEmbeddingFlag?: boolean;
+  }) => Promise<{ success: boolean; id: string; error?: string }>;
+  getEntry: (opts: {
+    key: string;
+    namespace?: string;
+  }) => Promise<{ success: boolean; found: boolean; entry?: { content: string } }>;
+  listEntries: (opts: {
+    namespace?: string;
+    limit?: number;
+    offset?: number;
+  }) => Promise<{ success: boolean; entries: Array<{ key: string }>; total: number }>;
+  deleteEntry: (opts: {
+    key: string;
+    namespace?: string;
+  }) => Promise<{ success: boolean; deleted: boolean }>;
+}
+
+export interface PersistedAgent {
+  id: string;
+  type: AgentType;
+  name: string;
+  status: AgentStatus;
+  capabilities: AgentCapabilities;
+  metrics: Omit<AgentMetrics, 'lastActivity'> & { lastActivity: string };
+  workload: number;
+  health: number;
+  domain?: AgentDomain;
+}
+
+export interface PersistedTopology {
+  type: TopologyState['type'];
+  nodeCount: number;
+  edgeCount: number;
+  partitionCount: number;
+  leader?: string;
+}
+
+export interface PersistedConsensus {
+  proposalId: string;
+  approved: boolean;
+  approvalRate: number;
+  decidedAt: string;
+}
+
+/**
+ * Thin write/read facade over `SwarmMemoryFns`. Writes are fire-and-forget so
+ * a failed/missing memory backend never blocks the in-memory coordinator —
+ * persistence is best-effort durability, not a hot-path dependency.
+ */
+export class SwarmPersistence {
+  private fns: SwarmMemoryFns;
+  private lastTopologyJson?: string;
+
+  constructor(fns: SwarmMemoryFns) {
+    this.fns = fns;
+  }
+
+  async persistAgent(agent: AgentState, domain?: AgentDomain): Promise<void> {
+    const record: PersistedAgent = {
+      id: agent.id.id,
+      type: agent.type,
+      name: agent.name,
+      status: agent.status,
+      capabilities: agent.capabilities,
+      metrics: {
+        ...agent.metrics,
+        lastActivity: agent.metrics.lastActivity.toISOString(),
+      },
+      workload: agent.workload,
+      health: agent.health,
+      domain,
+    };
+    await this.safeStore(`${AGENT_KEY_PREFIX}${agent.id.id}`, SWARM_AGENTS_NS, record, [
+      'swarm', 'agent', agent.type,
+    ]);
+  }
+
+  async removeAgent(agentId: string): Promise<void> {
+    try {
+      await this.fns.deleteEntry({
+        key: `${AGENT_KEY_PREFIX}${agentId}`,
+        namespace: SWARM_AGENTS_NS,
+      });
+    } catch { /* best-effort */ }
+  }
+
+  async persistTopology(topology: TopologyState): Promise<void> {
+    const snapshot: PersistedTopology = {
+      type: topology.type,
+      nodeCount: topology.nodes.length,
+      edgeCount: topology.edges.length,
+      partitionCount: topology.partitions.length,
+      leader: topology.leader,
+    };
+
+    // Skip the upsert when nothing changed since the last write — most spawn
+    // bursts emit node.added + topology.rebalanced back-to-back which would
+    // otherwise produce two identical rows.
+    const json = JSON.stringify(snapshot);
+    if (json === this.lastTopologyJson) return;
+    this.lastTopologyJson = json;
+
+    await this.safeStore(TOPOLOGY_KEY, SWARM_TOPOLOGY_NS, snapshot, ['swarm', 'topology']);
+  }
+
+  async persistConsensus(result: ConsensusResult): Promise<void> {
+    const record: PersistedConsensus = {
+      proposalId: result.proposalId,
+      approved: result.approved,
+      approvalRate: result.approvalRate,
+      decidedAt: new Date().toISOString(),
+    };
+    await this.safeStore(
+      `${PROPOSAL_KEY_PREFIX}${result.proposalId}`,
+      SWARM_CONSENSUS_NS,
+      record,
+      ['swarm', 'consensus', result.approved ? 'approved' : 'rejected'],
+    );
+  }
+
+  async loadAgents(): Promise<PersistedAgent[]> {
+    return this.loadList<PersistedAgent>(
+      SWARM_AGENTS_NS,
+      AGENT_KEY_PREFIX,
+      (r): boolean => {
+        const rec = r as Partial<PersistedAgent>;
+        return typeof rec.id === 'string' && typeof rec.type === 'string';
+      },
+    );
+  }
+
+  async loadTopology(): Promise<PersistedTopology | undefined> {
+    try {
+      const got = await this.fns.getEntry({ key: TOPOLOGY_KEY, namespace: SWARM_TOPOLOGY_NS });
+      if (!got.success || !got.found || !got.entry?.content) return undefined;
+      return JSON.parse(got.entry.content) as PersistedTopology;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async loadConsensusHistory(limit = 50): Promise<PersistedConsensus[]> {
+    return this.loadList<PersistedConsensus>(SWARM_CONSENSUS_NS, PROPOSAL_KEY_PREFIX, undefined, limit);
+  }
+
+  private async safeStore(
+    key: string,
+    namespace: string,
+    record: unknown,
+    tags: string[],
+  ): Promise<void> {
+    try {
+      await this.fns.storeEntry({
+        key,
+        value: JSON.stringify(record),
+        namespace,
+        tags,
+        upsert: true,
+        // High-churn lifecycle records — skip embedding to avoid hot-path
+        // model loads. They're keyed lookups, not semantic search targets.
+        generateEmbeddingFlag: false,
+      });
+    } catch {
+      // Best-effort: never let persistence failures crash the in-memory swarm.
+    }
+  }
+
+  private async loadList<T>(
+    namespace: string,
+    keyPrefix: string,
+    isValid?: (record: unknown) => boolean,
+    limit = 1000,
+  ): Promise<T[]> {
+    try {
+      const list = await this.fns.listEntries({ namespace, limit });
+      if (!list.success) return [];
+
+      const records: T[] = [];
+      for (const entry of list.entries) {
+        if (!entry.key.startsWith(keyPrefix)) continue;
+        const got = await this.fns.getEntry({ key: entry.key, namespace });
+        if (!got.success || !got.found || !got.entry?.content) continue;
+        try {
+          const parsed = JSON.parse(got.entry.content);
+          if (!isValid || isValid(parsed)) {
+            records.push(parsed as T);
+          }
+        } catch { /* drop malformed records */ }
+      }
+      return records;
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/cli/swarm/unified-coordinator.ts
+++ b/src/cli/swarm/unified-coordinator.ts
@@ -50,6 +50,7 @@ import { TopologyManager, createTopologyManager } from './topology-manager.js';
 import { MessageBus } from './message-bus.js';
 import { AgentPool, createAgentPool } from './agent-pool.js';
 import { ConsensusEngine, createConsensusEngine } from './consensus/index.js';
+import { SwarmPersistence, type PersistedAgent } from './swarm-persistence.js';
 
 // =============================================================================
 // Domain Types for 15-Agent Hierarchy
@@ -159,6 +160,10 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
   private heartbeatInterval?: NodeJS.Timeout;
   private healthCheckInterval?: NodeJS.Timeout;
   private metricsInterval?: NodeJS.Timeout;
+
+  // Optional write-through persistence; missing-backend safe.
+  private persistence?: SwarmPersistence;
+  private topologyPersistScheduled = false;
 
   constructor(config: Partial<CoordinatorConfig> = {}) {
     super();
@@ -298,7 +303,7 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
 
   async registerAgent(
     agentData: Omit<AgentState, 'id'>,
-    options?: { id?: string },
+    options?: { id?: string; skipPersist?: boolean },
   ): Promise<string> {
     const startTime = performance.now();
 
@@ -348,6 +353,9 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       registrationDurationMs: duration,
     });
 
+    if (!options?.skipPersist) {
+      void this.syncAgentToPersistence(agentId.id);
+    }
     return agentId.id;
   }
 
@@ -370,6 +378,7 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
     // Remove from state
     this.state.agents.delete(agentId);
 
+    void this.removeAgentFromPersistence(agentId);
     this.emitEvent('agent.left', { agentId });
   }
 
@@ -801,28 +810,115 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
   }
 
   private setupEventForwarding(): void {
-    // Forward topology events
+    // All three topology events trigger the same persist; the microtask
+    // debounce in `scheduleTopologyPersist` collapses bursts (e.g. addNode +
+    // its conditional rebalance) into a single upsert.
     this.topologyManager.on('node.added', (data) => {
       this.emitEvent('topology.updated', { action: 'node_added', ...data });
+      this.scheduleTopologyPersist();
     });
 
     this.topologyManager.on('node.removed', (data) => {
       this.emitEvent('topology.updated', { action: 'node_removed', ...data });
+      this.scheduleTopologyPersist();
     });
 
     this.topologyManager.on('topology.rebalanced', (data) => {
       this.emitEvent('topology.rebalanced', data);
+      this.scheduleTopologyPersist();
     });
 
-    // Forward consensus events
     this.consensusEngine.on('consensus.achieved', (data) => {
       this.state.metrics.consensusSuccessRate =
         (this.state.metrics.consensusSuccessRate * 0.9) + (data.approved ? 0.1 : 0);
+      if (this.persistence && data && typeof data.proposalId === 'string') {
+        void this.persistence.persistConsensus(data);
+      }
     });
 
-    // Forward message bus events
     this.messageBus.on('message.delivered', (data) => {
       this.emitEvent('message.received', data);
+    });
+  }
+
+  // ===== Persistence integration (story #806) =====
+
+  attachPersistence(persistence: SwarmPersistence): void {
+    this.persistence = persistence;
+  }
+
+  /** Replay persisted agents + topology into the live coordinator. */
+  async hydrateFromPersistence(): Promise<{ agents: number; topology: boolean }> {
+    if (!this.persistence) return { agents: 0, topology: false };
+
+    let restoredAgents = 0;
+    const records = await this.persistence.loadAgents();
+    for (const record of records) {
+      // Skip ids already present so the hydrate is safe to call repeatedly.
+      if (this.state.agents.has(record.id)) continue;
+      try {
+        await this.restoreAgent(record);
+        restoredAgents++;
+      } catch {
+        // Drop unrecoverable records rather than failing the whole hydrate.
+      }
+    }
+
+    const topology = await this.persistence.loadTopology();
+    return { agents: restoredAgents, topology: topology !== undefined };
+  }
+
+  private async restoreAgent(record: PersistedAgent): Promise<void> {
+    const agentData: Omit<AgentState, 'id'> = {
+      name: record.name,
+      type: record.type,
+      status: record.status,
+      capabilities: record.capabilities,
+      metrics: {
+        ...record.metrics,
+        lastActivity: new Date(record.metrics.lastActivity),
+      },
+      workload: record.workload,
+      health: record.health,
+      lastHeartbeat: new Date(),
+      topologyRole: record.type === 'queen' ? 'queen' : 'worker',
+      connections: [],
+    };
+
+    // Re-issue with the original id so cross-restart references survive, and
+    // suppress persist (we already have the row).
+    await this.registerAgent(agentData, { id: record.id, skipPersist: true });
+    if (record.domain) {
+      this.agentDomainMap.set(record.id, record.domain);
+    }
+  }
+
+  private async syncAgentToPersistence(agentId: string): Promise<void> {
+    if (!this.persistence) return;
+    const agent = this.state.agents.get(agentId);
+    if (!agent) return;
+    await this.persistence.persistAgent(agent, this.agentDomainMap.get(agentId));
+  }
+
+  private async removeAgentFromPersistence(agentId: string): Promise<void> {
+    if (!this.persistence) return;
+    await this.persistence.removeAgent(agentId);
+  }
+
+  /**
+   * Topology events fire bursty (addNode → rebalance → emit, multiple per
+   * spawn). Collapse all writes within a microtask to a single upsert.
+   */
+  private scheduleTopologyPersist(): void {
+    if (!this.persistence || this.topologyPersistScheduled) return;
+    this.topologyPersistScheduled = true;
+    queueMicrotask(() => {
+      this.topologyPersistScheduled = false;
+      // Re-read locally — `attachPersistence(undefined)` or `shutdown()` could
+      // clear `this.persistence` between scheduling and flush.
+      const p = this.persistence;
+      if (!p) return;
+      void p.persistTopology(this.topologyManager.getState());
     });
   }
 
@@ -1490,16 +1586,13 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
     agentNumber: number,
     options?: { id?: string },
   ): Promise<{ agentId: string; domain: AgentDomain }> {
-    // First register the agent normally
-    const agentId = await this.registerAgent(agentData, options);
+    // Suppress the inner persistence write — we'll do one final sync after
+    // domain bookkeeping so the persisted record is single-shot per spawn.
+    const agentId = await this.registerAgent(agentData, { ...options, skipPersist: true });
 
-    // Determine domain based on agent number
     const domain = this.getAgentDomain(agentNumber);
-
-    // Add to domain tracking
     this.agentDomainMap.set(agentId, domain);
 
-    // Add to domain pool
     const pool = this.domainPools.get(domain);
     const agent = this.state.agents.get(agentId);
     if (pool && agent) {
@@ -1512,6 +1605,7 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       domain,
     });
 
+    void this.syncAgentToPersistence(agentId);
     return { agentId, domain };
   }
 
@@ -1700,10 +1794,12 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       agentId = result.agentId;
       domain = result.domain;
     } else {
-      // Auto-assign to most appropriate domain based on type
+      // Auto-assign to most appropriate domain based on type. Suppress the
+      // inner persist so we write once below with the final domain.
       domain = this.agentTypeToDomain(options.type);
-      agentId = await this.registerAgent(agentData, { id: options.id });
+      agentId = await this.registerAgent(agentData, { id: options.id, skipPersist: true });
       this.agentDomainMap.set(agentId, domain);
+      void this.syncAgentToPersistence(agentId);
     }
 
     const duration = performance.now() - startTime;


### PR DESCRIPTION
## Summary

- Adds write-through persistence to `UnifiedSwarmCoordinator` so agents/topology/consensus survive an MCP-server restart, mirroring the Story #121 hive-mind pattern with three new namespaces (`swarm-agents`, `swarm-topology`, `swarm-consensus`).
- New `SwarmPersistence` is DI'd via a `SwarmMemoryFns` interface — production wires the lazy memory-initializer; tests inject an in-memory fake. Singleton skips persistence under VITEST so tests don't pay sql.js boot cost.
- Single-write-per-spawn via `skipPersist` flag + microtask-debounced topology snapshots avoids the 2-3x duplicate writes the naive wiring produced.

## Architecture notes

`SwarmPersistence` is a separate module from the existing `WriteThroughAdapter` (write-through-adapter.ts). The adapter is event-driven over `MessageBus.message.unified` — it persists `msg:{id}` TTL'd rows for in-flight messages. Coordinator state is keyed agent records / idempotent upserts / no TTL / must replay on hydrate, so reusing the adapter would force a synthetic message channel and break hydrate semantics.

Hydration is best-effort: missing memory backend or thrown hydrate boots the coordinator in-memory only — never blocks startup.

## Test plan

- [x] `src/cli/__tests__/swarm/persistence.test.ts` — 5 cases: writes-to-namespace / spawn→reset→list-recovers-2 / terminate-clears / topology-snapshot-persisted / no-backend-still-runs
- [x] All 287 swarm + mcp-tools tests pass (`npx vitest run src/cli/__tests__/swarm src/cli/__tests__/mcp-tools src/cli/__tests__/swarm-coordinator-singleton.test.ts`)
- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [x] Full suite: 7527 pass, 4 pre-existing fastembed failures unrelated to this PR (filed as #819)

## Out of scope / follow-ups

- `memory-initializer.listEntries` already SELECTs `content` from sql.js but discards it. Adding `{ includeContent: true }` would collapse `loadAgents()` from O(N) DB opens to 1. Fine to defer — agent count is bounded at 15 and hydrate is a one-time cold-boot cost.

Closes #806.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
