### PR TITLE
fix(813): atomic completion sentinel for fastembed cache

### DIFF
--- a/src/cli/__tests__/embeddings/fastembed-inline-model-loader.test.ts
+++ b/src/cli/__tests__/embeddings/fastembed-inline-model-loader.test.ts
@@ -4,12 +4,16 @@
  * with a mock fetch + mock tar extractor. No network, no real disk model.
  */
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Readable } from 'node:stream';
 
-import { resolveCacheDir, retrieveModel } from '../../embeddings/fastembed-inline/model-loader.js';
+import {
+  COMPLETION_SENTINEL,
+  resolveCacheDir,
+  retrieveModel,
+} from '../../embeddings/fastembed-inline/model-loader.js';
 
 let tmp: string;
 
@@ -47,16 +51,57 @@ describe('resolveCacheDir', () => {
 });
 
 describe('retrieveModel', () => {
-  it('short-circuits when the model directory already exists', async () => {
+  it('short-circuits when the model directory and completion marker both exist', async () => {
     const cacheDir = join(tmp, 'cache');
     const modelDir = join(cacheDir, 'fast-all-MiniLM-L6-v2');
     mkdirSync(modelDir, { recursive: true });
+    writeFileSync(join(modelDir, COMPLETION_SENTINEL), '');
     const fetchImpl = vi.fn();
     const result = await retrieveModel('fast-all-MiniLM-L6-v2', cacheDir, false, {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
     expect(result).toBe(modelDir);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('redownloads when the model directory exists but the completion marker is missing', async () => {
+    const cacheDir = join(tmp, 'cache');
+    const modelDir = join(cacheDir, 'fast-all-MiniLM-L6-v2');
+    // Simulate a partial extract: directory exists, model.onnx is truncated, no marker.
+    mkdirSync(modelDir, { recursive: true });
+    writeFileSync(join(modelDir, 'model.onnx'), 'truncated-bytes');
+
+    const fetchImpl = makeFetch(200, Buffer.from('fresh-tarball-content'));
+    const extract = vi.fn(async ({ cwd }: { file: string; cwd: string }) => {
+      mkdirSync(join(cwd, 'fast-all-MiniLM-L6-v2'), { recursive: true });
+      writeFileSync(join(cwd, 'fast-all-MiniLM-L6-v2', 'model.onnx'), 'full-good-bytes');
+    });
+
+    const result = await retrieveModel('fast-all-MiniLM-L6-v2', cacheDir, false, {
+      fetchImpl,
+      extract: extract as unknown as Parameters<typeof retrieveModel>[3]['extract'],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(extract).toHaveBeenCalledOnce();
+    expect(result).toBe(modelDir);
+    expect(existsSync(join(modelDir, COMPLETION_SENTINEL))).toBe(true);
+  });
+
+  it('writes the completion marker after a successful download+extract', async () => {
+    const cacheDir = join(tmp, 'cache');
+    const fetchImpl = makeFetch(200, Buffer.from('fake-tarball-content'));
+    const extract = vi.fn(async ({ cwd }: { file: string; cwd: string }) => {
+      mkdirSync(join(cwd, 'fast-all-MiniLM-L6-v2'), { recursive: true });
+      writeFileSync(join(cwd, 'fast-all-MiniLM-L6-v2', 'model.onnx'), '');
+    });
+
+    const modelDir = await retrieveModel('fast-all-MiniLM-L6-v2', cacheDir, false, {
+      fetchImpl,
+      extract: extract as unknown as Parameters<typeof retrieveModel>[3]['extract'],
+    });
+
+    expect(existsSync(join(modelDir, COMPLETION_SENTINEL))).toBe(true);
   });
 
   it('downloads the AllMiniLM tarball from the sentence-transformers slug', async () => {

--- a/src/cli/embeddings/fastembed-inline/model-loader.ts
+++ b/src/cli/embeddings/fastembed-inline/model-loader.ts
@@ -12,7 +12,14 @@
  * tarball through a unique temp path, so Windows file locks during extraction
  * never collide. The final model dir is the synchronization point.
  */
-import { createWriteStream, existsSync, mkdirSync, renameSync, rmSync } from 'node:fs';
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
@@ -21,6 +28,15 @@ import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import { x as tarExtract } from 'tar';
 
 const GCS_BASE_URL = 'https://storage.googleapis.com/qdrant-fastembed';
+
+/**
+ * Sentinel file written into the model directory only after the tarball has
+ * been fully downloaded AND extracted. Cache hits without it are treated as
+ * incomplete (interrupted download, partial extract, OS reboot mid-write) —
+ * the model dir is wiped and redownloaded. The `-v1` suffix lets us bump
+ * the format if the cache layout ever changes.
+ */
+export const COMPLETION_SENTINEL = '.moflo-fastembed-complete-v1';
 
 /**
  * Maps fastembed's on-disk model identifier to the GCS tarball slug. Most
@@ -88,8 +104,15 @@ async function downloadTarball(
 
 /**
  * Ensure the per-model directory exists in the cache. Returns the absolute
- * path. If already present, no network/disk work happens — this is the hot
- * path for every embed call after first run.
+ * path. If already present AND the completion sentinel is in place, no
+ * network/disk work happens — this is the hot path for every embed call
+ * after first run.
+ *
+ * If the directory exists without a sentinel, a prior download was
+ * interrupted (Ctrl+C, network drop, OS reboot during extract). The dir
+ * is wiped and redownloaded — otherwise truncated files like a 4.7 MB
+ * `model.onnx` (real is ~22 MB) silently slip through to ORT and blow up
+ * with an opaque "Protobuf parsing failed" at session-creation time.
  */
 export async function retrieveModel(
   model: string,
@@ -98,7 +121,15 @@ export async function retrieveModel(
   deps: DownloadDeps = {},
 ): Promise<string> {
   const modelDir = join(cacheDir, model);
-  if (existsSync(modelDir)) return modelDir;
+  if (existsSync(modelDir)) {
+    if (existsSync(join(modelDir, COMPLETION_SENTINEL))) return modelDir;
+    if (showProgress) {
+      process.stderr.write(
+        `fastembed: cached model at ${modelDir} is incomplete (no completion marker); redownloading.\n`,
+      );
+    }
+    rmSync(modelDir, { recursive: true, force: true });
+  }
 
   mkdirSync(cacheDir, { recursive: true });
   const tarballPath = join(cacheDir, `${model}.tar.gz`);
@@ -112,5 +143,6 @@ export async function retrieveModel(
   if (!existsSync(modelDir)) {
     throw new Error(`Model archive extracted but ${modelDir} is missing — corrupt tarball?`);
   }
+  writeFileSync(join(modelDir, COMPLETION_SENTINEL), '');
   return modelDir;
 }


### PR DESCRIPTION
## Summary

- `retrieveModel()` in `src/cli/embeddings/fastembed-inline/model-loader.ts` short-circuited on `existsSync(modelDir)` alone, so an interrupted download (Ctrl+C, network drop, partial extract, OS reboot) left a truncated `model.onnx` (4.7 MB instead of ~22 MB) that silently slipped through to ORT and died with an opaque "Protobuf parsing failed" inside `InferenceSession.create()`.
- Write a `.moflo-fastembed-complete-v1` sentinel ONLY after the post-extract `existsSync(modelDir)` guard passes. On cache hit, require the sentinel; if missing, wipe the dir and redownload. Surface a one-line stderr note (gated on `showProgress`) so users understand the unexpected redownload.
- Existing healthy caches lack the sentinel → users see one ~22 MB redownload on the first run after this lands. One-time cost for a robust atomic-completion guarantee.

## Test plan

- [x] `npx vitest run src/cli/__tests__/embeddings/fastembed-inline-model-loader.test.ts` — 10 passed (7 prior + 3 new: marker-present fast path, marker-missing recovery, marker-on-success).
- [x] Cleared local corrupt cache, ran `npx vitest run --config vitest.isolation.config.ts src/cli/__tests__/embeddings/fastembed-inline-integration.test.ts` — 2 passed in 4.31 s. Verified `model.onnx` is 90,387,630 bytes (full) and `.moflo-fastembed-complete-v1` is present after the run.
- [x] `npm test` — 7531 passed, 0 failed across parallel + isolation passes.
- [x] `npm run build` — clean.

## Trade-offs

- **No size/hash heuristic.** A zero-byte sentinel written last is a clean atomic-completion signal that doesn't depend on model-specific magic numbers. A torn write of an empty string degrades to "marker absent" — exactly the "incomplete" signal we want.
- **Versioned suffix (\`-v1\`)** leaves room for cache-format bumps without ambiguity.
- **Hot-path cost.** One extra \`existsSync\` per \`FlagEmbedding.init\` (not per embed call) — sub-microsecond against the kernel's dentry cache.

Closes #813

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)