### PR TITLE
feat(807): hive-mind workers via shared swarm coordinator

### DIFF
--- a/src/cli/__tests__/swarm/coordinator.test.ts
+++ b/src/cli/__tests__/swarm/coordinator.test.ts
@@ -412,7 +412,10 @@ describe('UnifiedSwarmCoordinator', () => {
       expect(hierarchy.get(5)?.domain).toBe('core');
 
       const status = coordinator.getStatus();
-      expect(status.domains).toHaveLength(5);
+      // 5 canonical 15-agent-hierarchy domains + 'hive-mind' (story #807,
+      // dynamic-roster, agentNumbers: [] — not spawned by spawnFullHierarchy).
+      expect(status.domains).toHaveLength(6);
+      expect(status.domains.map((d: { name: string }) => d.name)).toContain('hive-mind');
     });
   });
 

--- a/src/cli/mcp-tools/hive-mind-tools.ts
+++ b/src/cli/mcp-tools/hive-mind-tools.ts
@@ -9,6 +9,7 @@
  * write-through to Memory DB for configured namespaces.
  */
 
+import { randomBytes } from 'node:crypto';
 import type { MCPTool } from './types.js';
 import { MessageBus, WriteThroughAdapter } from '../swarm/message-bus/index.js';
 import { getSwarmCoordinator } from './swarm-coordinator-singleton.js';
@@ -245,25 +246,26 @@ export const hiveMindTools: MCPTool[] = [
         return { success: false, error: validation.error, agentType };
       }
 
-      const bus = await getMessageBus();
-      const coordinator = await getSwarmCoordinator();
+      const [bus, coordinator] = await Promise.all([getMessageBus(), getSwarmCoordinator()]);
       const agentStore = loadAgentStore();
 
       const spawnedWorkers: Array<{ agentId: string; role: string; joinedAt: string; bootstrap: string }> = [];
+      const joinBroadcasts: Promise<unknown>[] = [];
 
       for (let i = 0; i < count; i++) {
-        const agentId = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+        // Story #801 found Math.random() ID collisions under burst spawns —
+        // use the same randomBytes pattern as agent_spawn.
+        const agentId = `${prefix}-${randomBytes(12).toString('hex')}`;
         const joinedAt = new Date().toISOString();
 
-        // Story #807: register with the shared coordinator first. If this
-        // fails we surface the error and skip both the legacy file record
-        // and the MessageBus join so the three views stay consistent.
+        // Coordinator first: a failure here aborts the legacy file-store
+        // and MessageBus writes so the three views can never disagree.
         try {
           await coordinator.spawnAgent({
             id: agentId,
             type: agentType as AgentType,
             name: agentId,
-            domain: 'hive-mind',
+            domain: HIVE_NS,
             metadata: {
               hiveRole: role,
               hiveId: hiveState.hiveId,
@@ -284,16 +286,15 @@ export const hiveMindTools: MCPTool[] = [
         agentStore.agents[agentId] = {
           agentId, agentType, status: 'idle', health: 1.0, taskCount: 0,
           config: { role, hiveRole: role, bootstrap: SUBAGENT_BOOTSTRAP_DIRECTIVE },
-          createdAt: joinedAt, domain: 'hive-mind',
+          createdAt: joinedAt, domain: HIVE_NS,
         };
 
-        // Track in hive state
         if (!hiveState.workers.includes(agentId)) {
           hiveState.workers.push(agentId);
         }
 
-        // Publish agent_join via MessageBus
-        await bus.sendUnified({
+        // Broadcasts are independent — collect and parallelize after the loop.
+        joinBroadcasts.push(bus.sendUnified({
           type: 'agent_join',
           from: agentId,
           to: '*',
@@ -302,11 +303,12 @@ export const hiveMindTools: MCPTool[] = [
           priority: 'normal',
           requiresAck: false,
           ttlMs: HIVE_TTL_MS,
-        });
+        }));
 
         spawnedWorkers.push({ agentId, role, joinedAt, bootstrap: SUBAGENT_BOOTSTRAP_DIRECTIVE });
       }
 
+      await Promise.all(joinBroadcasts);
       saveAgentStore(agentStore);
 
       return {
@@ -777,10 +779,18 @@ export const hiveMindTools: MCPTool[] = [
 
       // Story #807: terminate coordinator-side worker records before we
       // wipe the hive state so swarm agent_list reflects the shutdown.
+      // allSettled so one failed terminate doesn't strand the rest.
       try {
         const coordinator = await getSwarmCoordinator();
-        for (const workerId of hiveState.workers) {
-          await coordinator.terminateAgent(workerId, { reason: 'hive-mind_shutdown', force: true });
+        const results = await Promise.allSettled(
+          hiveState.workers.map(id =>
+            coordinator.terminateAgent(id, { reason: 'hive-mind_shutdown', force: true })
+          ),
+        );
+        for (const r of results) {
+          if (r.status === 'rejected') {
+            process.stderr.write(`[hive-mind_shutdown] terminate failed: ${(r.reason as Error)?.message ?? r.reason}\n`);
+          }
         }
       } catch (err) {
         process.stderr.write(`[hive-mind_shutdown] coordinator cleanup failed: ${(err as Error).message}\n`);

--- a/src/cli/mcp-tools/hive-mind-tools.ts
+++ b/src/cli/mcp-tools/hive-mind-tools.ts
@@ -11,6 +11,10 @@
 
 import type { MCPTool } from './types.js';
 import { MessageBus, WriteThroughAdapter } from '../swarm/message-bus/index.js';
+import { getSwarmCoordinator } from './swarm-coordinator-singleton.js';
+import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../services/subagent-bootstrap.js';
+import { validateAgentType } from './agent-tools.js';
+import type { AgentType } from '../swarm/types.js';
 
 // Namespace constants — avoids hardcoded strings scattered across handlers
 const HIVE_NS = 'hive-mind' as const;
@@ -228,23 +232,59 @@ export const hiveMindTools: MCPTool[] = [
         return { success: false, error: 'Hive-mind not initialized. Run hive-mind/init first.' };
       }
 
-      const bus = await getMessageBus();
       const count = Math.min(Math.max(1, (input.count as number) || 1), 20);
       const role = (input.role as string) || 'worker';
       const agentType = (input.agentType as string) || 'worker';
       const prefix = (input.prefix as string) || 'hive-worker';
+
+      // Story #807: hive workers are coordinator agents in the 'hive-mind'
+      // domain. Validating up-front so the legacy file-store and the
+      // coordinator never disagree on which spawns were accepted.
+      const validation = validateAgentType(agentType);
+      if (!validation.ok) {
+        return { success: false, error: validation.error, agentType };
+      }
+
+      const bus = await getMessageBus();
+      const coordinator = await getSwarmCoordinator();
       const agentStore = loadAgentStore();
 
-      const spawnedWorkers: Array<{ agentId: string; role: string; joinedAt: string }> = [];
+      const spawnedWorkers: Array<{ agentId: string; role: string; joinedAt: string; bootstrap: string }> = [];
 
       for (let i = 0; i < count; i++) {
         const agentId = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
         const joinedAt = new Date().toISOString();
 
-        // Create agent record
+        // Story #807: register with the shared coordinator first. If this
+        // fails we surface the error and skip both the legacy file record
+        // and the MessageBus join so the three views stay consistent.
+        try {
+          await coordinator.spawnAgent({
+            id: agentId,
+            type: agentType as AgentType,
+            name: agentId,
+            domain: 'hive-mind',
+            metadata: {
+              hiveRole: role,
+              hiveId: hiveState.hiveId,
+              bootstrap: SUBAGENT_BOOTSTRAP_DIRECTIVE,
+            },
+          });
+        } catch (err) {
+          return {
+            success: false,
+            spawned: spawnedWorkers.length,
+            workers: spawnedWorkers,
+            error: `coordinator.spawnAgent failed for ${agentId}: ${(err as Error).message}`,
+          };
+        }
+
+        // Legacy file-store record kept in sync for agent_pool / agent_health
+        // tools that still read it (epic #798 leaves those for a later story).
         agentStore.agents[agentId] = {
           agentId, agentType, status: 'idle', health: 1.0, taskCount: 0,
-          config: { role, hiveRole: role }, createdAt: joinedAt, domain: 'hive-mind',
+          config: { role, hiveRole: role, bootstrap: SUBAGENT_BOOTSTRAP_DIRECTIVE },
+          createdAt: joinedAt, domain: 'hive-mind',
         };
 
         // Track in hive state
@@ -264,7 +304,7 @@ export const hiveMindTools: MCPTool[] = [
           ttlMs: HIVE_TTL_MS,
         });
 
-        spawnedWorkers.push({ agentId, role, joinedAt });
+        spawnedWorkers.push({ agentId, role, joinedAt, bootstrap: SUBAGENT_BOOTSTRAP_DIRECTIVE });
       }
 
       saveAgentStore(agentStore);
@@ -475,6 +515,17 @@ export const hiveMindTools: MCPTool[] = [
 
       if (index > -1) {
         hiveState.workers.splice(index, 1);
+
+        // Story #807: terminate the coordinator-side record so swarm
+        // agent_list / agent_status no longer see this worker. Best-effort —
+        // an agent that joined by ID alone (hive-mind_join) may not have a
+        // coordinator record, and that's fine.
+        try {
+          const coordinator = await getSwarmCoordinator();
+          await coordinator.terminateAgent(agentId, { reason: 'hive-mind_leave', force: true });
+        } catch (err) {
+          process.stderr.write(`[hive-mind_leave] coordinator.terminateAgent failed for ${agentId}: ${(err as Error).message}\n`);
+        }
 
         // Publish agent_leave via MessageBus
         const bus = await getMessageBus();
@@ -722,6 +773,17 @@ export const hiveMindTools: MCPTool[] = [
           pendingConsensus,
           workerCount,
         };
+      }
+
+      // Story #807: terminate coordinator-side worker records before we
+      // wipe the hive state so swarm agent_list reflects the shutdown.
+      try {
+        const coordinator = await getSwarmCoordinator();
+        for (const workerId of hiveState.workers) {
+          await coordinator.terminateAgent(workerId, { reason: 'hive-mind_shutdown', force: true });
+        }
+      } catch (err) {
+        process.stderr.write(`[hive-mind_shutdown] coordinator cleanup failed: ${(err as Error).message}\n`);
       }
 
       // Clear workers from agent store

--- a/src/cli/swarm/unified-coordinator.ts
+++ b/src/cli/swarm/unified-coordinator.ts
@@ -56,7 +56,7 @@ import { SwarmPersistence, type PersistedAgent } from './swarm-persistence.js';
 // Domain Types for 15-Agent Hierarchy
 // =============================================================================
 
-export type AgentDomain = 'queen' | 'security' | 'core' | 'integration' | 'support';
+export type AgentDomain = 'queen' | 'security' | 'core' | 'integration' | 'support' | 'hive-mind';
 
 export interface DomainConfig {
   name: AgentDomain;
@@ -131,6 +131,19 @@ const DOMAIN_CONFIGS: DomainConfig[] = [
     priority: 4,
     capabilities: ['tdd-testing', 'performance-benchmarking', 'deployment', 'release-management'],
     description: 'Testing, performance optimization, and deployment',
+  },
+  // hive-mind workers don't share the canonical 1-15 numbering; they're
+  // collective-intelligence participants spawned dynamically by hive-mind_spawn.
+  // The empty agentNumbers array signals "auto-assign without a fixed slot" —
+  // spawnAgent's existingAgents lookup falls back to agentNumbers[0] which we
+  // keep undefined to avoid accidental collisions with the queen/security/core
+  // numbered agents.
+  {
+    name: 'hive-mind',
+    agentNumbers: [],
+    priority: 5,
+    capabilities: ['collective-intelligence', 'consensus-voting', 'hive-coordination'],
+    description: 'Hive-mind workers (collective intelligence; story #807)',
   },
 ];
 
@@ -776,11 +789,17 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
   private async initializeDomainPools(): Promise<void> {
     for (const [domain, config] of this.domainConfigs) {
       const agentType = this.domainToAgentType(domain);
+      // Dynamic-roster domains (agentNumbers: []) have no fixed slot count,
+      // so pool capacity falls back to the swarm-wide maxAgents — the
+      // coordinator's own ceiling stays the only cap.
+      const maxSize = config.agentNumbers.length === 0
+        ? this.config.maxAgents
+        : config.agentNumbers.length;
       const pool = createAgentPool({
         name: `${domain}-domain-pool`,
         type: agentType,
         minSize: 0,
-        maxSize: config.agentNumbers.length,
+        maxSize,
         scaleUpThreshold: 0.8,
         scaleDownThreshold: 0.2,
         cooldownMs: 30000,
@@ -1784,15 +1803,32 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       agentId = result.agentId;
       domain = result.domain;
     } else if (options.domain) {
-      // Use provided domain, assign next available number in that domain
+      // Use provided domain, assign next available number in that domain.
+      // Dynamic-roster domains (e.g. hive-mind) declare agentNumbers: [] so
+      // hive workers don't collide with the canonical 1-15 slot map. For
+      // those we skip the numbered slot bookkeeping and store the domain
+      // mapping directly — getAgentDomain() can't be the source of truth
+      // when there is no fixed slot.
       const config = this.domainConfigs.get(options.domain);
-      const existingAgents = Array.from(this.agentDomainMap.entries())
-        .filter(([, d]) => d === options.domain)
-        .length;
-      const nextNumber = config?.agentNumbers[existingAgents] || config?.agentNumbers[0] || 1;
-      const result = await this.registerAgentWithDomain(agentData, nextNumber, { id: options.id });
-      agentId = result.agentId;
-      domain = result.domain;
+      if (config && config.agentNumbers.length === 0) {
+        agentId = await this.registerAgent(agentData, { id: options.id, skipPersist: true });
+        this.agentDomainMap.set(agentId, options.domain);
+        const pool = this.domainPools.get(options.domain);
+        const agent = this.state.agents.get(agentId);
+        if (pool && agent) {
+          await pool.add(agent);
+        }
+        void this.syncAgentToPersistence(agentId);
+        domain = options.domain;
+      } else {
+        const existingAgents = Array.from(this.agentDomainMap.entries())
+          .filter(([, d]) => d === options.domain)
+          .length;
+        const nextNumber = config?.agentNumbers[existingAgents] || config?.agentNumbers[0] || 1;
+        const result = await this.registerAgentWithDomain(agentData, nextNumber, { id: options.id });
+        agentId = result.agentId;
+        domain = result.domain;
+      }
     } else {
       // Auto-assign to most appropriate domain based on type. Suppress the
       // inner persist so we write once below with the final domain.

--- a/tests/hive-mind-coordinator-integration.test.ts
+++ b/tests/hive-mind-coordinator-integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Story #807 / epic #798 — hive-mind workers ride the shared coordinator.
+ *
+ * Asserts the three views stay in lockstep:
+ *  1. hive-mind_status workers === coordinator.listAgents({ domain: 'hive-mind' })
+ *  2. workers visible from BOTH hive-mind_status AND swarm agent_list
+ *  3. Bootstrap directive (story #800) is byte-equal on every coordinator record
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { hiveMindTools } from '../src/cli/mcp-tools/hive-mind-tools.js';
+import { agentTools } from '../src/cli/mcp-tools/agent-tools.js';
+import {
+  _resetSwarmCoordinatorForTest,
+  getSwarmCoordinator,
+} from '../src/cli/mcp-tools/swarm-coordinator-singleton.js';
+import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../src/cli/services/subagent-bootstrap.js';
+
+interface SpawnResult {
+  success: boolean;
+  spawned?: number;
+  workers?: Array<{ agentId: string; role: string; joinedAt: string; bootstrap: string }>;
+  totalWorkers?: number;
+  error?: string;
+}
+
+interface StatusResult {
+  workers: Array<{ id: string }>;
+  workerCount: number;
+}
+
+interface ListResult {
+  agents: Array<{ agentId: string; domain?: string }>;
+  total: number;
+}
+
+const tool = (name: string) => {
+  const t = hiveMindTools.find(x => x.name === name) ?? agentTools.find(x => x.name === name);
+  if (!t) throw new Error(`tool ${name} not found`);
+  return t;
+};
+
+const init = () => tool('hive-mind_init').handler({ topology: 'mesh' });
+const spawn = (count: number, role = 'worker') =>
+  tool('hive-mind_spawn').handler({ count, role, agentType: 'worker' }) as Promise<SpawnResult>;
+const status = () => tool('hive-mind_status').handler({}) as Promise<StatusResult>;
+const list = (domain?: string) =>
+  tool('agent_list').handler(domain ? { domain } : {}) as Promise<ListResult>;
+const leave = (agentId: string) => tool('hive-mind_leave').handler({ agentId });
+const shutdown = () => tool('hive-mind_shutdown').handler({ graceful: true, force: true });
+
+describe('hive-mind ↔ coordinator continuity (story #807)', () => {
+  beforeEach(async () => {
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  afterEach(async () => {
+    // Shutdown clears hive state singleton AND terminates coordinator agents,
+    // then reset the coordinator so the next test boots a fresh one.
+    try { await shutdown(); } catch { /* best-effort */ }
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('hive-mind_spawn registers each worker with the coordinator', async () => {
+    await init();
+    const result = await spawn(3);
+
+    expect(result.success).toBe(true);
+    expect(result.spawned).toBe(3);
+
+    const coord = await getSwarmCoordinator();
+    const live = coord.listAgents({ domain: 'hive-mind' });
+    expect(live.length).toBe(3);
+
+    // Every worker returned by spawn must be reachable via getAgent
+    for (const w of result.workers!) {
+      const agent = coord.getAgent(w.agentId);
+      expect(agent, `coordinator missing agent ${w.agentId}`).toBeDefined();
+      expect(agent!.type).toBe('worker');
+    }
+  });
+
+  it('hive-mind_status workerCount matches coordinator domain count', async () => {
+    await init();
+    await spawn(4);
+
+    const s = await status();
+    const coord = await getSwarmCoordinator();
+    const domainAgents = coord.listAgents({ domain: 'hive-mind' });
+
+    expect(s.workerCount).toBe(domainAgents.length);
+    expect(s.workers.length).toBe(domainAgents.length);
+  });
+
+  it('workers are visible from BOTH hive-mind_status AND swarm agent_list', async () => {
+    await init();
+    const result = await spawn(2);
+
+    const s = await status();
+    const swarmList = await list('hive-mind');
+
+    const hiveIds = new Set(s.workers.map(w => w.id));
+    const swarmIds = new Set(swarmList.agents.map(a => a.agentId));
+
+    for (const w of result.workers!) {
+      expect(hiveIds.has(w.agentId), `${w.agentId} missing from hive view`).toBe(true);
+      expect(swarmIds.has(w.agentId), `${w.agentId} missing from swarm view`).toBe(true);
+    }
+  });
+
+  it('embeds the canonical bootstrap directive byte-for-byte on every worker record', async () => {
+    await init();
+    const result = await spawn(3);
+
+    expect(result.success).toBe(true);
+    expect(result.workers!.length).toBe(3);
+
+    // Story-acceptance check: byte-equal directive on every spawn record.
+    for (const w of result.workers!) {
+      expect(w.bootstrap).toBe(SUBAGENT_BOOTSTRAP_DIRECTIVE);
+    }
+  });
+
+  it('hive-mind_leave terminates the coordinator-side record', async () => {
+    await init();
+    const result = await spawn(2);
+    const [w1] = result.workers!;
+
+    await leave(w1.agentId);
+
+    const coord = await getSwarmCoordinator();
+    expect(coord.getAgent(w1.agentId)).toBeUndefined();
+
+    // Survivor still present
+    const remaining = coord.listAgents({ domain: 'hive-mind' });
+    expect(remaining.length).toBe(1);
+  });
+
+  it('hive-mind_shutdown terminates every coordinator worker in the domain', async () => {
+    await init();
+    await spawn(3);
+
+    const coord = await getSwarmCoordinator();
+    expect(coord.listAgents({ domain: 'hive-mind' }).length).toBe(3);
+
+    await shutdown();
+
+    expect(coord.listAgents({ domain: 'hive-mind' }).length).toBe(0);
+  });
+
+  it('rejects unknown agent types without spawning a coordinator record', async () => {
+    await init();
+    const r = await tool('hive-mind_spawn').handler({
+      count: 1,
+      agentType: 'definitely-not-a-real-type',
+    }) as SpawnResult;
+
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/whitelist|allowed/i);
+
+    const coord = await getSwarmCoordinator();
+    expect(coord.listAgents({ domain: 'hive-mind' }).length).toBe(0);
+  });
+});

--- a/tests/hive-mind-coordinator-integration.test.ts
+++ b/tests/hive-mind-coordinator-integration.test.ts
@@ -56,8 +56,12 @@ describe('hive-mind ↔ coordinator continuity (story #807)', () => {
 
   afterEach(async () => {
     // Shutdown clears hive state singleton AND terminates coordinator agents,
-    // then reset the coordinator so the next test boots a fresh one.
-    try { await shutdown(); } catch { /* best-effort */ }
+    // then reset the coordinator so the next test boots a fresh one. Tests
+    // that already shut down (or error before init) make this a no-op; we
+    // surface the message so a real teardown bug isn't lost in the noise.
+    try { await shutdown(); } catch (err) {
+      process.stderr.write(`[test teardown] shutdown failed: ${(err as Error).message}\n`);
+    }
     await _resetSwarmCoordinatorForTest();
   });
 


### PR DESCRIPTION
## Summary
- Wires `hive-mind_spawn` through `UnifiedSwarmCoordinator.spawnAgent` so hive workers join the same registry as `agent_spawn` (story #801) — single source of truth across the file store, hive-mind view, and swarm `agent_list`.
- Adds `'hive-mind'` as a sixth `AgentDomain` (dynamic-roster: `agentNumbers: []` so hive workers don't collide with the canonical 1-15 slot map). Pool maxSize falls back to `coordinator.maxAgents`.
- Embeds `SUBAGENT_BOOTSTRAP_DIRECTIVE` byte-for-byte on every spawn record (parity with story #800/#801).
- `hive-mind_leave` / `hive-mind_shutdown` call `coordinator.terminateAgent` (shutdown via `Promise.allSettled` so one failure doesn't strand the rest).
- Worker IDs now use `randomBytes(12)` (matches story #801; fixes the `Math.random()` collision pattern under burst spawns).

Closes #807. Story 9 of epic #798.

## Test plan
- [x] New: `tests/hive-mind-coordinator-integration.test.ts` (7 cases — coordinator visibility, status counts, swarm/hive cross-view, bootstrap byte-equality, leave/shutdown, validation).
- [x] Updated: `src/cli/__tests__/swarm/coordinator.test.ts` 15-agent-hierarchy domain count 5 → 6.
- [x] Regression: `tests/hive-mind-messagebus.test.ts` and `src/cli/__tests__/mcp-tools/agent-spawn.test.ts` still pass.
- [x] Full suite green: 7538 tests passing.
- [x] Lint clean (`npm run lint`).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)