### PR TITLE
feat(808): system E2E tests for swarm + hive-mind (cap epic #798)

### DIFF
--- a/src/cli/__tests__/mcp-tools/_helpers.ts
+++ b/src/cli/__tests__/mcp-tools/_helpers.ts
@@ -7,6 +7,7 @@ import { hiveMindTools } from '../../mcp-tools/hive-mind-tools.js';
 import { swarmTools } from '../../mcp-tools/swarm-tools.js';
 import { taskTools } from '../../mcp-tools/task-tools.js';
 import type { MCPTool } from '../../mcp-tools/types.js';
+import { _resetSwarmCoordinatorForTest } from '../../mcp-tools/swarm-coordinator-singleton.js';
 
 export function getAgentTool(name: string): MCPTool {
   const tool = agentTools.find(t => t.name === name);
@@ -44,4 +45,14 @@ export async function spawnAgentForTest(
     throw new Error(`spawnAgentForTest failed: ${result.error ?? 'unknown'}`);
   }
   return result.agentId;
+}
+
+/**
+ * Standard system-test teardown: shutdown the hive-mind (returns
+ * `{success:false}` rather than throwing if not initialized) then drop the
+ * coordinator singleton so the next test boots fresh.
+ */
+export async function resetHiveAndSwarm(): Promise<void> {
+  await getHiveMindTool('hive-mind_shutdown').handler({ force: true });
+  await _resetSwarmCoordinatorForTest();
 }

--- a/src/cli/__tests__/mcp-tools/_helpers.ts
+++ b/src/cli/__tests__/mcp-tools/_helpers.ts
@@ -3,6 +3,7 @@
  */
 
 import { agentTools } from '../../mcp-tools/agent-tools.js';
+import { hiveMindTools } from '../../mcp-tools/hive-mind-tools.js';
 import { swarmTools } from '../../mcp-tools/swarm-tools.js';
 import { taskTools } from '../../mcp-tools/task-tools.js';
 import type { MCPTool } from '../../mcp-tools/types.js';
@@ -22,6 +23,12 @@ export function getSwarmTool(name: string): MCPTool {
 export function getTaskTool(name: string): MCPTool {
   const tool = taskTools.find(t => t.name === name);
   if (!tool) throw new Error(`task tool "${name}" not registered`);
+  return tool;
+}
+
+export function getHiveMindTool(name: string): MCPTool {
+  const tool = hiveMindTools.find(t => t.name === name);
+  if (!tool) throw new Error(`hive-mind tool "${name}" not registered`);
   return tool;
 }
 

--- a/src/cli/__tests__/mcp-tools/_helpers.ts
+++ b/src/cli/__tests__/mcp-tools/_helpers.ts
@@ -47,11 +47,7 @@ export async function spawnAgentForTest(
   return result.agentId;
 }
 
-/**
- * Standard system-test teardown: shutdown the hive-mind (returns
- * `{success:false}` rather than throwing if not initialized) then drop the
- * coordinator singleton so the next test boots fresh.
- */
+/** Standard system-test teardown — shut down hive-mind and drop the coordinator singleton. */
 export async function resetHiveAndSwarm(): Promise<void> {
   await getHiveMindTool('hive-mind_shutdown').handler({ force: true });
   await _resetSwarmCoordinatorForTest();

--- a/src/cli/__tests__/swarm/_in-memory-persistence.ts
+++ b/src/cli/__tests__/swarm/_in-memory-persistence.ts
@@ -1,0 +1,64 @@
+/**
+ * In-memory test fake for `SwarmMemoryFns` (story #806).
+ *
+ * Lets persistence-using tests assert the same writes that would have hit
+ * moflo.db in production, without touching sql.js. Imported by the unit-level
+ * `swarm/persistence.test.ts` and the system-level `tests/system/swarm-*` E2E
+ * tests so both layers exercise the same fake.
+ *
+ * Leading underscore signals "test fixture, not a test" — vitest's
+ * `*.{test,spec}.ts` include glob skips it.
+ */
+
+import type { SwarmMemoryFns } from '../../swarm/swarm-persistence.js';
+
+export interface FakeRow {
+  key: string;
+  namespace: string;
+  content: string;
+}
+
+export interface InMemoryPersistenceBackend {
+  fns: SwarmMemoryFns;
+  rows: Map<string, FakeRow>;
+}
+
+export function createInMemoryPersistence(): InMemoryPersistenceBackend {
+  const rows = new Map<string, FakeRow>();
+  const compositeKey = (namespace: string, key: string) => `${namespace}::${key}`;
+
+  const fns: SwarmMemoryFns = {
+    async storeEntry(opts) {
+      rows.set(compositeKey(opts.namespace, opts.key), {
+        key: opts.key,
+        namespace: opts.namespace,
+        content: opts.value,
+      });
+      return { success: true, id: `id_${rows.size}` };
+    },
+    async getEntry(opts) {
+      const ns = opts.namespace ?? 'default';
+      const row = rows.get(compositeKey(ns, opts.key));
+      if (!row) return { success: true, found: false };
+      return { success: true, found: true, entry: { content: row.content } };
+    },
+    async listEntries(opts) {
+      const ns = opts.namespace;
+      const entries = ns
+        ? Array.from(rows.values()).filter(r => r.namespace === ns)
+        : Array.from(rows.values());
+      return {
+        success: true,
+        entries: entries.map(r => ({ key: r.key })),
+        total: entries.length,
+      };
+    },
+    async deleteEntry(opts) {
+      const ns = opts.namespace ?? 'default';
+      const existed = rows.delete(compositeKey(ns, opts.key));
+      return { success: true, deleted: existed };
+    },
+  };
+
+  return { fns, rows };
+}

--- a/src/cli/__tests__/swarm/_in-memory-persistence.ts
+++ b/src/cli/__tests__/swarm/_in-memory-persistence.ts
@@ -1,13 +1,10 @@
 /**
- * In-memory test fake for `SwarmMemoryFns` (story #806).
+ * In-memory test fake for `SwarmMemoryFns`.
  *
  * Lets persistence-using tests assert the same writes that would have hit
- * moflo.db in production, without touching sql.js. Imported by the unit-level
- * `swarm/persistence.test.ts` and the system-level `tests/system/swarm-*` E2E
- * tests so both layers exercise the same fake.
- *
- * Leading underscore signals "test fixture, not a test" — vitest's
- * `*.{test,spec}.ts` include glob skips it.
+ * moflo.db in production, without touching sql.js. Leading underscore signals
+ * "test fixture, not a test" — vitest's `*.{test,spec}.ts` include glob
+ * skips it.
  */
 
 import type { SwarmMemoryFns } from '../../swarm/swarm-persistence.js';

--- a/src/cli/__tests__/swarm/persistence.test.ts
+++ b/src/cli/__tests__/swarm/persistence.test.ts
@@ -17,59 +17,8 @@ import {
   SWARM_AGENTS_NS,
   SWARM_TOPOLOGY_NS,
   SwarmPersistence,
-  type SwarmMemoryFns,
 } from '../../swarm/swarm-persistence.js';
-
-interface FakeRow {
-  key: string;
-  namespace: string;
-  content: string;
-}
-
-/**
- * sql.js-free fake persistence backend. Captures every storeEntry/deleteEntry
- * call across coordinator boots so tests can assert the same writes that
- * would have hit moflo.db in production.
- */
-function createInMemoryFns(): { fns: SwarmMemoryFns; rows: Map<string, FakeRow> } {
-  const rows = new Map<string, FakeRow>();
-  const compositeKey = (namespace: string, key: string) => `${namespace}::${key}`;
-
-  const fns: SwarmMemoryFns = {
-    async storeEntry(opts) {
-      rows.set(compositeKey(opts.namespace, opts.key), {
-        key: opts.key,
-        namespace: opts.namespace,
-        content: opts.value,
-      });
-      return { success: true, id: `id_${rows.size}` };
-    },
-    async getEntry(opts) {
-      const ns = opts.namespace ?? 'default';
-      const row = rows.get(compositeKey(ns, opts.key));
-      if (!row) return { success: true, found: false };
-      return { success: true, found: true, entry: { content: row.content } };
-    },
-    async listEntries(opts) {
-      const ns = opts.namespace;
-      const entries = ns
-        ? Array.from(rows.values()).filter(r => r.namespace === ns)
-        : Array.from(rows.values());
-      return {
-        success: true,
-        entries: entries.map(r => ({ key: r.key })),
-        total: entries.length,
-      };
-    },
-    async deleteEntry(opts) {
-      const ns = opts.namespace ?? 'default';
-      const existed = rows.delete(compositeKey(ns, opts.key));
-      return { success: true, deleted: existed };
-    },
-  };
-
-  return { fns, rows };
-}
+import { createInMemoryPersistence } from './_in-memory-persistence.js';
 
 function getAgentTool(name: string) {
   const tool = agentTools.find(t => t.name === name);
@@ -78,10 +27,10 @@ function getAgentTool(name: string) {
 }
 
 describe('Swarm restart persistence (story #806)', () => {
-  let backend: ReturnType<typeof createInMemoryFns>;
+  let backend: ReturnType<typeof createInMemoryPersistence>;
 
   beforeEach(() => {
-    backend = createInMemoryFns();
+    backend = createInMemoryPersistence();
     _setSwarmPersistenceForTest(new SwarmPersistence(backend.fns));
   });
 

--- a/src/cli/mcp-tools/agent-tools.ts
+++ b/src/cli/mcp-tools/agent-tools.ts
@@ -354,7 +354,7 @@ export const agentTools: MCPTool[] = [
   },
   {
     name: 'agent_terminate',
-    description: 'Terminate an agent',
+    description: 'Terminate an agent on the coordinator (force / grace-period supported; reassigns active tasks)',
     category: 'agent',
     inputSchema: {
       type: 'object',
@@ -399,7 +399,7 @@ export const agentTools: MCPTool[] = [
   },
   {
     name: 'agent_status',
-    description: 'Get agent status',
+    description: 'Get agent status from the coordinator (workload, health, last heartbeat, optional metrics)',
     category: 'agent',
     inputSchema: {
       type: 'object',
@@ -455,7 +455,7 @@ export const agentTools: MCPTool[] = [
   },
   {
     name: 'agent_list',
-    description: 'List all agents',
+    description: 'List coordinator-tracked agents (with status / type / domain filters and pagination)',
     category: 'agent',
     inputSchema: {
       type: 'object',

--- a/src/cli/mcp-tools/swarm-tools.ts
+++ b/src/cli/mcp-tools/swarm-tools.ts
@@ -80,7 +80,7 @@ function probeMemoryBackend(): { ok: boolean; message: string } {
 export const swarmTools: MCPTool[] = [
   {
     name: 'swarm_init',
-    description: 'Initialize a swarm',
+    description: 'Initialize the swarm coordinator (idempotent — returns the existing swarmId on re-init)',
     category: 'swarm',
     inputSchema: {
       type: 'object',
@@ -148,7 +148,7 @@ export const swarmTools: MCPTool[] = [
   },
   {
     name: 'swarm_status',
-    description: 'Get swarm status',
+    description: 'Get live swarm status from the coordinator (agent + task counts, topology, metrics)',
     category: 'swarm',
     inputSchema: {
       type: 'object',

--- a/tests/system/bootstrap-directive-parity.test.ts
+++ b/tests/system/bootstrap-directive-parity.test.ts
@@ -10,12 +10,12 @@
 
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { _resetSwarmCoordinatorForTest } from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
 import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../../src/cli/services/subagent-bootstrap.js';
 import { locateMofloRootPath } from '../../src/cli/services/moflo-require.js';
 import {
   getAgentTool,
   getHiveMindTool,
+  resetHiveAndSwarm,
 } from '../../src/cli/__tests__/mcp-tools/_helpers.js';
 
 interface SpawnAgentResult {
@@ -54,14 +54,7 @@ describe('System E2E — subagent bootstrap directive parity', () => {
     hookOutput = runHook();
   });
 
-  afterEach(async () => {
-    try {
-      await getHiveMindTool('hive-mind_shutdown').handler({ force: true });
-    } catch {
-      // hive may not be initialized in agent-only tests
-    }
-    await _resetSwarmCoordinatorForTest();
-  });
+  afterEach(resetHiveAndSwarm);
 
   it('SubagentStart hook emits additionalContext byte-for-byte equal to the canonical directive', () => {
     expect(hookOutput.hookSpecificOutput?.hookEventName).toBe('SubagentStart');

--- a/tests/system/bootstrap-directive-parity.test.ts
+++ b/tests/system/bootstrap-directive-parity.test.ts
@@ -1,0 +1,138 @@
+/**
+ * System E2E: bootstrap directive parity (epic #798, story #808).
+ *
+ * Story #800 made `.claude/helpers/subagent-bootstrap.json` the single source
+ * of truth for the memory-first directive. Stories #801 / #807 then injected
+ * that directive into every agent_spawn / hive-mind_spawn surface so spawned
+ * subagents bootstrap with the same instruction the cjs SubagentStart hook
+ * already injected.
+ *
+ * The unit-level parity is pinned in `tests/bin/subagent-start.test.ts` (cjs
+ * hook ↔ JSON ↔ TS fallback). This system test cross-validates the same
+ * canonical string flows out of the *MCP tool* surfaces — agent_spawn and
+ * hive-mind_spawn — byte-for-byte.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { agentTools } from '../../src/cli/mcp-tools/agent-tools.js';
+import { hiveMindTools } from '../../src/cli/mcp-tools/hive-mind-tools.js';
+import { _resetSwarmCoordinatorForTest } from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const JSON_PATH = resolve(REPO_ROOT, '.claude/helpers/subagent-bootstrap.json');
+const HOOK_PATH = resolve(REPO_ROOT, '.claude/helpers/subagent-start.cjs');
+
+function tool<T extends { name: string; handler: (input: Record<string, unknown>) => Promise<unknown> }>(
+  set: readonly T[],
+  name: string,
+): T {
+  const found = set.find(t => t.name === name);
+  if (!found) throw new Error(`tool "${name}" not registered`);
+  return found;
+}
+
+interface SpawnAgentResult {
+  success: boolean;
+  agentId: string;
+  bootstrap: string;
+}
+
+interface HiveSpawnResult {
+  success: boolean;
+  spawned: number;
+  workers: Array<{ agentId: string; role: string; bootstrap: string }>;
+}
+
+interface HookOutput {
+  hookSpecificOutput?: { hookEventName?: string; additionalContext?: string };
+}
+
+describe('System E2E — subagent bootstrap directive parity (story #800 + #801 + #807)', () => {
+  let canonicalDirective: string;
+
+  beforeAll(() => {
+    canonicalDirective = (
+      JSON.parse(readFileSync(JSON_PATH, 'utf-8')) as { directive: string }
+    ).directive;
+    expect(canonicalDirective.length).toBeGreaterThan(0);
+  });
+
+  afterEach(async () => {
+    try {
+      await tool(hiveMindTools, 'hive-mind_shutdown').handler({ force: true });
+    } catch {
+      // ignored — hive may not be initialized in agent-only tests
+    }
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('SubagentStart hook emits additionalContext byte-for-byte equal to the JSON', () => {
+    const stdout = execFileSync('node', [HOOK_PATH], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const output = JSON.parse(stdout) as HookOutput;
+    expect(output.hookSpecificOutput?.hookEventName).toBe('SubagentStart');
+    expect(output.hookSpecificOutput?.additionalContext).toBe(canonicalDirective);
+  });
+
+  it('agent_spawn injects the canonical directive into the MCP response', async () => {
+    const result = (await tool(agentTools, 'agent_spawn').handler({
+      agentType: 'coder',
+    })) as SpawnAgentResult;
+
+    expect(result.success).toBe(true);
+    expect(result.bootstrap).toBe(canonicalDirective);
+  });
+
+  it('hive-mind_spawn injects the canonical directive into every spawned worker (#807)', async () => {
+    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
+
+    const result = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+      count: 3,
+      role: 'worker',
+      agentType: 'worker',
+    })) as HiveSpawnResult;
+
+    expect(result.success).toBe(true);
+    expect(result.workers).toHaveLength(3);
+    for (const worker of result.workers) {
+      expect(worker.bootstrap, `worker ${worker.agentId}`).toBe(canonicalDirective);
+    }
+  });
+
+  it('all spawn surfaces share one canonical string (no fork allowed)', async () => {
+    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
+
+    const hookStdout = execFileSync('node', [HOOK_PATH], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const hookDirective = (JSON.parse(hookStdout) as HookOutput).hookSpecificOutput?.additionalContext;
+
+    const agentResult = (await tool(agentTools, 'agent_spawn').handler({
+      agentType: 'tester',
+    })) as SpawnAgentResult;
+
+    const hiveResult = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+      count: 1,
+      agentType: 'worker',
+    })) as HiveSpawnResult;
+
+    // Every surface — JSON, hook, agent_spawn, hive-mind_spawn — emits the
+    // same string. A drift here would mean a subagent bootstrap from one
+    // surface differs from another, breaking memory-first enforcement.
+    const allDirectives = new Set([
+      canonicalDirective,
+      hookDirective,
+      agentResult.bootstrap,
+      ...hiveResult.workers.map(w => w.bootstrap),
+    ]);
+    expect(allDirectives.size).toBe(1);
+  });
+});

--- a/tests/system/bootstrap-directive-parity.test.ts
+++ b/tests/system/bootstrap-directive-parity.test.ts
@@ -1,38 +1,22 @@
 /**
- * System E2E: bootstrap directive parity (epic #798, story #808).
+ * System E2E: bootstrap directive parity.
  *
- * Story #800 made `.claude/helpers/subagent-bootstrap.json` the single source
- * of truth for the memory-first directive. Stories #801 / #807 then injected
- * that directive into every agent_spawn / hive-mind_spawn surface so spawned
- * subagents bootstrap with the same instruction the cjs SubagentStart hook
- * already injected.
- *
- * The unit-level parity is pinned in `tests/bin/subagent-start.test.ts` (cjs
- * hook ↔ JSON ↔ TS fallback). This system test cross-validates the same
- * canonical string flows out of the *MCP tool* surfaces — agent_spawn and
- * hive-mind_spawn — byte-for-byte.
+ * Verifies the canonical memory-first directive in
+ * `.claude/helpers/subagent-bootstrap.json` flows byte-for-byte through every
+ * spawn surface — the cjs SubagentStart hook, `agent_spawn`, and
+ * `hive-mind_spawn`. Drift between any two surfaces would let a subagent
+ * bootstrap without the memory-first instruction.
  */
 
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { agentTools } from '../../src/cli/mcp-tools/agent-tools.js';
-import { hiveMindTools } from '../../src/cli/mcp-tools/hive-mind-tools.js';
 import { _resetSwarmCoordinatorForTest } from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
-
-const REPO_ROOT = resolve(__dirname, '../..');
-const JSON_PATH = resolve(REPO_ROOT, '.claude/helpers/subagent-bootstrap.json');
-const HOOK_PATH = resolve(REPO_ROOT, '.claude/helpers/subagent-start.cjs');
-
-function tool<T extends { name: string; handler: (input: Record<string, unknown>) => Promise<unknown> }>(
-  set: readonly T[],
-  name: string,
-): T {
-  const found = set.find(t => t.name === name);
-  if (!found) throw new Error(`tool "${name}" not registered`);
-  return found;
-}
+import { SUBAGENT_BOOTSTRAP_DIRECTIVE } from '../../src/cli/services/subagent-bootstrap.js';
+import { locateMofloRootPath } from '../../src/cli/services/moflo-require.js';
+import {
+  getAgentTool,
+  getHiveMindTool,
+} from '../../src/cli/__tests__/mcp-tools/_helpers.js';
 
 interface SpawnAgentResult {
   success: boolean;
@@ -50,49 +34,53 @@ interface HookOutput {
   hookSpecificOutput?: { hookEventName?: string; additionalContext?: string };
 }
 
-describe('System E2E — subagent bootstrap directive parity (story #800 + #801 + #807)', () => {
-  let canonicalDirective: string;
+function runHook(): HookOutput {
+  const hookPath = locateMofloRootPath('.claude/helpers/subagent-start.cjs');
+  if (!hookPath) throw new Error('subagent-start.cjs not found in moflo package root');
+  const stdout = execFileSync('node', [hookPath], {
+    encoding: 'utf-8',
+    timeout: 30_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return JSON.parse(stdout) as HookOutput;
+}
+
+describe('System E2E — subagent bootstrap directive parity', () => {
+  let hookOutput: HookOutput;
 
   beforeAll(() => {
-    canonicalDirective = (
-      JSON.parse(readFileSync(JSON_PATH, 'utf-8')) as { directive: string }
-    ).directive;
-    expect(canonicalDirective.length).toBeGreaterThan(0);
+    expect(SUBAGENT_BOOTSTRAP_DIRECTIVE.length).toBeGreaterThan(0);
+    // Cached once: node cold-start is ~150–300ms per spawn.
+    hookOutput = runHook();
   });
 
   afterEach(async () => {
     try {
-      await tool(hiveMindTools, 'hive-mind_shutdown').handler({ force: true });
+      await getHiveMindTool('hive-mind_shutdown').handler({ force: true });
     } catch {
-      // ignored — hive may not be initialized in agent-only tests
+      // hive may not be initialized in agent-only tests
     }
     await _resetSwarmCoordinatorForTest();
   });
 
-  it('SubagentStart hook emits additionalContext byte-for-byte equal to the JSON', () => {
-    const stdout = execFileSync('node', [HOOK_PATH], {
-      encoding: 'utf-8',
-      timeout: 30_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const output = JSON.parse(stdout) as HookOutput;
-    expect(output.hookSpecificOutput?.hookEventName).toBe('SubagentStart');
-    expect(output.hookSpecificOutput?.additionalContext).toBe(canonicalDirective);
+  it('SubagentStart hook emits additionalContext byte-for-byte equal to the canonical directive', () => {
+    expect(hookOutput.hookSpecificOutput?.hookEventName).toBe('SubagentStart');
+    expect(hookOutput.hookSpecificOutput?.additionalContext).toBe(SUBAGENT_BOOTSTRAP_DIRECTIVE);
   });
 
   it('agent_spawn injects the canonical directive into the MCP response', async () => {
-    const result = (await tool(agentTools, 'agent_spawn').handler({
+    const result = (await getAgentTool('agent_spawn').handler({
       agentType: 'coder',
     })) as SpawnAgentResult;
 
     expect(result.success).toBe(true);
-    expect(result.bootstrap).toBe(canonicalDirective);
+    expect(result.bootstrap).toBe(SUBAGENT_BOOTSTRAP_DIRECTIVE);
   });
 
-  it('hive-mind_spawn injects the canonical directive into every spawned worker (#807)', async () => {
-    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
+  it('hive-mind_spawn injects the canonical directive into every spawned worker', async () => {
+    await getHiveMindTool('hive-mind_init').handler({ topology: 'mesh' });
 
-    const result = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+    const result = (await getHiveMindTool('hive-mind_spawn').handler({
       count: 3,
       role: 'worker',
       agentType: 'worker',
@@ -101,35 +89,25 @@ describe('System E2E — subagent bootstrap directive parity (story #800 + #801 
     expect(result.success).toBe(true);
     expect(result.workers).toHaveLength(3);
     for (const worker of result.workers) {
-      expect(worker.bootstrap, `worker ${worker.agentId}`).toBe(canonicalDirective);
+      expect(worker.bootstrap, `worker ${worker.agentId}`).toBe(SUBAGENT_BOOTSTRAP_DIRECTIVE);
     }
   });
 
   it('all spawn surfaces share one canonical string (no fork allowed)', async () => {
-    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
+    await getHiveMindTool('hive-mind_init').handler({ topology: 'mesh' });
 
-    const hookStdout = execFileSync('node', [HOOK_PATH], {
-      encoding: 'utf-8',
-      timeout: 30_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    const hookDirective = (JSON.parse(hookStdout) as HookOutput).hookSpecificOutput?.additionalContext;
-
-    const agentResult = (await tool(agentTools, 'agent_spawn').handler({
+    const agentResult = (await getAgentTool('agent_spawn').handler({
       agentType: 'tester',
     })) as SpawnAgentResult;
 
-    const hiveResult = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+    const hiveResult = (await getHiveMindTool('hive-mind_spawn').handler({
       count: 1,
       agentType: 'worker',
     })) as HiveSpawnResult;
 
-    // Every surface — JSON, hook, agent_spawn, hive-mind_spawn — emits the
-    // same string. A drift here would mean a subagent bootstrap from one
-    // surface differs from another, breaking memory-first enforcement.
     const allDirectives = new Set([
-      canonicalDirective,
-      hookDirective,
+      SUBAGENT_BOOTSTRAP_DIRECTIVE,
+      hookOutput.hookSpecificOutput?.additionalContext,
       agentResult.bootstrap,
       ...hiveResult.workers.map(w => w.bootstrap),
     ]);

--- a/tests/system/hive-mind-e2e.test.ts
+++ b/tests/system/hive-mind-e2e.test.ts
@@ -1,38 +1,21 @@
 /**
- * System E2E: hive-mind end-to-end (epic #798, story #808).
+ * System E2E: hive-mind end-to-end.
  *
  * Drives every hive-mind MCP surface (init / spawn / broadcast / consensus /
- * shutdown) and cross-validates Story #807: hive workers spawned via
- * `hive-mind_spawn` MUST be visible to swarm `agent_list` because they are
- * registered with the same UnifiedSwarmCoordinator.
- *
- * Coverage:
- *   1. init → spawn × 3 → workers reachable from swarm agent_list (#807)
- *   2. broadcast publishes through MessageBus (recipients = worker count)
- *   3. consensus propose/vote tally crosses majority and flips status to
- *      `approved` — verifying real vote counting, not a stubbed result
- *   4. hive-mind_shutdown terminates the coordinator-side worker records
- *      so swarm agent_list no longer sees them
+ * shutdown) and verifies hive workers spawned via `hive-mind_spawn` are
+ * visible to swarm `agent_list` because they register with the same
+ * UnifiedSwarmCoordinator.
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { agentTools } from '../../src/cli/mcp-tools/agent-tools.js';
-import { hiveMindTools } from '../../src/cli/mcp-tools/hive-mind-tools.js';
 import {
   _resetSwarmCoordinatorForTest,
   getSwarmCoordinator,
 } from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
-
-// ===== helpers =====
-
-function tool<T extends { name: string; handler: (input: Record<string, unknown>) => Promise<unknown> }>(
-  set: readonly T[],
-  name: string,
-): T {
-  const found = set.find(t => t.name === name);
-  if (!found) throw new Error(`tool "${name}" not registered`);
-  return found;
-}
+import {
+  getAgentTool,
+  getHiveMindTool,
+} from '../../src/cli/__tests__/mcp-tools/_helpers.js';
 
 interface InitResult {
   success: boolean;
@@ -67,6 +50,14 @@ interface ConsensusVoteResult {
   votesAgainst: number;
 }
 
+interface ConsensusListResult {
+  recentHistory: Array<{
+    proposalId: string;
+    result: string;
+    votes: { for: number; against: number };
+  }>;
+}
+
 interface ShutdownResult {
   success: boolean;
   workersTerminated: number;
@@ -77,27 +68,24 @@ interface AgentListResult {
   total: number;
 }
 
-// ===== tests =====
-
-describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
+describe('System E2E — hive-mind', () => {
   afterEach(async () => {
-    // Best-effort hive shutdown — second one short-circuits when state is
-    // already cleared, which is what we want when a test left a live hive.
+    // Best-effort hive shutdown — short-circuits when state is already cleared.
     try {
-      await tool(hiveMindTools, 'hive-mind_shutdown').handler({ force: true });
+      await getHiveMindTool('hive-mind_shutdown').handler({ force: true });
     } catch {
-      // ignored — hive already torn down
+      // hive already torn down
     }
     await _resetSwarmCoordinatorForTest();
   });
 
-  it('init → spawn × 3 → workers visible via swarm agent_list (#807)', async () => {
-    const init = (await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' })) as InitResult;
+  it('init → spawn × 3 → workers visible via swarm agent_list', async () => {
+    const init = (await getHiveMindTool('hive-mind_init').handler({ topology: 'mesh' })) as InitResult;
     expect(init.success).toBe(true);
     expect(init.status).toBe('initialized');
     expect(init.hiveId).toBeTruthy();
 
-    const spawn = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+    const spawn = (await getHiveMindTool('hive-mind_spawn').handler({
       count: 3,
       role: 'worker',
       agentType: 'worker',
@@ -108,9 +96,8 @@ describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
     expect(spawn.workers).toHaveLength(3);
     expect(spawn.totalWorkers).toBe(3);
 
-    // Story #807: each spawned worker must be registered with the shared
-    // coordinator under the `hive-mind` domain — not just in the legacy
-    // file-store.
+    // Each spawned worker registers with the shared coordinator under the
+    // `hive-mind` domain — not just the legacy file-store.
     const coord = await getSwarmCoordinator();
     for (const worker of spawn.workers) {
       const live = coord.getAgent(worker.agentId);
@@ -118,7 +105,7 @@ describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
       expect(coord.getDomainForAgent(worker.agentId)).toBe('hive-mind');
     }
 
-    const list = (await tool(agentTools, 'agent_list').handler({ domain: 'hive-mind' })) as AgentListResult;
+    const list = (await getAgentTool('agent_list').handler({ domain: 'hive-mind' })) as AgentListResult;
     expect(list.total).toBe(3);
     const listIds = list.agents.map(a => a.agentId).sort();
     const spawnIds = spawn.workers.map(w => w.agentId).sort();
@@ -126,13 +113,13 @@ describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
   });
 
   it('broadcast reaches every spawned worker (recipients = worker count)', async () => {
-    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
-    const spawn = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+    await getHiveMindTool('hive-mind_init').handler({ topology: 'mesh' });
+    const spawn = (await getHiveMindTool('hive-mind_spawn').handler({
       count: 3,
       agentType: 'worker',
     })) as SpawnResult;
 
-    const broadcast = (await tool(hiveMindTools, 'hive-mind_broadcast').handler({
+    const broadcast = (await getHiveMindTool('hive-mind_broadcast').handler({
       message: 'test-broadcast',
       priority: 'high',
     })) as BroadcastResult;
@@ -143,14 +130,14 @@ describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
   });
 
   it('consensus tallies real votes (not a stubbed approval)', async () => {
-    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
-    const spawn = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+    await getHiveMindTool('hive-mind_init').handler({ topology: 'mesh' });
+    const spawn = (await getHiveMindTool('hive-mind_spawn').handler({
       count: 3,
       agentType: 'worker',
     })) as SpawnResult;
     const workerIds = spawn.workers.map(w => w.agentId);
 
-    const proposal = (await tool(hiveMindTools, 'hive-mind_consensus').handler({
+    const proposal = (await getHiveMindTool('hive-mind_consensus').handler({
       action: 'propose',
       type: 'test-decision',
       value: { proposed: true },
@@ -162,7 +149,7 @@ describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
     expect(proposal.requiredVotes).toBe(2);
 
     // First "for" vote — still pending, tally is 1/0.
-    const v1 = (await tool(hiveMindTools, 'hive-mind_consensus').handler({
+    const v1 = (await getHiveMindTool('hive-mind_consensus').handler({
       action: 'vote',
       proposalId: proposal.proposalId,
       vote: true,
@@ -173,7 +160,7 @@ describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
     expect(v1.status).toBe('pending');
 
     // Second "for" vote crosses majority — proposal flips to approved.
-    const v2 = (await tool(hiveMindTools, 'hive-mind_consensus').handler({
+    const v2 = (await getHiveMindTool('hive-mind_consensus').handler({
       action: 'vote',
       proposalId: proposal.proposalId,
       vote: true,
@@ -182,10 +169,10 @@ describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
     expect(v2.votesFor).toBe(2);
     expect(v2.status).toBe('approved');
 
-    // History must contain the resolved decision (not a stubbed `result: 'approved'`).
-    const list = (await tool(hiveMindTools, 'hive-mind_consensus').handler({
+    // History contains the resolved decision (not a stubbed `result: 'approved'`).
+    const list = (await getHiveMindTool('hive-mind_consensus').handler({
       action: 'list',
-    })) as { recentHistory: Array<{ proposalId: string; result: string; votes: { for: number; against: number } }> };
+    })) as ConsensusListResult;
     const decided = list.recentHistory.find(h => h.proposalId === proposal.proposalId);
     expect(decided).toBeDefined();
     expect(decided!.result).toBe('approved');
@@ -194,32 +181,30 @@ describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
   });
 
   it('hive-mind_shutdown terminates coordinator-side records (workers leave swarm agent_list)', async () => {
-    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
-    const spawn = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+    await getHiveMindTool('hive-mind_init').handler({ topology: 'mesh' });
+    const spawn = (await getHiveMindTool('hive-mind_spawn').handler({
       count: 2,
       agentType: 'worker',
     })) as SpawnResult;
 
-    const beforeList = (await tool(agentTools, 'agent_list').handler({
+    const beforeList = (await getAgentTool('agent_list').handler({
       domain: 'hive-mind',
     })) as AgentListResult;
     expect(beforeList.total).toBe(2);
 
-    const shutdown = (await tool(hiveMindTools, 'hive-mind_shutdown').handler({
+    const shutdown = (await getHiveMindTool('hive-mind_shutdown').handler({
       force: true,
     })) as ShutdownResult;
     expect(shutdown.success).toBe(true);
     expect(shutdown.workersTerminated).toBe(2);
 
-    // Story #807: workers must be torn down on the coordinator too —
-    // `agent_list` filtered to the hive-mind domain returns nothing because
-    // `terminateAgent` removes them via `unregisterAgent` (state.agents.delete).
-    const afterList = (await tool(agentTools, 'agent_list').handler({
+    // `terminateAgent` calls `unregisterAgent` (state.agents.delete) — workers
+    // are removed entirely, not held with status='terminated'.
+    const afterList = (await getAgentTool('agent_list').handler({
       domain: 'hive-mind',
     })) as AgentListResult;
     expect(afterList.total).toBe(0);
 
-    // Belt-and-suspenders: getAgent returns undefined now — workers fully gone.
     const coord = await getSwarmCoordinator();
     for (const worker of spawn.workers) {
       expect(coord.getAgent(worker.agentId)).toBeUndefined();

--- a/tests/system/hive-mind-e2e.test.ts
+++ b/tests/system/hive-mind-e2e.test.ts
@@ -8,13 +8,11 @@
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  _resetSwarmCoordinatorForTest,
-  getSwarmCoordinator,
-} from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
+import { getSwarmCoordinator } from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
 import {
   getAgentTool,
   getHiveMindTool,
+  resetHiveAndSwarm,
 } from '../../src/cli/__tests__/mcp-tools/_helpers.js';
 
 interface InitResult {
@@ -69,15 +67,7 @@ interface AgentListResult {
 }
 
 describe('System E2E — hive-mind', () => {
-  afterEach(async () => {
-    // Best-effort hive shutdown — short-circuits when state is already cleared.
-    try {
-      await getHiveMindTool('hive-mind_shutdown').handler({ force: true });
-    } catch {
-      // hive already torn down
-    }
-    await _resetSwarmCoordinatorForTest();
-  });
+  afterEach(resetHiveAndSwarm);
 
   it('init → spawn × 3 → workers visible via swarm agent_list', async () => {
     const init = (await getHiveMindTool('hive-mind_init').handler({ topology: 'mesh' })) as InitResult;

--- a/tests/system/hive-mind-e2e.test.ts
+++ b/tests/system/hive-mind-e2e.test.ts
@@ -1,0 +1,228 @@
+/**
+ * System E2E: hive-mind end-to-end (epic #798, story #808).
+ *
+ * Drives every hive-mind MCP surface (init / spawn / broadcast / consensus /
+ * shutdown) and cross-validates Story #807: hive workers spawned via
+ * `hive-mind_spawn` MUST be visible to swarm `agent_list` because they are
+ * registered with the same UnifiedSwarmCoordinator.
+ *
+ * Coverage:
+ *   1. init → spawn × 3 → workers reachable from swarm agent_list (#807)
+ *   2. broadcast publishes through MessageBus (recipients = worker count)
+ *   3. consensus propose/vote tally crosses majority and flips status to
+ *      `approved` — verifying real vote counting, not a stubbed result
+ *   4. hive-mind_shutdown terminates the coordinator-side worker records
+ *      so swarm agent_list no longer sees them
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { agentTools } from '../../src/cli/mcp-tools/agent-tools.js';
+import { hiveMindTools } from '../../src/cli/mcp-tools/hive-mind-tools.js';
+import {
+  _resetSwarmCoordinatorForTest,
+  getSwarmCoordinator,
+} from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
+
+// ===== helpers =====
+
+function tool<T extends { name: string; handler: (input: Record<string, unknown>) => Promise<unknown> }>(
+  set: readonly T[],
+  name: string,
+): T {
+  const found = set.find(t => t.name === name);
+  if (!found) throw new Error(`tool "${name}" not registered`);
+  return found;
+}
+
+interface InitResult {
+  success: boolean;
+  hiveId: string;
+  topology: string;
+  status: string;
+}
+
+interface SpawnResult {
+  success: boolean;
+  spawned: number;
+  workers: Array<{ agentId: string; role: string; bootstrap: string }>;
+  totalWorkers: number;
+}
+
+interface BroadcastResult {
+  success: boolean;
+  messageId: string;
+  recipients: number;
+}
+
+interface ConsensusProposeResult {
+  proposalId: string;
+  status: string;
+  requiredVotes: number;
+}
+
+interface ConsensusVoteResult {
+  proposalId: string;
+  status: string;
+  votesFor: number;
+  votesAgainst: number;
+}
+
+interface ShutdownResult {
+  success: boolean;
+  workersTerminated: number;
+}
+
+interface AgentListResult {
+  agents: Array<{ agentId: string; agentType: string; domain?: string }>;
+  total: number;
+}
+
+// ===== tests =====
+
+describe('System E2E — hive-mind (epic #798, story #807 cross-check)', () => {
+  afterEach(async () => {
+    // Best-effort hive shutdown — second one short-circuits when state is
+    // already cleared, which is what we want when a test left a live hive.
+    try {
+      await tool(hiveMindTools, 'hive-mind_shutdown').handler({ force: true });
+    } catch {
+      // ignored — hive already torn down
+    }
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('init → spawn × 3 → workers visible via swarm agent_list (#807)', async () => {
+    const init = (await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' })) as InitResult;
+    expect(init.success).toBe(true);
+    expect(init.status).toBe('initialized');
+    expect(init.hiveId).toBeTruthy();
+
+    const spawn = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+      count: 3,
+      role: 'worker',
+      agentType: 'worker',
+    })) as SpawnResult;
+
+    expect(spawn.success).toBe(true);
+    expect(spawn.spawned).toBe(3);
+    expect(spawn.workers).toHaveLength(3);
+    expect(spawn.totalWorkers).toBe(3);
+
+    // Story #807: each spawned worker must be registered with the shared
+    // coordinator under the `hive-mind` domain — not just in the legacy
+    // file-store.
+    const coord = await getSwarmCoordinator();
+    for (const worker of spawn.workers) {
+      const live = coord.getAgent(worker.agentId);
+      expect(live, `worker ${worker.agentId} should exist on coordinator`).toBeDefined();
+      expect(coord.getDomainForAgent(worker.agentId)).toBe('hive-mind');
+    }
+
+    const list = (await tool(agentTools, 'agent_list').handler({ domain: 'hive-mind' })) as AgentListResult;
+    expect(list.total).toBe(3);
+    const listIds = list.agents.map(a => a.agentId).sort();
+    const spawnIds = spawn.workers.map(w => w.agentId).sort();
+    expect(listIds).toEqual(spawnIds);
+  });
+
+  it('broadcast reaches every spawned worker (recipients = worker count)', async () => {
+    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
+    const spawn = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+      count: 3,
+      agentType: 'worker',
+    })) as SpawnResult;
+
+    const broadcast = (await tool(hiveMindTools, 'hive-mind_broadcast').handler({
+      message: 'test-broadcast',
+      priority: 'high',
+    })) as BroadcastResult;
+
+    expect(broadcast.success).toBe(true);
+    expect(broadcast.messageId).toBeTruthy();
+    expect(broadcast.recipients).toBe(spawn.workers.length);
+  });
+
+  it('consensus tallies real votes (not a stubbed approval)', async () => {
+    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
+    const spawn = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+      count: 3,
+      agentType: 'worker',
+    })) as SpawnResult;
+    const workerIds = spawn.workers.map(w => w.agentId);
+
+    const proposal = (await tool(hiveMindTools, 'hive-mind_consensus').handler({
+      action: 'propose',
+      type: 'test-decision',
+      value: { proposed: true },
+      voterId: workerIds[0],
+    })) as ConsensusProposeResult;
+    expect(proposal.proposalId).toBeTruthy();
+    expect(proposal.status).toBe('pending');
+    // 3 workers → majority is floor(3/2) + 1 = 2.
+    expect(proposal.requiredVotes).toBe(2);
+
+    // First "for" vote — still pending, tally is 1/0.
+    const v1 = (await tool(hiveMindTools, 'hive-mind_consensus').handler({
+      action: 'vote',
+      proposalId: proposal.proposalId,
+      vote: true,
+      voterId: workerIds[0],
+    })) as ConsensusVoteResult;
+    expect(v1.votesFor).toBe(1);
+    expect(v1.votesAgainst).toBe(0);
+    expect(v1.status).toBe('pending');
+
+    // Second "for" vote crosses majority — proposal flips to approved.
+    const v2 = (await tool(hiveMindTools, 'hive-mind_consensus').handler({
+      action: 'vote',
+      proposalId: proposal.proposalId,
+      vote: true,
+      voterId: workerIds[1],
+    })) as ConsensusVoteResult;
+    expect(v2.votesFor).toBe(2);
+    expect(v2.status).toBe('approved');
+
+    // History must contain the resolved decision (not a stubbed `result: 'approved'`).
+    const list = (await tool(hiveMindTools, 'hive-mind_consensus').handler({
+      action: 'list',
+    })) as { recentHistory: Array<{ proposalId: string; result: string; votes: { for: number; against: number } }> };
+    const decided = list.recentHistory.find(h => h.proposalId === proposal.proposalId);
+    expect(decided).toBeDefined();
+    expect(decided!.result).toBe('approved');
+    expect(decided!.votes.for).toBe(2);
+    expect(decided!.votes.against).toBe(0);
+  });
+
+  it('hive-mind_shutdown terminates coordinator-side records (workers leave swarm agent_list)', async () => {
+    await tool(hiveMindTools, 'hive-mind_init').handler({ topology: 'mesh' });
+    const spawn = (await tool(hiveMindTools, 'hive-mind_spawn').handler({
+      count: 2,
+      agentType: 'worker',
+    })) as SpawnResult;
+
+    const beforeList = (await tool(agentTools, 'agent_list').handler({
+      domain: 'hive-mind',
+    })) as AgentListResult;
+    expect(beforeList.total).toBe(2);
+
+    const shutdown = (await tool(hiveMindTools, 'hive-mind_shutdown').handler({
+      force: true,
+    })) as ShutdownResult;
+    expect(shutdown.success).toBe(true);
+    expect(shutdown.workersTerminated).toBe(2);
+
+    // Story #807: workers must be torn down on the coordinator too —
+    // `agent_list` filtered to the hive-mind domain returns nothing because
+    // `terminateAgent` removes them via `unregisterAgent` (state.agents.delete).
+    const afterList = (await tool(agentTools, 'agent_list').handler({
+      domain: 'hive-mind',
+    })) as AgentListResult;
+    expect(afterList.total).toBe(0);
+
+    // Belt-and-suspenders: getAgent returns undefined now — workers fully gone.
+    const coord = await getSwarmCoordinator();
+    for (const worker of spawn.workers) {
+      expect(coord.getAgent(worker.agentId)).toBeUndefined();
+    }
+  });
+});

--- a/tests/system/swarm-restoration-e2e.test.ts
+++ b/tests/system/swarm-restoration-e2e.test.ts
@@ -1,42 +1,23 @@
 /**
- * System E2E: swarm restoration end-to-end (epic #798, story #808).
+ * System E2E: swarm restoration end-to-end.
  *
  * Drives the swarm/agent/task MCP surface through a full lifecycle to prove
- * the wired path from stories #799–#807 holds together as one system, not
- * just per-handler. This is the cap test for the epic — if any story's wiring
- * regresses to a stub, this is where it shows up.
- *
- * Coverage:
- *   1. swarm_init → agent_spawn × 3 → task_orchestrate × 5
- *      Load-balanced distribution: no agent gets > 2 of the 5 tasks.
- *   2. swarm_status reflects live agent + task counts (not literal `0/0`).
- *   3. agent_terminate one → swarm_status drops it from `agentSummary`.
- *   4. MCP-server-restart smoke: spawn 2 → reset singleton → agent_list still
- *      returns both via persistence hydration (story #806 verified at the
- *      system layer rather than the persistence-unit layer).
+ * the wired path holds together as a system, not just per-handler. If any
+ * MCP handler regresses to a stub, this is where it shows up.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { agentTools } from '../../src/cli/mcp-tools/agent-tools.js';
-import { swarmTools } from '../../src/cli/mcp-tools/swarm-tools.js';
-import { taskTools } from '../../src/cli/mcp-tools/task-tools.js';
 import {
   _resetSwarmCoordinatorForTest,
   _setSwarmPersistenceForTest,
 } from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
 import { SwarmPersistence } from '../../src/cli/swarm/swarm-persistence.js';
 import { createInMemoryPersistence } from '../../src/cli/__tests__/swarm/_in-memory-persistence.js';
-
-// ===== helpers =====
-
-function tool<T extends { name: string; handler: (input: Record<string, unknown>) => Promise<unknown> }>(
-  set: readonly T[],
-  name: string,
-): T {
-  const found = set.find(t => t.name === name);
-  if (!found) throw new Error(`tool "${name}" not registered`);
-  return found;
-}
+import {
+  getAgentTool,
+  getSwarmTool,
+  getTaskTool,
+} from '../../src/cli/__tests__/mcp-tools/_helpers.js';
 
 interface SpawnResult {
   success: boolean;
@@ -70,30 +51,28 @@ interface AgentListResult {
   total: number;
 }
 
-// ===== tests =====
-
-describe('System E2E — swarm restoration (epic #798)', () => {
+describe('System E2E — swarm restoration', () => {
   afterEach(async () => {
     _setSwarmPersistenceForTest(null);
     await _resetSwarmCoordinatorForTest();
   });
 
-  it('end-to-end: init → spawn × 3 → orchestrate × 5 → status reflects everything', async () => {
-    const init = (await tool(swarmTools, 'swarm_init').handler({ topology: 'mesh' })) as {
+  it('init → spawn × 3 → orchestrate × 5 → status reflects everything', async () => {
+    const init = (await getSwarmTool('swarm_init').handler({ topology: 'mesh' })) as {
       success: boolean;
       swarmId: string;
     };
     expect(init.success).toBe(true);
     expect(init.swarmId).toBeTruthy();
 
-    const a1 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    const a2 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    const a3 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a1 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a2 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a3 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
     expect([a1.success, a2.success, a3.success]).toEqual([true, true, true]);
     const agentIds = [a1.agentId, a2.agentId, a3.agentId];
 
-    const orchestrate = (await tool(taskTools, 'task_orchestrate').handler({
-      tasks: Array.from({ length: 5 }).map((_, i) => ({
+    const orchestrate = (await getTaskTool('task_orchestrate').handler({
+      tasks: Array.from({ length: 5 }, (_, i) => ({
         type: 'coding',
         description: `task-${i}`,
         priority: 'normal',
@@ -103,16 +82,17 @@ describe('System E2E — swarm restoration (epic #798)', () => {
     expect(orchestrate.submitted).toBe(5);
     expect(orchestrate.rejected).toBe(0);
 
-    // Load balance AC: no agent gets > 2 of the 5 tasks. Coordinator's
-    // `assignTask` picks lowest-workload idle agent; sequential submit in
-    // task_orchestrate prevents the race that would let two submits observe
-    // the same idle agent.
+    // Coordinator's `assignTask` picks lowest-workload idle agent; sequential
+    // submit in task_orchestrate prevents two submits from observing the same
+    // idle agent. AC: no agent gets > 2 of the 5 tasks.
     const counts = new Map<string, number>(agentIds.map(id => [id, 0]));
     for (const task of orchestrate.tasks) {
       const owner = task.assignedTo[0];
-      if (owner && counts.has(owner)) {
-        counts.set(owner, counts.get(owner)! + 1);
+      if (!owner) continue;
+      if (!counts.has(owner)) {
+        expect.fail(`task ${task.taskId} assigned to unknown agent ${owner}`);
       }
+      counts.set(owner, counts.get(owner)! + 1);
     }
     for (const [agent, count] of counts) {
       expect(count, `agent ${agent} got ${count} tasks (max 2)`).toBeLessThanOrEqual(2);
@@ -121,8 +101,7 @@ describe('System E2E — swarm restoration (epic #798)', () => {
     expect(orchestrate.assigned).toBe(3);
     expect(orchestrate.queued).toBe(2);
 
-    // swarm_status must reflect the live coordinator state, NOT a 0/0 stub.
-    const status = (await tool(swarmTools, 'swarm_status').handler({})) as StatusResult;
+    const status = (await getSwarmTool('swarm_status').handler({})) as StatusResult;
     expect(status.swarmId).toBe(init.swarmId);
     expect(status.agentCount).toBe(3);
     expect(status.taskCount).toBe(5);
@@ -130,18 +109,18 @@ describe('System E2E — swarm restoration (epic #798)', () => {
     expect(status.status).toBe('running');
   });
 
-  it('agent_terminate is reflected in swarm_status (no stub)', async () => {
-    await tool(swarmTools, 'swarm_init').handler({ topology: 'mesh' });
+  it('agent_terminate is reflected in swarm_status', async () => {
+    await getSwarmTool('swarm_init').handler({ topology: 'mesh' });
 
-    const a1 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    const a2 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    const a3 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a1 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a2 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a3 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
 
-    const before = (await tool(swarmTools, 'swarm_status').handler({})) as StatusResult;
+    const before = (await getSwarmTool('swarm_status').handler({})) as StatusResult;
     expect(before.agentSummary.total).toBe(3);
     expect(before.agentCount).toBe(3);
 
-    const term = (await tool(agentTools, 'agent_terminate').handler({
+    const term = (await getAgentTool('agent_terminate').handler({
       agentId: a2.agentId,
       force: true,
       reason: 'system-test',
@@ -151,21 +130,19 @@ describe('System E2E — swarm restoration (epic #798)', () => {
 
     // Coordinator removes terminated agents from `state.agents` (via
     // unregisterAgent) — they're gone, not held in a `terminated` row.
-    // swarm_status reflects the live count drop.
-    const after = (await tool(swarmTools, 'swarm_status').handler({})) as StatusResult;
+    const after = (await getSwarmTool('swarm_status').handler({})) as StatusResult;
     expect(after.agentSummary.total).toBe(2);
     expect(after.agentCount).toBe(2);
     expect(after.agentSummary.idle + after.agentSummary.busy).toBe(2);
 
-    // Sanity: the surviving two agents are still listed.
-    const list = (await tool(agentTools, 'agent_list').handler({
+    const list = (await getAgentTool('agent_list').handler({
       status: 'idle',
     })) as AgentListResult;
     const survivors = list.agents.map(a => a.agentId).sort();
     expect(survivors).toEqual([a1.agentId, a3.agentId].sort());
   });
 
-  describe('MCP-server restart smoke (story #806 cross-validation)', () => {
+  describe('MCP-server restart smoke', () => {
     let backend: ReturnType<typeof createInMemoryPersistence>;
 
     beforeEach(() => {
@@ -173,21 +150,20 @@ describe('System E2E — swarm restoration (epic #798)', () => {
       _setSwarmPersistenceForTest(new SwarmPersistence(backend.fns));
     });
 
-    it('spawn 2 → reset singleton → agent_list still returns both via hydration', async () => {
-      const a1 = (await tool(agentTools, 'agent_spawn').handler({
+    it('spawn 2 → reset coordinator → agent_list returns both via persistence hydration', async () => {
+      const a1 = (await getAgentTool('agent_spawn').handler({
         agentType: 'coder',
       })) as SpawnResult;
-      const a2 = (await tool(agentTools, 'agent_spawn').handler({
+      const a2 = (await getAgentTool('agent_spawn').handler({
         agentType: 'researcher',
       })) as SpawnResult;
       expect(a1.success).toBe(true);
       expect(a2.success).toBe(true);
 
-      // Simulates MCP-server restart — the singleton's `_initPromise` is the
-      // boundary between two coordinator processes for the persistence layer.
+      // Singleton reset is the test analogue of an MCP-server restart.
       await _resetSwarmCoordinatorForTest();
 
-      const list = (await tool(agentTools, 'agent_list').handler({})) as AgentListResult;
+      const list = (await getAgentTool('agent_list').handler({})) as AgentListResult;
       expect(list.total).toBe(2);
       const ids = list.agents.map(a => a.agentId).sort();
       expect(ids).toEqual([a1.agentId, a2.agentId].sort());

--- a/tests/system/swarm-restoration-e2e.test.ts
+++ b/tests/system/swarm-restoration-e2e.test.ts
@@ -17,12 +17,8 @@ import {
   getAgentTool,
   getSwarmTool,
   getTaskTool,
+  spawnAgentForTest,
 } from '../../src/cli/__tests__/mcp-tools/_helpers.js';
-
-interface SpawnResult {
-  success: boolean;
-  agentId: string;
-}
 
 interface OrchestrateResult {
   success: boolean;
@@ -65,11 +61,11 @@ describe('System E2E — swarm restoration', () => {
     expect(init.success).toBe(true);
     expect(init.swarmId).toBeTruthy();
 
-    const a1 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    const a2 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    const a3 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    expect([a1.success, a2.success, a3.success]).toEqual([true, true, true]);
-    const agentIds = [a1.agentId, a2.agentId, a3.agentId];
+    const agentIds = [
+      await spawnAgentForTest({ agentType: 'coder' }),
+      await spawnAgentForTest({ agentType: 'coder' }),
+      await spawnAgentForTest({ agentType: 'coder' }),
+    ];
 
     const orchestrate = (await getTaskTool('task_orchestrate').handler({
       tasks: Array.from({ length: 5 }, (_, i) => ({
@@ -89,10 +85,11 @@ describe('System E2E — swarm restoration', () => {
     for (const task of orchestrate.tasks) {
       const owner = task.assignedTo[0];
       if (!owner) continue;
-      if (!counts.has(owner)) {
+      const current = counts.get(owner);
+      if (current === undefined) {
         expect.fail(`task ${task.taskId} assigned to unknown agent ${owner}`);
       }
-      counts.set(owner, counts.get(owner)! + 1);
+      counts.set(owner, current + 1);
     }
     for (const [agent, count] of counts) {
       expect(count, `agent ${agent} got ${count} tasks (max 2)`).toBeLessThanOrEqual(2);
@@ -112,16 +109,16 @@ describe('System E2E — swarm restoration', () => {
   it('agent_terminate is reflected in swarm_status', async () => {
     await getSwarmTool('swarm_init').handler({ topology: 'mesh' });
 
-    const a1 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    const a2 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
-    const a3 = (await getAgentTool('agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a1 = await spawnAgentForTest({ agentType: 'coder' });
+    const a2 = await spawnAgentForTest({ agentType: 'coder' });
+    const a3 = await spawnAgentForTest({ agentType: 'coder' });
 
     const before = (await getSwarmTool('swarm_status').handler({})) as StatusResult;
     expect(before.agentSummary.total).toBe(3);
     expect(before.agentCount).toBe(3);
 
     const term = (await getAgentTool('agent_terminate').handler({
-      agentId: a2.agentId,
+      agentId: a2,
       force: true,
       reason: 'system-test',
     })) as TerminateResult;
@@ -139,7 +136,7 @@ describe('System E2E — swarm restoration', () => {
       status: 'idle',
     })) as AgentListResult;
     const survivors = list.agents.map(a => a.agentId).sort();
-    expect(survivors).toEqual([a1.agentId, a3.agentId].sort());
+    expect(survivors).toEqual([a1, a3].sort());
   });
 
   describe('MCP-server restart smoke', () => {
@@ -151,14 +148,8 @@ describe('System E2E — swarm restoration', () => {
     });
 
     it('spawn 2 → reset coordinator → agent_list returns both via persistence hydration', async () => {
-      const a1 = (await getAgentTool('agent_spawn').handler({
-        agentType: 'coder',
-      })) as SpawnResult;
-      const a2 = (await getAgentTool('agent_spawn').handler({
-        agentType: 'researcher',
-      })) as SpawnResult;
-      expect(a1.success).toBe(true);
-      expect(a2.success).toBe(true);
+      const a1 = await spawnAgentForTest({ agentType: 'coder' });
+      const a2 = await spawnAgentForTest({ agentType: 'researcher' });
 
       // Singleton reset is the test analogue of an MCP-server restart.
       await _resetSwarmCoordinatorForTest();
@@ -166,7 +157,7 @@ describe('System E2E — swarm restoration', () => {
       const list = (await getAgentTool('agent_list').handler({})) as AgentListResult;
       expect(list.total).toBe(2);
       const ids = list.agents.map(a => a.agentId).sort();
-      expect(ids).toEqual([a1.agentId, a2.agentId].sort());
+      expect(ids).toEqual([a1, a2].sort());
       const types = list.agents.map(a => a.agentType).sort();
       expect(types).toEqual(['coder', 'researcher']);
     });

--- a/tests/system/swarm-restoration-e2e.test.ts
+++ b/tests/system/swarm-restoration-e2e.test.ts
@@ -1,0 +1,198 @@
+/**
+ * System E2E: swarm restoration end-to-end (epic #798, story #808).
+ *
+ * Drives the swarm/agent/task MCP surface through a full lifecycle to prove
+ * the wired path from stories #799–#807 holds together as one system, not
+ * just per-handler. This is the cap test for the epic — if any story's wiring
+ * regresses to a stub, this is where it shows up.
+ *
+ * Coverage:
+ *   1. swarm_init → agent_spawn × 3 → task_orchestrate × 5
+ *      Load-balanced distribution: no agent gets > 2 of the 5 tasks.
+ *   2. swarm_status reflects live agent + task counts (not literal `0/0`).
+ *   3. agent_terminate one → swarm_status drops it from `agentSummary`.
+ *   4. MCP-server-restart smoke: spawn 2 → reset singleton → agent_list still
+ *      returns both via persistence hydration (story #806 verified at the
+ *      system layer rather than the persistence-unit layer).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { agentTools } from '../../src/cli/mcp-tools/agent-tools.js';
+import { swarmTools } from '../../src/cli/mcp-tools/swarm-tools.js';
+import { taskTools } from '../../src/cli/mcp-tools/task-tools.js';
+import {
+  _resetSwarmCoordinatorForTest,
+  _setSwarmPersistenceForTest,
+} from '../../src/cli/mcp-tools/swarm-coordinator-singleton.js';
+import { SwarmPersistence } from '../../src/cli/swarm/swarm-persistence.js';
+import { createInMemoryPersistence } from '../../src/cli/__tests__/swarm/_in-memory-persistence.js';
+
+// ===== helpers =====
+
+function tool<T extends { name: string; handler: (input: Record<string, unknown>) => Promise<unknown> }>(
+  set: readonly T[],
+  name: string,
+): T {
+  const found = set.find(t => t.name === name);
+  if (!found) throw new Error(`tool "${name}" not registered`);
+  return found;
+}
+
+interface SpawnResult {
+  success: boolean;
+  agentId: string;
+}
+
+interface OrchestrateResult {
+  success: boolean;
+  submitted: number;
+  rejected: number;
+  assigned: number;
+  queued: number;
+  tasks: Array<{ taskId: string; assignedTo: string[]; status: string }>;
+}
+
+interface StatusResult {
+  swarmId: string;
+  agentCount: number;
+  taskCount: number;
+  agentSummary: { total: number; active: number; idle: number; busy: number; terminated: number };
+  status: string;
+}
+
+interface TerminateResult {
+  success: boolean;
+  terminated: boolean;
+}
+
+interface AgentListResult {
+  agents: Array<{ agentId: string; agentType: string }>;
+  total: number;
+}
+
+// ===== tests =====
+
+describe('System E2E — swarm restoration (epic #798)', () => {
+  afterEach(async () => {
+    _setSwarmPersistenceForTest(null);
+    await _resetSwarmCoordinatorForTest();
+  });
+
+  it('end-to-end: init → spawn × 3 → orchestrate × 5 → status reflects everything', async () => {
+    const init = (await tool(swarmTools, 'swarm_init').handler({ topology: 'mesh' })) as {
+      success: boolean;
+      swarmId: string;
+    };
+    expect(init.success).toBe(true);
+    expect(init.swarmId).toBeTruthy();
+
+    const a1 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a2 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a3 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    expect([a1.success, a2.success, a3.success]).toEqual([true, true, true]);
+    const agentIds = [a1.agentId, a2.agentId, a3.agentId];
+
+    const orchestrate = (await tool(taskTools, 'task_orchestrate').handler({
+      tasks: Array.from({ length: 5 }).map((_, i) => ({
+        type: 'coding',
+        description: `task-${i}`,
+        priority: 'normal',
+      })),
+    })) as OrchestrateResult;
+
+    expect(orchestrate.submitted).toBe(5);
+    expect(orchestrate.rejected).toBe(0);
+
+    // Load balance AC: no agent gets > 2 of the 5 tasks. Coordinator's
+    // `assignTask` picks lowest-workload idle agent; sequential submit in
+    // task_orchestrate prevents the race that would let two submits observe
+    // the same idle agent.
+    const counts = new Map<string, number>(agentIds.map(id => [id, 0]));
+    for (const task of orchestrate.tasks) {
+      const owner = task.assignedTo[0];
+      if (owner && counts.has(owner)) {
+        counts.set(owner, counts.get(owner)! + 1);
+      }
+    }
+    for (const [agent, count] of counts) {
+      expect(count, `agent ${agent} got ${count} tasks (max 2)`).toBeLessThanOrEqual(2);
+    }
+    // 3 agents × 1 concurrent each = 3 assigned, 2 queued.
+    expect(orchestrate.assigned).toBe(3);
+    expect(orchestrate.queued).toBe(2);
+
+    // swarm_status must reflect the live coordinator state, NOT a 0/0 stub.
+    const status = (await tool(swarmTools, 'swarm_status').handler({})) as StatusResult;
+    expect(status.swarmId).toBe(init.swarmId);
+    expect(status.agentCount).toBe(3);
+    expect(status.taskCount).toBe(5);
+    expect(status.agentSummary.total).toBe(3);
+    expect(status.status).toBe('running');
+  });
+
+  it('agent_terminate is reflected in swarm_status (no stub)', async () => {
+    await tool(swarmTools, 'swarm_init').handler({ topology: 'mesh' });
+
+    const a1 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a2 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+    const a3 = (await tool(agentTools, 'agent_spawn').handler({ agentType: 'coder' })) as SpawnResult;
+
+    const before = (await tool(swarmTools, 'swarm_status').handler({})) as StatusResult;
+    expect(before.agentSummary.total).toBe(3);
+    expect(before.agentCount).toBe(3);
+
+    const term = (await tool(agentTools, 'agent_terminate').handler({
+      agentId: a2.agentId,
+      force: true,
+      reason: 'system-test',
+    })) as TerminateResult;
+    expect(term.success).toBe(true);
+    expect(term.terminated).toBe(true);
+
+    // Coordinator removes terminated agents from `state.agents` (via
+    // unregisterAgent) — they're gone, not held in a `terminated` row.
+    // swarm_status reflects the live count drop.
+    const after = (await tool(swarmTools, 'swarm_status').handler({})) as StatusResult;
+    expect(after.agentSummary.total).toBe(2);
+    expect(after.agentCount).toBe(2);
+    expect(after.agentSummary.idle + after.agentSummary.busy).toBe(2);
+
+    // Sanity: the surviving two agents are still listed.
+    const list = (await tool(agentTools, 'agent_list').handler({
+      status: 'idle',
+    })) as AgentListResult;
+    const survivors = list.agents.map(a => a.agentId).sort();
+    expect(survivors).toEqual([a1.agentId, a3.agentId].sort());
+  });
+
+  describe('MCP-server restart smoke (story #806 cross-validation)', () => {
+    let backend: ReturnType<typeof createInMemoryPersistence>;
+
+    beforeEach(() => {
+      backend = createInMemoryPersistence();
+      _setSwarmPersistenceForTest(new SwarmPersistence(backend.fns));
+    });
+
+    it('spawn 2 → reset singleton → agent_list still returns both via hydration', async () => {
+      const a1 = (await tool(agentTools, 'agent_spawn').handler({
+        agentType: 'coder',
+      })) as SpawnResult;
+      const a2 = (await tool(agentTools, 'agent_spawn').handler({
+        agentType: 'researcher',
+      })) as SpawnResult;
+      expect(a1.success).toBe(true);
+      expect(a2.success).toBe(true);
+
+      // Simulates MCP-server restart — the singleton's `_initPromise` is the
+      // boundary between two coordinator processes for the persistence layer.
+      await _resetSwarmCoordinatorForTest();
+
+      const list = (await tool(agentTools, 'agent_list').handler({})) as AgentListResult;
+      expect(list.total).toBe(2);
+      const ids = list.agents.map(a => a.agentId).sort();
+      expect(ids).toEqual([a1.agentId, a2.agentId].sort());
+      const types = list.agents.map(a => a.agentType).sort();
+      expect(types).toEqual(['coder', 'researcher']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

End-to-end system tests that cap epic #798 by exercising the wired path through every MCP surface restored by stories #799–#807 — swarm, agent, task, hive-mind — at the system layer.

## What's tested

**`tests/system/swarm-restoration-e2e.test.ts`**
- `swarm_init` → `agent_spawn × 3` → `task_orchestrate × 5` with no-agent-over-2 load balance (matches story #805 AC)
- `swarm_status` reflects live agent + task counts (not a 0/0 stub)
- `agent_terminate` causes a real `agentSummary.total` drop
- MCP-server-restart smoke: spawn 2 → reset coordinator → `agent_list` still returns both via story #806 persistence hydration

**`tests/system/hive-mind-e2e.test.ts`**
- `init → spawn × 3 → broadcast → consensus`
- Consensus tally crosses majority and flips status `pending → approved` (real votes — not a stubbed result)
- Hive workers visible in swarm `agent_list` filtered by `domain='hive-mind'` (cross-check for #807)
- `hive-mind_shutdown` removes coordinator-side records — `agent_list` returns empty, `getAgent` returns undefined

**`tests/system/bootstrap-directive-parity.test.ts`**
- Canonical directive flows byte-for-byte through hook + `agent_spawn` + `hive-mind_spawn`
- Single-Set assertion proves all surfaces emit the same string (no fork allowed)

## Side fixes shipped

- Tightened generic MCP tool descriptions (`swarm_init`/`status`, `agent_terminate`/`status`/`list`) to reflect coordinator-backing
- Extracted shared `createInMemoryPersistence` fake (used by both the unit-level story #806 test and the new system tests)
- Added `getHiveMindTool` + `resetHiveAndSwarm` helpers to `_helpers.ts` so all four MCP-tool families share one access pattern
- Migrated 8 raw `agent_spawn` call sites to the existing `spawnAgentForTest` helper

## Side fix deferred (intentional)

`zod` input schemas were **not** added — handler-level validation (whitelists, slug regex, priority/type \`Set\` checks, topology/consensus alias maps, \`validateTaskId\`) added in stories #801 / #803 / #805 already meets the Ruflo \"validate at the boundary\" intent. Adding a second valibot/zod layer would re-implement the same checks. Documented in the issue body.

## Verification

- \`npm test\` — full suite green (parallel + isolation passes)
- \`npm run lint\` — clean (\`--max-warnings 0\`)
- \`flo doctor\` — 28/28
- Three /simplify passes, converged on \"clean\"

## Test plan

- [x] Three new E2E tests pass green in isolation
- [x] Full suite green (no regressions)
- [x] Lint clean (\`--max-warnings 0\`)
- [x] Doctor 28/28
- [x] Restart smoke verifies persistence hydration after coordinator reset
- [x] Bootstrap directive identical across hook + \`agent_spawn\` + \`hive-mind_spawn\`

Refs #798
Closes #808

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)