### PR TITLE
feat(818): doctor functional tripwires for swarm + hive-mind

### DIFF
--- a/src/cli/__tests__/doctor-checks-swarm.test.ts
+++ b/src/cli/__tests__/doctor-checks-swarm.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the swarm + hive-mind functional doctor checks (issue #818, epic #798).
+ *
+ * The detailed regression-detection contract is exercised end-to-end in
+ * `tests/system/swarm-restoration-e2e.test.ts` and
+ * `tests/system/hive-mind-e2e.test.ts` (via `flo doctor --json`); these unit
+ * tests cover the structural contract — return shape, detail records, and
+ * graceful-degradation when modules are missing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  checkSwarmFunctional,
+  checkHiveMindFunctional,
+  type FunctionalHealthCheck,
+} from '../commands/doctor-checks-swarm.js';
+
+function expectFunctionalShape(result: FunctionalHealthCheck) {
+  expect(result.name).toBeTruthy();
+  expect(['pass', 'warn', 'fail']).toContain(result.status);
+  expect(result.message.length).toBeGreaterThan(0);
+}
+
+describe('doctor-checks-swarm', () => {
+  describe('checkSwarmFunctional', () => {
+    it('returns a HealthCheck with details when modules are built', { timeout: 30_000 }, async () => {
+      const result = await checkSwarmFunctional();
+      expect(result.name).toBe('Swarm Functional');
+      expectFunctionalShape(result);
+
+      // When the dist is built, every subcheck has structured details (id +
+      // mcpTool + observed + expected). When it's not built, the check
+      // degrades to a single 'warn' with no details — that's the documented
+      // fallback.
+      if (result.status === 'pass' || result.status === 'fail') {
+        expect(Array.isArray(result.details)).toBe(true);
+        expect(result.details!.length).toBeGreaterThan(0);
+        for (const d of result.details!) {
+          expect(d.id).toBeTruthy();
+          expect(d.mcpTool).toBeTruthy();
+          expect(['pass', 'warn', 'fail']).toContain(d.status);
+          expect(d.expected).toBeTruthy();
+        }
+      }
+    });
+
+    it('passes against the real UnifiedSwarmCoordinator (regression tripwire)', { timeout: 30_000 }, async () => {
+      const result = await checkSwarmFunctional();
+
+      // A 'warn' here means the dist isn't built — skip the strict assertion
+      // (the dev repo always has dist; CI builds before testing).
+      if (result.status === 'warn' && /not built/i.test(result.message)) {
+        return;
+      }
+
+      expect(result.status, `expected pass, got ${result.status}: ${result.message}`).toBe('pass');
+      const details = result.details ?? [];
+      const ids = details.map(d => d.id);
+
+      // Spot-check the regression-critical subchecks are present.
+      expect(ids).toContain('swarm_init.coordinator-issued-id');
+      expect(ids).toContain('agent_spawn.coordinator-backed');
+      expect(ids).toContain('swarm_status.live-counts');
+      expect(ids).toContain('agent_list.coordinator-state');
+
+      // Every subcheck must have passed.
+      const failures = details.filter(d => d.status === 'fail');
+      expect(failures, `subcheck failures: ${JSON.stringify(failures, null, 2)}`).toHaveLength(0);
+    });
+  });
+
+  describe('checkHiveMindFunctional', () => {
+    it('returns a HealthCheck with details when modules are built', { timeout: 30_000 }, async () => {
+      const result = await checkHiveMindFunctional();
+      expect(result.name).toBe('Hive-Mind Functional');
+      expectFunctionalShape(result);
+
+      if (result.status === 'pass' || result.status === 'fail') {
+        expect(Array.isArray(result.details)).toBe(true);
+        expect(result.details!.length).toBeGreaterThan(0);
+        for (const d of result.details!) {
+          expect(d.id).toBeTruthy();
+          expect(d.mcpTool).toBeTruthy();
+          expect(['pass', 'warn', 'fail']).toContain(d.status);
+          expect(d.expected).toBeTruthy();
+        }
+      }
+    });
+
+    it('passes (or degrades to warn) against the real MessageBus + coordinator', { timeout: 30_000 }, async () => {
+      const result = await checkHiveMindFunctional();
+
+      if (result.status === 'warn' && /not built/i.test(result.message)) {
+        return;
+      }
+
+      // 'pass' is the happy path; 'warn' is acceptable only when memory backend
+      // is unavailable (softFailMessage path) — never 'fail'.
+      expect(result.status, `expected pass or warn, got fail: ${result.message}`).not.toBe('fail');
+
+      const details = result.details ?? [];
+      const ids = details.map(d => d.id);
+      expect(ids).toContain('hive-mind_init.bus-and-adapter');
+      expect(ids).toContain('hive-mind_spawn.shared-coordinator');
+      expect(ids).toContain('agent_list.hive-domain-visible');
+      expect(ids).toContain('hive-mind_broadcast.bus-exchange');
+
+      // No subcheck should have failed.
+      const failures = details.filter(d => d.status === 'fail');
+      expect(failures, `subcheck failures: ${JSON.stringify(failures, null, 2)}`).toHaveLength(0);
+    });
+  });
+
+  describe('consumer-path resolution', () => {
+    it('uses import.meta.url / findMofloPackageRoot, never process.cwd()', async () => {
+      const { readFileSync } = await import('fs');
+      const { join } = await import('path');
+      const source = readFileSync(
+        join(process.cwd(), 'src', 'cli', 'commands', 'doctor-checks-swarm.ts'),
+        'utf8',
+      );
+      // Same contract as doctor-checks-deep — no `process.cwd()` for module
+      // resolution because that breaks when moflo is installed under
+      // `node_modules/moflo/...` (see feedback_consumer_path_resolution.md).
+      // Path resolution is delegated to doctor-checks-deep's exported
+      // `findModule` + `toImportUrl`, which use `findMofloPackageRoot` under
+      // the hood — we just assert the import.
+      const cwdUsages = source.match(/process\.cwd\(\)/g) ?? [];
+      expect(cwdUsages.length).toBe(0);
+      expect(source).toMatch(/from '\.\/doctor-checks-deep\.js'/);
+      expect(source).toMatch(/findModule|toImportUrl/);
+    });
+  });
+});

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -33,7 +33,7 @@ export interface HealthCheck {
 // ============================================================================
 
 /** Convert an absolute path to a file:// URL for dynamic import() on Windows. */
-function toImportUrl(absolutePath: string): string {
+export function toImportUrl(absolutePath: string): string {
   return pathToFileURL(absolutePath).href;
 }
 
@@ -49,7 +49,7 @@ export function getMofloRoot(): string | undefined {
 /**
  * Find the first existing .js module from paths relative to the moflo root.
  */
-function findModule(...relativePaths: string[]): string | undefined {
+export function findModule(...relativePaths: string[]): string | undefined {
   const root = getMofloRoot();
   if (!root) return undefined;
   for (const rel of relativePaths) {

--- a/src/cli/commands/doctor-checks-swarm.ts
+++ b/src/cli/commands/doctor-checks-swarm.ts
@@ -1,0 +1,465 @@
+/**
+ * Functional Doctor Checks for Swarm + Hive-Mind (issue #818, epic #798)
+ *
+ * Exercises the real UnifiedSwarmCoordinator + MessageBus + WriteThroughAdapter
+ * paths through the MCP tool surface. Regression tripwire for the
+ * silent-disconnect failure that triggered #798: handlers returning hardcoded
+ * literals (e.g. `{ swarmId: 'swarm-' + Date.now() }`,
+ * `{ agentCount: 0, taskCount: 0 }`) while the install otherwise looks healthy.
+ *
+ * Path resolution mirrors `doctor-checks-deep.ts` — modules load from the
+ * moflo package root via `import.meta.url`, so checks behave identically in
+ * the dev tree and in `node_modules/moflo/...` consumer installs.
+ */
+
+import { errorDetail } from '../shared/utils/error-detail.js';
+import { findModule, toImportUrl, type HealthCheck } from './doctor-checks-deep.js';
+
+export interface FunctionalCheckDetail {
+  id: string;
+  mcpTool: string;
+  status: 'pass' | 'warn' | 'fail';
+  observed?: unknown;
+  expected: string;
+  message?: string;
+}
+
+export interface FunctionalHealthCheck extends HealthCheck {
+  details?: FunctionalCheckDetail[];
+}
+
+interface ToolHandler {
+  name: string;
+  handler?: (input: Record<string, unknown>, ctx?: unknown) => Promise<unknown>;
+}
+
+const SWARM_FUNCTIONAL_CHECK = 'Swarm Functional';
+const HIVE_FUNCTIONAL_CHECK = 'Hive-Mind Functional';
+
+/**
+ * Stub-sentinel pattern for the #798 regression:
+ * `swarmId: 'swarm-' + Date.now()` (hyphen + ms only). The live coordinator
+ * uses underscore separators with a random suffix
+ * (`swarm_${Date.now()}_${random}`); seeing a value matching the sentinel
+ * shape means the handler is disconnected from `UnifiedSwarmCoordinator`.
+ */
+const STUB_SWARM_ID_PATTERN = /^swarm-\d+$/;
+
+async function loadToolArrays(rels: Record<string, string>): Promise<Record<string, ToolHandler[]> | null> {
+  const paths: Record<string, string> = {};
+  for (const [k, rel] of Object.entries(rels)) {
+    const p = findModule(rel);
+    if (!p) return null;
+    paths[k] = p;
+  }
+  const entries = await Promise.all(
+    Object.entries(paths).map(async ([k, p]) => [k, await import(toImportUrl(p))] as const),
+  );
+  const out: Record<string, ToolHandler[]> = {};
+  for (const [k, mod] of entries) {
+    const arrName = Object.keys(mod).find(name => Array.isArray(mod[name]) && mod[name].every((t: unknown) => typeof (t as ToolHandler)?.name === 'string'));
+    if (!arrName) return null;
+    out[k] = mod[arrName] as ToolHandler[];
+  }
+  return out;
+}
+
+function getTool(tools: ToolHandler[], name: string): ToolHandler | undefined {
+  return tools.find(t => t.name === name);
+}
+
+interface Expectation {
+  id: string;
+  mcpTool: string;
+  expected: string;
+  /** Return null on pass, or a failure-reason string. */
+  assert: (out: unknown) => string | null;
+  /** When set, return value triggers `warn` instead of `fail` (environmental, not a regression). */
+  softFailMessage?: (out: unknown) => string | null;
+}
+
+async function safeInvoke(
+  tools: ToolHandler[],
+  name: string,
+  input: Record<string, unknown>,
+  details: FunctionalCheckDetail[],
+  ex: Expectation,
+): Promise<unknown> {
+  const tool = getTool(tools, name);
+  if (!tool?.handler) {
+    details.push({
+      id: ex.id, mcpTool: ex.mcpTool, status: 'fail',
+      observed: { reason: 'tool-not-registered' }, expected: ex.expected,
+      message: `MCP tool "${name}" not registered in the loaded tool array`,
+    });
+    return undefined;
+  }
+  try {
+    const out = await tool.handler(input);
+    const softReason = ex.softFailMessage?.(out);
+    if (softReason) {
+      details.push({ id: ex.id, mcpTool: ex.mcpTool, status: 'warn', observed: out, expected: ex.expected, message: softReason });
+      return out;
+    }
+    const failReason = ex.assert(out);
+    details.push(failReason
+      ? { id: ex.id, mcpTool: ex.mcpTool, status: 'fail', observed: out, expected: ex.expected, message: failReason }
+      : { id: ex.id, mcpTool: ex.mcpTool, status: 'pass', observed: out, expected: ex.expected },
+    );
+    return out;
+  } catch (err) {
+    const detail = errorDetail(err, { firstLineOnly: true });
+    details.push({
+      id: ex.id, mcpTool: ex.mcpTool, status: 'fail',
+      observed: { error: detail }, expected: ex.expected,
+      message: `handler threw: ${detail}`,
+    });
+    return undefined;
+  }
+}
+
+function summarize(name: string, details: FunctionalCheckDetail[]): FunctionalHealthCheck {
+  const fails = details.filter(d => d.status === 'fail');
+  const warns = details.filter(d => d.status === 'warn');
+  if (fails.length > 0) {
+    const first = fails[0];
+    return {
+      name, status: 'fail',
+      message: `${fails.length}/${details.length} subcheck(s) failed (e.g. ${first.id} via ${first.mcpTool}: ${first.message ?? first.expected})`,
+      fix: 'Run `flo doctor --json` for per-subcheck details; investigate any handler that disconnected from UnifiedSwarmCoordinator (epic #798)',
+      details,
+    };
+  }
+  if (warns.length > 0) {
+    return {
+      name, status: 'warn',
+      message: `${details.length - warns.length}/${details.length} pass; ${warns.length} degraded (likely environment, not regression)`,
+      details,
+    };
+  }
+  return { name, status: 'pass', message: `${details.length} subchecks OK (coordinator path verified)`, details };
+}
+
+// ============================================================================
+// Swarm Functional Check
+// ============================================================================
+
+export async function checkSwarmFunctional(): Promise<FunctionalHealthCheck> {
+  const details: FunctionalCheckDetail[] = [];
+
+  const mods = await loadToolArrays({
+    swarmTools: 'dist/src/cli/mcp-tools/swarm-tools.js',
+    agentTools: 'dist/src/cli/mcp-tools/agent-tools.js',
+    taskTools: 'dist/src/cli/mcp-tools/task-tools.js',
+  });
+  if (!mods) {
+    return { name: SWARM_FUNCTIONAL_CHECK, status: 'warn', message: 'swarm/agent/task tool modules not built', fix: 'npm run build' };
+  }
+  const { swarmTools, agentTools, taskTools } = mods;
+
+  // 1. swarm_init returns a coordinator-issued id, not the stub literal.
+  // Real id format is `swarm_${Date.now()}_${random}` (underscore); regression
+  // literal was `swarm-${Date.now()}` (hyphen).
+  await safeInvoke(swarmTools, 'swarm_init', { topology: 'mesh' }, details, {
+    id: 'swarm_init.coordinator-issued-id',
+    mcpTool: 'swarm_init',
+    expected: 'success=true with a non-stub swarmId from UnifiedSwarmCoordinator',
+    assert: (raw) => {
+      const out = raw as { success?: boolean; swarmId?: string };
+      if (!out?.success) return 'handler returned success=false';
+      if (typeof out.swarmId !== 'string' || !out.swarmId) return 'no swarmId returned';
+      if (STUB_SWARM_ID_PATTERN.test(out.swarmId)) {
+        return 'swarmId matches stub literal `swarm-${Date.now()}` shape — handler may be disconnected from coordinator';
+      }
+      return null;
+    },
+  });
+
+  // 2. agent_spawn registers an agent on the live coordinator.
+  const spawnOut = (await safeInvoke(agentTools, 'agent_spawn', { agentType: 'coder' }, details, {
+    id: 'agent_spawn.coordinator-backed',
+    mcpTool: 'agent_spawn',
+    expected: 'success=true with an agentId issued by coordinator.spawnAgent (not a JSON-store write)',
+    assert: (raw) => {
+      const out = raw as { success?: boolean; agentId?: string; spawned?: boolean };
+      if (!out?.success) return `success=false: ${JSON.stringify(out)}`;
+      if (typeof out.agentId !== 'string' || !out.agentId) return 'no agentId returned';
+      if (out.spawned !== true) return 'spawned!=true — coordinator may not have accepted the spawn';
+      return null;
+    },
+  })) as { agentId?: string } | undefined;
+  const agentId = spawnOut?.agentId;
+
+  // 3. agent_list reflects coordinator state, not the legacy file-store.
+  if (agentId) {
+    await safeInvoke(agentTools, 'agent_list', {}, details, {
+      id: 'agent_list.coordinator-state',
+      mcpTool: 'agent_list',
+      expected: `agent_list contains the just-spawned ${agentId} (proves coordinator-backed read, not JSON-store stub)`,
+      assert: (raw) => {
+        const agents = (raw as { agents?: Array<{ agentId: string }> })?.agents ?? [];
+        if (!Array.isArray(agents) || agents.length === 0) {
+          return 'agent_list returned 0 agents after agent_spawn — handler may be reading the legacy JSON store';
+        }
+        if (!agents.some(a => a.agentId === agentId)) {
+          return `spawned agent ${agentId} not in agent_list (got: ${agents.map(a => a.agentId).join(', ')})`;
+        }
+        return null;
+      },
+    });
+
+    // 4. agent_status returns coordinator-tracked status (idle | busy).
+    await safeInvoke(agentTools, 'agent_status', { agentId, includeMetrics: false }, details, {
+      id: 'agent_status.coordinator-state',
+      mcpTool: 'agent_status',
+      expected: 'agent_status returns coordinator-tracked status (idle | busy)',
+      assert: (raw) => {
+        const out = raw as { status?: string; agentId?: string };
+        if (!out?.status) return 'no status field in response';
+        if (!['idle', 'busy'].includes(out.status)) return `expected idle|busy, got "${out.status}"`;
+        if (out.agentId !== agentId) return `expected agentId=${agentId}, got ${out.agentId}`;
+        return null;
+      },
+    });
+  }
+
+  // 5. swarm_status agentCount/taskCount are live (regression returned hardcoded 0).
+  await safeInvoke(swarmTools, 'swarm_status', {}, details, {
+    id: 'swarm_status.live-counts',
+    mcpTool: 'swarm_status',
+    expected: 'agentCount > 0 and taskCount is a live coordinator counter',
+    assert: (raw) => {
+      const out = raw as { agentCount?: number; taskCount?: number; agentSummary?: { total?: number } };
+      if (typeof out?.agentCount !== 'number') return 'agentCount missing';
+      if (out.agentCount === 0) {
+        return 'agentCount=0 after agent_spawn — handler likely returns hardcoded `{ agentCount: 0, taskCount: 0 }` literal';
+      }
+      if (typeof out.taskCount !== 'number') return 'taskCount missing';
+      if (out.agentSummary?.total !== out.agentCount) {
+        return `agentSummary.total (${out.agentSummary?.total}) != agentCount (${out.agentCount})`;
+      }
+      return null;
+    },
+  });
+
+  // 6. swarm_health surfaces the coordinator probe.
+  await safeInvoke(swarmTools, 'swarm_health', {}, details, {
+    id: 'swarm_health.coordinator-probe',
+    mcpTool: 'swarm_health',
+    expected: 'checks[] includes a `coordinator` entry sourced from coordinator.getState()',
+    assert: (raw) => {
+      const out = raw as { checks?: Array<{ name: string }>; status?: string };
+      const checks = Array.isArray(out?.checks) ? out.checks : null;
+      if (!checks) return 'no checks[] in response — handler likely stubbed';
+      if (!checks.some(c => c.name === 'coordinator')) return `no coordinator check (got: ${checks.map(c => c.name).join(', ')})`;
+      if (typeof out.status !== 'string') return 'no overall status field';
+      return null;
+    },
+  });
+
+  // 7. task_create round-trips through coordinator.submitTask.
+  const taskOut = (await safeInvoke(taskTools, 'task_create', {
+    type: 'coding', description: 'doctor-functional-probe',
+  }, details, {
+    id: 'task_create.coordinator-submit',
+    mcpTool: 'task_create',
+    expected: 'success=true with a coordinator-issued taskId',
+    assert: (raw) => {
+      const out = raw as { success?: boolean; taskId?: string };
+      if (!out?.success) return `task_create returned ${JSON.stringify(out)}`;
+      if (typeof out.taskId !== 'string' || !out.taskId) return 'no taskId in response';
+      return null;
+    },
+  })) as { taskId?: string } | undefined;
+  const taskId = taskOut?.taskId;
+
+  // 8. task_complete advances state through coordinator.completeTask.
+  if (taskId) {
+    await safeInvoke(taskTools, 'task_complete', { taskId, result: { ok: true } }, details, {
+      id: 'task_complete.coordinator-state',
+      mcpTool: 'task_complete',
+      expected: 'success=true and status=completed via coordinator.completeTask',
+      assert: (raw) => {
+        const out = raw as { success?: boolean; status?: string };
+        if (!out?.success) return `task_complete returned ${JSON.stringify(out)}`;
+        if (out.status !== 'completed') return `expected status=completed, got "${out.status}"`;
+        return null;
+      },
+    });
+  }
+
+  // 9. agent_terminate flows through coordinator.terminateAgent (also cleanup).
+  if (agentId) {
+    await safeInvoke(agentTools, 'agent_terminate', { agentId, force: true, reason: 'doctor-cleanup' }, details, {
+      id: 'agent_terminate.coordinator-removes',
+      mcpTool: 'agent_terminate',
+      expected: 'success=true and terminated=true; agent removed from coordinator state',
+      assert: (raw) => {
+        const out = raw as { success?: boolean; terminated?: boolean };
+        if (!out?.success) return `agent_terminate returned ${JSON.stringify(out)}`;
+        if (out.terminated !== true) return `expected terminated=true, got ${out.terminated}`;
+        return null;
+      },
+    });
+  }
+
+  return summarize(SWARM_FUNCTIONAL_CHECK, details);
+}
+
+// ============================================================================
+// Hive-Mind Functional Check
+// ============================================================================
+
+export async function checkHiveMindFunctional(): Promise<FunctionalHealthCheck> {
+  const details: FunctionalCheckDetail[] = [];
+
+  const mods = await loadToolArrays({
+    hiveMindTools: 'dist/src/cli/mcp-tools/hive-mind-tools.js',
+    agentTools: 'dist/src/cli/mcp-tools/agent-tools.js',
+  });
+  if (!mods) {
+    return { name: HIVE_FUNCTIONAL_CHECK, status: 'warn', message: 'hive-mind / agent tool modules not built', fix: 'npm run build' };
+  }
+  const { hiveMindTools, agentTools } = mods;
+
+  // 1. hive-mind_init wires MessageBus + WriteThroughAdapter (story #121).
+  await safeInvoke(hiveMindTools, 'hive-mind_init', { topology: 'mesh' }, details, {
+    id: 'hive-mind_init.bus-and-adapter',
+    mcpTool: 'hive-mind_init',
+    expected: 'success=true with hiveId and status=initialized',
+    assert: (raw) => {
+      const out = raw as { success?: boolean; hiveId?: string; status?: string };
+      if (!out?.success) return 'init returned success=false';
+      if (typeof out.hiveId !== 'string' || !out.hiveId) return 'no hiveId returned';
+      if (out.status !== 'initialized') return `expected status=initialized, got "${out.status}"`;
+      return null;
+    },
+  });
+
+  // 2. hive-mind_spawn registers workers with the shared coordinator (story #807).
+  const spawnOut = (await safeInvoke(hiveMindTools, 'hive-mind_spawn', {
+    count: 2, role: 'worker', agentType: 'worker',
+  }, details, {
+    id: 'hive-mind_spawn.shared-coordinator',
+    mcpTool: 'hive-mind_spawn',
+    expected: 'spawned=2 with worker ids registered on the shared coordinator',
+    assert: (raw) => {
+      const out = raw as { success?: boolean; spawned?: number; workers?: Array<{ agentId: string }> };
+      if (!out?.success) return `hive-mind_spawn returned ${JSON.stringify(out)}`;
+      if (out.spawned !== 2) return `expected spawned=2, got ${out.spawned}`;
+      if (!Array.isArray(out.workers) || out.workers.length !== 2) {
+        return `workers[] missing or wrong length: ${JSON.stringify(out.workers)}`;
+      }
+      return null;
+    },
+  })) as { workers?: Array<{ agentId: string }> } | undefined;
+
+  const workerIds: string[] = (spawnOut?.workers ?? [])
+    .map(w => w.agentId)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  // 3. swarm agent_list({domain:'hive-mind'}) sees those workers — proves shared state.
+  if (workerIds.length > 0) {
+    await safeInvoke(agentTools, 'agent_list', { domain: 'hive-mind' }, details, {
+      id: 'agent_list.hive-domain-visible',
+      mcpTool: 'agent_list',
+      expected: `swarm agent_list({domain:'hive-mind'}) returns the ${workerIds.length} hive workers`,
+      assert: (raw) => {
+        const ids = ((raw as { agents?: Array<{ agentId: string }> })?.agents ?? []).map(a => a.agentId);
+        const missing = workerIds.filter(id => !ids.includes(id));
+        if (missing.length > 0) {
+          return `${missing.length} hive worker(s) missing from swarm agent_list — coordinator shared-state regression (${missing.join(', ')})`;
+        }
+        return null;
+      },
+    });
+  }
+
+  // 4. hive-mind_broadcast exchanges via MessageBus.
+  await safeInvoke(hiveMindTools, 'hive-mind_broadcast', {
+    message: 'doctor-probe', priority: 'normal',
+  }, details, {
+    id: 'hive-mind_broadcast.bus-exchange',
+    mcpTool: 'hive-mind_broadcast',
+    expected: 'success=true with messageId and recipients matching worker count',
+    assert: (raw) => {
+      const out = raw as { success?: boolean; messageId?: string; recipients?: number };
+      if (!out?.success) return 'broadcast returned success=false';
+      if (typeof out.messageId !== 'string' || !out.messageId) return 'no messageId from MessageBus';
+      if (out.recipients !== workerIds.length) return `recipients=${out.recipients} != worker count=${workerIds.length}`;
+      return null;
+    },
+  });
+
+  // 5. hive-mind_consensus tallies real votes.
+  if (workerIds.length >= 2) {
+    const propose = (await safeInvoke(hiveMindTools, 'hive-mind_consensus', {
+      action: 'propose', type: 'doctor-test', value: { x: 1 }, voterId: workerIds[0],
+    }, details, {
+      id: 'hive-mind_consensus.propose',
+      mcpTool: 'hive-mind_consensus',
+      expected: 'proposalId returned with status=pending',
+      assert: (raw) => {
+        const out = raw as { proposalId?: string; status?: string };
+        if (typeof out?.proposalId !== 'string' || !out.proposalId) return 'no proposalId';
+        if (out.status !== 'pending') return `expected status=pending, got "${out.status}"`;
+        return null;
+      },
+    })) as { proposalId?: string } | undefined;
+
+    if (propose?.proposalId) {
+      await safeInvoke(hiveMindTools, 'hive-mind_consensus', {
+        action: 'vote', proposalId: propose.proposalId, vote: true, voterId: workerIds[0],
+      }, details, {
+        id: 'hive-mind_consensus.vote-tally',
+        mcpTool: 'hive-mind_consensus',
+        expected: 'votesFor>=1 after first vote (real tally, not stubbed approval)',
+        assert: (raw) => {
+          const out = raw as { votesFor?: number };
+          if (typeof out?.votesFor !== 'number') return 'votesFor missing';
+          if (out.votesFor < 1) return `expected votesFor>=1, got ${out.votesFor}`;
+          return null;
+        },
+      });
+    }
+  }
+
+  // 6. hive-mind_memory roundtrips via Memory DB write-through.
+  // Memory backend unavailable (e.g. fresh smoke fixture before `memory init`)
+  // is environmental, not a regression — softFailMessage downgrades to warn.
+  const probeKey = `doctor-probe-${Date.now()}`;
+  const sentinel = `hive-doctor-${Date.now()}`;
+  const setOut = await safeInvoke(hiveMindTools, 'hive-mind_memory', {
+    action: 'set', key: probeKey, value: { sentinel },
+  }, details, {
+    id: 'hive-mind_memory.set',
+    mcpTool: 'hive-mind_memory',
+    expected: 'memory set succeeds via Memory DB write-through',
+    softFailMessage: (raw) => (raw as { success?: boolean })?.success === true
+      ? null
+      : 'memory set returned success=false — Memory DB unavailable (likely fresh consumer fixture, not a regression)',
+    assert: () => null,
+  });
+
+  if ((setOut as { success?: boolean } | undefined)?.success === true) {
+    await safeInvoke(hiveMindTools, 'hive-mind_memory', { action: 'get', key: probeKey }, details, {
+      id: 'hive-mind_memory.get',
+      mcpTool: 'hive-mind_memory',
+      expected: 'memory get returns previously-set value (proves shared store, not in-memory only)',
+      assert: (raw) => {
+        const out = raw as { exists?: boolean; value?: { sentinel?: string } };
+        if (!out?.exists) return 'get returned exists=false after a successful set — write-through to Memory DB is broken';
+        if (out.value?.sentinel !== sentinel) return `value mismatch: expected sentinel="${sentinel}", got ${JSON.stringify(out.value)}`;
+        return null;
+      },
+    });
+  }
+
+  // 7. Cleanup — graceful shutdown (best-effort; failures here aren't a regression signal).
+  try {
+    const shutdown = getTool(hiveMindTools, 'hive-mind_shutdown');
+    if (shutdown?.handler) await shutdown.handler({ force: true });
+  } catch { /* ignore */ }
+
+  return summarize(HIVE_FUNCTIONAL_CHECK, details);
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -26,6 +26,10 @@ import {
   getMofloRoot,
 } from './doctor-checks-deep.js';
 import { checkEmbeddingHygiene } from './doctor-embedding-hygiene.js';
+import {
+  checkSwarmFunctional,
+  checkHiveMindFunctional,
+} from './doctor-checks-swarm.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 import {
   legacyMemoryDbPath,
@@ -1260,7 +1264,7 @@ export const doctorCommand: Command = {
     {
       name: 'component',
       short: 'c',
-      description: 'Check specific component (version, node, npm, config, daemon, memory, embeddings, git, mcp, claude, disk, typescript, semantic, intelligence)',
+      description: 'Check specific component (version, node, npm, config, daemon, memory, embeddings, git, mcp, claude, disk, typescript, semantic, intelligence, swarm, hive-mind)',
       type: 'string'
     },
     {
@@ -1294,6 +1298,15 @@ export const doctorCommand: Command = {
       name: 'allow-warn',
       description: 'In --strict mode, comma-separated check names whose warnings are tolerated.',
       type: 'string'
+    },
+    {
+      // Issue #818: machine-readable output. Suppresses banner/spinner/auto-fix
+      // and emits a single JSON document so CI gates and smoke harnesses can
+      // consume per-check details (including FunctionalCheckDetail entries).
+      name: 'json',
+      description: 'Emit a single JSON document with per-check + per-subcheck details. Suppresses formatted output.',
+      type: 'boolean',
+      default: false
     }
   ],
   examples: [
@@ -1303,7 +1316,10 @@ export const doctorCommand: Command = {
     { command: 'claude-flow doctor --kill-zombies', description: 'Find and kill zombie processes' },
     { command: 'claude-flow doctor -c version', description: 'Check for stale npx cache' },
     { command: 'claude-flow doctor -c claude', description: 'Check Claude Code CLI only' },
-    { command: 'claude-flow doctor --strict', description: 'Fail (exit 1) on any warning — used by CI' }
+    { command: 'claude-flow doctor --strict', description: 'Fail (exit 1) on any warning — used by CI' },
+    { command: 'claude-flow doctor --json', description: 'Emit a single JSON doc with per-check + per-subcheck details (for CI/smoke gates)' },
+    { command: 'claude-flow doctor -c swarm', description: 'Run only the swarm + agent + task coordinator-path tripwire (epic #798)' },
+    { command: 'claude-flow doctor -c hive-mind', description: 'Run only the hive-mind MessageBus + shared-coordinator tripwire' }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const showFix = ctx.flags.fix as boolean;
@@ -1320,16 +1336,19 @@ export const doctorCommand: Command = {
     const allowWarnList = allowWarnRaw
       ? allowWarnRaw.split(',').map((s) => s.trim()).filter(Boolean)
       : [];
+    const jsonOutput = ctx.flags.json as boolean;
 
-    output.writeln();
-    output.writeln(output.bold('MoFlo Doctor'));
-    output.writeln(output.dim('System diagnostics and health check'));
-    output.writeln(output.dim('─'.repeat(50)));
-    output.writeln();
+    if (!jsonOutput) {
+      output.writeln();
+      output.writeln(output.bold('MoFlo Doctor'));
+      output.writeln(output.dim('System diagnostics and health check'));
+      output.writeln(output.dim('─'.repeat(50)));
+      output.writeln();
+    }
 
     // --allow-warn is meaningless without --strict; surface the misuse
     // under the banner so it reads as doctor output, not orphaned text.
-    if (allowWarnList.length > 0 && !strict) {
+    if (allowWarnList.length > 0 && !strict && !jsonOutput) {
       output.writeln(output.warning(
         '--allow-warn requires --strict; ignoring (warnings are tolerated by default).',
       ));
@@ -1571,6 +1590,11 @@ export const doctorCommand: Command = {
       checkHookExecution,
       checkGateHealth,
       checkMofloDbBridge,
+      // Issue #818 / epic #798 — coordinator-path tripwires. They share the
+      // singleton coordinator with checkSubagentHealth above and assert by
+      // agent-id (not absolute counts) so they tolerate the parallel batch.
+      checkSwarmFunctional,
+      checkHiveMindFunctional,
       checkSandboxTier,
     ];
 
@@ -1611,6 +1635,11 @@ export const doctorCommand: Command = {
       'sandbox-tier': checkSandboxTier,
       'moflodb': checkMofloDbBridge,
       'bridge': checkMofloDbBridge,
+      'swarm': checkSwarmFunctional,
+      'swarm-functional': checkSwarmFunctional,
+      'hive': checkHiveMindFunctional,
+      'hive-mind': checkHiveMindFunctional,
+      'hive-mind-functional': checkHiveMindFunctional,
     };
 
     let checksToRun = allChecks;
@@ -1622,20 +1651,43 @@ export const doctorCommand: Command = {
     const fixes: string[] = [];
 
     // OPTIMIZATION: Run all checks in parallel for 3-5x faster execution
-    const spinner = output.createSpinner({ text: 'Running health checks in parallel...', spinner: 'dots' });
-    spinner.start();
+    const spinner = jsonOutput
+      ? null
+      : output.createSpinner({ text: 'Running health checks in parallel...', spinner: 'dots' });
+    spinner?.start();
+
+    // Issue #818: in --json mode, several deep checks (spell engine probe,
+    // mcp-spell bridge, etc.) write `[spell] ...` log lines straight to
+    // stdout — that breaks the single-JSON-document contract. Capture and
+    // discard stdout writes while checks run; restore in `finally` so a
+    // throw can't leave the process with a stubbed stdout.
+    const realStdoutWrite = process.stdout.write.bind(process.stdout);
+    const restoreStdout = () => {
+      if (jsonOutput) {
+        (process.stdout as unknown as { write: typeof realStdoutWrite }).write = realStdoutWrite;
+      }
+    };
+    if (jsonOutput) {
+      (process.stdout as unknown as { write: (...args: unknown[]) => boolean }).write =
+        (..._args: unknown[]) => true;
+    }
 
     try {
       // Execute all checks concurrently
-      const checkResults = await Promise.allSettled(checksToRun.map(check => check()));
-      spinner.stop();
+      let checkResults: PromiseSettledResult<HealthCheck>[];
+      try {
+        checkResults = await Promise.allSettled(checksToRun.map(check => check()));
+      } finally {
+        spinner?.stop();
+        restoreStdout();
+      }
 
       // Process results in order
       for (const settledResult of checkResults) {
         if (settledResult.status === 'fulfilled') {
           const result = settledResult.value;
           results.push(result);
-          output.writeln(formatCheck(result));
+          if (!jsonOutput) output.writeln(formatCheck(result));
 
           if (result.fix && (result.status === 'fail' || result.status === 'warn')) {
             fixes.push(`${result.name}: ${result.fix}`);
@@ -1647,12 +1699,39 @@ export const doctorCommand: Command = {
             message: settledResult.reason?.message || 'Unknown error'
           };
           results.push(errorResult);
-          output.writeln(formatCheck(errorResult));
+          if (!jsonOutput) output.writeln(formatCheck(errorResult));
         }
       }
     } catch (error) {
-      spinner.stop();
-      output.writeln(output.error('Failed to run health checks'));
+      spinner?.stop();
+      restoreStdout();
+      if (!jsonOutput) output.writeln(output.error('Failed to run health checks'));
+    }
+
+    // Issue #818: machine-readable output. Emits a single JSON document with
+    // per-check fields (and any FunctionalCheckDetail entries from the swarm/
+    // hive checks) and exits with the right code. Skips auto-fix entirely —
+    // --json is read-only by intent so CI gates can consume it without
+    // mutating the working tree.
+    if (jsonOutput) {
+      const passed = results.filter(r => r.status === 'pass').length;
+      const warnings = results.filter(r => r.status === 'warn').length;
+      const failed = results.filter(r => r.status === 'fail').length;
+
+      const allowSet = new Set(allowWarnList);
+      const strictWarningFailures = strict
+        ? results.filter(r => r.status === 'warn' && !allowSet.has(r.name)).map(r => r.name)
+        : [];
+
+      const exitCode = failed > 0 || strictWarningFailures.length > 0 ? 1 : 0;
+
+      process.stdout.write(JSON.stringify({
+        summary: { passed, warnings, failed },
+        strict: strict ? { strictMode: true, warningsTriggeringFail: strictWarningFailures } : { strictMode: false },
+        results,
+      }, null, 2) + '\n');
+
+      return { success: exitCode === 0, exitCode, data: { passed, warnings, failed, results } };
     }
 
     // Auto-install missing dependencies if requested

--- a/tests/system/hive-mind-e2e.test.ts
+++ b/tests/system/hive-mind-e2e.test.ts
@@ -14,6 +14,7 @@ import {
   getHiveMindTool,
   resetHiveAndSwarm,
 } from '../../src/cli/__tests__/mcp-tools/_helpers.js';
+import { checkHiveMindFunctional } from '../../src/cli/commands/doctor-checks-swarm.js';
 
 interface InitResult {
   success: boolean;
@@ -168,6 +169,19 @@ describe('System E2E — hive-mind', () => {
     expect(decided!.result).toBe('approved');
     expect(decided!.votes.for).toBe(2);
     expect(decided!.votes.against).toBe(0);
+  });
+
+  // Issue #818: gate the regression that triggered epic #798. The doctor
+  // check exercises hive-mind_init / spawn / broadcast / consensus / memory
+  // through MessageBus + WriteThroughAdapter + shared coordinator — if any
+  // handler stubs out, this fails before the bad install ships.
+  it('checkHiveMindFunctional passes against the live MessageBus + coordinator', { timeout: 30_000 }, async () => {
+    const result = await checkHiveMindFunctional();
+    if (result.status === 'warn' && /not built/i.test(result.message)) return;
+
+    const failures = (result.details ?? []).filter(d => d.status === 'fail');
+    expect(failures, `hive-mind doctor failures (epic #798 regression?): ${JSON.stringify(failures, null, 2)}`).toHaveLength(0);
+    expect(result.status).not.toBe('fail');
   });
 
   it('hive-mind_shutdown terminates coordinator-side records (workers leave swarm agent_list)', async () => {

--- a/tests/system/swarm-restoration-e2e.test.ts
+++ b/tests/system/swarm-restoration-e2e.test.ts
@@ -19,6 +19,7 @@ import {
   getTaskTool,
   spawnAgentForTest,
 } from '../../src/cli/__tests__/mcp-tools/_helpers.js';
+import { checkSwarmFunctional } from '../../src/cli/commands/doctor-checks-swarm.js';
 
 interface OrchestrateResult {
   success: boolean;
@@ -137,6 +138,23 @@ describe('System E2E — swarm restoration', () => {
     })) as AgentListResult;
     const survivors = list.agents.map(a => a.agentId).sort();
     expect(survivors).toEqual([a1, a3].sort());
+  });
+
+  // Issue #818: gate the regression that triggered epic #798. The doctor
+  // check exercises the same MCP surface this file does — if a handler ever
+  // gets disconnected from the coordinator again, this test fails before
+  // ship, not after.
+  describe('Doctor regression tripwire', () => {
+    it('checkSwarmFunctional passes against the live coordinator', { timeout: 30_000 }, async () => {
+      const result = await checkSwarmFunctional();
+      // 'warn' is acceptable only when the dist isn't built — CI builds first
+      // (consumer-install-smoke + main test job both run `npm run build`).
+      if (result.status === 'warn' && /not built/i.test(result.message)) return;
+
+      const failures = (result.details ?? []).filter(d => d.status === 'fail');
+      expect(failures, `swarm doctor failures (epic #798 regression?): ${JSON.stringify(failures, null, 2)}`).toHaveLength(0);
+      expect(result.status).toBe('pass');
+    });
   });
 
   describe('MCP-server restart smoke', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,10 @@ export const isolationTests = [
   // intermittently exceed their per-test timeouts under full-suite load
   // (maxForks=2 + Windows fork contention). Confirmed green in isolation.
   'src/cli/__tests__/doctor-checks-deep.test.ts',
+  // Issue #818 — doctor-checks-swarm dynamically imports dist mcp-tools and
+  // exercises the real UnifiedSwarmCoordinator end-to-end. Same dynamic-import
+  // load profile as doctor-checks-deep above; same isolation rationale.
+  'src/cli/__tests__/doctor-checks-swarm.test.ts',
   'src/cli/__tests__/services/worker-daemon-resource-thresholds.test.ts',
   'src/cli/__tests__/spells/connector-lifecycle.test.ts',
   // prerequisites.test.ts split into 4 files (#522) — all share the same


### PR DESCRIPTION
## Summary

- Adds `Swarm Functional` (9 subchecks) and `Hive-Mind Functional` (8 subchecks) to `flo doctor` — exercises the real `UnifiedSwarmCoordinator` + `MessageBus` + `WriteThroughAdapter` paths through the MCP tool surface
- Adds `flo doctor --json` for machine-readable CI/smoke output (per-check + per-subcheck `id` / `mcpTool` / `observed` / `expected`)
- Wires the new checks as gate tests in `tests/system/{swarm-restoration,hive-mind}-e2e.test.ts` so any future #798-style regression fails CI before ship

## Why

Epic #798 paid for a real regression where MCP handlers were silently disconnected from their coordinators (returning hardcoded literals like `{ swarmId: 'swarm-' + Date.now() }`). Without a one-command tripwire, the next refactor / collapse / migration could re-disconnect a handler exactly the same way and `flo doctor` would still print all green.

## Coverage

**Swarm:** swarm_init • agent_spawn • agent_list • agent_status • swarm_status • swarm_health • task_create • task_complete • agent_terminate

**Hive-mind:** hive-mind_init (MessageBus + WriteThroughAdapter) • hive-mind_spawn (registers with shared coordinator, story #807) • agent_list({domain:'hive-mind'}) • hive-mind_broadcast (bus exchange) • hive-mind_consensus (propose+vote, real tally) • hive-mind_memory (set+get via Memory DB write-through, with environmental-soft-fail when backend isn't ready)

Each failure prints `mcpTool` + `observed` + `expected` + a regression hint. Memory backend unavailable (e.g. fresh consumer fixture before `memory init`) downgrades to `warn`, not `fail`, via `softFailMessage`.

## Test plan

- [x] Unit: `src/cli/__tests__/doctor-checks-swarm.test.ts` (5 tests, in `isolationTests` for the same dynamic-import-of-dist load profile as `doctor-checks-deep`)
- [x] System E2E gate: `tests/system/swarm-restoration-e2e.test.ts` + `tests/system/hive-mind-e2e.test.ts` call the new checks against the live coordinator and assert pass + zero subcheck failures
- [x] Manual: `node bin/cli.js doctor -c swarm --json` (passes 9/9 in ~3s); `-c hive-mind --json` (passes 8/8 in ~3s); full `doctor --json` runs 30 checks in ~10s (well under 30s AC)
- [x] Manual: `doctor --strict --json` round-trips exit code 0 with `strictMode: true`
- [x] Full `npm test`: 7556/7556 passing

## Acceptance criteria — issue #818

- [x] swarm_init returns coordinator-issued id (stub-pattern detection via `STUB_SWARM_ID_PATTERN`)
- [x] agent_spawn invokes `coordinator.spawnAgent`; spawned agent appears in `agent_list` / `agent_status`
- [x] swarm_status / swarm_health query the coordinator (live counts, not hardcoded `{ agentCount: 0, taskCount: 0 }`)
- [x] task_create / task_complete round-trip through coordinator
- [x] agent_list / agent_terminate reflect coordinator state
- [x] hive-mind_init routes through MessageBus + WriteThroughAdapter
- [x] hive-mind_spawn workers register with shared coordinator (visible in `agent_list({domain:'hive-mind'})`)
- [x] hive-mind_consensus + broadcast exchange via the bus
- [x] hive-mind_memory reads/writes via shared store
- [x] All checks complete in < 30s on a clean consumer install (~10s measured)
- [x] Each failure prints exact MCP tool / coordinator method bypassed + observed + expected
- [x] `flo doctor --json` includes machine-readable per-check + per-subcheck results
- [x] Smoke harness wires the new checks as a required gate (via existing `flo doctor --strict --allow-warn`)

Out of scope: `swarm_scale` direct probe (covered indirectly by `swarm_status.live-counts`); a separate `task_assign` / `task_cancel` round-trip (the create/complete pair already proves coordinator routing).

Closes #818.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)