### PR TITLE
fix(825): hive-mind agent store anchored on findProjectRoot()

### DIFF
--- a/src/cli/__tests__/mcp-tools/hive-mind-store-path.test.ts
+++ b/src/cli/__tests__/mcp-tools/hive-mind-store-path.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Issue #825: hive-mind_spawn / hive-mind_shutdown must write the legacy
+ * agents.json store under findProjectRoot()/.moflo, NOT under process.cwd().
+ *
+ * Mirrors agent-tools.ts (which already uses findProjectRoot via getAgentDir).
+ * Without this, an MCP server launched from a subdirectory writes the hive
+ * store outside the consumer's project — silently disagreeing with the
+ * agent_spawn-side store at <project-root>/.moflo/agents/store.json.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+let fakeProjectRoot = '';
+vi.mock('../../services/project-root.js', () => ({
+  findProjectRoot: () => fakeProjectRoot,
+}));
+
+import { hiveMindTools } from '../../mcp-tools/hive-mind-tools.js';
+import { _resetSwarmCoordinatorForTest } from '../../mcp-tools/swarm-coordinator-singleton.js';
+
+const initTool = hiveMindTools.find(t => t.name === 'hive-mind_init')!;
+const spawnTool = hiveMindTools.find(t => t.name === 'hive-mind_spawn')!;
+const shutdownTool = hiveMindTools.find(t => t.name === 'hive-mind_shutdown')!;
+
+describe('hive-mind agent store path (issue #825)', () => {
+  let originalCwd: string;
+  let cwdSentinel: string;
+
+  beforeEach(() => {
+    fakeProjectRoot = mkdtempSync(join(tmpdir(), 'moflo-hive-store-root-'));
+    writeFileSync(join(fakeProjectRoot, 'package.json'), '{"name":"fake"}');
+    cwdSentinel = mkdtempSync(join(tmpdir(), 'moflo-hive-store-cwd-'));
+    originalCwd = process.cwd();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await _resetSwarmCoordinatorForTest();
+    rmSync(fakeProjectRoot, { recursive: true, force: true });
+    rmSync(cwdSentinel, { recursive: true, force: true });
+    fakeProjectRoot = '';
+  });
+
+  it('writes agents.json under findProjectRoot()/.moflo on spawn', async () => {
+    await initTool.handler({ topology: 'mesh' });
+    const result = (await spawnTool.handler({ count: 1, agentType: 'worker' })) as {
+      success: boolean;
+      workers?: Array<{ agentId: string }>;
+    };
+    expect(result.success).toBe(true);
+    expect(result.workers?.length).toBe(1);
+
+    const expectedPath = resolve(fakeProjectRoot, '.moflo', 'agents.json');
+    expect(existsSync(expectedPath)).toBe(true);
+
+    const stored = JSON.parse(readFileSync(expectedPath, 'utf-8')) as {
+      agents: Record<string, unknown>;
+    };
+    expect(stored.agents[result.workers![0].agentId]).toBeDefined();
+
+    await shutdownTool.handler({ force: true });
+  });
+
+  it('does not write under process.cwd() when cwd diverges from project root', async () => {
+    process.chdir(cwdSentinel);
+
+    await initTool.handler({ topology: 'mesh' });
+    const result = (await spawnTool.handler({ count: 1, agentType: 'worker' })) as {
+      success: boolean;
+    };
+    expect(result.success).toBe(true);
+
+    // The bug would have created agents.json under cwd. With the fix in
+    // place, this must not exist.
+    const buggyPath = resolve(cwdSentinel, '.moflo', 'agents.json');
+    expect(existsSync(buggyPath)).toBe(false);
+
+    // And the correct project-root-anchored path must exist.
+    const correctPath = resolve(fakeProjectRoot, '.moflo', 'agents.json');
+    expect(existsSync(correctPath)).toBe(true);
+
+    await shutdownTool.handler({ force: true });
+  });
+
+  it('reads existing store from findProjectRoot()/.moflo on shutdown', async () => {
+    // Pre-seed the project-root-anchored store with a worker, then verify
+    // shutdown reads it from there (loadAgentStore path) and clears it.
+    const dotMoflo = resolve(fakeProjectRoot, '.moflo');
+    mkdirSync(dotMoflo, { recursive: true });
+    const storePath = join(dotMoflo, 'agents.json');
+
+    await initTool.handler({ topology: 'mesh' });
+    const spawn = (await spawnTool.handler({ count: 2, agentType: 'worker' })) as {
+      success: boolean;
+      workers?: Array<{ agentId: string }>;
+    };
+    expect(spawn.success).toBe(true);
+
+    const after = JSON.parse(readFileSync(storePath, 'utf-8')) as {
+      agents: Record<string, unknown>;
+    };
+    expect(Object.keys(after.agents).length).toBe(2);
+
+    await shutdownTool.handler({ force: true });
+
+    // shutdown's loadAgentStore + saveAgentStore should have removed the
+    // workers via the same project-root path.
+    const cleared = JSON.parse(readFileSync(storePath, 'utf-8')) as {
+      agents: Record<string, unknown>;
+    };
+    expect(Object.keys(cleared.agents).length).toBe(0);
+  });
+});

--- a/src/cli/mcp-tools/hive-mind-tools.ts
+++ b/src/cli/mcp-tools/hive-mind-tools.ts
@@ -193,9 +193,23 @@ async function memoryList(): Promise<string[]> {
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { mofloDir } from '../services/moflo-paths.js';
+import { findProjectRoot } from '../services/project-root.js';
+
+// Anchor on findProjectRoot() so the MCP server resolves <consumer>/.moflo/
+// even when its cwd diverges from the user's project root. process.cwd()
+// silently drifted store writes outside the project (issue #825). Mirrors
+// agent-tools.ts.
+function getAgentStoreDir(): string {
+  return mofloDir(findProjectRoot());
+}
+
+function getAgentStorePath(): string {
+  return join(getAgentStoreDir(), 'agents.json');
+}
 
 function loadAgentStore(): { agents: Record<string, unknown> } {
-  const storePath = join(process.cwd(), '.moflo', 'agents.json');
+  const storePath = getAgentStorePath();
   try {
     if (existsSync(storePath)) {
       return JSON.parse(readFileSync(storePath, 'utf-8'));
@@ -205,11 +219,11 @@ function loadAgentStore(): { agents: Record<string, unknown> } {
 }
 
 function saveAgentStore(store: { agents: Record<string, unknown> }): void {
-  const storeDir = join(process.cwd(), '.moflo');
+  const storeDir = getAgentStoreDir();
   if (!existsSync(storeDir)) {
     mkdirSync(storeDir, { recursive: true });
   }
-  writeFileSync(join(storeDir, 'agents.json'), JSON.stringify(store, null, 2), 'utf-8');
+  writeFileSync(getAgentStorePath(), JSON.stringify(store, null, 2), 'utf-8');
 }
 
 // ===== Tool definitions =====


### PR DESCRIPTION
## Summary

- Fixes #825. `loadAgentStore` / `saveAgentStore` in `src/cli/mcp-tools/hive-mind-tools.ts` were anchored on `process.cwd()`, while the parallel `agent-tools.ts` paths use `findProjectRoot()`. When the MCP server's working directory diverged from the consumer project root, `hive-mind_spawn` / `hive-mind_shutdown` silently wrote `.moflo/agents.json` outside the project — disagreeing with `agent_spawn`'s store at `<project-root>/.moflo/agents/store.json`.
- Routes both through `mofloDir(findProjectRoot())` + a single `getAgentStorePath()` helper so the two callsites cannot drift again.
- Adds `src/cli/__tests__/mcp-tools/hive-mind-store-path.test.ts` exercising spawn write path, cwd-divergence negative assertion, and shutdown round-trip via `hive-mind_init` -> `hive-mind_spawn` -> `hive-mind_shutdown`.

Per epic #798 close-out audit. Pre-existing from upstream (blamed `dfd4104157`); story #807 (PR #822) refactored this file but missed the cleanup.

The other `process.cwd()` callers in `mcp-tools/` (`json-store.ts`, `session-tools`, `github-tools`, `neural-tools`, `hooks-tools`) carry the same pattern -- deferred to a follow-up issue per #825's stated scope.

## Test plan

- [x] vitest hive-mind-store-path.test.ts -- 3/3 passing
- [x] vitest src/cli/__tests__/mcp-tools -- 87/87 passing (no regressions)
- [x] vitest --config vitest.isolation.config.ts mcp-tools-deep.test.ts -- 72/72
- [x] vitest tests/system/swarm-restoration-e2e.test.ts -- 4/4 (swarm+hive E2E protected per CLAUDE.md)
- [x] vitest --config vitest.isolation.config.ts doctor-checks-swarm.test.ts -- 5/5 (doctor tripwires)
- [x] vitest tests/hive-mind-messagebus.test.ts --config vitest.isolation.config.ts -- 25/25
- [x] tsc --noEmit -- clean
- [x] eslint changed files -- clean

Closes #825

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)