### PR TITLE
fix(831): inject embeddingLoader mock into 2 learning-bridge tests

### DIFF
--- a/src/cli/memory/learning-bridge.test.ts
+++ b/src/cli/memory/learning-bridge.test.ts
@@ -469,6 +469,7 @@ describe('LearningBridge', () => {
       const customBridge = new LearningBridge(backend, {
         consolidationThreshold: 2,
         neuralLoader: createNeuralLoader(neural),
+        embeddingLoader: createMockEmbeddingLoader(768),
       });
       neural.beginTask.mockReturnValueOnce('traj-1').mockReturnValueOnce('traj-2');
       await customBridge.onInsightRecorded(createTestInsight(), 'e-1');
@@ -745,7 +746,10 @@ describe('LearningBridge', () => {
   describe('neural initialization', () => {
     it('should only attempt neural load once', async () => {
       const loaderFn = vi.fn().mockResolvedValue(neural);
-      const b = new LearningBridge(backend, { neuralLoader: loaderFn });
+      const b = new LearningBridge(backend, {
+        neuralLoader: loaderFn,
+        embeddingLoader: createMockEmbeddingLoader(768),
+      });
 
       await b.onInsightRecorded(createTestInsight(), 'entry-1');
       await b.onInsightRecorded(createTestInsight({ summary: 'Second' }), 'entry-2');


### PR DESCRIPTION
## Summary

- Two tests built a fresh `LearningBridge` with a working `neuralLoader` but no `embeddingLoader`. `onInsightRecorded` → `embedText` → `initEmbeddings` then falls back to a real dynamic import of `../embeddings/embedding-service.js` and initialises the inlined fastembed runtime. On Linux CI under `maxForks=2` parallel-fork load with a cold model cache, that exceeds the 5 s per-test timeout — the flake reported in #831.
- Hash fallback was removed in epic #527, so the bridge must receive either a real embedding service or an injected mock. The sibling tests that pass `createFailingNeuralLoader()` short-circuit at `neural=null` and never reach `embedText`, so they're unaffected.
- Inject `createMockEmbeddingLoader(768)` — the helper already defined at the top of the file and used by the outer `beforeEach` — into the two affected cases. Default 5 s timeout stays.

## Affected tests

1. `src/cli/memory/learning-bridge.test.ts` `consolidate > should respect custom consolidationThreshold` (the reported flake)
2. `src/cli/memory/learning-bridge.test.ts` `neural initialization > should only attempt neural load once` (latent flake, same shape)

## Test plan

- [x] `npx vitest run src/cli/memory/learning-bridge.test.ts` — 57/57 green
- [x] 5 consecutive runs of the file — all green, ~285 ms each (was ~1.99 s, 1.7 s was real fastembed init in those two tests)
- [x] `npx vitest run src/cli/memory/` — 385/385 green
- [x] `npm test` (full repo, parallel + isolation) — 7574 passed, 0 failed
- [ ] CI green on the parallel pass for this PR

Closes #831

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)