### PR TITLE
fix(837): wire bridge embedder for search, honor explicit threshold=0

### DIFF
--- a/src/cli/__tests__/bridge-entries.test.ts
+++ b/src/cli/__tests__/bridge-entries.test.ts
@@ -17,7 +17,7 @@ import {
   _resetBridgeEmbedderCacheForTest,
   type BridgeEmbedder,
 } from '../memory/bridge-embedder.js';
-import { bridgeStoreEntry } from '../memory/bridge-entries.js';
+import { bridgeSearchEntries, bridgeStoreEntry } from '../memory/bridge-entries.js';
 import { _resetProjectRootForTest, execRows, getDb } from '../memory/bridge-core.js';
 import { shutdownBridge, getControllerRegistry } from '../memory/memory-bridge.js';
 
@@ -264,5 +264,79 @@ describe('refreshVectorStatsCache — missing counter (#649)', () => {
     const stats = JSON.parse(fs.readFileSync(statsPath, 'utf-8'));
     expect(stats.vectorCount).toBe(1);
     expect(stats.missing).toBe(2);
+  });
+});
+
+describe('bridgeSearchEntries — query embedder wiring (#837 Defect A)', () => {
+  it("uses the bridge embedder for the query, not the missing ctx.mofloDb.embedder", async () => {
+    const fixedVec = new Float32Array(384).fill(0.1);
+    const embedSpy = vi.fn(async () => fixedVec);
+    setBridgeEmbedderForTest({
+      model: 'fast-all-MiniLM-L6-v2',
+      dimensions: 384,
+      embed: embedSpy,
+    });
+
+    await bridgeStoreEntry({
+      key: 'probe',
+      value: 'subagent reaches MCP memory store path',
+      namespace: 'memdiag',
+      dbPath,
+    });
+
+    const writeCalls = embedSpy.mock.calls.length;
+
+    const result = await bridgeSearchEntries({
+      query: 'totally unrelated wording about banana logistics',
+      namespace: 'memdiag',
+      threshold: 0,
+      dbPath,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.success).toBe(true);
+    expect(embedSpy.mock.calls.length).toBe(writeCalls + 1);
+    expect(result?.searchMethod).toBe('hybrid-bm25-semantic');
+    expect(result?.results.length).toBeGreaterThan(0);
+    expect(result?.results[0]?.score).toBeGreaterThan(0.6);
+  });
+
+  it("threshold: 0 returns matches even when score is below the default 0.3", async () => {
+    // Orthogonal unit vectors with disjoint query terms keep total score
+    // below 0.3 regardless of weighting — exercises the threshold gate, not
+    // similarity ranking.
+    const storeVec = new Float32Array(384);
+    storeVec[0] = 1;
+    const queryVec = new Float32Array(384);
+    queryVec[1] = 1;
+
+    setBridgeEmbedderForTest({
+      model: 'fast-all-MiniLM-L6-v2',
+      dimensions: 384,
+      embed: vi.fn(async (text: string) => (text.includes('store-side') ? storeVec : queryVec)),
+    });
+
+    await bridgeStoreEntry({
+      key: 'low-sim',
+      value: 'store-side content with no overlap',
+      namespace: 'memdiag',
+      dbPath,
+    });
+
+    const filtered = await bridgeSearchEntries({
+      query: 'wholly different text',
+      namespace: 'memdiag',
+      dbPath,
+    });
+    expect(filtered?.results.length).toBe(0);
+
+    const unfiltered = await bridgeSearchEntries({
+      query: 'wholly different text',
+      namespace: 'memdiag',
+      threshold: 0,
+      dbPath,
+    });
+    expect(unfiltered?.results.length).toBe(1);
+    expect(unfiltered?.results[0]?.key).toBe('low-sim');
   });
 });

--- a/src/cli/__tests__/memory-tools-search-threshold.test.ts
+++ b/src/cli/__tests__/memory-tools-search-threshold.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MCPTool } from '../mcp-tools/types.js';
+
+const searchSpy = vi.fn(async () => ({
+  success: true,
+  results: [{ id: 'r1', key: 'k', content: 'c', score: 0.05, namespace: 'ns' }],
+  searchTime: 1,
+}));
+
+vi.mock('../memory/memory-initializer.js', () => ({
+  storeEntry: vi.fn(),
+  searchEntries: searchSpy,
+  listEntries: vi.fn(),
+  getEntry: vi.fn(),
+  deleteEntry: vi.fn(),
+  initializeMemoryDatabase: vi.fn(async () => ({ success: true, dbPath: '' })),
+  checkMemoryInitialization: vi.fn(async () => ({ initialized: true, dbPath: '', tableExists: true, version: '3.0.0' })),
+}));
+
+vi.mock('../services/spell-gate.js', () => ({
+  GateService: { notifyMemoryGate: vi.fn() },
+}));
+
+beforeEach(() => {
+  searchSpy.mockClear();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function getMemorySearchTool(): Promise<MCPTool> {
+  const mod = await import('../mcp-tools/memory-tools.js');
+  const tool = (mod.memoryTools as MCPTool[]).find(t => t.name === 'memory_search');
+  if (!tool) throw new Error('memory_search not registered');
+  return tool;
+}
+
+describe('memory_search MCP handler — threshold passthrough (#837)', () => {
+  it('passes a caller-supplied threshold of 0 through to searchEntries', async () => {
+    const tool = await getMemorySearchTool();
+    await tool.handler({ query: 'q', threshold: 0 });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy.mock.calls[0]?.[0]?.threshold).toBe(0);
+  });
+
+  it('uses 0.3 when threshold is omitted (backwards compatible default)', async () => {
+    const tool = await getMemorySearchTool();
+    await tool.handler({ query: 'q' });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy.mock.calls[0]?.[0]?.threshold).toBe(0.3);
+  });
+
+  it('passes other explicit thresholds through unchanged', async () => {
+    const tool = await getMemorySearchTool();
+    await tool.handler({ query: 'q', threshold: 0.05 });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy.mock.calls[0]?.[0]?.threshold).toBe(0.05);
+  });
+});

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -345,7 +345,10 @@ export const memoryTools: MCPTool[] = [
       const query = input.query as string;
       const namespace = (input.namespace as string) || 'all';
       const limit = (input.limit as number) || 10;
-      const threshold = (input.threshold as number) || 0.3;
+      // Falsiness check would coerce a caller-supplied 0 to 0.3 and silently
+      // filter low-similarity matches; use a typeof guard so explicit zero
+      // means "no threshold" (#837).
+      const threshold = typeof input.threshold === 'number' ? input.threshold : 0.3;
 
       validateMemoryInput(undefined, undefined, query);
 

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -9,7 +9,7 @@
  */
 
 import { cosineSim, execRows, generateId, persistBridgeDb, refreshVectorStatsCache, withDb } from './bridge-core.js';
-import { embeddingResponseFrom, resolveBridgeEmbedding } from './bridge-embedder.js';
+import { embeddingResponseFrom, getBridgeEmbedder, resolveBridgeEmbedding } from './bridge-embedder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 
 function makeEntryCacheKey(namespace: string, key: string): string {
@@ -337,17 +337,6 @@ export async function bridgeSearchEntries(options: {
     const { query: queryStr, namespace = 'default', limit = 10, threshold = 0.3 } = options;
     const startTime = Date.now();
 
-    let queryEmbedding: number[] | null = null;
-    try {
-      const embedder = ctx.mofloDb.embedder;
-      if (embedder) {
-        const emb = await embedder.embed(queryStr);
-        queryEmbedding = Array.from(emb);
-      }
-    } catch {
-      // Fall back to keyword search
-    }
-
     const nsFilter = namespace !== 'all' ? `AND namespace = ?` : '';
 
     let rows: Record<string, unknown>[];
@@ -361,6 +350,26 @@ export async function bridgeSearchEntries(options: {
       rows = namespace !== 'all' ? execRows(ctx.db, sql, [namespace]) : execRows(ctx.db, sql);
     } catch {
       return null;
+    }
+
+    // Skip the embed call when there's nothing to score against — fastembed
+    // is the dominant cost in this function (~50–200ms cold).
+    if (rows.length === 0) {
+      return { success: true, results: [], searchTime: Date.now() - startTime };
+    }
+
+    // ctx.mofloDb only carries { database, close } — `embedder` was always
+    // undefined here, silently dropping search to BM25-only and missing
+    // semantically-related rows (#837). Use the bridge embedder directly so
+    // the read path mirrors the write path. Same fix #648 applied to
+    // bridgeGenerateEmbedding.
+    let queryEmbedding: number[] | null = null;
+    try {
+      const embedder = getBridgeEmbedder();
+      const emb = await embedder.embed(queryStr);
+      queryEmbedding = Array.from(emb);
+    } catch {
+      // Fall back to keyword search
     }
 
     const queryTerms = queryStr.toLowerCase().split(/\s+/).filter(t => t.length > 1);


### PR DESCRIPTION
## Summary

Closes #837. Two related defects in `mcp__moflo__memory_search` / `bridgeSearchEntries` that combined to make newly stored rows look invisible.

- **Defect A (`bridgeSearchEntries`)**: read path looked up `ctx.mofloDb.embedder` — `controller-registry.initSqlJs` only sets `{ database, close }`, so the lookup always returned undefined and search silently degraded to BM25-only. Older rows with keyword overlap still surfaced; semantically-related rows did not. Same pattern as #648 fixed for `bridgeGenerateEmbedding`; this site was missed. Now uses `getBridgeEmbedder()` so the read path mirrors the write path.
- **Defect B (`memory_search` MCP handler)**: `const threshold = (input.threshold as number) || 0.3` coerced a caller-supplied `0` to the default. Switched to a `typeof === 'number'` guard so explicit zero passes through. Default-via-destructure further down the chain already handles `undefined` correctly.
- Added a zero-rows short-circuit in `bridgeSearchEntries` so we don't run fastembed when the namespace is empty (~50–200ms cold-path savings).

## Test plan

- [x] New: `bridgeSearchEntries` finds semantically-related rows with non-overlapping wording (would fail under the old `ctx.mofloDb.embedder` lookup — `searchMethod === 'bm25-only'` and zero results).
- [x] New: `threshold: 0` returns matches that score below the default 0.3.
- [x] New: `memory_search` MCP handler propagates `threshold: 0`, `0.05`, and `undefined` (defaulting to 0.3) correctly.
- [x] Full suite green: 7579 passed, 0 failed.
- [x] Type-check clean.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)