### PR TITLE
fix(838): enforce memory-first gate per-actor via session_id

### DIFF
--- a/.claude/helpers/gate-hook.mjs
+++ b/.claude/helpers/gate-hook.mjs
@@ -25,6 +25,13 @@ try { if (stdinData.trim()) hookContext = JSON.parse(stdinData); } catch (e) {}
 // Pass tool info as env vars for gate.cjs
 var env = Object.assign({}, process.env);
 if (hookContext.tool_name) env.TOOL_NAME = hookContext.tool_name;
+// Forward Claude Code's session_id so gate.cjs can enforce memory-first
+// per-actor (#838) — each spawned subagent gets its own session_id, so a
+// shared workflow-state.json no longer lets one subagent's directive be
+// silently satisfied by the parent's earlier search.
+if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
+  env.HOOK_SESSION_ID = hookContext.session_id;
+}
 if (hookContext.tool_input && typeof hookContext.tool_input === 'object') {
   Object.keys(hookContext.tool_input).forEach(function(key) {
     if (typeof hookContext.tool_input[key] === 'string') {

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -6,7 +6,37 @@ var path = require('path');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+
+// Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
+// is session-wide, so once the parent searches memory, every spawned subagent
+// inherits the satisfied flag and the directive's "WILL BLOCK" promise becomes
+// false. When gate-hook.mjs forwards Claude Code's stdin `session_id` as
+// HOOK_SESSION_ID, prefer the per-session map so each subagent must search
+// memory itself before its first Glob/Grep/Read. Falls back to the legacy
+// boolean when no session id is present (CLI invocations, tests, older hosts).
+function isMemorySearchedFor(state) {
+  var sid = process.env.HOOK_SESSION_ID || '';
+  if (sid) {
+    var map = state.memorySearchedBy || {};
+    return map[sid] === true;
+  }
+  return state.memorySearched === true;
+}
+
+// Stamp the legacy bool plus (when HOOK_SESSION_ID is set) the per-actor map.
+// Returns true if anything actually changed — callers gate writeState() on it
+// to avoid redundant fsyncs in tight bash-memory loops.
+function markMemorySearched(state) {
+  var sid = process.env.HOOK_SESSION_ID || '';
+  var changed = false;
+  if (state.memorySearched !== true) { state.memorySearched = true; changed = true; }
+  if (sid) {
+    if (!state.memorySearchedBy) state.memorySearchedBy = {};
+    if (state.memorySearchedBy[sid] !== true) { state.memorySearchedBy[sid] = true; changed = true; }
+  }
+  return changed;
+}
 
 function readState() {
   try {
@@ -77,7 +107,7 @@ switch (command) {
   case 'check-before-scan': {
     if (!config.memory_first) break;
     var s = readState();
-    if (s.memorySearched || !s.memoryRequired) break;
+    if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
     process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search.\n');
@@ -86,7 +116,7 @@ switch (command) {
   case 'check-before-read': {
     if (!config.memory_first) break;
     var s = readState();
-    if (s.memorySearched || !s.memoryRequired) break;
+    if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var fp = process.env.TOOL_INPUT_file_path || '';
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
@@ -102,18 +132,14 @@ switch (command) {
   }
   case 'record-memory-searched': {
     var s = readState();
-    if (!s.memorySearched) {
-      s.memorySearched = true;
-      writeState(s);
-    }
+    if (markMemorySearched(s)) writeState(s);
     break;
   }
   case 'check-bash-memory': {
     var cmd = process.env.TOOL_INPUT_command || '';
     if (/semantic-search|memory search|memory retrieve|memory-search/.test(cmd)) {
       var s = readState();
-      s.memorySearched = true;
-      writeState(s);
+      if (markMemorySearched(s)) writeState(s);
     }
     break;
   }
@@ -196,6 +222,9 @@ switch (command) {
   case 'prompt-reminder': {
     var s = readState();
     s.memorySearched = false;
+    // Wipe per-actor memory tracking too — a new user prompt is a fresh window
+    // for both parent AND any subagents the parent may spawn during this turn.
+    s.memorySearchedBy = {};
     // learningsStored is session-scoped — once stored, it stays true until session reset.
     // Resetting per-prompt caused false blocks when PR creation was on a later prompt.
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
@@ -218,7 +247,7 @@ switch (command) {
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
     break;
   }
   default:

--- a/bin/gate-hook.mjs
+++ b/bin/gate-hook.mjs
@@ -25,6 +25,13 @@ try { if (stdinData.trim()) hookContext = JSON.parse(stdinData); } catch (e) {}
 // Pass tool info as env vars for gate.cjs
 var env = Object.assign({}, process.env);
 if (hookContext.tool_name) env.TOOL_NAME = hookContext.tool_name;
+// Forward Claude Code's session_id so gate.cjs can enforce memory-first
+// per-actor (#838) — each spawned subagent gets its own session_id, so a
+// shared workflow-state.json no longer lets one subagent's directive be
+// silently satisfied by the parent's earlier search.
+if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
+  env.HOOK_SESSION_ID = hookContext.session_id;
+}
 if (hookContext.tool_input && typeof hookContext.tool_input === 'object') {
   Object.keys(hookContext.tool_input).forEach(function(key) {
     if (typeof hookContext.tool_input[key] === 'string') {

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -6,7 +6,37 @@ var path = require('path');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+
+// Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
+// is session-wide, so once the parent searches memory, every spawned subagent
+// inherits the satisfied flag and the directive's "WILL BLOCK" promise becomes
+// false. When gate-hook.mjs forwards Claude Code's stdin `session_id` as
+// HOOK_SESSION_ID, prefer the per-session map so each subagent must search
+// memory itself before its first Glob/Grep/Read. Falls back to the legacy
+// boolean when no session id is present (CLI invocations, tests, older hosts).
+function isMemorySearchedFor(state) {
+  var sid = process.env.HOOK_SESSION_ID || '';
+  if (sid) {
+    var map = state.memorySearchedBy || {};
+    return map[sid] === true;
+  }
+  return state.memorySearched === true;
+}
+
+// Stamp the legacy bool plus (when HOOK_SESSION_ID is set) the per-actor map.
+// Returns true if anything actually changed — callers gate writeState() on it
+// to avoid redundant fsyncs in tight bash-memory loops.
+function markMemorySearched(state) {
+  var sid = process.env.HOOK_SESSION_ID || '';
+  var changed = false;
+  if (state.memorySearched !== true) { state.memorySearched = true; changed = true; }
+  if (sid) {
+    if (!state.memorySearchedBy) state.memorySearchedBy = {};
+    if (state.memorySearchedBy[sid] !== true) { state.memorySearchedBy[sid] = true; changed = true; }
+  }
+  return changed;
+}
 
 function readState() {
   try {
@@ -77,7 +107,7 @@ switch (command) {
   case 'check-before-scan': {
     if (!config.memory_first) break;
     var s = readState();
-    if (s.memorySearched || !s.memoryRequired) break;
+    if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
     process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search.\n');
@@ -86,7 +116,7 @@ switch (command) {
   case 'check-before-read': {
     if (!config.memory_first) break;
     var s = readState();
-    if (s.memorySearched || !s.memoryRequired) break;
+    if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var fp = process.env.TOOL_INPUT_file_path || '';
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
@@ -102,18 +132,14 @@ switch (command) {
   }
   case 'record-memory-searched': {
     var s = readState();
-    if (!s.memorySearched) {
-      s.memorySearched = true;
-      writeState(s);
-    }
+    if (markMemorySearched(s)) writeState(s);
     break;
   }
   case 'check-bash-memory': {
     var cmd = process.env.TOOL_INPUT_command || '';
     if (/semantic-search|memory search|memory retrieve|memory-search/.test(cmd)) {
       var s = readState();
-      s.memorySearched = true;
-      writeState(s);
+      if (markMemorySearched(s)) writeState(s);
     }
     break;
   }
@@ -196,6 +222,9 @@ switch (command) {
   case 'prompt-reminder': {
     var s = readState();
     s.memorySearched = false;
+    // Wipe per-actor memory tracking too — a new user prompt is a fresh window
+    // for both parent AND any subagents the parent may spawn during this turn.
+    s.memorySearchedBy = {};
     // learningsStored is session-scoped — once stored, it stays true until session reset.
     // Resetting per-prompt caused false blocks when PR creation was on a later prompt.
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
@@ -218,7 +247,7 @@ switch (command) {
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
     break;
   }
   default:

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -217,7 +217,7 @@ var path = require('path');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\\/([a-z])\\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
 
 function readState() {
   try {
@@ -227,6 +227,32 @@ function readState() {
     }
   } catch (e) { /* reset on corruption */ }
   return Object.assign({}, STATE_DEFAULTS);
+}
+
+// Per-actor memory-search tracking (#838). When gate-hook.mjs forwards Claude
+// Code's stdin session_id as HOOK_SESSION_ID, prefer the per-session map so
+// each spawned subagent must search memory itself before its first
+// Glob/Grep/Read. Falls back to the legacy boolean otherwise.
+function isMemorySearchedFor(state) {
+  var sid = process.env.HOOK_SESSION_ID || '';
+  if (sid) {
+    var map = state.memorySearchedBy || {};
+    return map[sid] === true;
+  }
+  return state.memorySearched === true;
+}
+
+// Stamp the legacy bool plus (when HOOK_SESSION_ID is set) the per-actor map.
+// Returns true if anything actually changed — callers gate writeState() on it.
+function markMemorySearched(state) {
+  var sid = process.env.HOOK_SESSION_ID || '';
+  var changed = false;
+  if (state.memorySearched !== true) { state.memorySearched = true; changed = true; }
+  if (sid) {
+    if (!state.memorySearchedBy) state.memorySearchedBy = {};
+    if (state.memorySearchedBy[sid] !== true) { state.memorySearchedBy[sid] = true; changed = true; }
+  }
+  return changed;
 }
 
 function writeState(s) {
@@ -282,7 +308,7 @@ switch (command) {
   case 'check-before-scan': {
     if (!config.memory_first) break;
     var s = readState();
-    if (s.memorySearched || !s.memoryRequired) break;
+    if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
     process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search.\\n');
@@ -291,7 +317,7 @@ switch (command) {
   case 'check-before-read': {
     if (!config.memory_first) break;
     var s = readState();
-    if (s.memorySearched || !s.memoryRequired) break;
+    if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var fp = process.env.TOOL_INPUT_file_path || '';
     if (fp.indexOf('.claude/guidance/') < 0 && fp.indexOf('.claude\\\\guidance\\\\') < 0) break;
     process.stderr.write('BLOCKED: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\n');
@@ -306,18 +332,14 @@ switch (command) {
   }
   case 'record-memory-searched': {
     var s = readState();
-    if (!s.memorySearched) {
-      s.memorySearched = true;
-      writeState(s);
-    }
+    if (markMemorySearched(s)) writeState(s);
     break;
   }
   case 'check-bash-memory': {
     var cmd = process.env.TOOL_INPUT_command || '';
     if (/semantic-search|memory search|memory retrieve|memory-search/.test(cmd)) {
       var s = readState();
-      s.memorySearched = true;
-      writeState(s);
+      if (markMemorySearched(s)) writeState(s);
     }
     break;
   }
@@ -396,6 +418,9 @@ switch (command) {
   case 'prompt-reminder': {
     var s = readState();
     s.memorySearched = false;
+    // Wipe per-actor memory tracking too — a new user prompt is a fresh window
+    // for both parent AND any subagents the parent may spawn during this turn.
+    s.memorySearchedBy = {};
     // learningsStored is session-scoped — once stored, it stays true until session reset.
     // Resetting per-prompt caused false blocks when PR creation was on a later prompt.
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
@@ -416,7 +441,7 @@ switch (command) {
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
     break;
   }
   default:
@@ -461,6 +486,11 @@ try { if (stdinData.trim()) hookContext = JSON.parse(stdinData); } catch (e) {}
 // Pass tool info as env vars for gate.cjs
 var env = Object.assign({}, process.env);
 if (hookContext.tool_name) env.TOOL_NAME = hookContext.tool_name;
+// Forward Claude Code's session_id so gate.cjs can enforce memory-first
+// per-actor (#838) — each spawned subagent has its own session_id.
+if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
+  env.HOOK_SESSION_ID = hookContext.session_id;
+}
 if (hookContext.tool_input && typeof hookContext.tool_input === 'object') {
   Object.keys(hookContext.tool_input).forEach(function(key) {
     if (typeof hookContext.tool_input[key] === 'string') {

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -1385,6 +1385,242 @@ describe('end-to-end: spell lifecycle', () => {
   });
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// gate.cjs — per-actor memory-first enforcement (#838)
+// The legacy `memorySearched` boolean is session-wide and short-circuits the
+// gate for every actor as soon as the parent searches once. When the
+// gate-hook forwards Claude Code's session_id as HOOK_SESSION_ID, the gate
+// must enforce per-session: a fresh subagent (unknown session_id) gets
+// blocked even when the parent already satisfied its own gate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('gate.cjs: per-actor memory-first (#838)', () => {
+  it('blocks scan for an unknown subagent session even when parent has searched', () => {
+    writeState(tmpDir, {
+      memoryRequired: true,
+      memorySearched: true,
+      memorySearchedBy: { 'parent-session-1': true },
+    });
+    const env = baseEnv(tmpDir);
+    env.HOOK_SESSION_ID = 'subagent-session-fresh';
+    env.TOOL_INPUT_pattern = '**/*.ts';
+    const r = runGate('check-before-scan', env);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('BLOCKED');
+  });
+
+  it('allows scan for a subagent session that has already searched', () => {
+    writeState(tmpDir, {
+      memoryRequired: true,
+      memorySearched: true,
+      memorySearchedBy: {
+        'parent-session-1': true,
+        'subagent-session-A': true,
+      },
+    });
+    const env = baseEnv(tmpDir);
+    env.HOOK_SESSION_ID = 'subagent-session-A';
+    env.TOOL_INPUT_pattern = '**/*.ts';
+    const r = runGate('check-before-scan', env);
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('blocks read for an unknown subagent session', () => {
+    writeState(tmpDir, {
+      memoryRequired: true,
+      memorySearched: true,
+      memorySearchedBy: { 'parent-session-1': true },
+    });
+    const env = baseEnv(tmpDir);
+    env.HOOK_SESSION_ID = 'subagent-session-fresh';
+    env.TOOL_INPUT_file_path = '/project/src/index.ts';
+    const r = runGate('check-before-read', env);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('BLOCKED');
+  });
+
+  it('allows read for a subagent session that is in the map', () => {
+    writeState(tmpDir, {
+      memoryRequired: true,
+      memorySearched: true,
+      memorySearchedBy: { 'subagent-session-B': true },
+    });
+    const env = baseEnv(tmpDir);
+    env.HOOK_SESSION_ID = 'subagent-session-B';
+    env.TOOL_INPUT_file_path = '/project/src/index.ts';
+    const r = runGate('check-before-read', env);
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('record-memory-searched stamps the per-actor map when HOOK_SESSION_ID is set', () => {
+    writeState(tmpDir, { memorySearched: false, memorySearchedBy: {} });
+    const env = baseEnv(tmpDir);
+    env.HOOK_SESSION_ID = 'subagent-session-X';
+    runGate('record-memory-searched', env);
+    const s = readState(tmpDir) as { memorySearched: boolean; memorySearchedBy: Record<string, boolean> };
+    expect(s.memorySearched).toBe(true);
+    expect(s.memorySearchedBy['subagent-session-X']).toBe(true);
+  });
+
+  it('record-memory-searched without HOOK_SESSION_ID still updates the legacy bool only', () => {
+    writeState(tmpDir, { memorySearched: false, memorySearchedBy: {} });
+    runGate('record-memory-searched', baseEnv(tmpDir));
+    const s = readState(tmpDir) as { memorySearched: boolean; memorySearchedBy: Record<string, boolean> };
+    expect(s.memorySearched).toBe(true);
+    expect(Object.keys(s.memorySearchedBy)).toHaveLength(0);
+  });
+
+  it('check-bash-memory stamps the per-actor map when HOOK_SESSION_ID is set', () => {
+    writeState(tmpDir, { memorySearched: false, memorySearchedBy: {} });
+    const env = baseEnv(tmpDir);
+    env.HOOK_SESSION_ID = 'subagent-session-Y';
+    env.TOOL_INPUT_command = 'npx flo-search semantic-search "auth"';
+    runGate('check-bash-memory', env);
+    const s = readState(tmpDir) as { memorySearched: boolean; memorySearchedBy: Record<string, boolean> };
+    expect(s.memorySearched).toBe(true);
+    expect(s.memorySearchedBy['subagent-session-Y']).toBe(true);
+  });
+
+  it('check-bash-memory does not rewrite state when the actor is already marked', () => {
+    // Hot-path: a subagent that runs flo-search repeatedly should not fsync
+    // workflow-state.json on every invocation once it is already satisfied.
+    writeState(tmpDir, {
+      memorySearched: true,
+      memorySearchedBy: { 'subagent-session-Z': true },
+    });
+    const stateFile = join(tmpDir, '.claude', 'workflow-state.json');
+    const mtimeBefore = readState(tmpDir);
+    void mtimeBefore;
+    const before = readFileSync(stateFile, 'utf-8');
+    const env = baseEnv(tmpDir);
+    env.HOOK_SESSION_ID = 'subagent-session-Z';
+    env.TOOL_INPUT_command = 'npx flo-search semantic-search "auth"';
+    runGate('check-bash-memory', env);
+    const after = readFileSync(stateFile, 'utf-8');
+    expect(after).toBe(before);
+  });
+
+  it('prompt-reminder clears the per-actor map (new prompt = clean window)', () => {
+    writeState(tmpDir, {
+      memorySearched: true,
+      memorySearchedBy: { 'parent': true, 'subA': true },
+    });
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'fix the next bug please';
+    runGate('prompt-reminder', env);
+    const s = readState(tmpDir) as { memorySearched: boolean; memorySearchedBy: Record<string, boolean> };
+    expect(s.memorySearched).toBe(false);
+    expect(s.memorySearchedBy).toEqual({});
+  });
+
+  it('session-reset clears the per-actor map', () => {
+    writeState(tmpDir, {
+      memorySearched: true,
+      memorySearchedBy: { 'a': true, 'b': true },
+    });
+    runGate('session-reset', baseEnv(tmpDir));
+    const s = readState(tmpDir) as { memorySearchedBy: Record<string, boolean> };
+    expect(s.memorySearchedBy).toEqual({});
+  });
+
+  it('end-to-end: parent satisfies, subagent blocked, subagent searches, subagent allowed', () => {
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false, memorySearchedBy: {} });
+
+    // 1. Parent searches memory (no HOOK_SESSION_ID forwarded for the parent
+    //    when the host is older / the parent's session_id is the default).
+    //    Even with a parent session id, this test focuses on the subagent path.
+    const parentEnv = baseEnv(tmpDir);
+    parentEnv.HOOK_SESSION_ID = 'parent-S';
+    runGate('record-memory-searched', parentEnv);
+
+    // 2. Fresh subagent attempts Grep — should BLOCK because its session_id
+    //    isn't in the map yet, even though `memorySearched` is true.
+    const subEnv = baseEnv(tmpDir);
+    subEnv.HOOK_SESSION_ID = 'sub-S-1';
+    subEnv.TOOL_INPUT_pattern = 'src/**/*.ts';
+    let r = runGate('check-before-scan', subEnv);
+    expect(r.exitCode).toBe(2);
+
+    // 3. Subagent does its own memory search.
+    runGate('record-memory-searched', subEnv);
+
+    // 4. Subagent retries Grep — now allowed.
+    r = runGate('check-before-scan', subEnv);
+    expect(r.exitCode).toBe(0);
+
+    // 5. A second subagent (different session_id) is still blocked until it
+    //    too searches — proving the map is per-actor, not per-session-once.
+    const sub2Env = baseEnv(tmpDir);
+    sub2Env.HOOK_SESSION_ID = 'sub-S-2';
+    sub2Env.TOOL_INPUT_pattern = 'src/**/*.ts';
+    r = runGate('check-before-scan', sub2Env);
+    expect(r.exitCode).toBe(2);
+  });
+
+  it('legacy callers (no HOOK_SESSION_ID) still see the old session-wide behavior', () => {
+    // Existing tests assume gate.cjs invocations without HOOK_SESSION_ID
+    // behave exactly like before — the bool drives the gate. Pin that.
+    writeState(tmpDir, { memoryRequired: true, memorySearched: true });
+    const env = baseEnv(tmpDir);
+    delete env.HOOK_SESSION_ID;
+    env.TOOL_INPUT_pattern = '**/*.ts';
+    const r = runGate('check-before-scan', env);
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// gate-hook.mjs — forwards stdin session_id as HOOK_SESSION_ID (#838)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('gate-hook.mjs: session_id forwarding (#838)', () => {
+  it('blocks a fresh subagent scan even when parent has already satisfied the gate', async () => {
+    // Parent has searched (legacy bool true) and is in the per-actor map.
+    // Fresh subagent comes in via stdin with a new session_id — should block.
+    writeState(tmpDir, {
+      memoryRequired: true,
+      memorySearched: true,
+      memorySearchedBy: { 'parent-session': true },
+    });
+    const r = await runEsmWithStdin(GATE_HOOK, ['check-before-scan'], {
+      session_id: 'fresh-subagent-session',
+      tool_name: 'Grep',
+      tool_input: { pattern: 'TODO', path: 'src/' },
+      hook_event_name: 'PreToolUse',
+    }, baseEnv(tmpDir));
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('BLOCKED');
+  });
+
+  it('allows the fresh subagent scan after it records its own memory search', async () => {
+    writeState(tmpDir, {
+      memoryRequired: true,
+      memorySearched: true,
+      memorySearchedBy: { 'parent-session': true, 'subagent-A': true },
+    });
+    const r = await runEsmWithStdin(GATE_HOOK, ['check-before-scan'], {
+      session_id: 'subagent-A',
+      tool_name: 'Grep',
+      tool_input: { pattern: 'TODO', path: 'src/' },
+      hook_event_name: 'PreToolUse',
+    }, baseEnv(tmpDir));
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('record-memory-searched via gate-hook stamps the map keyed on stdin session_id', async () => {
+    writeState(tmpDir, { memorySearched: false, memorySearchedBy: {} });
+    await runEsmWithStdin(GATE_HOOK, ['record-memory-searched'], {
+      session_id: 'subagent-Z',
+      tool_name: 'mcp__moflo__memory_search',
+      tool_input: { query: 'auth', namespace: 'guidance' },
+      hook_event_name: 'PostToolUse',
+    }, baseEnv(tmpDir));
+    const s = readState(tmpDir) as { memorySearched: boolean; memorySearchedBy: Record<string, boolean> };
+    expect(s.memorySearched).toBe(true);
+    expect(s.memorySearchedBy['subagent-Z']).toBe(true);
+  });
+});
+
 // ── Settings.json PostToolUse Matcher Validation ────────────────────────────
 // Verifies that the hook matchers in settings.json correctly match MCP tool names.
 // This catches the class of bug where a generic matcher is shadowed by a specific one.


### PR DESCRIPTION
## Summary

- Forward Claude Code's stdin `session_id` from `gate-hook.mjs` as `HOOK_SESSION_ID`
- Add per-actor `memorySearchedBy: { [sessionId]: true }` map in `workflow-state.json`
- New helpers in `gate.cjs`: `isMemorySearchedFor(state)` and `markMemorySearched(state)`
- 14 new gate-helper tests covering per-actor enforcement, back-compat fallback, and a no-redundant-fsync invariant

## Why

The directive injected by SubagentStart promised:

> "The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this."

But the gate's `memorySearched` boolean lived in a session-wide `workflow-state.json`. Once the parent searched memory, every spawned subagent inherited the satisfied flag — directive became advisory text only. Issue #838 has the full repro and probe artifacts (three subagents probed: general-purpose, Explore, code-analyzer; all reported "injection works, enforcement does not").

## How

- `gate-hook.mjs` extracts `session_id` from the hook context JSON and forwards it as `HOOK_SESSION_ID`.
- `check-before-scan` / `check-before-read` call `isMemorySearchedFor(state)`:
  - If `HOOK_SESSION_ID` set → check the per-session map
  - Else → fall back to the legacy `memorySearched` boolean (preserves all existing 100+ gate-helper tests and CLI behavior)
- `record-memory-searched` and `check-bash-memory` call `markMemorySearched(state)`, which stamps both legacy bool + per-actor entry and returns `changed` so callers skip redundant `writeState()` fsyncs (fixes a small hot-path regression spotted in review).
- `prompt-reminder` and `session-reset` wipe the map alongside the bool — a new user prompt is a fresh window for both parent and any subagents spawned that turn.

## Sources of truth (kept in sync)

The doctor `Gate Health` check enforces byte-equality between the first two:

1. \`bin/gate.cjs\` — canonical source shipped to npm consumers
2. \`.claude/helpers/gate.cjs\` — this project's installed copy (synced from \`bin/\` at session start)
3. \`src/cli/init/helpers-generator.ts::generateGateScript()\` — escaped-string fallback template for fresh installs when source isn't found

Same pattern applied to \`gate-hook.mjs\` and \`generateGateHookScript()\`.

## Out of scope

\`src/cli/services/spell-gate.ts::GateService\` has a parallel \`GateState\` mirror but is only used by the user-facing \`flo gate\` CLI command — not wired into runtime hooks via \`.claude/settings.json\`. Left untouched here. Worth a follow-up if it ever gets wired into hot paths.

## Test plan

- [x] \`npx vitest run --config vitest.isolation.config.ts tests/bin/gate-helpers.test.ts\` — 149 passed (135 existing + 14 new)
- [x] \`npm test\` — full suite, 7593 tests passed, 0 failed
- [x] \`npm run build\` — TypeScript clean
- [x] \`bin/gate.cjs\` and \`.claude/helpers/gate.cjs\` byte-identical (doctor sync check)
- [x] subagent-start.cjs parity tests still green

Closes #838

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)