### PR TITLE
fix(860): early-exit launcher on CLAUDE_CODE_HEADLESS to break daemon→indexer loop

### DIFF
--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -14,6 +14,17 @@ import { fileURLToPath } from 'url';
 import { mofloDir } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 
+// Headless skip (#860). The daemon's headless workers spawn `claude --print`
+// with CLAUDE_CODE_HEADLESS=true (see src/cli/services/headless-worker-
+// executor.ts). Each spawned Claude inherits SessionStart hooks, which
+// would re-enter this launcher and fork the indexer chain — bumping
+// memory.db mtime, invalidating the 4.9.7 fingerprint gate, and pegging
+// CPU on the daemon's 15-min worker cycle.
+if (process.env.CLAUDE_CODE_HEADLESS === 'true' || process.env.CLAUDE_CODE_HEADLESS === '1') {
+  emitWarning('session-start-launcher skipped (CLAUDE_CODE_HEADLESS=true)');
+  process.exit(0);
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Single source of truth for the launcher's guidance-mirror header. Section 3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,26 @@
+## ⚠ MoFlo is a library shipped to other projects — READ FIRST, every change
+
+**This is an open-source library.** The package is installed as a `devDependency` into consumer projects to make Claude Code more effective in those projects. It is NOT a standalone application — every change you make ships to N consumers via `npm install moflo` and runs from their `node_modules/moflo/...` on their machines.
+
+**Before writing any code or opening any PR**, articulate three things to yourself (and to the user, if non-trivial):
+
+1. **Consumer surface touched** — which file class is this? `bin/`, `src/cli/`, `.claude/scripts/`, `mcp-tools/`, hook handlers, init/, settings-generator, `claudemd-generator.ts`, anything synced to `node_modules/moflo/`. Editing a test or internal helper has near-zero blast radius. Editing the launcher, a hook, or anything `flo init` writes touches every consumer.
+2. **Failure mode for the on-the-current-version consumer** — what breaks for someone on `moflo@<previous>` who picks this change up via `npm install moflo@<latest>`? Is there a migration? Does the consumer need to do anything? Will their existing `.moflo/` state still parse? Their hooks still wire?
+3. **Round-trip cost** — does this require *publish-then-reinstall* before it takes effect (most runtime fixes do — see the dogfood note below), or does the source edit alone suffice (build/test/internal code)?
+
+**Concrete examples of what "consumer impact" looks like in practice:**
+
+- **#860** — missing `CLAUDE_CODE_HEADLESS` guard in the launcher → daemon-spawned headless Claude in *every* consumer triggered the indexer chain, pegging CPU on a 15-min loop. Cost: a stale-since-shipped guard fired in N consumer environments before anyone noticed.
+- **#854** — silent `catch {}` in launcher upgrade flow → consumers stuck across moflo 4.8.x → 4.9.2 with partial migrations and no diagnostic crumbs. Cost: 4+ versions worth of consumer-invisible breakage.
+- **#586 / collapse epic** — workspace renamed `@claude-flow/*` → `@moflo/*` → every consumer with bare imports needed coordinated migration; 5-invariant drift guard now blocks regressions.
+- **#798** — MCP swarm/agent handlers stubbed out as a "simplification" → headline product surface broke in every consumer; 10-story epic to repair.
+
+If you can't name the consumer surface and failure mode for a non-trivial change, **stop and re-scope** before writing code. "I'll just clean this up while I'm here" is the antipattern that produced every bullet above.
+
+See `feedback_consumer_blast_radius.md` (auto-memory) for the full posture.
+
+---
+
 ## ⚠ This repo dogfoods MoFlo — read before any diagnostic
 
 **MoFlo IS the project AND the installed devDependency that drives the editor.** Two layers exist and they routinely diverge:

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -14,6 +14,17 @@ import { fileURLToPath } from 'url';
 import { mofloDir } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 
+// Headless skip (#860). The daemon's headless workers spawn `claude --print`
+// with CLAUDE_CODE_HEADLESS=true (see src/cli/services/headless-worker-
+// executor.ts). Each spawned Claude inherits SessionStart hooks, which
+// would re-enter this launcher and fork the indexer chain — bumping
+// memory.db mtime, invalidating the 4.9.7 fingerprint gate, and pegging
+// CPU on the daemon's 15-min worker cycle.
+if (process.env.CLAUDE_CODE_HEADLESS === 'true' || process.env.CLAUDE_CODE_HEADLESS === '1') {
+  emitWarning('session-start-launcher skipped (CLAUDE_CODE_HEADLESS=true)');
+  process.exit(0);
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Single source of truth for the launcher's guidance-mirror header. Section 3

--- a/tests/bin/launcher-headless-skip.test.ts
+++ b/tests/bin/launcher-headless-skip.test.ts
@@ -112,10 +112,11 @@ describe('bin/session-start-launcher.mjs — headless skip end-to-end (#860)', (
   it('honors CLAUDE_CODE_HEADLESS=1 (numeric form)', () => {
     const root = makeProject();
     try {
+      const beforeFiles = snapshotMoflo(root);
       const result = runLauncher({ CLAUDE_CODE_HEADLESS: '1' }, root);
       expect(result.status).toBe(0);
       expect(result.stderr).toContain('session-start-launcher skipped');
-      expect(snapshotMoflo(root)).toEqual([]);
+      expect(snapshotMoflo(root)).toEqual(beforeFiles);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/bin/launcher-headless-skip.test.ts
+++ b/tests/bin/launcher-headless-skip.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for issue #860 — session-start launcher must early-exit
+ * when invoked from a daemon-spawned headless Claude session.
+ *
+ * Symptoms in the wild (motailz/code, 2026-05-02): the daemon's headless
+ * workers (optimize/testgaps/etc.) spawn `claude --print` with
+ * CLAUDE_CODE_HEADLESS=true; each spawned Claude inherits SessionStart
+ * hooks, which re-enter this launcher and fork the indexer chain →
+ * `memory rebuild-index --force` pegs the box every 15 minutes on the
+ * daemon's worker cycle. Without the early-exit guard, the loop is
+ * unbreakable: the indexer run itself bumps memory.db mtime, which
+ * invalidates the 4.9.7 fingerprint gate (#857) and guarantees the next
+ * spawn re-runs the whole chain.
+ *
+ * This file mixes two coverage shapes:
+ *   - Source-invariant guards (fast; pin the literal env-var check so a
+ *     future refactor can't quietly remove it).
+ *   - End-to-end spawn (slow; proves the launcher actually exits without
+ *     touching .moflo/ or spawning children).
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, readdirSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+
+const BIN = resolve(__dirname, '../../bin');
+const LAUNCHER = resolve(BIN, 'session-start-launcher.mjs');
+
+describe('bin/session-start-launcher.mjs — headless skip (#860)', () => {
+  const src = readFileSync(LAUNCHER, 'utf-8');
+
+  it('contains the CLAUDE_CODE_HEADLESS early-exit guard', () => {
+    // Source-invariant: the literal env-var check + the process.exit(0)
+    // must remain at the top of the launcher. Without this, daemon-spawned
+    // headless Claude sessions trigger the upgrade-heal + indexer chain.
+    expect(src).toMatch(/process\.env\.CLAUDE_CODE_HEADLESS\s*===\s*['"]true['"]/);
+    expect(src).toMatch(/process\.env\.CLAUDE_CODE_HEADLESS\s*===\s*['"]1['"]/);
+    expect(src).toMatch(/process\.exit\(0\)/);
+  });
+
+  it('places the guard before any sync/spawn work', () => {
+    // The guard must run before any imports' side effects, manifest reads,
+    // version-stamp comparisons, or child spawns — otherwise we'd still
+    // mutate state on every headless invocation.
+    const guardIdx = src.search(/process\.env\.CLAUDE_CODE_HEADLESS/);
+    expect(guardIdx).toBeGreaterThan(0);
+
+    // No manifest/version/indexer references between imports and the guard.
+    const head = src.slice(0, guardIdx);
+    expect(head).not.toMatch(/installed-files\.json/);
+    expect(head).not.toMatch(/moflo-version/);
+    expect(head).not.toMatch(/index-all\.mjs/);
+  });
+
+  it('emits a one-line stderr trace for diagnosability', () => {
+    // The skip must not be silent — daemon worker logs capture stderr,
+    // and "session-start-launcher skipped" is the trail that explains why
+    // the indexer didn't fire when something downstream looks for it.
+    expect(src).toMatch(/session-start-launcher skipped/);
+    expect(src).toMatch(/CLAUDE_CODE_HEADLESS=true/);
+  });
+});
+
+describe('bin/session-start-launcher.mjs — headless skip end-to-end (#860)', () => {
+  // Each spawn runs against a throwaway project root so the launcher's
+  // would-be writes to .moflo/, .claude/scripts/, etc. are observable
+  // without touching the real repo. The headless-skip path must NOT touch
+  // any of these, even on a never-initialized project tree.
+  function makeProject(): string {
+    const root = mkdtempSync(join(tmpdir(), 'moflo-headless-skip-'));
+    // Minimal package.json so findProjectRoot() in the launcher locates this dir
+    writeFileSync(join(root, 'package.json'), '{"name":"tmp","version":"0.0.0"}');
+    mkdirSync(join(root, '.moflo'), { recursive: true });
+    mkdirSync(join(root, '.claude/scripts'), { recursive: true });
+    return root;
+  }
+
+  function snapshotMoflo(root: string): string[] {
+    try { return readdirSync(join(root, '.moflo')).sort(); } catch { return []; }
+  }
+
+  function runLauncher(env: NodeJS.ProcessEnv, root: string) {
+    return spawnSync('node', [LAUNCHER], {
+      cwd: root,
+      env: { ...process.env, ...env, CLAUDE_PROJECT_DIR: root },
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+  }
+
+  it('exits 0 fast with CLAUDE_CODE_HEADLESS=true and writes nothing', () => {
+    const root = makeProject();
+    try {
+      const beforeFiles = snapshotMoflo(root);
+      const start = Date.now();
+      const result = runLauncher({ CLAUDE_CODE_HEADLESS: 'true' }, root);
+      const elapsed = Date.now() - start;
+      const afterFiles = snapshotMoflo(root);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain('session-start-launcher skipped');
+      // Loose budget — node startup dominates; the guard itself is microseconds.
+      expect(elapsed).toBeLessThan(3000);
+      // No new files in .moflo/ — no manifest, no version stamp, no fingerprint.
+      expect(afterFiles).toEqual(beforeFiles);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('honors CLAUDE_CODE_HEADLESS=1 (numeric form)', () => {
+    const root = makeProject();
+    try {
+      const result = runLauncher({ CLAUDE_CODE_HEADLESS: '1' }, root);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain('session-start-launcher skipped');
+      expect(snapshotMoflo(root)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // Negative-path coverage (CLAUDE_CODE_HEADLESS unset / =false) is left to
+  // the source-invariant tests above — running the full launcher against a
+  // tmp project root spawns detached, unrefed indexer children that race
+  // rmSync cleanup on Windows.
+});


### PR DESCRIPTION
## Summary

- Fixes #860 — daemon headless workers were recursively triggering the indexer chain via SessionStart hooks, pegging consumer CPU on the daemon's 15-min worker cycle
- Adds a top-of-CLAUDE.md "Consumer surface" posture block to make MoFlo's library nature explicit before any change — #860 is cited as the canonical example of what happens when the consumer-impact frame gets skipped
- 5 vitest tests pin the fix (3 source-invariant guards + 2 positive-path spawns)

## Root cause

```
daemon (every 15min)
  → optimize/testgaps headless worker
    → spawn('claude', ['--print', prompt], { env: { CLAUDE_CODE_HEADLESS: 'true' } })
      → Claude Code child fires SessionStart hooks
        → session-start-launcher.mjs runs unconditionally
          → spawns index-all.mjs
            → spawns 'memory rebuild-index --force' (the CPU killer)
```

The 4.9.7 fingerprint gate (#857) cannot break the loop because the indexer itself bumps \`memory.db\` mtime, invalidating the gate on every cycle. Live evidence collected from the motailz consumer at the time of diagnosis showed the optimize worker averaging 207s/run with the testgaps worker stuck \`isRunning: true\` for 53 min.

## Changes

- \`bin/session-start-launcher.mjs\` + \`.claude/scripts/session-start-launcher.mjs\` — 11-line guard immediately after imports; uses the existing \`emitWarning()\` helper (function declaration → hoists). Mirrored to \`.claude/scripts/\` so this very repo is protected before the next install round-trip.
- \`tests/bin/launcher-headless-skip.test.ts\` — 5 tests:
  - 3 source-invariant guards (literal env-var pair, position-before-mutating-work, stderr trace marker)
  - 2 end-to-end spawns against \`mkdtempSync\` roots (CLAUDE_CODE_HEADLESS=true and =1 → exit 0, no \`.moflo/\` writes)
- \`CLAUDE.md\` — new top-of-file "MoFlo is a library shipped to other projects" block. Three-step articulation required before any non-trivial change: (a) consumer surface touched, (b) failure mode for on-current-version consumer, (c) round-trip cost. Cites #860/#854/#586/#798 as canonical examples.

## Test plan

- [x] \`npx vitest run tests/bin/launcher-headless-skip.test.ts\` — 5/5 pass
- [x] \`npx vitest run tests/bin/launcher-854-fixes.test.ts tests/bin/launcher-visibility.test.ts tests/bin/lib-sync.test.ts tests/bin/install-manifest.test.ts tests/bin/session-start-embedding-race.test.ts src/cli/__tests__/services/auto-update.test.ts src/cli/__tests__/post-install-bootstrap-drift-guard.test.ts\` — 94/94 pass (no regression in launcher-adjacent suites)
- [x] \`npx vitest run tests/bin/\` — 154/154 pass (full bin/ suite)
- [x] /simplify reviewed three passes (3 reviewers in parallel each pass) — applied: use existing \`emitWarning()\`, drop dead \`existsSync\` import, drop 2 risky negative-path spawns, trim meta-narration comments, line-118 snapshot consistency
- [ ] After merge + publish: verify in motailz consumer that running \`claude --print "ping"\` does NOT spawn an indexer chain (Get-Process node should show no \`index-all.mjs\` child)

## Follow-up

Filed as a separate task: design a \`/consumer-impact-check\` skill (or PreToolUse hook on Edit/Write for library-surface paths) to promote the consumer-blast-radius rule from memory-retrieval to active enforcement. Pilot the skill first; if Claude still skips the posture, escalate to hook.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)