### PR TITLE
fix(859): drop --force from session-start rebuild-index

### DIFF
--- a/bin/index-all.mjs
+++ b/bin/index-all.mjs
@@ -218,11 +218,20 @@ function buildStepPlan() {
 
   // HNSW MUST run last (after all DB writes are committed, #81). Same thread
   // cap — rebuild-index loads fastembed for stats lookups.
+  //
+  // No `--force`: the embeddings-migration service (run by the launcher
+  // before this chain) handles model bumps, and `build-embeddings` above
+  // fills any rows that lack embeddings. So `rebuild-index` finds nothing
+  // to embed in steady state and takes the no-work path, which still
+  // refreshes the HNSW sidecar via `writeSidecarOrFail` and is followed by
+  // the existsSync post-check below. `--force` only added a 4000-row
+  // re-embed that the fingerprint gate (#858) is specifically trying to
+  // avoid (#859).
   if (localCli) {
     plan.push({
       name: 'hnsw-rebuild',
       cmd: 'node',
-      args: [localCli, 'memory', 'rebuild-index', '--force'],
+      args: [localCli, 'memory', 'rebuild-index'],
       timeoutMs: 300_000,
       env: ONNX_THREAD_CAP,
     });

--- a/tests/bin/session-start-embedding-race.test.ts
+++ b/tests/bin/session-start-embedding-race.test.ts
@@ -91,7 +91,7 @@ describe('bin/index-all.mjs runStep timeout (#744)', () => {
   });
 });
 
-describe('bin/index-all.mjs hnsw-rebuild subcommand (#731)', () => {
+describe('bin/index-all.mjs hnsw-rebuild subcommand (#731, #859)', () => {
   const file = resolve(BIN, 'index-all.mjs');
   const src = readFileSync(file, 'utf-8');
 
@@ -101,6 +101,20 @@ describe('bin/index-all.mjs hnsw-rebuild subcommand (#731)', () => {
     // failure on every session-start.
     expect(src).toMatch(/['"]memory['"]\s*,\s*['"]rebuild-index['"]/);
     expect(src).not.toMatch(/['"]memory['"]\s*,\s*['"]rebuild['"]\s*,/);
+  });
+
+  it('does NOT pass --force to rebuild-index (#859)', () => {
+    // The launcher's embeddings-migration handles model bumps, and the
+    // earlier `build-embeddings` step fills missing rows + refreshes the
+    // sidecar. `rebuild-index` is the safety-net sidecar refresh — it must
+    // take the cheap no-work path on a healthy consumer, not re-embed
+    // every row. The no-work path still calls writeSidecarOrFail, and the
+    // existsSync post-check below the step catches a missing sidecar.
+    const hnswStep = src.match(/name:\s*'hnsw-rebuild'[\s\S]*?args:\s*\[([^\]]+)\]/);
+    expect(hnswStep, 'hnsw-rebuild step must exist with an args array').toBeTruthy();
+    const argsLiteral = hnswStep![1];
+    expect(argsLiteral).not.toMatch(/['"]--force['"]/);
+    expect(argsLiteral).not.toMatch(/['"]-f['"]/);
   });
 });
 

--- a/tests/hooks-test-indexing.test.ts
+++ b/tests/hooks-test-indexing.test.ts
@@ -35,47 +35,66 @@ describe('hooks.mjs indexing integration', () => {
     expect(sessionStart).toContain('sequential indexing chain');
   });
 
-  // ── index-all.mjs runs all indexers sequentially ──────────────────
+  // ── index-all.mjs registers all indexers via consider() ──────────────
+  // After #862 each step is registered through `consider(name, cfgKey,
+  // scriptName, binName, args, ...)` and dispatched through a single
+  // `runStep(step.name, ...)` call inside the plan loop. These tests pin
+  // the registration shape rather than the dispatcher call site.
 
-  it('index-all.mjs runs guidance indexer', () => {
-    expect(indexAllContent).toContain("resolveBin('flo-index', 'index-guidance.mjs')");
-    expect(indexAllContent).toContain("runStep('guidance-index'");
+  it('index-all.mjs registers guidance indexer', () => {
+    expect(indexAllContent).toMatch(
+      /consider\(\s*'guidance-index'\s*,\s*'guidance'\s*,\s*'index-guidance\.mjs'\s*,\s*'flo-index'/,
+    );
   });
 
-  it('index-all.mjs runs code map generator', () => {
-    expect(indexAllContent).toContain("resolveBin('flo-codemap', 'generate-code-map.mjs')");
-    expect(indexAllContent).toContain("runStep('code-map'");
+  it('index-all.mjs registers code map generator', () => {
+    expect(indexAllContent).toMatch(
+      /consider\(\s*'code-map'\s*,\s*'code_map'\s*,\s*'generate-code-map\.mjs'\s*,\s*'flo-codemap'/,
+    );
   });
 
-  it('index-all.mjs runs test indexer', () => {
-    expect(indexAllContent).toContain("resolveBin('flo-testmap', 'index-tests.mjs')");
-    expect(indexAllContent).toContain("runStep('test-index'");
+  it('index-all.mjs registers test indexer', () => {
+    expect(indexAllContent).toMatch(
+      /consider\(\s*'test-index'\s*,\s*'tests'\s*,\s*'index-tests\.mjs'\s*,\s*'flo-testmap'/,
+    );
   });
 
-  it('index-all.mjs runs patterns indexer', () => {
-    expect(indexAllContent).toContain("resolveBin('flo-patterns', 'index-patterns.mjs')");
-    expect(indexAllContent).toContain("runStep('patterns-index'");
+  it('index-all.mjs registers patterns indexer', () => {
+    expect(indexAllContent).toMatch(
+      /consider\(\s*'patterns-index'\s*,\s*'patterns'\s*,\s*'index-patterns\.mjs'\s*,\s*'flo-patterns'/,
+    );
   });
 
-  it('index-all.mjs runs pretrain', () => {
-    expect(indexAllContent).toContain("runStep('pretrain'");
+  it('index-all.mjs registers pretrain step', () => {
+    expect(indexAllContent).toMatch(/name:\s*'pretrain'/);
+    expect(indexAllContent).toContain("'hooks', 'pretrain'");
   });
 
-  it('index-all.mjs runs HNSW rebuild as final step', () => {
-    expect(indexAllContent).toContain("runStep('hnsw-rebuild'");
-    // HNSW rebuild must appear after all other runStep calls
-    const lastIndexer = indexAllContent.lastIndexOf("runStep('pretrain'");
-    const hnswRebuild = indexAllContent.indexOf("runStep('hnsw-rebuild'");
-    expect(hnswRebuild).toBeGreaterThan(lastIndexer);
+  it('index-all.mjs registers HNSW rebuild as final step', () => {
+    expect(indexAllContent).toMatch(/name:\s*'hnsw-rebuild'/);
+    // HNSW rebuild's plan entry must appear after every other `consider(`
+    // call so the sequential loop runs it last.
+    const lastConsider = indexAllContent.lastIndexOf('consider(');
+    const hnswRebuild = indexAllContent.indexOf("name: 'hnsw-rebuild'");
+    expect(hnswRebuild).toBeGreaterThan(lastConsider);
   });
 
   // ── auto_index flag support ───────────────────────────────────────
+  // `consider()` consults `isIndexEnabled(cfgKey)` for steps that take a
+  // moflo.yaml flag. Pin the helper + the four registered keys.
 
-  it('index-all.mjs checks auto_index flags via isIndexEnabled', () => {
-    expect(indexAllContent).toContain("isIndexEnabled('guidance')");
-    expect(indexAllContent).toContain("isIndexEnabled('code_map')");
-    expect(indexAllContent).toContain("isIndexEnabled('tests')");
-    expect(indexAllContent).toContain("isIndexEnabled('patterns')");
+  it('index-all.mjs gates registration via isIndexEnabled', () => {
+    expect(indexAllContent).toMatch(/isIndexEnabled\(\s*cfgKey\s*\)/);
+  });
+
+  it('index-all.mjs registers all four auto_index keys', () => {
+    // The cfgKey arg of each consider() call.
+    const keys = ['guidance', 'code_map', 'tests', 'patterns'];
+    for (const k of keys) {
+      expect(indexAllContent).toMatch(
+        new RegExp(`consider\\(\\s*'[^']+'\\s*,\\s*'${k}'`),
+      );
+    }
   });
 
   it('isIndexEnabled reads moflo.yaml and respects false flag', () => {


### PR DESCRIPTION
## Summary

- `bin/index-all.mjs` no longer passes `--force` to `flo memory rebuild-index`. Saves the ~4000-row re-embed on every fingerprint-passing session-start.
- Sidecar contract is unchanged: `writeSidecarOrFail` runs in the no-work path of `rebuild-index` (memory.ts:2204-2207) and the existsSync post-check at index-all.mjs:288-292 still catches a missing sidecar loud.
- New argv regression test pinning that the hnsw-rebuild step omits `--force` / `-f`.
- Refreshed `tests/hooks-test-indexing.test.ts` for the post-#862 step-plan API (7 pre-existing failures from that refactor land green).

Closes #859.

## Why this is safe

Walked the AC's six probes in the issue thread. Two upstream layers cover the cases that originally motivated `--force`:

1. **Launcher embeddings-migration** (`runEmbeddingsMigrationIfNeeded` in `session-start-launcher.mjs`) re-embeds rows whose `embedding_model != CANONICAL_EMBEDDING_MODEL` *before* the indexer chain starts — probe #6 (post-model-bump) covered.
2. **build-embeddings** runs in `index-all.mjs` immediately *before* this step, fills any rows missing embeddings, and rebuilds the sidecar via `ensureHnswSidecar(stats, { alwaysRebuild: true })` — probe #5 (fresh consumer) covered.

By the time `rebuild-index` runs, every active row has a current-model embedding. Without `--force` the SQL becomes `... AND (embedding IS NULL OR embedding = '')` which returns zero, the no-work path runs, `writeSidecarOrFail(false)` rebuilds the sidecar anyway, and the existsSync post-check guards against a silent miss.

`--force` was a holdover from when the sidecar was a phantom file (pre-#747).

## Test plan

- [x] `npx vitest run tests/hooks-test-indexing.test.ts tests/bin/session-start-embedding-race.test.ts` — 22 pass
- [x] `npx vitest run -c vitest.isolation.config.ts src/cli/__tests__/memory/hnsw-persistence.test.ts` — round-trip + atomic rename invariants still green
- [x] Full `npm test` — 7633 pass; 9 remaining failures pre-exist on `main` (filed as #864) and are unrelated full-suite-load flakes
- [x] Source-level invariant on `bin/index-all.mjs` (existsSync post-check) preserved

## Consumer impact

- **Surface**: `bin/index-all.mjs` (synced to `node_modules/moflo/bin/` and `.claude/scripts/` for consumers)
- **Failure mode for on-current-version consumer**: none — sidecar contract is preserved by writeSidecarOrFail in the no-work path
- **Round-trip cost**: needs publish + reinstall to take effect (consumer runs from `node_modules/moflo/bin/`)
- **Net effect on a healthy consumer**: 4000-row re-embed disappears, sidecar is still refreshed, existsSync post-check still catches misses

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)