### PR TITLE
fix(866): anchor session-start spawn paths on node_modules/moflo/bin

### DIFF
--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -289,7 +289,20 @@ async function main() {
         // chain and producing the sqlite_autoindex corruption that #743 had
         // to repair on subsequent sessions. The launcher's foreground §3e
         // migration is the canonical migration site. See #744.
-        spawnWindowless('node', [resolve(__dirname, 'index-all.mjs')], 'sequential indexing chain');
+        // Prefer the npm-bin copy of index-all.mjs over __dirname resolution
+        // (#866). When this hooks.mjs is loaded from `.claude/scripts/` (e.g.
+        // an older launcher spawned us before the launcher's bin-anchor fix
+        // landed), `resolve(__dirname, 'index-all.mjs')` would point at the
+        // synced mirror — which the launcher's section 3 may still be in the
+        // middle of overwriting during an upgrade. resolveBinOrLocal's
+        // bin-first ordering guarantees the spawned chain matches the
+        // installed package even when the mirror is mid-sync.
+        const indexAllScript = resolveBinOrLocal('flo-index-all', 'index-all.mjs');
+        if (indexAllScript) {
+          spawnWindowless('node', [indexAllScript], 'sequential indexing chain');
+        } else {
+          log('warn', 'index-all.mjs not found (checked npm bin + .claude/scripts/)');
+        }
         // Neural patterns now loaded by moflo core routing — no external patching.
         break;
       }

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -1106,11 +1106,20 @@ if (mutationCount > 0) {
 }
 
 // ── 4. Spawn background tasks ───────────────────────────────────────────────
-const localCli = resolve(projectRoot, 'node_modules/moflo/bin/cli.js');
-const hasLocalCli = existsSync(localCli);
 
-// hooks.mjs session-start (daemon, indexer, pretrain, HNSW, neural patterns)
-const hooksScript = resolve(projectRoot, '.claude/scripts/hooks.mjs');
+// hooks.mjs session-start (daemon, indexer, pretrain, HNSW, neural patterns).
+// Prefer the npm-bin copy over the `.claude/scripts/` mirror (#866). The mirror
+// is a derived sync that races the launcher's section-3 file copies during the
+// very upgrade session — spawning the still-stale `.claude/scripts/hooks.mjs`
+// then chaining `__dirname/index-all.mjs` produces an orphan running pre-
+// upgrade argv (e.g. `rebuild-index --force` after #859 had already dropped
+// it). The bin/ copy is updated atomically by `npm install moflo` (single-
+// step), so spawning from there guarantees the running hook code matches the
+// installed package. Falls back to the mirror only when the package copy is
+// unresolvable (development / symlinked installs).
+const hooksPkg = resolve(projectRoot, 'node_modules/moflo/bin/hooks.mjs');
+const hooksMirror = resolve(projectRoot, '.claude/scripts/hooks.mjs');
+const hooksScript = existsSync(hooksPkg) ? hooksPkg : hooksMirror;
 if (existsSync(hooksScript)) {
   fireAndForget('node', [hooksScript, 'session-start'], 'hooks session-start');
 }

--- a/tests/bin/launcher-866-bin-anchor.test.ts
+++ b/tests/bin/launcher-866-bin-anchor.test.ts
@@ -81,9 +81,6 @@ describe('bin/hooks.mjs session-start — anchor index-all.mjs spawn on npm bin 
   it('logs a warning when index-all.mjs is unresolvable rather than silently no-op', () => {
     // log+advise: a missing chain script must surface (#854 posture). Prevents
     // a "session-start indexer never ran" silent failure.
-    // Anchor on the `break;` that exits the case (rather than the next `case`
-    // or any close brace) — `}` would match nested if/else closures, and the
-    // next `case` would silently no-op if `session-start` ever became last.
     const sessionStart = src.match(/case 'session-start':\s*\{([\s\S]*?\n\s+break;)/);
     expect(sessionStart![1]).toMatch(/log\s*\(\s*['"]warn['"]\s*,\s*['"][^'"]*index-all\.mjs not found/);
   });

--- a/tests/bin/launcher-866-bin-anchor.test.ts
+++ b/tests/bin/launcher-866-bin-anchor.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression tests for issue #866 — stale-install repair races indexer chain
+ * spawn, leaving an orphan running pre-upgrade argv.
+ *
+ * Symptom in the wild (motailz, 4.9.7 → 4.9.8 upgrade):
+ *   - Launcher spawned `node .claude/scripts/index-all.mjs` from stale 4.9.7
+ *     bytes (still has `--force`).
+ *   - Section 3 sync overwrote `.claude/scripts/index-all.mjs` ~43 s later.
+ *   - The already-detached chain kept running with the old `--force` argv,
+ *     burning 4110 CPU-seconds re-embedding ~4000 rows the fingerprint gate
+ *     (#858) would otherwise have skipped.
+ *
+ * Structural fix: anchor both the launcher's `hooks.mjs` spawn AND
+ * hooks.mjs's `index-all.mjs` spawn on `node_modules/moflo/bin/` rather than
+ * the `.claude/scripts/` mirror. The bin/ copy is updated atomically by
+ * `npm install` (single-package, single-step), so it cannot be mid-overwrite
+ * the way the synced mirror can during an upgrade session.
+ *
+ * Source-invariant tests pin the structural fix into the file so a future
+ * "simplification" can't quietly regress it. Behavioural coverage already
+ * exists in launcher-visibility.test.ts and session-start-embedding-race.test.ts;
+ * this file is the cheap "did the fix actually land in source" gate.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const BIN = resolve(__dirname, '../../bin');
+
+describe('bin/session-start-launcher.mjs §4 — anchor hooks.mjs spawn on npm bin (#866)', () => {
+  const file = resolve(BIN, 'session-start-launcher.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('prefers node_modules/moflo/bin/hooks.mjs over the .claude/scripts/ mirror', () => {
+    // The `hooksPkg`/`hooksMirror` pair must exist and the spawn target must
+    // be the existsSync-gated preference of pkg over mirror. Mirrors the
+    // existing `runMigrationsPkg`/`runMigrationsMirror` pattern immediately
+    // below in the same section.
+    expect(src).toMatch(/const\s+hooksPkg\s*=\s*resolve\(projectRoot,\s*['"]node_modules\/moflo\/bin\/hooks\.mjs['"]\)/);
+    expect(src).toMatch(/const\s+hooksMirror\s*=\s*resolve\(projectRoot,\s*['"]\.claude\/scripts\/hooks\.mjs['"]\)/);
+    expect(src).toMatch(/const\s+hooksScript\s*=\s*existsSync\(hooksPkg\)\s*\?\s*hooksPkg\s*:\s*hooksMirror/);
+  });
+
+  it('does NOT spawn hooks.mjs directly from the .claude/scripts mirror without a bin-pref guard', () => {
+    // Pre-#866: `const hooksScript = resolve(projectRoot, '.claude/scripts/hooks.mjs');`
+    // — a single-source path that races the section-3 sync. The fix must not
+    // regress to that shape.
+    expect(src).not.toMatch(/const\s+hooksScript\s*=\s*resolve\(projectRoot,\s*['"]\.claude\/scripts\/hooks\.mjs['"]\)\s*;/);
+  });
+
+  it('still spawns via fireAndForget so the launcher exits immediately', () => {
+    // Sanity: don't accidentally make the spawn synchronous — the launcher
+    // must return fast so Claude Code's SessionStart hook doesn't block.
+    expect(src).toMatch(/fireAndForget\s*\(\s*['"]node['"]\s*,\s*\[\s*hooksScript\s*,\s*['"]session-start['"]\s*\]\s*,\s*['"]hooks session-start['"]\s*\)/);
+  });
+});
+
+describe('bin/hooks.mjs session-start — anchor index-all.mjs spawn on npm bin (#866)', () => {
+  const file = resolve(BIN, 'hooks.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('uses resolveBinOrLocal for the index-all.mjs spawn, not raw __dirname', () => {
+    // Locate the session-start case body and assert on its spawn target.
+    // Anchor on the case|default|close-brace boundary so this test can't
+    // silently no-op if `session-start` ever becomes the last case.
+    // Anchor on the `break;` that exits the case (rather than the next `case`
+    // or any close brace) — `}` would match nested if/else closures, and the
+    // next `case` would silently no-op if `session-start` ever became last.
+    const sessionStart = src.match(/case 'session-start':\s*\{([\s\S]*?\n\s+break;)/);
+    expect(sessionStart, 'session-start case must exist in hooks.mjs').toBeTruthy();
+    const body = sessionStart![1];
+
+    // Pre-#866 anti-pattern: `resolve(__dirname, 'index-all.mjs')` resolves to
+    // .claude/scripts/index-all.mjs whenever hooks.mjs itself was loaded from
+    // the synced mirror. Forbid the raw shape.
+    expect(body).not.toMatch(/spawnWindowless\s*\(\s*['"]node['"]\s*,\s*\[\s*resolve\s*\(\s*__dirname\s*,\s*['"]index-all\.mjs['"]\s*\)\s*\]/);
+
+    // Required shape: `resolveBinOrLocal('flo-index-all', 'index-all.mjs')`
+    // — same helper hooks.mjs already uses for `index-guidance.mjs` (line ~474).
+    expect(body).toMatch(/resolveBinOrLocal\s*\(\s*['"]flo-index-all['"]\s*,\s*['"]index-all\.mjs['"]\s*\)/);
+    expect(body).toMatch(/spawnWindowless\s*\(\s*['"]node['"]\s*,\s*\[\s*indexAllScript\s*\]/);
+  });
+
+  it('logs a warning when index-all.mjs is unresolvable rather than silently no-op', () => {
+    // log+advise: a missing chain script must surface (#854 posture). Prevents
+    // a "session-start indexer never ran" silent failure.
+    // Anchor on the `break;` that exits the case (rather than the next `case`
+    // or any close brace) — `}` would match nested if/else closures, and the
+    // next `case` would silently no-op if `session-start` ever became last.
+    const sessionStart = src.match(/case 'session-start':\s*\{([\s\S]*?\n\s+break;)/);
+    expect(sessionStart![1]).toMatch(/log\s*\(\s*['"]warn['"]\s*,\s*['"][^'"]*index-all\.mjs not found/);
+  });
+
+  it('resolveBinOrLocal still checks node_modules/moflo/bin before .claude/scripts', () => {
+    // The helper itself is the load-bearing piece. Pin its bin-first ordering
+    // so a future refactor can't silently flip the priority and reintroduce
+    // the stale-mirror race.
+    const helper = src.match(/function\s+resolveBinOrLocal\s*\([^)]*\)\s*\{[\s\S]*?\n\}/);
+    expect(helper, 'resolveBinOrLocal helper must exist').toBeTruthy();
+    const body = helper![0];
+
+    const mofloIdx = body.indexOf("'node_modules/moflo/bin'");
+    const mirrorIdx = body.indexOf("'.claude/scripts'");
+    expect(mofloIdx).toBeGreaterThan(-1);
+    expect(mirrorIdx).toBeGreaterThan(-1);
+    expect(mofloIdx).toBeLessThan(mirrorIdx);
+  });
+});

--- a/tests/bin/launcher-866-bin-anchor.test.ts
+++ b/tests/bin/launcher-866-bin-anchor.test.ts
@@ -60,12 +60,9 @@ describe('bin/hooks.mjs session-start — anchor index-all.mjs spawn on npm bin 
   const src = readFileSync(file, 'utf-8');
 
   it('uses resolveBinOrLocal for the index-all.mjs spawn, not raw __dirname', () => {
-    // Locate the session-start case body and assert on its spawn target.
-    // Anchor on the case|default|close-brace boundary so this test can't
-    // silently no-op if `session-start` ever becomes the last case.
-    // Anchor on the `break;` that exits the case (rather than the next `case`
-    // or any close brace) — `}` would match nested if/else closures, and the
-    // next `case` would silently no-op if `session-start` ever became last.
+    // Anchor on the `break;` that exits the case — `}` would match nested
+    // if/else closures inside the case, and `case '...'` would silently
+    // no-op this test if `session-start` ever became the last case.
     const sessionStart = src.match(/case 'session-start':\s*\{([\s\S]*?\n\s+break;)/);
     expect(sessionStart, 'session-start case must exist in hooks.mjs').toBeTruthy();
     const body = sessionStart![1];


### PR DESCRIPTION
## Summary

Closes #866. Anchors the launcher's `hooks.mjs session-start` spawn and hooks.mjs's `index-all.mjs` spawn on `node_modules/moflo/bin/` instead of the synced `.claude/scripts/` mirror, so the chain that runs during an upgrade session matches the installed package even when the mirror is mid-sync.

## Why

Two stale-bytes hops between `npm install` and the spawned indexer chain produced an orphan running pre-upgrade argv — the motailz consumer hit this on a 4.9.7 → 4.9.8 upgrade and burned 4110 CPU-seconds re-embedding 4000 rows the fingerprint gate (#858) would otherwise have skipped:

1. Launcher §4 spawned `.claude/scripts/hooks.mjs` (synced mirror, mid-overwrite).
2. hooks.mjs spawned `__dirname/index-all.mjs` (also `.claude/scripts/...` when hooks.mjs was loaded from the mirror).

The bin/ copy is updated atomically by `npm install moflo` (single-package, single-step), so spawning from there closes the race. Mirrors the existing `runMigrationsPkg`/`runMigrationsMirror` pattern 18 lines below in §4 and the `resolveBinOrLocal` pattern hooks.mjs already uses for `index-guidance.mjs`.

Per the codified rule in `feedback_consumer_path_resolution.md`: runtime imports of moflo internals must anchor on the npm-bin copy, not consumer-derived paths.

## Changes

- `bin/session-start-launcher.mjs` §4: prefer `node_modules/moflo/bin/hooks.mjs` over `.claude/scripts/hooks.mjs`. Falls back to the mirror only when the package copy is unresolvable (dev/symlink runs).
- `bin/hooks.mjs` session-start: replace `resolve(__dirname, 'index-all.mjs')` with `resolveBinOrLocal('flo-index-all', 'index-all.mjs')`. Logs a warning if neither path resolves (no silent failure).
- Removed dead module-scope `localCli`/`hasLocalCli` adjacent to §4 (the working CLI resolver lives inside `recycleDaemon` under a different name).
- New `tests/bin/launcher-866-bin-anchor.test.ts` (6 source-invariant tests, matches `launcher-854-fixes` style).

## Scope limit (called out in the issue)

The very upgrade session that introduces the fix still races — the in-flight launcher and `.claude/scripts/hooks.mjs` are still pre-fix bytes. Subsequent upgrades benefit because the post-fix launcher anchors on the npm-bin copy. Closing the upgrade-session race itself would require pointing settings.json's SessionStart hook at `node_modules/moflo/bin/session-start-launcher.mjs` directly — that's a larger contract change tracked separately.

## Follow-up worth filing

Lift `resolveBinOrLocal` (hooks.mjs:455) and `resolveBin` (index-all.mjs:63) into `bin/lib/resolve-bin.mjs` and migrate ~6 inline callsites in one focused PR. Deferred from this hotfix per the consumer-blast-radius posture (don't refactor the very surface the upgrade race is trying to traverse).

## Test plan

- [x] New `tests/bin/launcher-866-bin-anchor.test.ts` (6 tests) — pins both invariants in source.
- [x] Existing related suites green: `launcher-854-fixes`, `session-start-embedding-race`, `launcher-headless-skip`, `launcher-visibility`, `install-manifest`, `lib-sync`, `bin-scripts`, `hooks-test-indexing`, `guidance-mirror-prune`, `settings-statusline`, `auto-update`, `db-repair`, `post-install-bootstrap`, `post-install-bootstrap-drift-guard`, `published-package-drift-guard` (220 tests across 22 files).
- [ ] Manual: after publish + reinstall in a consumer, restart Claude Code on a fresh upgrade and verify no orphan `cli.js memory rebuild-index --force` survives section 3.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)