### PR TITLE
fix(867): reconcile post-install restart notice + TTY-direct banner

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -217,6 +217,112 @@ try {
   // own errors if the DB is still broken.
 }
 
+// ── 0d. Reconcile post-install notice files (#867) ─────────────────────────
+// scripts/post-install-notice.mjs writes `.moflo/restart-pending.json` and
+// `.moflo/last-install-banner.json` on every `npm install moflo` that runs
+// inside Claude Code. Both are version-stamped. Pre-#867 nothing ever
+// cleaned them up: the assistant was supposed to surface the message
+// verbatim and `unlinkSync` it, but the contract relied on the assistant
+// remembering — which failed often enough (see issue body) to leave the
+// files accumulating across upgrades.
+//
+// This block makes the cleanup self-healing:
+//   • notice.version === installed → upgrade has been picked up; unlink.
+//   • notice.version >  installed  → user is still on the older bits;
+//                                    re-emit the message via launcher
+//                                    stdout (Claude additionalContext) and
+//                                    leave the file in place so the next
+//                                    restart attempt also sees it.
+//   • notice.version <  installed  → file is stale (predates the running
+//                                    moflo); unlink silently.
+//
+// `last-install-banner.json` is the postinstall dedup tracker. It carries
+// no message, so the equality logic is the same minus the re-emit.
+//
+// Runs early — before section 3's upgrade detection — so the user / Claude
+// see "moflo: cleared post-install restart notice" alongside the upgrade
+// mutation lines (or, in the older-running-bits branch, sees the banner
+// before any mutation work).
+function compareSemverParts(a, b) {
+  // Pure numeric semver compare (X.Y.Z…). Returns -1/0/1. Trailing pre-
+  // release tags (4.9.8-beta) get split by the regex; non-numeric segments
+  // fall through to a string compare so something silly like "next" sorts
+  // deterministically rather than throwing. Good enough for the only
+  // version pair this block ever sees: moflo's package.json semver.
+  const parse = (v) => String(v).replace(/^v/, '').split(/[.+-]/);
+  const aParts = parse(a);
+  const bParts = parse(b);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i++) {
+    const av = aParts[i];
+    const bv = bParts[i];
+    if (av === bv) continue;
+    if (av === undefined) return -1;
+    if (bv === undefined) return 1;
+    const aNum = /^\d+$/.test(av) ? parseInt(av, 10) : null;
+    const bNum = /^\d+$/.test(bv) ? parseInt(bv, 10) : null;
+    if (aNum !== null && bNum !== null) return aNum < bNum ? -1 : 1;
+    return av < bv ? -1 : 1;
+  }
+  return 0;
+}
+
+try {
+  const mofloPkgPath = resolve(projectRoot, 'node_modules/moflo/package.json');
+  if (existsSync(mofloPkgPath)) {
+    const installedVersion = JSON.parse(readFileSync(mofloPkgPath, 'utf-8')).version;
+    const noticePath = join(mofloDir(projectRoot), 'restart-pending.json');
+    const trackerPath = join(mofloDir(projectRoot), 'last-install-banner.json');
+
+    if (installedVersion && existsSync(noticePath)) {
+      let payload = null;
+      try { payload = JSON.parse(readFileSync(noticePath, 'utf-8')); } catch { /* malformed — fall through to delete */ }
+      const noticeVersion = payload && typeof payload.version === 'string' ? payload.version : null;
+
+      if (!noticeVersion) {
+        // Malformed or missing version field — file can't be load-bearing.
+        try { unlinkSync(noticePath); } catch (err) { emitWarning(`failed to remove malformed restart-pending.json (${errMessage(err)})`); }
+      } else {
+        const cmp = compareSemverParts(noticeVersion, installedVersion);
+        if (cmp === 0) {
+          // Notice already applied — drop both files together.
+          try { unlinkSync(noticePath); emitMutation('cleared post-install restart notice', `${noticeVersion} now running`); } catch (err) { emitWarning(`failed to remove restart-pending.json (${errMessage(err)})`); }
+          try { unlinkSync(trackerPath); } catch { /* non-fatal — tracker may not exist */ }
+        } else if (cmp > 0) {
+          // Running bits are older than the file — this session still needs
+          // a restart onto installedVersion's predecessor. Re-emit so Claude
+          // additionalContext shows the message; leave the file in place.
+          const message = typeof payload.message === 'string' && payload.message.length > 0
+            ? payload.message
+            : `MoFlo ${noticeVersion} installed but session is running ${installedVersion} — please restart Claude Code.`;
+          try {
+            for (const line of message.split('\n')) {
+              if (line === '') continue; // collapse blank separators in the multi-line payload
+              process.stdout.write(`moflo: ${line}\n`);
+            }
+            mutationCount++;
+          } catch { /* stdout broken — no recovery */ }
+        } else {
+          // Notice predates the running moflo — pure stale, just unlink.
+          try { unlinkSync(noticePath); } catch (err) { emitWarning(`failed to remove stale restart-pending.json (${errMessage(err)})`); }
+          try { unlinkSync(trackerPath); } catch { /* non-fatal */ }
+        }
+      }
+    } else if (installedVersion && existsSync(trackerPath)) {
+      // Orphan tracker (no notice file) — reconcile by version. The tracker
+      // is purely a postinstall memo; once the running moflo has reached
+      // (or passed) its stamped version, it can go.
+      let trackerVersion = null;
+      try { trackerVersion = JSON.parse(readFileSync(trackerPath, 'utf-8'))?.version || null; } catch { /* malformed */ }
+      if (!trackerVersion || compareSemverParts(trackerVersion, installedVersion) <= 0) {
+        try { unlinkSync(trackerPath); } catch { /* non-fatal */ }
+      }
+    }
+  }
+} catch (err) {
+  emitWarning(`post-install notice reconciliation failed (${errMessage(err)})`);
+}
+
 // ── 1. Helper: fire-and-forget a background process ─────────────────────────
 function fireAndForget(cmd, args, label) {
   try {

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -218,37 +218,16 @@ try {
 }
 
 // ── 0d. Reconcile post-install notice files (#867) ─────────────────────────
-// scripts/post-install-notice.mjs writes `.moflo/restart-pending.json` and
-// `.moflo/last-install-banner.json` on every `npm install moflo` that runs
-// inside Claude Code. Both are version-stamped. Pre-#867 nothing ever
-// cleaned them up: the assistant was supposed to surface the message
-// verbatim and `unlinkSync` it, but the contract relied on the assistant
-// remembering — which failed often enough (see issue body) to leave the
-// files accumulating across upgrades.
-//
-// This block makes the cleanup self-healing:
-//   • notice.version === installed → upgrade has been picked up; unlink.
-//   • notice.version >  installed  → user is still on the older bits;
-//                                    re-emit the message via launcher
-//                                    stdout (Claude additionalContext) and
-//                                    leave the file in place so the next
-//                                    restart attempt also sees it.
-//   • notice.version <  installed  → file is stale (predates the running
-//                                    moflo); unlink silently.
-//
-// `last-install-banner.json` is the postinstall dedup tracker. It carries
-// no message, so the equality logic is the same minus the re-emit.
-//
-// Runs early — before section 3's upgrade detection — so the user / Claude
-// see "moflo: cleared post-install restart notice" alongside the upgrade
-// mutation lines (or, in the older-running-bits branch, sees the banner
-// before any mutation work).
+// scripts/post-install-notice.mjs drops `.moflo/restart-pending.json` (+ a
+// dedup tracker) on every `npm install moflo` inside Claude Code. Pre-#867
+// nothing cleaned them up — the contract relied on the assistant
+// remembering to surface + unlink, which often failed. Three branches:
+//   notice.version === installed → unlink (upgrade is live)
+//   notice.version >  installed  → re-emit message via stdout, keep file
+//   notice.version <  installed  → unlink as stale
 function compareSemverParts(a, b) {
-  // Pure numeric semver compare (X.Y.Z…). Returns -1/0/1. Trailing pre-
-  // release tags (4.9.8-beta) get split by the regex; non-numeric segments
-  // fall through to a string compare so something silly like "next" sorts
-  // deterministically rather than throwing. Good enough for the only
-  // version pair this block ever sees: moflo's package.json semver.
+  // Numeric semver compare (X.Y.Z…). Non-numeric segments fall through to
+  // string compare so pre-release tags sort deterministically.
   const parse = (v) => String(v).replace(/^v/, '').split(/[.+-]/);
   const aParts = parse(a);
   const bParts = parse(b);
@@ -267,55 +246,60 @@ function compareSemverParts(a, b) {
   return 0;
 }
 
+function readJsonOrNull(path) {
+  // Fast-path read that swallows ENOENT (common case). Other read/parse
+  // errors return null and are treated as "malformed" by the caller, which
+  // falls back to the delete branch.
+  try { return JSON.parse(readFileSync(path, 'utf-8')); }
+  catch { return null; }
+}
+function tryUnlink(path) {
+  try { unlinkSync(path); return true; }
+  catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    emitWarning(`failed to remove ${path} (${errMessage(err)})`);
+    return false;
+  }
+}
+
 try {
   const mofloPkgPath = resolve(projectRoot, 'node_modules/moflo/package.json');
-  if (existsSync(mofloPkgPath)) {
-    const installedVersion = JSON.parse(readFileSync(mofloPkgPath, 'utf-8')).version;
+  const pkg = readJsonOrNull(mofloPkgPath);
+  const installedVersion = pkg && typeof pkg.version === 'string' ? pkg.version : null;
+  if (installedVersion) {
     const noticePath = join(mofloDir(projectRoot), 'restart-pending.json');
     const trackerPath = join(mofloDir(projectRoot), 'last-install-banner.json');
+    const payload = readJsonOrNull(noticePath);
 
-    if (installedVersion && existsSync(noticePath)) {
-      let payload = null;
-      try { payload = JSON.parse(readFileSync(noticePath, 'utf-8')); } catch { /* malformed — fall through to delete */ }
-      const noticeVersion = payload && typeof payload.version === 'string' ? payload.version : null;
-
-      if (!noticeVersion) {
-        // Malformed or missing version field — file can't be load-bearing.
-        try { unlinkSync(noticePath); } catch (err) { emitWarning(`failed to remove malformed restart-pending.json (${errMessage(err)})`); }
+    if (payload && typeof payload.version === 'string') {
+      const cmp = compareSemverParts(payload.version, installedVersion);
+      if (cmp === 0) {
+        if (tryUnlink(noticePath)) emitMutation('cleared post-install restart notice', `${payload.version} now running`);
+        tryUnlink(trackerPath);
+      } else if (cmp > 0) {
+        const message = typeof payload.message === 'string' && payload.message.length > 0
+          ? payload.message
+          : `MoFlo ${payload.version} installed but session is running ${installedVersion} — please restart Claude Code.`;
+        try {
+          for (const line of message.split('\n')) {
+            if (line === '') continue;
+            process.stdout.write(`moflo: ${line}\n`);
+          }
+          mutationCount++;
+        } catch { /* stdout broken — emitWarning would also fail */ }
       } else {
-        const cmp = compareSemverParts(noticeVersion, installedVersion);
-        if (cmp === 0) {
-          // Notice already applied — drop both files together.
-          try { unlinkSync(noticePath); emitMutation('cleared post-install restart notice', `${noticeVersion} now running`); } catch (err) { emitWarning(`failed to remove restart-pending.json (${errMessage(err)})`); }
-          try { unlinkSync(trackerPath); } catch { /* non-fatal — tracker may not exist */ }
-        } else if (cmp > 0) {
-          // Running bits are older than the file — this session still needs
-          // a restart onto installedVersion's predecessor. Re-emit so Claude
-          // additionalContext shows the message; leave the file in place.
-          const message = typeof payload.message === 'string' && payload.message.length > 0
-            ? payload.message
-            : `MoFlo ${noticeVersion} installed but session is running ${installedVersion} — please restart Claude Code.`;
-          try {
-            for (const line of message.split('\n')) {
-              if (line === '') continue; // collapse blank separators in the multi-line payload
-              process.stdout.write(`moflo: ${line}\n`);
-            }
-            mutationCount++;
-          } catch { /* stdout broken — no recovery */ }
-        } else {
-          // Notice predates the running moflo — pure stale, just unlink.
-          try { unlinkSync(noticePath); } catch (err) { emitWarning(`failed to remove stale restart-pending.json (${errMessage(err)})`); }
-          try { unlinkSync(trackerPath); } catch { /* non-fatal */ }
-        }
+        tryUnlink(noticePath);
+        tryUnlink(trackerPath);
       }
-    } else if (installedVersion && existsSync(trackerPath)) {
-      // Orphan tracker (no notice file) — reconcile by version. The tracker
-      // is purely a postinstall memo; once the running moflo has reached
-      // (or passed) its stamped version, it can go.
-      let trackerVersion = null;
-      try { trackerVersion = JSON.parse(readFileSync(trackerPath, 'utf-8'))?.version || null; } catch { /* malformed */ }
-      if (!trackerVersion || compareSemverParts(trackerVersion, installedVersion) <= 0) {
-        try { unlinkSync(trackerPath); } catch { /* non-fatal */ }
+    } else if (existsSync(noticePath)) {
+      // Notice exists but is malformed/missing version — can't be load-bearing.
+      tryUnlink(noticePath);
+    } else {
+      // No notice file. Reconcile a possible orphan tracker.
+      const tracker = readJsonOrNull(trackerPath);
+      const trackerVersion = tracker && typeof tracker.version === 'string' ? tracker.version : null;
+      if (tracker && (!trackerVersion || compareSemverParts(trackerVersion, installedVersion) <= 0)) {
+        tryUnlink(trackerPath);
       }
     }
   }

--- a/scripts/post-install-notice.mjs
+++ b/scripts/post-install-notice.mjs
@@ -36,9 +36,10 @@
  * Failure posture: never blocks an install. Errors are swallowed; exit 0.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, openSync, writeSync, closeSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { platform } from 'node:os';
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 
@@ -97,12 +98,49 @@ function buildMessage(version) {
   ].join('\n');
 }
 
-function printBanner(version, message) {
-  // Stdout fallback for --foreground-scripts users. With npm's default
-  // config this output is captured and never seen — that's why the notice
-  // file exists. Kept anyway because it costs nothing.
+function ttyDevicePath() {
+  // Direct TTY write reaches the user's terminal even when npm 7+ captures
+  // stdout into log files (#867). POSIX has /dev/tty; Windows has the CON
+  // device. If neither resolves, the helper silently no-ops.
+  return platform() === 'win32' ? '\\\\.\\CON' : '/dev/tty';
+}
+
+function writeToTty(text) {
+  // Best-effort terminal write. Returns true on success so the caller knows
+  // not to also fall back to stdout (avoids double-printing when both work).
+  // CI / piped npm output / no-controlling-terminal cases trip the catch
+  // and return false — postinstall MUST never block install over a missing
+  // TTY, so all errors are swallowed.
+  let fd = null;
+  try {
+    fd = openSync(ttyDevicePath(), 'w');
+    writeSync(fd, text);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) {
+      try { closeSync(fd); } catch { /* fd already closed or failed to open */ }
+    }
+  }
+}
+
+function bannerText(version, message) {
   const border = '═'.repeat(67);
-  process.stdout.write(`\n${border}\n  MoFlo ${version} installed.\n\n  ⚠ ${message.split('\n')[2]}\n${border}\n\n`);
+  return `\n${border}\n  MoFlo ${version} installed.\n\n  ⚠ ${message.split('\n')[2]}\n${border}\n\n`;
+}
+
+function printBanner(version, message) {
+  // Two-channel print: TTY-direct first (works around npm's stdio capture
+  // in v7+ default `foreground-scripts: false` mode), stdout second as the
+  // belt-and-braces fallback for `--foreground-scripts` users and CI logs.
+  // Pre-#867 only stdout was attempted, which npm captured into log files
+  // the user never sees — the notice file existed solely to compensate.
+  const text = bannerText(version, message);
+  const ttyOk = writeToTty(text);
+  if (!ttyOk) {
+    try { process.stdout.write(text); } catch { /* stdout broken — give up silently */ }
+  }
 }
 
 function run() {

--- a/scripts/post-install-notice.mjs
+++ b/scripts/post-install-notice.mjs
@@ -99,18 +99,12 @@ function buildMessage(version) {
 }
 
 function ttyDevicePath() {
-  // Direct TTY write reaches the user's terminal even when npm 7+ captures
-  // stdout into log files (#867). POSIX has /dev/tty; Windows has the CON
-  // device. If neither resolves, the helper silently no-ops.
   return platform() === 'win32' ? '\\\\.\\CON' : '/dev/tty';
 }
 
 function writeToTty(text) {
-  // Best-effort terminal write. Returns true on success so the caller knows
-  // not to also fall back to stdout (avoids double-printing when both work).
-  // CI / piped npm output / no-controlling-terminal cases trip the catch
-  // and return false — postinstall MUST never block install over a missing
-  // TTY, so all errors are swallowed.
+  // Bypasses npm 7+ stdio capture (#867). Errors (no TTY in CI/piped) must
+  // never block install — caller falls back to stdout when this returns false.
   let fd = null;
   try {
     fd = openSync(ttyDevicePath(), 'w');
@@ -120,7 +114,7 @@ function writeToTty(text) {
     return false;
   } finally {
     if (fd !== null) {
-      try { closeSync(fd); } catch { /* fd already closed or failed to open */ }
+      try { closeSync(fd); } catch { /* fd already closed */ }
     }
   }
 }
@@ -131,15 +125,10 @@ function bannerText(version, message) {
 }
 
 function printBanner(version, message) {
-  // Two-channel print: TTY-direct first (works around npm's stdio capture
-  // in v7+ default `foreground-scripts: false` mode), stdout second as the
-  // belt-and-braces fallback for `--foreground-scripts` users and CI logs.
-  // Pre-#867 only stdout was attempted, which npm captured into log files
-  // the user never sees — the notice file existed solely to compensate.
+  // TTY-direct first (#867); stdout as fallback for --foreground-scripts users.
   const text = bannerText(version, message);
-  const ttyOk = writeToTty(text);
-  if (!ttyOk) {
-    try { process.stdout.write(text); } catch { /* stdout broken — give up silently */ }
+  if (!writeToTty(text)) {
+    try { process.stdout.write(text); } catch { /* stdout broken — give up */ }
   }
 }
 

--- a/src/cli/init/claudemd-generator.ts
+++ b/src/cli/init/claudemd-generator.ts
@@ -50,7 +50,7 @@ flo doctor --fix                             # Health check
 
 ### After upgrading MoFlo
 
-After running \`npm install moflo@*\` (or \`npm install\` that touches moflo), check \`.moflo/restart-pending.json\`. If it exists, surface the \`message\` field to the user verbatim (Claude Code can't pick up new hooks/MCP tools/launcher mid-session — they're only loaded at session-start), then delete the file.
+When \`npm install moflo@*\` runs, MoFlo's postinstall prints an upgrade banner directly to the user's terminal AND drops \`.moflo/restart-pending.json\` as a fallback. If you see that banner (or notice the file), tell the user that hooks/MCP tools/launcher only load at session-start — they need to restart Claude Code. The launcher self-reconciles \`restart-pending.json\` on the next session start (deletes it once the new version is running), so you do not need to clean it up manually.
 
 ### Full Reference
 

--- a/tests/bin/launcher-867-restart-notice-reconcile.test.ts
+++ b/tests/bin/launcher-867-restart-notice-reconcile.test.ts
@@ -45,10 +45,11 @@ describe('bin/session-start-launcher.mjs §0d — reconcile post-install notice 
   });
 
   it('re-emits the message when running bits are older than the notice (cmp > 0 path)', () => {
-    // The branch must write to stdout per-line so Claude additionalContext
-    // shows it. A regression that quietly dropped this branch would leave
-    // the file orphaned with no user-visible signal.
-    expect(src).toMatch(/process\.stdout\.write\(`moflo:\s*\$\{line\}\\n`\)/);
+    // The branch must write the message to stdout (Claude additionalContext);
+    // a regression that quietly dropped it would leave the file orphaned with
+    // no user-visible signal. Behavioural test below covers actual output.
+    expect(src).toMatch(/cmp\s*>\s*0/);
+    expect(src).toMatch(/payload\.message/);
   });
 
   it('runs BEFORE the section 4 hooks.mjs spawn so additionalContext reaches the user', () => {

--- a/tests/bin/launcher-867-restart-notice-reconcile.test.ts
+++ b/tests/bin/launcher-867-restart-notice-reconcile.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression tests for issue #867 — post-install restart notice files were
+ * written by `scripts/post-install-notice.mjs` but never reconciled by the
+ * SessionStart launcher, so `.moflo/restart-pending.json` and
+ * `.moflo/last-install-banner.json` accumulated across upgrades and the
+ * restart-required message was invisible to users who didn't have an
+ * assistant remembering to surface it manually.
+ *
+ * Fix: section 0d of `bin/session-start-launcher.mjs` reads each file,
+ * compares its `version` against the installed moflo version, and either
+ * unlinks (already applied / stale) or re-emits the message (running bits
+ * still older than the file → next restart still required).
+ *
+ * Source-invariant tests pin the structural fix into the launcher so a
+ * future "simplification" can't silently regress it. Behavioural tests
+ * spawn the actual launcher in an isolated temp project to verify the
+ * file state end-to-end.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { resolve, join } from 'path';
+
+const LAUNCHER = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+
+describe('bin/session-start-launcher.mjs §0d — reconcile post-install notice files (#867)', () => {
+  const file = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('declares section 0d with the #867 reference', () => {
+    expect(src).toMatch(/0d\.\s*Reconcile post-install notice files\s*\(#867\)/);
+  });
+
+  it('reads restart-pending.json and last-install-banner.json from .moflo/', () => {
+    expect(src).toMatch(/['"]restart-pending\.json['"]/);
+    expect(src).toMatch(/['"]last-install-banner\.json['"]/);
+  });
+
+  it('compares the file version against installed moflo version (not literal equality on the string field)', () => {
+    expect(src).toMatch(/compareSemverParts\s*\(/);
+  });
+
+  it('unlinks the notice on version match (cmp === 0 path)', () => {
+    expect(src).toMatch(/cleared post-install restart notice/);
+  });
+
+  it('re-emits the message when running bits are older than the notice (cmp > 0 path)', () => {
+    // The branch must write to stdout per-line so Claude additionalContext
+    // shows it. A regression that quietly dropped this branch would leave
+    // the file orphaned with no user-visible signal.
+    expect(src).toMatch(/process\.stdout\.write\(`moflo:\s*\$\{line\}\\n`\)/);
+  });
+
+  it('runs BEFORE the section 4 hooks.mjs spawn so additionalContext reaches the user', () => {
+    const idxSection0d = src.indexOf('Reconcile post-install notice files');
+    const idxSection4 = src.indexOf('// ── 4. Spawn background tasks');
+    expect(idxSection0d).toBeGreaterThan(-1);
+    expect(idxSection4).toBeGreaterThan(-1);
+    expect(idxSection0d).toBeLessThan(idxSection4);
+  });
+
+  it('routes failures through emitWarning, not bare catch (#854 posture)', () => {
+    expect(src).toMatch(/emitWarning\(`post-install notice reconciliation failed/);
+  });
+});
+
+describe('compareSemverParts — semver ordering (#867)', () => {
+  // The helper is small enough to inline-extract via Function() for direct
+  // unit coverage. Avoids spawning the full launcher just to test arithmetic.
+  const file = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+  const src = readFileSync(file, 'utf-8');
+  const fnMatch = src.match(/function\s+compareSemverParts\s*\([\s\S]*?\n\}/);
+  if (!fnMatch) throw new Error('compareSemverParts not found in launcher source');
+  // eslint-disable-next-line no-new-func
+  const compareSemverParts = new Function(`${fnMatch[0]}; return compareSemverParts;`)() as (a: string, b: string) => number;
+
+  it('returns 0 for equal versions', () => {
+    expect(compareSemverParts('4.9.8', '4.9.8')).toBe(0);
+  });
+
+  it('returns -1 when first version is older', () => {
+    expect(compareSemverParts('4.9.7', '4.9.8')).toBe(-1);
+    expect(compareSemverParts('4.8.99', '4.9.0')).toBe(-1);
+    expect(compareSemverParts('3.0.0', '4.0.0')).toBe(-1);
+  });
+
+  it('returns 1 when first version is newer', () => {
+    expect(compareSemverParts('4.9.8', '4.9.7')).toBe(1);
+    expect(compareSemverParts('4.10.0', '4.9.99')).toBe(1);
+  });
+
+  it('handles different segment counts (4.9 < 4.9.1)', () => {
+    expect(compareSemverParts('4.9', '4.9.1')).toBe(-1);
+    expect(compareSemverParts('4.9.1', '4.9')).toBe(1);
+  });
+});
+
+describe('session-start-launcher behavioural — notice file reconciliation (#867)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = resolve(
+      __dirname,
+      '../../.testoutput/.test-launcher-867-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+    );
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'launcher-867-test', version: '0.0.0' }));
+    // Stage a node_modules/moflo/package.json so the launcher has an
+    // installed version to compare against.
+    mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
+    writeFileSync(
+      join(root, 'node_modules', 'moflo', 'package.json'),
+      JSON.stringify({ name: 'moflo', version: '4.9.8' }),
+    );
+    mkdirSync(join(root, '.moflo'), { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle holds — non-fatal */ }
+  });
+
+  function runLauncher(): { stdout: string; stderr: string } {
+    const result = spawnSync('node', [LAUNCHER], { cwd: root, encoding: 'utf-8', timeout: 30_000 });
+    return { stdout: result.stdout || '', stderr: result.stderr || '' };
+  }
+
+  it('deletes restart-pending.json when its version matches installed moflo', () => {
+    const noticePath = join(root, '.moflo', 'restart-pending.json');
+    const trackerPath = join(root, '.moflo', 'last-install-banner.json');
+    writeFileSync(noticePath, JSON.stringify({
+      version: '4.9.8',
+      writtenAt: new Date().toISOString(),
+      message: 'MoFlo 4.9.8 installed.\n\nPlease restart Claude Code.',
+    }));
+    writeFileSync(trackerPath, JSON.stringify({ version: '4.9.8', shownAt: new Date().toISOString() }));
+
+    const { stdout } = runLauncher();
+
+    expect(existsSync(noticePath)).toBe(false);
+    expect(existsSync(trackerPath)).toBe(false);
+    expect(stdout).toMatch(/moflo: cleared post-install restart notice/);
+  });
+
+  it('deletes restart-pending.json when running version is newer than the notice (stale file)', () => {
+    const noticePath = join(root, '.moflo', 'restart-pending.json');
+    writeFileSync(noticePath, JSON.stringify({
+      version: '4.9.0',
+      writtenAt: new Date().toISOString(),
+      message: 'old message',
+    }));
+
+    const { stdout } = runLauncher();
+
+    expect(existsSync(noticePath)).toBe(false);
+    // Pure-stale branch is silent — no per-line message re-emit.
+    expect(stdout).not.toMatch(/MoFlo 4\.9\.0 installed/);
+  });
+
+  it('keeps restart-pending.json AND re-emits message when running version is older', () => {
+    const noticePath = join(root, '.moflo', 'restart-pending.json');
+    // Notice is for a future version (4.9.9) — running bits are 4.9.8.
+    writeFileSync(noticePath, JSON.stringify({
+      version: '4.9.9',
+      writtenAt: new Date().toISOString(),
+      message: 'MoFlo 4.9.9 installed.\n\nPlease restart Claude Code.',
+    }));
+
+    const { stdout } = runLauncher();
+
+    expect(existsSync(noticePath)).toBe(true);
+    expect(stdout).toMatch(/moflo: MoFlo 4\.9\.9 installed\./);
+    expect(stdout).toMatch(/moflo: Please restart Claude Code\./);
+  });
+
+  it('removes a malformed restart-pending.json silently rather than leaving it forever', () => {
+    const noticePath = join(root, '.moflo', 'restart-pending.json');
+    writeFileSync(noticePath, '{ this is not json');
+
+    runLauncher();
+
+    expect(existsSync(noticePath)).toBe(false);
+  });
+
+  it('reconciles an orphan last-install-banner.json (no notice file)', () => {
+    const trackerPath = join(root, '.moflo', 'last-install-banner.json');
+    writeFileSync(trackerPath, JSON.stringify({ version: '4.9.7', shownAt: new Date().toISOString() }));
+
+    runLauncher();
+
+    expect(existsSync(trackerPath)).toBe(false);
+  });
+
+  it('is silent on the fast path (no notice files present)', () => {
+    const { stdout } = runLauncher();
+    expect(stdout).not.toMatch(/cleared post-install restart notice/);
+  });
+});

--- a/tests/scripts/post-install-tty-fallback.test.mts
+++ b/tests/scripts/post-install-tty-fallback.test.mts
@@ -1,0 +1,68 @@
+/**
+ * Source-invariant tests for the TTY-direct write fallback in
+ * `scripts/post-install-notice.mjs` (#867).
+ *
+ * The postinstall used to print the upgrade banner to `process.stdout`
+ * only. npm 7+ defaults to `foreground-scripts: false` and captures
+ * postinstall stdio into log files the user never sees, which is why
+ * the notice file was created as a fallback in the first place. Per
+ * #867 we add a direct-to-TTY path (`/dev/tty` on POSIX, `\\.\CON` on
+ * Windows) so the banner reaches the terminal regardless of npm's
+ * stdio capture policy.
+ *
+ * The script is meant to run from npm's postinstall, not be imported,
+ * so the assertions here pin the structural fix into the source rather
+ * than executing it. The real-TTY path is exercised in CI by the
+ * `npm install` step itself; behavioural unit-testing of TTY writes
+ * would require a pty harness that's not worth the cost for a
+ * best-effort fallback.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SOURCE = resolve(__dirname, '../../scripts/post-install-notice.mjs');
+const src = readFileSync(SOURCE, 'utf-8');
+
+describe('scripts/post-install-notice.mjs — TTY-direct fallback (#867)', () => {
+  it('declares a writeToTty helper', () => {
+    expect(src).toMatch(/function\s+writeToTty\s*\(/);
+  });
+
+  it('uses the platform-correct TTY device path (/dev/tty on POSIX, \\\\.\\CON on Windows)', () => {
+    // Single source of truth function so the win32 vs POSIX choice can't
+    // drift. ttyDevicePath() returns '\\\\.\\CON' on win32 and '/dev/tty' elsewhere.
+    expect(src).toMatch(/function\s+ttyDevicePath\s*\(/);
+    expect(src).toMatch(/platform\(\)\s*===\s*['"]win32['"]/);
+    expect(src).toMatch(/['"]\\\\\\\\\.\\\\CON['"]/); // matches '\\\\.\\CON' literal in source
+    expect(src).toMatch(/['"]\/dev\/tty['"]/);
+  });
+
+  it('opens / writes / closes the fd through node:fs primitives', () => {
+    // The TTY write must use the low-level fd API — process.stdout.write
+    // would route back through npm's captured stdio and defeat the fix.
+    expect(src).toMatch(/openSync\s*\(\s*ttyDevicePath\(\)/);
+    expect(src).toMatch(/writeSync\s*\(\s*fd\s*,/);
+    expect(src).toMatch(/closeSync\s*\(\s*fd\s*\)/);
+  });
+
+  it('swallows TTY errors so a missing controlling terminal never blocks install', () => {
+    // CI / piped npm output / no-TTY shells must NOT throw out of the
+    // postinstall — the file fallback is enough on those hosts. Pin the
+    // try/catch return-false shape so a refactor can't regress to throw.
+    const fnMatch = src.match(/function\s+writeToTty\s*\([^)]*\)\s*\{[\s\S]*?\n\}/);
+    expect(fnMatch, 'writeToTty helper must be in source').toBeTruthy();
+    expect(fnMatch![0]).toMatch(/catch\s*\{\s*return\s+false\s*;\s*\}/);
+  });
+
+  it('falls back to process.stdout only when TTY write fails (no double print)', () => {
+    // printBanner must attempt TTY first and skip stdout when ttyOk is true,
+    // otherwise --foreground-scripts users would see two banners.
+    const fnMatch = src.match(/function\s+printBanner\s*\([^)]*\)\s*\{[\s\S]*?\n\}/);
+    expect(fnMatch, 'printBanner must be in source').toBeTruthy();
+    const body = fnMatch![0];
+    expect(body).toMatch(/const\s+ttyOk\s*=\s*writeToTty\s*\(/);
+    expect(body).toMatch(/if\s*\(\s*!\s*ttyOk\s*\)/);
+    expect(body).toMatch(/process\.stdout\.write\s*\(/);
+  });
+});

--- a/tests/scripts/post-install-tty-fallback.test.mts
+++ b/tests/scripts/post-install-tty-fallback.test.mts
@@ -30,12 +30,12 @@ describe('scripts/post-install-notice.mjs — TTY-direct fallback (#867)', () =>
   });
 
   it('uses the platform-correct TTY device path (/dev/tty on POSIX, \\\\.\\CON on Windows)', () => {
-    // Single source of truth function so the win32 vs POSIX choice can't
-    // drift. ttyDevicePath() returns '\\\\.\\CON' on win32 and '/dev/tty' elsewhere.
     expect(src).toMatch(/function\s+ttyDevicePath\s*\(/);
     expect(src).toMatch(/platform\(\)\s*===\s*['"]win32['"]/);
-    expect(src).toMatch(/['"]\\\\\\\\\.\\\\CON['"]/); // matches '\\\\.\\CON' literal in source
-    expect(src).toMatch(/['"]\/dev\/tty['"]/);
+    // Source contains the literal four-backslash escape '\\\\.\\CON' for the Windows
+    // device path; testing via toContain on the raw source keeps the assertion legible.
+    expect(src).toContain("'\\\\\\\\.\\\\CON'");
+    expect(src).toContain("'/dev/tty'");
   });
 
   it('opens / writes / closes the fd through node:fs primitives', () => {
@@ -56,13 +56,12 @@ describe('scripts/post-install-notice.mjs — TTY-direct fallback (#867)', () =>
   });
 
   it('falls back to process.stdout only when TTY write fails (no double print)', () => {
-    // printBanner must attempt TTY first and skip stdout when ttyOk is true,
+    // printBanner must attempt TTY first and skip stdout when it succeeds —
     // otherwise --foreground-scripts users would see two banners.
     const fnMatch = src.match(/function\s+printBanner\s*\([^)]*\)\s*\{[\s\S]*?\n\}/);
     expect(fnMatch, 'printBanner must be in source').toBeTruthy();
     const body = fnMatch![0];
-    expect(body).toMatch(/const\s+ttyOk\s*=\s*writeToTty\s*\(/);
-    expect(body).toMatch(/if\s*\(\s*!\s*ttyOk\s*\)/);
+    expect(body).toMatch(/!\s*writeToTty\s*\(/);
     expect(body).toMatch(/process\.stdout\.write\s*\(/);
   });
 });


### PR DESCRIPTION
## Summary

Two halves of the same flow that were missing pre-#867:

- **Gap A — postinstall must reach the user.** `scripts/post-install-notice.mjs` now writes the upgrade banner directly to the OS TTY (`\\.\CON` on Windows, `/dev/tty` on POSIX) before falling back to stdout. npm 7+ defaults to `foreground-scripts: false` and captures postinstall stdio into log files the user never sees — which is why the notice file existed as a fallback in the first place. Direct-TTY write reaches the terminal regardless of npm's stdio policy and silently no-ops on CI / piped / no-TTY hosts.
- **Gap B — session-start must reconcile the notice files.** `bin/session-start-launcher.mjs` adds section 0d, which version-compares `.moflo/restart-pending.json` and `.moflo/last-install-banner.json` against the installed moflo:
  - equal → unlink (the upgrade has already taken effect)
  - older → re-emit message via stdout so Claude additionalContext shows it, leave the file in place
  - newer → unlink as stale

Pre-#867 nothing ever cleaned these files up. The CLAUDE.md contract relied on the assistant remembering to surface + delete after every npm install, which failed often enough to leave both files accumulating across upgrades. src/cli/init/claudemd-generator.ts is simplified accordingly.

Closes #867.

## Test plan

- [x] tests/bin/launcher-867-restart-notice-reconcile.test.ts — 17 tests covering source-invariants on section 0d structure + behavioural launcher spawns in isolated temp projects (equal/older/newer/malformed/orphan-tracker/silent-fast-path)
- [x] tests/scripts/post-install-tty-fallback.test.mts — 5 source-invariant tests on the TTY-direct helper
- [x] npm run build clean
- [x] npm test — 7666/7666 passing across parallel + isolation batches
- [x] npm run lint clean
- [x] /simplify review applied — TOCTOU tightened, narrative comments trimmed, helpers extracted

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)