### PR TITLE
fix(867): surface restart notice via UserPromptSubmit hook

### DIFF
--- a/bin/prompt-hook.mjs
+++ b/bin/prompt-hook.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 // Read stdin JSON from Claude Code
@@ -70,6 +71,19 @@ if (TEST_HINTS.test(lower)) {
   }
 }
 
-var parts = [output.trim(), nsHint].filter(Boolean);
-if (parts.length) process.stdout.write(parts.join('\n') + '\n');
+// #867 — surface post-install restart notice. File is written by
+// scripts/post-install-notice.mjs and cleared by the SessionStart launcher
+// once the running moflo matches the file's version, so the file's
+// existence at prompt-time is itself the "still needs restart" signal.
+var restartNotice = '';
+try {
+  var pendingPath = resolve(projectDir, '.moflo', 'restart-pending.json');
+  var pending = JSON.parse(readFileSync(pendingPath, 'utf-8'));
+  if (pending && typeof pending.message === 'string' && pending.message.length > 0) {
+    restartNotice = pending.message;
+  }
+} catch (e) { /* ENOENT or malformed — silent fast-path */ }
+
+var parts = [restartNotice, output.trim(), nsHint].filter(Boolean);
+if (parts.length) process.stdout.write(parts.join('\n\n') + '\n');
 process.exit(0);

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -217,6 +217,23 @@ try {
   // own errors if the DB is still broken.
 }
 
+// ── 0d. Clear post-install restart notice when version is current (#867) ───
+// scripts/post-install-notice.mjs drops `.moflo/restart-pending.json` on every
+// `npm install moflo`. The UserPromptSubmit hook surfaces it on every prompt
+// until cleared, so this session only sees the message between install and
+// the FIRST restart that actually picks up the new bits.
+try {
+  const pendingPath = join(mofloDir(projectRoot), 'restart-pending.json');
+  const pkgPath = resolve(projectRoot, 'node_modules/moflo/package.json');
+  const pending = JSON.parse(readFileSync(pendingPath, 'utf-8'));
+  const installedVersion = JSON.parse(readFileSync(pkgPath, 'utf-8')).version;
+  if (pending && typeof pending.version === 'string' && pending.version === installedVersion) {
+    unlinkSync(pendingPath);
+    try { unlinkSync(join(mofloDir(projectRoot), 'last-install-banner.json')); } catch { /* tracker may not exist */ }
+    emitMutation('cleared post-install restart notice', `${installedVersion} now running`);
+  }
+} catch { /* file missing or malformed — silent fast-path */ }
+
 // ── 1. Helper: fire-and-forget a background process ─────────────────────────
 function fireAndForget(cmd, args, label) {
   try {

--- a/tests/bin/prompt-hook-restart-notice.test.ts
+++ b/tests/bin/prompt-hook-restart-notice.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #867 — UserPromptSubmit hook surfaces .moflo/restart-pending.json so the
+ * user/Claude actually sees the "please restart" message between install and
+ * the next session restart. Companion: launcher §0d clears the file once the
+ * running moflo matches the file's version.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { resolve, join } from 'path';
+
+const PROMPT_HOOK = resolve(__dirname, '../../bin/prompt-hook.mjs');
+const LAUNCHER = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+
+describe('bin/prompt-hook.mjs — surface restart notice (#867)', () => {
+  let root: string;
+  beforeEach(() => {
+    root = resolve(__dirname, '../../.testoutput/.test-prompt-hook-867-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
+    mkdirSync(join(root, '.moflo'), { recursive: true });
+  });
+  afterEach(() => {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle */ }
+  });
+
+  function runHook(): string {
+    const result = spawnSync('node', [PROMPT_HOOK], {
+      cwd: root,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+      input: JSON.stringify({ user_prompt: 'hello' }),
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    return result.stdout || '';
+  }
+
+  it('emits the restart-pending message when the file exists', () => {
+    writeFileSync(
+      join(root, '.moflo', 'restart-pending.json'),
+      JSON.stringify({
+        version: '4.9.9',
+        writtenAt: new Date().toISOString(),
+        message: 'MoFlo 4.9.9 installed.\n\nPlease restart Claude Code.',
+      }),
+    );
+    expect(runHook()).toContain('Please restart Claude Code');
+  });
+
+  it('is silent when no restart-pending file exists', () => {
+    expect(runHook()).not.toContain('Please restart Claude Code');
+  });
+
+  it('is silent when the file is malformed', () => {
+    writeFileSync(join(root, '.moflo', 'restart-pending.json'), '{ not json');
+    expect(runHook()).not.toContain('Please restart Claude Code');
+  });
+});
+
+describe('bin/session-start-launcher.mjs §0d — clear notice when version matches (#867)', () => {
+  let root: string;
+  beforeEach(() => {
+    root = resolve(__dirname, '../../.testoutput/.test-launcher-867-clear-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
+    mkdirSync(join(root, '.moflo'), { recursive: true });
+    mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'launcher-867-clear', version: '0.0.0' }));
+    writeFileSync(join(root, 'node_modules', 'moflo', 'package.json'), JSON.stringify({ name: 'moflo', version: '4.9.9' }));
+  });
+  afterEach(() => {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle */ }
+  });
+
+  function runLauncher(): string {
+    const result = spawnSync('node', [LAUNCHER], { cwd: root, encoding: 'utf-8', timeout: 30_000 });
+    return result.stdout || '';
+  }
+
+  it('deletes restart-pending.json + last-install-banner.json when versions match', () => {
+    const noticePath = join(root, '.moflo', 'restart-pending.json');
+    const trackerPath = join(root, '.moflo', 'last-install-banner.json');
+    writeFileSync(noticePath, JSON.stringify({ version: '4.9.9', message: 'restart please' }));
+    writeFileSync(trackerPath, JSON.stringify({ version: '4.9.9' }));
+
+    const stdout = runLauncher();
+
+    expect(existsSync(noticePath)).toBe(false);
+    expect(existsSync(trackerPath)).toBe(false);
+    expect(stdout).toMatch(/cleared post-install restart notice/);
+  });
+
+  it('leaves restart-pending.json in place when the file version differs', () => {
+    const noticePath = join(root, '.moflo', 'restart-pending.json');
+    writeFileSync(noticePath, JSON.stringify({ version: '4.9.10', message: 'restart please' }));
+
+    runLauncher();
+
+    expect(existsSync(noticePath)).toBe(true);
+  });
+
+  it('is silent when no notice file exists', () => {
+    expect(runLauncher()).not.toMatch(/cleared post-install restart notice/);
+  });
+});


### PR DESCRIPTION
## Summary

After the false-start in #870 (reverted), this is the actual fix. Goal: the user sees a "please restart" message inside their Claude Code session after `npm install moflo`. The channel that actually fires DURING the in-session window between install and restart is the UserPromptSubmit hook — its stdout becomes `additionalContext` and Claude relays it. No npm stdio capture problem, no TTY required.

- `bin/prompt-hook.mjs` reads `.moflo/restart-pending.json` (already written by postinstall) and prepends its message to the hook's stdout. The file's existence at prompt-time IS the "still needs restart" signal.
- `bin/session-start-launcher.mjs` §0d clears the file when the running moflo matches its version, so the message stops firing after a successful restart.

~10 functional lines across two files. Closes #867.

## Test plan

- [x] tests/bin/prompt-hook-restart-notice.test.ts — 6 tests covering hook surfacing + launcher cleanup
- [x] npm run build clean
- [x] npm test — 7650/7650 passing
- [x] npm run lint clean

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)