### PR TITLE
refactor(bin): lazy-import sql.js in index-patterns.mjs (#863)

### DIFF
--- a/bin/index-patterns.mjs
+++ b/bin/index-patterns.mjs
@@ -31,7 +31,6 @@ import { spawn } from 'child_process';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, MOFLO_DIR } from './lib/moflo-paths.mjs';
 import { applyIncrementalChunks, computeContentListHash } from './lib/incremental-write.mjs';
-const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -75,6 +74,9 @@ function ensureDbDir() {
 
 async function getDb() {
   ensureDbDir();
+  // Lazy: hash-cache-match and no-source-files early-exits in main() never
+  // reach this, and the sql.js wasm cold-load is ~400ms otherwise wasted.
+  const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
   const SQL = await initSqlJs();
   let db;
   if (existsSync(DB_PATH)) {


### PR DESCRIPTION
## Summary

Move sql.js dynamic import in `bin/index-patterns.mjs` from module top-level into `getDb()`. The two early-exit paths in `main()` (no-source-files, hash-cache match) now return without paying the ~400ms sql.js wasm cold-load.

## Scope cut

The original #863 proposed collapsing all six indexer subprocess spawns into a single in-process pass with a shared sql.js handle (~3 days, big refactor). That trades subprocess isolation across critical SessionStart code for ~13s savings on rare runs — the common case is already gate-skipped by #858/PR #862. Risk/reward was negative.

This PR keeps only the obviously-worthwhile piece: a single targeted lazy-import in the one indexer (`index-patterns`) that has TWO early-exit paths before any DB access. The other four indexers (`index-guidance`, `index-tests`, `generate-code-map`, `build-embeddings`) are not touched — they either always reach getDb, have only rare early-exits, or always need all heavy modules.

## Changes

- `bin/index-patterns.mjs` — move `const initSqlJs = (await import(...)).default;` from module top-level into `getDb()`. 1 line removed, 1 line added, 2-line WHY comment.

## Testing

- [x] `node --check bin/index-patterns.mjs` passes
- [x] `tests/bin/bin-scripts.test.ts` — 11/11 pass
- [x] `tests/bin/incremental-write.test.ts` — 18/18 pass
- [x] `tests/hooks-test-indexing.test.ts` — 12/12 pass
- [ ] Manual smoke in fresh consumer post-publish

## Behavior

Identical on the work path (sql.js loads on first `getDb()` call, same as before — just deferred a few ms). Faster on the no-work path. No API/CLI/exit-code changes.

Closes #863