### PR TITLE
feat(skills): adaptive /simplify skill that scales effort to diff size

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: simplify
+description: Review changed code for reuse, quality, and efficiency, then fix any issues found. Sizes review effort to the diff — trivial edits get a self-review, substantial edits get parallel agents.
+---
+
+# /simplify — Adaptive Code Review
+
+Review changed code for reuse opportunities, quality issues, and efficiency improvements. **Effort scales with diff size** — a 5-line comment trim doesn't get the same treatment as a 500-line refactor.
+
+## Phase 1: Identify changes
+
+Run `git diff HEAD` (working tree) and `git diff main...HEAD` (committed) to get the full set of changes since the branch diverged. If on `main` with uncommitted changes, just `git diff HEAD`.
+
+Treat the union of staged + unstaged + committed-since-base as the diff to review.
+
+## Phase 2: Classify the diff
+
+Pick the **smallest tier** the diff genuinely fits. When in doubt, escalate.
+
+### TRIVIAL — self-review, no agent spawn
+ALL of these must hold:
+- ≤10 net LOC changed (insertions + deletions, excluding pure whitespace)
+- Single file
+- No logic changes — only comments, formatting, renames of local vars, JSDoc, or string-literal edits
+- No new imports, no new exports, no new function/class declarations
+- No removed safety checks, error handlers, or guards
+
+Examples that qualify: trimming a comment, fixing a typo in a log message, renaming a private helper, reformatting a single block.
+Examples that DON'T qualify: changing an `if` condition, reordering function args, deleting a try/catch.
+
+### SMALL — single agent, all three categories
+ALL of these must hold:
+- ≤50 net LOC changed
+- ≤2 files
+- No structural changes (no new modules, no API additions/removals, no contract changes)
+
+Examples that qualify: extracting a constant, inlining a one-liner, swapping a `for` for a `forEach`, adding one early-return.
+
+### NORMAL — three parallel agents (the original flow)
+Anything that doesn't fit TRIVIAL or SMALL. Includes any diff that:
+- Spans 3+ files
+- Adds/removes/renames a public API
+- Changes control flow in a non-trivial way
+- Introduces or removes a dependency
+- Touches `bin/`, hooks, MCP tool handlers, or anything called out in `CLAUDE.md` as critical surface
+
+When CLAUDE.md flags a file as critical surface (SessionStart, launcher, hooks, MCP coordinator wiring, swarm/hive-mind), **always escalate to NORMAL** regardless of LOC count. Risk-weighted, not size-weighted.
+
+## Phase 3: Run the appropriate review
+
+### TRIVIAL: self-review
+Run the same three category checks (reuse / quality / efficiency) yourself, in one pass, against the diff. Most TRIVIAL diffs will be clean — the goal is to confirm, not to fan out. If you find an issue, fix it; otherwise stamp clean. Total budget: ~30 seconds, no Agent calls.
+
+### SMALL: one agent
+Launch a SINGLE Agent with subagent_type `reviewer` covering all three categories in one prompt. Pass the diff inline. Budget: ~1 minute.
+
+```
+Agent — subagent_type: "reviewer", prompt: "Review this diff for reuse, quality, and efficiency. <diff inline>. Flag specific issues with file:line; skip generic advice. Under 200 words."
+```
+
+### NORMAL: three parallel agents (original flow)
+Launch three agents in a single message — Reuse, Quality, Efficiency — passing the full diff to each. Use the original flow's category checklists.
+
+**Reuse**: existing helpers/utilities that should be used instead; duplicated patterns; new functions that re-implement something already in the codebase.
+
+**Quality**: redundant state, parameter sprawl, copy-paste with variation, leaky abstractions, stringly-typed code, nested conditionals 3+ levels, unnecessary comments (WHAT-explanations, task references).
+
+**Efficiency**: unnecessary work, missed concurrency, hot-path bloat, recurring no-op updates, TOCTOU existence checks, unbounded structures, over-broad reads.
+
+## Phase 4: Fix or skip
+
+Aggregate findings. Fix each one directly. False positives or not-worth-fixing — note and skip without arguing. If TRIVIAL self-review found nothing, just confirm clean and exit.
+
+If fixes were made, re-run tests to confirm nothing broke. If tests fail after a fix, revert it.
+
+## Phase 5: Stamp the gate
+
+Whatever tier ran, the gate (`check-before-pr`) registers /simplify as having executed. The skill is satisfied.
+
+## Briefly summarize
+
+End with one or two sentences: which tier, what was fixed (or "clean — no changes"). No headers, no bullets unless needed.


### PR DESCRIPTION
## Summary

Project-shipped `/simplify` skill that overrides the built-in with a three-tier classifier:

| Tier | When | Effort |
|---|---|---|
| TRIVIAL | ≤10 LOC, single file, no logic/API/safety changes (comments, formatting, var renames) | Self-review, no Agent calls |
| SMALL | ≤50 LOC, ≤2 files, no structural changes | Single combined reviewer agent |
| NORMAL | Everything else, OR any file CLAUDE.md flags as critical surface | 3 parallel agents (original flow) |

Conservative — when in doubt, escalate. Critical surface (`bin/`, hooks, MCP wiring, swarm/hive-mind, launcher) always escalates to NORMAL regardless of LOC. Risk-weighted, not size-weighted.

## Why

The built-in simplify always spawns 3 parallel reviewer agents. Appropriate for substantial diffs, but the workflow has a recurring tax: simplify finds an issue → fix it → gate forces another simplify run → 3 fresh agents review a 1-line comment trim. Several minutes and a lot of tokens to confirm a comment edit didn't break anything.

The gate stays exactly as-is — it just checks whether `/simplify` ran. The skill is what scales effort to the diff. Net effect: ~5–10× cheaper on trivial reruns, identical on substantial changes.

## Consumer impact

Ships via the existing `package.json` files glob `".claude/skills/**/*.md"` — consumers get the adaptive simplify on their next `npm install moflo@*`. Failure mode: classifier misjudges a non-trivial change as TRIVIAL and stamps clean without agent review. Mitigated by:

1. The "when in doubt, escalate" instruction in the skill text
2. The CLAUDE.md critical-surface escalation rule (always NORMAL for `bin/`, hooks, etc.)
3. Single-file, no-logic-change requirements for TRIVIAL — even an `if` condition flip disqualifies

Round-trip: requires publish + reinstall to take effect for consumers. Takes effect immediately for moflo dogfood (already loaded — visible in available-skills listing during this session).

## Testing

- [x] Skill loads in current session (visible in available-skills listing under the new description)
- [x] `package.json` `files` array already includes `.claude/skills/**/*.md` — ships to consumers automatically
- [ ] Manual test on next post-edit `/simplify` run (expected: TRIVIAL self-review on comment-only edits, NORMAL fan-out on substantive changes)

## Test plan

- [ ] Make a trivial comment edit in any file, run `/simplify` — should self-review without Agent spawns
- [ ] Make a substantive `bin/` edit, run `/simplify` — should escalate to NORMAL despite small LOC
- [ ] Make a SMALL-tier edit (~30 LOC, single file, no API change), run `/simplify` — should run a single agent