### PR TITLE
fix(tests): root-cause the three full-suite flakes from #864

### DIFF
--- a/src/cli/__tests__/doctor-checks-deep.test.ts
+++ b/src/cli/__tests__/doctor-checks-deep.test.ts
@@ -6,7 +6,7 @@
  * 2. Exercise subsystem lifecycles end-to-end
  * 3. Degrade gracefully when modules are unavailable
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 
 // Import the checks under test
 import {
@@ -17,6 +17,7 @@ import {
   checkHookExecution,
   checkGateHealth,
   REQUIRED_HOOK_WIRING,
+  type HealthCheck,
 } from '../commands/doctor-checks-deep.js';
 
 describe('doctor-checks-deep', () => {
@@ -36,20 +37,24 @@ describe('doctor-checks-deep', () => {
   });
 
   describe('checkSpellExecution', () => {
-    // 30s timeout: this probe runs a real spell end-to-end (subprocess + spell
-    // engine + step execution). 15s was OK alone but flaked under full-suite
-    // load after the parallel batch had spun up the system. The check itself
-    // typically runs in ~7s; the headroom absorbs noisy CI / loaded-host runs.
-    it('should return a HealthCheck object', { timeout: 30_000 }, async () => {
-      const result = await checkSpellExecution();
+    // Single shared probe: the check spawns a real bash subprocess via the
+    // spell engine (~7 s alone, more under load). Two consecutive calls put
+    // the suite at ~15 s baseline + tail risk under maxForks=2 fork
+    // contention (issue #864). One call, two assertions — same coverage,
+    // half the engine work.
+    let result: HealthCheck;
+    beforeAll(async () => {
+      result = await checkSpellExecution();
+    }, 30_000);
+
+    it('should return a HealthCheck object', () => {
       expect(result).toHaveProperty('name', 'Spell Execution');
       expect(result).toHaveProperty('status');
       expect(result).toHaveProperty('message');
       expect(['pass', 'warn', 'fail']).toContain(result.status);
     });
 
-    it('should pass when spell engine is built', { timeout: 30_000 }, async () => {
-      const result = await checkSpellExecution();
+    it('should pass when spell engine is built', () => {
       // In the dev repo with a successful build, this should pass
       if (result.status === 'pass') {
         expect(result.message).toContain('Probe OK');

--- a/src/cli/__tests__/services/dist-resolution-gate.test.ts
+++ b/src/cli/__tests__/services/dist-resolution-gate.test.ts
@@ -136,6 +136,11 @@ describe('dist resolution gate (issue #781 / #783)', () => {
   // Hoist the dist walk + extraction into beforeAll so test 1 + test 2 share
   // the same target list (saves a redundant filesystem walk + regex sweep).
   // Reset inside beforeAll so watch-mode re-runs don't accumulate entries.
+  //
+  // 30 s hook timeout: the dist tree is ~560 files / 19 MB and the sync
+  // readFile + regex sweep runs in ~1.5 s alone. Under maxForks=2 Windows
+  // fork contention the file-level setup window has flaked out under the
+  // default 10 s, manifesting as "test file failed to import" (issue #864).
   let allTargets: Target[] = [];
   beforeAll(() => {
     allTargets = [];
@@ -143,7 +148,7 @@ describe('dist resolution gate (issue #781 / #783)', () => {
     for (const file of walkJs(DIST_CLI_ROOT)) {
       allTargets.push(...extractTargets(file));
     }
-  });
+  }, 30_000);
 
   it.skipIf(!hasBuild)('every dynamic-import / require target in dist/ resolves to an existing file', () => {
     const offenders: string[] = [];

--- a/src/cli/__tests__/statusline-upgrade-notice.test.ts
+++ b/src/cli/__tests__/statusline-upgrade-notice.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { resolve, join, dirname } from 'node:path';
 
 const STATUSLINE = resolve(__dirname, '../../../.claude/helpers/statusline.cjs');
 const REPO_ROOT = resolve(__dirname, '../../..');
@@ -50,11 +50,32 @@ function cleanTempRoot(root: string) {
 }
 
 function runStatusline(cwd: string, args: string[] = ['--json-compact']): RunResult {
+  // Two issue #864 mitigations layered here:
+  //
+  // 1. GIT_CEILING_DIRECTORIES — temp roots live under <repo>/.testoutput/,
+  //    inside the real moflo git tree. Without this, the statusline's git
+  //    execs walk upward, find moflo's .git, and run `git status` /
+  //    `git rev-list` against the live working tree — the dominant cost
+  //    under maxForks=2 fork contention. Capping the walk at the tempRoot's
+  //    parent makes every git exec exit immediately with "not a git
+  //    repository", saving ~1–3 s per spawn on Windows.
+  //
+  // 2. 25 s spawn timeout (was 15 s) — even with git short-circuited, the
+  //    cumulative cost of `generateJSON()` (file probes, FS walks, node
+  //    startup) intermittently crosses 15 s under heavy fork contention,
+  //    yielding empty stdout and a JSON.parse failure. 25 s sits 5 s under
+  //    the vitest 30 s testTimeout, so the test still fails cleanly if the
+  //    spawn truly hangs rather than masking a real bug.
   const result = spawnSync('node', [STATUSLINE, ...args], {
     cwd,
     encoding: 'utf-8',
-    timeout: 15_000,
-    env: { ...process.env, CLAUDE_PROJECT_DIR: cwd, CI: '1' },
+    timeout: 25_000,
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: cwd,
+      CI: '1',
+      GIT_CEILING_DIRECTORIES: dirname(cwd),
+    },
     input: '',
   });
   return {


### PR DESCRIPTION
## Summary

Three test files flaked intermittently in the full-suite parallel run on main. Each got a source-level fix targeting its actual cost driver — no isolationTests parking, no per-test timeout bumps past 30s.

## Root causes & fixes

**`dist-resolution-gate.test.ts`** — file-level setup failure
- `beforeAll` synchronously walks ~560 dist .js files (~19MB) and regex-matches imports/requires. ~1.5s alone but the default 10s `hookTimeout` flaked under maxForks=2 fork contention, manifesting as "test file failed to import".
- Fix: pass `30_000` as the `beforeAll` timeout so the file-level setup window matches the work it actually does. Single-arg change.

**`doctor-checks-deep.test.ts > checkSpellExecution`** — shape-check assertion racing under load
- Two consecutive `it()` blocks each called `await checkSpellExecution()`, which spawns a real bash subprocess via the spell engine (~7s alone). Cumulative ~15s baseline, tail past 30s under load.
- Fix: hoist the probe into a shared `beforeAll`. Same coverage, half the engine work.

**`statusline-upgrade-notice.test.ts`** — empty stdout from spawnSync
- The test's tempRoot lives under `<repo>/.testoutput/`, **inside the real moflo git tree**. Without `GIT_CEILING_DIRECTORIES`, statusline's git execs walked upward, found moflo's `.git`, and ran `git status` / `git rev-list` against the live working tree — the dominant cost under fork contention.
- Fix: set `GIT_CEILING_DIRECTORIES: dirname(cwd)` in the spawn env so git stops at `.testoutput/` and exits immediately with "not a git repository". Also bumped the spawnSync internal timeout 15s → 25s for residual headroom (still 5s under the vitest 30s testTimeout — not a per-test bump).

## Testing

- [x] All three files pass cleanly in isolation (29 tests)
- [x] Full \`npm test\` green: 7650 passed, 0 failed (was 1–3 flakes before)
- [x] No tests added to \`isolationTests\`; no per-test timeout > 30s

Closes #864