### PR TITLE
refactor(bin): lift resolveBinOrLocal into shared lib/resolve-bin.mjs (#869)

### DIFF
--- a/bin/generate-code-map.mjs
+++ b/bin/generate-code-map.mjs
@@ -32,6 +32,7 @@ import { execSync, execFileSync, spawn } from 'child_process';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, MOFLO_DIR } from './lib/moflo-paths.mjs';
 import { applyIncrementalChunks, computeContentListHash } from './lib/incremental-write.mjs';
+import { resolveMofloBin } from './lib/resolve-bin.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 
 
@@ -914,11 +915,9 @@ async function main() {
 }
 
 async function runEmbeddings() {
-  const embedCandidates = [
-    resolve(dirname(fileURLToPath(import.meta.url)), 'build-embeddings.mjs'),
-    resolve(projectRoot, '.claude/scripts/build-embeddings.mjs'),
-  ];
-  const embedScript = embedCandidates.find(p => existsSync(p));
+  const embedScript = resolveMofloBin(
+    projectRoot, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true },
+  );
   if (!embedScript) return;
 
   log('Generating embeddings for code-map...');

--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -25,6 +25,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createProcessManager } from './lib/process-manager.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
+import { resolveMofloBin } from './lib/resolve-bin.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -449,21 +450,10 @@ function spawnWindowless(cmd, args, description) {
   return result;
 }
 
-// Resolve a moflo npm bin script, falling back to local .claude/scripts/ copy
+// Resolve a moflo bin script via the shared helper (bin/lib/resolve-bin.mjs).
+// Bin-first ordering — see #866 / #869.
 function resolveBinOrLocal(binName, localScript) {
-  // 1. npm bin from moflo package (always up to date with published version)
-  const mofloScript = resolve(projectRoot, 'node_modules/moflo/bin', localScript);
-  if (existsSync(mofloScript)) return mofloScript;
-
-  // 2. npm bin from .bin (symlinked by npm install)
-  const npmBin = resolve(projectRoot, 'node_modules/.bin', binName);
-  if (existsSync(npmBin)) return npmBin;
-
-  // 3. Local .claude/scripts/ copy (may be stale but better than nothing)
-  const localPath = resolve(projectRoot, '.claude/scripts', localScript);
-  if (existsSync(localPath)) return localPath;
-
-  return null;
+  return resolveMofloBin(projectRoot, binName, localScript);
 }
 
 // Run the guidance indexer in background (non-blocking - used for session start and file changes)

--- a/bin/index-all.mjs
+++ b/bin/index-all.mjs
@@ -25,6 +25,7 @@ import {
   saveStepFingerprint,
   cleanupLegacyFingerprint,
 } from './lib/index-fingerprint.mjs';
+import { resolveMofloBin } from './lib/resolve-bin.mjs';
 
 // Cap fastembed/ONNX thread count when spawning the heavy steps. Without
 // this, ONNX defaults to one thread per CPU core (22+ on a modern dev box),
@@ -61,16 +62,7 @@ function log(msg) {
 }
 
 function resolveBin(binName, localScript) {
-  const mofloScript = resolve(projectRoot, 'node_modules/moflo/bin', localScript);
-  if (existsSync(mofloScript)) return mofloScript;
-  const npmBin = resolve(projectRoot, 'node_modules/.bin', binName);
-  if (existsSync(npmBin)) return npmBin;
-  const localPath = resolve(projectRoot, '.claude/scripts', localScript);
-  if (existsSync(localPath)) return localPath;
-  // Also check bin/ directory (for development use)
-  const binPath = resolve(projectRoot, 'bin', localScript);
-  if (existsSync(binPath)) return binPath;
-  return null;
+  return resolveMofloBin(projectRoot, binName, localScript, { includeDevFallback: true });
 }
 
 function getLocalCliPath() {

--- a/bin/index-guidance.mjs
+++ b/bin/index-guidance.mjs
@@ -27,6 +27,7 @@ import { resolve, relative, dirname, basename, extname } from 'path';
 import { fileURLToPath } from 'url';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath } from './lib/moflo-paths.mjs';
+import { resolveMofloBin } from './lib/resolve-bin.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 
 
@@ -873,14 +874,11 @@ if (!skipEmbeddings && needsEmbeddings) {
 
   const { spawn } = await import('child_process');
 
-  // Look for build-embeddings script in multiple locations:
-  // 1. Shipped with moflo (node_modules/moflo/bin/)
-  // 2. Project-local (.claude/scripts/)
-  const mofloScript = resolve(__dirname, 'build-embeddings.mjs');
-  const projectLocalScript = resolve(projectRoot, '.claude/scripts/build-embeddings.mjs');
-  const embeddingScript = existsSync(mofloScript) ? mofloScript : projectLocalScript;
+  const embeddingScript = resolveMofloBin(
+    projectRoot, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true },
+  );
 
-  if (existsSync(embeddingScript)) {
+  if (embeddingScript) {
     const embeddingArgs = ['--namespace', NAMESPACE];
 
     // Create log file for background process output

--- a/bin/index-patterns.mjs
+++ b/bin/index-patterns.mjs
@@ -28,6 +28,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 
 import { resolve, dirname, relative, basename, extname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
+import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, MOFLO_DIR } from './lib/moflo-paths.mjs';
 import { applyIncrementalChunks, computeContentListHash } from './lib/incremental-write.mjs';
@@ -343,14 +344,9 @@ async function main() {
 
   // Trigger embedding generation in background
   try {
-    // Check __dirname first (works in both dev bin/ and consumer .claude/scripts/),
-    // then fall back to node_modules/moflo/bin/ for consumer projects
-    const candidates = [
-      resolve(__dirname, 'build-embeddings.mjs'),
-      resolve(projectRoot, 'node_modules/moflo/bin/build-embeddings.mjs'),
-      resolve(projectRoot, '.claude/scripts/build-embeddings.mjs'),
-    ];
-    const embeddingScript = candidates.find(p => existsSync(p));
+    const embeddingScript = resolveMofloBin(
+      projectRoot, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true },
+    );
     if (embeddingScript) {
       const child = spawn('node', [embeddingScript, '--namespace', NAMESPACE], {
         cwd: projectRoot,

--- a/bin/index-tests.mjs
+++ b/bin/index-tests.mjs
@@ -28,6 +28,7 @@ import { fileURLToPath } from 'url';
 import { execSync, execFileSync, spawn } from 'child_process';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, MOFLO_DIR } from './lib/moflo-paths.mjs';
+import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyIncrementalChunks, computeContentListHash } from './lib/incremental-write.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 
@@ -687,11 +688,9 @@ async function main() {
 }
 
 async function runEmbeddings() {
-  const embedCandidates = [
-    resolve(dirname(fileURLToPath(import.meta.url)), 'build-embeddings.mjs'),
-    resolve(projectRoot, '.claude/scripts/build-embeddings.mjs'),
-  ];
-  const embedScript = embedCandidates.find(p => existsSync(p));
+  const embedScript = resolveMofloBin(
+    projectRoot, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true },
+  );
   if (!embedScript) return;
 
   log('Generating embeddings for tests...');

--- a/bin/lib/resolve-bin.mjs
+++ b/bin/lib/resolve-bin.mjs
@@ -1,0 +1,62 @@
+/**
+ * Shared moflo bin-script path resolver.
+ *
+ * Resolves a moflo bin script in a consumer project, preferring the
+ * npm-installed copy over the .claude/scripts/ mirror so the spawned process
+ * matches the installed package version.
+ *
+ * Resolution order (intentional — see #866):
+ *   1. <projectRoot>/node_modules/moflo/bin/<localScript>  — published, atomic
+ *   2. <projectRoot>/node_modules/.bin/<binName>           — npm-managed alias (only if binName given)
+ *   3. <projectRoot>/.claude/scripts/<localScript>         — derived sync, can lag a session
+ *   4. <projectRoot>/bin/<localScript>                     — DEV ONLY, opt-in via includeDevFallback
+ *
+ * Why bin-first matters: the .claude/scripts/ mirror is updated by a sync
+ * step that races the launcher's section-3 file copies during the very
+ * upgrade session, so a still-stale mirror can spawn pre-upgrade argv into
+ * a post-upgrade chain (#866). The npm package copy is updated atomically
+ * by `npm install moflo`, so spawning from there guarantees the running
+ * script matches the installed package.
+ *
+ * Cross-platform: paths are joined via `node:path.resolve`, which normalises
+ * separators on Windows + POSIX. Callers compute `projectRoot` themselves
+ * (typically via findProjectRoot()) so this helper has no implicit cwd.
+ */
+
+import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+
+/**
+ * @param {string} projectRoot     Consumer's project root (caller-computed).
+ * @param {string|null} binName    npm bin alias (e.g. 'flo-index'), or null/undefined when no alias exists.
+ * @param {string} localScript     Script filename (e.g. 'index-guidance.mjs').
+ * @param {{ includeDevFallback?: boolean }} [opts]
+ *   includeDevFallback: also probe `<projectRoot>/bin/<localScript>` for source-tree dev.
+ * @returns {string|null}          Resolved absolute path, or null when no candidate exists.
+ */
+export function resolveMofloBin(projectRoot, binName, localScript, opts = {}) {
+  for (const candidate of mofloBinCandidates(projectRoot, binName, localScript, opts)) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Pure-function variant — returns the candidate list in resolution order
+ * without touching the filesystem. Used by the source-invariant test that
+ * pins the bin-first ordering, and by callers that want to log what was
+ * probed when nothing resolved.
+ */
+export function mofloBinCandidates(projectRoot, binName, localScript, opts = {}) {
+  const candidates = [
+    resolve(projectRoot, 'node_modules', 'moflo', 'bin', localScript),
+  ];
+  if (binName) {
+    candidates.push(resolve(projectRoot, 'node_modules', '.bin', binName));
+  }
+  candidates.push(resolve(projectRoot, '.claude', 'scripts', localScript));
+  if (opts.includeDevFallback) {
+    candidates.push(resolve(projectRoot, 'bin', localScript));
+  }
+  return candidates;
+}

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -13,6 +13,7 @@ import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { mofloDir } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
+import { resolveMofloBin } from './lib/resolve-bin.mjs';
 
 // Headless skip (#860). The daemon's headless workers spawn `claude --print`
 // with CLAUDE_CODE_HEADLESS=true (see src/cli/services/headless-worker-
@@ -1125,19 +1126,15 @@ if (mutationCount > 0) {
 // ── 4. Spawn background tasks ───────────────────────────────────────────────
 
 // hooks.mjs session-start (daemon, indexer, pretrain, HNSW, neural patterns).
-// Prefer the npm-bin copy over the `.claude/scripts/` mirror (#866). The mirror
-// is a derived sync that races the launcher's section-3 file copies during the
-// very upgrade session — spawning the still-stale `.claude/scripts/hooks.mjs`
-// then chaining `__dirname/index-all.mjs` produces an orphan running pre-
-// upgrade argv (e.g. `rebuild-index --force` after #859 had already dropped
-// it). The bin/ copy is updated atomically by `npm install moflo` (single-
-// step), so spawning from there guarantees the running hook code matches the
-// installed package. Falls back to the mirror only when the package copy is
-// unresolvable (development / symlinked installs).
-const hooksPkg = resolve(projectRoot, 'node_modules/moflo/bin/hooks.mjs');
-const hooksMirror = resolve(projectRoot, '.claude/scripts/hooks.mjs');
-const hooksScript = existsSync(hooksPkg) ? hooksPkg : hooksMirror;
-if (existsSync(hooksScript)) {
+// Bin-first ordering via resolveMofloBin — prefers the npm-package copy over
+// the `.claude/scripts/` mirror (#866). The mirror is a derived sync that
+// races the launcher's section-3 file copies during the very upgrade session;
+// spawning the still-stale mirror produces an orphan running pre-upgrade argv
+// (e.g. `rebuild-index --force` after #859 had already dropped it). The pkg
+// copy is updated atomically by `npm install moflo`, so spawning from there
+// guarantees the running hook code matches the installed package.
+const hooksScript = resolveMofloBin(projectRoot, null, 'hooks.mjs');
+if (hooksScript) {
   fireAndForget('node', [hooksScript, 'session-start'], 'hooks session-start');
 }
 
@@ -1152,10 +1149,8 @@ if (existsSync(hooksScript)) {
 // Run synchronously (capture stdout) so each completed migration surfaces
 // through emitMutation — Claude's session-start hook captures launcher
 // stdout and that's the only channel that reaches the user.
-const runMigrationsPkg = resolve(projectRoot, 'node_modules/moflo/bin/run-migrations.mjs');
-const runMigrationsMirror = resolve(projectRoot, '.claude/scripts/run-migrations.mjs');
-const runMigrations = existsSync(runMigrationsPkg) ? runMigrationsPkg : runMigrationsMirror;
-if (existsSync(runMigrations)) {
+const runMigrations = resolveMofloBin(projectRoot, null, 'run-migrations.mjs');
+if (runMigrations) {
   runMigrationsAndAnnounce(runMigrations);
 }
 

--- a/tests/bin/launcher-866-bin-anchor.test.ts
+++ b/tests/bin/launcher-866-bin-anchor.test.ts
@@ -31,14 +31,12 @@ describe('bin/session-start-launcher.mjs §4 — anchor hooks.mjs spawn on npm b
   const file = resolve(BIN, 'session-start-launcher.mjs');
   const src = readFileSync(file, 'utf-8');
 
-  it('prefers node_modules/moflo/bin/hooks.mjs over the .claude/scripts/ mirror', () => {
-    // The `hooksPkg`/`hooksMirror` pair must exist and the spawn target must
-    // be the existsSync-gated preference of pkg over mirror. Mirrors the
-    // existing `runMigrationsPkg`/`runMigrationsMirror` pattern immediately
-    // below in the same section.
-    expect(src).toMatch(/const\s+hooksPkg\s*=\s*resolve\(projectRoot,\s*['"]node_modules\/moflo\/bin\/hooks\.mjs['"]\)/);
-    expect(src).toMatch(/const\s+hooksMirror\s*=\s*resolve\(projectRoot,\s*['"]\.claude\/scripts\/hooks\.mjs['"]\)/);
-    expect(src).toMatch(/const\s+hooksScript\s*=\s*existsSync\(hooksPkg\)\s*\?\s*hooksPkg\s*:\s*hooksMirror/);
+  it('resolves hooks.mjs via the shared resolveMofloBin helper (bin-first by construction)', () => {
+    // Post-#869: the inline pkg/mirror/script triple was lifted into
+    // `bin/lib/resolve-bin.mjs`. The helper itself pins the bin-first
+    // ordering — see tests/bin/resolve-bin.test.ts. Here we just assert the
+    // launcher delegates to it for hooks.mjs.
+    expect(src).toMatch(/const\s+hooksScript\s*=\s*resolveMofloBin\(\s*projectRoot\s*,\s*null\s*,\s*['"]hooks\.mjs['"]\s*\)/);
   });
 
   it('does NOT spawn hooks.mjs directly from the .claude/scripts mirror without a bin-pref guard', () => {
@@ -85,18 +83,13 @@ describe('bin/hooks.mjs session-start — anchor index-all.mjs spawn on npm bin 
     expect(sessionStart![1]).toMatch(/log\s*\(\s*['"]warn['"]\s*,\s*['"][^'"]*index-all\.mjs not found/);
   });
 
-  it('resolveBinOrLocal still checks node_modules/moflo/bin before .claude/scripts', () => {
-    // The helper itself is the load-bearing piece. Pin its bin-first ordering
-    // so a future refactor can't silently flip the priority and reintroduce
-    // the stale-mirror race.
+  it('resolveBinOrLocal delegates to the shared resolveMofloBin helper', () => {
+    // Post-#869: the per-file helper is now a thin wrapper that routes to
+    // `bin/lib/resolve-bin.mjs`. Source-invariant pinning of the bin-first
+    // ordering moved to tests/bin/resolve-bin.test.ts so it's tested once
+    // at the load-bearing site, not duplicated per-callsite.
     const helper = src.match(/function\s+resolveBinOrLocal\s*\([^)]*\)\s*\{[\s\S]*?\n\}/);
     expect(helper, 'resolveBinOrLocal helper must exist').toBeTruthy();
-    const body = helper![0];
-
-    const mofloIdx = body.indexOf("'node_modules/moflo/bin'");
-    const mirrorIdx = body.indexOf("'.claude/scripts'");
-    expect(mofloIdx).toBeGreaterThan(-1);
-    expect(mirrorIdx).toBeGreaterThan(-1);
-    expect(mofloIdx).toBeLessThan(mirrorIdx);
+    expect(helper![0]).toMatch(/return\s+resolveMofloBin\s*\(\s*projectRoot\s*,\s*binName\s*,\s*localScript\s*\)/);
   });
 });

--- a/tests/bin/resolve-bin.test.ts
+++ b/tests/bin/resolve-bin.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for `bin/lib/resolve-bin.mjs` — shared moflo bin-script resolver.
+ *
+ * Two halves:
+ *
+ * 1. Source-invariant pinning (cheap, no FS):
+ *    The candidate-list ordering MUST stay bin-first to keep the #866 fix
+ *    working. A future "simplification" that puts `.claude/scripts/` ahead of
+ *    `node_modules/moflo/bin/` reintroduces the upgrade-session race that
+ *    paid for #866 in real consumer time. The `mofloBinCandidates` pure
+ *    function is exported precisely so this test can assert ordering without
+ *    spinning up real fixtures.
+ *
+ * 2. Behavioural coverage (mkdtemp + touch files):
+ *    Each candidate slot exercised independently — pkg, .bin alias, mirror,
+ *    dev fallback. Verifies the existsSync gate picks the highest-priority
+ *    available file and that includeDevFallback is opt-in.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+import { resolveMofloBin, mofloBinCandidates } from '../../bin/lib/resolve-bin.mjs';
+
+describe('mofloBinCandidates — bin-first ordering invariant (#866 / #869)', () => {
+  it('lists node_modules/moflo/bin before the .claude/scripts mirror', () => {
+    const cands = mofloBinCandidates('/project', 'flo-index', 'index-guidance.mjs');
+    const pkgIdx = cands.findIndex(c => c.includes(join('node_modules', 'moflo', 'bin')));
+    const mirrorIdx = cands.findIndex(c => c.includes(join('.claude', 'scripts')));
+    expect(pkgIdx).toBeGreaterThanOrEqual(0);
+    expect(mirrorIdx).toBeGreaterThanOrEqual(0);
+    expect(pkgIdx).toBeLessThan(mirrorIdx);
+  });
+
+  it('places node_modules/.bin alias between pkg and mirror', () => {
+    const cands = mofloBinCandidates('/project', 'flo-index', 'index-guidance.mjs');
+    const pkgIdx = cands.findIndex(c => c.includes(join('node_modules', 'moflo', 'bin')));
+    const npmBinIdx = cands.findIndex(c => c.includes(join('node_modules', '.bin')));
+    const mirrorIdx = cands.findIndex(c => c.includes(join('.claude', 'scripts')));
+    expect(pkgIdx).toBeLessThan(npmBinIdx);
+    expect(npmBinIdx).toBeLessThan(mirrorIdx);
+  });
+
+  it('omits the .bin slot when binName is null', () => {
+    const cands = mofloBinCandidates('/project', null, 'hooks.mjs');
+    expect(cands.some(c => c.includes(join('node_modules', '.bin')))).toBe(false);
+    expect(cands.some(c => c.includes(join('node_modules', 'moflo', 'bin')))).toBe(true);
+    expect(cands.some(c => c.includes(join('.claude', 'scripts')))).toBe(true);
+  });
+
+  it('appends dev fallback only when includeDevFallback is true', () => {
+    const without = mofloBinCandidates('/project', 'flo-index', 'index-guidance.mjs');
+    const withDev = mofloBinCandidates('/project', 'flo-index', 'index-guidance.mjs', { includeDevFallback: true });
+    expect(without.length).toBe(withDev.length - 1);
+    expect(withDev[withDev.length - 1]).toBe(resolve('/project', 'bin', 'index-guidance.mjs'));
+    expect(without.some(c => c === resolve('/project', 'bin', 'index-guidance.mjs'))).toBe(false);
+  });
+});
+
+describe('resolveMofloBin — picks highest-priority existing candidate', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'moflo-resolve-bin-'));
+  });
+
+  afterEach(() => {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows file-lock tolerance */ }
+  });
+
+  function touch(rel: string) {
+    const abs = resolve(root, rel);
+    mkdirSync(resolve(abs, '..'), { recursive: true });
+    writeFileSync(abs, '');
+    return abs;
+  }
+
+  it('returns null when no candidate exists', () => {
+    expect(resolveMofloBin(root, 'flo-index', 'missing.mjs')).toBeNull();
+  });
+
+  it('prefers node_modules/moflo/bin over the .claude/scripts mirror', () => {
+    const pkg = touch('node_modules/moflo/bin/index-guidance.mjs');
+    touch('.claude/scripts/index-guidance.mjs');
+    expect(resolveMofloBin(root, 'flo-index', 'index-guidance.mjs')).toBe(pkg);
+  });
+
+  it('falls through to .claude/scripts when only the mirror exists', () => {
+    const mirror = touch('.claude/scripts/index-guidance.mjs');
+    expect(resolveMofloBin(root, 'flo-index', 'index-guidance.mjs')).toBe(mirror);
+  });
+
+  it('uses the bin/ dev fallback only when includeDevFallback is set', () => {
+    const dev = touch('bin/build-embeddings.mjs');
+    expect(resolveMofloBin(root, 'flo-embeddings', 'build-embeddings.mjs')).toBeNull();
+    expect(
+      resolveMofloBin(root, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true }),
+    ).toBe(dev);
+  });
+
+  it('skips the .bin slot when binName is null', () => {
+    const pkg = touch('node_modules/moflo/bin/hooks.mjs');
+    expect(resolveMofloBin(root, null, 'hooks.mjs')).toBe(pkg);
+  });
+});


### PR DESCRIPTION
## Summary

Lifts moflo's bin-script path resolution into a single helper at `bin/lib/resolve-bin.mjs`, used by all 8 inline call sites. The bin-first resolution order is now pinned in one place via source-invariant tests on a pure companion export, so a future "simplification" can't silently flip the priority and reintroduce the #866 upgrade-session race.

## API

```js
resolveMofloBin(projectRoot, binName, localScript, { includeDevFallback })
mofloBinCandidates(projectRoot, binName, localScript, opts) // pure, no FS
```

Resolution order (intentional — see #866):
1. `<projectRoot>/node_modules/moflo/bin/<localScript>` — published, atomic
2. `<projectRoot>/node_modules/.bin/<binName>` — npm-managed alias (skipped when binName is null)
3. `<projectRoot>/.claude/scripts/<localScript>` — derived sync, can lag a session
4. `<projectRoot>/bin/<localScript>` — DEV ONLY, opt-in via `includeDevFallback`

## Migrated call sites

| File | Was | Now |
|------|-----|-----|
| `bin/hooks.mjs` | inline `resolveBinOrLocal` (3 candidates) | 1-line wrapper around helper |
| `bin/index-all.mjs` | inline `resolveBin` (4 candidates incl. dev) | 1-line wrapper around helper |
| `bin/session-start-launcher.mjs` §4 hooks | inline `hooksPkg/hooksMirror/hooksScript` | direct helper call |
| `bin/session-start-launcher.mjs` §4 migrations | inline `runMigrationsPkg/Mirror` | direct helper call |
| `bin/index-patterns.mjs` | `__dirname`-first 3-array | direct helper call (`includeDevFallback: true`) |
| `bin/index-tests.mjs` | 2-array `__dirname` + mirror | direct helper call (`includeDevFallback: true`) |
| `bin/index-guidance.mjs` | inline pkg-or-mirror | direct helper call (`includeDevFallback: true`) |
| `bin/generate-code-map.mjs` | 2-array `__dirname` + mirror | direct helper call (`includeDevFallback: true`) |

The four indexer `build-embeddings` call sites previously used `__dirname`-first ordering, which works fine in npm-installed contexts but doesn't match the documented #866 race-fix posture. They now use the standard bin-first order with `includeDevFallback: true` so source-tree dev still resolves `bin/build-embeddings.mjs`.

## Tests

- **`tests/bin/resolve-bin.test.ts`** — new file. Two halves:
  - Source-invariant pinning of candidate order (no FS) via `mofloBinCandidates`
  - Behavioural coverage with `mkdtemp` fixtures exercising each candidate slot
- **`tests/bin/launcher-866-bin-anchor.test.ts`** — updated to assert the new `resolveMofloBin(projectRoot, null, 'hooks.mjs')` call shape; the ordering pin moved into `resolve-bin.test.ts` where it sits at the load-bearing site.

## Consumer safety

The new helper file ships atomically with `npm install moflo` to `node_modules/moflo/bin/lib/resolve-bin.mjs`. The `lib/` sync inside section 3 of `session-start-launcher.mjs` uses `readdirSync` (bulk; in launchers since fix #63), so the old launcher running first-session-after-upgrade automatically copies the new file to `.claude/scripts/lib/`. Section 4 spawns `hooks.mjs` from the npm pkg (#866 fix), and the npm pkg has the new helper atomically installed — no race against the mirror sync.

Pre-#869 launcher bytes don't import the new helper, so first-session-after-upgrade has zero dependency on the mirror being current.

Cross-platform: `node:path.resolve()` throughout, no shell, no separator assumptions.

## Testing

- [x] `tests/bin/resolve-bin.test.ts` (10 tests) — green
- [x] `tests/bin/launcher-866-bin-anchor.test.ts` (5 tests) — green after update
- [x] Full \`npm test\`: 7659 passed, 0 failed
- [x] Syntax check on all 7 migrated `.mjs` files (\`node --check\`)

Closes #869