### PR TITLE
docs(guidance-rules): rule #12 — decide where guidance lives + how to ship

### DIFF
--- a/.claude/guidance/internal/guidance-rules.md
+++ b/.claude/guidance/internal/guidance-rules.md
@@ -159,6 +159,55 @@ The prefix is applied statically at the source — the sync process copies files
 
 ---
 
+## 12. Deciding Where a New Guidance File Lives
+
+**Pick the destination BEFORE writing.** Rules #10 and #11 say WHAT each bucket holds; this rule says HOW to choose between them, and HOW to actually ship a doc once you've chosen.
+
+### Decision Table
+
+| Question | If yes | Destination |
+|----------|--------|-------------|
+| Is the audience a Claude session running INSIDE a consumer project? | yes | `shipped/` |
+| Does it document a moflo CLI/MCP surface, agent, hook, spell, or config field? | yes | `shipped/` |
+| Could a regression in this doc break a consumer's workflow? | yes | `shipped/` |
+| Will only moflo developers ever read this (build, release, dogfooding, sync pipelines, upgrade contract)? | yes | `internal/` |
+| Does it describe source-vs-installed mechanics, dogfood gotchas, or publish gates? | yes | `internal/` |
+| Is the content tied to repo structure that doesn't exist in consumer projects? | yes | `internal/` |
+
+**When in doubt, choose `internal/`.** Promotion (internal → shipped) is cheap: rename + add `moflo-` prefix. Demotion (shipped → internal) is more disruptive because consumers may have built workflows around the doc. Shipped guidance is a public surface; treat new entries with the same care as a CLI flag.
+
+### Mechanical Steps to Ship a New Guidance File
+
+Once you've decided shipping is right, the actual mechanics are minimal:
+
+1. **Filename** — save as `.claude/guidance/shipped/moflo-<topic>.md`. The `moflo-` prefix is mandatory (rule #10).
+2. **Structure** — H1, then `**Purpose:**` line, then body following rules #1–#8, then `## See Also` (rule #9).
+3. **No `package.json` edit needed** — the `files` array already globs `.claude/guidance/shipped/**`. Sanity-check with `npm pack --dry-run | grep moflo-<topic>` if paranoid.
+4. **No source-code edit needed** — `syncAllShippedGuidance()` in `src/cli/init/moflo-init.ts` discovers `*.md` files dynamically; the launcher copies them to consumers via section 3 (see `internal/guidance-sync.md`).
+5. **No new test needed** — `commands-deep.test.ts:1558` only asserts the CLAUDE.md injection points at `moflo-core-guidance.md`; new sibling docs don't break it.
+6. **Cross-link bidirectionally** — add a See Also entry in at least one related shipped doc that points back at the new file. The hub is `moflo-core-guidance.md`; sibling links go through the most relevant topical neighbor.
+7. **Local verification** — `node bin/index-guidance.mjs` and confirm `chunk-guidance-moflo-<topic>-*` rows appear (per `internal/guidance-sync.md` § Verification Recipe).
+
+### Mechanical Steps to Promote internal → shipped
+
+If a doc starts in `internal/` and later earns its place in `shipped/`:
+
+1. `git mv .claude/guidance/internal/<topic>.md .claude/guidance/shipped/moflo-<topic>.md`
+2. Re-frame the `**Purpose:**` line for the consumer audience (no "moflo developers" framing).
+3. Update inbound See Also references — `grep -rn "<topic>.md" .claude/guidance/` finds them all.
+4. Update the partition table in rule #11 if the move changes the per-bucket enumeration.
+
+### Mechanical Steps to Demote shipped → internal
+
+This is rarer and riskier — only do it when you're sure no consumer relies on the doc:
+
+1. `git mv .claude/guidance/shipped/moflo-<topic>.md .claude/guidance/internal/<topic>.md`
+2. Drop the `moflo-` prefix.
+3. Verify the launcher's section 3 manifest-diff cleanup will prune the consumer's old top-level mirror (per `internal/guidance-sync.md` Layer 1).
+4. Update inbound See Also references.
+
+---
+
 ## See Also
 
 - `.claude/guidance/internal/dogfooding.md` — The shipped-vs-internal partition this doc enforces, framed from the dogfood loop's perspective


### PR DESCRIPTION
## Summary

Adds rule #12 to `internal/guidance-rules.md` covering:

- **Decision table** — 6 audience/coverage questions to pin a new doc to `shipped/` or `internal/`
- **Default to `internal/` when uncertain** — promotion is cheap, demotion is risky
- **Mechanical steps to ship a new file** — 7 items, mostly no-op thanks to dynamic discovery (`syncAllShippedGuidance()`) and the `package.json` files glob
- **Promote internal → shipped** procedure
- **Demote shipped → internal** procedure (with manifest-diff cleanup verification)

Closes the gap noted while finishing pre-publish work: rules previously said WHAT each bucket holds (#10, #11) but not HOW to choose between them or HOW to actually ship.

## Test plan

- [x] `wc -l` confirms doc still under 500 lines (218 → was 169)
- [x] Doc-only change; no source/test impact

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)