### PR TITLE
feat(guidance): split rules + ship /guidance skill

### DIFF
--- a/.claude/guidance/internal/dogfooding.md
+++ b/.claude/guidance/internal/dogfooding.md
@@ -56,7 +56,8 @@ MoFlo is a diverged fork of Ruflo/Claude Flow. See `UPSTREAM_SYNC.md` for the ch
 ## See Also
 
 - `.claude/guidance/internal/upgrade-contract.md` — The "user never re-runs init" invariant that dogfooding stress-tests on every dev session
-- `.claude/guidance/internal/guidance-rules.md` — Authoring rules for shipped vs internal docs (rule #11 has the partitioning contract)
+- `.claude/guidance/shipped/moflo-guidance-rules.md` — Universal writing rules every guidance file follows
+- `.claude/guidance/internal/guidance-rules.md` — Moflo-only extensions: `moflo-` prefix, shipped/internal partition, decision rules
 - `.claude/guidance/internal/testing-performance.md` — The "no flaky tests" standing decision; dogfooding catches flakes before they reach consumers
 - `.claude/guidance/internal/consumer-project-paths.md` — Why `bin/` scripts must use `findProjectRoot()` — dogfooding catches the path-resolution bugs first
 - `.claude/guidance/shipped/moflo-session-start.md` — Consumer-facing view of what runs on every session start (dogfood = we are the consumer)

--- a/.claude/guidance/internal/guidance-rules.md
+++ b/.claude/guidance/internal/guidance-rules.md
@@ -1,156 +1,29 @@
-# Guidance Rules — Writing Effective Guidance for Claude
+# Guidance Rules — Moflo-Only Extensions
 
-**Purpose:** Rules for writing `.claude/guidance/` documents that Claude parses, follows, and indexes most effectively. Reference this document whenever you are asked to create or revise guidance.
+**Purpose:** Moflo-specific extensions to the universal guidance-authoring rules. Use this whenever you create or revise guidance INSIDE the moflo repo. The universal writing rules (Purpose line, imperative voice, decision tables, concrete examples, 500-line cap, specific headings, anti-patterns, RAG chunking, See Also) live in `shipped/moflo-guidance-rules.md` — read those first; the rules below only cover what's unique to moflo's two-bucket layout.
 
----
-
-## 1. Structure for Scanability
-
-Claude processes guidance as part of a large context window alongside code, tool results, and conversation history. Guidance competes for attention.
-
-- **Lead with a `**Purpose:**` line** immediately after the H1. One sentence stating what this doc is for and when to use it. This is the single most important line — it determines whether Claude keeps reading or skips.
-- **Use H2 sections as entry points.** Claude may land in the middle of a doc via RAG chunk retrieval. Each H2 should be independently understandable without reading prior sections.
-- **Front-load the actionable rule, then explain.** Put the instruction first, rationale second. Claude acts on instructions; it uses rationale to resolve ambiguity.
-
-```markdown
-## Good
-**Always search memory before Glob/Grep.** Memory search is 150x faster and returns
-domain-aware results that Glob cannot provide.
-
-## Bad
-Memory search uses HNSW indexing with domain-aware embeddings that provide much better
-results than file-system search tools. Because of this, you should search memory first.
-```
+> **The universal rules live in `shipped/moflo-guidance-rules.md`.** This doc is moflo-specific.
 
 ---
 
-## 2. Be Imperative, Not Descriptive
+## 1. Shipped Guidance File Naming
 
-Claude follows instructions better than it infers behavior from descriptions. Write rules as direct commands.
-
-| Pattern | Example |
-|---------|---------|
-| Imperative (preferred) | **Use `mcp__moflo__memory_search` before Glob/Grep** |
-| Descriptive (weaker) | The memory search tool can be used to find guidance |
-| Passive (weakest) | Memory should be searched before file exploration |
-
----
-
-## 3. Use Tables for Decision Logic
-
-When guidance involves conditional behavior (if X then Y), tables are parsed faster and more reliably than prose or nested bullet lists.
-
-```markdown
-| Condition | Action |
-|-----------|--------|
-| Background agent | TaskCreate required |
-| 2+ parallel agents | TaskCreate for each |
-| Single foreground, simple task | Skip TaskCreate |
-```
-
-Avoid encoding decision trees in paragraph form. Claude frequently drops branches from prose-encoded conditionals.
-
----
-
-## 4. Code Examples Must Be Concrete
-
-Abstract examples get ignored. Concrete examples with realistic values get followed.
-
-```markdown
-## Good
-TaskCreate({
-  subject: "🔍 Investigate failing booking tests",
-  activeForm: "🔍 Investigating test failures"
-})
-
-## Bad
-TaskCreate({
-  subject: "[icon] [description of task]",
-  activeForm: "[icon] [present participle of task]"
-})
-```
-
----
-
-## 5. Keep Files Under 500 Lines
-
-Long guidance files lose effectiveness because:
-- RAG chunking splits them, and chunks lose cross-section context
-- Claude deprioritizes content deep in a long document
-- Competing chunks from the same file dilute search relevance
-
-If a doc exceeds 500 lines, split by concern into separate files. Each file should cover one topic thoroughly rather than many topics shallowly.
-
----
-
-## 6. Headings Must Be Specific
-
-RAG retrieval uses heading text as the primary signal for chunk relevance. Generic headings produce poor search results.
-
-| Generic (bad) | Specific (good) |
-|---------------|----------------|
-| Overview | Architecture: Two-Layer Task + Swarm Model |
-| Configuration | Anti-Drift Swarm Configuration |
-| Examples | Non-Swarm TaskCreate Examples |
-| Rules | Pull Request Target Repo Rules |
-
----
-
-## 7. Anti-Patterns in Guidance
-
-| Anti-pattern | Why it fails | Fix |
-|-------------|-------------|-----|
-| Repeating the same rule in multiple files | Claude encounters conflicting phrasings and picks arbitrarily | Single source of truth, cross-reference via See Also |
-| Long preambles before the first rule | Claude may stop reading before reaching actionable content | Purpose line, then rules, then explanation |
-| Embedding rules inside code comments | RAG indexes headings and prose, not code comments | State the rule in prose, then show the code |
-| Using "should" / "consider" / "might want to" | Hedged language gets deprioritized vs. firm instructions | Use "must" / "always" / "never" for critical rules |
-| Documenting what Claude already knows | Wastes context window and dilutes novel instructions | Only document project-specific rules and non-obvious constraints |
-
----
-
-## 8. Optimize for RAG Chunking
-
-Guidance files are chunked by heading boundaries and indexed with embeddings for semantic search. To maximize retrieval quality:
-
-- **Every H2 section should have a self-contained opening sentence** summarizing the section's purpose. This becomes the chunk's embedding anchor.
-- **Keep sections between 5-30 lines.** Shorter than 5 lines lacks context for useful embeddings. Longer than 30 lines gets truncated or split mid-thought.
-- **Avoid orphan content** — text between the H1 and first H2 that isn't under any heading. It gets chunked with minimal heading context, producing poor embeddings.
-- **Use `---` horizontal rules between major sections.** These are chunk boundary hints.
-
----
-
-## 9. See Also Sections
-
-End every guidance file with a `## See Also` section linking related docs. This helps Claude navigate between related concerns and helps RAG link related chunks.
-
-```markdown
-## See Also
-
-- `.claude/guidance/moflo-subagents.md` — Subagents protocol
-- `.claude/guidance/moflo-claude-swarm-cohesion.md` — Task & swarm coordination
-- `.claude/guidance/moflo-core-guidance.md` — Full CLI/MCP reference
-```
-
-Use relative names (not absolute paths) so the links work across project contexts.
-
----
-
-## 10. Shipped Guidance File Naming
-
-**All shipped guidance files in `.claude/guidance/shipped/` MUST begin with the `moflo-` prefix** (e.g., `moflo-subagents.md`, `moflo-memory-strategy.md`). This prevents name collisions when these files are synced into a consumer project's `.claude/guidance/` directory, where the project may have its own guidance files with generic names like `subagents.md` or `memory-strategy.md`.
+**All shipped guidance files in `.claude/guidance/shipped/` MUST begin with the `moflo-` prefix** (e.g., `moflo-subagents.md`, `moflo-memory-strategy.md`). This prevents name collisions when these files are synced into a consumer project's `.claude/guidance/` directory, where the project may already have its own guidance files with generic names like `subagents.md` or `memory-strategy.md`.
 
 The prefix is applied statically at the source — the sync process copies files as-is without modifying names.
 
+Consumer projects writing their OWN guidance do NOT use this prefix; the prefix is moflo-specific because moflo's files travel into other people's directories.
+
 ---
 
-## 11. Ship-vs-Local Partitioning Contract
+## 2. Ship-vs-Local Partitioning Contract
 
 **Three buckets, one ship boundary.** `package.json` `files` includes only `.claude/guidance/shipped/**`; everything else stays local.
 
 | Path | Tracked? | Ships? | Purpose |
 |------|----------|--------|---------|
 | `.claude/guidance/shipped/moflo-*.md` | yes | yes | Consumer-facing rules (CLI, swarm, memory, spells, sandboxing, icons, language, etc.) |
-| `.claude/guidance/internal/*.md` | yes | no | Dev-only (this file, dogfooding, testing, coding-style, upgrade-contract) |
+| `.claude/guidance/internal/*.md` | yes | no | Dev-only (this file, dogfooding, testing, coding-style, upgrade-contract, guidance-sync, pre-publish-rules) |
 | `.claude/guidance/*.md` (top level) | no | no | Auto-generated mirror written by session-start launcher; consumers regenerate on install |
 
 **Gitignore must target only the top-level mirror.** Use `/.claude/guidance/*.md` — a bare `.claude/guidance/` will silently swallow `shipped/` and `internal/` too, and the failure is invisible because `npm pack` ships from the working tree (not git), so a fresh CI clone publishes an incomplete `shipped/` set.
@@ -159,9 +32,9 @@ The prefix is applied statically at the source — the sync process copies files
 
 ---
 
-## 12. Deciding Where a New Guidance File Lives
+## 3. Deciding Where a New Guidance File Lives
 
-**Pick the destination BEFORE writing.** Rules #10 and #11 say WHAT each bucket holds; this rule says HOW to choose between them, and HOW to actually ship a doc once you've chosen.
+**Pick the destination BEFORE writing.** Rules #1 and #2 say WHAT each bucket holds; this rule says HOW to choose between them, and HOW to actually ship a doc once you've chosen.
 
 ### Decision Table
 
@@ -180,8 +53,8 @@ The prefix is applied statically at the source — the sync process copies files
 
 Once you've decided shipping is right, the actual mechanics are minimal:
 
-1. **Filename** — save as `.claude/guidance/shipped/moflo-<topic>.md`. The `moflo-` prefix is mandatory (rule #10).
-2. **Structure** — H1, then `**Purpose:**` line, then body following rules #1–#8, then `## See Also` (rule #9).
+1. **Filename** — save as `.claude/guidance/shipped/moflo-<topic>.md`. The `moflo-` prefix is mandatory (rule #1 of this doc).
+2. **Structure** — H1, then `**Purpose:**` line, then body following `shipped/moflo-guidance-rules.md` rules #1–#8, then `## See Also` (rule #9 there).
 3. **No `package.json` edit needed** — the `files` array already globs `.claude/guidance/shipped/**`. Sanity-check with `npm pack --dry-run | grep moflo-<topic>` if paranoid.
 4. **No source-code edit needed** — `syncAllShippedGuidance()` in `src/cli/init/moflo-init.ts` discovers `*.md` files dynamically; the launcher copies them to consumers via section 3 (see `internal/guidance-sync.md`).
 5. **No new test needed** — `commands-deep.test.ts:1558` only asserts the CLAUDE.md injection points at `moflo-core-guidance.md`; new sibling docs don't break it.
@@ -195,7 +68,7 @@ If a doc starts in `internal/` and later earns its place in `shipped/`:
 1. `git mv .claude/guidance/internal/<topic>.md .claude/guidance/shipped/moflo-<topic>.md`
 2. Re-frame the `**Purpose:**` line for the consumer audience (no "moflo developers" framing).
 3. Update inbound See Also references — `grep -rn "<topic>.md" .claude/guidance/` finds them all.
-4. Update the partition table in rule #11 if the move changes the per-bucket enumeration.
+4. Update the partition table in rule #2 if the move changes the per-bucket enumeration.
 
 ### Mechanical Steps to Demote shipped → internal
 
@@ -210,9 +83,11 @@ This is rarer and riskier — only do it when you're sure no consumer relies on 
 
 ## See Also
 
+- `.claude/guidance/shipped/moflo-guidance-rules.md` — Universal writing rules (#1–#9) every guidance file in any project must follow; this doc only adds the moflo-specific bucket extensions on top of those
 - `.claude/guidance/internal/dogfooding.md` — The shipped-vs-internal partition this doc enforces, framed from the dogfood loop's perspective
 - `.claude/guidance/internal/upgrade-contract.md` — Where the "user never re-runs init" invariant for guidance sync is defined
 - `.claude/guidance/internal/coding-style.md` — Sibling style rules but for source code; both files share the imperative/concrete/specific posture
 - `.claude/guidance/shipped/moflo-memory-strategy.md` — Companion shipped doc on writing guidance that indexes well for RAG (consumer audience)
 - `.claude/guidance/shipped/moflo-session-start.md` — Where shipped guidance gets synced to consumer projects (and why the `moflo-` prefix matters there)
-- `.claude/guidance/internal/guidance-sync.md` — Three-layer sync pipeline (filesystem → DB → HNSW); the chunking decisions in this doc shape Layer 2's behavior
+- `.claude/guidance/internal/guidance-sync.md` — Three-layer sync pipeline (filesystem → DB → HNSW); the chunking decisions in the universal rules feed Layer 2's behavior
+- `.claude/skills/guidance/SKILL.md` — `/guidance` skill that exercises the universal rules in consumer projects (uses only the shipped doc, not this internal one)

--- a/.claude/guidance/internal/guidance-sync.md
+++ b/.claude/guidance/internal/guidance-sync.md
@@ -147,7 +147,8 @@ If chunks remain after deletion, `cleanStaleEntries` did not run (likely `--file
 
 - `.claude/guidance/internal/upgrade-contract.md` — the larger upgrade contract this sync sits inside; "user must never re-run init" depends on these three layers cooperating
 - `.claude/guidance/internal/dogfooding.md` — why a sync regression bites moflo developers first (we are our own first consumer)
-- `.claude/guidance/internal/guidance-rules.md` — how to write guidance docs that index well; chunk shape decisions feed Layer 2's chunking heuristics
+- `.claude/guidance/shipped/moflo-guidance-rules.md` — universal writing rules; chunk shape decisions feed Layer 2's chunking heuristics
+- `.claude/guidance/internal/guidance-rules.md` — moflo-specific bucket rules (`moflo-` prefix, shipped/internal partition)
 - `.claude/guidance/shipped/moflo-memorydb-maintenance.md` — consumer-facing recovery commands (purge namespace, force reindex, restore from `.bak`)
 - `.claude/guidance/shipped/moflo-memory-strategy.md` — namespace conventions and search query patterns the synced data feeds
 - `.claude/guidance/shipped/moflo-session-start.md` — every launcher stage in execution order, including stages 3 and 3b documented above

--- a/.claude/guidance/internal/pre-publish-rules.md
+++ b/.claude/guidance/internal/pre-publish-rules.md
@@ -53,7 +53,7 @@ Moflo ships to N consumers via `npm install moflo`. Every change runs from their
 | Runtime imports of moflo internals use `import.meta.url` via `mofloPath()`/`mofloUrl()`, not `process.cwd()` | Consumer's `cwd` is their project root, not moflo's | `feedback_consumer_path_resolution` + lint smoke stderr scan |
 | Helper scripts ship as static files in `bin/`, not generated at runtime | Static-files rule from `moflo-core-guidance.md` § Session Start Automation | Manual review |
 | New `bin/` script is added to the `scriptFiles` array in `session-start-launcher.mjs` AND in `init/moflo-init.ts`'s sync helper AND any third sync site | Missing entries cause silent sync drift (#777) | `feedback_scriptfiles_sync` |
-| New shipped guidance file is in `.claude/guidance/shipped/` with `moflo-` prefix | Filename collisions in consumer projects + auto-discovery requires the prefix | `internal/guidance-rules.md` rules #10–#11 |
+| New shipped guidance file is in `.claude/guidance/shipped/` with `moflo-` prefix | Filename collisions in consumer projects + auto-discovery requires the prefix | `internal/guidance-rules.md` rules #1–#2 |
 | `package.json` `files` glob covers any new shipped file class | Otherwise the file ships nowhere; npm install grabs zero copies | Inspect `npm pack --dry-run` output |
 
 **Verification**: run the smoke harness (Gate 5) — it packs, installs, and exercises the consumer surface end-to-end. If you've changed any path-resolution code, run `npm run test:smoke` BEFORE you commit.

--- a/.claude/guidance/internal/upgrade-contract.md
+++ b/.claude/guidance/internal/upgrade-contract.md
@@ -91,6 +91,7 @@ Before merging any PR that touches config, ask:
 - `shipped/moflo-settings-injection.md` — consumer-facing contract on settings.json self-heal.
 - `internal/dogfooding.md` — how the moflo repo eats its own dog food (which is why broken upgrades break us first).
 - `internal/consumer-project-paths.md` — `findProjectRoot()` rule for `bin/` scripts; the launcher's path-resolution depends on this contract holding.
-- `internal/guidance-rules.md` — shipped-vs-internal partition contract (rule #11) and the `moflo-` prefix requirement for shipped docs.
+- `internal/guidance-rules.md` — shipped-vs-internal partition contract (rule #2) and the `moflo-` prefix requirement for shipped docs (rule #1).
+- `shipped/moflo-guidance-rules.md` — universal writing rules every guidance file follows (consumer-facing companion).
 - `internal/testing-sandboxing.md` — pattern for end-to-end probe tests; same posture is needed for upgrade-contract regressions (e.g. issue #879's record/check asymmetry).
 - `internal/guidance-sync.md` — How shipped guidance reaches consumer search through three sync layers; the cleanup paths the contract relies on for stale-content removal.

--- a/.claude/guidance/shipped/moflo-guidance-rules.md
+++ b/.claude/guidance/shipped/moflo-guidance-rules.md
@@ -1,0 +1,144 @@
+# Guidance Rules — Writing Guidance Claude Will Actually Follow
+
+**Purpose:** The universal rules for writing `.claude/guidance/**/*.md` documents that Claude parses, follows, and indexes most effectively. Reference this whenever you create or revise a guidance file in your project. The rules below are the same ones moflo follows for its own shipped guidance.
+
+---
+
+## 1. Structure for Scanability
+
+Claude processes guidance as part of a large context window alongside code, tool results, and conversation history. Guidance competes for attention.
+
+- **Lead with a `**Purpose:**` line** immediately after the H1. One sentence stating what this doc is for and when to use it. This is the single most important line — it determines whether Claude keeps reading or skips.
+- **Use H2 sections as entry points.** Claude may land in the middle of a doc via RAG chunk retrieval. Each H2 should be independently understandable without reading prior sections.
+- **Front-load the actionable rule, then explain.** Put the instruction first, rationale second. Claude acts on instructions; it uses rationale to resolve ambiguity.
+
+```markdown
+## Good
+**Always search memory before Glob/Grep.** Memory search is 150x faster and returns
+domain-aware results that Glob cannot provide.
+
+## Bad
+Memory search uses HNSW indexing with domain-aware embeddings that provide much better
+results than file-system search tools. Because of this, you should search memory first.
+```
+
+---
+
+## 2. Be Imperative, Not Descriptive
+
+Claude follows instructions better than it infers behavior from descriptions. Write rules as direct commands.
+
+| Pattern | Example |
+|---------|---------|
+| Imperative (preferred) | **Use `mcp__moflo__memory_search` before Glob/Grep** |
+| Descriptive (weaker) | The memory search tool can be used to find guidance |
+| Passive (weakest) | Memory should be searched before file exploration |
+
+---
+
+## 3. Use Tables for Decision Logic
+
+When guidance involves conditional behavior (if X then Y), tables are parsed faster and more reliably than prose or nested bullet lists.
+
+```markdown
+| Condition | Action |
+|-----------|--------|
+| Background agent | TaskCreate required |
+| 2+ parallel agents | TaskCreate for each |
+| Single foreground, simple task | Skip TaskCreate |
+```
+
+Avoid encoding decision trees in paragraph form. Claude frequently drops branches from prose-encoded conditionals.
+
+---
+
+## 4. Code Examples Must Be Concrete
+
+Abstract examples get ignored. Concrete examples with realistic values get followed.
+
+```markdown
+## Good
+TaskCreate({
+  subject: "🔍 Investigate failing booking tests",
+  activeForm: "🔍 Investigating test failures"
+})
+
+## Bad
+TaskCreate({
+  subject: "[icon] [description of task]",
+  activeForm: "[icon] [present participle of task]"
+})
+```
+
+---
+
+## 5. Keep Files Under 500 Lines
+
+Long guidance files lose effectiveness because:
+
+- RAG chunking splits them, and chunks lose cross-section context
+- Claude deprioritizes content deep in a long document
+- Competing chunks from the same file dilute search relevance
+
+If a doc exceeds 500 lines, split by concern into separate files. Each file should cover one topic thoroughly rather than many topics shallowly.
+
+---
+
+## 6. Headings Must Be Specific
+
+RAG retrieval uses heading text as the primary signal for chunk relevance. Generic headings produce poor search results.
+
+| Generic (bad) | Specific (good) |
+|---------------|----------------|
+| Overview | Architecture: Two-Layer Task + Swarm Model |
+| Configuration | Anti-Drift Swarm Configuration |
+| Examples | Non-Swarm TaskCreate Examples |
+| Rules | Pull Request Target Repo Rules |
+
+---
+
+## 7. Anti-Patterns in Guidance
+
+| Anti-pattern | Why it fails | Fix |
+|-------------|-------------|-----|
+| Repeating the same rule in multiple files | Claude encounters conflicting phrasings and picks arbitrarily | Single source of truth, cross-reference via See Also |
+| Long preambles before the first rule | Claude may stop reading before reaching actionable content | Purpose line, then rules, then explanation |
+| Embedding rules inside code comments | RAG indexes headings and prose, not code comments | State the rule in prose, then show the code |
+| Using "should" / "consider" / "might want to" | Hedged language gets deprioritized vs. firm instructions | Use "must" / "always" / "never" for critical rules |
+| Documenting what Claude already knows | Wastes context window and dilutes novel instructions | Only document project-specific rules and non-obvious constraints |
+
+---
+
+## 8. Optimize for RAG Chunking
+
+Guidance files are chunked by heading boundaries and indexed with embeddings for semantic search. To maximize retrieval quality:
+
+- **Every H2 section should have a self-contained opening sentence** summarizing the section's purpose. This becomes the chunk's embedding anchor.
+- **Keep sections between 5–30 lines.** Shorter than 5 lines lacks context for useful embeddings. Longer than 30 lines gets truncated or split mid-thought.
+- **Avoid orphan content** — text between the H1 and first H2 that isn't under any heading. It gets chunked with minimal heading context, producing poor embeddings.
+- **Use `---` horizontal rules between major sections.** These are chunk boundary hints.
+
+---
+
+## 9. See Also Sections
+
+End every guidance file with a `## See Also` section linking related docs. This helps Claude navigate between related concerns and helps RAG link related chunks.
+
+```markdown
+## See Also
+
+- `.claude/guidance/<other-doc>.md` — One-line description of why this is related
+- `.claude/guidance/<other-doc>.md` — Use Title Case "See Also" (not "See also")
+```
+
+Use relative names (not absolute paths) so the links work across project contexts.
+
+---
+
+## See Also
+
+- `.claude/guidance/shipped/moflo-memory-strategy.md` — Companion rules on namespaces, RAG indexing, and search patterns the data feeds
+- `.claude/guidance/shipped/moflo-task-icons.md` — UX rule for `TaskCreate` and `Agent` description fields (ICON + [Role])
+- `.claude/guidance/shipped/moflo-user-facing-language.md` — How to phrase any text shown to end users (plain risk-level language, no jargon)
+- `.claude/guidance/shipped/moflo-subagents.md` — Memory-first protocol any guidance you write should reinforce
+- `.claude/skills/guidance/SKILL.md` — `/guidance` skill that helps you author or audit guidance against these rules

--- a/.claude/guidance/shipped/moflo-source-hygiene.md
+++ b/.claude/guidance/shipped/moflo-source-hygiene.md
@@ -98,6 +98,6 @@ Before creating any new source file, verify:
 ## See Also
 
 - `CLAUDE.md` — Project-wide rules, consumer project checklist
-- `.claude/guidance/internal/guidance-rules.md` — Rules for writing guidance docs
+- `.claude/guidance/shipped/moflo-guidance-rules.md` — Rules for writing guidance docs
 - `docs/BUILD.md` — Build and publish process
 - `docs/adr/0001-collapse-moflo-workspace-packages.md` — The ADR that documents the collapse

--- a/.claude/skills/connector-builder/SKILL.md
+++ b/.claude/skills/connector-builder/SKILL.md
@@ -32,7 +32,7 @@ Ask the user:
 
 **Important:** Simple service integrations (Slack webhook, S3 upload, Jira comment) should compose existing connectors (`http`, `github-cli`, `playwright`) in spell YAML — no dedicated connector needed. However, platforms requiring complex multi-step browser interaction (like Outlook.com web UI) DO warrant a dedicated connector. See `.claude/skills/spell-builder/architecture.md` for the decision tree.
 
-**Documentation requirement:** When creating any new step command or connector, you MUST also create a README.md following `.claude/guidance/internal/guidance-rules.md`. Use existing READMEs in `.claude/skills/spell-builder/steps/` or `connectors/` as templates. Apply automatically — the user should never need to ask.
+**Documentation requirement:** When creating any new step command or connector, you MUST also create a README.md following `.claude/guidance/shipped/moflo-guidance-rules.md`. Use existing READMEs in `.claude/skills/spell-builder/steps/` or `connectors/` as templates. Apply automatically — the user should never need to ask.
 
 Then follow the appropriate section below.
 

--- a/.claude/skills/guidance/SKILL.md
+++ b/.claude/skills/guidance/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: guidance
+description: Add, edit, or audit guidance docs in this project's .claude/guidance/ directory following moflo's universal guidance rules. Default mode walks the user through one doc (creating or improving it); the -a flag audits every doc in the directory and offers per-file improvements.
+arguments: "[-a] [<topic-or-path>]"
+---
+
+# /guidance — Author and audit project guidance
+
+Help the user write, edit, or audit guidance files in their `.claude/guidance/` directory so Claude actually follows the rules they wrote. The skill applies the universal rules from `.claude/guidance/shipped/moflo-guidance-rules.md` — that doc is the single source of truth, do not paraphrase or duplicate it here.
+
+**Arguments:** $ARGUMENTS
+
+## Modes
+
+| Mode | Trigger | What it does |
+|------|---------|--------------|
+| Single-doc | no flag, optional `<topic-or-path>` arg | Walk the user through creating one new doc OR improving one existing doc |
+| Audit | `-a` flag | Scan every `.md` in `.claude/guidance/` (recursively), score each against the rules, present a triage report, then offer to fix per-file or in batch |
+
+## Step 0 — Memory First
+
+Before reading any files, run a memory search:
+
+```
+mcp__moflo__memory_search { query: "guidance rules writing project conventions", namespace: "guidance" }
+```
+
+This pulls the user's project-specific guidance conventions (if any) plus the moflo universal rules into context. The memory-first gate will block file reads otherwise.
+
+## Step 1 — Pick the Mode and Target
+
+Parse the argument:
+
+| Input | Mode | Target |
+|-------|------|--------|
+| empty | single-doc | Ask the user for a topic; default destination is `.claude/guidance/<kebab-topic>.md` |
+| `<topic>` (no slash) | single-doc | Use `.claude/guidance/<kebab-topic>.md`; if it exists, edit; else create |
+| `<path>` (has `.claude/guidance/`) | single-doc | Edit that exact file; if it doesn't exist, create at that path |
+| `-a` | audit | All `.md` files under `.claude/guidance/` recursively |
+| `-a <subdir>` | audit | All `.md` files under `.claude/guidance/<subdir>/` recursively |
+
+If single-doc and the file already exists, briefly summarize what it contains (one sentence) before walking the user through edits — confirm you have the right file.
+
+## Step 2 — Single-Doc Mode
+
+Apply the universal rules from `.claude/guidance/shipped/moflo-guidance-rules.md`. The rules cover (do not paraphrase — read the source):
+
+1. Lead with `**Purpose:**` line after the H1
+2. Be imperative, not descriptive
+3. Use tables for decision logic
+4. Code examples must be concrete
+5. Keep files under 500 lines
+6. Headings must be specific
+7. Avoid the listed anti-patterns
+8. Optimize for RAG chunking
+9. End with a `## See Also` section
+
+### Creating a new doc — scaffold this shape
+
+```markdown
+# <Specific Title — what this doc is and when to use>
+
+**Purpose:** <one sentence on what this doc covers and when to reference it>
+
+---
+
+## <Specific H2 — first actionable rule or topic>
+
+<Imperative rule, then rationale, then example.>
+
+---
+
+## <Specific H2 — second>
+
+<Same shape.>
+
+---
+
+## See Also
+
+- `.claude/guidance/<related-doc>.md` — One-line description of why related
+- `.claude/guidance/<another>.md` — One-line description
+```
+
+After scaffolding, ask the user 2–4 targeted questions to populate the body — never auto-write opinionated content into the user's project. Their guidance must reflect their conventions, not Claude's.
+
+### Editing an existing doc — checklist before proposing changes
+
+For the loaded file, evaluate against the universal rules and report findings as a short table BEFORE editing:
+
+| Check | Status |
+|-------|--------|
+| Has `**Purpose:**` line right after H1 | yes / no |
+| Has `## See Also` section at end | yes / no |
+| Under 500 lines | <count> lines |
+| H2 headings are specific (not "Overview", "Configuration", "Examples") | list any generic ones |
+| Uses imperative voice for rules ("must"/"always"/"never") not hedged ("should"/"might"/"consider") | list hedged phrases found |
+| Has prose preamble before first rule | yes / no |
+
+Then propose edits as concrete diffs — never rewrite the whole file unless the user asks.
+
+## Step 3 — Audit Mode (`-a`)
+
+When `-a` is passed, scan the guidance directory and produce a triage report. Walk the directory yourself with `Glob` and `Read`; do not delegate to a subagent for the audit itself unless the user has 30+ files.
+
+For each `.md` file:
+
+1. Count lines (`wc -l` via Bash, or read + split)
+2. Check for `**Purpose:**` line right after H1
+3. Check for `## See Also` (Title Case, capital A) at end
+4. Look for generic headings: `^## (Overview|Configuration|Examples|Rules|Notes|Details|Information)$`
+5. Look for hedged language: `\b(should|might|consider|may want to)\b` in rule contexts
+6. Detect prose preambles (>3 paragraphs between H1 and first H2 rule)
+
+Render the report as a sortable table with one row per file, columns: file, lines, has-purpose, has-see-also, generic-headings count, hedged count. Highlight the worst offenders first.
+
+After the table, list the **top 3–5 priority fixes** in plain English (not table format). For each, explain WHY (rule citation) and propose either a per-file fix or a batch fix.
+
+Ask the user which to apply, then walk through the chosen fixes one at a time. **Never apply audit fixes without explicit per-file confirmation** — guidance is high-leverage; silent edits are dangerous.
+
+## Step 4 — After Editing
+
+Once the user confirms the doc looks right:
+
+1. Save the file via `Write` (new) or `Edit` (existing).
+2. If you added a new doc, ask the user which existing doc should link to it via See Also (rule #9 needs bidirectional links to work).
+3. Suggest re-indexing if the user runs moflo: `node bin/index-guidance.mjs` (or just wait for next session-start auto-reindex).
+
+## Cheatsheet — Universal Rules Recap
+
+The full rules live in `.claude/guidance/shipped/moflo-guidance-rules.md`. Quick recap:
+
+| # | Rule | One-line |
+|---|------|----------|
+| 1 | Structure for scanability | Purpose line + specific H2s + rule-first ordering |
+| 2 | Imperative voice | "Must" / "always" / "never", not "should" / "might" |
+| 3 | Tables for decisions | Conditional logic in tables, not nested bullets |
+| 4 | Concrete examples | Realistic values, not `[placeholder]` |
+| 5 | <500 lines | Split by concern when over |
+| 6 | Specific headings | Not "Overview" / "Configuration" |
+| 7 | Anti-patterns | Single source of truth, no preambles, prose for rules (not code comments) |
+| 8 | RAG chunking | 5–30 lines per H2, self-contained openings, `---` between sections |
+| 9 | See Also | Title Case, end of every file, relative paths |
+
+## Important
+
+- **Memory-first is mandatory.** Always run `mcp__moflo__memory_search` in step 0 — the gate blocks reads otherwise.
+- **Never duplicate the rules in this skill.** Reference `.claude/guidance/shipped/moflo-guidance-rules.md` and ask the user to read it if they want depth.
+- **Never auto-write opinionated content.** Guidance is the user's project policy; ask before injecting your own opinions.
+- **Confirm per file in audit mode.** Bulk edits to the user's guidance directory are high-blast-radius — confirm each one.
+- **The `moflo-` filename prefix is moflo-only.** Consumer projects writing their own guidance do not need it; it exists to avoid collisions when moflo's shipped guidance syncs into a consumer's directory.
+
+## See Also
+
+- `.claude/guidance/shipped/moflo-guidance-rules.md` — Universal writing rules this skill enforces
+- `.claude/guidance/shipped/moflo-memory-strategy.md` — How well-written guidance feeds the RAG index
+- `.claude/guidance/shipped/moflo-task-icons.md` — UX rule the skill checks for any TaskCreate examples in the user's guidance
+- `.claude/guidance/shipped/moflo-user-facing-language.md` — Companion rule for any user-visible text the user's guidance discusses

--- a/.claude/skills/spell-builder/SKILL.md
+++ b/.claude/skills/spell-builder/SKILL.md
@@ -356,7 +356,7 @@ Write the updated YAML back to the original file (or a new path if requested).
 
 **Runtime source:** `src/cli/spells/commands/` — each step is a TypeScript file registered in `index.ts`.
 
-**Adding a new step:** Create a directory under `steps/<name>/` with a `README.md`. Follow `.claude/guidance/internal/guidance-rules.md` and use existing step READMEs as templates. The step command source goes in `src/cli/spells/commands/` and is registered in `index.ts`. No changes to this SKILL.md needed.
+**Adding a new step:** Create a directory under `steps/<name>/` with a `README.md`. Follow `.claude/guidance/shipped/moflo-guidance-rules.md` and use existing step READMEs as templates. The step command source goes in `src/cli/spells/commands/` and is registered in `index.ts`. No changes to this SKILL.md needed.
 
 ### Connectors
 
@@ -371,7 +371,7 @@ Write the updated YAML back to the original file (or a new path if requested).
 
 **Runtime source:** `src/cli/spells/connectors/` — each connector is a TypeScript file registered in `index.ts`.
 
-**Adding a new connector:** Create a directory under `connectors/<name>/` with a `README.md`. Follow `.claude/guidance/internal/guidance-rules.md` and use existing connector READMEs as templates. The connector source goes in `src/cli/spells/connectors/` and is registered in `index.ts`. No changes to this SKILL.md needed.
+**Adding a new connector:** Create a directory under `connectors/<name>/` with a `README.md`. Follow `.claude/guidance/shipped/moflo-guidance-rules.md` and use existing connector READMEs as templates. The connector source goes in `src/cli/spells/connectors/` and is registered in `index.ts`. No changes to this SKILL.md needed.
 
 **When to create a new connector vs composing existing ones:** See [architecture.md](architecture.md) for the decision tree.
 

--- a/.claude/skills/spell-builder/architecture.md
+++ b/.claude/skills/spell-builder/architecture.md
@@ -153,7 +153,7 @@ steps:
 
 ## Documentation Rules for New Components
 
-**Every new step, connector, or spell MUST include a README.md.** Apply the rules in `.claude/guidance/internal/guidance-rules.md` automatically — do not wait for the user to ask. Use existing READMEs in `steps/` and `connectors/` as templates.
+**Every new step, connector, or spell MUST include a README.md.** Apply the rules in `.claude/guidance/shipped/moflo-guidance-rules.md` automatically — do not wait for the user to ask. Use existing READMEs in `steps/` and `connectors/` as templates.
 
 **Where to put the README:**
 - Steps: `.claude/skills/spell-builder/steps/<name>/README.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,15 +87,19 @@ After running `npm install moflo@*` (or `npm install` that touches moflo), check
 - **CLI, hooks, swarm, memory, moflo.yaml:** `.claude/guidance/shipped/moflo-core-guidance.md`
 <!-- MOFLO:INJECTED:END -->
 
-## ⚠ Writing or editing guidance — guidance-rules.md is mandatory
+## ⚠ Writing or editing guidance — both rule sets are mandatory
 
-**Whenever you create, rewrite, or edit any `.claude/guidance/**/*.md` file, `.claude/guidance/internal/guidance-rules.md` MUST be followed.** That file is the single source of truth for guidance authoring: required `**Purpose:**` line, imperative voice, decision tables, concrete examples, 500-line cap, specific H2 headings, mandatory `## See Also` section, the shipped/internal partition, and the `moflo-` filename prefix on shipped docs.
+**Whenever you create, rewrite, or edit any `.claude/guidance/**/*.md` file, BOTH rule sets MUST be followed:**
+
+1. **`.claude/guidance/shipped/moflo-guidance-rules.md`** — Universal writing rules (#1–#9): required `**Purpose:**` line, imperative voice, decision tables, concrete examples, 500-line cap, specific H2 headings, anti-patterns, RAG chunking, mandatory `## See Also` section.
+2. **`.claude/guidance/internal/guidance-rules.md`** — Moflo-only extensions (#1–#3): the `moflo-` prefix on shipped files, the shipped/internal partitioning contract, and the decision rules for which bucket new docs go in.
 
 This applies to:
+
 - New shipped guidance (`.claude/guidance/shipped/moflo-*.md`)
 - New internal guidance (`.claude/guidance/internal/*.md`)
-- Edits to existing guidance — drive-by edits must not introduce drift from the rules
-- Auto-memory files under `~/.claude/projects/.../memory/` (same structural rules apply where they make sense)
+- Edits to existing guidance — drive-by edits must not introduce drift from either rule set
+- Auto-memory files under `~/.claude/projects/.../memory/` (the universal rules apply where they make sense)
 
 If you find yourself writing prose preambles, generic headings, hedged "should/might" language, or omitting See Also — stop and re-read the rules.
 


### PR DESCRIPTION
## Summary

Splits guidance-authoring rules so consumer projects can apply the universal rules to their own `.claude/guidance/` without inheriting moflo's shipped/internal partition (which doesn't apply to them), and ships a new `/guidance` skill that walks consumers through writing or auditing their docs.

- **New `shipped/moflo-guidance-rules.md`** (144 lines) — universal writing rules #1–#9 (Purpose, imperative voice, tables, examples, 500-line cap, specific headings, anti-patterns, RAG chunking, See Also).
- **Refactored `internal/guidance-rules.md`** (93 lines) — moflo-only extensions: `moflo-` prefix, partitioning contract, decision rules. Points at the shipped doc as the universal foundation.
- **New `/guidance` skill** (158 lines) — consumer-facing skill. Default: walk one doc. `-a`: audit every `.md` under `.claude/guidance/`, triage table, top-priority fixes, per-file confirmation before applying.
- **Cross-references migrated** — shipped docs and skills point at the shipped rules (correct for consumer audience); internal docs reference both. CLAUDE.md now mandates BOTH rule sets when editing guidance.
- **Renumbered inbound refs** — old rule #10 → new #1, old #11 → new #2, old #10–11 → new #1–2.

## Test plan

- [x] 479 regression tests passing (commands-deep, cross-platform, hook-wiring)
- [x] All three new docs under 500-line cap
- [x] `/guidance` visible in available skills list (auto-discovered)
- [x] No internal/guidance-rules.md references in shipped docs or skills (consumers don't have internal/)
- [x] CLAUDE.md updated to require both rule sets

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)