### PR TITLE
fix(887): silence post-install restart notice cleanup

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -218,11 +218,17 @@ try {
   // own errors if the DB is still broken.
 }
 
-// ── 0d. Clear post-install restart notice when version is current (#867) ───
+// ── 0d. Silently clear post-install restart notice when version is current (#867, #887) ─
 // scripts/post-install-notice.mjs drops `.moflo/restart-pending.json` on every
 // `npm install moflo`. The UserPromptSubmit hook surfaces it on every prompt
 // until cleared, so this session only sees the message between install and
 // the FIRST restart that actually picks up the new bits.
+//
+// Cleanup is silent (#887): the user already saw + acted on the restart prompt
+// — surfacing a "cleared notice" line on the very next session reads like an
+// error in additionalContext and inflates mutationCount, which would also fire
+// the closing "starting background tasks" framing. Both are noise on a
+// successful post-restart session.
 try {
   const pendingPath = join(mofloDir(projectRoot), 'restart-pending.json');
   const pkgPath = resolve(projectRoot, 'node_modules/moflo/package.json');
@@ -231,7 +237,6 @@ try {
   if (pending && typeof pending.version === 'string' && pending.version === installedVersion) {
     unlinkSync(pendingPath);
     try { unlinkSync(join(mofloDir(projectRoot), 'last-install-banner.json')); } catch { /* tracker may not exist */ }
-    emitMutation('cleared post-install restart notice', `${installedVersion} now running`);
   }
 } catch { /* file missing or malformed — silent fast-path */ }
 

--- a/tests/bin/prompt-hook-restart-notice.test.ts
+++ b/tests/bin/prompt-hook-restart-notice.test.ts
@@ -63,27 +63,36 @@ describe('bin/session-start-launcher.mjs §0d — clear notice when version matc
     mkdirSync(join(root, 'node_modules', 'moflo'), { recursive: true });
     writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'launcher-867-clear', version: '0.0.0' }));
     writeFileSync(join(root, 'node_modules', 'moflo', 'package.json'), JSON.stringify({ name: 'moflo', version: '4.9.9' }));
+    // Pre-stamp the version so section 3 (upgrade work) short-circuits — we're
+    // testing §0d's silent-cleanup behaviour, not the upgrade path.
+    writeFileSync(join(root, '.moflo', 'moflo-version'), '4.9.9');
+    writeFileSync(join(root, '.moflo', 'installed-files.json'), '[]');
   });
   afterEach(() => {
     try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle */ }
   });
 
-  function runLauncher(): string {
+  function runLauncher(): { stdout: string; stderr: string } {
     const result = spawnSync('node', [LAUNCHER], { cwd: root, encoding: 'utf-8', timeout: 30_000 });
-    return result.stdout || '';
+    return { stdout: result.stdout || '', stderr: result.stderr || '' };
   }
 
-  it('deletes restart-pending.json + last-install-banner.json when versions match', () => {
+  it('silently deletes restart-pending.json + last-install-banner.json when versions match (#887)', () => {
     const noticePath = join(root, '.moflo', 'restart-pending.json');
     const trackerPath = join(root, '.moflo', 'last-install-banner.json');
     writeFileSync(noticePath, JSON.stringify({ version: '4.9.9', message: 'restart please' }));
     writeFileSync(trackerPath, JSON.stringify({ version: '4.9.9' }));
 
-    const stdout = runLauncher();
+    const { stdout, stderr } = runLauncher();
 
     expect(existsSync(noticePath)).toBe(false);
     expect(existsSync(trackerPath)).toBe(false);
-    expect(stdout).toMatch(/cleared post-install restart notice/);
+    // Cleanup must be silent — surfacing it inflates mutationCount and triggers
+    // the closing "starting background tasks" framing, both noise on a clean
+    // post-restart session (#887).
+    expect(stdout).not.toMatch(/cleared post-install restart notice/);
+    expect(stdout).not.toMatch(/starting background tasks/);
+    expect(stderr).not.toMatch(/cleared post-install restart notice/);
   });
 
   it('leaves restart-pending.json in place when the file version differs', () => {
@@ -96,6 +105,7 @@ describe('bin/session-start-launcher.mjs §0d — clear notice when version matc
   });
 
   it('is silent when no notice file exists', () => {
-    expect(runLauncher()).not.toMatch(/cleared post-install restart notice/);
+    const { stdout } = runLauncher();
+    expect(stdout).not.toMatch(/cleared post-install restart notice/);
   });
 });


### PR DESCRIPTION
## Summary

Section 0d of `bin/session-start-launcher.mjs` was firing `emitMutation('cleared post-install restart notice', ...)` on the first session after every `npm install moflo` — bumping `mutationCount`, which in turn triggered the closing `moflo: starting background tasks (daemon, indexer, pretrain — CPU may briefly spike)` framing.

End user perception: two error-styled lines appearing in Claude Code right after they did a deliberate upgrade and restart. Looks alarming, scares users.

The cleanup is bookkeeping. Drop the `emitMutation` call; keep both `unlinkSync` calls. The user already saw the restart message via `prompt-hook.mjs` and acted on it.

### What still works
- **Statusline "upgrading/upgraded"** — driven by section 3 + `writeUpgradeNotice()`, untouched.
- **"Please restart Claude Code" inside the session post-install** — postinstall still drops `.moflo/restart-pending.json`, `bin/prompt-hook.mjs` still surfaces the `message` field on every prompt; 0d still unlinks once `pending.version === installedVersion`, just silently now.

### Test plan

- [x] `tests/bin/prompt-hook-restart-notice.test.ts` rewritten: asserts silence on both stdout and stderr; pre-seeds `.moflo/moflo-version` + `installed-files.json` so section 3 short-circuits and the test isolates §0d behaviour. 6/6 pass.
- [x] `tests/bin/` (full bin suite) — 174/174 pass
- [x] `npm run build` clean
- [x] Empirical repro of user's scenario — both files cleared, zero stdout/stderr output

### Out of scope

`tests/bin/process-manager-stress.test.ts:full lifecycle…` flakes under full-suite host load (3 failures observed); passes 29/29 in isolation on both this branch and main. Same flake parked on the standing isolationTests list — not introduced by this change.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)