### PR TITLE
feat(881): hash-based settings.json hook-block drift detection

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -309,7 +309,7 @@ try {
 // Controlled by `auto_update.enabled` in moflo.yaml (default: true).
 // When moflo is upgraded (npm install), scripts and helpers may be stale.
 // Detect version change and sync from source before running hooks.
-let autoUpdateConfig = { enabled: true, scripts: true, helpers: true };
+let autoUpdateConfig = { enabled: true, scripts: true, helpers: true, hookBlockDrift: 'warn' };
 try {
   const mofloYaml = resolve(projectRoot, 'moflo.yaml');
   if (existsSync(mofloYaml)) {
@@ -318,9 +318,12 @@ try {
     const enabledMatch = yamlContent.match(/auto_update:\s*\n\s+enabled:\s*(true|false)/);
     const scriptsMatch = yamlContent.match(/auto_update:\s*\n(?:\s+\w+:.*\n)*?\s+scripts:\s*(true|false)/);
     const helpersMatch = yamlContent.match(/auto_update:\s*\n(?:\s+\w+:.*\n)*?\s+helpers:\s*(true|false)/);
+    // #881: hook-block drift detector (warn | regenerate | off; default warn)
+    const driftMatch = yamlContent.match(/auto_update:\s*\n(?:\s+\w+:.*\n)*?\s+hook_block_drift:\s*(warn|regenerate|off)/);
     if (enabledMatch) autoUpdateConfig.enabled = enabledMatch[1] === 'true';
     if (scriptsMatch) autoUpdateConfig.scripts = scriptsMatch[1] === 'true';
     if (helpersMatch) autoUpdateConfig.helpers = helpersMatch[1] === 'true';
+    if (driftMatch) autoUpdateConfig.hookBlockDrift = driftMatch[1];
   }
 } catch (err) {
   // Defaults (all true) keep the upgrade flow alive but the user should
@@ -884,6 +887,73 @@ try {
 } catch (err) {
   // #854: silent fail-loop hid hook breakage — surface so the user can act.
   emitWarning(`settings.json migration failed (${errMessage(err)})`);
+}
+
+// ── 3a-vi. Hook-block drift detection (#881) ───────────────────────────────
+// Hash the consumer's settings.json hook block against the reference block
+// `generateHooksConfig()` would produce for this moflo version. Catches
+// drift the per-bug `repairHookWiring` / `rewriteIncorrectHookWiring` rules
+// don't cover (future hook events, partial migrations, hand-edited commands).
+// Runs every session under `auto_update.enabled`, not only on version change.
+//
+// Modes (`auto_update.hook_block_drift` in moflo.yaml):
+//   warn        — print a one-line summary + diff to stdout (default)
+//   regenerate  — additively add missing hooks; falls back to warn when the
+//                 consumer has extra (custom) hooks, to avoid clobbering
+//   off         — skip entirely
+//
+// Also respects a `claudeFlow.hooks.locked: true` sentinel in settings.json
+// — if set, the user has explicitly opted out of drift surfacing.
+try {
+  if (autoUpdateConfig.enabled && autoUpdateConfig.hookBlockDrift !== 'off') {
+    const settingsPath = resolve(projectRoot, '.claude', 'settings.json');
+    let settingsRaw;
+    try { settingsRaw = readFileSync(settingsPath, 'utf-8'); } catch { settingsRaw = null; }
+    if (settingsRaw) {
+      const hbhPaths = [
+        resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/hook-block-hash.js'),
+        resolve(projectRoot, 'dist/src/cli/services/hook-block-hash.js'),
+      ];
+      const hbhPath = hbhPaths.find(p => existsSync(p));
+      if (hbhPath) {
+        const settings = JSON.parse(settingsRaw);
+        const mod = await import(`file://${hbhPath.replace(/\\/g, '/')}`);
+        const locked = typeof mod.isHookBlockLocked === 'function' && mod.isHookBlockLocked(settings);
+        if (!locked && typeof mod.computeHookBlockDrift === 'function') {
+          const report = mod.computeHookBlockDrift(settings.hooks || {});
+          if (report.drifted) {
+            const wantRegenerate = autoUpdateConfig.hookBlockDrift === 'regenerate';
+            const safeToRegenerate = wantRegenerate && report.extra.length === 0;
+            if (safeToRegenerate && typeof mod.applyAdditiveRegeneration === 'function') {
+              const { added } = mod.applyAdditiveRegeneration(settings, report);
+              if (added > 0) {
+                writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+                emitMutation(
+                  'regenerated hook block',
+                  `added ${plural(added, 'missing hook entry')} (drift ${report.consumerHash} → ${report.referenceHash})`,
+                );
+              }
+            } else {
+              const parts = [];
+              if (report.missing.length > 0) parts.push(plural(report.missing.length, 'missing entry'));
+              if (report.extra.length > 0) parts.push(`${plural(report.extra.length, 'custom hook')} preserved`);
+              const reason = parts.join(', ') || 'reordered';
+              // stdout (not stderr) so Claude sees this in `additionalContext` and
+              // can surface it to the user. Not counted as a mutation since we
+              // didn't change anything.
+              try {
+                process.stdout.write(
+                  `moflo: hook block drift (${reason}); run \`flo doctor hook-drift\` or set auto_update.hook_block_drift: regenerate in moflo.yaml\n`,
+                );
+              } catch { /* broken stdout — non-fatal */ }
+            }
+          }
+        }
+      }
+    }
+  }
+} catch (err) {
+  emitWarning(`hook-block drift check skipped (${errMessage(err)})`);
 }
 
 // ── 3b. Ensure shipped guidance files exist (even without version change) ──

--- a/src/cli/__tests__/services/hook-block-hash.test.ts
+++ b/src/cli/__tests__/services/hook-block-hash.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Hook Block Hash / Drift Detection Tests (#881)
+ *
+ * Validates the self-contained `hook-block-hash` module that the session-start
+ * launcher uses to surface drift between a consumer's `.claude/settings.json`
+ * hook block and the reference block `generateHooksConfig()` would produce.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  normaliseHooks,
+  computeHookBlockHash,
+  computeHookBlockDrift,
+  formatDriftReport,
+  getReferenceHookBlock,
+} from '../../services/hook-block-hash.js';
+import { generateSettings } from '../../init/settings-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../../init/types.js';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cross-check: the inlined reference must match what generateHooksConfig
+// would produce with all hook flags enabled — the canonical `flo init` shape.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('hook-block-hash — reference parity with settings-generator', () => {
+  it('getReferenceHookBlock matches generateHooksConfig (DEFAULT_INIT_OPTIONS)', () => {
+    const settings = generateSettings(DEFAULT_INIT_OPTIONS) as { hooks: Record<string, unknown> };
+    const reference = getReferenceHookBlock();
+    expect(computeHookBlockHash(reference)).toBe(computeHookBlockHash(settings.hooks));
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Hash determinism + normalisation
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('computeHookBlockHash — determinism', () => {
+  it('returns the same hash for the same input across runs', () => {
+    const ref = getReferenceHookBlock();
+    expect(computeHookBlockHash(ref)).toBe(computeHookBlockHash(ref));
+  });
+
+  it('is stable under event-key reordering', () => {
+    const ref = getReferenceHookBlock();
+    const reordered: Record<string, unknown> = {};
+    const keys = Object.keys(ref).sort().reverse();
+    for (const k of keys) reordered[k] = (ref as Record<string, unknown>)[k];
+    expect(computeHookBlockHash(reordered)).toBe(computeHookBlockHash(ref));
+  });
+
+  it('is stable under hook-array reordering within a matcher block', () => {
+    const a = {
+      PreToolUse: [
+        { matcher: '^Bash$', hooks: [
+          { type: 'command', command: 'a', timeout: 1000 },
+          { type: 'command', command: 'b', timeout: 1000 },
+        ] },
+      ],
+    };
+    const b = {
+      PreToolUse: [
+        { matcher: '^Bash$', hooks: [
+          { type: 'command', command: 'b', timeout: 1000 },
+          { type: 'command', command: 'a', timeout: 1000 },
+        ] },
+      ],
+    };
+    expect(computeHookBlockHash(a)).toBe(computeHookBlockHash(b));
+  });
+
+  it('normalises whitespace inside commands', () => {
+    const a = { PreToolUse: [{ matcher: '^Bash$', hooks: [{ type: 'command', command: 'node  script.js  --flag', timeout: 1000 }] }] };
+    const b = { PreToolUse: [{ matcher: '^Bash$', hooks: [{ type: 'command', command: 'node script.js --flag', timeout: 1000 }] }] };
+    expect(computeHookBlockHash(a)).toBe(computeHookBlockHash(b));
+  });
+
+  it('produces different hashes for different command sets', () => {
+    const a = { PreToolUse: [{ matcher: '^Bash$', hooks: [{ type: 'command', command: 'a', timeout: 1 }] }] };
+    const b = { PreToolUse: [{ matcher: '^Bash$', hooks: [{ type: 'command', command: 'b', timeout: 1 }] }] };
+    expect(computeHookBlockHash(a)).not.toBe(computeHookBlockHash(b));
+  });
+
+  it('handles empty / null / non-object inputs gracefully', () => {
+    expect(computeHookBlockHash(null)).toBe(computeHookBlockHash(undefined));
+    expect(computeHookBlockHash({})).toBe(computeHookBlockHash(null));
+    expect(() => computeHookBlockHash('not an object' as unknown)).not.toThrow();
+  });
+});
+
+describe('normaliseHooks', () => {
+  it('drops invalid blocks and entries without throwing', () => {
+    const out = normaliseHooks({
+      PreToolUse: [
+        null,
+        { /* no hooks */ },
+        { hooks: 'not-an-array' },
+        { hooks: [{ /* no command */ }] },
+        { hooks: [{ command: 'real', timeout: 100 }] },
+      ],
+    });
+    expect(out.PreToolUse).toBeDefined();
+    expect(out.PreToolUse.length).toBe(1);
+    expect(out.PreToolUse[0].hooks[0].command).toBe('real');
+  });
+
+  it('drops events with no surviving blocks rather than emitting empty arrays', () => {
+    const out = normaliseHooks({
+      PreToolUse: [{ hooks: [] }],
+      PostToolUse: [{ hooks: [{ command: 'ok', timeout: 1 }] }],
+    });
+    expect(out.PreToolUse).toBeUndefined();
+    expect(out.PostToolUse).toBeDefined();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Drift detection — covers the two AC test cases verbatim
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('computeHookBlockDrift — AC test cases', () => {
+  it('AC: consumer hand-edits a hook command — drift is "modified" (warn fires, no rewrite)', () => {
+    // Take the reference and tweak one Bash command to add a custom flag.
+    // Drift detector should report 1 missing (original) + 1 extra (tweaked).
+    // The launcher handles "no rewrite when extras exist" — this test only
+    // proves the report surfaces the modification.
+    const consumer = JSON.parse(JSON.stringify(getReferenceHookBlock())) as Record<string, unknown[]>;
+    const bashBlock = (consumer.PreToolUse as Array<{ matcher?: string; hooks: Array<{ command: string }> }>)
+      .find(b => b.matcher === '^Bash$')!;
+    const target = bashBlock.hooks.find(h => h.command.includes('check-dangerous-command'))!;
+    target.command = target.command + ' --my-custom-flag';
+
+    const report = computeHookBlockDrift(consumer);
+    expect(report.drifted).toBe(true);
+    // Original command shows up as missing
+    expect(report.missing.some(m => m.command.endsWith('check-dangerous-command'))).toBe(true);
+    // Customised command shows up as extra
+    expect(report.extra.some(e => e.command.endsWith('--my-custom-flag'))).toBe(true);
+    // No unrelated entries are missing — only the one modification
+    expect(report.missing.length).toBe(1);
+    expect(report.extra.length).toBe(1);
+  });
+
+  it('AC: a future hook event ships — drift detects the missing event without nuking unrelated hooks', () => {
+    // Simulate a future moflo version that ships a `SessionEnd` event the
+    // consumer doesn't yet have. The reference (synthesised here) includes it;
+    // the consumer is on today's reference.
+    const futureReference = JSON.parse(JSON.stringify(getReferenceHookBlock())) as Record<string, unknown>;
+    (futureReference as Record<string, unknown[]>).SessionEnd = [
+      { hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/session-end.cjs"', timeout: 5000 }] },
+    ];
+
+    const consumer = getReferenceHookBlock();
+    const report = computeHookBlockDrift(consumer, futureReference);
+
+    expect(report.drifted).toBe(true);
+    // Exactly one missing entry — the new event
+    expect(report.missing.length).toBe(1);
+    expect(report.missing[0].event).toBe('SessionEnd');
+    // No unrelated drift — every other event is identical
+    expect(report.extra.length).toBe(0);
+    // Confirm unrelated existing matchers are unchanged in the consumer
+    const consumerHooks = consumer as Record<string, unknown[]>;
+    expect(consumerHooks.PreToolUse).toBeDefined();
+    expect(consumerHooks.PostToolUse).toBeDefined();
+  });
+
+  it('reports drifted=false when consumer matches reference exactly', () => {
+    const report = computeHookBlockDrift(getReferenceHookBlock());
+    expect(report.drifted).toBe(false);
+    expect(report.missing).toEqual([]);
+    expect(report.extra).toEqual([]);
+    expect(report.consumerHash).toBe(report.referenceHash);
+  });
+
+  it('reports purely-additive drift correctly (consumer missing entries, no extras)', () => {
+    // Consumer has a stripped-down hook block with only the Read gate.
+    const consumer = {
+      PreToolUse: [
+        { matcher: '^Read$', hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-before-read', timeout: 3000 }] },
+      ],
+    };
+    const report = computeHookBlockDrift(consumer);
+    expect(report.drifted).toBe(true);
+    expect(report.missing.length).toBeGreaterThan(0);
+    expect(report.extra.length).toBe(0);
+  });
+});
+
+describe('formatDriftReport', () => {
+  it('produces a one-line "matches" string when no drift', () => {
+    const report = computeHookBlockDrift(getReferenceHookBlock());
+    expect(formatDriftReport(report)).toContain('matches reference');
+  });
+
+  it('produces a multi-line summary listing missing + extra entries', () => {
+    const consumer = {
+      PreToolUse: [
+        { matcher: '^Read$', hooks: [{ type: 'command', command: 'custom-read-handler', timeout: 1000 }] },
+      ],
+    };
+    const report = computeHookBlockDrift(consumer);
+    const formatted = formatDriftReport(report);
+    expect(formatted).toContain('drift detected');
+    expect(formatted).toContain('missing');
+    expect(formatted).toContain('extra');
+    // Human-readable: contains event names + matcher + command
+    expect(formatted).toMatch(/PreToolUse.*\^Bash\$/);
+  });
+});

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -623,3 +623,69 @@ export async function checkGateHealth(): Promise<HealthCheck> {
     message: `${caseCount} gate cases, ${hookCount} hook bindings, state file OK`,
   };
 }
+
+/**
+ * Hash-based hook-block drift check (#881). Complements `checkGateHealth`'s
+ * required-pattern probe by detecting drift in *any* direction — missing
+ * events, modified commands, future hook events not yet covered by
+ * `REQUIRED_HOOK_WIRING`. Uses the self-contained `hook-block-hash` module so
+ * the same logic runs in `flo doctor`, the launcher, and unit tests.
+ *
+ * Reports `pass` when no drift, `warn` with a count summary when drift exists.
+ * Never `fail` — drift is informational; the user (or `regenerate` mode) is
+ * responsible for deciding what to do.
+ */
+export async function checkHookBlockDrift(): Promise<HealthCheck> {
+  const projectDir = findConsumerProjectDir();
+  const settingsPath = join(projectDir, '.claude', 'settings.json');
+
+  if (!existsSync(settingsPath)) {
+    return {
+      name: 'Hook Block Drift',
+      status: 'warn',
+      message: '.claude/settings.json not found',
+      fix: 'npx moflo init',
+    };
+  }
+
+  let settings: Record<string, unknown>;
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  } catch (e) {
+    return {
+      name: 'Hook Block Drift',
+      status: 'warn',
+      message: `cannot parse .claude/settings.json: ${errorDetail(e)}`,
+    };
+  }
+
+  const { computeHookBlockDrift, isHookBlockLocked } = await import('../services/hook-block-hash.js');
+  if (isHookBlockLocked(settings)) {
+    return {
+      name: 'Hook Block Drift',
+      status: 'pass',
+      message: 'drift check skipped — claudeFlow.hooks.locked: true',
+    };
+  }
+  const report = computeHookBlockDrift(settings.hooks ?? {});
+
+  if (!report.drifted) {
+    return {
+      name: 'Hook Block Drift',
+      status: 'pass',
+      message: `hook block matches reference (${report.consumerHash})`,
+    };
+  }
+
+  const parts: string[] = [];
+  parts.push(`drift ${report.consumerHash} vs ${report.referenceHash}`);
+  if (report.missing.length > 0) parts.push(`${report.missing.length} missing`);
+  if (report.extra.length > 0) parts.push(`${report.extra.length} custom`);
+
+  return {
+    name: 'Hook Block Drift',
+    status: 'warn',
+    message: parts.join(', '),
+    fix: 'set auto_update.hook_block_drift: regenerate in moflo.yaml, or claudeFlow.hooks.locked: true to suppress',
+  };
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -22,6 +22,7 @@ import {
   checkHookExecution,
   checkMcpSpellIntegration,
   checkGateHealth,
+  checkHookBlockDrift,
   checkMofloDbBridge,
   getMofloRoot,
 } from './doctor-checks-deep.js';
@@ -1618,6 +1619,7 @@ export const doctorCommand: Command = {
       checkMcpSpellIntegration,
       checkHookExecution,
       checkGateHealth,
+      checkHookBlockDrift,
       checkMofloDbBridge,
       // Issue #818 / epic #798 — coordinator-path tripwires. They share the
       // singleton coordinator with checkSubagentHealth above and assert by
@@ -1666,6 +1668,8 @@ export const doctorCommand: Command = {
       'hooks': checkHookExecution,
       'gates': checkGateHealth,
       'gate': checkGateHealth,
+      'hook-drift': checkHookBlockDrift,
+      'drift': checkHookBlockDrift,
       'sandbox': checkSandboxTier,
       'sandbox-tier': checkSandboxTier,
       'moflodb': checkMofloDbBridge,

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -93,6 +93,8 @@ export interface MofloConfig {
     enabled: boolean;
     scripts: boolean;
     helpers: boolean;
+    /** #881 — hash-based hook-block drift detection mode. */
+    hook_block_drift: 'warn' | 'regenerate' | 'off';
   };
 
   sandbox: {
@@ -196,6 +198,7 @@ const DEFAULT_CONFIG: MofloConfig = {
     enabled: true,
     scripts: true,
     helpers: true,
+    hook_block_drift: 'warn',
   },
   sandbox: {
     enabled: false,
@@ -333,6 +336,12 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
       enabled: raw.auto_update?.enabled ?? raw.autoUpdate?.enabled ?? DEFAULT_CONFIG.auto_update.enabled,
       scripts: raw.auto_update?.scripts ?? raw.autoUpdate?.scripts ?? DEFAULT_CONFIG.auto_update.scripts,
       helpers: raw.auto_update?.helpers ?? raw.autoUpdate?.helpers ?? DEFAULT_CONFIG.auto_update.helpers,
+      hook_block_drift: (() => {
+        const v = raw.auto_update?.hook_block_drift ?? raw.autoUpdate?.hookBlockDrift;
+        return v === 'regenerate' || v === 'off' || v === 'warn'
+          ? v
+          : DEFAULT_CONFIG.auto_update.hook_block_drift;
+      })(),
     },
     sandbox: {
       enabled: raw.sandbox?.enabled ?? DEFAULT_CONFIG.sandbox.enabled,
@@ -530,6 +539,10 @@ auto_update:
   enabled: true                  # Master toggle for version-change auto-sync
   scripts: true                  # Sync .claude/scripts/ from moflo bin/
   helpers: true                  # Sync .claude/helpers/ from moflo source
+  hook_block_drift: warn         # warn | regenerate | off
+                                 # warn = print drift summary on session start (default)
+                                 # regenerate = auto-add missing hooks (only when no customisations)
+                                 # off = skip detection entirely
 
 # OS-level sandbox for spell bash steps
 # Denylist always runs regardless of this setting

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -1,0 +1,386 @@
+/**
+ * Settings.json hook-block drift detection (#881).
+ *
+ * Hashes the consumer's `.claude/settings.json` `hooks` block and the
+ * reference hook block that `generateHooksConfig()` would produce for the
+ * current moflo version.  When the hashes differ, the session-start launcher
+ * surfaces the diff (or, in `regenerate` mode, adds purely-additive missing
+ * hooks).  This is the broader complement to the per-bug `repairHookWiring`
+ * and `rewriteIncorrectHookWiring` rules — it catches drift in any direction,
+ * including future hook events we haven't shipped yet.
+ *
+ * IMPORTANT: This module must remain self-contained with ZERO imports from
+ * other moflo modules (mirrors the constraint on `services/hook-wiring.ts`).
+ * It is dynamically imported at runtime by `bin/session-start-launcher.mjs`
+ * in consumer projects, where transitive dependencies may not resolve.
+ *
+ * The reference hook block is duplicated from `init/settings-generator.ts`
+ * on purpose — the launcher cannot pull in `init/types.js` at runtime, and a
+ * unit test (`hook-block-hash.test.ts`) asserts the two stay in sync.
+ */
+import { createHash } from 'crypto';
+
+export interface HookEntry {
+  type: string;
+  command: string;
+  timeout: number;
+}
+
+export interface HookBlock {
+  matcher?: string;
+  hooks: HookEntry[];
+}
+
+export type HooksTree = Record<string, HookBlock[]>;
+
+export const DRIFT_MODES = ['warn', 'regenerate', 'off'] as const;
+export type DriftMode = typeof DRIFT_MODES[number];
+
+export interface HookDriftEntry {
+  event: string;
+  matcher: string;
+  command: string;
+}
+
+export interface HookDriftReport {
+  /** Stable hash of the consumer's normalised hook block. */
+  consumerHash: string;
+  /** Stable hash of the reference hook block for this moflo version. */
+  referenceHash: string;
+  /** True when the hashes differ. */
+  drifted: boolean;
+  /** Hook entries present in reference but missing from consumer. */
+  missing: HookDriftEntry[];
+  /** Hook entries present in consumer but absent from reference (likely user customisations). */
+  extra: HookDriftEntry[];
+}
+
+export interface RegenerationResult {
+  /** The (mutated) settings tree for convenience. */
+  settings: Record<string, unknown>;
+  /** Number of missing hook entries that were added back. */
+  added: number;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Reference hook block — kept in sync with init/settings-generator.ts
+// ────────────────────────────────────────────────────────────────────────────
+
+const HELPERS_PREFIX = '$CLAUDE_PROJECT_DIR/.claude/helpers';
+const SCRIPTS_PREFIX = '$CLAUDE_PROJECT_DIR/.claude/scripts';
+
+/** Build a `node "<helper> <subcommand>"` hook entry. */
+const helperHook = (helper: string, sub: string, timeout: number): HookEntry => ({
+  type: 'command',
+  command: `node "${HELPERS_PREFIX}/${helper}"${sub ? ` ${sub}` : ''}`,
+  timeout,
+});
+
+/** Build a `node "<scripts/file>"` hook entry (no subcommand). */
+const scriptHook = (file: string, timeout: number): HookEntry => ({
+  type: 'command',
+  command: `node "${SCRIPTS_PREFIX}/${file}"`,
+  timeout,
+});
+
+const gateHook = (sub: string, timeout: number) => helperHook('gate-hook.mjs', sub, timeout);
+const gateCjs = (sub: string, timeout: number) => helperHook('gate.cjs', sub, timeout);
+const handler = (sub: string, timeout: number) => helperHook('hook-handler.cjs', sub, timeout);
+const autoMemory = (sub: string, timeout: number) => helperHook('auto-memory-hook.mjs', sub, timeout);
+
+/**
+ * Build the reference hook block — the canonical block `generateHooksConfig()`
+ * produces with all hook flags enabled (the default for `flo init`).
+ *
+ * If you change `generateHooksConfig()` in `init/settings-generator.ts`, also
+ * change this function — and the unit test `getReferenceHookBlock matches
+ * generateHooksConfig` will fail until the two agree.
+ */
+export function getReferenceHookBlock(): HooksTree {
+  return {
+    PreToolUse: [
+      { matcher: '^(Write|Edit|MultiEdit)$', hooks: [handler('post-edit', 5000)] },
+      { matcher: '^(Glob|Grep)$',             hooks: [gateHook('check-before-scan', 3000)] },
+      { matcher: '^Read$',                    hooks: [gateHook('check-before-read', 3000)] },
+      {
+        matcher: '^Bash$',
+        hooks: [gateHook('check-dangerous-command', 2000), gateHook('check-before-pr', 2000)],
+      },
+    ],
+    PostToolUse: [
+      {
+        matcher: '^(Write|Edit|MultiEdit)$',
+        hooks: [handler('post-edit', 5000), gateHook('reset-edit-gates', 2000)],
+      },
+      { matcher: '^Agent$',                       hooks: [handler('post-task', 5000)] },
+      { matcher: '^TaskCreate$',                  hooks: [gateCjs('record-task-created', 2000)] },
+      {
+        matcher: '^Bash$',
+        hooks: [gateHook('check-bash-memory', 2000), gateHook('record-test-run', 2000)],
+      },
+      { matcher: '^Skill$',                       hooks: [gateHook('record-skill-run', 2000)] },
+      { matcher: 'mcp__moflo__memory_',           hooks: [gateHook('record-memory-searched', 3000)] },
+      { matcher: '^TaskUpdate$',                  hooks: [gateCjs('check-task-transition', 2000)] },
+      { matcher: '^mcp__moflo__memory_store$',    hooks: [gateCjs('record-learnings-stored', 2000)] },
+    ],
+    UserPromptSubmit: [
+      { hooks: [helperHook('prompt-hook.mjs', '', 3000)] },
+      { hooks: [gateHook('prompt-reminder', 3000)] },
+    ],
+    SubagentStart: [
+      { hooks: [helperHook('subagent-start.cjs', '', 2000)] },
+    ],
+    SessionStart: [
+      {
+        hooks: [scriptHook('session-start-launcher.mjs', 3000), autoMemory('import', 8000)],
+      },
+    ],
+    Stop: [
+      { hooks: [handler('session-end', 5000), autoMemory('sync', 10000)] },
+    ],
+    PreCompact: [
+      { hooks: [gateCjs('compact-guidance', 3000)] },
+    ],
+    Notification: [
+      { hooks: [handler('notification', 3000)] },
+    ],
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Normalisation + hashing
+// ────────────────────────────────────────────────────────────────────────────
+
+function normaliseHookEntry(raw: unknown): HookEntry | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.command !== 'string') return null;
+  return {
+    type: typeof r.type === 'string' ? r.type : 'command',
+    command: r.command.replace(/\s+/g, ' ').trim(),
+    timeout: typeof r.timeout === 'number' && isFinite(r.timeout) ? r.timeout : 0,
+  };
+}
+
+function normaliseHookBlock(raw: unknown): HookBlock | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const hooksIn = Array.isArray(r.hooks) ? r.hooks : [];
+  const hooks = hooksIn.map(normaliseHookEntry).filter((h): h is HookEntry => h !== null);
+  if (hooks.length === 0) return null;
+  hooks.sort((a, b) => a.command.localeCompare(b.command));
+  const out: HookBlock = { hooks };
+  if (typeof r.matcher === 'string' && r.matcher.length > 0) out.matcher = r.matcher;
+  return out;
+}
+
+/**
+ * Produce a stable, sorted view of a hook tree suitable for hashing or diffing.
+ * Drops unknown keys, coerces missing fields to defaults, and sorts events,
+ * matchers, and commands so semantically-equal trees compare equal.
+ */
+export function normaliseHooks(raw: unknown): HooksTree {
+  if (!raw || typeof raw !== 'object') return {};
+  const events = raw as Record<string, unknown>;
+  const out: HooksTree = {};
+  const eventNames = Object.keys(events).sort();
+  for (const event of eventNames) {
+    const arr = events[event];
+    if (!Array.isArray(arr)) continue;
+    const blocks = arr
+      .map(normaliseHookBlock)
+      .filter((b): b is HookBlock => b !== null);
+    if (blocks.length === 0) continue;
+    blocks.sort((a, b) => {
+      const am = a.matcher ?? '';
+      const bm = b.matcher ?? '';
+      if (am !== bm) return am.localeCompare(bm);
+      return (a.hooks[0]?.command ?? '').localeCompare(b.hooks[0]?.command ?? '');
+    });
+    out[event] = blocks;
+  }
+  return out;
+}
+
+function hashNormalised(tree: HooksTree): string {
+  return createHash('sha256').update(JSON.stringify(tree)).digest('hex').slice(0, 16);
+}
+
+/**
+ * Hash a hook tree.  Stable across runs (deterministic normalisation), and
+ * insensitive to key order, whitespace inside commands, or matcher block
+ * grouping.  Returns a 16-char hex prefix of sha256 — long enough to make
+ * collisions a non-concern for the small space of valid hook trees while
+ * staying readable in launcher output.
+ */
+export function computeHookBlockHash(raw: unknown): string {
+  return hashNormalised(normaliseHooks(raw));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Diff
+// ────────────────────────────────────────────────────────────────────────────
+
+function entryKey(event: string, matcher: string, command: string): string {
+  return `${event} ${matcher} ${command}`;
+}
+
+function flatten(tree: HooksTree): Map<string, HookDriftEntry> {
+  const out = new Map<string, HookDriftEntry>();
+  for (const event of Object.keys(tree)) {
+    for (const block of tree[event]) {
+      const matcher = block.matcher ?? '';
+      for (const hook of block.hooks) {
+        const entry: HookDriftEntry = { event, matcher, command: hook.command };
+        out.set(entryKey(event, matcher, hook.command), entry);
+      }
+    }
+  }
+  return out;
+}
+
+interface ReferenceCache {
+  tree: HooksTree;
+  normalised: HooksTree;
+  hash: string;
+  flat: Map<string, HookDriftEntry>;
+}
+
+let cachedReference: ReferenceCache | null = null;
+function getCachedReference(): ReferenceCache {
+  if (!cachedReference) {
+    const tree = getReferenceHookBlock();
+    const normalised = normaliseHooks(tree);
+    cachedReference = { tree, normalised, hash: hashNormalised(normalised), flat: flatten(normalised) };
+  }
+  return cachedReference;
+}
+
+/**
+ * Compare a consumer hook block against the reference and report what's
+ * missing / extra.  Pass an explicit `referenceHooks` to test against a
+ * frozen reference (used by tests); omit it to use the current moflo
+ * reference from `getReferenceHookBlock()` (memoised — built once per process).
+ */
+export function computeHookBlockDrift(
+  consumerHooks: unknown,
+  referenceHooks?: unknown,
+): HookDriftReport {
+  const consumerNormalised = normaliseHooks(consumerHooks);
+  const consumerHash = hashNormalised(consumerNormalised);
+  const consumerFlat = flatten(consumerNormalised);
+
+  let referenceHash: string;
+  let referenceFlat: Map<string, HookDriftEntry>;
+  if (referenceHooks === undefined) {
+    const ref = getCachedReference();
+    referenceHash = ref.hash;
+    referenceFlat = ref.flat;
+  } else {
+    const refNormalised = normaliseHooks(referenceHooks);
+    referenceHash = hashNormalised(refNormalised);
+    referenceFlat = flatten(refNormalised);
+  }
+
+  const missing: HookDriftEntry[] = [];
+  for (const [k, v] of referenceFlat) {
+    if (!consumerFlat.has(k)) missing.push(v);
+  }
+  const extra: HookDriftEntry[] = [];
+  for (const [k, v] of consumerFlat) {
+    if (!referenceFlat.has(k)) extra.push(v);
+  }
+
+  return {
+    consumerHash,
+    referenceHash,
+    drifted: consumerHash !== referenceHash,
+    missing,
+    extra,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Settings.json helpers — shared between launcher + doctor
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * True when the user has set `claudeFlow.hooks.locked: true` in their
+ * settings.json — a sentinel that suppresses drift surfacing entirely.
+ */
+export function isHookBlockLocked(settings: unknown): boolean {
+  const root = settings as Record<string, unknown> | null | undefined;
+  const cf = root?.claudeFlow as Record<string, unknown> | undefined;
+  const hooks = cf?.hooks as Record<string, unknown> | undefined;
+  return hooks?.locked === true;
+}
+
+/**
+ * Additively repair drift: for every entry in `report.missing`, locate the
+ * corresponding hook in the reference block and graft it into the consumer's
+ * settings.  Only safe when `report.extra.length === 0` — otherwise the
+ * caller should fall back to `warn` mode to avoid clobbering customisations.
+ *
+ * Mutates `settings` in place; caller is responsible for writing the file.
+ */
+export function applyAdditiveRegeneration(
+  settings: Record<string, unknown>,
+  report: HookDriftReport,
+): RegenerationResult {
+  if (report.missing.length === 0) return { settings, added: 0 };
+  const ref = getCachedReference().tree;
+  const hooks = (settings.hooks ?? {}) as Record<string, HookBlock[]>;
+  let added = 0;
+
+  for (const miss of report.missing) {
+    const arr = Array.isArray(hooks[miss.event]) ? hooks[miss.event] : [];
+    let block = arr.find(b => (b?.matcher ?? '') === miss.matcher);
+    if (!block) {
+      block = { hooks: [] };
+      if (miss.matcher) block.matcher = miss.matcher;
+      arr.push(block);
+    }
+    if (!Array.isArray(block.hooks)) block.hooks = [];
+
+    const refArr = ref[miss.event] ?? [];
+    const refBlock = refArr.find(b => (b?.matcher ?? '') === miss.matcher);
+    const refHook = refBlock?.hooks.find(h => h.command === miss.command);
+    if (refHook && !block.hooks.some(h => h?.command === miss.command)) {
+      block.hooks.push(refHook);
+      added++;
+    }
+    hooks[miss.event] = arr;
+  }
+
+  if (added > 0) settings.hooks = hooks;
+  return { settings, added };
+}
+
+/**
+ * Format a drift report for human-readable output (multi-line, no colour).
+ * Used by `flo doctor` and the session-start launcher's stdout summary.
+ */
+export function formatDriftReport(report: HookDriftReport): string {
+  if (!report.drifted) {
+    return `hook block matches reference (${report.consumerHash})`;
+  }
+  const lines: string[] = [];
+  lines.push(
+    `hook block drift detected (consumer ${report.consumerHash} vs reference ${report.referenceHash})`,
+  );
+  if (report.missing.length > 0) {
+    lines.push(`  ${report.missing.length} missing:`);
+    for (const m of report.missing) {
+      const m2 = m.matcher ? ` ${m.matcher}` : '';
+      lines.push(`    - ${m.event}${m2}: ${m.command}`);
+    }
+  }
+  if (report.extra.length > 0) {
+    lines.push(`  ${report.extra.length} extra (likely customisations):`);
+    for (const e of report.extra) {
+      const m2 = e.matcher ? ` ${e.matcher}` : '';
+      lines.push(`    + ${e.event}${m2}: ${e.command}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/src/cli/services/index.ts
+++ b/src/cli/services/index.ts
@@ -90,6 +90,23 @@ export {
   type RepairResult,
 } from './hook-wiring.js';
 
+// Hook Block Drift Detection (#881 — hash-based reconciliation)
+export {
+  computeHookBlockHash,
+  computeHookBlockDrift,
+  formatDriftReport,
+  getReferenceHookBlock,
+  normaliseHooks,
+  isHookBlockLocked,
+  applyAdditiveRegeneration,
+  DRIFT_MODES,
+  type HookDriftReport,
+  type HookDriftEntry,
+  type DriftMode,
+  type HooksTree,
+  type RegenerationResult,
+} from './hook-block-hash.js';
+
 // Subagent Bootstrap Directive (single-source for SubagentStart + agent_spawn surfaces)
 export { SUBAGENT_BOOTSTRAP_DIRECTIVE } from './subagent-bootstrap.js';
 


### PR DESCRIPTION
## Summary

Implements #881 — a broader, hash-based hook-block drift detector that complements the per-bug `repairHookWiring` / `rewriteIncorrectHookWiring` rules. Surfaces (or, in regenerate mode, additively repairs) drift between a consumer's `.claude/settings.json` hook block and the reference block `generateHooksConfig()` produces for the current moflo version.

## Changes

- **New** `src/cli/services/hook-block-hash.ts` — zero-imports module (matches `hook-wiring.ts` constraint for dynamic import in consumer projects). Exports: `getReferenceHookBlock`, `normaliseHooks`, `computeHookBlockHash`, `computeHookBlockDrift`, `formatDriftReport`, `isHookBlockLocked`, `applyAdditiveRegeneration`. Reference cache memoised at module scope; sha256-prefix-16 hash; additive-only regenerate that preserves customisations.
- **New** `src/cli/__tests__/services/hook-block-hash.test.ts` — 15 tests covering hash determinism, normalisation, both AC scenarios verbatim (hand-edited command, future hook event shipped), reference parity with `generateHooksConfig(DEFAULT_INIT_OPTIONS)`.
- `bin/session-start-launcher.mjs` — section 3a-vi runs every session under `auto_update.enabled`. Reads `auto_update.hook_block_drift` (`warn` | `regenerate` | `off`, default `warn`) plus the `claudeFlow.hooks.locked: true` sentinel.
- `src/cli/commands/doctor-checks-deep.ts` — adds `checkHookBlockDrift` and wires it into `flo doctor` (`hook-drift` / `drift` aliases).
- `src/cli/config/moflo-config.ts` — adds `auto_update.hook_block_drift` field + yaml template entry. Backwards-compatible default.

## Acceptance criteria

- [x] Drift detection runs every session start (under existing `auto_update.enabled` gate).
- [x] Default behaviour is `warn` — never silently rewrites consumer hooks.
- [x] User can lock the hook block via `claudeFlow.hooks.locked: true` (or `auto_update.hook_block_drift: off`).
- [x] AC test: consumer hand-edits a hook command — drift fires, no rewrite happens (`regenerate` falls back to warn when `extra > 0`).
- [x] AC test: a future hook event ships — drift detection notices the missing event without nuking unrelated existing hooks.

## Test plan

- [x] `npx vitest run src/cli/__tests__/services/hook-block-hash.test.ts` — 15/15 pass
- [x] `npm test` (parallel + isolation) — 7752/7752 pass
- [x] `flo doctor` — new `Hook Block Drift` check correctly reports the legitimate custom hook in this dev repo (`session-reset` on SessionStart) and preserves it
- [x] `node bin/session-start-launcher.mjs` — section 3a-vi fires, surfaces a one-line drift summary on stdout
- [x] Build clean (`npm run build`)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)