### PR TITLE
perf(881): mtime cache fast-path + TOCTOU fix in launcher hook-drift check

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -10,7 +10,7 @@
 import { spawn, execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { mofloDir } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
@@ -904,52 +904,117 @@ try {
 //
 // Also respects a `claudeFlow.hooks.locked: true` sentinel in settings.json
 // — if set, the user has explicitly opted out of drift surfacing.
+// Fast-path: `.moflo/hook-drift-cache.json` records the last clean run. If
+// settings.json + the dist module both still match the cached mtimes and the
+// cached check was clean (consumerHash === referenceHash), skip readFile +
+// JSON.parse + dynamic import entirely. This block runs every session; the
+// cache makes it ~free in the steady state.
+//
+// Returns the values to persist on the slow path, or null when skipped
+// (cache hit, no settings.json, no dist module, locked, etc.). Pulled out
+// to keep the guard chain flat — the original inline form was 9 levels deep.
+async function runHookBlockDriftCheck() {
+  const settingsPath = resolve(projectRoot, '.claude', 'settings.json');
+  let settingsStat;
+  try { settingsStat = statSync(settingsPath); } catch { return null; }
+
+  // statSync each candidate doubles as existence check + provides the mtime
+  // we need for the cache key, avoiding the existsSync→import TOCTOU pattern.
+  const hbhCandidates = [
+    resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/hook-block-hash.js'),
+    resolve(projectRoot, 'dist/src/cli/services/hook-block-hash.js'),
+  ];
+  let hbhPath = null;
+  let hbhStat = null;
+  for (const p of hbhCandidates) {
+    try { hbhStat = statSync(p); hbhPath = p; break; } catch { /* try next */ }
+  }
+  if (!hbhPath) return null;
+
+  // Fast-path requires consumerHash === referenceHash (a previously *clean*
+  // run). A drifted-but-cached state still needs to re-emit the warning each
+  // session, so we always re-do the work in that case.
+  const cachePath = join(mofloDir(projectRoot), 'hook-drift-cache.json');
+  let cached = null;
+  try { cached = JSON.parse(readFileSync(cachePath, 'utf-8')); } catch { /* missing or corrupt */ }
+  if (
+    cached &&
+    cached.settingsMtimeMs === settingsStat.mtimeMs &&
+    cached.moduleMtimeMs === hbhStat.mtimeMs &&
+    cached.consumerHash === cached.referenceHash
+  ) return null;
+
+  // Try-catch around the dynamic import handles the file disappearing
+  // between statSync and import (TOCTOU); module-load errors fall through.
+  let mod = null;
+  try { mod = await import(pathToFileURL(hbhPath).href); } catch { /* TOCTOU or load error — skip */ return null; }
+  if (typeof mod.computeHookBlockDrift !== 'function') return null;
+
+  const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  if (typeof mod.isHookBlockLocked === 'function' && mod.isHookBlockLocked(settings)) return null;
+
+  const report = mod.computeHookBlockDrift(settings.hooks || {});
+  let regenerated = false;
+
+  if (report.drifted) {
+    const wantRegenerate = autoUpdateConfig.hookBlockDrift === 'regenerate';
+    const safeToRegenerate = wantRegenerate && report.extra.length === 0;
+    if (safeToRegenerate && typeof mod.applyAdditiveRegeneration === 'function') {
+      const { added } = mod.applyAdditiveRegeneration(settings, report);
+      if (added > 0) {
+        writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+        regenerated = true;
+        emitMutation(
+          'regenerated hook block',
+          `added ${plural(added, 'missing hook entry')} (drift ${report.consumerHash} → ${report.referenceHash})`,
+        );
+      }
+    } else {
+      const parts = [];
+      if (report.missing.length > 0) parts.push(plural(report.missing.length, 'missing entry'));
+      if (report.extra.length > 0) parts.push(`${plural(report.extra.length, 'custom hook')} preserved`);
+      const reason = parts.join(', ') || 'reordered';
+      // stdout (not stderr) so Claude sees this in `additionalContext` and
+      // surfaces it to the user — not a mutation since we didn't change anything.
+      try {
+        process.stdout.write(
+          `moflo: hook block drift (${reason}); run \`flo doctor hook-drift\` or set auto_update.hook_block_drift: regenerate in moflo.yaml\n`,
+        );
+      } catch { /* broken stdout — non-fatal */ }
+    }
+  }
+
+  // Regeneration mutated settings.json — re-stat for the fresh mtime so next
+  // session's fast-path matches; otherwise reuse the stat we already have.
+  let finalSettingsMtime = settingsStat.mtimeMs;
+  if (regenerated) {
+    try { finalSettingsMtime = statSync(settingsPath).mtimeMs; } catch { /* keep prior */ }
+  }
+  // After successful regeneration consumerHash matches referenceHash by construction.
+  const finalConsumerHash = regenerated ? report.referenceHash : report.consumerHash;
+
+  return {
+    cachePath,
+    settingsMtimeMs: finalSettingsMtime,
+    moduleMtimeMs: hbhStat.mtimeMs,
+    consumerHash: finalConsumerHash,
+    referenceHash: report.referenceHash,
+  };
+}
+
 try {
   if (autoUpdateConfig.enabled && autoUpdateConfig.hookBlockDrift !== 'off') {
-    const settingsPath = resolve(projectRoot, '.claude', 'settings.json');
-    let settingsRaw;
-    try { settingsRaw = readFileSync(settingsPath, 'utf-8'); } catch { settingsRaw = null; }
-    if (settingsRaw) {
-      const hbhPaths = [
-        resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/hook-block-hash.js'),
-        resolve(projectRoot, 'dist/src/cli/services/hook-block-hash.js'),
-      ];
-      const hbhPath = hbhPaths.find(p => existsSync(p));
-      if (hbhPath) {
-        const settings = JSON.parse(settingsRaw);
-        const mod = await import(`file://${hbhPath.replace(/\\/g, '/')}`);
-        const locked = typeof mod.isHookBlockLocked === 'function' && mod.isHookBlockLocked(settings);
-        if (!locked && typeof mod.computeHookBlockDrift === 'function') {
-          const report = mod.computeHookBlockDrift(settings.hooks || {});
-          if (report.drifted) {
-            const wantRegenerate = autoUpdateConfig.hookBlockDrift === 'regenerate';
-            const safeToRegenerate = wantRegenerate && report.extra.length === 0;
-            if (safeToRegenerate && typeof mod.applyAdditiveRegeneration === 'function') {
-              const { added } = mod.applyAdditiveRegeneration(settings, report);
-              if (added > 0) {
-                writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
-                emitMutation(
-                  'regenerated hook block',
-                  `added ${plural(added, 'missing hook entry')} (drift ${report.consumerHash} → ${report.referenceHash})`,
-                );
-              }
-            } else {
-              const parts = [];
-              if (report.missing.length > 0) parts.push(plural(report.missing.length, 'missing entry'));
-              if (report.extra.length > 0) parts.push(`${plural(report.extra.length, 'custom hook')} preserved`);
-              const reason = parts.join(', ') || 'reordered';
-              // stdout (not stderr) so Claude sees this in `additionalContext` and
-              // can surface it to the user. Not counted as a mutation since we
-              // didn't change anything.
-              try {
-                process.stdout.write(
-                  `moflo: hook block drift (${reason}); run \`flo doctor hook-drift\` or set auto_update.hook_block_drift: regenerate in moflo.yaml\n`,
-                );
-              } catch { /* broken stdout — non-fatal */ }
-            }
-          }
-        }
-      }
+    const result = await runHookBlockDriftCheck();
+    if (result) {
+      try {
+        mkdirSync(mofloDir(projectRoot), { recursive: true });
+        writeFileSync(result.cachePath, JSON.stringify({
+          settingsMtimeMs: result.settingsMtimeMs,
+          moduleMtimeMs: result.moduleMtimeMs,
+          consumerHash: result.consumerHash,
+          referenceHash: result.referenceHash,
+        }));
+      } catch { /* cache is opportunistic — non-fatal */ }
     }
   }
 } catch (err) {


### PR DESCRIPTION
## Summary

Two follow-up improvements to the hook-block drift check shipped in #888.

- **Mtime cache fast-path** — `.moflo/hook-drift-cache.json` keyed on `{settingsMtimeMs, moduleMtimeMs}`. When both mtimes match AND the cached run was clean (`consumerHash === referenceHash`), skip readFile + JSON.parse + dynamic import. Steady-state: 2 stats + 1 cache read + 1 small JSON.parse.
- **Replace `existsSync→import` TOCTOU** — walk dist-module candidates with `statSync` (doubles as existence check + supplies the mtime for the cache key) and wrap the dynamic import in try-catch so the file disappearing between stat and import falls through cleanly.

Also refactored the inline guard chain (was 9-10 levels deep) into a `runHookBlockDriftCheck()` helper using early returns, and switched the hand-rolled Windows path hack `\→/` to `pathToFileURL(...).href`.

## Behaviour

| Scenario | Slow path | Cache write |
|----------|-----------|-------------|
| First run, drifted | yes — emits warning | yes (real hashes) |
| Repeat run, still drifted | yes — re-emits warning | yes (refreshed mtimes) |
| First run, clean | yes — silent | yes (consumerHash === referenceHash) |
| Repeat run, still clean | **no — skipped** | no |
| settings.json edited | yes — re-checks | yes |
| npm install moflo@* (module mtime bump) | yes — re-checks | yes |

## Test plan

- [x] vitest hook-block-hash.test.ts — 15/15 pass
- [x] full npm test — 7752/7752 pass
- [x] Smoke test (drifted state — session-reset custom hook): slow path emits, cache stores drifted hashes, repeat run still emits
- [x] Faked clean cache: fast-path hit confirmed (no output, no cache write)
- [x] Mtime invalidation via utimesSync: triggers slow path again
- [x] flo doctor hook-drift — passes

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)