### PR TITLE
chore(simplify): tier-based fan-out + model routing for cost-aware code review

### DIFF
--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -1,55 +1,103 @@
 ---
-description: Review changed code for reuse, quality, and efficiency, then fix any issues found.
+description: Review changed code for reuse, quality, and efficiency, then fix any issues found. Sizes review effort to the diff and routes the cheapest model that fits.
 ---
 
-# /simplify — Gate-Compliant Code Review
+# /simplify — Adaptive Gate-Compliant Code Review
 
-Review all changed files for reuse opportunities, code quality, and efficiency improvements.
+Review changed code for reuse, quality, and efficiency. **Effort scales with diff size; model is routed for cost.** A 5-line comment trim does not get 3 Opus agents.
 
-**This command overrides any built-in simplify skill.** Follow these steps exactly.
+## Phase 0: Gate prerequisites
 
-## Prerequisites (MANDATORY — do these FIRST)
+These satisfy the memory-first and task-create-first gates. Always do them before any Agent spawn.
 
-1. **Memory search**: Search for relevant patterns before reviewing
-```
-mcp__moflo__memory_search — query: "code quality patterns", namespace: "patterns"
-```
+1. **Memory search** — `mcp__moflo__memory_search — query: "code quality patterns", namespace: "patterns"`
+2. **Task create** — `TaskCreate — subject: "🔍 [Reviewer] Simplify changed code"`
 
-2. **Create task**: Track the simplification work
-```
-TaskCreate — subject: "🔍 [Reviewer] Simplify changed code", description: "Review changed files for reuse, quality, and efficiency"
-```
-
-## Execution
-
-After prerequisites are satisfied, get the list of changed files:
+## Phase 1: Identify the diff
 
 ```bash
-git diff --name-only HEAD~1
+git diff HEAD          # working tree
+git diff main...HEAD   # committed since branch base
 ```
 
-Then launch 3 reviewer agents **in parallel** (single message, multiple Agent tool calls).
+Treat the union as the diff. Note whether `/simplify` already ran on this branch in this session — if so, you are in a **validation pass** (Phase 4 below).
 
-**CRITICAL**: Each agent prompt below includes a mandatory memory search step. This is required because subagents must satisfy the memory-first gate independently before using Glob, Grep, or Read tools. Do NOT remove the memory search from agent prompts.
+## Phase 2: Classify the diff
 
-### Agent 1: Reuse Reviewer
+Pick the smallest tier the diff genuinely fits.
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **TRIVIAL** | ≤10 net LOC, single file, comments/formatting/local renames only | Self-review, zero agents |
+| **SMALL** | ≤200 net LOC, ≤2 files, no API/dependency change | **One agent** (default for most diffs, including critical surface) |
+| **NORMAL** | ≥3 files, OR >200 LOC, OR public API change, OR new/removed dependency, OR cross-cutting refactor | Three parallel agents |
+
+Critical-surface files (launcher, hooks, MCP wiring) raise the *care* of the agent prompt — sharper checklist, blast-radius framing — they do **not** automatically escalate to NORMAL. Risk-weighted ≠ headcount-weighted.
+
+## Phase 3: Route the model (skip for TRIVIAL)
+
+Before spawning any Agent, ask the moflo router which model to use:
+
 ```
-Agent — name: "reuse-reviewer", run_in_background: true, subagent_type: "reviewer", prompt: "FIRST ACTION: Run mcp__moflo__memory_search with query 'code reuse patterns' and namespace 'patterns'. You MUST do this before any Glob, Grep, or Read calls. THEN review these changed files for code reuse opportunities. Look for: duplicated logic that could use existing utilities, patterns already solved elsewhere in the codebase, opportunities to extract shared helpers. Files: $CHANGED_FILES"
+mcp__moflo__hooks_model-route — {
+  task: "Review N-line change in <files> for reuse, quality, efficiency",
+  preferCost: true
+}
 ```
 
-### Agent 2: Quality Reviewer
+**Wording rules:** the router's complexity score is keyword-sensitive. Avoid `refactor`, `architect`, `audit`, `system`, `redesign`, `migrate` — those force opus even when scoring suggests sonnet. State LOC count, file count, and "review for reuse, quality, efficiency". Nothing more.
+
+**Hard rule for `/simplify`: opus is never correct.** Code review never needs Opus reasoning, even on critical surface. If the router returns `opus`, downgrade to `sonnet`. On router failure, default to `sonnet`. Comment trims and pure formatting → `haiku`.
+
+## Phase 4: Validation pass (re-run after fixes from a prior simplify)
+
+If `/simplify` already ran on this branch in this session AND the only edits since are fixes the prior pass surfaced, **default to TRIVIAL self-review** regardless of LOC count. The fan-out happened; the fix is small relative to the already-reviewed diff.
+
+Escalate one tier (self-review → SMALL agent) only if the fix introduced a new file, a new exported symbol, a new dependency, or a control-flow change not covered by the original findings. Never escalate a validation pass to NORMAL.
+
+## Phase 5: Run the appropriate review
+
+### TRIVIAL / Validation
+Run the three category checks (reuse / quality / efficiency) yourself in one pass against the diff. Most TRIVIAL diffs are clean — confirm and exit. Budget: ~30 seconds, no Agent.
+
+### SMALL — one agent
 ```
-Agent — name: "quality-reviewer", run_in_background: true, subagent_type: "reviewer", prompt: "FIRST ACTION: Run mcp__moflo__memory_search with query 'code quality patterns' and namespace 'patterns'. You MUST do this before any Glob, Grep, or Read calls. THEN review these changed files for code quality issues. Look for: unclear naming, overly complex logic, missing error handling at system boundaries, potential bugs, consistency with existing patterns. Files: $CHANGED_FILES"
+Agent — {
+  subagent_type: "reviewer",
+  model: "<sonnet (or haiku for trivial-formatting tier from router)>",
+  prompt: "FIRST ACTION: Run mcp__moflo__memory_search with query 'code review patterns' and namespace 'patterns' to satisfy the memory-first gate. THEN review this diff for reuse, quality, and efficiency. <diff inline>. Flag specific issues as file:line + 1-line description. Max 5 file reads. Under 200 words. Skip cosmetic style. Don't suggest cross-cutting refactors of code outside this diff."
+}
 ```
 
-### Agent 3: Efficiency Reviewer
+For critical-surface files, prepend a 1-line risk note (e.g., "This is `bin/session-start-launcher.mjs` — runs in every consumer's session-start hot path; cross-platform + blast-radius matter."). One careful agent, not three.
+
+### NORMAL — three parallel agents
+Launch three agents in a single message, each at the routed model (typically sonnet). Each agent gets the SMALL-tier tool-budget cap.
+
+- **Agent 1 (Reuse):** existing helpers/utilities that should be used; duplicated patterns; functions re-implementing something already in the codebase.
+- **Agent 2 (Quality):** redundant state, parameter sprawl, copy-paste with variation, leaky abstractions, stringly-typed code, nested conditionals 3+ levels, unnecessary comments.
+- **Agent 3 (Efficiency):** unnecessary work, missed concurrency, hot-path bloat, recurring no-op updates, TOCTOU existence checks, unbounded structures, over-broad reads.
+
+Each agent prompt must start with `FIRST ACTION: mcp__moflo__memory_search ... namespace: "patterns"` — subagents must satisfy the memory-first gate independently before Glob/Grep/Read.
+
+## Phase 6: Fix or skip
+
+Aggregate findings. Fix each issue directly that's worth fixing. False positives or out-of-scope: note and skip without arguing.
+
+If fixes were made, re-run tests to confirm nothing broke. If tests fail after a fix, revert it.
+
+After fixes: the next `/simplify` invocation is a **validation pass** (Phase 4). Bundle related fixes into one batch so a single validation pass covers them — don't re-fan-out for cosmetic micro-corrections.
+
+## Phase 7: Optional — record routing outcome
+
+If you spawned an agent, feed back the outcome so the router learns:
+
 ```
-Agent — name: "efficiency-reviewer", run_in_background: true, subagent_type: "reviewer", prompt: "FIRST ACTION: Run mcp__moflo__memory_search with query 'performance optimization patterns' and namespace 'patterns'. You MUST do this before any Glob, Grep, or Read calls. THEN review these changed files for efficiency improvements. Look for: unnecessary allocations, O(n^2) where O(n) is possible, redundant operations, opportunities to batch or cache. Files: $CHANGED_FILES"
+mcp__moflo__hooks_model-outcome — { task: "...", model: "<chosen>", outcome: "success" | "failure" | "escalated" }
 ```
 
-## Post-Review
+`escalated` only when a real miss happened that a higher tier would have caught — never used to retroactively justify opus.
 
-1. Collect findings from all 3 reviewers
-2. Apply fixes that preserve ALL existing functionality — no behavior changes
-3. If fixes were made, re-run tests to confirm nothing broke
-4. If tests fail after fixes, revert the simplification changes
+## Briefly summarize
+
+End with one or two sentences: which tier ran, which model, what was fixed (or "clean — no changes"). No headers, no bullets.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -5,7 +5,7 @@ description: Review changed code for reuse, quality, and efficiency, then fix an
 
 # /simplify — Adaptive Code Review
 
-Review changed code for reuse opportunities, quality issues, and efficiency improvements. **Effort scales with diff size** — a 5-line comment trim doesn't get the same treatment as a 500-line refactor.
+Review changed code for reuse opportunities, quality issues, and efficiency improvements. **Effort scales with diff size and reuses prior context** — a 5-line comment trim doesn't get the same treatment as a 500-line refactor, and a re-run after fixing pass-1 findings doesn't re-pay for a fresh fan-out.
 
 ## Phase 1: Identify changes
 
@@ -13,9 +13,11 @@ Run `git diff HEAD` (working tree) and `git diff main...HEAD` (committed) to get
 
 Treat the union of staged + unstaged + committed-since-base as the diff to review.
 
+Also note: was `/simplify` already run on this branch in this session? If yes, you're in a **validation pass** (Phase 2.5 below) — most of the heavy lifting is done.
+
 ## Phase 2: Classify the diff
 
-Pick the **smallest tier** the diff genuinely fits. When in doubt, escalate.
+Pick the **smallest tier** the diff genuinely fits. When in doubt, escalate one step (not two).
 
 ### TRIVIAL — self-review, no agent spawn
 ALL of these must hold:
@@ -28,38 +30,103 @@ ALL of these must hold:
 Examples that qualify: trimming a comment, fixing a typo in a log message, renaming a private helper, reformatting a single block.
 Examples that DON'T qualify: changing an `if` condition, reordering function args, deleting a try/catch.
 
-### SMALL — single agent, all three categories
+### SMALL — single agent, all three categories (DEFAULT for most diffs)
 ALL of these must hold:
-- ≤50 net LOC changed
+- ≤200 net LOC changed
 - ≤2 files
 - No structural changes (no new modules, no API additions/removals, no contract changes)
 
-Examples that qualify: extracting a constant, inlining a one-liner, swapping a `for` for a `forEach`, adding one early-return.
+This is the default tier for **most real diffs**, including changes to critical surface (launcher, hooks, MCP wiring). Critical surface raises the *care* of the agent prompt (sharper checklist, blast-radius framing), not the *number* of agents.
 
-### NORMAL — three parallel agents (the original flow)
-Anything that doesn't fit TRIVIAL or SMALL. Includes any diff that:
-- Spans 3+ files
+Examples that qualify: extracting a constant, inlining a one-liner, swapping a `for` for a `forEach`, adding one early-return, refactoring a single function within a file, adding a cache fast-path inside an existing block.
+
+### NORMAL — three parallel agents
+Reserved for **genuinely cross-cutting** changes. ANY of these triggers NORMAL:
+- 3+ files changed
+- >200 net LOC changed
 - Adds/removes/renames a public API
-- Changes control flow in a non-trivial way
 - Introduces or removes a dependency
-- Touches `bin/`, hooks, MCP tool handlers, or anything called out in `CLAUDE.md` as critical surface
+- Cross-cutting refactor (touches the same pattern in multiple modules)
 
-When CLAUDE.md flags a file as critical surface (SessionStart, launcher, hooks, MCP coordinator wiring, swarm/hive-mind), **always escalate to NORMAL** regardless of LOC count. Risk-weighted, not size-weighted.
+Three agents exist to cover orthogonal axes (Reuse / Quality / Efficiency) when the change is broad enough that one agent's tool-call budget can't survey it all. For single-file edits, one focused agent always covers all three axes — three is duplication, not coverage.
+
+## Phase 2.5: Validation pass (re-run after fixes)
+
+If `/simplify` already ran on this branch in this session AND the only edits since are fixes driven by the prior pass's findings, default to **self-review tier** regardless of LOC count. The fan-out already happened; the fix is small relative to the diff that was already reviewed.
+
+Escalate one tier (self-review → SMALL agent) only if the fix introduced any of:
+- A new file
+- A new exported symbol
+- A new dependency or import from a previously-untouched module
+- A change to control flow not covered in the original findings
+
+Do **not** escalate to NORMAL on a validation pass. If the fix is so structural that NORMAL is warranted, treat it as a fresh diff and start over from Phase 1.
+
+## Phase 2.7: Route the model (before any Agent spawn)
+
+For every tier that spawns an Agent (SMALL / NORMAL — TRIVIAL self-review skips this), call the moflo router to pick the cheapest model that fits the task **before** invoking Agent:
+
+```
+mcp__moflo__hooks_model-route — {
+  task: "<diff summary — see wording rules below>",
+  preferCost: true
+}
+```
+
+### Wording the task description
+
+The router's complexity score is keyword-sensitive. Words like `refactor`, `architect`, `audit`, `system`, `redesign`, `migrate` flip a high-complexity flag and force opus *even when scoring suggests sonnet*. For `/simplify` you are **always doing code review**, never genuine architecture, so frame the task accordingly:
+
+- ✅ Good: `"Review 110-line single-file change in bin/session-start-launcher.mjs for reuse, quality, efficiency."`
+- ❌ Bad: `"Review refactor that adds mtime-cache fast-path and architects new caching layer."`
+
+Drop the trigger words. State LOC count, file count, and "review for reuse, quality, efficiency". That's enough signal.
+
+### Applying the result
+
+The router returns `{ model: 'haiku' | 'sonnet' | 'opus', complexity, reasoning, alternatives, ... }`.
+
+**Hard rule for `/simplify`: opus is never correct.** Code review does not require Opus-tier reasoning even on critical surface. If the router returns `opus`:
+
+1. Look at `alternatives` — if `sonnet` scores higher than the selected model's confidence, downgrade to sonnet.
+2. Otherwise, downgrade to sonnet anyway (treat opus as "router was uncertain — pick the safer middle").
+
+Pass the final model verbatim to the Agent's `model` parameter (Agent accepts `'haiku' | 'sonnet' | 'opus'`). On router failure (MCP call errors), default to `'sonnet'`.
+
+In practice: comment trims and pure formatting → haiku; everything else for `/simplify` → sonnet.
+
+### Feed back the outcome
+
+After the agent completes, record the outcome so the router learns:
+
+```
+mcp__moflo__hooks_model-outcome — { task: "<same wording as route call>", model: "<chosen>", outcome: "success" | "failure" | "escalated" }
+```
+
+`escalated` = the agent missed something a higher-tier pass would have caught. That signal teaches the router to bias similar tasks upward next time. Don't fake `escalated` to retroactively justify opus — only record it when a *real* miss happened.
 
 ## Phase 3: Run the appropriate review
 
-### TRIVIAL: self-review
-Run the same three category checks (reuse / quality / efficiency) yourself, in one pass, against the diff. Most TRIVIAL diffs will be clean — the goal is to confirm, not to fan out. If you find an issue, fix it; otherwise stamp clean. Total budget: ~30 seconds, no Agent calls.
+### TRIVIAL / Validation: self-review
+Run the same three category checks (reuse / quality / efficiency) yourself, in one pass, against the diff. Most TRIVIAL and validation diffs will be clean — the goal is to confirm, not to fan out. If you find an issue, fix it; otherwise stamp clean. Total budget: ~30 seconds, no Agent calls. No router call needed.
 
-### SMALL: one agent
-Launch a SINGLE Agent with subagent_type `reviewer` covering all three categories in one prompt. Pass the diff inline. Budget: ~1 minute.
+### SMALL: one agent (model from router)
+Launch a SINGLE Agent with subagent_type `reviewer`, passing the model returned by Phase 2.7's router call. Cap the agent's tool budget by being explicit:
 
 ```
-Agent — subagent_type: "reviewer", prompt: "Review this diff for reuse, quality, and efficiency. <diff inline>. Flag specific issues with file:line; skip generic advice. Under 200 words."
+Agent — {
+  subagent_type: "reviewer",
+  model: "<from router, typically 'sonnet'>",
+  prompt: "Review this diff for reuse, quality, and efficiency. <diff inline>. Flag specific issues as file:line + 1-line description. Max 5 file reads. Under 200 words. Skip cosmetic style. Don't suggest cross-cutting refactors of code outside this diff."
+}
 ```
 
-### NORMAL: three parallel agents (original flow)
-Launch three agents in a single message — Reuse, Quality, Efficiency — passing the full diff to each. Use the original flow's category checklists.
+For critical-surface files, prepend a 1-line risk note to the prompt (e.g., "This is `bin/session-start-launcher.mjs` — runs in every consumer's session-start hot path; cross-platform + blast-radius matter."). One careful agent, not three.
+
+Budget: ~1 minute.
+
+### NORMAL: three parallel agents (model from router, applied to all)
+Launch three agents in a single message — Reuse, Quality, Efficiency — passing the full diff and the same routed `model` to each. Each agent gets the same tool-budget cap as SMALL.
 
 **Reuse**: existing helpers/utilities that should be used instead; duplicated patterns; new functions that re-implement something already in the codebase.
 
@@ -69,14 +136,16 @@ Launch three agents in a single message — Reuse, Quality, Efficiency — passi
 
 ## Phase 4: Fix or skip
 
-Aggregate findings. Fix each one directly. False positives or not-worth-fixing — note and skip without arguing. If TRIVIAL self-review found nothing, just confirm clean and exit.
+Aggregate findings. Fix each one directly. False positives or not-worth-fixing — note and skip without arguing. If self-review found nothing, just confirm clean and exit.
 
 If fixes were made, re-run tests to confirm nothing broke. If tests fail after a fix, revert it.
 
+After fixes: the next `/simplify` invocation is a **validation pass** (Phase 2.5). Do not re-fan-out unless the fix added genuinely new concerns — bundle related fixes into one batch so a single validation pass covers them.
+
 ## Phase 5: Stamp the gate
 
-Whatever tier ran, the gate (`check-before-pr`) registers /simplify as having executed. The skill is satisfied.
+Whatever tier ran, the gate (`check-before-pr`) registers /simplify as having executed. The skill is satisfied. Self-review counts.
 
 ## Briefly summarize
 
-End with one or two sentences: which tier, what was fixed (or "clean — no changes"). No headers, no bullets unless needed.
+End with one or two sentences: which tier ran, what was fixed (or "clean — no changes"). No headers, no bullets unless needed.


### PR DESCRIPTION
## Summary

Reduce `/simplify` token cost by ~60-75% in the steady state through three behavioral changes:

1. **SMALL (1 agent) is the default for most diffs.** Critical-surface files (launcher, hooks, MCP wiring) raise the *care* of the prompt, not the *number* of agents. NORMAL (3 parallel) is reserved for genuinely cross-cutting changes (≥3 files, >200 LOC, public API changes, dependency changes, cross-cutting refactors).
2. **Validation-pass tier added.** When `/simplify` is re-invoked after fixes from a prior pass, default to TRIVIAL self-review regardless of LOC count. Stops the \"loop tax\" of re-fanning 3 agents to validate cosmetic micro-fixes.
3. **Model routing via `mcp__moflo__hooks_model-route`.** Sonnet for review, Haiku for trivial formatting, opus *never* (hard rule — code review doesn't need opus reasoning even on critical surface). Includes wording guidance so the router's keyword-sensitive complexity score doesn't force opus on review tasks.

Both `.claude/skills/simplify/SKILL.md` (Skill-tool entry) and `.claude/commands/simplify.md` (slash-command override) updated. The override file previously hardcoded 3-agent fan-out and ignored the SKILL tier system — that was the dominant path users actually hit, so updating only SKILL.md would have left the bug in place.

## Context

A single night of work hit \$200 in tokens, primarily from `/simplify` repeatedly fanning out 3 Opus agents on small single-file diffs. This PR addresses #1 and #2 from the post-mortem; #3 (router wiring) was added on user request after confirming `mcp__moflo__hooks_model-route` and `AGENT_TYPE_MODEL_DEFAULTS` already exist — they just weren't being called from this skill.

## Side-finding

Smoke-testing the router during this work surfaced **#890** (router returns opus despite higher sonnet alternative score). The `/simplify` skill ships with an opus→sonnet downgrade workaround until that's fixed.

## Test plan

- [x] Skill files validated against existing TaskCreate / memory_search gate flow
- [x] Smoke-tested router with three task descriptions (comment trim → haiku ✓; code review → opus pending #890; SaaS auth architecture → opus ✓)
- [x] Confirmed both files load via Skill tool surface listing

## Estimated savings

Per `/simplify` invocation:
- 3-agent NORMAL → 1-agent SMALL: ~67% reduction in agent overhead
- Opus → Sonnet model: ~80% reduction in per-token cost
- Compound: ~75% reduction in steady-state simplify cost
- Plus: validation-pass tier eliminates re-fan-out for cosmetic micro-fixes (was happening 2-3× per change cycle this session)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)