### PR TITLE
chore(config): default model_routing.enabled=true; review default sonnet not opus

### DIFF
--- a/moflo.yaml
+++ b/moflo.yaml
@@ -78,17 +78,19 @@ status_line:
   show_mcp: true
 
 # Model preferences (haiku, sonnet, opus)
+# These are static fallbacks. When model_routing.enabled is true (default),
+# the dynamic router takes precedence based on task complexity.
 models:
-  default: opus        # Model for general tasks
+  default: opus        # Model for general tasks (kept high for unknowns)
   research: sonnet     # Model for research/exploration agents
-  review: opus         # Model for code review agents
+  review: sonnet       # Code review never needs opus reasoning
   test: sonnet         # Model for test-writing agents
 
 # Intelligent model routing (auto-selects haiku/sonnet/opus per task)
 # When enabled, overrides the static model preferences above
 # by analyzing task complexity and routing to the cheapest capable model.
 model_routing:
-  enabled: false                   # Set to true to enable dynamic routing
+  enabled: true                    # Set to false to pin to the static models above
   confidence_threshold: 0.85       # Min confidence before escalating to a more capable model
   cost_optimization: true          # Prefer cheaper models when confidence is high
   circuit_breaker: true            # Penalize models that fail repeatedly

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -175,11 +175,11 @@ const DEFAULT_CONFIG: MofloConfig = {
   models: {
     default: 'opus',
     research: 'sonnet',
-    review: 'opus',
+    review: 'sonnet',
     test: 'sonnet',
   },
   model_routing: {
-    enabled: false,
+    enabled: true,
     confidence_threshold: 0.85,
     cost_optimization: true,
     circuit_breaker: true,
@@ -526,7 +526,7 @@ models:
 # When enabled, overrides the static model preferences above
 # by analyzing task complexity and routing to the cheapest capable model.
 model_routing:
-  enabled: false                   # Set to true to enable dynamic routing
+  enabled: true                    # Set to false to pin to the static models above
   confidence_threshold: 0.85       # Min confidence before escalating to a more capable model
   cost_optimization: true          # Prefer cheaper models when confidence is high
   circuit_breaker: true            # Penalize models that fail repeatedly

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -438,17 +438,19 @@ status_line:
   show_mcp: true
 
 # Model preferences (haiku, sonnet, opus)
+# These are static fallbacks. When model_routing.enabled is true (default),
+# the dynamic router takes precedence based on task complexity.
 models:
-  default: opus        # Model for general tasks
+  default: opus        # Model for general tasks (kept high for unknowns)
   research: sonnet     # Model for research/exploration agents
-  review: opus         # Model for code review agents
+  review: sonnet       # Code review never needs opus reasoning
   test: sonnet         # Model for test-writing agents
 
 # Intelligent model routing (auto-selects haiku/sonnet/opus per task)
 # When enabled, overrides the static model preferences above
 # by analyzing task complexity and routing to the cheapest capable model.
 model_routing:
-  enabled: false                   # Set to true to enable dynamic routing
+  enabled: true                    # Set to false to pin to the static models above
   confidence_threshold: 0.85       # Min confidence before escalating to a more capable model
   cost_optimization: true          # Prefer cheaper models when confidence is high
   circuit_breaker: true            # Penalize models that fail repeatedly


### PR DESCRIPTION
## Summary

Two related defaults flipped to drive cost-aware routing for all consumers, not just this repo.

| Setting | Before | After | Why |
|---------|--------|-------|-----|
| `model_routing.enabled` | `false` | `true` | The router has been in place since `src/cli/movector/model-router.ts` shipped — was gated off by default. Flipping it means new consumers get dynamic routing out of the box. |
| `models.review` | `opus` | `sonnet` | Code review never needs opus reasoning. Same anti-pattern `/simplify` (#892) worked around with a downgrade rule — this fixes the default at the source. |

Tests were already `sonnet`. This brings the sibling `review` default in line.

## Three locations updated

- `src/cli/config/moflo-config.ts` — `DEFAULT_CONFIG` + yaml template
- `src/cli/init/moflo-init.ts` — yaml template generated by `flo init`
- `moflo.yaml` — this repo's local config (dogfood)

## Consumer impact (ships via npm to every install)

- Consumers with **no explicit \`model_routing\` block**: pick up \`enabled=true\` automatically on next session-start (parser falls back to DEFAULT_CONFIG).
- Consumers with **explicit \`enabled: false\`**: keep their setting — explicit overrides honored. They opted out deliberately; we don't override.
- Consumers with **explicit \`enabled: true\`**: no change.

Same for \`models.review\`. Explicit \`review: opus\` is preserved; absent settings inherit the new sonnet default.

## Test plan

- [x] \`npm run build\` — clean tsc
- [x] config tests — 39/39 pass
- [x] full \`npm test\` — 7752/7752 pass

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)