### PR TITLE
fix(886): register bin/ build-embeddings spawns with ProcessManager

### DIFF
--- a/bin/index-guidance.mjs
+++ b/bin/index-guidance.mjs
@@ -28,6 +28,7 @@ import { fileURLToPath } from 'url';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath } from './lib/moflo-paths.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
+import { createProcessManager } from './lib/process-manager.mjs';
 const initSqlJs = (await import(mofloResolveURL('sql.js'))).default;
 
 
@@ -872,36 +873,25 @@ if (!skipEmbeddings && needsEmbeddings) {
   console.log('');
   log('Spawning embedding generation in background...');
 
-  const { spawn } = await import('child_process');
-
   const embeddingScript = resolveMofloBin(
     projectRoot, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true },
   );
 
   if (embeddingScript) {
-    const embeddingArgs = ['--namespace', NAMESPACE];
-
-    // Create log file for background process output
-    const logDir = resolve(projectRoot, '.moflo/logs');
-    if (!existsSync(logDir)) {
-      mkdirSync(logDir, { recursive: true });
+    // Register the spawn with the shared ProcessManager (#886). Stdout/stderr
+    // route through `.swarm/background.log` (pm.spawn default) instead of the
+    // bespoke `.moflo/logs/embeddings.log` so the registry, dedup, and
+    // session-end drain stay consistent with every other tracked spawn.
+    const pm = createProcessManager(projectRoot);
+    const result = pm.spawn('node', [embeddingScript, '--namespace', NAMESPACE], `build-embeddings-${NAMESPACE}`);
+    if (result.skipped) {
+      log(`Background embedding already running (PID: ${result.pid})`);
+    } else if (result.pid) {
+      log(`Background embedding started (PID: ${result.pid})`);
+      log(`Log file: .swarm/background.log`);
+    } else {
+      log('⚠️  Failed to spawn background embedding');
     }
-    const logFile = resolve(logDir, 'embeddings.log');
-    const { openSync } = await import('fs');
-    const out = openSync(logFile, 'a');
-    const err = openSync(logFile, 'a');
-
-    // Spawn in background - don't wait for completion
-    const proc = spawn('node', [embeddingScript, ...embeddingArgs], {
-      stdio: ['ignore', out, err],
-      cwd: projectRoot,
-      detached: true,
-      windowsHide: true  // Suppress command windows on Windows
-    });
-    proc.unref();  // Allow parent to exit independently
-
-    log(`Background embedding started (PID: ${proc.pid})`);
-    log(`Log file: .moflo/logs/embeddings.log`);
   } else {
     log('⚠️  Embedding script not found, skipping embedding generation');
   }

--- a/bin/index-patterns.mjs
+++ b/bin/index-patterns.mjs
@@ -27,11 +27,11 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { resolve, dirname, relative, basename, extname } from 'path';
 import { fileURLToPath } from 'url';
-import { spawn } from 'child_process';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { mofloResolveURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, MOFLO_DIR } from './lib/moflo-paths.mjs';
 import { applyIncrementalChunks, computeContentListHash } from './lib/incremental-write.mjs';
+import { createProcessManager } from './lib/process-manager.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -342,20 +342,23 @@ async function main() {
   // Save hash
   writeFileSync(HASH_CACHE_PATH, currentHash, 'utf-8');
 
-  // Trigger embedding generation in background
+  // Trigger embedding generation in background. Register with the shared
+  // ProcessManager (#886) so doctor's zombie scan allowlists it and the
+  // session-end / smoke-teardown drain reaps it. Stable label dedupes against
+  // the index-all chain's later `build-embeddings` step when both run within
+  // the same lock window.
   try {
     const embeddingScript = resolveMofloBin(
       projectRoot, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true },
     );
     if (embeddingScript) {
-      const child = spawn('node', [embeddingScript, '--namespace', NAMESPACE], {
-        cwd: projectRoot,
-        detached: true,
-        stdio: 'ignore',
-        windowsHide: true,
-      });
-      child.unref();
-      debug('Embedding generation started in background');
+      const pm = createProcessManager(projectRoot);
+      const result = pm.spawn('node', [embeddingScript, '--namespace', NAMESPACE], `build-embeddings-${NAMESPACE}`);
+      if (result.skipped) {
+        debug(`Embedding generation already running (PID: ${result.pid})`);
+      } else if (result.pid) {
+        debug(`Embedding generation started in background (PID: ${result.pid})`);
+      }
     }
   } catch { /* ignore */ }
 

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -443,10 +443,6 @@ const SMOKE_ALLOWED_DOCTOR_WARNINGS = [
   'Hook Block Drift', // settings.json not found in fresh fixture (warn since #888)
   'Semantic Quality', // empty DB, no patterns yet
   'Disk Space',       // macOS GitHub runner is constantly >80% used (warn threshold)
-  'Zombie Processes', // #886 — transient false-positive on Windows during smoke;
-                      // real registration fixes shipped for the two known TS
-                      // spawn paths but a third path still produces a brief
-                      // orphan that's gone before we can identify it.
 ];
 
 export function doctor(consumerDir) {

--- a/tests/bin/index-embeddings-pm-registration.test.ts
+++ b/tests/bin/index-embeddings-pm-registration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression tests for #886 — index-patterns.mjs and index-guidance.mjs must
+ * register their detached `build-embeddings.mjs` background spawns with the
+ * shared ProcessManager (`bin/lib/process-manager.mjs`).
+ *
+ * Before this fix both files used raw `spawn(..., { detached: true })` with
+ * `child.unref()`. The resulting `node build-embeddings.mjs` PIDs:
+ *
+ *   1. matched doctor's `findZombieProcesses` regex (cmdline contains "moflo")
+ *   2. had a dead immediate parent (the index-*.mjs script exited before the
+ *      embedding job finished)
+ *   3. were NOT in `.moflo/background-pids.json`, so doctor's tracked-PID
+ *      allowlist did not skip them
+ *
+ * Result: a transient `⚠ Zombie Processes` warning on `flo doctor --strict`
+ * during smoke / first-session-after-install.
+ *
+ * The fix is to spawn through `createProcessManager(...).spawn(...)` so each
+ * PID is registered, deduped, and reaped at session-end / smoke teardown.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const BIN = resolve(__dirname, '../../bin');
+
+describe('bin/index-patterns.mjs background-embedding spawn (#886)', () => {
+  const file = resolve(BIN, 'index-patterns.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('imports createProcessManager from process-manager.mjs', () => {
+    expect(src).toMatch(/from\s+['"]\.\/lib\/process-manager\.mjs['"]/);
+    expect(src).toMatch(/createProcessManager/);
+  });
+
+  it('does NOT import raw `spawn` from child_process', () => {
+    // Raw spawn import re-introduces the zombie-flagging path. The shared
+    // pm.spawn helper is the only sanctioned way to start a background
+    // moflo node process from this file.
+    expect(src).not.toMatch(/from\s+['"]child_process['"]/);
+  });
+
+  it('does NOT call raw spawn() (detached or otherwise)', () => {
+    // Defence in depth — even without an import, `await import('child_process')`
+    // would re-introduce the regression. Match any `spawn(` token NOT preceded
+    // by `pm.` or `.spawn` (which is the sanctioned ProcessManager helper).
+    const stripComments = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    expect(stripComments).not.toMatch(/(?<!\.)\bspawn\s*\(/);
+  });
+
+  it('uses pm.spawn with a stable namespace-derived label', () => {
+    // The label must be stable so dedup correctly skips a second spawn from
+    // index-all.mjs's later `build-embeddings` step within the lock window.
+    expect(src).toMatch(/pm\.spawn\s*\(/);
+    expect(src).toMatch(/build-embeddings-\$\{NAMESPACE\}/);
+  });
+});
+
+describe('bin/index-guidance.mjs background-embedding spawn (#886)', () => {
+  const file = resolve(BIN, 'index-guidance.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('imports createProcessManager from process-manager.mjs', () => {
+    expect(src).toMatch(/from\s+['"]\.\/lib\/process-manager\.mjs['"]/);
+    expect(src).toMatch(/createProcessManager/);
+  });
+
+  it('does NOT dynamically import child_process for the embedding spawn', () => {
+    // The previous code did `const { spawn } = await import('child_process')`
+    // immediately before the detached spawn. That path is gone.
+    expect(src).not.toMatch(/await\s+import\s*\(\s*['"]child_process['"]\s*\)/);
+  });
+
+  it('does NOT call raw spawn() (detached or otherwise)', () => {
+    const stripComments = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    expect(stripComments).not.toMatch(/(?<!\.)\bspawn\s*\(/);
+  });
+
+  it('uses pm.spawn with a stable namespace-derived label', () => {
+    expect(src).toMatch(/pm\.spawn\s*\(/);
+    expect(src).toMatch(/build-embeddings-\$\{NAMESPACE\}/);
+  });
+});
+
+describe('harness/consumer-smoke/lib/checks.mjs (#886 follow-up)', () => {
+  const file = resolve(__dirname, '../../harness/consumer-smoke/lib/checks.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('does NOT allowlist `Zombie Processes` (root cause is fixed)', () => {
+    // Allowlist removal is part of the ticket's acceptance criteria — keeping
+    // the entry would mask a regression of the underlying registration bug.
+    const allowlist = src.match(/SMOKE_ALLOWED_DOCTOR_WARNINGS\s*=\s*\[([\s\S]*?)\]/);
+    expect(allowlist, 'allowlist constant must exist').toBeTruthy();
+    expect(allowlist![1]).not.toMatch(/['"]Zombie Processes['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

- Identified the "third unidentified spawn path" causing transient `⚠ Zombie Processes` warnings on Windows during smoke: actually two paths in `bin/` — `index-patterns.mjs:351` and `index-guidance.mjs:895`. Both fire `node build-embeddings.mjs --namespace <ns>` with `detached: true`/`child.unref()` and never register with ProcessManager.
- Switched both spawns to the shared `createProcessManager(projectRoot).spawn(...)` helper from `bin/lib/process-manager.mjs`. Stable labels (`build-embeddings-${NAMESPACE}`) dedupe correctly against the index-all chain's later `build-embeddings` step within the same lock window.
- Removed the `Zombie Processes` allowlist from `harness/consumer-smoke/lib/checks.mjs` — root cause is fixed, so masking the symptom would only hide a future regression.
- Added `tests/bin/index-embeddings-pm-registration.test.ts` with source-level invariants on both files (no raw spawn, pm.spawn used, namespace-derived label) and a guard that the smoke allowlist no longer contains the entry.

## Why this is the fix

The 4.9.11 PR (commit 73c1dcca7) registered the two TS auto-start daemon paths and added the tracked-PID allowlist to `findZombieProcesses`, but the `bin/` indexer chain still fired unregistered detached children. The patterns one fires every session-start in a fresh consumer, which is exactly when smoke runs `flo doctor --strict`.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run tests/bin/index-embeddings-pm-registration.test.ts` — 9/9 pass
- [x] `npx vitest run tests/bin/process-manager.test.ts tests/bin/session-start-embedding-race.test.ts` — 22/22 pass (no regression on the existing PM + race coverage)
- [x] `npm test` — full suite 7761/0
- [ ] Smoke verification on Windows (`npm run test:smoke`) — to be re-run on this branch; if a still-deeper transient surfaces we'll restore the allowlist with a follow-up issue, but local testing on the dogfood project did not reproduce the warning after these registrations land.

Closes #886

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)