### PR TITLE
fix(890): use pathToFileURL for dynamic import() in bin/

### DIFF
--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -22,7 +22,7 @@
 import { spawn } from 'child_process';
 import { existsSync, appendFileSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { createProcessManager } from './lib/process-manager.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
@@ -520,7 +520,7 @@ let _getDaemonLockHolder = null;
 try {
   const daemonLockPath = resolve(__dirname, '..', 'src', '@claude-flow', 'cli', 'dist', 'src', 'services', 'daemon-lock.js');
   if (existsSync(daemonLockPath)) {
-    const mod = await import('file://' + daemonLockPath.replace(/\\/g, '/'));
+    const mod = await import(pathToFileURL(daemonLockPath).href);
     _getDaemonLockHolder = mod.getDaemonLockHolder;
   }
 } catch { /* fallback below */ }

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -409,7 +409,7 @@ try {
         ];
         const cherryPickPath = cherryPickPaths.find((p) => existsSync(p));
         if (cherryPickPath) {
-          const mod = await import(`file://${cherryPickPath.replace(/\\/g, '/')}`);
+          const mod = await import(pathToFileURL(cherryPickPath).href);
           if (typeof mod.cherryPickLearningsFromLegacy === 'function') {
             const result = await mod.cherryPickLearningsFromLegacy({ projectRoot });
             if (result.copied > 0) {
@@ -858,7 +858,7 @@ try {
       ];
       const hwPath = hwPaths.find(p => existsSync(p));
       if (hwPath) {
-        const mod = await import(`file://${hwPath.replace(/\\/g, '/')}`);
+        const mod = await import(pathToFileURL(hwPath).href);
         if (typeof mod.rewriteIncorrectHookWiring === 'function') {
           const { rewrites } = mod.rewriteIncorrectHookWiring(settings);
           if (rewrites.length > 0) {
@@ -1116,7 +1116,7 @@ try {
   const upgraderPath = upgraderPaths.find((p) => existsSync(p));
   const mofloYaml = resolve(projectRoot, 'moflo.yaml');
   if (upgraderPath && existsSync(mofloYaml)) {
-    const { ensureYamlSections } = await import(`file://${upgraderPath.replace(/\\/g, '/')}`);
+    const { ensureYamlSections } = await import(pathToFileURL(upgraderPath).href);
     const appended = ensureYamlSections(mofloYaml);
     if (Array.isArray(appended) && appended.length > 0) {
       emitMutation(
@@ -1135,7 +1135,7 @@ try {
   const localShimLib = resolve(projectRoot, 'bin/lib/install-global-shim.mjs');
   const shimPath = existsSync(shimLib) ? shimLib : existsSync(localShimLib) ? localShimLib : null;
   if (shimPath) {
-    const { installGlobalShim } = await import(`file://${shimPath.replace(/\\/g, '/')}`);
+    const { installGlobalShim } = await import(pathToFileURL(shimPath).href);
     const shimResult = installGlobalShim({ silent: true });
     if (shimResult?.installed) {
       emitMutation('installed global flo shim', 'bare `flo` now resolves to project install');
@@ -1162,7 +1162,7 @@ try {
   ];
   const migrationPath = migrationPaths.find((p) => existsSync(p));
   if (migrationPath) {
-    const mod = await import(`file://${migrationPath.replace(/\\/g, '/')}`);
+    const mod = await import(pathToFileURL(migrationPath).href);
     if (typeof mod.runEmbeddingsMigrationIfNeeded === 'function') {
       await mod.runEmbeddingsMigrationIfNeeded({
         out: process.stderr,
@@ -1198,7 +1198,7 @@ try {
   ];
   const purgePath = purgePaths.find((p) => existsSync(p));
   if (purgePath) {
-    const { purgeSoftDeletedEntries } = await import(`file://${purgePath.replace(/\\/g, '/')}`);
+    const { purgeSoftDeletedEntries } = await import(pathToFileURL(purgePath).href);
     const result = await purgeSoftDeletedEntries();
     if (result?.purged > 0) {
       emitMutation(
@@ -1230,7 +1230,7 @@ try {
   ];
   const purgePath = purgePaths.find((p) => existsSync(p));
   if (purgePath) {
-    const { purgeEphemeralNamespaces } = await import(`file://${purgePath.replace(/\\/g, '/')}`);
+    const { purgeEphemeralNamespaces } = await import(pathToFileURL(purgePath).href);
     const result = await purgeEphemeralNamespaces();
     if (result?.purged > 0) {
       emitMutation(

--- a/tests/bin/path-to-file-url.test.ts
+++ b/tests/bin/path-to-file-url.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression guard for #890 — every dynamic `import()` of a path-resolved
+ * module in `bin/` MUST use Node's `pathToFileURL` primitive instead of the
+ * hand-rolled `file://${path.replace(/\\/g, '/')}` pattern.
+ *
+ * The hand-rolled pattern misbehaves for paths containing `%`, `#`, `?`,
+ * spaces, UNC prefixes, or non-Latin-1 components — silently importing the
+ * wrong module or throwing at parse time. `pathToFileURL` percent-encodes
+ * correctly and round-trips through Node's URL machinery.
+ *
+ * Scope: every file under `bin/` (mjs, cjs, js). Lib helpers are included —
+ * the rule is uniform.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, join, extname } from 'path';
+
+const BIN_DIR = resolve(__dirname, '../../bin');
+
+function listScripts(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...listScripts(full));
+    } else if (['.mjs', '.cjs', '.js'].includes(extname(entry))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const scripts = listScripts(BIN_DIR);
+
+describe('bin/ scripts must use pathToFileURL for dynamic import (#890)', () => {
+  it('no `file://${path.replace(/\\\\/g, "/")}` template literals', () => {
+    const offenders: string[] = [];
+    for (const file of scripts) {
+      const src = readFileSync(file, 'utf-8');
+      // Match: `file://${...replace(/\\/g, '/')...}` template literal
+      if (/`file:\/\/\$\{[^}]*replace\s*\(\s*\/\\\\\/g[^}]*\}/.test(src)) {
+        offenders.push(file);
+      }
+    }
+    expect(offenders, 'use pathToFileURL(p).href instead').toEqual([]);
+  });
+
+  it('no `"file://" + path.replace(...)` string concatenation', () => {
+    const offenders: string[] = [];
+    for (const file of scripts) {
+      const src = readFileSync(file, 'utf-8');
+      // Match: 'file://' + something.replace(/\\/g, '/')
+      if (/['"]file:\/\/['"]\s*\+\s*[^;]*\.replace\s*\(\s*\/\\\\\/g/.test(src)) {
+        offenders.push(file);
+      }
+    }
+    expect(offenders, 'use pathToFileURL(p).href instead').toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaced 8 hand-rolled `\`file://${path.replace(/\/g, '/')}\`` patterns with `pathToFileURL(path).href` (Node stdlib).
- 7 sites in `bin/session-start-launcher.mjs`, 1 in `bin/hooks.mjs`. Added the `pathToFileURL` named import to `hooks.mjs`; the launcher already had it post-#889.
- New regression guard `tests/bin/path-to-file-url.test.ts` walks every script under `bin/` and rejects both the template-literal and string-concat forms.

## Why

The hand-rolled pattern only handles backslashes — it skips URI encoding entirely. Concretely broken:

- Paths with `%`, `#`, `?`, or spaces — not URI-encoded → `import()` fails or resolves wrong target
- UNC paths (`\\server\share\...`) → collapse to `file://server/share` which Node rejects
- Drive-letter casing (`C:` vs `c:`) → distinct URL strings → same module loaded twice in the ESM cache
- Non-Latin-1 components → fail under strict URL parsing

`pathToFileURL` handles all four correctly.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run tests/bin/path-to-file-url.test.ts` — 2/2 pass (regression guard)
- [x] `npx vitest run tests/bin/` — 185/185 pass
- [x] `npm test` — full suite 7763/0
- [x] `node --check` clean on both modified scripts

Closes #890

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)