### PR TITLE
fix(891): stop force-escalating sonnet→opus on uncertainty in model router

### DIFF
--- a/src/cli/__tests__/movector/model-router.test.ts
+++ b/src/cli/__tests__/movector/model-router.test.ts
@@ -1,0 +1,200 @@
+/**
+ * ModelRouter — selection-bias regression tests for issue #891.
+ *
+ * These exercise the public `route()` API to ensure:
+ *   1. preferCost / preferSpeed are honored
+ *   2. The router does NOT force-escalate sonnet → opus on uncertainty alone
+ *   3. Real-architecture tasks (≥2 high-complexity indicators) still pick opus
+ *   4. The legacy `route(task, embedding[])` second-arg form still works
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ModelRouter, type ClaudeModel } from '../../movector/model-router';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('ModelRouter selection (issue #891)', () => {
+  let router: ModelRouter;
+  let tmpStateDir: string;
+
+  beforeEach(() => {
+    // Isolate persistent state under a temp dir so tests don't pollute .swarm/
+    tmpStateDir = mkdtempSync(join(tmpdir(), 'moflo-router-test-'));
+    router = new ModelRouter({
+      statePath: join(tmpStateDir, 'state.json'),
+      autoSaveInterval: 1_000_000, // effectively disable auto-save
+    });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpStateDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  describe('AC1 — no force-escalate to opus on uncertainty', () => {
+    it('returns sonnet for plain code-review task (the bug repro)', async () => {
+      const result = await router.route(
+        'Review 110-line single-file change in bin/session-start-launcher.mjs for reuse, quality, efficiency.'
+      );
+      expect(result.model).toBe('sonnet');
+    });
+
+    it('does not escalate single-keyword "audit" tasks to opus', async () => {
+      const result = await router.route('Audit findings in this report.');
+      expect(result.model).not.toBe('opus');
+    });
+
+    it('does not escalate single-keyword "review" tasks to opus', async () => {
+      const result = await router.route('Review the diff in module.ts.');
+      expect(result.model).not.toBe('opus');
+    });
+  });
+
+  describe('AC2 — preferCost honors cheaper competitive model', () => {
+    it('picks sonnet when preferCost is true on the bug repro', async () => {
+      const result = await router.route(
+        'Review 110-line single-file change in bin/session-start-launcher.mjs for reuse, quality, efficiency.',
+        { preferCost: true }
+      );
+      expect(result.model).toBe('sonnet');
+    });
+
+    it('picks the cheaper model when two scores are within 0.1', async () => {
+      // Synthetic scores: opus 0.80, sonnet 0.78, haiku 0.10 — within window 0.1.
+      // preferCost should pick sonnet (cheaper) over opus.
+      const scores = { haiku: 0.1, sonnet: 0.78, opus: 0.8, inherit: 0 } as Record<
+        ClaudeModel,
+        number
+      >;
+      const complexity = {
+        score: 0.5,
+        indicators: { high: [], medium: [], low: [] },
+        features: {
+          lexicalComplexity: 0,
+          semanticDepth: 0,
+          taskScope: 0,
+          uncertaintyLevel: 0,
+        },
+      };
+      // Access private selectModel via type assertion (test-only).
+      const select = (router as unknown as {
+        selectModel: (
+          s: Record<ClaudeModel, number>,
+          c: typeof complexity,
+          o: { preferCost?: boolean }
+        ) => { model: ClaudeModel };
+      }).selectModel.bind(router);
+
+      const out = select(scores, complexity, { preferCost: true });
+      expect(out.model).toBe('sonnet');
+    });
+
+    it('does NOT pick a much-lower-scoring cheap model (only within window)', async () => {
+      // Synthetic: opus 0.80, sonnet 0.50, haiku 0.40 — sonnet outside 0.1 window.
+      const scores = { haiku: 0.4, sonnet: 0.5, opus: 0.8, inherit: 0 } as Record<
+        ClaudeModel,
+        number
+      >;
+      const complexity = {
+        score: 0.7,
+        indicators: { high: [], medium: [], low: [] },
+        features: {
+          lexicalComplexity: 0,
+          semanticDepth: 0,
+          taskScope: 0,
+          uncertaintyLevel: 0,
+        },
+      };
+      const select = (router as unknown as {
+        selectModel: (
+          s: Record<ClaudeModel, number>,
+          c: typeof complexity,
+          o: { preferCost?: boolean }
+        ) => { model: ClaudeModel };
+      }).selectModel.bind(router);
+
+      const out = select(scores, complexity, { preferCost: true });
+      expect(out.model).toBe('opus');
+    });
+  });
+
+  describe('AC3 — real architecture still escalates to opus', () => {
+    it('picks opus for "architect new auth system across 12 services"', async () => {
+      const result = await router.route(
+        'architect new auth system across 12 services'
+      );
+      expect(result.model).toBe('opus');
+    });
+
+    it('picks opus for "design distributed consensus algorithm with Byzantine fault tolerance"', async () => {
+      const result = await router.route(
+        'design distributed consensus algorithm with Byzantine fault tolerance'
+      );
+      expect(result.model).toBe('opus');
+    });
+
+    it('respects preferCost even on architecture tasks (cheaper-within-window)', async () => {
+      // With preferCost, an architecture task picks the cheapest competitive model.
+      // We assert it's NOT opus when sonnet is within 0.1 of opus's score.
+      const result = await router.route(
+        'architect new auth system across 12 services',
+        { preferCost: true }
+      );
+      expect(result.model).not.toBe('opus');
+    });
+  });
+
+  describe('AC4 — legacy embedding[] second-arg still works', () => {
+    it('accepts a number[] as the legacy embedding parameter', async () => {
+      const embedding = new Array(64).fill(0).map((_, i) => i / 64);
+      const result = await router.route('simple task', embedding);
+      expect(result).toHaveProperty('model');
+      expect(result).toHaveProperty('complexity');
+    });
+  });
+
+  describe('preferSpeed mirror behaviour', () => {
+    it('picks the faster model when scores are within 0.1', () => {
+      const scores = { haiku: 0.78, sonnet: 0.8, opus: 0.4, inherit: 0 } as Record<
+        ClaudeModel,
+        number
+      >;
+      const complexity = {
+        score: 0.3,
+        indicators: { high: [], medium: [], low: [] },
+        features: {
+          lexicalComplexity: 0,
+          semanticDepth: 0,
+          taskScope: 0,
+          uncertaintyLevel: 0,
+        },
+      };
+      const select = (router as unknown as {
+        selectModel: (
+          s: Record<ClaudeModel, number>,
+          c: typeof complexity,
+          o: { preferSpeed?: boolean }
+        ) => { model: ClaudeModel };
+      }).selectModel.bind(router);
+
+      const out = select(scores, complexity, { preferSpeed: true });
+      expect(out.model).toBe('haiku');
+    });
+  });
+
+  describe('result shape', () => {
+    it('reports the selected model in costMultiplier and excludes it from alternatives', async () => {
+      const result = await router.route(
+        'Review 110-line single-file change in bin/session-start-launcher.mjs for reuse, quality, efficiency.'
+      );
+      expect(result.model).toBe('sonnet');
+      expect(result.alternatives.find((a) => a.model === 'sonnet')).toBeUndefined();
+      expect(result.alternatives.find((a) => a.model === 'opus')).toBeDefined();
+      expect(result.costMultiplier).toBeLessThan(1); // sonnet < opus
+    });
+  });
+});

--- a/src/cli/mcp-tools/hooks-tools.ts
+++ b/src/cli/mcp-tools/hooks-tools.ts
@@ -3018,6 +3018,8 @@ export const hooksModelRoute: MCPTool = {
   },
   handler: async (params: Record<string, unknown>) => {
     const task = params.task as string;
+    const preferCost = params.preferCost as boolean | undefined;
+    const preferSpeed = params.preferSpeed as boolean | undefined;
     const router = await getModelRouterInstance();
 
     if (!router) {
@@ -3032,7 +3034,7 @@ export const hooksModelRoute: MCPTool = {
       };
     }
 
-    const result = await router.route(task);
+    const result = await router.route(task, { preferCost, preferSpeed });
     return {
       model: result.model,
       confidence: result.confidence,

--- a/src/cli/movector/model-router.ts
+++ b/src/cli/movector/model-router.ts
@@ -108,6 +108,24 @@ export interface ModelRouterConfig {
 }
 
 /**
+ * Per-call routing preferences
+ */
+export interface RouteOptions {
+  /** When true, prefer the cheapest model whose score is competitive with the best */
+  preferCost?: boolean;
+  /** When true, prefer the fastest model whose score is competitive with the best */
+  preferSpeed?: boolean;
+  /** Optional embedding for richer complexity analysis */
+  embedding?: number[];
+}
+
+/**
+ * Score window (absolute score units) within which a model is considered
+ * "competitive" with the best — used by preferCost/preferSpeed tie-breaking.
+ */
+const COMPETITIVE_SCORE_WINDOW = 0.1;
+
+/**
  * Routing decision result
  */
 export interface ModelRoutingResult {
@@ -208,13 +226,23 @@ export class ModelRouter {
   }
 
   /**
-   * Route a task to the optimal model
+   * Route a task to the optimal model.
+   *
+   * Accepts `RouteOptions` (preferCost / preferSpeed / embedding) — the legacy
+   * `number[]` second-arg form is still accepted and treated as `embedding`.
    */
-  async route(task: string, embedding?: number[]): Promise<ModelRoutingResult> {
+  async route(
+    task: string,
+    optionsOrEmbedding?: RouteOptions | number[]
+  ): Promise<ModelRoutingResult> {
+    const options: RouteOptions = Array.isArray(optionsOrEmbedding)
+      ? { embedding: optionsOrEmbedding }
+      : (optionsOrEmbedding ?? {});
+
     const startTime = performance.now();
 
     // Analyze task complexity
-    const complexity = this.analyzeComplexity(task, embedding);
+    const complexity = this.analyzeComplexity(task, options.embedding);
 
     // Compute base model scores
     const scores = this.computeModelScores(complexity);
@@ -223,7 +251,11 @@ export class ModelRouter {
     const adjustedScores = this.applyCircuitBreaker(scores);
 
     // Select best model
-    const { model, confidence, uncertainty } = this.selectModel(adjustedScores, complexity.score);
+    const { model, confidence, uncertainty } = this.selectModel(
+      adjustedScores,
+      complexity,
+      options
+    );
 
     const inferenceTimeUs = (performance.now() - startTime) * 1000;
 
@@ -332,10 +364,12 @@ export class ModelRouter {
    * Compute task scope from content analysis
    */
   private computeTaskScope(task: string, words: string[]): number {
-    // Multi-file indicators
+    // Multi-file / multi-system indicators
     const multiFilePatterns = [
       /multiple files?/i, /across.*modules?/i, /refactor.*codebase/i,
       /all.*files/i, /entire.*project/i, /system.*wide/i,
+      /across\s+\S+\s*(services?|systems?|modules?|packages?|microservices?)/i,
+      /\b\d+\s+(services?|systems?|modules?|packages?|microservices?)\b/i,
     ];
     const hasMultiFile = multiFilePatterns.some(p => p.test(task)) ? 0.4 : 0;
 
@@ -405,35 +439,76 @@ export class ModelRouter {
   }
 
   /**
-   * Select the best model from scores
+   * Select the best model from scores.
+   *
+   * Selection rules (in order):
+   *   1. If `preferCost`: among models within COMPETITIVE_SCORE_WINDOW of the
+   *      best score, return the cheapest by `costMultiplier`.
+   *   2. If `preferSpeed`: same window, return the fastest by `speedMultiplier`.
+   *   3. Otherwise: return the highest-scoring model. Escalate one tier ONLY
+   *      when there are 2+ high-complexity indicators (real architecture
+   *      signal) — single-keyword tasks like "review" or "audit X" do not
+   *      force a more expensive model.
+   *
+   * Note: prior versions force-escalated `sonnet → opus` whenever
+   * `uncertainty > maxUncertainty (0.15)`, which fired on essentially every
+   * code-review-shaped task and defeated the cost-saving point of the router.
    */
   private selectModel(
     scores: Record<ClaudeModel, number>,
-    complexityScore: number
+    complexity: ComplexityAnalysis,
+    options: RouteOptions = {}
   ): { model: ClaudeModel; confidence: number; uncertainty: number } {
-    // Get sorted models by score
     const sorted = (Object.entries(scores) as [ClaudeModel, number][])
       .filter(([m]) => m !== 'inherit')
       .sort((a, b) => b[1] - a[1]);
 
     const [bestModel, bestScore] = sorted[0];
-    const [secondModel, secondScore] = sorted[1] || ['sonnet', 0];
+    const secondScore = sorted[1]?.[1] ?? 0;
 
-    // Confidence is how much better the best is vs second
-    const confidence = bestScore > 0 ? Math.min(1, bestScore / (bestScore + secondScore + 0.01)) : 0.5;
-
-    // Uncertainty based on score spread and complexity
+    const confidence = bestScore > 0
+      ? Math.min(1, bestScore / (bestScore + secondScore + 0.01))
+      : 0.5;
     const scoreSpread = bestScore - secondScore;
     const uncertainty = Math.max(0, 1 - scoreSpread - confidence * 0.5);
 
-    // Escalate if uncertainty is too high
-    let model = bestModel;
-    if (uncertainty > this.config.maxUncertainty && bestModel !== 'opus') {
-      // Escalate to more capable model
-      model = bestModel === 'haiku' ? 'sonnet' : 'opus';
+    if (options.preferCost) {
+      const threshold = bestScore - COMPETITIVE_SCORE_WINDOW;
+      const competitive = sorted
+        .filter(([, s]) => s >= threshold)
+        .sort(
+          (a, b) =>
+            MODEL_CAPABILITIES[a[0]].costMultiplier -
+            MODEL_CAPABILITIES[b[0]].costMultiplier
+        );
+      return { model: competitive[0][0], confidence, uncertainty };
     }
 
-    return { model, confidence, uncertainty };
+    if (options.preferSpeed) {
+      const threshold = bestScore - COMPETITIVE_SCORE_WINDOW;
+      const competitive = sorted
+        .filter(([, s]) => s >= threshold)
+        .sort(
+          (a, b) =>
+            MODEL_CAPABILITIES[b[0]].speedMultiplier -
+            MODEL_CAPABILITIES[a[0]].speedMultiplier
+        );
+      return { model: competitive[0][0], confidence, uncertainty };
+    }
+
+    // Real-architecture escalation: multiple high-complexity indicators
+    // (e.g. "architect" + "system", "design" + "distributed") signal work
+    // that's worth a more capable model even if the score curve favours sonnet.
+    const hasArchitectureSignal = complexity.indicators.high.length >= 2;
+    if (hasArchitectureSignal && bestModel !== 'opus') {
+      return {
+        model: bestModel === 'haiku' ? 'sonnet' : 'opus',
+        confidence,
+        uncertainty,
+      };
+    }
+
+    return { model: bestModel, confidence, uncertainty };
   }
 
   /**
@@ -652,10 +727,10 @@ export async function routeToModel(task: string): Promise<ClaudeModel> {
  */
 export async function routeToModelFull(
   task: string,
-  embedding?: number[]
+  embeddingOrOptions?: number[] | RouteOptions
 ): Promise<ModelRoutingResult> {
   const router = getModelRouter();
-  return router.route(task, embedding);
+  return router.route(task, embeddingOrOptions);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `mcp__moflo__hooks_model-route` was returning `opus` for plain code-review tasks even when the `alternatives` array showed sonnet scoring higher, defeating the cost-saving point of the router (the `/simplify` skill ships with a workaround for this).
- Two bugs: (1) the MCP handler accepted `preferCost`/`preferSpeed` in its schema but never forwarded them; (2) `selectModel()` force-escalated `sonnet → opus` on `uncertainty > 0.15`, which fires on essentially every close race.

## What changed

- `ModelRouter.route()` now accepts `RouteOptions { preferCost?, preferSpeed?, embedding? }`. Legacy `number[]` second-arg form still works.
- `hooks_model-route` MCP handler forwards `preferCost`/`preferSpeed` to the router.
- `selectModel()`:
  - `preferCost`: among models within 0.1 of the best score, pick the cheapest by `costMultiplier`.
  - `preferSpeed`: same window, pick the fastest by `speedMultiplier`.
  - Otherwise: highest-scoring model wins. Escalate one tier **only** when there are 2+ high-complexity indicators (real architecture signal) — single-keyword tasks like `"review"` or `"audit X"` don't force opus.
- Added `across N services/systems/modules` and `N services/...` patterns to multifile `taskScope` detection so genuine cross-system architecture work raises complexity legitimately rather than relying on the dropped escalation.

## Test plan

- [x] New tests at `src/cli/__tests__/movector/model-router.test.ts` (12 tests, all green) covering:
  - Bug repro returns `sonnet`, with and without `preferCost`
  - Single-keyword `audit`/`review` tasks don't escalate to opus
  - `preferCost: true` picks cheaper model when scores within 0.1
  - `preferCost: true` does NOT pick a much-lower-scoring cheap model (only within window)
  - `"architect new auth system across 12 services"` still returns opus
  - `"design distributed consensus algorithm with Byzantine fault tolerance"` still returns opus
  - `preferSpeed` mirror behaviour
  - Legacy `route(task, embedding[])` form still works
- [x] Full vitest suite green (7775 tests).
- [x] `tsc --noEmit` clean.
- [ ] Verify against the original repro after merge: `mcp__moflo__hooks_model-route { task: "Review 110-line single-file change in bin/session-start-launcher.mjs for reuse, quality, efficiency.", preferCost: true }` → returns `sonnet`.

## Follow-up

The `/simplify` skill ships with a hard `opus → sonnet` downgrade rule for code review. Once this lands and the router is doing the right thing, that workaround can be removed (or made conditional on router availability).

Closes #891

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)