### PR TITLE
fix(896): launcher heals stale hook entries on regenerate (wholesale)

### DIFF
--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -958,8 +958,28 @@ async function runHookBlockDriftCheck() {
 
   if (report.drifted) {
     const wantRegenerate = autoUpdateConfig.hookBlockDrift === 'regenerate';
-    const safeToRegenerate = wantRegenerate && report.extra.length === 0;
-    if (safeToRegenerate && typeof mod.applyAdditiveRegeneration === 'function') {
+    // #896: regenerate is wholesale when available — the additive variant
+    // can't drop stale extras (e.g. the `gate.cjs session-reset` SessionStart
+    // hook removed in #842), which is the very case consumers hit. Older
+    // moflo installs without `applyWholesaleRegeneration` fall back to the
+    // additive path, which still heals purely-additive drift.
+    const wholesale = wantRegenerate && typeof mod.applyWholesaleRegeneration === 'function';
+    const additiveSafe = wantRegenerate && !wholesale &&
+      report.extra.length === 0 && typeof mod.applyAdditiveRegeneration === 'function';
+    if (wholesale) {
+      const { added, removed } = mod.applyWholesaleRegeneration(settings, report);
+      if (added > 0 || removed > 0) {
+        writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+        regenerated = true;
+        const parts = [];
+        if (added > 0) parts.push(`added ${plural(added, 'missing entry')}`);
+        if (removed > 0) parts.push(`removed ${plural(removed, 'stale entry')}`);
+        emitMutation(
+          'regenerated hook block',
+          `${parts.join(', ')} (drift ${report.consumerHash} → ${report.referenceHash})`,
+        );
+      }
+    } else if (additiveSafe) {
       const { added } = mod.applyAdditiveRegeneration(settings, report);
       if (added > 0) {
         writeFileSync(settingsPath, JSON.stringify(settings, null, 2));

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -958,8 +958,28 @@ async function runHookBlockDriftCheck() {
 
   if (report.drifted) {
     const wantRegenerate = autoUpdateConfig.hookBlockDrift === 'regenerate';
-    const safeToRegenerate = wantRegenerate && report.extra.length === 0;
-    if (safeToRegenerate && typeof mod.applyAdditiveRegeneration === 'function') {
+    // #896: regenerate is wholesale when available — the additive variant
+    // can't drop stale extras (e.g. the `gate.cjs session-reset` SessionStart
+    // hook removed in #842), which is the very case consumers hit. Older
+    // moflo installs without `applyWholesaleRegeneration` fall back to the
+    // additive path, which still heals purely-additive drift.
+    const wholesale = wantRegenerate && typeof mod.applyWholesaleRegeneration === 'function';
+    const additiveSafe = wantRegenerate && !wholesale &&
+      report.extra.length === 0 && typeof mod.applyAdditiveRegeneration === 'function';
+    if (wholesale) {
+      const { added, removed } = mod.applyWholesaleRegeneration(settings, report);
+      if (added > 0 || removed > 0) {
+        writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+        regenerated = true;
+        const parts = [];
+        if (added > 0) parts.push(`added ${plural(added, 'missing entry')}`);
+        if (removed > 0) parts.push(`removed ${plural(removed, 'stale entry')}`);
+        emitMutation(
+          'regenerated hook block',
+          `${parts.join(', ')} (drift ${report.consumerHash} → ${report.referenceHash})`,
+        );
+      }
+    } else if (additiveSafe) {
       const { added } = mod.applyAdditiveRegeneration(settings, report);
       if (added > 0) {
         writeFileSync(settingsPath, JSON.stringify(settings, null, 2));

--- a/src/cli/__tests__/doctor-hook-drift-off-mode.test.ts
+++ b/src/cli/__tests__/doctor-hook-drift-off-mode.test.ts
@@ -1,0 +1,97 @@
+/**
+ * #896: doctor's `Hook Block Drift` check honours `auto_update.hook_block_drift: off`.
+ *
+ * Pre-#896, the launcher was the only consumer of this config; the doctor
+ * still emitted a warn even when the user had explicitly opted out, leaving
+ * `flo doctor --strict` red on consumers using `off` mode. This test pins
+ * the suppression so a future change can't silently drop it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { checkHookBlockDrift } from '../commands/doctor-checks-deep.js';
+import { getReferenceHookBlock } from '../services/hook-block-hash.js';
+
+describe('checkHookBlockDrift — auto_update.hook_block_drift: off (#896)', () => {
+  let tmpDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'moflo-doctor-hook-drift-off-'));
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    // findProjectRoot() walks up from cwd looking for package.json/.git.
+    // Drop a marker so it stops at tmpDir instead of bubbling up into the
+    // host project (which would cause the doctor check to read the wrong files).
+    writeFileSync(join(tmpDir, 'package.json'), '{"name":"tmp-fixture"}');
+    prevCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('returns pass when settings have drift but yaml mode is off', () => {
+    // Drifted settings: stripped block, would normally produce a warn.
+    writeFileSync(
+      join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: '^Read$', hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-before-read', timeout: 3000 }] },
+          ],
+        },
+      }),
+    );
+    writeFileSync(
+      join(tmpDir, 'moflo.yaml'),
+      `auto_update:\n  enabled: true\n  hook_block_drift: off\n`,
+    );
+
+    return checkHookBlockDrift().then((result) => {
+      expect(result.status).toBe('pass');
+      expect(result.message).toContain('off');
+    });
+  });
+
+  it('still warns when drift exists and yaml mode is warn (default behaviour preserved)', () => {
+    writeFileSync(
+      join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: '^Read$', hooks: [{ type: 'command', command: 'custom-handler', timeout: 1000 }] },
+          ],
+        },
+      }),
+    );
+    writeFileSync(
+      join(tmpDir, 'moflo.yaml'),
+      `auto_update:\n  enabled: true\n  hook_block_drift: warn\n`,
+    );
+
+    return checkHookBlockDrift().then((result) => {
+      expect(result.status).toBe('warn');
+      expect(result.message).toContain('drift');
+    });
+  });
+
+  it('passes when settings match reference regardless of mode', () => {
+    writeFileSync(
+      join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({ hooks: getReferenceHookBlock() }),
+    );
+    writeFileSync(
+      join(tmpDir, 'moflo.yaml'),
+      `auto_update:\n  enabled: true\n  hook_block_drift: regenerate\n`,
+    );
+
+    return checkHookBlockDrift().then((result) => {
+      expect(result.status).toBe('pass');
+      expect(result.message).toContain('matches reference');
+    });
+  });
+});

--- a/src/cli/__tests__/services/hook-block-hash.test.ts
+++ b/src/cli/__tests__/services/hook-block-hash.test.ts
@@ -12,6 +12,9 @@ import {
   computeHookBlockDrift,
   formatDriftReport,
   getReferenceHookBlock,
+  applyWholesaleRegeneration,
+  applyAdditiveRegeneration,
+  isHookBlockLocked,
 } from '../../services/hook-block-hash.js';
 import { generateSettings } from '../../init/settings-generator.js';
 import { DEFAULT_INIT_OPTIONS } from '../../init/types.js';
@@ -182,6 +185,103 @@ describe('computeHookBlockDrift — AC test cases', () => {
     expect(report.drifted).toBe(true);
     expect(report.missing.length).toBeGreaterThan(0);
     expect(report.extra.length).toBe(0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Wholesale regeneration (#896) — heals stale extras the additive variant
+// cannot drop. Covers the AC that exposes the gap that triggered #896.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('applyWholesaleRegeneration (#896)', () => {
+  it('replaces hooks block wholesale — drops extras AND adds missing in one pass', () => {
+    // Simulates the #896 repro: consumer settings carry a stale SessionStart
+    // hook from before #842 (an extra) plus a partial canonical block (missing entries).
+    const settings: Record<string, unknown> = {
+      permissions: { allow: ['Bash(npm:*)'] },
+      hooks: {
+        PreToolUse: [
+          { matcher: '^Read$', hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-before-read', timeout: 3000 }] },
+        ],
+        SessionStart: [
+          { hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" session-reset', timeout: 2000 }] },
+        ],
+      },
+    };
+    const report = computeHookBlockDrift(settings.hooks);
+    expect(report.drifted).toBe(true);
+    expect(report.extra.length).toBeGreaterThan(0);
+    expect(report.missing.length).toBeGreaterThan(0);
+
+    const result = applyWholesaleRegeneration(settings, report);
+    expect(result.added).toBe(report.missing.length);
+    expect(result.removed).toBe(report.extra.length);
+
+    // Post-regeneration, the hook block must match the canonical reference.
+    const post = computeHookBlockDrift(settings.hooks);
+    expect(post.drifted).toBe(false);
+    expect(post.missing).toEqual([]);
+    expect(post.extra).toEqual([]);
+
+    // Non-hooks fields (permissions, etc.) survive untouched — wholesale only
+    // replaces the `hooks` field.
+    expect(settings.permissions).toEqual({ allow: ['Bash(npm:*)'] });
+  });
+
+  it('is a no-op when not drifted', () => {
+    const settings: Record<string, unknown> = { hooks: getReferenceHookBlock() };
+    const report = computeHookBlockDrift(settings.hooks);
+    const result = applyWholesaleRegeneration(settings, report);
+    expect(result.added).toBe(0);
+    expect(result.removed).toBe(0);
+  });
+
+  it('does not corrupt the cached reference (returns a deep clone)', () => {
+    // Defence-in-depth: if a future caller mutates settings.hooks after
+    // wholesale regen, the cached reference used by computeHookBlockDrift
+    // must not see those mutations on the next call.
+    const a: Record<string, unknown> = { hooks: { PreToolUse: [{ matcher: '^Read$', hooks: [{ command: 'wrong', timeout: 1 }] }] } };
+    applyWholesaleRegeneration(a, computeHookBlockDrift(a.hooks));
+    const aHooks = a.hooks as Record<string, Array<{ matcher?: string; hooks: unknown[] }>>;
+    aHooks.PreToolUse.push({ matcher: '^Custom$', hooks: [{ command: 'mut', timeout: 1 }] });
+
+    // A fresh consumer, drifted, run through the same call should not see
+    // the previous test's mutation in its own regenerated block.
+    const b: Record<string, unknown> = { hooks: { PreToolUse: [{ matcher: '^Read$', hooks: [{ command: 'wrong', timeout: 1 }] }] } };
+    applyWholesaleRegeneration(b, computeHookBlockDrift(b.hooks));
+    const bHooks = b.hooks as Record<string, Array<{ matcher?: string }>>;
+    expect(bHooks.PreToolUse.some((blk) => blk.matcher === '^Custom$')).toBe(false);
+  });
+});
+
+describe('isHookBlockLocked', () => {
+  it('returns true when claudeFlow.hooks.locked === true', () => {
+    expect(isHookBlockLocked({ claudeFlow: { hooks: { locked: true } } })).toBe(true);
+  });
+
+  it('returns false on missing/falsy/non-object input', () => {
+    expect(isHookBlockLocked({})).toBe(false);
+    expect(isHookBlockLocked(null)).toBe(false);
+    expect(isHookBlockLocked({ claudeFlow: {} })).toBe(false);
+    expect(isHookBlockLocked({ claudeFlow: { hooks: { locked: false } } })).toBe(false);
+  });
+});
+
+describe('applyAdditiveRegeneration — kept for fallback path', () => {
+  it('still adds missing entries without touching extras (regression guard)', () => {
+    // The launcher uses additive only when wholesale isn't exported (older
+    // moflo install). Pin the legacy contract so we don't accidentally drop
+    // both code paths in a future cleanup.
+    const settings: Record<string, unknown> = {
+      hooks: {
+        PreToolUse: [
+          { matcher: '^Read$', hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-before-read', timeout: 3000 }] },
+        ],
+      },
+    };
+    const report = computeHookBlockDrift(settings.hooks);
+    const result = applyAdditiveRegeneration(settings, report);
+    expect(result.added).toBeGreaterThan(0);
   });
 });
 

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -667,6 +667,19 @@ export async function checkHookBlockDrift(): Promise<HealthCheck> {
       message: 'drift check skipped — claudeFlow.hooks.locked: true',
     };
   }
+  // #896: respect `auto_update.hook_block_drift: off` — opt-out for consumers
+  // who explicitly don't want drift surfaced (mirrors the launcher's behaviour).
+  try {
+    const { loadMofloConfig } = await import('../config/moflo-config.js');
+    const cfg = loadMofloConfig(projectDir);
+    if (cfg.auto_update.hook_block_drift === 'off') {
+      return {
+        name: 'Hook Block Drift',
+        status: 'pass',
+        message: 'drift check skipped — auto_update.hook_block_drift: off',
+      };
+    }
+  } catch { /* config read failure — fall through to drift check */ }
   const report = computeHookBlockDrift(settings.hooks ?? {});
 
   if (!report.drifted) {

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -60,6 +60,8 @@ export interface RegenerationResult {
   settings: Record<string, unknown>;
   /** Number of missing hook entries that were added back. */
   added: number;
+  /** Number of extra hook entries that were removed (additive: always 0). */
+  removed: number;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -327,7 +329,7 @@ export function applyAdditiveRegeneration(
   settings: Record<string, unknown>,
   report: HookDriftReport,
 ): RegenerationResult {
-  if (report.missing.length === 0) return { settings, added: 0 };
+  if (report.missing.length === 0) return { settings, added: 0, removed: 0 };
   const ref = getCachedReference().tree;
   const hooks = (settings.hooks ?? {}) as Record<string, HookBlock[]>;
   let added = 0;
@@ -353,7 +355,31 @@ export function applyAdditiveRegeneration(
   }
 
   if (added > 0) settings.hooks = hooks;
-  return { settings, added };
+  return { settings, added, removed: 0 };
+}
+
+/**
+ * Wholesale regeneration: replace `settings.hooks` with the canonical reference
+ * block. Drops extras (stale entries from previous moflo versions, e.g. the
+ * `gate.cjs session-reset` SessionStart hook removed in #842) AND adds missing
+ * entries — the additive variant only does the latter.
+ *
+ * The caller MUST check `isHookBlockLocked(settings)` first; if locked, the
+ * user has opted out and this function should not be called. Non-hooks fields
+ * on `settings` (permissions, env, claudeFlow.*, etc.) are preserved.
+ *
+ * Mutates `settings` in place; caller is responsible for writing the file.
+ */
+export function applyWholesaleRegeneration(
+  settings: Record<string, unknown>,
+  report: HookDriftReport,
+): RegenerationResult {
+  if (!report.drifted) return { settings, added: 0, removed: 0 };
+  // Clone the cached reference so a later mutation of settings.hooks (by the
+  // launcher's settings.json migrations, doctor --fix, etc.) cannot corrupt
+  // the cached tree shared across `computeHookBlockDrift` calls in this process.
+  settings.hooks = structuredClone(getCachedReference().tree);
+  return { settings, added: report.missing.length, removed: report.extra.length };
 }
 
 /**

--- a/tests/bin/launcher-896-hook-drift-regenerate.test.ts
+++ b/tests/bin/launcher-896-hook-drift-regenerate.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for issue #896 — launcher must heal stale hook entries
+ * (extras), not just add missing ones, when `auto_update.hook_block_drift:
+ * regenerate` is set.
+ *
+ * Symptom in the wild: consumers carrying the `gate.cjs session-reset`
+ * SessionStart hook from before #842 were stuck on a `flo doctor --strict`
+ * Hook Block Drift warning. The launcher honoured `regenerate` mode only on
+ * the purely-additive path (`report.extra.length === 0`); when extras existed
+ * (the actual repro), it fell back to warn and the consumer couldn't self-heal.
+ *
+ * These are source-invariant tests so a future "simplification" can't drop
+ * the wholesale-preferred path and silently re-introduce the hang. End-to-end
+ * coverage of the regeneration helpers themselves lives in
+ * `src/cli/__tests__/services/hook-block-hash.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(__dirname, '../..');
+
+describe.each([
+  ['bin/session-start-launcher.mjs', resolve(ROOT, 'bin', 'session-start-launcher.mjs')],
+  ['.claude/scripts/session-start-launcher.mjs', resolve(ROOT, '.claude', 'scripts', 'session-start-launcher.mjs')],
+])('%s — hook-block drift regenerate (#896)', (_label, file) => {
+  const src = readFileSync(file, 'utf-8');
+
+  it('prefers applyWholesaleRegeneration when the export is available', () => {
+    // The whole point of #896: wholesale must be the primary path so stale
+    // extras (gate.cjs session-reset, etc.) get dropped instead of preserved.
+    expect(src).toMatch(/applyWholesaleRegeneration/);
+    // Specifically: the wholesale-availability check must precede the
+    // additive fallback.
+    const idxWholesale = src.indexOf('applyWholesaleRegeneration');
+    const idxAdditive = src.indexOf('applyAdditiveRegeneration');
+    expect(idxWholesale).toBeGreaterThan(0);
+    expect(idxAdditive).toBeGreaterThan(0);
+    expect(idxWholesale, 'wholesale must be checked before additive').toBeLessThan(idxAdditive);
+  });
+
+  it('drops the report.extra.length === 0 guard from the wholesale branch', () => {
+    // Pre-#896: `safeToRegenerate = wantRegenerate && report.extra.length === 0`
+    // was the bug — extras (the repro case) made regenerate a no-op. The
+    // wholesale path must NOT be gated on extras count. We pin the gating
+    // shape so a refactor can't reintroduce the guard.
+    const wholesaleLine = src.match(/const\s+wholesale\s*=\s*[^;]+;/);
+    expect(wholesaleLine, 'wholesale gate must exist').toBeTruthy();
+    expect(wholesaleLine![0]).toMatch(/wantRegenerate/);
+    expect(wholesaleLine![0]).toMatch(/applyWholesaleRegeneration/);
+    expect(wholesaleLine![0]).not.toMatch(/extra\.length/);
+  });
+
+  it('still respects the locked sentinel before any regeneration', () => {
+    // Defence-in-depth: the locked: true opt-out is the user's documented
+    // way to suppress drift surfacing. Wholesale regeneration must not run
+    // before the locked check.
+    const idxLocked = src.indexOf('isHookBlockLocked');
+    const idxRegen = src.indexOf('applyWholesaleRegeneration');
+    expect(idxLocked).toBeGreaterThan(0);
+    expect(idxLocked, 'lock check must run before regeneration').toBeLessThan(idxRegen);
+  });
+
+  it('emits a mutation message naming both added and removed counts', () => {
+    // Without removed counts the user sees `added 0 missing entries` for the
+    // pure-extras case (e.g. only `gate.cjs session-reset` to remove) and
+    // can't tell anything happened. Pin the shape.
+    expect(src).toMatch(/removed\s+\$\{plural\(removed,\s*'stale entry'\)\}/);
+    expect(src).toMatch(/added\s+\$\{plural\(added,\s*'missing entry'\)\}/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -73,6 +73,9 @@ export const isolationTests = [
   'src/cli/__tests__/bridge-entries.test.ts',
   // process.chdir per-test, same singleton/cwd contention as bridge-entries.
   'src/cli/__tests__/bridge-vector-stats-anti-clobber.test.ts',
+  // #896 — process.chdir per-test to redirect findProjectRoot at the doctor
+  // check; cwd-global means parallel forks would step on each other.
+  'src/cli/__tests__/doctor-hook-drift-off-mode.test.ts',
   // performance/timing assertions (initialize<500ms, shutdown<100ms, access
   // overhead<threshold) bust under Windows parallel-fork contention; whole
   // file passes <200ms in isolation.


### PR DESCRIPTION
## Summary

- `auto_update.hook_block_drift: regenerate` now wholesale-replaces the consumer's hooks block on session-start, instead of additively-only — closing the gap where consumers carrying stale entries (e.g. the `gate.cjs session-reset` SessionStart hook removed in #842) couldn't self-heal because the additive path fell back to warn whenever `report.extra.length > 0`.
- Doctor's `Hook Block Drift` check now also honours `auto_update.hook_block_drift: off` (was launcher-only — a consumer setting `off` would still get warned by `flo doctor --strict`).
- `claudeFlow.hooks.locked: true` remains the documented opt-out, checked before any regeneration.
- Default mode stays `warn` — changing the default is a separate consumer-blast-radius decision; this PR fixes the bug, doesn't move the default.

## Consumer surface + failure mode

- **Surface touched:** `bin/session-start-launcher.mjs` (synced to `.claude/scripts/`), `src/cli/services/hook-block-hash.ts`, `src/cli/commands/doctor-checks-deep.ts`.
- **On-current-version (warn mode) consumers:** zero behaviour change. Hot-path cache preserved.
- **Opt-in regenerate consumers:** `.claude/settings.json` `hooks` field gets rewritten on next session-start when drift exists. `locked: true` skips this entirely. Customisations under non-canonical matchers ARE replaced — this is the documented trade-off (the issue text endorses it: \"otherwise replace wholesale\"). Customers wanting to keep customs use `locked: true`.
- **Round-trip cost:** publish-then-reinstall required; the bug fix lives in code that runs from \`node_modules/moflo/...\` on consumer machines.

## Test plan

- [x] Unit (\`hook-block-hash.test.ts\`): \`applyWholesaleRegeneration\` clean drift, removes extras, preserves non-hooks fields, deep-clones to avoid corrupting the cached reference, no-op when not drifted.
- [x] Source-invariant (\`tests/bin/launcher-896-hook-drift-regenerate.test.ts\`): launcher prefers wholesale over additive, drops the \`extra.length === 0\` guard from the wholesale branch, locked sentinel precedes regeneration.
- [x] Doctor (\`doctor-hook-drift-off-mode.test.ts\`): returns pass when \`off\` mode set; warns when \`warn\` mode + drift; passes when settings match reference regardless of mode.
- [x] \`npm run build\` clean.
- [x] \`services/\`, \`bin/\`, \`init/\` test trees: 608 tests pass.

Closes #896

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)