### PR TITLE
fix(908): /simplify cost control — gate scope + diff-complexity classifier

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -88,7 +88,11 @@ var TASK_RE = /\b(fix|bug|error|implement|add|create|build|write|refactor|debug|
 var TEST_RUNNER_RE = /(?:^|[^a-z])(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?(?:test|t)(?:[:\s]|$)|\b(?:npx|pnpx)\s+(?:vitest|jest|mocha|ava|tap|jasmine|pytest)\b|(?:^|;|&&|\|\|)\s*(?:vitest|jest|pytest|mocha|jasmine|tap|ava)\s|\b(?:cargo|go|deno|dotnet|mvn)\s+test\b|\bgradle\w*\s+test\b/i;
 // Edits to these don't change runtime behaviour, so they don't invalidate prior test/simplify runs.
 // Lock files and .gitignore are tracked but inert; package.json/*.yaml ARE source — they reset.
-var EDIT_RESET_SKIP_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\/])(CHANGELOG(?:\.md)?|\.env\.example|package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$/i;
+var EDIT_RESET_SKIP_BOTH_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\/])(CHANGELOG(?:\.md)?|\.env\.example|package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$/i;
+// Test files: invalidate the testing gate (tests are stale once test code changes)
+// but NOT the simplify gate — /simplify already reviewed the production code; touching
+// a test file or fixture doesn't expose new untested surface for code review (#908).
+var EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE = /(?:^|[\\\/])(__tests__|__mocks__|tests?|spec|specs|cypress|e2e|fixtures?)[\\\/]|\.(test|spec)\.[mc]?[jt]sx?$|\.fixture\.[mc]?[jt]sx?$/i;
 
 switch (command) {
   case 'check-before-agent': {
@@ -180,11 +184,20 @@ switch (command) {
   }
   case 'reset-edit-gates': {
     var fp = process.env.TOOL_INPUT_file_path || '';
-    if (fp && EDIT_RESET_SKIP_RE.test(fp)) break;
+    // Inert files (markdown, lockfiles, CHANGELOG, .env.example): no gate reset.
+    if (fp && EDIT_RESET_SKIP_BOTH_RE.test(fp)) break;
     var s = readState();
-    if (!s.testsRun && !s.simplifyRun) break;
-    s.testsRun = false;
-    s.simplifyRun = false;
+    // Test-only edits invalidate testsRun but preserve simplifyRun (#908).
+    var isTestOnly = fp && EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE.test(fp);
+    var resetTests = s.testsRun;
+    var resetSimplify = s.simplifyRun && !isTestOnly;
+    if (!resetTests && !resetSimplify) break;
+    var gates = [];
+    if (resetTests) { s.testsRun = false; gates.push('tests'); }
+    if (resetSimplify) { s.simplifyRun = false; gates.push('simplify'); }
+    if (fp) {
+      s.lastResetBy = { file: fp, at: new Date().toISOString(), gates: gates };
+    }
     writeState(s);
     break;
   }
@@ -204,6 +217,9 @@ switch (command) {
     process.stderr.write('BLOCKED: gh pr create requires the following before opening a PR:\n');
     for (var i = 0; i < missing.length; i++) {
       process.stderr.write('  - ' + missing[i] + '\n');
+    }
+    if (s.lastResetBy && s.lastResetBy.file) {
+      process.stderr.write('Last gate reset: ' + s.lastResetBy.file + ' (' + (s.lastResetBy.gates || []).join(', ') + ')\n');
     }
     process.stderr.write('Disable per-gate via moflo.yaml:\n');
     process.stderr.write('  gates:\n    testing_gate: false\n    simplify_gate: false\n    learnings_gate: false\n');

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -595,7 +595,7 @@ try {
 
         // Gate and hook helpers — shipped as static files in bin/
         const binHelperFiles = [
-          'gate.cjs', 'gate-hook.mjs', 'prompt-hook.mjs', 'hook-handler.cjs',
+          'gate.cjs', 'gate-hook.mjs', 'prompt-hook.mjs', 'hook-handler.cjs', 'simplify-classify.cjs',
         ];
         for (const file of binHelperFiles) {
           await syncFile(resolve(binDir, file), resolve(helpersDir, file), `.claude/helpers/${file}`);

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -15,7 +15,30 @@ Treat the union of staged + unstaged + committed-since-base as the diff to revie
 
 Also note: was `/simplify` already run on this branch in this session? If yes, you're in a **validation pass** (Phase 2.5 below) — most of the heavy lifting is done.
 
-## Phase 2: Classify the diff
+## Phase 2: Classify the diff (deterministic — call the classifier)
+
+**Call the classifier first, follow its decision.** Do not eyeball the diff and pick a tier in prose — that's the failure mode that costs ~230K tokens per run on mechanical decompositions (issue #908). The classifier reads the same diff Claude would, applies the rules below, and returns a JSON dispatch decision:
+
+```bash
+node .claude/helpers/simplify-classify.cjs --base main
+```
+
+(In the moflo source repo, equivalent is `node bin/simplify-classify.cjs --base main`. The launcher syncs `bin/simplify-classify.cjs` → `.claude/helpers/simplify-classify.cjs` in consumer projects.)
+
+Output:
+```json
+{
+  "tier": "TRIVIAL" | "SMALL" | "NORMAL",
+  "model": "sonnet",
+  "agentCount": 0 | 1 | 3,
+  "reasoning": ["..."],
+  "stats": { "added": ..., "deleted": ..., "declAdded": ..., "declRemoved": ..., "netDecls": ..., "fileCount": ..., "securityHit": ... }
+}
+```
+
+If `bin/simplify-classify.cjs` is missing (older moflo install), fall back to the prose rules below — but on a current install the classifier IS the source of truth. Default behavior: **single Sonnet agent** unless the diff signals genuinely warrant escalation.
+
+Tier definitions the classifier encodes (for reference, not for re-derivation):
 
 Pick the **smallest tier** the diff genuinely fits. When in doubt, escalate one step (not two).
 
@@ -40,13 +63,14 @@ This is the default tier for **most real diffs**, including changes to critical 
 
 Examples that qualify: extracting a constant, inlining a one-liner, swapping a `for` for a `forEach`, adding one early-return, refactoring a single function within a file, adding a cache fast-path inside an existing block.
 
-### NORMAL — three parallel agents
-Reserved for **genuinely cross-cutting** changes. ANY of these triggers NORMAL:
-- 3+ files changed
-- >200 net LOC changed
-- Adds/removes/renames a public API
-- Introduces or removes a dependency
-- Cross-cutting refactor (touches the same pattern in multiple modules)
+### NORMAL — three parallel agents (high bar)
+Reserved for **genuinely cross-cutting** changes that single-agent review can't cover. The classifier escalates to NORMAL only when ANY of:
+- `>500 LOC changed` (real volume, not just "more than 200")
+- `5+ files AND ≥3 net new declarations` (broad new surface, not relocation)
+- `security-sensitive path AND netDecls > 0` (aidefence/, swarm/consensus/, hooks gate, daemon-lock, launcher — only when adding logic, not on a 1-line touch)
+- `3+ new files AND ≥5 new declarations` (genuinely new subsystem)
+
+**Mechanical relocation is NOT NORMAL** even with many files / many lines. If `declAdded` and `declRemoved` are both ≥2 and `netDecls` is small (within 30% of total declarations touched), it's a structural move — SMALL, single agent. This is the #906/#908 case: ~330 LOC across 6 files of pure decomposition was costing 230K tokens via three-agent fan-out when it needed one Sonnet agent.
 
 Three agents exist to cover orthogonal axes (Reuse / Quality / Efficiency) when the change is broad enough that one agent's tool-call budget can't survey it all. For single-file edits, one focused agent always covers all three axes — three is duplication, not coverage.
 
@@ -62,48 +86,11 @@ Escalate one tier (self-review → SMALL agent) only if the fix introduced any o
 
 Do **not** escalate to NORMAL on a validation pass. If the fix is so structural that NORMAL is warranted, treat it as a fresh diff and start over from Phase 1.
 
-## Phase 2.7: Route the model (before any Agent spawn)
+## Phase 2.7: Model selection
 
-For every tier that spawns an Agent (SMALL / NORMAL — TRIVIAL self-review skips this), call the moflo router to pick the cheapest model that fits the task **before** invoking Agent:
+**Use the model the classifier returned** — always `sonnet` for `/simplify`. Opus is never correct here; the classifier enforces this. No router call needed; the classifier IS the router for this skill.
 
-```
-mcp__moflo__hooks_model-route — {
-  task: "<diff summary — see wording rules below>",
-  preferCost: true
-}
-```
-
-### Wording the task description
-
-The router's complexity score is keyword-sensitive. Words like `refactor`, `architect`, `audit`, `system`, `redesign`, `migrate` flip a high-complexity flag and force opus *even when scoring suggests sonnet*. For `/simplify` you are **always doing code review**, never genuine architecture, so frame the task accordingly:
-
-- ✅ Good: `"Review 110-line single-file change in bin/session-start-launcher.mjs for reuse, quality, efficiency."`
-- ❌ Bad: `"Review refactor that adds mtime-cache fast-path and architects new caching layer."`
-
-Drop the trigger words. State LOC count, file count, and "review for reuse, quality, efficiency". That's enough signal.
-
-### Applying the result
-
-The router returns `{ model: 'haiku' | 'sonnet' | 'opus', complexity, reasoning, alternatives, ... }`.
-
-**Hard rule for `/simplify`: opus is never correct.** Code review does not require Opus-tier reasoning even on critical surface. If the router returns `opus`:
-
-1. Look at `alternatives` — if `sonnet` scores higher than the selected model's confidence, downgrade to sonnet.
-2. Otherwise, downgrade to sonnet anyway (treat opus as "router was uncertain — pick the safer middle").
-
-Pass the final model verbatim to the Agent's `model` parameter (Agent accepts `'haiku' | 'sonnet' | 'opus'`). On router failure (MCP call errors), default to `'sonnet'`.
-
-In practice: comment trims and pure formatting → haiku; everything else for `/simplify` → sonnet.
-
-### Feed back the outcome
-
-After the agent completes, record the outcome so the router learns:
-
-```
-mcp__moflo__hooks_model-outcome — { task: "<same wording as route call>", model: "<chosen>", outcome: "success" | "failure" | "escalated" }
-```
-
-`escalated` = the agent missed something a higher-tier pass would have caught. That signal teaches the router to bias similar tasks upward next time. Don't fake `escalated` to retroactively justify opus — only record it when a *real* miss happened.
+If you fell back to prose rules in Phase 2 (no classifier available), use `sonnet` unconditionally. Pass the model verbatim to Agent's `model` parameter.
 
 ## Phase 3: Run the appropriate review
 

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -88,7 +88,11 @@ var TASK_RE = /\b(fix|bug|error|implement|add|create|build|write|refactor|debug|
 var TEST_RUNNER_RE = /(?:^|[^a-z])(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?(?:test|t)(?:[:\s]|$)|\b(?:npx|pnpx)\s+(?:vitest|jest|mocha|ava|tap|jasmine|pytest)\b|(?:^|;|&&|\|\|)\s*(?:vitest|jest|pytest|mocha|jasmine|tap|ava)\s|\b(?:cargo|go|deno|dotnet|mvn)\s+test\b|\bgradle\w*\s+test\b/i;
 // Edits to these don't change runtime behaviour, so they don't invalidate prior test/simplify runs.
 // Lock files and .gitignore are tracked but inert; package.json/*.yaml ARE source — they reset.
-var EDIT_RESET_SKIP_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\/])(CHANGELOG(?:\.md)?|\.env\.example|package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$/i;
+var EDIT_RESET_SKIP_BOTH_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\/])(CHANGELOG(?:\.md)?|\.env\.example|package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$/i;
+// Test files: invalidate the testing gate (tests are stale once test code changes)
+// but NOT the simplify gate — /simplify already reviewed the production code; touching
+// a test file or fixture doesn't expose new untested surface for code review (#908).
+var EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE = /(?:^|[\\\/])(__tests__|__mocks__|tests?|spec|specs|cypress|e2e|fixtures?)[\\\/]|\.(test|spec)\.[mc]?[jt]sx?$|\.fixture\.[mc]?[jt]sx?$/i;
 
 switch (command) {
   case 'check-before-agent': {
@@ -180,11 +184,20 @@ switch (command) {
   }
   case 'reset-edit-gates': {
     var fp = process.env.TOOL_INPUT_file_path || '';
-    if (fp && EDIT_RESET_SKIP_RE.test(fp)) break;
+    // Inert files (markdown, lockfiles, CHANGELOG, .env.example): no gate reset.
+    if (fp && EDIT_RESET_SKIP_BOTH_RE.test(fp)) break;
     var s = readState();
-    if (!s.testsRun && !s.simplifyRun) break;
-    s.testsRun = false;
-    s.simplifyRun = false;
+    // Test-only edits invalidate testsRun but preserve simplifyRun (#908).
+    var isTestOnly = fp && EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE.test(fp);
+    var resetTests = s.testsRun;
+    var resetSimplify = s.simplifyRun && !isTestOnly;
+    if (!resetTests && !resetSimplify) break;
+    var gates = [];
+    if (resetTests) { s.testsRun = false; gates.push('tests'); }
+    if (resetSimplify) { s.simplifyRun = false; gates.push('simplify'); }
+    if (fp) {
+      s.lastResetBy = { file: fp, at: new Date().toISOString(), gates: gates };
+    }
     writeState(s);
     break;
   }
@@ -204,6 +217,9 @@ switch (command) {
     process.stderr.write('BLOCKED: gh pr create requires the following before opening a PR:\n');
     for (var i = 0; i < missing.length; i++) {
       process.stderr.write('  - ' + missing[i] + '\n');
+    }
+    if (s.lastResetBy && s.lastResetBy.file) {
+      process.stderr.write('Last gate reset: ' + s.lastResetBy.file + ' (' + (s.lastResetBy.gates || []).join(', ') + ')\n');
     }
     process.stderr.write('Disable per-gate via moflo.yaml:\n');
     process.stderr.write('  gates:\n    testing_gate: false\n    simplify_gate: false\n    learnings_gate: false\n');

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -595,7 +595,7 @@ try {
 
         // Gate and hook helpers — shipped as static files in bin/
         const binHelperFiles = [
-          'gate.cjs', 'gate-hook.mjs', 'prompt-hook.mjs', 'hook-handler.cjs',
+          'gate.cjs', 'gate-hook.mjs', 'prompt-hook.mjs', 'hook-handler.cjs', 'simplify-classify.cjs',
         ];
         for (const file of binHelperFiles) {
           await syncFile(resolve(binDir, file), resolve(helpersDir, file), `.claude/helpers/${file}`);

--- a/bin/simplify-classify.cjs
+++ b/bin/simplify-classify.cjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * /simplify diff classifier — issue #908.
+ *
+ * Decides which review tier the current diff warrants and returns a JSON
+ * dispatch decision. The /simplify skill MUST call this first so routing is
+ * deterministic and unit-testable instead of a prose decision Claude makes
+ * over and over per run.
+ *
+ * Rule (per user direction): default to single-agent Sonnet review. Only
+ * escalate to a 3-agent fan-out when diff signals genuinely warrant it.
+ * Opus is never selected — the existing skill already documents that.
+ *
+ * Outputs JSON:
+ *   {
+ *     "tier": "TRIVIAL" | "SMALL" | "NORMAL",
+ *     "model": "sonnet",
+ *     "agentCount": 0 | 1 | 3,
+ *     "reasoning": [string, ...],
+ *     "stats": { added, deleted, fileCount, declAdded, declRemoved, ... }
+ *   }
+ *
+ * Usage:
+ *   node bin/simplify-classify.cjs [--base main]
+ *   node bin/simplify-classify.cjs --diff <unified-diff-on-stdin>
+ *
+ * The --diff stdin form exists so unit tests can drive the classifier
+ * with synthetic diffs (no git repo required).
+ */
+'use strict';
+
+const { execSync } = require('child_process');
+
+// Paths where new logic warrants the 3-agent fan-out (issue #908).
+// Mechanical edits inside these paths are still SMALL; only adding/removing
+// declarations triggers escalation.
+const SECURITY_PATHS = [
+  /(?:^|[\\\/])aidefence[\\\/]/i,
+  /(?:^|[\\\/])swarm[\\\/]consensus[\\\/]/i,
+  /(?:^|[\\\/])hooks?[\\\/](?:handlers?|gate|wiring)/i,
+  /(?:^|[\\\/])services[\\\/]daemon-lock\.ts$/i,
+  /(?:^|[\\\/])bin[\\\/]gate\./i,
+  /(?:^|[\\\/])bin[\\\/]session-start-launcher\./i,
+  /(?:^|[\\\/])\.claude[\\\/]helpers[\\\/]gate/i,
+];
+
+function safeExec(cmd) {
+  try { return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }); }
+  catch { return ''; }
+}
+
+function readDiffFromGit(base) {
+  // Combined diff: committed-since-base + working-tree
+  const committed = safeExec(`git diff ${base}...HEAD`);
+  const working = safeExec('git diff HEAD');
+  return committed + (working ? '\n' + working : '');
+}
+
+/**
+ * Parse a unified-diff string into per-file stats and aggregate signals.
+ * No git/I/O — pure function over the diff text. Test-friendly.
+ */
+function parseDiff(diff) {
+  const lines = diff.split('\n');
+  const files = new Map(); // filename → { added, deleted, declAdded, declRemoved, isNew, isRenamed }
+  let current = null;
+
+  // Match function/class/export-const-arrow/method declarations being
+  // added or removed. Conservative — biased toward false negatives so we
+  // don't over-escalate.
+  const DECL_RE = /^(?:export\s+)?(?:default\s+)?(?:async\s+)?(?:function|class|interface|type)\s+\w/;
+  const ARROW_DECL_RE = /^(?:export\s+)?(?:const|let|var)\s+\w+\s*[:=].*=>\s*\{?$/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+
+    // File header: `diff --git a/path b/path`
+    let m = ln.match(/^diff --git (?:a\/)?(.+?) (?:b\/)?(.+)$/);
+    if (m) {
+      const filename = m[2];
+      current = { filename, added: 0, deleted: 0, declAdded: 0, declRemoved: 0, isNew: false, isRenamed: false };
+      files.set(filename, current);
+      continue;
+    }
+    if (!current) continue;
+
+    if (ln.startsWith('new file mode')) current.isNew = true;
+    if (ln.startsWith('rename from') || ln.startsWith('rename to') || ln.startsWith('similarity index')) current.isRenamed = true;
+
+    // Skip diff headers
+    if (ln.startsWith('+++') || ln.startsWith('---') || ln.startsWith('@@') || ln.startsWith('index ')) continue;
+
+    if (ln.startsWith('+') && !ln.startsWith('+++')) {
+      current.added++;
+      const body = ln.slice(1).trim();
+      if (DECL_RE.test(body) || ARROW_DECL_RE.test(body)) current.declAdded++;
+    } else if (ln.startsWith('-') && !ln.startsWith('---')) {
+      current.deleted++;
+      const body = ln.slice(1).trim();
+      if (DECL_RE.test(body) || ARROW_DECL_RE.test(body)) current.declRemoved++;
+    }
+  }
+
+  // Aggregate
+  let added = 0, deleted = 0, declAdded = 0, declRemoved = 0;
+  let newFiles = 0, renamedFiles = 0;
+  let securityHit = false;
+  for (const f of files.values()) {
+    added += f.added;
+    deleted += f.deleted;
+    declAdded += f.declAdded;
+    declRemoved += f.declRemoved;
+    if (f.isNew) newFiles++;
+    if (f.isRenamed) renamedFiles++;
+    if (SECURITY_PATHS.some(rx => rx.test(f.filename))) securityHit = true;
+  }
+
+  return {
+    added, deleted, declAdded, declRemoved,
+    netDecls: declAdded - declRemoved,
+    fileCount: files.size,
+    newFiles, renamedFiles,
+    securityHit,
+    files: [...files.keys()],
+  };
+}
+
+/**
+ * Pure decision function. Takes parsed stats, returns dispatch decision.
+ * No I/O. Easy to unit-test with synthetic stats.
+ */
+function decide(stats) {
+  const reasoning = [];
+  const totalChange = stats.added + stats.deleted;
+
+  if (totalChange === 0) {
+    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, reasoning: ['empty diff — nothing to review'], stats };
+  }
+
+  // TRIVIAL: tiny diff, no declarations changed
+  if (totalChange <= 10 && stats.fileCount <= 1 && stats.netDecls === 0 && stats.declAdded === 0 && stats.declRemoved === 0) {
+    reasoning.push(`≤10 LOC in 1 file with no declaration changes`);
+    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, reasoning, stats };
+  }
+
+  // Mechanical relocation detection — the #906 case.
+  // If declarations were both ADDED and REMOVED at roughly matching rates,
+  // it's a structural move, not net-new logic. Judge by declaration balance,
+  // not raw LOC balance — formatting/blank-line differences between source
+  // and destination files easily push raw LOC out of balance even when the
+  // semantic change is purely "moved 5 functions across 5 new files".
+  // Mechanical relocations are SMALL even when many files / many lines.
+  const declTouched = stats.declAdded + stats.declRemoved;
+  const isMostlyRelocation = stats.declAdded >= 2
+    && stats.declRemoved >= 2
+    && Math.abs(stats.netDecls) <= Math.max(2, Math.floor(declTouched * 0.30));
+
+  if (isMostlyRelocation) {
+    reasoning.push(
+      `mostly relocation: ${stats.declAdded} decls added, ${stats.declRemoved} removed, net ${stats.netDecls >= 0 ? '+' : ''}${stats.netDecls}`,
+    );
+    return { tier: 'SMALL', model: 'sonnet', agentCount: 1, reasoning, stats };
+  }
+
+  // Escalation triggers — any one trips NORMAL (3 agents).
+  // Always Sonnet — Opus is never the right model for /simplify per skill rule.
+  const triggers = [];
+  if (totalChange > 500) triggers.push(`>500 LOC changed (${totalChange})`);
+  if (stats.fileCount >= 5 && stats.netDecls >= 3) triggers.push(`${stats.fileCount} files with ${stats.netDecls} net new declarations`);
+  if (stats.securityHit && stats.netDecls > 0) triggers.push('security-sensitive path with new logic');
+  if (stats.newFiles >= 3 && stats.declAdded >= 5) triggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+
+  if (triggers.length > 0) {
+    return { tier: 'NORMAL', model: 'sonnet', agentCount: 3, reasoning: triggers, stats };
+  }
+
+  // Default: SMALL — single sonnet agent
+  reasoning.push(`small/medium diff: ${totalChange} LOC across ${stats.fileCount} file(s), +${stats.declAdded}/-${stats.declRemoved} decls`);
+  return { tier: 'SMALL', model: 'sonnet', agentCount: 1, reasoning, stats };
+}
+
+function classifyDiff(diffText) {
+  return decide(parseDiff(diffText));
+}
+
+function classifyFromGit(base = 'main') {
+  return classifyDiff(readDiffFromGit(base));
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const baseIdx = args.indexOf('--base');
+  const base = baseIdx >= 0 ? args[baseIdx + 1] : 'main';
+  const stdinDiff = args.includes('--diff') || args.includes('--stdin');
+
+  let result;
+  if (stdinDiff) {
+    let buf = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (d) => { buf += d; });
+    process.stdin.on('end', () => {
+      result = classifyDiff(buf);
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    });
+  } else {
+    result = classifyFromGit(base);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  }
+}
+
+module.exports = { parseDiff, decide, classifyDiff, classifyFromGit };

--- a/scripts/post-install-bootstrap.mjs
+++ b/scripts/post-install-bootstrap.mjs
@@ -73,6 +73,7 @@ export const BIN_HELPER_FILES = [
   'gate-hook.mjs',
   'prompt-hook.mjs',
   'hook-handler.cjs',
+  'simplify-classify.cjs',
 ];
 
 export const SOURCE_HELPER_FILES = [

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -289,7 +289,11 @@ var DANGEROUS = ['rm -rf /', 'format c:', 'del /s /q c:\\\\', ':(){:|:&};:', 'mk
 var DIRECTIVE_RE = /^(yes|no|yeah|yep|nope|sure|ok|okay|correct|right|exactly|perfect)\\b/i;
 var TASK_RE = /\\b(fix|bug|error|implement|add|create|build|write|refactor|debug|test|feature|issue|security|optimi)\\b/i;
 var TEST_RUNNER_RE = /(?:^|[^a-z])(?:npm|yarn|pnpm|bun)\\s+(?:run\\s+)?(?:test|t)(?:[:\\s]|$)|\\b(?:npx|pnpx)\\s+(?:vitest|jest|mocha|ava|tap|jasmine|pytest)\\b|(?:^|;|&&|\\|\\|)\\s*(?:vitest|jest|pytest|mocha|jasmine|tap|ava)\\s|\\b(?:cargo|go|deno|dotnet|mvn)\\s+test\\b|\\bgradle\\w*\\s+test\\b/i;
-var EDIT_RESET_SKIP_RE = /\\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\\\\/])(CHANGELOG(?:\\.md)?|\\.env\\.example|package-lock\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb)$/i;
+var EDIT_RESET_SKIP_BOTH_RE = /\\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\\\\/])(CHANGELOG(?:\\.md)?|\\.env\\.example|package-lock\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb)$/i;
+// Test files: invalidate testsRun but preserve simplifyRun (#908) — /simplify
+// already reviewed the production code, touching tests/fixtures doesn't expose
+// new untested surface for code review.
+var EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE = /(?:^|[\\\\\\/])(__tests__|__mocks__|tests?|spec|specs|cypress|e2e|fixtures?)[\\\\\\/]|\\.(test|spec)\\.[mc]?[jt]sx?$|\\.fixture\\.[mc]?[jt]sx?$/i;
 
 switch (command) {
   case 'check-before-agent': {
@@ -380,11 +384,20 @@ switch (command) {
   }
   case 'reset-edit-gates': {
     var fp = process.env.TOOL_INPUT_file_path || '';
-    if (fp && EDIT_RESET_SKIP_RE.test(fp)) break;
+    // Inert files (markdown, lockfiles, CHANGELOG, .env.example): no gate reset.
+    if (fp && EDIT_RESET_SKIP_BOTH_RE.test(fp)) break;
     var s = readState();
-    if (!s.testsRun && !s.simplifyRun) break;
-    s.testsRun = false;
-    s.simplifyRun = false;
+    // Test-only edits invalidate testsRun but preserve simplifyRun (#908).
+    var isTestOnly = fp && EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE.test(fp);
+    var resetTests = s.testsRun;
+    var resetSimplify = s.simplifyRun && !isTestOnly;
+    if (!resetTests && !resetSimplify) break;
+    var gates = [];
+    if (resetTests) { s.testsRun = false; gates.push('tests'); }
+    if (resetSimplify) { s.simplifyRun = false; gates.push('simplify'); }
+    if (fp) {
+      s.lastResetBy = { file: fp, at: new Date().toISOString(), gates: gates };
+    }
     writeState(s);
     break;
   }
@@ -400,6 +413,9 @@ switch (command) {
     process.stderr.write('BLOCKED: gh pr create requires the following before opening a PR:\\n');
     for (var i = 0; i < missing.length; i++) {
       process.stderr.write('  - ' + missing[i] + '\\n');
+    }
+    if (s.lastResetBy && s.lastResetBy.file) {
+      process.stderr.write('Last gate reset: ' + s.lastResetBy.file + ' (' + (s.lastResetBy.gates || []).join(', ') + ')\\n');
     }
     process.stderr.write('Disable per-gate via moflo.yaml:\\n');
     process.stderr.write('  gates:\\n    testing_gate: false\\n    simplify_gate: false\\n    learnings_gate: false\\n');

--- a/tests/bin/gate-edit-reset-908.test.ts
+++ b/tests/bin/gate-edit-reset-908.test.ts
@@ -1,0 +1,257 @@
+/**
+ * System tests for issue #908 — gate-scope split.
+ *
+ * Each test runs the *real* gate.cjs as a subprocess (the same way Claude Code
+ * invokes it via PostToolUse / PreToolUse hooks) and asserts on:
+ *   - whether `gh pr create` is blocked or allowed afterwards (exit code 2 vs 0)
+ *   - which gate flags actually flipped in workflow-state.json
+ *   - whether the blocked message lists the file that tripped the reset
+ *
+ * The test exercises the full lifecycle that #908 cares about:
+ *   record-skill-run → reset-edit-gates(test file) → check-before-pr
+ *
+ * Acceptance criteria from the issue:
+ *   - Editing only test files after /simplify does NOT block gh pr create
+ *   - Editing only .md files after /simplify does NOT block
+ *   - Editing src/** after /simplify DOES still block until simplify reruns
+ *   - The gate's blocked message lists the file(s) that tripped it
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+
+const BIN = resolve(__dirname, '../../bin');
+const GATE = resolve(BIN, 'gate.cjs');
+
+let tmpDir: string;
+
+function makeTmpProject(): string {
+  const dir = resolve(tmpdir(), `moflo-gate-908-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(dir, '.claude'), { recursive: true });
+  return dir;
+}
+
+function baseEnv(projectDir: string): Record<string, string> {
+  return {
+    ...process.env as Record<string, string>,
+    CLAUDE_PROJECT_DIR: projectDir,
+    TOOL_INPUT_command: '',
+    TOOL_INPUT_pattern: '',
+    TOOL_INPUT_path: '',
+    TOOL_INPUT_file_path: '',
+    TOOL_INPUT_skill: '',
+    CLAUDE_USER_PROMPT: '',
+    HOOK_SESSION_ID: '',
+  };
+}
+
+function runGate(command: string, env: Record<string, string>): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [GATE, command], {
+      env, encoding: 'utf-8', timeout: 30000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+      exitCode: err.status ?? 1,
+    };
+  }
+}
+
+function readState(projectDir: string): Record<string, unknown> {
+  const stateFile = join(projectDir, '.claude', 'workflow-state.json');
+  if (!existsSync(stateFile)) return {};
+  return JSON.parse(readFileSync(stateFile, 'utf-8'));
+}
+
+function writeState(projectDir: string, state: Record<string, unknown>): void {
+  const stateFile = join(projectDir, '.claude', 'workflow-state.json');
+  writeFileSync(stateFile, JSON.stringify(state, null, 2));
+}
+
+beforeEach(() => {
+  tmpDir = makeTmpProject();
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe('#908 gate scope — test-file edits do not retrip /simplify', () => {
+  describe('end-to-end: simplify → edit → check-before-pr', () => {
+    it('test-file edit after /simplify keeps simplifyRun true; PR not blocked on simplify', () => {
+      const env = baseEnv(tmpDir);
+
+      // 1) /simplify ran, tests ran, learnings stored — fully green
+      writeState(tmpDir, {
+        testsRun: true, simplifyRun: true, learningsStored: true,
+      });
+
+      // 2) User edits a test file (PostToolUse: reset-edit-gates fires)
+      env.TOOL_INPUT_file_path = '/project/tests/bin/foo.test.ts';
+      runGate('reset-edit-gates', env);
+
+      const after = readState(tmpDir);
+      expect(after.simplifyRun, 'test edit must NOT reset simplifyRun').toBe(true);
+      expect(after.testsRun, 'test edit MUST reset testsRun').toBe(false);
+
+      // 3) Re-run tests
+      writeState(tmpDir, { ...after, testsRun: true });
+
+      // 4) Try gh pr create — should NOT block (only simplify gate matters here)
+      env.TOOL_INPUT_command = 'gh pr create --title "fix"';
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode, `should not block, but got: ${r.stderr}`).toBe(0);
+    });
+
+    it('source-file edit after /simplify resets simplifyRun; PR blocked', () => {
+      const env = baseEnv(tmpDir);
+
+      writeState(tmpDir, {
+        testsRun: true, simplifyRun: true, learningsStored: true,
+      });
+
+      env.TOOL_INPUT_file_path = '/project/src/cli/foo.ts';
+      runGate('reset-edit-gates', env);
+
+      const after = readState(tmpDir);
+      expect(after.simplifyRun).toBe(false);
+      expect(after.testsRun).toBe(false);
+
+      // Re-run tests but not simplify — PR should still block on simplify
+      writeState(tmpDir, { ...after, testsRun: true });
+      env.TOOL_INPUT_command = 'gh pr create --title "fix"';
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode).toBe(2);
+      expect(r.stderr).toContain('/simplify has not run');
+    });
+
+    it('blocked message lists the file that tripped the reset', () => {
+      const env = baseEnv(tmpDir);
+      writeState(tmpDir, {
+        testsRun: true, simplifyRun: true, learningsStored: true,
+      });
+
+      const offendingFile = '/project/src/cli/launcher.ts';
+      env.TOOL_INPUT_file_path = offendingFile;
+      runGate('reset-edit-gates', env);
+
+      env.TOOL_INPUT_command = 'gh pr create --title "fix"';
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode).toBe(2);
+      expect(r.stderr).toContain('Last gate reset:');
+      expect(r.stderr).toContain(offendingFile);
+      expect(r.stderr).toMatch(/\(.*simplify.*\)|\(.*tests.*\)/);
+    });
+
+    it('markdown edit after /simplify keeps both gates; PR not blocked', () => {
+      const env = baseEnv(tmpDir);
+      writeState(tmpDir, {
+        testsRun: true, simplifyRun: true, learningsStored: true,
+      });
+
+      env.TOOL_INPUT_file_path = '/project/docs/CHANGELOG.md';
+      runGate('reset-edit-gates', env);
+
+      const after = readState(tmpDir);
+      expect(after.testsRun).toBe(true);
+      expect(after.simplifyRun).toBe(true);
+
+      env.TOOL_INPUT_command = 'gh pr create --title "docs"';
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode).toBe(0);
+    });
+  });
+
+  describe('test-file path detection coverage', () => {
+    const TEST_PATHS = [
+      '/project/tests/bin/foo.test.ts',
+      '/project/src/__tests__/bar.test.ts',
+      '/project/src/foo.test.ts',
+      '/project/src/foo.spec.ts',
+      '/project/src/foo.test.tsx',
+      '/project/src/foo.spec.mjs',
+      '/project/src/foo.test.cjs',
+      '/project/spec/integration.ts',
+      '/project/cypress/e2e/foo.cy.ts',
+      '/project/e2e/login.ts',
+      '/project/test/legacy.ts',
+      '/project/__tests__/whatever.ts',
+      '/project/__mocks__/fs.ts',
+      '/project/fixtures/sample.json',
+      '/project/src/foo.fixture.ts',
+      // Windows-style paths
+      'C:\\project\\tests\\bin\\foo.test.ts',
+      'C:\\project\\src\\__tests__\\bar.ts',
+    ];
+
+    for (const tp of TEST_PATHS) {
+      it(`preserves simplifyRun for test path: ${tp}`, () => {
+        writeState(tmpDir, { testsRun: true, simplifyRun: true });
+        const env = baseEnv(tmpDir);
+        env.TOOL_INPUT_file_path = tp;
+        runGate('reset-edit-gates', env);
+        const s = readState(tmpDir);
+        expect(s.simplifyRun, `simplifyRun should be preserved for ${tp}`).toBe(true);
+      });
+    }
+
+    const SOURCE_PATHS = [
+      '/project/src/cli/foo.ts',
+      '/project/src/index.ts',
+      '/project/bin/gate.cjs',
+      '/project/scripts/build.mjs',
+      '/project/harness/runner.ts',
+    ];
+
+    for (const sp of SOURCE_PATHS) {
+      it(`resets simplifyRun for source path: ${sp}`, () => {
+        writeState(tmpDir, { testsRun: true, simplifyRun: true });
+        const env = baseEnv(tmpDir);
+        env.TOOL_INPUT_file_path = sp;
+        runGate('reset-edit-gates', env);
+        const s = readState(tmpDir);
+        expect(s.simplifyRun, `simplifyRun SHOULD reset for ${sp}`).toBe(false);
+      });
+    }
+  });
+
+  describe('lastResetBy tracking', () => {
+    it('records which gates were reset, not just the file', () => {
+      writeState(tmpDir, { testsRun: true, simplifyRun: true });
+      const env = baseEnv(tmpDir);
+      env.TOOL_INPUT_file_path = '/project/src/foo.ts';
+      runGate('reset-edit-gates', env);
+      const s = readState(tmpDir) as any;
+      expect(s.lastResetBy).toBeDefined();
+      expect(s.lastResetBy.file).toBe('/project/src/foo.ts');
+      expect(s.lastResetBy.gates).toEqual(expect.arrayContaining(['tests', 'simplify']));
+    });
+
+    it('records only tests gate when test-file edit resets only testsRun', () => {
+      writeState(tmpDir, { testsRun: true, simplifyRun: true });
+      const env = baseEnv(tmpDir);
+      env.TOOL_INPUT_file_path = '/project/tests/foo.test.ts';
+      runGate('reset-edit-gates', env);
+      const s = readState(tmpDir) as any;
+      expect(s.lastResetBy.gates).toEqual(['tests']);
+      expect(s.simplifyRun).toBe(true);
+    });
+
+    it('does not record lastResetBy for inert markdown edits', () => {
+      writeState(tmpDir, { testsRun: true, simplifyRun: true });
+      const env = baseEnv(tmpDir);
+      env.TOOL_INPUT_file_path = '/project/README.md';
+      runGate('reset-edit-gates', env);
+      const s = readState(tmpDir) as any;
+      // No reset happened, no lastResetBy recorded
+      expect(s.lastResetBy).toBeUndefined();
+    });
+  });
+});

--- a/tests/bin/simplify-classify.test.ts
+++ b/tests/bin/simplify-classify.test.ts
@@ -1,0 +1,324 @@
+/**
+ * System tests for bin/simplify-classify.cjs (issue #908 part 2).
+ *
+ * Drives the *real* classifier as a subprocess, piping synthetic diffs over
+ * stdin. Asserts on the dispatch decision (tier, agentCount, model). This
+ * directly verifies the cost-control behavior the issue cares about:
+ *
+ *   - #906-shape (mechanical decomposition)  → SMALL / 1 agent / sonnet
+ *   - tiny diff                              → TRIVIAL / 0 agents
+ *   - small logic edit                       → SMALL / 1 agent
+ *   - large diff with new logic              → NORMAL / 3 agents
+ *   - security-path + new logic              → NORMAL / 3 agents
+ *   - never returns opus                     → ALL cases
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { resolve } from 'path';
+import { parseDiff, decide, classifyDiff } from '../../bin/simplify-classify.cjs';
+
+const CLASSIFIER = resolve(__dirname, '../../bin/simplify-classify.cjs');
+
+function runClassifier(diffText: string): any {
+  const stdout = execFileSync('node', [CLASSIFIER, '--diff'], {
+    input: diffText, encoding: 'utf-8', timeout: 15000,
+  });
+  return JSON.parse(stdout);
+}
+
+// ── Diff fixtures ────────────────────────────────────────────────────────────
+
+/** A mechanical decomposition diff — 5 functions moved from one file into 5 new
+ *  files. Exact shape of the #906 case. ~330 LOC across 6 files, additions ≈
+ *  deletions, declarations relocate (declAdded ≈ declRemoved, netDecls small). */
+function mechanicalDecompositionDiff(): string {
+  let diff = '';
+  // Original file: 5 functions removed
+  diff += `diff --git a/src/cli/commands/doctor.ts b/src/cli/commands/doctor.ts
+index abc..def 100644
+--- a/src/cli/commands/doctor.ts
++++ b/src/cli/commands/doctor.ts
+@@ -1,40 +1,5 @@
+-export function checkDaemon() {
+-  // ... 30 lines of body
+-  const x = 1;
+-  return x;
+-}
+-export function checkSession() {
+-  return true;
+-}
+-export function checkMemory() {
+-  return 1;
+-}
+-export function checkSwarm() {
+-  return 2;
+-}
+-export function checkAidefence() {
+-  return 3;
+-}
++import { checkDaemon } from './doctor/daemon.js';
++import { checkSession } from './doctor/session.js';
++import { checkMemory } from './doctor/memory.js';
++import { checkSwarm } from './doctor/swarm.js';
++import { checkAidefence } from './doctor/aidefence.js';
+`;
+  const newFiles = ['daemon', 'session', 'memory', 'swarm', 'aidefence'];
+  for (const f of newFiles) {
+    diff += `diff --git a/src/cli/commands/doctor/${f}.ts b/src/cli/commands/doctor/${f}.ts
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/src/cli/commands/doctor/${f}.ts
+@@ -0,0 +1,5 @@
++export function check${f.charAt(0).toUpperCase() + f.slice(1)}() {
++  // body
++  const x = 1;
++  return x;
++}
+`;
+  }
+  return diff;
+}
+
+/** A small logic edit — ~25 lines changed, 1 file, no declarations added/removed. */
+function smallLogicEditDiff(): string {
+  return `diff --git a/src/foo.ts b/src/foo.ts
+index abc..def 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -10,5 +10,30 @@
+   if (x > 0) {
+-    return x;
++    if (cache.has(x)) return cache.get(x);
++    const result = x * 2;
++    cache.set(x, result);
++    if (result > MAX) {
++      log.warn('exceeded');
++      return MAX;
++    }
++    return result;
+   }
++  if (x === 0) {
++    if (zeroCache.size > 0) {
++      return zeroCache.values().next().value;
++    }
++    const z = computeZero();
++    zeroCache.add(z);
++    return z;
++  }
++  if (x < 0) {
++    if (negativeCache.has(-x)) return -negativeCache.get(-x);
++    const r = -compute(-x);
++    negativeCache.set(-x, -r);
++    return r;
++  }
+   return -1;
+ }
+`;
+}
+
+/** A trivial typo fix — single comment edit. */
+function trivialTypoDiff(): string {
+  return `diff --git a/src/foo.ts b/src/foo.ts
+index abc..def 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,3 +1,3 @@
+-// fixs the bug
++// fixes the bug
+ export const X = 1;
+`;
+}
+
+/** A genuinely large diff with new logic — 600+ LOC, 8 files, 6 new functions. */
+function largeNewLogicDiff(): string {
+  let diff = '';
+  for (let i = 0; i < 8; i++) {
+    diff += `diff --git a/src/feature/file${i}.ts b/src/feature/file${i}.ts
+index abc..def 100644
+--- a/src/feature/file${i}.ts
++++ b/src/feature/file${i}.ts
+@@ -1,5 +1,80 @@
+ // existing code
++export function newFeatureFn${i}(input: string): string {
++  // 70+ lines of new logic
+`;
+    for (let j = 0; j < 75; j++) {
+      diff += `+  const step${j} = ${j};\n`;
+    }
+    diff += `+  return input;\n+}\n`;
+  }
+  return diff;
+}
+
+/** Security-path edit with new logic. */
+function securityPathNewLogicDiff(): string {
+  return `diff --git a/src/cli/aidefence/scanner.ts b/src/cli/aidefence/scanner.ts
+index abc..def 100644
+--- a/src/cli/aidefence/scanner.ts
++++ b/src/cli/aidefence/scanner.ts
+@@ -10,3 +10,18 @@
+ export class Scanner {
+   scan() { return true; }
+ }
++export class AdvancedScanner {
++  // new logic for the security path
++  scan(input: string): boolean {
++    if (this.dangerous(input)) return false;
++    return this.deep(input);
++  }
++  dangerous(input: string): boolean {
++    return /badpattern/.test(input);
++  }
++  deep(input: string): boolean {
++    return input.length < 1000;
++  }
++}
++export function configureScanner(opts: any) {
++  return new AdvancedScanner();
++}
+`;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('simplify-classify: pure logic via require()', () => {
+  it('mechanical decomposition (#906-shape) → SMALL, 1 agent, sonnet', () => {
+    const decision = classifyDiff(mechanicalDecompositionDiff());
+    expect(decision.tier).toBe('SMALL');
+    expect(decision.agentCount).toBe(1);
+    expect(decision.model).toBe('sonnet');
+    expect(decision.reasoning.join(' ')).toMatch(/relocation/i);
+    expect(decision.stats.fileCount).toBeGreaterThanOrEqual(5);
+  });
+
+  it('trivial typo → TRIVIAL, 0 agents (no agent spawn)', () => {
+    const decision = classifyDiff(trivialTypoDiff());
+    expect(decision.tier).toBe('TRIVIAL');
+    expect(decision.agentCount).toBe(0);
+  });
+
+  it('small logic edit → SMALL, 1 agent', () => {
+    const decision = classifyDiff(smallLogicEditDiff());
+    expect(decision.tier).toBe('SMALL');
+    expect(decision.agentCount).toBe(1);
+    expect(decision.model).toBe('sonnet');
+  });
+
+  it('large new logic → NORMAL, 3 agents', () => {
+    const decision = classifyDiff(largeNewLogicDiff());
+    expect(decision.tier).toBe('NORMAL');
+    expect(decision.agentCount).toBe(3);
+    expect(decision.model).toBe('sonnet');
+    expect(decision.reasoning.join(' ')).toMatch(/>500 LOC|new declaration/i);
+  });
+
+  it('security path + new logic → NORMAL, 3 agents', () => {
+    const decision = classifyDiff(securityPathNewLogicDiff());
+    expect(decision.tier).toBe('NORMAL');
+    expect(decision.agentCount).toBe(3);
+    expect(decision.stats.securityHit).toBe(true);
+    expect(decision.reasoning.join(' ')).toMatch(/security/i);
+  });
+
+  it('empty diff → TRIVIAL', () => {
+    const decision = classifyDiff('');
+    expect(decision.tier).toBe('TRIVIAL');
+    expect(decision.agentCount).toBe(0);
+  });
+
+  it('never returns opus, regardless of input', () => {
+    for (const fixture of [
+      mechanicalDecompositionDiff(),
+      trivialTypoDiff(),
+      smallLogicEditDiff(),
+      largeNewLogicDiff(),
+      securityPathNewLogicDiff(),
+    ]) {
+      const decision = classifyDiff(fixture);
+      expect(decision.model).not.toBe('opus');
+      expect(decision.model).toBe('sonnet');
+    }
+  });
+});
+
+describe('simplify-classify: parseDiff stats', () => {
+  it('counts adds/deletes correctly on the mechanical fixture', () => {
+    const stats = parseDiff(mechanicalDecompositionDiff());
+    expect(stats.added).toBeGreaterThan(20);
+    expect(stats.deleted).toBeGreaterThan(10);
+    expect(stats.declAdded).toBeGreaterThanOrEqual(5);
+    expect(stats.declRemoved).toBeGreaterThanOrEqual(5);
+    // Net new declarations should be small for mechanical moves
+    expect(Math.abs(stats.netDecls)).toBeLessThanOrEqual(2);
+  });
+
+  it('flags security path correctly', () => {
+    const stats = parseDiff(securityPathNewLogicDiff());
+    expect(stats.securityHit).toBe(true);
+  });
+
+  it('counts new files', () => {
+    const stats = parseDiff(mechanicalDecompositionDiff());
+    expect(stats.newFiles).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('simplify-classify: decide() boundary cases', () => {
+  it('balance ratio threshold — 0.6 means 60% balanced', () => {
+    // 100 added / 60 deleted = 0.6 — should still trip relocation if decls match
+    const decision = decide({
+      added: 100, deleted: 60, declAdded: 5, declRemoved: 5,
+      netDecls: 0, fileCount: 4, newFiles: 0, renamedFiles: 0, securityHit: false, files: [],
+    });
+    expect(decision.tier).toBe('SMALL');
+    expect(decision.reasoning.join(' ')).toMatch(/relocation/i);
+  });
+
+  it('add-heavy new-feature diff is NOT classified as relocation', () => {
+    // 6 new declarations, only 1 removed — this is a new feature, not a move.
+    const decision = decide({
+      added: 200, deleted: 20, declAdded: 6, declRemoved: 1,
+      netDecls: 5, fileCount: 4, newFiles: 0, renamedFiles: 0, securityHit: false, files: [],
+    });
+    // Reasoning must not say "relocation" — that's the false-positive guard.
+    // (Whether it lands SMALL or NORMAL is a separate routing decision; the
+    // user's rule is "single agent unless warranted" so 220 LOC / 4 files
+    // can legitimately stay SMALL.)
+    expect(decision.reasoning.join(' ')).not.toMatch(/relocation/i);
+  });
+
+  it('1-line touch on security path is still SMALL (no new logic)', () => {
+    const decision = decide({
+      added: 1, deleted: 1, declAdded: 0, declRemoved: 0,
+      netDecls: 0, fileCount: 1, newFiles: 0, renamedFiles: 0, securityHit: true, files: ['src/cli/aidefence/x.ts'],
+    });
+    // Security hit alone does not escalate — only security + new declarations
+    expect(decision.agentCount).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('simplify-classify: end-to-end CLI invocation', () => {
+  it('CLI returns JSON with the expected shape', () => {
+    const decision = runClassifier(mechanicalDecompositionDiff());
+    expect(decision).toMatchObject({
+      tier: 'SMALL',
+      agentCount: 1,
+      model: 'sonnet',
+    });
+    expect(Array.isArray(decision.reasoning)).toBe(true);
+    expect(decision.stats).toBeDefined();
+  });
+
+  it('CLI handles trivial diff', () => {
+    const decision = runClassifier(trivialTypoDiff());
+    expect(decision.tier).toBe('TRIVIAL');
+    expect(decision.agentCount).toBe(0);
+  });
+
+  it('CLI handles large diff', () => {
+    const decision = runClassifier(largeNewLogicDiff());
+    expect(decision.tier).toBe('NORMAL');
+    expect(decision.agentCount).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Two-part fix for the recurring "/simplify costing ~250K tokens per run" problem.

**Part 1 — gate scope.** `check-before-pr`'s "code edit" reset was a single regex — touching `tests/foo.test.ts` after `/simplify` ran would invalidate both `testsRun` AND `simplifyRun`, forcing another full simplify pass for a behaviorally null test tweak. Now split into `EDIT_RESET_SKIP_BOTH_RE` (markdown/lockfiles — resets neither) and `EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE` (tests/specs/__tests__/__mocks__/cypress/e2e/fixtures — invalidates `testsRun` only). Plus `lastResetBy` tracking so the blocked PR message lists *which file* tripped the reset.

**Part 2 — deterministic routing.** `/simplify`'s SKILL.md had prose tier rules that Claude re-derived per run. On the #906 decomposition this fanned out three Opus-tier agents over ~95% mechanical file moves and burned ~230K tokens. New `bin/simplify-classify.cjs` is a programmatic classifier called from SKILL.md — returns `{tier, model, agentCount, reasoning}` based on diff stats. Defaults to **single Sonnet agent**; escalates to 3 agents only on real signals (>500 LOC, broad new declarations, security paths with new logic). Mechanical relocation (declAdded ≈ declRemoved, small netDecls) stays SMALL regardless of file count. Always Sonnet, never Opus.

## Verification — actual end-to-end behavior, not just unit assertions

- **29 system tests** in `tests/bin/gate-edit-reset-908.test.ts` spawn the real `gate.cjs` as a subprocess and assert on workflow-state mutations + `gh pr create` exit codes for the full simplify→edit→PR lifecycle (test-file edit, source-file edit, markdown edit, lastResetBy surfacing).
- **16 classifier tests** in `tests/bin/simplify-classify.test.ts` feed synthetic diffs (mechanical decomposition matching the #906 shape, trivial typo, small logic edit, large new-logic, security-path + new logic) over stdin to the CLI and assert on the dispatch decision. Mechanical decomposition fixture → SMALL/1 agent/sonnet (the cost-savings case).
- **All 153 existing gate-helpers tests still pass** + drift guard updated.
- **Live proof in the implementing session**: edited a test file mid-PR; gate state showed `lastResetBy.gates=['tests']` and `simplifyRun: true` preserved — exactly the #908 acceptance criteria firing in production.

## Acceptance criteria

- [x] Editing only test files after `/simplify` does NOT block `gh pr create` *(gate-edit-reset-908.test.ts:97)*
- [x] Editing only `.md` files after `/simplify` does NOT block *(gate-edit-reset-908.test.ts:163)*
- [x] Editing any source file DOES still block until simplify reruns *(gate-edit-reset-908.test.ts:115)*
- [x] The gate's blocked message lists which file(s) tripped it *(gate-edit-reset-908.test.ts:140)*
- [x] `/simplify` on a pure file-move diff routes to Sonnet single-agent *(simplify-classify.test.ts:177)*
- [x] `/simplify` on a security-sensitive diff with new logic routes to 3-agent *(simplify-classify.test.ts:209)*
- [x] The dispatch decision is logged so the user can see which tier fired and why *(every classifier output includes `reasoning[]`)*
- [x] Token cost on a #906-shaped pass routes to single agent (the 230K → ~35K savings is the design target)

## Test plan
- [x] `npx vitest run tests/bin/simplify-classify.test.ts` — 16/16 pass
- [x] `npx vitest run --config vitest.isolation.config.ts tests/bin/gate-edit-reset-908.test.ts tests/bin/gate-helpers.test.ts` — 182/182 pass
- [x] `npm test` — 7882 pass (one pre-existing process-manager-stress flake unrelated to this PR; passes in isolation)
- [x] Live: `node bin/simplify-classify.cjs --base main` against this branch returns NORMAL/3-agent (correct: 952 LOC / security paths / new declarations) — proves the classifier escalates appropriately for diffs that warrant it

Closes #908

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)