### PR TITLE
fix(907): smoke harness --summary mode (auto-on for non-TTY)

### DIFF
--- a/.claude/helpers/simplify-classify.cjs
+++ b/.claude/helpers/simplify-classify.cjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * /simplify diff classifier — issue #908.
+ *
+ * Decides which review tier the current diff warrants and returns a JSON
+ * dispatch decision. The /simplify skill MUST call this first so routing is
+ * deterministic and unit-testable instead of a prose decision Claude makes
+ * over and over per run.
+ *
+ * Rule (per user direction): default to single-agent Sonnet review. Only
+ * escalate to a 3-agent fan-out when diff signals genuinely warrant it.
+ * Opus is never selected — the existing skill already documents that.
+ *
+ * Outputs JSON:
+ *   {
+ *     "tier": "TRIVIAL" | "SMALL" | "NORMAL",
+ *     "model": "sonnet",
+ *     "agentCount": 0 | 1 | 3,
+ *     "reasoning": [string, ...],
+ *     "stats": { added, deleted, fileCount, declAdded, declRemoved, ... }
+ *   }
+ *
+ * Usage:
+ *   node bin/simplify-classify.cjs [--base main]
+ *   node bin/simplify-classify.cjs --diff <unified-diff-on-stdin>
+ *
+ * The --diff stdin form exists so unit tests can drive the classifier
+ * with synthetic diffs (no git repo required).
+ */
+'use strict';
+
+const { execSync } = require('child_process');
+
+// Paths where new logic warrants the 3-agent fan-out (issue #908).
+// Mechanical edits inside these paths are still SMALL; only adding/removing
+// declarations triggers escalation.
+const SECURITY_PATHS = [
+  /(?:^|[\\\/])aidefence[\\\/]/i,
+  /(?:^|[\\\/])swarm[\\\/]consensus[\\\/]/i,
+  /(?:^|[\\\/])hooks?[\\\/](?:handlers?|gate|wiring)/i,
+  /(?:^|[\\\/])services[\\\/]daemon-lock\.ts$/i,
+  /(?:^|[\\\/])bin[\\\/]gate\./i,
+  /(?:^|[\\\/])bin[\\\/]session-start-launcher\./i,
+  /(?:^|[\\\/])\.claude[\\\/]helpers[\\\/]gate/i,
+];
+
+function safeExec(cmd) {
+  try { return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }); }
+  catch { return ''; }
+}
+
+function readDiffFromGit(base) {
+  // Combined diff: committed-since-base + working-tree
+  const committed = safeExec(`git diff ${base}...HEAD`);
+  const working = safeExec('git diff HEAD');
+  return committed + (working ? '\n' + working : '');
+}
+
+/**
+ * Parse a unified-diff string into per-file stats and aggregate signals.
+ * No git/I/O — pure function over the diff text. Test-friendly.
+ */
+function parseDiff(diff) {
+  const lines = diff.split('\n');
+  const files = new Map(); // filename → { added, deleted, declAdded, declRemoved, isNew, isRenamed }
+  let current = null;
+
+  // Match function/class/export-const-arrow/method declarations being
+  // added or removed. Conservative — biased toward false negatives so we
+  // don't over-escalate.
+  const DECL_RE = /^(?:export\s+)?(?:default\s+)?(?:async\s+)?(?:function|class|interface|type)\s+\w/;
+  const ARROW_DECL_RE = /^(?:export\s+)?(?:const|let|var)\s+\w+\s*[:=].*=>\s*\{?$/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+
+    // File header: `diff --git a/path b/path`
+    let m = ln.match(/^diff --git (?:a\/)?(.+?) (?:b\/)?(.+)$/);
+    if (m) {
+      const filename = m[2];
+      current = { filename, added: 0, deleted: 0, declAdded: 0, declRemoved: 0, isNew: false, isRenamed: false };
+      files.set(filename, current);
+      continue;
+    }
+    if (!current) continue;
+
+    if (ln.startsWith('new file mode')) current.isNew = true;
+    if (ln.startsWith('rename from') || ln.startsWith('rename to') || ln.startsWith('similarity index')) current.isRenamed = true;
+
+    // Skip diff headers
+    if (ln.startsWith('+++') || ln.startsWith('---') || ln.startsWith('@@') || ln.startsWith('index ')) continue;
+
+    if (ln.startsWith('+') && !ln.startsWith('+++')) {
+      current.added++;
+      const body = ln.slice(1).trim();
+      if (DECL_RE.test(body) || ARROW_DECL_RE.test(body)) current.declAdded++;
+    } else if (ln.startsWith('-') && !ln.startsWith('---')) {
+      current.deleted++;
+      const body = ln.slice(1).trim();
+      if (DECL_RE.test(body) || ARROW_DECL_RE.test(body)) current.declRemoved++;
+    }
+  }
+
+  // Aggregate
+  let added = 0, deleted = 0, declAdded = 0, declRemoved = 0;
+  let newFiles = 0, renamedFiles = 0;
+  let securityHit = false;
+  for (const f of files.values()) {
+    added += f.added;
+    deleted += f.deleted;
+    declAdded += f.declAdded;
+    declRemoved += f.declRemoved;
+    if (f.isNew) newFiles++;
+    if (f.isRenamed) renamedFiles++;
+    if (SECURITY_PATHS.some(rx => rx.test(f.filename))) securityHit = true;
+  }
+
+  return {
+    added, deleted, declAdded, declRemoved,
+    netDecls: declAdded - declRemoved,
+    fileCount: files.size,
+    newFiles, renamedFiles,
+    securityHit,
+    files: [...files.keys()],
+  };
+}
+
+/**
+ * Pure decision function. Takes parsed stats, returns dispatch decision.
+ * No I/O. Easy to unit-test with synthetic stats.
+ */
+function decide(stats) {
+  const reasoning = [];
+  const totalChange = stats.added + stats.deleted;
+
+  if (totalChange === 0) {
+    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, reasoning: ['empty diff — nothing to review'], stats };
+  }
+
+  // TRIVIAL: tiny diff, no declarations changed
+  if (totalChange <= 10 && stats.fileCount <= 1 && stats.netDecls === 0 && stats.declAdded === 0 && stats.declRemoved === 0) {
+    reasoning.push(`≤10 LOC in 1 file with no declaration changes`);
+    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, reasoning, stats };
+  }
+
+  // Mechanical relocation detection — the #906 case.
+  // If declarations were both ADDED and REMOVED at roughly matching rates,
+  // it's a structural move, not net-new logic. Judge by declaration balance,
+  // not raw LOC balance — formatting/blank-line differences between source
+  // and destination files easily push raw LOC out of balance even when the
+  // semantic change is purely "moved 5 functions across 5 new files".
+  // Mechanical relocations are SMALL even when many files / many lines.
+  const declTouched = stats.declAdded + stats.declRemoved;
+  const isMostlyRelocation = stats.declAdded >= 2
+    && stats.declRemoved >= 2
+    && Math.abs(stats.netDecls) <= Math.max(2, Math.floor(declTouched * 0.30));
+
+  if (isMostlyRelocation) {
+    reasoning.push(
+      `mostly relocation: ${stats.declAdded} decls added, ${stats.declRemoved} removed, net ${stats.netDecls >= 0 ? '+' : ''}${stats.netDecls}`,
+    );
+    return { tier: 'SMALL', model: 'sonnet', agentCount: 1, reasoning, stats };
+  }
+
+  // Escalation triggers — any one trips NORMAL (3 agents).
+  // Always Sonnet — Opus is never the right model for /simplify per skill rule.
+  const triggers = [];
+  if (totalChange > 500) triggers.push(`>500 LOC changed (${totalChange})`);
+  if (stats.fileCount >= 5 && stats.netDecls >= 3) triggers.push(`${stats.fileCount} files with ${stats.netDecls} net new declarations`);
+  if (stats.securityHit && stats.netDecls > 0) triggers.push('security-sensitive path with new logic');
+  if (stats.newFiles >= 3 && stats.declAdded >= 5) triggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+
+  if (triggers.length > 0) {
+    return { tier: 'NORMAL', model: 'sonnet', agentCount: 3, reasoning: triggers, stats };
+  }
+
+  // Default: SMALL — single sonnet agent
+  reasoning.push(`small/medium diff: ${totalChange} LOC across ${stats.fileCount} file(s), +${stats.declAdded}/-${stats.declRemoved} decls`);
+  return { tier: 'SMALL', model: 'sonnet', agentCount: 1, reasoning, stats };
+}
+
+function classifyDiff(diffText) {
+  return decide(parseDiff(diffText));
+}
+
+function classifyFromGit(base = 'main') {
+  return classifyDiff(readDiffFromGit(base));
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const baseIdx = args.indexOf('--base');
+  const base = baseIdx >= 0 ? args[baseIdx + 1] : 'main';
+  const stdinDiff = args.includes('--diff') || args.includes('--stdin');
+
+  let result;
+  if (stdinDiff) {
+    let buf = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (d) => { buf += d; });
+    process.stdin.on('end', () => {
+      result = classifyDiff(buf);
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    });
+  } else {
+    result = classifyFromGit(base);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  }
+}
+
+module.exports = { parseDiff, decide, classifyDiff, classifyFromGit };

--- a/harness/consumer-smoke/lib/report.mjs
+++ b/harness/consumer-smoke/lib/report.mjs
@@ -1,30 +1,78 @@
 /**
  * Smoke-harness reporting: structured status records + summary output.
  * status values: 'pass' | 'fail' | 'warn' | 'info'
+ *
+ * Summary mode (issue #907): suppress per-check PASS/INFO rows and section
+ * dividers when the run is going to a log file or an LLM tool. Section
+ * headers are deferred and only emitted lazily when a FAIL/WARN lands inside
+ * the section — so the reader sees the failure with its breadcrumb.
  */
 
 const results = [];
-const started = Date.now();
+let started = Date.now();
 let jsonMode = false;
+let summaryMode = false;
+let pendingSection = null;
 
-export function configure({ json }) { jsonMode = !!json; }
+export function configure({ json, summary } = {}) {
+  jsonMode = !!json;
+  summaryMode = !!summary;
+}
 
-export function log(...args) { if (!jsonMode) console.log(...args); }
+export function log(...args) {
+  if (jsonMode || summaryMode) return;
+  console.log(...args);
+}
+
+function emitSection(title) {
+  const bar = '─'.repeat(Math.max(1, 60 - title.length - 4));
+  console.log(`\n── ${title} ${bar}`);
+}
 
 export function section(title) {
   if (jsonMode) return;
-  const bar = '─'.repeat(Math.max(1, 60 - title.length - 4));
-  log(`\n── ${title} ${bar}`);
+  if (summaryMode) {
+    pendingSection = title;
+    return;
+  }
+  emitSection(title);
 }
 
 export function record(step, status, detail) {
   results.push({ step, status, detail });
   if (jsonMode) return;
+  if (summaryMode && status !== 'fail' && status !== 'warn') return;
+  if (summaryMode && pendingSection) {
+    emitSection(pendingSection);
+    pendingSection = null;
+  }
   const icon = { pass: 'PASS', fail: 'FAIL', warn: 'WARN', info: 'INFO' }[status] ?? '----';
-  log(`[${icon}] ${step}${detail ? ` — ${detail}` : ''}`);
+  console.log(`[${icon}] ${step}${detail ? ` — ${detail}` : ''}`);
 }
 
 export function getResults() { return results; }
+
+/**
+ * Issue #907: resolve summary mode from argv. Explicit `--summary` /
+ * `--no-summary` win; otherwise default to summary when stdout is non-TTY
+ * (piped to a file or LLM tool) and not in --json mode. Shared by both
+ * harness runners so flag semantics can't drift.
+ */
+export function resolveSummaryMode(argv, { isTTY = process.stdout.isTTY } = {}) {
+  if (argv.includes('--no-summary')) return false;
+  if (argv.includes('--summary')) return true;
+  if (argv.includes('--json')) return false;
+  return isTTY === false;
+}
+
+/** Test-only: reset module-level state between cases. */
+export function _resetForTest() {
+  results.length = 0;
+  jsonMode = false;
+  summaryMode = false;
+  pendingSection = null;
+  started = Date.now();
+}
 
 /**
  * Collapse the `record(step, res.code === 0 ? 'pass' : 'fail', res.code === 0 ? '' : 'exit N…')`

--- a/harness/consumer-smoke/run-populated.mjs
+++ b/harness/consumer-smoke/run-populated.mjs
@@ -11,6 +11,8 @@
  *   node harness/consumer-smoke/run-populated.mjs              # full run
  *   node harness/consumer-smoke/run-populated.mjs --skip-pack  # reuse last tarball
  *   node harness/consumer-smoke/run-populated.mjs --keep       # keep .work for inspection
+ *   node harness/consumer-smoke/run-populated.mjs --summary    # suppress PASS rows; failures + tail only (auto-on when stdout is non-TTY)
+ *   node harness/consumer-smoke/run-populated.mjs --no-summary # force verbose output even when piped
  *   node harness/consumer-smoke/run-populated.mjs --tarball PATH
  *
  * Exit codes:
@@ -37,12 +39,13 @@ const opts = {
   keep: argv.includes('--keep'),
   verbose: argv.includes('--verbose') || argv.includes('-v'),
   json: argv.includes('--json'),
+  summary: report.resolveSummaryMode(argv),
   tarball: null,
 };
 const tIdx = argv.indexOf('--tarball');
 if (tIdx !== -1 && argv[tIdx + 1]) opts.tarball = resolve(argv[tIdx + 1]);
 
-report.configure({ json: opts.json });
+report.configure({ json: opts.json, summary: opts.summary });
 proc.configure({ verbose: opts.verbose });
 
 async function main() {

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -23,6 +23,8 @@
  *   node harness/consumer-smoke/run.mjs --keep         # keep .work for inspection
  *   node harness/consumer-smoke/run.mjs --verbose      # stream subprocess output
  *   node harness/consumer-smoke/run.mjs --json         # machine-readable summary
+ *   node harness/consumer-smoke/run.mjs --summary      # suppress PASS rows; failures + tail only (auto-on when stdout is non-TTY)
+ *   node harness/consumer-smoke/run.mjs --no-summary   # force verbose output even when piped
  *   node harness/consumer-smoke/run.mjs --tarball PATH # use an existing tarball
  *
  * Exit codes:
@@ -48,12 +50,13 @@ const opts = {
   keep: argv.includes('--keep'),
   verbose: argv.includes('--verbose') || argv.includes('-v'),
   json: argv.includes('--json'),
+  summary: report.resolveSummaryMode(argv),
   tarball: null,
 };
 const tIdx = argv.indexOf('--tarball');
 if (tIdx !== -1 && argv[tIdx + 1]) opts.tarball = resolve(argv[tIdx + 1]);
 
-report.configure({ json: opts.json });
+report.configure({ json: opts.json, summary: opts.summary });
 proc.configure({ verbose: opts.verbose });
 
 async function main() {

--- a/tests/harness/report.test.ts
+++ b/tests/harness/report.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for harness/consumer-smoke/lib/report.mjs (issue #907).
+ *
+ * Verifies summary-mode behavior: pass/info rows + section dividers are
+ * suppressed; section headers lazy-emit when a fail/warn lands inside; the
+ * tail (Summary line + Failed: block) always prints.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+// .mjs ESM module — vitest resolves the relative path from project root.
+// @ts-ignore — JS module without .d.ts.
+import * as report from '../../harness/consumer-smoke/lib/report.mjs';
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+function lines(): string[] {
+  return logSpy.mock.calls.map((c: any[]) => String(c[0]));
+}
+
+beforeEach(() => {
+  report._resetForTest();
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+});
+
+describe('report.resolveSummaryMode', () => {
+  it('--no-summary wins over everything', () => {
+    expect(report.resolveSummaryMode(['--no-summary', '--summary'], { isTTY: false })).toBe(false);
+  });
+
+  it('--summary forces on', () => {
+    expect(report.resolveSummaryMode(['--summary'], { isTTY: true })).toBe(true);
+  });
+
+  it('--json suppresses auto-default', () => {
+    expect(report.resolveSummaryMode(['--json'], { isTTY: false })).toBe(false);
+  });
+
+  it('non-TTY auto-enables summary', () => {
+    expect(report.resolveSummaryMode([], { isTTY: false })).toBe(true);
+  });
+
+  it('TTY default leaves summary off', () => {
+    expect(report.resolveSummaryMode([], { isTTY: true })).toBe(false);
+  });
+});
+
+describe('report summary mode', () => {
+  it('all-pass run prints only the tail (Summary line + closer)', () => {
+    report.configure({ summary: true });
+    report.section('Verify dist hygiene');
+    report.record('check-a', 'pass');
+    report.record('check-b', 'pass');
+    report.section('Doctor');
+    report.record('doctor', 'pass', 'exit 0');
+    report.printSummary();
+
+    const out = lines();
+    expect(out.some(l => l.includes('[PASS]'))).toBe(false);
+    expect(out.some(l => l.startsWith('── '))).toBe(false);
+    expect(out.some(l => l.startsWith('Summary:'))).toBe(true);
+    expect(out.some(l => l.includes('Failed:'))).toBe(false);
+  });
+
+  it('failure inside a section emits the section header lazily, then the FAIL line', () => {
+    report.configure({ summary: true });
+    report.section('Verify dist hygiene');
+    report.record('check-a', 'pass');
+    report.section('Doctor');
+    report.record('doctor', 'fail', 'exit 1: boom');
+    report.printSummary();
+
+    const out = lines();
+    const passes = out.filter(l => l.includes('[PASS]'));
+    expect(passes.length).toBe(0);
+    const headers = out.filter(l => l.startsWith('\n── '));
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toContain('Doctor');
+    expect(out.some(l => l.includes('[FAIL] doctor — exit 1: boom'))).toBe(true);
+    expect(out.some(l => l.includes('Failed:'))).toBe(true);
+  });
+
+  it('warn behaves like fail for header emission', () => {
+    report.configure({ summary: true });
+    report.section('Hooks surface');
+    report.record('hooks-known', 'warn', 'known regression');
+    report.printSummary();
+
+    const out = lines();
+    expect(out.some(l => l.includes('── Hooks surface'))).toBe(true);
+    expect(out.some(l => l.includes('[WARN] hooks-known'))).toBe(true);
+  });
+
+  it('multiple fails in same section emit header once', () => {
+    report.configure({ summary: true });
+    report.section('Doctor');
+    report.record('a', 'fail', 'x');
+    report.record('b', 'fail', 'y');
+    report.printSummary();
+
+    const out = lines();
+    const headers = out.filter(l => l.startsWith('\n── '));
+    expect(headers).toHaveLength(1);
+    expect(out.some(l => l.includes('[FAIL] a'))).toBe(true);
+    expect(out.some(l => l.includes('[FAIL] b'))).toBe(true);
+  });
+
+  it('section with only passes is fully suppressed even after a later failing section', () => {
+    report.configure({ summary: true });
+    report.section('Quiet section');
+    report.record('quiet-1', 'pass');
+    report.record('quiet-2', 'pass');
+    report.section('Loud section');
+    report.record('loud-1', 'fail', 'oops');
+    report.printSummary();
+
+    const out = lines();
+    expect(out.some(l => l.includes('Quiet section'))).toBe(false);
+    expect(out.some(l => l.includes('Loud section'))).toBe(true);
+  });
+
+  it('log() calls are suppressed in summary mode', () => {
+    report.configure({ summary: true });
+    report.log('ambient progress chatter');
+    report.printSummary();
+
+    const out = lines();
+    expect(out.some(l => l.includes('ambient progress chatter'))).toBe(false);
+  });
+});
+
+describe('report verbose (default) mode unchanged', () => {
+  it('prints PASS rows + section headers', () => {
+    report.configure({});
+    report.section('Doctor');
+    report.record('doctor', 'pass', 'exit 0');
+    report.printSummary();
+
+    const out = lines();
+    expect(out.some(l => l.includes('── Doctor'))).toBe(true);
+    expect(out.some(l => l.includes('[PASS] doctor'))).toBe(true);
+    expect(out.some(l => l.startsWith('Summary:'))).toBe(true);
+  });
+});
+
+describe('report json mode unaffected', () => {
+  it('emits a single JSON object and nothing else', () => {
+    report.configure({ json: true });
+    report.section('ignored');
+    report.record('a', 'pass');
+    report.record('b', 'fail', 'boom');
+    report.printSummary();
+
+    const out = lines();
+    expect(out.length).toBe(1);
+    const parsed = JSON.parse(out[0]);
+    expect(parsed.pass).toBe(1);
+    expect(parsed.fail).toBe(1);
+    expect(parsed.results).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `--summary` to `run.mjs` / `run-populated.mjs` that suppresses per-check `[PASS]` rows + section dividers; auto-on when `stdout.isTTY === false` (log files, LLM tool calls).
- Section headers are deferred — only lazy-emitted when a `[FAIL]` / `[WARN]` lands inside, so the reader sees the failure with its breadcrumb. Pass/info records and ambient `log()` chatter are dropped.
- `--no-summary` overrides the auto-default; `--json` mode unchanged.
- Real-run measure: 200-line green log → 3 lines in summary mode. Failing runs still print the failed section header + full `[FAIL]` line + tail.

## Why
Case study #903 — single dev session tail/grep'd 5+ smoke runs; each round-trip cost ~5K tokens loading the full PASS-line list to find the summary line. Verifying a fix only needs failure detail + summary; the per-check breakdown is decoration.

## Implementation
- `lib/report.mjs`: `configure({ json, summary })` extended; new `summaryMode` + `pendingSection` state; `section()` defers in summary mode, `record()` lazy-emits the pending header on first fail/warn and suppresses pass/info; new shared `resolveSummaryMode(argv, { isTTY })` so both runners can't drift; `_resetForTest` for unit tests.
- `run.mjs` + `run-populated.mjs`: parse the flag via the shared helper, pass `summary` to `configure`.
- `tests/harness/report.test.ts`: 13 new vitest cases covering the flag matrix, lazy header behavior, suppression, and json/verbose modes still untouched.

## Decision
Non-TTY auto-enables summary (the new default for piped runs). TTY behavior is unchanged.

## Test plan
- [x] \`npx vitest run tests/harness/report.test.ts\` — 13/13 pass
- [x] \`node harness/consumer-smoke/run.mjs --skip-pack --summary\` piped — 18 lines (with one unrelated doctor failure on this workspace), tail emits Summary + Failed
- [x] \`node harness/consumer-smoke/run.mjs --skip-pack --no-summary\` piped — 160 lines (verbose preserved when overridden)
- [x] Existing classifier tests still green — \`tests/bin/simplify-classify.test.ts\`

Closes #907

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)