### PR TITLE
docs(909): codify 'filter at source, never tee-then-read' for verbose commands

### DIFF
--- a/.claude/guidance/shipped/moflo-core-guidance.md
+++ b/.claude/guidance/shipped/moflo-core-guidance.md
@@ -307,3 +307,4 @@ See `moflo-memory-strategy.md` for memory-specific troubleshooting.
 - `.claude/guidance/shipped/moflo-session-start.md` — Complete session-start lifecycle (DB heal, sync, migrations, daemon)
 - `.claude/guidance/shipped/moflo-settings-injection.md` — What moflo writes into `.claude/` and how surgical self-heal works
 - `.claude/guidance/shipped/moflo-cross-platform.md` — Windows/macOS/Linux portability rules for any code change
+- `.claude/guidance/shipped/moflo-verbose-command-filtering.md` — Filter long verbose commands at the source; never tee-then-grep

--- a/.claude/guidance/shipped/moflo-verbose-command-filtering.md
+++ b/.claude/guidance/shipped/moflo-verbose-command-filtering.md
@@ -1,0 +1,45 @@
+# Verbose Command Filtering — Filter at Source, Never Tee-Then-Read
+
+**Purpose:** Pipe long verbose commands (smoke runs, full test suites, builds with `--verbose`) through a filter at execution time so only relevant lines reach the model context. Never tee output to disk and `tail`/`grep` it later — every follow-up read re-loads the full file into context (~5K tokens per round-trip).
+
+---
+
+## The Rule
+
+| Pattern | Verdict |
+|---------|---------|
+| `cmd 2>&1 \| grep -E "FAIL\|Summary"` (run_in_background) | ✅ Filter at source |
+| `cmd 2>&1 \| tee .tmp.log` then later `tail`/`grep` `.tmp.log` | ❌ Tee-then-read |
+
+Tee-then-read is the silent context killer. The Bash tool surfaces stdout into context, so each follow-up `grep`/`tail` of a tee'd file re-reads the file fresh on every call. Three follow-ups burn 15K+ tokens before any decision lands. Filtering at source emits the matching lines once.
+
+## When to Apply
+
+Smoke harness runs, full `vitest`/`jest` suites, builds with `--verbose`, anything passing `--trace`, any `node ... --verbose` invocation. If you genuinely need the full log for post-mortem, write it to disk but inspect it OUTSIDE the model loop (have the user open it, attach it to an issue) — do NOT pipe a tee'd file back through Bash.
+
+## Concrete Examples
+
+```bash
+# ✅ Smoke harness
+node harness/consumer-smoke/run.mjs 2>&1 | grep -E "FAIL|Summary|Zombie"
+# ❌ node harness/consumer-smoke/run.mjs 2>&1 | tee .tmp.log; tail .tmp.log
+
+# ✅ Vitest full suite
+npm test -- --reporter=verbose 2>&1 | grep -E "FAIL|✗|Error:"
+# ❌ npm test 2>&1 | tee .test.log; grep FAIL .test.log
+
+# ✅ Build with verbose
+npm run build -- --verbose 2>&1 | grep -E "error TS|Failed|Cannot find"
+# ❌ npm run build 2>&1 | tee .build.log; grep "error TS" .build.log
+```
+
+## Why It Matters
+
+Case study: issue #903 burned ~25K tokens across 5 tee-then-grep round-trips where a single grep-at-source would have surfaced the same signal once. Filtering at source is not an optimization — it is the default shape for any verbose command whose full output you do not need in your context.
+
+---
+
+## See Also
+
+- `.claude/guidance/shipped/moflo-core-guidance.md` — Hub for moflo's CLI/MCP surface and runtime conventions
+- `.claude/guidance/shipped/moflo-memory-strategy.md` — Companion rules on RAG indexing and context discipline


### PR DESCRIPTION
## Summary

- Add `.claude/guidance/shipped/moflo-verbose-command-filtering.md` (45 lines) — codifies the rule for smoke runs, full test suites, and verbose builds.
- Cross-link from `moflo-core-guidance.md` See Also.

## Why

Case study #903: 5 tee-then-grep round-trips burned ~25K tokens where one grep-at-source would have surfaced the same signal once. The Bash tool surfaces stdout into model context, so each follow-up \`grep\`/\`tail\` of a tee'd file re-reads the full file. Filtering at the source emits matching lines once and keeps context lean across the whole session.

## Acceptance criteria (from #909)

- [x] New guidance doc < 50 lines (45), follows `shipped/moflo-guidance-rules.md`
- [x] Cross-linked from `moflo-core-guidance.md` See Also
- [x] One concrete example each for smoke / vitest / build

## Test plan

- [x] `npm run build` clean (filtered at source, no errors)
- [x] `commands-deep.test.ts` + `auto-update.test.ts` — 426 tests passed (these own the CLAUDE.md / shipped-guidance assertions)
- [x] `node bin/index-guidance.mjs --file <new-doc>` → 6 chunks indexed, 0 errors
- [x] `npx flo-search "filter at source verbose command"` → new doc ranks #1 (score 0.847)

Closes #909

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)