### PR TITLE
fix(913): classify pre-publish bin/helper gate drift as expected, not fail

### DIFF
--- a/src/cli/__tests__/doctor-checks-deep.test.ts
+++ b/src/cli/__tests__/doctor-checks-deep.test.ts
@@ -16,9 +16,13 @@ import {
   checkMcpSpellIntegration,
   checkHookExecution,
   checkGateHealth,
+  isExpectedPrePublishDrift,
   REQUIRED_HOOK_WIRING,
   type HealthCheck,
 } from '../commands/doctor-checks-deep.js';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 describe('doctor-checks-deep', () => {
   describe('checkSubagentHealth', () => {
@@ -141,6 +145,57 @@ describe('doctor-checks-deep', () => {
       expect(result).toHaveProperty('status');
       expect(result).toHaveProperty('message');
       expect(['pass', 'warn', 'fail']).toContain(result.status);
+    });
+  });
+
+  // #913 — distinguish "expected pre-publish drift" (helper matches installed
+  // bin, source bin is ahead) from genuine helper drift. The first state is
+  // the moflo dogfood steady state between PR-landing and `npm install
+  // moflo@<new>`; surfacing it as `fail` triggered a false-success
+  // "Auto-fixed 1 issue" log line because the auto-fix path was a no-op for
+  // content drift.
+  describe('isExpectedPrePublishDrift (#913)', () => {
+    let tmp: string;
+    let installedBinGate: string;
+
+    beforeEach(() => {
+      tmp = mkdtempSync(join(tmpdir(), 'moflo-913-'));
+      const installedBinDir = join(tmp, 'node_modules', 'moflo', 'bin');
+      mkdirSync(installedBinDir, { recursive: true });
+      installedBinGate = join(installedBinDir, 'gate.cjs');
+    });
+
+    afterEach(() => {
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('returns true when helper matches installed bin and source bin is ahead', () => {
+      writeFileSync(installedBinGate, 'INSTALLED_4_9_13', 'utf8');
+      // helper === installed (correctly synced), source bin is the newer content
+      expect(isExpectedPrePublishDrift(installedBinGate, 'INSTALLED_4_9_13', 'SOURCE_AHEAD')).toBe(true);
+    });
+
+    it('returns false when helper matches source bin (no drift to call out)', () => {
+      writeFileSync(installedBinGate, 'INSTALLED_4_9_13', 'utf8');
+      expect(isExpectedPrePublishDrift(installedBinGate, 'SAME', 'SAME')).toBe(false);
+    });
+
+    it('returns false when helper differs from installed (genuine helper corruption)', () => {
+      writeFileSync(installedBinGate, 'INSTALLED_4_9_13', 'utf8');
+      // Helper drifted from BOTH source and installed → real fail, not pre-publish
+      expect(isExpectedPrePublishDrift(installedBinGate, 'CORRUPTED_HELPER', 'SOURCE_AHEAD')).toBe(false);
+    });
+
+    it('returns false when node_modules/moflo/bin/gate.cjs is missing', () => {
+      // Installed bin not present (consumer never installed moflo, or unusual
+      // path) — fall back to existing drift handling instead of guessing.
+      expect(isExpectedPrePublishDrift(installedBinGate, 'A', 'B')).toBe(false);
+    });
+
+    it('returns false when source bin and installed bin are identical', () => {
+      // No source-vs-installed drift means we're not in the pre-publish window.
+      writeFileSync(installedBinGate, 'PUBLISHED', 'utf8');
+      expect(isExpectedPrePublishDrift(installedBinGate, 'PUBLISHED', 'PUBLISHED')).toBe(false);
     });
   });
 

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -501,6 +501,35 @@ import { REQUIRED_HOOK_WIRING } from '../services/hook-wiring.js';
 export { REQUIRED_HOOK_WIRING };
 
 /**
+ * Detect "expected pre-publish drift" — source `bin/gate.cjs` is ahead of the
+ * installed `node_modules/moflo/bin/gate.cjs`, but the deployed
+ * `.claude/helpers/gate.cjs` still matches the installed version. This is the
+ * steady state in the moflo dogfood repo while a PR has landed but no
+ * `npm install moflo@<new>` has rotated the package.
+ *
+ * Returns true only when both are true:
+ *   - helper content equals installed bin content (helper is correctly synced
+ *     to what's installed)
+ *   - installed bin content differs from source bin content (source is ahead)
+ *
+ * If `node_modules/moflo/bin/gate.cjs` is missing (consumer never installed
+ * moflo, or path is unusual) we conservatively return false so other drift
+ * detection still applies.
+ */
+export function isExpectedPrePublishDrift(
+  installedBinGate: string,
+  helperContent: string,
+  sourceBinContent: string,
+): boolean {
+  try {
+    const installedContent = readFileSync(installedBinGate, 'utf8');
+    return installedContent === helperContent && installedContent !== sourceBinContent;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Verify gate infrastructure health:
  * 1. gate.cjs exists and contains all required cases
  * 2. settings.json hooks reference all required gates
@@ -545,14 +574,28 @@ export async function checkGateHealth(): Promise<HealthCheck> {
   }
 
   // 2. Check bin/gate.cjs sync
+  //
+  // The launcher syncs `node_modules/moflo/bin/gate.cjs` → `.claude/helpers/gate.cjs`
+  // on version change. Source `bin/gate.cjs` is only present in the moflo dogfood
+  // repo. During the dogfood publish window — between a PR landing and the next
+  // `npm install moflo@<new>` — source bin/ legitimately moves ahead of the
+  // installed bin/, while the helper continues to mirror the installed version.
+  // That's the expected steady state, not a bug; downgrade it to `warn` and skip
+  // the `fix` field so `--fix` doesn't paint a false success (#913).
   const binGate = join(projectDir, 'bin', 'gate.cjs');
+  const installedBinGate = join(projectDir, 'node_modules', 'moflo', 'bin', 'gate.cjs');
   if (existsSync(binGate)) {
     try {
       const binContent = readFileSync(binGate, 'utf8');
       if (binContent !== gateContent) {
-        // Check if it's a size difference (likely out of sync) vs whitespace
         const sizeDiff = Math.abs(binContent.length - gateContent.length);
-        if (sizeDiff > 10) {
+        const prePublishDrift = isExpectedPrePublishDrift(installedBinGate, gateContent, binContent);
+        if (prePublishDrift) {
+          warnings.push(
+            `source bin/gate.cjs is ${sizeDiff} chars ahead of node_modules/moflo/bin/gate.cjs ` +
+            '(expected pre-publish drift; resolves on next `npm install moflo@<new>`)'
+          );
+        } else if (sizeDiff > 10) {
           issues.push(`bin/gate.cjs out of sync with .claude/helpers/gate.cjs (${sizeDiff} chars differ)`);
         } else {
           warnings.push('bin/gate.cjs minor drift from .claude/helpers/gate.cjs');


### PR DESCRIPTION
## Summary

- Stops `flo doctor` from reporting expected dogfood pre-publish drift as a `Gate Health` `fail`
- Stops `--fix` from logging `Auto-fixed 1 issue` for content drift its fix path can't actually fix
- Genuine helper drift still surfaces as `fail` with the existing fix string

Closes #913.

## Root cause

Two-part:

1. `fixGateHealthHooks()` was a silent no-op for content drift — it only repairs `settings.json` hook wiring. When hooks were already wired (the common case) it returned `true` without copying anything, producing the false-success log line.
2. The drift itself wasn't a bug. The launcher syncs `node_modules/moflo/bin/gate.cjs` → `.claude/helpers/gate.cjs` on version change, so while source `bin/` is ahead of the installed package (between PR-landing and `npm install moflo@<new>`), the helper correctly mirrors the installed version. Source ≠ helper is the steady state during the dogfood publish window. Consumer projects don't have a source `bin/gate.cjs`, so this state never affects them.

A naive copy-fix wouldn't have persisted: the next session-start launcher would have re-synced from the older `node_modules/moflo/bin/gate.cjs` and recreated the drift, looking exactly like the daemon "reverted" the fix.

## Change

`checkGateHealth` now distinguishes:

| source bin | installed bin | helper | Status |
|---|---|---|---|
| A | B | B | `warn` — expected pre-publish drift |
| B | B | B | `pass` |
| B | B | A | `fail` — existing message + fix |
| no source | B | B | `pass` (consumer, unchanged) |

The warn case has no `fix` field, so the auto-fix loop skips it and the false-success log line goes away.

## Consumer surface impact

- File: `src/cli/commands/doctor-checks-deep.ts` — runs from `node_modules/moflo/dist/...`
- New branch only fires when source `bin/gate.cjs` exists in the project root, which only happens in the moflo dogfood repo — consumer behavior is unchanged.
- Round-trip: consumers pick this up at next `npm install moflo@<latest>`.

## Test plan

- [x] 5 unit tests for `isExpectedPrePublishDrift` covering pre-publish drift, healthy, helper corruption, missing installed bin, source==installed
- [x] Existing `checkGateHealth` test still passes (21/21 in `doctor-checks-deep.test.ts`)
- [x] `tsc --noEmit` clean
- [x] No existing test lost — only additions

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)