### PR TITLE
fix(skills): SKILL.md `arguments:` regex-poison crash + smoke guard

### DIFF
--- a/.claude/skills/eldar/SKILL.md
+++ b/.claude/skills/eldar/SKILL.md
@@ -92,15 +92,18 @@ Count `.md` files under `.claude/guidance/` (recursive). Severity table:
 
 ### 1g. Guidance Structure (only if 1f found ≥1 file)
 
-Apply the universal rules from `.claude/guidance/shipped/moflo-guidance-rules.md`. For each `.md` file, check:
+Invoke `/guidance -a` via the `Skill` tool to run the structural audit. The /guidance skill enforces the universal rules from `.claude/guidance/shipped/moflo-guidance-rules.md` (Purpose lines, See Also, generic H2s, hedged language, 500-line cap, RAG chunking) and is the single source of truth for those checks — never re-implement them here.
 
-- Has `**Purpose:**` line right after H1
-- Has `## See Also` at end
-- Under 500 lines
-- H2 headings are specific (not "Overview", "Configuration", "Examples")
-- No hedged language in rule contexts (`should`, `might`, `consider`)
+Fold the result into the Eldar report under the "Guidance structure" row:
 
-Do **not** duplicate `/guidance -a`'s logic verbatim — just produce a one-line summary per file (`<file>: <N issues>`). The Eldar surface gaps; `/guidance -a` does the deep audit.
+| Outcome of `/guidance -a` | Eldar row severity |
+|---------------------------|--------------------|
+| 0 files with issues       | ok                 |
+| 1–2 files with issues     | info               |
+| 3+ files with issues      | warn               |
+| `/guidance` itself errors | warn — quote the error verbatim so the user can fix the offending file before re-running |
+
+When the user is in `--fix` mode and chooses guidance fixes from the triage menu (3b), the same /guidance skill is the handoff target — so the audit and the fix flow share one implementation.
 
 ### 1h. Memory Health
 
@@ -204,7 +207,9 @@ TOP 3 RECOMMENDATIONS
 2. Add Drizzle conventions guidance (info — high leverage)
    You use Drizzle ORM but have no DB-conventions doc. This is the
    single highest-leverage gap for getting Claude to write idiomatic
-   queries and migrations in your codebase.
+   queries and migrations in your codebase. /guidance -a (run inline
+   in step 1g) flagged 3 existing docs with structural issues; pick
+   one to fix alongside this new one.
    See: .claude/guidance/shipped/moflo-guidance-rules.md
 
 3. Run `flo healer --fix` (warn)

--- a/.claude/skills/guidance/SKILL.md
+++ b/.claude/skills/guidance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guidance
 description: Add, edit, or audit guidance docs in this project's .claude/guidance/ directory following moflo's universal guidance rules. Default mode walks the user through one doc (creating or improving it); the -a flag audits every doc in the directory and offers per-file improvements.
-arguments: "[-a] [<topic-or-path>]"
+arguments: "[-a] <topic-or-path>"
 ---
 
 # /guidance — Author and audit project guidance

--- a/.claude/skills/spell-schedule/SKILL.md
+++ b/.claude/skills/spell-schedule/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Use when the user wants to schedule, automate, or recurringly run one of THEIR spells locally —
   e.g. "schedule the oap spell every hour", "run my audit spell every weekday at 9am", "fire X once tomorrow morning".
   This is the LOCAL daemon path. For remote Anthropic-cloud agents, use /schedule instead.
-arguments: "[spell-name-or-alias]"
+arguments: "<spell-name-or-alias>"
 ---
 
 # /spell-schedule — Schedule a Local Spell

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -699,6 +699,75 @@ export function floSkillPackaged(consumerDir) {
   record('flo-skill', 'pass', relative(consumerDir, skill));
 }
 
+/**
+ * Every shipped `.claude/skills/<name>/SKILL.md` whose frontmatter has an
+ * `arguments:` field must be safe to load by Claude Code's slash-command
+ * harness. The harness compiles that field as a JS regex; any `[...]`
+ * segment containing a hyphen between alphabetically-descending letters
+ * (e.g. `[topic-or-path]` → `r-p`, `[spell-name-or-alias]` → `n-a`)
+ * raises `SyntaxError: Range out of order in character class` and the
+ * skill never loads.
+ *
+ * Both bugs shipped — guidance/SKILL.md and spell-schedule/SKILL.md —
+ * before this check existed. Any regression now fails the smoke run.
+ */
+export function verifyShippedSkillArguments(consumerDir) {
+  section('Shipped SKILL.md `arguments:` field is regex-safe');
+  const skillsDir = join(consumerDir, 'node_modules', 'moflo', '.claude', 'skills');
+  if (!existsSync(skillsDir)) {
+    record('skill-arguments-regex-safe', 'fail', '.claude/skills/ missing in installed moflo');
+    return;
+  }
+
+  const offenders = [];
+  let scanned = 0;
+  for (const skillFile of walkSkillFiles(skillsDir)) {
+    scanned++;
+    let text;
+    try { text = readFileSync(skillFile, 'utf8'); }
+    catch { continue; }
+    const fmMatch = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fmMatch) continue;
+    const fm = fmMatch[1];
+    const argLine = fm.split(/\r?\n/).find(l => /^arguments:/.test(l));
+    if (!argLine) continue;
+    const value = argLine.replace(/^arguments:\s*/, '').replace(/^['"]|['"]$/g, '');
+    const classes = value.match(/\[[^\]]*\]/g) || [];
+    for (const cls of classes) {
+      try { new RegExp(cls); }
+      catch (err) {
+        offenders.push({
+          file: relative(consumerDir, skillFile),
+          segment: cls,
+          error: err.message.replace(/^Invalid regular expression: /, ''),
+        });
+      }
+    }
+  }
+
+  if (offenders.length > 0) {
+    const preview = offenders.slice(0, 3)
+      .map(o => `${o.file} → \`${o.segment}\` (${o.error})`)
+      .join(' | ');
+    const suffix = offenders.length > 3 ? ` (+${offenders.length - 3} more)` : '';
+    record('skill-arguments-regex-safe', 'fail',
+      `${offenders.length} SKILL.md(s) with regex-poison \`arguments:\` field — ${preview}${suffix}`);
+    return;
+  }
+  record('skill-arguments-regex-safe', 'pass', `${scanned} SKILL.md(s) scanned, all clean`);
+}
+
+function* walkSkillFiles(dir) {
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); }
+  catch { return; }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) { yield* walkSkillFiles(full); continue; }
+    if (entry.isFile() && entry.name === 'SKILL.md') yield full;
+  }
+}
+
 export function consumerInvariants(consumerDir) {
   section('Consumer invariants');
 

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -87,6 +87,7 @@ async function main() {
       () => check.floSearch(consumerDir),
       () => check.hooks(consumerDir),
       () => check.floSkillPackaged(consumerDir),
+      () => check.verifyShippedSkillArguments(consumerDir),
       () => check.consumerInvariants(consumerDir),
       () => check.installSurface(consumerDir),
       () => check.verifyPrunedBinaries(consumerDir),


### PR DESCRIPTION
## Summary

- Two shipped skills had `arguments:` frontmatter values that parse as invalid JS regex character classes, crashing Claude Code's slash-command harness with `Range out of order in character class` before the SKILL body renders. Both rewritten to `<placeholder>` form. Real consumer bug — anyone who ran `/guidance -a` or `/spell-schedule` hit the cryptic stderr error and the skill silently failed to load.
- New smoke-harness check `verifyShippedSkillArguments()` walks every shipped SKILL.md, extracts the `arguments:` field, and compiles each `[...]` segment — any regex error fails the smoke run, blocking regression.
- /eldar step 1g rewritten to invoke `/guidance -a` via the Skill tool and fold its findings into the audit report (by severity table), replacing the previous "we surface gaps; user runs deep audit" handoff. Audit and `--fix` flow now share one /guidance implementation.

## Why this matters

The compiler that explodes lives in Claude Code itself, not moflo — exhaustive grep of `src/` for `frontmatter`/`SKILL.md`/`$ARGUMENTS` showed moflo only writes SKILL.md frontmatter (`generators.ts`) and parses memory-import frontmatter (`memory/migration.ts:570`). The fix is defensive: rename to a regex-safe documentation-string convention and add a smoke guard so future authored skills can't reintroduce it.

The bracket footgun:

```
new RegExp('[topic-or-path]')      // SyntaxError: c-o range valid, then r-p (114 to 112) fails
new RegExp('[spell-name-or-alias]') // SyntaxError: n-a (110 to 97) fails
```

## Consumer surface

- `.claude/skills/**/*.md` is in the `package.json` files array — three SKILL.md edits reach consumers on the next moflo publish + `npm install`.
- No state migration; SKILL.md is rendered text only.
- `harness/consumer-smoke/**` is internal CI only — zero consumer impact.

## Test plan

- [x] Reproducer confirmed — `new RegExp('[topic-or-path]')` raises Range out of order
- [x] All 7 shipped SKILLs scanned: 0 offenders after fix
- [x] `npm run lint` passes
- [x] `node --check` on both modified .mjs files passes
- [x] Full test suite ran (one pre-existing flake in vitest exclude-list, unrelated)
- [ ] Full `npm run test:smoke` round-trip (skipped here — manual inline scan covered the new check's logic)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)