### PR TITLE
docs(guidance): fill MCP tool/hook/testing authoring gaps + rename generic H2s

### DIFF
--- a/.claude/guidance/internal/hook-authoring.md
+++ b/.claude/guidance/internal/hook-authoring.md
@@ -1,0 +1,192 @@
+# Authoring MoFlo Hook Handlers
+
+**Purpose:** How to write or edit hook handlers under `.claude/helpers/`. Covers the stdin-JSON contract, exit-code semantics, `$CLAUDE_PROJECT_DIR` resolution (with the Windows path quirk), and the gate-vs-handler split. Internal-only — consumers configure hooks via `settings.json` but do not author the helper scripts (those are synced from moflo on session-start).
+
+> Hook handlers run in *every consumer's* environment after install. A regression here is a consumer-blast-radius event (#860 was a missing `CLAUDE_CODE_HEADLESS` guard that pegged CPU on every consumer for 15 minutes per session). Treat hook code with the same care as the launcher.
+
+---
+
+## 1. The `.claude/helpers/` Directory Surface
+
+| File | Role | Triggered by |
+|------|------|--------------|
+| `gate-hook.mjs` | PreToolUse gate dispatcher — parses Claude Code's stdin JSON, delegates to `gate.cjs` | `Read`, `Glob`, `Grep`, `Bash`, etc. |
+| `gate.cjs` | Gate logic — memory-first, task-first, dangerous-command, PR safety | Invoked by `gate-hook.mjs` |
+| `hook-handler.cjs` | PostToolUse + Stop + Notification dispatcher | `Write`/`Edit`/`Agent`, session end, notifications |
+| `prompt-hook.mjs` | UserPromptSubmit handler | Each user prompt |
+| `subagent-start.cjs` | SubagentStart handler — bootstrap reminders | Subagent spawn |
+| `auto-memory-hook.mjs` | SessionStart `import` + Stop `sync` for the auto-memory directory | Session start, session end |
+| `statusline.cjs` | Status-line renderer | Status-line refresh |
+| `intelligence.cjs` | Helper module loaded by gate.cjs (not a direct hook entry) | Internal |
+| `simplify-classify.cjs` | Helper module for the simplify gate | Internal |
+
+**Two-layer design (gate-hook.mjs + gate.cjs):** the `.mjs` entry parses Claude Code's stdin JSON and forwards via env vars; the `.cjs` does the actual decision logic. Keep this split — mixing JSON parsing into the decision layer makes both harder to test.
+
+---
+
+## 2. Hook Event → Settings.json Wiring
+
+Hooks fire from `.claude/settings.json`. Each event has a matcher and one or more `command` entries. The hook helper paths must use `$CLAUDE_PROJECT_DIR` — never relative paths or hardcoded user directories.
+
+| Event | When | Typical helper |
+|-------|------|----------------|
+| `SessionStart` | Claude Code starts | `.claude/scripts/session-start-launcher.mjs`, `auto-memory-hook.mjs import` |
+| `UserPromptSubmit` | Each user prompt | `prompt-hook.mjs`, `gate-hook.mjs prompt-reminder` |
+| `PreToolUse` | Before any tool call | `gate-hook.mjs check-before-{scan,read}`, `gate-hook.mjs check-dangerous-command` |
+| `PostToolUse` | After any tool call | `hook-handler.cjs post-edit`, `gate-hook.mjs reset-edit-gates` |
+| `SubagentStart` | New subagent | `subagent-start.cjs` |
+| `PreCompact` | Before context compaction | `gate.cjs compact-guidance` |
+| `Stop` | Session end | `hook-handler.cjs session-end`, `auto-memory-hook.mjs sync` |
+| `Notification` | OS notification surface | `hook-handler.cjs notification` |
+
+**Matchers are regex on tool name.** `^(Write|Edit|MultiEdit)$` fires for those three only; `mcp__moflo__memory_` (no anchors) fires on any memory MCP tool. Quote anchors carefully — a missing `$` causes false positives that are hard to debug.
+
+---
+
+## 3. The Stdin JSON Contract
+
+**Claude Code passes hook context as JSON on stdin.** Read it with a 500ms timeout to handle the no-stdin case (TTY, no tool fired). Never block waiting for stdin without a timeout — orphan hooks pin the session.
+
+```js
+let stdinData = '';
+try {
+  stdinData = await new Promise((res) => {
+    let data = '';
+    const timeout = setTimeout(() => res(data), 500);
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => { clearTimeout(timeout); res(data); });
+    process.stdin.on('error', () => { clearTimeout(timeout); res(''); });
+    if (process.stdin.isTTY) { clearTimeout(timeout); res(''); }
+  });
+} catch { /* no stdin */ }
+
+let hookContext = {};
+try { if (stdinData.trim()) hookContext = JSON.parse(stdinData); } catch {}
+```
+
+Keys you can rely on (when present):
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `tool_name` | string | The Claude Code tool that fired (e.g. `'Read'`) |
+| `tool_input` | object | The tool's input parameters; values may be objects or strings |
+| `session_id` | string | Per-actor session ID — distinct across subagents, even within one Claude Code instance |
+| `transcript_path` | string | Path to the current session transcript (for hooks that need history) |
+
+**Forward `session_id` per-actor (issue #838).** Each spawned subagent gets a distinct `session_id`. A shared workflow-state file keyed only by tool name lets one subagent's directive be silently satisfied by the parent's earlier action. Always include `session_id` in your gate-state key when the gate is per-actor.
+
+---
+
+## 4. Exit-Code Semantics
+
+**Exit codes are the entire contract.** Anything Claude Code reads about the hook's decision comes from exit code + stderr.
+
+| Exit code | Meaning | When to use |
+|-----------|---------|-------------|
+| `0` | Continue — tool call proceeds | Default; no objection |
+| `1` | Soft block (deprecated, treated as block) | Avoid; use `2` |
+| `2` | Hard block — tool call refused; stderr surfaced to user and to Claude | Memory-first violation, dangerous command, missing prerequisite |
+
+**Translate gate exit codes carefully.** `gate-hook.mjs` shells out to `gate.cjs` via `execFileSync`. Map the inner exit code to the outer hook exit code explicitly — don't trust the default.
+
+```js
+try {
+  execFileSync('node', [gateScript, command], { /* ... */ });
+  process.exit(0);
+} catch (err) {
+  if (err.stderr) process.stderr.write(err.stderr);
+  process.exit(err.status === 2 || err.status === 1 ? 2 : 0);
+}
+```
+
+**Never silently catch errors in a hook (`feedback_no_silent_failures`).** Either log + advise (when continuing) or block + surface stderr (when refusing). A `try {} catch {}` empty in a hook produced 4 versions of consumer-invisible breakage in #854.
+
+---
+
+## 5. `$CLAUDE_PROJECT_DIR` Resolution
+
+**Always resolve hook-relative paths via `$CLAUDE_PROJECT_DIR`** — Claude Code sets it to the current project root. Falling back to `process.cwd()` works on Mac/Linux but breaks on Windows when the hook is invoked from a different working directory.
+
+```js
+const projectDir = (process.env.CLAUDE_PROJECT_DIR || process.cwd())
+  .replace(/^\/([a-z])\//i, '$1:/');  // /c/Users → C:/Users on Windows
+const gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');
+```
+
+The `replace` step is necessary because Claude Code on Windows-via-WSL sometimes emits POSIX-style paths (`/c/Users/...`) that `path.resolve` doesn't normalize. Skip this and the hook fails silently on Windows.
+
+See `internal/consumer-project-paths.md` for the cross-cutting rule on path resolution.
+
+---
+
+## 6. Cross-Platform Constraints
+
+**Hook handlers run on Windows, macOS, and Linux. POSIX-only assumptions break on Windows.** See `shipped/moflo-cross-platform.md` for the universal rule. Hook-specific gotchas:
+
+| Gotcha | Fix |
+|--------|-----|
+| `/dev/null` in stdio redirects | Use `'ignore'` in `spawn` options |
+| Bash heredoc in helper code | Don't — use `node -e` or write a temp `.mjs` file |
+| Forward slashes in command paths | OK; Node normalizes both ways |
+| Hardcoded `~` for home dir | Use `os.homedir()` |
+| `execFileSync` without `windowsHide: true` | Spawns a flash window on Windows; always include the flag |
+
+---
+
+## 7. Performance Budget
+
+**Hook timeouts in `settings.json` are tight by design.** `PreToolUse` hooks have 2–3 seconds; exceeding this blocks the user's tool call.
+
+| Hook | Typical timeout | Implication |
+|------|-----------------|-------------|
+| Pre-Bash dangerous-command check | 2000ms | Synchronous — keep cheap; lookups must be O(1) |
+| Pre-Read/Glob/Grep memory-first | 3000ms | One memory_search check is fine; no DB mutation |
+| Post-Edit (formatter, indexer) | 5000ms | Run async work in background — don't block the hook |
+| SessionStart launcher | 3000ms | Defer heavy work to spawned daemon; the hook should return fast |
+
+**Move slow work into the daemon.** Indexing, embedding generation, network calls — anything that can take >1 s — belongs in `node_modules/moflo`'s daemon, not in a synchronous hook handler. The session-start launcher uses this pattern: it forks the daemon and returns within a few hundred ms.
+
+---
+
+## 8. Adding a New Hook — Checklist
+
+1. **Pick the event** — match the lifecycle moment, not the tool name; e.g. "after the user submits a prompt" is `UserPromptSubmit`, not a `Bash` matcher.
+2. **Pick the matcher** — anchored regex (`^Foo$`) unless you specifically want prefix matching (`mcp__moflo__memory_`).
+3. **Write the entry** in `.claude/settings.json` under the appropriate event array; use `$CLAUDE_PROJECT_DIR/.claude/helpers/<file>` for the command.
+4. **Choose the helper file** — extend an existing one if the new logic is small; create a new helper for a fresh concern. Keep `.cjs` for sync logic loaded into other helpers, `.mjs` for entry points.
+5. **stdin JSON parsing** — copy the 500ms-timeout pattern from `gate-hook.mjs`. Never block forever.
+6. **Exit codes** — `0` = continue, `2` = block. Map inner errors carefully; never swallow.
+7. **Path resolution** — `$CLAUDE_PROJECT_DIR` + the Windows `/c/` normalize step.
+8. **Cross-platform** — no `/dev/null`, no `~`, `windowsHide: true` on every `execFileSync`.
+9. **Test it** — `tests/bin/gate-helpers.test.ts` is the canonical test target for gate logic; mirror that file's structure for new helpers.
+10. **Healer drift check** — `flo healer` includes a `Hook Block Drift` check (`hook block matches reference`). Update the reference hash in `src/cli/commands/doctor-checks-config.ts` (or the canonical owner) if you intentionally change the canonical hook block.
+
+---
+
+## 9. Editing an Existing Hook — Failure Modes to Watch
+
+Hook regressions are silent. The user notices "Claude is acting weird" days later, not at the moment of the broken hook. Specific traps:
+
+| Trap | What happens | Prevention |
+|------|--------------|------------|
+| `try { ... } catch {}` swallows hook failures | User never sees the error; behavior degrades silently | Log + advise + re-throw or return; never empty `catch {}` |
+| Removing a hook block hash bump | Healer drift check fires for every consumer | Bump the hash in the same PR |
+| Adding cwd-relative path | Works in dev, breaks for consumers | Always anchor on `$CLAUDE_PROJECT_DIR` |
+| Adding a network call to `PreToolUse` | Pegs every tool invocation under flaky network | Hooks are local-only — defer net to the daemon |
+| Forgetting `windowsHide: true` on spawn | Flash console window on Windows | Add it |
+
+**Run the dogfood loop before merging:** the hook lives in `.claude/helpers/` *and* gets synced into `node_modules/moflo/.claude/helpers/`. After local edit, the running session is still on the previously installed version (`feedback_dogfood_install_vs_source`). Publish a build or use `npm pack` + reinstall to actually exercise the change.
+
+---
+
+## See Also
+
+- `.claude/guidance/internal/mcp-tool-authoring.md` — Sibling for MCP tool surface; coordinator-backed contract analogue to the gate-vs-handler split here
+- `.claude/guidance/internal/testing-conventions.md` — Vitest patterns; the canonical hook tests (`tests/bin/gate-helpers.test.ts`) follow these rules
+- `.claude/guidance/internal/coding-style.md` — Decomposition + DRY rules; helper modules under `.claude/helpers/` must follow them too
+- `.claude/guidance/internal/consumer-project-paths.md` — Why `$CLAUDE_PROJECT_DIR`, never `process.cwd()`
+- `.claude/guidance/internal/dogfooding.md` — Why hook edits don't take effect until the next session/install
+- `.claude/guidance/shipped/moflo-cross-platform.md` — Cross-platform constraints applied to hook authoring
+- `.claude/guidance/shipped/moflo-session-start.md` — SessionStart event wiring and the launcher contract
+- `.claude/guidance/shipped/moflo-error-handling.md` — No silent catches; this is a hook-critical rule

--- a/.claude/guidance/internal/mcp-tool-authoring.md
+++ b/.claude/guidance/internal/mcp-tool-authoring.md
@@ -77,7 +77,7 @@ export const swarmTools: MCPTool[] = [
 | `inputSchema` | yes | Inline JSONSchema; document every property |
 | `handler` | yes | `async (input) => result`; validate `input` defensively (cast unknown to typed via guards) |
 
-**Idempotent operations should say so in the description and prove it in the handler.** `swarm_init` is the canonical example: re-init returns the existing swarmId rather than creating a new swarm.
+**Idempotent operations MUST say so in the description and prove it in the handler.** `swarm_init` is the canonical example: re-init returns the existing swarmId rather than creating a new swarm.
 
 ---
 

--- a/.claude/guidance/internal/mcp-tool-authoring.md
+++ b/.claude/guidance/internal/mcp-tool-authoring.md
@@ -1,0 +1,182 @@
+# Authoring MoFlo MCP Tools
+
+**Purpose:** How to add or edit MCP tools under `src/cli/mcp-tools/`. Codifies the coordinator-backed contract that CLAUDE.md's ⛔ block enforces (epic #798) so the rule lives in the corpus Claude searches before it edits, not just in CLAUDE.md prose. Internal-only — consumers do not author moflo MCP tools.
+
+> The CLAUDE.md ⛔ "Protected functionality — swarm + hive-mind" block is the load-bearing version of these rules. This doc is the indexed reference; CLAUDE.md is the project entry point. They must stay aligned.
+
+---
+
+## 1. File Layout and Tool Surface
+
+**Group tools by domain in `src/cli/mcp-tools/<domain>-tools.ts`.** Each file exports an `MCPTool[]` array. Domains today: `agent`, `aidefence`, `coordination`, `github`, `hive-mind`, `hooks`, `memory`, `moflodb`, `neural`, `performance`, `security`, `session`, `spell`, `swarm`, `system`, `task`. Add a new file when the new tool's domain is genuinely separate; do not invent a 16th domain to host one tool.
+
+| File | What lives there |
+|------|-------------------|
+| `src/cli/mcp-tools/<domain>-tools.ts` | `MCPTool[]` array — `name`, `description`, `category`, `inputSchema`, `handler` |
+| `src/cli/mcp-tools/<domain>-coordinator-singleton.ts` | Singleton accessor for the underlying coordinator (one per domain) |
+| `src/cli/mcp-tools/types.ts` | Shared `MCPTool` type — never redefine inline |
+| `src/cli/mcp-tools/_helpers.ts` (under `__tests__/`) | Test helpers like `getSwarmTool`, `getAgentTool` — reuse, don't fork |
+
+**Canonical example for the wired-coordinator pattern: `src/cli/mcp-tools/swarm-tools.ts`.** Read it before writing a new MCP tool. The post-#798 surface is the contract.
+
+---
+
+## 2. The Coordinator-Backed Contract
+
+**Every handler that owns runtime state MUST route through its domain coordinator — never a JSON-store write, never a hardcoded literal, never `Date.now()`-suffixed fake IDs.** This is the rule epic #798 (10 stories) was opened to repair after handlers were silently stubbed during a "simplification" pass.
+
+| Anti-pattern | What's wrong | Correct pattern |
+|--------------|--------------|-----------------|
+| `return { swarmId: 'swarm-' + Date.now() }` | Synthetic ID, no coordinator state | `await coordinator.initialize(...)` returns the real ID |
+| `return { agentCount: 0, taskCount: 0 }` | Hardcoded literal, lies about live state | `coordinator.getState()` / `coordinator.getAgents()` |
+| `await fs.writeFile(stateFile, JSON.stringify(...))` | File-based bypass of coordinator | `coordinator.spawnAgent(...)` and let the coordinator persist |
+| `if (!coordinator) return { success: true }` | "We'll wire it later" — silent stub | Throw or return `success: false` with a real error |
+
+**Verification on every change to `src/cli/mcp-tools/{swarm,agent,task,hive-mind}-tools.ts`** (see CLAUDE.md ⛔ for the canonical list):
+
+1. `agent_spawn` invokes `coordinator.spawnAgent(...)`
+2. `swarm_init` invokes `coordinator.initialize(...)`
+3. `swarm_status` / `swarm_health` query the coordinator (not literals)
+4. `task_*` invokes `coordinator.distributeTasks` / `executeTask` / `cancelTask`
+5. `hive-mind_*` routes through `MessageBus` + `WriteThroughAdapter`; workers register with the shared coordinator
+6. `tests/system/swarm-restoration-e2e.test.ts` exercises the wired path end-to-end
+
+---
+
+## 3. Tool Definition Structure
+
+**Use inline JSONSchema in `inputSchema`.** There is no shared validator library across MCP tools today (valibot is used for config, not for tool inputs). Inline schema keeps the tool self-describing for the MCP client.
+
+```ts
+export const swarmTools: MCPTool[] = [
+  {
+    name: 'swarm_init',
+    description: 'Initialize the swarm coordinator (idempotent — returns the existing swarmId on re-init)',
+    category: 'swarm',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        topology: { type: 'string', description: 'Swarm topology (...)' },
+        maxAgents: { type: 'number', description: 'Maximum number of agents' },
+      },
+    },
+    handler: async (input) => {
+      const coordinator = await getSwarmCoordinator({ /* config */ });
+      // ... real coordinator call ...
+      return { success: true, swarmId: coordinator.id, /* live state */ };
+    },
+  },
+];
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `name` | yes | Snake_case, domain-prefixed (`swarm_init`, `agent_spawn`); the MCP wire name |
+| `description` | yes | One sentence. State the contract (idempotent? side-effecting?) |
+| `category` | yes | Matches the file's domain (`'swarm'`, `'agent'`, etc.) |
+| `inputSchema` | yes | Inline JSONSchema; document every property |
+| `handler` | yes | `async (input) => result`; validate `input` defensively (cast unknown to typed via guards) |
+
+**Idempotent operations should say so in the description and prove it in the handler.** `swarm_init` is the canonical example: re-init returns the existing swarmId rather than creating a new swarm.
+
+---
+
+## 4. Path Resolution Inside Handlers
+
+**Always use `findProjectRoot()` from `../services/project-root.js` for the project root** — never `process.cwd()` (the daemon-launched MCP server inherits cwd from wherever it was spawned). Compose project-relative paths via `MOFLO_DIR` from `../services/moflo-paths.js`, never literal `'.moflo'`.
+
+```ts
+import { findProjectRoot } from '../services/project-root.js';
+import { MOFLO_DIR } from '../services/moflo-paths.js';
+
+const dir = join(findProjectRoot(), MOFLO_DIR);  // correct
+const dir = join(process.cwd(), '.moflo');       // wrong — cwd is unstable
+```
+
+See `internal/consumer-project-paths.md` for the cross-cutting rule.
+
+---
+
+## 5. Healer Probe Contract
+
+**Any MCP tool whose correctness depends on coordinator state MUST be exercised by a `flo healer` functional probe.** The probe lives in `src/cli/commands/doctor-checks-<domain>.ts` (e.g. `doctor-checks-swarm.ts`) and runs in CI on every release. If a regression turns a real handler into a stub, healer fails — that is the whole point.
+
+| Probe shape | Purpose |
+|-------------|---------|
+| `swarm_init` returns `success: true` with a non-stub `swarmId` from `UnifiedSwarmCoordinator` | Catches synthetic-ID stubs |
+| `swarm_status` returns `agentCount > 0` after a real spawn | Catches `0`-literal stubs |
+| `agent_list` includes the just-spawned agentId | Catches JSON-store-only writes |
+| `agent_terminate` with `terminated: true` removes from coordinator state | Catches no-op handlers |
+
+The healer JSON output (`flo healer --json`) shows each subcheck's `expected` and `observed` — model new probes after the existing entries in `doctor-checks-swarm.ts` and `doctor-checks-hive-mind.ts`.
+
+---
+
+## 6. Test Contract — Both Levels
+
+**Two test layers are required for any tool that owns runtime state.** Skipping the system E2E is the failure mode that allowed #798 to ship.
+
+| Layer | File pattern | Asserts |
+|-------|--------------|---------|
+| Unit | `src/cli/__tests__/mcp-tools/<tool-name>.test.ts` | Per-handler input validation, schema enforcement, error paths |
+| System E2E | `tests/system/<domain>-restoration-e2e.test.ts` | Full lifecycle through real coordinator; afterEach resets singletons via `_resetXForTest()` |
+
+**The system E2E pattern (from `tests/system/swarm-restoration-e2e.test.ts`):**
+
+```ts
+afterEach(async () => {
+  _setSwarmPersistenceForTest(null);
+  await _resetSwarmCoordinatorForTest();
+});
+
+it('init → spawn × 3 → orchestrate × 5 → status reflects everything', async () => {
+  const init = (await getSwarmTool('swarm_init').handler({ topology: 'mesh' })) as { swarmId: string };
+  // ... lifecycle assertions on live coordinator state ...
+});
+```
+
+If the unit test passes but the E2E catches a regression, the unit test was mocking the coordinator. Tighten the unit test until the regression would have been visible there too.
+
+---
+
+## 7. Adding a New Tool — Checklist
+
+Before opening a PR that adds an MCP tool:
+
+1. **File chosen** by domain; reusing existing `<domain>-tools.ts` if domain already exists, new file only if genuinely separate.
+2. **`MCPTool` shape** — `name`, `description`, `category`, `inputSchema`, `handler`.
+3. **Coordinator-backed** — handler invokes the real coordinator method; no synthetic literals.
+4. **Path resolution** — `findProjectRoot()` + `MOFLO_DIR`, never `process.cwd()` or `'.moflo'`.
+5. **Unit test** at `src/cli/__tests__/mcp-tools/<tool>.test.ts`.
+6. **System E2E entry** in `tests/system/<domain>-restoration-e2e.test.ts` if state-owning.
+7. **Healer probe** in `doctor-checks-<domain>.ts` with `expected` / `observed` shape matching siblings.
+8. **CLAUDE.md ⛔ list** — if the new tool is part of swarm/agent/task/hive-mind, ensure the verification list still covers it.
+9. **Smoke** — `flo healer` passes locally; `npm test` green; the system E2E green individually (`vitest run tests/system/<file>`).
+
+---
+
+## 8. Editing an Existing Tool — Regression Risks
+
+**Before changing an existing handler, name what would break for someone on `moflo@<previous>` picking the change up via `npm install`.** The MCP wire name is part of the public surface. Rename = breaking. Removing a property from `inputSchema` = breaking. Tightening a description without behavior change = safe.
+
+| Change type | Consumer impact | Action |
+|-------------|------------------|--------|
+| Rename `name` field | Breaks existing callers | Don't — add a new tool, alias the old |
+| Remove `inputSchema` property | Breaks callers passing it | Don't — make it optional with a deprecation note |
+| Tighten validation (was permissive) | May reject previously-accepted input | Surface in CHANGELOG; consider grace-period default |
+| Add new optional property | Backward-compatible | Safe; document in description |
+| Refactor handler internals | Invisible if behavior preserved | Run system E2E to confirm |
+
+**The healer probe is the regression net.** If a refactor makes the probe fail, the refactor changed observable behavior — investigate before "fixing" the probe.
+
+---
+
+## See Also
+
+- `CLAUDE.md` (root) — ⛔ Protected functionality block; load-bearing version of section 2
+- `.claude/guidance/internal/hook-authoring.md` — Sibling rules for `.claude/helpers/` hook handlers
+- `.claude/guidance/internal/testing-conventions.md` — Vitest patterns, isolation list, and the bootstrap rules cited in section 6
+- `.claude/guidance/internal/coding-style.md` — Decomposition + DRY rules that apply to MCP tool source files
+- `.claude/guidance/internal/consumer-project-paths.md` — Why `findProjectRoot()` not `process.cwd()`
+- `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` — Consumer-facing description of the swarm/agent/task surface this doc authors
+- `.claude/guidance/shipped/moflo-error-handling.md` — Imperative-vs-defensive style applied to handler bodies

--- a/.claude/guidance/internal/testing-conventions.md
+++ b/.claude/guidance/internal/testing-conventions.md
@@ -1,0 +1,194 @@
+# MoFlo Vitest Testing Conventions
+
+**Purpose:** General Vitest patterns and discipline rules for moflo's own test suite. Sibling to `internal/testing-performance.md` (parallelism + fork contention) and `internal/testing-sandboxing.md` (Docker-sandbox tests). Internal-only — consumers do not run moflo's test suite.
+
+> The Broken Window Theory rule from `CLAUDE.md` is non-negotiable here: every failing test, every warning, every flake gets fixed before moving on. A red signal is never acceptable as background noise. This doc covers *how* to fix them; CLAUDE.md sets the bar.
+
+---
+
+## 1. The Two Configs
+
+| Config | Purpose | Driven by |
+|--------|---------|-----------|
+| `vitest.config.ts` | Parallel run with `maxForks=2`; excludes the `isolationTests` array | `npm test` (default) |
+| `vitest.isolation.config.ts` | Sequential run of `isolationTests` only | `scripts/test-runner.mjs` second pass |
+
+**`scripts/test-runner.mjs` runs both passes.** The full-suite signal you care about (red/green) is what `npm test` reports, which orchestrates both. Never run `vitest` directly when validating a fix — you'll skip the isolation pass and get a false-green.
+
+---
+
+## 2. The `isolationTests` List Is Not a Park-It-And-Forget Bin
+
+**Adding a test to `isolationTests` is acknowledging a real problem, not avoiding it.** Tests on the list typically suffer from:
+
+- Dynamic-import load + Windows fork contention (`maxForks=2` on Windows isn't enough headroom)
+- `process.chdir` per test (cwd is process-global; parallel forks step on each other)
+- Singleton/registry resets (module-shared state)
+- Performance/timing assertions that bust under parallel load
+
+**Each isolation entry MUST have a comment explaining WHY** — see existing entries in `vitest.config.ts` for the canonical shape. A bare path is a TODO, not a justification.
+
+| Reason | Example entry |
+|--------|---------------|
+| Dynamic-import load on Windows | `'src/cli/__tests__/doctor-checks-deep.test.ts'` |
+| `process.chdir` + module singleton | `'src/cli/__tests__/bridge-entries.test.ts'` |
+| Cold-start network/model load | `'src/cli/__tests__/embeddings/fastembed-inline-integration.test.ts'` |
+| Timing-based parallelism assertion | `'src/cli/__tests__/spells/preflights.test.ts'` |
+
+**Never bump per-test timeouts above 30s as a workaround** (`feedback_no_test_timeout_bumps`). A slow test is a bug at the source — find the contention and fix it, or move the test to isolation with a real comment. Don't paper over it with `{ timeout: 60_000 }`.
+
+---
+
+## 3. AgentDB / ReasoningBank / GuidanceProvider — beforeAll, Not beforeEach
+
+**Cold-boot of moflo's memory layer is ~5s.** Tests that exercise `ReasoningBank`, `GuidanceProvider`, or any `AgentDB`-backed component MUST initialize the backend in `beforeAll` and use the explicit `_clearForTest()` reset between cases — not `beforeEach` re-init.
+
+```ts
+let bank: ReasoningBank;
+
+beforeAll(async () => {
+  bank = await ReasoningBank.createForTest();  // ~5s cold boot
+});
+
+beforeEach(async () => {
+  await bank._clearForTest();  // <50ms; just clears state
+});
+```
+
+Doing this with `beforeEach` recreates the AgentDB on every test — a 50-test file becomes a 250-second file. See `feedback_reasoningbank_test_bootstrap` for the incident that produced this rule.
+
+---
+
+## 4. The `_helpers.ts` and `_*ForTest()` Pattern
+
+**Test-only helpers and resets live next to the code they exercise, prefixed with `_`.** Examples:
+
+| Path | Purpose |
+|------|---------|
+| `src/cli/__tests__/mcp-tools/_helpers.ts` | `getSwarmTool(name)`, `getAgentTool(name)`, `spawnAgentForTest()` — reusable across MCP tests |
+| `src/cli/__tests__/swarm/_in-memory-persistence.ts` | `createInMemoryPersistence()` — substitute for `SwarmPersistence` in tests |
+| `_resetSwarmCoordinatorForTest()` | Module-exported reset for the singleton |
+| `_setSwarmPersistenceForTest()` | Module-exported persistence injection |
+
+**The `_` prefix is the export convention for test-only API surface.** Real consumers must never call these. Lint rules block external imports of `_*ForTest()` helpers — keep them internal-only.
+
+---
+
+## 5. System E2E Tests — `tests/system/`
+
+**System E2Es exercise the full wired path through real coordinators.** They are the safety net for the CLAUDE.md ⛔ contract on swarm/agent/task/hive-mind. Pattern:
+
+```ts
+afterEach(async () => {
+  _setSwarmPersistenceForTest(null);
+  await _resetSwarmCoordinatorForTest();
+});
+
+it('init → spawn × 3 → orchestrate × 5 → status reflects everything', async () => {
+  // Drive the MCP handler through a real lifecycle.
+  // Assert real coordinator state at each step.
+});
+```
+
+| Rule | Reason |
+|------|--------|
+| Always reset singletons in `afterEach` | Bleed-over masks regressions and flakes neighbors |
+| Use real coordinators, real persistence (in-memory variant OK) | Mocked coordinators hid the #798 stub regression for months |
+| Assert observable state, not internal calls | Stubs satisfy "method was called" but lie about state |
+| Mirror the `flo healer` probe | If both system E2E and healer agree, the surface is wired |
+
+---
+
+## 6. Random-Input / Property Tests — Mismatch Char Outside the Alphabet
+
+**When testing string validators with a "must differ from valid" mismatch, the mismatch character must be OUTSIDE the valid alphabet.** Otherwise random sampling will pick the mismatch char as a valid generated value and the test green-flakes (`feedback_test_mismatch_chars`).
+
+```ts
+// Wrong — 'X' is in the valid base64 alphabet, ~1/64 chance the random input is just 'X'
+const invalid = original + 'X';
+
+// Right — '!' is never in base64url
+const invalid = original + '!';
+```
+
+Audit any test with `invalid = valid + <char>` against the validator's accepted set.
+
+---
+
+## 7. Spell / Bash Step Tests — Permissions and Sandbox Constraints
+
+**Bash spell step tests must verify both the capability set AND the `permissionLevel`** (`feedback_double_check_step_permissions`). Spells running under bwrap with default permissions get `--unshare-net`; tests that exercise DNS/SSH must explicitly assert `permissionLevel: elevated`.
+
+| Constraint | Test must assert |
+|------------|------------------|
+| Bash step needs network | `permissionLevel: 'elevated'` is set |
+| Bash step needs `git push` | `GH_TOKEN` is injected and elevated permission held |
+| Bash step writes outside `/workspace` | Capability list includes the path |
+| Sandbox uses bind-mounted git config | `git config --system` not `--global` (Dockerfile) |
+
+**Never end a Bash step with `cleanup || true`** (`feedback_bash_trailing_or_true`) — the trailing `|| true` masks upstream failures including the very thing the cleanup was meant to handle. Lead with `set -e` and let real failures surface.
+
+---
+
+## 8. Cross-Platform — Tests Run On Windows Too
+
+**No `/dev/null`, no POSIX `mkdir -p`, no bash heredoc in spell-step bash bodies on Windows** (`feedback_spell_bash_minimal_path`). Use `node -e` with `fs`/`os` for file ops in tests that exercise spell steps. The CI matrix runs Windows, macOS, and Linux — tests that pass only on POSIX block releases until rewritten.
+
+See `shipped/moflo-cross-platform.md` for the full universal rule.
+
+---
+
+## 9. Embeddings Are Required, Not Optional
+
+**Hash embeddings are banned** (`project_embeddings_hard_require`). All test fixtures that use vector search must use the real `fastembed`/`onnxruntime-node` runtime. Hash fallbacks made test results meaningless because semantic similarity collapsed to keyword match. The `tests/guards/hash-fallback-guard.test.ts` enforces this — never disable it.
+
+First-run downloads the ~25 MB ONNX model from GCS; subsequent runs hit the cache. The cache-cold path is in `isolationTests` for that reason.
+
+---
+
+## 10. Smoke Harness — `npm run test:smoke`
+
+**The consumer-smoke harness lives in `harness/consumer-smoke/run.mjs` and exercises moflo from a fresh consumer-shaped project.** It catches issues that pure unit tests miss — package files-array drift, postinstall failures, launcher path resolution — before they ship to real consumers.
+
+| When to run | Command |
+|-------------|---------|
+| Before a publish | `npm run test:smoke` (and `:populated` for the populated-project variant) |
+| After editing `bin/`, init/, or settings-generator | Same |
+| Routine PR | Not required; CI handles it |
+
+The smoke harness is also a path-safety enforcement point — see `feedback_path_safety_gates`. Internal `process.cwd()` leaks fail the smoke stderr scan.
+
+---
+
+## 11. Diagnosing a Failure — Re-Verify Individually
+
+**A test that fails in the full suite is either a real failure or a flake; the way to tell is to re-run it alone.** Per the Broken Window rule:
+
+```bash
+# Suite run shows the failure
+npm test
+
+# Re-run the file alone to distinguish real vs flake
+npx vitest run path/to/the/failing.test.ts
+```
+
+| Outcome | Action |
+|---------|--------|
+| Fails alone too | Real failure — fix it |
+| Passes alone | Flake under load — investigate the contention; isolation is a last resort, not a first response |
+| Passes only sometimes alone | Genuine race — fix the race, not the symptom |
+
+**Never just re-run the full suite hoping for green.** That's a broken window; the next failing test will be ignored too.
+
+---
+
+## See Also
+
+- `.claude/guidance/internal/testing-performance.md` — Parallelism, fork contention, and per-test perf budgets
+- `.claude/guidance/internal/testing-sandboxing.md` — Docker-sandbox-specific test rules
+- `.claude/guidance/internal/mcp-tool-authoring.md` — System E2E pattern for MCP tools (section 6 there) is the load-bearing variant
+- `.claude/guidance/internal/hook-authoring.md` — Hook tests use `tests/bin/gate-helpers.test.ts` as the canonical target
+- `.claude/guidance/internal/coding-style.md` — Decomposition rules apply to test files too; multi-thousand-line test files are a smell
+- `.claude/guidance/internal/pre-publish-rules.md` — Pre-publish checks that depend on a clean test suite
+- `.claude/guidance/shipped/moflo-cross-platform.md` — Cross-platform constraints applied to test code
+- `.claude/guidance/shipped/moflo-error-handling.md` — Imperative error rules; tests must surface real failures, not swallow them

--- a/.claude/guidance/shipped/moflo-epic-processing.md
+++ b/.claude/guidance/shipped/moflo-epic-processing.md
@@ -4,7 +4,7 @@
 
 ---
 
-## Configuration (moflo.yaml)
+## moflo.yaml epic Section
 
 **Add an `epic` section to `moflo.yaml` to control epic behavior.** All settings have sensible defaults.
 

--- a/.claude/guidance/shipped/moflo-task-icons.md
+++ b/.claude/guidance/shipped/moflo-task-icons.md
@@ -41,7 +41,7 @@ description: "ICON [Role] Brief description"
 | performance-* | ⚡ | `⚡ [Perf] Profile query bottleneck` |
 | general-purpose | 🤖 | `🤖 [Agent] Execute multi-step task` |
 
-## Examples
+## Wrong vs Right Examples
 
 ### TaskCreate
 


### PR DESCRIPTION
Closes #918.

## Summary

Acts on the info-tier findings from `/eldar` audit (no errors or warns; this is polish).

### New `internal/` docs (moflo-development guidance, not shipped to consumers)

- `internal/mcp-tool-authoring.md` — coordinator-backed contract from CLAUDE.md ⛔ block + healer probe + `swarm-restoration-e2e` test pattern, indexed for semantic search before anyone edits `src/cli/mcp-tools/`. Codifies the rules epic #798 (10 stories) was opened to repair.
- `internal/hook-authoring.md` — stdin-JSON contract, exit-code semantics, `\$CLAUDE_PROJECT_DIR` resolution (incl. Windows `/c/` normalize), gate-vs-handler split, hook-event wiring. Cites #860 and #854 as failure modes a missing doc enabled.
- `internal/testing-conventions.md` — Vitest two-config pattern, AgentDB beforeAll discipline, `_*ForTest` helper convention, system E2E pattern, no-timeout-bumps rule, broken-window posture.

### Structural fixes (existing `shipped/` docs)

Universal rule #6 — specific H2s, not generic ones:

- `moflo-task-icons.md`: `## Examples` → `## Wrong vs Right Examples`
- `moflo-epic-processing.md`: `## Configuration (moflo.yaml)` → `## moflo.yaml epic Section`

## Bucket choice (internal/ not shipped/)

Per `internal/guidance-rules.md` decision table: audience = moflo developers, tied to repo structure (`src/cli/mcp-tools/`, `.claude/helpers/`, `tests/`) that doesn't exist in consumer projects. No `moflo-` prefix (shipped-only).

## Test plan

- [x] `flo healer` was 33/33 green at audit start
- [x] Targeted run: `tests/system/swarm-restoration-e2e.test.ts` 4/4 passed in 1.16s (the canonical E2E referenced in the new mcp-tool-authoring doc)
- [x] No `commands-deep.test.ts` impact — it asserts only the CLAUDE.md injection point at `moflo-core-guidance.md`, not sibling docs
- [x] `package.json` `files` array globs `.claude/guidance/shipped/**` only — internal/ docs correctly stay local
- [x] All new docs follow universal rules: Purpose line, imperative voice (one self-review hedge fixed in followup commit), decision tables, concrete examples, <500 lines, specific H2s, RAG chunking, See Also (14/14 cross-references resolve)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)