### PR TITLE
feat(spells): persist credentials between casts (epic #880)

### DIFF
--- a/src/cli/__tests__/commands/spell-credentials.test.ts
+++ b/src/cli/__tests__/commands/spell-credentials.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Spell Credentials CLI tests — story #925.
+ *
+ * Drives each subcommand directly via its `action(ctx)` so the assertions
+ * focus on store interactions and exit codes, not on stdout formatting.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CommandContext } from '../../types.js';
+import { CredentialStore } from '../../spells/credentials/credential-store.js';
+
+let workDir: string;
+let credFile: string;
+let keyFile: string;
+
+function makeCtx(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    args: [],
+    flags: { _: [] },
+    cwd: workDir,
+    interactive: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'moflo-spell-creds-cli-'));
+  credFile = join(workDir, 'credentials.json');
+  keyFile = join(workDir, 'credentials.key');
+  process.env.MOFLO_CREDENTIALS_FILE = credFile;
+  process.env.MOFLO_CREDENTIALS_KEY_FILE = keyFile;
+  process.env.MOFLO_CREDENTIALS_PASSPHRASE = 'cli-test-passphrase-12345';
+});
+
+afterEach(() => {
+  delete process.env.MOFLO_CREDENTIALS_FILE;
+  delete process.env.MOFLO_CREDENTIALS_KEY_FILE;
+  delete process.env.MOFLO_CREDENTIALS_PASSPHRASE;
+  rmSync(workDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function loadCommand(name: 'list' | 'set' | 'unset' | 'clear' | 'passphrase') {
+  const { spellCredentialsCommand } = await import('../../commands/spell-credentials.js');
+  const sub = spellCredentialsCommand.subcommands!.find(c => c.name === name);
+  if (!sub) throw new Error(`subcommand ${name} not found`);
+  return sub;
+}
+
+async function seedCred(name: string, value: string, description?: string) {
+  const store = new CredentialStore({
+    filePath: credFile,
+    passphrase: process.env.MOFLO_CREDENTIALS_PASSPHRASE!,
+  });
+  await store.store(name, value, description);
+}
+
+describe('spell credentials list', () => {
+  it('prints "no credentials" when the store is empty', async () => {
+    const cmd = await loadCommand('list');
+    const result = await cmd.action!(makeCtx({ flags: { _: [], format: 'json' } }));
+    expect(result?.success).toBe(true);
+    expect(result?.data).toEqual([]);
+  });
+
+  it('lists names + descriptions but never values', async () => {
+    await seedCred('GRAPH_TOKEN', 'super-secret-value', 'Graph API token');
+    await seedCred('SLACK_HOOK', 'webhook-url', 'OAP target');
+
+    const cmd = await loadCommand('list');
+    const result = await cmd.action!(makeCtx({ flags: { _: [], format: 'json' } }));
+    expect(result?.success).toBe(true);
+    const data = result?.data as Array<{ name: string; description?: string }>;
+    expect(data.map(d => d.name).sort()).toEqual(['GRAPH_TOKEN', 'SLACK_HOOK']);
+    // Values must NEVER appear
+    const serialised = JSON.stringify(data);
+    expect(serialised).not.toContain('super-secret-value');
+    expect(serialised).not.toContain('webhook-url');
+  });
+
+  it('returns locked-store error when the key file is corrupt and credentials exist', async () => {
+    // First seed a credential so credentials.json exists, then corrupt the
+    // key file. The resolver refuses to regenerate the key while creds exist
+    // (would silently invalidate them) and returns the locked-store error.
+    await seedCred('SOMETHING', 'value');
+    delete process.env.MOFLO_CREDENTIALS_PASSPHRASE;
+    writeFileSync(keyFile, 'short', 'utf-8');
+
+    const originalWarn = console.warn;
+    console.warn = () => { /* swallow expected warning */ };
+    try {
+      const cmd = await loadCommand('list');
+      const result = await cmd.action!(makeCtx());
+      expect(result?.success).toBe(false);
+      expect(result?.exitCode).toBe(1);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+describe('spell credentials unset', () => {
+  it('removes a stored credential', async () => {
+    await seedCred('TO_DELETE', 'val');
+    const cmd = await loadCommand('unset');
+    const result = await cmd.action!(makeCtx({ args: ['TO_DELETE'] }));
+    expect(result?.success).toBe(true);
+
+    const verify = new CredentialStore({
+      filePath: credFile,
+      passphrase: process.env.MOFLO_CREDENTIALS_PASSPHRASE!,
+    });
+    expect(await verify.has('TO_DELETE')).toBe(false);
+  });
+
+  it('returns exit 1 when credential name is missing', async () => {
+    const cmd = await loadCommand('unset');
+    const result = await cmd.action!(makeCtx({ args: [] }));
+    expect(result?.success).toBe(false);
+    expect(result?.exitCode).toBe(1);
+  });
+
+  it('returns exit 1 when credential does not exist', async () => {
+    const cmd = await loadCommand('unset');
+    const result = await cmd.action!(makeCtx({ args: ['NEVER_STORED'] }));
+    expect(result?.success).toBe(false);
+    expect(result?.exitCode).toBe(1);
+  });
+});
+
+describe('spell credentials clear', () => {
+  it('refuses to clear without --force in non-interactive mode', async () => {
+    await seedCred('K1', 'v1');
+    const cmd = await loadCommand('clear');
+    const result = await cmd.action!(makeCtx({ interactive: false, flags: { _: [] } }));
+    expect(result?.success).toBe(false);
+    expect(result?.exitCode).toBe(1);
+
+    // Verify nothing was deleted
+    const verify = new CredentialStore({
+      filePath: credFile,
+      passphrase: process.env.MOFLO_CREDENTIALS_PASSPHRASE!,
+    });
+    expect(await verify.has('K1')).toBe(true);
+  });
+
+  it('clears all credentials when --force is given', async () => {
+    await seedCred('K1', 'v1');
+    await seedCred('K2', 'v2');
+    const cmd = await loadCommand('clear');
+    const result = await cmd.action!(makeCtx({ interactive: false, flags: { _: [], force: true } }));
+    expect(result?.success).toBe(true);
+
+    const verify = new CredentialStore({
+      filePath: credFile,
+      passphrase: process.env.MOFLO_CREDENTIALS_PASSPHRASE!,
+    });
+    expect(await verify.list()).toEqual([]);
+  });
+
+  it('reports "no credentials to clear" when store is empty', async () => {
+    const cmd = await loadCommand('clear');
+    const result = await cmd.action!(makeCtx({ flags: { _: [], force: true } }));
+    expect(result?.success).toBe(true);
+  });
+});
+
+describe('spell credentials set', () => {
+  it('refuses non-interactive runs', async () => {
+    const cmd = await loadCommand('set');
+    const result = await cmd.action!(makeCtx({ interactive: false, args: ['NAME'] }));
+    expect(result?.success).toBe(false);
+    expect(result?.exitCode).toBe(1);
+  });
+
+  it('returns exit 1 when name is missing', async () => {
+    const cmd = await loadCommand('set');
+    const result = await cmd.action!(makeCtx({ args: [] }));
+    expect(result?.success).toBe(false);
+    expect(result?.exitCode).toBe(1);
+  });
+});
+
+describe('spell credentials passphrase', () => {
+  it('refuses non-interactive runs', async () => {
+    const cmd = await loadCommand('passphrase');
+    const result = await cmd.action!(makeCtx({ interactive: false }));
+    expect(result?.success).toBe(false);
+    expect(result?.exitCode).toBe(1);
+  });
+});
+
+describe('parent spell credentials command', () => {
+  it('lists subcommands', async () => {
+    const { spellCredentialsCommand } = await import('../../commands/spell-credentials.js');
+    expect(spellCredentialsCommand.name).toBe('credentials');
+    const subnames = spellCredentialsCommand.subcommands!.map(s => s.name).sort();
+    expect(subnames).toEqual(['clear', 'list', 'passphrase', 'set', 'unset']);
+  });
+
+  it('is wired under the parent spell command', async () => {
+    const { spellCommand } = await import('../../commands/spell.js');
+    const creds = spellCommand.subcommands!.find(s => s.name === 'credentials');
+    expect(creds).toBeDefined();
+  });
+});

--- a/src/cli/__tests__/spell-command.test.ts
+++ b/src/cli/__tests__/spell-command.test.ts
@@ -24,7 +24,7 @@ describe('Spell CLI Command', () => {
 
   it('has expected subcommands', () => {
     const subNames = spellCommand.subcommands!.map(s => s.name).sort();
-    expect(subNames).toEqual(['cast', 'list', 'schedule', 'status', 'stop', 'template', 'validate']);
+    expect(subNames).toEqual(['cast', 'credentials', 'list', 'schedule', 'status', 'stop', 'template', 'validate']);
   });
 
   it('cast subcommand has "run" alias for backwards compat', () => {

--- a/src/cli/__tests__/spells/credentials/default-store.test.ts
+++ b/src/cli/__tests__/spells/credentials/default-store.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Default Credential Store — wiring tests for story #922.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getDefaultCredentialStore,
+  resetDefaultCredentialStore,
+  lockedNoopAccessor,
+} from '../../../spells/credentials/default-store.js';
+import { CredentialStore } from '../../../spells/credentials/credential-store.js';
+
+let workDir: string;
+let credFile: string;
+let keyFile: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'moflo-default-store-'));
+  credFile = join(workDir, 'credentials.json');
+  keyFile = join(workDir, 'credentials.key');
+  resetDefaultCredentialStore();
+  delete process.env.MOFLO_CREDENTIALS_FILE;
+  delete process.env.MOFLO_CREDENTIALS_PASSPHRASE;
+  delete process.env.MOFLO_CREDENTIALS_KEY_FILE;
+});
+
+afterEach(() => {
+  resetDefaultCredentialStore();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('getDefaultCredentialStore', () => {
+  it('returns an unlocked CredentialStore using the auto-generated key file', async () => {
+    const accessor = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+
+    expect(accessor).toBeInstanceOf(CredentialStore);
+    expect(existsSync(keyFile)).toBe(true);
+
+    await accessor.store('TEST_TOKEN', 'secret-val');
+    expect(await accessor.get('TEST_TOKEN')).toBe('secret-val');
+  });
+
+  it('reuses the same passphrase across resets so existing credentials decrypt', async () => {
+    const a = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    await a.store('K', 'v1');
+    expect(await a.get('K')).toBe('v1');
+
+    resetDefaultCredentialStore();
+    const b = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    expect(await b.get('K')).toBe('v1');
+  });
+
+  it('caches the singleton across calls', () => {
+    const a = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    const b = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    expect(a).toBe(b);
+  });
+
+  it('honours MOFLO_CREDENTIALS_PASSPHRASE over the key file', async () => {
+    process.env.MOFLO_CREDENTIALS_PASSPHRASE = 'env-passphrase-12345';
+    const accessor = getDefaultCredentialStore({ filePath: credFile });
+    await accessor.store('FROM_ENV', 'val');
+
+    resetDefaultCredentialStore();
+    const accessor2 = getDefaultCredentialStore({ filePath: credFile });
+    expect(await accessor2.get('FROM_ENV')).toBe('val');
+  });
+
+  it('writes the key file with mode 0o600 (owner-only) on POSIX', () => {
+    if (process.platform === 'win32') return;
+    getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    const mode = statSync(keyFile).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('refuses to regenerate the key file when credentials.json exists alongside a corrupt key', async () => {
+    const accessor = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    await accessor.store('K', 'v');
+    expect(existsSync(credFile)).toBe(true);
+
+    writeFileSync(keyFile, 'short', 'utf-8');
+    resetDefaultCredentialStore();
+
+    const originalWarn = console.warn;
+    let warned = '';
+    console.warn = (msg: string) => { warned = msg; };
+    try {
+      const recovered = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+      expect(recovered).toBe(lockedNoopAccessor);
+      expect(warned).toContain('corrupt');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('returns lockedNoopAccessor and warns when key file path is unreadable', () => {
+    if (process.platform === 'win32') return;
+    const originalWarn = console.warn;
+    console.warn = () => { /* swallow */ };
+    try {
+      const accessor = getDefaultCredentialStore({
+        filePath: credFile,
+        keyFilePath: '/proc/1/key',
+      });
+      expect(accessor).toBe(lockedNoopAccessor);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+describe('lockedNoopAccessor', () => {
+  it('matches the historical noop shape — never persists, never throws', async () => {
+    expect(await lockedNoopAccessor.get('anything')).toBeUndefined();
+    expect(await lockedNoopAccessor.has('anything')).toBe(false);
+    await lockedNoopAccessor.store('anything', 'val');
+    expect(await lockedNoopAccessor.get('anything')).toBeUndefined();
+  });
+});
+
+describe('resetDefaultCredentialStore', () => {
+  it('clears the singleton so the next call rebuilds', () => {
+    const a = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    resetDefaultCredentialStore();
+    const b = getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('runner-factory + bridge integration', () => {
+  it('runner-factory uses default store when credentials option is omitted', async () => {
+    process.env.MOFLO_CREDENTIALS_FILE = credFile;
+    process.env.MOFLO_CREDENTIALS_PASSPHRASE = 'integration-passphrase-12345';
+    resetDefaultCredentialStore();
+
+    const seed = new CredentialStore({ filePath: credFile, passphrase: 'integration-passphrase-12345' });
+    await seed.store('SEEDED', 'value-from-seed');
+
+    const { createRunner } = await import('../../../spells/factory/runner-factory.js');
+    const runner = createRunner();
+    const store = getDefaultCredentialStore({ filePath: credFile });
+    expect(await store.get('SEEDED')).toBe('value-from-seed');
+    expect(runner).toBeDefined();
+  });
+});
+
+describe('readFileSync handling', () => {
+  it('reuses an existing key file rather than overwriting it', () => {
+    const seedKey = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    writeFileSync(keyFile, seedKey, 'utf-8');
+
+    getDefaultCredentialStore({ filePath: credFile, keyFilePath: keyFile });
+    expect(readFileSync(keyFile, 'utf-8').trim()).toBe(seedKey);
+  });
+});

--- a/src/cli/__tests__/spells/helpers.ts
+++ b/src/cli/__tests__/spells/helpers.ts
@@ -42,10 +42,21 @@ export function makeCommand(overrides: Partial<StepCommand> = {}): StepCommand {
   };
 }
 
-export function makeCredentials(store: Record<string, string> = {}): CredentialAccessor {
+export function makeCredentials(initial: Record<string, string> = {}): CredentialAccessor & {
+  readonly snapshot: Record<string, string>;
+  readonly storeCalls: ReadonlyArray<readonly [string, string]>;
+} {
+  const data = { ...initial };
+  const storeCalls: Array<[string, string]> = [];
   return {
-    async get(name: string) { return store[name]; },
-    async has(name: string) { return name in store; },
+    async get(name: string) { return data[name]; },
+    async has(name: string) { return name in data; },
+    async store(name: string, value: string) {
+      storeCalls.push([name, value]);
+      data[name] = value;
+    },
+    snapshot: data,
+    storeCalls,
   };
 }
 

--- a/src/cli/__tests__/spells/prerequisites-resolve.test.ts
+++ b/src/cli/__tests__/spells/prerequisites-resolve.test.ts
@@ -15,6 +15,7 @@ import {
 import type { Prerequisite } from '../../spells/types/step-command.types.js';
 import type { PrerequisiteSpec } from '../../spells/types/spell-definition.types.js';
 import { makePrereq } from './helpers/prereq-fixtures.js';
+import { makeCredentials } from './helpers.js';
 
 describe('resolveUnmetPrerequisites', () => {
   const ENV_KEY = 'FLO_RESOLVE_TEST_460';
@@ -141,5 +142,139 @@ describe('resolveUnmetPrerequisites', () => {
       log: () => {},
     });
     expect(result.ok).toBe(false);
+  });
+
+  // ==========================================================================
+  // Story #923 — credential store integration
+  // ==========================================================================
+
+  describe('credential store resolution chain (story #923)', () => {
+    const KEY = 'CRED_STORE_TEST_923';
+    beforeEach(() => { delete process.env[KEY]; });
+
+    it('pulls value from store when env is unset — no prompt, no save', async () => {
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        detect: { type: 'env', key: KEY },
+      });
+      const credentials = makeCredentials({ [KEY]: 'value-from-store' });
+      const promptLine = vi.fn<PromptLineFn>(async () => 'should-not-be-called');
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: () => {},
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.resolvedNames).toEqual(['TOKEN']);
+      expect(process.env[KEY]).toBe('value-from-store');
+      expect(promptLine).not.toHaveBeenCalled();
+      expect(credentials.storeCalls).toEqual([]);
+    });
+
+    it('persists prompt answer to the store after a successful TTY prompt', async () => {
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        detect: { type: 'env', key: KEY },
+      });
+      const credentials = makeCredentials({});
+      const promptLine = vi.fn<PromptLineFn>(async () => 'fresh-answer');
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: () => {},
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(process.env[KEY]).toBe('fresh-answer');
+      expect(credentials.storeCalls).toEqual([[KEY, 'fresh-answer']]);
+    });
+
+    it('non-TTY + missing + no store → fails with MISSING_CREDENTIAL errorCode', async () => {
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        docsUrl: 'https://docs.example/token',
+        detect: { type: 'env', key: KEY },
+      });
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: false,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.errorCode).toBe('MISSING_CREDENTIAL');
+      expect(result.missingCredentials).toEqual([KEY]);
+      expect(result.message).toContain('Missing credentials');
+      expect(result.message).toContain(KEY);
+      expect(result.message).toContain('https://docs.example/token');
+      expect(result.message).toContain('flo spell credentials set');
+    });
+
+    it('non-TTY + store has the value → satisfies without errorCode', async () => {
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        detect: { type: 'env', key: KEY },
+      });
+      const credentials = makeCredentials({ [KEY]: 'unattended-value' });
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: false,
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.errorCode).toBeUndefined();
+      expect(process.env[KEY]).toBe('unattended-value');
+    });
+
+    it('non-env unmet prereq (command) on non-TTY → falls through to standard error path, no MISSING_CREDENTIAL', async () => {
+      const envPrereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        promptOnMissing: false, // explicit opt-out so it's not "promptable"
+        detect: { type: 'env', key: KEY },
+      });
+      const cmdPrereq = compilePrerequisiteSpec({
+        name: 'UNICORN_CLI',
+        detect: { type: 'command', command: 'this-command-does-not-exist-xyz-923' },
+      });
+
+      const result = await resolveUnmetPrerequisites([envPrereq, cmdPrereq], {
+        interactive: false,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.errorCode).toBeUndefined();
+      expect(result.message).toContain('Missing prerequisites');
+      expect(result.message).toContain('UNICORN_CLI');
+    });
+
+    it('credentials.store rejection is logged but does not abort the cast', async () => {
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        detect: { type: 'env', key: KEY },
+      });
+      const credentials: import('../../spells/types/step-command.types.js').CredentialAccessor = {
+        async get() { return undefined; },
+        async has() { return false; },
+        async store() { throw new Error('disk full'); },
+      };
+      const promptLine = vi.fn<PromptLineFn>(async () => 'answer');
+      const logged: string[] = [];
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: (l) => logged.push(l),
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(process.env[KEY]).toBe('answer');
+      expect(logged.some(l => l.includes('disk full'))).toBe(true);
+    });
   });
 });

--- a/src/cli/__tests__/spells/prompt-command.test.ts
+++ b/src/cli/__tests__/spells/prompt-command.test.ts
@@ -18,7 +18,7 @@ import {
   registerTTYPauser,
   _resetTTYLockForTest,
 } from '../../spells/core/tty-lock.js';
-import { createMockContext } from './helpers.js';
+import { createMockContext, makeCredentials } from './helpers.js';
 
 describe('resolveDefault', () => {
   const now = Date.parse('2026-04-17T12:00:00Z');
@@ -215,6 +215,118 @@ describe('promptCommand', () => {
         _resetTTYLockForTest();
       }
       expect(events).toEqual(['pause', 'resume']);
+    });
+  });
+
+  // ==========================================================================
+  // Story #924 — saveAs credential persistence
+  // ==========================================================================
+
+  describe('saveAs (credential persistence)', () => {
+    it('rejects saveAs when not a string', () => {
+      const result = promptCommand.validate(
+        { message: 'Token?', saveAs: 42 as never },
+        createMockContext(),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].path).toBe('saveAs');
+    });
+
+    it('rejects empty saveAs', () => {
+      const result = promptCommand.validate(
+        { message: 'Token?', saveAs: '   ' },
+        createMockContext(),
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it('returns stored value without prompting when store has it', async () => {
+      const credentials = makeCredentials({ GRAPH_TOKEN: 'pre-existing-secret' });
+      const ctx = createMockContext({ credentials });
+      // Even though TTY is "interactive", the store hit short-circuits
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+      const output = await promptCommand.execute(
+        { message: 'Token?', saveAs: 'GRAPH_TOKEN' },
+        ctx,
+      );
+
+      expect(output.data.response).toBe('pre-existing-secret');
+      expect(output.data.interactive).toBe(false);
+      expect(output.data.fromStore).toBe(true);
+    });
+
+    it('prompts and persists answer when store is empty (TTY)', async () => {
+      const credentials = makeCredentials();
+      const ctx = createMockContext({ credentials });
+      scriptedAnswer = 'fresh-secret';
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+      const output = await promptCommand.execute(
+        { message: 'Token?', saveAs: 'GRAPH_TOKEN' },
+        ctx,
+      );
+
+      expect(output.data.response).toBe('fresh-secret');
+      expect(output.data.fromStore).toBe(false);
+      expect(output.data.interactive).toBe(true);
+      expect(credentials.snapshot.GRAPH_TOKEN).toBe('fresh-secret');
+    });
+
+    it('does NOT save when non-TTY (no real prompt happened)', async () => {
+      const credentials = makeCredentials();
+      const ctx = createMockContext({ credentials });
+
+      const output = await promptCommand.execute(
+        { message: 'Token?', saveAs: 'GRAPH_TOKEN', default: 'fallback' },
+        ctx,
+      );
+
+      expect(output.data.response).toBe('fallback');
+      expect(output.data.interactive).toBe(false);
+      expect(credentials.snapshot.GRAPH_TOKEN).toBeUndefined();
+    });
+
+    it('saveAs unset → no store interaction, behaviour unchanged', async () => {
+      const credentials = makeCredentials({ SHOULD_NOT_BE_READ: 'x' });
+      const ctx = createMockContext({ credentials });
+
+      const output = await promptCommand.execute(
+        { message: 'Continue?', default: 'yes' },
+        ctx,
+      );
+
+      expect(output.data.response).toBe('yes');
+      expect((output.data as { fromStore?: boolean }).fromStore).toBe(false);
+    });
+
+    it('does not crash when credentials.store rejects after a prompt', async () => {
+      const ctx = createMockContext({
+        credentials: {
+          async get() { return undefined; },
+          async has() { return false; },
+          async store() { throw new Error('disk full'); },
+        },
+      });
+      scriptedAnswer = 'answer';
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+      const warns: string[] = [];
+      const origWarn = console.warn;
+      console.warn = (msg: string) => { warns.push(msg); };
+      try {
+        const output = await promptCommand.execute(
+          { message: 'Token?', saveAs: 'GRAPH_TOKEN' },
+          ctx,
+        );
+        expect(output.success).toBe(true);
+        expect(output.data.response).toBe('answer');
+        expect(warns.some(w => w.includes('disk full'))).toBe(true);
+      } finally {
+        console.warn = origWarn;
+      }
     });
   });
 });

--- a/src/cli/commands/spell-credentials.ts
+++ b/src/cli/commands/spell-credentials.ts
@@ -1,0 +1,271 @@
+/**
+ * Spell Credentials CLI
+ *
+ * `moflo spell credentials list/set/unset/clear/passphrase` — manage the
+ * encrypted credential store the spell runner uses for unattended casts.
+ *
+ * Story #925 (epic #880).
+ */
+
+import { existsSync } from 'node:fs';
+import type { Command, CommandContext, CommandResult } from '../types.js';
+import { output } from '../output.js';
+import { confirm, input } from '../prompt.js';
+import {
+  CredentialStore,
+  CredentialStoreError,
+  MIN_PASSPHRASE_LENGTH,
+  resolveCredentialFilePath,
+  resolvePassphrase,
+  type CredentialMeta,
+} from '../spells/credentials/index.js';
+
+/**
+ * Build a CredentialStore using the runner's passphrase resolution.
+ * Returns null when no passphrase is available — caller surfaces the actionable error.
+ */
+function openStore(): CredentialStore | null {
+  const filePath = resolveCredentialFilePath();
+  const passphrase = resolvePassphrase();
+  if (!passphrase) return null;
+  try {
+    return new CredentialStore({ filePath, passphrase });
+  } catch (err) {
+    output.printError(`Could not open credential store: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+function noStoreError(): CommandResult {
+  output.printError('Credential store is locked.');
+  output.writeln('');
+  output.writeln('  Set MOFLO_CREDENTIALS_PASSPHRASE in your environment, or run:');
+  output.writeln('    flo spell credentials passphrase');
+  output.writeln('');
+  output.writeln('  to initialise a per-machine encryption key.');
+  return { success: false, exitCode: 1 };
+}
+
+const listCommand: Command = {
+  name: 'list',
+  aliases: ['ls'],
+  description: 'List stored credential names (never values)',
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const store = openStore();
+    if (!store) return noStoreError();
+
+    const meta = await store.list();
+    if (ctx.flags.format === 'json') {
+      output.printJson(meta);
+      return { success: true, data: meta };
+    }
+
+    if (meta.length === 0) {
+      output.printInfo('No credentials stored. Use `flo spell credentials set <name>` to add one.');
+      return { success: true };
+    }
+
+    output.writeln();
+    output.writeln(output.bold('Stored credentials'));
+    output.writeln();
+    output.printTable({
+      columns: [
+        { key: 'name', header: 'Name', width: 28 },
+        { key: 'description', header: 'Description', width: 35, format: (v: unknown) => v ? String(v) : '-' },
+        { key: 'updatedAt', header: 'Updated', width: 22, format: (v: unknown) => v ? new Date(String(v)).toLocaleString() : '-' },
+      ],
+      data: meta as unknown as Record<string, unknown>[],
+    });
+    output.writeln();
+    output.printInfo(`${meta.length} credential${meta.length === 1 ? '' : 's'}`);
+    return { success: true, data: meta };
+  },
+};
+
+const setCommand: Command = {
+  name: 'set',
+  description: 'Store a credential (prompts for the value with hidden input)',
+  options: [
+    { name: 'description', short: 'd', description: 'Optional description', type: 'string' },
+  ],
+  examples: [
+    { command: 'moflo spell credentials set GRAPH_ACCESS_TOKEN', description: 'Store the Graph token' },
+    { command: 'moflo spell credentials set SLACK_WEBHOOK_URL --description "OAP target"', description: 'With a description' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const name = ctx.args[0];
+    if (!name) {
+      output.printError('Credential name is required (e.g. `flo spell credentials set TOKEN`)');
+      return { success: false, exitCode: 1 };
+    }
+    const store = openStore();
+    if (!store) return noStoreError();
+
+    if (!ctx.interactive) {
+      output.printError('`set` requires an interactive TTY (the value is entered with hidden input).');
+      return { success: false, exitCode: 1 };
+    }
+
+    const value = await input({ message: `Value for ${name}:`, mask: true });
+    if (!value) {
+      output.printError('No value entered — credential not stored.');
+      return { success: false, exitCode: 1 };
+    }
+
+    const description = ctx.flags.description as string | undefined;
+    await store.store(name, value, description);
+    output.printSuccess(`Stored credential ${output.highlight(name)}.`);
+    return { success: true };
+  },
+};
+
+const unsetCommand: Command = {
+  name: 'unset',
+  aliases: ['delete', 'rm'],
+  description: 'Remove a single credential',
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const name = ctx.args[0];
+    if (!name) {
+      output.printError('Credential name is required (e.g. `flo spell credentials unset TOKEN`)');
+      return { success: false, exitCode: 1 };
+    }
+    const store = openStore();
+    if (!store) return noStoreError();
+
+    const removed = await store.delete(name);
+    if (!removed) {
+      output.printError(`Credential ${output.highlight(name)} not found.`);
+      return { success: false, exitCode: 1 };
+    }
+    output.printSuccess(`Removed credential ${output.highlight(name)}.`);
+    return { success: true };
+  },
+};
+
+const clearCommand: Command = {
+  name: 'clear',
+  description: 'Remove all stored credentials',
+  options: [
+    { name: 'force', short: 'f', description: 'Skip confirmation', type: 'boolean', default: false },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const store = openStore();
+    if (!store) return noStoreError();
+
+    const meta = await store.list();
+    if (meta.length === 0) {
+      output.printInfo('No credentials to clear.');
+      return { success: true };
+    }
+
+    if (!(ctx.flags.force as boolean)) {
+      if (!ctx.interactive) {
+        output.printError('Refusing to clear without --force in non-interactive mode.');
+        return { success: false, exitCode: 1 };
+      }
+      const ok = await confirm({
+        message: `Delete all ${meta.length} stored credential${meta.length === 1 ? '' : 's'}?`,
+        default: false,
+      });
+      if (!ok) {
+        output.printInfo('Cancelled.');
+        return { success: true };
+      }
+    }
+
+    const removed = await store.clear();
+    output.printSuccess(`Removed ${removed} credential${removed === 1 ? '' : 's'}.`);
+    return { success: true };
+  },
+};
+
+const passphraseCommand: Command = {
+  name: 'passphrase',
+  aliases: ['init', 'rotate'],
+  description: 'Initialise the credential store passphrase, or rotate an existing one',
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    if (!ctx.interactive) {
+      output.printError('`passphrase` requires an interactive TTY.');
+      return { success: false, exitCode: 1 };
+    }
+    const filePath = resolveCredentialFilePath();
+    const exists = existsSync(filePath);
+    const minHint = `(min ${MIN_PASSPHRASE_LENGTH} chars)`;
+
+    if (!exists) {
+      const newPass = await input({ message: `Choose a passphrase ${minHint}:`, mask: true });
+      const confirmed = await input({ message: 'Confirm passphrase:', mask: true });
+      if (newPass !== confirmed) {
+        output.printError('Passphrases do not match.');
+        return { success: false, exitCode: 1 };
+      }
+      try {
+        const store = new CredentialStore({ filePath, passphrase: newPass });
+        // Force a salted file write so the chosen passphrase locks the store.
+        await store.store('__init__', 'init');
+        await store.delete('__init__');
+      } catch (err) {
+        if (err instanceof CredentialStoreError && err.code === 'WEAK_PASSPHRASE') {
+          output.printError(err.message);
+          return { success: false, exitCode: 1 };
+        }
+        throw err;
+      }
+      output.printSuccess(`Initialised credential store at ${filePath}`);
+      output.printInfo('Set MOFLO_CREDENTIALS_PASSPHRASE in your environment to keep schedules running unattended.');
+      return { success: true };
+    }
+
+    const oldPass = await input({ message: 'Current passphrase:', mask: true });
+    const newPass = await input({ message: `New passphrase ${minHint}:`, mask: true });
+    const confirmed = await input({ message: 'Confirm new passphrase:', mask: true });
+    if (newPass !== confirmed) {
+      output.printError('Passphrases do not match.');
+      return { success: false, exitCode: 1 };
+    }
+    try {
+      const store = new CredentialStore({ filePath, passphrase: oldPass });
+      await store.rotate(oldPass, newPass);
+    } catch (err) {
+      if (err instanceof CredentialStoreError) {
+        output.printError(err.message);
+        return { success: false, exitCode: 1 };
+      }
+      throw err;
+    }
+    output.printSuccess('Passphrase rotated. Update MOFLO_CREDENTIALS_PASSPHRASE if you set it in your environment.');
+    return { success: true };
+  },
+};
+
+export const spellCredentialsCommand: Command = {
+  name: 'credentials',
+  aliases: ['creds'],
+  description: 'Manage the encrypted credential store used for unattended spell casts',
+  subcommands: [listCommand, setCommand, unsetCommand, clearCommand, passphraseCommand],
+  options: [],
+  examples: [
+    { command: 'moflo spell credentials list', description: 'Show stored credential names' },
+    { command: 'moflo spell credentials set GRAPH_TOKEN', description: 'Store a credential' },
+    { command: 'moflo spell credentials unset GRAPH_TOKEN', description: 'Remove a credential' },
+    { command: 'moflo spell credentials clear --force', description: 'Wipe all credentials' },
+  ],
+  action: async (): Promise<CommandResult> => {
+    output.writeln();
+    output.writeln(output.bold('Spell Credentials'));
+    output.writeln();
+    output.writeln('Usage: moflo spell credentials <subcommand>');
+    output.writeln();
+    output.printList([
+      `${output.highlight('list')}        - List stored credential names`,
+      `${output.highlight('set')}         - Store a credential (hidden input)`,
+      `${output.highlight('unset')}       - Remove a single credential`,
+      `${output.highlight('clear')}       - Remove all stored credentials`,
+      `${output.highlight('passphrase')}  - Initialise or rotate the passphrase`,
+    ]);
+    return { success: true };
+  },
+};
+
+// Re-exported types kept available for tests that import them via this module.
+export type { CredentialMeta };

--- a/src/cli/commands/spell.ts
+++ b/src/cli/commands/spell.ts
@@ -30,6 +30,7 @@ import {
 } from '../mcp-tools/tool-names.js';
 import { formatStatus, handleMCPError } from '../services/cli-formatters.js';
 import { scheduleCommand } from './spell-schedule.js';
+import { spellCredentialsCommand } from './spell-credentials.js';
 import { loadSpellEngine } from '../services/engine-loader.js';
 
 // Re-export formatStatus as formatStageStatus for table column references
@@ -670,7 +671,7 @@ export const spellCommand: Command = {
   name: 'spell',
   aliases: ['workflow'],
   description: 'Spell casting and management',
-  subcommands: [castCommand, validateCommand, listCommand, statusCommand, stopCommand, templateCommand, scheduleCommand],
+  subcommands: [castCommand, validateCommand, listCommand, statusCommand, stopCommand, templateCommand, scheduleCommand, spellCredentialsCommand],
   options: [],
   examples: [
     { command: 'moflo spell cast -n development', description: 'Cast spell by name' },
@@ -692,8 +693,9 @@ export const spellCommand: Command = {
       `${output.highlight('list')}      - List spells (grimoire + casts)`,
       `${output.highlight('status')}    - Show spell status`,
       `${output.highlight('stop')}      - Dispel a running spell`,
-      `${output.highlight('template')}  - Browse grimoire templates`,
-      `${output.highlight('schedule')}  - Manage scheduled spells`,
+      `${output.highlight('template')}    - Browse grimoire templates`,
+      `${output.highlight('schedule')}    - Manage scheduled spells`,
+      `${output.highlight('credentials')} - Manage stored secrets for unattended casts`,
     ]);
     output.writeln();
     output.writeln('Run "moflo spell <subcommand> --help" for more info');

--- a/src/cli/services/moflo-paths.ts
+++ b/src/cli/services/moflo-paths.ts
@@ -19,6 +19,7 @@
  * `cli/services/cherry-pick-learnings.ts` and is dynamically imported from
  * the compiled `dist/` by the launcher.
  */
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 export const MOFLO_DIR = '.moflo';
@@ -41,6 +42,11 @@ export const LEGACY_MEMORY_DB_BAK_SUFFIX = '.bak';
 
 export function mofloDir(projectRoot: string): string {
   return join(projectRoot, MOFLO_DIR);
+}
+
+/** User-scope MoFlo state dir: `~/.moflo`. Holds credentials and other per-machine state. */
+export function mofloHomeDir(): string {
+  return join(homedir(), MOFLO_DIR);
 }
 
 export function legacyClaudeFlowDir(projectRoot: string): string {

--- a/src/cli/spells/commands/prompt-command.ts
+++ b/src/cli/spells/commands/prompt-command.ts
@@ -41,6 +41,13 @@ export interface PromptStepConfig extends StepConfig {
    * this many days in the past. Useful for first-run date prompts.
    */
   readonly fallbackDaysAgo?: number;
+  /**
+   * Persist the response to the credential store under this name. When set,
+   * a stored value short-circuits the prompt; a successful TTY answer is
+   * persisted so future casts skip the prompt. Use for secrets — the store
+   * encrypts at rest.
+   */
+  readonly saveAs?: string;
 }
 
 /**
@@ -81,6 +88,10 @@ export const promptCommand: StepCommand<PromptStepConfig> = {
         type: 'number',
         description: 'Used when default resolves to empty/null — produces ISO timestamp N days ago',
       },
+      saveAs: {
+        type: 'string',
+        description: 'Persist the response under this name in the credential store; later casts read it back without prompting',
+      },
     },
     required: ['message'],
   } satisfies JSONSchema,
@@ -101,12 +112,42 @@ export const promptCommand: StepCommand<PromptStepConfig> = {
     if (config.fallbackDaysAgo !== undefined && typeof config.fallbackDaysAgo !== 'number') {
       errors.push({ path: 'fallbackDaysAgo', message: 'fallbackDaysAgo must be a number' });
     }
+    if (config.saveAs !== undefined && typeof config.saveAs !== 'string') {
+      errors.push({ path: 'saveAs', message: 'saveAs must be a string' });
+    }
+    if (typeof config.saveAs === 'string' && config.saveAs.trim().length === 0) {
+      errors.push({ path: 'saveAs', message: 'saveAs cannot be empty' });
+    }
     return { valid: errors.length === 0, errors };
   },
 
   async execute(config: PromptStepConfig, context: CastingContext): Promise<StepOutput> {
     const start = Date.now();
     const message = interpolateString(config.message, context);
+    const saveAs = config.saveAs?.trim();
+
+    if (saveAs) {
+      try {
+        const stored = await context.credentials.get(saveAs);
+        if (typeof stored === 'string' && stored.length > 0) {
+          return {
+            success: true,
+            data: {
+              message,
+              options: config.options ?? null,
+              outputVar: config.outputVar ?? 'response',
+              response: stored,
+              default: '',
+              interactive: false,
+              fromStore: true,
+            },
+            duration: Date.now() - start,
+          };
+        }
+      } catch {
+        // Store unavailable — fall through to normal prompt path.
+      }
+    }
 
     // Interpolate default — pure-ref interpolation may yield null; tolerate it.
     let interpolatedDefault: string | null = null;
@@ -136,6 +177,15 @@ export const promptCommand: StepCommand<PromptStepConfig> = {
       }
     }
 
+    // Best-effort persist — a failed save shouldn't fail a cast that already has a working answer.
+    if (saveAs && interactive && response) {
+      try {
+        await context.credentials.store(saveAs, response);
+      } catch (err) {
+        console.warn(`[moflo:credentials] could not persist "${saveAs}": ${(err as Error).message}`);
+      }
+    }
+
     return {
       success: true,
       data: {
@@ -145,6 +195,7 @@ export const promptCommand: StepCommand<PromptStepConfig> = {
         response,
         default: effectiveDefault,
         interactive,
+        fromStore: false,
       },
       duration: Date.now() - start,
     };
@@ -157,6 +208,7 @@ export const promptCommand: StepCommand<PromptStepConfig> = {
       { name: 'outputVar', type: 'string' },
       { name: 'default', type: 'string', description: 'Effective default after fallback chain' },
       { name: 'interactive', type: 'boolean', description: 'Whether the user was actually prompted' },
+      { name: 'fromStore', type: 'boolean', description: 'True when the response was returned from the credential store' },
     ];
   },
 };

--- a/src/cli/spells/core/prerequisite-checker.ts
+++ b/src/cli/spells/core/prerequisite-checker.ts
@@ -17,7 +17,7 @@
 import { execFile } from 'node:child_process';
 import { access } from 'node:fs/promises';
 import { promisify } from 'node:util';
-import type { StepCommand, Prerequisite, PrerequisiteResult } from '../types/step-command.types.js';
+import type { StepCommand, Prerequisite, PrerequisiteResult, CredentialAccessor } from '../types/step-command.types.js';
 import type {
   SpellDefinition,
   StepDefinition,
@@ -181,10 +181,20 @@ export function formatPrerequisiteErrors(results: readonly PrerequisiteResult[])
 
   const lines = ['Missing prerequisites:'];
   for (const f of failed) {
-    lines.push(`  - ${f.name}: ${f.installHint}`);
-    if (f.url) lines.push(`    ${f.url}`);
+    appendPrereqLine(lines, f.name, f.installHint, f.url);
   }
   return lines.join('\n');
+}
+
+function appendPrereqLine(
+  lines: string[],
+  name: string,
+  hint: string | undefined,
+  url: string | undefined,
+): void {
+  const hintSuffix = hint ? `: ${hint}` : '';
+  lines.push(`  - ${name}${hintSuffix}`);
+  if (url) lines.push(`    ${url}`);
 }
 
 // ============================================================================
@@ -202,21 +212,41 @@ export interface ResolvePrerequisitesOptions {
   readonly promptLine?: PromptLineFn;
   /** Sink for preflight UI output. Defaults to console.log. */
   readonly log?: (line: string) => void;
+  /**
+   * Credential accessor consulted before prompting. When present and
+   * `credentials.has(envKey)` is true, the resolver populates
+   * `process.env[envKey]` from the store and skips the prompt.
+   * When a TTY prompt produces an answer, it's persisted via
+   * `credentials.store(envKey, answer)` so the next cast doesn't prompt.
+   */
+  readonly credentials?: CredentialAccessor;
 }
 
 export interface ResolvePrerequisitesResult {
   readonly ok: boolean;
   /** Present when ok === false. Suitable for surfacing as a SpellError message. */
   readonly message?: string;
-  /** Names of prereqs that were prompted and resolved this call. */
+  /** Names of prereqs satisfied this call (from the store and/or prompt). */
   readonly resolvedNames: readonly string[];
+  /**
+   * `'MISSING_CREDENTIAL'` distinguishes "spell can't run unattended yet"
+   * from generic preflight failure so the runner can surface a more
+   * actionable error to schedulers.
+   */
+  readonly errorCode?: 'MISSING_CREDENTIAL';
+  /** Env keys that were missing for the `MISSING_CREDENTIAL` path. */
+  readonly missingCredentials?: readonly string[];
 }
 
 /**
- * Evaluate all prereqs. On a TTY, prompts the user for unmet env-type prereqs
- * whose spec opted into `promptOnMissing`, writes answers into process.env,
- * then re-checks. Non-TTY calls and non-promptable unmet prereqs short-circuit
- * to a single formatted failure report.
+ * Evaluate all prereqs. Resolution chain for env-type prereqs:
+ *   1. process.env[key] already set → satisfied.
+ *   2. credentials.get(key) returns a value → write to process.env, satisfied.
+ *   3. TTY interactive → prompt → write to process.env AND credentials.store.
+ *   4. Non-TTY or no credentials → fail fast with `errorCode: 'MISSING_CREDENTIAL'`.
+ *
+ * Non-env prereqs (`command`, `file`) bypass the credential chain and surface
+ * through the standard "Missing prerequisites" path.
  */
 export async function resolveUnmetPrerequisites(
   prerequisites: readonly Prerequisite[],
@@ -229,29 +259,67 @@ export async function resolveUnmetPrerequisites(
   const interactive = options.interactive
     ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
   const log = options.log ?? ((line: string) => console.log(line));
+  const credentials = options.credentials;
 
   const initial = await checkPrerequisites(prerequisites);
-  const unmet = prerequisites.filter((_, i) => !initial[i].satisfied);
-  if (unmet.length === 0) {
+  const unmetIndices = initial.flatMap((r, i) => r.satisfied ? [] : [i]);
+  if (unmetIndices.length === 0) {
     return { ok: true, resolvedNames: [] };
   }
 
-  const promptable = unmet.filter(
+  // Pull env-type prereqs from the store in parallel — each resolved index
+  // lets us skip a re-check of the cheap env detector.
+  const resolvedFromStoreNames: string[] = [];
+  const storeResolved = new Set<number>();
+  if (credentials) {
+    await Promise.all(unmetIndices.map(async (i) => {
+      const prereq = prerequisites[i];
+      if (!prereq.envKey) return;
+      const stored = await credentials.get(prereq.envKey);
+      if (typeof stored === 'string' && stored.length > 0) {
+        process.env[prereq.envKey] = stored;
+        storeResolved.add(i);
+        resolvedFromStoreNames.push(prereq.name);
+      }
+    }));
+  }
+
+  const stillUnmetIdx = unmetIndices.filter(i => !storeResolved.has(i));
+  if (stillUnmetIdx.length === 0) {
+    return { ok: true, resolvedNames: resolvedFromStoreNames };
+  }
+
+  const stillUnmet = stillUnmetIdx.map(i => prerequisites[i]);
+  const promptable = stillUnmet.filter(
     p => interactive && p.promptOnMissing === true && typeof p.envKey === 'string',
   );
 
   if (!interactive || promptable.length === 0) {
+    const promptableEnvKeys = stillUnmet
+      .filter(p => p.promptOnMissing === true && typeof p.envKey === 'string')
+      .map(p => p.envKey!);
+
+    if (promptableEnvKeys.length > 0) {
+      return {
+        ok: false,
+        message: formatMissingCredentialMessage(promptableEnvKeys, stillUnmet),
+        resolvedNames: resolvedFromStoreNames,
+        errorCode: 'MISSING_CREDENTIAL',
+        missingCredentials: promptableEnvKeys,
+      };
+    }
     return {
       ok: false,
-      message: formatPrerequisiteErrors(initial),
-      resolvedNames: [],
+      message: formatPrerequisiteErrors(stillUnmetIdx.map(i => initial[i])),
+      resolvedNames: resolvedFromStoreNames,
     };
   }
 
-  printPreflightBanner(log, unmet.length);
+  printPreflightBanner(log, stillUnmet.length);
 
   const promptLine = options.promptLine ?? readLineFromStdin;
-  const resolvedNames: string[] = [];
+  const promptedNames: string[] = [];
+  const promptableSet = new Set(promptable);
   const lock = acquireTTYLock();
   try {
     for (const prereq of promptable) {
@@ -259,7 +327,7 @@ export async function resolveUnmetPrerequisites(
         return {
           ok: false,
           message: 'Prerequisite resolution aborted',
-          resolvedNames,
+          resolvedNames: [...resolvedFromStoreNames, ...promptedNames],
         };
       }
       if (prereq.description) log(prereq.description);
@@ -272,37 +340,59 @@ export async function resolveUnmetPrerequisites(
         return {
           ok: false,
           message: `Prerequisite "${prereq.name}" prompt failed: ${(err as Error).message}`,
-          resolvedNames,
+          resolvedNames: [...resolvedFromStoreNames, ...promptedNames],
         };
       }
       if (!answer || answer.length === 0) {
         return {
           ok: false,
           message: `Prerequisite "${prereq.name}" was not provided`,
-          resolvedNames,
+          resolvedNames: [...resolvedFromStoreNames, ...promptedNames],
         };
       }
       if (prereq.envKey) {
         process.env[prereq.envKey] = answer;
+        if (credentials) {
+          try {
+            await credentials.store(prereq.envKey, answer);
+          } catch (err) {
+            log(`  (could not persist credential "${prereq.envKey}": ${(err as Error).message})`);
+          }
+        }
       }
-      resolvedNames.push(prereq.name);
+      promptedNames.push(prereq.name);
     }
   } finally {
     lock.release();
   }
 
-  // Re-check everything — any still unmet (e.g. command/file prereqs that
-  // couldn't be resolved via prompt) fail now with the up-to-date report.
-  const rerun = await checkPrerequisites(prerequisites);
-  const stillUnmet = rerun.filter(r => !r.satisfied);
-  if (stillUnmet.length > 0) {
+  // Anything in stillUnmet that wasn't promptable (typically command/file
+  // prereqs) is still broken — carry forward the initial detector result.
+  const unfixableIdx = stillUnmetIdx.filter(i => !promptableSet.has(prerequisites[i]));
+  if (unfixableIdx.length > 0) {
     return {
       ok: false,
-      message: formatPrerequisiteErrors(rerun),
-      resolvedNames,
+      message: formatPrerequisiteErrors(unfixableIdx.map(i => initial[i])),
+      resolvedNames: [...resolvedFromStoreNames, ...promptedNames],
     };
   }
-  return { ok: true, resolvedNames };
+  return { ok: true, resolvedNames: [...resolvedFromStoreNames, ...promptedNames] };
+}
+
+function formatMissingCredentialMessage(
+  envKeys: readonly string[],
+  prereqs: readonly Prerequisite[],
+): string {
+  const lines = ['Missing credentials (cannot prompt — non-interactive run):'];
+  for (const key of envKeys) {
+    const prereq = prereqs.find(p => p.envKey === key);
+    const label = `${prereq?.name ?? key} (${key})`;
+    appendPrereqLine(lines, label, prereq?.installHint, prereq?.url);
+  }
+  lines.push('');
+  lines.push('Prime these by casting the spell once interactively, or run:');
+  lines.push('  flo spell credentials set <name>');
+  return lines.join('\n');
 }
 
 function printPreflightBanner(log: (line: string) => void, unmetCount: number): void {

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -152,17 +152,18 @@ export class SpellCaster {
       }
     }
 
-    // Pre-flight prerequisite checks — walks YAML + step-command sources,
-    // prompts on a TTY for unmet env-type prereqs (issue #460).
+    // Pre-flight prerequisite checks (issue #460) — walks YAML + step-command
+    // sources, pulls from credential store, prompts on TTY, persists answers.
     if (!options.dryRun) {
       const prerequisites = collectPrerequisites(definition, this.registry);
       if (prerequisites.length > 0) {
         const resolution = await resolveUnmetPrerequisites(prerequisites, {
           abortSignal: options.signal,
+          credentials: this.credentials,
         });
         if (!resolution.ok) {
           return this.failureResult(spellId, startTime, [{
-            code: 'PREREQUISITES_FAILED',
+            code: resolution.errorCode ?? 'PREREQUISITES_FAILED',
             message: resolution.message ?? 'Prerequisites failed',
           }], definition.name);
         }

--- a/src/cli/spells/credentials/credential-store.ts
+++ b/src/cli/spells/credentials/credential-store.ts
@@ -63,6 +63,9 @@ const KEY_BYTES = 32;
 const PBKDF2_ITERATIONS = 100_000;
 const PBKDF2_DIGEST = 'sha512';
 
+/** User-typeable floor for any passphrase that protects the store. */
+export const MIN_PASSPHRASE_LENGTH = 8;
+
 // ============================================================================
 // Encryption Helpers
 // ============================================================================
@@ -116,8 +119,11 @@ export class CredentialStore implements CredentialAccessor {
    * Derives the encryption key and loads existing data.
    */
   unlock(passphrase: string): void {
-    if (passphrase.length < 8) {
-      throw new CredentialStoreError('Passphrase must be at least 8 characters', 'WEAK_PASSPHRASE');
+    if (passphrase.length < MIN_PASSPHRASE_LENGTH) {
+      throw new CredentialStoreError(
+        `Passphrase must be at least ${MIN_PASSPHRASE_LENGTH} characters`,
+        'WEAK_PASSPHRASE',
+      );
     }
     this.data = this.readFile();
     const salt = Buffer.from(this.data.salt, 'hex');
@@ -194,6 +200,20 @@ export class CredentialStore implements CredentialAccessor {
   }
 
   /**
+   * Remove every credential in a single write — preferred over a delete loop
+   * because each `delete()` rewrites the entire encrypted file.
+   * Returns the number of credentials removed.
+   */
+  async clear(): Promise<number> {
+    this.ensureUnlocked();
+    const count = Object.keys(this.data!.credentials).length;
+    if (count === 0) return 0;
+    this.data!.credentials = {};
+    this.writeFile(this.data!);
+    return count;
+  }
+
+  /**
    * List credential metadata (names + descriptions, never values).
    */
   async list(): Promise<readonly CredentialMeta[]> {
@@ -230,8 +250,11 @@ export class CredentialStore implements CredentialAccessor {
    * and derived key, re-encrypts everything, and writes atomically.
    */
   async rotate(oldPassphrase: string, newPassphrase: string): Promise<void> {
-    if (newPassphrase.length < 8) {
-      throw new CredentialStoreError('Passphrase must be at least 8 characters', 'WEAK_PASSPHRASE');
+    if (newPassphrase.length < MIN_PASSPHRASE_LENGTH) {
+      throw new CredentialStoreError(
+        `Passphrase must be at least ${MIN_PASSPHRASE_LENGTH} characters`,
+        'WEAK_PASSPHRASE',
+      );
     }
 
     // Verify old passphrase by unlocking with it

--- a/src/cli/spells/credentials/default-store.ts
+++ b/src/cli/spells/credentials/default-store.ts
@@ -1,0 +1,143 @@
+/**
+ * Default Credential Store
+ *
+ * Singleton `CredentialAccessor` wired into the runner factory, MCP bridge,
+ * and daemon executor so spells persist secrets between casts.
+ *
+ * Passphrase resolution: `MOFLO_CREDENTIALS_PASSPHRASE` env var, else an
+ * auto-generated `~/.moflo/credentials.key` (32 random bytes hex, mode
+ * 0o600) created on first need. The auto-key gives zero-config at-rest
+ * encryption — the threat model matches `~/.aws/credentials`: filesystem
+ * read by an attacker compromises the store either way.
+ *
+ * Failures degrade to `lockedNoopAccessor` (returns undefined / no-op
+ * persists) so the spell engine never crashes on a missing or unreadable
+ * credentials path.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { CredentialStore, MIN_PASSPHRASE_LENGTH } from './credential-store.js';
+import { mofloHomeDir } from '../../services/moflo-paths.js';
+import type { CredentialAccessor } from '../types/step-command.types.js';
+
+const KEY_BYTES = 32;
+/** 64 hex chars from `KEY_BYTES`; floor of 16 catches truncation/corruption. */
+const KEY_FILE_MIN_HEX_LENGTH = 16;
+
+export const DEFAULT_CREDENTIALS_FILE = join(mofloHomeDir(), 'credentials.json');
+export const DEFAULT_CREDENTIALS_KEY_FILE = join(mofloHomeDir(), 'credentials.key');
+
+let cached: CredentialAccessor | null = null;
+
+export interface DefaultCredentialStoreOptions {
+  /** Override the credentials JSON path (else `MOFLO_CREDENTIALS_FILE` env or `~/.moflo/credentials.json`). */
+  readonly filePath?: string;
+  /** Override the auto-key file path (else `MOFLO_CREDENTIALS_KEY_FILE` env or `~/.moflo/credentials.key`). */
+  readonly keyFilePath?: string;
+  /** Override the passphrase (else `MOFLO_CREDENTIALS_PASSPHRASE` or generated key file). */
+  readonly passphrase?: string;
+}
+
+/**
+ * Resolve the singleton default credential store. Returns an unlocked
+ * `CredentialStore` when a passphrase is available, otherwise a locked
+ * no-op accessor. Never throws.
+ */
+export function getDefaultCredentialStore(
+  options: DefaultCredentialStoreOptions = {},
+): CredentialAccessor {
+  if (cached) return cached;
+
+  const filePath = resolveCredentialFilePath(options.filePath);
+  const passphrase = resolvePassphrase(options.passphrase, options.keyFilePath);
+
+  let accessor: CredentialAccessor;
+  if (passphrase) {
+    try {
+      accessor = new CredentialStore({ filePath, passphrase });
+    } catch (err) {
+      console.warn(`[moflo:credentials] store unavailable: ${(err as Error).message}`);
+      accessor = lockedNoopAccessor;
+    }
+  } else {
+    accessor = lockedNoopAccessor;
+  }
+
+  cached = accessor;
+  return accessor;
+}
+
+/** Reset the cached singleton — used by tests and CLI subcommands. */
+export function resetDefaultCredentialStore(): void {
+  cached = null;
+}
+
+/** Resolve the credentials JSON path (override → env → default). */
+export function resolveCredentialFilePath(explicit?: string): string {
+  return explicit ?? process.env.MOFLO_CREDENTIALS_FILE ?? DEFAULT_CREDENTIALS_FILE;
+}
+
+/** Resolve the key file path (override → env → default). */
+export function resolveKeyFilePath(explicit?: string): string {
+  return explicit ?? process.env.MOFLO_CREDENTIALS_KEY_FILE ?? DEFAULT_CREDENTIALS_KEY_FILE;
+}
+
+/**
+ * Resolve a passphrase from explicit override, `MOFLO_CREDENTIALS_PASSPHRASE`,
+ * or the auto-generated key file. Returns `undefined` when no path yields a
+ * usable value (locked-store mode).
+ */
+export function resolvePassphrase(
+  explicit?: string,
+  keyFilePathOverride?: string,
+): string | undefined {
+  if (explicit) return explicit;
+  const envPass = process.env.MOFLO_CREDENTIALS_PASSPHRASE;
+  if (envPass && envPass.length >= MIN_PASSPHRASE_LENGTH) return envPass;
+  return resolveKeyFilePassphrase(keyFilePathOverride);
+}
+
+function resolveKeyFilePassphrase(override: string | undefined): string | undefined {
+  const keyPath = resolveKeyFilePath(override);
+
+  try {
+    let content: string | null = null;
+    try {
+      content = readFileSync(keyPath, 'utf-8').trim();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+
+    if (content !== null) {
+      if (content.length >= KEY_FILE_MIN_HEX_LENGTH) return content;
+      // Refuse to regenerate over a corrupt key when credentials exist —
+      // a fresh key would silently invalidate every stored secret.
+      const credPath = join(dirname(keyPath), 'credentials.json');
+      try {
+        readFileSync(credPath);
+        console.warn(`[moflo:credentials] key file at ${keyPath} is corrupt; refusing to regenerate while ${credPath} exists`);
+        return undefined;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+    }
+
+    mkdirSync(dirname(keyPath), { recursive: true });
+    const generated = randomBytes(KEY_BYTES).toString('hex');
+    writeFileSync(keyPath, generated, { encoding: 'utf-8', mode: 0o600 });
+    // chmod after write in case the create mode was masked by umask.
+    try { chmodSync(keyPath, 0o600); } catch { /* best-effort on Windows */ }
+    return generated;
+  } catch (err) {
+    console.warn(`[moflo:credentials] could not read/create key file: ${(err as Error).message}`);
+    return undefined;
+  }
+}
+
+export const lockedNoopAccessor: CredentialAccessor = {
+  async get() { return undefined; },
+  async has() { return false; },
+  async store() { /* no-op */ },
+};

--- a/src/cli/spells/credentials/index.ts
+++ b/src/cli/spells/credentials/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Credentials barrel — public surface of the credential subsystem.
+ */
+
+export {
+  CredentialStore,
+  CredentialStoreError,
+  MIN_PASSPHRASE_LENGTH,
+  type CredentialMeta,
+  type CredentialStoreOptions,
+  type CredentialStoreErrorCode,
+} from './credential-store.js';
+
+export {
+  getDefaultCredentialStore,
+  resetDefaultCredentialStore,
+  resolveCredentialFilePath,
+  resolveKeyFilePath,
+  resolvePassphrase,
+  lockedNoopAccessor,
+  DEFAULT_CREDENTIALS_FILE,
+  DEFAULT_CREDENTIALS_KEY_FILE,
+  type DefaultCredentialStoreOptions,
+} from './default-store.js';

--- a/src/cli/spells/factory/runner-bridge.ts
+++ b/src/cli/spells/factory/runner-bridge.ts
@@ -14,6 +14,7 @@ import type { CredentialAccessor, MemoryAccessor } from '../types/step-command.t
 import type { SandboxConfig } from '../core/platform-sandbox.js';
 import { loadSandboxConfigFromProject } from '../core/platform-sandbox.js';
 import { createRunner, runSpellFromContent } from './runner-factory.js';
+import { getDefaultCredentialStore } from '../credentials/default-store.js';
 
 /**
  * Resolve sandbox config: prefer caller-supplied; fall back to auto-loading
@@ -51,13 +52,14 @@ export async function bridgeRunSpell(
 
   try {
     const sandboxConfig = await resolveSandbox(options.sandboxConfig, options.projectRoot);
+    const credentials = options.credentials ?? getDefaultCredentialStore();
     const result = await runSpellFromContent(content, sourceFile, {
       spellId,
       args,
       dryRun: options.dryRun,
       signal: controller.signal,
       memory: options.memory,
-      credentials: options.credentials,
+      credentials,
       ...(options.projectRoot ? { projectRoot: options.projectRoot } : {}),
       ...(sandboxConfig ? { sandboxConfig } : {}),
     });
@@ -81,7 +83,8 @@ export async function bridgeExecuteSpell(
 
   try {
     const sandboxConfig = await resolveSandbox(options.sandboxConfig, options.projectRoot);
-    const runner = createRunner({ memory: options.memory, credentials: options.credentials });
+    const credentials = options.credentials ?? getDefaultCredentialStore();
+    const runner = createRunner({ memory: options.memory, credentials });
     return await runner.run(definition, args, {
       spellId,
       signal: controller.signal,

--- a/src/cli/spells/factory/runner-factory.ts
+++ b/src/cli/spells/factory/runner-factory.ts
@@ -18,6 +18,7 @@ import { validateSpellDefinition } from '../schema/validator.js';
 import { SpellConnectorRegistry } from '../registry/connector-registry.js';
 import { loadSandboxConfigFromProject } from '../core/platform-sandbox.js';
 import { errorDetail } from '../../shared/utils/error-detail.js';
+import { getDefaultCredentialStore } from '../credentials/default-store.js';
 
 // ============================================================================
 // Types
@@ -61,7 +62,7 @@ export function createRunner(options: RunnerFactoryOptions = {}): SpellCaster {
     registry.loadFromDirectories(options.stepDirs);
   }
 
-  const credentials = options.credentials ?? noopCredentials;
+  const credentials = options.credentials ?? getDefaultCredentialStore();
   const memory = options.memory ?? noopMemory;
 
   // Auto-register shipped connectors into the connector registry
@@ -132,9 +133,10 @@ export async function runSpellFromContent(
 // Noop Accessors (for standalone usage without full CLI context)
 // ============================================================================
 
-const noopCredentials: CredentialAccessor = {
+export const noopCredentials: CredentialAccessor = {
   async get() { return undefined; },
   async has() { return false; },
+  async store() { /* no-op */ },
 };
 
 export const noopMemory: MemoryAccessor = {

--- a/src/cli/spells/index.ts
+++ b/src/cli/spells/index.ts
@@ -257,10 +257,14 @@ export {
 export {
   CredentialStore,
   CredentialStoreError,
+  getDefaultCredentialStore,
+  resetDefaultCredentialStore,
+  lockedNoopAccessor,
   type CredentialMeta,
   type CredentialStoreOptions,
   type CredentialStoreErrorCode,
-} from './credentials/credential-store.js';
+  type DefaultCredentialStoreOptions,
+} from './credentials/index.js';
 
 // ============================================================================
 // Spell Registry (abbreviation lookup + list/info)

--- a/src/cli/spells/types/runner.types.ts
+++ b/src/cli/spells/types/runner.types.ts
@@ -32,6 +32,7 @@ export type SpellErrorCode =
   | 'PAUSED_STATE_EXPIRED'
   | 'PREREQUISITES_FAILED'
   | 'PREFLIGHT_FAILED'
+  | 'MISSING_CREDENTIAL'
   | 'SPELL_CANCELLED';
 
 // ============================================================================

--- a/src/cli/spells/types/step-command.types.ts
+++ b/src/cli/spells/types/step-command.types.ts
@@ -80,6 +80,11 @@ export interface OutputDescriptor {
 export interface CredentialAccessor {
   get(name: string): Promise<string | undefined>;
   has(name: string): Promise<boolean>;
+  /**
+   * Persist a credential by name. Read-only accessors (e.g. fixture mocks)
+   * may make this a no-op; callers should not assume durability.
+   */
+  store(name: string, value: string): Promise<void>;
 }
 
 export interface MemoryAccessor {


### PR DESCRIPTION
## Summary

Wires the existing `CredentialStore` (AES-256-GCM, PBKDF2) end-to-end so secrets persist between casts and scheduled spells (#877) can run unattended after a one-time priming.

Closes #880, #922, #923, #924, #925. Inline epic per the standing decision.

## Stories shipped

- **#922** — Default `CredentialStore` singleton at `~/.moflo/credentials.json`, passphrase from `MOFLO_CREDENTIALS_PASSPHRASE` or an auto-generated `~/.moflo/credentials.key` (mode 0o600). Threaded through `runner-factory`, `runner-bridge`, daemon executor.
- **#923** — Prerequisites resolver: `env -> store -> prompt -> persist` chain. Non-TTY runs surface `MISSING_CREDENTIAL` distinct from the generic `PREREQUISITES_FAILED` so schedulers can act on it.
- **#924** — `prompt` step gains a `saveAs:` opt-in. Stored value short-circuits the prompt; TTY answers persist back to the store.
- **#925** — `flo spell credentials list/set/unset/clear/passphrase` CLI.

## /simplify pass (multi-agent review applied inline)

- New `mofloHomeDir()` in `services/moflo-paths.ts`; both `default-store` and the CLI compose paths from it.
- `MIN_PASSPHRASE_LENGTH` + `resolveCredentialFilePath` / `resolveKeyFilePath` / `resolvePassphrase` exported from `credentials/` for CLI reuse.
- `CredentialAccessor.store` made required; `?.store` chains removed.
- `CredentialStore.clear()` replaces the per-name delete loop (one file write instead of N).
- Prerequisites resolver: `Promise.all` over store-pull, single `checkPrerequisites` round (down from three), `errorCode` aligned with `SpellErrorCode` union.
- TOCTOU `existsSync -> readFileSync` replaced with single read + ENOENT.

## Behavior change worth flagging

`flo spell credentials list` on a fresh machine now silently auto-inits `~/.moflo/credentials.key` and reports an empty store, instead of "locked store, run passphrase to init." More forgiving UX, consistent with the runner. The locked-state path still triggers when the key file is corrupt and credentials exist alongside it.

## Test plan

- [x] tsc --noEmit clean
- [x] default-store.test.ts — 11 tests (singleton, env-passphrase precedence, key file mode, corrupt-key refusal, integration)
- [x] spell-credentials.test.ts — 14 tests (list/set/unset/clear/passphrase + parent wiring)
- [x] prompt-command.test.ts — 27 tests including new saveAs paths
- [x] prerequisites-resolve.test.ts — 13 tests including new credential-store chain
- [x] spell-command.test.ts — credentials subcommand wired
- [x] Regression: runner.test.ts, runner-bridge.test.ts, prerequisites-integration.test.ts — 71 tests all green

## Threat model note

Auto-key approach matches `~/.aws/credentials`: filesystem read by an attacker compromises the store either way. The user can always opt into `MOFLO_CREDENTIALS_PASSPHRASE` for a stronger profile (key never on disk).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)