### PR TITLE
perf(simplify): tune gate so trivial deltas don't burn tokens

### DIFF
--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -34,20 +34,15 @@ Pick the smallest tier the diff genuinely fits.
 
 Critical-surface files (launcher, hooks, MCP wiring) raise the *care* of the agent prompt — sharper checklist, blast-radius framing — they do **not** automatically escalate to NORMAL. Risk-weighted ≠ headcount-weighted.
 
-## Phase 3: Route the model (skip for TRIVIAL)
+## Phase 3: Use the classifier's model (skip for TRIVIAL)
 
-Before spawning any Agent, ask the moflo router which model to use:
+The classifier returns the right model for the tier — no separate router call needed:
 
-```
-mcp__moflo__hooks_model-route — {
-  task: "Review N-line change in <files> for reuse, quality, efficiency",
-  preferCost: true
-}
-```
+- `sonnet` (default) — real logic edits, single agent or 3-agent fan-out.
+- `haiku` — mostly-relocation diffs (mechanical moves; pattern-matching beats deep reasoning).
+- `opus` — never returned. Code review is breadth-bound, not depth-bound; sonnet 3-way IS the high-effort tier.
 
-**Wording rules:** the router's complexity score is keyword-sensitive. Avoid `refactor`, `architect`, `audit`, `system`, `redesign`, `migrate` — those force opus even when scoring suggests sonnet. State LOC count, file count, and "review for reuse, quality, efficiency". Nothing more.
-
-**Hard rule for `/simplify`: opus is never correct.** Code review never needs Opus reasoning, even on critical surface. If the router returns `opus`, downgrade to `sonnet`. On router failure, default to `sonnet`. Comment trims and pure formatting → `haiku`.
+Pass the classifier's `model` field verbatim to Agent's `model` parameter. If you fell back to prose rules in Phase 2 (no classifier), default to `sonnet`.
 
 ## Phase 4: Validation pass (re-run after fixes from a prior simplify)
 
@@ -57,8 +52,11 @@ Escalate one tier (self-review → SMALL agent) only if the fix introduced a new
 
 ## Phase 5: Run the appropriate review
 
-### TRIVIAL / Validation
-Run the three category checks (reuse / quality / efficiency) yourself in one pass against the diff. Most TRIVIAL diffs are clean — confirm and exit. Budget: ~30 seconds, no Agent.
+### TRIVIAL
+Print one confirmation line (`simplify: TRIVIAL — N LOC, 1 file — stamped`) and exit. **Do not** walk the three-category check; the classifier already concluded the diff is below the review-value threshold. Budget: <5 seconds, no Agent.
+
+### Validation pass
+Run the three category checks against the post-fix diff in one pass. Most are clean — confirm and exit. Budget: ~30 seconds, no Agent.
 
 ### SMALL — one agent
 ```

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -7,7 +7,7 @@ var cp = require('child_process');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -99,6 +99,79 @@ var EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE = /(?:^|[\\\/])(__tests__|__mocks__|tests?|
 // Anchored to end-of-path so e.g. `foo.md.js` does not match. Excludes lock files / configs
 // on purpose — those are inert for edit-reset (above) but not "documentation".
 var DOCS_ONLY_RE = /\.(md|markdown|txt|rst|adoc|html?|pdf|png|jpe?g|gif|svg|webp|ico|bmp)$/i;
+
+// Classifier-aware simplify gate skip. Returns a string reason if the gate
+// can be auto-passed, or null if /simplify must run. Uses simplify-classify.cjs
+// so the gate's "trivial" definition matches the skill's exactly.
+//
+// Two paths:
+//   1. snapshot path — /simplify ran earlier on this branch. Classify the diff
+//      between simplifySnapshotSha and current HEAD/working-tree. If TRIVIAL,
+//      the prior review still covers the branch — no re-run needed.
+//   2. baseline path — no snapshot (first time). Classify the entire branch
+//      diff vs merge-base. If TRIVIAL, the whole PR is below the threshold
+//      where /simplify provides value — auto-pass without ever invoking it.
+//
+// Fail-safe: any error (no classifier, no git, no merge-base) returns null,
+// which forces /simplify to run as today.
+function classifyForGateSkip(state) {
+  var classify;
+  try {
+    classify = require('./simplify-classify.cjs').classifyDiff;
+  } catch (e) { return null; }
+  if (typeof classify !== 'function') return null;
+
+  function tryClassify(diffText, label) {
+    try {
+      var dec = classify(diffText);
+      if (dec.tier === 'TRIVIAL') {
+        var loc = (dec.stats.added || 0) + (dec.stats.deleted || 0);
+        return label + ' is TRIVIAL (' + loc + ' LOC, ' + (dec.stats.fileCount || 0) + ' file(s))';
+      }
+    } catch (e) { /* fall through */ }
+    return null;
+  }
+
+  function gitDiff(args) {
+    try {
+      return cp.execFileSync('git', args, {
+        cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 5000, windowsHide: true,
+        stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 8 * 1024 * 1024
+      });
+    } catch (e) { return null; }
+  }
+
+  // Snapshot path: classify everything since /simplify last ran.
+  if (state.simplifySnapshotSha) {
+    var snapDiff = gitDiff(['diff', state.simplifySnapshotSha + '...HEAD']);
+    var workTreeA = gitDiff(['diff', 'HEAD']) || '';
+    if (snapDiff !== null) {
+      var combined = snapDiff + (workTreeA ? '\n' + workTreeA : '');
+      var hit = tryClassify(combined, 'delta since last /simplify');
+      if (hit) return hit;
+    }
+  }
+
+  // Baseline path: classify the whole branch vs merge-base.
+  var bases = ['origin/main', 'main', 'origin/master', 'master'];
+  for (var i = 0; i < bases.length; i++) {
+    var base;
+    try {
+      base = cp.execFileSync('git', ['merge-base', 'HEAD', bases[i]], {
+        cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 2000, windowsHide: true,
+        stdio: ['ignore', 'pipe', 'ignore']
+      }).trim();
+    } catch (e) { continue; }
+    if (!base) continue;
+    var branchDiff = gitDiff(['diff', base + '...HEAD']);
+    var workTreeB = gitDiff(['diff', 'HEAD']) || '';
+    if (branchDiff !== null) {
+      return tryClassify(branchDiff + (workTreeB ? '\n' + workTreeB : ''), 'branch diff');
+    }
+    break;
+  }
+  return null;
+}
 
 // Get the file list changed on the current branch vs the merge-base with origin/main
 // (falling back to local main). Returns an array of repo-relative paths, or null on
@@ -206,10 +279,19 @@ switch (command) {
   case 'record-skill-run': {
     if ((process.env.TOOL_INPUT_skill || '') === 'simplify') {
       var s = readState();
-      if (!s.simplifyRun) {
-        s.simplifyRun = true;
-        writeState(s);
-      }
+      var changed = false;
+      if (!s.simplifyRun) { s.simplifyRun = true; changed = true; }
+      // Snapshot HEAD so check-before-pr can classify delta-since-simplify and
+      // skip a redundant /simplify re-run when only trivial fixes followed.
+      // Non-fatal — gate falls through to current behaviour without the snapshot.
+      try {
+        var sha = cp.execFileSync('git', ['rev-parse', 'HEAD'], {
+          cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 2000, windowsHide: true,
+          stdio: ['ignore', 'pipe', 'ignore']
+        }).trim();
+        if (sha && s.simplifySnapshotSha !== sha) { s.simplifySnapshotSha = sha; changed = true; }
+      } catch (e) { /* no git or detached state — skip snapshot, gate still works */ }
+      if (changed) writeState(s);
     }
     break;
   }
@@ -249,6 +331,19 @@ switch (command) {
       break;
     }
     var s = readState();
+    // Classifier-aware skip: if delta-since-snapshot or whole-branch diff is
+    // TRIVIAL, satisfy the simplify gate silently. Reuses the same classifier
+    // the skill uses — same "trivial" definition, no drift. Same threshold that
+    // already maps to TRIVIAL=0 agents inside /simplify, so trusting it at the
+    // gate level is the same trust profile, just one decision earlier.
+    if (config.simplify_gate && !s.simplifyRun) {
+      var skipReason = classifyForGateSkip(s);
+      if (skipReason) {
+        s.simplifyRun = true;
+        writeState(s);
+        process.stdout.write('Simplify gate auto-passed: ' + skipReason + '\n');
+      }
+    }
     var missing = [];
     if (config.testing_gate && !s.testsRun) missing.push('tests have not run since the last code edit (run npm test, vitest, jest, pytest, or similar)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/simplify has not run since the last code edit');

--- a/.claude/helpers/simplify-classify.cjs
+++ b/.claude/helpers/simplify-classify.cjs
@@ -159,7 +159,10 @@ function decide(stats) {
     reasoning.push(
       `mostly relocation: ${stats.declAdded} decls added, ${stats.declRemoved} removed, net ${stats.netDecls >= 0 ? '+' : ''}${stats.netDecls}`,
     );
-    return { tier: 'SMALL', model: 'sonnet', agentCount: 1, reasoning, stats };
+    // Haiku is sufficient for mechanical moves: code already existed and worked,
+    // so review reduces to copy-paste-divergence / dead-after-move pattern checks
+    // — exactly haiku's strength. ~5x cheaper than sonnet on relocation-shape diffs.
+    return { tier: 'SMALL', model: 'haiku', agentCount: 1, reasoning, stats };
   }
 
   // Escalation triggers — any one trips NORMAL (3 agents).

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -42,13 +42,8 @@ Tier definitions the classifier encodes (for reference, not for re-derivation):
 
 Pick the **smallest tier** the diff genuinely fits. When in doubt, escalate one step (not two).
 
-### TRIVIAL — self-review, no agent spawn
-ALL of these must hold:
-- ≤10 net LOC changed (insertions + deletions, excluding pure whitespace)
-- Single file
-- No logic changes — only comments, formatting, renames of local vars, JSDoc, or string-literal edits
-- No new imports, no new exports, no new function/class declarations
-- No removed safety checks, error handlers, or guards
+### TRIVIAL — gate stamp, no review
+The classifier already proved the diff is below the threshold where review provides value (≤10 net LOC, single file, no declaration/import/export changes, no removed guards). **Stamp the gate with one line of confirmation and exit immediately.** Do not walk the three-category check yourself — the classifier IS the review at this tier, and at the gate level the classifier-aware skip (`bin/gate.cjs:classifyForGateSkip`) often satisfies the gate without invoking this skill at all.
 
 Examples that qualify: trimming a comment, fixing a typo in a log message, renaming a private helper, reformatting a single block.
 Examples that DON'T qualify: changing an `if` condition, reordering function args, deleting a try/catch.
@@ -88,14 +83,21 @@ Do **not** escalate to NORMAL on a validation pass. If the fix is so structural 
 
 ## Phase 2.7: Model selection
 
-**Use the model the classifier returned** — always `sonnet` for `/simplify`. Opus is never correct here; the classifier enforces this. No router call needed; the classifier IS the router for this skill.
+**Use the model the classifier returned.** The classifier IS the router for this skill — no separate router call needed. Possible outputs:
 
-If you fell back to prose rules in Phase 2 (no classifier available), use `sonnet` unconditionally. Pass the model verbatim to Agent's `model` parameter.
+- `sonnet` (default) — real logic changes, single agent or three-agent fan-out.
+- `haiku` — mostly-relocation diffs (mechanical moves where pattern-matching beats deep reasoning, ~5x cheaper).
+- `opus` — never. Code review is breadth-bound, not depth-bound; the three-agent fan-out at sonnet is the high-effort tier.
+
+If you fell back to prose rules in Phase 2 (no classifier available), use `sonnet` unconditionally. Pass the classifier's `model` field verbatim to Agent's `model` parameter.
 
 ## Phase 3: Run the appropriate review
 
-### TRIVIAL / Validation: self-review
-Run the same three category checks (reuse / quality / efficiency) yourself, in one pass, against the diff. Most TRIVIAL and validation diffs will be clean — the goal is to confirm, not to fan out. If you find an issue, fix it; otherwise stamp clean. Total budget: ~30 seconds, no Agent calls. No router call needed.
+### TRIVIAL: stamp and exit
+The classifier proved the diff is below the review-value threshold. Print one confirmation line (e.g. `simplify: TRIVIAL — N LOC, 1 file — stamped`) and exit. **Do not** walk the three-category check; the classifier already concluded the answer is "clean." Budget: <5 seconds, no Agent calls.
+
+### Validation pass: confirm clean
+Run the three category checks (reuse / quality / efficiency) yourself, in one pass, against the post-fix diff. Most validation passes are clean — the goal is to confirm fixes didn't introduce new concerns, not to fan out. Budget: ~30 seconds, no Agent calls.
 
 ### SMALL: one agent (model from router)
 Launch a SINGLE Agent with subagent_type `reviewer`, passing the model returned by Phase 2.7's router call. Cap the agent's tool budget by being explicit:

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -7,7 +7,7 @@ var cp = require('child_process');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -99,6 +99,79 @@ var EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE = /(?:^|[\\\/])(__tests__|__mocks__|tests?|
 // Anchored to end-of-path so e.g. `foo.md.js` does not match. Excludes lock files / configs
 // on purpose — those are inert for edit-reset (above) but not "documentation".
 var DOCS_ONLY_RE = /\.(md|markdown|txt|rst|adoc|html?|pdf|png|jpe?g|gif|svg|webp|ico|bmp)$/i;
+
+// Classifier-aware simplify gate skip. Returns a string reason if the gate
+// can be auto-passed, or null if /simplify must run. Uses simplify-classify.cjs
+// so the gate's "trivial" definition matches the skill's exactly.
+//
+// Two paths:
+//   1. snapshot path — /simplify ran earlier on this branch. Classify the diff
+//      between simplifySnapshotSha and current HEAD/working-tree. If TRIVIAL,
+//      the prior review still covers the branch — no re-run needed.
+//   2. baseline path — no snapshot (first time). Classify the entire branch
+//      diff vs merge-base. If TRIVIAL, the whole PR is below the threshold
+//      where /simplify provides value — auto-pass without ever invoking it.
+//
+// Fail-safe: any error (no classifier, no git, no merge-base) returns null,
+// which forces /simplify to run as today.
+function classifyForGateSkip(state) {
+  var classify;
+  try {
+    classify = require('./simplify-classify.cjs').classifyDiff;
+  } catch (e) { return null; }
+  if (typeof classify !== 'function') return null;
+
+  function tryClassify(diffText, label) {
+    try {
+      var dec = classify(diffText);
+      if (dec.tier === 'TRIVIAL') {
+        var loc = (dec.stats.added || 0) + (dec.stats.deleted || 0);
+        return label + ' is TRIVIAL (' + loc + ' LOC, ' + (dec.stats.fileCount || 0) + ' file(s))';
+      }
+    } catch (e) { /* fall through */ }
+    return null;
+  }
+
+  function gitDiff(args) {
+    try {
+      return cp.execFileSync('git', args, {
+        cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 5000, windowsHide: true,
+        stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 8 * 1024 * 1024
+      });
+    } catch (e) { return null; }
+  }
+
+  // Snapshot path: classify everything since /simplify last ran.
+  if (state.simplifySnapshotSha) {
+    var snapDiff = gitDiff(['diff', state.simplifySnapshotSha + '...HEAD']);
+    var workTreeA = gitDiff(['diff', 'HEAD']) || '';
+    if (snapDiff !== null) {
+      var combined = snapDiff + (workTreeA ? '\n' + workTreeA : '');
+      var hit = tryClassify(combined, 'delta since last /simplify');
+      if (hit) return hit;
+    }
+  }
+
+  // Baseline path: classify the whole branch vs merge-base.
+  var bases = ['origin/main', 'main', 'origin/master', 'master'];
+  for (var i = 0; i < bases.length; i++) {
+    var base;
+    try {
+      base = cp.execFileSync('git', ['merge-base', 'HEAD', bases[i]], {
+        cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 2000, windowsHide: true,
+        stdio: ['ignore', 'pipe', 'ignore']
+      }).trim();
+    } catch (e) { continue; }
+    if (!base) continue;
+    var branchDiff = gitDiff(['diff', base + '...HEAD']);
+    var workTreeB = gitDiff(['diff', 'HEAD']) || '';
+    if (branchDiff !== null) {
+      return tryClassify(branchDiff + (workTreeB ? '\n' + workTreeB : ''), 'branch diff');
+    }
+    break;
+  }
+  return null;
+}
 
 // Get the file list changed on the current branch vs the merge-base with origin/main
 // (falling back to local main). Returns an array of repo-relative paths, or null on
@@ -206,10 +279,19 @@ switch (command) {
   case 'record-skill-run': {
     if ((process.env.TOOL_INPUT_skill || '') === 'simplify') {
       var s = readState();
-      if (!s.simplifyRun) {
-        s.simplifyRun = true;
-        writeState(s);
-      }
+      var changed = false;
+      if (!s.simplifyRun) { s.simplifyRun = true; changed = true; }
+      // Snapshot HEAD so check-before-pr can classify delta-since-simplify and
+      // skip a redundant /simplify re-run when only trivial fixes followed.
+      // Non-fatal — gate falls through to current behaviour without the snapshot.
+      try {
+        var sha = cp.execFileSync('git', ['rev-parse', 'HEAD'], {
+          cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 2000, windowsHide: true,
+          stdio: ['ignore', 'pipe', 'ignore']
+        }).trim();
+        if (sha && s.simplifySnapshotSha !== sha) { s.simplifySnapshotSha = sha; changed = true; }
+      } catch (e) { /* no git or detached state — skip snapshot, gate still works */ }
+      if (changed) writeState(s);
     }
     break;
   }
@@ -249,6 +331,19 @@ switch (command) {
       break;
     }
     var s = readState();
+    // Classifier-aware skip: if delta-since-snapshot or whole-branch diff is
+    // TRIVIAL, satisfy the simplify gate silently. Reuses the same classifier
+    // the skill uses — same "trivial" definition, no drift. Same threshold that
+    // already maps to TRIVIAL=0 agents inside /simplify, so trusting it at the
+    // gate level is the same trust profile, just one decision earlier.
+    if (config.simplify_gate && !s.simplifyRun) {
+      var skipReason = classifyForGateSkip(s);
+      if (skipReason) {
+        s.simplifyRun = true;
+        writeState(s);
+        process.stdout.write('Simplify gate auto-passed: ' + skipReason + '\n');
+      }
+    }
     var missing = [];
     if (config.testing_gate && !s.testsRun) missing.push('tests have not run since the last code edit (run npm test, vitest, jest, pytest, or similar)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/simplify has not run since the last code edit');

--- a/bin/simplify-classify.cjs
+++ b/bin/simplify-classify.cjs
@@ -159,7 +159,10 @@ function decide(stats) {
     reasoning.push(
       `mostly relocation: ${stats.declAdded} decls added, ${stats.declRemoved} removed, net ${stats.netDecls >= 0 ? '+' : ''}${stats.netDecls}`,
     );
-    return { tier: 'SMALL', model: 'sonnet', agentCount: 1, reasoning, stats };
+    // Haiku is sufficient for mechanical moves: code already existed and worked,
+    // so review reduces to copy-paste-divergence / dead-after-move pattern checks
+    // — exactly haiku's strength. ~5x cheaper than sonnet on relocation-shape diffs.
+    return { tier: 'SMALL', model: 'haiku', agentCount: 1, reasoning, stats };
   }
 
   // Escalation triggers — any one trips NORMAL (3 agents).

--- a/tests/bin/gate-simplify-snapshot.test.ts
+++ b/tests/bin/gate-simplify-snapshot.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Gate snapshot + baseline-TRIVIAL skip — bin/gate.cjs
+ *
+ * Covers two cost-control paths added on top of issue #908:
+ *
+ *   1. Snapshot path — when /simplify ran earlier on this branch, gate.cjs
+ *      stamps `simplifySnapshotSha = HEAD`. On `gh pr create`, if the diff
+ *      between the snapshot and current HEAD classifies TRIVIAL, the gate
+ *      auto-passes the simplify check without forcing a /simplify re-run.
+ *
+ *   2. Baseline path — first time on a branch, no snapshot. If the entire
+ *      branch diff (merge-base...HEAD) classifies TRIVIAL, the gate auto-passes
+ *      without ever invoking /simplify (typo-only PRs, etc.).
+ *
+ * Each test uses a real on-disk git repo so gate.cjs's git-rev-parse and
+ * git-diff calls produce a real diff for the classifier to see.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, execSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+
+const BIN = resolve(__dirname, '../../bin');
+const GATE = resolve(BIN, 'gate.cjs');
+const CLASSIFIER = resolve(BIN, 'simplify-classify.cjs');
+
+let tmpDir: string;
+
+function makeTmpRepo(): string {
+  const dir = resolve(tmpdir(), `moflo-gate-snap-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(dir, '.claude'), { recursive: true });
+  // Co-locate the classifier next to gate.cjs's expected lookup path —
+  // gate.cjs does `require('./simplify-classify.cjs')`, which resolves
+  // relative to the gate.cjs file itself, not the project dir. So no copy
+  // needed: we always run gate.cjs from BIN so its sibling classifier loads.
+  // Initialise a real git repo so merge-base/diff calls have something to read.
+  execSync('git init -q -b main', { cwd: dir });
+  execSync('git config user.email "test@example.com"', { cwd: dir });
+  execSync('git config user.name "Test"', { cwd: dir });
+  // Seed an initial commit so HEAD exists and merge-base resolves.
+  writeFileSync(join(dir, 'src.ts'), 'export const X = 1;\n');
+  execSync('git add -A', { cwd: dir });
+  execSync('git commit -q -m "init"', { cwd: dir });
+  return dir;
+}
+
+function baseEnv(projectDir: string): Record<string, string> {
+  return {
+    ...process.env as Record<string, string>,
+    CLAUDE_PROJECT_DIR: projectDir,
+    TOOL_INPUT_command: '',
+    TOOL_INPUT_pattern: '',
+    TOOL_INPUT_path: '',
+    TOOL_INPUT_file_path: '',
+    TOOL_INPUT_skill: '',
+    CLAUDE_USER_PROMPT: '',
+    HOOK_SESSION_ID: '',
+  };
+}
+
+function runGate(command: string, env: Record<string, string>): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [GATE, command], {
+      env, encoding: 'utf-8', timeout: 30000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+      exitCode: err.status ?? 1,
+    };
+  }
+}
+
+function readState(projectDir: string): Record<string, unknown> {
+  const stateFile = join(projectDir, '.claude', 'workflow-state.json');
+  if (!existsSync(stateFile)) return {};
+  return JSON.parse(readFileSync(stateFile, 'utf-8'));
+}
+
+function writeState(projectDir: string, state: Record<string, unknown>): void {
+  const stateFile = join(projectDir, '.claude', 'workflow-state.json');
+  writeFileSync(stateFile, JSON.stringify(state, null, 2));
+}
+
+beforeEach(() => {
+  tmpDir = makeTmpRepo();
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe('gate snapshot — record-skill-run captures HEAD SHA', () => {
+  it('stamps simplifySnapshotSha when /simplify runs', () => {
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_skill = 'simplify';
+    runGate('record-skill-run', env);
+    const s = readState(tmpDir) as any;
+    expect(s.simplifyRun).toBe(true);
+    expect(typeof s.simplifySnapshotSha).toBe('string');
+    expect(s.simplifySnapshotSha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('updates the snapshot SHA on subsequent /simplify runs', () => {
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_skill = 'simplify';
+    runGate('record-skill-run', env);
+    const sha1 = (readState(tmpDir) as any).simplifySnapshotSha;
+    // Make a new commit so HEAD advances, then record again
+    writeFileSync(join(tmpDir, 'src.ts'), 'export const X = 2;\n');
+    execSync('git add -A && git commit -q -m "advance"', { cwd: tmpDir });
+    runGate('record-skill-run', env);
+    const sha2 = (readState(tmpDir) as any).simplifySnapshotSha;
+    expect(sha2).not.toBe(sha1);
+    expect(sha2).toMatch(/^[0-9a-f]{40}$/);
+  });
+});
+
+describe('gate snapshot path — TRIVIAL delta-since-simplify auto-passes', () => {
+  it('a tiny edit after /simplify does not block gh pr create', () => {
+    const env = baseEnv(tmpDir);
+    // /simplify ran on prior HEAD
+    env.TOOL_INPUT_skill = 'simplify';
+    runGate('record-skill-run', env);
+    // simplifyRun is now true. Simulate the post-edit reset that would
+    // normally fire (edit-reset-gates flips simplifyRun back to false).
+    const s = readState(tmpDir) as any;
+    s.simplifyRun = false;
+    s.testsRun = true;
+    s.learningsStored = true;
+    writeState(tmpDir, s);
+
+    // Make a 2-line trivial edit and commit it
+    writeFileSync(join(tmpDir, 'src.ts'), 'export const X = 1;\n// fix typo in comment\n');
+    execSync('git add -A && git commit -q -m "typo"', { cwd: tmpDir });
+
+    // gh pr create — should auto-pass via snapshot classifier
+    env.TOOL_INPUT_command = 'gh pr create --title "fix typo"';
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode, `expected pass, stderr=${r.stderr} stdout=${r.stdout}`).toBe(0);
+    expect(r.stdout).toMatch(/auto-passed/i);
+
+    // simplifyRun re-stamped silently
+    expect((readState(tmpDir) as any).simplifyRun).toBe(true);
+  });
+
+  it('a substantial edit after /simplify still blocks gh pr create', () => {
+    const env = baseEnv(tmpDir);
+    // Branch off so merge-base != HEAD — otherwise the baseline-classifier
+    // path sees an empty branch diff (HEAD == main) and would auto-pass for
+    // the wrong reason. Mirrors how PRs actually work.
+    execSync('git checkout -q -b feature', { cwd: tmpDir });
+
+    env.TOOL_INPUT_skill = 'simplify';
+    runGate('record-skill-run', env);
+    const s = readState(tmpDir) as any;
+    s.simplifyRun = false;
+    s.testsRun = true;
+    s.learningsStored = true;
+    writeState(tmpDir, s);
+
+    // Real new function (not trivial — should classify SMALL, gate must NOT
+    // auto-pass since gate only auto-passes on TRIVIAL).
+    const big = 'export function bigNewFn() {\n' + Array(40).fill('  console.log("x");').join('\n') + '\n}\n';
+    writeFileSync(join(tmpDir, 'src.ts'), 'export const X = 1;\n' + big);
+    execSync('git add -A && git commit -q -m "new fn"', { cwd: tmpDir });
+
+    env.TOOL_INPUT_command = 'gh pr create --title "feat"';
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode, 'non-trivial delta should still block').toBe(2);
+    expect(r.stderr).toContain('/simplify has not run');
+  });
+});
+
+describe('gate baseline path — TRIVIAL whole-branch diff auto-passes', () => {
+  // The whole-branch baseline path runs when there is NO snapshot (first time
+  // on a branch, no /simplify run yet). If the entire branch diff vs main
+  // classifies TRIVIAL, /simplify would provide ~zero value, so skip it.
+  it('a typo-only branch (no /simplify run) does not block gh pr create', () => {
+    const env = baseEnv(tmpDir);
+    // Branch off main with one tiny edit
+    execSync('git checkout -q -b feature', { cwd: tmpDir });
+    writeFileSync(join(tmpDir, 'src.ts'), 'export const X = 1; // typo: fixed\n');
+    execSync('git add -A && git commit -q -m "typo"', { cwd: tmpDir });
+
+    // No /simplify ever ran — testsRun true, learningsStored true, simplifyRun false
+    writeState(tmpDir, { testsRun: true, simplifyRun: false, learningsStored: true });
+
+    env.TOOL_INPUT_command = 'gh pr create --title "typo"';
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode, `expected pass, stderr=${r.stderr} stdout=${r.stdout}`).toBe(0);
+    expect(r.stdout).toMatch(/auto-passed.*branch diff is TRIVIAL/i);
+  });
+
+  it('a non-trivial branch (no /simplify run) still blocks gh pr create', () => {
+    const env = baseEnv(tmpDir);
+    execSync('git checkout -q -b feature', { cwd: tmpDir });
+    // Real new code, not a typo
+    const big = 'export function bigNewFn() {\n' + Array(40).fill('  console.log("x");').join('\n') + '\n}\n';
+    writeFileSync(join(tmpDir, 'src.ts'), 'export const X = 1;\n' + big);
+    execSync('git add -A && git commit -q -m "feat"', { cwd: tmpDir });
+
+    writeState(tmpDir, { testsRun: true, simplifyRun: false, learningsStored: true });
+    env.TOOL_INPUT_command = 'gh pr create --title "feat"';
+    const r = runGate('check-before-pr', env);
+    expect(r.exitCode, 'non-trivial branch should block').toBe(2);
+    expect(r.stderr).toContain('/simplify has not run');
+  });
+});
+
+describe('classifier sanity for the gate path', () => {
+  // Belt-and-suspenders: gate.cjs requires('./simplify-classify.cjs') — make
+  // sure that resolution actually returns a usable classifyDiff function.
+  it('the bundled classifier is loadable and TRIVIAL for tiny diffs', () => {
+    const classifier = require(CLASSIFIER);
+    expect(typeof classifier.classifyDiff).toBe('function');
+    const diff = `diff --git a/src.ts b/src.ts
+--- a/src.ts
++++ b/src.ts
+@@ -1 +1 @@
+-export const X = 1;
++export const X = 2;
+`;
+    const dec = classifier.classifyDiff(diff);
+    expect(dec.tier).toBe('TRIVIAL');
+  });
+});

--- a/tests/bin/simplify-classify.test.ts
+++ b/tests/bin/simplify-classify.test.ts
@@ -183,11 +183,13 @@ index abc..def 100644
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('simplify-classify: pure logic via require()', () => {
-  it('mechanical decomposition (#906-shape) → SMALL, 1 agent, sonnet', () => {
+  it('mechanical decomposition (#906-shape) → SMALL, 1 agent, haiku', () => {
+    // Relocations get haiku: pattern-matching review beats deep reasoning,
+    // ~5x cheaper than sonnet, negligible miss rate.
     const decision = classifyDiff(mechanicalDecompositionDiff());
     expect(decision.tier).toBe('SMALL');
     expect(decision.agentCount).toBe(1);
-    expect(decision.model).toBe('sonnet');
+    expect(decision.model).toBe('haiku');
     expect(decision.reasoning.join(' ')).toMatch(/relocation/i);
     expect(decision.stats.fileCount).toBeGreaterThanOrEqual(5);
   });
@@ -228,6 +230,8 @@ describe('simplify-classify: pure logic via require()', () => {
   });
 
   it('never returns opus, regardless of input', () => {
+    // Code review is breadth-bound, not depth-bound — opus is never the right
+    // model. Sonnet (default) and haiku (mechanical relocations) are valid.
     for (const fixture of [
       mechanicalDecompositionDiff(),
       trivialTypoDiff(),
@@ -237,7 +241,7 @@ describe('simplify-classify: pure logic via require()', () => {
     ]) {
       const decision = classifyDiff(fixture);
       expect(decision.model).not.toBe('opus');
-      expect(decision.model).toBe('sonnet');
+      expect(['sonnet', 'haiku']).toContain(decision.model);
     }
   });
 });
@@ -304,7 +308,7 @@ describe('simplify-classify: end-to-end CLI invocation', () => {
     expect(decision).toMatchObject({
       tier: 'SMALL',
       agentCount: 1,
-      model: 'sonnet',
+      model: 'haiku',
     });
     expect(Array.isArray(decision.reasoning)).toBe(true);
     expect(decision.stats).toBeDefined();


### PR DESCRIPTION
## Summary

Three layered cost wins on the same axis (gate fires too often vs cost-per-fire). Issue #908 already shrunk per-fire cost via the classifier; this PR shrinks the *number of fires* by reusing that same classifier at the gate level, and shrinks per-fire further on relocation diffs.

- **Snapshot-based gate skip** — `record-skill-run` stamps `simplifySnapshotSha = HEAD`; `check-before-pr` classifies `snapshot…HEAD` and auto-passes when TRIVIAL. Kills the "fix one typo after `/simplify`, must re-run `/simplify`" treadmill.
- **Branch-baseline TRIVIAL exemption** — first-time check classifies `merge-base…HEAD`; if TRIVIAL the entire PR skips `/simplify` invocation. Typo-only / log-message PRs no longer pay the skill walkthrough.
- **Haiku for relocation tier** — `simplify-classify.cjs` now returns `model: 'haiku'` for `isMostlyRelocation`. Mechanical moves are pattern-matching territory; ~5x cheaper than sonnet, negligible miss rate.

Both gate paths reuse `bin/simplify-classify.cjs` so the gate's "trivial" definition matches the skill's exactly — same Node module, no drift. Any classifier/git error returns null and the gate falls back to current blocking behaviour (fail-safe).

`SKILL.md` / `commands/simplify.md` updated: TRIVIAL exits-fast (no three-category self-review when the classifier already concluded the diff is below the review-value threshold), and `haiku` is documented as a valid classifier output alongside `sonnet`.

## Consumer impact

- **Surface touched:** \`bin/{gate,simplify-classify}.cjs\` (synced to \`.claude/helpers/\` in consumer projects), \`.claude/skills/simplify/SKILL.md\`, \`.claude/commands/simplify.md\`. All ship via \`npm install moflo\`.
- **Failure mode for current consumers:** existing branches with no \`simplifySnapshotSha\` field fall through to current behaviour — no migration. New \`/simplify\` runs start populating it. No state-format break.
- **Round-trip:** runtime change; takes effect on consumers after publish + reinstall.

## Test plan
- [x] \`tests/bin/gate-simplify-snapshot.test.ts\` (new, 7 tests) — snapshot capture, snapshot-delta TRIVIAL auto-pass, baseline-TRIVIAL auto-pass, continued blocking on non-trivial deltas
- [x] \`tests/bin/simplify-classify.test.ts\` — relocation tier returns haiku; no-opus invariant preserved
- [x] \`npx vitest run tests/bin/\` — 247 / 247 passing
- [x] \`npx tsc --noEmit -p tsconfig.json\` — clean

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)