### PR TITLE
fix(launcher): skip drift heal in moflo's own repo (#928)

### DIFF
--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -63,6 +63,12 @@ const projectRoot = findProjectRoot();
 // NOT node_modules/moflo/package.json. Defaults to false on any read/parse
 // error so a corrupt package.json never silently disables drift heal in a
 // real consumer.
+//
+// Workspace caveat: findProjectRoot() walks up to the nearest package.json,
+// so in a workspace child (packages/foo/) the read sees the child package
+// (name !== "moflo") and the guard stays false. moflo isn't a workspace
+// today; if it ever becomes one, run sessions from the repo root or extend
+// this check to walk further up.
 let isMofloDogfood = false;
 try {
   const projectPkgPath = resolve(projectRoot, 'package.json');
@@ -70,8 +76,11 @@ try {
     const projectPkg = JSON.parse(readFileSync(projectPkgPath, 'utf-8'));
     isMofloDogfood = projectPkg?.name === 'moflo';
   }
-} catch {
-  // Defaults to false — safer than accidentally disabling drift heal.
+} catch (err) {
+  // Defaults to false — safer than accidentally disabling drift heal in a
+  // real consumer. Surface the failure so a corrupt project package.json
+  // doesn't silently change launcher behavior (per feedback_no_silent_failures).
+  process.stderr.write(`[moflo] dogfood-guard package.json read failed: ${err && err.message ? err.message : String(err)}\n`);
 }
 
 // Visible mutation reporter (#716). Claude Code's SessionStart hook captures

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -53,6 +53,27 @@ function findProjectRoot() {
 
 const projectRoot = findProjectRoot();
 
+// Dogfood guard (#928). When this launcher runs inside the moflo repo itself,
+// .claude/scripts/, .claude/helpers/, and .claude/guidance/ are committed git
+// files — they ARE moflo's source of truth, not destinations to be re-synced
+// from node_modules. Drift heal would silently revert any post-publish edit
+// to one of those files (e.g. story #927's gate.cjs got reverted overnight
+// because manifest.size still pointed at the previously-published version).
+// Detection is `package.json#name === "moflo"` — the project's own package.json,
+// NOT node_modules/moflo/package.json. Defaults to false on any read/parse
+// error so a corrupt package.json never silently disables drift heal in a
+// real consumer.
+let isMofloDogfood = false;
+try {
+  const projectPkgPath = resolve(projectRoot, 'package.json');
+  if (existsSync(projectPkgPath)) {
+    const projectPkg = JSON.parse(readFileSync(projectPkgPath, 'utf-8'));
+    isMofloDogfood = projectPkg?.name === 'moflo';
+  }
+} catch {
+  // Defaults to false — safer than accidentally disabling drift heal.
+}
+
 // Visible mutation reporter (#716). Claude Code's SessionStart hook captures
 // stdout as `additionalContext`, so each line here surfaces to Claude — and
 // through it to the user — explaining what the launcher just changed. Keep
@@ -360,6 +381,8 @@ try {
         }
       }
     }
+    // Dogfood (#928): never drift-heal moflo's own committed copies.
+    if (isMofloDogfood) manifestDrifted = false;
 
     if (installedVersion !== cachedVersion || manifestDrifted) {
       if (installedVersion !== cachedVersion) {
@@ -443,6 +466,20 @@ try {
       }
 
       const binDir = resolve(projectRoot, 'node_modules/moflo/bin');
+
+      // Dogfood (#928): in moflo's own repo, the destinations under
+      // .claude/scripts/, .claude/helpers/, .claude/guidance/ are committed
+      // git files — copying node_modules/moflo content over them clobbers
+      // in-flight work (the same bug that silently reverted #927 between
+      // commit and publish). Skip the sync, cleanup, and manifest write
+      // entirely; queue the version-stamp write so we don't re-enter this
+      // branch on every subsequent session. Daemon recycle still happens
+      // (the stopDaemon call earlier handled this) and 3a-pre will spawn a
+      // fresh daemon under the new code.
+      if (isMofloDogfood) {
+        pendingVersionStampWrite = { path: versionStampPath, version: installedVersion };
+        emitMutation('skipped file-sync', 'moflo dogfood — committed dogfood copies preserved');
+      } else {
 
       // ── Manifest-based auto-update ──────────────────────────────────────
       //
@@ -709,6 +746,7 @@ try {
         // queued for 3g.
         emitWarning(`manifest write failed (${errMessage(err)})`);
       }
+      } // end !isMofloDogfood file-sync branch (#928)
     }
   }
 } catch (err) {

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -63,6 +63,12 @@ const projectRoot = findProjectRoot();
 // NOT node_modules/moflo/package.json. Defaults to false on any read/parse
 // error so a corrupt package.json never silently disables drift heal in a
 // real consumer.
+//
+// Workspace caveat: findProjectRoot() walks up to the nearest package.json,
+// so in a workspace child (packages/foo/) the read sees the child package
+// (name !== "moflo") and the guard stays false. moflo isn't a workspace
+// today; if it ever becomes one, run sessions from the repo root or extend
+// this check to walk further up.
 let isMofloDogfood = false;
 try {
   const projectPkgPath = resolve(projectRoot, 'package.json');
@@ -70,8 +76,11 @@ try {
     const projectPkg = JSON.parse(readFileSync(projectPkgPath, 'utf-8'));
     isMofloDogfood = projectPkg?.name === 'moflo';
   }
-} catch {
-  // Defaults to false — safer than accidentally disabling drift heal.
+} catch (err) {
+  // Defaults to false — safer than accidentally disabling drift heal in a
+  // real consumer. Surface the failure so a corrupt project package.json
+  // doesn't silently change launcher behavior (per feedback_no_silent_failures).
+  process.stderr.write(`[moflo] dogfood-guard package.json read failed: ${err && err.message ? err.message : String(err)}\n`);
 }
 
 // Visible mutation reporter (#716). Claude Code's SessionStart hook captures

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -53,6 +53,27 @@ function findProjectRoot() {
 
 const projectRoot = findProjectRoot();
 
+// Dogfood guard (#928). When this launcher runs inside the moflo repo itself,
+// .claude/scripts/, .claude/helpers/, and .claude/guidance/ are committed git
+// files — they ARE moflo's source of truth, not destinations to be re-synced
+// from node_modules. Drift heal would silently revert any post-publish edit
+// to one of those files (e.g. story #927's gate.cjs got reverted overnight
+// because manifest.size still pointed at the previously-published version).
+// Detection is `package.json#name === "moflo"` — the project's own package.json,
+// NOT node_modules/moflo/package.json. Defaults to false on any read/parse
+// error so a corrupt package.json never silently disables drift heal in a
+// real consumer.
+let isMofloDogfood = false;
+try {
+  const projectPkgPath = resolve(projectRoot, 'package.json');
+  if (existsSync(projectPkgPath)) {
+    const projectPkg = JSON.parse(readFileSync(projectPkgPath, 'utf-8'));
+    isMofloDogfood = projectPkg?.name === 'moflo';
+  }
+} catch {
+  // Defaults to false — safer than accidentally disabling drift heal.
+}
+
 // Visible mutation reporter (#716). Claude Code's SessionStart hook captures
 // stdout as `additionalContext`, so each line here surfaces to Claude — and
 // through it to the user — explaining what the launcher just changed. Keep
@@ -360,6 +381,8 @@ try {
         }
       }
     }
+    // Dogfood (#928): never drift-heal moflo's own committed copies.
+    if (isMofloDogfood) manifestDrifted = false;
 
     if (installedVersion !== cachedVersion || manifestDrifted) {
       if (installedVersion !== cachedVersion) {
@@ -443,6 +466,20 @@ try {
       }
 
       const binDir = resolve(projectRoot, 'node_modules/moflo/bin');
+
+      // Dogfood (#928): in moflo's own repo, the destinations under
+      // .claude/scripts/, .claude/helpers/, .claude/guidance/ are committed
+      // git files — copying node_modules/moflo content over them clobbers
+      // in-flight work (the same bug that silently reverted #927 between
+      // commit and publish). Skip the sync, cleanup, and manifest write
+      // entirely; queue the version-stamp write so we don't re-enter this
+      // branch on every subsequent session. Daemon recycle still happens
+      // (the stopDaemon call earlier handled this) and 3a-pre will spawn a
+      // fresh daemon under the new code.
+      if (isMofloDogfood) {
+        pendingVersionStampWrite = { path: versionStampPath, version: installedVersion };
+        emitMutation('skipped file-sync', 'moflo dogfood — committed dogfood copies preserved');
+      } else {
 
       // ── Manifest-based auto-update ──────────────────────────────────────
       //
@@ -709,6 +746,7 @@ try {
         // queued for 3g.
         emitWarning(`manifest write failed (${errMessage(err)})`);
       }
+      } // end !isMofloDogfood file-sync branch (#928)
     }
   }
 } catch (err) {

--- a/tests/bin/launcher-928-dogfood-skip.test.ts
+++ b/tests/bin/launcher-928-dogfood-skip.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression tests for #928 — drift heal silently reverted committed dogfood
+ * edits in moflo's own repo.
+ *
+ * Symptom in the wild: story #927 grew `.claude/helpers/gate.cjs` from 15,147
+ * to 19,379 bytes. The next session-start in moflo's own repo (before publish)
+ * saw size mismatch vs the manifest that still pointed at the previously-
+ * published 4.9.18 version, classified it as drift, and `copyFileSync`'d
+ * `node_modules/moflo/bin/gate.cjs` (= old) over `.claude/helpers/gate.cjs`
+ * (= the just-committed #927 content). Working tree silently reverted; only
+ * signal was the "📦 install repaired" badge.
+ *
+ * Fix: when `package.json#name === "moflo"` (i.e. we're running inside the
+ * moflo repo itself), `.claude/scripts/`, `.claude/helpers/`, and
+ * `.claude/guidance/` are committed git files — they ARE source of truth,
+ * not destinations to overwrite. The dogfood guard skips:
+ *   - drift detection (size mismatch never triggers "repair")
+ *   - file-sync stages (real version-change still recycles daemon + cherry-
+ *     picks learnings + queues version stamp, but no copyFileSync runs)
+ *
+ * Coverage:
+ *   - Source-invariant: the guard exists, gates the right paths.
+ *   - End-to-end (consumer): drift IS healed — regression guard for normal
+ *     consumers who depend on the repair flow.
+ *   - End-to-end (moflo): drift is NOT healed — committed edits survive.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, statSync } from 'fs';
+import { resolve, join } from 'path';
+
+const LAUNCHER = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+
+function makeTempRoot(label: string): string {
+  const root = resolve(
+    __dirname,
+    '../../.testoutput/.test-launcher-928-' + label + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows occasionally holds handles — non-fatal */
+  }
+}
+
+function runLauncher(cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync('node', [LAUNCHER], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status };
+}
+
+/**
+ * Stage the exact precondition that triggered the #927 clobber: a tracked
+ * destination file exists at one size, the install manifest claims a
+ * different size, `node_modules/moflo/bin/<file>` has the old content.
+ *
+ * Caller passes `pkgName` to choose dogfood vs consumer behavior.
+ */
+function stageDriftScenario(root: string, pkgName: string) {
+  // Project-level package.json — the dogfood guard reads this one.
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: pkgName, version: '0.0.0' }));
+
+  // Pretend node_modules/moflo is installed at 4.9.18 with a small gate.cjs.
+  const nmDir = join(root, 'node_modules/moflo');
+  mkdirSync(join(nmDir, 'bin'), { recursive: true });
+  writeFileSync(join(nmDir, 'package.json'), JSON.stringify({ name: 'moflo', version: '4.9.18' }));
+  const oldGateContent = '// old gate cjs (4.9.18) — small\nmodule.exports = {};\n';
+  writeFileSync(join(nmDir, 'bin/gate.cjs'), oldGateContent);
+  // Stub the other bin entries the launcher tries to copy — empty files, so
+  // syncFile() finds them and copies (size==0). They're not the focus here.
+  for (const f of [
+    'hooks.mjs', 'session-start-launcher.mjs', 'index-guidance.mjs',
+    'build-embeddings.mjs', 'generate-code-map.mjs', 'semantic-search.mjs',
+    'index-tests.mjs', 'index-patterns.mjs', 'index-all.mjs',
+    'setup-project.mjs', 'run-migrations.mjs',
+    'gate-hook.mjs', 'prompt-hook.mjs', 'hook-handler.cjs', 'simplify-classify.cjs',
+  ]) {
+    writeFileSync(join(nmDir, 'bin', f), '');
+  }
+
+  // Working-tree dogfood-edited gate.cjs — bigger than the 4.9.18 version,
+  // simulating a just-committed edit.
+  mkdirSync(join(root, '.claude/helpers'), { recursive: true });
+  const newGateContent = '// new gate cjs (post-#927) — bigger because the file grew\nmodule.exports = { snapshotSkip: true, branchTrivial: true };\n';
+  writeFileSync(join(root, '.claude/helpers/gate.cjs'), newGateContent);
+
+  // Manifest pretends the destination matched the old (4.9.18) size at last
+  // sync. Drift detection sees `statSync(dest).size != manifest.size` and
+  // triggers the repair path in non-dogfood mode.
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  writeFileSync(
+    join(root, '.moflo', 'installed-files.json'),
+    JSON.stringify([{ path: '.claude/helpers/gate.cjs', size: oldGateContent.length }]),
+  );
+  // Version stamp matches the installed version → versions are equal, ONLY
+  // manifest drift can trigger the repair branch.
+  writeFileSync(join(root, '.moflo', 'moflo-version'), '4.9.18');
+
+  return { oldGateContent, newGateContent };
+}
+
+describe('session-start-launcher — dogfood drift skip (#928)', () => {
+  describe('source-invariant', () => {
+    const src = readFileSync(LAUNCHER, 'utf-8');
+
+    it('detects moflo dogfood mode via package.json#name', () => {
+      // The guard is named isMofloDogfood and reads the project-level
+      // package.json (NOT node_modules/moflo/package.json).
+      expect(src).toMatch(/isMofloDogfood/);
+      expect(src).toMatch(/projectPkg\?\.\s*name\s*===\s*['"]moflo['"]/);
+    });
+
+    it('forces manifestDrifted to false in dogfood mode', () => {
+      // After the size-mismatch loop, dogfood override sets manifestDrifted
+      // back to false unconditionally — drift heal never fires in our repo.
+      expect(src).toMatch(/if\s*\(\s*isMofloDogfood\s*\)\s*manifestDrifted\s*=\s*false/);
+    });
+
+    it('skips file-sync stages in dogfood mode but still queues version stamp', () => {
+      // The if/else fork wraps the entire manifest-based sync block. Dogfood
+      // path queues pendingVersionStampWrite (so we don't re-enter forever)
+      // and emits a visible mutation; consumer path runs the full sync.
+      expect(src).toMatch(/if\s*\(\s*isMofloDogfood\s*\)\s*\{[\s\S]*?pendingVersionStampWrite\s*=/);
+      expect(src).toMatch(/skipped file-sync/);
+      expect(src).toMatch(/end !isMofloDogfood file-sync branch/);
+    });
+  });
+
+  describe('end-to-end', () => {
+    let root: string;
+    afterEach(() => { if (root) cleanTempRoot(root); });
+
+    it('CONSUMER mode: drift is healed (regression guard for non-moflo consumers)', () => {
+      root = makeTempRoot('consumer');
+      const { oldGateContent, newGateContent } = stageDriftScenario(root, 'some-consumer-app');
+
+      const result = runLauncher(root);
+
+      // Pre-condition sanity: working-tree gate.cjs started at NEW content.
+      // Post-condition: launcher detected drift and reverted it to OLD content.
+      const after = readFileSync(join(root, '.claude/helpers/gate.cjs'), 'utf-8');
+      expect(after).toBe(oldGateContent);
+      expect(after).not.toBe(newGateContent);
+      expect(result.stdout).toMatch(/repaired stale install|manifest drift detected/);
+    });
+
+    it('DOGFOOD mode: drift is preserved (committed edits survive)', () => {
+      root = makeTempRoot('dogfood');
+      const { newGateContent } = stageDriftScenario(root, 'moflo');
+
+      const result = runLauncher(root);
+
+      // Working-tree gate.cjs untouched — the whole point of the fix.
+      const after = readFileSync(join(root, '.claude/helpers/gate.cjs'), 'utf-8');
+      expect(after).toBe(newGateContent);
+      // No "install repaired" / "manifest drift" mutation emitted.
+      expect(result.stdout).not.toMatch(/repaired stale install/);
+      expect(result.stdout).not.toMatch(/manifest drift detected/);
+    });
+
+    it('DOGFOOD mode: real version-change still skips file-sync', () => {
+      // Stage a version mismatch (cached=4.9.17, installed=4.9.18) — without
+      // the dogfood guard the launcher would copy node_modules content over
+      // .claude/helpers. With the guard, the upgrade branch enters but the
+      // file-sync block is skipped and the dogfood file is preserved.
+      root = makeTempRoot('dogfood-vchange');
+      const { newGateContent } = stageDriftScenario(root, 'moflo');
+      writeFileSync(join(root, '.moflo', 'moflo-version'), '4.9.17'); // force version-change branch
+
+      const result = runLauncher(root);
+
+      const after = readFileSync(join(root, '.claude/helpers/gate.cjs'), 'utf-8');
+      expect(after).toBe(newGateContent);
+      // The dogfood-skip mutation surfaces so the user sees what happened.
+      expect(result.stdout).toMatch(/skipped file-sync/);
+      expect(result.stdout).toMatch(/moflo dogfood/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Story #927 was silently reverted overnight: session-start saw `.claude/helpers/gate.cjs` size differ from the manifest (still pointing at the previously-published 4.9.18) and copied the old `node_modules/moflo/bin/gate.cjs` over the just-committed #927 content. Only signal was the `📦 install repaired` badge.
- Fix detects moflo dogfood mode via `package.json#name === "moflo"` (the project's own, **not** `node_modules/moflo/package.json`) and skips drift detection + file-sync. Real version-change still recycles the daemon, queues the version stamp, and cherry-picks learnings — only `copyFileSync` is skipped.
- Zero consumer impact (`name !== "moflo"` everywhere except this repo). Defaults to `false` on any read/parse error; the catch writes to `process.stderr` (per `feedback_no_silent_failures`) so a corrupt project package.json never silently disables drift heal in a real consumer.

## Workspace caveat
`findProjectRoot()` walks up to the nearest `package.json`, so a workspace child (`packages/foo/`) would resolve to the child package and the guard stays `false`. moflo isn't a workspace today; called out in the inline comment for whoever crosses that bridge.

## Test plan
- [x] `tests/bin/launcher-928-dogfood-skip.test.ts` (new, 6 tests):
  - source-invariant (3): `isMofloDogfood` exists, gates `manifestDrifted`, fork wraps file-sync
  - e2e CONSUMER (`name: 'some-consumer-app'`) → drift IS healed (regression guard for non-moflo consumers)
  - e2e DOGFOOD (`name: 'moflo'`, equal versions) → drift NOT healed
  - e2e DOGFOOD + version-change → file-sync skipped, dogfood file preserved, `skipped file-sync` mutation emitted
- [x] All 25 bin/ test files (253 tests) pass
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `/simplify` NORMAL tier (security-sensitive launcher) — three reviewer agents (Reuse / Quality / Efficiency); silent-catch finding addressed in second commit, validated as clean

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)