### PR TITLE
fix(929): anchor PostToolUse memory_ matcher; auto-heal stale consumers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,7 +109,7 @@
         ]
       },
       {
-        "matcher": "mcp__moflo__memory_",
+        "matcher": "^mcp__moflo__memory_(search|retrieve|list|stats|store)$",
         "hooks": [
           {
             "type": "command",

--- a/src/cli/__tests__/services/hook-wiring.test.ts
+++ b/src/cli/__tests__/services/hook-wiring.test.ts
@@ -240,7 +240,7 @@ describe('rewriteIncorrectHookWiring (#879)', () => {
       hooks: {
         PostToolUse: [
           {
-            matcher: 'mcp__moflo__memory_',
+            matcher: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$',
             hooks: [
               {
                 type: 'command',
@@ -254,6 +254,85 @@ describe('rewriteIncorrectHookWiring (#879)', () => {
     };
     const { rewrites } = rewriteIncorrectHookWiring(settings);
     expect(rewrites).toEqual([]);
+  });
+
+  // ── Issue #929 — matcher rewrite for the per-actor memory gate ──────────────
+  // Claude Code anchors hook matchers (`^…$` semantics), so the bare
+  // `mcp__moflo__memory_` matcher introduced by #882's #879 fix never fires
+  // for any real MCP tool name. The launcher must rewrite this in-place so
+  // existing consumers self-heal on session start without `flo doctor --fix`.
+
+  it('rewrites broken `mcp__moflo__memory_` matcher to anchored alternation (#929)', () => {
+    const settings: Record<string, unknown> = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'mcp__moflo__memory_',
+            hooks: [
+              {
+                type: 'command',
+                command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-memory-searched',
+                timeout: 3000,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const { rewrites, settings: patched } = rewriteIncorrectHookWiring(settings);
+
+    expect(rewrites.some(r => r.name.includes('#929'))).toBe(true);
+    const block = ((patched.hooks as Record<string, unknown[]>).PostToolUse as Array<{ matcher: string }>)[0];
+    expect(block.matcher).toBe('^mcp__moflo__memory_(search|retrieve|list|stats|store)$');
+  });
+
+  it('matcher rewrite is idempotent — no second-pass changes', () => {
+    const settings: Record<string, unknown> = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'mcp__moflo__memory_',
+            hooks: [
+              {
+                type: 'command',
+                command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-memory-searched',
+                timeout: 3000,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    rewriteIncorrectHookWiring(settings);
+    const before = JSON.stringify(settings);
+    const { rewrites } = rewriteIncorrectHookWiring(settings);
+    expect(rewrites).toEqual([]);
+    expect(JSON.stringify(settings)).toBe(before);
+  });
+
+  it('matcher rewrite skips blocks whose hook command does not match the gating substring', () => {
+    // A user-customised block that happens to share the broken matcher but
+    // wires a different action — must NOT be rewritten.
+    const settings: Record<string, unknown> = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'mcp__moflo__memory_',
+            hooks: [
+              {
+                type: 'command',
+                command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/my-custom-logger.mjs"',
+                timeout: 1000,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const { rewrites, settings: patched } = rewriteIncorrectHookWiring(settings);
+    expect(rewrites.some(r => r.name.includes('#929'))).toBe(false);
+    const block = ((patched.hooks as Record<string, unknown[]>).PostToolUse as Array<{ matcher: string }>)[0];
+    expect(block.matcher).toBe('mcp__moflo__memory_');
   });
 
   it('handles malformed hooks gracefully (no throw on missing keys)', () => {

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -326,12 +326,16 @@ function generateHooks(root: string, force?: boolean, answers?: MofloInitAnswers
         "hooks": [{ "type": "command", "command": gateHook('record-skill-run'), "timeout": 2000 }]
       },
       {
+        // Anchored alternation — Claude Code anchors hook matchers (`^…$` semantics),
+        // so a bare `mcp__moflo__memory_` never matches any real MCP tool name and the
+        // hook silently no-ops (#929 regression). The explicit suffix list keeps the
+        // matcher narrow while catching every memory_* tool we ship.
         // Use gateHook (not gate) so the wrapper forwards Claude Code's session_id as
         // HOOK_SESSION_ID — record-memory-searched needs this to mark the per-actor map
         // (memorySearchedBy[sid]) that check-before-read consults under #838's per-actor gating.
         // Without it, the legacy boolean is set but the per-actor map stays empty, and the gate
         // blocks every Read forever within the turn (issue #879).
-        "matcher": "mcp__moflo__memory_",
+        "matcher": "^mcp__moflo__memory_(search|retrieve|list|stats|store)$",
         "hooks": [{ "type": "command", "command": gateHook('record-memory-searched'), "timeout": 3000 }]
       },
       {

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -293,13 +293,16 @@ function generateHooksConfig(config: HooksConfig): object {
         hooks: [{ type: 'command', command: gateHookCmd('record-skill-run'), timeout: 2000 }],
       },
       {
-        // Simplified matcher — anchored regex with parens doesn't match MCP tool names reliably.
-        // Use gateHookCmd (not gateCmd) so the wrapper forwards Claude Code's session_id as
-        // HOOK_SESSION_ID — record-memory-searched needs this to mark the per-actor map
-        // (memorySearchedBy[sid]) that check-before-read consults under #838's per-actor gating.
-        // Without it, the legacy boolean is set but the per-actor map stays empty, and the gate
-        // blocks every Read forever within the turn (issue #879).
-        matcher: 'mcp__moflo__memory_',
+        // Anchored alternation — Claude Code anchors hook matchers (`^…$` semantics),
+        // so a bare `mcp__moflo__memory_` never matches any real MCP tool name and the
+        // hook silently no-ops (#929 regression). Listing the explicit suffixes keeps
+        // the matcher narrow while still catching every memory_* tool we ship.
+        // Use gateHookCmd (not gateCmd) so the wrapper forwards Claude Code's session_id
+        // as HOOK_SESSION_ID — record-memory-searched needs this to mark the per-actor
+        // map (memorySearchedBy[sid]) that check-before-read consults under #838's
+        // per-actor gating. Without it, the legacy boolean is set but the per-actor map
+        // stays empty, and the gate blocks every Read forever within the turn (#879).
+        matcher: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$',
         hooks: [{ type: 'command', command: gateHookCmd('record-memory-searched'), timeout: 3000 }],
       },
       {

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -121,7 +121,7 @@ export function getReferenceHookBlock(): HooksTree {
         hooks: [gateHook('check-bash-memory', 2000), gateHook('record-test-run', 2000)],
       },
       { matcher: '^Skill$',                       hooks: [gateHook('record-skill-run', 2000)] },
-      { matcher: 'mcp__moflo__memory_',           hooks: [gateHook('record-memory-searched', 3000)] },
+      { matcher: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$', hooks: [gateHook('record-memory-searched', 3000)] },
       { matcher: '^TaskUpdate$',                  hooks: [gateCjs('check-task-transition', 2000)] },
       { matcher: '^mcp__moflo__memory_store$',    hooks: [gateCjs('record-learnings-stored', 2000)] },
     ],

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -55,7 +55,11 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   // record-memory-searched MUST go through gate-hook.mjs (not gate.cjs directly)
   // — the wrapper forwards Claude Code's session_id as HOOK_SESSION_ID, which
   // markMemorySearched needs to stamp the per-actor map (#879).
-  'record-memory-searched':   { event: 'PostToolUse',      matcher: 'mcp__moflo__memory_',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-memory-searched', timeout: 3000 } },
+  // Matcher MUST be a fully-anchored regex: Claude Code anchors hook matchers
+  // (`^...$` semantics), so a bare `mcp__moflo__memory_` never fires for any
+  // tool name (#929 regression — the hook silently no-ops, leaving every
+  // memory_search uncounted by the gate).
+  'record-memory-searched':   { event: 'PostToolUse',      matcher: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$', hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-memory-searched', timeout: 3000 } },
   'check-task-transition':    { event: 'PostToolUse',      matcher: '^TaskUpdate$',               hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" check-task-transition', timeout: 2000 } },
   'record-learnings-stored':  { event: 'PostToolUse',      matcher: '^mcp__moflo__memory_store$', hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-learnings-stored', timeout: 2000 } },
   'check-bash-memory':        { event: 'PostToolUse',      matcher: '^Bash$',                     hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-bash-memory', timeout: 2000 } },
@@ -157,6 +161,42 @@ export const HOOK_REWRITE_RULES: ReadonlyArray<HookRewriteRule> = [
   },
 ];
 
+// ────────────────────────────────────────────────────────────────────────────
+// Matcher rewrite rules — fix existing-but-wrong block-level `matcher` strings.
+//
+// HOOK_REWRITE_RULES rewrites hook command substrings; this rewrites the
+// outer block matcher itself. Each rule fires only when a block has the exact
+// `from` matcher AND contains a hook command matching `cmdContains` — that
+// guard prevents an accidental rewrite of an unrelated user-customised block
+// that happens to share the matcher string.
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface MatcherRewriteRule {
+  /** Diagnostic name surfaced when the rewrite fires */
+  name: string;
+  /** Exact matcher string to find on `block.matcher` */
+  from: string;
+  /** Replacement matcher string */
+  to: string;
+  /** Hook command must contain this substring for the rewrite to fire — guards
+   *  against rewriting an unrelated user-customised block. */
+  cmdContains: string;
+}
+
+export const MATCHER_REWRITE_RULES: ReadonlyArray<MatcherRewriteRule> = [
+  // Issue #929 — Claude Code anchors hook matchers (`^…$` semantics), so a
+  // bare `mcp__moflo__memory_` never matches any real MCP tool name and the
+  // record-memory-searched stamp silently no-ops on every memory_search.
+  // The fix is anchored alternation. Existing consumers that upgrade through
+  // this version self-heal here without needing `flo doctor --fix`.
+  {
+    name: '#929: anchor record-memory-searched matcher',
+    from: 'mcp__moflo__memory_',
+    to: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$',
+    cmdContains: 'record-memory-searched',
+  },
+];
+
 export interface RewriteResult {
   /** The (mutated) settings */
   settings: Record<string, unknown>;
@@ -190,6 +230,26 @@ export function rewriteIncorrectHookWiring(
             count++;
           }
         }
+      }
+    }
+    if (count > 0) rewrites.push({ name: rule.name, count });
+  }
+
+  for (const rule of MATCHER_REWRITE_RULES) {
+    let count = 0;
+    for (const eventName of Object.keys(hooks)) {
+      const eventArray = hooks[eventName];
+      if (!Array.isArray(eventArray)) continue;
+      for (const block of eventArray as Array<Record<string, unknown>>) {
+        if (block.matcher !== rule.from) continue;
+        const blockHooks = block.hooks;
+        if (!Array.isArray(blockHooks)) continue;
+        const hasMatchingCmd = (blockHooks as Array<Record<string, unknown>>).some(
+          (h) => typeof h.command === 'string' && h.command.includes(rule.cmdContains),
+        );
+        if (!hasMatchingCmd) continue;
+        block.matcher = rule.to;
+        count++;
       }
     }
     if (count > 0) rewrites.push({ name: rule.name, count });

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -1637,11 +1637,19 @@ describe('settings.json: PostToolUse matcher coverage', () => {
     postToolUseMatchers = [];
   }
 
-  // Claude Code fires ALL matching entries for a tool, not just the first.
-  // Gather every entry whose matcher regex matches the tool name; assertions
-  // then look across the union of their hook commands.
+  // Claude Code fires ALL matching entries for a tool, not just the first —
+  // and it requires the matcher regex to match the WHOLE tool name (anchored
+  // semantics). A bare `new RegExp(matcher).test(name)` partial-matches, which
+  // would let an unanchored matcher like `mcp__moflo__memory_` falsely appear
+  // to match `mcp__moflo__memory_search` and hide regressions like #929 where
+  // the hook never fires in production. Compare the captured match against
+  // the full input to enforce full-match without double-anchoring matchers
+  // that already start with `^` / end with `$`.
   function findAllMatchingEntries(toolName: string) {
-    return postToolUseMatchers.filter(entry => new RegExp(entry.matcher).test(toolName));
+    return postToolUseMatchers.filter(entry => {
+      const m = toolName.match(new RegExp(entry.matcher));
+      return m !== null && m[0] === toolName;
+    });
   }
   function allCommandsFor(toolName: string): string[] {
     return findAllMatchingEntries(toolName).flatMap(e => e.hooks.map(h => h.command));


### PR DESCRIPTION
## Summary

- Claude Code anchors hook matchers (`^…$` semantics), so the bare `mcp__moflo__memory_` matcher introduced by #882 never fires for any real MCP tool name — `record-memory-searched` silently no-ops on every `memory_search` and the gate blocks every guidance Read for the rest of the turn.
- Anchored alternation `^mcp__moflo__memory_(search|retrieve|list|stats|store)$` mirrored across all five sources of truth (settings.json, settings-generator.ts, moflo-init.ts, hook-wiring.ts HOOK_ENTRY_MAP, hook-block-hash.ts reference).
- New `MATCHER_REWRITE_RULES` + extended `rewriteIncorrectHookWiring` so existing consumers self-heal on session-start (the launcher already calls this at line 909). `cmdContains` guard prevents rewriting unrelated user-customised blocks.

## Why the regression slipped through CI

`tests/bin/gate-helpers.test.ts` matcher-coverage tests used `new RegExp(matcher).test(toolName)` — a PARTIAL match — so they passed for both the broken (unanchored) and fixed (anchored) matchers. The helper now uses full-match semantics (`m[0] === toolName`) so the regression class can't slip past green tests again.

## Preserves #842 per-agent gating

A fresh prompt with the unfixed matcher leaves `memorySearched: false` after a `memory_search`. With this fix, both `memorySearched: true` AND `memorySearchedBy[<session-id>]: true` get stamped — the per-actor map (`memorySearchedBy`) introduced by #842 is intact, so subagents still must search memory themselves.

## Testing

- [x] `tests/bin/gate-helpers.test.ts` (153 tests, isolation) — green
- [x] `src/cli/__tests__/services/hook-wiring.test.ts` (19 + 3 new tests) — green
- [x] Full parallel suite (292 files, 7028 tests) — green
- [x] Manual repro: trigger `mcp__moflo__memory_search` in a fresh session, verify `.claude/workflow-state.json` shows `memorySearched: true` + `memorySearchedBy[sid]: true`
- [x] Manual repro: with broken matcher restored, verify hook does NOT fire (confirms test discrimination)

## Files

- `.claude/settings.json` — matcher updated
- `src/cli/init/{settings-generator,moflo-init}.ts` — matcher + corrected comments
- `src/cli/services/hook-wiring.ts` — HOOK_ENTRY_MAP + new MATCHER_REWRITE_RULES + extended rewriter
- `src/cli/services/hook-block-hash.ts` — drift reference matcher
- `src/cli/__tests__/services/hook-wiring.test.ts` — 3 new tests for #929 matcher rewrite
- `tests/bin/gate-helpers.test.ts` — full-match semantics in matcher coverage helper

Closes #929