### PR TITLE
Token cost cleanup: memory hygiene shipped guidance + publish --check flag

### DIFF
--- a/.claude/guidance/internal/pre-publish-rules.md
+++ b/.claude/guidance/internal/pre-publish-rules.md
@@ -25,6 +25,42 @@ Moflo ships to N consumers via `npm install moflo`. Every change runs from their
 
 ---
 
+## Trigger-Based Gating (`/publish` default mode)
+
+The `/publish` skill takes a presence-only `--check` / `-ch` flag. **Default behavior is `--check=false`** because most publishes happen right after a green PR where CI has already run lint, build, tests, and smoke (clean + populated, on three OSes). Re-running them locally pays for a CI workflow that already passed.
+
+| Gate | Default mode (no flag) | `--check` mode | Rationale for default |
+|------|------------------------|----------------|----------------------|
+| Lint | skip | run | `ci.yml` runs `npm run lint` on every PR with `max-warnings 0` |
+| Build | **always run** | run | Confirms the deliverables on disk match the new version; `prepublishOnly` would catch it but earlier is better |
+| Tests | skip | run | `ci.yml` runs `npm test` on every PR |
+| Doctor | **always run** (`--fix`) | run (`--strict`) | Only check with no CI equivalent — local-only state (daemon, embeddings, vector-stats) |
+| Smoke (clean) | skip | run | `consumer-install-smoke.yml` runs on PR + push to main, three OSes |
+| Smoke (populated) | skip | run | Same workflow as above |
+| Manual gate walk (rows below) | **trigger-based** | run all | A cheap bash fingerprint computes which gates the diff actually touches |
+
+The trigger fingerprint is `.claude/skills/publish/fingerprint.sh`. It diffs `HEAD` against the most recent `chore: install moflo@*` commit and pattern-matches the file list against the manual-gate triggers. Output is one block (~50 tokens), then Claude only walks the gates whose triggers fired.
+
+| Trigger flag | Manual check | Diff signal |
+|--------------|--------------|-------------|
+| `split-newlines` | Gate 1 — `.split(/\r?\n/)` | TS/JS file containing `readFile`/`fs.read*` was changed |
+| `homedir-tmpdir` | Gate 1 — `os.homedir()`/`os.tmpdir()` | Code touches `process.env.HOME`/`TMPDIR`/`TMP`/`TEMP` or `'/tmp/'` literal |
+| `bwrap-permissions` | Gate 1 — `permissionLevel: elevated` for net | Spell YAML or spell bash step changed |
+| `posix-only-spell-bash` | Gate 1 — no `mkdir`/`rm`/`cp` in spell bash | Spell bash step changed |
+| `bin-scriptfiles-sync` | Gate 2 — `scriptFiles` array (3 sites) | New file added to `bin/` |
+| `helper-static-files` | Gate 2 — helpers ship as static files | `bin/` or `init/` script-gen logic changed |
+| `shipped-guidance-prefix` | Gate 2 — `moflo-` prefix + shipped/internal partition | New file added to `.claude/guidance/shipped/` |
+| `files-glob-coverage` | Gate 6 — `npm pack --dry-run` review | New file class under `.claude/{skills,guidance/shipped,scripts,hooks}/` |
+| `info-loss-audit` | Gate 6 — bullet-by-bullet destination check | Any file deleted or renamed |
+
+If the trigger set is empty AND `--check=false`: the manual walk is skipped entirely, with explicit "Triggered manual checks: none" in the publish summary.
+
+**When to use `--check=true`:** publishes that didn't go through a green PR, broad refactors, infrastructure surface changes, or belt-and-suspenders for risky releases. The flag forces the full ten-item TL;DR walk regardless of triggers.
+
+**Why "errs toward triggering":** the fingerprint script prefers false positives (one extra cheap manual check) over false negatives (a real bug class slipping). The trigger map is the source of truth — whenever a manual-check row is added to a gate below, the matching trigger MUST be added to `fingerprint.sh` in the same commit.
+
+---
+
 ## Gate 1 — Cross-Platform Compatibility
 
 **Every code change MUST work on Windows + macOS + Linux.** The full rule set lives in `shipped/moflo-cross-platform.md`. Pre-publish, verify:
@@ -136,20 +172,30 @@ When you split, rename, or remove a shipped file, the consumer cleanup must work
 
 ## TL;DR — The Pre-Flight Checklist
 
-Before invoking `/publish`, confirm in order:
+Before invoking `/publish`, the gates run in two layers depending on the `--check` flag.
 
-1. [ ] `npm run lint` — exits 0, max-warnings 0
-2. [ ] `npm run build` — exits 0
-3. [ ] `npm test` — 0 failed test files; flakes investigated individually
-4. [ ] `npx moflo doctor --strict` — exits 0
-5. [ ] `npm run test:smoke` — green
-6. [ ] `npm run test:smoke:populated` — green
-7. [ ] Cross-platform diff walk — no `\\`, no chained `'..'`, no string `file://`, no `.split('\n')` on file content
-8. [ ] Consumer-install posture — `bin/` scripts use `findProjectRoot()`, runtime imports anchor on `import.meta.url`
-9. [ ] Manifest sanity — `npm pack --dry-run` includes new shipped files; removed files trace through guidance-sync layers cleanly
-10. [ ] Information-loss audit on any split/move — bullet-by-bullet destination check
+### Default mode (`/publish`, no flag) — runs always
 
-Only when ALL ten are green: invoke `/publish`.
+1. [ ] `npm run build` — exits 0 (Step 2 of the skill, never skippable)
+2. [ ] `npx moflo doctor --fix` — exits 0 (only check with no CI equivalent)
+3. [ ] Trigger fingerprint computed; manual walk performed only on triggered gates
+
+The default mode trusts CI for items 4–7 below. Use it when publishing right after a merged green PR — the common case.
+
+### Full mode (`/publish --check` or `-ch`) — runs everything
+
+In addition to the three above:
+
+4. [ ] `npm run lint` — exits 0, max-warnings 0
+5. [ ] `npm test` — 0 failed test files; flakes investigated individually
+6. [ ] `npm run test:smoke` — green
+7. [ ] `npm run test:smoke:populated` — green
+8. [ ] Cross-platform diff walk — no `\\`, no chained `'..'`, no string `file://`, no `.split('\n')` on file content
+9. [ ] Consumer-install posture — `bin/` scripts use `findProjectRoot()`, runtime imports anchor on `import.meta.url`
+10. [ ] Manifest sanity — `npm pack --dry-run` includes new shipped files; removed files trace through guidance-sync layers cleanly
+11. [ ] Information-loss audit on any split/move — bullet-by-bullet destination check
+
+Use `--check` when the publish didn't go through a green PR, when the change is risky (broad refactor, packaging, infrastructure), or for belt-and-suspenders.
 
 ---
 
@@ -163,5 +209,8 @@ Only when ALL ten are green: invoke `/publish`.
 - `.claude/guidance/internal/dogfooding.md` — Why moflo's dogfood loop catches consumer regressions first
 - `.claude/guidance/shipped/moflo-source-hygiene.md` — Source-code hygiene rules consumed at lint time (Gate 7)
 - `.claude/skills/publish/SKILL.md` — The `/publish` skill that references this doc
+- `.claude/skills/publish/fingerprint.sh` — Trigger-fingerprint script that drives default-mode gating
 - `harness/consumer-smoke/README.md` — Smoke harness profiles + checks (Gate 5)
 - `docs/BUILD.md` — Step-by-step build/publish process the `/publish` skill follows
+- `.github/workflows/ci.yml` — Lint/build/test gates default mode skips
+- `.github/workflows/consumer-install-smoke.yml` — Smoke gates default mode skips

--- a/.claude/guidance/shipped/moflo-core-guidance.md
+++ b/.claude/guidance/shipped/moflo-core-guidance.md
@@ -304,6 +304,7 @@ See `moflo-memory-strategy.md` for memory-specific troubleshooting.
 - `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` — Task & swarm coordination with TaskCreate/TaskUpdate
 - `.claude/guidance/shipped/moflo-memory-strategy.md` — Database schema, namespaces, search commands, RAG linking
 - `.claude/guidance/shipped/moflo-memorydb-maintenance.md` — Reindexing, namespace purging, recovery
+- `.claude/guidance/shipped/moflo-memory-hygiene.md` — When and how to retire stale auto-memory entries (every entry costs per-prompt tokens)
 - `.claude/guidance/shipped/moflo-session-start.md` — Complete session-start lifecycle (DB heal, sync, migrations, daemon)
 - `.claude/guidance/shipped/moflo-settings-injection.md` — What moflo writes into `.claude/` and how surgical self-heal works
 - `.claude/guidance/shipped/moflo-cross-platform.md` — Windows/macOS/Linux portability rules for any code change

--- a/.claude/guidance/shipped/moflo-memory-hygiene.md
+++ b/.claude/guidance/shipped/moflo-memory-hygiene.md
@@ -1,0 +1,146 @@
+# Memory Hygiene — Retiring Stale Auto-Memory Entries
+
+**Purpose:** Rules for keeping a project's auto-memory (`MEMORY.md` + per-entry `*.md` files under `~/.claude/projects/<project>/memory/`) lean. Apply periodically — every memory entry is loaded into context every prompt, so stale entries are a recurring per-prompt token cost in every future session.
+
+---
+
+## When to Sweep
+
+Sweep whenever any of the following is true:
+
+| Trigger | Why |
+|---------|-----|
+| `MEMORY.md` exceeds ~50 entries | Index alone now costs >2K tokens per prompt |
+| User pays unexpectedly high context cost across sessions | Stale entries are a likely contributor |
+| User asks for a memory audit / says "clean up memory" | Direct request |
+| You retired a major epic / closed a long-standing incident | Its supporting memories likely went stale in the same moment |
+| You shipped a machine-enforced gate (lint, smoke, drift guard) for a rule | The matching memory entry can be retired — the gate carries the load now |
+
+**Do NOT sweep mid-task.** A sweep is a focused activity. Mixing it into other work risks deleting an entry whose rule is actively informing the current change.
+
+---
+
+## Retire Decision Table
+
+For each entry, classify into exactly one bucket:
+
+| Classification | When to apply | Action |
+|---------------|---------------|--------|
+| **KEEP** | Entry still drives a decision you might make today | No change |
+| **RETIRE** | Resolved incident, completed migration, or rule now enforced by lint/test/CI | Delete the `.md` file + drop the index line |
+| **COMPRESS** | Entry is load-bearing but verbose; durable signal fits in 1–3 sentences | Rewrite to a one-paragraph version |
+| **MERGE** | Two+ entries cover the same rule with overlapping examples | Pick the most specific, link the others' best phrasing into it, delete the duplicates |
+
+**The retirement test:** "If I removed this entry today, would any future me-decision be wrong?" If the answer is no — because (a) the situation no longer arises, or (b) a machine gate already prevents the failure — retire it.
+
+---
+
+## Retire Criteria — Concrete Examples
+
+### RETIRE: Status notes for resolved incidents
+
+A memory entry whose body opens with "RESOLVED in vX.Y.Z" or "Closed epic #N (date)" is a status note, not a rule. Retire it once the durable enforcement (CI smoke, drift guard, ESLint rule, code fix) is in place. The fix itself is the source of truth — re-stating it in memory adds noise.
+
+```markdown
+## Retire example
+project_docker_sandbox_root_bug.md says "RESOLVED in moflo@4.8.75"
+→ The fix is in `docker-sandbox.ts`; the Dockerfile sets USER node.
+→ Tests assert `/home/node/...` paths.
+→ Memory entry adds zero behavioral signal. RETIRE.
+```
+
+### RETIRE: Rules superseded by machine gates
+
+If a rule has been promoted into an ESLint check, a drift-guard test, a smoke-harness probe, or a pre-commit hook, the memory entry no longer prevents the failure — only the gate does. Retire the memory and let the gate carry the load.
+
+```markdown
+## Retire example
+feedback_no_fixed_depth_paths.md and feedback_consumer_project_paths.md
+both teach "don't count `../` segments across moflo packages."
+→ ESLint rule in `.eslintrc.path-safety.cjs` now bans the patterns.
+→ Consumer-smoke probe scans for `Cannot find module` / `MOFLO_BRIDGE_QUIET`.
+→ Memory entries are advisory; the gate is enforcing. RETIRE the memories.
+```
+
+### RETIRE: Outdated targets, stale numbers
+
+Memory bodies that reference specific version numbers, package sizes, file counts, or "next target is X" milestones decay fast. If the stated target has moved (e.g. the package was removed, the size threshold changed), retire it. Replace with a fresh entry only if the new target genuinely drives behavior.
+
+### COMPRESS: Long incident retros
+
+Multi-paragraph entries documenting "what we found in the audit" are useful as breadcrumbs but the durable signal is usually one sentence: which test, lint rule, or gate now blocks the regression. Compress everything else.
+
+```markdown
+## Compress example
+Before (25 lines): a full audit retro listing five categories of residue.
+After (3 lines):  "Post-collapse residue is now machine-blocked by 5 invariants
+                   in `published-package-drift-guard.test.ts`. Sibling guards in
+                   `.eslintrc.cjs` ban deep `../` paths + hash-embedding identifiers."
+```
+
+### KEEP: Standing rules with concrete cost the user paid
+
+Entries that quote a real user incident ("$50 in tokens", "broke publish 4.8.62", "credibility with stakeholders") and pair it with a specific fix-or-avoidance pattern are load-bearing. They teach future-Claude how to recognize the failure mode before repeating it. Keep them as-is.
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails | Fix |
+|-------------|-------------|-----|
+| Sweeping during active work | Risk of deleting an entry whose rule is informing the current change | Sweep as its own focused session |
+| Retiring entries because they're "old" | Age alone is not a signal — many durable rules are years old | Apply the retirement test, not the calendar |
+| Merging distinct entries to shrink the index | Each entry has a distinct origin/cost; merging loses specificity | Only merge when the rules truly overlap (same fix, same trigger) |
+| Retiring `feedback_*` entries en masse | These typically encode behavioral rules, not status notes; far less likely to be retire-eligible than `project_*` | Bias toward keeping `feedback_*`, retiring `project_*` |
+| Deleting a memory file but leaving its `MEMORY.md` line | Leaves a dangling link that loads as broken context every prompt | Always update both atomically |
+
+---
+
+## Mechanics — Retiring an Entry
+
+1. **Delete the per-entry file** under the memory directory: `rm <name>.md`.
+2. **Remove the `MEMORY.md` line** that points to it.
+3. **Verify no dangling links remain** — every `(file.md)` reference in `MEMORY.md` should resolve to a file on disk.
+4. **No re-indexing needed** — auto-memory files are loaded directly into context by the system, not via the moflo memory DB. The retirement takes effect on the next session start.
+
+```bash
+## Quick verify
+ls -1 *.md > /tmp/files.txt
+grep -oE '\([a-z_]+\.md\)' MEMORY.md | tr -d '()' | sort -u > /tmp/indexed.txt
+comm -23 /tmp/files.txt /tmp/indexed.txt   # orphans on disk
+comm -13 /tmp/files.txt /tmp/indexed.txt   # dangling index lines
+```
+
+---
+
+## Mechanics — Compressing an Entry
+
+1. Read the existing entry.
+2. Identify the **single durable signal** — usually a rule + a pointer to where the rule is enforced (test file, lint rule, code path).
+3. Rewrite the body to that signal in 1–3 sentences. Keep the frontmatter (`name`, `description`, `type`).
+4. Update the matching `MEMORY.md` line so the one-line description still summarizes the new body accurately.
+
+---
+
+## What NOT to Retire
+
+The user's auto-memory system already documents what should never be saved (see the system instructions for memory). The flip side: the rules below are durable and should survive every sweep:
+
+- `feedback_consumer_blast_radius` — the library posture itself
+- `feedback_swarm_hive_never_regress` — protected product surface
+- `feedback_broken_window_theory` — quality posture
+- `feedback_dogfood_install_vs_source` — diagnostic posture
+- `feedback_no_layered_workarounds` / `feedback_no_unverified_fix_claims` — fix-quality posture
+- `feedback_call_out_fix_or_file` / `feedback_fix_all_bugs` — bug-discipline posture
+- `project_identity` / `project_moflo_is_a_library` / `project_free_open_source` — identity invariants
+
+These are non-negotiable framing rules. Even if their original incident is years old, the rule still drives every future change.
+
+---
+
+## See Also
+
+- `.claude/guidance/shipped/moflo-memory-strategy.md` — Architecture of moflo's *project* memory system (different from the user's auto-memory, but related)
+- `.claude/guidance/shipped/moflo-guidance-rules.md` — Universal rules for writing any guidance file; memory entries follow similar imperative-voice + concrete-example posture
+- `.claude/guidance/shipped/moflo-session-start.md` — Where the `auto-memory-hook.mjs` lives and how it loads MEMORY.md every prompt
+- `.claude/guidance/shipped/moflo-core-guidance.md` — Hub doc that links to this file from its memory section

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish
 description: Bump version, build, test, publish to npm, and install locally
-arguments: "[patch|minor|major] [-rc]"
+arguments: "[patch|minor|major] [-rc] [--check|-ch]"
 ---
 
 # /publish - Version Bump, Build, Test & Publish
@@ -13,30 +13,33 @@ Automated release pipeline for moflo. Bumps version, commits, builds, tests, run
 ## Usage
 
 ```
-/publish              # patch bump (4.8.56 → 4.8.57)
+/publish              # patch bump, default mode (skips CI-covered gates)
 /publish minor        # minor bump (4.8.56 → 4.9.0)
 /publish major        # major bump (4.8.56 → 5.0.0)
-/publish -rc          # patch RC bump (4.8.56 → 4.8.57-rc.1, or 4.8.57-rc.1 → 4.8.57-rc.2)
+/publish -rc          # patch RC bump (4.8.56 → 4.8.57-rc.1)
 /publish minor -rc    # minor RC bump (4.8.56 → 4.9.0-rc.1)
-/publish patch        # explicit patch bump
+/publish --check      # full pre-flight (lint + test + smoke + everything)
+/publish -ch          # short form of --check
+/publish minor -ch    # combine: full pre-flight on a minor bump
 ```
 
-## Pre-Publish Gate — REQUIRED
+## --check / -ch flag (presence-only)
 
-**Before Step 1, walk the full pre-flight checklist in `.claude/guidance/internal/pre-publish-rules.md`.** That document is the authoritative ruleset for every publish — the seven layered gates (lint, build, tests, doctor, smoke, populated smoke, manifest sanity) plus the cross-platform and consumer-install posture checks. Do not paraphrase or shortcut the rules here; read them and confirm every item.
+**Default (flag absent):** runs build + doctor + trigger-based manual checks only. Skips lint/test/smoke because those gates are covered by CI on every PR + push to main (`ci.yml`, `consumer-install-smoke.yml`).
 
-If you cannot confirm all ten checklist items at the bottom of `pre-publish-rules.md`, STOP. Fix the failing gate first and only then resume from Step 1 below. Skipping the gate to "just get this small change out" is the antipattern that produced the historical incidents named in the rules doc.
+**With `--check` or `-ch` (any presence):** runs the full pre-flight from `pre-publish-rules.md` — lint, build, test, doctor (strict), clean smoke, populated smoke, and a forced full walk of every manual gate. Use this for publishes that didn't go through a green PR, risky releases, or when you want belt-and-suspenders.
+
+The flag is presence-only. `--check` and `-ch` both set it to true. There is no `--check=true` / `--check=false` syntax — absence means false.
 
 ---
 
 ## Step-by-Step Procedure
 
-Follow docs/BUILD.md exactly. Every step must succeed before proceeding to the next.
-
-### Step 1: Parse Arguments
+### Step 0: Parse Arguments
 
 - Default bump type is `patch` if not specified
-- If `-rc` flag is present, produce a release candidate version
+- `-rc` flag: produce a release candidate
+- `--check` or `-ch` (presence): set `CHECK_MODE=true`. Otherwise `CHECK_MODE=false`.
 - Determine the new version string:
   - **Without `-rc`:** Use `npm version <patch|minor|major> --no-git-tag-version`
   - **With `-rc`:** Calculate manually:
@@ -44,33 +47,96 @@ Follow docs/BUILD.md exactly. Every step must succeed before proceeding to the n
     - Otherwise, bump the base version and append `-rc.1` (e.g., `4.8.56` → `4.8.57-rc.1`)
     - Write with: `npm version <new-version> --no-git-tag-version`
 
-### Step 2: Rebuild After Version Bump
+### Step 1: Compute Manual-Check Fingerprint (always)
+
+```bash
+bash .claude/skills/publish/fingerprint.sh
+```
+
+The script diffs `HEAD` against the most recent `chore: install moflo@*` commit and pattern-matches the file list against the manual-gate triggers from `pre-publish-rules.md`. Output is one block:
+
+```
+Triggered manual checks: bin-scriptfiles-sync info-loss-audit
+Diff range: <last-publish-sha>..HEAD
+Changed files: 7
+```
+
+`Triggered manual checks: none` means gates 7/8/10 don't apply to this diff — skip them entirely.
+
+This step costs ~50 tokens and is the cornerstone of token-efficient default mode.
+
+### Step 2: Build (always)
 
 ```bash
 npm run build
 ```
 
-This syncs the version to `src/cli/version.ts` via the `version` lifecycle script, then compiles all TypeScript.
+Always runs regardless of `CHECK_MODE`. Syncs the version to `src/cli/version.ts` via the `version` lifecycle script, then compiles all TypeScript. Confirms the deliverables on disk are correct.
 
 **Must exit 0.** If it fails, stop and fix the build error.
 
-### Step 3: Run Tests
+### Step 3: Lint (only if `CHECK_MODE=true`)
+
+```bash
+npm run lint
+```
+
+Skipped by default — `ci.yml` runs lint on every PR with `max-warnings 0`. Run when `--check` is set.
+
+### Step 4: Tests (only if `CHECK_MODE=true`)
 
 ```bash
 npm test
 ```
 
+Skipped by default — `ci.yml` runs the full test suite on every PR. Run when `--check` is set.
+
 **Must have 0 test file failures.** If any test files fail, retest them individually to distinguish real failures from flaky ones (per broken window theory). Fix all real failures before proceeding.
 
-### Step 4: Run Doctor
+### Step 5: Doctor (always)
 
+Default mode:
 ```bash
 npx moflo doctor --fix
 ```
 
-All checks must pass (warnings are acceptable on Windows for sandbox tier). If doctor finds fixable issues, it will auto-fix them. If manual fixes are needed, stop and address them.
+Check mode (`CHECK_MODE=true`):
+```bash
+npx moflo doctor --strict
+```
 
-### Step 5: Commit & Push
+Doctor is the only check with no CI equivalent — it inspects local state (daemon lock, embeddings hygiene, sandbox tier, vector-stats freshness) that CI cannot validate for you. Always runs.
+
+### Step 6: Smoke Tests (only if `CHECK_MODE=true`)
+
+```bash
+npm run test:smoke
+npm run test:smoke:populated
+```
+
+Skipped by default — `consumer-install-smoke.yml` runs both profiles on Ubuntu/macOS/Windows on every PR + push to main. Run when `--check` is set.
+
+### Step 7: Manual Gate Walk (trigger-based, even in default mode)
+
+Read the fingerprint output from Step 1.
+
+| Trigger | Manual check (gate) | What to walk |
+|---------|---------------------|--------------|
+| `split-newlines` | Gate 7 | Diff the changed file-reading code; verify any newline split uses `/\r?\n/` not `'\n'` |
+| `homedir-tmpdir` | Gate 7 | Verify env-var literals use `os.homedir()` / `os.tmpdir()`, not raw `process.env.HOME` / `/tmp` |
+| `bwrap-permissions` | Gate 7 | Spell bash steps that need network declare `permissionLevel: elevated` |
+| `posix-only-spell-bash` | Gate 7 | Spell bash steps avoid `mkdir`/`rm`/`cp`; use `node -e` with `fs`/`os` for cross-platform file ops |
+| `bin-scriptfiles-sync` | Gate 8 | New `bin/` script appears in all three `scriptFiles` arrays (`session-start-launcher.mjs`, `init/moflo-init.ts`, third sync site) |
+| `helper-static-files` | Gate 8 | New helpers ship as static `bin/` files, not generated at runtime |
+| `shipped-guidance-prefix` | Gate 8 | New shipped guidance has `moflo-` prefix and lives in `.claude/guidance/shipped/` |
+| `files-glob-coverage` | Gate 9 | Run `npm pack --dry-run` and confirm new shipped files appear in the tarball listing |
+| `info-loss-audit` | Gate 10 | For each deleted/renamed file, audit destinations bullet-by-bullet — every piece of removed content has a home |
+
+If `CHECK_MODE=true`, walk **all** manual gates regardless of triggers (full audit). If `CHECK_MODE=false`, walk **only triggered** ones.
+
+If the trigger set is `none` AND `CHECK_MODE=false`: skip Step 7 entirely.
+
+### Step 8: Commit & Push
 
 Commit the version bump files:
 
@@ -82,15 +148,13 @@ git push origin main
 
 Only commit version-related files. Do not stage unrelated changes.
 
-### Step 6: Verify npm Authentication
-
-Before publishing, verify npm auth is valid:
+### Step 9: Verify npm Authentication
 
 ```bash
 npm whoami
 ```
 
-If this returns a 401 or "not logged in" error, the auth token in `~/.npmrc` is missing or expired. Ask the user to provide a valid npm publish token.
+If 401 or "not logged in": auth token in `~/.npmrc` is missing or expired. Ask the user for a valid npm publish token.
 
 **How to create a token** (provide these instructions to the user if needed):
 1. Go to https://www.npmjs.com/settings/~/tokens
@@ -104,9 +168,9 @@ Once the user provides the token, write it to `~/.npmrc`:
 echo "//registry.npmjs.org/:_authToken=<token>" > ~/.npmrc
 ```
 
-Then verify with `npm whoami` before proceeding.
+Verify with `npm whoami` before proceeding.
 
-### Step 7: Publish to npm
+### Step 10: Publish to npm
 
 ```bash
 npm publish --tag <tag>
@@ -120,7 +184,7 @@ npm publish --tag <tag>
 - Then retry with: `npm publish --otp=<code> --tag <tag>`
 - Tip: Granular access tokens created on npmjs.com do NOT require OTP — prefer those over legacy tokens
 
-### Step 8: Verify Publication
+### Step 11: Verify Publication
 
 ```bash
 npm view moflo version
@@ -129,7 +193,7 @@ npm view moflo dist-tags
 
 Confirm the published version matches what we just built.
 
-### Step 9: Install Locally
+### Step 12: Install Locally
 
 ```bash
 npm install moflo@<new-version> --save-dev
@@ -137,7 +201,7 @@ npm install moflo@<new-version> --save-dev
 
 This updates `package.json` and `package-lock.json` to use the newly published version as a devDependency.
 
-### Step 10: Final Commit
+### Step 13: Final Commit
 
 If `package.json` or `package-lock.json` changed from the install:
 
@@ -147,6 +211,8 @@ git commit -m "chore: install moflo@<new-version>"
 git push origin main
 ```
 
+The `chore: install moflo@<version>` commit message is the anchor the fingerprint uses to bound future diffs — keep the prefix exact.
+
 ## Output
 
 Print a summary at the end:
@@ -154,13 +220,18 @@ Print a summary at the end:
 ```
 Publish Summary
 ───────────────
-Version:    <old> → <new>
-Tag:        latest | rc
-Build:      passed
-Tests:      <N> files passed, <N> tests passed
-Doctor:     <N> passed, <N> warnings
-Published:  moflo@<new-version>
-Installed:  moflo@<new-version> (devDependency)
+Mode:            default | --check
+Version:         <old> → <new>
+Tag:             latest | rc
+Build:           passed
+Tests:           skipped (CI-covered) | <N> files passed, <N> tests passed
+Lint:            skipped (CI-covered) | passed
+Doctor:          <N> passed, <N> warnings
+Smoke (clean):   skipped (CI-covered) | passed
+Smoke (popl):    skipped (CI-covered) | passed
+Triggered gates: <list> | none
+Published:       moflo@<new-version>
+Installed:       moflo@<new-version> (devDependency)
 ```
 
 ## Important
@@ -168,13 +239,27 @@ Installed:  moflo@<new-version> (devDependency)
 - All commands run from the project root — never cd into subdirectories
 - Never use `--force` on npm publish
 - Never install moflo globally — it is always a local devDependency
-- If any step fails, stop and fix the issue before proceeding — do not skip steps
-- The `prepublishOnly` script in package.json runs `npm run build` automatically, so npm publish will fail-fast on any TypeScript or asset-bundling error
+- If any step that DID run fails, stop and fix the issue before proceeding — do not skip steps
+- The `prepublishOnly` script in package.json runs `npm run build` automatically, so npm publish will fail-fast on any TypeScript or asset-bundling error even if Step 2 had been skipped (it isn't — Step 2 always runs)
 - Pre-publish rules live in `.claude/guidance/internal/pre-publish-rules.md` — never duplicate or paraphrase them in this skill; reference and follow
+
+## When to use `--check`
+
+Use `--check` / `-ch` when:
+
+- The PR didn't go through CI (e.g., publishing from a local-only branch)
+- You're publishing a risky change (broad refactor, infrastructure surface, packaging changes)
+- CI was red on something orthogonal you waived, and you want belt-and-suspenders locally
+- You explicitly want to re-walk gates 7/8/10 manually regardless of trigger output
+
+For the common case — publishing right after a merged green PR — the default mode is correct and meaningfully cheaper in tokens and time.
 
 ## See Also
 
-- `.claude/guidance/internal/pre-publish-rules.md` — Mandatory cross-platform + consumer-install gates that gate every publish
+- `.claude/skills/publish/fingerprint.sh` — Trigger-fingerprint script invoked by Step 1
+- `.claude/guidance/internal/pre-publish-rules.md` — Authoritative gate ruleset (gates 1–10) and trigger map
 - `docs/BUILD.md` — Step-by-step build/publish process this skill mirrors
 - `.claude/guidance/internal/dogfooding.md` — Why we catch consumer-facing regressions first as our own dependency
 - `harness/consumer-smoke/README.md` — Smoke harness profiles (clean + populated) that prove a consumer install works
+- `.github/workflows/ci.yml` — Lint/build/test gates this skill skips by default
+- `.github/workflows/consumer-install-smoke.yml` — Smoke gates this skill skips by default

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -61,7 +61,7 @@ Diff range: <last-publish-sha>..HEAD
 Changed files: 7
 ```
 
-`Triggered manual checks: none` means gates 7/8/10 don't apply to this diff — skip them entirely.
+`Triggered manual checks: none` means gates 1/2/6 don't apply to this diff — skip them entirely.
 
 This step costs ~50 tokens and is the cornerstone of token-efficient default mode.
 

--- a/.claude/skills/publish/fingerprint.sh
+++ b/.claude/skills/publish/fingerprint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Publish-skill fingerprint: pattern-matches the diff since last publish
-# against the manual-check triggers from pre-publish-rules.md (gates 7/8/10).
+# against the manual-check triggers from pre-publish-rules.md (gates 1/2/6).
 # Prints `Triggered manual checks: ...` (or `none`) on stdout. Pure shell —
 # no Claude tokens. Errs toward triggering on ambiguity.
 #
@@ -27,29 +27,29 @@ DELETED=$(git diff --name-only --diff-filter=DR "$LAST_PUBLISH..HEAD" || true)
 
 triggered=()
 
-# Gate 7 — TS/JS files reading file content → check `.split(/\r?\n/)` review.
+# Gate 1 — TS/JS files reading file content → check `.split(/\r?\n/)` review.
 if echo "$CHANGED" | grep -qE '\.(ts|tsx|js|mjs|cjs)$'; then
-  TS_FILES=$(echo "$CHANGED" | grep -E '\.(ts|tsx|js|mjs|cjs)$' | tr '\n' ' ')
-  # Restrict to files that actually exist (the diff includes deletes too).
-  EXISTING=""
-  for f in $TS_FILES; do
-    [ -f "$f" ] && EXISTING="$EXISTING $f"
-  done
-  if [ -n "$EXISTING" ] && grep -lE 'readFile|readFileSync|fs\.read' $EXISTING >/dev/null 2>&1; then
+  # Build EXISTING as an array so paths with spaces survive (consumer projects
+  # may live under "C:\Users\Some Name\..." on Windows).
+  EXISTING=()
+  while IFS= read -r f; do
+    [ -f "$f" ] && EXISTING+=("$f")
+  done < <(echo "$CHANGED" | grep -E '\.(ts|tsx|js|mjs|cjs)$')
+  if [ "${#EXISTING[@]}" -gt 0 ] && grep -lE 'readFile|readFileSync|fs\.read' "${EXISTING[@]}" >/dev/null 2>&1; then
     triggered+=("split-newlines")
   fi
-  # Gate 7 — `os.homedir()` / `os.tmpdir()` review when env-var literals appear.
-  if [ -n "$EXISTING" ] && grep -lE "process\.env\.(HOME|TMPDIR|TMP|TEMP)|['\"]\\/tmp\\/" $EXISTING >/dev/null 2>&1; then
+  # Gate 1 — `os.homedir()` / `os.tmpdir()` review when env-var literals appear.
+  if [ "${#EXISTING[@]}" -gt 0 ] && grep -lE "process\.env\.(HOME|TMPDIR|TMP|TEMP)|['\"]\\/tmp\\/" "${EXISTING[@]}" >/dev/null 2>&1; then
     triggered+=("homedir-tmpdir")
   fi
 fi
 
-# Gate 7 — spell yaml or spell bash steps changed.
+# Gate 1 — spell yaml or spell bash steps changed.
 if echo "$CHANGED" | grep -qE '(^spells/|spells/.*\.(ya?ml|sh|bash)$|\.spell\.ya?ml$)'; then
   triggered+=("bwrap-permissions" "posix-only-spell-bash")
 fi
 
-# Gate 8 — new file added under bin/ (only adds, not modifications, count for
+# Gate 2 — new file added under bin/ (only adds, not modifications, count for
 # scriptFiles sync). Guard the `--diff-filter=A` lookup separately from the
 # generic CHANGED set so a touched-but-not-added file doesn't fire it.
 ADDED=$(git diff --name-only --diff-filter=A "$LAST_PUBLISH..HEAD" || true)
@@ -57,24 +57,24 @@ if echo "$ADDED" | grep -q '^bin/'; then
   triggered+=("bin-scriptfiles-sync")
 fi
 
-# Gate 8 — anything in bin/ or init/ script-generation logic changed.
+# Gate 2 — anything in bin/ or init/ script-generation logic changed.
 if echo "$CHANGED" | grep -qE '^(bin/|init/|src/cli/init/)'; then
   triggered+=("helper-static-files")
 fi
 
-# Gate 8 — new file added under .claude/guidance/shipped/ (prefix + partition).
+# Gate 2 — new file added under .claude/guidance/shipped/ (prefix + partition).
 if echo "$ADDED" | grep -q '^\.claude/guidance/shipped/'; then
   triggered+=("shipped-guidance-prefix")
 fi
 
-# Gate 9 — new shipped file class. Conservative trigger: any new top-level
+# Gate 6 — new shipped file class. Conservative trigger: any new top-level
 # directory under .claude/ or any new pattern under shipped/. We approximate
 # "new file class" as "any added file the existing files-glob might miss".
 if echo "$ADDED" | grep -qE '^\.claude/(skills|guidance/shipped|scripts|hooks)/'; then
   triggered+=("files-glob-coverage")
 fi
 
-# Gate 10 — any file deleted or renamed → information-loss audit.
+# Gate 6 — any file deleted or renamed → information-loss audit.
 if [ -n "$DELETED" ]; then
   triggered+=("info-loss-audit")
 fi

--- a/.claude/skills/publish/fingerprint.sh
+++ b/.claude/skills/publish/fingerprint.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Publish-skill fingerprint: pattern-matches the diff since last publish
+# against the manual-check triggers from pre-publish-rules.md (gates 7/8/10).
+# Prints `Triggered manual checks: ...` (or `none`) on stdout. Pure shell —
+# no Claude tokens. Errs toward triggering on ambiguity.
+#
+# Usage: bash .claude/skills/publish/fingerprint.sh
+#
+# Exit codes: 0 always (output is what the skill consumes).
+
+set -euo pipefail
+
+# Find the commit that installed the most recently published moflo. The
+# /publish skill's Step 10 makes a `chore: install moflo@<version>` commit, so
+# everything between that commit and HEAD is what the next publish will ship.
+LAST_PUBLISH=$(git log --grep='^chore: install moflo@' -n 1 --format=%H 2>/dev/null || true)
+
+if [ -z "$LAST_PUBLISH" ]; then
+  # No prior publish commit found — fingerprint can't bound the diff. Trigger
+  # everything and let the manual walk decide. False positive > false negative.
+  echo "Triggered manual checks: split-newlines homedir-tmpdir bwrap-permissions posix-only-spell-bash bin-scriptfiles-sync helper-static-files shipped-guidance-prefix files-glob-coverage info-loss-audit (no prior publish commit found — running full audit)"
+  exit 0
+fi
+
+CHANGED=$(git diff --name-only "$LAST_PUBLISH..HEAD" || true)
+DELETED=$(git diff --name-only --diff-filter=DR "$LAST_PUBLISH..HEAD" || true)
+
+triggered=()
+
+# Gate 7 — TS/JS files reading file content → check `.split(/\r?\n/)` review.
+if echo "$CHANGED" | grep -qE '\.(ts|tsx|js|mjs|cjs)$'; then
+  TS_FILES=$(echo "$CHANGED" | grep -E '\.(ts|tsx|js|mjs|cjs)$' | tr '\n' ' ')
+  # Restrict to files that actually exist (the diff includes deletes too).
+  EXISTING=""
+  for f in $TS_FILES; do
+    [ -f "$f" ] && EXISTING="$EXISTING $f"
+  done
+  if [ -n "$EXISTING" ] && grep -lE 'readFile|readFileSync|fs\.read' $EXISTING >/dev/null 2>&1; then
+    triggered+=("split-newlines")
+  fi
+  # Gate 7 — `os.homedir()` / `os.tmpdir()` review when env-var literals appear.
+  if [ -n "$EXISTING" ] && grep -lE "process\.env\.(HOME|TMPDIR|TMP|TEMP)|['\"]\\/tmp\\/" $EXISTING >/dev/null 2>&1; then
+    triggered+=("homedir-tmpdir")
+  fi
+fi
+
+# Gate 7 — spell yaml or spell bash steps changed.
+if echo "$CHANGED" | grep -qE '(^spells/|spells/.*\.(ya?ml|sh|bash)$|\.spell\.ya?ml$)'; then
+  triggered+=("bwrap-permissions" "posix-only-spell-bash")
+fi
+
+# Gate 8 — new file added under bin/ (only adds, not modifications, count for
+# scriptFiles sync). Guard the `--diff-filter=A` lookup separately from the
+# generic CHANGED set so a touched-but-not-added file doesn't fire it.
+ADDED=$(git diff --name-only --diff-filter=A "$LAST_PUBLISH..HEAD" || true)
+if echo "$ADDED" | grep -q '^bin/'; then
+  triggered+=("bin-scriptfiles-sync")
+fi
+
+# Gate 8 — anything in bin/ or init/ script-generation logic changed.
+if echo "$CHANGED" | grep -qE '^(bin/|init/|src/cli/init/)'; then
+  triggered+=("helper-static-files")
+fi
+
+# Gate 8 — new file added under .claude/guidance/shipped/ (prefix + partition).
+if echo "$ADDED" | grep -q '^\.claude/guidance/shipped/'; then
+  triggered+=("shipped-guidance-prefix")
+fi
+
+# Gate 9 — new shipped file class. Conservative trigger: any new top-level
+# directory under .claude/ or any new pattern under shipped/. We approximate
+# "new file class" as "any added file the existing files-glob might miss".
+if echo "$ADDED" | grep -qE '^\.claude/(skills|guidance/shipped|scripts|hooks)/'; then
+  triggered+=("files-glob-coverage")
+fi
+
+# Gate 10 — any file deleted or renamed → information-loss audit.
+if [ -n "$DELETED" ]; then
+  triggered+=("info-loss-audit")
+fi
+
+# Dedupe (bash 4+ assoc array). Skip dedupe entirely on older bash — duplicates
+# are harmless (Claude reads them either way), so a degraded run still works.
+if declare -A seen 2>/dev/null; then
+  unique=()
+  if [ "${#triggered[@]}" -gt 0 ]; then
+    for t in "${triggered[@]}"; do
+      [ -z "$t" ] && continue
+      if [ -z "${seen[$t]:-}" ]; then
+        seen[$t]=1
+        unique+=("$t")
+      fi
+    done
+  fi
+  triggered=()
+  if [ "${#unique[@]}" -gt 0 ]; then
+    triggered=("${unique[@]}")
+  fi
+fi
+
+# Count non-empty lines without tripping `set -e`. `grep -c .` succeeds with
+# exit 1 on zero matches and `... || echo 0` then double-prints; use awk.
+CHANGED_COUNT=$(printf '%s\n' "$CHANGED" | awk 'NF { n++ } END { print n+0 }')
+
+if [ "${#triggered[@]}" -eq 0 ]; then
+  echo "Triggered manual checks: none"
+else
+  echo "Triggered manual checks: ${triggered[*]}"
+fi
+echo "Diff range: $LAST_PUBLISH..HEAD"
+echo "Changed files: $CHANGED_COUNT"


### PR DESCRIPTION
## Summary

Two cost-reduction levers, bundled per ask:

- **Memory hygiene** (`docs/guidance`): Adds `.claude/guidance/shipped/moflo-memory-hygiene.md` (147 lines) teaching Claude how to retire stale entries from a project's auto-memory `MEMORY.md`. Every memory entry costs per-prompt tokens in every session; the doc provides retire/compress/merge decision tables, concrete examples, anti-patterns, and verification mechanics. Indexed (17 RAG chunks, top similarity 0.889). Cross-linked from `moflo-core-guidance.md`.

- **Publish `--check` flag**: Default `/publish` now skips CI-covered gates (lint, tests, smoke) since `ci.yml` and `consumer-install-smoke.yml` already run them on every PR + push to main. A new `fingerprint.sh` diffs HEAD against the most recent `chore: install moflo@*` commit and pattern-matches the file list to decide which manual gates to walk. `--check` / `-ch` forces the full pre-flight (lint + tests + smoke + all manual gates) for risky / non-PR publishes.

## Test plan

- [x] memory-hygiene doc indexed via `node bin/index-guidance.mjs` (17 chunks, no errors)
- [x] flo-search returns the new doc as top hit for "retire stale memory hygiene" (0.889 similarity)
- [x] core-guidance See Also link verified
- [x] full test suite green (337 test files passed across 2 suites)
- [x] /simplify reviewer pass (SMALL tier) — 3 findings fixed in followup commit (array-quote paths, refresh gate numbers)
- [x] fingerprint.sh smoke-tested locally
- [ ] follow-up: file separate issues for the remaining token levers (#931 hook dedupe, #932 agent audit, #933 skill audit, #934 consumer CLAUDE.md)

## Related issues

This PR ships the first lever from the 2026-05-06 token-audit session. Remaining levers tracked in #931 / #932 / #933 / #934.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)