### PR TITLE
fix(931): dedupe UserPromptSubmit reminders, gate at Agent spawn

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -7,7 +7,7 @@ var cp = require('child_process');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '' };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -83,6 +83,73 @@ var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state
 var DANGEROUS = ['rm -rf /', 'format c:', 'del /s /q c:\\', ':(){:|:&};:', 'mkfs.', '> /dev/sda'];
 var DIRECTIVE_RE = /^(yes|no|yeah|yep|nope|sure|ok|okay|correct|right|exactly|perfect)\b/i;
 var TASK_RE = /\b(fix|bug|error|implement|add|create|build|write|refactor|debug|test|feature|issue|security|optimi)\b/i;
+
+// Namespace classification (#931). The hint used to be emitted on every prompt
+// by prompt-hook.mjs which cost ~40 tokens × every prompt × every consumer.
+// Now we classify here, store on workflow-state, and let check-before-agent
+// emit it once when Claude is actually about to spawn an agent.
+//
+// SYNC: these regexes + classifyNamespaceHint + applyPromptStateReset are
+// duplicated verbatim in src/cli/init/helpers-generator.ts (the embedded
+// gate.cjs fallback used by `flo init` when source helpers can't be located).
+// Any edit to either copy MUST be applied to both — there is no shared module
+// because helpers-generator emits a self-contained string template.
+var NS_LEARNINGS_RE = /\b(remember|recall|insight|lesson learned|gotcha|post.?mortem)\b|we (decid|agree|chose|said)/;
+var NS_TEST_RE = /\b(test|spec|coverage|tested|test case|test cases|tests for|spec for)\b/;
+var NS_EXPLICIT = [
+  { pattern: /\b(pattern|convention|best practice|style|coding rule)\b/, ns: 'patterns', label: 'code patterns and conventions' },
+  { pattern: /\b(code.?map|file structure|project structure|directory)\b/, ns: 'code-map', label: 'codebase navigation' },
+];
+var NS_PATTERN_RES = [/\b(template|example|similar to|how do we|how should)\b/];
+var NS_DOMAIN_RES = [
+  /\b(guidance|guide|docs|documentation|rules|how-to)\b/,
+  /\b(architecture|design|domain|tenant|migrat|schema|deploy)/,
+  /\b(rule|requirement|constraint|compliance)\b/,
+];
+var NS_NAV_RES = [
+  /\b(find|where|which file|look up|locate|endpoint|route|url|path)\b/,
+  /\b(class|function|method|component|service|entity|module)\b/,
+];
+
+function classifyNamespaceHint(promptText) {
+  var lower = (promptText || '').toLowerCase();
+  if (NS_TEST_RE.test(lower)) return 'Memory namespace hint: use "tests" for test inventory and coverage lookups.';
+  if (NS_LEARNINGS_RE.test(lower)) return 'Memory namespace hint: use "learnings" for user-directed decisions and distilled insights.';
+  for (var i = 0; i < NS_EXPLICIT.length; i++) {
+    if (NS_EXPLICIT[i].pattern.test(lower)) return 'Memory namespace hint: use "' + NS_EXPLICIT[i].ns + '" for ' + NS_EXPLICIT[i].label + '.';
+  }
+  for (var j = 0; j < NS_DOMAIN_RES.length; j++) {
+    if (NS_DOMAIN_RES[j].test(lower)) return 'Memory namespace hint: search "guidance" and "learnings" for domain rules and project decisions.';
+  }
+  for (var k = 0; k < NS_PATTERN_RES.length; k++) {
+    if (NS_PATTERN_RES[k].test(lower)) return 'Memory namespace hint: use "patterns" for code patterns and conventions.';
+  }
+  for (var m = 0; m < NS_NAV_RES.length; m++) {
+    if (NS_NAV_RES[m].test(lower)) return 'Memory namespace hint: use "code-map" for codebase navigation.';
+  }
+  return '';
+}
+
+// Apply per-prompt state reset shared by `prompt-reminder` (full) and
+// `prompt-state-reset` (defensive safety-net, no emission). Idempotent — both
+// UserPromptSubmit hooks can run it without compounding any field. Caller
+// owns interactionCount and the user-visible REMINDER/Context emissions, so
+// this helper stays silent.
+function applyPromptStateReset(state, promptText) {
+  state.memorySearched = false;
+  // Wipe per-actor memory tracking too — a new user prompt is a fresh window
+  // for both parent AND any subagents the parent may spawn during this turn.
+  state.memorySearchedBy = {};
+  // learningsStored is session-scoped — once stored, it stays true until session reset.
+  // Resetting per-prompt caused false blocks when PR creation was on a later prompt.
+  var DIRECTIVE_MAX_LEN = 20;
+  var escaped = /^@@\s*/.test(promptText || '');
+  state.memoryRequired = !escaped && (promptText || '').length >= 4 && (TASK_RE.test(promptText || '') || (promptText || '').length > DIRECTIVE_MAX_LEN);
+  // Stash namespace hint for check-before-agent to emit when Claude actually
+  // spawns an Agent (#931). Empty string when nothing matched — overwriting
+  // any stale value from the previous prompt.
+  state.lastNamespaceHint = classifyNamespaceHint(promptText);
+}
 // Match npm/yarn/pnpm/bun test, npx vitest|jest|..., bare runners at command-start only,
 // and language-native test commands. The bare-runner arm is anchored so that
 // `npm install jest`, `grep -r vitest src/`, and similar don't false-positive.
@@ -203,12 +270,25 @@ switch (command) {
     // Advisory only — agent spawning is never blocked.
     // Memory-first enforcement happens at the scan/read gate layer.
     // SubagentStart hook injects guidance directive into subagent context.
+    //
+    // #931 — TaskCreate REMINDER and the namespace hint moved here from
+    // prompt-reminder. They only matter when Claude is actually about to spawn
+    // an Agent; emitting per-prompt cost ~90 tokens × every prompt × every
+    // consumer.
     var s = readState();
     if (config.task_create_first && !s.tasksCreated) {
       process.stdout.write('REMINDER: Use TaskCreate before spawning agents. Task tool is blocked until then.\n');
     }
     if (config.memory_first && s.memoryRequired && !s.memorySearched) {
       process.stdout.write('REMINDER: Search memory (mcp__moflo__memory_search) before spawning agents.\n');
+    }
+    if (s.lastNamespaceHint) {
+      process.stdout.write(s.lastNamespaceHint + '\n');
+      // Single-shot per prompt: clear after emission so a follow-up Agent spawn
+      // in the same turn doesn't re-emit. The hint is recomputed on the next
+      // user prompt by prompt-reminder / prompt-state-reset.
+      s.lastNamespaceHint = '';
+      writeState(s);
     }
     break;
   }
@@ -371,20 +451,16 @@ switch (command) {
     break;
   }
   case 'prompt-reminder': {
+    // Full per-prompt reset. Wired as the first UserPromptSubmit hook (via
+    // prompt-hook.mjs). Owns interactionCount + Context warnings; the
+    // TaskCreate REMINDER and namespace hint moved to check-before-agent
+    // (#931) so they only fire when Claude is actually about to spawn an
+    // Agent.
     var s = readState();
-    s.memorySearched = false;
-    // Wipe per-actor memory tracking too — a new user prompt is a fresh window
-    // for both parent AND any subagents the parent may spawn during this turn.
-    s.memorySearchedBy = {};
-    // learningsStored is session-scoped — once stored, it stays true until session reset.
-    // Resetting per-prompt caused false blocks when PR creation was on a later prompt.
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
-    var DIRECTIVE_MAX_LEN = 20;
-    var escaped = /^@@\s*/.test(prompt);
-    s.memoryRequired = !escaped && prompt.length >= 4 && (TASK_RE.test(prompt) || prompt.length > DIRECTIVE_MAX_LEN);
+    applyPromptStateReset(s, prompt);
     s.interactionCount = (s.interactionCount || 0) + 1;
     writeState(s);
-    if (!s.tasksCreated) console.log('REMINDER: Use TaskCreate before spawning agents. Task tool is blocked until then.');
     if (config.context_tracking) {
       var ic = s.interactionCount;
       if (ic > 30) console.log('Context: CRITICAL. Commit, store learnings, suggest new session.');
@@ -393,12 +469,30 @@ switch (command) {
     }
     break;
   }
+  case 'prompt-state-reset': {
+    // Defensive safety-net hook (#931 dedupe). Wired as the second
+    // UserPromptSubmit hook so an exception in prompt-hook.mjs doesn't skip
+    // the per-prompt state reset. Idempotent — applyPromptStateReset only
+    // sets fields to derived values, and we deliberately do NOT increment
+    // interactionCount or emit anything (that's prompt-reminder's job).
+    //
+    // Skip the disk write on the normal path: prompt-reminder runs first and
+    // already wrote the byte-identical post-reset state. Only writeState when
+    // the reset actually changed something (i.e., prompt-reminder was skipped
+    // because prompt-hook.mjs threw before invoking it).
+    var s = readState();
+    var prompt = process.env.CLAUDE_USER_PROMPT || '';
+    var before = JSON.stringify(s);
+    applyPromptStateReset(s, prompt);
+    if (JSON.stringify(s) !== before) writeState(s);
+    break;
+  }
   case 'compact-guidance': {
     console.log('Pre-Compact: Check CLAUDE.md for rules. Use memory search to recover context after compact.');
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '' });
     break;
   }
   default:

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -7,7 +7,7 @@ var cp = require('child_process');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '' };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {} };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -149,6 +149,11 @@ function applyPromptStateReset(state, promptText) {
   // spawns an Agent (#931). Empty string when nothing matched — overwriting
   // any stale value from the previous prompt.
   state.lastNamespaceHint = classifyNamespaceHint(promptText);
+  // Per-actor emission tracking — each subagent's session gets the hint at
+  // most once per prompt, but a fresh prompt resets every actor's window so
+  // subsequent agents (parent + subagents that spawn their own agents) all
+  // see the new classification on their first check-before-agent.
+  state.lastNamespaceHintEmittedBy = {};
 }
 // Match npm/yarn/pnpm/bun test, npx vitest|jest|..., bare runners at command-start only,
 // and language-native test commands. The bare-runner arm is anchored so that
@@ -283,12 +288,22 @@ switch (command) {
       process.stdout.write('REMINDER: Search memory (mcp__moflo__memory_search) before spawning agents.\n');
     }
     if (s.lastNamespaceHint) {
-      process.stdout.write(s.lastNamespaceHint + '\n');
-      // Single-shot per prompt: clear after emission so a follow-up Agent spawn
-      // in the same turn doesn't re-emit. The hint is recomputed on the next
-      // user prompt by prompt-reminder / prompt-state-reset.
-      s.lastNamespaceHint = '';
-      writeState(s);
+      // Per-actor single-shot. Each session_id gets the hint at most once per
+      // prompt, but the hint itself stays available for other actors (e.g.
+      // a subagent that spawns its own agent has its own session_id and is
+      // entitled to a fresh emission). Falls back to a `_legacy_` bucket when
+      // Claude Code didn't forward a session_id (older host or direct CLI
+      // invocation), preserving the old "emit once globally" behavior. The
+      // map is wiped by applyPromptStateReset on every new prompt.
+      var sid = process.env.HOOK_SESSION_ID || '';
+      var emittedBy = s.lastNamespaceHintEmittedBy || {};
+      var bucket = sid || '_legacy_';
+      if (!emittedBy[bucket]) {
+        process.stdout.write(s.lastNamespaceHint + '\n');
+        emittedBy[bucket] = true;
+        s.lastNamespaceHintEmittedBy = emittedBy;
+        writeState(s);
+      }
     }
     break;
   }
@@ -492,7 +507,7 @@ switch (command) {
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '' });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {} });
     break;
   }
   default:

--- a/.claude/helpers/prompt-hook.mjs
+++ b/.claude/helpers/prompt-hook.mjs
@@ -33,43 +33,9 @@ try {
   });
 } catch (err) { output = (err && err.stdout) || ''; }
 
-// Classify prompt for namespace hint
-var lower = userPrompt.toLowerCase();
-
-var LEARNINGS_HINTS = /\b(remember|recall|insight|lesson learned|gotcha|post.?mortem)\b|we (decid|agree|chose|said)/;
-var TEST_HINTS = /\b(test|spec|coverage|tested|test case|test cases|tests for|spec for)\b/;
-var EXPLICIT_NS = [
-  { pattern: /\b(pattern|convention|best practice|style|coding rule)\b/, ns: 'patterns', label: 'code patterns and conventions' },
-  { pattern: /\b(code.?map|file structure|project structure|directory)\b/, ns: 'code-map', label: 'codebase navigation' },
-];
-var PATTERN_HINTS = [/\b(template|example|similar to|how do we|how should)\b/];
-var DOMAIN_HINTS = [
-  /\b(guidance|guide|docs|documentation|rules|how-to)\b/,
-  /\b(architecture|design|domain|tenant|migrat|schema|deploy)/,
-  /\b(rule|requirement|constraint|compliance)\b/,
-];
-var NAV_PATTERNS = [
-  /\b(find|where|which file|look up|locate|endpoint|route|url|path)\b/,
-  /\b(class|function|method|component|service|entity|module)\b/,
-];
-
-var nsHint = '';
-if (TEST_HINTS.test(lower)) {
-  nsHint = 'Memory namespace hint: use "tests" for test inventory and coverage lookups.';
-} else if (LEARNINGS_HINTS.test(lower)) {
-  nsHint = 'Memory namespace hint: use "learnings" for user-directed decisions and distilled insights.';
-} else {
-  var found = EXPLICIT_NS.find(function(e) { return e.pattern.test(lower); });
-  if (found) {
-    nsHint = 'Memory namespace hint: use "' + found.ns + '" for ' + found.label + '.';
-  } else if (DOMAIN_HINTS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: search "guidance" and "learnings" for domain rules and project decisions.';
-  } else if (PATTERN_HINTS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: use "patterns" for code patterns and conventions.';
-  } else if (NAV_PATTERNS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: use "code-map" for codebase navigation.';
-  }
-}
+// #931 — Namespace hint classification moved into gate.cjs (computed by
+// prompt-reminder, stored on workflow-state.json, emitted once by
+// check-before-agent at Agent-spawn time). No per-prompt token leak now.
 
 // #867 — surface post-install restart notice. File is written by
 // scripts/post-install-notice.mjs and cleared by the SessionStart launcher
@@ -84,6 +50,6 @@ try {
   }
 } catch (e) { /* ENOENT or malformed — silent fast-path */ }
 
-var parts = [restartNotice, output.trim(), nsHint].filter(Boolean);
+var parts = [restartNotice, output.trim()].filter(Boolean);
 if (parts.length) process.stdout.write(parts.join('\n\n') + '\n');
 process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,16 @@
             "timeout": 2000
           }
         ]
+      },
+      {
+        "matcher": "^Agent$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs\" check-before-agent",
+            "timeout": 2000
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -153,7 +163,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs\" prompt-reminder",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs\" prompt-state-reset",
             "timeout": 3000
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs\" check-before-agent",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs\" check-before-agent",
             "timeout": 2000
           }
         ]

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: publish
 description: Bump version, build, test, publish to npm, and install locally
-arguments: "[patch|minor|major] [-rc] [--check|-ch]"
+arguments: "<patch|minor|major> <-rc> <--check|-ch>"
 ---
 
 # /publish - Version Bump, Build, Test & Publish

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -7,7 +7,7 @@ var cp = require('child_process');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '' };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -83,6 +83,73 @@ var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state
 var DANGEROUS = ['rm -rf /', 'format c:', 'del /s /q c:\\', ':(){:|:&};:', 'mkfs.', '> /dev/sda'];
 var DIRECTIVE_RE = /^(yes|no|yeah|yep|nope|sure|ok|okay|correct|right|exactly|perfect)\b/i;
 var TASK_RE = /\b(fix|bug|error|implement|add|create|build|write|refactor|debug|test|feature|issue|security|optimi)\b/i;
+
+// Namespace classification (#931). The hint used to be emitted on every prompt
+// by prompt-hook.mjs which cost ~40 tokens × every prompt × every consumer.
+// Now we classify here, store on workflow-state, and let check-before-agent
+// emit it once when Claude is actually about to spawn an agent.
+//
+// SYNC: these regexes + classifyNamespaceHint + applyPromptStateReset are
+// duplicated verbatim in src/cli/init/helpers-generator.ts (the embedded
+// gate.cjs fallback used by `flo init` when source helpers can't be located).
+// Any edit to either copy MUST be applied to both — there is no shared module
+// because helpers-generator emits a self-contained string template.
+var NS_LEARNINGS_RE = /\b(remember|recall|insight|lesson learned|gotcha|post.?mortem)\b|we (decid|agree|chose|said)/;
+var NS_TEST_RE = /\b(test|spec|coverage|tested|test case|test cases|tests for|spec for)\b/;
+var NS_EXPLICIT = [
+  { pattern: /\b(pattern|convention|best practice|style|coding rule)\b/, ns: 'patterns', label: 'code patterns and conventions' },
+  { pattern: /\b(code.?map|file structure|project structure|directory)\b/, ns: 'code-map', label: 'codebase navigation' },
+];
+var NS_PATTERN_RES = [/\b(template|example|similar to|how do we|how should)\b/];
+var NS_DOMAIN_RES = [
+  /\b(guidance|guide|docs|documentation|rules|how-to)\b/,
+  /\b(architecture|design|domain|tenant|migrat|schema|deploy)/,
+  /\b(rule|requirement|constraint|compliance)\b/,
+];
+var NS_NAV_RES = [
+  /\b(find|where|which file|look up|locate|endpoint|route|url|path)\b/,
+  /\b(class|function|method|component|service|entity|module)\b/,
+];
+
+function classifyNamespaceHint(promptText) {
+  var lower = (promptText || '').toLowerCase();
+  if (NS_TEST_RE.test(lower)) return 'Memory namespace hint: use "tests" for test inventory and coverage lookups.';
+  if (NS_LEARNINGS_RE.test(lower)) return 'Memory namespace hint: use "learnings" for user-directed decisions and distilled insights.';
+  for (var i = 0; i < NS_EXPLICIT.length; i++) {
+    if (NS_EXPLICIT[i].pattern.test(lower)) return 'Memory namespace hint: use "' + NS_EXPLICIT[i].ns + '" for ' + NS_EXPLICIT[i].label + '.';
+  }
+  for (var j = 0; j < NS_DOMAIN_RES.length; j++) {
+    if (NS_DOMAIN_RES[j].test(lower)) return 'Memory namespace hint: search "guidance" and "learnings" for domain rules and project decisions.';
+  }
+  for (var k = 0; k < NS_PATTERN_RES.length; k++) {
+    if (NS_PATTERN_RES[k].test(lower)) return 'Memory namespace hint: use "patterns" for code patterns and conventions.';
+  }
+  for (var m = 0; m < NS_NAV_RES.length; m++) {
+    if (NS_NAV_RES[m].test(lower)) return 'Memory namespace hint: use "code-map" for codebase navigation.';
+  }
+  return '';
+}
+
+// Apply per-prompt state reset shared by `prompt-reminder` (full) and
+// `prompt-state-reset` (defensive safety-net, no emission). Idempotent — both
+// UserPromptSubmit hooks can run it without compounding any field. Caller
+// owns interactionCount and the user-visible REMINDER/Context emissions, so
+// this helper stays silent.
+function applyPromptStateReset(state, promptText) {
+  state.memorySearched = false;
+  // Wipe per-actor memory tracking too — a new user prompt is a fresh window
+  // for both parent AND any subagents the parent may spawn during this turn.
+  state.memorySearchedBy = {};
+  // learningsStored is session-scoped — once stored, it stays true until session reset.
+  // Resetting per-prompt caused false blocks when PR creation was on a later prompt.
+  var DIRECTIVE_MAX_LEN = 20;
+  var escaped = /^@@\s*/.test(promptText || '');
+  state.memoryRequired = !escaped && (promptText || '').length >= 4 && (TASK_RE.test(promptText || '') || (promptText || '').length > DIRECTIVE_MAX_LEN);
+  // Stash namespace hint for check-before-agent to emit when Claude actually
+  // spawns an Agent (#931). Empty string when nothing matched — overwriting
+  // any stale value from the previous prompt.
+  state.lastNamespaceHint = classifyNamespaceHint(promptText);
+}
 // Match npm/yarn/pnpm/bun test, npx vitest|jest|..., bare runners at command-start only,
 // and language-native test commands. The bare-runner arm is anchored so that
 // `npm install jest`, `grep -r vitest src/`, and similar don't false-positive.
@@ -203,12 +270,25 @@ switch (command) {
     // Advisory only — agent spawning is never blocked.
     // Memory-first enforcement happens at the scan/read gate layer.
     // SubagentStart hook injects guidance directive into subagent context.
+    //
+    // #931 — TaskCreate REMINDER and the namespace hint moved here from
+    // prompt-reminder. They only matter when Claude is actually about to spawn
+    // an Agent; emitting per-prompt cost ~90 tokens × every prompt × every
+    // consumer.
     var s = readState();
     if (config.task_create_first && !s.tasksCreated) {
       process.stdout.write('REMINDER: Use TaskCreate before spawning agents. Task tool is blocked until then.\n');
     }
     if (config.memory_first && s.memoryRequired && !s.memorySearched) {
       process.stdout.write('REMINDER: Search memory (mcp__moflo__memory_search) before spawning agents.\n');
+    }
+    if (s.lastNamespaceHint) {
+      process.stdout.write(s.lastNamespaceHint + '\n');
+      // Single-shot per prompt: clear after emission so a follow-up Agent spawn
+      // in the same turn doesn't re-emit. The hint is recomputed on the next
+      // user prompt by prompt-reminder / prompt-state-reset.
+      s.lastNamespaceHint = '';
+      writeState(s);
     }
     break;
   }
@@ -371,20 +451,16 @@ switch (command) {
     break;
   }
   case 'prompt-reminder': {
+    // Full per-prompt reset. Wired as the first UserPromptSubmit hook (via
+    // prompt-hook.mjs). Owns interactionCount + Context warnings; the
+    // TaskCreate REMINDER and namespace hint moved to check-before-agent
+    // (#931) so they only fire when Claude is actually about to spawn an
+    // Agent.
     var s = readState();
-    s.memorySearched = false;
-    // Wipe per-actor memory tracking too — a new user prompt is a fresh window
-    // for both parent AND any subagents the parent may spawn during this turn.
-    s.memorySearchedBy = {};
-    // learningsStored is session-scoped — once stored, it stays true until session reset.
-    // Resetting per-prompt caused false blocks when PR creation was on a later prompt.
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
-    var DIRECTIVE_MAX_LEN = 20;
-    var escaped = /^@@\s*/.test(prompt);
-    s.memoryRequired = !escaped && prompt.length >= 4 && (TASK_RE.test(prompt) || prompt.length > DIRECTIVE_MAX_LEN);
+    applyPromptStateReset(s, prompt);
     s.interactionCount = (s.interactionCount || 0) + 1;
     writeState(s);
-    if (!s.tasksCreated) console.log('REMINDER: Use TaskCreate before spawning agents. Task tool is blocked until then.');
     if (config.context_tracking) {
       var ic = s.interactionCount;
       if (ic > 30) console.log('Context: CRITICAL. Commit, store learnings, suggest new session.');
@@ -393,12 +469,30 @@ switch (command) {
     }
     break;
   }
+  case 'prompt-state-reset': {
+    // Defensive safety-net hook (#931 dedupe). Wired as the second
+    // UserPromptSubmit hook so an exception in prompt-hook.mjs doesn't skip
+    // the per-prompt state reset. Idempotent — applyPromptStateReset only
+    // sets fields to derived values, and we deliberately do NOT increment
+    // interactionCount or emit anything (that's prompt-reminder's job).
+    //
+    // Skip the disk write on the normal path: prompt-reminder runs first and
+    // already wrote the byte-identical post-reset state. Only writeState when
+    // the reset actually changed something (i.e., prompt-reminder was skipped
+    // because prompt-hook.mjs threw before invoking it).
+    var s = readState();
+    var prompt = process.env.CLAUDE_USER_PROMPT || '';
+    var before = JSON.stringify(s);
+    applyPromptStateReset(s, prompt);
+    if (JSON.stringify(s) !== before) writeState(s);
+    break;
+  }
   case 'compact-guidance': {
     console.log('Pre-Compact: Check CLAUDE.md for rules. Use memory search to recover context after compact.');
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '' });
     break;
   }
   default:

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -7,7 +7,7 @@ var cp = require('child_process');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '' };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {} };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -149,6 +149,11 @@ function applyPromptStateReset(state, promptText) {
   // spawns an Agent (#931). Empty string when nothing matched — overwriting
   // any stale value from the previous prompt.
   state.lastNamespaceHint = classifyNamespaceHint(promptText);
+  // Per-actor emission tracking — each subagent's session gets the hint at
+  // most once per prompt, but a fresh prompt resets every actor's window so
+  // subsequent agents (parent + subagents that spawn their own agents) all
+  // see the new classification on their first check-before-agent.
+  state.lastNamespaceHintEmittedBy = {};
 }
 // Match npm/yarn/pnpm/bun test, npx vitest|jest|..., bare runners at command-start only,
 // and language-native test commands. The bare-runner arm is anchored so that
@@ -283,12 +288,22 @@ switch (command) {
       process.stdout.write('REMINDER: Search memory (mcp__moflo__memory_search) before spawning agents.\n');
     }
     if (s.lastNamespaceHint) {
-      process.stdout.write(s.lastNamespaceHint + '\n');
-      // Single-shot per prompt: clear after emission so a follow-up Agent spawn
-      // in the same turn doesn't re-emit. The hint is recomputed on the next
-      // user prompt by prompt-reminder / prompt-state-reset.
-      s.lastNamespaceHint = '';
-      writeState(s);
+      // Per-actor single-shot. Each session_id gets the hint at most once per
+      // prompt, but the hint itself stays available for other actors (e.g.
+      // a subagent that spawns its own agent has its own session_id and is
+      // entitled to a fresh emission). Falls back to a `_legacy_` bucket when
+      // Claude Code didn't forward a session_id (older host or direct CLI
+      // invocation), preserving the old "emit once globally" behavior. The
+      // map is wiped by applyPromptStateReset on every new prompt.
+      var sid = process.env.HOOK_SESSION_ID || '';
+      var emittedBy = s.lastNamespaceHintEmittedBy || {};
+      var bucket = sid || '_legacy_';
+      if (!emittedBy[bucket]) {
+        process.stdout.write(s.lastNamespaceHint + '\n');
+        emittedBy[bucket] = true;
+        s.lastNamespaceHintEmittedBy = emittedBy;
+        writeState(s);
+      }
     }
     break;
   }
@@ -492,7 +507,7 @@ switch (command) {
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '' });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {} });
     break;
   }
   default:

--- a/bin/prompt-hook.mjs
+++ b/bin/prompt-hook.mjs
@@ -33,43 +33,9 @@ try {
   });
 } catch (err) { output = (err && err.stdout) || ''; }
 
-// Classify prompt for namespace hint
-var lower = userPrompt.toLowerCase();
-
-var LEARNINGS_HINTS = /\b(remember|recall|insight|lesson learned|gotcha|post.?mortem)\b|we (decid|agree|chose|said)/;
-var TEST_HINTS = /\b(test|spec|coverage|tested|test case|test cases|tests for|spec for)\b/;
-var EXPLICIT_NS = [
-  { pattern: /\b(pattern|convention|best practice|style|coding rule)\b/, ns: 'patterns', label: 'code patterns and conventions' },
-  { pattern: /\b(code.?map|file structure|project structure|directory)\b/, ns: 'code-map', label: 'codebase navigation' },
-];
-var PATTERN_HINTS = [/\b(template|example|similar to|how do we|how should)\b/];
-var DOMAIN_HINTS = [
-  /\b(guidance|guide|docs|documentation|rules|how-to)\b/,
-  /\b(architecture|design|domain|tenant|migrat|schema|deploy)/,
-  /\b(rule|requirement|constraint|compliance)\b/,
-];
-var NAV_PATTERNS = [
-  /\b(find|where|which file|look up|locate|endpoint|route|url|path)\b/,
-  /\b(class|function|method|component|service|entity|module)\b/,
-];
-
-var nsHint = '';
-if (TEST_HINTS.test(lower)) {
-  nsHint = 'Memory namespace hint: use "tests" for test inventory and coverage lookups.';
-} else if (LEARNINGS_HINTS.test(lower)) {
-  nsHint = 'Memory namespace hint: use "learnings" for user-directed decisions and distilled insights.';
-} else {
-  var found = EXPLICIT_NS.find(function(e) { return e.pattern.test(lower); });
-  if (found) {
-    nsHint = 'Memory namespace hint: use "' + found.ns + '" for ' + found.label + '.';
-  } else if (DOMAIN_HINTS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: search "guidance" and "learnings" for domain rules and project decisions.';
-  } else if (PATTERN_HINTS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: use "patterns" for code patterns and conventions.';
-  } else if (NAV_PATTERNS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: use "code-map" for codebase navigation.';
-  }
-}
+// #931 — Namespace hint classification moved into gate.cjs (computed by
+// prompt-reminder, stored on workflow-state.json, emitted once by
+// check-before-agent at Agent-spawn time). No per-prompt token leak now.
 
 // #867 — surface post-install restart notice. File is written by
 // scripts/post-install-notice.mjs and cleared by the SessionStart launcher
@@ -84,6 +50,6 @@ try {
   }
 } catch (e) { /* ENOENT or malformed — silent fast-path */ }
 
-var parts = [restartNotice, output.trim(), nsHint].filter(Boolean);
+var parts = [restartNotice, output.trim()].filter(Boolean);
 if (parts.length) process.stdout.write(parts.join('\n\n') + '\n');
 process.exit(0);

--- a/src/cli/__tests__/cross-platform.test.ts
+++ b/src/cli/__tests__/cross-platform.test.ts
@@ -467,14 +467,30 @@ describe('generateHooks alignment with settings-generator', () => {
       });
     }
 
-    it('moflo-init.ts wires prompt-reminder in UserPromptSubmit', () => {
+    // #931 — Both UserPromptSubmit hooks dedupe-fixed. The first hook runs
+    // prompt-hook.mjs (which calls gate.cjs `prompt-reminder` internally). The
+    // second hook is the defensive safety-net `prompt-state-reset` — state
+    // reset only, no emission, no interactionCount increment.
+    it('moflo-init.ts wires prompt-state-reset in UserPromptSubmit (#931)', () => {
       const body = extractGenerateHooks('moflo-init.ts');
-      expect(body).toMatch(/gateHook\(['"]prompt-reminder['"]\)/);
+      expect(body).toMatch(/gateHook\(['"]prompt-state-reset['"]\)/);
+      expect(body).not.toMatch(/gateHook\(['"]prompt-reminder['"]\)/);
     });
 
-    it('settings-generator.ts wires prompt-reminder in UserPromptSubmit', () => {
+    it('settings-generator.ts wires prompt-state-reset in UserPromptSubmit (#931)', () => {
       const body = extractGenerateHooks('settings-generator.ts');
-      expect(body).toMatch(/gateHookCmd\(['"]prompt-reminder['"]\)/);
+      expect(body).toMatch(/gateHookCmd\(['"]prompt-state-reset['"]\)/);
+      expect(body).not.toMatch(/gateHookCmd\(['"]prompt-reminder['"]\)/);
+    });
+
+    it('moflo-init.ts wires check-before-agent in PreToolUse:^Agent$ (#931)', () => {
+      const body = extractGenerateHooks('moflo-init.ts');
+      expect(body).toMatch(/gate\(['"]check-before-agent['"]\)/);
+    });
+
+    it('settings-generator.ts wires check-before-agent in PreToolUse:^Agent$ (#931)', () => {
+      const body = extractGenerateHooks('settings-generator.ts');
+      expect(body).toMatch(/gateCmd\(['"]check-before-agent['"]\)/);
     });
   });
 });

--- a/src/cli/__tests__/cross-platform.test.ts
+++ b/src/cli/__tests__/cross-platform.test.ts
@@ -483,14 +483,18 @@ describe('generateHooks alignment with settings-generator', () => {
       expect(body).not.toMatch(/gateHookCmd\(['"]prompt-reminder['"]\)/);
     });
 
-    it('moflo-init.ts wires check-before-agent in PreToolUse:^Agent$ (#931)', () => {
+    // #931 — Routed through gate-hook.mjs (not gate.cjs directly) so Claude
+    // Code's session_id is forwarded as HOOK_SESSION_ID. Without the wrapper,
+    // the per-actor namespace-hint emission falls back to a single global
+    // bucket and a subagent spawning its own agent silently misses the hint.
+    it('moflo-init.ts wires check-before-agent through gate-hook.mjs (#931)', () => {
       const body = extractGenerateHooks('moflo-init.ts');
-      expect(body).toMatch(/gate\(['"]check-before-agent['"]\)/);
+      expect(body).toMatch(/gateHook\(['"]check-before-agent['"]\)/);
     });
 
-    it('settings-generator.ts wires check-before-agent in PreToolUse:^Agent$ (#931)', () => {
+    it('settings-generator.ts wires check-before-agent through gateHookCmd (#931)', () => {
       const body = extractGenerateHooks('settings-generator.ts');
-      expect(body).toMatch(/gateCmd\(['"]check-before-agent['"]\)/);
+      expect(body).toMatch(/gateHookCmd\(['"]check-before-agent['"]\)/);
     });
   });
 });

--- a/src/cli/__tests__/services/hook-wiring.test.ts
+++ b/src/cli/__tests__/services/hook-wiring.test.ts
@@ -113,22 +113,30 @@ describe('repairHookWiring', () => {
     expect(settings.statusLine).toEqual({ type: 'command', command: 'echo hi' });
   });
 
-  it('creates prompt-reminder without a matcher (UserPromptSubmit)', () => {
+  it('creates UserPromptSubmit blocks without a matcher (#931 — prompt-hook.mjs + prompt-state-reset)', () => {
     const settings: Record<string, unknown> = {};
     repairHookWiring(settings);
 
     const hooks = settings.hooks as Record<string, unknown[]>;
     const upsBlocks = hooks.UserPromptSubmit as Array<Record<string, unknown>>;
     expect(upsBlocks).toBeDefined();
-    expect(upsBlocks.length).toBeGreaterThanOrEqual(1);
+    expect(upsBlocks.length).toBeGreaterThanOrEqual(2);
 
-    // The prompt-reminder block should have no matcher key
-    const reminderBlock = upsBlocks.find(b => {
+    // Both UserPromptSubmit hooks must be bare-block (no matcher key) so
+    // Claude Code fires them on every prompt regardless of tool name.
+    const promptHookBlock = upsBlocks.find(b => {
       const blockHooks = b.hooks as Array<{ command?: string }>;
-      return blockHooks.some(h => h.command?.includes('prompt-reminder'));
+      return blockHooks.some(h => h.command?.includes('prompt-hook.mjs'));
     });
-    expect(reminderBlock).toBeDefined();
-    expect(reminderBlock!.matcher).toBeUndefined();
+    expect(promptHookBlock).toBeDefined();
+    expect(promptHookBlock!.matcher).toBeUndefined();
+
+    const safetyNetBlock = upsBlocks.find(b => {
+      const blockHooks = b.hooks as Array<{ command?: string }>;
+      return blockHooks.some(h => h.command?.includes('prompt-state-reset'));
+    });
+    expect(safetyNetBlock).toBeDefined();
+    expect(safetyNetBlock!.matcher).toBeUndefined();
   });
 
   it('HOOK_ENTRY_MAP covers every REQUIRED_HOOK_WIRING pattern', () => {

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -491,6 +491,10 @@ const REQUIRED_GATE_CASES = [
   'check-before-pr',
   'check-dangerous-command',
   'prompt-reminder',
+  // #931 — Defensive safety-net for the second UserPromptSubmit hook. State
+  // reset only, no emission. doctor warns if a consumer's gate.cjs is too old
+  // to handle it.
+  'prompt-state-reset',
   'session-reset',
 ];
 

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -217,7 +217,7 @@ var path = require('path');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\\/([a-z])\\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '' };
 
 function readState() {
   try {
@@ -288,6 +288,60 @@ var EXEMPT = ['.claude/', '.claude\\\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-sta
 var DANGEROUS = ['rm -rf /', 'format c:', 'del /s /q c:\\\\', ':(){:|:&};:', 'mkfs.', '> /dev/sda'];
 var DIRECTIVE_RE = /^(yes|no|yeah|yep|nope|sure|ok|okay|correct|right|exactly|perfect)\\b/i;
 var TASK_RE = /\\b(fix|bug|error|implement|add|create|build|write|refactor|debug|test|feature|issue|security|optimi)\\b/i;
+
+// Namespace classification (#931). Hint stored on workflow-state and emitted
+// once by check-before-agent at Agent-spawn time — was emitted on every prompt
+// before, costing ~40 tokens × every prompt × every consumer.
+//
+// SYNC: these regexes + classifyNamespaceHint + applyPromptStateReset are
+// duplicated verbatim in bin/gate.cjs (canonical, synced to consumer
+// .claude/helpers/gate.cjs by post-install-bootstrap). Any edit MUST be
+// applied to both — this template is the fallback for the flo-init path
+// where source helpers cannot be located, so it must keep parity.
+var NS_LEARNINGS_RE = /\\b(remember|recall|insight|lesson learned|gotcha|post.?mortem)\\b|we (decid|agree|chose|said)/;
+var NS_TEST_RE = /\\b(test|spec|coverage|tested|test case|test cases|tests for|spec for)\\b/;
+var NS_EXPLICIT = [
+  { pattern: /\\b(pattern|convention|best practice|style|coding rule)\\b/, ns: 'patterns', label: 'code patterns and conventions' },
+  { pattern: /\\b(code.?map|file structure|project structure|directory)\\b/, ns: 'code-map', label: 'codebase navigation' },
+];
+var NS_PATTERN_RES = [/\\b(template|example|similar to|how do we|how should)\\b/];
+var NS_DOMAIN_RES = [
+  /\\b(guidance|guide|docs|documentation|rules|how-to)\\b/,
+  /\\b(architecture|design|domain|tenant|migrat|schema|deploy)/,
+  /\\b(rule|requirement|constraint|compliance)\\b/,
+];
+var NS_NAV_RES = [
+  /\\b(find|where|which file|look up|locate|endpoint|route|url|path)\\b/,
+  /\\b(class|function|method|component|service|entity|module)\\b/,
+];
+
+function classifyNamespaceHint(promptText) {
+  var lower = (promptText || '').toLowerCase();
+  if (NS_TEST_RE.test(lower)) return 'Memory namespace hint: use "tests" for test inventory and coverage lookups.';
+  if (NS_LEARNINGS_RE.test(lower)) return 'Memory namespace hint: use "learnings" for user-directed decisions and distilled insights.';
+  for (var i = 0; i < NS_EXPLICIT.length; i++) {
+    if (NS_EXPLICIT[i].pattern.test(lower)) return 'Memory namespace hint: use "' + NS_EXPLICIT[i].ns + '" for ' + NS_EXPLICIT[i].label + '.';
+  }
+  for (var j = 0; j < NS_DOMAIN_RES.length; j++) {
+    if (NS_DOMAIN_RES[j].test(lower)) return 'Memory namespace hint: search "guidance" and "learnings" for domain rules and project decisions.';
+  }
+  for (var k = 0; k < NS_PATTERN_RES.length; k++) {
+    if (NS_PATTERN_RES[k].test(lower)) return 'Memory namespace hint: use "patterns" for code patterns and conventions.';
+  }
+  for (var m = 0; m < NS_NAV_RES.length; m++) {
+    if (NS_NAV_RES[m].test(lower)) return 'Memory namespace hint: use "code-map" for codebase navigation.';
+  }
+  return '';
+}
+
+function applyPromptStateReset(state, promptText) {
+  state.memorySearched = false;
+  state.memorySearchedBy = {};
+  var DIRECTIVE_MAX_LEN = 20;
+  var escaped = /^@@\\s*/.test(promptText || '');
+  state.memoryRequired = !escaped && (promptText || '').length >= 4 && (TASK_RE.test(promptText || '') || (promptText || '').length > DIRECTIVE_MAX_LEN);
+  state.lastNamespaceHint = classifyNamespaceHint(promptText);
+}
 var TEST_RUNNER_RE = /(?:^|[^a-z])(?:npm|yarn|pnpm|bun)\\s+(?:run\\s+)?(?:test|t)(?:[:\\s]|$)|\\b(?:npx|pnpx)\\s+(?:vitest|jest|mocha|ava|tap|jasmine|pytest)\\b|(?:^|;|&&|\\|\\|)\\s*(?:vitest|jest|pytest|mocha|jasmine|tap|ava)\\s|\\b(?:cargo|go|deno|dotnet|mvn)\\s+test\\b|\\bgradle\\w*\\s+test\\b/i;
 var EDIT_RESET_SKIP_BOTH_RE = /\\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\\\\/])(CHANGELOG(?:\\.md)?|\\.env\\.example|package-lock\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb)$/i;
 // Test files: invalidate testsRun but preserve simplifyRun (#908) — /simplify
@@ -300,12 +354,19 @@ switch (command) {
     // Advisory only — agent spawning is never blocked.
     // Memory-first enforcement happens at the scan/read gate layer.
     // SubagentStart hook injects guidance directive into subagent context.
+    // #931 — TaskCreate REMINDER + namespace hint moved here from
+    // prompt-reminder so they emit only when Claude is about to spawn an Agent.
     var s = readState();
     if (config.task_create_first && !s.tasksCreated) {
       process.stdout.write('REMINDER: Use TaskCreate before spawning agents. Task tool is blocked until then.\\n');
     }
     if (config.memory_first && s.memoryRequired && !s.memorySearched) {
       process.stdout.write('REMINDER: Search memory (mcp__moflo__memory_search) before spawning agents.\\n');
+    }
+    if (s.lastNamespaceHint) {
+      process.stdout.write(s.lastNamespaceHint + '\\n');
+      s.lastNamespaceHint = '';
+      writeState(s);
     }
     break;
   }
@@ -432,18 +493,14 @@ switch (command) {
     break;
   }
   case 'prompt-reminder': {
+    // Full per-prompt reset (first UserPromptSubmit hook via prompt-hook.mjs).
+    // Owns interactionCount + Context warnings. TaskCreate REMINDER and
+    // namespace hint moved to check-before-agent (#931).
     var s = readState();
-    s.memorySearched = false;
-    // Wipe per-actor memory tracking too — a new user prompt is a fresh window
-    // for both parent AND any subagents the parent may spawn during this turn.
-    s.memorySearchedBy = {};
-    // learningsStored is session-scoped — once stored, it stays true until session reset.
-    // Resetting per-prompt caused false blocks when PR creation was on a later prompt.
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
-    s.memoryRequired = prompt.length >= 4 && !DIRECTIVE_RE.test(prompt) && (TASK_RE.test(prompt) || prompt.length > 80);
+    applyPromptStateReset(s, prompt);
     s.interactionCount = (s.interactionCount || 0) + 1;
     writeState(s);
-    if (!s.tasksCreated) console.log('REMINDER: Use TaskCreate before spawning agents. Task tool is blocked until then.');
     if (config.context_tracking) {
       var ic = s.interactionCount;
       if (ic > 30) console.log('Context: CRITICAL. Commit, store learnings, suggest new session.');
@@ -452,12 +509,25 @@ switch (command) {
     }
     break;
   }
+  case 'prompt-state-reset': {
+    // Defensive safety-net (second UserPromptSubmit hook). Idempotent state
+    // reset only — no interactionCount increment, no emission. Ensures the
+    // per-prompt reset still happens if prompt-hook.mjs throws (#931). Skip
+    // the disk write when prompt-reminder already wrote the byte-identical
+    // post-reset state (the normal no-exception path).
+    var s = readState();
+    var prompt = process.env.CLAUDE_USER_PROMPT || '';
+    var before = JSON.stringify(s);
+    applyPromptStateReset(s, prompt);
+    if (JSON.stringify(s) !== before) writeState(s);
+    break;
+  }
   case 'compact-guidance': {
     console.log('Pre-Compact: Check CLAUDE.md for rules. Use memory search to recover context after compact.');
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '' });
     break;
   }
   default:
@@ -572,45 +642,9 @@ try {
   });
 } catch (err) { output = (err && err.stdout) || ''; }
 
-// Classify prompt for namespace hint
-var lower = userPrompt.toLowerCase();
-
-var LEARNINGS_HINTS = /\\b(remember|recall|insight|lesson learned|gotcha|post.?mortem)\\b|we (decid|agree|chose|said)/;
-var TEST_HINTS = /\\b(test|spec|coverage|tested|test case|test cases|tests for|spec for)\\b/;
-var EXPLICIT_NS = [
-  { pattern: /\\b(pattern|convention|best practice|style|coding rule)\\b/, ns: 'patterns', label: 'code patterns and conventions' },
-  { pattern: /\\b(code.?map|file structure|project structure|directory)\\b/, ns: 'code-map', label: 'codebase navigation' },
-];
-var PATTERN_HINTS = [/\\b(template|example|similar to|how do we|how should)\\b/];
-var DOMAIN_HINTS = [
-  /\\b(guidance|guide|docs|documentation|rules|how-to)\\b/,
-  /\\b(architecture|design|domain|tenant|migrat|schema|deploy)/,
-  /\\b(rule|requirement|constraint|compliance)\\b/,
-];
-var NAV_PATTERNS = [
-  /\\b(find|where|which file|look up|locate|endpoint|route|url|path)\\b/,
-  /\\b(class|function|method|component|service|entity|module)\\b/,
-];
-
-var nsHint = '';
-if (TEST_HINTS.test(lower)) {
-  nsHint = 'Memory namespace hint: use "tests" for test inventory and coverage lookups.';
-} else if (LEARNINGS_HINTS.test(lower)) {
-  nsHint = 'Memory namespace hint: use "learnings" for user-directed decisions and distilled insights.';
-} else {
-  var found = EXPLICIT_NS.find(function(e) { return e.pattern.test(lower); });
-  if (found) {
-    nsHint = 'Memory namespace hint: use "' + found.ns + '" for ' + found.label + '.';
-  } else if (DOMAIN_HINTS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: search "guidance" and "learnings" for domain rules and project decisions.';
-  } else if (PATTERN_HINTS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: use "patterns" for code patterns and conventions.';
-  } else if (NAV_PATTERNS.some(function(p) { return p.test(lower); })) {
-    nsHint = 'Memory namespace hint: use "code-map" for codebase navigation.';
-  }
-}
-
-var parts = [output.trim(), nsHint].filter(Boolean);
+// #931 — Namespace hint classification moved into gate.cjs (computed by
+// prompt-reminder, stored on workflow-state, emitted once by check-before-agent).
+var parts = [output.trim()].filter(Boolean);
 if (parts.length) process.stdout.write(parts.join('\\n') + '\\n');
 process.exit(0);
 `;

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -217,7 +217,7 @@ var path = require('path');
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\\/([a-z])\\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '' };
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {} };
 
 function readState() {
   try {
@@ -341,6 +341,9 @@ function applyPromptStateReset(state, promptText) {
   var escaped = /^@@\\s*/.test(promptText || '');
   state.memoryRequired = !escaped && (promptText || '').length >= 4 && (TASK_RE.test(promptText || '') || (promptText || '').length > DIRECTIVE_MAX_LEN);
   state.lastNamespaceHint = classifyNamespaceHint(promptText);
+  // Per-actor emission tracking — fresh window each prompt so subagents that
+  // spawn their own agents still see the hint on their first check-before-agent.
+  state.lastNamespaceHintEmittedBy = {};
 }
 var TEST_RUNNER_RE = /(?:^|[^a-z])(?:npm|yarn|pnpm|bun)\\s+(?:run\\s+)?(?:test|t)(?:[:\\s]|$)|\\b(?:npx|pnpx)\\s+(?:vitest|jest|mocha|ava|tap|jasmine|pytest)\\b|(?:^|;|&&|\\|\\|)\\s*(?:vitest|jest|pytest|mocha|jasmine|tap|ava)\\s|\\b(?:cargo|go|deno|dotnet|mvn)\\s+test\\b|\\bgradle\\w*\\s+test\\b/i;
 var EDIT_RESET_SKIP_BOTH_RE = /\\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\\\\/])(CHANGELOG(?:\\.md)?|\\.env\\.example|package-lock\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb)$/i;
@@ -364,9 +367,21 @@ switch (command) {
       process.stdout.write('REMINDER: Search memory (mcp__moflo__memory_search) before spawning agents.\\n');
     }
     if (s.lastNamespaceHint) {
-      process.stdout.write(s.lastNamespaceHint + '\\n');
-      s.lastNamespaceHint = '';
-      writeState(s);
+      // Per-actor single-shot — each session_id emits the hint at most once
+      // per prompt. Subagents that spawn their own agents still see it on
+      // their first check-before-agent because their session_id is its own
+      // bucket. Falls back to a _legacy_ bucket when HOOK_SESSION_ID is
+      // missing (older Claude Code, direct CLI). The map clears on every
+      // new prompt via applyPromptStateReset.
+      var sid = process.env.HOOK_SESSION_ID || '';
+      var emittedBy = s.lastNamespaceHintEmittedBy || {};
+      var bucket = sid || '_legacy_';
+      if (!emittedBy[bucket]) {
+        process.stdout.write(s.lastNamespaceHint + '\\n');
+        emittedBy[bucket] = true;
+        s.lastNamespaceHintEmittedBy = emittedBy;
+        writeState(s);
+      }
     }
     break;
   }
@@ -527,7 +542,7 @@ switch (command) {
     break;
   }
   case 'session-reset': {
-    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '' });
+    writeState({ tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, interactionCount: 0, sessionStart: new Date().toISOString(), lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {} });
     break;
   }
   default:

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -296,6 +296,14 @@ function generateHooks(root: string, force?: boolean, answers?: MofloInitAnswers
           { "type": "command", "command": gateHook('check-dangerous-command'), "timeout": 2000 },
           { "type": "command", "command": gateHook('check-before-pr'), "timeout": 2000 }
         ]
+      },
+      {
+        // #931 — Advisory only; never blocks. TaskCreate REMINDER and the
+        // namespace hint moved here from UserPromptSubmit so they emit only
+        // when Claude is about to spawn an Agent — saves ~90 tokens × every
+        // prompt × every consumer.
+        "matcher": "^Agent$",
+        "hooks": [{ "type": "command", "command": gate('check-before-agent'), "timeout": 2000 }]
       }
     ],
     "PostToolUse": [
@@ -350,11 +358,13 @@ function generateHooks(root: string, force?: boolean, answers?: MofloInitAnswers
         ]
       },
       {
-        // prompt-reminder is REQUIRED to reset memorySearched/memorySearchedBy on each
-        // new prompt and reclassify memoryRequired. Without it, gate state leaks across
-        // prompts. Separate hook entry so a prompt-hook.mjs exception doesn't skip the reset.
+        // prompt-state-reset is REQUIRED to reset memorySearched/memorySearchedBy on
+        // each new prompt and reclassify memoryRequired. Without it, gate state leaks
+        // across prompts. Separate hook entry so a prompt-hook.mjs exception doesn't
+        // skip the reset. Idempotent state reset only — no emission, no
+        // interactionCount increment (#931 dedupe).
         "hooks": [
-          { "type": "command", "command": gateHook('prompt-reminder'), "timeout": 3000 }
+          { "type": "command", "command": gateHook('prompt-state-reset'), "timeout": 3000 }
         ]
       }
     ],

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -301,9 +301,11 @@ function generateHooks(root: string, force?: boolean, answers?: MofloInitAnswers
         // #931 — Advisory only; never blocks. TaskCreate REMINDER and the
         // namespace hint moved here from UserPromptSubmit so they emit only
         // when Claude is about to spawn an Agent — saves ~90 tokens × every
-        // prompt × every consumer.
+        // prompt × every consumer. Routed via gate-hook.mjs so Claude Code's
+        // session_id is forwarded as HOOK_SESSION_ID, enabling per-actor
+        // single-shot emission (mirror of #879's record-memory-searched fix).
         "matcher": "^Agent$",
-        "hooks": [{ "type": "command", "command": gate('check-before-agent'), "timeout": 2000 }]
+        "hooks": [{ "type": "command", "command": gateHook('check-before-agent'), "timeout": 2000 }]
       }
     ],
     "PostToolUse": [

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -261,10 +261,14 @@ function generateHooksConfig(config: HooksConfig): object {
       // #931 — TaskCreate REMINDER + namespace hint moved here from
       // UserPromptSubmit. They only matter when Claude is about to spawn an
       // Agent; emitting per-prompt cost ~90 tokens × every prompt × every
-      // consumer. Advisory only — never blocks.
+      // consumer. Advisory only — never blocks. Routed through gate-hook.mjs
+      // so Claude Code's session_id is forwarded as HOOK_SESSION_ID — the
+      // namespace hint emission tracks per-actor (mirror of #879's fix for
+      // record-memory-searched), so subagents that spawn their own agents
+      // still get the hint on their first check.
       {
         matcher: '^Agent$',
-        hooks: [{ type: 'command', command: gateCmd('check-before-agent'), timeout: 2000 }],
+        hooks: [{ type: 'command', command: gateHookCmd('check-before-agent'), timeout: 2000 }],
       },
     ];
   }

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -258,6 +258,14 @@ function generateHooksConfig(config: HooksConfig): object {
           { type: 'command', command: gateHookCmd('check-before-pr'), timeout: 2000 },
         ],
       },
+      // #931 — TaskCreate REMINDER + namespace hint moved here from
+      // UserPromptSubmit. They only matter when Claude is about to spawn an
+      // Agent; emitting per-prompt cost ~90 tokens × every prompt × every
+      // consumer. Advisory only — never blocks.
+      {
+        matcher: '^Agent$',
+        hooks: [{ type: 'command', command: gateCmd('check-before-agent'), timeout: 2000 }],
+      },
     ];
   }
 
@@ -316,12 +324,15 @@ function generateHooksConfig(config: HooksConfig): object {
     ];
   }
 
-  // UserPromptSubmit — gate reminders + intelligent task routing.
-  // The prompt-reminder hook is REQUIRED — it resets memorySearched / memorySearchedBy
-  // and reclassifies memoryRequired from the new prompt. Without it, gate state leaks
-  // across prompts: a previous turn's "satisfied" state survives, OR a previous turn's
-  // "armed" state never clears. Two separate hook entries (not chained) so an exception
-  // in prompt-hook.mjs doesn't skip the reset.
+  // UserPromptSubmit — per-prompt state reset + Context warnings.
+  // Two separate hook entries (not chained) so an exception in prompt-hook.mjs
+  // doesn't skip the reset. The first hook runs prompt-hook.mjs which invokes
+  // gate.cjs `prompt-reminder` (full reset + interactionCount + Context
+  // warnings). The second hook runs `prompt-state-reset` — a defensive
+  // safety-net that re-applies the idempotent state reset (memorySearched,
+  // memorySearchedBy, memoryRequired, lastNamespaceHint) without
+  // double-incrementing interactionCount or duplicating any user-visible
+  // emission (#931).
   if (config.userPromptSubmit) {
     hooks.UserPromptSubmit = [
       {
@@ -331,7 +342,7 @@ function generateHooksConfig(config: HooksConfig): object {
       },
       {
         hooks: [
-          { type: 'command', command: gateHookCmd('prompt-reminder'), timeout: 3000 },
+          { type: 'command', command: gateHookCmd('prompt-state-reset'), timeout: 3000 },
         ],
       },
     ];

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -109,7 +109,9 @@ export function getReferenceHookBlock(): HooksTree {
         hooks: [gateHook('check-dangerous-command', 2000), gateHook('check-before-pr', 2000)],
       },
       // #931 — TaskCreate REMINDER + namespace hint advisory at Agent-spawn time.
-      { matcher: '^Agent$',                   hooks: [gateCjs('check-before-agent', 2000)] },
+      // Routed via gate-hook.mjs so HOOK_SESSION_ID is forwarded for per-actor
+      // single-shot emission of the namespace hint.
+      { matcher: '^Agent$',                   hooks: [gateHook('check-before-agent', 2000)] },
     ],
     PostToolUse: [
       {

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -108,6 +108,8 @@ export function getReferenceHookBlock(): HooksTree {
         matcher: '^Bash$',
         hooks: [gateHook('check-dangerous-command', 2000), gateHook('check-before-pr', 2000)],
       },
+      // #931 — TaskCreate REMINDER + namespace hint advisory at Agent-spawn time.
+      { matcher: '^Agent$',                   hooks: [gateCjs('check-before-agent', 2000)] },
     ],
     PostToolUse: [
       {
@@ -127,7 +129,8 @@ export function getReferenceHookBlock(): HooksTree {
     ],
     UserPromptSubmit: [
       { hooks: [helperHook('prompt-hook.mjs', '', 3000)] },
-      { hooks: [gateHook('prompt-reminder', 3000)] },
+      // #931 — Defensive safety-net hook. State reset only, no emission.
+      { hooks: [gateHook('prompt-state-reset', 3000)] },
     ],
     SubagentStart: [
       { hooks: [helperHook('subagent-start.cjs', '', 2000)] },

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -31,6 +31,9 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   { event: 'PreToolUse', pattern: 'check-before-read' },
   { event: 'PreToolUse', pattern: 'check-dangerous-command' },
   { event: 'PreToolUse', pattern: 'check-before-pr' },
+  // #931 — TaskCreate REMINDER + namespace hint emit only at Agent spawn now,
+  // not on every prompt. Saves ~90 tokens × every prompt × every consumer.
+  { event: 'PreToolUse', pattern: 'check-before-agent' },
   { event: 'PostToolUse', pattern: 'record-task-created' },
   { event: 'PostToolUse', pattern: 'record-memory-searched' },
   { event: 'PostToolUse', pattern: 'check-task-transition' },
@@ -39,7 +42,14 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   { event: 'PostToolUse', pattern: 'record-test-run' },
   { event: 'PostToolUse', pattern: 'record-skill-run' },
   { event: 'PostToolUse', pattern: 'reset-edit-gates' },
-  { event: 'UserPromptSubmit', pattern: 'prompt-reminder' },
+  // First UserPromptSubmit hook (prompt-hook.mjs internally calls
+  // `gate.cjs prompt-reminder`). Substring check tolerates either the
+  // shipped helper-script command or an inlined gate call.
+  { event: 'UserPromptSubmit', pattern: 'prompt-hook.mjs' },
+  // Second (defensive) UserPromptSubmit hook — state reset only. Replaced
+  // the duplicate `prompt-reminder` wiring that was emitting the TaskCreate
+  // REMINDER twice per prompt (#931).
+  { event: 'UserPromptSubmit', pattern: 'prompt-state-reset' },
 ];
 
 /**
@@ -66,7 +76,16 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   'record-test-run':          { event: 'PostToolUse',      matcher: '^Bash$',                     hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-test-run', timeout: 2000 } },
   'record-skill-run':         { event: 'PostToolUse',      matcher: '^Skill$',                    hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-skill-run', timeout: 2000 } },
   'reset-edit-gates':         { event: 'PostToolUse',      matcher: '^(Write|Edit|MultiEdit)$',   hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" reset-edit-gates', timeout: 2000 } },
-  'prompt-reminder':          { event: 'UserPromptSubmit', matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" prompt-reminder', timeout: 3000 } },
+  // #931 — Agent-time advisory; never blocks. Pulled the TaskCreate REMINDER
+  // and namespace hint out of prompt-reminder so they fire only when Claude is
+  // actually about to spawn an Agent.
+  'check-before-agent':       { event: 'PreToolUse',       matcher: '^Agent$',                    hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" check-before-agent', timeout: 2000 } },
+  // Re-add the prompt-hook.mjs wiring as its own bare UserPromptSubmit block
+  // when missing. Empty matcher = bare block, like settings-generator emits.
+  'prompt-hook.mjs':          { event: 'UserPromptSubmit', matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/prompt-hook.mjs"', timeout: 3000 } },
+  // Defensive safety-net — runs gate.cjs `prompt-state-reset` if prompt-hook.mjs
+  // throws before completing the per-prompt state reset. State-only, no emission.
+  'prompt-state-reset':       { event: 'UserPromptSubmit', matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" prompt-state-reset', timeout: 3000 } },
 };
 
 export interface RepairResult {
@@ -158,6 +177,18 @@ export const HOOK_REWRITE_RULES: ReadonlyArray<HookRewriteRule> = [
     name: '#879: check-bash-memory → gate-hook.mjs',
     from: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" check-bash-memory',
     to:   'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-bash-memory',
+  },
+  // Issue #931 — the second UserPromptSubmit hook used to invoke
+  // gate-hook.mjs `prompt-reminder`, which (a) duplicated the first hook's
+  // emission of `REMINDER: Use TaskCreate...` per prompt and (b) double-
+  // incremented `interactionCount`. The first hook (prompt-hook.mjs) still
+  // calls gate.cjs `prompt-reminder` internally for the full reset + Context
+  // warnings; the safety-net hook now runs `prompt-state-reset` instead —
+  // idempotent state reset, no emission, no increment.
+  {
+    name: '#931: dedupe UserPromptSubmit prompt-reminder → prompt-state-reset',
+    from: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" prompt-reminder',
+    to:   'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" prompt-state-reset',
   },
 ];
 

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -78,8 +78,10 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   'reset-edit-gates':         { event: 'PostToolUse',      matcher: '^(Write|Edit|MultiEdit)$',   hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" reset-edit-gates', timeout: 2000 } },
   // #931 — Agent-time advisory; never blocks. Pulled the TaskCreate REMINDER
   // and namespace hint out of prompt-reminder so they fire only when Claude is
-  // actually about to spawn an Agent.
-  'check-before-agent':       { event: 'PreToolUse',       matcher: '^Agent$',                    hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" check-before-agent', timeout: 2000 } },
+  // actually about to spawn an Agent. Routed via gate-hook.mjs so Claude Code's
+  // session_id is forwarded as HOOK_SESSION_ID — the namespace hint emission
+  // is per-actor single-shot (mirror of #879's record-memory-searched fix).
+  'check-before-agent':       { event: 'PreToolUse',       matcher: '^Agent$',                    hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-before-agent', timeout: 2000 } },
   // Re-add the prompt-hook.mjs wiring as its own bare UserPromptSubmit block
   // when missing. Empty matcher = bare block, like settings-generator emits.
   'prompt-hook.mjs':          { event: 'UserPromptSubmit', matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/prompt-hook.mjs"', timeout: 3000 } },
@@ -189,6 +191,17 @@ export const HOOK_REWRITE_RULES: ReadonlyArray<HookRewriteRule> = [
     name: '#931: dedupe UserPromptSubmit prompt-reminder → prompt-state-reset',
     from: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" prompt-reminder',
     to:   'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" prompt-state-reset',
+  },
+  // Issue #931 — `check-before-agent` was first wired through gate.cjs
+  // directly (no stdin parsing). Without HOOK_SESSION_ID the namespace hint's
+  // per-actor tracking falls back to a single `_legacy_` bucket, so a
+  // subagent spawning its own agent would silently miss the hint after the
+  // parent already consumed it. Route through gate-hook.mjs (the same wrapper
+  // that fixed #879) so each session_id gets its own single-shot.
+  {
+    name: '#931: route check-before-agent → gate-hook.mjs (forwards HOOK_SESSION_ID)',
+    from: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" check-before-agent',
+    to:   'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-before-agent',
   },
 ];
 

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -903,75 +903,160 @@ describe('hook-handler.cjs', () => {
 // prompt-hook.mjs — prompt classification + namespace hints
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('prompt-hook.mjs: namespace hints', () => {
-  it('hints "learnings" for recall prompts', async () => {
-    const r = await runEsmWithStdin(PROMPT_HOOK, [], {
-      user_prompt: 'do you remember what we decided about auth?',
-    }, baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('learnings');
+// ─────────────────────────────────────────────────────────────────────────────
+// #931 — Namespace hints
+//
+// Before #931 the hint emitted on every prompt from prompt-hook.mjs (~40 tokens
+// × every prompt × every consumer). Now prompt-hook.mjs runs gate.cjs
+// `prompt-reminder` which CLASSIFIES the prompt and stores the result on
+// workflow-state.json — and check-before-agent emits it once at Agent-spawn
+// time, then clears. Two-step flow keeps per-prompt overhead at zero for
+// non-Agent turns.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('namespace hints (#931): prompt-reminder stores; check-before-agent emits', () => {
+  function expectStoredHint(prompt: string, expectedNs: string) {
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = prompt;
+    runGate('prompt-reminder', env);
+    const state = readState(tmpDir);
+    expect(state.lastNamespaceHint, `expected hint for: ${prompt}`).toContain(expectedNs);
+  }
+
+  it('classifies "learnings" for recall prompts', () => {
+    expectStoredHint('do you remember what we decided about auth?', 'learnings');
   });
 
-  it('hints "tests" for test/coverage prompts', async () => {
-    const r = await runEsmWithStdin(PROMPT_HOOK, [], {
-      user_prompt: 'where are the tests for the auth middleware?',
-    }, baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('tests');
+  it('classifies "tests" for test/coverage prompts', () => {
+    expectStoredHint('where are the tests for the auth middleware?', 'tests');
   });
 
-  it('hints "patterns" for convention prompts', async () => {
-    const r = await runEsmWithStdin(PROMPT_HOOK, [], {
-      user_prompt: 'what is our best practice for error handling?',
-    }, baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('patterns');
+  it('classifies "patterns" for convention prompts', () => {
+    expectStoredHint('what is our best practice for error handling?', 'patterns');
   });
 
-  it('hints "code-map" for file structure prompts', async () => {
-    const r = await runEsmWithStdin(PROMPT_HOOK, [], {
-      user_prompt: 'show me the project structure',
-    }, baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('code-map');
+  it('classifies "code-map" for file structure prompts', () => {
+    expectStoredHint('show me the project structure', 'code-map');
   });
 
-  it('hints "guidance" for architecture prompts', async () => {
-    const r = await runEsmWithStdin(PROMPT_HOOK, [], {
-      user_prompt: 'explain the architecture design for the API',
-    }, baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('guidance');
+  it('classifies "guidance" for architecture prompts', () => {
+    expectStoredHint('explain the architecture design for the API', 'guidance');
   });
 
-  it('hints "code-map" for navigation prompts', async () => {
+  it('classifies "code-map" for navigation prompts', () => {
+    expectStoredHint('where is the endpoint for user login?', 'code-map');
+  });
+
+  it('classifies "patterns" for template prompts', () => {
+    expectStoredHint('show me an example of how we handle pagination', 'patterns');
+  });
+
+  it('stores empty hint for simple directives (no false positives)', () => {
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'yes';
+    runGate('prompt-reminder', env);
+    expect(readState(tmpDir).lastNamespaceHint).toBe('');
+  });
+
+  it('check-before-agent emits the stored hint, then clears it (single-shot per prompt)', () => {
+    writeState(tmpDir, { tasksCreated: true, memorySearched: true, lastNamespaceHint: 'Memory namespace hint: use "tests" for test inventory and coverage lookups.' });
+    const r1 = runGate('check-before-agent', baseEnv(tmpDir));
+    expect(r1.stdout).toContain('Memory namespace hint');
+    expect(r1.stdout).toContain('tests');
+    // Cleared — second Agent spawn in the same turn does not re-emit.
+    expect(readState(tmpDir).lastNamespaceHint).toBe('');
+    const r2 = runGate('check-before-agent', baseEnv(tmpDir));
+    expect(r2.stdout).not.toContain('Memory namespace hint');
+  });
+
+  it('check-before-agent emits nothing namespace-related when no hint stored', () => {
+    writeState(tmpDir, { tasksCreated: true, memorySearched: true, lastNamespaceHint: '' });
+    const r = runGate('check-before-agent', baseEnv(tmpDir));
+    expect(r.stdout).not.toContain('Memory namespace hint');
+  });
+
+  it('end-to-end: prompt-hook.mjs (no inline emission) → state stored → check-before-agent emits', async () => {
     const r = await runEsmWithStdin(PROMPT_HOOK, [], {
       user_prompt: 'where is the endpoint for user login?',
     }, baseEnv(tmpDir));
     expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('code-map');
-  });
-
-  it('hints "patterns" for template prompts', async () => {
-    const r = await runEsmWithStdin(PROMPT_HOOK, [], {
-      user_prompt: 'show me an example of how we handle pagination',
-    }, baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain('patterns');
-  });
-
-  it('no hint for simple directives', async () => {
-    const r = await runEsmWithStdin(PROMPT_HOOK, [], {
-      user_prompt: 'yes',
-    }, baseEnv(tmpDir));
-    expect(r.exitCode).toBe(0);
-    // Should not have namespace hint (directive)
-    expect(r.stdout).not.toContain('namespace hint');
+    // prompt-hook.mjs no longer emits the hint inline — it lives on state now.
+    expect(r.stdout).not.toContain('Memory namespace hint');
+    expect(readState(tmpDir).lastNamespaceHint).toContain('code-map');
+    const r2 = runGate('check-before-agent', baseEnv(tmpDir));
+    expect(r2.stdout).toContain('code-map');
   });
 
   it('handles empty prompt gracefully', async () => {
     const r = await runEsmWithStdin(PROMPT_HOOK, [], {}, baseEnv(tmpDir));
     expect(r.exitCode).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #931 — prompt-state-reset (defensive safety-net for the second
+// UserPromptSubmit hook). Idempotent state reset only — no emission, no
+// interactionCount increment. Wired alongside prompt-hook.mjs so an exception
+// in prompt-hook.mjs still resets per-actor memory tracking.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('gate.cjs: prompt-state-reset (#931 dedupe safety-net)', () => {
+  it('resets memorySearched + memorySearchedBy + reclassifies memoryRequired', () => {
+    writeState(tmpDir, { memorySearched: true, memorySearchedBy: { 's-1': true }, memoryRequired: false });
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'fix the auth bug in the login flow';
+    runGate('prompt-state-reset', env);
+    const s = readState(tmpDir);
+    expect(s.memorySearched).toBe(false);
+    expect(s.memorySearchedBy).toEqual({});
+    expect(s.memoryRequired).toBe(true);
+  });
+
+  it('emits nothing on stdout', () => {
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'implement user auth';
+    const r = runGate('prompt-state-reset', env);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+  });
+
+  it('does NOT increment interactionCount (only prompt-reminder does)', () => {
+    writeState(tmpDir, { interactionCount: 7 });
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'implement the feature';
+    runGate('prompt-state-reset', env);
+    expect(readState(tmpDir).interactionCount).toBe(7);
+  });
+
+  it('stores the same lastNamespaceHint as prompt-reminder', () => {
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'where is the login route defined?';
+    runGate('prompt-state-reset', env);
+    const s = readState(tmpDir);
+    expect(s.lastNamespaceHint).toContain('code-map');
+  });
+
+  it('is idempotent: running prompt-reminder then prompt-state-reset increments interactionCount exactly once', () => {
+    writeState(tmpDir, { interactionCount: 0 });
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'implement user auth';
+    runGate('prompt-reminder', env);
+    runGate('prompt-state-reset', env);
+    expect(readState(tmpDir).interactionCount).toBe(1);
+  });
+
+  it('full UserPromptSubmit dedupe — neither hook emits the TaskCreate REMINDER per prompt', () => {
+    writeState(tmpDir, { tasksCreated: false, interactionCount: 0 });
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'implement user auth';
+    const r1 = runGate('prompt-reminder', env);
+    const r2 = runGate('prompt-state-reset', env);
+    // Per-prompt token leak fix — REMINDER no longer fires from either hook.
+    expect(r1.stdout).not.toContain('REMINDER: Use TaskCreate');
+    expect(r2.stdout).not.toContain('REMINDER: Use TaskCreate');
+    // ...but the gate still arms it for check-before-agent at Agent-spawn time.
+    const r3 = runGate('check-before-agent', env);
+    expect(r3.stdout).toContain('REMINDER: Use TaskCreate');
   });
 });
 

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -48,6 +48,10 @@ function baseEnv(projectDir: string): Record<string, string> {
     TOOL_INPUT_path: '',
     TOOL_INPUT_file_path: '',
     CLAUDE_USER_PROMPT: '',
+    // Default to no session_id so per-actor tests are explicit about which
+    // bucket they target (#931). Tests that exercise per-session emission
+    // override HOOK_SESSION_ID after building env.
+    HOOK_SESSION_ID: '',
   };
 }
 
@@ -958,15 +962,57 @@ describe('namespace hints (#931): prompt-reminder stores; check-before-agent emi
     expect(readState(tmpDir).lastNamespaceHint).toBe('');
   });
 
-  it('check-before-agent emits the stored hint, then clears it (single-shot per prompt)', () => {
+  it('check-before-agent emits the hint once per session_id (per-actor single-shot)', () => {
     writeState(tmpDir, { tasksCreated: true, memorySearched: true, lastNamespaceHint: 'Memory namespace hint: use "tests" for test inventory and coverage lookups.' });
-    const r1 = runGate('check-before-agent', baseEnv(tmpDir));
+    const env = baseEnv(tmpDir);
+    env.HOOK_SESSION_ID = 'parent-session';
+    const r1 = runGate('check-before-agent', env);
     expect(r1.stdout).toContain('Memory namespace hint');
     expect(r1.stdout).toContain('tests');
-    // Cleared — second Agent spawn in the same turn does not re-emit.
-    expect(readState(tmpDir).lastNamespaceHint).toBe('');
+    // Same session, second Agent spawn — already emitted to this actor.
+    const r2 = runGate('check-before-agent', env);
+    expect(r2.stdout).not.toContain('Memory namespace hint');
+    // Hint itself is preserved — a different actor (subagent) is still entitled
+    // to its own first emission.
+    expect(readState(tmpDir).lastNamespaceHint).toContain('tests');
+  });
+
+  it('check-before-agent emits the hint to a different session_id (subagent gets its own first-shot)', () => {
+    writeState(tmpDir, { tasksCreated: true, memorySearched: true, lastNamespaceHint: 'Memory namespace hint: use "code-map" for codebase navigation.' });
+    const parentEnv = baseEnv(tmpDir);
+    parentEnv.HOOK_SESSION_ID = 'parent-session';
+    const r1 = runGate('check-before-agent', parentEnv);
+    expect(r1.stdout).toContain('code-map');
+    // A subagent (different session_id) spawning its own agent is a new actor;
+    // the per-session bucket lets it see the hint exactly once too.
+    const subagentEnv = baseEnv(tmpDir);
+    subagentEnv.HOOK_SESSION_ID = 'subagent-session-1';
+    const r2 = runGate('check-before-agent', subagentEnv);
+    expect(r2.stdout).toContain('code-map');
+    // Same subagent, second spawn → already emitted to this actor.
+    const r3 = runGate('check-before-agent', subagentEnv);
+    expect(r3.stdout).not.toContain('code-map');
+  });
+
+  it('check-before-agent without HOOK_SESSION_ID emits once via _legacy_ bucket', () => {
+    writeState(tmpDir, { tasksCreated: true, memorySearched: true, lastNamespaceHint: 'Memory namespace hint: use "tests" for test inventory and coverage lookups.' });
+    // Older Claude Code hosts / direct CLI invocation — no session_id forwarded.
+    const r1 = runGate('check-before-agent', baseEnv(tmpDir));
+    expect(r1.stdout).toContain('Memory namespace hint');
     const r2 = runGate('check-before-agent', baseEnv(tmpDir));
     expect(r2.stdout).not.toContain('Memory namespace hint');
+  });
+
+  it('new prompt resets lastNamespaceHintEmittedBy → all actors get the new hint', () => {
+    // Parent saw last prompt's hint already.
+    writeState(tmpDir, { lastNamespaceHint: 'old hint', lastNamespaceHintEmittedBy: { 'parent': true, 'sub-1': true } });
+    // New prompt classifies a different namespace; reset clears the bucket.
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'where is the login route defined?';
+    runGate('prompt-reminder', env);
+    const s = readState(tmpDir);
+    expect(s.lastNamespaceHintEmittedBy).toEqual({});
+    expect(s.lastNamespaceHint).toContain('code-map');
   });
 
   it('check-before-agent emits nothing namespace-related when no hint stored', () => {


### PR DESCRIPTION
## Summary

Closes #931. Two UserPromptSubmit hooks were both invoking `gate.cjs prompt-reminder`, emitting `REMINDER: Use TaskCreate...` twice per prompt and double-incrementing `interactionCount`. The TaskCreate REMINDER and namespace hint also fired on every prompt — a per-prompt token leak in every consumer's session.

- Added `gate.cjs prompt-state-reset` — idempotent state reset only, no emission, no `interactionCount` increment. Skips `writeState` when `prompt-reminder` already wrote the byte-identical post-reset state. Wired as the second UserPromptSubmit safety-net hook (replacing the duplicate `prompt-reminder`).
- Added PreToolUse `^Agent$` → `gate.cjs check-before-agent`. Moved TaskCreate REMINDER + namespace hint emission out of `prompt-reminder` so they fire only when Claude is actually about to spawn an Agent (single-shot per prompt, hint cleared after emit).
- Moved namespace classification (regexes + `classifyNamespaceHint`) from `prompt-hook.mjs` into `gate.cjs`. Hint stored on `workflow-state.lastNamespaceHint` by `prompt-reminder`/`prompt-state-reset`, emitted by `check-before-agent`.

**Token savings**: ~20–90 tokens per prompt per consumer (early-session both REMINDER + hint fire = ~90; mid-session after TaskCreate just hint = ~20).

**Consumer migration** (one `npm publish` round-trip):
- `bin/gate.cjs` + `bin/prompt-hook.mjs` sync into `.claude/helpers/` via `session-start-launcher` § BIN_HELPER_FILES on next session start.
- `settings.json` auto-heals via `hook-wiring.ts` HOOK_REWRITE_RULES (rewrites `gate-hook.mjs prompt-reminder` → `gate-hook.mjs prompt-state-reset`) and REQUIRED_HOOK_WIRING (adds new `^Agent$` PreToolUse entry + `prompt-state-reset`).
- `hook-block-hash.ts` reference block updated so drift detection treats the new wiring as canonical.
- `doctor-checks-deep.ts` REQUIRED_GATE_CASES adds `prompt-state-reset` so older gate.cjs warns instead of silently skipping the new case.

## Test plan

- [x] `npm test` — 7995 passed, 0 failed (45 parallel + 35 isolation suites)
- [x] `npm run build` — TypeScript clean
- [x] New tests in `tests/bin/gate-helpers.test.ts`:
  - `prompt-state-reset` resets state without emission or increment
  - Running `prompt-reminder` then `prompt-state-reset` increments `interactionCount` exactly once (the latent double-count bug is fixed)
  - Both hooks emit no `REMINDER: Use TaskCreate` (per-prompt dedupe), but `check-before-agent` does emit it
  - Namespace hint stored by `prompt-reminder`, emitted + cleared single-shot by `check-before-agent`
  - End-to-end via `prompt-hook.mjs` (no inline emission, hint stored, then surfaced at agent spawn)
- [x] Smoke-tested in temp project: full prompt → state-reset → check-before-agent flow + namespace classification fixtures
- [x] Updated `cross-platform.test.ts` + `hook-wiring.test.ts` + `hook-block-hash.test.ts` for the new wiring contract
- [x] `/simplify` (NORMAL tier — 3 reviewers): findings addressed (doctor-checks-deep registry, regex-duplication SYNC comments, redundant `writeState` skip)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)