### PR TITLE
fix(#934): consumer-bound CLAUDE.md path fix + dedup three CLAUDE.md generators

### DIFF
--- a/.claude/guidance/internal/consumer-bound-references.md
+++ b/.claude/guidance/internal/consumer-bound-references.md
@@ -1,0 +1,107 @@
+# Consumer-Bound Cross-Reference Paths
+
+**Purpose:** Rule for any text that Claude will read on a consumer's machine — guidance See Also sections, skill SKILL.md links, injected CLAUDE.md templates, runtime subagent directives, and anything else that ships in the npm package and tells Claude to read a file. The destination filesystem layout on a consumer is not the same as moflo's own dogfood tree, and using `shipped/` in cross-references silently produces ENOENT for every consumer.
+
+---
+
+## The Rule
+
+**Consumer-bound references to a moflo guidance doc MUST use `.claude/guidance/<file>.md`. They MUST NOT use `.claude/guidance/shipped/<file>.md`.**
+
+The `shipped/` segment is a SOURCE-tree artifact inside moflo's package. It is never created as a destination directory on a consumer project.
+
+---
+
+## Why
+
+On a consumer machine after `npm install moflo` + first session-start, the on-disk layout is:
+
+| Path | Exists? | Notes |
+|------|---------|-------|
+| `<consumer-root>/.claude/guidance/moflo-<file>.md` | yes | Mirror written by `bin/session-start-launcher.mjs` and `src/cli/init/moflo-init.ts`. Both write the auto-generated header at the top. |
+| `<consumer-root>/.claude/guidance/shipped/` | **no** | Never created. The `shipped/` token only ever appears as a SOURCE segment inside `node_modules/moflo/.claude/guidance/shipped/`. |
+| `<consumer-root>/node_modules/moflo/.claude/guidance/shipped/moflo-<file>.md` | yes | Read-only inside `node_modules`. Not what Claude resolves when the user's CLAUDE.md says `.claude/guidance/shipped/...`. |
+
+A path written `.claude/guidance/shipped/<file>.md` resolves relative to the consumer's project root, not their `node_modules/moflo`. The Read tool returns ENOENT.
+
+The bug is invisible inside moflo's own dogfooding repo because the source `shipped/` directory IS at the project root there. That mirror-vs-source asymmetry is exactly why this rule exists.
+
+---
+
+## Where the rule applies
+
+| Surface | Ships to consumers? | Rule |
+|---------|---------------------|------|
+| `.claude/guidance/shipped/**/*.md` (See Also + inline refs) | yes (synced to `<root>/.claude/guidance/`) | use `.claude/guidance/<file>.md` |
+| `.claude/skills/**/*.md` (any path-bearing string) | yes (synced to `<root>/.claude/skills/`) | use `.claude/guidance/<file>.md` |
+| `.claude/agents/**/*.md` | yes | use `.claude/guidance/<file>.md` |
+| `.claude/commands/**/*.md` | yes | use `.claude/guidance/<file>.md` |
+| `.claude/helpers/subagent-bootstrap.json` (`directive` field) | yes (read at every subagent spawn on consumer) | use `.claude/guidance/<file>.md` |
+| `src/cli/services/subagent-bootstrap.ts` (`FALLBACK_DIRECTIVE`) | runs on consumer | use `.claude/guidance/<file>.md` |
+| `src/cli/init/claudemd-generator.ts` (injected template strings) | injected into consumer's CLAUDE.md | use `.claude/guidance/<file>.md` |
+| `src/cli/init/moflo-init.ts` (`generateClaudeMd` template) | same | use `.claude/guidance/<file>.md` |
+| `bin/setup-project.mjs` (CLAUDE.md template) | injected into consumer's CLAUDE.md | use `.claude/guidance/<file>.md` |
+| `.claude/guidance/internal/**/*.md` | **no** (dev-only) | `shipped/<file>.md` is fine — only resolved inside moflo's repo |
+| moflo's own `CLAUDE.md` (root, `src/cli/CLAUDE.md`, etc.) | no (not in npm package) | `shipped/<file>.md` is fine |
+| `bin/*.mjs` log/error strings describing source paths | runs on consumer | OK to mention `node_modules/moflo/.claude/guidance/shipped/...` as descriptive context — that path exists |
+
+---
+
+## Exceptions (intentional `shipped/` references in shipped content)
+
+A handful of shipped docs reference `shipped/` deliberately as descriptive context — they describe moflo's package layout to the consumer rather than telling Claude to read a file. Keep these:
+
+- `shipped/moflo-settings-injection.md` — describes the read-only `.claude/guidance/shipped/**` directory inside `node_modules/moflo`.
+- `shipped/moflo-session-start.md` — explains the launcher copies from `node_modules/moflo/.claude/guidance/shipped/` to the consumer's `.claude/guidance/`.
+- `shipped/moflo-source-hygiene.md` — moflo-developer guidance about where to place new shipped files (debatable whether this should ship at all, but the path it references is correct as-is).
+
+The distinguishing test: **does the path follow the word "see", "read", "reference", or appear in a See Also bullet?** Then it's a directive Claude will try to resolve, and it must be the consumer path. If it's inside descriptive prose explaining "moflo lays out its source tree this way", `shipped/` is fine.
+
+---
+
+## Anti-patterns
+
+```markdown
+<!-- WRONG — ENOENT on every consumer -->
+- `.claude/guidance/shipped/moflo-core-guidance.md` — CLI reference
+
+<!-- RIGHT -->
+- `.claude/guidance/moflo-core-guidance.md` — CLI reference
+```
+
+```ts
+// WRONG — injected into consumer's CLAUDE.md
+const ref = '.claude/guidance/shipped/moflo-core-guidance.md';
+
+// RIGHT
+const ref = '.claude/guidance/moflo-core-guidance.md';
+```
+
+```json
+// WRONG — every subagent on a consumer reads this string
+{ "directive": "... follow `.claude/guidance/shipped/moflo-subagents.md` protocol." }
+
+// RIGHT
+{ "directive": "... follow `.claude/guidance/moflo-subagents.md` protocol." }
+```
+
+---
+
+## Authoring checklist (applies to any change)
+
+Before committing any change that touches a path-bearing string in shipped content:
+
+1. Is the file under `.claude/guidance/shipped/`, `.claude/skills/`, `.claude/agents/`, `.claude/commands/`, `.claude/helpers/`, or a source file that injects into consumer CLAUDE.md / subagent context?
+2. Does the change reference `.claude/guidance/shipped/`?
+3. If both yes, is it descriptive context (an exception above) or a directive? If directive — strip the `shipped/`.
+
+A periodic grep is the cheapest enforcement: `grep -rn '.claude/guidance/shipped/' .claude/guidance/shipped/ .claude/skills/ src/cli/init/ bin/ .claude/helpers/` should only return the documented exceptions.
+
+---
+
+## See Also
+
+- `.claude/guidance/internal/guidance-rules.md` — Moflo-only extensions to universal guidance rules; rule 2 covers the ship-vs-local partition that this rule operationalizes for cross-references
+- `.claude/guidance/internal/consumer-project-paths.md` — Sibling rule for `bin/*.mjs` script path resolution on consumer projects
+- `.claude/guidance/internal/guidance-sync.md` — How shipped guidance moves from moflo's repo into a consumer's `.claude/guidance/`; the source of truth for what destination layout this rule assumes
+- `.claude/guidance/shipped/moflo-settings-injection.md` — Consumer-facing description of what moflo writes into `.claude/`; one of the legitimate `shipped/` descriptive references

--- a/.claude/guidance/internal/guidance-rules.md
+++ b/.claude/guidance/internal/guidance-rules.md
@@ -28,7 +28,7 @@ Consumer projects writing their OWN guidance do NOT use this prefix; the prefix 
 
 **Gitignore must target only the top-level mirror.** Use `/.claude/guidance/*.md` — a bare `.claude/guidance/` will silently swallow `shipped/` and `internal/` too, and the failure is invisible because `npm pack` ships from the working tree (not git), so a fresh CI clone publishes an incomplete `shipped/` set.
 
-**CLAUDE.md cross-references should point to `shipped/` paths**, not the top-level mirror. The mirror only exists once session-start has run; `shipped/` is the durable source.
+**Consumer-bound cross-references must use the top-level mirror path** — `.claude/guidance/<file>.md`, not `.claude/guidance/shipped/<file>.md`. The `shipped/` segment only exists at the moflo source root and inside `node_modules/moflo/`; it is never created as a destination directory on a consumer project, so a `shipped/`-prefixed path 404s for every consumer. This applies to injected CLAUDE.md templates, See Also sections in shipped guidance, shipped skill SKILL.md files, and the runtime subagent directive. Internal docs (`.claude/guidance/internal/**`) MAY continue to use `shipped/` paths because they only execute inside moflo's own repo. See `internal/consumer-bound-references.md` for the full rule, exceptions list, and authoring checklist.
 
 ---
 
@@ -87,6 +87,7 @@ This is rarer and riskier — only do it when you're sure no consumer relies on 
 - `.claude/guidance/internal/dogfooding.md` — The shipped-vs-internal partition this doc enforces, framed from the dogfood loop's perspective
 - `.claude/guidance/internal/upgrade-contract.md` — Where the "user never re-runs init" invariant for guidance sync is defined
 - `.claude/guidance/internal/coding-style.md` — Sibling style rules but for source code; both files share the imperative/concrete/specific posture
+- `.claude/guidance/internal/consumer-bound-references.md` — Operational rule for path-bearing strings in shipped content (See Also links, injected templates, runtime directives) — required reading before editing any cross-reference
 - `.claude/guidance/shipped/moflo-memory-strategy.md` — Companion shipped doc on writing guidance that indexes well for RAG (consumer audience)
 - `.claude/guidance/shipped/moflo-session-start.md` — Where shipped guidance gets synced to consumer projects (and why the `moflo-` prefix matters there)
 - `.claude/guidance/internal/guidance-sync.md` — Three-layer sync pipeline (filesystem → DB → HNSW); the chunking decisions in the universal rules feed Layer 2's behavior

--- a/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
+++ b/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
@@ -384,7 +384,7 @@ npx flo swarm init --topology hierarchical-mesh --max-agents 15 --strategy speci
 
 ## Subagent Context Rules
 
-**Subagents automatically receive guidance via the `SubagentStart` hook.** When any subagent spawns, the hook injects a directive telling it to read `.claude/guidance/shipped/moflo-subagents.md` before doing any work. This is centralized — no per-agent configuration needed.
+**Subagents automatically receive guidance via the `SubagentStart` hook.** When any subagent spawns, the hook injects a directive telling it to read `.claude/guidance/moflo-subagents.md` before doing any work. This is centralized — no per-agent configuration needed.
 
 **What subagents receive automatically:**
 - `SubagentStart` hook directive to read subagent protocol guidance

--- a/.claude/guidance/shipped/moflo-cli-reference.md
+++ b/.claude/guidance/shipped/moflo-cli-reference.md
@@ -193,9 +193,9 @@ npx flo daemon start
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-core-guidance.md` — Hub: getting started, MCP setup, troubleshooting, comparison table
-- `.claude/guidance/shipped/moflo-yaml-reference.md` — `moflo.yaml` schema and runtime env-var overrides for the surfaces listed here
-- `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` — How TaskCreate + swarm coordinators cooperate (uses the agent codes above)
-- `.claude/guidance/shipped/moflo-subagents.md` — Subagent memory-first protocol and store-back rules
-- `.claude/guidance/shipped/moflo-memory-strategy.md` — Memory namespaces, RAG linking, and search query patterns
-- `.claude/guidance/shipped/moflo-memorydb-maintenance.md` — How the namespaces above are populated and refreshed
+- `.claude/guidance/moflo-core-guidance.md` — Hub: getting started, MCP setup, troubleshooting, comparison table
+- `.claude/guidance/moflo-yaml-reference.md` — `moflo.yaml` schema and runtime env-var overrides for the surfaces listed here
+- `.claude/guidance/moflo-claude-swarm-cohesion.md` — How TaskCreate + swarm coordinators cooperate (uses the agent codes above)
+- `.claude/guidance/moflo-subagents.md` — Subagent memory-first protocol and store-back rules
+- `.claude/guidance/moflo-memory-strategy.md` — Memory namespaces, RAG linking, and search query patterns
+- `.claude/guidance/moflo-memorydb-maintenance.md` — How the namespaces above are populated and refreshed

--- a/.claude/guidance/shipped/moflo-core-guidance.md
+++ b/.claude/guidance/shipped/moflo-core-guidance.md
@@ -298,14 +298,14 @@ See `moflo-memory-strategy.md` for memory-specific troubleshooting.
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-cli-reference.md` — CLI commands, agents, hooks, hive-mind, RuVector
-- `.claude/guidance/shipped/moflo-yaml-reference.md` — `moflo.yaml` schema, environment variables, `.mcp.json` setup
-- `.claude/guidance/shipped/moflo-subagents.md` — Subagents memory-first protocol and store patterns
-- `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` — Task & swarm coordination with TaskCreate/TaskUpdate
-- `.claude/guidance/shipped/moflo-memory-strategy.md` — Database schema, namespaces, search commands, RAG linking
-- `.claude/guidance/shipped/moflo-memorydb-maintenance.md` — Reindexing, namespace purging, recovery
-- `.claude/guidance/shipped/moflo-memory-hygiene.md` — When and how to retire stale auto-memory entries (every entry costs per-prompt tokens)
-- `.claude/guidance/shipped/moflo-session-start.md` — Complete session-start lifecycle (DB heal, sync, migrations, daemon)
-- `.claude/guidance/shipped/moflo-settings-injection.md` — What moflo writes into `.claude/` and how surgical self-heal works
-- `.claude/guidance/shipped/moflo-cross-platform.md` — Windows/macOS/Linux portability rules for any code change
-- `.claude/guidance/shipped/moflo-verbose-command-filtering.md` — Filter long verbose commands at the source; never tee-then-grep
+- `.claude/guidance/moflo-cli-reference.md` — CLI commands, agents, hooks, hive-mind, RuVector
+- `.claude/guidance/moflo-yaml-reference.md` — `moflo.yaml` schema, environment variables, `.mcp.json` setup
+- `.claude/guidance/moflo-subagents.md` — Subagents memory-first protocol and store patterns
+- `.claude/guidance/moflo-claude-swarm-cohesion.md` — Task & swarm coordination with TaskCreate/TaskUpdate
+- `.claude/guidance/moflo-memory-strategy.md` — Database schema, namespaces, search commands, RAG linking
+- `.claude/guidance/moflo-memorydb-maintenance.md` — Reindexing, namespace purging, recovery
+- `.claude/guidance/moflo-memory-hygiene.md` — When and how to retire stale auto-memory entries (every entry costs per-prompt tokens)
+- `.claude/guidance/moflo-session-start.md` — Complete session-start lifecycle (DB heal, sync, migrations, daemon)
+- `.claude/guidance/moflo-settings-injection.md` — What moflo writes into `.claude/` and how surgical self-heal works
+- `.claude/guidance/moflo-cross-platform.md` — Windows/macOS/Linux portability rules for any code change
+- `.claude/guidance/moflo-verbose-command-filtering.md` — Filter long verbose commands at the source; never tee-then-grep

--- a/.claude/guidance/shipped/moflo-cross-platform.md
+++ b/.claude/guidance/shipped/moflo-cross-platform.md
@@ -163,4 +163,4 @@ Before submitting any code change, verify:
 ## See Also
 
 - `CLAUDE.md` — Consumer project checklist, build rules
-- `.claude/guidance/shipped/moflo-source-hygiene.md` — Source code hygiene rules
+- `.claude/guidance/moflo-source-hygiene.md` — Source code hygiene rules

--- a/.claude/guidance/shipped/moflo-error-handling.md
+++ b/.claude/guidance/shipped/moflo-error-handling.md
@@ -70,5 +70,5 @@ if (!result.ok) syncFailures.push({ key, message: `${errMessage(result.err)} (re
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-source-hygiene.md` — General source code standards
-- `.claude/guidance/shipped/moflo-cross-platform.md` — Cross-platform rules
+- `.claude/guidance/moflo-source-hygiene.md` — General source code standards
+- `.claude/guidance/moflo-cross-platform.md` — Cross-platform rules

--- a/.claude/guidance/shipped/moflo-guidance-rules.md
+++ b/.claude/guidance/shipped/moflo-guidance-rules.md
@@ -137,8 +137,8 @@ Use relative names (not absolute paths) so the links work across project context
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-memory-strategy.md` — Companion rules on namespaces, RAG indexing, and search patterns the data feeds
-- `.claude/guidance/shipped/moflo-task-icons.md` — UX rule for `TaskCreate` and `Agent` description fields (ICON + [Role])
-- `.claude/guidance/shipped/moflo-user-facing-language.md` — How to phrase any text shown to end users (plain risk-level language, no jargon)
-- `.claude/guidance/shipped/moflo-subagents.md` — Memory-first protocol any guidance you write should reinforce
+- `.claude/guidance/moflo-memory-strategy.md` — Companion rules on namespaces, RAG indexing, and search patterns the data feeds
+- `.claude/guidance/moflo-task-icons.md` — UX rule for `TaskCreate` and `Agent` description fields (ICON + [Role])
+- `.claude/guidance/moflo-user-facing-language.md` — How to phrase any text shown to end users (plain risk-level language, no jargon)
+- `.claude/guidance/moflo-subagents.md` — Memory-first protocol any guidance you write should reinforce
 - `.claude/skills/guidance/SKILL.md` — `/guidance` skill that helps you author or audit guidance against these rules

--- a/.claude/guidance/shipped/moflo-memory-hygiene.md
+++ b/.claude/guidance/shipped/moflo-memory-hygiene.md
@@ -140,7 +140,7 @@ These are non-negotiable framing rules. Even if their original incident is years
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-memory-strategy.md` — Architecture of moflo's *project* memory system (different from the user's auto-memory, but related)
-- `.claude/guidance/shipped/moflo-guidance-rules.md` — Universal rules for writing any guidance file; memory entries follow similar imperative-voice + concrete-example posture
-- `.claude/guidance/shipped/moflo-session-start.md` — Where the `auto-memory-hook.mjs` lives and how it loads MEMORY.md every prompt
-- `.claude/guidance/shipped/moflo-core-guidance.md` — Hub doc that links to this file from its memory section
+- `.claude/guidance/moflo-memory-strategy.md` — Architecture of moflo's *project* memory system (different from the user's auto-memory, but related)
+- `.claude/guidance/moflo-guidance-rules.md` — Universal rules for writing any guidance file; memory entries follow similar imperative-voice + concrete-example posture
+- `.claude/guidance/moflo-session-start.md` — Where the `auto-memory-hook.mjs` lives and how it loads MEMORY.md every prompt
+- `.claude/guidance/moflo-core-guidance.md` — Hub doc that links to this file from its memory section

--- a/.claude/guidance/shipped/moflo-memorydb-maintenance.md
+++ b/.claude/guidance/shipped/moflo-memorydb-maintenance.md
@@ -131,8 +131,8 @@ flo memory restore-learnings --from .swarm/memory.db.bak
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-memory-strategy.md` — When to use which namespace; semantic search query patterns
-- `.claude/guidance/shipped/moflo-core-guidance.md` — `flo memory` CLI subcommands and `flo doctor` output
-- `.claude/guidance/shipped/moflo-session-start.md` — Where the auto-reindex chain runs in the launcher lifecycle
-- `.claude/guidance/shipped/moflo-subagents.md` — Memory-first protocol that depends on these indexes being healthy
+- `.claude/guidance/moflo-memory-strategy.md` — When to use which namespace; semantic search query patterns
+- `.claude/guidance/moflo-core-guidance.md` — `flo memory` CLI subcommands and `flo doctor` output
+- `.claude/guidance/moflo-session-start.md` — Where the auto-reindex chain runs in the launcher lifecycle
+- `.claude/guidance/moflo-subagents.md` — Memory-first protocol that depends on these indexes being healthy
 - `.claude/guidance/internal/guidance-sync.md` — Internal: how guidance content actually flows from `shipped/` into the DB and out to search (three-layer pipeline + cleanup paths)

--- a/.claude/guidance/shipped/moflo-source-hygiene.md
+++ b/.claude/guidance/shipped/moflo-source-hygiene.md
@@ -98,6 +98,6 @@ Before creating any new source file, verify:
 ## See Also
 
 - `CLAUDE.md` — Project-wide rules, consumer project checklist
-- `.claude/guidance/shipped/moflo-guidance-rules.md` — Rules for writing guidance docs
+- `.claude/guidance/moflo-guidance-rules.md` — Rules for writing guidance docs
 - `docs/BUILD.md` — Build and publish process
 - `docs/adr/0001-collapse-moflo-workspace-packages.md` — The ADR that documents the collapse

--- a/.claude/guidance/shipped/moflo-spell-connectors.md
+++ b/.claude/guidance/shipped/moflo-spell-connectors.md
@@ -128,6 +128,6 @@ If you do need one:
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-spell-sandboxing.md` — CapabilityGateway and enforcement rules
-- `.claude/guidance/shipped/moflo-spell-engine.md` — Running spells, step command types
-- `.claude/guidance/shipped/moflo-spell-engine-architecture.md` — Architecture decisions
+- `.claude/guidance/moflo-spell-sandboxing.md` — CapabilityGateway and enforcement rules
+- `.claude/guidance/moflo-spell-engine.md` — Running spells, step command types
+- `.claude/guidance/moflo-spell-engine-architecture.md` — Architecture decisions

--- a/.claude/guidance/shipped/moflo-spell-custom-steps.md
+++ b/.claude/guidance/shipped/moflo-spell-custom-steps.md
@@ -120,7 +120,7 @@ const runner = createRunner({
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-spell-engine.md` — Built-in step types, spell definition format, runner lifecycle, error codes
-- `.claude/guidance/shipped/moflo-spell-sandboxing.md` — Capability declarations a custom step must include and how the sandbox enforces them
-- `.claude/guidance/shipped/moflo-spell-connectors.md` — When to write a connector instead of a custom step (resource-shaped vs. action-shaped extension)
-- `.claude/guidance/shipped/moflo-spell-engine-architecture.md` — Architecture decisions for the pluggable step loader
+- `.claude/guidance/moflo-spell-engine.md` — Built-in step types, spell definition format, runner lifecycle, error codes
+- `.claude/guidance/moflo-spell-sandboxing.md` — Capability declarations a custom step must include and how the sandbox enforces them
+- `.claude/guidance/moflo-spell-connectors.md` — When to write a connector instead of a custom step (resource-shaped vs. action-shaped extension)
+- `.claude/guidance/moflo-spell-engine-architecture.md` — Architecture decisions for the pluggable step loader

--- a/.claude/guidance/shipped/moflo-spell-engine-architecture.md
+++ b/.claude/guidance/shipped/moflo-spell-engine-architecture.md
@@ -140,6 +140,6 @@ Stories #101-#108, #105, #117 have no dependency on Epic #110.
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-core-guidance.md` — CLI, hooks, swarm, memory reference
-- `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` — Task & swarm coordination
-- `.claude/guidance/shipped/moflo-subagents.md` — Subagents protocol
+- `.claude/guidance/moflo-core-guidance.md` — CLI, hooks, swarm, memory reference
+- `.claude/guidance/moflo-claude-swarm-cohesion.md` — Task & swarm coordination
+- `.claude/guidance/moflo-subagents.md` — Subagents protocol

--- a/.claude/guidance/shipped/moflo-spell-engine.md
+++ b/.claude/guidance/shipped/moflo-spell-engine.md
@@ -15,7 +15,7 @@
 | `CAPABILITY_DENIED` means stop | Do not attempt workarounds — report the denial and halt the step |
 | No improvisation between steps | Do not perform actions outside of step boundaries, even if "obvious" (e.g., do not auto-fix a failing step's output before passing it to the next step unless the spell defines a step for that) |
 
-See `.claude/guidance/shipped/moflo-spell-sandboxing.md` for the full Execution Constraint Principle and capability type reference.
+See `.claude/guidance/moflo-spell-sandboxing.md` for the full Execution Constraint Principle and capability type reference.
 
 ---
 
@@ -407,9 +407,9 @@ Credential values listed in `RunnerOptions.credentialValues` are automatically r
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-spell-custom-steps.md` — Pluggable step commands: JS/TS, YAML, and `moflo-step-*` npm packages
-- `.claude/guidance/shipped/moflo-spell-connectors.md` — Connectors: resource adapters, registry, step-vs-connector decision
-- `.claude/guidance/shipped/moflo-spell-sandboxing.md` — Capability-based security for steps
-- `.claude/guidance/shipped/moflo-spell-engine-architecture.md` — Architecture decisions for Epic #100
-- `.claude/guidance/shipped/moflo-core-guidance.md` — CLI, hooks, swarm, memory reference
-- `.claude/guidance/shipped/moflo-subagents.md` — Subagents protocol
+- `.claude/guidance/moflo-spell-custom-steps.md` — Pluggable step commands: JS/TS, YAML, and `moflo-step-*` npm packages
+- `.claude/guidance/moflo-spell-connectors.md` — Connectors: resource adapters, registry, step-vs-connector decision
+- `.claude/guidance/moflo-spell-sandboxing.md` — Capability-based security for steps
+- `.claude/guidance/moflo-spell-engine-architecture.md` — Architecture decisions for Epic #100
+- `.claude/guidance/moflo-core-guidance.md` — CLI, hooks, swarm, memory reference
+- `.claude/guidance/moflo-subagents.md` — Subagents protocol

--- a/.claude/guidance/shipped/moflo-spell-sandboxing.md
+++ b/.claude/guidance/shipped/moflo-spell-sandboxing.md
@@ -300,10 +300,10 @@ Or declare the `net` capability explicitly if the step doesn't need the full `el
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-spell-engine.md` — Spell engine usage and YAML format
-- `.claude/guidance/shipped/moflo-spell-connectors.md` — Optional resource adapters (not the enforcement layer)
-- `.claude/guidance/shipped/moflo-spell-engine-architecture.md` — Engine architecture and messaging
-- `.claude/guidance/shipped/moflo-core-guidance.md` — Full CLI/MCP reference
+- `.claude/guidance/moflo-spell-engine.md` — Spell engine usage and YAML format
+- `.claude/guidance/moflo-spell-connectors.md` — Optional resource adapters (not the enforcement layer)
+- `.claude/guidance/moflo-spell-engine-architecture.md` — Engine architecture and messaging
+- `.claude/guidance/moflo-core-guidance.md` — Full CLI/MCP reference
 - `src/cli/spells/core/permission-resolver.ts` — Capability → permission level derivation
 - `src/cli/spells/core/permission-disclosure.ts` — Risk classification and reporting
 - `src/cli/spells/core/permission-acceptance.ts` — Acceptance storage and gate

--- a/.claude/guidance/shipped/moflo-subagents.md
+++ b/.claude/guidance/shipped/moflo-subagents.md
@@ -106,7 +106,7 @@ This applies to ALL `gh` commands that target a repo: `pr create`, `pr merge`, `
 
 ### Task Icons (MANDATORY)
 - `TaskCreate` MUST use **ICON + [Role]** in `subject` and `activeForm`
-- Full icon map: `.claude/guidance/shipped/moflo-task-icons.md`
+- Full icon map: `.claude/guidance/moflo-task-icons.md`
 - Example: `🧪 [Tester] Run unit tests` / activeForm: `🧪 Running unit tests`
 
 ---
@@ -143,8 +143,8 @@ npx flo memory store --namespace patterns --key "brief-descriptive-key" --value 
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-task-icons.md` — Mandatory ICON + [Role] format for every `TaskCreate` and `Agent` description spawned by a coordinator
-- `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` — How task lists and swarm coordinators cooperate when subagents are spawned in batches
-- `.claude/guidance/shipped/moflo-memory-strategy.md` — The memory-search-first rule this protocol enforces, with namespace-selection guidance
-- `.claude/guidance/shipped/moflo-memorydb-maintenance.md` — How the memory namespaces are populated and refreshed; required reading when search returns no results
-- `.claude/guidance/shipped/moflo-core-guidance.md` — Full CLI/MCP reference including the spell gates that block subagent spawn before memory is searched
+- `.claude/guidance/moflo-task-icons.md` — Mandatory ICON + [Role] format for every `TaskCreate` and `Agent` description spawned by a coordinator
+- `.claude/guidance/moflo-claude-swarm-cohesion.md` — How task lists and swarm coordinators cooperate when subagents are spawned in batches
+- `.claude/guidance/moflo-memory-strategy.md` — The memory-search-first rule this protocol enforces, with namespace-selection guidance
+- `.claude/guidance/moflo-memorydb-maintenance.md` — How the memory namespaces are populated and refreshed; required reading when search returns no results
+- `.claude/guidance/moflo-core-guidance.md` — Full CLI/MCP reference including the spell gates that block subagent spawn before memory is searched

--- a/.claude/guidance/shipped/moflo-task-icons.md
+++ b/.claude/guidance/shipped/moflo-task-icons.md
@@ -66,7 +66,7 @@ The spinner is the primary visual feedback during agent execution. Without icons
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-subagents.md` — Subagent protocol; `TaskCreate`/`Agent` icon rule is enforced as part of the spawning checklist
-- `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` — How task lists and swarms cooperate; icons distinguish swarm-spawned vs single-agent work
-- `.claude/guidance/shipped/moflo-user-facing-language.md` — Companion UX rule for any text shown to end users
-- `.claude/guidance/shipped/moflo-core-guidance.md` — Spell Gate that enforces icon format on `TaskCreate`
+- `.claude/guidance/moflo-subagents.md` — Subagent protocol; `TaskCreate`/`Agent` icon rule is enforced as part of the spawning checklist
+- `.claude/guidance/moflo-claude-swarm-cohesion.md` — How task lists and swarms cooperate; icons distinguish swarm-spawned vs single-agent work
+- `.claude/guidance/moflo-user-facing-language.md` — Companion UX rule for any text shown to end users
+- `.claude/guidance/moflo-core-guidance.md` — Spell Gate that enforces icon format on `TaskCreate`

--- a/.claude/guidance/shipped/moflo-user-facing-language.md
+++ b/.claude/guidance/shipped/moflo-user-facing-language.md
@@ -37,6 +37,6 @@
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-task-icons.md` — Companion UX rule: spinner text must use ICON + [Role] so non-technical users can identify the working agent
-- `.claude/guidance/shipped/moflo-spell-sandboxing.md` — Permission disclosure output where this language rule has the largest user-visible surface
-- `.claude/guidance/shipped/moflo-error-handling.md` — Sibling rule for what error messages must contain; this doc governs how those messages are phrased
+- `.claude/guidance/moflo-task-icons.md` — Companion UX rule: spinner text must use ICON + [Role] so non-technical users can identify the working agent
+- `.claude/guidance/moflo-spell-sandboxing.md` — Permission disclosure output where this language rule has the largest user-visible surface
+- `.claude/guidance/moflo-error-handling.md` — Sibling rule for what error messages must contain; this doc governs how those messages are phrased

--- a/.claude/guidance/shipped/moflo-verbose-command-filtering.md
+++ b/.claude/guidance/shipped/moflo-verbose-command-filtering.md
@@ -41,5 +41,5 @@ Case study: issue #903 burned ~25K tokens across 5 tee-then-grep round-trips whe
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-core-guidance.md` — Hub for moflo's CLI/MCP surface and runtime conventions
-- `.claude/guidance/shipped/moflo-memory-strategy.md` — Companion rules on RAG indexing and context discipline
+- `.claude/guidance/moflo-core-guidance.md` — Hub for moflo's CLI/MCP surface and runtime conventions
+- `.claude/guidance/moflo-memory-strategy.md` — Companion rules on RAG indexing and context discipline

--- a/.claude/guidance/shipped/moflo-yaml-reference.md
+++ b/.claude/guidance/shipped/moflo-yaml-reference.md
@@ -184,8 +184,8 @@ Global registration is useful for ad-hoc projects where you don't want to commit
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-core-guidance.md` — Hub: getting started, anti-drift defaults, troubleshooting
-- `.claude/guidance/shipped/moflo-cli-reference.md` — Commands, agents, hooks, hive-mind, ruvector — the surfaces this config gates
-- `.claude/guidance/shipped/moflo-spell-sandboxing.md` — What `sandbox:` actually does at the bash-step boundary, with capability/permission interaction
-- `.claude/guidance/shipped/moflo-session-start.md` — Where these config fields are read and applied during session start
-- `.claude/guidance/shipped/moflo-settings-injection.md` — What moflo writes into `.claude/settings.json` (the hook wiring; complementary to `moflo.yaml` toggles)
+- `.claude/guidance/moflo-core-guidance.md` — Hub: getting started, anti-drift defaults, troubleshooting
+- `.claude/guidance/moflo-cli-reference.md` — Commands, agents, hooks, hive-mind, ruvector — the surfaces this config gates
+- `.claude/guidance/moflo-spell-sandboxing.md` — What `sandbox:` actually does at the bash-step boundary, with capability/permission interaction
+- `.claude/guidance/moflo-session-start.md` — Where these config fields are read and applied during session start
+- `.claude/guidance/moflo-settings-injection.md` — What moflo writes into `.claude/settings.json` (the hook wiring; complementary to `moflo.yaml` toggles)

--- a/.claude/helpers/subagent-bootstrap.json
+++ b/.claude/helpers/subagent-bootstrap.json
@@ -1,3 +1,3 @@
 {
-  "directive": "MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/shipped/moflo-subagents.md` protocol."
+  "directive": "MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/moflo-subagents.md` protocol."
 }

--- a/.claude/helpers/subagent-start.cjs
+++ b/.claude/helpers/subagent-start.cjs
@@ -22,7 +22,7 @@ const path = require('path');
 // Defense-in-depth copy of the canonical directive in subagent-bootstrap.json.
 // Kept as a single-line literal so the parity test in tests/bin/subagent-start.test.ts
 // can verify it matches the JSON via plain substring containment.
-const FALLBACK_DIRECTIVE = 'MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/shipped/moflo-subagents.md` protocol.';
+const FALLBACK_DIRECTIVE = 'MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/moflo-subagents.md` protocol.';
 
 function loadDirective() {
   const jsonPath = path.join(__dirname, 'subagent-bootstrap.json');

--- a/.claude/scripts/setup-project.mjs
+++ b/.claude/scripts/setup-project.mjs
@@ -11,78 +11,79 @@
  *   flo-setup --check    # Check if setup is current
  *
  * What it does:
- *   1. Copies .claude/guidance/shipped/moflo-subagents.md → project's .claude/guidance/moflo-bootstrap.md
+ *   1. Copies moflo/.claude/guidance/shipped/moflo-subagents.md → project's .claude/guidance/moflo-bootstrap.md
  *   2. Appends a subagent protocol section to CLAUDE.md (idempotent, with markers)
  *
  * The project can layer its own guidance files on top for
  * project-specific rules (companyId, entity templates, etc.).
+ *
+ * The CLAUDE.md content is owned by `src/cli/init/claudemd-generator.ts` (compiled to
+ * `dist/src/cli/init/claudemd-generator.js`). This script is a thin wrapper so consumers
+ * always get byte-identical output regardless of which entry point they use
+ * (`flo init` vs `flo-setup`).
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const mofloRoot = resolve(__dirname, '..');
+
+// Find the installed moflo package root regardless of where this script runs from.
+// Two valid locations:
+//   1. <moflo>/bin/setup-project.mjs           — moflo source repo or `npm bin` resolution
+//   2. <consumer>/.claude/scripts/setup-project.mjs — synced copy from session-start
+// Strategy: walk up from this file looking for a package.json with name="moflo",
+// then fall back to Node's module resolution.
+function findMofloRoot() {
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    const pkg = join(dir, 'package.json');
+    if (existsSync(pkg)) {
+      try {
+        const data = JSON.parse(readFileSync(pkg, 'utf-8'));
+        if (data.name === 'moflo') return dir;
+      } catch { /* not parseable, keep walking */ }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  try {
+    const require = createRequire(import.meta.url);
+    return dirname(require.resolve('moflo/package.json'));
+  } catch {
+    return null;
+  }
+}
+
+const mofloRoot = findMofloRoot();
+if (!mofloRoot) {
+  console.error('[flo-setup] ❌ Could not locate moflo package root');
+  process.exit(1);
+}
+
+const claudeMdGenUrl = pathToFileURL(
+  join(mofloRoot, 'dist/src/cli/init/claudemd-generator.js')
+).href;
+const {
+  generateClaudeMd,
+  MARKER_START,
+  MARKER_END,
+  LEGACY_MARKER_STARTS,
+  LEGACY_MARKER_ENDS,
+} = await import(claudeMdGenUrl);
 
 const args = process.argv.slice(2);
 const updateOnly = args.includes('--update');
 const checkOnly = args.includes('--check');
 
-// Markers for idempotent CLAUDE.md updates — keep in sync with claudemd-generator.ts
-const MARKER_START = '<!-- MOFLO:INJECTED:START -->';
-const MARKER_END = '<!-- MOFLO:INJECTED:END -->';
-// Legacy markers to detect and replace
-const LEGACY_STARTS = ['<!-- MOFLO:SUBAGENT-PROTOCOL:START -->', '<!-- MOFLO:START -->'];
-const LEGACY_ENDS = ['<!-- MOFLO:SUBAGENT-PROTOCOL:END -->', '<!-- MOFLO:END -->'];
-
-// Minimal injection — just enough for Claude to work with moflo.
-// All detailed docs live in .claude/guidance/shipped/moflo-core-guidance.md.
-const CLAUDE_MD_SECTION = `${MARKER_START}
-## MoFlo — AI Agent Orchestration
-
-This project uses [MoFlo](https://github.com/eric-cielo/moflo) for AI-assisted development workflows.
-
-### FIRST ACTION ON EVERY PROMPT: Search Memory
-
-Your first tool call for every new user prompt MUST be a memory search. Do this BEFORE Glob, Grep, Read, or any file exploration.
-
-\`\`\`
-mcp__moflo__memory_search — query: "<task description>", namespace: "guidance" or "patterns" or "learnings" or "code-map" or "tests"
-\`\`\`
-
-Search \`guidance\`, \`patterns\`, and \`learnings\` namespaces on every prompt. Search \`code-map\` when navigating the codebase, \`tests\` when looking for test inventory or coverage.
-When the user asks you to remember something: \`mcp__moflo__memory_store\` with namespace \`learnings\`.
-
-### Workflow Gates (enforced automatically)
-
-- **Memory-first**: Must search memory before Glob/Grep/Read
-- **TaskCreate-first**: Must call TaskCreate before spawning Agent tool
-
-- **Task Icons**: \`TaskCreate\` MUST use ICON+[Role] format — see \`.claude/guidance/moflo-task-icons.md\`
-
-### MCP Tools (preferred over CLI)
-
-| Tool | Purpose |
-|------|---------|
-| \`mcp__moflo__memory_search\` | Semantic search across indexed knowledge |
-| \`mcp__moflo__memory_store\` | Store patterns and decisions |
-| \`mcp__moflo__hooks_route\` | Route task to optimal agent type |
-| \`mcp__moflo__hooks_pre-task\` | Record task start |
-| \`mcp__moflo__hooks_post-task\` | Record task completion for learning |
-
-### CLI Fallback
-
-\`\`\`bash
-flo-search "[query]" --namespace guidance   # Semantic search
-flo doctor --fix                             # Health check
-\`\`\`
-
-### Full Reference
-
-For CLI commands, hooks, agents, swarm config, memory commands, and moflo.yaml options, see:
-\`.claude/guidance/shipped/moflo-core-guidance.md\`
-${MARKER_END}`;
+// Canonical section content (owned by claudemd-generator.ts). Trim the trailing newline
+// that generateClaudeMd appends so the marker-replace logic below stays exact.
+const CLAUDE_MD_SECTION = generateClaudeMd({}).trimEnd();
+const LEGACY_STARTS = [...LEGACY_MARKER_STARTS];
+const LEGACY_ENDS = [...LEGACY_MARKER_ENDS];
 
 function log(msg) {
   console.log(`[flo-setup] ${msg}`);

--- a/.claude/scripts/setup-project.mjs
+++ b/.claude/scripts/setup-project.mjs
@@ -25,55 +25,23 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { mofloInternalURL } from './lib/moflo-resolve.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+// Resolve moflo's installed package root via Node module resolution so the script
+// works identically from bin/ (canonical) or from .claude/scripts/ (synced copy).
+const mofloRoot = dirname(fileURLToPath(mofloInternalURL('package.json')));
 
-// Find the installed moflo package root regardless of where this script runs from.
-// Two valid locations:
-//   1. <moflo>/bin/setup-project.mjs           — moflo source repo or `npm bin` resolution
-//   2. <consumer>/.claude/scripts/setup-project.mjs — synced copy from session-start
-// Strategy: walk up from this file looking for a package.json with name="moflo",
-// then fall back to Node's module resolution.
-function findMofloRoot() {
-  let dir = __dirname;
-  for (let i = 0; i < 6; i++) {
-    const pkg = join(dir, 'package.json');
-    if (existsSync(pkg)) {
-      try {
-        const data = JSON.parse(readFileSync(pkg, 'utf-8'));
-        if (data.name === 'moflo') return dir;
-      } catch { /* not parseable, keep walking */ }
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  try {
-    const require = createRequire(import.meta.url);
-    return dirname(require.resolve('moflo/package.json'));
-  } catch {
-    return null;
-  }
-}
-
-const mofloRoot = findMofloRoot();
-if (!mofloRoot) {
-  console.error('[flo-setup] ❌ Could not locate moflo package root');
-  process.exit(1);
-}
-
-const claudeMdGenUrl = pathToFileURL(
-  join(mofloRoot, 'dist/src/cli/init/claudemd-generator.js')
-).href;
+// Single source of truth: claudemd-generator.ts owns the section content.
+// Use the shared mofloInternalURL helper so the script works identically when
+// invoked from bin/ (canonical) or from .claude/scripts/ (synced copy).
 const {
   generateClaudeMd,
   MARKER_START,
   MARKER_END,
   LEGACY_MARKER_STARTS,
   LEGACY_MARKER_ENDS,
-} = await import(claudeMdGenUrl);
+} = await import(mofloInternalURL('dist/src/cli/init/claudemd-generator.js'));
 
 const args = process.argv.slice(2);
 const updateOnly = args.includes('--update');
@@ -82,8 +50,6 @@ const checkOnly = args.includes('--check');
 // Canonical section content (owned by claudemd-generator.ts). Trim the trailing newline
 // that generateClaudeMd appends so the marker-replace logic below stays exact.
 const CLAUDE_MD_SECTION = generateClaudeMd({}).trimEnd();
-const LEGACY_STARTS = [...LEGACY_MARKER_STARTS];
-const LEGACY_ENDS = [...LEGACY_MARKER_ENDS];
 
 function log(msg) {
   console.log(`[flo-setup] ${msg}`);
@@ -174,8 +140,8 @@ function updateClaudeMd(projectRoot) {
   const content = readFileSync(claudeMdPath, 'utf-8');
 
   // Check for current or legacy markers and replace
-  const allStarts = [MARKER_START, ...LEGACY_STARTS];
-  const allEnds = [MARKER_END, ...LEGACY_ENDS];
+  const allStarts = [MARKER_START, ...LEGACY_MARKER_STARTS];
+  const allEnds = [MARKER_END, ...LEGACY_MARKER_ENDS];
 
   for (let i = 0; i < allStarts.length; i++) {
     if (content.includes(allStarts[i])) {

--- a/.claude/skills/connector-builder/SKILL.md
+++ b/.claude/skills/connector-builder/SKILL.md
@@ -32,7 +32,7 @@ Ask the user:
 
 **Important:** Simple service integrations (Slack webhook, S3 upload, Jira comment) should compose existing connectors (`http`, `github-cli`, `playwright`) in spell YAML — no dedicated connector needed. However, platforms requiring complex multi-step browser interaction (like Outlook.com web UI) DO warrant a dedicated connector. See `.claude/skills/spell-builder/architecture.md` for the decision tree.
 
-**Documentation requirement:** When creating any new step command or connector, you MUST also create a README.md following `.claude/guidance/shipped/moflo-guidance-rules.md`. Use existing READMEs in `.claude/skills/spell-builder/steps/` or `connectors/` as templates. Apply automatically — the user should never need to ask.
+**Documentation requirement:** When creating any new step command or connector, you MUST also create a README.md following `.claude/guidance/moflo-guidance-rules.md`. Use existing READMEs in `.claude/skills/spell-builder/steps/` or `connectors/` as templates. Apply automatically — the user should never need to ask.
 
 Then follow the appropriate section below.
 

--- a/.claude/skills/eldar/SKILL.md
+++ b/.claude/skills/eldar/SKILL.md
@@ -65,7 +65,7 @@ Compute minor-version delta. Warn if behind by ≥3 minors; info if behind by 1�
 mcp__moflo__hooks_model-stats — {}
 ```
 
-If recent sonnet→opus escalation rate exceeds ~30%, flag as `info`: "router escalating frequently — see `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` for tuning". If stats unavailable (no history), skip silently.
+If recent sonnet→opus escalation rate exceeds ~30%, flag as `info`: "router escalating frequently — see `.claude/guidance/moflo-claude-swarm-cohesion.md` for tuning". If stats unavailable (no history), skip silently.
 
 ### 1e. CLAUDE.md
 
@@ -94,7 +94,7 @@ Count `.md` files under `.claude/guidance/` (recursive). Severity table:
 
 **This step is not optional.** If 1f found ≥1 guidance file, you MUST invoke `/guidance -a` via the `Skill` tool *inline, during this audit run, before rendering the report.* Do not defer it ("rerun separately if you want"), do not skip it because the corpus is large, do not substitute a hand-rolled grep pass — that defeats the single-source-of-truth contract.
 
-The /guidance skill enforces the universal rules from `.claude/guidance/shipped/moflo-guidance-rules.md` (Purpose lines, See Also, generic H2s, hedged language, 500-line cap, RAG chunking) and is the single source of truth for those checks — never re-implement them here.
+The /guidance skill enforces the universal rules from `.claude/guidance/moflo-guidance-rules.md` (Purpose lines, See Also, generic H2s, hedged language, 500-line cap, RAG chunking) and is the single source of truth for those checks — never re-implement them here.
 
 If `/guidance -a` is genuinely too expensive (50+ files AND user explicitly asks for a fast read), skip it only after asking and surface the skip explicitly in the report (`Guidance structure | skipped at user request | warn`). Default behaviour is always to run it.
 
@@ -206,7 +206,7 @@ TOP 3 RECOMMENDATIONS
    queries and migrations in your codebase. /guidance -a (run inline
    in step 1g) flagged 3 existing docs with structural issues; pick
    one to fix alongside this new one.
-   See: .claude/guidance/shipped/moflo-guidance-rules.md
+   See: .claude/guidance/moflo-guidance-rules.md
 
 3. Run `flo healer --fix` (warn)
    One auto-fixable warning. Run via `/eldar --fix` and select Healer.
@@ -301,7 +301,7 @@ Never leave the user without a clear next step.
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-guidance-rules.md` — Universal guidance writing rules used by `/guidance` and surfaced in 1g
+- `.claude/guidance/moflo-guidance-rules.md` — Universal guidance writing rules used by `/guidance` and surfaced in 1g
 - `.claude/skills/guidance/SKILL.md` — The skill `/eldar --fix` hands off to for guidance authoring
-- `.claude/guidance/shipped/moflo-core-guidance.md` — moflo CLI / hooks / memory reference; useful when explaining wiring findings
-- `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` — Subagent + task coordination reference cited in routing findings
+- `.claude/guidance/moflo-core-guidance.md` — moflo CLI / hooks / memory reference; useful when explaining wiring findings
+- `.claude/guidance/moflo-claude-swarm-cohesion.md` — Subagent + task coordination reference cited in routing findings

--- a/.claude/skills/guidance/SKILL.md
+++ b/.claude/skills/guidance/SKILL.md
@@ -6,7 +6,7 @@ arguments: "[-a] <topic-or-path>"
 
 # /guidance — Author and audit project guidance
 
-Help the user write, edit, or audit guidance files in their `.claude/guidance/` directory so Claude actually follows the rules they wrote. The skill applies the universal rules from `.claude/guidance/shipped/moflo-guidance-rules.md` — that doc is the single source of truth, do not paraphrase or duplicate it here.
+Help the user write, edit, or audit guidance files in their `.claude/guidance/` directory so Claude actually follows the rules they wrote. The skill applies the universal rules from `.claude/guidance/moflo-guidance-rules.md` — that doc is the single source of truth, do not paraphrase or duplicate it here.
 
 **Arguments:** $ARGUMENTS
 
@@ -43,7 +43,7 @@ If single-doc and the file already exists, briefly summarize what it contains (o
 
 ## Step 2 — Single-Doc Mode
 
-Apply the universal rules from `.claude/guidance/shipped/moflo-guidance-rules.md`. The rules cover (do not paraphrase — read the source):
+Apply the universal rules from `.claude/guidance/moflo-guidance-rules.md`. The rules cover (do not paraphrase — read the source):
 
 1. Lead with `**Purpose:**` line after the H1
 2. Be imperative, not descriptive
@@ -170,7 +170,7 @@ Once the user confirms the doc looks right:
 
 ## Cheatsheet — Universal Rules Recap
 
-The full rules live in `.claude/guidance/shipped/moflo-guidance-rules.md`. Quick recap:
+The full rules live in `.claude/guidance/moflo-guidance-rules.md`. Quick recap:
 
 | # | Rule | One-line |
 |---|------|----------|
@@ -187,14 +187,14 @@ The full rules live in `.claude/guidance/shipped/moflo-guidance-rules.md`. Quick
 ## Important
 
 - **Memory-first is mandatory.** Always run `mcp__moflo__memory_search` in step 0 — the gate blocks reads otherwise.
-- **Never duplicate the rules in this skill.** Reference `.claude/guidance/shipped/moflo-guidance-rules.md` and ask the user to read it if they want depth.
+- **Never duplicate the rules in this skill.** Reference `.claude/guidance/moflo-guidance-rules.md` and ask the user to read it if they want depth.
 - **Never auto-write opinionated content.** Guidance is the user's project policy; ask before injecting your own opinions.
 - **Confirm per file in audit mode.** Bulk edits to the user's guidance directory are high-blast-radius — confirm each one.
 - **The `moflo-` filename prefix is moflo-only.** Consumer projects writing their own guidance do not need it; it exists to avoid collisions when moflo's shipped guidance syncs into a consumer's directory.
 
 ## See Also
 
-- `.claude/guidance/shipped/moflo-guidance-rules.md` — Universal writing rules this skill enforces
-- `.claude/guidance/shipped/moflo-memory-strategy.md` — How well-written guidance feeds the RAG index
-- `.claude/guidance/shipped/moflo-task-icons.md` — UX rule the skill checks for any TaskCreate examples in the user's guidance
-- `.claude/guidance/shipped/moflo-user-facing-language.md` — Companion rule for any user-visible text the user's guidance discusses
+- `.claude/guidance/moflo-guidance-rules.md` — Universal writing rules this skill enforces
+- `.claude/guidance/moflo-memory-strategy.md` — How well-written guidance feeds the RAG index
+- `.claude/guidance/moflo-task-icons.md` — UX rule the skill checks for any TaskCreate examples in the user's guidance
+- `.claude/guidance/moflo-user-facing-language.md` — Companion rule for any user-visible text the user's guidance discusses

--- a/.claude/skills/memory-patterns/SKILL.md
+++ b/.claude/skills/memory-patterns/SKILL.md
@@ -133,4 +133,4 @@ This is the same fan-out the `/flo` spell does — cheap (HNSW, parallel) and re
 
 - `vector-search` skill — RAG patterns over your own documents
 - `memory-optimization` skill — HNSW tuning, quantization, batch ops
-- `.claude/guidance/shipped/moflo-core-guidance.md` — CLI/MCP reference
+- `.claude/guidance/moflo-core-guidance.md` — CLI/MCP reference

--- a/.claude/skills/spell-builder/SKILL.md
+++ b/.claude/skills/spell-builder/SKILL.md
@@ -356,7 +356,7 @@ Write the updated YAML back to the original file (or a new path if requested).
 
 **Runtime source:** `src/cli/spells/commands/` — each step is a TypeScript file registered in `index.ts`.
 
-**Adding a new step:** Create a directory under `steps/<name>/` with a `README.md`. Follow `.claude/guidance/shipped/moflo-guidance-rules.md` and use existing step READMEs as templates. The step command source goes in `src/cli/spells/commands/` and is registered in `index.ts`. No changes to this SKILL.md needed.
+**Adding a new step:** Create a directory under `steps/<name>/` with a `README.md`. Follow `.claude/guidance/moflo-guidance-rules.md` and use existing step READMEs as templates. The step command source goes in `src/cli/spells/commands/` and is registered in `index.ts`. No changes to this SKILL.md needed.
 
 ### Connectors
 
@@ -371,7 +371,7 @@ Write the updated YAML back to the original file (or a new path if requested).
 
 **Runtime source:** `src/cli/spells/connectors/` — each connector is a TypeScript file registered in `index.ts`.
 
-**Adding a new connector:** Create a directory under `connectors/<name>/` with a `README.md`. Follow `.claude/guidance/shipped/moflo-guidance-rules.md` and use existing connector READMEs as templates. The connector source goes in `src/cli/spells/connectors/` and is registered in `index.ts`. No changes to this SKILL.md needed.
+**Adding a new connector:** Create a directory under `connectors/<name>/` with a `README.md`. Follow `.claude/guidance/moflo-guidance-rules.md` and use existing connector READMEs as templates. The connector source goes in `src/cli/spells/connectors/` and is registered in `index.ts`. No changes to this SKILL.md needed.
 
 **When to create a new connector vs composing existing ones:** See [architecture.md](architecture.md) for the decision tree.
 

--- a/.claude/skills/spell-builder/architecture.md
+++ b/.claude/skills/spell-builder/architecture.md
@@ -153,7 +153,7 @@ steps:
 
 ## Documentation Rules for New Components
 
-**Every new step, connector, or spell MUST include a README.md.** Apply the rules in `.claude/guidance/shipped/moflo-guidance-rules.md` automatically — do not wait for the user to ask. Use existing READMEs in `steps/` and `connectors/` as templates.
+**Every new step, connector, or spell MUST include a README.md.** Apply the rules in `.claude/guidance/moflo-guidance-rules.md` automatically — do not wait for the user to ask. Use existing READMEs in `steps/` and `connectors/` as templates.
 
 **Where to put the README:**
 - Steps: `.claude/skills/spell-builder/steps/<name>/README.md`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+      # See test job for context — postinstall clobber workaround.
+      - name: Restore source after postinstall clobber
+        run: git checkout -- .claude/helpers/ .claude/scripts/
+
       - name: Build all packages
         run: npm run build
 
@@ -66,6 +70,16 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+      # Pre-#937: the published moflo's postinstall bootstrapper clobbers
+      # source .claude/helpers/* and .claude/scripts/* with stale published
+      # artifacts when run as a devDependency. The fix in this PR
+      # (scripts/post-install-bootstrap.mjs detecting
+      # `consumerProjectRoot/package.json` name === "moflo") only takes effect
+      # once a moflo with that fix is published and pinned. Until then,
+      # restore source files from git after install.
+      - name: Restore source after postinstall clobber
+        run: git checkout -- .claude/helpers/ .claude/scripts/
+
       - name: Build all packages (tests import compiled output)
         run: npm run build
 
@@ -92,6 +106,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
+
+      # See test job for context — postinstall clobber workaround.
+      - name: Restore source after postinstall clobber
+        run: git checkout -- .claude/helpers/ .claude/scripts/
 
       - name: Lint
         run: npm run lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,42 +30,28 @@ Before opening any issue or "fixing" anything observable in the editor (statusli
 <!-- MOFLO:INJECTED:START -->
 ## MoFlo — AI Agent Orchestration
 
-This project uses [MoFlo](https://github.com/eric-cielo/moflo) for AI-assisted development spells.
-
 ### FIRST ACTION ON EVERY PROMPT: Search Memory
 
-MUST call `mcp__moflo__memory_search` BEFORE any Glob/Grep/Read/file exploration. Namespaces: `guidance`+`patterns`+`learnings` every prompt; `code-map` when navigating code. When the user says "remember this": `mcp__moflo__memory_store` with namespace `learnings`.
+Your first tool call MUST be `mcp__moflo__memory_search` — before any Glob/Grep/Read. Search `guidance`, `patterns`, and `learnings` every prompt; add `code-map` when navigating code, `tests` when looking for test inventory or coverage. When the user says "remember this", call `mcp__moflo__memory_store` with namespace `learnings`.
 
-### Spell Gates (enforced automatically)
+### Auto-enforced gates
 
-- **Memory-first**: Must search memory before Glob/Grep/Read
-- **TaskCreate-first**: Must call TaskCreate before spawning Agent tool
+- **TaskCreate-first**: Call `TaskCreate` before spawning the Agent tool
+- **Task Icons**: `TaskCreate` entries MUST use ICON+[Role] format — see `.claude/guidance/moflo-task-icons.md`
 
-- **Task Icons**: `TaskCreate` MUST use ICON+[Role] format — see `.claude/guidance/shipped/moflo-task-icons.md`
+### Tools
 
-### MCP Tools (preferred over CLI)
-
-| Tool | Purpose |
-|------|---------|
-| `mcp__moflo__memory_search` | Semantic search across indexed knowledge |
-| `mcp__moflo__memory_store` | Store patterns and decisions |
-
-### CLI Fallback
-
-```bash
-flo-search "[query]" --namespace guidance   # Semantic search
-flo doctor --fix                             # Health check
-```
+Prefer MCP (`mcp__moflo__*` — memory, swarm, agent, task, hooks, hive-mind, neural) over the CLI. CLI binaries: `flo` (main), `flo-search` (semantic search), `flo doctor --fix` (heal). Full catalog: `.claude/guidance/moflo-core-guidance.md`.
 
 ### After upgrading MoFlo
 
-After running `npm install moflo@*` (or `npm install` that touches moflo), check `.moflo/restart-pending.json`. If it exists, surface the `message` field to the user verbatim (Claude Code can't pick up new hooks/MCP tools/launcher mid-session — they're only loaded at session-start), then delete the file.
+After `npm install` touches moflo, check `.moflo/restart-pending.json` — if present, surface its `message` field to the user verbatim, then delete the file. (Claude Code only loads new hooks/MCP/launcher at session start.)
 
 ### Full Reference
 
-- **Subagents protocol:** `.claude/guidance/shipped/moflo-subagents.md`
-- **Task + swarm coordination:** `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md`
-- **CLI, hooks, swarm, memory, moflo.yaml:** `.claude/guidance/shipped/moflo-core-guidance.md`
+- Subagents protocol: `.claude/guidance/moflo-subagents.md`
+- Task + swarm coordination: `.claude/guidance/moflo-claude-swarm-cohesion.md`
+- CLI, hooks, swarm, memory, moflo.yaml: `.claude/guidance/moflo-core-guidance.md`
 <!-- MOFLO:INJECTED:END -->
 
 ## ⚠ Editing guidance — read both rule sets first

--- a/bin/setup-project.mjs
+++ b/bin/setup-project.mjs
@@ -11,78 +11,79 @@
  *   flo-setup --check    # Check if setup is current
  *
  * What it does:
- *   1. Copies .claude/guidance/shipped/moflo-subagents.md → project's .claude/guidance/moflo-bootstrap.md
+ *   1. Copies moflo/.claude/guidance/shipped/moflo-subagents.md → project's .claude/guidance/moflo-bootstrap.md
  *   2. Appends a subagent protocol section to CLAUDE.md (idempotent, with markers)
  *
  * The project can layer its own guidance files on top for
  * project-specific rules (companyId, entity templates, etc.).
+ *
+ * The CLAUDE.md content is owned by `src/cli/init/claudemd-generator.ts` (compiled to
+ * `dist/src/cli/init/claudemd-generator.js`). This script is a thin wrapper so consumers
+ * always get byte-identical output regardless of which entry point they use
+ * (`flo init` vs `flo-setup`).
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const mofloRoot = resolve(__dirname, '..');
+
+// Find the installed moflo package root regardless of where this script runs from.
+// Two valid locations:
+//   1. <moflo>/bin/setup-project.mjs           — moflo source repo or `npm bin` resolution
+//   2. <consumer>/.claude/scripts/setup-project.mjs — synced copy from session-start
+// Strategy: walk up from this file looking for a package.json with name="moflo",
+// then fall back to Node's module resolution.
+function findMofloRoot() {
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    const pkg = join(dir, 'package.json');
+    if (existsSync(pkg)) {
+      try {
+        const data = JSON.parse(readFileSync(pkg, 'utf-8'));
+        if (data.name === 'moflo') return dir;
+      } catch { /* not parseable, keep walking */ }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  try {
+    const require = createRequire(import.meta.url);
+    return dirname(require.resolve('moflo/package.json'));
+  } catch {
+    return null;
+  }
+}
+
+const mofloRoot = findMofloRoot();
+if (!mofloRoot) {
+  console.error('[flo-setup] ❌ Could not locate moflo package root');
+  process.exit(1);
+}
+
+const claudeMdGenUrl = pathToFileURL(
+  join(mofloRoot, 'dist/src/cli/init/claudemd-generator.js')
+).href;
+const {
+  generateClaudeMd,
+  MARKER_START,
+  MARKER_END,
+  LEGACY_MARKER_STARTS,
+  LEGACY_MARKER_ENDS,
+} = await import(claudeMdGenUrl);
 
 const args = process.argv.slice(2);
 const updateOnly = args.includes('--update');
 const checkOnly = args.includes('--check');
 
-// Markers for idempotent CLAUDE.md updates — keep in sync with claudemd-generator.ts
-const MARKER_START = '<!-- MOFLO:INJECTED:START -->';
-const MARKER_END = '<!-- MOFLO:INJECTED:END -->';
-// Legacy markers to detect and replace
-const LEGACY_STARTS = ['<!-- MOFLO:SUBAGENT-PROTOCOL:START -->', '<!-- MOFLO:START -->'];
-const LEGACY_ENDS = ['<!-- MOFLO:SUBAGENT-PROTOCOL:END -->', '<!-- MOFLO:END -->'];
-
-// Minimal injection — just enough for Claude to work with moflo.
-// All detailed docs live in .claude/guidance/shipped/moflo-core-guidance.md.
-const CLAUDE_MD_SECTION = `${MARKER_START}
-## MoFlo — AI Agent Orchestration
-
-This project uses [MoFlo](https://github.com/eric-cielo/moflo) for AI-assisted development workflows.
-
-### FIRST ACTION ON EVERY PROMPT: Search Memory
-
-Your first tool call for every new user prompt MUST be a memory search. Do this BEFORE Glob, Grep, Read, or any file exploration.
-
-\`\`\`
-mcp__moflo__memory_search — query: "<task description>", namespace: "guidance" or "patterns" or "learnings" or "code-map" or "tests"
-\`\`\`
-
-Search \`guidance\`, \`patterns\`, and \`learnings\` namespaces on every prompt. Search \`code-map\` when navigating the codebase, \`tests\` when looking for test inventory or coverage.
-When the user asks you to remember something: \`mcp__moflo__memory_store\` with namespace \`learnings\`.
-
-### Workflow Gates (enforced automatically)
-
-- **Memory-first**: Must search memory before Glob/Grep/Read
-- **TaskCreate-first**: Must call TaskCreate before spawning Agent tool
-
-- **Task Icons**: \`TaskCreate\` MUST use ICON+[Role] format — see \`.claude/guidance/moflo-task-icons.md\`
-
-### MCP Tools (preferred over CLI)
-
-| Tool | Purpose |
-|------|---------|
-| \`mcp__moflo__memory_search\` | Semantic search across indexed knowledge |
-| \`mcp__moflo__memory_store\` | Store patterns and decisions |
-| \`mcp__moflo__hooks_route\` | Route task to optimal agent type |
-| \`mcp__moflo__hooks_pre-task\` | Record task start |
-| \`mcp__moflo__hooks_post-task\` | Record task completion for learning |
-
-### CLI Fallback
-
-\`\`\`bash
-flo-search "[query]" --namespace guidance   # Semantic search
-flo doctor --fix                             # Health check
-\`\`\`
-
-### Full Reference
-
-For CLI commands, hooks, agents, swarm config, memory commands, and moflo.yaml options, see:
-\`.claude/guidance/shipped/moflo-core-guidance.md\`
-${MARKER_END}`;
+// Canonical section content (owned by claudemd-generator.ts). Trim the trailing newline
+// that generateClaudeMd appends so the marker-replace logic below stays exact.
+const CLAUDE_MD_SECTION = generateClaudeMd({}).trimEnd();
+const LEGACY_STARTS = [...LEGACY_MARKER_STARTS];
+const LEGACY_ENDS = [...LEGACY_MARKER_ENDS];
 
 function log(msg) {
   console.log(`[flo-setup] ${msg}`);

--- a/bin/setup-project.mjs
+++ b/bin/setup-project.mjs
@@ -25,55 +25,23 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { mofloInternalURL } from './lib/moflo-resolve.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+// Resolve moflo's installed package root via Node module resolution so the script
+// works identically from bin/ (canonical) or from .claude/scripts/ (synced copy).
+const mofloRoot = dirname(fileURLToPath(mofloInternalURL('package.json')));
 
-// Find the installed moflo package root regardless of where this script runs from.
-// Two valid locations:
-//   1. <moflo>/bin/setup-project.mjs           — moflo source repo or `npm bin` resolution
-//   2. <consumer>/.claude/scripts/setup-project.mjs — synced copy from session-start
-// Strategy: walk up from this file looking for a package.json with name="moflo",
-// then fall back to Node's module resolution.
-function findMofloRoot() {
-  let dir = __dirname;
-  for (let i = 0; i < 6; i++) {
-    const pkg = join(dir, 'package.json');
-    if (existsSync(pkg)) {
-      try {
-        const data = JSON.parse(readFileSync(pkg, 'utf-8'));
-        if (data.name === 'moflo') return dir;
-      } catch { /* not parseable, keep walking */ }
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  try {
-    const require = createRequire(import.meta.url);
-    return dirname(require.resolve('moflo/package.json'));
-  } catch {
-    return null;
-  }
-}
-
-const mofloRoot = findMofloRoot();
-if (!mofloRoot) {
-  console.error('[flo-setup] ❌ Could not locate moflo package root');
-  process.exit(1);
-}
-
-const claudeMdGenUrl = pathToFileURL(
-  join(mofloRoot, 'dist/src/cli/init/claudemd-generator.js')
-).href;
+// Single source of truth: claudemd-generator.ts owns the section content.
+// Use the shared mofloInternalURL helper so the script works identically when
+// invoked from bin/ (canonical) or from .claude/scripts/ (synced copy).
 const {
   generateClaudeMd,
   MARKER_START,
   MARKER_END,
   LEGACY_MARKER_STARTS,
   LEGACY_MARKER_ENDS,
-} = await import(claudeMdGenUrl);
+} = await import(mofloInternalURL('dist/src/cli/init/claudemd-generator.js'));
 
 const args = process.argv.slice(2);
 const updateOnly = args.includes('--update');
@@ -82,8 +50,6 @@ const checkOnly = args.includes('--check');
 // Canonical section content (owned by claudemd-generator.ts). Trim the trailing newline
 // that generateClaudeMd appends so the marker-replace logic below stays exact.
 const CLAUDE_MD_SECTION = generateClaudeMd({}).trimEnd();
-const LEGACY_STARTS = [...LEGACY_MARKER_STARTS];
-const LEGACY_ENDS = [...LEGACY_MARKER_ENDS];
 
 function log(msg) {
   console.log(`[flo-setup] ${msg}`);
@@ -174,8 +140,8 @@ function updateClaudeMd(projectRoot) {
   const content = readFileSync(claudeMdPath, 'utf-8');
 
   // Check for current or legacy markers and replace
-  const allStarts = [MARKER_START, ...LEGACY_STARTS];
-  const allEnds = [MARKER_END, ...LEGACY_ENDS];
+  const allStarts = [MARKER_START, ...LEGACY_MARKER_STARTS];
+  const allEnds = [MARKER_END, ...LEGACY_MARKER_ENDS];
 
   for (let i = 0; i < allStarts.length; i++) {
     if (content.includes(allStarts[i])) {

--- a/scripts/post-install-bootstrap.mjs
+++ b/scripts/post-install-bootstrap.mjs
@@ -41,6 +41,7 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   statSync,
 } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -175,9 +176,27 @@ export async function runBootstrap({
   // The source repo's .claude/ IS the truth source — we'd be copying
   // the very files we just built ON TOP of themselves, which on Windows
   // hits the same file-lock issues we're trying to avoid.
+  //
+  // Two paths can hit this branch:
+  //   1. The source's own postinstall: mofloRoot === projectRoot (path equality).
+  //   2. The DEPENDENCY's postinstall on `npm ci` of the moflo source repo:
+  //      mofloRoot = <src>/node_modules/moflo/, projectRoot = <src>/. Path
+  //      equality fails — moflo-as-its-own-devDep would clobber the source
+  //      .claude/helpers/ with the OLDER published artifacts, breaking CI
+  //      against any in-flight fixes. Detect by reading projectRoot's
+  //      package.json name and bailing whenever it's "moflo".
   if (resolve(projectRoot) === resolve(mofloRoot)) {
     return { ran: false, reason: 'moflo-self-install' };
   }
+  try {
+    const projectPkgPath = resolve(projectRoot, 'package.json');
+    if (existsSync(projectPkgPath)) {
+      const projectPkg = JSON.parse(readFileSync(projectPkgPath, 'utf-8'));
+      if (projectPkg.name === 'moflo') {
+        return { ran: false, reason: 'moflo-self-dev-install' };
+      }
+    }
+  } catch { /* unparseable package.json — fall through, treat as consumer */ }
 
   const binDir = resolve(mofloRoot, 'bin');
   if (!existsSync(binDir)) {

--- a/src/cli/__tests__/commands-deep.test.ts
+++ b/src/cli/__tests__/commands-deep.test.ts
@@ -1537,14 +1537,17 @@ describe('Init System', () => {
       expect(md).toContain('mcp__moflo__memory_search');
     });
 
-    it('should contain spell gates', () => {
+    it('should contain auto-enforced gates section', () => {
       const md = generateClaudeMd(DEFAULT_INIT_OPTIONS);
-      expect(md).toContain('Spell Gates');
+      expect(md).toContain('Auto-enforced gates');
+      expect(md).toContain('TaskCreate-first');
     });
 
-    it('should contain MCP tools table', () => {
+    it('should reference MCP tools and the CLI', () => {
       const md = generateClaudeMd(DEFAULT_INIT_OPTIONS);
-      expect(md).toContain('MCP Tools');
+      // Tools section names the MCP namespace + CLI binaries (compact form, no table).
+      expect(md).toContain('mcp__moflo__*');
+      expect(md).toContain('flo doctor --fix');
     });
 
     it('should contain injection markers', () => {
@@ -1555,7 +1558,10 @@ describe('Init System', () => {
 
     it('should reference full docs in guidance', () => {
       const md = generateClaudeMd(DEFAULT_INIT_OPTIONS);
-      expect(md).toContain('.claude/guidance/shipped/moflo-core-guidance.md');
+      // Consumer-bound path — must be the mirror, not the source `shipped/`.
+      // See .claude/guidance/internal/consumer-bound-references.md.
+      expect(md).toContain('.claude/guidance/moflo-core-guidance.md');
+      expect(md).not.toContain('.claude/guidance/shipped/');
     });
 
     it('should instruct Claude to read .moflo/restart-pending.json after upgrading', () => {
@@ -1564,7 +1570,7 @@ describe('Init System', () => {
       // and surfaces it to the user.
       const md = generateClaudeMd(DEFAULT_INIT_OPTIONS);
       expect(md).toContain('restart-pending.json');
-      expect(md).toContain('npm install moflo');
+      expect(md).toMatch(/npm install.*moflo|moflo.*npm install/);
     });
 
     it('all templates should produce identical output', () => {

--- a/src/cli/init/claudemd-generator.ts
+++ b/src/cli/init/claudemd-generator.ts
@@ -3,7 +3,7 @@
  *
  * Generates ONLY the MoFlo section to inject into a project's CLAUDE.md.
  * This must be minimal — just enough for Claude to work with moflo.
- * All detailed docs live in .claude/guidance/shipped/moflo-core-guidance.md (copied at install).
+ * All detailed docs live in .claude/guidance/moflo-core-guidance.md on consumer projects (synced from .claude/guidance/shipped/ inside node_modules/moflo).
  *
  * Principle: we are guests in the user's CLAUDE.md. Keep it small.
  */
@@ -13,56 +13,53 @@ import type { InitOptions, ClaudeMdTemplate } from './types.js';
 const MARKER_START = '<!-- MOFLO:INJECTED:START -->';
 const MARKER_END = '<!-- MOFLO:INJECTED:END -->';
 
+// Legacy markers from earlier moflo versions — detected and replaced on re-injection.
+// Single source of truth so moflo-init.ts and bin/setup-project.mjs stay in sync.
+const LEGACY_MARKER_STARTS = [
+  '<!-- MOFLO:START -->',
+  '<!-- MOFLO:SUBAGENT-PROTOCOL:START -->',
+] as const;
+const LEGACY_MARKER_ENDS = [
+  '<!-- MOFLO:END -->',
+  '<!-- MOFLO:SUBAGENT-PROTOCOL:END -->',
+] as const;
+
 /**
  * The single moflo section injected into CLAUDE.md.
- * ~40 lines. Points to moflo-core-guidance.md for everything else.
+ * ~22 lines. Points to moflo-core-guidance.md for everything else.
  */
 function mofloSection(): string {
   return `${MARKER_START}
 ## MoFlo — AI Agent Orchestration
 
-This project uses [MoFlo](https://github.com/eric-cielo/moflo) for AI-assisted development spells.
-
 ### FIRST ACTION ON EVERY PROMPT: Search Memory
 
-MUST call \`mcp__moflo__memory_search\` BEFORE any Glob/Grep/Read/file exploration. Namespaces: \`guidance\`+\`patterns\`+\`learnings\` every prompt; \`code-map\` when navigating code; \`tests\` when looking for test inventory or coverage. When the user says "remember this": \`mcp__moflo__memory_store\` with namespace \`learnings\`.
+Your first tool call MUST be \`mcp__moflo__memory_search\` — before any Glob/Grep/Read. Search \`guidance\`, \`patterns\`, and \`learnings\` every prompt; add \`code-map\` when navigating code, \`tests\` when looking for test inventory or coverage. When the user says "remember this", call \`mcp__moflo__memory_store\` with namespace \`learnings\`.
 
-### Spell Gates (enforced automatically)
+### Auto-enforced gates
 
-- **Memory-first**: Must search memory before Glob/Grep/Read
-- **TaskCreate-first**: Must call TaskCreate before spawning Agent tool
+- **TaskCreate-first**: Call \`TaskCreate\` before spawning the Agent tool
+- **Task Icons**: \`TaskCreate\` entries MUST use ICON+[Role] format — see \`.claude/guidance/moflo-task-icons.md\`
 
-- **Task Icons**: \`TaskCreate\` MUST use ICON+[Role] format — see \`.claude/guidance/moflo-task-icons.md\`
+### Tools
 
-### MCP Tools (preferred over CLI)
-
-| Tool | Purpose |
-|------|---------|
-| \`mcp__moflo__memory_search\` | Semantic search across indexed knowledge |
-| \`mcp__moflo__memory_store\` | Store patterns and decisions |
-
-### CLI Fallback
-
-\`\`\`bash
-flo-search "[query]" --namespace guidance   # Semantic search
-flo doctor --fix                             # Health check
-\`\`\`
+Prefer MCP (\`mcp__moflo__*\` — memory, swarm, agent, task, hooks, hive-mind, neural) over the CLI. CLI binaries: \`flo\` (main), \`flo-search\` (semantic search), \`flo doctor --fix\` (heal). Full catalog: \`.claude/guidance/moflo-core-guidance.md\`.
 
 ### After upgrading MoFlo
 
-After running \`npm install moflo@*\` (or \`npm install\` that touches moflo), check \`.moflo/restart-pending.json\`. If it exists, surface the \`message\` field to the user verbatim (Claude Code can't pick up new hooks/MCP tools/launcher mid-session — they're only loaded at session-start), then delete the file.
+After \`npm install\` touches moflo, check \`.moflo/restart-pending.json\` — if present, surface its \`message\` field to the user verbatim, then delete the file. (Claude Code only loads new hooks/MCP/launcher at session start.)
 
 ### Full Reference
 
-- **Subagents protocol:** \`.claude/guidance/shipped/moflo-subagents.md\`
-- **Task + swarm coordination:** \`.claude/guidance/shipped/moflo-claude-swarm-cohesion.md\`
-- **CLI, hooks, swarm, memory, moflo.yaml:** \`.claude/guidance/shipped/moflo-core-guidance.md\`
+- Subagents protocol: \`.claude/guidance/moflo-subagents.md\`
+- Task + swarm coordination: \`.claude/guidance/moflo-claude-swarm-cohesion.md\`
+- CLI, hooks, swarm, memory, moflo.yaml: \`.claude/guidance/moflo-core-guidance.md\`
 ${MARKER_END}`;
 }
 
 // --- Public API ---
 
-export { MARKER_START, MARKER_END };
+export { MARKER_START, MARKER_END, LEGACY_MARKER_STARTS, LEGACY_MARKER_ENDS };
 
 /**
  * Generate the MoFlo section to inject into CLAUDE.md.
@@ -82,12 +79,12 @@ export function generateMinimalClaudeMd(options: InitOptions): string {
 
 /** Available template names for CLI wizard (kept for backward compat, all produce same output) */
 export const CLAUDE_MD_TEMPLATES: Array<{ name: ClaudeMdTemplate; description: string }> = [
-  { name: 'minimal', description: 'Recommended — memory search, spell gates, MCP tools (~40 lines injected)' },
-  { name: 'standard', description: 'Same as minimal (detailed docs in .claude/guidance/shipped/moflo-core-guidance.md)' },
-  { name: 'full', description: 'Same as minimal (detailed docs in .claude/guidance/shipped/moflo-core-guidance.md)' },
-  { name: 'security', description: 'Same as minimal (detailed docs in .claude/guidance/shipped/moflo-core-guidance.md)' },
-  { name: 'performance', description: 'Same as minimal (detailed docs in .claude/guidance/shipped/moflo-core-guidance.md)' },
-  { name: 'solo', description: 'Same as minimal (detailed docs in .claude/guidance/shipped/moflo-core-guidance.md)' },
+  { name: 'minimal', description: 'Recommended — memory search, gates, tools, upgrade hint (~22 lines injected)' },
+  { name: 'standard', description: 'Same as minimal (detailed docs in .claude/guidance/moflo-core-guidance.md)' },
+  { name: 'full', description: 'Same as minimal (detailed docs in .claude/guidance/moflo-core-guidance.md)' },
+  { name: 'security', description: 'Same as minimal (detailed docs in .claude/guidance/moflo-core-guidance.md)' },
+  { name: 'performance', description: 'Same as minimal (detailed docs in .claude/guidance/moflo-core-guidance.md)' },
+  { name: 'solo', description: 'Same as minimal (detailed docs in .claude/guidance/moflo-core-guidance.md)' },
 ];
 
 export default generateClaudeMd;

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -22,6 +22,14 @@ import {
   renderMofloYaml,
   type MofloYamlConfig,
 } from './moflo-yaml-template.js';
+import {
+  generateClaudeMd as generateMofloSection,
+  MARKER_START,
+  MARKER_END,
+  LEGACY_MARKER_STARTS,
+  LEGACY_MARKER_ENDS,
+} from './claudemd-generator.js';
+import { DEFAULT_INIT_OPTIONS } from './types.js';
 
 export { discoverTestDirs };
 
@@ -486,28 +494,19 @@ function generateSkill(root: string, force?: boolean): MofloInitResult['steps'][
 // Step 4: CLAUDE.md MoFlo section
 // ============================================================================
 
-// Markers for idempotent CLAUDE.md injection — keep in sync with claudemd-generator.ts
-const MOFLO_MARKER = '<!-- MOFLO:INJECTED:START -->';
-const MOFLO_MARKER_END = '<!-- MOFLO:INJECTED:END -->';
-// Also detect legacy markers so we can replace them
-const LEGACY_MARKERS = ['<!-- MOFLO:START -->', '<!-- MOFLO:SUBAGENT-PROTOCOL:START -->'];
-const LEGACY_MARKERS_END = ['<!-- MOFLO:END -->', '<!-- MOFLO:SUBAGENT-PROTOCOL:END -->'];
-
-function generateClaudeMd(root: string, force?: boolean): MofloInitResult['steps'][0] {
+function generateClaudeMd(root: string, _force?: boolean): MofloInitResult['steps'][0] {
   const claudeMdPath = path.join(root, 'CLAUDE.md');
   let existing = '';
 
   if (fs.existsSync(claudeMdPath)) {
     existing = fs.readFileSync(claudeMdPath, 'utf-8');
 
-    // Check for current or legacy markers
-    const allStartMarkers = [MOFLO_MARKER, ...LEGACY_MARKERS];
-    const allEndMarkers = [MOFLO_MARKER_END, ...LEGACY_MARKERS_END];
+    // Strip current or legacy MoFlo block so we can re-inject the latest content.
+    const allStartMarkers = [MARKER_START, ...LEGACY_MARKER_STARTS];
+    const allEndMarkers = [MARKER_END, ...LEGACY_MARKER_ENDS];
 
     for (let i = 0; i < allStartMarkers.length; i++) {
       if (existing.includes(allStartMarkers[i])) {
-        // Always strip the existing section so we can re-inject the latest version.
-        // This ensures CLAUDE.md stays current when moflo updates its injected content.
         const startIdx = existing.indexOf(allStartMarkers[i]);
         const endIdx = existing.indexOf(allEndMarkers[i]);
         if (endIdx > startIdx) {
@@ -517,62 +516,15 @@ function generateClaudeMd(root: string, force?: boolean): MofloInitResult['steps
     }
   }
 
-  // Minimal injection — just enough for Claude to work with moflo.
-  // All detailed docs live in .claude/guidance/shipped/moflo-core-guidance.md.
-  const mofloSection = `
-${MOFLO_MARKER}
-## MoFlo — AI Agent Orchestration
-
-This project uses [MoFlo](https://github.com/eric-cielo/moflo) for AI-assisted development spells.
-
-### FIRST ACTION ON EVERY PROMPT: Search Memory
-
-Your first tool call for every new user prompt MUST be a memory search. Do this BEFORE Glob, Grep, Read, or any file exploration.
-
-\`\`\`
-mcp__moflo__memory_search — query: "<task description>", namespace: "guidance" or "patterns" or "learnings" or "code-map" or "tests"
-\`\`\`
-
-Search \`guidance\`, \`patterns\`, and \`learnings\` namespaces on every prompt. Search \`code-map\` when navigating the codebase, \`tests\` when looking for test inventory or coverage.
-When the user asks you to remember something: \`mcp__moflo__memory_store\` with namespace \`learnings\`.
-
-### Spell Gates (enforced automatically)
-
-- **Memory-first**: Must search memory before Glob/Grep/Read
-- **TaskCreate-first**: Must call TaskCreate before spawning Agent tool
-- **Task Icons**: \`TaskCreate\` MUST use ICON+[Role] format — see \`.claude/guidance/moflo-task-icons.md\`
-
-### MCP Tools (preferred over CLI)
-
-| Tool | Purpose |
-|------|---------|
-| \`mcp__moflo__memory_search\` | Semantic search across indexed knowledge |
-| \`mcp__moflo__memory_store\` | Store patterns and decisions |
-| \`mcp__moflo__hooks_route\` | Route task to optimal agent type |
-| \`mcp__moflo__hooks_pre-task\` | Record task start |
-| \`mcp__moflo__hooks_post-task\` | Record task completion for learning |
-
-### CLI Fallback
-
-\`\`\`bash
-flo-search "[query]" --namespace guidance   # Semantic search
-flo doctor --fix                             # Health check
-\`\`\`
-
-### Full Reference
-
-For CLI commands, hooks, agents, swarm config, memory commands, and moflo.yaml options, see:
-\`.claude/guidance/shipped/moflo-core-guidance.md\`
-${MOFLO_MARKER_END}
-`;
-
-  const finalContent = existing.trimEnd() + '\n' + mofloSection;
+  // Single source of truth: claudemd-generator.ts owns the section content.
+  const canonical = generateMofloSection(DEFAULT_INIT_OPTIONS);
+  const finalContent = existing.trimEnd() + '\n\n' + canonical;
   fs.writeFileSync(claudeMdPath, finalContent, 'utf-8');
 
   return {
     name: 'CLAUDE.md',
     status: existing ? 'updated' : 'created',
-    detail: 'MoFlo section injected (~35 lines)',
+    detail: 'MoFlo section injected (~22 lines)',
   };
 }
 

--- a/src/cli/services/subagent-bootstrap.ts
+++ b/src/cli/services/subagent-bootstrap.ts
@@ -23,7 +23,7 @@ const BOOTSTRAP_JSON_REL = '.claude/helpers/subagent-bootstrap.json';
 // Defense-in-depth copy of the canonical directive in subagent-bootstrap.json.
 // Kept as a single-line literal so the parity test can verify it matches the
 // JSON via plain substring containment.
-const FALLBACK_DIRECTIVE = 'MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/shipped/moflo-subagents.md` protocol.';
+const FALLBACK_DIRECTIVE = 'MANDATORY FIRST ACTION: Your very first tool call MUST be mcp__moflo__memory_search (any query, any namespace). The memory-first gate WILL BLOCK all Glob, Grep, and Read calls until you do this. After memory search, follow `.claude/guidance/moflo-subagents.md` protocol.';
 
 function loadDirective(): string {
   const jsonPath = locateMofloRootPath(BOOTSTRAP_JSON_REL);

--- a/tests/guidance/consumer-bound-references.test.ts
+++ b/tests/guidance/consumer-bound-references.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Consumer-bound reference gate (#934).
+ *
+ * Enforces `.claude/guidance/internal/consumer-bound-references.md`:
+ * any text that ships to consumers (shipped guidance See Also, skill SKILL.md,
+ * shipped agents/commands, runtime subagent directive, injected CLAUDE.md
+ * templates) must reference moflo guidance docs at the consumer destination
+ * path `.claude/guidance/<file>.md` — never the source `.claude/guidance/shipped/<file>.md`,
+ * which only exists inside moflo's own repo and inside `node_modules/moflo/`.
+ *
+ * The gate distinguishes consumer-bound directives from descriptive source-tree
+ * references. A path preceded by `moflo/` (covering both
+ * `node_modules/moflo/.claude/guidance/shipped/moflo-…` and
+ * `Source: moflo/.claude/guidance/shipped/moflo-…` style headers) is descriptive
+ * context and allowed. Anything else is a directive Claude will try to resolve,
+ * which will ENOENT on every consumer.
+ *
+ * If this test fires on a new file, either: (1) strip `shipped/` from the path
+ * to use the consumer mirror, or (2) qualify the path with a `moflo/` prefix
+ * if it's intentional descriptive context.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+
+// Directories whose contents ship to consumers (full recursive scan).
+const CONSUMER_BOUND_DIRS = [
+  '.claude/guidance/shipped',
+  '.claude/skills',
+  '.claude/agents',
+  '.claude/commands',
+];
+
+// Individual files that ship or generate consumer-bound text at runtime.
+const CONSUMER_BOUND_FILES = [
+  '.claude/helpers/subagent-bootstrap.json',
+  '.claude/helpers/subagent-start.cjs',
+  'src/cli/services/subagent-bootstrap.ts',
+  'src/cli/init/claudemd-generator.ts',
+  'src/cli/init/moflo-init.ts',
+  'bin/setup-project.mjs',
+];
+
+// Globs to keep file enumeration tight — text-bearing surfaces only.
+const TEXT_EXTENSIONS = ['.md', '.json', '.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs', '.sh'];
+
+function walkText(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const abs = join(dir, name);
+    let st;
+    try { st = statSync(abs); } catch { continue; }
+    if (st.isDirectory()) {
+      out.push(...walkText(abs));
+    } else if (TEXT_EXTENSIONS.some(ext => name.endsWith(ext))) {
+      out.push(abs);
+    }
+  }
+  return out;
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function findViolations(absFile: string): Violation[] {
+  const violations: Violation[] = [];
+  let content: string;
+  try {
+    content = readFileSync(absFile, 'utf-8');
+  } catch {
+    return violations;
+  }
+  const lines = content.split(/\r?\n/);
+  const rel = absFile.startsWith(ROOT + sep)
+    ? absFile.slice(ROOT.length + 1).split(sep).join('/')
+    : absFile;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const re = /\.claude\/guidance\/shipped\/moflo-/g;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(line)) !== null) {
+      const before = line.slice(0, match.index);
+      // Allow when preceded by `moflo/` — descriptive source-tree path
+      // (e.g. `node_modules/moflo/.claude/guidance/shipped/moflo-...`,
+      //       `Source: moflo/.claude/guidance/shipped/moflo-...`).
+      if (/moflo\/$/.test(before)) continue;
+      violations.push({ file: rel, line: i + 1, text: line.trim() });
+    }
+  }
+  return violations;
+}
+
+function gatherTargets(): string[] {
+  const targets: string[] = [];
+  for (const rel of CONSUMER_BOUND_DIRS) {
+    const abs = resolve(ROOT, rel);
+    if (existsSync(abs)) targets.push(...walkText(abs));
+  }
+  for (const rel of CONSUMER_BOUND_FILES) {
+    const abs = resolve(ROOT, rel);
+    if (existsSync(abs)) targets.push(abs);
+  }
+  return targets;
+}
+
+describe('consumer-bound cross-reference paths', () => {
+  const targets = gatherTargets();
+
+  it('finds at least the expected consumer-bound surfaces', () => {
+    // Sanity: if this drops to zero, the path lists above silently broke.
+    expect(targets.length).toBeGreaterThan(20);
+  });
+
+  it('no consumer-bound file references `.claude/guidance/shipped/moflo-…` as a directive', () => {
+    const allViolations: Violation[] = [];
+    for (const abs of targets) {
+      allViolations.push(...findViolations(abs));
+    }
+    if (allViolations.length > 0) {
+      const summary = allViolations
+        .slice(0, 30)
+        .map(v => `  ${v.file}:${v.line}: ${v.text}`)
+        .join('\n');
+      const more = allViolations.length > 30 ? `\n  …and ${allViolations.length - 30} more` : '';
+      expect.fail(
+        `Found ${allViolations.length} consumer-bound \`shipped/\` reference(s).\n` +
+        `Strip \`shipped/\` (use \`.claude/guidance/<file>.md\`) or qualify with \`moflo/\` if intentional descriptive context.\n` +
+        `See .claude/guidance/internal/consumer-bound-references.md.\n\n` +
+        summary + more,
+      );
+    }
+  });
+});

--- a/tests/guidance/consumer-bound-references.test.ts
+++ b/tests/guidance/consumer-bound-references.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 
 const ROOT = resolve(__dirname, '../..');
@@ -49,19 +49,17 @@ const TEXT_EXTENSIONS = ['.md', '.json', '.ts', '.tsx', '.mts', '.cts', '.js', '
 
 function walkText(dir: string): string[] {
   const out: string[] = [];
-  let entries: string[];
+  let entries;
   try {
-    entries = readdirSync(dir);
+    entries = readdirSync(dir, { withFileTypes: true });
   } catch {
     return out;
   }
-  for (const name of entries) {
-    const abs = join(dir, name);
-    let st;
-    try { st = statSync(abs); } catch { continue; }
-    if (st.isDirectory()) {
+  for (const entry of entries) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) {
       out.push(...walkText(abs));
-    } else if (TEXT_EXTENSIONS.some(ext => name.endsWith(ext))) {
+    } else if (entry.isFile() && TEXT_EXTENSIONS.some(ext => entry.name.endsWith(ext))) {
       out.push(abs);
     }
   }
@@ -82,6 +80,9 @@ function findViolations(absFile: string): Violation[] {
   } catch {
     return violations;
   }
+  // Fast path: skip files that don't contain the banned substring at all.
+  // The vast majority of scanned files have zero matches.
+  if (!content.includes('.claude/guidance/shipped/moflo-')) return violations;
   const lines = content.split(/\r?\n/);
   const rel = absFile.startsWith(ROOT + sep)
     ? absFile.slice(ROOT.length + 1).split(sep).join('/')

--- a/tests/guidance/lint-guidance.test.ts
+++ b/tests/guidance/lint-guidance.test.ts
@@ -399,7 +399,18 @@ describe('Guidance Compliance Linter', () => {
 
     it('CLAUDE.md references full docs in guidance', () => {
       const content = readFile('CLAUDE.md');
-      expect(content).toContain('.claude/guidance/shipped/moflo-core-guidance.md');
+      // Consumer-bound mirror path — see internal/consumer-bound-references.md.
+      // The injected block must NOT use `shipped/` because consumers don't have that subdir.
+      expect(content).toContain('.claude/guidance/moflo-core-guidance.md');
+      // Carve-out: prose outside the MOFLO:INJECTED block may still cite `shipped/`
+      // (moflo dogfoods, so both paths resolve in this repo). The test only fails
+      // if the injected block itself regresses.
+      const start = content.indexOf('<!-- MOFLO:INJECTED:START -->');
+      const end = content.indexOf('<!-- MOFLO:INJECTED:END -->');
+      if (start >= 0 && end > start) {
+        const injected = content.slice(start, end);
+        expect(injected).not.toContain('.claude/guidance/shipped/');
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Three interlocking fixes for what consumers receive when they `npm install moflo`:

1. **Claim 1 of #934 audit** — every consumer-bound directive of the form `.claude/guidance/shipped/moflo-*.md` was unresolvable on consumer projects. Shipped guidance lives at the FLAT mirror `.claude/guidance/<file>.md` after session-start auto-sync, never under `shipped/`. Fixed across 20 shipped guidance docs, 6 shipped skills, the runtime SubagentStart directive (cjs + json + ts parity), and the injected CLAUDE.md template. Added new operational rule at `.claude/guidance/internal/consumer-bound-references.md` and a gate test that fires on any new bare `shipped/` reference.

2. **Three duplicate CLAUDE.md generators → one canonical** — audit revealed `src/cli/init/claudemd-generator.ts`, `src/cli/init/moflo-init.ts:496`, and `bin/setup-project.mjs:42` all produced the `MOFLO:INJECTED` block, all slightly drifted. Made `claudemd-generator.ts` the single source of truth; the other two delegate via the shared `bin/lib/moflo-resolve.mjs:mofloInternalURL()` helper used by every other bin script. Also exported `LEGACY_MARKER_STARTS` / `LEGACY_MARKER_ENDS` from canonical so the legacy-marker list is single-source-of-truth too.

3. **Content trim** — with dedup in place, tightened canonical content from ~40 to ~22 lines (~45% reduction): dropped redundant tagline, duplicate Memory-first bullet, 5-line MCP-tools table + 4-line CLI-fallback block (replaced with one paragraph naming the MCP namespace + the three CLI binaries). No operational directive lost.

## Bonus pre-existing bug fix

`bin/setup-project.mjs:copyBootstrap` used `mofloRoot = resolve(__dirname, '..')` which broke when run from the synced `.claude/scripts/` location. Switched to the same `mofloInternalURL`-derived path so both invocation paths work end-to-end.

## Verified end-to-end on this repo

- `flo init` path: temp-dir test with pre-existing legacy markers — strip + canonical re-inject + pre-existing content preserved
- `flo-setup` path: temp-dir test — canonical injection appended to pre-existing CLAUDE.md
- `flo-setup --check` from BOTH `bin/setup-project.mjs` AND `.claude/scripts/setup-project.mjs` (synced) reports dogfooded CLAUDE.md is byte-identical to canonical
- tsc clean
- 8004 tests pass (parallel + isolation)
- 0 ESLint warnings
- /simplify NORMAL pass: 3 findings addressed (reuse \`mofloInternalURL\` helper, drop redundant spread aliases, efficiency wins in gate test); validation pass clean

## Consumer surface touched

- **Runtime directive** (`subagent-bootstrap.json` + `subagent-start.cjs`): every subagent now sees the correct path
- **CLAUDE.md template** (`claudemd-generator.ts`): every new `flo init` and `flo-setup` writes the corrected, tightened block
- **Shipped guidance docs** (20): See Also blocks now use the consumer mirror path
- **Shipped skills** (6): cross-references updated to consumer mirror path

## Failure mode for on-current-version consumer

Picks up automatically on next session-start (launcher auto-syncs guidance + helpers from `node_modules/moflo`). No migration. No user action required. Existing CLAUDE.md is auto-rewritten by `flo init` next time it runs; older injection content remains valid until then (the new content is strictly better but the old paths still ENOENT — same as before this PR for newly-cloned consumers).

## Out of scope (flagged, not fixed here)

Session-start auto-sync currently does NOT auto-refresh stale `MOFLO:INJECTED` content in CLAUDE.md (it only syncs guidance + helpers + scripts). Per `feedback_auto_upgrade_session_start.md`, ideally the launcher would call the canonical generator and re-inject when content drifts. Worth a follow-up issue.

## Test plan

- [x] tsc clean
- [x] Full unit suite (8004 tests, parallel + isolation)
- [x] ESLint (max-warnings 0)
- [x] End-to-end `flo init` on temp dir with legacy markers
- [x] End-to-end `flo-setup` on temp dir with pre-existing CLAUDE.md
- [x] `flo-setup --check` from canonical AND synced-copy script locations
- [x] /simplify NORMAL review (reuse + quality + efficiency agents) + validation pass

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)