### PR TITLE
feat(#878): per-spell sandbox.required with more-strict-wins composition

### DIFF
--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -847,6 +847,28 @@ This is what makes spells safe for unattended and scheduled execution. You can r
 
 For full details on the sandboxing tiers, restriction rules, and how to declare capabilities on custom step commands, see [Spell Sandboxing](SPELL-SANDBOXING.md).
 
+### Per-spell `sandbox.required`
+
+A spell can declare that it MUST run inside an OS sandbox. This is useful for spells that handle untrusted input, talk to third-party APIs, or write outside the project root — the spell author gets to encode "don't even try without isolation," independent of the consumer's `moflo.yaml` settings.
+
+```yaml
+name: outlook-attachment-processor
+sandbox:
+  required: true       # default false
+steps:
+  - ...
+```
+
+The two settings — global `sandbox.enabled`/`sandbox.tier` in `moflo.yaml` and per-spell `sandbox.required` — compose under **more strict wins**: either source can opt in to sandboxing; neither can opt out of what the other requires.
+
+| Global `sandbox.enabled` | Spell `sandbox.required` | Result |
+|--------------------------|--------------------------|--------|
+| on  | (any) | sandboxed |
+| off | true  | runner refuses to cast — `SANDBOX_REQUIRED` |
+| off | false / unset | not sandboxed (existing default) |
+
+When a spell with `sandbox.required: true` is cast and no OS sandbox is active, the runner fails fast with `SANDBOX_REQUIRED`, naming the spell and pointing at the `moflo.yaml` knobs to flip. The same happens for scheduled casts via the spell scheduler — the requirement violation surfaces as a `schedule:skipped` event (not `schedule:failed`), since it's a configuration mismatch the user can resolve. `nextRunAt` still advances so cron pacing continues.
+
 ## Dry Run
 
 Dry-run mode validates everything without executing anything. It checks:

--- a/src/cli/__tests__/spells/spell-sandbox-required.test.ts
+++ b/src/cli/__tests__/spells/spell-sandbox-required.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Per-spell `sandbox.required` — more-strict-wins matrix
+ *
+ * Covers issue #878:
+ * - Schema validator accepts/rejects shapes
+ * - Runner enforces SANDBOX_REQUIRED when spell opts in but no OS sandbox is active
+ * - Runner casts normally when global sandbox is active OR when neither side requires it
+ * - Scheduler emits schedule:skipped (not schedule:failed) on SANDBOX_REQUIRED
+ *
+ * @see https://github.com/eric-cielo/moflo/issues/878
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the platform-sandbox module BEFORE importing anything that pulls it in,
+// so the runner sees our deterministic resolver instead of probing the host.
+const { resolveEffectiveSandbox } = vi.hoisted(() => ({ resolveEffectiveSandbox: vi.fn() }));
+vi.mock('../../spells/core/platform-sandbox.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../spells/core/platform-sandbox.js')>();
+  return { ...actual, resolveEffectiveSandbox };
+});
+
+import { validateSpellDefinition } from '../../spells/schema/validator.js';
+import { SpellCaster } from '../../spells/core/runner.js';
+import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
+import { SpellScheduler, type SpellExecutor } from '../../spells/scheduler/scheduler.js';
+import type { SpellSchedule } from '../../spells/scheduler/schedule.types.js';
+import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
+import type { SpellResult, SpellError } from '../../spells/types/runner.types.js';
+import type { EffectiveSandbox } from '../../spells/core/platform-sandbox.js';
+import { makeCommand, makeCredentials, makeMemory } from './helpers.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeEffectiveSandbox(useOsSandbox: boolean): EffectiveSandbox {
+  return {
+    useOsSandbox,
+    capability: {
+      platform: 'linux',
+      available: useOsSandbox,
+      tool: useOsSandbox ? 'bwrap' : null,
+      overhead: useOsSandbox ? 'low' : null,
+    },
+    config: { enabled: useOsSandbox, tier: 'auto' },
+    displayStatus: useOsSandbox ? 'OS sandbox: bwrap (linux)' : 'OS sandbox: disabled (denylist active)',
+  };
+}
+
+function buildRunner() {
+  const registry = new StepCommandRegistry();
+  registry.register(makeCommand({
+    type: 'noop',
+    capabilities: [],
+    execute: async () => ({ success: true, data: { ok: true } }),
+  }));
+  return new SpellCaster(registry, makeCredentials(), makeMemory());
+}
+
+const SPELL_REQUIRED: SpellDefinition = {
+  name: 'must-be-sandboxed',
+  sandbox: { required: true },
+  steps: [{ id: 's1', type: 'noop', config: {} }],
+};
+
+const SPELL_NOT_REQUIRED: SpellDefinition = {
+  name: 'free-to-run',
+  steps: [{ id: 's1', type: 'noop', config: {} }],
+};
+
+beforeEach(() => {
+  resolveEffectiveSandbox.mockReset();
+});
+
+// ============================================================================
+// Validator
+// ============================================================================
+
+describe('validator — sandbox block', () => {
+  it.each([
+    { label: 'missing', sandbox: undefined },
+    { label: 'empty object', sandbox: {} },
+    { label: 'required: true', sandbox: { required: true } },
+    { label: 'required: false', sandbox: { required: false } },
+  ])('accepts $label', ({ sandbox }) => {
+    const def: SpellDefinition = {
+      name: 'ok',
+      steps: [{ id: 's1', type: 'noop', config: {} }],
+      ...(sandbox !== undefined ? { sandbox } : {}),
+    };
+    const result = validateSpellDefinition(def, { knownStepTypes: ['noop'] });
+    expect(result.errors.filter(e => e.path.startsWith('sandbox'))).toHaveLength(0);
+  });
+
+  it('rejects sandbox as a non-object value', () => {
+    const def = {
+      name: 'bad', steps: [{ id: 's1', type: 'noop', config: {} }],
+      sandbox: 'yes',
+    } as unknown as SpellDefinition;
+    const result = validateSpellDefinition(def, { knownStepTypes: ['noop'] });
+    expect(result.errors).toContainEqual({ path: 'sandbox', message: 'sandbox must be an object' });
+  });
+
+  it('rejects sandbox.required as a non-boolean', () => {
+    const def = {
+      name: 'bad', steps: [{ id: 's1', type: 'noop', config: {} }],
+      sandbox: { required: 'true' },
+    } as unknown as SpellDefinition;
+    const result = validateSpellDefinition(def, { knownStepTypes: ['noop'] });
+    expect(result.errors).toContainEqual({
+      path: 'sandbox.required',
+      message: 'sandbox.required must be a boolean',
+    });
+  });
+});
+
+// ============================================================================
+// Runner — more-strict-wins matrix
+// ============================================================================
+
+describe('runner — more-strict-wins matrix', () => {
+  it('Cell 1: global on, spell.sandbox.required=true → cast proceeds (sandboxed)', async () => {
+    resolveEffectiveSandbox.mockResolvedValue(makeEffectiveSandbox(true));
+    const result = await buildRunner().run(SPELL_REQUIRED, {});
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('Cell 2: global off, spell.sandbox.required=true → SANDBOX_REQUIRED', async () => {
+    resolveEffectiveSandbox.mockResolvedValue(makeEffectiveSandbox(false));
+    const result = await buildRunner().run(SPELL_REQUIRED, {});
+    expect(result.success).toBe(false);
+    expect(result.errors[0].code).toBe('SANDBOX_REQUIRED');
+    expect(result.errors[0].message).toContain('must-be-sandboxed');
+    expect(result.errors[0].message).toContain('sandbox.enabled');
+    // No steps should have run
+    expect(result.steps).toHaveLength(0);
+  });
+
+  it('Cell 3: global off, spell.sandbox.required=false/unset → cast proceeds (no sandbox)', async () => {
+    resolveEffectiveSandbox.mockResolvedValue(makeEffectiveSandbox(false));
+    const result = await buildRunner().run(SPELL_NOT_REQUIRED, {});
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('Cell 4: global on, spell.sandbox.required=false → cast proceeds (more-strict-wins via global)', async () => {
+    resolveEffectiveSandbox.mockResolvedValue(makeEffectiveSandbox(true));
+    const result = await buildRunner().run(SPELL_NOT_REQUIRED, {});
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('explicit sandbox.required=false behaves the same as unset', async () => {
+    resolveEffectiveSandbox.mockResolvedValue(makeEffectiveSandbox(false));
+    const def: SpellDefinition = {
+      name: 'opted-out',
+      sandbox: { required: false },
+      steps: [{ id: 's1', type: 'noop', config: {} }],
+    };
+    const result = await buildRunner().run(def, {});
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Scheduler — schedule:skipped on SANDBOX_REQUIRED
+// ============================================================================
+
+describe('scheduler — SANDBOX_REQUIRED → schedule:skipped', () => {
+  function makeSchedulerExecutor(result: SpellResult): SpellExecutor {
+    return {
+      execute: vi.fn().mockResolvedValue(result),
+      exists: () => true,
+    };
+  }
+
+  function makeFailureResult(error: SpellError): SpellResult {
+    return {
+      spellId: 'sp-test',
+      success: false,
+      steps: [],
+      outputs: {},
+      errors: [error],
+      duration: 1,
+      cancelled: false,
+    };
+  }
+
+  function makeFixture(): SpellSchedule {
+    return {
+      id: 'sched-fixture-1',
+      spellName: 'x',
+      spellPath: '/x.yaml',
+      interval: '1m',
+      nextRunAt: Date.now(),
+      enabled: true,
+      createdAt: Date.now(),
+      source: 'adhoc',
+    };
+  }
+
+  // executeCore is private; cast through `unknown` to drive it directly so we
+  // don't have to drag in a memory backend that supports `search()`.
+  type SchedulerInternals = {
+    executeCore: (s: SpellSchedule, n: number, o: { manual: boolean }) => Promise<unknown>;
+  };
+
+  it('emits schedule:skipped (not schedule:failed) when runner returns SANDBOX_REQUIRED', async () => {
+    const executor = makeSchedulerExecutor(makeFailureResult({
+      code: 'SANDBOX_REQUIRED',
+      message: 'Spell "x" requires an OS sandbox but none is active.',
+    }));
+    const scheduler = new SpellScheduler(makeMemory(), executor);
+    const events: string[] = [];
+    scheduler.on(e => events.push(`${e.type}:${e.message}`));
+
+    await (scheduler as unknown as SchedulerInternals).executeCore(
+      makeFixture(), Date.now(), { manual: true },
+    );
+
+    const skipped = events.find(e => e.startsWith('schedule:skipped'));
+    const failed = events.find(e => e.startsWith('schedule:failed'));
+    expect(skipped).toBeDefined();
+    expect(skipped).toContain('OS sandbox');
+    expect(failed).toBeUndefined();
+  });
+
+  it('still emits schedule:failed for non-sandbox failures', async () => {
+    const executor = makeSchedulerExecutor(makeFailureResult({
+      code: 'STEP_EXECUTION_FAILED',
+      message: 'something else broke',
+    }));
+    const scheduler = new SpellScheduler(makeMemory(), executor);
+    const events: string[] = [];
+    scheduler.on(e => events.push(`${e.type}:${e.message}`));
+
+    await (scheduler as unknown as SchedulerInternals).executeCore(
+      makeFixture(), Date.now(), { manual: true },
+    );
+
+    expect(events.find(e => e.startsWith('schedule:failed'))).toBeDefined();
+    expect(events.find(e => e.startsWith('schedule:skipped'))).toBeUndefined();
+  });
+});

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -214,6 +214,20 @@ export class SpellCaster {
       }], definition.name);
     }
 
+    // Per-spell sandbox requirement (#878) — "more strict wins": the spell
+    // can opt in to sandboxing even when the global config is off, and the
+    // runner refuses to cast if no OS sandbox is active.
+    if (definition.sandbox?.required === true && !effectiveSandbox.useOsSandbox) {
+      return this.failureResult(spellId, startTime, [{
+        code: 'SANDBOX_REQUIRED',
+        message:
+          `Spell "${definition.name}" requires an OS sandbox but none is active ` +
+          `(${effectiveSandbox.displayStatus}). Enable sandboxing by setting ` +
+          `\`sandbox.enabled: true\` in moflo.yaml (and \`sandbox.tier: auto\` ` +
+          `or \`full\`), or remove \`sandbox.required: true\` from the spell.`,
+      }], definition.name);
+    }
+
     return this.executeSteps(definition, resolvedArgs, spellId, options, startTime, effectiveSandbox);
   }
 

--- a/src/cli/spells/scheduler/scheduler.ts
+++ b/src/cli/spells/scheduler/scheduler.ts
@@ -491,15 +491,29 @@ export class SpellScheduler {
       };
       await this.memory.write(NAMESPACE_EXECUTIONS, executionId, finalRecord);
 
-      this.emit({
-        type: result.success ? 'schedule:completed' : 'schedule:failed',
-        scheduleId: schedule.id,
-        spellName: schedule.spellName,
-        message: result.success
-          ? `Completed in ${finalRecord.duration}ms`
-          : `Failed: ${finalRecord.error}`,
-        timestamp: completedAt,
-      });
+      // SANDBOX_REQUIRED (#878) is a configuration mismatch, not a runtime
+      // failure — surface it as a skip so dashboards/oncall don't page on a
+      // missing sandbox the user can resolve in moflo.yaml.
+      const sandboxRequiredErr = result.errors.find(e => e.code === 'SANDBOX_REQUIRED');
+      if (!result.success && sandboxRequiredErr) {
+        this.emit({
+          type: 'schedule:skipped',
+          scheduleId: schedule.id,
+          spellName: schedule.spellName,
+          message: sandboxRequiredErr.message,
+          timestamp: completedAt,
+        });
+      } else {
+        this.emit({
+          type: result.success ? 'schedule:completed' : 'schedule:failed',
+          scheduleId: schedule.id,
+          spellName: schedule.spellName,
+          message: result.success
+            ? `Completed in ${finalRecord.duration}ms`
+            : `Failed: ${finalRecord.error}`,
+          timestamp: completedAt,
+        });
+      }
     } catch (err) {
       const completedAt = Date.now();
       finalRecord = {

--- a/src/cli/spells/schema/validator.ts
+++ b/src/cli/spells/schema/validator.ts
@@ -22,7 +22,7 @@ import type {
 import { isValidMofloLevel } from '../core/capability-validator.js';
 import { MOFLO_LEVEL_ORDER } from '../types/step-command.types.js';
 import { validateSchedule } from '../scheduler/cron-parser.js';
-import { validateTopLevel, validateArguments, matchesArgumentType } from './validators/top-level.js';
+import { validateTopLevel, validateArguments, matchesArgumentType, validateSandbox } from './validators/top-level.js';
 import { validateSteps } from './validators/steps.js';
 import { validatePrerequisites } from './validators/prerequisites.js';
 import { validateVariableReferences } from './validators/references.js';
@@ -43,6 +43,7 @@ export function validateSpellDefinition(
   const errors: ValidationError[] = [];
 
   validateTopLevel(def, errors);
+  validateSandbox(def, errors);
 
   if (def.mofloLevel !== undefined && !isValidMofloLevel(def.mofloLevel)) {
     errors.push({

--- a/src/cli/spells/schema/validators/top-level.ts
+++ b/src/cli/spells/schema/validators/top-level.ts
@@ -75,6 +75,26 @@ export function validateArguments(
   }
 }
 
+/**
+ * Validate the optional `sandbox` block on a spell definition.
+ * Accepts: missing, `{}`, `{ required: boolean }`.
+ * Rejects: non-object value, non-boolean `required`.
+ */
+export function validateSandbox(def: SpellDefinition, errors: ValidationError[]): void {
+  const sandbox = (def as { sandbox?: unknown }).sandbox;
+  if (sandbox === undefined) return;
+
+  if (sandbox === null || typeof sandbox !== 'object' || Array.isArray(sandbox)) {
+    errors.push({ path: 'sandbox', message: 'sandbox must be an object' });
+    return;
+  }
+
+  const { required } = sandbox as { required?: unknown };
+  if (required !== undefined && typeof required !== 'boolean') {
+    errors.push({ path: 'sandbox.required', message: 'sandbox.required must be a boolean' });
+  }
+}
+
 /** Check whether a value matches a declared ArgumentType. */
 export function matchesArgumentType(value: unknown, type: ArgumentType): boolean {
   switch (type) {

--- a/src/cli/spells/types/runner.types.ts
+++ b/src/cli/spells/types/runner.types.ts
@@ -33,6 +33,7 @@ export type SpellErrorCode =
   | 'PREREQUISITES_FAILED'
   | 'PREFLIGHT_FAILED'
   | 'MISSING_CREDENTIAL'
+  | 'SANDBOX_REQUIRED'
   | 'SPELL_CANCELLED';
 
 // ============================================================================

--- a/src/cli/spells/types/spell-definition.types.ts
+++ b/src/cli/spells/types/spell-definition.types.ts
@@ -154,6 +154,25 @@ export interface PreflightSpec {
 }
 
 // ============================================================================
+// Sandbox Requirement
+// ============================================================================
+
+/**
+ * Per-spell sandboxing requirement. Composes with the global `sandbox` block
+ * in `moflo.yaml` under "more strict wins": either source can opt in to OS
+ * sandboxing, neither can opt out of what the other requires.
+ *
+ * @see https://github.com/eric-cielo/moflo/issues/878
+ */
+export interface SandboxRequirement {
+  /**
+   * When true, the runner refuses to cast this spell unless the effective
+   * sandbox is active (`useOsSandbox: true`). Default: false.
+   */
+  readonly required?: boolean;
+}
+
+// ============================================================================
 // Spell Definition
 // ============================================================================
 
@@ -174,6 +193,12 @@ export interface SpellDefinition {
    * interactive prompt. See `PrerequisiteSpec` for detector details.
    */
   readonly prerequisites?: readonly PrerequisiteSpec[];
+  /**
+   * Per-spell sandbox requirement. When `sandbox.required` is true, the runner
+   * refuses to cast unless the effective sandbox is active. Composes with the
+   * global `sandbox` config in `moflo.yaml` under "more strict wins".
+   */
+  readonly sandbox?: SandboxRequirement;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds an optional `sandbox: { required: boolean }` block on spell definitions. When `required: true`, the runner refuses to cast unless an OS sandbox is active — independent of the consumer's `moflo.yaml` settings. Either source can opt in to sandboxing; neither can opt out of what the other requires.

| Global `sandbox.enabled` | Spell `sandbox.required` | Result |
|--------------------------|--------------------------|--------|
| on  | (any)         | sandboxed |
| off | true          | runner refuses with `SANDBOX_REQUIRED` |
| off | false / unset | not sandboxed (existing default) |

## Changes

- `types/spell-definition.types.ts` — new `SandboxRequirement` interface, `SpellDefinition.sandbox?: SandboxRequirement`.
- `types/runner.types.ts` — `SANDBOX_REQUIRED` added to `SpellErrorCode`.
- `schema/validators/top-level.ts` + `schema/validator.ts` — new `validateSandbox` rejects malformed `sandbox` blocks at definition-load time.
- `core/runner.ts` — after `resolveEffectiveSandbox`, refuses cast with a message naming the spell + remediation steps (`sandbox.enabled: true` / `sandbox.tier: auto|full`).
- `scheduler/scheduler.ts` — `executeCore` branches on `SANDBOX_REQUIRED` to emit `schedule:skipped` (not `:failed`) since the violation is a configuration mismatch the user can resolve. `nextRunAt` still advances.
- `docs/SPELLS.md` — new \"Per-spell `sandbox.required`\" subsection with the matrix table.
- `__tests__/spells/spell-sandbox-required.test.ts` — 13 new tests covering validator shapes, all four matrix cells, and the scheduler skip branch (plus non-sandbox failures still emit `:failed`).

## Design decisions (hive-mind consensus)

1. **Schema shape**: nested `sandbox: { required: boolean }` rather than flat `requireSandbox: true` — leaves the namespace open for future fields (per-spell tier override etc.) without re-litigating it later.
2. **Runner is single source of truth** for sandbox enforcement. The scheduler does not re-load `moflo.yaml` — it just branches on the runner's error code.
3. **Validator severity**: error at definition load (not warning) — surfaces malformed YAML faster.

## Test plan

- [x] 13 new unit/integration tests in `spell-sandbox-required.test.ts` — pass solo
- [x] Full spells suite (50 files / 1034 tests) passes
- [x] Adjacent suites (sandboxing, scheduler, definition-loader, yaml-loader) pass
- [x] `tsc --noEmit` clean
- [x] Pre-existing full-suite failures filed under #955 (mcp-tools-drift-guard timeout) and #956 (ADR-049 benchmark flake) — verified to also fail on `main`, not caused by this change

Closes #878