### PR TITLE
fix(#955): drift-guard walker skips .claude/worktrees (kills 7x I/O amplification)

### DIFF
--- a/src/cli/__tests__/mcp-tools-drift-guard.test.ts
+++ b/src/cli/__tests__/mcp-tools-drift-guard.test.ts
@@ -166,7 +166,10 @@ function buildCorpus(): CorpusEntry[] {
       if (st.isDirectory()) {
         // tmp/ holds one-shot audit scripts (e.g. .claude/tmp/audit-693-*) that
         // intentionally enumerate stale tool names — exclude from drift guard.
-        if (e === 'node_modules' || e === 'dist' || e === '.git' || e === 'tmp') continue;
+        // worktrees/ holds parallel-agent git worktrees, each a full clone of
+        // .claude/. Without this skip the walker reads every guidance/agent
+        // file 1+N times (#955 — fork heap pressure pushed beforeAll past 30s).
+        if (e === 'node_modules' || e === 'dist' || e === '.git' || e === 'tmp' || e === 'worktrees') continue;
         walk(full);
       } else if (st.isFile()) {
         if (SKIP_BASENAMES.has(e)) continue;
@@ -256,9 +259,9 @@ function findConsumers(tool: RegisteredTool): string[] {
 }
 
 describe('MCP Tools Drift Guard (#693)', () => {
-  // #847: warm the lazy corpus + consumer-index memos in beforeAll so the
-  // ~350ms-in-isolation / 5s+-under-load AST work doesn't burn the per-test
-  // 5s budget. Vitest's hookTimeout (10s) covers this comfortably.
+  // #847/#955: warm the lazy corpus + consumer-index memos in beforeAll so
+  // the walker work (~100 ms cold post-#955) doesn't land inside any single
+  // test's per-test budget. Defense-in-depth — it's costless when fast.
   beforeAll(() => {
     getConsumerIndex(); // also triggers getCorpus() via buildConsumerIndex()
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -96,11 +96,6 @@ export const isolationTests = [
   // real subsystem; reliably fits in 10 s alone, can drift past full-suite
   // per-test ceilings under fork contention.
   'src/cli/__tests__/doctor-checks-memory-access.test.ts',
-  // Recursively walks the entire repo (skills/agents/docs/settings + every
-  // src/.claude/scripts file) cross-referencing MCP tool names — heavy I/O
-  // hits the suite-hook setup window first and fails as a file-level error
-  // under maxForks=2 Windows contention. Passes alone in ~540 ms (4 tests).
-  'src/cli/__tests__/mcp-tools-drift-guard.test.ts',
 ];
 
 export default defineConfig({

--- a/vitest.isolation.config.ts
+++ b/vitest.isolation.config.ts
@@ -9,10 +9,6 @@ import { defineConfig } from 'vitest/config';
  * finish in 1–2 s alone can still take 10–15 s under cumulative fork
  * pressure (transform cache, dynamic imports, GC). The default 5 s is not
  * enough.
- *
- * hookTimeout matters for files like mcp-tools-drift-guard.test.ts whose
- * beforeAll primes a corpus/AST scan — fast alone, but late-batch fork
- * heap pressure pushes it past the default 10 s.
  */
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary

- `mcp-tools-drift-guard.test.ts`'s `buildCorpus()` walker recursed into `.claude/worktrees/` (parallel-agent git worktrees, each a full `.claude/` clone). With 5 active worktrees, it read every guidance/agent file 6× — 7,769 files / 77 MB / 798 corpus entries vs the real 1,163 / 11.7 MB / 83.
- Under fork heap pressure (after ~40 isolation files share one fork), the allocation churn pushed `beforeAll` past the (already-bumped) 30 s `hookTimeout`. Adding `worktrees` to the walker's directory skip list — mirroring the `.claude/worktrees/**` exclude vitest itself uses (`vitest.config.ts:134`) — drops cold time from 862 ms to 111 ms.
- Drift-guard returns to the parallel pass (Pass 1, ~355 ms) and is removed from `isolationTests`. The `hookTimeout` bump in `vitest.isolation.config.ts` stays (touching it risks unrelated isolation tests) but its drift-guard rationale comment is dropped.

## Why this happened

The 30 s `hookTimeout` bump in `df3e91bf` was the last patch on top of the original #847 isolation move — a `feedback_no_test_timeout_bumps.md` violation that masked the real bug for ~5 days. The next failure (#955) surfaced the actual cause: walker amplification from parallel-agent worktrees. Root-cause fix → walker stays correct, no timeouts touched.

## Test plan
- [x] `npx vitest run src/cli/__tests__/mcp-tools-drift-guard.test.ts` — passes in 342 ms (was ~540 ms / now reads 111 ms cold)
- [x] `npm test` — full suite green twice (8097/0); drift-guard ran in Pass 1 parallel suite at 355 ms, not Pass 2 isolation
- [x] Walker correctness: still detects every existing MCP tool consumer (drift-guard's three `it()` blocks all pass — registered/orphan/allowlist/inverse-direction checks)
- [x] Reviewer pass: no other test walker rooted in `.claude/` is at risk (`_helpers/repo-walk.ts` already skips dot-prefix dirs implicitly; `published-package-drift-guard` and `skill-and-guidance-size-drift` don't root in `.claude/`)

Closes #955

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)