### PR TITLE
fix(#956): move ADR-049 perf benchmark out of npm test into npm run bench

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -393,8 +393,11 @@ module.exports = {
       //  - `__mocks__/` — vitest manual mock dirs (incl. production-adjacent
       //    mock-provider modules imported from prod via `useMockEmbeddings`)
       //  - `tests/` — package-level alt layout (e.g. guidance package)
-      //  - `benchmarks/` — microbenchmarks that simulate hash embeddings
-      //    intentionally to measure vector-math throughput
+      //  - `benchmarks/`, `*.bench.ts`, `*.perf.ts` — microbenchmarks /
+      //    perf-threshold suites that simulate hash embeddings intentionally
+      //    to measure vector-math throughput. `*.perf.ts` runs via
+      //    `npm run bench` (#956); excluded from npm publish via package.json
+      //    `!**/*.perf.js`, so this allowlist is dev-only — never ships.
       files: [
         'src/**/__tests__/**',
         'src/**/__mocks__/**',
@@ -403,6 +406,7 @@ module.exports = {
         'src/**/*.test.ts',
         'src/**/*.test.js',
         'src/**/*.bench.ts',
+        'src/**/*.perf.ts',
         'src/**/*.spec.ts',
         'src/**/*.spec.js',
         'src/__tests__/**',

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:ui": "vitest --ui",
     "test:smoke": "node harness/consumer-smoke/run.mjs",
     "test:smoke:populated": "node harness/consumer-smoke/run-populated.mjs",
+    "bench": "vitest run --config vitest.bench.config.ts",
     "lint": "eslint src/ bin/ .claude/scripts/ --ext .ts,.tsx,.mts,.cts,.js,.mjs,.cjs --max-warnings 0",
     "security:audit": "npm audit --omit=dev --audit-level high",
     "security:fix": "npm audit fix",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "src/cli/spells/definitions/**/*.yaml",
     "!**/*.test.js",
     "!**/*.spec.js",
+    "!**/*.perf.js",
     "!**/__tests__/**",
     ".claude/commands/**/*.md",
     ".claude/agents/**/*.md",

--- a/src/cli/memory/benchmark.perf.ts
+++ b/src/cli/memory/benchmark.perf.ts
@@ -1,3 +1,7 @@
+// ADR-049 perf-threshold suite. Run with `npm run bench` — this file is
+// .perf.ts so it sits outside the vitest test-include glob and doesn't
+// gate `npm test` (#956: hard thresholds were tripping under Windows
+// maxForks=2 fork CPU contention even though the code wasn't regressing).
 import { describe, it, expect, vi } from 'vitest';
 import { tmpdir } from 'node:os';
 import { MemoryGraph } from './memory-graph.js';

--- a/vitest.bench.config.ts
+++ b/vitest.bench.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Bench config: runs `*.perf.ts` files outside the `npm test` gate.
+ * Wired via `npm run bench`. See #956 — perf-threshold suites belong in
+ * a dedicated phase, not racing with the unit-test fork pool for CPU.
+ */
+export default defineConfig({
+  test: {
+    pool: 'forks',
+    execArgv: ['--max-old-space-size=12288'],
+    maxForks: 1,
+    minForks: 1,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    include: ['src/cli/**/*.perf.ts'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '.git/**',
+      '.claude/worktrees/**',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

- Closes #956. Moves the 16-test ADR-049 perf-threshold suite (`src/cli/memory/benchmark.test.ts`) out of `npm test` into a new `npm run bench` phase. Was failing intermittently when its hard `expect(dt).toBeLessThan(...)` bounds tripped under maxForks=2 Windows fork CPU contention — the code wasn't regressing, the gate was.
- `git mv → benchmark.perf.ts` so the file sits outside vitest's main include glob (`*.{test,spec}.{ts,mts}`); no `exclude:` entry needed in `vitest.config.ts`. Reserves `.bench.ts` for vitest-bench-mode files (e.g. `vector-search.bench.ts`).
- New `vitest.bench.config.ts` (single-fork, `include: ['src/cli/**/*.perf.ts']`) + `npm run bench` script. Threshold assertions stay `it()`/`expect()` so real regressions still fail-fast — just not against fork pool contention.

## Test plan

- [x] `npm run bench` → 16/16 pass locally in 840 ms
- [x] `npx vitest list` → file no longer discovered by main config
- [x] `npm test` full suite → 8081 passed, 0 failed (parallel + isolation passes)
- [x] `feedback_no_test_timeout_bumps.md` posture upheld — no `isolationTests` parking, no timeout bumps in main test config

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)