### PR TITLE
fix(#963): surface memory_delete failure reasons

### DIFF
--- a/src/cli/__tests__/bridge-entries.test.ts
+++ b/src/cli/__tests__/bridge-entries.test.ts
@@ -17,7 +17,7 @@ import {
   _resetBridgeEmbedderCacheForTest,
   type BridgeEmbedder,
 } from '../memory/bridge-embedder.js';
-import { bridgeSearchEntries, bridgeStoreEntry } from '../memory/bridge-entries.js';
+import { bridgeDeleteEntry, bridgeListEntries, bridgeSearchEntries, bridgeStoreEntry } from '../memory/bridge-entries.js';
 import { _resetProjectRootForTest, execRows, getDb } from '../memory/bridge-core.js';
 import { shutdownBridge, getControllerRegistry } from '../memory/memory-bridge.js';
 
@@ -396,5 +396,74 @@ describe('bridgeSearchEntries — query embedder wiring (#837 Defect A)', () => 
     });
     expect(unfiltered?.results.length).toBe(1);
     expect(unfiltered?.results[0]?.key).toBe('low-sim');
+  });
+});
+
+describe('bridgeDeleteEntry — error surfacing (#963)', () => {
+  it('successfully deletes an existing entry and removes it from list', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    await bridgeStoreEntry({
+      key: 'k-delete-me',
+      value: 'goodbye',
+      namespace: 'scheduled-spells',
+      dbPath,
+    });
+
+    const before = await bridgeListEntries({ namespace: 'scheduled-spells', dbPath });
+    expect(before?.entries.find(e => e.key === 'k-delete-me')).toBeDefined();
+
+    const result = await bridgeDeleteEntry({
+      key: 'k-delete-me',
+      namespace: 'scheduled-spells',
+      dbPath,
+    });
+
+    expect(result?.success).toBe(true);
+    expect(result?.deleted).toBe(true);
+    expect(result?.error).toBeUndefined();
+
+    const after = await bridgeListEntries({ namespace: 'scheduled-spells', dbPath });
+    expect(after?.entries.find(e => e.key === 'k-delete-me')).toBeUndefined();
+  });
+
+  it('returns success:false with a key-not-found error when the key does not exist', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    const result = await bridgeDeleteEntry({
+      key: 'never-existed',
+      namespace: 'scheduled-spells',
+      dbPath,
+    });
+
+    expect(result?.success).toBe(false);
+    expect(result?.deleted).toBe(false);
+    expect(result?.error).toBe("Key 'never-existed' not found in namespace 'scheduled-spells'");
+  });
+
+  it('returns success:false with a key-not-found error when the namespace is wrong', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    await bridgeStoreEntry({
+      key: 'k-ns-test',
+      value: 'in-correct-ns',
+      namespace: 'correct-ns',
+      dbPath,
+    });
+
+    const result = await bridgeDeleteEntry({
+      key: 'k-ns-test',
+      namespace: 'wrong-ns',
+      dbPath,
+    });
+
+    expect(result?.success).toBe(false);
+    expect(result?.deleted).toBe(false);
+    expect(result?.error).toContain('not found in namespace');
+    expect(result?.error).toContain('wrong-ns');
+
+    // Original entry still in correct namespace
+    const list = await bridgeListEntries({ namespace: 'correct-ns', dbPath });
+    expect(list?.entries.find(e => e.key === 'k-ns-test')).toBeDefined();
   });
 });

--- a/src/cli/__tests__/memory-tools-delete-error-reasons.test.ts
+++ b/src/cli/__tests__/memory-tools-delete-error-reasons.test.ts
@@ -3,7 +3,7 @@
  * whenever the delete fails, instead of silently returning
  * { success: false, deleted: false }.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MCPTool } from '../mcp-tools/types.js';
 
 const deleteSpy = vi.fn();
@@ -24,9 +24,6 @@ vi.mock('../services/spell-gate.js', () => ({
 
 beforeEach(() => {
   deleteSpy.mockReset();
-});
-afterEach(() => {
-  vi.restoreAllMocks();
 });
 
 async function getDeleteTool(): Promise<MCPTool> {

--- a/src/cli/__tests__/memory-tools-delete-error-reasons.test.ts
+++ b/src/cli/__tests__/memory-tools-delete-error-reasons.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Issue #963 — memory_delete must surface a human-readable error
+ * whenever the delete fails, instead of silently returning
+ * { success: false, deleted: false }.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MCPTool } from '../mcp-tools/types.js';
+
+const deleteSpy = vi.fn();
+
+vi.mock('../memory/memory-initializer.js', () => ({
+  storeEntry: vi.fn(),
+  searchEntries: vi.fn(),
+  listEntries: vi.fn(),
+  getEntry: vi.fn(),
+  deleteEntry: deleteSpy,
+  initializeMemoryDatabase: vi.fn(async () => ({ success: true, dbPath: '' })),
+  checkMemoryInitialization: vi.fn(async () => ({ initialized: true, dbPath: '', tableExists: true, version: '3.0.0' })),
+}));
+
+vi.mock('../services/spell-gate.js', () => ({
+  GateService: class { recordMemorySearched() { /* noop */ } },
+}));
+
+beforeEach(() => {
+  deleteSpy.mockReset();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function getDeleteTool(): Promise<MCPTool> {
+  const mod = await import('../mcp-tools/memory-tools.js');
+  const tool = (mod.memoryTools as MCPTool[]).find(t => t.name === 'memory_delete');
+  if (!tool) throw new Error('memory_delete not registered');
+  return tool;
+}
+
+describe('memory_delete MCP handler — error surfacing (#963)', () => {
+  it('returns success:true and deleted:true on a real deletion', async () => {
+    deleteSpy.mockResolvedValueOnce({
+      success: true,
+      deleted: true,
+      key: 'k1',
+      namespace: 'ns',
+      remainingEntries: 0,
+    });
+
+    const tool = await getDeleteTool();
+    const out = await tool.handler({ key: 'k1', namespace: 'ns' }) as Record<string, unknown>;
+
+    expect(out.success).toBe(true);
+    expect(out.deleted).toBe(true);
+    expect(out.error).toBeUndefined();
+  });
+
+  it('passes through a "key not found" error from the storage layer', async () => {
+    deleteSpy.mockResolvedValueOnce({
+      success: false,
+      deleted: false,
+      key: 'missing',
+      namespace: 'ns',
+      remainingEntries: 0,
+      error: "Key 'missing' not found in namespace 'ns'",
+    });
+
+    const tool = await getDeleteTool();
+    const out = await tool.handler({ key: 'missing', namespace: 'ns' }) as Record<string, unknown>;
+
+    expect(out.success).toBe(false);
+    expect(out.deleted).toBe(false);
+    expect(out.error).toBe("Key 'missing' not found in namespace 'ns'");
+  });
+
+  it('synthesises an error when the storage layer returns deleted:false with no reason', async () => {
+    // Simulates the legacy silent-failure shape; should NEVER appear post-fix
+    // from the bridge, but the handler still belt-and-braces it.
+    deleteSpy.mockResolvedValueOnce({
+      success: true,
+      deleted: false,
+      key: 'k2',
+      namespace: 'ns',
+      remainingEntries: 0,
+    });
+
+    const tool = await getDeleteTool();
+    const out = await tool.handler({ key: 'k2', namespace: 'ns' }) as Record<string, unknown>;
+
+    expect(out.success).toBe(false);
+    expect(out.deleted).toBe(false);
+    expect(typeof out.error).toBe('string');
+    expect(out.error as string).toContain("k2");
+    expect(out.error as string).toContain("ns");
+  });
+
+  it('surfaces a thrown exception as the error field', async () => {
+    deleteSpy.mockRejectedValueOnce(new Error('disk write failed'));
+
+    const tool = await getDeleteTool();
+    const out = await tool.handler({ key: 'k3', namespace: 'ns' }) as Record<string, unknown>;
+
+    expect(out.success).toBe(false);
+    expect(out.deleted).toBe(false);
+    expect(out.error).toBe('disk write failed');
+  });
+
+  it('defaults namespace to "default" when omitted', async () => {
+    deleteSpy.mockResolvedValueOnce({
+      success: true,
+      deleted: true,
+      key: 'k4',
+      namespace: 'default',
+      remainingEntries: 0,
+    });
+
+    const tool = await getDeleteTool();
+    const out = await tool.handler({ key: 'k4' }) as Record<string, unknown>;
+
+    expect(deleteSpy).toHaveBeenCalledWith({ key: 'k4', namespace: 'default' });
+    expect(out.namespace).toBe('default');
+    expect(out.success).toBe(true);
+  });
+});

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -424,12 +424,23 @@ export const memoryTools: MCPTool[] = [
       try {
         const result = await deleteEntry({ key, namespace });
 
+        // Issue #963: surface the underlying reason when delete fails.
+        // `result.success` reflects whether the call itself succeeded; we
+        // require `deleted === true` for the MCP-level success boolean,
+        // and pass `result.error` through whenever the delete didn't take.
+        const deleted = result.deleted === true;
+        const errorReason = result.error
+          ?? (deleted
+            ? undefined
+            : `No entry deleted (key='${key}', namespace='${namespace}'); reason not reported by storage layer`);
+
         return {
-          success: result.deleted,
+          success: result.success === true && deleted,
           key,
           namespace,
-          deleted: result.deleted,
+          deleted,
           backend: 'sql.js + HNSW',
+          ...(errorReason ? { error: errorReason } : {}),
         };
       } catch (error) {
         return {

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -429,10 +429,9 @@ export const memoryTools: MCPTool[] = [
         // require `deleted === true` for the MCP-level success boolean,
         // and pass `result.error` through whenever the delete didn't take.
         const deleted = result.deleted === true;
-        const errorReason = result.error
-          ?? (deleted
-            ? undefined
-            : `No entry deleted (key='${key}', namespace='${namespace}'); reason not reported by storage layer`);
+        const errorReason = !deleted
+          ? (result.error ?? `No entry deleted (key='${key}', namespace='${namespace}'); reason not reported by storage layer`)
+          : undefined;
 
         return {
           success: result.success === true && deleted,

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -597,7 +597,11 @@ export async function bridgeGetEntry(options: {
 }
 
 /**
- * Soft-delete an entry. Guarded, cache-invalidated, attested.
+ * Hard-delete an entry. Guarded, cache-invalidated, attested.
+ *
+ * Failure modes (issue #963): every non-success path now carries a
+ * human-readable `error` so MCP callers can surface the reason instead
+ * of seeing a silent `{ deleted: false }`.
  */
 export async function bridgeDeleteEntry(options: {
   key: string;
@@ -620,6 +624,36 @@ export async function bridgeDeleteEntry(options: {
       return { success: false, deleted: false, key, namespace, remainingEntries: 0, error: `MutationGuard rejected: ${guardResult.reason}` };
     }
 
+    let existed = false;
+    try {
+      const existsRows = execRows(
+        ctx.db,
+        `SELECT 1 as found FROM memory_entries WHERE key = ? AND namespace = ? AND status = 'active' LIMIT 1`,
+        [key, namespace],
+      );
+      existed = existsRows.length > 0;
+    } catch (err) {
+      return {
+        success: false,
+        deleted: false,
+        key,
+        namespace,
+        remainingEntries: 0,
+        error: `DB read failed during delete pre-check: ${errorDetail(err)}`,
+      };
+    }
+
+    if (!existed) {
+      return {
+        success: false,
+        deleted: false,
+        key,
+        namespace,
+        remainingEntries: 0,
+        error: `Key '${key}' not found in namespace '${namespace}'`,
+      };
+    }
+
     let changes = 0;
     try {
       ctx.db.prepare(`
@@ -629,31 +663,48 @@ export async function bridgeDeleteEntry(options: {
       // sql.js Statement.run returns true/false, not { changes }. Use
       // db.getRowsModified() to read the row count from the last statement.
       changes = ctx.db.getRowsModified?.() ?? 0;
-    } catch {
-      return null;
+    } catch (err) {
+      return {
+        success: false,
+        deleted: false,
+        key,
+        namespace,
+        remainingEntries: 0,
+        error: `DELETE failed: ${errorDetail(err)}`,
+      };
     }
 
-    if (changes > 0) persistBridgeDb(ctx.db, options.dbPath);
+    if (changes === 0) {
+      // SELECT found the row but DELETE removed nothing. Most likely cause:
+      // bridge holds an in-memory snapshot that diverged from disk
+      // (sql.js writeback semantics — see feedback_sqljs_writeback_clobber.md).
+      return {
+        success: false,
+        deleted: false,
+        key,
+        namespace,
+        remainingEntries: 0,
+        error: `Internal inconsistency: row matched SELECT but DELETE removed 0 rows (key='${key}', namespace='${namespace}'). Possible bridge cache staleness — restart the daemon and retry.`,
+      };
+    }
 
+    persistBridgeDb(ctx.db, options.dbPath);
     await cacheInvalidate(registry, makeEntryCacheKey(namespace, key));
-
-    if (changes > 0) {
-      await logAttestation(registry, 'delete', key, { namespace });
-    }
+    await logAttestation(registry, 'delete', key, { namespace });
 
     let remaining = 0;
     try {
       const result = ctx.db.exec(`SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active'`);
       remaining = result[0]?.values?.[0]?.[0] ?? 0;
     } catch {
-      // Non-fatal
+      // Non-fatal — count is informational
     }
 
-    if (changes > 0) refreshVectorStatsCache();
+    refreshVectorStatsCache();
 
     return {
       success: true,
-      deleted: changes > 0,
+      deleted: true,
       key,
       namespace,
       remainingEntries: remaining,

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -618,10 +618,12 @@ export async function bridgeDeleteEntry(options: {
 } | null> {
   return withDb(options.dbPath, async (ctx, registry) => {
     const { key, namespace = 'default' } = options;
+    const deleteFail = (error: string) =>
+      ({ success: false, deleted: false, key, namespace, remainingEntries: 0, error } as const);
 
     const guardResult = await guardValidate(registry, 'delete', { key, namespace });
     if (!guardResult.allowed) {
-      return { success: false, deleted: false, key, namespace, remainingEntries: 0, error: `MutationGuard rejected: ${guardResult.reason}` };
+      return deleteFail(`MutationGuard rejected: ${guardResult.reason}`);
     }
 
     let existed = false;
@@ -633,25 +635,11 @@ export async function bridgeDeleteEntry(options: {
       );
       existed = existsRows.length > 0;
     } catch (err) {
-      return {
-        success: false,
-        deleted: false,
-        key,
-        namespace,
-        remainingEntries: 0,
-        error: `DB read failed during delete pre-check: ${errorDetail(err)}`,
-      };
+      return deleteFail(`DB read failed during delete pre-check: ${errorDetail(err)}`);
     }
 
     if (!existed) {
-      return {
-        success: false,
-        deleted: false,
-        key,
-        namespace,
-        remainingEntries: 0,
-        error: `Key '${key}' not found in namespace '${namespace}'`,
-      };
+      return deleteFail(`Key '${key}' not found in namespace '${namespace}'`);
     }
 
     let changes = 0;
@@ -664,28 +652,16 @@ export async function bridgeDeleteEntry(options: {
       // db.getRowsModified() to read the row count from the last statement.
       changes = ctx.db.getRowsModified?.() ?? 0;
     } catch (err) {
-      return {
-        success: false,
-        deleted: false,
-        key,
-        namespace,
-        remainingEntries: 0,
-        error: `DELETE failed: ${errorDetail(err)}`,
-      };
+      return deleteFail(`DELETE failed: ${errorDetail(err)}`);
     }
 
     if (changes === 0) {
       // SELECT found the row but DELETE removed nothing. Most likely cause:
       // bridge holds an in-memory snapshot that diverged from disk
       // (sql.js writeback semantics — see feedback_sqljs_writeback_clobber.md).
-      return {
-        success: false,
-        deleted: false,
-        key,
-        namespace,
-        remainingEntries: 0,
-        error: `Internal inconsistency: row matched SELECT but DELETE removed 0 rows (key='${key}', namespace='${namespace}'). Possible bridge cache staleness — restart the daemon and retry.`,
-      };
+      return deleteFail(
+        `Internal inconsistency: row matched SELECT but DELETE removed 0 rows (key='${key}', namespace='${namespace}'). Possible bridge cache staleness — restart the daemon and retry.`,
+      );
     }
 
     persistBridgeDb(ctx.db, options.dbPath);
@@ -694,8 +670,8 @@ export async function bridgeDeleteEntry(options: {
 
     let remaining = 0;
     try {
-      const result = ctx.db.exec(`SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active'`);
-      remaining = result[0]?.values?.[0]?.[0] ?? 0;
+      const countRows = execRows(ctx.db, `SELECT COUNT(*) as cnt FROM memory_entries WHERE status = 'active'`);
+      remaining = Number(countRows[0]?.cnt ?? 0);
     } catch {
       // Non-fatal — count is informational
     }


### PR DESCRIPTION
## Summary

- `mcp__moflo__memory_delete` returned `{ success: false, deleted: false }` with no `error` field even when the storage layer knew exactly why (e.g. "Key 'X' not found in namespace 'Y'"). Two layers were swallowing the reason.
- MCP handler (`src/cli/mcp-tools/memory-tools.ts`) now passes `result.error` through and uses `result.success && deleted` for the success boolean.
- Bridge (`src/cli/memory/bridge-entries.ts`) does an existence SELECT before the DELETE and returns distinct errors for guard-rejected, key-not-found, DB-read failed, DELETE failed, and the inconsistency case (SELECT matched but DELETE removed 0 rows — likely sql.js writeback/cache staleness).

## Consumer impact

- **Surface touched:** MCP `memory_delete` handler + bridge layer. Runs in every consumer's MCP server / daemon.
- **Failure mode for on-current-version consumers:** strictly additive. Existing successful deletes continue to return the same shape; failed deletes now include an `error` field. No migration needed.
- **Round-trip cost:** runtime fix — needs to be published to npm before consumers see it.

## Test plan

- [x] Unit tests for the MCP handler (5 cases): success, key-not-found passthrough, defensive synthesis, thrown exception, default namespace.
- [x] Integration tests against the real bridge (3 cases): happy delete + list-confirms-removed, key-not-found, wrong-namespace.
- [x] Full \`npm test\` — 8117 tests pass (no regressions).
- [x] Lint clean.
- [x] /flo-simplify SMALL pass + validation pass clean.

Closes #963

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)