### PR TITLE
feat(#964): The Arcane Console rebrand + live schedule-event SSE stream

### DIFF
--- a/.claude/guidance/shipped/moflo-spell-scheduling.md
+++ b/.claude/guidance/shipped/moflo-spell-scheduling.md
@@ -94,7 +94,7 @@ Practical floors:
 | Namespace | Contents | Written by | Read by |
 |-----------|----------|------------|---------|
 | `scheduled-spells` | `SpellSchedule` records (id, spellName, timing, nextRunAt, enabled, args) | `flo spell schedule create`, definition load | Scheduler poll loop, `flo spell schedule list` |
-| `schedule-executions` | `ScheduleExecution` audit records (startedAt, completedAt, success, error, duration, manualRun) | Scheduler at execute-start and execute-end | Daemon dashboard, `flo spell schedule executions` |
+| `schedule-executions` | `ScheduleExecution` audit records (startedAt, completedAt, success, error, duration, manualRun) | Scheduler at execute-start and execute-end | The Arcane Console, `flo spell schedule executions` |
 
 When debugging "did my schedule fire?", read `schedule-executions` directly via `mcp__moflo__memory_list namespace=schedule-executions` if the CLI is unavailable.
 

--- a/.claude/skills/spell-schedule/SKILL.md
+++ b/.claude/skills/spell-schedule/SKILL.md
@@ -125,7 +125,7 @@ npx flo spell schedule executions --schedule <schedule-id> 2>&1
 
 `executions` reads from the daemon-written `schedule-executions` namespace and shows started time, status (success/failed/running), duration, and whether the run was manual. This is the only command that proves a schedule actually fired — `flo spell schedule list` only shows the schedule definition.
 
-If the user wants to wait for the first fire (interval ≤ 5m), poll `flo spell schedule executions --schedule <id>` or watch the daemon dashboard. Otherwise, summarize and exit:
+If the user wants to wait for the first fire (interval ≤ 5m), poll `flo spell schedule executions --schedule <id>` or watch The Arcane Console (the daemon's localhost UI). Otherwise, summarize and exit:
 
 ```
 Scheduled: <schedule-id>

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ flo daemon status    # shows whether the service is registered AND running
 
 `flo spell schedule create` warns when the daemon isn't installed so you don't quietly miss runs.
 
-**Monitoring.** The daemon dashboard surfaces live schedules, recent executions, and per-schedule controls (disable / re-enable / run now). It starts alongside the daemon at `http://localhost:3117` (override with `--dashboard-port` or disable with `--no-dashboard`).
+**Monitoring.** **The Arcane Console** (the moflo daemon's localhost UI) surfaces live schedules, recent executions, and per-schedule controls (disable / re-enable / run now). It starts alongside the daemon at `http://localhost:3117` (override with `--dashboard-port` or disable with `--no-dashboard`).
 
 For full configuration (`scheduler:` block in `moflo.yaml`), event types, and the catch-up window after restarts, see [docs/SPELLS.md#scheduling](docs/SPELLS.md#scheduling).
 

--- a/src/cli/__tests__/daemon-dashboard.test.ts
+++ b/src/cli/__tests__/daemon-dashboard.test.ts
@@ -592,8 +592,12 @@ describe('DaemonDashboard', () => {
       req.setTimeout(3000, () => { req.destroy(); reject(new Error('timeout')); });
     });
 
-    // Allow the server's 'close' handler to run before asserting.
-    await new Promise(r => setTimeout(r, 50));
+    // Poll the listener count rather than sleeping — slow CI machines need
+    // more than a fixed 50ms wall-clock for the close handler to fire.
+    const deadline = Date.now() + 2000;
+    while (scheduler.__listenerCount() > 0 && Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, 10));
+    }
     expect(scheduler.__listenerCount()).toBe(0);
   });
 });

--- a/src/cli/__tests__/daemon-dashboard.test.ts
+++ b/src/cli/__tests__/daemon-dashboard.test.ts
@@ -1,5 +1,5 @@
 /**
- * Daemon Dashboard Tests
+ * The Arcane Console (daemon dashboard) Tests
  *
  * Tests the dashboard HTTP server, API routes, and HTML serving.
  */
@@ -33,6 +33,7 @@ function makeMockScheduler(opts: {
   const schedules = new Map<string, Record<string, unknown>>();
   for (const s of opts.schedules ?? []) schedules.set(s.id as string, { ...s });
   const history = { ...(opts.history ?? {}) };
+  const listeners: Array<(ev: Record<string, unknown>) => void> = [];
 
   const scheduler = {
     listSchedules: vi.fn().mockImplementation(async () => [...schedules.values()]),
@@ -69,6 +70,19 @@ function makeMockScheduler(opts: {
       history[id] = [...(history[id] ?? []), exec];
       return exec;
     }),
+    on: vi.fn().mockImplementation((listener: (ev: Record<string, unknown>) => void) => {
+      listeners.push(listener);
+      return () => {
+        const idx = listeners.indexOf(listener);
+        if (idx >= 0) listeners.splice(idx, 1);
+      };
+    }),
+    /** Test helper: synthesize an event to all subscribers. */
+    __emit: (ev: Record<string, unknown>) => {
+      for (const l of listeners) l(ev);
+    },
+    /** Test helper: number of currently attached listeners. */
+    __listenerCount: () => listeners.length,
   };
   return { scheduler, schedules, history };
 }
@@ -191,7 +205,7 @@ describe('DaemonDashboard', () => {
     const res = await fetchDashboard(testPort, '/');
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/html');
-    expect(res.body).toContain('MoFlo Dashboard');
+    expect(res.body).toContain('The Arcane Console');
     expect(res.body).toContain('<!DOCTYPE html>');
     expect(res.body).toContain('switchTab');
   });
@@ -494,6 +508,93 @@ describe('DaemonDashboard', () => {
     expect(data.executions[0].context).toEqual(context);
     expect(data.executions[0].context.type).toBe('ticket');
     expect(data.executions[0].context.label).toContain('#350');
+  });
+
+  it('GET /api/schedules/events returns 503 when scheduler is not attached', async () => {
+    const daemon = makeMockDaemon({}, /*scheduler*/ null);
+    dashboard = await startDashboard(daemon, { port: testPort, schedulerEnabledInConfig: true });
+
+    const res = await fetchDashboard(testPort, '/api/schedules/events');
+    expect(res.status).toBe(503);
+    const data = JSON.parse(res.body);
+    expect(data.error).toContain('Scheduler not attached');
+  });
+
+  it('GET /api/schedules/events streams scheduler events as SSE frames', async () => {
+    const { scheduler } = makeMockScheduler({ schedules: [] });
+    const daemon = makeMockDaemon({}, scheduler);
+    dashboard = await startDashboard(daemon, { port: testPort, schedulerEnabledInConfig: true });
+
+    // Open the SSE stream and collect frames as they arrive
+    const frames: string[] = await new Promise((resolve, reject) => {
+      const collected: string[] = [];
+      const req = http.get(`http://127.0.0.1:${testPort}/api/schedules/events`, (res) => {
+        expect(res.statusCode).toBe(200);
+        expect(res.headers['content-type']).toContain('text/event-stream');
+        res.setEncoding('utf8');
+        let buf = '';
+        res.on('data', (chunk: string) => {
+          buf += chunk;
+          // SSE frames end with \n\n; emit completed frames
+          let idx;
+          while ((idx = buf.indexOf('\n\n')) >= 0) {
+            collected.push(buf.slice(0, idx));
+            buf = buf.slice(idx + 2);
+            if (collected.length >= 2) {
+              req.destroy();
+              resolve(collected);
+              return;
+            }
+          }
+        });
+        res.on('error', reject);
+        res.on('close', () => { if (collected.length > 0) resolve(collected); });
+      });
+      req.on('error', reject);
+      req.setTimeout(3000, () => { req.destroy(); reject(new Error('timeout')); });
+
+      // Emit a synthetic event after a short delay so the listener is attached
+      setTimeout(() => {
+        scheduler.__emit({
+          type: 'schedule:catchup',
+          scheduleId: 'sched-x',
+          spellName: 'demo',
+          message: 'Catching up after restart',
+          timestamp: Date.now(),
+        });
+      }, 30);
+    });
+
+    // Frame 0 should be the 'ready' announcement; frame 1 the catchup event
+    expect(frames[0]).toContain('event: ready');
+    expect(frames[1]).toContain('event: schedule:catchup');
+    expect(frames[1]).toContain('"spellName":"demo"');
+  });
+
+  it('SSE listener is detached when client disconnects', async () => {
+    const { scheduler } = makeMockScheduler({ schedules: [] });
+    const daemon = makeMockDaemon({}, scheduler);
+    dashboard = await startDashboard(daemon, { port: testPort, schedulerEnabledInConfig: true });
+
+    expect(scheduler.__listenerCount()).toBe(0);
+
+    // Open the stream long enough to register the listener, then bail out.
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get(`http://127.0.0.1:${testPort}/api/schedules/events`, (res) => {
+        res.on('data', () => {
+          // Any byte means the handler ran scheduler.on() \u2014 close the stream now.
+          req.destroy();
+          resolve();
+        });
+        res.on('error', reject);
+      });
+      req.on('error', () => resolve());
+      req.setTimeout(3000, () => { req.destroy(); reject(new Error('timeout')); });
+    });
+
+    // Allow the server's 'close' handler to run before asserting.
+    await new Promise(r => setTimeout(r, 50));
+    expect(scheduler.__listenerCount()).toBe(0);
   });
 });
 

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -144,7 +144,7 @@ const startCommand: Command = {
             `Max Concurrent: ${status.config.maxConcurrent}`,
             `Max CPU Load: ${status.config.resourceThresholds.maxCpuLoad}`,
             `Min Free Memory: ${status.config.resourceThresholds.minFreeMemoryPercent}%`,
-            ...(dashboard ? [`Dashboard: http://localhost:${dashboard.port}`] : []),
+            ...(dashboard ? [`The Arcane Console: http://localhost:${dashboard.port}`] : []),
           ].join('\n'),
           'Daemon Status'
         );
@@ -242,9 +242,9 @@ async function attachDaemonServices(
         memory,
         schedulerEnabledInConfig: schedulerConfig.enabled,
       });
-      if (opts.verbose) output.printSuccess(`Dashboard: http://localhost:${dashboard.port}`);
+      if (opts.verbose) output.printSuccess(`The Arcane Console: http://localhost:${dashboard.port}`);
     } catch (err) {
-      logWarn(`Dashboard failed to start: ${errorDetail(err)}`);
+      logWarn(`The Arcane Console failed to start: ${errorDetail(err)}`);
     }
   }
 
@@ -422,7 +422,7 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean, maxCpu
   if (!quiet) {
     output.printSuccess(`Daemon started in background (PID: ${pid})`);
     if (!noDashboard) {
-      output.printInfo(`Dashboard: http://localhost:${dashboardPort ?? DEFAULT_DASHBOARD_PORT}`);
+      output.printInfo(`The Arcane Console: http://localhost:${dashboardPort ?? DEFAULT_DASHBOARD_PORT}`);
     }
     output.printInfo(`Logs: ${logFile}`);
     output.printInfo(`Stop with: claude-flow daemon stop`);

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -502,26 +502,31 @@ function handleSchedulesEventStream(
   // the first scheduler event arrives (which may be minutes away).
   res.write(`event: ready\ndata: ${JSON.stringify({ timestamp: Date.now() })}\n\n`);
 
-  const unsubscribe = scheduler.on((event) => {
-    try {
-      res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
-    } catch {
-      // Socket may have torn down between event emission and write — close
-      // path below will run; nothing to do here.
-    }
-  });
-
-  const heartbeat = setInterval(() => {
-    try { res.write(`: ping ${Date.now()}\n\n`); } catch { /* close path handles it */ }
-  }, SSE_HEARTBEAT_MS);
-  // Don't keep the event loop alive solely for heartbeats.
-  if (typeof heartbeat.unref === 'function') heartbeat.unref();
-
+  let cleaned = false;
   const cleanup = (): void => {
+    if (cleaned) return;
+    cleaned = true;
     clearInterval(heartbeat);
     unsubscribe();
     try { res.end(); } catch { /* already ended */ }
   };
+
+  const unsubscribe = scheduler.on((event) => {
+    try {
+      res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+    } catch {
+      // Half-open socket: the request may never emit 'close'. Defer cleanup
+      // to the next microtask so we don't splice the listeners array we are
+      // currently being iterated from inside.
+      queueMicrotask(cleanup);
+    }
+  });
+
+  const heartbeat = setInterval(() => {
+    try { res.write(`: ping ${Date.now()}\n\n`); } catch { queueMicrotask(cleanup); }
+  }, SSE_HEARTBEAT_MS);
+  if (typeof heartbeat.unref === 'function') heartbeat.unref();
+
   req.on('close', cleanup);
   req.on('error', cleanup);
 }
@@ -679,7 +684,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <div id="status-bar" class="status-bar"><div class="empty">Loading...</div></div>
   <div class="nav" id="nav"></div>
   <div id="panel-workers" class="panel"></div>
-  <div id="panel-schedules" class="panel" style="display:none"></div>
+  <div id="panel-schedules" class="panel" style="display:none"><div id="schedules-active"></div><div id="schedules-events"></div></div>
   <div id="panel-executions" class="panel" style="display:none"></div>
   <div id="panel-memory" class="panel" style="display:none"></div>
   <div id="poll-indicator" class="poll-indicator"></div>
@@ -785,26 +790,23 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
     window.__schedAction = scheduleAction;
 
     function renderSchedules(sc) {
-      const el = document.getElementById('panel-schedules');
+      const el = document.getElementById('schedules-active');
       if (!sc) { el.innerHTML = '<div class="empty">Loading...</div>'; return; }
 
       if (sc.disabledInConfig) {
         el.innerHTML = '<h2>Scheduled Spells</h2>' +
           '<div class="empty">Scheduler disabled in moflo.yaml (scheduler.enabled: false)</div>';
-        appendEventsTail(el);
         return;
       }
       if (!sc.schedulerAttached && !sc.available) {
         el.innerHTML = '<h2>Scheduled Spells</h2>' +
           '<div class="empty">Scheduler not attached — start the daemon to activate</div>';
-        appendEventsTail(el);
         return;
       }
       if (!sc.schedules || sc.schedules.length === 0) {
         el.innerHTML = '<h2>Scheduled Spells</h2>' +
           '<div class="empty">No active schedules &middot; create one with <code>moflo spell schedule create</code></div>';
         if (sc.history && sc.history.length) renderSchedulesHistory(el, sc.history, /*append*/ true);
-        appendEventsTail(el);
         return;
       }
       const canControl = !!sc.schedulerAttached;
@@ -827,27 +829,29 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         '<tbody>' + rows + '</tbody></table>';
 
       if (sc.history && sc.history.length) renderSchedulesHistory(el, sc.history, /*append*/ true);
-      appendEventsTail(el);
     }
 
     // Live events tail (Server-Sent Events from /api/schedules/events).
-    // Schedules-panel re-renders wholesale every poll, so we keep the tail
-    // in a JS-side ring buffer and re-paint it after each poll.
+    // The events div lives outside renderSchedules' write target so polled
+    // re-renders of the schedules panel don't touch it; pushSchedEvent is
+    // the only writer. Single source of truth for known event types + their
+    // badge color — adding a new schedule:* type means one entry here.
+    const SCHED_EVENT_BADGES = {
+      'schedule:due': 'gray',
+      'schedule:started': 'gray',
+      'schedule:completed': 'green',
+      'schedule:failed': 'red',
+      'schedule:skipped': 'yellow',
+      'schedule:disabled': 'yellow',
+      'schedule:catchup': 'yellow',
+    };
+    const SCHED_EVENT_TYPES = Object.keys(SCHED_EVENT_BADGES);
     const SCHED_EVENTS_MAX = 50;
     const schedEvents = [];
-    function pushSchedEvent(ev) {
-      schedEvents.unshift(ev);
-      if (schedEvents.length > SCHED_EVENTS_MAX) schedEvents.length = SCHED_EVENTS_MAX;
+
+    function renderEventsTail() {
       const el = document.getElementById('schedules-events');
-      if (el) renderEventsTailInto(el);
-    }
-    function eventBadgeClass(t) {
-      if (t === 'schedule:catchup' || t === 'schedule:skipped' || t === 'schedule:disabled') return 'yellow';
-      if (t === 'schedule:failed') return 'red';
-      if (t === 'schedule:completed') return 'green';
-      return 'gray';
-    }
-    function renderEventsTailInto(el) {
+      if (!el) return;
       if (schedEvents.length === 0) {
         el.innerHTML = '<h2>Live Events</h2><div class="empty">Waiting for scheduler activity…</div>';
         return;
@@ -856,7 +860,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         const t = e.type || '?';
         const short = String(t).replace('schedule:', '');
         return '<tr><td>' + new Date(e.timestamp || Date.now()).toLocaleTimeString() + '</td>' +
-          '<td>' + badge(short, eventBadgeClass(t)) + '</td>' +
+          '<td>' + badge(short, SCHED_EVENT_BADGES[t] || 'gray') + '</td>' +
           '<td>' + esc(e.spellName || '-') + '</td>' +
           '<td>' + esc(e.message || '') + '</td></tr>';
       }).join('');
@@ -864,14 +868,15 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         '<table><thead><tr><th>Time</th><th>Event</th><th>Spell</th><th>Detail</th></tr></thead>' +
         '<tbody>' + rows + '</tbody></table>';
     }
-    function appendEventsTail(panelEl) {
-      panelEl.innerHTML += '<div id="schedules-events"></div>';
-      renderEventsTailInto(panelEl.querySelector('#schedules-events'));
+    function pushSchedEvent(ev) {
+      schedEvents.unshift(ev);
+      if (schedEvents.length > SCHED_EVENTS_MAX) schedEvents.length = SCHED_EVENTS_MAX;
+      renderEventsTail();
     }
+    renderEventsTail(); // Initial empty-state paint.
 
     // Subscribe via EventSource. Browser handles auto-reconnect with backoff.
     let evtSource = null;
-    const SCHED_EVENT_TYPES = ['schedule:due','schedule:started','schedule:completed','schedule:failed','schedule:skipped','schedule:disabled','schedule:catchup'];
     function connectEventStream() {
       try { if (evtSource) evtSource.close(); } catch (e) { /* ignore */ }
       try {
@@ -881,7 +886,6 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
             try { pushSchedEvent(JSON.parse(ev.data)); } catch (e) { /* malformed frame */ }
           });
         });
-        // 'ready' frame just confirms the channel is live; no UI update needed.
       } catch (e) {
         console.warn('Event stream unavailable:', e);
       }

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -1,8 +1,14 @@
 /**
- * Daemon Dashboard — Lightweight localhost HTTP server
+ * The Arcane Console — Lightweight localhost HTTP server
  *
- * Serves a read-only VanJS dashboard for daemon status, spell logs,
- * and memory stats. Binds to 127.0.0.1 only (no auth needed).
+ * Serves the moflo Arcane Console (read-only daemon view) for status,
+ * scheduled spells, executions, and memory stats. Binds to 127.0.0.1
+ * only (no auth needed).
+ *
+ * Internal/code identifiers retain the term "dashboard" (CLI flags
+ * `--dashboard-port` / `--no-dashboard`, internal port constant) for
+ * stability with existing consumer scripts; only user-facing surface
+ * is rebranded.
  *
  * @module daemon-dashboard
  */
@@ -386,6 +392,8 @@ async function handleRequest(
       sendJson(res, 200, handleStatus(daemon));
     } else if (url === '/api/schedules') {
       sendJson(res, 200, await handleSchedules(daemon, opts));
+    } else if (url === '/api/schedules/events') {
+      handleSchedulesEventStream(req, res, daemon);
     } else if (url === '/api/spells') {
       sendJson(res, 200, await handleSpells(opts.memory));
     } else if (url === '/api/memory/stats') {
@@ -456,6 +464,66 @@ function getSchedulerErrorCode(err: unknown): SchedulerErrorCode | null {
     if (code === 'not-found' || code === 'spell-missing' || code === 'busy') return code;
   }
   return null;
+}
+
+/** Heartbeat interval for the schedule-event SSE stream (keeps proxies + idle clients alive). */
+const SSE_HEARTBEAT_MS = 25_000;
+
+/**
+ * Stream `schedule:*` events to the client via Server-Sent Events.
+ *
+ * Subscribes to `scheduler.on(listener)` and forwards each event as an SSE
+ * frame (`event: <type>\ndata: <JSON>\n\n`). Sends an initial `ready` frame
+ * so the client can distinguish "connected, waiting" from "scheduler down",
+ * plus a comment heartbeat every 25s. Cleans up on client disconnect.
+ *
+ * Returns 503 when the scheduler is not attached so the client can fall back
+ * to polling. Reuses duck-typing via `daemon.getScheduler()` — no new types
+ * exported from this module.
+ */
+function handleSchedulesEventStream(
+  req: IncomingMessage,
+  res: ServerResponse,
+  daemon: WorkerDaemon,
+): void {
+  const scheduler = daemon.getScheduler();
+  if (!scheduler) {
+    sendJson(res, 503, { error: 'Scheduler not attached' });
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+  // Initial frame so the client knows the channel is live even before
+  // the first scheduler event arrives (which may be minutes away).
+  res.write(`event: ready\ndata: ${JSON.stringify({ timestamp: Date.now() })}\n\n`);
+
+  const unsubscribe = scheduler.on((event) => {
+    try {
+      res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+    } catch {
+      // Socket may have torn down between event emission and write — close
+      // path below will run; nothing to do here.
+    }
+  });
+
+  const heartbeat = setInterval(() => {
+    try { res.write(`: ping ${Date.now()}\n\n`); } catch { /* close path handles it */ }
+  }, SSE_HEARTBEAT_MS);
+  // Don't keep the event loop alive solely for heartbeats.
+  if (typeof heartbeat.unref === 'function') heartbeat.unref();
+
+  const cleanup = (): void => {
+    clearInterval(heartbeat);
+    unsubscribe();
+    try { res.end(); } catch { /* already ended */ }
+  };
+  req.on('close', cleanup);
+  req.on('error', cleanup);
 }
 
 // ============================================================================
@@ -550,7 +618,10 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>MoFlo Dashboard</title>
+  <title>The Arcane Console</title>
+  <meta name="description" content="The Arcane Console — moflo daemon, scheduled spells, and live event stream">
+  <meta property="og:title" content="The Arcane Console">
+  <meta property="og:description" content="The Arcane Console — moflo daemon, scheduled spells, and live event stream">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0d1117; color: #c9d1d9; padding: 20px; }
@@ -602,8 +673,8 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
 </head>
 <body>
   <div class="header">
-    <h1>MoFlo Dashboard</h1>
-    <span class="subtitle">read-only &bull; localhost</span>
+    <h1>The Arcane Console</h1>
+    <span class="subtitle">moflo daemon &bull; localhost</span>
   </div>
   <div id="status-bar" class="status-bar"><div class="empty">Loading...</div></div>
   <div class="nav" id="nav"></div>
@@ -720,17 +791,20 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       if (sc.disabledInConfig) {
         el.innerHTML = '<h2>Scheduled Spells</h2>' +
           '<div class="empty">Scheduler disabled in moflo.yaml (scheduler.enabled: false)</div>';
+        appendEventsTail(el);
         return;
       }
       if (!sc.schedulerAttached && !sc.available) {
         el.innerHTML = '<h2>Scheduled Spells</h2>' +
           '<div class="empty">Scheduler not attached — start the daemon to activate</div>';
+        appendEventsTail(el);
         return;
       }
       if (!sc.schedules || sc.schedules.length === 0) {
         el.innerHTML = '<h2>Scheduled Spells</h2>' +
           '<div class="empty">No active schedules &middot; create one with <code>moflo spell schedule create</code></div>';
         if (sc.history && sc.history.length) renderSchedulesHistory(el, sc.history, /*append*/ true);
+        appendEventsTail(el);
         return;
       }
       const canControl = !!sc.schedulerAttached;
@@ -753,7 +827,66 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         '<tbody>' + rows + '</tbody></table>';
 
       if (sc.history && sc.history.length) renderSchedulesHistory(el, sc.history, /*append*/ true);
+      appendEventsTail(el);
     }
+
+    // Live events tail (Server-Sent Events from /api/schedules/events).
+    // Schedules-panel re-renders wholesale every poll, so we keep the tail
+    // in a JS-side ring buffer and re-paint it after each poll.
+    const SCHED_EVENTS_MAX = 50;
+    const schedEvents = [];
+    function pushSchedEvent(ev) {
+      schedEvents.unshift(ev);
+      if (schedEvents.length > SCHED_EVENTS_MAX) schedEvents.length = SCHED_EVENTS_MAX;
+      const el = document.getElementById('schedules-events');
+      if (el) renderEventsTailInto(el);
+    }
+    function eventBadgeClass(t) {
+      if (t === 'schedule:catchup' || t === 'schedule:skipped' || t === 'schedule:disabled') return 'yellow';
+      if (t === 'schedule:failed') return 'red';
+      if (t === 'schedule:completed') return 'green';
+      return 'gray';
+    }
+    function renderEventsTailInto(el) {
+      if (schedEvents.length === 0) {
+        el.innerHTML = '<h2>Live Events</h2><div class="empty">Waiting for scheduler activity…</div>';
+        return;
+      }
+      const rows = schedEvents.map(e => {
+        const t = e.type || '?';
+        const short = String(t).replace('schedule:', '');
+        return '<tr><td>' + new Date(e.timestamp || Date.now()).toLocaleTimeString() + '</td>' +
+          '<td>' + badge(short, eventBadgeClass(t)) + '</td>' +
+          '<td>' + esc(e.spellName || '-') + '</td>' +
+          '<td>' + esc(e.message || '') + '</td></tr>';
+      }).join('');
+      el.innerHTML = '<h2>Live Events</h2>' +
+        '<table><thead><tr><th>Time</th><th>Event</th><th>Spell</th><th>Detail</th></tr></thead>' +
+        '<tbody>' + rows + '</tbody></table>';
+    }
+    function appendEventsTail(panelEl) {
+      panelEl.innerHTML += '<div id="schedules-events"></div>';
+      renderEventsTailInto(panelEl.querySelector('#schedules-events'));
+    }
+
+    // Subscribe via EventSource. Browser handles auto-reconnect with backoff.
+    let evtSource = null;
+    const SCHED_EVENT_TYPES = ['schedule:due','schedule:started','schedule:completed','schedule:failed','schedule:skipped','schedule:disabled','schedule:catchup'];
+    function connectEventStream() {
+      try { if (evtSource) evtSource.close(); } catch (e) { /* ignore */ }
+      try {
+        evtSource = new EventSource('/api/schedules/events');
+        SCHED_EVENT_TYPES.forEach(t => {
+          evtSource.addEventListener(t, ev => {
+            try { pushSchedEvent(JSON.parse(ev.data)); } catch (e) { /* malformed frame */ }
+          });
+        });
+        // 'ready' frame just confirms the channel is live; no UI update needed.
+      } catch (e) {
+        console.warn('Event stream unavailable:', e);
+      }
+    }
+    connectEventStream();
 
     function renderSchedulesHistory(el, history, append) {
       const rows = history.map(h => {


### PR DESCRIPTION
## Summary

- Rebrand the daemon dashboard to **The Arcane Console** across the user-facing surface (page title, H1, OG metadata, `flo daemon` console output, README, `/spell-schedule` skill, shipped scheduling guidance). Internal identifiers (`--dashboard-port`, `--no-dashboard`, `daemon-dashboard.ts`) intentionally retained for consumer-script stability.
- Add `GET /api/schedules/events` Server-Sent Events endpoint that subscribes to `scheduler.on(listener)` and forwards each `schedule:*` event as an SSE frame. `503` when scheduler unattached, `ready` frame on connect, 25 s heartbeat, idempotent listener cleanup on client disconnect.
- Add a **Live Events** panel under the Schedules tab — `EventSource` subscriber, 50-event ring buffer, color-coded badges (catchup/skipped/disabled yellow, failed red, completed green). Schedules panel split into stable `schedules-active` + `schedules-events` siblings so polled re-renders don't touch the events tail.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run src/cli/__tests__/daemon-dashboard.test.ts` — **37 pass** (was 34)
  - +3 new SSE tests: 503 when scheduler unattached, frame format (`ready` + forwarded `schedule:catchup`), listener detach on client disconnect
- [x] `npx vitest run src/cli/__tests__/services/daemon-scheduler-bootstrap.test.ts src/cli/__tests__/spells/scheduler` — **87/87 pass** (no scheduler regressions)
- [x] `/flo-simplify` NORMAL fan-out + validation pass — fixes (idempotent cleanup, panel split, badge map, poll-until-condition test) applied as second commit
- [ ] Cross-platform smoke (Win/macOS/Linux daemon hosts) — not gated on this PR; change is pure HTML/SSE with no platform-specific code

## Acceptance (from #964)

- [x] Three sections render: active schedules, recent executions, **live events**
- [x] Per-row Run Now / Disable / Re-enable wired (already shipped; #966 unblocked the UPSERT bridge)
- [x] Live event stream updates without manual refresh
- [x] Rename across page title, H1, OG metadata, README, `flo dashboard` print, skill, shipped guidance

Closes #964
Unblocked by #966.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)