### PR TITLE
fix(#968): tasklist survives session restart + Flo Runs render path

### DIFF
--- a/.claude/guidance/internal/session-start.md
+++ b/.claude/guidance/internal/session-start.md
@@ -91,10 +91,11 @@ Best-effort install of a shim into npm's global bin so bare `flo` resolves to th
 
 `runEmbeddingsMigrationIfNeeded` checks `.moflo/moflo.db` for embeddings-version drift and, if needed, re-embeds rows in chunks. Runs synchronously with piped stdio so the renderer's progress bar reaches the user. Returns fast (~ms) when no migration is needed.
 
-### 3e-728, 3e-729. Hard-purge legacy memory rows
+### 3e-728, 3e-729, 3e-968. Hard-purge legacy + trim flo-run history
 
 - Soft-deleted tombstones (status='deleted' rows from pre-#728 builds) are hard-deleted and the DB is VACUUMed.
-- Ephemeral-namespace rows (`hive-mind`, `tasklist`, `epic-state`, `test-bridge-fix`) accumulated by pre-#729 builds are hard-deleted; going forward, writes to those namespaces skip embedding generation entirely.
+- Ephemeral-namespace rows in `hive-mind`, `epic-state`, and `test-bridge-fix` are hard-deleted on every session start. Writes to all four embedding-skipped namespaces (those three plus `tasklist`) bypass embedding generation entirely.
+- `tasklist` is **not** purged — those rows back the dashboard's "Flo Runs" tab and need to outlive the session. The launcher trims tasklist to the most recent `TASKLIST_RETENTION_CAP` rows (default: 200), so the table stays bounded without losing recent history ([#968](https://github.com/eric-cielo/moflo/issues/968)).
 
 Both run **before** the daemon is restarted in stage 4 so a concurrent sql.js flush can't clobber the foreground purge.
 

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -1316,14 +1316,15 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
-// ── 3e-729. Purge ephemeral-namespace rows (#729) ───────────────────────────
-// Four namespaces (hive-mind, tasklist, epic-state, test-bridge-fix) store
-// internal moflo run-tracking — never user knowledge — and were polluting the
-// embeddings index. Going forward, writes to those namespaces skip embedding
-// generation (see EPHEMERAL_NAMESPACES in memory/bridge-embedder.ts); existing
-// rows from prior versions get hard-deleted here. Idempotent — returns
-// `purged: 0` once the DB is clean. Runs BEFORE background MCP/daemon spawn
-// so the foreground sql.js write isn't overwritten by a concurrent flush.
+// ── 3e-729. Purge ephemeral-namespace rows + trim tasklist (#729, #968) ─────
+// Three namespaces (hive-mind, epic-state, test-bridge-fix) store internal
+// run-tracking and get hard-deleted on every session start. The fourth
+// embedding-skipped namespace, `tasklist`, backs the dashboard's Flo Runs
+// tab — it's *trimmed* to a retention cap instead of purged so prior runs
+// survive a session restart (#968). Idempotent: returns
+// `{ purged: 0, trimmed: 0 }` when nothing needs cleaning. Runs BEFORE the
+// background MCP/daemon spawn so the foreground sql.js write isn't
+// overwritten by a concurrent flush.
 try {
   const purgePaths = [
     resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/ephemeral-namespace-purge.js'),
@@ -1337,6 +1338,12 @@ try {
       emitMutation(
         'pruned ephemeral namespace rows',
         `${plural(result.purged, 'row')} from internal run-tracking`,
+      );
+    }
+    if (result?.trimmed > 0) {
+      emitMutation(
+        'trimmed flo run history',
+        `${plural(result.trimmed, 'old row')} beyond retention cap`,
       );
     }
   }

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -2,6 +2,47 @@
 
 Phase-by-phase notes for the full `/flo <issue>` run. Phase 2 (Ticket) lives in `./ticket.md`.
 
+## Phase 0: Record run start (Flo Runs dashboard)
+
+Before research, write a row to the `tasklist` namespace so the Arcane Console "Flo Runs" tab shows this run live and after the next session restart (#968). Skip this phase ONLY when `--epic-branch` is set — the epic orchestrator owns the parent record and the per-story spell engine writes its own row.
+
+Compute and **remember** for Phase 5:
+- `runId` — `flo-<issue-number-or-"new">-<startedAt-ms>` (sortable, unique).
+- `startedAt` — `Date.now()` snapshot (ms since epoch).
+
+Pick the matching `context.type`:
+| Mode | type | label format |
+|------|------|--------------|
+| Full / ticket on existing issue | `ticket` | `#<n> — <title>` |
+| `-r` research | `research` | `#<n> — Research` |
+| `-t` with title (no issue # yet) | `new-ticket` | `New: <title>` |
+| Epic detected | `epic` | `Epic #<n> — <title> (0/<total> stories)` |
+| `-wf <spell>` | `spell` | `<spell-name> → <args>` |
+
+Then call once:
+
+```
+mcp__moflo__memory_store
+  namespace: "tasklist"
+  key: "<runId>"
+  upsert: true
+  value: {
+    "status": "running",
+    "context": {
+      "type": "<ticket|research|new-ticket|epic|spell>",
+      "label": "<computed label>",
+      "issueNumber": <n | omit>,
+      "issueTitle": "<title | omit>",
+      "execMode": "<normal|swarm|hive>"
+    },
+    "spellName": "<same as label>",
+    "startedAt": <startedAt>,
+    "updatedAt": "<new Date().toISOString()>"
+  }
+```
+
+The schema mirrors `storeFloRunRecord` in `src/cli/services/daemon-dashboard.ts` — keep it in sync if you ever change one. The session-start launcher retains the most recent ~200 tasklist rows so this record outlives the session and renders in the Flo Runs tab on subsequent restarts.
+
 ## Phase 1: Research (also `-r`)
 
 ### 1.1 Fetch the issue + history (cheap, before any file exploration)
@@ -150,3 +191,29 @@ Closes #<issue-number>"
 gh issue edit <issue-number> --remove-label "in-progress" --add-label "ready-for-review"
 gh issue comment <issue-number> --body "PR created: <pr-url>"
 ```
+
+### 5.5 Finalize run record (Flo Runs dashboard)
+
+Update the tasklist row written in Phase 0 with the terminal status. Same `runId`, `upsert: true`. On success:
+
+```
+mcp__moflo__memory_store
+  namespace: "tasklist"
+  key: "<runId>"          # same key from Phase 0
+  upsert: true
+  value: {
+    "status": "completed",
+    "success": true,
+    "context": <same context object as Phase 0>,
+    "spellName": "<same label as Phase 0>",
+    "startedAt": <startedAt from Phase 0>,
+    "duration": <Date.now() - startedAt>,
+    "updatedAt": "<new Date().toISOString()>"
+  }
+```
+
+On failure (tests still red after retries, or any aborting error): same shape with `"status": "failed"`, `"success": false`, and an `"error": "<short summary>"` field.
+
+This finalize call MUST also fire if the run aborts *before* reaching Phase 5 (early failure during research, ticket, or implement) — otherwise the dashboard shows a permanently "running" row for a dead run.
+
+Skip this when `--epic-branch` is set — the epic orchestrator records its own outcome.

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -1435,14 +1435,15 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
-// ── 3e-729. Purge ephemeral-namespace rows (#729) ───────────────────────────
-// Four namespaces (hive-mind, tasklist, epic-state, test-bridge-fix) store
-// internal moflo run-tracking — never user knowledge — and were polluting the
-// embeddings index. Going forward, writes to those namespaces skip embedding
-// generation (see EPHEMERAL_NAMESPACES in memory/bridge-embedder.ts); existing
-// rows from prior versions get hard-deleted here. Idempotent — returns
-// `purged: 0` once the DB is clean. Runs BEFORE background MCP/daemon spawn
-// so the foreground sql.js write isn't overwritten by a concurrent flush.
+// ── 3e-729. Purge ephemeral-namespace rows + trim tasklist (#729, #968) ─────
+// Three namespaces (hive-mind, epic-state, test-bridge-fix) store internal
+// run-tracking and get hard-deleted on every session start. The fourth
+// embedding-skipped namespace, `tasklist`, backs the dashboard's Flo Runs
+// tab — it's *trimmed* to a retention cap instead of purged so prior runs
+// survive a session restart (#968). Idempotent: returns
+// `{ purged: 0, trimmed: 0 }` when nothing needs cleaning. Runs BEFORE the
+// background MCP/daemon spawn so the foreground sql.js write isn't
+// overwritten by a concurrent flush.
 try {
   const purgePaths = [
     resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/ephemeral-namespace-purge.js'),
@@ -1456,6 +1457,12 @@ try {
       emitMutation(
         'pruned ephemeral namespace rows',
         `${plural(result.purged, 'row')} from internal run-tracking`,
+      );
+    }
+    if (result?.trimmed > 0) {
+      emitMutation(
+        'trimmed flo run history',
+        `${plural(result.trimmed, 'old row')} beyond retention cap`,
       );
     }
   }

--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -1116,12 +1116,13 @@ flo daemon status    # shows whether the service is registered AND the process i
 
 ### Storage namespaces
 
-| Namespace | Contents |
-|-----------|----------|
-| `scheduled-spells` | One record per `SpellSchedule` (`id`, `spellName`, timing, `nextRunAt`, `enabled`, `args`, etc.) |
-| `schedule-executions` | One record per `ScheduleExecution` — the audit trail surfaced by the dashboard |
+| Namespace | Contents | Retention |
+|-----------|----------|-----------|
+| `scheduled-spells` | One record per `SpellSchedule` (`id`, `spellName`, timing, `nextRunAt`, `enabled`, `args`, etc.) | Survives session restarts; user removes via `flo spell schedule cancel` |
+| `schedule-executions` | One record per `ScheduleExecution` — the audit trail surfaced by the Arcane Console | Survives session restarts; not pruned by the launcher |
+| `tasklist` | One record per `/flo` run + per spell-engine run, surfaced as the "Flo Runs" tab on the Arcane Console | Survives session restarts; trimmed to `TASKLIST_RETENTION_CAP` (200) by the session-start launcher (#968) |
 
-Both namespaces are scoped to the project's memory database, so schedules and history don't leak across projects.
+All three namespaces are scoped to the project's memory database, so schedules, history, and run records don't leak across projects.
 
 ## Further Reading
 

--- a/harness/consumer-smoke/lib/populated.mjs
+++ b/harness/consumer-smoke/lib/populated.mjs
@@ -74,7 +74,12 @@ function quiesceLauncherBackground(consumerDir) {
 }
 
 const ACTIVE_NAMESPACES = ['guidance', 'patterns', 'code-map', 'tests', 'knowledge', 'learnings', 'default'];
+// Skip-embedding set (matches EPHEMERAL_NAMESPACES in src/cli/memory/bridge-embedder.ts).
 const EPHEMERAL_NAMESPACES = ['hive-mind', 'tasklist', 'epic-state', 'test-bridge-fix'];
+// Hard-purge set (matches PURGE_ON_SESSION_START_NAMESPACES). #968: tasklist
+// is in EPHEMERAL_NAMESPACES (skip-embed) but NOT here — those rows back the
+// dashboard Flo Runs tab and survive across session restarts.
+const PURGED_NAMESPACES = ['hive-mind', 'epic-state', 'test-bridge-fix'];
 const ROWS_PER_ACTIVE_NAMESPACE = 20;
 const ROWS_PER_EPHEMERAL_NAMESPACE = 5;
 const ARCHIVED_ROW_COUNT = 3;
@@ -310,14 +315,17 @@ function inspectInstalledEphemeralNamespaces(consumerDir) {
     return;
   }
   // Loading via dynamic import would also drag in fastembed transitives; a
-  // text scan is sufficient because EPHEMERAL_NAMESPACES is a static literal.
+  // text scan is sufficient because both namespace sets are static literals.
   const source = readFileSync(sourcePath, 'utf8');
-  const missing = EPHEMERAL_NAMESPACES.filter(ns => !source.includes(`'${ns}'`));
+  const missing = [
+    ...EPHEMERAL_NAMESPACES.filter(ns => !source.includes(`'${ns}'`)),
+    ...PURGED_NAMESPACES.filter(ns => !source.includes(`'${ns}'`)),
+  ];
   if (missing.length === 0) {
     record('populated:ephemeral-namespace-parity', 'pass', `harness list matches installed dist`);
   } else {
     record('populated:ephemeral-namespace-parity', 'fail',
-      `harness list drift — installed dist missing: ${missing.join(', ')} (update harness or check #729 regression)`);
+      `harness list drift — installed dist missing: ${missing.join(', ')} (update harness or check #729/#968 regression)`);
   }
 }
 
@@ -426,14 +434,27 @@ function assertDeletedRowsPurged(snapshot) {
 
 function assertEphemeralRowsPurged(snapshot) {
   const offenders = [];
-  for (const ns of EPHEMERAL_NAMESPACES) {
+  for (const ns of PURGED_NAMESPACES) {
     const active = snapshot.byNamespaceStatus[`${ns}/active`] ?? 0;
     if (active > 0) offenders.push(`${ns}=${active}`);
   }
   if (offenders.length === 0) {
-    record('populated:ephemeral-purged', 'pass', 'no ephemeral-namespace rows remain (#729)');
+    record('populated:ephemeral-purged', 'pass', 'no purgeable namespace rows remain (#729)');
   } else {
-    record('populated:ephemeral-purged', 'fail', `ephemeral rows leaked through #729 purge: ${offenders.join(', ')}`);
+    record('populated:ephemeral-purged', 'fail', `purgeable rows leaked through #729 purge: ${offenders.join(', ')}`);
+  }
+
+  // #968: tasklist is the dashboard's Flo Runs data source. The seeded rows
+  // must SURVIVE the session-start launcher (it trims to retention cap, not
+  // bulk-purges). With ROWS_PER_EPHEMERAL_NAMESPACE=5 well under the 200-row
+  // cap, every seeded row is expected to remain.
+  const tasklistActive = snapshot.byNamespaceStatus['tasklist/active'] ?? 0;
+  if (tasklistActive >= ROWS_PER_EPHEMERAL_NAMESPACE) {
+    record('populated:tasklist-retained', 'pass',
+      `${tasklistActive} tasklist rows survived the launcher (#968 retention)`);
+  } else {
+    record('populated:tasklist-retained', 'fail',
+      `expected ≥${ROWS_PER_EPHEMERAL_NAMESPACE} tasklist rows after launcher, got ${tasklistActive} (regression on #968 — Flo Runs tab will be empty)`);
   }
 }
 

--- a/src/cli/__tests__/daemon-dashboard.test.ts
+++ b/src/cli/__tests__/daemon-dashboard.test.ts
@@ -210,6 +210,21 @@ describe('DaemonDashboard', () => {
     expect(res.body).toContain('switchTab');
   });
 
+  it('renders the title with a wizardy font and per-word color spans (#968)', async () => {
+    const daemon = makeMockDaemon();
+    dashboard = await startDashboard(daemon, { port: testPort });
+    const res = await fetchDashboard(testPort, '/');
+    // Three-word colored title with wizardy font family
+    expect(res.body).toContain('<span class="w-the">The</span>');
+    expect(res.body).toContain('<span class="w-arcane">Arcane</span>');
+    expect(res.body).toContain('<span class="w-console">Console</span>');
+    expect(res.body).toContain('Cinzel Decorative');
+    // Each word has a distinct color
+    expect(res.body).toMatch(/\.w-the\s*\{\s*color:\s*#8b5cf6/);
+    expect(res.body).toMatch(/\.w-arcane\s*\{\s*color:\s*#2563eb/);
+    expect(res.body).toMatch(/\.w-console\s*\{\s*color:\s*#059669/);
+  });
+
   it('returns daemon status at GET /api/status', async () => {
     const daemon = makeMockDaemon();
     dashboard = await startDashboard(daemon, { port: testPort });
@@ -231,6 +246,20 @@ describe('DaemonDashboard', () => {
     expect(data.workers[0].successCount).toBe(4);
     expect(data.workers[1].type).toBe('audit');
     expect(data.workers[1].isRunning).toBe(true);
+  });
+
+  it('exposes per-worker enabled flag so disabled workers render distinct (#968)', async () => {
+    const daemon = makeMockDaemon();
+    dashboard = await startDashboard(daemon, { port: testPort });
+    const res = await fetchDashboard(testPort, '/api/status');
+    const data = JSON.parse(res.body);
+    // map + audit are enabled in the default mock; predict is disabled.
+    // (predict isn't in workers Map by default, so add a workers entry would
+    // be needed — instead just verify the join logic emits the flag for
+    // listed workers.)
+    const byType = Object.fromEntries(data.workers.map((w: { type: string; enabled: boolean }) => [w.type, w.enabled]));
+    expect(byType.map).toBe(true);
+    expect(byType.audit).toBe(true);
   });
 
   it('returns schedules at GET /api/schedules', async () => {

--- a/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
+++ b/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
@@ -1,13 +1,15 @@
 /**
- * Unit tests for the #729 ephemeral-namespace purge service.
+ * Unit tests for the #729 / #968 session-start memory cleanup service.
  *
  * Covers:
- *  - Hard-deletes rows from each of the four ephemeral namespaces
- *    (hive-mind, tasklist, epic-state, test-bridge-fix)
+ *  - Hard-purges rows from PURGE_ON_SESSION_START_NAMESPACES
+ *    (hive-mind, epic-state, test-bridge-fix)
+ *  - Preserves tasklist rows up to retention cap (#968 fix)
+ *  - Trims tasklist beyond retention cap, keeping the most recent entries
  *  - Preserves rows in unrelated namespaces (knowledge, patterns, etc.)
- *  - Idempotent: clean DB returns purged: 0 and does not rewrite the file
+ *  - Idempotent: clean DB returns { purged: 0, trimmed: 0 } without writing
  *  - Skips DBs that lack memory_entries
- *  - Returns purged: 0 when the DB does not exist
+ *  - Returns zero counts when the DB does not exist
  */
 
 import { describe, it, expect, beforeAll, afterEach } from 'vitest';
@@ -16,7 +18,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { purgeEphemeralNamespaces } from '../../services/ephemeral-namespace-purge.js';
-import { EPHEMERAL_NAMESPACES } from '../../memory/bridge-embedder.js';
+import {
+  EPHEMERAL_NAMESPACES,
+  PURGE_ON_SESSION_START_NAMESPACES,
+  TASKLIST_RETENTION_CAP,
+} from '../../memory/bridge-embedder.js';
 import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
 
 type SqlJsDb = {
@@ -70,15 +76,15 @@ function countByNamespace(dbBytes: Uint8Array, namespace: string): number {
   }
 }
 
-describe('purgeEphemeralNamespaces (#729)', () => {
-  it('returns purged: 0 when the DB file does not exist', async () => {
+describe('purgeEphemeralNamespaces (#729, #968)', () => {
+  it('returns zero counts when the DB file does not exist', async () => {
     const result = await purgeEphemeralNamespaces({
       dbPath: join(tmpdir(), 'moflo-missing-729', 'nope.db'),
     });
-    expect(result).toEqual({ purged: 0 });
+    expect(result).toEqual({ purged: 0, trimmed: 0 });
   });
 
-  it('hard-deletes rows from every ephemeral namespace and preserves others', async () => {
+  it('hard-deletes only PURGE_ON_SESSION_START_NAMESPACES and preserves tasklist + others', async () => {
     const dbPath = await makeTmpDb((db) => {
       let n = 0;
       const insert = (id: string, ns: string, content: string) =>
@@ -87,31 +93,68 @@ describe('purgeEphemeralNamespaces (#729)', () => {
           [id, `k-${id}`, ns, content],
         );
 
-      // 2 rows per ephemeral namespace
-      for (const ns of EPHEMERAL_NAMESPACES) {
-        insert(`${ns}-${++n}`, ns, `ephemeral-${ns}-1`);
-        insert(`${ns}-${++n}`, ns, `ephemeral-${ns}-2`);
+      // 2 rows per purge-set namespace
+      for (const ns of PURGE_ON_SESSION_START_NAMESPACES) {
+        insert(`${ns}-${++n}`, ns, `purge-${ns}-1`);
+        insert(`${ns}-${++n}`, ns, `purge-${ns}-2`);
       }
+      // 3 tasklist rows — well under retention cap, all should survive
+      insert('tl-1', 'tasklist', 'flo-100-1700000000000');
+      insert('tl-2', 'tasklist', 'flo-101-1700000001000');
+      insert('tl-3', 'tasklist', 'flo-102-1700000002000');
 
-      // Untouchable: 3 rows in real namespaces with valid content
+      // Untouchable: rows in real user namespaces
       insert('keep-1', 'knowledge', 'real user knowledge');
       insert('keep-2', 'patterns', 'a learned pattern');
       insert('keep-3', 'guidance', 'guidance entry');
     });
 
     const result = await purgeEphemeralNamespaces({ dbPath });
-    expect(result.purged).toBe(EPHEMERAL_NAMESPACES.size * 2);
+    expect(result.purged).toBe(PURGE_ON_SESSION_START_NAMESPACES.size * 2);
+    expect(result.trimmed).toBe(0); // 3 < cap, no trim
 
     const after = await readFile(dbPath);
-    for (const ns of EPHEMERAL_NAMESPACES) {
+    for (const ns of PURGE_ON_SESSION_START_NAMESPACES) {
       expect(countByNamespace(after, ns)).toBe(0);
     }
+    // #968: tasklist must survive
+    expect(countByNamespace(after, 'tasklist')).toBe(3);
     expect(countByNamespace(after, 'knowledge')).toBe(1);
     expect(countByNamespace(after, 'patterns')).toBe(1);
     expect(countByNamespace(after, 'guidance')).toBe(1);
   });
 
-  it('is idempotent: a clean DB returns purged: 0 without writing', async () => {
+  it('trims tasklist beyond retention cap, keeping the most recent rows (#968)', async () => {
+    const dbPath = await makeTmpDb((db) => {
+      // 7 tasklist rows with monotonic created_at; cap=3 keeps last 3.
+      const base = 1_700_000_000_000;
+      for (let i = 0; i < 7; i++) {
+        db.run(
+          `INSERT INTO memory_entries (id, key, namespace, content, status, created_at) VALUES (?, ?, ?, ?, 'active', ?)`,
+          [`tl-${i}`, `flo-${i}`, 'tasklist', `record-${i}`, base + i * 1000],
+        );
+      }
+    });
+
+    const result = await purgeEphemeralNamespaces({ dbPath, tasklistRetentionCap: 3 });
+    expect(result.purged).toBe(0);
+    expect(result.trimmed).toBe(4); // 7 - 3 = 4 oldest deleted
+
+    const after = await readFile(dbPath);
+    expect(countByNamespace(after, 'tasklist')).toBe(3);
+
+    // The three most recent (tl-4, tl-5, tl-6) should be the survivors.
+    const db = new SQL.Database(after);
+    try {
+      const rows = db.exec(`SELECT id FROM memory_entries WHERE namespace = 'tasklist' ORDER BY created_at ASC`);
+      const ids = (rows[0]?.values ?? []).map(r => r[0]);
+      expect(ids).toEqual(['tl-4', 'tl-5', 'tl-6']);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('is idempotent: a clean DB returns zero counts without writing', async () => {
     const dbPath = await makeTmpDb((db) => {
       db.run(
         `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
@@ -121,7 +164,7 @@ describe('purgeEphemeralNamespaces (#729)', () => {
 
     const before = await readFile(dbPath);
     const result = await purgeEphemeralNamespaces({ dbPath });
-    expect(result).toEqual({ purged: 0 });
+    expect(result).toEqual({ purged: 0, trimmed: 0 });
 
     // No write means the file bytes are unchanged.
     const after = await readFile(dbPath);
@@ -132,7 +175,7 @@ describe('purgeEphemeralNamespaces (#729)', () => {
     const dbPath = await makeTmpDb((db) => {
       db.run(
         `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
-        ['t1', 'k1', 'tasklist', 'sp-foo'],
+        ['t1', 'k1', 'hive-mind', 'msg-foo'],
       );
       db.run(
         `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
@@ -142,9 +185,10 @@ describe('purgeEphemeralNamespaces (#729)', () => {
 
     const first = await purgeEphemeralNamespaces({ dbPath });
     expect(first.purged).toBe(2);
+    expect(first.trimmed).toBe(0);
 
     const second = await purgeEphemeralNamespaces({ dbPath });
-    expect(second.purged).toBe(0);
+    expect(second).toEqual({ purged: 0, trimmed: 0 });
   });
 
   it('skips DBs that lack a memory_entries table', async () => {
@@ -158,14 +202,29 @@ describe('purgeEphemeralNamespaces (#729)', () => {
     await writeFile(dbPath, Buffer.from(bytes));
 
     const result = await purgeEphemeralNamespaces({ dbPath });
-    expect(result).toEqual({ purged: 0 });
+    expect(result).toEqual({ purged: 0, trimmed: 0 });
   });
 });
 
-describe('EPHEMERAL_NAMESPACES (#729)', () => {
-  it('contains exactly the four documented namespaces', () => {
+describe('namespace constants (#729, #968)', () => {
+  it('EPHEMERAL_NAMESPACES contains exactly the four embedding-skip namespaces', () => {
     expect(Array.from(EPHEMERAL_NAMESPACES).sort()).toEqual(
       ['epic-state', 'hive-mind', 'tasklist', 'test-bridge-fix'],
     );
+  });
+
+  it('PURGE_ON_SESSION_START_NAMESPACES is a strict subset that excludes tasklist (#968)', () => {
+    expect(Array.from(PURGE_ON_SESSION_START_NAMESPACES).sort()).toEqual(
+      ['epic-state', 'hive-mind', 'test-bridge-fix'],
+    );
+    expect(PURGE_ON_SESSION_START_NAMESPACES.has('tasklist')).toBe(false);
+    for (const ns of PURGE_ON_SESSION_START_NAMESPACES) {
+      expect(EPHEMERAL_NAMESPACES.has(ns)).toBe(true);
+    }
+  });
+
+  it('TASKLIST_RETENTION_CAP is set to a sensible default', () => {
+    expect(TASKLIST_RETENTION_CAP).toBeGreaterThan(0);
+    expect(TASKLIST_RETENTION_CAP).toBeLessThanOrEqual(1000);
   });
 });

--- a/src/cli/memory/bridge-embedder.ts
+++ b/src/cli/memory/bridge-embedder.ts
@@ -55,11 +55,9 @@ export const EMBEDDING_MODEL_OPT_OUT = 'none';
 export const EMBEDDING_MODEL_LEGACY_DEFAULT = 'local';
 
 /**
- * Namespaces that store internal moflo run-tracking, never user knowledge.
- * Writes here skip embedding generation entirely — both `embedding` and
- * `embedding_model` land as NULL, distinct from the opt-out path which still
- * tags rows with `'none'`. Existing rows in these namespaces are hard-deleted
- * on upgrade by `services/ephemeral-namespace-purge.ts`.
+ * Namespaces that skip embedding generation in the bridge write path. Rows
+ * land with both `embedding` and `embedding_model` NULL (distinct from the
+ * opt-out path which still tags rows with `'none'`).
  *
  * Members:
  * - `hive-mind`     — MCP broadcast traffic (msg:*, agent_join, consensus_propose)
@@ -67,7 +65,11 @@ export const EMBEDDING_MODEL_LEGACY_DEFAULT = 'local';
  * - `epic-state`    — Epic progress (epic-N, story-M) written by commands/epic.ts
  * - `test-bridge-fix` — Single 2026-04-23 row left over from a one-off test
  *
- * See story #729 for the source-trace and rationale.
+ * See story #729 for the source-trace and rationale. The session-start
+ * launcher only purges {@link PURGE_ON_SESSION_START_NAMESPACES} — a strict
+ * subset that *excludes* `tasklist`, because the dashboard's Flo Runs tab
+ * (`daemon-dashboard.ts handleSpells`) reads tasklist; purging it on every
+ * session would empty the tab between sessions (#968).
  */
 export const EPHEMERAL_NAMESPACES: ReadonlySet<string> = new Set([
   'hive-mind',
@@ -75,6 +77,26 @@ export const EPHEMERAL_NAMESPACES: ReadonlySet<string> = new Set([
   'epic-state',
   'test-bridge-fix',
 ]);
+
+/**
+ * Subset of {@link EPHEMERAL_NAMESPACES} that the session-start launcher
+ * hard-purges via `services/ephemeral-namespace-purge.ts`. Excludes
+ * `tasklist` — those rows back the dashboard's "Flo Runs" tab and are
+ * trimmed by row-count retention instead of bulk purge (#968).
+ */
+export const PURGE_ON_SESSION_START_NAMESPACES: ReadonlySet<string> = new Set([
+  'hive-mind',
+  'epic-state',
+  'test-bridge-fix',
+]);
+
+/**
+ * Maximum number of `tasklist` rows kept across session restarts. The
+ * session-start retention pass deletes oldest rows beyond this cap, so the
+ * dashboard's "Flo Runs" tab shows recent history without unbounded growth
+ * (#968). Sized for ~2 weeks of /flo activity at typical use.
+ */
+export const TASKLIST_RETENTION_CAP = 200;
 
 /**
  * Minimal contract the bridge needs from an embedder. Tests inject a stub

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -112,10 +112,17 @@ function tryParseSafe(s: string): unknown {
 
 function handleStatus(daemon: WorkerDaemon): object {
   const status = daemon.getStatus();
+  // Index config rows by worker type so the row renderer can show a
+  // "disabled" badge instead of "Last run: never" for default-off workers
+  // (audit, predict, document — see #968 user feedback).
+  const configByType = new Map<string, { enabled: boolean }>();
+  for (const w of status.config.workers) configByType.set(w.type, { enabled: w.enabled });
+
   const workers: Record<string, unknown>[] = [];
   for (const [type, state] of status.workers) {
     workers.push({
       type,
+      enabled: configByType.get(type)?.enabled ?? true,
       isRunning: state.isRunning,
       lastRun: state.lastRun?.toISOString() ?? null,
       nextRun: state.nextRun?.toISOString() ?? null,
@@ -627,10 +634,24 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <meta name="description" content="The Arcane Console — moflo daemon, scheduled spells, and live event stream">
   <meta property="og:title" content="The Arcane Console">
   <meta property="og:description" content="The Arcane Console — moflo daemon, scheduled spells, and live event stream">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700;900&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0d1117; color: #c9d1d9; padding: 20px; }
-    h1 { color: #58a6ff; margin-bottom: 4px; font-size: 1.5rem; }
+    /* Wizardy chain — Cinzel Decorative is the Google Font; the rest are
+       the most likely system serifs across macOS / Windows / Linux so the
+       title still reads "arcane" if the user is offline or behind a font-CDN
+       block (Georgia ships everywhere; serif is the universal fallback). */
+    h1 { font-family: 'Cinzel Decorative', 'Cinzel', 'Trajan Pro', 'Palatino Linotype', 'Book Antiqua', Georgia, serif; font-weight: 900; letter-spacing: 0.04em; margin-bottom: 4px; font-size: 1.85rem; }
+    /* Per-word arcane palette. Hues chosen at L≈45-50%, S≈60-70% so they read on
+       both #0d1117 (dark) and #ffffff (light) — WCAG-AA at large-text size on
+       both. Each word's shadow matches its own hue so the glow doesn't bleed
+       a single color across all three. */
+    h1 .w-the     { color: #8b5cf6; text-shadow: 0 0 18px rgba(139, 92, 246, 0.18); }
+    h1 .w-arcane  { color: #2563eb; text-shadow: 0 0 18px rgba(37, 99, 235, 0.18); }
+    h1 .w-console { color: #059669; text-shadow: 0 0 18px rgba(5, 150, 105, 0.18); }
     h2 { color: #8b949e; font-size: 1.1rem; margin: 16px 0 12px; border-bottom: 1px solid #21262d; padding-bottom: 6px; }
     .header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 16px; }
     .subtitle { color: #8b949e; font-size: 0.85rem; }
@@ -678,7 +699,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
 </head>
 <body>
   <div class="header">
-    <h1>The Arcane Console</h1>
+    <h1><span class="w-the">The</span> <span class="w-arcane">Arcane</span> <span class="w-console">Console</span></h1>
     <span class="subtitle">moflo daemon &bull; localhost</span>
   </div>
   <div id="status-bar" class="status-bar"><div class="empty">Loading...</div></div>
@@ -760,15 +781,25 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
 
     function renderWorkers(s) {
       if (!s) return;
-      const rows = s.workers.map(w =>
-        '<tr><td>' + esc(w.type) + '</td>' +
-        '<td>' + (w.isRunning ? badge('running','yellow') : badge('idle','gray')) + '</td>' +
-        '<td>' + w.runCount + '</td>' +
-        '<td>' + pct(w.successCount, w.failureCount) + '</td>' +
-        '<td>' + fmtDuration(w.averageDurationMs) + '</td>' +
-        '<td>' + fmtTimeAgo(w.lastRun) + '</td>' +
-        '<td>' + (w.nextRun ? fmtTime(w.nextRun) : '-') + '</td></tr>'
-      ).join('');
+      // Disabled workers show a clear "disabled" badge and dim "—" cells
+      // instead of "idle"/"never" — those terms imply the worker is healthy
+      // but quiet, which misled users into thinking audit/predict/document
+      // were broken (#968).
+      const rows = s.workers.map(w => {
+        const statusBadge = w.enabled === false
+          ? badge('disabled', 'gray')
+          : (w.isRunning ? badge('running', 'yellow') : badge('idle', 'gray'));
+        const dim = '<span class="dim">—</span>';
+        const lastRun = w.enabled === false && !w.lastRun ? dim : fmtTimeAgo(w.lastRun);
+        const nextRun = w.enabled === false ? dim : (w.nextRun ? fmtTime(w.nextRun) : '-');
+        return '<tr><td>' + esc(w.type) + '</td>' +
+          '<td>' + statusBadge + '</td>' +
+          '<td>' + w.runCount + '</td>' +
+          '<td>' + pct(w.successCount, w.failureCount) + '</td>' +
+          '<td>' + fmtDuration(w.averageDurationMs) + '</td>' +
+          '<td>' + lastRun + '</td>' +
+          '<td>' + nextRun + '</td></tr>';
+      }).join('');
       document.getElementById('panel-workers').innerHTML =
         '<h2>Worker Status</h2>' +
         '<table><thead><tr><th>Worker</th><th>Status</th><th>Runs</th><th>Success</th><th>Avg</th><th>Last Run</th><th>Next Run</th></tr></thead>' +

--- a/src/cli/services/ephemeral-namespace-purge.ts
+++ b/src/cli/services/ephemeral-namespace-purge.ts
@@ -1,24 +1,27 @@
 /**
- * Idempotent ephemeral-namespace purge for moflo's memory DB (`.moflo/moflo.db`).
+ * Idempotent session-start memory cleanup for moflo's memory DB
+ * (`.moflo/moflo.db`).
  *
- * Story #729 retired four namespaces from the persistent memory layer because
- * they store internal moflo run-tracking — not user knowledge — and embedding
- * them polluted the search index:
+ * Two passes run in a single sql.js open:
  *
- *  - `hive-mind`        (MCP broadcast traffic)
- *  - `tasklist`         (spell run records)
- *  - `epic-state`       (epic progress tracking)
- *  - `test-bridge-fix`  (single-row leftover from a one-off test)
+ * 1. **Hard-purge** namespaces in {@link PURGE_ON_SESSION_START_NAMESPACES} —
+ *    `hive-mind`, `epic-state`, `test-bridge-fix`. These store internal
+ *    run-tracking that does not need to survive a session restart. (#729)
  *
- * This service hard-deletes any rows in those namespaces left over from prior
- * moflo versions, then VACUUMs to reclaim disk. Future writes to these
- * namespaces still land in the DB — but skip embedding generation entirely
- * (see {@link EPHEMERAL_NAMESPACES} in `memory/bridge-embedder.ts`).
+ * 2. **Retention trim** the `tasklist` namespace down to the most recent
+ *    {@link TASKLIST_RETENTION_CAP} rows. `tasklist` is the dashboard's
+ *    "Flo Runs" tab data source (`daemon-dashboard.ts handleSpells`); the
+ *    pre-#968 contract hard-purged it on every session start, leaving the tab
+ *    permanently empty. Trim instead so users see recent history without
+ *    unbounded growth.
+ *
+ * Both passes share the file open + final VACUUM + atomic write, so disk I/O
+ * is the same as before. Writes back to disk only when something changed.
  *
  * Lives in `services/` so it has no dependency on the CLI command machinery.
- * That lets `bin/session-start-launcher.mjs` dynamic-import it and run the
- * purge in foreground BEFORE long-lived sql.js consumers (MCP server, daemon)
- * open the DB — sql.js dumps the whole snapshot on every flush and would
+ * That lets `bin/session-start-launcher.mjs` dynamic-import it and run in
+ * foreground BEFORE long-lived sql.js consumers (MCP server, daemon) open
+ * the DB — sql.js dumps the whole snapshot on every flush and would
  * otherwise clobber our cleanup (see #727's clobber-hazard analysis).
  *
  * @module cli/services/ephemeral-namespace-purge
@@ -26,7 +29,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { EPHEMERAL_NAMESPACES } from '../memory/bridge-embedder.js';
+import {
+  PURGE_ON_SESSION_START_NAMESPACES,
+  TASKLIST_RETENTION_CAP,
+} from '../memory/bridge-embedder.js';
 import { mofloImport } from './moflo-require.js';
 import { atomicWriteFileSync } from './atomic-file-write.js';
 import { memoryDbPath } from './moflo-paths.js';
@@ -34,19 +40,28 @@ import { memoryDbPath } from './moflo-paths.js';
 export interface PurgeEphemeralNamespacesOptions {
   /** Path to the memory DB. Defaults to `<cwd>/.moflo/moflo.db`. */
   dbPath?: string;
+  /**
+   * Override the tasklist retention cap. Defaults to
+   * {@link TASKLIST_RETENTION_CAP}. Tests use this to drive the trim path
+   * without seeding hundreds of rows.
+   */
+  tasklistRetentionCap?: number;
 }
 
 export interface PurgeEphemeralNamespacesResult {
-  /** Number of rows hard-deleted across all ephemeral namespaces. 0 when nothing to purge. */
+  /** Number of rows hard-deleted from {@link PURGE_ON_SESSION_START_NAMESPACES}. */
   purged: number;
+  /** Number of `tasklist` rows trimmed by the retention pass. */
+  trimmed: number;
 }
 
 /**
- * Hard-delete every row whose namespace is in {@link EPHEMERAL_NAMESPACES}
- * and VACUUM. Returns `{ purged: 0 }` on the happy path: no DB, sql.js
- * unavailable, schema lacks `memory_entries`, or no ephemeral rows present.
- * Errors propagate to the caller (the launcher absorbs them so a failed
- * purge never blocks session start).
+ * Hard-delete rows in {@link PURGE_ON_SESSION_START_NAMESPACES} and trim the
+ * `tasklist` namespace to its retention cap, then VACUUM. Returns
+ * `{ purged: 0, trimmed: 0 }` on the happy path: no DB, sql.js unavailable,
+ * schema lacks `memory_entries`, or nothing to clean. Errors propagate to
+ * the caller (the launcher absorbs them so a failed purge never blocks
+ * session start).
  */
 export async function purgeEphemeralNamespaces(
   options: PurgeEphemeralNamespacesOptions = {},
@@ -55,10 +70,10 @@ export async function purgeEphemeralNamespaces(
   const path = await import('path');
 
   const dbPath = path.resolve(options.dbPath ?? memoryDbPath(process.cwd()));
-  if (!fs.existsSync(dbPath)) return { purged: 0 };
+  if (!fs.existsSync(dbPath)) return { purged: 0, trimmed: 0 };
 
   const initSqlJs = (await mofloImport('sql.js'))?.default;
-  if (!initSqlJs) return { purged: 0 };
+  if (!initSqlJs) return { purged: 0, trimmed: 0 };
 
   const SQL = await initSqlJs();
   const buffer = fs.readFileSync(dbPath);
@@ -70,27 +85,59 @@ export async function purgeEphemeralNamespaces(
     const probe = db.exec(
       `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_entries' LIMIT 1`,
     );
-    if (!probe[0]?.values?.[0]) return { purged: 0 };
+    if (!probe[0]?.values?.[0]) return { purged: 0, trimmed: 0 };
 
-    const namespaces = Array.from(EPHEMERAL_NAMESPACES);
+    // Single COUNT pass to gate both DELETEs — a clean DB is the steady
+    // state and we don't want two no-op DELETEs (with their query-planner
+    // overhead) on every session start.
+    const namespaces = Array.from(PURGE_ON_SESSION_START_NAMESPACES);
+    const cap = options.tasklistRetentionCap ?? TASKLIST_RETENTION_CAP;
     const placeholders = namespaces.map(() => '?').join(', ');
-
-    // Single-scan delete + rowsModified: skips a redundant COUNT pass on dirty
-    // DBs and avoids the prepare/bind/step/free overhead on clean ones. VACUUM
-    // (and the disk write) only run when something was actually deleted.
-    db.run(
-      `DELETE FROM memory_entries WHERE namespace IN (${placeholders})`,
+    const countRows = db.exec(
+      `SELECT
+         (SELECT COUNT(*) FROM memory_entries WHERE namespace IN (${placeholders})) AS purgeable,
+         (SELECT COUNT(*) FROM memory_entries WHERE namespace = 'tasklist') AS tasklistTotal`,
       namespaces,
     );
-    const purged = db.getRowsModified?.() ?? 0;
-    if (purged === 0) return { purged: 0 };
+    const counts = countRows[0]?.values?.[0] ?? [0, 0];
+    const purgeable = Number(counts[0] ?? 0);
+    const tasklistTotal = Number(counts[1] ?? 0);
+
+    let purged = 0;
+    if (purgeable > 0) {
+      db.run(
+        `DELETE FROM memory_entries WHERE namespace IN (${placeholders})`,
+        namespaces,
+      );
+      purged = db.getRowsModified?.() ?? 0;
+    }
+
+    let trimmed = 0;
+    if (tasklistTotal > cap) {
+      // Keep the newest `cap` rows by created_at, falling back to `id DESC`
+      // for legacy rows that predate the created_at-not-null schema (#728-era).
+      db.run(
+        `DELETE FROM memory_entries
+         WHERE namespace = 'tasklist'
+           AND id NOT IN (
+             SELECT id FROM memory_entries
+             WHERE namespace = 'tasklist'
+             ORDER BY created_at DESC, id DESC
+             LIMIT ?
+           )`,
+        [cap],
+      );
+      trimmed = db.getRowsModified?.() ?? 0;
+    }
+
+    if (purged === 0 && trimmed === 0) return { purged: 0, trimmed: 0 };
 
     // VACUUM has to run outside any open transaction; sql.js auto-commits
     // each `db.run`, so this is safe to chain.
     db.run('VACUUM');
 
     atomicWriteFileSync(dbPath, db.export());
-    return { purged };
+    return { purged, trimmed };
   } finally {
     db.close();
   }


### PR DESCRIPTION
## Summary

The dashboard's "Flo Runs" tab rendered nothing because the session-start launcher and the dashboard pointed at the same `tasklist` rows from opposite directions: #729 hard-purged them every launch, while #359 expected them to persist. Resolves the contradiction and wires the four non-spell-engine `/flo` paths (ticket / research / new-ticket / epic) that #359 left empty.

- Split `EPHEMERAL_NAMESPACES` (skip-embedding) from a strict subset `PURGE_ON_SESSION_START_NAMESPACES` (hard-delete on launch). `tasklist` stays in the first, drops out of the second.
- Launcher trims `tasklist` to `TASKLIST_RETENTION_CAP` (200) most-recent rows instead of bulk-purging — bounded growth, prior runs survive.
- Single `SELECT COUNT` pre-flight gates both DELETEs so a clean DB pays zero SQL on the steady-state session start.
- `/flo` skill calls `mcp__moflo__memory_store` at start (Phase 0) + finalize (Phase 5.5), schema mirrored on `storeFloRunRecord` in `daemon-dashboard.ts`.
- Worker Status table now distinguishes `disabled` (default-off, intentional) from `idle` (default-on, quiet). Prior display showed `audit`/`predict`/`document` as `idle` with "Last run: never" which read as broken. (#970 tracks ripping the three workers entirely.)
- "The Arcane Console" title gets per-word colored spans (purple / blue / green, L≈45-50% / S≈60-70% for WCAG-AA on both dark and light backgrounds) and a wizardy font chain led by `Cinzel Decorative` with offline-friendly system-serif fallbacks (down to Georgia + serif).

## Consumer impact

- **Surface touched**: `bin/session-start-launcher.mjs` (runtime — every consumer), `daemon-dashboard.ts` (UI seen by every consumer), `phases.md` (shipped skill), public exports from `bridge-embedder.ts`.
- **Failure mode for prior-version consumer**: none. The new launcher purges *fewer* rows than before (tasklist now retained), and adds row-count retention. Old `EPHEMERAL_NAMESPACES` export preserved as the embedding-skip set; new `PURGE_ON_SESSION_START_NAMESPACES` and `TASKLIST_RETENTION_CAP` are additive.
- **Round-trip cost**: requires publish-then-reinstall before consumer launchers pick up the trim semantics.

## Test plan

- [x] `npm test` — 8125/8125 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] Unit: `ephemeral-namespace-purge.test.ts` asserts (a) tasklist survives bulk purge, (b) trim keeps newest N rows, (c) clean DB writes nothing, (d) idempotent on second pass, (e) constants are properly partitioned.
- [x] Unit: `daemon-dashboard.test.ts` asserts the colored title spans render, the wizardy font is referenced, and `/api/status` exposes per-worker `enabled`.
- [x] Consumer-smoke harness: `populated.mjs` now asserts `tasklist` rows seeded into a moflo DB survive the launcher (would have caught this regression).
- [ ] Manual: visit \`http://127.0.0.1:3117/\` after a `/flo` session and a session restart to confirm Flo Runs populates and persists.
- [ ] Cross-platform daemon hosts: validated on Windows 11; macOS / Linux smoke runs to follow during release validation.

Closes #968
Related #729 #359 #964 #970

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)