### PR TITLE
refactor(#970): remove audit/predict/document workers + headless infra

### DIFF
--- a/.claude/guidance/shipped/moflo-cli-reference.md
+++ b/.claude/guidance/shipped/moflo-cli-reference.md
@@ -130,22 +130,25 @@ npx flo daemon start
 | `coverage-suggest` | Suggest coverage improvements            | `--path`                                    |
 | `coverage-gaps`    | List coverage gaps with priorities       | `--format`, `--limit`                       |
 
-### 12 Background Workers
+### Background Workers
 
-| Worker        | Priority | Description                |
-|---------------|----------|----------------------------|
-| `ultralearn`  | normal   | Deep knowledge acquisition |
-| `optimize`    | high     | Performance optimization   |
-| `consolidate` | low      | Memory consolidation       |
-| `predict`     | normal   | Predictive preloading      |
-| `audit`       | critical | Security analysis          |
-| `map`         | normal   | Codebase mapping           |
-| `preload`     | low      | Resource preloading        |
-| `deepdive`    | normal   | Deep code analysis         |
-| `document`    | normal   | Auto-documentation         |
-| `refactor`    | normal   | Refactoring suggestions    |
-| `benchmark`   | normal   | Performance benchmarking   |
-| `testgaps`    | normal   | Test coverage analysis     |
+The daemon ships nine workers — four scheduled by default plus five
+manual-trigger only. The pre-#970 `audit`, `predict`, and `document`
+workers were removed because they ran without a surfacing layer for
+findings; if AI-driven security scanning returns it should be an opt-in
+`flo doctor` one-shot, not a recurring background task.
+
+| Worker        | Priority | Default       | Description                |
+|---------------|----------|---------------|----------------------------|
+| `map`         | normal   | scheduled 15m | Codebase mapping           |
+| `optimize`    | high     | scheduled 15m | Performance optimization   |
+| `consolidate` | low      | scheduled 30m | Memory consolidation       |
+| `testgaps`    | normal   | scheduled 20m | Test coverage analysis     |
+| `ultralearn`  | normal   | manual        | Deep knowledge acquisition |
+| `refactor`    | normal   | manual        | Refactoring suggestions    |
+| `deepdive`    | normal   | manual        | Deep code analysis         |
+| `benchmark`   | normal   | manual        | Performance benchmarking   |
+| `preload`     | low      | manual        | Resource preloading        |
 
 ### Essential Hook Commands (MCP Preferred)
 

--- a/.claude/guidance/shipped/moflo-core-guidance.md
+++ b/.claude/guidance/shipped/moflo-core-guidance.md
@@ -126,8 +126,6 @@ For the full `moflo.yaml` schema, gate toggles, model routing, and sandbox confi
 |---------|--------|---------|
 | After major refactor | `optimize` | Performance optimization |
 | After adding features | `testgaps` | Find missing test coverage |
-| After security changes | `audit` | Security analysis |
-| After API changes | `document` | Update documentation |
 | Every 5+ file changes | `map` | Update codebase map |
 | Complex debugging | `deepdive` | Deep code analysis |
 

--- a/src/cli/__tests__/daemon-dashboard.test.ts
+++ b/src/cli/__tests__/daemon-dashboard.test.ts
@@ -102,7 +102,7 @@ function makeMockDaemon(overrides: Record<string, unknown> = {}, scheduler: any 
         failureCount: 1,
         averageDurationMs: 1200,
       }],
-      ['audit', {
+      ['testgaps', {
         isRunning: true,
         lastRun: new Date('2026-03-31T10:08:00Z'),
         nextRun: null,
@@ -118,8 +118,8 @@ function makeMockDaemon(overrides: Record<string, unknown> = {}, scheduler: any 
       resourceThresholds: { maxCpuLoad: 4.0, minFreeMemoryPercent: 10 },
       workers: [
         { type: 'map', intervalMs: 900000, priority: 'normal', description: 'Codebase mapping', enabled: true },
-        { type: 'audit', intervalMs: 600000, priority: 'critical', description: 'Security analysis', enabled: true },
-        { type: 'predict', intervalMs: 600000, priority: 'low', description: 'Predictive preloading', enabled: false },
+        { type: 'testgaps', intervalMs: 600000, priority: 'normal', description: 'Test coverage analysis', enabled: true },
+        { type: 'refactor', intervalMs: 600000, priority: 'low', description: 'Refactoring suggestions', enabled: false },
       ],
     },
     ...overrides,
@@ -244,7 +244,7 @@ describe('DaemonDashboard', () => {
     expect(data.workers[0].type).toBe('map');
     expect(data.workers[0].runCount).toBe(5);
     expect(data.workers[0].successCount).toBe(4);
-    expect(data.workers[1].type).toBe('audit');
+    expect(data.workers[1].type).toBe('testgaps');
     expect(data.workers[1].isRunning).toBe(true);
   });
 
@@ -253,13 +253,12 @@ describe('DaemonDashboard', () => {
     dashboard = await startDashboard(daemon, { port: testPort });
     const res = await fetchDashboard(testPort, '/api/status');
     const data = JSON.parse(res.body);
-    // map + audit are enabled in the default mock; predict is disabled.
-    // (predict isn't in workers Map by default, so add a workers entry would
-    // be needed — instead just verify the join logic emits the flag for
-    // listed workers.)
+    // map + testgaps are enabled in the default mock; refactor is disabled
+    // (config-only — not in workers Map). Verify the join logic emits the
+    // flag for listed workers.
     const byType = Object.fromEntries(data.workers.map((w: { type: string; enabled: boolean }) => [w.type, w.enabled]));
     expect(byType.map).toBe(true);
-    expect(byType.audit).toBe(true);
+    expect(byType.testgaps).toBe(true);
   });
 
   it('returns schedules at GET /api/schedules', async () => {

--- a/src/cli/__tests__/services/headless-worker-executor.test.ts
+++ b/src/cli/__tests__/services/headless-worker-executor.test.ts
@@ -478,7 +478,7 @@ describe('HeadlessWorkerExecutor', () => {
     it('should emit output events during execution', async () => {
       const config: HeadlessWorkerConfig = {
         workerId: 'test-2',
-        workerType: 'audit',
+        workerType: 'optimize',
         prompt: 'Security audit',
       };
 
@@ -563,7 +563,7 @@ describe('HeadlessWorkerExecutor', () => {
     it('should pass sandbox option to claude', async () => {
       const config: HeadlessWorkerConfig = {
         workerId: 'test-6',
-        workerType: 'audit',
+        workerType: 'optimize',
         prompt: 'Security scan',
         sandbox: 'strict',
       };
@@ -877,7 +877,7 @@ describe('HeadlessWorkerExecutor', () => {
 
       const config: HeadlessWorkerConfig = {
         workerId: 'error-emit-test',
-        workerType: 'audit',
+        workerType: 'optimize',
         prompt: 'Audit',
       };
 
@@ -950,7 +950,7 @@ describe('HeadlessWorkerExecutor', () => {
 
       const config: HeadlessWorkerConfig = {
         workerId: 'error-emit',
-        workerType: 'audit',
+        workerType: 'optimize',
         prompt: 'Test',
       };
 
@@ -1140,26 +1140,26 @@ describe('HeadlessWorkerExecutor', () => {
       );
     });
 
-    it('should execute audit worker with strict sandbox', async () => {
+    it('should execute optimize worker with strict sandbox', async () => {
       (glob as Mock).mockResolvedValue([]);
 
       const config: HeadlessWorkerConfig = {
-        workerId: 'audit-001',
-        workerType: 'audit',
-        prompt: 'Perform security audit',
+        workerId: 'optimize-001',
+        workerType: 'optimize',
+        prompt: 'Perform optimization analysis',
         sandbox: 'strict',
         outputFormat: 'markdown',
       };
 
       setTimeout(() => {
-        mockChildProcess.stdout?.emit('data', Buffer.from('# Security Audit\n\nNo issues found.'));
+        mockChildProcess.stdout?.emit('data', Buffer.from('# Optimization Report\n\nNo issues found.'));
         mockChildProcess.emit('close', 0);
       }, 10);
 
       const result = await executor.execute(config);
 
       expect(result.success).toBe(true);
-      expect(result.output).toContain('Security Audit');
+      expect(result.output).toContain('Optimization Report');
       expect(spawn).toHaveBeenCalledWith(
         expect.any(String),
         expect.arrayContaining(['--sandbox', 'strict']),
@@ -1172,7 +1172,7 @@ describe('HeadlessWorkerExecutor', () => {
 
       const configs: HeadlessWorkerConfig[] = [
         { workerId: 'concurrent-1', workerType: 'map', prompt: 'Task 1' },
-        { workerId: 'concurrent-2', workerType: 'audit', prompt: 'Task 2' },
+        { workerId: 'concurrent-2', workerType: 'optimize', prompt: 'Task 2' },
         { workerId: 'concurrent-3', workerType: 'optimize', prompt: 'Task 3' },
       ];
 

--- a/src/cli/__tests__/services/worker-daemon-resource-thresholds.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-resource-thresholds.test.ts
@@ -352,7 +352,7 @@ describe('WorkerDaemon resource thresholds', () => {
       });
 
       const pendingWorkers = (daemon as any).pendingWorkers as string[];
-      pendingWorkers.push('audit');
+      pendingWorkers.push('optimize');
 
       // Ensure no workers are currently running
       expect((daemon as any).runningWorkers.size).toBe(0);

--- a/src/cli/__tests__/services/worker-daemon.test.ts
+++ b/src/cli/__tests__/services/worker-daemon.test.ts
@@ -59,7 +59,7 @@ describe('WorkerDaemon', () => {
       autoStart: false,
       workers: [
         { type: 'map', intervalMs: 60000, priority: 'normal', description: 'Codebase mapping', enabled: true },
-        { type: 'audit', intervalMs: 120000, priority: 'critical', description: 'Security analysis', enabled: false },
+        { type: 'refactor', intervalMs: 120000, priority: 'normal', description: 'Refactoring suggestions', enabled: false },
       ],
     });
   });
@@ -81,15 +81,16 @@ describe('WorkerDaemon', () => {
       expect(typeof daemon.emit).toBe('function');
     });
 
-    it('default registry has audit worker disabled (#633)', () => {
+    it('default registry no longer ships audit/predict/document (#970)', () => {
       // No explicit workers config — falls through to DEFAULT_WORKERS
       const defaultDaemon = new WorkerDaemon('/tmp/test-default', { autoStart: false });
-      const audit = defaultDaemon.getStatus().config.workers.find(w => w.type === 'audit');
-      expect(audit).toBeDefined();
-      expect(audit?.enabled).toBe(false);
+      const workers = defaultDaemon.getStatus().config.workers;
+      for (const removed of ['audit', 'predict', 'document'] as const) {
+        expect(workers.find(w => w.type === removed as never)).toBeUndefined();
+      }
     });
 
-    it('default registry keeps non-audit workers enabled', () => {
+    it('default registry keeps the four scheduled workers enabled', () => {
       const defaultDaemon = new WorkerDaemon('/tmp/test-default-others', { autoStart: false });
       const workers = defaultDaemon.getStatus().config.workers;
       const map = workers.find(w => w.type === 'map');
@@ -178,7 +179,7 @@ describe('WorkerDaemon', () => {
     it('should include all configured worker types', () => {
       const status = daemon.getStatus();
       expect(status.workers.has('map')).toBe(true);
-      expect(status.workers.has('audit')).toBe(true);
+      expect(status.workers.has('refactor')).toBe(true);
     });
 
     it('should initialize worker states with zero counts', () => {
@@ -197,6 +198,48 @@ describe('WorkerDaemon', () => {
   describe('headless', () => {
     it('should report headless as unavailable when Claude Code is not present', () => {
       expect(daemon.isHeadlessAvailable()).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // State migration on upgrade (#970)
+  // ===========================================================================
+  describe('initializeWorkerStates — unknown-type drop (#970)', () => {
+    it('silently drops daemon-state entries for worker types no longer in the union', async () => {
+      const fs = await import('fs');
+      const stateFile = '/tmp/test-stale-workers/daemon-state.json';
+      const staleState = {
+        running: false,
+        workers: {
+          // Pre-#970 workers no longer in the WorkerType union
+          audit:    { runCount: 7, successCount: 7, failureCount: 0, averageDurationMs: 1000, consecutiveOverruns: 0 },
+          predict:  { runCount: 3, successCount: 0, failureCount: 3, averageDurationMs: 500,  consecutiveOverruns: 2 },
+          document: { runCount: 1, successCount: 1, failureCount: 0, averageDurationMs: 200,  consecutiveOverruns: 0 },
+          // Survivor — should be restored
+          map:      { runCount: 5, successCount: 5, failureCount: 0, averageDurationMs: 800,  consecutiveOverruns: 0 },
+        },
+        config: { workers: [{ type: 'map', enabled: true }] },
+        savedAt: '2026-04-01T00:00:00.000Z',
+      };
+      // Path-aware override: the constructor reads config.json BEFORE
+      // daemon-state.json, so a one-shot mock would intercept the wrong file.
+      vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+        const p = String(filePath);
+        if (p.includes('daemon-state.json')) return JSON.stringify(staleState);
+        if (p.includes('config.json')) return '{}';
+        throw new Error('ENOENT');
+      });
+
+      const upgraded = new WorkerDaemon('/tmp/test-stale-workers', { autoStart: false, stateFile });
+      const workers = upgraded.getStatus().workers;
+
+      // Stale entries are dropped — no orphan keys, no crash
+      expect(workers.has('audit' as never)).toBe(false);
+      expect(workers.has('predict' as never)).toBe(false);
+      expect(workers.has('document' as never)).toBe(false);
+      // Survivor's runtime stats are restored
+      expect(workers.get('map')?.runCount).toBe(5);
+      expect(workers.get('map')?.successCount).toBe(5);
     });
   });
 });

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -24,7 +24,7 @@ const startCommand: Command = {
   name: 'start',
   description: 'Start the worker daemon with all enabled background workers',
   options: [
-    { name: 'workers', short: 'w', type: 'string', description: 'Comma-separated list of workers to enable (default: map,audit,optimize,consolidate,testgaps)' },
+    { name: 'workers', short: 'w', type: 'string', description: 'Comma-separated list of workers to enable (default: map,optimize,consolidate,testgaps)' },
     { name: 'quiet', short: 'Q', type: 'boolean', description: 'Suppress output' },
     { name: 'background', short: 'b', type: 'boolean', description: 'Run daemon in background (detached process)', default: true },
     { name: 'foreground', short: 'f', type: 'boolean', description: 'Run daemon in foreground (blocks terminal)' },
@@ -38,7 +38,7 @@ const startCommand: Command = {
   examples: [
     { command: 'claude-flow daemon start', description: 'Start daemon in background (default)' },
     { command: 'claude-flow daemon start --foreground', description: 'Start in foreground (blocks terminal)' },
-    { command: 'claude-flow daemon start -w map,audit,optimize', description: 'Start with specific workers' },
+    { command: 'claude-flow daemon start -w map,optimize', description: 'Start with specific workers' },
     { command: 'claude-flow daemon start --headless --sandbox strict', description: 'Start with headless workers in strict sandbox' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
@@ -699,8 +699,7 @@ const triggerCommand: Command = {
   ],
   examples: [
     { command: 'claude-flow daemon trigger -w map', description: 'Trigger the map worker' },
-    { command: 'claude-flow daemon trigger -w audit', description: 'Trigger security audit' },
-    { command: 'claude-flow daemon trigger -w audit --headless', description: 'Trigger audit in headless sandbox' },
+    { command: 'claude-flow daemon trigger -w optimize --headless', description: 'Trigger optimize in headless sandbox' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const workerType = ctx.flags.worker as WorkerType;
@@ -708,7 +707,7 @@ const triggerCommand: Command = {
     if (!workerType) {
       output.printError('Worker type is required. Use --worker or -w flag.');
       output.writeln();
-      output.writeln('Available workers: map, audit, optimize, consolidate, testgaps, predict, document, ultralearn, refactor, benchmark, deepdive, preload');
+      output.writeln('Available workers: map, optimize, consolidate, testgaps, ultralearn, refactor, benchmark, deepdive, preload');
       return { success: false, exitCode: 1 };
     }
 
@@ -749,8 +748,8 @@ const enableCommand: Command = {
     { name: 'disable', short: 'd', type: 'boolean', description: 'Disable instead of enable' },
   ],
   examples: [
-    { command: 'claude-flow daemon enable -w predict', description: 'Enable predict worker' },
-    { command: 'claude-flow daemon enable -w document --disable', description: 'Disable document worker' },
+    { command: 'claude-flow daemon enable -w testgaps', description: 'Enable testgaps worker' },
+    { command: 'claude-flow daemon enable -w refactor --disable', description: 'Disable refactor worker' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const workerType = ctx.flags.worker as WorkerType;
@@ -885,7 +884,7 @@ export const daemonCommand: Command = {
     { command: 'claude-flow daemon start --headless', description: 'Start with headless workers (E2B sandbox)' },
     { command: 'claude-flow daemon status', description: 'Check daemon status' },
     { command: 'claude-flow daemon stop', description: 'Stop the daemon' },
-    { command: 'claude-flow daemon trigger -w audit', description: 'Run security audit' },
+    { command: 'claude-flow daemon trigger -w optimize', description: 'Run the optimize worker' },
     { command: 'claude-flow daemon install', description: 'Register as OS login service' },
     { command: 'claude-flow daemon uninstall', description: 'Remove OS login service' },
   ],
@@ -894,7 +893,7 @@ export const daemonCommand: Command = {
     output.writeln(output.bold('MoFlo Daemon - Background Task Management'));
     output.writeln();
     output.writeln('Node.js-based background worker system that auto-runs like shell daemons.');
-    output.writeln('Manages 12 specialized workers for continuous optimization and monitoring.');
+    output.writeln('Manages 9 specialized workers for continuous optimization and monitoring.');
     output.writeln();
     output.writeln(output.bold('Headless Mode'));
     output.writeln('Workers can run in headless mode using E2B sandboxes for isolated execution.');
@@ -903,13 +902,10 @@ export const daemonCommand: Command = {
 
     output.writeln(output.bold('Available Workers'));
     output.printList([
-      `${output.highlight('map')}         - Codebase mapping (5 min interval)`,
-      `${output.highlight('audit')}       - Security analysis (10 min interval)`,
+      `${output.highlight('map')}         - Codebase mapping (15 min interval)`,
       `${output.highlight('optimize')}    - Performance optimization (15 min interval)`,
       `${output.highlight('consolidate')} - Memory consolidation (30 min interval)`,
       `${output.highlight('testgaps')}    - Test coverage analysis (20 min interval)`,
-      `${output.highlight('predict')}     - Predictive preloading (2 min, disabled by default)`,
-      `${output.highlight('document')}    - Auto-documentation (60 min, disabled by default)`,
       `${output.highlight('ultralearn')}  - Deep knowledge acquisition (manual trigger)`,
       `${output.highlight('refactor')}    - Code refactoring suggestions (manual trigger)`,
       `${output.highlight('benchmark')}   - Performance benchmarking (manual trigger)`,

--- a/src/cli/commands/hooks.ts
+++ b/src/cli/commands/hooks.ts
@@ -2199,14 +2199,14 @@ const workerDispatchCommand: Command = {
   name: 'dispatch',
   description: 'Dispatch a background worker for analysis/optimization',
   options: [
-    { name: 'trigger', short: 't', type: 'string', description: 'Worker type (ultralearn, optimize, audit, map, etc.)', required: true },
+    { name: 'trigger', short: 't', type: 'string', description: 'Worker type (ultralearn, optimize, map, testgaps, etc.)', required: true },
     { name: 'context', short: 'c', type: 'string', description: 'Context for the worker (file path, topic)' },
     { name: 'priority', short: 'p', type: 'string', description: 'Priority (low, normal, high, critical)' },
     { name: 'sync', short: 's', type: 'boolean', description: 'Wait for completion (synchronous)' },
   ],
   examples: [
     { command: 'claude-flow hooks worker dispatch -t optimize -c src/', description: 'Dispatch optimize worker' },
-    { command: 'claude-flow hooks worker dispatch -t audit -p critical', description: 'Security audit with critical priority' },
+    { command: 'claude-flow hooks worker dispatch -t deepdive -p high', description: 'Deep code analysis with high priority' },
     { command: 'claude-flow hooks worker dispatch -t testgaps --sync', description: 'Test coverage analysis (sync)' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
@@ -2217,7 +2217,7 @@ const workerDispatchCommand: Command = {
 
     if (!trigger) {
       output.printError('--trigger is required');
-      output.writeln('Available triggers: ultralearn, optimize, consolidate, predict, audit, map, preload, deepdive, document, refactor, benchmark, testgaps');
+      output.writeln('Available triggers: ultralearn, optimize, consolidate, map, preload, deepdive, refactor, benchmark, testgaps');
       return { success: false, exitCode: 1 };
     }
 
@@ -3127,12 +3127,9 @@ const workerCommand: Command = {
       `${output.highlight('ultralearn')}   - Deep knowledge acquisition`,
       `${output.highlight('optimize')}     - Performance optimization`,
       `${output.highlight('consolidate')} - Memory consolidation`,
-      `${output.highlight('predict')}      - Predictive preloading`,
-      `${output.highlight('audit')}        - Security analysis (critical)`,
       `${output.highlight('map')}          - Codebase mapping`,
       `${output.highlight('preload')}      - Resource preloading`,
       `${output.highlight('deepdive')}     - Deep code analysis`,
-      `${output.highlight('document')}     - Auto-documentation`,
       `${output.highlight('refactor')}     - Refactoring suggestions`,
       `${output.highlight('benchmark')}    - Performance benchmarks`,
       `${output.highlight('testgaps')}     - Test coverage analysis`,

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -116,9 +116,11 @@ export function generateSettings(options: InitOptions): object {
     daemon: {
       autoStart: true,
       // Note: this list is documentation for the user — the daemon's actual
-      // worker registry lives in src/cli/services/worker-daemon.ts DEFAULT_WORKERS.
-      // 'audit' is intentionally absent here because it's default-disabled
-      // pending the perf fix in #631.
+      // worker registry lives in src/cli/services/worker-daemon.ts
+      // DEFAULT_WORKERS. The `audit`/`predict`/`document` workers were
+      // removed in #970 (no surfacing layer for findings + dashboard
+      // pollution); restore them as opt-in `flo doctor` one-shots if their
+      // value is ever re-established.
       workers: [
         'map',           // Codebase mapping
         'optimize',      // Performance optimization (high priority)
@@ -126,15 +128,12 @@ export function generateSettings(options: InitOptions): object {
         'testgaps',      // Test coverage gaps
         'ultralearn',    // Deep knowledge acquisition
         'deepdive',      // Deep code analysis
-        'document',      // Auto-documentation for ADRs
         'refactor',      // Refactoring suggestions (DDD alignment)
         'benchmark',     // Performance benchmarking
       ],
       schedules: {
-        audit: { interval: '1h', priority: 'critical' },
         optimize: { interval: '30m', priority: 'high' },
         consolidate: { interval: '2h', priority: 'low' },
-        document: { interval: '1h', priority: 'normal', triggers: ['adr-update', 'api-change'] },
         deepdive: { interval: '4h', priority: 'normal', triggers: ['complex-change'] },
         ultralearn: { interval: '1h', priority: 'normal' },
       },

--- a/src/cli/services/headless-worker-executor.ts
+++ b/src/cli/services/headless-worker-executor.ts
@@ -2,21 +2,14 @@
  * Headless Worker Executor
  * Enables workers to invoke Claude Code in headless mode with configurable sandbox profiles.
  *
- * ADR-020: Headless Worker Integration Architecture
+ * ADR-020: Headless Worker Integration Architecture (#970 dropped the
+ * `audit`/`document`/`predict` workers — those entries from the original
+ * ADR are superseded; the rest still applies).
  * - Integrates with CLAUDE_CODE_HEADLESS and CLAUDE_CODE_SANDBOX_MODE environment variables
  * - Provides process pool for concurrent execution
  * - Builds context from file glob patterns
  * - Supports prompt templates and output parsing
  * - Implements timeout and graceful error handling
- *
- * Key Features:
- * - Process pool with configurable maxConcurrent
- * - Context building from file glob patterns with caching
- * - Prompt template system with context injection
- * - Output parsing (text, json, markdown)
- * - Timeout handling with graceful termination
- * - Execution logging for debugging
- * - Event emission for monitoring
  */
 
 import { spawn, execSync, type ChildProcess } from 'child_process';
@@ -31,17 +24,15 @@ import { errorDetail } from '../shared/utils/error-detail.js';
 // ============================================
 
 /**
- * Headless worker types - workers that use Claude Code AI
+ * Headless worker types - workers that use Claude Code AI.
+ * `audit`/`document`/`predict` removed in #970.
  */
 export type HeadlessWorkerType =
-  | 'audit'
   | 'optimize'
   | 'testgaps'
-  | 'document'
   | 'ultralearn'
   | 'refactor'
-  | 'deepdive'
-  | 'predict';
+  | 'deepdive';
 
 /**
  * Local worker types - workers that run locally without AI
@@ -246,17 +237,14 @@ export interface PoolStatus {
 // ============================================
 
 /**
- * Array of headless worker types for runtime checking
+ * Array of headless worker types for runtime checking.
  */
 export const HEADLESS_WORKER_TYPES: HeadlessWorkerType[] = [
-  'audit',
   'optimize',
   'testgaps',
-  'document',
   'ultralearn',
   'refactor',
   'deepdive',
-  'predict',
 ];
 
 /**
@@ -279,38 +267,11 @@ const MODEL_IDS: Record<ModelType, string> = {
 };
 
 /**
- * Default headless worker configurations based on ADR-020
+ * Default headless worker configurations based on ADR-020 (the
+ * `audit`/`document`/`predict` entries from the original ADR were dropped
+ * in #970 — see worker-daemon.ts header for rationale).
  */
 export const HEADLESS_WORKER_CONFIGS: Record<HeadlessWorkerType, HeadlessWorkerConfig> = {
-  audit: {
-    type: 'audit',
-    mode: 'headless',
-    intervalMs: 30 * 60 * 1000,
-    priority: 'critical',
-    description: 'AI-powered security analysis',
-    enabled: true,
-    headless: {
-      promptTemplate: `Analyze this codebase for security vulnerabilities:
-- Check for hardcoded secrets (API keys, passwords)
-- Identify SQL injection risks
-- Find XSS vulnerabilities
-- Check for insecure dependencies
-- Identify authentication/authorization issues
-
-Provide a JSON report with:
-{
-  "vulnerabilities": [{ "severity": "high|medium|low", "file": "...", "line": N, "description": "..." }],
-  "riskScore": 0-100,
-  "recommendations": ["..."]
-}`,
-      sandbox: 'strict',
-      model: 'haiku',
-      outputFormat: 'json',
-      contextPatterns: ['**/*.ts', '**/*.js', '**/.env*', '**/package.json'],
-      timeoutMs: 5 * 60 * 1000,
-    },
-  },
-
   optimize: {
     type: 'optimize',
     mode: 'headless',
@@ -355,30 +316,6 @@ For each gap, provide a test skeleton.`,
       model: 'sonnet',
       outputFormat: 'markdown',
       contextPatterns: ['src/**/*.ts', 'tests/**/*.ts', '__tests__/**/*.ts'],
-      timeoutMs: 10 * 60 * 1000,
-    },
-  },
-
-  document: {
-    type: 'document',
-    mode: 'headless',
-    intervalMs: 120 * 60 * 1000,
-    priority: 'low',
-    description: 'AI documentation generation',
-    enabled: false,
-    headless: {
-      promptTemplate: `Generate documentation for undocumented code:
-- Add JSDoc comments to functions
-- Create README sections for modules
-- Document API endpoints
-- Add inline comments for complex logic
-- Generate usage examples
-
-Focus on public APIs and exported functions.`,
-      sandbox: 'permissive',
-      model: 'haiku',
-      outputFormat: 'markdown',
-      contextPatterns: ['src/**/*.ts'],
       timeoutMs: 10 * 60 * 1000,
     },
   },
@@ -461,34 +398,6 @@ Provide comprehensive report.`,
     },
   },
 
-  predict: {
-    type: 'predict',
-    mode: 'headless',
-    intervalMs: 10 * 60 * 1000,
-    priority: 'low',
-    description: 'Predictive preloading',
-    enabled: false,
-    headless: {
-      promptTemplate: `Based on recent activity, predict what the developer needs:
-- Files likely to be edited next
-- Tests that should be run
-- Documentation to reference
-- Dependencies to check
-
-Provide preload suggestions as JSON:
-{
-  "filesToPreload": ["..."],
-  "testsToRun": ["..."],
-  "docsToReference": ["..."],
-  "confidence": 0.0-1.0
-}`,
-      sandbox: 'strict',
-      model: 'haiku',
-      outputFormat: 'json',
-      contextPatterns: ['.moflo/metrics/*.json'],
-      timeoutMs: 2 * 60 * 1000,
-    },
-  },
 };
 
 /**

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -1,13 +1,21 @@
 /**
  * Worker Daemon Service
- * Node.js-based background worker system that auto-runs like shell daemons
+ * Node.js-based background worker system that auto-runs like shell daemons.
  *
- * Workers:
- * - map: Codebase mapping (5 min interval)
- * - audit: Security analysis (10 min interval)
+ * Default workers:
+ * - map: Codebase mapping (15 min interval)
  * - optimize: Performance optimization (15 min interval)
  * - consolidate: Memory consolidation (30 min interval)
  * - testgaps: Test coverage analysis (20 min interval)
+ *
+ * Manual-trigger-only workers (disabled by default, no scheduled run):
+ * ultralearn, refactor, deepdive, benchmark, preload.
+ *
+ * The `audit`, `predict`, and `document` workers were removed in #970 —
+ * they were default-disabled with no surfacing layer for findings, and the
+ * dashboard rendered them as "disabled" rows that read as broken. If a
+ * security or doc scan returns it should land as an opt-in `flo doctor`
+ * one-shot with a real findings UI, not as a recurring background worker.
  */
 
 import { EventEmitter } from 'events';
@@ -34,20 +42,42 @@ import { calculateDelay } from '../production/retry.js';
 import { CircuitBreaker } from '../production/circuit-breaker.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 
-// Worker types matching hooks-tools.ts
+// Worker types matching hooks-tools.ts. `audit`, `predict`, `document`
+// were removed in #970 — the WorkerType union is the source of truth for
+// `daemon-state.json` validation, so dropping them here is what makes the
+// state loader silently drop stale entries (see `initializeWorkerStates`).
 export type WorkerType =
   | 'ultralearn'
   | 'optimize'
   | 'consolidate'
-  | 'predict'
-  | 'audit'
   | 'map'
   | 'preload'
   | 'deepdive'
-  | 'document'
   | 'refactor'
   | 'benchmark'
   | 'testgaps';
+
+/**
+ * Runtime allow-list of known {@link WorkerType} values. Used by
+ * `initializeWorkerStates` to silently drop entries from a stale
+ * `daemon-state.json` after a worker is removed from the union (#970).
+ * Keep in sync with the `WorkerType` definition above.
+ */
+const KNOWN_WORKER_TYPES: ReadonlySet<WorkerType> = new Set<WorkerType>([
+  'ultralearn',
+  'optimize',
+  'consolidate',
+  'map',
+  'preload',
+  'deepdive',
+  'refactor',
+  'benchmark',
+  'testgaps',
+]);
+
+function isKnownWorkerType(value: unknown): value is WorkerType {
+  return typeof value === 'string' && KNOWN_WORKER_TYPES.has(value as WorkerType);
+}
 
 interface WorkerConfig {
   type: WorkerType;
@@ -115,15 +145,9 @@ interface WorkerConfigInternal extends WorkerConfig {
 // Default worker configurations with improved intervals (P0 fix: map 5min -> 15min)
 const DEFAULT_WORKERS: WorkerConfigInternal[] = [
   { type: 'map', intervalMs: 15 * 60 * 1000, offsetMs: 0, priority: 'normal', description: 'Codebase mapping', enabled: true },
-  // Default-disabled until the perf regression in #631 is remediated. The
-  // worker averages 238 s/run on real installs, saturating cores back-to-back
-  // when scheduled at the 10-minute interval. Re-enable here when #631 ships.
-  { type: 'audit', intervalMs: 10 * 60 * 1000, offsetMs: 2 * 60 * 1000, priority: 'critical', description: 'Security analysis', enabled: false },
   { type: 'optimize', intervalMs: 15 * 60 * 1000, offsetMs: 4 * 60 * 1000, priority: 'high', description: 'Performance optimization', enabled: true },
   { type: 'consolidate', intervalMs: 30 * 60 * 1000, offsetMs: 6 * 60 * 1000, priority: 'low', description: 'Memory consolidation', enabled: true },
   { type: 'testgaps', intervalMs: 20 * 60 * 1000, offsetMs: 8 * 60 * 1000, priority: 'normal', description: 'Test coverage analysis', enabled: true },
-  { type: 'predict', intervalMs: 10 * 60 * 1000, offsetMs: 0, priority: 'low', description: 'Predictive preloading', enabled: false },
-  { type: 'document', intervalMs: 60 * 60 * 1000, offsetMs: 0, priority: 'low', description: 'Auto-documentation', enabled: false },
 ];
 
 // Worker timeout (5 minutes max per worker)
@@ -454,9 +478,15 @@ export class WorkerDaemon extends EventEmitter {
           this.config.workerTimeoutMs = saved.config.workerTimeoutMs;
         }
 
-        // Restore worker runtime states (runCount, successCount, etc.)
+        // Restore worker runtime states (runCount, successCount, etc.).
+        // Unknown worker types (left over from a prior moflo version where
+        // `audit`/`predict`/`document` existed) are silently dropped — see
+        // KNOWN_WORKER_TYPES + #970 — so consumers upgrading don't crash on
+        // stale state, and the orphan entries don't get re-persisted on the
+        // next saveState.
         if (saved.workers) {
           for (const [type, state] of Object.entries(saved.workers)) {
+            if (!isKnownWorkerType(type)) continue;
             const savedState = state as Record<string, unknown>;
             const lastRunValue = savedState.lastRun;
             const restoredState: WorkerState = {
@@ -937,18 +967,12 @@ export class WorkerDaemon extends EventEmitter {
     switch (workerConfig.type) {
       case 'map':
         return this.runMapWorker();
-      case 'audit':
-        return this.runAuditWorkerLocal();
       case 'optimize':
         return this.runOptimizeWorkerLocal();
       case 'consolidate':
         return this.runConsolidateWorker();
       case 'testgaps':
         return this.runTestGapsWorkerLocal();
-      case 'predict':
-        return this.runPredictWorkerLocal();
-      case 'document':
-        return this.runDocumentWorkerLocal();
       case 'ultralearn':
         return this.runUltralearnWorkerLocal();
       case 'refactor':
@@ -989,35 +1013,6 @@ export class WorkerDaemon extends EventEmitter {
 
     writeFileSync(metricsFile, JSON.stringify(map, null, 2));
     return map;
-  }
-
-  /**
-   * Local audit worker (fallback when headless unavailable)
-   */
-  private async runAuditWorkerLocal(): Promise<unknown> {
-    // Basic security checks
-    const auditFile = join(this.projectRoot, '.moflo', 'metrics', 'security-audit.json');
-    const metricsDir = join(this.projectRoot, '.moflo', 'metrics');
-
-    if (!existsSync(metricsDir)) {
-      mkdirSync(metricsDir, { recursive: true });
-    }
-
-    const audit = {
-      timestamp: new Date().toISOString(),
-      mode: 'local',
-      checks: {
-        envFilesProtected: !existsSync(join(this.projectRoot, '.env.local')),
-        gitIgnoreExists: existsSync(join(this.projectRoot, '.gitignore')),
-        noHardcodedSecrets: true, // Would need actual scanning
-      },
-      riskLevel: 'low',
-      recommendations: [],
-      note: 'Install Claude Code CLI for AI-powered security analysis',
-    };
-
-    writeFileSync(auditFile, JSON.stringify(audit, null, 2));
-    return audit;
   }
 
   /**
@@ -1091,32 +1086,6 @@ export class WorkerDaemon extends EventEmitter {
 
     writeFileSync(testGapsFile, JSON.stringify(result, null, 2));
     return result;
-  }
-
-  /**
-   * Local predict worker (fallback when headless unavailable)
-   */
-  private async runPredictWorkerLocal(): Promise<unknown> {
-    return {
-      timestamp: new Date().toISOString(),
-      mode: 'local',
-      predictions: [],
-      preloaded: [],
-      note: 'Install Claude Code CLI for AI-powered predictions',
-    };
-  }
-
-  /**
-   * Local document worker (fallback when headless unavailable)
-   */
-  private async runDocumentWorkerLocal(): Promise<unknown> {
-    return {
-      timestamp: new Date().toISOString(),
-      mode: 'local',
-      filesDocumented: 0,
-      suggestedDocs: [],
-      note: 'Install Claude Code CLI for AI-powered documentation generation',
-    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Three default-disabled background workers (`audit`, `predict`, `document`) shipped with no surfacing layer for findings. The Arcane Console's Worker Status tab rendered them as "disabled" rows that read as broken — the user surfaced the confusion during /flo 968. `npm audit` + `git-secrets` + ESLint security rules cover ~80% of audit's stated value at 0% recurring CPU; predict and document had no measured uplift and no consumer.

This PR rips them end-to-end from the daemon-runtime side:

- `WorkerType` / `HeadlessWorkerType` unions trimmed; the three handler blocks in `headless-worker-executor.ts` and three local-fallback methods in `worker-daemon.ts` are gone.
- `DEFAULT_WORKERS` shrinks to 4 scheduled (map / optimize / consolidate / testgaps); 5 workers stay manual-trigger only.
- `flo daemon` + `flo hooks worker dispatch` CLI help text and examples cleaned to match.
- Settings-generator's default schedules + worker list trimmed.
- `moflo-cli-reference.md` and `moflo-core-guidance.md` updated.

## Consumer migration safety

Consumers on the prior version have these worker types in their on-disk `daemon-state.json`. After upgrade, the new `WorkerType` union doesn't include them. New `KNOWN_WORKER_TYPES: ReadonlySet<WorkerType>` + `isKnownWorkerType` typeguard in `initializeWorkerStates` silently drops unknown entries during restore — orphans don't get re-persisted on the next `saveState`. Test asserts the drop with a seeded stale state file.

## Out of scope (kept intentionally)

The parallel `WorkerType` / `WorkerTrigger` unions in `mcp-tools/hooks-tools.ts` and `swarm/workers/worker-dispatch.ts` are prompt-routing taxonomies (Tool-keyword matching for routing prompts to specialized agents), **not** daemon-runtime worker definitions. They don't surface in the dashboard and don't poll/run anything. Removing them would require its own ticket and rationale.

## Test plan

- [x] `npm test` — 8126/8126 pass (one more than before — new unknown-type drop test).
- [x] `npx tsc --noEmit` — clean.
- [x] Worker-daemon test asserts post-#970 default registry no longer ships the three; new test asserts saved state with stale entries doesn't crash the daemon and that survivor stats are preserved.
- [x] Headless-worker-executor tests rebound from audit→optimize fixtures (the strict-sandbox test logic is unchanged).
- [x] Dashboard test mock now uses testgaps (enabled) + refactor (disabled) so the per-worker `enabled` flag from #968 still has a default-off worker to assert against.
- [ ] Cross-platform smoke run on macOS / Linux during release validation.
- [ ] Manual: bring up daemon, confirm Worker Status tab shows 4 workers (no more "disabled" stale rows from the removed three).

Closes #970
Related #968 #631 #638

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)