### PR TITLE
fix(memory): bridge persist failures surface as success:false (#982)

### DIFF
--- a/src/cli/__tests__/bridge-entries.test.ts
+++ b/src/cli/__tests__/bridge-entries.test.ts
@@ -17,8 +17,8 @@ import {
   _resetBridgeEmbedderCacheForTest,
   type BridgeEmbedder,
 } from '../memory/bridge-embedder.js';
-import { bridgeDeleteEntry, bridgeListEntries, bridgeSearchEntries, bridgeStoreEntry } from '../memory/bridge-entries.js';
-import { _resetProjectRootForTest, execRows, getDb } from '../memory/bridge-core.js';
+import { bridgeDeleteEntry, bridgeListEntries, bridgeSearchEntries, bridgeStoreEntries, bridgeStoreEntry } from '../memory/bridge-entries.js';
+import { _resetProjectRootForTest, execRows, getDb, persistBridgeDb, tryPersistBridgeDb } from '../memory/bridge-core.js';
 import { shutdownBridge, getControllerRegistry } from '../memory/memory-bridge.js';
 
 let tmpDir: string;
@@ -465,5 +465,143 @@ describe('bridgeDeleteEntry — error surfacing (#963)', () => {
     // Original entry still in correct namespace
     const list = await bridgeListEntries({ namespace: 'correct-ns', dbPath });
     expect(list?.entries.find(e => e.key === 'k-ns-test')).toBeDefined();
+  });
+});
+
+// ===========================================================================
+// #982 — bridge persist failures must NOT be silently swallowed.
+//
+// Repros the silent-data-loss pattern: pre-#982 the inner sql.js insert
+// succeeded but `atomicWriteFileSync` threw (EBUSY on Windows when another
+// process held the dbfile open, ENOSPC, perm denied), the throw was logged
+// once to stderr, and `bridgeStoreEntry` returned `{ success: true }`. Every
+// caller upstream (memory-initializer.storeEntry, dashboard accessor,
+// runner.storeProgress) trusted the success and the data died with the
+// process. Same pattern in `bridgeStoreEntries` and `bridgeDeleteEntry`.
+// ===========================================================================
+describe('#982 — persist failures surface as success:false', () => {
+  /** Inject EBUSY into the rename leg of atomicWriteFileSync. */
+  function makeRenameThrow(): NodeJS.ErrnoException {
+    const err: NodeJS.ErrnoException = new Error('EBUSY: resource busy or locked, rename');
+    err.code = 'EBUSY';
+    return err;
+  }
+
+  it('persistBridgeDb rethrows the underlying error (no silent swallow)', () => {
+    const fakeDb = { export: () => { throw makeRenameThrow(); } };
+    expect(() => persistBridgeDb(fakeDb, dbPath)).toThrow(/EBUSY/);
+  });
+
+  it('tryPersistBridgeDb returns ok:false instead of throwing', () => {
+    const fakeDb = { export: () => { throw makeRenameThrow(); } };
+    const result = tryPersistBridgeDb(fakeDb, dbPath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error.message).toMatch(/EBUSY/);
+    }
+  });
+
+  /**
+   * Override the bridge db's `.export()` to throw the given error. Returns
+   * a restore function. We can't `vi.spyOn(fs, 'renameSync')` because ESM
+   * namespaces aren't configurable; intercepting `db.export()` exercises
+   * the same code path because `atomicWriteFileSync(target, db.export())`
+   * evaluates `export()` first, and `persistBridgeDb`'s try/catch wraps
+   * the whole call.
+   */
+  async function injectPersistFailure(err: Error): Promise<() => void> {
+    const reg = await getControllerRegistry(dbPath);
+    if (!reg) throw new Error('test bridge registry unavailable');
+    const ctx = getDb(reg);
+    if (!ctx) throw new Error('test bridge db ctx unavailable');
+    const orig = ctx.db.export.bind(ctx.db);
+    ctx.db.export = () => { throw err; };
+    return () => { ctx.db.export = orig; };
+  }
+
+  it('bridgeStoreEntry returns success:false with persist failed when atomic-write throws', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    // Land one successful row first so the bridge is fully initialized
+    // (registry + embedder cache warm) before we inject the failure. This
+    // mirrors the real-world reproduction: short-lived `flo epic` runs
+    // start with a healthy DB, then hit EBUSY on a later persist.
+    const ok = await bridgeStoreEntry({ key: 'pre-fail', value: 'baseline', namespace: 'tasklist', dbPath });
+    expect(ok?.success).toBe(true);
+
+    const restore = await injectPersistFailure(makeRenameThrow());
+    try {
+      const result = await bridgeStoreEntry({
+        key: 'should-fail',
+        value: 'data that never reaches disk',
+        namespace: 'tasklist',
+        dbPath,
+      });
+      expect(result?.success).toBe(false);
+      expect(result?.error).toContain('persist failed');
+      expect(result?.error).toMatch(/EBUSY/);
+    } finally {
+      restore();
+    }
+  });
+
+  it('bridgeStoreEntries flips ALL successful results to failed when the final persist throws', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    // Warm the bridge with a successful baseline write
+    const ok = await bridgeStoreEntry({ key: 'warm-up', value: 'x', namespace: 'tasklist', dbPath });
+    expect(ok?.success).toBe(true);
+
+    const restore = await injectPersistFailure(makeRenameThrow());
+    try {
+      const results = await bridgeStoreEntries(
+        [
+          { key: 'batch-1', value: 'a', namespace: 'tasklist' },
+          { key: 'batch-2', value: 'b', namespace: 'tasklist' },
+          { key: 'batch-3', value: 'c', namespace: 'tasklist' },
+        ],
+        dbPath,
+      );
+      expect(results).not.toBeNull();
+      expect(results).toHaveLength(3);
+      // sql.js dumps the entire DB snapshot in one persist call, so a single
+      // throw means NONE of the batch reached disk — every entry must report
+      // persist failed, regardless of how its inserts went in RAM.
+      for (const r of results!) {
+        expect(r.success).toBe(false);
+        expect(r.error).toContain('persist failed');
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('bridgeDeleteEntry returns success:false with persist failed when atomic-write throws', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    // Insert the row to be deleted
+    const inserted = await bridgeStoreEntry({
+      key: 'k-to-delete',
+      value: 'doomed',
+      namespace: 'scheduled-spells',
+      dbPath,
+    });
+    expect(inserted?.success).toBe(true);
+
+    const restore = await injectPersistFailure(makeRenameThrow());
+    try {
+      const result = await bridgeDeleteEntry({
+        key: 'k-to-delete',
+        namespace: 'scheduled-spells',
+        dbPath,
+      });
+      expect(result?.success).toBe(false);
+      expect(result?.deleted).toBe(false);
+      expect(result?.error).toContain('persist failed');
+      expect(result?.error).toMatch(/EBUSY/);
+    } finally {
+      restore();
+    }
   });
 });

--- a/src/cli/epic/runner-adapter.ts
+++ b/src/cli/epic/runner-adapter.ts
@@ -16,6 +16,30 @@ import {
   type PreflightWarningDecision,
 } from '../services/engine-loader.js';
 import { createDashboardMemoryAccessor } from '../services/daemon-dashboard.js';
+import type { MemoryAccessor } from '../spells/types/step-command.types.js';
+
+/**
+ * Wrap a MemoryAccessor with a write-failure counter so the [epic] summary
+ * can warn when spell progress didn't reach disk (#982). Without this, a
+ * persist failure surfaces only as a `[spell] storeProgress(...) failed`
+ * line buried mid-run, easily missed in shell scrollback.
+ */
+function trackPersistFailures(inner: MemoryAccessor): MemoryAccessor & { failedWrites: number } {
+  const tracker = {
+    failedWrites: 0,
+    async read(ns: string, key: string) { return inner.read(ns, key); },
+    async write(ns: string, key: string, value: unknown) {
+      try {
+        await inner.write(ns, key, value);
+      } catch (err) {
+        tracker.failedWrites++;
+        throw err;
+      }
+    },
+    async search(ns: string, query: string) { return inner.search(ns, query); },
+  };
+  return tracker;
+}
 
 /** Minimal spell result shape matching SpellResult from the inlined spell engine. */
 export type EpicSpellResult = Pick<
@@ -53,7 +77,7 @@ export interface EpicRunOptions {
 export type { PreflightWarning, PreflightWarningDecision };
 
 /** Cached memory accessor — created once per process. */
-let memoryAccessor: Awaited<ReturnType<typeof createDashboardMemoryAccessor>> | null = null;
+let memoryAccessor: ReturnType<typeof trackPersistFailures> | null = null;
 
 /** Prompt the user to accept or decline spell permissions. */
 async function promptAcceptPermissions(): Promise<boolean> {
@@ -84,7 +108,8 @@ export async function runEpicSpell(
   // are persisted and visible in the dashboard.
   if (!memoryAccessor) {
     try {
-      memoryAccessor = await createDashboardMemoryAccessor();
+      const inner = await createDashboardMemoryAccessor();
+      memoryAccessor = trackPersistFailures(inner);
       console.log('[epic] Memory accessor ready — spell progress will be persisted');
     } catch (err) {
       console.warn(`[epic] ⚠ Dashboard memory unavailable: ${(err as Error).message ?? err}`);
@@ -92,9 +117,27 @@ export async function runEpicSpell(
     }
   }
 
+  // memoryAccessor is module-cached, so `failedWrites` is cumulative across
+  // every spell run in this process. Capturing the count BEFORE this run
+  // and computing the delta below isolates "this run's failures" from any
+  // prior run's. Spell runs are sequential per process, so no race.
+  const failuresBefore = memoryAccessor?.failedWrites ?? 0;
   const runOpts = { ...options, projectRoot: process.cwd(), ...(memoryAccessor ? { memory: memoryAccessor } : {}) };
 
-  const result = await engine.runSpellFromContent(
+  // Print the persist-failure summary on every return path. Without this,
+  // a #982-style failure surfaces only as scattered `[spell] storeProgress
+  // failed` lines mid-run that get lost in scrollback. The summary line is
+  // the user's signal that the dashboard / Luminarium will show empty
+  // history despite a successful-looking spell run.
+  const reportPersistFailures = (): void => {
+    if (!memoryAccessor) return;
+    const failed = memoryAccessor.failedWrites - failuresBefore;
+    if (failed > 0) {
+      console.warn(`[epic] ⚠ Spell progress was not fully persisted (${failed} write${failed === 1 ? '' : 's'} failed) — run history may be missing from the dashboard.`);
+    }
+  };
+
+  let result = await engine.runSpellFromContent(
     yamlContent, undefined, runOpts,
   ) as EpicSpellResult;
 
@@ -107,6 +150,7 @@ export async function runEpicSpell(
   if (hasAcceptanceError) {
     const accepted = await promptAcceptPermissions();
     if (!accepted) {
+      reportPersistFailures();
       return result;
     }
 
@@ -133,10 +177,11 @@ export async function runEpicSpell(
     await recordAcceptance(projectRoot, parsed.definition.name, report.permissionHash);
     console.log(`[epic] Permissions accepted for "${parsed.definition.name}" — retrying...\n`);
 
-    return engine.runSpellFromContent(
+    result = await engine.runSpellFromContent(
       yamlContent, undefined, runOpts,
-    ) as Promise<EpicSpellResult>;
+    ) as EpicSpellResult;
   }
 
+  reportPersistFailures();
   return result;
 }

--- a/src/cli/memory/bridge-core.ts
+++ b/src/cli/memory/bridge-core.ts
@@ -80,8 +80,15 @@ export function getBridgeLastError(): Error | null {
   return lastBridgeError;
 }
 
-function logBridgeError(context: string, err: unknown): void {
-  if (process.env.MOFLO_BRIDGE_QUIET) return;
+/**
+ * Log a bridge error. By default `MOFLO_BRIDGE_QUIET` suppresses the line
+ * to keep test output clean for read-path noise. Pass `{ alwaysLog: true }`
+ * for write-path errors that mean data did NOT reach disk — those MUST
+ * always log, since the quiet env var is for read-path noise control,
+ * not for masking data loss (#982 / #854 / #962 anti-pattern).
+ */
+function logBridgeError(context: string, err: unknown, opts?: { alwaysLog?: boolean }): void {
+  if (process.env.MOFLO_BRIDGE_QUIET && !opts?.alwaysLog) return;
   const msg = errorDetail(err);
   console.error(`[moflo] ${context}: ${msg}`);
 }
@@ -206,6 +213,17 @@ export function execRows(db: any, sql: string, params?: unknown[]): Record<strin
  * Persist the in-memory sql.js DB back to disk. sql.js is purely in-memory —
  * without an explicit export+writeFileSync after each mutation, writes vanish
  * when the process exits, which breaks store→retrieve across CLI commands.
+ *
+ * Throws on failure (#982). Callers that issued a mutation MUST treat a
+ * persist throw as the mutation having failed: the in-memory DB still has
+ * the new row, but it never reached disk and dies with the process.
+ *
+ * Pre-#982 this swallowed silently and logged once to stderr — the
+ * `bridgeStoreEntry` path then returned `{ success: true }` despite the
+ * data being lost, the success-lie pattern that cost #854 and #962 too.
+ *
+ * Use {@link tryPersistBridgeDb} for the rare best-effort caller (cache
+ * invalidation, idempotent maintenance) that genuinely doesn't care.
  */
 export function persistBridgeDb(db: any, dbPath?: string): void {
   // Mirror the read-side resolution so writes land where reads come from.
@@ -218,7 +236,27 @@ export function persistBridgeDb(db: any, dbPath?: string): void {
     fs.mkdirSync(path.dirname(target), { recursive: true });
     atomicWriteFileSync(target, db.export());
   } catch (err) {
-    logBridgeError('bridge persist failed', err);
+    logBridgeError('bridge persist failed', err, { alwaysLog: true });
+    throw err;
+  }
+}
+
+/**
+ * Best-effort variant of {@link persistBridgeDb}. Returns `{ ok: false }`
+ * on failure instead of throwing. Reserve for callers where a missed
+ * persist is genuinely acceptable (e.g. cache invalidation that the next
+ * mutation will redo). Always-log policy still applies — write failures
+ * cannot be silenced.
+ */
+export function tryPersistBridgeDb(
+  db: any,
+  dbPath?: string,
+): { ok: true } | { ok: false; error: Error } {
+  try {
+    persistBridgeDb(db, dbPath);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err : new Error(String(err)) };
   }
 }
 

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -12,6 +12,21 @@ import { cosineSim, execRows, generateId, persistBridgeDb, refreshVectorStatsCac
 import { embeddingResponseFrom, getBridgeEmbedder, resolveBridgeEmbedding } from './bridge-embedder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 
+/**
+ * Run `persistBridgeDb` and convert any throw into a `persist failed:`
+ * error string for the caller. Centralises the #982 single-store /
+ * bulk-store / delete pattern so the failure shape can never drift
+ * across the three call sites.
+ */
+function tryPersist(db: any, dbPath?: string): { ok: true } | { ok: false; error: string } {
+  try {
+    persistBridgeDb(db, dbPath);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: `persist failed: ${errorDetail(err)}` };
+  }
+}
+
 function makeEntryCacheKey(namespace: string, key: string): string {
   const safeNs = String(namespace).replace(/:/g, '_');
   const safeKey = String(key).replace(/:/g, '_');
@@ -176,7 +191,16 @@ export async function bridgeStoreEntry(options: {
       now, now,
       ttl ? now + (ttl * 1000) : null,
     ]);
-    persistBridgeDb(ctx.db, options.dbPath);
+
+    // Honest persist (#982). If atomicWriteFileSync throws (Windows EBUSY
+    // on a daemon-held file, ENOSPC, perm denied, antivirus rename block),
+    // surface it as `success: false` instead of returning a lying success.
+    // Skip post-persist bookkeeping so cache + attestation cannot diverge
+    // from on-disk state.
+    const persisted = tryPersist(ctx.db, options.dbPath);
+    if (!persisted.ok) {
+      return { success: false, id, error: persisted.error };
+    }
 
     const cacheKey = makeEntryCacheKey(namespace, key);
     await cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson });
@@ -219,7 +243,13 @@ export async function bridgeStoreEntries(items: Array<{
   if (items.length === 0) return [];
   return withDb(dbPath, async (ctx, registry) => {
     const results: Array<{ success: boolean; id: string; embedding?: { dimensions: number; model: string }; error?: string }> = [];
-    const bookkeeping: Promise<void>[] = [];
+    /**
+     * Per-item bookkeeping fired AFTER persist succeeds (#982). If we
+     * fired cache/attestation during the loop and then persist threw,
+     * the cache would be warm with rows that never reached disk — the
+     * exact divergence #982 is fixing in the single-store path. Defer.
+     */
+    const deferredBookkeeping: Array<{ cacheKey: string; cacheValue: unknown; entryId: string; entryKey: string; namespace: string; hasEmbedding: boolean }> = [];
     let anyEmbedded = false;
     let anyWritten = false;
 
@@ -288,9 +318,14 @@ export async function bridgeStoreEntries(items: Array<{
       anyWritten = true;
       if (embeddingJson) anyEmbedded = true;
 
-      const cacheKey = makeEntryCacheKey(namespace, key);
-      bookkeeping.push(cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson }));
-      bookkeeping.push(logAttestation(registry, 'store', id, { key, namespace, hasEmbedding: !!embeddingJson }));
+      deferredBookkeeping.push({
+        cacheKey: makeEntryCacheKey(namespace, key),
+        cacheValue: { id, key, namespace, content: value, embedding: embeddingJson },
+        entryId: id,
+        entryKey: key,
+        namespace,
+        hasEmbedding: !!embeddingJson,
+      });
 
       results.push({
         success: true,
@@ -299,11 +334,31 @@ export async function bridgeStoreEntries(items: Array<{
       });
     }
 
-    // Cache writes and attestation logs are independent post-hoc bookkeeping —
-    // overlap them while the final persist runs. SQL inserts above stayed
-    // sequential because sql.js is single-threaded.
-    await Promise.all(bookkeeping);
-    if (anyWritten) persistBridgeDb(ctx.db, dbPath);
+    // Honest persist (#982). The whole batch shares one persist call: if it
+    // throws, NONE of the rows reached disk, so flip every successful entry
+    // to a failure with the same error. Per-row partial success is impossible
+    // — sql.js dumps the entire DB snapshot atomically. Bookkeeping (cache
+    // + attestation) is deferred until AFTER persist succeeds so the cache
+    // cannot warm rows that never reached disk.
+    if (anyWritten) {
+      const persisted = tryPersist(ctx.db, dbPath);
+      if (!persisted.ok) {
+        for (let i = 0; i < results.length; i++) {
+          if (results[i].success) {
+            results[i] = { success: false, id: results[i].id, error: persisted.error };
+          }
+        }
+        return results;
+      }
+    }
+
+    // Persist succeeded — fire deferred bookkeeping in parallel.
+    await Promise.all(
+      deferredBookkeeping.flatMap(b => [
+        cacheSet(registry, b.cacheKey, b.cacheValue),
+        logAttestation(registry, 'store', b.entryId, { key: b.entryKey, namespace: b.namespace, hasEmbedding: b.hasEmbedding }),
+      ]),
+    );
     if (anyEmbedded) refreshVectorStatsCache();
 
     return results;
@@ -664,7 +719,13 @@ export async function bridgeDeleteEntry(options: {
       );
     }
 
-    persistBridgeDb(ctx.db, options.dbPath);
+    // Honest persist (#982). If the persist throws, the DELETE didn't reach
+    // disk — the row will reappear on next process load. Surface as a failure
+    // and skip cache invalidation so the cache stays consistent with disk.
+    const persisted = tryPersist(ctx.db, options.dbPath);
+    if (!persisted.ok) {
+      return deleteFail(persisted.error);
+    }
     await cacheInvalidate(registry, makeEntryCacheKey(namespace, key));
     await logAttestation(registry, 'delete', key, { namespace });
 

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -75,7 +75,12 @@ export async function createDashboardMemoryAccessor(): Promise<MemoryAccessor> {
     async write(namespace: string, key: string, value: unknown): Promise<void> {
       const result = await storeEntry({ key, value: typeof value === 'string' ? value : JSON.stringify(value), namespace, upsert: true });
       if (!result.success) {
-        console.warn(`[dashboard] memory.write(${namespace}, ${key}) failed: ${result.error ?? 'unknown'}`);
+        // #982 — surface the failure to callers (runner.storeProgress wraps
+        // this in a try/catch + console.warn). Pre-#982 we just warned and
+        // returned cleanly, which let the spell engine claim success on a
+        // run whose progress writes never reached disk.
+        const err = `memory.write(${namespace}, ${key}) failed: ${result.error ?? 'unknown'}`;
+        throw new Error(err);
       }
     },
     async search(namespace: string, query: string): Promise<Array<{ key: string; value: unknown; score: number }>> {


### PR DESCRIPTION
## Summary

Closes #982 — the silent-data-loss defect where `persistBridgeDb` swallowed throws from `atomicWriteFileSync` and `bridgeStoreEntry` returned `{ success: true }` despite the data never reaching disk. Same silent-catch + lying-success anti-pattern that bit us in #854 (launcher) and #962 (UNIQUE constraint).

This is independent of the just-merged Epic #981 (single-writer architecture) — that change moves the persist call into the daemon process when the daemon is up, but the same success-lie pattern in `persistBridgeDb` still applies to either the daemon's persist or the fallback direct path. Both paths benefit from the fix.

## What changed

### `bridge-core.ts`
- `persistBridgeDb` rethrows on failure (was silent-catch + stderr log).
- New `tryPersistBridgeDb` is the explicit best-effort variant for the rare caller that genuinely doesn't care (cache invalidation, idempotent maintenance).
- Write-path errors always log regardless of `MOFLO_BRIDGE_QUIET` — env var is for read-path noise control, never for masking data loss. Single `logBridgeError(context, err, { alwaysLog: true })` form replaces the previous near-duplicate pair.

### `bridge-entries.ts`
- `bridgeStoreEntry` / `bridgeStoreEntries` / `bridgeDeleteEntry` route persist through a new `tryPersist` helper that returns `{ ok: true } | { ok: false; error: 'persist failed: <detail>' }`. Centralises the failure shape so it can never drift across call sites.
- **Bulk path**: bookkeeping (cache writes + attestation logs) is deferred until AFTER persist succeeds. Pre-fix the bookkeeping fired during the loop and was awaited BEFORE the final persist call — if persist threw, the cache was already warm with rows that officially never reached disk. Caught in the /flo-simplify pass.

### `daemon-dashboard.ts`
- `createDashboardMemoryAccessor().write` throws on `!result.success` (was silent warn). `runner.storeProgress`'s existing try/catch + console.warn surfaces the failure visibly mid-run.

### `epic/runner-adapter.ts`
- Wraps the dashboard memory accessor with `trackPersistFailures` (counts write throws). Per-call `failuresBefore` capture isolates this run's failures from any prior run's cumulative count.
- Prints `[epic] ⚠ Spell progress was not fully persisted (N writes failed) — run history may be missing from the dashboard.` on every return path so users see the dashboard-may-be-empty signal.

### Tests (`bridge-entries.test.ts`)
5 new tests under `#982 — persist failures surface as success:false`:
1. `persistBridgeDb` rethrows the underlying error (no silent swallow)
2. `tryPersistBridgeDb` returns `ok:false` instead of throwing
3. `bridgeStoreEntry` returns `success:false` with `persist failed`
4. `bridgeStoreEntries` flips ALL successful results to failed when the final persist throws (bulk-atomicity invariant)
5. `bridgeDeleteEntry` returns `success:false` with `persist failed`

ESM workaround: `vi.spyOn(fs, 'renameSync')` fails on the immutable ESM namespace, so the integration tests intercept `db.export()` instead. `atomicWriteFileSync(target, db.export())` evaluates `export()` first, exercising the same `persistBridgeDb` try/catch path.

## Consumer-blast-radius (per CLAUDE.md)

- **Surface**: `src/cli/memory/{bridge-core,bridge-entries}.ts`, `services/daemon-dashboard.ts` (memory accessor), `epic/runner-adapter.ts` (summary). All ship to `node_modules/moflo/` in every consumer.
- **Failure mode for current-version consumer**: today persist failures are silent → data loss; after fix the same paths return `{ success: false, error: 'persist failed: …' }` and existing `if (!result.success)` callers (memory-initializer, daemon-memory-rpc, MemoryAccessor.write callers) begin surfacing real errors instead of silently lying. **Zero breaking change to the success path.**
- **Round-trip cost**: runtime fix → must publish to npm + reinstall to take effect for consumers. Source change alone is enough for tests/CI.

## Test plan

- [x] Full suite: 8219/8219 (+5 net new vs pre-#982, zero regressions)
- [x] \`npm run build\`: clean
- [x] \`npm run lint\`: clean
- [x] \`npx tsc --noEmit\`: clean
- [x] \`tests/system/swarm-restoration-e2e.test.ts\`: 4/4 (protected surface — swarm + hive-mind unchanged)
- [x] \`bridge-entries.test.ts\` (isolation): 22/22
- [ ] Post-merge: confirm the \`[epic] ⚠ Spell progress was not fully persisted\` summary fires on a real consumer that reproduces the original Windows EBUSY scenario
- [ ] Post-publish: verify the success-shaped callers (memory-initializer.storeEntry, daemon-memory-rpc) propagate the new \`success: false\` cleanly to their respective UI surfaces

Closes #982.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)