### PR TITLE
fix(test): phantom path for installFromLocal nonexistent test (#988)

### DIFF
--- a/src/cli/__tests__/plugins-transfer-deep.test.ts
+++ b/src/cli/__tests__/plugins-transfer-deep.test.ts
@@ -18,6 +18,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as crypto from 'crypto';
+import * as os from 'os';
+import * as path from 'path';
 
 // ============================================================================
 // 1. Plugin Manager
@@ -107,7 +109,8 @@ describe('PluginManager', () => {
 
   it('should fail installFromLocal with nonexistent path', async () => {
     await manager.initialize();
-    const result = await manager.installFromLocal('/nonexistent/path');
+    const phantomPath = path.join(os.tmpdir(), `nonexistent-${crypto.randomUUID()}`);
+    const result = await manager.installFromLocal(phantomPath);
     expect(result.success).toBe(false);
     expect(result.error).toContain('does not exist');
   });


### PR DESCRIPTION
## Summary

- Closes #988. `plugins-transfer-deep.test.ts` asserted that `/nonexistent/path` doesn't exist, but on Windows that resolves to `C:\nonexistent\path` and may genuinely exist on a dev box, masking the existence-check branch with a `package.json not found` failure.
- Switched the literal to `path.join(os.tmpdir(), 'nonexistent-' + crypto.randomUUID())` so the phantom path is guaranteed not to exist on any platform.

## Test plan

- [x] `npx vitest run src/cli/__tests__/plugins-transfer-deep.test.ts` — full file: 204 passed.
- [x] Reproduced original failure by `mkdir C:\nonexistent\path` and confirmed the patched test still passes (3/3).
- [x] No new dependencies — reuses existing `crypto` import, adds `os` + `path` from Node stdlib.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)