### PR TITLE
fix(doctor): sequence zombie scan after parallel checks (#992)

### DIFF
--- a/src/cli/commands/doctor-registry.ts
+++ b/src/cli/commands/doctor-registry.ts
@@ -52,7 +52,13 @@ import type { CheckFn, HealthCheck } from './doctor-types.js';
 
 export type { CheckFn, HealthCheck };
 
-/** Order matters — top entries surface first under the spinner. */
+/** Order matters — top entries surface first under the spinner.
+ * `checkZombieProcesses` is intentionally NOT in this list — it must run AFTER
+ * the parallel batch settles (see `zombieScanCheck` below and #992). Otherwise
+ * doctor's own subprocess probes (e.g. `checkBuildTools` running `npx tsc
+ * --version`) can be flagged as their own zombies on Windows, where the npx
+ * shim exits before its tsc child finishes.
+ */
 export const allChecks: CheckFn[] = [
   checkVersionFreshness,
   checkNodeVersion,
@@ -75,7 +81,6 @@ export const allChecks: CheckFn[] = [
   checkSemanticQuality,
   checkIntelligence,
   checkSpellEngine,
-  checkZombieProcesses,
   checkSubagentHealth,
   checkSpellExecution,
   checkMcpToolInvocation,
@@ -94,6 +99,9 @@ export const allChecks: CheckFn[] = [
   checkMemoryAccessFunctional,
   checkSandboxTier,
 ];
+
+/** Sequenced check that runs AFTER `allChecks` settles. Issue #992. */
+export const zombieScanCheck: CheckFn = checkZombieProcesses;
 
 /** Lookup table for `flo doctor -c <name>`. */
 export const componentMap: Record<string, CheckFn> = {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -13,7 +13,7 @@
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
-import { allChecks, componentMap } from './doctor-registry.js';
+import { allChecks, componentMap, zombieScanCheck } from './doctor-registry.js';
 import type { HealthCheck } from './doctor-types.js';
 import {
   emitJsonOutput,
@@ -182,6 +182,16 @@ export const doctorCommand: Command = {
       let checkResults: PromiseSettledResult<HealthCheck>[];
       try {
         checkResults = await Promise.allSettled(checksToRun.map(check => check()));
+        // Issue #992: zombie scan must follow the parallel batch, not race it.
+        // Several parallel checks spawn short-lived subprocesses (notably
+        // `checkBuildTools` running `npx tsc --version`); on Windows the npx
+        // shim exits before its tsc child, leaving a transient orphan that
+        // the zombie scan would otherwise flag as a real leak. Skip in
+        // single-component (`-c`) runs since those are targeted diagnostics.
+        if (!component) {
+          const zombieSettled = await Promise.allSettled([zombieScanCheck()]);
+          checkResults.push(zombieSettled[0]);
+        }
       } finally {
         spinner?.stop();
         restoreStdout();

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -189,8 +189,11 @@ export const doctorCommand: Command = {
         // the zombie scan would otherwise flag as a real leak. Skip in
         // single-component (`-c`) runs since those are targeted diagnostics.
         if (!component) {
-          const zombieSettled = await Promise.allSettled([zombieScanCheck()]);
-          checkResults.push(zombieSettled[0]);
+          try {
+            checkResults.push({ status: 'fulfilled', value: await zombieScanCheck() });
+          } catch (reason) {
+            checkResults.push({ status: 'rejected', reason });
+          }
         }
       } finally {
         spinner?.stop();

--- a/tests/doctor-zombie-scan-sequencing.test.ts
+++ b/tests/doctor-zombie-scan-sequencing.test.ts
@@ -11,6 +11,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 describe('doctor zombie scan sequencing (#992)', () => {
   it('checkZombieProcesses is not part of the parallel allChecks batch', async () => {
@@ -31,5 +34,15 @@ describe('doctor zombie scan sequencing (#992)', () => {
     const registry = await import('../src/cli/commands/doctor-registry.js');
     const runtime = await import('../src/cli/commands/doctor-checks-runtime.js');
     expect(registry.allChecks).toContain(runtime.checkBuildTools);
+  });
+
+  it('doctor.ts orchestrator imports and invokes zombieScanCheck', () => {
+    // Catches the inverse failure mode: the registry-side guard above passes
+    // even if someone removes the sequential block from doctor.ts. Read the
+    // source directly to lock the orchestration invariant.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const doctorTs = readFileSync(join(here, '..', 'src', 'cli', 'commands', 'doctor.ts'), 'utf8');
+    expect(doctorTs).toMatch(/import\s+\{[^}]*\bzombieScanCheck\b[^}]*\}\s+from\s+['"]\.\/doctor-registry/);
+    expect(doctorTs).toMatch(/zombieScanCheck\s*\(\s*\)/);
   });
 });

--- a/tests/doctor-zombie-scan-sequencing.test.ts
+++ b/tests/doctor-zombie-scan-sequencing.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for #992: doctor's zombie scan must NOT race the parallel
+ * health checks. `checkBuildTools` runs `npx tsc --version`; on Windows the
+ * npx shim exits before its tsc child finishes, briefly orphaning tsc. If the
+ * zombie scan runs in the same Promise.allSettled batch, it picks up that
+ * tsc as a leak — flagging doctor's own subprocess as a zombie.
+ *
+ * The architectural invariant: `checkZombieProcesses` is exported as
+ * `zombieScanCheck` and is NOT in `allChecks`. The doctor action runs it
+ * sequentially after the parallel batch settles.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('doctor zombie scan sequencing (#992)', () => {
+  it('checkZombieProcesses is not part of the parallel allChecks batch', async () => {
+    const registry = await import('../src/cli/commands/doctor-registry.js');
+    const zombies = await import('../src/cli/commands/doctor-zombies.js');
+    expect(registry.allChecks).not.toContain(zombies.checkZombieProcesses);
+  });
+
+  it('exports zombieScanCheck so doctor.ts can sequence it after the batch', async () => {
+    const registry = await import('../src/cli/commands/doctor-registry.js');
+    const zombies = await import('../src/cli/commands/doctor-zombies.js');
+    expect(registry.zombieScanCheck).toBe(zombies.checkZombieProcesses);
+  });
+
+  it('checkBuildTools (the offending npx-spawning check) is in allChecks', async () => {
+    // Lock the relationship: as long as checkBuildTools runs in the parallel
+    // batch and zombieScanCheck does not, the race in #992 cannot recur.
+    const registry = await import('../src/cli/commands/doctor-registry.js');
+    const runtime = await import('../src/cli/commands/doctor-checks-runtime.js');
+    expect(registry.allChecks).toContain(runtime.checkBuildTools);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #992. `flo doctor --strict` was failing on Windows because doctor's own `npx tsc --version` probe (from `checkBuildTools`) ran in the same `Promise.allSettled` batch as its zombie scanner. The npx shim exits before its tsc child, briefly orphaning tsc — and the parallel zombie scan flagged that orphan as a real leak.
- Moved `checkZombieProcesses` out of `allChecks`. The doctor action now awaits the parallel batch, then runs the zombie scan as a final sequential pass via try/catch (skipped in `-c <component>` targeted runs).
- Different culprit from #886/#903 (those fixed detached `build-embeddings.mjs` spawns via ProcessManager). This is a synchronous probe doctor itself fires — no detached process, just bad scan ordering.

## Why no ProcessManager registration

There is no detached background process here. `npx tsc --version` is a synchronous probe with a 10s timeout that doctor awaits. Registering it with ProcessManager would be misleading and wouldn't fix anything — the race is purely about *when* the zombie scan runs relative to the probe.

## Test plan

- [x] `tests/doctor-zombie-scan-sequencing.test.ts` — 4 assertions: zombie check NOT in `allChecks`; `zombieScanCheck === checkZombieProcesses`; `checkBuildTools` (the offender) IS in `allChecks`; `doctor.ts` source imports + invokes `zombieScanCheck` (locks the orchestration invariant, not just the registry).
- [x] `node scripts/test-runner.mjs --filter doctor` — 8222 passed / 0 failed (parallel + isolation).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean.
- [x] `/flo-simplify` review — two findings addressed (try/catch in place of `Promise.allSettled([single])`, orchestration test gap closed); validation pass clean.
- [ ] CI Windows consumer-smoke confirms `flo doctor --strict` no longer flags doctor's own probes.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)