### PR TITLE
fix(memory): post-persist bookkeeping must not propagate (#994)

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -489,17 +489,39 @@ export function memoryInit(consumerDir) {
   if (!recordExit('memory-init', r)) throw new Error('memory init failed');
 }
 
+/**
+ * Issue #994: dump full stdout + stderr for a memory-CRUD subprocess so a
+ * future flake gives us the actual error, not a 200-char tail. recordExit's
+ * built-in truncation hid the real failure on Ubuntu (the onnxruntime
+ * GetPciBusId warning consumed the entire visible window).
+ */
+function dumpFullCrudOutput(label, res) {
+  log(`--- ${label} full output (failure dump) ---`);
+  log(`exit ${res.code}`);
+  if (res.stdout) {
+    log('--- stdout ---');
+    log(res.stdout);
+  }
+  if (res.stderr) {
+    log('--- stderr ---');
+    log(res.stderr);
+  }
+  log(`--- end ${label} ---`);
+}
+
 export function memoryCrud(consumerDir) {
   section('Memory CRUD round-trip');
   const key = `smoke-${Date.now()}`;
   const value = 'smoke-harness-sentinel';
 
-  recordExit('memory-store', flo(consumerDir, ['memory', 'store', '-k', key, '-v', value, '--namespace', 'smoke']));
+  const store = flo(consumerDir, ['memory', 'store', '-k', key, '-v', value, '--namespace', 'smoke']);
+  if (!recordExit('memory-store', store)) dumpFullCrudOutput('memory-store', store);
 
   const get = flo(consumerDir, ['memory', 'retrieve', '-k', key, '--namespace', 'smoke']);
   const ok = get.code === 0 && get.stdout.includes(value);
   record('memory-retrieve', ok ? 'pass' : 'fail',
     ok ? 'value round-trips' : `exit ${get.code}, value missing from output`);
+  if (!ok) dumpFullCrudOutput('memory-retrieve', get);
 
   recordExit('memory-search', flo(consumerDir, ['memory', 'search', '-q', 'smoke', '--namespace', 'smoke', '--limit', '5']));
 

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -517,10 +517,22 @@ export function memoryCrud(consumerDir) {
   const store = flo(consumerDir, ['memory', 'store', '-k', key, '-v', value, '--namespace', 'smoke']);
   if (!recordExit('memory-store', store)) dumpFullCrudOutput('memory-store', store);
 
-  const get = flo(consumerDir, ['memory', 'retrieve', '-k', key, '--namespace', 'smoke']);
-  const ok = get.code === 0 && get.stdout.includes(value);
+  // Issue #994: use --format=json so the round-trip check parses a structured
+  // payload instead of grepping the ASCII printBox output. The box rendering
+  // intermittently dropped its content rows on Windows CI (top/bottom borders
+  // landed in captured stdout, the inner `| Namespace: ... |` lines didn't —
+  // looked like a writeback race in the harness output but turned out to be
+  // a stdout-flush issue downstream of printBox). JSON output goes through
+  // a single console.log call and is what callers should rely on anyway.
+  const get = flo(consumerDir, ['memory', 'retrieve', '-k', key, '--namespace', 'smoke', '--format', 'json']);
+  let parsedContent = null;
+  if (get.code === 0) {
+    try { parsedContent = JSON.parse(get.stdout.trim())?.content ?? null; }
+    catch { /* fall through to fail with the raw exit/stdout */ }
+  }
+  const ok = parsedContent === value;
   record('memory-retrieve', ok ? 'pass' : 'fail',
-    ok ? 'value round-trips' : `exit ${get.code}, value missing from output`);
+    ok ? 'value round-trips' : `exit ${get.code}, content=${JSON.stringify(parsedContent)}`);
   if (!ok) dumpFullCrudOutput('memory-retrieve', get);
 
   recordExit('memory-search', flo(consumerDir, ['memory', 'search', '-q', 'smoke', '--namespace', 'smoke', '--limit', '5']));

--- a/src/cli/__tests__/bridge-entries.test.ts
+++ b/src/cli/__tests__/bridge-entries.test.ts
@@ -605,3 +605,93 @@ describe('#982 — persist failures surface as success:false', () => {
     }
   });
 });
+
+// ===========================================================================
+// #994 — post-persist bookkeeping failures must NOT downgrade success.
+//
+// `bridgeStoreEntry` runs `tryPersist()` first (atomic write → disk), then
+// performs observability steps: cache warm, attestation log, statusline
+// stats. Pre-#994 a throw in any of those propagated through `withDb`'s
+// catch and made the bridge return `null`, prompting `storeEntry` to fall
+// back to raw sql.js. The fallback then collided with the bridge's already-
+// persisted row on UNIQUE constraint and the CLI exited 1 — even though
+// `memory retrieve` could find the value moments later. The Ubuntu signature
+// of issue #994 in CI.
+// ===========================================================================
+describe('#994 — post-persist bookkeeping failures stay non-fatal', () => {
+  /**
+   * Stub the tieredCache controller's `set` to throw. Mirrors the production
+   * failure mode: a post-persist `cacheSet` raises, the row is already on
+   * disk, but the throw used to propagate.
+   */
+  async function injectCacheSetFailure(err: Error): Promise<() => void> {
+    const reg = await getControllerRegistry(dbPath);
+    if (!reg) throw new Error('test bridge registry unavailable');
+    const cache = reg.get('tieredCache');
+    if (!cache) throw new Error('test bridge tieredCache unavailable');
+    const origSet = cache.set.bind(cache);
+    cache.set = async () => { throw err; };
+    return () => { cache.set = origSet; };
+  }
+
+  it('bridgeStoreEntry still returns success:true when cacheSet throws after persist', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    // Warm the bridge so the registry + tieredCache are resolved
+    const warm = await bridgeStoreEntry({ key: 'warm', value: 'baseline', namespace: 'test', dbPath });
+    expect(warm?.success).toBe(true);
+
+    const restore = await injectCacheSetFailure(new Error('synthetic cache write failure'));
+    try {
+      const result = await bridgeStoreEntry({
+        key: 'k-bookkeeping-fail',
+        value: 'data IS on disk',
+        namespace: 'test',
+        dbPath,
+      });
+      expect(result?.success).toBe(true);
+      expect(result?.cached).toBe(false);
+
+      // The retrieve-equivalent: the row is on disk and queryable. This is
+      // the exact invariant Ubuntu CI proved (memory-retrieve passed) but
+      // the CLI's exit code lied because the bookkeeping throw cascaded.
+      const rows = await readRows('SELECT content FROM memory_entries WHERE key = ?', ['k-bookkeeping-fail']);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.content).toBe('data IS on disk');
+    } finally {
+      restore();
+    }
+  });
+
+  it('bridgeStoreEntries reports per-row success when batch bookkeeping throws after persist', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    // Warm-up entry so registry is fully initialized
+    const warm = await bridgeStoreEntry({ key: 'warm', value: 'x', namespace: 'test', dbPath });
+    expect(warm?.success).toBe(true);
+
+    const restore = await injectCacheSetFailure(new Error('synthetic batch cache failure'));
+    try {
+      const results = await bridgeStoreEntries(
+        [
+          { key: 'batch-a', value: '1', namespace: 'test' },
+          { key: 'batch-b', value: '2', namespace: 'test' },
+        ],
+        dbPath,
+      );
+      expect(results).not.toBeNull();
+      expect(results).toHaveLength(2);
+      for (const r of results!) {
+        expect(r.success).toBe(true);
+      }
+
+      // All rows reached disk; durable storage must be observable.
+      const rows = await readRows(
+        "SELECT key FROM memory_entries WHERE namespace = 'test' AND key LIKE 'batch-%' ORDER BY key",
+      );
+      expect(rows.map(r => r.key)).toEqual(['batch-a', 'batch-b']);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/cli/memory/bridge-core.ts
+++ b/src/cli/memory/bridge-core.ts
@@ -87,7 +87,7 @@ export function getBridgeLastError(): Error | null {
  * always log, since the quiet env var is for read-path noise control,
  * not for masking data loss (#982 / #854 / #962 anti-pattern).
  */
-function logBridgeError(context: string, err: unknown, opts?: { alwaysLog?: boolean }): void {
+export function logBridgeError(context: string, err: unknown, opts?: { alwaysLog?: boolean }): void {
   if (process.env.MOFLO_BRIDGE_QUIET && !opts?.alwaysLog) return;
   const msg = errorDetail(err);
   console.error(`[moflo] ${context}: ${msg}`);

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -8,7 +8,7 @@
  * @module v3/cli/bridge-entries
  */
 
-import { cosineSim, execRows, generateId, persistBridgeDb, refreshVectorStatsCache, withDb } from './bridge-core.js';
+import { cosineSim, execRows, generateId, logBridgeError, persistBridgeDb, refreshVectorStatsCache, withDb } from './bridge-core.js';
 import { embeddingResponseFrom, getBridgeEmbedder, resolveBridgeEmbedding } from './bridge-embedder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 
@@ -202,19 +202,42 @@ export async function bridgeStoreEntry(options: {
       return { success: false, id, error: persisted.error };
     }
 
+    // Post-persist bookkeeping (#994). The row is durable on disk; cache
+    // warming, attestation, and statusline stats are observability only.
+    // A throw here MUST NOT propagate — withDb would catch it, return null,
+    // and storeEntry would fall back to raw sql.js, which then fails with
+    // UNIQUE constraint (the bridge already wrote the row) and reports
+    // exit 1 even though `memory retrieve` finds the value moments later.
+    // Same #982 invariant in the inverse direction.
     const cacheKey = makeEntryCacheKey(namespace, key);
-    await cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson });
+    let cached = true;
+    try {
+      await cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson });
+    } catch (err) {
+      cached = false;
+      logBridgeError('post-persist cache set failed', err);
+    }
 
-    await logAttestation(registry, 'store', id, { key, namespace, hasEmbedding: !!embeddingJson });
+    // logAttestation already swallows internally; the await catches any
+    // pre-call registry-resolution throw too. Logged so a recurring failure
+    // is visible without crashing the write path.
+    try {
+      await logAttestation(registry, 'store', id, { key, namespace, hasEmbedding: !!embeddingJson });
+    } catch (err) {
+      logBridgeError('post-persist attestation failed', err);
+    }
 
-    if (embeddingJson) refreshVectorStatsCache();
+    if (embeddingJson) {
+      try { refreshVectorStatsCache(); }
+      catch (err) { logBridgeError('post-persist stats refresh failed', err); }
+    }
 
     return {
       success: true,
       id,
       embedding: embeddingResponse,
       guarded: true,
-      cached: true,
+      cached,
       attested: true,
     };
   });
@@ -353,13 +376,25 @@ export async function bridgeStoreEntries(items: Array<{
     }
 
     // Persist succeeded — fire deferred bookkeeping in parallel.
-    await Promise.all(
-      deferredBookkeeping.flatMap(b => [
-        cacheSet(registry, b.cacheKey, b.cacheValue),
-        logAttestation(registry, 'store', b.entryId, { key: b.entryKey, namespace: b.namespace, hasEmbedding: b.hasEmbedding }),
-      ]),
-    );
-    if (anyEmbedded) refreshVectorStatsCache();
+    // Wrapped in try/catch (#994): rows are already durable, so a cache or
+    // attestation throw must not propagate to withDb's catch and downgrade
+    // every successful row to a fallback retry that fails on UNIQUE.
+    // Promise.all short-circuits, so partial bookkeeping is silently lost
+    // on a throw — log so a recurring failure is debuggable.
+    try {
+      await Promise.all(
+        deferredBookkeeping.flatMap(b => [
+          cacheSet(registry, b.cacheKey, b.cacheValue),
+          logAttestation(registry, 'store', b.entryId, { key: b.entryKey, namespace: b.namespace, hasEmbedding: b.hasEmbedding }),
+        ]),
+      );
+    } catch (err) {
+      logBridgeError('post-persist batch bookkeeping failed', err);
+    }
+    if (anyEmbedded) {
+      try { refreshVectorStatsCache(); }
+      catch (err) { logBridgeError('post-persist stats refresh failed', err); }
+    }
 
     return results;
   });


### PR DESCRIPTION
## Summary

- Wrap post-persist bookkeeping in `bridgeStoreEntry` and `bridgeStoreEntries` so a throw after `tryPersist()` succeeds never propagates to `withDb`'s catch — closes the Ubuntu smoke flake where `memory store` exited 1 with the data durable on disk.
- Route the wrapped catches through `logBridgeError` so a recurring bookkeeping issue remains visible in stderr.
- Smoke harness improvements:
  - Switch `memory-retrieve` check to `--format=json` (deterministic single-line stdout) — works around a Windows printBox/libuv stdout race that masked correct storage behind a corrupted box render. The actual runtime bug is filed as #996.
  - Dump full stdout/stderr on `memory-store` / `memory-retrieve` failure (the existing `recordExit` truncated to 200 chars, which on Ubuntu got entirely consumed by an onnxruntime stderr warning).

## Root cause — Ubuntu (signature A)

`bridgeStoreEntry` runs `tryPersist()` first (atomic write → disk), then performs observability steps: cache warm, attestation, statusline stats. Pre-fix, a throw in any of those propagated through `withDb`'s catch and made the bridge return `null`. `storeEntry` then treated the bridge as a no-op and fell through to the raw sql.js fallback. The fallback's plain `INSERT` collided with the bridge's already-persisted row on UNIQUE constraint, `storeEntry` returned `success: false`, the CLI exited 1 — and the next `memory retrieve` found the value because it was never lost. Inverse of the #982 honest-persist contract.

The fix re-establishes the symmetric invariant: once the row reaches disk, the call MUST report success. Bookkeeping failures are non-fatal and observable via `[moflo] post-persist <stage> failed: ...` stderr lines, not exit 1.

## Root cause — Windows (signature B)

The new diagnostic dump revealed that on the failing Windows run the `memory retrieve` action printed the box's top + bottom borders but the inner `| Namespace: ... |` lines were missing from captured stdout, even though `exit 0` was reported. Locally the same call trips `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)` in libuv. Both symptoms of `drainAndExit`'s stdout flush racing `process.exit` on Windows async pipes — `stream.write('', cb)` callback fires when the **empty** chunk is handled, not when prior queued writes have drained.

That's a real Windows runtime bug with `flo memory retrieve`'s interactive box rendering — filed as #996 for a separate fix. The smoke harness sidesteps it by using `--format=json` (single `console.log` of a JSON string), which is what callers should rely on for parsed output anyway.

## Test plan

- [x] Targeted: 24/24 passing on `bridge-entries.test.ts` including 2 new `#994` regression tests
- [x] Full suite: 8225/8225 passing across both parallel + isolation passes
- [x] Lint, tsc, build all clean
- [x] Smoke harness: confirmed `memory retrieve --format json` produces parseable output locally
- [ ] CI verification on this PR
- [ ] Post-merge: confirm Ubuntu + Windows smoke green on at least 5 consecutive runs

Closes #994. Filed #996 for the printBox/Windows runtime fix (separate PR).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)