### PR TITLE
fix(cli): drain stdout/stderr before exit to avoid Windows async-pipe race (#996)

### DIFF
--- a/src/cli/__tests__/drain-stream.test.ts
+++ b/src/cli/__tests__/drain-stream.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression tests for `drainStream` — the two-stage stdout/stderr drain that
+ * `drainAndExit` uses to avoid the Windows async-pipe race that drops printBox
+ * content rows and trips libuv's UV_HANDLE_CLOSING assertion (issue #996).
+ *
+ * `drainStream` must:
+ *   1. Resolve immediately when the stream is already drained.
+ *   2. Wait for a `'drain'` event before issuing the libuv-level empty-write
+ *      probe when `writableNeedDrain` is set.
+ *   3. Resolve via the safety timeout when `'drain'` never fires (broken pipe).
+ *   4. Resolve immediately when the stream is unwritable or destroyed.
+ */
+
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { drainStream } from '../index.js';
+
+interface FakeStream extends EventEmitter {
+  writable: boolean;
+  destroyed: boolean;
+  writableNeedDrain: boolean;
+  write: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeStream(opts: Partial<Omit<FakeStream, keyof EventEmitter | 'write'>> = {}): FakeStream {
+  const stream = new EventEmitter() as FakeStream;
+  stream.writable = opts.writable ?? true;
+  stream.destroyed = opts.destroyed ?? false;
+  stream.writableNeedDrain = opts.writableNeedDrain ?? false;
+
+  // Default `write` resolves the empty-write callback synchronously next tick,
+  // mimicking Node's behaviour when libuv has nothing queued.
+  stream.write = vi.fn((_chunk: string, cb?: () => void) => {
+    if (cb) queueMicrotask(cb);
+    return true;
+  });
+
+  return stream;
+}
+
+describe('drainStream', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves via the empty-write probe when the buffer is already drained', async () => {
+    const stream = makeFakeStream({ writableNeedDrain: false });
+
+    await drainStream(stream as unknown as NodeJS.WriteStream);
+
+    expect(stream.write).toHaveBeenCalledTimes(1);
+    expect(stream.write).toHaveBeenCalledWith('', expect.any(Function));
+  });
+
+  it('waits for "drain" before issuing the empty-write probe when the buffer is full', async () => {
+    const stream = makeFakeStream({ writableNeedDrain: true });
+
+    const drained = drainStream(stream as unknown as NodeJS.WriteStream);
+
+    // The probe must NOT have fired yet — libuv may still hold a queued write.
+    await Promise.resolve();
+    expect(stream.write).not.toHaveBeenCalled();
+
+    // Simulate Node flushing the userspace buffer to libuv.
+    stream.emit('drain');
+
+    await drained;
+    expect(stream.write).toHaveBeenCalledTimes(1);
+    expect(stream.write).toHaveBeenCalledWith('', expect.any(Function));
+  });
+
+  it('resolves via the safety timeout when "drain" never fires', async () => {
+    vi.useFakeTimers();
+    const stream = makeFakeStream({ writableNeedDrain: true });
+
+    const drained = drainStream(stream as unknown as NodeJS.WriteStream);
+
+    // Advance past the 250 ms safety window without emitting 'drain'.
+    await vi.advanceTimersByTimeAsync(300);
+
+    await expect(drained).resolves.toBeUndefined();
+    // Probe never ran because we bailed via the timeout.
+    expect(stream.write).not.toHaveBeenCalled();
+    // And the listener was cleaned up so a stray late 'drain' won't NPE.
+    expect(stream.listenerCount('drain')).toBe(0);
+  });
+
+  it('resolves immediately when the stream is not writable', async () => {
+    const stream = makeFakeStream({ writable: false });
+
+    await drainStream(stream as unknown as NodeJS.WriteStream);
+
+    expect(stream.write).not.toHaveBeenCalled();
+  });
+
+  it('resolves immediately when the stream is destroyed', async () => {
+    const stream = makeFakeStream({ destroyed: true });
+
+    await drainStream(stream as unknown as NodeJS.WriteStream);
+
+    expect(stream.write).not.toHaveBeenCalled();
+  });
+
+  it('resolves even if the empty-write probe throws synchronously', async () => {
+    const stream = makeFakeStream({ writableNeedDrain: false });
+    stream.write = vi.fn(() => {
+      throw new Error('EPIPE');
+    });
+
+    await expect(drainStream(stream as unknown as NodeJS.WriteStream)).resolves.toBeUndefined();
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,9 +21,51 @@ export { VERSION };
 const LONG_RUNNING_COMMANDS = ['mcp', 'daemon'];
 
 /**
- * Flush stdout/stderr, shut down the memory bridge if it was initialized,
+ * Wait for a writable's userspace buffer to drain, then issue an empty write
+ * whose callback fires after libuv has committed the now-front-of-queue write.
+ *
+ * Issue #996: on Windows async pipes, the empty-write trick alone fires before
+ * prior multi-line writes (e.g. `printBox`) have left libuv's buffer, racing
+ * `process.exit` and either dropping content rows or tripping the libuv
+ * `UV_HANDLE_CLOSING` assertion in `src/win/async.c`.
+ *
+ * Two-stage wait: first await `'drain'` if the userspace buffer is full, then
+ * the empty-write callback for the libuv-level commit. A 250 ms unref'd safety
+ * timeout covers broken pipes where `'drain'` never fires.
+ */
+export function drainStream(stream: NodeJS.WriteStream): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!stream.writable || stream.destroyed) return resolve();
+
+    const finalize = () => {
+      try {
+        stream.write('', () => resolve());
+      } catch {
+        resolve();
+      }
+    };
+
+    if (stream.writableNeedDrain) {
+      const onDrain = () => {
+        clearTimeout(timer);
+        finalize();
+      };
+      stream.once('drain', onDrain);
+      const timer = setTimeout(() => {
+        stream.removeListener('drain', onDrain);
+        resolve();
+      }, 250);
+      timer.unref();
+    } else {
+      finalize();
+    }
+  });
+}
+
+/**
+ * Drain stdout/stderr, shut down the memory bridge if it was initialized,
  * then `process.exit(code)`. Prevents the libuv `uv_async_send` assertion
- * on Windows when stdout is an async pipe (issue #504).
+ * on Windows when stdout is an async pipe (issues #504, #996).
  */
 async function drainAndExit(code: number): Promise<void> {
   try {
@@ -33,13 +75,8 @@ async function drainAndExit(code: number): Promise<void> {
     // Bridge may not have been loaded — that's fine
   }
 
-  const flush = (stream: NodeJS.WriteStream) =>
-    new Promise<void>((resolve) => {
-      if (!stream.writable) return resolve();
-      stream.write('', () => resolve());
-    });
-
-  await Promise.all([flush(process.stdout), flush(process.stderr)]);
+  process.exitCode = code;
+  await Promise.all([drainStream(process.stdout), drainStream(process.stderr)]);
   process.exit(code);
 }
 


### PR DESCRIPTION
## Summary

- `drainAndExit`'s empty-write trick (`stream.write('', cb)`) didn't actually wait for prior queued writes to leave libuv's buffer on Windows async pipes.
- Replaced with a two-stage drain helper (`drainStream`) that waits for `'drain'` then probes via empty-write; covered by 6 unit tests.
- Fixes intermittent dropped `printBox` content rows + libuv `UV_HANDLE_CLOSING` assertion in `flo memory retrieve` on Windows.

## Changes

- `src/cli/index.ts` — new exported `drainStream` helper; `drainAndExit` now waits on `writableNeedDrain` → `'drain'` → empty-write probe; sets `process.exitCode` before exit.
- `src/cli/__tests__/drain-stream.test.ts` — 6 new tests covering: already-drained, drain-then-probe, safety-timeout, unwritable, destroyed, throwing-write.

## Testing

- [x] New unit tests pass (6/6)
- [x] CLI test suite green (197 passed | 5 skipped)
- [x] Memory test suite green (150/150)
- [x] `tsc --noEmit` clean
- [ ] Manual repro on Windows — race is intermittent so absence of crash on a single run isn't conclusive; the fix is reasoned from Node's documented stream semantics

Closes #996