### PR TITLE
fix(287): epic spell catches unmerged paths and surfaces stash-pop conflicts

### DIFF
--- a/src/cli/spells/definitions/epic-auto-merge.yaml
+++ b/src/cli/spells/definitions/epic-auto-merge.yaml
@@ -87,8 +87,12 @@ steps:
         # elevated — bwrap network access for git pull (see single-branch create-branch).
         permissionLevel: elevated
         preflight:
+          # `git diff --name-only --diff-filter=U` always exits 0 — it just
+          # lists paths. Use `--quiet`, which exits 1 when any unmerged path
+          # exists, so this preflight actually catches a half-merged index
+          # (e.g. left by an earlier failed run).
           - name: "no unmerged files"
-            command: "git diff --name-only --diff-filter=U"
+            command: "git diff --quiet --diff-filter=U"
             expectExitCode: 0
             hint: "You have unresolved merge conflicts. Resolve them and commit before running this spell."
           - name: "working tree clean (tracked changes)"
@@ -116,9 +120,25 @@ steps:
             command: "git remote get-url origin"
             hint: "This repo has no 'origin' remote. Set one with: git remote add origin <url>"
         config:
-          # set -e: fail fast if checkout/pull fails; otherwise the trailing
-          # `stash pop ... || true` would mask the real failure.
-          command: "set -e; git stash --include-untracked -q 2>/dev/null || true; git checkout {args.base_branch}; git pull origin {args.base_branch}; git stash pop -q 2>/dev/null || true"
+          # set -e: fail fast if checkout/pull fails.
+          #
+          # We deliberately do NOT auto-stash here. Preflight enforces a clean
+          # tree (or runs the user-chosen stash-and-carry resolution), so the
+          # only stash we should ever pop is the preflight's
+          # `moflo-epic-autostash` marker. Popping the unconditionally-top
+          # stash (the previous design) was the source of #287's stash-pop
+          # conflict that left the index half-merged.
+          command: |
+            set -e
+            git checkout {args.base_branch}
+            git pull origin {args.base_branch}
+            TOP_MSG=$(git stash list --format='%s' -1)
+            if [[ "$TOP_MSG" == *"moflo-epic-autostash"* ]]; then
+              if ! git stash pop -q; then
+                echo "[epic] carrying-over stash conflicted on {args.base_branch} — resolve unmerged paths and re-run the spell" >&2
+                exit 1
+              fi
+            fi
           failOnError: true
 
       # 2: Spawn Claude agent to implement the story (creates branch + PR)
@@ -155,7 +175,18 @@ steps:
         permissionLevel: elevated
         config:
           # set -e: fail fast if checkout/pull fails (see checkout-base).
-          command: "set -e; git stash --include-untracked -q 2>/dev/null || true; git checkout {args.base_branch}; git pull origin {args.base_branch}; git stash pop -q 2>/dev/null || true"
+          # No in-step stash; pop only the preflight's autostash marker.
+          command: |
+            set -e
+            git checkout {args.base_branch}
+            git pull origin {args.base_branch}
+            TOP_MSG=$(git stash list --format='%s' -1)
+            if [[ "$TOP_MSG" == *"moflo-epic-autostash"* ]]; then
+              if ! git stash pop -q; then
+                echo "[epic] carrying-over stash conflicted on {args.base_branch} — resolve unmerged paths and re-run the spell" >&2
+                exit 1
+              fi
+            fi
           failOnError: true
 
       # 6: Comment on epic with progress

--- a/src/cli/spells/definitions/epic-auto-merge.yaml
+++ b/src/cli/spells/definitions/epic-auto-merge.yaml
@@ -101,7 +101,7 @@ steps:
             hint: "You have uncommitted changes to tracked files. If you want them carried onto the epic branch, pick 'Stash and carry over'."
             resolutions:
               - label: "Stash changes and carry them onto the epic branch"
-                command: "git stash push --include-untracked --message 'moflo-epic-autostash'"
+                command: "git stash push --include-untracked --message 'moflo-epic-{args.epic_number}-autostash'"
               - label: "Commit changes to the current branch first, then continue"
                 command: "git commit -am 'wip: pre-epic snapshot'"
           - name: "working tree clean (staged changes)"
@@ -110,7 +110,7 @@ steps:
             hint: "You have staged changes that aren't committed. If you want them carried onto the epic branch, pick 'Stash and carry over'."
             resolutions:
               - label: "Stash staged changes and carry them onto the epic branch"
-                command: "git stash push --include-untracked --message 'moflo-epic-autostash'"
+                command: "git stash push --include-untracked --message 'moflo-epic-{args.epic_number}-autostash'"
               - label: "Commit staged changes to the current branch first, then continue"
                 command: "git commit -m 'wip: pre-epic snapshot'"
           - name: "gh cli authenticated"
@@ -132,8 +132,11 @@ steps:
             set -e
             git checkout {args.base_branch}
             git pull origin {args.base_branch}
+            # Scoped by epic_number to prevent a stale autostash from an
+            # unrelated abandoned run getting popped here.
+            EXPECTED_STASH_TAG="moflo-epic-{args.epic_number}-autostash"
             TOP_MSG=$(git stash list --format='%s' -1)
-            if [[ "$TOP_MSG" == *"moflo-epic-autostash"* ]]; then
+            if [[ "$TOP_MSG" == *"$EXPECTED_STASH_TAG"* ]]; then
               if ! git stash pop -q; then
                 echo "[epic] carrying-over stash conflicted on {args.base_branch} — resolve unmerged paths and re-run the spell" >&2
                 exit 1
@@ -175,13 +178,15 @@ steps:
         permissionLevel: elevated
         config:
           # set -e: fail fast if checkout/pull fails (see checkout-base).
-          # No in-step stash; pop only the preflight's autostash marker.
+          # No in-step stash; pop only the preflight's autostash marker
+          # (scoped by epic_number — see checkout-base).
           command: |
             set -e
             git checkout {args.base_branch}
             git pull origin {args.base_branch}
+            EXPECTED_STASH_TAG="moflo-epic-{args.epic_number}-autostash"
             TOP_MSG=$(git stash list --format='%s' -1)
-            if [[ "$TOP_MSG" == *"moflo-epic-autostash"* ]]; then
+            if [[ "$TOP_MSG" == *"$EXPECTED_STASH_TAG"* ]]; then
               if ! git stash pop -q; then
                 echo "[epic] carrying-over stash conflicted on {args.base_branch} — resolve unmerged paths and re-run the spell" >&2
                 exit 1

--- a/src/cli/spells/definitions/epic-single-branch.yaml
+++ b/src/cli/spells/definitions/epic-single-branch.yaml
@@ -87,8 +87,12 @@ steps:
     # has working network.
     permissionLevel: elevated
     preflight:
+      # `git diff --name-only --diff-filter=U` always exits 0 — it just lists
+      # paths. Use `--quiet`, which exits 1 when any unmerged path exists, so
+      # the preflight actually catches a half-merged index left by an earlier
+      # failed run (e.g. a stash-pop conflict).
       - name: "no unmerged files"
-        command: "git diff --name-only --diff-filter=U"
+        command: "git diff --quiet --diff-filter=U"
         expectExitCode: 0
         hint: "You have unresolved merge conflicts. Resolve them and commit before running this spell."
       - name: "working tree clean (tracked changes)"
@@ -113,11 +117,33 @@ steps:
         command: "gh auth status"
         hint: "The GitHub CLI isn't signed in. Run: gh auth login"
     config:
-      # set -e: any failing step aborts the whole command. Without it, the
-      # trailing `git stash pop ... || true` would swallow real failures
-      # (e.g., checkout/pull/branch-create errors) and report success,
-      # leaving later steps to crash when the epic branch isn't there.
-      command: "set -e; git stash --include-untracked -q 2>/dev/null || true; git checkout {args.base_branch}; git pull origin {args.base_branch}; BRANCH=\"epic/{args.epic_number}-{args.epic_slug}\"; if git show-ref --verify --quiet \"refs/heads/$BRANCH\"; then git checkout \"$BRANCH\"; else git checkout -b \"$BRANCH\"; fi; git stash pop -q 2>/dev/null || true"
+      # set -e: any failing step aborts the whole command.
+      #
+      # We deliberately do NOT auto-stash here. Preflight has already enforced
+      # a clean tree (or run the user-chosen stash-and-carry resolution), so
+      # the only stash we should ever pop is the preflight's `moflo-epic-autostash`
+      # marker. Popping the unconditionally-top stash (the previous design)
+      # was the source of #287's stash-pop conflict that left the index
+      # half-merged — `git stash pop ... || true` masked the conflict
+      # failure and the next step's `git checkout` then died with
+      # "you need to resolve your current index first".
+      command: |
+        set -e
+        git checkout {args.base_branch}
+        git pull origin {args.base_branch}
+        BRANCH="epic/{args.epic_number}-{args.epic_slug}"
+        if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+          git checkout "$BRANCH"
+        else
+          git checkout -b "$BRANCH"
+        fi
+        TOP_MSG=$(git stash list --format='%s' -1)
+        if [[ "$TOP_MSG" == *"moflo-epic-autostash"* ]]; then
+          if ! git stash pop -q; then
+            echo "[epic] carrying-over stash conflicted on $BRANCH — resolve unmerged paths and re-run the spell" >&2
+            exit 1
+          fi
+        fi
       timeout: 120000
       failOnError: true
 

--- a/src/cli/spells/definitions/epic-single-branch.yaml
+++ b/src/cli/spells/definitions/epic-single-branch.yaml
@@ -101,7 +101,7 @@ steps:
         hint: "You have uncommitted changes to tracked files. If you want them carried onto the epic branch, pick 'Stash and carry over'."
         resolutions:
           - label: "Stash changes and carry them onto the epic branch"
-            command: "git stash push --include-untracked --message 'moflo-epic-autostash'"
+            command: "git stash push --include-untracked --message 'moflo-epic-{args.epic_number}-autostash'"
           - label: "Commit changes to the current branch first, then continue"
             command: "git commit -am 'wip: pre-epic snapshot'"
       - name: "working tree clean (staged changes)"
@@ -110,7 +110,7 @@ steps:
         hint: "You have staged changes that aren't committed. If you want them carried onto the epic branch, pick 'Stash and carry over'."
         resolutions:
           - label: "Stash staged changes and carry them onto the epic branch"
-            command: "git stash push --include-untracked --message 'moflo-epic-autostash'"
+            command: "git stash push --include-untracked --message 'moflo-epic-{args.epic_number}-autostash'"
           - label: "Commit staged changes to the current branch first, then continue"
             command: "git commit -m 'wip: pre-epic snapshot'"
       - name: "gh cli authenticated"
@@ -137,8 +137,13 @@ steps:
         else
           git checkout -b "$BRANCH"
         fi
+        # Scope the marker by epic_number so a stale autostash from an
+        # abandoned previous run of a DIFFERENT epic doesn't get popped onto
+        # this branch unintentionally. Same-epic re-runs still carry over,
+        # which is the intended recovery path.
+        EXPECTED_STASH_TAG="moflo-epic-{args.epic_number}-autostash"
         TOP_MSG=$(git stash list --format='%s' -1)
-        if [[ "$TOP_MSG" == *"moflo-epic-autostash"* ]]; then
+        if [[ "$TOP_MSG" == *"$EXPECTED_STASH_TAG"* ]]; then
           if ! git stash pop -q; then
             echo "[epic] carrying-over stash conflicted on $BRANCH — resolve unmerged paths and re-run the spell" >&2
             exit 1

--- a/tests/epic-spells.test.ts
+++ b/tests/epic-spells.test.ts
@@ -244,14 +244,29 @@ describe('epic-single-branch.yaml', () => {
     // conflict failures and left the index unmerged. The next step's
     // `git checkout` then died with "you need to resolve your current
     // index first". The fix: only pop when the preflight autostash
-    // marker sits at the top of the stash list, and surface conflicts
-    // with exit 1 + an actionable hint.
+    // marker (scoped by epic_number) sits at the top of the stash list,
+    // and surface conflicts with exit 1 + an actionable hint.
     def = loadYaml('epic-single-branch.yaml');
     const createBranch = def.steps.find(s => s.id === 'create-branch')!;
     const cmd = (createBranch.config as Record<string, unknown>).command as string;
     expect(cmd).not.toMatch(/git stash pop[^\n]*\|\|\s*true/);
-    expect(cmd).toContain('moflo-epic-autostash');
+    expect(cmd).toContain('moflo-epic-{args.epic_number}-autostash');
     expect(cmd).toMatch(/exit\s+1/);
+  });
+
+  it("preflight stash-and-carry resolution scopes the marker by epic_number (regression #287)", () => {
+    // Stale `moflo-epic-autostash` entries from an abandoned previous run of
+    // a DIFFERENT epic must not be auto-popped onto this run. Scoping the
+    // marker by epic_number narrows the pop to the same epic only.
+    def = loadYaml('epic-single-branch.yaml');
+    const createBranch = def.steps.find(s => s.id === 'create-branch')!;
+    const stashResolutions = (createBranch.preflight ?? [])
+      .flatMap(p => p.resolutions ?? [])
+      .filter(r => typeof r.command === 'string' && r.command!.includes('git stash push'));
+    expect(stashResolutions.length).toBeGreaterThan(0);
+    for (const r of stashResolutions) {
+      expect(r.command).toContain('moflo-epic-{args.epic_number}-autostash');
+    }
   });
 });
 
@@ -346,7 +361,21 @@ describe('epic-auto-merge.yaml', () => {
       const step = loop.steps!.find(s => s.id === id)!;
       const cmd = (step.config as Record<string, unknown>).command as string;
       expect(cmd, `${id}: stash-pop conflict must not be masked`).not.toMatch(/git stash pop[^\n]*\|\|\s*true/);
-      expect(cmd, `${id}: must reference moflo-epic-autostash marker`).toContain('moflo-epic-autostash');
+      expect(cmd, `${id}: must scope marker by epic_number`).toContain('moflo-epic-{args.epic_number}-autostash');
+      expect(cmd, `${id}: must surface stash-pop conflict as exit 1`).toMatch(/exit\s+1/);
+    }
+  });
+
+  it('preflight stash-and-carry resolution scopes the marker by epic_number (regression #287)', () => {
+    def = loadYaml('epic-auto-merge.yaml');
+    const loop = def.steps.find(s => s.id === 'process-stories')!;
+    const checkoutBase = loop.steps!.find(s => s.id === 'checkout-base')!;
+    const stashResolutions = (checkoutBase.preflight ?? [])
+      .flatMap(p => p.resolutions ?? [])
+      .filter(r => typeof r.command === 'string' && r.command!.includes('git stash push'));
+    expect(stashResolutions.length).toBeGreaterThan(0);
+    for (const r of stashResolutions) {
+      expect(r.command).toContain('moflo-epic-{args.epic_number}-autostash');
     }
   });
 });

--- a/tests/epic-spells.test.ts
+++ b/tests/epic-spells.test.ts
@@ -227,6 +227,32 @@ describe('epic-single-branch.yaml', () => {
     def = loadYaml('epic-single-branch.yaml');
     expect(def.mofloLevel).toBe('hooks');
   });
+
+  it("'no unmerged files' preflight uses git diff --quiet (regression #287)", () => {
+    // Regression: `git diff --name-only --diff-filter=U` always exits 0
+    // (it just lists paths), so with expectExitCode: 0 the preflight
+    // never caught a half-merged index. `--quiet` exits 1 on unmerged
+    // paths, which is what we actually need here.
+    def = loadYaml('epic-single-branch.yaml');
+    const createBranch = def.steps.find(s => s.id === 'create-branch')!;
+    const check = createBranch.preflight!.find(p => p.name === 'no unmerged files')!;
+    expect(check.command).toBe('git diff --quiet --diff-filter=U');
+  });
+
+  it('create-branch does not silently mask stash-pop conflicts (regression #287)', () => {
+    // Regression: `git stash pop -q 2>/dev/null || true` swallowed real
+    // conflict failures and left the index unmerged. The next step's
+    // `git checkout` then died with "you need to resolve your current
+    // index first". The fix: only pop when the preflight autostash
+    // marker sits at the top of the stash list, and surface conflicts
+    // with exit 1 + an actionable hint.
+    def = loadYaml('epic-single-branch.yaml');
+    const createBranch = def.steps.find(s => s.id === 'create-branch')!;
+    const cmd = (createBranch.config as Record<string, unknown>).command as string;
+    expect(cmd).not.toMatch(/git stash pop[^\n]*\|\|\s*true/);
+    expect(cmd).toContain('moflo-epic-autostash');
+    expect(cmd).toMatch(/exit\s+1/);
+  });
 });
 
 // ============================================================================
@@ -303,6 +329,25 @@ describe('epic-auto-merge.yaml', () => {
   it('sets mofloLevel to hooks', () => {
     def = loadYaml('epic-auto-merge.yaml');
     expect(def.mofloLevel).toBe('hooks');
+  });
+
+  it("'no unmerged files' preflight uses git diff --quiet (regression #287)", () => {
+    def = loadYaml('epic-auto-merge.yaml');
+    const loop = def.steps.find(s => s.id === 'process-stories')!;
+    const checkoutBase = loop.steps!.find(s => s.id === 'checkout-base')!;
+    const check = checkoutBase.preflight!.find(p => p.name === 'no unmerged files')!;
+    expect(check.command).toBe('git diff --quiet --diff-filter=U');
+  });
+
+  it('checkout-base and pull-merged do not silently mask stash-pop conflicts (regression #287)', () => {
+    def = loadYaml('epic-auto-merge.yaml');
+    const loop = def.steps.find(s => s.id === 'process-stories')!;
+    for (const id of ['checkout-base', 'pull-merged']) {
+      const step = loop.steps!.find(s => s.id === id)!;
+      const cmd = (step.config as Record<string, unknown>).command as string;
+      expect(cmd, `${id}: stash-pop conflict must not be masked`).not.toMatch(/git stash pop[^\n]*\|\|\s*true/);
+      expect(cmd, `${id}: must reference moflo-epic-autostash marker`).toContain('moflo-epic-autostash');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- `git diff --name-only --diff-filter=U` always exits 0 — the "no unmerged files" preflight has been a silent no-op since #765. Switch to `git diff --quiet --diff-filter=U` so it actually trips when the index is half-merged.
- Drop `git stash pop -q 2>/dev/null || true` from `create-branch` (single-branch) and `checkout-base` / `pull-merged` (auto-merge). It was masking real conflict failures and leaving unmerged paths for the next step's `git checkout` to die on with "you need to resolve your current index first" — exact failure mode reported on epic #287. Same silent-catch antipattern as #854.
- New flow: preflight enforces a clean tree (or runs the user's stash-and-carry resolution that tags the stash with `moflo-epic-{args.epic_number}-autostash`); the step pops only when that marker is at the top of the stash list, and surfaces pop conflicts with `exit 1` + an actionable hint.
- Marker is scoped by `epic_number` so a stale autostash from an abandoned previous run of a *different* epic can't be auto-popped onto a fresh run. Same-epic re-runs continue to carry over (intended recovery semantics).

## Why now
Epic spells ship to consumer projects via the npm package; every `flo cast esb` / `flo cast eam` runner downstream is exposed.

## Test plan
- [x] `npx vitest run tests/epic-spells.test.ts` — 37 tests pass, including 6 new regression guards (preflight `--quiet` shape on both YAMLs; no `git stash pop ... || true` in any step; autostash marker scoped by epic_number in both step commands and preflight resolutions; `exit 1` on stash-pop conflict for all three steps).
- [x] `npx vitest run tests/epic-spells.test.ts src/cli/__tests__/spells/ src/cli/spells/__tests__/` — 1069 spell-related tests pass.
- [x] `npm run build` — clean.
- [x] `/flo-simplify` reviewer pass (single sonnet agent) flagged a residual cross-epic autostash collision risk; addressed in second commit with epic_number scoping + missing test assertion.
- [ ] After merge: republish, reinstall in consumers, re-run epic 287.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)