### PR TITLE
feat(1002): batched Y/n save offer + --reprompt-creds for prereq credentials

### DIFF
--- a/src/cli/__tests__/spells/prerequisites-resolve.test.ts
+++ b/src/cli/__tests__/spells/prerequisites-resolve.test.ts
@@ -174,13 +174,15 @@ describe('resolveUnmetPrerequisites', () => {
       expect(credentials.storeCalls).toEqual([]);
     });
 
-    it('persists prompt answer to the store after a successful TTY prompt', async () => {
+    it('persists prompt answer to the store when user accepts the save offer (default Y)', async () => {
       const prereq = compilePrerequisiteSpec({
         name: 'TOKEN',
         detect: { type: 'env', key: KEY },
       });
       const credentials = makeCredentials({});
-      const promptLine = vi.fn<PromptLineFn>(async () => 'fresh-answer');
+      // First call: prereq value. Second call: save-offer answer (empty = default Y).
+      const responses = ['fresh-answer', ''];
+      const promptLine = vi.fn<PromptLineFn>(async () => responses.shift() ?? '');
 
       const result = await resolveUnmetPrerequisites([prereq], {
         interactive: true,
@@ -192,6 +194,101 @@ describe('resolveUnmetPrerequisites', () => {
       expect(result.ok).toBe(true);
       expect(process.env[KEY]).toBe('fresh-answer');
       expect(credentials.storeCalls).toEqual([[KEY, 'fresh-answer']]);
+      expect(promptLine).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not persist when user declines the save offer (n)', async () => {
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        detect: { type: 'env', key: KEY },
+      });
+      const credentials = makeCredentials({});
+      const responses = ['fresh-answer', 'n'];
+      const promptLine = vi.fn<PromptLineFn>(async () => responses.shift() ?? '');
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: () => {},
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(process.env[KEY]).toBe('fresh-answer');
+      expect(credentials.storeCalls).toEqual([]);
+    });
+
+    it('batches the save offer when multiple prereqs are prompted', async () => {
+      const KEY_A = 'CRED_BATCH_A_1002';
+      const KEY_B = 'CRED_BATCH_B_1002';
+      delete process.env[KEY_A];
+      delete process.env[KEY_B];
+
+      const prereqA = compilePrerequisiteSpec({ name: 'A', detect: { type: 'env', key: KEY_A } });
+      const prereqB = compilePrerequisiteSpec({ name: 'B', detect: { type: 'env', key: KEY_B } });
+      const credentials = makeCredentials({});
+      const responses = ['answer-a', 'answer-b', 'y'];
+      const promptLine = vi.fn<PromptLineFn>(async () => responses.shift() ?? '');
+      const logged: string[] = [];
+
+      const result = await resolveUnmetPrerequisites([prereqA, prereqB], {
+        interactive: true,
+        promptLine,
+        log: (l) => logged.push(l),
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(promptLine).toHaveBeenCalledTimes(3);
+      expect(credentials.storeCalls).toEqual([
+        [KEY_A, 'answer-a'],
+        [KEY_B, 'answer-b'],
+      ]);
+      // The save-offer prompt mentions the count, not each name individually.
+      const savePromptCall = promptLine.mock.calls[2][0];
+      expect(savePromptCall).toMatch(/Save 2 credentials/);
+    });
+
+    it('does not show the save offer when no prereqs were prompted (all from store)', async () => {
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        detect: { type: 'env', key: KEY },
+      });
+      const credentials = makeCredentials({ [KEY]: 'cached' });
+      const promptLine = vi.fn<PromptLineFn>(async () => 'should-not-fire');
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: () => {},
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(promptLine).not.toHaveBeenCalled();
+      expect(credentials.storeCalls).toEqual([]);
+    });
+
+    it('forceCredentialReprompt skips store lookup and prompts even when value is cached', async () => {
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        detect: { type: 'env', key: KEY },
+      });
+      const credentials = makeCredentials({ [KEY]: 'old-stale-value' });
+      const responses = ['rotated-value', 'y'];
+      const promptLine = vi.fn<PromptLineFn>(async () => responses.shift() ?? '');
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: () => {},
+        credentials,
+        forceCredentialReprompt: true,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(process.env[KEY]).toBe('rotated-value');
+      expect(credentials.storeCalls).toEqual([[KEY, 'rotated-value']]);
     });
 
     it('non-TTY + missing + no store → fails with MISSING_CREDENTIAL errorCode', async () => {
@@ -262,7 +359,9 @@ describe('resolveUnmetPrerequisites', () => {
         async has() { return false; },
         async store() { throw new Error('disk full'); },
       };
-      const promptLine = vi.fn<PromptLineFn>(async () => 'answer');
+      // First call: prereq value. Second call: save-offer answer (default Y triggers the failing store).
+      const responses = ['answer', ''];
+      const promptLine = vi.fn<PromptLineFn>(async () => responses.shift() ?? '');
       const logged: string[] = [];
 
       const result = await resolveUnmetPrerequisites([prereq], {

--- a/src/cli/__tests__/spells/prerequisites-resolve.test.ts
+++ b/src/cli/__tests__/spells/prerequisites-resolve.test.ts
@@ -289,6 +289,9 @@ describe('resolveUnmetPrerequisites', () => {
       expect(result.ok).toBe(true);
       expect(process.env[KEY]).toBe('rotated-value');
       expect(credentials.storeCalls).toEqual([[KEY, 'rotated-value']]);
+      // Two calls (value + save-offer) prove the store-lookup path was bypassed —
+      // without forceCredentialReprompt, the cached value would have suppressed the prompt.
+      expect(promptLine).toHaveBeenCalledTimes(2);
     });
 
     it('non-TTY + missing + no store → fails with MISSING_CREDENTIAL errorCode', async () => {

--- a/src/cli/commands/spell.ts
+++ b/src/cli/commands/spell.ts
@@ -163,6 +163,12 @@ export const castCommand: Command = {
       description: 'Single key=value spell argument (repeatable). Numeric/boolean strings are coerced.',
       type: 'array',
     },
+    {
+      name: 'reprompt-creds',
+      description: 'Force re-prompting for env-type prereqs (rotate or correct stored credentials)',
+      type: 'boolean',
+      default: false,
+    },
   ],
   examples: [
     { command: 'moflo spell cast -n development', description: 'Cast spell by name' },
@@ -170,6 +176,7 @@ export const castCommand: Command = {
     { command: 'moflo spell cast -n sa --dry-run', description: 'Validate via abbreviation' },
     { command: "moflo spell cast -n oap --args '{\"maxEmails\":50}'", description: 'Pass spell arguments as JSON' },
     { command: 'moflo spell cast -n oap --arg headless=false --arg maxEmails=50', description: 'Pass arguments as key=value pairs' },
+    { command: 'moflo spell cast -n oap --reprompt-creds', description: 'Re-prompt for credentials (rotate stored secrets)' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const name = (ctx.flags.name as string) || ctx.args[0];
@@ -252,6 +259,7 @@ export const castCommand: Command = {
         file: file || undefined,
         args,
         dryRun,
+        forceCredentialReprompt: ctx.flags.repromptCreds as boolean | undefined,
       });
 
       if (result.error) {

--- a/src/cli/mcp-tools/spell-tools.ts
+++ b/src/cli/mcp-tools/spell-tools.ts
@@ -88,13 +88,18 @@ async function executeAndTrack(
   engine: EngineModule,
   definition: SpellDefinition,
   args: Record<string, unknown>,
+  options: { forceCredentialReprompt?: boolean } = {},
 ): Promise<Record<string, unknown>> {
   const spellId = `sp-${Date.now()}`;
   const tracked = trackStart(spellId, definition.name, definition.description);
 
   try {
     const sandboxConfig = await engine.loadSandboxConfigFromProject(findProjectRoot());
-    const result = await engine.bridgeExecuteSpell(definition, args, { spellId, sandboxConfig });
+    const result = await engine.bridgeExecuteSpell(definition, args, {
+      spellId,
+      sandboxConfig,
+      forceCredentialReprompt: options.forceCredentialReprompt,
+    });
     trackResult(tracked, result);
     return serializeResult(result);
   } catch (err) {
@@ -193,11 +198,16 @@ export const spellTools: MCPTool[] = [
         content: { type: 'string', description: 'Inline YAML/JSON spell incantation' },
         args: { type: 'object', description: 'Reagents (arguments) to pass to the spell' },
         dryRun: { type: 'boolean', description: 'Preview the spell without casting' },
+        forceCredentialReprompt: {
+          type: 'boolean',
+          description: 'Force re-prompting for env-type prereqs even when the credential store has a stored value (used to rotate or correct stored secrets)',
+        },
       },
     },
     handler: async (input) => {
       const args = (input.args as Record<string, unknown>) ?? {};
       const dryRun = input.dryRun as boolean | undefined;
+      const forceCredentialReprompt = input.forceCredentialReprompt as boolean | undefined;
 
       if (input.name) {
         // Resolve via registry and execute the parsed definition directly
@@ -207,7 +217,7 @@ export const spellTools: MCPTool[] = [
           return { error: `Spell not found in grimoire: ${input.name}` };
         }
         const engine = await loadSpellEngine();
-        return executeAndTrack(engine, loaded.definition, args);
+        return executeAndTrack(engine, loaded.definition, args, { forceCredentialReprompt });
       }
 
       // Determine raw content source
@@ -234,7 +244,9 @@ export const spellTools: MCPTool[] = [
       // Run from raw content via bridge
       const engine = await loadSpellEngine();
       const sandboxConfig = await engine.loadSandboxConfigFromProject(findProjectRoot());
-      const result = await engine.bridgeRunSpell(content, sourceFile, args, { dryRun, sandboxConfig });
+      const result = await engine.bridgeRunSpell(content, sourceFile, args, {
+        dryRun, sandboxConfig, forceCredentialReprompt,
+      });
       const tracked = trackStart(result.spellId, spellName);
       trackResult(tracked, result);
       return serializeResult(result);

--- a/src/cli/services/engine-loader.ts
+++ b/src/cli/services/engine-loader.ts
@@ -43,12 +43,24 @@ export interface EngineModule {
     content: string,
     sourceFile: string | undefined,
     args: Record<string, unknown>,
-    options?: { dryRun?: boolean; projectRoot?: string; memory?: unknown; sandboxConfig?: SandboxConfig },
+    options?: {
+      dryRun?: boolean;
+      projectRoot?: string;
+      memory?: unknown;
+      sandboxConfig?: SandboxConfig;
+      forceCredentialReprompt?: boolean;
+    },
   ) => Promise<SpellResult>;
   bridgeExecuteSpell: (
     definition: SpellDefinition,
     args: Record<string, unknown>,
-    options?: { spellId?: string; projectRoot?: string; memory?: unknown; sandboxConfig?: SandboxConfig },
+    options?: {
+      spellId?: string;
+      projectRoot?: string;
+      memory?: unknown;
+      sandboxConfig?: SandboxConfig;
+      forceCredentialReprompt?: boolean;
+    },
   ) => Promise<SpellResult>;
   bridgeCancelSpell: (spellId: string) => boolean;
   bridgeIsRunning: (spellId: string) => boolean;

--- a/src/cli/spells/core/prerequisite-checker.ts
+++ b/src/cli/spells/core/prerequisite-checker.ts
@@ -334,6 +334,7 @@ export async function resolveUnmetPrerequisites(
   const promptableSet = new Set(promptable);
   const pendingSaves: Array<{ envKey: string; value: string }> = [];
   const lock = acquireTTYLock();
+  let shouldSave = false;
   try {
     for (const prereq of promptable) {
       if (options.abortSignal?.aborted) {
@@ -373,21 +374,24 @@ export async function resolveUnmetPrerequisites(
     // One batched save offer covers every collected answer — issuing N
     // confirmations would be repetitive when most users want all-or-nothing.
     if (credentials && pendingSaves.length > 0) {
-      const shouldSave = await promptSaveCredentialsConfirmation(
+      shouldSave = await promptSaveCredentialsConfirmation(
         promptLine, pendingSaves.length, options.abortSignal,
       );
-      if (shouldSave) {
-        for (const { envKey, value } of pendingSaves) {
-          try {
-            await credentials.store(envKey, value);
-          } catch (err) {
-            log(`  (could not persist credential "${envKey}": ${(err as Error).message})`);
-          }
-        }
-      }
     }
   } finally {
     lock.release();
+  }
+
+  // Persist outside the TTY lock so slow disk/keychain writes don't block
+  // concurrent stdin readers waiting on the same lock.
+  if (credentials && shouldSave) {
+    for (const { envKey, value } of pendingSaves) {
+      try {
+        await credentials.store(envKey, value);
+      } catch (err) {
+        log(`  (could not persist credential "${envKey}": ${(err as Error).message})`);
+      }
+    }
   }
 
   // Anything in stillUnmet that wasn't promptable (typically command/file

--- a/src/cli/spells/core/prerequisite-checker.ts
+++ b/src/cli/spells/core/prerequisite-checker.ts
@@ -216,10 +216,18 @@ export interface ResolvePrerequisitesOptions {
    * Credential accessor consulted before prompting. When present and
    * `credentials.has(envKey)` is true, the resolver populates
    * `process.env[envKey]` from the store and skips the prompt.
-   * When a TTY prompt produces an answer, it's persisted via
-   * `credentials.store(envKey, answer)` so the next cast doesn't prompt.
+   * When a TTY prompt produces answers, the resolver asks ONCE at the
+   * end whether to persist them all to the store (default Y); on Y
+   * each `envKey` is written via `credentials.store(envKey, value)`.
    */
   readonly credentials?: CredentialAccessor;
+  /**
+   * When true, skip the `credentials.get(envKey)` resolution step so every
+   * env-type prereq goes through the interactive prompt — even when the
+   * store already holds a value. Used to rotate or correct stored
+   * credentials without manually deleting them first. Story #1002.
+   */
+  readonly forceCredentialReprompt?: boolean;
 }
 
 export interface ResolvePrerequisitesResult {
@@ -242,7 +250,9 @@ export interface ResolvePrerequisitesResult {
  * Evaluate all prereqs. Resolution chain for env-type prereqs:
  *   1. process.env[key] already set → satisfied.
  *   2. credentials.get(key) returns a value → write to process.env, satisfied.
- *   3. TTY interactive → prompt → write to process.env AND credentials.store.
+ *   3. TTY interactive → prompt → write to process.env. After ALL prompts,
+ *      one Y/n offer asks whether to persist the collected answers to the
+ *      credential store as a batch (default Y). Story #1002.
  *   4. Non-TTY or no credentials → fail fast with `errorCode: 'MISSING_CREDENTIAL'`.
  *
  * Non-env prereqs (`command`, `file`) bypass the credential chain and surface
@@ -269,9 +279,11 @@ export async function resolveUnmetPrerequisites(
 
   // Pull env-type prereqs from the store in parallel — each resolved index
   // lets us skip a re-check of the cheap env detector.
+  // `forceCredentialReprompt` bypasses this step so users can rotate or
+  // correct stored credentials by re-running through the prompt path.
   const resolvedFromStoreNames: string[] = [];
   const storeResolved = new Set<number>();
-  if (credentials) {
+  if (credentials && !options.forceCredentialReprompt) {
     await Promise.all(unmetIndices.map(async (i) => {
       const prereq = prerequisites[i];
       if (!prereq.envKey) return;
@@ -320,6 +332,7 @@ export async function resolveUnmetPrerequisites(
   const promptLine = options.promptLine ?? readLineFromStdin;
   const promptedNames: string[] = [];
   const promptableSet = new Set(promptable);
+  const pendingSaves: Array<{ envKey: string; value: string }> = [];
   const lock = acquireTTYLock();
   try {
     for (const prereq of promptable) {
@@ -352,15 +365,26 @@ export async function resolveUnmetPrerequisites(
       }
       if (prereq.envKey) {
         process.env[prereq.envKey] = answer;
-        if (credentials) {
+        if (credentials) pendingSaves.push({ envKey: prereq.envKey, value: answer });
+      }
+      promptedNames.push(prereq.name);
+    }
+
+    // One batched save offer covers every collected answer — issuing N
+    // confirmations would be repetitive when most users want all-or-nothing.
+    if (credentials && pendingSaves.length > 0) {
+      const shouldSave = await promptSaveCredentialsConfirmation(
+        promptLine, pendingSaves.length, options.abortSignal,
+      );
+      if (shouldSave) {
+        for (const { envKey, value } of pendingSaves) {
           try {
-            await credentials.store(prereq.envKey, answer);
+            await credentials.store(envKey, value);
           } catch (err) {
-            log(`  (could not persist credential "${prereq.envKey}": ${(err as Error).message})`);
+            log(`  (could not persist credential "${envKey}": ${(err as Error).message})`);
           }
         }
       }
-      promptedNames.push(prereq.name);
     }
   } finally {
     lock.release();
@@ -393,6 +417,29 @@ function formatMissingCredentialMessage(
   lines.push('Prime these by casting the spell once interactively, or run:');
   lines.push('  flo spell credentials set <name>');
   return lines.join('\n');
+}
+
+/**
+ * Ask once whether to persist every collected prereq answer to the
+ * credential store. Empty input or `y/yes` → true (default Y); `n/no` →
+ * false. A failed prompt (e.g. abort) silently declines so the cast
+ * still proceeds with the in-memory env values.
+ */
+async function promptSaveCredentialsConfirmation(
+  promptLine: PromptLineFn,
+  count: number,
+  abortSignal: AbortSignal | undefined,
+): Promise<boolean> {
+  const noun = count === 1 ? 'credential' : 'credentials';
+  const prompt = `  Save ${count} ${noun} to the encrypted credential store for future runs? [Y/n] `;
+  let answer: string;
+  try {
+    answer = await promptLine(prompt, abortSignal);
+  } catch {
+    return false;
+  }
+  const trimmed = answer.trim().toLowerCase();
+  return trimmed === '' || trimmed === 'y' || trimmed === 'yes';
 }
 
 function printPreflightBanner(log: (line: string) => void, unmetCount: number): void {

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -160,6 +160,7 @@ export class SpellCaster {
         const resolution = await resolveUnmetPrerequisites(prerequisites, {
           abortSignal: options.signal,
           credentials: this.credentials,
+          forceCredentialReprompt: options.forceCredentialReprompt,
         });
         if (!resolution.ok) {
           return this.failureResult(spellId, startTime, [{

--- a/src/cli/spells/factory/runner-bridge.ts
+++ b/src/cli/spells/factory/runner-bridge.ts
@@ -44,7 +44,14 @@ export async function bridgeRunSpell(
   content: string,
   sourceFile: string | undefined,
   args: Record<string, unknown>,
-  options: { dryRun?: boolean; memory?: MemoryAccessor; credentials?: CredentialAccessor; projectRoot?: string; sandboxConfig?: SandboxConfig } = {},
+  options: {
+    dryRun?: boolean;
+    memory?: MemoryAccessor;
+    credentials?: CredentialAccessor;
+    projectRoot?: string;
+    sandboxConfig?: SandboxConfig;
+    forceCredentialReprompt?: boolean;
+  } = {},
 ): Promise<SpellResult> {
   const spellId = `sp-${Date.now()}`;
   const controller = new AbortController();
@@ -60,6 +67,7 @@ export async function bridgeRunSpell(
       signal: controller.signal,
       memory: options.memory,
       credentials,
+      forceCredentialReprompt: options.forceCredentialReprompt,
       ...(options.projectRoot ? { projectRoot: options.projectRoot } : {}),
       ...(sandboxConfig ? { sandboxConfig } : {}),
     });
@@ -75,7 +83,14 @@ export async function bridgeRunSpell(
 export async function bridgeExecuteSpell(
   definition: import('../types/spell-definition.types.js').SpellDefinition,
   args: Record<string, unknown>,
-  options: { spellId?: string; memory?: MemoryAccessor; credentials?: CredentialAccessor; projectRoot?: string; sandboxConfig?: SandboxConfig } = {},
+  options: {
+    spellId?: string;
+    memory?: MemoryAccessor;
+    credentials?: CredentialAccessor;
+    projectRoot?: string;
+    sandboxConfig?: SandboxConfig;
+    forceCredentialReprompt?: boolean;
+  } = {},
 ): Promise<SpellResult> {
   const spellId = options.spellId ?? `sp-${Date.now()}`;
   const controller = new AbortController();
@@ -88,6 +103,7 @@ export async function bridgeExecuteSpell(
     return await runner.run(definition, args, {
       spellId,
       signal: controller.signal,
+      forceCredentialReprompt: options.forceCredentialReprompt,
       ...(options.projectRoot ? { projectRoot: options.projectRoot } : {}),
       ...(sandboxConfig ? { sandboxConfig } : {}),
     });

--- a/src/cli/spells/types/runner.types.ts
+++ b/src/cli/spells/types/runner.types.ts
@@ -199,6 +199,15 @@ export interface RunnerOptions {
    * non-interactive contexts like CI, daemons, and scheduled spells).
    */
   readonly onPreflightWarnings?: PreflightWarningHandler;
+
+  /**
+   * Force re-prompting for every env-type prereq instead of pulling values
+   * from the credential store. Used to rotate or correct stored secrets
+   * (e.g. expired Graph token) without manually editing the store. After
+   * the prompt loop, the standard Y/n save offer covers persistence.
+   * Story #1002.
+   */
+  readonly forceCredentialReprompt?: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Replace the silent post-prompt credential save with one all-or-nothing `Save N credentials? [Y/n]` confirmation (default Y).
- Add `forceCredentialReprompt` plumbed through `RunnerOptions` → MCP `spell_cast` input → `flo spell cast --reprompt-creds` so users can rotate or correct stored secrets without manually editing the store.
- Save offer is suppressed when no prereqs were prompted (i.e. all values came from env or the store).

Closes #1002 (epic #1004)

## Behaviour change
Before: every promptOnMissing answer was silently written to the credential store.
After: answers are buffered, then a single Y/n save offer fires once after the last prereq prompt. Default Y preserves the prior end-state; declining keeps the current run working but skips the write.

## Consumer blast radius
- Surface: `dist/src/cli/spells/core/prerequisite-checker.js`, `runner.js`, `runner-bridge.js`, `mcp-tools/spell-tools.js`, `commands/spell.js`. Ships via standard `npm install moflo` round-trip.
- Failure mode for on-current-version consumer: zero. Default Y reproduces prior auto-save; no migration; no state-format change. The new `--reprompt-creds` flag and `forceCredentialReprompt` MCP/runner option are additive.

## Test plan
- [x] `prerequisites-resolve.test.ts` — 6 new/updated cases: default-Y persists, n declines, batched offer for multiple prereqs, no-prompt path skips offer, forceCredentialReprompt rotates a cached value, store() rejection logged but cast continues.
- [x] `prerequisites-integration.test.ts` — OAP retrofit unaffected (env-set path).
- [x] Full `npm test` suite: 8248 passed / 0 failed.
- [x] `tsc --noEmit` clean.
- [x] /flo-simplify pass: TTY lock released before credential store writes; assertion added to forceCredentialReprompt test.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

Co-Authored-By: moflo <noreply@motailz.com>