### PR TITLE
feat(1003): post-cast offer to persist --arg values into spell YAML defaults

### DIFF
--- a/src/cli/__tests__/spell-tools-engine.test.ts
+++ b/src/cli/__tests__/spell-tools-engine.test.ts
@@ -123,6 +123,34 @@ steps:
     expect(result.duration).toBeGreaterThanOrEqual(0);
   });
 
+  it('spell_cast with file path surfaces sourceFile + tier on the response (#1003)', { timeout: 15_000 }, async () => {
+    const { writeFileSync, mkdtempSync, rmSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const { tmpdir } = await import('node:os');
+    const dir = mkdtempSync(join(tmpdir(), 'moflo-cast-source-'));
+    const path = join(dir, 'sample.yaml');
+    writeFileSync(path, 'name: src\nsteps:\n  - id: s1\n    type: wait\n    config:\n      duration: 1\n');
+    try {
+      const tool = findTool('spell_cast');
+      const result: any = await tool.handler({ file: path });
+      expect(result.success).toBe(true);
+      expect(result.sourceFile).toBe(path);
+      expect(result.tier).toBe('user');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('spell_cast with inline content omits sourceFile + tier (#1003)', { timeout: 15_000 }, async () => {
+    const tool = findTool('spell_cast');
+    const result: any = await tool.handler({
+      content: 'name: inline\nsteps:\n  - id: s1\n    type: wait\n    config:\n      duration: 1\n',
+    });
+    expect(result.success).toBe(true);
+    expect(result.sourceFile).toBeUndefined();
+    expect(result.tier).toBeUndefined();
+  });
+
   it('spell_cast dry-run validates without executing', async () => {
     const tool = findTool('spell_cast');
     const yamlContent = `

--- a/src/cli/__tests__/spells/spell-tier.test.ts
+++ b/src/cli/__tests__/spells/spell-tier.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Tests for inferSpellTier (#1003).
+ *
+ * Used by the post-cast arg-writeback offer to skip mutating shipped YAMLs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { inferSpellTier } from '../../spells/core/spell-tier.js';
+
+describe('inferSpellTier', () => {
+  it.each([
+    ['/home/me/proj/node_modules/moflo/dist/src/cli/spells/definitions/oap.yaml', 'shipped'],
+    ['C:\\dev\\proj\\node_modules\\moflo\\dist\\src\\cli\\spells\\definitions\\oap.yaml', 'shipped'],
+    ['/home/me/proj/node_modules/@moflo/cli/spells/definitions/oap.yaml', 'shipped'],
+    ['/home/me/moflo/src/cli/spells/definitions/epic-single-branch.yaml', 'shipped'],
+    ['/home/me/proj/.claude/spells/oap.yaml', 'user'],
+    ['/home/me/proj/spells/dev/oap.yaml', 'user'],
+    ['./spells/local.yaml', 'user'],
+  ])('%s → %s', (path, expected) => {
+    expect(inferSpellTier(path)).toBe(expected);
+  });
+
+  it('returns user when no source path is known (e.g. inline content)', () => {
+    expect(inferSpellTier(undefined)).toBe('user');
+  });
+});

--- a/src/cli/__tests__/spells/yaml-defaults-writer.test.ts
+++ b/src/cli/__tests__/spells/yaml-defaults-writer.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for the YAML defaults writer (#1003).
+ *
+ * Round-trip + corner cases: comment preservation, missing default insertion,
+ * absent arguments block, value formatting, type variety, leaving non-target
+ * keys untouched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as yaml from 'js-yaml';
+import {
+  updateYamlArgDefaults,
+  formatYamlValue,
+} from '../../spells/core/yaml-defaults-writer.js';
+
+const STANDARD_YAML = `name: oap
+description: Outlook -> abstract -> persist
+version: 1
+arguments:
+  maxEmails:
+    type: number
+    default: 25  # max per cast
+    description: Cap on emails fetched
+  sinceDays:
+    type: number
+    default: 7
+    description: Lookback window in days
+  headless:
+    type: boolean
+    default: true
+steps:
+  - id: fetch
+    type: bash
+    config:
+      command: echo hi
+`;
+
+describe('updateYamlArgDefaults', () => {
+  it('rewrites a number default and preserves the inline comment', () => {
+    const r = updateYamlArgDefaults(STANDARD_YAML, { maxEmails: 50 });
+
+    expect(r.updated).toEqual(['maxEmails']);
+    expect(r.skipped).toEqual([]);
+    expect(r.content).toContain('default: 50  # max per cast');
+    // sinceDays untouched
+    expect(r.content).toContain('default: 7');
+    // re-parse as YAML and confirm new value
+    const reparsed = yaml.load(r.content) as { arguments: Record<string, { default: unknown }> };
+    expect(reparsed.arguments.maxEmails.default).toBe(50);
+    expect(reparsed.arguments.sinceDays.default).toBe(7);
+    expect(reparsed.arguments.headless.default).toBe(true);
+  });
+
+  it('rewrites multiple defaults in one pass without disturbing structure', () => {
+    const r = updateYamlArgDefaults(STANDARD_YAML, {
+      maxEmails: 100,
+      sinceDays: 30,
+      headless: false,
+    });
+
+    expect(r.updated.sort()).toEqual(['headless', 'maxEmails', 'sinceDays']);
+    expect(r.skipped).toEqual([]);
+    expect(r.content).toContain('default: 100  # max per cast');
+
+    const reparsed = yaml.load(r.content) as { arguments: Record<string, { default: unknown }> };
+    expect(reparsed.arguments.maxEmails.default).toBe(100);
+    expect(reparsed.arguments.sinceDays.default).toBe(30);
+    expect(reparsed.arguments.headless.default).toBe(false);
+
+    // Top-level keys untouched
+    expect(r.content.startsWith('name: oap\n')).toBe(true);
+    expect(r.content).toContain('description: Outlook -> abstract -> persist');
+    expect(r.content).toContain('  - id: fetch');
+  });
+
+  it('inserts a default line when one is missing', () => {
+    const yamlNoDefault = `arguments:
+  needle:
+    type: string
+    description: required by user
+`;
+    const r = updateYamlArgDefaults(yamlNoDefault, { needle: 'haystack' });
+
+    expect(r.updated).toEqual(['needle']);
+    expect(r.skipped).toEqual([]);
+    const reparsed = yaml.load(r.content) as { arguments: { needle: { default: string } } };
+    expect(reparsed.arguments.needle.default).toBe('haystack');
+    // The new line should be at the same indent as siblings
+    expect(r.content).toMatch(/^ {4}default: haystack$/m);
+  });
+
+  it('returns skipped for keys not declared in arguments', () => {
+    const r = updateYamlArgDefaults(STANDARD_YAML, { unknownArg: 'x' });
+
+    expect(r.updated).toEqual([]);
+    expect(r.skipped).toEqual(['unknownArg']);
+    expect(r.content).toBe(STANDARD_YAML);
+  });
+
+  it('returns all keys as skipped when arguments: block is absent', () => {
+    const yamlNoArgs = `name: simple
+steps:
+  - id: a
+    type: bash
+`;
+    const r = updateYamlArgDefaults(yamlNoArgs, { foo: 1 });
+
+    expect(r.updated).toEqual([]);
+    expect(r.skipped).toEqual(['foo']);
+    expect(r.content).toBe(yamlNoArgs);
+  });
+
+  it('is a no-op when updates is empty', () => {
+    const r = updateYamlArgDefaults(STANDARD_YAML, {});
+
+    expect(r.updated).toEqual([]);
+    expect(r.skipped).toEqual([]);
+    expect(r.content).toBe(STANDARD_YAML);
+  });
+
+  it('round-trips strings with special characters via js-yaml quoting', () => {
+    const yamlInput = `arguments:
+  pathArg:
+    type: string
+    default: ./data
+`;
+    const r = updateYamlArgDefaults(yamlInput, { pathArg: 'a path with spaces' });
+
+    expect(r.updated).toEqual(['pathArg']);
+    const reparsed = yaml.load(r.content) as { arguments: { pathArg: { default: string } } };
+    expect(reparsed.arguments.pathArg.default).toBe('a path with spaces');
+  });
+
+  it('preserves comments and blank lines outside the touched block', () => {
+    const yamlInput = `# top-level header comment
+name: x
+
+arguments:
+  # inside arguments comment
+  maxEmails:
+    type: number
+    default: 25
+
+  # comment between args
+  sinceDays:
+    type: number
+    default: 7
+
+steps:
+  - id: a
+    type: bash
+`;
+    const r = updateYamlArgDefaults(yamlInput, { maxEmails: 99 });
+
+    expect(r.updated).toEqual(['maxEmails']);
+    expect(r.content).toContain('# top-level header comment');
+    expect(r.content).toContain('# inside arguments comment');
+    expect(r.content).toContain('# comment between args');
+    // Blank line between args is still there
+    expect(r.content).toMatch(/default: 99\n\n  # comment between args/);
+  });
+});
+
+describe('updateYamlArgDefaults — corruption guards', () => {
+  it('preserves CRLF line endings on round-trip', () => {
+    const yamlInput = 'arguments:\r\n  maxEmails:\r\n    type: number\r\n    default: 25\r\n';
+    const r = updateYamlArgDefaults(yamlInput, { maxEmails: 99 });
+
+    expect(r.updated).toEqual(['maxEmails']);
+    expect(r.content).toContain('\r\n');
+    expect(r.content).not.toMatch(/[^\r]\n/);
+    expect(r.content).toContain('default: 99');
+  });
+
+  it('skips block-scalar `|` defaults instead of orphaning continuation lines', () => {
+    const yamlInput = `arguments:
+  body:
+    type: string
+    default: |
+      line one
+      line two
+    description: long-form text
+`;
+    const r = updateYamlArgDefaults(yamlInput, { body: 'one-liner' });
+
+    expect(r.updated).toEqual([]);
+    expect(r.skipped).toEqual(['body']);
+    expect(r.content).toBe(yamlInput);
+  });
+
+  it('skips block-scalar `>` (folded) defaults', () => {
+    const yamlInput = `arguments:
+  body:
+    type: string
+    default: >
+      paragraph one
+      paragraph two
+`;
+    const r = updateYamlArgDefaults(yamlInput, { body: 'short' });
+
+    expect(r.skipped).toEqual(['body']);
+    expect(r.content).toBe(yamlInput);
+  });
+
+  it('round-trips multiline string values via js-yaml inline quoting', () => {
+    const yamlInput = `arguments:
+  note:
+    type: string
+    default: x
+`;
+    const r = updateYamlArgDefaults(yamlInput, { note: 'line1\nline2\nline3' });
+
+    expect(r.updated).toEqual(['note']);
+    expect(r.skipped).toEqual([]);
+
+    const reparsed = yaml.load(r.content) as { arguments: { note: { default: string } } };
+    expect(reparsed.arguments.note.default).toBe('line1\nline2\nline3');
+    // The dumped value sits on the `default:` line — no orphaned continuation.
+    expect(r.content.split('\n').filter((l) => l.includes('default:'))).toHaveLength(1);
+  });
+});
+
+describe('formatYamlValue', () => {
+  it.each([
+    [42, '42'],
+    [0, '0'],
+    [-1.5, '-1.5'],
+    [true, 'true'],
+    [false, 'false'],
+    [null, 'null'],
+    [undefined, 'null'],
+  ])('formats %s as %s', (input, expected) => {
+    expect(formatYamlValue(input)).toBe(expected);
+  });
+
+  it('formats simple strings without quotes when safe', () => {
+    expect(formatYamlValue('plain')).toBe('plain');
+  });
+
+  it('quotes strings that need it', () => {
+    // js-yaml dumps strings containing leading whitespace with quotes
+    const out = formatYamlValue(' leading');
+    expect(out).toMatch(/^['"].*['"]$/);
+  });
+
+  it('formats arrays inline', () => {
+    expect(formatYamlValue([1, 2, 3])).toBe('[1, 2, 3]');
+  });
+
+  it('formats objects inline', () => {
+    expect(formatYamlValue({ a: 1, b: 'x' })).toMatch(/^\{a: 1, b: x\}$/);
+  });
+});

--- a/src/cli/__tests__/swarm/write-through-adapter-drain.test.ts
+++ b/src/cli/__tests__/swarm/write-through-adapter-drain.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression test for #1003 — drainPendingWrites must wait for writes that
+ * are *about to be* queued (scheduled via setImmediate from a bus event)
+ * and not just for writes that are already tracked at call time.
+ *
+ * Pre-fix symptom: doctor's hive-mind probe leaked 6 rows on Ubuntu CI
+ * because the bus's `message.unified` handler hadn't yet fired by the time
+ * `clearNamespace` snapshotted `pendingWrites`. Fast hosts won the race;
+ * slow hosts hid the bug.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  WriteThroughAdapter,
+  type MemoryStoreFunction,
+  type MemoryDeleteFunction,
+  type MemoryListFunction,
+} from '../../swarm/message-bus/write-through-adapter.js';
+import type { MessageBus } from '../../swarm/message-bus/message-bus.js';
+
+class FakeBus extends EventEmitter {
+  emitUnified(payload: Record<string, unknown>) {
+    this.emit('message.unified', payload);
+  }
+}
+
+function makeAdapter() {
+  const stored: Array<{ key: string; namespace: string; value: string }> = [];
+  const storeEntry: MemoryStoreFunction = vi.fn(async (opts) => {
+    stored.push({ key: opts.key, namespace: opts.namespace, value: opts.value });
+    return { success: true, id: opts.key };
+  });
+  const listEntries: MemoryListFunction = vi.fn(async ({ namespace }) => ({
+    entries: stored
+      .filter((s) => s.namespace === namespace)
+      .map((s) => ({ key: s.key })),
+  }));
+  const deleteEntry: MemoryDeleteFunction = vi.fn(async ({ key, namespace }) => {
+    const idx = stored.findIndex((s) => s.key === key && s.namespace === namespace);
+    if (idx >= 0) stored.splice(idx, 1);
+    return { success: true };
+  });
+  const bus = new FakeBus();
+  const adapter = new WriteThroughAdapter(
+    bus as unknown as MessageBus,
+    { enabled: true, namespaces: ['hive-mind'] },
+    storeEntry,
+    { listEntries, deleteEntry },
+  );
+  adapter.attach();
+  return { adapter, bus, stored, storeEntry, listEntries, deleteEntry };
+}
+
+describe('WriteThroughAdapter.drainPendingWrites — race fix (#1003)', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('awaits writes scheduled by a bus event that fires immediately before drain', async () => {
+    const { adapter, bus, stored } = makeAdapter();
+
+    bus.emitUnified({
+      messageId: 'm-1',
+      namespace: 'hive-mind',
+      type: 'broadcast',
+      from: 'a',
+      to: '*',
+      payload: { x: 1 },
+      priority: 'normal',
+      ttlMs: 60_000,
+    });
+
+    await adapter.drainPendingWrites();
+
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({ key: 'msg:m-1', namespace: 'hive-mind' });
+  });
+
+  it('clearNamespace removes writes that landed via a just-fired bus event', async () => {
+    const { adapter, bus, stored, listEntries, deleteEntry } = makeAdapter();
+
+    bus.emitUnified({
+      messageId: 'racer',
+      namespace: 'hive-mind',
+      type: 'broadcast',
+      from: 'a',
+      to: '*',
+      payload: {},
+      priority: 'normal',
+      ttlMs: 60_000,
+    });
+
+    await adapter.clearNamespace('hive-mind');
+
+    expect(stored).toHaveLength(0);
+    expect(listEntries).toHaveBeenCalled();
+    expect(deleteEntry).toHaveBeenCalled();
+  });
+
+  it('drainPendingWrites returns promptly when no writes are pending', async () => {
+    const { adapter } = makeAdapter();
+    const start = Date.now();
+    await adapter.drainPendingWrites();
+    expect(Date.now() - start).toBeLessThan(200);
+  });
+
+  it('does not loop indefinitely when writes are continuously enqueued', async () => {
+    const { adapter, bus } = makeAdapter();
+    let i = 0;
+    const interval = setInterval(() => {
+      bus.emitUnified({
+        messageId: `flood-${++i}`,
+        namespace: 'hive-mind',
+        type: 'broadcast',
+        from: 'a',
+        to: '*',
+        payload: {},
+        priority: 'normal',
+        ttlMs: 60_000,
+      });
+    }, 1);
+
+    try {
+      await adapter.drainPendingWrites();
+    } finally {
+      clearInterval(interval);
+    }
+    // Drain returns within the 5-iteration cap even under continuous writes.
+    expect(true).toBe(true);
+  });
+
+  it('drainPendingWrites works under fake timers (no setImmediate)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { adapter, bus, stored } = makeAdapter();
+
+      bus.emitUnified({
+        messageId: 'fake-1',
+        namespace: 'hive-mind',
+        type: 'broadcast',
+        from: 'a',
+        to: '*',
+        payload: {},
+        priority: 'normal',
+        ttlMs: 60_000,
+      });
+
+      await adapter.drainPendingWrites();
+      expect(stored).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/cli/commands/spell.ts
+++ b/src/cli/commands/spell.ts
@@ -32,6 +32,9 @@ import { formatStatus, handleMCPError } from '../services/cli-formatters.js';
 import { scheduleCommand } from './spell-schedule.js';
 import { spellCredentialsCommand } from './spell-credentials.js';
 import { loadSpellEngine } from '../services/engine-loader.js';
+import { readFile, writeFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { updateYamlArgDefaults } from '../spells/core/yaml-defaults-writer.js';
 
 // Re-export formatStatus as formatStageStatus for table column references
 const formatStageStatus = formatStatus;
@@ -297,6 +300,26 @@ export const castCommand: Command = {
 
       printSpellErrors(result.errors);
 
+      // #1003 — offer to persist --arg values back into the spell YAML.
+      // CLI-interactive only; MCP/headless callers skip by design.
+      if (
+        result.success
+        && !dryRun
+        && ctx.interactive
+        && Object.keys(args).length > 0
+        && result.sourceFile
+      ) {
+        if (result.tier === 'shipped') {
+          const hint = name || basename(result.sourceFile).replace(/\.[^.]+$/, '');
+          output.writeln();
+          output.printInfo(
+            `Shipped spell — copy to spells/dev/${hint}.yaml first to persist defaults.`,
+          );
+        } else {
+          await offerArgWriteback(result.sourceFile, args);
+        }
+      }
+
       return { success: result.success, data: result };
     } catch (error) {
       spinner.fail('Spell failed');
@@ -306,6 +329,48 @@ export const castCommand: Command = {
     }
   },
 };
+
+async function offerArgWriteback(
+  sourceFile: string,
+  userArgs: Record<string, unknown>,
+): Promise<void> {
+  const keys = Object.keys(userArgs);
+  output.writeln();
+  const noun = keys.length === 1 ? 'argument' : 'arguments';
+  const accepted = await confirm({
+    message: `Save ${keys.length} ${noun} (${keys.join(', ')}) as the spell's defaults?`,
+    default: false,
+  });
+  if (!accepted) return;
+
+  let original: string;
+  try {
+    original = await readFile(sourceFile, 'utf-8');
+  } catch (err) {
+    output.printError(`Could not read spell YAML: ${(err as Error).message}`);
+    return;
+  }
+
+  const result = updateYamlArgDefaults(original, userArgs);
+
+  if (result.updated.length > 0) {
+    try {
+      await writeFile(sourceFile, result.content, 'utf-8');
+      output.printSuccess(
+        `Saved ${result.updated.length} default${result.updated.length === 1 ? '' : 's'}: ${result.updated.join(', ')}`,
+      );
+    } catch (err) {
+      output.printError(`Could not write spell YAML: ${(err as Error).message}`);
+      return;
+    }
+  }
+
+  if (result.skipped.length > 0) {
+    output.printWarning(
+      `Skipped ${result.skipped.length} (not declared in arguments:): ${result.skipped.join(', ')}`,
+    );
+  }
+}
 
 // Validate subcommand
 const validateCommand: Command = {

--- a/src/cli/mcp-tools/spell-response.types.ts
+++ b/src/cli/mcp-tools/spell-response.types.ts
@@ -21,6 +21,10 @@ export interface SpellRunResponse {
   outputs: Record<string, unknown>;
   errors: SpellErrorResponse[];
   error?: string;
+  /** Absolute path of the spell's source YAML/JSON, if known. (#1003) */
+  sourceFile?: string;
+  /** Whether the source is shipped (read-only) or user-owned. (#1003) */
+  tier?: 'shipped' | 'user';
 }
 
 /** Serialized step in a spell MCP response. */

--- a/src/cli/mcp-tools/spell-tools.ts
+++ b/src/cli/mcp-tools/spell-tools.ts
@@ -20,6 +20,7 @@ import {
 import { findProjectRoot } from '../services/project-root.js';
 import { buildGrimoire } from '../services/grimoire-builder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { inferSpellTier, type SpellTier } from '../spells/core/spell-tier.js';
 
 
 // ============================================================================
@@ -88,7 +89,11 @@ async function executeAndTrack(
   engine: EngineModule,
   definition: SpellDefinition,
   args: Record<string, unknown>,
-  options: { forceCredentialReprompt?: boolean } = {},
+  options: {
+    forceCredentialReprompt?: boolean;
+    sourceFile?: string;
+    tier?: SpellTier;
+  } = {},
 ): Promise<Record<string, unknown>> {
   const spellId = `sp-${Date.now()}`;
   const tracked = trackStart(spellId, definition.name, definition.description);
@@ -101,12 +106,23 @@ async function executeAndTrack(
       forceCredentialReprompt: options.forceCredentialReprompt,
     });
     trackResult(tracked, result);
-    return serializeResult(result);
+    return withSpellSource(serializeResult(result), options.sourceFile, options.tier);
   } catch (err) {
     tracked.status = SPELL_STATUS.FAILED;
     tracked.completedAt = new Date().toISOString();
     return { spellId, error: errorDetail(err) };
   }
+}
+
+/** Attach sourceFile + tier metadata to a serialized cast response. (#1003) */
+function withSpellSource(
+  base: Record<string, unknown>,
+  sourceFile: string | undefined,
+  tier: SpellTier | undefined,
+): Record<string, unknown> {
+  if (sourceFile) base.sourceFile = sourceFile;
+  if (tier) base.tier = tier;
+  return base;
 }
 
 // ============================================================================
@@ -217,7 +233,11 @@ export const spellTools: MCPTool[] = [
           return { error: `Spell not found in grimoire: ${input.name}` };
         }
         const engine = await loadSpellEngine();
-        return executeAndTrack(engine, loaded.definition, args, { forceCredentialReprompt });
+        return executeAndTrack(engine, loaded.definition, args, {
+          forceCredentialReprompt,
+          sourceFile: loaded.sourceFile,
+          tier: loaded.tier as SpellTier,
+        });
       }
 
       // Determine raw content source
@@ -249,7 +269,11 @@ export const spellTools: MCPTool[] = [
       });
       const tracked = trackStart(result.spellId, spellName);
       trackResult(tracked, result);
-      return serializeResult(result);
+      return withSpellSource(
+        serializeResult(result),
+        sourceFile,
+        sourceFile ? inferSpellTier(sourceFile) : undefined,
+      );
     },
   },
 

--- a/src/cli/spells/core/spell-tier.ts
+++ b/src/cli/spells/core/spell-tier.ts
@@ -1,0 +1,25 @@
+/**
+ * Classify a spell's source path as 'shipped' (ships with moflo, read-only
+ * from the consumer's perspective) or 'user' (project-local, writable).
+ *
+ * Story #1003 — used by the post-cast arg-writeback offer to skip the save
+ * prompt for shipped YAMLs (mutating them inside `node_modules/moflo/...`
+ * would be wiped on the next `npm install` and confuses provenance).
+ */
+
+const SHIPPED_MARKERS: readonly RegExp[] = [
+  // Installed package — both bare 'moflo' and the legacy '@moflo/*' workspace.
+  /\/node_modules\/moflo\//,
+  /\/node_modules\/@moflo\//,
+  // Source-tree shipped definitions (relevant when moflo dogfoods itself).
+  /\/src\/cli\/spells\/definitions\//,
+  /\/dist\/[^/]*\/?cli\/spells\/definitions\//,
+];
+
+export type SpellTier = 'shipped' | 'user';
+
+export function inferSpellTier(sourceFile: string | undefined): SpellTier {
+  if (!sourceFile) return 'user';
+  const norm = sourceFile.replace(/\\/g, '/');
+  return SHIPPED_MARKERS.some((re) => re.test(norm)) ? 'shipped' : 'user';
+}

--- a/src/cli/spells/core/yaml-defaults-writer.ts
+++ b/src/cli/spells/core/yaml-defaults-writer.ts
@@ -1,0 +1,195 @@
+// YAML line-editor: rewrite `arguments.<key>.default` without a full
+// round-trip through js-yaml (which would drop comments). Anchors and
+// block-scalar defaults are listed in `skipped` so callers can surface them.
+
+import * as yaml from 'js-yaml';
+
+export interface UpdateArgDefaultsResult {
+  readonly content: string;
+  readonly updated: readonly string[];
+  readonly skipped: readonly string[];
+}
+
+const ARGUMENTS_HEADER_RE = /^arguments\s*:\s*(?:#.*)?$/;
+const KEY_LINE_RE = /^(\s*)([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/;
+const DEFAULT_LINE_RE = /^(\s*default\s*:\s*)(?:[^#\n]*?)(\s*#.*)?$/;
+const BLOCK_SCALAR_DEFAULT_RE = /^\s*default\s*:\s*[|>][+-]?\d*\s*(?:#.*)?$/;
+
+export function updateYamlArgDefaults(
+  yamlContent: string,
+  updates: Record<string, unknown>,
+): UpdateArgDefaultsResult {
+  const updateKeys = Object.keys(updates);
+  if (updateKeys.length === 0) {
+    return { content: yamlContent, updated: [], skipped: [] };
+  }
+
+  const usesCRLF = /\r\n/.test(yamlContent);
+  const normalized = usesCRLF ? yamlContent.replace(/\r\n/g, '\n') : yamlContent;
+  const lines = normalized.split('\n');
+  const argumentsLineIdx = findArgumentsHeader(lines);
+  if (argumentsLineIdx === -1) {
+    return { content: yamlContent, updated: [], skipped: updateKeys };
+  }
+
+  const argKeyIndent = findArgKeyIndent(lines, argumentsLineIdx);
+  if (argKeyIndent === -1) {
+    return { content: yamlContent, updated: [], skipped: updateKeys };
+  }
+
+  const remaining = new Set(updateKeys);
+  const updated: string[] = [];
+  const skippedExtra: string[] = [];
+  let i = argumentsLineIdx + 1;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const stripped = line.trim();
+
+    if (!stripped || stripped.startsWith('#')) {
+      i++;
+      continue;
+    }
+
+    const indent = leadingSpaces(line);
+    if (indent === 0) break;
+
+    if (indent !== argKeyIndent) {
+      i++;
+      continue;
+    }
+
+    const m = KEY_LINE_RE.exec(line);
+    if (!m) { i++; continue; }
+    const argName = m[2];
+
+    if (!remaining.has(argName)) {
+      i = skipBlock(lines, i + 1, argKeyIndent);
+      continue;
+    }
+
+    const blockStart = i + 1;
+    const blockEnd = skipBlock(lines, blockStart, argKeyIndent);
+    const propIndent = findPropIndent(lines, blockStart, blockEnd, argKeyIndent);
+    const defaultLineIdx = findDefaultLine(lines, blockStart, blockEnd, propIndent);
+    const newValueStr = formatYamlValue(updates[argName]);
+
+    // Refuse to touch block-scalar defaults — replacing the header line with
+    // an inline scalar would orphan the continuation lines as sibling keys.
+    if (defaultLineIdx !== -1 && BLOCK_SCALAR_DEFAULT_RE.test(lines[defaultLineIdx])) {
+      skippedExtra.push(argName);
+      remaining.delete(argName);
+      i = skipBlock(lines, i + 1, argKeyIndent);
+      continue;
+    }
+    // Refuse multi-line dumped values for the same orphan-line reason.
+    if (newValueStr.includes('\n')) {
+      skippedExtra.push(argName);
+      remaining.delete(argName);
+      i = skipBlock(lines, i + 1, argKeyIndent);
+      continue;
+    }
+
+    if (defaultLineIdx !== -1) {
+      lines[defaultLineIdx] = replaceDefaultValue(lines[defaultLineIdx], newValueStr);
+    } else {
+      const insertIndent = ' '.repeat(propIndent);
+      lines.splice(blockStart, 0, `${insertIndent}default: ${newValueStr}`);
+    }
+
+    updated.push(argName);
+    remaining.delete(argName);
+    i = skipBlock(lines, i + 1, argKeyIndent);
+  }
+
+  const joined = lines.join('\n');
+  const content = usesCRLF ? joined.replace(/\n/g, '\r\n') : joined;
+  return {
+    content,
+    updated,
+    skipped: [...remaining, ...skippedExtra],
+  };
+}
+
+function findArgumentsHeader(lines: readonly string[]): number {
+  for (let i = 0; i < lines.length; i++) {
+    if (leadingSpaces(lines[i]) === 0 && ARGUMENTS_HEADER_RE.test(lines[i].trim())) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function findArgKeyIndent(lines: readonly string[], headerIdx: number): number {
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const stripped = lines[i].trim();
+    if (!stripped || stripped.startsWith('#')) continue;
+    const indent = leadingSpaces(lines[i]);
+    if (indent === 0) return -1;
+    return indent;
+  }
+  return -1;
+}
+
+function findPropIndent(
+  lines: readonly string[],
+  blockStart: number,
+  blockEnd: number,
+  argKeyIndent: number,
+): number {
+  for (let j = blockStart; j < blockEnd; j++) {
+    const stripped = lines[j].trim();
+    if (!stripped || stripped.startsWith('#')) continue;
+    return leadingSpaces(lines[j]);
+  }
+  return argKeyIndent + 2;
+}
+
+function findDefaultLine(
+  lines: readonly string[],
+  blockStart: number,
+  blockEnd: number,
+  propIndent: number,
+): number {
+  for (let j = blockStart; j < blockEnd; j++) {
+    const stripped = lines[j].trim();
+    if (!stripped || stripped.startsWith('#')) continue;
+    if (leadingSpaces(lines[j]) !== propIndent) continue;
+    if (/^default\s*:/.test(stripped)) return j;
+  }
+  return -1;
+}
+
+function skipBlock(lines: readonly string[], start: number, parentIndent: number): number {
+  for (let i = start; i < lines.length; i++) {
+    const stripped = lines[i].trim();
+    if (!stripped || stripped.startsWith('#')) continue;
+    if (leadingSpaces(lines[i]) <= parentIndent) return i;
+  }
+  return lines.length;
+}
+
+function leadingSpaces(line: string): number {
+  let n = 0;
+  while (n < line.length && line[n] === ' ') n++;
+  return n;
+}
+
+function replaceDefaultValue(line: string, newValue: string): string {
+  const m = DEFAULT_LINE_RE.exec(line);
+  if (!m) return line;
+  const prefix = m[1];
+  const trailingComment = m[2] ?? '';
+  return `${prefix}${newValue}${trailingComment}`;
+}
+
+export function formatYamlValue(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+  const dumped = yaml.dump(value, {
+    flowLevel: 0,
+    lineWidth: -1,
+    noRefs: true,
+  }).replace(/\r?\n$/, '');
+  return dumped;
+}

--- a/src/cli/swarm/message-bus/write-through-adapter.ts
+++ b/src/cli/swarm/message-bus/write-through-adapter.ts
@@ -166,15 +166,16 @@ export class WriteThroughAdapter {
     }
   }
 
-  /**
-   * Wait for every fire-and-forget write currently in flight to settle.
-   * No-op when no writes are queued. Bounded by `Promise.allSettled` so a
-   * single hung write can't block forever (each individual write has its
-   * own daemon-write-client timeout).
-   */
+  // #1003 — yield to the microtask queue and re-check until pendingWrites
+  // settles. The single-snapshot pattern lost a race on fast hosts (Ubuntu CI)
+  // where a caller's awaited bus.sendUnified resolved before its `.then()`
+  // chain registered the write-through promise.
   async drainPendingWrites(): Promise<void> {
-    if (this.pendingWrites.size === 0) return;
-    await Promise.allSettled([...this.pendingWrites]);
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      if (this.pendingWrites.size === 0) return;
+      await Promise.allSettled([...this.pendingWrites]);
+    }
   }
 
   private onUnifiedMessage(event: UnifiedMessageEvent): void {


### PR DESCRIPTION
Closes #1003 (sister of merged #1002, both under epic #1004).

## Summary
- Adds a Y/N (default N) prompt at the end of a successful CLI cast asking whether to write user-supplied `--arg` values into the spell YAML's `arguments.<key>.default` fields.
- Skips when no `--arg` was passed, on dry-run, non-interactive sessions, cast failure, or for shipped spells (with a hint to copy to `spells/dev/` first).
- The YAML editor is line-level surgical (not a js-yaml round-trip) — comments, blank lines, and untouched keys are preserved verbatim.
- Block-scalar (`|`/`>`) and multi-line dumped values are refused with a `skipped` warning to avoid orphan-line data corruption.
- CRLF inputs are detected and restored on write.

## Ubuntu-CI flake fix bundled in
The previous PR (#1005) merged green but produced an intermittent failure on the post-merge `Consumer install smoke / ubuntu-latest` job: `populated:ephemeral-purged — purgeable rows leaked through #729 purge: hive-mind=6`.

Root cause: `flo doctor`'s `checkHiveMindFunctional` writes 6 hive-mind rows via the WriteThroughAdapter and relies on `hive-mind_shutdown`'s `clearNamespace` to clean up. `clearNamespace` calls `drainPendingWrites` which snapshotted `pendingWrites` synchronously — but writes scheduled via Promise-chain `.then()` callbacks weren't yet registered. Linux scheduled the writes fast enough that they landed AFTER `clearNamespace` finished. macOS/Windows hid the bug because the doctor process exited before those writes flushed at all.

Fix: `drainPendingWrites` now yields to the microtask queue and re-checks until `pendingWrites` stabilises (5-iteration cap). Microtask yield (`await Promise.resolve()`) is fake-timer compatible — `setImmediate` would have hung the existing `tests/hive-mind-messagebus.test.ts` suite.

## Test plan
- [x] `npm test` (8286/0 — full suite + isolation passes)
- [x] `npx tsc --noEmit` clean
- [x] New unit tests:
  - `yaml-defaults-writer.test.ts` (23 cases: round-trip, comment preservation, missing-default insertion, CRLF, block-scalar refusal, formatYamlValue)
  - `spell-tier.test.ts` (9 cases covering shipped vs user path heuristics)
  - `write-through-adapter-drain.test.ts` (5 cases including fake-timer compat + race regression)
  - +2 cases on `spell-tools-engine.test.ts` for the new `sourceFile`/`tier` response fields
- [ ] Watch CI on the PR — Ubuntu Consumer install smoke must go green and stay green

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)