### PR TITLE
feat(1007): auto-reject stale stored credentials

### DIFF
--- a/src/cli/__tests__/spells/credential-validation.test.ts
+++ b/src/cli/__tests__/spells/credential-validation.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for `validateStoredCredential` (#1007).
+ *
+ * Two heuristics, both conservative — only invalidate when the stored
+ * value is positively bad. Anything else passes through unchanged.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateStoredCredential } from '../../spells/core/credential-validation.js';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = base64url(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const body = base64url(JSON.stringify(payload));
+  return `${header}.${body}.signature-placeholder`;
+}
+
+function base64url(input: string): string {
+  return Buffer.from(input, 'utf-8').toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+describe('validateStoredCredential', () => {
+  describe('JWT-shaped values', () => {
+    it('passes when exp is in the future', () => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600; // +1h
+      const token = makeJwt({ sub: 'user', exp: futureExp });
+      expect(validateStoredCredential('GRAPH_ACCESS_TOKEN', token))
+        .toEqual({ valid: true });
+    });
+
+    it('rejects when exp is in the past with a humanized duration', () => {
+      const pastExp = Math.floor(Date.now() / 1000) - 7200; // -2h
+      const token = makeJwt({ sub: 'user', exp: pastExp });
+      const result = validateStoredCredential('GRAPH_ACCESS_TOKEN', token);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason).toMatch(/JWT expired/);
+        expect(result.reason).toMatch(/h/); // duration includes hours
+      }
+    });
+
+    it('passes when JWT has no exp claim (legacy/stateful tokens)', () => {
+      const token = makeJwt({ sub: 'user' });
+      expect(validateStoredCredential('GRAPH_ACCESS_TOKEN', token))
+        .toEqual({ valid: true });
+    });
+
+    it('passes when JWT payload fails to decode (conservative)', () => {
+      // Three valid-shape segments but middle is not valid base64-encoded JSON
+      const token = 'aGVhZGVy.bm90LWpzb24.c2ln';
+      expect(validateStoredCredential('TOKEN', token))
+        .toEqual({ valid: true });
+    });
+
+    it('passes when exp is non-numeric (treats as no-exp)', () => {
+      const token = makeJwt({ sub: 'user', exp: 'never' as unknown as number });
+      expect(validateStoredCredential('TOKEN', token))
+        .toEqual({ valid: true });
+    });
+
+    it('passes opaque API key (no JWT shape — not invalidated)', () => {
+      expect(validateStoredCredential('GITHUB_TOKEN', 'ghp_abc123def456'))
+        .toEqual({ valid: true });
+    });
+
+    it('passes a value with two dots that is not base64url (not JWT-shaped)', () => {
+      expect(validateStoredCredential('TOKEN', 'foo.bar.baz!'))
+        .toEqual({ valid: true });
+    });
+
+    it('passes a value with one dot (not 3 segments)', () => {
+      expect(validateStoredCredential('TOKEN', 'header.payload'))
+        .toEqual({ valid: true });
+    });
+  });
+
+  describe('_URL keys', () => {
+    it('passes a valid https webhook URL', () => {
+      expect(validateStoredCredential(
+        'SLACK_WEBHOOK_URL',
+        'https://hooks.slack.com/services/T0/B0/abc',
+      )).toEqual({ valid: true });
+    });
+
+    it('rejects raw garbage as URL', () => {
+      const result = validateStoredCredential('SLACK_WEBHOOK_URL', 'not-a-url');
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toMatch(/not a valid URL/);
+    });
+
+    it('rejects an empty-host URL', () => {
+      // A scheme-only URL has no host
+      const result = validateStoredCredential('FOO_URL', 'file:///');
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toMatch(/missing host/);
+    });
+
+    it('passes a non-_URL key even if the value is garbage (not validated)', () => {
+      expect(validateStoredCredential('OPAQUE_SECRET', 'not-a-url'))
+        .toEqual({ valid: true });
+    });
+  });
+});

--- a/src/cli/__tests__/spells/prerequisites-resolve.test.ts
+++ b/src/cli/__tests__/spells/prerequisites-resolve.test.ts
@@ -17,6 +17,19 @@ import type { PrerequisiteSpec } from '../../spells/types/spell-definition.types
 import { makePrereq } from './helpers/prereq-fixtures.js';
 import { makeCredentials } from './helpers.js';
 
+function base64url(input: string): string {
+  return Buffer.from(input, 'utf-8').toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function makeExpiredJwt(): string {
+  const header = base64url(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({ exp: Math.floor(Date.now() / 1000) - 7200 }));
+  return `${header}.${payload}.signature-placeholder`;
+}
+
 describe('resolveUnmetPrerequisites', () => {
   const ENV_KEY = 'FLO_RESOLVE_TEST_460';
 
@@ -350,6 +363,110 @@ describe('resolveUnmetPrerequisites', () => {
       expect(result.errorCode).toBeUndefined();
       expect(result.message).toContain('Missing prerequisites');
       expect(result.message).toContain('UNICORN_CLI');
+    });
+
+    // ==========================================================================
+    // Story #1007 — auto-reject stale stored credentials (JWT-exp + URL shape)
+    // ==========================================================================
+
+    it('rejects an expired stored JWT and falls through to the prompt path', async () => {
+      const KEY_EXP = 'CRED_EXPIRED_JWT_1007';
+      delete process.env[KEY_EXP];
+
+      const expiredJwt = makeExpiredJwt();
+      const prereq = compilePrerequisiteSpec({
+        name: 'GRAPH_ACCESS_TOKEN',
+        detect: { type: 'env', key: KEY_EXP },
+      });
+      const credentials = makeCredentials({ [KEY_EXP]: expiredJwt });
+      const responses = ['fresh-token', 'n']; // n = decline save offer
+      const promptLine = vi.fn<PromptLineFn>(async () => responses.shift() ?? '');
+      const logged: string[] = [];
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: (l) => logged.push(l),
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(process.env[KEY_EXP]).toBe('fresh-token');
+      // Banner explains why the stored value was rejected
+      expect(logged.some(l => l.includes(`Stored ${KEY_EXP} rejected`))).toBe(true);
+      expect(logged.some(l => l.includes('JWT expired'))).toBe(true);
+    });
+
+    it('rejects a malformed _URL stored value and falls through to the prompt path', async () => {
+      const KEY_URL = 'CRED_BAD_1007_URL';
+      delete process.env[KEY_URL];
+
+      const prereq = compilePrerequisiteSpec({
+        name: 'WEBHOOK',
+        detect: { type: 'env', key: KEY_URL },
+      });
+      const credentials = makeCredentials({ [KEY_URL]: 'not-a-url' });
+      const responses = ['https://hooks.example.com/x', 'n'];
+      const promptLine = vi.fn<PromptLineFn>(async () => responses.shift() ?? '');
+      const logged: string[] = [];
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: (l) => logged.push(l),
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(process.env[KEY_URL]).toBe('https://hooks.example.com/x');
+      expect(logged.some(l => l.includes(`Stored ${KEY_URL} rejected`))).toBe(true);
+      expect(logged.some(l => l.includes('not a valid URL'))).toBe(true);
+    });
+
+    it('non-TTY + expired stored JWT → MISSING_CREDENTIAL with rejection reason in the message', async () => {
+      const KEY_EXP_NI = 'CRED_EXPIRED_JWT_NI_1007';
+      delete process.env[KEY_EXP_NI];
+
+      const expiredJwt = makeExpiredJwt();
+      const prereq = compilePrerequisiteSpec({
+        name: 'TOKEN',
+        detect: { type: 'env', key: KEY_EXP_NI },
+      });
+      const credentials = makeCredentials({ [KEY_EXP_NI]: expiredJwt });
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: false,
+        credentials,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.errorCode).toBe('MISSING_CREDENTIAL');
+      expect(result.message).toContain('Stored value(s) rejected');
+      expect(result.message).toContain(KEY_EXP_NI);
+      expect(result.message).toContain('JWT expired');
+    });
+
+    it('does NOT reject an opaque (non-JWT, non-URL) stored value — passes through unchanged', async () => {
+      const KEY_OPAQUE = 'CRED_OPAQUE_1007';
+      delete process.env[KEY_OPAQUE];
+
+      const prereq = compilePrerequisiteSpec({
+        name: 'API_KEY',
+        detect: { type: 'env', key: KEY_OPAQUE },
+      });
+      const credentials = makeCredentials({ [KEY_OPAQUE]: 'sk_live_abc123' });
+      const promptLine = vi.fn<PromptLineFn>(async () => 'should-not-be-called');
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: () => {},
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(process.env[KEY_OPAQUE]).toBe('sk_live_abc123');
+      expect(promptLine).not.toHaveBeenCalled();
     });
 
     it('credentials.store rejection is logged but does not abort the cast', async () => {

--- a/src/cli/spells/core/credential-validation.ts
+++ b/src/cli/spells/core/credential-validation.ts
@@ -1,0 +1,93 @@
+/**
+ * Credential Validation
+ *
+ * Lightweight, no-config shape checks applied to values pulled from the
+ * encrypted credential store before they are promoted to `process.env`.
+ *
+ * Two heuristics, both conservative — only invalidate when there is
+ * positive evidence the stored value is bad. Anything we can't classify
+ * passes through unchanged.
+ *
+ *   - JWT-shaped values (3 base64url segments) get their `exp` claim
+ *     parsed and compared to "now". An expired JWT is reported as such.
+ *   - Env keys ending in `_URL` must parse via the WHATWG `URL`
+ *     constructor and have a non-empty host.
+ *
+ * Story #1007: avoid silently reusing stale stored credentials (e.g.
+ * Microsoft Graph access tokens, which expire in ~1h) so the resolver
+ * can fall through to the prompt path and the user understands why.
+ */
+
+const VALID_JWT_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+export type StoredCredentialValidation =
+  | { readonly valid: true }
+  | { readonly valid: false; readonly reason: string };
+
+export function validateStoredCredential(
+  envKey: string,
+  value: string,
+): StoredCredentialValidation {
+  if (envKey.endsWith('_URL')) {
+    return validateUrlValue(value);
+  }
+  if (looksLikeJwt(value)) {
+    return validateJwtExpiry(value);
+  }
+  return { valid: true };
+}
+
+function validateUrlValue(value: string): StoredCredentialValidation {
+  try {
+    const parsed = new URL(value);
+    if (!parsed.host) {
+      return { valid: false, reason: 'stored value is not a valid URL (missing host)' };
+    }
+    return { valid: true };
+  } catch {
+    return { valid: false, reason: 'stored value is not a valid URL' };
+  }
+}
+
+function looksLikeJwt(value: string): boolean {
+  const parts = value.split('.');
+  if (parts.length !== 3) return false;
+  return parts.every(p => p.length > 0 && VALID_JWT_SEGMENT.test(p));
+}
+
+function validateJwtExpiry(value: string): StoredCredentialValidation {
+  const exp = readJwtExp(value);
+  if (exp == null) return { valid: true };
+  const expiryMs = exp * 1000;
+  const now = Date.now();
+  if (expiryMs >= now) return { valid: true };
+  return { valid: false, reason: `JWT expired ${formatDuration(now - expiryMs)} ago` };
+}
+
+function readJwtExp(value: string): number | null {
+  try {
+    const payload = value.split('.')[1];
+    const padLen = (4 - (payload.length % 4)) % 4;
+    const b64 = payload.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat(padLen);
+    const decoded = Buffer.from(b64, 'base64').toString('utf-8');
+    const parsed: unknown = JSON.parse(decoded);
+    if (typeof parsed === 'object' && parsed !== null) {
+      const exp = (parsed as { exp?: unknown }).exp;
+      if (typeof exp === 'number' && Number.isFinite(exp)) return exp;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}

--- a/src/cli/spells/core/prerequisite-checker.ts
+++ b/src/cli/spells/core/prerequisite-checker.ts
@@ -26,6 +26,7 @@ import type {
 import type { StepCommandRegistry } from './step-command-registry.js';
 import { acquireTTYLock } from './tty-lock.js';
 import { readLineFromStdin } from './stdin-reader.js';
+import { validateStoredCredential } from './credential-validation.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -281,18 +282,26 @@ export async function resolveUnmetPrerequisites(
   // lets us skip a re-check of the cheap env detector.
   // `forceCredentialReprompt` bypasses this step so users can rotate or
   // correct stored credentials by re-running through the prompt path.
+  // Stored values are shape-validated (#1007): expired JWTs and malformed
+  // _URL values are rejected and surface in the preflight banner, so the
+  // resolver re-prompts instead of silently feeding garbage to the spell.
   const resolvedFromStoreNames: string[] = [];
   const storeResolved = new Set<number>();
+  const rejectedFromStore: Array<{ envKey: string; reason: string }> = [];
   if (credentials && !options.forceCredentialReprompt) {
     await Promise.all(unmetIndices.map(async (i) => {
       const prereq = prerequisites[i];
       if (!prereq.envKey) return;
       const stored = await credentials.get(prereq.envKey);
-      if (typeof stored === 'string' && stored.length > 0) {
-        process.env[prereq.envKey] = stored;
-        storeResolved.add(i);
-        resolvedFromStoreNames.push(prereq.name);
+      if (typeof stored !== 'string' || stored.length === 0) return;
+      const validation = validateStoredCredential(prereq.envKey, stored);
+      if (!validation.valid) {
+        rejectedFromStore.push({ envKey: prereq.envKey, reason: validation.reason });
+        return;
       }
+      process.env[prereq.envKey] = stored;
+      storeResolved.add(i);
+      resolvedFromStoreNames.push(prereq.name);
     }));
   }
 
@@ -314,7 +323,7 @@ export async function resolveUnmetPrerequisites(
     if (promptableEnvKeys.length > 0) {
       return {
         ok: false,
-        message: formatMissingCredentialMessage(promptableEnvKeys, stillUnmet),
+        message: formatMissingCredentialMessage(promptableEnvKeys, stillUnmet, rejectedFromStore),
         resolvedNames: resolvedFromStoreNames,
         errorCode: 'MISSING_CREDENTIAL',
         missingCredentials: promptableEnvKeys,
@@ -328,6 +337,12 @@ export async function resolveUnmetPrerequisites(
   }
 
   printPreflightBanner(log, stillUnmet.length);
+  if (rejectedFromStore.length > 0) {
+    for (const r of rejectedFromStore) {
+      log(`  Stored ${r.envKey} rejected — ${r.reason}. Re-enter below.`);
+    }
+    log('');
+  }
 
   const promptLine = options.promptLine ?? readLineFromStdin;
   const promptedNames: string[] = [];
@@ -410,12 +425,20 @@ export async function resolveUnmetPrerequisites(
 function formatMissingCredentialMessage(
   envKeys: readonly string[],
   prereqs: readonly Prerequisite[],
+  rejectedFromStore: ReadonlyArray<{ readonly envKey: string; readonly reason: string }>,
 ): string {
   const lines = ['Missing credentials (cannot prompt — non-interactive run):'];
   for (const key of envKeys) {
     const prereq = prereqs.find(p => p.envKey === key);
     const label = `${prereq?.name ?? key} (${key})`;
     appendPrereqLine(lines, label, prereq?.installHint, prereq?.url);
+  }
+  if (rejectedFromStore.length > 0) {
+    lines.push('');
+    lines.push('Stored value(s) rejected as stale or invalid:');
+    for (const r of rejectedFromStore) {
+      lines.push(`  - ${r.envKey}: ${r.reason}`);
+    }
   }
   lines.push('');
   lines.push('Prime these by casting the spell once interactively, or run:');


### PR DESCRIPTION
## Summary
- Closes #1007. Stored credentials are now shape-validated at read time inside `resolveUnmetPrerequisites` — expired JWTs and malformed `_URL` values fall through to the prompt path automatically, with a one-line reason in the preflight banner.
- No new flags, no YAML schema changes. Two conservative heuristics: JWT-`exp` check (only kicks in for true JWT-shaped values with a parseable `exp`) and URL-shape check for env keys ending in `_URL`. Everything else passes through unchanged.
- Non-TTY runs get the rejection reason embedded in the `MISSING_CREDENTIAL` error so unattended schedulers can surface why.

## Files
- **new** `src/cli/spells/core/credential-validation.ts` (~85 LOC, kept separate to keep `prerequisite-checker.ts` under the 500-line cap)
- **edit** `src/cli/spells/core/prerequisite-checker.ts` — wires validation into the existing `credentials.get(...)` block; banner + `MISSING_CREDENTIAL` message updated
- **new** `src/cli/__tests__/spells/credential-validation.test.ts` (12 unit tests — JWT future/expired/no-exp/malformed, URL valid/garbage/empty-host, opaque passthrough)
- **edit** `src/cli/__tests__/spells/prerequisites-resolve.test.ts` (4 new integration tests)

## Consumer impact
Backward compatible. Existing stored credentials that aren't JWT- or URL-shaped behave identically. Previously-silent 401s from expired Graph/Azure tokens now auto-prompt with no flag — strict improvement.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 8302 tests passed, 0 failed (parallel + isolation)
- [x] Targeted: `credential-validation.test.ts` (12) + `prerequisites-resolve.test.ts` (21) all green
- [x] /flo-simplify SMALL-tier review passed (no reuse gaps, no bugs, no efficiency issues)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)