### PR TITLE
feat(1009): reject non-JWT stored credentials when prereq declares format: jwt

### DIFF
--- a/spells/dev/outlook-attachment-processor.yaml
+++ b/spells/dev/outlook-attachment-processor.yaml
@@ -33,6 +33,7 @@ prerequisites:
       type: env
       key: GRAPH_ACCESS_TOKEN
     promptOnMissing: true
+    format: jwt
 
   - name: SLACK_WEBHOOK_URL
     description: >

--- a/src/cli/__tests__/spells/credential-validation.test.ts
+++ b/src/cli/__tests__/spells/credential-validation.test.ts
@@ -76,6 +76,55 @@ describe('validateStoredCredential', () => {
     });
   });
 
+  describe("declared format: 'jwt'", () => {
+    it('rejects a value with no dots even though the heuristic would pass it', () => {
+      const result = validateStoredCredential('GRAPH_ACCESS_TOKEN', 'opaque-no-dots', 'jwt');
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason).toMatch(/not a JWT/);
+        expect(result.reason).toMatch(/three base64url segments/);
+      }
+    });
+
+    it('rejects a value with two dots that is not base64url', () => {
+      const result = validateStoredCredential('GRAPH_ACCESS_TOKEN', 'foo.bar.baz!', 'jwt');
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects a value with one dot (not 3 segments)', () => {
+      const result = validateStoredCredential('GRAPH_ACCESS_TOKEN', 'header.payload', 'jwt');
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts a JWT-shaped value with no exp claim', () => {
+      const token = makeJwt({ sub: 'user' });
+      expect(validateStoredCredential('GRAPH_ACCESS_TOKEN', token, 'jwt'))
+        .toEqual({ valid: true });
+    });
+
+    it('rejects a JWT-shaped value with an expired exp claim', () => {
+      const pastExp = Math.floor(Date.now() / 1000) - 7200;
+      const token = makeJwt({ sub: 'user', exp: pastExp });
+      const result = validateStoredCredential('GRAPH_ACCESS_TOKEN', token, 'jwt');
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toMatch(/JWT expired/);
+    });
+
+    it('accepts a JWT-shaped value with a future exp claim', () => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const token = makeJwt({ sub: 'user', exp: futureExp });
+      expect(validateStoredCredential('GRAPH_ACCESS_TOKEN', token, 'jwt'))
+        .toEqual({ valid: true });
+    });
+
+    it('takes precedence over the _URL heuristic when both could apply', () => {
+      // Hypothetical key ending in _URL but declared as jwt — format wins.
+      const result = validateStoredCredential('SOMETHING_URL', 'not-a-jwt', 'jwt');
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.reason).toMatch(/not a JWT/);
+    });
+  });
+
   describe('_URL keys', () => {
     it('passes a valid https webhook URL', () => {
       expect(validateStoredCredential(

--- a/src/cli/__tests__/spells/prerequisites-resolve.test.ts
+++ b/src/cli/__tests__/spells/prerequisites-resolve.test.ts
@@ -469,6 +469,60 @@ describe('resolveUnmetPrerequisites', () => {
       expect(promptLine).not.toHaveBeenCalled();
     });
 
+    // ==========================================================================
+    // Story #1009 — author-declared format: 'jwt' rejects non-JWT stored values
+    // ==========================================================================
+
+    it('rejects a non-JWT stored value when format=jwt is declared (no dots)', async () => {
+      const KEY_FMT = 'CRED_FORMAT_JWT_1009';
+      delete process.env[KEY_FMT];
+
+      const prereq = compilePrerequisiteSpec({
+        name: 'GRAPH_ACCESS_TOKEN',
+        detect: { type: 'env', key: KEY_FMT },
+        format: 'jwt',
+      });
+      const credentials = makeCredentials({ [KEY_FMT]: 'opaque-no-dots' });
+      const responses = ['fresh.jwt.token', 'n'];
+      const promptLine = vi.fn<PromptLineFn>(async () => responses.shift() ?? '');
+      const logged: string[] = [];
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: true,
+        promptLine,
+        log: (l) => logged.push(l),
+        credentials,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(process.env[KEY_FMT]).toBe('fresh.jwt.token');
+      expect(logged.some(l => l.includes(`Stored ${KEY_FMT} rejected`))).toBe(true);
+      expect(logged.some(l => l.includes('not a JWT'))).toBe(true);
+    });
+
+    it('non-TTY + format=jwt non-JWT stored value → MISSING_CREDENTIAL', async () => {
+      const KEY_FMT_NI = 'CRED_FORMAT_JWT_NI_1009';
+      delete process.env[KEY_FMT_NI];
+
+      const prereq = compilePrerequisiteSpec({
+        name: 'GRAPH_ACCESS_TOKEN',
+        detect: { type: 'env', key: KEY_FMT_NI },
+        format: 'jwt',
+      });
+      const credentials = makeCredentials({ [KEY_FMT_NI]: 'opaque-no-dots' });
+
+      const result = await resolveUnmetPrerequisites([prereq], {
+        interactive: false,
+        credentials,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.errorCode).toBe('MISSING_CREDENTIAL');
+      expect(result.message).toContain('Stored value(s) rejected');
+      expect(result.message).toContain(KEY_FMT_NI);
+      expect(result.message).toContain('not a JWT');
+    });
+
     it('credentials.store rejection is logged but does not abort the cast', async () => {
       const prereq = compilePrerequisiteSpec({
         name: 'TOKEN',

--- a/src/cli/__tests__/spells/prerequisites-spec.test.ts
+++ b/src/cli/__tests__/spells/prerequisites-spec.test.ts
@@ -100,6 +100,15 @@ describe('compilePrerequisiteSpec', () => {
     });
     expect(compiled.promptOnMissing).toBe(false);
   });
+
+  it("forwards declared format to the compiled prereq", () => {
+    const compiled = compilePrerequisiteSpec({
+      name: 'GRAPH_ACCESS_TOKEN',
+      detect: { type: 'env', key: 'GRAPH_ACCESS_TOKEN' },
+      format: 'jwt',
+    });
+    expect(compiled.format).toBe('jwt');
+  });
 });
 
 describe('collectPrerequisites — YAML walker', () => {

--- a/src/cli/__tests__/spells/schema.test.ts
+++ b/src/cli/__tests__/spells/schema.test.ts
@@ -558,6 +558,50 @@ describe('validateSpellDefinition — prerequisites', () => {
     expect(result.errors.some(e => e.message.includes('detect.path is required'))).toBe(true);
   });
 
+  it('accepts format: jwt on an env-detect prerequisite', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      prerequisites: [{
+        name: 'TOKEN',
+        detect: { type: 'env', key: 'TOKEN' },
+        format: 'jwt',
+      }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects unknown format value', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      prerequisites: [{
+        name: 'TOKEN',
+        detect: { type: 'env', key: 'TOKEN' },
+        // @ts-expect-error intentionally wrong
+        format: 'magic',
+      }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.path.endsWith('.format'))).toBe(true);
+  });
+
+  it('rejects format on a non-env detector', () => {
+    const result = validateSpellDefinition({
+      name: 'x',
+      prerequisites: [{
+        name: 'TOKEN',
+        detect: { type: 'command', command: 'gh' },
+        format: 'jwt',
+      }],
+      steps: [minimalStep],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e =>
+      e.message.includes('format is only valid on env-type prerequisites'),
+    )).toBe(true);
+  });
+
   it('validates step-level prerequisites under step path', () => {
     const result = validateSpellDefinition({
       name: 'x',

--- a/src/cli/spells/core/credential-validation.ts
+++ b/src/cli/spells/core/credential-validation.ts
@@ -1,22 +1,28 @@
 /**
  * Credential Validation
  *
- * Lightweight, no-config shape checks applied to values pulled from the
- * encrypted credential store before they are promoted to `process.env`.
+ * Shape checks applied to values pulled from the encrypted credential store
+ * before they are promoted to `process.env`. Two layers:
  *
- * Two heuristics, both conservative — only invalidate when there is
- * positive evidence the stored value is bad. Anything we can't classify
- * passes through unchanged.
+ *   1. **Author-declared format** (preferred): the YAML prereq sets
+ *      `format: jwt`, and the validator enforces JWT shape + expiry. Any
+ *      non-JWT value (e.g. a value with no dots) is rejected outright,
+ *      catching the failure mode where a stored value isn't even a JWT
+ *      and the spell would otherwise fail mid-cast with a 401.
  *
- *   - JWT-shaped values (3 base64url segments) get their `exp` claim
- *     parsed and compared to "now". An expired JWT is reported as such.
- *   - Env keys ending in `_URL` must parse via the WHATWG `URL`
- *     constructor and have a non-empty host.
+ *   2. **Conservative heuristics** (fallback when no format is declared):
+ *        - JWT-shaped values (3 base64url segments) get their `exp` claim
+ *          parsed and rejected when expired.
+ *        - Env keys ending in `_URL` must parse via the WHATWG `URL`
+ *          constructor and have a non-empty host.
+ *      Anything else passes through.
  *
- * Story #1007: avoid silently reusing stale stored credentials (e.g.
- * Microsoft Graph access tokens, which expire in ~1h) so the resolver
- * can fall through to the prompt path and the user understands why.
+ * Story #1007: catch expired JWTs that survived past their TTL.
+ * Story #1009: extend to catch values that aren't even JWT-shaped when
+ * the prereq has declared `format: jwt`.
  */
+
+import type { PrerequisiteFormat } from '../types/spell-definition.types.js';
 
 const VALID_JWT_SEGMENT = /^[A-Za-z0-9_-]+$/;
 
@@ -27,7 +33,11 @@ export type StoredCredentialValidation =
 export function validateStoredCredential(
   envKey: string,
   value: string,
+  format?: PrerequisiteFormat,
 ): StoredCredentialValidation {
+  if (format === 'jwt') {
+    return validateJwtFormat(value);
+  }
   if (envKey.endsWith('_URL')) {
     return validateUrlValue(value);
   }
@@ -35,6 +45,16 @@ export function validateStoredCredential(
     return validateJwtExpiry(value);
   }
   return { valid: true };
+}
+
+function validateJwtFormat(value: string): StoredCredentialValidation {
+  if (!looksLikeJwt(value)) {
+    return {
+      valid: false,
+      reason: 'stored value is not a JWT (expected three base64url segments separated by ".")',
+    };
+  }
+  return validateJwtExpiry(value);
 }
 
 function validateUrlValue(value: string): StoredCredentialValidation {

--- a/src/cli/spells/core/prerequisite-checker.ts
+++ b/src/cli/spells/core/prerequisite-checker.ts
@@ -83,6 +83,7 @@ export function compilePrerequisiteSpec(spec: PrerequisiteSpec): Prerequisite {
     description: spec.description,
     promptOnMissing,
     envKey,
+    format: spec.format,
   };
 }
 
@@ -294,7 +295,7 @@ export async function resolveUnmetPrerequisites(
       if (!prereq.envKey) return;
       const stored = await credentials.get(prereq.envKey);
       if (typeof stored !== 'string' || stored.length === 0) return;
-      const validation = validateStoredCredential(prereq.envKey, stored);
+      const validation = validateStoredCredential(prereq.envKey, stored, prereq.format);
       if (!validation.valid) {
         rejectedFromStore.push({ envKey: prereq.envKey, reason: validation.reason });
         return;

--- a/src/cli/spells/schema/validators/prerequisites.ts
+++ b/src/cli/spells/schema/validators/prerequisites.ts
@@ -10,6 +10,7 @@ import type { ValidationError } from '../../types/step-command.types.js';
 import type { PrerequisiteSpec } from '../../types/spell-definition.types.js';
 
 const VALID_DETECT_TYPES = ['env', 'command', 'file'] as const;
+const VALID_FORMATS = ['jwt'] as const;
 
 export function validatePrerequisites(
   prereqs: readonly PrerequisiteSpec[],
@@ -46,6 +47,15 @@ export function validatePrerequisites(
     }
     if (p.promptOnMissing !== undefined && typeof p.promptOnMissing !== 'boolean') {
       errors.push({ path: `${pPath}.promptOnMissing`, message: 'promptOnMissing must be a boolean' });
+    }
+    if (
+      p.format !== undefined
+      && !VALID_FORMATS.includes(p.format as typeof VALID_FORMATS[number])
+    ) {
+      errors.push({
+        path: `${pPath}.format`,
+        message: `format must be one of: ${VALID_FORMATS.join(', ')}`,
+      });
     }
 
     const detect = p.detect as PrerequisiteSpec['detect'] | undefined;

--- a/src/cli/spells/schema/validators/prerequisites.ts
+++ b/src/cli/spells/schema/validators/prerequisites.ts
@@ -83,5 +83,14 @@ export function validatePrerequisites(
         errors.push({ path: `${pPath}.detect.path`, message: 'detect.path is required for file detector' });
       }
     }
+
+    // `format` only applies to stored env values — silently ignoring it on
+    // command/file detectors would mask author mistakes.
+    if (p.format !== undefined && detect.type !== 'env') {
+      errors.push({
+        path: `${pPath}.format`,
+        message: 'format is only valid on env-type prerequisites',
+      });
+    }
   });
 }

--- a/src/cli/spells/types/spell-definition.types.ts
+++ b/src/cli/spells/types/spell-definition.types.ts
@@ -111,6 +111,20 @@ export type PrerequisiteDetect =
   /** Satisfied when `path` exists on disk. */
   | { readonly type: 'file'; readonly path: string };
 
+/**
+ * Expected value format for a stored credential. Lets the resolver shape-check
+ * the value pulled from the credential store before promoting it to
+ * `process.env`, so a malformed value re-prompts instead of being silently
+ * fed to the spell.
+ *
+ *   - `'jwt'`: must be three non-empty base64url segments separated by `.`,
+ *     and (if an `exp` claim is present) not expired.
+ *
+ * Story #1009: extends #1007 to catch values that aren't even JWT-shaped
+ * (e.g. opaque strings stored under a key that requires a JWT).
+ */
+export type PrerequisiteFormat = 'jwt';
+
 /** YAML-declared prerequisite on a spell or step. */
 export interface PrerequisiteSpec {
   /** Stable name used for dedupe across spell + step + built-in sources. */
@@ -129,6 +143,15 @@ export interface PrerequisiteSpec {
    * Defaults to `true`.
    */
   readonly promptOnMissing?: boolean;
+  /**
+   * Declared format for env-type values. When set, stored values pulled from
+   * the credential store must match the declared shape or the resolver
+   * rejects them and re-prompts. Authors set this on prereqs whose API
+   * contract is unambiguous (e.g. Microsoft Graph `_ACCESS_TOKEN` is always
+   * a JWT). Without it, validation falls back to the conservative shape
+   * heuristics in `validateStoredCredential`.
+   */
+  readonly format?: PrerequisiteFormat;
 }
 
 /** Declarative preflight check in a step definition. */

--- a/src/cli/spells/types/step-command.types.ts
+++ b/src/cli/spells/types/step-command.types.ts
@@ -2,7 +2,7 @@
  * Spell Step Command Type Definitions
  */
 
-import type { PreflightSeverity, PreflightResolution } from './spell-definition.types.js';
+import type { PreflightSeverity, PreflightResolution, PrerequisiteFormat } from './spell-definition.types.js';
 
 // ============================================================================
 // Validation
@@ -196,6 +196,12 @@ export interface Prerequisite {
    * is what makes a prereq resolvable via prompt.
    */
   readonly envKey?: string;
+  /**
+   * Declared shape for stored values (e.g. `'jwt'`). Forwarded to
+   * `validateStoredCredential` so a malformed stored value re-prompts
+   * instead of silently feeding garbage to downstream steps.
+   */
+  readonly format?: PrerequisiteFormat;
 }
 
 /** Result of checking a single prerequisite. */


### PR DESCRIPTION
Closes #1009. Follow-up to #1007 / #1008.

## Summary

- #1008 only invalidates stored credentials that *parse as a JWT* with an expired `exp`. Values with **no dots** (or two dots that aren't base64url) fell through as `{valid: true}` and got promoted to `process.env`, where Microsoft Graph rejected them with `IDX14100: JWT is not well formed, there are no dots`. Same silent-401 UX as the bug #1007 was meant to close, just via a different code path.
- Adds author-declared `format: 'jwt'` on `PrerequisiteSpec`. When set, `validateStoredCredential` enforces JWT shape (three base64url segments) before running the existing expiry check, then the resolver re-prompts with the existing banner. Schema-driven so opaque-token prereqs (GitHub PATs etc.) keep passing through.
- Schema validator rejects `format` on non-env detectors (a `format: jwt` on a `command`/`file` prereq would be silently ignored — easy author mistake).
- Marks the OAP spell's `GRAPH_ACCESS_TOKEN` prereq with `format: jwt` (the actual report came from this spell).

## Consumer impact

Runtime fix in shipped code (`src/cli/spells/**` + `spells/dev/outlook-attachment-processor.yaml`) — needs publish + reinstall before consumers see it. Backward compatible: prereqs without `format` keep the #1007 heuristics unchanged.

## Test plan

- [x] `vitest run credential-validation` — 19 passing, including new "rejects no-dots / one-dot / two-dots-non-base64url with format=jwt" cases
- [x] `vitest run --config vitest.isolation.config.ts prerequisites-spec` — 12 passing, including `format` is forwarded by `compilePrerequisiteSpec`
- [x] `vitest run --config vitest.isolation.config.ts prerequisites-resolve` — 23 passing, including TTY re-prompt + non-TTY `MISSING_CREDENTIAL` for the new `format: jwt` rejection
- [x] `vitest run schema` — 51 passing (validator accepts `format: jwt`, rejects unknown values, rejects on non-env detectors)
- [x] `tsc --noEmit` clean
- [x] /flo-simplify: SMALL tier (1 sonnet reviewer) → schema guard finding fixed → validation pass clean

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)