### PR TITLE
fix(1013): silence bridge UNIQUE-recovered noise and ORT PCI bus warning

### DIFF
--- a/src/cli/embeddings/fastembed-inline/index.ts
+++ b/src/cli/embeddings/fastembed-inline/index.ts
@@ -166,6 +166,15 @@ export class FlagEmbedding {
     const session = await InferenceSession.create(modelPath, {
       executionProviders: ['cpu'],
       graphOptimizationLevel: 'all',
+      // Suppress ORT's WARNING-level chatter on session bring-up. ORT 1.26.0
+      // emits a `[W:onnxruntime ... GetPciBusId] Skipping pci_bus_id` line on
+      // Linux Azure VMs whose `/sys/devices/...` filenames don't match the
+      // `[0-9a-f]+:[0-9a-f]+:[0-9a-f]+.[0-9a-f]+` PCI pattern; the warning
+      // is harmless (we run on the CPU EP only) but leaks to stderr and
+      // confuses users into thinking moflo is broken. 0=verbose, 1=info,
+      // 2=warning (default), 3=error, 4=fatal — error is the right level
+      // because session bring-up genuine failures still surface.
+      logSeverityLevel: 3,
     });
     return new FlagEmbedding(tokenizer, session);
   }

--- a/src/cli/embeddings/fastembed-inline/index.ts
+++ b/src/cli/embeddings/fastembed-inline/index.ts
@@ -174,6 +174,11 @@ export class FlagEmbedding {
       // confuses users into thinking moflo is broken. 0=verbose, 1=info,
       // 2=warning (default), 3=error, 4=fatal — error is the right level
       // because session bring-up genuine failures still surface.
+      //
+      // Re-audit when bumping fastembed or onnxruntime-node: ORT
+      // occasionally promotes deprecation / model-compatibility notices to
+      // WARNING that would now be hidden. If a model upgrade ever lands
+      // alongside this suppression, drop to 2 once to scan the output.
       logSeverityLevel: 3,
     });
     return new FlagEmbedding(tokenizer, session);

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -200,6 +200,16 @@ export async function bridgeStoreEntry(options: {
     // a plain INSERT would trip UNIQUE and surface as `[moflo] bridge
     // operation failed:` stderr noise even though the data is durable.
     // Probe first so withDb never sees the throw.
+    //
+    // Limitations carried forward: only `content` is compared, not `tags`
+    // or `ttl`. The targeted scenario is the same caller's request being
+    // processed twice (daemon write + client retry), where every option is
+    // identical by definition — a different caller varying `tags` after a
+    // missed-ack would still see this as an idempotent no-op rather than
+    // an update. `cached: false, attested: false` because the prior writer
+    // already ran post-persist bookkeeping; this process's in-memory cache
+    // stays cold for one retrieve until the read path warms it (perf only,
+    // not correctness).
     if (!options.upsert) {
       let existingId: string | null = null;
       let existingContent: string | null = null;

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -194,6 +194,40 @@ export async function bridgeStoreEntry(options: {
     const { json: embeddingJson, dimensions, model } = resolved;
     const embeddingResponse = embeddingResponseFrom(resolved);
 
+    // Idempotency guard, mirrors the one in `memory-initializer.ts`'s raw-
+    // sql.js fallback. When the daemon route just wrote this exact row but
+    // the client missed the ack, we land here with the row already on disk;
+    // a plain INSERT would trip UNIQUE and surface as `[moflo] bridge
+    // operation failed:` stderr noise even though the data is durable.
+    // Probe first so withDb never sees the throw.
+    if (!options.upsert) {
+      let existingId: string | null = null;
+      let existingContent: string | null = null;
+      const probe = ctx.db.prepare(
+        `SELECT id, content FROM memory_entries WHERE namespace = ? AND key = ? AND status = 'active' LIMIT 1`,
+      );
+      try {
+        probe.bind([namespace, key]);
+        if (probe.step()) {
+          const row = probe.getAsObject() as { id: string; content: string };
+          existingId = String(row.id);
+          existingContent = row.content;
+        }
+      } finally {
+        probe.free();
+      }
+      if (existingId && existingContent === value) {
+        return {
+          success: true,
+          id: existingId,
+          embedding: embeddingResponse,
+          guarded: true,
+          cached: false,
+          attested: false,
+        };
+      }
+    }
+
     const insertSql = options.upsert
       ? `INSERT OR REPLACE INTO memory_entries (
           id, key, namespace, content, type,


### PR DESCRIPTION
Closes #1013. Cleanup after #1011/#1012.

## Summary

Two stderr-noise sources surviving the storeEntry idempotency fix in #1012:

1. `[moflo] bridge operation failed: UNIQUE constraint failed:` — when the client's bridgeStoreEntry hits UNIQUE on its INSERT (because the daemon route just wrote the row), `withDb`'s catch block logs to stderr before storeEntry's raw-sql.js fallback recovers. The CLI exits 0 but the noise is still visible.
2. `[W:onnxruntime ... GetPciBusId] Skipping pci_bus_id...` — ORT 1.26.0 emits this WARNING on Linux Azure VMs (e.g. ubuntu CI runners) when `/sys/devices/...` filenames don't match its expected PCI pattern. Harmless on the CPU EP but confusing to users.

## Fix

1. `bridgeStoreEntry` now probes for an existing `(namespace, key)` row before INSERT — same pattern as the storeEntry fallback in #1011. When the row exists with the caller's value (and `upsert` is false), bridge returns success immediately. `withDb` never sees a throw, no stderr leak.
2. `InferenceSession.create` in fastembed-inline now passes `logSeverityLevel: 3` (ERROR). Genuine session failures still surface; PCI bus chatter doesn't.

Documented limitations:
- Bridge probe only compares `content`, not `tags`/`ttl` (symmetric with the existing fallback probe — only matters for future callers who vary tags after a missed ack).
- Early-return path skips cache/attestation/stats bookkeeping; the prior writer already ran them. Cache stays cold for one retrieve in this process (perf only, not correctness).
- `logSeverityLevel: 3` could hide ORT deprecation/model-compat warnings on future fastembed/ORT bumps. Re-audit at level 2 when bumping.

## Consumer impact

Runtime fix in shipped code (`src/cli/memory/bridge-entries.ts`, `src/cli/embeddings/fastembed-inline/index.ts`). Needs publish + reinstall before consumers see clean console output.

## Test plan

- [x] Existing 8 store-entry-routing tests still pass (matching-content idempotency assertion already covers the bridge probe path)
- [x] `bridge-entries` + `fastembed-embedding-service` test suites pass
- [x] `tsc --noEmit` clean
- [x] /flo-simplify SMALL tier; reviewer flagged 3 items; all 3 documented inline as limitations rather than fixed (edge-case or perf-only)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)