### PR TITLE
fix(1016): wire memory into spell_cast so flo runs appear in Luminarium

### DIFF
--- a/src/cli/mcp-tools/spell-tools.ts
+++ b/src/cli/mcp-tools/spell-tools.ts
@@ -94,21 +94,23 @@ function trackResult(tracked: TrackedSpell, result: SpellResult): void {
 // the missing link.
 // ============================================================================
 
-let memoryAccessor: MemoryAccessor | null = null;
-let memoryInitFailed = false;
+// Promise-memoized so two concurrent first-casts share a single init —
+// otherwise both would open their own DB handle and the loser's accessor
+// would leak.
+let memoryAccessorPromise: Promise<MemoryAccessor | null> | null = null;
 
-async function getMemoryAccessor(): Promise<MemoryAccessor | null> {
-  if (memoryAccessor) return memoryAccessor;
-  if (memoryInitFailed) return null;
-  try {
-    memoryAccessor = await createDashboardMemoryAccessor();
-    return memoryAccessor;
-  } catch (err) {
-    memoryInitFailed = true;
-    console.warn(`[spell-tools] memory accessor unavailable: ${(err as Error).message ?? err}`);
-    console.warn('[spell-tools] spell runs will NOT appear in The Luminarium');
-    return null;
-  }
+function getMemoryAccessor(): Promise<MemoryAccessor | null> {
+  if (memoryAccessorPromise) return memoryAccessorPromise;
+  memoryAccessorPromise = (async () => {
+    try {
+      return await createDashboardMemoryAccessor();
+    } catch (err) {
+      console.warn(`[spell-tools] memory accessor unavailable: ${(err as Error).message ?? err}`);
+      console.warn('[spell-tools] spell runs will NOT appear in The Luminarium');
+      return null;
+    }
+  })();
+  return memoryAccessorPromise;
 }
 
 /** Execute a definition via the engine with tracking and error handling. */

--- a/src/cli/mcp-tools/spell-tools.ts
+++ b/src/cli/mcp-tools/spell-tools.ts
@@ -21,6 +21,8 @@ import { findProjectRoot } from '../services/project-root.js';
 import { buildGrimoire } from '../services/grimoire-builder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { inferSpellTier, type SpellTier } from '../spells/core/spell-tier.js';
+import { createDashboardMemoryAccessor } from '../services/daemon-dashboard.js';
+import type { MemoryAccessor } from '../spells/types/step-command.types.js';
 
 
 // ============================================================================
@@ -84,6 +86,31 @@ function trackResult(tracked: TrackedSpell, result: SpellResult): void {
   tracked.completedAt = new Date().toISOString();
 }
 
+// ============================================================================
+// Memory accessor (lazy, cached) — #1016
+// Without this, runner.storeProgress() writes go to noopMemory and the
+// Luminarium's "Flo Runs" tab never sees flo run / spell_cast invocations.
+// Epic runs already wire this via runner-adapter.ts; MCP spell tools were
+// the missing link.
+// ============================================================================
+
+let memoryAccessor: MemoryAccessor | null = null;
+let memoryInitFailed = false;
+
+async function getMemoryAccessor(): Promise<MemoryAccessor | null> {
+  if (memoryAccessor) return memoryAccessor;
+  if (memoryInitFailed) return null;
+  try {
+    memoryAccessor = await createDashboardMemoryAccessor();
+    return memoryAccessor;
+  } catch (err) {
+    memoryInitFailed = true;
+    console.warn(`[spell-tools] memory accessor unavailable: ${(err as Error).message ?? err}`);
+    console.warn('[spell-tools] spell runs will NOT appear in The Luminarium');
+    return null;
+  }
+}
+
 /** Execute a definition via the engine with tracking and error handling. */
 async function executeAndTrack(
   engine: EngineModule,
@@ -100,10 +127,12 @@ async function executeAndTrack(
 
   try {
     const sandboxConfig = await engine.loadSandboxConfigFromProject(findProjectRoot());
+    const memory = await getMemoryAccessor();
     const result = await engine.bridgeExecuteSpell(definition, args, {
       spellId,
       sandboxConfig,
       forceCredentialReprompt: options.forceCredentialReprompt,
+      ...(memory ? { memory } : {}),
     });
     trackResult(tracked, result);
     return withSpellSource(serializeResult(result), options.sourceFile, options.tier);


### PR DESCRIPTION
## Summary

Closes #1016.

`flo run <spell>` (alias of `flo spell cast`) was invisible in The Luminarium's **Flo Runs** tab. Epic runs appeared; plain spell runs didn't.

**Root cause:** the MCP `spell_cast` handler invoked `bridgeExecuteSpell` without passing a `MemoryAccessor`. `runner-factory` fell back to `noopMemory`, so `runner.storeProgress()` writes to the `tasklist` namespace went nowhere. Epic runs worked because `runner-adapter.ts` wires its own accessor via `createDashboardMemoryAccessor()`.

**Fix:** lazy-init `createDashboardMemoryAccessor()` once per MCP-server lifetime in `spell-tools.ts` and thread it through `executeAndTrack` → `bridgeExecuteSpell`. Mirrors the epic-adapter pattern. Promise-memoized so concurrent first-casts share one init (caught by /flo-simplify review). If init fails, log a clear warning and continue.

## Verification

- Built dist, copied `spell-tools.js` into the dogfood `node_modules/moflo`, restarted daemon.
- Ran `flo run wqp` (smoke spell). Run appeared in `/api/spells` with full step detail (`spellId`, `spellName`, status, steps, duration, error).
- Before the fix: 0 executions for non-epic casts. After: 6 executions including the new run.

## Test plan

- [x] `npm run build` clean
- [x] `vitest run src/cli/__tests__/spell-tools-engine.test.ts src/cli/__tests__/daemon-dashboard.test.ts` — 65/65
- [x] `vitest run src/cli/__tests__/spells/runner-bridge.test.ts --config vitest.isolation.config.ts` — 14/14
- [x] Live verification via `/api/spells`

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)