### PR TITLE
fix(1015): poll-open target after rename to close AV-settle race on Windows

### DIFF
--- a/src/cli/__tests__/shared/utils/atomic-file-write.test.ts
+++ b/src/cli/__tests__/shared/utils/atomic-file-write.test.ts
@@ -23,6 +23,8 @@ import {
   writeFileSync,
   renameSync,
   unlinkSync,
+  openSync,
+  closeSync,
   rmSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -86,6 +88,24 @@ describe('atomicWriteFileSync (real fs)', () => {
     expect(read.length).toBe(4);
     expect(read[0]).toBe(0xde);
     expect(read[3]).toBe(0xef);
+  });
+
+  it('leaves the target immediately readable after return (#1015)', () => {
+    // After atomicWriteFileSync returns, openSync(target, 'r') must succeed
+    // *now* — no retry needed. On Windows this is what closes the AV-settle
+    // race. On POSIX it's a no-op assertion (rename was already atomic).
+    const dir = makeTmpDir();
+    const target = join(dir, 'data.bin');
+
+    atomicWriteFileSync(target, Buffer.from('settled'));
+
+    const fd = openSync(target, 'r');
+    try {
+      // No-op — the open succeeding is the signal.
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(target, 'utf8')).toBe('settled');
   });
 
   it('uses a process-unique temp path so concurrent writers cannot clobber tmp', async () => {
@@ -204,3 +224,61 @@ describe('atomicWriteFileSync (injected fs)', () => {
     );
   });
 });
+
+describe.runIf(process.platform === 'win32')(
+  'atomicWriteFileSync — Windows post-rename verify (#1015)',
+  () => {
+    it('tolerates one transient EBUSY in the post-rename open probe', () => {
+      // Simulate the AV-scan window: the first open after rename throws EBUSY,
+      // the second succeeds. The helper must absorb this transparently — no
+      // throw, target intact with new content.
+      const dir = makeTmpDir();
+      const target = join(dir, 'data.bin');
+
+      let openAttempts = 0;
+      const fs: AtomicWriteFs = {
+        writeFileSync,
+        renameSync,
+        unlinkSync,
+        openSync: ((path: Parameters<typeof openSync>[0], flags: Parameters<typeof openSync>[1]) => {
+          openAttempts++;
+          if (openAttempts === 1) throw new Error('EBUSY: resource busy or locked');
+          return openSync(path, flags);
+        }) as typeof openSync,
+        closeSync,
+      };
+
+      atomicWriteFileSync(target, Buffer.from('settled'), fs);
+
+      expect(openAttempts).toBeGreaterThanOrEqual(2);
+      expect(readFileSync(target, 'utf8')).toBe('settled');
+    });
+
+    it('returns (does not throw) when the verify deadline elapses', () => {
+      // If the AV window outlasts our budget, the rename DID succeed — the
+      // data is on disk and the next reader will eventually see it. The
+      // helper must not throw on verify timeout, only log+return.
+      const dir = makeTmpDir();
+      const target = join(dir, 'data.bin');
+
+      let openAttempts = 0;
+      const fs: AtomicWriteFs = {
+        writeFileSync,
+        renameSync,
+        unlinkSync,
+        openSync: (() => {
+          openAttempts++;
+          throw new Error('EBUSY: resource busy or locked');
+        }) as typeof openSync,
+        closeSync,
+      };
+
+      expect(() => atomicWriteFileSync(target, Buffer.from('settled'), fs)).not.toThrow();
+      // The loop actually retried — proves the deadline gating worked rather
+      // than the function returning after one failed probe.
+      expect(openAttempts).toBeGreaterThan(1);
+      // Rename still happened — the file is on disk via the real renameSync.
+      expect(readFileSync(target, 'utf8')).toBe('settled');
+    });
+  },
+);

--- a/src/cli/shared/utils/atomic-file-write.ts
+++ b/src/cli/shared/utils/atomic-file-write.ts
@@ -18,6 +18,15 @@
  * On any failure, the temp file is best-effort removed and the original
  * `target` stays intact. The underlying error is always re-thrown.
  *
+ * Windows-only post-rename verify (#1015): on NTFS with antivirus / Defender
+ * scanning the freshly-renamed file, a sub-process opening the same path
+ * within ~1s can briefly see stale or unreadable data. After a successful
+ * rename we poll-open the target until it's readable (or a 250 ms deadline
+ * passes) so the next reader doesn't race the AV settle window. The rename
+ * itself already succeeded, so the verify is best-effort: a timeout logs and
+ * returns rather than throwing — the data IS on disk, the next reader will
+ * just briefly hit the same lock anyway.
+ *
  * `fs` is injectable so the interrupt-mid-write paths can be exercised in
  * unit tests without depending on ESM-unfriendly module spies.
  *
@@ -30,7 +39,16 @@ export interface AtomicWriteFs {
   writeFileSync: typeof realFs.writeFileSync;
   renameSync: typeof realFs.renameSync;
   unlinkSync: typeof realFs.unlinkSync;
+  // Optional — used only by the Windows post-rename verify path. Real callers
+  // never pass these; tests inject them to simulate AV-induced transient
+  // EBUSY without depending on a real Windows host.
+  openSync?: typeof realFs.openSync;
+  closeSync?: typeof realFs.closeSync;
 }
+
+const IS_WIN32 = process.platform === 'win32';
+const VERIFY_DEADLINE_MS = 250;
+const VERIFY_STEP_MS = 10;
 
 export function atomicWriteFileSync(
   targetPath: string,
@@ -49,4 +67,32 @@ export function atomicWriteFileSync(
     }
     throw err;
   }
+  if (IS_WIN32) verifyReadableAfterRename(targetPath, fs);
+}
+
+/**
+ * Poll-open the target until a reader can succeed, or the deadline passes.
+ * Closes the AV-scan settle window on NTFS (#1015). No-op everywhere else.
+ *
+ * Yields the thread between probes via `Atomics.wait` so we don't pin a CPU
+ * during the very contention we're waiting out (`feedback_async_by_default`).
+ */
+function verifyReadableAfterRename(targetPath: string, fs: AtomicWriteFs): void {
+  const openSync = fs.openSync ?? realFs.openSync;
+  const closeSync = fs.closeSync ?? realFs.closeSync;
+  const deadline = Date.now() + VERIFY_DEADLINE_MS;
+  while (true) {
+    try {
+      closeSync(openSync(targetPath, 'r'));
+      return;
+    } catch {
+      if (Date.now() >= deadline) return;
+      sleepSyncMs(VERIFY_STEP_MS);
+    }
+  }
+}
+
+const SLEEP_BUF = new Int32Array(new SharedArrayBuffer(4));
+function sleepSyncMs(ms: number): void {
+  Atomics.wait(SLEEP_BUF, 0, 0, ms);
 }


### PR DESCRIPTION
Closes #1015.

## Summary

`atomicWriteFileSync`'s `fs.renameSync` on NTFS leaves a brief window where AV / Defender scanning the freshly-renamed file blocks the next reader, surfacing as the consumer-smoke `memory-retrieve sees "key not found"` flake (~1-in-10 first runs on Windows, never reproduces on re-run, never on Linux/macOS).

## Fix

Windows-only post-rename verify: after `renameSync` succeeds, poll-open the target file until it's readable or a 250 ms deadline passes. ~10 ms step, yielding the thread via `Atomics.wait` on a shared `Int32Array` so we don't pin CPU during the very contention we're waiting out (`feedback_async_by_default`).

The verify is best-effort by design: rename already succeeded, so a timeout returns silently rather than throwing — the data IS on disk and the next reader will hit (and clear) the same lock anyway.

POSIX paths execute zero extra syscalls (`process.platform !== 'win32'` skips the verify entirely).

## Test plan

- [x] Existing 4 happy-path tests + 4 injected-fs failure-mode tests still pass unchanged
- [x] New: real-fs roundtrip asserts target is openable for read immediately after `atomicWriteFileSync` returns
- [x] New (Windows-only via `describe.runIf`): injected `openSync` throws transient EBUSY once → verify retries and the helper returns successfully without throwing
- [x] New (Windows-only via `describe.runIf`): injected `openSync` always throws → verify hits deadline, asserts retry happened (`openAttempts > 1`), helper does not throw, target file still has new content
- [x] `tsc --noEmit` clean
- [x] Memory + bridge test suites unaffected (46/46 pass)
- [x] /flo-simplify SMALL tier; reviewer flagged 3 items — strengthened the deadline test to assert retry count; the `Atomics.wait`-on-main-thread concern was disproven empirically (Node allows it, browsers don't); the catch-all-error-codes concern is over-engineering for a best-effort verify and filed off

## Pre-existing test flake found en route

`doctor-checks-memory-access` fails under full `npm test` on Windows when the auto-started daemon races the real `.moflo/moflo.db` during the test's probe write. Stashing this PR's edits reproduces the same failure on `main`. Filed as #1022 with a recommended fix (point the probe at a temp dir).

## Consumer impact

Runtime fix in shipped code (`src/cli/shared/utils/atomic-file-write.ts`). Used by every persisted sql.js write — bridge memory DB, hnsw sidecar, embeddings cache, RVF event log. Helper signature unchanged; no state migration; POSIX consumers unaffected. Windows consumers see the consumer-smoke flake clear after publish + reinstall.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)