### PR TITLE
chore(1018): suppress Windows EBUSY rmSync warnings during consumer-smoke cleanup

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -1175,12 +1175,15 @@ function killDaemonByLockFile(consumerDir) {
  * noise. Other failures (EPERM, EACCES, ENOENT, *anything* on POSIX) are
  * still real signals worth surfacing.
  *
+ * Matches against `err.code` (the canonical, locale-proof Node SystemError
+ * field) rather than the human-readable `err.message` text.
+ *
  * Exported so the classifier can be unit-tested without standing up a real
  * workdir + daemon. `platform` is a parameter so tests can exercise the
  * POSIX branch on Windows hosts and vice-versa.
  */
 export function isKnownWindowsCleanupQuirk(err, platform) {
-  return platform === 'win32' && /\bEBUSY\b/.test(err?.message ?? '');
+  return platform === 'win32' && err?.code === 'EBUSY';
 }
 
 export async function cleanupWorkDir(workDir, { keep }) {

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -1166,6 +1166,23 @@ function killDaemonByLockFile(consumerDir) {
   }
 }
 
+/**
+ * #1018: After cleanupWorkDir's 2.5s retry budget, a Windows EBUSY on rmSync
+ * is a known platform quirk — AV scans, Windows indexer, and OS handle
+ * release latency can keep the dir locked past our patience. CI runners are
+ * ephemeral and the next run uses a fresh `consumer-<timestamp>` dir, so the
+ * leftover dir doesn't poison subsequent tests. The warning was pure log
+ * noise. Other failures (EPERM, EACCES, ENOENT, *anything* on POSIX) are
+ * still real signals worth surfacing.
+ *
+ * Exported so the classifier can be unit-tested without standing up a real
+ * workdir + daemon. `platform` is a parameter so tests can exercise the
+ * POSIX branch on Windows hosts and vice-versa.
+ */
+export function isKnownWindowsCleanupQuirk(err, platform) {
+  return platform === 'win32' && /\bEBUSY\b/.test(err?.message ?? '');
+}
+
 export async function cleanupWorkDir(workDir, { keep }) {
   if (keep) {
     log(`\nKept: ${workDir}`);
@@ -1181,7 +1198,9 @@ export async function cleanupWorkDir(workDir, { keep }) {
     try {
       rmSync(full, { recursive: true, force: true, maxRetries: 5, retryDelay: 500 });
     } catch (err) {
-      log(`  warning: could not remove ${name}: ${err.message}`);
+      if (!isKnownWindowsCleanupQuirk(err, process.platform)) {
+        log(`  warning: could not remove ${name}: ${err.message}`);
+      }
     }
   }
 }

--- a/tests/harness/cleanup-quirk.test.ts
+++ b/tests/harness/cleanup-quirk.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for `isKnownWindowsCleanupQuirk` in harness/consumer-smoke/lib/checks.mjs (#1018).
+ *
+ * The classifier decides whether `cleanupWorkDir` should swallow a stray
+ * post-retry rmSync error: yes for Windows EBUSY (known platform quirk
+ * already covered by the retry budget + ephemeral CI runners), no for
+ * everything else.
+ */
+import { describe, it, expect } from 'vitest';
+// .mjs ESM module — vitest resolves the relative path from project root.
+// @ts-ignore — JS module without .d.ts.
+import { isKnownWindowsCleanupQuirk } from '../../harness/consumer-smoke/lib/checks.mjs';
+
+describe('isKnownWindowsCleanupQuirk (#1018)', () => {
+  it('returns true for Windows + EBUSY (the case we suppress)', () => {
+    const err = new Error('EBUSY: resource busy or locked, rmdir');
+    expect(isKnownWindowsCleanupQuirk(err, 'win32')).toBe(true);
+  });
+
+  it('returns false for Windows + EPERM (a real signal worth warning on)', () => {
+    const err = new Error('EPERM: operation not permitted, unlink');
+    expect(isKnownWindowsCleanupQuirk(err, 'win32')).toBe(false);
+  });
+
+  it('returns false for Windows + EACCES', () => {
+    const err = new Error('EACCES: permission denied');
+    expect(isKnownWindowsCleanupQuirk(err, 'win32')).toBe(false);
+  });
+
+  it('returns false for POSIX + EBUSY (no Windows AV/indexer story to excuse it)', () => {
+    const err = new Error('EBUSY: resource busy or locked');
+    expect(isKnownWindowsCleanupQuirk(err, 'linux')).toBe(false);
+    expect(isKnownWindowsCleanupQuirk(err, 'darwin')).toBe(false);
+  });
+
+  it('returns false for an error with no message field', () => {
+    expect(isKnownWindowsCleanupQuirk({}, 'win32')).toBe(false);
+    expect(isKnownWindowsCleanupQuirk(null, 'win32')).toBe(false);
+    expect(isKnownWindowsCleanupQuirk(undefined, 'win32')).toBe(false);
+  });
+
+  it('matches EBUSY only on word boundaries (avoids false positives on substrings)', () => {
+    // A theoretical error whose message merely *contains* "EBUSY" as part of
+    // another token shouldn't qualify — only standalone EBUSY does.
+    const err = new Error('NOTEBUSYY: something else');
+    expect(isKnownWindowsCleanupQuirk(err, 'win32')).toBe(false);
+  });
+});

--- a/tests/harness/cleanup-quirk.test.ts
+++ b/tests/harness/cleanup-quirk.test.ts
@@ -5,44 +5,59 @@
  * post-retry rmSync error: yes for Windows EBUSY (known platform quirk
  * already covered by the retry budget + ephemeral CI runners), no for
  * everything else.
+ *
+ * Matches against `err.code` (the canonical Node SystemError field), so
+ * tests construct synthetic errors with explicit `code` properties.
  */
 import { describe, it, expect } from 'vitest';
 // .mjs ESM module — vitest resolves the relative path from project root.
 // @ts-ignore — JS module without .d.ts.
 import { isKnownWindowsCleanupQuirk } from '../../harness/consumer-smoke/lib/checks.mjs';
 
+function fsErr(code: string, message = `${code}: simulated`): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
 describe('isKnownWindowsCleanupQuirk (#1018)', () => {
   it('returns true for Windows + EBUSY (the case we suppress)', () => {
-    const err = new Error('EBUSY: resource busy or locked, rmdir');
-    expect(isKnownWindowsCleanupQuirk(err, 'win32')).toBe(true);
+    expect(isKnownWindowsCleanupQuirk(fsErr('EBUSY'), 'win32')).toBe(true);
   });
 
   it('returns false for Windows + EPERM (a real signal worth warning on)', () => {
-    const err = new Error('EPERM: operation not permitted, unlink');
-    expect(isKnownWindowsCleanupQuirk(err, 'win32')).toBe(false);
+    expect(isKnownWindowsCleanupQuirk(fsErr('EPERM'), 'win32')).toBe(false);
   });
 
   it('returns false for Windows + EACCES', () => {
-    const err = new Error('EACCES: permission denied');
-    expect(isKnownWindowsCleanupQuirk(err, 'win32')).toBe(false);
+    expect(isKnownWindowsCleanupQuirk(fsErr('EACCES'), 'win32')).toBe(false);
+  });
+
+  it('returns false for Windows + ENOENT', () => {
+    expect(isKnownWindowsCleanupQuirk(fsErr('ENOENT'), 'win32')).toBe(false);
   });
 
   it('returns false for POSIX + EBUSY (no Windows AV/indexer story to excuse it)', () => {
-    const err = new Error('EBUSY: resource busy or locked');
-    expect(isKnownWindowsCleanupQuirk(err, 'linux')).toBe(false);
-    expect(isKnownWindowsCleanupQuirk(err, 'darwin')).toBe(false);
+    expect(isKnownWindowsCleanupQuirk(fsErr('EBUSY'), 'linux')).toBe(false);
+    expect(isKnownWindowsCleanupQuirk(fsErr('EBUSY'), 'darwin')).toBe(false);
   });
 
-  it('returns false for an error with no message field', () => {
-    expect(isKnownWindowsCleanupQuirk({}, 'win32')).toBe(false);
+  it('returns false for an error with no code field', () => {
+    // Ordinary Error with no .code — must not be classified as the quirk.
+    const plain = new Error('something went wrong');
+    expect(isKnownWindowsCleanupQuirk(plain, 'win32')).toBe(false);
+  });
+
+  it('returns false for null / undefined err (defensive)', () => {
     expect(isKnownWindowsCleanupQuirk(null, 'win32')).toBe(false);
     expect(isKnownWindowsCleanupQuirk(undefined, 'win32')).toBe(false);
   });
 
-  it('matches EBUSY only on word boundaries (avoids false positives on substrings)', () => {
-    // A theoretical error whose message merely *contains* "EBUSY" as part of
-    // another token shouldn't qualify — only standalone EBUSY does.
-    const err = new Error('NOTEBUSYY: something else');
+  it('does not match on err.message containing EBUSY when err.code differs', () => {
+    // Guards against reverting to message-based matching: an error whose
+    // message text mentions EBUSY but whose canonical code is something
+    // else MUST NOT be classified as the quirk.
+    const err = fsErr('EPERM', 'EPERM: operation not permitted (was: EBUSY earlier)');
     expect(isKnownWindowsCleanupQuirk(err, 'win32')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Suppresses the cosmetic `warning: could not remove consumer-…: EBUSY …` log line that pollutes Windows CI consumer-smoke output
- EBUSY-post-retry-budget on Windows is a known platform quirk (AV scans, indexer, OS handle release latency) — the dir leak is harmless because CI runners are ephemeral and each run uses a fresh `consumer-<timestamp>` dir
- Other failures (EPERM, EACCES, anything on POSIX) still warn — those are real signals worth surfacing

## Approach

Extracted a tiny pure `isKnownWindowsCleanupQuirk(err, platform)` helper from `cleanupWorkDir` and gated the warning behind it. The classifier matches against `err.code` (the canonical, locale-proof Node SystemError field) — simpler and tighter than regexing the human-readable message.

The `platform` parameter is injected so tests exercise both branches on any host.

## Blast radius

`harness/consumer-smoke/lib/checks.mjs` is moflo's internal CI harness, **not shipped to consumers via npm**. No consumer-side surface, no migration, no round-trip cost. Zero behavior change on Linux/macOS (gate is `platform === 'win32'`).

## Test plan

- [x] `npx vitest run tests/harness/cleanup-quirk.test.ts tests/harness/report.test.ts` → 21/21 pass locally on Windows
- [x] Local consumer-smoke run on Windows: zero `EBUSY` cleanup warnings; pre-existing EPERM warnings (real signal) correctly still surface
- [ ] CI green on ubuntu-latest, macos-latest, windows-latest (smoke runs all three)

## Test cases covered

| Platform | err.code | Expected | Result |
|----------|----------|----------|--------|
| win32 | EBUSY | suppress | OK |
| win32 | EPERM | warn | OK |
| win32 | EACCES | warn | OK |
| win32 | ENOENT | warn | OK |
| linux/darwin | EBUSY | warn (no AV story) | OK |
| any | no .code | warn | OK |
| any | null/undefined err | warn (defensive) | OK |
| win32 | code='EPERM' but message mentions EBUSY | warn (regression guard) | OK |

Closes #1018

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)