### PR TITLE
fix(1022): isolate doctor-memprobe to temp dir to dodge daemon-held DB on Windows

### DIFF
--- a/src/cli/__tests__/doctor-checks-memory-access.test.ts
+++ b/src/cli/__tests__/doctor-checks-memory-access.test.ts
@@ -5,13 +5,87 @@
  * states) and the end-to-end behavior against the real memory subsystem +
  * coordinator. The memory round-trip is exercised through the actual
  * memory_store / memory_search MCP tool handlers — no mocks.
+ *
+ * Isolation note (#1022): the probe's bridge writes through `atomicWriteFileSync`
+ * targeting `<projectRoot>/.moflo/moflo.db`. Under `npm test` an earlier suite
+ * may have triggered the auto-started daemon, which holds the canonical DB
+ * open with a non-shareable handle on Windows — and the probe's rename then
+ * fails with EPERM. We redirect `CLAUDE_PROJECT_DIR` to a per-suite temp dir
+ * so the probe never collides with the live daemon's DB. No production code
+ * change — the runtime contract ("daemon owns the canonical DB") is honored;
+ * only the test environment moves out of the way.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   checkMemoryAccessFunctional,
 } from '../commands/doctor-checks-memory-access.js';
 import type { FunctionalHealthCheck } from '../commands/doctor-checks-swarm.js';
+import { findMofloPackageRoot } from '../services/moflo-require.js';
+
+let tempProjectDir: string | undefined;
+let originalProjectDir: string | undefined;
+let originalDisableRouting: string | undefined;
+
+/**
+ * Reset the dist bridge-core module's cached project root and registry so
+ * the env var change takes effect. The probe's MCP tool handlers load from
+ * `dist/`, so we must reset the same module instance — not the source
+ * import. Best-effort: skipped if dist isn't built (the suite degrades to
+ * the "not built" warn path anyway).
+ */
+async function resetDistBridgeState(): Promise<void> {
+  const root = findMofloPackageRoot();
+  if (!root) return;
+  const bridgeCorePath = join(root, 'dist/src/cli/memory/bridge-core.js');
+  if (!existsSync(bridgeCorePath)) return;
+  const bc = await import(pathToFileURL(bridgeCorePath).href) as {
+    shutdownBridge?: () => Promise<void>;
+    _resetProjectRootForTest?: () => void;
+  };
+  if (bc.shutdownBridge) await bc.shutdownBridge();
+  bc._resetProjectRootForTest?.();
+}
+
+beforeAll(async () => {
+  tempProjectDir = mkdtempSync(join(tmpdir(), 'doctor-memprobe-'));
+  // `.moflo/` is created by `persistBridgeDb` on first write; no pre-seed needed.
+  // Bridge resolves project root from CLAUDE_PROJECT_DIR directly — no marker
+  // file lookup happens when the env var is set.
+
+  originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+  originalDisableRouting = process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+  process.env.CLAUDE_PROJECT_DIR = tempProjectDir;
+  // Belt: even if the daemon is up, we want every write to go through
+  // the bridge into the temp DB — never the live daemon's canonical one.
+  process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+
+  // Symmetric with afterAll: a genuine dist load error shouldn't abort the
+  // entire suite with an opaque message — let the test bodies surface the
+  // real problem (e.g. via the "not built" warn path).
+  await resetDistBridgeState().catch(() => { /* best-effort */ });
+});
+
+afterAll(async () => {
+  // Reset again so subsequent tests in the same vitest worker don't see
+  // a cached registry pointing at the deleted temp dir.
+  await resetDistBridgeState().catch(() => { /* best-effort */ });
+
+  if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+
+  if (originalDisableRouting === undefined) delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+  else process.env.MOFLO_DISABLE_DAEMON_ROUTING = originalDisableRouting;
+
+  if (tempProjectDir) {
+    try { rmSync(tempProjectDir, { recursive: true, force: true }); }
+    catch { /* Windows EBUSY at process teardown is benign — see #1018 */ }
+  }
+});
 
 function expectFunctionalShape(result: FunctionalHealthCheck) {
   expect(result.name).toBe('Memory Access Functional');


### PR DESCRIPTION
## Summary

- Fixes #1022. The `doctor-checks-memory-access.test.ts` Windows flake (`EPERM rename .moflo/moflo.db.tmp -> .moflo/moflo.db`) under full `npm test` happened because an earlier suite triggered the auto-started daemon — which holds the canonical DB open with a non-shareable handle on Windows — and the probe's `atomicWriteFileSync` rename refused.
- Test-only fix: redirect the probe to a per-suite temp dir via `CLAUDE_PROJECT_DIR`. The bridge's `getProjectRoot()` short-circuits to the env var, so writes go to `<temp>/.moflo/moflo.db` — no collision with the daemon-held canonical DB.
- Sibling of #1028 (the read-side variant in the consumer-smoke harness). The pattern here is reusable for that follow-up.

## Why a test fix, not a production fix

The runtime contract is **"the daemon owns the canonical DB; readers/writers coordinate through it or stay outside its territory."** The test was implicitly asserting "bridge can write to the canonical DB even when the daemon owns it" — which is NOT a runtime promise.

Per `.claude/guidance/shipped/moflo-root-cause-discipline.md` (added in PR #1027): *fix the test environment, don't degrade production code to satisfy a too-strict assertion.* This is the second application of that lens.

## What changed

- `beforeAll` creates a `mkdtempSync` temp dir and points `CLAUDE_PROJECT_DIR` at it.
- Sets `MOFLO_DISABLE_DAEMON_ROUTING=1` so even with the daemon up, writes never route to its canonical store.
- Resets the **dist** bridge-core's cached `_projectRoot` and `registryPromise` — the probe loads MCP tools from `dist/`, so the reset must hit that module instance (not the source one vitest transpiles) to take effect.
- `afterAll` restores env vars and rms the temp dir; Windows EBUSY at teardown is swallowed (benign — same pattern as #1018).

No production code changed.

## Test plan

- [x] Isolated run: 6/6 pass with the daemon running locally
- [x] Full suite: \`npm test\` — 8337/8337 pass, 0 failures (daemon was active during the run)
- [x] Reviewer-flagged issues addressed: removed redundant \`mkdirSync('.moflo')\`, wrapped \`beforeAll\` reset in \`.catch\` so a genuine dist load error doesn't abort the suite opaquely
- [ ] CI green across windows-latest, ubuntu-latest, macos-latest

## Follow-up

#1028 (sibling) applies the same lens to the consumer-smoke harness's \`memory-retrieve\` flake — same family (Windows + daemon-owned DB), distinct symptom (silent null read instead of EPERM rename). The temp-dir + env-redirect pattern from this PR becomes the template for that fix.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)