### PR TITLE
fix(1028): disable daemon in consumer-smoke memoryCrud to dodge bridge-vs-daemon race

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -511,35 +511,67 @@ function dumpFullCrudOutput(label, res) {
 
 export function memoryCrud(consumerDir) {
   section('Memory CRUD round-trip');
-  const key = `smoke-${Date.now()}`;
-  const value = 'smoke-harness-sentinel';
 
-  const store = flo(consumerDir, ['memory', 'store', '-k', key, '-v', value, '--namespace', 'smoke']);
-  if (!recordExit('memory-store', store)) dumpFullCrudOutput('memory-store', store);
+  // Issue #1028: confine the round-trip to the bridge-direct path. The
+  // runtime contract for cross-process memory visibility is daemon-
+  // coordinated, but `flo memory retrieve` has no daemon-routed read — so a
+  // daemon-up CRUD round-trip races the daemon's flush against the harness's
+  // bridge-direct read. Mirroring #1029 (#1022): move the test environment
+  // out of the daemon's territory by disabling daemon auto-start in the
+  // consumer and stopping any daemon prior checks may have started. With
+  // auto-start off the next `flo memory <op>` falls through `storeEntry` to
+  // `bridgeStoreEntry` in-process, sequential subprocesses + atomicWrite
+  // (fsync → rename → Win post-rename verify) make the round-trip
+  // deterministic. Daemon-coordinated CRUD has dedicated coverage at
+  // src/cli/__tests__/memory/store-entry-routing.test.ts and
+  // src/cli/__tests__/services/daemon-memory-rpc.test.ts.
+  //
+  // Localized to memoryCrud: try/finally restores any prior moflo.yaml so
+  // downstream checks see the same environment they would have without the
+  // intervention (the smoke fixture intentionally ships without one — see
+  // SMOKE_ALLOWED_DOCTOR_WARNINGS).
+  const yamlPath = join(consumerDir, 'moflo.yaml');
+  const priorYaml = existsSync(yamlPath) ? readFileSync(yamlPath, 'utf8') : null;
+  writeFileSync(yamlPath, 'daemon:\n  auto_start: false\n');
+  stopConsumerDaemon(consumerDir);
 
-  // Issue #994: use --format=json so the round-trip check parses a structured
-  // payload instead of grepping the ASCII printBox output. The box rendering
-  // intermittently dropped its content rows on Windows CI (top/bottom borders
-  // landed in captured stdout, the inner `| Namespace: ... |` lines didn't —
-  // looked like a writeback race in the harness output but turned out to be
-  // a stdout-flush issue downstream of printBox). JSON output goes through
-  // a single console.log call and is what callers should rely on anyway.
-  const get = flo(consumerDir, ['memory', 'retrieve', '-k', key, '--namespace', 'smoke', '--format', 'json']);
-  let parsedContent = null;
-  if (get.code === 0) {
-    try { parsedContent = JSON.parse(get.stdout.trim())?.content ?? null; }
-    catch { /* fall through to fail with the raw exit/stdout */ }
+  try {
+    const key = `smoke-${Date.now()}`;
+    const value = 'smoke-harness-sentinel';
+
+    const store = flo(consumerDir, ['memory', 'store', '-k', key, '-v', value, '--namespace', 'smoke']);
+    if (!recordExit('memory-store', store)) dumpFullCrudOutput('memory-store', store);
+
+    // Issue #994: use --format=json so the round-trip check parses a structured
+    // payload instead of grepping the ASCII printBox output. The box rendering
+    // intermittently dropped its content rows on Windows CI (top/bottom borders
+    // landed in captured stdout, the inner `| Namespace: ... |` lines didn't —
+    // looked like a writeback race in the harness output but turned out to be
+    // a stdout-flush issue downstream of printBox). JSON output goes through
+    // a single console.log call and is what callers should rely on anyway.
+    const get = flo(consumerDir, ['memory', 'retrieve', '-k', key, '--namespace', 'smoke', '--format', 'json']);
+    let parsedContent = null;
+    if (get.code === 0) {
+      try { parsedContent = JSON.parse(get.stdout.trim())?.content ?? null; }
+      catch { /* fall through to fail with the raw exit/stdout */ }
+    }
+    const ok = parsedContent === value;
+    record('memory-retrieve', ok ? 'pass' : 'fail',
+      ok ? 'value round-trips' : `exit ${get.code}, content=${JSON.stringify(parsedContent)}`);
+    if (!ok) dumpFullCrudOutput('memory-retrieve', get);
+
+    recordExit('memory-search', flo(consumerDir, ['memory', 'search', '-q', 'smoke', '--namespace', 'smoke', '--limit', '5']));
+
+    recordExit('memory-list', flo(consumerDir, ['memory', 'list', '--namespace', 'smoke']));
+
+    recordExit('memory-delete', flo(consumerDir, ['memory', 'delete', '-k', key, '--namespace', 'smoke']));
+  } finally {
+    if (priorYaml !== null) writeFileSync(yamlPath, priorYaml);
+    else {
+      try { rmSync(yamlPath); }
+      catch { /* benign — file may have been removed by a subprocess */ }
+    }
   }
-  const ok = parsedContent === value;
-  record('memory-retrieve', ok ? 'pass' : 'fail',
-    ok ? 'value round-trips' : `exit ${get.code}, content=${JSON.stringify(parsedContent)}`);
-  if (!ok) dumpFullCrudOutput('memory-retrieve', get);
-
-  recordExit('memory-search', flo(consumerDir, ['memory', 'search', '-q', 'smoke', '--namespace', 'smoke', '--limit', '5']));
-
-  recordExit('memory-list', flo(consumerDir, ['memory', 'list', '--namespace', 'smoke']));
-
-  recordExit('memory-delete', flo(consumerDir, ['memory', 'delete', '-k', key, '--namespace', 'smoke']));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Read-side sibling of #1022 (write-side EPERM, fixed by #1029). Same family: Windows + daemon-owned `.moflo/moflo.db` + test isolation. Distinct symptom: harness's `flo memory retrieve` returns `content=null` after a successful `flo memory store`.
- Diagnosis (per `.claude/guidance/shipped/moflo-root-cause-discipline.md`): the harness asserts cross-process visibility through bridge-direct reads while the runtime contract is **daemon-coordinated**. There is no `flo memory retrieve` daemon route today — only `store` and `delete` route through the daemon RPC.
- Fix mirrors #1029's pattern: write a minimal `moflo.yaml` (`daemon.auto_start: false`) to the consumer scratch dir, stop any running daemon, run CRUD on the bridge-direct path, restore prior yaml in `finally`. Sequential subprocesses + `atomicWriteFileSync` (fsync → rename → Win post-rename verify) make the round-trip deterministic.

## Why this and not "fix the runtime"

Adding a daemon-routed `retrieve` is a real product improvement, but it's a production change with consumer impact (every consumer's read path changes). That's a separate, intentional workstream — not a fix for a CI flake. The contract the harness was asserting is one the runtime simply doesn't promise; the discipline says fix the test, not pile a fourth shutdown-ordering layer onto `atomicWriteFileSync`.

Daemon-coordinated CRUD keeps its existing coverage in:

- `src/cli/__tests__/memory/store-entry-routing.test.ts` (routing gates + fallback)
- `src/cli/__tests__/services/daemon-memory-rpc.test.ts` (HTTP RPC handlers)

Bridge-direct CRUD is what consumers see when they opt out of the daemon (`daemon.auto_start: false`) — a real shipping path, not a synthetic one.

## What changed

- `harness/consumer-smoke/lib/checks.mjs::memoryCrud` — wraps the existing CRUD body in a `try/finally`. Pre-CRUD: persists any prior `moflo.yaml`, writes the daemon-disabled override, stops any running daemon. Post-CRUD: restores the original yaml content (or removes the file if it didn't exist).
- No production code touched. No new exports. No schema changes.

## Test plan

- [x] Local Windows 11 run: `node harness/consumer-smoke/run.mjs` → 41 passed, 0 failed
- [x] `npm test` baseline: 8337 passed, 0 failed
- [x] Targeted: `npx vitest run src/cli/__tests__/memory/store-entry-routing.test.ts src/cli/__tests__/services/daemon-memory-rpc.test.ts` → 32 passed
- [ ] Windows-latest CI: confirm the original `memory-retrieve content=null` flake no longer surfaces over multiple runs

## Reviewer notes

The fix was reviewed via `/flo-simplify` (SMALL tier, single sonnet reviewer). Reviewer flagged two real issues — clobbering an existing `moflo.yaml` and not restoring downstream harness state — both addressed in the committed version via `existsSync` + read-and-restore + `try/finally`. Validation pass clean.

Closes #1028

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)