### PR TITLE
fix(spells): drop format:jwt from OAP so MSA opaque tokens stop re-prompting

### DIFF
--- a/spells/dev/outlook-attachment-processor.yaml
+++ b/spells/dev/outlook-attachment-processor.yaml
@@ -28,12 +28,13 @@ prerequisites:
       Microsoft Graph access token for reading your Outlook/Microsoft 365 inbox.
       Get one (expires in ~1h): open Graph Explorer, sign in with the account
       whose mailbox you want to scan, click the "Access token" tab, copy the token.
+      Personal MS accounts return opaque tokens; work/school accounts return JWTs —
+      both are accepted, so no `format` is declared here.
     docsUrl: https://developer.microsoft.com/en-us/graph/graph-explorer
     detect:
       type: env
       key: GRAPH_ACCESS_TOKEN
     promptOnMissing: true
-    format: jwt
 
   - name: SLACK_WEBHOOK_URL
     description: >


### PR DESCRIPTION
## Summary
- OAP's `GRAPH_ACCESS_TOKEN` prereq declared `format: jwt` (added in #1010 alongside #1009's strict validator), but Microsoft Graph Explorer returns **opaque** tokens for personal/consumer MS accounts (e.g. `EwBYBMl6...`, no dots) — only work/school accounts return JWTs. Result: every cast → store returns opaque token → validator rejects ("not a JWT") → re-prompt loop forever, even after answering Y to save.
- Drops `format: jwt` from the prereq and adds a description note explaining the trap. The validator's no-format heuristic already does the right thing — JWT-shaped values still get expiry-checked, opaque values pass through.

## Root cause
`af6c8cb47` (#1010) tightened `validateStoredCredential` to reject any non-JWT-shaped value when `format: jwt` is declared, **and** added `format: jwt` to OAP in the same commit. The validator change is correct in principle; the spell-author assumption was the bug.

## Verification
End-to-end resolver simulation against the real `~/.moflo/credentials.json` after the fix:
```
result: { ok: true, resolvedNames: [ 'GRAPH_ACCESS_TOKEN', 'SLACK_WEBHOOK_URL' ], errorCode: undefined }
env GRAPH set: true, env SLACK set: true
```

Manually re-cast OAP locally — second cast no longer prompts. Cleared store + recast also confirms the prompt-then-save path still works correctly.

## Test plan
- [x] Cast OAP with stored opaque token → no prompt (verified locally)
- [x] Clear store, cast OAP → both creds prompted, batched save offer appears (verified locally)
- [x] Existing `prerequisites-resolve.test.ts` and `credential-validation.test.ts` still pass

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)