### PR TITLE
fix(1034): re-scan Grimoire each fire so daemon picks up yaml edits without restart

### DIFF
--- a/src/cli/__tests__/services/daemon-spell-executor.test.ts
+++ b/src/cli/__tests__/services/daemon-spell-executor.test.ts
@@ -8,9 +8,13 @@
  * Story #445.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { Mock } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { DaemonSpellExecutor } from '../../services/daemon-spell-executor.js';
+import { Grimoire as RealGrimoire } from '../../spells/registry/spell-registry.js';
 import type { EngineModule, SandboxConfig } from '../../services/engine-loader.js';
 import type { SpellResult } from '../../../spells/src/types/runner.types.js';
 import type { SpellDefinition } from '../../../spells/src/types/spell-definition.types.js';
@@ -74,6 +78,7 @@ function makeRegistry(map: Record<string, SpellDefinition>): Grimoire {
     list: vi.fn(() => Object.values(map).map(d => ({ name: d.name, tier: 'user' }))),
     info: vi.fn(),
     load: vi.fn(),
+    invalidate: vi.fn(),
   } as unknown as Grimoire;
 }
 
@@ -104,6 +109,24 @@ describe('DaemonSpellExecutor', () => {
 
       expect(exec.exists('missing')).toBe(false);
     });
+
+    it('invalidates the registry cache before resolving (#1034)', () => {
+      // Scheduler poll calls exists() once per schedule per minute and
+      // auto-disables on stale-false. Must re-scan disk each call so a
+      // yaml added at runtime doesn't cause a schedule to be cancelled.
+      const def = makeDefinition({ name: 'wf' });
+      const registry = makeRegistry({ wf: def });
+      const invalidateMock = registry.invalidate as Mock;
+      const resolveMock = registry.resolve as Mock;
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      exec.exists('wf');
+
+      expect(invalidateMock).toHaveBeenCalledTimes(1);
+      expect(invalidateMock.mock.invocationCallOrder[0]).toBeLessThan(
+        resolveMock.mock.invocationCallOrder[0],
+      );
+    });
   });
 
   describe('execute', () => {
@@ -132,6 +155,24 @@ describe('DaemonSpellExecutor', () => {
       expect(result.success).toBe(false);
       expect(result.errors[0].message).toMatch(/not found in grimoire/);
       expect(engine.bridgeExecuteSpell).not.toHaveBeenCalled();
+    });
+
+    it('invalidates the registry cache before resolving (#1034)', async () => {
+      // Daemons live forever; without per-fire invalidation, yaml edits on
+      // disk are invisible until restart. Invalidate must happen before
+      // resolve so the next call re-scans definition files.
+      const def = makeDefinition({ name: 'wf' });
+      const registry = makeRegistry({ wf: def });
+      const invalidateMock = registry.invalidate as Mock;
+      const resolveMock = registry.resolve as Mock;
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      await exec.execute('wf', {});
+
+      expect(invalidateMock).toHaveBeenCalledTimes(1);
+      const invalidateOrder = invalidateMock.mock.invocationCallOrder[0];
+      const resolveOrder = resolveMock.mock.invocationCallOrder[0];
+      expect(invalidateOrder).toBeLessThan(resolveOrder);
     });
 
     it('surfaces an engine-returned validation failure transparently', async () => {
@@ -273,5 +314,64 @@ describe('DaemonSpellExecutor', () => {
       const [, , opts] = engine.bridgeExecuteSpell.mock.calls[0];
       expect(opts.sandboxConfig).toBe(customSandbox);
     });
+  });
+});
+
+// ============================================================================
+// Integration — real Grimoire backed by a temp dir (#1034)
+// ============================================================================
+
+describe('DaemonSpellExecutor — yaml reload (real Grimoire)', () => {
+  let tmpDir: string;
+  let engine: ReturnType<typeof makeEngine>;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `daemon-exec-reload-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    engine = makeEngine();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('picks up yaml edits between fires without reconstruction', async () => {
+    // The executor must invalidate the registry cache before resolve, otherwise
+    // long-lived daemons hold a snapshot from startup and ignore disk edits
+    // until restart. This test mirrors PR #1032's real-world repro: change a
+    // spell definition between two scheduled fires, observe the new shape.
+    const yamlPath = join(tmpDir, 'reload-test.yaml');
+    writeFileSync(yamlPath, [
+      'name: reload-test',
+      'version: "1.0"',
+      'steps:',
+      '  - id: s1',
+      '    type: bash',
+      '    config:',
+      '      command: echo before',
+    ].join('\n'), 'utf-8');
+
+    const registry = new RealGrimoire({ userDirs: [tmpDir], skipValidation: true });
+    const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+    await exec.execute('reload-test', {});
+    const [firstDef] = engine.bridgeExecuteSpell.mock.calls[0];
+    expect(firstDef.version).toBe('1.0');
+    expect(firstDef.steps[0].config.command).toBe('echo before');
+
+    writeFileSync(yamlPath, [
+      'name: reload-test',
+      'version: "2.0"',
+      'steps:',
+      '  - id: s1',
+      '    type: bash',
+      '    config:',
+      '      command: echo after',
+    ].join('\n'), 'utf-8');
+
+    await exec.execute('reload-test', {});
+    const [secondDef] = engine.bridgeExecuteSpell.mock.calls[1];
+    expect(secondDef.version).toBe('2.0');
+    expect(secondDef.steps[0].config.command).toBe('echo after');
   });
 });

--- a/src/cli/services/daemon-spell-executor.ts
+++ b/src/cli/services/daemon-spell-executor.ts
@@ -57,6 +57,11 @@ export class DaemonSpellExecutor implements SpellExecutor {
   }
 
   exists(spellName: string): boolean {
+    // Invalidate before resolve so newly-added yamls are visible to the
+    // poll loop. Without this, stale-false from exists() causes the
+    // scheduler to auto-disable schedules whose spell was added on disk
+    // after daemon boot (#1034).
+    this.registry.invalidate();
     return this.registry.resolve(spellName) !== undefined;
   }
 
@@ -66,6 +71,9 @@ export class DaemonSpellExecutor implements SpellExecutor {
     signal?: AbortSignal,
     mofloLevel?: MofloLevel,
   ): Promise<SpellResult> {
+    // Invalidate before resolve so yaml edits on disk reach the next fire
+    // without needing a daemon restart (#1034).
+    this.registry.invalidate();
     const loaded = this.registry.resolve(spellName);
     if (!loaded) {
       return failedResult(


### PR DESCRIPTION
## Summary
- `DaemonSpellExecutor.exists()` and `execute()` now call `registry.invalidate()` before `resolve()`, so the next call re-scans the shipped + user yaml dirs from disk.
- Fixes the staleness that bit us on PR #1032 — the OAP yaml change shipped, but scheduled runs kept failing against the **pre-edit** definition until the daemon was restarted.
- Both methods need it: `scheduler.poll()` calls `exists()` per schedule per minute and auto-disables on stale-false, so without it a yaml added at runtime would silently cancel a matching schedule.

## Why per-fire invalidate over fs.watch / IPC reload
- Daemon polls at most once per minute. A Grimoire reload is a few-dozen YAML reads + parse — negligible compared to actual spell execution.
- No new lifecycle (no `fs.watch`, no chokidar dep, no Windows watcher flakiness, no IPC surface).
- Re-uses an existing tested method (`Grimoire.invalidate()` at `spell-registry.ts:172`, tested at `spell-registry.test.ts:383`).
- Eliminates the cache divergence entirely instead of patching observability around it.

## Test plan
- [x] `npx vitest run src/cli/__tests__/services/daemon-spell-executor.test.ts` — 16 tests pass (was 13, +3 new: 1 for `exists()`, 1 for `execute()`, 1 integration with a real Grimoire on a temp dir editing yaml between fires)
- [x] `npx vitest run src/cli/__tests__/services/daemon-scheduler-bootstrap.test.ts src/cli/__tests__/spells/scheduler` — 87 existing tests still green
- [x] `npx vitest run src/cli/__tests__/spells/spell-registry.test.ts` — 20 existing tests still green
- [x] `npx tsc --noEmit` — clean

Closes #1034.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)