### PR TITLE
fix(1035): mtime-driven CredentialStore reload so daemon picks up CLI writes without restart

### DIFF
--- a/src/cli/__tests__/spells/credential-store.test.ts
+++ b/src/cli/__tests__/spells/credential-store.test.ts
@@ -410,4 +410,71 @@ describe('CredentialStore', () => {
     );
     store.lock();
   });
+
+  // --------------------------------------------------------------------------
+  // #1035 — long-lived instance picks up external writes (mtime reload)
+  // --------------------------------------------------------------------------
+
+  it('picks up writes from another instance without re-construction (#1035)', async () => {
+    // Simulates the daemon scenario: process A holds an unlocked
+    // CredentialStore, process B (CLI subprocess) writes a new credential
+    // to the same file. A.get() must return the freshly-stored value.
+    //
+    // Pre-create the file so reader + writer share a salt (the real-world
+    // scenario — the daemon and CLI subprocesses both unlock against an
+    // existing credentials.json that was initialised on first use).
+    const primer = new CredentialStore({ filePath, passphrase: 'shared-pass' });
+    await primer.store('priming', 'init');
+    primer.lock();
+
+    const reader = new CredentialStore({ filePath, passphrase: 'shared-pass' });
+    expect(await reader.get('graph-token')).toBeUndefined();
+
+    const writer = new CredentialStore({ filePath, passphrase: 'shared-pass' });
+    await writer.store('graph-token', 'EwBYBMl6opaque');
+    writer.lock();
+
+    // Force a stat-detectable mtime difference on filesystems with coarse
+    // mtime resolution (Windows ~10ms). On a fast machine, the writer's
+    // writeFile and the reader's next get can land in the same tick, which
+    // would mask the regression in test even though it can't in real use.
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(await reader.get('graph-token')).toBe('EwBYBMl6opaque');
+    reader.lock();
+  });
+
+  it('picks up updates to an existing credential without re-construction (#1035)', async () => {
+    const reader = new CredentialStore({ filePath, passphrase: 'shared-pass' });
+    await reader.store('api-key', 'v1');
+    expect(await reader.get('api-key')).toBe('v1');
+
+    // Mutate via a separate instance — mirrors the CLI-writes / daemon-reads split.
+    const writer = new CredentialStore({ filePath, passphrase: 'shared-pass' });
+    await writer.store('api-key', 'v2');
+    writer.lock();
+
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(await reader.get('api-key')).toBe('v2');
+    reader.lock();
+  });
+
+  it('picks up clears from another instance (#1035)', async () => {
+    const reader = new CredentialStore({ filePath, passphrase: 'shared-pass' });
+    await reader.store('a', '1');
+    await reader.store('b', '2');
+    expect((await reader.list()).length).toBe(2);
+
+    const writer = new CredentialStore({ filePath, passphrase: 'shared-pass' });
+    expect(await writer.clear()).toBe(2);
+    writer.lock();
+
+    await new Promise(r => setTimeout(r, 20));
+
+    expect((await reader.list()).length).toBe(0);
+    expect(await reader.has('a')).toBe(false);
+    reader.lock();
+  });
+
 });

--- a/src/cli/spells/credentials/credential-store.ts
+++ b/src/cli/spells/credentials/credential-store.ts
@@ -14,7 +14,7 @@ import {
   randomBytes,
   pbkdf2Sync,
 } from 'node:crypto';
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { CredentialAccessor } from '../types/step-command.types.js';
 
@@ -106,6 +106,11 @@ export class CredentialStore implements CredentialAccessor {
   private readonly filePath: string;
   private derivedKey: Buffer | null = null;
   private data: StoreData | null = null;
+  // Tracks the file mtime that produced `this.data`. `null` means the file
+  // didn't exist when we last read. refreshIfStale() compares against the
+  // current mtime to detect external writes (e.g. CLI subprocesses calling
+  // `flo spell credentials set` while the daemon's instance is alive — #1035).
+  private lastReadMtimeMs: number | null = null;
 
   constructor(options: CredentialStoreOptions) {
     this.filePath = options.filePath;
@@ -126,6 +131,7 @@ export class CredentialStore implements CredentialAccessor {
       );
     }
     this.data = this.readFile();
+    this.lastReadMtimeMs = this.fileMtimeMs();
     const salt = Buffer.from(this.data.salt, 'hex');
     this.derivedKey = deriveKey(passphrase, salt);
   }
@@ -143,9 +149,17 @@ export class CredentialStore implements CredentialAccessor {
 
   /**
    * Store an encrypted credential.
+   *
+   * The refreshIfStale() call rebases on the latest on-disk state so we don't
+   * write back a snapshot that's missing concurrent additions. It is NOT a
+   * mutual-exclusion primitive: two processes calling store() on the same key
+   * concurrently still race, and the last writer wins. Cross-process locking
+   * is out of scope; the file write is small and the typical layout (one
+   * daemon reader + occasional CLI writers) makes the race window vanishing.
    */
   async store(name: string, value: string, description?: string): Promise<void> {
     this.ensureUnlocked();
+    this.refreshIfStale();
     const now = new Date().toISOString();
     const encrypted = encrypt(value, this.derivedKey!);
 
@@ -166,6 +180,7 @@ export class CredentialStore implements CredentialAccessor {
    */
   async get(name: string): Promise<string | undefined> {
     this.ensureUnlocked();
+    this.refreshIfStale();
     const entry = this.data!.credentials[name];
     if (!entry) return undefined;
 
@@ -185,6 +200,7 @@ export class CredentialStore implements CredentialAccessor {
    */
   async has(name: string): Promise<boolean> {
     this.ensureUnlocked();
+    this.refreshIfStale();
     return name in this.data!.credentials;
   }
 
@@ -193,6 +209,7 @@ export class CredentialStore implements CredentialAccessor {
    */
   async delete(name: string): Promise<boolean> {
     this.ensureUnlocked();
+    this.refreshIfStale();
     if (!(name in this.data!.credentials)) return false;
     delete this.data!.credentials[name];
     this.writeFile(this.data!);
@@ -206,6 +223,7 @@ export class CredentialStore implements CredentialAccessor {
    */
   async clear(): Promise<number> {
     this.ensureUnlocked();
+    this.refreshIfStale();
     const count = Object.keys(this.data!.credentials).length;
     if (count === 0) return 0;
     this.data!.credentials = {};
@@ -218,6 +236,7 @@ export class CredentialStore implements CredentialAccessor {
    */
   async list(): Promise<readonly CredentialMeta[]> {
     this.ensureUnlocked();
+    this.refreshIfStale();
     return Object.entries(this.data!.credentials).map(([name, entry]) => ({
       name,
       description: entry.description,
@@ -232,6 +251,7 @@ export class CredentialStore implements CredentialAccessor {
    */
   async allValues(): Promise<readonly string[]> {
     this.ensureUnlocked();
+    this.refreshIfStale();
     const values: string[] = [];
     for (const entry of Object.values(this.data!.credentials)) {
       try {
@@ -357,6 +377,48 @@ export class CredentialStore implements CredentialAccessor {
   private writeFile(data: StoreData): void {
     mkdirSync(dirname(this.filePath), { recursive: true });
     writeFileSync(this.filePath, JSON.stringify(data, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    // Adopt the just-written mtime so refreshIfStale() doesn't trigger an
+    // unnecessary re-read on the next operation through this instance.
+    this.lastReadMtimeMs = this.fileMtimeMs();
+  }
+
+  /**
+   * Return the file's mtime in ms, or null when the file doesn't exist.
+   * Other errors (permissions, etc.) are surfaced — they signal a real problem
+   * worth raising rather than silently treating as "no file".
+   */
+  private fileMtimeMs(): number | null {
+    try {
+      return statSync(this.filePath).mtimeMs;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    }
+  }
+
+  /**
+   * Reload `this.data` from disk when the file's mtime differs from what we
+   * last read. This is the per-call hook that keeps long-lived instances
+   * (the daemon's singleton CredentialStore — see #1035) consistent with
+   * writes made by CLI subprocesses.
+   *
+   * Limitations:
+   * - If another process rotated the passphrase, the salt in the reloaded
+   *   data will mismatch our derivedKey. Subsequent decrypt() calls throw
+   *   DECRYPTION_FAILED, which the resolver treats as missing — same UX as
+   *   today's stale-daemon failure mode and only resolved by daemon restart.
+   *   Rotation-aware reload would need the new passphrase, which we don't
+   *   have post-construction; out of scope here.
+   * - Designed for local filesystems. Network mounts (NFS/SMB) can return
+   *   coarse or stale mtimes via client caching, which would weaken the
+   *   detection. The credentials file lives at `~/.moflo/credentials.json`
+   *   and is expected to be local; network-mounted homedirs aren't supported.
+   */
+  private refreshIfStale(): void {
+    const current = this.fileMtimeMs();
+    if (current === this.lastReadMtimeMs) return;
+    this.data = this.readFile();
+    this.lastReadMtimeMs = current;
   }
 }
 


### PR DESCRIPTION
## Summary
- `CredentialStore` now stats `credentials.json` before every read/write op; if its mtime differs from the last-read mtime, `this.data` is reloaded from disk before proceeding. After each `writeFile`, the just-written mtime is adopted so in-process operations don't trigger a redundant reload.
- Fixes the staleness exposed during the OAP / #1034 retest — `flo spell credentials set` writes were invisible to the running daemon's singleton until restart.

## Why mtime over fs.watch / IPC reload
- One `statSync` per access — µs cost, no new lifecycle, no chokidar dep, no Windows watcher flakiness, no IPC surface.
- Re-uses the existing singleton cache; the file is only re-read when it actually changed.
- Works across processes that share `~/.moflo/credentials.json` regardless of who wrote it.

## Limitations (documented inline)
- Cross-process **passphrase rotation** invalidates the in-memory `derivedKey` (the salt in the reloaded data changes). Subsequent decrypt() throws `DECRYPTION_FAILED`, which the resolver treats as missing. Same UX as today's stale-daemon for rotation; only resolved by daemon restart. Rotation-aware reload would need the new passphrase — not available post-construction. Out of scope.
- Designed for local filesystems. NFS/SMB clients can return coarse or stale mtimes via caching, which would weaken detection. The credentials file is expected to be local.

## Test plan
- [x] `npx vitest run src/cli/__tests__/spells/credential-store.test.ts` — 32 tests pass (was 29, +3 new: writes / updates / clears from another instance visible to a long-lived reader)
- [x] `npx vitest run src/cli/__tests__/spells/credentials src/cli/__tests__/spells/credential-store.test.ts src/cli/__tests__/commands/spell-credentials.test.ts` — 57 credential-related tests still green
- [x] `npx tsc --noEmit` — clean

The new tests use a "primer" instance to seed `credentials.json` so reader + writer share a salt (each unprimed `readFile`-on-ENOENT generates a fresh random salt, which would defeat decryption regardless of the mtime fix). They include a 20ms sleep to defeat coarse Windows mtime resolution in CI.

Closes #1035.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)