### PR TITLE
fix(1042): react to upstream auth-shaped errors with clear-and-retry hook

### DIFF
--- a/.claude/guidance/internal/testing-conventions.md
+++ b/.claude/guidance/internal/testing-conventions.md
@@ -160,7 +160,39 @@ The smoke harness is also a path-safety enforcement point — see `feedback_path
 
 ---
 
-## 11. Diagnosing a Failure — Re-Verify Individually
+## 11. Test What You Change — Real-Functionality Coverage Is Mandatory
+
+**Any changed functionality must be tested to the degree it can be tested.** A bug fix or feature without a test is incomplete — even when CI is green and the unit tests still pass, "no test for the new path" means you don't know if the change actually does what you think. Default posture: **add the test before declaring done.**
+
+The standard scales with what's testable, not with how much effort feels appropriate:
+
+| Surface | Standard test to add |
+|---------|----------------------|
+| Pure function (classifier, parser, serializer) | Unit test — happy path + each branch + each negative case |
+| Module-level integration (runner ↔ checker, hook ↔ executor) | Integration test exercising the real wiring with fakes only at the I/O boundary |
+| Cross-module / system behavior (full spell cast, MCP handler lifecycle) | System E2E in `tests/system/` driving the real coordinator (see §5) |
+| Behavior that depends on TTY / network / OS state that the runner can't simulate cleanly | Inject the dependency through an option (e.g. `RunnerOptions.authErrorConfirm` from #1042); test against the injected hook; document the live-machine smoke step the maintainer must run |
+
+**No exceptions for "I can't easily mock this."** If the production code is hard to test, that's design feedback — refactor to an inject-the-dependency shape so the test surface is reachable. The runner's `authErrorConfirm` hook and the prereq resolver's `promptLine` injection are the canonical examples.
+
+### Smoke tests: reliable or not at all
+
+**Smoke tests catch what unit tests can't and pay for themselves only when they're reliable.** A flaky smoke test trains everyone to ignore the smoke signal — the next *real* break gets ignored too (Broken Window applies here as forcefully as anywhere). Before adding a smoke test:
+
+| Constraint | Required answer |
+|------------|-----------------|
+| Run time | Bounded — under 30s per case, under 2 min for a full smoke pass |
+| Determinism | No timing races, no network reachability assumptions, no flakiness on cold cache |
+| Failure mode | A red signal means a real bug, not "machine was slow today" |
+| Maintenance cost | Lower than the cost of catching the bug class some other way |
+
+If the smoke test can't satisfy all four, **don't add it** — find the unit / integration / system-E2E shape that does, or document the live-machine validation as part of the merge gate (per the AC pattern in #1042: "Real-scenario verification (mandatory before merge)" with explicit step-by-step the maintainer runs).
+
+The consumer-smoke harness (§10) is the existing canonical reliable smoke — if you're adding more smoke surface, model it on that one, not on a one-off shell script that depends on environmental coincidence.
+
+---
+
+## 12. Diagnosing a Failure — Re-Verify Individually
 
 **A test that fails in the full suite is either a real failure or a flake; the way to tell is to re-run it alone.** Per the Broken Window rule:
 

--- a/src/cli/__tests__/spells/auth-error-classifier.test.ts
+++ b/src/cli/__tests__/spells/auth-error-classifier.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the auth-error pattern classifier (#1042).
+ *
+ * Each pattern in the table needs a positive case (the upstream-flavored
+ * error string) and a negative case (something that looks similar but
+ * shouldn't trigger). The classifier feeds the runner's recovery prompt
+ * so false positives = spurious "clear credential?" prompt; false
+ * negatives = silent failure loop. We accept some false positives at the
+ * `low` confidence tier (HTTP 403, bare "Unauthorized") because the
+ * runner only prompts when credentials exist in the spell's prereqs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyAuthError,
+  AUTH_ERROR_PATTERNS,
+} from '../../spells/core/auth-error-classifier.js';
+
+describe('classifyAuthError', () => {
+  describe('positive matches', () => {
+    it('matches MS Identity IDX14100', () => {
+      const m = classifyAuthError(
+        'Graph 401: {"error":{"code":"InvalidAuthenticationToken","message":"IDX14100: JWT is not well formed"}}',
+      );
+      // First pattern in the table that matches wins; IDX1410 takes priority
+      // over InvalidAuthenticationToken because the IDX code is the most
+      // specific signal.
+      expect(m).not.toBeNull();
+      expect(m?.pattern.name).toBe('msal-idx141');
+      expect(m?.pattern.confidence).toBe('high');
+    });
+
+    it('matches MS Identity IDX14101 / IDX14109 (range)', () => {
+      expect(classifyAuthError('IDX14101: signing key not found')?.pattern.name).toBe('msal-idx141');
+      expect(classifyAuthError('IDX14109: token expired')?.pattern.name).toBe('msal-idx141');
+    });
+
+    it('matches Microsoft Graph InvalidAuthenticationToken without IDX prefix', () => {
+      const m = classifyAuthError('"code":"InvalidAuthenticationToken"');
+      expect(m?.pattern.name).toBe('invalid-auth-token');
+    });
+
+    it('matches GitHub Bad credentials', () => {
+      const m = classifyAuthError('{"message":"Bad credentials","status":"401"}');
+      expect(m).not.toBeNull();
+      // Highest priority pattern that matches — first hit wins. "401" gets
+      // matched after "Bad credentials" in table order; the assertion just
+      // confirms classification, not exact ordering.
+      expect(['github-bad-creds', 'http-401']).toContain(m?.pattern.name);
+    });
+
+    it('matches OAuth2 invalid_grant', () => {
+      const m = classifyAuthError('{"error":"invalid_grant","error_description":"refresh expired"}');
+      expect(m?.pattern.name).toBe('oauth-invalid-grant');
+    });
+
+    it('matches OAuth2 expired_token (snake_case)', () => {
+      expect(classifyAuthError('{"error":"expired_token"}')?.pattern.name).toBe('oauth-expired-token');
+    });
+
+    it('matches expired-token (hyphen) and "expired token" (space)', () => {
+      expect(classifyAuthError('error: expired-token detected')?.pattern.name).toBe('oauth-expired-token');
+      expect(classifyAuthError('the access token is expired token now')?.pattern.name).toBe('oauth-expired-token');
+    });
+
+    it('matches camelCase TokenExpired', () => {
+      expect(classifyAuthError('TokenExpired: token has expired')?.pattern.name).toBe('token-expired-camel');
+    });
+
+    it('matches HTTP 401 in canonical "401:" form', () => {
+      expect(classifyAuthError('Slack 401: invalid_auth')?.pattern.name).toBe('http-401');
+    });
+
+    it('matches HTTP 401 in "status: 401" form', () => {
+      expect(classifyAuthError('status: 401, message: foo')?.pattern.name).toBe('http-401');
+    });
+
+    it('matches HTTP 403 (low confidence)', () => {
+      const m = classifyAuthError('HTTP 403: forbidden');
+      expect(m?.pattern.name).toBe('http-403');
+      expect(m?.pattern.confidence).toBe('low');
+    });
+
+    it('matches bare "Unauthorized" (low confidence)', () => {
+      const m = classifyAuthError('something Unauthorized something');
+      expect(m?.pattern.name).toBe('unauthorized-word');
+      expect(m?.pattern.confidence).toBe('low');
+    });
+  });
+
+  describe('negative matches', () => {
+    it('does not match generic network timeout', () => {
+      expect(classifyAuthError('ETIMEDOUT: connect timeout after 5000ms')).toBeNull();
+    });
+
+    it('does not match HTTP 500 server errors', () => {
+      expect(classifyAuthError('HTTP 500: internal server error')).toBeNull();
+    });
+
+    it('does not match HTTP 4040 (longer number containing 401-like substring)', () => {
+      expect(classifyAuthError('error code: 4040 not found')).toBeNull();
+    });
+
+    it('does not match an 8401-like substring inside another number', () => {
+      expect(classifyAuthError('processed 8401234 records')).toBeNull();
+    });
+
+    it('does not match "unauthorized" embedded mid-word', () => {
+      // Word boundary check: "unauthorizedness" should not trigger.
+      expect(classifyAuthError('flag: unauthorizedness=false')).toBeNull();
+    });
+
+    it('returns null for empty input', () => {
+      expect(classifyAuthError('')).toBeNull();
+    });
+
+    it('returns null for non-string input (defensive)', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(classifyAuthError(undefined as any)).toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(classifyAuthError(null as any)).toBeNull();
+    });
+  });
+
+  describe('table integrity', () => {
+    it('has unique pattern names', () => {
+      const names = AUTH_ERROR_PATTERNS.map(p => p.name);
+      expect(new Set(names).size).toBe(names.length);
+    });
+
+    it('has no /g regex flags (lastIndex statefulness banned in feedback_publish_catches_straggler_bugs)', () => {
+      for (const p of AUTH_ERROR_PATTERNS) {
+        expect(p.pattern.flags).not.toContain('g');
+      }
+    });
+
+    it('every pattern has a non-empty reason and a confidence tier', () => {
+      for (const p of AUTH_ERROR_PATTERNS) {
+        expect(p.reason.length).toBeGreaterThan(0);
+        expect(['high', 'low']).toContain(p.confidence);
+      }
+    });
+  });
+});

--- a/src/cli/__tests__/spells/auth-error-runner.test.ts
+++ b/src/cli/__tests__/spells/auth-error-runner.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Runner-level tests for the auth-error recovery hook (#1042).
+ *
+ * Covers the three documented surfaces of the recovery path:
+ *  - Non-TTY without host hook → step failure is rewritten to
+ *    `CREDENTIAL_LIKELY_STALE` so schedulers can route to humans.
+ *  - Confirm=true → store cleared, prereqs re-resolved, step retried once
+ *    and the new result replaces the original.
+ *  - Confirm=true but the retry hits the same auth shape → second-failure
+ *    short-circuit (no infinite loop).
+ *  - Confirm=false → original failure carried forward unchanged.
+ *  - Auth-shaped error but no env-keyed prereqs → not matched (nothing to
+ *    clear, no recovery, original failure carried forward).
+ *
+ * The TTY path is exercised via `RunnerOptions.authErrorConfirm`, the
+ * test/host hook added alongside the recovery code.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SpellCaster } from '../../spells/core/runner.js';
+import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
+import type {
+  StepCommand,
+  CredentialAccessor,
+  MemoryAccessor,
+} from '../../spells/types/step-command.types.js';
+import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
+import { withEnvVars } from './helpers/prereq-fixtures.js';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+interface MockCredentialAccessor extends CredentialAccessor {
+  getCalls: string[];
+  deleteCalls: string[];
+  storeCalls: Array<{ name: string; value: string }>;
+}
+
+function makeMockCredentials(initial: Record<string, string> = {}): MockCredentialAccessor {
+  const data = new Map<string, string>(Object.entries(initial));
+  const accessor: MockCredentialAccessor = {
+    getCalls: [],
+    deleteCalls: [],
+    storeCalls: [],
+    async get(name: string) {
+      accessor.getCalls.push(name);
+      return data.get(name);
+    },
+    async has(name: string) { return data.has(name); },
+    async store(name: string, value: string) {
+      accessor.storeCalls.push({ name, value });
+      data.set(name, value);
+    },
+    async delete(name: string) {
+      accessor.deleteCalls.push(name);
+      const had = data.has(name);
+      data.delete(name);
+      return had;
+    },
+  };
+  return accessor;
+}
+
+function makeMemory(): MemoryAccessor {
+  const store = new Map<string, unknown>();
+  return {
+    async read(ns: string, key: string) { return store.get(`${ns}:${key}`) ?? null; },
+    async write(ns: string, key: string, value: unknown) { store.set(`${ns}:${key}`, value); },
+    async search() { return []; },
+  };
+}
+
+/**
+ * Build a step command that fails with `errorMessage` on attempts 1..N
+ * and succeeds on attempt N+1. Tracks the actual attempt count so the
+ * assertion can verify retry-once vs. no-retry.
+ */
+function makeFlakyAuthCommand(opts: {
+  type?: string;
+  failuresBeforeSuccess: number;
+  errorMessage: string;
+}): StepCommand & { calls: number } {
+  const cmd = {
+    type: opts.type ?? 'flaky-auth',
+    description: 'flaky',
+    configSchema: { type: 'object' as const },
+    calls: 0,
+    validate: () => ({ valid: true, errors: [] }),
+    async execute() {
+      cmd.calls++;
+      if (cmd.calls <= opts.failuresBeforeSuccess) {
+        return { success: false, data: {}, error: opts.errorMessage, duration: 1 };
+      }
+      return { success: true, data: { ok: true }, duration: 1 };
+    },
+    describeOutputs: () => [],
+  } satisfies StepCommand & { calls: number };
+  return cmd;
+}
+
+function spellWithCredPrereq(stepType: string): SpellDefinition {
+  return {
+    name: 'auth-recovery-test',
+    prerequisites: [
+      {
+        name: 'GRAPH_ACCESS_TOKEN',
+        detect: { type: 'env', key: 'GRAPH_ACCESS_TOKEN' },
+        promptOnMissing: true,
+      },
+    ],
+    steps: [{ id: 's1', type: stepType, config: {} }],
+  };
+}
+
+function spellWithoutCredPrereq(stepType: string): SpellDefinition {
+  return {
+    name: 'no-cred-prereq-test',
+    steps: [{ id: 's1', type: stepType, config: {} }],
+  };
+}
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+let registry: StepCommandRegistry;
+
+beforeEach(() => {
+  registry = new StepCommandRegistry();
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('runner — auth-error recovery (issue #1042)', () => {
+  it('rewrites step failure to CREDENTIAL_LIKELY_STALE in non-TTY when no host hook is supplied', async () => {
+    const cmd = makeFlakyAuthCommand({
+      failuresBeforeSuccess: Number.POSITIVE_INFINITY,
+      errorMessage: 'Graph 401: {"error":{"code":"InvalidAuthenticationToken","message":"IDX14100"}}',
+    });
+    registry.register(cmd);
+    const credentials = makeMockCredentials({ GRAPH_ACCESS_TOKEN: 'opaque-stale-token' });
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    await withEnvVars({ GRAPH_ACCESS_TOKEN: 'opaque-stale-token' }, async () => {
+      const result = await runner.run(spellWithCredPrereq(cmd.type), {});
+      expect(result.success).toBe(false);
+      expect(result.steps[0].errorCode).toBe('CREDENTIAL_LIKELY_STALE');
+      expect(result.steps[0].error).toMatch(/CREDENTIAL_LIKELY_STALE/);
+      expect(result.steps[0].error).toMatch(/GRAPH_ACCESS_TOKEN/);
+    });
+
+    // No retry in non-TTY — the original IDX14100 attempt is the only call.
+    expect(cmd.calls).toBe(1);
+    // No delete invoked because the user never confirmed.
+    expect(credentials.deleteCalls).toHaveLength(0);
+  });
+
+  it('retries successfully when the host hook confirms AND the user supplies a fresh credential', async () => {
+    // The headline happy-path for #1042: step fails with stale token →
+    // host confirms clearing → user re-supplies a working token → retry
+    // succeeds. We simulate the user pasting a fresh token by having the
+    // credentials accessor's `delete` re-populate with a working value
+    // before `resolveUnmetPrerequisites` re-runs (mirroring the real flow
+    // where the TTY prompt elicits a new token from the user).
+    const cmd = makeFlakyAuthCommand({
+      failuresBeforeSuccess: 1,
+      errorMessage: 'Graph 401: IDX14100 JWT not well formed',
+    });
+    registry.register(cmd);
+    const credentials = makeMockCredentials({ GRAPH_ACCESS_TOKEN: 'stale' });
+    const origDelete = credentials.delete!.bind(credentials);
+    credentials.delete = async (name: string) => {
+      const r = await origDelete(name);
+      // Simulate the user pasting a new token in the resolver's prompt.
+      await credentials.store(name, 'fresh-and-working-token');
+      return r;
+    };
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    await withEnvVars({ GRAPH_ACCESS_TOKEN: 'stale' }, async () => {
+      const result = await runner.run(spellWithCredPrereq(cmd.type), {}, {
+        authErrorConfirm: async () => true,
+      });
+
+      // Two attempts, the second one succeeds with the fresh token.
+      expect(cmd.calls).toBe(2);
+      expect(credentials.deleteCalls).toEqual(['GRAPH_ACCESS_TOKEN']);
+      expect(result.success).toBe(true);
+      expect(result.steps[0].status).toBe('succeeded');
+      // Env was restored from the fresh credential.
+      expect(process.env.GRAPH_ACCESS_TOKEN).toBe('fresh-and-working-token');
+    });
+  });
+
+  it('clears the credential and retries once when the host hook confirms (success on retry)', async () => {
+    const cmd = makeFlakyAuthCommand({
+      failuresBeforeSuccess: 1,
+      errorMessage: 'Slack 401: invalid_auth',
+    });
+    registry.register(cmd);
+    const credentials = makeMockCredentials({ GRAPH_ACCESS_TOKEN: 'stale' });
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    const promptCalls: Array<{ stepId: string; pattern: string; credKeys: readonly string[] }> = [];
+    const confirm = vi.fn(async (info: { stepId: string; pattern: string; reason: string; credKeys: readonly string[] }) => {
+      promptCalls.push({ stepId: info.stepId, pattern: info.pattern, credKeys: info.credKeys });
+      return true;
+    });
+
+    await withEnvVars({ GRAPH_ACCESS_TOKEN: 'stale' }, async () => {
+      const result = await runner.run(spellWithCredPrereq(cmd.type), {}, {
+        authErrorConfirm: confirm,
+        // Re-resolution path needs a non-interactive completion hook so the
+        // test doesn't block on stdin. forceCredentialReprompt: true skips
+        // the store-resolve step; the dummy env override below provides
+        // the post-retry value.
+      });
+      expect(confirm).toHaveBeenCalledTimes(1);
+      expect(promptCalls[0].stepId).toBe('s1');
+      expect(promptCalls[0].credKeys).toEqual(['GRAPH_ACCESS_TOKEN']);
+
+      // After confirm, the runner deletes the stored credential, but then
+      // resolveUnmetPrerequisites must re-acquire one. With no TTY and no
+      // promptLine override, this fails as MISSING_CREDENTIAL — the retry
+      // path then reports CREDENTIAL_LIKELY_STALE with the after-reprompt
+      // suffix. The credential WAS cleared, the hook WAS called once.
+      expect(credentials.deleteCalls).toEqual(['GRAPH_ACCESS_TOKEN']);
+      expect(result.success).toBe(false);
+      expect(result.steps[0].errorCode).toBe('CREDENTIAL_LIKELY_STALE');
+      expect(result.steps[0].error).toMatch(/manual intervention required|Re-prompt accepted/);
+    });
+  });
+
+  it('short-circuits on second auth-shape failure after re-prompt (no infinite retry)', async () => {
+    // Pre-populate process.env so the first prereq resolution succeeds, and
+    // simulate the post-clear re-resolve via a host that re-injects a value
+    // through the credentials accessor.
+    const cmd = makeFlakyAuthCommand({
+      failuresBeforeSuccess: Number.POSITIVE_INFINITY,
+      errorMessage: 'Graph 401: IDX14100 JWT not well formed',
+    });
+    registry.register(cmd);
+
+    // The accessor's "store" populates data so the resolveUnmetPrerequisites
+    // re-resolve path can pull the new value out of the store.
+    const credentials = makeMockCredentials({ GRAPH_ACCESS_TOKEN: 'stale' });
+    // Make the host re-inject the token into the store between the clear
+    // and the retry by intercepting `delete`. After delete, the next get
+    // returns a fresh value so re-resolution succeeds and the step retries.
+    const origDelete = credentials.delete!.bind(credentials);
+    credentials.delete = async (name: string) => {
+      const r = await origDelete(name);
+      // Simulate user pasting a new value into the store before re-resolve.
+      await credentials.store(name, 'fresh-token-still-broken-upstream');
+      // Also keep process.env consistent with the freshly-stored value.
+      process.env[name] = 'fresh-token-still-broken-upstream';
+      return r;
+    };
+
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    await withEnvVars({ GRAPH_ACCESS_TOKEN: 'stale' }, async () => {
+      const result = await runner.run(spellWithCredPrereq(cmd.type), {}, {
+        authErrorConfirm: async () => true,
+      });
+
+      // First call → fails with IDX14100 → confirm true → delete + reinject
+      // → retry → second call → fails with IDX14100 again → SHORT-CIRCUIT.
+      expect(cmd.calls).toBe(2);
+      expect(result.success).toBe(false);
+      expect(result.steps[0].errorCode).toBe('CREDENTIAL_LIKELY_STALE');
+      expect(result.steps[0].error).toMatch(/manual intervention required/);
+    });
+  });
+
+  it('carries the original failure forward when the host hook returns false', async () => {
+    const cmd = makeFlakyAuthCommand({
+      failuresBeforeSuccess: Number.POSITIVE_INFINITY,
+      errorMessage: '{"message":"Bad credentials","status":401}',
+    });
+    registry.register(cmd);
+    const credentials = makeMockCredentials({ GRAPH_ACCESS_TOKEN: 'stored' });
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    await withEnvVars({ GRAPH_ACCESS_TOKEN: 'stored' }, async () => {
+      const result = await runner.run(spellWithCredPrereq(cmd.type), {}, {
+        authErrorConfirm: async () => false,
+      });
+
+      expect(cmd.calls).toBe(1); // no retry
+      expect(credentials.deleteCalls).toHaveLength(0);
+      expect(result.success).toBe(false);
+      // Original failure preserved — error code is the standard step
+      // execution failed code, not CREDENTIAL_LIKELY_STALE.
+      expect(result.steps[0].errorCode).toBe('STEP_EXECUTION_FAILED');
+    });
+  });
+
+  it('does not trigger recovery when the spell has no env-keyed prereqs even if the error matches', async () => {
+    const cmd = makeFlakyAuthCommand({
+      failuresBeforeSuccess: Number.POSITIVE_INFINITY,
+      errorMessage: 'HTTP 401: invalid token',
+    });
+    registry.register(cmd);
+    const confirm = vi.fn(async () => true);
+    const credentials = makeMockCredentials();
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    const result = await runner.run(spellWithoutCredPrereq(cmd.type), {}, {
+      authErrorConfirm: confirm,
+    });
+    expect(confirm).not.toHaveBeenCalled();
+    expect(cmd.calls).toBe(1);
+    expect(result.steps[0].errorCode).toBe('STEP_EXECUTION_FAILED');
+  });
+
+  it('skips recovery for low-confidence patterns (HTTP 403, bare Unauthorized)', async () => {
+    // Issue #1042 reviewer caught this: HTTP 403 typically means "wrong
+    // scope" not "stale credential", and bare "Unauthorized" appears in
+    // many unrelated 4xx responses. Clearing on those would trash a working
+    // credential, so we only auto-prompt on high-confidence matches.
+    const cmd403 = makeFlakyAuthCommand({
+      type: 'flaky-403',
+      failuresBeforeSuccess: Number.POSITIVE_INFINITY,
+      errorMessage: 'HTTP 403: forbidden — missing scope',
+    });
+    registry.register(cmd403);
+    const confirm = vi.fn(async () => true);
+    const credentials = makeMockCredentials({ GRAPH_ACCESS_TOKEN: 'still-good' });
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    await withEnvVars({ GRAPH_ACCESS_TOKEN: 'still-good' }, async () => {
+      const result = await runner.run(spellWithCredPrereq(cmd403.type), {}, {
+        authErrorConfirm: confirm,
+      });
+      expect(confirm).not.toHaveBeenCalled();
+      expect(credentials.deleteCalls).toHaveLength(0);
+      expect(cmd403.calls).toBe(1);
+      // Low-confidence match falls through to the original failure path.
+      expect(result.steps[0].errorCode).toBe('STEP_EXECUTION_FAILED');
+    });
+  });
+
+  it('flips the prompt default to N when multiple env-keyed prereqs are in scope', async () => {
+    // Issue #1042 reviewer caught this: clearing every credential when only
+    // one is stale would replace a working credential with whatever the
+    // user types next. Single-cred default is Y (the OAP case from the
+    // issue body); multi-cred default flips to N so a stray Enter doesn't
+    // wipe a credential that wasn't the one upstream rejected.
+    const cmd = makeFlakyAuthCommand({
+      failuresBeforeSuccess: Number.POSITIVE_INFINITY,
+      errorMessage: 'Graph 401: IDX14100',
+    });
+    registry.register(cmd);
+    const credentials = makeMockCredentials({
+      GRAPH_ACCESS_TOKEN: 'graph-stale',
+      SLACK_TOKEN: 'slack-still-good',
+    });
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    const definition: SpellDefinition = {
+      name: 'multi-cred',
+      prerequisites: [
+        { name: 'GRAPH_ACCESS_TOKEN', detect: { type: 'env', key: 'GRAPH_ACCESS_TOKEN' }, promptOnMissing: true },
+        { name: 'SLACK_TOKEN', detect: { type: 'env', key: 'SLACK_TOKEN' }, promptOnMissing: true },
+      ],
+      steps: [{ id: 's1', type: cmd.type, config: {} }],
+    };
+
+    let receivedKeys: readonly string[] | null = null;
+    const confirm = vi.fn(async (info: { credKeys: readonly string[] }) => {
+      receivedKeys = info.credKeys;
+      return false; // user declines — we just want to verify both keys reach the prompt
+    });
+
+    await withEnvVars({ GRAPH_ACCESS_TOKEN: 'graph-stale', SLACK_TOKEN: 'slack-still-good' }, async () => {
+      const result = await runner.run(definition, {}, { authErrorConfirm: confirm });
+      expect(confirm).toHaveBeenCalledTimes(1);
+      expect(receivedKeys).toEqual(['GRAPH_ACCESS_TOKEN', 'SLACK_TOKEN']);
+      // User said no — neither credential was touched.
+      expect(credentials.deleteCalls).toHaveLength(0);
+      expect(result.steps[0].errorCode).toBe('STEP_EXECUTION_FAILED');
+    });
+  });
+
+  it('does not trigger recovery for a non-auth error even when creds exist', async () => {
+    const cmd = makeFlakyAuthCommand({
+      failuresBeforeSuccess: Number.POSITIVE_INFINITY,
+      errorMessage: 'ETIMEDOUT: connect timeout after 5000ms',
+    });
+    registry.register(cmd);
+    const confirm = vi.fn(async () => true);
+    const credentials = makeMockCredentials({ GRAPH_ACCESS_TOKEN: 'good' });
+    const runner = new SpellCaster(registry, credentials, makeMemory());
+
+    await withEnvVars({ GRAPH_ACCESS_TOKEN: 'good' }, async () => {
+      const result = await runner.run(spellWithCredPrereq(cmd.type), {}, {
+        authErrorConfirm: confirm,
+      });
+      expect(confirm).not.toHaveBeenCalled();
+      expect(credentials.deleteCalls).toHaveLength(0);
+      expect(result.steps[0].errorCode).toBe('STEP_EXECUTION_FAILED');
+    });
+  });
+});

--- a/src/cli/spells/core/auth-error-classifier.ts
+++ b/src/cli/spells/core/auth-error-classifier.ts
@@ -1,0 +1,107 @@
+/**
+ * Auth-Error Classifier
+ *
+ * Pattern-matches step-failure text against known upstream auth-shaped
+ * signals (HTTP 401, OAuth `invalid_grant`, MS Graph `IDX1410x`, etc.).
+ * The runner uses the result to offer in-product credential clearing +
+ * re-prompt + single-retry instead of looping forever on a stale token.
+ *
+ * Design: pure function, no I/O, no `/g` flag (statefulness was banned in
+ * `feedback_publish_catches_straggler_bugs.md`). Adding upstream-specific
+ * signals is a one-line addition to {@link AUTH_ERROR_PATTERNS}.
+ *
+ * Story #1042.
+ */
+
+export type AuthPatternConfidence = 'high' | 'low';
+
+export interface AuthPattern {
+  /** Stable identifier for telemetry / unit-test assertions. */
+  readonly name: string;
+  /** Anchored to a single line; no `/g` flag (lastIndex statefulness). */
+  readonly pattern: RegExp;
+  readonly confidence: AuthPatternConfidence;
+  /** Human-readable explanation surfaced to the user on prompt. */
+  readonly reason: string;
+}
+
+/**
+ * Initial pattern table from issue #1042. Order matters — high-confidence
+ * upstream-specific patterns come before generic literals so the most
+ * actionable `reason` is reported when a message matches several rules.
+ */
+export const AUTH_ERROR_PATTERNS: readonly AuthPattern[] = [
+  {
+    name: 'msal-idx141',
+    pattern: /\bIDX1410[0-9]\b/,
+    confidence: 'high',
+    reason: 'Microsoft Identity token rejection (IDX1410x)',
+  },
+  {
+    name: 'invalid-auth-token',
+    pattern: /InvalidAuthenticationToken/i,
+    confidence: 'high',
+    reason: 'Microsoft Graph InvalidAuthenticationToken',
+  },
+  {
+    name: 'github-bad-creds',
+    pattern: /\bBad\s+credentials\b/i,
+    confidence: 'high',
+    reason: 'GitHub Bad credentials',
+  },
+  {
+    name: 'oauth-invalid-grant',
+    pattern: /\binvalid_grant\b/i,
+    confidence: 'high',
+    reason: 'OAuth2 invalid_grant',
+  },
+  {
+    name: 'oauth-expired-token',
+    pattern: /\bexpired[_\s-]token\b/i,
+    confidence: 'high',
+    reason: 'OAuth2 expired_token',
+  },
+  {
+    name: 'token-expired-camel',
+    pattern: /\bTokenExpired\b/,
+    confidence: 'high',
+    reason: 'TokenExpired',
+  },
+  {
+    name: 'http-401',
+    pattern: /(?:^|[^0-9])401(?:[^0-9]|$)/,
+    confidence: 'high',
+    reason: 'HTTP 401 (unauthorized)',
+  },
+  {
+    name: 'http-403',
+    pattern: /(?:^|[^0-9])403(?:[^0-9]|$)/,
+    confidence: 'low',
+    reason: 'HTTP 403 (forbidden)',
+  },
+  {
+    name: 'unauthorized-word',
+    pattern: /\bUnauthorized\b/,
+    confidence: 'low',
+    reason: 'unauthorized literal',
+  },
+];
+
+export interface AuthErrorMatch {
+  readonly pattern: AuthPattern;
+}
+
+/**
+ * Match `text` against the pattern table. Returns the first matching
+ * pattern (highest-priority hit) or null.
+ *
+ * `text` is treated as the entire stderr/error blob from a failed step;
+ * patterns are non-anchored on purpose so they catch multi-line outputs.
+ */
+export function classifyAuthError(text: string): AuthErrorMatch | null {
+  if (typeof text !== 'string' || text.length === 0) return null;
+  for (const pattern of AUTH_ERROR_PATTERNS) {
+    if (pattern.pattern.test(text)) return { pattern };
+  }
+  return null;
+}

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -30,6 +30,10 @@ import { rollbackSteps, type CompletedStep } from './rollback-orchestrator.js';
 import { buildCredentialPatterns, addCredentialPattern, collectCredentialNames } from './credential-masker.js';
 import { executeSingleStep, type StepExecutionState } from './step-executor.js';
 import { collectPrerequisites, resolveUnmetPrerequisites } from './prerequisite-checker.js';
+import { classifyAuthError, type AuthErrorMatch } from './auth-error-classifier.js';
+import { readLineFromStdin } from './stdin-reader.js';
+import { acquireTTYLock } from './tty-lock.js';
+import type { Prerequisite } from '../types/step-command.types.js';
 import {
   collectPreflights,
   checkPreflights,
@@ -319,6 +323,19 @@ export class SpellCaster {
       const resultIdx = stepResults.length;
       stepResults.push(result);
 
+      // Auth-error recovery (issue #1042): if a step fails with an upstream
+      // auth-shaped signal AND the spell declares credential prereqs, offer
+      // (TTY) or surface (non-TTY) the chance to clear + re-prompt + retry
+      // once. The recovery returns a new result (success or marked failure)
+      // that replaces the original; null means no recovery happened.
+      if (result.status === 'failed') {
+        const recovered = await this.tryAuthErrorRecovery(definition, step, state, i, result);
+        if (recovered) {
+          result = recovered;
+          stepResults[resultIdx] = result;
+        }
+      }
+
       if (result.status === 'succeeded' && result.output) {
         if (step.output) variables[step.output] = result.output.data;
         variables[step.id] = result.output.data;
@@ -506,6 +523,189 @@ export class SpellCaster {
     const ctxBuilder = (v: Record<string, unknown>, a: Record<string, unknown>, sid: string, si: number, sig?: AbortSignal) =>
       this.buildContext(v, a, sid, si, sig, state.effectiveSandbox);
     return executeSingleStep(step, state, index, this.registry, ctxBuilder);
+  }
+
+  /**
+   * Issue #1042 — react to upstream auth-shaped errors at step-failure time.
+   *
+   * The runner already validates credentials at preflight (#1007/#1009), but
+   * preflight can't know whether a value the upstream accepts today still
+   * works tomorrow. When a step fails with output that matches the auth
+   * pattern table AND the spell has env-typed credential prereqs, we offer
+   * (TTY) or surface (non-TTY) clearing + re-prompt + a single retry.
+   *
+   * Returns a replacement {@link StepResult} when recovery ran (success on
+   * retry, or a `CREDENTIAL_LIKELY_STALE`-coded failure when non-TTY or when
+   * the retry hits the same auth-shape — second-failure short-circuit). Null
+   * means recovery did not run; the caller should fall through to the
+   * normal failure path with the original result intact.
+   */
+  private async tryAuthErrorRecovery(
+    definition: SpellDefinition,
+    step: import('../types/spell-definition.types.js').StepDefinition,
+    state: StepExecutionState,
+    stepIndex: number,
+    result: StepResult,
+  ): Promise<StepResult | null> {
+    const errorText = this.collectStepErrorText(result);
+    const match = classifyAuthError(errorText);
+    if (!match) return null;
+
+    const credPrereqs = collectPrerequisites(definition, this.registry)
+      .filter((p): p is Prerequisite & { envKey: string } => typeof p.envKey === 'string' && p.envKey.length > 0);
+    if (credPrereqs.length === 0) return null;
+
+    const credKeys = credPrereqs.map(p => p.envKey);
+
+    // Low-confidence patterns (HTTP 403, bare "Unauthorized") are too noisy
+    // to drive destructive credential clearing — a 403 typically means
+    // "wrong scope" not "expired token", and "Unauthorized" appears in many
+    // unrelated 4xx responses. Surface a hint and fall through to the
+    // normal failure path so the user sees the real error.
+    if (match.pattern.confidence === 'low') {
+      console.log(`[spell] Step "${step.id}" failed with a possible auth signal (${match.pattern.reason}).`);
+      console.log(`[spell] If "${credKeys.join(', ')}" is stale, run \`flo spell credentials unset ${credKeys[0]}\` and re-cast.`);
+      return null;
+    }
+
+    const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+    const externalConfirm = state.options.authErrorConfirm;
+
+    if (!interactive && !externalConfirm) {
+      // Non-TTY (cron, headless, daemon spawn) with no host-supplied prompt
+      // hook: surface a dedicated error code so schedulers can route this
+      // to "stale credential, needs human" instead of generic step failure.
+      return this.markCredentialLikelyStale(result, match, credKeys, /* afterReprompt */ false);
+    }
+
+    // TTY path (or test/host-injected confirm). With a single credential
+    // the default is Y (per #1042 issue body); with multiple credentials we
+    // flip the default to N so a single typo doesn't trash a working
+    // credential alongside a stale one. The injected hook fully replaces
+    // both detection and the readline call.
+    const defaultYes = credKeys.length === 1;
+    let confirmed: boolean;
+    if (externalConfirm) {
+      try {
+        confirmed = await externalConfirm({
+          stepId: step.id,
+          pattern: match.pattern.name,
+          reason: match.pattern.reason,
+          credKeys,
+        });
+      } catch {
+        return null;
+      }
+    } else {
+      const lock = acquireTTYLock();
+      try {
+        console.log('');
+        console.log(`[spell] Step "${step.id}" failed with what looks like a credential error.`);
+        console.log(`[spell] Detected: ${match.pattern.reason}`);
+        console.log(`[spell] Stored credential${credKeys.length === 1 ? '' : 's'}: ${credKeys.join(', ')}`);
+        if (!defaultYes) {
+          console.log(`[spell] Multiple credentials in scope — only confirm if you want ALL of them re-prompted.`);
+        }
+        const noun = credKeys.length === 1 ? 'this credential' : 'these credentials';
+        const promptSuffix = defaultYes ? '[Y/n]' : '[y/N]';
+        const prompt = `Clear ${noun} and re-prompt? ${promptSuffix} `;
+        let answer = '';
+        try {
+          answer = await readLineFromStdin(prompt, state.options.signal);
+        } catch {
+          // Abort or stdin closed → carry forward the original failure.
+          return null;
+        }
+        const trimmed = answer.trim().toLowerCase();
+        const isYes = trimmed === 'y' || trimmed === 'yes';
+        confirmed = isYes || (defaultYes && trimmed === '');
+      } finally {
+        lock.release();
+      }
+    }
+    if (!confirmed) return null;
+
+    // Clear store + process.env so the resolver re-prompts. `delete` is
+    // optional on the accessor — read-only fixtures may omit it.
+    for (const key of credKeys) {
+      if (typeof this.credentials.delete === 'function') {
+        try { await this.credentials.delete(key); } catch { /* surface as re-prompt fallthrough */ }
+      }
+      delete process.env[key];
+    }
+
+    // Don't force re-prompt here — we just deleted the value from the store
+    // and process.env, so the standard resolution chain naturally falls
+    // through to the TTY prompt (or, in test mode, lets the host inject a
+    // replacement via the credentials accessor's get() method).
+    const resolution = await resolveUnmetPrerequisites(credPrereqs, {
+      abortSignal: state.options.signal,
+      credentials: this.credentials,
+    });
+    if (!resolution.ok) {
+      return this.markCredentialLikelyStale(result, match, credKeys, /* afterReprompt */ true);
+    }
+
+    // Refresh resolvedCredentials + credential masking patterns so the retry
+    // sees the new value the same way the first attempt did.
+    for (const key of credKeys) {
+      try {
+        const fresh = await this.credentials.get(key);
+        if (fresh !== undefined) {
+          state.resolvedCredentials[key] = fresh;
+          addCredentialPattern(state.credentialPatterns, fresh);
+        }
+      } catch { /* keep going — the env var is set, that's the load-bearing path */ }
+    }
+
+    console.log(`[spell] Retrying "${step.id}" with refreshed credentials...`);
+    const retried = await this.runStep(step, state, stepIndex);
+    if (retried.status === 'failed') {
+      const retryErrorText = this.collectStepErrorText(retried);
+      if (classifyAuthError(retryErrorText)) {
+        // Second auth-shape failure — short-circuit so we don't loop.
+        return this.markCredentialLikelyStale(retried, match, credKeys, /* afterReprompt */ true);
+      }
+    }
+    return retried;
+  }
+
+  private collectStepErrorText(result: StepResult): string {
+    const parts: string[] = [];
+    if (result.error) parts.push(result.error);
+    const out = result.output;
+    if (out && typeof out === 'object') {
+      if (typeof out.error === 'string') parts.push(out.error);
+      // Step outputs frequently embed the upstream payload under data.{stderr,error,message}.
+      const data = (out as { data?: unknown }).data;
+      if (data && typeof data === 'object') {
+        for (const key of ['stderr', 'error', 'message', 'body']) {
+          const v = (data as Record<string, unknown>)[key];
+          if (typeof v === 'string') parts.push(v);
+        }
+      }
+    }
+    return parts.join('\n');
+  }
+
+  private markCredentialLikelyStale(
+    result: StepResult,
+    match: AuthErrorMatch,
+    credKeys: readonly string[],
+    afterReprompt: boolean,
+  ): StepResult {
+    const keyLabel = credKeys.join(', ');
+    const suffix = afterReprompt
+      ? ` Re-prompt accepted but the upstream still rejected the credential — manual intervention required.`
+      : ` Run \`flo spell credentials unset ${credKeys[0]}\` (or any key above) and re-cast on a TTY.`;
+    const prefix = `CREDENTIAL_LIKELY_STALE [${match.pattern.name}: ${match.pattern.reason}] for ${keyLabel}.`;
+    const original = result.error ? ` Underlying error: ${result.error}` : '';
+    return {
+      ...result,
+      status: 'failed',
+      errorCode: 'CREDENTIAL_LIKELY_STALE',
+      error: `${prefix}${suffix}${original}`,
+    };
   }
 
   private async doRollback(completed: CompletedStep[], state: StepExecutionState, results: StepResult[]) {

--- a/src/cli/spells/credentials/default-store.ts
+++ b/src/cli/spells/credentials/default-store.ts
@@ -140,4 +140,5 @@ export const lockedNoopAccessor: CredentialAccessor = {
   async get() { return undefined; },
   async has() { return false; },
   async store() { /* no-op */ },
+  async delete() { return false; },
 };

--- a/src/cli/spells/types/runner.types.ts
+++ b/src/cli/spells/types/runner.types.ts
@@ -33,6 +33,7 @@ export type SpellErrorCode =
   | 'PREREQUISITES_FAILED'
   | 'PREFLIGHT_FAILED'
   | 'MISSING_CREDENTIAL'
+  | 'CREDENTIAL_LIKELY_STALE'
   | 'SANDBOX_REQUIRED'
   | 'SPELL_CANCELLED';
 
@@ -208,6 +209,22 @@ export interface RunnerOptions {
    * Story #1002.
    */
   readonly forceCredentialReprompt?: boolean;
+
+  /**
+   * Override the auth-error recovery confirm prompt (issue #1042). When
+   * provided, the runner skips TTY detection and the stdin readline call
+   * and uses the returned boolean to decide whether to clear + re-prompt
+   * + retry. Returning true triggers the recovery path even in non-TTY
+   * environments. Returning false carries forward the original failure.
+   * Used by integration tests and by hosts that want to drive the prompt
+   * through their own UI (e.g. dashboard, MCP, daemon).
+   */
+  readonly authErrorConfirm?: (info: {
+    stepId: string;
+    pattern: string;
+    reason: string;
+    credKeys: readonly string[];
+  }) => Promise<boolean>;
 }
 
 // ============================================================================

--- a/src/cli/spells/types/step-command.types.ts
+++ b/src/cli/spells/types/step-command.types.ts
@@ -85,6 +85,13 @@ export interface CredentialAccessor {
    * may make this a no-op; callers should not assume durability.
    */
   store(name: string, value: string): Promise<void>;
+  /**
+   * Remove a credential. Returns true when an entry was deleted, false when
+   * no entry by that name existed. Optional — read-only accessors may omit
+   * it; the runner's auth-error recovery path (#1042) checks for presence
+   * before invoking.
+   */
+  delete?(name: string): Promise<boolean>;
 }
 
 export interface MemoryAccessor {

--- a/tests/system/auth-error-recovery-e2e.test.ts
+++ b/tests/system/auth-error-recovery-e2e.test.ts
@@ -1,0 +1,259 @@
+/**
+ * System E2E: auth-error recovery end-to-end (#1042).
+ *
+ * Drives the spell runner against a *real* `CredentialStore` (an encrypted
+ * file on disk in a tmpdir) and the real `resolveUnmetPrerequisites` flow,
+ * not the unit-test mock. The point is to prove the production wiring
+ * works as a system: stale credentials get cleared from the actual file,
+ * the resolver re-resolves through the real chain, and the runner retries
+ * the failing step with a fresh value.
+ *
+ * If any of the runner ↔ prerequisite-checker ↔ credential-store contract
+ * regresses, this is where it shows up — not in the per-module unit tests.
+ *
+ * Scenarios, mirroring the AC merge gate from the issue body:
+ *   1. Headline fix: stale token → confirm → fresh token → retry succeeds.
+ *   2. Initial cast (no creds): existing MISSING_CREDENTIAL path unchanged.
+ *   3. Happy path (valid stored creds): step succeeds, recovery never fires.
+ *   4. Confirm declined: original failure carried forward, store untouched.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SpellCaster } from '../../src/cli/spells/core/runner.js';
+import { StepCommandRegistry } from '../../src/cli/spells/core/step-command-registry.js';
+import {
+  CredentialStore,
+} from '../../src/cli/spells/credentials/credential-store.js';
+import type {
+  StepCommand,
+  MemoryAccessor,
+} from '../../src/cli/spells/types/step-command.types.js';
+import type { SpellDefinition } from '../../src/cli/spells/types/spell-definition.types.js';
+
+// ============================================================================
+// Test scaffolding
+// ============================================================================
+
+function makeMemory(): MemoryAccessor {
+  const m = new Map<string, unknown>();
+  return {
+    async read(ns, key) { return m.get(`${ns}:${key}`) ?? null; },
+    async write(ns, key, value) { m.set(`${ns}:${key}`, value); },
+    async search() { return []; },
+  };
+}
+
+interface FlakyAuth {
+  command: StepCommand;
+  /** Number of times execute() was invoked. */
+  calls: () => number;
+}
+
+/**
+ * Build a step command that fails with a Graph-style 401 on attempts
+ * 1..N and then returns success on attempt N+1. Used to model the real
+ * upstream behavior the recovery hook is designed to handle.
+ */
+function makeFlakyGraphCommand(failuresBeforeSuccess: number): FlakyAuth {
+  let calls = 0;
+  const command: StepCommand = {
+    type: 'graph-flaky',
+    description: 'Simulates Graph 401 on stale token',
+    configSchema: { type: 'object' },
+    validate: () => ({ valid: true, errors: [] }),
+    async execute() {
+      calls++;
+      if (calls <= failuresBeforeSuccess) {
+        return {
+          success: false,
+          data: {},
+          error:
+            'Graph read-inbox failed: Graph 401:{"error":{"code":"InvalidAuthenticationToken","message":"IDX14100: JWT is not well formed, there are no dots (.)"}}',
+          duration: 1,
+        };
+      }
+      return { success: true, data: { messages: [] }, duration: 1 };
+    },
+    describeOutputs: () => [],
+  };
+  return { command, calls: () => calls };
+}
+
+function spellWithGraphPrereq(): SpellDefinition {
+  return {
+    name: 'oap-style-test-spell',
+    prerequisites: [
+      {
+        name: 'GRAPH_ACCESS_TOKEN',
+        detect: { type: 'env', key: 'GRAPH_ACCESS_TOKEN' },
+        promptOnMissing: true,
+        description: 'Microsoft Graph access token',
+      },
+    ],
+    steps: [{ id: 'read-inbox', type: 'graph-flaky', config: {} }],
+  };
+}
+
+// Reusable env-restore guard so a failed assertion doesn't leak GRAPH_ACCESS_TOKEN
+// into other tests.
+let savedToken: string | undefined;
+let tmpDir: string;
+let store: CredentialStore;
+
+beforeEach(() => {
+  savedToken = process.env.GRAPH_ACCESS_TOKEN;
+  delete process.env.GRAPH_ACCESS_TOKEN;
+  tmpDir = mkdtempSync(join(tmpdir(), 'moflo-auth-e2e-'));
+  store = new CredentialStore({
+    filePath: join(tmpDir, 'credentials.json'),
+    passphrase: 'test-passphrase-1234',
+  });
+});
+
+afterEach(() => {
+  if (savedToken === undefined) delete process.env.GRAPH_ACCESS_TOKEN;
+  else process.env.GRAPH_ACCESS_TOKEN = savedToken;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('System E2E — auth-error recovery (#1042)', () => {
+  it('headline: stale token → confirm → fresh token → retry succeeds (real CredentialStore)', async () => {
+    // Pre-store a "stale" token in the encrypted store + env.
+    await store.store('GRAPH_ACCESS_TOKEN', 'stale-opaque-token-from-yesterday');
+    process.env.GRAPH_ACCESS_TOKEN = 'stale-opaque-token-from-yesterday';
+
+    const flaky = makeFlakyGraphCommand(/* failuresBeforeSuccess */ 1);
+    const registry = new StepCommandRegistry();
+    registry.register(flaky.command);
+    const caster = new SpellCaster(registry, store, makeMemory());
+
+    // Simulate the user typing a fresh token at the resolver's prompt by
+    // intercepting the credentials accessor between the runner's clear and
+    // the prereq resolver's get. The accessor hands back a fresh value to
+    // the resolver, which writes it to env+store.
+    const realDelete = store.delete.bind(store);
+    const realStore = store.store.bind(store);
+    let userPastedFresh = false;
+    (store as unknown as { delete: (n: string) => Promise<boolean> }).delete = async (
+      name: string,
+    ): Promise<boolean> => {
+      const r = await realDelete(name);
+      // Mimic the resolver's TTY prompt eliciting a new token from the user.
+      await realStore(name, 'fresh-real-graph-token-eyJ...working');
+      userPastedFresh = true;
+      return r;
+    };
+
+    const result = await caster.run(spellWithGraphPrereq(), {}, {
+      authErrorConfirm: async (info) => {
+        expect(info.stepId).toBe('read-inbox');
+        expect(info.credKeys).toEqual(['GRAPH_ACCESS_TOKEN']);
+        expect(info.pattern).toBe('msal-idx141');
+        return true;
+      },
+    });
+
+    expect(userPastedFresh).toBe(true);
+    expect(flaky.calls()).toBe(2);
+    expect(result.success).toBe(true);
+    expect(result.steps[0].status).toBe('succeeded');
+
+    // Verify the encrypted file on disk reflects the new token, not the stale one.
+    const stored = await store.get('GRAPH_ACCESS_TOKEN');
+    expect(stored).toBe('fresh-real-graph-token-eyJ...working');
+    expect(process.env.GRAPH_ACCESS_TOKEN).toBe('fresh-real-graph-token-eyJ...working');
+
+    // The credentials.json file should exist and contain encrypted data
+    // (not the plaintext token — sanity check that we used the real
+    // CredentialStore not a mock that skipped encryption).
+    const credsPath = join(tmpDir, 'credentials.json');
+    expect(existsSync(credsPath)).toBe(true);
+    const raw = readFileSync(credsPath, 'utf-8');
+    expect(raw).not.toContain('fresh-real-graph-token');
+    expect(raw).not.toContain('stale-opaque-token');
+  });
+
+  it('initial cast (no stored creds, non-TTY): MISSING_CREDENTIAL surfaces unchanged', async () => {
+    // Empty store, no env — recovery code should never trigger because
+    // the spell fails at preflight resolution, not at step execution.
+    const flaky = makeFlakyGraphCommand(Number.POSITIVE_INFINITY);
+    const registry = new StepCommandRegistry();
+    registry.register(flaky.command);
+    const caster = new SpellCaster(registry, store, makeMemory());
+
+    const result = await caster.run(spellWithGraphPrereq(), {});
+    expect(result.success).toBe(false);
+    expect(flaky.calls()).toBe(0); // step never ran — preflight blocked
+    expect(result.errors[0].code).toBe('MISSING_CREDENTIAL');
+  });
+
+  it('happy path (valid stored creds): step succeeds, recovery never fires', async () => {
+    await store.store('GRAPH_ACCESS_TOKEN', 'valid-and-working-token');
+    process.env.GRAPH_ACCESS_TOKEN = 'valid-and-working-token';
+
+    const flaky = makeFlakyGraphCommand(/* failuresBeforeSuccess */ 0);
+    const registry = new StepCommandRegistry();
+    registry.register(flaky.command);
+    const caster = new SpellCaster(registry, store, makeMemory());
+
+    let confirmCalled = false;
+    const result = await caster.run(spellWithGraphPrereq(), {}, {
+      authErrorConfirm: async () => { confirmCalled = true; return true; },
+    });
+
+    expect(confirmCalled).toBe(false);
+    expect(flaky.calls()).toBe(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('confirm declined: original failure carried forward, encrypted store untouched', async () => {
+    await store.store('GRAPH_ACCESS_TOKEN', 'still-working-token');
+    process.env.GRAPH_ACCESS_TOKEN = 'still-working-token';
+
+    const flaky = makeFlakyGraphCommand(/* failuresBeforeSuccess */ 5);
+    const registry = new StepCommandRegistry();
+    registry.register(flaky.command);
+    const caster = new SpellCaster(registry, store, makeMemory());
+
+    const result = await caster.run(spellWithGraphPrereq(), {}, {
+      authErrorConfirm: async () => false, // user declines
+    });
+
+    expect(flaky.calls()).toBe(1); // no retry
+    expect(result.success).toBe(false);
+    // Original failure preserved — error code is the standard step failure,
+    // not CREDENTIAL_LIKELY_STALE (that code is reserved for non-TTY surface
+    // and after-reprompt second-failure).
+    expect(result.steps[0].errorCode).toBe('STEP_EXECUTION_FAILED');
+    // Store value is unchanged.
+    expect(await store.get('GRAPH_ACCESS_TOKEN')).toBe('still-working-token');
+  });
+
+  it('non-TTY without host hook: surface CREDENTIAL_LIKELY_STALE (scheduler-friendly)', async () => {
+    await store.store('GRAPH_ACCESS_TOKEN', 'stale-opaque');
+    process.env.GRAPH_ACCESS_TOKEN = 'stale-opaque';
+
+    const flaky = makeFlakyGraphCommand(Number.POSITIVE_INFINITY);
+    const registry = new StepCommandRegistry();
+    registry.register(flaky.command);
+    const caster = new SpellCaster(registry, store, makeMemory());
+
+    // No authErrorConfirm hook, no TTY in test env → recovery surfaces a
+    // dedicated error code without prompting or destroying the store.
+    const result = await caster.run(spellWithGraphPrereq(), {});
+
+    expect(result.success).toBe(false);
+    expect(flaky.calls()).toBe(1); // first attempt only
+    expect(result.steps[0].errorCode).toBe('CREDENTIAL_LIKELY_STALE');
+    expect(result.steps[0].error).toMatch(/CREDENTIAL_LIKELY_STALE.*GRAPH_ACCESS_TOKEN/);
+    // Store untouched — non-TTY recovery is informational, not destructive.
+    expect(await store.get('GRAPH_ACCESS_TOKEN')).toBe('stale-opaque');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a post-step auth-error classifier in the spell runner: when a step fails with a known upstream auth signal (MS Graph `IDX1410x`, `InvalidAuthenticationToken`, OAuth `invalid_grant`/`expired_token`, GitHub `Bad credentials`, HTTP 401) AND the spell has env-typed credential prereqs, the runner offers (TTY) or surfaces (non-TTY) the chance to clear the stored credential, re-prompt, and retry the failing step once.
- Pattern table lives in one file (`src/cli/spells/core/auth-error-classifier.ts`); adding upstream signals is a one-line edit.
- Reviewer-driven safety gates: low-confidence patterns (HTTP 403, bare "Unauthorized") only log a hint — never auto-clear; multi-cred prompt default flips Y→N to prevent a stray Enter from wiping a working credential.

Closes #1042.

## Changes
- **New** `src/cli/spells/core/auth-error-classifier.ts` — pure module with the pattern table + `classifyAuthError(text)` function. No `/g` flag (statefulness ban from `feedback_publish_catches_straggler_bugs`).
- **`src/cli/spells/core/runner.ts`** — new private `tryAuthErrorRecovery` hook called between step failure and the standard failure flow. Replaces the result on retry success or short-circuits with `CREDENTIAL_LIKELY_STALE` on second auth-shape failure.
- **`src/cli/spells/types/{runner.types.ts,step-command.types.ts}`** — adds `CREDENTIAL_LIKELY_STALE` error code, new optional `RunnerOptions.authErrorConfirm` hook (test/host injection), and optional `CredentialAccessor.delete` method.
- **`src/cli/spells/credentials/default-store.ts`** — `lockedNoopAccessor.delete` no-op.
- **`.claude/guidance/internal/testing-conventions.md`** — new §11 "Test What You Change" + "Smoke tests: reliable or not at all" — internal-only standard.

## Testing
**8397 tests pass**, including three dedicated suites:

- [x] `src/cli/__tests__/spells/auth-error-classifier.test.ts` — 15 cases covering each pattern positive + negative, plus table integrity (unique names, no `/g` flags, every pattern has a confidence tier).
- [x] `src/cli/__tests__/spells/auth-error-runner.test.ts` — 10 runner-level scenarios via the `authErrorConfirm` host hook: non-TTY surface, retry-succeeds happy path, second-failure short-circuit, decline carries original error, no-creds-in-prereqs skip, non-auth-error skip, low-confidence skip, multi-cred default-N flip.
- [x] `tests/system/auth-error-recovery-e2e.test.ts` — 5 system E2E cases against a **real** encrypted `CredentialStore` on disk (tmpdir): stale-token + confirm + fresh-token retry succeeds (with on-disk verification), missing-creds path unchanged, valid-creds happy path, decline-carries-forward, non-TTY scheduler-friendly surface.
- [x] `npm run build` clean.
- [x] `npm test` (parallel + isolation passes) green.

### Live-machine validation (the issue's mandatory merge gate)
The system E2E exercises the full runner ↔ prereq-checker ↔ credential-store contract against a real on-disk encrypted store, covering the three AC paths (stale recovery, initial cast, happy path) deterministically.

After install on a consumer project, the maintainer should still spot-check the OAP scenario (the original failure mode):
1. Cast OAP with a deliberately-expired/invalid Graph token → triggers prompt → paste fresh token → cast completes.
2. Cast OAP with no stored creds → existing `promptOnMissing` path fires unchanged.
3. Cast OAP with valid stored creds → cast completes with zero prompts.

## Consumer impact
- Surface touched: `src/cli/spells/core/runner.ts` (runtime — every consumer's spell cast goes through this).
- Failure mode for on-current-version consumer: additive — new code path only fires on step failure with an auth-pattern match AND env-keyed credential prereqs. Unchanged paths are byte-identical.
- Round-trip cost: yes — requires publish + reinstall to reach consumers.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)