### PR TITLE
feat(1044): Claude Stats tab in The Luminarium with local session metrics

### DIFF
--- a/src/cli/__tests__/services/claude-stats.test.ts
+++ b/src/cli/__tests__/services/claude-stats.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for the Claude Stats aggregator (#1044).
+ *
+ * Drive the JSONL streaming aggregator against a real on-disk tmpdir of
+ * fixture transcripts. The cost computation, time-bucketing, and tool/error
+ * extraction logic is what's at risk of regression — exercise each
+ * end-to-end rather than mocking out fs and re-implementing the loop.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  _resetClaudeStatsCache,
+  aggregateClaudeStats,
+  encodeCwdForClaudeProjects,
+} from '../../services/claude-stats.js';
+import {
+  CLAUDE_RATES,
+  canonicalModelKey,
+  costFromUsage,
+  rateForModel,
+} from '../../services/claude-model-rates.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface UsageBlock {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+interface AssistantLineOpts {
+  ts: string;
+  sessionId: string;
+  model: string;
+  usage: UsageBlock;
+  toolName?: string;
+}
+
+function assistantLine(o: AssistantLineOpts): string {
+  const content: object[] = [{ type: 'text', text: 'hi' }];
+  if (o.toolName) content.push({ type: 'tool_use', name: o.toolName });
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: o.ts,
+    sessionId: o.sessionId,
+    message: { role: 'assistant', model: o.model, content, usage: o.usage },
+  });
+}
+
+function toolErrorLine(ts: string, sessionId: string): string {
+  return JSON.stringify({
+    type: 'user',
+    timestamp: ts,
+    sessionId,
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', is_error: true }],
+    },
+  });
+}
+
+let dir: string;
+
+beforeEach(() => {
+  _resetClaudeStatsCache();
+  dir = mkdtempSync(join(tmpdir(), 'moflo-claude-stats-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ============================================================================
+// Path encoding
+// ============================================================================
+
+describe('encodeCwdForClaudeProjects', () => {
+  it('encodes Windows-style CWDs to the dashed form Claude Code uses', () => {
+    expect(encodeCwdForClaudeProjects('C:\\Users\\eric\\Projects\\moflo'))
+      .toBe('C--Users-eric-Projects-moflo');
+  });
+
+  it('encodes POSIX-style CWDs', () => {
+    expect(encodeCwdForClaudeProjects('/Users/alice/proj/moflo'))
+      .toBe('-Users-alice-proj-moflo');
+  });
+});
+
+// ============================================================================
+// Rate table + canonicalisation
+// ============================================================================
+
+describe('claude-model-rates', () => {
+  it('maps dated/dotted model names to canonical keys', () => {
+    expect(canonicalModelKey('claude-opus-4-7')).toBe('opus');
+    expect(canonicalModelKey('claude-3-5-sonnet-20241022')).toBe('sonnet');
+    expect(canonicalModelKey('haiku-4-5')).toBe('haiku');
+    expect(canonicalModelKey('Opus')).toBe('opus');
+    expect(canonicalModelKey('made-up-model')).toBe('unknown');
+    expect(canonicalModelKey(undefined)).toBe('unknown');
+  });
+
+  it('computes USD cost per million tokens correctly', () => {
+    const rate = CLAUDE_RATES.sonnet;
+    // 1M input tokens at $3 + 0.5M output at $15 = $3 + $7.50 = $10.50.
+    const cost = costFromUsage(rate, { input: 1_000_000, output: 500_000 });
+    expect(cost).toBeCloseTo(10.5, 5);
+  });
+
+  it('rateForModel falls back to unknown for unrecognised', () => {
+    expect(rateForModel('vapor-ai-7')).toEqual(CLAUDE_RATES.unknown);
+  });
+});
+
+// ============================================================================
+// Aggregation
+// ============================================================================
+
+describe('aggregateClaudeStats', () => {
+  it('returns the all-zero unavailable shape when the project dir is empty', async () => {
+    const stats = await aggregateClaudeStats('cwd-ignored', { projectDir: dir });
+    expect(stats.available).toBe(false);
+    expect(stats.totalSessions).toBe(0);
+    expect(stats.windows.lifetime.tokens.total).toBe(0);
+    expect(stats.windows.lifetime.costUsd).toBe(0);
+  });
+
+  it('returns the all-zero unavailable shape when the dir does not exist', async () => {
+    const stats = await aggregateClaudeStats('cwd', { projectDir: join(dir, 'no-such') });
+    expect(stats.available).toBe(false);
+  });
+
+  it('parses a single assistant line and surfaces token + cost totals', async () => {
+    writeFileSync(
+      join(dir, 'session-a.jsonl'),
+      assistantLine({
+        ts: '2026-05-09T12:00:00Z',
+        sessionId: 'A',
+        model: 'claude-opus-4-7',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 1000,
+          cache_read_input_tokens: 500,
+        },
+      }),
+    );
+
+    const stats = await aggregateClaudeStats('cwd', {
+      projectDir: dir,
+      now: Date.parse('2026-05-09T12:30:00Z'),
+    });
+
+    expect(stats.available).toBe(true);
+    expect(stats.totalSessions).toBe(1);
+    expect(stats.windows.lifetime.tokens.input).toBe(100);
+    expect(stats.windows.lifetime.tokens.output).toBe(50);
+    expect(stats.windows.lifetime.tokens.cacheCreate).toBe(1000);
+    expect(stats.windows.lifetime.tokens.cacheRead).toBe(500);
+    expect(stats.windows.lifetime.tokens.total).toBe(1650);
+
+    // Hand-computed: 100 * 15 + 50 * 75 + 1000 * 18.75 + 500 * 1.5
+    //              = 1500 + 3750 + 18750 + 750 = 24750 (per-1M units).
+    // Divide by 1e6 → 0.02475
+    expect(stats.windows.lifetime.costUsd).toBeCloseTo(0.0248, 3);
+  });
+
+  it('buckets tokens correctly across today / 7d / 30d / lifetime', async () => {
+    const now = Date.parse('2026-05-09T12:00:00Z');
+    const within24h = new Date(now - 1 * 60 * 60 * 1000).toISOString(); // 1h ago
+    const within7d = new Date(now - 5 * 86_400_000).toISOString();
+    const within30d = new Date(now - 20 * 86_400_000).toISOString();
+    const beyond30d = new Date(now - 100 * 86_400_000).toISOString();
+
+    const lines = [
+      assistantLine({ ts: within24h, sessionId: 'today', model: 'opus', usage: { input_tokens: 1 } }),
+      assistantLine({ ts: within7d, sessionId: 'week', model: 'opus', usage: { input_tokens: 2 } }),
+      assistantLine({ ts: within30d, sessionId: 'month', model: 'opus', usage: { input_tokens: 4 } }),
+      assistantLine({ ts: beyond30d, sessionId: 'old', model: 'opus', usage: { input_tokens: 8 } }),
+    ];
+    writeFileSync(join(dir, 'multi.jsonl'), lines.join('\n'));
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir, now });
+
+    expect(stats.windows.today.tokens.input).toBe(1);
+    expect(stats.windows.last7d.tokens.input).toBe(1 + 2);
+    expect(stats.windows.last30d.tokens.input).toBe(1 + 2 + 4);
+    expect(stats.windows.lifetime.tokens.input).toBe(1 + 2 + 4 + 8);
+    expect(stats.windows.lifetime.sessions).toBe(4);
+    expect(stats.windows.last30d.sessions).toBe(3);
+  });
+
+  it('skips lines with no usage block (user/system/etc)', async () => {
+    const ts = '2026-05-09T12:00:00Z';
+    const lines = [
+      JSON.stringify({ type: 'permission-mode', sessionId: 'x', timestamp: ts }),
+      JSON.stringify({ type: 'user', timestamp: ts, sessionId: 'x', message: { role: 'user', content: [{ type: 'text', text: 'hi' }] } }),
+      assistantLine({ ts, sessionId: 'x', model: 'opus', usage: { input_tokens: 7 } }),
+    ];
+    writeFileSync(join(dir, 'mixed.jsonl'), lines.join('\n'));
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(stats.windows.lifetime.tokens.input).toBe(7);
+    expect(stats.parseErrors).toBe(0);
+  });
+
+  it('counts malformed lines as parseErrors without throwing', async () => {
+    const ts = '2026-05-09T12:00:00Z';
+    const lines = [
+      '{ this is not json',
+      assistantLine({ ts, sessionId: 'a', model: 'sonnet', usage: { input_tokens: 1 } }),
+      'also { broken',
+    ];
+    writeFileSync(join(dir, 'broken.jsonl'), lines.join('\n'));
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(stats.parseErrors).toBe(2);
+    expect(stats.windows.lifetime.tokens.input).toBe(1);
+  });
+
+  it('aggregates the model distribution sorted by tokens desc', async () => {
+    const ts = '2026-05-09T12:00:00Z';
+    const lines = [
+      assistantLine({ ts, sessionId: 'a', model: 'haiku', usage: { input_tokens: 1 } }),
+      assistantLine({ ts, sessionId: 'a', model: 'opus', usage: { input_tokens: 100 } }),
+      assistantLine({ ts, sessionId: 'b', model: 'sonnet', usage: { input_tokens: 10 } }),
+      assistantLine({ ts, sessionId: 'b', model: 'opus', usage: { input_tokens: 50 } }),
+    ];
+    writeFileSync(join(dir, 'models.jsonl'), lines.join('\n'));
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(stats.models[0].model).toBe('opus');
+    expect(stats.models[0].tokens).toBe(150);
+    expect(stats.models[0].messages).toBe(2);
+    expect(stats.models[1].model).toBe('sonnet');
+    expect(stats.models[2].model).toBe('haiku');
+  });
+
+  it('captures top tools and counts each tool_use block', async () => {
+    const ts = '2026-05-09T12:00:00Z';
+    const lines = [
+      assistantLine({ ts, sessionId: 'a', model: 'opus', usage: { input_tokens: 1 }, toolName: 'Read' }),
+      assistantLine({ ts, sessionId: 'a', model: 'opus', usage: { input_tokens: 1 }, toolName: 'Read' }),
+      assistantLine({ ts, sessionId: 'a', model: 'opus', usage: { input_tokens: 1 }, toolName: 'Bash' }),
+    ];
+    writeFileSync(join(dir, 'tools.jsonl'), lines.join('\n'));
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    const byName = Object.fromEntries(stats.tools.map(t => [t.name, t.count]));
+    expect(byName.Read).toBe(2);
+    expect(byName.Bash).toBe(1);
+  });
+
+  it('marks sessions with tool_result errors and counts only distinct sessions', async () => {
+    const ts = '2026-05-09T12:00:00Z';
+    const lines = [
+      assistantLine({ ts, sessionId: 'happy', model: 'opus', usage: { input_tokens: 1 } }),
+      assistantLine({ ts, sessionId: 'sad', model: 'opus', usage: { input_tokens: 1 } }),
+      toolErrorLine(ts, 'sad'),
+      toolErrorLine(ts, 'sad'), // second error on same session — still 1
+    ];
+    writeFileSync(join(dir, 'errors.jsonl'), lines.join('\n'));
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(stats.errorSessions).toBe(1);
+    expect(stats.totalSessions).toBe(2);
+  });
+
+  it('computes session duration from first/last timestamp per session', async () => {
+    const lines = [
+      assistantLine({ ts: '2026-05-09T12:00:00Z', sessionId: 's1', model: 'opus', usage: { input_tokens: 1 } }),
+      assistantLine({ ts: '2026-05-09T12:30:00Z', sessionId: 's1', model: 'opus', usage: { input_tokens: 1 } }),
+      assistantLine({ ts: '2026-05-09T11:00:00Z', sessionId: 's2', model: 'opus', usage: { input_tokens: 1 } }),
+      assistantLine({ ts: '2026-05-09T11:10:00Z', sessionId: 's2', model: 'opus', usage: { input_tokens: 1 } }),
+    ];
+    writeFileSync(join(dir, 'durations.jsonl'), lines.join('\n'));
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    // Two durations: 30min + 10min. Median (lower-of-2 by Math.floor) = 30min.
+    expect(stats.sessionDurationMs.median).toBe(30 * 60 * 1000);
+    expect(stats.sessionDurationMs.p95).toBe(30 * 60 * 1000);
+  });
+
+  it('caches results for repeat calls within TTL', async () => {
+    writeFileSync(
+      join(dir, 'cache.jsonl'),
+      assistantLine({ ts: '2026-05-09T12:00:00Z', sessionId: 'A', model: 'opus', usage: { input_tokens: 1 } }),
+    );
+
+    const first = await aggregateClaudeStats('cwd', { projectDir: dir });
+    const second = await aggregateClaudeStats('cwd', { projectDir: dir });
+    // Same object reference proves the cache short-circuited.
+    expect(second).toBe(first);
+
+    const fresh = await aggregateClaudeStats('cwd', { projectDir: dir, skipCache: true });
+    // Fresh aggregation produces a structurally identical but distinct object.
+    expect(fresh).not.toBe(first);
+    expect(fresh.windows.lifetime.tokens.input).toBe(first.windows.lifetime.tokens.input);
+  });
+});

--- a/src/cli/__tests__/services/dashboard-claude-stats-route.test.ts
+++ b/src/cli/__tests__/services/dashboard-claude-stats-route.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration test: GET /api/claude-stats end-to-end (#1044).
+ *
+ * Boots a real `startDashboard` against a stub `WorkerDaemon`, writes a
+ * tiny on-disk JSONL fixture, then issues a real HTTP GET. Validates the
+ * shape — wires the consumer (poll loop) would consume.
+ *
+ * Why not unit-test `handleClaudeStats` directly? The route registration in
+ * `handleRequest` is exactly the kind of thing that breaks silently if a
+ * future refactor moves the endpoint string or the `if/else` chain.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { request } from 'node:http';
+import {
+  startDashboard,
+  type DashboardHandle,
+} from '../../services/daemon-dashboard.js';
+import { _resetClaudeStatsCache } from '../../services/claude-stats.js';
+
+let tmpRoot: string;
+let savedHome: string | undefined;
+let savedHomedrive: string | undefined;
+let savedHomepath: string | undefined;
+let savedUserprofile: string | undefined;
+let savedCwd: string;
+let handle: DashboardHandle | null = null;
+
+const stubDaemon = {
+  getStatus: () => ({
+    running: true,
+    pid: process.pid,
+    startedAt: new Date(),
+    config: { maxConcurrent: 1, workerTimeoutMs: 1000, resourceThresholds: {}, workers: [] },
+    workers: new Map(),
+  }),
+  getScheduler: () => null,
+} as unknown as Parameters<typeof startDashboard>[0];
+
+beforeEach(() => {
+  _resetClaudeStatsCache();
+  tmpRoot = mkdtempSync(join(tmpdir(), 'moflo-cs-route-'));
+  savedHome = process.env.HOME;
+  savedHomedrive = process.env.HOMEDRIVE;
+  savedHomepath = process.env.HOMEPATH;
+  savedUserprofile = process.env.USERPROFILE;
+  process.env.HOME = tmpRoot;
+  process.env.USERPROFILE = tmpRoot;
+  delete process.env.HOMEDRIVE;
+  delete process.env.HOMEPATH;
+  savedCwd = process.cwd();
+});
+
+afterEach(async () => {
+  if (handle) {
+    await handle.stop();
+    handle = null;
+  }
+  if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+  if (savedHomedrive === undefined) delete process.env.HOMEDRIVE; else process.env.HOMEDRIVE = savedHomedrive;
+  if (savedHomepath === undefined) delete process.env.HOMEPATH; else process.env.HOMEPATH = savedHomepath;
+  if (savedUserprofile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = savedUserprofile;
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// Avoid the well-known dashboard port range so a daemon already running
+// on the dev machine doesn't clash with the test. startDashboard tries
+// port+1..port+9 on EADDRINUSE so a random base above 30000 is plenty.
+function pickPort(): number {
+  return 30_000 + Math.floor(Math.random() * 30_000);
+}
+
+function getJson(port: number, path: string): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const req = request({ host: '127.0.0.1', port, path, method: 'GET' }, res => {
+      const chunks: Buffer[] = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf-8');
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(body) });
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body });
+        }
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('GET /api/claude-stats', () => {
+  it('returns the empty-shape body when no transcripts exist for this CWD', async () => {
+    // homedir() is now tmpRoot but no .claude/projects/<cwd>/ dir exists.
+    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    const { status, body } = await getJson(handle.port, '/api/claude-stats');
+    expect(status).toBe(200);
+    const shape = body as { available: boolean; totalSessions: number };
+    expect(shape.available).toBe(false);
+    expect(shape.totalSessions).toBe(0);
+  });
+
+  it('returns aggregated stats when transcripts exist for the CWD', async () => {
+    const cwd = process.cwd();
+    const encoded = cwd.replace(/[\\/:]/g, '-');
+    const projDir = join(tmpRoot, '.claude', 'projects', encoded);
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      join(projDir, 'session.jsonl'),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: new Date().toISOString(),
+        sessionId: 'route-test',
+        message: { role: 'assistant', model: 'claude-opus-4-7', content: [], usage: { input_tokens: 10, output_tokens: 5 } },
+      }),
+    );
+
+    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    const { status, body } = await getJson(handle.port, '/api/claude-stats');
+    expect(status).toBe(200);
+    const shape = body as {
+      available: boolean;
+      totalSessions: number;
+      windows: { lifetime: { tokens: { input: number; output: number } } };
+    };
+    expect(shape.available).toBe(true);
+    expect(shape.totalSessions).toBe(1);
+    expect(shape.windows.lifetime.tokens.input).toBe(10);
+    expect(shape.windows.lifetime.tokens.output).toBe(5);
+  });
+});

--- a/src/cli/services/claude-model-rates.ts
+++ b/src/cli/services/claude-model-rates.ts
@@ -1,0 +1,83 @@
+/**
+ * Claude model rate table for The Luminarium "Claude Stats" tab cost
+ * estimation. Rates are USD per 1M tokens for the public list-price tier
+ * sourced from https://www.anthropic.com/pricing.
+ *
+ * The cost number rendered in the UI is *clearly labelled an estimate* —
+ * actual billing depends on the user's contract, plan, and any cache
+ * discounts Anthropic adjusts behind the scenes. Drift is bounded user
+ * impact: a stale rate just means the displayed dollar figure lags reality
+ * by a small percentage until the next moflo release.
+ *
+ * Source: https://www.anthropic.com/pricing
+ * Last verified: 2026-05-09
+ */
+export interface ClaudeRate {
+  /** USD per 1M input tokens. */
+  readonly input: number;
+  /** USD per 1M output tokens. */
+  readonly output: number;
+  /** USD per 1M cache-creation tokens (5m or 1h ephemeral cache writes). */
+  readonly cacheCreate: number;
+  /** USD per 1M cache-read tokens (cheap re-reads). */
+  readonly cacheRead: number;
+}
+
+/**
+ * Per-model USD/1M rates. Lookup goes through {@link rateForModel}, which
+ * normalises the transcript's loose model names ("opus", "claude-opus-4-7",
+ * "haiku-4-5", etc.) onto a canonical key.
+ */
+export const CLAUDE_RATES: Record<string, ClaudeRate> = {
+  // Opus 4.x family
+  opus: { input: 15, output: 75, cacheCreate: 18.75, cacheRead: 1.5 },
+  // Sonnet 4.x family
+  sonnet: { input: 3, output: 15, cacheCreate: 3.75, cacheRead: 0.3 },
+  // Haiku 4.x family
+  haiku: { input: 0.8, output: 4, cacheCreate: 1, cacheRead: 0.08 },
+  // Unknown — zeroed out so the cost UI shows $0 for unrecognised models
+  // rather than guessing wrong. The model name still surfaces in the
+  // distribution card so the user can see the gap.
+  unknown: { input: 0, output: 0, cacheCreate: 0, cacheRead: 0 },
+};
+
+/** Canonical model keys, ordered most-expensive → cheapest for stable display. */
+export const CANONICAL_MODELS: readonly string[] = ['opus', 'sonnet', 'haiku', 'unknown'];
+
+/**
+ * Map a transcript model name to a canonical rate key. Recognises:
+ *   - bare family names: "opus", "sonnet", "haiku"
+ *   - dated/dotted variants: "claude-opus-4-7", "claude-3-5-sonnet-20241022"
+ *   - case-insensitive
+ * Anything else falls through to `'unknown'`.
+ */
+export function canonicalModelKey(model: string | null | undefined): string {
+  if (!model || typeof model !== 'string') return 'unknown';
+  const lower = model.toLowerCase();
+  if (lower.includes('opus')) return 'opus';
+  if (lower.includes('sonnet')) return 'sonnet';
+  if (lower.includes('haiku')) return 'haiku';
+  return 'unknown';
+}
+
+/** Resolve a `ClaudeRate` row for the given (possibly raw) model name. */
+export function rateForModel(model: string | null | undefined): ClaudeRate {
+  return CLAUDE_RATES[canonicalModelKey(model)] ?? CLAUDE_RATES.unknown;
+}
+
+/**
+ * Compute USD cost for a single usage record.
+ * Rates are per 1M tokens; divide by 1e6 once at the end.
+ */
+export function costFromUsage(
+  rate: ClaudeRate,
+  usage: { input?: number; output?: number; cacheCreate?: number; cacheRead?: number },
+): number {
+  const i = usage.input ?? 0;
+  const o = usage.output ?? 0;
+  const cc = usage.cacheCreate ?? 0;
+  const cr = usage.cacheRead ?? 0;
+  return (
+    (i * rate.input + o * rate.output + cc * rate.cacheCreate + cr * rate.cacheRead) / 1_000_000
+  );
+}

--- a/src/cli/services/claude-stats.ts
+++ b/src/cli/services/claude-stats.ts
@@ -1,0 +1,451 @@
+/**
+ * Claude Stats aggregator — issue #1044.
+ *
+ * Reads `~/.claude/projects/<encoded-cwd>/*.jsonl` line-by-line and produces
+ * the JSON shape consumed by The Luminarium's "Claude Stats" tab. Pure I/O
+ * + reduce; no persistent storage, no network.
+ *
+ * Performance posture:
+ *   - Streaming readline (not `readFileSync().split('\n')`) — transcripts
+ *     can grow to tens of MB and we don't want to balloon dashboard memory.
+ *   - Aggregate counters only — message bodies are dropped after extracting
+ *     `usage`, `model`, `tool_use.name`, `tool_result.is_error`.
+ *   - 30s TTL cache keyed on the most-recent file mtime in the project dir
+ *     so consecutive dashboard polls reuse the prior aggregation when no
+ *     transcript has changed.
+ */
+
+import { createReadStream } from 'node:fs';
+import { stat, readdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import { canonicalModelKey, costFromUsage, rateForModel } from './claude-model-rates.js';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface ClaudeStatsWindow {
+  readonly sessions: number;
+  readonly tokens: {
+    readonly input: number;
+    readonly output: number;
+    readonly cacheCreate: number;
+    readonly cacheRead: number;
+    readonly total: number;
+  };
+  readonly costUsd: number;
+}
+
+export interface ModelDistribution {
+  readonly model: string;
+  readonly messages: number;
+  readonly tokens: number;
+}
+
+export interface ToolUsage {
+  readonly name: string;
+  readonly count: number;
+}
+
+export interface ClaudeStatsShape {
+  readonly available: boolean;
+  readonly projectDir: string | null;
+  readonly windows: {
+    readonly today: ClaudeStatsWindow;
+    readonly last7d: ClaudeStatsWindow;
+    readonly last30d: ClaudeStatsWindow;
+    readonly lifetime: ClaudeStatsWindow;
+  };
+  readonly models: readonly ModelDistribution[];
+  readonly tools: readonly ToolUsage[];
+  /** Sessions whose transcript contained at least one tool_result.is_error. */
+  readonly errorSessions: number;
+  /** Median + p95 of (last - first timestamp) per session, milliseconds. */
+  readonly sessionDurationMs: { readonly median: number; readonly p95: number };
+  /** Total session count over lifetime (== windows.lifetime.sessions). */
+  readonly totalSessions: number;
+  /** Lines that failed to parse — surfaced for debugging, not user-facing. */
+  readonly parseErrors: number;
+  /** Aggregation wall-clock duration in ms — populated when computed. */
+  readonly elapsedMs: number;
+}
+
+// ============================================================================
+// Path resolution
+// ============================================================================
+
+/**
+ * Encode a CWD the same way Claude Code does for `~/.claude/projects/<dir>`.
+ * Replaces `\`, `/`, and `:` with `-` so `C:\Users\eric\Projects\moflo` →
+ * `C--Users-eric-Projects-moflo`.
+ */
+export function encodeCwdForClaudeProjects(cwd: string): string {
+  return cwd.replace(/[\\/:]/g, '-');
+}
+
+/** Absolute path to `~/.claude/projects/<encoded-cwd>` for the given CWD. */
+export function claudeProjectDirFor(cwd: string): string {
+  return join(homedir(), '.claude', 'projects', encodeCwdForClaudeProjects(cwd));
+}
+
+// ============================================================================
+// Cache
+// ============================================================================
+
+interface CacheEntry {
+  readonly key: string; // most-recent-mtime + total-bytes signature
+  readonly value: ClaudeStatsShape;
+  readonly cachedAt: number;
+}
+
+const CACHE_TTL_MS = 30_000;
+let cache: CacheEntry | null = null;
+
+/** Test-only — drop the in-memory cache so the next call re-aggregates. */
+export function _resetClaudeStatsCache(): void {
+  cache = null;
+}
+
+// ============================================================================
+// Aggregation
+// ============================================================================
+
+const DAY_MS = 86_400_000;
+
+interface MutableWindow {
+  sessions: Set<string>;
+  input: number;
+  output: number;
+  cacheCreate: number;
+  cacheRead: number;
+  costUsd: number;
+}
+
+function emptyWindow(): MutableWindow {
+  return { sessions: new Set(), input: 0, output: 0, cacheCreate: 0, cacheRead: 0, costUsd: 0 };
+}
+
+function freezeWindow(w: MutableWindow): ClaudeStatsWindow {
+  const total = w.input + w.output + w.cacheCreate + w.cacheRead;
+  return {
+    sessions: w.sessions.size,
+    tokens: {
+      input: w.input,
+      output: w.output,
+      cacheCreate: w.cacheCreate,
+      cacheRead: w.cacheRead,
+      total,
+    },
+    costUsd: round4(w.costUsd),
+  };
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10_000) / 10_000;
+}
+
+interface SessionMeta {
+  firstTs: number;
+  lastTs: number;
+  hasError: boolean;
+}
+
+interface Aggregator {
+  today: MutableWindow;
+  last7d: MutableWindow;
+  last30d: MutableWindow;
+  lifetime: MutableWindow;
+  modelMessages: Map<string, number>;
+  modelTokens: Map<string, number>;
+  toolCounts: Map<string, number>;
+  sessions: Map<string, SessionMeta>;
+  parseErrors: number;
+}
+
+function makeAggregator(): Aggregator {
+  return {
+    today: emptyWindow(),
+    last7d: emptyWindow(),
+    last30d: emptyWindow(),
+    lifetime: emptyWindow(),
+    modelMessages: new Map(),
+    modelTokens: new Map(),
+    toolCounts: new Map(),
+    sessions: new Map(),
+    parseErrors: 0,
+  };
+}
+
+interface JsonlLine {
+  type?: string;
+  timestamp?: string;
+  sessionId?: string;
+  message?: {
+    role?: string;
+    model?: string;
+    content?: unknown;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+}
+
+/** Walk one parsed JSONL line and update the aggregator. */
+function consumeLine(agg: Aggregator, line: JsonlLine, now: number): void {
+  const ts = line.timestamp ? Date.parse(line.timestamp) : NaN;
+  const sessionId = line.sessionId;
+
+  if (sessionId && Number.isFinite(ts)) {
+    const meta = agg.sessions.get(sessionId);
+    if (meta) {
+      if (ts < meta.firstTs) (meta as { firstTs: number }).firstTs = ts;
+      if (ts > meta.lastTs) (meta as { lastTs: number }).lastTs = ts;
+    } else {
+      agg.sessions.set(sessionId, { firstTs: ts, lastTs: ts, hasError: false });
+    }
+  }
+
+  // Tool-error detection: tool_result blocks with is_error: true.
+  // These appear on `type:"user"` lines whose message.content is an array
+  // of tool_result blocks. We only check is_error so we don't have to
+  // copy any payloads.
+  const content = line.message?.content;
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const b = block as { type?: string; name?: string; is_error?: boolean };
+      if (b.type === 'tool_use' && typeof b.name === 'string') {
+        agg.toolCounts.set(b.name, (agg.toolCounts.get(b.name) ?? 0) + 1);
+      } else if (b.type === 'tool_result' && b.is_error === true && sessionId) {
+        const meta = agg.sessions.get(sessionId);
+        if (meta) (meta as { hasError: boolean }).hasError = true;
+      }
+    }
+  }
+
+  // Only assistant lines carry billable usage. Skip everything else.
+  if (line.type !== 'assistant') return;
+  const usage = line.message?.usage;
+  if (!usage) return;
+
+  const input = usage.input_tokens ?? 0;
+  const output = usage.output_tokens ?? 0;
+  const cc = usage.cache_creation_input_tokens ?? 0;
+  const cr = usage.cache_read_input_tokens ?? 0;
+  const totalThisLine = input + output + cc + cr;
+
+  const modelKey = canonicalModelKey(line.message?.model);
+  const rate = rateForModel(line.message?.model);
+  const cost = costFromUsage(rate, { input, output, cacheCreate: cc, cacheRead: cr });
+
+  agg.modelMessages.set(modelKey, (agg.modelMessages.get(modelKey) ?? 0) + 1);
+  agg.modelTokens.set(modelKey, (agg.modelTokens.get(modelKey) ?? 0) + totalThisLine);
+
+  // Lifetime always.
+  bump(agg.lifetime, sessionId, input, output, cc, cr, cost);
+
+  // Bucketed windows — only when we have a usable timestamp.
+  if (Number.isFinite(ts)) {
+    const ageMs = now - ts;
+    if (ageMs >= 0 && ageMs < DAY_MS) bump(agg.today, sessionId, input, output, cc, cr, cost);
+    if (ageMs >= 0 && ageMs < 7 * DAY_MS) bump(agg.last7d, sessionId, input, output, cc, cr, cost);
+    if (ageMs >= 0 && ageMs < 30 * DAY_MS) bump(agg.last30d, sessionId, input, output, cc, cr, cost);
+  }
+}
+
+function bump(
+  w: MutableWindow,
+  sessionId: string | undefined,
+  input: number,
+  output: number,
+  cc: number,
+  cr: number,
+  cost: number,
+): void {
+  if (sessionId) w.sessions.add(sessionId);
+  w.input += input;
+  w.output += output;
+  w.cacheCreate += cc;
+  w.cacheRead += cr;
+  w.costUsd += cost;
+}
+
+// ============================================================================
+// File walking
+// ============================================================================
+
+/** List the `.jsonl` files in a project dir, returning [path, mtime, size]. */
+async function listTranscripts(
+  dir: string,
+): Promise<Array<{ path: string; mtimeMs: number; size: number }>> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  const candidates = entries.filter(n => n.endsWith('.jsonl'));
+  // Stat in parallel — at ~700 files a serial loop is the dominant cost
+  // before any file content is read.
+  const stats = await Promise.all(
+    candidates.map(async (name) => {
+      const full = join(dir, name);
+      try {
+        const s = await stat(full);
+        return s.isFile() ? { path: full, mtimeMs: s.mtimeMs, size: s.size } : null;
+      } catch {
+        // Skip transient ENOENT (file rotated mid-listing) and perms errors.
+        return null;
+      }
+    }),
+  );
+  return stats.filter((s): s is { path: string; mtimeMs: number; size: number } => s !== null);
+}
+
+async function streamFile(agg: Aggregator, path: string, now: number): Promise<void> {
+  const stream = createReadStream(path, { encoding: 'utf-8' });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  for await (const raw of rl) {
+    if (!raw) continue;
+    let parsed: JsonlLine;
+    try {
+      parsed = JSON.parse(raw) as JsonlLine;
+    } catch {
+      agg.parseErrors++;
+      continue;
+    }
+    consumeLine(agg, parsed, now);
+  }
+}
+
+// ============================================================================
+// Public entry point
+// ============================================================================
+
+export interface AggregateOptions {
+  /** Override the project directory — primarily for tests. */
+  readonly projectDir?: string;
+  /** Bypass the 30s TTL cache. */
+  readonly skipCache?: boolean;
+  /** Override "now" — primarily for tests. */
+  readonly now?: number;
+}
+
+/**
+ * Build the JSON shape returned by `GET /api/claude-stats`.
+ *
+ * Returns an `available: false` shape when the project dir doesn't exist or
+ * holds no transcripts — the dashboard renders a "no sessions found" empty
+ * state from that signal.
+ */
+export async function aggregateClaudeStats(
+  cwd: string,
+  options: AggregateOptions = {},
+): Promise<ClaudeStatsShape> {
+  const startedAt = Date.now();
+  const dir = options.projectDir ?? claudeProjectDirFor(cwd);
+  const now = options.now ?? Date.now();
+
+  const files = await listTranscripts(dir);
+  if (files.length === 0) {
+    return emptyShape(dir, Date.now() - startedAt);
+  }
+
+  // Cache key: max(mtime) + sum(size). If neither shifts, the prior
+  // aggregation is still valid. Also folds in the number of files so a
+  // delete invalidates correctly.
+  const maxMtime = files.reduce((m, f) => Math.max(m, f.mtimeMs), 0);
+  const totalSize = files.reduce((s, f) => s + f.size, 0);
+  const cacheKey = `${dir}|${files.length}|${maxMtime}|${totalSize}`;
+
+  if (!options.skipCache && cache && cache.key === cacheKey && Date.now() - cache.cachedAt < CACHE_TTL_MS) {
+    return cache.value;
+  }
+
+  const agg = makeAggregator();
+  for (const f of files) {
+    try {
+      await streamFile(agg, f.path, now);
+    } catch (err) {
+      // One bad file shouldn't blank the whole tab.
+      console.warn(`[claude-stats] failed to read ${f.path}: ${(err as Error).message ?? err}`);
+    }
+  }
+
+  const value = freezeAggregator(agg, dir, Date.now() - startedAt);
+  cache = { key: cacheKey, value, cachedAt: Date.now() };
+  return value;
+}
+
+/** Build the all-zero shape — exported so the dashboard route handler can
+ *  reuse it on its own catch path without re-declaring the structure. */
+export function emptyClaudeStatsShape(dir: string | null = null, elapsedMs = 0): ClaudeStatsShape {
+  return emptyShape(dir, elapsedMs);
+}
+
+function emptyShape(dir: string | null, elapsedMs: number): ClaudeStatsShape {
+  const empty = freezeWindow(emptyWindow());
+  return {
+    available: false,
+    projectDir: dir,
+    windows: { today: empty, last7d: empty, last30d: empty, lifetime: empty },
+    models: [],
+    tools: [],
+    errorSessions: 0,
+    sessionDurationMs: { median: 0, p95: 0 },
+    totalSessions: 0,
+    parseErrors: 0,
+    elapsedMs,
+  };
+}
+
+function freezeAggregator(agg: Aggregator, dir: string, elapsedMs: number): ClaudeStatsShape {
+  const models: ModelDistribution[] = [];
+  for (const key of agg.modelMessages.keys()) {
+    models.push({
+      model: key,
+      messages: agg.modelMessages.get(key) ?? 0,
+      tokens: agg.modelTokens.get(key) ?? 0,
+    });
+  }
+  models.sort((a, b) => b.tokens - a.tokens);
+
+  const tools: ToolUsage[] = Array.from(agg.toolCounts, ([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
+  let errorSessions = 0;
+  const durations: number[] = [];
+  for (const meta of agg.sessions.values()) {
+    if (meta.hasError) errorSessions++;
+    const span = meta.lastTs - meta.firstTs;
+    if (span > 0) durations.push(span);
+  }
+  durations.sort((a, b) => a - b);
+  const median = durations.length ? durations[Math.floor(durations.length / 2)] : 0;
+  const p95 = durations.length ? durations[Math.min(durations.length - 1, Math.floor(durations.length * 0.95))] : 0;
+
+  return {
+    available: true,
+    projectDir: dir,
+    windows: {
+      today: freezeWindow(agg.today),
+      last7d: freezeWindow(agg.last7d),
+      last30d: freezeWindow(agg.last30d),
+      lifetime: freezeWindow(agg.lifetime),
+    },
+    models,
+    tools,
+    errorSessions,
+    sessionDurationMs: { median, p95 },
+    totalSessions: agg.sessions.size,
+    parseErrors: agg.parseErrors,
+    elapsedMs,
+  };
+}

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -25,6 +25,7 @@ import {
   handleMemoryBatch,
   matchMemoryRpcRoute,
 } from './daemon-memory-rpc.js';
+import { aggregateClaudeStats, emptyClaudeStatsShape } from './claude-stats.js';
 
 // ============================================================================
 // Types
@@ -287,6 +288,23 @@ async function handleMemoryStats(): Promise<object> {
   }
 }
 
+/**
+ * Build the `/api/claude-stats` response (#1044).
+ *
+ * Reads `~/.claude/projects/<encoded-cwd>/*.jsonl` for the daemon's CWD
+ * and returns the aggregated shape consumed by the Claude Stats tab.
+ * Failures degrade to an empty shape rather than 500ing — the dashboard
+ * is read-only context, never the user's primary workflow.
+ */
+async function handleClaudeStats(): Promise<object> {
+  try {
+    return await aggregateClaudeStats(process.cwd());
+  } catch (err) {
+    console.warn(`[dashboard] claude-stats failed: ${(err as Error).message ?? err}`);
+    return emptyClaudeStatsShape();
+  }
+}
+
 // ============================================================================
 // Flo Run Context — build and store human-readable run metadata
 // ============================================================================
@@ -469,6 +487,8 @@ async function handleRequest(
       sendJson(res, 200, await handleSpells(opts.memory));
     } else if (url === '/api/memory/stats') {
       sendJson(res, 200, await handleMemoryStats());
+    } else if (url === '/api/claude-stats') {
+      sendJson(res, 200, await handleClaudeStats());
     } else {
       sendJson(res, 404, { error: 'Not found' });
     }
@@ -777,14 +797,16 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <div id="panel-schedules" class="panel" style="display:none"><div id="schedules-active"></div><div id="schedules-events"></div></div>
   <div id="panel-executions" class="panel" style="display:none"></div>
   <div id="panel-memory" class="panel" style="display:none"></div>
+  <div id="panel-claude-stats" class="panel" style="display:none"></div>
   <div id="poll-indicator" class="poll-indicator"></div>
   <script>
     // Tab navigation — plain DOM, no framework
-    const tabIds = ['workers', 'schedules', 'executions', 'memory'];
-    const tabLabels = ['Workers', 'Schedules', 'Flo Runs', 'Memory'];
+    const tabIds = ['workers', 'schedules', 'executions', 'memory', 'claude-stats'];
+    const tabLabels = ['Workers', 'Schedules', 'Flo Runs', 'Memory', 'Claude Stats'];
     let activeTab = 'workers';
 
     function switchTab(id) {
+      const prev = activeTab;
       activeTab = id;
       tabIds.forEach(t => {
         document.getElementById('panel-' + t).style.display = t === id ? '' : 'none';
@@ -792,6 +814,12 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       document.querySelectorAll('.nav-tab').forEach(el => {
         el.classList.toggle('active', el.dataset.tab === id);
       });
+      // Tabs whose data is fetched lazily (currently only Claude Stats)
+      // need an immediate poll on entry — otherwise the user waits up to
+      // the 5s polling interval for first paint.
+      if (id === 'claude-stats' && prev !== id && typeof poll === 'function') {
+        poll();
+      }
     }
 
     // Build nav tabs
@@ -1087,20 +1115,132 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         '<table><thead><tr><th>Namespace</th><th>Entries</th></tr></thead><tbody>' + rows + '</tbody></table>';
     }
 
+    // Format: 1234567 → "1.23M", 5432 → "5.43K"
+    const fmtCount = (n) => {
+      if (n == null) return '-';
+      if (n < 1000) return String(n);
+      if (n < 1_000_000) return (n / 1000).toFixed(2) + 'K';
+      if (n < 1_000_000_000) return (n / 1_000_000).toFixed(2) + 'M';
+      return (n / 1_000_000_000).toFixed(2) + 'B';
+    };
+    // USD with two decimals; sub-cent renders as "<$0.01".
+    const fmtUsd = (n) => {
+      if (n == null) return '-';
+      if (n === 0) return '$0.00';
+      if (n < 0.01) return '<$0.01';
+      return '$' + n.toFixed(2);
+    };
+
+    function renderClaudeStats(cs) {
+      const el = document.getElementById('panel-claude-stats');
+      if (!cs) { el.innerHTML = '<div class="empty">Loading...</div>'; return; }
+
+      // Always-visible disclaimer banner — kept verbatim per the issue's
+      // wording so the user understands the scope and limits at a glance.
+      const disclaimer =
+        '<div style="background:#161b22;border:1px solid #30363d;border-left:3px solid #d29922;border-radius:6px;padding:10px 14px;margin-bottom:16px;color:#c9d1d9;font-size:0.85rem;line-height:1.5">' +
+        '<strong>Local stats only.</strong> Counts what Claude Code wrote to disk for THIS project on THIS machine. ' +
+        'Doesn\\'t include claude.ai web sessions, other projects, other devices, or your account-level plan quota. ' +
+        'Cost is a local estimate using current public model rates.' +
+        '</div>';
+
+      if (!cs.available) {
+        el.innerHTML = disclaimer +
+          '<div class="empty">No Claude Code sessions found in this project' +
+          (cs.projectDir ? ' (looked in <code style="color:#8b949e">' + esc(cs.projectDir) + '</code>)' : '') +
+          '</div>';
+        return;
+      }
+
+      const w = cs.windows;
+
+      // Summary windows (today / 7d / 30d / lifetime).
+      const winRow = (label, win) => {
+        return '<tr><td style="font-weight:600">' + label + '</td>' +
+          '<td>' + fmtCount(win.sessions) + '</td>' +
+          '<td>' + fmtCount(win.tokens.total) + '</td>' +
+          '<td>' + fmtCount(win.tokens.input) + '</td>' +
+          '<td>' + fmtCount(win.tokens.output) + '</td>' +
+          '<td>' + fmtCount(win.tokens.cacheCreate) + '</td>' +
+          '<td>' + fmtCount(win.tokens.cacheRead) + '</td>' +
+          '<td>' + fmtUsd(win.costUsd) + '</td></tr>';
+      };
+      const winTable =
+        '<h2>Sessions, Tokens, Cost</h2>' +
+        '<table><thead><tr>' +
+          '<th>Window</th><th>Sessions</th><th>Total Tokens</th>' +
+          '<th>Input</th><th>Output</th><th>Cache Create</th><th>Cache Read</th><th>Est. Cost</th>' +
+        '</tr></thead><tbody>' +
+        winRow('Today', w.today) +
+        winRow('Last 7 days', w.last7d) +
+        winRow('Last 30 days', w.last30d) +
+        winRow('Lifetime', w.lifetime) +
+        '</tbody></table>';
+
+      // Model distribution.
+      const modelRows = (cs.models && cs.models.length)
+        ? cs.models.map(m => '<tr><td>' + esc(m.model) + '</td>' +
+            '<td>' + fmtCount(m.messages) + '</td>' +
+            '<td>' + fmtCount(m.tokens) + '</td></tr>').join('')
+        : '<tr><td colspan="3" class="empty">No model data</td></tr>';
+      const modelsTable =
+        '<h2>Models Used</h2>' +
+        '<table><thead><tr><th>Model</th><th>Messages</th><th>Total Tokens</th></tr></thead>' +
+        '<tbody>' + modelRows + '</tbody></table>';
+
+      // Top-10 tools.
+      const toolRows = (cs.tools && cs.tools.length)
+        ? cs.tools.map(t => '<tr><td>' + esc(t.name) + '</td><td>' + fmtCount(t.count) + '</td></tr>').join('')
+        : '<tr><td colspan="2" class="empty">No tool calls recorded</td></tr>';
+      const toolsTable =
+        '<h2>Top Tools</h2>' +
+        '<table><thead><tr><th>Tool</th><th>Calls</th></tr></thead>' +
+        '<tbody>' + toolRows + '</tbody></table>';
+
+      // Headline cards.
+      const cards =
+        '<div class="grid">' +
+        '<div class="stat-card"><div class="label">Total Sessions</div><div class="value">' + fmtCount(cs.totalSessions) + '</div></div>' +
+        '<div class="stat-card"><div class="label">Sessions w/ Errors</div><div class="value">' + fmtCount(cs.errorSessions) + '</div></div>' +
+        '<div class="stat-card"><div class="label">Median Duration</div><div class="value">' + fmtDuration(cs.sessionDurationMs.median) + '</div></div>' +
+        '<div class="stat-card"><div class="label">p95 Duration</div><div class="value">' + fmtDuration(cs.sessionDurationMs.p95) + '</div></div>' +
+        '</div>';
+
+      // Footer note linking to the rate-table source comment.
+      const footer =
+        '<div class="dim" style="margin-top:12px">' +
+        'Cost estimate uses rates from <code>src/cli/services/claude-model-rates.ts</code> ' +
+        '(USD/1M tokens, list price). Aggregation took ' + fmtDuration(cs.elapsedMs) +
+        (cs.parseErrors ? ' &middot; ' + cs.parseErrors + ' lines skipped (parse error)' : '') +
+        '</div>';
+
+      el.innerHTML = disclaimer + cards + winTable + modelsTable + toolsTable + footer;
+    }
+
     // Polling
     const poll = async () => {
       try {
-        const [s, sc, w, m] = await Promise.all([
+        // Claude Stats aggregation walks the user's transcript dir — only
+        // pull it when the tab is visible so steady-state polling stays
+        // four lightweight endpoints. Switching to the tab triggers an
+        // immediate poll so the user doesn't wait up to 5s for first paint.
+        const wantClaudeStats = activeTab === 'claude-stats';
+        const fetches = [
           fetch('/api/status').then(r => r.json()),
           fetch('/api/schedules').then(r => r.json()),
           fetch('/api/spells').then(r => r.json()),
           fetch('/api/memory/stats').then(r => r.json()),
-        ]);
+          wantClaudeStats
+            ? fetch('/api/claude-stats').then(r => r.json()).catch(() => null)
+            : Promise.resolve(null),
+        ];
+        const [s, sc, w, m, cs] = await Promise.all(fetches);
         renderStatus(s);
         renderWorkers(s);
         renderSchedules(sc);
         renderExecutions(w);
         renderMemory(m);
+        if (wantClaudeStats) renderClaudeStats(cs);
         document.getElementById('poll-indicator').textContent = 'Last poll: ' + new Date().toLocaleTimeString();
       } catch (e) {
         console.error('Poll failed:', e);


### PR DESCRIPTION
## Summary

- Adds a fifth tab to The Luminarium that aggregates sessions / tokens / cost estimate / model distribution / top tools / error sessions / session duration parsed from `~/.claude/projects/<encoded-cwd>/*.jsonl` for the daemon's CWD.
- New service module `claude-stats.ts` with streaming readline aggregation, 30s TTL cache keyed on (count, max mtime, total size), and parallel `stat()` (5.1s → 1.7s cold-path on 700 real transcripts; warm-path 4ms).
- New `/api/claude-stats` route, new render function, and an always-visible disclaimer banner clarifying that the metrics are local-only and the cost is an estimate.

Closes #1044.

## Implementation notes

- **No network calls.** Strictly reads local JSONL files. The dashboard remains bound to `127.0.0.1`.
- **Cost rates** live in `claude-model-rates.ts` with a `Last verified` date in the file comment; the UI labels the cost an "estimate" so drift in published rates is bounded user impact.
- **Lazy fetch.** The `/api/claude-stats` poll is gated by `activeTab === 'claude-stats'` so idle background tabs don't burn aggregation cycles. Switching to the tab triggers an immediate poll for first paint.

## Test plan

- [x] Unit tests for path encoding, rate lookup, hand-computed cost, bucketing across today/7d/30d/lifetime, malformed-line tolerance, model distribution sort, top-tools, error-session detection, session-duration percentiles, and TTL cache behaviour
- [x] Integration test that boots a real `startDashboard`, writes a tmpdir transcript, and issues real HTTP GETs against `/api/claude-stats`
- [x] Full `services/` test sweep (480 tests) passes locally
- [x] Real-machine spot-check on the maintainer's transcripts: 482 sessions, 12B tokens, $28K lifetime estimate, 0 parse errors, top tools Bash/Read/Edit/TaskUpdate/Grep — consistent with ground truth
- [ ] Live Luminarium spot-check after publish (per AC merge gate): tab loads <2s warm / <5s cold, disclaimer visible without scrolling, lifetime token total within 1% of manual sum, no DOM-leak when tab-switching
- [ ] Verify rendering on a freshly-cloned project with no `~/.claude/projects/<dir>` — should show the "No Claude Code sessions found" empty state

## Consumer impact

- New service module + new route + new tab. Backwards compatible.
- No new runtime deps (uses `node:readline`, `node:fs`).
- Round-trip: requires publish + reinstall to reach consumers.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)