### PR TITLE
fix(1046): stop false-success auto-fix on Embedding hygiene when daemon is alive

### DIFF
--- a/src/cli/__tests__/commands/doctor-fixes-embedding-hygiene.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-embedding-hygiene.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the Embedding hygiene auto-fix gate (#1046).
+ *
+ * Pre-#1046 the autoFixCheck for "Embedding hygiene" fell through to a
+ * generic shell-out: `npx moflo embeddings init`. The migration child
+ * correctly re-embedded dirty rows, but a long-lived moflo process
+ * (daemon, MCP server) holding a stale sql.js in-memory snapshot would
+ * flush back the legacy state seconds later — the repair was silently
+ * undone, and healer reported a false success.
+ *
+ * The fix: when a daemon is alive, skip the auto-fix and surface a
+ * "restart Claude Code" message that points to the existing session-start
+ * launcher repair path. When no daemon is running (CI, fresh shell,
+ * post-`daemon stop`), invoke the migration in-process directly.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Hoisted mocks. These must be set up via `vi.mock` (which Vitest hoists
+// above all imports) rather than `vi.doMock` + dynamic re-import, because
+// `autoFixCheck` is loaded once and cached by the worker — a doMock+reimport
+// pattern silently no-ops once the cache is warm. See PR review on #1046.
+vi.mock('../../services/daemon-lock.js', () => ({
+  getDaemonLockHolder: vi.fn(),
+}));
+vi.mock('../../services/embeddings-migration.js', () => ({
+  runEmbeddingsMigrationIfNeeded: vi.fn(),
+}));
+
+import { autoFixCheck } from '../../commands/doctor-fixes.js';
+import { getDaemonLockHolder } from '../../services/daemon-lock.js';
+import { runEmbeddingsMigrationIfNeeded } from '../../services/embeddings-migration.js';
+
+const mockGetHolder = vi.mocked(getDaemonLockHolder);
+const mockMigrate = vi.mocked(runEmbeddingsMigrationIfNeeded);
+
+let originalCwd: string;
+let tmpDir: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = mkdtempSync(join(tmpdir(), 'moflo-hygiene-fix-'));
+  process.chdir(tmpDir);
+  mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+  mockGetHolder.mockReset();
+  mockMigrate.mockReset();
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const hygieneCheck = {
+  name: 'Embedding hygiene',
+  status: 'warn' as const,
+  message: '277 row(s) with embedding_model=local AND embedding IS NULL',
+  // Vestigial — the new code path inside `autoFixCheck` does NOT read
+  // `check.fix` for this check. Kept non-empty so the early `if
+  // (!check.fix) return false` guard at the top of `autoFixCheck` lets us
+  // reach the dispatch.
+  fix: 'session-start launcher',
+};
+
+describe('Embedding hygiene auto-fix — daemon-aware skip (#1046)', () => {
+  it('refuses to run when a daemon is alive (returns false, never invokes migration)', async () => {
+    mockGetHolder.mockReturnValue(process.pid);
+
+    const result = await autoFixCheck(hygieneCheck);
+
+    expect(result).toBe(false);
+    expect(mockMigrate).not.toHaveBeenCalled();
+  });
+
+  it('runs the migration in-process when no daemon is alive', async () => {
+    mockGetHolder.mockReturnValue(null);
+    mockMigrate.mockResolvedValue(true);
+
+    const result = await autoFixCheck(hygieneCheck);
+
+    expect(mockGetHolder).toHaveBeenCalledTimes(1);
+    expect(mockMigrate).toHaveBeenCalledTimes(1);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the migration runs but completes with no work (no eligible rows)', async () => {
+    mockGetHolder.mockReturnValue(null);
+    mockMigrate.mockResolvedValue(false);
+
+    const result = await autoFixCheck(hygieneCheck);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the migration throws — does not bubble up', async () => {
+    mockGetHolder.mockReturnValue(null);
+    mockMigrate.mockRejectedValue(new Error('embed service unavailable'));
+
+    const result = await autoFixCheck(hygieneCheck);
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 import { output } from '../output.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
+import { getDaemonLockHolder } from '../services/daemon-lock.js';
 import { findZombieProcesses } from './doctor-zombies.js';
 import { installClaudeCode, runCommand } from './doctor-checks-runtime.js';
 import type { HealthCheck } from './doctor-types.js';
@@ -175,6 +176,40 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     },
     'Gate Health': async () => {
       return fixGateHealthHooks();
+    },
+    'Embedding hygiene': async () => {
+      // The session-start launcher already runs the same migration BEFORE
+      // daemon/MCP boot — that's where consumer autoheal happens. Running
+      // it here mid-session is unsafe because any long-lived moflo writer
+      // (daemon, MCP server) holds its own sql.js in-memory snapshot from
+      // before we'd repair, and on its next flush dumps the stale buffer
+      // back to disk, clobbering the repair. Pre-#1046 we shelled out to
+      // `npx moflo embeddings init` here and falsely reported success
+      // when the writeback clobber was about to undo it.
+      // `getDaemonLockHolder` validates both PID liveness AND
+      // that the process is actually a moflo daemon (Windows PID
+      // recycling is real — see daemon-lock.ts:isDaemonProcess).
+      if (getDaemonLockHolder(process.cwd()) !== null) {
+        output.writeln(output.dim(
+          '  Embedding hygiene is repaired automatically by the session-start launcher.',
+        ));
+        output.writeln(output.dim(
+          '  Restart Claude Code (or run `flo daemon stop` first) to apply.',
+        ));
+        return false;
+      }
+      // No daemon — safe to run the migration in-process. In-process is
+      // preferred over `runFixCommand` because the migration's TTY/stderr
+      // progress UI is then visible to the user, and any thrown error
+      // surfaces in the autoFixCheck try/catch instead of being swallowed
+      // by a child-process exit code.
+      try {
+        const { runEmbeddingsMigrationIfNeeded } = await import('../services/embeddings-migration.js');
+        return await runEmbeddingsMigrationIfNeeded();
+      } catch (e) {
+        output.writeln(output.warning(`  Embeddings migration failed: ${errorDetail(e)}`));
+        return false;
+      }
     },
     'Status Line': async () => {
       const settingsPath = join(process.cwd(), '.claude', 'settings.json');


### PR DESCRIPTION
## Summary

- Adds a daemon-aware fix-action for the \`Embedding hygiene\` check in \`flo doctor --fix\` / \`flo healer --fix\`. When a moflo daemon is alive, the auto-fix now prints a "restart Claude Code to apply" pointer (instead of running a migration that gets silently clobbered) and returns \`false\` so doctor doesn't claim success.
- When no daemon is alive (CI, fresh shell, post-\`daemon stop\`), invokes \`runEmbeddingsMigrationIfNeeded\` in-process — eliminates the comment-in-shell-string footgun in the previous \`'npx moflo embeddings init  # ...'\` fallback and surfaces errors via the existing try/catch.
- Reuses the canonical \`getDaemonLockHolder\` helper from \`daemon-lock.ts\` (validates PID liveness AND that the process is actually a moflo daemon — guards against Windows PID recycling).

Closes #1046.

## Why this is subtractive, not additive

The session-start launcher (\`bin/session-start-launcher.mjs:1394-1422\`) already invokes \`runEmbeddingsMigrationIfNeeded\` BEFORE daemon/MCP boot, citing the #727 clobber-hazard analysis. Consumer autoheal-on-install already worked. The only thing broken was that healer's mid-session auto-fix shelled out to a child process which correctly repaired the DB, then long-lived moflo writers (daemon, MCP server) holding stale sql.js snapshots flushed and clobbered the repair. Healer's post-fix check ran before the clobber landed, so it falsely reported "no residue."

This PR removes the false-success path. It does NOT add new healing infrastructure — that path already exists at session start.

## Test plan

- [x] 4 unit tests: daemon-alive skip (no migration call), no-daemon migration path, no-eligible-rows passthrough, migration-throws containment
- [x] 96 tests pass across \`commands/\` + \`daemon-lock\` test sweep
- [x] Real-machine verification on maintainer's previously-dirty DB: 277 \`local+NULL\` guidance rows + 6 unknown + 2 \`none\` = 286 ineligible. With all moflo writers stopped, \`runEmbeddingsMigrationIfNeeded\` re-embedded all 286 rows in 8s and the result stuck on disk. \`doctor --strict\` then passes 34/34 with zero warnings.
- [ ] Live spot-check after publish/install: \`flo healer --fix\` on a fresh consumer machine with active daemon should print the restart message and NOT claim success; the next session start should auto-repair via the existing launcher path.

## Consumer impact

- Single-file change in \`src/cli/commands/doctor-fixes.ts\` (one new \`fixActions\` entry, one new top-level import). Backwards compatible.
- No new runtime deps. No new launcher hooks. No new IPC.
- Round-trip: requires publish + reinstall. The autoheal-on-session-start path (already shipped) does the actual repair on next launch.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)