### PR TITLE
fix(1048): match Claude Code's full non-alphanumeric encoding for ~/.claude/projects/

### DIFF
--- a/src/cli/__tests__/services/claude-stats.test.ts
+++ b/src/cli/__tests__/services/claude-stats.test.ts
@@ -85,6 +85,23 @@ describe('encodeCwdForClaudeProjects', () => {
     expect(encodeCwdForClaudeProjects('/Users/alice/proj/moflo'))
       .toBe('-Users-alice-proj-moflo');
   });
+
+  // Issue #1048: every non-alphanumeric character in the cwd must collapse
+  // to a dash, matching Claude Code's own directory naming.
+  it('replaces underscores, dots, plus, and spaces with dashes', () => {
+    expect(encodeCwdForClaudeProjects('/Users/me/dev/some_project'))
+      .toBe('-Users-me-dev-some-project');
+    expect(encodeCwdForClaudeProjects('C:\\Users\\me\\foo.bar'))
+      .toBe('C--Users-me-foo-bar');
+    expect(encodeCwdForClaudeProjects('/var/lib/app+v2'))
+      .toBe('-var-lib-app-v2');
+    expect(encodeCwdForClaudeProjects('/path with space/x'))
+      .toBe('-path-with-space-x');
+  });
+
+  it('leaves an all-alphanumeric CWD untouched', () => {
+    expect(encodeCwdForClaudeProjects('alphaOnly42')).toBe('alphaOnly42');
+  });
 });
 
 // ============================================================================

--- a/src/cli/__tests__/services/dashboard-claude-stats-route.test.ts
+++ b/src/cli/__tests__/services/dashboard-claude-stats-route.test.ts
@@ -20,6 +20,7 @@ import {
   type DashboardHandle,
 } from '../../services/daemon-dashboard.js';
 import { _resetClaudeStatsCache } from '../../services/claude-stats.js';
+import { encodeCwdForClaudeProjects } from '../../shared/utils/claude-projects-path.js';
 
 let tmpRoot: string;
 let savedHome: string | undefined;
@@ -105,7 +106,7 @@ describe('GET /api/claude-stats', () => {
 
   it('returns aggregated stats when transcripts exist for the CWD', async () => {
     const cwd = process.cwd();
-    const encoded = cwd.replace(/[\\/:]/g, '-');
+    const encoded = encodeCwdForClaudeProjects(cwd);
     const projDir = join(tmpRoot, '.claude', 'projects', encoded);
     mkdirSync(projDir, { recursive: true });
     writeFileSync(

--- a/src/cli/memory/auto-memory-bridge.test.ts
+++ b/src/cli/memory/auto-memory-bridge.test.ts
@@ -19,6 +19,7 @@ import {
   pruneTopicFile,
   hasSummaryLine,
 } from './auto-memory-bridge.js';
+import { encodeCwdForClaudeProjects } from '../shared/utils/claude-projects-path.js';
 import type {
   MemoryInsight,
 } from './auto-memory-bridge.js';
@@ -101,6 +102,23 @@ describe('resolveAutoMemoryDir', () => {
     const a = resolveAutoMemoryDir('/workspaces/my-project');
     const b = resolveAutoMemoryDir('/workspaces/my-project');
     expect(a).toBe(b);
+  });
+
+  // Issue #1048 — every non-alphanumeric character in the working directory
+  // must collapse to `-`, matching Claude Code's own directory naming.
+  it('should replace underscores and dots with dashes', () => {
+    const result = resolveAutoMemoryDir('/Users/me/dev/some_project.v2');
+    expect(result).toContain(`${path.sep}-Users-me-dev-some-project-v2${path.sep}memory`);
+  });
+
+  // Drift guard: resolveAutoMemoryDir must produce the same encoded suffix
+  // as encodeCwdForClaudeProjects so both consumers of `~/.claude/projects/`
+  // agree on which directory belongs to a given cwd.
+  it('produces the same encoded segment as encodeCwdForClaudeProjects', () => {
+    const cwd = '/Users/me/dev/some_project.v2';
+    const memoryDir = resolveAutoMemoryDir(cwd);
+    const expectedSegment = encodeCwdForClaudeProjects(cwd);
+    expect(memoryDir).toContain(`${path.sep}${expectedSegment}${path.sep}memory`);
   });
 });
 

--- a/src/cli/memory/auto-memory-bridge.ts
+++ b/src/cli/memory/auto-memory-bridge.ts
@@ -13,11 +13,11 @@
  */
 
 import { createHash } from 'node:crypto';
-import { homedir } from 'node:os';
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs/promises';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import * as path from 'node:path';
+import { claudeProjectDirFor } from '../shared/utils/claude-projects-path.js';
 import {
   createDefaultEntry,
   type IMemoryBackend,
@@ -747,28 +747,17 @@ export class AutoMemoryBridge extends EventEmitter {
 
 /**
  * Resolve the auto memory directory for a given working directory.
- * Mirrors Claude Code's path derivation from git root.
+ *
+ * The git root is preferred over the raw cwd so a session in
+ * `<repo>/packages/foo` resolves to the repo's auto-memory store, matching
+ * Claude Code's own behaviour. The encoded suffix is produced by the shared
+ * `claudeProjectDirFor` helper so this bridge cannot drift away from the
+ * Claude Code directory naming convention (issue #1048).
  */
 export function resolveAutoMemoryDir(workingDir: string): string {
   const gitRoot = findGitRoot(workingDir);
   const basePath = gitRoot || workingDir;
-
-  // Claude Code normalizes to forward slashes then replaces with dashes
-  // The leading dash IS preserved (e.g. /workspaces/foo -> -workspaces-foo)
-  // On Windows, strip drive letter prefix (C:) for cleaner keys
-  let normalized = basePath.split(path.sep).join('/');
-  if (process.platform === 'win32') {
-    normalized = normalized.replace(/^[A-Za-z]:/, '');
-  }
-  const projectKey = normalized.replace(/\//g, '-');
-
-  return path.join(
-    homedir(),
-    '.claude',
-    'projects',
-    projectKey,
-    'memory',
-  );
+  return path.join(claudeProjectDirFor(basePath), 'memory');
 }
 
 /**

--- a/src/cli/services/claude-stats.ts
+++ b/src/cli/services/claude-stats.ts
@@ -23,9 +23,14 @@
 
 import { createReadStream } from 'node:fs';
 import { stat, readdir } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
+import {
+  claudeProjectDirFor,
+  encodeCwdForClaudeProjects,
+} from '../shared/utils/claude-projects-path.js';
+
+export { claudeProjectDirFor, encodeCwdForClaudeProjects };
 
 /**
  * Map a transcript model name to a stable display key. Recognises bare family
@@ -89,24 +94,6 @@ export interface ClaudeStatsShape {
   readonly parseErrors: number;
   /** Aggregation wall-clock duration in ms — populated when computed. */
   readonly elapsedMs: number;
-}
-
-// ============================================================================
-// Path resolution
-// ============================================================================
-
-/**
- * Encode a CWD the same way Claude Code does for `~/.claude/projects/<dir>`.
- * Replaces `\`, `/`, and `:` with `-` so `C:\Users\eric\Projects\moflo` →
- * `C--Users-eric-Projects-moflo`.
- */
-export function encodeCwdForClaudeProjects(cwd: string): string {
-  return cwd.replace(/[\\/:]/g, '-');
-}
-
-/** Absolute path to `~/.claude/projects/<encoded-cwd>` for the given CWD. */
-export function claudeProjectDirFor(cwd: string): string {
-  return join(homedir(), '.claude', 'projects', encodeCwdForClaudeProjects(cwd));
 }
 
 // ============================================================================

--- a/src/cli/shared/utils/claude-projects-path.ts
+++ b/src/cli/shared/utils/claude-projects-path.ts
@@ -1,0 +1,34 @@
+/**
+ * Encode a working directory the same way Claude Code does for its
+ * `~/.claude/projects/<dir>/` transcript & memory store.
+ *
+ * Claude Code replaces *every* non-alphanumeric character in the absolute
+ * path with `-`. Earlier moflo versions used a narrower class (`/[\\/:]/g`,
+ * or split-and-rejoin variants) which agreed with Claude Code only for
+ * paths whose every other character was alphanumeric — issue #1048.
+ *
+ * Centralised here so the stats aggregator and the auto-memory bridge
+ * cannot drift apart.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Encode a CWD to the form Claude Code uses as a `~/.claude/projects/`
+ * subdirectory name. Replaces every non-alphanumeric character with `-`.
+ *
+ * @example
+ *   encodeCwdForClaudeProjects('C:\\Users\\me\\some_project')
+ *     → 'C--Users-me-some-project'
+ *   encodeCwdForClaudeProjects('/Users/me/dev/some_project')
+ *     → '-Users-me-dev-some-project'
+ */
+export function encodeCwdForClaudeProjects(cwd: string): string {
+  return cwd.replace(/[^A-Za-z0-9]/g, '-');
+}
+
+/** Absolute path to `~/.claude/projects/<encoded-cwd>` for the given CWD. */
+export function claudeProjectDirFor(cwd: string): string {
+  return join(homedir(), '.claude', 'projects', encodeCwdForClaudeProjects(cwd));
+}


### PR DESCRIPTION
## Summary
- Closes #1048. Claude Code replaces every non-alphanumeric character in the cwd with `-` when naming `~/.claude/projects/<encoded>/`. Two moflo encoders used a narrower class and silently produced a different directory key for any cwd containing `_`, `.`, `+`, space, etc. — surfacing as "No Claude Code sessions found" in `flo stats` / Luminarium, and as a silently no-op auto-memory bridge.
- Consolidate both encoders into `src/cli/shared/utils/claude-projects-path.ts` with regex `/[^A-Za-z0-9]/g`; `resolveAutoMemoryDir` now derives its path from the shared `claudeProjectDirFor` helper.
- Incidental fix: `resolveAutoMemoryDir` was also stripping the Windows drive letter (producing `-Users-eric-Projects-moflo` instead of the correct `C--Users-eric-Projects-moflo`); reusing the shared helper eliminates that path entirely.

## Why this was load-bearing
Both call sites ship to consumers via `node_modules/moflo/...`. On-current-version consumers pick the fix up via `npm install moflo@<next>` — no migration needed; moflo just starts looking at the directory Claude Code already writes. Reporter (Kelsey G.) hit this on a path with an underscore.

## Test plan
- [x] `claude-stats.test.ts`: extended `encodeCwdForClaudeProjects` with `_`, `.`, `+`, space, and an all-alphanumeric pass-through case.
- [x] `auto-memory-bridge.test.ts`: extended `resolveAutoMemoryDir` for `_` + `.`, plus a drift guard that asserts the encoded segment matches `encodeCwdForClaudeProjects` for the same input.
- [x] `npm run build` clean.
- [x] `npm test` — 8421/8421 pass.
- [x] `/flo-simplify` reviewer pass — approved, no findings.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)