### PR TITLE
feat(init): gitignore moflo-synced guidance + scripts in consumer projects

### DIFF
--- a/src/cli/__tests__/init-gitignore.test.ts
+++ b/src/cli/__tests__/init-gitignore.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for updateGitignore step in flo init.
+ *
+ * These additions matter because moflo writes (and overwrites on every install)
+ * ~25 guidance files under `.claude/guidance/moflo-*.md` plus 11 scripts under
+ * `.claude/scripts/`. Without gitignore coverage, those show up as untracked
+ * additions in every consumer's `git status` and tempt commits of derived
+ * state. The leading `/` anchor is mandatory — see the `guidance-gitignore-
+ * shipped-trap` learning for why a bare `.claude/guidance/` rule once silently
+ * swallowed shipped subdirectories and broke `npm pack`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { updateGitignore, SCRIPT_MAP } from '../init/moflo-init.js';
+
+describe('updateGitignore', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-init-gitignore-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function readGitignore(): string {
+    return fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf-8');
+  }
+
+  it('creates .gitignore with all moflo entries when none exists', () => {
+    const result = updateGitignore(tmpDir);
+
+    expect(result.status).toBe('created');
+    const content = readGitignore();
+
+    // Default consumer entries
+    expect(content).toContain('node_modules/');
+    expect(content).toContain('dist/');
+    expect(content).toContain('.env');
+
+    // MoFlo runtime/state entries
+    expect(content).toContain('.claude-epic/');
+    expect(content).toContain('.moflo/');
+    expect(content).toContain('.swarm/');
+    expect(content).toContain('.claude/settings.local.json');
+    expect(content).toContain('.claude/scheduled_tasks.lock');
+    expect(content).toContain('**/workflow-state.json');
+
+    // Auto-synced moflo files (the new entries)
+    expect(content).toContain('/.claude/guidance/moflo-*.md');
+    for (const name of SCRIPT_MAP) {
+      expect(content).toContain(`/.claude/scripts/${name}`);
+    }
+  });
+
+  it('appends moflo entries to an existing .gitignore', () => {
+    const existing = 'node_modules/\nbuild/\n# user comment\n';
+    fs.writeFileSync(path.join(tmpDir, '.gitignore'), existing, 'utf-8');
+
+    const result = updateGitignore(tmpDir);
+
+    expect(result.status).toBe('updated');
+    const content = readGitignore();
+
+    // Existing lines preserved
+    expect(content.startsWith(existing)).toBe(true);
+    expect(content).toContain('build/');
+    expect(content).toContain('# user comment');
+
+    // New entries appended under the heading
+    expect(content).toContain('# MoFlo state (gitignored)');
+    expect(content).toContain('/.claude/guidance/moflo-*.md');
+    for (const name of SCRIPT_MAP) {
+      expect(content).toContain(`/.claude/scripts/${name}`);
+    }
+  });
+
+  it('is idempotent — second call is a no-op', () => {
+    fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules/\n', 'utf-8');
+
+    updateGitignore(tmpDir);
+    const afterFirst = readGitignore();
+
+    const second = updateGitignore(tmpDir);
+    const afterSecond = readGitignore();
+
+    expect(second.status).toBe('skipped');
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it('does not duplicate .moflo/ in the entries list', () => {
+    updateGitignore(tmpDir);
+    const content = readGitignore();
+
+    const matches = content.split(/\r?\n/).filter(line => line.trim() === '.moflo/');
+    expect(matches).toHaveLength(1);
+  });
+
+  it('anchors guidance + scripts patterns with a leading slash', () => {
+    updateGitignore(tmpDir);
+    const content = readGitignore();
+
+    // Leading slash is mandatory — bare patterns once swallowed shipped subdirs
+    // (guidance-gitignore-shipped-trap learning).
+    expect(content).toContain('/.claude/guidance/moflo-*.md');
+    expect(content).not.toMatch(/^\.claude\/guidance\/moflo-\*\.md$/m);
+
+    for (const name of SCRIPT_MAP) {
+      expect(content).toContain(`/.claude/scripts/${name}`);
+    }
+  });
+
+  it('treats leading-slash and bare forms as equivalent for dedup', () => {
+    // Consumer added the un-anchored form manually before this fix shipped, or
+    // copy-pasted from older moflo — neither should produce a duplicate.
+    const existing = [
+      'node_modules/',
+      '.claude/guidance/moflo-*.md',
+      '.claude/scripts/hooks.mjs',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.gitignore'), existing, 'utf-8');
+
+    updateGitignore(tmpDir);
+    const content = readGitignore();
+
+    const guidanceLines = content
+      .split(/\r?\n/)
+      .filter(l => l.includes('.claude/guidance/moflo-*.md'));
+    expect(guidanceLines).toHaveLength(1);
+
+    const hooksLines = content
+      .split(/\r?\n/)
+      .filter(l => l.includes('.claude/scripts/hooks.mjs'));
+    expect(hooksLines).toHaveLength(1);
+  });
+
+  it('appends only the missing entries when some are already present', () => {
+    const existing = [
+      'node_modules/',
+      '.moflo/',
+      '/.claude/scripts/hooks.mjs',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.gitignore'), existing, 'utf-8');
+
+    const result = updateGitignore(tmpDir);
+    expect(result.status).toBe('updated');
+
+    const content = readGitignore();
+    // The pre-existing .moflo/ stays as a single occurrence
+    const moflo = content.split(/\r?\n/).filter(l => l.trim() === '.moflo/');
+    expect(moflo).toHaveLength(1);
+
+    // hooks.mjs entry stays as a single occurrence
+    const hooks = content
+      .split(/\r?\n/)
+      .filter(l => l.trim() === '/.claude/scripts/hooks.mjs');
+    expect(hooks).toHaveLength(1);
+
+    // Other SCRIPT_MAP entries got appended
+    expect(content).toContain('/.claude/scripts/session-start-launcher.mjs');
+    expect(content).toContain('/.claude/guidance/moflo-*.md');
+  });
+});

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -536,7 +536,7 @@ function generateClaudeMd(root: string, _force?: boolean): MofloInitResult['step
 // scriptFiles array in bin/session-start-launcher.mjs — first-init drops any
 // script missing here, and the launcher's manifest cleanup later treats it as
 // orphan residue and deletes it (#777, feedback_scriptfiles_sync.md).
-const SCRIPT_MAP: string[] = [
+export const SCRIPT_MAP: string[] = [
   'hooks.mjs',
   'session-start-launcher.mjs',
   'index-guidance.mjs',
@@ -600,17 +600,26 @@ function isStale(srcPath: string, destPath: string): boolean {
 // Step 6: .gitignore
 // ============================================================================
 
-function updateGitignore(root: string): MofloInitResult['steps'][0] {
+export function updateGitignore(root: string): MofloInitResult['steps'][0] {
   const gitignorePath = path.join(root, '.gitignore');
   const entries = [
     '.claude-epic/',
     '.moflo/',
     '.swarm/',
-    '.moflo/',
     '.claude/settings.local.json',
     '.claude/scheduled_tasks.lock',
     '**/workflow-state.json',
+    // Leading `/` anchors to gitignore root — bare `.claude/guidance/` once
+    // swallowed shipped/internal subdirs and broke `npm pack`
+    // (guidance-gitignore-shipped-trap).
+    '/.claude/guidance/moflo-*.md',
+    ...SCRIPT_MAP.map(name => `/.claude/scripts/${name}`),
   ];
+
+  // Treat `/.foo` and `.foo` as the same rule when checking for prior presence
+  // — both forms anchor at gitignore root, so a consumer who wrote either
+  // shouldn't get a duplicate appended.
+  const normalize = (s: string) => s.replace(/^\//, '');
 
   if (!fs.existsSync(gitignorePath)) {
     const defaultEntries = ['node_modules/', 'dist/', '.env', '.env.*', ''];
@@ -621,9 +630,9 @@ function updateGitignore(root: string): MofloInitResult['steps'][0] {
 
   const existing = fs.readFileSync(gitignorePath, 'utf-8');
   const existingLines = new Set(
-    existing.split(/\r?\n/).map(l => l.trim()).filter(l => l && !l.startsWith('#')),
+    existing.split(/\r?\n/).map(l => normalize(l.trim())).filter(l => l && !l.startsWith('#')),
   );
-  const toAdd = entries.filter(e => !existingLines.has(e));
+  const toAdd = entries.filter(e => !existingLines.has(normalize(e)));
 
   if (toAdd.length === 0) {
     return { name: '.gitignore', status: 'skipped', detail: 'Entries already present' };


### PR DESCRIPTION
## Summary

`flo init` now adds gitignore entries for the files moflo auto-overwrites on every install — `.claude/guidance/moflo-*.md` and the 11 scripts in `SCRIPT_MAP`. Consumers no longer see 30+ untracked moflo-derived files in their `git status` after upgrade.

## Changes

- `src/cli/init/moflo-init.ts:updateGitignore` — appends `/.claude/guidance/moflo-*.md` plus `/.claude/scripts/<name>` for each `SCRIPT_MAP` entry. Patterns anchored with leading `/` per `guidance-gitignore-shipped-trap` learning.
- Added a local `normalize` helper that strips a single leading `/` during dedup, so `/.foo` and `.foo` are treated as the same rule (consumers who wrote either form manually don't get a duplicate appended).
- Dedupes a stale `.moflo/` line that appeared twice in `entries`.
- `SCRIPT_MAP` and `updateGitignore` exported for direct unit testing.
- `src/cli/__tests__/init-gitignore.test.ts` — 7 new vitest cases.

## Robustness — no `.gitignore`?

The function already handles the consumer-has-no-`.gitignore` case (creates one with both default consumer entries and moflo entries). Quick audit confirms the only other moflo path that writes a `.gitignore` (`src/cli/init/executor.ts:1474` for `.moflo/.gitignore`) is also `existsSync`-gated. Principle holds across the codebase.

## Design notes

- **Why derive from `SCRIPT_MAP`** — the launcher's `scriptFiles`, executor's `UPGRADE_SCRIPT_MAP`, and init's `SCRIPT_MAP` are kept in lockstep by `init-copy-maps.test.ts`. Spreading `SCRIPT_MAP` into the gitignore entries piggy-backs on that existing parity guard with zero new drift surface.
- **Why leading `/`** — bare `.claude/guidance/` once swallowed shipped/internal subdirs and broke `npm pack` (memory: `guidance-gitignore-shipped-trap`). The leading-`/` anchor scopes the rule to the top-level mirror only.

## Testing

- [x] 7 new tests in `src/cli/__tests__/init-gitignore.test.ts` — all pass
- [x] Existing init tests (`init-copy-maps`, `init-envrc`, `init-test-dirs`) — all pass, no regression
- [x] Type-check clean (`tsc --noEmit`)
- [ ] Manual smoke after publish: `npm install moflo@<next>` in scratch project, run `flo init`, confirm `.gitignore` contains entries and `git status` shows no untracked moflo-synced files

## Round-trip

Runtime fix → ships via `npm publish`, takes effect on next consumer install. Pre-existing committed copies of these files in consumer repos won't be retroactively untracked — to be called out in release notes (one-shot `git rm --cached` for affected consumers; we don't auto-mutate consumer git state).

Closes #1050