### PR TITLE
fix(1061): serialize daemon start behind indexer chain via indexer.lock

### DIFF
--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -27,6 +27,7 @@ import { createProcessManager } from './lib/process-manager.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { findProjectRoot } from './lib/moflo-paths.mjs';
+import { isIndexerLockHeld } from './lib/indexer-lock.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -266,8 +267,6 @@ async function main() {
       }
 
       case 'session-start': {
-        // Start daemon quietly in background (no DB writes)
-        runDaemonStartBackground();
         // Run all DB-writing indexers SEQUENTIALLY in a single background process.
         // This avoids sql.js last-write-wins concurrency (#78) and ensures
         // HNSW rebuild runs after all indexers finish (#81).
@@ -289,11 +288,21 @@ async function main() {
         // middle of overwriting during an upgrade. resolveBinOrLocal's
         // bin-first ordering guarantees the spawned chain matches the
         // installed package even when the mirror is mid-sync.
+        //
+        // #1061 — Daemon-start is the LAST step of the indexer chain, not a
+        // parallel spawn here. Forking the daemon at the same instant as the
+        // chain lets the daemon's stale sql.js snapshot clobber the chain's
+        // on-disk writes on its next flush. By letting index-all.mjs spawn
+        // the daemon AFTER it releases the indexer lock, the daemon comes up
+        // against the stable post-chain state. If the chain script is
+        // missing, fall back to the direct daemon start so a missing-bin
+        // failure doesn't also lose the daemon.
         const indexAllScript = resolveBinOrLocal('flo-index-all', 'index-all.mjs');
         if (indexAllScript) {
           spawnWindowless('node', [indexAllScript], 'sequential indexing chain');
         } else {
-          log('warn', 'index-all.mjs not found (checked npm bin + .claude/scripts/)');
+          log('warn', 'index-all.mjs not found (checked npm bin + .claude/scripts/) — direct daemon start fallback');
+          runDaemonStartBackground();
         }
         // Neural patterns now loaded by moflo core routing — no external patching.
         break;
@@ -335,6 +344,9 @@ async function main() {
       case 'daemon-start': {
         if (isDaemonLockHeld()) {
           log('info', 'Daemon already running (lock held), skipping start');
+        } else if (isIndexerLockHeld(projectRoot)) {
+          // #1061 — indexer chain owns the daemon wakeup at its end.
+          log('info', 'Indexer chain in progress, deferring daemon start (#1061)');
         } else if (isDaemonSpawnRecent()) {
           log('info', 'Daemon spawn debounced (recent attempt), skipping');
         } else {
@@ -574,7 +586,16 @@ function runDaemonStartBackground() {
     return;
   }
 
-  // 3. Debounce: skip if we spawned recently (prevents thundering herd)
+  // 3. #1061 — indexer chain in progress. The chain spawns the daemon at
+  //    its end against the post-chain stable state. Starting in parallel
+  //    lets the daemon's stale sql.js snapshot clobber the chain's writes
+  //    on its next flush.
+  if (isIndexerLockHeld(projectRoot)) {
+    log('info', 'Indexer chain in progress, deferring daemon start (#1061)');
+    return;
+  }
+
+  // 4. Debounce: skip if we spawned recently (prevents thundering herd)
   if (isDaemonSpawnRecent()) {
     log('info', 'Daemon spawn debounced (recent attempt), skipping');
     return;
@@ -586,7 +607,7 @@ function runDaemonStartBackground() {
     return;
   }
 
-  // 4. Write stamp BEFORE spawning so concurrent callers see it immediately
+  // 5. Write stamp BEFORE spawning so concurrent callers see it immediately
   touchSpawnStamp();
 
   spawnWindowless('node', [localCli, 'daemon', 'start', '--quiet'], 'daemon');

--- a/bin/index-all.mjs
+++ b/bin/index-all.mjs
@@ -26,6 +26,8 @@ import {
   cleanupLegacyFingerprint,
 } from './lib/index-fingerprint.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
+import { acquireIndexerLock, releaseIndexerLock } from './lib/indexer-lock.mjs';
+import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 
 // Cap fastembed/ONNX thread count when spawning the heavy steps. Without
 // this, ONNX defaults to one thread per CPU core (22+ on a modern dev box),
@@ -224,8 +226,64 @@ function buildStepPlan() {
   return plan;
 }
 
+// After the indexer chain finishes (success OR fail), the daemon needs to
+// come up against the now-stable on-disk DB. hooks.mjs session-start no
+// longer races us in — daemon-start checks isIndexerLockHeld() and defers
+// while we hold the lock (#1061), so we own the wakeup. Idempotent: the
+// daemon CLI itself is a no-op when a live daemon lock is already held.
+function spawnDaemonAfterChain() {
+  // Honor the same opt-out hooks.mjs's runDaemonStartBackground checks —
+  // .claude/settings.json claudeFlow.daemon.autoStart. Without this gate,
+  // moving the daemon spawn from hooks.mjs into here would silently
+  // override the user's daemon-disabled preference.
+  if (!shouldDaemonAutoStart(projectRoot)) {
+    log('SKIP  daemon-start (claudeFlow.daemon.autoStart=false)');
+    return;
+  }
+  const localCli = getLocalCliPath();
+  if (!localCli) {
+    log('SKIP  daemon-start (CLI not found)');
+    return;
+  }
+  try {
+    const child = spawn('node', [localCli, 'daemon', 'start', '--quiet'], {
+      cwd: projectRoot,
+      stdio: 'ignore',
+      windowsHide: true,
+      detached: platform() !== 'win32',
+      env: process.env,
+    });
+    if (platform() !== 'win32') child.unref();
+    log(`DONE  daemon-start (pid=${child.pid ?? 'n/a'})`);
+  } catch (err) {
+    const msg = (err && err.message) ? err.message.split('\n')[0] : 'unknown';
+    log(`FAIL  daemon-start: ${msg}`);
+  }
+}
+
 async function main() {
   const startTime = Date.now();
+
+  // #1061 — hold the lock across the whole chain so daemon-start defers
+  // until our writes have landed. Stale-aware (dead pid OR mtime > 10 min).
+  const acquired = acquireIndexerLock(projectRoot);
+  if (!acquired) {
+    log('SKIP  another indexer chain holds the lock — exiting');
+    return;
+  }
+  // Release on every exit path. The `exit` listener catches normal returns;
+  // signal handlers cover ctrl+C / SIGTERM from the parent (#744 tree-kill
+  // path applies to OUR children, not to us — these handlers cover us).
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    try { releaseIndexerLock(projectRoot); } catch { /* non-fatal */ }
+  };
+  process.on('exit', release);
+  process.on('SIGINT', () => { release(); process.exit(130); });
+  process.on('SIGTERM', () => { release(); process.exit(143); });
+
   const plan = buildStepPlan();
 
   let ranAny = false;
@@ -283,10 +341,19 @@ async function main() {
     ? `Sequential indexing chain complete (${totalElapsed}s)`
     : `Sequential indexing chain skipped — all steps gated unchanged (${totalElapsed}s)`);
 
+  // Release the lock BEFORE spawning the daemon so the daemon's own
+  // isIndexerLockHeld() probe (#1061) sees the cleared state.
+  release();
+  spawnDaemonAfterChain();
+
   if (!hnswOk) process.exit(1);
 }
 
 main().catch(err => {
   log(`FATAL: ${err.message}`);
+  // Best-effort release on fatal path — the exit listener will catch it
+  // anyway, but explicit release here ensures the daemon spawn that
+  // follows isn't blocked by our own lock if we ever add one.
+  try { releaseIndexerLock(projectRoot); } catch { /* non-fatal */ }
   process.exit(1);
 });

--- a/bin/index-all.mjs
+++ b/bin/index-all.mjs
@@ -28,6 +28,7 @@ import {
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { acquireIndexerLock, releaseIndexerLock } from './lib/indexer-lock.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
+import { createProcessManager } from './lib/process-manager.mjs';
 
 // Cap fastembed/ONNX thread count when spawning the heavy steps. Without
 // this, ONNX defaults to one thread per CPU core (22+ on a modern dev box),
@@ -57,7 +58,11 @@ function resolveBin(binName, localScript) {
   return resolveMofloBin(projectRoot, binName, localScript, { includeDevFallback: true });
 }
 
+// Memoize — called twice (buildStepPlan + spawnDaemonAfterChain). Both
+// paths probe the same 3 candidates via existsSync.
+let _localCliPathCache;
 function getLocalCliPath() {
+  if (_localCliPathCache !== undefined) return _localCliPathCache;
   const paths = [
     resolve(projectRoot, 'node_modules/moflo/bin/cli.js'),
     resolve(projectRoot, 'node_modules/.bin/flo'),
@@ -65,9 +70,9 @@ function getLocalCliPath() {
     resolve(projectRoot, 'bin/cli.js'),
   ];
   for (const p of paths) {
-    if (existsSync(p)) return p;
+    if (existsSync(p)) return (_localCliPathCache = p);
   }
-  return null;
+  return (_localCliPathCache = null);
 }
 
 /** Read moflo.yaml once and cache auto_index flags. */
@@ -229,8 +234,9 @@ function buildStepPlan() {
 // After the indexer chain finishes (success OR fail), the daemon needs to
 // come up against the now-stable on-disk DB. hooks.mjs session-start no
 // longer races us in — daemon-start checks isIndexerLockHeld() and defers
-// while we hold the lock (#1061), so we own the wakeup. Idempotent: the
-// daemon CLI itself is a no-op when a live daemon lock is already held.
+// while we hold the lock (#1061), so we own the wakeup. Routed through the
+// shared ProcessManager so the spawn gets label-dedup, PID tracking, and
+// .swarm/background.log capture — same surface every other bin/ spawn uses.
 function spawnDaemonAfterChain() {
   // Honor the same opt-out hooks.mjs's runDaemonStartBackground checks —
   // .claude/settings.json claudeFlow.daemon.autoStart. Without this gate,
@@ -245,19 +251,14 @@ function spawnDaemonAfterChain() {
     log('SKIP  daemon-start (CLI not found)');
     return;
   }
-  try {
-    const child = spawn('node', [localCli, 'daemon', 'start', '--quiet'], {
-      cwd: projectRoot,
-      stdio: 'ignore',
-      windowsHide: true,
-      detached: platform() !== 'win32',
-      env: process.env,
-    });
-    if (platform() !== 'win32') child.unref();
-    log(`DONE  daemon-start (pid=${child.pid ?? 'n/a'})`);
-  } catch (err) {
-    const msg = (err && err.message) ? err.message.split('\n')[0] : 'unknown';
-    log(`FAIL  daemon-start: ${msg}`);
+  const pm = createProcessManager(projectRoot);
+  const result = pm.spawn('node', [localCli, 'daemon', 'start', '--quiet'], 'daemon');
+  if (result.skipped) {
+    log(`SKIP  daemon-start (already running, pid=${result.pid})`);
+  } else if (result.pid) {
+    log(`DONE  daemon-start (pid=${result.pid})`);
+  } else {
+    log('FAIL  daemon-start (spawn returned no pid)');
   }
 }
 
@@ -274,15 +275,12 @@ async function main() {
   // Release on every exit path. The `exit` listener catches normal returns;
   // signal handlers cover ctrl+C / SIGTERM from the parent (#744 tree-kill
   // path applies to OUR children, not to us — these handlers cover us).
-  let released = false;
-  const release = () => {
-    if (released) return;
-    released = true;
-    try { releaseIndexerLock(projectRoot); } catch { /* non-fatal */ }
-  };
-  process.on('exit', release);
-  process.on('SIGINT', () => { release(); process.exit(130); });
-  process.on('SIGTERM', () => { release(); process.exit(143); });
+  // releaseIndexerLock is itself idempotent (re-entry sees the file gone or
+  // owned by another pid and bails), so once-listeners are sufficient.
+  const release = () => { try { releaseIndexerLock(projectRoot); } catch { /* non-fatal */ } };
+  process.once('exit', release);
+  process.once('SIGINT', () => { release(); process.exit(130); });
+  process.once('SIGTERM', () => { release(); process.exit(143); });
 
   const plan = buildStepPlan();
 

--- a/bin/lib/indexer-lock.mjs
+++ b/bin/lib/indexer-lock.mjs
@@ -1,0 +1,123 @@
+/**
+ * Indexer-lock helper (#1061 — cross-process write race: indexer chain vs daemon).
+ *
+ * The session-start indexer chain (bin/index-all.mjs) and the daemon both
+ * write to `.moflo/moflo.db` via sql.js whole-file flush. If the daemon
+ * performs any write during the seconds-to-minutes the chain runs, its next
+ * flush clobbers the indexer's on-disk state with the daemon's stale in-RAM
+ * snapshot.
+ *
+ * Fix: the indexer chain writes `.moflo/indexer.lock` at startup and removes
+ * it at exit. Daemon-start (in bin/hooks.mjs) waits for the lock to clear
+ * before forking — the indexer chain itself spawns the daemon at the end, so
+ * the daemon comes up against a stable on-disk state.
+ *
+ * Stale-lock detection: a lock whose `pid` is no longer alive OR whose
+ * mtime is older than MAX_LOCK_AGE_MS is treated as cleared. This guards
+ * against indexer crashes that skip the release path.
+ *
+ * Contract — every function in this module:
+ *   - Never throws. FS errors degrade gracefully (return false from
+ *     acquire/release, treat lock as not-held from isHeld).
+ *   - Returns synchronously.
+ *
+ * @module bin/lib/indexer-lock
+ */
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const LOCK_FILENAME = 'indexer.lock';
+
+/** Max age before a lock is treated as stale (10 min — covers cold-install indexer + slack). */
+const MAX_LOCK_AGE_MS = 10 * 60 * 1000;
+
+export function indexerLockPath(projectRoot) {
+  return join(projectRoot, '.moflo', LOCK_FILENAME);
+}
+
+function isPidAlive(pid) {
+  if (typeof pid !== 'number' || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the pid exists but we lack permission to signal it — still
+    // counts as "alive". ESRCH means it's truly gone.
+    return err && err.code === 'EPERM';
+  }
+}
+
+function readLock(lockPath) {
+  try {
+    const raw = readFileSync(lockPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+  } catch { /* malformed — treat as absent */ }
+  return null;
+}
+
+/**
+ * Returns true iff the lockfile exists, its recorded pid is alive (or
+ * EPERM-protected), AND its mtime is within MAX_LOCK_AGE_MS. Anything else
+ * is "not held" — caller may proceed.
+ */
+export function isIndexerLockHeld(projectRoot) {
+  const lockPath = indexerLockPath(projectRoot);
+  if (!existsSync(lockPath)) return false;
+
+  let mtime;
+  try { mtime = statSync(lockPath).mtimeMs; }
+  catch { return false; }
+  if (Date.now() - mtime > MAX_LOCK_AGE_MS) return false;
+
+  const lock = readLock(lockPath);
+  if (!lock) return false;
+  return isPidAlive(lock.pid);
+}
+
+/**
+ * Acquire the lock for this process. Returns true on success, false if
+ * another live indexer holds it. Stale locks (dead pid or old mtime) are
+ * silently overwritten.
+ *
+ * FS errors are non-fatal — returns true so the indexer chain still runs
+ * even if .moflo/ is unwritable; the indexer's own writes will then fail
+ * loudly with a clearer error than "lock acquire failed".
+ */
+export function acquireIndexerLock(projectRoot) {
+  const lockPath = indexerLockPath(projectRoot);
+  try {
+    if (isIndexerLockHeld(projectRoot)) {
+      // Another live indexer is running — bail.
+      return false;
+    }
+    const dir = dirname(lockPath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    }));
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Release the lock IF this process owns it. Mismatched-pid locks are not
+ * touched (someone else owns them). Missing lock is a no-op.
+ *
+ * Safe to call multiple times (exit + signal handlers both call it).
+ */
+export function releaseIndexerLock(projectRoot) {
+  const lockPath = indexerLockPath(projectRoot);
+  try {
+    if (!existsSync(lockPath)) return;
+    const lock = readLock(lockPath);
+    if (lock && typeof lock.pid === 'number' && lock.pid !== process.pid) {
+      // Another process holds it now — don't touch.
+      return;
+    }
+    unlinkSync(lockPath);
+  } catch { /* already gone or unreadable */ }
+}

--- a/bin/lib/indexer-lock.mjs
+++ b/bin/lib/indexer-lock.mjs
@@ -25,26 +25,22 @@
  */
 import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { isAlive } from './process-manager.mjs';
 
 const LOCK_FILENAME = 'indexer.lock';
 
-/** Max age before a lock is treated as stale (10 min — covers cold-install indexer + slack). */
+/**
+ * Max age before a lock is treated as stale. Picked to match the indexer
+ * chain's absolute worst-case wall clock: `build-embeddings` (5 min timeout
+ * in index-all.mjs:199) + `hnsw-rebuild` (5 min timeout, line 217) = 10 min.
+ * There is intentionally zero slack — the pid-liveness check is the primary
+ * staleness signal; mtime is the backstop for a crashed-without-cleanup
+ * indexer whose pid was already recycled by the OS.
+ */
 const MAX_LOCK_AGE_MS = 10 * 60 * 1000;
 
 export function indexerLockPath(projectRoot) {
   return join(projectRoot, '.moflo', LOCK_FILENAME);
-}
-
-function isPidAlive(pid) {
-  if (typeof pid !== 'number' || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    // EPERM means the pid exists but we lack permission to signal it — still
-    // counts as "alive". ESRCH means it's truly gone.
-    return err && err.code === 'EPERM';
-  }
 }
 
 function readLock(lockPath) {
@@ -72,7 +68,7 @@ export function isIndexerLockHeld(projectRoot) {
 
   const lock = readLock(lockPath);
   if (!lock) return false;
-  return isPidAlive(lock.pid);
+  return isAlive(lock.pid);
 }
 
 /**
@@ -80,19 +76,23 @@ export function isIndexerLockHeld(projectRoot) {
  * another live indexer holds it. Stale locks (dead pid or old mtime) are
  * silently overwritten.
  *
- * FS errors are non-fatal — returns true so the indexer chain still runs
- * even if .moflo/ is unwritable; the indexer's own writes will then fail
- * loudly with a clearer error than "lock acquire failed".
+ * FS errors: returns true so the indexer chain still runs — the chain's own
+ * writes will fail loudly with a clearer error than "lock acquire failed".
+ * Trade-off: the unwritable-`.moflo/` scenario also means the lock can't be
+ * read by hooks.mjs, so daemon-start won't see a held lock and will fork in
+ * parallel — re-introducing the race. That window is identical to "no fix
+ * at all" and only opens when `.moflo/` is unwritable; we accept it rather
+ * than failing the entire indexer chain over a lock-FS error.
  */
 export function acquireIndexerLock(projectRoot) {
   const lockPath = indexerLockPath(projectRoot);
   try {
     if (isIndexerLockHeld(projectRoot)) {
-      // Another live indexer is running — bail.
       return false;
     }
-    const dir = dirname(lockPath);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    // mkdirSync({recursive:true}) is a no-op when the dir already exists —
+    // no need for an existsSync precheck.
+    mkdirSync(dirname(lockPath), { recursive: true });
     writeFileSync(lockPath, JSON.stringify({
       pid: process.pid,
       startedAt: new Date().toISOString(),
@@ -106,6 +106,10 @@ export function acquireIndexerLock(projectRoot) {
 /**
  * Release the lock IF this process owns it. Mismatched-pid locks are not
  * touched (someone else owns them). Missing lock is a no-op.
+ *
+ * Precondition: caller MUST have successfully called acquireIndexerLock
+ * earlier in the same process. Calling release without a matching acquire
+ * is a no-op (mismatched pid path).
  *
  * Safe to call multiple times (exit + signal handlers both call it).
  */

--- a/bin/lib/process-manager.mjs
+++ b/bin/lib/process-manager.mjs
@@ -36,13 +36,24 @@ function ensureDir(dir) {
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 }
 
-/** Check if a PID is alive (cross-platform). */
-function isAlive(pid) {
+/**
+ * Check if a PID is alive (cross-platform).
+ *
+ * Exported so other bin/lib helpers (e.g. indexer-lock.mjs) reuse the same
+ * cross-platform implementation instead of redefining it.
+ *
+ * EPERM (we lack permission to signal the target pid — e.g. pid 1 / system
+ * processes / containerized contexts) is treated as alive: the process
+ * demonstrably exists; the only reason we can't signal it is permissions.
+ * ESRCH is the "truly gone" code.
+ */
+export function isAlive(pid) {
+  if (typeof pid !== 'number' || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    return err && err.code === 'EPERM';
   }
 }
 

--- a/tests/bin/indexer-lock.test.ts
+++ b/tests/bin/indexer-lock.test.ts
@@ -13,8 +13,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, utimesSync } from 'fs';
-import { resolve, join } from 'path';
-import { tmpdir } from 'os';
+import { join } from 'path';
 import {
   acquireIndexerLock,
   releaseIndexerLock,
@@ -22,18 +21,17 @@ import {
   indexerLockPath,
   // @ts-expect-error — pure JS module, no ambient types
 } from '../../bin/lib/indexer-lock.mjs';
-
-const TMP_ROOT = resolve(tmpdir(), 'moflo-indexer-lock-test-' + Date.now());
+import { makeTempRoot, cleanTempRoot } from './_helpers';
 
 let projectRoot: string;
 
 beforeEach(() => {
-  projectRoot = resolve(TMP_ROOT, `proj-${Math.random().toString(36).slice(2, 8)}`);
+  projectRoot = makeTempRoot('indexer-lock');
   mkdirSync(join(projectRoot, '.moflo'), { recursive: true });
 });
 
 afterEach(() => {
-  try { rmSync(projectRoot, { recursive: true, force: true }); } catch { /* ok */ }
+  cleanTempRoot(projectRoot);
 });
 
 describe('acquireIndexerLock', () => {

--- a/tests/bin/indexer-lock.test.ts
+++ b/tests/bin/indexer-lock.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for bin/lib/indexer-lock.mjs (#1061 — cross-process write race:
+ * indexer chain vs daemon).
+ *
+ * Contract under test:
+ *   - acquireIndexerLock writes a {pid, startedAt} JSON file.
+ *   - releaseIndexerLock removes the lockfile if (and only if) we own it.
+ *   - isIndexerLockHeld returns true ONLY when the file exists AND its
+ *     recorded pid is alive AND its mtime is within 10 minutes.
+ *   - Stale locks (dead pid OR old mtime) are treated as cleared, and a
+ *     fresh acquire overwrites them.
+ *   - All helpers are non-throwing.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, utimesSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+import {
+  acquireIndexerLock,
+  releaseIndexerLock,
+  isIndexerLockHeld,
+  indexerLockPath,
+  // @ts-expect-error — pure JS module, no ambient types
+} from '../../bin/lib/indexer-lock.mjs';
+
+const TMP_ROOT = resolve(tmpdir(), 'moflo-indexer-lock-test-' + Date.now());
+
+let projectRoot: string;
+
+beforeEach(() => {
+  projectRoot = resolve(TMP_ROOT, `proj-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(projectRoot, '.moflo'), { recursive: true });
+});
+
+afterEach(() => {
+  try { rmSync(projectRoot, { recursive: true, force: true }); } catch { /* ok */ }
+});
+
+describe('acquireIndexerLock', () => {
+  it('writes a lockfile with our pid and startedAt timestamp', () => {
+    const ok = acquireIndexerLock(projectRoot);
+    expect(ok).toBe(true);
+
+    const lockPath = indexerLockPath(projectRoot);
+    expect(existsSync(lockPath)).toBe(true);
+
+    const lock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+    expect(lock.pid).toBe(process.pid);
+    expect(typeof lock.startedAt).toBe('string');
+    expect(new Date(lock.startedAt).toString()).not.toBe('Invalid Date');
+  });
+
+  it('creates the .moflo/ directory if missing', () => {
+    rmSync(join(projectRoot, '.moflo'), { recursive: true, force: true });
+    const ok = acquireIndexerLock(projectRoot);
+    expect(ok).toBe(true);
+    expect(existsSync(indexerLockPath(projectRoot))).toBe(true);
+  });
+
+  it('returns false when a live indexer holds the lock', () => {
+    // Fake another live indexer by writing a lock with the test runner's pid
+    // (which is alive). acquireIndexerLock should refuse.
+    writeFileSync(indexerLockPath(projectRoot), JSON.stringify({
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    }));
+    // Now pretend we are a different process by faking the lock's pid as a
+    // different live one — but since process.pid IS live and the helper uses
+    // process.kill(pid, 0) to probe, any live pid works. The behavior under
+    // test: "lock held by a live pid blocks fresh acquire".
+    const ok = acquireIndexerLock(projectRoot);
+    expect(ok).toBe(false);
+  });
+
+  it('overwrites a stale lock (dead pid)', () => {
+    // PID 999999 is unlikely to be a real running process on either platform.
+    const deadPid = 999999;
+    writeFileSync(indexerLockPath(projectRoot), JSON.stringify({
+      pid: deadPid,
+      startedAt: new Date().toISOString(),
+    }));
+    expect(isIndexerLockHeld(projectRoot)).toBe(false);
+
+    const ok = acquireIndexerLock(projectRoot);
+    expect(ok).toBe(true);
+    const lock = JSON.parse(readFileSync(indexerLockPath(projectRoot), 'utf-8'));
+    expect(lock.pid).toBe(process.pid);
+  });
+
+  it('overwrites a stale lock (old mtime, even with live pid)', () => {
+    writeFileSync(indexerLockPath(projectRoot), JSON.stringify({
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    }));
+    // Backdate the mtime to 20 minutes ago — past the 10-min stale threshold.
+    const twentyMinAgo = (Date.now() - 20 * 60 * 1000) / 1000;
+    utimesSync(indexerLockPath(projectRoot), twentyMinAgo, twentyMinAgo);
+
+    expect(isIndexerLockHeld(projectRoot)).toBe(false);
+    const ok = acquireIndexerLock(projectRoot);
+    expect(ok).toBe(true);
+  });
+
+  it('overwrites a malformed lock file', () => {
+    writeFileSync(indexerLockPath(projectRoot), 'not-json-at-all');
+    expect(isIndexerLockHeld(projectRoot)).toBe(false);
+    const ok = acquireIndexerLock(projectRoot);
+    expect(ok).toBe(true);
+  });
+});
+
+describe('releaseIndexerLock', () => {
+  it('removes the lockfile when we own it', () => {
+    acquireIndexerLock(projectRoot);
+    expect(existsSync(indexerLockPath(projectRoot))).toBe(true);
+
+    releaseIndexerLock(projectRoot);
+    expect(existsSync(indexerLockPath(projectRoot))).toBe(false);
+  });
+
+  it('is a no-op when the lockfile is missing', () => {
+    expect(() => releaseIndexerLock(projectRoot)).not.toThrow();
+    expect(existsSync(indexerLockPath(projectRoot))).toBe(false);
+  });
+
+  it('does NOT remove a lockfile owned by a different live pid', () => {
+    // Write a lock that claims to be held by process.pid but pretend we are
+    // a different process by leaving it as a foreign pid. We can't truly run
+    // as another pid in-test, but we CAN write the foreign pid value and
+    // verify the helper checks pid before unlinking.
+    //
+    // Use 1 (init on Linux, System on Windows) — guaranteed alive on POSIX,
+    // and on Windows process.kill(1, 0) returns EPERM (treated as alive).
+    writeFileSync(indexerLockPath(projectRoot), JSON.stringify({
+      pid: 1,
+      startedAt: new Date().toISOString(),
+    }));
+    releaseIndexerLock(projectRoot);
+    // Should still be there — owned by pid 1, not us.
+    expect(existsSync(indexerLockPath(projectRoot))).toBe(true);
+  });
+
+  it('is idempotent — safe to call multiple times', () => {
+    acquireIndexerLock(projectRoot);
+    releaseIndexerLock(projectRoot);
+    releaseIndexerLock(projectRoot);
+    releaseIndexerLock(projectRoot);
+    expect(existsSync(indexerLockPath(projectRoot))).toBe(false);
+  });
+});
+
+describe('isIndexerLockHeld', () => {
+  it('returns false when the lockfile does not exist', () => {
+    expect(isIndexerLockHeld(projectRoot)).toBe(false);
+  });
+
+  it('returns true when a live indexer holds the lock', () => {
+    acquireIndexerLock(projectRoot);
+    expect(isIndexerLockHeld(projectRoot)).toBe(true);
+  });
+
+  it('returns false after release', () => {
+    acquireIndexerLock(projectRoot);
+    releaseIndexerLock(projectRoot);
+    expect(isIndexerLockHeld(projectRoot)).toBe(false);
+  });
+
+  it('returns false for a dead-pid lock', () => {
+    writeFileSync(indexerLockPath(projectRoot), JSON.stringify({
+      pid: 999999,
+      startedAt: new Date().toISOString(),
+    }));
+    expect(isIndexerLockHeld(projectRoot)).toBe(false);
+  });
+
+  it('returns false for a stale (>10min mtime) lock even with a live pid', () => {
+    writeFileSync(indexerLockPath(projectRoot), JSON.stringify({
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    }));
+    const twentyMinAgo = (Date.now() - 20 * 60 * 1000) / 1000;
+    utimesSync(indexerLockPath(projectRoot), twentyMinAgo, twentyMinAgo);
+    expect(isIndexerLockHeld(projectRoot)).toBe(false);
+  });
+
+  it('returns false for a malformed lockfile', () => {
+    writeFileSync(indexerLockPath(projectRoot), '{not valid json');
+    expect(isIndexerLockHeld(projectRoot)).toBe(false);
+  });
+});

--- a/tests/bin/session-start-indexer-daemon-race.test.ts
+++ b/tests/bin/session-start-indexer-daemon-race.test.ts
@@ -87,10 +87,11 @@ describe('bin/index-all.mjs (#1061)', () => {
   it('registers exit + signal handlers that release the lock', () => {
     // The handlers cover normal exit + SIGINT (ctrl+C from the user) +
     // SIGTERM (parent kill). Without these, a crash leaves the lock
-    // dangling until the 10-min stale check clears it.
-    expect(src).toMatch(/process\.on\s*\(\s*['"]exit['"]/);
-    expect(src).toMatch(/process\.on\s*\(\s*['"]SIGINT['"]/);
-    expect(src).toMatch(/process\.on\s*\(\s*['"]SIGTERM['"]/);
+    // dangling until the 10-min stale check clears it. `on` or `once`
+    // both satisfy the contract — releaseIndexerLock is itself idempotent.
+    expect(src).toMatch(/process\.(on|once)\s*\(\s*['"]exit['"]/);
+    expect(src).toMatch(/process\.(on|once)\s*\(\s*['"]SIGINT['"]/);
+    expect(src).toMatch(/process\.(on|once)\s*\(\s*['"]SIGTERM['"]/);
     expect(src).toMatch(/releaseIndexerLock\s*\(/);
   });
 

--- a/tests/bin/session-start-indexer-daemon-race.test.ts
+++ b/tests/bin/session-start-indexer-daemon-race.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for the indexer-vs-daemon cross-process write race (#1061).
+ *
+ * Before this fix, bin/hooks.mjs session-start forked the daemon AND the
+ * index-all.mjs chain at the same instant. Both opened their own sql.js
+ * handle and wrote to .moflo/moflo.db. If the daemon performed any write
+ * during the seconds-to-minutes the chain ran, its next flush clobbered
+ * the indexer's on-disk state with the daemon's stale in-RAM snapshot.
+ *
+ * Fix: the indexer chain holds .moflo/indexer.lock from start to finish and
+ * is the sole spawner of the daemon at end-of-chain. hooks.mjs no longer
+ * forks the daemon in parallel; runDaemonStartBackground + case 'daemon-start'
+ * defer when the lock is held.
+ *
+ * These are source-level invariants. The lock helper's behavioural contract
+ * is exercised in indexer-lock.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const BIN = resolve(__dirname, '../../bin');
+
+describe('bin/hooks.mjs session-start (#1061)', () => {
+  const file = resolve(BIN, 'hooks.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('imports isIndexerLockHeld from ./lib/indexer-lock.mjs', () => {
+    expect(src).toMatch(/from\s+['"]\.\/lib\/indexer-lock\.mjs['"]/);
+    expect(src).toMatch(/\bisIndexerLockHeld\b/);
+  });
+
+  it('session-start case does NOT unconditionally call runDaemonStartBackground', () => {
+    // The chain spawns the daemon at its end (#1061). Parallel daemon
+    // spawn at session-start re-introduces the race. Fallback to a direct
+    // call is allowed ONLY when the index-all.mjs script can't be located —
+    // in that branch the chain never runs, so the lock is never held, and
+    // the daemon needs a direct kick.
+    const sessionStart = src.match(/case 'session-start':\s*\{([\s\S]*?)\n\s+case '/);
+    expect(sessionStart, 'session-start case must exist in hooks.mjs').toBeTruthy();
+    const body = sessionStart![1];
+
+    // The fallback "else" branch is allowed to call runDaemonStartBackground
+    // — but the success branch (script-located, indexer spawning) must not.
+    // Easiest invariant: the runDaemonStartBackground call sits inside an
+    // `else` branch following an `if (indexAllScript)` test.
+    const directCallsToDaemonStart = (body.match(/runDaemonStartBackground\s*\(/g) || []).length;
+    expect(directCallsToDaemonStart, 'session-start should call runDaemonStartBackground at most once (the missing-script fallback)').toBeLessThanOrEqual(1);
+
+    if (directCallsToDaemonStart === 1) {
+      // The single call must be guarded by the missing-script else-branch.
+      const guardedFallback = body.match(/if\s*\(indexAllScript\)[\s\S]*?else[\s\S]*?runDaemonStartBackground/);
+      expect(guardedFallback, 'runDaemonStartBackground in session-start must sit in the missing-script else branch').toBeTruthy();
+    }
+  });
+
+  it('runDaemonStartBackground checks isIndexerLockHeld', () => {
+    const fn = src.match(/function\s+runDaemonStartBackground\s*\([^)]*\)\s*\{([\s\S]*?)\n\}/);
+    expect(fn, 'runDaemonStartBackground function must exist').toBeTruthy();
+    expect(fn![1]).toMatch(/isIndexerLockHeld\s*\(/);
+  });
+
+  it("case 'daemon-start' checks isIndexerLockHeld before spawning", () => {
+    // The hook-event handler must also defer when the chain is running —
+    // otherwise an external `flo hooks daemon-start` call mid-chain still
+    // races.
+    const caseBody = src.match(/case 'daemon-start':\s*\{([\s\S]*?)\n\s+case '/);
+    expect(caseBody, "case 'daemon-start' must exist").toBeTruthy();
+    expect(caseBody![1]).toMatch(/isIndexerLockHeld\s*\(/);
+  });
+});
+
+describe('bin/index-all.mjs (#1061)', () => {
+  const file = resolve(BIN, 'index-all.mjs');
+  const src = readFileSync(file, 'utf-8');
+
+  it('imports acquireIndexerLock and releaseIndexerLock', () => {
+    expect(src).toMatch(/from\s+['"]\.\/lib\/indexer-lock\.mjs['"]/);
+    expect(src).toMatch(/\bacquireIndexerLock\b/);
+    expect(src).toMatch(/\breleaseIndexerLock\b/);
+  });
+
+  it('acquires the lock inside main()', () => {
+    expect(src).toMatch(/acquireIndexerLock\s*\(\s*projectRoot\s*\)/);
+  });
+
+  it('registers exit + signal handlers that release the lock', () => {
+    // The handlers cover normal exit + SIGINT (ctrl+C from the user) +
+    // SIGTERM (parent kill). Without these, a crash leaves the lock
+    // dangling until the 10-min stale check clears it.
+    expect(src).toMatch(/process\.on\s*\(\s*['"]exit['"]/);
+    expect(src).toMatch(/process\.on\s*\(\s*['"]SIGINT['"]/);
+    expect(src).toMatch(/process\.on\s*\(\s*['"]SIGTERM['"]/);
+    expect(src).toMatch(/releaseIndexerLock\s*\(/);
+  });
+
+  it('spawns the daemon after the chain finishes (releases lock first)', () => {
+    // The chain owns the daemon wakeup at end-of-run. The spawn must come
+    // AFTER the explicit release() so the daemon's own probe sees the
+    // cleared state.
+    const mainBody = src.match(/async\s+function\s+main\s*\(\s*\)\s*\{([\s\S]*?)\n\}/);
+    expect(mainBody, 'main() must exist').toBeTruthy();
+    const body = mainBody![1];
+
+    // The tail of main must have both a release() call and a daemon spawn.
+    expect(body).toMatch(/release\s*\(\s*\)/);
+    expect(body).toMatch(/spawnDaemonAfterChain\s*\(\s*\)|\bdaemon\b.*?\bstart\b/);
+  });
+
+  it('end-of-chain daemon spawn honors shouldDaemonAutoStart', () => {
+    // Moving the daemon spawn from hooks.mjs's runDaemonStartBackground
+    // (which checks .claude/settings.json claudeFlow.daemon.autoStart) into
+    // index-all.mjs MUST preserve that user opt-out — otherwise consumers
+    // with the daemon explicitly disabled get one started anyway.
+    expect(src).toMatch(/shouldDaemonAutoStart/);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1061 — daemon-vs-indexer-chain cross-process write race (residual from #1057)
- Adds `.moflo/indexer.lock` (Option 1 from the issue body) — indexer chain holds it from start to finish and owns the daemon wakeup at end-of-chain
- Both `daemon-start` surfaces in `bin/hooks.mjs` defer when the lock is held; stale-aware (dead PID OR mtime > 10 min)

## Why

Before this PR, `hooks.mjs session-start` forked the daemon AND `index-all.mjs` at the same instant. Each opens its own sql.js handle and writes `.moflo/moflo.db` via whole-file flush. If the daemon performed any write during the seconds-to-minutes the indexer chain ran, its next flush clobbered the indexer's on-disk state with the daemon's stale in-RAM snapshot.

This is the residual scope explicitly documented in `docs/internal/1054-writer-audit.md` for `bin/build-embeddings.mjs` and the indexer family — "cross-process race with daemon remains for follow-up."

## Approach

The simplest option from the issue body — Option 1 (indexer lock). No API surface added, no daemon-internal redesign.

1. New `bin/lib/indexer-lock.mjs` — `acquireIndexerLock` / `releaseIndexerLock` / `isIndexerLockHeld`. Stale detection (dead pid OR mtime > 10 min) prevents an indexer crash from permanently blocking the daemon.
2. `bin/index-all.mjs` acquires the lock at start, releases on every exit path (`process.once('exit'|'SIGINT'|'SIGTERM')`), and spawns the daemon at end-of-chain via the shared `ProcessManager` — honoring the same `shouldDaemonAutoStart` opt-out that `runDaemonStartBackground` checks.
3. `bin/hooks.mjs` no longer forks the daemon in parallel from `session-start`. Both daemon-start surfaces (`runDaemonStartBackground` and `case 'daemon-start'`) defer when the indexer lock is held. Fallback to direct daemon start only when the `index-all.mjs` script can't be located.
4. `bin/lib/process-manager.mjs` exports `isAlive` (with EPERM handling) — one canonical cross-platform pid-liveness check shared by both modules.

## Consumer impact

- Ships via the existing `bin/` sync. The new `bin/lib/indexer-lock.mjs` is auto-picked-up by the launcher's recursive `bin/lib/` → `.claude/scripts/lib/` copy — no `scriptFiles` change needed.
- No state-format change, no migration.
- On-current-version consumers see fewer clobber-class regressions on cold installs and heavy session-start workloads.

## Out of scope (deliberately — keeping blast radius small)

- Daemon-internal write-path gating for the "existing daemon + new indexer" case. The current scope handles the issue's stated trigger ("forks the daemon AND the indexer chain at the same instant"); #1057 content-diff + #1058 read-side mtime-coherence already shrink the residual write-side surface for an already-running daemon.
- Bulk write RPC (Option 2) and indexer-in-daemon (Option 3) from the issue body — both larger redesigns.

## Test plan

- [x] `npx vitest run tests/bin/indexer-lock.test.ts tests/bin/session-start-indexer-daemon-race.test.ts tests/bin/session-start-embedding-race.test.ts` — 35 passed
- [x] `npx vitest run tests/bin/` — full bin test suite: 329 passed (31 files)
- [x] `npx vitest run tests/bin/process-manager.test.ts tests/bin/process-manager-stress.test.ts tests/bin/index-embeddings-pm-registration.test.ts tests/bin/lib-sync.test.ts` — green (verifies the `isAlive` export change is safe for existing consumers)
- [x] `npx vitest run tests/system/moflo-db-writer-audit.test.ts` — writer-audit lint still green
- [x] `npx vitest run src/cli/__tests__/post-install-bootstrap-drift-guard.test.ts src/cli/__tests__/services/auto-update.test.ts` — drift guards still green
- [x] `npm run build` — clean
- [x] `node --check` on each modified `.mjs` file — clean

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)