### PR TITLE
fix(1088): consumer-smoke fixture in os.tmpdir() + project-root gate

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -4,7 +4,7 @@
  * prerequisites) is handled by the caller via re-thrown errors.
  */
 
-import { existsSync, mkdirSync, writeFileSync, readdirSync, rmSync, statSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, readdirSync, rmSync, statSync, readFileSync, realpathSync } from 'node:fs';
 import { basename, join, relative } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { execFileSync, spawn } from 'node:child_process';
@@ -220,8 +220,16 @@ console.log(JSON.stringify({
     record('project-root-gate', 'fail', `probe stdout not JSON: ${r.stdout.trim().slice(0, 200)}`);
     throw new Error('project-root gate failed');
   }
-  // Normalize for case-insensitive Windows paths + trailing-slash differences.
-  const norm = (p) => p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  // Normalize for:
+  //   - Windows case-insensitivity + backslash separators
+  //   - macOS /var → /private/var symlink (os.tmpdir() returns /var/...;
+  //     process.cwd() inside the subprocess returns the realpath
+  //     /private/var/... — string compare without realpath divergence FPs).
+  const norm = (p) => {
+    let r = p;
+    try { r = realpathSync(p); } catch { /* path may not exist on either side; fall through */ }
+    return r.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  };
   if (norm(parsed.resolved) !== norm(consumerDir)) {
     record(
       'project-root-gate',

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -173,6 +173,70 @@ export function installConsumer({ workDir, tarballPath }) {
   return consumerDir;
 }
 
+/**
+ * #1088 broken-window gate. The bug class: any moflo writer that resolves
+ * paths via `findProjectRoot()` will walk past the consumer dir and land
+ * on whatever moflo-shaped ancestor is above it. That ancestor used to be
+ * the moflo source repo (workDir under `harness/consumer-smoke/.work`),
+ * which produced #1088 + cousins #1054/#1057/#1058. The structural fix is
+ * to put the consumer in `os.tmpdir()` — but a sane place + a future
+ * accidental nesting (e.g. someone runs the harness from inside another
+ * moflo repo, or `tmpdir()` itself ever grows a `.moflo/`) would silently
+ * re-introduce the mismatch.
+ *
+ * This gate runs early and asserts `findProjectRoot()` from inside the
+ * consumer dir returns the consumer dir itself. If anything above the
+ * consumer has a `.moflo/moflo.db`, `.swarm/memory.db`, or
+ * `CLAUDE.md + package.json` marker pair, the resolver picks it up first
+ * and we hard-fail HERE — at a single, named gate — instead of a probe
+ * 30 checks downstream returning a confusing `not found` error.
+ */
+export function verifyConsumerIsProjectRoot(consumerDir) {
+  section('Verify findProjectRoot resolves to the consumer dir (#1088)');
+  const probe = join(consumerDir, '_project-root-gate.mjs');
+  const mofloPathsPath = join(consumerDir, 'node_modules', 'moflo', 'bin', 'lib', 'moflo-paths.mjs');
+  if (!existsSync(mofloPathsPath)) {
+    record('project-root-gate', 'fail', `bin/lib/moflo-paths.mjs missing from install: ${mofloPathsPath}`);
+    return;
+  }
+  writeFileSync(probe, `
+import { pathToFileURL } from 'node:url';
+const mod = await import(pathToFileURL(${JSON.stringify(mofloPathsPath)}).href);
+console.log(JSON.stringify({
+  cwd: process.cwd(),
+  resolved: mod.findProjectRoot({ honorEnv: false }),
+}));
+`);
+  const r = runNode(probe, [], { cwd: consumerDir, timeout: 15_000 });
+  try { rmSync(probe, { force: true }); } catch { /* ok */ }
+  if (r.code !== 0) {
+    record('project-root-gate', 'fail', `probe exit ${r.code}: ${(r.stderr || r.stdout).trim().slice(0, 200)}`);
+    throw new Error('project-root gate failed');
+  }
+  let parsed;
+  // Split on /\r?\n/ so a Windows CRLF line ending doesn't leave a trailing
+  // '\r' on the popped value and trip JSON.parse (cf. fix(1054) in launcher).
+  try { parsed = JSON.parse(r.stdout.trim().split(/\r?\n/).pop()); } catch {
+    record('project-root-gate', 'fail', `probe stdout not JSON: ${r.stdout.trim().slice(0, 200)}`);
+    throw new Error('project-root gate failed');
+  }
+  // Normalize for case-insensitive Windows paths + trailing-slash differences.
+  const norm = (p) => p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  if (norm(parsed.resolved) !== norm(consumerDir)) {
+    record(
+      'project-root-gate',
+      'fail',
+      `findProjectRoot resolved to "${parsed.resolved}", expected "${consumerDir}". ` +
+      `An ancestor of the consumer dir has a moflo marker (.moflo/moflo.db, .swarm/memory.db, ` +
+      `or CLAUDE.md+package.json) — every downstream daemon/bridge/probe will read/write the ` +
+      `wrong file. Run the harness from a workDir that has no moflo-shaped ancestors ` +
+      `(default: os.tmpdir()/moflo-consumer-smoke).`,
+    );
+    throw new Error('project-root gate failed');
+  }
+  record('project-root-gate', 'pass', `consumer is its own project root (${norm(consumerDir)})`);
+}
+
 export function verifyForbiddenDeps(consumerDir) {
   section('Verify forbidden transitive deps absent');
   const nm = join(consumerDir, 'node_modules');
@@ -449,6 +513,9 @@ const SMOKE_ALLOWED_DOCTOR_WARNINGS = [
   'Hook Block Drift', // settings.json not found in fresh fixture (warn since #888)
   'Semantic Quality', // empty DB, no patterns yet
   'Disk Space',       // macOS GitHub runner is constantly >80% used (warn threshold)
+  'TypeScript',       // a fresh consumer fixture in os.tmpdir() has no tsc on PATH
+                      // (pre-#1088 the fixture lived inside the moflo repo and
+                      // inherited the repo's node_modules/.bin/tsc via npx walk-up)
 ];
 
 export function doctor(consumerDir) {
@@ -1078,8 +1145,12 @@ const meta = (i, total) => JSON.stringify({
 });
 
 // Use the same DB path memory_store would use. The bridge resolves it via
-// memoryDbPath(process.cwd()); for the smoke harness, the consumer is
-// already at process.cwd() with .moflo/ initialized by memory init.
+// memoryDbPath(findProjectRoot()); the smoke harness runs this probe with
+// cwd = consumer dir AND the consumer dir lives outside the moflo source
+// repo (see harness/consumer-smoke/run.mjs workDir = os.tmpdir()), so the
+// walk-up resolves to the consumer naturally. Using a bare '.moflo/moflo.db'
+// is therefore equivalent to memoryDbPath(findProjectRoot()) and matches
+// what every other in-consumer writer hits.
 mkdirSync('.moflo', { recursive: true });
 const dbPath = '.moflo/moflo.db';
 const { default: initSqlJs } = await import('sql.js');

--- a/harness/consumer-smoke/run-populated.mjs
+++ b/harness/consumer-smoke/run-populated.mjs
@@ -23,6 +23,7 @@
 
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
 
 import * as report from './lib/report.mjs';
 import * as proc from './lib/proc.mjs';
@@ -31,7 +32,10 @@ import { runPopulatedConsumerProfile } from './lib/populated.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..', '..');
-const workDir = join(__dirname, '.work');
+// #1088: workDir lives in os.tmpdir() so the consumer dir has NO moflo-repo
+// ancestor with markers that findProjectRoot would resolve to instead of
+// the consumer itself. See run.mjs for the full rationale.
+const workDir = join(tmpdir(), 'moflo-consumer-smoke-populated');
 
 const argv = process.argv.slice(2);
 const opts = {

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -35,6 +35,7 @@
 
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
 
 import * as report from './lib/report.mjs';
 import * as proc from './lib/proc.mjs';
@@ -42,7 +43,16 @@ import * as check from './lib/checks.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..', '..');
-const workDir = join(__dirname, '.work');
+// #1088: workDir lives in os.tmpdir() so the consumer dir has NO moflo-repo
+// ancestor with `CLAUDE.md+package.json` or `.moflo/moflo.db`. Without this,
+// every walk-up resolver inside the consumer (findProjectRoot, the daemon's
+// bridge, every bin/ script) lands on the moflo source repo and writes to
+// the wrong DB. Nesting under `harness/consumer-smoke/.work` produced a
+// recurring bug class — #1054 single-writer epic, #1057 unified resolver,
+// #1058 daemon-routed reads, #1088 — each exposed the same path mismatch in
+// a different code path. The fix is structural: put the consumer somewhere
+// the resolver can't accidentally walk up out of.
+const workDir = join(tmpdir(), 'moflo-consumer-smoke');
 
 const argv = process.argv.slice(2);
 const opts = {
@@ -72,6 +82,12 @@ async function main() {
     consumerDir = check.installConsumer({ workDir, tarballPath: tarball });
 
     const checks = [
+      // #1088 broken-window gate — must run FIRST. If the consumer dir isn't
+      // its own project root, every downstream daemon/bridge/probe quietly
+      // reads/writes the wrong DB and individual probe failures look like
+      // unrelated bugs (we've debugged that pattern 3+ times). Fail here
+      // with a single named error instead.
+      () => check.verifyConsumerIsProjectRoot(consumerDir),
       () => check.verifyForbiddenDeps(consumerDir),
       () => check.verifyRequiredDeps(consumerDir),
       () => check.verifyNoBannedEmbeddings(consumerDir),

--- a/src/cli/commands/doctor-checks-memory-access.ts
+++ b/src/cli/commands/doctor-checks-memory-access.ts
@@ -27,6 +27,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { mofloImport } from '../services/moflo-require.js';
 import { memoryDbPath } from '../services/moflo-paths.js';
+import { findProjectRoot } from '../services/project-root.js';
 import { type HealthCheck } from './doctor-checks-deep.js';
 import {
   type FunctionalCheckDetail,
@@ -285,14 +286,16 @@ async function probeMemoryGetNeighbors(
   // the bridge ever sees these keys means memory_get_neighbors → getEntry
   // hits fresh disk state and our injected metadata is what comes back.
   //
-  // Match the bridge's project-root resolution (`bridge-core.ts:getProjectRoot`)
-  // so the seed writes to the SAME `.moflo/moflo.db` the bridge reads from.
-  // Pre-#1058 this used `process.cwd()` unconditionally, which broke the
-  // doctor test under vitest where `CLAUDE_PROJECT_DIR` redirects the bridge
-  // to a temp dir while cwd stays at the repo root — the seed wrote to the
-  // wrong file and the read found nothing.
-  const seedRoot = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
-  const dbPath = memoryDbPath(seedRoot);
+  // Use the unified findProjectRoot so the seed writes to the SAME
+  // `.moflo/moflo.db` the bridge reads from. Earlier versions used
+  // `process.cwd()` (#844) and then `CLAUDE_PROJECT_DIR ?? process.cwd()`
+  // (#1058) — both diverged from the bridge whenever the bridge's walk
+  // resolved to a parent dir (e.g. consumer-smoke nested under moflo-repo,
+  // where the bridge's high-priority pass hits the repo's CLAUDE.md +
+  // package.json marker pair before reaching cwd). With daemon-routed
+  // reads (#1058/#1076), the seed's row was invisible to the daemon and
+  // memory_get_neighbors returned not-found (#1088).
+  const dbPath = memoryDbPath(findProjectRoot());
   if (!existsSync(dbPath)) {
     details.push({
       id: 'neighbors.seed',


### PR DESCRIPTION
## Summary

- **Move smoke `workDir` to `os.tmpdir()`** so the consumer dir has no moflo-shaped ancestors. Eliminates the recurring path-mismatch bug class that surfaced in #1054, #1057, #1058, and now #1088 — each one a different code path tripping the same nested-fixture walk-up.
- **Add `verifyConsumerIsProjectRoot` gate** that runs first in the smoke check sequence and hard-fails with a named, actionable error if anything ever re-introduces a moflo ancestor above the consumer.
- **Doctor's `probeMemoryGetNeighbors` now uses `findProjectRoot()`** instead of `CLAUDE_PROJECT_DIR ?? process.cwd()` — defense-in-depth so the seed path matches the bridge's resolution in every consumer environment.

## Root cause

`harness/consumer-smoke/.work/consumer-<ts>` lived INSIDE the moflo source repo. `findProjectRoot()` from inside the consumer walked up past the consumer's bare `package.json` and landed on the moflo repo's `CLAUDE.md+package.json` (high-priority marker). Direct sql.js writers used `process.cwd()` → wrote to `<consumer>/.moflo/moflo.db`. Daemon-routed reads added in #1058 used the bridge's `findProjectRoot` → read from `<moflo-repo>/.moflo/moflo.db`. Different files, invisible writes, `found=false` on a key just stored.

Pre-#1058 this was masked because reads stayed in-process: the probe's direct write created `consumer/.moflo/moflo.db` BEFORE the bridge initialised, hitting the high-priority `.moflo/moflo.db` marker on the first walk-up step. Once daemon-routed reads fired the bridge in a separate process whose cache predated the probe's write, the divergence became fatal.

## Test plan

- [x] `npm run test:smoke` on Windows: 49 passed, 0 failed (was 1 failed before the fix).
- [x] `doctor-checks-memory-access.test.ts`: 6 passed (vitest, single-fork isolation).
- [x] `tests/system/project-root-twin.test.ts`: 8 passed (algorithm unchanged).
- [ ] CI matrix (ubuntu / macos / windows) green on `Consumer install smoke`.

Closes #1088.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)