### PR TITLE
fix(1101): surface daemon 4xx as error instead of silent bridge-fallback

### DIFF
--- a/src/cli/__tests__/memory/daemon-write-client.test.ts
+++ b/src/cli/__tests__/memory/daemon-write-client.test.ts
@@ -239,17 +239,67 @@ describe('daemon-write-client', () => {
     expect(r.routed).toBe(false);
   });
 
-  it('tryDaemonStore returns routed:false when daemon returns 400 (validation reject)', async () => {
+  it('tryDaemonStore returns routed:true,ok:false,error on 400 (#1101 — propagate, no fallback)', async () => {
     fake = await startFakeDaemon();
     process.env.MOFLO_DAEMON_PORT = String(fake.port);
     fake.setHandler((req, res) => {
       if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
-      res.writeHead(400); res.end('{"error":"bad"}');
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end('{"error":"Invalid store request","message":"invalid namespace (must match /^[a-zA-Z0-9._-]{1,64}$/, ≤64 chars)"}');
     });
 
     const r = await tryDaemonStore({ namespace: 'ns', key: 'k', value: 'v' });
-    // 400 → routed:false so caller falls back to direct write rather than
-    // silently losing the entry
+    // 4xx is a deterministic payload reject — the bridge has the same
+    // validation and would fail the same way. Surface the daemon's error
+    // instead of silently falling back.
+    expect(r.routed).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/invalid namespace/);
+  });
+
+  it('tryDaemonStore returns routed:true,ok:false,error on 413 (oversized body)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(413, { 'Content-Type': 'application/json' });
+      res.end('{"error":"Payload too large"}');
+    });
+
+    const r = await tryDaemonStore({ namespace: 'ns', key: 'k', value: 'v' });
+    expect(r.routed).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/payload too large/i);
+  });
+
+  it('tryDaemonStore surfaces a generic message when 4xx body is not JSON', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('not json');
+    });
+
+    const r = await tryDaemonStore({ namespace: 'ns', key: 'k', value: 'v' });
+    expect(r.routed).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/daemon returned 400/);
+  });
+
+  it('tryDaemonStore returns routed:false on socket destroyed mid-stream', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    // Warm the health cache so the probe doesn't tank — we want to test
+    // the WRITE-side socket destroy.
+    expect(await isDaemonAvailable()).toBe(true);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      // Kill the socket without sending any response.
+      req.socket.destroy();
+    });
+
+    const r = await tryDaemonStore({ namespace: 'ns', key: 'k', value: 'v' });
     expect(r.routed).toBe(false);
   });
 
@@ -403,6 +453,36 @@ describe('daemon-write-client', () => {
 
     const r = await tryDaemonGet({ namespace: 'ns', key: 'k' });
     expect(r.routed).toBe(false);
+  });
+
+  it('tryDaemonGet returns routed:true,error on 400 (#1101)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end('{"error":"Invalid get request","message":"invalid namespace"}');
+    });
+
+    const r = await tryDaemonGet({ namespace: 'bad ns', key: 'k' });
+    expect(r.routed).toBe(true);
+    expect(r.data).toBeUndefined();
+    expect(r.error).toMatch(/invalid namespace/);
+  });
+
+  it('tryDaemonSearch returns routed:true,error on 400 (#1101)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end('{"error":"Invalid search request","message":"limit must be a positive integer ≤1000"}');
+    });
+
+    const r = await tryDaemonSearch({ query: 'q', limit: 9999 });
+    expect(r.routed).toBe(true);
+    expect(r.data).toBeUndefined();
+    expect(r.error).toMatch(/limit must be a positive integer/);
   });
 
   // ── tryDaemonSearch (#1058) ───────────────────────────────────────────

--- a/src/cli/memory/daemon-write-client.ts
+++ b/src/cli/memory/daemon-write-client.ts
@@ -353,6 +353,25 @@ export async function tryDaemonList(opts: {
 // Internal HTTP poster — never throws, bounded timeout
 // ============================================================================
 
+/**
+ * Extract a human-readable error message from a daemon 4xx response body.
+ * Prefers `message` (the daemon's specific reason — e.g. "invalid namespace"),
+ * falls back to `error` (the daemon's error category), then to a generic
+ * status-code string when the body is non-JSON.
+ */
+function parse4xxError(buf: string, status: number): string {
+  try {
+    const data = JSON.parse(buf);
+    const detail = typeof data?.message === 'string' ? data.message
+      : typeof data?.error === 'string' ? data.error
+      : undefined;
+    if (detail) return detail;
+  } catch {
+    // Non-JSON 4xx body — fall through to the generic message.
+  }
+  return `daemon returned ${status}`;
+}
+
 function postJson(path: string, body: unknown): Promise<DaemonWriteResult> {
   return new Promise((resolve) => {
     let done = false;
@@ -388,9 +407,9 @@ function postJson(path: string, body: unknown): Promise<DaemonWriteResult> {
           //   2xx  → routed:true,  ok:true   (caller uses data)
           //   4xx  → routed:true,  ok:false  (caller propagates daemon error)
           //   5xx  → routed:false           (caller falls back to bridge)
-          //   parse fail / non-classified → routed:false (fall back)
+          //   parse fail → routed:false (fall back)
           const status = res.statusCode ?? 0;
-          if (status >= 500) {
+          if (status >= 500 || status < 200) {
             finish({ routed: false });
             return;
           }
@@ -398,21 +417,7 @@ function postJson(path: string, body: unknown): Promise<DaemonWriteResult> {
             // Daemon validated the payload and rejected it. Bridge-direct
             // has the same validation; falling back loses the actionable
             // error. Surface it to the caller instead.
-            let errorMsg = `daemon returned ${status}`;
-            try {
-              const data = JSON.parse(buf);
-              const detail = typeof data?.message === 'string' ? data.message
-                : typeof data?.error === 'string' ? data.error
-                : undefined;
-              if (detail) errorMsg = detail;
-            } catch {
-              // Non-JSON 4xx body — keep the generic status-code message.
-            }
-            finish({ routed: true, ok: false, error: errorMsg });
-            return;
-          }
-          if (status < 200) {
-            finish({ routed: false });
+            finish({ routed: true, ok: false, error: parse4xxError(buf, status) });
             return;
           }
           try {
@@ -484,26 +489,12 @@ function postReadJson<T>(
           //   4xx  → routed:true with error (no data) — caller propagates
           //   5xx  → routed:false (caller falls back)
           const status = res.statusCode ?? 0;
-          if (status >= 500) {
+          if (status >= 500 || status < 200) {
             finish({ routed: false });
             return;
           }
           if (status >= 400) {
-            let errorMsg = `daemon returned ${status}`;
-            try {
-              const data = JSON.parse(buf);
-              const detail = typeof data?.message === 'string' ? data.message
-                : typeof data?.error === 'string' ? data.error
-                : undefined;
-              if (detail) errorMsg = detail;
-            } catch {
-              // Non-JSON 4xx body — keep the generic message.
-            }
-            finish({ routed: true, error: errorMsg });
-            return;
-          }
-          if (status < 200) {
-            finish({ routed: false });
+            finish({ routed: true, error: parse4xxError(buf, status) });
             return;
           }
           try {

--- a/src/cli/memory/daemon-write-client.ts
+++ b/src/cli/memory/daemon-write-client.ts
@@ -10,12 +10,26 @@
  * #1058 (sql.js never re-reads disk after init).
  *
  * Contract — every function in this module:
- *   - Never throws. Any error path returns `{ routed: false }`.
+ *   - Never throws. Outcomes are reported via the result envelope.
  *   - Returns within ≤100ms even if the daemon is dead/slow (HTTP timeout).
  *   - Caches daemon health for 5s to keep the hot path cheap.
  *   - Short-circuits without HTTP when:
  *       (a) `process.env.MOFLO_IS_DAEMON === '1'` (daemon's own process)
  *       (b) `moflo.yaml` has `daemon.auto_start: false`
+ *
+ * Failure-shape contract (#1101 — surface 4xx as a real error):
+ *   - 4xx response                 → `routed: true, ok: false, error: <msg>` (writes)
+ *                                  → `routed: true, error: <msg>` (reads)
+ *                                  → caller PROPAGATES the error; does NOT fall back.
+ *   - 5xx, 503, timeout,           → `routed: false`
+ *     ECONNREFUSED, malformed JSON,  → caller falls back to bridge-direct.
+ *     socket destroyed mid-stream
+ *
+ * The 4xx codes only fire on daemon-side payload validation (see
+ * daemon-memory-rpc.ts). Bridge-direct has the same validation and would
+ * fail the same way — falling back silently loses the daemon's actionable
+ * error message. 5xx and transport faults are transient/daemon-side bugs;
+ * bridge-direct is the right next step.
  *
  * Naming note: the module is named `daemon-write-client` for compat with
  * existing importers, but as of #1058 it also covers reads.
@@ -43,28 +57,40 @@ const HEALTH_CACHE_TTL_MS = 5_000;
 // ============================================================================
 
 /**
- * Result of a daemon-routed write. `routed: false` means the caller MUST
- * fall back to its direct-write path (the daemon is unavailable or
- * disabled, OR we are inside the daemon process itself).
+ * Result of a daemon-routed write.
+ *
+ *   - `routed: false`                → daemon unreachable / transport fault /
+ *                                      5xx / daemon-process short-circuit.
+ *                                      Caller MUST fall back to direct write.
+ *   - `routed: true,  ok: true`      → daemon accepted; `id` carries the entry id.
+ *   - `routed: true,  ok: false`     → daemon REJECTED the payload (4xx
+ *                                      validation). Caller MUST propagate
+ *                                      `error` to the user and NOT fall back —
+ *                                      bridge-direct has the same validation
+ *                                      and will fail the same way (#1101).
  */
 export interface DaemonWriteResult {
-  /** True iff the write was successfully delivered to the daemon (regardless of daemon's outcome). */
+  /** True iff the daemon answered with a structured payload (2xx or 4xx). */
   routed: boolean;
-  /** Set when routed=true: the daemon's response status. */
+  /** True on 2xx; false on 4xx (validation reject). Undefined when routed=false. */
   ok?: boolean;
   /** Set on a successful store: the entry id the daemon assigned. */
   id?: string;
   /** Set on a successful delete: whether the row existed. */
   deleted?: boolean;
-  /** Set on routed-but-failed: the daemon's error message. */
+  /** Set on routed-but-failed (4xx): the daemon's error message. */
   error?: string;
 }
 
 /**
- * Result of a daemon-routed read (#1058). `routed: false` means fall back to
- * the local bridge / raw-sql.js path; `routed: true` means HTTP succeeded
- * and `data` carries the daemon's response payload (or `error` if the daemon
- * itself returned a 5xx with a structured error).
+ * Result of a daemon-routed read (#1058).
+ *
+ *   - `routed: false`                → daemon unreachable / transport fault /
+ *                                      5xx / daemon-process short-circuit.
+ *                                      Caller falls back to bridge / direct.
+ *   - `routed: true,  data: ...`     → daemon answered 2xx; use `data`.
+ *   - `routed: true,  error: ...`    → daemon REJECTED (4xx). Caller MUST
+ *     (no `data`)                      propagate `error`, NOT fall back (#1101).
  */
 export interface DaemonReadResult<T> {
   routed: boolean;
@@ -358,12 +384,34 @@ function postJson(path: string, body: unknown): Promise<DaemonWriteResult> {
         res.setEncoding('utf8');
         res.on('data', (chunk: string) => { buf += chunk; });
         res.on('end', () => {
-          // Status >=500 is a daemon-side fault; treat as unrouted so the
-          // caller falls back. Status 4xx (validation) is ALSO unrouted —
-          // we don't want a malformed payload silently lost just because
-          // the HTTP delivery succeeded.
+          // #1101 — per-shape failure contract:
+          //   2xx  → routed:true,  ok:true   (caller uses data)
+          //   4xx  → routed:true,  ok:false  (caller propagates daemon error)
+          //   5xx  → routed:false           (caller falls back to bridge)
+          //   parse fail / non-classified → routed:false (fall back)
           const status = res.statusCode ?? 0;
-          if (status < 200 || status >= 300) {
+          if (status >= 500) {
+            finish({ routed: false });
+            return;
+          }
+          if (status >= 400) {
+            // Daemon validated the payload and rejected it. Bridge-direct
+            // has the same validation; falling back loses the actionable
+            // error. Surface it to the caller instead.
+            let errorMsg = `daemon returned ${status}`;
+            try {
+              const data = JSON.parse(buf);
+              const detail = typeof data?.message === 'string' ? data.message
+                : typeof data?.error === 'string' ? data.error
+                : undefined;
+              if (detail) errorMsg = detail;
+            } catch {
+              // Non-JSON 4xx body — keep the generic status-code message.
+            }
+            finish({ routed: true, ok: false, error: errorMsg });
+            return;
+          }
+          if (status < 200) {
             finish({ routed: false });
             return;
           }
@@ -431,8 +479,30 @@ function postReadJson<T>(
         res.setEncoding('utf8');
         res.on('data', (chunk: string) => { buf += chunk; });
         res.on('end', () => {
+          // #1101 — mirror postJson contract for reads:
+          //   2xx  → routed:true with shaped data
+          //   4xx  → routed:true with error (no data) — caller propagates
+          //   5xx  → routed:false (caller falls back)
           const status = res.statusCode ?? 0;
-          if (status < 200 || status >= 300) {
+          if (status >= 500) {
+            finish({ routed: false });
+            return;
+          }
+          if (status >= 400) {
+            let errorMsg = `daemon returned ${status}`;
+            try {
+              const data = JSON.parse(buf);
+              const detail = typeof data?.message === 'string' ? data.message
+                : typeof data?.error === 'string' ? data.error
+                : undefined;
+              if (detail) errorMsg = detail;
+            } catch {
+              // Non-JSON 4xx body — keep the generic message.
+            }
+            finish({ routed: true, error: errorMsg });
+            return;
+          }
+          if (status < 200) {
             finish({ routed: false });
             return;
           }

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -1910,6 +1910,12 @@ export async function storeEntry(options: {
       if (routed.routed && routed.ok) {
         return { success: true, id: routed.id ?? '' };
       }
+      // #1101 — daemon validated and rejected (4xx). Bridge-direct would
+      // fail the same way; surface the daemon's error instead of silently
+      // falling back.
+      if (routed.routed && routed.ok === false) {
+        return { success: false, id: '', error: routed.error ?? 'Daemon rejected store request' };
+      }
     } catch (err) {
       logRoutingFault(err);
     }
@@ -2175,6 +2181,10 @@ export async function searchEntries(options: {
           searchTime: routed.data.searchTime ?? 0,
         };
       }
+      // #1101 — daemon rejected query (4xx); propagate instead of falling back.
+      if (routed.routed && routed.error) {
+        return { success: false, results: [], searchTime: 0, error: routed.error };
+      }
     } catch (err) {
       logRoutingFault(err);
     }
@@ -2356,6 +2366,10 @@ export async function listEntries(options: {
       if (routed.routed && routed.data) {
         return { success: true, entries: routed.data.entries, total: routed.data.total };
       }
+      // #1101 — daemon rejected list args (4xx); propagate.
+      if (routed.routed && routed.error) {
+        return { success: false, entries: [], total: 0, error: routed.error };
+      }
     } catch (err) {
       logRoutingFault(err);
     }
@@ -2486,6 +2500,10 @@ export async function getEntry(options: {
       });
       if (routed.routed && routed.data) {
         return { success: true, found: routed.data.found, entry: routed.data.entry };
+      }
+      // #1101 — daemon rejected get args (4xx); propagate.
+      if (routed.routed && routed.error) {
+        return { success: false, found: false, error: routed.error };
       }
     } catch (err) {
       logRoutingFault(err);
@@ -2622,6 +2640,17 @@ export async function deleteEntry(options: {
           // this value (the `flo memory delete` CLI) read it from a
           // subsequent stat query, not this return shape.
           remainingEntries: 0,
+        };
+      }
+      // #1101 — daemon rejected delete args (4xx); propagate.
+      if (routed.routed && routed.ok === false) {
+        return {
+          success: false,
+          deleted: false,
+          key: options.key,
+          namespace: options.namespace ?? 'default',
+          remainingEntries: 0,
+          error: routed.error ?? 'Daemon rejected delete request',
         };
       }
     } catch (err) {


### PR DESCRIPTION
Closes #1101.

## Summary

- `daemon-write-client.ts` — split 4xx from 5xx/transport/parse in `postJson` + `postReadJson`. 4xx → `routed: true, ok: false, error: <msg>` (writes) / `routed: true, error: <msg>` (reads); 5xx and below stay `routed: false`. Helper `parse4xxError(buf, status)` extracts the daemon's `message`-or-`error` field, falling back to `daemon returned <status>` for non-JSON bodies.
- `memory-initializer.ts` — five callers (store, get, search, list, delete) propagate the daemon's 4xx error instead of silently falling back to bridge-direct.
- `daemon-write-client.test.ts` — flipped the existing 400-test that pinned the old contract; added 413, non-JSON-4xx-body, socket-destroyed-mid-stream, plus read-side 4xx coverage for `tryDaemonGet` + `tryDaemonSearch`.

Split out of #1063 — the data-loss clobber #1063 tracked is architecturally killed by the node:sqlite migration (#1078 / PR #1096). The observability concern survived: today's silent-fallback-on-4xx drops the daemon's actionable error message on the floor. Bridge-direct has the same validation and would fail the same way, so falling back is never the right thing for a 4xx.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run src/cli/__tests__/memory/daemon-write-client.test.ts src/cli/__tests__/memory/store-entry-routing.test.ts` — 53/53 passed
- [x] `npx vitest run src/cli/__tests__/services/daemon-memory-rpc.test.ts src/cli/__tests__/services/shared-memory-accessor.test.ts src/cli/__tests__/bridge-entries.test.ts src/cli/__tests__/memory` — 292/292 passed
- [x] `npm test` — 8581 passed. 3 pre-existing flakes in #1042 auth-error-recovery tests passed in isolation; tracked separately at #1102.

## Consumer impact (per CLAUDE.md library blast-radius posture)

- **Surface touched:** `src/cli/memory/daemon-write-client.ts` + `memory-initializer.ts` — runtime modules every consumer hits via `node_modules/moflo/dist/...` when storing/searching memory.
- **Behaviour change for on-current-version consumers:** previously a daemon-side validation reject (4xx) silently fell back to bridge-direct, which then also failed and surfaced a generic write error. Now the daemon's actual error message reaches the user. **No fewer writes succeed; users get a clearer error on the same failure cases.** Bridge-direct's own validation has not changed.
- **Round-trip cost:** runtime fix — takes effect for consumers after \`npm publish\` + \`npm install moflo@<new>\`.

## Out of scope (intentionally)

- The verification repro for #1063 closure — still pending, will be a separate fixture.
- The 100ms HTTP timeout — orthogonal tuning question.
- Daemon-side use of 422 / other 4xx codes — daemon only emits 400/413 today (see audit in #1101 body).