### PR TITLE
test(1061): verify node:sqlite WAL kills cross-process writer race

### DIFF
--- a/tests/system/cross-process-writer-race-1061.test.ts
+++ b/tests/system/cross-process-writer-race-1061.test.ts
@@ -42,8 +42,9 @@ const FACTORY_PATH = path.join(REPO_ROOT, 'bin', 'lib', 'get-backend.mjs');
 interface WriterResult {
   role: string;
   written: number;
-  durationMs: number;
 }
+
+type WriteShape = 'autocommit' | 'transaction';
 
 function makeTempRoot(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), `moflo-1061-${prefix}-`));
@@ -62,15 +63,24 @@ function cleanupRoot(root: string): void {
  * bin/* scripts use (the path consumers exercise), opens .moflo/moflo.db, and
  * writes `rowCount` rows tagged with `role`. Returns parsed result JSON.
  *
- * Inline script body is kept short — it's the minimum surface needed to
- * exercise openBackend + a prepared INSERT loop, matching how
- * bin/index-guidance.mjs, bin/index-tests.mjs, etc. write.
+ * `shape` controls the transaction wrapping:
+ *   - 'autocommit' — one implicit transaction per INSERT. Matches the
+ *     bin/index-*.mjs indexer chain.
+ *   - 'transaction' — single explicit `BEGIN IMMEDIATE` … `COMMIT` around
+ *     the loop. Matches src/cli/memory/sqlite-backend.ts:withTransaction
+ *     and controllers/batch-operations.ts (the daemon's actual write path).
+ *
+ * Mixing shapes is deliberate: #1061's failure scenario is specifically the
+ * indexer (autocommit) competing with the daemon (BEGIN IMMEDIATE batch),
+ * which is the contention pattern that surfaced the busy_handler trap fixed
+ * in #1099. Uniform autocommit would weaken the verification.
  */
 function spawnWriter(
   projectRoot: string,
   scriptDir: string,
   role: string,
   rowCount: number,
+  shape: WriteShape,
 ): Promise<WriterResult> {
   const factoryUrl = 'file://' + FACTORY_PATH.replace(/\\/g, '/');
   const scriptPath = path.join(scriptDir, `writer-${role}.mjs`);
@@ -80,19 +90,28 @@ function spawnWriter(
     const projectRoot = ${JSON.stringify(projectRoot)};
     const role = ${JSON.stringify(role)};
     const rowCount = ${rowCount};
-    const startedAt = Date.now();
+    const shape = ${JSON.stringify(shape)};
     const db = await openBackend(projectRoot);
     try {
       const ins = db.prepare('INSERT INTO cross_writes (role, idx) VALUES (?, ?)');
-      for (let i = 0; i < rowCount; i++) {
-        ins.run([role, i]);
+      if (shape === 'transaction') db.run('BEGIN IMMEDIATE');
+      try {
+        for (let i = 0; i < rowCount; i++) {
+          ins.run([role, i]);
+        }
+        if (shape === 'transaction') db.run('COMMIT');
+      } catch (err) {
+        if (shape === 'transaction') {
+          try { db.run('ROLLBACK'); } catch { /* already closed */ }
+        }
+        throw err;
+      } finally {
+        ins.free();
       }
-      ins.free();
     } finally {
       db.close();
     }
-    const durationMs = Date.now() - startedAt;
-    process.stdout.write(JSON.stringify({ role, written: rowCount, durationMs }));
+    process.stdout.write(JSON.stringify({ role, written: rowCount }));
   `;
   fs.writeFileSync(scriptPath, script);
 
@@ -101,6 +120,15 @@ function spawnWriter(
       cwd: REPO_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: false,
+      env: {
+        ...process.env,
+        // Pin the subprocess's project-root resolver to the temp DB. Today
+        // openBackend takes projectRoot explicitly so this is belt-and-braces;
+        // if the resolver ever becomes load-bearing for a sub-helper, this
+        // prevents the subprocess from walking up into the moflo repo and
+        // corrupting the real .moflo/moflo.db. See feedback_unified_project_root_resolver.
+        CLAUDE_PROJECT_DIR: projectRoot,
+      },
     });
 
     let stdout = '';
@@ -185,11 +213,11 @@ describe('System verification — cross-process writer race (#1061)', () => {
     cleanupRoot(scriptDir);
   });
 
-  it('two concurrent writers (indexer + daemon shape) lose no rows', async () => {
+  it('two concurrent writers (indexer autocommit + daemon BEGIN IMMEDIATE) lose no rows', async () => {
     const ROWS_PER_WRITER = 200;
     const [a, b] = await Promise.all([
-      spawnWriter(projectRoot, scriptDir, 'indexer', ROWS_PER_WRITER),
-      spawnWriter(projectRoot, scriptDir, 'daemon', ROWS_PER_WRITER),
+      spawnWriter(projectRoot, scriptDir, 'indexer', ROWS_PER_WRITER, 'autocommit'),
+      spawnWriter(projectRoot, scriptDir, 'daemon', ROWS_PER_WRITER, 'transaction'),
     ]);
 
     expect(a.written).toBe(ROWS_PER_WRITER);
@@ -201,37 +229,41 @@ describe('System verification — cross-process writer race (#1061)', () => {
     expect(counts.perRole.get('daemon')).toBe(ROWS_PER_WRITER);
   }, 60_000);
 
-  it('four concurrent writers (overload — indexer chain steps + daemon) lose no rows', async () => {
+  it('four concurrent writers (full indexer chain + daemon batch) lose no rows', async () => {
     // The original repro's worst case: index-guidance, index-tests,
     // index-patterns, and the daemon's memory_store burst can all hit the file
     // in the same window if the user invokes MCP tools while the chain is
     // mid-flight. Under sql.js this multiplied the clobber probability; under
-    // WAL all four serialize.
+    // WAL the indexers serialize via page locks and the daemon's transaction
+    // exercises busy_timeout (#1099 path).
     const ROWS_PER_WRITER = 100;
-    const roles = ['index-guidance', 'index-tests', 'index-patterns', 'daemon'];
+    const writers: Array<{ role: string; shape: WriteShape }> = [
+      { role: 'index-guidance', shape: 'autocommit' },
+      { role: 'index-tests',    shape: 'autocommit' },
+      { role: 'index-patterns', shape: 'autocommit' },
+      { role: 'daemon',         shape: 'transaction' },
+    ];
     const results = await Promise.all(
-      roles.map((r) => spawnWriter(projectRoot, scriptDir, r, ROWS_PER_WRITER)),
+      writers.map((w) => spawnWriter(projectRoot, scriptDir, w.role, ROWS_PER_WRITER, w.shape)),
     );
     for (const r of results) {
       expect(r.written).toBe(ROWS_PER_WRITER);
     }
 
     const counts = await countRows(projectRoot);
-    expect(counts.total).toBe(ROWS_PER_WRITER * roles.length);
-    for (const role of roles) {
-      expect(counts.perRole.get(role)).toBe(ROWS_PER_WRITER);
+    expect(counts.total).toBe(ROWS_PER_WRITER * writers.length);
+    for (const w of writers) {
+      expect(counts.perRole.get(w.role)).toBe(ROWS_PER_WRITER);
     }
   }, 90_000);
 
   it('journal_mode reports WAL — proves the page-level serialization mechanism is engaged', async () => {
     // If WAL ever silently regressed (e.g. journal_mode left at delete due to
-    // a network-FS open), the two-writer test could still pass via OS-level
+    // a network-FS open), the row-count tests could still pass via OS-level
     // exclusive locking but degrade severely in real traffic.
     //
-    // Reading PRAGMA journal_mode is the structural proof — and unlike the
-    // -wal sidecar file (which may be checkpointed-and-removed after writers
-    // close), the pragma value is stable as long as a handle is open.
-    await spawnWriter(projectRoot, scriptDir, 'wal-probe', 5);
+    // The PRAGMA value is stable across opens; the seed already wrote rows,
+    // so no further activity is needed before reading it back.
     const db = await openBackend(projectRoot, { readOnly: true });
     try {
       const result = db.exec('PRAGMA journal_mode');
@@ -239,5 +271,5 @@ describe('System verification — cross-process writer race (#1061)', () => {
     } finally {
       db.close();
     }
-  }, 30_000);
+  }, 10_000);
 });

--- a/tests/system/cross-process-writer-race-1061.test.ts
+++ b/tests/system/cross-process-writer-race-1061.test.ts
@@ -1,0 +1,243 @@
+/**
+ * System verification for #1061 — cross-process writer race under node:sqlite + WAL.
+ *
+ * Original repro (from the issue body):
+ *   "hooks.mjs session-start forks daemon + indexer chain at the same instant.
+ *    They each open their own sql.js handle and write to .moflo/moflo.db via
+ *    atomic-write. If the daemon performs any write during the seconds-to-minutes
+ *    the indexer chain runs, its next flush overwrites the indexer's on-disk
+ *    state with the daemon's stale in-RAM snapshot."
+ *
+ * Status post #1096 (epic #1078 Phase 4):
+ *   sql.js is retired. Every bin/* and TS writer routes through
+ *   `bin/lib/get-backend.mjs::openBackend()` → `node:sqlite` with WAL +
+ *   busy_timeout. SQLite serializes page-level writes via the OS file lock;
+ *   there is no whole-file flush that can clobber another writer.
+ *
+ * This test reproduces the exact shape of the original race — N real OS
+ * subprocesses, each opening `.moflo/moflo.db` through the canonical factory
+ * consumers use, each doing M writes concurrently — and asserts no row loss.
+ * Under sql.js this would have lost rows (last-flusher-wins). Under WAL it
+ * must be lossless and order-independent.
+ *
+ * Closes the verification AC on issue #1061 (acceptance: re-test against
+ * original repro post-migration; close on proof of non-reproduction).
+ *
+ * Cross-platform: spawns via `process.execPath`, paths via node:path,
+ * cleanup tolerant of Windows WAL/shm handle release latency.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { openBackend } from '../../bin/lib/get-backend.mjs';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FACTORY_PATH = path.join(REPO_ROOT, 'bin', 'lib', 'get-backend.mjs');
+
+interface WriterResult {
+  role: string;
+  written: number;
+  durationMs: number;
+}
+
+function makeTempRoot(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `moflo-1061-${prefix}-`));
+}
+
+function cleanupRoot(root: string): void {
+  try {
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  } catch {
+    /* best-effort — Windows can hold a brief WAL/shm sidecar lock */
+  }
+}
+
+/**
+ * Spawn one writer subprocess. The subprocess imports the SAME factory that
+ * bin/* scripts use (the path consumers exercise), opens .moflo/moflo.db, and
+ * writes `rowCount` rows tagged with `role`. Returns parsed result JSON.
+ *
+ * Inline script body is kept short — it's the minimum surface needed to
+ * exercise openBackend + a prepared INSERT loop, matching how
+ * bin/index-guidance.mjs, bin/index-tests.mjs, etc. write.
+ */
+function spawnWriter(
+  projectRoot: string,
+  scriptDir: string,
+  role: string,
+  rowCount: number,
+): Promise<WriterResult> {
+  const factoryUrl = 'file://' + FACTORY_PATH.replace(/\\/g, '/');
+  const scriptPath = path.join(scriptDir, `writer-${role}.mjs`);
+  // Single-quoted JSON literals inside the inline script keep injection-free.
+  const script = `
+    import { openBackend } from ${JSON.stringify(factoryUrl)};
+    const projectRoot = ${JSON.stringify(projectRoot)};
+    const role = ${JSON.stringify(role)};
+    const rowCount = ${rowCount};
+    const startedAt = Date.now();
+    const db = await openBackend(projectRoot);
+    try {
+      const ins = db.prepare('INSERT INTO cross_writes (role, idx) VALUES (?, ?)');
+      for (let i = 0; i < rowCount; i++) {
+        ins.run([role, i]);
+      }
+      ins.free();
+    } finally {
+      db.close();
+    }
+    const durationMs = Date.now() - startedAt;
+    process.stdout.write(JSON.stringify({ role, written: rowCount, durationMs }));
+  `;
+  fs.writeFileSync(scriptPath, script);
+
+  return new Promise<WriterResult>((resolve, reject) => {
+    const child: ChildProcess = spawn(process.execPath, [scriptPath], {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout!.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr!.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      try { fs.unlinkSync(scriptPath); } catch { /* best-effort */ }
+      if (code !== 0) {
+        reject(new Error(`writer "${role}" exited ${code}: ${stderr || stdout}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch (err) {
+        reject(new Error(`writer "${role}" produced unparsable stdout: ${stdout} (${String(err)})`));
+      }
+    });
+  });
+}
+
+/**
+ * Seed the schema in the parent so the writer subprocesses only execute their
+ * INSERT loop. Mirrors the production shape: the bridge runs migrations
+ * pre-boot (#1057), and the indexer/daemon writers find the schema already in
+ * place when they open.
+ */
+async function seedSchema(projectRoot: string): Promise<void> {
+  const db = await openBackend(projectRoot);
+  try {
+    db.run(`
+      CREATE TABLE IF NOT EXISTS cross_writes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        role TEXT NOT NULL,
+        idx INTEGER NOT NULL
+      )
+    `);
+  } finally {
+    db.close();
+  }
+}
+
+interface RowCounts {
+  total: number;
+  perRole: Map<string, number>;
+}
+
+async function countRows(projectRoot: string): Promise<RowCounts> {
+  const db = await openBackend(projectRoot, { readOnly: true });
+  try {
+    const result = db.exec('SELECT role, COUNT(*) as n FROM cross_writes GROUP BY role');
+    const perRole = new Map<string, number>();
+    let total = 0;
+    if (result.length > 0) {
+      for (const row of result[0].values) {
+        const role = String(row[0]);
+        const n = Number(row[1]);
+        perRole.set(role, n);
+        total += n;
+      }
+    }
+    return { total, perRole };
+  } finally {
+    db.close();
+  }
+}
+
+describe('System verification — cross-process writer race (#1061)', () => {
+  let projectRoot: string;
+  let scriptDir: string;
+
+  beforeEach(async () => {
+    projectRoot = makeTempRoot('proj');
+    scriptDir = makeTempRoot('scripts');
+    await seedSchema(projectRoot);
+  });
+
+  afterEach(() => {
+    cleanupRoot(projectRoot);
+    cleanupRoot(scriptDir);
+  });
+
+  it('two concurrent writers (indexer + daemon shape) lose no rows', async () => {
+    const ROWS_PER_WRITER = 200;
+    const [a, b] = await Promise.all([
+      spawnWriter(projectRoot, scriptDir, 'indexer', ROWS_PER_WRITER),
+      spawnWriter(projectRoot, scriptDir, 'daemon', ROWS_PER_WRITER),
+    ]);
+
+    expect(a.written).toBe(ROWS_PER_WRITER);
+    expect(b.written).toBe(ROWS_PER_WRITER);
+
+    const counts = await countRows(projectRoot);
+    expect(counts.total).toBe(ROWS_PER_WRITER * 2);
+    expect(counts.perRole.get('indexer')).toBe(ROWS_PER_WRITER);
+    expect(counts.perRole.get('daemon')).toBe(ROWS_PER_WRITER);
+  }, 60_000);
+
+  it('four concurrent writers (overload — indexer chain steps + daemon) lose no rows', async () => {
+    // The original repro's worst case: index-guidance, index-tests,
+    // index-patterns, and the daemon's memory_store burst can all hit the file
+    // in the same window if the user invokes MCP tools while the chain is
+    // mid-flight. Under sql.js this multiplied the clobber probability; under
+    // WAL all four serialize.
+    const ROWS_PER_WRITER = 100;
+    const roles = ['index-guidance', 'index-tests', 'index-patterns', 'daemon'];
+    const results = await Promise.all(
+      roles.map((r) => spawnWriter(projectRoot, scriptDir, r, ROWS_PER_WRITER)),
+    );
+    for (const r of results) {
+      expect(r.written).toBe(ROWS_PER_WRITER);
+    }
+
+    const counts = await countRows(projectRoot);
+    expect(counts.total).toBe(ROWS_PER_WRITER * roles.length);
+    for (const role of roles) {
+      expect(counts.perRole.get(role)).toBe(ROWS_PER_WRITER);
+    }
+  }, 90_000);
+
+  it('journal_mode reports WAL — proves the page-level serialization mechanism is engaged', async () => {
+    // If WAL ever silently regressed (e.g. journal_mode left at delete due to
+    // a network-FS open), the two-writer test could still pass via OS-level
+    // exclusive locking but degrade severely in real traffic.
+    //
+    // Reading PRAGMA journal_mode is the structural proof — and unlike the
+    // -wal sidecar file (which may be checkpointed-and-removed after writers
+    // close), the pragma value is stable as long as a handle is open.
+    await spawnWriter(projectRoot, scriptDir, 'wal-probe', 5);
+    const db = await openBackend(projectRoot, { readOnly: true });
+    try {
+      const result = db.exec('PRAGMA journal_mode');
+      expect(result[0]?.values?.[0]?.[0]).toBe('wal');
+    } finally {
+      db.close();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Closes the verification AC on #1061 — re-test against the original repro post-#1096 (sql.js → node:sqlite Phase 4 migration).
- Adds `tests/system/cross-process-writer-race-1061.test.ts` — spawns N real OS subprocesses, each opening `.moflo/moflo.db` via the canonical `bin/lib/get-backend.mjs::openBackend()` factory, each writing M rows concurrently with a mix of autocommit + `BEGIN IMMEDIATE` shapes. Asserts zero row loss.
- Existing #981/#987 coverage uses a fake HTTP daemon (RPC routing). This fills the #1061-shaped gap: two real SQLite handles competing for the file with the exact production write shapes.

## Why a test, not a fix

#1061 was parked pending epic #1078. PR #1096 (Phase 4) flipped the default backend to node:sqlite + WAL — sql.js's whole-file flush is gone, SQLite serializes page-level writes via the OS file lock + ` busy_timeout=15000`. The bug class is architecturally dead. The issue's AC explicitly required proof of non-reproduction, not transitive closure.

## Test shape

The two write shapes the test mixes mirror production exactly:
- **autocommit** — `bin/index-*.mjs` indexer chain. One implicit transaction per INSERT.
- **transaction** — `src/cli/memory/sqlite-backend.ts:withTransaction` + `controllers/batch-operations.ts`. Single `BEGIN IMMEDIATE` … `COMMIT` around the loop.

The #1061 race was specifically these two shapes colliding. Uniform autocommit would not exercise the `busy_handler` engagement that the daemon's transaction path needs (the trap fixed in #1099).

## Coverage

| Scenario | Writers | Rows each | Expected | Result |
|----------|---------|-----------|----------|--------|
| Indexer (autocommit) + daemon (BEGIN IMMEDIATE) | 2 | 200 | 400 rows | ✅ Lossless |
| Full chain + daemon batch | 4 | 100 | 400 rows | ✅ Lossless |
| WAL active after writes | — | — | `journal_mode=wal` | ✅ Confirmed |

`tests/system/` (11 files / 56 tests) all green in 2.44s.

## Simplify pass

Tier: **SMALL** (243 LOC, +7 decls, 1 file). One reviewer agent (sonnet). Four findings applied in the second commit:
1. Mixed write shapes (autocommit + BEGIN IMMEDIATE) replacing uniform autocommit.
2. Dropped unused `durationMs` field from `WriterResult`.
3. Set `CLAUDE_PROJECT_DIR` on subprocess env per `feedback_unified_project_root_resolver`.
4. WAL PRAGMA test no longer spawns a redundant subprocess.

Two findings skipped (DRY extraction of `spawnWriter` and `cleanupRoot` across peer test files) — pre-existing duplication, cross-file refactor would expand scope beyond verification. Filed as follow-up if a third call site arrives.

## Consumer impact

Zero. New test file under `tests/system/` — no `bin/` or `src/` changes ship to consumer projects.

## Out of scope (filed as follow-up if measurable)

- `bin/index-all.mjs:8-10` carries a stale comment claiming sequential execution is required to avoid sql.js last-write-wins. Under WAL the chain could parallelize, but that's an optimization, not a correctness fix.

## Test plan

- [x] `npx vitest run tests/system/cross-process-writer-race-1061.test.ts` — 3 tests pass in 367ms
- [x] `npx vitest run tests/system/ tests/bin/get-backend.test.ts` — 56 tests pass in 2.44s
- [x] Cross-platform: uses `process.execPath`, node:path joins, `rmSync({maxRetries:5})` for Windows WAL/shm sidecar release

Closes #1061

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)