### PR TITLE
feat(1064): thread metadata field through memory_store chokepoint

### DIFF
--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -1114,46 +1114,27 @@ export function memoryTraversalProtocol(consumerDir) {
   const memToolsPath = join(consumerDir, 'node_modules', 'moflo', 'dist', 'src', 'cli', 'mcp-tools', 'memory-tools.js')
     .replace(/\\/g, '/');
   writeFileSync(probe, `
-// Filter the once-per-process \`SQLite is an experimental feature\` warning
-// before the \`node:sqlite\` import below fires it (#1098).
-{
-  const originalEmitWarning = process.emitWarning;
-  process.emitWarning = function (warning, ...args) {
-    const msg = typeof warning === 'string' ? warning : (warning && warning.message) || '';
-    if (msg.includes('SQLite is an experimental feature')) return;
-    return originalEmitWarning.apply(this, [warning, ...args]);
-  };
-}
 import { pathToFileURL } from 'node:url';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync } from 'node:fs';
 const mod = await import(pathToFileURL(${JSON.stringify(memToolsPath)}).href);
 const tools = mod.memoryTools;
 const get = name => tools.find(t => t.name === name);
 
+const store = get('memory_store');
 const neighbors = get('memory_get_neighbors');
 const del = get('memory_delete');
 
-if (!neighbors || !del) {
+if (!store || !neighbors || !del) {
   console.log(JSON.stringify({ ok: false, reason: 'tools missing', tools: tools.map(t => t.name) }));
   process.exit(0);
 }
 
-// Seed three chunks via DIRECT node:sqlite write (no memory_store call). Going
-// through memory_store would warm the bridge cache with metadata='{}', and
-// a subsequent direct UPDATE would race the bridge's writeback. Writing
-// straight to the DB before the bridge sees these keys means the bridge's
-// first read (memory_get_neighbors → getEntry) hits fresh state via WAL.
-//
-// Phase 4 (#1083) flipped the default to node:sqlite + WAL: every writer on
-// .moflo/moflo.db MUST use node:sqlite. The pre-Phase-4 seed used
-// sql.js + writeFileSync(...export()) — that pattern is exactly the WAL
-// clobber the migration kills (the catastrophic case where the whole-file
-// dump overwrites the bridge's WAL sidecar between commits).
-import { DatabaseSync } from 'node:sqlite';
+// Seed three chunks via memory_store with chunk-shaped metadata in-band
+// (#1064 — the chokepoint now accepts the navigation fields directly, so
+// this probe matches the same code path every real producer hits).
 const ns = 'smoke-1053';
 const keys = ['chunk-smoke-foo-0', 'chunk-smoke-foo-1', 'chunk-smoke-foo-2'];
-const meta = (i, total) => JSON.stringify({
+const meta = (i, total) => ({
   type: 'chunk',
   parentDoc: 'doc-smoke-foo',
   parentPath: '/foo.md',
@@ -1169,50 +1150,26 @@ const meta = (i, total) => JSON.stringify({
   docContentHash: 'smoke-1053-hash',
 });
 
-// Use the same DB path memory_store would use. The bridge resolves it via
-// memoryDbPath(findProjectRoot()); the smoke harness runs this probe with
-// cwd = consumer dir AND the consumer dir lives outside the moflo source
-// repo (see harness/consumer-smoke/run.mjs workDir = os.tmpdir()), so the
-// walk-up resolves to the consumer naturally. Using a bare '.moflo/moflo.db'
-// is therefore equivalent to memoryDbPath(findProjectRoot()) and matches
-// what every other in-consumer writer hits.
+// memory_store resolves the DB path itself; just make sure the directory
+// is in place so a freshly-initialised consumer can write the first row.
 mkdirSync('.moflo', { recursive: true });
 const dbPath = '.moflo/moflo.db';
-
-// If the DB doesn't exist yet (memory init hasn't run before our probe),
-// give up gracefully — the smoke harness runs memoryInit BEFORE this check
-// per the order in run.mjs, so this should not happen in practice.
 if (!existsSync(dbPath)) {
   console.log(JSON.stringify({ ok: false, reason: \`memory.db not at \${dbPath}\` }));
   process.exit(0);
 }
 
-const db = new DatabaseSync(dbPath);
-try {
-  // busy_timeout BEFORE journal_mode=WAL — daemon may hold the lock briefly
-  // during checkpoint and we'd otherwise hit "database is locked" with no
-  // retry budget (#1097).
-  // 15000ms — matches daemon-backend.ts; see #1098 for the rationale.
-  db.exec('PRAGMA busy_timeout = 15000');
-  db.exec('PRAGMA journal_mode = WAL');
-  db.exec('PRAGMA synchronous = NORMAL');
-  const insert = db.prepare(
-    "INSERT OR REPLACE INTO memory_entries (id, key, namespace, content, type, tags, metadata, created_at, updated_at, status) VALUES (?, ?, ?, ?, 'semantic', '[]', ?, ?, ?, 'active')"
-  );
-  const now = Date.now();
-  for (let i = 0; i < keys.length; i++) {
-    insert.run(
-      'memprobe-' + randomBytes(8).toString('hex'),
-      keys[i],
-      ns,
-      \`chunk body \${i}\`,
-      meta(i, keys.length),
-      now, now,
-    );
+for (let i = 0; i < keys.length; i++) {
+  const out = await store.handler({
+    key: keys[i],
+    value: \`chunk body \${i}\`,
+    namespace: ns,
+    metadata: meta(i, keys.length),
+  });
+  if (!out || out.success !== true) {
+    console.log(JSON.stringify({ ok: false, reason: 'seed failed', chunk: keys[i], error: out && out.error }));
+    process.exit(0);
   }
-  // node:sqlite WAL commits incrementally; no whole-file dump needed.
-} finally {
-  db.close();
 }
 
 const result = await neighbors.handler({ key: 'chunk-smoke-foo-1', namespace: ns });

--- a/src/cli/__tests__/bridge-entries.test.ts
+++ b/src/cli/__tests__/bridge-entries.test.ts
@@ -770,3 +770,111 @@ describe('bridgeGetEntry — no-row detection (#998)', () => {
     expect(result?.entry?.id).not.toBe('undefined');
   });
 });
+
+describe('bridgeStoreEntry — metadata column round-trip (#1064)', () => {
+  it('persists a plain-object metadata blob to the metadata column', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    const meta = {
+      type: 'chunk',
+      parentDoc: 'doc-1064',
+      chunkIndex: 1,
+      totalChunks: 3,
+      prevChunk: 'k0',
+      nextChunk: 'k2',
+      siblings: ['k0', 'k1', 'k2'],
+    };
+
+    const store = await bridgeStoreEntry({
+      key: 'k1',
+      value: 'chunk body',
+      namespace: 'meta-test',
+      metadata: meta,
+      dbPath,
+    });
+    expect(store?.success).toBe(true);
+
+    const rows = await readRows(
+      `SELECT metadata FROM memory_entries WHERE namespace = ? AND key = ?`,
+      ['meta-test', 'k1'],
+    );
+    expect(rows.length).toBe(1);
+    expect(JSON.parse(String(rows[0].metadata))).toMatchObject(meta);
+  });
+
+  it('accepts a pre-stringified JSON blob and stores it verbatim', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    const raw = JSON.stringify({ type: 'chunk', parentDoc: 'd', chunkIndex: 0 });
+    await bridgeStoreEntry({
+      key: 'k-raw',
+      value: 'v',
+      namespace: 'meta-test',
+      metadata: raw,
+      dbPath,
+    });
+
+    const rows = await readRows(
+      `SELECT metadata FROM memory_entries WHERE namespace = ? AND key = ?`,
+      ['meta-test', 'k-raw'],
+    );
+    expect(String(rows[0].metadata)).toBe(raw);
+  });
+
+  it('defaults to {} when metadata is omitted (matches pre-#1064 shape)', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    await bridgeStoreEntry({
+      key: 'k-omit',
+      value: 'v',
+      namespace: 'meta-test',
+      dbPath,
+    });
+
+    const rows = await readRows(
+      `SELECT metadata FROM memory_entries WHERE namespace = ? AND key = ?`,
+      ['meta-test', 'k-omit'],
+    );
+    expect(String(rows[0].metadata)).toBe('{}');
+  });
+
+  it('surfaces metadata through bridgeGetEntry on the same row', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    const meta = { type: 'chunk', parentDoc: 'd', chunkTitle: 'T' };
+    await bridgeStoreEntry({
+      key: 'k-get',
+      value: 'v',
+      namespace: 'meta-test',
+      metadata: meta,
+      dbPath,
+    });
+
+    const got = await bridgeGetEntry({ key: 'k-get', namespace: 'meta-test', dbPath });
+    expect(got?.success).toBe(true);
+    expect(got?.found).toBe(true);
+    expect(got?.entry?.metadata).toBeDefined();
+    expect(JSON.parse(String(got?.entry?.metadata))).toMatchObject(meta);
+  });
+
+  it('persists per-item metadata through bridgeStoreEntries (batch)', async () => {
+    setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));
+
+    const items = [
+      { key: 'b0', value: 'v0', namespace: 'meta-test', metadata: { type: 'chunk', chunkIndex: 0 } },
+      { key: 'b1', value: 'v1', namespace: 'meta-test', metadata: { type: 'chunk', chunkIndex: 1 } },
+      { key: 'b2', value: 'v2', namespace: 'meta-test' /* defaults to '{}' */ },
+    ];
+    const results = await bridgeStoreEntries(items, dbPath);
+    expect(results?.every(r => r.success)).toBe(true);
+
+    const rows = await readRows(
+      `SELECT key, metadata FROM memory_entries WHERE namespace = ? ORDER BY key`,
+      ['meta-test'],
+    );
+    expect(rows.length).toBe(3);
+    expect(JSON.parse(String(rows[0].metadata))).toMatchObject({ type: 'chunk', chunkIndex: 0 });
+    expect(JSON.parse(String(rows[1].metadata))).toMatchObject({ type: 'chunk', chunkIndex: 1 });
+    expect(String(rows[2].metadata)).toBe('{}');
+  });
+});

--- a/src/cli/__tests__/services/daemon-memory-rpc.test.ts
+++ b/src/cli/__tests__/services/daemon-memory-rpc.test.ts
@@ -171,6 +171,75 @@ describe('daemon-memory-rpc', () => {
     expect(args.ttl).toBe(3600);
   });
 
+  // ── metadata (#1064) ──────────────────────────────────────────────────
+
+  it('POST /api/memory/store forwards a plain-object metadata payload to storeEntry (pre-serialised)', async () => {
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    const meta = {
+      type: 'chunk',
+      parentDoc: 'doc-1064',
+      chunkIndex: 1,
+      totalChunks: 3,
+      prevChunk: 'k0',
+      nextChunk: 'k2',
+      siblings: ['k0', 'k1', 'k2'],
+    };
+    const res = await postJson(testPort, '/api/memory/store', {
+      namespace: 'rpc-meta', key: 'k1', value: 'v', metadata: meta,
+    });
+    expect(res.status).toBe(200);
+    // validateMetadata pre-serialises so the INSERT site doesn't re-stringify.
+    const got = mockStoreEntry.mock.calls[0][0].metadata;
+    expect(typeof got).toBe('string');
+    expect(JSON.parse(got)).toEqual(meta);
+  });
+
+  it('POST /api/memory/store forwards a stringified metadata blob unchanged', async () => {
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    const raw = JSON.stringify({ type: 'chunk', parentDoc: 'd' });
+    const res = await postJson(testPort, '/api/memory/store', {
+      namespace: 'rpc-meta', key: 'k1', value: 'v', metadata: raw,
+    });
+    expect(res.status).toBe(200);
+    expect(mockStoreEntry.mock.calls[0][0].metadata).toBe(raw);
+  });
+
+  it('POST /api/memory/store leaves metadata undefined when omitted', async () => {
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    await postJson(testPort, '/api/memory/store', { namespace: 'rpc-meta', key: 'k1', value: 'v' });
+    expect(mockStoreEntry.mock.calls[0][0].metadata).toBeUndefined();
+  });
+
+  it('POST /api/memory/store rejects non-object metadata with 400', async () => {
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    const res = await postJson(testPort, '/api/memory/store', {
+      namespace: 'rpc-meta', key: 'k1', value: 'v', metadata: 42,
+    });
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).message).toMatch(/metadata must be/i);
+    expect(mockStoreEntry).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/memory/store rejects an unparseable metadata string with 400', async () => {
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    const res = await postJson(testPort, '/api/memory/store', {
+      namespace: 'rpc-meta', key: 'k1', value: 'v', metadata: '{not json',
+    });
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).message).toMatch(/not valid json/i);
+  });
+
+  it('POST /api/memory/store rejects oversized metadata with 400', async () => {
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    // 64 KB cap — pad a string field past it.
+    const fat = { type: 'chunk', pad: 'a'.repeat(70 * 1024) };
+    const res = await postJson(testPort, '/api/memory/store', {
+      namespace: 'rpc-meta', key: 'k1', value: 'v', metadata: fat,
+    });
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).message).toMatch(/exceeds/i);
+  });
+
   it('POST /api/memory/store rejects invalid namespace with 400', async () => {
     dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
     const res = await postJson(testPort, '/api/memory/store', {

--- a/src/cli/commands/doctor-checks-memory-access.ts
+++ b/src/cli/commands/doctor-checks-memory-access.ts
@@ -27,7 +27,6 @@ import { existsSync } from 'fs';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { memoryDbPath } from '../services/moflo-paths.js';
 import { findProjectRoot } from '../services/project-root.js';
-import { openDaemonDatabase } from '../memory/daemon-backend.js';
 import { type HealthCheck } from './doctor-checks-deep.js';
 import {
   type FunctionalCheckDetail,
@@ -240,13 +239,11 @@ interface NeighborsResult {
  * the metadata-passthrough plumbing in S1), this probe fails BEFORE the
  * stub ships to consumers.
  *
- * Three chunks are stored via memory_store, then their `metadata` columns
- * are written directly via sql.js to inject chunk-shaped nav fields
- * (memory_store always sets metadata to '{}', so the chunker write path is
- * the only producer in steady state — bypass it here for an in-process
- * probe). The middle chunk's neighbors are then fetched and verified to
- * carry navigation back, proving S1 + S2 + the metadata column passthrough
- * survive end-to-end.
+ * Three chunks are stored via `memory_store` with the chunk-shaped metadata
+ * passed in-band (#1064 — the chokepoint now accepts `metadata` so producers
+ * no longer have to open their own DB handle). The middle chunk's neighbors
+ * are then fetched and verified to carry navigation back, proving S1 + S2 +
+ * the metadata column passthrough survive end-to-end.
  */
 async function probeMemoryGetNeighbors(
   memoryTools: ToolHandler[],
@@ -278,25 +275,10 @@ async function probeMemoryGetNeighbors(
   const chunkKeys = [`${prefix}-0`, `${prefix}-1`, `${prefix}-2`];
   const middleKey = chunkKeys[1];
 
-  // Seed three chunks via DIRECT node:sqlite write (skipping memory_store).
-  // Going through memory_store would warm the bridge's TieredCache with
-  // metadata='{}', and a follow-up direct UPDATE would race the bridge's
-  // writeback. Writing straight to disk before the bridge ever sees these
-  // keys means memory_get_neighbors → getEntry hits fresh disk state and
-  // our injected metadata is what comes back.
-  //
-  // Phase 4 (#1083) flipped the engine to node:sqlite + WAL. The pre-Phase-4
-  // path opened sql.js, mutated in-memory, and `writeFileSync(...export())`d
-  // the whole buffer back — which would have CLOBBERED any concurrent WAL
-  // writes from the daemon's bridge (#1088, the consumer-smoke Windows
-  // failure that drove Phase 5). Going through openDaemonDatabase keeps
-  // the write coherent with every other node:sqlite reader on the same DB.
-  //
-  // Use the unified findProjectRoot so the seed writes to the SAME
-  // `.moflo/moflo.db` the bridge reads from. Earlier versions used
-  // `process.cwd()` (#844) and then `CLAUDE_PROJECT_DIR ?? process.cwd()`
-  // (#1058) — both diverged from the bridge whenever the bridge's walk
-  // resolved to a parent dir.
+  // Seed three chunks through `memory_store` with metadata in-band (#1064).
+  // The chokepoint now accepts `metadata`, so we no longer open our own
+  // node:sqlite handle here — the bridge's TieredCache stays consistent with
+  // disk, and the writer-audit no longer has to whitelist a probe-only bypass.
   const dbPath = memoryDbPath(findProjectRoot());
   if (!existsSync(dbPath)) {
     details.push({
@@ -309,56 +291,52 @@ async function probeMemoryGetNeighbors(
     });
     return { key: middleKey, namespace, chunkKeys };
   }
-  try {
-    const db = openDaemonDatabase(dbPath);
+  for (let i = 0; i < chunkKeys.length; i++) {
+    const meta = {
+      type: 'chunk',
+      parentDoc: 'doc-doctor-neighbors',
+      parentPath: '/doctor-neighbors.md',
+      chunkIndex: i,
+      totalChunks: chunkKeys.length,
+      prevChunk: i > 0 ? chunkKeys[i - 1] : null,
+      nextChunk: i < chunkKeys.length - 1 ? chunkKeys[i + 1] : null,
+      siblings: chunkKeys,
+      hierarchicalParent: null,
+      hierarchicalChildren: null,
+      chunkTitle: `Doctor Probe Chunk ${i}`,
+      headerLevel: 2,
+      docContentHash: stamp,
+    };
     try {
-      const insert = db.prepare(
-        `INSERT OR REPLACE INTO memory_entries
-          (id, key, namespace, content, type, tags, metadata, created_at, updated_at, status)
-         VALUES (?, ?, ?, ?, 'semantic', '[]', ?, ?, ?, 'active')`,
-      );
-      const now = Date.now();
-      for (let i = 0; i < chunkKeys.length; i++) {
-        const meta = {
-          type: 'chunk',
-          parentDoc: 'doc-doctor-neighbors',
-          parentPath: '/doctor-neighbors.md',
-          chunkIndex: i,
-          totalChunks: chunkKeys.length,
-          prevChunk: i > 0 ? chunkKeys[i - 1] : null,
-          nextChunk: i < chunkKeys.length - 1 ? chunkKeys[i + 1] : null,
-          siblings: chunkKeys,
-          hierarchicalParent: null,
-          hierarchicalChildren: null,
-          chunkTitle: `Doctor Probe Chunk ${i}`,
-          headerLevel: 2,
-          docContentHash: stamp,
-        };
-        insert.run([
-          `memprobe-neighbors-${stamp}-${i}`,
-          chunkKeys[i],
-          namespace,
-          `chunk body ${i}`,
-          JSON.stringify(meta),
-          now, now,
-        ]);
+      const out = (await invokeOrThrow(memoryTools, 'memory_store', {
+        key: chunkKeys[i],
+        value: `chunk body ${i}`,
+        namespace,
+        metadata: meta,
+      })) as StoreOut;
+      if (!out?.success) {
+        details.push({
+          id: 'neighbors.seed',
+          mcpTool: 'memory_get_neighbors',
+          status: 'fail',
+          observed: { chunk: chunkKeys[i], error: out?.error ?? 'unknown' },
+          expected: 'memory_store accepts chunk-shaped metadata in-band',
+          message: `seed failed at chunk ${i}: ${out?.error ?? 'unknown'}`,
+        });
+        return { key: middleKey, namespace, chunkKeys };
       }
-      insert.free();
-      // node:sqlite persists incrementally through WAL — no whole-file dump.
-    } finally {
-      db.close();
+    } catch (err) {
+      const msg = errorDetail(err, { firstLineOnly: true });
+      details.push({
+        id: 'neighbors.seed',
+        mcpTool: 'memory_get_neighbors',
+        status: 'fail',
+        observed: { error: msg },
+        expected: 'three chunk rows seeded via memory_store with chunk-shaped metadata',
+        message: `seed failed: ${msg}`,
+      });
+      return { key: middleKey, namespace, chunkKeys };
     }
-  } catch (err) {
-    const msg = errorDetail(err, { firstLineOnly: true });
-    details.push({
-      id: 'neighbors.seed',
-      mcpTool: 'memory_get_neighbors',
-      status: 'fail',
-      observed: { error: msg },
-      expected: 'three chunk rows seeded with chunk-shaped metadata',
-      message: `seed failed: ${msg}`,
-    });
-    return { key: middleKey, namespace, chunkKeys };
   }
 
   // 3. The probe itself — fetch prev + next of the middle chunk.

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -313,7 +313,7 @@ async function ensureInitialized(): Promise<void> {
 export const memoryTools: MCPTool[] = [
   {
     name: 'memory_store',
-    description: 'Store a value in memory with vector embedding for semantic search (sql.js + HNSW backend). Upserts by default — pass upsert:false to fail on duplicate keys.',
+    description: 'Store a value in memory with vector embedding for semantic search (sql.js + HNSW backend). Upserts by default — pass upsert:false to fail on duplicate keys. Optional `metadata` lets chunk-row producers set the navigation fields (parentDoc, prevChunk, nextChunk, siblings, …) that `memory_get_neighbors` reads.',
     category: 'memory',
     inputSchema: {
       type: 'object',
@@ -328,6 +328,11 @@ export const memoryTools: MCPTool[] = [
         },
         ttl: { type: 'number', description: 'Time-to-live in seconds (optional)' },
         upsert: { type: 'boolean', description: 'If false, fail on duplicate keys instead of replacing (default: true)' },
+        metadata: {
+          type: 'object',
+          additionalProperties: true,
+          description: 'Optional per-row metadata persisted to the `metadata` TEXT column. For chunk entries, include `type: "chunk"` plus the navigation fields (parentDoc, parentPath, chunkIndex, totalChunks, prevChunk, nextChunk, siblings, hierarchicalParent, hierarchicalChildren, chunkTitle, headerLevel) so `memory_get_neighbors` can traverse. Capped at 64KB serialised.',
+        },
       },
       required: ['key', 'value'],
     },
@@ -340,6 +345,7 @@ export const memoryTools: MCPTool[] = [
       const value = typeof input.value === 'string' ? input.value : JSON.stringify(input.value);
       const tags = (input.tags as string[]) || [];
       const ttl = input.ttl as number | undefined;
+      const metadata = input.metadata as Record<string, unknown> | string | undefined;
       // #962: default upsert=true — silent UNIQUE-constraint failures on update
       // were dropping schedule cancels and similar updates on the floor.
       const upsert = input.upsert === false ? false : true;
@@ -356,6 +362,7 @@ export const memoryTools: MCPTool[] = [
           generateEmbeddingFlag: true,
           tags,
           ttl,
+          metadata,
           upsert,
         });
 

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -33,6 +33,14 @@ function makeEntryCacheKey(namespace: string, key: string): string {
   return `entry:${safeNs}:${safeKey}`;
 }
 
+/** Normalise `metadata` for the `metadata` TEXT column; `undefined` → `'{}'` (#1064). */
+export function serialiseMetadata(metadata: Record<string, unknown> | string | undefined): string {
+  if (metadata == null) return '{}';
+  if (typeof metadata === 'string') return metadata;
+  try { return JSON.stringify(metadata); }
+  catch { return '{}'; }
+}
+
 function bm25Score(
   queryTerms: string[],
   docContent: string,
@@ -171,6 +179,8 @@ export async function bridgeStoreEntry(options: {
   ttl?: number;
   dbPath?: string;
   upsert?: boolean;
+  /** Per-row JSON for the `metadata` TEXT column; chunk-shaped rows need this so #1064 producers stop bypassing the chokepoint. */
+  metadata?: Record<string, unknown> | string;
 }): Promise<{
   success: boolean;
   id: string;
@@ -279,12 +289,13 @@ export async function bridgeStoreEntry(options: {
         ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`;
 
     // sql.js Statement.run takes an array of bindings — not varargs.
+    const metadataJson = serialiseMetadata(options.metadata);
     const stmt = ctx.db.prepare(insertSql);
     stmt.run([
       id, key, namespace, value,
       embeddingJson, dimensions || null, model,
       tags.length > 0 ? JSON.stringify(tags) : null,
-      '{}',
+      metadataJson,
       now, now,
       ttl ? now + (ttl * 1000) : null,
     ]);
@@ -309,7 +320,16 @@ export async function bridgeStoreEntry(options: {
     const cacheKey = makeEntryCacheKey(namespace, key);
     let cached = true;
     try {
-      await cacheSet(registry, cacheKey, { id, key, namespace, content: value, embedding: embeddingJson });
+      // #1064 — include metadata in the cache value so a subsequent
+      // bridgeGetEntry cache-hit returns the same shape as a fresh disk read.
+      // Without this, chunk-row producers writing through the chokepoint would
+      // get `{}` back from cache and the full metadata from disk — exactly the
+      // divergence the cache is supposed to mask.
+      await cacheSet(registry, cacheKey, {
+        id, key, namespace, content: value,
+        embedding: embeddingJson,
+        metadata: metadataJson,
+      });
     } catch (err) {
       cached = false;
       logBridgeError('post-persist cache set failed', err);
@@ -360,6 +380,8 @@ export async function bridgeStoreEntries(items: Array<{
   tags?: string[];
   ttl?: number;
   upsert?: boolean;
+  /** Per-item metadata. See {@link bridgeStoreEntry} for the shape contract. */
+  metadata?: Record<string, unknown> | string;
 }>, dbPath?: string): Promise<Array<{
   success: boolean;
   id: string;
@@ -426,13 +448,14 @@ export async function bridgeStoreEntries(items: Array<{
             tags, metadata, created_at, updated_at, expires_at, status
           ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, ?, ?, ?, 'active')`;
 
+      const metadataJson = serialiseMetadata(opts.metadata);
       try {
         const stmt = ctx.db.prepare(insertSql);
         stmt.run([
           id, key, namespace, value,
           embeddingJson, dimensions || null, model,
           tags.length > 0 ? JSON.stringify(tags) : null,
-          '{}',
+          metadataJson,
           now, now,
           ttl ? now + (ttl * 1000) : null,
         ]);
@@ -446,7 +469,12 @@ export async function bridgeStoreEntries(items: Array<{
 
       deferredBookkeeping.push({
         cacheKey: makeEntryCacheKey(namespace, key),
-        cacheValue: { id, key, namespace, content: value, embedding: embeddingJson },
+        // #1064 — keep cache shape in sync with disk (see single-store path).
+        cacheValue: {
+          id, key, namespace, content: value,
+          embedding: embeddingJson,
+          metadata: metadataJson,
+        },
         entryId: id,
         entryKey: key,
         namespace,

--- a/src/cli/memory/daemon-write-client.ts
+++ b/src/cli/memory/daemon-write-client.ts
@@ -254,6 +254,8 @@ export async function tryDaemonStore(opts: {
   value: unknown;
   tags?: string[];
   ttl?: number;
+  /** Per-row metadata forwarded to the daemon's `metadata` column (#1064). */
+  metadata?: Record<string, unknown> | string;
 }): Promise<DaemonWriteResult> {
   if (!(await isDaemonAvailable())) return { routed: false };
   return postJson('/api/memory/store', {
@@ -262,6 +264,7 @@ export async function tryDaemonStore(opts: {
     value: opts.value,
     tags: opts.tags,
     ttl: opts.ttl,
+    metadata: opts.metadata,
   });
 }
 

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -24,6 +24,7 @@ import { tryLoadHnswSidecar } from './hnsw-persistence.js';
 import { EMBEDDING_MODEL_OPT_OUT, EPHEMERAL_NAMESPACES, getBridgeEmbedder } from './bridge-embedder.js';
 import { parseEmbeddingJson, toFloat32 } from './controllers/_shared.js';
 import { writeVectorStatsJson } from './bridge-core.js';
+import { serialiseMetadata } from './bridge-entries.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import {
   MOFLO_DIR,
@@ -1870,6 +1871,8 @@ export async function storeEntry(options: {
   ttl?: number;
   dbPath?: string;
   upsert?: boolean;
+  /** Per-row JSON for the `metadata` TEXT column; defaults to `'{}'` when omitted (#1064). */
+  metadata?: Record<string, unknown> | string;
 }): Promise<{
   success: boolean;
   id: string;
@@ -1906,6 +1909,7 @@ export async function storeEntry(options: {
         value: options.value,
         tags: options.tags,
         ttl: options.ttl,
+        metadata: options.metadata,
       });
       if (routed.routed && routed.ok) {
         return { success: true, id: routed.id ?? '' };
@@ -2046,7 +2050,7 @@ export async function storeEntry(options: {
       embeddingDimensions,
       embeddingModel,
       tags.length > 0 ? JSON.stringify(tags) : null,
-      '{}',
+      serialiseMetadata(options.metadata),
       now,
       now,
       ttl ? now + (ttl * 1000) : null
@@ -2113,6 +2117,8 @@ export async function storeEntries(items: Array<{
   tags?: string[];
   ttl?: number;
   upsert?: boolean;
+  /** See {@link storeEntry} for the metadata contract (#1064). */
+  metadata?: Record<string, unknown> | string;
 }>, dbPath?: string): Promise<Array<{
   success: boolean;
   id: string;

--- a/src/cli/services/daemon-memory-rpc.ts
+++ b/src/cli/services/daemon-memory-rpc.ts
@@ -43,6 +43,9 @@ const KEY_MAX_LENGTH = 256;
 /** Max ops per batch. Bounds memory + write time per request. */
 export const BATCH_MAX_OPS = 100;
 
+/** Cap on serialised `metadata` per op (#1064); 64 KB leaves room for a 100-op batch under {@link MEMORY_RPC_MAX_BODY_BYTES}. */
+const METADATA_MAX_BYTES = 64 * 1024;
+
 // ============================================================================
 // Op shapes (validated; not exported as the wire-format contract is HTTP)
 // ============================================================================
@@ -54,6 +57,8 @@ interface StoreOp {
   value: unknown;
   tags?: string[];
   ttl?: number;
+  /** Pre-serialised JSON for the `metadata` TEXT column; capped at METADATA_MAX_BYTES (#1064). */
+  metadata?: string;
 }
 
 interface DeleteOp {
@@ -145,6 +150,29 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every(v => typeof v === 'string');
 }
 
+/** Validate optional `metadata` and return the already-serialised string so the INSERT site doesn't re-stringify (#1064). */
+function validateMetadata(value: unknown): { ok: true; metadata: string | undefined } | { ok: false; error: string } {
+  if (value === undefined) return { ok: true, metadata: undefined };
+  if (typeof value === 'string') {
+    if (Buffer.byteLength(value, 'utf8') > METADATA_MAX_BYTES) {
+      return { ok: false, error: `metadata exceeds ${METADATA_MAX_BYTES} bytes` };
+    }
+    try { JSON.parse(value); }
+    catch { return { ok: false, error: 'metadata string is not valid JSON' }; }
+    return { ok: true, metadata: value };
+  }
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return { ok: false, error: 'metadata must be a JSON object or stringified JSON' };
+  }
+  let serialised: string;
+  try { serialised = JSON.stringify(value); }
+  catch { return { ok: false, error: 'metadata is not serialisable' }; }
+  if (Buffer.byteLength(serialised, 'utf8') > METADATA_MAX_BYTES) {
+    return { ok: false, error: `metadata exceeds ${METADATA_MAX_BYTES} bytes` };
+  }
+  return { ok: true, metadata: serialised };
+}
+
 function validateStorePayload(body: unknown): { ok: true; op: StoreOp } | { ok: false; error: string } {
   if (typeof body !== 'object' || body === null) return { ok: false, error: 'body must be a JSON object' };
   const b = body as Record<string, unknown>;
@@ -155,6 +183,8 @@ function validateStorePayload(body: unknown): { ok: true; op: StoreOp } | { ok: 
   if (b.ttl !== undefined && (typeof b.ttl !== 'number' || !Number.isFinite(b.ttl) || b.ttl <= 0)) {
     return { ok: false, error: 'ttl must be a positive finite number (seconds)' };
   }
+  const metaResult = validateMetadata(b.metadata);
+  if (!metaResult.ok) return { ok: false, error: metaResult.error };
   return {
     ok: true,
     op: {
@@ -163,6 +193,7 @@ function validateStorePayload(body: unknown): { ok: true; op: StoreOp } | { ok: 
       value: b.value,
       tags: b.tags as string[] | undefined,
       ttl: b.ttl as number | undefined,
+      metadata: metaResult.metadata,
     },
   };
 }
@@ -339,6 +370,7 @@ export async function handleMemoryStore(
       namespace: v.op.namespace,
       tags: v.op.tags,
       ttl: v.op.ttl,
+      metadata: v.op.metadata,
       upsert: true,
     });
     if (!result.success) {
@@ -430,6 +462,7 @@ export async function handleMemoryBatch(
           namespace: op.namespace,
           tags: op.tags,
           ttl: op.ttl,
+          metadata: op.metadata,
           upsert: true,
         });
         if (r.success) {

--- a/tests/system/fixtures/writer-audit-whitelist.json
+++ b/tests/system/fixtures/writer-audit-whitelist.json
@@ -75,8 +75,7 @@
     {
       "file": "src/cli/commands/doctor-checks-memory-access.ts",
       "classification": "daemon-rpc",
-      "notes": "POST-S3: probe seed routes via daemon-write-client (eliminates #1053/#1054 raw db.export() bypass)",
-      "pending_fix": "S3 #1057"
+      "notes": "Probe seed routes via memory_store with chunk metadata in-band (#1064); chokepoint accepts metadata so no direct DB handle remains"
     },
     {
       "file": "src/cli/commands/doctor-checks-memory.ts",


### PR DESCRIPTION
## Summary

Closes #1064 — the metadata API gap on the `memory_store` write chokepoint.

- `memory_store` MCP / `storeEntry` / `bridgeStoreEntry[Entries]` / `tryDaemonStore` / `daemon-memory-rpc.handleMemoryStore` now thread an optional `metadata` field down to the `memory_entries.metadata` TEXT column. Plain object or pre-stringified blob; capped at 64 KB serialised at the daemon boundary; pre-serialised once so the INSERT site doesn't re-stringify.
- Two known bypass sites migrated to the chokepoint: `src/cli/commands/doctor-checks-memory-access.ts` (Memory Access doctor probe) and `harness/consumer-smoke/lib/checks.mjs` (`memoryTraversalProtocol`). Both used to open their own node:sqlite handles because the chokepoint hardcoded the column to `'{}'`.
- `pending_fix: S3 #1057` annotation removed from `tests/system/fixtures/writer-audit-whitelist.json` — that file now routes via memory_store.

## Scope clarification

Per the issue owner's 2026-05-11 comment, #1064 had two dimensions. The **clobber dimension** was killed structurally by epic #1078 (sql.js → node:sqlite migration, closed 2026-05-12 — concurrent writers safe under WAL). This PR covers the **API gap dimension** that remained: the chokepoint API had no way to set the navigation columns (`parentDoc`, `prevChunk`, `nextChunk`, `siblings`, …) that `memory_get_neighbors` reads, forcing chunk-row producers to bypass.

## Consumer blast radius

- **Surface touched**: `memory_store` MCP inputSchema (additive — `metadata` optional, no breaking change for existing callers), bridge/chokepoint signatures (optional new field), daemon-RPC POST body (validates new field, ignores when omitted).
- **Failure mode for on-current-version consumer**: existing callers that don't pass `metadata` see identical behaviour (default `'{}'` preserved). New callers can now set chunk metadata in-band instead of bypassing.
- **Round-trip cost**: requires `npm install` to ship the new memory_store schema + handler.

## Implementation notes (reviewer follow-up applied)

- `serialiseMetadata` exported from `bridge-entries.ts` and reused in `memory-initializer.ts`'s direct-fallback path (replacing a 5-line IIFE flagged in /flo-simplify review).
- `validateMetadata` in `daemon-memory-rpc.ts` returns the already-stringified blob (caches the size-check serialisation) so daemon-RPC writes don't re-stringify at the INSERT site.
- Bridge's TieredCache value now includes `metadata` so cache-hits match disk reads.

## Test plan

- [x] `npm run build` clean (tsc)
- [x] `src/cli/__tests__/bridge-entries.test.ts` — +5 tests covering single-store + batch metadata round-trip (object passthrough, pre-stringified passthrough, `{}` default, bridgeGetEntry surfaces metadata)
- [x] `src/cli/__tests__/services/daemon-memory-rpc.test.ts` — +6 tests covering HTTP boundary (object → pre-serialised, string passthrough, undefined, non-object reject, unparseable string reject, 64 KB cap)
- [x] `tests/system/moflo-db-writer-audit.test.ts` — passes with `pending_fix` removed
- [x] Full suite — 8600 passed, 0 #1064-related failures
- [x] Pre-existing flake (`spell-credentials.test.ts:204` dynamic-import timeout under load) filed as #1107; passes in isolation

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)