### PR TITLE
fix(1065): surface embedding metadata through daemon-routed memory_store

### DIFF
--- a/src/cli/__tests__/memory/daemon-write-client.test.ts
+++ b/src/cli/__tests__/memory/daemon-write-client.test.ts
@@ -211,6 +211,53 @@ describe('daemon-write-client', () => {
     expect(body.value).toEqual({ x: 1 });
   });
 
+  // #1065 — the daemon's POST /api/memory/store response carries the
+  // bridge's `embedding: { dimensions, model }`. The client must surface
+  // it so callers can preserve the bridge-direct shape end-to-end.
+  it('tryDaemonStore surfaces embedding when the daemon includes it (#1065)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        ok: true,
+        stored: true,
+        id: 'entry_with_emb',
+        embedding: { dimensions: 384, model: 'fastembed-bge-small-en-v1.5' },
+      }));
+    });
+
+    const r = await tryDaemonStore({ namespace: 'ns', key: 'k', value: 'v' });
+    expect(r.routed).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(r.embedding).toEqual({ dimensions: 384, model: 'fastembed-bge-small-en-v1.5' });
+  });
+
+  it('tryDaemonStore leaves embedding undefined when an older daemon omits it', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    // Default handler returns the pre-#1065 shape (no embedding field).
+    const r = await tryDaemonStore({ namespace: 'ns', key: 'k', value: 'v' });
+    expect(r.routed).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(r.embedding).toBeUndefined();
+  });
+
+  it('tryDaemonStore drops a malformed embedding field instead of failing the response', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, stored: true, id: 'e', embedding: { dimensions: 'bad', model: 42 } }));
+    });
+    const r = await tryDaemonStore({ namespace: 'ns', key: 'k', value: 'v' });
+    expect(r.routed).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(r.embedding).toBeUndefined();
+  });
+
   it('tryDaemonStore returns routed:false when daemon is down', async () => {
     process.env.MOFLO_DAEMON_PORT = String(40000 + Math.floor(Math.random() * 10000));
     const r = await tryDaemonStore({ namespace: 'ns', key: 'k', value: 'v' });

--- a/src/cli/__tests__/memory/store-entry-routing.test.ts
+++ b/src/cli/__tests__/memory/store-entry-routing.test.ts
@@ -54,6 +54,8 @@ interface FakeDaemon {
   setGetResponse(body: Record<string, unknown>): void;
   setSearchResponse(body: Record<string, unknown>): void;
   setListResponse(body: Record<string, unknown>): void;
+  /** Override the store response so #1065 tests don't need to monkey-patch the request listener. */
+  setStoreResponse(body: Record<string, unknown>): void;
   stop(): Promise<void>;
 }
 
@@ -66,6 +68,7 @@ async function startFakeDaemon(): Promise<FakeDaemon> {
   let getResponse: Record<string, unknown> = { ok: true, found: false };
   let searchResponse: Record<string, unknown> = { ok: true, results: [], searchTime: 0 };
   let listResponse: Record<string, unknown> = { ok: true, entries: [], total: 0 };
+  let storeResponse: Record<string, unknown> = { ok: true, stored: true, id: 'fake_routed_id' };
 
   const server = http.createServer((req, res) => {
     let buf = '';
@@ -79,7 +82,7 @@ async function startFakeDaemon(): Promise<FakeDaemon> {
       if (req.url === '/api/memory/store' && req.method === 'POST') {
         try { storeRequests.push(JSON.parse(buf)); } catch { /* malformed */ }
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, stored: true, id: 'fake_routed_id' }));
+        res.end(JSON.stringify(storeResponse));
         return;
       }
       if (req.url === '/api/memory/delete' && req.method === 'POST') {
@@ -128,6 +131,7 @@ async function startFakeDaemon(): Promise<FakeDaemon> {
     setGetResponse(body) { getResponse = body; },
     setSearchResponse(body) { searchResponse = body; },
     setListResponse(body) { listResponse = body; },
+    setStoreResponse(body) { storeResponse = body; },
     async stop() {
       server.closeAllConnections?.();
       await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -186,6 +190,65 @@ describe('memory-initializer routing preamble (#985)', () => {
     const req = fake.storeRequests[0];
     expect(req.namespace).toBe('tasklist');
     expect(req.key).toBe('flo-run-981');
+  });
+
+  // #1065 — the daemon now echoes `embedding: { dimensions, model }` so the
+  // routed return shape matches bridge-direct. Without this, MCP memory_store
+  // reports hasEmbedding:false on daemon-routed writes and the doctor Memory
+  // Access check fails.
+  it('storeEntry surfaces embedding metadata from the daemon-routed response (#1065)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setStoreResponse({
+      ok: true,
+      stored: true,
+      id: 'routed_with_emb',
+      embedding: { dimensions: 384, model: 'fastembed-bge-small-en-v1.5' },
+    });
+
+    const result = await storeEntry({ key: 'k', value: 'v', namespace: 'ns' });
+    expect(result.success).toBe(true);
+    expect(result.id).toBe('routed_with_emb');
+    expect(result.embedding).toEqual({ dimensions: 384, model: 'fastembed-bge-small-en-v1.5' });
+  });
+
+  // #1065 — daemon-route and bridge-direct paths must produce the same
+  // user-visible shape for storeEntry. Without this, MCP `memory_store`
+  // reports hasEmbedding inconsistently depending on which path served the
+  // call — invisible to integration tests that exercise only one path.
+  it('storeEntry shape parity: daemon-route and bridge-direct both yield {success,id,embedding}', async () => {
+    // (a) Daemon-routed path with the new echo-embedding shape.
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setStoreResponse({
+      ok: true, stored: true, id: 'routed_id',
+      embedding: { dimensions: 384, model: 'fastembed-bge-small-en-v1.5' },
+    });
+    const routed = await storeEntry({ key: 'k-routed', value: 'v', namespace: 'ns' });
+
+    // (b) Bridge-direct path with precomputed embedding so fastembed never runs.
+    process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+    const direct = await storeEntry({
+      key: 'k-direct',
+      value: 'v',
+      namespace: 'ns',
+      precomputedEmbedding: new Float32Array(384).fill(0.1),
+      dbPath: tempDbPath(),
+    });
+
+    // Both paths advertise the same caller-visible keys.
+    expect(routed.success).toBe(true);
+    expect(direct.success).toBe(true);
+    expect(typeof routed.id).toBe('string');
+    expect(typeof direct.id).toBe('string');
+    // Both paths surface embedding with dimensions + model. The model string
+    // may differ (mock vs real bridge embedder) but the shape must match.
+    expect(routed.embedding).toBeDefined();
+    expect(direct.embedding).toBeDefined();
+    expect(typeof routed.embedding!.dimensions).toBe('number');
+    expect(typeof direct.embedding!.dimensions).toBe('number');
+    expect(typeof routed.embedding!.model).toBe('string');
+    expect(typeof direct.embedding!.model).toBe('string');
   });
 
   it('storeEntry skips routing when MOFLO_IS_DAEMON=1', async () => {

--- a/src/cli/__tests__/services/daemon-memory-rpc.test.ts
+++ b/src/cli/__tests__/services/daemon-memory-rpc.test.ts
@@ -294,6 +294,35 @@ describe('daemon-memory-rpc', () => {
     expect(JSON.parse(res.body).error).toMatch(/not attached/i);
   });
 
+  // #1065 — embedding metadata must round-trip from storeEntry through the
+  // HTTP boundary; without it, the MCP memory_store handler reports
+  // hasEmbedding:false on every daemon-routed write that actually succeeded
+  // and the doctor Memory Access check fails.
+  it('POST /api/memory/store includes embedding in response when storeEntry produced one (#1065)', async () => {
+    mockStoreEntry.mockResolvedValueOnce({
+      success: true,
+      id: 'entry_with_emb',
+      embedding: { dimensions: 384, model: 'fastembed-bge-small-en-v1.5' },
+    });
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    const res = await postJson(testPort, '/api/memory/store', { namespace: 'ns', key: 'k', value: 'v' });
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.ok).toBe(true);
+    expect(data.id).toBe('entry_with_emb');
+    expect(data.embedding).toEqual({ dimensions: 384, model: 'fastembed-bge-small-en-v1.5' });
+  });
+
+  it('POST /api/memory/store omits embedding when storeEntry did not produce one (opt-out path)', async () => {
+    mockStoreEntry.mockResolvedValueOnce({ success: true, id: 'entry_no_emb' });
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    const res = await postJson(testPort, '/api/memory/store', { namespace: 'ns', key: 'k', value: 'v' });
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.ok).toBe(true);
+    expect(data.embedding).toBeUndefined();
+  });
+
   it('POST /api/memory/store surfaces storeEntry failure as 500', async () => {
     mockStoreEntry.mockResolvedValueOnce({ success: false, id: '', error: 'disk full' });
     dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
@@ -353,6 +382,30 @@ describe('daemon-memory-rpc', () => {
     expect(data.results.every((r: { ok: boolean }) => r.ok)).toBe(true);
     expect(mockStoreEntry).toHaveBeenCalledTimes(2);
     expect(mockDeleteEntry).toHaveBeenCalledTimes(1);
+  });
+
+  // #1065 — batch endpoint must propagate embedding per-store the same way
+  // the single /store endpoint does, so batch callers can report
+  // hasEmbedding correctly per result without a separate read round-trip.
+  it('POST /api/memory/batch propagates embedding per store result (#1065)', async () => {
+    mockStoreEntry
+      .mockResolvedValueOnce({ success: true, id: 'b1', embedding: { dimensions: 384, model: 'fastembed-bge-small-en-v1.5' } })
+      .mockResolvedValueOnce({ success: true, id: 'b2' }); // opt-out / ephemeral path
+    dashboard = await startDashboard(makeMockDaemon(), { port: testPort, memory: makeMockMemory() });
+    const res = await postJson(testPort, '/api/memory/batch', {
+      ops: [
+        { op: 'store', namespace: 'ns', key: 'k1', value: 'v1' },
+        { op: 'store', namespace: 'ephemeral', key: 'k2', value: 'v2' },
+        { op: 'delete', namespace: 'ns', key: 'k0' },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.results[0].embedding).toEqual({ dimensions: 384, model: 'fastembed-bge-small-en-v1.5' });
+    expect(data.results[1].embedding).toBeUndefined();
+    // Delete results never carry embedding.
+    expect(data.results[2].embedding).toBeUndefined();
+    expect(data.results[2].deleted).toBe(true);
   });
 
   it('POST /api/memory/batch fails-all on any invalid op (no partial application)', async () => {

--- a/src/cli/memory/daemon-write-client.ts
+++ b/src/cli/memory/daemon-write-client.ts
@@ -78,6 +78,12 @@ export interface DaemonWriteResult {
   id?: string;
   /** Set on a successful delete: whether the row existed. */
   deleted?: boolean;
+  /**
+   * Set on a successful store when the bridge embedded the row (#1065).
+   * Mirrors `bridgeStoreEntry`'s return shape so the daemon-routed path
+   * and the bridge-direct fallback are indistinguishable to callers.
+   */
+  embedding?: { dimensions: number; model: string };
   /** Set on routed-but-failed (4xx): the daemon's error message. */
   error?: string;
 }
@@ -375,6 +381,20 @@ function parse4xxError(buf: string, status: number): string {
   return `daemon returned ${status}`;
 }
 
+/**
+ * Narrow a parsed JSON value to the `{ dimensions, model }` embedding-response
+ * shape (#1065). Returns `undefined` when the field is missing or malformed —
+ * a malformed field is treated as "no embedding info" rather than failing the
+ * whole response, so an older daemon that hasn't been updated still works.
+ */
+function parseEmbeddingField(value: unknown): { dimensions: number; model: string } | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const v = value as { dimensions?: unknown; model?: unknown };
+  if (typeof v.dimensions !== 'number' || !Number.isFinite(v.dimensions)) return undefined;
+  if (typeof v.model !== 'string' || v.model.length === 0) return undefined;
+  return { dimensions: v.dimensions, model: v.model };
+}
+
 function postJson(path: string, body: unknown): Promise<DaemonWriteResult> {
   return new Promise((resolve) => {
     let done = false;
@@ -430,6 +450,7 @@ function postJson(path: string, body: unknown): Promise<DaemonWriteResult> {
               ok: !!data?.ok,
               id: typeof data?.id === 'string' ? data.id : undefined,
               deleted: typeof data?.deleted === 'boolean' ? data.deleted : undefined,
+              embedding: parseEmbeddingField(data?.embedding),
               error: typeof data?.error === 'string' ? data.error : undefined,
             });
           } catch {

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -1912,7 +1912,10 @@ export async function storeEntry(options: {
         metadata: options.metadata,
       });
       if (routed.routed && routed.ok) {
-        return { success: true, id: routed.id ?? '' };
+        // #1065 — surface the daemon's embedding metadata so the MCP
+        // memory_store handler reports `hasEmbedding: true` on
+        // daemon-routed writes (matching the bridge-direct shape).
+        return { success: true, id: routed.id ?? '', embedding: routed.embedding };
       }
       // #1101 — daemon validated and rejected (4xx). Bridge-direct would
       // fail the same way; surface the daemon's error instead of silently

--- a/src/cli/services/daemon-memory-rpc.ts
+++ b/src/cli/services/daemon-memory-rpc.ts
@@ -377,7 +377,11 @@ export async function handleMemoryStore(
       sendJson(res, 500, { error: 'Store failed', message: result.error ?? 'unknown' });
       return;
     }
-    sendJson(res, 200, { ok: true, stored: true, id: result.id });
+    // #1065 — preserve the bridge's `embedding: { dimensions, model }` shape
+    // through the wire boundary. Without this, MCP `memory_store` reports
+    // `hasEmbedding: false` on every daemon-routed write that actually
+    // succeeded, and the doctor Memory Access check fails.
+    sendJson(res, 200, { ok: true, stored: true, id: result.id, embedding: result.embedding });
   } catch (err) {
     sendJson(res, 500, { error: 'Internal error', message: errorDetail(err) });
   }
@@ -451,7 +455,7 @@ export async function handleMemoryBatch(
     return;
   }
   const { storeEntry, deleteEntry } = await getMemoryFns();
-  const results: Array<{ ok: boolean; id?: string; deleted?: boolean; error?: string }> = [];
+  const results: Array<{ ok: boolean; id?: string; deleted?: boolean; embedding?: { dimensions: number; model: string }; error?: string }> = [];
   let anyFailed = false;
   for (const op of v.ops) {
     try {
@@ -466,7 +470,9 @@ export async function handleMemoryBatch(
           upsert: true,
         });
         if (r.success) {
-          results.push({ ok: true, id: r.id });
+          // #1065 — same shape carry-through as /store: include embedding
+          // so batch callers can report hasEmbedding accurately.
+          results.push({ ok: true, id: r.id, embedding: r.embedding });
         } else {
           results.push({ ok: false, error: r.error ?? 'unknown' });
           anyFailed = true;


### PR DESCRIPTION
## Summary

- `handleMemoryStore` returned `{ ok, stored, id }` but dropped `result.embedding`. The bridge-direct path returns `{ success, id, embedding: { dimensions, model } }`; MCP `memory_store` reports `hasEmbedding: !!result.embedding`, so the doctor Memory Access check failed on every daemon-routed write that actually succeeded.
- Hidden pre-fix because the 100ms shared daemon-RPC probe+request timeout often forced fallback to bridge-direct (which kept the embedding). The durable daemon-routing work in #1063 made the gap visible — daemon route now actually succeeds on the store path.
- Threaded the field through all four chokepoints in the AC: daemon HTTP response, `DaemonWriteResult`, `postJson` parser, and `storeEntry`'s routed-success return.

## Wire-shape compatibility

Both directions verified — the change is additive only:

| Daemon | Client | Outcome |
| --- | --- | --- |
| New | New | `embedding` round-trips end-to-end → `hasEmbedding=true` |
| Old | New | `parseEmbeddingField` returns undefined on missing field → pre-fix behavior, no regression |
| New | Old | Older client ignores unknown JSON field → safe |

## What changed

- ` daemon-memory-rpc.ts:handleMemoryStore + handleMemoryBatch` — echo `embedding: result.embedding` in 200 responses
- `daemon-write-client.ts` — `DaemonWriteResult.embedding?: { dimensions, model }`; new `parseEmbeddingField` defensively narrows wire value (returns undefined on missing OR malformed)
- `memory-initializer.ts:storeEntry` — daemon-route success path propagates `routed.embedding`
- Tests: HTTP-boundary echo (single + batch), client-side surfacing, malformed-tolerant parsing, `storeEntry` return shape, end-to-end parity vs bridge-direct
- FakeDaemon fixture grew a `setStoreResponse` setter parallel with the existing `setGetResponse`/`setSearchResponse`/`setListResponse` (replaces a brittle `removeAllListeners` monkey-patch in two new tests)

## Test plan

- [x] `npx vitest run src/cli/__tests__/services/daemon-memory-rpc.test.ts src/cli/__tests__/memory/daemon-write-client.test.ts src/cli/__tests__/memory/store-entry-routing.test.ts` — 109 passed
- [x] `npx vitest run src/cli/__tests__/services/ src/cli/__tests__/memory/ src/cli/__tests__/doctor-checks-memory-access.test.ts src/cli/__tests__/bridge-entries.test.ts` — 593 passed
- [x] `npx vitest run tests/system/daemon-fallback-cross-process-1063.test.ts tests/system/multi-process-write-visibility.test.ts tests/system/mcp-memory-roundtrip.test.ts` — 9 passed
- [x] `npx tsc --noEmit` — clean

Closes #1065. Related: #1054 (epic), #1063 (durable daemon-routing that surfaced this), #1064 (metadata threading via the same chokepoint).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)