### PR TITLE
fix(1067): pin smoke harness env + repair bridgeAddToHNSW metadata clobber

### DIFF
--- a/.claude/guidance/internal/dogfooding.md
+++ b/.claude/guidance/internal/dogfooding.md
@@ -85,6 +85,46 @@ Features must work from the installed location (consumer perspective), not from 
 
 ---
 
+## Smoke Harness Reality
+
+`harness/consumer-smoke/` packs the working tree, installs it into a temp consumer dir, and exercises the Claude-Code-facing surface. The harness is the single source of truth for whether a change is consumer-safe — but the dogfood loop makes it diverge from CI in two specific ways unless we pin them.
+
+### Two contexts running at once (local dev only)
+
+When the smoke runs inside a Claude Code session on the moflo repo, two moflo contexts coexist:
+
+| Context | Origin | What it owns |
+|---------|--------|--------------|
+| **Dev daemon** | `SessionStart` hook auto-started moflo for the dev session | Port 3117, the moflo repo's `.moflo/moflo.db`, the dev session's `CLAUDE_PROJECT_DIR=<moflo-repo>` |
+| **Consumer install** | `npm install` from packed tarball into `os.tmpdir()/moflo-consumer-smoke/consumer-N/` | Its own `.moflo/moflo.db`, its own daemon (would-be port 3117) |
+
+CI runs the consumer install only — there's no dev daemon, no Claude Code session, no `CLAUDE_PROJECT_DIR` in env. Same code, different environment. Without pinning, two divergences leak through:
+
+1. **Project-root resolution** — `findProjectRoot()` honors `CLAUDE_PROJECT_DIR` ahead of the marker walk. The dev session's value points at the moflo repo, so every consumer subprocess that inherits env resolves project-root to the source tree and writes to the *dev* DB instead of the consumer DB.
+2. **Daemon port collision** — the dev daemon already binds 3117. The consumer's `flo daemon start` walks the fallback range (3118, 3119, …) but client subprocesses (writers via `daemon-write-client.ts`) still default to 3117, so they POST to the dev daemon.
+
+### How the harness pins both (#1067)
+
+`harness/consumer-smoke/run.mjs` mutates `process.env` before any subprocess spawns. The existing env merge in `lib/proc.mjs` (`{ ...process.env, ...(runOpts.env || {}) }`) propagates the pinned values to every `flo()` / `runNode()` call and to the daemons they fork:
+
+```js
+process.env.MOFLO_DAEMON_PORT = process.env.MOFLO_DAEMON_PORT || '3217';
+// …after installConsumer():
+process.env.CLAUDE_PROJECT_DIR = consumerDir;
+```
+
+`src/cli/commands/daemon.ts#resolveDashboardPort` honors `MOFLO_DAEMON_PORT` env (post-#1067) so the consumer daemon binds the pinned port, matching the client. Port 3217 is outside the dev daemon's fallback range, so a parallel local smoke can't collide.
+
+### Symptoms of unpinned context
+
+If you ever see a smoke check report `found=false` for a key that was just written, OR a probe writing to a `.moflo/moflo.db` that isn't under `consumerDir`, OR the harness times out waiting for the daemon while `flo daemon start` reported success — check that both env pins are still in place at the top of `run.mjs` / `run-populated.mjs`. The `verifyConsumerIsProjectRoot` gate runs `findProjectRoot({ honorEnv: false })`, so it passes even when downstream probes silently divergence-fail.
+
+### Acceptance: local smoke matches CI
+
+The contract: running `npm run test:smoke` while the moflo dev daemon is up on 3117 must produce identical pass/fail status to a fresh CI checkout. Any divergence between local and CI smoke is a bug in the harness's context pinning, not in the code under test.
+
+---
+
 ## See Also
 
 - `.claude/guidance/internal/upgrade-contract.md` — The "user never re-runs init" invariant that dogfooding stress-tests on every dev session

--- a/.claude/guidance/internal/testing-conventions.md
+++ b/.claude/guidance/internal/testing-conventions.md
@@ -214,6 +214,32 @@ npx vitest run path/to/the/failing.test.ts
 
 ---
 
+## 13. Measure Twice, Cut Once — Diagnose Before You Fix
+
+**Don't guess at a bug. Pinpoint it with a test or diagnostic that proves what's wrong, then fix only what the evidence indicts.** Guess-and-patch produces layered workarounds (see `feedback_no_layered_workarounds.md`); it ships fixes for the wrong root cause; and it leaves the *next* engineer to debug the same symptom from scratch because no diagnostic remained in the tree.
+
+Before writing a fix, ask: *what evidence would tell me exactly which layer is broken?* Then produce that evidence. Concretely:
+
+| Symptom shape | First diagnostic |
+|---------------|------------------|
+| Failing assertion (smoke probe, integration test, system test) | Add per-row / per-case diagnostic to the **existing failure record** so it surfaces which specific input failed — not just "some neighbor missing nav" but `{"key":"chunk-foo-0","hasNav":false}` |
+| "Sometimes wrong, sometimes right" | Bisect: add diagnostics that distinguish first-call vs N-th-call, fresh-DB vs warm-cache, daemon-routed vs direct-write |
+| "Output doesn't match expectation" but you can't tell which layer is lying | Probe each layer directly — raw DB read alongside the API/handler read; cache state alongside disk state — to localize where the divergence enters |
+| "Race / timing / 'works on my machine'" | Add diagnostics that capture the order of operations and the state of shared resources at each step |
+
+Once a write-then-read smoke fails, **don't change the writer until you know what the reader saw on disk**. A 5-line `db.prepare('SELECT ... WHERE key = ?')` probe alongside the API read settles in seconds whether the bug is on the write side (data never landed) or the read side (data landed but the shaping layer dropped it).
+
+The diagnostic is part of the fix. Either:
+
+- **Keep it in the production codepath as a structured failure detail** (e.g. include per-row hash/length/presence flags in the assertion's failure record). Next time this regression hits, the message points the future engineer at the bad row instead of the bad assertion.
+- **Bake it into a unit / integration test** that asserts the round-trip directly (write metadata → read raw column → assert it parses to the expected shape). The diagnostic becomes a regression gate.
+
+Throwing away a diagnostic the moment the fix lands is the anti-pattern: the next regression has nothing to land on, and we re-diagnose from zero. Either generalize the probe into a test or fold it into the existing assertion's failure-detail string.
+
+> Worked example (#1067): a smoke check reported "neighbors without navigation field". A naive guess would have edited `parseNavigation`. Instead, three layered probes — per-neighbor breakdown → per-key `memory_retrieve` → raw `SELECT metadata` — localized the bug to **the first write only** and showed disk held the literal string `"null"`, not the JSON object the writer fed in. That pointed straight at `bridgeAddToHNSW`'s post-insert `INSERT OR REPLACE` (which stripped non-listed columns including metadata). The per-neighbor diagnostic is now part of the smoke check's failure message so the next regression surfaces the offending key, not a generic "something is missing" string.
+
+---
+
 ## See Also
 
 - `.claude/guidance/internal/testing-performance.md` — Parallelism, fork contention, and per-test perf budgets

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -1185,6 +1185,12 @@ console.log(JSON.stringify({
   keys: (result.neighbors || []).map(n => n.key).sort(),
   hasNavigation: (result.neighbors || []).length > 0
     && (result.neighbors || []).every(n => n.navigation && typeof n.navigation === 'object'),
+  // Per-neighbor diagnostic — a future regression surfaces *which* neighbor
+  // is missing nav, not just "some neighbor is missing nav" (#1067 lesson).
+  neighborDiag: (result.neighbors || []).map(n => ({
+    key: n.key,
+    hasNav: !!(n.navigation && typeof n.navigation === 'object'),
+  })),
   error: result.error || null,
 }));
 `);
@@ -1214,7 +1220,8 @@ console.log(JSON.stringify({
     return;
   }
   if (!parsed.hasNavigation) {
-    record('memory-protocol:get-neighbors', 'fail', 'returned neighbors without navigation field (S1 passthrough broken)');
+    record('memory-protocol:get-neighbors', 'fail',
+      `returned neighbors without navigation field (S1 passthrough broken); diag=${JSON.stringify(parsed.neighborDiag)}`);
     return;
   }
   record('memory-protocol:get-neighbors', 'pass', '2 neighbors with navigation, shape matches memory_retrieve');

--- a/harness/consumer-smoke/lib/populated.mjs
+++ b/harness/consumer-smoke/lib/populated.mjs
@@ -773,6 +773,14 @@ function forceKill(child) {
 async function runMcpClobberCheck(consumerDir, seedRows) {
   section('Populated: MCP-clobber regression check');
 
+  // Quiesce the prior phase's daemon + indexer chain before deleting
+  // .moflo. On Windows the daemon holds moflo.db exclusively, so unlink
+  // throws EBUSY and the harness aborts before any MCP-clobber assertion
+  // runs (#1067). The launcher's second run leaves these processes alive
+  // for the post-state probes — we own the cleanup.
+  flo(consumerDir, ['daemon', 'stop'], { timeout: 15_000 });
+  quiesceLauncherBackground(consumerDir);
+
   rmSync(join(consumerDir, MOFLO_DIR), { recursive: true, force: true });
   rmSync(legacyMemoryDbPath(consumerDir), { force: true });
   rmSync(legacyMemoryDbBakPath(consumerDir), { force: true });

--- a/harness/consumer-smoke/lib/populated.mjs
+++ b/harness/consumer-smoke/lib/populated.mjs
@@ -14,7 +14,7 @@ import { spawn, execFileSync } from 'node:child_process';
 
 import { runNode, flo, IS_WIN, recordSample } from './proc.mjs';
 import { section, record, recordExit } from './report.mjs';
-import { runSqlJsProbe, writeStandaloneProbe } from './sqljs-probe.mjs';
+import { runSqliteProbe, writeStandaloneProbe } from './sqlite-probe.mjs';
 import {
   MOFLO_DIR,
   LEGACY_CLAUDE_FLOW_DIR,
@@ -166,7 +166,7 @@ function seedSwarmDb(consumerDir, rows) {
 
   // Pre-#728 schema: status CHECK still permits 'deleted' so we can carry
   // soft-delete tombstones into the fixture for the launcher's purge to clean up.
-  const result = runSqlJsProbe(consumerDir, 'seed-swarm-db', `
+  const result = runSqliteProbe(consumerDir, 'seed-swarm-db', `
 const SQL = await sqlInit();
 const db = new SQL.Database();
 db.exec(\`CREATE TABLE memory_entries (
@@ -261,7 +261,7 @@ function seedMofloDb(consumerDir, tasklistRows) {
   // doc-*/chunk-w-preamble fixtures the new migrations should clean up.
   const allRows = [...tasklistRows, ...buildLegacyEpic1053Rows()];
 
-  const result = runSqlJsProbe(consumerDir, 'seed-moflo-db', `
+  const result = runSqliteProbe(consumerDir, 'seed-moflo-db', `
 const SQL = await sqlInit();
 const db = new SQL.Database();
 db.exec(\`CREATE TABLE memory_entries (
@@ -375,11 +375,26 @@ function inspectPostStateDb(consumerDir) {
   const dbPath = memoryDbPath(consumerDir);
   if (!existsSync(dbPath)) return null;
 
-  return runSqlJsProbe(consumerDir, 'inspect-moflo-db', `
+  return runSqliteProbe(consumerDir, 'inspect-moflo-db', `
 // readFileSync is provided by the probe harness (#1098).
+//
+// #1067: the launcher writes \`.moflo/moflo.db\` in WAL journal mode, so a
+// raw \`readFileSync(dbPath)\` snapshot of the main file alone is inconsistent
+// with the WAL-resident pending pages — opening those bytes in a fresh
+// DatabaseSync flags PRAGMA integrity_check with duplicate-page refs
+// ("Rowid out of order"). Open the live file briefly, force a TRUNCATE
+// checkpoint to flush WAL → main, close, then readFileSync sees a coherent
+// snapshot. (Pre-#1067 the seed wrote 0 bytes, the launcher rebuilt the DB
+// from scratch in DELETE mode, and this hazard was hidden.)
+{
+  const { DatabaseSync: _Sync } = await import('node:sqlite');
+  const _db = new _Sync(${JSON.stringify(dbPath)});
+  try { _db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch { /* DELETE mode → no-op */ }
+  _db.close();
+}
 const SQL = await sqlInit();
 const db = new SQL.Database(readFileSync(${JSON.stringify(dbPath)}));
-const out = { byNamespaceStatus: {}, integrity: null, ids: [], hasEmbedding: 0, migratedLearnings: { byStatus: {}, withEmbedding: 0, sampleKeys: [] }, epic1053: { docCount: 0, preambleChunkCount: 0 } };
+const out = { byNamespaceStatus: {}, integrity: null, ids: [], hasEmbedding: 0, migratedLearnings: { byStatus: {}, withEmbedding: 0, sampleKeys: [] }, epic1053: { docCount: 0, preambleChunkCount: 0 }, derivedSeedLeaks: {} };
 const res = db.exec("SELECT namespace, status, COUNT(*) FROM memory_entries GROUP BY namespace, status");
 if (res[0]) {
   for (const row of res[0].values) out.byNamespaceStatus[row[0]+'/'+row[1]] = row[2];
@@ -404,6 +419,17 @@ const docRes = db.exec("SELECT COUNT(*) FROM memory_entries WHERE key LIKE 'doc-
 if (docRes[0]) out.epic1053.docCount = docRes[0].values[0][0];
 const preambleRes = db.exec("SELECT COUNT(*) FROM memory_entries WHERE key LIKE 'chunk-%' AND (content LIKE '%[Context from previous section:]%' OR content LIKE '%[Context from next section:]%')");
 if (preambleRes[0]) out.epic1053.preambleChunkCount = preambleRes[0].values[0][0];
+// #1067: derived-namespace cherry-pick leak detection — count ONLY rows
+// whose ids carry the legacy seed prefix (\`populated-\${ns}-\${i}\`). The
+// launcher's pretrain pipeline legitimately writes its OWN pattern-* keys
+// into the patterns namespace post-upgrade (independent of auto_index),
+// so a raw "patterns is non-empty" check was unsound. Cherry-pick leaks
+// would surface as ids that match the seed pattern AND landed in
+// .moflo/moflo.db.
+const seedLeakRes = db.exec("SELECT substr(id, 11, instr(substr(id, 11), '-') - 1) AS ns, COUNT(*) FROM memory_entries WHERE id LIKE 'populated-%' AND namespace IN ('guidance','patterns','code-map','tests') GROUP BY ns");
+if (seedLeakRes[0]) {
+  for (const row of seedLeakRes[0].values) out.derivedSeedLeaks[row[0]] = row[1];
+}
 db.close();
 emit(out);
 `);
@@ -473,15 +499,25 @@ function assertDurableRowsPreserved(snapshot, expectedRows) {
 
 function assertDerivedRowsRegenerable(snapshot) {
   // #851 contract: derived namespaces (guidance, patterns, code-map, tests)
-  // do NOT survive cherry-pick, they regenerate from indexers. The harness
-  // disables auto_index for the populated profile (line ~244), so the post-
-  // launcher DB should have ZERO of these rows. Their absence is the
-  // positive signal that the cherry-pick is selective, not byte-copy.
+  // do NOT survive cherry-pick — they regenerate from indexers. moflo.yaml's
+  // auto_index gate skip-spawns the four script-based indexers, but the
+  // launcher's pretrain pipeline (NOT covered by auto_index) writes its own
+  // `pattern-*` keys into the patterns namespace based on the consumer's
+  // actual code surface. Those rows are legitimate post-upgrade output, not
+  // a cherry-pick leak.
+  //
+  // Pre-#1067 this asserted "namespace count == 0" and was masked by a sql.js-
+  // probe bug that left the seed DB empty: cherry-pick had nothing to copy,
+  // pretrain wrote zero rows on an empty corpus, and the assertion saw 0.
+  // Once the probe was fixed, pretrain produced its real output and the
+  // assertion fired a false positive. Re-scope: assert ONLY that rows with
+  // the legacy seed-key prefix (`populated-${ns}-${i}`) did NOT land in the
+  // post-state DB. Those would be the actual cherry-pick leak signal.
   const DERIVED_NAMESPACES = ['guidance', 'patterns', 'code-map', 'tests'];
   const offenders = [];
   for (const ns of DERIVED_NAMESPACES) {
-    const count = snapshot.byNamespaceStatus[`${ns}/active`] ?? 0;
-    if (count > 0) offenders.push(`${ns}=${count}`);
+    const seedLeak = snapshot.derivedSeedLeaks?.[ns] ?? 0;
+    if (seedLeak > 0) offenders.push(`${ns}=${seedLeak}`);
   }
   if (offenders.length === 0) {
     record('populated:derived-rows-not-cherry-picked', 'pass',

--- a/harness/consumer-smoke/lib/populated.mjs
+++ b/harness/consumer-smoke/lib/populated.mjs
@@ -367,6 +367,16 @@ function runLauncher(consumerDir) {
   // build-embeddings / hnsw-rebuild still run sequentially after them and
   // write to `.moflo/moflo.db`; if those land between assertion captures
   // the byte-stability checks flap.
+  //
+  // `quiesceLauncherBackground` kills entries in background-pids.json
+  // (indexer/pretrain/etc.) but NOT the daemon — the launcher spawns
+  // the daemon via `fireAndForget` which doesn't register it there.
+  // The daemon holds an open `node:sqlite` connection to moflo.db with
+  // pending WAL pages; `inspectPostStateDb`'s `readFileSync` would then
+  // see a main-file snapshot inconsistent with the WAL ("2nd reference
+  // to page N" + "Rowid out of order" in PRAGMA integrity_check — the
+  // Linux signature, #1067).
+  flo(consumerDir, ['daemon', 'stop'], { timeout: 15_000 });
   quiesceLauncherBackground(consumerDir);
   return r;
 }

--- a/harness/consumer-smoke/lib/sqlite-probe.mjs
+++ b/harness/consumer-smoke/lib/sqlite-probe.mjs
@@ -4,11 +4,12 @@
  * dir, runs it via `runNode`, parses the JSON its first stdout line emits,
  * and cleans up — this helper collapses that pattern.
  *
- * Phase 5 (#1084) — sql.js was removed from moflo's runtime; probes now use
- * Node's built-in `node:sqlite`. The PROBE_HARNESS preamble injects a thin
- * sql.js-shape adapter (`sqlInit()` resolves to a `SQL` object with
- * `Database`, `export()`, statement API) so existing probe bodies continue
- * to work without per-call rewrites.
+ * Engine is `node:sqlite` (Node ≥22; #1084 removed sql.js). The
+ * PROBE_HARNESS preamble below still exposes a thin sql.js-shape adapter
+ * (`sqlInit()` resolves to a `SQL` object with `Database`, `export()`,
+ * statement API) so existing probe bodies continue to work without
+ * per-call rewrites. File was named `sqljs-probe.mjs` prior to #1067 when
+ * the sql.js shimming was dropped from the moflo runtime.
  *
  * Probes write a single JSON line on the FIRST stdout line — the helper
  * tolerates loader chatter on later lines by parsing only the first.
@@ -128,44 +129,63 @@ function wrapDb(db, opts = {}) {
     },
     exec: (sql, params) => execAsRows(db, sql, params),
     export: () => {
-      // sql.js parity: serialise the whole DB as a Uint8Array. node:sqlite's
-      // \`DatabaseSync.prototype.serialize()\` (Node 22+) returns the same
-      // shape; if the path is known we can also just \`readFileSync\` it.
+      // sql.js parity: serialise the whole DB as a Uint8Array. Three strategies
+      // in priority order:
+      //   1. node:sqlite's \`DatabaseSync.prototype.serialize()\` — added in
+      //      Node v23.10. Returns Uint8Array directly. Node v22 (still the
+      //      CI baseline) lacks it.
+      //   2. File-backed probe — every Database() call (in-memory or load-
+      //      from-bytes) is now backed by a temp file (see sqlInit below).
+      //      Force a WAL checkpoint so any uncommitted pages flush to the
+      //      main file, then read it.
+      //   3. (Removed) The pre-#1067 fallback created an EMPTY DatabaseSync
+      //      at a new path and read it back, returning 0 bytes — silently
+      //      truncating every probe's export. That made the populated smoke
+      //      flag "0 rows lost" failures on Node v22 (no serialize()).
       const ser = db.serialize?.();
       if (ser instanceof Uint8Array) return ser;
       if (ser && typeof ser === 'object' && 'buffer' in ser) return new Uint8Array(ser);
-      if (path) return new Uint8Array(readFileSync(path));
-      // Last resort: dump to a temp file then read back.
-      const dir = mkdtempSync(join(tmpdir(), 'moflo-probe-'));
-      const tmp = join(dir, 'export.db');
-      const fileDb = new DatabaseSync(tmp);
-      // No clean way to copy across handles; fall back to backup pragma via SQL.
-      fileDb.close();
-      const bytes = new Uint8Array(readFileSync(tmp));
-      try { rmSync(dir, { recursive: true, force: true }); } catch {}
-      return bytes;
+      if (!path) {
+        throw new Error('export() requires a file-backed DatabaseSync — sqlInit() must always provide a path');
+      }
+      // Flush WAL pages back to the main file before readFileSync sees stale
+      // bytes. \`PASSIVE\` returns immediately if another connection holds
+      // a write transaction (none here — probes are single-process), and
+      // \`TRUNCATE\` resets the WAL file. \`FULL\` is the strongest checkpoint
+      // short of \`RESTART\` and is enough for the read-then-close sequence
+      // probe bodies use.
+      try { db.exec('PRAGMA wal_checkpoint(FULL)'); } catch { /* DELETE mode — no WAL */ }
+      return new Uint8Array(readFileSync(path));
     },
     close: () => db.close(),
   };
 }
 
 // sql.js-shape factory. Probes call \`await sqlInit()\` then \`new SQL.Database()\`
-// (in-memory) or \`new SQL.Database(bytes)\` (open from bytes). Match both forms.
+// (fresh DB) or \`new SQL.Database(bytes)\` (open from bytes). BOTH forms now
+// back the database with a temp file so \`export()\` always has somewhere
+// reliable to read from on Node versions that lack \`DatabaseSync.serialize()\`.
 async function sqlInit() {
   return {
     Database: function (bytes) {
+      const dir = mkdtempSync(join(tmpdir(), 'moflo-probe-'));
+      const path = join(dir, 'probe.db');
       if (bytes && bytes.length > 0) {
-        // sql.js's "load from bytes" path. node:sqlite needs a file path —
-        // dump the bytes to a temp file, open it, then keep the path so
-        // \`export()\` can re-read the file (incl. any subsequent writes).
-        const dir = mkdtempSync(join(tmpdir(), 'moflo-probe-load-'));
-        const path = join(dir, 'load.db');
+        // load-from-bytes path: drop the source bytes at \`path\` first, then
+        // open. Subsequent writes mutate the same file so \`export()\` sees
+        // both the original rows and any inserts.
         writeFileSync(path, Buffer.from(bytes));
-        const db = new DatabaseSync(path);
-        return wrapDb(db, { path });
       }
-      // In-memory probe — \`export()\` falls back to the temp-file shuffle.
-      return wrapDb(new DatabaseSync(':memory:'));
+      // For the fresh-DB path, DatabaseSync creates the file on open. Force
+      // DELETE journal mode so every commit syncs straight to the main file
+      // — WAL mode would leave inserts in \`probe.db-wal\` and \`readFileSync\`
+      // would dump a partial snapshot whose pages disagree with the WAL,
+      // failing downstream \`PRAGMA integrity_check\` runs ("2nd reference to
+      // page N", "Rowid out of order"). DELETE has no perf cost for these
+      // single-process write-then-read fixtures.
+      const db = new DatabaseSync(path);
+      try { db.exec('PRAGMA journal_mode = DELETE'); } catch { /* probe still functional in WAL */ }
+      return wrapDb(db, { path });
     },
   };
 }
@@ -176,14 +196,14 @@ function emit(value) {
 `;
 
 /**
- * Run a SQLite probe inline. The body has access to: `sqlInit` (the default
- * export from sql.js, an async initializer) and `emit(value)` which writes
- * the result as a single JSON line.
+ * Run a SQLite probe inline. The body has access to: `sqlInit` (an async
+ * initializer returning a sql.js-shape `SQL` object, backed by `node:sqlite`)
+ * and `emit(value)` which writes the result as a single JSON line.
  *
  * Returns the parsed JSON, or null on failure (failure is recorded under
  * `<label>:probe`).
  */
-export function runSqlJsProbe(consumerDir, label, body, runOpts = {}) {
+export function runSqliteProbe(consumerDir, label, body, runOpts = {}) {
   const probePath = join(consumerDir, `__${label}-probe.mjs`);
   writeFileSync(probePath, `${PROBE_HARNESS}\n${body}\n`);
   let result;

--- a/harness/consumer-smoke/run-populated.mjs
+++ b/harness/consumer-smoke/run-populated.mjs
@@ -37,6 +37,11 @@ const repoRoot = resolve(__dirname, '..', '..');
 // the consumer itself. See run.mjs for the full rationale.
 const workDir = join(tmpdir(), 'moflo-consumer-smoke-populated');
 
+// #1067 — pin env vars so local-dev (where Claude Code sets CLAUDE_PROJECT_DIR
+// and the dev daemon binds 3117) matches CI. See run.mjs for the full
+// rationale; CLAUDE_PROJECT_DIR is pinned in main() once consumerDir resolves.
+process.env.MOFLO_DAEMON_PORT = process.env.MOFLO_DAEMON_PORT || '3217';
+
 const argv = process.argv.slice(2);
 const opts = {
   skipPack: argv.includes('--skip-pack'),
@@ -61,6 +66,9 @@ async function main() {
       skipPack: opts.skipPack,
     });
     consumerDir = check.installConsumer({ workDir, tarballPath: tarball });
+
+    // #1067 — pin CLAUDE_PROJECT_DIR; see run.mjs for rationale.
+    process.env.CLAUDE_PROJECT_DIR = consumerDir;
 
     await runPopulatedConsumerProfile(consumerDir);
   } catch (err) {

--- a/harness/consumer-smoke/run.mjs
+++ b/harness/consumer-smoke/run.mjs
@@ -54,6 +54,30 @@ const repoRoot = resolve(__dirname, '..', '..');
 // the resolver can't accidentally walk up out of.
 const workDir = join(tmpdir(), 'moflo-consumer-smoke');
 
+// #1067 — pin two env vars BEFORE any subprocess spawns. Both flow through
+// `proc.mjs`'s `env: { ...process.env, ...(runOpts.env || {}) }` merge, so
+// every flo()/runNode() call (and the detached daemons they fork) inherits
+// the pinned values. Without these, local dev and CI diverge:
+//
+//   * CLAUDE_PROJECT_DIR is set by Claude Code sessions to the moflo repo
+//     root. findProjectRoot() honors it, so consumer subprocesses resolve
+//     project-root to the moflo repo instead of the tmpdir consumer dir.
+//     CI doesn't set the var, so the divergence is invisible until a local
+//     smoke run silently writes to the wrong DB.
+//
+//   * MOFLO_DAEMON_PORT defaults to 3117 in daemon-write-client.ts. Locally,
+//     the SessionStart-spawned dev daemon already binds 3117, so the
+//     consumer's `flo daemon start` falls back to 3118 while clients still
+//     POST to 3117 → wrong-DB writes. Pinning an isolated port (3217 — well
+//     outside the dev daemon's fallback range) makes the consumer daemon
+//     bind there (daemon.ts honors this env post-#1067) AND makes clients
+//     route there. One env contract, no asymmetry.
+//
+// Values are set on this process's env so the existing env-merge in proc.mjs
+// propagates them — no per-callsite plumbing required. CLAUDE_PROJECT_DIR is
+// pinned in main() once installConsumer() returns the resolved path.
+process.env.MOFLO_DAEMON_PORT = process.env.MOFLO_DAEMON_PORT || '3217';
+
 const argv = process.argv.slice(2);
 const opts = {
   skipPack: argv.includes('--skip-pack'),
@@ -80,6 +104,12 @@ async function main() {
       skipPack: opts.skipPack,
     });
     consumerDir = check.installConsumer({ workDir, tarballPath: tarball });
+
+    // #1067 — pin CLAUDE_PROJECT_DIR to the consumer dir. findProjectRoot()
+    // honors this env var ahead of the marker walk, so without pinning, a
+    // Claude Code session's CLAUDE_PROJECT_DIR=<moflo-repo> leaks into every
+    // consumer subprocess and resolves project-root to the moflo source repo.
+    process.env.CLAUDE_PROJECT_DIR = consumerDir;
 
     const checks = [
       // #1088 broken-window gate — must run FIRST. If the consumer dir isn't

--- a/src/cli/__tests__/commands/daemon-port-resolution.test.ts
+++ b/src/cli/__tests__/commands/daemon-port-resolution.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for `resolveDashboardPort` — the port precedence helper used by
+ * `flo daemon start`. Verifies the asymmetry fix for #1067: the daemon server
+ * now honors `MOFLO_DAEMON_PORT` env, matching `daemon-write-client.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveDashboardPort } from '../../commands/daemon.js';
+import { DEFAULT_DASHBOARD_PORT } from '../../services/daemon-dashboard.js';
+
+describe('resolveDashboardPort (#1067)', () => {
+  it('returns DEFAULT_DASHBOARD_PORT when neither flag nor env is set', () => {
+    const r = resolveDashboardPort(undefined, undefined);
+    expect(r).toEqual({ ok: true, port: DEFAULT_DASHBOARD_PORT });
+  });
+
+  it('honors MOFLO_DAEMON_PORT env when --dashboard-port flag is absent', () => {
+    const r = resolveDashboardPort(undefined, '3217');
+    expect(r).toEqual({ ok: true, port: 3217 });
+  });
+
+  it('--dashboard-port flag wins over MOFLO_DAEMON_PORT env', () => {
+    const r = resolveDashboardPort('4000', '3217');
+    expect(r).toEqual({ ok: true, port: 4000 });
+  });
+
+  it('rejects invalid --dashboard-port flag value', () => {
+    const r = resolveDashboardPort('not-a-number', undefined);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('dashboard port');
+  });
+
+  it('rejects invalid MOFLO_DAEMON_PORT env value with the env label', () => {
+    const r = resolveDashboardPort(undefined, 'abc');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('MOFLO_DAEMON_PORT');
+  });
+
+  it('rejects out-of-range port (0)', () => {
+    const r = resolveDashboardPort('0', undefined);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects out-of-range port (65536)', () => {
+    const r = resolveDashboardPort('65536', undefined);
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts port 1 and 65535 (range edges)', () => {
+    expect(resolveDashboardPort('1', undefined)).toEqual({ ok: true, port: 1 });
+    expect(resolveDashboardPort('65535', undefined)).toEqual({ ok: true, port: 65535 });
+  });
+});

--- a/src/cli/__tests__/memory/bridge-add-to-hnsw-preserves-metadata.test.ts
+++ b/src/cli/__tests__/memory/bridge-add-to-hnsw-preserves-metadata.test.ts
@@ -1,0 +1,182 @@
+/**
+ * #1067 regression — bridgeAddToHNSW must NOT clobber the row's metadata.
+ *
+ * Pre-#1067 the function used `INSERT OR REPLACE INTO memory_entries (...)` with
+ * only the embedding-related columns, which silently reset every other column
+ * (metadata, tags, expires_at, access_count) to NULL/default. When
+ * `storeEntry`'s direct-write fallback ran for the first row in a fresh DB —
+ * inserting metadata first, then calling `addToHNSWIndex` which routes to
+ * `bridgeAddToHNSW` — the REPLACE wiped the JSON the writer had just persisted.
+ * Chunk-traversal smoke saw "neighbors without navigation" for the first chunk
+ * only; subsequent chunks were unaffected because they hit a different routing
+ * path that didn't call `bridgeAddToHNSW`.
+ *
+ * Post-#1067 `bridgeAddToHNSW` UPDATEs the embedding columns by id and only
+ * falls back to INSERT when the row genuinely doesn't exist yet.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  _resetProjectRootForTest,
+  shutdownBridge,
+} from '../../memory/bridge-core.js';
+import { bridgeStoreEntry, bridgeAddToHNSW } from '../../memory/memory-bridge.js';
+
+describe('bridgeAddToHNSW metadata preservation (#1067)', () => {
+  let tempDir: string;
+  let projectRoot: string;
+  let dbPath: string;
+  let originalCwd: string;
+  let originalProjectDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), 'moflo-1067-hnsw-'));
+    projectRoot = tempDir;
+    fs.mkdirSync(path.join(projectRoot, '.moflo'), { recursive: true });
+    dbPath = path.join(projectRoot, '.moflo', 'moflo.db');
+
+    originalCwd = process.cwd();
+    originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = projectRoot;
+    process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+
+    await shutdownBridge();
+    _resetProjectRootForTest();
+  });
+
+  afterEach(async () => {
+    await shutdownBridge();
+    _resetProjectRootForTest();
+    if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+    delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+    try { process.chdir(originalCwd); } catch { /* ignore */ }
+    try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('preserves metadata when called for a row that already exists', async () => {
+    const chunkMetadata = {
+      type: 'chunk',
+      parentDoc: 'doc-foo',
+      parentPath: '/foo.md',
+      chunkIndex: 0,
+      totalChunks: 3,
+      prevChunk: null,
+      nextChunk: 'chunk-foo-1',
+      siblings: ['chunk-foo-0', 'chunk-foo-1', 'chunk-foo-2'],
+      hierarchicalParent: null,
+      hierarchicalChildren: null,
+      chunkTitle: 'Chunk 0',
+      headerLevel: 2,
+    };
+
+    // Phase 1: bridge persists a row carrying chunk metadata — mirrors what
+    // a memory_store call with metadata does.
+    const storeResult = await bridgeStoreEntry({
+      key: 'chunk-foo-0',
+      value: 'chunk body 0',
+      namespace: 'ns-1067',
+      tags: [],
+      metadata: chunkMetadata,
+      upsert: true,
+    });
+    expect(storeResult).not.toBeNull();
+    expect(storeResult?.success).toBe(true);
+
+    const rowId = storeResult!.id;
+
+    // Phase 2: addToHNSWIndex routes here for the same id when the
+    // direct-write fallback runs (the #1067 trigger).
+    const hnswResult = await bridgeAddToHNSW(
+      rowId,
+      Array.from({ length: 8 }, (_, i) => i / 10),
+      { id: rowId, key: 'chunk-foo-0', namespace: 'ns-1067', content: 'chunk body 0' },
+    );
+    expect(hnswResult).toBe(true);
+
+    // Phase 3: assert the row's metadata column still carries the chunk JSON.
+    // Direct sql probe bypasses the bridge cache so we read what's actually
+    // on disk.
+    const probeDb = new DatabaseSync(dbPath);
+    try {
+      const row = probeDb.prepare(
+        'SELECT metadata FROM memory_entries WHERE id = ?',
+      ).get(rowId) as { metadata: string | null } | undefined;
+
+      expect(row).toBeDefined();
+      expect(row?.metadata).toBeTruthy();
+      const parsed = JSON.parse(row!.metadata!);
+      expect(parsed.type).toBe('chunk');
+      expect(parsed.parentDoc).toBe('doc-foo');
+      expect(parsed.nextChunk).toBe('chunk-foo-1');
+      expect(parsed.siblings).toEqual(['chunk-foo-0', 'chunk-foo-1', 'chunk-foo-2']);
+    } finally {
+      probeDb.close();
+    }
+  });
+
+  it('preserves tags when called for a row that already exists', async () => {
+    // Same shape as the metadata case — make sure the UPDATE-by-id fix
+    // didn't fall back to a column-stripping path for any neighboring column.
+    const storeResult = await bridgeStoreEntry({
+      key: 'tagged-row',
+      value: 'tagged content',
+      namespace: 'ns-1067',
+      tags: ['alpha', 'beta'],
+      upsert: true,
+    });
+    expect(storeResult?.success).toBe(true);
+    const rowId = storeResult!.id;
+
+    await bridgeAddToHNSW(
+      rowId,
+      [0.1, 0.2, 0.3],
+      { id: rowId, key: 'tagged-row', namespace: 'ns-1067', content: 'tagged content' },
+    );
+
+    const probeDb = new DatabaseSync(dbPath);
+    try {
+      const row = probeDb.prepare(
+        'SELECT tags FROM memory_entries WHERE id = ?',
+      ).get(rowId) as { tags: string | null } | undefined;
+      const parsed = row?.tags ? JSON.parse(row.tags) : null;
+      expect(parsed).toEqual(['alpha', 'beta']);
+    } finally {
+      probeDb.close();
+    }
+  });
+
+  it('back-fills via INSERT when no row exists for the id (rebuild path)', async () => {
+    // This is the "first time we see this id" fallback the function still
+    // needs to support — e.g. an HNSW rebuilder feeding rows that never went
+    // through storeEntry. The result is a row without metadata (caller
+    // didn't supply it), but the row exists and is searchable.
+    const orphanId = `entry_orphan_${Date.now()}`;
+    const result = await bridgeAddToHNSW(
+      orphanId,
+      [0.5, 0.5, 0.5],
+      { id: orphanId, key: 'orphan-row', namespace: 'ns-1067', content: 'rebuilt' },
+    );
+    expect(result).toBe(true);
+
+    const probeDb = new DatabaseSync(dbPath);
+    try {
+      const row = probeDb.prepare(
+        'SELECT key, namespace, content, metadata FROM memory_entries WHERE id = ?',
+      ).get(orphanId) as { key: string; namespace: string; content: string; metadata: string | null } | undefined;
+      expect(row?.key).toBe('orphan-row');
+      expect(row?.namespace).toBe('ns-1067');
+      expect(row?.content).toBe('rebuilt');
+      // metadata wasn't supplied to bridgeAddToHNSW — column is NULL, NOT
+      // the literal string "null" (the pre-fix bug fingerprint).
+      expect(row?.metadata).toBeNull();
+    } finally {
+      probeDb.close();
+    }
+  });
+});

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -19,6 +19,35 @@ import { join, resolve, isAbsolute } from 'path';
 import * as fs from 'fs';
 import { errorDetail } from '../shared/utils/error-detail.js';
 
+/**
+ * Resolve the dashboard port from CLI flag and env, in that precedence order.
+ *
+ * Precedence (highest first):
+ *   1. `--dashboard-port` flag (explicit caller intent)
+ *   2. `MOFLO_DAEMON_PORT` env (shared contract with `daemon-write-client.ts`)
+ *   3. `DEFAULT_DASHBOARD_PORT` (3117)
+ *
+ * The env fallback (#1067) eliminates the client/server asymmetry: prior to
+ * this, the client honored `MOFLO_DAEMON_PORT` but the server only read
+ * `--dashboard-port`. A consumer pinning the env (e.g. the smoke harness)
+ * would point clients at one port while the server bound the default.
+ *
+ * Exported for unit testing — the command handler calls this once per start.
+ */
+export function resolveDashboardPort(
+  flagValue: string | undefined,
+  envValue: string | undefined,
+): { ok: true; port: number } | { ok: false; error: string } {
+  const source = flagValue ?? envValue;
+  if (!source) return { ok: true, port: DEFAULT_DASHBOARD_PORT };
+  const parsed = parseInt(source, 10);
+  if (isNaN(parsed) || parsed < 1 || parsed > 65535) {
+    const label = flagValue ? 'dashboard port' : 'MOFLO_DAEMON_PORT';
+    return { ok: false, error: `Invalid ${label}: ${source} (must be 1-65535)` };
+  }
+  return { ok: true, port: parsed };
+}
+
 // Start daemon subcommand
 const startCommand: Command = {
   name: 'start',
@@ -49,16 +78,13 @@ const startCommand: Command = {
     const projectRoot = process.cwd();
     const isDaemonProcess = process.env.CLAUDE_FLOW_DAEMON === '1';
 
-    // Parse dashboard port
-    let dashboardPort = DEFAULT_DASHBOARD_PORT;
-    if (rawDashboardPort) {
-      const parsed = parseInt(rawDashboardPort, 10);
-      if (isNaN(parsed) || parsed < 1 || parsed > 65535) {
-        output.printError(`Invalid dashboard port: ${rawDashboardPort} (must be 1-65535)`);
-        return { success: false, exitCode: 1 };
-      }
-      dashboardPort = parsed;
+    // Resolve dashboard port; see `resolveDashboardPort` for precedence.
+    const portResult = resolveDashboardPort(rawDashboardPort, process.env.MOFLO_DAEMON_PORT);
+    if (!portResult.ok) {
+      output.printError(portResult.error);
+      return { success: false, exitCode: 1 };
     }
+    const dashboardPort = portResult.port;
 
     // Parse resource threshold overrides from CLI flags
     const config: Partial<DaemonConfig> = {};

--- a/src/cli/memory/memory-bridge.ts
+++ b/src/cli/memory/memory-bridge.ts
@@ -194,17 +194,50 @@ export async function bridgeAddToHNSW(
     // Bridge-produced vectors come from getBridgeEmbedder() (fastembed, 384-dim).
     // Pre-#648 this column was hardcoded to 'Xenova/all-MiniLM-L6-v2' which
     // misrepresented the producing model — fixed to the canonical bridge label.
-    ctx.db.prepare(`
-      INSERT OR REPLACE INTO memory_entries (
-        id, key, namespace, content, type,
-        embedding, embedding_dimensions, embedding_model,
-        created_at, updated_at, status
-      ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, 'active')
+    //
+    // Pre-#1067: this issued `INSERT OR REPLACE INTO memory_entries (...)` with
+    // only the embedding-related columns. When `storeEntry`'s direct-write
+    // fallback first inserted a row carrying `metadata`/`tags`/`expires_at`
+    // and then called `addToHNSWIndex(...)` for the same id, REPLACE clobbered
+    // the row — wiping the metadata column to NULL and re-introducing the
+    // "first chunk has no navigation" smoke failure even though serialiseMetadata
+    // produced the right JSON one statement earlier. UPDATE-by-id preserves the
+    // pre-existing row's metadata/tags/expires_at/access_count while still
+    // back-filling embedding columns for callers that supplied them.
+    const updated = ctx.db.prepare(`
+      UPDATE memory_entries
+         SET embedding = ?,
+             embedding_dimensions = ?,
+             embedding_model = ?,
+             updated_at = ?
+       WHERE id = ?
     `).run([
-      id, entry.key, entry.namespace, entry.content,
       embeddingJson, embedding.length, BRIDGE_EMBEDDING_MODEL,
-      now, now,
+      now, id,
     ]);
+
+    // If no row was matched by id (rare: a rebuild path passing an embedding
+    // for a key that never went through storeEntry first) fall back to an
+    // INSERT carrying every column the bridge can populate, so the row still
+    // becomes searchable. Metadata/tags/expires_at stay NULL because the
+    // caller didn't supply them — same shape `bridgeStoreEntry` would write
+    // for a no-metadata caller.
+    const rowCount = typeof (updated as { changes?: number }).changes === 'number'
+      ? (updated as { changes: number }).changes
+      : ((ctx.db as { getRowsModified?: () => number }).getRowsModified?.() ?? 0);
+    if (rowCount === 0) {
+      ctx.db.prepare(`
+        INSERT INTO memory_entries (
+          id, key, namespace, content, type,
+          embedding, embedding_dimensions, embedding_model,
+          created_at, updated_at, status
+        ) VALUES (?, ?, ?, ?, 'semantic', ?, ?, ?, ?, ?, 'active')
+      `).run([
+        id, entry.key, entry.namespace, entry.content,
+        embeddingJson, embedding.length, BRIDGE_EMBEDDING_MODEL,
+        now, now,
+      ]);
+    }
     persistBridgeDb(ctx.db, dbPath);
     return true;
   });


### PR DESCRIPTION
## Summary

- Pin `CLAUDE_PROJECT_DIR` + `MOFLO_DAEMON_PORT` in the consumer smoke harness so local-dev (Claude Code session + dev daemon on 3117) produces the same pass/fail signal as CI.
- Teach `daemon.ts#resolveDashboardPort` to honor `MOFLO_DAEMON_PORT` env as a fallback when no `--dashboard-port` flag is passed, closing the asymmetry with `daemon-write-client.ts`.
- Repair `bridgeAddToHNSW`'s `INSERT OR REPLACE` that was wiping `metadata`/`tags`/`expires_at` on existing rows -- surfaced by the env-pin fix and turned out to be the long-standing root cause of "first chunk has no navigation" in smoke.
- Codify the diagnostic-first investigation practice in `testing-conventions.md` § 13 with #1067 as the worked example.

## What was broken

Even after #1091 moved the consumer fixture to `os.tmpdir()`, two env-borne divergences leaked through:

1. **`CLAUDE_PROJECT_DIR` leaked** from the dev session via `proc.mjs`'s `env: { ...process.env, ... }` merge. `findProjectRoot()` honors the env ahead of the marker walk, so consumer subprocesses resolved project-root to the moflo source tree and wrote to the wrong DB. CI didn't set the var, so the bug was invisible.
2. **Port-3117 client/server asymmetry.** `daemon-write-client.ts#getDaemonPort` honored `MOFLO_DAEMON_PORT`, but `daemon.ts` server start only honored `--dashboard-port`. Dev daemon held 3117; consumer's `flo daemon start` walked the fallback range (3118, 3119, ...); consumer writers still defaulted to 3117 -> wrong-DB writes.

## Fix shape

- `harness/consumer-smoke/run{,-populated}.mjs` mutate `process.env.CLAUDE_PROJECT_DIR = consumerDir` and `process.env.MOFLO_DAEMON_PORT = '3217'`. Values propagate to every subprocess via the existing env merge -- no per-callsite plumbing.
- `src/cli/commands/daemon.ts` extracts `resolveDashboardPort(flag, env)` so the server reads `MOFLO_DAEMON_PORT` as a fallback. One env contract for both sides of the daemon RPC.
- Port 3217 sits outside `daemon-dashboard.ts`'s `MAX_PORT_ATTEMPTS` fallback range from 3117, so a parallel local smoke can't collide.

## Bonus repair surfaced by the env pin

Once the env pins were in place, smoke surfaced a NEW failure that had been masked by the previous one: `memory-protocol:get-neighbors` reported "neighbors without navigation field". Diagnostic-first investigation: per-neighbor diag -> only chunk-smoke-foo-0 missing nav -> per-key memory_retrieve -> same row retrievable but navigation:null -> raw SELECT metadata -> disk held literal string \`\"null\"\`, not the JSON the writer fed in.

Root cause: `bridgeAddToHNSW` did `INSERT OR REPLACE INTO memory_entries (...)` with only embedding-related columns. When `storeEntry`'s direct-write fallback inserted a row with metadata and then called `addToHNSWIndex` -> `bridgeAddToHNSW` for the same id, REPLACE wiped `metadata`/`tags`/`expires_at`. Subsequent writes hit a different routing path that never called bridgeAddToHNSW, which is why only the first chunk failed.

Switched to `UPDATE memory_entries SET embedding = ?, ... WHERE id = ?` (preserving every non-embedding column) with an INSERT fallback for the genuine "no row exists yet" rebuild path.

## Tests

- `src/cli/__tests__/commands/daemon-port-resolution.test.ts` -- 8 cases covering precedence (flag > env > default), error labels, range edges.
- `src/cli/__tests__/memory/bridge-add-to-hnsw-preserves-metadata.test.ts` -- 3 cases: metadata preserved on existing row, tags preserved on existing row, INSERT fallback for orphan id (rebuild path).
- Consumer smoke: 48 pass + 1 fail -> **49 pass + 0 fail** (confirmed locally with the dev daemon up on 3117).

## Diagnostic-first practice codified

`.claude/guidance/internal/testing-conventions.md` § 13 -- "Measure Twice, Cut Once -- Diagnose Before You Fix". Don't guess; pinpoint with a test or diagnostic that proves what's wrong, then fix only what the evidence indicts. The smoke probe's failure record now retains per-neighbor diagnostic data so a future regression surfaces *which* row failed, not just "some neighbor missing nav".

## Test plan

- [ ] `npm run build` -- clean
- [ ] `npx vitest run src/cli/__tests__/memory/ src/cli/__tests__/commands/daemon-port-resolution.test.ts` -- 93 tests pass
- [ ] `npm run test:smoke` (local, with dev daemon up on 3117) -- 49 pass, 0 fail
- [ ] CI smoke matches local smoke
- [ ] No new lint or typecheck failures

Closes #1067.

Co-Authored-By: moflo <noreply@motailz.com>