### PR TITLE
fix(1086): skip Windows daemon OS-introspection in tests

### DIFF
--- a/src/cli/services/daemon-lock.ts
+++ b/src/cli/services/daemon-lock.ts
@@ -276,13 +276,9 @@ function isProcessAlive(pid: number): boolean {
  * to avoid accidentally allowing duplicates on exotic platforms.
  */
 export function isDaemonProcess(pid: number): boolean {
-  // #1086: in test mode, skip OS-introspection (Windows runs `tasklist`
-  // 3s timeout + `powershell Get-CimInstance` 5s timeout — combined worst
-  // case 8s, which exceeds vitest's 5s per-test budget under parallel-suite
-  // contention). Liveness is already verified separately by callers via
-  // `process.kill(pid, 0)`; this function only filters non-daemon processes
-  // that happen to share the PID, and tests write `process.pid` into the
-  // lock so trusting it is correct. Production never sets this env var.
+  // #1086: Windows execSync introspection (8s worst-case: tasklist 3s +
+  // powershell 5s) starves under parallel vitest workers and pushes tests
+  // past the 5s budget. Production never sets this env var.
   if (process.env.MOFLO_TEST_TRUST_DAEMON_PID === '1') {
     return true;
   }

--- a/src/cli/services/daemon-lock.ts
+++ b/src/cli/services/daemon-lock.ts
@@ -276,6 +276,16 @@ function isProcessAlive(pid: number): boolean {
  * to avoid accidentally allowing duplicates on exotic platforms.
  */
 export function isDaemonProcess(pid: number): boolean {
+  // #1086: in test mode, skip OS-introspection (Windows runs `tasklist`
+  // 3s timeout + `powershell Get-CimInstance` 5s timeout — combined worst
+  // case 8s, which exceeds vitest's 5s per-test budget under parallel-suite
+  // contention). Liveness is already verified separately by callers via
+  // `process.kill(pid, 0)`; this function only filters non-daemon processes
+  // that happen to share the PID, and tests write `process.pid` into the
+  // lock so trusting it is correct. Production never sets this env var.
+  if (process.env.MOFLO_TEST_TRUST_DAEMON_PID === '1') {
+    return true;
+  }
   try {
     if (process.platform === 'win32') {
       return isDaemonProcessWindows(pid);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -26,10 +26,22 @@ import './src/cli/memory/suppress-sqlite-warning.js';
 // Set once at module load (every test file imports this setup).
 process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
 
+// #1086 — skip the Windows tasklist/powershell daemon-introspection chain
+// in tests. The two execSync calls (3s + 5s timeouts) inside isDaemonProcess
+// can starve under parallel-suite contention and push daemon-lock-reading
+// tests past vitest's 5s per-test budget. Tests that write `process.pid`
+// into a synthetic `daemon.lock` rely on this trust to verify the
+// version-skew / payload-read logic without depending on OS introspection
+// surviving load. Production never sets this env var.
+process.env.MOFLO_TEST_TRUST_DAEMON_PID = '1';
+
 // Re-set in `beforeEach` so a test that intentionally cleared it for a
 // routing scenario doesn't bleed into the next test.
 beforeEach(() => {
   if (process.env.MOFLO_DISABLE_DAEMON_ROUTING !== '1') {
     process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+  }
+  if (process.env.MOFLO_TEST_TRUST_DAEMON_PID !== '1') {
+    process.env.MOFLO_TEST_TRUST_DAEMON_PID = '1';
   }
 });


### PR DESCRIPTION
## Summary

Closes #1086. `doctor-version-skew.test.ts` was flaking 1-3/5 tests under `node scripts/test-runner.mjs` while passing 5/5 in isolation.

## Root cause (not what the issue guessed)

#1086 hypothesised `findProjectRoot` escaping the test's `tmpDir`. Wrong — `getDaemonLockPayload(projectRoot)` takes the root directly with no walk. Capturing the actual failure showed `Test timed out in 5000ms`, not an assertion mismatch.

The real cause: `isDaemonProcessWindows` chains `execSync('tasklist ...', { timeout: 3000 })` + `execSync('powershell Get-CimInstance ...', { timeout: 5000 })` — worst-case 8s. Under parallel-suite contention these external-process spawns starve and exceed vitest's 5s per-test budget.

## Fix

Env-var escape hatch `MOFLO_TEST_TRUST_DAEMON_PID=1` short-circuits `isDaemonProcess` to `true`. Liveness is still verified separately by callers via `process.kill(pid, 0)`; `isDaemonProcess` only filtered non-daemon processes sharing the PID, and tests write `process.pid` into the synthetic lock so trusting it is correct. Set globally in `vitest.setup.ts` (same pattern as the existing `MOFLO_DISABLE_DAEMON_ROUTING`). Production never sets the var.

18 lines, no production behaviour change.

## /flo-simplify findings actioned

- Trimmed 8-line comment in `daemon-lock.ts` to 3 lines per the project's "WHY-only" rule (commit 2).
- Reviewer flagged: PID-recycling test coverage was already absent before this PR (existing tests acknowledge the gap at `daemon-lock.test.ts:94-98`); env var makes the gap explicit but doesn't widen it. Parallel suite is the drift guard for the env-var contract — adding a unit test would just re-validate what the parallel suite already proves. Out of scope for #1086.

## Test plan

- [x] `npx vitest run src/cli/__tests__/commands/doctor-version-skew.test.ts src/cli/__tests__/services/daemon-lock.test.ts` — 28/28 in 467ms (was ~4s pre-fix for version-skew alone due to the Windows OS-introspection chain)
- [x] `node scripts/test-runner.mjs` (full parallel suite) — doctor-version-skew clean, run #1
- [x] `node scripts/test-runner.mjs` (full parallel suite) — doctor-version-skew clean, run #2
- [x] `npm run build` — clean
- [x] `/flo-simplify` — SMALL tier, 1 sonnet reviewer; one finding actioned (comment trim)

## Pre-existing flakes (not caused by this PR, surfaced during verification)

These flaked across the two pre-fix and two post-fix parallel runs — separate from #1086, worth tracking under broken-window:

- `tests/bin/simplify-classify.test.ts > falls back to init.defaultBranch when origin/HEAD is missing`
- `tests/bin/gate-swarm-mandatory-952.test.ts`
- `tests/system/auth-error-recovery-e2e.test.ts > stale token → confirm → fresh token → retry succeeds`
- `src/cli/__tests__/spells/auth-error-runner.test.ts` (2 tests)
- `tests/bin/process-manager-stress.test.ts > full lifecycle ... 0 orphans`

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)