### PR TITLE
fix(1093): collapse flaky-under-load test contention at the source

### DIFF
--- a/bin/simplify-classify.cjs
+++ b/bin/simplify-classify.cjs
@@ -45,34 +45,55 @@ const SECURITY_PATHS = [
   /(?:^|[\\\/])\.claude[\\\/]helpers[\\\/]gate/i,
 ];
 
-function safeExec(cmd) {
-  try { return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }); }
-  catch { return ''; }
+function safeExec(cmd, opts) {
+  try {
+    return execSync(cmd, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(opts && opts.cwd ? { cwd: opts.cwd } : {}),
+    });
+  } catch { return ''; }
 }
 
 // Detect the consumer's default branch. Hardcoding 'main' silently miscalibrates
 // classification on repos that use 'master', 'develop', etc. — empty diff →
 // TRIVIAL → gate stamps clean without any real review.
 let _cachedDefaultBranch = null;
-function detectDefaultBranch() {
-  if (_cachedDefaultBranch !== null) return _cachedDefaultBranch;
+function detectDefaultBranch(cwd) {
+  // Cache by cwd so tests probing multiple repos in-process don't return a
+  // single stale value; CLI use passes no cwd and benefits from the cache.
+  if (cwd === undefined && _cachedDefaultBranch !== null) return _cachedDefaultBranch;
+  const opts = cwd ? { cwd } : undefined;
 
   // Preferred: origin/HEAD points to whatever the remote considers default.
-  const symbolic = safeExec('git symbolic-ref --short refs/remotes/origin/HEAD').trim();
-  if (symbolic.startsWith('origin/')) return (_cachedDefaultBranch = symbolic.slice('origin/'.length));
+  const symbolic = safeExec('git symbolic-ref --short refs/remotes/origin/HEAD', opts).trim();
+  if (symbolic.startsWith('origin/')) {
+    const v = symbolic.slice('origin/'.length);
+    if (cwd === undefined) _cachedDefaultBranch = v;
+    return v;
+  }
 
   // Fallback: local init.defaultBranch (set by `git init -b <name>` or config).
-  const configured = safeExec('git config --get init.defaultBranch').trim();
-  if (configured) return (_cachedDefaultBranch = configured);
+  const configured = safeExec('git config --get init.defaultBranch', opts).trim();
+  if (configured) {
+    if (cwd === undefined) _cachedDefaultBranch = configured;
+    return configured;
+  }
 
   // Last resort: 'main' (most common modern default).
-  return (_cachedDefaultBranch = 'main');
+  if (cwd === undefined) _cachedDefaultBranch = 'main';
+  return 'main';
 }
 
-function readDiffFromGit(base) {
+function _resetCacheForTest() {
+  _cachedDefaultBranch = null;
+}
+
+function readDiffFromGit(base, cwd) {
+  const opts = cwd ? { cwd } : undefined;
   // Combined diff: committed-since-base + working-tree
-  const committed = safeExec(`git diff ${base}...HEAD`);
-  const working = safeExec('git diff HEAD');
+  const committed = safeExec(`git diff ${base}...HEAD`, opts);
+  const working = safeExec('git diff HEAD', opts);
   return committed + (working ? '\n' + working : '');
 }
 
@@ -206,9 +227,9 @@ function classifyDiff(diffText) {
   return decide(parseDiff(diffText));
 }
 
-function classifyFromGit(base) {
-  const resolved = base || detectDefaultBranch();
-  return classifyDiff(readDiffFromGit(resolved));
+function classifyFromGit(base, cwd) {
+  const resolved = base || detectDefaultBranch(cwd);
+  return classifyDiff(readDiffFromGit(resolved, cwd));
 }
 
 if (require.main === module) {
@@ -232,4 +253,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { parseDiff, decide, classifyDiff, classifyFromGit, detectDefaultBranch };
+module.exports = { parseDiff, decide, classifyDiff, classifyFromGit, detectDefaultBranch, _resetCacheForTest };

--- a/src/cli/__tests__/spells/auth-error-runner.test.ts
+++ b/src/cli/__tests__/spells/auth-error-runner.test.ts
@@ -16,7 +16,7 @@
  * test/host hook added alongside the recovery code.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import { SpellCaster } from '../../spells/core/runner.js';
 import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
 import type {
@@ -124,10 +124,35 @@ function spellWithoutCredPrereq(stepType: string): SpellDefinition {
 // Setup
 // ============================================================================
 
+// #1093: hoist the registry AND warm the runner pipeline in beforeAll. The
+// first SpellCaster.run() in a fresh process pays a ~500 ms cold-start tax —
+// platform-sandbox detection, validator, prereq-checker, step-executor, etc.
+// all wake up. Those caches (_cachedDetection in platform-sandbox.ts) persist
+// for the rest of the file, so subsequent tests run in <2 ms. The warm-up
+// pays that tax inside beforeAll (default 10 s ceiling) instead of inside the
+// first test (5 s ceiling), which under fork contention is what tipped the
+// first test over the line.
 let registry: StepCommandRegistry;
 
-beforeEach(() => {
+beforeAll(async () => {
   registry = new StepCommandRegistry();
+
+  const warmCmd: StepCommand = {
+    type: '__warmup__',
+    description: 'pre-warm sandbox detection + runner pipeline',
+    configSchema: { type: 'object' as const },
+    validate: () => ({ valid: true, errors: [] }),
+    async execute() { return { success: true, data: {}, duration: 0 }; },
+    describeOutputs: () => [],
+  };
+  registry.register(warmCmd);
+  const warmRunner = new SpellCaster(registry, makeMockCredentials(), makeMemory());
+  await warmRunner.run({ name: 'warmup', steps: [{ id: 'w', type: '__warmup__', config: {} }] }, {});
+  registry.clear();
+});
+
+afterEach(() => {
+  registry.clear();
 });
 
 // ============================================================================

--- a/tests/bin/simplify-classify.test.ts
+++ b/tests/bin/simplify-classify.test.ts
@@ -18,7 +18,14 @@ import { execFileSync, execSync } from 'child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
-import { parseDiff, decide, classifyDiff, detectDefaultBranch } from '../../bin/simplify-classify.cjs';
+import {
+  parseDiff,
+  decide,
+  classifyDiff,
+  classifyFromGit,
+  detectDefaultBranch,
+  _resetCacheForTest,
+} from '../../bin/simplify-classify.cjs';
 
 const CLASSIFIER = resolve(__dirname, '../../bin/simplify-classify.cjs');
 
@@ -306,7 +313,12 @@ describe('simplify-classify: decide() boundary cases', () => {
 });
 
 describe('simplify-classify: end-to-end CLI invocation', () => {
-  it('CLI returns JSON with the expected shape', () => {
+  // Single subprocess smoke — verifies the binary parses stdin, emits valid JSON,
+  // and routes through classifyDiff. The shape variants (trivial/normal/security)
+  // are covered by the pure-logic block above; spawning a node child per shape
+  // adds subprocess-startup cost without unique coverage and was the main source
+  // of #1093 timeouts under fork contention.
+  it('CLI returns JSON with the expected shape (smoke)', () => {
     const decision = runClassifier(mechanicalDecompositionDiff());
     expect(decision).toMatchObject({
       tier: 'SMALL',
@@ -316,18 +328,6 @@ describe('simplify-classify: end-to-end CLI invocation', () => {
     expect(Array.isArray(decision.reasoning)).toBe(true);
     expect(decision.stats).toBeDefined();
   });
-
-  it('CLI handles trivial diff', () => {
-    const decision = runClassifier(trivialTypoDiff());
-    expect(decision.tier).toBe('TRIVIAL');
-    expect(decision.agentCount).toBe(0);
-  });
-
-  it('CLI handles large diff', () => {
-    const decision = runClassifier(largeNewLogicDiff());
-    expect(decision.tier).toBe('NORMAL');
-    expect(decision.agentCount).toBe(3);
-  });
 });
 
 describe('simplify-classify: default-branch detection', () => {
@@ -335,6 +335,11 @@ describe('simplify-classify: default-branch detection', () => {
   // 'master', 'develop', or any other default branch — empty diff → TRIVIAL →
   // gate stamps clean without any real review. detectDefaultBranch must read
   // the consumer's actual default.
+  //
+  // #1093: the probes here call detectDefaultBranch / classifyFromGit
+  // in-process (passing cwd through) rather than spawning a node subprocess
+  // per probe. Subprocess startup under fork contention was pushing these
+  // tests past vitest's 5 s per-test ceiling.
   const tempRepos: string[] = [];
 
   function newTempDir(prefix: string): string {
@@ -363,22 +368,8 @@ describe('simplify-classify: default-branch detection', () => {
     return dir;
   }
 
-  // Spawn a fresh Node subprocess in `cwd` so each probe gets an unprimed module
-  // (the classifier memoizes detectDefaultBranch within a single process).
-  function probeDefaultBranch(cwd: string): string {
-    return execFileSync(
-      'node',
-      ['-e', `process.chdir(${JSON.stringify(cwd)}); const m = require(${JSON.stringify(CLASSIFIER)}); process.stdout.write(m.detectDefaultBranch());`],
-      { encoding: 'utf-8', timeout: 10000 },
-    );
-  }
-
-  function runClassifierIn(cwd: string): any {
-    const stdout = execFileSync('node', [CLASSIFIER], { cwd, encoding: 'utf-8', timeout: 15000 });
-    return JSON.parse(stdout);
-  }
-
   afterEach(() => {
+    _resetCacheForTest();
     for (const d of tempRepos.splice(0)) {
       try { rmSync(d, { recursive: true, force: true }); } catch {}
     }
@@ -386,41 +377,35 @@ describe('simplify-classify: default-branch detection', () => {
 
   it('picks up origin/HEAD when set (non-main default branch)', () => {
     const dir = makeRepo({ defaultBranch: 'develop', setOriginHead: true });
-    expect(probeDefaultBranch(dir)).toBe('develop');
+    expect(detectDefaultBranch(dir)).toBe('develop');
   });
 
   it('falls back to init.defaultBranch when origin/HEAD is missing', () => {
     const dir = makeRepo({ defaultBranch: 'trunk', setOriginHead: false });
     execSync('git config init.defaultBranch trunk', { cwd: dir });
-    expect(probeDefaultBranch(dir)).toBe('trunk');
+    expect(detectDefaultBranch(dir)).toBe('trunk');
   });
 
   it('falls back to "main" when no signals available', () => {
     // Not even a git repo — both git calls fail, fallback is 'main'
     const dir = newTempDir('simplify-classify-bare-');
-    expect(probeDefaultBranch(dir)).toBe('main');
+    expect(detectDefaultBranch(dir)).toBe('main');
   });
 
-  it('CLI uses the detected branch as merge base, not hardcoded "main"', () => {
+  it('detected branch is the merge base, not hardcoded "main"', () => {
     // The discriminator: commit a change ON `develop`, with NO working-tree
     // changes. A correct implementation diffs against `develop` (sees the
     // commit). A hardcoded-`main` implementation diffs against a non-existent
     // ref (`git diff main...HEAD` errors → safeExec returns ''), so committed
     // diff is invisible and `stats.added` would be 0.
-    //
-    // Scenario: branch off develop, add commits on the branch, classifier
-    // invoked from the branch tip with no --base.
     const dir = makeRepo({ defaultBranch: 'develop', setOriginHead: true });
     execSync('git checkout -q -b feature', { cwd: dir });
     writeFileSync(join(dir, 'README.md'), '# t\nadded line 1\nadded line 2\nadded line 3\nadded line 4\n');
     execSync('git add README.md', { cwd: dir });
     execSync('git commit -m feat -q', { cwd: dir });
 
-    const decision = runClassifierIn(dir);
+    const decision = classifyFromGit(undefined, dir);
     expect(decision.stats).toBeDefined();
-    // 4 added lines committed since the develop merge-base. If the classifier
-    // hardcoded 'main', `git diff main...HEAD` would error and committed diff
-    // would be empty (working tree is clean too) — stats.added would be 0.
     expect(decision.stats.added).toBeGreaterThanOrEqual(4);
   });
 });

--- a/tests/system/auth-error-recovery-e2e.test.ts
+++ b/tests/system/auth-error-recovery-e2e.test.ts
@@ -18,7 +18,7 @@
  *   4. Confirm declined: original failure carried forward, store untouched.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -99,23 +99,47 @@ function spellWithGraphPrereq(): SpellDefinition {
 
 // Reusable env-restore guard so a failed assertion doesn't leak GRAPH_ACCESS_TOKEN
 // into other tests.
+//
+// #1093: hoist the tmpdir + CredentialStore to beforeAll. CredentialStore.unlock
+// runs PBKDF2 with 100k iterations synchronously; doing that 5x per test file in
+// `beforeEach` adds ~0.5–2 s of CPU per file under fork contention, pushing
+// individual tests past vitest's per-test ceiling. State is still scoped per
+// test — each test clears the stored credential in `afterEach`.
 let savedToken: string | undefined;
 let tmpDir: string;
 let store: CredentialStore;
 
-beforeEach(() => {
-  savedToken = process.env.GRAPH_ACCESS_TOKEN;
-  delete process.env.GRAPH_ACCESS_TOKEN;
+let originalDelete: CredentialStore['delete'];
+let originalStore: CredentialStore['store'];
+
+beforeAll(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'moflo-auth-e2e-'));
   store = new CredentialStore({
     filePath: join(tmpDir, 'credentials.json'),
     passphrase: 'test-passphrase-1234',
   });
+  originalDelete = store.delete.bind(store);
+  originalStore = store.store.bind(store);
 });
 
-afterEach(() => {
+beforeEach(() => {
+  savedToken = process.env.GRAPH_ACCESS_TOKEN;
+  delete process.env.GRAPH_ACCESS_TOKEN;
+});
+
+afterEach(async () => {
   if (savedToken === undefined) delete process.env.GRAPH_ACCESS_TOKEN;
   else process.env.GRAPH_ACCESS_TOKEN = savedToken;
+  // Restore any monkey-patched methods from the test body (the headline test
+  // wraps `delete` to simulate the user pasting a fresh token at the prompt).
+  store.delete = originalDelete;
+  store.store = originalStore;
+  // Per-test state: clear any credentials this test stored so the next test
+  // starts from an empty store. delete() is a no-op when the key isn't present.
+  try { await store.delete('GRAPH_ACCESS_TOKEN'); } catch { /* fine — may not exist */ }
+});
+
+afterAll(() => {
   rmSync(tmpDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

Three test files were flaking under the full `npm test` parallel suite (vitest `maxForks: 2` + CPU-bound dev box). Each had a different contention shape; each is fixed at the source per the AC — no timeout bumps, no `isolationTests` parking.

- **`tests/bin/simplify-classify.test.ts`** — was spawning ~7 node/git subprocesses per file. `detectDefaultBranch` / `readDiffFromGit` / `classifyFromGit` now take an optional `cwd` so the default-branch + end-to-end assertions run in-process. Three CLI invocation variants collapsed to one smoke. Subprocess count: 7 → 2 (AC #4).
- **`src/cli/__tests__/spells/auth-error-runner.test.ts`** — registry creation moved from `beforeEach` to `beforeAll`, plus a warm-up `SpellCaster.run()` that pays the ~500 ms platform-sandbox / runner-pipeline cold-start inside the 10 s `beforeAll` ceiling instead of the 5 s per-test one.
- **`tests/system/auth-error-recovery-e2e.test.ts`** — `CredentialStore` + tmpdir hoisted to `beforeAll`, so PBKDF2 100k iterations run once per file rather than 5x in `beforeEach`. Per-test isolation preserved via `afterEach` that clears the stored credential and restores any monkey-patched methods.

## Consumer impact

`bin/simplify-classify.cjs` ships into every consumer via `SOURCE_HELPER_FILES`. The new `cwd` argument is optional and defaults to `process.cwd()`, so CLI behavior is unchanged. The `_resetCacheForTest` export is test-only — consumers don't call it. Signature backward compatible.

## Test plan

- [x] `tests/bin/simplify-classify.test.ts` — 18 tests, 1.71s
- [x] `src/cli/__tests__/spells/auth-error-runner.test.ts` — 9 tests, 1.28s
- [x] `tests/system/auth-error-recovery-e2e.test.ts` — 5 tests, 994ms
- [x] All three files together — 10/10 green under contention (32 tests/run, ~1.3s/run)
- [x] Full suite green locally — 997 passed / 11 skipped / 0 failed (8618 incl. isolation batches)
- [ ] CI matrix confirms no flake across platforms

Closes #1093

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)