### PR TITLE
fix(1107): hoist spell-command imports to module scope to fix flake

### DIFF
--- a/src/cli/__tests__/commands/spell-credentials.test.ts
+++ b/src/cli/__tests__/commands/spell-credentials.test.ts
@@ -11,6 +11,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Command, CommandContext } from '../../types.js';
 import { CredentialStore } from '../../spells/credentials/credential-store.js';
+// Hoisted to module scope (#1107): importing `spell.js` inside an `it()` body
+// triggers `mcp-client.ts` to register 15 MCP tool packages, which exceeds the
+// per-test 5s budget under full-suite contention. Module-scope load pays the
+// cold-start once during file setup, outside the per-test timer.
 import { spellCredentialsCommand } from '../../commands/spell-credentials.js';
 import { spellCommand } from '../../commands/spell.js';
 
@@ -195,10 +199,6 @@ describe('spell credentials passphrase', () => {
 });
 
 describe('parent spell credentials command', () => {
-  // Imports are hoisted to module scope (#1107) so the MCP-tool registry
-  // cold-start (15 packages registered in mcp-client.ts) is paid once during
-  // file setup, not inside the per-test 5s timer.
-
   it('lists subcommands', () => {
     expect(spellCredentialsCommand.name).toBe('credentials');
     const subnames = spellCredentialsCommand.subcommands!.map(s => s.name).sort();

--- a/src/cli/__tests__/commands/spell-credentials.test.ts
+++ b/src/cli/__tests__/commands/spell-credentials.test.ts
@@ -9,8 +9,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { CommandContext } from '../../types.js';
+import type { Command, CommandContext } from '../../types.js';
 import { CredentialStore } from '../../spells/credentials/credential-store.js';
+import { spellCredentialsCommand } from '../../commands/spell-credentials.js';
+import { spellCommand } from '../../commands/spell.js';
 
 let workDir: string;
 let credFile: string;
@@ -43,8 +45,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function loadCommand(name: 'list' | 'set' | 'unset' | 'clear' | 'passphrase') {
-  const { spellCredentialsCommand } = await import('../../commands/spell-credentials.js');
+function loadCommand(name: 'list' | 'set' | 'unset' | 'clear' | 'passphrase'): Command {
   const sub = spellCredentialsCommand.subcommands!.find(c => c.name === name);
   if (!sub) throw new Error(`subcommand ${name} not found`);
   return sub;
@@ -60,7 +61,7 @@ async function seedCred(name: string, value: string, description?: string) {
 
 describe('spell credentials list', () => {
   it('prints "no credentials" when the store is empty', async () => {
-    const cmd = await loadCommand('list');
+    const cmd = loadCommand('list');
     const result = await cmd.action!(makeCtx({ flags: { _: [], format: 'json' } }));
     expect(result?.success).toBe(true);
     expect(result?.data).toEqual([]);
@@ -70,7 +71,7 @@ describe('spell credentials list', () => {
     await seedCred('GRAPH_TOKEN', 'super-secret-value', 'Graph API token');
     await seedCred('SLACK_HOOK', 'webhook-url', 'OAP target');
 
-    const cmd = await loadCommand('list');
+    const cmd = loadCommand('list');
     const result = await cmd.action!(makeCtx({ flags: { _: [], format: 'json' } }));
     expect(result?.success).toBe(true);
     const data = result?.data as Array<{ name: string; description?: string }>;
@@ -92,7 +93,7 @@ describe('spell credentials list', () => {
     const originalWarn = console.warn;
     console.warn = () => { /* swallow expected warning */ };
     try {
-      const cmd = await loadCommand('list');
+      const cmd = loadCommand('list');
       const result = await cmd.action!(makeCtx());
       expect(result?.success).toBe(false);
       expect(result?.exitCode).toBe(1);
@@ -105,7 +106,7 @@ describe('spell credentials list', () => {
 describe('spell credentials unset', () => {
   it('removes a stored credential', async () => {
     await seedCred('TO_DELETE', 'val');
-    const cmd = await loadCommand('unset');
+    const cmd = loadCommand('unset');
     const result = await cmd.action!(makeCtx({ args: ['TO_DELETE'] }));
     expect(result?.success).toBe(true);
 
@@ -117,14 +118,14 @@ describe('spell credentials unset', () => {
   });
 
   it('returns exit 1 when credential name is missing', async () => {
-    const cmd = await loadCommand('unset');
+    const cmd = loadCommand('unset');
     const result = await cmd.action!(makeCtx({ args: [] }));
     expect(result?.success).toBe(false);
     expect(result?.exitCode).toBe(1);
   });
 
   it('returns exit 1 when credential does not exist', async () => {
-    const cmd = await loadCommand('unset');
+    const cmd = loadCommand('unset');
     const result = await cmd.action!(makeCtx({ args: ['NEVER_STORED'] }));
     expect(result?.success).toBe(false);
     expect(result?.exitCode).toBe(1);
@@ -134,7 +135,7 @@ describe('spell credentials unset', () => {
 describe('spell credentials clear', () => {
   it('refuses to clear without --force in non-interactive mode', async () => {
     await seedCred('K1', 'v1');
-    const cmd = await loadCommand('clear');
+    const cmd = loadCommand('clear');
     const result = await cmd.action!(makeCtx({ interactive: false, flags: { _: [] } }));
     expect(result?.success).toBe(false);
     expect(result?.exitCode).toBe(1);
@@ -150,7 +151,7 @@ describe('spell credentials clear', () => {
   it('clears all credentials when --force is given', async () => {
     await seedCred('K1', 'v1');
     await seedCred('K2', 'v2');
-    const cmd = await loadCommand('clear');
+    const cmd = loadCommand('clear');
     const result = await cmd.action!(makeCtx({ interactive: false, flags: { _: [], force: true } }));
     expect(result?.success).toBe(true);
 
@@ -162,7 +163,7 @@ describe('spell credentials clear', () => {
   });
 
   it('reports "no credentials to clear" when store is empty', async () => {
-    const cmd = await loadCommand('clear');
+    const cmd = loadCommand('clear');
     const result = await cmd.action!(makeCtx({ flags: { _: [], force: true } }));
     expect(result?.success).toBe(true);
   });
@@ -170,14 +171,14 @@ describe('spell credentials clear', () => {
 
 describe('spell credentials set', () => {
   it('refuses non-interactive runs', async () => {
-    const cmd = await loadCommand('set');
+    const cmd = loadCommand('set');
     const result = await cmd.action!(makeCtx({ interactive: false, args: ['NAME'] }));
     expect(result?.success).toBe(false);
     expect(result?.exitCode).toBe(1);
   });
 
   it('returns exit 1 when name is missing', async () => {
-    const cmd = await loadCommand('set');
+    const cmd = loadCommand('set');
     const result = await cmd.action!(makeCtx({ args: [] }));
     expect(result?.success).toBe(false);
     expect(result?.exitCode).toBe(1);
@@ -186,7 +187,7 @@ describe('spell credentials set', () => {
 
 describe('spell credentials passphrase', () => {
   it('refuses non-interactive runs', async () => {
-    const cmd = await loadCommand('passphrase');
+    const cmd = loadCommand('passphrase');
     const result = await cmd.action!(makeCtx({ interactive: false }));
     expect(result?.success).toBe(false);
     expect(result?.exitCode).toBe(1);
@@ -194,15 +195,17 @@ describe('spell credentials passphrase', () => {
 });
 
 describe('parent spell credentials command', () => {
-  it('lists subcommands', async () => {
-    const { spellCredentialsCommand } = await import('../../commands/spell-credentials.js');
+  // Imports are hoisted to module scope (#1107) so the MCP-tool registry
+  // cold-start (15 packages registered in mcp-client.ts) is paid once during
+  // file setup, not inside the per-test 5s timer.
+
+  it('lists subcommands', () => {
     expect(spellCredentialsCommand.name).toBe('credentials');
     const subnames = spellCredentialsCommand.subcommands!.map(s => s.name).sort();
     expect(subnames).toEqual(['clear', 'list', 'passphrase', 'set', 'unset']);
   });
 
-  it('is wired under the parent spell command', async () => {
-    const { spellCommand } = await import('../../commands/spell.js');
+  it('is wired under the parent spell command', () => {
     const creds = spellCommand.subcommands!.find(s => s.name === 'credentials');
     expect(creds).toBeDefined();
   });


### PR DESCRIPTION
## Summary

`src/cli/__tests__/commands/spell-credentials.test.ts:204` (`'is wired under the parent spell command'`) was timing out at 5s under `npm test` full-suite contention. The dynamic `await import('../../commands/spell.js')` inside the `it()` body forced first-time evaluation of `mcp-client.ts`, which on module-load synchronously registers **15 MCP tool packages** (agent / swarm / memory / hooks / task / session / hive-mind / spell / security / system / neural / performance / github / coordination / moflodb). That cold-start exceeds the per-test 5s budget when paid inside the timer.

**Fix:** hoist `spellCommand` and `spellCredentialsCommand` to module-scope static imports. `Command` objects are pure data; their `action()` reads env vars at invocation time, not at module-load, so eager imports are safe. The registry cold-start is now paid once per worker during file-setup, outside the per-test timer.

`loadCommand` becomes a synchronous lookup; the two wiring tests in the `parent spell credentials command` describe block become synchronous `.find()` calls against the eagerly-imported references.

## Why not the alternatives

- Bumping `testTimeout` — banned by `feedback_no_test_timeout_bumps.md`.
- Parking in `isolationTests` — banned by `feedback_vitest_isolation_list.md`.
- Source-string introspection — would hide future regressions if the subcommands array changes shape.
- Fragmenting `spellCommand.subcommands` for test convenience — the array IS the structural invariant under test.

Same posture as #1115 (auth-error-runner hoisted to `beforeAll`) and #1114 (structural invariants for quickScan).

## Consumer surface

**Test-only diff.** No `bin/`, hook, MCP, launcher, settings, init, or runtime code touched. Zero blast radius for consumers on the prior version. No round-trip publish required.

## Test plan

- [x] `npx vitest run src/cli/__tests__/commands/spell-credentials.test.ts` — **14/14 passing, 2.46s** (was 4.9s borderline).
- [x] `npm run build` — clean tsc.
- [x] `npm test` (full parallel + isolation passes) — **997 passed / 11 skipped / 0 failed (8618 incl. isolation batches)** — flake gone.
- [x] `/flo-simplify` SMALL tier (1 reviewer agent) — flagged comment-placement; moved hoist rationale to module scope above the imports it explains.
- [ ] CI matrix confirms no flake across platforms.

Closes #1107

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)