### PR TITLE
fix(1111): literal-key fallback in Memory Access Functional check

### DIFF
--- a/src/cli/__tests__/doctor-checks-memory-access.test.ts
+++ b/src/cli/__tests__/doctor-checks-memory-access.test.ts
@@ -22,9 +22,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
+  _runMemoryRoundTripForTest,
   checkMemoryAccessFunctional,
 } from '../commands/doctor-checks-memory-access.js';
-import type { FunctionalHealthCheck } from '../commands/doctor-checks-swarm.js';
+import type { FunctionalCheckDetail, FunctionalHealthCheck, ToolHandler } from '../commands/doctor-checks-functional-shared.js';
 import { findMofloPackageRoot } from '../services/moflo-require.js';
 
 let tempProjectDir: string | undefined;
@@ -221,5 +222,107 @@ describe('doctor-checks-memory-access', () => {
         `${ns} has ${remaining.length} stragglers after cleanup: ${remaining.map(e => e.key).join(', ')}`,
       ).toBe(0);
     }
+  });
+});
+
+/**
+ * #1111 regression: on a fresh consumer install, pretrain seeds the DB
+ * asynchronously and the HNSW index can be empty (`0 vectors indexed`) when
+ * `flo doctor` runs. The probe's `memory_store` returns hasEmbedding=true,
+ * but `memory_search` returns 0 results — historically that failed the
+ * Memory Access Functional check ~2/3 of the time on the smoke harness.
+ *
+ * Fix (a) from the issue: when search returns 0, do a literal-key fallback
+ * via `memory_retrieve`. If the row is reachable, demote the search subcheck
+ * to `warn` (memory access works; only the vector index is unpopulated).
+ *
+ * The behavior is tested with a synthetic memoryTools array so the test
+ * doesn't depend on a real fresh-install timing window.
+ */
+describe('doctor-checks-memory-access — #1111 HNSW-empty fallback', () => {
+  function buildEmptyHnswTools(opts: { retrieveFinds: boolean }): ToolHandler[] {
+    const stored = new Map<string, { value: unknown }>();
+    return [
+      {
+        name: 'memory_store',
+        handler: async (input) => {
+          const k = `${(input.namespace as string) ?? 'default'}::${input.key as string}`;
+          stored.set(k, { value: input.value });
+          return {
+            success: true,
+            key: input.key,
+            namespace: input.namespace,
+            hasEmbedding: true,
+            embeddingDimensions: 384,
+            backend: 'sql.js + HNSW',
+          };
+        },
+      },
+      {
+        name: 'memory_search',
+        // The race: store succeeded, but HNSW has 0 vectors so search
+        // returns empty. Matches the production failure mode in #1111.
+        handler: async () => ({ results: [], total: 0, backend: 'HNSW + sql.js' }),
+      },
+      {
+        name: 'memory_retrieve',
+        handler: async (input) => {
+          if (!opts.retrieveFinds) return { key: input.key, namespace: input.namespace, value: null, found: false };
+          const k = `${(input.namespace as string) ?? 'default'}::${input.key as string}`;
+          const row = stored.get(k);
+          if (!row) return { key: input.key, namespace: input.namespace, value: null, found: false };
+          // Echo the same shape the probe expects (sentinel-bearing object).
+          return { key: input.key, namespace: input.namespace, value: row.value, found: true };
+        },
+      },
+      {
+        name: 'memory_delete',
+        handler: async () => ({ success: true }),
+      },
+    ];
+  }
+
+  it('demotes memory_search to warn when search is empty but literal retrieve finds the row', async () => {
+    const details: FunctionalCheckDetail[] = [];
+    await _runMemoryRoundTripForTest({
+      persona: 'unit', idPrefix: 'unit',
+      memoryTools: buildEmptyHnswTools({ retrieveFinds: true }),
+      details,
+    });
+
+    const searchDetail = details.find(d => d.id === 'unit.memory_search');
+    expect(searchDetail, 'memory_search subcheck must be recorded').toBeDefined();
+    expect(searchDetail!.status, `expected warn, got ${searchDetail!.status}: ${searchDetail!.message}`).toBe('warn');
+    expect(searchDetail!.message).toMatch(/HNSW index not yet populated|pretrain/i);
+
+    // search-finds-key must NOT fail when the race has been detected — it
+    // would be a redundant fail on the same root cause. Demote to warn.
+    const findsKeyDetail = details.find(d => d.id === 'unit.search-finds-key');
+    expect(findsKeyDetail, 'search-finds-key subcheck must be recorded').toBeDefined();
+    expect(findsKeyDetail!.status).toBe('warn');
+
+    // The literal retrieve subcheck must still pass — that's the proof
+    // memory access works even when HNSW is empty.
+    const retrieveDetail = details.find(d => d.id === 'unit.retrieve-roundtrip');
+    expect(retrieveDetail).toBeDefined();
+    expect(retrieveDetail!.status).toBe('pass');
+
+    // No fail rows — the whole point of the fix.
+    expect(details.filter(d => d.status === 'fail')).toHaveLength(0);
+  });
+
+  it('keeps memory_search as fail when both search AND retrieve come back empty', async () => {
+    const details: FunctionalCheckDetail[] = [];
+    await _runMemoryRoundTripForTest({
+      persona: 'unit', idPrefix: 'unit',
+      memoryTools: buildEmptyHnswTools({ retrieveFinds: false }),
+      details,
+    });
+
+    // Real memory-access regression: row was supposedly stored but neither
+    // semantic nor literal access can find it. Must still fail.
+    const searchDetail = details.find(d => d.id === 'unit.memory_search');
+    expect(searchDetail).toBeDefined();
+    expect(searchDetail!.status).toBe('fail');
   });
 });

--- a/src/cli/commands/doctor-checks-memory-access.ts
+++ b/src/cli/commands/doctor-checks-memory-access.ts
@@ -66,7 +66,7 @@ interface SearchOut {
   error?: string;
 }
 
-interface RoundTripContext {
+export interface RoundTripContext {
   /** Persona label, e.g. "subagent". */
   persona: string;
   /** Sub-check id prefix for FunctionalCheckDetail rows. */
@@ -81,7 +81,15 @@ interface RoundTripContext {
  * Run a memory_store + memory_search round-trip and append three details
  * (store, search, value-match). Returns the unique key/namespace used so the
  * caller can clean up. Never throws — assertion failures land in `details`.
+ *
+ * Exported (under `_` prefix) for the #1111 regression test that simulates
+ * the empty-HNSW race with a synthetic `memoryTools` array. Not part of the
+ * public doctor surface; use `checkMemoryAccessFunctional` from real callers.
  */
+export async function _runMemoryRoundTripForTest(ctx: RoundTripContext): Promise<{ key: string; namespace: string }> {
+  return runMemoryRoundTrip(ctx);
+}
+
 async function runMemoryRoundTrip(ctx: RoundTripContext): Promise<{ key: string; namespace: string }> {
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const key = `doctor-memprobe-${ctx.persona}-${stamp}`;
@@ -115,12 +123,21 @@ async function runMemoryRoundTrip(ctx: RoundTripContext): Promise<{ key: string;
   // 2. memory_search with threshold=0 — must find the row we just stored.
   // threshold=0 is the explicit "no threshold" value (#837); regressions
   // there silently filter out matches even when the row is in the index.
+  //
+  // #1111: when search returns 0 results we do a literal-key fallback via
+  // memory_retrieve. On a fresh consumer install pretrain is still computing
+  // embeddings async, so the HNSW index can be empty (`0 vectors indexed`)
+  // even when the row IS in the DB. The check tests memory access, not
+  // embedding-index readiness — a successful literal retrieve demotes the
+  // search fail to a warn so the doctor surfaces the race without misreporting
+  // it as broken memory access.
   const searchMeta = {
     id: `${ctx.idPrefix}.memory_search`,
     mcpTool: 'memory_search',
-    expected: 'total>=1 with backend including HNSW',
+    expected: 'total>=1 via semantic search, OR row retrievable by key when HNSW is unpopulated',
   };
   let searchOut: SearchOut | undefined;
+  let hnswIndexEmpty = false;
   try {
     searchOut = (await invokeOrThrow(ctx.memoryTools, 'memory_search', {
       query: sentinel,
@@ -129,12 +146,27 @@ async function runMemoryRoundTrip(ctx: RoundTripContext): Promise<{ key: string;
       limit: 5,
     })) as SearchOut;
     const failReason = assertSearch(searchOut);
-    pushDetail(
-      ctx.details,
-      searchMeta,
-      failReason ? searchOut : { total: searchOut?.total, backend: searchOut?.backend, topKey: searchOut?.results?.[0]?.key },
-      failReason,
-    );
+
+    if (failReason && searchOut?.total === 0) {
+      const retrievable = await literalKeyReachable(ctx.memoryTools, key, namespace);
+      if (retrievable) {
+        hnswIndexEmpty = true;
+        ctx.details.push({
+          ...searchMeta, status: 'warn',
+          observed: { total: 0, backend: searchOut.backend, literalRetrieve: 'found' },
+          message: 'search returned 0 results despite threshold=0, but row IS reachable by key — HNSW index not yet populated (likely pretrain/embeddings race on fresh install; memory access path works, only the vector index is empty)',
+        });
+      } else {
+        pushDetail(ctx.details, searchMeta, searchOut, failReason);
+      }
+    } else {
+      pushDetail(
+        ctx.details,
+        searchMeta,
+        failReason ? searchOut : { total: searchOut?.total, backend: searchOut?.backend, topKey: searchOut?.results?.[0]?.key },
+        failReason,
+      );
+    }
   } catch (err) {
     const detail = errorDetail(err, { firstLineOnly: true });
     ctx.details.push({
@@ -147,13 +179,25 @@ async function runMemoryRoundTrip(ctx: RoundTripContext): Promise<{ key: string;
   // 3. The just-stored row must come back from search so callers can find
   // what they wrote. memory_search returns a 60-char content snippet, so
   // full-value verification belongs in the retrieve subcheck below.
-  const top = searchOut.results?.find(r => r.key === key);
-  pushDetail(
-    ctx.details,
-    { id: `${ctx.idPrefix}.search-finds-key`, mcpTool: 'memory_search', expected: `result containing key=${key}` },
-    top ? { topKey: top.key, similarity: top.similarity } : { allKeys: searchOut.results?.map(r => r.key) },
-    top ? null : `stored key ${key} not in results (got: ${searchOut?.results?.map(r => r.key).join(', ') ?? 'none'})`,
-  );
+  // When step 2 already observed the HNSW index as empty, the literal retrieve
+  // in step 4 covers reachability; mark this subcheck warn instead of double-
+  // failing on the same root cause.
+  if (hnswIndexEmpty) {
+    ctx.details.push({
+      id: `${ctx.idPrefix}.search-finds-key`, mcpTool: 'memory_search', status: 'warn',
+      observed: { hnswEmpty: true },
+      expected: `result containing key=${key} via semantic search`,
+      message: 'skipped semantic match — HNSW index empty (see memory_search subcheck); literal-key retrieve below covers reachability',
+    });
+  } else {
+    const top = searchOut.results?.find(r => r.key === key);
+    pushDetail(
+      ctx.details,
+      { id: `${ctx.idPrefix}.search-finds-key`, mcpTool: 'memory_search', expected: `result containing key=${key}` },
+      top ? { topKey: top.key, similarity: top.similarity } : { allKeys: searchOut.results?.map(r => r.key) },
+      top ? null : `stored key ${key} not in results (got: ${searchOut?.results?.map(r => r.key).join(', ') ?? 'none'})`,
+    );
+  }
 
   // 4. memory_retrieve returns the full value (search content is truncated
   // to a 60-char snippet). Catches write clobber and namespace bleed — we
@@ -222,6 +266,23 @@ function assertRetrieve(
 
 async function safeDelete(memoryTools: ToolHandler[], key: string, namespace: string): Promise<void> {
   try { await invokeOrThrow(memoryTools, 'memory_delete', { key, namespace }); } catch { /* best-effort */ }
+}
+
+/**
+ * #1111: Probe whether a row is reachable via literal-key lookup. Used to
+ * distinguish a real memory-access failure (row missing) from the HNSW-empty
+ * race (row written, but vector index not yet populated by pretrain).
+ *
+ * Best-effort: a thrown handler or missing tool returns false rather than
+ * propagating, so the caller still reports the original search failure.
+ */
+async function literalKeyReachable(memoryTools: ToolHandler[], key: string, namespace: string): Promise<boolean> {
+  try {
+    const out = (await invokeOrThrow(memoryTools, 'memory_retrieve', { key, namespace })) as { found?: boolean };
+    return out?.found === true;
+  } catch {
+    return false;
+  }
 }
 
 interface NeighborsResult {


### PR DESCRIPTION
## Summary

- Fixes #1111: `flo doctor`'s Memory Access Functional subcheck flaked on fresh consumer installs because pretrain seeds embeddings asynchronously — `memory_search(threshold=0)` could return 0 results even when `memory_store` reported `hasEmbedding=true`.
- The check tests memory access, not embedding-index readiness. When search returns 0, the probe now falls back to `memory_retrieve` by key. If the row is reachable, the search subcheck is demoted to `warn` ("HNSW index not yet populated") instead of failing. The dependent `search-finds-key` subcheck is similarly demoted so we don't double-fail on the same root cause.
- Real regressions still fail: if both semantic search AND literal retrieve come back empty, the row genuinely wasn't stored, and the subcheck stays `fail`.

## Test plan

- [x] New regression tests in `src/cli/__tests__/doctor-checks-memory-access.test.ts` (`#1111 HNSW-empty fallback` describe block) using synthetic memoryTools — covers (a) search empty + retrieve finds row → `warn`, no fail rows; (b) both empty → `fail` preserved.
- [x] Full test suite: 8620 passing, 0 failed.
- [x] Smoke harness `npm run test:smoke -- --skip-pack`: 3/3 runs green (`Summary: 49 passed, 0 failed, 0 warn`). The issue reported 2/3 runs failing pre-fix.
- [x] `_runMemoryRoundTripForTest` exported with `_` prefix so the regression test can drive `runMemoryRoundTrip` with synthetic tools — not part of the public doctor surface.

Closes #1111

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)