### PR TITLE
fix(1102): warm runner pipeline in e2e beforeAll to kill headline flake

### DIFF
--- a/src/cli/__tests__/spells/auth-error-runner.test.ts
+++ b/src/cli/__tests__/spells/auth-error-runner.test.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../spells/types/step-command.types.js';
 import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
 import { withEnvVars } from './helpers/prereq-fixtures.js';
+import { warmRunnerPipeline } from './helpers/warm-runner.js';
 
 // ============================================================================
 // Mocks
@@ -124,31 +125,17 @@ function spellWithoutCredPrereq(stepType: string): SpellDefinition {
 // Setup
 // ============================================================================
 
-// #1093: hoist the registry AND warm the runner pipeline in beforeAll. The
-// first SpellCaster.run() in a fresh process pays a ~500 ms cold-start tax —
-// platform-sandbox detection, validator, prereq-checker, step-executor, etc.
-// all wake up. Those caches (_cachedDetection in platform-sandbox.ts) persist
-// for the rest of the file, so subsequent tests run in <2 ms. The warm-up
-// pays that tax inside beforeAll (default 10 s ceiling) instead of inside the
-// first test (5 s ceiling), which under fork contention is what tipped the
-// first test over the line.
+// #1093: hoist the registry AND warm the runner pipeline in beforeAll via the
+// shared `warmRunnerPipeline` helper. The first SpellCaster.run() in a fresh
+// worker pays a ~500 ms cold-start tax (platform-sandbox detection cache in
+// platform-sandbox.ts:_cachedDetection, validator, prereq-checker, etc.); the
+// helper pays it against beforeAll's 10 s ceiling instead of the 5 s per-test
+// ceiling that tipped over under fork contention.
 let registry: StepCommandRegistry;
 
 beforeAll(async () => {
   registry = new StepCommandRegistry();
-
-  const warmCmd: StepCommand = {
-    type: '__warmup__',
-    description: 'pre-warm sandbox detection + runner pipeline',
-    configSchema: { type: 'object' as const },
-    validate: () => ({ valid: true, errors: [] }),
-    async execute() { return { success: true, data: {}, duration: 0 }; },
-    describeOutputs: () => [],
-  };
-  registry.register(warmCmd);
-  const warmRunner = new SpellCaster(registry, makeMockCredentials(), makeMemory());
-  await warmRunner.run({ name: 'warmup', steps: [{ id: 'w', type: '__warmup__', config: {} }] }, {});
-  registry.clear();
+  await warmRunnerPipeline(makeMockCredentials(), makeMemory());
 });
 
 afterEach(() => {

--- a/src/cli/__tests__/spells/helpers/warm-runner.ts
+++ b/src/cli/__tests__/spells/helpers/warm-runner.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared warm-up for spell-runner tests.
+ *
+ * The first `SpellCaster.run()` in a fresh worker fork pays a ~500 ms
+ * cold-start tax: platform-sandbox detection (`_cachedDetection` in
+ * `platform-sandbox.ts`), validator, prereq-checker, step-executor and
+ * adjacent caches all wake up. Once warm, subsequent runs in the same
+ * worker complete in <2 ms.
+ *
+ * Test files that run multiple spells should call this in `beforeAll`
+ * so the cold-start tax is paid against vitest's 10 s `beforeAll`
+ * ceiling rather than the 5 s per-test ceiling — which is what tipped
+ * the first test over the line under fork contention (#1093, #1102).
+ *
+ * The helper creates its own throwaway registry, so it does not touch
+ * the caller's registry or credential state. Pass whatever
+ * `CredentialAccessor`/`MemoryAccessor` the test file already has — a
+ * real store works, a mock works, neither is exercised by the warm-up
+ * spell (it has no prerequisites).
+ */
+
+import { SpellCaster } from '../../../spells/core/runner.js';
+import { StepCommandRegistry } from '../../../spells/core/step-command-registry.js';
+import type {
+  StepCommand,
+  CredentialAccessor,
+  MemoryAccessor,
+} from '../../../spells/types/step-command.types.js';
+
+export async function warmRunnerPipeline(
+  credentials: CredentialAccessor,
+  memory: MemoryAccessor,
+): Promise<void> {
+  const registry = new StepCommandRegistry();
+  const warmCmd: StepCommand = {
+    type: '__warmup__',
+    description: 'pre-warm sandbox detection + runner pipeline',
+    configSchema: { type: 'object' as const },
+    validate: () => ({ valid: true, errors: [] }),
+    async execute() {
+      return { success: true, data: {}, duration: 0 };
+    },
+    describeOutputs: () => [],
+  };
+  registry.register(warmCmd);
+  const runner = new SpellCaster(registry, credentials, memory);
+  await runner.run(
+    { name: 'warmup', steps: [{ id: 'w', type: '__warmup__', config: {} }] },
+    {},
+  );
+}

--- a/tests/system/auth-error-recovery-e2e.test.ts
+++ b/tests/system/auth-error-recovery-e2e.test.ts
@@ -32,6 +32,7 @@ import type {
   MemoryAccessor,
 } from '../../src/cli/spells/types/step-command.types.js';
 import type { SpellDefinition } from '../../src/cli/spells/types/spell-definition.types.js';
+import { warmRunnerPipeline } from '../../src/cli/__tests__/spells/helpers/warm-runner.js';
 
 // ============================================================================
 // Test scaffolding
@@ -105,6 +106,11 @@ function spellWithGraphPrereq(): SpellDefinition {
 // `beforeEach` adds ~0.5–2 s of CPU per file under fork contention, pushing
 // individual tests past vitest's per-test ceiling. State is still scoped per
 // test — each test clears the stored credential in `afterEach`.
+//
+// #1102: also warm the SpellCaster pipeline (platform-sandbox detection,
+// validator, prereq-checker — see helpers/warm-runner.ts) here in beforeAll.
+// Without this, the headline test ate the ~500 ms cold-start inline and tipped
+// past the 5 s per-test ceiling ~1/3 of the time under full-suite fork load.
 let savedToken: string | undefined;
 let tmpDir: string;
 let store: CredentialStore;
@@ -112,7 +118,7 @@ let store: CredentialStore;
 let originalDelete: CredentialStore['delete'];
 let originalStore: CredentialStore['store'];
 
-beforeAll(() => {
+beforeAll(async () => {
   tmpDir = mkdtempSync(join(tmpdir(), 'moflo-auth-e2e-'));
   store = new CredentialStore({
     filePath: join(tmpDir, 'credentials.json'),
@@ -120,6 +126,7 @@ beforeAll(() => {
   });
   originalDelete = store.delete.bind(store);
   originalStore = store.store.bind(store);
+  await warmRunnerPipeline(store, makeMemory());
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

- Headline `auth-error-recovery-e2e` test regressed under load after #1115 because the e2e file got only **half** of that fix.
- #1115 hoisted `CredentialStore` to `beforeAll` (paying PBKDF2 100k cost once) but did not also hoist a `SpellCaster.run(...)` warm-up. The first `caster.run(...)` in a fresh worker pays a ~500 ms cold-start tax (platform-sandbox detection cache at `src/cli/spells/core/platform-sandbox.ts:83`, validator, prereq-checker, step-executor). Under fork contention that tipped the headline test past the 5 s per-test ceiling ~1/3 of the time.
- Extracted the warm-up into a shared helper `warmRunnerPipeline(creds, memory)` and called it in `beforeAll` of both `auth-error-runner.test.ts` (replaces the inline warm-up — DRY) and the e2e file (the actual fix).

## Why the partial fix happened in #1115

#1115's title scoped to issue #1093. The runner test got the full treatment (registry hoist + warm-up). The e2e test got only the CredentialStore hoist. The user's regression report on #1102 narrowed the symptom to the headline test specifically (the other 4 in the file stay green), which fits: every test after the first one runs against an already-warm `_cachedDetection`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` the two touched files in isolation — 14/14 green in 2.35 s
- [x] 6 consecutive `npm test` full-suite runs locally — headline test 0 failures across all 6 (#1102 fix holds)
- [x] /flo-simplify SMALL-tier reviewer pass — clean
- Pre-existing unrelated load-flakes observed at low rates (1× dashboard-claude-stats-route, 1× published-package-drift-guard across 6 runs). Neither reproduces in isolation. Intentionally out of scope for this PR per feedback_issue_kills_bug_class (scope tightly to the named bug class).

Closes #1102.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)