### PR TITLE
fix(1090): sync bin/lib + bin/migrations in flo init

### DIFF
--- a/src/cli/__tests__/init-syncs-lib-and-migrations.test.ts
+++ b/src/cli/__tests__/init-syncs-lib-and-migrations.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression: `flo init` must populate `.claude/scripts/lib/` and
+ * `.claude/scripts/migrations/` (#1090).
+ *
+ * Pre-fix, `src/cli/init/moflo-init.ts` `syncScripts` only copied the
+ * top-level scripts listed in `SCRIPT_MAP`. The synced scripts import
+ * `./lib/moflo-resolve.mjs`, so a consumer that ran `flo init` and then
+ * invoked a script directly (e.g. `node .claude/scripts/index-guidance.mjs`)
+ * hit `ERR_MODULE_NOT_FOUND` until a separate path (post-install bootstrap
+ * or session-start launcher §3) eventually synced `lib/`.
+ *
+ * pnpm 10+ exposes this most visibly because its default `onlyBuiltDependencies`
+ * gate disables npm postinstall scripts, so the bootstrap fallback never runs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { initMoflo } from '../init/moflo-init.js';
+
+describe('flo init — syncs bin/lib and bin/migrations (#1090)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-init-1090-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('populates .claude/scripts/lib/ so synced scripts can resolve ./lib/* imports', async () => {
+    await initMoflo({ projectRoot: tmpDir, minimal: true, force: true });
+
+    const libDir = path.join(tmpDir, '.claude', 'scripts', 'lib');
+    expect(fs.existsSync(libDir), 'expected .claude/scripts/lib/ after init').toBe(true);
+
+    const resolveHelper = path.join(libDir, 'moflo-resolve.mjs');
+    expect(fs.existsSync(resolveHelper), 'expected moflo-resolve.mjs in synced lib/').toBe(true);
+    expect(fs.statSync(resolveHelper).size).toBeGreaterThan(0);
+  });
+
+  it('synced .claude/scripts/lib/ matches bin/lib/ file-for-file', async () => {
+    await initMoflo({ projectRoot: tmpDir, minimal: true, force: true });
+
+    const repoBinLib = path.resolve(__dirname, '..', '..', '..', 'bin', 'lib');
+    const syncedLib = path.join(tmpDir, '.claude', 'scripts', 'lib');
+
+    const listFiles = (root: string): string[] => {
+      const entries = fs.readdirSync(root, { recursive: true, withFileTypes: true }) as fs.Dirent[];
+      return entries
+        .filter(e => e.isFile())
+        .map(e => {
+          const parent = (e as fs.Dirent & { parentPath?: string }).parentPath
+            ?? (e as fs.Dirent & { path?: string }).path
+            ?? root;
+          return path.relative(root, path.join(parent, e.name)).split(path.sep).join('/');
+        })
+        .sort();
+    };
+
+    expect(listFiles(syncedLib)).toEqual(listFiles(repoBinLib));
+  });
+
+  it('populates .claude/scripts/migrations/ when migrations source exists', async () => {
+    const repoMigrations = path.resolve(__dirname, '..', '..', '..', 'bin', 'migrations');
+    if (!fs.existsSync(repoMigrations)) return; // source not present, nothing to assert
+
+    await initMoflo({ projectRoot: tmpDir, minimal: true, force: true });
+
+    const migrationsDir = path.join(tmpDir, '.claude', 'scripts', 'migrations');
+    expect(fs.existsSync(migrationsDir), 'expected .claude/scripts/migrations/ after init').toBe(true);
+    const entries = fs.readdirSync(migrationsDir);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+});

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -582,10 +582,48 @@ function syncScripts(root: string, force?: boolean): MofloInitResult['steps'][0]
     }
   }
 
+  // Sync bin/lib/ and bin/migrations/ recursively. The top-level scripts
+  // import `./lib/moflo-resolve.mjs` etc., so omitting these subtrees leaves
+  // every synced script unable to load (#1090). The upgrade path in
+  // executor.ts and the post-install bootstrap both sync these trees — init
+  // had drifted out of step.
+  copied += syncTree(path.join(binDir, 'lib'), path.join(scriptsDir, 'lib'), force);
+  copied += syncTree(path.join(binDir, 'migrations'), path.join(scriptsDir, 'migrations'), force);
+
   if (copied === 0) {
     return { name: '.claude/scripts/', status: 'skipped', detail: 'Scripts already up to date' };
   }
   return { name: '.claude/scripts/', status: 'updated', detail: `${copied} scripts synced from moflo` };
+}
+
+function syncTree(srcRoot: string, destRoot: string, force?: boolean): number {
+  if (!fs.existsSync(srcRoot)) return 0;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(srcRoot, { recursive: true, withFileTypes: true }) as fs.Dirent[];
+  } catch {
+    return 0;
+  }
+  let copied = 0;
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const parent = (entry as fs.Dirent & { parentPath?: string }).parentPath
+      ?? (entry as fs.Dirent & { path?: string }).path
+      ?? srcRoot;
+    const absSrc = path.join(parent, entry.name);
+    const rel = path.relative(srcRoot, absSrc).split(path.sep).join('/');
+    const absDest = path.join(destRoot, rel);
+    try {
+      fs.mkdirSync(path.dirname(absDest), { recursive: true });
+      if (!fs.existsSync(absDest) || force || isStale(absSrc, absDest)) {
+        fs.copyFileSync(absSrc, absDest);
+        copied++;
+      }
+    } catch {
+      // Non-fatal — skip individual file on error
+    }
+  }
+  return copied;
 }
 
 function isStale(srcPath: string, destPath: string): boolean {


### PR DESCRIPTION
## Summary

- `flo init`'s `syncScripts` (`src/cli/init/moflo-init.ts:553`) only copied top-level scripts from `bin/`. The synced scripts import `./lib/moflo-resolve.mjs`, so every one of them failed immediately with `ERR_MODULE_NOT_FOUND`.
- Three other code paths sync `bin/lib/` correctly (post-install bootstrap, session-start launcher §3, `executor.ts` upgrade) — init had drifted out of step.
- Bug surfaces most visibly under pnpm 10+ because its default `onlyBuiltDependencies` gate disables `postinstall`, so the post-install bootstrap doesn't rescue pnpm consumers.

## Root cause vs reporter hypothesis

The original title hypothesised that `createRequire(import.meta.url)` in `bin/lib/moflo-resolve.mjs` can't resolve moflo's private deps under pnpm's strict layout. Traced each caller — that's not the failure path: `mofloInternalURL` only joins paths and dynamically `import()`s moflo's own dist files; once `import()` loads them, Node anchors resolution inside `node_modules/moflo/` where pnpm's nested symlinks expose private deps. The error the reporter pasted (`Cannot find module '.../.claude/scripts/lib/moflo-resolve.mjs'`) is the missing-lib bug, not a createRequire failure. See enhanced issue body for the full trace.

## Implementation

Added a `syncTree(srcRoot, destRoot, force)` helper modeled after `executor.ts:syncTreeForUpgrade` (upgrade flow) and invoke it for `bin/lib` and `bin/migrations` from `syncScripts`. Used `.split(path.sep).join('/')` on the relative path for Windows consistency (matches `executor.ts:521`).

## Consumer blast radius

- **Surface**: `src/cli/init/moflo-init.ts` (`flo init`) — direct consumer touch.
- **Failure mode for current consumers**: Any pnpm-10+ consumer who ran `flo init` then tried a synced script before Claude Code started a session. Fix auto-applies on next `flo init` after upgrade.
- **Round-trip cost**: Publish → `pnpm/npm install moflo@<new>` → re-run `flo init`. No state migration.

## Follow-up worth filing

Four code paths now sync the same trees (init / upgrade / launcher §3 / postinstall bootstrap). The existing drift guard (`post-install-bootstrap-drift-guard.test.ts`) covers launcher ↔ bootstrap, not init ↔ launcher. If init's `SCRIPT_MAP` drifts again, the same class of failure reappears. Worth a future story to either consolidate or extend the drift guard.

## Test plan

- [x] New regression test `src/cli/__tests__/init-syncs-lib-and-migrations.test.ts` — 3 cases (lib synced, file-for-file recursive match, migrations synced).
- [x] Existing init + drift-guard tests pass (`init-copy-maps`, `init-envrc`, `init-gitignore`, `init-moflo-yaml-template`, `post-install-bootstrap-drift-guard`, `post-install-bootstrap`).
- [x] Full `npm test` — 8623 tests pass.
- [ ] Manual: `pnpm add moflo@<this-version>` + `flo init` + `node .claude/scripts/index-guidance.mjs --help` exits 0.

Closes #1090

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)