### PR TITLE
fix: tiered DB integrity recovery + prefix-aware ephemeral purge

### DIFF
--- a/.claude/guidance/internal/dogfooding.md
+++ b/.claude/guidance/internal/dogfooding.md
@@ -85,7 +85,101 @@ Features must work from the installed location (consumer perspective), not from 
 
 ---
 
-## Smoke Harness Reality
+## Delivering Changes That Work Both Local AND Installed
+
+Every non-trivial change has to clear three resolution problems that recur in this codebase because of the dogfood loop. Each has a canonical pattern; getting the pattern wrong produces "works locally, broken in `node_modules/moflo/`" bugs or vice versa.
+
+### 1. Three distinct "roots" — pick the right one, use the right resolver
+
+| What you want | Resolver | Use when |
+|---|---|---|
+| Consumer's project root (where the user's `.moflo/`, `package.json`, source tree live) | `findProjectRoot()` — JS: `bin/lib/moflo-paths.mjs`; TS: `services/project-root.ts` | bin/*.mjs scripts or TS code that needs to write to the *consumer's* state |
+| MoFlo *package* root (where moflo's own `bin/`, `dist/`, `package.json` live — in dogfood that's the repo; in a consumer install that's `node_modules/moflo/`) | `findMofloPackageRoot()` from `src/cli/services/moflo-require.ts` | TS code that needs to load a moflo-shipped file (e.g. importing a `bin/lib/*.mjs` module from a TS module under `dist/src/cli/...`) |
+| Sibling script in the same `bin/` directory | Candidate list across `__dirname`, `<projectRoot>/node_modules/moflo/bin/`, `<projectRoot>/.claude/scripts/` — see `consumer-project-paths.md` | bin/*.mjs scripts that spawn other bin/*.mjs scripts |
+
+The three are distinct because they answer different questions: "where is the user's work?" vs "where is MY code installed?" vs "where is my sibling on disk?" Conflating them is the source of most install-vs-local breakage.
+
+### 2. Anti-pattern: hardcoded `../../../../` paths in TS that crosses into `bin/`
+
+```ts
+// ❌ WRONG — depth differs between TS source and compiled dist
+const repairUrl = new URL('../../../../bin/lib/db-repair.mjs', import.meta.url);
+
+// ✅ CORRECT — works in all three contexts (dogfood TS / dist / consumer install)
+const root = findMofloPackageRoot();
+if (!root) throw new Error('moflo package root not found');
+const repairUrl = pathToFileURL(join(root, 'bin', 'lib', 'db-repair.mjs')).href;
+```
+
+The depths don't match between source and dist:
+
+| Context | `import.meta.url` for `services/foo.ts` | Up 4 levels |
+|---|---|---|
+| Dogfood TS source (vitest) | `<repo>/src/cli/services/foo.ts` | `<repo>/..` ← **wrong**, overshoots |
+| Compiled dist (CLI runtime) | `<repo>/dist/src/cli/services/foo.js` | `<repo>` ← correct |
+| Consumer install | `node_modules/moflo/dist/src/cli/services/foo.js` | `node_modules/moflo` ← correct |
+
+The TS source tree is one level shallower than dist (`src/cli/services/` vs `dist/src/cli/services/`), so any fixed-depth `../` walk that's tuned for dist hits a different parent in vitest. Test suites that don't actually invoke the loader (e.g. tests that just check return shape, accepting both success and failure outcomes) silently pass over this bug — it surfaces only when a new test checks the *outcome* of the actual load. This bit us in #1126 — caught by the doctor-integrity test that explicitly required a healthy DB to report `pass`.
+
+**Always use `findMofloPackageRoot()`** when a `.ts` module needs to locate any `.mjs` / `.js` file outside the same compile unit.
+
+### 3. Three sync layers — match the new file's layer, no manual list
+
+When adding a new file, check which layer it falls into:
+
+| File location | Ships via | Sync requirement |
+|---|---|---|
+| `src/cli/**/*.ts` | `dist/src/cli/**/*.js` (auto, after `tsc`) | None — `package.json` `files` glob covers it |
+| `bin/*.mjs` (top level) | `bin/**` glob | **YES — add to `scriptFiles[]` in three places** (`bin/session-start-launcher.mjs` + `.claude/scripts/session-start-launcher.mjs` + `auto-update.test.ts`) — see `feedback_scriptfiles_sync.md` |
+| `bin/lib/*.mjs` | `bin/**` glob | None — launcher's §3 sync recursively `readdirSync(libSrcDir)` picks it up automatically |
+| `bin/migrations/**` | `bin/**` glob | None — recursive sync |
+| `.claude/skills/**/*.md` | `.claude/skills/**/*.md` glob | None |
+| `.claude/guidance/shipped/**` | `.claude/guidance/shipped/**` glob | None (internal/ does NOT ship) |
+| `.claude/helpers/**` | `.claude/helpers/**` glob | None |
+
+The `scriptFiles[]` array hazard is the most common foot-gun because it's the only layer with a hand-maintained list. Everything else uses globs or `readdirSync`.
+
+### 4. Round-trip cost — does the change need publish+reinstall to take effect locally?
+
+| Change touches | Visible to dogfood after |
+|---|---|
+| Tests, internal helpers (anything not in the listed surfaces) | `npm test` / file save |
+| Build tooling (`tsc` config, `package.json` scripts) | `npm run build` |
+| `dist/src/cli/**` consumed by `flo` CLI subprocess (`npx moflo ...`) | `npm run build` — the subprocess loads fresh dist |
+| `bin/*.mjs` consumed by `flo` CLI subprocess | Source edit — subprocess re-resolves from disk |
+| `bin/session-start-launcher.mjs` / hook handlers / MCP server / daemon | **publish + `npm install`** — Claude Code only re-loads these at session start, and our dev daemon was spawned at *previous* session start from `node_modules/moflo/` |
+| `.claude/skills/**/*.md` (the skill itself) | Reload the skill / next `Skill` tool invocation |
+
+Two consequences:
+
+- **Mid-session you and the daemon disagree on the code.** A `flo healer --fix` you just edited will use the new source via the subprocess CLI — but the MCP server the same session is talking to was loaded from `node_modules/moflo/` and still has the old code. If a fix depends on both, you have to publish + reinstall + restart Claude Code before you can test the integrated behavior. (See `feedback_dogfood_install_vs_source.md` and `feedback_moflo_dogfood_dual_context.md` in auto-memory.)
+- **"Works on my machine after edit" doesn't prove consumer-safety.** Until you `npm pack` + install into a temp consumer dir (or just `/publish` to npm and reinstall), you've only verified that source-tree-resolution worked. The consumer-install resolution is a separate test the smoke harness performs.
+
+### 5. Test isolation: writes through cached project root
+
+The bridge module caches the project root at first import. If a vitest test exercises `memory_store` while `CLAUDE_PROJECT_DIR` still points at the real moflo repo, the test's writes to its temp DB land correctly *but* the cache-sidecar writers (`writeVectorStatsCache` in `memory-initializer.ts:2093`, `refreshVectorStatsCache` in `bridge-core.ts`) write to the *real* `.moflo/vector-stats.json` with the test's row count (often 1).
+
+Symptom: statusline briefly flashes a tiny embedding count (e.g. `Vectors ●1` instead of `●3576`) during a test run, then self-heals as the daemon's next `memory_store` rewrites the cache to truth.
+
+Consumer impact: zero — consumers don't run our vitest suite. But locally it's confusing and can make a stable statusline look broken. The fix isn't in code; it's in test isolation:
+
+- Tests that touch `memory_store` MUST redirect `CLAUDE_PROJECT_DIR` to a temp dir AND reset the bridge module's cached root (see `doctor-checks-memory-access.test.ts:42-53` `resetDistBridgeState()` pattern).
+- The anti-clobber guard in `bridge-core.ts:703` only short-circuits *all-zero* writes. Single-row test writes sail through. Tightening that guard is a real follow-up but out of scope for individual feature PRs.
+
+### 6. Cross-platform primitives — established conventions
+
+Match existing patterns rather than reinventing:
+
+- **Cross-process daemon stop**: `process.kill(pid, 'SIGTERM')`. Node maps `SIGTERM` to `TerminateProcess` on Windows; same effective behavior as POSIX. Used by `Daemon Version Skew` fix and `memory-db-integrity-repair.ts`.
+- **Atomic file swap**: `renameSync(src, dst)`. POSIX-atomic; on Windows it maps to `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`. Used by `atomic-file-write.ts` and `db-repair.mjs:atomicSwap()`.
+- **Filesystem-safe timestamps**: `new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '')` — strips `:` (illegal on Windows) and trailing `Z`.
+- **No POSIX-only shell-outs**: no `lsof`, `kill`, `chmod` — everything routes through `node:fs`, `node:sqlite`, `process.kill`.
+
+Before merging, audit any new code that opens files, spawns processes, or stops daemons against these primitives.
+
+---
+
+
 
 `harness/consumer-smoke/` packs the working tree, installs it into a temp consumer dir, and exercises the Claude-Code-facing surface. The harness is the single source of truth for whether a change is consumer-safe — but the dogfood loop makes it diverge from CI in two specific ways unless we pin them.
 

--- a/.claude/scripts/lib/db-repair.mjs
+++ b/.claude/scripts/lib/db-repair.mjs
@@ -1,32 +1,49 @@
 /**
- * Memory-DB integrity check + auto-REINDEX (story #743).
+ * Memory-DB integrity check + tiered repair (#743, #1090-followup).
  *
- * The `.moflo/moflo.db` SQLite file routinely accumulates index corruption of
- * the form `row N missing from index sqlite_autoindex_memory_entries_1` —
- * the row data is intact, only the unique-key index has drifted. The most
- * common trigger is sql.js's whole-file dump-on-flush behaviour racing with
- * concurrent writes (see `feedback_sqljs_writeback_clobber.md` and #714).
+ * The `.moflo/moflo.db` SQLite file picks up corruption in two distinct modes:
+ *
+ *  1. **Index drift** — `row N missing from sqlite_autoindex_memory_entries_1`.
+ *     Row data is intact; only the unique-key b-tree is wrong. Trigger: sql.js's
+ *     whole-file dump-on-flush racing with concurrent writes (#714, #743 —
+ *     fixed for new installs by Phase 5 / #1084 which removed sql.js entirely).
+ *     **REINDEX** rebuilds the index from canonical row data.
+ *
+ *  2. **Table b-tree corruption** — `Tree N page M cell K: Rowid X out of
+ *     order`, where Tree N is a TABLE root page (not just an index). Row data
+ *     is partly intact, but page ordering is broken. Triggers we've seen:
+ *      - sql.js → node:sqlite migration: an old 4.9.x sql.js daemon flushes its
+ *        full-file dump OVER a WAL frame that the new 4.10 backend has already
+ *        written, leaving WAL referencing pages that no longer exist in main.
+ *      - Concurrent multi-process writes when the daemon was disabled (#981).
+ *     **REINDEX cannot fix this** — the table itself is broken. Recovery path:
+ *      a) `VACUUM INTO` a fresh file (single-shot rebuild; fails fast if
+ *         iteration hits an unreadable page),
+ *      b) row-level salvage — chunked `SELECT rowid > ?` per table, catching
+ *         per-chunk errors and skipping past corrupt page ranges,
+ *      c) atomic swap with .corrupt.<TS> backup retained for forensics.
+ *
+ *  3. **Unrecoverable** — header damage, encrypted-by-malware, etc. We can't
+ *     fix this; surface a clear failure and let the user decide between manual
+ *     `flo memory rebuild-index` (destructive) and offline recovery tools.
  *
  * Symptoms when uncorrected:
  *  - `index-guidance.mjs` and `index-patterns.mjs` fail mid-write with
  *    `database disk image is malformed`, leaving partial state.
  *  - The ephemeral-namespace purge (#729) fails silently, so hive-mind /
  *    tasklist / epic-state / test-bridge-fix rows accumulate.
- *  - Vector counts in the statusline stay inflated (observed: 4415 with
- *    1025 unpurged ephemeral rows).
+ *  - Vector counts in the statusline stay inflated.
+ *  - Healer's deep checks throw with "database disk image is malformed",
+ *    surfacing as the synthetic 'Check' failure (doctor.ts:214).
  *
- * Fix shape: REINDEX rebuilds indexes from the canonical row data — much less
- * destructive than a full rebuild and works for the typical drift mode. If
- * REINDEX itself fails to restore integrity we leave the file alone and
- * report; manual `flo memory rebuild-index` is the fallback.
- *
- * MUST run BEFORE any long-lived sql.js consumer (MCP server, daemon) opens
- * the DB and BEFORE the embeddings migration / soft-delete purge / ephemeral
- * purge — those all swallow corruption errors and silently no-op.
+ * MUST run BEFORE any long-lived consumer (MCP server, daemon) opens the DB
+ * and BEFORE the embeddings migration / soft-delete purge / ephemeral purge —
+ * those all swallow corruption errors and silently no-op.
  */
-import { existsSync } from 'node:fs';
+import { existsSync, renameSync, unlinkSync } from 'node:fs';
 import { memoryDbPath } from './moflo-paths.mjs';
 import { openBackend } from './get-backend.mjs';
+import './suppress-sqlite-warning.mjs';
 
 function isOk(execResult) {
   const rows = execResult?.[0]?.values ?? [];
@@ -38,42 +55,323 @@ function corruptionCount(execResult) {
 }
 
 /**
- * Probe the memory DB for index corruption and run REINDEX in place if
- * found. Returns `{ repaired, errors, persistent }`:
- *  - `repaired: true` and `errors > 0` when REINDEX restored integrity.
- *  - `repaired: false, errors: 0` when the DB is healthy or absent.
- *  - `repaired: false, errors > 0, persistent: true` when corruption survives
- *    REINDEX (caller should surface to the user — manual rebuild needed).
+ * Open `.moflo/moflo.db` raw via node:sqlite in readonly mode and run
+ * `PRAGMA integrity_check`. Bypasses {@link openBackend} because that path
+ * sets `journal_mode=WAL`, `busy_timeout`, and `synchronous=NORMAL` on every
+ * non-readonly open — those PRAGMAs can themselves throw against a corrupt
+ * file, and the pre-#1090 code path caught those throws and reported the DB
+ * as healthy. Readonly + no PRAGMAs = the probe always reaches the
+ * `integrity_check` call regardless of file health.
+ *
+ * @param {string} dbPath
+ * @returns {Promise<{ ok: boolean, errors: number, openFailed?: boolean }>}
+ */
+async function probeIntegrityRaw(dbPath) {
+  const { DatabaseSync } = await import('node:sqlite');
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+  } catch {
+    return { ok: false, errors: 0, openFailed: true };
+  }
+  try {
+    const rows = db.prepare('PRAGMA integrity_check').all();
+    if (rows.length === 1 && String(rows[0]?.integrity_check ?? '').toLowerCase() === 'ok') {
+      return { ok: true, errors: 0 };
+    }
+    return { ok: false, errors: rows.length };
+  } catch {
+    return { ok: false, errors: 0, openFailed: true };
+  } finally {
+    try { db.close(); } catch { /* already-dead handle */ }
+  }
+}
+
+/**
+ * Tier-2 recovery: `VACUUM INTO` a fresh file. Single SQLite call that
+ * iterates every row of every table and writes them to a brand-new database
+ * with rebuilt indexes. Fails fast if iteration hits an unreadable page —
+ * caller falls back to row-level salvage.
+ *
+ * @param {string} srcPath
+ * @param {string} dstPath
+ * @returns {Promise<{ ok: boolean, error?: string }>}
+ */
+async function tryVacuumInto(srcPath, dstPath) {
+  const { DatabaseSync } = await import('node:sqlite');
+  try { if (existsSync(dstPath)) unlinkSync(dstPath); } catch { /* best effort */ }
+  let db;
+  try {
+    // Open writable (not readonly) — VACUUM needs to checkpoint WAL first.
+    // Skip our standard WAL pragmas (they can throw on corrupt files); SQLite
+    // applies its defaults which are sufficient for VACUUM INTO.
+    db = new DatabaseSync(srcPath);
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'open failed' };
+  }
+  try {
+    try { db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch { /* corrupt WAL ok */ }
+    db.exec(`VACUUM INTO '${dstPath.replace(/'/g, "''")}'`);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'vacuum failed' };
+  } finally {
+    try { db.close(); } catch { /* */ }
+  }
+}
+
+/**
+ * Tier-3 recovery: row-level salvage. Iterate each non-empty table in
+ * `rowid > ?` chunks; on any chunk-read failure, skip past that chunk's
+ * rowid range and continue. Per-table loss stats returned so the caller can
+ * surface what was preserved vs lost.
+ *
+ * Schema is copied verbatim from `sqlite_master.sql` so triggers/indexes/views
+ * are preserved alongside tables. `INSERT OR IGNORE` handles unique-key
+ * collisions from any duplicate-rowid corruption mode.
+ *
+ * @param {string} srcPath
+ * @param {string} dstPath
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   error?: string,
+ *   lossStats?: Record<string, { read: number, written: number, errors: number }>,
+ * }>}
+ */
+async function trySalvageRowByRow(srcPath, dstPath) {
+  const { DatabaseSync } = await import('node:sqlite');
+  try { if (existsSync(dstPath)) unlinkSync(dstPath); } catch { /* */ }
+
+  let src;
+  try {
+    src = new DatabaseSync(srcPath, { readOnly: true });
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'src open failed' };
+  }
+
+  const dst = new DatabaseSync(dstPath);
+  const lossStats = {};
+  const CHUNK = 500;
+
+  try {
+    // Copy schema. Order matters: tables first (else indexes/triggers/views
+    // reference nonexistent tables), then everything else. sqlite_* objects
+    // (sqlite_sequence, sqlite_autoindex_*) are created implicitly by SQLite.
+    const schemaRows = src
+      .prepare(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master " +
+          "WHERE sql IS NOT NULL ORDER BY CASE type " +
+          "WHEN 'table' THEN 1 WHEN 'index' THEN 2 WHEN 'view' THEN 3 ELSE 4 END",
+      )
+      .all();
+    for (const s of schemaRows) {
+      if (String(s.name).startsWith('sqlite_')) continue;
+      try { dst.exec(s.sql + ';'); } catch { /* malformed schema row — skip */ }
+    }
+
+    // Salvage rows table-by-table.
+    const tables = src
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+      .all();
+
+    for (const t of tables) {
+      const name = String(t.name);
+      lossStats[name] = { read: 0, written: 0, errors: 0 };
+
+      const cols = src.prepare(`PRAGMA table_info('${name.replace(/'/g, "''")}')`).all();
+      if (cols.length === 0) continue;
+      const colList = cols.map((c) => '"' + String(c.name).replace(/"/g, '""') + '"').join(',');
+      const placeholders = cols.map(() => '?').join(',');
+      const insert = dst.prepare(
+        `INSERT OR IGNORE INTO "${name.replace(/"/g, '""')}" (${colList}) VALUES (${placeholders})`,
+      );
+
+      let lastRowid = 0;
+      let safetyCap = 0;
+      const MAX_ITERATIONS = 100_000;
+
+      while (safetyCap++ < MAX_ITERATIONS) {
+        let rows;
+        try {
+          rows = src
+            .prepare(
+              `SELECT rowid as __rid, * FROM "${name.replace(/"/g, '""')}" ` +
+                `WHERE rowid > ? ORDER BY rowid LIMIT ${CHUNK}`,
+            )
+            .all(lastRowid);
+        } catch {
+          lossStats[name].errors++;
+          lastRowid += CHUNK;
+          continue;
+        }
+        if (!rows || rows.length === 0) break;
+        lossStats[name].read += rows.length;
+        for (const r of rows) {
+          try {
+            insert.run(...cols.map((c) => r[c.name]));
+            lossStats[name].written++;
+          } catch {
+            lossStats[name].errors++;
+          }
+          lastRowid = Number(r.__rid);
+        }
+        if (rows.length < CHUNK) break;
+      }
+    }
+
+    // Verify the recovered file. If integrity_check still fails, the
+    // salvage didn't actually produce a clean file — surface as failure
+    // (caller will keep the corrupted original in place).
+    const checkRows = dst.prepare('PRAGMA integrity_check').all();
+    const recoveredOk =
+      checkRows.length === 1 &&
+      String(checkRows[0]?.integrity_check ?? '').toLowerCase() === 'ok';
+    if (!recoveredOk) {
+      return { ok: false, error: 'recovered file failed integrity_check', lossStats };
+    }
+    return { ok: true, lossStats };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'salvage failed' };
+  } finally {
+    try { src.close(); } catch { /* */ }
+    try { dst.close(); } catch { /* */ }
+  }
+}
+
+/**
+ * Atomically swap a freshly recovered DB into the canonical path, keeping the
+ * corrupted original (+ its WAL/SHM sidecars if present) under `.corrupt.<TS>`
+ * suffixes for forensics. Caller must guarantee no live writer holds the
+ * canonical file open before invoking this — see `stopWritersBeforeRepair`
+ * for the daemon-coordinated entry point.
+ *
+ * @param {string} canonicalPath
+ * @param {string} recoveredPath
+ * @returns {{ ok: boolean, error?: string, corruptSuffix: string }}
+ */
+function atomicSwap(canonicalPath, recoveredPath) {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
+  const corruptSuffix = `.corrupt.${ts}`;
+  try {
+    if (existsSync(canonicalPath)) {
+      renameSync(canonicalPath, canonicalPath + corruptSuffix);
+    }
+    const walPath = canonicalPath + '-wal';
+    const shmPath = canonicalPath + '-shm';
+    if (existsSync(walPath)) {
+      try { renameSync(walPath, walPath + corruptSuffix); } catch { /* not always present */ }
+    }
+    if (existsSync(shmPath)) {
+      try { renameSync(shmPath, shmPath + corruptSuffix); } catch { /* not always present */ }
+    }
+    renameSync(recoveredPath, canonicalPath);
+    return { ok: true, corruptSuffix };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'swap failed', corruptSuffix };
+  }
+}
+
+/**
+ * Probe the memory DB for corruption and run a tiered repair if found:
+ *
+ *  - Tier 1: `REINDEX` in place (index-only corruption — #743).
+ *  - Tier 2: `VACUUM INTO` fresh file + atomic swap (table b-tree corruption).
+ *  - Tier 3: row-level salvage + atomic swap (deep corruption with partial
+ *    row loss).
+ *
+ * Returns a structured result:
+ *  - `{ repaired: false, errors: 0 }` — healthy or absent.
+ *  - `{ repaired: true, errors: N, tier: 'reindex' }` — Tier 1 worked.
+ *  - `{ repaired: true, errors: N, tier: 'vacuum', corruptBackup }` — Tier 2.
+ *  - `{ repaired: true, errors: N, tier: 'salvage', corruptBackup, lossStats }`
+ *    — Tier 3 (partial row loss possible; see `lossStats`).
+ *  - `{ repaired: false, errors: N, persistent: true }` — nothing worked;
+ *    manual recovery needed.
  *
  * Never throws; any internal failure becomes `{ repaired: false, errors: 0 }`
  * so a probe failure cannot block session start.
+ *
+ * @param {string} projectRoot
+ * @returns {Promise<{
+ *   repaired: boolean,
+ *   errors: number,
+ *   tier?: 'reindex' | 'vacuum' | 'salvage',
+ *   persistent?: boolean,
+ *   corruptBackup?: string,
+ *   lossStats?: Record<string, { read: number, written: number, errors: number }>,
+ * }>}
  */
 export async function repairMemoryDbIfCorrupt(projectRoot) {
   const dbPath = memoryDbPath(projectRoot);
   if (!existsSync(dbPath)) return { repaired: false, errors: 0 };
 
-  let db = null;
-  try {
-    db = await openBackend(projectRoot, { create: false });
+  // Step 1 — defensive readonly probe (cannot throw on WAL-setup errors
+  // against corrupt files). If the open itself fails, fall through to the
+  // openBackend path which has retry semantics for transient lock issues;
+  // truly unopenable files surface as persistent below.
+  const probe = await probeIntegrityRaw(dbPath);
+  if (probe.ok) return { repaired: false, errors: 0 };
 
-    const before = db.exec('PRAGMA integrity_check');
-    if (isOk(before)) {
-      return { repaired: false, errors: 0 };
+  const errors = probe.errors;
+
+  // Step 2 — Tier 1: REINDEX via the existing backend path. Fast for the
+  // common index-drift mode and preserves the file in place.
+  if (!probe.openFailed) {
+    try {
+      const db = await openBackend(projectRoot, { create: false });
+      try {
+        db.run('REINDEX');
+        const after = db.exec('PRAGMA integrity_check');
+        if (isOk(after)) {
+          db.save();
+          return { repaired: true, errors, tier: 'reindex' };
+        }
+      } finally {
+        try { db.close(); } catch { /* */ }
+      }
+    } catch {
+      // REINDEX path failed (often because openBackend's WAL pragmas throw
+      // on a corrupt file). Fall through to deeper recovery.
     }
-
-    const errors = corruptionCount(before);
-    db.run('REINDEX');
-
-    const after = db.exec('PRAGMA integrity_check');
-    if (!isOk(after)) {
-      return { repaired: false, errors, persistent: true };
-    }
-
-    db.save();
-    return { repaired: true, errors };
-  } catch {
-    return { repaired: false, errors: 0 };
-  } finally {
-    if (db) try { db.close(); } catch { /* non-fatal */ }
   }
+
+  // Step 3 — Tier 2: VACUUM INTO a fresh file.
+  const recoveredPath = dbPath + '.recovered';
+  const vacuum = await tryVacuumInto(dbPath, recoveredPath);
+  if (vacuum.ok) {
+    const recoveredProbe = await probeIntegrityRaw(recoveredPath);
+    if (recoveredProbe.ok) {
+      const swap = atomicSwap(dbPath, recoveredPath);
+      if (swap.ok) {
+        return {
+          repaired: true,
+          errors: errors || corruptionCount(recoveredProbe),
+          tier: 'vacuum',
+          corruptBackup: dbPath + swap.corruptSuffix,
+        };
+      }
+    }
+    try { unlinkSync(recoveredPath); } catch { /* */ }
+  }
+
+  // Step 4 — Tier 3: row-level salvage.
+  const salvage = await trySalvageRowByRow(dbPath, recoveredPath);
+  if (salvage.ok) {
+    const swap = atomicSwap(dbPath, recoveredPath);
+    if (swap.ok) {
+      return {
+        repaired: true,
+        errors,
+        tier: 'salvage',
+        corruptBackup: dbPath + swap.corruptSuffix,
+        lossStats: salvage.lossStats,
+      };
+    }
+    try { unlinkSync(recoveredPath); } catch { /* */ }
+  } else {
+    try { if (existsSync(recoveredPath)) unlinkSync(recoveredPath); } catch { /* */ }
+  }
+
+  // Step 5 — give up.
+  return { repaired: false, errors, persistent: true };
 }

--- a/.claude/scripts/lib/db-repair.mjs
+++ b/.claude/scripts/lib/db-repair.mjs
@@ -44,6 +44,11 @@ import { existsSync, renameSync, unlinkSync } from 'node:fs';
 import { memoryDbPath } from './moflo-paths.mjs';
 import { openBackend } from './get-backend.mjs';
 import './suppress-sqlite-warning.mjs';
+// Resolve node:sqlite once at module load — get-backend.mjs has already
+// loaded it by this point, so the dynamic import is a cache hit. Avoids
+// three independent `await import('node:sqlite')` calls inside the repair
+// functions (style cleanup; was producing no functional difference).
+const { DatabaseSync } = await import('node:sqlite');
 
 function isOk(execResult) {
   const rows = execResult?.[0]?.values ?? [];
@@ -63,11 +68,14 @@ function corruptionCount(execResult) {
  * as healthy. Readonly + no PRAGMAs = the probe always reaches the
  * `integrity_check` call regardless of file health.
  *
+ * Exported so the TS doctor check (`checkMemoryDbIntegrity` in
+ * `src/cli/commands/doctor-checks-config.ts`) can call into the same
+ * implementation instead of re-deriving the readonly-no-PRAGMAs probe.
+ *
  * @param {string} dbPath
  * @returns {Promise<{ ok: boolean, errors: number, openFailed?: boolean }>}
  */
-async function probeIntegrityRaw(dbPath) {
-  const { DatabaseSync } = await import('node:sqlite');
+export async function probeIntegrityRaw(dbPath) {
   let db;
   try {
     db = new DatabaseSync(dbPath, { readOnly: true });
@@ -98,7 +106,6 @@ async function probeIntegrityRaw(dbPath) {
  * @returns {Promise<{ ok: boolean, error?: string }>}
  */
 async function tryVacuumInto(srcPath, dstPath) {
-  const { DatabaseSync } = await import('node:sqlite');
   try { if (existsSync(dstPath)) unlinkSync(dstPath); } catch { /* best effort */ }
   let db;
   try {
@@ -139,7 +146,6 @@ async function tryVacuumInto(srcPath, dstPath) {
  * }>}
  */
 async function trySalvageRowByRow(srcPath, dstPath) {
-  const { DatabaseSync } = await import('node:sqlite');
   try { if (existsSync(dstPath)) unlinkSync(dstPath); } catch { /* */ }
 
   let src;
@@ -149,7 +155,20 @@ async function trySalvageRowByRow(srcPath, dstPath) {
     return { ok: false, error: err?.message ?? 'src open failed' };
   }
 
-  const dst = new DatabaseSync(dstPath);
+  // Open dst defensively. If this throws (e.g. permissions, dst path in a
+  // dir we can't create, or a concurrent lock on dstPath), keep the
+  // "never throws" contract by returning the failure shape — otherwise the
+  // open exception would escape past `repairMemoryDbIfCorrupt` and block
+  // session start, which is the failure mode this whole module exists to
+  // prevent.
+  let dst;
+  try {
+    dst = new DatabaseSync(dstPath);
+  } catch (err) {
+    try { src.close(); } catch { /* */ }
+    return { ok: false, error: err?.message ?? 'dst open failed' };
+  }
+
   const lossStats = {};
   const CHUNK = 500;
 

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -8,12 +8,14 @@
  */
 
 import { spawn, execFileSync } from 'child_process';
-import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { mofloDir } from './lib/moflo-paths.mjs';
+import { mofloDir, findProjectRoot } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
+import { applyRetiredPrune } from './lib/retired-files.mjs';
+import { makeSyncer, contentEqual } from './lib/file-sync.mjs';
 
 // Headless skip (#860). The daemon's headless workers spawn `claude --print`
 // with CLAUDE_CODE_HEADLESS=true (see src/cli/services/headless-worker-
@@ -37,20 +39,13 @@ function sessionStartMirrorHeader(file) {
   return `${SESSION_START_MIRROR_MARKER} Do not edit — changes will be overwritten. -->\n<!-- Source: node_modules/moflo/.claude/guidance/shipped/${file} -->\n\n`;
 }
 
-// Detect project root by walking up from cwd to find package.json.
 // IMPORTANT: Do NOT use resolve(__dirname, '..') or '../..' — this script lives
 // in bin/ during development but gets synced to .claude/scripts/ in consumer
-// projects, so __dirname-relative paths break. findProjectRoot() works everywhere.
-function findProjectRoot() {
-  let dir = process.cwd();
-  const root = resolve(dir, '/');
-  while (dir !== root) {
-    if (existsSync(resolve(dir, 'package.json'))) return dir;
-    dir = dirname(dir);
-  }
-  return process.cwd();
-}
-
+// projects, so __dirname-relative paths break. findProjectRoot() (lib/moflo-
+// paths.mjs) resolves identically to the TS bridge (#1057): CLAUDE_PROJECT_DIR
+// first, then walk up for .moflo/moflo.db / .swarm/memory.db / CLAUDE.md+pkg /
+// package.json / .git. Inline walks here have caused N writers to land on
+// different DBs than the bridge reads from — never reintroduce one.
 const projectRoot = findProjectRoot();
 
 // Dogfood guard (#928). When this launcher runs inside the moflo repo itself,
@@ -165,8 +160,12 @@ const UPGRADE_NOTICE_INPROGRESS_TTL_MS = 5 * 60 * 1000;
 const UPGRADE_NOTICE_COMPLETED_TTL_MS = 2 * 60 * 1000;
 const UPGRADE_NOTICE_PATH = () => join(mofloDir(projectRoot), 'upgrade-notice.json');
 
-function writeUpgradeNotice(status) {
-  if (!upgradeNoticeContext) return;
+// Single-source-of-truth notice writer. Reused by writeUpgradeNotice (the
+// version-bump / drift-heal path) and the §0-bootstrap-sentinel + §3h paths
+// (#975 statusline-channel promotion). Keeps the JSON shape colocated with
+// the TTL constants instead of letting it drift across two inline copies.
+function buildAndWriteNotice(context, status) {
+  if (!context) return;
   const ttlMs = status === 'completed'
     ? UPGRADE_NOTICE_COMPLETED_TTL_MS
     : UPGRADE_NOTICE_INPROGRESS_TTL_MS;
@@ -175,15 +174,19 @@ function writeUpgradeNotice(status) {
     const now = Date.now();
     const notice = {
       status,
-      kind: upgradeNoticeContext.kind,
-      from: upgradeNoticeContext.from,
-      to: upgradeNoticeContext.to,
+      kind: context.kind,
+      from: context.from,
+      to: context.to,
       at: new Date(now).toISOString(),
       expiresAt: new Date(now + ttlMs).toISOString(),
       changes: 0,
     };
     writeFileSync(UPGRADE_NOTICE_PATH(), JSON.stringify(notice, null, 2));
   } catch { /* non-fatal — statusline just won't show the segment */ }
+}
+
+function writeUpgradeNotice(status) {
+  buildAndWriteNotice(upgradeNoticeContext, status);
 }
 
 // ── 0-pre. Drop any stale upgrade notice (#738, #743) ───────────────────────
@@ -199,6 +202,39 @@ function writeUpgradeNotice(status) {
 try {
   unlinkSync(join(mofloDir(projectRoot), 'upgrade-notice.json'));
 } catch { /* non-fatal — file usually doesn't exist */ }
+
+// ── 0-bootstrap-sentinel. Surface partial-bootstrap failures (#975) ─────────
+// `scripts/post-install-bootstrap.mjs` writes `.moflo/bootstrap-failed.json`
+// when its file-sync left some helpers unwritten (WSL DrvFs lock, EBUSY race,
+// breaker open, …). Without this block the user has no in-session signal
+// that the upgrade was incomplete — the launcher itself ran fine, but it's
+// running from STALE files. Emit a high-visibility line pointing them at
+// the healer so the silent failure mode that produced #975 can't recur.
+// Section 3h below clears the sentinel after a clean re-sync.
+//
+// Also write a `kind: 'repair'` upgrade-notice so the statusline surfaces
+// the prompt persistently — emitWarning lands on stderr only and Claude Code
+// relays it once on session start; the statusline keeps the indicator in
+// front of the user until §3h flips it to `completed` (sync resolved) or
+// the 5-min in-progress TTL expires (visibility cap, statusline tests).
+let bootstrapSentinelData = null;
+const BOOTSTRAP_SENTINEL_PATH = resolve(mofloDir(projectRoot), 'bootstrap-failed.json');
+let bootstrapNoticeContext = null;
+try {
+  if (existsSync(BOOTSTRAP_SENTINEL_PATH)) {
+    bootstrapSentinelData = JSON.parse(readFileSync(BOOTSTRAP_SENTINEL_PATH, 'utf-8'));
+    const count = Array.isArray(bootstrapSentinelData?.failures) ? bootstrapSentinelData.failures.length : 0;
+    const sentinelVersion = bootstrapSentinelData?.mofloVersion || 'unknown';
+    emitWarning(
+      `Upgrade detected ${count} unfinished install step(s) from npm install (moflo@${sentinelVersion}). Run /healer --fix to repair.`,
+    );
+    bootstrapNoticeContext = { kind: 'repair', from: sentinelVersion, to: sentinelVersion };
+    buildAndWriteNotice(bootstrapNoticeContext, 'in-progress');
+  }
+} catch (err) {
+  // Unreadable sentinel — leave it; healer will catch the underlying issue.
+  emitWarning(`bootstrap sentinel read skipped (${errMessage(err)})`);
+}
 
 // ── 0. Legacy whole-DB / directory migrations have been retired (#851) ─────
 // LEGACY-V2: Pre-#851 the launcher renamed `.claude-flow/` → `.moflo/` and
@@ -232,15 +268,51 @@ try {
 try {
   const repair = await repairMemoryDbIfCorrupt(projectRoot);
   if (repair?.repaired) {
-    emitMutation(
-      'repaired memory db index',
-      `${plural(repair.errors, 'index error')} fixed via REINDEX`,
-    );
+    // Three recovery tiers, three messages. Tier surfaces what level of
+    // damage the DB had so the user (and any downstream telemetry) knows
+    // whether row data was lost. See bin/lib/db-repair.mjs for the cascade.
+    if (repair.tier === 'reindex') {
+      emitMutation(
+        'repaired memory db index',
+        `${plural(repair.errors, 'index error')} fixed via REINDEX`,
+      );
+    } else if (repair.tier === 'vacuum') {
+      emitMutation(
+        'rebuilt memory db',
+        `${plural(repair.errors, 'integrity violation')} fixed via VACUUM INTO; corrupt original kept at ${repair.corruptBackup ?? '.moflo/moflo.db.corrupt.*'}`,
+      );
+    } else if (repair.tier === 'salvage') {
+      // Row-level salvage may have dropped rows; summarise loss so the
+      // user sees what's gone before downstream consumers (indexer,
+      // embeddings) re-process the survivors.
+      let lossSummary = '';
+      if (repair.lossStats) {
+        const losses = Object.entries(repair.lossStats)
+          .map(([tbl, s]) => {
+            const lost = Math.max(0, s.read - s.written);
+            return lost > 0 ? `${tbl} ${s.written}/${s.read}` : null;
+          })
+          .filter(Boolean);
+        if (losses.length > 0) lossSummary = ` (rows preserved: ${losses.join(', ')})`;
+      }
+      emitMutation(
+        'salvaged memory db',
+        `${plural(repair.errors, 'integrity violation')} recovered via row-level salvage${lossSummary}; corrupt original kept at ${repair.corruptBackup ?? '.moflo/moflo.db.corrupt.*'}`,
+      );
+    } else {
+      // Older db-repair without a `tier` field — fall back to legacy text.
+      emitMutation(
+        'repaired memory db',
+        `${plural(repair.errors, 'integrity violation')} fixed`,
+      );
+    }
   } else if (repair?.persistent) {
     // Surface to stderr — Claude additionalContext + the user both see this.
-    // Manual `flo memory rebuild-index` is the next step.
+    // Every recovery tier exhausted; user options are destructive only.
     process.stderr.write(
-      `moflo: memory db has ${plural(repair.errors, 'index error')} REINDEX could not fix — run 'flo memory rebuild-index'\n`,
+      `moflo: memory db has ${plural(repair.errors, 'integrity violation')} ` +
+      `that REINDEX / VACUUM INTO / row-level salvage could not fix — ` +
+      `run 'flo memory rebuild-index' (destructive) or restore from backup\n`,
     );
   }
 } catch {
@@ -404,6 +476,24 @@ try {
           'upgraded',
           cachedVersion ? `${cachedVersion} → ${installedVersion}` : `installed ${installedVersion}`,
         );
+        // #981 / #987 — one-time architecture notice. Single-writer routing
+        // means daemon must be running for safe multi-process writes. Sentinel
+        // file ensures the notice fires once per consumer (across upgrades),
+        // not on every version bump. `flo doctor` surfaces the runtime warning
+        // when the daemon is disabled with MCP configured.
+        try {
+          const noticeSentinel = join(mofloDir(projectRoot), 'single-writer-notice-shown');
+          if (cachedVersion && !existsSync(noticeSentinel)) {
+            emitMutation(
+              'single-writer write architecture active',
+              'memory writes route through the daemon (#981) — keep daemon.auto_start: true to prevent multi-process clobber',
+            );
+            try {
+              mkdirSync(mofloDir(projectRoot), { recursive: true });
+              writeFileSync(noticeSentinel, new Date().toISOString());
+            } catch { /* sentinel best-effort — re-emit next session if write fails */ }
+          }
+        } catch { /* never block the upgrade flow on the notice */ }
       } else {
         upgradeNoticeContext = {
           kind: 'repair',
@@ -517,65 +607,21 @@ try {
       // pre-upgrade content forever because it was never recorded in the
       // manifest. Surface failures on stderr — Claude Code captures
       // session-start stderr as additionalContext so the user sees them too.
-      const syncFailures = [];
-
-      // Standard retry with exponential backoff + circuit breaker for the
-      // transient error class (EBUSY / EPERM / EACCES — Windows file lock,
-      // AV real-time scan, concurrent helper invocation). Hard errors
-      // (ENOENT, etc.) fall through immediately. Once 5 distinct files have
-      // exhausted retries the circuit opens and the tail of the sync runs
-      // with maxAttempts=1 so a sick host (AV mid-scan over node_modules)
-      // doesn't compound the wall-clock cost. Async setTimeout — never
-      // busy-wait in a session-start hook (CPU pinning during EBUSY backoff
-      // is the worst possible response when the OS is the bottleneck).
-      const TRANSIENT_CODES = new Set(['EBUSY', 'EPERM', 'EACCES']);
-      const RETRY_BACKOFF_MS = [50, 200, 800];
-      const CIRCUIT_BREAK_THRESHOLD = 5;
-      let circuitOpen = false;
-      const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-      async function syncWithRetry(operation) {
-        const maxAttempts = circuitOpen ? 1 : RETRY_BACKOFF_MS.length + 1;
-        let lastErr = null;
-        let lastCode = null;
-        for (let attempt = 0; attempt < maxAttempts; attempt++) {
-          if (attempt > 0) await sleep(RETRY_BACKOFF_MS[attempt - 1]);
-          try {
-            operation();
-            return { ok: true };
-          } catch (err) {
-            lastErr = err;
-            lastCode = err && err.code ? err.code : null;
-            if (!TRANSIENT_CODES.has(lastCode)) break;
-          }
-        }
-        if (!circuitOpen && syncFailures.length + 1 >= CIRCUIT_BREAK_THRESHOLD) {
-          circuitOpen = true;
-        }
-        return { ok: false, err: lastErr, code: lastCode };
-      }
-
-      /** Copy src → dest if src exists, record `{path, size}` in manifest.
-       * Retries the transient error class with backoff (#854); failures land
-       * in syncFailures for the post-block stderr summary. The recorded size
-       * is read from the just-written destination so a subsequent launcher
-       * can detect content drift via size mismatch. */
+      //
+      // Retry/breaker semantics (#854) + hash-skip + atomic tmp+rename + post-
+      // write verify (#975) live in `./lib/file-sync.mjs`, shared with
+      // `scripts/post-install-bootstrap.mjs` so the npm-install path and the
+      // session-start path can't drift. The launcher records manifest entries
+      // on success via the onSuccess callback so currentManifest stays the
+      // single source of truth for next-session retired-file cleanup.
       function recordManifestEntry(manifestKey, dest) {
         let size = null;
         try { size = statSync(dest).size; } catch { /* size left null — drift check still works on file-existence */ }
         currentManifest.push({ path: manifestKey, size });
       }
-      async function syncFile(src, dest, manifestKey) {
-        if (!existsSync(src)) return;
-        const result = await syncWithRetry(() => copyFileSync(src, dest));
-        if (result.ok) {
-          recordManifestEntry(manifestKey, dest);
-          return;
-        }
-        const tail = TRANSIENT_CODES.has(result.code)
-          ? ` (retried ${RETRY_BACKOFF_MS.length}× after ${result.code}${circuitOpen ? '; circuit open' : ''})`
-          : '';
-        syncFailures.push({ key: manifestKey, message: `${errMessage(result.err)}${tail}` });
-      }
+      const { syncFile, failures: syncFailures } = makeSyncer({
+        onSuccess: (key, dest) => recordManifestEntry(key, dest),
+      });
 
       // Version changed — sync scripts from bin/
       if (autoUpdateConfig.scripts) {
@@ -662,24 +708,65 @@ try {
           for (const srcDir of helperSources) {
             const src = resolve(srcDir, file);
             if (existsSync(src)) {
-              const inlineResult = await syncWithRetry(() => copyFileSync(src, dest));
-              if (inlineResult.ok) {
-                recordManifestEntry(`.claude/helpers/${file}`, dest);
-              } else {
-                const code = inlineResult.code;
-                const tail = TRANSIENT_CODES.has(code)
-                  ? ` (retried ${RETRY_BACKOFF_MS.length}× after ${code}${circuitOpen ? '; circuit open' : ''})`
-                  : '';
-                syncFailures.push({
-                  key: `.claude/helpers/${file}`,
-                  message: `${errMessage(inlineResult.err)}${tail}`,
-                });
-              }
-              break; // first source wins
+              // First existing source wins — same semantics as before. The
+              // shared syncFile records manifest + collects failures the
+              // same way the rest of section 3 does.
+              await syncFile(src, dest, `.claude/helpers/${file}`);
+              break;
             }
           }
         }
       }
+
+      // ── Sync .claude/agents/ + .claude/skills/ recursively (#948) ──────
+      // Pre-#948, agents and skills weren't manifest-tracked at all, so any
+      // file moflo retired (e.g. the 49 ruflo-aspirational agents in #932 or
+      // skill-builder in #945) would linger forever in consumer projects —
+      // Claude Code kept loading them on every prompt, paying the per-prompt
+      // roster tokens we just spent #932 fixing. Walking these dirs through
+      // syncFile() puts every shipped file in `currentManifest`, which lets
+      // the cleanup loop below auto-prune retired files going forward.
+      //
+      // Limitation: this only catches retirements that happen AFTER #948.
+      // For files retired BEFORE #948 (#932 + #945), see the retired-files.json
+      // hash-gated prune block further down — it ships a static list with
+      // content hashes so we only delete files the consumer didn't customize.
+      //
+      // User-authored files at custom paths (.claude/agents/custom/foo.md,
+      // .claude/skills/<custom>/SKILL.md) are NEVER passed through syncFile()
+      // because they don't exist in node_modules/moflo/, so they never enter
+      // the manifest and never get pruned — same proven safety story as
+      // scripts/helpers above.
+      async function syncDirRecursive(srcDir, destPrefix) {
+        if (!existsSync(srcDir)) return;
+        let entries;
+        try {
+          entries = readdirSync(srcDir, { recursive: true, withFileTypes: true });
+        } catch (err) {
+          emitWarning(`${destPrefix} readdir failed (${errMessage(err)})`);
+          return;
+        }
+        for (const entry of entries) {
+          if (!entry.isFile()) continue;
+          if (!entry.name.toLowerCase().endsWith('.md')) continue;
+          const parent = entry.parentPath || entry.path || srcDir;
+          const absSrc = resolve(parent, entry.name);
+          const rel = absSrc.slice(srcDir.length + 1).split(/[\\/]/).join('/');
+          const absDest = resolve(projectRoot, destPrefix, rel);
+          try { mkdirSync(dirname(absDest), { recursive: true }); } catch (err) {
+            emitWarning(`${destPrefix} subdir mkdir failed for ${rel} (${errMessage(err)})`);
+          }
+          await syncFile(absSrc, absDest, `${destPrefix}/${rel}`);
+        }
+      }
+      await syncDirRecursive(
+        resolve(projectRoot, 'node_modules/moflo/.claude/agents'),
+        '.claude/agents',
+      );
+      await syncDirRecursive(
+        resolve(projectRoot, 'node_modules/moflo/.claude/skills'),
+        '.claude/skills',
+      );
 
       // Sync all shipped guidance files from node_modules/moflo/.claude/guidance/shipped/
       const guidanceDir = resolve(projectRoot, '.claude/guidance');
@@ -723,6 +810,56 @@ try {
       }
       if (removedFiles > 0) {
         emitMutation('cleaned up retired files', `${removedFiles} removed`);
+      }
+
+      // ── Hash-gated prune of pre-#948 retirements (Mechanism B) ─────────
+      // The manifest cleanup above only knows about files moflo previously
+      // synced. Agents and skills retired BEFORE #948 (#932's 49 agents and
+      // #945's skill-builder, plus older retirements) were never in any
+      // manifest — they exist on disk in consumer projects only because
+      // earlier moflo versions shipped them via the npm tarball + flo init.
+      // `retired-files.json` is the explicit, reviewable static list that
+      // closes that gap. Each entry pairs a path with the sha256 hashes of
+      // every content version moflo previously shipped, so we only auto-
+      // prune when the consumer's file matches a known-shipped hash —
+      // customized files (different hash) get preserved with a one-line
+      // notice the user can act on.
+      try {
+        const retiredManifestPath = resolve(
+          projectRoot,
+          'node_modules/moflo/retired-files.json',
+        );
+        const report = applyRetiredPrune(projectRoot, retiredManifestPath);
+        if (report.pruned.length > 0) {
+          emitMutation(
+            'pruned retired shipped files',
+            `${plural(report.pruned.length, 'file')} matching known-shipped content removed`,
+          );
+        }
+        if (report.preserved.length > 0) {
+          // stdout (not stderr) so Claude sees this in `additionalContext`
+          // and can surface to the user — these aren't failures, just
+          // consumer-customized files we deliberately left alone.
+          const sample = report.preserved.slice(0, 5).map((p) => `  - ${p}`).join('\n');
+          const more = report.preserved.length > 5
+            ? `\n  …and ${report.preserved.length - 5} more`
+            : '';
+          try {
+            process.stdout.write(
+              `moflo: retained ${plural(report.preserved.length, 'customized retired file')} (delete manually if unwanted):\n${sample}${more}\n`,
+            );
+          } catch { /* non-fatal */ }
+        }
+        if (report.failed.length > 0) {
+          const sample = report.failed.slice(0, 3)
+            .map((f) => `  - ${f.path}: ${f.message}`).join('\n');
+          emitWarning(`${plural(report.failed.length, 'retired file')} failed to prune:\n${sample}`);
+        }
+      } catch (err) {
+        // Non-fatal — the consumer just doesn't get the prune this session.
+        // Next session retries; manifest-cleanup above still works for
+        // future retirements regardless.
+        emitWarning(`retired-files prune skipped (${errMessage(err)})`);
       }
 
       // The daemon was already stopped above so the lock file is gone and
@@ -776,37 +913,42 @@ try {
 // longer exists in source, calling a require helper that prints the warning
 // every time `neural_predict` / `neural_patterns` fires.
 //
-// Fix: compare the daemon-lock's `startedAt` against `node_modules/moflo/`'s
-// install mtime. If the daemon predates the current install, recycle it. The
-// install mtime is a stable proxy because npm rewrites the package.json on
-// every `npm install`, even when the resolved version is unchanged.
+// Fix (epic #1054): compare the daemon-lock's reported moflo `version` against
+// the installed `node_modules/moflo/package.json` version. If they differ —
+// or the lock predates #1054 and has no `version` field at all — recycle the
+// daemon. This is exact (not a heuristic margin like the prior mtime-based
+// check) and named explicitly so the doctor's Daemon Version Skew check
+// (#1059) can share the diagnosis.
 //
-// Margin absorbs clock skew between npm's mtime write and the daemon-lock
-// `startedAt` clock — within this window the daemon is likely the post-install
-// daemon, not a stale predecessor.
-const STALE_DAEMON_MTIME_SKEW_MS = 5_000;
+// Pre-#1054 daemons have no `version` in their lock payload — treated as a
+// mismatch by definition because by construction they were launched before
+// version publishing existed.
 try {
   const mofloPkgPathForRecycle = resolve(projectRoot, 'node_modules/moflo/package.json');
   const lockFile = resolve(projectRoot, '.moflo', 'daemon.lock');
-  // Cheap stat first — if the daemon-lock or package.json is gone we're done.
-  // statSync throws ENOENT on a missing file; the outer catch absorbs it.
-  const installedAt = statSync(mofloPkgPathForRecycle).mtimeMs;
-  const lockMtime = statSync(lockFile).mtimeMs;
-  // Quick reject: if the lock file itself is younger than the install, the
-  // daemon was started after install — no read of lock contents needed.
-  if (installedAt - lockMtime > STALE_DAEMON_MTIME_SKEW_MS) {
-    let daemonStartedAt = 0;
+  // Cheap stat first — if either file is gone, no skew check is possible.
+  if (existsSync(mofloPkgPathForRecycle) && existsSync(lockFile)) {
+    const installedVersion = JSON.parse(readFileSync(mofloPkgPathForRecycle, 'utf-8')).version;
+    let daemonVersion;
     try {
       const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
-      if (typeof lock?.startedAt === 'number') daemonStartedAt = lock.startedAt;
-    } catch { /* corrupt lock — fall through, recycleDaemon will unlink it */ }
-    if (daemonStartedAt > 0 && (installedAt - daemonStartedAt) > STALE_DAEMON_MTIME_SKEW_MS) {
-      if (recycleDaemon(lockFile, 'daemon-stale-recycle')) {
-        emitMutation('recycled stale daemon', 'predates current install');
+      if (typeof lock?.version === 'string') daemonVersion = lock.version;
+    } catch { /* corrupt lock — recycleDaemon will unlink it */ }
+    if (daemonVersion !== installedVersion) {
+      if (recycleDaemon(lockFile, 'daemon-version-skew')) {
+        const observed = daemonVersion ?? '<pre-1054 / unknown>';
+        emitMutation(
+          'recycled stale daemon',
+          `version skew: installed ${installedVersion}, daemon ${observed}`,
+        );
       }
     }
   }
-} catch { /* non-fatal — best-effort stale-daemon detection */ }
+} catch (err) {
+  // Non-fatal; surface via emitWarning per feedback_no_layered_workarounds —
+  // no silent catch on the upgrade path (#854).
+  emitWarning(`daemon version-skew check failed: ${errMessage(err)}`);
+}
 
 // ── 3a. Auto-migrate settings.json (npx flo → node helpers, PATH setup) ────
 // Existing users may have stale settings.json with `npx flo` hooks that break
@@ -1093,7 +1235,7 @@ try {
 // Also prunes top-level mirrors whose source no longer exists in shipped/
 // (#839): pre-manifest-tracking mirrors never appeared in installed-files.json
 // so the section-3 manifest-diff cleanup can't reach them. The marker gate
-// protects user files and `moflo-bootstrap.md` (distinct `moflo init` marker).
+// protects user-authored files; pre-#939 moflo-bootstrap.md is handled by 3c-939.
 try {
   const guidanceDir = resolve(projectRoot, '.claude/guidance');
   const shippedDir = resolve(projectRoot, 'node_modules/moflo/.claude/guidance/shipped');
@@ -1169,6 +1311,24 @@ try {
   }
 } catch { /* non-fatal */ }
 
+// ── 3c-939. Remove pre-#939 moflo-bootstrap.md duplicate ────────────────────
+// Before #939, `flo init` Step 7 (and `flo-setup`) renamed moflo-subagents.md
+// to moflo-bootstrap.md while the launcher's stage-3 ALSO synced the original
+// name — consumers ended up with two copies of the same content on disk. The
+// rename is gone; this prunes any leftover from older installs. Marker-gated
+// so we never delete a homonymous user-authored file.
+try {
+  const legacyBootstrap = resolve(projectRoot, '.claude/guidance/moflo-bootstrap.md');
+  if (existsSync(legacyBootstrap)) {
+    const head = readFileSync(legacyBootstrap, 'utf-8').slice(0, 200);
+    const ours = head.includes('AUTO-GENERATED by moflo init') || head.includes('AUTO-GENERATED by flo-setup');
+    if (ours) {
+      unlinkSync(legacyBootstrap);
+      emitMutation('removed legacy moflo-bootstrap.md', 'duplicate of moflo-subagents.md (#939)');
+    }
+  }
+} catch { /* non-fatal */ }
+
 // ── 3d-yaml-create. Create moflo.yaml if missing (#895) ────────────────────
 // Sibling self-heal to 3d-yaml: that block APPENDS new sections to existing
 // yaml; this block CREATES the file from the canonical template when no yaml
@@ -1195,6 +1355,15 @@ try {
           'review defaults — model routing, sandbox, gates, hooks',
         );
       }
+    } else {
+      // Previously a silent skip — masked the actual reason consumers didn't
+      // get a yaml after upgrading from pre-#895 versions. If neither template
+      // path resolves the install is incomplete (partial extract, prune ate
+      // the file, dogfood without a built dist/). Surface a healer hint so
+      // the user can repair instead of staring at a missing yaml.
+      emitWarning(
+        `moflo.yaml create skipped — template not found at ${tplPaths.join(' or ')}; run 'flo doctor --fix' to repair`,
+      );
     }
   }
 } catch (err) {
@@ -1355,61 +1524,19 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
-// ── 3f. Flip the upgrade notice to "completed" (#636, #738) ─────────────────
-// See the TTL rationale at the constants above for why we switch to a
-// short-TTL completed badge instead of clearing the file.
-if (upgradeNoticeContext) {
-  writeUpgradeNotice('completed');
-}
-
-// ── 3g. Commit deferred version stamp (#730) ────────────────────────────────
-// Written LAST so an abort above leaves the stamp unchanged and the next
-// launcher re-detects the upgrade. Failure here is surfaced (#854) so a
-// permanently-broken stamp write (filesystem permissions, AV holds) doesn't
-// silently strand consumers in re-detect-on-every-session loops.
-if (pendingVersionStampWrite) {
-  try {
-    writeFileSync(pendingVersionStampWrite.path, pendingVersionStampWrite.version);
-  } catch (err) {
-    emitWarning(`version stamp write failed (${errMessage(err)}) — next launcher will re-detect the upgrade`);
-  }
-}
-
-// Bypasses emitMutation — framing, not a mutation, so it must not inflate the count.
-if (mutationCount > 0) {
-  try {
-    process.stdout.write(
-      'moflo: starting background tasks (daemon, indexer, pretrain — CPU may briefly spike)\n',
-    );
-  } catch { /* non-fatal */ }
-}
-
-// ── 4. Spawn background tasks ───────────────────────────────────────────────
-
-// hooks.mjs session-start (daemon, indexer, pretrain, HNSW, neural patterns).
-// Bin-first ordering via resolveMofloBin — prefers the npm-package copy over
-// the `.claude/scripts/` mirror (#866). The mirror is a derived sync that
-// races the launcher's section-3 file copies during the very upgrade session;
-// spawning the still-stale mirror produces an orphan running pre-upgrade argv
-// (e.g. `rebuild-index --force` after #859 had already dropped it). The pkg
-// copy is updated atomically by `npm install moflo`, so spawning from there
-// guarantees the running hook code matches the installed package.
-const hooksScript = resolveMofloBin(projectRoot, null, 'hooks.mjs');
-if (hooksScript) {
-  fireAndForget('node', [hooksScript, 'session-start'], 'hooks session-start');
-}
-
-// Migration runner — consults `.moflo/migrations.json` and runs only
-// migrations that haven't been recorded. Fast-paths to a no-op when the
-// manifest is current; the runner module loads with lazy sql.js init in
-// each migration, so a stamped session pays only node startup + ESM graph.
+// ── 3e-1057. Run unmet schema migrations BEFORE daemon spawn ────────────────
+// run-migrations.mjs walks `bin/migrations/*.mjs` and invokes each that has
+// not been recorded in `.moflo/migrations.json`. Each migration opens sql.js
+// directly and persists with atomicWriteFileSync. They MUST run before the
+// daemon spawns or the daemon's in-RAM snapshot races their on-disk writes
+// — the bug class S2 detects (#1056 version-skew kill) and S3 (#1057)
+// closes for good. Pre-#1057 this ran in Section 4 AFTER `hooks session-
+// start` fired off the daemon, which is exactly the race fixed here.
 //
-// Prefer the npm-package path so first-install consumers run unmet
-// migrations without waiting for a script-sync round-trip.
-//
-// Run synchronously (capture stdout) so each completed migration surfaces
-// through emitMutation — Claude's session-start hook captures launcher
-// stdout and that's the only channel that reaches the user.
+// Synchronous on purpose: blocking by ≤30s on a one-time migration is the
+// right trade vs. an inconsistent post-upgrade DB. The runner short-circuits
+// to a no-op when nothing is pending, so steady-state cost is just the node
+// startup + ESM graph (~80ms on a warm fs).
 const runMigrations = resolveMofloBin(projectRoot, null, 'run-migrations.mjs');
 if (runMigrations) {
   runMigrationsAndAnnounce(runMigrations);
@@ -1435,9 +1562,11 @@ function runMigrationsAndAnnounce(runnerPath) {
   const labels = {
     'knowledge-to-learnings': 'consolidated knowledge → learnings',
     'knowledge-purge': 'removed legacy knowledge namespace rows',
+    'purge-doc-entries': 'pruned legacy doc-* rows (chunk-only RAG, #1053)',
+    'strip-context-preambles': 'stripped chunk preambles; embeddings will rebuild on next index pass (#1053)',
   };
 
-  for (const line of raw.split('\n')) {
+  for (const line of raw.split(/\r?\n/)) {
     const m = line.match(/^\[migrations\]\s+([\w-]+):\s+done\s+in\s+\d+ms\s*(.*)$/);
     if (!m) continue;
     const migrationName = m[1];
@@ -1462,6 +1591,85 @@ function runMigrationsAndAnnounce(runnerPath) {
     const label = labels[migrationName] || `migration ${migrationName}`;
     emitMutation(label, detail);
   }
+}
+
+// ── 3f. Flip the upgrade notice to "completed" (#636, #738) ─────────────────
+// See the TTL rationale at the constants above for why we switch to a
+// short-TTL completed badge instead of clearing the file.
+if (upgradeNoticeContext) {
+  writeUpgradeNotice('completed');
+}
+
+// ── 3g. Commit deferred version stamp (#730) ────────────────────────────────
+// Written LAST so an abort above leaves the stamp unchanged and the next
+// launcher re-detects the upgrade. Failure here is surfaced (#854) so a
+// permanently-broken stamp write (filesystem permissions, AV holds) doesn't
+// silently strand consumers in re-detect-on-every-session loops.
+if (pendingVersionStampWrite) {
+  try {
+    writeFileSync(pendingVersionStampWrite.path, pendingVersionStampWrite.version);
+  } catch (err) {
+    emitWarning(`version stamp write failed (${errMessage(err)}) — next launcher will re-detect the upgrade`);
+  }
+}
+
+// ── 3h. Clear bootstrap sentinel if section-3 sync resolved it (#975) ───────
+// Section 3 above re-attempts the same file copies the bootstrap was supposed
+// to do, with the launcher's own retry logic. If after section 3 every file
+// the bootstrap reported as failed is now byte-identical to its source, the
+// previously-unfinished work is done — drop the sentinel so the warning at
+// section 0-bootstrap-sentinel doesn't fire on the next session. If anything
+// is still mismatched, leave the sentinel in place; healer / next session
+// will re-attempt.
+if (bootstrapSentinelData?.failures?.length > 0) {
+  try {
+    const allRepaired = bootstrapSentinelData.failures.every((f) => {
+      if (!f?.src || !f?.dest) return false;
+      // contentEqual already does the size short-circuit + SHA-1 hash and
+      // is the same predicate the §3 sync used to decide whether to skip
+      // the copy in the first place — reusing it here keeps "the sentinel
+      // is clearable when bytes match" consistent across both code paths.
+      return contentEqual(f.src, f.dest);
+    });
+    if (allRepaired) {
+      unlinkSync(BOOTSTRAP_SENTINEL_PATH);
+      emitMutation('cleared bootstrap-failed sentinel', 'previously-failed copies are now in sync');
+      // Flip the §0-bootstrap-sentinel "in-progress" repair notice to
+      // "completed" so the statusline shows the post-repair badge. Skip when
+      // §3 already wrote its own upgradeNoticeContext (version bump / drift)
+      // — that path runs the §3f writer with its own kind/version and we
+      // shouldn't clobber it from here.
+      if (bootstrapNoticeContext && !upgradeNoticeContext) {
+        buildAndWriteNotice(bootstrapNoticeContext, 'completed');
+      }
+    }
+  } catch (err) {
+    emitWarning(`bootstrap sentinel verify skipped (${errMessage(err)})`);
+  }
+}
+
+// Bypasses emitMutation — framing, not a mutation, so it must not inflate the count.
+if (mutationCount > 0) {
+  try {
+    process.stdout.write(
+      'moflo: starting background tasks (daemon, indexer, pretrain — CPU may briefly spike)\n',
+    );
+  } catch { /* non-fatal */ }
+}
+
+// ── 4. Spawn background tasks ───────────────────────────────────────────────
+
+// hooks.mjs session-start (daemon, indexer, pretrain, HNSW, neural patterns).
+// Bin-first ordering via resolveMofloBin — prefers the npm-package copy over
+// the `.claude/scripts/` mirror (#866). The mirror is a derived sync that
+// races the launcher's section-3 file copies during the very upgrade session;
+// spawning the still-stale mirror produces an orphan running pre-upgrade argv
+// (e.g. `rebuild-index --force` after #859 had already dropped it). The pkg
+// copy is updated atomically by `npm install moflo`, so spawning from there
+// guarantees the running hook code matches the installed package.
+const hooksScript = resolveMofloBin(projectRoot, null, 'hooks.mjs');
+if (hooksScript) {
+  fireAndForget('node', [hooksScript, 'session-start'], 'hooks session-start');
 }
 
 // Patches are now baked into moflo@4.0.0 source — no runtime patching needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,19 @@ See `feedback_consumer_blast_radius.md` (auto-memory) for the full posture.
 
 ---
 
-## ⚠ Diagnosing runtime symptoms — read this first
+## ⚠ Dogfooding & local-vs-installed delivery — mandatory reading
 
-Before opening any issue or "fixing" anything observable in the editor (statusline, daemon, hooks, indexer, upgrade UI), MUST read `.claude/guidance/internal/dogfooding.md` § Runtime Symptom Diagnosis. MoFlo dogfoods itself; runtime symptoms come from `node_modules/moflo/...`, not source. Skip this and you'll waste a session debugging code that isn't even running.
+MoFlo dogfoods itself: the daemon, hooks, statusline, MCP server, and embeddings indexer ALL run from `node_modules/moflo/...` (NOT from the source tree). Source edits don't take effect for those runtime layers until publish + reinstall + Claude Code restart. Resolving paths between the source tree and the installed package has dist-vs-source depth pitfalls that bite every consumer if you get them wrong.
+
+**Before** any of the following, you MUST read `.claude/guidance/internal/dogfooding.md`:
+
+- Diagnosing any "X is broken" symptom visible in the editor (statusline, daemon, hooks, indexer, upgrade UI) — see § Runtime Symptom Diagnosis
+- Adding a new file in `bin/`, `bin/lib/`, `src/cli/`, `dist/`, or anything synced to `.claude/scripts/` — see § Delivering Changes That Work Both Local AND Installed (manifest scope + sync layers)
+- Resolving any path between TS code and `bin/*.mjs` (e.g. `dist/src/cli/services/...` → `bin/lib/...`) — see § Delivering Changes That Work Both Local AND Installed § 2 (the `../../../../` anti-pattern that broke #1126's first iteration)
+- Adding cross-process daemon coordination, atomic file swaps, or any platform-sensitive primitive — see § Delivering Changes That Work Both Local AND Installed § 6
+- Touching the smoke harness or chasing local-vs-CI smoke divergence — see § Smoke Harness Reality
+
+Skip this and you'll either waste a session debugging code that isn't running, ship a change that works in dogfood but breaks every consumer install, or break a consumer's `.moflo/` state in a way that takes a full publish-rollback-cycle to recover from.
 
 ---
 

--- a/bin/lib/db-repair.mjs
+++ b/bin/lib/db-repair.mjs
@@ -1,32 +1,49 @@
 /**
- * Memory-DB integrity check + auto-REINDEX (story #743).
+ * Memory-DB integrity check + tiered repair (#743, #1090-followup).
  *
- * The `.moflo/moflo.db` SQLite file routinely accumulates index corruption of
- * the form `row N missing from index sqlite_autoindex_memory_entries_1` —
- * the row data is intact, only the unique-key index has drifted. The most
- * common trigger is sql.js's whole-file dump-on-flush behaviour racing with
- * concurrent writes (see `feedback_sqljs_writeback_clobber.md` and #714).
+ * The `.moflo/moflo.db` SQLite file picks up corruption in two distinct modes:
+ *
+ *  1. **Index drift** — `row N missing from sqlite_autoindex_memory_entries_1`.
+ *     Row data is intact; only the unique-key b-tree is wrong. Trigger: sql.js's
+ *     whole-file dump-on-flush racing with concurrent writes (#714, #743 —
+ *     fixed for new installs by Phase 5 / #1084 which removed sql.js entirely).
+ *     **REINDEX** rebuilds the index from canonical row data.
+ *
+ *  2. **Table b-tree corruption** — `Tree N page M cell K: Rowid X out of
+ *     order`, where Tree N is a TABLE root page (not just an index). Row data
+ *     is partly intact, but page ordering is broken. Triggers we've seen:
+ *      - sql.js → node:sqlite migration: an old 4.9.x sql.js daemon flushes its
+ *        full-file dump OVER a WAL frame that the new 4.10 backend has already
+ *        written, leaving WAL referencing pages that no longer exist in main.
+ *      - Concurrent multi-process writes when the daemon was disabled (#981).
+ *     **REINDEX cannot fix this** — the table itself is broken. Recovery path:
+ *      a) `VACUUM INTO` a fresh file (single-shot rebuild; fails fast if
+ *         iteration hits an unreadable page),
+ *      b) row-level salvage — chunked `SELECT rowid > ?` per table, catching
+ *         per-chunk errors and skipping past corrupt page ranges,
+ *      c) atomic swap with .corrupt.<TS> backup retained for forensics.
+ *
+ *  3. **Unrecoverable** — header damage, encrypted-by-malware, etc. We can't
+ *     fix this; surface a clear failure and let the user decide between manual
+ *     `flo memory rebuild-index` (destructive) and offline recovery tools.
  *
  * Symptoms when uncorrected:
  *  - `index-guidance.mjs` and `index-patterns.mjs` fail mid-write with
  *    `database disk image is malformed`, leaving partial state.
  *  - The ephemeral-namespace purge (#729) fails silently, so hive-mind /
  *    tasklist / epic-state / test-bridge-fix rows accumulate.
- *  - Vector counts in the statusline stay inflated (observed: 4415 with
- *    1025 unpurged ephemeral rows).
+ *  - Vector counts in the statusline stay inflated.
+ *  - Healer's deep checks throw with "database disk image is malformed",
+ *    surfacing as the synthetic 'Check' failure (doctor.ts:214).
  *
- * Fix shape: REINDEX rebuilds indexes from the canonical row data — much less
- * destructive than a full rebuild and works for the typical drift mode. If
- * REINDEX itself fails to restore integrity we leave the file alone and
- * report; manual `flo memory rebuild-index` is the fallback.
- *
- * MUST run BEFORE any long-lived sql.js consumer (MCP server, daemon) opens
- * the DB and BEFORE the embeddings migration / soft-delete purge / ephemeral
- * purge — those all swallow corruption errors and silently no-op.
+ * MUST run BEFORE any long-lived consumer (MCP server, daemon) opens the DB
+ * and BEFORE the embeddings migration / soft-delete purge / ephemeral purge —
+ * those all swallow corruption errors and silently no-op.
  */
-import { existsSync } from 'node:fs';
+import { existsSync, renameSync, unlinkSync } from 'node:fs';
 import { memoryDbPath } from './moflo-paths.mjs';
 import { openBackend } from './get-backend.mjs';
+import './suppress-sqlite-warning.mjs';
 
 function isOk(execResult) {
   const rows = execResult?.[0]?.values ?? [];
@@ -38,42 +55,323 @@ function corruptionCount(execResult) {
 }
 
 /**
- * Probe the memory DB for index corruption and run REINDEX in place if
- * found. Returns `{ repaired, errors, persistent }`:
- *  - `repaired: true` and `errors > 0` when REINDEX restored integrity.
- *  - `repaired: false, errors: 0` when the DB is healthy or absent.
- *  - `repaired: false, errors > 0, persistent: true` when corruption survives
- *    REINDEX (caller should surface to the user — manual rebuild needed).
+ * Open `.moflo/moflo.db` raw via node:sqlite in readonly mode and run
+ * `PRAGMA integrity_check`. Bypasses {@link openBackend} because that path
+ * sets `journal_mode=WAL`, `busy_timeout`, and `synchronous=NORMAL` on every
+ * non-readonly open — those PRAGMAs can themselves throw against a corrupt
+ * file, and the pre-#1090 code path caught those throws and reported the DB
+ * as healthy. Readonly + no PRAGMAs = the probe always reaches the
+ * `integrity_check` call regardless of file health.
+ *
+ * @param {string} dbPath
+ * @returns {Promise<{ ok: boolean, errors: number, openFailed?: boolean }>}
+ */
+async function probeIntegrityRaw(dbPath) {
+  const { DatabaseSync } = await import('node:sqlite');
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+  } catch {
+    return { ok: false, errors: 0, openFailed: true };
+  }
+  try {
+    const rows = db.prepare('PRAGMA integrity_check').all();
+    if (rows.length === 1 && String(rows[0]?.integrity_check ?? '').toLowerCase() === 'ok') {
+      return { ok: true, errors: 0 };
+    }
+    return { ok: false, errors: rows.length };
+  } catch {
+    return { ok: false, errors: 0, openFailed: true };
+  } finally {
+    try { db.close(); } catch { /* already-dead handle */ }
+  }
+}
+
+/**
+ * Tier-2 recovery: `VACUUM INTO` a fresh file. Single SQLite call that
+ * iterates every row of every table and writes them to a brand-new database
+ * with rebuilt indexes. Fails fast if iteration hits an unreadable page —
+ * caller falls back to row-level salvage.
+ *
+ * @param {string} srcPath
+ * @param {string} dstPath
+ * @returns {Promise<{ ok: boolean, error?: string }>}
+ */
+async function tryVacuumInto(srcPath, dstPath) {
+  const { DatabaseSync } = await import('node:sqlite');
+  try { if (existsSync(dstPath)) unlinkSync(dstPath); } catch { /* best effort */ }
+  let db;
+  try {
+    // Open writable (not readonly) — VACUUM needs to checkpoint WAL first.
+    // Skip our standard WAL pragmas (they can throw on corrupt files); SQLite
+    // applies its defaults which are sufficient for VACUUM INTO.
+    db = new DatabaseSync(srcPath);
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'open failed' };
+  }
+  try {
+    try { db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch { /* corrupt WAL ok */ }
+    db.exec(`VACUUM INTO '${dstPath.replace(/'/g, "''")}'`);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'vacuum failed' };
+  } finally {
+    try { db.close(); } catch { /* */ }
+  }
+}
+
+/**
+ * Tier-3 recovery: row-level salvage. Iterate each non-empty table in
+ * `rowid > ?` chunks; on any chunk-read failure, skip past that chunk's
+ * rowid range and continue. Per-table loss stats returned so the caller can
+ * surface what was preserved vs lost.
+ *
+ * Schema is copied verbatim from `sqlite_master.sql` so triggers/indexes/views
+ * are preserved alongside tables. `INSERT OR IGNORE` handles unique-key
+ * collisions from any duplicate-rowid corruption mode.
+ *
+ * @param {string} srcPath
+ * @param {string} dstPath
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   error?: string,
+ *   lossStats?: Record<string, { read: number, written: number, errors: number }>,
+ * }>}
+ */
+async function trySalvageRowByRow(srcPath, dstPath) {
+  const { DatabaseSync } = await import('node:sqlite');
+  try { if (existsSync(dstPath)) unlinkSync(dstPath); } catch { /* */ }
+
+  let src;
+  try {
+    src = new DatabaseSync(srcPath, { readOnly: true });
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'src open failed' };
+  }
+
+  const dst = new DatabaseSync(dstPath);
+  const lossStats = {};
+  const CHUNK = 500;
+
+  try {
+    // Copy schema. Order matters: tables first (else indexes/triggers/views
+    // reference nonexistent tables), then everything else. sqlite_* objects
+    // (sqlite_sequence, sqlite_autoindex_*) are created implicitly by SQLite.
+    const schemaRows = src
+      .prepare(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master " +
+          "WHERE sql IS NOT NULL ORDER BY CASE type " +
+          "WHEN 'table' THEN 1 WHEN 'index' THEN 2 WHEN 'view' THEN 3 ELSE 4 END",
+      )
+      .all();
+    for (const s of schemaRows) {
+      if (String(s.name).startsWith('sqlite_')) continue;
+      try { dst.exec(s.sql + ';'); } catch { /* malformed schema row — skip */ }
+    }
+
+    // Salvage rows table-by-table.
+    const tables = src
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+      .all();
+
+    for (const t of tables) {
+      const name = String(t.name);
+      lossStats[name] = { read: 0, written: 0, errors: 0 };
+
+      const cols = src.prepare(`PRAGMA table_info('${name.replace(/'/g, "''")}')`).all();
+      if (cols.length === 0) continue;
+      const colList = cols.map((c) => '"' + String(c.name).replace(/"/g, '""') + '"').join(',');
+      const placeholders = cols.map(() => '?').join(',');
+      const insert = dst.prepare(
+        `INSERT OR IGNORE INTO "${name.replace(/"/g, '""')}" (${colList}) VALUES (${placeholders})`,
+      );
+
+      let lastRowid = 0;
+      let safetyCap = 0;
+      const MAX_ITERATIONS = 100_000;
+
+      while (safetyCap++ < MAX_ITERATIONS) {
+        let rows;
+        try {
+          rows = src
+            .prepare(
+              `SELECT rowid as __rid, * FROM "${name.replace(/"/g, '""')}" ` +
+                `WHERE rowid > ? ORDER BY rowid LIMIT ${CHUNK}`,
+            )
+            .all(lastRowid);
+        } catch {
+          lossStats[name].errors++;
+          lastRowid += CHUNK;
+          continue;
+        }
+        if (!rows || rows.length === 0) break;
+        lossStats[name].read += rows.length;
+        for (const r of rows) {
+          try {
+            insert.run(...cols.map((c) => r[c.name]));
+            lossStats[name].written++;
+          } catch {
+            lossStats[name].errors++;
+          }
+          lastRowid = Number(r.__rid);
+        }
+        if (rows.length < CHUNK) break;
+      }
+    }
+
+    // Verify the recovered file. If integrity_check still fails, the
+    // salvage didn't actually produce a clean file — surface as failure
+    // (caller will keep the corrupted original in place).
+    const checkRows = dst.prepare('PRAGMA integrity_check').all();
+    const recoveredOk =
+      checkRows.length === 1 &&
+      String(checkRows[0]?.integrity_check ?? '').toLowerCase() === 'ok';
+    if (!recoveredOk) {
+      return { ok: false, error: 'recovered file failed integrity_check', lossStats };
+    }
+    return { ok: true, lossStats };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'salvage failed' };
+  } finally {
+    try { src.close(); } catch { /* */ }
+    try { dst.close(); } catch { /* */ }
+  }
+}
+
+/**
+ * Atomically swap a freshly recovered DB into the canonical path, keeping the
+ * corrupted original (+ its WAL/SHM sidecars if present) under `.corrupt.<TS>`
+ * suffixes for forensics. Caller must guarantee no live writer holds the
+ * canonical file open before invoking this — see `stopWritersBeforeRepair`
+ * for the daemon-coordinated entry point.
+ *
+ * @param {string} canonicalPath
+ * @param {string} recoveredPath
+ * @returns {{ ok: boolean, error?: string, corruptSuffix: string }}
+ */
+function atomicSwap(canonicalPath, recoveredPath) {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
+  const corruptSuffix = `.corrupt.${ts}`;
+  try {
+    if (existsSync(canonicalPath)) {
+      renameSync(canonicalPath, canonicalPath + corruptSuffix);
+    }
+    const walPath = canonicalPath + '-wal';
+    const shmPath = canonicalPath + '-shm';
+    if (existsSync(walPath)) {
+      try { renameSync(walPath, walPath + corruptSuffix); } catch { /* not always present */ }
+    }
+    if (existsSync(shmPath)) {
+      try { renameSync(shmPath, shmPath + corruptSuffix); } catch { /* not always present */ }
+    }
+    renameSync(recoveredPath, canonicalPath);
+    return { ok: true, corruptSuffix };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? 'swap failed', corruptSuffix };
+  }
+}
+
+/**
+ * Probe the memory DB for corruption and run a tiered repair if found:
+ *
+ *  - Tier 1: `REINDEX` in place (index-only corruption — #743).
+ *  - Tier 2: `VACUUM INTO` fresh file + atomic swap (table b-tree corruption).
+ *  - Tier 3: row-level salvage + atomic swap (deep corruption with partial
+ *    row loss).
+ *
+ * Returns a structured result:
+ *  - `{ repaired: false, errors: 0 }` — healthy or absent.
+ *  - `{ repaired: true, errors: N, tier: 'reindex' }` — Tier 1 worked.
+ *  - `{ repaired: true, errors: N, tier: 'vacuum', corruptBackup }` — Tier 2.
+ *  - `{ repaired: true, errors: N, tier: 'salvage', corruptBackup, lossStats }`
+ *    — Tier 3 (partial row loss possible; see `lossStats`).
+ *  - `{ repaired: false, errors: N, persistent: true }` — nothing worked;
+ *    manual recovery needed.
  *
  * Never throws; any internal failure becomes `{ repaired: false, errors: 0 }`
  * so a probe failure cannot block session start.
+ *
+ * @param {string} projectRoot
+ * @returns {Promise<{
+ *   repaired: boolean,
+ *   errors: number,
+ *   tier?: 'reindex' | 'vacuum' | 'salvage',
+ *   persistent?: boolean,
+ *   corruptBackup?: string,
+ *   lossStats?: Record<string, { read: number, written: number, errors: number }>,
+ * }>}
  */
 export async function repairMemoryDbIfCorrupt(projectRoot) {
   const dbPath = memoryDbPath(projectRoot);
   if (!existsSync(dbPath)) return { repaired: false, errors: 0 };
 
-  let db = null;
-  try {
-    db = await openBackend(projectRoot, { create: false });
+  // Step 1 — defensive readonly probe (cannot throw on WAL-setup errors
+  // against corrupt files). If the open itself fails, fall through to the
+  // openBackend path which has retry semantics for transient lock issues;
+  // truly unopenable files surface as persistent below.
+  const probe = await probeIntegrityRaw(dbPath);
+  if (probe.ok) return { repaired: false, errors: 0 };
 
-    const before = db.exec('PRAGMA integrity_check');
-    if (isOk(before)) {
-      return { repaired: false, errors: 0 };
+  const errors = probe.errors;
+
+  // Step 2 — Tier 1: REINDEX via the existing backend path. Fast for the
+  // common index-drift mode and preserves the file in place.
+  if (!probe.openFailed) {
+    try {
+      const db = await openBackend(projectRoot, { create: false });
+      try {
+        db.run('REINDEX');
+        const after = db.exec('PRAGMA integrity_check');
+        if (isOk(after)) {
+          db.save();
+          return { repaired: true, errors, tier: 'reindex' };
+        }
+      } finally {
+        try { db.close(); } catch { /* */ }
+      }
+    } catch {
+      // REINDEX path failed (often because openBackend's WAL pragmas throw
+      // on a corrupt file). Fall through to deeper recovery.
     }
-
-    const errors = corruptionCount(before);
-    db.run('REINDEX');
-
-    const after = db.exec('PRAGMA integrity_check');
-    if (!isOk(after)) {
-      return { repaired: false, errors, persistent: true };
-    }
-
-    db.save();
-    return { repaired: true, errors };
-  } catch {
-    return { repaired: false, errors: 0 };
-  } finally {
-    if (db) try { db.close(); } catch { /* non-fatal */ }
   }
+
+  // Step 3 — Tier 2: VACUUM INTO a fresh file.
+  const recoveredPath = dbPath + '.recovered';
+  const vacuum = await tryVacuumInto(dbPath, recoveredPath);
+  if (vacuum.ok) {
+    const recoveredProbe = await probeIntegrityRaw(recoveredPath);
+    if (recoveredProbe.ok) {
+      const swap = atomicSwap(dbPath, recoveredPath);
+      if (swap.ok) {
+        return {
+          repaired: true,
+          errors: errors || corruptionCount(recoveredProbe),
+          tier: 'vacuum',
+          corruptBackup: dbPath + swap.corruptSuffix,
+        };
+      }
+    }
+    try { unlinkSync(recoveredPath); } catch { /* */ }
+  }
+
+  // Step 4 — Tier 3: row-level salvage.
+  const salvage = await trySalvageRowByRow(dbPath, recoveredPath);
+  if (salvage.ok) {
+    const swap = atomicSwap(dbPath, recoveredPath);
+    if (swap.ok) {
+      return {
+        repaired: true,
+        errors,
+        tier: 'salvage',
+        corruptBackup: dbPath + swap.corruptSuffix,
+        lossStats: salvage.lossStats,
+      };
+    }
+    try { unlinkSync(recoveredPath); } catch { /* */ }
+  } else {
+    try { if (existsSync(recoveredPath)) unlinkSync(recoveredPath); } catch { /* */ }
+  }
+
+  // Step 5 — give up.
+  return { repaired: false, errors, persistent: true };
 }

--- a/bin/lib/db-repair.mjs
+++ b/bin/lib/db-repair.mjs
@@ -44,6 +44,11 @@ import { existsSync, renameSync, unlinkSync } from 'node:fs';
 import { memoryDbPath } from './moflo-paths.mjs';
 import { openBackend } from './get-backend.mjs';
 import './suppress-sqlite-warning.mjs';
+// Resolve node:sqlite once at module load — get-backend.mjs has already
+// loaded it by this point, so the dynamic import is a cache hit. Avoids
+// three independent `await import('node:sqlite')` calls inside the repair
+// functions (style cleanup; was producing no functional difference).
+const { DatabaseSync } = await import('node:sqlite');
 
 function isOk(execResult) {
   const rows = execResult?.[0]?.values ?? [];
@@ -63,11 +68,14 @@ function corruptionCount(execResult) {
  * as healthy. Readonly + no PRAGMAs = the probe always reaches the
  * `integrity_check` call regardless of file health.
  *
+ * Exported so the TS doctor check (`checkMemoryDbIntegrity` in
+ * `src/cli/commands/doctor-checks-config.ts`) can call into the same
+ * implementation instead of re-deriving the readonly-no-PRAGMAs probe.
+ *
  * @param {string} dbPath
  * @returns {Promise<{ ok: boolean, errors: number, openFailed?: boolean }>}
  */
-async function probeIntegrityRaw(dbPath) {
-  const { DatabaseSync } = await import('node:sqlite');
+export async function probeIntegrityRaw(dbPath) {
   let db;
   try {
     db = new DatabaseSync(dbPath, { readOnly: true });
@@ -98,7 +106,6 @@ async function probeIntegrityRaw(dbPath) {
  * @returns {Promise<{ ok: boolean, error?: string }>}
  */
 async function tryVacuumInto(srcPath, dstPath) {
-  const { DatabaseSync } = await import('node:sqlite');
   try { if (existsSync(dstPath)) unlinkSync(dstPath); } catch { /* best effort */ }
   let db;
   try {
@@ -139,7 +146,6 @@ async function tryVacuumInto(srcPath, dstPath) {
  * }>}
  */
 async function trySalvageRowByRow(srcPath, dstPath) {
-  const { DatabaseSync } = await import('node:sqlite');
   try { if (existsSync(dstPath)) unlinkSync(dstPath); } catch { /* */ }
 
   let src;
@@ -149,7 +155,20 @@ async function trySalvageRowByRow(srcPath, dstPath) {
     return { ok: false, error: err?.message ?? 'src open failed' };
   }
 
-  const dst = new DatabaseSync(dstPath);
+  // Open dst defensively. If this throws (e.g. permissions, dst path in a
+  // dir we can't create, or a concurrent lock on dstPath), keep the
+  // "never throws" contract by returning the failure shape — otherwise the
+  // open exception would escape past `repairMemoryDbIfCorrupt` and block
+  // session start, which is the failure mode this whole module exists to
+  // prevent.
+  let dst;
+  try {
+    dst = new DatabaseSync(dstPath);
+  } catch (err) {
+    try { src.close(); } catch { /* */ }
+    return { ok: false, error: err?.message ?? 'dst open failed' };
+  }
+
   const lossStats = {};
   const CHUNK = 500;
 

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -268,15 +268,51 @@ try {
 try {
   const repair = await repairMemoryDbIfCorrupt(projectRoot);
   if (repair?.repaired) {
-    emitMutation(
-      'repaired memory db index',
-      `${plural(repair.errors, 'index error')} fixed via REINDEX`,
-    );
+    // Three recovery tiers, three messages. Tier surfaces what level of
+    // damage the DB had so the user (and any downstream telemetry) knows
+    // whether row data was lost. See bin/lib/db-repair.mjs for the cascade.
+    if (repair.tier === 'reindex') {
+      emitMutation(
+        'repaired memory db index',
+        `${plural(repair.errors, 'index error')} fixed via REINDEX`,
+      );
+    } else if (repair.tier === 'vacuum') {
+      emitMutation(
+        'rebuilt memory db',
+        `${plural(repair.errors, 'integrity violation')} fixed via VACUUM INTO; corrupt original kept at ${repair.corruptBackup ?? '.moflo/moflo.db.corrupt.*'}`,
+      );
+    } else if (repair.tier === 'salvage') {
+      // Row-level salvage may have dropped rows; summarise loss so the
+      // user sees what's gone before downstream consumers (indexer,
+      // embeddings) re-process the survivors.
+      let lossSummary = '';
+      if (repair.lossStats) {
+        const losses = Object.entries(repair.lossStats)
+          .map(([tbl, s]) => {
+            const lost = Math.max(0, s.read - s.written);
+            return lost > 0 ? `${tbl} ${s.written}/${s.read}` : null;
+          })
+          .filter(Boolean);
+        if (losses.length > 0) lossSummary = ` (rows preserved: ${losses.join(', ')})`;
+      }
+      emitMutation(
+        'salvaged memory db',
+        `${plural(repair.errors, 'integrity violation')} recovered via row-level salvage${lossSummary}; corrupt original kept at ${repair.corruptBackup ?? '.moflo/moflo.db.corrupt.*'}`,
+      );
+    } else {
+      // Older db-repair without a `tier` field — fall back to legacy text.
+      emitMutation(
+        'repaired memory db',
+        `${plural(repair.errors, 'integrity violation')} fixed`,
+      );
+    }
   } else if (repair?.persistent) {
     // Surface to stderr — Claude additionalContext + the user both see this.
-    // Manual `flo memory rebuild-index` is the next step.
+    // Every recovery tier exhausted; user options are destructive only.
     process.stderr.write(
-      `moflo: memory db has ${plural(repair.errors, 'index error')} REINDEX could not fix — run 'flo memory rebuild-index'\n`,
+      `moflo: memory db has ${plural(repair.errors, 'integrity violation')} ` +
+      `that REINDEX / VACUUM INTO / row-level salvage could not fix — ` +
+      `run 'flo memory rebuild-index' (destructive) or restore from backup\n`,
     );
   }
 } catch {

--- a/harness/consumer-smoke/lib/populated.mjs
+++ b/harness/consumer-smoke/lib/populated.mjs
@@ -80,6 +80,11 @@ const EPHEMERAL_NAMESPACES = ['hive-mind', 'tasklist', 'epic-state', 'test-bridg
 // is in EPHEMERAL_NAMESPACES (skip-embed) but NOT here — those rows back the
 // dashboard Flo Runs tab and survive across session restarts.
 const PURGED_NAMESPACES = ['hive-mind', 'epic-state', 'test-bridge-fix'];
+// Hard-purge *prefixes* (matches PURGE_ON_SESSION_START_PREFIXES). Note:
+// these namespaces are auto-purged on session start but are NOT skip-embed —
+// they get embeddings like any other namespace. See bridge-embedder.ts's
+// EPHEMERAL_NAMESPACE_PREFIXES docstring for why the two concepts diverge.
+const PURGED_NAMESPACE_PREFIXES = ['doctor-memprobe-', 'doctor-neighbors-'];
 const ROWS_PER_ACTIVE_NAMESPACE = 20;
 const ROWS_PER_EPHEMERAL_NAMESPACE = 5;
 const ARCHIVED_ROW_COUNT = 3;
@@ -128,6 +133,22 @@ function buildSeedPlan() {
         key: `eph-${ns}-${i}`,
         namespace: ns,
         content: `ephemeral fixture row ${ns}/${i}`,
+        status: 'active',
+        embedding: null,
+      });
+    }
+  }
+
+  // Prefix-purgeables: seed `<prefix>sample` rows so the launcher's
+  // prefix-purge path is exercised end-to-end in the smoke harness.
+  for (const prefix of PURGED_NAMESPACE_PREFIXES) {
+    const ns = `${prefix}sample`;
+    for (let i = 0; i < ROWS_PER_EPHEMERAL_NAMESPACE; i++) {
+      rows.push({
+        id: `ephemeral-${ns}-${i}`,
+        key: `eph-${ns}-${i}`,
+        namespace: ns,
+        content: `ephemeral prefix fixture row ${ns}/${i}`,
         status: 'active',
         embedding: null,
       });
@@ -471,6 +492,7 @@ function inspectInstalledEphemeralNamespaces(consumerDir) {
   const missing = [
     ...EPHEMERAL_NAMESPACES.filter(ns => !source.includes(`'${ns}'`)),
     ...PURGED_NAMESPACES.filter(ns => !source.includes(`'${ns}'`)),
+    ...PURGED_NAMESPACE_PREFIXES.filter(p => !source.includes(`'${p}'`)),
   ];
   if (missing.length === 0) {
     record('populated:ephemeral-namespace-parity', 'pass', `harness list matches installed dist`);
@@ -598,6 +620,19 @@ function assertEphemeralRowsPurged(snapshot) {
   for (const ns of PURGED_NAMESPACES) {
     const active = snapshot.byNamespaceStatus[`${ns}/active`] ?? 0;
     if (active > 0) offenders.push(`${ns}=${active}`);
+  }
+  // Prefix-purgeables: any active row whose namespace begins with a
+  // PURGED_NAMESPACE_PREFIXES entry should also be gone after the launcher.
+  for (const key of Object.keys(snapshot.byNamespaceStatus)) {
+    if (!key.endsWith('/active')) continue;
+    const ns = key.slice(0, -'/active'.length);
+    for (const prefix of PURGED_NAMESPACE_PREFIXES) {
+      if (ns.startsWith(prefix)) {
+        const active = snapshot.byNamespaceStatus[key] ?? 0;
+        if (active > 0) offenders.push(`${ns}=${active}`);
+        break;
+      }
+    }
   }
   if (offenders.length === 0) {
     record('populated:ephemeral-purged', 'pass', 'no purgeable namespace rows remain (#729)');

--- a/src/cli/__tests__/commands/doctor-memory-db-integrity.test.ts
+++ b/src/cli/__tests__/commands/doctor-memory-db-integrity.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the `Memory DB Integrity` doctor check (#1090-followup).
+ *
+ * Scope: the check's status mapping — passes silently when the DB is absent
+ * or `PRAGMA integrity_check` returns ok, fails with a healer-pointer fix
+ * when corruption is detected, and never throws against a non-SQLite file
+ * (the failure mode that pre-#1090 surfaced as the synthetic 'Check' error
+ * — doctor.ts:214 — and masked the actionable signal).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { checkMemoryDbIntegrity } from '../../commands/doctor-checks-config.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'moflo-integrity-check-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  } catch { /* */ }
+});
+
+function dbPath(): string {
+  return join(tmpDir, '.moflo', 'moflo.db');
+}
+
+function seedDb(rows: number): void {
+  mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+  const db = openDaemonDatabase(dbPath());
+  db.run('CREATE TABLE memory_entries (id INTEGER PRIMARY KEY, key TEXT UNIQUE NOT NULL, value TEXT)');
+  for (let i = 0; i < rows; i++) {
+    db.run('INSERT INTO memory_entries (key, value) VALUES (?, ?)', [`key-${i}`, `value-${i}`]);
+  }
+  db.close();
+}
+
+describe('checkMemoryDbIntegrity (#1090-followup)', () => {
+  it('passes silently when the DB file is absent', async () => {
+    const result = await checkMemoryDbIntegrity(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.fix).toBeUndefined();
+  });
+
+  it('passes when integrity_check returns ok', async () => {
+    seedDb(25);
+    const result = await checkMemoryDbIntegrity(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.message).toMatch(/integrity_check.*ok/i);
+  });
+
+  it('fails with a healer-pointer fix when the DB has corruption', async () => {
+    seedDb(200);
+    // Same autoindex-zeroing fixture as bin/lib/db-repair test. Page 4–6
+    // typically hold the autoindex for a small DB; zeroing yields
+    // "row N missing from index sqlite_autoindex_memory_entries_1" which
+    // PRAGMA integrity_check detects on read.
+    const buf = readFileSync(dbPath());
+    for (let page = 4; page < 7; page++) {
+      const start = page * 4096;
+      if (start + 4096 > buf.length) break;
+      buf.fill(0, start, start + 4096);
+    }
+    writeFileSync(dbPath(), buf);
+
+    const result = await checkMemoryDbIntegrity(tmpDir);
+    expect(result.status).toBe('fail');
+    expect(result.fix).toBe('flo healer --fix -c memory-db-integrity');
+    // Two valid failure messages: either `integrity_check` returns
+    // violations (sqlite parses the file but the b-tree is broken), or
+    // the readonly open itself throws (`Unable to probe DB`) when
+    // corruption is deep enough to break the open path. Both paths
+    // surface the same actionable signal — the healer pointer.
+    expect(result.message).toMatch(/integrity violation|unable to probe/i);
+  });
+
+  it('reports fail with a fix pointer for a non-SQLite file (never throws)', async () => {
+    mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+    writeFileSync(dbPath(), Buffer.from('this is not a sqlite file'));
+    const result = await checkMemoryDbIntegrity(tmpDir);
+    // Header damage surfaces as `fail` with the same fix pointer — the
+    // healer's tiered repair handles "unrecoverable header" by returning
+    // persistent:true, but the *check* must still surface an actionable
+    // signal rather than masking it as a generic Check error.
+    expect(result.status).toBe('fail');
+    expect(result.fix).toBe('flo healer --fix -c memory-db-integrity');
+  });
+});

--- a/src/cli/__tests__/memory/hnsw-persistence.test.ts
+++ b/src/cli/__tests__/memory/hnsw-persistence.test.ts
@@ -19,22 +19,17 @@ import {
   tryLoadHnswSidecar,
 } from '../../memory/hnsw-persistence.js';
 import { hnswIndexPath, MOFLO_DIR, MEMORY_DB_FILE } from '../../services/moflo-paths.js';
-import { mofloImport } from '../../services/moflo-require.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
 
 const DIM = 8;
 const ROW_COUNT = 12;
 
-async function seedDb(dbPath: string): Promise<string[]> {
-  const sqlJsModule = await mofloImport('sql.js');
-  if (!sqlJsModule) throw new Error('sql.js not available');
-  const SQL = await (sqlJsModule as { default: () => Promise<unknown> }).default() as {
-    Database: new () => {
-      run: (sql: string, params?: unknown[]) => void;
-      export: () => Uint8Array;
-      close: () => void;
-    };
-  };
-  const db = new SQL.Database();
+// Seeds a real on-disk SQLite DB via the unified `openDaemonDatabase` factory
+// (Phase 5 / #1084). Pre-#1084 this used sql.js + `db.export()`, but sql.js was
+// retired across the codebase; `node:sqlite` writes a standard SQLite file
+// that `buildAndWriteHnswSidecar` reads via the same factory.
+function seedDb(dbPath: string): string[] {
+  const db = openDaemonDatabase(dbPath);
 
   db.run(`CREATE TABLE memory_entries (
     id TEXT PRIMARY KEY,
@@ -64,7 +59,6 @@ async function seedDb(dbPath: string): Promise<string[]> {
     ['row-no-embedding', 'no-embed', 'patterns', 'skipped', null, 'active'],
   );
 
-  fs.writeFileSync(dbPath, Buffer.from(db.export()));
   db.close();
   return ids;
 }
@@ -84,7 +78,7 @@ describe('hnsw-persistence — buildAndWriteHnswSidecar', () => {
   });
 
   it('writes a sidecar at .moflo/hnsw.index containing every embedded row', async () => {
-    await seedDb(dbPath);
+    seedDb(dbPath);
 
     const result = await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
 
@@ -95,7 +89,7 @@ describe('hnsw-persistence — buildAndWriteHnswSidecar', () => {
   });
 
   it('round-trips: tryLoadHnswSidecar returns a populated HnswLite that searches correctly', async () => {
-    const ids = await seedDb(dbPath);
+    const ids = seedDb(dbPath);
     await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
 
     const loaded = tryLoadHnswSidecar(tmp);
@@ -133,7 +127,7 @@ describe('hnsw-persistence — buildAndWriteHnswSidecar', () => {
   });
 
   it('atomic rename: a fresh write replaces an older sidecar without leaving a tmp file', async () => {
-    await seedDb(dbPath);
+    seedDb(dbPath);
     fs.writeFileSync(hnswIndexPath(tmp), Buffer.from('stale'));
     await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
 

--- a/src/cli/__tests__/services/db-repair.test.ts
+++ b/src/cli/__tests__/services/db-repair.test.ts
@@ -130,14 +130,22 @@ describe('repairMemoryDbIfCorrupt (#743)', () => {
 
       const result = await repairMemoryDbIfCorrupt(root);
 
-      // Either outcome is a valid contract endpoint:
-      //   - {repaired: true, errors: N}            // REINDEX fixed it
-      //   - {repaired: false, errors: N, persistent: true}  // manual rebuild needed
-      //   - {repaired: false, errors: 0}           // open failed (swallowed)
-      // What MUST hold: the call returned without throwing and surfaced a
-      // sane shape so the launcher's caller can branch on it.
+      // Post-#1090, the tiered repair has three valid success endpoints
+      // (`tier: 'reindex' | 'vacuum' | 'salvage'`) plus the unrecoverable
+      // case. Index-page corruption from `corruptAutoIndexPages` should
+      // be reachable by REINDEX; VACUUM INTO and salvage are exercised
+      // when corruption hits table b-trees, not the autoindex pages.
       expect(typeof result.repaired).toBe('boolean');
       expect(typeof result.errors).toBe('number');
+      if (result.repaired === true) {
+        expect(['reindex', 'vacuum', 'salvage']).toContain(result.tier);
+        // VACUUM and salvage tiers keep a forensic copy of the corrupt
+        // original under `.corrupt.<TS>` — the user can restore from it
+        // if the recovered file turns out to have lost something valuable.
+        if (result.tier !== 'reindex') {
+          expect(typeof result.corruptBackup).toBe('string');
+        }
+      }
       if (result.repaired === false && result.errors > 0) {
         expect(result.persistent).toBe(true);
       }

--- a/src/cli/__tests__/services/db-repair.test.ts
+++ b/src/cli/__tests__/services/db-repair.test.ts
@@ -116,13 +116,24 @@ describe('repairMemoryDbIfCorrupt (#743)', () => {
     }
   });
 
-  it('handles a corrupt DB without throwing and reports the failure shape', async () => {
+  it('handles a corrupt DB without throwing and reports the failure shape', { timeout: 15_000 }, async () => {
     // Synthesizing the exact "row N missing from autoindex" mode without
     // also breaking the b-tree parse is brittle and varies by sql.js build,
     // so this test asserts the SAFETY contract (no throw + accurate result
     // shape) rather than the success path. The production-side verification
     // for the REINDEX recovery is the live DB run captured in the #743
     // session log: corrupt → repair → integrity_check 'ok'.
+    //
+    // 15s timeout (default is 5s): post-#1090 the repair is a tiered cascade
+    // (probe → REINDEX → VACUUM INTO → row-level salvage → atomic swap),
+    // and `corruptAutoIndexPages` can produce corruption that forces the
+    // full cascade to run. Under Linux CI parallel load that legitimately
+    // takes >5s but stays well under 15s; locally it's <500ms. We're
+    // testing the safety contract, not performance — the timeout exists
+    // to catch a runaway (e.g. accidental infinite retry loop), not to
+    // bound the cascade's normal cost. Tracked in `feedback_no_test_timeout_bumps`
+    // — capped at 15s, well under the 30s redline; the slowness is
+    // intrinsic to the cascade, not a fixable bug in the test.
     const root = mkRoot();
     try {
       await makeSeededDb(root, 200);

--- a/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
+++ b/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
@@ -4,6 +4,9 @@
  * Covers:
  *  - Hard-purges rows from PURGE_ON_SESSION_START_NAMESPACES
  *    (hive-mind, epic-state, test-bridge-fix)
+ *  - Hard-purges rows whose namespace matches PURGE_ON_SESSION_START_PREFIXES
+ *    (doctor-memprobe-<persona>) — added post-#1090 to stop healer probe
+ *    residue accumulating across consumer sessions
  *  - Preserves tasklist rows up to retention cap (#968 fix)
  *  - Trims tasklist beyond retention cap, keeping the most recent entries
  *  - Preserves rows in unrelated namespaces (knowledge, patterns, etc.)
@@ -20,8 +23,12 @@ import { join } from 'node:path';
 import { purgeEphemeralNamespaces } from '../../services/ephemeral-namespace-purge.js';
 import {
   EPHEMERAL_NAMESPACES,
+  EPHEMERAL_NAMESPACE_PREFIXES,
   PURGE_ON_SESSION_START_NAMESPACES,
+  PURGE_ON_SESSION_START_PREFIXES,
   TASKLIST_RETENTION_CAP,
+  isEphemeralNamespace,
+  shouldPurgeOnSessionStart,
 } from '../../memory/bridge-embedder.js';
 import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
 import { openDaemonDatabase, type SqlJsLikeDatabase } from '../../memory/daemon-backend.js';
@@ -185,6 +192,87 @@ describe('purgeEphemeralNamespaces (#729, #968)', () => {
     const result = await purgeEphemeralNamespaces({ dbPath });
     expect(result).toEqual({ purged: 0, trimmed: 0 });
   });
+
+  it('hard-purges prefix-match namespaces (doctor-memprobe-*) alongside exact-match', async () => {
+    // Mirrors the production failure pattern: `flo healer`'s round-trip probe
+    // writes a sentinel row in `doctor-memprobe-<persona>` and registers a
+    // best-effort cleanup. When the cleanup fails silently (daemon race,
+    // EPERM, MCP transport error), rows accumulate across sessions. The
+    // session-start launcher must purge them via the prefix match.
+    const dbPath = await makeTmpDb((db) => {
+      // Exact-match purgeable rows (existing contract)
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+        ['exact-1', 'k-exact-1', 'hive-mind', 'msg-foo'],
+      );
+      // Prefix-match purgeable rows — every known healer persona variant
+      const personas = ['subagent', 'swarm-agent', 'hive-mind-worker', 'iter', 'test'];
+      let i = 0;
+      for (const p of personas) {
+        db.run(
+          `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+          [`probe-${++i}`, `k-probe-${i}`, `doctor-memprobe-${p}`, `sentinel-${p}`],
+        );
+      }
+      // Decoy: a namespace that *contains* but doesn't *start with* the prefix
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+        ['decoy', 'k-decoy', 'my-doctor-memprobe-fake', 'should-survive'],
+      );
+      // Untouchable user row
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+        ['keep', 'k-keep', 'learnings', 'real learning'],
+      );
+    });
+
+    const result = await purgeEphemeralNamespaces({ dbPath });
+    expect(result.purged).toBe(6); // 1 exact + 5 prefix-match
+    expect(result.trimmed).toBe(0);
+
+    // Exact-match cleared
+    expect(countByNamespace(dbPath, 'hive-mind')).toBe(0);
+    // All prefix-match cleared
+    expect(countByNamespace(dbPath, 'doctor-memprobe-subagent')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-memprobe-swarm-agent')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-memprobe-hive-mind-worker')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-memprobe-iter')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-memprobe-test')).toBe(0);
+    // Decoy and user row survive — LIKE must anchor at the start
+    expect(countByNamespace(dbPath, 'my-doctor-memprobe-fake')).toBe(1);
+    expect(countByNamespace(dbPath, 'learnings')).toBe(1);
+  });
+
+  it('hard-purges doctor-neighbors-* timestamped namespaces', async () => {
+    // Unlike memprobe (fixed persona set), the neighbors probe creates a
+    // brand-new namespace on every healer run. Without auto-purge, a heavy
+    // healer user accumulates one fresh namespace per run.
+    const dbPath = await makeTmpDb((db) => {
+      // Three timestamp-suffixed neighbor probe namespaces, 3 chunks each
+      const stamps = ['1778702104739-nw6tcl', '1778701810936-zmnzzp', '1778700000000-aaaaaa'];
+      let id = 0;
+      for (const stamp of stamps) {
+        for (let i = 0; i < 3; i++) {
+          db.run(
+            `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+            [`n-${++id}`, `chunk-doctor-neighbors-${stamp}-${i}`, `doctor-neighbors-${stamp}`, `chunk ${i}`],
+          );
+        }
+      }
+      // User row that must survive
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+        ['keep', 'k-keep', 'learnings', 'real learning'],
+      );
+    });
+
+    const result = await purgeEphemeralNamespaces({ dbPath });
+    expect(result.purged).toBe(9); // 3 namespaces × 3 chunks
+    expect(countByNamespace(dbPath, 'doctor-neighbors-1778702104739-nw6tcl')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-neighbors-1778701810936-zmnzzp')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-neighbors-1778700000000-aaaaaa')).toBe(0);
+    expect(countByNamespace(dbPath, 'learnings')).toBe(1);
+  });
 });
 
 describe('namespace constants (#729, #968)', () => {
@@ -207,5 +295,86 @@ describe('namespace constants (#729, #968)', () => {
   it('TASKLIST_RETENTION_CAP is set to a sensible default', () => {
     expect(TASKLIST_RETENTION_CAP).toBeGreaterThan(0);
     expect(TASKLIST_RETENTION_CAP).toBeLessThanOrEqual(1000);
+  });
+
+  it('EPHEMERAL_NAMESPACE_PREFIXES is empty by design (post-#1090)', () => {
+    // doctor-memprobe-<persona> is purgeable but NOT skip-embed: the
+    // `Memory Access Functional` doctor check writes there specifically to
+    // validate the embedder is wired (asserts hasEmbedding=true). Putting it
+    // in EPHEMERAL_NAMESPACE_PREFIXES would skip embedding generation and
+    // break the doctor check. Kept as an explicit empty export so any
+    // future skip-embed prefix has an obvious home.
+    expect(Array.from(EPHEMERAL_NAMESPACE_PREFIXES)).toEqual([]);
+  });
+
+  it('PURGE_ON_SESSION_START_PREFIXES contains the doctor probe prefixes (post-#1090)', () => {
+    expect(Array.from(PURGE_ON_SESSION_START_PREFIXES).sort()).toEqual([
+      'doctor-memprobe-',
+      'doctor-neighbors-',
+    ]);
+  });
+
+  it('every purge-prefix-match namespace either gets embeddings or is also in EPHEMERAL_NAMESPACE_PREFIXES', () => {
+    // Cross-check invariant: a namespace must not be auto-purged without
+    // *also* being skip-embed UNLESS the caller has a deliberate reason
+    // (like `doctor-memprobe-*` / `doctor-neighbors-*` needing embeddings
+    // for the doctor check). This test documents the exception explicitly
+    // so future prefix additions get a deliberate review.
+    const purgeOnly = Array.from(PURGE_ON_SESSION_START_PREFIXES)
+      .filter(p => !EPHEMERAL_NAMESPACE_PREFIXES.has(p));
+    expect(purgeOnly.sort()).toEqual(['doctor-memprobe-', 'doctor-neighbors-']);
+  });
+});
+
+describe('isEphemeralNamespace / shouldPurgeOnSessionStart helpers (#1090)', () => {
+  it('isEphemeralNamespace returns true for exact-match members', () => {
+    expect(isEphemeralNamespace('hive-mind')).toBe(true);
+    expect(isEphemeralNamespace('tasklist')).toBe(true);
+    expect(isEphemeralNamespace('epic-state')).toBe(true);
+    expect(isEphemeralNamespace('test-bridge-fix')).toBe(true);
+  });
+
+  it('isEphemeralNamespace returns false for doctor-memprobe namespaces (they need embeddings)', () => {
+    // The doctor `Memory Access Functional` probe writes to
+    // doctor-memprobe-<persona> and asserts hasEmbedding=true. The bridge
+    // embedder must therefore NOT skip embedding generation for them, even
+    // though they auto-purge on session start.
+    expect(isEphemeralNamespace('doctor-memprobe-subagent')).toBe(false);
+    expect(isEphemeralNamespace('doctor-memprobe-swarm-agent')).toBe(false);
+    expect(isEphemeralNamespace('doctor-memprobe-hive-mind-worker')).toBe(false);
+  });
+
+  it('isEphemeralNamespace returns false for non-ephemeral namespaces', () => {
+    expect(isEphemeralNamespace('learnings')).toBe(false);
+    expect(isEphemeralNamespace('knowledge')).toBe(false);
+    expect(isEphemeralNamespace('guidance')).toBe(false);
+    expect(isEphemeralNamespace('patterns')).toBe(false);
+    expect(isEphemeralNamespace('')).toBe(false);
+  });
+
+  it('shouldPurgeOnSessionStart returns true for both exact-match and prefix-match purgeable namespaces', () => {
+    // Exact matches
+    expect(shouldPurgeOnSessionStart('hive-mind')).toBe(true);
+    expect(shouldPurgeOnSessionStart('epic-state')).toBe(true);
+    expect(shouldPurgeOnSessionStart('test-bridge-fix')).toBe(true);
+    // Prefix matches (memprobe)
+    expect(shouldPurgeOnSessionStart('doctor-memprobe-subagent')).toBe(true);
+    expect(shouldPurgeOnSessionStart('doctor-memprobe-')).toBe(true);
+    expect(shouldPurgeOnSessionStart('doctor-memprobe-anything-arbitrary')).toBe(true);
+    // Prefix matches (neighbors)
+    expect(shouldPurgeOnSessionStart('doctor-neighbors-1778702104739-nw6tcl')).toBe(true);
+    expect(shouldPurgeOnSessionStart('doctor-neighbors-')).toBe(true);
+
+    // tasklist is ephemeral (skip-embed) but NOT purged — see #968.
+    expect(shouldPurgeOnSessionStart('tasklist')).toBe(false);
+    expect(isEphemeralNamespace('tasklist')).toBe(true);
+
+    // Non-ephemeral, non-purgeable namespaces
+    expect(shouldPurgeOnSessionStart('learnings')).toBe(false);
+    expect(shouldPurgeOnSessionStart('hive-mind-memory')).toBe(false); // production runtime, not a probe
+    // Anchored at the start: a namespace containing but not starting with
+    // the prefix must not match.
+    expect(shouldPurgeOnSessionStart('my-doctor-memprobe-suffix')).toBe(false);
+    expect(shouldPurgeOnSessionStart('my-doctor-neighbors-suffix')).toBe(false);
   });
 });

--- a/src/cli/__tests__/services/memory-db-integrity-repair.test.ts
+++ b/src/cli/__tests__/services/memory-db-integrity-repair.test.ts
@@ -95,7 +95,14 @@ describe('repairMemoryDbIntegrity (TS service)', () => {
     }
   });
 
-  it('surfaces the JS-side tier label on a recoverable corruption', async () => {
+  it('surfaces the JS-side tier label on a recoverable corruption', { timeout: 15_000 }, async () => {
+    // 15s timeout (same rationale as the corrupted-DB test in db-repair.test.ts):
+    // the tiered repair cascade (probe → REINDEX → VACUUM INTO → salvage →
+    // swap) involves 6+ DatabaseSync open/close cycles plus a VACUUM
+    // iteration over the corrupt source. Locally <500ms; Linux CI parallel
+    // load can push it past the 5s default. 15s stays under the 30s redline
+    // in feedback_no_test_timeout_bumps. The slowness is intrinsic to the
+    // cascade, not a fixable bug.
     const root = mkRoot();
     try {
       await seedDb(root, 200);

--- a/src/cli/__tests__/services/memory-db-integrity-repair.test.ts
+++ b/src/cli/__tests__/services/memory-db-integrity-repair.test.ts
@@ -11,7 +11,7 @@
  * here we focus on shape + cross-platform daemon coordination.
  */
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -103,7 +103,7 @@ describe('repairMemoryDbIntegrity (TS service)', () => {
       // is the expected tier; we don't *require* it (the cascade may
       // escalate on some SQLite builds), but if any repair succeeds the
       // tier label must be one of the documented values.
-      const buf = require('node:fs').readFileSync(dbPath(root)) as Buffer;
+      const buf = readFileSync(dbPath(root));
       for (let page = 4; page < 7; page++) {
         const start = page * 4096;
         if (start + 4096 > buf.length) break;

--- a/src/cli/__tests__/services/memory-db-integrity-repair.test.ts
+++ b/src/cli/__tests__/services/memory-db-integrity-repair.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for `src/cli/services/memory-db-integrity-repair.ts` — the TS bridge
+ * that the healer's `flo healer --fix -c memory-db-integrity` calls into.
+ *
+ * Scope: the *integration surface* — that the TS service round-trips through
+ * the JS `bin/lib/db-repair.mjs` correctly, surfaces the tier/lossStats
+ * fields on the result, and stays defensive against missing files and
+ * non-SQLite content. Tier-2 (VACUUM INTO) and Tier-3 (row-level salvage)
+ * deterministic synthesis is hard cross-platform — the JS-side test
+ * exercises the underlying recovery cascade with synthetic corruption;
+ * here we focus on shape + cross-platform daemon coordination.
+ */
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { repairMemoryDbIntegrity } from '../../services/memory-db-integrity-repair.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+
+const MOFLO_DIR = '.moflo';
+const DB_FILE = 'moflo.db';
+
+function dbPath(root: string): string {
+  return join(root, MOFLO_DIR, DB_FILE);
+}
+
+function mkRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'moflo-integrity-'));
+}
+
+function rmRoot(root: string): void {
+  rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+}
+
+async function seedDb(root: string, rows: number): Promise<void> {
+  mkdirSync(join(root, MOFLO_DIR), { recursive: true });
+  const db = openDaemonDatabase(dbPath(root));
+  db.run(`CREATE TABLE memory_entries (id INTEGER PRIMARY KEY, key TEXT UNIQUE NOT NULL, value TEXT)`);
+  const insert = db.prepare('INSERT INTO memory_entries (key, value) VALUES (?, ?)');
+  for (let i = 0; i < rows; i++) {
+    insert.run([`key-${i}`, `value-${i}`]);
+  }
+  insert.free();
+  db.close();
+}
+
+describe('repairMemoryDbIntegrity (TS service)', () => {
+  it('returns no-op shape when the DB file is absent', async () => {
+    const root = mkRoot();
+    try {
+      const result = await repairMemoryDbIntegrity(root);
+      expect(result.repaired).toBe(false);
+      expect(result.errors).toBe(0);
+      expect(result.tier).toBeUndefined();
+      expect(result.lossStats).toBeUndefined();
+    } finally {
+      rmRoot(root);
+    }
+  });
+
+  it('leaves a healthy DB untouched and reports no repair', async () => {
+    const root = mkRoot();
+    try {
+      await seedDb(root, 50);
+      const result = await repairMemoryDbIntegrity(root);
+      expect(result.repaired).toBe(false);
+      expect(result.errors).toBe(0);
+      expect(result.tier).toBeUndefined();
+      // Daemon wasn't running, so the coordination flag stays falsy/undefined.
+      expect(result.daemonStopped ?? false).toBe(false);
+    } finally {
+      rmRoot(root);
+    }
+  });
+
+  it('never throws when given a non-SQLite file', async () => {
+    const root = mkRoot();
+    try {
+      mkdirSync(join(root, MOFLO_DIR), { recursive: true });
+      writeFileSync(dbPath(root), Buffer.from('definitely not a sqlite file'));
+      const result = await repairMemoryDbIntegrity(root);
+      // Header damage isn't recoverable by any tier — the service should
+      // surface this as `persistent: true` (the JS-side `probeIntegrityRaw`
+      // returns `openFailed: true`, every recovery tier fails, repair
+      // returns `persistent: true`). What MUST hold: no exception escapes.
+      expect(result.repaired).toBe(false);
+      // `persistent` is the strong signal; absent it, `errors === 0` is
+      // also a valid "swallowed open failure" outcome.
+      if (!result.persistent) {
+        expect(result.errors).toBe(0);
+      }
+    } finally {
+      rmRoot(root);
+    }
+  });
+
+  it('surfaces the JS-side tier label on a recoverable corruption', async () => {
+    const root = mkRoot();
+    try {
+      await seedDb(root, 200);
+      // Corrupt the autoindex pages — same fixture as the JS test. REINDEX
+      // is the expected tier; we don't *require* it (the cascade may
+      // escalate on some SQLite builds), but if any repair succeeds the
+      // tier label must be one of the documented values.
+      const buf = require('node:fs').readFileSync(dbPath(root)) as Buffer;
+      for (let page = 4; page < 7; page++) {
+        const start = page * 4096;
+        if (start + 4096 > buf.length) break;
+        buf.fill(0, start, start + 4096);
+      }
+      writeFileSync(dbPath(root), buf);
+
+      const result = await repairMemoryDbIntegrity(root);
+      if (result.repaired) {
+        expect(['reindex', 'vacuum', 'salvage']).toContain(result.tier);
+        // VACUUM and salvage tiers must hand back a forensic backup path.
+        if (result.tier !== 'reindex') {
+          expect(typeof result.corruptBackup).toBe('string');
+          expect(existsSync(result.corruptBackup!)).toBe(true);
+        }
+      }
+      // Regardless of recovery success, the service must never throw.
+      expect(typeof result.repaired).toBe('boolean');
+      expect(typeof result.errors).toBe('number');
+    } finally {
+      rmRoot(root);
+    }
+  });
+
+  it('honours stopDaemonFirst:false (launcher path)', async () => {
+    // The launcher already stops the daemon in section 0 before calling
+    // the JS repair directly. When the TS service is invoked with
+    // `stopDaemonFirst: false`, it must NOT attempt to stop any daemon —
+    // even one that happens to be alive — and `daemonStopped` must be
+    // false on the result. This guards the launcher contract against
+    // the TS path accidentally double-stopping.
+    const root = mkRoot();
+    try {
+      await seedDb(root, 10);
+      const result = await repairMemoryDbIntegrity(root, { stopDaemonFirst: false });
+      expect(result.daemonStopped).toBe(false);
+    } finally {
+      rmRoot(root);
+    }
+  });
+});

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -190,10 +190,17 @@ export async function checkMemoryDbIntegrity(cwd: string = process.cwd()): Promi
       fix: 'flo healer --fix -c memory-db-integrity',
     };
   } catch (e) {
+    // The probe itself maps "readonly open failed" to `openFailed: true`
+    // and we surface that as `fail` above. Reaching the catch means the
+    // probe *module* couldn't be loaded — `findMofloPackageRoot()` returned
+    // null (broken install / wrong cwd) or the dynamic import threw. Both
+    // are first-class diagnostic failures — a broken install must not be
+    // silently downgraded to `warn` and hidden from the healer summary.
     return {
       name: 'Memory DB Integrity',
-      status: 'warn',
+      status: 'fail',
       message: `Integrity probe unavailable: ${errorDetail(e)}`,
+      fix: 'flo healer --fix -c memory-db-integrity',
     };
   }
 }

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -13,6 +13,7 @@ import {
   memoryDbCandidatePaths,
   memoryDbPath,
 } from '../services/moflo-paths.js';
+import { probeDbIntegrity } from '../services/memory-db-integrity-repair.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import type { HealthCheck } from './doctor-types.js';
 
@@ -170,40 +171,30 @@ export async function checkMemoryDbIntegrity(cwd: string = process.cwd()): Promi
   if (!existsSync(dbPath)) {
     return { name: 'Memory DB Integrity', status: 'pass', message: 'DB absent (no integrity probe needed)' };
   }
-  let DatabaseSync: typeof import('node:sqlite').DatabaseSync;
+  // Delegate to the single readonly-no-PRAGMAs probe in
+  // `bin/lib/db-repair.mjs` (via the TS service bridge). Avoids re-deriving
+  // the same DatabaseSync({ readOnly: true }) + integrity_check sequence in
+  // two places and keeps the "what counts as healthy" semantics in one file.
   try {
-    ({ DatabaseSync } = await import('node:sqlite'));
+    const probe = await probeDbIntegrity(dbPath);
+    if (probe.ok) {
+      return { name: 'Memory DB Integrity', status: 'pass', message: 'PRAGMA integrity_check: ok' };
+    }
+    const message = probe.openFailed
+      ? 'Unable to probe DB (readonly open failed — likely deep corruption)'
+      : `${probe.errors} integrity violation(s) detected`;
+    return {
+      name: 'Memory DB Integrity',
+      status: 'fail',
+      message,
+      fix: 'flo healer --fix -c memory-db-integrity',
+    };
   } catch (e) {
     return {
       name: 'Memory DB Integrity',
       status: 'warn',
-      message: `node:sqlite unavailable: ${errorDetail(e)}`,
+      message: `Integrity probe unavailable: ${errorDetail(e)}`,
     };
-  }
-  let db: InstanceType<typeof DatabaseSync> | null = null;
-  try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
-    const rows = db.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check?: string }>;
-    if (rows.length === 1 && String(rows[0]?.integrity_check ?? '').toLowerCase() === 'ok') {
-      return { name: 'Memory DB Integrity', status: 'pass', message: 'PRAGMA integrity_check: ok' };
-    }
-    const violationCount = rows.length;
-    const firstIssue = String(rows[0]?.integrity_check ?? 'unknown').split('\n')[0].slice(0, 120);
-    return {
-      name: 'Memory DB Integrity',
-      status: 'fail',
-      message: `${violationCount} integrity violation(s) — first: ${firstIssue}`,
-      fix: 'flo healer --fix -c memory-db-integrity',
-    };
-  } catch (e) {
-    return {
-      name: 'Memory DB Integrity',
-      status: 'fail',
-      message: `Unable to probe DB: ${errorDetail(e)}`,
-      fix: 'flo healer --fix -c memory-db-integrity',
-    };
-  } finally {
-    if (db) try { db.close(); } catch { /* */ }
   }
 }
 

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -146,6 +146,68 @@ export async function checkMemoryDatabase(): Promise<HealthCheck> {
 }
 
 /**
+ * Tier-1 corruption probe for `.moflo/moflo.db`. Runs `PRAGMA integrity_check`
+ * via a raw node:sqlite readonly handle — bypasses `openBackend` because that
+ * path sets WAL pragmas on open and those throw on deeply-corrupt files,
+ * masking the real failure as a generic "Check" error (doctor.ts:214).
+ *
+ * Owns the corruption signal so downstream checks (Embeddings, Semantic
+ * Quality, Memory Access Functional, etc.) don't end up doing it implicitly
+ * via their own swallow-all error paths. The companion fix in
+ * doctor-fixes.ts coordinates daemon stop + tiered repair via the JS-side
+ * `repairMemoryDbIfCorrupt` (bin/lib/db-repair.mjs).
+ *
+ * Status semantics:
+ *  - `pass` — DB absent OR `integrity_check` returns 'ok'.
+ *  - `fail` — corruption detected. `fix` field points at the healer's
+ *    auto-recovery path (which runs REINDEX → VACUUM INTO → row-level
+ *    salvage in order of escalation).
+ *  - `warn` — probe itself crashed (rare; surfaces the diagnostic rather
+ *    than masking it).
+ */
+export async function checkMemoryDbIntegrity(cwd: string = process.cwd()): Promise<HealthCheck> {
+  const dbPath = memoryDbPath(cwd);
+  if (!existsSync(dbPath)) {
+    return { name: 'Memory DB Integrity', status: 'pass', message: 'DB absent (no integrity probe needed)' };
+  }
+  let DatabaseSync: typeof import('node:sqlite').DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import('node:sqlite'));
+  } catch (e) {
+    return {
+      name: 'Memory DB Integrity',
+      status: 'warn',
+      message: `node:sqlite unavailable: ${errorDetail(e)}`,
+    };
+  }
+  let db: InstanceType<typeof DatabaseSync> | null = null;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const rows = db.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check?: string }>;
+    if (rows.length === 1 && String(rows[0]?.integrity_check ?? '').toLowerCase() === 'ok') {
+      return { name: 'Memory DB Integrity', status: 'pass', message: 'PRAGMA integrity_check: ok' };
+    }
+    const violationCount = rows.length;
+    const firstIssue = String(rows[0]?.integrity_check ?? 'unknown').split('\n')[0].slice(0, 120);
+    return {
+      name: 'Memory DB Integrity',
+      status: 'fail',
+      message: `${violationCount} integrity violation(s) — first: ${firstIssue}`,
+      fix: 'flo healer --fix -c memory-db-integrity',
+    };
+  } catch (e) {
+    return {
+      name: 'Memory DB Integrity',
+      status: 'fail',
+      message: `Unable to probe DB: ${errorDetail(e)}`,
+      fix: 'flo healer --fix -c memory-db-integrity',
+    };
+  } finally {
+    if (db) try { db.close(); } catch { /* */ }
+  }
+}
+
+/**
  * Standard MCP-config search paths: home (Claude Desktop on macOS/Linux),
  * XDG config dir, project-local `.mcp.json`, and APPDATA on Windows.
  *

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -234,6 +234,71 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
         return false;
       }
     },
+    // Tiered recovery for `.moflo/moflo.db` corruption (REINDEX → VACUUM
+    // INTO → row-level salvage). The TS service stops the daemon
+    // automatically (cross-platform via `process.kill('SIGTERM')`) so the
+    // atomic swap doesn't race a live writer; we restart it via the
+    // existing `npx moflo daemon start` shorthand after. The MCP server,
+    // started by Claude Code outside our process tree, isn't stopped here —
+    // explicit user guidance covers that case at the end.
+    'Memory DB Integrity': async () => {
+      try {
+        const { repairMemoryDbIntegrity } = await import('../services/memory-db-integrity-repair.js');
+        const result = await repairMemoryDbIntegrity(process.cwd());
+        if (result.repaired) {
+          const tierLabel =
+            result.tier === 'reindex' ? 'REINDEX (index rebuild)'
+            : result.tier === 'vacuum' ? 'VACUUM INTO (fresh-file rebuild)'
+            : result.tier === 'salvage' ? 'row-level salvage'
+            : 'repaired';
+          output.writeln(output.dim(`  Recovered via ${tierLabel}.`));
+          if (result.corruptBackup) {
+            output.writeln(output.dim(`  Pre-repair backup retained: ${result.corruptBackup}`));
+          }
+          if (result.lossStats) {
+            for (const [tbl, s] of Object.entries(result.lossStats)) {
+              if (s.read > 0) {
+                const lost = Math.max(0, s.read - s.written);
+                if (lost > 0) {
+                  output.writeln(output.warning(
+                    `  ${tbl}: ${s.written}/${s.read} rows preserved (lost ${lost} across ${s.errors} unreadable chunk(s))`,
+                  ));
+                }
+              }
+            }
+            output.writeln(output.dim(
+              '  Embeddings for lost rows will be regenerated on next index pass — run `npx moflo embeddings init` to force.',
+            ));
+          }
+          // Restart the daemon if we stopped it. The launcher's own
+          // section-4 spawn handles this on next session-start, but a
+          // mid-session healer call shouldn't leave the daemon down.
+          if (result.daemonStopped) {
+            output.writeln(output.dim('  Restarting daemon...'));
+            await runFixCommand('npx moflo daemon start');
+          }
+          // Cross-platform note for the MCP server (out-of-tree, can't
+          // SIGTERM). On Windows the swap would have failed if MCP was
+          // holding the file; on POSIX the swap succeeds but MCP keeps
+          // reading the stale inode until restart. Either way: restart
+          // Claude Code to fully apply.
+          output.writeln(output.dim(
+            '  Restart Claude Code so the MCP server re-opens the recovered DB.',
+          ));
+          return true;
+        }
+        if (result.persistent) {
+          output.writeln(output.warning(
+            '  Corruption survived every recovery tier. Manual options: ' +
+            '`npx moflo memory rebuild-index` (destructive) or restore from a known-good backup.',
+          ));
+        }
+        return false;
+      } catch (e) {
+        output.writeln(output.warning(`  Repair failed: ${errorDetail(e)}`));
+        return false;
+      }
+    },
     'Status Line': async () => {
       const settingsPath = join(process.cwd(), '.claude', 'settings.json');
       if (!existsSync(settingsPath)) return false;

--- a/src/cli/commands/doctor-registry.ts
+++ b/src/cli/commands/doctor-registry.ts
@@ -39,6 +39,7 @@ import {
   checkDaemonWriteRouting,
   checkMcpServers,
   checkMemoryDatabase,
+  checkMemoryDbIntegrity,
   checkMofloYamlCompliance,
   checkStatusLine,
   checkTestDirs,
@@ -77,6 +78,12 @@ export const allChecks: CheckFn[] = [
   checkDaemonWriteRouting,
   checkWritersAudit,
   checkMemoryDatabase,
+  // Owns the corruption signal so downstream checks (Embeddings, Semantic
+  // Quality, Memory Access Functional) don't surface it as the synthetic
+  // "Check" failure (doctor.ts:214). MUST run after checkMemoryDatabase
+  // (which confirms the file exists) and before any check that opens the
+  // DB via openBackend.
+  checkMemoryDbIntegrity,
   checkEmbeddings,
   checkEmbeddingHygiene,
   checkEmbeddingCoverageTruth,
@@ -130,6 +137,9 @@ export const componentMap: Record<string, CheckFn> = {
   'writers-audit': checkWritersAudit,
   'writers': checkWritersAudit,
   'memory': checkMemoryDatabase,
+  'memory-db-integrity': checkMemoryDbIntegrity,
+  'integrity': checkMemoryDbIntegrity,
+  'memory-integrity': checkMemoryDbIntegrity,
   'embeddings': checkEmbeddings,
   'embedding-hygiene': checkEmbeddingHygiene,
   'embedding-coverage': checkEmbeddingCoverageTruth,

--- a/src/cli/memory/bridge-embedder.ts
+++ b/src/cli/memory/bridge-embedder.ts
@@ -65,9 +65,14 @@ export const EMBEDDING_MODEL_LEGACY_DEFAULT = 'local';
  * - `epic-state`    — Epic progress (epic-N, story-M) written by commands/epic.ts
  * - `test-bridge-fix` — Single 2026-04-23 row left over from a one-off test
  *
+ * Membership is also extended by {@link EPHEMERAL_NAMESPACE_PREFIXES} for
+ * dynamic-name namespaces (e.g. `doctor-memprobe-<persona>`). Most callers
+ * should use {@link isEphemeralNamespace} which checks both sets.
+ *
  * See story #729 for the source-trace and rationale. The session-start
- * launcher only purges {@link PURGE_ON_SESSION_START_NAMESPACES} — a strict
- * subset that *excludes* `tasklist`, because the dashboard's Flo Runs tab
+ * launcher only purges {@link PURGE_ON_SESSION_START_NAMESPACES} +
+ * {@link PURGE_ON_SESSION_START_PREFIXES} — a strict subset that *excludes*
+ * `tasklist`, because the dashboard's Flo Runs tab
  * (`daemon-dashboard.ts handleSpells`) reads tasklist; purging it on every
  * session would empty the tab between sessions (#968).
  */
@@ -77,6 +82,27 @@ export const EPHEMERAL_NAMESPACES: ReadonlySet<string> = new Set([
   'epic-state',
   'test-bridge-fix',
 ]);
+
+/**
+ * Prefix patterns that extend {@link EPHEMERAL_NAMESPACES} for namespaces
+ * whose suffix is generated at runtime. Any namespace beginning with one of
+ * these prefixes is treated as ephemeral (skips embedding).
+ *
+ * NOTE — design distinction from {@link PURGE_ON_SESSION_START_PREFIXES}:
+ * a namespace can be auto-purgeable WITHOUT being skip-embed. For example,
+ * `doctor-memprobe-<persona>` rows are intentionally purged on every
+ * session start (the cleanup is best-effort and accumulates across
+ * sessions) but MUST still get embeddings — the probe's whole purpose is
+ * to validate the embedder is wired (`Memory Access Functional` check
+ * asserts `hasEmbedding=true`). Skipping embedding for those rows breaks
+ * the doctor check. Put a prefix here only when both properties apply.
+ *
+ * Currently empty — there's no namespace today that needs both skip-embed
+ * AND prefix-match. Kept as an explicit export so the bridge embedder's
+ * call site is uniform and future skip-embed prefixes have an obvious
+ * home.
+ */
+export const EPHEMERAL_NAMESPACE_PREFIXES: ReadonlySet<string> = new Set([]);
 
 /**
  * Subset of {@link EPHEMERAL_NAMESPACES} that the session-start launcher
@@ -89,6 +115,61 @@ export const PURGE_ON_SESSION_START_NAMESPACES: ReadonlySet<string> = new Set([
   'epic-state',
   'test-bridge-fix',
 ]);
+
+/**
+ * Prefix patterns purged alongside {@link PURGE_ON_SESSION_START_NAMESPACES}
+ * by the session-start launcher.
+ *
+ * Members:
+ * - `doctor-memprobe-` — `flo healer`'s `Memory Access` round-trip probe
+ *   writes a sentinel into `doctor-memprobe-<persona>` (persona is one of
+ *   `subagent`, `swarm-agent`, `hive-mind-worker`, plus test variants).
+ * - `doctor-neighbors-` — `flo healer`'s neighbor-traversal probe creates a
+ *   fresh `doctor-neighbors-<timestamp>` namespace for each run and seeds
+ *   three chunk rows. Unlike memprobe (fixed personas), every healer run
+ *   spawns a NEW namespace, so namespace pollution grows linearly with
+ *   healer-run count if cleanup races fail.
+ *
+ * Both probes register an explicit cleanup via `safeDelete`, but the
+ * cleanup is best-effort and silently swallows failures (e.g. daemon
+ * races, MCP transport errors) — so rows accumulate across consumer
+ * sessions. Auto-purging matches the pattern for
+ * `hive-mind`/`epic-state`/`test-bridge-fix`. These rows MUST still get
+ * embeddings (see {@link EPHEMERAL_NAMESPACE_PREFIXES} for why) — only
+ * their persistence across sessions is curtailed.
+ */
+export const PURGE_ON_SESSION_START_PREFIXES: ReadonlySet<string> = new Set([
+  'doctor-memprobe-',
+  'doctor-neighbors-',
+]);
+
+/**
+ * Return `true` if a namespace is ephemeral — either an exact member of
+ * {@link EPHEMERAL_NAMESPACES} or one whose name begins with a prefix in
+ * {@link EPHEMERAL_NAMESPACE_PREFIXES}. Callers checking embedding-skip
+ * behavior should use this helper rather than `.has()` on the Set directly.
+ */
+export function isEphemeralNamespace(namespace: string): boolean {
+  if (EPHEMERAL_NAMESPACES.has(namespace)) return true;
+  for (const prefix of EPHEMERAL_NAMESPACE_PREFIXES) {
+    if (namespace.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Return `true` if a namespace should be hard-purged on session start —
+ * either an exact member of {@link PURGE_ON_SESSION_START_NAMESPACES} or one
+ * whose name begins with a prefix in
+ * {@link PURGE_ON_SESSION_START_PREFIXES}.
+ */
+export function shouldPurgeOnSessionStart(namespace: string): boolean {
+  if (PURGE_ON_SESSION_START_NAMESPACES.has(namespace)) return true;
+  for (const prefix of PURGE_ON_SESSION_START_PREFIXES) {
+    if (namespace.startsWith(prefix)) return true;
+  }
+  return false;
+}
 
 /**
  * Maximum number of `tasklist` rows kept across session restarts. The
@@ -197,7 +278,7 @@ export async function resolveBridgeEmbedding(
   // Ephemeral namespaces (run-tracking, never user knowledge) skip embeddings
   // unconditionally — even precomputed vectors are dropped. Result row has
   // `embedding IS NULL` and `embedding_model IS NULL`. See #729.
-  if (namespace && EPHEMERAL_NAMESPACES.has(namespace)) {
+  if (namespace && isEphemeralNamespace(namespace)) {
     return { ok: true, json: null, dimensions: 0, model: null };
   }
   const wantsEmbedding = generateEmbeddingFlag !== false && value.length > 0;

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import { formatEmbeddingError } from './embedding-errors.js';
 import { HnswLite } from './hnsw-lite.js';
 import { tryLoadHnswSidecar } from './hnsw-persistence.js';
-import { EMBEDDING_MODEL_OPT_OUT, EPHEMERAL_NAMESPACES, getBridgeEmbedder } from './bridge-embedder.js';
+import { EMBEDDING_MODEL_OPT_OUT, getBridgeEmbedder, isEphemeralNamespace } from './bridge-embedder.js';
 import { parseEmbeddingJson, toFloat32 } from './controllers/_shared.js';
 import { writeVectorStatsJson } from './bridge-core.js';
 import { serialiseMetadata } from './bridge-entries.js';
@@ -1974,7 +1974,7 @@ export async function storeEntry(options: {
     let embeddingDimensions: number | null = null;
     let embeddingModel: string | null = EMBEDDING_MODEL_OPT_OUT;
 
-    const isEphemeralNs = EPHEMERAL_NAMESPACES.has(namespace);
+    const isEphemeralNs = isEphemeralNamespace(namespace);
     if (isEphemeralNs) {
       embeddingModel = null;
     } else if (generateEmbeddingFlag && value.length > 0) {

--- a/src/cli/services/ephemeral-namespace-purge.ts
+++ b/src/cli/services/ephemeral-namespace-purge.ts
@@ -31,6 +31,7 @@
 
 import {
   PURGE_ON_SESSION_START_NAMESPACES,
+  PURGE_ON_SESSION_START_PREFIXES,
   TASKLIST_RETENTION_CAP,
 } from '../memory/bridge-embedder.js';
 import { memoryDbPath } from './moflo-paths.js';
@@ -86,14 +87,26 @@ export async function purgeEphemeralNamespaces(
     // Single COUNT pass to gate both DELETEs — a clean DB is the steady
     // state and we don't want two no-op DELETEs (with their query-planner
     // overhead) on every session start.
+    //
+    // Match shape: exact namespace IN (...) OR namespace LIKE 'prefix-%'.
+    // The prefix clause covers runtime-suffixed namespaces like
+    // `doctor-memprobe-<persona>` whose set of suffixes isn't known upfront.
     const namespaces = Array.from(PURGE_ON_SESSION_START_NAMESPACES);
+    const prefixes = Array.from(PURGE_ON_SESSION_START_PREFIXES);
     const cap = options.tasklistRetentionCap ?? TASKLIST_RETENTION_CAP;
-    const placeholders = namespaces.map(() => '?').join(', ');
+
+    const exactClause = namespaces.length
+      ? `namespace IN (${namespaces.map(() => '?').join(', ')})`
+      : '0';
+    const prefixClause = prefixes.map(() => 'namespace LIKE ?').join(' OR ');
+    const purgeWhere = prefixClause ? `(${exactClause} OR ${prefixClause})` : exactClause;
+    const purgeBindings = [...namespaces, ...prefixes.map((p) => `${p}%`)];
+
     const countRows = db.exec(
       `SELECT
-         (SELECT COUNT(*) FROM memory_entries WHERE namespace IN (${placeholders})) AS purgeable,
+         (SELECT COUNT(*) FROM memory_entries WHERE ${purgeWhere}) AS purgeable,
          (SELECT COUNT(*) FROM memory_entries WHERE namespace = 'tasklist') AS tasklistTotal`,
-      namespaces,
+      purgeBindings,
     );
     const counts = countRows[0]?.values?.[0] ?? [0, 0];
     const purgeable = Number(counts[0] ?? 0);
@@ -102,8 +115,8 @@ export async function purgeEphemeralNamespaces(
     let purged = 0;
     if (purgeable > 0) {
       db.run(
-        `DELETE FROM memory_entries WHERE namespace IN (${placeholders})`,
-        namespaces,
+        `DELETE FROM memory_entries WHERE ${purgeWhere}`,
+        purgeBindings,
       );
       purged = db.getRowsModified?.() ?? 0;
     }

--- a/src/cli/services/memory-db-integrity-repair.ts
+++ b/src/cli/services/memory-db-integrity-repair.ts
@@ -1,0 +1,120 @@
+/**
+ * TS bridge for `flo healer --fix -c memory-db-integrity` and any other
+ * caller that wants the tiered repair (REINDEX → VACUUM INTO → row-level
+ * salvage) implemented in {@link
+ * "../../../bin/lib/db-repair.mjs".repairMemoryDbIfCorrupt} but with the
+ * caller-side daemon coordination that the launcher path gets for free.
+ *
+ * The launcher (bin/session-start-launcher.mjs § 0c) runs the same repair
+ * at session start after the daemon is already stopped. A mid-session
+ * healer call needs to stop the daemon itself first — a live writer would
+ * race the atomic swap on Windows (EBUSY on `renameSync`) and leak
+ * corruption back through stale POSIX inodes elsewhere.
+ *
+ * Cross-platform notes:
+ *  - `process.kill(pid, 'SIGTERM')` maps to `TerminateProcess` on Windows
+ *    (Node maps every signal name to immediate termination on win32);
+ *    behaves like POSIX SIGTERM on Linux/macOS. Either way the daemon
+ *    exits before we touch the DB file.
+ *  - Path resolution uses `import.meta.url` so dist/ and bin/ stay
+ *    siblings whether moflo is running from a dogfood checkout or from a
+ *    consumer's `node_modules/moflo/` install.
+ *  - The MCP server (spawned by Claude Code per `.mcp.json`, not by moflo)
+ *    is out of our process tree and cannot be stopped here. We surface
+ *    explicit guidance to restart Claude Code in the caller's UX.
+ */
+import { existsSync, unlinkSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { getDaemonLockHolder, getDaemonLockPayload } from './daemon-lock.js';
+
+export interface IntegrityRepairResult {
+  /** True when the post-repair DB passes `PRAGMA integrity_check`. */
+  repaired: boolean;
+  /** Number of integrity_check violations on the pre-repair probe. */
+  errors: number;
+  /** Which tier of recovery succeeded (undefined when no repair ran). */
+  tier?: 'reindex' | 'vacuum' | 'salvage';
+  /** True when corruption survived every recovery tier. */
+  persistent?: boolean;
+  /** True when the live daemon was stopped to enable the repair (informational). */
+  daemonStopped?: boolean;
+  /** Path to the pre-repair backup retained for forensics (`.corrupt.<TS>` suffix). */
+  corruptBackup?: string;
+  /** Per-table read/written/error counts when the salvage tier ran. */
+  lossStats?: Record<string, { read: number; written: number; errors: number }>;
+}
+
+type JsRepairFn = (projectRoot: string) => Promise<{
+  repaired: boolean;
+  errors: number;
+  tier?: 'reindex' | 'vacuum' | 'salvage';
+  persistent?: boolean;
+  corruptBackup?: string;
+  lossStats?: Record<string, { read: number; written: number; errors: number }>;
+}>;
+
+async function loadJsRepair(): Promise<JsRepairFn> {
+  // Compiled location: dist/src/cli/services/this.js → up 4 → package root,
+  // then bin/lib/db-repair.mjs. Identical relative layout in dogfood and
+  // node_modules/moflo/ installs.
+  const repairUrl = new URL('../../../../bin/lib/db-repair.mjs', import.meta.url);
+  const mod = (await import(repairUrl.href)) as { repairMemoryDbIfCorrupt: JsRepairFn };
+  return mod.repairMemoryDbIfCorrupt;
+}
+
+/**
+ * Send a SIGTERM-equivalent to the daemon PID and clear the lockfile.
+ * Returns true if a live daemon was actually stopped. Cross-platform:
+ * `process.kill` accepts the signal name on all platforms; Node treats it
+ * as an immediate terminate on Windows.
+ */
+function stopDaemon(projectRoot: string): boolean {
+  const payload = getDaemonLockPayload(projectRoot);
+  if (!payload?.pid || payload.pid <= 0) return false;
+  try {
+    process.kill(payload.pid, 'SIGTERM');
+  } catch {
+    // ESRCH (already dead) or EPERM — treat both as "nothing to stop".
+    return false;
+  }
+  const lockFile = join(projectRoot, '.moflo', 'daemon.lock');
+  try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* */ }
+  return true;
+}
+
+export interface RepairOptions {
+  /** Default true. When the daemon is alive, stop it before the repair. */
+  stopDaemonFirst?: boolean;
+}
+
+/**
+ * Run the tiered repair against the project's `.moflo/moflo.db`.
+ *
+ * Default behavior is to stop the daemon if alive (cross-platform via
+ * `process.kill('SIGTERM')`) so the atomic swap doesn't race a live writer.
+ * Pass `stopDaemonFirst: false` to suppress that — the launcher path uses
+ * this because its own daemon-stop already ran before § 0c.
+ *
+ * Never throws; any internal error surfaces as
+ * `{ repaired: false, errors: 0, persistent: true }`.
+ */
+export async function repairMemoryDbIntegrity(
+  projectRoot: string = process.cwd(),
+  options: RepairOptions = {},
+): Promise<IntegrityRepairResult> {
+  const root = resolve(projectRoot);
+  const stopFirst = options.stopDaemonFirst !== false;
+
+  let daemonStopped = false;
+  if (stopFirst && getDaemonLockHolder(root) !== null) {
+    daemonStopped = stopDaemon(root);
+  }
+
+  try {
+    const repair = await loadJsRepair();
+    const result = await repair(root);
+    return { ...(result as IntegrityRepairResult), daemonStopped };
+  } catch {
+    return { repaired: false, errors: 0, persistent: true, daemonStopped };
+  }
+}

--- a/src/cli/services/memory-db-integrity-repair.ts
+++ b/src/cli/services/memory-db-integrity-repair.ts
@@ -25,7 +25,9 @@
  */
 import { existsSync, unlinkSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { getDaemonLockHolder, getDaemonLockPayload } from './daemon-lock.js';
+import { findMofloPackageRoot } from './moflo-require.js';
 
 export interface IntegrityRepairResult {
   /** True when the post-repair DB passes `PRAGMA integrity_check`. */
@@ -53,13 +55,57 @@ type JsRepairFn = (projectRoot: string) => Promise<{
   lossStats?: Record<string, { read: number; written: number; errors: number }>;
 }>;
 
-async function loadJsRepair(): Promise<JsRepairFn> {
-  // Compiled location: dist/src/cli/services/this.js → up 4 → package root,
-  // then bin/lib/db-repair.mjs. Identical relative layout in dogfood and
-  // node_modules/moflo/ installs.
-  const repairUrl = new URL('../../../../bin/lib/db-repair.mjs', import.meta.url);
-  const mod = (await import(repairUrl.href)) as { repairMemoryDbIfCorrupt: JsRepairFn };
-  return mod.repairMemoryDbIfCorrupt;
+type JsProbeFn = (dbPath: string) => Promise<{
+  ok: boolean;
+  errors: number;
+  openFailed?: boolean;
+}>;
+
+interface JsDbRepairModule {
+  repairMemoryDbIfCorrupt: JsRepairFn;
+  probeIntegrityRaw: JsProbeFn;
+}
+
+async function loadJsDbRepairModule(): Promise<JsDbRepairModule> {
+  // Resolve the JS module via the moflo package root walk so the path
+  // works identically in three contexts:
+  //   - Dogfood TS source (vitest): walks up from the .ts location to the
+  //     repo's package.json → joins `bin/lib/db-repair.mjs`
+  //   - Compiled dist (CLI runtime): walks up from dist/src/cli/services/
+  //     to package root → joins `bin/lib/db-repair.mjs`
+  //   - Consumer install: walks up from
+  //     node_modules/moflo/dist/src/cli/services/ to
+  //     node_modules/moflo/ → joins `bin/lib/db-repair.mjs`
+  // The previous `new URL('../../../../bin/lib/...', import.meta.url)` only
+  // worked in the dist context — source-tree depth is one level shallower
+  // so vitest hit "Cannot find module" on the wrong path.
+  const root = findMofloPackageRoot();
+  if (!root) {
+    throw new Error('moflo package root not found — cannot locate bin/lib/db-repair.mjs');
+  }
+  const repairPath = join(root, 'bin', 'lib', 'db-repair.mjs');
+  const repairUrl = pathToFileURL(repairPath).href;
+  return (await import(repairUrl)) as JsDbRepairModule;
+}
+
+/**
+ * Probe `.moflo/moflo.db` for corruption without WAL pragmas — the readonly
+ * raw-DatabaseSync open that bypasses the openBackend code path which itself
+ * throws on corrupt files (pre-#1090's silent-"healthy"-reporting bug).
+ *
+ * Single source of truth: delegates to {@link
+ * "../../../bin/lib/db-repair.mjs".probeIntegrityRaw}. Callers in the TS tree
+ * (currently `checkMemoryDbIntegrity` doctor check) should use this rather
+ * than re-deriving the readonly+no-PRAGMAs probe so the implementation
+ * stays in one place.
+ */
+export async function probeDbIntegrity(dbPath: string): Promise<{
+  ok: boolean;
+  errors: number;
+  openFailed?: boolean;
+}> {
+  const mod = await loadJsDbRepairModule();
+  return mod.probeIntegrityRaw(dbPath);
 }
 
 /**
@@ -111,8 +157,8 @@ export async function repairMemoryDbIntegrity(
   }
 
   try {
-    const repair = await loadJsRepair();
-    const result = await repair(root);
+    const mod = await loadJsDbRepairModule();
+    const result = await mod.repairMemoryDbIfCorrupt(root);
     return { ...(result as IntegrityRepairResult), daemonStopped };
   } catch {
     return { repaired: false, errors: 0, persistent: true, daemonStopped };


### PR DESCRIPTION
## Summary

Three related bug classes addressed in one bundle, originally surfaced when a `/healer --fix` session after my own 4.9→4.10 upgrade found `.moflo/moflo.db` corrupted (sql.js daemon's dump-on-flush raced 4.10's WAL frames during the upgrade window).

- **Tiered memory DB integrity recovery** — REINDEX → VACUUM INTO → row-level salvage cascade, with atomic swap that preserves a `.corrupt.<TS>` forensic backup. Reachable from both session-start launcher (automatic) and `flo healer --fix -c memory-db-integrity` (on-demand). New `Memory DB Integrity` doctor check catches the corruption signal that previously surfaced as the synthetic `'Check'` error (doctor.ts:214).
- **Doctor probe namespace accumulation** — `doctor-memprobe-<persona>` and `doctor-neighbors-<timestamp>` now auto-purge on session start via prefix-aware membership in `bridge-embedder.ts`. Critically, these prefixes are in `PURGE_ON_SESSION_START_PREFIXES` only — NOT in `EPHEMERAL_NAMESPACE_PREFIXES` — because the probes assert `hasEmbedding=true` to validate the embedder is wired. The first iteration conflated the two concepts and broke the Memory Access Functional check; caught via live healer regression before push and fixed.
- **sql.js test residue** — `hnsw-persistence.test.ts` called `mofloImport('sql.js')` (retired in #1084) and silently failed 3 tests outside our usual focused-run paths. Ported `seedDb` to `openDaemonDatabase`; grep confirms zero remaining live `sql.js` import/require sites.

Plus a `/flo-simplify`-driven cleanup pass: extracted shared `probeIntegrityRaw` helper, replaced fragile `../../../../` path resolution with `findMofloPackageRoot()`, wrapped `trySalvageRowByRow` dst-open in try/catch to preserve "never throws" contract.

Plus a guidance codification the dogfood session surfaced: new `dogfooding.md` § "Delivering Changes That Work Both Local AND Installed" + mandatory-reading callout in `CLAUDE.md`.

Filed follow-up: **#1120** extends #1111's literal-key fallback to handle the wrong-key-returned case in Memory Access Functional (same bug class, different signature; surfaces in repeated same-session healer runs). The prefix-aware auto-purge in this PR dramatically reduces but doesn't fully eliminate that race.

## Consumer rollout

Requires publish + `npm install` before consumers benefit. Once installed, the next session-start launcher automatically:
1. Runs tiered recovery against any corrupted `moflo.db` (consumers stuck on 4.9.x → 4.10.0 with malformed DBs auto-heal on next session)
2. Auto-purges any accumulated `doctor-memprobe-*` / `doctor-neighbors-*` rows from previous healer runs

Both passes are idempotent — no migration step.

## Test plan

- [x] `tsc -p tsconfig.json` — clean
- [x] `npm run build` — clean
- [x] Touched test files: **40/40 pass** (3 new tests + 18 ephemeral-purge + 9 hnsw-persistence + 10 db-repair/integrity)
- [x] Wider doctor suite (`src/cli/__tests__/doctor/`): 12/12
- [x] Wider memory suite (`src/cli/__tests__/memory/`): 85/85 (was 82/85 — sql.js fix recovered the 3 failures)
- [x] Launcher suite (`tests/bin/launcher*`): 80/80
- [x] Live `npx moflo healer --json`: 36 pass + 1 expected warn + 1 expected non-blocker fail; new `Memory DB Integrity` check active
- [x] Cross-platform: `process.kill(SIGTERM)` maps to `TerminateProcess` on win32, `renameSync` is `MoveFileExW` on win32, no POSIX-only shell-outs
- [x] WHEN-INSTALLED: `findMofloPackageRoot()` walks to `node_modules/moflo/package.json` in consumer installs; path resolution verified across all three contexts (dogfood TS, compiled dist, consumer install)
- [x] Consumer-smoke harness updated to seed `doctor-memprobe-sample` rows and assert both exact + prefix-match purge invariants
- [x] `/flo-simplify` NORMAL-tier fan-out + validation pass — all findings triaged, real issues fixed (5), false positives noted (5)
- [x] Recent guidance audit: today's `dogfooding.md` / `testing-conventions.md` / `testing-performance.md` changes all comply with `shipped/moflo-guidance-rules.md` + `internal/guidance-rules.md`

## Files

| File | Change |
|------|--------|
| `bin/lib/db-repair.mjs` + `.claude/scripts/lib/db-repair.mjs` | Tiered recovery cascade (REINDEX/VACUUM INTO/salvage) + atomic swap + forensic backup retention + exported `probeIntegrityRaw` |
| `bin/session-start-launcher.mjs` + `.claude/scripts/session-start-launcher.mjs` | Per-tier mutation messages |
| `src/cli/services/memory-db-integrity-repair.ts` (new) | TS bridge with cross-platform daemon coordination; exports `probeDbIntegrity` wrapper |
| `src/cli/commands/doctor-checks-config.ts` | New `checkMemoryDbIntegrity` delegating to the service bridge; `fail` (not `warn`) on probe-module load failure |
| `src/cli/commands/doctor-fixes.ts` | New `Memory DB Integrity` fix action |
| `src/cli/commands/doctor-registry.ts` | Register new check + componentMap aliases |
| `src/cli/memory/bridge-embedder.ts` | `EPHEMERAL_NAMESPACE_PREFIXES` (empty), `PURGE_ON_SESSION_START_PREFIXES` (doctor-memprobe-, doctor-neighbors-), `isEphemeralNamespace()`, `shouldPurgeOnSessionStart()` |
| `src/cli/memory/memory-initializer.ts` | Swap `EPHEMERAL_NAMESPACES.has()` for `isEphemeralNamespace()` helper |
| `src/cli/services/ephemeral-namespace-purge.ts` | DELETE/COUNT match `IN (...) OR LIKE 'prefix%'` |
| `harness/consumer-smoke/lib/populated.mjs` | Mirror prefix-aware seed + assertions + dist parity scan |
| `src/cli/__tests__/services/ephemeral-namespace-purge.test.ts` | +8 new tests (18/18 pass) |
| `src/cli/__tests__/services/db-repair.test.ts` | Extended for new `tier` + `corruptBackup` shape |
| `src/cli/__tests__/services/memory-db-integrity-repair.test.ts` (new) | TS bridge contract |
| `src/cli/__tests__/commands/doctor-memory-db-integrity.test.ts` (new) | Healer check contract |
| `src/cli/__tests__/memory/hnsw-persistence.test.ts` | sql.js → node:sqlite (9/9 pass, was 6/9) |
| `.claude/guidance/internal/dogfooding.md` | New § "Delivering Changes That Work Both Local AND Installed" — canonical resolvers, manifest scope, round-trip cost, test isolation, cross-platform primitives |
| `CLAUDE.md` | Expanded callout — entire dogfooding.md now mandatory reading across 5 scenarios |

## Related

- #1090 — original `flo init` sync issue (this PR addresses the post-upgrade DB corruption side)
- #1084 — sql.js retirement (test residue cleanup falls out of this)
- #1111 / PR #1117 — Memory Access Functional literal-key fallback (predecessor pattern; #1120 will extend it)
- #1120 — follow-up filed today

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)