### PR TITLE
fix(doctor): run action flags before JSON emit (#1122)

### DIFF
--- a/.claude/skills/healer/SKILL.md
+++ b/.claude/skills/healer/SKILL.md
@@ -30,7 +30,9 @@ Thin wrapper around the `flo healer` CLI. All check + fix logic lives in the CLI
    - `✓ N passing` (count only)
    - `⚠ warnings` — list `name: message`; flag with `[auto-fixable]` when the result has a `fix` field
    - `✗ failures` — same
-   - If `--fix` mode, also list which fixes were applied vs which need manual action.
+   - If `--fix` mode, read `fixesApplied[]` from the JSON payload and list `{name, applied}` per entry — applied=true → "fixed", applied=false → "needs manual action". The `results[]` array is post-fix state (re-evaluated), so report the final status.
+   - If `--install` was passed, surface `claudeCodeInstall.installed` from the payload.
+   - If `--kill-zombies` was passed, surface `zombieScan.killed` / `zombieScan.found` from the payload.
 
 4. **Nudge based on what changed.** Only mention next steps for state that *actually* changed:
    - Daemon restarted → `Statusline should refresh within ~5s.`

--- a/src/cli/__tests__/commands/doctor-json-fix.test.ts
+++ b/src/cli/__tests__/commands/doctor-json-fix.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Issue #1122: `npx moflo doctor --json --fix` (and `--json --install` /
+ * `--json --kill-zombies`) used to silently no-op because the JSON branch
+ * early-returned BEFORE runAutoFix / maybeAutoInstallClaudeCode were called.
+ * Every consumer running `/healer --fix` saw the failure persist after the
+ * "fix" completed with no diagnostic.
+ *
+ * These tests pin the post-fix orchestration contract:
+ *   - `runAutoFix` returns a structured outcome (fixesApplied + reEvaluated)
+ *     in both rendered and silent modes.
+ *   - `emitJsonOutput` carries `fixesApplied`, `zombieScan`, `claudeCodeInstall`
+ *     through when provided, and omits them when not.
+ *   - Silent mode suppresses stdout so the JSON document stays single-doc.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { autoFixCheckMock } = vi.hoisted(() => ({
+  autoFixCheckMock: vi.fn<(check: { name: string }) => Promise<boolean>>(),
+}));
+
+vi.mock('../../commands/doctor-fixes.js', () => ({
+  autoFixCheck: autoFixCheckMock,
+}));
+
+import {
+  emitJsonOutput,
+  runAutoFix,
+  type FixOutcome,
+} from '../../commands/doctor-render.js';
+import type { CheckFn, HealthCheck } from '../../commands/doctor-types.js';
+
+let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+let capturedStdout: string;
+
+beforeEach(() => {
+  capturedStdout = '';
+  stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(
+    (chunk: unknown) => {
+      capturedStdout += String(chunk);
+      return true;
+    },
+  );
+  autoFixCheckMock.mockReset();
+});
+
+afterEach(() => {
+  stdoutWriteSpy.mockRestore();
+});
+
+describe('runAutoFix (#1122) — structured outcome', () => {
+  it('returns fixesApplied + reEvaluated when at least one fix succeeds', async () => {
+    autoFixCheckMock.mockResolvedValue(true);
+
+    const results: HealthCheck[] = [
+      { name: 'Stub Check A', status: 'fail', message: 'broken', fix: 'fix-it' },
+      { name: 'Stub Check B', status: 'pass', message: 'fine' },
+    ];
+    const fixes = ['Stub Check A: fix-it'];
+
+    let reCheckCalls = 0;
+    const fakeCheck: CheckFn = async () => {
+      reCheckCalls++;
+      return { name: 'Stub Check A', status: 'pass', message: 'now ok' };
+    };
+
+    const outcome = await runAutoFix(results, fixes, [fakeCheck], { silent: true });
+
+    expect(outcome.fixesApplied).toEqual([
+      { name: 'Stub Check A', applied: true },
+    ]);
+    expect(outcome.reEvaluated).not.toBeNull();
+    expect(outcome.reEvaluated?.[0].status).toBe('pass');
+    expect(reCheckCalls).toBe(1);
+  });
+
+  it('returns fixesApplied with applied=false and null reEvaluated when fix fails', async () => {
+    autoFixCheckMock.mockResolvedValue(false);
+
+    const results: HealthCheck[] = [
+      { name: 'Stub Check A', status: 'fail', message: 'broken', fix: 'fix-it' },
+    ];
+    const fixes = ['Stub Check A: fix-it'];
+    const fakeCheck: CheckFn = async () => ({ name: 'Stub Check A', status: 'fail', message: 'still broken' });
+
+    const outcome = await runAutoFix(results, fixes, [fakeCheck], { silent: true });
+
+    expect(outcome.fixesApplied).toEqual([{ name: 'Stub Check A', applied: false }]);
+    expect(outcome.reEvaluated).toBeNull();
+  });
+
+  it('silent mode writes nothing to stdout; rendered mode writes the banner', async () => {
+    autoFixCheckMock.mockResolvedValue(true);
+
+    const results: HealthCheck[] = [
+      { name: 'Stub Check A', status: 'fail', message: 'broken', fix: 'fix-it' },
+    ];
+    const fixes = ['Stub Check A: fix-it'];
+    const fakeCheck: CheckFn = async () => ({ name: 'Stub Check A', status: 'pass', message: 'ok' });
+
+    capturedStdout = '';
+    await runAutoFix(results, fixes, [fakeCheck], { silent: true });
+    expect(capturedStdout).toBe('');
+
+    capturedStdout = '';
+    await runAutoFix(results, fixes, [fakeCheck], { silent: false });
+    expect(capturedStdout).toContain('Auto-fixing issues');
+    expect(capturedStdout).toContain('Auto-fixed 1 issue');
+  });
+
+  it('no fixes → empty fixesApplied, no re-evaluation, no work performed', async () => {
+    const outcome = await runAutoFix([], [], [], { silent: true });
+    expect(outcome).toEqual({ fixesApplied: [], reEvaluated: null });
+    expect(autoFixCheckMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('emitJsonOutput (#1122) — payload extensions', () => {
+  const baseOpts = {
+    results: [{ name: 'A', status: 'pass' as const, message: 'fine' }],
+    strict: false,
+    allowWarnList: [],
+  };
+
+  it('omits fixesApplied / zombieScan / claudeCodeInstall when not provided (backwards compatibility)', () => {
+    capturedStdout = '';
+    emitJsonOutput(baseOpts);
+    const doc = JSON.parse(capturedStdout);
+    expect(doc).toHaveProperty('summary');
+    expect(doc).toHaveProperty('results');
+    expect(doc).not.toHaveProperty('fixesApplied');
+    expect(doc).not.toHaveProperty('zombieScan');
+    expect(doc).not.toHaveProperty('claudeCodeInstall');
+  });
+
+  it('includes fixesApplied when provided', () => {
+    capturedStdout = '';
+    const fixesApplied: FixOutcome[] = [
+      { name: 'Daemon Version Skew', applied: true },
+      { name: 'Memory Database', applied: false, error: 'permission denied' },
+    ];
+    emitJsonOutput({ ...baseOpts, fixesApplied });
+    const doc = JSON.parse(capturedStdout);
+    expect(doc.fixesApplied).toEqual(fixesApplied);
+  });
+
+  it('includes zombieScan when provided', () => {
+    capturedStdout = '';
+    emitJsonOutput({
+      ...baseOpts,
+      zombieScan: { registryKilled: 2, found: 1, killed: 1, details: [] },
+    });
+    const doc = JSON.parse(capturedStdout);
+    expect(doc.zombieScan).toEqual({ registryKilled: 2, found: 1, killed: 1, details: [] });
+  });
+
+  it('includes claudeCodeInstall when provided', () => {
+    capturedStdout = '';
+    emitJsonOutput({
+      ...baseOpts,
+      claudeCodeInstall: { attempted: true, installed: true },
+    });
+    const doc = JSON.parse(capturedStdout);
+    expect(doc.claudeCodeInstall).toEqual({ attempted: true, installed: true });
+  });
+
+  it('emits empty fixesApplied array (distinct from absent) so automation can detect --fix ran with nothing to do', () => {
+    capturedStdout = '';
+    emitJsonOutput({ ...baseOpts, fixesApplied: [] });
+    const doc = JSON.parse(capturedStdout);
+    expect(doc.fixesApplied).toEqual([]);
+  });
+});

--- a/src/cli/__tests__/doctor-checks-memory-access.test.ts
+++ b/src/cli/__tests__/doctor-checks-memory-access.test.ts
@@ -326,3 +326,125 @@ describe('doctor-checks-memory-access — #1111 HNSW-empty fallback', () => {
     expect(searchDetail!.status).toBe('fail');
   });
 });
+
+/**
+ * #1120 regression: same bug class as #1111, but the search returns a
+ * non-empty result set that doesn't include the just-stored key — typical
+ * when the doctor probe runs 2+ times in the same session and the namespace
+ * still has rows from previous runs (safeDelete is best-effort). The new
+ * write hasn't propagated to the HNSW index yet, so search returns a stale
+ * neighbor as the top hit. #1111's fallback only fired on `total === 0`, so
+ * this case slipped through as `fail` — even though the row IS in the DB
+ * and the memory access path is working.
+ *
+ * Fix: extend the literal-key fallback to the non-zero-results case. If our
+ * key isn't in the search results AND literal retrieve finds it, demote
+ * `search-finds-key` to warn (matching the spirit of #1111: distinguish
+ * stack-broken from stack-working-but-state-not-yet-ready). `memory_search`
+ * itself stays pass — total>=1 with HNSW backend is a healthy search.
+ */
+describe('doctor-checks-memory-access — #1120 stale-neighbor fallback', () => {
+  function buildStaleNeighborTools(opts: { retrieveFinds: boolean }): ToolHandler[] {
+    const stored = new Map<string, { value: unknown }>();
+    const stalePriorKey = 'doctor-memprobe-unit-OLD-stale-row';
+    return [
+      {
+        name: 'memory_store',
+        handler: async (input) => {
+          const k = `${(input.namespace as string) ?? 'default'}::${input.key as string}`;
+          stored.set(k, { value: input.value });
+          return {
+            success: true,
+            key: input.key,
+            namespace: input.namespace,
+            hasEmbedding: true,
+            embeddingDimensions: 384,
+            backend: 'sql.js + HNSW',
+          };
+        },
+      },
+      {
+        name: 'memory_search',
+        // The race: store succeeded, but HNSW returns a stale neighbor from
+        // a prior probe run and not the just-written row. Matches the
+        // production failure mode in #1120.
+        handler: async (input) => ({
+          results: [{
+            key: stalePriorKey,
+            namespace: (input.namespace as string) ?? 'default',
+            value: 'stale prior probe value',
+            similarity: 0.3,
+          }],
+          total: 1,
+          backend: 'HNSW + sql.js',
+        }),
+      },
+      {
+        name: 'memory_retrieve',
+        handler: async (input) => {
+          if (!opts.retrieveFinds) return { key: input.key, namespace: input.namespace, value: null, found: false };
+          const k = `${(input.namespace as string) ?? 'default'}::${input.key as string}`;
+          const row = stored.get(k);
+          if (!row) return { key: input.key, namespace: input.namespace, value: null, found: false };
+          return { key: input.key, namespace: input.namespace, value: row.value, found: true };
+        },
+      },
+      {
+        name: 'memory_delete',
+        handler: async () => ({ success: true }),
+      },
+    ];
+  }
+
+  it('demotes search-finds-key to warn when search returned wrong rows but literal retrieve finds our key', async () => {
+    const details: FunctionalCheckDetail[] = [];
+    await _runMemoryRoundTripForTest({
+      persona: 'unit', idPrefix: 'unit',
+      memoryTools: buildStaleNeighborTools({ retrieveFinds: true }),
+      details,
+    });
+
+    // memory_search subcheck stays pass — total>=1, HNSW backend, threshold
+    // honored. The bug only manifests at the search-finds-key subcheck.
+    const searchDetail = details.find(d => d.id === 'unit.memory_search');
+    expect(searchDetail, 'memory_search subcheck must be recorded').toBeDefined();
+    expect(
+      searchDetail!.status,
+      `expected pass, got ${searchDetail!.status}: ${searchDetail!.message}`,
+    ).toBe('pass');
+
+    // search-finds-key demoted to warn (the new #1120 fallback path).
+    const findsKeyDetail = details.find(d => d.id === 'unit.search-finds-key');
+    expect(findsKeyDetail, 'search-finds-key subcheck must be recorded').toBeDefined();
+    expect(
+      findsKeyDetail!.status,
+      `expected warn, got ${findsKeyDetail!.status}: ${findsKeyDetail!.message}`,
+    ).toBe('warn');
+    expect(findsKeyDetail!.message).toMatch(/stale-neighbor|literal retrieve|not yet propagated/i);
+
+    // retrieve-roundtrip still passes — proof memory access works even when
+    // the HNSW index is racing the new write.
+    const retrieveDetail = details.find(d => d.id === 'unit.retrieve-roundtrip');
+    expect(retrieveDetail).toBeDefined();
+    expect(retrieveDetail!.status).toBe('pass');
+
+    // No fail rows — the whole point of the fix.
+    expect(details.filter(d => d.status === 'fail')).toHaveLength(0);
+  });
+
+  it('keeps search-finds-key as fail when neither search nor literal retrieve find our key', async () => {
+    const details: FunctionalCheckDetail[] = [];
+    await _runMemoryRoundTripForTest({
+      persona: 'unit', idPrefix: 'unit',
+      memoryTools: buildStaleNeighborTools({ retrieveFinds: false }),
+      details,
+    });
+
+    // Real memory-access regression: row was supposedly stored but neither
+    // semantic nor literal access can find our specific key. Must still fail.
+    const findsKeyDetail = details.find(d => d.id === 'unit.search-finds-key');
+    expect(findsKeyDetail).toBeDefined();
+    expect(findsKeyDetail!.status).toBe('fail');
+    expect(findsKeyDetail!.message).toMatch(/not in results/i);
+  });
+});

--- a/src/cli/__tests__/memory/bridge-stale-handle-retry.test.ts
+++ b/src/cli/__tests__/memory/bridge-stale-handle-retry.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Issue #1123: stale-handle race in `withDb`.
+ *
+ * Reproduction context — concurrent doctor probes (`checkMemoryAccessFunctional`,
+ * `checkHiveMindFunctional`, etc.) run in `Promise.allSettled`. Each calls
+ * `withDb`, which front-loads `checkBridgeCoherence`. If probe B's coherence
+ * check observes another writer's mtime advance, it calls `shutdownBridge()`
+ * — closing the registry's underlying `DatabaseSync`. Probe A has already
+ * resolved its `ctx` from the now-closed registry, so A's `fn(ctx, ...)`
+ * throws node:sqlite's `ERR_INVALID_STATE: database is not open`.
+ *
+ * Pre-fix behaviour: `withDb` caught the error, logged
+ * `[moflo] bridge operation failed: database is not open` to stderr, and
+ * returned `null`. Callers fell back to direct-write (so no data loss), but
+ * stderr noise corrupted `healer --json --fix` output and masked a real race.
+ *
+ * Post-fix contract: bounded one-shot retry against a freshly-acquired
+ * registry, matching the shape of `withBusyRetry` for `SQLITE_BUSY`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  _resetProjectRootForTest,
+  shutdownBridge,
+  withDb,
+} from '../../memory/bridge-core.js';
+import { storeEntry } from '../../memory/memory-initializer.js';
+
+function makeStaleHandleError(): Error {
+  const err = new Error('database is not open');
+  (err as Error & { code: string }).code = 'ERR_INVALID_STATE';
+  return err;
+}
+
+describe('withDb stale-handle retry (#1123)', () => {
+  let tempDir: string;
+  let originalProjectDir: string | undefined;
+  let stderrLines: string[];
+  let origConsoleError: typeof console.error;
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), 'moflo-1123-'));
+    fs.mkdirSync(path.join(tempDir, '.moflo'), { recursive: true });
+    originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = tempDir;
+    process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+
+    await shutdownBridge();
+    _resetProjectRootForTest();
+
+    stderrLines = [];
+    origConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      stderrLines.push(args.map((a) => String(a)).join(' '));
+    };
+
+    // Anchor the bridge against a real DB so `withDb` has a registry to
+    // re-acquire. Without this initial write, `getRegistry` may resolve to
+    // null on the retry path and we'd be testing the wrong failure mode.
+    const seed = await storeEntry({ key: 'seed', value: 's', namespace: 'ns' });
+    if (!seed.success) {
+      throw new Error(`test setup failed — seed write rejected: ${seed.error ?? 'unknown'}`);
+    }
+  });
+
+  afterEach(async () => {
+    console.error = origConsoleError;
+    await shutdownBridge();
+    _resetProjectRootForTest();
+    if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+    delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+    try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('retries once with a fresh registry when fn throws stale-handle error', async () => {
+    let calls = 0;
+    const result = await withDb<{ ok: true }>(undefined, async () => {
+      calls++;
+      if (calls === 1) throw makeStaleHandleError();
+      return { ok: true };
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toBe(2);
+    expect(stderrLines.filter((s) => s.includes('bridge operation failed'))).toEqual([]);
+  });
+
+  it('recognises plain "database is not open" message even without ERR_INVALID_STATE code', async () => {
+    let calls = 0;
+    const result = await withDb<{ ok: true }>(undefined, async () => {
+      calls++;
+      if (calls === 1) throw new Error('database is not open');
+      return { ok: true };
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toBe(2);
+  });
+
+  it('gives up after one retry — bounded so a broken bridge still surfaces', async () => {
+    let calls = 0;
+    const result = await withDb<{ ok: true }>(undefined, async () => {
+      calls++;
+      throw makeStaleHandleError();
+    });
+
+    expect(result).toBeNull();
+    expect(calls).toBe(2);
+    expect(
+      stderrLines.some((s) => s.includes('bridge operation failed: database is not open')),
+    ).toBe(true);
+  });
+
+  it('does not retry on unrelated errors (no semantic change for non-race failures)', async () => {
+    let calls = 0;
+    const result = await withDb<{ ok: true }>(undefined, async () => {
+      calls++;
+      throw new Error('something else entirely');
+    });
+
+    expect(result).toBeNull();
+    expect(calls).toBe(1);
+    expect(
+      stderrLines.some((s) => s.includes('bridge operation failed: something else entirely')),
+    ).toBe(true);
+  });
+});

--- a/src/cli/commands/doctor-checks-memory-access.ts
+++ b/src/cli/commands/doctor-checks-memory-access.ts
@@ -191,12 +191,41 @@ async function runMemoryRoundTrip(ctx: RoundTripContext): Promise<{ key: string;
     });
   } else {
     const top = searchOut.results?.find(r => r.key === key);
-    pushDetail(
-      ctx.details,
-      { id: `${ctx.idPrefix}.search-finds-key`, mcpTool: 'memory_search', expected: `result containing key=${key}` },
-      top ? { topKey: top.key, similarity: top.similarity } : { allKeys: searchOut.results?.map(r => r.key) },
-      top ? null : `stored key ${key} not in results (got: ${searchOut?.results?.map(r => r.key).join(', ') ?? 'none'})`,
-    );
+    if (top) {
+      pushDetail(
+        ctx.details,
+        { id: `${ctx.idPrefix}.search-finds-key`, mcpTool: 'memory_search', expected: `result containing key=${key}` },
+        { topKey: top.key, similarity: top.similarity },
+        null,
+      );
+    } else {
+      // #1120: search returned results but our just-stored key wasn't among
+      // them. Mirrors the #1111 empty-HNSW fallback for the non-zero case:
+      // if the row IS reachable by literal key, demote to warn — memory
+      // access works, the HNSW index just hasn't propagated the new write
+      // yet (stale-neighbor race when healer runs 2+ times in one session
+      // against accumulated probe rows). If literal retrieve also fails,
+      // surface the original fail unchanged.
+      const otherKeys = searchOut?.results?.map(r => r.key).join(', ') ?? 'none';
+      const retrievable = await literalKeyReachable(ctx.memoryTools, key, namespace);
+      if (retrievable) {
+        ctx.details.push({
+          id: `${ctx.idPrefix}.search-finds-key`,
+          mcpTool: 'memory_search',
+          status: 'warn',
+          observed: { topKeys: searchOut?.results?.map(r => r.key), retrievable: true },
+          expected: `result containing key=${key}`,
+          message: `search returned results but our key was not among them (got: ${otherKeys}); row IS reachable by literal retrieve — HNSW stale-neighbor race (newly-written row not yet propagated to the index). Memory access path works.`,
+        });
+      } else {
+        pushDetail(
+          ctx.details,
+          { id: `${ctx.idPrefix}.search-finds-key`, mcpTool: 'memory_search', expected: `result containing key=${key}` },
+          { allKeys: searchOut.results?.map(r => r.key) },
+          `stored key ${key} not in results (got: ${otherKeys})`,
+        );
+      }
+    }
   }
 
   // 4. memory_retrieve returns the full value (search content is truncated

--- a/src/cli/commands/doctor-render.ts
+++ b/src/cli/commands/doctor-render.ts
@@ -11,8 +11,40 @@ import {
   findZombieProcesses,
   formatZombieDetail,
   killTrackedProcesses,
+  type ZombieDetail,
 } from './doctor-zombies.js';
 import type { CheckFn, HealthCheck } from './doctor-types.js';
+
+/**
+ * Issue #1122: action flags (`--fix`, `--install`, `--kill-zombies`) must
+ * honor the JSON-output contract. These types describe the post-fix payload
+ * the JSON document carries so automation (e.g. the shipped `/healer` skill)
+ * can tell what changed without re-parsing prose.
+ */
+export interface FixOutcome {
+  name: string;
+  applied: boolean;
+  error?: string;
+}
+
+export interface AutoFixResult {
+  fixesApplied: FixOutcome[];
+  /** Re-evaluated checks when at least one fix succeeded; null when nothing was applied. */
+  reEvaluated: HealthCheck[] | null;
+}
+
+export interface KillZombiesResult {
+  registryKilled: number;
+  found: number;
+  killed: number;
+  details: ZombieDetail[];
+}
+
+export interface ClaudeCodeInstallResult {
+  attempted: boolean;
+  installed: boolean;
+  postCheck?: HealthCheck;
+}
 
 export function formatCheck(check: HealthCheck): string {
   const icon = check.status === 'pass' ? output.success('✓') :
@@ -31,12 +63,21 @@ function tally(results: HealthCheck[]): SummaryCounts {
   };
 }
 
-export async function runKillZombiesBanner(): Promise<void> {
-  output.writeln(output.bold('Zombie Process Scan'));
-  output.writeln();
+/**
+ * Run the kill-zombies scan, with optional rendering. Issue #1122: in JSON
+ * mode the prose banner would corrupt the single-document contract, so the
+ * caller passes `silent: true` and surfaces the structured result inside the
+ * JSON payload instead.
+ */
+export async function runKillZombies(opts: { silent?: boolean } = {}): Promise<KillZombiesResult> {
+  const silent = !!opts.silent;
+  if (!silent) {
+    output.writeln(output.bold('Zombie Process Scan'));
+    output.writeln();
+  }
 
   const registryKilled = killTrackedProcesses();
-  if (registryKilled > 0) {
+  if (!silent && registryKilled > 0) {
     output.writeln(output.success(`  Killed ${registryKilled} tracked background process(es) from registry`));
   }
 
@@ -44,42 +85,62 @@ export async function runKillZombiesBanner(): Promise<void> {
   const result = await findZombieProcesses(true);
   const found = result.details.length;
 
-  if (found === 0) {
-    if (registryKilled === 0) {
-      output.writeln(output.success('  No orphaned moflo processes found'));
+  if (!silent) {
+    if (found === 0) {
+      if (registryKilled === 0) {
+        output.writeln(output.success('  No orphaned moflo processes found'));
+      }
+    } else {
+      output.writeln(output.warning(`  Found ${found} additional orphaned process(es):`));
+      for (const d of result.details) {
+        output.writeln(output.dim(`    ${formatZombieDetail(d)}`));
+      }
+      if (result.killed > 0) {
+        output.writeln(output.success(`  Killed ${result.killed} zombie process(es)`));
+      }
+      if (result.killed < found) {
+        output.writeln(output.warning(`  ${found - result.killed} process(es) could not be killed`));
+      }
     }
-  } else {
-    output.writeln(output.warning(`  Found ${found} additional orphaned process(es):`));
-    for (const d of result.details) {
-      output.writeln(output.dim(`    ${formatZombieDetail(d)}`));
-    }
-    if (result.killed > 0) {
-      output.writeln(output.success(`  Killed ${result.killed} zombie process(es)`));
-    }
-    if (result.killed < found) {
-      output.writeln(output.warning(`  ${found - result.killed} process(es) could not be killed`));
-    }
+
+    output.writeln();
+    output.writeln(output.dim('─'.repeat(50)));
+    output.writeln();
   }
 
-  output.writeln();
-  output.writeln(output.dim('─'.repeat(50)));
-  output.writeln();
+  return { registryKilled, found, killed: result.killed, details: result.details };
 }
 
 interface JsonOutputOpts {
   results: HealthCheck[];
   strict: boolean;
   allowWarnList: string[];
+  /** Issue #1122: per-fix outcomes when --fix ran on the JSON path. */
+  fixesApplied?: FixOutcome[];
+  /** Issue #1122: --kill-zombies scan summary when that flag was passed. */
+  zombieScan?: KillZombiesResult;
+  /** Issue #1122: --install outcome when that flag was passed. */
+  claudeCodeInstall?: ClaudeCodeInstallResult;
 }
 
 /**
  * Issue #818: machine-readable output. Emits a single JSON document with
  * per-check fields (and any FunctionalCheckDetail entries from the swarm/
- * hive checks) and exits with the right code. Skips auto-fix entirely —
- * --json is read-only by intent so CI gates can consume it without
- * mutating the working tree.
+ * hive checks) and exits with the right code.
+ *
+ * Issue #1122: action flags (`--fix`, `--install`, `--kill-zombies`) now run
+ * before this is called and their outcomes are passed in so automation can
+ * tell what changed without re-parsing prose. `results` reflects post-fix
+ * state when `fixesApplied` includes any successful fix.
  */
-export function emitJsonOutput({ results, strict, allowWarnList }: JsonOutputOpts): CommandResult {
+export function emitJsonOutput({
+  results,
+  strict,
+  allowWarnList,
+  fixesApplied,
+  zombieScan,
+  claudeCodeInstall,
+}: JsonOutputOpts): CommandResult {
   const { passed, warnings, failed } = tally(results);
 
   const allowSet = new Set(allowWarnList);
@@ -89,24 +150,46 @@ export function emitJsonOutput({ results, strict, allowWarnList }: JsonOutputOpt
 
   const exitCode = failed > 0 || strictWarningFailures.length > 0 ? 1 : 0;
 
-  process.stdout.write(JSON.stringify({
+  const payload: {
+    summary: SummaryCounts;
+    strict: { strictMode: true; warningsTriggeringFail: string[] } | { strictMode: false };
+    results: HealthCheck[];
+    fixesApplied?: FixOutcome[];
+    zombieScan?: KillZombiesResult;
+    claudeCodeInstall?: ClaudeCodeInstallResult;
+  } = {
     summary: { passed, warnings, failed },
     strict: strict ? { strictMode: true, warningsTriggeringFail: strictWarningFailures } : { strictMode: false },
     results,
-  }, null, 2) + '\n');
+  };
+  if (fixesApplied !== undefined) payload.fixesApplied = fixesApplied;
+  if (zombieScan !== undefined) payload.zombieScan = zombieScan;
+  if (claudeCodeInstall !== undefined) payload.claudeCodeInstall = claudeCodeInstall;
+
+  process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
 
   return { success: exitCode === 0, exitCode, data: { passed, warnings, failed, results } };
 }
 
-/** Re-runs Claude Code CLI install + check if --install was passed and the prior result wasn't pass. */
+/**
+ * Re-runs Claude Code CLI install + check if --install was passed and the
+ * prior result wasn't pass. Issue #1122: accepts `{silent}` so the JSON path
+ * runs the install without writing prose to the corrupted stdout, and
+ * returns a structured outcome for inclusion in the JSON document.
+ */
 export async function maybeAutoInstallClaudeCode(
   results: HealthCheck[],
   fixes: string[],
-): Promise<void> {
+  opts: { silent?: boolean } = {},
+): Promise<ClaudeCodeInstallResult> {
+  const silent = !!opts.silent;
   const claudeCodeResult = results.find(r => r.name === 'Claude Code CLI');
-  if (!claudeCodeResult || claudeCodeResult.status === 'pass') return;
+  if (!claudeCodeResult || claudeCodeResult.status === 'pass') {
+    return { attempted: false, installed: false };
+  }
   const installed = await installClaudeCode();
-  if (!installed) return;
+  if (!installed) return { attempted: true, installed: false };
+
   const newCheck = await checkClaudeCode();
   const idx = results.findIndex(r => r.name === 'Claude Code CLI');
   if (idx !== -1) {
@@ -116,7 +199,8 @@ export async function maybeAutoInstallClaudeCode(
       fixes.splice(fixIdx, 1);
     }
   }
-  output.writeln(formatCheck(newCheck));
+  if (!silent) output.writeln(formatCheck(newCheck));
+  return { attempted: true, installed: true, postCheck: newCheck };
 }
 
 export function renderSummary(results: HealthCheck[]): SummaryCounts {
@@ -135,66 +219,86 @@ export function renderSummary(results: HealthCheck[]): SummaryCounts {
   return counts;
 }
 
-/** Auto-fix loop, including the post-fix re-run. Mutates `results` and `fixes` in place when fixes succeed. */
+/**
+ * Auto-fix loop, including the post-fix re-run. Mutates `results` and `fixes`
+ * in place when fixes succeed and returns a structured outcome.
+ *
+ * Issue #1122: accepts `{silent}` so the JSON path can run the same fix work
+ * without writing prose to a stubbed stdout, and emit `fixesApplied` +
+ * post-fix `results` from the returned data.
+ */
 export async function runAutoFix(
   results: HealthCheck[],
   fixes: string[],
   checksToRun: CheckFn[],
-): Promise<void> {
-  if (fixes.length === 0) return;
+  opts: { silent?: boolean } = {},
+): Promise<AutoFixResult> {
+  const silent = !!opts.silent;
+  if (fixes.length === 0) return { fixesApplied: [], reEvaluated: null };
 
-  output.writeln();
-  output.writeln(output.bold('Auto-fixing issues...'));
-  output.writeln();
+  if (!silent) {
+    output.writeln();
+    output.writeln(output.bold('Auto-fixing issues...'));
+    output.writeln();
+  }
 
   const fixableResults = results.filter(r => r.fix && (r.status === 'fail' || r.status === 'warn'));
-  let fixed = 0;
-  const unfixed: string[] = [];
+  const fixesApplied: FixOutcome[] = [];
 
   for (const check of fixableResults) {
     const success = await autoFixCheck(check);
-    if (success) {
-      fixed++;
-    } else {
-      unfixed.push(`${check.name}: ${check.fix}`);
+    fixesApplied.push({ name: check.name, applied: success });
+  }
+
+  const fixed = fixesApplied.filter(f => f.applied).length;
+  const unfixed = fixesApplied.filter(f => !f.applied);
+
+  if (!silent) {
+    if (fixed > 0) {
+      output.writeln();
+      output.writeln(output.success(`Auto-fixed ${fixed} issue${fixed > 1 ? 's' : ''}`));
+    }
+    if (unfixed.length > 0) {
+      output.writeln();
+      output.writeln(output.bold('Manual fixes needed:'));
+      for (const f of unfixed) {
+        const check = results.find(r => r.name === f.name);
+        output.writeln(output.dim(`  ${f.name}: ${check?.fix ?? ''}`));
+      }
     }
   }
 
-  if (fixed > 0) {
-    output.writeln();
-    output.writeln(output.success(`Auto-fixed ${fixed} issue${fixed > 1 ? 's' : ''}`));
-  }
-  if (unfixed.length > 0) {
-    output.writeln();
-    output.writeln(output.bold('Manual fixes needed:'));
-    for (const fix of unfixed) {
-      output.writeln(output.dim(`  ${fix}`));
-    }
-  }
+  if (fixed === 0) return { fixesApplied, reEvaluated: null };
 
-  if (fixed === 0) return;
+  const reSettled = await Promise.allSettled(checksToRun.map(check => check()));
+  const reEvaluated: HealthCheck[] = reSettled.map((sr) =>
+    sr.status === 'fulfilled'
+      ? sr.value
+      : { name: 'Check', status: 'fail' as const, message: (sr.reason as { message?: string } | undefined)?.message ?? 'Unknown error' },
+  );
 
-  output.writeln();
-  output.writeln(output.dim('Re-checking...'));
-  output.writeln();
-  const reResults = await Promise.allSettled(checksToRun.map(check => check()));
-  let rePassed = 0, reWarnings = 0, reFailed = 0;
-  for (const sr of reResults) {
-    if (sr.status === 'fulfilled') {
-      output.writeln(formatCheck(sr.value));
-      if (sr.value.status === 'pass') rePassed++;
-      else if (sr.value.status === 'warn') reWarnings++;
+  if (!silent) {
+    output.writeln();
+    output.writeln(output.dim('Re-checking...'));
+    output.writeln();
+    let rePassed = 0, reWarnings = 0, reFailed = 0;
+    for (const r of reEvaluated) {
+      output.writeln(formatCheck(r));
+      if (r.status === 'pass') rePassed++;
+      else if (r.status === 'warn') reWarnings++;
       else reFailed++;
     }
+    output.writeln();
+    output.writeln(output.dim('─'.repeat(50)));
+    const reSummary = [
+      output.success(`${rePassed} passed`),
+      reWarnings > 0 ? output.warning(`${reWarnings} warnings`) : null,
+      reFailed > 0 ? output.error(`${reFailed} failed`) : null,
+    ].filter(Boolean);
+    output.writeln(`After fix: ${reSummary.join(', ')}`);
   }
-  output.writeln();
-  output.writeln(output.dim('─'.repeat(50)));
-  const reSummary = [
-    output.success(`${rePassed} passed`),
-    reWarnings > 0 ? output.warning(`${reWarnings} warnings`) : null,
-    reFailed > 0 ? output.error(`${reFailed} failed`) : null,
-  ].filter(Boolean);
-  output.writeln(`After fix: ${reSummary.join(', ')}`);
+
+  return { fixesApplied, reEvaluated };
 }
 
 interface FinalizeOpts {

--- a/src/cli/commands/doctor-render.ts
+++ b/src/cli/commands/doctor-render.ts
@@ -261,9 +261,9 @@ export async function runAutoFix(
     if (unfixed.length > 0) {
       output.writeln();
       output.writeln(output.bold('Manual fixes needed:'));
+      const fixByName = new Map(fixableResults.map(r => [r.name, r.fix ?? '']));
       for (const f of unfixed) {
-        const check = results.find(r => r.name === f.name);
-        output.writeln(output.dim(`  ${f.name}: ${check?.fix ?? ''}`));
+        output.writeln(output.dim(`  ${f.name}: ${fixByName.get(f.name) ?? ''}`));
       }
     }
   }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -245,10 +245,25 @@ export const doctorCommand: Command = {
         const outcome = await runAutoFix(results, fixes, checksToRun, { silent: jsonOutput });
         fixesApplied = outcome.fixesApplied;
         // Replace `results` with post-fix state so JSON consumers see the
-        // re-evaluated truth, not the pre-fix snapshot.
+        // re-evaluated truth, not the pre-fix snapshot. Mirror the #992
+        // post-parallel zombie-scan append so the post-fix shape matches
+        // pre-fix shape (otherwise `--json --fix` silently drops the
+        // Zombie Processes entry from the JSON `results[]`).
         if (outcome.reEvaluated) {
+          const finalChecks = [...outcome.reEvaluated];
+          if (!component) {
+            try {
+              finalChecks.push(await zombieScanCheck());
+            } catch (reason) {
+              finalChecks.push({
+                name: 'Zombie Processes',
+                status: 'fail',
+                message: (reason as { message?: string } | undefined)?.message ?? 'Unknown error',
+              });
+            }
+          }
           results.length = 0;
-          results.push(...outcome.reEvaluated);
+          results.push(...finalChecks);
         }
       } else if (fixes.length > 0 && !showFix && !jsonOutput) {
         output.writeln();

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -22,7 +22,10 @@ import {
   maybeAutoInstallClaudeCode,
   renderSummary,
   runAutoFix,
-  runKillZombiesBanner,
+  runKillZombies,
+  type ClaudeCodeInstallResult,
+  type FixOutcome,
+  type KillZombiesResult,
 } from './doctor-render.js';
 import { checkEmbeddings } from './doctor-checks-memory.js';
 import { checkMofloYamlCompliance } from './doctor-checks-config.js';
@@ -145,28 +148,23 @@ export const doctorCommand: Command = {
       output.writeln();
     }
 
-    if (killZombies) {
-      await runKillZombiesBanner();
-    }
-
     const checksToRun = component && componentMap[component]
       ? [componentMap[component]]
       : allChecks;
 
     const results: HealthCheck[] = [];
     const fixes: string[] = [];
-
-    // OPTIMIZATION: Run all checks in parallel for 3-5x faster execution
-    const spinner = jsonOutput
-      ? null
-      : output.createSpinner({ text: 'Running health checks in parallel...', spinner: 'dots' });
-    spinner?.start();
+    let zombieScan: KillZombiesResult | undefined;
+    let claudeCodeInstall: ClaudeCodeInstallResult | undefined;
+    let fixesApplied: FixOutcome[] | undefined;
 
     // Issue #818: in --json mode, several deep checks (spell engine probe,
     // mcp-spell bridge, etc.) write `[spell] ...` log lines straight to
     // stdout — that breaks the single-JSON-document contract. Capture and
-    // discard stdout writes while checks run; restore in `finally` so a
-    // throw can't leave the process with a stubbed stdout.
+    // discard stdout writes while checks AND post-check actions run; restore
+    // in `finally` so a throw can't leave the process with a stubbed stdout.
+    // Issue #1122: extended to wrap zombie-kill banner, --install, and
+    // --fix work so each runs on the JSON path with prose suppressed.
     const realStdoutWrite = process.stdout.write.bind(process.stdout);
     const restoreStdout = () => {
       if (jsonOutput) {
@@ -178,7 +176,20 @@ export const doctorCommand: Command = {
         (..._args: unknown[]) => true;
     }
 
+    // OPTIMIZATION: Run all checks in parallel for 3-5x faster execution
+    const spinner = jsonOutput
+      ? null
+      : output.createSpinner({ text: 'Running health checks in parallel...', spinner: 'dots' });
+
     try {
+      // Issue #1122: kill-zombies prose used to write BEFORE the JSON
+      // suppression activated, corrupting the JSON document. Now runs
+      // under suppression and feeds a structured result into the payload.
+      if (killZombies) {
+        zombieScan = await runKillZombies({ silent: jsonOutput });
+      }
+
+      spinner?.start();
       let checkResults: PromiseSettledResult<HealthCheck>[];
       try {
         checkResults = await Promise.allSettled(checksToRun.map(check => check()));
@@ -197,7 +208,6 @@ export const doctorCommand: Command = {
         }
       } finally {
         spinner?.stop();
-        restoreStdout();
       }
 
       for (const settledResult of checkResults) {
@@ -219,27 +229,47 @@ export const doctorCommand: Command = {
           if (!jsonOutput) output.writeln(formatCheck(errorResult));
         }
       }
+
+      // Issue #1122: action flags must run on BOTH the JSON path and the
+      // formatted path. Previously the JSON branch early-returned before
+      // any of this ran, so `--json --fix` (and `--json --install`) silently
+      // no-op'd. Now they execute under stdout suppression and their
+      // outcomes feed the JSON payload below.
+      if (autoInstall) {
+        claudeCodeInstall = await maybeAutoInstallClaudeCode(results, fixes, { silent: jsonOutput });
+      }
+
+      if (!jsonOutput) renderSummary(results);
+
+      if (showFix && fixes.length > 0) {
+        const outcome = await runAutoFix(results, fixes, checksToRun, { silent: jsonOutput });
+        fixesApplied = outcome.fixesApplied;
+        // Replace `results` with post-fix state so JSON consumers see the
+        // re-evaluated truth, not the pre-fix snapshot.
+        if (outcome.reEvaluated) {
+          results.length = 0;
+          results.push(...outcome.reEvaluated);
+        }
+      } else if (fixes.length > 0 && !showFix && !jsonOutput) {
+        output.writeln();
+        output.writeln(output.dim(`Run with --fix to auto-fix ${fixes.length} issue${fixes.length > 1 ? 's' : ''}`));
+      }
     } catch {
       spinner?.stop();
-      restoreStdout();
       if (!jsonOutput) output.writeln(output.error('Failed to run health checks'));
+    } finally {
+      restoreStdout();
     }
 
     if (jsonOutput) {
-      return emitJsonOutput({ results, strict, allowWarnList });
-    }
-
-    if (autoInstall) {
-      await maybeAutoInstallClaudeCode(results, fixes);
-    }
-
-    renderSummary(results);
-
-    if (showFix && fixes.length > 0) {
-      await runAutoFix(results, fixes, checksToRun);
-    } else if (fixes.length > 0 && !showFix) {
-      output.writeln();
-      output.writeln(output.dim(`Run with --fix to auto-fix ${fixes.length} issue${fixes.length > 1 ? 's' : ''}`));
+      return emitJsonOutput({
+        results,
+        strict,
+        allowWarnList,
+        fixesApplied,
+        zombieScan,
+        claudeCodeInstall,
+      });
     }
 
     return finalize({ results, strict, allowWarnList });

--- a/src/cli/memory/bridge-core.ts
+++ b/src/cli/memory/bridge-core.ts
@@ -110,6 +110,26 @@ export function logBridgeError(context: string, err: unknown, opts?: { alwaysLog
 }
 
 /**
+ * Recognises the node:sqlite "operation on closed handle" error shape.
+ *
+ * #1123 — A concurrent `withDb` call's `checkBridgeCoherence` can fire
+ * `shutdownBridge()` between our `getDb(registry)` and `fn(ctx, registry)`,
+ * closing the underlying `DatabaseSync`. Our previously-captured `ctx.db`
+ * then throws `ERR_INVALID_STATE: database is not open` on the next op.
+ *
+ * The operation hadn't started its mutation yet, so a single retry against a
+ * fresh registry is safe (matches the `withBusyRetry` shape for SQLITE_BUSY).
+ * Bounded to one retry so a *genuinely* broken DB still surfaces — we don't
+ * want to mask a registry that can't be re-acquired.
+ */
+function isStaleHandleError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { message?: unknown; code?: unknown };
+  if (e.code === 'ERR_INVALID_STATE') return true;
+  return typeof e.message === 'string' && /database is not open/i.test(e.message);
+}
+
+/**
  * Treats an error as a SQLITE_BUSY lock-contention failure if either the
  * error code or message indicates it. Belt-and-suspenders around node:sqlite,
  * whose surface intermittently surfaces busy-conflicts as either `code:
@@ -477,6 +497,14 @@ export async function withDb<T>(
   dbPath: string | undefined,
   fn: (ctx: BridgeDbContext, registry: any) => Promise<T | null>,
 ): Promise<T | null> {
+  return withDbInner(dbPath, fn, 0);
+}
+
+async function withDbInner<T>(
+  dbPath: string | undefined,
+  fn: (ctx: BridgeDbContext, registry: any) => Promise<T | null>,
+  attempt: number,
+): Promise<T | null> {
   await checkBridgeCoherence(dbPath);
   const registry = await getRegistry(dbPath);
   if (!registry) return null;
@@ -522,6 +550,18 @@ export async function withDb<T>(
     }
     return result;
   } catch (err) {
+    // #1123 — stale-handle race: a concurrent withDb's coherence check tore
+    // the registry down between our getDb() and fn() execution, closing the
+    // underlying DatabaseSync. Drop the dead handle and retry once against a
+    // freshly-acquired registry. The first attempt threw BEFORE its mutation
+    // landed (node:sqlite errors at prepare/exec time, not mid-statement), so
+    // a retry is idempotent. Bounded to one retry so a genuinely-unrecoverable
+    // bridge (e.g. corrupt file, missing module) still surfaces as a null
+    // return + logged error, not an infinite loop.
+    if (attempt === 0 && isStaleHandleError(err)) {
+      await shutdownBridge();
+      return await withDbInner(dbPath, fn, attempt + 1);
+    }
     logBridgeError('bridge operation failed', err);
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes #1122 — `flo doctor --json --fix` (and `--json --install`, `--json --kill-zombies`) silently no-op'd because the JSON branch in `src/cli/commands/doctor.ts` early-returned at `emitJsonOutput(...)` BEFORE reaching the action handlers. Every consumer running the shipped `/healer --fix` skill saw failures persist with no diagnostic.

Also fixes #1123 — bridge stderr noise `[moflo] bridge operation failed: database is not open` on `healer --json --fix`, which was masking a real TOCTOU race in `withDb`.

Also fixes #1120 — `Memory Access Functional` `search-finds-key` subcheck failed when healer ran 2+ times in the same session against accumulated probe rows (HNSW stale-neighbor race that slipped past #1111's empty-only fallback).

### #1122 — doctor JSON action flags

- Restructure the action so `runKillZombies`, `maybeAutoInstallClaudeCode`, and `runAutoFix` execute INSIDE the existing stdout-suppression block, ABOVE the JSON early-return.
- Each handler now accepts `{silent}` and returns a structured outcome (`FixOutcome`, `KillZombiesResult`, `ClaudeCodeInstallResult`) that feeds the JSON payload as **additive** fields — existing JSON consumers see no schema change.
- `results[]` is replaced in-place with the post-fix re-evaluation so JSON consumers see post-fix truth, not the pre-fix snapshot. Mirrors the #992 post-parallel `zombieScanCheck` append so post-fix shape matches pre-fix shape.
- Spotted while reviewing: `runKillZombiesBanner` was previously called BEFORE stdout suppression activated, corrupting the JSON document on `--json --kill-zombies`. Now runs inside the suppression block. Renamed → `runKillZombies` (no back-compat shim — sole caller updated).
- `.claude/skills/healer/SKILL.md` updated to surface `fixesApplied[]`, `claudeCodeInstall.installed`, and `zombieScan.killed/found` from the JSON payload.

### #1123 — bridge stale-handle race

Root cause (traced via temporary `MOFLO_BRIDGE_TRACE` instrumentation): concurrent doctor probes (`checkMemoryAccessFunctional`, `checkHiveMindFunctional`) call `withDb` in `Promise.allSettled`. Probe A resolves `ctx = getDb(registry)` and is mid-`fn(ctx)`. Probe B's `checkBridgeCoherence` observes another writer's mtime advance, fires `shutdownBridge()` — closing the underlying `DatabaseSync`. A's next `ctx.db.prepare(...)` throws node:sqlite `ERR_INVALID_STATE: database is not open`. Pre-fix: caught + logged to stderr + returned null (caller fell through to direct-write fallback, no data loss, but stderr noise corrupted `2>&1 | jq` usage and masked the race).

Fix mirrors `withBusyRetry` shape: classify the error, drop the dead handle via `shutdownBridge()`, retry once with a fresh registry. node:sqlite errors at prepare()/exec() time so the mutation either never started or rolled back — the retry is idempotent. Bounded to one retry so a genuinely-broken bridge still surfaces.

End-to-end verification: `npx moflo healer --json --fix` now emits **zero stderr lines** on a green run (was 2).

### #1120 — Memory Access Functional stale-neighbor fallback

Same bug class as #1111, but for the case where search returns non-empty results that don't include the just-stored key. #1111 only fired the literal-key fallback on `total === 0`; this case has `total >= 1` (a stale prior probe row from earlier in the session), so the fallback never triggered and `search-finds-key` failed outright — even though the row IS in the DB and memory access works.

Fix: when `top` isn't found in the search results, fall back to `literalKeyReachable`. If retrievable, demote `search-finds-key` to `warn` (`memory_search` itself stays `pass` — total>=1 with HNSW backend is a healthy search). Same posture as #1111: distinguish stack-broken from stack-working-but-state-not-yet-ready. Two new unit tests mirror the existing `buildEmptyHnswTools` describe block with a `buildStaleNeighborTools` helper.

## Consumer impact

- **Surface**: `src/cli/commands/doctor.ts`, `doctor-render.ts`, `doctor-checks-memory-access.ts`, `src/cli/memory/bridge-core.ts` — all shipped via `dist/` and consumed by every `npx moflo doctor`/`healer` and every bridge memory op in consumer projects.
- **Pre-fix consumer state**: every `/healer --fix` call silently dropped the action; concurrent bridge ops occasionally produced stderr noise + fell through to the slower direct-write path; repeat-in-session healer runs occasionally false-positive-failed memory access.
- **Post-fix consumer state**: actions actually run; JSON document now includes `fixesApplied[]`, `claudeCodeInstall`, `zombieScan` (additive); concurrent bridge ops self-heal via one bounded retry; stale-neighbor races demote to warn with a clear reason. Requires republish + reinstall + Claude Code restart for runtime effect.
- **Migration**: none — additive JSON change, in-process call sites already updated, bridge retry is internal, doctor-check change loosens an existing fail path into warn.

## Test plan

- [x] `src/cli/__tests__/commands/doctor-json-fix.test.ts` — 9 tests pinning the new orchestration contract (#1122)
- [x] `src/cli/__tests__/memory/bridge-stale-handle-retry.test.ts` — 4 tests covering retry-on-stale-handle, message-only detection, bounded-to-one-retry, no-retry-on-unrelated-errors (#1123)
- [x] `src/cli/__tests__/doctor-checks-memory-access.test.ts` — 2 new tests pinning the #1120 stale-neighbor fallback (10 total in the file)
- [x] All 55 existing doctor command tests still pass
- [x] All 89 memory tests still pass (no regression in bridge coherence / mtime / store-routing tests)
- [x] Type-check (tsc --noEmit) clean
- [x] `node bin/cli.js healer --json --fix 2>/tmp/err.txt` — confirms 0 stderr lines on green run
- [x] /flo-simplify run on diff: NORMAL tier 3-agent review surfaced + addressed (O(n*m) → Map, zombie-scan-loss in post-fix results[] fixed); #1123 reviewer caught missing `await` on recursive call + suggested seed-failure guard, both applied; #1120 self-review pass (validation tier — reuses existing helper, mirrors existing pattern)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)