### PR TITLE
fix(launcher): recycle daemon when behind installed version on session start

### DIFF
--- a/.claude/scripts/lib/daemon-recycler.mjs
+++ b/.claude/scripts/lib/daemon-recycler.mjs
@@ -26,9 +26,8 @@
  */
 
 import { spawn, execFileSync } from 'node:child_process';
-import { existsSync, unlinkSync, writeFileSync, readFileSync } from 'node:fs';
+import { existsSync, openSync, closeSync, unlinkSync, writeFileSync, readFileSync } from 'node:fs';
 import { resolve, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 const [, , projectRootArg, pidArg, installedVersion] = process.argv;
 
@@ -42,14 +41,31 @@ const projectRoot = resolve(projectRootArg);
 const pid = Number.parseInt(pidArg, 10);
 const lockFile = join(projectRoot, '.moflo', 'daemon.lock');
 
+// EPERM means "exists but owned by another user" — treat as alive (matches
+// launcher's isDaemonPidAlive contract). ESRCH means "no such process" — dead.
+//
+// Linux zombie handling: on Linux, `kill(pid, 0)` succeeds for zombie processes
+// (exited but not yet reaped). A zombie can't write to the DB or hold locks, so
+// treating it as alive exhausts the 5s kill budget polling a corpse. Read
+// /proc/<pid>/stat and treat 'Z' as dead — same logic the launcher uses (#1083).
 function isAlive(p) {
   if (!p || p <= 0) return false;
   try {
     process.kill(p, 0);
-    return true;
   } catch (err) {
     return err && err.code === 'EPERM';
   }
+  if (process.platform === 'linux') {
+    try {
+      const stat = readFileSync(`/proc/${p}/stat`, 'utf-8');
+      const lastParen = stat.lastIndexOf(')');
+      if (lastParen !== -1 && stat.charAt(lastParen + 2) === 'Z') return false;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return false;
+      // /proc unavailable — fall through with the kill(0) verdict.
+    }
+  }
+  return true;
 }
 
 function sleepSyncMs(ms) {
@@ -76,7 +92,40 @@ function writeOutcome(status, detail) {
   } catch { /* best-effort — doctor reads this file optionally */ }
 }
 
+// ── 0. Single-recycler advisory lock ────────────────────────────────────────
+// Two session starts within the same second can both fire §2a, both detect
+// behind, both spawn this recycler against the same PID. Without the lock,
+// both call `daemon start` and race for daemon-lock acquisition — only one
+// daemon wins but the other wastes a spawn cycle. Use O_EXCL on a sentinel
+// file so the second invocation exits early.
+const recycleLock = join(projectRoot, '.moflo', 'recycle.lock');
+let lockFd;
+let lockAcquired = false;
+try {
+  lockFd = openSync(recycleLock, 'wx'); // O_CREAT | O_EXCL
+  lockAcquired = true;
+} catch (err) {
+  if (err && err.code === 'EEXIST') {
+    // Another recycler is mid-flight. Bail silently — it will handle the kill.
+    writeOutcome('already-running', `another recycler holds ${recycleLock}`);
+    process.exit(0);
+  }
+  // Unexpected — proceed without the lock rather than blocking the recycle.
+}
+
+// Release the advisory lock on every exit path, including process.exit() and
+// crashes. Idempotent: if the lock wasn't acquired this becomes a no-op.
+process.on('exit', () => {
+  if (!lockAcquired) return;
+  try { closeSync(lockFd); } catch { /* already closed */ }
+  try { unlinkSync(recycleLock); } catch { /* already gone */ }
+});
+
 // ── 1. Force-kill ───────────────────────────────────────────────────────────
+// EPERM on the kill attempt means the daemon is owned by another user. Can't
+// kill it. Don't proceed to unlink + restart — that'd resurrect a fresh daemon
+// alongside the foreign-owned one, double-writing the DB.
+let killBlockedByEperm = false;
 if (Number.isFinite(pid) && pid > 0 && isAlive(pid)) {
   try {
     if (process.platform === 'win32') {
@@ -84,7 +133,17 @@ if (Number.isFinite(pid) && pid > 0 && isAlive(pid)) {
     } else {
       process.kill(pid, 'SIGKILL');
     }
-  } catch { /* dead or unreachable — liveness poll below confirms */ }
+  } catch (err) {
+    if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+      killBlockedByEperm = true;
+    }
+    // Other errors (ESRCH = already dead) — fall through; liveness poll confirms.
+  }
+}
+
+if (killBlockedByEperm) {
+  writeOutcome('kill-permission-denied', `PID ${pid} owned by another user — leaving daemon alive, not spawning replacement`);
+  process.exit(1);
 }
 
 // ── 2. Wait for death, then unlink the lockfile ─────────────────────────────

--- a/.claude/scripts/lib/daemon-recycler.mjs
+++ b/.claude/scripts/lib/daemon-recycler.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Detached recycler for §2a of session-start-launcher.mjs.
+ *
+ * The launcher used to inline the kill-and-restart synchronously, which kept
+ * up to 500ms of liveness-polling in the foreground — fine on Linux, but on
+ * Windows under the SessionStart hook's 3000ms timeout it eroded the budget
+ * that's supposed to be spent on real work. Per the launcher's contract
+ * ("spawns background tasks via spawn(detached + unref) and exits
+ * immediately"), the daemon recycle belongs in a detached worker.
+ *
+ * Invocation (from §2a, via fireAndForget):
+ *   node bin/lib/daemon-recycler.mjs <projectRoot> <pid> <installedVersion>
+ *
+ * Steps:
+ *   1. Force-kill <pid> (Windows: taskkill /F /T, Unix: SIGKILL). Skip
+ *      graceful — by this point the launcher has already decided the daemon
+ *      is running stale code and its shutdown handlers are stale too.
+ *   2. Poll liveness up to 5s. Unlink the lockfile only once the PID is gone,
+ *      so a surviving daemon can't re-attach to the unlinked path.
+ *   3. Spawn `node node_modules/moflo/bin/cli.js daemon start --quiet`
+ *      detached + unref so this recycler can exit immediately.
+ *
+ * Output is intentionally silent — there's no parent to read it. Failures are
+ * surfaced via `.moflo/daemon-recycle.last.json` for `flo doctor` to read.
+ */
+
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync, unlinkSync, writeFileSync, readFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const [, , projectRootArg, pidArg, installedVersion] = process.argv;
+
+if (!projectRootArg || !pidArg) {
+  // No way to surface this — the launcher fire-and-forgets us, no parent
+  // captures stderr. Bail silently.
+  process.exit(2);
+}
+
+const projectRoot = resolve(projectRootArg);
+const pid = Number.parseInt(pidArg, 10);
+const lockFile = join(projectRoot, '.moflo', 'daemon.lock');
+
+function isAlive(p) {
+  if (!p || p <= 0) return false;
+  try {
+    process.kill(p, 0);
+    return true;
+  } catch (err) {
+    return err && err.code === 'EPERM';
+  }
+}
+
+function sleepSyncMs(ms) {
+  const buf = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(buf, 0, 0, ms);
+}
+
+function writeOutcome(status, detail) {
+  try {
+    writeFileSync(
+      join(projectRoot, '.moflo', 'daemon-recycle.last.json'),
+      JSON.stringify(
+        {
+          status,
+          detail,
+          pid,
+          installedVersion: installedVersion ?? null,
+          completedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch { /* best-effort — doctor reads this file optionally */ }
+}
+
+// ── 1. Force-kill ───────────────────────────────────────────────────────────
+if (Number.isFinite(pid) && pid > 0 && isAlive(pid)) {
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], { windowsHide: true, timeout: 5000 });
+    } else {
+      process.kill(pid, 'SIGKILL');
+    }
+  } catch { /* dead or unreachable — liveness poll below confirms */ }
+}
+
+// ── 2. Wait for death, then unlink the lockfile ─────────────────────────────
+const deadline = Date.now() + 5000;
+let killed = !isAlive(pid);
+while (!killed && Date.now() < deadline) {
+  sleepSyncMs(100);
+  killed = !isAlive(pid);
+}
+
+if (!killed) {
+  writeOutcome('kill-failed', `PID ${pid} survived 5s force-kill window`);
+  process.exit(1);
+}
+
+// Only unlink once we know nothing's holding the lock file's old identity.
+// A surviving daemon would re-write a lockfile with its stale PID + version
+// and defeat the whole purpose of the recycle.
+try {
+  if (existsSync(lockFile)) {
+    // Defensive: if the lockfile has been re-written under us (another
+    // recycler raced), only unlink if the PID still matches what we killed.
+    try {
+      const current = JSON.parse(readFileSync(lockFile, 'utf-8'));
+      if (typeof current?.pid === 'number' && current.pid !== pid) {
+        writeOutcome('lock-changed', `another daemon (PID ${current.pid}) wrote the lock; leaving it alone`);
+        process.exit(0);
+      }
+    } catch { /* unreadable / malformed — fall through and unlink */ }
+    unlinkSync(lockFile);
+  }
+} catch { /* non-fatal */ }
+
+// ── 3. Spawn fresh daemon, detached + unref ─────────────────────────────────
+const cliPath = join(projectRoot, 'node_modules', 'moflo', 'bin', 'cli.js');
+if (existsSync(cliPath)) {
+  try {
+    const child = spawn('node', [cliPath, 'daemon', 'start', '--quiet'], {
+      cwd: projectRoot,
+      stdio: 'ignore',
+      detached: true,
+      shell: false,
+      windowsHide: true,
+    });
+    child.unref();
+    writeOutcome('ok', 'fresh daemon spawn requested');
+  } catch (err) {
+    writeOutcome('spawn-failed', err && err.message ? err.message : String(err));
+    process.exit(1);
+  }
+} else {
+  writeOutcome('cli-missing', `node_modules/moflo/bin/cli.js not present at ${cliPath}`);
+  process.exit(1);
+}
+
+// Recycler's job is done. Exit fast.
+process.exit(0);

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -578,16 +578,24 @@ try {
 try {
   const mofloPkgPath = resolve(projectRoot, 'node_modules/moflo/package.json');
   const lockFile = resolve(projectRoot, '.moflo', 'daemon.lock');
-  if (existsSync(mofloPkgPath) && existsSync(lockFile)) {
-    const installedVersion = JSON.parse(readFileSync(mofloPkgPath, 'utf-8')).version;
-    let daemonVersion;
-    let daemonPid;
-    try {
-      const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
-      if (typeof lock?.version === 'string') daemonVersion = lock.version;
-      if (typeof lock?.pid === 'number' && lock.pid > 0) daemonPid = lock.pid;
-    } catch { /* corrupt lock — fall through; unlink + restart still safe */ }
+  // Single readFileSync each (try/catch instead of existsSync + readFileSync)
+  // — halves the syscalls in the hot path and closes the TOCTOU window where
+  // the file existed for existsSync but was unlinked before readFileSync.
+  let installedVersion;
+  let daemonVersion;
+  let daemonPid;
+  try {
+    installedVersion = JSON.parse(readFileSync(mofloPkgPath, 'utf-8')).version;
+  } catch { /* node_modules/moflo absent — fresh consumer or fatal, nothing §2a can do */ }
+  let lockReadOk = false;
+  try {
+    const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
+    lockReadOk = true;
+    if (typeof lock?.version === 'string') daemonVersion = lock.version;
+    if (typeof lock?.pid === 'number' && lock.pid > 0) daemonPid = lock.pid;
+  } catch { /* no lock or corrupt — no daemon to recycle, skip the block below */ }
 
+  if (installedVersion && lockReadOk) {
     const isBehind = !daemonVersion || compareVersionsSemver(daemonVersion, installedVersion) < 0;
     if (isBehind) {
       const observed = daemonVersion ?? '<pre-1054 / unknown>';

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -432,40 +432,48 @@ function stopDaemon(lockFile) {
 
   let killed = false;
   if (stalePid !== null && isDaemonPidAlive(stalePid)) {
-    // Graceful signal — platform-aware. On Windows, `process.kill(pid, 'SIGTERM')`
-    // silently force-kills (skipping the daemon's shutdown handlers that flush
-    // sql.js + release lock cleanly), so use bare `taskkill` (no /F) for a
-    // close-event signal.
-    try {
-      if (process.platform === 'win32') {
-        execFileSync('taskkill', ['/PID', String(stalePid)], { windowsHide: true, timeout: 5000 });
-      } else {
-        process.kill(stalePid, 'SIGTERM');
-      }
-    } catch { /* signal/spawn failed — fall through to liveness poll + force */ }
-
-    // Poll for death up to 3s. The daemon's shutdown handler does a final
-    // sql.js dump + lock release, which under load can take ~1s.
-    const gracefulDeadline = Date.now() + 3000;
-    while (Date.now() < gracefulDeadline) {
-      if (!isDaemonPidAlive(stalePid)) { killed = true; break; }
-      sleepSyncMs(100);
-    }
-
-    // Force-kill if still alive.
-    if (!killed) {
+    // Platform-split shutdown. On Linux/macOS, SIGTERM lets the daemon's
+    // shutdown handler run a final sql.js dump + lock release before we
+    // escalate.
+    //
+    // On Windows there is no SIGTERM equivalent for our headless detached
+    // Node daemon — `taskkill /PID` (no /F) sends a window-close message
+    // that a non-GUI process can't receive and always fails with the visible
+    // error 'process can only be terminated forcefully'. The prior
+    // implementation invoked it anyway, swallowed the error, then polled
+    // alive for 3s before escalating — exactly the time-waste that pushed
+    // §3's stopDaemon past the 3000ms SessionStart hook timeout. Go
+    // straight to /F /T (tree-kill, in case a worker child outlived its
+    // parent) on Win.
+    if (process.platform === 'win32') {
       try {
-        if (process.platform === 'win32') {
-          execFileSync('taskkill', ['/F', '/T', '/PID', String(stalePid)], { windowsHide: true, timeout: 5000 });
-        } else {
-          process.kill(stalePid, 'SIGKILL');
-        }
-      } catch { /* dead or unreachable */ }
-      // Short grace period for OS reap.
+        execFileSync('taskkill', ['/F', '/T', '/PID', String(stalePid)], { windowsHide: true, timeout: 5000 });
+      } catch { /* dead or unreachable — liveness poll below confirms */ }
+      // Short grace period for OS reap (typically ~ms).
       const forceDeadline = Date.now() + 1000;
       while (Date.now() < forceDeadline) {
         if (!isDaemonPidAlive(stalePid)) { killed = true; break; }
         sleepSyncMs(100);
+      }
+    } else {
+      try { process.kill(stalePid, 'SIGTERM'); } catch { /* signal failed — escalate below */ }
+
+      // Poll for death up to 3s. The daemon's shutdown handler does a final
+      // sql.js dump + lock release, which under load can take ~1s.
+      const gracefulDeadline = Date.now() + 3000;
+      while (Date.now() < gracefulDeadline) {
+        if (!isDaemonPidAlive(stalePid)) { killed = true; break; }
+        sleepSyncMs(100);
+      }
+
+      // Force-kill if still alive.
+      if (!killed) {
+        try { process.kill(stalePid, 'SIGKILL'); } catch { /* dead or unreachable */ }
+        const forceDeadline = Date.now() + 1000;
+        while (Date.now() < forceDeadline) {
+          if (!isDaemonPidAlive(stalePid)) { killed = true; break; }
+          sleepSyncMs(100);
+        }
       }
     }
 
@@ -499,6 +507,42 @@ function recycleDaemon(lockFile, label) {
   return true;
 }
 
+// Numeric semver compare. Returns -1 / 0 / +1 for a vs b. Treats missing
+// segments as 0 so '4.10' < '4.10.4'. Strips pre-release tags ('1.2.3-beta'
+// compares as '1.2.3') — close enough for "is the daemon's version behind
+// the installed package's version", which is all §2a needs.
+function compareVersionsSemver(a, b) {
+  const norm = (v) => String(v || '').split('-')[0].split('.').map((s) => {
+    const n = parseInt(s, 10);
+    return Number.isFinite(n) ? n : 0;
+  });
+  const aa = norm(a);
+  const bb = norm(b);
+  const len = Math.max(aa.length, bb.length);
+  for (let i = 0; i < len; i++) {
+    const av = aa[i] ?? 0;
+    const bv = bb[i] ?? 0;
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+  }
+  return 0;
+}
+
+// Resolve `bin/lib/daemon-recycler.mjs` across the three places it can live:
+//   1. node_modules/moflo/bin/lib/  (consumer install, always present)
+//   2. .claude/scripts/lib/         (synced copy in consumer/dogfood projects)
+//   3. bin/lib/                     (dogfood source tree)
+// Returns null when not found — §2a falls back to inline force-kill in that
+// case, which is the pre-recycler behavior.
+function resolveDaemonRecyclerPath() {
+  const candidates = [
+    resolve(projectRoot, 'node_modules/moflo/bin/lib/daemon-recycler.mjs'),
+    resolve(projectRoot, '.claude/scripts/lib/daemon-recycler.mjs'),
+    resolve(projectRoot, 'bin/lib/daemon-recycler.mjs'),
+  ];
+  return candidates.find((p) => existsSync(p)) || null;
+}
+
 // ── 2. Reset workflow state for new session ──────────────────────────────────
 const stateDir = resolve(projectRoot, '.claude');
 const stateFile = resolve(stateDir, 'workflow-state.json');
@@ -512,6 +556,76 @@ try {
   }, null, 2));
 } catch {
   // Non-fatal - workflow gate will use defaults
+}
+
+// ── 2a. Recycle daemon when behind installed version (#1054 follow-up) ──────
+// Promoted from §3a-pre to run BEFORE §3's file-sync work. The launcher has
+// a 3000ms SessionStart hook timeout (src/cli/services/hook-block-hash.ts);
+// §0c (DB repair) + §3 (file-sync, manifest, cherry-pick) + stopDaemon's
+// up-to-4s graceful poll routinely exceeds it on upgrade sessions, killing
+// the launcher mid-§3. Result: §3a-pre never ran on the very sessions that
+// needed it, leaving a stale-version daemon alive after `npm install moflo`
+// + Claude restart — `📊 ?` in the statusline (this bug's tell).
+//
+// Semver-BEHIND only — a downgrade-test daemon ahead of installed is left
+// alone. Pre-#1054 daemons (no `version` field in the lock) are treated as
+// behind because by construction they predate version publishing.
+//
+// Force-kill skips the graceful poll: a stale-code daemon's flush handlers
+// are themselves stale, and losing one in-flight flush beats running past
+// the hook timeout. fireAndForget the fresh `daemon start` so spawn returns
+// immediately and the launcher can move on to §3.
+try {
+  const mofloPkgPath = resolve(projectRoot, 'node_modules/moflo/package.json');
+  const lockFile = resolve(projectRoot, '.moflo', 'daemon.lock');
+  if (existsSync(mofloPkgPath) && existsSync(lockFile)) {
+    const installedVersion = JSON.parse(readFileSync(mofloPkgPath, 'utf-8')).version;
+    let daemonVersion;
+    let daemonPid;
+    try {
+      const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
+      if (typeof lock?.version === 'string') daemonVersion = lock.version;
+      if (typeof lock?.pid === 'number' && lock.pid > 0) daemonPid = lock.pid;
+    } catch { /* corrupt lock — fall through; unlink + restart still safe */ }
+
+    const isBehind = !daemonVersion || compareVersionsSemver(daemonVersion, installedVersion) < 0;
+    if (isBehind) {
+      const observed = daemonVersion ?? '<pre-1054 / unknown>';
+      const recyclerPath = resolveDaemonRecyclerPath();
+      if (recyclerPath && daemonPid && daemonPid > 0) {
+        // Fire-and-forget the detached recycler. Per the launcher's contract
+        // ("spawns background tasks ... and exits immediately"), the
+        // kill+wait+restart sequence runs in a separate process so §2a's
+        // foreground cost is ~ms instead of up-to-5s. The recycler writes
+        // .moflo/daemon-recycle.last.json on completion for doctor to read.
+        fireAndForget(
+          'node',
+          [recyclerPath, projectRoot, String(daemonPid), installedVersion],
+          'daemon-behind-recycle',
+        );
+        emitMutation(
+          'recycled stale daemon',
+          `behind: daemon v${observed} → installed v${installedVersion}`,
+        );
+      } else if (!recyclerPath) {
+        // Recycler script missing — happens during the transition release
+        // where the launcher upgraded but bin/lib/daemon-recycler.mjs hasn't
+        // synced yet. Surface so /healer can flag; §3 below will sync the
+        // recycler on this session and §2a covers it on the next.
+        emitWarning(
+          `daemon-behind recycle: bin/lib/daemon-recycler.mjs not resolvable — ` +
+          `daemon v${observed} stays alive this session, will recycle on the next`,
+        );
+      } else {
+        // No PID — lockfile is corrupt or malformed. Unlink it so a fresh
+        // daemon can start cleanly on the next worker request.
+        try { unlinkSync(lockFile); } catch { /* non-fatal */ }
+        emitMutation('cleared malformed daemon lock', `version field: ${observed}`);
+      }
+    }
+  }
+} catch (err) {
+  emitWarning(`daemon-behind check failed: ${errMessage(err)}`);
 }
 
 // ── 3. Auto-sync scripts and helpers on version change ───────────────────────
@@ -1009,53 +1123,12 @@ try {
   emitWarning(`upgrade section failed (${errMessage(err)})`);
 }
 
-// ── 3a-pre. Recycle daemons started before the current moflo install ────────
-// The version-bump block above only fires when `installedVersion !== cachedVersion`.
-// That misses the common case where a user upgraded moflo, ran ONE session
-// (which bumped the stamp + recycled the daemon), then on a subsequent session
-// the version stamp matches but the daemon they started long-ago is still
-// holding stale module cache from a pre-collapse moflo image. The
-// `[neural-tools] @moflo/embeddings not resolvable` spam (#639) is the
-// observable symptom of exactly this: a daemon running pre-#592 code that no
-// longer exists in source, calling a require helper that prints the warning
-// every time `neural_predict` / `neural_patterns` fires.
-//
-// Fix (epic #1054): compare the daemon-lock's reported moflo `version` against
-// the installed `node_modules/moflo/package.json` version. If they differ —
-// or the lock predates #1054 and has no `version` field at all — recycle the
-// daemon. This is exact (not a heuristic margin like the prior mtime-based
-// check) and named explicitly so the doctor's Daemon Version Skew check
-// (#1059) can share the diagnosis.
-//
-// Pre-#1054 daemons have no `version` in their lock payload — treated as a
-// mismatch by definition because by construction they were launched before
-// version publishing existed.
-try {
-  const mofloPkgPathForRecycle = resolve(projectRoot, 'node_modules/moflo/package.json');
-  const lockFile = resolve(projectRoot, '.moflo', 'daemon.lock');
-  // Cheap stat first — if either file is gone, no skew check is possible.
-  if (existsSync(mofloPkgPathForRecycle) && existsSync(lockFile)) {
-    const installedVersion = JSON.parse(readFileSync(mofloPkgPathForRecycle, 'utf-8')).version;
-    let daemonVersion;
-    try {
-      const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
-      if (typeof lock?.version === 'string') daemonVersion = lock.version;
-    } catch { /* corrupt lock — recycleDaemon will unlink it */ }
-    if (daemonVersion !== installedVersion) {
-      if (recycleDaemon(lockFile, 'daemon-version-skew')) {
-        const observed = daemonVersion ?? '<pre-1054 / unknown>';
-        emitMutation(
-          'recycled stale daemon',
-          `version skew: installed ${installedVersion}, daemon ${observed}`,
-        );
-      }
-    }
-  }
-} catch (err) {
-  // Non-fatal; surface via emitWarning per feedback_no_layered_workarounds —
-  // no silent catch on the upgrade path (#854).
-  emitWarning(`daemon version-skew check failed: ${errMessage(err)}`);
-}
+// ── 3a-pre. (removed) Daemon-version-skew recycle moved to §2a. ─────────────
+// The previous version of this block ran AFTER §3's heavy file-sync work,
+// which routinely exceeded the 3000ms SessionStart hook timeout and was
+// killed before reaching this point. §2a now runs early and force-kills the
+// stale daemon before §3 can starve out. Don't restore §3a-pre — keep the
+// recycle in one place so the two paths can't drift.
 
 // ── 3a. Auto-migrate settings.json (npx flo → node helpers, PATH setup) ────
 // Existing users may have stale settings.json with `npx flo` hooks that break

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -206,7 +206,7 @@
           {
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/session-start-launcher.mjs\"",
-            "timeout": 3000
+            "timeout": 5000
           },
           {
             "type": "command",

--- a/bin/lib/daemon-recycler.mjs
+++ b/bin/lib/daemon-recycler.mjs
@@ -26,9 +26,8 @@
  */
 
 import { spawn, execFileSync } from 'node:child_process';
-import { existsSync, unlinkSync, writeFileSync, readFileSync } from 'node:fs';
+import { existsSync, openSync, closeSync, unlinkSync, writeFileSync, readFileSync } from 'node:fs';
 import { resolve, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 const [, , projectRootArg, pidArg, installedVersion] = process.argv;
 
@@ -42,14 +41,31 @@ const projectRoot = resolve(projectRootArg);
 const pid = Number.parseInt(pidArg, 10);
 const lockFile = join(projectRoot, '.moflo', 'daemon.lock');
 
+// EPERM means "exists but owned by another user" — treat as alive (matches
+// launcher's isDaemonPidAlive contract). ESRCH means "no such process" — dead.
+//
+// Linux zombie handling: on Linux, `kill(pid, 0)` succeeds for zombie processes
+// (exited but not yet reaped). A zombie can't write to the DB or hold locks, so
+// treating it as alive exhausts the 5s kill budget polling a corpse. Read
+// /proc/<pid>/stat and treat 'Z' as dead — same logic the launcher uses (#1083).
 function isAlive(p) {
   if (!p || p <= 0) return false;
   try {
     process.kill(p, 0);
-    return true;
   } catch (err) {
     return err && err.code === 'EPERM';
   }
+  if (process.platform === 'linux') {
+    try {
+      const stat = readFileSync(`/proc/${p}/stat`, 'utf-8');
+      const lastParen = stat.lastIndexOf(')');
+      if (lastParen !== -1 && stat.charAt(lastParen + 2) === 'Z') return false;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return false;
+      // /proc unavailable — fall through with the kill(0) verdict.
+    }
+  }
+  return true;
 }
 
 function sleepSyncMs(ms) {
@@ -76,7 +92,40 @@ function writeOutcome(status, detail) {
   } catch { /* best-effort — doctor reads this file optionally */ }
 }
 
+// ── 0. Single-recycler advisory lock ────────────────────────────────────────
+// Two session starts within the same second can both fire §2a, both detect
+// behind, both spawn this recycler against the same PID. Without the lock,
+// both call `daemon start` and race for daemon-lock acquisition — only one
+// daemon wins but the other wastes a spawn cycle. Use O_EXCL on a sentinel
+// file so the second invocation exits early.
+const recycleLock = join(projectRoot, '.moflo', 'recycle.lock');
+let lockFd;
+let lockAcquired = false;
+try {
+  lockFd = openSync(recycleLock, 'wx'); // O_CREAT | O_EXCL
+  lockAcquired = true;
+} catch (err) {
+  if (err && err.code === 'EEXIST') {
+    // Another recycler is mid-flight. Bail silently — it will handle the kill.
+    writeOutcome('already-running', `another recycler holds ${recycleLock}`);
+    process.exit(0);
+  }
+  // Unexpected — proceed without the lock rather than blocking the recycle.
+}
+
+// Release the advisory lock on every exit path, including process.exit() and
+// crashes. Idempotent: if the lock wasn't acquired this becomes a no-op.
+process.on('exit', () => {
+  if (!lockAcquired) return;
+  try { closeSync(lockFd); } catch { /* already closed */ }
+  try { unlinkSync(recycleLock); } catch { /* already gone */ }
+});
+
 // ── 1. Force-kill ───────────────────────────────────────────────────────────
+// EPERM on the kill attempt means the daemon is owned by another user. Can't
+// kill it. Don't proceed to unlink + restart — that'd resurrect a fresh daemon
+// alongside the foreign-owned one, double-writing the DB.
+let killBlockedByEperm = false;
 if (Number.isFinite(pid) && pid > 0 && isAlive(pid)) {
   try {
     if (process.platform === 'win32') {
@@ -84,7 +133,17 @@ if (Number.isFinite(pid) && pid > 0 && isAlive(pid)) {
     } else {
       process.kill(pid, 'SIGKILL');
     }
-  } catch { /* dead or unreachable — liveness poll below confirms */ }
+  } catch (err) {
+    if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+      killBlockedByEperm = true;
+    }
+    // Other errors (ESRCH = already dead) — fall through; liveness poll confirms.
+  }
+}
+
+if (killBlockedByEperm) {
+  writeOutcome('kill-permission-denied', `PID ${pid} owned by another user — leaving daemon alive, not spawning replacement`);
+  process.exit(1);
 }
 
 // ── 2. Wait for death, then unlink the lockfile ─────────────────────────────

--- a/bin/lib/daemon-recycler.mjs
+++ b/bin/lib/daemon-recycler.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Detached recycler for §2a of session-start-launcher.mjs.
+ *
+ * The launcher used to inline the kill-and-restart synchronously, which kept
+ * up to 500ms of liveness-polling in the foreground — fine on Linux, but on
+ * Windows under the SessionStart hook's 3000ms timeout it eroded the budget
+ * that's supposed to be spent on real work. Per the launcher's contract
+ * ("spawns background tasks via spawn(detached + unref) and exits
+ * immediately"), the daemon recycle belongs in a detached worker.
+ *
+ * Invocation (from §2a, via fireAndForget):
+ *   node bin/lib/daemon-recycler.mjs <projectRoot> <pid> <installedVersion>
+ *
+ * Steps:
+ *   1. Force-kill <pid> (Windows: taskkill /F /T, Unix: SIGKILL). Skip
+ *      graceful — by this point the launcher has already decided the daemon
+ *      is running stale code and its shutdown handlers are stale too.
+ *   2. Poll liveness up to 5s. Unlink the lockfile only once the PID is gone,
+ *      so a surviving daemon can't re-attach to the unlinked path.
+ *   3. Spawn `node node_modules/moflo/bin/cli.js daemon start --quiet`
+ *      detached + unref so this recycler can exit immediately.
+ *
+ * Output is intentionally silent — there's no parent to read it. Failures are
+ * surfaced via `.moflo/daemon-recycle.last.json` for `flo doctor` to read.
+ */
+
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync, unlinkSync, writeFileSync, readFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const [, , projectRootArg, pidArg, installedVersion] = process.argv;
+
+if (!projectRootArg || !pidArg) {
+  // No way to surface this — the launcher fire-and-forgets us, no parent
+  // captures stderr. Bail silently.
+  process.exit(2);
+}
+
+const projectRoot = resolve(projectRootArg);
+const pid = Number.parseInt(pidArg, 10);
+const lockFile = join(projectRoot, '.moflo', 'daemon.lock');
+
+function isAlive(p) {
+  if (!p || p <= 0) return false;
+  try {
+    process.kill(p, 0);
+    return true;
+  } catch (err) {
+    return err && err.code === 'EPERM';
+  }
+}
+
+function sleepSyncMs(ms) {
+  const buf = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(buf, 0, 0, ms);
+}
+
+function writeOutcome(status, detail) {
+  try {
+    writeFileSync(
+      join(projectRoot, '.moflo', 'daemon-recycle.last.json'),
+      JSON.stringify(
+        {
+          status,
+          detail,
+          pid,
+          installedVersion: installedVersion ?? null,
+          completedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch { /* best-effort — doctor reads this file optionally */ }
+}
+
+// ── 1. Force-kill ───────────────────────────────────────────────────────────
+if (Number.isFinite(pid) && pid > 0 && isAlive(pid)) {
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], { windowsHide: true, timeout: 5000 });
+    } else {
+      process.kill(pid, 'SIGKILL');
+    }
+  } catch { /* dead or unreachable — liveness poll below confirms */ }
+}
+
+// ── 2. Wait for death, then unlink the lockfile ─────────────────────────────
+const deadline = Date.now() + 5000;
+let killed = !isAlive(pid);
+while (!killed && Date.now() < deadline) {
+  sleepSyncMs(100);
+  killed = !isAlive(pid);
+}
+
+if (!killed) {
+  writeOutcome('kill-failed', `PID ${pid} survived 5s force-kill window`);
+  process.exit(1);
+}
+
+// Only unlink once we know nothing's holding the lock file's old identity.
+// A surviving daemon would re-write a lockfile with its stale PID + version
+// and defeat the whole purpose of the recycle.
+try {
+  if (existsSync(lockFile)) {
+    // Defensive: if the lockfile has been re-written under us (another
+    // recycler raced), only unlink if the PID still matches what we killed.
+    try {
+      const current = JSON.parse(readFileSync(lockFile, 'utf-8'));
+      if (typeof current?.pid === 'number' && current.pid !== pid) {
+        writeOutcome('lock-changed', `another daemon (PID ${current.pid}) wrote the lock; leaving it alone`);
+        process.exit(0);
+      }
+    } catch { /* unreadable / malformed — fall through and unlink */ }
+    unlinkSync(lockFile);
+  }
+} catch { /* non-fatal */ }
+
+// ── 3. Spawn fresh daemon, detached + unref ─────────────────────────────────
+const cliPath = join(projectRoot, 'node_modules', 'moflo', 'bin', 'cli.js');
+if (existsSync(cliPath)) {
+  try {
+    const child = spawn('node', [cliPath, 'daemon', 'start', '--quiet'], {
+      cwd: projectRoot,
+      stdio: 'ignore',
+      detached: true,
+      shell: false,
+      windowsHide: true,
+    });
+    child.unref();
+    writeOutcome('ok', 'fresh daemon spawn requested');
+  } catch (err) {
+    writeOutcome('spawn-failed', err && err.message ? err.message : String(err));
+    process.exit(1);
+  }
+} else {
+  writeOutcome('cli-missing', `node_modules/moflo/bin/cli.js not present at ${cliPath}`);
+  process.exit(1);
+}
+
+// Recycler's job is done. Exit fast.
+process.exit(0);

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -578,16 +578,24 @@ try {
 try {
   const mofloPkgPath = resolve(projectRoot, 'node_modules/moflo/package.json');
   const lockFile = resolve(projectRoot, '.moflo', 'daemon.lock');
-  if (existsSync(mofloPkgPath) && existsSync(lockFile)) {
-    const installedVersion = JSON.parse(readFileSync(mofloPkgPath, 'utf-8')).version;
-    let daemonVersion;
-    let daemonPid;
-    try {
-      const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
-      if (typeof lock?.version === 'string') daemonVersion = lock.version;
-      if (typeof lock?.pid === 'number' && lock.pid > 0) daemonPid = lock.pid;
-    } catch { /* corrupt lock — fall through; unlink + restart still safe */ }
+  // Single readFileSync each (try/catch instead of existsSync + readFileSync)
+  // — halves the syscalls in the hot path and closes the TOCTOU window where
+  // the file existed for existsSync but was unlinked before readFileSync.
+  let installedVersion;
+  let daemonVersion;
+  let daemonPid;
+  try {
+    installedVersion = JSON.parse(readFileSync(mofloPkgPath, 'utf-8')).version;
+  } catch { /* node_modules/moflo absent — fresh consumer or fatal, nothing §2a can do */ }
+  let lockReadOk = false;
+  try {
+    const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
+    lockReadOk = true;
+    if (typeof lock?.version === 'string') daemonVersion = lock.version;
+    if (typeof lock?.pid === 'number' && lock.pid > 0) daemonPid = lock.pid;
+  } catch { /* no lock or corrupt — no daemon to recycle, skip the block below */ }
 
+  if (installedVersion && lockReadOk) {
     const isBehind = !daemonVersion || compareVersionsSemver(daemonVersion, installedVersion) < 0;
     if (isBehind) {
       const observed = daemonVersion ?? '<pre-1054 / unknown>';

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -432,40 +432,48 @@ function stopDaemon(lockFile) {
 
   let killed = false;
   if (stalePid !== null && isDaemonPidAlive(stalePid)) {
-    // Graceful signal — platform-aware. On Windows, `process.kill(pid, 'SIGTERM')`
-    // silently force-kills (skipping the daemon's shutdown handlers that flush
-    // sql.js + release lock cleanly), so use bare `taskkill` (no /F) for a
-    // close-event signal.
-    try {
-      if (process.platform === 'win32') {
-        execFileSync('taskkill', ['/PID', String(stalePid)], { windowsHide: true, timeout: 5000 });
-      } else {
-        process.kill(stalePid, 'SIGTERM');
-      }
-    } catch { /* signal/spawn failed — fall through to liveness poll + force */ }
-
-    // Poll for death up to 3s. The daemon's shutdown handler does a final
-    // sql.js dump + lock release, which under load can take ~1s.
-    const gracefulDeadline = Date.now() + 3000;
-    while (Date.now() < gracefulDeadline) {
-      if (!isDaemonPidAlive(stalePid)) { killed = true; break; }
-      sleepSyncMs(100);
-    }
-
-    // Force-kill if still alive.
-    if (!killed) {
+    // Platform-split shutdown. On Linux/macOS, SIGTERM lets the daemon's
+    // shutdown handler run a final sql.js dump + lock release before we
+    // escalate.
+    //
+    // On Windows there is no SIGTERM equivalent for our headless detached
+    // Node daemon — `taskkill /PID` (no /F) sends a window-close message
+    // that a non-GUI process can't receive and always fails with the visible
+    // error 'process can only be terminated forcefully'. The prior
+    // implementation invoked it anyway, swallowed the error, then polled
+    // alive for 3s before escalating — exactly the time-waste that pushed
+    // §3's stopDaemon past the 3000ms SessionStart hook timeout. Go
+    // straight to /F /T (tree-kill, in case a worker child outlived its
+    // parent) on Win.
+    if (process.platform === 'win32') {
       try {
-        if (process.platform === 'win32') {
-          execFileSync('taskkill', ['/F', '/T', '/PID', String(stalePid)], { windowsHide: true, timeout: 5000 });
-        } else {
-          process.kill(stalePid, 'SIGKILL');
-        }
-      } catch { /* dead or unreachable */ }
-      // Short grace period for OS reap.
+        execFileSync('taskkill', ['/F', '/T', '/PID', String(stalePid)], { windowsHide: true, timeout: 5000 });
+      } catch { /* dead or unreachable — liveness poll below confirms */ }
+      // Short grace period for OS reap (typically ~ms).
       const forceDeadline = Date.now() + 1000;
       while (Date.now() < forceDeadline) {
         if (!isDaemonPidAlive(stalePid)) { killed = true; break; }
         sleepSyncMs(100);
+      }
+    } else {
+      try { process.kill(stalePid, 'SIGTERM'); } catch { /* signal failed — escalate below */ }
+
+      // Poll for death up to 3s. The daemon's shutdown handler does a final
+      // sql.js dump + lock release, which under load can take ~1s.
+      const gracefulDeadline = Date.now() + 3000;
+      while (Date.now() < gracefulDeadline) {
+        if (!isDaemonPidAlive(stalePid)) { killed = true; break; }
+        sleepSyncMs(100);
+      }
+
+      // Force-kill if still alive.
+      if (!killed) {
+        try { process.kill(stalePid, 'SIGKILL'); } catch { /* dead or unreachable */ }
+        const forceDeadline = Date.now() + 1000;
+        while (Date.now() < forceDeadline) {
+          if (!isDaemonPidAlive(stalePid)) { killed = true; break; }
+          sleepSyncMs(100);
+        }
       }
     }
 
@@ -499,6 +507,42 @@ function recycleDaemon(lockFile, label) {
   return true;
 }
 
+// Numeric semver compare. Returns -1 / 0 / +1 for a vs b. Treats missing
+// segments as 0 so '4.10' < '4.10.4'. Strips pre-release tags ('1.2.3-beta'
+// compares as '1.2.3') — close enough for "is the daemon's version behind
+// the installed package's version", which is all §2a needs.
+function compareVersionsSemver(a, b) {
+  const norm = (v) => String(v || '').split('-')[0].split('.').map((s) => {
+    const n = parseInt(s, 10);
+    return Number.isFinite(n) ? n : 0;
+  });
+  const aa = norm(a);
+  const bb = norm(b);
+  const len = Math.max(aa.length, bb.length);
+  for (let i = 0; i < len; i++) {
+    const av = aa[i] ?? 0;
+    const bv = bb[i] ?? 0;
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+  }
+  return 0;
+}
+
+// Resolve `bin/lib/daemon-recycler.mjs` across the three places it can live:
+//   1. node_modules/moflo/bin/lib/  (consumer install, always present)
+//   2. .claude/scripts/lib/         (synced copy in consumer/dogfood projects)
+//   3. bin/lib/                     (dogfood source tree)
+// Returns null when not found — §2a falls back to inline force-kill in that
+// case, which is the pre-recycler behavior.
+function resolveDaemonRecyclerPath() {
+  const candidates = [
+    resolve(projectRoot, 'node_modules/moflo/bin/lib/daemon-recycler.mjs'),
+    resolve(projectRoot, '.claude/scripts/lib/daemon-recycler.mjs'),
+    resolve(projectRoot, 'bin/lib/daemon-recycler.mjs'),
+  ];
+  return candidates.find((p) => existsSync(p)) || null;
+}
+
 // ── 2. Reset workflow state for new session ──────────────────────────────────
 const stateDir = resolve(projectRoot, '.claude');
 const stateFile = resolve(stateDir, 'workflow-state.json');
@@ -512,6 +556,76 @@ try {
   }, null, 2));
 } catch {
   // Non-fatal - workflow gate will use defaults
+}
+
+// ── 2a. Recycle daemon when behind installed version (#1054 follow-up) ──────
+// Promoted from §3a-pre to run BEFORE §3's file-sync work. The launcher has
+// a 3000ms SessionStart hook timeout (src/cli/services/hook-block-hash.ts);
+// §0c (DB repair) + §3 (file-sync, manifest, cherry-pick) + stopDaemon's
+// up-to-4s graceful poll routinely exceeds it on upgrade sessions, killing
+// the launcher mid-§3. Result: §3a-pre never ran on the very sessions that
+// needed it, leaving a stale-version daemon alive after `npm install moflo`
+// + Claude restart — `📊 ?` in the statusline (this bug's tell).
+//
+// Semver-BEHIND only — a downgrade-test daemon ahead of installed is left
+// alone. Pre-#1054 daemons (no `version` field in the lock) are treated as
+// behind because by construction they predate version publishing.
+//
+// Force-kill skips the graceful poll: a stale-code daemon's flush handlers
+// are themselves stale, and losing one in-flight flush beats running past
+// the hook timeout. fireAndForget the fresh `daemon start` so spawn returns
+// immediately and the launcher can move on to §3.
+try {
+  const mofloPkgPath = resolve(projectRoot, 'node_modules/moflo/package.json');
+  const lockFile = resolve(projectRoot, '.moflo', 'daemon.lock');
+  if (existsSync(mofloPkgPath) && existsSync(lockFile)) {
+    const installedVersion = JSON.parse(readFileSync(mofloPkgPath, 'utf-8')).version;
+    let daemonVersion;
+    let daemonPid;
+    try {
+      const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
+      if (typeof lock?.version === 'string') daemonVersion = lock.version;
+      if (typeof lock?.pid === 'number' && lock.pid > 0) daemonPid = lock.pid;
+    } catch { /* corrupt lock — fall through; unlink + restart still safe */ }
+
+    const isBehind = !daemonVersion || compareVersionsSemver(daemonVersion, installedVersion) < 0;
+    if (isBehind) {
+      const observed = daemonVersion ?? '<pre-1054 / unknown>';
+      const recyclerPath = resolveDaemonRecyclerPath();
+      if (recyclerPath && daemonPid && daemonPid > 0) {
+        // Fire-and-forget the detached recycler. Per the launcher's contract
+        // ("spawns background tasks ... and exits immediately"), the
+        // kill+wait+restart sequence runs in a separate process so §2a's
+        // foreground cost is ~ms instead of up-to-5s. The recycler writes
+        // .moflo/daemon-recycle.last.json on completion for doctor to read.
+        fireAndForget(
+          'node',
+          [recyclerPath, projectRoot, String(daemonPid), installedVersion],
+          'daemon-behind-recycle',
+        );
+        emitMutation(
+          'recycled stale daemon',
+          `behind: daemon v${observed} → installed v${installedVersion}`,
+        );
+      } else if (!recyclerPath) {
+        // Recycler script missing — happens during the transition release
+        // where the launcher upgraded but bin/lib/daemon-recycler.mjs hasn't
+        // synced yet. Surface so /healer can flag; §3 below will sync the
+        // recycler on this session and §2a covers it on the next.
+        emitWarning(
+          `daemon-behind recycle: bin/lib/daemon-recycler.mjs not resolvable — ` +
+          `daemon v${observed} stays alive this session, will recycle on the next`,
+        );
+      } else {
+        // No PID — lockfile is corrupt or malformed. Unlink it so a fresh
+        // daemon can start cleanly on the next worker request.
+        try { unlinkSync(lockFile); } catch { /* non-fatal */ }
+        emitMutation('cleared malformed daemon lock', `version field: ${observed}`);
+      }
+    }
+  }
+} catch (err) {
+  emitWarning(`daemon-behind check failed: ${errMessage(err)}`);
 }
 
 // ── 3. Auto-sync scripts and helpers on version change ───────────────────────
@@ -1009,53 +1123,12 @@ try {
   emitWarning(`upgrade section failed (${errMessage(err)})`);
 }
 
-// ── 3a-pre. Recycle daemons started before the current moflo install ────────
-// The version-bump block above only fires when `installedVersion !== cachedVersion`.
-// That misses the common case where a user upgraded moflo, ran ONE session
-// (which bumped the stamp + recycled the daemon), then on a subsequent session
-// the version stamp matches but the daemon they started long-ago is still
-// holding stale module cache from a pre-collapse moflo image. The
-// `[neural-tools] @moflo/embeddings not resolvable` spam (#639) is the
-// observable symptom of exactly this: a daemon running pre-#592 code that no
-// longer exists in source, calling a require helper that prints the warning
-// every time `neural_predict` / `neural_patterns` fires.
-//
-// Fix (epic #1054): compare the daemon-lock's reported moflo `version` against
-// the installed `node_modules/moflo/package.json` version. If they differ —
-// or the lock predates #1054 and has no `version` field at all — recycle the
-// daemon. This is exact (not a heuristic margin like the prior mtime-based
-// check) and named explicitly so the doctor's Daemon Version Skew check
-// (#1059) can share the diagnosis.
-//
-// Pre-#1054 daemons have no `version` in their lock payload — treated as a
-// mismatch by definition because by construction they were launched before
-// version publishing existed.
-try {
-  const mofloPkgPathForRecycle = resolve(projectRoot, 'node_modules/moflo/package.json');
-  const lockFile = resolve(projectRoot, '.moflo', 'daemon.lock');
-  // Cheap stat first — if either file is gone, no skew check is possible.
-  if (existsSync(mofloPkgPathForRecycle) && existsSync(lockFile)) {
-    const installedVersion = JSON.parse(readFileSync(mofloPkgPathForRecycle, 'utf-8')).version;
-    let daemonVersion;
-    try {
-      const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
-      if (typeof lock?.version === 'string') daemonVersion = lock.version;
-    } catch { /* corrupt lock — recycleDaemon will unlink it */ }
-    if (daemonVersion !== installedVersion) {
-      if (recycleDaemon(lockFile, 'daemon-version-skew')) {
-        const observed = daemonVersion ?? '<pre-1054 / unknown>';
-        emitMutation(
-          'recycled stale daemon',
-          `version skew: installed ${installedVersion}, daemon ${observed}`,
-        );
-      }
-    }
-  }
-} catch (err) {
-  // Non-fatal; surface via emitWarning per feedback_no_layered_workarounds —
-  // no silent catch on the upgrade path (#854).
-  emitWarning(`daemon version-skew check failed: ${errMessage(err)}`);
-}
+// ── 3a-pre. (removed) Daemon-version-skew recycle moved to §2a. ─────────────
+// The previous version of this block ran AFTER §3's heavy file-sync work,
+// which routinely exceeded the 3000ms SessionStart hook timeout and was
+// killed before reaching this point. §2a now runs early and force-kills the
+// stale daemon before §3 can starve out. Don't restore §3a-pre — keep the
+// recycle in one place so the two paths can't drift.
 
 // ── 3a. Auto-migrate settings.json (npx flo → node helpers, PATH setup) ────
 // Existing users may have stale settings.json with `npx flo` hooks that break

--- a/src/cli/__tests__/cross-platform.test.ts
+++ b/src/cli/__tests__/cross-platform.test.ts
@@ -20,25 +20,32 @@ import { execFileSync } from 'child_process';
 
 describe('platform-aware process killing', () => {
   describe('daemon killBackgroundDaemon', () => {
-    it('should use taskkill on win32 instead of SIGKILL/SIGTERM', async () => {
-      // Read the compiled daemon source to verify platform branching
+    it('should use taskkill /F /T on win32 (no graceful step — Windows headless daemons cannot receive close events)', async () => {
+      // Read the daemon source to verify platform branching.
       const daemonSrc = readFileSync(
         join(__dirname, '..', 'commands', 'daemon.ts'),
         'utf-8'
       );
 
-      // Verify SIGKILL is wrapped in platform check
+      // Platform branch still in place.
       expect(daemonSrc).toContain("process.platform === 'win32'");
       expect(daemonSrc).toContain("execFileSync('taskkill'");
 
-      // Verify graceful kill uses taskkill without /F first
-      const gracefulMatch = daemonSrc.match(/taskkill.*?\/PID.*?holderPid/s);
-      expect(gracefulMatch).toBeTruthy();
+      // Force + tree kill — /F to bypass the "process can only be terminated
+      // forcefully" error a headless Node daemon emits for `taskkill /PID`,
+      // /T to clean up any worker children that outlived their parent.
+      expect(daemonSrc).toContain("'/F', '/T', '/PID'");
 
-      // Verify force kill uses /F flag
-      expect(daemonSrc).toContain("'/F', '/PID'");
+      // No graceful Windows step. The prior implementation invoked
+      // `taskkill /PID` (no /F) first, which always failed on a headless
+      // daemon with visible error output and wasted ~1s before escalating.
+      // Assert the dead-code pattern is gone: a taskkill arg array that
+      // contains '/PID' but NOT '/F' would be the graceful form.
+      const gracefulCallPattern = /execFileSync\('taskkill',\s*\[\s*'\/PID'/;
+      expect(daemonSrc).not.toMatch(gracefulCallPattern);
 
-      // Verify Unix path still uses SIGTERM and SIGKILL
+      // Unix path still uses SIGTERM → SIGKILL escalation (where graceful
+      // shutdown actually works).
       expect(daemonSrc).toContain("process.kill(holderPid, 'SIGTERM')");
       expect(daemonSrc).toContain("process.kill(holderPid, 'SIGKILL')");
     });

--- a/src/cli/__tests__/session-start-launcher-daemon-behind.test.ts
+++ b/src/cli/__tests__/session-start-launcher-daemon-behind.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Launcher §2a recycles a daemon whose lockfile reports a version BEHIND the
+ * installed package (#1054 follow-up).
+ *
+ * Regression for the failure mode where §3a-pre's recycle, positioned after
+ * §3's heavy file-sync work, got killed by the 3000ms SessionStart hook
+ * timeout before it could run. §2a now runs early — this test asserts the
+ * detection + lockfile cleanup happens on a minimal consumer fixture.
+ *
+ * The fixture uses a dead PID so the launcher's force-kill path returns
+ * immediately (via isDaemonPidAlive). That keeps the test cross-platform and
+ * exercises the version-compare + unlink path that swallowed the prior bug.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { findRepoRoot } from './_helpers/repo-walk.js';
+
+const REPO_ROOT = findRepoRoot(import.meta.url);
+const LAUNCHER = join(REPO_ROOT, 'bin', 'session-start-launcher.mjs');
+const RECYCLER_SRC = join(REPO_ROOT, 'bin', 'lib', 'daemon-recycler.mjs');
+
+// PID guaranteed to be dead on every platform. 99_999_999 exceeds Linux's
+// default pid_max (4_194_304) and Windows' practical PID range, so
+// `process.kill(pid, 0)` and `taskkill /PID 99999999` both fail with
+// "no such process" — the recycler's isAlive check short-circuits and the
+// kill is a no-op. Must be > 0 so §2a's `daemonPid > 0` guard passes (PID
+// 0 takes the "malformed lock" branch in the launcher).
+const DEAD_PID = 99_999_999;
+
+function makeConsumer(opts: { daemonVersion: string | null; installedVersion: string }): string {
+  const tmp = mkdtempSync(join(tmpdir(), 'moflo-launcher-behind-'));
+  mkdirSync(join(tmp, '.claude'), { recursive: true });
+  mkdirSync(join(tmp, '.moflo'), { recursive: true });
+  mkdirSync(join(tmp, 'node_modules', 'moflo', 'bin'), { recursive: true });
+
+  writeFileSync(
+    join(tmp, 'package.json'),
+    JSON.stringify({ name: 'behind-fixture', version: '0.0.0' }, null, 2),
+  );
+  writeFileSync(
+    join(tmp, 'node_modules', 'moflo', 'package.json'),
+    JSON.stringify({ name: 'moflo', version: opts.installedVersion }, null, 2),
+  );
+  // Pre-stamp moflo-version matching installed so §3's version-bump path
+  // does NOT fire — we want to isolate §2a's behavior, not test §3's
+  // stopDaemon side effect on the lockfile.
+  writeFileSync(join(tmp, '.moflo', 'moflo-version'), opts.installedVersion);
+  // Stub cli.js so fireAndForget('daemon start') has something to spawn.
+  // Body is a no-op; we never wait on it and it exits immediately.
+  writeFileSync(join(tmp, 'node_modules', 'moflo', 'bin', 'cli.js'), 'process.exit(0);\n');
+  // §2a resolves bin/lib/daemon-recycler.mjs from node_modules/moflo first.
+  // Copy the real recycler in so the fire-and-forget actually runs.
+  mkdirSync(join(tmp, 'node_modules', 'moflo', 'bin', 'lib'), { recursive: true });
+  copyFileSync(RECYCLER_SRC, join(tmp, 'node_modules', 'moflo', 'bin', 'lib', 'daemon-recycler.mjs'));
+
+  const lockPayload: Record<string, unknown> = { pid: DEAD_PID, startedAt: Date.now(), label: 'moflo-daemon' };
+  if (opts.daemonVersion !== null) lockPayload.version = opts.daemonVersion;
+  writeFileSync(join(tmp, '.moflo', 'daemon.lock'), JSON.stringify(lockPayload));
+
+  return tmp;
+}
+
+// Windows holds the temp dir open briefly while the launcher's detached
+// `cli.js` child exits. Retry cleanup so EPERM doesn't fail the test.
+function rmConsumerWithRetry(root: string) {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      rmSync(root, { recursive: true, force: true });
+      return;
+    } catch {
+      // Tiny synchronous backoff — busy-wait, no async machinery in afterEach.
+      const deadline = Date.now() + 100;
+      while (Date.now() < deadline) { /* spin */ }
+    }
+  }
+  // Last attempt — swallow; the OS will clean the temp dir on reboot if needed.
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+// §2a spawns the recycler detached, so the unlink + restart happens async
+// after the launcher exits. Poll for the completion marker the recycler
+// writes (`.moflo/daemon-recycle.last.json`) up to ~5s.
+async function waitForRecyclerCompletion(root: string, timeoutMs = 5000): Promise<{ status: string; detail?: string } | null> {
+  const markerPath = join(root, '.moflo', 'daemon-recycle.last.json');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(markerPath)) {
+      try {
+        return JSON.parse(readFileSync(markerPath, 'utf-8'));
+      } catch { /* still being written — retry */ }
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return null;
+}
+
+function runLauncher(cwd: string) {
+  return spawnSync('node', [LAUNCHER], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      CI: '1',
+      CLAUDE_PROJECT_DIR: cwd,
+    },
+    input: '',
+  });
+}
+
+describe('launcher §2a daemon-behind-installed recycle (#1054 follow-up)', () => {
+  let consumerRoot: string;
+
+  afterEach(() => {
+    if (consumerRoot) rmConsumerWithRetry(consumerRoot);
+  });
+
+  it('recycles when daemon version is behind installed (semver compare)', async () => {
+    consumerRoot = makeConsumer({ daemonVersion: '4.10.3', installedVersion: '4.10.4' });
+
+    const result = runLauncher(consumerRoot);
+    expect(result.status, `launcher stderr: ${result.stderr}`).toBe(0);
+
+    // §2a emits the mutation synchronously before spawning the recycler.
+    expect(result.stdout).toMatch(/recycled stale daemon/);
+    expect(result.stdout).toMatch(/behind: daemon v4\.10\.3 → installed v4\.10\.4/);
+
+    // Recycler is detached + async — poll for its completion marker.
+    const outcome = await waitForRecyclerCompletion(consumerRoot);
+    expect(outcome, 'recycler did not write daemon-recycle.last.json within 5s').not.toBeNull();
+    expect(outcome!.status).toBe('ok');
+
+    // Lockfile gone after recycler completes.
+    expect(existsSync(join(consumerRoot, '.moflo', 'daemon.lock'))).toBe(false);
+  });
+
+  it('treats pre-#1054 daemons (no version field) as behind', async () => {
+    consumerRoot = makeConsumer({ daemonVersion: null, installedVersion: '4.10.4' });
+
+    const result = runLauncher(consumerRoot);
+    expect(result.status, `launcher stderr: ${result.stderr}`).toBe(0);
+
+    expect(result.stdout).toMatch(/recycled stale daemon/);
+    expect(result.stdout).toMatch(/<pre-1054 \/ unknown>/);
+
+    const outcome = await waitForRecyclerCompletion(consumerRoot);
+    expect(outcome, 'recycler did not write daemon-recycle.last.json within 5s').not.toBeNull();
+    expect(outcome!.status).toBe('ok');
+    expect(existsSync(join(consumerRoot, '.moflo', 'daemon.lock'))).toBe(false);
+  });
+
+  it('leaves an ahead-of-installed daemon alone (downgrade-test scenario)', () => {
+    consumerRoot = makeConsumer({ daemonVersion: '4.11.0', installedVersion: '4.10.4' });
+
+    const result = runLauncher(consumerRoot);
+    expect(result.status, `launcher stderr: ${result.stderr}`).toBe(0);
+
+    // Lockfile preserved — §2a's semver-BEHIND check is intentionally one-way.
+    const lockPath = join(consumerRoot, '.moflo', 'daemon.lock');
+    expect(existsSync(lockPath)).toBe(true);
+    const lock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+    expect(lock.version).toBe('4.11.0');
+    expect(result.stdout).not.toMatch(/recycled stale daemon/);
+
+    // Recycler must NOT have run.
+    expect(existsSync(join(consumerRoot, '.moflo', 'daemon-recycle.last.json'))).toBe(false);
+  });
+
+  it('leaves a matching-version daemon alone', () => {
+    consumerRoot = makeConsumer({ daemonVersion: '4.10.4', installedVersion: '4.10.4' });
+
+    const result = runLauncher(consumerRoot);
+    expect(result.status, `launcher stderr: ${result.stderr}`).toBe(0);
+
+    expect(existsSync(join(consumerRoot, '.moflo', 'daemon.lock'))).toBe(true);
+    expect(result.stdout).not.toMatch(/recycled stale daemon/);
+    expect(existsSync(join(consumerRoot, '.moflo', 'daemon-recycle.last.json'))).toBe(false);
+  });
+});

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -526,31 +526,34 @@ export async function killBackgroundDaemon(projectRoot: string): Promise<boolean
   }
 
   try {
-    // Graceful kill — platform-aware
+    // Platform-split shutdown. On Linux/macOS we try SIGTERM first so the
+    // daemon's shutdown handlers (sql.js flush, lock release) can run; force-
+    // kill only if it doesn't exit within ~1s.
+    //
+    // On Windows there is no SIGTERM equivalent for our headless detached
+    // Node daemon — `taskkill /PID` (no /F) sends a window-close message
+    // that a non-GUI process can't receive, so it always fails with the
+    // visible error 'process can only be terminated forcefully'. The prior
+    // implementation invoked it anyway, ate the error in a bare catch, then
+    // slept 1s before escalating to /F. Skip the dead step: go straight to
+    // /F /T (tree-kill, in case a worker child outlived its parent) on Win.
     if (process.platform === 'win32') {
-      // SIGTERM silently force-kills on Windows; use taskkill for clean shutdown
       try {
-        execFileSync('taskkill', ['/PID', String(holderPid)], { windowsHide: true });
+        execFileSync('taskkill', ['/F', '/T', '/PID', String(holderPid)], { windowsHide: true });
       } catch {
-        // taskkill may fail if process already exiting
+        // Already exiting / unreachable — process.kill(pid, 0) below verifies.
       }
     } else {
       process.kill(holderPid, 'SIGTERM');
-    }
-
-    // Wait a moment then force kill if needed
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
-    try {
-      process.kill(holderPid, 0);
-      // Still alive, force kill
-      if (process.platform === 'win32') {
-        execFileSync('taskkill', ['/F', '/PID', String(holderPid)], { windowsHide: true });
-      } else {
+      // Wait briefly so SIGTERM has a chance to land before checking liveness.
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      try {
+        process.kill(holderPid, 0);
+        // Still alive — force kill.
         process.kill(holderPid, 'SIGKILL');
+      } catch {
+        // Process terminated
       }
-    } catch {
-      // Process terminated
     }
 
     // Release lock

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -384,7 +384,7 @@ function generateHooksConfig(config: HooksConfig): object {
           {
             type: 'command',
             command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/session-start-launcher.mjs"',
-            timeout: 3000,
+            timeout: 5000,
           },
           {
             type: 'command',

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -143,7 +143,7 @@ export function getReferenceHookBlock(): HooksTree {
     ],
     SessionStart: [
       {
-        hooks: [scriptHook('session-start-launcher.mjs', 3000), autoMemory('import', 8000)],
+        hooks: [scriptHook('session-start-launcher.mjs', 5000), autoMemory('import', 8000)],
       },
     ],
     Stop: [

--- a/tests/bin/launcher-1056-version-skew.test.ts
+++ b/tests/bin/launcher-1056-version-skew.test.ts
@@ -24,53 +24,84 @@ import { resolve } from 'path';
 
 const BIN = resolve(__dirname, '../../bin');
 
-describe('bin/session-start-launcher.mjs — daemon version-skew detection (#1056)', () => {
+describe('bin/session-start-launcher.mjs — daemon version-skew detection (#1056, promoted to §2a)', () => {
   const file = resolve(BIN, 'session-start-launcher.mjs');
   const src = readFileSync(file, 'utf-8');
 
   it('compares installed moflo version against the daemon-lock version field', () => {
-    // The version-skew block reads version from both sides and compares them.
-    expect(src).toMatch(/JSON\.parse\(readFileSync\(mofloPkgPathForRecycle[\s\S]{0,80}\)\.version/);
+    // The §2a block reads installed version from node_modules/moflo/package.json
+    // and daemon version from the lock, then uses semver-BEHIND comparison
+    // (not just !==, so downgrade-test daemons ahead of installed are left
+    // alone).
+    expect(src).toMatch(/node_modules\/moflo\/package\.json/);
+    // readFileSync takes (path, encoding) — outer JSON.parse(...).version.
+    // The regex needs to tolerate the inner readFileSync close-paren before
+    // matching the JSON.parse close + .version. Use [\s\S]*? to span the
+    // nested calls non-greedily.
+    expect(src).toMatch(/JSON\.parse\(\s*readFileSync\([\s\S]*?\)\s*\)\s*\.version/);
     expect(src).toMatch(/lock\?\.\s*version|lock\.version/);
-    expect(src).toMatch(/daemonVersion\s*!==\s*installedVersion/);
+    expect(src).toMatch(/compareVersionsSemver\(\s*daemonVersion\s*,\s*installedVersion\s*\)\s*<\s*0/);
   });
 
-  it('recycles the daemon with a "daemon-version-skew" label on mismatch', () => {
-    // The label is the named diagnosis — doctor's Daemon Version Skew check
-    // (#1059) will consume the same name so users can correlate.
-    expect(src).toMatch(/recycleDaemon\(\s*lockFile,\s*['"]daemon-version-skew['"]/);
+  it('fires the detached recycler on BEHIND via fireAndForget with a "daemon-behind-recycle" label', () => {
+    // The §2a block hands the kill+wait+restart to bin/lib/daemon-recycler.mjs
+    // detached so the launcher's foreground cost stays ~ms (within the 5000ms
+    // SessionStart hook budget). The label is the named diagnosis doctor reads
+    // via daemon-recycle.last.json.
+    expect(src).toMatch(/fireAndForget\(\s*['"]node['"]\s*,\s*\[\s*recyclerPath/);
+    expect(src).toMatch(/['"]daemon-behind-recycle['"]/);
   });
 
   it('emits a user-visible mutation message naming both versions', () => {
     // Per feedback_no_layered_workarounds — no silent catches. The emitMutation
     // call surfaces what changed via the launcher's stdout protocol to Claude.
     expect(src).toMatch(/emitMutation\(\s*['"]recycled stale daemon['"]/);
-    expect(src).toMatch(/version skew/);
-    expect(src).toMatch(/installed.*\$\{installedVersion\}/);
+    expect(src).toMatch(/behind:\s*daemon\s+v\$\{observed\}/);
+    expect(src).toMatch(/installed\s+v\$\{installedVersion\}/);
   });
 
-  it('treats a missing version field as a mismatch (pre-#1054 daemon)', () => {
+  it('treats a missing version field as behind (pre-#1054 daemon)', () => {
     // Lock payloads written by daemons pre-version-publishing have no
-    // version field. The launcher must treat undefined !== installedVersion
-    // as a mismatch (it naturally does — `undefined !== 'x.y.z'` is true).
-    // Pin the fallback diagnosis text so it stays user-comprehensible.
+    // version field. The §2a block treats `!daemonVersion` as behind
+    // by construction, so they get recycled. Pin the fallback diagnosis
+    // text so it stays user-comprehensible.
+    expect(src).toMatch(/!daemonVersion\s*\|\|\s*compareVersionsSemver/);
     expect(src).toMatch(/<pre-1054 \/ unknown>/);
   });
 
   it('removes the pre-#1054 mtime-margin heuristic', () => {
     // The old check was a 5-second mtime margin — now eliminated by the
-    // exact version comparison. Per root-cause-discipline, no
+    // exact semver comparison. Per root-cause-discipline, no
     // belt-and-suspenders: the version check supersedes the margin.
     expect(src).not.toMatch(/STALE_DAEMON_MTIME_SKEW_MS/);
     expect(src).not.toMatch(/predates current install/);
   });
 
+  it('uses semver-BEHIND (not !==) so ahead-of-installed daemons are left alone', () => {
+    // Downgrade-testing scenario: developer pins moflo to an older version
+    // while the running daemon is at a newer one. The recycle must be
+    // one-way (BEHIND only) so the test daemon isn't killed.
+    expect(src).toMatch(/compareVersionsSemver/);
+    expect(src).not.toMatch(/daemonVersion\s*!==\s*installedVersion/);
+  });
+
   it('surfaces version-check errors via emitWarning instead of silent catch', () => {
-    // The entire version-skew block is wrapped in try/catch; the catch must
-    // route through emitWarning so a parse/I/O failure shows up in the
-    // launcher's user-visible output (per #854 / feedback_no_layered_workarounds).
+    // The §2a block is wrapped in try/catch; the catch must route through
+    // emitWarning so a parse/I/O failure shows up in the launcher's
+    // user-visible output (per #854 / feedback_no_layered_workarounds).
     expect(src).toMatch(
-      /daemon version-skew check failed[\s\S]{0,80}emitWarning|emitWarning[\s\S]{0,80}daemon version-skew check failed/,
+      /daemon-behind check failed[\s\S]{0,80}emitWarning|emitWarning[\s\S]{0,80}daemon-behind check failed/,
     );
+  });
+
+  it('§2a runs BEFORE §3 (placement invariant)', () => {
+    // The whole point of the §2a promotion (#1054 follow-up) is to run the
+    // version-skew check early so §3's heavy file-sync work can't starve
+    // it out under the SessionStart hook timeout. Pin the source ordering.
+    const s2aIdx = src.search(/daemon-behind-recycle/);
+    const s3Idx = src.indexOf('// ── 3. Auto-sync scripts');
+    expect(s2aIdx).toBeGreaterThan(-1);
+    expect(s3Idx).toBeGreaterThan(-1);
+    expect(s2aIdx).toBeLessThan(s3Idx);
   });
 });

--- a/tests/bin/launcher-stopdaemon-escalation.test.ts
+++ b/tests/bin/launcher-stopdaemon-escalation.test.ts
@@ -68,22 +68,32 @@ for (const launcherPath of LAUNCHER_PATHS) {
       expect(stopBlock).toMatch(/isDaemonPidAlive\(\s*stalePid\s*\)/);
     });
 
-    it('sends a graceful signal first — Windows uses bare taskkill, Unix uses SIGTERM', () => {
-      // Bare `process.kill(pid, 'SIGTERM')` on Windows silently force-kills,
-      // bypassing the daemon's shutdown handler (sql.js dump + lock release).
-      // Use `taskkill` without /F for a close-event signal so the daemon
-      // gets a chance to flush cleanly.
+    it('platform-split shutdown — Windows goes straight to /F /T (no graceful), Unix uses SIGTERM first', () => {
+      // Pre-fix this test enforced a "Windows bare taskkill /PID first" step,
+      // but `taskkill /PID` (no /F) on a headless Node daemon sends a window-
+      // close message that a non-GUI process can't receive and always fails
+      // with the visible 'process can only be terminated forcefully' error.
+      // The graceful step was dead code that wasted up to 3s polling for
+      // death-that-couldn't-happen — exactly what blew the 3000ms SessionStart
+      // hook timeout and starved §3a-pre. Windows now goes straight to /F /T.
+      //
+      // Linux/macOS still get the graceful SIGTERM step because SIGTERM is a
+      // real signal the daemon's shutdown handler can trap for a clean sql.js
+      // flush before SIGKILL escalation.
       expect(stopBlock).toMatch(/process\.platform\s*===\s*['"]win32['"]/);
-      // Graceful Windows call: taskkill without /F flag
-      expect(stopBlock).toMatch(/execFileSync\(\s*['"]taskkill['"]\s*,\s*\[\s*['"]\/PID['"]/);
-      // Graceful Unix call: SIGTERM
+      // Windows: /F /T present, bare /PID (without /F) absent.
+      expect(stopBlock).toMatch(/['"]\/F['"]\s*,\s*['"]\/T['"]\s*,\s*['"]\/PID['"]/);
+      expect(stopBlock).not.toMatch(/execFileSync\(\s*['"]taskkill['"]\s*,\s*\[\s*['"]\/PID['"]/);
+      // Unix: SIGTERM graceful step preserved.
       expect(stopBlock).toMatch(/process\.kill\(\s*stalePid\s*,\s*['"]SIGTERM['"]\s*\)/);
     });
 
-    it('polls for death up to 3s after the graceful signal', () => {
+    it('polls for death up to 3s after the Unix SIGTERM graceful signal', () => {
       // The daemon's shutdown handler does a final sql.js dump which under
-      // load can take ~1s. 3s is the canonical budget (mirrors
-      // killBackgroundDaemon's 1s + retry cycle).
+      // load can take ~1s. 3s is the canonical budget on Unix where the
+      // graceful signal actually works (mirrors killBackgroundDaemon's
+      // 1s + retry cycle). Windows skips this poll entirely since there is
+      // no graceful path.
       expect(stopBlock).toMatch(/Date\.now\(\)\s*\+\s*3000/);
       expect(stopBlock).toMatch(/while\s*\(\s*Date\.now\(\)\s*<\s*gracefulDeadline\s*\)/);
       expect(stopBlock).toMatch(/sleepSyncMs\(\s*100\s*\)/);

--- a/tests/system/launcher-version-skew-upgrade-boundary.test.ts
+++ b/tests/system/launcher-version-skew-upgrade-boundary.test.ts
@@ -33,6 +33,7 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const LAUNCHER_PATH = path.join(REPO_ROOT, 'bin', 'session-start-launcher.mjs');
+const RECYCLER_PATH = path.join(REPO_ROOT, 'bin', 'lib', 'daemon-recycler.mjs');
 
 function makeRoot(): string {
   return fs.mkdtempSync(path.join(tmpdir(), 'moflo-1083-vskew-'));
@@ -89,6 +90,29 @@ async function waitForExit(
   }
 }
 
+/**
+ * The §2a recycler is detached, so the lockfile unlink + fresh daemon spawn
+ * happen after the launcher exits. Poll for the recycler's completion marker
+ * (`.moflo/daemon-recycle.last.json`, written by bin/lib/daemon-recycler.mjs)
+ * up to `timeoutMs` so the test doesn't race the unlink.
+ */
+async function waitForRecyclerCompletion(
+  root: string,
+  timeoutMs: number,
+): Promise<{ status: string } | null> {
+  const markerPath = path.join(root, '.moflo', 'daemon-recycle.last.json');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(markerPath)) {
+      try {
+        return JSON.parse(fs.readFileSync(markerPath, 'utf-8'));
+      } catch { /* mid-write — retry */ }
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return null;
+}
+
 interface SeedOptions {
   daemonPid: number;
   daemonVersion: string | undefined;
@@ -99,7 +123,7 @@ interface SeedOptions {
 
 function seedConsumerLayout(root: string, opts: SeedOptions): void {
   fs.mkdirSync(path.join(root, '.moflo'), { recursive: true });
-  fs.mkdirSync(path.join(root, 'node_modules', 'moflo'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'node_modules', 'moflo', 'bin', 'lib'), { recursive: true });
   const lockPayload: Record<string, unknown> = { pid: opts.daemonPid, startedAt: Date.now() };
   if (opts.daemonVersion !== undefined) lockPayload.version = opts.daemonVersion;
   fs.writeFileSync(
@@ -110,6 +134,12 @@ function seedConsumerLayout(root: string, opts: SeedOptions): void {
     path.join(root, 'node_modules', 'moflo', 'package.json'),
     JSON.stringify({ name: 'moflo', version: opts.installedVersion }),
   );
+  // §2a fire-and-forgets the detached recycler — must be present in the
+  // fixture's node_modules/moflo/bin/lib/ for resolveDaemonRecyclerPath to
+  // find it. A stub `cli.js` is also required so the recycler's
+  // `daemon start --quiet` spawn has a target.
+  fs.copyFileSync(RECYCLER_PATH, path.join(root, 'node_modules', 'moflo', 'bin', 'lib', 'daemon-recycler.mjs'));
+  fs.writeFileSync(path.join(root, 'node_modules', 'moflo', 'bin', 'cli.js'), 'process.exit(0);\n');
   fs.writeFileSync(
     path.join(root, 'package.json'),
     JSON.stringify({ name: 'fixture-consumer-1083' }),
@@ -178,10 +208,18 @@ describe('launcher version-skew kill at upgrade boundary (#1056 / #1083 Phase 4)
     expect(result.stdout).toMatch(/stopped daemon for upgrade/);
   });
 
-  it('safety net (section 3a-pre): kills stale daemon when stamp matches but lock disagrees', async () => {
-    // Stamp matches installed, so section 3 (upgrade detection) skips. The
-    // backup version-skew check at section 3a-pre is the only thing left
-    // standing between an old daemon and the new node:sqlite writers.
+  it('safety net (§2a, promoted from §3a-pre): recycles stale daemon when stamp matches but lock disagrees', async () => {
+    // Stamp matches installed, so §3 (upgrade detection) skips. §2a is the
+    // backup version-BEHIND check — the only thing left standing between an
+    // old daemon and the new node:sqlite writers. The check used to live at
+    // §3a-pre (downstream of §3's heavy work) and got killed by the 3000ms
+    // SessionStart hook timeout on the very sessions that needed it.
+    //
+    // §2a now fire-and-forgets bin/lib/daemon-recycler.mjs detached. The
+    // launcher returns inside its budget; the recycler does the kill+wait+
+    // restart in a separate process. From the test's perspective, the
+    // sentinel still gets killed and the lockfile still gets removed —
+    // just by the recycler, not the launcher itself.
     sentinel = spawnDaemonSentinel();
     seedConsumerLayout(root, {
       daemonPid: sentinel.pid,
@@ -193,11 +231,15 @@ describe('launcher version-skew kill at upgrade boundary (#1056 / #1083 Phase 4)
     const result = runLauncher(root);
 
     expect(await waitForExit(sentinel, 5_000)).toBe(true);
+    // Recycler is detached — wait for its completion marker before asserting
+    // on the lockfile unlink it owns.
+    const outcome = await waitForRecyclerCompletion(root, 5_000);
+    expect(outcome?.status, `recycler did not complete cleanly. stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe('ok');
     expect(fs.existsSync(path.join(root, '.moflo', 'daemon.lock'))).toBe(false);
     expect(result.stdout).toMatch(/recycled stale daemon/);
-    expect(result.stdout).toMatch(/version skew/);
-    expect(result.stdout).toMatch(/installed 4\.10\.0/);
-    expect(result.stdout).toMatch(/daemon 4\.9\.99/);
+    // New §2a message format names both versions inline.
+    expect(result.stdout).toMatch(/behind:\s*daemon\s+v4\.9\.99/);
+    expect(result.stdout).toMatch(/installed\s+v4\.10\.0/);
   });
 
   it('safety net handles pre-#1054 daemon (no version field) — recycles via fallback diagnosis', async () => {
@@ -212,6 +254,8 @@ describe('launcher version-skew kill at upgrade boundary (#1056 / #1083 Phase 4)
     const result = runLauncher(root);
 
     expect(await waitForExit(sentinel, 5_000)).toBe(true);
+    const outcome = await waitForRecyclerCompletion(root, 5_000);
+    expect(outcome?.status, `recycler did not complete cleanly. stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe('ok');
     expect(fs.existsSync(path.join(root, '.moflo', 'daemon.lock'))).toBe(false);
     expect(result.stdout).toMatch(/recycled stale daemon/);
     // The fallback label is the load-bearing one — pin it so doctor's


### PR DESCRIPTION
## Summary

- Promote the daemon-version-skew recycle to a first-class **§2a startup check** that runs *before* §3's heavy file-sync work. The prior §3a-pre check lived downstream of §3 and got killed by the 3000ms SessionStart hook timeout on the exact sessions that needed it.
- New detached `bin/lib/daemon-recycler.mjs` does the kill+wait+restart in a separate process so the launcher's foreground cost is ~ms — well inside the hook budget regardless of what §3 does.
- Skip the Windows graceful `taskkill /PID` step in both `stopDaemon` (launcher) and `killBackgroundDaemon` (daemon.ts) — it always failed on a headless Node daemon with the visible *"process can only be terminated forcefully"* error and wasted up to 3s before escalating. Go straight to `taskkill /F /T` on Windows; Linux/macOS path unchanged.
- Bump SessionStart hook timeout `3000 → 5000ms` in both `hook-block-hash.ts` and `settings-generator.ts` (reference-parity test catches drift).

## Why

After `npm install moflo@<new>` + Claude restart, consumers saw `📊 ?` in the statusline. Live diagnosis: daemon.lock reported `4.10.3` while `node_modules/moflo/package.json` said `4.10.4`. The §3a-pre check existed (epic #1054) but never ran because §3's cherry-pick + file-sync + stopDaemon's up-to-4s graceful poll routinely blew the 3000ms hook timeout. The check was downstream — it got killed by Claude Code before it could fire.

§2a runs early and is fast: read two files, compare semver, fireAndForget the recycler. Even if §3 still times out, the daemon is already being recycled in the detached worker.

## Robustness (from /flo-simplify review)

Three-agent reviewer fan-out surfaced four real issues, all addressed:

- **EPERM kill silently swallowed** — process.kill(pid, SIGKILL) against a foreign-owned daemon threw EPERM, the bare catch ate it, recycler polled for 5s and wrote kill-failed without restarting. Now caught explicitly; writes kill-permission-denied, exits without spawning a duplicate.
- **Concurrent-recycler race** — two near-simultaneous session starts spawned two recyclers. Added openSync(path, wx) advisory lock at .moflo/recycle.lock; second invocation gets EEXIST and bails with already-running. Released on every exit path via process.on(exit).
- **Linux zombies** — recyclers isAlive missed the /proc/<pid>/stat Z guard the launchers isDaemonPidAlive added in #1083. Zombie would burn the full 5s poll. Inlined the same check.
- **§2a TOCTOU** — two existsSync + two readFileSync (4 syscalls) replaced with two readFileSync + try/catch (2 syscalls). Closes the existsSync->readFileSync window.

## Cross-platform / consumer-install

- All branches use process.platform === win32 for taskkill vs process.kill/SIGKILL.
- Recycler ships at bin/lib/daemon-recycler.mjs (in npm tarball via bin/**) and resolves from node_modules/moflo/bin/lib/ first, with fallbacks to .claude/scripts/lib/ (synced) and dogfood bin/lib/.
- The bumped timeout is in **both** the reference (hook-block-hash) and the generator (settings-generator) — drift caught by hook-block-hash.test.ts.

## Caveat: one-session lag on the transition release

Consumers on a pre-§2a moflo upgrading to this release: the OLD launcher runs once on their first restart (no §2a, no recycler). §3 still has to complete to sync the new launcher into .claude/scripts/. On the *next* restart, §2a is wired and the recycle self-heals. Unavoidable without a postinstall hook that runs before SessionStart.

## Not in scope (filed as follow-up)

The stale .moflo/moflo-version marker is the same root cause — §3 getting killed by the hook timeout before reaching §3gs stamp write. Solving it properly needs a §3 fire-and-forget refactor (move file-sync + cherry-pick into a worker like the recycler). Separate PR.

## Test plan

- [x] npx vitest run on affected suites — 99/99 passing
- [x] npm run build — clean
- [x] Manual: killed live 4.10.3 daemon, verified fresh 4.10.4 daemon comes up cleanly with flo daemon status
- [x] /flo-simplify three-agent review (NORMAL tier) + validation pass after fixes — clean
- [ ] Reviewer: spin up a fresh consumer with node_modules/moflo/bin/lib/daemon-recycler.mjs and a fake-behind .moflo/daemon.lock, restart Claude, confirm 📊 ? clears
- [ ] CI: green across linux/macOS/Windows

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)