### PR TITLE
chore: sweep stale sql.js references + file #1145 analysis doc

### DIFF
--- a/.claude/guidance/shipped/moflo-cli-reference.md
+++ b/.claude/guidance/shipped/moflo-cli-reference.md
@@ -13,7 +13,7 @@
 | `init`      | 4           | Project initialization with wizard, presets, skills, hooks               |
 | `agent`     | 8           | Agent lifecycle (spawn, list, status, stop, metrics, pool, health, logs) |
 | `swarm`     | 6           | Multi-agent swarm coordination and orchestration                         |
-| `memory`    | 11          | sql.js + HNSW vector search, 150x-12,500x faster                         |
+| `memory`    | 11          | node:sqlite + HNSW vector search, 150x-12,500x faster                    |
 | `mcp`       | 9           | MCP server management and tool execution                                 |
 | `task`      | 6           | Task creation, assignment, and lifecycle                                 |
 | `session`   | 7           | Session state management and persistence                                 |

--- a/.claude/guidance/shipped/moflo-memory-strategy.md
+++ b/.claude/guidance/shipped/moflo-memory-strategy.md
@@ -9,7 +9,7 @@
 Source files (`.claude/guidance/*.md`, `docs/**/*.md`, code, tests) flow through four stages:
 
 1. **Index** — `bin/index-*.mjs` chunks markdown on `##` headers and walks code/tests for structural facts
-2. **Store** — entries land in `.moflo/moflo.db` (SQLite via sql.js) with metadata + RAG links
+2. **Store** — entries land in `.moflo/moflo.db` (SQLite via Node 22's built-in `node:sqlite`) with metadata + RAG links
 3. **Embed** — `bin/build-embeddings.mjs` generates 384-dim vectors via `fastembed` (mandatory, see ADR-EMB-001)
 4. **Search** — `mcp__moflo__memory_search` (preferred), `npx flo memory search` (fallback), or `npx flo-search` (verbose) hit an HNSW index for nearest-neighbor lookup
 

--- a/.claude/guidance/shipped/moflo-yaml-reference.md
+++ b/.claude/guidance/shipped/moflo-yaml-reference.md
@@ -47,7 +47,7 @@ auto_index:
 
 # Memory backend
 memory:
-  backend: sql.js                 # sql.js (WASM) | json
+  backend: node-sqlite            # node:sqlite (Node 22+ built-in) | json — runtime always uses node:sqlite (Phase 5 #1084); this knob is informational only
   embedding_model: Xenova/all-MiniLM-L6-v2   # 384-dim neural embeddings
   namespace: default              # Default namespace for memory operations
 

--- a/.claude/skills/memory-optimization/SKILL.md
+++ b/.claude/skills/memory-optimization/SKILL.md
@@ -112,7 +112,7 @@ const stats = await mcp.memory_stats({});
 - **Don't rebuild the index on every test.** Use a module-level singleton + `beforeAll`. HNSW cold-boot is ~5s.
 - **Don't raise `ef` globally.** Raise it on the specific queries that need recall. Default is fine for 90% of calls.
 - **Don't quantize a small corpus.** Below ~500k vectors the RAM saving doesn't justify the recall cost.
-- **Don't measure in dev mode.** sql.js WASM behaves differently under `NODE_ENV=production`; benches should match the target.
+- **Don't measure in dev mode.** The memory stack behaves differently under `NODE_ENV=production`; benches should match the target.
 
 ## See Also
 

--- a/.claude/skills/memory-patterns/SKILL.md
+++ b/.claude/skills/memory-patterns/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "memory-patterns"
-description: "Persistent memory patterns for moflo agents — session memory, long-term knowledge, pattern learning, and cross-session context via moflo's sql.js + HNSW vector store. Use when building stateful agents or assistants that need to remember across runs."
+description: "Persistent memory patterns for moflo agents — session memory, long-term knowledge, pattern learning, and cross-session context via moflo's node:sqlite + HNSW vector store. Use when building stateful agents or assistants that need to remember across runs."
 ---
 
 # MoFlo Memory Patterns
 
-Persistent, semantically-searchable memory for moflo-enabled projects. Backed by `.swarm/memory.db` (sql.js + HNSW vector index) and exposed through MCP tools.
+Persistent, semantically-searchable memory for moflo-enabled projects. Backed by `.moflo/moflo.db` (node:sqlite + HNSW vector index) and exposed through MCP tools.
 
 ## Core API
 
@@ -124,7 +124,7 @@ This is the same fan-out the `/flo` spell does — cheap (HNSW, parallel) and re
 
 ## Persistence & Indexing
 
-- File: `.swarm/memory.db` at project root (sql.js).
+- File: `.moflo/moflo.db` at project root (node:sqlite, Node 22+ built-in).
 - Embeddings: built by cli's embeddings module; indexed with HNSW from `src/cli/memory/`.
 - Cold-start cost: ~5 seconds to initialize HNSW. Tests should share a single instance (`beforeAll`, not `beforeEach`).
 - Namespace isolation: each namespace is a logical partition, but the HNSW index spans the table. Query time scales with `limit` and `threshold`, not total row count.

--- a/.claude/skills/vector-search/SKILL.md
+++ b/.claude/skills/vector-search/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "vector-search"
-description: "Semantic vector search with moflo — RAG over your own documents, similarity matching, context-aware retrieval via HNSW (sql.js-backed). Use when building retrieval layers for chat, search, or context-assembly."
+description: "Semantic vector search with moflo — RAG over your own documents, similarity matching, context-aware retrieval via HNSW (node:sqlite-backed). Use when building retrieval layers for chat, search, or context-assembly."
 ---
 
 # MoFlo Vector Search (RAG)
 
-Semantic search over your own documents, backed by moflo's HNSW index in `.swarm/memory.db`. Small enough to ship in a devDependency; fast enough for interactive retrieval at 100k–1M vectors.
+Semantic search over your own documents, backed by moflo's HNSW index in `.moflo/moflo.db` (node:sqlite, Node 22+ built-in). Small enough to ship in a devDependency; fast enough for interactive retrieval at 100k–1M vectors.
 
 ## When to Use This vs `memory-patterns`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ MoFlo makes deliberate choices so you don't have to:
 - **Fully self-contained** — No external services, no cloud dependencies, no API keys. Everything runs locally on your machine.
 - **Minimal dependencies** — small runtime dep set, all WASM or prebuilt binaries. No native compilation, no `node-gyp`, no platform-specific build steps.
 - **Node.js runtime** — Targets Node.js specifically. All scripts, hooks, and tooling are JavaScript/TypeScript. No Python, no Rust binaries, no native compilation.
-- **sql.js (WASM)** — The memory database uses sql.js, a pure WebAssembly build of SQLite. No native `better-sqlite3` bindings to compile, no platform-specific build steps. Works identically on Windows, macOS, and Linux.
+- **node:sqlite (built-in)** — The memory database uses Node 22's built-in SQLite engine. No `better-sqlite3` native bindings to compile, no WASM round-trip, no platform-specific build steps. Works identically on Windows, macOS, and Linux.
 - **Neural embeddings by default** — 384-dimensional embeddings using `all-MiniLM-L6-v2`. No hash fallback, no peer-optional setup, no install prompts — real semantic search works out of the box. A `postinstall` step trims the embedding runtime to your platform and strips GPU-only libraries the runtime never loads, reclaiming roughly 340 MB on Linux and 150 MB on Windows from a fresh install. Set `MOFLO_NO_PRUNE=1` to skip the trim, or `ONNXRUNTIME_NODE_INSTALL_CUDA=true` to keep CUDA GPU support.
 - **Full learning stack wired up OOTB** — All configured and functional from `flo init`, no manual setup:
   - **SONA** (Self-Optimizing Neural Architecture) — learns from task trajectories
@@ -537,7 +537,7 @@ flo diagnose --json              # JSON output for CI/automation
 | **MCP Spell Integration** | Bridge between MCP tools and spell engine functions correctly |
 | **Hook Execution** | Hook executor is functional and can fire hooks |
 | **Gate Health** | All gate cases, hook bindings, and state file are intact |
-| **MofloDb Bridge** | Memory DB adapter (sql.js + HNSW) is wired and routable |
+| **MofloDb Bridge** | Memory DB adapter (node:sqlite + HNSW) is wired and routable |
 | **Sandbox Tier** | Detects which sandbox backend is available (Docker / bwrap / sandbox-exec / none) |
 
 **Auto-fix mode** (`flo healer --fix`) attempts to repair each failing check automatically:
@@ -645,7 +645,7 @@ These are the backend systems that hooks and commands interact with.
 
 | System | What It Does | Why It Matters | Enabled OOTB |
 |--------|-------------|----------------|:---:|
-| **Semantic Memory** | SQLite database (sql.js/WASM) storing knowledge entries with 384-dim vector embeddings | Your AI assistant accumulates project knowledge across sessions instead of starting from scratch each time | Yes |
+| **Semantic Memory** | SQLite database (Node's built-in `node:sqlite`) storing knowledge entries with 384-dim vector embeddings | Your AI assistant accumulates project knowledge across sessions instead of starting from scratch each time | Yes |
 | **HNSW Vector Search** | Hierarchical Navigable Small World index for fast nearest-neighbor search | Searches across thousands of stored entries return in milliseconds instead of scanning linearly | Yes |
 | **Guidance Indexing** | Chunks markdown docs into overlapping segments, embeds each with MiniLM-L6-v2 | Your project documentation becomes searchable by meaning ("how does auth work?") not just keywords | Yes |
 | **Code Map** | Parses source files for exports, classes, functions, types | The AI can answer "where is X defined?" from the index instead of running Glob/Grep | Yes |
@@ -720,7 +720,7 @@ Routing outcomes persist across sessions. You can inspect them with `flo hooks p
 
 ### Memory & Knowledge Storage
 
-MoFlo uses a SQLite database (via sql.js/WASM — no native deps) to store three types of knowledge:
+MoFlo uses a SQLite database (via Node 22's built-in `node:sqlite` — no native deps) to store three types of knowledge:
 
 | Namespace | What's Stored | How It Gets There |
 |-----------|---------------|-------------------|
@@ -861,7 +861,7 @@ MoFlo started from [Ruflo/Claude Flow](https://github.com/ruvnet/ruflo) but is n
 
 My use case was just one of those many scenarios: day-to-day local coding, enhancing my normal Claude Code experience on a single project. The original supported this — it was all in there — but because the project served so many different needs, I found myself configuring and tailoring things for my specific setup each time I pulled in updates. That isn't a shortcoming of the original; it's the natural trade-off of a tool designed to be that flexible and powerful.
 
-So I started from that foundation and narrowed the focus to my particular corner of it. I baked in the defaults I kept setting manually, added automatic indexing and memory gating at session start, and tuned the out-of-box experience so that `npm install` and `flo init` gets you straight to coding. Over time MoFlo grew its own architecture (workspace collapse, in-tree fastembed runtime, sql.js + HNSW memory layer, spell engine, daemon-driven scheduling) and the two projects fully diverged.
+So I started from that foundation and narrowed the focus to my particular corner of it. I baked in the defaults I kept setting manually, added automatic indexing and memory gating at session start, and tuned the out-of-box experience so that `npm install` and `flo init` gets you straight to coding. Over time MoFlo grew its own architecture (workspace collapse, in-tree fastembed runtime, node:sqlite + HNSW memory layer, spell engine, daemon-driven scheduling) and the two projects fully diverged.
 
 If you're exploring the full breadth of agent orchestration, go look at [Ruflo/Claude Flow](https://github.com/ruvnet/ruflo) — it's the real deal. If your needs are similar to mine — a focused, opinionated local dev setup that just works — MoFlo is for you.
 

--- a/docs/MOFLO_INIT_TEST_PLAN.md
+++ b/docs/MOFLO_INIT_TEST_PLAN.md
@@ -115,7 +115,7 @@ flo init --yes --force
 | code_map.extensions | `.js` detected | PASS |
 | gates (memory_first, etc.) | All enabled | PASS |
 | auto_index | Both enabled | PASS |
-| memory.backend | sql.js | PASS |
+| memory.backend | node-sqlite | PASS |
 
 ---
 
@@ -201,7 +201,7 @@ flo memory stats
 ```
 
 **Expected**: Shows backend type, version, entry count.
-**Status**: PASS — Reports `sql.js + HNSW`, version `3.0.0`
+**Status**: PASS — Reports `node:sqlite + HNSW`, version `3.0.0`
 
 ---
 

--- a/docs/internal/1145-daemon-port-collision-analysis.md
+++ b/docs/internal/1145-daemon-port-collision-analysis.md
@@ -1,0 +1,438 @@
+# Daemon Port Collision — Cross-Project Routing Analysis
+
+**Issue:** [#1145](https://github.com/eric-cielo/moflo/issues/1145) — `critical: fixed daemon port (3117) causes silent cross-project DB routing`
+
+**Status:** Audit complete. Fix strategy committed. Recovery path documented. Ready for implementation scoping.
+
+---
+
+## 1. TL;DR
+
+moflo's daemon HTTP server defaults to a fixed port (3117). The **server side** retries 3117→3118→…→3126 on `EADDRINUSE` (`src/cli/services/daemon-dashboard.ts:655-666`). The **client side** does NOT — `src/cli/memory/daemon-write-client.ts:47` hard-defaults to 3117 with no fallback. This asymmetry is the root mechanic: when project A binds 3117 first, project B's daemon binds 3118 successfully but project B's clients still POST to 3117 and silently hit project A.
+
+Consequences proven on the audit machine:
+
+- **Reads are wrong**: project B's `flo memory stats` / `memory list` / `memory retrieve` return project A's data.
+- **Writes are wrong** (chokepoint surface): project B's MCP `memory_store` / `memory_delete`, `flo memory store/delete` CLI, swarm persistence, aidefence, and write-through-adapter land in project A's `.moflo/moflo.db` — **lost from B, foreign in A**. Indexers and migrations are safe (they bypass HTTP — see §6).
+- **Orphan daemons accumulate**: same-project daemon proliferation. waxstack has TWO live daemons (3118, 3119) because stale-daemon detection failed.
+- **No surface signal**: nothing logs, no health probe disagrees, daemon.lock contains no port — discovery is impossible without `netstat`.
+
+The original consumer-reported symptom (`memory_stats reports totalEntries:0`) is one downstream effect among seven stacked bugs (§4).
+
+---
+
+## 2. Live Reproducer State
+
+Three moflo daemons running on the audit machine at the time of investigation:
+
+| PID | Port | Project | Version | Identity |
+|-----|------|---------|---------|----------|
+| 19580 | 3117 | `C:/Users/eric/Projects/moflo` (moflo-dev) | 4.10.6 | First to bind; owns the default port |
+| 23040 | 3118 | `C:/Users/eric/Projects/motailz/code` (waxstack) | 4.10.7 | **Orphan** — not in any daemon.lock |
+| 30344 | 3119 | `C:/Users/eric/Projects/motailz/code` (waxstack) | 4.10.7 | Current — owns waxstack's `.moflo/daemon.lock` |
+
+`waxstack/.moflo/daemon.lock`:
+```json
+{"pid":30344,"startedAt":1778845531679,"label":"moflo-daemon","version":"4.10.7"}
+```
+
+**No `port` field.** Clients cannot discover the actual bound port.
+
+### Direct reproducer
+
+```bash
+# From waxstack, with daemon routing enabled (default):
+$ flo memory stats
+  Total Entries:        0       # LIE. DB has 5,909.
+
+$ flo memory list
+  [INFO] Showing 5 of 4364 entries   # LIE. Those are moflo-dev's rows.
+
+# Bypass daemon, hit SQL directly:
+$ MOFLO_DISABLE_DAEMON_ROUTING=1 flo memory stats
+  Total Entries:        5,909   # CORRECT.
+```
+
+Verified via direct `node:sqlite` open of both DB files:
+- waxstack DB: 5,909 rows; namespaces `guidance` (2,620), `code-map` (1,414), `patterns` (1,297), `tests` (489)
+- moflo-dev DB: 4,364 rows; namespaces `code-map` (1,385), `guidance` (1,018), `patterns` (971), `tests` (852)
+- Different content, totally distinct projects.
+
+### HTTP-level reproducer
+
+```bash
+# All three daemons share /api/memory/list shape but serve their own DB:
+$ curl 127.0.0.1:3117/api/memory/list -d '{"limit":5}'
+  → moflo-dev rows (4,364 total)
+
+$ curl 127.0.0.1:3118/api/memory/list -d '{"limit":5}'
+  → waxstack rows (5,909 total) — first row: chunk-guidance-analysis-output-location-4
+
+$ curl 127.0.0.1:3119/api/memory/list -d '{"limit":5}'
+  → identical to 3118 (same DB file)
+
+# /api/health does not exist on any of them:
+$ curl 127.0.0.1:3117/api/health
+  → {"error":"Not found"}
+```
+
+---
+
+## 3. Root Cause — The Asymmetric Port Fallback
+
+Two source-of-truth constants for the same singleton (DRY violation surfaced in the audit):
+
+```ts
+// src/cli/services/daemon-dashboard.ts:59
+export const DEFAULT_DASHBOARD_PORT = 3117;
+
+// src/cli/memory/daemon-write-client.ts:47
+const DEFAULT_DAEMON_PORT = 3117;
+```
+
+The server's port-fallback loop (`daemon-dashboard.ts:655-666`):
+
+```ts
+for (let attempt = 0; attempt < MAX_PORT_ATTEMPTS; attempt++) {
+  const port = basePort + attempt;
+  try {
+    const handle = await tryListenOnPort(daemon, opts, port);
+    return handle;
+  } catch (err) {
+    if (err.code === 'EADDRINUSE' && attempt < MAX_PORT_ATTEMPTS - 1) continue;
+    throw err;
+  }
+}
+```
+
+`MAX_PORT_ATTEMPTS = 10` — tries 3117, 3118, …, 3126.
+
+The client's port resolution (`daemon-write-client.ts:165`):
+
+```ts
+function getDaemonPort(): number {
+  const fromEnv = process.env.MOFLO_DAEMON_PORT;
+  if (fromEnv) { return parseInt(fromEnv, 10); }
+  return DEFAULT_DAEMON_PORT;  // always 3117
+}
+```
+
+**Server moves; client doesn't follow.** Every successful "I'm-listening" on a port > 3117 produces a silent collision waiting to happen.
+
+---
+
+## 4. Stacked Bugs Map
+
+| # | Bug | Layer | Status |
+|---|-----|-------|--------|
+| 1 | Client port hard-defaults to 3117 (no fallback, no discovery) | `daemon-write-client.ts:47,165` | **Main #1145** |
+| 2 | Two source-of-truths for `3117` | `daemon-dashboard.ts:59` + `daemon-write-client.ts:47` | **Part of #1145 fix** (collapse to one) |
+| 3 | `.moflo/daemon.lock` has no `port` field | lock writer in launcher / `worker-daemon.ts` | **Part of #1145 fix** |
+| 4 | Daemon has no `/api/health` (404 for identity probe) | `daemon-dashboard.ts` / `daemon-memory-rpc.ts` | **Part of #1145 fix** (add it) |
+| 5 | Daemon `/api/memory/list` caps `limit ≤ 10000` | `daemon-memory-rpc.ts` request validator | **Sibling — separate issue** |
+| 6 | MCP `memory_stats` requests `limit:100000` | `src/cli/mcp-tools/memory-tools.ts:732` | **Sibling — separate issue** |
+| 7 | `tryDaemonList` transformer defaults `total: 0` on malformed shapes | `daemon-write-client.ts:354-357` | **Sibling — separate issue** |
+| 8 | MCP `memory_stats` handler ignores `success: false` | `memory-tools.ts:732` (same file as #6) | **Sibling — separate issue** |
+| 9 | Orphan daemon proliferation (multiple daemons per project) | daemon spawn / cleanup | **Sibling — separate issue** |
+| 10 | MCP server PID file in `os.tmpdir()` (cross-project collision) | `src/cli/mcp-server.ts:70-71` | **Sibling — separate issue** |
+| 11 | `~/.moflo/neural/` cross-project pattern bleed | `src/cli/memory/intelligence.ts:31` | **Sibling — separate issue** |
+
+#1145's fix scope covers bugs **1–4**. Bugs 5–11 are filed separately so each is owned, tested, and reviewed independently.
+
+---
+
+## 5. Daemon HTTP Endpoint Inventory
+
+From `src/cli/services/daemon-memory-rpc.ts:626-639`:
+
+| Path | Method | Purpose | Cross-project-vulnerable? |
+|------|--------|---------|---------------------------|
+| `/api/memory/store` | POST | Single-entry write (chokepoint) | **YES** |
+| `/api/memory/delete` | POST | Single-entry delete | **YES** |
+| `/api/memory/batch` | POST | Bulk write/delete | **YES** |
+| `/api/memory/get` | POST | Single-key retrieve | **YES** |
+| `/api/memory/search` | POST | Semantic search | **YES** |
+| `/api/memory/list` | POST | Paginated list | **YES** |
+| `/api/health` | GET | (does not exist) | **N/A — needs to be added** |
+
+Dashboard routes (`/`, `/api/events`, etc.) are read-only and present a different surface; not enumerated here.
+
+---
+
+## 6. Write-Path Pollution Analysis
+
+Detailed audit results (parallel to `docs/internal/1054-writer-audit.md` and `981-writer-audit.md` — same shape):
+
+### Write routing matrix
+
+| Writer | Route | HTTP path | Direct fallback | Verdict |
+|--------|-------|-----------|-----------------|---------|
+| MCP `memory_store` / `memory_delete` | `storeEntry`/`deleteEntry` → `tryDaemonStore`/`tryDaemonDelete` first | `/api/memory/{store,delete}` | `openDaemonDatabase(memoryDbPath(cwd))` on `routed:false` | **wrong-daemon-vulnerable** |
+| MCP aidefence (`aidefence-moflodb-store.ts:48,92`) | `storeEntry`/`deleteEntry` chokepoint | same | same fallback | **wrong-daemon-vulnerable** |
+| CLI `flo memory store/delete` | `storeEntry`/`deleteEntry` chokepoint | same | same fallback | **wrong-daemon-vulnerable** |
+| Swarm persistence + write-through-adapter | DI'd `storeEntry`/`deleteEntry` | same | same fallback | **wrong-daemon-vulnerable** |
+| `bin/index-{guidance,tests,patterns}.mjs` | Direct `openBackend(projectRoot)` | none | local node:sqlite WAL | **direct-only-safe** |
+| `bin/generate-code-map.mjs`, `bin/build-embeddings.mjs` | Direct `openBackend` | none | same | **direct-only-safe** |
+| `bin/migrations/*.mjs` | Direct `openBackend` | none | same | **direct-only-safe** |
+| `bin/lib/db-repair.mjs` | Direct `openBackend` | none | same | **direct-only-safe** |
+| `services/learning-service.ts:387,639` (called from `commands/hooks.ts`) | Direct `openDaemonDatabase` (NOT routed) | none | direct | **direct-only-safe** |
+| Doctor seed (`doctor-checks-memory-access.ts:335`) | Raw `db.export()` | none | direct | **direct-only-safe** |
+
+### Bottom line on data damage
+
+During the daemon-overlap window:
+
+- **Foreign rows landed in moflo-dev's DB** from every chokepoint write originating in waxstack: MCP `memory_store` (Claude session "remember this", agent memory, hive-mind state), `flo memory store/delete` CLI, swarm coordination, aidefence learnings.
+- **Lost rows from waxstack's DB**: the same writes never reached waxstack's local file. No shadow copy. Data is gone unless the user reconstructs from the foreign DB.
+- **Intact in waxstack**: indexer-populated namespaces (`guidance`, `code-map`, `tests`, `patterns`) and learning-service `learned_patterns` (in-session writes). These bypass HTTP and write direct.
+- **Intact in moflo-dev (its own namespaces)**: indexers ran direct against moflo-dev's DB too, so its `guidance`/`code-map`/`tests`/`patterns` are correct. The pollution shows up in `learnings`/`tasklist`/`swarm-*`/`default` namespaces (the MCP-store-targeted set).
+
+Spot-check on the audit machine: moflo-dev's `learnings` namespace had 27 entries. Surface inspection of recent rows showed moflo-internal content (e.g., `1140-dead-mjs-collapse-residue`) — no obvious waxstack pollution in the visible sample. A full audit requires diffing every MCP-store-routable namespace against waxstack's expected content. Out of scope for the fix PR; tracked as recovery surface (§10).
+
+---
+
+## 7. Sidecar / HNSW Pollution Status
+
+| File | moflo-dev | waxstack | Polluted? |
+|------|-----------|----------|-----------|
+| `.moflo/moflo.db` | 49 MB, 4,364 rows | 60 MB, 5,909 rows | **Yes** (foreign chokepoint rows in moflo-dev; missing chokepoint rows in waxstack) |
+| `.moflo/hnsw.index` | 7.2 MB | 9.9 MB | **Indirect** — HNSW is rebuilt server-side by the daemon owning the project. waxstack's HNSW reflects waxstack's local DB (correct shape). moflo-dev's HNSW reflects moflo-dev's DB (including foreign rows it absorbed). |
+| `.moflo/embeddings.json` | 317 B | 317 B | LOW — small bookkeeping; not a primary risk |
+| `.moflo/daemon.lock` | per-project, valid PID | per-project, valid PID | **Schema gap** — no port field; clients can't discover bound port |
+| `.moflo/daemon-state.json` | per-project | per-project | OK — describes the daemon's own workers, project-local |
+| `.moflo/daemon-spawn.stamp` | per-project | per-project | OK |
+
+HNSW pollution implications:
+
+- waxstack's `.moflo/hnsw.index` is **complete for direct-write content** (indexers wrote rows + embeddings local; HNSW rebuild covered them). It's **missing vectors** for chokepoint writes that went elsewhere — so semantic-search in waxstack will fail to surface anything the user stored via MCP during the overlap window.
+- moflo-dev's `.moflo/hnsw.index` includes **foreign vectors** for waxstack's chokepoint writes (HNSW rebuild covered the rows physically present in moflo-dev's DB regardless of origin). A search in moflo-dev surfaces waxstack content as plausible hits.
+
+Recovery requires HNSW rebuild after row migration (§10).
+
+---
+
+## 8. Sibling Shared-Resource Collisions
+
+Audit found other singleton-shared-resource assumptions that are bug-class siblings of #1145 — they would produce silent cross-project collisions on any developer's machine. Listed in severity order.
+
+### HIGH severity (silent wrong-answers / data bleed)
+
+| Resource | Location | Failure mode |
+|----------|----------|--------------|
+| Asymmetric server-vs-client port fallback | `daemon-dashboard.ts:655-666` vs `daemon-write-client.ts:47` | **Root mechanic of #1145.** Fix here. |
+| MCP server PID file | `os.tmpdir()/claude-flow-mcp.pid` (`mcp-server.ts:70`) | Two projects' MCP servers overwrite each other's PID; "stop MCP" kills wrong process |
+| MCP server log file | `os.tmpdir()/claude-flow-mcp.log` (`mcp-server.ts:71`) | Interleaved log lines, lost diagnostics |
+| Neural intelligence patterns | `~/.moflo/neural/` (`memory/intelligence.ts:31`) | Cross-project pattern bleed; project A's neural learnings overwrite project B's |
+| Spell credentials keyring | `~/.moflo/credentials.json`, `~/.moflo/credentials.key` (`spells/credentials/default-store.ts:29-30`) | Single keyring for the whole machine; two projects share creds |
+
+### MEDIUM severity (noisy crashes / shared state)
+
+| Resource | Location | Failure mode |
+|----------|----------|--------------|
+| Browser profile (Outlook) | `~/.moflo/browser-profiles/outlook` | Session-cookie collisions across projects |
+| Claims store | `~/.config/claude-flow/claims.json` | Global claims; not project-scoped |
+| Smoke-harness hardcoded `3217` | `harness/consumer-smoke/run.mjs:79` | Two parallel smokes collide noisily |
+
+### LOW severity (cosmetic / read-mostly)
+
+| Resource | Location | Notes |
+|----------|----------|-------|
+| Update-state JSON | `~/.moflo/update-state.json` | Rate-limit only |
+| Update-history JSON | `~/.moflo/update-history.json` | Append-mostly |
+| fastembed model cache | `~/.cache/fastembed/` | Content-addressed, read-mostly |
+| Sandbox tmpfiles | `os.tmpdir()/moflo-sandbox-*.sb` | Per-invocation random suffix |
+
+### Project-scoped (correctly isolated — for reference)
+
+All locks under `.moflo/` follow the right pattern: `daemon.lock`, `recycle.lock`, `spawn.lock`, `indexer.lock`, `daemon-spawn.stamp`, `background-pids.json`. These are NOT siblings of #1145.
+
+### Historical incidents (auto-memory)
+
+- `1061-indexer-daemon-race-lock-pattern` — same shape; solved with project-scoped `.moflo/indexer.lock`.
+- `feedback_moflo_dogfood_dual_context.md` — already documents the port-3117 dev-daemon-vs-smoke collision *within moflo's repo*; smoke uses 3217 as a workaround, not a fix.
+- `launcher-stopdaemon-windows-escalation` — same lifecycle class as collision recovery.
+
+---
+
+## 9. Fix Strategy (Revised)
+
+Three sub-fixes land in the same PR. Defense-in-depth — any one alone is insufficient.
+
+### 9.1 Per-project deterministic port allocation
+
+Single source-of-truth (kills #2 in §4 simultaneously). Both `daemon-dashboard.ts` and `daemon-write-client.ts` import from a shared `src/cli/services/daemon-port.ts`:
+
+```ts
+// src/cli/services/daemon-port.ts
+import { createHash } from 'node:crypto';
+
+const PORT_RANGE_BASE = 33000;
+const PORT_RANGE_SIZE = 1000;
+const LEGACY_DEFAULT_PORT = 3117;   // honored on read-only, not written
+
+export function resolveProjectPort(projectRoot: string): number {
+  if (process.env.MOFLO_DAEMON_PORT) {
+    return parseInt(process.env.MOFLO_DAEMON_PORT, 10);
+  }
+  const hash = createHash('sha256').update(projectRoot).digest();
+  return PORT_RANGE_BASE + (hash.readUInt16BE(0) % PORT_RANGE_SIZE);
+}
+```
+
+- Same project path → same port across daemon restarts (no stale-lock confusion).
+- Different paths → ~1/1000 collision probability; identity check (§9.3) catches it.
+- Range 33000-34000 avoids common dev ports (3000, 3001, 5000, 5173, 8000, 8080).
+- Env override preserves; legacy 3117 is no longer the unconditional fallback.
+
+### 9.2 Port in `.moflo/daemon.lock`
+
+Extend lock schema:
+
+```json
+{
+  "pid": 30344,
+  "startedAt": 1778845531679,
+  "label": "moflo-daemon",
+  "version": "4.10.7",
+  "port": 33421
+}
+```
+
+Clients **prefer** the lock-file port over `resolveProjectPort` so even if the server bound a non-default port (collision in the deterministic range), the client follows. Backward compat: when `lock.port` is missing, fall back to `resolveProjectPort(projectRoot)`, then env, then legacy 3117 with a deprecation warn.
+
+### 9.3 Daemon identity endpoint + client identity check
+
+Add `GET /api/health` to the daemon (currently 404):
+
+```json
+{
+  "status": "ok",
+  "projectRoot": "C:\\Users\\eric\\Projects\\motailz\\code",
+  "pid": 30344,
+  "version": "4.10.7",
+  "uptimeMs": 36043927
+}
+```
+
+Every client call probes `/api/health` (cached for 5 seconds, invalidated on routed-failure). Compare returned `projectRoot` to the client's `findProjectRoot()` result (unified resolver from #1057). On mismatch:
+
+- Set `routed: false`; fall through to direct-SQL path (proven correct via `MOFLO_DISABLE_DAEMON_ROUTING=1`).
+- Emit ONE stderr line per process per mismatched daemon: `[moflo] daemon at port X claims project '/foo' but cwd is '/bar' — using direct DB. Run flo healer --fix to repair.`
+- Invalidate health cache.
+
+### 9.4 Hard-fail on bind failure with non-default port
+
+When `tryListenOnPort` exhausts the deterministic-range candidates and falls into the legacy retry, the daemon **must exit non-zero** rather than stay alive doing internal-worker-only work. Today's silent half-alive state (waxstack PID 30344) is the trap.
+
+Spawn launcher detects the non-zero exit, retries up to N times with exponential backoff, then surfaces to healer.
+
+### 9.5 Healer subcheck — `daemon-identity-match`
+
+New doctor/healer subcheck:
+
+1. Read `.moflo/daemon.lock` → extract claimed `port` + `pid`.
+2. `GET 127.0.0.1:<port>/api/health` → extract reported `projectRoot`.
+3. Assert `projectRoot === findProjectRoot(cwd)`.
+4. On fail: `flo healer --fix daemon-identity` kills the wrong-project daemon process (only if its `commandLine` clearly belongs to a moflo install — see §10 recovery), restarts the local daemon.
+
+---
+
+## 10. Recovery Path for Affected Consumers
+
+### 10.1 Detect
+
+Healer's new `daemon-identity-match` subcheck (§9.5) surfaces the collision. Until that lands, consumers can manually run:
+
+```bash
+node --no-warnings -e "
+const http = require('node:http');
+const { readFileSync } = require('node:fs');
+const lock = JSON.parse(readFileSync('.moflo/daemon.lock', 'utf-8'));
+const port = lock.port ?? 3117;
+http.get('http://127.0.0.1:' + port + '/api/health', res => {
+  let body = ''; res.on('data', c => body += c);
+  res.on('end', () => console.log('Port', port, 'identity:', body));
+}).on('error', e => console.error('No daemon at', port, e.message));
+"
+```
+
+If `/api/health` 404s (current state), check identity via `netstat -ano | grep :3117` + `tasklist /PID <pid>` (Windows) or `lsof -i :3117` (macOS/Linux).
+
+### 10.2 Reconciliation (manual, pre-fix)
+
+For consumers whose data went to a foreign DB during the overlap window:
+
+1. **Stop all moflo daemons on the machine.** Find them: `ps aux | grep moflo` or `Get-CimInstance Win32_Process -Filter "Name='node.exe'" | Where-Object CommandLine -Match 'moflo.*daemon'`. Kill each.
+2. **Identify victim and donor DBs.** Victim = project whose `.moflo/moflo.db` is missing chokepoint writes. Donor = project whose daemon was bound on 3117 first.
+3. **Audit donor for foreign rows.** Per namespace audit. The `learnings`, `default`, `swarm-*`, `tasklist`, and any custom-MCP-store namespaces are the polluted set. Indexer-populated namespaces (`guidance`, `code-map`, `tests`, `patterns`) are safe.
+4. **Manual extract + reinsert** of identified foreign rows. There is no auto-attribution — content origin must be inferred from `key` patterns, `metadata` JSON, or content text. A scripted helper for this could ship with the #1145 fix PR.
+5. **Rebuild HNSW** in victim project: `flo memory rebuild-index` (or `flo embeddings init`).
+6. **Restart daemons** post-fix in any order — the fix prevents recurrence.
+
+### 10.3 Disclosure to consumers
+
+The fix PR's CHANGELOG entry must clearly state:
+
+> **Data-integrity advisory:** moflo versions ≤4.10.7 had a daemon-routing bug (#1145) where two moflo-using projects on the same machine could silently cross-write each other's databases. If you ran `flo memory store`, `mcp__moflo__memory_store`, or `flo swarm` across multiple projects concurrently, audit `.moflo/moflo.db` in each project for foreign entries before considering the fix complete. See `docs/internal/1145-daemon-port-collision-analysis.md` §10.2 for the manual reconciliation procedure.
+
+---
+
+## 11. Test Surface
+
+### 11.1 New tests (must fail on `main`, pass after fix)
+
+| Test | Location | What it asserts |
+|------|----------|-----------------|
+| Cross-project port allocation | `tests/system/daemon-port-isolation.test.ts` | Two daemons rooted at different paths each bind successfully; deterministic ports differ |
+| Identity-check rejection | `tests/system/daemon-identity-mismatch.test.ts` | Client calling a daemon whose `/api/health` reports a different `projectRoot` falls through to direct SQL with one stderr warn |
+| Lock-file port discovery | `tests/bin/daemon-lock-port-discovery.test.ts` | Client reads `port` field from `.moflo/daemon.lock` and uses it over `resolveProjectPort` |
+| Hard-fail on bind exhaustion | `tests/bin/daemon-bind-exhaustion.test.ts` | When all candidate ports are taken, daemon exits non-zero; spawn launcher retries N times |
+| Smoke harness extension | `harness/consumer-smoke/run-dual-consumer.mjs` (new) | Spawns two consumer-smokes back-to-back in different temp dirs; asserts each `flo memory stats` returns own row count |
+
+### 11.2 Existing test surface to update
+
+- `src/cli/__tests__/memory/daemon-write-client.test.ts` — fixture updates for port resolution
+- `src/cli/__tests__/services/daemon-memory-rpc.test.ts` — `/api/health` route assertions
+- `src/cli/__tests__/services/dashboard-claude-stats-route.test.ts` — already on `isolationTests`; verify still green post-fix
+- All `tryDaemon*` tests in `daemon-write-client.test.ts` — gain identity-mismatch case
+
+### 11.3 Regression guard
+
+Add `tests/system/no-fixed-3117.test.ts` — static grep that any future commit reintroducing a literal `3117` outside `daemon-port.ts` fails the test. Same posture as `tests/bin/get-backend.test.ts` for the sql.js retirement.
+
+---
+
+## 12. Migration / Rollout Plan
+
+### Phase 1 — Land #1145 (this issue)
+
+PR includes:
+- §9.1–9.5 implemented
+- §11 tests green on Linux + macOS + Windows
+- CHANGELOG advisory (§10.3)
+
+### Phase 2 — File and resolve siblings (post-#1145)
+
+Each sibling bug from §4 gets its own issue + PR:
+- **memory_stats overhaul** — collapses bugs 5+6+7+8: dedicated `/api/memory/stats` endpoint with server-side aggregations, no client-side iteration; client surfaces 4xx errors instead of defaulting to 0.
+- **orphan daemon cleanup** (bug 9) — startup probe: any moflo daemon process with same projectRoot but PID ≠ lock.pid gets killed before this daemon binds.
+- **MCP PID/log relocation** (bug 10) — move `claude-flow-mcp.pid|log` from `os.tmpdir()` to `<projectRoot>/.moflo/mcp-server.{pid,log}`.
+- **neural-pattern namespacing** (bug 11) — `~/.moflo/neural/` partitioned by project-hash subdirectory.
+
+### Phase 3 — Tighten audit posture
+
+Add a CI guard that fails on any new code path that:
+- Reads/writes a fixed port outside `daemon-port.ts`
+- Writes a PID/lock/state file outside `<projectRoot>/.moflo/` (with explicit allowlist for the four sibling-cleanup files in Phase 2)
+- References `127.0.0.1:` literals outside the central daemon-port resolver
+
+---
+
+## 13. See Also
+
+- `docs/internal/1054-writer-audit.md` — sibling writer audit (sql.js multi-process clobber); same audit shape, same posture
+- `docs/internal/981-writer-audit.md` — earlier sibling audit (sql.js single-writer)
+- `.claude/guidance/internal/dogfooding.md` — explains why `bin/**` requires publish-reinstall verification
+- `feedback_consumer_blast_radius.md` — mandatory pre-change articulation rule (consumer surface / failure mode / round-trip cost) that this audit follows
+- `feedback_moflo_dogfood_dual_context.md` — documents the local-only port-3117 collision class this issue escalates to the consumer-fleet scale
+- `feedback_unified_project_root_resolver.md` — every `findProjectRoot()` caller pattern; §9.3 identity check relies on this

--- a/docs/linkedin-flo-state.html
+++ b/docs/linkedin-flo-state.html
@@ -159,7 +159,7 @@
 <h2>One database to rule them all: MoFlo DB</h2>
 
 <p>The biggest invisible upgrade is the storage layer. Memory, swarm coordination, hive-mind state, AIDefence threat patterns, learned routing outcomes — all of it now lives in a single
-  <code>sql.js + HNSW</code> store at <code>.moflo/moflo.db</code>.</p>
+  <code>node:sqlite + HNSW</code> store at <code>.moflo/moflo.db</code>.</p>
 
 <ul>
   <li><strong>It consumes everything that matters</strong> — project guidance, reusable patterns, code maps (exports, classes, functions, types), test-to-source mappings, and a continuously updated stream of learnings from <em>both</em> Claude and the humans on the team. A correction you make once, a convention you write down, a routing decision that worked: all of it lands in the same index and shows up the next time it's relevant.</li>

--- a/docs/linkedin-luminarium.html
+++ b/docs/linkedin-luminarium.html
@@ -215,7 +215,7 @@
   <img src="https://raw.githubusercontent.com/eric-cielo/moflo/main/docs/Luminarium_Memory.png" alt="The Luminarium's Memory tab — total entries 4246 across 13 namespaces including code-map, guidance, patterns, tests, learnings, knowledge, tasklist, swarm-agents, memdiag, epic-state, swarm-topology, smoke, default" />
 </figure>
 
-<p>The fourth tab is a window into the MoFlo DB itself — the single <code>sql.js + HNSW</code> store at <code>.moflo/moflo.db</code> that backs memory, swarm coordination, learned routing, and AIDefence patterns. The summary cards show <strong>total entries</strong> and <strong>namespace count</strong>; the table below breaks it down by namespace.</p>
+<p>The fourth tab is a window into the MoFlo DB itself — the single <code>node:sqlite + HNSW</code> store at <code>.moflo/moflo.db</code> that backs memory, swarm coordination, learned routing, and AIDefence patterns. The summary cards show <strong>total entries</strong> and <strong>namespace count</strong>; the table below breaks it down by namespace.</p>
 
 <p>The numbers tell you a lot in a glance:</p>
 

--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -2,7 +2,7 @@
 
 > **Inlined into `@moflo/cli` by [#598](https://github.com/eric-cielo/moflo/issues/598)** (epic [#586](https://github.com/eric-cielo/moflo/issues/586) / [ADR-0001](../adr/0001-collapse-moflo-workspace-packages.md)). The `@moflo/memory` workspace package no longer exists — its contents live at `src/cli/memory/` and ship inside the `moflo` tarball.
 
-The unified memory service backed by sql.js + HNSW indexing (150x-12,500x faster than brute-force vector search per ADR-006/009). Provides `MofloDbAdapter`, `HnswLite`, `ControllerRegistry`, `UnifiedMemoryService`, `LearningBridge`, `MemoryGraph`, `RvfLearningStore`, `PersistentSonaCoordinator`, plus migration tooling and the auto-memory bridge (ADR-048/049).
+The unified memory service backed by node:sqlite + HNSW indexing (150x-12,500x faster than brute-force vector search per ADR-006/009). Provides `MofloDbAdapter`, `HnswLite`, `ControllerRegistry`, `UnifiedMemoryService`, `LearningBridge`, `MemoryGraph`, `RvfLearningStore`, `PersistentSonaCoordinator`, plus migration tooling and the auto-memory bridge (ADR-048/049).
 
 ## Where things live
 

--- a/harness/consumer-smoke/README.md
+++ b/harness/consumer-smoke/README.md
@@ -38,7 +38,7 @@ The harness has two entry points sharing the same pack/install pipeline:
 | Required deps | `required-deps` | `onnxruntime-node` and `@anush008/tokenizers` are present (embedding stack intact) |
 | CLI | `cli-version` | `flo --version` reports a semver |
 | CLI | `doctor` | `flo doctor --json` runs (exit 0 or 1) |
-| Memory | `memory-init` | `flo memory init` initializes the sql.js+HNSW store |
+| Memory | `memory-init` | `flo memory init` initializes the node:sqlite+HNSW store |
 | Memory | `memory-store/retrieve/search/list/delete` | CRUD round-trips |
 | Spell | `spell-list` | `flo spell list` runs (exit 0 or 1) |
 | MCP | `mcp-tools:moflodb` | `flo mcp tools` lists `moflodb_*` tools |

--- a/moflo.yaml
+++ b/moflo.yaml
@@ -45,15 +45,9 @@ auto_index:
 
 # Memory backend
 memory:
-  backend: sql.js
+  backend: node-sqlite
   embedding_model: Xenova/all-MiniLM-L6-v2
   namespace: default
-  # Phase 3 of epic #1078 — dogfood the node:sqlite backend alongside sql.js so
-  # any cross-engine divergence surfaces before the Phase 4 default flip.
-  # Mirrors every write to a sibling .moflo/moflo.shadow.db and compares reads;
-  # divergences land in .moflo/shadow-divergence.log. moflo's own repo only —
-  # consumers' moflo.yaml never declares this (default OFF).
-  shadow_read: true
 
 # Hook toggles (all on by default — disable to slim down)
 hooks:

--- a/src/cli/__tests__/doctor-checks-memory-access.test.ts
+++ b/src/cli/__tests__/doctor-checks-memory-access.test.ts
@@ -254,7 +254,7 @@ describe('doctor-checks-memory-access — #1111 HNSW-empty fallback', () => {
             namespace: input.namespace,
             hasEmbedding: true,
             embeddingDimensions: 384,
-            backend: 'sql.js + HNSW',
+            backend: 'node:sqlite + HNSW',
           };
         },
       },
@@ -262,7 +262,7 @@ describe('doctor-checks-memory-access — #1111 HNSW-empty fallback', () => {
         name: 'memory_search',
         // The race: store succeeded, but HNSW has 0 vectors so search
         // returns empty. Matches the production failure mode in #1111.
-        handler: async () => ({ results: [], total: 0, backend: 'HNSW + sql.js' }),
+        handler: async () => ({ results: [], total: 0, backend: 'node:sqlite + HNSW' }),
       },
       {
         name: 'memory_retrieve',
@@ -359,7 +359,7 @@ describe('doctor-checks-memory-access — #1120 stale-neighbor fallback', () => 
             namespace: input.namespace,
             hasEmbedding: true,
             embeddingDimensions: 384,
-            backend: 'sql.js + HNSW',
+            backend: 'node:sqlite + HNSW',
           };
         },
       },
@@ -376,7 +376,7 @@ describe('doctor-checks-memory-access — #1120 stale-neighbor fallback', () => 
             similarity: 0.3,
           }],
           total: 1,
-          backend: 'HNSW + sql.js',
+          backend: 'node:sqlite + HNSW',
         }),
       },
       {

--- a/src/cli/__tests__/hooks/guidance-provider.test.ts
+++ b/src/cli/__tests__/hooks/guidance-provider.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vite
 import { GuidanceProvider, type ClaudeHookOutput } from '../../hooks/reasoningbank/guidance-provider.js';
 import { ReasoningBank } from '../../hooks/reasoningbank/index.js';
 
-// ReasoningBank.initialize() loads AgentDB (sql.js + HNSW + Transformers);
+// ReasoningBank.initialize() loads AgentDB (node:sqlite + HNSW + Transformers);
 // the one-time native module boot can exceed 5s under Linux CI parallel load.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 

--- a/src/cli/__tests__/hooks/reasoningbank.test.ts
+++ b/src/cli/__tests__/hooks/reasoningbank.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { ReasoningBank, type GuidancePattern } from '../../hooks/reasoningbank/index.js';
 
-// ReasoningBank.initialize() loads AgentDB (sql.js + HNSW + Transformers);
+// ReasoningBank.initialize() loads AgentDB (node:sqlite + HNSW + Transformers);
 // the one-time native module boot can exceed 5s under Linux CI parallel load.
 vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
 

--- a/src/cli/__tests__/memory-tools-search-cosmetic.test.ts
+++ b/src/cli/__tests__/memory-tools-search-cosmetic.test.ts
@@ -63,6 +63,6 @@ describe('memory_search — cosmetic trims (#1053 S6)', () => {
   it('retains backend field (doctor dependency)', async () => {
     const tool = await getSearchTool();
     const result = await tool.handler({ query: 'q' }) as { backend: string };
-    expect(result.backend).toBe('HNSW + sql.js');
+    expect(result.backend).toBe('node:sqlite + HNSW');
   });
 });

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -115,7 +115,7 @@ const storeCommand: Command = {
 
     output.printInfo(`Storing in ${namespace}/${key}...`);
 
-    // Use direct sql.js storage with automatic embedding generation
+    // Use direct memory-backend storage with automatic embedding generation
     try {
       const { storeEntry } = await import('../memory/memory-initializer.js');
 
@@ -195,7 +195,7 @@ const retrieveCommand: Command = {
       return { success: false, exitCode: 1 };
     }
 
-    // Use sql.js directly for consistent data access
+    // Use the memory backend directly for consistent data access
     try {
       const { getEntry } = await import('../memory/memory-initializer.js');
       const result = await getEntry({ key, namespace });
@@ -335,7 +335,7 @@ const searchCommand: Command = {
     output.printInfo(`Searching: "${query}" (${searchType})`);
     output.writeln();
 
-    // Use direct sql.js search with vector similarity
+    // Use direct memory-backend search with vector similarity
     try {
       const { searchEntries } = await import('../memory/memory-initializer.js');
 
@@ -424,7 +424,7 @@ const listCommand: Command = {
     const namespace = ctx.flags.namespace as string;
     const limit = ctx.flags.limit as number;
 
-    // Use sql.js directly for consistent data access
+    // Use the memory backend directly for consistent data access
     try {
       const { listEntries } = await import('../memory/memory-initializer.js');
       const listResult = await listEntries({ namespace, limit, offset: 0 });
@@ -554,7 +554,7 @@ const deleteCommand: Command = {
       }
     }
 
-    // Use sql.js directly for consistent data access (Issue #980)
+    // Use the memory backend directly for consistent data access (Issue #980)
     try {
       const { deleteEntry } = await import('../memory/memory-initializer.js');
       const result = await deleteEntry({ key, namespace });
@@ -1204,10 +1204,10 @@ const importCommand: Command = {
   }
 };
 
-// Init subcommand - initialize memory database using sql.js
+// Init subcommand - initialize memory database using node:sqlite
 const initMemoryCommand: Command = {
   name: 'init',
-  description: 'Initialize memory database with sql.js (WASM SQLite) - includes vector embeddings, pattern learning, temporal decay',
+  description: 'Initialize memory database with node:sqlite (Node 22+ built-in) - includes vector embeddings, pattern learning, temporal decay',
   options: [
     {
       name: 'backend',
@@ -2995,7 +2995,7 @@ export const memoryCommand: Command = {
     output.writeln();
     output.writeln('Subcommands:');
     output.printList([
-      `${output.highlight('init')}       - Initialize memory database (sql.js)`,
+      `${output.highlight('init')}       - Initialize memory database (node:sqlite)`,
       `${output.highlight('store')}      - Store data in memory`,
       `${output.highlight('retrieve')}   - Retrieve data from memory`,
       `${output.highlight('search')}     - Semantic/vector search`,

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -46,7 +46,7 @@ export interface MofloConfig {
   };
 
   memory: {
-    backend: 'sql.js' | 'agentdb' | 'json';
+    backend: 'node-sqlite' | 'sql.js' | 'agentdb' | 'json';
     embedding_model: string;
     namespace: string;
   };
@@ -159,7 +159,7 @@ const DEFAULT_CONFIG: MofloConfig = {
     code_map: true,
   },
   memory: {
-    backend: 'sql.js',
+    backend: 'node-sqlite',
     embedding_model: 'Xenova/all-MiniLM-L6-v2',
     namespace: 'default',
   },
@@ -497,7 +497,7 @@ auto_index:
 
 # Memory backend
 memory:
-  backend: sql.js              # sql.js (WASM, no native deps) | agentdb | json
+  backend: node-sqlite         # node:sqlite (Node 22+ built-in) | agentdb | json — runtime always uses node:sqlite (Phase 5 #1084); this knob is informational only
   embedding_model: Xenova/all-MiniLM-L6-v2
   namespace: default
 

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -224,7 +224,7 @@ auto_index:
 
 # Memory backend
 memory:
-  backend: sql.js
+  backend: node-sqlite
   embedding_model: Xenova/all-MiniLM-L6-v2
   namespace: default
 

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -1,11 +1,9 @@
 /**
- * Memory MCP Tools for CLI - V3 with sql.js/HNSW Backend
+ * Memory MCP Tools for CLI — node:sqlite + HNSW backend
  *
- * UPGRADED: Now uses the advanced sql.js + HNSW backend for:
- * - 150x-12,500x faster semantic search
- * - Vector embeddings with cosine similarity
- * - Persistent SQLite storage (WASM)
- * - Backward compatible with legacy JSON storage (auto-migrates)
+ * Backed by Node's built-in `node:sqlite` engine (Phase 4 #1083 flipped the
+ * default; Phase 5 #1084 deleted the prior sql.js path) plus an HNSW vector
+ * index for semantic search. Auto-migrates legacy JSON stores on first use.
  *
  * @module v3/cli/mcp-tools/memory-tools
  */
@@ -14,6 +12,7 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from '
 import { join, resolve } from 'path';
 import type { MCPTool } from './types.js';
 import { GateService } from '../services/spell-gate.js';
+import { BACKEND_LABEL } from '../memory/database-provider.js';
 
 // Legacy JSON store interface (for migration)
 interface LegacyMemoryEntry {
@@ -192,7 +191,7 @@ function shapeRetrievedEntry(entry: MemoryEntryWithMeta): RetrievedEntry {
     hasEmbedding: entry.hasEmbedding,
     navigation: parseNavigation(entry.metadata, 'full'),
     found: true,
-    backend: 'sql.js + HNSW',
+    backend: BACKEND_LABEL,
   };
 }
 
@@ -285,7 +284,7 @@ async function ensureInitialized(): Promise<void> {
   if (hasLegacyStore()) {
     const legacyStore = loadLegacyStore();
     if (legacyStore && Object.keys(legacyStore.entries).length > 0) {
-      console.error('[MCP Memory] Migrating legacy JSON store to sql.js...');
+      console.error('[MCP Memory] Migrating legacy JSON store to node:sqlite...');
       let migrated = 0;
 
       for (const [key, entry] of Object.entries(legacyStore.entries)) {
@@ -313,7 +312,7 @@ async function ensureInitialized(): Promise<void> {
 export const memoryTools: MCPTool[] = [
   {
     name: 'memory_store',
-    description: 'Store a value in memory with vector embedding for semantic search (sql.js + HNSW backend). Upserts by default — pass upsert:false to fail on duplicate keys. Optional `metadata` lets chunk-row producers set the navigation fields (parentDoc, prevChunk, nextChunk, siblings, …) that `memory_get_neighbors` reads.',
+    description: 'Store a value in memory with vector embedding for semantic search (node:sqlite + HNSW backend). Upserts by default — pass upsert:false to fail on duplicate keys. Optional `metadata` lets chunk-row producers set the navigation fields (parentDoc, prevChunk, nextChunk, siblings, …) that `memory_get_neighbors` reads.',
     category: 'memory',
     inputSchema: {
       type: 'object',
@@ -376,7 +375,7 @@ export const memoryTools: MCPTool[] = [
           storedAt: new Date().toISOString(),
           hasEmbedding: !!result.embedding,
           embeddingDimensions: result.embedding?.dimensions || null,
-          backend: 'sql.js + HNSW',
+          backend: BACKEND_LABEL,
           storeTime: `${duration.toFixed(2)}ms`,
           error: result.error,
         };
@@ -504,7 +503,7 @@ export const memoryTools: MCPTool[] = [
           query,
           results,
           total: results.length,
-          backend: 'HNSW + sql.js',
+          backend: BACKEND_LABEL,
         };
       } catch (error) {
         return {
@@ -600,7 +599,7 @@ export const memoryTools: MCPTool[] = [
           include,
           neighbors,
           total: neighbors.length,
-          backend: 'sql.js + HNSW',
+          backend: BACKEND_LABEL,
         };
       } catch (error) {
         return {
@@ -648,7 +647,7 @@ export const memoryTools: MCPTool[] = [
           key,
           namespace,
           deleted,
-          backend: 'sql.js + HNSW',
+          backend: BACKEND_LABEL,
           ...(errorReason ? { error: errorReason } : {}),
         };
       } catch (error) {
@@ -704,7 +703,7 @@ export const memoryTools: MCPTool[] = [
           total: result.total,
           limit,
           offset,
-          backend: 'sql.js + HNSW',
+          backend: BACKEND_LABEL,
         };
       } catch (error) {
         return {
@@ -750,7 +749,7 @@ export const memoryTools: MCPTool[] = [
             ? `${((withEmbeddings / allEntries.total) * 100).toFixed(1)}%`
             : '0%',
           namespaces,
-          backend: 'sql.js + HNSW',
+          backend: BACKEND_LABEL,
           version: status.version || '3.0.0',
           features: status.features || {
             vectorEmbeddings: true,

--- a/src/cli/memory/auto-memory-bridge.ts
+++ b/src/cli/memory/auto-memory-bridge.ts
@@ -3,7 +3,7 @@
  *
  * Per ADR-048: Bridges Claude Code's auto memory (markdown files at
  * ~/.claude/projects/<project>/memory/) with claude-flow's unified memory
- * system (MofloDb: sql.js + HNSW).
+ * system (MofloDb: node:sqlite + HNSW).
  *
  * Auto memory files are human-readable markdown that Claude loads into its
  * system prompt. MEMORY.md (first 200 lines) is the entrypoint; topic files

--- a/src/cli/memory/controllers/attestation-log.ts
+++ b/src/cli/memory/controllers/attestation-log.ts
@@ -2,7 +2,7 @@
  * AttestationLog — moflo-owned append-only audit log (epic #464 Phase C2).
  *
  * Replaces `agentdb.AttestationLog`. Writes observability records into a
- * sql.js-backed table with a hash chain so tampering can be detected.
+ * SQLite table with a hash chain so tampering can be detected.
  *
  * Consumer surface (from src/cli/memory/memory-bridge.ts):
  *   - record({ operation, entryId, timestamp?, ...metadata })

--- a/src/cli/memory/controllers/causal-graph.ts
+++ b/src/cli/memory/controllers/causal-graph.ts
@@ -2,7 +2,7 @@
  * CausalGraph — moflo-owned causal edge store.
  *
  * Replaces `agentdb.CausalGraph.addEdge`. Stores typed edges between
- * memory-entry IDs in a sql.js-backed table with composite indexes so
+ * memory-entry IDs in a SQLite table with composite indexes so
  * CausalRecall's BFS walks don't hit a full scan on the relation filter.
  */
 

--- a/src/cli/memory/database-provider.ts
+++ b/src/cli/memory/database-provider.ts
@@ -34,6 +34,14 @@ import { SqliteBackend, SqliteBackendConfig } from './sqlite-backend.js';
 export type DatabaseProvider = 'sql.js' | 'node-sqlite' | 'json' | 'rvf' | 'auto';
 
 /**
+ * Canonical label returned in MCP `backend` fields and other consumer-visible
+ * surfaces. Single source of truth so a future engine swap is a one-line edit
+ * instead of an 8-site grep. Phase 5 (#1084) finalized node:sqlite as the
+ * only SQLite backend; the HNSW vector index sits on top.
+ */
+export const BACKEND_LABEL = 'node:sqlite + HNSW';
+
+/**
  * Database creation options
  */
 export interface DatabaseOptions {


### PR DESCRIPTION
## Summary

- Sweep stale `sql.js + HNSW` backend label everywhere it survived Phase 5 (#1084) — MCP responses, init defaults, shipped guidance, README, skills, docs. Single source of truth in new `BACKEND_LABEL` constant.
- File deep-dive analysis doc for #1145 (daemon port-3117 collision causes silent cross-project DB routing) at `docs/internal/1145-daemon-port-collision-analysis.md` — 11 stacked bugs mapped, fix strategy committed, recovery path for affected consumers documented.
- Diagnostics surfaced two issues filed alongside this PR (no code change here): #1144 (config-schema duplication cleanup) and #1145 (port collision — the critical one).

## Background

User asked why their consumer project (waxstack) saw Claude reporting "backend: sql.js + HNSW" even though Phase 5 had retired sql.js. Three independent MCP probes returned the same stale label, so the consumer-visible runtime literally claims sql.js is in use. The fix is a label sweep + config defaults refresh; the audit also surfaced the much-bigger #1145 routing bug while diagnosing why `memory_stats` was returning 0 entries.

## Why CHANGELOG.md is not touched

`CHANGELOG.md:130` is a historical entry recording when sql.js + HNSW was first introduced. It's accurate history, not a stale claim about current state — left intact. Same posture for `bin/lib/*.mjs` historical comments and `sqljs-migration-store.ts` (legitimately a sql.js-shape adapter for migration). Only stale CURRENT-state claims were rewritten.

## Test plan

- [x] `npm run build` green
- [x] `npm test` green: 8,831 tests passed across parallel + isolation passes
- [x] Targeted re-run of touched fixtures: `memory-tools-search-cosmetic.test.ts`, `doctor-checks-memory-access.test.ts`, `hooks/{guidance-provider,reasoningbank}.test.ts` — all green
- [x] Grep audit for `sql.js + HNSW` / `HNSW + sql.js` / `backend: 'sql.js'` outside historical / explicitly-retained contexts — clean

## Issues filed alongside

- #1144 — `chore: collapse config-adapter / V3Config / SystemConfig duplication — single MofloConfig source of truth`
- #1145 — `critical: fixed daemon port (3117) causes silent cross-project DB routing` (with deep analysis in `docs/internal/1145-daemon-port-collision-analysis.md`)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
