### PR TITLE
fix(daemon): per-project port allocation + identity check (#1145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to MoFlo are documented here. Pre-2026-03 entries below desc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed — Daemon port collision (#1145, CRITICAL)
+
+Pre-#1145, moflo's daemon HTTP server defaulted to a fixed port (3117). The server retried 3117→3126 on `EADDRINUSE`; the client always POSTed to 3117. When two moflo-using projects ran daemons concurrently on the same machine, the second project's clients routed to the first project's daemon — silently. `flo memory stats`, `flo memory list`, `memory_search`, MCP `memory_store`, `flo memory store/delete`, swarm persistence, aidefence, and write-through-adapter all crossed projects.
+
+#### What changed
+
+- New shared port resolver `src/cli/services/daemon-port.ts` (JS twin at `bin/lib/daemon-port.mjs`). Both server bind site and client RPC route through `resolveProjectPort(projectRoot)` — deterministic `33000 + sha256(path) % 1000` so every project gets its own port.
+- `.moflo/daemon.lock` gained a `port` field. Server stamps the actually-bound port after `listen()`; clients read it to discover the daemon without guessing.
+- New `GET /api/health` endpoint on the daemon returns `{status, projectRoot, pid, version, uptimeMs}`. Clients probe it on every reachability check; a confirmed `projectRoot` mismatch downgrades the call to direct-SQL (the path that's been provably correct) and emits ONE stderr warn per mismatched port.
+- Daemon now hard-fails if the dashboard can't bind any candidate port — pre-#1145 the daemon stayed alive doing internal-worker-only work while HTTP was dead.
+- New healer subcheck: `flo healer --fix -c daemon-identity` (alias `identity`). Detects identity mismatches, kills the local daemon, clears the lock, respawns on the per-project port.
+- Regression guard at `tests/system/no-fixed-3117-port.test.ts` rejects any new shipped code that references the legacy literal outside the central resolver.
+
+#### Compatibility
+
+- `MOFLO_DAEMON_PORT` env override still wins. Consumers pinning the env keep the pre-#1145 behavior.
+- Clients running against pre-#1145 daemons (no `/api/health`, no lock-file `port`) fall through to `LEGACY_DEFAULT_PORT` (3117) — no breakage during the upgrade window.
+- Daemons running against pre-#1145 clients keep working; the new port is just announced through the lock file the old client will ignore.
+
+#### Data-integrity advisory
+
+moflo versions ≤4.10.7 had a daemon-routing bug (#1145) where two moflo-using projects on the same machine could silently cross-write each other's databases during any overlap window. If you ran `flo memory store`, MCP `memory_store`, or `flo swarm` across multiple projects concurrently, audit `.moflo/moflo.db` in each project for foreign entries (especially in the `learnings`, `default`, `swarm-*`, and `tasklist` namespaces — indexer-populated namespaces like `guidance`, `code-map`, `tests`, `patterns` are safe because they bypass HTTP). See `docs/internal/1145-daemon-port-collision-analysis.md` §10.2 for the manual reconciliation procedure.
+
 ## [3.5.0] - 2026-02-27
 
 ### Ruflo v3.5 — First Major Stable Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,36 @@
-## ⚠ MoFlo is a library shipped to other projects — READ FIRST, every change
+## ⚠ Rule #1 — All shipped code MUST be cross-platform (Linux + macOS + Windows)
+
+**Hard requirement, no exceptions.** Consumers run moflo on Windows dev boxes, macOS laptops, and Linux CI runners. Any code that ships in `bin/`, `src/cli/`, `.claude/scripts/`, or `node_modules/moflo/` MUST work identically on all three. The smoke harness runs on all three CI platforms specifically to catch divergence.
+
+**Before any change, audit it against the cross-platform checklist:**
+
+1. **Paths** — use `path.join`, `path.sep`, `path.resolve`. NEVER hardcode `/` or `\`. NEVER hardcode `/tmp`, `/usr/local`, `C:\\Users`, etc.
+2. **Symlinks** — POSIX has them; Windows mostly doesn't. If you compare two paths for identity, `fs.realpathSync` BOTH sides first (otherwise `/var/folders/...` ≠ `/private/var/folders/...` on macOS — see #1145).
+3. **Case sensitivity** — POSIX FS is case-sensitive; macOS APFS + Windows NTFS are case-insensitive by default. Don't write `Foo.ts` and `foo.ts` in the same directory.
+4. **Line endings** — files written by moflo MUST use platform-appropriate EOL or be marked `text=auto` in `.gitattributes`. Tests that hash file contents must normalize.
+5. **Shell commands** — `bash`/`grep`/`sed`/`cat`/`find` don't exist on Windows out of the box. Use Node primitives (`fs`, `child_process` with `spawn` not shell, `Glob`/`Grep` tools) instead of shelling out. If you MUST shell, branch on `process.platform`.
+6. **Process introspection** — `tasklist`/`wmic`/`Get-CimInstance` on Windows vs `ps`/`/proc/<pid>/cmdline` on POSIX. See `daemon-lock.ts:isDaemonProcess*` for the right shape.
+7. **Spawning daemons** — Windows requires `shell: true` + quoted strings (Node 24 DEP0190); POSIX uses `detached: true`. See `commands/daemon.ts:startBackgroundDaemon`.
+8. **Tempdir + Windows port reservations** — `os.tmpdir()` is platform-correct; ports 49152-65535 are reserved on Windows (EACCES) — use 40000-44999 in tests.
+9. **`rm`/`cp`/`mkdir`** in spell bash steps — Windows lacks these on PATH. Use `node -e` with `fs`/`os` for file ops in cross-platform spells.
+
+**Verify before pushing — don't trust your local OS:**
+
+- The smoke harness (`harness/consumer-smoke/run.mjs`) covers all three platforms in CI. Watch macOS + Ubuntu runs, not just Windows.
+- `tests/system/` runs cross-platform; `tests/bin/` has explicit Windows + POSIX branches.
+- If your local OS is Windows, mentally simulate the POSIX path (symlinks, case-sensitivity, missing `tasklist`). If POSIX, simulate Windows.
+
+**Concrete examples of what cross-platform misses look like in practice:**
+
+- **#1145 follow-up (this session)** — `normalizeProjectRoot` didn't `realpathSync` → macOS daemon resolved `/var/folders/...` → `/private/var/folders/...` while client saw the unresolved path → identity check false-positived → smoke failed on macOS + Ubuntu, passed on Windows. Shipped because verification was Windows-only.
+- **`feedback_spell_bash_minimal_path.md`** — spell bash steps on Windows lack `mkdir`/`rm`/`cp` on PATH; use `node -e` with fs/os.
+- **`feedback_docker_sandbox_git_safe_directory.md`** — `git config --global safe.directory` gets overridden by bind-mounted `.gitconfig`; must use `--system`.
+
+See `feedback_cross_platform_mandatory.md` (auto-memory) for the running list.
+
+---
+
+## ⚠ Rule #2 — MoFlo is a library shipped to other projects — READ FIRST, every change
 
 **This is an open-source library.** The package is installed as a `devDependency` into consumer projects to make Claude Code more effective in those projects. It is NOT a standalone application — every change you make ships to N consumers via `npm install moflo` and runs from their `node_modules/moflo/...` on their machines.
 

--- a/bin/lib/daemon-port.mjs
+++ b/bin/lib/daemon-port.mjs
@@ -1,0 +1,66 @@
+/**
+ * Pure-JS counterpart to src/cli/services/daemon-port.ts.
+ *
+ * Lives in bin/lib because session-start-launcher.mjs and other bin/ scripts
+ * run before any TS compilation has happened. The TS file is the canonical
+ * API; this file MUST stay algorithmically identical (asserted by
+ * `tests/system/daemon-port-twin.test.ts`).
+ *
+ * See `src/cli/services/daemon-port.ts` for the full doc + history.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const PORT_RANGE_BASE = 33000;
+export const PORT_RANGE_SIZE = 1000;
+export const LEGACY_DEFAULT_PORT = 3117;
+
+export function readEnvPortOverride() {
+  const raw = process.env.MOFLO_DAEMON_PORT;
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1 || n > 65535) return null;
+  return n;
+}
+
+export function resolveProjectPort(projectRoot) {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return envPort;
+  const hash = createHash('sha256').update(projectRoot).digest();
+  return PORT_RANGE_BASE + (hash.readUInt16BE(0) % PORT_RANGE_SIZE);
+}
+
+export function resolveClientPort(projectRoot) {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return envPort;
+
+  try {
+    const lockFile = join(projectRoot, '.moflo', 'daemon.lock');
+    if (existsSync(lockFile)) {
+      const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
+      const lockPort = typeof lock?.port === 'number' ? lock.port : null;
+      if (lockPort && Number.isFinite(lockPort) && lockPort > 0 && lockPort < 65536) {
+        return lockPort;
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  return resolveProjectPort(projectRoot);
+}
+
+export function serverPortCandidates(projectRoot, maxAttempts = 10) {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return [envPort];
+
+  const base = resolveProjectPort(projectRoot);
+  const attempts = Math.min(Math.max(1, maxAttempts), PORT_RANGE_SIZE);
+  const ports = [];
+  for (let i = 0; i < attempts; i++) {
+    const candidate = PORT_RANGE_BASE + ((base - PORT_RANGE_BASE + i) % PORT_RANGE_SIZE);
+    ports.push(candidate);
+  }
+  return ports;
+}

--- a/src/cli/__tests__/commands/daemon-port-resolution.test.ts
+++ b/src/cli/__tests__/commands/daemon-port-resolution.test.ts
@@ -8,20 +8,20 @@ import { describe, it, expect } from 'vitest';
 import { resolveDashboardPort } from '../../commands/daemon.js';
 import { DEFAULT_DASHBOARD_PORT } from '../../services/daemon-dashboard.js';
 
-describe('resolveDashboardPort (#1067)', () => {
-  it('returns DEFAULT_DASHBOARD_PORT when neither flag nor env is set', () => {
+describe('resolveDashboardPort (#1067 / #1145)', () => {
+  it('returns DEFAULT_DASHBOARD_PORT when neither flag nor env is set (not explicit)', () => {
     const r = resolveDashboardPort(undefined, undefined);
-    expect(r).toEqual({ ok: true, port: DEFAULT_DASHBOARD_PORT });
+    expect(r).toEqual({ ok: true, port: DEFAULT_DASHBOARD_PORT, explicit: false });
   });
 
-  it('honors MOFLO_DAEMON_PORT env when --dashboard-port flag is absent', () => {
+  it('honors MOFLO_DAEMON_PORT env when --dashboard-port flag is absent (explicit)', () => {
     const r = resolveDashboardPort(undefined, '3217');
-    expect(r).toEqual({ ok: true, port: 3217 });
+    expect(r).toEqual({ ok: true, port: 3217, explicit: true });
   });
 
-  it('--dashboard-port flag wins over MOFLO_DAEMON_PORT env', () => {
+  it('--dashboard-port flag wins over MOFLO_DAEMON_PORT env (explicit)', () => {
     const r = resolveDashboardPort('4000', '3217');
-    expect(r).toEqual({ ok: true, port: 4000 });
+    expect(r).toEqual({ ok: true, port: 4000, explicit: true });
   });
 
   it('rejects invalid --dashboard-port flag value', () => {
@@ -47,7 +47,7 @@ describe('resolveDashboardPort (#1067)', () => {
   });
 
   it('accepts port 1 and 65535 (range edges)', () => {
-    expect(resolveDashboardPort('1', undefined)).toEqual({ ok: true, port: 1 });
-    expect(resolveDashboardPort('65535', undefined)).toEqual({ ok: true, port: 65535 });
+    expect(resolveDashboardPort('1', undefined)).toEqual({ ok: true, port: 1, explicit: true });
+    expect(resolveDashboardPort('65535', undefined)).toEqual({ ok: true, port: 65535, explicit: true });
   });
 });

--- a/src/cli/__tests__/daemon-dashboard-1145.test.ts
+++ b/src/cli/__tests__/daemon-dashboard-1145.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Dashboard tests for #1145 — `/api/health` identity endpoint, per-project
+ * port allocation, lock-file port stamping, hard-fail on bind exhaustion.
+ *
+ * Hermetic: uses in-process mocks for the WorkerDaemon and skips real
+ * memory init. Each test picks a random port in a high range so we never
+ * collide with anything else on the machine.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import http from 'node:http';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+// Mock memory-initializer so startDashboard doesn't drag in real DB code.
+vi.mock('../memory/memory-initializer.js', () => ({
+  getNamespaceCounts: vi.fn().mockResolvedValue({ namespaces: {}, total: 0 }),
+  searchEntries: vi.fn().mockResolvedValue({ success: true, results: [], searchTime: 0 }),
+  getEntry: vi.fn().mockResolvedValue({ success: true, found: false }),
+  storeEntry: vi.fn().mockResolvedValue({ success: true }),
+  listEntries: vi.fn().mockResolvedValue({ success: true, entries: [], total: 0 }),
+  initializeMemoryDatabase: vi.fn(),
+  checkMemoryInitialization: vi.fn(),
+}));
+
+import {
+  startDashboard,
+  type DashboardHandle,
+} from '../services/daemon-dashboard.js';
+import {
+  acquireDaemonLock,
+  releaseDaemonLock,
+  getDaemonLockPayload,
+} from '../services/daemon-lock.js';
+
+function makeDaemon(): any {
+  return {
+    getStatus: () => ({
+      running: true,
+      pid: process.pid,
+      startedAt: new Date(Date.now() - 5_000),
+      workers: new Map(),
+      config: {
+        maxConcurrent: 1,
+        workerTimeoutMs: 1000,
+        resourceThresholds: { maxCpuLoad: 4, minFreeMemoryPercent: 10 },
+        workers: [],
+      },
+    }),
+    getScheduler: () => null,
+  };
+}
+
+async function getJson(port: number, path: string): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get({ host: '127.0.0.1', port, path, timeout: 2000 }, (res) => {
+      let buf = '';
+      res.setEncoding('utf8');
+      res.on('data', (c: string) => buf += c);
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode ?? 0, body: JSON.parse(buf) }); }
+        catch { resolve({ status: res.statusCode ?? 0, body: buf }); }
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+  });
+}
+
+const PRIOR_TRUST = process.env.MOFLO_TEST_TRUST_DAEMON_PID;
+const PRIOR_ENV = process.env.MOFLO_DAEMON_PORT;
+
+const handles: DashboardHandle[] = [];
+const tmpRoots: string[] = [];
+
+beforeEach(() => {
+  process.env.MOFLO_TEST_TRUST_DAEMON_PID = '1';
+  delete process.env.MOFLO_DAEMON_PORT;
+});
+
+afterEach(async () => {
+  for (const h of handles.splice(0)) {
+    try { await h.stop(); } catch { /* ignore */ }
+  }
+  for (const root of tmpRoots.splice(0)) {
+    try { releaseDaemonLock(root, process.pid, true); } catch { /* ignore */ }
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+  if (PRIOR_TRUST != null) process.env.MOFLO_TEST_TRUST_DAEMON_PID = PRIOR_TRUST;
+  else delete process.env.MOFLO_TEST_TRUST_DAEMON_PID;
+  if (PRIOR_ENV != null) process.env.MOFLO_DAEMON_PORT = PRIOR_ENV;
+});
+
+function makeProjectRoot(): string {
+  const root = join(tmpdir(), `dashboard-1145-${randomUUID()}`);
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  tmpRoots.push(root);
+  return root;
+}
+
+describe('GET /api/health (#1145)', () => {
+  it('returns 200 with projectRoot, pid, version, uptimeMs', async () => {
+    const root = makeProjectRoot();
+    const port = 45000 + Math.floor(Math.random() * 100);
+    const handle = await startDashboard(makeDaemon(), { port, projectRoot: root });
+    handles.push(handle);
+
+    const { status, body } = await getJson(handle.port, '/api/health');
+    expect(status).toBe(200);
+    expect(body.status).toBe('ok');
+    expect(body.projectRoot).toBe(root);
+    expect(body.pid).toBe(process.pid);
+    expect(typeof body.uptimeMs).toBe('number');
+    expect(body.uptimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('reports the requesting cwd when projectRoot opt is omitted', async () => {
+    const port = 46000 + Math.floor(Math.random() * 100);
+    const handle = await startDashboard(makeDaemon(), { port });
+    handles.push(handle);
+
+    const { status, body } = await getJson(handle.port, '/api/health');
+    expect(status).toBe(200);
+    expect(typeof body.projectRoot).toBe('string');
+    expect(body.projectRoot.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Per-project port allocation (#1145)', () => {
+  it('two dashboards rooted at different paths bind successfully', async () => {
+    const rootA = makeProjectRoot();
+    const rootB = makeProjectRoot();
+
+    // No port pinned — both should auto-resolve to their per-project
+    // deterministic port (or fall through to the next candidate if the
+    // dev daemon happens to own one).
+    const handleA = await startDashboard(makeDaemon(), { projectRoot: rootA });
+    handles.push(handleA);
+    const handleB = await startDashboard(makeDaemon(), { projectRoot: rootB });
+    handles.push(handleB);
+
+    expect(handleA.port).not.toBe(handleB.port);
+    expect(handleA.port).toBeGreaterThanOrEqual(33000);
+    expect(handleA.port).toBeLessThan(34000);
+    expect(handleB.port).toBeGreaterThanOrEqual(33000);
+    expect(handleB.port).toBeLessThan(34000);
+
+    // Each daemon's /api/health reports its own root.
+    const healthA = await getJson(handleA.port, '/api/health');
+    const healthB = await getJson(handleB.port, '/api/health');
+    expect(healthA.body.projectRoot).toBe(rootA);
+    expect(healthB.body.projectRoot).toBe(rootB);
+  });
+
+  it('stamps the bound port into .moflo/daemon.lock', async () => {
+    const root = makeProjectRoot();
+    // Acquire the lock first so writeLockPort has something to stamp.
+    acquireDaemonLock(root);
+
+    const handle = await startDashboard(makeDaemon(), { projectRoot: root });
+    handles.push(handle);
+
+    const payload = getDaemonLockPayload(root);
+    expect(payload).not.toBeNull();
+    expect(payload?.port).toBe(handle.port);
+  });
+});
+
+describe('Bind exhaustion (#1145 §9.4)', () => {
+  it('throws when the explicitly-pinned port is in use', async () => {
+    const port = 47000 + Math.floor(Math.random() * 100);
+    // First server claims the port.
+    const blocker = http.createServer((_, res) => res.end('blocker'));
+    await new Promise<void>((resolve, reject) => {
+      blocker.on('error', reject);
+      blocker.listen(port, '127.0.0.1', () => resolve());
+    });
+
+    try {
+      await expect(
+        startDashboard(makeDaemon(), { port }),
+      ).rejects.toThrow(/EADDRINUSE|in use|all dashboard ports/i);
+    } finally {
+      await new Promise<void>((r) => blocker.close(() => r()));
+    }
+  });
+});

--- a/src/cli/__tests__/memory/daemon-identity-mismatch.test.ts
+++ b/src/cli/__tests__/memory/daemon-identity-mismatch.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Client-side identity check tests for #1145.
+ *
+ * Spins up a fake daemon HTTP server that reports a `projectRoot` in its
+ * `/api/health` response, and verifies that:
+ *   - When `projectRoot` matches the client's `findProjectRoot()`, the
+ *     client routes through it (returns `routed: true`).
+ *   - When it mismatches, the client refuses (`routed: false`), emits a
+ *     single stderr line per mismatched port, and downstream callers fall
+ *     through to direct-SQL.
+ *   - Legacy daemons that 404 on `/api/health` still get routed to (the
+ *     port-discovery + lock-file primary defence is sufficient).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import http from 'node:http';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+import {
+  _resetForTest,
+  tryDaemonList,
+  isDaemonAvailable,
+} from '../../memory/daemon-write-client.js';
+
+interface FakeDaemon {
+  port: number;
+  stop: () => Promise<void>;
+}
+
+async function spawnFakeDaemon(opts: {
+  projectRoot?: string;
+  healthStatus?: number; // 200 (with body) / 404 (legacy)
+  port: number;
+}): Promise<FakeDaemon> {
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? '';
+    if (url === '/api/health') {
+      if (opts.healthStatus === 404) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Not found' }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'ok',
+        projectRoot: opts.projectRoot ?? '/some/foreign/project',
+        pid: 12345,
+        version: '4.10.7',
+        uptimeMs: 1000,
+      }));
+      return;
+    }
+    if (url === '/api/status') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ running: true }));
+      return;
+    }
+    if (req.method === 'POST' && url === '/api/memory/list') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, entries: [], total: 42 }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(opts.port, '127.0.0.1', () => resolve());
+  });
+
+  return {
+    port: opts.port,
+    stop: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+const PRIOR_ENV = process.env.MOFLO_DAEMON_PORT;
+const PRIOR_PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR;
+const PRIOR_IS_DAEMON = process.env.MOFLO_IS_DAEMON;
+
+let cleanup: Array<() => Promise<void>> = [];
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  _resetForTest();
+  cleanup = [];
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((() => true) as any);
+  // Make sure we're not "in" the daemon — otherwise isDaemonAvailable returns false.
+  delete process.env.MOFLO_IS_DAEMON;
+});
+
+afterEach(async () => {
+  for (const c of cleanup) await c();
+  stderrSpy.mockRestore();
+  _resetForTest();
+  if (PRIOR_ENV != null) process.env.MOFLO_DAEMON_PORT = PRIOR_ENV;
+  else delete process.env.MOFLO_DAEMON_PORT;
+  if (PRIOR_PROJECT_DIR != null) process.env.CLAUDE_PROJECT_DIR = PRIOR_PROJECT_DIR;
+  else delete process.env.CLAUDE_PROJECT_DIR;
+  if (PRIOR_IS_DAEMON != null) process.env.MOFLO_IS_DAEMON = PRIOR_IS_DAEMON;
+});
+
+function makeProjectRoot(): string {
+  const root = join(tmpdir(), `identity-mismatch-${randomUUID()}`);
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  // CLAUDE.md + package.json so findProjectRoot anchors here.
+  writeFileSync(join(root, 'CLAUDE.md'), '# test\n');
+  writeFileSync(join(root, 'package.json'), '{"name":"test"}');
+  return root;
+}
+
+function setProjectRoot(root: string): void {
+  // findProjectRoot honors CLAUDE_PROJECT_DIR as the high-priority anchor.
+  process.env.CLAUDE_PROJECT_DIR = root;
+}
+
+describe('isDaemonAvailable with identity check (#1145)', () => {
+  it('returns true when daemon reports matching projectRoot', async () => {
+    const root = makeProjectRoot();
+    setProjectRoot(root);
+    const port = 40000 + Math.floor(Math.random() * 1000);
+    process.env.MOFLO_DAEMON_PORT = String(port);
+
+    const daemon = await spawnFakeDaemon({ port, projectRoot: root });
+    cleanup.push(daemon.stop);
+
+    expect(await isDaemonAvailable()).toBe(true);
+  });
+
+  it('returns false on projectRoot mismatch + emits stderr warn for the mismatched port', async () => {
+    const root = makeProjectRoot();
+    setProjectRoot(root);
+    const port = 41000 + Math.floor(Math.random() * 1000);
+    process.env.MOFLO_DAEMON_PORT = String(port);
+
+    const daemon = await spawnFakeDaemon({
+      port,
+      projectRoot: '/some/foreign/project',
+    });
+    cleanup.push(daemon.stop);
+
+    expect(await isDaemonAvailable()).toBe(false);
+
+    const writes = stderrSpy.mock.calls.flatMap((c) => [c[0] as string]);
+    // Filter to warns for OUR port so a parallel test pointing at a
+    // different fake daemon can't leak in.
+    const portWarns = writes.filter(
+      (s) => typeof s === 'string' && new RegExp(`daemon at 127\\.0\\.0\\.1:${port}\\b`).test(s),
+    );
+    expect(portWarns.length).toBe(1);
+    expect(portWarns[0]).toMatch(/claims project '\/some\/foreign\/project'/);
+
+    // Reset health cache and probe again — _resetForTest clears the
+    // module-level "warned ports" set as part of the test seam, so the
+    // warn fires once more. (Production bound is one-per-port-per-process.)
+    _resetForTest();
+    stderrSpy.mockClear();
+    expect(await isDaemonAvailable()).toBe(false);
+    const writes2 = stderrSpy.mock.calls.flatMap((c) => [c[0] as string]);
+    const portWarns2 = writes2.filter(
+      (s) => typeof s === 'string' && new RegExp(`daemon at 127\\.0\\.0\\.1:${port}\\b`).test(s),
+    );
+    expect(portWarns2.length).toBe(1);
+  });
+
+  it('treats 404 on /api/health as a legacy daemon (routes)', async () => {
+    const root = makeProjectRoot();
+    setProjectRoot(root);
+    const port = 42000 + Math.floor(Math.random() * 1000);
+    process.env.MOFLO_DAEMON_PORT = String(port);
+
+    const daemon = await spawnFakeDaemon({
+      port,
+      healthStatus: 404,
+    });
+    cleanup.push(daemon.stop);
+
+    // Legacy daemon — port-discovery is the primary defence; identity
+    // check abstains and lets the routing through. This avoids breaking
+    // every consumer's first request after upgrading the client but
+    // before the daemon restarts.
+    expect(await isDaemonAvailable()).toBe(true);
+  });
+
+  it('tryDaemonList routes through identity-matched daemon', async () => {
+    const root = makeProjectRoot();
+    setProjectRoot(root);
+    const port = 43000 + Math.floor(Math.random() * 1000);
+    process.env.MOFLO_DAEMON_PORT = String(port);
+
+    const daemon = await spawnFakeDaemon({ port, projectRoot: root });
+    cleanup.push(daemon.stop);
+
+    const result = await tryDaemonList({ limit: 10 });
+    expect(result.routed).toBe(true);
+    expect(result.data?.total).toBe(42);
+  });
+
+  it('tryDaemonList refuses to route through identity-mismatched daemon', async () => {
+    const root = makeProjectRoot();
+    setProjectRoot(root);
+    const port = 44000 + Math.floor(Math.random() * 1000);
+    process.env.MOFLO_DAEMON_PORT = String(port);
+
+    const daemon = await spawnFakeDaemon({ port, projectRoot: '/elsewhere' });
+    cleanup.push(daemon.stop);
+
+    const result = await tryDaemonList({ limit: 10 });
+    expect(result.routed).toBe(false);
+  });
+});

--- a/src/cli/__tests__/memory/daemon-write-client.test.ts
+++ b/src/cli/__tests__/memory/daemon-write-client.test.ts
@@ -369,6 +369,10 @@ describe('daemon-write-client', () => {
     let invoked = 0;
     fake.setHandler((req, res, _body) => {
       if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      // #1145 — identity probe is best-effort; failure mode is "treat as
+      // legacy-no-health" and proceed. Excluded from the store-attempt
+      // count below.
+      if (req.url === '/api/health') { res.writeHead(404); res.end(); return; }
       invoked++;
       // Hold the connection open beyond the 100ms timeout
       setTimeout(() => { res.writeHead(200); res.end('{}'); }, 500);

--- a/src/cli/__tests__/services/daemon-lock-port.test.ts
+++ b/src/cli/__tests__/services/daemon-lock-port.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the lock-file `port` field (#1145).
+ *
+ * Verifies:
+ *   - `writeLockPort` stamps the port onto a lock the current PID owns
+ *   - It refuses to overwrite a lock owned by a different PID
+ *   - Idempotent: calling with the same port twice is a no-op
+ *   - `transferDaemonLock` preserves the port across PID transfers
+ *   - `getDaemonLockPayload` surfaces the port to readers
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+import {
+  acquireDaemonLock,
+  releaseDaemonLock,
+  writeLockPort,
+  transferDaemonLock,
+  lockPath,
+} from '../../services/daemon-lock.js';
+
+let tmp: string;
+const PRIOR_TRUST = process.env.MOFLO_TEST_TRUST_DAEMON_PID;
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `daemon-lock-port-${randomUUID()}`);
+  mkdirSync(join(tmp, '.moflo'), { recursive: true });
+  // Bypass platform process-introspection — these tests use synthetic PIDs.
+  process.env.MOFLO_TEST_TRUST_DAEMON_PID = '1';
+});
+
+afterEach(() => {
+  if (PRIOR_TRUST != null) process.env.MOFLO_TEST_TRUST_DAEMON_PID = PRIOR_TRUST;
+  else delete process.env.MOFLO_TEST_TRUST_DAEMON_PID;
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('writeLockPort', () => {
+  it('stamps port onto a lock owned by the current PID', () => {
+    const acquired = acquireDaemonLock(tmp);
+    expect(acquired.acquired).toBe(true);
+
+    const stamped = writeLockPort(tmp, 33421);
+    expect(stamped).toBe(true);
+
+    const raw = readFileSync(lockPath(tmp), 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.port).toBe(33421);
+    expect(parsed.pid).toBe(process.pid);
+  });
+
+  it('returns false (no-op) when lock is owned by a different PID', () => {
+    // Manually write a lock with a different PID — claim it's alive via
+    // the test bypass.
+    writeFileSync(
+      lockPath(tmp),
+      JSON.stringify({ pid: 99999, startedAt: Date.now(), label: 'moflo-daemon' }),
+    );
+    const stamped = writeLockPort(tmp, 33421);
+    expect(stamped).toBe(false);
+    // Lock content unchanged.
+    const parsed = JSON.parse(readFileSync(lockPath(tmp), 'utf-8'));
+    expect(parsed.port).toBeUndefined();
+  });
+
+  it('returns false when lock is absent', () => {
+    expect(writeLockPort(tmp, 33421)).toBe(false);
+  });
+
+  it('idempotent — same port twice', () => {
+    acquireDaemonLock(tmp);
+    expect(writeLockPort(tmp, 33421)).toBe(true);
+    expect(writeLockPort(tmp, 33421)).toBe(true);
+  });
+
+  it('rejects invalid ports', () => {
+    acquireDaemonLock(tmp);
+    expect(writeLockPort(tmp, 0)).toBe(false);
+    expect(writeLockPort(tmp, -1)).toBe(false);
+    expect(writeLockPort(tmp, 70000)).toBe(false);
+    expect(writeLockPort(tmp, NaN)).toBe(false);
+  });
+});
+
+describe('transferDaemonLock preserves port', () => {
+  it('keeps the port field across PID transfer', () => {
+    acquireDaemonLock(tmp);
+    writeLockPort(tmp, 33500);
+
+    const transferred = transferDaemonLock(tmp, 88888);
+    expect(transferred).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(lockPath(tmp), 'utf-8'));
+    expect(parsed.pid).toBe(88888);
+    expect(parsed.port).toBe(33500);
+
+    // Cleanup — release as the new PID.
+    releaseDaemonLock(tmp, 88888, true);
+  });
+
+  it('transfer without prior port leaves port absent (backward-compat)', () => {
+    acquireDaemonLock(tmp);
+    const transferred = transferDaemonLock(tmp, 88888);
+    expect(transferred).toBe(true);
+    const parsed = JSON.parse(readFileSync(lockPath(tmp), 'utf-8'));
+    expect(parsed.port).toBeUndefined();
+    releaseDaemonLock(tmp, 88888, true);
+  });
+});

--- a/src/cli/__tests__/services/daemon-port.test.ts
+++ b/src/cli/__tests__/services/daemon-port.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for `src/cli/services/daemon-port.ts` (#1145).
+ *
+ * Pure-function tests — no daemon spin-up. Covers:
+ *   - Env override precedence (`MOFLO_DAEMON_PORT`)
+ *   - Deterministic hash → port range
+ *   - Lock-file `port` field discovery
+ *   - Server candidate ordering + wrap behavior
+ *   - JS twin (`bin/lib/daemon-port.mjs`) algorithmic parity
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+import {
+  PORT_RANGE_BASE,
+  PORT_RANGE_SIZE,
+  LEGACY_DEFAULT_PORT,
+  resolveProjectPort,
+  resolveClientPort,
+  serverPortCandidates,
+  readEnvPortOverride,
+} from '../../services/daemon-port.js';
+
+const PRIOR_ENV = process.env.MOFLO_DAEMON_PORT;
+
+beforeEach(() => { delete process.env.MOFLO_DAEMON_PORT; });
+afterEach(() => {
+  if (PRIOR_ENV != null) process.env.MOFLO_DAEMON_PORT = PRIOR_ENV;
+  else delete process.env.MOFLO_DAEMON_PORT;
+});
+
+describe('resolveProjectPort', () => {
+  it('returns a port in [33000, 34000)', () => {
+    const port = resolveProjectPort('/some/project');
+    expect(port).toBeGreaterThanOrEqual(PORT_RANGE_BASE);
+    expect(port).toBeLessThan(PORT_RANGE_BASE + PORT_RANGE_SIZE);
+  });
+
+  it('is deterministic — same input → same output', () => {
+    const a = resolveProjectPort('/path/to/foo');
+    const b = resolveProjectPort('/path/to/foo');
+    expect(a).toBe(b);
+  });
+
+  it('produces different ports for different roots', () => {
+    // Hash collisions in a 1000-port range are possible — pick paths that
+    // we've verified avoid them. If this becomes flaky, the algorithm
+    // changed and the JS-twin test will catch it too.
+    const a = resolveProjectPort('/project-a');
+    const b = resolveProjectPort('/project-b');
+    const c = resolveProjectPort('/project-c-totally-distinct');
+    // At least one pair must differ.
+    expect(new Set([a, b, c]).size).toBeGreaterThan(1);
+  });
+
+  it('honors MOFLO_DAEMON_PORT env override', () => {
+    process.env.MOFLO_DAEMON_PORT = '54321';
+    expect(resolveProjectPort('/any/path')).toBe(54321);
+  });
+
+  it('ignores malformed env override and falls back to deterministic', () => {
+    process.env.MOFLO_DAEMON_PORT = 'not-a-port';
+    const port = resolveProjectPort('/some/path');
+    expect(port).toBeGreaterThanOrEqual(PORT_RANGE_BASE);
+    expect(port).toBeLessThan(PORT_RANGE_BASE + PORT_RANGE_SIZE);
+  });
+
+  it('rejects env values outside 1-65535', () => {
+    process.env.MOFLO_DAEMON_PORT = '70000';
+    expect(readEnvPortOverride()).toBeNull();
+    process.env.MOFLO_DAEMON_PORT = '0';
+    expect(readEnvPortOverride()).toBeNull();
+    process.env.MOFLO_DAEMON_PORT = '-5';
+    expect(readEnvPortOverride()).toBeNull();
+  });
+});
+
+describe('resolveClientPort', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = join(tmpdir(), `daemon-port-test-${randomUUID()}`);
+    mkdirSync(join(tmp, '.moflo'), { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('reads port from daemon.lock when present', () => {
+    writeFileSync(
+      join(tmp, '.moflo', 'daemon.lock'),
+      JSON.stringify({ pid: 12345, startedAt: Date.now(), label: 'moflo-daemon', port: 33421 }),
+    );
+    expect(resolveClientPort(tmp)).toBe(33421);
+  });
+
+  it('falls back to resolveProjectPort when lock has no port field', () => {
+    writeFileSync(
+      join(tmp, '.moflo', 'daemon.lock'),
+      JSON.stringify({ pid: 12345, startedAt: Date.now(), label: 'moflo-daemon' }),
+    );
+    expect(resolveClientPort(tmp)).toBe(resolveProjectPort(tmp));
+  });
+
+  it('falls back when lock is corrupt', () => {
+    writeFileSync(join(tmp, '.moflo', 'daemon.lock'), '{ not valid json');
+    expect(resolveClientPort(tmp)).toBe(resolveProjectPort(tmp));
+  });
+
+  it('falls back when lock is absent', () => {
+    expect(resolveClientPort(tmp)).toBe(resolveProjectPort(tmp));
+  });
+
+  it('env override beats lock-file port', () => {
+    process.env.MOFLO_DAEMON_PORT = '40000';
+    writeFileSync(
+      join(tmp, '.moflo', 'daemon.lock'),
+      JSON.stringify({ pid: 1, startedAt: 1, label: 'moflo-daemon', port: 33333 }),
+    );
+    expect(resolveClientPort(tmp)).toBe(40000);
+  });
+
+  it('rejects malformed port in lock', () => {
+    writeFileSync(
+      join(tmp, '.moflo', 'daemon.lock'),
+      JSON.stringify({ pid: 1, startedAt: 1, label: 'moflo-daemon', port: 99999 }),
+    );
+    // 99999 is > 65535, so it falls back to deterministic
+    expect(resolveClientPort(tmp)).toBe(resolveProjectPort(tmp));
+  });
+});
+
+describe('serverPortCandidates', () => {
+  it('returns deterministic port first, then offsets', () => {
+    const ports = serverPortCandidates('/some/project', 5);
+    expect(ports.length).toBe(5);
+    expect(ports[0]).toBe(resolveProjectPort('/some/project'));
+    // Each successive port is adjacent (modulo wrap).
+    for (let i = 1; i < ports.length; i++) {
+      const expected = PORT_RANGE_BASE + ((ports[0] - PORT_RANGE_BASE + i) % PORT_RANGE_SIZE);
+      expect(ports[i]).toBe(expected);
+    }
+  });
+
+  it('honors env override — collapses to single candidate', () => {
+    process.env.MOFLO_DAEMON_PORT = '12345';
+    expect(serverPortCandidates('/anywhere', 10)).toEqual([12345]);
+  });
+
+  it('caps attempts at PORT_RANGE_SIZE', () => {
+    const ports = serverPortCandidates('/x', 2000);
+    expect(ports.length).toBe(PORT_RANGE_SIZE);
+  });
+
+  it('all candidates stay in [33000, 34000)', () => {
+    const ports = serverPortCandidates('/y', 100);
+    for (const p of ports) {
+      expect(p).toBeGreaterThanOrEqual(PORT_RANGE_BASE);
+      expect(p).toBeLessThan(PORT_RANGE_BASE + PORT_RANGE_SIZE);
+    }
+  });
+});
+
+describe('LEGACY_DEFAULT_PORT', () => {
+  it('is 3117 (pre-#1145 default — read-only fallback)', () => {
+    expect(LEGACY_DEFAULT_PORT).toBe(3117);
+  });
+});
+
+describe('JS twin parity (bin/lib/daemon-port.mjs)', () => {
+  it('produces the same port as the TS resolver', async () => {
+    // Dynamic import so vitest doesn't try to type-check the JS twin.
+    const jsTwin = await import('../../../../bin/lib/daemon-port.mjs');
+    const testPaths = [
+      '/project-a',
+      '/project-b-unique',
+      'C:\\Users\\eric\\Projects\\moflo',
+      '/Users/eric/Projects/motailz/code',
+    ];
+    for (const p of testPaths) {
+      expect(jsTwin.resolveProjectPort(p)).toBe(resolveProjectPort(p));
+    }
+  });
+
+  it('JS twin exports same range constants', async () => {
+    const jsTwin = await import('../../../../bin/lib/daemon-port.mjs');
+    expect(jsTwin.PORT_RANGE_BASE).toBe(PORT_RANGE_BASE);
+    expect(jsTwin.PORT_RANGE_SIZE).toBe(PORT_RANGE_SIZE);
+    expect(jsTwin.LEGACY_DEFAULT_PORT).toBe(LEGACY_DEFAULT_PORT);
+  });
+});

--- a/src/cli/__tests__/services/daemon-port.test.ts
+++ b/src/cli/__tests__/services/daemon-port.test.ts
@@ -172,6 +172,48 @@ describe('LEGACY_DEFAULT_PORT', () => {
   });
 });
 
+describe('normalizeProjectRoot (#1145 follow-up — macOS/Ubuntu symlink false-positive)', () => {
+  it('resolves symlinks before comparing', async () => {
+    const { normalizeProjectRoot } = await import('../../services/daemon-port.js');
+    const { mkdtempSync, symlinkSync, rmSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const { tmpdir } = await import('node:os');
+
+    // POSIX: realpath through a symlink. Skip on Windows where symlink
+    // creation requires admin (test would silently passthrough anyway).
+    if (process.platform === 'win32') return;
+
+    const realDir = mkdtempSync(join(tmpdir(), 'realpath-test-'));
+    const linkDir = `${realDir}-link`;
+    try {
+      symlinkSync(realDir, linkDir);
+      // Same project, accessed via two paths — must normalize equal.
+      expect(normalizeProjectRoot(realDir)).toBe(normalizeProjectRoot(linkDir));
+    } finally {
+      try { rmSync(linkDir, { force: true }); } catch { /* ignore */ }
+      try { rmSync(realDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('falls back to input on non-existent paths (never throws)', async () => {
+    const { normalizeProjectRoot } = await import('../../services/daemon-port.js');
+    const nonexistent = '/this/path/does/not/exist/' + Math.random();
+    // Should return the input (lowercased on Windows) without throwing.
+    const result = normalizeProjectRoot(nonexistent);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('lowercases on Windows for case-insensitive FS', async () => {
+    const { normalizeProjectRoot } = await import('../../services/daemon-port.js');
+    if (process.platform !== 'win32') return;
+    // Use a known-existent path so realpath succeeds; assert casing.
+    const upper = process.cwd().toUpperCase();
+    const lower = process.cwd().toLowerCase();
+    expect(normalizeProjectRoot(upper)).toBe(normalizeProjectRoot(lower));
+  });
+});
+
 describe('JS twin parity (bin/lib/daemon-port.mjs)', () => {
   it('produces the same port as the TS resolver', async () => {
     // Dynamic import so vitest doesn't try to type-check the JS twin.

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -37,15 +37,15 @@ import { errorDetail } from '../shared/utils/error-detail.js';
 export function resolveDashboardPort(
   flagValue: string | undefined,
   envValue: string | undefined,
-): { ok: true; port: number } | { ok: false; error: string } {
+): { ok: true; port: number; explicit: boolean } | { ok: false; error: string } {
   const source = flagValue ?? envValue;
-  if (!source) return { ok: true, port: DEFAULT_DASHBOARD_PORT };
+  if (!source) return { ok: true, port: DEFAULT_DASHBOARD_PORT, explicit: false };
   const parsed = parseInt(source, 10);
   if (isNaN(parsed) || parsed < 1 || parsed > 65535) {
     const label = flagValue ? 'dashboard port' : 'MOFLO_DAEMON_PORT';
     return { ok: false, error: `Invalid ${label}: ${source} (must be 1-65535)` };
   }
-  return { ok: true, port: parsed };
+  return { ok: true, port: parsed, explicit: true };
 }
 
 // Start daemon subcommand
@@ -85,6 +85,7 @@ const startCommand: Command = {
       return { success: false, exitCode: 1 };
     }
     const dashboardPort = portResult.port;
+    const dashboardPortExplicit = portResult.explicit;
 
     // Parse resource threshold overrides from CLI flags
     const config: Partial<DaemonConfig> = {};
@@ -120,7 +121,14 @@ const startCommand: Command = {
 
     // Background mode (default): fork a detached process
     if (!foreground) {
-      return startBackgroundDaemon(projectRoot, quiet, rawMaxCpu, rawMinMem, dashboardPort, noDashboard);
+      return startBackgroundDaemon(
+        projectRoot,
+        quiet,
+        rawMaxCpu,
+        rawMinMem,
+        dashboardPortExplicit ? dashboardPort : undefined,
+        noDashboard,
+      );
     }
 
     // Foreground mode: run in current process (blocks terminal)
@@ -169,7 +177,7 @@ const startCommand: Command = {
         spinner.succeed('Worker daemon started (foreground mode)');
 
         const { dashboard } = await attachDaemonServices(daemon, {
-          projectRoot, noDashboard, dashboardPort, verbose: true,
+          projectRoot, noDashboard, dashboardPort, dashboardPortExplicit, verbose: true,
         });
 
         output.writeln();
@@ -233,7 +241,7 @@ const startCommand: Command = {
         await new Promise(() => {}); // Never resolves - daemon runs until killed
       } else {
         const daemon = await startDaemon(projectRoot, config);
-        await attachDaemonServices(daemon, { projectRoot, noDashboard, dashboardPort, verbose: false });
+        await attachDaemonServices(daemon, { projectRoot, noDashboard, dashboardPort, dashboardPortExplicit, verbose: false });
         await new Promise(() => {}); // Keep alive
       }
 
@@ -255,7 +263,18 @@ const startCommand: Command = {
  */
 async function attachDaemonServices(
   daemon: WorkerDaemon,
-  opts: { projectRoot: string; noDashboard?: boolean; dashboardPort: number; verbose: boolean },
+  opts: {
+    projectRoot: string;
+    noDashboard?: boolean;
+    dashboardPort: number;
+    /**
+     * True when the caller pinned the port via `--dashboard-port` or
+     * `MOFLO_DAEMON_PORT`. When false, the dashboard picks a deterministic
+     * per-project port via `serverPortCandidates` (#1145).
+     */
+    dashboardPortExplicit?: boolean;
+    verbose: boolean;
+  },
 ): Promise<{ dashboard: DashboardHandle | null; memory: MemoryAccessor | null }> {
   const logWarn = (msg: string) => opts.verbose
     ? output.printWarning(msg)
@@ -275,13 +294,23 @@ async function attachDaemonServices(
   if (!opts.noDashboard) {
     try {
       dashboard = await startDashboard(daemon, {
-        port: opts.dashboardPort,
+        // Pass the resolved port only when the caller explicitly pinned it
+        // (CLI flag / env). Otherwise let startDashboard pick the
+        // deterministic per-project port via serverPortCandidates (#1145).
+        port: opts.dashboardPortExplicit ? opts.dashboardPort : undefined,
         memory,
         schedulerEnabledInConfig: schedulerConfig.enabled,
+        projectRoot: opts.projectRoot,
       });
       if (opts.verbose) output.printSuccess(`The Luminarium: http://localhost:${dashboard.port}`);
     } catch (err) {
-      logWarn(`The Luminarium failed to start: ${errorDetail(err)}`);
+      // #1145 §9.4 — hard-fail on bind exhaustion. Pre-#1145 we swallowed
+      // this; the daemon stayed alive doing worker-only work while clients
+      // routed to whichever daemon happened to be on the legacy default
+      // port. Re-throw so the spawn launcher sees a non-zero exit and the
+      // healer flags the failure instead of silently continuing.
+      logWarn(`The Luminarium failed to bind — daemon will exit so clients don't silently route to a foreign daemon: ${errorDetail(err)}`);
+      throw err;
     }
   }
 
@@ -392,10 +421,13 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean, maxCpu
   if (minFreeMemory && SPAWN_NUMERIC_RE.test(minFreeMemory)) {
     spawnArgs.push('--min-free-memory', minFreeMemory);
   }
-  // Forward dashboard flags
+  // Forward dashboard flags. With #1145 the foreground child resolves its
+  // own deterministic per-project port when no `--dashboard-port` flag is
+  // passed — only forward the flag when the caller explicitly pinned it
+  // (signaled by `dashboardPort` being defined here).
   if (noDashboard) {
     spawnArgs.push('--no-dashboard');
-  } else if (dashboardPort && dashboardPort !== DEFAULT_DASHBOARD_PORT) {
+  } else if (dashboardPort != null) {
     spawnArgs.push('--dashboard-port', String(dashboardPort));
   }
 
@@ -461,7 +493,13 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean, maxCpu
   if (!quiet) {
     output.printSuccess(`Daemon started in background (PID: ${pid})`);
     if (!noDashboard) {
-      output.printInfo(`The Luminarium: http://localhost:${dashboardPort ?? DEFAULT_DASHBOARD_PORT}`);
+      if (dashboardPort != null) {
+        output.printInfo(`The Luminarium: http://localhost:${dashboardPort}`);
+      } else {
+        // #1145 — port is project-deterministic and assigned at bind time;
+        // read it from .moflo/daemon.lock once the child finishes startup.
+        output.printInfo(`The Luminarium: see http://localhost:<port from .moflo/daemon.lock>`);
+      }
     }
     output.printInfo(`Logs: ${logFile}`);
     output.printInfo(`Stop with: claude-flow daemon stop`);

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -7,7 +7,13 @@
 import { existsSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import os from 'os';
-import { getDaemonLockHolder } from '../services/daemon-lock.js';
+import { getDaemonLockHolder, getDaemonLockPayload } from '../services/daemon-lock.js';
+import {
+  resolveClientPort,
+  LEGACY_DEFAULT_PORT,
+  probeDaemonHealth as probeDaemonHealthIdentity,
+  normalizeProjectRoot,
+} from '../services/daemon-port.js';
 import {
   legacyMemoryDbPath,
   memoryDbCandidatePaths,
@@ -114,6 +120,95 @@ export async function checkDaemonStatus(): Promise<HealthCheck> {
   } catch (e) {
     return { name: 'Daemon Status', status: 'warn', message: `Unable to check: ${errorDetail(e)}`, fix: 'claude-flow daemon status' };
   }
+}
+
+/**
+ * Daemon identity check (#1145).
+ *
+ * Reads `.moflo/daemon.lock` → probes `/api/health` on the recorded port →
+ * confirms the daemon's reported `projectRoot` matches `findProjectRoot()`.
+ * Catches the silent cross-project routing class where two moflo daemons
+ * (e.g. moflo-dev + a consumer) share a port and the client hits the wrong
+ * one.
+ *
+ * Status semantics:
+ *   - `pass` — no daemon (cleanly absent) OR identity matches.
+ *   - `warn` — daemon has no port in lock (pre-#1145 daemon; harmless if
+ *     no collision, but should be recycled to upgrade).
+ *   - `fail` — `/api/health` reports a different project. Routing is
+ *     polluted; the healer fix kills the foreign-identity daemon and
+ *     respawns the local one.
+ */
+export async function checkDaemonIdentity(cwd: string = process.cwd()): Promise<HealthCheck> {
+  const projectRoot = findProjectRoot({ cwd });
+  const payload = getDaemonLockPayload(projectRoot);
+
+  if (!payload) {
+    return {
+      name: 'Daemon Identity Match',
+      status: 'pass',
+      message: 'No daemon running (nothing to verify)',
+    };
+  }
+
+  // Lock present but no port field — pre-#1145 daemon. Identity check is
+  // best-effort; surface as warn so the user knows to recycle but don't
+  // hard-fail unless we can prove cross-project routing.
+  const portFromLock = payload.port;
+  const probePort = portFromLock ?? resolveClientPort(projectRoot);
+
+  if (!portFromLock) {
+    // Try the legacy default explicitly so consumers running an
+    // un-upgraded daemon still get a useful diagnostic.
+    const probe = await probeDaemonHealthIdentity(LEGACY_DEFAULT_PORT, 1500);
+    if (probe.kind === 'identity'
+        && normalizeProjectRoot(probe.projectRoot) !== normalizeProjectRoot(projectRoot)) {
+      return {
+        name: 'Daemon Identity Match',
+        status: 'fail',
+        message: `Daemon at 127.0.0.1:${LEGACY_DEFAULT_PORT} claims project '${probe.projectRoot}' — cross-project routing active`,
+        fix: 'flo healer --fix -c daemon-identity',
+      };
+    }
+    return {
+      name: 'Daemon Identity Match',
+      status: 'warn',
+      message: 'Daemon lock has no port field — pre-#1145 daemon; recycle to enable port discovery',
+      fix: 'flo healer --fix -c daemon-identity',
+    };
+  }
+
+  const probe = await probeDaemonHealthIdentity(probePort, 1500);
+  if (probe.kind === 'unreachable') {
+    return {
+      name: 'Daemon Identity Match',
+      status: 'warn',
+      message: `Daemon at 127.0.0.1:${probePort} unreachable on /api/health`,
+      fix: 'flo healer --fix -c daemon-identity',
+    };
+  }
+  if (probe.kind === 'legacy') {
+    return {
+      name: 'Daemon Identity Match',
+      status: 'warn',
+      message: `Daemon at 127.0.0.1:${probePort} has no /api/health (legacy) — recycle to upgrade`,
+      fix: 'flo healer --fix -c daemon-identity',
+    };
+  }
+  if (normalizeProjectRoot(probe.projectRoot) !== normalizeProjectRoot(projectRoot)) {
+    return {
+      name: 'Daemon Identity Match',
+      status: 'fail',
+      message: `Daemon at 127.0.0.1:${probePort} claims project '${probe.projectRoot}' but cwd is '${projectRoot}'`,
+      fix: 'flo healer --fix -c daemon-identity',
+    };
+  }
+
+  return {
+    name: 'Daemon Identity Match',
+    status: 'pass',
+    message: `OK (port ${probePort}, pid ${payload.pid})`,
+  };
 }
 
 export async function checkMemoryDatabase(): Promise<HealthCheck> {

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -183,6 +183,22 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
       return runFixCommand('npx moflo daemon start');
     },
+    // #1145 — daemon claims a different projectRoot than ours (or has no
+    // port in its lock so we can't verify). Same recycle pattern as version
+    // skew: SIGTERM the local daemon, clear the lock, respawn. Then the new
+    // daemon binds the per-project deterministic port and stamps it into
+    // the lock — clients can discover it without guessing.
+    'Daemon Identity Match': async () => {
+      const cwd = process.cwd();
+      const { getDaemonLockPayload } = await import('../services/daemon-lock.js');
+      const payload = getDaemonLockPayload(cwd);
+      if (payload?.pid && payload.pid > 0) {
+        try { process.kill(payload.pid, 'SIGTERM'); } catch { /* already dead */ }
+      }
+      const lockFile = join(cwd, '.moflo', 'daemon.lock');
+      try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
+      return runFixCommand('npx moflo daemon start');
+    },
     'Embedding Coverage Truth': async () => {
       // Same as the existing Embeddings fix — rebuild the cache by re-running
       // the embeddings pipeline. Routes through `npx moflo` so the consumer

--- a/src/cli/commands/doctor-registry.ts
+++ b/src/cli/commands/doctor-registry.ts
@@ -36,6 +36,7 @@ import {
 } from './doctor-checks-runtime.js';
 import {
   checkConfigFile,
+  checkDaemonIdentity,
   checkDaemonStatus,
   checkDaemonWriteRouting,
   checkMcpServers,
@@ -76,6 +77,7 @@ export const allChecks: CheckFn[] = [
   checkStatusLine,
   checkDaemonStatus,
   checkDaemonVersionSkew,
+  checkDaemonIdentity,
   checkDaemonWriteRouting,
   checkWritersAudit,
   checkMemoryDatabase,
@@ -136,6 +138,9 @@ export const componentMap: Record<string, CheckFn> = {
   'skew': checkDaemonVersionSkew,
   'daemon-write-routing': checkDaemonWriteRouting,
   'write-routing': checkDaemonWriteRouting,
+  'daemon-identity': checkDaemonIdentity,
+  'daemon-identity-match': checkDaemonIdentity,
+  'identity': checkDaemonIdentity,
   'writers-audit': checkWritersAudit,
   'writers': checkWritersAudit,
   'memory': checkMemoryDatabase,

--- a/src/cli/memory/daemon-write-client.ts
+++ b/src/cli/memory/daemon-write-client.ts
@@ -38,13 +38,25 @@
  */
 
 import * as http from 'node:http';
+import { findProjectRoot } from '../services/project-root.js';
+import {
+  resolveClientPort,
+  LEGACY_DEFAULT_PORT,
+  probeDaemonHealth as probeDaemonHealthIdentity,
+  normalizeProjectRoot,
+} from '../services/daemon-port.js';
 
 // ============================================================================
 // Constants
 // ============================================================================
 
-/** Default daemon HTTP port. Mirrors `DEFAULT_DASHBOARD_PORT` in daemon-dashboard.ts. */
-const DEFAULT_DAEMON_PORT = 3117;
+/**
+ * Read-only legacy default exported for tests; the actual port comes from
+ * `getDaemonPort()` which delegates to `resolveClientPort(findProjectRoot())`.
+ * Routes through `LEGACY_DEFAULT_PORT` so no literal port number lives in
+ * this file — see `daemon-port.ts` and the no-fixed-port regression guard.
+ */
+const DEFAULT_DAEMON_PORT = LEGACY_DEFAULT_PORT;
 
 /** HTTP timeout for ALL daemon requests (probe + write). Bounds the worst-case CLI hang. */
 const DAEMON_HTTP_TIMEOUT_MS = 100;
@@ -156,19 +168,37 @@ let configCache: { daemonEnabled: boolean; checkedAt: number } | null = null;
 export function _resetForTest(): void {
   healthCache = null;
   configCache = null;
+  identityCache = null;
+  _portCache = null;
+  _identityWarnedFor.clear();
 }
 
 // ============================================================================
 // Resolve daemon port (env override → moflo.yaml unused for v1 → default)
 // ============================================================================
 
+/**
+ * Resolve the daemon HTTP port for this project.
+ *
+ * Delegates to `resolveClientPort(findProjectRoot())`:
+ *   1. `MOFLO_DAEMON_PORT` env override (consumer pin)
+ *   2. `port` field in `<projectRoot>/.moflo/daemon.lock` (server records
+ *      the actual bound port after startup — #1145)
+ *   3. Deterministic per-project port `33000 + sha256(path)%1000`
+ *
+ * Cached per-process — the lock-file path doesn't change once a process is
+ * up. On a routed-failure the health cache is invalidated (which triggers
+ * the next port resolve), keeping the client honest about daemon location
+ * after a recycle.
+ */
+let _portCache: { port: number; projectRoot: string } | null = null;
+
 function getDaemonPort(): number {
-  const fromEnv = process.env.MOFLO_DAEMON_PORT;
-  if (fromEnv) {
-    const n = parseInt(fromEnv, 10);
-    if (Number.isFinite(n) && n > 0 && n < 65536) return n;
-  }
-  return DEFAULT_DAEMON_PORT;
+  const projectRoot = findProjectRoot();
+  if (_portCache && _portCache.projectRoot === projectRoot) return _portCache.port;
+  const port = resolveClientPort(projectRoot);
+  _portCache = { port, projectRoot };
+  return port;
 }
 
 // ============================================================================
@@ -198,9 +228,34 @@ async function isDaemonEnabledInConfig(): Promise<boolean> {
 // Health probe (cached) — GET /api/status
 // ============================================================================
 
+// ============================================================================
+// Identity check (#1145) — refuse to route to a daemon owning a different
+// project. Before this, the client trusted any daemon on the resolved port.
+// ============================================================================
+
+interface IdentityCache {
+  matches: boolean;
+  checkedAt: number;
+  /** What the daemon reported. Used in the stderr warn on mismatch. */
+  daemonProjectRoot?: string;
+  /** What we expected. Used in the stderr warn on mismatch. */
+  ourProjectRoot: string;
+}
+
+let identityCache: IdentityCache | null = null;
+
+/**
+ * Ports we've already warned about during this process — bounded by the
+ * number of distinct daemon ports a single client process can see in its
+ * lifetime (usually 1). Keeps the stderr noise to a single line per
+ * mismatched daemon per process.
+ */
+const _identityWarnedFor = new Set<number>();
+
 /**
  * Cached daemon health probe. Returns true iff the daemon's HTTP server
- * is reachable on `127.0.0.1:<port>` within {@link DAEMON_HTTP_TIMEOUT_MS}.
+ * is reachable on `127.0.0.1:<port>` within {@link DAEMON_HTTP_TIMEOUT_MS}
+ * AND its `/api/health` reports a `projectRoot` matching ours (#1145).
  *
  * Cache survives 5s in either direction — so a daemon that just came up
  * is missed for ≤5s, and a daemon that just died is incorrectly assumed
@@ -219,9 +274,85 @@ export async function isDaemonAvailable(): Promise<boolean> {
     return healthCache.available;
   }
 
-  const available = await probeDaemonHealth(getDaemonPort());
-  healthCache = { available, checkedAt: now };
-  return available;
+  const port = getDaemonPort();
+  const reachable = await probeDaemonHealth(port);
+  if (!reachable) {
+    healthCache = { available: false, checkedAt: now };
+    return false;
+  }
+
+  // 4) Identity check — daemon reachable but is it OUR daemon?
+  const identityOk = await isDaemonIdentityMatch(port);
+  healthCache = { available: identityOk, checkedAt: now };
+  return identityOk;
+}
+
+/**
+ * Probe `/api/health` and confirm the daemon's reported `projectRoot`
+ * matches ours. Caches the result for {@link HEALTH_CACHE_TTL_MS}.
+ *
+ * Mismatch consequence: this function returns `false`, the caller falls
+ * through to the direct-SQL path (the path that is provably correct, see
+ * the `MOFLO_DISABLE_DAEMON_ROUTING=1` reproducer in
+ * `docs/internal/1145-daemon-port-collision-analysis.md`), and we emit
+ * ONE stderr line per port per process so the user can see the wrong-
+ * project daemon is the problem.
+ *
+ * Tolerant of legacy daemons that don't expose `/api/health`: a 404 means
+ * the daemon predates #1145, so we trust the legacy port resolution (the
+ * client is presumably hitting the same project's daemon anyway) and
+ * return `true`. The lock-file port-discovery path is the primary
+ * collision defence; identity check is the safety net.
+ */
+async function isDaemonIdentityMatch(port: number): Promise<boolean> {
+  const now = Date.now();
+  const ourProjectRoot = findProjectRoot();
+
+  if (
+    identityCache &&
+    identityCache.ourProjectRoot === ourProjectRoot &&
+    (now - identityCache.checkedAt) < HEALTH_CACHE_TTL_MS
+  ) {
+    return identityCache.matches;
+  }
+
+  const probe = await probeDaemonHealthIdentity(port, DAEMON_HTTP_TIMEOUT_MS);
+  if (probe.kind === 'legacy' || probe.kind === 'unreachable') {
+    // No identity to compare — daemon either predates #1145 or the probe
+    // itself failed transport-side. Fall open: rely on port-discovery
+    // (lock file + deterministic hash) as the primary defence. Only a
+    // CONFIRMED mismatch blocks routing — that's the conservative safety
+    // net that doesn't break upgraded-client-against-legacy-daemon.
+    //
+    // Asymmetry with doctor's `checkDaemonIdentity`: the healer probes
+    // LEGACY_DEFAULT_PORT explicitly and flags a foreign legacy daemon
+    // as `fail`, while this hot path lets it through. That's intentional
+    // — the doctor runs on-demand for diagnostics, and live writes must
+    // not block when the cluster is mid-upgrade. The CHANGELOG migration
+    // window is the agreed remediation surface.
+    identityCache = { matches: true, checkedAt: now, ourProjectRoot };
+    return true;
+  }
+
+  const matches = normalizeProjectRoot(probe.projectRoot) === normalizeProjectRoot(ourProjectRoot);
+  identityCache = {
+    matches,
+    checkedAt: now,
+    ourProjectRoot,
+    daemonProjectRoot: probe.projectRoot,
+  };
+
+  if (!matches && !_identityWarnedFor.has(port)) {
+    _identityWarnedFor.add(port);
+    // One stderr line per mismatched daemon, ever. Quiet enough that scripts
+    // don't drown but loud enough that healer-class diagnostics surface it.
+    process.stderr.write(
+      `[moflo] daemon at 127.0.0.1:${port} claims project '${probe.projectRoot}' but cwd is '${ourProjectRoot}' — ` +
+      `using direct DB. Run flo healer --fix to repair daemon binding (#1145).\n`,
+    );
+  }
+
+  return matches;
 }
 
 function probeDaemonHealth(port: number): Promise<boolean> {
@@ -404,7 +535,14 @@ function postJson(path: string, body: unknown): Promise<DaemonWriteResult> {
       // On routed-failure, invalidate the health cache so the next call
       // re-probes and trips back to direct-write quickly when the daemon
       // is dying.
-      if (result.routed === false) healthCache = null;
+      if (result.routed === false) {
+        // Daemon recycled to a different port (post #1145 server restart)
+        // → invalidate the port cache too so the next call re-reads
+        // .moflo/daemon.lock. Otherwise we'd keep hammering a stale port.
+        healthCache = null;
+        identityCache = null;
+        _portCache = null;
+      }
       resolve(result);
     };
 
@@ -486,7 +624,14 @@ function postReadJson<T>(
     const finish = (result: DaemonReadResult<T>): void => {
       if (done) return;
       done = true;
-      if (result.routed === false) healthCache = null;
+      if (result.routed === false) {
+        // Daemon recycled to a different port (post #1145 server restart)
+        // → invalidate the port cache too so the next call re-reads
+        // .moflo/daemon.lock. Otherwise we'd keep hammering a stale port.
+        healthCache = null;
+        identityCache = null;
+        _portCache = null;
+      }
       resolve(result);
     };
 

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -29,14 +29,23 @@ import {
   matchMemoryRpcRoute,
 } from './daemon-memory-rpc.js';
 import { aggregateClaudeStats, emptyClaudeStatsShape } from './claude-stats.js';
+import { serverPortCandidates, LEGACY_DEFAULT_PORT } from './daemon-port.js';
+import { writeLockPort } from './daemon-lock.js';
+import { findProjectRoot } from './project-root.js';
+import { readOwnMofloVersion } from './daemon-lock.js';
 
 // ============================================================================
 // Types
 // ============================================================================
 
 export interface DashboardOptions {
-  /** Port to listen on (default: 3117). */
-  port: number;
+  /**
+   * Port to listen on. Treated as the first candidate; the server falls
+   * through to the project-deterministic range from `serverPortCandidates`
+   * on `EADDRINUSE`. When omitted, the resolver picks the deterministic
+   * port directly (#1145).
+   */
+  port?: number;
   /** Optional MemoryAccessor for namespace stats. */
   memory?: MemoryAccessor;
   /**
@@ -45,6 +54,12 @@ export interface DashboardOptions {
    * than the generic "not connected" placeholder.
    */
   schedulerEnabledInConfig?: boolean;
+  /**
+   * Absolute project root the daemon is serving. Stamped into
+   * `/api/health` so clients can verify they're hitting their own
+   * project's daemon (#1145). Defaults to `findProjectRoot()`.
+   */
+  projectRoot?: string;
 }
 
 export interface DashboardHandle {
@@ -56,7 +71,14 @@ export interface DashboardHandle {
   stop(): Promise<void>;
 }
 
-export const DEFAULT_DASHBOARD_PORT = 3117;
+/**
+ * Legacy default port retained as a re-export of {@link LEGACY_DEFAULT_PORT}
+ * for backward compat with existing importers (`commands/daemon.ts`,
+ * `__tests__/daemon-dashboard.test.ts`). The actual port a daemon binds is
+ * now resolved deterministically per project via `serverPortCandidates()` —
+ * see `daemon-port.ts` and `docs/internal/1145-daemon-port-collision-analysis.md`.
+ */
+export const DEFAULT_DASHBOARD_PORT = LEGACY_DEFAULT_PORT;
 
 /**
  * Process-wide promise for the shared MemoryAccessor. Memoized as a *promise*
@@ -164,6 +186,28 @@ export async function createDashboardMemoryAccessor(): Promise<MemoryAccessor> {
 
 function tryParseSafe(s: string): unknown {
   try { return JSON.parse(s); } catch { return s; }
+}
+
+/**
+ * Build the `/api/health` response (#1145).
+ *
+ * Identity payload — clients compare `projectRoot` against their own
+ * `findProjectRoot()` and refuse to route to this daemon on mismatch.
+ * Also surfaces `pid`, `version`, and `uptimeMs` for healer-class
+ * diagnostics and orphan-daemon detection.
+ *
+ * Read-only, no-auth, localhost-only (the dashboard binds 127.0.0.1).
+ */
+function handleHealth(daemon: WorkerDaemon, opts: DashboardOptions): object {
+  const status = daemon.getStatus();
+  const startedAt = status.startedAt instanceof Date ? status.startedAt : null;
+  return {
+    status: 'ok',
+    projectRoot: opts.projectRoot ?? findProjectRoot(),
+    pid: status.pid ?? process.pid,
+    version: readOwnMofloVersion() ?? null,
+    uptimeMs: startedAt ? Date.now() - startedAt.getTime() : 0,
+  };
 }
 
 function handleStatus(daemon: WorkerDaemon): object {
@@ -483,6 +527,10 @@ async function handleRequest(
 
     if (url === '/') {
       sendHtml(res, DASHBOARD_HTML);
+    } else if (url === '/api/health') {
+      // #1145 — identity probe. Clients use this to confirm they're talking
+      // to the daemon for their OWN project before routing memory ops here.
+      sendJson(res, 200, handleHealth(daemon, opts));
     } else if (url === '/api/status') {
       sendJson(res, 200, handleStatus(daemon));
     } else if (url === '/api/schedules') {
@@ -638,37 +686,69 @@ const MAX_PORT_ATTEMPTS = 10;
 /**
  * Start the dashboard HTTP server.
  *
- * Tries the requested port first, then falls back to port+1, port+2, ...
- * up to MAX_PORT_ATTEMPTS to avoid crashing the daemon when another
- * project's daemon already holds the default port.
+ * Port selection (#1145):
+ *   1. `opts.port`, if explicitly set (CLI `--dashboard-port` flag).
+ *   2. Otherwise `serverPortCandidates(projectRoot)` — deterministic per-
+ *      project port + collision-fallback range.
+ * Both honor `MOFLO_DAEMON_PORT` (collapses the candidate list to one).
  *
- * @param daemon - WorkerDaemon instance for status data
- * @param opts - Dashboard configuration
- * @returns A handle to stop the server (port reflects the actual bound port)
+ * On successful bind the bound port is stamped into `.moflo/daemon.lock`
+ * via `writeLockPort()` so clients can discover it without guessing.
+ *
+ * On bind exhaustion (every candidate in use) the server throws — the
+ * caller is expected to surface the failure rather than stay half-alive
+ * (the silent-trap pattern that produced #1145).
+ *
+ * @returns handle whose `.port` field reflects the actually bound port
  */
 export async function startDashboard(
   daemon: WorkerDaemon,
   opts: DashboardOptions,
 ): Promise<DashboardHandle> {
-  const basePort = opts.port;
+  const projectRoot = opts.projectRoot ?? findProjectRoot();
+  const candidates = buildBindCandidates(opts.port, projectRoot, MAX_PORT_ATTEMPTS);
 
-  for (let attempt = 0; attempt < MAX_PORT_ATTEMPTS; attempt++) {
-    const port = basePort + attempt;
+  let lastErr: unknown = null;
+  for (let i = 0; i < candidates.length; i++) {
+    const port = candidates[i];
     try {
-      const handle = await tryListenOnPort(daemon, opts, port);
+      const handle = await tryListenOnPort(daemon, { ...opts, projectRoot }, port);
+      // Stamp the bound port into the lock so clients discover us reliably.
+      // Best-effort: a missing/locked-by-another-pid lock means stamping
+      // is a no-op — the deterministic fallback still works.
+      try { writeLockPort(projectRoot, handle.port); } catch { /* ignore */ }
       return handle;
     } catch (err: unknown) {
+      lastErr = err;
       const code = err && typeof err === 'object' && 'code' in err ? (err as { code: string }).code : '';
-      if (code === 'EADDRINUSE' && attempt < MAX_PORT_ATTEMPTS - 1) {
-        // Port taken — try the next one
-        continue;
-      }
+      if (code === 'EADDRINUSE' && i < candidates.length - 1) continue;
       throw err;
     }
   }
 
-  // Should be unreachable, but satisfies the type checker
-  throw new Error(`All dashboard ports ${basePort}–${basePort + MAX_PORT_ATTEMPTS - 1} are in use`);
+  // Bind exhaustion — surface so the daemon can hard-fail (#1145 §9.4).
+  throw lastErr ?? new Error(
+    `All dashboard ports (${candidates[0]}…${candidates[candidates.length - 1]}) are in use`,
+  );
+}
+
+/**
+ * Build the ordered list of ports to try.
+ *
+ * When the caller pinned a port (CLI flag), respect it without any
+ * fallback — the consumer pinned it on purpose. When they didn't, use
+ * the deterministic per-project candidates so two projects never collide
+ * silently on a fixed default.
+ */
+function buildBindCandidates(
+  explicitPort: number | undefined,
+  projectRoot: string,
+  maxAttempts: number,
+): number[] {
+  if (typeof explicitPort === 'number' && explicitPort > 0 && explicitPort < 65536) {
+    return [explicitPort];
+  }
+  return serverPortCandidates(projectRoot, maxAttempts);
 }
 
 /**

--- a/src/cli/services/daemon-lock.ts
+++ b/src/cli/services/daemon-lock.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
+import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 
 export interface DaemonLockPayload {
   pid: number;
@@ -26,6 +27,15 @@ export interface DaemonLockPayload {
    * the same as a mismatch (recycle).
    */
   version?: string;
+  /**
+   * Actual port the daemon's HTTP server bound to. Added in #1145 so clients
+   * can discover the bound port from the lock file rather than guessing the
+   * fixed default (which produced silent cross-project routing when two
+   * moflo daemons collided). Stamped by `writeLockPort()` after a successful
+   * bind. Missing on locks written by pre-#1145 daemons; clients fall back
+   * to `resolveProjectPort()` then `LEGACY_DEFAULT_PORT`.
+   */
+  port?: number;
 }
 
 const LOCK_FILENAME = 'daemon.lock';
@@ -137,6 +147,49 @@ export function releaseDaemonLock(projectRoot: string, pid: number = process.pid
 }
 
 /**
+ * Stamp the daemon's bound HTTP port into the lock file (#1145).
+ *
+ * Called by `daemon-dashboard.startDashboard()` after a successful bind so
+ * clients can read the actual port (vs. guessing the fixed default and
+ * silently hitting another project's daemon).
+ *
+ * Best-effort by design:
+ *   - Missing lock → no-op (the daemon didn't acquire the lock; this is
+ *     a test or unusual startup path).
+ *   - Lock owned by a different PID → no-op (we don't overwrite locks we
+ *     don't own).
+ *   - Write failure → swallowed (the daemon still serves; clients fall
+ *     back to the deterministic port resolution).
+ *
+ * Returns `true` on a successful stamp, `false` otherwise. The boolean is
+ * informational — production callers don't branch on it.
+ */
+export function writeLockPort(
+  projectRoot: string,
+  port: number,
+  pid: number = process.pid,
+): boolean {
+  if (!Number.isFinite(port) || port < 1 || port > 65535) return false;
+  const lock = lockPath(projectRoot);
+  const existing = readLockPayload(lock);
+  if (!existing) return false;
+  if (existing.pid !== pid) return false;
+  if (existing.port === port) return true;
+
+  const updated: DaemonLockPayload = { ...existing, port };
+  try {
+    // Atomic write-then-rename: a client reading mid-write never sees a
+    // truncated JSON. The vulnerable window is precisely a re-stamp after
+    // a daemon recycle on a different port, when clients are likeliest
+    // to be probing the lock for the new port.
+    atomicWriteFileSync(lock, JSON.stringify(updated));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Atomically transfer the daemon lock to a new PID (e.g. parent → child).
  *
  * Overwrites the lock file in-place so there is no window where the lock
@@ -159,6 +212,9 @@ export function transferDaemonLock(
     startedAt: Date.now(),
     label: LOCK_LABEL,
     version: existing.version ?? readOwnMofloVersion(),
+    // Preserve the port field across PID transfers (#1145) — the child
+    // process inherits the parent's binding, so the port is still valid.
+    ...(existing.port != null ? { port: existing.port } : {}),
   };
 
   try {

--- a/src/cli/services/daemon-port.ts
+++ b/src/cli/services/daemon-port.ts
@@ -1,0 +1,235 @@
+/**
+ * Daemon port resolution — single source of truth for the moflo daemon's
+ * HTTP port.
+ *
+ * Before #1145, `DEFAULT_DASHBOARD_PORT` in `daemon-dashboard.ts` and
+ * `DEFAULT_DAEMON_PORT` in `daemon-write-client.ts` were two separate `3117`
+ * literals. The server tried 3117 → 3126 on `EADDRINUSE`; the client always
+ * POSTed to 3117. When a second moflo project's daemon bound 3118+, that
+ * project's clients still hit 3117 → silent cross-project read/write
+ * routing. See `docs/internal/1145-daemon-port-collision-analysis.md`.
+ *
+ * This module collapses both literals into one resolver. Every entry point
+ * MUST go through `resolveProjectPort()` (or read the `port` field a
+ * already-bound daemon recorded in `.moflo/daemon.lock`).
+ *
+ * Resolution precedence — server and client agree:
+ *   1. `MOFLO_DAEMON_PORT` env override (consumer pin / smoke harness — wins)
+ *   2. Lock-file `port` field (client-only — server WRITES this after bind)
+ *   3. `resolveProjectPort(projectRoot)` — sha256(path) → 33000+(hash%1000)
+ *   4. `LEGACY_DEFAULT_PORT` (3117) — read-only fallback for ancient locks
+ *      with no port field and no env override; warns once via stderr
+ *
+ * @module cli/services/daemon-port
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as http from 'node:http';
+
+/**
+ * Deterministic port range. 33000-33999 — clear of every common dev-server
+ * port (3000, 3001, 4000, 5000, 5173, 8000, 8080), every well-known service
+ * (≤ 1024), and the moflo legacy default (3117). Collision probability across
+ * N active projects is ~N/1000; the identity check (`isDaemonIdentityMatch`)
+ * is the safety net when collisions do hit.
+ */
+export const PORT_RANGE_BASE = 33000;
+export const PORT_RANGE_SIZE = 1000;
+
+/**
+ * Legacy default port — used by daemons that haven't been upgraded past
+ * 4.10.7 and locks that never recorded a port field. Kept as a read-only
+ * fallback so a fresh client probing an old daemon still finds it; clients
+ * that fall through to this path emit a one-time deprecation warn.
+ *
+ * NEW code must NEVER reference this constant outside `daemon-port.ts`. The
+ * regression guard at `tests/system/no-fixed-3117.test.ts` enforces.
+ */
+export const LEGACY_DEFAULT_PORT = 3117;
+
+/**
+ * Resolve the canonical port for a given project root.
+ *
+ * Pure function — no I/O. Same project path → same port across daemon
+ * restarts, across processes, across machines (the hash is deterministic).
+ *
+ * @param projectRoot absolute path to the project root (use `findProjectRoot()`)
+ * @returns port in `[PORT_RANGE_BASE, PORT_RANGE_BASE + PORT_RANGE_SIZE)`
+ */
+export function resolveProjectPort(projectRoot: string): number {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return envPort;
+  const hash = createHash('sha256').update(projectRoot).digest();
+  return PORT_RANGE_BASE + (hash.readUInt16BE(0) % PORT_RANGE_SIZE);
+}
+
+/**
+ * Read `MOFLO_DAEMON_PORT` from the environment. Returns the parsed port
+ * (1-65535) or `null` if unset/invalid.
+ *
+ * Exported so callers can short-circuit lock-file reads when the env is
+ * pinned — useful in the smoke harness and CI where the env is the
+ * authoritative pin.
+ */
+export function readEnvPortOverride(): number | null {
+  const raw = process.env.MOFLO_DAEMON_PORT;
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1 || n > 65535) return null;
+  return n;
+}
+
+/**
+ * Lock-file payload subset relevant to port resolution. Mirrors
+ * `DaemonLockPayload` in `daemon-lock.ts` without importing it (this module
+ * is loaded from `bin/` JS twins; avoid the TS-only import cycle).
+ */
+interface LockPortShape {
+  port?: number;
+  pid?: number;
+}
+
+/**
+ * Resolve the daemon port a CLIENT should connect to for a given project.
+ *
+ * Reads `.moflo/daemon.lock` to discover the actual bound port — if the
+ * daemon collided with another project in its deterministic-range bucket
+ * and the dashboard retry loop bumped it forward, the lock reflects reality
+ * and the client follows. Falls back to `resolveProjectPort` when the lock
+ * is absent (daemon not yet started), the lock has no `port` field (old
+ * daemon predating #1145), or the port reads as invalid.
+ *
+ * Never throws — every I/O failure degrades to the deterministic fallback.
+ */
+export function resolveClientPort(projectRoot: string): number {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return envPort;
+
+  try {
+    const lockFile = join(projectRoot, '.moflo', 'daemon.lock');
+    if (existsSync(lockFile)) {
+      const raw = readFileSync(lockFile, 'utf-8');
+      const lock = JSON.parse(raw) as LockPortShape;
+      const lockPort = typeof lock?.port === 'number' ? lock.port : null;
+      if (lockPort && Number.isFinite(lockPort) && lockPort > 0 && lockPort < 65536) {
+        return lockPort;
+      }
+    }
+  } catch {
+    // Corrupt or unreadable lock — fall through to deterministic port.
+  }
+
+  return resolveProjectPort(projectRoot);
+}
+
+/**
+ * Build the list of ports the SERVER should try, in order, when starting
+ * the daemon. First entry is the deterministic port; the rest are the
+ * collision-fallback range. Capped at `PORT_RANGE_SIZE` so the loop can
+ * never wrap past the bucket.
+ *
+ * If the env override is set, the list collapses to that single port —
+ * the consumer pinned it on purpose; respect their choice and hard-fail
+ * if it's already in use.
+ */
+export function serverPortCandidates(projectRoot: string, maxAttempts = 10): number[] {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return [envPort];
+
+  const base = resolveProjectPort(projectRoot);
+  const attempts = Math.min(Math.max(1, maxAttempts), PORT_RANGE_SIZE);
+  const ports: number[] = [];
+  for (let i = 0; i < attempts; i++) {
+    ports.push(PORT_RANGE_BASE + ((base - PORT_RANGE_BASE + i) % PORT_RANGE_SIZE));
+  }
+  return ports;
+}
+
+// ============================================================================
+// Identity probe — shared by client + healer (#1145)
+// ============================================================================
+
+/**
+ * Case-normalize project root paths so `C:\Users\...` and `c:\users\...`
+ * compare equal on Windows. POSIX is case-sensitive — pass through.
+ */
+export function normalizeProjectRoot(p: string): string {
+  return process.platform === 'win32' ? p.toLowerCase() : p;
+}
+
+/**
+ * Result of probing a daemon's `/api/health` endpoint.
+ *
+ *   - `{ kind: 'identity', projectRoot }` — daemon answered with a project
+ *     root the caller should compare against its own `findProjectRoot()`.
+ *   - `{ kind: 'legacy' }` — daemon predates #1145 (404 on `/api/health`)
+ *     OR answered 200 but without a recognisable identity field. Caller
+ *     should fall through to port-based discovery (the primary defence).
+ *   - `{ kind: 'unreachable' }` — transport error / timeout. Caller's
+ *     reachability layer already established the daemon's liveness; this
+ *     means identity is unknowable, not that the daemon is down.
+ */
+export type DaemonIdentityProbe =
+  | { kind: 'identity'; projectRoot: string }
+  | { kind: 'legacy' }
+  | { kind: 'unreachable' };
+
+/**
+ * Send `GET /api/health` to `127.0.0.1:<port>` and parse the daemon's
+ * identity payload. Never throws — every failure mode maps to a
+ * `DaemonIdentityProbe` variant.
+ *
+ * Shared by `daemon-write-client.ts` (per-request safety net) and
+ * `doctor-checks-config.ts` (`checkDaemonIdentity` subcheck).
+ */
+export function probeDaemonHealth(
+  port: number,
+  timeoutMs: number,
+): Promise<DaemonIdentityProbe> {
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (r: DaemonIdentityProbe): void => {
+      if (done) return;
+      done = true;
+      resolve(r);
+    };
+    const req = http.get(
+      { host: '127.0.0.1', port, path: '/api/health', timeout: timeoutMs },
+      (res) => {
+        const status = res.statusCode ?? 0;
+        if (status === 404) {
+          res.resume();
+          finish({ kind: 'legacy' });
+          return;
+        }
+        if (status !== 200) {
+          res.resume();
+          finish({ kind: 'unreachable' });
+          return;
+        }
+        let buf = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk: string) => { buf += chunk; });
+        res.on('end', () => {
+          try {
+            const data = JSON.parse(buf);
+            if (typeof data?.projectRoot === 'string' && data.projectRoot.length > 0) {
+              finish({ kind: 'identity', projectRoot: data.projectRoot });
+              return;
+            }
+            // 200 but no identity field — pre-#1145 daemon that 200s on
+            // every URL. Same handling as a 404.
+            finish({ kind: 'legacy' });
+          } catch {
+            finish({ kind: 'legacy' });
+          }
+        });
+        res.on('error', () => finish({ kind: 'unreachable' }));
+      },
+    );
+    req.on('error', () => finish({ kind: 'unreachable' }));
+    req.on('timeout', () => { req.destroy(); finish({ kind: 'unreachable' }); });
+  });
+}

--- a/src/cli/services/daemon-port.ts
+++ b/src/cli/services/daemon-port.ts
@@ -24,7 +24,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import * as http from 'node:http';
 
@@ -152,11 +152,27 @@ export function serverPortCandidates(projectRoot: string, maxAttempts = 10): num
 // ============================================================================
 
 /**
- * Case-normalize project root paths so `C:\Users\...` and `c:\users\...`
- * compare equal on Windows. POSIX is case-sensitive — pass through.
+ * Normalize project root paths for identity comparison.
+ *
+ *   - Resolve symlinks via `realpathSync`. macOS aliases `/var/folders`
+ *     → `/private/var/folders`; one side of the daemon/client pair may
+ *     resolve the symlink and the other may not, producing false-positive
+ *     identity mismatches on otherwise-matching project roots (caught by
+ *     the consumer-smoke harness on macOS + Ubuntu after the original
+ *     #1145 fix). Ubuntu hits the same shape via `/tmp` symlinks under
+ *     certain mount configurations.
+ *   - Lowercase on Windows so `C:\Users\...` and `c:\users\...` compare
+ *     equal. POSIX is case-sensitive — pass through.
+ *
+ * Never throws — a path that doesn't exist (or that we lack permission
+ * to stat) falls back to the input string. The fallback case is safe
+ * because the symlink-mismatch class only fires on paths that DO exist
+ * (both daemon and client just resolved them).
  */
 export function normalizeProjectRoot(p: string): string {
-  return process.platform === 'win32' ? p.toLowerCase() : p;
+  let resolved = p;
+  try { resolved = realpathSync(p); } catch { /* path doesn't exist / EACCES — use input */ }
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
 }
 
 /**

--- a/tests/system/no-fixed-3117-port.test.ts
+++ b/tests/system/no-fixed-3117-port.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression guard for #1145 — no fixed `3117` port literal outside the
+ * central resolver.
+ *
+ * Background: pre-#1145, two separate `DEFAULT_*_PORT = 3117` constants
+ * (server in `daemon-dashboard.ts`, client in `daemon-write-client.ts`)
+ * produced silent cross-project DB routing when two moflo daemons collided.
+ * The fix collapses both to one `daemon-port.ts` module. This test pins the
+ * collapse so a future drive-by edit can't reintroduce the bug class.
+ *
+ * Allowlist intentionally narrow:
+ *   - `src/cli/services/daemon-port.ts` (the canonical resolver — owns
+ *     `LEGACY_DEFAULT_PORT = 3117`)
+ *   - `bin/lib/daemon-port.mjs` (JS twin — same constant)
+ *   - This file (it must reference the literal to fail-detect it)
+ *   - `docs/internal/1145-daemon-port-collision-analysis.md` (audit doc)
+ *   - `CHANGELOG.md` advisory (records the migration)
+ *   - existing test fixtures and the issue body — pattern is "3117" inside
+ *     a string literal in a test or doc; case-by-case allowlist below.
+ *
+ * Any NEW file matching `3117` will fail the test. The fix is to route
+ * through `resolveProjectPort` / `resolveClientPort` / `serverPortCandidates`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+/** Paths allowed to reference the literal `3117`. Forward-slashes only. */
+const ALLOWLIST = new Set<string>([
+  'src/cli/services/daemon-port.ts',
+  'bin/lib/daemon-port.mjs',
+  'tests/system/no-fixed-3117-port.test.ts',
+  'docs/internal/1145-daemon-port-collision-analysis.md',
+  'CHANGELOG.md',
+  // Existing test/doc fixtures that reference the legacy port as historical
+  // context. NEW additions to this list need a PR comment justifying why
+  // the literal can't route through the resolver.
+  'src/cli/__tests__/daemon-dashboard.test.ts',
+  'src/cli/__tests__/memory/daemon-write-client.test.ts',
+  'src/cli/__tests__/memory/store-entry-routing.test.ts',
+  'src/cli/__tests__/services/daemon-port.test.ts',
+  'src/cli/commands/daemon.ts',
+  'harness/consumer-smoke/lib/checks.mjs',
+  'harness/consumer-smoke/run.mjs',
+  'harness/consumer-smoke/run-populated.mjs',
+  'README.md',
+  '.claude/guidance/internal/dogfooding.md',
+  '.claude/guidance/internal/testing-performance.md',
+  'docs/linkedin-luminarium.html',
+]);
+
+describe('no-fixed-3117 regression guard (#1145)', () => {
+  it('no shipped source references the literal 3117 outside the allowlist', () => {
+    // Use git grep so we only scan tracked files. Exit code 1 = no matches
+    // (success); 0 = matches found.
+    let raw = '';
+    try {
+      raw = execSync('git grep -nF 3117 -- "src/**" "bin/**" "harness/**" "tests/**" "docs/**" "*.md" ".claude/**"', {
+        encoding: 'utf-8',
+        cwd: REPO_ROOT,
+        timeout: 30_000,
+      });
+    } catch (err) {
+      // git grep exits 1 when no matches; treat as "all clean".
+      const status = (err as { status?: number }).status;
+      if (status === 1) return;
+      throw err;
+    }
+
+    const violations: string[] = [];
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line) continue;
+      const colonIdx = line.indexOf(':');
+      if (colonIdx === -1) continue;
+      const file = line.slice(0, colonIdx).split(/[\\/]/).join('/');
+      if (ALLOWLIST.has(file)) continue;
+      violations.push(line);
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        `Found ${violations.length} reference(s) to the legacy port 3117 outside the allowlist.`,
+        'Route through src/cli/services/daemon-port.ts (resolveProjectPort / resolveClientPort / serverPortCandidates).',
+        'Violations:',
+        ...violations.slice(0, 20),
+      ].join('\n');
+      expect(violations, message).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1145.

Pre-#1145 the daemon HTTP server defaulted to a fixed port (3117) with **asymmetric** fallback: server retried 3117→3126 on `EADDRINUSE`; client always POSTed to 3117. Two moflo-using projects on one machine silently cross-routed reads AND writes — every `memory_store`, `memory_list`, swarm/aidefence call going through the daemon landed on whichever daemon happened to bind first. Reproducer in the issue body + full audit at `docs/internal/1145-daemon-port-collision-analysis.md`.

## What's in the fix (defense in depth — all four sub-fixes ship here)

- **Per-project deterministic port** — new `src/cli/services/daemon-port.ts` (+ JS twin `bin/lib/daemon-port.mjs`). `resolveProjectPort()` → `33000 + sha256(absPath) % 1000`. Both server bind site AND client RPC route through it. Single source of truth — no more two `DEFAULT_*_PORT = 3117` literals drifting apart.
- **Lock-file `port` field** — server stamps the actually-bound port via `writeLockPort()` (atomic write) after a successful `server.listen()`. Clients read it first, fall back to the deterministic resolver, then to legacy 3117 (read-only).
- **`GET /api/health` endpoint** — daemon answers `{status, projectRoot, pid, version, uptimeMs}`. Client probes on every reachability check (5s cache). On a **confirmed** `projectRoot` mismatch: downgrade to direct-SQL, emit ONE stderr warn per port per process. Legacy daemons (404 / no identity field) → fall-OPEN; port-discovery is the primary defence and that is enough during the upgrade window.
- **Hard-fail on bind exhaustion** — `attachDaemonServices` now re-throws when the dashboard cannot bind any candidate port. Pre-#1145 the daemon stayed alive doing internal-worker-only work while HTTP was dead (the silent-trap that produced this whole issue class).
- **Healer subcheck** `daemon-identity-match` (`flo healer --fix -c daemon-identity`) — reads the lock, probes `/api/health`, asserts `projectRoot === findProjectRoot(cwd)`. `--fix` is the same SIGTERM-kill-respawn dance as version-skew.
- **Regression guard** at `tests/system/no-fixed-3117-port.test.ts` — git-grep based; any new shipped code referencing the legacy literal outside the resolver fails the test.

## Compatibility

- `MOFLO_DAEMON_PORT` env override still wins. Consumers pinning the env keep pre-#1145 behavior.
- Upgraded clients running against pre-#1145 daemons → identity probe sees 404 → treats as legacy → routes. No breakage during the upgrade window.
- Pre-#1145 clients running against upgraded daemons → keep hitting 3117 (legacy default); upgraded daemon does not bind there in the default deterministic flow, so they fall through to direct-SQL. Same as today's failure mode.

## Test plan

- [x] `npm run build` — clean.
- [x] Unit tests for the resolver (env override, deterministic hash, lock-file discovery, JS-twin parity) — `src/cli/__tests__/services/daemon-port.test.ts` (19 tests).
- [x] Unit tests for the lock-port writer (idempotent, refuses foreign PIDs, preserved across transfer) — `src/cli/__tests__/services/daemon-lock-port.test.ts` (7 tests).
- [x] Dashboard integration tests for `/api/health`, cross-project bind, bind exhaustion — `src/cli/__tests__/daemon-dashboard-1145.test.ts` (5 tests).
- [x] Client identity-mismatch tests with a fake daemon — `src/cli/__tests__/memory/daemon-identity-mismatch.test.ts` (5 tests).
- [x] Regression guard at `tests/system/no-fixed-3117-port.test.ts` (1 test).
- [x] Full suite green: 8831 passed, 0 failed (Windows, full + isolation batches).
- [x] Existing dashboard / write-client / port-resolution tests still pass.
- [ ] **Manual reproducer on a real machine**: two consumer projects, both with the upgraded moflo — verify `flo memory stats` returns each project's own row count, not the other's. (To be done by a reviewer with two moflo-using projects on the same host before merge.)

## Data-integrity advisory

CHANGELOG includes a notice for consumers who ran moflo ≤4.10.7 with daemons in two projects concurrently — their `.moflo/moflo.db` files may contain foreign chokepoint writes in the `learnings` / `default` / `swarm-*` / `tasklist` namespaces. Recovery procedure in `docs/internal/1145-daemon-port-collision-analysis.md` §10.2.

## Out of scope (intentional)

11 stacked bugs identified in the analysis doc. This PR fixes bugs 1-4 (port collision surface). Sibling bugs (memory_stats overhaul covering bugs 5-8, orphan daemon cleanup, MCP PID in tmpdir, neural-pattern bleed) need separate issues — kept scoped per the bug-class-kill rule so each gets its own owned, tested, reviewed surface.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)