### PR TITLE
ci: parallelize smoke harnesses + skip CI on doc-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,18 @@ on:
     # on typo/wording PRs without losing signal. Code-touching PRs always
     # run; doc-touching paths added to a code PR don't filter out (any
     # non-ignored path triggers the workflow).
+    #
+    # Narrow ignore list — only ROOT-level Markdown / templates / LICENSE.
+    # Do NOT match `**/*.md` recursively: src/CLAUDE.md, src/cli/CLAUDE.md,
+    # `.claude/guidance/**/*.md`, and test fixtures under tests/ are all
+    # functional (consumed by claudemd-generator, drift guards, and indexer
+    # tests). Changing them MUST trigger CI.
     paths-ignore:
       - 'docs/**'
-      - '**/*.md'
+      - '*.md'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE/**'
       - 'LICENSE'
-      - 'CODE_OF_CONDUCT.md'
 
 env:
   NODE_VERSION: '22'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,17 @@ name: CI
 on:
   pull_request:
     branches: [main, 'epic/*']
+    # Skip CI on PRs that only touch documentation — saves runner minutes
+    # on typo/wording PRs without losing signal. Code-touching PRs always
+    # run; doc-touching paths added to a code PR don't filter out (any
+    # non-ignored path triggers the workflow).
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
 
 env:
   NODE_VERSION: '22'

--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -14,8 +14,26 @@ name: Consumer install smoke
 on:
   pull_request:
     branches: [main, 'epic/*']
+    # Skip CI on PRs that only touch documentation. Smoke runs on Windows
+    # cost ~10 minutes wall clock; doc-only PRs pay that cost for zero
+    # signal. The drift-guard test still runs as part of the main CI
+    # workflow's `Tests` job so consumer-shape regressions in CLAUDE.md
+    # injection are still caught.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
   push:
     branches: [main, 'epic/*']
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'LICENSE'
 
 env:
   NODE_VERSION: '22'
@@ -29,11 +47,20 @@ concurrency:
 
 jobs:
   smoke:
-    name: ${{ matrix.os }}
+    # Split into a 3 × 2 matrix (3 OS × 2 harnesses) so consumer-smoke and
+    # populated-smoke run in PARALLEL on each runner instead of sequentially.
+    # Pre-split Windows wall time: ~10m52s (consumer 2m47s + populated 5m35s
+    # + shared setup ~2m30s). Post-split: max(consumer, populated) + shared
+    # setup ≈ ~7m. The populated harness still bears the heaviest single
+    # chunk (3-min consumer-install) so this approaches but doesn't beat
+    # that floor; further wins need harness-level caching of node_modules
+    # (separate issue).
+    name: ${{ matrix.harness }} / ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        harness: [consumer, populated]
     runs-on: ${{ matrix.os }}
     # Acceptance criterion: < 5 min on Ubuntu. Cap all runners conservatively
     # so a stuck install can't hold the queue.
@@ -68,11 +95,13 @@ jobs:
         run: npm run build
 
       - name: Run consumer smoke harness
+        if: matrix.harness == 'consumer'
         run: npm run test:smoke
 
-      # Issue #736 — safety gate for stories #727/#728/#729/#735. Reuses the
-      # tarball that test:smoke just packed (skip-pack) so we don't pay
-      # `npm pack` twice. The previous step keeps `.work/` because pack-only
-      # cleanup happens at the end of each run.
+      # Issue #736 — safety gate for stories #727/#728/#729/#735. Pre-split
+      # this step reused the consumer-smoke tgz via --skip-pack; post-split
+      # each harness packs independently (pack is ~3s on Windows, negligible
+      # vs. the ~5m the split saves).
       - name: Run populated-consumer smoke harness
-        run: npm run test:smoke:populated -- --skip-pack
+        if: matrix.harness == 'populated'
+        run: npm run test:smoke:populated

--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -19,18 +19,22 @@ on:
     # signal. The drift-guard test still runs as part of the main CI
     # workflow's `Tests` job so consumer-shape regressions in CLAUDE.md
     # injection are still caught.
+    # Narrow ignore list — only ROOT-level Markdown / templates / LICENSE.
+    # Do NOT match `**/*.md` recursively: src/CLAUDE.md, src/cli/CLAUDE.md,
+    # `.claude/guidance/**/*.md`, and shipped fixtures under tests/ are all
+    # functional (consumed by claudemd-generator, drift guards, and indexer
+    # tests). Changing them MUST trigger CI.
     paths-ignore:
       - 'docs/**'
-      - '**/*.md'
+      - '*.md'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE/**'
       - 'LICENSE'
-      - 'CODE_OF_CONDUCT.md'
   push:
     branches: [main, 'epic/*']
     paths-ignore:
       - 'docs/**'
-      - '**/*.md'
+      - '*.md'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE/**'
       - 'LICENSE'


### PR DESCRIPTION
## Summary

CI wall-clock averaging ~10m, bottlenecked by Windows. Two YAML-only changes:

1. **Parallelize smoke harnesses.** Matrix becomes 3 OS × 2 harness (`consumer` + `populated`) instead of 3 OS × 1 sequential job. Pre-split, populated alone took 5m35s on Windows because it does its own `npm install moflo@<tgz>` (3m03s of NTFS file copies + native module post-installs). Now both harnesses run in parallel, gated only by the slower populated job. Expected Windows wall time: ~7m (down from 10m52s).

2. **`paths-ignore` for doc-only PRs.** Doc/typo PRs no longer trigger 10m of CI. Code+docs PRs still run — `paths-ignore` only filters when ALL changed paths match.

## ACTION REQUIRED before merging — branch protection

Job names change from `windows-latest` / `macos-latest` / `ubuntu-latest` to `consumer / windows-latest`, `populated / windows-latest`, etc. **Required status checks on the protected branch are matched by exact job name** — if `windows-latest` is currently a required check, merges will be blocked until the required checks list is updated in repo settings.

To fix, after this PR merges (or before, on a feature branch first), update branch protection on `main`:
- Remove required checks: `windows-latest`, `macos-latest`, `ubuntu-latest`
- Add required checks: `consumer / windows-latest`, `consumer / macos-latest`, `consumer / ubuntu-latest`, `populated / windows-latest`, `populated / macos-latest`, `populated / ubuntu-latest`

`Build`, `Tests`, `Lint & Security` job names are unchanged.

## Cost

- Duplicated `npm pack` step (~3s on Windows; was reused via `--skip-pack` pre-split). Negligible vs. the ~5m the split saves.
- Matrix cells doubled from 3 → 6. Each cell finishes faster than the pre-split single cell; total runner-minutes roughly equal.

## Narrowed paths-ignore (review fix)

Initial draft used `**/*.md` which would have silently skipped CI on changes to `src/CLAUDE.md`, `src/cli/CLAUDE.md`, `.claude/guidance/**/*.md` (functional — consumed by claudemd-generator + drift guards), and test-fixture Markdown. Narrowed to ROOT-level only: `*.md`, `docs/**`, issue/PR templates, LICENSE.

## What's still slow + tracked

- **#1153** — cache consumer's `node_modules` across runs to skip the 3m install (warm-donor pattern; needs harness changes). Getting Windows under 5 minutes needs both this PR and #1153.
- **#1154** — pre-existing test flake from `process.cwd()` contamination under maxForks=2. Surfaced again while running tests for this PR; passes on retry. Root-cause fix is a vitest.setup.ts global cwd-restore hook.

## Test plan

- [x] YAML reviewed by sonnet reviewer; both findings addressed.
- [x] `npm test` green on Windows.
- [ ] First post-merge CI run confirms wall-clock drop on Windows.
- [ ] Branch protection updated for new required-check names (manual step).
- [ ] Doc-only follow-up PR confirms `paths-ignore` skips smoke as expected.

## Consumer surface

None — workflow YAML only, no code changes ship to consumers.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)