### PR TITLE
fix(memory): route memory_stats through dedicated stats endpoint (#1149)

### DIFF
--- a/src/cli/__tests__/daemon-dashboard.test.ts
+++ b/src/cli/__tests__/daemon-dashboard.test.ts
@@ -318,18 +318,38 @@ describe('DaemonDashboard', () => {
     mockGetNamespaceCounts.mockResolvedValue({
       namespaces: { guidance: 34, patterns: 29, 'code-map': 100, knowledge: 3, tests: 10 },
       total: 176,
+      withEmbeddings: 170,
     });
     dashboard = await startDashboard(daemon, { port: testPort });
 
     const res = await fetchDashboard(testPort, '/api/memory/stats');
     const data = JSON.parse(res.body);
+    // #1149 — `ok:true` lets MCP clients distinguish a real 200 from a
+    // misrouted/empty response; `withEmbeddings` removes the need to
+    // iterate /api/memory/list just to compute embedding coverage.
+    expect(data.ok).toBe(true);
     expect(data.available).toBe(true);
     expect(data.totalEntries).toBe(176);
+    expect(data.withEmbeddings).toBe(170);
     expect(data.namespaces.guidance).toBe(34);
     expect(data.namespaces.patterns).toBe(29);
     expect(data.namespaces.knowledge).toBe(3);
     expect(data.namespaces['code-map']).toBe(100);
     expect(data.namespaces.tests).toBe(10);
+  });
+
+  // #1149 — totals must NOT silently default to 0 when getNamespaceCounts
+  // fails. The daemon returns 500 so MCP clients fall back to a direct
+  // local query (or surface the error) instead of seeing `totalEntries: 0`.
+  it('returns 500 from /api/memory/stats when underlying query throws', async () => {
+    const daemon = makeMockDaemon();
+    mockGetNamespaceCounts.mockRejectedValueOnce(new Error('disk read failed'));
+    dashboard = await startDashboard(daemon, { port: testPort });
+
+    const res = await fetchDashboard(testPort, '/api/memory/stats');
+    expect(res.status).toBe(500);
+    const data = JSON.parse(res.body);
+    expect(data.message).toContain('disk read failed');
   });
 
   it('returns 404 for unknown routes', async () => {

--- a/src/cli/__tests__/mcp-tools-deep.test.ts
+++ b/src/cli/__tests__/mcp-tools-deep.test.ts
@@ -91,6 +91,8 @@ vi.mock('../memory/memory-initializer.js', () => ({
   getEntry: vi.fn(async () => null),
   deleteEntry: vi.fn(async () => ({ success: true })),
   getStats: vi.fn(async () => ({ totalEntries: 0 })),
+  // memory_stats handler imports this lazily on routed:false fallback (#1149)
+  getNamespaceCounts: vi.fn(async () => ({ namespaces: {}, total: 0, withEmbeddings: 0 })),
   initializeDatabase: vi.fn(async () => ({ success: true })),
   initializeMemoryDatabase: vi.fn(async () => ({ success: true })),
   checkMemoryInitialization: vi.fn(async () => ({ initialized: true, version: '3.0.0' })),

--- a/src/cli/__tests__/memory-tools-stats.test.ts
+++ b/src/cli/__tests__/memory-tools-stats.test.ts
@@ -1,0 +1,169 @@
+/**
+ * #1149 — memory_stats MCP handler must never silently report 0 entries on
+ * populated DBs.
+ *
+ * Pre-#1149 the handler iterated /api/memory/list with `limit: 100000`, the
+ * daemon capped that at 10 000 → 400 → tryDaemonList defaulted `total: 0`,
+ * and the handler returned `totalEntries: 0` on every DB with > 10 000 rows
+ * or any daemon-side validation slip. These tests pin the post-#1149 contract:
+ *
+ *   - happy path goes through tryDaemonStats() (dedicated stats endpoint)
+ *   - daemon unreachable → fall back to a direct getNamespaceCounts() query
+ *   - daemon explicitly errored → surface the error (no `totalEntries: 0`)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MCPTool } from '../mcp-tools/types.js';
+
+const getNamespaceCountsSpy = vi.fn();
+const listEntriesSpy = vi.fn();
+const checkInitSpy = vi.fn(async () => ({
+  initialized: true,
+  version: '3.0.0',
+  features: { vectorEmbeddings: true, hnswIndex: true, semanticSearch: true },
+}));
+const tryDaemonStatsSpy = vi.fn();
+
+vi.mock('../memory/memory-initializer.js', () => ({
+  storeEntry: vi.fn(),
+  searchEntries: vi.fn(),
+  listEntries: listEntriesSpy,
+  getEntry: vi.fn(),
+  deleteEntry: vi.fn(),
+  initializeMemoryDatabase: vi.fn(async () => ({ success: true, dbPath: '' })),
+  checkMemoryInitialization: checkInitSpy,
+  getNamespaceCounts: getNamespaceCountsSpy,
+}));
+
+vi.mock('../memory/daemon-write-client.js', () => ({
+  tryDaemonStats: tryDaemonStatsSpy,
+}));
+
+vi.mock('../services/spell-gate.js', () => ({
+  GateService: class { recordMemorySearched(): void { /* no-op */ } },
+}));
+
+beforeEach(() => {
+  getNamespaceCountsSpy.mockReset();
+  listEntriesSpy.mockReset();
+  tryDaemonStatsSpy.mockReset();
+});
+afterEach(() => { vi.restoreAllMocks(); });
+
+async function getStatsTool(): Promise<MCPTool> {
+  const mod = await import('../mcp-tools/memory-tools.js');
+  const t = (mod.memoryTools as MCPTool[]).find(x => x.name === 'memory_stats');
+  if (!t) throw new Error('memory_stats not registered');
+  return t;
+}
+
+interface StatsResult {
+  initialized?: boolean;
+  totalEntries?: number;
+  entriesWithEmbeddings?: number;
+  embeddingCoverage?: string;
+  namespaces?: Record<string, number>;
+  error?: string;
+  backend?: string;
+}
+
+describe('memory_stats — #1149 dedicated stats endpoint', () => {
+  it('uses tryDaemonStats() result on success (no listEntries iteration)', async () => {
+    tryDaemonStatsSpy.mockResolvedValue({
+      routed: true,
+      data: {
+        namespaces: { guidance: 2620, 'code-map': 1414, patterns: 1297 },
+        totalEntries: 5331,
+        withEmbeddings: 5300,
+      },
+    });
+
+    const tool = await getStatsTool();
+    const result = await tool.handler({}) as StatsResult;
+
+    expect(result.totalEntries).toBe(5331);
+    expect(result.entriesWithEmbeddings).toBe(5300);
+    expect(result.namespaces?.guidance).toBe(2620);
+    expect(result.namespaces?.['code-map']).toBe(1414);
+    // The 100k-row iteration MUST NOT fire on the happy path — that's the
+    // foot-gun this issue fixes.
+    expect(listEntriesSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to direct getNamespaceCounts when daemon unreachable (routed:false)', async () => {
+    tryDaemonStatsSpy.mockResolvedValue({ routed: false });
+    getNamespaceCountsSpy.mockResolvedValue({
+      namespaces: { learnings: 42, guidance: 9 },
+      total: 51,
+      withEmbeddings: 50,
+    });
+
+    const tool = await getStatsTool();
+    const result = await tool.handler({}) as StatsResult;
+
+    expect(getNamespaceCountsSpy).toHaveBeenCalledTimes(1);
+    expect(result.totalEntries).toBe(51);
+    expect(result.entriesWithEmbeddings).toBe(50);
+    expect(result.namespaces?.learnings).toBe(42);
+    expect(listEntriesSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the daemon error on routed:true with error (no fake 0)', async () => {
+    tryDaemonStatsSpy.mockResolvedValue({
+      routed: true,
+      error: 'limit must be a positive integer ≤10000',
+    });
+
+    const tool = await getStatsTool();
+    const result = await tool.handler({}) as StatsResult;
+
+    expect(result.error).toContain('limit must be a positive integer');
+    // Critical: must NOT report totalEntries:0 — that's the exact silent
+    // wrong-answer the issue catches.
+    expect(result.totalEntries).toBeUndefined();
+    expect(getNamespaceCountsSpy).not.toHaveBeenCalled();
+  });
+
+  it('computes embeddingCoverage from server-side counts', async () => {
+    tryDaemonStatsSpy.mockResolvedValue({
+      routed: true,
+      data: { namespaces: { x: 10 }, totalEntries: 10, withEmbeddings: 7 },
+    });
+
+    const tool = await getStatsTool();
+    const result = await tool.handler({}) as StatsResult;
+
+    expect(result.embeddingCoverage).toBe('70.0%');
+  });
+
+  it('reports 0% embedding coverage when DB is empty (clean signal, not a lie)', async () => {
+    tryDaemonStatsSpy.mockResolvedValue({
+      routed: true,
+      data: { namespaces: {}, totalEntries: 0, withEmbeddings: 0 },
+    });
+
+    const tool = await getStatsTool();
+    const result = await tool.handler({}) as StatsResult;
+
+    expect(result.totalEntries).toBe(0);
+    expect(result.embeddingCoverage).toBe('0%');
+  });
+
+  it('reports real N from direct fallback even when N is large (≥10 000)', async () => {
+    // The exact reproducer in the issue body: post-#1145, N>10000 caused
+    // the old iterate-namespaces path to 400 on the limit cap and silently
+    // default to totalEntries:0. With the new path the daemon may be
+    // unreachable mid-call; the direct fallback must still report N.
+    tryDaemonStatsSpy.mockResolvedValue({ routed: false });
+    getNamespaceCountsSpy.mockResolvedValue({
+      namespaces: { bulk: 12_345 },
+      total: 12_345,
+      withEmbeddings: 12_000,
+    });
+
+    const tool = await getStatsTool();
+    const result = await tool.handler({}) as StatsResult;
+
+    expect(result.totalEntries).toBe(12_345);
+    expect(result.entriesWithEmbeddings).toBe(12_000);
+  });
+});

--- a/src/cli/__tests__/memory/daemon-write-client.test.ts
+++ b/src/cli/__tests__/memory/daemon-write-client.test.ts
@@ -23,6 +23,7 @@ import {
   tryDaemonGet,
   tryDaemonSearch,
   tryDaemonList,
+  tryDaemonStats,
   _resetForTest,
 } from '../../memory/daemon-write-client.js';
 
@@ -619,6 +620,104 @@ describe('daemon-write-client', () => {
     process.env.MOFLO_DAEMON_PORT = String(40000 + Math.floor(Math.random() * 10000));
     const r = await tryDaemonList({});
     expect(r.routed).toBe(false);
+  });
+
+  // ── tryDaemonStats (#1149) ────────────────────────────────────────────
+
+  it('tryDaemonStats returns routed:true with namespaces+totals on 200', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      if (req.url === '/api/memory/stats') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: true,
+          namespaces: { guidance: 2620, 'code-map': 1414, patterns: 1297 },
+          totalEntries: 5331,
+          withEmbeddings: 5300,
+          available: true,
+        }));
+        return;
+      }
+      res.writeHead(404); res.end();
+    });
+
+    const r = await tryDaemonStats();
+    expect(r.routed).toBe(true);
+    expect(r.data?.totalEntries).toBe(5331);
+    expect(r.data?.withEmbeddings).toBe(5300);
+    expect(r.data?.namespaces.guidance).toBe(2620);
+    expect(r.data?.namespaces['code-map']).toBe(1414);
+    expect(fake.requests.find(req => req.url === '/api/memory/stats')?.method).toBe('GET');
+  });
+
+  it('tryDaemonStats issues a GET (no request body)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, namespaces: {}, totalEntries: 0, withEmbeddings: 0 }));
+    });
+    await tryDaemonStats();
+    const statsReq = fake.requests.find(req => req.url === '/api/memory/stats');
+    expect(statsReq?.method).toBe('GET');
+    expect(statsReq?.body).toBe('');
+  });
+
+  it('tryDaemonStats returns routed:true,error on 4xx (caller propagates, no fake zero)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'bad request' }));
+    });
+    const r = await tryDaemonStats();
+    expect(r.routed).toBe(true);
+    expect(r.data).toBeUndefined();
+    expect(r.error).toBe('bad request');
+  });
+
+  it('tryDaemonStats returns routed:false on 5xx (caller falls back to direct)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(500); res.end('boom');
+    });
+    expect((await tryDaemonStats()).routed).toBe(false);
+  });
+
+  it('tryDaemonStats returns routed:false when daemon down (ECONNREFUSED)', async () => {
+    process.env.MOFLO_DAEMON_PORT = String(40000 + Math.floor(Math.random() * 10000));
+    expect((await tryDaemonStats()).routed).toBe(false);
+  });
+
+  it('tryDaemonStats returns routed:false when response is missing totalEntries (malformed)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, namespaces: {} })); // no totalEntries
+    });
+    expect((await tryDaemonStats()).routed).toBe(false);
+  });
+
+  it('tryDaemonStats defaults withEmbeddings to 0 when daemon omits it (older daemon)', async () => {
+    fake = await startFakeDaemon();
+    process.env.MOFLO_DAEMON_PORT = String(fake.port);
+    fake.setHandler((req, res) => {
+      if (req.url === '/api/status') { res.writeHead(200); res.end('{}'); return; }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ namespaces: { x: 3 }, totalEntries: 3 }));
+    });
+    const r = await tryDaemonStats();
+    expect(r.routed).toBe(true);
+    expect(r.data?.totalEntries).toBe(3);
+    expect(r.data?.withEmbeddings).toBe(0);
   });
 
   // ── port resolution ───────────────────────────────────────────────────

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -726,27 +726,47 @@ export const memoryTools: MCPTool[] = [
     },
     handler: async () => {
       await ensureInitialized();
-      const { checkMemoryInitialization, listEntries } = await getMemoryFunctions();
+      const { checkMemoryInitialization } = await getMemoryFunctions();
 
       try {
         const status = await checkMemoryInitialization();
-        const allEntries = await listEntries({ limit: 100000 });
 
-        // Count by namespace
-        const namespaces: Record<string, number> = {};
-        let withEmbeddings = 0;
+        // #1149 — server-side aggregation. The pre-fix path iterated every
+        // namespace via listEntries({limit:100000}) and tripped the daemon's
+        // `limit ≤ 10 000` cap → 400 → tryDaemonList defaulted total to 0 →
+        // the MCP tool silently reported zero entries on populated DBs.
+        // Route through the dedicated stats endpoint; on routed:false, run
+        // the same GROUP BY in-process so users always see real counts; on
+        // a daemon error, surface it rather than masking it as zero.
+        const { tryDaemonStats } = await import('../memory/daemon-write-client.js');
+        const routed = await tryDaemonStats();
 
-        for (const entry of allEntries.entries) {
-          namespaces[entry.namespace] = (namespaces[entry.namespace] || 0) + 1;
-          if (entry.hasEmbedding) withEmbeddings++;
+        let namespaces: Record<string, number>;
+        let totalEntries: number;
+        let withEmbeddings: number;
+
+        if (routed.routed && routed.data) {
+          ({ namespaces, totalEntries, withEmbeddings } = routed.data);
+        } else if (routed.routed && routed.error) {
+          return {
+            initialized: status.initialized,
+            error: `daemon memory_stats failed: ${routed.error}`,
+            backend: BACKEND_LABEL,
+          };
+        } else {
+          const { getNamespaceCounts } = await import('../memory/memory-initializer.js');
+          const direct = await getNamespaceCounts();
+          namespaces = direct.namespaces;
+          totalEntries = direct.total;
+          withEmbeddings = direct.withEmbeddings;
         }
 
         return {
           initialized: status.initialized,
-          totalEntries: allEntries.total,
+          totalEntries,
           entriesWithEmbeddings: withEmbeddings,
-          embeddingCoverage: allEntries.total > 0
-            ? `${((withEmbeddings / allEntries.total) * 100).toFixed(1)}%`
+          embeddingCoverage: totalEntries > 0
+            ? `${((withEmbeddings / totalEntries) * 100).toFixed(1)}%`
             : '0%',
           namespaces,
           backend: BACKEND_LABEL,

--- a/src/cli/memory/daemon-write-client.ts
+++ b/src/cli/memory/daemon-write-client.ts
@@ -152,6 +152,17 @@ export interface DaemonListEntry {
   hasEmbedding: boolean;
 }
 
+/**
+ * Shape returned by GET /api/memory/stats (#1149). Server-side aggregation
+ * over `memory_entries` — namespace counts, total active rows, and rows with
+ * an embedding, all from one GROUP BY query.
+ */
+export interface DaemonStats {
+  namespaces: Record<string, number>;
+  totalEntries: number;
+  withEmbeddings: number;
+}
+
 // ============================================================================
 // Module state — cached probes, never persisted
 // ============================================================================
@@ -489,6 +500,30 @@ export async function tryDaemonList(opts: {
   );
 }
 
+/**
+ * Route a memory-stats query through the daemon (#1149). Single GROUP BY
+ * query server-side — replaces the list-and-iterate path in the MCP
+ * `memory_stats` handler that fetched up to 100 000 rows just to count
+ * them and tripped the daemon's `limit ≤ 10 000` cap.
+ *
+ * Returns `{ routed: false }` when the daemon is unavailable or any 5xx /
+ * transport fault fires — caller falls back to a direct
+ * `getNamespaceCounts()` so users never see a fake zero.
+ */
+export async function tryDaemonStats(): Promise<DaemonReadResult<DaemonStats>> {
+  if (!(await isDaemonAvailable())) return { routed: false };
+  return requestReadJson<DaemonStats>('GET', '/api/memory/stats', undefined, (data) => {
+    if (typeof data?.totalEntries !== 'number') return null;
+    return {
+      namespaces: (data?.namespaces && typeof data.namespaces === 'object')
+        ? (data.namespaces as Record<string, number>)
+        : {},
+      totalEntries: data.totalEntries,
+      withEmbeddings: typeof data?.withEmbeddings === 'number' ? data.withEmbeddings : 0,
+    };
+  });
+}
+
 // ============================================================================
 // Internal HTTP poster — never throws, bounded timeout
 // ============================================================================
@@ -606,17 +641,26 @@ function postJson(path: string, body: unknown): Promise<DaemonWriteResult> {
 }
 
 /**
- * Generic JSON POST that returns a daemon-read envelope. Same transport
- * guarantees as `postJson`: never throws, bounded timeout, invalidates health
- * cache on routed-failure.
+ * Generic JSON read-request that returns a daemon-read envelope. Never
+ * throws, bounded by `DAEMON_HTTP_TIMEOUT_MS`, invalidates the health +
+ * identity + port caches on any routed-failure (daemon-recycle covers).
  *
- * The `shape` callback maps the daemon's parsed JSON payload to the typed
- * data shape the caller expects. Returning `null` from `shape` (or a parse
- * failure) downgrades to `{ routed: false }` so the caller falls back.
+ * Failure-shape contract (#1101):
+ *   2xx                            → routed:true with shape(data)
+ *   4xx                            → routed:true with error (caller propagates)
+ *   5xx / transport / parse-fail   → routed:false (caller falls back)
+ *
+ * `body === undefined` ⇒ GET (no Content-* headers); otherwise POST with
+ * JSON body. The `shape` callback maps parsed JSON to the typed payload;
+ * returning `null` downgrades the response to routed:false so the caller
+ * falls back to bridge-direct.
  */
-function postReadJson<T>(
+function requestReadJson<T>(
+  method: 'GET' | 'POST',
   path: string,
-  body: unknown,
+  body: unknown | undefined,
+  // `data` is a JSON.parse boundary — typed `any` here mirrors JSON.parse's
+  // own return type so callers can do safe optional-chaining narrowing.
   shape: (data: any) => T | null,
 ): Promise<DaemonReadResult<T>> {
   return new Promise((resolve) => {
@@ -625,9 +669,9 @@ function postReadJson<T>(
       if (done) return;
       done = true;
       if (result.routed === false) {
-        // Daemon recycled to a different port (post #1145 server restart)
-        // → invalidate the port cache too so the next call re-reads
-        // .moflo/daemon.lock. Otherwise we'd keep hammering a stale port.
+        // Daemon may have recycled to a new port (post-#1145 restart) →
+        // invalidate the lock-file-port cache and the identity probe so
+        // the next call re-discovers reality.
         healthCache = null;
         identityCache = null;
         _portCache = null;
@@ -635,45 +679,27 @@ function postReadJson<T>(
       resolve(result);
     };
 
-    const payload = JSON.stringify(body);
+    const payload = body === undefined ? undefined : JSON.stringify(body);
+    const headers = payload === undefined
+      ? undefined
+      : { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) };
+
     const req = http.request(
-      {
-        host: '127.0.0.1',
-        port: getDaemonPort(),
-        path,
-        method: 'POST',
-        timeout: DAEMON_HTTP_TIMEOUT_MS,
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(payload),
-        },
-      },
+      { host: '127.0.0.1', port: getDaemonPort(), path, method, timeout: DAEMON_HTTP_TIMEOUT_MS, headers },
       (res) => {
         let buf = '';
         res.setEncoding('utf8');
         res.on('data', (chunk: string) => { buf += chunk; });
         res.on('end', () => {
-          // #1101 — mirror postJson contract for reads:
-          //   2xx  → routed:true with shaped data
-          //   4xx  → routed:true with error (no data) — caller propagates
-          //   5xx  → routed:false (caller falls back)
           const status = res.statusCode ?? 0;
-          if (status >= 500 || status < 200) {
-            finish({ routed: false });
-            return;
-          }
+          if (status >= 500 || status < 200) { finish({ routed: false }); return; }
           if (status >= 400) {
             finish({ routed: true, error: parse4xxError(buf, status) });
             return;
           }
           try {
-            const parsed = JSON.parse(buf);
-            const shaped = shape(parsed);
-            if (shaped === null) {
-              finish({ routed: false });
-              return;
-            }
-            finish({ routed: true, data: shaped });
+            const shaped = shape(JSON.parse(buf));
+            finish(shaped === null ? { routed: false } : { routed: true, data: shaped });
           } catch {
             finish({ routed: false });
           }
@@ -683,7 +709,15 @@ function postReadJson<T>(
     );
     req.on('error', () => finish({ routed: false }));
     req.on('timeout', () => { req.destroy(); finish({ routed: false }); });
-    req.write(payload);
+    if (payload !== undefined) req.write(payload);
     req.end();
   });
+}
+
+function postReadJson<T>(
+  path: string,
+  body: unknown,
+  shape: (data: any) => T | null,
+): Promise<DaemonReadResult<T>> {
+  return requestReadJson('POST', path, body, shape);
 }

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -2759,39 +2759,50 @@ export async function deleteEntry(options: {
 }
 
 /**
- * Get per-namespace entry counts via a single GROUP BY query.
- * Returns { namespaces: Record<string, number>, total: number }.
+ * Get memory stats via a single GROUP BY query — namespace counts plus the
+ * number of rows that carry a non-null embedding. One trip to disk; the
+ * server-side aggregation replaces a pre-#1149 client iteration that
+ * fetched 100 000 rows just to count them.
+ *
+ * Throws on DB read errors. Returns a zero shape ONLY when the DB file
+ * doesn't exist yet (the real "empty project" signal) — never swallows a
+ * locked/corrupt-DB error into a fake zero, since that's the exact silent
+ * wrong-answer this fix is for.
  */
 export async function getNamespaceCounts(dbPath?: string): Promise<{
   namespaces: Record<string, number>;
   total: number;
+  withEmbeddings: number;
 }> {
   const resolvedPath = dbPath || memoryDbPath(process.cwd());
 
-  try {
-    if (!fs.existsSync(resolvedPath)) {
-      return { namespaces: {}, total: 0 };
-    }
-    const db = openDaemonDatabase(resolvedPath);
+  if (!fs.existsSync(resolvedPath)) {
+    return { namespaces: {}, total: 0, withEmbeddings: 0 };
+  }
 
+  const db = openDaemonDatabase(resolvedPath);
+  try {
     const result = db.exec(
-      "SELECT namespace, COUNT(*) as cnt FROM memory_entries WHERE status = 'active' GROUP BY namespace ORDER BY cnt DESC"
+      "SELECT namespace, COUNT(*) AS cnt, SUM(CASE WHEN embedding IS NOT NULL THEN 1 ELSE 0 END) AS emb_cnt " +
+      "FROM memory_entries WHERE status = 'active' GROUP BY namespace ORDER BY cnt DESC"
     );
-    db.close();
 
     const namespaces: Record<string, number> = {};
     let total = 0;
+    let withEmbeddings = 0;
     if (result[0]?.values) {
       for (const row of result[0].values) {
         const ns = String(row[0]);
         const count = Number(row[1]);
+        const embCount = Number(row[2] ?? 0);
         namespaces[ns] = count;
         total += count;
+        withEmbeddings += embCount;
       }
     }
-    return { namespaces, total };
-  } catch {
-    return { namespaces: {}, total: 0 };
+    return { namespaces, total, withEmbeddings };
+  } finally {
+    db.close();
   }
 }
 

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -325,14 +325,18 @@ function tryParse(s: string): Record<string, unknown> {
 }
 
 async function handleMemoryStats(): Promise<object> {
-  // Single GROUP BY query — no hardcoded namespace list, no row fetching
-  try {
-    const { getNamespaceCounts } = await import('../memory/memory-initializer.js');
-    const { namespaces, total } = await getNamespaceCounts();
-    return { namespaces, totalEntries: total, available: total > 0 || Object.keys(namespaces).length > 0 };
-  } catch {
-    return { namespaces: {}, totalEntries: 0, available: false };
-  }
+  // Single GROUP BY query — no hardcoded namespace list, no row fetching.
+  // Errors propagate to the request handler's outer try/catch → 500, so
+  // MCP clients see a real failure instead of a silent `totalEntries: 0`.
+  const { getNamespaceCounts } = await import('../memory/memory-initializer.js');
+  const { namespaces, total, withEmbeddings } = await getNamespaceCounts();
+  return {
+    ok: true,
+    namespaces,
+    totalEntries: total,
+    withEmbeddings,
+    available: total > 0 || Object.keys(namespaces).length > 0,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace the MCP `memory_stats` handler's 100 000-row `listEntries` iteration with a single GROUP BY query, routed through the dedicated `/api/memory/stats` endpoint. The pre-fix path tripped the daemon's `limit ≤ 10 000` cap → 400 → silent `totalEntries: 0` on every populated DB.
- Stop swallowing daemon/DB errors into a `totalEntries: 0` shape (the exact silent-wrong-answer anti-pattern #1149 names). `getNamespaceCounts` now throws on DB read errors; the daemon endpoint maps that to 500; MCP surfaces routed-error or falls back to a direct in-process query.
- Merge the new GET helper with the existing `postReadJson` into one `requestReadJson(method, path, body?, shape)` so cache invalidation + timeout + status branching stay in one place.

## Implementation notes

- `getNamespaceCounts()` now returns `{ namespaces, total, withEmbeddings }` from one `SELECT … SUM(CASE WHEN embedding IS NOT NULL THEN 1 ELSE 0 END) … GROUP BY namespace` query. No more client-side iteration to compute embedding coverage.
- Daemon `GET /api/memory/stats` gains `ok: true` + `withEmbeddings`. The dashboard's polling shape stays backward-compatible.
- `tryDaemonStats()` is GET-only with no body; uses the merged `requestReadJson` and tolerates legacy daemons (missing `withEmbeddings` → 0).
- MCP `memory_stats`: routed:true+data uses it; routed:true+error surfaces the daemon error (no fake zero); routed:false falls back to in-process `getNamespaceCounts()` so users always see real counts. `getNamespaceCounts` is lazy-imported so test mocks in unrelated files don't need updating.

## Test plan

- [x] `npm run build` clean
- [x] New unit tests: `src/cli/__tests__/memory-tools-stats.test.ts` (six cases pinning the three-branch handler + 12 345-row count + clean-zero-on-empty signal)
- [x] New unit tests: `src/cli/__tests__/memory/daemon-write-client.test.ts` (seven cases for `tryDaemonStats`: 200 success, GET-with-no-body, 4xx surfaces error, 5xx routed:false, ECONNREFUSED routed:false, malformed-shape rejection, missing-`withEmbeddings` tolerant default)
- [x] Updated dashboard test pins new `ok` + `withEmbeddings` fields and verifies error → 500 propagation
- [x] `npm test` green (8 848 passed)
- [ ] Post-merge: `flo memory store` N entries, then `mcp__moflo__memory_stats` returns N (verify on a consumer install after publish)

Closes #1149

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)