### PR TITLE
fix(neural): anchor pattern storage on findProjectRoot (#1152)

### DIFF
--- a/src/cli/__tests__/memory/intelligence-projectroot-1152.test.ts
+++ b/src/cli/__tests__/memory/intelligence-projectroot-1152.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Issue #1152 — `intelligence.ts` neural pattern storage must anchor on
+ * `findProjectRoot()`, never `process.cwd()` or `homedir()`.
+ *
+ * Pre-fix: when cwd lacked a `.moflo` directory, `getDataDir()` fell back to
+ * `~/.moflo/neural/` — a global path shared by every moflo-using project on
+ * the machine. Cross-project ReasoningBank bleed surfaced as `findSimilar`
+ * hits from foreign-repo patterns.
+ *
+ * The fix routes through `findProjectRoot()` (matching `neural-tools.ts` and
+ * the #829 store-path precedent) and copies legacy `~/.moflo/neural/{patterns,
+ * stats}.json` once into the active project on first load so users do not
+ * lose history.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+
+const realHome = homedir();
+const realHomeNeural = join(realHome, '.moflo', 'neural');
+const homePatternsPath = join(realHomeNeural, 'patterns.json');
+const homeStatsPath = join(realHomeNeural, 'stats.json');
+let backupSuffix: string | null = null;
+
+function stashHomeNeural(): void {
+  if (existsSync(realHomeNeural)) {
+    backupSuffix = `.bak-1152-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const stash = `${realHomeNeural}${backupSuffix}`;
+    rmSync(stash, { recursive: true, force: true });
+    renameSync(realHomeNeural, stash);
+  }
+}
+
+function restoreHomeNeural(): void {
+  if (backupSuffix) {
+    const stash = `${realHomeNeural}${backupSuffix}`;
+    rmSync(realHomeNeural, { recursive: true, force: true });
+    if (existsSync(stash)) {
+      renameSync(stash, realHomeNeural);
+    }
+    backupSuffix = null;
+  } else {
+    rmSync(realHomeNeural, { recursive: true, force: true });
+  }
+}
+
+describe('intelligence.ts neural storage anchors on findProjectRoot (#1152)', () => {
+  let projectRoot: string;
+  let foreignCwd: string;
+  let prevCwd: string;
+  let prevClaudeProjectDir: string | undefined;
+
+  beforeEach(async () => {
+    stashHomeNeural();
+    projectRoot = mkdtempSync(join(tmpdir(), 'moflo-1152-root-'));
+    foreignCwd = mkdtempSync(join(tmpdir(), 'moflo-1152-cwd-'));
+    // Use the CLAUDE.md + package.json marker pair (not moflo.db) — having
+    // a moflo.db at projectRoot makes memory-bridge open it as a real DB,
+    // which on Windows holds a file handle that EPERMs the temp-dir cleanup.
+    writeFileSync(join(projectRoot, 'CLAUDE.md'), '# fake');
+    writeFileSync(join(projectRoot, 'package.json'), '{"name":"fake-1152"}');
+    prevCwd = process.cwd();
+    prevClaudeProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = projectRoot;
+    process.chdir(foreignCwd);
+
+    // Reset module-level migration latch so each test exercises the copy path.
+    const intel = await import('../../memory/intelligence.js');
+    intel.clearIntelligence();
+  });
+
+  afterEach(async () => {
+    // Tear module state down so the debounced ReasoningBank flush cannot
+    // fire after the temp dirs are removed.
+    const intel = await import('../../memory/intelligence.js');
+    intel.flushPatterns();
+    intel.clearIntelligence();
+
+    process.chdir(prevCwd);
+    if (prevClaudeProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = prevClaudeProjectDir;
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(foreignCwd, { recursive: true, force: true });
+    restoreHomeNeural();
+  });
+
+  it('getNeuralDataDir() returns <projectRoot>/.moflo/neural, not cwd or homedir', async () => {
+    const { getNeuralDataDir } = await import('../../memory/intelligence.js');
+    const dir = getNeuralDataDir();
+    expect(dir).toBe(join(projectRoot, '.moflo', 'neural'));
+    expect(dir).not.toBe(join(foreignCwd, '.moflo', 'neural'));
+    expect(dir).not.toBe(realHomeNeural);
+  });
+
+  it('persists patterns under projectRoot, never under homedir', async () => {
+    const intel = await import('../../memory/intelligence.js');
+    await intel.initializeIntelligence();
+    // Provide a pre-computed embedding so the bridge/fastembed loader is not
+    // touched (avoids holding a moflo.db handle that EPERMs Windows cleanup).
+    await intel.recordStep({
+      type: 'thought',
+      content: 'project-A-pattern',
+      embedding: [0.1, 0.2, 0.3],
+    });
+    intel.flushPatterns();
+
+    expect(existsSync(join(projectRoot, '.moflo', 'neural', 'patterns.json'))).toBe(true);
+    expect(existsSync(homePatternsPath)).toBe(false);
+    expect(existsSync(join(foreignCwd, '.moflo', 'neural', 'patterns.json'))).toBe(false);
+  });
+
+  it('copies legacy ~/.moflo/neural/patterns.json into projectRoot on first load (migration)', async () => {
+    // Seed the legacy global location as if an older moflo build wrote there.
+    mkdirSync(realHomeNeural, { recursive: true });
+    const seeded = [{
+      id: 'legacy-1',
+      type: 'observation',
+      embedding: [0.1, 0.2, 0.3],
+      content: 'legacy pattern from pre-1152 build',
+      confidence: 1.0,
+      usageCount: 0,
+      createdAt: Date.now(),
+      lastUsedAt: Date.now(),
+    }];
+    writeFileSync(homePatternsPath, JSON.stringify(seeded));
+    writeFileSync(homeStatsPath, JSON.stringify({ trajectoriesRecorded: 7, lastAdaptation: 12345 }));
+
+    const intel = await import('../../memory/intelligence.js');
+    await intel.initializeIntelligence();
+
+    // Migration is triggered on load; the file should now exist locally.
+    const localPatterns = join(projectRoot, '.moflo', 'neural', 'patterns.json');
+    expect(existsSync(localPatterns)).toBe(true);
+    expect(existsSync(join(projectRoot, '.moflo', 'neural', 'stats.json'))).toBe(true);
+
+    const copied = JSON.parse(readFileSync(localPatterns, 'utf-8'));
+    expect(Array.isArray(copied)).toBe(true);
+    expect(copied[0].id).toBe('legacy-1');
+
+    // Legacy file must still exist — copy, not move (other projects on older
+    // moflo versions may still read from it).
+    expect(existsSync(homePatternsPath)).toBe(true);
+    expect(existsSync(homeStatsPath)).toBe(true);
+
+    const stats = intel.getIntelligenceStats();
+    expect(stats.trajectoriesRecorded).toBe(7);
+  });
+
+  it('does NOT clobber an existing local patterns.json with the legacy copy', async () => {
+    const localNeural = join(projectRoot, '.moflo', 'neural');
+    mkdirSync(localNeural, { recursive: true });
+    const existingLocal = [{
+      id: 'local-1',
+      type: 'thought',
+      embedding: [0.9, 0.8, 0.7],
+      content: 'local pattern already present',
+      confidence: 1.0,
+      usageCount: 0,
+      createdAt: Date.now(),
+      lastUsedAt: Date.now(),
+    }];
+    writeFileSync(join(localNeural, 'patterns.json'), JSON.stringify(existingLocal));
+
+    mkdirSync(realHomeNeural, { recursive: true });
+    writeFileSync(homePatternsPath, JSON.stringify([{
+      id: 'legacy-should-not-overwrite',
+      type: 'observation',
+      embedding: [0.1, 0.1, 0.1],
+      content: 'must NOT clobber',
+      confidence: 1.0,
+      usageCount: 0,
+      createdAt: Date.now(),
+      lastUsedAt: Date.now(),
+    }]));
+
+    const intel = await import('../../memory/intelligence.js');
+    await intel.initializeIntelligence();
+    const all = await intel.getAllPatterns();
+    expect(all.map(p => p.id)).toContain('local-1');
+    expect(all.map(p => p.id)).not.toContain('legacy-should-not-overwrite');
+  });
+
+  it('two projects with the same cwd-divergence write to separate neural dirs (cross-project isolation)', async () => {
+    // Project A
+    const intelA = await import('../../memory/intelligence.js');
+    await intelA.initializeIntelligence();
+    await intelA.recordStep({
+      type: 'thought',
+      content: 'A-pattern',
+      embedding: [0.1, 0.2, 0.3],
+    });
+    intelA.flushPatterns();
+    intelA.clearIntelligence();
+
+    // Switch to Project B
+    const projectRootB = mkdtempSync(join(tmpdir(), 'moflo-1152-root-B-'));
+    writeFileSync(join(projectRootB, 'CLAUDE.md'), '# fake');
+    writeFileSync(join(projectRootB, 'package.json'), '{"name":"fake-1152-B"}');
+    process.env.CLAUDE_PROJECT_DIR = projectRootB;
+
+    try {
+      const intelB = await import('../../memory/intelligence.js');
+      await intelB.initializeIntelligence();
+      const bPatterns = await intelB.getAllPatterns();
+      // B must not see A's pattern through any shared global path.
+      expect(bPatterns.find(p => p.content === 'A-pattern')).toBeUndefined();
+
+      // And A's patterns.json lives under A's root, not under B's.
+      expect(existsSync(join(projectRoot, '.moflo', 'neural', 'patterns.json'))).toBe(true);
+      expect(existsSync(join(projectRootB, '.moflo', 'neural', 'patterns.json'))).toBe(false);
+    } finally {
+      rmSync(projectRootB, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/commands/neural.ts
+++ b/src/cli/commands/neural.ts
@@ -8,6 +8,8 @@
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { mofloImport, mofloResolve } from '../services/moflo-require.js';
+import { findProjectRoot } from '../services/project-root.js';
+import { MOFLO_DIR } from '../services/moflo-paths.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 
 // Train subcommand - REAL WASM training with MoVector
@@ -790,8 +792,8 @@ const optimizeCommand: Command = {
       const patterns = await getAllPatterns();
       const stats = getIntelligenceStats();
 
-      // Get actual pattern storage size
-      const patternDir = path.join(process.cwd(), '.moflo', 'neural');
+      // Get actual pattern storage size (#1152: anchor on projectRoot, not cwd)
+      const patternDir = path.join(findProjectRoot(), MOFLO_DIR, 'neural');
       let beforeSize = 0;
       try {
         const patternFile = path.join(patternDir, 'patterns.json');
@@ -986,8 +988,8 @@ const exportCommand: Command = {
         },
       };
 
-      // Load patterns from local storage
-      const memoryDir = path.join(process.cwd(), '.moflo', 'memory');
+      // Load patterns from local storage (#1152: projectRoot-anchored)
+      const memoryDir = path.join(findProjectRoot(), MOFLO_DIR, 'memory');
       const patternsFile = path.join(memoryDir, 'patterns.json');
 
       if (fs.existsSync(patternsFile)) {
@@ -1469,8 +1471,8 @@ const importCommand: Command = {
         output.writeln(output.warning(`Filtered ${patterns.length - validPatterns.length} suspicious patterns`));
       }
 
-      // Save to local memory
-      const memoryDir = path.join(process.cwd(), '.moflo', 'memory');
+      // Save to local memory (#1152: projectRoot-anchored)
+      const memoryDir = path.join(findProjectRoot(), MOFLO_DIR, 'memory');
       if (!fs.existsSync(memoryDir)) {
         fs.mkdirSync(memoryDir, { recursive: true });
       }

--- a/src/cli/memory/intelligence.ts
+++ b/src/cli/memory/intelligence.ts
@@ -11,36 +11,35 @@
  * @module v3/cli/intelligence
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { findProjectRoot } from '../services/project-root.js';
+import { MOFLO_DIR, mofloHomeDir } from '../services/moflo-paths.js';
 
 // ============================================================================
 // Persistence Configuration
 // ============================================================================
 
-/**
- * Get the data directory for neural pattern persistence
- * Uses .moflo/neural in the current working directory,
- * falling back to home directory
- */
+const NEURAL_SUBDIR = 'neural';
+const PATTERNS_FILE = 'patterns.json';
+const STATS_FILE = 'stats.json';
+
+// #1152: pre-fix builds wrote neural patterns to `~/.moflo/neural/` whenever
+// cwd lacked `.moflo`. The bleed was silent — every moflo-using project on
+// the machine shared one ReasoningBank. Resolver now anchors on
+// findProjectRoot() like neural-tools.ts (#829); legacy home-dir files are
+// copied (not moved) into the active project on first load so users do not
+// lose history when older co-installed projects still point at the home-dir
+// copy.
 function getDataDir(): string {
-  const cwd = process.cwd();
-  const localDir = join(cwd, '.moflo', 'neural');
-  const homeDir = join(homedir(), '.moflo', 'neural');
-
-  // Prefer local directory if .moflo exists
-  if (existsSync(join(cwd, '.moflo'))) {
-    return localDir;
-  }
-
-  return homeDir;
+  return join(findProjectRoot(), MOFLO_DIR, NEURAL_SUBDIR);
 }
 
-/**
- * Ensure the data directory exists
- */
+function getLegacyDataDir(): string {
+  return join(mofloHomeDir(), NEURAL_SUBDIR);
+}
+
 function ensureDataDir(): string {
   const dir = getDataDir();
   if (!existsSync(dir)) {
@@ -49,18 +48,38 @@ function ensureDataDir(): string {
   return dir;
 }
 
-/**
- * Get the patterns file path
- */
 function getPatternsPath(): string {
-  return join(getDataDir(), 'patterns.json');
+  return join(getDataDir(), PATTERNS_FILE);
 }
 
-/**
- * Get the stats file path
- */
 function getStatsPath(): string {
-  return join(getDataDir(), 'stats.json');
+  return join(getDataDir(), STATS_FILE);
+}
+
+// Latch is intentionally not async-safe — all I/O in this module is
+// synchronous so re-entry only happens via clearIntelligence() in tests.
+let legacyMigrationAttempted = false;
+
+function migrateLegacyIfNeeded(): void {
+  if (legacyMigrationAttempted) return;
+  legacyMigrationAttempted = true;
+
+  const legacyDir = getLegacyDataDir();
+  const localDir = getDataDir();
+  if (legacyDir === localDir) return;
+
+  for (const file of [PATTERNS_FILE, STATS_FILE]) {
+    const legacy = join(legacyDir, file);
+    const local = join(localDir, file);
+    if (existsSync(legacy) && !existsSync(local)) {
+      try {
+        mkdirSync(localDir, { recursive: true });
+        copyFileSync(legacy, local);
+      } catch {
+        // Best-effort migration; failures fall through to a fresh local store.
+      }
+    }
+  }
 }
 
 // ============================================================================
@@ -262,6 +281,7 @@ class LocalReasoningBank {
    */
   private loadFromDisk(): void {
     try {
+      migrateLegacyIfNeeded();
       const path = getPatternsPath();
       if (existsSync(path)) {
         const data = JSON.parse(readFileSync(path, 'utf-8'));
@@ -299,6 +319,14 @@ class LocalReasoningBank {
    * Immediately flush patterns to disk
    */
   flushToDisk(): void {
+    // Cancel any pending debounced save — we are writing right now and the
+    // deferred handler would otherwise fire post-teardown on short-lived
+    // processes (test runners hit this as a Windows EPERM during cleanup).
+    if (this.saveTimeout) {
+      clearTimeout(this.saveTimeout);
+      this.saveTimeout = null;
+    }
+
     if (!this.persistenceEnabled || !this.dirty) return;
 
     try {
@@ -484,6 +512,7 @@ let globalStats = {
  */
 function loadPersistedStats(): void {
   try {
+    migrateLegacyIfNeeded();
     const path = getStatsPath();
     if (existsSync(path)) {
       const data = JSON.parse(readFileSync(path, 'utf-8'));
@@ -756,6 +785,7 @@ export function clearIntelligence(): void {
   sonaCoordinator = null;
   reasoningBank = null;
   intelligenceInitialized = false;
+  legacyMigrationAttempted = false;
   globalStats = {
     trajectoriesRecorded: 0,
     lastAdaptation: null


### PR DESCRIPTION
## Summary

Closes #1152. Sibling of #1145 — same shared-singleton bug class, different file.

Pre-fix builds wrote neural patterns to \`~/.moflo/neural/\` whenever \`process.cwd()\` lacked a \`.moflo\` directory. That home-dir location is shared by every moflo-using project on the machine. Project A's ReasoningBank learnings surface as \`findSimilarPatterns()\` hits when Project B (a different codebase) queries \`mcp__moflo__neural_patterns\`. The \`flo neural quantize | export | import\` commands had a parallel disease in \`process.cwd()\` form (the #829 family that #829 only partly closed).

## What changed

- **\`src/cli/memory/intelligence.ts\`** — \`getDataDir()\` now resolves through \`findProjectRoot()/.moflo/neural/\`. Drops the \`~/.moflo/neural/\` fallback entirely. One-shot legacy migration copies \`~/.moflo/neural/{patterns,stats}.json\` into the active project on first load (copy, not move — older co-installed projects may still read the home-dir copy until they pick up this release).
- **\`src/cli/commands/neural.ts\`** — four \`process.cwd()\` neural/memory paths (quantize sizing × 2, export load, import save) switched to \`findProjectRoot()\`.
- **Side-tightening** — \`LocalReasoningBank.flushToDisk()\` cancels its pending debounced \`saveTimeout\` so the deferred handler can't fire post-teardown and EPERM the temp-dir cleanup on Windows test runners.
- **New test** — \`src/cli/__tests__/memory/intelligence-projectroot-1152.test.ts\` covers the path resolver, live writes, legacy migration (copy not move), no-clobber when local exists, and cross-project isolation.

The sibling MCP surface \`src/cli/mcp-tools/neural-tools.ts\` was already correct (uses \`findProjectRoot()\`); existing #829 \`store-paths.test.ts\` neural assertion still passes — this PR closes the other half of the fleet.

## Consumer impact

- Runtime fix — ships through \`node_modules/moflo/...\` to every consumer via the next publish. Round-trip cost: publish + reinstall + Claude Code restart.
- Existing patterns under \`~/.moflo/neural/\` are not lost: copied into the active project's \`.moflo/neural/\` on first load after upgrade.
- No moflo.yaml / settings changes required by consumers.
- No \`.moflo/\` schema change.

## Test plan

- [x] \`npx vitest run src/cli/__tests__/memory/intelligence-projectroot-1152.test.ts\` — 5/5 green
- [x] \`npx vitest run src/cli/__tests__/memory-movector-deep.test.ts src/cli/__tests__/mcp-tools/store-paths.test.ts\` — 143/143 green
- [x] \`npx vitest run src/cli/__tests__/memory/\` — 106/106 green
- [x] \`npx tsc --noEmit\` — clean
- [ ] CI smoke harness on Linux + macOS + Windows
- [ ] Manual verification: train pattern in waxstack consumer, train differently in moflo-dev, confirm \`flo neural patterns search\` in each returns only that project's results

## See also

- #1145 — parent (sibling shared-resource collision class, fixed for moflo.db routing)
- #829 — partial precedent (MCP store paths anchored on \`findProjectRoot()\`)
- \`docs/internal/1145-daemon-port-collision-analysis.md\` §11 — original surface listing

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)