### PR TITLE
fix(test): restore cwd between tests to fix flaky cwd-class failures (#1154)

### DIFF
--- a/src/cli/__tests__/services/dashboard-claude-stats-route.test.ts
+++ b/src/cli/__tests__/services/dashboard-claude-stats-route.test.ts
@@ -64,6 +64,13 @@ afterEach(async () => {
   if (savedHomedrive === undefined) delete process.env.HOMEDRIVE; else process.env.HOMEDRIVE = savedHomedrive;
   if (savedHomepath === undefined) delete process.env.HOMEPATH; else process.env.HOMEPATH = savedHomepath;
   if (savedUserprofile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = savedUserprofile;
+  // #1154 — belt-and-suspenders with vitest.setup.ts. The handler under test
+  // reads `process.cwd()` at request time; if a prior test in this fork
+  // chdir'd and threw before its own restore, our fixture path (encoded from
+  // cwd at line below) wouldn't match the handler's lookup.
+  if (process.cwd() !== savedCwd) {
+    try { process.chdir(savedCwd); } catch { /* ignore */ }
+  }
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -23,6 +23,21 @@ import { beforeEach } from 'vitest';
 // that snapshot or assert on stderr. (#1098)
 import './src/cli/memory/suppress-sqlite-warning.js';
 
+// #1154 — every vitest fork runs many test files sequentially with shared
+// process state. Several test files `process.chdir(tmpDir)` to redirect
+// `findProjectRoot()` and restore in afterEach, but a throw before the
+// restore — or a module that caches `process.cwd()` at import time — leaves
+// the next test file in the same fork running at a stale or deleted path.
+// Victims that read `process.cwd()` (dashboard-claude-stats-route, the
+// simplify-classify default-branch detector under git contention) then flake
+// 0–3× per `npm test` run on Windows.
+//
+// INITIAL_CWD is captured once at module load (each fork loads this setup
+// fresh). The beforeEach below restores it for every test as belt-and-
+// suspenders — tests that intentionally chdir do so in their own
+// beforeEach, which runs *after* this one.
+const INITIAL_CWD = process.cwd();
+
 // Set once at module load (every test file imports this setup).
 process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
 
@@ -45,6 +60,10 @@ process.env.MOFLO_TEST_SKIP_ORPHAN_SCAN = '1';
 // Re-set in `beforeEach` so a test that intentionally cleared it for a
 // routing scenario doesn't bleed into the next test.
 beforeEach(() => {
+  // #1154 — restore cwd first so subsequent env/init code runs at a known path.
+  if (process.cwd() !== INITIAL_CWD) {
+    try { process.chdir(INITIAL_CWD); } catch { /* dir may have been removed */ }
+  }
   if (process.env.MOFLO_DISABLE_DAEMON_ROUTING !== '1') {
     process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
   }


### PR DESCRIPTION
## Summary
- Adds a global `beforeEach` cwd-restore hook in `vitest.setup.ts` (captures `INITIAL_CWD` once at module load and restores it before every test) — defends against tests that `process.chdir(tmpDir)` and throw before restoring, which previously poisoned the next test file in the same fork.
- Adds a belt-and-suspenders afterEach cwd restore in `dashboard-claude-stats-route.test.ts` since it records `savedCwd` in beforeEach but never restored it.

## Why
Vitest runs with `pool: 'forks'`, `maxForks: 2` — each fork runs many test files sequentially. A throw before a chdir-restore leaves the next test file in that fork at a stale or deleted path. Tests that read `process.cwd()` then flake 0–3× per `npm test` run on Windows:
- `dashboard-claude-stats-route.test.ts > GET /api/claude-stats returns aggregated stats when transcripts exist for the CWD`
- `tests/bin/simplify-classify.test.ts > simplify-classify: default-branch detection ... detected branch is the merge base, not hardcoded "main"`

Root-causing rather than parking on `isolationTests`, per the issue's explicit guidance and `feedback_no_test_timeout_bumps`.

## Test plan
- [x] 5 back-to-back `npm test` runs on Windows
- [x] 8871/8871 tests passed each run
- [x] 0 cwd-class failures across all 5 runs
- [x] Neither flaky test added to `isolationTests`

Closes #1154

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)