### PR TITLE
fix(healer): auto-migrate .swarm/ residue and relocate source defaults

### DIFF
--- a/.claude/scripts/hooks.mjs
+++ b/.claude/scripts/hooks.mjs
@@ -45,14 +45,15 @@ function findProjectRoot() {
 }
 
 const projectRoot = findProjectRoot();
-const logFile = resolve(projectRoot, '.swarm/hooks.log');
+const logFile = resolve(projectRoot, '.moflo', 'logs', 'hooks.log');
+try { mkdirSync(dirname(logFile), { recursive: true }); } catch { /* best effort */ }
 const pm = createProcessManager(projectRoot);
 
 // Parse command line args
 const args = process.argv.slice(2);
 const hookType = args[0];
 
-// Simple log function - writes to .swarm/hooks.log
+// Simple log function - writes to .moflo/logs/hooks.log
 function log(level, message) {
   const timestamp = new Date().toISOString();
   const line = `[${timestamp}] [${level.toUpperCase()}] [${hookType || 'unknown'}] ${message}\n`;

--- a/.claude/scripts/index-all.mjs
+++ b/.claude/scripts/index-all.mjs
@@ -13,7 +13,7 @@
  * Spawned as a single detached background process by hooks.mjs session-start.
  */
 
-import { existsSync, appendFileSync, readFileSync } from 'fs';
+import { existsSync, appendFileSync, readFileSync, mkdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn, spawnSync } from 'child_process';
@@ -53,7 +53,8 @@ function findProjectRoot() {
 }
 
 const projectRoot = findProjectRoot();
-const LOG_PATH = resolve(projectRoot, '.swarm/hooks.log');
+const LOG_PATH = resolve(projectRoot, '.moflo', 'logs', 'hooks.log');
+try { mkdirSync(dirname(LOG_PATH), { recursive: true }); } catch { /* best effort */ }
 
 function log(msg) {
   const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);

--- a/.claude/scripts/index-guidance.mjs
+++ b/.claude/scripts/index-guidance.mjs
@@ -845,16 +845,16 @@ if (!skipEmbeddings && needsEmbeddings) {
 
   if (embeddingScript) {
     // Register the spawn with the shared ProcessManager (#886). Stdout/stderr
-    // route through `.swarm/background.log` (pm.spawn default) instead of the
-    // bespoke `.moflo/logs/embeddings.log` so the registry, dedup, and
-    // session-end drain stay consistent with every other tracked spawn.
+    // route through `.moflo/logs/background.log` (pm.spawn default) so the
+    // registry, dedup, and session-end drain stay consistent with every other
+    // tracked spawn.
     const pm = createProcessManager(projectRoot);
     const result = pm.spawn('node', [embeddingScript, '--namespace', NAMESPACE], `build-embeddings-${NAMESPACE}`);
     if (result.skipped) {
       log(`Background embedding already running (PID: ${result.pid})`);
     } else if (result.pid) {
       log(`Background embedding started (PID: ${result.pid})`);
-      log(`Log file: .swarm/background.log`);
+      log(`Log file: .moflo/logs/background.log`);
     } else {
       log('⚠️  Failed to spawn background embedding');
     }

--- a/.claude/scripts/lib/process-manager.mjs
+++ b/.claude/scripts/lib/process-manager.mjs
@@ -164,9 +164,9 @@ export function createProcessManager(root) {
         // This ensures errors from background indexers/pretrain are captured
         let stdio = 'ignore';
         try {
-          const swarmDir = resolve(projectRoot, '.swarm');
-          ensureDir(swarmDir);
-          const logPath = resolve(swarmDir, 'background.log');
+          const logsDir = resolve(projectRoot, '.moflo', 'logs');
+          ensureDir(logsDir);
+          const logPath = resolve(logsDir, 'background.log');
           const fd = openSync(logPath, 'a');
           stdio = ['ignore', fd, fd];
         } catch {

--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -36,14 +36,15 @@ const __dirname = dirname(__filename);
 // projects, so __dirname-relative paths break. findProjectRoot() works
 // everywhere and resolves identically to the TS bridge (see lib/moflo-paths.mjs).
 const projectRoot = findProjectRoot();
-const logFile = resolve(projectRoot, '.swarm/hooks.log');
+const logFile = resolve(projectRoot, '.moflo', 'logs', 'hooks.log');
+try { mkdirSync(dirname(logFile), { recursive: true }); } catch { /* best effort */ }
 const pm = createProcessManager(projectRoot);
 
 // Parse command line args
 const args = process.argv.slice(2);
 const hookType = args[0];
 
-// Simple log function - writes to .swarm/hooks.log
+// Simple log function - writes to .moflo/logs/hooks.log
 function log(level, message) {
   const timestamp = new Date().toISOString();
   const line = `[${timestamp}] [${level.toUpperCase()}] [${hookType || 'unknown'}] ${message}\n`;

--- a/bin/index-all.mjs
+++ b/bin/index-all.mjs
@@ -13,7 +13,7 @@
  * Spawned as a single detached background process by hooks.mjs session-start.
  */
 
-import { existsSync, appendFileSync, readFileSync } from 'fs';
+import { existsSync, appendFileSync, readFileSync, mkdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn, spawnSync } from 'child_process';
@@ -43,7 +43,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // so __dirname-relative paths break. findProjectRoot() (lib/moflo-paths.mjs)
 // works in both locations and resolves identically to the TS bridge.
 const projectRoot = findProjectRoot();
-const LOG_PATH = resolve(projectRoot, '.swarm/hooks.log');
+const LOG_PATH = resolve(projectRoot, '.moflo', 'logs', 'hooks.log');
+try { mkdirSync(dirname(LOG_PATH), { recursive: true }); } catch { /* best effort */ }
 
 function log(msg) {
   const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);

--- a/bin/index-guidance.mjs
+++ b/bin/index-guidance.mjs
@@ -845,16 +845,16 @@ if (!skipEmbeddings && needsEmbeddings) {
 
   if (embeddingScript) {
     // Register the spawn with the shared ProcessManager (#886). Stdout/stderr
-    // route through `.swarm/background.log` (pm.spawn default) instead of the
-    // bespoke `.moflo/logs/embeddings.log` so the registry, dedup, and
-    // session-end drain stay consistent with every other tracked spawn.
+    // route through `.moflo/logs/background.log` (pm.spawn default) so the
+    // registry, dedup, and session-end drain stay consistent with every other
+    // tracked spawn.
     const pm = createProcessManager(projectRoot);
     const result = pm.spawn('node', [embeddingScript, '--namespace', NAMESPACE], `build-embeddings-${NAMESPACE}`);
     if (result.skipped) {
       log(`Background embedding already running (PID: ${result.pid})`);
     } else if (result.pid) {
       log(`Background embedding started (PID: ${result.pid})`);
-      log(`Log file: .swarm/background.log`);
+      log(`Log file: .moflo/logs/background.log`);
     } else {
       log('⚠️  Failed to spawn background embedding');
     }

--- a/bin/lib/process-manager.mjs
+++ b/bin/lib/process-manager.mjs
@@ -164,9 +164,9 @@ export function createProcessManager(root) {
         // This ensures errors from background indexers/pretrain are captured
         let stdio = 'ignore';
         try {
-          const swarmDir = resolve(projectRoot, '.swarm');
-          ensureDir(swarmDir);
-          const logPath = resolve(swarmDir, 'background.log');
+          const logsDir = resolve(projectRoot, '.moflo', 'logs');
+          ensureDir(logsDir);
+          const logPath = resolve(logsDir, 'background.log');
           const fd = openSync(logPath, 'a');
           stdio = ['ignore', fd, fd];
         } catch {

--- a/src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the `.swarm/` residue auto-fix (Swarm Residue check).
+ *
+ * Validates that the migrator:
+ *  - deletes `.swarm/memory.db` + `.bak` once `.moflo/moflo.db` exists
+ *  - skips DB deletion when canonical is absent (surface advice, not destroy)
+ *  - renames router state JSONs into `.moflo/movector/`, preserving content
+ *  - keeps canonical state files when both exist (drops the legacy copy)
+ *  - relocates `hooks.log` + `background.log` into `.moflo/logs/`, appending
+ *    onto any pre-existing canonical log so history isn't lost
+ *  - rmdirs `.swarm/` when empty
+ *  - leaves `.swarm/` in place with unrecognised siblings, returning false
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { autoFixCheck } from '../../commands/doctor-fixes.js';
+
+let originalCwd: string;
+let tmpDir: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = mkdtempSync(join(tmpdir(), 'moflo-swarm-residue-'));
+  process.chdir(tmpDir);
+  mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const residueCheck = {
+  name: 'Swarm Residue',
+  status: 'warn' as const,
+  message: 'legacy artifacts in .swarm/',
+  fix: 'flo healer --fix -c swarm-residue',
+};
+
+function seedSwarm(files: Record<string, string>) {
+  const swarmDir = join(tmpDir, '.swarm');
+  mkdirSync(swarmDir, { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(swarmDir, name), contents, 'utf-8');
+  }
+}
+
+describe('Swarm Residue auto-fix — fixSwarmLegacyResidue', () => {
+  it('returns true and is a no-op when .swarm/ is absent', async () => {
+    const result = await autoFixCheck(residueCheck);
+    expect(result).toBe(true);
+    expect(existsSync(join(tmpDir, '.swarm'))).toBe(false);
+  });
+
+  it('deletes .swarm/memory.db + .bak once .moflo/moflo.db exists', async () => {
+    writeFileSync(join(tmpDir, '.moflo', 'moflo.db'), 'canonical', 'utf-8');
+    seedSwarm({
+      'memory.db': 'legacy',
+      'memory.db.bak': 'legacy-backup',
+    });
+
+    const result = await autoFixCheck(residueCheck);
+
+    expect(result).toBe(true);
+    expect(existsSync(join(tmpDir, '.swarm'))).toBe(false);
+    expect(readFileSync(join(tmpDir, '.moflo', 'moflo.db'), 'utf-8')).toBe('canonical');
+  });
+
+  it('refuses to delete memory.db when canonical is absent (returns false)', async () => {
+    seedSwarm({ 'memory.db': 'legacy' });
+
+    const result = await autoFixCheck(residueCheck);
+
+    expect(result).toBe(false);
+    expect(existsSync(join(tmpDir, '.swarm', 'memory.db'))).toBe(true);
+  });
+
+  it('relocates router state JSONs into .moflo/movector/ with content preserved', async () => {
+    seedSwarm({
+      'q-learning-model.json': '{"q":1}',
+      'model-router-state.json': '{"state":"router"}',
+    });
+
+    const result = await autoFixCheck(residueCheck);
+
+    expect(result).toBe(true);
+    expect(existsSync(join(tmpDir, '.swarm'))).toBe(false);
+    expect(readFileSync(join(tmpDir, '.moflo', 'movector', 'q-learning-model.json'), 'utf-8')).toBe('{"q":1}');
+    expect(readFileSync(join(tmpDir, '.moflo', 'movector', 'model-router-state.json'), 'utf-8')).toBe('{"state":"router"}');
+  });
+
+  it('keeps the canonical state file when both locations have content', async () => {
+    mkdirSync(join(tmpDir, '.moflo', 'movector'), { recursive: true });
+    writeFileSync(join(tmpDir, '.moflo', 'movector', 'q-learning-model.json'), '{"canonical":true}', 'utf-8');
+    seedSwarm({ 'q-learning-model.json': '{"legacy":true}' });
+
+    const result = await autoFixCheck(residueCheck);
+
+    expect(result).toBe(true);
+    expect(readFileSync(join(tmpDir, '.moflo', 'movector', 'q-learning-model.json'), 'utf-8')).toBe('{"canonical":true}');
+    expect(existsSync(join(tmpDir, '.swarm'))).toBe(false);
+  });
+
+  it('relocates logs into .moflo/logs/, appending onto an existing canonical', async () => {
+    mkdirSync(join(tmpDir, '.moflo', 'logs'), { recursive: true });
+    writeFileSync(join(tmpDir, '.moflo', 'logs', 'hooks.log'), 'canonical-line\n', 'utf-8');
+    seedSwarm({
+      'hooks.log': 'legacy-line\n',
+      'background.log': 'bg-legacy\n',
+    });
+
+    const result = await autoFixCheck(residueCheck);
+
+    expect(result).toBe(true);
+    expect(readFileSync(join(tmpDir, '.moflo', 'logs', 'hooks.log'), 'utf-8')).toBe('canonical-line\nlegacy-line\n');
+    expect(readFileSync(join(tmpDir, '.moflo', 'logs', 'background.log'), 'utf-8')).toBe('bg-legacy\n');
+    expect(existsSync(join(tmpDir, '.swarm'))).toBe(false);
+  });
+
+  it('leaves .swarm/ in place when an unrecognised file survives, returns false', async () => {
+    writeFileSync(join(tmpDir, '.moflo', 'moflo.db'), 'canonical', 'utf-8');
+    seedSwarm({
+      'memory.db': 'legacy',
+      'mystery-artifact.dat': 'unknown',
+    });
+
+    const result = await autoFixCheck(residueCheck);
+
+    expect(result).toBe(false);
+    expect(existsSync(join(tmpDir, '.swarm'))).toBe(true);
+    expect(existsSync(join(tmpDir, '.swarm', 'mystery-artifact.dat'))).toBe(true);
+    expect(existsSync(join(tmpDir, '.swarm', 'memory.db'))).toBe(false);
+  });
+});

--- a/src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts
@@ -27,17 +27,27 @@ import { join } from 'node:path';
 import { autoFixCheck } from '../../commands/doctor-fixes.js';
 
 let originalCwd: string;
+let originalClaudeProjectDir: string | undefined;
 let tmpDir: string;
 
 beforeEach(() => {
   originalCwd = process.cwd();
+  originalClaudeProjectDir = process.env.CLAUDE_PROJECT_DIR;
   tmpDir = mkdtempSync(join(tmpdir(), 'moflo-swarm-residue-'));
   process.chdir(tmpDir);
+  // `findProjectRoot()` honors CLAUDE_PROJECT_DIR. Pin it at the temp dir so
+  // the migrator can't escape to the real moflo repo when tests run under it.
+  process.env.CLAUDE_PROJECT_DIR = tmpDir;
   mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
 });
 
 afterEach(() => {
   process.chdir(originalCwd);
+  if (originalClaudeProjectDir === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = originalClaudeProjectDir;
+  }
   rmSync(tmpDir, { recursive: true, force: true });
 });
 

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -282,14 +282,10 @@ export async function checkMemoryDatabase(): Promise<HealthCheck> {
     const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
 
     if (dbPath === canonical) {
-      let message = `.moflo/moflo.db (${sizeMB} MB)`;
-      // Unfinished migration tail: source still present means the launcher's
-      // rename-to-.bak step failed (Windows lock most often). Flag so the user
-      // knows to clear the stale source.
-      if (existsSync(legacyMemoryDbPath(root))) {
-        message += ' — legacy .swarm/memory.db still present (delete it after confirming canonical is healthy)';
-      }
-      return { name: 'Memory Database', status: 'pass', message };
+      // Legacy `.swarm/memory.db` residue is owned by the separate
+      // `checkSwarmResidue` check so we keep this check focused on the
+      // canonical DB. That check carries the auto-fix.
+      return { name: 'Memory Database', status: 'pass', message: `.moflo/moflo.db (${sizeMB} MB)` };
     }
 
     return {
@@ -301,6 +297,48 @@ export async function checkMemoryDatabase(): Promise<HealthCheck> {
   }
 
   return { name: 'Memory Database', status: 'warn', message: 'Not initialized', fix: 'claude-flow memory configure --backend hybrid' };
+}
+
+/**
+ * Catches `.swarm/` residue that survived past the canonical migration:
+ *  - `memory.db` / `memory.db.bak` — stale once `.moflo/moflo.db` exists.
+ *  - `q-learning-model.json` / `model-router-state.json` — live router state
+ *    that pre-dates the `.moflo/movector/` defaults; migrate, don't delete.
+ *  - `hooks.log` / `background.log` — diagnostic logs the launcher used to
+ *    route to `.swarm/`; relocate to `.moflo/logs/`.
+ *
+ * Passes when `.swarm/` is absent OR contains nothing the migrator recognises.
+ * Otherwise warns with `fix: 'flo healer --fix -c swarm-residue'` so the auto-fix
+ * dispatcher (`fixSwarmLegacyResidue` in doctor-fixes.ts) can clean it up in
+ * one pass.
+ */
+export async function checkSwarmResidue(): Promise<HealthCheck> {
+  const root = process.cwd();
+  const swarmDir = join(root, '.swarm');
+  if (!existsSync(swarmDir)) {
+    return { name: 'Swarm Residue', status: 'pass', message: 'No .swarm/ directory present' };
+  }
+
+  const artifacts = [
+    'memory.db',
+    'memory.db.bak',
+    'q-learning-model.json',
+    'model-router-state.json',
+    'hooks.log',
+    'background.log',
+  ];
+  const present = artifacts.filter(name => existsSync(join(swarmDir, name)));
+
+  if (present.length === 0) {
+    return { name: 'Swarm Residue', status: 'pass', message: '.swarm/ present but no known residue' };
+  }
+
+  return {
+    name: 'Swarm Residue',
+    status: 'warn',
+    message: `${present.length} legacy artifact(s) in .swarm/: ${present.join(', ')}`,
+    fix: 'flo healer --fix -c swarm-residue',
+  };
 }
 
 /**

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -19,6 +19,7 @@ import {
   normalizeProjectRoot,
 } from '../services/daemon-port.js';
 import {
+  LEGACY_SWARM_DIR,
   legacyMemoryDbPath,
   memoryDbCandidatePaths,
   memoryDbPath,
@@ -313,8 +314,8 @@ export async function checkMemoryDatabase(): Promise<HealthCheck> {
  * one pass.
  */
 export async function checkSwarmResidue(): Promise<HealthCheck> {
-  const root = process.cwd();
-  const swarmDir = join(root, '.swarm');
+  const root = findProjectRoot();
+  const swarmDir = join(root, LEGACY_SWARM_DIR);
   if (!existsSync(swarmDir)) {
     return { name: 'Swarm Residue', status: 'pass', message: 'No .swarm/ directory present' };
   }

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -6,7 +6,7 @@
  * if it looks like an `npx`/`npm`/`claude` command.
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, rmdirSync, unlinkSync, writeFileSync, readdirSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmdirSync, unlinkSync, writeFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { output } from '../output.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
@@ -14,6 +14,7 @@ import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 import { getDaemonLockHolder } from '../services/daemon-lock.js';
 import { findProjectRoot } from '../services/project-root.js';
+import { legacyMemoryDbPath, legacyMemoryDbBakPath, memoryDbPath, mofloDir } from '../services/moflo-paths.js';
 import { findZombieProcesses } from './doctor-zombies.js';
 import { inspectMcpConfigs } from './doctor-checks-config.js';
 import { installClaudeCode, runCommand } from './doctor-checks-runtime.js';
@@ -123,19 +124,26 @@ async function fixGateHealthHooks(): Promise<boolean> {
  * contents.
  */
 async function fixSwarmLegacyResidue(): Promise<boolean> {
-  const root = process.cwd();
+  const root = findProjectRoot();
   const swarmDir = join(root, '.swarm');
   if (!existsSync(swarmDir)) return true;
 
-  const canonicalDb = join(root, '.moflo', 'moflo.db');
-  const movectorDir = join(root, '.moflo', 'movector');
-  const logsDir = join(root, '.moflo', 'logs');
+  const canonicalDb = memoryDbPath(root);
+  const moflo = mofloDir(root);
+  const movectorDir = join(moflo, 'movector');
+  const logsDir = join(moflo, 'logs');
 
   let allMigrated = true;
 
-  // (1) memory.db + .bak — only safe to delete once the canonical exists.
-  for (const name of ['memory.db', 'memory.db.bak']) {
-    const src = join(swarmDir, name);
+  // (1) memory.db + .bak — both are migration artifacts of the launcher's
+  // copy-verify-rename step; if the canonical isn't yet in place neither
+  // source is safe to delete. The launcher creates the `.bak` only AFTER
+  // canonical exists, so this guard is conservative but correct.
+  const legacyDbPaths: Array<[string, string]> = [
+    ['memory.db', legacyMemoryDbPath(root)],
+    ['memory.db.bak', legacyMemoryDbBakPath(root)],
+  ];
+  for (const [name, src] of legacyDbPaths) {
     if (!existsSync(src)) continue;
     if (!existsSync(canonicalDb)) {
       output.writeln(output.warning(
@@ -177,8 +185,8 @@ async function fixSwarmLegacyResidue(): Promise<boolean> {
   }
 
   // (3) logs — best-effort move. Append into canonical if it already exists
-  // (don't drop history) by reading + appending + unlinking. Logs are small
-  // enough that the read-into-memory cost is acceptable.
+  // (don't drop history). Hook + background logs are bounded to kilobytes in
+  // practice so the read-into-memory cost is acceptable.
   const logFiles = ['hooks.log', 'background.log'];
   for (const name of logFiles) {
     const src = join(swarmDir, name);
@@ -187,10 +195,7 @@ async function fixSwarmLegacyResidue(): Promise<boolean> {
     try {
       mkdirSync(logsDir, { recursive: true });
       if (existsSync(target)) {
-        const legacyContents = readFileSync(src);
-        // appendFileSync via writeFileSync with flag:'a' to avoid pulling in
-        // another import; functionally identical for our purposes.
-        writeFileSync(target, legacyContents, { flag: 'a' });
+        appendFileSync(target, readFileSync(src));
         unlinkSync(src);
       } else {
         renameSync(src, target);

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -6,7 +6,7 @@
  * if it looks like an `npx`/`npm`/`claude` command.
  */
 
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, rmdirSync, unlinkSync, writeFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { output } from '../output.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
@@ -97,6 +97,128 @@ async function fixGateHealthHooks(): Promise<boolean> {
   }
 
   return driftFixed && wiringFixed;
+}
+
+/**
+ * Migrate `.swarm/` residue to its canonical home and remove the legacy directory.
+ *
+ * Three categories of artifact:
+ *   1. `memory.db` (+ `.bak`)               — stale once `.moflo/moflo.db` exists; delete.
+ *   2. `q-learning-model.json` / `model-router-state.json` — live RL state.
+ *      Rename into `.moflo/movector/`. If the canonical target already exists
+ *      (consumer ran moflo on the new defaults before the auto-fix), the
+ *      canonical wins and the `.swarm/` copy is unlinked.
+ *   3. `hooks.log` / `background.log`       — diagnostic logs. Relocate to
+ *      `.moflo/logs/`; append into the canonical file if it already exists
+ *      so we don't drop history. Best-effort — log loss is acceptable.
+ *
+ * Finally `rmdir .swarm/` if and only if it's empty. Anything we didn't
+ * recognise is left in place rather than silently deleted.
+ *
+ * Cross-platform: uses `fs.rename`/`rmdir` (Node primitives), forward-slash-free
+ * joins via `path.join`. Works on Windows + POSIX.
+ *
+ * Returns true if the directory was fully retired OR if there was nothing to
+ * migrate; false if any relocation throws or `.swarm/` survives with unknown
+ * contents.
+ */
+async function fixSwarmLegacyResidue(): Promise<boolean> {
+  const root = process.cwd();
+  const swarmDir = join(root, '.swarm');
+  if (!existsSync(swarmDir)) return true;
+
+  const canonicalDb = join(root, '.moflo', 'moflo.db');
+  const movectorDir = join(root, '.moflo', 'movector');
+  const logsDir = join(root, '.moflo', 'logs');
+
+  let allMigrated = true;
+
+  // (1) memory.db + .bak — only safe to delete once the canonical exists.
+  for (const name of ['memory.db', 'memory.db.bak']) {
+    const src = join(swarmDir, name);
+    if (!existsSync(src)) continue;
+    if (!existsSync(canonicalDb)) {
+      output.writeln(output.warning(
+        `  Skipping ${name}: .moflo/moflo.db absent — run \`flo memory init\` first.`,
+      ));
+      allMigrated = false;
+      continue;
+    }
+    try {
+      unlinkSync(src);
+    } catch (e) {
+      output.writeln(output.warning(`  Failed to delete ${name}: ${errorDetail(e)}`));
+      allMigrated = false;
+    }
+  }
+
+  // (2) router state JSONs — rename into .moflo/movector/.
+  const stateFiles = [
+    { name: 'q-learning-model.json', dest: movectorDir },
+    { name: 'model-router-state.json', dest: movectorDir },
+  ];
+  for (const { name, dest } of stateFiles) {
+    const src = join(swarmDir, name);
+    if (!existsSync(src)) continue;
+    const target = join(dest, name);
+    try {
+      mkdirSync(dest, { recursive: true });
+      if (existsSync(target)) {
+        // Canonical already populated by a fresh save on the new defaults.
+        // Keep the canonical, drop the legacy copy.
+        unlinkSync(src);
+      } else {
+        renameSync(src, target);
+      }
+    } catch (e) {
+      output.writeln(output.warning(`  Failed to relocate ${name}: ${errorDetail(e)}`));
+      allMigrated = false;
+    }
+  }
+
+  // (3) logs — best-effort move. Append into canonical if it already exists
+  // (don't drop history) by reading + appending + unlinking. Logs are small
+  // enough that the read-into-memory cost is acceptable.
+  const logFiles = ['hooks.log', 'background.log'];
+  for (const name of logFiles) {
+    const src = join(swarmDir, name);
+    if (!existsSync(src)) continue;
+    const target = join(logsDir, name);
+    try {
+      mkdirSync(logsDir, { recursive: true });
+      if (existsSync(target)) {
+        const legacyContents = readFileSync(src);
+        // appendFileSync via writeFileSync with flag:'a' to avoid pulling in
+        // another import; functionally identical for our purposes.
+        writeFileSync(target, legacyContents, { flag: 'a' });
+        unlinkSync(src);
+      } else {
+        renameSync(src, target);
+      }
+    } catch (e) {
+      output.writeln(output.warning(`  Failed to relocate ${name}: ${errorDetail(e)}`));
+      allMigrated = false;
+    }
+  }
+
+  // (4) rmdir .swarm/ if it's empty. Anything left is unrecognised — leave it
+  // for the user to inspect rather than silently delete.
+  try {
+    const remaining = readdirSync(swarmDir);
+    if (remaining.length === 0) {
+      rmdirSync(swarmDir);
+    } else {
+      output.writeln(output.dim(
+        `  .swarm/ kept (${remaining.length} unrecognised entr${remaining.length === 1 ? 'y' : 'ies'}): ${remaining.join(', ')}`,
+      ));
+      allMigrated = false;
+    }
+  } catch (e) {
+    output.writeln(output.warning(`  Failed to remove .swarm/: ${errorDetail(e)}`));
+    allMigrated = false;
+  }
+
+  return allMigrated;
 }
 
 /**
@@ -427,6 +549,12 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
         output.writeln(output.warning(`  Repair failed: ${errorDetail(e)}`));
         return false;
       }
+    },
+    // Migrate `.swarm/` residue (legacy memory.db, RL state JSONs, hook/bg logs)
+    // into their canonical `.moflo/` homes and rmdir the directory once empty.
+    // See `fixSwarmLegacyResidue` for the per-artifact policy.
+    'Swarm Residue': async () => {
+      return fixSwarmLegacyResidue();
     },
     'Status Line': async () => {
       const settingsPath = join(process.cwd(), '.claude', 'settings.json');

--- a/src/cli/commands/doctor-registry.ts
+++ b/src/cli/commands/doctor-registry.ts
@@ -45,6 +45,7 @@ import {
   checkMemoryDbIntegrity,
   checkMofloYamlCompliance,
   checkStatusLine,
+  checkSwarmResidue,
   checkTestDirs,
 } from './doctor-checks-config.js';
 import { checkSpellEngine, checkSandboxTier } from './doctor-checks-platform.js';
@@ -83,6 +84,10 @@ export const allChecks: CheckFn[] = [
   checkDaemonWriteRouting,
   checkWritersAudit,
   checkMemoryDatabase,
+  // Surfaces leftover `.swarm/` artifacts (memory.db, router state, logs) so
+  // the auto-fix can relocate or delete them. Independent of the canonical
+  // DB checks — runs cheap (statSync only).
+  checkSwarmResidue,
   // Owns the corruption signal so downstream checks (Embeddings, Semantic
   // Quality, Memory Access Functional) don't surface it as the synthetic
   // "Check" failure (doctor.ts:214). MUST run after checkMemoryDatabase
@@ -150,6 +155,8 @@ export const componentMap: Record<string, CheckFn> = {
   'writers-audit': checkWritersAudit,
   'writers': checkWritersAudit,
   'memory': checkMemoryDatabase,
+  'swarm-residue': checkSwarmResidue,
+  'residue': checkSwarmResidue,
   'memory-db-integrity': checkMemoryDbIntegrity,
   'integrity': checkMemoryDbIntegrity,
   'memory-integrity': checkMemoryDbIntegrity,

--- a/src/cli/movector/model-router.ts
+++ b/src/cli/movector/model-router.ts
@@ -196,7 +196,7 @@ const DEFAULT_CONFIG: ModelRouterConfig = {
   maxUncertainty: 0.15,
   enableCircuitBreaker: true,
   circuitBreakerThreshold: 5,
-  statePath: '.swarm/model-router-state.json',
+  statePath: '.moflo/movector/model-router-state.json',
   autoSaveInterval: 1, // Save after every decision for CLI persistence
   enableCostOptimization: true,
   preferSpeed: true,

--- a/src/cli/movector/q-learning-router.ts
+++ b/src/cli/movector/q-learning-router.ts
@@ -9,7 +9,7 @@
  * - Optimized state space with feature hashing
  * - Epsilon decay with exponential annealing
  * - Experience replay buffer for stable learning
- * - Model persistence to .swarm/q-learning-model.json
+ * - Model persistence to .moflo/movector/q-learning-model.json
  *
  * @module q-learning-router
  */
@@ -48,7 +48,7 @@ export interface QLearningRouterConfig {
   cacheSize: number;
   /** Cache TTL in milliseconds (default: 300000 = 5 minutes) */
   cacheTTL: number;
-  /** Model persistence path (default: '.swarm/q-learning-model.json') */
+  /** Model persistence path (default: '.moflo/movector/q-learning-model.json') */
   modelPath: string;
   /** Auto-save interval in updates (default: 100) */
   autoSaveInterval: number;
@@ -140,7 +140,7 @@ const DEFAULT_CONFIG: QLearningRouterConfig = {
   enableReplay: true,
   cacheSize: 256,
   cacheTTL: 300000,
-  modelPath: '.swarm/q-learning-model.json',
+  modelPath: '.moflo/movector/q-learning-model.json',
   autoSaveInterval: 100,
   stateSpaceDim: 64,
 };


### PR DESCRIPTION
## Summary
- `.swarm/memory.db` kept reappearing after manual deletes because four other writers (q-learning router, model router, hooks.log, background.log) still defaulted to `.swarm/`, leaving the directory alive for the legacy DB to hide in.
- Relocates source defaults so new consumer installs never create `.swarm/`: router state → `.moflo/movector/`, hook + background logs → `.moflo/logs/`.
- Adds a `Swarm Residue` doctor check + `fixSwarmLegacyResidue` migrator under `flo healer --fix` that deletes the stale DB once canonical exists, relocates live RL state (canonical wins on collision), appends legacy logs onto canonical, and rmdirs `.swarm/` if empty.

## Why these aren't just deletes
The two router state JSONs hold accumulated Q-values used by `flo route` and `sona-optimizer`. Wiping them resets routing to defaults. The migrator renames so learned state survives the relocation. `memory.db` itself is the only category we delete outright, and only after confirming `.moflo/moflo.db` exists.

## Files
- `src/cli/movector/q-learning-router.ts` + `model-router.ts` — source default paths moved to `.moflo/movector/`.
- `bin/{hooks,index-all,index-guidance,lib/process-manager}.mjs` and the four `.claude/scripts/` synced twins — log paths moved to `.moflo/logs/`, mkdirSync guards added so the first post-migration hook fire doesnt lose writes.
- `src/cli/commands/doctor-checks-config.ts` — new `checkSwarmResidue`; existing `checkMemoryDatabase` no longer carries the inline legacy tail.
- `src/cli/commands/doctor-fixes.ts` — `fixSwarmLegacyResidue` migrator wired into the dispatcher.
- `src/cli/commands/doctor-registry.ts` — registered new check + componentMap aliases (`swarm-residue`, `residue`).
- `src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts` — 7 cases covering absent dir, canonical-missing refusal, content preservation, collision policy, log-append, unknown-residue refusal.

## Test plan
- [x] `npm run build` (clean)
- [x] `npx vitest run src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts` — 7 / 7 pass
- [x] `npx vitest run src/cli/__tests__/movector src/cli/__tests__/commands/doctor-*` — 670+ existing tests still pass
- [x] `npx vitest run src/cli/__tests__/services/published-package-drift-guard.test.ts` — drift guard still passes
- [x] `npx vitest run tests/bin/launcher-visibility.test.ts` — bin/ scripts load correctly with relocated log paths
- [ ] Manual: post-merge, run `flo healer --fix` against a project with seeded `.swarm/` residue; verify `.swarm/` is gone and `.moflo/movector/`, `.moflo/logs/` populated

## Cross-platform (CLAUDE.md Rule #1)
Migrator uses `fs.rename` / `fs.rmdir` / `path.join` only — no shell-outs. `mkdirSync(..., { recursive: true })` for log-dir creation. Verified on Windows; same primitives apply identically on macOS + Linux.

## Consumer surface (CLAUDE.md Rule #2)
- Source defaults — consumers reinstall, new defaults apply; existing `.swarm/` state is migrated by the healer fix
- bin/ + .claude/scripts/ twins — kept in sync per scriptFiles convention; log-dir guard added so first hook fire after migration doesnt lose writes
- Doctor surface — one new check (`Swarm Residue`); targeted invocation via `flo healer --fix -c swarm-residue`

## Review-pass fixups applied before push
- Migrator resolves via `findProjectRoot()` (not `process.cwd()`) to avoid re-introducing the #1057 path-mismatch bug class
- Reuses `memoryDbPath()`, `legacyMemoryDbPath()`, `legacyMemoryDbBakPath()`, `LEGACY_SWARM_DIR` from `services/moflo-paths.ts` instead of inline string joins
- Test pins `CLAUDE_PROJECT_DIR` to its tempdir so `findProjectRoot()` cant escape upward to the real moflo repo

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)