### PR TITLE
fix(daemon): retry /api/health probe to absorb Windows boot race (#1163)

### DIFF
--- a/src/cli/__tests__/services/daemon-port-retry.test.ts
+++ b/src/cli/__tests__/services/daemon-port-retry.test.ts
@@ -80,16 +80,18 @@ describe('probeDaemonHealthWithRetry — #1163', () => {
     const targetPort = (probeOnly.address() as AddressInfo).port;
     await new Promise<void>((r) => probeOnly.close(() => r()));
 
-    // Start the retry in parallel; server comes up after ~150ms (after the
-    // first backoff of 50ms but during the second of 200ms).
+    // Start the retry in parallel; server comes up after ~150ms (during the
+    // probe's second attempt window). Capture the late server into the
+    // module-level `server` so `afterEach` closes it — leaving it listening
+    // leaks the ephemeral port across tests.
     const probePromise = probeDaemonHealthWithRetry(targetPort, 300);
     setTimeout(() => {
-      createServer((_req, res) => {
+      const lateServer = createServer((_req, res) => {
         res.writeHead(200, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ projectRoot: '/late/boot' }));
-      }).listen(targetPort, '127.0.0.1', () => {
-        // capture for cleanup
-        server = null;
+      });
+      lateServer.listen(targetPort, '127.0.0.1', () => {
+        server = lateServer;
       });
     }, 150);
 

--- a/src/cli/__tests__/services/daemon-port-retry.test.ts
+++ b/src/cli/__tests__/services/daemon-port-retry.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for `probeDaemonHealthWithRetry` (#1163).
+ *
+ * Validates that the retry wrapper absorbs transient `unreachable` results
+ * (Windows CI daemon-mid-boot race) while letting `identity` and `legacy`
+ * pass through as terminal.
+ *
+ * Uses a real localhost HTTP server bound to an ephemeral port so we exercise
+ * the same TCP path the production probe uses — no mocking of `http.get`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import {
+  probeDaemonHealth,
+  probeDaemonHealthWithRetry,
+} from '../../services/daemon-port.js';
+
+let server: Server | null = null;
+let port = 0;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = null;
+  }
+});
+
+function startServer(handler: (req: any, res: any) => void): Promise<number> {
+  return new Promise((resolve) => {
+    const s = createServer(handler);
+    s.listen(0, '127.0.0.1', () => {
+      const addr = s.address() as AddressInfo;
+      server = s;
+      port = addr.port;
+      resolve(addr.port);
+    });
+  });
+}
+
+describe('probeDaemonHealthWithRetry — #1163', () => {
+  it('returns identity on first success without retry overhead', async () => {
+    await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ projectRoot: '/some/root' }));
+    });
+
+    const start = Date.now();
+    const probe = await probeDaemonHealthWithRetry(port, 500);
+    const elapsed = Date.now() - start;
+
+    expect(probe).toEqual({ kind: 'identity', projectRoot: '/some/root' });
+    // First attempt is immediate (no backoff sleep), so elapsed << 50ms.
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it('passes through legacy (404) without retrying', async () => {
+    await startServer((_req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+
+    const start = Date.now();
+    const probe = await probeDaemonHealthWithRetry(port, 500);
+    const elapsed = Date.now() - start;
+
+    expect(probe).toEqual({ kind: 'legacy' });
+    // 404 is terminal — no backoff sleeps fired.
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it('retries on unreachable and recovers when the server comes up mid-cycle', async () => {
+    // Find an unused port: bind+immediately close a server. Race window is
+    // narrow but acceptable for a test — if EADDRINUSE fires the test will
+    // legitimately fail.
+    const probeOnly = createServer();
+    await new Promise<void>((r) => probeOnly.listen(0, '127.0.0.1', () => r()));
+    const targetPort = (probeOnly.address() as AddressInfo).port;
+    await new Promise<void>((r) => probeOnly.close(() => r()));
+
+    // Start the retry in parallel; server comes up after ~150ms (after the
+    // first backoff of 50ms but during the second of 200ms).
+    const probePromise = probeDaemonHealthWithRetry(targetPort, 300);
+    setTimeout(() => {
+      createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ projectRoot: '/late/boot' }));
+      }).listen(targetPort, '127.0.0.1', () => {
+        // capture for cleanup
+        server = null;
+      });
+    }, 150);
+
+    const probe = await probePromise;
+    expect(probe.kind).toBe('identity');
+    if (probe.kind === 'identity') {
+      expect(probe.projectRoot).toBe('/late/boot');
+    }
+  });
+
+  it('returns unreachable after exhausting retries (no listener at all)', async () => {
+    // Same probe-and-close trick to find a free port we know is empty.
+    const probeOnly = createServer();
+    await new Promise<void>((r) => probeOnly.listen(0, '127.0.0.1', () => r()));
+    const deadPort = (probeOnly.address() as AddressInfo).port;
+    await new Promise<void>((r) => probeOnly.close(() => r()));
+
+    const start = Date.now();
+    const probe = await probeDaemonHealthWithRetry(deadPort, 100);
+    const elapsed = Date.now() - start;
+
+    expect(probe).toEqual({ kind: 'unreachable' });
+    // 4 attempts × ~100ms probe + 50+200+800ms backoff ≈ ~1450ms floor.
+    // Allow generous slack for CI scheduler jitter; the important assertion
+    // is that we ARE waiting for the retries, not bailing on first failure.
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+  });
+
+  it('base probeDaemonHealth does NOT retry (regression guard)', async () => {
+    const probeOnly = createServer();
+    await new Promise<void>((r) => probeOnly.listen(0, '127.0.0.1', () => r()));
+    const deadPort = (probeOnly.address() as AddressInfo).port;
+    await new Promise<void>((r) => probeOnly.close(() => r()));
+
+    const start = Date.now();
+    const probe = await probeDaemonHealth(deadPort, 100);
+    const elapsed = Date.now() - start;
+
+    expect(probe).toEqual({ kind: 'unreachable' });
+    // One-shot — should return within ~timeout + connect-refuse latency.
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -15,7 +15,7 @@ import {
 import {
   resolveClientPort,
   LEGACY_DEFAULT_PORT,
-  probeDaemonHealth as probeDaemonHealthIdentity,
+  probeDaemonHealthWithRetry as probeDaemonHealthIdentity,
   normalizeProjectRoot,
 } from '../services/daemon-port.js';
 import {

--- a/src/cli/services/daemon-port.ts
+++ b/src/cli/services/daemon-port.ts
@@ -267,6 +267,11 @@ const PROBE_RETRY_BACKOFF_MS = [50, 200, 800] as const;
  * Mirrors the retry pattern from `bin/lib/file-sync.mjs:syncWithRetry`
  * (`feedback_transient_retry_circuit_breaker` — every transient-error op
  * uses 50/200/800ms backoff).
+ *
+ * Worst-case elapsed = (PROBE_RETRY_BACKOFF_MS.length + 1) × timeoutMs
+ * + sum(PROBE_RETRY_BACKOFF_MS). For doctor's 1500ms timeout that's
+ * 4 × 1500 + 1050 ≈ 7s, fully off the hot path; callers picking a tighter
+ * timeout should account for the 4× multiplier.
  */
 export async function probeDaemonHealthWithRetry(
   port: number,

--- a/src/cli/services/daemon-port.ts
+++ b/src/cli/services/daemon-port.ts
@@ -249,3 +249,39 @@ export function probeDaemonHealth(
     req.on('timeout', () => { req.destroy(); finish({ kind: 'unreachable' }); });
   });
 }
+
+/** Retry backoff schedule for HTTP liveness probes (#1163 — Windows CI race). */
+const PROBE_RETRY_BACKOFF_MS = [50, 200, 800] as const;
+
+/**
+ * {@link probeDaemonHealth} with retry on transient `unreachable` results.
+ *
+ * The bare one-shot probe was tripping in CI when a daemon was mid-boot on
+ * Windows: the lockfile said v4.10.8 was alive but the HTTP server hadn't
+ * accepted /api/health yet, and the doctor check raised "unreachable" inside
+ * the 1500ms window. This wrapper retries 3× at 50/200/800 ms — total
+ * worst-case ~1s extra — and only on `unreachable`. `identity` and `legacy`
+ * are terminal: a daemon answering with a different project root or 404 is
+ * a real signal, not a race.
+ *
+ * Mirrors the retry pattern from `bin/lib/file-sync.mjs:syncWithRetry`
+ * (`feedback_transient_retry_circuit_breaker` — every transient-error op
+ * uses 50/200/800ms backoff).
+ */
+export async function probeDaemonHealthWithRetry(
+  port: number,
+  timeoutMs: number,
+): Promise<DaemonIdentityProbe> {
+  let last: DaemonIdentityProbe = { kind: 'unreachable' };
+  const maxAttempts = PROBE_RETRY_BACKOFF_MS.length + 1;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, PROBE_RETRY_BACKOFF_MS[attempt - 1]),
+      );
+    }
+    last = await probeDaemonHealth(port, timeoutMs);
+    if (last.kind !== 'unreachable') return last;
+  }
+  return last;
+}


### PR DESCRIPTION
## Summary
Closes #1163.

`checkDaemonIdentity` was calling `probeDaemonHealth` as a one-shot 1500ms HTTP timeout. On Windows CI runners the daemon's HTTP server can be mid-boot when doctor probes (the lockfile is already stamped — `Daemon Version Skew` passes — but `/api/health` hasn't accepted connections yet), so the identity probe times out, `--strict` flips warn→fail, and the consumer-smoke job goes red on a transient race. Hit on PR #1162 Windows: https://github.com/eric-cielo/moflo/actions/runs/25945073770/job/76271331169

## Approach
Add `probeDaemonHealthWithRetry` next to `probeDaemonHealth`. Same 50/200/800ms backoff schedule `bin/lib/file-sync.mjs:syncWithRetry` uses (per `feedback_transient_retry_circuit_breaker` — every transient-error op retries, never one-shot). Retries only on `{ kind: 'unreachable' }`; `identity` and `legacy` are terminal so a daemon answering with a foreign project root or a 404 still surfaces immediately. Worst case = 4 × timeoutMs + 1050ms backoff ≈ 7s for the default doctor 1500ms timeout — fully off the hot path.

`checkDaemonIdentity` swaps to the retry variant via the existing `probeDaemonHealthIdentity` import alias — no callsite changes downstream.

## Files
- `src/cli/services/daemon-port.ts` — new `probeDaemonHealthWithRetry` + `PROBE_RETRY_BACKOFF_MS` constant; base `probeDaemonHealth` unchanged.
- `src/cli/commands/doctor-checks-config.ts` — one-line alias swap on the import.
- `src/cli/__tests__/services/daemon-port-retry.test.ts` — 5 unit tests using real localhost HTTP servers (no http.get mocking).

## Test plan
- [x] `npm run build` (clean)
- [x] `npx vitest run src/cli/__tests__/services/daemon-port-retry.test.ts src/cli/__tests__/services/daemon-port.test.ts` — 27 / 27 pass
- [x] `npx vitest run src/cli/__tests__/commands/doctor-fixes-*.test.ts src/cli/__tests__/commands/doctor-embedding-hygiene.test.ts` — 53 / 53 pass
- [ ] Three consecutive consumer-smoke Windows runs clear without rerun (acceptance criterion from #1163)

## Why `legacy` stays terminal
A post-#1145 daemon registers `/api/health` BEFORE entering the accept loop, so the window "port accepts connections but route is 404" doesn't exist in practice. Pre-#1145 daemons that 200/404 every URL are a real signal (recycle to upgrade), not a race.

## Review-pass fixups applied before push
- Test resource leak: late-boot test server now captured into the module-level `server` so `afterEach` closes it on failure paths.
- `probeDaemonHealthWithRetry` JSDoc documents the worst-case formula (4 × timeoutMs + sum(backoffs)) so callers picking a tighter timeout understand the 4× multiplier.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)