### PR TITLE
feat(dashboard): spinner on Claude Stats first load + /luminarium skill

### DIFF
--- a/.claude/skills/luminarium/SKILL.md
+++ b/.claude/skills/luminarium/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: luminarium
+description: |
+  Print the localhost URL for The Luminarium — moflo's daemon dashboard — for the current project.
+  Use when the user asks for "the luminarium link", "the moflo dashboard", "the daemon UI", or anything synonymous.
+  Each project gets a deterministic port in 33000–33999; the actual bound port is recorded in `.moflo/daemon.lock`.
+---
+
+# /luminarium — Project Dashboard Link
+
+Surface the URL for The Luminarium (the moflo daemon's localhost UI) for the project that this session is running in. No prompts, no confirmations — print the link and stop.
+
+## Procedure
+
+1. **Find the project root.** Walk up from `process.cwd()` looking for a `.moflo/` directory. The session's cwd is almost always the project root, so check there first.
+
+2. **Read `.moflo/daemon.lock`.** It's a JSON file written by the daemon at bind time. The dashboard port is the `port` field:
+
+   ```json
+   { "pid": 12345, "port": 33421, "startedAt": "...", ... }
+   ```
+
+   - If the file exists and `port` is a valid number → the daemon is running and bound. Use that port.
+   - If the file is missing or `port` is absent/invalid → the daemon is not running. See step 4.
+
+3. **Print the link** in a single line, with the path verbatim — Claude Code renders it as clickable:
+
+   ```
+   The Luminarium: http://localhost:<port>
+   ```
+
+   Nothing else. No banner, no follow-up question, no "what would you like to do?".
+
+4. **If the daemon isn't running** (no lock file, or unparseable), say so in one line and offer the start command — don't run it:
+
+   ```
+   The moflo daemon isn't running for this project. Start it with: npx flo daemon start
+   ```
+
+## Why read the lock, not compute the port
+
+The port is project-deterministic (sha256(projectRoot) mapped into 33000–33999), but if the deterministic port was already taken at bind time the daemon scans forward and binds an alternate. The lock file is the only source of truth for what's actually bound. Do not compute the hash yourself — read the file.
+
+## Don't
+
+- Don't fall back to `http://localhost:3117` — that's the retired pre-#1145 port and routes to a foreign daemon on multi-project machines.
+- Don't compute the deterministic port and report it as the link when the lock is missing — the daemon may be down, or bound to an alternate port. Report "not running" instead.
+- Don't run `flo daemon start` automatically — the user asked for a link, not for daemon management. Leave starting to `/healer` or the user.
+- Don't open a browser. Print the URL; let the user click.
+
+## Output
+
+A single line. Examples:
+
+```
+The Luminarium: http://localhost:33421
+```
+
+```
+The moflo daemon isn't running for this project. Start it with: npx flo daemon start
+```
+
+## See Also
+
+- `/healer` — diagnoses and (with `--fix`) starts the daemon if it's not running.
+- `src/cli/services/daemon-port.ts` (and its JS twin `bin/lib/daemon-port.mjs`) — canonical port-resolution helpers; `resolveClientPort()` is what the rest of moflo uses.

--- a/.claude/skills/luminarium/SKILL.md
+++ b/.claude/skills/luminarium/SKILL.md
@@ -43,7 +43,7 @@ The port is project-deterministic (sha256(projectRoot) mapped into 33000–33999
 
 ## Don't
 
-- Don't fall back to `http://localhost:3117` — that's the retired pre-#1145 port and routes to a foreign daemon on multi-project machines.
+- Don't fall back to any hardcoded port — there is no project-agnostic dashboard port; a literal would route to a foreign daemon on a multi-project machine. If the lock is missing, report "not running".
 - Don't compute the deterministic port and report it as the link when the lock is missing — the daemon may be down, or bound to an alternate port. Report "not running" instead.
 - Don't run `flo daemon start` automatically — the user asked for a link, not for daemon management. Leave starting to `/healer` or the user.
 - Don't open a browser. Print the URL; let the user click.

--- a/src/cli/init/executor.ts
+++ b/src/cli/init/executor.ts
@@ -47,6 +47,7 @@ export const SKILLS_MAP: Record<string, string[]> = {
     'guidance',
     'healer',
     'flo-simplify',
+    'luminarium',
     'reasoningbank-intelligence',
   ],
   memory: [

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -895,7 +895,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <div id="panel-schedules" class="panel" style="display:none"><div id="schedules-active"></div><div id="schedules-events"></div></div>
   <div id="panel-executions" class="panel" style="display:none"></div>
   <div id="panel-memory" class="panel" style="display:none"></div>
-  <div id="panel-claude-stats" class="panel" style="display:none"><div class="loading-block"><div class="spinner"></div><div class="msg">Reading Claude Code transcripts…</div><div class="hint">First load can take 10–15 seconds — moflo walks every session file in this project's transcript directory. Subsequent loads in this tab are much faster.</div></div></div>
+  <div id="panel-claude-stats" class="panel" style="display:none"><div class="loading-block" role="status" aria-label="Loading Claude Code transcripts"><div class="spinner"></div><div class="msg">Reading Claude Code transcripts…</div><div class="hint">First load can take 10–15 seconds — moflo walks every session file in this project's transcript directory. Subsequent loads in this tab are much faster.</div></div></div>
   <div id="poll-indicator" class="poll-indicator"></div>
   <script>
     // Tab navigation — plain DOM, no framework
@@ -1229,7 +1229,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       // network blip — better than a static "Loading..." that looks frozen.
       if (!cs) {
         el.innerHTML =
-          '<div class="loading-block">' +
+          '<div class="loading-block" role="status" aria-label="Loading Claude Code transcripts">' +
             '<div class="spinner"></div>' +
             '<div class="msg">Reading Claude Code transcripts…</div>' +
             '<div class="hint">First load can take 10–15 seconds — moflo walks every session file in this project\\'s transcript directory. Subsequent loads in this tab are much faster.</div>' +

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -874,6 +874,14 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
     .btn-primary { background: #238636; border-color: #2ea043; color: #fff; }
     .btn-primary:hover { background: #2ea043; border-color: #3fb950; }
     .dim { color: #484f58; font-size: 0.75rem; font-style: italic; }
+    /* Loading state for tabs whose data is slow on first paint (currently
+       Claude Stats, which walks the user's transcript dir — can take 10–15s
+       on a long history). Pure-CSS spinner; no image, no framework. */
+    .loading-block { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px; padding: 48px 16px; color: #8b949e; }
+    .loading-block .spinner { width: 28px; height: 28px; border: 3px solid #30363d; border-top-color: #58a6ff; border-radius: 50%; animation: lum-spin 0.85s linear infinite; }
+    .loading-block .msg { font-size: 0.9rem; color: #c9d1d9; }
+    .loading-block .hint { font-size: 0.8rem; color: #8b949e; font-style: italic; max-width: 480px; text-align: center; line-height: 1.5; }
+    @keyframes lum-spin { to { transform: rotate(360deg); } }
   </style>
 </head>
 <body>
@@ -887,7 +895,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <div id="panel-schedules" class="panel" style="display:none"><div id="schedules-active"></div><div id="schedules-events"></div></div>
   <div id="panel-executions" class="panel" style="display:none"></div>
   <div id="panel-memory" class="panel" style="display:none"></div>
-  <div id="panel-claude-stats" class="panel" style="display:none"></div>
+  <div id="panel-claude-stats" class="panel" style="display:none"><div class="loading-block"><div class="spinner"></div><div class="msg">Reading Claude Code transcripts…</div><div class="hint">First load can take 10–15 seconds — moflo walks every session file in this project's transcript directory. Subsequent loads in this tab are much faster.</div></div></div>
   <div id="poll-indicator" class="poll-indicator"></div>
   <script>
     // Tab navigation — plain DOM, no framework
@@ -1215,7 +1223,19 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
     };
     function renderClaudeStats(cs) {
       const el = document.getElementById('panel-claude-stats');
-      if (!cs) { el.innerHTML = '<div class="empty">Loading...</div>'; return; }
+      // cs is null on first paint AND on fetch error (Promise chain uses
+      // .catch(() => null)). Render the spinner block on both so the user
+      // sees motion during the 10–15s transcript walk and during a transient
+      // network blip — better than a static "Loading..." that looks frozen.
+      if (!cs) {
+        el.innerHTML =
+          '<div class="loading-block">' +
+            '<div class="spinner"></div>' +
+            '<div class="msg">Reading Claude Code transcripts…</div>' +
+            '<div class="hint">First load can take 10–15 seconds — moflo walks every session file in this project\\'s transcript directory. Subsequent loads in this tab are much faster.</div>' +
+          '</div>';
+        return;
+      }
 
       // Always-visible disclaimer banner — keeps the scope and limits in
       // view so the numbers aren't read as account-wide truth.


### PR DESCRIPTION
## Summary
- **Claude Stats loading UX** — first paint of the Claude Stats tab walks the user's transcript directory and can take 10–15s on a long history. Replaces the static "Loading…" with a CSS spinner + hint text so the tab doesn't look frozen. Pure CSS, no framework, no images. Both copies (initial paint markup + JS re-render path) carry `role="status"` + descriptive `aria-label` for screen readers.
- **/luminarium skill** — new core skill that reads `.moflo/daemon.lock` and prints `http://localhost:<port>` in one line. Doesn't compute the deterministic port itself (the lock is the only source of truth — daemon may have bound an alternate), doesn't fall back to the retired pre-#1145 `:3117`, doesn't `flo daemon start`, doesn't open a browser.
- Classified luminarium in `SKILLS_MAP.core` so `flo init` copies it into consumer projects (satisfies `skills-classification-drift.test.ts`).

## Known follow-up (not in this PR)
`renderClaudeStats(null)` is called on both first paint and on `fetch.catch(() => null)` — the spinner copy says "Reading Claude Code transcripts…" in both cases, which is mildly misleading on a transient fetch error. Pre-existing in the data flow (the `.catch(() => null)` predates this diff). A future change could differentiate `undefined` (loading) from `null` (error) to show a "Failed to load — retrying…" state.

## Test plan
- [x] `daemon-dashboard.test.ts` + `dashboard-claude-stats-route.test.ts` pass
- [x] `skills-classification-drift.test.ts` + `skill-and-guidance-size-drift.test.ts` pass
- [ ] Open the dashboard, switch to Claude Stats — spinner is visible until stats finish loading
- [ ] `/luminarium` prints `http://localhost:<port>` for the bound daemon
- [ ] `/luminarium` with no daemon running prints the "isn't running" message and the start hint

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)