### PR TITLE
fix(doctor): sweep doctor-memprobe-/doctor-neighbors- namespaces in finally (#1166)

### DIFF
--- a/src/cli/__tests__/doctor-checks-memory-access.test.ts
+++ b/src/cli/__tests__/doctor-checks-memory-access.test.ts
@@ -223,6 +223,61 @@ describe('doctor-checks-memory-access', () => {
       ).toBe(0);
     }
   });
+
+  it('namespace sweep mops up a row a missed safeDelete would have leaked (#1166)', { timeout: 60_000 }, async () => {
+    // Simulates the production flake: a probe row that the doctor's per-key
+    // safeDelete never deletes (transport error, daemon race, or the row
+    // wasn't visible to the DELETE's WHERE clause at the moment it ran).
+    // The fix in #1166 adds a namespace-level sweep in the finally block —
+    // any row in `doctor-memprobe-*` is gone when the check returns,
+    // regardless of how it got there.
+    const { findMofloPackageRoot } = await import('../services/moflo-require.js');
+    const { pathToFileURL } = await import('url');
+    const { existsSync } = await import('fs');
+    const { join } = await import('path');
+    const root = findMofloPackageRoot();
+    if (!root) return;
+    const memToolsPath = join(root, 'dist/src/cli/mcp-tools/memory-tools.js');
+    if (!existsSync(memToolsPath)) return;
+    const { memoryTools } = await import(pathToFileURL(memToolsPath).href);
+    const store = memoryTools.find((t: { name: string }) => t.name === 'memory_store');
+    const list = memoryTools.find((t: { name: string }) => t.name === 'memory_list');
+    if (!store?.handler || !list?.handler) return;
+
+    // First run primes the bridge / creates moflo.db inside the temp project.
+    const priming = await checkMemoryAccessFunctional();
+    if (priming.status === 'warn' && /not built/i.test(priming.message)) return;
+
+    // Plant a synthetic leak: a key the doctor's safeDelete will never see
+    // because it's not in the cleanups[] array. Pre-#1166 this row survived
+    // checkMemoryAccessFunctional's finally — the bug the smoke harness's
+    // populated:ephemeral-purged catches.
+    const leakedKey = `doctor-memprobe-swarm-agent-leaked-${Date.now()}`;
+    const leakedNs = 'doctor-memprobe-swarm-agent';
+    await store.handler({ key: leakedKey, value: { sentinel: 'leak' }, namespace: leakedNs });
+
+    // Confirm it really landed (otherwise the test is vacuous).
+    {
+      const before = await list.handler({ namespace: leakedNs, limit: 100 });
+      const rows = (before as { entries?: Array<{ key: string }>; results?: Array<{ key: string }> }).entries
+        ?? (before as { results?: Array<{ key: string }> }).results
+        ?? [];
+      expect(rows.some(r => r.key === leakedKey), 'synthetic leak row must be present before doctor sweep').toBe(true);
+    }
+
+    // The fix: any row in doctor-memprobe-*/doctor-neighbors-* is swept by
+    // the finally block, regardless of whether safeDelete touched it.
+    await checkMemoryAccessFunctional();
+
+    const after = await list.handler({ namespace: leakedNs, limit: 100 });
+    const remaining = (after as { entries?: Array<{ key: string }>; results?: Array<{ key: string }> }).entries
+      ?? (after as { results?: Array<{ key: string }> }).results
+      ?? [];
+    expect(
+      remaining.map(r => r.key),
+      `expected ${leakedNs} empty after sweep, found: ${remaining.map(r => r.key).join(', ')}`,
+    ).not.toContain(leakedKey);
+  });
 });
 
 /**

--- a/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
+++ b/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
@@ -20,7 +20,10 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { purgeEphemeralNamespaces } from '../../services/ephemeral-namespace-purge.js';
+import {
+  purgeEphemeralNamespaces,
+  purgeMemoryProbeNamespaces,
+} from '../../services/ephemeral-namespace-purge.js';
 import {
   EPHEMERAL_NAMESPACES,
   EPHEMERAL_NAMESPACE_PREFIXES,
@@ -272,6 +275,101 @@ describe('purgeEphemeralNamespaces (#729, #968)', () => {
     expect(countByNamespace(dbPath, 'doctor-neighbors-1778701810936-zmnzzp')).toBe(0);
     expect(countByNamespace(dbPath, 'doctor-neighbors-1778700000000-aaaaaa')).toBe(0);
     expect(countByNamespace(dbPath, 'learnings')).toBe(1);
+  });
+});
+
+describe('purgeMemoryProbeNamespaces (#1166)', () => {
+  it('returns { purged: 0 } when the DB file does not exist', async () => {
+    const result = await purgeMemoryProbeNamespaces({
+      dbPath: join(tmpdir(), 'moflo-missing-1166', 'nope.db'),
+    });
+    expect(result).toEqual({ purged: 0 });
+  });
+
+  it('hard-deletes only prefix-match namespaces; exact ephemerals and user data survive', async () => {
+    // The doctor's namespace sweep must NOT clobber hive-mind / epic-state /
+    // test-bridge-fix (the launcher owns those) and obviously NOT user data.
+    const dbPath = await makeTmpDb((db) => {
+      const insert = (id: string, key: string, ns: string, content: string) =>
+        db.run(
+          `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+          [id, key, ns, content],
+        );
+
+      // Prefix-match probe rows — every healer persona plus a neighbors stamp.
+      const personas = ['subagent', 'swarm-agent', 'hive-mind-worker'];
+      let i = 0;
+      for (const p of personas) {
+        insert(`probe-${++i}`, `k-probe-${i}`, `doctor-memprobe-${p}`, `sentinel-${p}`);
+      }
+      for (let n = 0; n < 3; n++) {
+        insert(
+          `nbr-${++i}`,
+          `chunk-doctor-neighbors-1778702104739-nw6tcl-${n}`,
+          'doctor-neighbors-1778702104739-nw6tcl',
+          `chunk ${n}`,
+        );
+      }
+
+      // Exact ephemerals the doctor must NOT touch (launcher owns these).
+      for (const ns of PURGE_ON_SESSION_START_NAMESPACES) {
+        insert(`exact-${++i}`, `k-exact-${i}`, ns, `exact-${ns}`);
+      }
+
+      // Decoy: namespace contains the prefix but doesn't start with it.
+      insert(`decoy`, 'k-decoy', 'my-doctor-memprobe-fake', 'should-survive');
+
+      // User rows that must survive.
+      insert('keep-1', 'k-keep-1', 'learnings', 'real learning');
+      insert('keep-2', 'k-keep-2', 'knowledge', 'real knowledge');
+      insert('keep-3', 'k-keep-3', 'tasklist', 'flo-1-1700000000000');
+    });
+
+    const result = await purgeMemoryProbeNamespaces({ dbPath });
+    expect(result.purged).toBe(3 + 3); // 3 personas + 3 neighbors chunks
+
+    // Prefix-match cleared.
+    expect(countByNamespace(dbPath, 'doctor-memprobe-subagent')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-memprobe-swarm-agent')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-memprobe-hive-mind-worker')).toBe(0);
+    expect(countByNamespace(dbPath, 'doctor-neighbors-1778702104739-nw6tcl')).toBe(0);
+
+    // Exact ephemerals untouched — the launcher owns those.
+    for (const ns of PURGE_ON_SESSION_START_NAMESPACES) {
+      expect(countByNamespace(dbPath, ns)).toBe(1);
+    }
+    // Decoy and user data survive.
+    expect(countByNamespace(dbPath, 'my-doctor-memprobe-fake')).toBe(1);
+    expect(countByNamespace(dbPath, 'learnings')).toBe(1);
+    expect(countByNamespace(dbPath, 'knowledge')).toBe(1);
+    expect(countByNamespace(dbPath, 'tasklist')).toBe(1);
+  });
+
+  it('is idempotent — second pass over a clean DB returns { purged: 0 }', async () => {
+    const dbPath = await makeTmpDb((db) => {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, status) VALUES (?, ?, ?, ?, 'active')`,
+        ['p1', 'kp1', 'doctor-memprobe-subagent', 'probe'],
+      );
+    });
+
+    const first = await purgeMemoryProbeNamespaces({ dbPath });
+    expect(first.purged).toBe(1);
+
+    const second = await purgeMemoryProbeNamespaces({ dbPath });
+    expect(second).toEqual({ purged: 0 });
+  });
+
+  it('skips DBs that lack a memory_entries table', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'moflo-probe-purge-other-'));
+    tmpDirs.push(dir);
+    const dbPath = join(dir, 'something.db');
+    const db = openDaemonDatabase(dbPath);
+    db.run(`CREATE TABLE other_table (id TEXT PRIMARY KEY);`);
+    db.close();
+
+    const result = await purgeMemoryProbeNamespaces({ dbPath });
+    expect(result).toEqual({ purged: 0 });
   });
 });
 

--- a/src/cli/commands/doctor-checks-memory-access.ts
+++ b/src/cli/commands/doctor-checks-memory-access.ts
@@ -27,6 +27,7 @@ import { existsSync } from 'fs';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { memoryDbPath } from '../services/moflo-paths.js';
 import { findProjectRoot } from '../services/project-root.js';
+import { purgeMemoryProbeNamespaces } from '../services/ephemeral-namespace-purge.js';
 import { type HealthCheck } from './doctor-checks-deep.js';
 import {
   type FunctionalCheckDetail,
@@ -642,6 +643,11 @@ export async function checkMemoryAccessFunctional(): Promise<FunctionalHealthChe
         if (shutdown?.handler) await shutdown.handler({ force: true });
       } catch { /* ignore */ }
     }
+    // #1166 — namespace-level sweep backstop for the per-key safeDelete
+    // loop above (see purgeMemoryProbeNamespaces docstring for why).
+    try {
+      await purgeMemoryProbeNamespaces({ dbPath: memoryDbPath(findProjectRoot()) });
+    } catch { /* best-effort */ }
   }
 
   return summarizeFunctional(MEMORY_ACCESS_CHECK, details, {

--- a/src/cli/memory/bridge-embedder.ts
+++ b/src/cli/memory/bridge-embedder.ts
@@ -130,13 +130,16 @@ export const PURGE_ON_SESSION_START_NAMESPACES: ReadonlySet<string> = new Set([
  *   spawns a NEW namespace, so namespace pollution grows linearly with
  *   healer-run count if cleanup races fail.
  *
- * Both probes register an explicit cleanup via `safeDelete`, but the
- * cleanup is best-effort and silently swallows failures (e.g. daemon
- * races, MCP transport errors) — so rows accumulate across consumer
- * sessions. Auto-purging matches the pattern for
- * `hive-mind`/`epic-state`/`test-bridge-fix`. These rows MUST still get
- * embeddings (see {@link EPHEMERAL_NAMESPACE_PREFIXES} for why) — only
- * their persistence across sessions is curtailed.
+ * Both probes register an explicit cleanup via `safeDelete`. Post-#1166
+ * the doctor also runs an in-process namespace sweep over these prefixes
+ * inside `checkMemoryAccessFunctional`'s finally block, so a healthy
+ * doctor run leaves zero rows behind. The session-start launcher's
+ * prefix-purge is now strictly a safety net for crashed-process residue
+ * (the doctor never reached its finally) or pre-#1166 consumer DBs that
+ * still carry accumulated probe rows. Auto-purging matches the pattern
+ * for `hive-mind`/`epic-state`/`test-bridge-fix`. These rows MUST still
+ * get embeddings (see {@link EPHEMERAL_NAMESPACE_PREFIXES} for why) —
+ * only their persistence across sessions is curtailed.
  */
 export const PURGE_ON_SESSION_START_PREFIXES: ReadonlySet<string> = new Set([
   'doctor-memprobe-',

--- a/src/cli/services/ephemeral-namespace-purge.ts
+++ b/src/cli/services/ephemeral-namespace-purge.ts
@@ -150,3 +150,64 @@ export async function purgeEphemeralNamespaces(
     db.close();
   }
 }
+
+export interface PurgeMemoryProbeNamespacesOptions {
+  /** Path to the memory DB. Defaults to `<cwd>/.moflo/moflo.db`. */
+  dbPath?: string;
+}
+
+/**
+ * Hard-delete rows whose namespace matches one of
+ * {@link PURGE_ON_SESSION_START_PREFIXES} — currently `doctor-memprobe-*`
+ * and `doctor-neighbors-*`. Scoped down from {@link purgeEphemeralNamespaces}:
+ * no exact-namespace pass, no tasklist trim, no VACUUM. Returns
+ * `{ purged: 0 }` on a missing DB / missing `memory_entries` / clean state.
+ *
+ * Intended for the doctor's Memory Access functional check finally block
+ * (#1166). Only the doctor writes to these namespaces in production, so
+ * sweeping by prefix at the end of every healer run kills the
+ * `populated:ephemeral-purged` flake class — a per-key `safeDelete` that
+ * silently no-ops (row not visible at delete time, MCP transport error,
+ * `memory_delete` returning `success: true, deleted: false`) no longer
+ * leaks a row into the next assertion. The launcher's session-start
+ * purge stays in place as a defence-in-depth safety net for residue from
+ * crashed-process scenarios where the doctor never reached its finally.
+ *
+ * Errors propagate to the caller (the doctor absorbs them so a failed
+ * sweep never poisons the check return value).
+ */
+export async function purgeMemoryProbeNamespaces(
+  options: PurgeMemoryProbeNamespacesOptions = {},
+): Promise<{ purged: number }> {
+  const fs = await import('fs');
+  const path = await import('path');
+
+  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(process.cwd()));
+  if (!fs.existsSync(dbPath)) return { purged: 0 };
+
+  const prefixes = Array.from(PURGE_ON_SESSION_START_PREFIXES);
+  if (prefixes.length === 0) return { purged: 0 };
+
+  const db = openDaemonDatabase(dbPath);
+  try {
+    const probe = db.exec(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_entries' LIMIT 1`,
+    );
+    if (!probe[0]?.values?.[0]) return { purged: 0 };
+
+    const whereClause = prefixes.map(() => 'namespace LIKE ?').join(' OR ');
+    const bindings = prefixes.map((p) => `${p}%`);
+
+    const countRows = db.exec(
+      `SELECT COUNT(*) FROM memory_entries WHERE ${whereClause}`,
+      bindings,
+    );
+    const purgeable = Number(countRows[0]?.values?.[0]?.[0] ?? 0);
+    if (purgeable === 0) return { purged: 0 };
+
+    db.run(`DELETE FROM memory_entries WHERE ${whereClause}`, bindings);
+    return { purged: db.getRowsModified?.() ?? 0 };
+  } finally {
+    db.close();
+  }
+}


### PR DESCRIPTION
## Summary

- Closes #1166.
- Adds `purgeMemoryProbeNamespaces()` in `src/cli/services/ephemeral-namespace-purge.ts` scoped to `PURGE_ON_SESSION_START_PREFIXES` (`doctor-memprobe-`, `doctor-neighbors-`) and calls it from `checkMemoryAccessFunctional`'s `finally` block after the existing per-key cleanups.
- Kills the `populated:ephemeral-purged` Ubuntu flake class: any probe row the doctor's silent-on-failure `safeDelete` misses is wholesale-deleted before the check returns, so the smoke harness's same-session assertion can never see it.
- Bridge-embedder docstring reworded — the launcher's prefix-purge is now strictly the safety net for crashed-process residue, not the primary cleaner.

## Why this and not "fix safeDelete"

`memory_delete` returns `{ success: true, deleted: false }` when the row isn't visible at delete time, and the per-key cleanup paths are wrapped in `try/catch` that swallow any reject. That layering is racy by design; making it stricter risks new false-positives. Only the doctor writes to `doctor-memprobe-*` / `doctor-neighbors-*` in production (`grep -r 'doctor-memprobe-' src/` confirms), so a wholesale prefix DELETE inside the doctor's own finally cannot clobber legitimate data and kills the bug class cold.

## Test plan

- [x] `npx vitest run src/cli/__tests__/services/ephemeral-namespace-purge.test.ts` — 22/22 green (4 new tests: missing DB, prefix-only with decoy + user data survival, idempotency, no-`memory_entries`-table case).
- [x] `npx vitest run --config vitest.isolation.config.ts src/cli/__tests__/doctor-checks-memory-access.test.ts` — 11/11 green (new test plants a synthetic leak row `safeDelete` would never see and asserts the sweep removes it).
- [x] `npx tsc --noEmit` — clean.
- [ ] Watch CI `populated:ephemeral-purged` Ubuntu runs — flake rate should go to zero.

## Acceptance criteria (from #1166)

- [x] `purgeMemoryProbeNamespaces` exported, scoped to `PURGE_ON_SESSION_START_PREFIXES` only.
- [x] `checkMemoryAccessFunctional` calls it from the finally block after existing cleanups.
- [x] No `doctor-memprobe-<persona>/active` row visible after `checkMemoryAccessFunctional` returns.
- [x] Bridge-embedder docstring updated.
- [x] New unit tests cover prefix-only purge, decoy non-match, idempotency.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)