### PR TITLE
fix(swarm-residue): stop neural runtime + doctor writers recreating .swarm/ (#1168)

### DIFF
--- a/src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts
@@ -152,4 +152,41 @@ describe('Swarm Residue auto-fix — fixSwarmLegacyResidue', () => {
     expect(existsSync(join(tmpDir, '.swarm', 'mystery-artifact.dat'))).toBe(true);
     expect(existsSync(join(tmpDir, '.swarm', 'memory.db'))).toBe(false);
   });
+
+  // #1168: writer relocations require the residue migrator to recognise the
+  // new artifact set so legacy `.swarm/` directories left by pre-#1168 saves
+  // get fully retired in one healer pass.
+  it('relocates #1168 neural runtime state into .moflo/{movector,neural,swarm,memory}/', async () => {
+    seedSwarm({
+      'lora-weights.json': '{"lora":true}',
+      'moe-weights.json': '{"moe":true}',
+      'ewc-fisher.json': '{"ewc":true}',
+      'sona-patterns.json': '{"sona":true}',
+      'state.json': '{"swarm-state":true}',
+      'code-map-hash.txt': 'abc123',
+    });
+
+    const result = await autoFixCheck(residueCheck);
+
+    expect(result).toBe(true);
+    expect(existsSync(join(tmpDir, '.swarm'))).toBe(false);
+    expect(readFileSync(join(tmpDir, '.moflo', 'movector', 'lora-weights.json'), 'utf-8')).toBe('{"lora":true}');
+    expect(readFileSync(join(tmpDir, '.moflo', 'movector', 'moe-weights.json'), 'utf-8')).toBe('{"moe":true}');
+    expect(readFileSync(join(tmpDir, '.moflo', 'neural', 'ewc-fisher.json'), 'utf-8')).toBe('{"ewc":true}');
+    expect(readFileSync(join(tmpDir, '.moflo', 'neural', 'sona-patterns.json'), 'utf-8')).toBe('{"sona":true}');
+    expect(readFileSync(join(tmpDir, '.moflo', 'swarm', 'state.json'), 'utf-8')).toBe('{"swarm-state":true}');
+    expect(readFileSync(join(tmpDir, '.moflo', 'memory', 'code-map-hash.txt'), 'utf-8')).toBe('abc123');
+  });
+
+  it('keeps the canonical lora-weights.json when both locations have content', async () => {
+    mkdirSync(join(tmpDir, '.moflo', 'movector'), { recursive: true });
+    writeFileSync(join(tmpDir, '.moflo', 'movector', 'lora-weights.json'), '{"canonical":true}', 'utf-8');
+    seedSwarm({ 'lora-weights.json': '{"legacy":true}' });
+
+    const result = await autoFixCheck(residueCheck);
+
+    expect(result).toBe(true);
+    expect(readFileSync(join(tmpDir, '.moflo', 'movector', 'lora-weights.json'), 'utf-8')).toBe('{"canonical":true}');
+    expect(existsSync(join(tmpDir, '.swarm'))).toBe(false);
+  });
 });

--- a/src/cli/__tests__/commands/swarm-path-relocation.test.ts
+++ b/src/cli/__tests__/commands/swarm-path-relocation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #1168 — Neural runtime + swarm/memory command writers must resolve to
+ * `.moflo/...` under the project root, not `.swarm/` under cwd.
+ *
+ * The pre-#1168 defaults captured `process.cwd()` at module-load time (or
+ * used bare relative paths resolved against cwd at use time) and joined
+ * `.swarm/`. Any consumer that imported these modules through the daemon or
+ * MCP server got an empty `.swarm/` directory regenerated every session.
+ *
+ * This test pins the default-path invariant for all four neural-runtime
+ * persisters + the two explicit-command writers. We never construct the
+ * persisters with overrides — that's the only path that's supposed to
+ * trigger the default.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let originalCwd: string;
+let originalClaudeProjectDir: string | undefined;
+let tmpDir: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  originalClaudeProjectDir = process.env.CLAUDE_PROJECT_DIR;
+  tmpDir = mkdtempSync(join(tmpdir(), 'moflo-1168-default-paths-'));
+  process.chdir(tmpDir);
+  process.env.CLAUDE_PROJECT_DIR = tmpDir;
+  mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (originalClaudeProjectDir === undefined) {
+    delete process.env.CLAUDE_PROJECT_DIR;
+  } else {
+    process.env.CLAUDE_PROJECT_DIR = originalClaudeProjectDir;
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('#1168 — neural runtime defaults land under .moflo/, never .swarm/', () => {
+  it('LoRAAdapter default weightsPath resolves to .moflo/movector/lora-weights.json', async () => {
+    const { LoRAAdapter } = await import('../../movector/lora-adapter.js');
+    const adapter = new LoRAAdapter();
+    // Public surface intentionally exposes config; rely on it.
+    const cfg = (adapter as unknown as { config: { weightsPath: string } }).config;
+    expect(cfg.weightsPath).toBe(join(tmpDir, '.moflo', 'movector', 'lora-weights.json'));
+    expect(cfg.weightsPath).not.toMatch(/\.swarm/);
+  });
+
+  it('MoERouter default weightsPath resolves to .moflo/movector/moe-weights.json', async () => {
+    const { MoERouter } = await import('../../movector/moe-router.js');
+    const router = new MoERouter();
+    const cfg = (router as unknown as { config: { weightsPath: string } }).config;
+    expect(cfg.weightsPath).toBe(join(tmpDir, '.moflo', 'movector', 'moe-weights.json'));
+    expect(cfg.weightsPath).not.toMatch(/\.swarm/);
+  });
+
+  it('EWCConsolidator default storagePath resolves to .moflo/neural/ewc-fisher.json', async () => {
+    const { EWCConsolidator } = await import('../../memory/ewc-consolidation.js');
+    const c = new EWCConsolidator();
+    const cfg = (c as unknown as { config: { storagePath: string } }).config;
+    expect(cfg.storagePath).toBe(join(tmpDir, '.moflo', 'neural', 'ewc-fisher.json'));
+    expect(cfg.storagePath).not.toMatch(/\.swarm/);
+  });
+
+  it('SONAOptimizer default persistencePath resolves to .moflo/neural/sona-patterns.json', async () => {
+    const { SONAOptimizer } = await import('../../memory/sona-optimizer.js');
+    const sona = new SONAOptimizer();
+    const persistencePath = (sona as unknown as { persistencePath: string }).persistencePath;
+    expect(persistencePath).toBe(join(tmpDir, '.moflo', 'neural', 'sona-patterns.json'));
+    expect(persistencePath).not.toMatch(/\.swarm/);
+  });
+});

--- a/src/cli/__tests__/services/published-package-drift-guard.test.ts
+++ b/src/cli/__tests__/services/published-package-drift-guard.test.ts
@@ -258,6 +258,66 @@ describe('published-package drift guard (issue #585)', () => {
     ).toEqual([]);
   });
 
+  it('no `.swarm/` *writer* paths re-enter production source (#1168)', () => {
+    // Issue #1168: moflo's canonical runtime store is `.moflo/`. The legacy
+    // `.swarm/` path is read-only — used by the cherry-pick recovery, the
+    // bridge migration window probe, and the doctor 'Swarm Residue' fix as
+    // a source. Production code MUST NOT *write* to `.swarm/` (mkdirSync,
+    // writeFileSync, or join-then-write) — that's the bug class #1168 closed.
+    //
+    // Read-only references (legacyMemoryDbPath, fallback existsSync probes,
+    // doc strings, comments) are allowed without a marker. The guard flags
+    // only suspicious *mutating* patterns; if a contributor adds a new
+    // legitimate read path the regex won't fire. If a future PR genuinely
+    // needs to write `.swarm/` (e.g. for a new migration codepath), they
+    // add an explicit `LEGACY-V2-WRITE` marker on the same line.
+    const SCAN_ROOTS = [
+      join(REPO_ROOT, 'src', 'cli'),
+      join(REPO_ROOT, 'bin'),
+      join(REPO_ROOT, 'scripts'),
+      join(REPO_ROOT, '.claude', 'guidance', 'shipped'),
+      join(REPO_ROOT, '.claude', 'helpers'),
+      join(REPO_ROOT, '.claude', 'skills'),
+    ];
+    // A "writer" pattern: any of mkdirSync/mkdir/writeFileSync/renameSync/
+    // appendFileSync called on a path string that contains `.swarm`. We scan
+    // for the call-site shape on the same line as `.swarm` to keep this
+    // simple — multi-line writer chains aren't a current shape in the repo.
+    const WRITER_RE = /(mkdirSync|writeFileSync|renameSync|appendFileSync|fs\.mkdir\b)[^\n]*['"`][^'"`]*\.swarm/;
+    const ALLOWED_MARKERS = /LEGACY-V2-WRITE|pre-#1168/;
+    // Files whose entire purpose is `.swarm/` migration logic — they may
+    // legitimately write to `.swarm/` (e.g. for restore-during-migration).
+    // Currently empty: post-#1168 there's no such writer in moflo.
+    const MIGRATION_FILES = new Set<string>([]);
+
+    const offenders: string[] = [];
+    for (const root of SCAN_ROOTS) {
+      if (!existsSync(root)) continue;
+      for (const file of walkAll(root)) {
+        if (file.endsWith('published-package-drift-guard.test.ts')) continue;
+        if (/[/\\]__tests__[/\\]/.test(file)) continue;
+        if (file.endsWith('.db') || file.endsWith('.bin') || file.endsWith('.wasm')) continue;
+        const rel = relative(REPO_ROOT, file).replace(/\\/g, '/');
+        if (MIGRATION_FILES.has(rel)) continue;
+        const text = readFileSync(file, 'utf8');
+        if (!WRITER_RE.test(text)) continue;
+        const lines = text.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          if (!WRITER_RE.test(lines[i])) continue;
+          if (ALLOWED_MARKERS.test(lines[i])) continue;
+          offenders.push(`${rel}:${i + 1}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Production code writes to .swarm/ (issue #1168 moved every writer to .moflo/).\n` +
+        `If the new write is intentional (e.g. a new migration codepath), add\n` +
+        `the marker LEGACY-V2-WRITE or pre-#1168 to the same line.\n` +
+        `Offenders:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
   it('no `npm install @moflo/<pkg>` strings remain in source or shipped guidance', () => {
     // Issue #661: moflo publishes as a single npm package called `moflo`. Any
     // `npm install @moflo/cli` (or @moflo/neural, @moflo/memory, …) string in

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -305,6 +305,12 @@ export async function checkMemoryDatabase(): Promise<HealthCheck> {
  *  - `memory.db` / `memory.db.bak` — stale once `.moflo/moflo.db` exists.
  *  - `q-learning-model.json` / `model-router-state.json` — live router state
  *    that pre-dates the `.moflo/movector/` defaults; migrate, don't delete.
+ *  - `lora-weights.json` / `moe-weights.json` — LoRA + MoE weights (#1168
+ *    moved the writers to `.moflo/movector/`).
+ *  - `ewc-fisher.json` / `sona-patterns.json` — neural runtime state (#1168
+ *    moved the writers to `.moflo/neural/`).
+ *  - `state.json` — `flo swarm init` snapshot (#1168 → `.moflo/swarm/`).
+ *  - `code-map-hash.txt` — `flo memory code-map` cache (#1168 → `.moflo/memory/`).
  *  - `hooks.log` / `background.log` — diagnostic logs the launcher used to
  *    route to `.swarm/`; relocate to `.moflo/logs/`.
  *
@@ -325,6 +331,12 @@ export async function checkSwarmResidue(): Promise<HealthCheck> {
     'memory.db.bak',
     'q-learning-model.json',
     'model-router-state.json',
+    'lora-weights.json',
+    'moe-weights.json',
+    'ewc-fisher.json',
+    'sona-patterns.json',
+    'state.json',
+    'code-map-hash.txt',
     'hooks.log',
     'background.log',
   ];

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -160,10 +160,27 @@ async function fixSwarmLegacyResidue(): Promise<boolean> {
     }
   }
 
-  // (2) router state JSONs — rename into .moflo/movector/.
+  // (2) router state + neural state JSONs — rename into .moflo/{movector,neural,swarm,memory}/.
+  //
+  // q-learning-model.json + model-router-state.json: shipped at #727.
+  // lora-weights.json + moe-weights.json: writer relocation in #1168
+  //   (lora-adapter.ts, moe-router.ts).
+  // ewc-fisher.json + sona-patterns.json: writer relocation in #1168
+  //   (ewc-consolidation.ts, sona-optimizer.ts).
+  // state.json + code-map-hash.txt: writer relocation in #1168
+  //   (commands/swarm.ts, commands/memory.ts).
+  const neuralDir = join(moflo, 'neural');
+  const swarmStateDir = join(moflo, 'swarm');
+  const memoryStateDir = join(moflo, 'memory');
   const stateFiles = [
     { name: 'q-learning-model.json', dest: movectorDir },
     { name: 'model-router-state.json', dest: movectorDir },
+    { name: 'lora-weights.json', dest: movectorDir },
+    { name: 'moe-weights.json', dest: movectorDir },
+    { name: 'ewc-fisher.json', dest: neuralDir },
+    { name: 'sona-patterns.json', dest: neuralDir },
+    { name: 'state.json', dest: swarmStateDir },
+    { name: 'code-map-hash.txt', dest: memoryStateDir },
   ];
   for (const { name, dest } of stateFiles) {
     const src = join(swarmDir, name);
@@ -236,9 +253,11 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
   // Map checks to programmatic fixes (not just shell commands)
   const fixActions: Record<string, () => Promise<boolean>> = {
     'Memory Database': async () => {
+      // Canonical DB lives at `.moflo/moflo.db`; `initializeMemoryDatabase`
+      // creates the parent dir itself. The pre-#1168 fix also `mkdirSync`'d
+      // `.swarm/` — vestigial residue that fought the 'Swarm Residue' fix in
+      // the same healer pass. Removed.
       try {
-        const swarmDir = join(process.cwd(), '.swarm');
-        if (!existsSync(swarmDir)) mkdirSync(swarmDir, { recursive: true });
         const { initializeMemoryDatabase } = await import('../memory/memory-initializer.js');
         const result = await initializeMemoryDatabase({ force: true, verbose: false });
         return result.success;
@@ -247,11 +266,11 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       }
     },
     'Embeddings': async () => {
+      // Same fix as Memory Database — ensure the canonical DB exists, then
+      // populate embeddings. Pre-#1168 wrote to `.swarm/memory.db` directly,
+      // contradicting the post-#727 layout; that branch is removed.
       try {
-        const swarmDir = join(process.cwd(), '.swarm');
-        if (!existsSync(swarmDir)) mkdirSync(swarmDir, { recursive: true });
-        const dbPath = join(swarmDir, 'memory.db');
-        if (!existsSync(dbPath)) {
+        if (!existsSync(memoryDbPath(findProjectRoot()))) {
           const { initializeMemoryDatabase } = await import('../memory/memory-initializer.js');
           await initializeMemoryDatabase({ force: true, verbose: false });
         }

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -13,6 +13,7 @@ import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { openDaemonDatabase, type SqlJsLikeDatabase } from '../memory/daemon-backend.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { legacySwarmPath, runtimePath } from '../services/moflo-paths.js';
 
 // Memory backends
 const BACKENDS = [
@@ -2436,7 +2437,10 @@ const codeMapCommand: Command = {
     const { createHash } = await import('crypto');
 
     const cwd = ctx.cwd || process.cwd();
-    const hashCachePath = pathModule.join(cwd, '.swarm', 'code-map-hash.txt');
+    // Post-#1168: canonical at `.moflo/memory/code-map-hash.txt`. Legacy
+    // `.swarm/code-map-hash.txt` is read-only fallback for upgrade scenarios.
+    const hashCachePath = runtimePath('memory', 'code-map-hash.txt');
+    const legacyHashCachePath = legacySwarmPath('code-map-hash.txt');
 
     output.writeln();
     output.writeln(output.bold('Generating Code Map'));
@@ -2484,9 +2488,12 @@ const codeMapCommand: Command = {
       return { success: true };
     }
 
-    // Check if unchanged
-    if (!forceRegen && fs.existsSync(hashCachePath)) {
-      const cached = fs.readFileSync(hashCachePath, 'utf-8').trim();
+    // Check if unchanged — canonical first, then legacy `.swarm/` fallback.
+    const cachedReadPath = fs.existsSync(hashCachePath)
+      ? hashCachePath
+      : (fs.existsSync(legacyHashCachePath) ? legacyHashCachePath : null);
+    if (!forceRegen && cachedReadPath) {
+      const cached = fs.readFileSync(cachedReadPath, 'utf-8').trim();
       if (cached === currentHash) {
         const { db } = await openDb(cwd);
         const stmt = db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = ?`);

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -9,16 +9,28 @@ import { select, confirm, multiSelect } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import * as fs from 'fs';
 import * as path from 'path';
-import { memoryDbCandidatePaths } from '../services/moflo-paths.js';
+import { LEGACY_SWARM_DIR, memoryDbCandidatePaths, mofloDir } from '../services/moflo-paths.js';
+import { findProjectRoot } from '../services/project-root.js';
 
 // Get dynamic swarm status from memory/session files
 function getSwarmStatus(swarmId?: string) {
-  const swarmDir = path.join(process.cwd(), '.swarm');
+  const projectRoot = findProjectRoot();
+  // `.moflo/swarm/state.json` is canonical post-#1168; `.swarm/state.json`
+  // is a read-only fallback so a consumer who initialised on an older moflo
+  // still sees their swarm. The pre-#1168 agents/tasks JSON probe blocks
+  // were removed — no current writer creates those directories, so they
+  // always produced 0 counts. The coordinator-backed MCP tools
+  // (agent_list / task_list) are the live source of truth.
+  const canonicalSwarmDir = path.join(mofloDir(projectRoot), 'swarm');
+  const legacySwarmDir = path.join(projectRoot, LEGACY_SWARM_DIR);
   const sessionDir = path.join(process.cwd(), '.claude', 'sessions');
   const memoryPaths = memoryDbCandidatePaths(process.cwd());
 
-  // Check for active swarm state file
-  const swarmStateFile = path.join(swarmDir, 'state.json');
+  // Check for active swarm state file — canonical first, then legacy.
+  let swarmStateFile = path.join(canonicalSwarmDir, 'state.json');
+  if (!fs.existsSync(swarmStateFile)) {
+    swarmStateFile = path.join(legacySwarmDir, 'state.json');
+  }
   let swarmState: Record<string, unknown> | null = null;
 
   if (fs.existsSync(swarmStateFile)) {
@@ -29,28 +41,14 @@ function getSwarmStatus(swarmId?: string) {
     }
   }
 
-  // Count active agents from process files
-  let activeAgents = 0;
-  let totalAgents = 0;
-  const agentsDir = path.join(swarmDir, 'agents');
-  if (fs.existsSync(agentsDir)) {
-    try {
-      const agentFiles = fs.readdirSync(agentsDir).filter(f => f.endsWith('.json'));
-      totalAgents = agentFiles.length;
-      for (const file of agentFiles) {
-        try {
-          const agent = JSON.parse(fs.readFileSync(path.join(agentsDir, file), 'utf-8'));
-          if (agent.status === 'active' || agent.status === 'running') {
-            activeAgents++;
-          }
-        } catch {
-          // Ignore
-        }
-      }
-    } catch {
-      // Ignore
-    }
-  }
+  // agents/tasks counters: no file-store readers post-#1168. Coordinator
+  // MCP tools own the live counts; getSwarmStatus surfaces a static summary
+  // of the persisted state file plus session/memory rough indicators.
+  const activeAgents = 0;
+  const totalAgents = 0;
+  const completedTasks = 0;
+  const inProgressTasks = 0;
+  const pendingTasks = 0;
 
   // Get session count
   let sessionCount = 0;
@@ -72,33 +70,6 @@ function getSwarmStatus(swarmId?: string) {
       } catch {
         // Ignore
       }
-    }
-  }
-
-  // Count task files if they exist
-  let completedTasks = 0;
-  let inProgressTasks = 0;
-  let pendingTasks = 0;
-  const tasksDir = path.join(swarmDir, 'tasks');
-  if (fs.existsSync(tasksDir)) {
-    try {
-      const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith('.json'));
-      for (const file of taskFiles) {
-        try {
-          const task = JSON.parse(fs.readFileSync(path.join(tasksDir, file), 'utf-8'));
-          if (task.status === 'completed' || task.status === 'done') {
-            completedTasks++;
-          } else if (task.status === 'in_progress' || task.status === 'running') {
-            inProgressTasks++;
-          } else {
-            pendingTasks++;
-          }
-        } catch {
-          // Ignore
-        }
-      }
-    } catch {
-      // Ignore
     }
   }
 
@@ -302,8 +273,11 @@ const initCommand: Command = {
       output.writeln();
       output.printSuccess('Swarm initialized successfully');
 
-      // Save swarm state locally for status command to read
-      const swarmDir = path.join(process.cwd(), '.swarm');
+      // Save swarm state locally for status command to read. Post-#1168 the
+      // canonical home is `<root>/.moflo/swarm/state.json`; the legacy
+      // `.swarm/state.json` path is preserved as a read-only fallback in
+      // `getSwarmStatus`.
+      const swarmDir = path.join(mofloDir(findProjectRoot()), 'swarm');
       try {
         if (!fs.existsSync(swarmDir)) {
           fs.mkdirSync(swarmDir, { recursive: true });

--- a/src/cli/memory/ewc-consolidation.ts
+++ b/src/cli/memory/ewc-consolidation.ts
@@ -16,7 +16,8 @@
  * - Fisher Information Matrix computation from gradient history
  * - Online EWC updates for streaming patterns
  * - Selective consolidation based on pattern importance
- * - Persistent storage in .swarm/ewc-fisher.json
+ * - Persistent storage in .moflo/neural/ewc-fisher.json
+ *   (legacy fallback read: .swarm/ewc-fisher.json)
  *
  * @module v3/cli/memory/ewc-consolidation
  */
@@ -24,6 +25,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { legacySwarmPath, runtimePath } from '../services/moflo-paths.js';
 
 // ============================================================================
 // Types
@@ -143,12 +145,11 @@ interface GradientSample {
 // Default Configuration
 // ============================================================================
 
-const DEFAULT_EWC_CONFIG: EWCConfig = {
+const DEFAULT_EWC_CONFIG: Omit<EWCConfig, 'storagePath'> = {
   lambda: 0.4,
   maxPatterns: 1000,
   fisherDecayRate: 0.01,
   importanceThreshold: 0.3,
-  storagePath: path.join(process.cwd(), '.swarm', 'ewc-fisher.json'),
   onlineMode: true,
   dimensions: 384
 };
@@ -171,7 +172,15 @@ export class EWCConsolidator {
   private initialized: boolean = false;
 
   constructor(config?: Partial<EWCConfig>) {
-    this.config = { ...DEFAULT_EWC_CONFIG, ...config };
+    // Resolve storagePath lazily here (#1168) — the default routes through
+    // findProjectRoot at construct-time, not module-load time. Default-rescue
+    // runs *last* so an explicit `storagePath: undefined` falls back to the
+    // canonical path instead of leaving the field undefined.
+    this.config = {
+      ...DEFAULT_EWC_CONFIG,
+      ...config,
+      storagePath: config?.storagePath ?? runtimePath('neural', 'ewc-fisher.json'),
+    };
     this.globalFisher = new Array(this.config.dimensions).fill(0);
   }
 
@@ -635,11 +644,18 @@ export class EWCConsolidator {
    * Load state from disk
    */
   private async loadFromDisk(): Promise<void> {
-    if (!fs.existsSync(this.config.storagePath)) {
-      throw new Error('No persisted state found');
+    // Canonical path first, then legacy `.swarm/ewc-fisher.json` as a
+    // read-only fallback for consumers who upgraded mid-training (#1168).
+    let sourcePath = this.config.storagePath;
+    if (!fs.existsSync(sourcePath)) {
+      const legacy = legacySwarmPath('ewc-fisher.json');
+      if (!fs.existsSync(legacy)) {
+        throw new Error('No persisted state found');
+      }
+      sourcePath = legacy;
     }
 
-    const content = fs.readFileSync(this.config.storagePath, 'utf-8');
+    const content = fs.readFileSync(sourcePath, 'utf-8');
     const state = JSON.parse(content);
 
     // Validate version

--- a/src/cli/memory/sona-optimizer.ts
+++ b/src/cli/memory/sona-optimizer.ts
@@ -8,14 +8,16 @@
  * - Processes trajectory outcomes from the spell-engine trajectory pipeline
  * - Extracts keywords from tasks for pattern matching
  * - Maintains learned routing patterns with confidence scoring
- * - Persists patterns to .swarm/sona-patterns.json
+ * - Persists patterns to .moflo/neural/sona-patterns.json
+ *   (legacy fallback read: .swarm/sona-patterns.json)
  * - Integrates with Q-learning router for combined routing
  *
  * @module v3/cli/memory/sona-optimizer
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname, isAbsolute, resolve } from 'path';
+import { legacySwarmPath, runtimePath } from '../services/moflo-paths.js';
 
 // ============================================================================
 // Types
@@ -119,7 +121,6 @@ interface PersistedState {
 // Constants
 // ============================================================================
 
-const DEFAULT_PERSISTENCE_PATH = '.swarm/sona-patterns.json';
 const PATTERN_VERSION = '1.0.0';
 const MIN_CONFIDENCE = 0.1;
 const MAX_CONFIDENCE = 0.99;
@@ -211,7 +212,12 @@ export class SONAOptimizer {
   private qLearningEnabled = false;
 
   constructor(options?: { persistencePath?: string }) {
-    this.persistencePath = options?.persistencePath || DEFAULT_PERSISTENCE_PATH;
+    // Resolve persistencePath lazily here (#1168). When the caller supplies
+    // one we honor it verbatim (may be relative — preserved for existing
+    // tests/callers that join against their own cwd). When unset, we route
+    // through runtimePath so writes land under `.moflo/neural/` regardless
+    // of subprocess cwd.
+    this.persistencePath = options?.persistencePath || runtimePath('neural', 'sona-patterns.json');
   }
 
   /**
@@ -685,9 +691,16 @@ export class SONAOptimizer {
    */
   private loadFromDisk(): boolean {
     try {
-      const fullPath = join(process.cwd(), this.persistencePath);
+      // Treat absolute persistencePath verbatim (new #1168 default routes
+      // through runtimePath → absolute `.moflo/neural/...`); relative paths
+      // preserve the pre-#1168 behaviour of resolving against cwd.
+      let fullPath = isAbsolute(this.persistencePath)
+        ? this.persistencePath
+        : resolve(process.cwd(), this.persistencePath);
       if (!existsSync(fullPath)) {
-        return false;
+        const legacy = legacySwarmPath('sona-patterns.json');
+        if (!existsSync(legacy)) return false;
+        fullPath = legacy;
       }
 
       const data = readFileSync(fullPath, 'utf-8');
@@ -727,7 +740,11 @@ export class SONAOptimizer {
    */
   private saveToDisk(): boolean {
     try {
-      const fullPath = join(process.cwd(), this.persistencePath);
+      // See loadFromDisk: absolute persistencePath is taken verbatim, relative
+      // paths resolve against cwd. New #1168 default writes to `.moflo/neural/`.
+      const fullPath = isAbsolute(this.persistencePath)
+        ? this.persistencePath
+        : resolve(process.cwd(), this.persistencePath);
       const dir = dirname(fullPath);
 
       // Ensure directory exists

--- a/src/cli/movector/lora-adapter.ts
+++ b/src/cli/movector/lora-adapter.ts
@@ -8,7 +8,7 @@
  * - Rank decomposition (r << d) for memory efficiency
  * - Additive weight updates: W' = W + BA (where B ∈ R^{d×r}, A ∈ R^{r×k})
  * - Support for multiple adaptation heads
- * - Persistence to .swarm/lora-weights.json
+ * - Persistence to .moflo/movector/lora-weights.json (legacy fallback: .swarm/lora-weights.json)
  *
  * Memory savings:
  * - Original: d × k parameters
@@ -19,7 +19,8 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
+import { legacySwarmPath, runtimePath } from '../services/moflo-paths.js';
 
 // ============================================================================
 // Types & Constants
@@ -115,13 +116,12 @@ export interface LoRAStats {
 // Default Configuration
 // ============================================================================
 
-const DEFAULT_CONFIG: LoRAConfig = {
+const DEFAULT_CONFIG: Omit<LoRAConfig, 'weightsPath'> = {
   rank: DEFAULT_RANK,
   alpha: DEFAULT_ALPHA,
   inputDim: INPUT_DIM,
   outputDim: OUTPUT_DIM,
   learningRate: 0.001,
-  weightsPath: join(process.cwd(), '.swarm', 'lora-weights.json'),
   enableDropout: true,
   dropoutProb: 0.1,
   autoSaveInterval: 50,
@@ -144,7 +144,16 @@ export class LoRAAdapter {
   private updatesSinceLastSave = 0;
 
   constructor(config?: Partial<LoRAConfig>) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    // Resolve weightsPath lazily here, not at module load — captures the
+    // *current* consumer project root, not the cwd at first import (#1168).
+    // Default-rescue runs *last* so an explicit `weightsPath: undefined` from
+    // the caller still falls back to the canonical path instead of crashing
+    // save/load on an undefined string.
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+      weightsPath: config?.weightsPath ?? runtimePath('movector', 'lora-weights.json'),
+    };
     this.weights = this.initializeWeights();
   }
 
@@ -420,11 +429,16 @@ export class LoRAAdapter {
    */
   loadWeights(): boolean {
     try {
-      if (!existsSync(this.config.weightsPath)) {
-        return false;
+      // Canonical path first, then legacy `.swarm/lora-weights.json` as a
+      // read-only fallback for consumers who upgraded mid-training (#1168).
+      let sourcePath = this.config.weightsPath;
+      if (!existsSync(sourcePath)) {
+        const legacy = legacySwarmPath('lora-weights.json');
+        if (!existsSync(legacy)) return false;
+        sourcePath = legacy;
       }
 
-      const content = readFileSync(this.config.weightsPath, 'utf-8');
+      const content = readFileSync(sourcePath, 'utf-8');
       const data = JSON.parse(content);
 
       if (data.version !== 1) {

--- a/src/cli/movector/moe-router.ts
+++ b/src/cli/movector/moe-router.ts
@@ -6,7 +6,8 @@
  * - Gating network for soft expert selection (top-k)
  * - Online weight updates via reward signals
  * - Load balancing with auxiliary loss
- * - Weight persistence to .swarm/moe-weights.json
+ * - Weight persistence to .moflo/movector/moe-weights.json
+ *   (legacy fallback read: .swarm/moe-weights.json)
  *
  * Architecture:
  * - Input: 384-dim task embedding (from ONNX)
@@ -17,7 +18,8 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
+import { legacySwarmPath, runtimePath } from '../services/moflo-paths.js';
 
 // ============================================================================
 // Types & Constants
@@ -77,7 +79,7 @@ export interface MoERouterConfig {
   temperature: number;
   /** Load balancing coefficient (default: 0.01) */
   loadBalanceCoef: number;
-  /** Path for weight persistence (default: '.swarm/moe-weights.json') */
+  /** Path for weight persistence (default: '<root>/.moflo/movector/moe-weights.json') */
   weightsPath: string;
   /** Auto-save interval in updates (default: 50) */
   autoSaveInterval: number;
@@ -146,14 +148,15 @@ interface PersistedModel {
 }
 
 /**
- * Default configuration
+ * Default configuration. `weightsPath` is overridden lazily in the
+ * MoERouter constructor (see #1168) so the path resolves against the
+ * consumer's project root, not the module-load cwd.
  */
-const DEFAULT_CONFIG: MoERouterConfig = {
+const DEFAULT_CONFIG: Omit<MoERouterConfig, 'weightsPath'> = {
   topK: 2,
   learningRate: 0.01,
   temperature: 1.0,
   loadBalanceCoef: 0.01,
-  weightsPath: '.swarm/moe-weights.json',
   autoSaveInterval: 50,
   enableNoise: true,
   noiseStd: 0.1,
@@ -328,7 +331,15 @@ export class MoERouter {
   private lastSelectedExperts: number[] = [];
 
   constructor(config: Partial<MoERouterConfig> = {}) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    // Resolve weightsPath lazily here (#1168) — the default routes through
+    // findProjectRoot at construct-time, not module-load time. Default-rescue
+    // runs *last* so an explicit `weightsPath: undefined` falls back to the
+    // canonical path instead of leaving the field undefined.
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+      weightsPath: config.weightsPath ?? runtimePath('movector', 'moe-weights.json'),
+    };
 
     // Initialize weights
     this.W1 = xavierInit(INPUT_DIM, HIDDEN_DIM);
@@ -616,10 +627,14 @@ export class MoERouter {
    * Load weights from persistence file
    */
   async loadWeights(path?: string): Promise<boolean> {
-    const weightsPath = path || this.config.weightsPath;
+    // Canonical path first, then legacy `.swarm/moe-weights.json` as a
+    // read-only fallback for consumers who upgraded mid-training (#1168).
+    let weightsPath = path || this.config.weightsPath;
     try {
       if (!existsSync(weightsPath)) {
-        return false;
+        const legacy = legacySwarmPath('moe-weights.json');
+        if (!existsSync(legacy)) return false;
+        weightsPath = legacy;
       }
 
       const data = readFileSync(weightsPath, 'utf-8');

--- a/src/cli/services/moflo-paths.ts
+++ b/src/cli/services/moflo-paths.ts
@@ -21,6 +21,7 @@
  */
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { findProjectRoot } from './project-root.js';
 
 export const MOFLO_DIR = '.moflo';
 /** Canonical memory DB filename (post-#727). Lives at `<root>/.moflo/moflo.db`. */
@@ -77,6 +78,27 @@ export function legacyHnswIndexPath(projectRoot: string): string {
 /** Backup sentinel kept for one upgrade cycle: `<root>/.swarm/memory.db.bak`. */
 export function legacyMemoryDbBakPath(projectRoot: string): string {
   return join(projectRoot, LEGACY_SWARM_DIR, `${LEGACY_MEMORY_DB_FILE}${LEGACY_MEMORY_DB_BAK_SUFFIX}`);
+}
+
+/**
+ * Resolve a runtime-state path under `.moflo/<subdir>/<filename>` at the
+ * project root. Lazy by design — every call routes through `findProjectRoot()`
+ * so the path never bakes in `process.cwd()` at module-load time (#1168 bug
+ * class). Use this for any persisted runtime state the daemon, MCP server,
+ * or neural runtime writes (weights, fisher matrix, routing patterns, etc.).
+ */
+export function runtimePath(subdir: string, filename: string): string {
+  return join(mofloDir(findProjectRoot()), subdir, filename);
+}
+
+/**
+ * Legacy `.swarm/<filename>` path at the project root. Read-only fallback for
+ * consumers who saved state under the pre-#1168 location; never written by
+ * production code (enforced by the drift-guard in
+ * `published-package-drift-guard.test.ts`).
+ */
+export function legacySwarmPath(filename: string): string {
+  return join(findProjectRoot(), LEGACY_SWARM_DIR, filename);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Relocated 6 production writers from legacy `.swarm/` to canonical `.moflo/` subdirectories (`movector/`, `neural/`, `swarm/`, `memory/`) — fixes the "healer keeps finding and deleting `.swarm/`" loop.
- Module-level `DEFAULT_CONFIG` no longer captures `process.cwd()` at import time; new `runtimePath(subdir, filename)` helper routes through the unified `findProjectRoot()` resolver lazily.
- Static drift-guard prevents reintroduction of `.swarm/` writers in production source; doctor's `Swarm Residue` migrator now retires the directory in one healer pass for consumers with legacy state.

## Changes

**Neural runtime + command writers relocated (lazy, via `runtimePath()`)**
- `src/cli/movector/lora-adapter.ts` → `.moflo/movector/lora-weights.json`
- `src/cli/movector/moe-router.ts` → `.moflo/movector/moe-weights.json`
- `src/cli/memory/ewc-consolidation.ts` → `.moflo/neural/ewc-fisher.json`
- `src/cli/memory/sona-optimizer.ts` → `.moflo/neural/sona-patterns.json`
- `src/cli/commands/swarm.ts` (`flo swarm init`) → `.moflo/swarm/state.json`
- `src/cli/commands/memory.ts` (`flo memory code-map`) → `.moflo/memory/code-map-hash.txt`

Each loader reads canonical first, falls back to `.swarm/<file>` once for mid-upgrade consumers; saves always go to canonical.

**Doctor self-contradiction removed**
- `src/cli/commands/doctor-fixes.ts` — dropped vestigial `mkdirSync(.swarm)` from the 'Memory Database' + 'Embeddings' auto-fixes. The canonical `initializeMemoryDatabase` already creates `.moflo/`. Pre-#1168 these fixes created `.swarm/` while the same healer pass deleted it.

**Residue migrator + checker expanded**
- `src/cli/commands/doctor-fixes.ts:fixSwarmLegacyResidue` — now recognises and relocates `lora-weights.json`, `moe-weights.json`, `ewc-fisher.json`, `sona-patterns.json`, `state.json`, `code-map-hash.txt` into the right `.moflo/<subdir>/`.
- `src/cli/commands/doctor-checks-config.ts:checkSwarmResidue` — artifact list expanded to match.

**Shared helpers (DRY)**
- `src/cli/services/moflo-paths.ts` — added `runtimePath(subdir, filename)` + `legacySwarmPath(filename)`. Removed 8 inline factory functions across the 4 neural modules.

**Static drift-guard**
- `src/cli/__tests__/services/published-package-drift-guard.test.ts` — new rule scans for `mkdirSync|writeFileSync|renameSync|appendFileSync|fs.mkdir` near `.swarm` literals in production source; offenders require an explicit `LEGACY-V2-WRITE` or `pre-#1168` marker on the same line.

**Tests**
- New: `src/cli/__tests__/commands/swarm-path-relocation.test.ts` — pins default paths for LoRAAdapter / MoERouter / EWCConsolidator / SONAOptimizer under `.moflo/`.
- Extended: `src/cli/__tests__/commands/doctor-fixes-swarm-residue.test.ts` — covers migration of the 6 new artifacts + canonical-wins behaviour.

**Other quality wins from `/flo-simplify` review**
- Fixed constructor merge order so explicit `weightsPath: undefined` from callers falls back to canonical instead of crashing (default-rescue now runs *after* the trailing `...config` spread).
- Removed dead `.swarm/agents/` + `.swarm/tasks/` JSON probes in `getSwarmStatus` — no writer creates them; coordinator MCP tools are the live source.

## Testing

- [x] Unit + extended residue tests pass (173 in the focused set)
- [x] Full suite green: 8,895 tests pass, 0 failures
- [x] `tsc --noEmit` clean
- [x] Static drift-guard catches any future `.swarm/` writer reintroduction
- [ ] Manual: install on a real consumer with legacy `.swarm/` state, run `flo healer --fix`, confirm `.swarm/` is fully retired in one pass and never recreated

Closes #1168

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)