### PR TITLE
ci(cost): move cross-platform smoke off every-PR runs to publish-time

### DIFF
--- a/.claude/guidance/internal/pre-publish-rules.md
+++ b/.claude/guidance/internal/pre-publish-rules.md
@@ -27,7 +27,7 @@ Moflo ships to N consumers via `npm install moflo`. Every change runs from their
 
 ## Trigger-Based Gating (`/publish` default mode)
 
-The `/publish` skill takes a presence-only `--check` / `-ch` flag. **Default behavior is `--check=false`** because most publishes happen right after a green PR where CI has already run lint, build, tests, and smoke (clean + populated, on three OSes). Re-running them locally pays for a CI workflow that already passed.
+The `/publish` skill takes a presence-only `--check` / `-ch` flag. **Default behavior is `--check=false`** because most publishes happen right after a green PR where CI has already run lint, build, tests, and ubuntu-only smoke — and the publish skill itself dispatches the **full 3-OS smoke matrix** (`release-smoke.yml`) at Step 8.5 against the exact commit being published. Re-running lint/test locally pays for a CI workflow that already passed; the cross-platform smoke is paid once per publish via the dispatched matrix.
 
 | Gate | Default mode (no flag) | `--check` mode | Rationale for default |
 |------|------------------------|----------------|----------------------|
@@ -35,8 +35,9 @@ The `/publish` skill takes a presence-only `--check` / `-ch` flag. **Default beh
 | Build | **always run** | run | Confirms the deliverables on disk match the new version; `prepublishOnly` would catch it but earlier is better |
 | Tests | skip | run | `ci.yml` runs `npm test` on every PR |
 | Doctor | **always run** (`--fix`) | run (`--strict`) | Only check with no CI equivalent — local-only state (daemon, embeddings, vector-stats) |
-| Smoke (clean) | skip | run | `consumer-install-smoke.yml` runs on PR + push to main, three OSes |
-| Smoke (populated) | skip | run | Same workflow as above |
+| Smoke (local clean) | skip | run | `release-smoke.yml` dispatched at Step 8.5 covers the same ubuntu profile as local clean smoke, plus macOS + Windows |
+| Smoke (local populated) | skip | run | Same — `release-smoke.yml` matrix includes the populated harness |
+| Release-smoke dispatch | **always run** (Step 8.5) | run | Full 3-OS × 2-harness matrix on the publish SHA. Replaces what used to be every-PR cross-platform smoke. |
 | Manual gate walk (rows below) | **trigger-based** | run all | A cheap bash fingerprint computes which gates the diff actually touches |
 
 The trigger fingerprint is `.claude/skills/publish/fingerprint.sh`. It diffs `HEAD` against the most recent `chore: install moflo@*` commit and pattern-matches the file list against the manual-gate triggers. Output is one block (~50 tokens), then Claude only walks the gates whose triggers fired.
@@ -213,4 +214,6 @@ Use `--check` when the publish didn't go through a green PR, when the change is 
 - `harness/consumer-smoke/README.md` — Smoke harness profiles + checks (Gate 5)
 - `docs/BUILD.md` — Step-by-step build/publish process the `/publish` skill follows
 - `.github/workflows/ci.yml` — Lint/build/test gates default mode skips
-- `.github/workflows/consumer-install-smoke.yml` — Smoke gates default mode skips
+- `.github/workflows/consumer-install-smoke.yml` — Per-PR + push-to-main ubuntu-only smoke
+- `.github/workflows/file-sync-smoke.yml` — Per-PR + push-to-main ubuntu-only file-sync smoke
+- `.github/workflows/release-smoke.yml` — Full 3-OS × 2-harness matrix dispatched by `/publish` Step 8.5

--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -25,9 +25,9 @@ Automated release pipeline for moflo. Bumps version, commits, builds, tests, run
 
 ## --check / -ch flag (presence-only)
 
-**Default (flag absent):** runs build + doctor + trigger-based manual checks only. Skips lint/test/smoke because those gates are covered by CI on every PR + push to main (`ci.yml`, `consumer-install-smoke.yml`).
+**Default (flag absent):** runs build + doctor + trigger-based manual checks only. Skips local lint/test/smoke because lint+test are covered by `ci.yml` on every PR + push to main, and **cross-platform smoke is dispatched as part of this skill** (Step 8.5 below) — the `release-smoke.yml` workflow runs the full 3-OS matrix on the exact commit about to be published.
 
-**With `--check` or `-ch` (any presence):** runs the full pre-flight from `pre-publish-rules.md` — lint, build, test, doctor (strict), clean smoke, populated smoke, and a forced full walk of every manual gate. Use this for publishes that didn't go through a green PR, risky releases, or when you want belt-and-suspenders.
+**With `--check` or `-ch` (any presence):** runs the full pre-flight from `pre-publish-rules.md` — lint, build, test, doctor (strict), local clean smoke, local populated smoke, and a forced full walk of every manual gate. Use this for publishes that didn't go through a green PR, risky releases, or when you want belt-and-suspenders on the local box in addition to the CI matrix.
 
 The flag is presence-only. `--check` and `-ch` both set it to true. There is no `--check=true` / `--check=false` syntax — absence means false.
 
@@ -103,14 +103,14 @@ Doctor is the only check with no CI equivalent — it inspects local state (daem
 
 **Never `--fix` on the publish path.** A release pipeline must fail fast on broken local state, not silently repair it; a doctor that auto-repairs masks the very signal we want — "something is off, stop and investigate before shipping." If `doctor --strict` fails, stop and run `flo healer --fix` (or `npx moflo doctor --fix`) interactively, verify the repair, then retry the publish.
 
-### Step 6: Smoke Tests (only if `CHECK_MODE=true`)
+### Step 6: Local Smoke Tests (only if `CHECK_MODE=true`)
 
 ```bash
 npm run test:smoke
 npm run test:smoke:populated
 ```
 
-Skipped by default — `consumer-install-smoke.yml` runs both profiles on Ubuntu/macOS/Windows on every PR + push to main. Run when `--check` is set.
+Skipped by default. Local smoke covers the same harness as CI's Ubuntu leg, so it adds little signal over `release-smoke.yml`'s Ubuntu matrix entry (Step 8.5). Run only when `--check` is set — useful if you want belt-and-suspenders on the local box before dispatching the full CI matrix.
 
 ### Step 7: Manual Gate Walk (trigger-based, even in default mode)
 
@@ -143,6 +143,42 @@ git push origin main
 ```
 
 Only commit version-related files. Do not stage unrelated changes.
+
+### Step 8.5: Dispatch release-smoke and block until green
+
+```bash
+# Capture the SHA we just pushed — release-smoke runs against this exact commit.
+PUBLISH_SHA=$(git rev-parse HEAD)
+
+# Trigger the full 3-OS × 2-harness matrix. `sha` is a required workflow input
+# so the dispatched run is unambiguously bound to this commit.
+gh workflow run release-smoke.yml --ref main -f sha="$PUBLISH_SHA"
+
+# Give GitHub a moment to register the dispatched run.
+sleep 10
+
+# Find the run we just dispatched by matching head_sha. This is robust against
+# concurrent dispatches (e.g. a manual UI retry from another tab) — never use
+# `--limit 1` alone, which would race against any unrelated in-flight run.
+RUN_ID=$(gh run list --workflow=release-smoke.yml --branch main \
+  --json databaseId,headSha \
+  --jq ".[] | select(.headSha == \"$PUBLISH_SHA\") | .databaseId" \
+  | head -1)
+
+if [ -z "$RUN_ID" ]; then
+  echo "ERROR: no release-smoke run found for SHA $PUBLISH_SHA. Wait a few seconds and retry, or check https://github.com/eric-cielo/moflo/actions/workflows/release-smoke.yml" >&2
+  exit 1
+fi
+
+# Block until the run completes. Exits non-zero on failure.
+gh run watch "$RUN_ID" --exit-status
+```
+
+`release-smoke.yml` runs full consumer + populated smoke on Ubuntu/macOS/Windows, plus file-sync smoke on all three filesystems. Per-PR CI is intentionally Ubuntu-only to keep recurring cost manageable — the full cross-platform matrix is paid once here, at publish time, against the exact commit we're about to publish.
+
+**Wall time expectations**: typical run is ~15-20 min once caches are warm. **The first dispatch after `release-smoke.yml` lands will have cold caches on every leg** (no prior runs of this workflow exist to populate the `consumer-warm` and `fastembed` caches per-OS). Expect ~25-35 min on that first dispatch — the macOS leg is the long pole. Subsequent dispatches reuse the cache and settle to the typical ~15 min.
+
+**If `gh run watch` exits non-zero**: stop immediately. Inspect the failed leg with `gh run view "$RUN_ID" --log-failed`, fix the underlying issue, push the fix, then re-run this step (no need to rerun Steps 0–8 — the bump commit is already on main, and the SHA-filtered lookup will pick up the new dispatched run against the same SHA only after `cancel-in-progress: false` lets the previous run drain). Do not proceed to `npm publish` until release-smoke is green for the SHA you intend to publish.
 
 ### Step 9: Verify npm Authentication
 
@@ -223,8 +259,8 @@ Build:           passed
 Tests:           skipped (CI-covered) | <N> files passed, <N> tests passed
 Lint:            skipped (CI-covered) | passed
 Doctor:          <N> passed, <N> warnings
-Smoke (clean):   skipped (CI-covered) | passed
-Smoke (popl):    skipped (CI-covered) | passed
+Smoke (local):   skipped (CI-covered) | passed
+Release-smoke:   green (run <id>, 3-OS × 2-harness)
 Triggered gates: <list> | none
 Published:       moflo@<new-version>
 Installed:       moflo@<new-version> (devDependency)
@@ -257,5 +293,7 @@ For the common case — publishing right after a merged green PR — the default
 - `docs/BUILD.md` — Step-by-step build/publish process this skill mirrors
 - `.claude/guidance/internal/dogfooding.md` — Why we catch consumer-facing regressions first as our own dependency
 - `harness/consumer-smoke/README.md` — Smoke harness profiles (clean + populated) that prove a consumer install works
-- `.github/workflows/ci.yml` — Lint/build/test gates this skill skips by default
-- `.github/workflows/consumer-install-smoke.yml` — Smoke gates this skill skips by default
+- `.github/workflows/ci.yml` — Lint/build/test gates this skill skips by default (ubuntu-only)
+- `.github/workflows/consumer-install-smoke.yml` — Per-PR ubuntu-only smoke
+- `.github/workflows/file-sync-smoke.yml` — Per-PR ubuntu-only file-sync smoke
+- `.github/workflows/release-smoke.yml` — Full 3-OS × 2-harness matrix this skill dispatches at Step 8.5

--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -51,19 +51,25 @@ concurrency:
 
 jobs:
   smoke:
-    # Split into a 3 × 2 matrix (3 OS × 2 harnesses) so consumer-smoke and
-    # populated-smoke run in PARALLEL on each runner instead of sequentially.
-    # Pre-split Windows wall time: ~10m52s (consumer 2m47s + populated 5m35s
-    # + shared setup ~2m30s). Post-split: max(consumer, populated) + shared
-    # setup ≈ ~7m. The populated harness still bears the heaviest single
-    # chunk (3-min consumer-install) so this approaches but doesn't beat
-    # that floor; further wins need harness-level caching of node_modules
-    # (separate issue).
+    # Per-PR + push-to-main: ubuntu-only consumer and populated smoke.
+    # Cross-OS coverage (mac + windows) runs in `release-smoke.yml` on
+    # workflow_dispatch, gated by the /publish skill. This split exists
+    # because mac runners bill at 10× and windows at 2× — paying that on
+    # every doc tweak / typo fix was the dominant CI cost. Pre-split per-PR
+    # cost was ~197 equivalent-minutes (the smoke matrix alone was ~182);
+    # post-split per-PR cost is ~29 eq-min. The full matrix is paid once
+    # per publish instead of once per PR.
+    #
+    # Job-name template ("${harness} / ${os}") is preserved verbatim so the
+    # protected-branch required status checks `consumer / ubuntu-latest` and
+    # `populated / ubuntu-latest` continue to post. The four removed mac +
+    # windows contexts MUST be deleted from branch protection in the same
+    # change that lands this file — see the PR body for the gh api call.
     name: ${{ matrix.harness }} / ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         harness: [consumer, populated]
     runs-on: ${{ matrix.os }}
     # Acceptance criterion: < 5 min on Ubuntu. Cap all runners conservatively

--- a/.github/workflows/file-sync-smoke.yml
+++ b/.github/workflows/file-sync-smoke.yml
@@ -58,17 +58,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Native: NTFS / APFS / ext4 each have their own lock + rename semantics.
-  # Bug #975's failure venue was DrvFs (covered separately below) but the
-  # other native filesystems have caught a long tail of platform-specific
-  # rename behavior, so we keep all three on every change.
+  # Per-PR + push-to-main: ubuntu-only file-sync smoke. Cross-OS coverage
+  # for NTFS / APFS rename semantics runs in `release-smoke.yml` on
+  # workflow_dispatch (gated by /publish). Same cost-driven split as
+  # consumer-install-smoke. The workflow_dispatch trigger below is kept
+  # so maintainers can still kick off this lightweight suite on demand.
   native:
-    name: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    name: ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,143 @@
+name: Release smoke (pre-publish)
+
+# Full cross-platform smoke matrix, gated to publish time only.
+#
+# Per-PR and push-to-main CI runs ubuntu-only smoke (see
+# `consumer-install-smoke.yml` + `file-sync-smoke.yml`) to keep recurring CI
+# cost manageable. Mac runners bill at 10× and Windows at 2×, so paying the
+# full matrix on every doc tweak or typo fix is unaffordable at PR volume.
+#
+# This workflow runs the full matrix on `workflow_dispatch` only. The
+# `/publish` skill dispatches it (`gh workflow run release-smoke.yml`),
+# polls until green via `gh run watch`, and only then proceeds with
+# `npm publish` from the maintainer's machine.
+#
+# Coverage:
+#   consumer:  ubuntu × {consumer, populated}, macos × {consumer, populated},
+#              windows × {consumer, populated}  → 6 jobs
+#   file-sync: ubuntu, macos, windows                                  → 3 jobs
+#
+# Cost (equivalent-minutes per dispatch, approx):
+#   ubuntu  consumer ~14 × 1  + file-sync ~5 × 1   =  ~19
+#   macos   consumer ~14 × 10 + file-sync ~5 × 10  = ~190
+#   windows consumer ~14 × 2  + file-sync ~5 × 2   =  ~38
+#                                       total      ≈ 247 eq-min per publish
+#
+# Note: 247 > the previous ~197/PR consumer-only number because release-smoke
+# rolls the file-sync 3-OS matrix into the same dispatch. Pre-split that
+# matrix only ran on PRs that touched a path-filtered file list; rolling it
+# into every publish ensures cross-platform file-sync regressions can't ship
+# unnoticed between path-filtered runs. The net economic win remains: per-PR
+# drops from ~197 (or ~262 with file-sync paths touched) to ~29, paid against
+# the steady stream of PR throughput; ~247/publish is paid at publish cadence
+# (a few per week). ~85% reduction in CI cost at PR volume.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        # Required so the concurrency group below is deterministic. /publish
+        # passes the SHA it just pushed at Step 8.5; manual UI dispatches
+        # must explicitly type the SHA they want to verify (a deliberate
+        # "are you sure?" moment for an action that costs ~250 eq-min).
+        description: 'Commit SHA to verify (full or short SHA)'
+        required: true
+        type: string
+
+env:
+  NODE_VERSION: '22'
+
+# Do NOT cancel in-flight release-smoke runs. /publish polls a specific run;
+# a cancellation would cause /publish to misread the run as failed.
+# Keyed off the input SHA so two publishes against different commits run in
+# parallel, but two dispatches of the same SHA queue (the second waits for
+# the first to finish rather than racing).
+concurrency:
+  group: release-smoke-${{ github.event.inputs.sha }}
+  cancel-in-progress: false
+
+jobs:
+  consumer-smoke:
+    # Full 3 × 2 matrix — what was previously the every-PR cost-driver.
+    # Same job body as `consumer-install-smoke.yml`; the only difference is
+    # the matrix axis and the trigger surface. If these two ever diverge in
+    # the per-step logic, fold the shared shape into a composite action.
+    name: ${{ matrix.harness }} / ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        harness: [consumer, populated]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.sha }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      # Same caching scheme as consumer-install-smoke.yml — see that file
+      # for the per-key rationale (ADR-EMB-001, issues #1021/#1153).
+      - name: Cache fastembed model
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/fastembed
+          key: fastembed-${{ runner.os }}-${{ hashFiles('src/cli/embeddings/fastembed-inline/**/*.ts') }}-fast-all-MiniLM-L6-v2
+
+      - name: Cache consumer-install node_modules
+        uses: actions/cache@v5
+        with:
+          path: .work/consumer-warm
+          key: consumer-warm-${{ runner.os }}-${{ matrix.harness }}-${{ hashFiles('package-lock.json', 'scripts/prune-native-binaries.mjs', 'scripts/post-install-bootstrap.mjs', 'scripts/post-install-notice.mjs') }}
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build all packages
+        run: npm run build
+
+      - name: Run consumer smoke harness
+        if: matrix.harness == 'consumer'
+        run: npm run test:smoke -- --warm-donor .work/consumer-warm
+
+      - name: Run populated-consumer smoke harness
+        if: matrix.harness == 'populated'
+        run: npm run test:smoke:populated -- --warm-donor .work/consumer-warm
+
+  file-sync-smoke:
+    # 3-OS native: NTFS / APFS / ext4 each have their own lock + rename
+    # semantics. Same coverage as `file-sync-smoke.yml`'s pre-split shape.
+    name: file-sync / ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.sha }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build (tsc only — tests need the source helpers under bin/lib/)
+        run: npm run build
+
+      - name: Run file-sync smoke tests
+        run: npx vitest run --reporter=default
+          src/cli/__tests__/file-sync-helper.test.ts
+          src/cli/__tests__/post-install-bootstrap.test.ts
+          src/cli/__tests__/bootstrap-sentinel-promotion.test.ts
+          src/cli/__tests__/post-install-bootstrap-drift-guard.test.ts
+          tests/bin/launcher-854-fixes.test.ts


### PR DESCRIPTION
## Summary

Cuts per-PR CI cost from ~197 equivalent-minutes (or ~262 with file-sync paths) down to ~29 by trimming the cross-platform smoke matrices off `pull_request` + `push` triggers. The full 3-OS × 2-harness consumer-install matrix and the 3-OS file-sync matrix now run on a new `release-smoke.yml` workflow that fires on `workflow_dispatch` only, and the `/publish` skill dispatches + polls it against the publish SHA before running `npm publish` locally.

- Mac runners bill at 10×, Windows at 2× — paying that on every doc tweak / typo fix wasn't sustainable.
- The full matrix still runs against the exact commit we publish, just once per publish instead of once per PR.
- Net economic win: **~85% reduction in per-PR CI minutes** at the throughput where most cost actually accrues.

## Changes

- `.github/workflows/consumer-install-smoke.yml` — `matrix.os` constrained to `[ubuntu-latest]`. Two-axis matrix template preserved so `consumer / ubuntu-latest` and `populated / ubuntu-latest` status check names continue to post.
- `.github/workflows/file-sync-smoke.yml` — `matrix.os` removed, hardcoded to `ubuntu-latest`. `workflow_dispatch` trigger retained for on-demand manual runs.
- `.github/workflows/release-smoke.yml` — **new.** Full 3-OS consumer matrix + 3-OS file-sync, `workflow_dispatch` only, `required: true` on the `sha` input so the concurrency group is always deterministic.
- `.claude/skills/publish/SKILL.md` — new Step 8.5 between version-bump push and `npm publish`: dispatch `release-smoke.yml` with the publish SHA, look up the dispatched run by `head_sha` filter (NOT `--limit 1` — that races against any concurrent manual dispatch), `gh run watch --exit-status` to block until green. Stop on red.
- `.claude/guidance/internal/pre-publish-rules.md` — table + See Also updated to reflect the new shape.

## Branch protection — already updated

The pre-PR required statuses were:
```
Build, Tests, Lint & Security,
consumer / {ubuntu,macos,windows}-latest,
populated / {ubuntu,macos,windows}-latest
```
The 4 mac+windows contexts would never post after this PR, so I updated branch protection via `gh api PATCH` to:
```
Build, Tests, Lint & Security,
consumer / ubuntu-latest, populated / ubuntu-latest
```
The two ubuntu contexts continue to post (matrix-template preserved). Reversible if needed.

## Review fixes pre-PR

A reviewer agent pass found two BLOCKING issues, both fixed:
1. **`gh run list --limit 1` race**: SHA-filtered lookup (`select(.headSha == \$PUBLISH_SHA)`) made the primary path, not a footnote workaround.
2. **Concurrency / SHA-input ambiguity**: `sha` input is now `required: true`; concurrency group keyed off it deterministically; `cancel-in-progress: false` so /publish's polling never misreads a cancelled run as failed.

Also fixed: cost-math comment clarified (247 eq-min/publish > previous 197/PR because release-smoke rolls in the file-sync 3-OS matrix that previously only ran path-filtered); cold-cache wall-time note added to Step 8.5.

## Test plan

- [ ] CI green on this PR (ubuntu-only smoke posts the 2 ubuntu contexts; mac+windows no longer required)
- [ ] After merge, kick off `release-smoke.yml` manually with a recent main SHA to confirm end-to-end (cold caches: expect ~25-35 min)
- [ ] Next /publish run dispatches release-smoke at Step 8.5 and blocks correctly

## Follow-up (not blocking)

- Composite action: `release-smoke.yml` duplicates ~30 LOC of YAML (cache keys + steps) from `consumer-install-smoke.yml`. If cache logic ever diverges, extract into a composite action.
- Gate-friction systemic fix: this PR itself tripped the test gate even though the diff is YAML+MD-only (no source code). A separate PR will teach the gate's PR-creation classifier to recognize CI-config-only / docs-only diffs.

## Context

Per `feedback_consumer_blast_radius.md` — this is a maintainer-surface change, not a consumer-surface change. The publish skill ships to consumers via /init, but consumers don't run `/publish` themselves; they install pinned versions. The `release-smoke.yml` workflow only runs in this repo. No round-trip cost for consumers.

Closes paused work: the #1170/#1173 combined PR resumes once this lands so we don't burn the old per-PR cost on that small fix.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)