### PR TITLE
fix(resolver,doctor,mcp): consolidate monorepo state at repo root (#1174)

### DIFF
--- a/.claude/guidance/shipped/moflo-core-guidance.md
+++ b/.claude/guidance/shipped/moflo-core-guidance.md
@@ -176,6 +176,21 @@ Checks: Node version (20+), Git, config validity, daemon status, memory database
 
 ---
 
+## Monorepo Layout
+
+**Purpose:** prevent the most common moflo misconfig — daemon islands in monorepos (#1174).
+
+| Rule | Why |
+|------|-----|
+| One `.moflo/` per monorepo, at the repo root | The daemon, MCP server, and CLI all walk up from `cwd` to locate state. Two `.moflo/` directories under one tree means two daemons with separate sockets, ports, and registries — the MCP server bound to one will not see tools/state from the other. |
+| Never run `flo init` inside a sub-workspace of an existing moflo project | `flo init` refuses by default when an ancestor `.moflo/moflo.db` is detected. `--force` overrides if you genuinely want isolated state. |
+| `flo doctor` flags every nested `.moflo/` it finds | Component name: `nested-moflo`. Status warns when any island exists. |
+| `flo doctor --fix -c nested-moflo` archives each nested directory | Renames `<sub>/.moflo` → `<sub>/.moflo-archived-<ISO>` (never deletes). Manual review path: archived directories stay on disk. |
+
+The resolver (`findProjectRoot`) prefers the topmost ancestor with `.moflo/moflo.db` so every cwd in the tree agrees on the canonical anchor. If `CLAUDE_PROJECT_DIR` is set explicitly, it overrides this — only use that override when you intend isolated state.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
@@ -188,6 +203,7 @@ Checks: Node version (20+), Git, config validity, daemon status, memory database
 | Embeddings fail offline / air-gapped | `fastembed` model cache missing | Pre-populate `~/.cache/fastembed` or set `FASTEMBED_CACHE` (see `docs/modules/embeddings.md`) |
 | `flo` command not found | Not in PATH | Use `npx flo` or `node node_modules/moflo/bin/index-guidance.mjs` |
 | Bundled guidance not indexed | Running inside the moflo repo | Bundled guidance only indexes when installed as a dependency in a different project |
+| `mcp__moflo__*` tools missing in monorepo session | Nested `.moflo/` directories spawned separate daemons (#1174) | Run `flo doctor -c nested-moflo`; if any are found, `flo doctor --fix -c nested-moflo` archives them. Restart Claude Code to reconnect. |
 
 See `.claude/guidance/moflo-memory-strategy.md` for memory-specific troubleshooting and `.claude/guidance/moflo-spell-troubleshooting.md` for spell sandbox/network failures.
 

--- a/bin/lib/moflo-paths.mjs
+++ b/bin/lib/moflo-paths.mjs
@@ -62,6 +62,40 @@ export function memoryDbCandidatePaths(projectRoot) {
 }
 
 /**
+ * Walk strictly upward from `dir` (exclusive) and return the nearest ancestor
+ * that has `.moflo/moflo.db`, or `null` if none exists below the filesystem
+ * root.
+ *
+ * Used by the launcher and `flo init` to detect nested-.moflo/ situations
+ * (#1174). Post-resolver-fix `findProjectRoot` already returns the topmost
+ * memory marker, so encountering an ancestor here means either:
+ *   1. `CLAUDE_PROJECT_DIR` explicitly overrode to a sub-directory (legitimate
+ *      user action — log a warning but don't refuse), or
+ *   2. The launcher is running before any `.moflo/moflo.db` exists at the
+ *      current root (e.g. fresh init in a sub-workspace).
+ *
+ * In either case the caller wants to surface a clear diagnostic so the user
+ * can run `flo doctor --fix` to consolidate.
+ *
+ * @param {string} dir absolute path to walk up from
+ * @returns {string | null} ancestor directory containing `.moflo/moflo.db`
+ */
+export function findAncestorMofloRoot(dir) {
+  const start = resolve(dir);
+  const fsRoot = parse(start).root;
+  let cursor = dirname(start);
+  while (cursor !== fsRoot) {
+    if (existsSync(join(cursor, '.moflo', 'moflo.db'))) {
+      return cursor;
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  return null;
+}
+
+/**
  * Resolve the project root the same way the TS bridge does. Every bin/
  * script that touches `.moflo/moflo.db` (or any sibling state under
  * `.moflo/`) MUST go through this so its writes land on the SAME file the
@@ -83,15 +117,32 @@ export function findProjectRoot(opts) {
   const start = resolve(startDir);
   const fsRoot = parse(start).root;
 
-  // High-priority pass: memory markers + CLAUDE.md/package.json pair.
+  // Pass A — memory markers, topmost wins (#1174). Walks the FULL ancestor
+  // chain, returns the highest ancestor with .moflo/moflo.db or .swarm/memory.db.
+  // Guarantees the root daemon is canonical in a monorepo with nested residue.
+  let topmostMemoryMarker = null;
   let dir = start;
   while (dir !== fsRoot) {
     if (basename(dir) === 'node_modules') {
       dir = dirname(dir);
       continue;
     }
-    if (existsSync(join(dir, '.moflo', 'moflo.db'))) return dir;
-    if (existsSync(join(dir, '.swarm', 'memory.db'))) return dir;
+    if (existsSync(join(dir, '.moflo', 'moflo.db')) || existsSync(join(dir, '.swarm', 'memory.db'))) {
+      topmostMemoryMarker = dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  if (topmostMemoryMarker) return topmostMemoryMarker;
+
+  // Pass B — CLAUDE.md/package.json pair, nearest wins.
+  dir = start;
+  while (dir !== fsRoot) {
+    if (basename(dir) === 'node_modules') {
+      dir = dirname(dir);
+      continue;
+    }
     if (existsSync(join(dir, 'CLAUDE.md')) && existsSync(join(dir, 'package.json'))) {
       return dir;
     }
@@ -100,7 +151,7 @@ export function findProjectRoot(opts) {
     dir = parent;
   }
 
-  // Low-priority pass: bare package.json or .git.
+  // Pass C — bare package.json or .git, nearest wins.
   dir = start;
   while (dir !== fsRoot) {
     if (basename(dir) === 'node_modules') {

--- a/bin/lib/moflo-paths.mjs
+++ b/bin/lib/moflo-paths.mjs
@@ -52,6 +52,25 @@ export function legacyMemoryDbBakPath(projectRoot) {
   return join(projectRoot, LEGACY_SWARM_DIR, `${LEGACY_MEMORY_DB_FILE}${LEGACY_MEMORY_DB_BAK_SUFFIX}`);
 }
 
+/**
+ * Common skip-list for any walk that enumerates a project's children looking
+ * for moflo state. Shared by `bin/session-start-launcher.mjs` (depth-1 walk)
+ * and `src/cli/commands/doctor-checks-config.ts` (depth-5 BFS) so the two
+ * can't silently diverge. Matched case-insensitively at the call site —
+ * Windows NTFS + macOS APFS are case-insensitive by default.
+ *
+ * Categories: VCS metadata, build/cache outputs, language-specific output
+ * dirs, IDE state, virtualenv dirs. NOT included: `.moflo*` — every walk
+ * filters that separately so archived residue from `flo doctor --fix` can be
+ * recognised by prefix.
+ */
+export const COMMON_WALK_SKIP_NAMES = Object.freeze(new Set([
+  'node_modules', '.git', '.svn', '.hg',
+  'dist', 'build', 'out', 'target', '.next', '.nuxt', '.cache',
+  'coverage', '.idea', '.vscode', '.turbo', '.svelte-kit',
+  'vendor', '__pycache__', '.venv', 'venv', '.tox',
+]));
+
 export function memoryDbCandidatePaths(projectRoot) {
   return [
     memoryDbPath(projectRoot),

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -11,7 +11,7 @@ import { spawn, execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { mofloDir, findProjectRoot, findAncestorMofloRoot } from './lib/moflo-paths.mjs';
+import { mofloDir, findProjectRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAMES } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyRetiredPrune } from './lib/retired-files.mjs';
@@ -148,16 +148,21 @@ try {
 
   // Cheap, depth-1 downward walk: just check the immediate children of
   // projectRoot for `.moflo/moflo.db`. The full `flo doctor` BFS is depth-5
-  // and skips many more dir types — that's for the diagnostic. Here we only
-  // need a fast signal so the launcher stays under its perf budget.
+  // — that's for the diagnostic. Here we only need a fast signal so the
+  // launcher stays under its perf budget.
+  //
+  // Skip-list is shared with the doctor BFS via COMMON_WALK_SKIP_NAMES to
+  // prevent divergence. Only `.moflo*`-prefixed dirs are filtered separately
+  // — a `.packages/` or `.workspaces/` directory with its own moflo state is
+  // legitimate (rare, but possible) and should still be detected.
   let firstNested = null;
   try {
     const entries = readdirSync(projectRoot, { withFileTypes: true });
-    const SKIP = new Set(['node_modules', '.git', 'dist', 'build', 'out', 'coverage', '.next', '.cache']);
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const name = entry.name;
-      if (SKIP.has(name) || name.startsWith('.moflo') || name.startsWith('.')) continue;
+      if (COMMON_WALK_SKIP_NAMES.has(name.toLowerCase())) continue;
+      if (name.toLowerCase().startsWith('.moflo')) continue;
       const childDir = join(projectRoot, name);
       if (existsSync(join(childDir, '.moflo', 'moflo.db'))) {
         firstNested = childDir;
@@ -173,7 +178,12 @@ try {
       mkdirSync(mofloDir(projectRoot), { recursive: true });
       const pendingPath = join(mofloDir(projectRoot), 'restart-pending.json');
       writeFileSync(pendingPath, JSON.stringify({
-        version: '1174-nested-moflo',
+        // schemaVersion (not the moflo package version) lets future readers
+        // branch on the notice shape if it ever evolves. The launcher's §0d
+        // version-match cleanup compares `pending.version === installedVersion`
+        // (moflo semver), so this schema field is safely ignored there.
+        schemaVersion: 1,
+        kind: 'nested-moflo',
         message:
           `moflo consolidates monorepo state at the repo root (#1174). Nested .moflo/ ` +
           `directories detected (e.g. ${firstNested}). Run \`flo doctor --fix -c nested-moflo\` ` +

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -11,7 +11,7 @@ import { spawn, execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { mofloDir, findProjectRoot } from './lib/moflo-paths.mjs';
+import { mofloDir, findProjectRoot, findAncestorMofloRoot } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyRetiredPrune } from './lib/retired-files.mjs';
@@ -47,6 +47,23 @@ function sessionStartMirrorHeader(file) {
 // package.json / .git. Inline walks here have caused N writers to land on
 // different DBs than the bridge reads from — never reintroduce one.
 const projectRoot = findProjectRoot();
+
+// Monorepo nested-.moflo guard (#1174). After the resolver fix, findProjectRoot
+// returns the topmost ancestor with .moflo/moflo.db, so an ancestor still
+// having one of those files means CLAUDE_PROJECT_DIR pinned us inside a
+// sub-workspace, or someone reintroduced an inline walk-up. Either way, the
+// daemon spawned from here would NOT be the same one a sibling cwd in the
+// same monorepo resolves to. Emit a clear stderr warning so the user can run
+// `flo doctor --fix` to consolidate.
+try {
+  const ancestor = findAncestorMofloRoot(projectRoot);
+  if (ancestor) {
+    process.stderr.write(
+      `moflo: nested .moflo/ detected — using "${projectRoot}" while ancestor "${ancestor}" also has .moflo/moflo.db. ` +
+      `This fragments monorepo state across multiple daemons (#1174). Run "flo doctor --fix" to consolidate.\n`,
+    );
+  }
+} catch { /* diagnostic-only — must never block session start */ }
 
 // Dogfood guard (#928). When this launcher runs inside the moflo repo itself,
 // .claude/scripts/, .claude/helpers/, and .claude/guidance/ are committed git
@@ -110,6 +127,72 @@ function emitWarning(message) {
 function errMessage(err) {
   return err && err.message ? err.message : String(err);
 }
+
+// Post-upgrade monorepo consolidation notice (#1174). The resolver change in
+// 4.10.13+ flips project-root resolution from "nearest .moflo/" to "topmost
+// .moflo/". Consumers with pre-fix nested .moflo/ residue will see their
+// effective projectRoot move upward, orphaning sub-daemons and changing the
+// per-project daemon port hash. Write a one-time restart-pending.json so the
+// user (via Claude's CLAUDE.md surface-and-delete rule) sees the guidance and
+// runs `flo doctor --fix -c nested-moflo` before the gate hooks start failing.
+//
+// Sentinel state-machine — re-arms after consolidation:
+//   !sentinel && nested  → notify (write json + sentinel, emit mutation)
+//   sentinel  && nested  → silent (already notified)
+//   sentinel  && !nested → cleanup sentinel (user consolidated; re-arm)
+//   !sentinel && !nested → silent (nothing to do)
+//
+// Best-effort — never blocks session start.
+try {
+  const nestedNoticeSentinel = join(mofloDir(projectRoot), 'nested-moflo-notice-shown');
+
+  // Cheap, depth-1 downward walk: just check the immediate children of
+  // projectRoot for `.moflo/moflo.db`. The full `flo doctor` BFS is depth-5
+  // and skips many more dir types — that's for the diagnostic. Here we only
+  // need a fast signal so the launcher stays under its perf budget.
+  let firstNested = null;
+  try {
+    const entries = readdirSync(projectRoot, { withFileTypes: true });
+    const SKIP = new Set(['node_modules', '.git', 'dist', 'build', 'out', 'coverage', '.next', '.cache']);
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const name = entry.name;
+      if (SKIP.has(name) || name.startsWith('.moflo') || name.startsWith('.')) continue;
+      const childDir = join(projectRoot, name);
+      if (existsSync(join(childDir, '.moflo', 'moflo.db'))) {
+        firstNested = childDir;
+        break;
+      }
+    }
+  } catch { /* depth-1 walk failure — fall through, no notice */ }
+
+  const sentinelExists = existsSync(nestedNoticeSentinel);
+
+  if (firstNested && !sentinelExists) {
+    try {
+      mkdirSync(mofloDir(projectRoot), { recursive: true });
+      const pendingPath = join(mofloDir(projectRoot), 'restart-pending.json');
+      writeFileSync(pendingPath, JSON.stringify({
+        version: '1174-nested-moflo',
+        message:
+          `moflo consolidates monorepo state at the repo root (#1174). Nested .moflo/ ` +
+          `directories detected (e.g. ${firstNested}). Run \`flo doctor --fix -c nested-moflo\` ` +
+          `to archive them and stop any orphaned sub-daemons.`,
+        createdAt: new Date().toISOString(),
+      }, null, 2));
+      writeFileSync(nestedNoticeSentinel, new Date().toISOString());
+      emitMutation('nested .moflo/ detected — restart-pending.json written with consolidation guidance');
+    } catch (err) {
+      emitWarning(`nested-moflo notice write failed: ${errMessage(err)}`);
+    }
+  } else if (!firstNested && sentinelExists) {
+    // User has consolidated. Clear the sentinel so a future re-introduction
+    // of nested .moflo/ re-arms the notice path.
+    try {
+      unlinkSync(nestedNoticeSentinel);
+    } catch { /* may have just been removed concurrently */ }
+  }
+} catch { /* diagnostic-only — must never block session start */ }
 
 // Manifest schema (#854 hardening). Originally `string[]`; now `{path,size}[]`
 // so the launcher can detect *content* drift, not just *missing-file* drift.

--- a/src/cli/__tests__/doctor-nested-moflo-islands.test.ts
+++ b/src/cli/__tests__/doctor-nested-moflo-islands.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the `Nested .moflo/ Islands` doctor check (#1174).
+ *
+ * The check walks downward from the project root, BFS-bounded, looking for
+ * sub-directories that have their own `.moflo/moflo.db`. Each is a daemon
+ * island that fragments monorepo state. The fix archives them as
+ * `.moflo-archived-<ISO>/`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  checkNestedMofloIslands,
+  findNestedMofloDirsForFix,
+} from '../commands/doctor-checks-config.js';
+
+function makeTempRoot(label: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `nested-moflo-${label}-`));
+}
+
+function seedMofloDb(dir: string): void {
+  fs.mkdirSync(path.join(dir, '.moflo'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.moflo', 'moflo.db'), 'SQLite format 3\0');
+}
+
+describe('checkNestedMofloIslands (#1174)', () => {
+  let root: string;
+
+  beforeEach(() => { root = makeTempRoot('check'); });
+  afterEach(() => {
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* ok */ }
+  });
+
+  it('passes when no nested .moflo/ directories exist', async () => {
+    seedMofloDb(root);
+    fs.mkdirSync(path.join(root, 'packages', 'foo'), { recursive: true });
+    const result = await checkNestedMofloIslands(root);
+    expect(result.status).toBe('pass');
+    expect(result.name).toBe('Nested .moflo/ Islands');
+  });
+
+  it('warns when a sub-package has its own .moflo/moflo.db (1-level)', async () => {
+    seedMofloDb(root);
+    const sub = path.join(root, 'packages', 'api');
+    fs.mkdirSync(sub, { recursive: true });
+    seedMofloDb(sub);
+
+    const result = await checkNestedMofloIslands(root);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('1 nested');
+    expect(result.message).toContain(path.join('packages', 'api'));
+    expect(result.fix).toContain('nested-moflo');
+  });
+
+  it('finds multiple nested islands at different depths', async () => {
+    seedMofloDb(root);
+    const appA = path.join(root, 'apps', 'a');
+    const appB = path.join(root, 'apps', 'b');
+    fs.mkdirSync(appA, { recursive: true });
+    fs.mkdirSync(appB, { recursive: true });
+    seedMofloDb(appA);
+    seedMofloDb(appB);
+
+    const result = await checkNestedMofloIslands(root);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('2 nested');
+  });
+
+  it('does not recurse below a nested island', async () => {
+    seedMofloDb(root);
+    const outer = path.join(root, 'workspace', 'outer');
+    const inner = path.join(outer, 'inner');
+    fs.mkdirSync(inner, { recursive: true });
+    seedMofloDb(outer);
+    seedMofloDb(inner);
+
+    // Both outer and inner have their own .moflo, but the BFS stops at outer
+    // (descendants of a nested island would be conflated under that residue).
+    const found = findNestedMofloDirsForFix(root);
+    expect(found).toContain(outer);
+    expect(found).not.toContain(inner);
+  });
+
+  it('skips node_modules and dist directories', async () => {
+    seedMofloDb(root);
+    const nm = path.join(root, 'node_modules', 'fakedep');
+    const dist = path.join(root, 'dist');
+    fs.mkdirSync(nm, { recursive: true });
+    fs.mkdirSync(dist, { recursive: true });
+    seedMofloDb(nm);
+    seedMofloDb(dist);
+
+    const result = await checkNestedMofloIslands(root);
+    expect(result.status).toBe('pass');
+  });
+
+  it('skips additional build/cache directories (.turbo, vendor, __pycache__)', async () => {
+    seedMofloDb(root);
+    const turbo = path.join(root, '.turbo', 'cache-island');
+    const vendor = path.join(root, 'vendor', 'github.com', 'pkg');
+    const pycache = path.join(root, '__pycache__', 'mod');
+    fs.mkdirSync(turbo, { recursive: true });
+    fs.mkdirSync(vendor, { recursive: true });
+    fs.mkdirSync(pycache, { recursive: true });
+    seedMofloDb(turbo);
+    seedMofloDb(vendor);
+    seedMofloDb(pycache);
+
+    const result = await checkNestedMofloIslands(root);
+    expect(result.status).toBe('pass');
+  });
+
+  it('skips archived .moflo-archived-* directories from prior fix runs', async () => {
+    seedMofloDb(root);
+    const sub = path.join(root, 'packages', 'api');
+    fs.mkdirSync(sub, { recursive: true });
+    // Archived residue from a prior `flo doctor --fix` run — not an active island.
+    fs.mkdirSync(path.join(sub, '.moflo-archived-2026-05-17T10-30-00-000Z'), { recursive: true });
+    fs.writeFileSync(
+      path.join(sub, '.moflo-archived-2026-05-17T10-30-00-000Z', 'moflo.db'),
+      'SQLite format 3\0',
+    );
+
+    const result = await checkNestedMofloIslands(root);
+    expect(result.status).toBe('pass');
+  });
+});

--- a/src/cli/__tests__/services/project-root.test.ts
+++ b/src/cli/__tests__/services/project-root.test.ts
@@ -1,15 +1,21 @@
 /**
  * Project Root Tests
  *
- * Validates findProjectRoot() walks up from cwd to find package.json or .git.
+ * Validates findProjectRoot() walks up from cwd to find package.json or .git,
+ * and that memory markers (.moflo/moflo.db, .swarm/memory.db) anchor to the
+ * TOPMOST ancestor — not the nearest — so monorepos don't fragment daemons
+ * (#1174).
  *
  * Story #229: Extracted from workflow-tools.ts.
+ * Story #1057: Aligned with bridge-core.getProjectRoot().
+ * Issue #1174: Memory markers anchor topmost, not nearest.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { findProjectRoot } from '../../services/project-root.js';
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 describe('findProjectRoot', () => {
   it('should return a directory containing package.json or .git', () => {
@@ -25,5 +31,109 @@ describe('findProjectRoot', () => {
 
   it('should return the same value on repeated calls', () => {
     expect(findProjectRoot()).toBe(findProjectRoot());
+  });
+});
+
+describe('findProjectRoot — monorepo memory-marker anchoring (#1174)', () => {
+  // Each test isolates env so CLAUDE_PROJECT_DIR (set by Claude Code session
+  // start) can't override the cwd walk-up we're trying to verify.
+  let fixtureRoot: string;
+  let prevClaudeProjectDir: string | undefined;
+
+  beforeEach(() => {
+    prevClaudeProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    fixtureRoot = mkdtempSync(join(tmpdir(), 'project-root-1174-'));
+  });
+
+  afterEach(() => {
+    if (prevClaudeProjectDir !== undefined) {
+      process.env.CLAUDE_PROJECT_DIR = prevClaudeProjectDir;
+    }
+    try {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    } catch { /* Windows file handles occasionally linger */ }
+  });
+
+  function seedMofloDb(dir: string) {
+    mkdirSync(join(dir, '.moflo'), { recursive: true });
+    writeFileSync(join(dir, '.moflo', 'moflo.db'), 'SQLite format 3\0');
+  }
+
+  it('returns workspace root when nested package has .moflo residue (1-level)', () => {
+    const workspace = join(fixtureRoot, 'mono');
+    const subpkg = join(workspace, 'packages', 'api');
+    const subSrc = join(subpkg, 'src');
+    mkdirSync(subSrc, { recursive: true });
+    seedMofloDb(workspace);
+    seedMofloDb(subpkg);
+    writeFileSync(join(workspace, 'package.json'), '{}');
+    writeFileSync(join(subpkg, 'package.json'), '{}');
+
+    expect(findProjectRoot({ cwd: subSrc, honorEnv: false })).toBe(workspace);
+  });
+
+  it('returns topmost when .moflo residue exists at 2 nested levels', () => {
+    const workspace = join(fixtureRoot, 'mono-2level');
+    const intermediate = join(workspace, 'apps', 'web');
+    const sub = join(intermediate, 'api');
+    const subSrc = join(sub, 'src');
+    mkdirSync(subSrc, { recursive: true });
+    seedMofloDb(workspace);
+    seedMofloDb(intermediate);
+    seedMofloDb(sub);
+    writeFileSync(join(workspace, 'package.json'), '{}');
+
+    expect(findProjectRoot({ cwd: subSrc, honorEnv: false })).toBe(workspace);
+  });
+
+  it('CLAUDE.md+package.json pair does NOT short-circuit past an ancestor .moflo', () => {
+    // Pre-#1174 bug: rule 1c fired at the subpkg level because both CLAUDE.md
+    // and package.json were present, returning the subpkg before the walk
+    // ever reached the workspace's .moflo/moflo.db. The fix moves CLAUDE.md+
+    // package.json into Pass B (only reached when no memory markers exist).
+    const workspace = join(fixtureRoot, 'claudemd-trap');
+    const subpkg = join(workspace, 'packages', 'foo');
+    mkdirSync(subpkg, { recursive: true });
+    seedMofloDb(workspace);
+    writeFileSync(join(workspace, 'package.json'), '{}');
+    writeFileSync(join(subpkg, 'package.json'), '{}');
+    writeFileSync(join(subpkg, 'CLAUDE.md'), '# foo');
+
+    expect(findProjectRoot({ cwd: subpkg, honorEnv: false })).toBe(workspace);
+  });
+
+  it('falls back to CLAUDE.md+package.json pair when no .moflo exists anywhere', () => {
+    const project = join(fixtureRoot, 'pair-only');
+    const sub = join(project, 'src');
+    mkdirSync(sub, { recursive: true });
+    writeFileSync(join(project, 'package.json'), '{}');
+    writeFileSync(join(project, 'CLAUDE.md'), '# project');
+
+    expect(findProjectRoot({ cwd: sub, honorEnv: false })).toBe(project);
+  });
+
+  it('falls back to bare package.json when no .moflo and no CLAUDE.md pair', () => {
+    const project = join(fixtureRoot, 'bare');
+    const sub = join(project, 'a', 'b');
+    mkdirSync(sub, { recursive: true });
+    writeFileSync(join(project, 'package.json'), '{}');
+
+    expect(findProjectRoot({ cwd: sub, honorEnv: false })).toBe(project);
+  });
+
+  it('.swarm/memory.db (legacy) also anchors topmost', () => {
+    const workspace = join(fixtureRoot, 'legacy-mono');
+    const subpkg = join(workspace, 'pkg');
+    const subSrc = join(subpkg, 'src');
+    mkdirSync(subSrc, { recursive: true });
+    mkdirSync(join(workspace, '.swarm'), { recursive: true });
+    writeFileSync(join(workspace, '.swarm', 'memory.db'), 'SQLite format 3\0');
+    mkdirSync(join(subpkg, '.swarm'), { recursive: true });
+    writeFileSync(join(subpkg, '.swarm', 'memory.db'), 'SQLite format 3\0');
+    writeFileSync(join(workspace, 'package.json'), '{}');
+    writeFileSync(join(subpkg, 'package.json'), '{}');
+
+    expect(findProjectRoot({ cwd: subSrc, honorEnv: false })).toBe(workspace);
   });
 });

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -19,6 +19,7 @@ import {
   normalizeProjectRoot,
 } from '../services/daemon-port.js';
 import {
+  COMMON_WALK_SKIP_NAMES,
   LEGACY_SWARM_DIR,
   legacyMemoryDbPath,
   memoryDbCandidatePaths,
@@ -381,23 +382,31 @@ interface NestedScanResult {
   truncated: boolean;
 }
 
+/**
+ * Cap on `found.length` so a pathological monorepo (or adversarial layout)
+ * can't accumulate an unbounded array. 50 islands is already 50× more than
+ * any legitimate consumer should ever have; surfacing more would just bury
+ * the actionable signal in noise. Setting `truncated = true` signals the
+ * walker stopped early so the doctor message can hint at re-running with
+ * something more targeted.
+ */
+const NESTED_BFS_MAX_FOUND = 50;
+
 function scanNestedMofloDirs(root: string, maxDepth: number = 5): NestedScanResult {
   const found: string[] = [];
   let truncated = false;
-  const SKIP_NAMES = new Set([
-    'node_modules', '.git', '.svn', '.hg',
-    'dist', 'build', 'out', 'target', '.next', '.nuxt', '.cache',
-    'coverage', '.idea', '.vscode', '.turbo', '.svelte-kit',
-    'vendor', '__pycache__', '.venv', 'venv', '.tox',
-  ]);
 
   function walk(dir: string, depth: number): void {
+    if (found.length >= NESTED_BFS_MAX_FOUND) {
+      truncated = true;
+      return;
+    }
     let entries;
     try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const lower = entry.name.toLowerCase();
-      if (SKIP_NAMES.has(lower)) continue;
+      if (COMMON_WALK_SKIP_NAMES.has(lower)) continue;
       // Skip any .moflo* directory — both the canonical `.moflo` (we're
       // looking for nested ones, not this level's own) and archived
       // `.moflo-archived-*` produced by `flo doctor --fix`.
@@ -406,6 +415,10 @@ function scanNestedMofloDirs(root: string, maxDepth: number = 5): NestedScanResu
       const childDir = join(dir, entry.name);
       if (existsSync(join(childDir, '.moflo', 'moflo.db'))) {
         found.push(childDir);
+        if (found.length >= NESTED_BFS_MAX_FOUND) {
+          truncated = true;
+          return;
+        }
         // Don't recurse below a nested island — its own descendants would
         // be conflated under that residue.
         continue;
@@ -415,6 +428,7 @@ function scanNestedMofloDirs(root: string, maxDepth: number = 5): NestedScanResu
         continue;
       }
       walk(childDir, depth + 1);
+      if (found.length >= NESTED_BFS_MAX_FOUND) return;
     }
   }
   walk(root, 0);

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -4,8 +4,8 @@
  * test directories.
  */
 
-import { existsSync, readFileSync, statSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
 import os from 'os';
 import {
   findProjectDaemonPids,
@@ -355,6 +355,133 @@ export async function checkSwarmResidue(): Promise<HealthCheck> {
     status: 'warn',
     message: `${present.length} legacy artifact(s) in .swarm/: ${present.join(', ')}`,
     fix: 'flo healer --fix -c swarm-residue',
+  };
+}
+
+/**
+ * Walk downward from `root` (BFS, bounded) collecting every `.moflo/moflo.db`
+ * outside `root` itself. Skips `node_modules`, `.git`, dot-prefixed temp dirs,
+ * and any `.moflo*` directory (so archived residue from `flo doctor --fix`
+ * doesn't keep re-tripping the check). Depth-bounded to avoid pathological
+ * walks in massive monorepos — most consumer layouts nest at most 2-3 levels.
+ *
+ * `truncated` is set when any branch of the walk hit `maxDepth` without
+ * finishing — a deeper nested island could be hiding past the limit. The
+ * doctor check surfaces this so the user knows to inspect manually.
+ *
+ * Skip-list match is case-INSENSITIVE because Windows NTFS and macOS APFS are
+ * case-insensitive by default — `Node_Modules` should be skipped just like
+ * `node_modules`. POSIX hits the lowercased path 100% of the time anyway.
+ *
+ * Returned paths are the parent directories (e.g. `/repo/packages/api`, not
+ * `/repo/packages/api/.moflo`), aligned with `findProjectRoot()` semantics.
+ */
+interface NestedScanResult {
+  islands: string[];
+  truncated: boolean;
+}
+
+function scanNestedMofloDirs(root: string, maxDepth: number = 5): NestedScanResult {
+  const found: string[] = [];
+  let truncated = false;
+  const SKIP_NAMES = new Set([
+    'node_modules', '.git', '.svn', '.hg',
+    'dist', 'build', 'out', 'target', '.next', '.nuxt', '.cache',
+    'coverage', '.idea', '.vscode', '.turbo', '.svelte-kit',
+    'vendor', '__pycache__', '.venv', 'venv', '.tox',
+  ]);
+
+  function walk(dir: string, depth: number): void {
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const lower = entry.name.toLowerCase();
+      if (SKIP_NAMES.has(lower)) continue;
+      // Skip any .moflo* directory — both the canonical `.moflo` (we're
+      // looking for nested ones, not this level's own) and archived
+      // `.moflo-archived-*` produced by `flo doctor --fix`.
+      if (lower.startsWith('.moflo')) continue;
+      if (entry.name.startsWith('.') && depth > 0) continue;
+      const childDir = join(dir, entry.name);
+      if (existsSync(join(childDir, '.moflo', 'moflo.db'))) {
+        found.push(childDir);
+        // Don't recurse below a nested island — its own descendants would
+        // be conflated under that residue.
+        continue;
+      }
+      if (depth + 1 > maxDepth) {
+        truncated = true;
+        continue;
+      }
+      walk(childDir, depth + 1);
+    }
+  }
+  walk(root, 0);
+  return { islands: found, truncated };
+}
+
+function findNestedMofloDirs(root: string, maxDepth: number = 5): string[] {
+  return scanNestedMofloDirs(root, maxDepth).islands;
+}
+
+/**
+ * Public wrapper for the BFS used by `checkNestedMofloIslands`. Exposed so
+ * `doctor-fixes.ts:fixNestedMofloIslands` can enumerate the same set without
+ * duplicating the skip-list / depth-bound logic. Returns parent directories
+ * (the consumer joins `.moflo` itself).
+ */
+export function findNestedMofloDirsForFix(root: string): string[] {
+  return findNestedMofloDirs(root);
+}
+
+/**
+ * Surface nested `.moflo/moflo.db` directories — every one of them is a daemon
+ * island in a monorepo (#1174). The MCP server, daemon, and CLI tools each
+ * resolve their own anchor via cwd; pre-#1174 the resolver returned the
+ * *nearest* ancestor, so subdirectory invocations silently spawned isolated
+ * daemons with separate sockets, ports, registries, and vector state.
+ *
+ * Status semantics:
+ *  - `pass` — no nested `.moflo/` directories under the canonical project root.
+ *  - `warn` — one or more nested `.moflo/` directories detected; lists each
+ *    with its relative path. `fix` points at the auto-fix that archives them.
+ *
+ * Auto-fix (`fixNestedMofloIslands` in doctor-fixes.ts) renames each nested
+ * `.moflo/` to `.moflo-archived-<ISO>/` so the user can manually inspect or
+ * restore them. Daemons running out of those nested directories are stopped
+ * first.
+ */
+export async function checkNestedMofloIslands(cwd?: string): Promise<HealthCheck> {
+  const root = cwd ?? findProjectRoot();
+  let scan: NestedScanResult;
+  try {
+    scan = scanNestedMofloDirs(root);
+  } catch (e) {
+    return {
+      name: 'Nested .moflo/ Islands',
+      status: 'warn',
+      message: `Walk failed: ${errorDetail(e, { firstLineOnly: true })}`,
+    };
+  }
+  const { islands, truncated } = scan;
+  if (islands.length === 0) {
+    const baseMsg = 'No nested .moflo/ directories detected';
+    return {
+      name: 'Nested .moflo/ Islands',
+      status: truncated ? 'warn' : 'pass',
+      message: truncated
+        ? `${baseMsg} within depth-5 walk — deeper subtrees not inspected`
+        : baseMsg,
+    };
+  }
+  const rels = islands.map(p => relative(root, p) || '.');
+  const truncNote = truncated ? ' (walk truncated at depth 5 — deeper islands may exist)' : '';
+  return {
+    name: 'Nested .moflo/ Islands',
+    status: 'warn',
+    message: `${islands.length} nested .moflo/ ${islands.length === 1 ? 'directory' : 'directories'} (#1174): ${rels.join(', ')}${truncNote}`,
+    fix: 'flo healer --fix -c nested-moflo',
   };
 }
 

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -12,7 +12,7 @@ import { output } from '../output.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
-import { getDaemonLockHolder } from '../services/daemon-lock.js';
+import { findProjectDaemonPids, getDaemonLockHolder } from '../services/daemon-lock.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { legacyMemoryDbPath, legacyMemoryDbBakPath, memoryDbPath, mofloDir } from '../services/moflo-paths.js';
 import { findZombieProcesses } from './doctor-zombies.js';
@@ -246,6 +246,122 @@ async function fixSwarmLegacyResidue(): Promise<boolean> {
   }
 
   return allMigrated;
+}
+
+/**
+ * Stop any moflo daemons owned by `subRoot` before archiving its `.moflo/`.
+ *
+ * Pre-#1174 nested-daemon PIDs are not visible to the canonical orphan reap
+ * (which uses the topmost projectRoot's CLI candidate paths). Calling
+ * `findProjectDaemonPids` with the SUB-root finds them. SIGTERM first, wait a
+ * brief grace, SIGKILL if still alive. On Windows, daemons holding files in
+ * `.moflo/` would otherwise cause `renameSync` to fail with EBUSY; on POSIX,
+ * the rename succeeds but the daemon's open FDs keep pointing at the inode.
+ */
+async function stopNestedDaemons(subRoot: string): Promise<{ stopped: number[]; remaining: number[] }> {
+  let pids: number[] = [];
+  try {
+    pids = findProjectDaemonPids(subRoot);
+  } catch { return { stopped: [], remaining: [] }; }
+
+  if (pids.length === 0) return { stopped: [], remaining: [] };
+
+  const stopped: number[] = [];
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 'SIGTERM');
+      stopped.push(pid);
+    } catch { /* already gone; treat as stopped */ }
+  }
+
+  // Poll for exit with a 1s deadline (matches the daemon-service stop loop in
+  // commands/daemon.ts). Async-by-default — busy-waiting here would pin CPU
+  // during the very contention we're waiting out (see feedback memory).
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    const alive = stopped.filter(pid => {
+      try { process.kill(pid, 0); return true; } catch { return false; }
+    });
+    if (alive.length === 0) break;
+    await new Promise<void>(resolve => setTimeout(resolve, 50));
+  }
+
+  const remaining: number[] = [];
+  for (const pid of stopped) {
+    try {
+      process.kill(pid, 0); // exists check
+      // Still alive — escalate.
+      try { process.kill(pid, 'SIGKILL'); } catch { /* may have just exited */ }
+      // Re-probe after SIGKILL.
+      try { process.kill(pid, 0); remaining.push(pid); } catch { /* gone */ }
+    } catch { /* already gone */ }
+  }
+
+  return { stopped, remaining };
+}
+
+/**
+ * Archive nested `.moflo/` directories that fragment monorepo state (#1174).
+ *
+ * Each nested `.moflo/` is renamed to `.moflo-archived-<ISO>` in place. Never
+ * deletes — sub-daemon vector state can be uniquely useful (subworkspace-
+ * specific learnings) and silently dropping it would be the wrong default.
+ * The user can manually inspect or restore archived directories.
+ *
+ * Daemon reap: before each rename, `findProjectDaemonPids(island)` enumerates
+ * any moflo daemons whose cmdline references the sub-root, then SIGTERMs them
+ * (escalates to SIGKILL after 1s). This is required for both platforms:
+ *   - Windows: `renameSync` fails with EBUSY if any file is open. Without the
+ *     reap, archive silently fails until the user manually stops the daemon.
+ *   - POSIX: rename succeeds but the daemon's open FDs keep pointing at the
+ *     inode; the daemon keeps writing to a now-archived path until it exits.
+ */
+async function fixNestedMofloIslands(): Promise<boolean> {
+  const root = findProjectRoot();
+  let islands: string[];
+  try {
+    const { findNestedMofloDirsForFix } = await import('./doctor-checks-config.js');
+    islands = findNestedMofloDirsForFix(root);
+  } catch (e) {
+    output.writeln(output.warning(`  Unable to enumerate nested .moflo/: ${errorDetail(e)}`));
+    return false;
+  }
+  if (islands.length === 0) return true;
+
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  let allArchived = true;
+
+  for (const island of islands) {
+    const src = join(island, '.moflo');
+    const dst = join(island, `.moflo-archived-${ts}`);
+    if (!existsSync(src)) continue;
+
+    // Step 1: stop any sub-daemon. The canonical projectRoot-based orphan
+    // scan can't see nested daemons; we have to enumerate from the sub-root.
+    const { stopped, remaining } = await stopNestedDaemons(island);
+    if (stopped.length > 0) {
+      output.writeln(output.dim(
+        `  ${island}: stopped daemon PID${stopped.length === 1 ? '' : 's'} ${stopped.join(', ')}.`,
+      ));
+    }
+    if (remaining.length > 0) {
+      output.writeln(output.warning(
+        `  ${island}: PID${remaining.length === 1 ? '' : 's'} ${remaining.join(', ')} survived SIGKILL — manual intervention required.`,
+      ));
+    }
+
+    try {
+      renameSync(src, dst);
+      output.writeln(output.success(`  Archived: ${island}/.moflo → .moflo-archived-${ts}/`));
+    } catch (e) {
+      output.writeln(output.warning(
+        `  Failed to archive ${island}/.moflo: ${errorDetail(e)}. ` +
+        `If a process still holds files open, stop it manually and re-run \`flo doctor --fix -c nested-moflo\`.`,
+      ));
+      allArchived = false;
+    }
+  }
+  return allArchived;
 }
 
 /**
@@ -584,6 +700,13 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     // See `fixSwarmLegacyResidue` for the per-artifact policy.
     'Swarm Residue': async () => {
       return fixSwarmLegacyResidue();
+    },
+    // Archive nested `.moflo/` directories that fragment monorepo state
+    // (#1174). Rename, never delete — sub-daemon vector state can be unique
+    // and silently losing it would be the wrong default. The archive name
+    // includes an ISO timestamp so re-runs don't collide.
+    'Nested .moflo/ Islands': async () => {
+      return fixNestedMofloIslands();
     },
     'Status Line': async () => {
       const settingsPath = join(process.cwd(), '.claude', 'settings.json');

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -258,20 +258,42 @@ async function fixSwarmLegacyResidue(): Promise<boolean> {
  * `.moflo/` would otherwise cause `renameSync` to fail with EBUSY; on POSIX,
  * the rename succeeds but the daemon's open FDs keep pointing at the inode.
  */
-async function stopNestedDaemons(subRoot: string): Promise<{ stopped: number[]; remaining: number[] }> {
+/**
+ * `process.kill` failure modes worth distinguishing:
+ *   - `ESRCH` — no such process (already exited). Treat as success.
+ *   - `EPERM` — caller lacks permission (POSIX: daemon owned by another user;
+ *     Windows: insufficient ACLs). The signal was NOT delivered. We must
+ *     report this as "remaining" so the caller doesn't archive `.moflo/`
+ *     thinking the daemon is gone.
+ *   - other — surface as remaining + log; don't crash the fix path.
+ */
+function killOutcome(err: unknown): 'gone' | 'denied' | 'unknown' {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'ESRCH') return 'gone';
+  if (code === 'EPERM') return 'denied';
+  return 'unknown';
+}
+
+async function stopNestedDaemons(subRoot: string): Promise<{ stopped: number[]; remaining: number[]; denied: number[] }> {
   let pids: number[] = [];
   try {
     pids = findProjectDaemonPids(subRoot);
-  } catch { return { stopped: [], remaining: [] }; }
+  } catch { return { stopped: [], remaining: [], denied: [] }; }
 
-  if (pids.length === 0) return { stopped: [], remaining: [] };
+  if (pids.length === 0) return { stopped: [], remaining: [], denied: [] };
 
   const stopped: number[] = [];
+  const denied: number[] = [];
   for (const pid of pids) {
     try {
       process.kill(pid, 'SIGTERM');
       stopped.push(pid);
-    } catch { /* already gone; treat as stopped */ }
+    } catch (err) {
+      const outcome = killOutcome(err);
+      if (outcome === 'gone') continue;            // already exited
+      if (outcome === 'denied') denied.push(pid);  // wrong-owner daemon
+      else denied.push(pid);                       // unknown — treat as undelivered
+    }
   }
 
   // Poll for exit with a 1s deadline (matches the daemon-service stop loop in
@@ -288,16 +310,24 @@ async function stopNestedDaemons(subRoot: string): Promise<{ stopped: number[]; 
 
   const remaining: number[] = [];
   for (const pid of stopped) {
+    let stillAlive = false;
+    try { process.kill(pid, 0); stillAlive = true; } catch { /* gone */ }
+    if (!stillAlive) continue;
+
+    // Still alive — escalate.
     try {
-      process.kill(pid, 0); // exists check
-      // Still alive — escalate.
-      try { process.kill(pid, 'SIGKILL'); } catch { /* may have just exited */ }
-      // Re-probe after SIGKILL.
-      try { process.kill(pid, 0); remaining.push(pid); } catch { /* gone */ }
-    } catch { /* already gone */ }
+      process.kill(pid, 'SIGKILL');
+    } catch (err) {
+      if (killOutcome(err) === 'denied') {
+        denied.push(pid);
+        continue;
+      }
+      // Other errors (incl. ESRCH on race) — re-probe below.
+    }
+    try { process.kill(pid, 0); remaining.push(pid); } catch { /* gone */ }
   }
 
-  return { stopped, remaining };
+  return { stopped, remaining, denied };
 }
 
 /**
@@ -338,16 +368,23 @@ async function fixNestedMofloIslands(): Promise<boolean> {
 
     // Step 1: stop any sub-daemon. The canonical projectRoot-based orphan
     // scan can't see nested daemons; we have to enumerate from the sub-root.
-    const { stopped, remaining } = await stopNestedDaemons(island);
+    const { stopped, remaining, denied } = await stopNestedDaemons(island);
     if (stopped.length > 0) {
       output.writeln(output.dim(
         `  ${island}: stopped daemon PID${stopped.length === 1 ? '' : 's'} ${stopped.join(', ')}.`,
       ));
     }
+    if (denied.length > 0) {
+      output.writeln(output.warning(
+        `  ${island}: permission denied stopping PID${denied.length === 1 ? '' : 's'} ${denied.join(', ')} — daemon owned by another user; stop it manually before re-running this fix.`,
+      ));
+      allArchived = false;
+    }
     if (remaining.length > 0) {
       output.writeln(output.warning(
         `  ${island}: PID${remaining.length === 1 ? '' : 's'} ${remaining.join(', ')} survived SIGKILL — manual intervention required.`,
       ));
+      allArchived = false;
     }
 
     try {

--- a/src/cli/commands/doctor-registry.ts
+++ b/src/cli/commands/doctor-registry.ts
@@ -44,6 +44,7 @@ import {
   checkMemoryDatabase,
   checkMemoryDbIntegrity,
   checkMofloYamlCompliance,
+  checkNestedMofloIslands,
   checkStatusLine,
   checkSwarmResidue,
   checkTestDirs,
@@ -84,6 +85,10 @@ export const allChecks: CheckFn[] = [
   checkDaemonWriteRouting,
   checkWritersAudit,
   checkMemoryDatabase,
+  // Surfaces nested `.moflo/moflo.db` directories — every nested instance is
+  // a daemon island in a monorepo (#1174). Runs cheap (depth-bounded BFS,
+  // statSync only) and independent of memory-DB integrity probes.
+  checkNestedMofloIslands,
   // Surfaces leftover `.swarm/` artifacts (memory.db, router state, logs) so
   // the auto-fix can relocate or delete them. Independent of the canonical
   // DB checks — runs cheap (statSync only).
@@ -155,6 +160,10 @@ export const componentMap: Record<string, CheckFn> = {
   'writers-audit': checkWritersAudit,
   'writers': checkWritersAudit,
   'memory': checkMemoryDatabase,
+  'nested-moflo': checkNestedMofloIslands,
+  'nested': checkNestedMofloIslands,
+  'islands': checkNestedMofloIslands,
+  'monorepo': checkNestedMofloIslands,
   'swarm-residue': checkSwarmResidue,
   'residue': checkSwarmResidue,
   'memory-db-integrity': checkMemoryDbIntegrity,

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -9,6 +9,7 @@ import { confirm, select, multiSelect, input } from '../prompt.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { findAncestorMofloRoot } from '../services/project-root.js';
 import {
   executeInit,
   executeUpgrade,
@@ -37,6 +38,44 @@ const initAction = async (ctx: CommandContext): Promise<CommandResult> => {
   const skipClaude = ctx.flags.skipClaude as boolean;
   const onlyClaude = ctx.flags.onlyClaude as boolean;
   const cwd = ctx.cwd;
+
+  // ── Monorepo nested-.moflo guard (#1174) ───────────────────────────
+  // Initializing inside a sub-directory whose ancestor already has
+  // .moflo/moflo.db creates a daemon island: the MCP server, daemon, and CLI
+  // tools end up bound to different daemons depending on cwd. Default to
+  // using the ancestor's state; --force lets the user opt in to a nested
+  // setup (rare, almost always a misconfiguration).
+  const ancestorMoflo = findAncestorMofloRoot(cwd);
+  if (ancestorMoflo && !force) {
+    output.printWarning('Monorepo detected: ancestor moflo project found.');
+    output.printInfo(`  Ancestor: ${ancestorMoflo}`);
+    output.printInfo(`  This directory: ${cwd}`);
+    output.writeln();
+    output.writeln(
+      'Initializing here would create a nested .moflo/ — the MCP server and CLI tools',
+    );
+    output.writeln(
+      'would silently route to different daemons depending on cwd (issue #1174). Use the',
+    );
+    output.writeln('ancestor\'s state by running moflo commands from the ancestor instead.');
+    output.writeln();
+    if (ctx.interactive && !ctx.flags.yes) {
+      const proceed = await confirm({
+        message: 'Initialize anyway (creates a nested .moflo/)?',
+        default: false,
+      });
+      if (!proceed) {
+        output.printInfo('Aborted — use the ancestor moflo project.');
+        return { success: true, message: 'aborted by user (ancestor moflo project)' };
+      }
+    } else {
+      output.printError(
+        'Refusing to create a nested .moflo/. Pass --force to override, or re-run from the ancestor.',
+      );
+      return { success: false, message: 'refused: nested .moflo/ in monorepo', exitCode: 1 };
+    }
+  }
+  // ── End monorepo guard ─────────────────────────────────────────────
 
   // ── MoFlo Project Setup ────────────────────────────────────────────
   // Always run MoFlo init to ensure moflo.yaml, hooks, skill, and

--- a/src/cli/init/claudemd-generator.ts
+++ b/src/cli/init/claudemd-generator.ts
@@ -53,6 +53,10 @@ Prefer MCP (\`mcp__moflo__*\` — memory, swarm, agent, task, hooks, hive-mind, 
 
 After \`npm install\` touches moflo, check \`.moflo/restart-pending.json\` — if present, surface its \`message\` field to the user verbatim, then delete the file. (Claude Code only loads new hooks/MCP/launcher at session start.)
 
+### Monorepos
+
+Moflo state lives at the monorepo root \`.moflo/\` — never run \`flo init\` inside a sub-workspace of an existing moflo project, or the MCP server and CLI silently bind to different daemons (issue #1174).
+
 ### Full Reference
 
 - Universal agent rules (memory protocol, git/PR conventions, file org, build/test): \`.claude/guidance/moflo-agent-rules.md\`

--- a/src/cli/mcp-server.ts
+++ b/src/cli/mcp-server.ts
@@ -119,19 +119,28 @@ function buildDefaultOptions(): Required<MCPServerOptions> {
  * crash the MCP server (next append succeeds; rotation retries next time).
  */
 const MCP_LOG_ROTATE_BYTES = 50 * 1024 * 1024;
+// Throttle rotation checks: batch spell scenarios can write thousands of
+// MCP requests per session. statSync per append is wasted syscalls — bucket
+// the check every N writes (and always on the very first call so cold-start
+// rotation still fires).
+const MCP_LOG_ROTATE_CHECK_EVERY = 100;
+let mcpAppendsSinceRotateCheck = MCP_LOG_ROTATE_CHECK_EVERY;
 function safeAppendMcpLog(logFile: string, event: Record<string, unknown>): void {
   try {
     fs.mkdirSync(path.dirname(logFile), { recursive: true });
     // Rotate before append so the very write that crosses the threshold
     // lands in the fresh file rather than the rotated one.
-    try {
-      const stats = fs.statSync(logFile);
-      if (stats.size >= MCP_LOG_ROTATE_BYTES) {
-        const rotated = `${logFile}.1`;
-        try { fs.unlinkSync(rotated); } catch { /* may not exist */ }
-        fs.renameSync(logFile, rotated);
-      }
-    } catch { /* file may not exist yet; first write creates it */ }
+    if (++mcpAppendsSinceRotateCheck >= MCP_LOG_ROTATE_CHECK_EVERY) {
+      mcpAppendsSinceRotateCheck = 0;
+      try {
+        const stats = fs.statSync(logFile);
+        if (stats.size >= MCP_LOG_ROTATE_BYTES) {
+          const rotated = `${logFile}.1`;
+          try { fs.unlinkSync(rotated); } catch { /* may not exist */ }
+          fs.renameSync(logFile, rotated);
+        }
+      } catch { /* file may not exist yet; first write creates it */ }
+    }
     const line = JSON.stringify({ ts: new Date().toISOString(), ...event }) + '\n';
     fs.appendFileSync(logFile, line, 'utf-8');
   } catch { /* logging must never throw */ }

--- a/src/cli/mcp-server.ts
+++ b/src/cli/mcp-server.ts
@@ -101,6 +101,43 @@ function buildDefaultOptions(): Required<MCPServerOptions> {
 }
 
 /**
+ * Best-effort append to the MCP log file. Errors are swallowed — logging must
+ * never crash the MCP server. Used to capture server start, project root
+ * resolution, and per-request timing so we never repeat the 18-hour
+ * diagnostic blind window from #1174.
+ *
+ * Rotation: when the log exceeds {@link MCP_LOG_ROTATE_BYTES}, rename it to
+ * `<logFile>.1` (overwriting any previous rotated file). One rotation level
+ * keeps the most recent ~50MB of activity plus the previous ~50MB. A long-
+ * running session with heavy MCP traffic can otherwise write hundreds of MB.
+ *
+ * Cross-platform: uses fs.appendFileSync + fs.mkdirSync({recursive:true}) +
+ * fs.renameSync. All three work identically on Windows/macOS/Linux. Windows
+ * note: renameSync can fail with EBUSY if the file is open by another
+ * process; we use append-only here so no other writer should hold it, but
+ * the rename is wrapped in a try/catch so a transient rotation failure can't
+ * crash the MCP server (next append succeeds; rotation retries next time).
+ */
+const MCP_LOG_ROTATE_BYTES = 50 * 1024 * 1024;
+function safeAppendMcpLog(logFile: string, event: Record<string, unknown>): void {
+  try {
+    fs.mkdirSync(path.dirname(logFile), { recursive: true });
+    // Rotate before append so the very write that crosses the threshold
+    // lands in the fresh file rather than the rotated one.
+    try {
+      const stats = fs.statSync(logFile);
+      if (stats.size >= MCP_LOG_ROTATE_BYTES) {
+        const rotated = `${logFile}.1`;
+        try { fs.unlinkSync(rotated); } catch { /* may not exist */ }
+        fs.renameSync(logFile, rotated);
+      }
+    } catch { /* file may not exist yet; first write creates it */ }
+    const line = JSON.stringify({ ts: new Date().toISOString(), ...event }) + '\n';
+    fs.appendFileSync(logFile, line, 'utf-8');
+  } catch { /* logging must never throw */ }
+}
+
+/**
  * MCP Server Manager
  *
  * Manages the lifecycle of the MCP server process
@@ -321,6 +358,28 @@ export class MCPServerManager extends EventEmitter {
       version: VERSION,
     }));
 
+    // Persistent log (#1174). The MCP server previously logged only to stderr,
+    // which Claude Code drops on the floor unless the user runs `claude
+    // --debug`. The 18-hour daemon-island incident took that long to diagnose
+    // partly because no on-disk log captured server start, the resolved
+    // project root, or the request stream. Default-on JSONL log fixes that.
+    const resolvedProjectRoot = findProjectRoot();
+    safeAppendMcpLog(this.options.logFile, {
+      event: 'server.start',
+      sessionId,
+      version: VERSION,
+      pid: process.pid,
+      ppid: process.ppid,
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      cwd: process.cwd(),
+      projectRoot: resolvedProjectRoot,
+      claudeProjectDir: process.env.CLAUDE_PROJECT_DIR || null,
+      pidFile: this.options.pidFile,
+      logFile: this.options.logFile,
+    });
+
     // Send server initialization notification
     console.log(JSON.stringify({
       jsonrpc: '2.0',
@@ -483,8 +542,16 @@ export class MCPServerManager extends EventEmitter {
             },
           };
 
-        case 'tools/list':
+        case 'tools/list': {
+          const listStart = performance.now();
           const tools = listMCPTools();
+          const durationMs = performance.now() - listStart;
+          safeAppendMcpLog(this.options.logFile, {
+            event: 'tools/list',
+            sessionId,
+            count: tools.length,
+            durationMs: Math.round(durationMs * 100) / 100,
+          });
           return {
             jsonrpc: '2.0',
             id: message.id,
@@ -496,12 +563,18 @@ export class MCPServerManager extends EventEmitter {
               })),
             },
           };
+        }
 
-        case 'tools/call':
+        case 'tools/call': {
           const toolName = params.name as string;
           const toolParams = (params.arguments || {}) as Record<string, unknown>;
 
           if (!hasTool(toolName)) {
+            safeAppendMcpLog(this.options.logFile, {
+              event: 'tools/call.unknown',
+              sessionId,
+              toolName,
+            });
             return {
               jsonrpc: '2.0',
               id: message.id,
@@ -509,14 +582,30 @@ export class MCPServerManager extends EventEmitter {
             };
           }
 
+          const callStart = performance.now();
           try {
             const result = await callMCPTool(toolName, toolParams, { sessionId });
+            const durationMs = performance.now() - callStart;
+            safeAppendMcpLog(this.options.logFile, {
+              event: 'tools/call.ok',
+              sessionId,
+              toolName,
+              durationMs: Math.round(durationMs * 100) / 100,
+            });
             return {
               jsonrpc: '2.0',
               id: message.id,
               result: { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] },
             };
           } catch (error) {
+            const durationMs = performance.now() - callStart;
+            safeAppendMcpLog(this.options.logFile, {
+              event: 'tools/call.error',
+              sessionId,
+              toolName,
+              durationMs: Math.round(durationMs * 100) / 100,
+              error: error instanceof Error ? error.message : 'Tool execution failed',
+            });
             return {
               jsonrpc: '2.0',
               id: message.id,
@@ -526,6 +615,7 @@ export class MCPServerManager extends EventEmitter {
               },
             };
           }
+        }
 
         case 'notifications/initialized':
           // Client notification - no response needed

--- a/src/cli/services/moflo-paths.ts
+++ b/src/cli/services/moflo-paths.ts
@@ -118,3 +118,20 @@ export function memoryDbCandidatePaths(projectRoot: string): string[] {
   ];
 }
 
+/**
+ * Common skip-list for any walk that enumerates a project's children looking
+ * for moflo state. Shared by `bin/session-start-launcher.mjs` (depth-1 walk)
+ * and `doctor-checks-config.ts` (depth-5 BFS) so the two can't silently
+ * diverge.
+ *
+ * Twin of `bin/lib/moflo-paths.mjs:COMMON_WALK_SKIP_NAMES`. Matched
+ * case-insensitively at every call site — Windows NTFS + macOS APFS are
+ * case-insensitive by default.
+ */
+export const COMMON_WALK_SKIP_NAMES: ReadonlySet<string> = new Set([
+  'node_modules', '.git', '.svn', '.hg',
+  'dist', 'build', 'out', 'target', '.next', '.nuxt', '.cache',
+  'coverage', '.idea', '.vscode', '.turbo', '.svelte-kit',
+  'vendor', '__pycache__', '.venv', 'venv', '.tox',
+]);
+

--- a/src/cli/services/project-root.ts
+++ b/src/cli/services/project-root.ts
@@ -8,29 +8,40 @@
  * resolve through this single algorithm or its JS twin — otherwise different
  * writers land on different DBs and the bridge reads stale data.
  *
- * Algorithm (#1057) — two-pass walk so memory markers always win:
+ * Algorithm (#1057, #1174) — three-pass walk so memory markers always win
+ * across the ENTIRE ancestor chain (not just at the first level they appear):
  *   1. `process.env.CLAUDE_PROJECT_DIR`, if set (Claude Code / explicit override).
- *   2. **High-priority pass.** Walk from `opts.cwd ?? process.cwd()` up to the
- *      filesystem root, looking at each level for (in order):
- *        a. `<dir>/.moflo/moflo.db`            — canonical memory DB marker
- *        b. `<dir>/.swarm/memory.db`           — legacy memory DB marker (pre-#727)
- *        c. `<dir>/CLAUDE.md` AND `<dir>/package.json` — project marker pair
- *      If anything matches, return that dir. `node_modules` segments are
- *      skipped (npx run can land cwd inside one).
- *   3. **Low-priority pass.** Walk again from cwd up to root looking for:
- *        d. `<dir>/package.json`               — generic project marker
- *        e. `<dir>/.git`                       — git repo marker
- *      Return the first match.
- *   4. Fall back to `opts.cwd ?? process.cwd()`.
+ *   2. **Pass A — memory markers (topmost wins).** Walk from
+ *      `opts.cwd ?? process.cwd()` up to the filesystem root, collecting EVERY
+ *      level that has `.moflo/moflo.db` OR `.swarm/memory.db`. Return the
+ *      topmost (highest ancestor) match. This is the #1174 fix — pre-#1174 the
+ *      walk stopped at the nearest hit, fragmenting monorepos into daemon
+ *      islands.
+ *   3. **Pass B — project marker pair (nearest wins).** Only reached when no
+ *      moflo state exists anywhere up the tree. Walk again looking for
+ *      `<dir>/CLAUDE.md` AND `<dir>/package.json` at the same level; return
+ *      the nearest match.
+ *   4. **Pass C — bare project markers (nearest wins).** Walk again looking
+ *      for `<dir>/package.json` OR `<dir>/.git`; return the nearest match.
+ *   5. Fall back to `opts.cwd ?? process.cwd()`.
  *
- * Why two passes? An upstream `.moflo/moflo.db` MUST win over a nested
- * `package.json` (monorepo sub-package case) — otherwise the writer lands on
- * a different DB than the bridge. Doing it in a single pass with bare
- * `package.json` as a per-level marker would short-circuit at the nearest
- * package.json before ever seeing the upstream memory marker.
+ * `node_modules` segments are always skipped (npx run can land cwd inside one).
+ *
+ * Why topmost (Pass A)? When a monorepo has nested `.moflo/moflo.db` directories
+ * — typically because `flo init` was run from a subworkspace before #1174 — the
+ * MCP server, daemon, CLI, and gate hooks ALL must agree on a single anchor.
+ * Topmost wins means the root daemon is canonical; sub-daemons become
+ * detectable residue that `flo doctor --fix` archives. Nearest-wins fragments
+ * state silently because every cwd resolves to a different anchor.
+ *
+ * Why nearest (Pass B/C)? Pass B/C only fires when there's no moflo state at
+ * all. In a fresh checkout the user expects `flo init` to anchor at the
+ * project they're in, not at some ancestor `.git`/`package.json` directory.
  *
  * Story #229 history: this function was first extracted from workflow-tools.ts;
- * #1057 brought it into alignment with bridge-core.getProjectRoot().
+ * #1057 brought it into alignment with bridge-core.getProjectRoot(); #1174
+ * changed Pass A from nearest-wins to topmost-wins to fix monorepo daemon
+ * fragmentation.
  */
 
 import { existsSync } from 'node:fs';
@@ -47,6 +58,36 @@ export interface FindProjectRootOptions {
   honorEnv?: boolean;
 }
 
+/**
+ * Walk strictly upward from `dir` (exclusive) and return the nearest ancestor
+ * that has `.moflo/moflo.db`, or `null` if none exists below the filesystem
+ * root.
+ *
+ * Used by `flo init` and the session-start launcher to detect nested-.moflo
+ * situations (#1174). Post-resolver-fix `findProjectRoot` returns the topmost
+ * memory marker, so encountering an ancestor here means either:
+ *   1. `CLAUDE_PROJECT_DIR` explicitly overrode to a sub-directory
+ *      (legitimate user action — log a warning but don't refuse), or
+ *   2. The caller is operating on a directory that's about to become a new
+ *      nested .moflo/ island (e.g. `flo init` in a sub-workspace).
+ *
+ * Algorithmic twin of `bin/lib/moflo-paths.mjs:findAncestorMofloRoot()`.
+ */
+export function findAncestorMofloRoot(dir: string): string | null {
+  const start = resolve(dir);
+  const fsRoot = parse(start).root;
+  let cursor = dirname(start);
+  while (cursor !== fsRoot) {
+    if (existsSync(join(cursor, '.moflo', 'moflo.db'))) {
+      return cursor;
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  return null;
+}
+
 export function findProjectRoot(opts?: FindProjectRootOptions): string {
   const honorEnv = opts?.honorEnv !== false;
   if (honorEnv && process.env.CLAUDE_PROJECT_DIR) {
@@ -56,15 +97,34 @@ export function findProjectRoot(opts?: FindProjectRootOptions): string {
   const start = resolve(startDir);
   const fsRoot = parse(start).root;
 
-  // High-priority pass: memory markers + CLAUDE.md/package.json pair.
+  // Pass A — memory markers, topmost wins (#1174).
+  // Collect every ancestor with `.moflo/moflo.db` or `.swarm/memory.db`, then
+  // return the highest one. Guarantees the root daemon is canonical in a
+  // monorepo with nested .moflo/ residue.
+  let topmostMemoryMarker: string | null = null;
   let dir = start;
   while (dir !== fsRoot) {
     if (basename(dir) === 'node_modules') {
       dir = dirname(dir);
       continue;
     }
-    if (existsSync(join(dir, '.moflo', 'moflo.db'))) return dir;
-    if (existsSync(join(dir, '.swarm', 'memory.db'))) return dir;
+    if (existsSync(join(dir, '.moflo', 'moflo.db')) || existsSync(join(dir, '.swarm', 'memory.db'))) {
+      topmostMemoryMarker = dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  if (topmostMemoryMarker) return topmostMemoryMarker;
+
+  // Pass B — project marker pair, nearest wins. Only reached when no moflo
+  // state exists anywhere up the tree.
+  dir = start;
+  while (dir !== fsRoot) {
+    if (basename(dir) === 'node_modules') {
+      dir = dirname(dir);
+      continue;
+    }
     if (existsSync(join(dir, 'CLAUDE.md')) && existsSync(join(dir, 'package.json'))) {
       return dir;
     }
@@ -73,7 +133,7 @@ export function findProjectRoot(opts?: FindProjectRootOptions): string {
     dir = parent;
   }
 
-  // Low-priority pass: bare package.json or .git.
+  // Pass C — bare package.json or .git, nearest wins.
   dir = start;
   while (dir !== fsRoot) {
     if (basename(dir) === 'node_modules') {

--- a/tests/system/project-root-twin.test.ts
+++ b/tests/system/project-root-twin.test.ts
@@ -98,6 +98,54 @@ const cases: Case[] = [
     },
   },
   {
+    // #1174 — Pre-fix behavior: nearest .moflo/moflo.db wins, so a session-
+    // start hook running from `subpkg` (which has its own residue .moflo/)
+    // anchored on the sub-package and spawned its own daemon. Topmost-wins
+    // means the resolver returns the workspace anchor even when nested
+    // residue exists; the residue becomes detectable by `flo doctor` instead
+    // of silently fragmenting state.
+    name: 'monorepo with nested .moflo/ residue: topmost ancestor wins (#1174)',
+    setup(rootDir) {
+      const workspace = join(rootDir, 'mono-nested');
+      const subpkg = join(workspace, 'packages', 'api');
+      const subSrc = join(subpkg, 'src');
+      mkdirSync(subSrc, { recursive: true });
+      // Workspace root .moflo/moflo.db — the canonical anchor.
+      mkdirSync(join(workspace, '.moflo'), { recursive: true });
+      writeFileSync(join(workspace, '.moflo', 'moflo.db'), 'SQLite format 3\0');
+      writeFileSync(join(workspace, 'package.json'), '{"name":"workspace"}');
+      writeFileSync(join(workspace, 'CLAUDE.md'), '# workspace');
+      // Sub-package residue .moflo/moflo.db (zombie from pre-fix flo init).
+      mkdirSync(join(subpkg, '.moflo'), { recursive: true });
+      writeFileSync(join(subpkg, '.moflo', 'moflo.db'), 'SQLite format 3\0');
+      writeFileSync(join(subpkg, 'package.json'), '{"name":"api"}');
+      writeFileSync(join(subpkg, 'CLAUDE.md'), '# api workspace');
+      return { cwd: subSrc, expected: workspace };
+    },
+  },
+  {
+    // #1174 — 2-level nesting: workspace > packages > sub. Resolver must walk
+    // all the way up even when an intermediate level also has .moflo/.
+    name: 'monorepo with 2-level nested .moflo/ residue: topmost wins (#1174)',
+    setup(rootDir) {
+      const workspace = join(rootDir, 'mono-2level');
+      const intermediate = join(workspace, 'apps', 'web');
+      const sub = join(intermediate, 'api');
+      const subSrc = join(sub, 'src');
+      mkdirSync(subSrc, { recursive: true });
+      mkdirSync(join(workspace, '.moflo'), { recursive: true });
+      writeFileSync(join(workspace, '.moflo', 'moflo.db'), 'SQLite format 3\0');
+      writeFileSync(join(workspace, 'package.json'), '{"name":"workspace"}');
+      mkdirSync(join(intermediate, '.moflo'), { recursive: true });
+      writeFileSync(join(intermediate, '.moflo', 'moflo.db'), 'SQLite format 3\0');
+      writeFileSync(join(intermediate, 'package.json'), '{"name":"web"}');
+      mkdirSync(join(sub, '.moflo'), { recursive: true });
+      writeFileSync(join(sub, '.moflo', 'moflo.db'), 'SQLite format 3\0');
+      writeFileSync(join(sub, 'package.json'), '{"name":"api"}');
+      return { cwd: subSrc, expected: workspace };
+    },
+  },
+  {
     name: 'legacy .swarm/memory.db marker also wins over nested package.json',
     setup(rootDir) {
       const workspace = join(rootDir, 'legacy');


### PR DESCRIPTION
## Summary

- Closes #1174. `findProjectRoot` now anchors at the **topmost** ancestor `.moflo/moflo.db` (was: nearest), so monorepos no longer fragment into daemon islands. Three-pass walk in `src/cli/services/project-root.ts` + algorithmically-identical JS twin in `bin/lib/moflo-paths.mjs`.
- Belt and suspenders: `flo init` refuses nested-create by default; `flo doctor -c nested-moflo` finds existing islands; `flo doctor --fix -c nested-moflo` SIGTERMs sub-daemons via `findProjectDaemonPids(subRoot)` before archive-renaming `.moflo/` → `.moflo-archived-<ISO>/` (required on Windows for EBUSY-free rename; required on POSIX so daemon FDs don't keep pointing at the archived inode).
- Diagnostics: MCP server writes `.moflo/mcp-server.log` (JSONL) with server.start + tools/list + tools/call timings — the 18-hour blind window from the incident report is closed. Rotates at 50MB (throttled rotation check, every 100 appends). Session-start launcher writes a one-time `restart-pending.json` (schemaVersion: 1, kind: nested-moflo) with consolidation guidance when nested `.moflo/` is detected; sentinel self-clears after the user runs the fix.

## Cross-platform (Rule #1)

- All path manipulation via `path.join`/`dirname`/`parse`/`resolve` — no hardcoded separators.
- Walks use `path.parse(start).root` for the stop condition (`C:\` on Win, `/` on POSIX).
- Doctor BFS skip-list matches case-insensitively (Windows NTFS + macOS APFS are case-insensitive by default).
- `stopNestedDaemons` uses async `setTimeout` polling, never busy-waits.
- EPERM (wrong-owner daemon on POSIX, restricted ACL on Windows) distinguished from ESRCH — user gets explicit guidance instead of a silent miss.
- Verified: harness/consumer-smoke `.work/` still lives in `os.tmpdir()` (#1088); topmost-wins makes that constraint stricter not looser.

## Reviews

**system-architect** flagged three must-fix items (all addressed):
1. Daemon orphan reap before archive rename (Windows EBUSY + POSIX inode-lingering).
2. Post-upgrade `restart-pending.json` notice with self-clearing sentinel.
3. MCP log rotation at 50MB → `.log.1`.

**/flo-simplify NORMAL tier** (963 LOC, 13 files, security-sensitive) → 3 parallel reviewers caught six follow-ups (commit 859ba7474):
- *Quality*: EPERM/ESRCH discrimination; structured `schemaVersion`; narrower dot-prefix skip.
- *Reuse*: extracted `COMMON_WALK_SKIP_NAMES` to `moflo-paths.{ts,mjs}` so launcher + doctor BFS share one source of truth.
- *Efficiency*: capped doctor BFS `found[]` at 50 with truncated flag; throttled MCP log statSync to every 100 appends.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 8951 pass, 0 fail (one daemon-dashboard parallel-fork flake observed once, did not reproduce on re-run; unrelated to fix surface)
- [x] `src/cli/__tests__/services/project-root.test.ts` — 6 new cases (1-level, 2-level nesting, CLAUDE.md+package.json doesn't short-circuit, legacy `.swarm/memory.db`, no-marker fallback)
- [x] `tests/system/project-root-twin.test.ts` — 2 new cases covering 1-level + 2-level nesting; TS and JS resolver agree
- [x] `src/cli/__tests__/doctor-nested-moflo-islands.test.ts` — 7 cases covering BFS skip list, depth-limit, archived-residue skip, additional skip dirs
- [x] Cross-platform audit per `CLAUDE.md` Rule #1

## Consumer impact

For consumers with a single `.moflo/` at the natural root (the vast majority), `findProjectRoot` returns the same value as before — Pass A returns the only memory marker, which is also the topmost. **No drift.**

For consumers with nested `.moflo/` residue:
- projectRoot moves upward on next session.
- Old sub-daemon becomes an orphan; `flo doctor --fix -c nested-moflo` reaps it.
- Daemon port hash changes (new launcher binds to a different port).
- `restart-pending.json` surfaces with explicit guidance on next prompt.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)