### PR TITLE
fix(#1180): preserve consumer customisations in wholesale hook-block regen

### DIFF
--- a/src/cli/__tests__/services/hook-block-hash.test.ts
+++ b/src/cli/__tests__/services/hook-block-hash.test.ts
@@ -347,13 +347,33 @@ describe('applyWholesaleRegeneration (#896)', () => {
 });
 
 describe('isHookBlockLocked', () => {
-  it('returns true when claudeFlow.hooks.locked === true', () => {
+  it('returns true when moflo.hooks.locked === true (canonical)', () => {
+    expect(isHookBlockLocked({ moflo: { hooks: { locked: true } } })).toBe(true);
+  });
+
+  it('returns true when claudeFlow.hooks.locked === true (legacy alias)', () => {
     expect(isHookBlockLocked({ claudeFlow: { hooks: { locked: true } } })).toBe(true);
+  });
+
+  it('honours moflo.hooks.locked even when claudeFlow.hooks.locked is false', () => {
+    expect(isHookBlockLocked({
+      moflo: { hooks: { locked: true } },
+      claudeFlow: { hooks: { locked: false } },
+    })).toBe(true);
+  });
+
+  it('falls back to claudeFlow when moflo.hooks.locked is missing', () => {
+    expect(isHookBlockLocked({
+      moflo: { hooks: {} },
+      claudeFlow: { hooks: { locked: true } },
+    })).toBe(true);
   });
 
   it('returns false on missing/falsy/non-object input', () => {
     expect(isHookBlockLocked({})).toBe(false);
     expect(isHookBlockLocked(null)).toBe(false);
+    expect(isHookBlockLocked({ moflo: {} })).toBe(false);
+    expect(isHookBlockLocked({ moflo: { hooks: { locked: false } } })).toBe(false);
     expect(isHookBlockLocked({ claudeFlow: {} })).toBe(false);
     expect(isHookBlockLocked({ claudeFlow: { hooks: { locked: false } } })).toBe(false);
   });

--- a/src/cli/__tests__/services/hook-block-hash.test.ts
+++ b/src/cli/__tests__/services/hook-block-hash.test.ts
@@ -15,6 +15,7 @@ import {
   applyWholesaleRegeneration,
   applyAdditiveRegeneration,
   isHookBlockLocked,
+  type HookEntry,
 } from '../../services/hook-block-hash.js';
 import { generateSettings } from '../../init/settings-generator.js';
 import { DEFAULT_INIT_OPTIONS } from '../../init/types.js';
@@ -235,6 +236,96 @@ describe('applyWholesaleRegeneration (#896)', () => {
     const result = applyWholesaleRegeneration(settings, report);
     expect(result.added).toBe(0);
     expect(result.removed).toBe(0);
+  });
+
+  it('#1180: preserves consumer customisations (non-moflo helper commands) while dropping stale moflo entries', () => {
+    // Repro of the waxstak shape: consumer has a PostToolUse customisation
+    // calling their own helper (`project-analysis-gate.cjs`) alongside a
+    // stale moflo entry (`gate.cjs session-reset` from before #842). The
+    // wholesale path used to drop both — it must now preserve the consumer
+    // entry and only drop the stale moflo entry.
+    const customCmd = 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/project-analysis-gate.cjs"';
+    const staleMofloCmd = 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" session-reset';
+
+    const settings: Record<string, unknown> = {
+      permissions: { allow: ['Bash(npm:*)'] },
+      hooks: {
+        ...JSON.parse(JSON.stringify(getReferenceHookBlock())),
+        // Consumer-owned PostToolUse customisation on the Write/Edit matcher
+        PostToolUse: [
+          ...(getReferenceHookBlock().PostToolUse),
+          {
+            matcher: '^(Write|Edit|MultiEdit)$',
+            hooks: [{ type: 'command', command: customCmd, timeout: 4000 }],
+          },
+        ],
+        // Stale moflo SessionStart entry that wholesale regen should drop
+        SessionStart: [
+          {
+            hooks: [
+              ...(getReferenceHookBlock().SessionStart[0].hooks),
+              { type: 'command', command: staleMofloCmd, timeout: 2000 },
+            ],
+          },
+        ],
+      },
+    };
+
+    const report = computeHookBlockDrift(settings.hooks);
+    expect(report.drifted).toBe(true);
+    // Two extras: one customisation + one stale moflo entry.
+    expect(report.extra.some(e => e.command === customCmd)).toBe(true);
+    expect(report.extra.some(e => e.command === staleMofloCmd)).toBe(true);
+
+    const result = applyWholesaleRegeneration(settings, report);
+    // Only the stale moflo entry was removed; the customisation survived.
+    expect(result.removed).toBe(1);
+
+    // Post-regen, walk the hooks tree and assert both invariants:
+    // (a) the customisation is present, under its original matcher, with its
+    //     original timeout/type preserved;
+    // (b) the stale moflo entry is gone.
+    const hooks = settings.hooks as Record<string, Array<{ matcher?: string; hooks: HookEntry[] }>>;
+    const postBlock = hooks.PostToolUse?.find(b => b.matcher === '^(Write|Edit|MultiEdit)$');
+    expect(postBlock).toBeDefined();
+    const customHook = postBlock!.hooks.find(h => h.command === customCmd);
+    expect(customHook).toBeDefined();
+    expect(customHook!.timeout).toBe(4000);
+    expect(customHook!.type).toBe('command');
+
+    const sessionStartBlock = hooks.SessionStart?.[0];
+    expect(sessionStartBlock).toBeDefined();
+    expect(sessionStartBlock!.hooks.some(h => h.command === staleMofloCmd)).toBe(false);
+
+    // Non-hooks fields untouched.
+    expect(settings.permissions).toEqual({ allow: ['Bash(npm:*)'] });
+  });
+
+  it('#1180: grafts a customisation into a fresh matcher block when the matcher is new', () => {
+    // Customisation targets an event/matcher pair that doesn't exist in the
+    // reference at all — wholesale regen must create the block.
+    const customCmd = 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/my-custom-handler.cjs"';
+    const settings: Record<string, unknown> = {
+      hooks: {
+        ...JSON.parse(JSON.stringify(getReferenceHookBlock())),
+        PostToolUse: [
+          ...(getReferenceHookBlock().PostToolUse),
+          {
+            matcher: '^MyCustomTool$',
+            hooks: [{ type: 'command', command: customCmd, timeout: 1500 }],
+          },
+        ],
+      },
+    };
+    const report = computeHookBlockDrift(settings.hooks);
+    const result = applyWholesaleRegeneration(settings, report);
+    expect(result.removed).toBe(0);
+
+    const hooks = settings.hooks as Record<string, Array<{ matcher?: string; hooks: HookEntry[] }>>;
+    const block = hooks.PostToolUse?.find(b => b.matcher === '^MyCustomTool$');
+    expect(block).toBeDefined();
+    expect(block!.hooks[0].command).toBe(customCmd);
+    expect(block!.hooks[0].timeout).toBe(1500);
   });
 
   it('does not corrupt the cached reference (returns a deep clone)', () => {

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -325,14 +325,25 @@ export function computeHookBlockDrift(
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * True when the user has set `claudeFlow.hooks.locked: true` in their
- * settings.json — a sentinel that suppresses drift surfacing entirely.
+ * True when the user has set `moflo.hooks.locked: true` (canonical) or
+ * `claudeFlow.hooks.locked: true` (legacy alias) in their settings.json —
+ * a sentinel that suppresses drift surfacing entirely.
+ *
+ * The `claudeFlow.*` settings tree is a pre-rebrand legacy name that survives
+ * in writers + readers across the codebase. Renaming the whole tree is a
+ * separate effort; this one reader accepts `moflo.hooks.locked` ahead of the
+ * legacy key so the #1180 escape hatch is documented under the canonical
+ * brand from day one and consumers never have to migrate the key after we
+ * tell them to set it.
  */
 export function isHookBlockLocked(settings: unknown): boolean {
   const root = settings as Record<string, unknown> | null | undefined;
+  const moflo = root?.moflo as Record<string, unknown> | undefined;
+  const mofloHooks = moflo?.hooks as Record<string, unknown> | undefined;
+  if (mofloHooks?.locked === true) return true;
   const cf = root?.claudeFlow as Record<string, unknown> | undefined;
-  const hooks = cf?.hooks as Record<string, unknown> | undefined;
-  return hooks?.locked === true;
+  const cfHooks = cf?.hooks as Record<string, unknown> | undefined;
+  return cfHooks?.locked === true;
 }
 
 /**
@@ -414,8 +425,9 @@ function getMofloHelperBasenames(): Set<string> {
  * alternative (preserve any non-exact match) would silently retain stale
  * entries like `gate.cjs session-reset` (removed in #842), defeating the
  * whole point of wholesale regen. Consumers who need a tweaked moflo command
- * should either lock the hook block via `claudeFlow.hooks.locked: true` or
- * route through their own helper basename.
+ * should either lock the hook block via `moflo.hooks.locked: true`
+ * (`claudeFlow.hooks.locked` is still honoured as a legacy alias) or route
+ * through their own helper basename.
  *
  * Cross-platform: regex matches forward slashes only — what moflo always
  * emits (Claude Code expands `$CLAUDE_PROJECT_DIR` on every OS). A consumer
@@ -445,7 +457,7 @@ function isMofloOwnedHookEntry(command: string): boolean {
  *
  * The caller MUST check `isHookBlockLocked(settings)` first; if locked, the
  * user has opted out and this function should not be called. Non-hooks fields
- * on `settings` (permissions, env, claudeFlow.*, etc.) are preserved.
+ * on `settings` (permissions, env, moflo.*, claudeFlow.*, etc.) are preserved.
  *
  * Mutates `settings` in place; caller is responsible for writing the file.
  */

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -400,7 +400,29 @@ function getMofloHelperBasenames(): Set<string> {
   return out;
 }
 
-/** True when a hook command references a moflo-shipped helper basename. */
+/**
+ * True when a hook command references a moflo-shipped helper basename.
+ *
+ * Design: moflo "owns" the slot for any command pointing at one of its shipped
+ * helpers, so wholesale regen is free to replace that slot with the current
+ * reference. Conversely, a command pointing at a non-moflo helper basename is
+ * a consumer-owned customisation that must survive (#1180).
+ *
+ * Trade-off — hand-edits to a moflo helper command (e.g. consumer adds
+ * `--my-flag` to `gate-hook.mjs check-dangerous-command`) are treated as
+ * moflo-owned and replaced with the current reference shape on regen. The
+ * alternative (preserve any non-exact match) would silently retain stale
+ * entries like `gate.cjs session-reset` (removed in #842), defeating the
+ * whole point of wholesale regen. Consumers who need a tweaked moflo command
+ * should either lock the hook block via `claudeFlow.hooks.locked: true` or
+ * route through their own helper basename.
+ *
+ * Cross-platform: regex matches forward slashes only — what moflo always
+ * emits (Claude Code expands `$CLAUDE_PROJECT_DIR` on every OS). A consumer
+ * who hand-edited `settings.json` with backslashes on Windows would fail to
+ * match here and be treated as a customisation (preserved). That's the safer
+ * default — we'd rather keep an unfamiliar entry than delete user work.
+ */
 function isMofloOwnedHookEntry(command: string): boolean {
   const m = command.match(/\.claude\/(?:helpers|scripts)\/([\w.\-]+)/);
   return m ? getMofloHelperBasenames().has(m[1]) : false;

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -377,10 +377,49 @@ export function applyAdditiveRegeneration(
 }
 
 /**
+ * Set of helper-script basenames that moflo ships under `.claude/helpers/` and
+ * `.claude/scripts/`. Built once from `getReferenceHookBlock()` so it always
+ * tracks whatever the current reference block actually emits. Used by the
+ * wholesale-regen path to tell "stale moflo entry from a removed reference
+ * shape" (drop) apart from "consumer customisation we never owned" (preserve).
+ */
+let MOFLO_HELPER_BASENAMES_CACHE: Set<string> | null = null;
+function getMofloHelperBasenames(): Set<string> {
+  if (MOFLO_HELPER_BASENAMES_CACHE) return MOFLO_HELPER_BASENAMES_CACHE;
+  const out = new Set<string>();
+  const tree = getReferenceHookBlock();
+  for (const event of Object.keys(tree)) {
+    for (const block of tree[event]) {
+      for (const hook of block.hooks) {
+        const m = hook.command.match(/\.claude\/(?:helpers|scripts)\/([\w.\-]+)/);
+        if (m) out.add(m[1]);
+      }
+    }
+  }
+  MOFLO_HELPER_BASENAMES_CACHE = out;
+  return out;
+}
+
+/** True when a hook command references a moflo-shipped helper basename. */
+function isMofloOwnedHookEntry(command: string): boolean {
+  const m = command.match(/\.claude\/(?:helpers|scripts)\/([\w.\-]+)/);
+  return m ? getMofloHelperBasenames().has(m[1]) : false;
+}
+
+/**
  * Wholesale regeneration: replace `settings.hooks` with the canonical reference
- * block. Drops extras (stale entries from previous moflo versions, e.g. the
- * `gate.cjs session-reset` SessionStart hook removed in #842) AND adds missing
- * entries — the additive variant only does the latter.
+ * block, then graft consumer customisations back in. Drops stale moflo entries
+ * (e.g. the `gate.cjs session-reset` SessionStart hook removed in #842) AND
+ * adds missing entries — the additive variant only does the latter.
+ *
+ * #1180 — `report.extra` carries both stale moflo entries AND consumer-owned
+ * customisations (e.g. waxstak's `project-analysis-gate.cjs`). The wholesale
+ * path used to drop both; it now distinguishes them via the helper-basename
+ * discriminator: any extra command referencing a moflo-shipped helper under
+ * `.claude/helpers/` or `.claude/scripts/` is stale moflo and gets dropped;
+ * anything else is consumer-owned and gets grafted back into the fresh tree
+ * under the same `(event, matcher)`, with its original `HookEntry`
+ * (type/timeout) snapshotted before the replace.
  *
  * The caller MUST check `isHookBlockLocked(settings)` first; if locked, the
  * user has opted out and this function should not be called. Non-hooks fields
@@ -393,11 +432,57 @@ export function applyWholesaleRegeneration(
   report: HookDriftReport,
 ): RegenerationResult {
   if (!report.drifted) return { settings, added: 0, removed: 0 };
+
+  // Snapshot full `HookEntry` objects for consumer customisations BEFORE we
+  // overwrite settings.hooks — the drift report carries command strings only,
+  // not timeout/type. Walk the consumer's existing tree, match against each
+  // non-moflo `extra` on (event, matcher, command).
+  const customisations: Array<{ event: string; matcher: string; hook: HookEntry }> = [];
+  const consumerHooks = (settings.hooks ?? {}) as Record<string, HookBlock[]>;
+  for (const extra of report.extra) {
+    if (isMofloOwnedHookEntry(extra.command)) continue;
+    const evtArr = consumerHooks[extra.event];
+    if (!Array.isArray(evtArr)) continue;
+    for (const block of evtArr) {
+      if ((block?.matcher ?? '') !== extra.matcher) continue;
+      const found = Array.isArray(block.hooks)
+        ? block.hooks.find((h: HookEntry | undefined) => h?.command === extra.command)
+        : undefined;
+      if (found) {
+        customisations.push({ event: extra.event, matcher: extra.matcher, hook: found });
+        break;
+      }
+    }
+  }
+
   // Clone the cached reference so a later mutation of settings.hooks (by the
   // launcher's settings.json migrations, doctor --fix, etc.) cannot corrupt
   // the cached tree shared across `computeHookBlockDrift` calls in this process.
-  settings.hooks = structuredClone(getCachedReference().tree);
-  return { settings, added: report.missing.length, removed: report.extra.length };
+  const fresh = structuredClone(getCachedReference().tree);
+
+  // Graft customisations into the fresh tree, slotting them under the same
+  // matcher block (created if absent).
+  for (const { event, matcher, hook } of customisations) {
+    let arr = fresh[event];
+    if (!Array.isArray(arr)) {
+      arr = [];
+      fresh[event] = arr;
+    }
+    let block = arr.find(b => (b?.matcher ?? '') === matcher);
+    if (!block) {
+      block = { hooks: [] };
+      if (matcher) block.matcher = matcher;
+      arr.push(block);
+    }
+    if (!Array.isArray(block.hooks)) block.hooks = [];
+    if (!block.hooks.some((h: HookEntry) => h?.command === hook.command)) {
+      block.hooks.push(hook);
+    }
+  }
+
+  settings.hooks = fresh;
+  const removed = report.extra.length - customisations.length;
+  return { settings, added: report.missing.length, removed };
 }
 
 /**


### PR DESCRIPTION
Fixes #1180

## Summary

- `applyWholesaleRegeneration` no longer drops `report.extra` entries that aren't moflo-owned
- Stale moflo entries (e.g. `gate.cjs session-reset` from before #842) still get dropped — original #896 contract preserved
- Customisations keep their original `HookEntry` shape (timeout + type) via a pre-replace snapshot
- `RegenerationResult.removed` reflects actual drops only, not `report.extra.length`
- `isHookBlockLocked` now accepts `moflo.hooks.locked: true` as the canonical escape hatch with `claudeFlow.hooks.locked: true` honoured as a legacy alias — so the documented opt-out lands under the canonical brand from day one

## Root cause

`src/cli/services/hook-block-hash.ts:391-401` (pre-fix) did `settings.hooks = structuredClone(reference)` and treated every `extra` as removable. PR #1171 widened Bash → (Bash|PowerShell) matchers, bumped the reference hash, and triggered wholesale regen on every consumer running `auto_update.hook_block_drift: regenerate`. Consumer-owned PostToolUse hooks (waxstak's `project-analysis-gate.cjs`) were collateral damage.

## How the fix discriminates

Build a set of moflo-shipped helper basenames once from `getReferenceHookBlock()` (auto-tracks whatever the current reference emits — no manual list to maintain). For each `extra`:

- Command matches `.claude/(helpers|scripts)/<known-moflo-basename>` → stale moflo, drop
- Anything else → consumer customisation, snapshot the full `HookEntry` from `settings.hooks` before the replace, then graft it into the fresh tree under the same `(event, matcher)`

The basename heuristic intentionally trades off the hand-edited-moflo-command case (a consumer who adds `--my-flag` to `gate-hook.mjs check-dangerous-command` will see the flag stripped). The alternative (preserve any non-exact-match) would re-break #896 by silently retaining stale moflo entries forever. Trade-off and escape hatch (`moflo.hooks.locked: true`) are documented in the function's leading comment.

Cross-platform: regex matches forward slashes only. Moflo always emits forward slashes with `$CLAUDE_PROJECT_DIR` (Claude Code expands on every OS). Backslash hand-edits on Windows fall through to the "preserve as customisation" path — safer default than deleting user work.

## Escape hatch — canonical key naming

The opt-out sentinel is now read from `moflo.hooks.locked: true` first, with `claudeFlow.hooks.locked: true` honoured as a legacy alias. The wider `claudeFlow.*` → `moflo.*` settings-tree rename (65 references across 20 files) is a separate focused migration; folding the canonical key in here means we don't have to keep `claudeFlow` as a permanent alias for the one key consumers are about to be told to set.

## Test plan

- [x] `src/cli/__tests__/services/hook-block-hash.test.ts` — 26 tests pass, including 2 new #1180 customisation cases + 3 new `isHookBlockLocked` cases (canonical, fallback, precedence)
- [x] `tests/bin/launcher-896-hook-drift-regenerate.test.ts` — #896 wholesale-regen contract still holds
- [x] `src/cli/__tests__/services/hook-wiring.test.ts` — repair-wiring path unaffected
- [x] Broader sweep: 612 tests across `src/cli/__tests__/services/` + `src/cli/__tests__/init/` all pass

## Consumer impact

Surface touched: `src/cli/services/hook-block-hash.ts` — dynamically imported by `bin/session-start-launcher.mjs` in every consumer install. Round-trip cost: publish + reinstall + Claude Code restart. Consumers on the current version who had customisations silently stripped will need to re-add them in `settings.json`; after upgrade their customisations will survive future drift checks. Consumers who already set `claudeFlow.hooks.locked: true` keep working unchanged.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)