### PR TITLE
feat: passive session-continuity loop — capture + relevance-gated injection (#1185)

### DIFF
--- a/.claude/scripts/hooks.mjs
+++ b/.claude/scripts/hooks.mjs
@@ -26,24 +26,15 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { createProcessManager } from './lib/process-manager.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
+import { findProjectRoot } from './lib/moflo-paths.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Detect project root by walking up from cwd to find package.json.
 // IMPORTANT: Do NOT use resolve(__dirname, '..') or '../..' — this script lives
 // in bin/ during development but gets synced to .claude/scripts/ in consumer
-// projects, so __dirname-relative paths break. findProjectRoot() works everywhere.
-function findProjectRoot() {
-  let dir = process.cwd();
-  const root = resolve(dir, '/');
-  while (dir !== root) {
-    if (existsSync(resolve(dir, 'package.json'))) return dir;
-    dir = dirname(dir);
-  }
-  return process.cwd();
-}
-
+// projects, so __dirname-relative paths break. findProjectRoot() works
+// everywhere and resolves identically to the TS bridge (see lib/moflo-paths.mjs).
 const projectRoot = findProjectRoot();
 const logFile = resolve(projectRoot, '.moflo', 'logs', 'hooks.log');
 try { mkdirSync(dirname(logFile), { recursive: true }); } catch { /* best effort */ }

--- a/.claude/scripts/lib/daemon-port.mjs
+++ b/.claude/scripts/lib/daemon-port.mjs
@@ -1,0 +1,66 @@
+/**
+ * Pure-JS counterpart to src/cli/services/daemon-port.ts.
+ *
+ * Lives in bin/lib because session-start-launcher.mjs and other bin/ scripts
+ * run before any TS compilation has happened. The TS file is the canonical
+ * API; this file MUST stay algorithmically identical (asserted by
+ * `tests/system/daemon-port-twin.test.ts`).
+ *
+ * See `src/cli/services/daemon-port.ts` for the full doc + history.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const PORT_RANGE_BASE = 33000;
+export const PORT_RANGE_SIZE = 1000;
+export const LEGACY_DEFAULT_PORT = 3117;
+
+export function readEnvPortOverride() {
+  const raw = process.env.MOFLO_DAEMON_PORT;
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1 || n > 65535) return null;
+  return n;
+}
+
+export function resolveProjectPort(projectRoot) {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return envPort;
+  const hash = createHash('sha256').update(projectRoot).digest();
+  return PORT_RANGE_BASE + (hash.readUInt16BE(0) % PORT_RANGE_SIZE);
+}
+
+export function resolveClientPort(projectRoot) {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return envPort;
+
+  try {
+    const lockFile = join(projectRoot, '.moflo', 'daemon.lock');
+    if (existsSync(lockFile)) {
+      const lock = JSON.parse(readFileSync(lockFile, 'utf-8'));
+      const lockPort = typeof lock?.port === 'number' ? lock.port : null;
+      if (lockPort && Number.isFinite(lockPort) && lockPort > 0 && lockPort < 65536) {
+        return lockPort;
+      }
+    }
+  } catch {
+    // fall through
+  }
+
+  return resolveProjectPort(projectRoot);
+}
+
+export function serverPortCandidates(projectRoot, maxAttempts = 10) {
+  const envPort = readEnvPortOverride();
+  if (envPort != null) return [envPort];
+
+  const base = resolveProjectPort(projectRoot);
+  const attempts = Math.min(Math.max(1, maxAttempts), PORT_RANGE_SIZE);
+  const ports = [];
+  for (let i = 0; i < attempts; i++) {
+    const candidate = PORT_RANGE_BASE + ((base - PORT_RANGE_BASE + i) % PORT_RANGE_SIZE);
+    ports.push(candidate);
+  }
+  return ports;
+}

--- a/.claude/scripts/lib/file-sync.mjs
+++ b/.claude/scripts/lib/file-sync.mjs
@@ -1,0 +1,200 @@
+/**
+ * Shared file-sync helper for the launcher (#854 §3) and the postinstall
+ * bootstrap (#857 / #975).
+ *
+ * Both layers used to inline the same retry/breaker + copy logic. They drifted
+ * once already (the bootstrap added hash-skip + atomic tmp+rename for #975
+ * while the launcher kept the bare copyFileSync), so this module is the single
+ * source of truth.
+ *
+ * Responsibilities:
+ *   - hash-skip when src and dest are byte-identical (eliminates the dominant
+ *     failure class — overwriting an unchanged file open by Claude/indexer).
+ *   - atomic tmp + rename so concurrent readers never see a torn write.
+ *   - post-write size verify to catch torn writes from AV mid-stream and
+ *     partial DrvFs writes that returned success codes.
+ *   - retry the transient error class (EBUSY/EPERM/EACCES + EVERIFY) with
+ *     exponential backoff [50,200,800]ms.
+ *   - circuit-break after CIRCUIT_BREAK_THRESHOLD distinct exhausted-retry
+ *     failures so a sick host (AV mid-scan over node_modules) doesn't compound
+ *     wall-clock cost.
+ *
+ * Ships at `bin/lib/file-sync.mjs`. Bootstrap imports via relative path from
+ * `scripts/`; launcher imports via `./lib/file-sync.mjs` after sync to
+ * `<consumer>/.claude/scripts/lib/`.
+ */
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { dirname } from 'node:path';
+
+export const TRANSIENT_CODES = new Set(['EBUSY', 'EPERM', 'EACCES']);
+export const RETRY_BACKOFF_MS = [50, 200, 800];
+export const CIRCUIT_BREAK_THRESHOLD = 5;
+
+// Code attached to the post-write size-verify failure. Treated as transient by
+// syncWithRetry so torn writes from AV mid-stream / partial DrvFs writes get a
+// retry instead of immediately surfacing as a hard failure.
+export const VERIFY_FAIL_CODE = 'EVERIFY';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export function fileHash(path) {
+  try {
+    return createHash('sha1').update(readFileSync(path)).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+export function contentEqual(srcPath, destPath) {
+  if (!existsSync(destPath)) return false;
+  // Size check first — skips the SHA-1 pass on every mis-sized pair without
+  // any I/O on the file body. For the bootstrap's small file set the SHA-1
+  // is cheap, but this fires on every file on every session-start with
+  // version drift, and under load (AV lock + retries) the reads compound.
+  let srcSize, destSize;
+  try {
+    srcSize = statSync(srcPath).size;
+    destSize = statSync(destPath).size;
+  } catch {
+    return false;
+  }
+  if (srcSize !== destSize) return false;
+  const srcHash = fileHash(srcPath);
+  if (!srcHash) return false;
+  const destHash = fileHash(destPath);
+  return destHash !== null && srcHash === destHash;
+}
+
+/**
+ * Atomic copy via tmp + rename with post-write size verify.
+ *
+ * Steps:
+ *   1. copyFileSync(src, dest.tmp)
+ *   2. Verify dest.tmp size matches src size (catches torn writes from AV
+ *      mid-stream and partial DrvFs writes that returned success codes).
+ *      Mismatch unlinks the tmp and throws { code: 'EVERIFY' }, which the
+ *      retry loop treats as transient.
+ *   3. renameSync(dest.tmp, dest) — atomic on Win/macOS/Linux/WSL/DrvFs.
+ *
+ * If rename fails, the .tmp sidecar persists as a recovery breadcrumb — next
+ * session-start can complete the swap once the original lock has cleared.
+ *
+ * `deps` is dependency injection for tests (#976 fault injection of the
+ * truncated-tmp / partial-DrvFs scenario). Production callers omit it.
+ */
+export function atomicCopy(src, dest, deps = {}) {
+  const _copyFile = deps.copyFile || copyFileSync;
+  const _stat = deps.stat || statSync;
+  const _rename = deps.rename || renameSync;
+  const _unlink = deps.unlink || unlinkSync;
+
+  const tmp = `${dest}.tmp`;
+  _copyFile(src, tmp);
+  let srcSize, tmpSize;
+  try {
+    srcSize = _stat(src).size;
+    tmpSize = _stat(tmp).size;
+  } catch (statErr) {
+    try { _unlink(tmp); } catch { /* best-effort cleanup */ }
+    const err = new Error(`atomicCopy verify stat failed: ${statErr.message || statErr}`);
+    err.code = statErr.code || VERIFY_FAIL_CODE;
+    throw err;
+  }
+  if (srcSize !== tmpSize) {
+    try { _unlink(tmp); } catch { /* best-effort cleanup */ }
+    const err = new Error(
+      `atomicCopy size mismatch (src=${srcSize} tmp=${tmpSize}) for ${dest}`,
+    );
+    err.code = VERIFY_FAIL_CODE;
+    throw err;
+  }
+  _rename(tmp, dest);
+}
+
+export function errMessage(err) {
+  if (!err) return 'unknown error';
+  return err.code ? `${err.code} ${err.message || ''}`.trim() : (err.message || String(err));
+}
+
+/**
+ * Build a retry-aware syncer.
+ *
+ * @param {object} [options]
+ * @param {(key: string, dest: string) => void} [options.onSuccess]
+ *   Fires after every successful syncFile (including hash-skip identical
+ *   paths). Use it to record manifest entries from the launcher; bootstrap
+ *   ignores it.
+ *
+ * @returns {{
+ *   syncFile: (src: string, dest: string, key: string) => Promise<{ok?: boolean, skipped?: true | 'identical'}>,
+ *   failures: Array<{key: string, message: string, src?: string, dest?: string}>,
+ *   isCircuitOpen: () => boolean,
+ * }}
+ */
+export function makeSyncer({ onSuccess } = {}) {
+  let circuitOpen = false;
+  const failures = [];
+
+  async function syncWithRetry(operation) {
+    const maxAttempts = circuitOpen ? 1 : RETRY_BACKOFF_MS.length + 1;
+    let lastErr = null;
+    let lastCode = null;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (attempt > 0) await sleep(RETRY_BACKOFF_MS[attempt - 1]);
+      try {
+        operation();
+        return { ok: true };
+      } catch (err) {
+        lastErr = err;
+        lastCode = err && err.code ? err.code : null;
+        const transient = TRANSIENT_CODES.has(lastCode) || lastCode === VERIFY_FAIL_CODE;
+        if (!transient) break;
+      }
+    }
+    if (!circuitOpen && failures.length + 1 >= CIRCUIT_BREAK_THRESHOLD) {
+      circuitOpen = true;
+    }
+    return { ok: false, err: lastErr, code: lastCode };
+  }
+
+  async function syncFile(src, dest, key) {
+    if (!existsSync(src)) return { skipped: true };
+    try {
+      mkdirSync(dirname(dest), { recursive: true });
+    } catch (err) {
+      failures.push({ key, message: errMessage(err), src, dest });
+      return { ok: false };
+    }
+    if (contentEqual(src, dest)) {
+      try { onSuccess?.(key, dest); } catch { /* non-fatal */ }
+      return { ok: true, skipped: 'identical' };
+    }
+    const result = await syncWithRetry(() => atomicCopy(src, dest));
+    if (result.ok) {
+      try { onSuccess?.(key, dest); } catch { /* non-fatal */ }
+      return { ok: true };
+    }
+    const transient = TRANSIENT_CODES.has(result.code) || result.code === VERIFY_FAIL_CODE;
+    const tail = transient
+      ? ` (retried ${RETRY_BACKOFF_MS.length}× after ${result.code}${circuitOpen ? '; circuit open' : ''})`
+      : '';
+    failures.push({ key, message: `${errMessage(result.err)}${tail}`, src, dest });
+    return { ok: false };
+  }
+
+  return {
+    syncFile,
+    failures,
+    isCircuitOpen: () => circuitOpen,
+  };
+}

--- a/.claude/scripts/lib/incremental-write.mjs
+++ b/.claude/scripts/lib/incremental-write.mjs
@@ -66,16 +66,30 @@ export function computeContentListHash(files) {
 }
 
 /**
- * Load `key → content` for every active row in the namespace.
+ * Load `key → content` for every active row in the namespace, optionally
+ * scoped to keys starting with `keyPrefix` (one doc's chunks at a time —
+ * lets per-file indexers like `index-guidance.mjs` content-diff without
+ * loading every chunk across every file).
+ *
  * @param {object} db - sql.js Database
  * @param {string} namespace
+ * @param {string} [keyPrefix] — when set, restricts the scan to `key LIKE '<prefix>%'`.
+ *   The same prefix scopes the orphan sweep in {@link applyIncrementalChunks}.
  * @returns {Map<string,string>}
  */
-export function loadExistingContent(db, namespace) {
-  const stmt = db.prepare(
-    `SELECT key, content FROM memory_entries WHERE namespace = ? AND status = 'active'`,
-  );
-  stmt.bind([namespace]);
+export function loadExistingContent(db, namespace, keyPrefix) {
+  const stmt = keyPrefix
+    ? db.prepare(
+        `SELECT key, content FROM memory_entries WHERE namespace = ? AND key LIKE ? AND status = 'active'`,
+      )
+    : db.prepare(
+        `SELECT key, content FROM memory_entries WHERE namespace = ? AND status = 'active'`,
+      );
+  if (keyPrefix) {
+    stmt.bind([namespace, `${keyPrefix}%`]);
+  } else {
+    stmt.bind([namespace]);
+  }
   const map = new Map();
   while (stmt.step()) {
     const row = stmt.getAsObject();
@@ -95,11 +109,17 @@ export function loadExistingContent(db, namespace) {
  * @param {object} [opts]
  * @param {boolean} [opts.serialize=true] - JSON.stringify metadata/tags before
  *   writing. Set false when callers already pass strings.
+ * @param {string} [opts.keyPrefix] — when set, the existing-content load AND
+ *   the orphan sweep are restricted to keys matching `<prefix>%`. Use this
+ *   when processing a single file's chunks at a time (e.g. index-guidance.mjs
+ *   iterates files independently) — without it the sweep would delete every
+ *   chunk from every OTHER file as an orphan on each call.
  * @returns {{inserted:number, updated:number, unchanged:number, removed:number}}
  */
 export function applyIncrementalChunks(db, namespace, chunks, opts = {}) {
   const serialize = opts.serialize !== false;
-  const existing = loadExistingContent(db, namespace);
+  const keyPrefix = opts.keyPrefix;
+  const existing = loadExistingContent(db, namespace, keyPrefix);
   const newKeys = new Set();
   let inserted = 0;
   let updated = 0;

--- a/.claude/scripts/lib/moflo-paths.mjs
+++ b/.claude/scripts/lib/moflo-paths.mjs
@@ -1,16 +1,19 @@
 /**
- * Pure-JS counterpart to src/cli/services/moflo-paths.ts.
+ * Pure-JS counterpart to src/cli/services/moflo-paths.ts and the
+ * findProjectRoot helper in src/cli/services/project-root.ts.
  *
  * Lives in bin/lib because session-start-launcher.mjs and other bin/ scripts
  * run before any TS compilation has happened — they can't import the .ts
- * source. The TS version is the canonical programmatic API; this version
- * exposes the same path constants + helpers.
+ * source. The TS versions are the canonical programmatic API; this file
+ * exposes the same path constants + helpers and MUST stay algorithmically
+ * identical (see tests/system/project-root-twin.test.ts).
  *
  * Per #851, the legacy `.claude-flow/` rename + `.swarm/memory.db` byte-copy
  * helpers no longer ship: the version-bump-gated cherry-pick lives entirely
  * in the launcher and the TS service `cli/services/cherry-pick-learnings.ts`.
  */
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { basename, dirname, join, parse, resolve } from 'node:path';
 
 export const MOFLO_DIR = '.moflo';
 export const MEMORY_DB_FILE = 'moflo.db';
@@ -49,6 +52,25 @@ export function legacyMemoryDbBakPath(projectRoot) {
   return join(projectRoot, LEGACY_SWARM_DIR, `${LEGACY_MEMORY_DB_FILE}${LEGACY_MEMORY_DB_BAK_SUFFIX}`);
 }
 
+/**
+ * Common skip-list for any walk that enumerates a project's children looking
+ * for moflo state. Shared by `bin/session-start-launcher.mjs` (depth-1 walk)
+ * and `src/cli/commands/doctor-checks-config.ts` (depth-5 BFS) so the two
+ * can't silently diverge. Matched case-insensitively at the call site —
+ * Windows NTFS + macOS APFS are case-insensitive by default.
+ *
+ * Categories: VCS metadata, build/cache outputs, language-specific output
+ * dirs, IDE state, virtualenv dirs. NOT included: `.moflo*` — every walk
+ * filters that separately so archived residue from `flo doctor --fix` can be
+ * recognised by prefix.
+ */
+export const COMMON_WALK_SKIP_NAMES = Object.freeze(new Set([
+  'node_modules', '.git', '.svn', '.hg',
+  'dist', 'build', 'out', 'target', '.next', '.nuxt', '.cache',
+  'coverage', '.idea', '.vscode', '.turbo', '.svelte-kit',
+  'vendor', '__pycache__', '.venv', 'venv', '.tox',
+]));
+
 export function memoryDbCandidatePaths(projectRoot) {
   return [
     memoryDbPath(projectRoot),
@@ -56,4 +78,112 @@ export function memoryDbCandidatePaths(projectRoot) {
     join(projectRoot, 'data', LEGACY_MEMORY_DB_FILE),
     join(projectRoot, '.claude', LEGACY_MEMORY_DB_FILE),
   ];
+}
+
+/**
+ * Walk strictly upward from `dir` (exclusive) and return the nearest ancestor
+ * that has `.moflo/moflo.db`, or `null` if none exists below the filesystem
+ * root.
+ *
+ * Used by the launcher and `flo init` to detect nested-.moflo/ situations
+ * (#1174). Post-resolver-fix `findProjectRoot` already returns the topmost
+ * memory marker, so encountering an ancestor here means either:
+ *   1. `CLAUDE_PROJECT_DIR` explicitly overrode to a sub-directory (legitimate
+ *      user action — log a warning but don't refuse), or
+ *   2. The launcher is running before any `.moflo/moflo.db` exists at the
+ *      current root (e.g. fresh init in a sub-workspace).
+ *
+ * In either case the caller wants to surface a clear diagnostic so the user
+ * can run `flo doctor --fix` to consolidate.
+ *
+ * @param {string} dir absolute path to walk up from
+ * @returns {string | null} ancestor directory containing `.moflo/moflo.db`
+ */
+export function findAncestorMofloRoot(dir) {
+  const start = resolve(dir);
+  const fsRoot = parse(start).root;
+  let cursor = dirname(start);
+  while (cursor !== fsRoot) {
+    if (existsSync(join(cursor, '.moflo', 'moflo.db'))) {
+      return cursor;
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  return null;
+}
+
+/**
+ * Resolve the project root the same way the TS bridge does. Every bin/
+ * script that touches `.moflo/moflo.db` (or any sibling state under
+ * `.moflo/`) MUST go through this so its writes land on the SAME file the
+ * bridge reads from.
+ *
+ * Algorithmic twin of `src/cli/services/project-root.ts:findProjectRoot()`
+ * and `src/cli/memory/bridge-core.ts:getProjectRoot()`. See those files for
+ * the canonical algorithm comment.
+ *
+ * @param {{ cwd?: string; honorEnv?: boolean }} [opts]
+ * @returns {string} absolute project root
+ */
+export function findProjectRoot(opts) {
+  const honorEnv = opts?.honorEnv !== false;
+  if (honorEnv && process.env.CLAUDE_PROJECT_DIR) {
+    return process.env.CLAUDE_PROJECT_DIR;
+  }
+  const startDir = opts?.cwd ?? process.cwd();
+  const start = resolve(startDir);
+  const fsRoot = parse(start).root;
+
+  // Pass A — memory markers, topmost wins (#1174). Walks the FULL ancestor
+  // chain, returns the highest ancestor with .moflo/moflo.db or .swarm/memory.db.
+  // Guarantees the root daemon is canonical in a monorepo with nested residue.
+  let topmostMemoryMarker = null;
+  let dir = start;
+  while (dir !== fsRoot) {
+    if (basename(dir) === 'node_modules') {
+      dir = dirname(dir);
+      continue;
+    }
+    if (existsSync(join(dir, '.moflo', 'moflo.db')) || existsSync(join(dir, '.swarm', 'memory.db'))) {
+      topmostMemoryMarker = dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  if (topmostMemoryMarker) return topmostMemoryMarker;
+
+  // Pass B — CLAUDE.md/package.json pair, nearest wins.
+  dir = start;
+  while (dir !== fsRoot) {
+    if (basename(dir) === 'node_modules') {
+      dir = dirname(dir);
+      continue;
+    }
+    if (existsSync(join(dir, 'CLAUDE.md')) && existsSync(join(dir, 'package.json'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  // Pass C — bare package.json or .git, nearest wins.
+  dir = start;
+  while (dir !== fsRoot) {
+    if (basename(dir) === 'node_modules') {
+      dir = dirname(dir);
+      continue;
+    }
+    if (existsSync(join(dir, 'package.json')) || existsSync(join(dir, '.git'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return startDir;
 }

--- a/.claude/scripts/lib/pii-scrub.mjs
+++ b/.claude/scripts/lib/pii-scrub.mjs
@@ -1,0 +1,119 @@
+/**
+ * Credential / secret scrubber for the session-continuity persist path (#1185).
+ *
+ * THREAT MODEL — this is deliberately NOT the transfer/anonymization pipeline
+ * (`src/cli/transfer/anonymization/index.ts`). That module makes a CFP safe to
+ * publish *externally* (aggressive, lossy, deterministic pseudonymisation of
+ * emails / home paths / IPs). This module has a narrower job: a session digest
+ * is written to the user's OWN local `.moflo/moflo.db`, so the only thing we
+ * must never persist is a literal *secret* that happened to appear in the
+ * session (an API key, a JWT, a private-key block). We intentionally KEEP
+ * benign context like file paths and branch names — they're the whole point of
+ * a "where you left off" digest and are not sensitive on the user's own disk.
+ *
+ * Two different purposes → two focused scrubbers, not one over-coupled one.
+ *
+ * Pure + synchronous + dependency-free so a bin/*.mjs hook can call it on the
+ * hot path without loading a model. Cross-platform (Rule #1): plain regex, no
+ * shell, no path assumptions.
+ */
+
+/**
+ * Ordered list of { name, pattern, replace } secret shapes. Order matters:
+ * multi-line PEM blocks and specific vendor token formats are neutralised
+ * before the generic `key=value` assignment sweep so the specific redaction
+ * label wins.
+ *
+ * Each `pattern` carries the global flag so `String.replace` hits every match.
+ */
+export const SECRET_PATTERNS = [
+  // PEM private-key blocks (RSA / EC / OPENSSH / generic) — match the whole block.
+  {
+    name: 'private-key',
+    pattern: /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z]+ )?PRIVATE KEY-----/g,
+    replace: '[REDACTED_PRIVATE_KEY]',
+  },
+  // JSON Web Tokens — header.payload.signature, both segments start with `eyJ`.
+  {
+    name: 'jwt',
+    pattern: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+    replace: '[REDACTED_JWT]',
+  },
+  // OpenAI / Anthropic-style keys: sk-..., sk-ant-..., pk-...
+  {
+    name: 'openai-anthropic-key',
+    pattern: /\b(?:sk|pk)-(?:ant-)?[A-Za-z0-9_-]{20,}\b/g,
+    replace: '[REDACTED_API_KEY]',
+  },
+  // AWS access key id.
+  { name: 'aws-access-key', pattern: /\bAKIA[0-9A-Z]{16}\b/g, replace: '[REDACTED_AWS_KEY]' },
+  // GitHub tokens (classic ghp_/gho_/ghu_/ghs_/ghr_ + fine-grained github_pat_).
+  {
+    name: 'github-token',
+    pattern: /\b(?:gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,})\b/g,
+    replace: '[REDACTED_GITHUB_TOKEN]',
+  },
+  // Slack tokens.
+  { name: 'slack-token', pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, replace: '[REDACTED_SLACK_TOKEN]' },
+  // Google API keys.
+  { name: 'google-api-key', pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g, replace: '[REDACTED_GOOGLE_KEY]' },
+  // Bearer tokens in Authorization headers / curl snippets.
+  {
+    name: 'bearer-token',
+    pattern: /\b[Bb]earer\s+[A-Za-z0-9._-]{16,}/g,
+    replace: 'Bearer [REDACTED_TOKEN]',
+  },
+  // Credentials embedded in a URL: scheme://user:secret@host → drop the secret.
+  // The negative lookahead keeps the scrub idempotent — it won't re-match the
+  // `[REDACTED]` placeholder it just wrote (so containsSecret(scrubbed) is false).
+  {
+    name: 'url-credentials',
+    pattern: /\b([a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^/\s:@]+):(?!\[REDACTED\]@)[^/\s@]+@/g,
+    replace: '$1:[REDACTED]@',
+  },
+  // Generic `secret=value` / `password: value` / `token = value` / `api_key=...`
+  // assignments. Quote-aware so it stops at the closing quote or whitespace.
+  // Runs LAST so the specific vendor formats above keep their precise labels.
+  // The negative lookahead skips the `[REDACTED]` placeholder so a re-scan of
+  // already-scrubbed text reports clean (idempotent detection).
+  {
+    name: 'assigned-secret',
+    pattern: /\b(api[_-]?key|secret|password|passwd|token|access[_-]?token|auth[_-]?token)(["']?\s*[:=]\s*["']?)(?!\[REDACTED)([^\s"']{6,})/gi,
+    replace: (_m, key, sep) => `${key}${sep}[REDACTED]`,
+  },
+];
+
+/**
+ * Replace every recognised secret in `text` with a redaction label. Returns the
+ * scrubbed string. Non-string input is coerced to '' (capture must never throw).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function scrubSecrets(text) {
+  if (typeof text !== 'string' || text.length === 0) return '';
+  let out = text;
+  for (const { pattern, replace } of SECRET_PATTERNS) {
+    // Fresh lastIndex each pass — these regexes are module-shared and carry /g,
+    // so a prior `.test()`/`.exec()` elsewhere must not leak state (the exact
+    // RegExp-lastIndex bug class from feedback_publish_catches_straggler_bugs).
+    pattern.lastIndex = 0;
+    out = out.replace(pattern, replace);
+  }
+  return out;
+}
+
+/**
+ * True if `text` contains at least one recognised secret. Used by tests and by
+ * the capture path's defensive "did we miss anything" assertion.
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function containsSecret(text) {
+  if (typeof text !== 'string' || text.length === 0) return false;
+  return SECRET_PATTERNS.some(({ pattern }) => {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  });
+}

--- a/.claude/scripts/lib/retired-files.mjs
+++ b/.claude/scripts/lib/retired-files.mjs
@@ -1,0 +1,146 @@
+/**
+ * Retired-shipped-files prune helper (#948).
+ *
+ * Closes the gap that retired agents (#932) and retired skills (#945) leave
+ * in consumer projects: the manifest cleanup at section 3 of the launcher
+ * only knows about files moflo previously synced, but `.claude/agents/` and
+ * `.claude/skills/` were not in the manifest before #948. So files retired
+ * before #948 lands stay on disk forever — Claude Code keeps loading them as
+ * subagents on every prompt, paying the per-prompt roster tokens we just
+ * spent #932 fixing.
+ *
+ * This module reads `retired-files.json` (shipped at the moflo package
+ * root) and, for each entry, only prunes the consumer-side path when the
+ * file's sha256 matches one of `knownContentHashes` — i.e. the file matches
+ * a version moflo actually shipped, so the consumer didn't customize it.
+ * Customized files are preserved and a one-line notice is emitted so the
+ * user can act.
+ *
+ * Manifest format:
+ *
+ *   {
+ *     "version": 1,
+ *     "retired": [
+ *       {
+ *         "path": ".claude/agents/v3/performance-engineer.md",
+ *         "retiredIn": "4.9.22",
+ *         "retiredBy": "#932",
+ *         "knownContentHashes": ["sha256:abc...", "sha256:def..."]
+ *       }
+ *     ]
+ *   }
+ *
+ * @module bin/lib/retired-files
+ */
+
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { resolve } from 'path';
+import { createHash } from 'crypto';
+
+/**
+ * Compute sha256 of file content. Returns null on read errors so the caller
+ * can decide what to do — we never want a transient stat/read failure to
+ * trigger a prune of a file we couldn't actually verify.
+ *
+ * @param {string} absPath
+ * @returns {string|null} `sha256:<hex>` or null
+ */
+export function fileSha256(absPath) {
+  try {
+    const buf = readFileSync(absPath);
+    return 'sha256:' + createHash('sha256').update(buf).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load + validate the retired-files manifest. Returns `{ entries: [] }` for
+ * any failure mode (missing file, invalid JSON, wrong shape) — the launcher
+ * must never block on a corrupt manifest.
+ *
+ * @param {string} manifestPath - absolute path to retired-files.json
+ * @returns {{ entries: Array<{path:string, retiredIn?:string, retiredBy?:string, knownContentHashes:string[]}> }}
+ */
+export function loadRetiredManifest(manifestPath) {
+  if (!existsSync(manifestPath)) return { entries: [] };
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  } catch { return { entries: [] }; }
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.retired)) {
+    return { entries: [] };
+  }
+  // Filter out malformed entries — guards against a hand-edited file
+  // dropping the wrong shape into a launcher that runs on N consumer
+  // machines. A skipped entry never auto-prunes (safest default).
+  const entries = parsed.retired.filter((entry) =>
+    entry &&
+    typeof entry.path === 'string' &&
+    entry.path.length > 0 &&
+    Array.isArray(entry.knownContentHashes) &&
+    entry.knownContentHashes.length > 0 &&
+    entry.knownContentHashes.every((h) => typeof h === 'string' && h.startsWith('sha256:'))
+  );
+  return { entries };
+}
+
+/**
+ * Decide what to do with a consumer-side path against a retirement entry:
+ *
+ *   - 'absent'     — path doesn't exist on disk; nothing to do
+ *   - 'prune'      — file exists and content hash matches a known-shipped
+ *                    value; safe to delete (consumer didn't customize)
+ *   - 'preserve'   — file exists but content differs from every known-shipped
+ *                    hash; consumer customized, leave alone
+ *   - 'unknown'    — file exists but its hash couldn't be read (transient
+ *                    error); leave alone, retry next session
+ *
+ * @param {string} projectRoot
+ * @param {{path:string, knownContentHashes:string[]}} entry
+ * @returns {{ action: 'absent'|'prune'|'preserve'|'unknown', actualHash: string|null }}
+ */
+export function classifyRetiredFile(projectRoot, entry) {
+  const abs = resolve(projectRoot, entry.path);
+  if (!existsSync(abs)) return { action: 'absent', actualHash: null };
+  const actualHash = fileSha256(abs);
+  if (!actualHash) return { action: 'unknown', actualHash: null };
+  if (entry.knownContentHashes.includes(actualHash)) {
+    return { action: 'prune', actualHash };
+  }
+  return { action: 'preserve', actualHash };
+}
+
+/**
+ * Walk the manifest and apply prune decisions. Returns a small report so
+ * the caller can emit one summary line (the launcher pattern) instead of
+ * forcing it to track per-entry state.
+ *
+ * Failures are non-fatal — a single un-deletable file (Windows AV hold,
+ * EBUSY) must not stop pruning the rest. The caller surfaces the report.
+ *
+ * @param {string} projectRoot
+ * @param {string} manifestPath
+ * @returns {{ pruned: string[], preserved: string[], unknown: string[], failed: Array<{path:string, message:string}> }}
+ */
+export function applyRetiredPrune(projectRoot, manifestPath) {
+  const { entries } = loadRetiredManifest(manifestPath);
+  const report = { pruned: [], preserved: [], unknown: [], failed: [] };
+  for (const entry of entries) {
+    const { action } = classifyRetiredFile(projectRoot, entry);
+    if (action === 'absent') continue;
+    if (action === 'preserve') { report.preserved.push(entry.path); continue; }
+    if (action === 'unknown') { report.unknown.push(entry.path); continue; }
+    // action === 'prune'
+    try {
+      unlinkSync(resolve(projectRoot, entry.path));
+      report.pruned.push(entry.path);
+    } catch (err) {
+      report.failed.push({
+        path: entry.path,
+        message: err && err.message ? err.message : String(err),
+      });
+    }
+  }
+  return report;
+}

--- a/.claude/scripts/lib/session-continuity.mjs
+++ b/.claude/scripts/lib/session-continuity.mjs
@@ -1,0 +1,372 @@
+/**
+ * Passive session-continuity — pure logic + store helpers shared by the capture
+ * orchestrator (`bin/session-continuity.mjs`, wired to the Stop hook) and the
+ * injection path (`bin/session-start-launcher.mjs`). See issue #1185.
+ *
+ * DESIGN (owner-signed-off):
+ *   - CAPTURE is default-on, silent, mechanical-first (no model call): assemble a
+ *     digest from data we already have — git state, recent `learnings`, the
+ *     session goal — scrub secrets, persist one record per session.
+ *   - INJECTION is default-on but RELEVANCE-GATED: at session-start we score
+ *     recent digests and inject only the single best one IF it clears a
+ *     threshold (same branch / file overlap / recency / unfinished work). A
+ *     fresh, unrelated session injects nothing — that's what keeps the feature
+ *     from going context-negative.
+ *   - The injected block stores only NON-RECONSTRUCTABLE context (goal,
+ *     decisions, where-you-stopped) and is framed as a verifiable lead, never
+ *     ground truth — git/tests are the source of truth the next session checks.
+ *
+ * STORAGE: a dedicated `.moflo/continuity/` JSON store, NOT `.moflo/moflo.db`.
+ * Capture fires on the Stop hook while the daemon is live; the moflo.db writer
+ * audit (docs/internal/1054-writer-audit.md) requires cross-process DB writers
+ * to route through the daemon chokepoint. A separate JSON store sidesteps that
+ * entirely — these digests are operational state, not semantic memory, carry no
+ * embeddings, and never belong in the HNSW index. One file per session avoids
+ * concurrent-write conflicts between simultaneous sessions.
+ *
+ * Cross-platform (Rule #1): `spawnSync` with arg arrays (no shell, no
+ * `2>/dev/null`), forward-slash path compares (git porcelain emits `/` on every
+ * OS), Node fs/path primitives only.
+ */
+
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync, unlinkSync } from 'fs';
+import { resolve, join } from 'path';
+import { randomBytes } from 'crypto';
+
+// ── Relevance-scoring tunables (exported for tests) ─────────────────────────
+export const MAINLINE_BRANCHES = ['main', 'master', 'develop', 'trunk'];
+export const SCORE = Object.freeze({
+  BRANCH_MATCH: 0.5,           // feature branch identity is a strong continuation signal
+  MAINLINE_BRANCH_MATCH: 0.25, // main/master is weak — everyone's always "on main"
+  FILE_OVERLAP_PER_FILE: 0.1,
+  FILE_OVERLAP_MAX: 0.3,
+  RECENCY_MAX: 0.2,
+  RECENCY_HALFLIFE_HOURS: 24,
+  UNFINISHED_BONUS: 0.15,
+  INJECT_THRESHOLD: 0.5,
+});
+export const DEFAULT_MAX_AGE_HOURS = 72;
+/** Hard cap on the injected block (~250 tokens). Bounds context cost even when
+ *  a digest does fire. */
+export const INJECT_MAX_CHARS = 1000;
+/** Rotation: keep the most recent N sessions' digests. */
+export const KEEP_DIGESTS = 30;
+
+// ── Store helpers (.moflo/continuity/) ──────────────────────────────────────
+
+export function continuityDir(projectRoot) {
+  return resolve(projectRoot, '.moflo', 'continuity');
+}
+
+/** Stable, filesystem-safe filename for a session's digest record. */
+export function digestFileName(key) {
+  const safe = String(key).replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 120);
+  return `${safe || 'session'}.json`;
+}
+
+/**
+ * Persist a digest record atomically (temp + rename) so a crash mid-write can
+ * never leave a half-written file the injection path would choke on.
+ *
+ * @param {string} projectRoot
+ * @param {string} key - stable per-session key
+ * @param {{content: string, metadata: object}} record
+ */
+export function writeDigest(projectRoot, key, record) {
+  const dir = continuityDir(projectRoot);
+  mkdirSync(dir, { recursive: true });
+  const dest = join(dir, digestFileName(key));
+  const tmp = `${dest}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+  writeFileSync(tmp, JSON.stringify(record), 'utf-8');
+  renameSync(tmp, dest);
+}
+
+/**
+ * Read recent digest records, newest first, capped to `limit`. Tolerates a
+ * partially-written / malformed file (skips it) — never throws.
+ *
+ * @param {string} projectRoot
+ * @param {{limit?: number}} [opts]
+ * @returns {Array<{content: string, metadata: object}>}
+ */
+export function readDigests(projectRoot, opts = {}) {
+  const limit = opts.limit ?? KEEP_DIGESTS;
+  const dir = continuityDir(projectRoot);
+  let files;
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return []; // no store yet
+  }
+  const withTime = files.map((f) => ({ f, mtime: fileMtime(join(dir, f)) }));
+  withTime.sort((a, b) => b.mtime - a.mtime);
+  const out = [];
+  for (const { f } of withTime.slice(0, limit)) {
+    try {
+      const rec = JSON.parse(readFileSync(join(dir, f), 'utf-8'));
+      if (rec && typeof rec.content === 'string') out.push(rec);
+    } catch { /* skip malformed / mid-write */ }
+  }
+  return out;
+}
+
+/** Delete the oldest digest files beyond `keep` (housekeeping; never fatal). */
+export function rotateDigests(projectRoot, keep = KEEP_DIGESTS) {
+  const dir = continuityDir(projectRoot);
+  let names;
+  try {
+    names = readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return;
+  }
+  if (names.length <= keep) return; // common case — no per-file stat sweep needed
+  const entries = names.map((f) => ({ f, mtime: fileMtime(join(dir, f)) }));
+  entries.sort((a, b) => b.mtime - a.mtime);
+  for (const { f } of entries.slice(keep)) {
+    try { unlinkSync(join(dir, f)); } catch { /* already gone */ }
+  }
+}
+
+// ── moflo.yaml config (regex read, matching the launcher's no-js-yaml style) ─
+
+/**
+ * Read the `session_continuity` block from moflo.yaml without a YAML parser
+ * (the launcher and bin scripts avoid the js-yaml dependency for speed). Both
+ * flags default ON; injection is still relevance-gated at runtime.
+ *
+ * @param {string} projectRoot
+ * @returns {{capture: boolean, inject: boolean, maxAgeHours: number}}
+ */
+export function readContinuityConfig(projectRoot) {
+  const cfg = { capture: true, inject: true, maxAgeHours: DEFAULT_MAX_AGE_HOURS };
+  try {
+    const yamlPath = resolve(projectRoot, 'moflo.yaml');
+    if (!existsSync(yamlPath)) return cfg;
+    const text = readFileSync(yamlPath, 'utf-8');
+    const capture = text.match(/session_continuity:\s*\n(?:\s+\w+:.*\n)*?\s+capture:\s*(true|false)/);
+    const inject = text.match(/session_continuity:\s*\n(?:\s+\w+:.*\n)*?\s+inject:\s*(true|false)/);
+    const maxAge = text.match(/session_continuity:\s*\n(?:\s+\w+:.*\n)*?\s+max_age_hours:\s*(\d+)/);
+    if (capture) cfg.capture = capture[1] === 'true';
+    if (inject) cfg.inject = inject[1] === 'true';
+    if (maxAge) cfg.maxAgeHours = Math.max(1, parseInt(maxAge[1], 10));
+  } catch {
+    // Defaults (on) keep the feature alive if the file is mid-write / malformed.
+  }
+  return cfg;
+}
+
+// ── Git state (cross-platform, no shell) ────────────────────────────────────
+
+function git(projectRoot, args) {
+  try {
+    const r = spawnSync('git', args, {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      timeout: 2000,
+      windowsHide: true,
+    });
+    if (r.status !== 0 || typeof r.stdout !== 'string') return null;
+    return r.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Current branch, changed-file paths, last-commit subject and uncommitted count.
+ * Returns null-ish fields rather than throwing in a non-git directory.
+ *
+ * @param {string} projectRoot
+ * @returns {{branch: string|null, changedFiles: string[], lastCommit: string|null, uncommittedCount: number}}
+ */
+export function readGitState(projectRoot) {
+  const branchRaw = git(projectRoot, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  let branch = null;
+  if (branchRaw === 'HEAD') branch = 'detached'; // detached HEAD checkout
+  else if (branchRaw) branch = branchRaw;        // null when not a git repo
+  const status = git(projectRoot, ['status', '--porcelain']);
+  const changedFiles = status
+    ? status
+        .split('\n')
+        .map((l) => l.slice(3).trim()) // strip the 2-char XY status + space
+        .filter(Boolean)
+        .map((p) => (p.includes(' -> ') ? p.split(' -> ')[1] : p)) // renames
+        .slice(0, 50)
+    : [];
+  const lastCommit = git(projectRoot, ['log', '-1', '--pretty=%s']) || null;
+  return { branch, changedFiles, lastCommit, uncommittedCount: changedFiles.length };
+}
+
+// ── Opt-out ─────────────────────────────────────────────────────────────────
+
+/** Honor a `<private>` opt-out tag anywhere in the supplied text (e.g. the
+ *  recent transcript). Case-insensitive. */
+export function hasPrivateOptOut(text) {
+  return typeof text === 'string' && /<private>/i.test(text);
+}
+
+// ── Digest assembly (pure) ──────────────────────────────────────────────────
+
+/** statSync mtime that never throws (file may vanish between readdir and stat). */
+function fileMtime(p) {
+  try { return statSync(p).mtimeMs; } catch { return 0; }
+}
+
+function trimList(items, max) {
+  return (Array.isArray(items) ? items : []).map((s) => String(s).trim()).filter(Boolean).slice(0, max);
+}
+
+/**
+ * Build the digest CONTENT — only non-reconstructable context. Git facts appear
+ * as a single "stopped at" anchor line, not as the payload (the next session can
+ * re-derive git state for free; it can't re-derive intent or rejected options).
+ *
+ * @param {{goal?: string, decisions?: string[], openThreads?: string[],
+ *          gitState?: {branch?: string|null, lastCommit?: string|null, uncommittedCount?: number}}} parts
+ * @returns {string} markdown (may be empty if nothing substantive was captured)
+ */
+export function assembleDigestContent(parts = {}) {
+  const lines = [];
+  const goal = parts.goal && String(parts.goal).trim();
+  if (goal) lines.push(`**Goal:** ${goal}`);
+
+  const decisions = trimList(parts.decisions, 5);
+  if (decisions.length) lines.push(`**Decisions this session:** ${decisions.join('; ')}`);
+
+  const threads = trimList(parts.openThreads, 5);
+  if (threads.length) lines.push(`**Open threads:** ${threads.join('; ')}`);
+
+  const g = parts.gitState || {};
+  if (g.branch) {
+    const bits = [`on \`${g.branch}\``];
+    if (g.lastCommit) bits.push(`last commit: "${g.lastCommit}"`);
+    if (g.uncommittedCount) bits.push(`${g.uncommittedCount} uncommitted file(s)`);
+    lines.push(`**Stopped at:** ${bits.join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Metadata persisted alongside the digest — the scoring signals (never shown).
+ *
+ * @returns {{branch: string|null, changedFiles: string[], endedAt: number,
+ *            sessionId: string|null, hadUnfinished: boolean}}
+ */
+export function buildDigestMetadata({ gitState = {}, sessionId = null, openThreads = [], endedAt = Date.now() } = {}) {
+  const uncommitted = Number(gitState.uncommittedCount || 0);
+  return {
+    branch: gitState.branch ?? null,
+    changedFiles: Array.isArray(gitState.changedFiles) ? gitState.changedFiles.slice(0, 50) : [],
+    endedAt,
+    sessionId: sessionId ?? null,
+    hadUnfinished: uncommitted > 0 || (Array.isArray(openThreads) && openThreads.length > 0),
+  };
+}
+
+// ── Relevance scoring + selection (pure) ────────────────────────────────────
+
+function metaOf(row) {
+  if (!row) return {};
+  const raw = row.metadata;
+  if (raw && typeof raw === 'object') return raw;
+  if (typeof raw === 'string') {
+    try { return JSON.parse(raw); } catch { return {}; }
+  }
+  return {};
+}
+
+function overlapCount(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length === 0 || b.length === 0) return 0;
+  const set = new Set(a);
+  let n = 0;
+  for (const x of b) if (set.has(x)) n++;
+  return n;
+}
+
+/**
+ * Score how relevant a stored digest is to the session starting now. Higher =
+ * more likely a continuation. Returns 0 for digests older than maxAgeHours.
+ *
+ * @param {object} meta - parsed digest metadata (branch, changedFiles, endedAt, hadUnfinished)
+ * @param {{branch: string|null, changedFiles: string[]}} ctx - current session context
+ * @param {{now?: number, maxAgeHours?: number}} [opts]
+ * @returns {number}
+ */
+export function scoreDigest(meta, ctx, opts = {}) {
+  const now = opts.now ?? Date.now();
+  const maxAgeHours = opts.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS;
+  const endedAt = Number(meta?.endedAt || 0);
+  if (!endedAt) return 0;
+  // Clamp small negative ages (clock skew / NTP step between capture and this
+  // start) to 0 = most-recent, rather than silently dropping a fresh digest.
+  const ageHours = Math.max(0, (now - endedAt) / 3_600_000);
+  if (ageHours > maxAgeHours) return 0;
+
+  let score = 0;
+  if (meta.branch && ctx.branch && meta.branch === ctx.branch) {
+    score += MAINLINE_BRANCHES.includes(meta.branch) ? SCORE.MAINLINE_BRANCH_MATCH : SCORE.BRANCH_MATCH;
+  }
+  const overlap = overlapCount(meta.changedFiles, ctx.changedFiles);
+  if (overlap > 0) score += Math.min(SCORE.FILE_OVERLAP_MAX, overlap * SCORE.FILE_OVERLAP_PER_FILE);
+  score += SCORE.RECENCY_MAX * Math.exp(-ageHours / SCORE.RECENCY_HALFLIFE_HOURS);
+  if (meta.hadUnfinished) score += SCORE.UNFINISHED_BONUS;
+  return score;
+}
+
+/**
+ * Pick the single most relevant digest to inject, or null if none clear the
+ * threshold. Skips the row matching `excludeSessionId` (don't replay the very
+ * session that just started, if it somehow already wrote a record).
+ *
+ * @param {Array<{content: string, metadata: any}>} rows
+ * @param {{branch: string|null, changedFiles: string[]}} ctx
+ * @param {{now?: number, maxAgeHours?: number, excludeSessionId?: string|null}} [opts]
+ * @returns {{row: object, meta: object, score: number}|null}
+ */
+export function selectBestDigest(rows, ctx, opts = {}) {
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  let best = null;
+  for (const row of rows) {
+    const meta = metaOf(row);
+    if (opts.excludeSessionId && meta.sessionId && meta.sessionId === opts.excludeSessionId) continue;
+    if (!row.content || !String(row.content).trim()) continue;
+    const score = scoreDigest(meta, ctx, opts);
+    if (score >= SCORE.INJECT_THRESHOLD && (!best || score > best.score)) {
+      best = { row, meta, score };
+    }
+  }
+  return best;
+}
+
+// ── Injection formatting (pure) ─────────────────────────────────────────────
+
+/** Humanise an elapsed-millis duration into a short phrase. */
+export function relativeTime(endedAt, now = Date.now()) {
+  const mins = Math.max(0, Math.round((now - endedAt) / 60_000));
+  if (mins < 60) return mins <= 1 ? 'just now' : `${mins} minutes ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+/**
+ * Format the selected digest as the SessionStart injection block — framed as a
+ * verifiable lead (not ground truth) and hard-capped at INJECT_MAX_CHARS.
+ *
+ * @param {{row: {content: string}, meta: {endedAt?: number}}} selection
+ * @param {number} [now]
+ * @returns {string}
+ */
+export function formatInjection(selection, now = Date.now()) {
+  const content = String(selection?.row?.content || '').trim();
+  if (!content) return '';
+  const when = selection?.meta?.endedAt ? relativeTime(selection.meta.endedAt, now) : 'recently';
+  const header = `📌 Where you left off (${when}) — verify current state before continuing:`;
+  const budget = INJECT_MAX_CHARS - header.length - 2;
+  if (budget <= 0) return header; // header alone already at the cap (defensive)
+  let body = content;
+  if (body.length > budget) body = body.slice(0, budget - 1).trimEnd() + '…';
+  return `${header}\n${body}`;
+}

--- a/.claude/scripts/lib/shipped-scripts.json
+++ b/.claude/scripts/lib/shipped-scripts.json
@@ -12,7 +12,8 @@
     "index-reference.mjs",
     "index-all.mjs",
     "setup-project.mjs",
-    "run-migrations.mjs"
+    "run-migrations.mjs",
+    "session-continuity.mjs"
   ],
   "binHelperFiles": [
     "gate.cjs",

--- a/.claude/scripts/lib/yaml-upgrader.mjs
+++ b/.claude/scripts/lib/yaml-upgrader.mjs
@@ -23,6 +23,20 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
  */
 export const REQUIRED_SECTIONS = [
   {
+    key: 'session_continuity',
+    block: `# Passive session-continuity — pick up where you left off across sessions.
+# capture: silently record a compact "where you left off" digest at turn-end.
+# inject:  surface the single most-relevant recent digest at session-start
+#          (relevance-gated by branch / changed files / recency, so an unrelated
+#          session shows nothing). Add "<private>" to a message to skip capturing
+#          that session. Set either to false to opt out.
+session_continuity:
+  capture: true
+  inject: true
+  max_age_hours: 72            # ignore digests older than this when injecting
+`,
+  },
+  {
     key: 'sandbox',
     block: `# Spell step sandboxing (OS-level process isolation for bash steps)
 # Platform support: macOS (sandbox-exec), Linux/WSL (bwrap). Windows has no OS sandbox.

--- a/.claude/scripts/run-migrations.mjs
+++ b/.claude/scripts/run-migrations.mjs
@@ -23,18 +23,9 @@ import { existsSync, readdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { hasMigrationRun, markMigrationDone, listMigrations, clearMigration } from './lib/migrations.mjs';
+import { findProjectRoot } from './lib/moflo-paths.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function findProjectRoot() {
-  let dir = process.cwd();
-  const root = resolve(dir, '/');
-  while (dir !== root) {
-    if (existsSync(resolve(dir, 'package.json'))) return dir;
-    dir = dirname(dir);
-  }
-  return process.cwd();
-}
 
 const projectRoot = findProjectRoot();
 const args = process.argv.slice(2);

--- a/.claude/scripts/session-continuity.mjs
+++ b/.claude/scripts/session-continuity.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Passive session-continuity CAPTURE (#1185).
+ *
+ * Wired to Claude Code's Stop hook (fires at the end of each assistant turn).
+ * On each fire it assembles a compact "where you left off" digest from data
+ * moflo already has — git state, recent `learnings`, the session goal — scrubs
+ * any secrets, and writes ONE record per session into the `.moflo/continuity/`
+ * JSON store. The matching injection runs at session-start inside
+ * session-start-launcher.mjs.
+ *
+ * Why a JSON store and not moflo.db: capture fires while the daemon is live, and
+ * the moflo.db writer audit requires cross-process DB writers to route through
+ * the daemon chokepoint. A dedicated JSON store sidesteps that — these digests
+ * are operational state, not semantic memory. We still READ moflo.db read-only
+ * for recent learnings (safe under WAL; reads never clobber).
+ *
+ * Why Stop (per-turn) and not only a clean SessionEnd: capturing on every turn
+ * makes the digest crash-robust — the latest state survives even if the session
+ * never exits cleanly ("closed my laptop"). A throttle keeps the real work to at
+ * most once per THROTTLE_MS so per-turn cost stays negligible across consumers.
+ *
+ * Invoked by: node .claude/scripts/session-continuity.mjs capture
+ *
+ * Cross-platform (Rule #1): Node fs/path/child_process primitives only.
+ */
+
+import { existsSync, readFileSync, writeFileSync, statSync, openSync, readSync, closeSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { findProjectRoot } from './lib/moflo-paths.mjs';
+import { openBackend } from './lib/get-backend.mjs';
+import { scrubSecrets } from './lib/pii-scrub.mjs';
+import {
+  readContinuityConfig,
+  readGitState,
+  hasPrivateOptOut,
+  assembleDigestContent,
+  buildDigestMetadata,
+  writeDigest,
+  rotateDigests,
+} from './lib/session-continuity.mjs';
+
+const THROTTLE_MS = 30_000;     // skip the work if we captured <30s ago this session
+const LEARNINGS_SAMPLE = 5;     // how many recent learnings to fold in as "decisions"
+
+function warn(msg) {
+  try { process.stderr.write(`moflo: session-continuity ${msg}\n`); } catch { /* never throw from a hook */ }
+}
+
+/** Read the Stop hook's JSON stdin (session_id, transcript_path). Bounded so a
+ *  missing/withheld stdin can never hang the hook. */
+async function readHookInput() {
+  if (process.stdin.isTTY) return {};
+  return new Promise((res) => {
+    let data = '';
+    let done = false;
+    const parse = (s) => { try { return s ? JSON.parse(s) : {}; } catch { return {}; } };
+    const finish = () => { if (done) return; done = true; res(parse(data)); };
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (c) => { if (!done) data += c; });
+    process.stdin.on('end', finish);
+    process.stdin.on('error', finish);
+    setTimeout(finish, 500);
+  });
+}
+
+/** First user message (the session goal) from a transcript JSONL head. */
+function extractFirstUserGoal(headText) {
+  for (const line of headText.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; }
+    const role = obj?.message?.role ?? obj?.role;
+    if (role !== 'user') continue;
+    let content = obj?.message?.content ?? obj?.content;
+    if (Array.isArray(content)) {
+      content = content.map((b) => (typeof b === 'string' ? b : b?.text || '')).join(' ');
+    }
+    if (typeof content !== 'string') continue;
+    const firstLine = content.replace(/\s+/g, ' ').trim();
+    // Skip slash-command / hook-noise openers — they aren't a goal statement.
+    if (!firstLine || firstLine.startsWith('<')) continue;
+    return firstLine.slice(0, 200);
+  }
+  return null;
+}
+
+/** Bounded transcript read: goal from the head, `<private>` opt-out scan over
+ *  head+tail. Large transcripts are read at the edges only. */
+function readTranscriptInfo(path) {
+  const info = { goal: null, optOut: false };
+  try {
+    if (!path || !existsSync(path)) return info;
+    const size = statSync(path).size;
+    let head;
+    let tail;
+    if (size <= 1_048_576) {
+      head = tail = readFileSync(path, 'utf-8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const hb = Buffer.alloc(32_768);
+        readSync(fd, hb, 0, hb.length, 0);
+        head = hb.toString('utf-8');
+        const tlen = 131_072;
+        const tb = Buffer.alloc(tlen);
+        readSync(fd, tb, 0, tlen, Math.max(0, size - tlen));
+        tail = tb.toString('utf-8');
+      } finally {
+        closeSync(fd);
+      }
+    }
+    info.optOut = hasPrivateOptOut(head) || hasPrivateOptOut(tail);
+    info.goal = extractFirstUserGoal(head);
+  } catch {
+    // Transcript is best-effort context; never block capture on it.
+  }
+  return info;
+}
+
+/** Throttle gate — true if we should skip capturing this turn. */
+function shouldThrottle(statePath, sessionId, now) {
+  try {
+    if (!existsSync(statePath)) return false;
+    const s = JSON.parse(readFileSync(statePath, 'utf-8'));
+    return s.sessionId === sessionId && typeof s.lastCaptureMs === 'number' && now - s.lastCaptureMs < THROTTLE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function writeThrottleState(statePath, sessionId, now) {
+  try {
+    mkdirSync(dirname(statePath), { recursive: true });
+    writeFileSync(statePath, JSON.stringify({ sessionId, lastCaptureMs: now }), 'utf-8');
+  } catch { /* non-fatal */ }
+}
+
+/** Recent learnings → short "decision" bullets. Read-only moflo.db access; safe
+ *  under WAL and never blocks the daemon. Best-effort: any failure → []. */
+async function readRecentDecisions(projectRoot, limit) {
+  let db;
+  try {
+    db = await openBackend(projectRoot, { create: false, readOnly: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  try {
+    const stmt = db.prepare(
+      `SELECT content FROM memory_entries WHERE namespace='learnings' AND status='active' ORDER BY created_at DESC LIMIT ?`,
+    );
+    stmt.bind([limit]);
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      const firstLine = String(row.content || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .find((l) => l && !l.startsWith('#') && !l.startsWith('---'));
+      if (firstLine) out.push(firstLine.slice(0, 120));
+    }
+    stmt.free();
+  } catch {
+    // learnings table may not exist yet, or DB mid-repair — optional source.
+  } finally {
+    try { if (typeof db.close === 'function') db.close(); } catch { /* already closed */ }
+  }
+  return out;
+}
+
+async function capture() {
+  const projectRoot = findProjectRoot();
+  const cfg = readContinuityConfig(projectRoot);
+  if (!cfg.capture) return;
+
+  const input = await readHookInput();
+  const sessionId = input.session_id || input.sessionId || null;
+  const now = Date.now();
+
+  const statePath = resolve(projectRoot, '.moflo', 'continuity-state.json');
+  if (shouldThrottle(statePath, sessionId, now)) return;
+
+  const transcript = readTranscriptInfo(input.transcript_path || input.transcriptPath);
+  if (transcript.optOut) {
+    // User asked this session not to be remembered — record nothing, but stamp
+    // the throttle so we don't re-scan the transcript every turn.
+    writeThrottleState(statePath, sessionId, now);
+    return;
+  }
+
+  const gitState = readGitState(projectRoot);
+  const decisions = await readRecentDecisions(projectRoot, LEARNINGS_SAMPLE);
+
+  const content = scrubSecrets(
+    assembleDigestContent({ goal: transcript.goal, decisions, gitState }),
+  );
+  if (!content.trim()) {
+    writeThrottleState(statePath, sessionId, now);
+    return; // nothing substantive to remember
+  }
+
+  const metadata = buildDigestMetadata({ gitState, sessionId, endedAt: now });
+  const key = sessionId
+    ? `session-${sessionId}`
+    : `session-${gitState.branch || 'nobranch'}-${new Date(now).toISOString().slice(0, 10)}`;
+
+  try {
+    writeDigest(projectRoot, key, { content, metadata });
+    rotateDigests(projectRoot);
+    writeThrottleState(statePath, sessionId, now);
+  } catch (err) {
+    warn(`persist failed (${err && err.message ? err.message : String(err)})`);
+  }
+}
+
+const sub = process.argv[2];
+if (sub === 'capture') {
+  capture().catch((err) => warn(`failed (${err && err.message ? err.message : String(err)})`));
+} else {
+  warn(`unknown subcommand "${sub || ''}" (expected: capture)`);
+}

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -17,6 +17,13 @@ import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyRetiredPrune } from './lib/retired-files.mjs';
 import { makeSyncer, contentEqual } from './lib/file-sync.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
+import {
+  readContinuityConfig,
+  readGitState,
+  readDigests,
+  selectBestDigest,
+  formatInjection,
+} from './lib/session-continuity.mjs';
 
 // Headless skip (#860). The daemon's headless workers spawn `claude --print`
 // with CLAUDE_CODE_HEADLESS=true (see src/cli/services/headless-worker-
@@ -2197,6 +2204,39 @@ if (bootstrapSentinelData?.failures?.length > 0) {
   } catch (err) {
     emitWarning(`bootstrap sentinel verify skipped (${errMessage(err)})`);
   }
+}
+
+// Passive session-continuity injection (#1185). Relevance-gated: read recent
+// digests, score them against the current branch/changed-files/recency, and
+// emit ONLY the single best one if it clears the threshold. A fresh, unrelated
+// session injects nothing — that's what keeps it from going context-negative.
+// Framed as a verifiable lead, never ground truth. Wrapped so it can never
+// block or break session start. NOT routed through emitMutation: it's context,
+// not a mutation, so it must not inflate the count or trigger the spawn notice.
+function maybeInjectContinuity() {
+  const cfg = readContinuityConfig(projectRoot);
+  if (!cfg.inject) return;
+
+  const rows = readDigests(projectRoot, { limit: 12 });
+  if (rows.length === 0) return; // first-ever session — nothing to inject, no git calls
+
+  const git = readGitState(projectRoot);
+  const best = selectBestDigest(
+    rows,
+    { branch: git.branch, changedFiles: git.changedFiles },
+    { maxAgeHours: cfg.maxAgeHours, now: Date.now() },
+  );
+  if (!best) return;
+
+  const block = formatInjection(best, Date.now());
+  if (block) {
+    try { process.stdout.write(block + '\n'); } catch { /* broken stdout must not throw */ }
+  }
+}
+try {
+  maybeInjectContinuity();
+} catch (err) {
+  emitWarning(`continuity injection skipped (${errMessage(err)})`);
 }
 
 // Bypasses emitMutation — framing, not a mutation, so it must not inflate the count.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -228,6 +228,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/auto-memory-hook.mjs\" sync",
             "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/session-continuity.mjs\" capture",
+            "timeout": 5000
           }
         ]
       }

--- a/bin/lib/pii-scrub.mjs
+++ b/bin/lib/pii-scrub.mjs
@@ -1,0 +1,119 @@
+/**
+ * Credential / secret scrubber for the session-continuity persist path (#1185).
+ *
+ * THREAT MODEL — this is deliberately NOT the transfer/anonymization pipeline
+ * (`src/cli/transfer/anonymization/index.ts`). That module makes a CFP safe to
+ * publish *externally* (aggressive, lossy, deterministic pseudonymisation of
+ * emails / home paths / IPs). This module has a narrower job: a session digest
+ * is written to the user's OWN local `.moflo/moflo.db`, so the only thing we
+ * must never persist is a literal *secret* that happened to appear in the
+ * session (an API key, a JWT, a private-key block). We intentionally KEEP
+ * benign context like file paths and branch names — they're the whole point of
+ * a "where you left off" digest and are not sensitive on the user's own disk.
+ *
+ * Two different purposes → two focused scrubbers, not one over-coupled one.
+ *
+ * Pure + synchronous + dependency-free so a bin/*.mjs hook can call it on the
+ * hot path without loading a model. Cross-platform (Rule #1): plain regex, no
+ * shell, no path assumptions.
+ */
+
+/**
+ * Ordered list of { name, pattern, replace } secret shapes. Order matters:
+ * multi-line PEM blocks and specific vendor token formats are neutralised
+ * before the generic `key=value` assignment sweep so the specific redaction
+ * label wins.
+ *
+ * Each `pattern` carries the global flag so `String.replace` hits every match.
+ */
+export const SECRET_PATTERNS = [
+  // PEM private-key blocks (RSA / EC / OPENSSH / generic) — match the whole block.
+  {
+    name: 'private-key',
+    pattern: /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z]+ )?PRIVATE KEY-----/g,
+    replace: '[REDACTED_PRIVATE_KEY]',
+  },
+  // JSON Web Tokens — header.payload.signature, both segments start with `eyJ`.
+  {
+    name: 'jwt',
+    pattern: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+    replace: '[REDACTED_JWT]',
+  },
+  // OpenAI / Anthropic-style keys: sk-..., sk-ant-..., pk-...
+  {
+    name: 'openai-anthropic-key',
+    pattern: /\b(?:sk|pk)-(?:ant-)?[A-Za-z0-9_-]{20,}\b/g,
+    replace: '[REDACTED_API_KEY]',
+  },
+  // AWS access key id.
+  { name: 'aws-access-key', pattern: /\bAKIA[0-9A-Z]{16}\b/g, replace: '[REDACTED_AWS_KEY]' },
+  // GitHub tokens (classic ghp_/gho_/ghu_/ghs_/ghr_ + fine-grained github_pat_).
+  {
+    name: 'github-token',
+    pattern: /\b(?:gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{22,})\b/g,
+    replace: '[REDACTED_GITHUB_TOKEN]',
+  },
+  // Slack tokens.
+  { name: 'slack-token', pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, replace: '[REDACTED_SLACK_TOKEN]' },
+  // Google API keys.
+  { name: 'google-api-key', pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g, replace: '[REDACTED_GOOGLE_KEY]' },
+  // Bearer tokens in Authorization headers / curl snippets.
+  {
+    name: 'bearer-token',
+    pattern: /\b[Bb]earer\s+[A-Za-z0-9._-]{16,}/g,
+    replace: 'Bearer [REDACTED_TOKEN]',
+  },
+  // Credentials embedded in a URL: scheme://user:secret@host → drop the secret.
+  // The negative lookahead keeps the scrub idempotent — it won't re-match the
+  // `[REDACTED]` placeholder it just wrote (so containsSecret(scrubbed) is false).
+  {
+    name: 'url-credentials',
+    pattern: /\b([a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^/\s:@]+):(?!\[REDACTED\]@)[^/\s@]+@/g,
+    replace: '$1:[REDACTED]@',
+  },
+  // Generic `secret=value` / `password: value` / `token = value` / `api_key=...`
+  // assignments. Quote-aware so it stops at the closing quote or whitespace.
+  // Runs LAST so the specific vendor formats above keep their precise labels.
+  // The negative lookahead skips the `[REDACTED]` placeholder so a re-scan of
+  // already-scrubbed text reports clean (idempotent detection).
+  {
+    name: 'assigned-secret',
+    pattern: /\b(api[_-]?key|secret|password|passwd|token|access[_-]?token|auth[_-]?token)(["']?\s*[:=]\s*["']?)(?!\[REDACTED)([^\s"']{6,})/gi,
+    replace: (_m, key, sep) => `${key}${sep}[REDACTED]`,
+  },
+];
+
+/**
+ * Replace every recognised secret in `text` with a redaction label. Returns the
+ * scrubbed string. Non-string input is coerced to '' (capture must never throw).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function scrubSecrets(text) {
+  if (typeof text !== 'string' || text.length === 0) return '';
+  let out = text;
+  for (const { pattern, replace } of SECRET_PATTERNS) {
+    // Fresh lastIndex each pass — these regexes are module-shared and carry /g,
+    // so a prior `.test()`/`.exec()` elsewhere must not leak state (the exact
+    // RegExp-lastIndex bug class from feedback_publish_catches_straggler_bugs).
+    pattern.lastIndex = 0;
+    out = out.replace(pattern, replace);
+  }
+  return out;
+}
+
+/**
+ * True if `text` contains at least one recognised secret. Used by tests and by
+ * the capture path's defensive "did we miss anything" assertion.
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function containsSecret(text) {
+  if (typeof text !== 'string' || text.length === 0) return false;
+  return SECRET_PATTERNS.some(({ pattern }) => {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  });
+}

--- a/bin/lib/session-continuity.mjs
+++ b/bin/lib/session-continuity.mjs
@@ -1,0 +1,372 @@
+/**
+ * Passive session-continuity — pure logic + store helpers shared by the capture
+ * orchestrator (`bin/session-continuity.mjs`, wired to the Stop hook) and the
+ * injection path (`bin/session-start-launcher.mjs`). See issue #1185.
+ *
+ * DESIGN (owner-signed-off):
+ *   - CAPTURE is default-on, silent, mechanical-first (no model call): assemble a
+ *     digest from data we already have — git state, recent `learnings`, the
+ *     session goal — scrub secrets, persist one record per session.
+ *   - INJECTION is default-on but RELEVANCE-GATED: at session-start we score
+ *     recent digests and inject only the single best one IF it clears a
+ *     threshold (same branch / file overlap / recency / unfinished work). A
+ *     fresh, unrelated session injects nothing — that's what keeps the feature
+ *     from going context-negative.
+ *   - The injected block stores only NON-RECONSTRUCTABLE context (goal,
+ *     decisions, where-you-stopped) and is framed as a verifiable lead, never
+ *     ground truth — git/tests are the source of truth the next session checks.
+ *
+ * STORAGE: a dedicated `.moflo/continuity/` JSON store, NOT `.moflo/moflo.db`.
+ * Capture fires on the Stop hook while the daemon is live; the moflo.db writer
+ * audit (docs/internal/1054-writer-audit.md) requires cross-process DB writers
+ * to route through the daemon chokepoint. A separate JSON store sidesteps that
+ * entirely — these digests are operational state, not semantic memory, carry no
+ * embeddings, and never belong in the HNSW index. One file per session avoids
+ * concurrent-write conflicts between simultaneous sessions.
+ *
+ * Cross-platform (Rule #1): `spawnSync` with arg arrays (no shell, no
+ * `2>/dev/null`), forward-slash path compares (git porcelain emits `/` on every
+ * OS), Node fs/path primitives only.
+ */
+
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync, unlinkSync } from 'fs';
+import { resolve, join } from 'path';
+import { randomBytes } from 'crypto';
+
+// ── Relevance-scoring tunables (exported for tests) ─────────────────────────
+export const MAINLINE_BRANCHES = ['main', 'master', 'develop', 'trunk'];
+export const SCORE = Object.freeze({
+  BRANCH_MATCH: 0.5,           // feature branch identity is a strong continuation signal
+  MAINLINE_BRANCH_MATCH: 0.25, // main/master is weak — everyone's always "on main"
+  FILE_OVERLAP_PER_FILE: 0.1,
+  FILE_OVERLAP_MAX: 0.3,
+  RECENCY_MAX: 0.2,
+  RECENCY_HALFLIFE_HOURS: 24,
+  UNFINISHED_BONUS: 0.15,
+  INJECT_THRESHOLD: 0.5,
+});
+export const DEFAULT_MAX_AGE_HOURS = 72;
+/** Hard cap on the injected block (~250 tokens). Bounds context cost even when
+ *  a digest does fire. */
+export const INJECT_MAX_CHARS = 1000;
+/** Rotation: keep the most recent N sessions' digests. */
+export const KEEP_DIGESTS = 30;
+
+// ── Store helpers (.moflo/continuity/) ──────────────────────────────────────
+
+export function continuityDir(projectRoot) {
+  return resolve(projectRoot, '.moflo', 'continuity');
+}
+
+/** Stable, filesystem-safe filename for a session's digest record. */
+export function digestFileName(key) {
+  const safe = String(key).replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 120);
+  return `${safe || 'session'}.json`;
+}
+
+/**
+ * Persist a digest record atomically (temp + rename) so a crash mid-write can
+ * never leave a half-written file the injection path would choke on.
+ *
+ * @param {string} projectRoot
+ * @param {string} key - stable per-session key
+ * @param {{content: string, metadata: object}} record
+ */
+export function writeDigest(projectRoot, key, record) {
+  const dir = continuityDir(projectRoot);
+  mkdirSync(dir, { recursive: true });
+  const dest = join(dir, digestFileName(key));
+  const tmp = `${dest}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+  writeFileSync(tmp, JSON.stringify(record), 'utf-8');
+  renameSync(tmp, dest);
+}
+
+/**
+ * Read recent digest records, newest first, capped to `limit`. Tolerates a
+ * partially-written / malformed file (skips it) — never throws.
+ *
+ * @param {string} projectRoot
+ * @param {{limit?: number}} [opts]
+ * @returns {Array<{content: string, metadata: object}>}
+ */
+export function readDigests(projectRoot, opts = {}) {
+  const limit = opts.limit ?? KEEP_DIGESTS;
+  const dir = continuityDir(projectRoot);
+  let files;
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return []; // no store yet
+  }
+  const withTime = files.map((f) => ({ f, mtime: fileMtime(join(dir, f)) }));
+  withTime.sort((a, b) => b.mtime - a.mtime);
+  const out = [];
+  for (const { f } of withTime.slice(0, limit)) {
+    try {
+      const rec = JSON.parse(readFileSync(join(dir, f), 'utf-8'));
+      if (rec && typeof rec.content === 'string') out.push(rec);
+    } catch { /* skip malformed / mid-write */ }
+  }
+  return out;
+}
+
+/** Delete the oldest digest files beyond `keep` (housekeeping; never fatal). */
+export function rotateDigests(projectRoot, keep = KEEP_DIGESTS) {
+  const dir = continuityDir(projectRoot);
+  let names;
+  try {
+    names = readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return;
+  }
+  if (names.length <= keep) return; // common case — no per-file stat sweep needed
+  const entries = names.map((f) => ({ f, mtime: fileMtime(join(dir, f)) }));
+  entries.sort((a, b) => b.mtime - a.mtime);
+  for (const { f } of entries.slice(keep)) {
+    try { unlinkSync(join(dir, f)); } catch { /* already gone */ }
+  }
+}
+
+// ── moflo.yaml config (regex read, matching the launcher's no-js-yaml style) ─
+
+/**
+ * Read the `session_continuity` block from moflo.yaml without a YAML parser
+ * (the launcher and bin scripts avoid the js-yaml dependency for speed). Both
+ * flags default ON; injection is still relevance-gated at runtime.
+ *
+ * @param {string} projectRoot
+ * @returns {{capture: boolean, inject: boolean, maxAgeHours: number}}
+ */
+export function readContinuityConfig(projectRoot) {
+  const cfg = { capture: true, inject: true, maxAgeHours: DEFAULT_MAX_AGE_HOURS };
+  try {
+    const yamlPath = resolve(projectRoot, 'moflo.yaml');
+    if (!existsSync(yamlPath)) return cfg;
+    const text = readFileSync(yamlPath, 'utf-8');
+    const capture = text.match(/session_continuity:\s*\n(?:\s+\w+:.*\n)*?\s+capture:\s*(true|false)/);
+    const inject = text.match(/session_continuity:\s*\n(?:\s+\w+:.*\n)*?\s+inject:\s*(true|false)/);
+    const maxAge = text.match(/session_continuity:\s*\n(?:\s+\w+:.*\n)*?\s+max_age_hours:\s*(\d+)/);
+    if (capture) cfg.capture = capture[1] === 'true';
+    if (inject) cfg.inject = inject[1] === 'true';
+    if (maxAge) cfg.maxAgeHours = Math.max(1, parseInt(maxAge[1], 10));
+  } catch {
+    // Defaults (on) keep the feature alive if the file is mid-write / malformed.
+  }
+  return cfg;
+}
+
+// ── Git state (cross-platform, no shell) ────────────────────────────────────
+
+function git(projectRoot, args) {
+  try {
+    const r = spawnSync('git', args, {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      timeout: 2000,
+      windowsHide: true,
+    });
+    if (r.status !== 0 || typeof r.stdout !== 'string') return null;
+    return r.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Current branch, changed-file paths, last-commit subject and uncommitted count.
+ * Returns null-ish fields rather than throwing in a non-git directory.
+ *
+ * @param {string} projectRoot
+ * @returns {{branch: string|null, changedFiles: string[], lastCommit: string|null, uncommittedCount: number}}
+ */
+export function readGitState(projectRoot) {
+  const branchRaw = git(projectRoot, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  let branch = null;
+  if (branchRaw === 'HEAD') branch = 'detached'; // detached HEAD checkout
+  else if (branchRaw) branch = branchRaw;        // null when not a git repo
+  const status = git(projectRoot, ['status', '--porcelain']);
+  const changedFiles = status
+    ? status
+        .split('\n')
+        .map((l) => l.slice(3).trim()) // strip the 2-char XY status + space
+        .filter(Boolean)
+        .map((p) => (p.includes(' -> ') ? p.split(' -> ')[1] : p)) // renames
+        .slice(0, 50)
+    : [];
+  const lastCommit = git(projectRoot, ['log', '-1', '--pretty=%s']) || null;
+  return { branch, changedFiles, lastCommit, uncommittedCount: changedFiles.length };
+}
+
+// ── Opt-out ─────────────────────────────────────────────────────────────────
+
+/** Honor a `<private>` opt-out tag anywhere in the supplied text (e.g. the
+ *  recent transcript). Case-insensitive. */
+export function hasPrivateOptOut(text) {
+  return typeof text === 'string' && /<private>/i.test(text);
+}
+
+// ── Digest assembly (pure) ──────────────────────────────────────────────────
+
+/** statSync mtime that never throws (file may vanish between readdir and stat). */
+function fileMtime(p) {
+  try { return statSync(p).mtimeMs; } catch { return 0; }
+}
+
+function trimList(items, max) {
+  return (Array.isArray(items) ? items : []).map((s) => String(s).trim()).filter(Boolean).slice(0, max);
+}
+
+/**
+ * Build the digest CONTENT — only non-reconstructable context. Git facts appear
+ * as a single "stopped at" anchor line, not as the payload (the next session can
+ * re-derive git state for free; it can't re-derive intent or rejected options).
+ *
+ * @param {{goal?: string, decisions?: string[], openThreads?: string[],
+ *          gitState?: {branch?: string|null, lastCommit?: string|null, uncommittedCount?: number}}} parts
+ * @returns {string} markdown (may be empty if nothing substantive was captured)
+ */
+export function assembleDigestContent(parts = {}) {
+  const lines = [];
+  const goal = parts.goal && String(parts.goal).trim();
+  if (goal) lines.push(`**Goal:** ${goal}`);
+
+  const decisions = trimList(parts.decisions, 5);
+  if (decisions.length) lines.push(`**Decisions this session:** ${decisions.join('; ')}`);
+
+  const threads = trimList(parts.openThreads, 5);
+  if (threads.length) lines.push(`**Open threads:** ${threads.join('; ')}`);
+
+  const g = parts.gitState || {};
+  if (g.branch) {
+    const bits = [`on \`${g.branch}\``];
+    if (g.lastCommit) bits.push(`last commit: "${g.lastCommit}"`);
+    if (g.uncommittedCount) bits.push(`${g.uncommittedCount} uncommitted file(s)`);
+    lines.push(`**Stopped at:** ${bits.join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Metadata persisted alongside the digest — the scoring signals (never shown).
+ *
+ * @returns {{branch: string|null, changedFiles: string[], endedAt: number,
+ *            sessionId: string|null, hadUnfinished: boolean}}
+ */
+export function buildDigestMetadata({ gitState = {}, sessionId = null, openThreads = [], endedAt = Date.now() } = {}) {
+  const uncommitted = Number(gitState.uncommittedCount || 0);
+  return {
+    branch: gitState.branch ?? null,
+    changedFiles: Array.isArray(gitState.changedFiles) ? gitState.changedFiles.slice(0, 50) : [],
+    endedAt,
+    sessionId: sessionId ?? null,
+    hadUnfinished: uncommitted > 0 || (Array.isArray(openThreads) && openThreads.length > 0),
+  };
+}
+
+// ── Relevance scoring + selection (pure) ────────────────────────────────────
+
+function metaOf(row) {
+  if (!row) return {};
+  const raw = row.metadata;
+  if (raw && typeof raw === 'object') return raw;
+  if (typeof raw === 'string') {
+    try { return JSON.parse(raw); } catch { return {}; }
+  }
+  return {};
+}
+
+function overlapCount(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length === 0 || b.length === 0) return 0;
+  const set = new Set(a);
+  let n = 0;
+  for (const x of b) if (set.has(x)) n++;
+  return n;
+}
+
+/**
+ * Score how relevant a stored digest is to the session starting now. Higher =
+ * more likely a continuation. Returns 0 for digests older than maxAgeHours.
+ *
+ * @param {object} meta - parsed digest metadata (branch, changedFiles, endedAt, hadUnfinished)
+ * @param {{branch: string|null, changedFiles: string[]}} ctx - current session context
+ * @param {{now?: number, maxAgeHours?: number}} [opts]
+ * @returns {number}
+ */
+export function scoreDigest(meta, ctx, opts = {}) {
+  const now = opts.now ?? Date.now();
+  const maxAgeHours = opts.maxAgeHours ?? DEFAULT_MAX_AGE_HOURS;
+  const endedAt = Number(meta?.endedAt || 0);
+  if (!endedAt) return 0;
+  // Clamp small negative ages (clock skew / NTP step between capture and this
+  // start) to 0 = most-recent, rather than silently dropping a fresh digest.
+  const ageHours = Math.max(0, (now - endedAt) / 3_600_000);
+  if (ageHours > maxAgeHours) return 0;
+
+  let score = 0;
+  if (meta.branch && ctx.branch && meta.branch === ctx.branch) {
+    score += MAINLINE_BRANCHES.includes(meta.branch) ? SCORE.MAINLINE_BRANCH_MATCH : SCORE.BRANCH_MATCH;
+  }
+  const overlap = overlapCount(meta.changedFiles, ctx.changedFiles);
+  if (overlap > 0) score += Math.min(SCORE.FILE_OVERLAP_MAX, overlap * SCORE.FILE_OVERLAP_PER_FILE);
+  score += SCORE.RECENCY_MAX * Math.exp(-ageHours / SCORE.RECENCY_HALFLIFE_HOURS);
+  if (meta.hadUnfinished) score += SCORE.UNFINISHED_BONUS;
+  return score;
+}
+
+/**
+ * Pick the single most relevant digest to inject, or null if none clear the
+ * threshold. Skips the row matching `excludeSessionId` (don't replay the very
+ * session that just started, if it somehow already wrote a record).
+ *
+ * @param {Array<{content: string, metadata: any}>} rows
+ * @param {{branch: string|null, changedFiles: string[]}} ctx
+ * @param {{now?: number, maxAgeHours?: number, excludeSessionId?: string|null}} [opts]
+ * @returns {{row: object, meta: object, score: number}|null}
+ */
+export function selectBestDigest(rows, ctx, opts = {}) {
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  let best = null;
+  for (const row of rows) {
+    const meta = metaOf(row);
+    if (opts.excludeSessionId && meta.sessionId && meta.sessionId === opts.excludeSessionId) continue;
+    if (!row.content || !String(row.content).trim()) continue;
+    const score = scoreDigest(meta, ctx, opts);
+    if (score >= SCORE.INJECT_THRESHOLD && (!best || score > best.score)) {
+      best = { row, meta, score };
+    }
+  }
+  return best;
+}
+
+// ── Injection formatting (pure) ─────────────────────────────────────────────
+
+/** Humanise an elapsed-millis duration into a short phrase. */
+export function relativeTime(endedAt, now = Date.now()) {
+  const mins = Math.max(0, Math.round((now - endedAt) / 60_000));
+  if (mins < 60) return mins <= 1 ? 'just now' : `${mins} minutes ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+/**
+ * Format the selected digest as the SessionStart injection block — framed as a
+ * verifiable lead (not ground truth) and hard-capped at INJECT_MAX_CHARS.
+ *
+ * @param {{row: {content: string}, meta: {endedAt?: number}}} selection
+ * @param {number} [now]
+ * @returns {string}
+ */
+export function formatInjection(selection, now = Date.now()) {
+  const content = String(selection?.row?.content || '').trim();
+  if (!content) return '';
+  const when = selection?.meta?.endedAt ? relativeTime(selection.meta.endedAt, now) : 'recently';
+  const header = `📌 Where you left off (${when}) — verify current state before continuing:`;
+  const budget = INJECT_MAX_CHARS - header.length - 2;
+  if (budget <= 0) return header; // header alone already at the cap (defensive)
+  let body = content;
+  if (body.length > budget) body = body.slice(0, budget - 1).trimEnd() + '…';
+  return `${header}\n${body}`;
+}

--- a/bin/lib/shipped-scripts.json
+++ b/bin/lib/shipped-scripts.json
@@ -12,7 +12,8 @@
     "index-reference.mjs",
     "index-all.mjs",
     "setup-project.mjs",
-    "run-migrations.mjs"
+    "run-migrations.mjs",
+    "session-continuity.mjs"
   ],
   "binHelperFiles": [
     "gate.cjs",

--- a/bin/lib/yaml-upgrader.mjs
+++ b/bin/lib/yaml-upgrader.mjs
@@ -23,6 +23,20 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
  */
 export const REQUIRED_SECTIONS = [
   {
+    key: 'session_continuity',
+    block: `# Passive session-continuity — pick up where you left off across sessions.
+# capture: silently record a compact "where you left off" digest at turn-end.
+# inject:  surface the single most-relevant recent digest at session-start
+#          (relevance-gated by branch / changed files / recency, so an unrelated
+#          session shows nothing). Add "<private>" to a message to skip capturing
+#          that session. Set either to false to opt out.
+session_continuity:
+  capture: true
+  inject: true
+  max_age_hours: 72            # ignore digests older than this when injecting
+`,
+  },
+  {
     key: 'sandbox',
     block: `# Spell step sandboxing (OS-level process isolation for bash steps)
 # Platform support: macOS (sandbox-exec), Linux/WSL (bwrap). Windows has no OS sandbox.

--- a/bin/session-continuity.mjs
+++ b/bin/session-continuity.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Passive session-continuity CAPTURE (#1185).
+ *
+ * Wired to Claude Code's Stop hook (fires at the end of each assistant turn).
+ * On each fire it assembles a compact "where you left off" digest from data
+ * moflo already has — git state, recent `learnings`, the session goal — scrubs
+ * any secrets, and writes ONE record per session into the `.moflo/continuity/`
+ * JSON store. The matching injection runs at session-start inside
+ * session-start-launcher.mjs.
+ *
+ * Why a JSON store and not moflo.db: capture fires while the daemon is live, and
+ * the moflo.db writer audit requires cross-process DB writers to route through
+ * the daemon chokepoint. A dedicated JSON store sidesteps that — these digests
+ * are operational state, not semantic memory. We still READ moflo.db read-only
+ * for recent learnings (safe under WAL; reads never clobber).
+ *
+ * Why Stop (per-turn) and not only a clean SessionEnd: capturing on every turn
+ * makes the digest crash-robust — the latest state survives even if the session
+ * never exits cleanly ("closed my laptop"). A throttle keeps the real work to at
+ * most once per THROTTLE_MS so per-turn cost stays negligible across consumers.
+ *
+ * Invoked by: node .claude/scripts/session-continuity.mjs capture
+ *
+ * Cross-platform (Rule #1): Node fs/path/child_process primitives only.
+ */
+
+import { existsSync, readFileSync, writeFileSync, statSync, openSync, readSync, closeSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { findProjectRoot } from './lib/moflo-paths.mjs';
+import { openBackend } from './lib/get-backend.mjs';
+import { scrubSecrets } from './lib/pii-scrub.mjs';
+import {
+  readContinuityConfig,
+  readGitState,
+  hasPrivateOptOut,
+  assembleDigestContent,
+  buildDigestMetadata,
+  writeDigest,
+  rotateDigests,
+} from './lib/session-continuity.mjs';
+
+const THROTTLE_MS = 30_000;     // skip the work if we captured <30s ago this session
+const LEARNINGS_SAMPLE = 5;     // how many recent learnings to fold in as "decisions"
+
+function warn(msg) {
+  try { process.stderr.write(`moflo: session-continuity ${msg}\n`); } catch { /* never throw from a hook */ }
+}
+
+/** Read the Stop hook's JSON stdin (session_id, transcript_path). Bounded so a
+ *  missing/withheld stdin can never hang the hook. */
+async function readHookInput() {
+  if (process.stdin.isTTY) return {};
+  return new Promise((res) => {
+    let data = '';
+    let done = false;
+    const parse = (s) => { try { return s ? JSON.parse(s) : {}; } catch { return {}; } };
+    const finish = () => { if (done) return; done = true; res(parse(data)); };
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (c) => { if (!done) data += c; });
+    process.stdin.on('end', finish);
+    process.stdin.on('error', finish);
+    setTimeout(finish, 500);
+  });
+}
+
+/** First user message (the session goal) from a transcript JSONL head. */
+function extractFirstUserGoal(headText) {
+  for (const line of headText.split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; }
+    const role = obj?.message?.role ?? obj?.role;
+    if (role !== 'user') continue;
+    let content = obj?.message?.content ?? obj?.content;
+    if (Array.isArray(content)) {
+      content = content.map((b) => (typeof b === 'string' ? b : b?.text || '')).join(' ');
+    }
+    if (typeof content !== 'string') continue;
+    const firstLine = content.replace(/\s+/g, ' ').trim();
+    // Skip slash-command / hook-noise openers — they aren't a goal statement.
+    if (!firstLine || firstLine.startsWith('<')) continue;
+    return firstLine.slice(0, 200);
+  }
+  return null;
+}
+
+/** Bounded transcript read: goal from the head, `<private>` opt-out scan over
+ *  head+tail. Large transcripts are read at the edges only. */
+function readTranscriptInfo(path) {
+  const info = { goal: null, optOut: false };
+  try {
+    if (!path || !existsSync(path)) return info;
+    const size = statSync(path).size;
+    let head;
+    let tail;
+    if (size <= 1_048_576) {
+      head = tail = readFileSync(path, 'utf-8');
+    } else {
+      const fd = openSync(path, 'r');
+      try {
+        const hb = Buffer.alloc(32_768);
+        readSync(fd, hb, 0, hb.length, 0);
+        head = hb.toString('utf-8');
+        const tlen = 131_072;
+        const tb = Buffer.alloc(tlen);
+        readSync(fd, tb, 0, tlen, Math.max(0, size - tlen));
+        tail = tb.toString('utf-8');
+      } finally {
+        closeSync(fd);
+      }
+    }
+    info.optOut = hasPrivateOptOut(head) || hasPrivateOptOut(tail);
+    info.goal = extractFirstUserGoal(head);
+  } catch {
+    // Transcript is best-effort context; never block capture on it.
+  }
+  return info;
+}
+
+/** Throttle gate — true if we should skip capturing this turn. */
+function shouldThrottle(statePath, sessionId, now) {
+  try {
+    if (!existsSync(statePath)) return false;
+    const s = JSON.parse(readFileSync(statePath, 'utf-8'));
+    return s.sessionId === sessionId && typeof s.lastCaptureMs === 'number' && now - s.lastCaptureMs < THROTTLE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function writeThrottleState(statePath, sessionId, now) {
+  try {
+    mkdirSync(dirname(statePath), { recursive: true });
+    writeFileSync(statePath, JSON.stringify({ sessionId, lastCaptureMs: now }), 'utf-8');
+  } catch { /* non-fatal */ }
+}
+
+/** Recent learnings → short "decision" bullets. Read-only moflo.db access; safe
+ *  under WAL and never blocks the daemon. Best-effort: any failure → []. */
+async function readRecentDecisions(projectRoot, limit) {
+  let db;
+  try {
+    db = await openBackend(projectRoot, { create: false, readOnly: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  try {
+    const stmt = db.prepare(
+      `SELECT content FROM memory_entries WHERE namespace='learnings' AND status='active' ORDER BY created_at DESC LIMIT ?`,
+    );
+    stmt.bind([limit]);
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      const firstLine = String(row.content || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .find((l) => l && !l.startsWith('#') && !l.startsWith('---'));
+      if (firstLine) out.push(firstLine.slice(0, 120));
+    }
+    stmt.free();
+  } catch {
+    // learnings table may not exist yet, or DB mid-repair — optional source.
+  } finally {
+    try { if (typeof db.close === 'function') db.close(); } catch { /* already closed */ }
+  }
+  return out;
+}
+
+async function capture() {
+  const projectRoot = findProjectRoot();
+  const cfg = readContinuityConfig(projectRoot);
+  if (!cfg.capture) return;
+
+  const input = await readHookInput();
+  const sessionId = input.session_id || input.sessionId || null;
+  const now = Date.now();
+
+  const statePath = resolve(projectRoot, '.moflo', 'continuity-state.json');
+  if (shouldThrottle(statePath, sessionId, now)) return;
+
+  const transcript = readTranscriptInfo(input.transcript_path || input.transcriptPath);
+  if (transcript.optOut) {
+    // User asked this session not to be remembered — record nothing, but stamp
+    // the throttle so we don't re-scan the transcript every turn.
+    writeThrottleState(statePath, sessionId, now);
+    return;
+  }
+
+  const gitState = readGitState(projectRoot);
+  const decisions = await readRecentDecisions(projectRoot, LEARNINGS_SAMPLE);
+
+  const content = scrubSecrets(
+    assembleDigestContent({ goal: transcript.goal, decisions, gitState }),
+  );
+  if (!content.trim()) {
+    writeThrottleState(statePath, sessionId, now);
+    return; // nothing substantive to remember
+  }
+
+  const metadata = buildDigestMetadata({ gitState, sessionId, endedAt: now });
+  const key = sessionId
+    ? `session-${sessionId}`
+    : `session-${gitState.branch || 'nobranch'}-${new Date(now).toISOString().slice(0, 10)}`;
+
+  try {
+    writeDigest(projectRoot, key, { content, metadata });
+    rotateDigests(projectRoot);
+    writeThrottleState(statePath, sessionId, now);
+  } catch (err) {
+    warn(`persist failed (${err && err.message ? err.message : String(err)})`);
+  }
+}
+
+const sub = process.argv[2];
+if (sub === 'capture') {
+  capture().catch((err) => warn(`failed (${err && err.message ? err.message : String(err)})`));
+} else {
+  warn(`unknown subcommand "${sub || ''}" (expected: capture)`);
+}

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -17,6 +17,13 @@ import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyRetiredPrune } from './lib/retired-files.mjs';
 import { makeSyncer, contentEqual } from './lib/file-sync.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
+import {
+  readContinuityConfig,
+  readGitState,
+  readDigests,
+  selectBestDigest,
+  formatInjection,
+} from './lib/session-continuity.mjs';
 
 // Headless skip (#860). The daemon's headless workers spawn `claude --print`
 // with CLAUDE_CODE_HEADLESS=true (see src/cli/services/headless-worker-
@@ -2197,6 +2204,39 @@ if (bootstrapSentinelData?.failures?.length > 0) {
   } catch (err) {
     emitWarning(`bootstrap sentinel verify skipped (${errMessage(err)})`);
   }
+}
+
+// Passive session-continuity injection (#1185). Relevance-gated: read recent
+// digests, score them against the current branch/changed-files/recency, and
+// emit ONLY the single best one if it clears the threshold. A fresh, unrelated
+// session injects nothing — that's what keeps it from going context-negative.
+// Framed as a verifiable lead, never ground truth. Wrapped so it can never
+// block or break session start. NOT routed through emitMutation: it's context,
+// not a mutation, so it must not inflate the count or trigger the spawn notice.
+function maybeInjectContinuity() {
+  const cfg = readContinuityConfig(projectRoot);
+  if (!cfg.inject) return;
+
+  const rows = readDigests(projectRoot, { limit: 12 });
+  if (rows.length === 0) return; // first-ever session — nothing to inject, no git calls
+
+  const git = readGitState(projectRoot);
+  const best = selectBestDigest(
+    rows,
+    { branch: git.branch, changedFiles: git.changedFiles },
+    { maxAgeHours: cfg.maxAgeHours, now: Date.now() },
+  );
+  if (!best) return;
+
+  const block = formatInjection(best, Date.now());
+  if (block) {
+    try { process.stdout.write(block + '\n'); } catch { /* broken stdout must not throw */ }
+  }
+}
+try {
+  maybeInjectContinuity();
+} catch (err) {
+  emitWarning(`continuity injection skipped (${errMessage(err)})`);
 }
 
 // Bypasses emitMutation — framing, not a mutation, so it must not inflate the count.

--- a/src/cli/__tests__/doctor-checks-deep.test.ts
+++ b/src/cli/__tests__/doctor-checks-deep.test.ts
@@ -131,7 +131,7 @@ describe('doctor-checks-deep', () => {
     });
 
     it('should have valid event types', () => {
-      const validEvents = ['PreToolUse', 'PostToolUse', 'UserPromptSubmit'];
+      const validEvents = ['PreToolUse', 'PostToolUse', 'UserPromptSubmit', 'Stop'];
       for (const hook of REQUIRED_HOOK_WIRING) {
         expect(validEvents).toContain(hook.event);
       }

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -52,6 +52,18 @@ export interface MofloConfig {
     code_map: boolean;
   };
 
+  /**
+   * Passive session-continuity (#1185). `capture` silently records a compact
+   * "where you left off" digest at each turn-end; `inject` surfaces the single
+   * most-relevant recent digest at the next session-start (relevance-gated, so
+   * an unrelated session shows nothing). Both default on.
+   */
+  session_continuity: {
+    capture: boolean;
+    inject: boolean;
+    max_age_hours: number;
+  };
+
   memory: {
     /**
      * Memory backend selection. Maps directly to the
@@ -180,6 +192,11 @@ const DEFAULT_CONFIG: MofloConfig = {
   auto_index: {
     guidance: true,
     code_map: true,
+  },
+  session_continuity: {
+    capture: true,
+    inject: true,
+    max_age_hours: 72,
   },
   memory: {
     backend: 'node-sqlite',
@@ -346,6 +363,11 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
     auto_index: {
       guidance: raw.auto_index?.guidance ?? raw.autoIndex?.guidance ?? DEFAULT_CONFIG.auto_index.guidance,
       code_map: raw.auto_index?.code_map ?? raw.autoIndex?.code_map ?? DEFAULT_CONFIG.auto_index.code_map,
+    },
+    session_continuity: {
+      capture: raw.session_continuity?.capture ?? raw.sessionContinuity?.capture ?? DEFAULT_CONFIG.session_continuity.capture,
+      inject: raw.session_continuity?.inject ?? raw.sessionContinuity?.inject ?? DEFAULT_CONFIG.session_continuity.inject,
+      max_age_hours: raw.session_continuity?.max_age_hours ?? raw.sessionContinuity?.maxAgeHours ?? DEFAULT_CONFIG.session_continuity.max_age_hours,
     },
     memory: {
       backend: coerceMemoryBackend(raw.memory?.backend),

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -222,6 +222,17 @@ auto_index:
   code_map: ${codeMap}
   tests: ${tests}
 
+# Passive session-continuity — pick up where you left off across sessions.
+# capture: silently record a compact "where you left off" digest at turn-end.
+# inject:  surface the single most-relevant recent digest at session-start
+#          (relevance-gated by branch / changed files / recency, so an unrelated
+#          session shows nothing). Add "<private>" to a message to skip capturing
+#          that session. Set either to false to opt out.
+session_continuity:
+  capture: true
+  inject: true
+  max_age_hours: 72            # ignore digests older than this when injecting
+
 # Memory backend
 memory:
   backend: node-sqlite
@@ -331,6 +342,7 @@ export const REQUIRED_TOP_LEVEL_SECTIONS = [
   'tests',
   'gates',
   'auto_index',
+  'session_continuity',
   'memory',
   'hooks',
   'mcp',

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -195,6 +195,12 @@ function autoMemoryCmd(subcommand: string): string {
   return hookCmdEsm('"$CLAUDE_PROJECT_DIR/.claude/helpers/auto-memory-hook.mjs"', subcommand);
 }
 
+/** Shorthand for the ESM session-continuity capture command (#1185). Lives in
+ *  .claude/scripts/ (a synced scriptFile), beside its ./lib/ helpers. */
+function continuityCmd(subcommand: string): string {
+  return hookCmdEsm('"$CLAUDE_PROJECT_DIR/.claude/scripts/session-continuity.mjs"', subcommand);
+}
+
 /** Shorthand for gate commands (lightweight JSON state checks) */
 function gateCmd(subcommand: string): string {
   return hookCmd('"$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs"', subcommand);
@@ -405,13 +411,14 @@ function generateHooksConfig(config: HooksConfig): object {
     ];
   }
 
-  // Stop — persist session + sync auto memory
+  // Stop — persist session + sync auto memory + capture continuity digest (#1185)
   if (config.stop) {
     hooks.Stop = [
       {
         hooks: [
           { type: 'command', command: hookHandlerCmd('session-end'), timeout: 5000 },
           { type: 'command', command: autoMemoryCmd('sync'), timeout: 10000 },
+          { type: 'command', command: continuityCmd('capture'), timeout: 5000 },
         ],
       },
     ];

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -85,6 +85,13 @@ const scriptHook = (file: string, timeout: number): HookEntry => ({
   timeout,
 });
 
+/** Build a `node "<scripts/file>" <subcommand>` hook entry. */
+const scriptHookSub = (file: string, sub: string, timeout: number): HookEntry => ({
+  type: 'command',
+  command: `node "${SCRIPTS_PREFIX}/${file}"${sub ? ` ${sub}` : ''}`,
+  timeout,
+});
+
 const gateHook = (sub: string, timeout: number) => helperHook('gate-hook.mjs', sub, timeout);
 const gateCjs = (sub: string, timeout: number) => helperHook('gate.cjs', sub, timeout);
 const handler = (sub: string, timeout: number) => helperHook('hook-handler.cjs', sub, timeout);
@@ -156,7 +163,7 @@ export function getReferenceHookBlock(): HooksTree {
       },
     ],
     Stop: [
-      { hooks: [handler('session-end', 5000), autoMemory('sync', 10000)] },
+      { hooks: [handler('session-end', 5000), autoMemory('sync', 10000), scriptHookSub('session-continuity.mjs', 'capture', 5000)] },
     ],
     PreCompact: [
       { hooks: [gateCjs('compact-guidance', 3000)] },

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -50,6 +50,11 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   // the duplicate `prompt-reminder` wiring that was emitting the TaskCreate
   // REMINDER twice per prompt (#931).
   { event: 'UserPromptSubmit', pattern: 'prompt-state-reset' },
+  // #1185 — passive session-continuity capture on the Stop hook. Self-heals
+  // into existing consumers on upgrade so the feature reaches everyone, not
+  // just fresh `flo init`. Capture is default-on (silent); injection is
+  // relevance-gated at session-start.
+  { event: 'Stop', pattern: 'session-continuity.mjs' },
 ];
 
 /**
@@ -92,6 +97,10 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   // Defensive safety-net — runs gate.cjs `prompt-state-reset` if prompt-hook.mjs
   // throws before completing the per-prompt state reset. State-only, no emission.
   'prompt-state-reset':       { event: 'UserPromptSubmit', matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" prompt-state-reset', timeout: 3000 } },
+  // #1185 — passive session-continuity capture (Stop hook). Bare block (no
+  // matcher), like the UserPromptSubmit entries; Claude Code fires every Stop
+  // block, so a separate block alongside session-end/sync is fine.
+  'session-continuity.mjs':   { event: 'Stop',             matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/session-continuity.mjs" capture', timeout: 5000 } },
 };
 
 export interface RepairResult {

--- a/tests/bin/launcher-928-dogfood-skip.test.ts
+++ b/tests/bin/launcher-928-dogfood-skip.test.ts
@@ -83,7 +83,7 @@ function stageDriftScenario(root: string, pkgName: string) {
     'hooks.mjs', 'session-start-launcher.mjs', 'index-guidance.mjs',
     'build-embeddings.mjs', 'generate-code-map.mjs', 'semantic-search.mjs',
     'index-tests.mjs', 'index-patterns.mjs', 'index-reference.mjs', 'index-all.mjs',
-    'setup-project.mjs', 'run-migrations.mjs',
+    'setup-project.mjs', 'run-migrations.mjs', 'session-continuity.mjs',
     'gate-hook.mjs', 'prompt-hook.mjs', 'hook-handler.cjs', 'simplify-classify.cjs',
   ]) {
     writeFileSync(join(nmDir, 'bin', f), '');

--- a/tests/bin/session-continuity.test.ts
+++ b/tests/bin/session-continuity.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for passive session-continuity (#1185).
+ *
+ * Covers the pure logic (secret scrub, digest assembly, relevance scoring,
+ * selection, capped formatting), the JSON store round-trip, and an end-to-end
+ * capture subprocess (stdin → digest file, including the `<private>` opt-out).
+ *
+ * Cross-platform (Rule #1): temp dirs via os/path, capture driven by spawnSync
+ * with arg arrays, no shell or POSIX-only assumptions.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync, readdirSync } from 'fs';
+import { resolve, join } from 'path';
+
+import { scrubSecrets, containsSecret } from '../../bin/lib/pii-scrub.mjs';
+import {
+  SCORE,
+  DEFAULT_MAX_AGE_HOURS,
+  INJECT_MAX_CHARS,
+  KEEP_DIGESTS,
+  readContinuityConfig,
+  hasPrivateOptOut,
+  assembleDigestContent,
+  buildDigestMetadata,
+  scoreDigest,
+  selectBestDigest,
+  relativeTime,
+  formatInjection,
+  writeDigest,
+  readDigests,
+  rotateDigests,
+  continuityDir,
+} from '../../bin/lib/session-continuity.mjs';
+
+const CAPTURE_SCRIPT = resolve(__dirname, '../../bin/session-continuity.mjs');
+const HOUR = 3_600_000;
+
+function makeTempRoot(label: string): string {
+  const root = resolve(
+    __dirname,
+    '../../.testoutput/.test-continuity-' + label + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  return root;
+}
+function cleanTempRoot(root: string) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle hold — non-fatal */ }
+}
+
+// ── Secret scrubbing ────────────────────────────────────────────────────────
+
+describe('pii-scrub: scrubSecrets', () => {
+  it('redacts API keys, JWTs, tokens and private keys', () => {
+    const samples = [
+      'sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789',
+      'eyJhbGciOiAiSFMyNTYifQ.eyJzdWIiOiAiMTIzNDU2In0.dozjgNryP4J3jVmNHl0w',
+      'AKIAIOSFODNN7EXAMPLE',
+      'ghp_0123456789012345678901234567890123456789',
+      'export TOKEN=supersecretvalue123',
+    ];
+    for (const s of samples) {
+      const out = scrubSecrets(s);
+      expect(containsSecret(out)).toBe(false);
+      expect(out).toMatch(/REDACTED/);
+    }
+  });
+
+  it('redacts credentials embedded in a URL but keeps the host', () => {
+    const out = scrubSecrets('postgres://admin:hunter2@db.internal:5432/app');
+    expect(out).toContain('postgres://admin:[REDACTED]@');
+    expect(out).not.toContain('hunter2');
+  });
+
+  it('KEEPS benign context — file paths and branch names are not sensitive on local disk', () => {
+    const text = '**Stopped at:** on `feat/1185-continuity`, 3 uncommitted file(s) in src/cli/init/';
+    expect(scrubSecrets(text)).toBe(text);
+  });
+
+  it('is idempotent and safe on non-string input', () => {
+    const once = scrubSecrets('token=abcdef123456');
+    expect(scrubSecrets(once)).toBe(once);
+    expect(scrubSecrets(undefined as unknown as string)).toBe('');
+    expect(scrubSecrets(123 as unknown as string)).toBe('');
+  });
+});
+
+// ── Digest assembly ─────────────────────────────────────────────────────────
+
+describe('assembleDigestContent', () => {
+  it('emits only the sections that have content (non-reconstructable first)', () => {
+    const out = assembleDigestContent({
+      goal: 'Implement session continuity',
+      decisions: ['capture-on + gated inject', 'reject /flo:save'],
+      gitState: { branch: 'feat/x', lastCommit: 'wire capture', uncommittedCount: 2 },
+    });
+    expect(out).toContain('**Goal:** Implement session continuity');
+    expect(out).toContain('**Decisions this session:** capture-on + gated inject; reject /flo:save');
+    expect(out).toContain('**Stopped at:** on `feat/x`, last commit: "wire capture", 2 uncommitted file(s)');
+  });
+
+  it('returns empty string when nothing substantive was captured', () => {
+    expect(assembleDigestContent({})).toBe('');
+    expect(assembleDigestContent({ gitState: { branch: null } })).toBe('');
+  });
+});
+
+describe('buildDigestMetadata', () => {
+  it('flags unfinished work from uncommitted files', () => {
+    const m = buildDigestMetadata({ gitState: { branch: 'main', changedFiles: ['a.ts'], uncommittedCount: 1 }, sessionId: 's1', endedAt: 100 });
+    expect(m).toMatchObject({ branch: 'main', sessionId: 's1', endedAt: 100, hadUnfinished: true });
+    expect(m.changedFiles).toEqual(['a.ts']);
+  });
+  it('clean tree with no open threads is not unfinished', () => {
+    const m = buildDigestMetadata({ gitState: { branch: 'main', changedFiles: [], uncommittedCount: 0 } });
+    expect(m.hadUnfinished).toBe(false);
+  });
+});
+
+// ── Relevance scoring ───────────────────────────────────────────────────────
+
+describe('scoreDigest', () => {
+  const now = 1_000 * HOUR;
+  const fresh = now - HOUR; // 1h ago
+
+  it('feature-branch match + recency clears the inject threshold', () => {
+    const meta = { branch: 'feat/x', changedFiles: [], endedAt: fresh };
+    const s = scoreDigest(meta, { branch: 'feat/x', changedFiles: [] }, { now });
+    expect(s).toBeGreaterThanOrEqual(SCORE.INJECT_THRESHOLD);
+  });
+
+  it('mainline branch match alone does NOT clear the threshold (everyone is on main)', () => {
+    const meta = { branch: 'main', changedFiles: [], endedAt: fresh, hadUnfinished: false };
+    const s = scoreDigest(meta, { branch: 'main', changedFiles: [] }, { now });
+    expect(s).toBeLessThan(SCORE.INJECT_THRESHOLD);
+  });
+
+  it('mainline match + file overlap + unfinished does clear the threshold', () => {
+    const meta = { branch: 'main', changedFiles: ['src/a.ts', 'src/b.ts'], endedAt: fresh, hadUnfinished: true };
+    const s = scoreDigest(meta, { branch: 'main', changedFiles: ['src/a.ts', 'src/b.ts'] }, { now });
+    expect(s).toBeGreaterThanOrEqual(SCORE.INJECT_THRESHOLD);
+  });
+
+  it('returns 0 for digests older than maxAgeHours', () => {
+    const meta = { branch: 'feat/x', changedFiles: [], endedAt: now - 100 * HOUR };
+    expect(scoreDigest(meta, { branch: 'feat/x', changedFiles: [] }, { now, maxAgeHours: 72 })).toBe(0);
+  });
+
+  it('recency decays — older same-branch scores lower than fresher', () => {
+    const ctx = { branch: 'feat/x', changedFiles: [] };
+    const older = scoreDigest({ branch: 'feat/x', changedFiles: [], endedAt: now - 48 * HOUR }, ctx, { now });
+    const newer = scoreDigest({ branch: 'feat/x', changedFiles: [], endedAt: now - 1 * HOUR }, ctx, { now });
+    expect(newer).toBeGreaterThan(older);
+  });
+});
+
+describe('selectBestDigest', () => {
+  const now = 1_000 * HOUR;
+  const ctx = { branch: 'feat/x', changedFiles: ['src/a.ts'] };
+
+  it('picks the highest-scoring digest above threshold', () => {
+    const rows = [
+      { content: 'old', metadata: { branch: 'feat/x', changedFiles: [], endedAt: now - 40 * HOUR } },
+      { content: 'best', metadata: { branch: 'feat/x', changedFiles: ['src/a.ts'], endedAt: now - 1 * HOUR, hadUnfinished: true } },
+    ];
+    const best = selectBestDigest(rows, ctx, { now });
+    expect(best?.row.content).toBe('best');
+  });
+
+  it('returns null when nothing is relevant (fresh unrelated session)', () => {
+    const rows = [{ content: 'x', metadata: { branch: 'other-branch', changedFiles: [], endedAt: now - 50 * HOUR } }];
+    expect(selectBestDigest(rows, ctx, { now })).toBeNull();
+  });
+
+  it('skips empty-content rows and the excluded session', () => {
+    const rows = [
+      { content: '', metadata: { branch: 'feat/x', endedAt: now - HOUR } },
+      { content: 'self', metadata: { branch: 'feat/x', endedAt: now - HOUR, sessionId: 'me' } },
+    ];
+    expect(selectBestDigest(rows, ctx, { now, excludeSessionId: 'me' })).toBeNull();
+  });
+});
+
+// ── Formatting ──────────────────────────────────────────────────────────────
+
+describe('formatInjection', () => {
+  it('frames as a verifiable lead and stays under the size cap', () => {
+    const now = 10 * HOUR;
+    const out = formatInjection({ row: { content: 'X'.repeat(5000) }, meta: { endedAt: now - 3 * HOUR } }, now);
+    expect(out).toContain('Where you left off');
+    expect(out).toContain('verify current state before continuing');
+    expect(out).toContain('3 hours ago');
+    expect(out.length).toBeLessThanOrEqual(INJECT_MAX_CHARS);
+    expect(out.endsWith('…')).toBe(true);
+  });
+  it('returns empty for empty content', () => {
+    expect(formatInjection({ row: { content: '   ' }, meta: {} })).toBe('');
+  });
+});
+
+describe('relativeTime', () => {
+  it('humanises minutes / hours / days', () => {
+    const now = 1000 * HOUR;
+    expect(relativeTime(now - 30 * 60_000, now)).toBe('30 minutes ago');
+    expect(relativeTime(now - 5 * HOUR, now)).toBe('5 hours ago');
+    expect(relativeTime(now - 50 * HOUR, now)).toBe('2 days ago');
+  });
+});
+
+// ── Opt-out + config ────────────────────────────────────────────────────────
+
+describe('hasPrivateOptOut', () => {
+  it('detects the <private> tag case-insensitively', () => {
+    expect(hasPrivateOptOut('please <PRIVATE> do not store')).toBe(true);
+    expect(hasPrivateOptOut('normal message')).toBe(false);
+  });
+});
+
+describe('readContinuityConfig', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot('cfg'); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('defaults both flags on with no moflo.yaml', () => {
+    expect(readContinuityConfig(root)).toEqual({ capture: true, inject: true, maxAgeHours: DEFAULT_MAX_AGE_HOURS });
+  });
+
+  it('parses explicit false flags and max_age_hours', () => {
+    writeFileSync(resolve(root, 'moflo.yaml'), 'session_continuity:\n  capture: true\n  inject: false\n  max_age_hours: 24\n');
+    expect(readContinuityConfig(root)).toEqual({ capture: true, inject: false, maxAgeHours: 24 });
+  });
+});
+
+// ── Store round-trip ────────────────────────────────────────────────────────
+
+describe('JSON digest store', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot('store'); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('writeDigest → readDigests round-trips content + metadata', () => {
+    writeDigest(root, 'session-abc', { content: 'hello', metadata: { branch: 'feat/x', endedAt: 1 } });
+    const rows = readDigests(root);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe('hello');
+    expect(rows[0].metadata.branch).toBe('feat/x');
+  });
+
+  it('upserts by key — same session overwrites, does not accumulate', () => {
+    writeDigest(root, 'session-abc', { content: 'v1', metadata: {} });
+    writeDigest(root, 'session-abc', { content: 'v2', metadata: {} });
+    const rows = readDigests(root);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe('v2');
+  });
+
+  it('rotateDigests keeps only the most recent KEEP_DIGESTS', () => {
+    for (let i = 0; i < KEEP_DIGESTS + 5; i++) {
+      writeDigest(root, `session-${i}`, { content: `c${i}`, metadata: { endedAt: i } });
+    }
+    rotateDigests(root);
+    const files = readdirSync(continuityDir(root)).filter((f) => f.endsWith('.json'));
+    expect(files.length).toBe(KEEP_DIGESTS);
+  });
+
+  it('readDigests tolerates a malformed file', () => {
+    mkdirSync(continuityDir(root), { recursive: true });
+    writeFileSync(join(continuityDir(root), 'broken.json'), '{ not valid json');
+    writeDigest(root, 'good', { content: 'ok', metadata: {} });
+    const rows = readDigests(root);
+    expect(rows.map((r) => r.content)).toContain('ok');
+  });
+});
+
+// ── End-to-end capture subprocess ───────────────────────────────────────────
+
+function runCapture(root: string, input: object) {
+  return spawnSync('node', [CAPTURE_SCRIPT, 'capture'], {
+    cwd: root,
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    timeout: 20_000,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+  });
+}
+
+function writeTranscript(root: string, userMessages: string[]): string {
+  const p = resolve(root, 'transcript.jsonl');
+  const lines = userMessages.map((m) => JSON.stringify({ type: 'user', message: { role: 'user', content: m } }));
+  writeFileSync(p, lines.join('\n') + '\n', 'utf-8');
+  return p;
+}
+
+describe('capture subprocess (end-to-end)', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot('e2e'); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('writes a scrubbed digest from the session goal', () => {
+    const transcript = writeTranscript(root, ['Implement the new export feature with key sk-ant-secret0123456789abcdefghij']);
+    const r = runCapture(root, { session_id: 'sess-1', transcript_path: transcript });
+    expect(r.status).toBe(0);
+
+    const rows = readDigests(root);
+    expect(rows.length).toBe(1);
+    expect(rows[0].content).toContain('Implement the new export feature');
+    // The secret that rode in on the goal text must be scrubbed before persist.
+    expect(rows[0].content).not.toContain('sk-ant-secret');
+    expect(containsSecret(rows[0].content)).toBe(false);
+    expect(rows[0].metadata.sessionId).toBe('sess-1');
+  });
+
+  it('honors the <private> opt-out — no digest is written', () => {
+    const transcript = writeTranscript(root, ['<private> work on the secret prototype, do not remember this']);
+    const r = runCapture(root, { session_id: 'sess-2', transcript_path: transcript });
+    expect(r.status).toBe(0);
+    expect(existsSync(continuityDir(root))).toBe(false);
+  });
+
+  it('respects capture: false in moflo.yaml', () => {
+    writeFileSync(resolve(root, 'moflo.yaml'), 'session_continuity:\n  capture: false\n');
+    const transcript = writeTranscript(root, ['Some goal worth remembering']);
+    const r = runCapture(root, { session_id: 'sess-3', transcript_path: transcript });
+    expect(r.status).toBe(0);
+    expect(existsSync(continuityDir(root))).toBe(false);
+  });
+});

--- a/tests/bin/yaml-upgrader.test.ts
+++ b/tests/bin/yaml-upgrader.test.ts
@@ -95,8 +95,11 @@ describe('yaml-upgrader', () => {
       expect(content).toContain('tier: auto');
     });
 
-    it('is idempotent when sandbox is already present', () => {
-      const existing = 'project:\n  name: foo\nsandbox:\n  enabled: true\n  tier: full\n';
+    it('is idempotent when all required sections are already present', () => {
+      const existing =
+        'project:\n  name: foo\n' +
+        'session_continuity:\n  capture: true\n  inject: true\n' +
+        'sandbox:\n  enabled: true\n  tier: full\n';
       writeFileSync(yamlPath, existing, 'utf-8');
 
       const firstRun = ensureYamlSections(yamlPath);

--- a/tests/system/no-fixed-3117-port.test.ts
+++ b/tests/system/no-fixed-3117-port.test.ts
@@ -32,6 +32,11 @@ const REPO_ROOT = resolve(__dirname, '..', '..');
 const ALLOWLIST = new Set<string>([
   'src/cli/services/daemon-port.ts',
   'bin/lib/daemon-port.mjs',
+  // Dogfood mirror twin of bin/lib/daemon-port.mjs — same LEGACY_DEFAULT_PORT
+  // constant. .claude/scripts/ is the byte-for-byte mirror a consumer's launcher
+  // syncs from bin/ (#1185 restored it after dogfood drift), so it carries the
+  // same allowlisted resolver.
+  '.claude/scripts/lib/daemon-port.mjs',
   'tests/system/no-fixed-3117-port.test.ts',
   'docs/internal/1145-daemon-port-collision-analysis.md',
   'CHANGELOG.md',


### PR DESCRIPTION
## What

Implements **#1185** — a passive session-continuity loop so Claude picks up where you left off across sessions.

**Owner sign-off (this issue gated on it):** default = **capture-on + relevance-gated injection**.

- **Capture** — default-on, silent, mechanical-first. On each turn-end (Stop hook, throttled to ≤1/30s) moflo assembles a compact digest from data it already has — git state, recent `learnings` (read-only), the session goal — scrubs secrets, and writes one record per session.
- **Injection** — default-on but **relevance-gated**. At session-start moflo scores recent digests (branch match, changed-file overlap, recency decay, unfinished-work bonus) and injects **only the single best one if it clears a threshold**, hard-capped (~250 tokens), framed as a *verifiable lead* ("verify current state before continuing"). A fresh, unrelated session injects **nothing** — this is what keeps it from going context-negative.

Prior art brackets the design space: claude-mem injects ~10 sessions every start (context tax → ignored); SuperClaude is manual `/sc:save` (forgotten → empty). The sweet spot is passive capture + gated injection.

## Key design decisions

- **Storage: dedicated `.moflo/continuity/` JSON store, NOT `moflo.db`.** Capture fires while the daemon is live; the moflo.db writer audit (`docs/internal/1054-writer-audit.md`) requires cross-process DB writers to route through the daemon chokepoint. A separate JSON store sidesteps that entirely, avoids cross-process clobber, and keeps non-semantic digests out of the HNSW/embeddings pipeline. Capture still *reads* `learnings` read-only (safe under WAL).
- **Content = non-reconstructable only** (goal, decisions, where-you-stopped). Git facts the next session can re-derive for free are a single anchor line, not the payload — that's the difference between making Claude *effective* vs merely *informed*.
- **Privacy:** secrets scrubbed via the new `bin/lib/pii-scrub.mjs` (local-disk threat model) before persist; `<private>` in any session message skips capture; `session_continuity.{capture,inject}` kill switches in `moflo.yaml`.
- **Reach:** self-heals into existing consumers via the `hook-wiring` registry, not just fresh `flo init`.

## Files

**New**
- `bin/session-continuity.mjs` — Stop-hook capture orchestrator
- `bin/lib/session-continuity.mjs` — pure logic (config, git, assembly, scoring, store)
- `bin/lib/pii-scrub.mjs` — credential scrubber
- `tests/bin/session-continuity.test.ts` — scrub, scoring, store, capture e2e (29 tests)

**Wired**
- `session-start-launcher.mjs` — relevance-gated injection (no DB open)
- `settings-generator.ts` + `hook-wiring.ts` + `hook-block-hash.ts` — Stop capture hook (+ existing-consumer self-heal + drift-hash reference)
- `moflo-config.ts` + `moflo-yaml-template.ts` + `yaml-upgrader.mjs` — `session_continuity` block
- `shipped-scripts.json` — `session-continuity.mjs` scriptFile (single-source manifest from #1191)

## Testing

- New suite: 29 tests (secret scrub incl. idempotency, relevance scoring incl. mainline/age/recency edges, JSON store round-trip + rotation, end-to-end capture subprocess incl. `<private>` opt-out + `capture:false`).
- **Full repo suite green: 9038 passed / 0 failed.** Both consumer smoke harnesses green on Windows (49/0 and 31/0) — `probe:session-start-launcher` confirms injection doesn't break consumer session-start. CI covers Linux/macOS.
- `/flo-simplify`: NORMAL tier (3 agents); findings triaged — clock-skew age clamp, `budget<=0` guard, stdin-handler guard, `rotateDigests` stat-sweep skip, bounded injection read all applied; false positives rejected with reasons.

## Cross-platform (Rule #1)

Node `fs`/`path`/`child_process` only; `spawnSync` with arg arrays (no shell, no `2>/dev/null`); git porcelain `/`-paths compared consistently on every OS; atomic temp+rename writes.

## Acceptance criteria

- [x] Compact digest persisted to a dedicated namespace after a session
- [x] Next session-start injects the digest (size-capped, relevance-gated)
- [x] Capture + injection non-blocking
- [x] Opt-out honored; secrets scrubbed before persist
- [x] Graceful degradation on missing/locked DB (store is separate; learnings read is best-effort)
- [x] Smoke-harness green (Windows verified; CI covers Linux/macOS)

Filed alongside: #1193 (pre-existing `transfer/anonymization` apiKey gap found during review).

Closes #1185

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
