### PR TITLE
fix(transfer): redact sk-ant-/GitHub/AWS/Slack/Google/PEM secrets in CFP anonymizer (#1193)

### DIFF
--- a/src/cli/__tests__/plugins-transfer-deep.test.ts
+++ b/src/cli/__tests__/plugins-transfer-deep.test.ts
@@ -620,89 +620,91 @@ import {
 } from '../transfer/anonymization/index.js';
 
 describe('Anonymization', () => {
-  it('should detect email PII', () => {
-    const result = detectPII('Contact user@example.com for support');
+  it('should detect email PII', async () => {
+    const result = await detectPII('Contact user@example.com for support');
     expect(result.found).toBe(true);
     expect(result.types.email).toBe(1);
   });
 
-  it('should detect phone PII', () => {
-    const result = detectPII('Call 555-123-4567 for help');
+  it('should detect phone PII', async () => {
+    const result = await detectPII('Call 555-123-4567 for help');
     expect(result.found).toBe(true);
     expect(result.types.phone).toBe(1);
   });
 
-  it('should detect IPv4 PII', () => {
-    const result = detectPII('Server at 192.168.1.100');
+  it('should detect IPv4 PII', async () => {
+    const result = await detectPII('Server at 192.168.1.100');
     expect(result.found).toBe(true);
     expect(result.types.ipv4).toBe(1);
   });
 
-  it('should detect API key PII', () => {
-    const result = detectPII('Use sk-abcdefghijklmnopqrstuvwxyz123456');
+  it('should detect API key PII', async () => {
+    const result = await detectPII('Use sk-abcdefghijklmnopqrstuvwxyz123456');
     expect(result.found).toBe(true);
-    expect(result.types.apiKey).toBe(1);
+    // Secret shapes now come from the shared pii-scrub.mjs set, where the
+    // OpenAI/Anthropic key shape is named 'openai-anthropic-key' (#1193).
+    expect(result.types['openai-anthropic-key']).toBe(1);
   });
 
-  it('should detect JWT PII', () => {
-    const result = detectPII('Token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc_def-ghi');
+  it('should detect JWT PII', async () => {
+    const result = await detectPII('Token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc_def-ghi');
     expect(result.found).toBe(true);
     expect(result.types.jwt).toBe(1);
   });
 
-  it('should detect home path PII', () => {
-    const result = detectPII('File at /Users/johndoe/Documents');
+  it('should detect home path PII', async () => {
+    const result = await detectPII('File at /Users/johndoe/Documents');
     expect(result.found).toBe(true);
     expect(result.types.homePath).toBe(1);
   });
 
-  it('should not find PII in clean content', () => {
-    const result = detectPII('Just a normal description with no personal data');
+  it('should not find PII in clean content', async () => {
+    const result = await detectPII('Just a normal description with no personal data');
     expect(result.found).toBe(false);
     expect(result.count).toBe(0);
   });
 
-  it('should redact email', () => {
-    const redacted = redactPII('Contact user@example.com');
+  it('should redact email', async () => {
+    const redacted = await redactPII('Contact user@example.com');
     expect(redacted).not.toContain('user@example.com');
     expect(redacted).toContain('@example.com');
   });
 
-  it('should redact IP addresses', () => {
-    const redacted = redactPII('Server: 192.168.1.1');
+  it('should redact IP addresses', async () => {
+    const redacted = await redactPII('Server: 192.168.1.1');
     expect(redacted).toContain('0.0.0.0');
   });
 
-  it('should redact API keys', () => {
-    const redacted = redactPII('Key: sk-abcdefghijklmnopqrstuvwxyz123456');
+  it('should redact API keys', async () => {
+    const redacted = await redactPII('Key: sk-abcdefghijklmnopqrstuvwxyz123456');
     expect(redacted).toContain('[REDACTED_API_KEY]');
   });
 
-  it('should apply minimal anonymization (remove author name)', () => {
+  it('should apply minimal anonymization (remove author name)', async () => {
     const cfp = createCFP({
       name: 'anon-test',
       description: 'test',
       patterns: createMockPatterns(),
       author: { id: 'auth1', displayName: 'John Doe' },
     });
-    const { cfp: anonymized, transforms } = anonymizeCFP(cfp, 'minimal');
+    const { cfp: anonymized, transforms } = await anonymizeCFP(cfp, 'minimal');
     expect(anonymized.metadata.author?.displayName).toBeUndefined();
     expect(transforms).toContain('author-name-removed');
   });
 
-  it('should apply standard anonymization (PII redacted)', () => {
+  it('should apply standard anonymization (PII redacted)', async () => {
     const patterns = createMockPatterns();
     patterns.routing[0].context = { note: 'Contact user@example.com' };
     const cfp = createCFP({ name: 'std', description: 'test', patterns });
-    const { cfp: anonymized, transforms } = anonymizeCFP(cfp, 'standard');
+    const { cfp: anonymized, transforms } = await anonymizeCFP(cfp, 'standard');
     expect(transforms).toContain('pii-redacted');
     expect(transforms).toContain('timestamps-generalized');
     expect(anonymized.anonymization.piiRedacted).toBe(true);
   });
 
-  it('should apply strict anonymization (hash IDs, remove context)', () => {
+  it('should apply strict anonymization (hash IDs, remove context)', async () => {
     const cfp = createCFP({ name: 'strict', description: 'test', patterns: createMockPatterns() });
-    const { cfp: anonymized, transforms } = anonymizeCFP(cfp, 'strict');
+    const { cfp: anonymized, transforms } = await anonymizeCFP(cfp, 'strict');
     expect(transforms).toContain('ids-hashed');
     expect(transforms).toContain('context-removed');
     expect(transforms).toContain('paths-stripped');
@@ -710,21 +712,124 @@ describe('Anonymization', () => {
     expect(anonymized.patterns.routing[0].id).toMatch(/^pattern_/);
   });
 
-  it('should apply paranoid anonymization (differential privacy, remove learnings)', () => {
+  it('should apply paranoid anonymization (differential privacy, remove learnings)', async () => {
     const cfp = createCFP({ name: 'paranoid', description: 'test', patterns: createMockPatterns() });
-    const { cfp: anonymized, transforms } = anonymizeCFP(cfp, 'paranoid');
+    const { cfp: anonymized, transforms } = await anonymizeCFP(cfp, 'paranoid');
     expect(transforms).toContain('differential-privacy-noise');
     expect(transforms).toContain('learnings-removed');
     // Trajectory learnings should be empty
     expect(anonymized.patterns.trajectory[0].learnings).toHaveLength(0);
   });
 
-  it('scanCFPForPII detects PII in patterns', () => {
+  it('scanCFPForPII detects PII in patterns', async () => {
     const patterns = createMockPatterns();
     patterns.routing[0].context = { email: 'test@pii.com' };
     const cfp = createCFP({ name: 'scan', description: 'test', patterns });
-    const result = scanCFPForPII(cfp);
+    const result = await scanCFPForPII(cfp);
     expect(result.found).toBe(true);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// #1193 — modern secret shapes single-sourced from bin/lib/pii-scrub.mjs.
+// The pre-#1193 `apiKey` regex (`(sk-|pk-|api_key)[a-z0-9]{20,}`) broke on the
+// first hyphen of `sk-ant-…`, so live Anthropic/GitHub/AWS/Slack/Google keys and
+// PEM blocks could survive anonymization and leak in an externally-shared CFP.
+// detectPII/redactPII now load the shared SECRET_PATTERNS, so each shape below
+// must be both detected and redacted.
+// ----------------------------------------------------------------------------
+describe('Anonymization — modern secret shapes (#1193)', () => {
+  const SECRET_SHAPES: Array<{
+    label: string;
+    sample: string;
+    typeName: string;
+    redactedTo: string;
+  }> = [
+    {
+      label: 'Anthropic sk-ant- key',
+      sample: 'sk-ant-api03-AABBCCDDEEFFGGHHIIJJKKLL',
+      typeName: 'openai-anthropic-key',
+      redactedTo: '[REDACTED_API_KEY]',
+    },
+    {
+      label: 'GitHub classic token (ghp_)',
+      sample: 'ghp_0123456789ABCDEFGHIJ0123456789abcdefij',
+      typeName: 'github-token',
+      redactedTo: '[REDACTED_GITHUB_TOKEN]',
+    },
+    {
+      label: 'GitHub fine-grained PAT (github_pat_)',
+      sample: 'github_pat_0123456789abcdefghij012345',
+      typeName: 'github-token',
+      redactedTo: '[REDACTED_GITHUB_TOKEN]',
+    },
+    {
+      label: 'AWS access key (AKIA)',
+      sample: 'AKIAIOSFODNN7EXAMPLE',
+      typeName: 'aws-access-key',
+      redactedTo: '[REDACTED_AWS_KEY]',
+    },
+    {
+      label: 'Slack token (xoxb-)',
+      sample: 'xoxb-1234567890-abcdefghij',
+      typeName: 'slack-token',
+      redactedTo: '[REDACTED_SLACK_TOKEN]',
+    },
+    {
+      label: 'Google API key (AIza)',
+      sample: `AIza${'b'.repeat(35)}`,
+      typeName: 'google-api-key',
+      redactedTo: '[REDACTED_GOOGLE_KEY]',
+    },
+  ];
+
+  for (const { label, sample, typeName, redactedTo } of SECRET_SHAPES) {
+    it(`detects ${label}`, async () => {
+      const result = await detectPII(`Found ${sample} in the logs`);
+      expect(result.found).toBe(true);
+      expect(result.types[typeName] ?? 0).toBeGreaterThanOrEqual(1);
+      // Secret shapes are always reported as the highest severity.
+      const loc = result.locations.find((l) => l.type === typeName);
+      expect(loc?.severity).toBe('critical');
+    });
+
+    it(`redacts ${label}`, async () => {
+      const redacted = await redactPII(`Found ${sample} in the logs`);
+      expect(redacted).not.toContain(sample);
+      expect(redacted).toContain(redactedTo);
+    });
+  }
+
+  const PEM_BLOCK = [
+    '-----BEGIN RSA PRIVATE KEY-----',
+    'MIIEpAIBAAKCAQEA0123456789abcdefghijklmnopqrstuvwxyz0123456789AB',
+    'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz0123',
+    '-----END RSA PRIVATE KEY-----',
+  ].join('\n');
+
+  it('detects PEM private-key blocks', async () => {
+    const result = await detectPII(`config:\n${PEM_BLOCK}\nend`);
+    expect(result.found).toBe(true);
+    expect(result.types['private-key'] ?? 0).toBeGreaterThanOrEqual(1);
+  });
+
+  it('redacts PEM private-key blocks', async () => {
+    const redacted = await redactPII(`config:\n${PEM_BLOCK}\nend`);
+    expect(redacted).not.toContain('BEGIN RSA PRIVATE KEY');
+    expect(redacted).toContain('[REDACTED_PRIVATE_KEY]');
+  });
+
+  it('anonymizeCFP redacts an Anthropic key embedded in pattern context', async () => {
+    const patterns = createMockPatterns();
+    patterns.routing[0].context = {
+      note: 'deploy used sk-ant-api03-AABBCCDDEEFFGGHHIIJJKKLL last run',
+    };
+    const cfp = createCFP({ name: 'secret-leak', description: 'test', patterns });
+    const { cfp: anonymized, transforms } = await anonymizeCFP(cfp, 'standard');
+    const serialized = JSON.stringify(anonymized.patterns);
+    expect(transforms).toContain('pii-redacted');
+    expect(serialized).not.toContain('sk-ant-api03');
+    expect(serialized).toContain('[REDACTED_API_KEY]');
   });
 });
 

--- a/src/cli/__tests__/plugins-transfer-deep.test.ts
+++ b/src/cli/__tests__/plugins-transfer-deep.test.ts
@@ -831,6 +831,32 @@ describe('Anonymization — modern secret shapes (#1193)', () => {
     expect(serialized).not.toContain('sk-ant-api03');
     expect(serialized).toContain('[REDACTED_API_KEY]');
   });
+
+  it('anonymizeCFP redacts a secret pasted into free-text metadata', async () => {
+    const cfp = createCFP({
+      name: 'note xoxb-1234567890-abcdefghij here',
+      description: 'deploy used sk-ant-api03-AABBCCDDEEFFGGHHIIJJKKLL last run',
+      patterns: createMockPatterns(),
+      tags: ['ghp_0123456789ABCDEFGHIJ0123456789abcdefij'],
+    });
+    const { cfp: anonymized } = await anonymizeCFP(cfp, 'standard');
+    expect(anonymized.metadata.description).not.toContain('sk-ant-api03');
+    expect(anonymized.metadata.description).toContain('[REDACTED_API_KEY]');
+    expect(anonymized.metadata.name).not.toContain('xoxb-1234567890');
+    expect(anonymized.metadata.tags.join(',')).not.toContain('ghp_0123456789');
+    expect(anonymized.metadata.tags.join(',')).toContain('[REDACTED_GITHUB_TOKEN]');
+  });
+
+  it('scanCFPForPII detects a secret in metadata.description', async () => {
+    const cfp = createCFP({
+      name: 'scan-meta',
+      description: 'token is sk-ant-api03-AABBCCDDEEFFGGHHIIJJKKLL',
+      patterns: createMockPatterns(),
+    });
+    const result = await scanCFPForPII(cfp);
+    expect(result.found).toBe(true);
+    expect(result.types['openai-anthropic-key'] ?? 0).toBeGreaterThanOrEqual(1);
+  });
 });
 
 // ============================================================================

--- a/src/cli/transfer/anonymization/index.ts
+++ b/src/cli/transfer/anonymization/index.ts
@@ -1,43 +1,122 @@
 /**
  * Anonymization Pipeline
- * PII detection and redaction for pattern export
+ * PII detection and redaction before a CFP is shared **externally**.
+ *
+ * ── Secret-pattern sourcing (#1193) ─────────────────────────────────────────
+ * The secret/credential *detection shapes* (Anthropic/OpenAI `sk-`/`sk-ant-`
+ * keys, GitHub `ghp_`/`github_pat_`, AWS `AKIA…`, Slack `xox…`, Google `AIza…`,
+ * JWTs, PEM private-key blocks, bearer / url / assigned secrets) are
+ * SINGLE-SOURCED from the session-continuity scrubber `bin/lib/pii-scrub.mjs`
+ * (its exported `SECRET_PATTERNS` + `scrubSecrets`).
+ *
+ * Before #1193 this module carried its own narrow `apiKey` regex
+ * (`/\b(sk-|pk-|api[_-]?key[_-]?)[a-zA-Z0-9]{20,}\b/gi`). For `sk-ant-api03-…`
+ * the hyphen after `sk-ant` broke the `[a-zA-Z0-9]{20,}` run, so a *live*
+ * Anthropic key — plus GitHub/AWS/Slack tokens — survived anonymization and
+ * could leak in a CFP published externally. Rather than re-type the broader
+ * shapes here (which would drift from the scrubber), we load the canonical set.
+ *
+ * The two modules keep DIFFERENT threat models, so only the SECRET shapes are
+ * shared, not the policies:
+ *   - `pii-scrub.mjs` protects the user's OWN local disk → deliberately KEEPS
+ *     benign context (file paths, IPs) and only nukes literal secrets.
+ *   - this module pseudonymises for EXTERNAL publication → additionally strips
+ *     emails / phones / IPs / home paths. Those non-secret PII patterns and
+ *     their replacement policy stay defined locally below.
+ *
+ * ── Cross-boundary loading (CLAUDE.md Rule #1 + dogfooding) ──────────────────
+ * `bin/lib/pii-scrub.mjs` lives outside this module's TypeScript compile unit.
+ * A static `../../../../bin/lib/pii-scrub.mjs` import is the banned depth-mismatch
+ * anti-pattern (the path differs between `src/cli/**` and `dist/src/cli/**`), so
+ * the scrubber is reached the sanctioned way: `locateMofloRootPath()` (the
+ * shared moflo-package anchor, which also existence-checks) + `pathToFileURL()`
+ * + dynamic `import()`. `pathToFileURL` is what makes the ESM
+ * `import()` work on Windows; the join is platform-agnostic. That dynamic load
+ * is why `detectPII` / `redactPII` / `anonymizeCFP` / `scanCFPForPII` are async.
+ *
+ * The loader is fail-CLOSED: if the scrubber can't be resolved we throw rather
+ * than silently export un-redacted content — a credential leak is the worse
+ * outcome for an external-share path.
  */
 
 import type {
   CFPFormat,
   AnonymizationLevel,
-  AnonymizationRecord,
   PIIDetectionResult,
 } from '../types.js';
 import * as crypto from 'crypto';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { locateMofloRootPath } from '../../services/moflo-require.js';
 
 /**
- * PII detection patterns
+ * Non-secret PII detection patterns owned by THIS module's external-share
+ * policy. Secret shapes are NOT here — they come from `bin/lib/pii-scrub.mjs`
+ * (see file header) so they only have to be maintained in one place.
  */
-const PII_PATTERNS = {
+const PII_PATTERNS: Record<string, RegExp> = {
   email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g,
   phone: /\b(\+?\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g,
   ipv4: /\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/g,
   ipv6: /\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b/g,
-  apiKey: /\b(sk-|pk-|api[_-]?key[_-]?)[a-zA-Z0-9]{20,}\b/gi,
-  jwt: /\beyJ[a-zA-Z0-9_-]*\.eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]*\b/g,
   homePath: /\/(Users|home|Documents)\/[a-zA-Z0-9_.-]+/g,
   windowsPath: /[A-Z]:\\Users\\[a-zA-Z0-9_.-]+/g,
 };
 
 /**
- * Redaction replacements
+ * Replacement policy for the local non-secret PII patterns above. Secret
+ * replacements are applied by `scrubSecrets` from the shared module.
  */
 const REDACTIONS: Record<string, string | ((match: string) => string)> = {
   email: (match) => `user_${hash(match).slice(0, 8)}@example.com`,
   phone: '[REDACTED_PHONE]',
   ipv4: '0.0.0.0',
   ipv6: '::1',
-  apiKey: '[REDACTED_API_KEY]',
-  jwt: '[REDACTED_JWT]',
   homePath: '/user/anonymous',
   windowsPath: 'C:\\Users\\anonymous',
 };
+
+/** One secret-shape entry as exported by `bin/lib/pii-scrub.mjs`. */
+interface SecretPattern {
+  name: string;
+  pattern: RegExp;
+  replace: string | ((...args: any[]) => string);
+}
+
+interface PiiScrubModule {
+  SECRET_PATTERNS: SecretPattern[];
+  scrubSecrets: (text: string) => string;
+}
+
+/**
+ * Lazily import the shared scrubber once per process and cache the promise.
+ * Fail-closed: a missing/garbled scrubber throws so the export aborts instead
+ * of shipping un-redacted credentials.
+ */
+let piiScrubPromise: Promise<PiiScrubModule> | null = null;
+
+function loadPiiScrub(): Promise<PiiScrubModule> {
+  if (!piiScrubPromise) {
+    piiScrubPromise = (async () => {
+      const scrubPath = locateMofloRootPath(join('bin', 'lib', 'pii-scrub.mjs'));
+      if (!scrubPath) {
+        throw new Error(
+          '[anonymization] bin/lib/pii-scrub.mjs not found under the moflo package root — ' +
+            'refusing to anonymize without the shared secret scrubber (would risk leaking ' +
+            'credentials in an external share).'
+        );
+      }
+      const mod = (await import(pathToFileURL(scrubPath).href)) as Partial<PiiScrubModule>;
+      if (!Array.isArray(mod.SECRET_PATTERNS) || typeof mod.scrubSecrets !== 'function') {
+        throw new Error(
+          '[anonymization] bin/lib/pii-scrub.mjs is missing SECRET_PATTERNS/scrubSecrets — broken moflo install.'
+        );
+      }
+      return mod as PiiScrubModule;
+    })();
+  }
+  return piiScrubPromise;
+}
 
 /**
  * Hash a string for consistent pseudonymization
@@ -47,9 +126,10 @@ function hash(input: string): string {
 }
 
 /**
- * Detect PII in a string
+ * Detect PII in a string. Combines the shared secret shapes (always `critical`)
+ * with this module's local non-secret PII patterns.
  */
-export function detectPII(content: string): PIIDetectionResult {
+export async function detectPII(content: string): Promise<PIIDetectionResult> {
   const result: PIIDetectionResult = {
     found: false,
     count: 0,
@@ -57,35 +137,47 @@ export function detectPII(content: string): PIIDetectionResult {
     locations: [],
   };
 
-  for (const [type, pattern] of Object.entries(PII_PATTERNS)) {
+  const record = (
+    type: string,
+    pattern: RegExp,
+    severity: 'low' | 'medium' | 'high' | 'critical'
+  ): void => {
+    // Reset lastIndex defensively — these regexes are module-shared and carry
+    // /g, so a prior .test()/.exec() elsewhere must not leak state.
+    pattern.lastIndex = 0;
     const matches = content.match(pattern);
-    if (matches) {
-      result.found = true;
-      result.count += matches.length;
-      result.types[type] = matches.length;
-
-      for (const match of matches.slice(0, 5)) { // Limit to first 5 samples
-        result.locations.push({
-          type,
-          path: 'content',
-          sample: match.slice(0, 20) + (match.length > 20 ? '...' : ''),
-          severity: getSeverity(type),
-        });
-      }
+    if (!matches) return;
+    result.found = true;
+    result.count += matches.length;
+    result.types[type] = (result.types[type] ?? 0) + matches.length;
+    for (const match of matches.slice(0, 5)) {
+      // Limit to first 5 samples
+      result.locations.push({
+        type,
+        path: 'content',
+        sample: match.slice(0, 20) + (match.length > 20 ? '...' : ''),
+        severity,
+      });
     }
+  };
+
+  const { SECRET_PATTERNS } = await loadPiiScrub();
+  for (const { name, pattern } of SECRET_PATTERNS) {
+    record(name, pattern, 'critical');
+  }
+  for (const [type, pattern] of Object.entries(PII_PATTERNS)) {
+    record(type, pattern, getSeverity(type));
   }
 
   return result;
 }
 
 /**
- * Get severity for PII type
+ * Get severity for a local (non-secret) PII type. Secret shapes are always
+ * reported as `critical` by `detectPII`, so they never reach this helper.
  */
 function getSeverity(type: string): 'low' | 'medium' | 'high' | 'critical' {
   switch (type) {
-    case 'apiKey':
-    case 'jwt':
-      return 'critical';
     case 'email':
     case 'phone':
       return 'high';
@@ -98,18 +190,18 @@ function getSeverity(type: string): 'low' | 'medium' | 'high' | 'critical' {
 }
 
 /**
- * Redact PII from a string
+ * Redact PII from a string. Secrets are removed first via the shared scrubber
+ * (broad vendor-token coverage), then this module's external-share PII policy
+ * pseudonymises emails / phones / IPs / home paths.
  */
-export function redactPII(content: string): string {
-  let result = content;
+export async function redactPII(content: string): Promise<string> {
+  const { scrubSecrets } = await loadPiiScrub();
+  let result = scrubSecrets(content);
 
   for (const [type, pattern] of Object.entries(PII_PATTERNS)) {
+    pattern.lastIndex = 0;
     const replacement = REDACTIONS[type];
-    if (typeof replacement === 'function') {
-      result = result.replace(pattern, replacement);
-    } else {
-      result = result.replace(pattern, replacement);
-    }
+    result = result.replace(pattern, replacement as string);
   }
 
   return result;
@@ -118,10 +210,10 @@ export function redactPII(content: string): string {
 /**
  * Apply anonymization to CFP document
  */
-export function anonymizeCFP(
+export async function anonymizeCFP(
   cfp: CFPFormat,
   level: AnonymizationLevel
-): { cfp: CFPFormat; transforms: string[] } {
+): Promise<{ cfp: CFPFormat; transforms: string[] }> {
   const transforms: string[] = [];
   const anonymized = JSON.parse(JSON.stringify(cfp)) as CFPFormat;
 
@@ -138,7 +230,7 @@ export function anonymizeCFP(
   if (['standard', 'strict', 'paranoid'].includes(level)) {
     // Redact PII from all string fields
     const jsonStr = JSON.stringify(anonymized.patterns);
-    const redacted = redactPII(jsonStr);
+    const redacted = await redactPII(jsonStr);
     anonymized.patterns = JSON.parse(redacted);
     transforms.push('pii-redacted');
 
@@ -201,7 +293,7 @@ export function anonymizeCFP(
 /**
  * Scan CFP for PII without modification
  */
-export function scanCFPForPII(cfp: CFPFormat): PIIDetectionResult {
+export async function scanCFPForPII(cfp: CFPFormat): Promise<PIIDetectionResult> {
   const content = JSON.stringify(cfp.patterns);
   return detectPII(content);
 }

--- a/src/cli/transfer/anonymization/index.ts
+++ b/src/cli/transfer/anonymization/index.ts
@@ -113,7 +113,13 @@ function loadPiiScrub(): Promise<PiiScrubModule> {
         );
       }
       return mod as PiiScrubModule;
-    })();
+    })().catch((err) => {
+      // Never cache a rejected promise — a transient/early failure must not
+      // poison every later anonymize call. Clear the singleton so a subsequent
+      // call re-attempts the load (still fail-closed: it re-throws here).
+      piiScrubPromise = null;
+      throw err;
+    });
   }
   return piiScrubPromise;
 }
@@ -201,7 +207,13 @@ export async function redactPII(content: string): Promise<string> {
   for (const [type, pattern] of Object.entries(PII_PATTERNS)) {
     pattern.lastIndex = 0;
     const replacement = REDACTIONS[type];
-    result = result.replace(pattern, replacement as string);
+    // Narrow the union for `String.replace`'s overloads: email is a function
+    // replacer, the rest are literal strings. A blanket `as string` cast would
+    // mis-describe (and risk silently breaking) the function case.
+    result =
+      typeof replacement === 'function'
+        ? result.replace(pattern, replacement)
+        : result.replace(pattern, replacement);
   }
 
   return result;
@@ -228,10 +240,27 @@ export async function anonymizeCFP(
 
   // Level: Standard
   if (['standard', 'strict', 'paranoid'].includes(level)) {
-    // Redact PII from all string fields
+    // Redact secrets/PII from the patterns body...
     const jsonStr = JSON.stringify(anonymized.patterns);
     const redacted = await redactPII(jsonStr);
     anonymized.patterns = JSON.parse(redacted);
+
+    // ...and from free-text metadata (name / description / tags), which is the
+    // SAME external-share leak vector (#1193): a secret pasted into a CFP's
+    // description or a tag would otherwise survive at every level. The rest of
+    // metadata is structured (ids, timestamps, license); author displayName was
+    // already dropped at the minimal level above.
+    if (anonymized.metadata.name) {
+      anonymized.metadata.name = await redactPII(anonymized.metadata.name);
+    }
+    if (anonymized.metadata.description) {
+      anonymized.metadata.description = await redactPII(anonymized.metadata.description);
+    }
+    if (Array.isArray(anonymized.metadata.tags) && anonymized.metadata.tags.length > 0) {
+      anonymized.metadata.tags = await Promise.all(
+        anonymized.metadata.tags.map((tag) => redactPII(tag))
+      );
+    }
     transforms.push('pii-redacted');
 
     // Generalize timestamps
@@ -294,6 +323,15 @@ export async function anonymizeCFP(
  * Scan CFP for PII without modification
  */
 export async function scanCFPForPII(cfp: CFPFormat): Promise<PIIDetectionResult> {
-  const content = JSON.stringify(cfp.patterns);
+  // Scan the same surface anonymizeCFP redacts: the patterns body plus the
+  // free-text metadata fields (name / description / tags) — so the scan can't
+  // report "clean" on a CFP whose description carries a secret (#1193).
+  const meta = cfp.metadata;
+  const content = JSON.stringify({
+    patterns: cfp.patterns,
+    name: meta?.name,
+    description: meta?.description,
+    tags: meta?.tags,
+  });
   return detectPII(content);
 }

--- a/src/cli/transfer/deploy-seraphine.ts
+++ b/src/cli/transfer/deploy-seraphine.ts
@@ -163,7 +163,7 @@ async function deploy(): Promise<void> {
 
   // Step 3: Scan for PII
   console.log('🔍 Scanning for PII...');
-  const piiScan = scanCFPForPII(genesis);
+  const piiScan = await scanCFPForPII(genesis);
   if (piiScan.found) {
     console.log(`   Found ${piiScan.count} PII items:`);
     for (const [type, count] of Object.entries(piiScan.types)) {

--- a/src/cli/transfer/export.ts
+++ b/src/cli/transfer/export.ts
@@ -34,13 +34,13 @@ export async function exportPatterns(
   } = options;
 
   // Step 1: Scan for PII
-  const piiScan = scanCFPForPII(cfp);
+  const piiScan = await scanCFPForPII(cfp);
   if (piiScan.found && redactPii) {
     console.log(`Found ${piiScan.count} PII items, will be redacted`);
   }
 
   // Step 2: Apply anonymization
-  const { cfp: anonymizedCfp, transforms } = anonymizeCFP(cfp, anonymize);
+  const { cfp: anonymizedCfp, transforms } = await anonymizeCFP(cfp, anonymize);
   console.log(`Applied ${transforms.length} anonymization transforms: ${transforms.join(', ')}`);
 
   // Step 3: Serialize

--- a/src/cli/transfer/store/publish.ts
+++ b/src/cli/transfer/store/publish.ts
@@ -41,7 +41,7 @@ export class PatternPublisher {
 
     try {
       // Step 1: Anonymize if needed
-      const anonymized = anonymizeCFP(cfp, options.anonymize);
+      const anonymized = await anonymizeCFP(cfp, options.anonymize);
       console.log(`[Publish] Anonymization level: ${options.anonymize}`);
 
       // Step 2: Serialize content


### PR DESCRIPTION
Fixes #1193.

## Problem

`src/cli/transfer/anonymization/index.ts` redacts secrets before a CFP is shared **externally**, but its `apiKey` regex `(sk-|pk-|api_key)[a-zA-Z0-9]{20,}` broke on the first hyphen of `sk-ant-…`. The `[a-zA-Z0-9]{20,}` run stopped at the hyphen, so a **live Anthropic key** — plus GitHub (`ghp_`/`github_pat_`), AWS (`AKIA…`), Slack (`xox…`), Google (`AIza…`) tokens and PEM private-key blocks — survived anonymization and could leak in an externally-published CFP.

## Fix

Single-source the secret **detection shapes** from `bin/lib/pii-scrub.mjs` (`SECRET_PATTERNS` + `scrubSecrets`) rather than re-typing the broader patterns here, where they would inevitably drift.

The two modules keep **different threat models**, so only the *shapes* are shared, not the *policies* (the shape proposed in the issue):

- `pii-scrub.mjs` protects the user's **own local disk** → keeps benign context (file paths, IPs), nukes only literal secrets.
- this module pseudonymises for **external publication** → additionally strips emails / phones / IPs / home paths.

The scrubber lives outside this module's TS compile unit, so it's reached the sanctioned cross-boundary way — `locateMofloRootPath()` + `pathToFileURL()` + dynamic `import()` — **not** a depth-mismatched `../../../../` static import (the path differs between `src/**` and `dist/src/**`). That makes `detectPII` / `redactPII` / `anonymizeCFP` / `scanCFPForPII` async; the 3 callers (`export.ts`, `publish.ts`, `deploy-seraphine.ts`) are updated. The loader is **fail-closed**: a missing/garbled scrubber throws rather than ship un-redacted credentials.

## Review-driven hardening (second commit)

A `/flo-simplify` review surfaced three issues, all fixed here:

- **Metadata leak (same bug class):** `anonymizeCFP` only redacted `cfp.patterns`, leaving free-text `metadata.name`/`description`/`tags` untouched — a secret pasted into a CFP description survived every level. Now redacted alongside patterns, and `scanCFPForPII` scans the same surface.
- **Poisoned loader singleton:** a rejected load promise was cached, so a transient/early failure would throw forever. Now cleared in `.catch()` before re-throwing (still fail-closed).
- **Misleading cast:** dropped `replacement as string` in `redactPII` in favour of union narrowing, so the email function-replacer case is correctly typed.

## Verification

- `npm run build` (tsc) — clean
- `vitest run plugins-transfer-deep.test.ts` — **212 passed**, incl. detect+redact for every shape, an end-to-end `anonymizeCFP` redaction, and the new metadata leak tests
- **Runtime test against the compiled `dist/` module** — confirmed the dynamic import resolves `bin/lib/pii-scrub.mjs` from the real package-root walk-up (the faithful `node_modules/moflo/` layout); all shapes redacted. This is the layer the source-level unit tests do not cover.
- `npm pack --dry-run` — confirmed `bin/lib/pii-scrub.mjs` ships in the tarball, so the fail-closed runtime dependency holds for consumers.
- **Rule #1 (cross-platform):** `path.join` for the path; `pathToFileURL` for the Windows-mandatory `file://` conversion (verified empirically — the dist run executed on Windows, the harder ESM-import case); lowercase filename matches the real file; no file-write/EOL concerns; no new shipped-script-list obligations (consumes an existing `.mjs`).

## Acceptance criteria

- [x] `anonymization` redacts `sk-ant-…` Anthropic keys
- [x] Coverage for `gh*_` / `github_pat_`, `AKIA…`, `xox[baprs]-…`, `AIza…`, and PEM private-key blocks
- [x] A test asserts each shape is redacted by the CFP anonymizer
- [x] Decision documented on single-sourcing with `bin/lib/pii-scrub.mjs` (shared **pattern set**, separate **policies** — see file header)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
