### PR TITLE
feat(reflect): auto-reflect — automatic session-end distillation of durable learnings (#1198)

### DIFF
--- a/.claude/scripts/lib/hook-io.mjs
+++ b/.claude/scripts/lib/hook-io.mjs
@@ -1,0 +1,63 @@
+/**
+ * Shared hook I/O primitives for moflo's bin/*.mjs hook handlers.
+ *
+ * Extracted (#1198) so the UserPromptSubmit/Stop capture hook
+ * (reflect-capture.mjs) and the passive session-continuity Stop hook
+ * (session-continuity.mjs) share ONE implementation of "read the hook's JSON
+ * stdin" — a bug in the bounded-read logic gets fixed once, not per copy.
+ *
+ * Cross-platform (Rule #1): Node fs primitives only; no shell.
+ */
+
+import { existsSync, openSync, readSync, closeSync, statSync, readFileSync } from 'fs';
+
+/**
+ * Read a hook's JSON stdin (session_id, transcript_path, prompt, …). Bounded by
+ * a 500ms cap so a missing/withheld stdin can never hang the hook; the timer is
+ * cleared on a normal end so the process exits immediately instead of lingering
+ * up to 500ms. Never throws — returns {} on any parse/IO error.
+ *
+ * @returns {Promise<Record<string, any>>}
+ */
+export async function readHookStdin() {
+  if (process.stdin.isTTY) return {};
+  return new Promise((res) => {
+    let data = '';
+    let done = false;
+    let timer = null;
+    const parse = (s) => { try { return s ? JSON.parse(s) : {}; } catch { return {}; } };
+    const finish = () => { if (done) return; done = true; if (timer) clearTimeout(timer); res(parse(data)); };
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (c) => { if (!done) data += c; });
+    process.stdin.on('end', finish);
+    process.stdin.on('error', finish);
+    timer = setTimeout(finish, 500);
+  });
+}
+
+/**
+ * Read the last `bytes` of a file as UTF-8. Returns '' on any error. The first
+ * (likely partial) line is the caller's concern — JSONL/transcript parsers
+ * tolerate a truncated leading line.
+ *
+ * @param {string} path
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function readFileTail(path, bytes) {
+  try {
+    if (!path || !existsSync(path)) return '';
+    const size = statSync(path).size;
+    if (size <= bytes) return readFileSync(path, 'utf-8');
+    const fd = openSync(path, 'r');
+    try {
+      const buf = Buffer.alloc(bytes);
+      readSync(fd, buf, 0, bytes, size - bytes);
+      return buf.toString('utf-8');
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return '';
+  }
+}

--- a/.claude/scripts/lib/reflect.mjs
+++ b/.claude/scripts/lib/reflect.mjs
@@ -120,11 +120,12 @@ const DECISION_PATTERNS = [
 
 // Tight, low-false-positive markers only — tool output mentions "error" benignly
 // all the time, so we anchor on structured failure signals, not the bare word.
+// `[1-9]\d*` (not `\d+`) so a SUCCESS line like "0 failed" never triggers.
 const ERROR_PATTERNS = [
   /"is_error"\s*:\s*true/,
   /\bexit code [1-9]\d*/i,
   /Traceback \(most recent call last\)/,
-  /\b\d+ (failed|failing)\b/i,
+  /\b[1-9]\d* (failed|failing)\b/i,
 ];
 
 function anyMatch(patterns, text) {
@@ -149,6 +150,31 @@ export function detectSignal(prompt, transcriptTail = '') {
   if (anyMatch(DECISION_PATTERNS, p) || anyMatch(DECISION_PATTERNS, t)) return { hit: true, kind: 'decision' };
   if (anyMatch(ERROR_PATTERNS, t)) return { hit: true, kind: 'error_fix' };
   return { hit: false, kind: null };
+}
+
+/**
+ * Text of the MOST RECENT turn — everything in the transcript tail after the
+ * last user message. The detect hook scopes error/decision detection to this
+ * slice so STALE markers from earlier in the session (a test failure 20 turns
+ * ago) don't keep re-firing the capture directive. Falls back to the whole tail
+ * when no user line is present. Tolerates a truncated leading JSONL line.
+ *
+ * @param {string} tailText - raw JSONL tail
+ * @returns {string}
+ */
+export function recentTranscriptTurn(tailText) {
+  if (typeof tailText !== 'string' || !tailText) return '';
+  const lines = tailText.split('\n');
+  let lastUserIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (!t || t[0] !== '{') continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; }
+    const role = obj?.message?.role ?? obj?.role;
+    if (role === 'user') lastUserIdx = i;
+  }
+  return (lastUserIdx >= 0 ? lines.slice(lastUserIdx + 1) : lines).join('\n');
 }
 
 // ── Stage 1: the injected directive (DRY with #1187 /reflect) ───────────────

--- a/.claude/scripts/lib/reflect.mjs
+++ b/.claude/scripts/lib/reflect.mjs
@@ -1,0 +1,435 @@
+/**
+ * Auto-reflect (#1198) — pure logic shared by the capture hook
+ * (`bin/reflect-capture.mjs`, wired to UserPromptSubmit + Stop) and the distill
+ * orchestrator (`bin/reflect-distill.mjs`, fired detached by the session-start
+ * launcher).
+ *
+ * DESIGN (owner-signed-off, #1198): two-stage Recognize → Distill.
+ *   - RECOGNIZE happens in the LIVE session. A UserPromptSubmit hook detects a
+ *     strong signal (user correction / error→fix / explicit decision) and, on a
+ *     hit, injects an answer-first directive asking the model — which has full
+ *     context at the moment of insight — to append ONE <reflect-capture> line IF
+ *     a durable lesson emerged. A Stop hook scrapes that tag into a JSON ledger.
+ *     No moflo.db write, no dedup yet — the ledger is raw, high-quality material.
+ *   - DISTILL happens at the NEXT session-start. The launcher fire-and-forgets a
+ *     detached process that runs ONE bounded headless Haiku `claude --print`
+ *     executing #1187's /reflect distillation over the ledger one-liners —
+ *     dedup-search `learnings` (≥0.80 → update same key), store via memory_store
+ *     (routes through the daemon = writer-safe). Haiku is a FORMATTER, not a
+ *     judge: the durability gate already passed upstream in the live model, so
+ *     unattended runs cannot pollute `learnings` with junk.
+ *
+ * Default-OFF (moflo.yaml `auto_reflect.enabled`). Every entry point early-
+ * returns cheaply when the flag is off OR `CLAUDE_CODE_HEADLESS` is set — the
+ * distill's own headless session must never re-enter capture or re-spawn distill
+ * (the #860 / infinite-spawn guard the prior finding flagged).
+ *
+ * STORAGE: `.moflo/reflect-ledger.json` (single file) + `.moflo/reflect-state.json`
+ * (rate-limit). Deliberately NOT under `.moflo/continuity/` — that directory is
+ * rotation-managed by #1185 (`rotateDigests` would delete a stray file there).
+ *
+ * Cross-platform (Rule #1): Node fs/path primitives only; no shell.
+ */
+
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'fs';
+import { resolve, join, dirname } from 'path';
+import { randomBytes } from 'crypto';
+
+// ── Tunables (exported for tests) ───────────────────────────────────────────
+/** Model used for the bounded distillation pass (cheap; Haiku is a formatter). */
+export const HAIKU_MODEL_ID = 'claude-haiku-4-5-20251001';
+/** Min gap between in-session capture directives, so a chatty correction streak
+ *  can't spam the model. */
+export const INJECT_WINDOW_MS = 8 * 60_000;
+/** Hard cap on directives per session (belt-and-braces over the time window). */
+export const INJECT_MAX_PER_SESSION = 6;
+/** Ledger size cap — distilled entries are pruned first, then oldest. */
+export const MAX_LEDGER_ENTRIES = 200;
+/** Keep this many already-distilled entries for idempotency/debug before pruning. */
+export const KEEP_DISTILLED = 50;
+/** Hard cap on a single captured lesson (defensive against a runaway tag). */
+export const MAX_LESSON_CHARS = 320;
+/** Bytes of transcript tail the capture hook scans for signals / tags. */
+export const TRANSCRIPT_TAIL_BYTES = 32_768;
+
+const LEDGER_FILE = 'reflect-ledger.json';
+const STATE_FILE = 'reflect-state.json';
+
+// ── moflo.yaml config (regex read, matching the launcher's no-js-yaml style) ─
+
+/**
+ * Read the `auto_reflect` block from moflo.yaml without a YAML parser. Defaults
+ * OFF — auto-reflect touches the session hot path in every consumer and must be
+ * opt-in until measured (#1198 blast-radius posture).
+ *
+ * @param {string} projectRoot
+ * @returns {{enabled: boolean}}
+ */
+export function readReflectConfig(projectRoot) {
+  const cfg = { enabled: false };
+  try {
+    const yamlPath = resolve(projectRoot, 'moflo.yaml');
+    if (!existsSync(yamlPath)) return cfg;
+    const text = readFileSync(yamlPath, 'utf-8');
+    const enabled = text.match(/auto_reflect:\s*\n(?:\s+\w+:.*\n)*?\s+enabled:\s*(true|false)/);
+    if (enabled) cfg.enabled = enabled[1] === 'true';
+  } catch {
+    // Default OFF keeps the feature inert if the file is mid-write / malformed.
+  }
+  return cfg;
+}
+
+/** True when running inside a spawned headless Claude (the distill pass, or any
+ *  other moflo headless worker). Capture + distill MUST no-op here so the
+ *  distill session can't re-enter capture or re-spawn another distill (#860). */
+export function isHeadless(env = process.env) {
+  return env.CLAUDE_CODE_HEADLESS === 'true' || env.CLAUDE_CODE_HEADLESS === '1';
+}
+
+// ── Stage 1: signal detection (pure) ────────────────────────────────────────
+//
+// Recall over precision by design: the live model's "append nothing" is the
+// real precision filter, so a mis-fire just produces no tag (~zero cost). These
+// patterns aim to catch the genuine "moment of insight", not to be exhaustive.
+
+const CORRECTION_PATTERNS = [
+  /^\s*(no|nope|nah|stop|wait)\b/i,
+  /\bthat'?s (not|wrong|incorrect)\b/i,
+  /\b(that|this) is (wrong|incorrect|not right)\b/i,
+  /\bdo ?n'?t\b/i,
+  /\b(actually|instead)\b/i,
+  /\bi (said|asked|told you|meant|wanted)\b/i,
+  /\byou (were supposed to|should(n'?t)? have|misunderstood|got it wrong)\b/i,
+  /\b(revert|undo|roll ?back)\b/i,
+  /\bwhy did you\b/i,
+  /\bnot what i\b/i,
+  /\b(that'?s|this is) not (it|right|correct)\b/i,
+];
+
+const DECISION_PATTERNS = [
+  /\blet'?s (go with|use|do|stick with)\b/i,
+  /\bwe'?ll (go with|use|do)\b/i,
+  /\b(decided|decision)\b/i,
+  /\bgoing with\b/i,
+  /\bthe plan is\b/i,
+  /\bwe should (use|go with|do)\b/i,
+  /\bi'?ll go with\b/i,
+];
+
+// Tight, low-false-positive markers only — tool output mentions "error" benignly
+// all the time, so we anchor on structured failure signals, not the bare word.
+const ERROR_PATTERNS = [
+  /"is_error"\s*:\s*true/,
+  /\bexit code [1-9]\d*/i,
+  /Traceback \(most recent call last\)/,
+  /\b\d+ (failed|failing)\b/i,
+];
+
+function anyMatch(patterns, text) {
+  if (!text) return false;
+  for (const re of patterns) if (re.test(text)) return true;
+  return false;
+}
+
+/**
+ * Classify the strongest signal in the current turn. `prompt` is the user's
+ * message; `transcriptTail` is recent transcript text (for error→fix / decision
+ * markers that live in the assistant/tool output).
+ *
+ * @param {string} prompt
+ * @param {string} [transcriptTail]
+ * @returns {{hit: boolean, kind: 'correction'|'decision'|'error_fix'|null}}
+ */
+export function detectSignal(prompt, transcriptTail = '') {
+  const p = typeof prompt === 'string' ? prompt : '';
+  const t = typeof transcriptTail === 'string' ? transcriptTail : '';
+  if (anyMatch(CORRECTION_PATTERNS, p)) return { hit: true, kind: 'correction' };
+  if (anyMatch(DECISION_PATTERNS, p) || anyMatch(DECISION_PATTERNS, t)) return { hit: true, kind: 'decision' };
+  if (anyMatch(ERROR_PATTERNS, t)) return { hit: true, kind: 'error_fix' };
+  return { hit: false, kind: null };
+}
+
+// ── Stage 1: the injected directive (DRY with #1187 /reflect) ───────────────
+
+/** The durability bar — single canonical wording shared by the capture
+ *  directive AND the distill prompt, mirroring `.claude/skills/reflect/SKILL.md`
+ *  Step 2 so the automatic path applies the exact same standard as `/reflect`. */
+export const DURABILITY_BAR =
+  'A durable lesson would help a FUTURE session on a DIFFERENT task: a reusable ' +
+  'pattern ("for X do Y because Z"), a recurring gotcha/trap, or a decision plus ' +
+  'the rationale future work must honor. NOT durable: "fixed bug X in file Y" ' +
+  '(that is git history), restating an existing rule, or session state.';
+
+const KIND_LABEL = {
+  correction: 'course-correction',
+  decision: 'decision',
+  error_fix: 'error-then-fix',
+};
+
+/**
+ * Build the answer-first capture directive injected as UserPromptSubmit context.
+ * Answer-first so the user's actual request is never degraded; "append nothing"
+ * is framed as the correct common outcome so a mis-fire is cheap.
+ *
+ * @param {'correction'|'decision'|'error_fix'} kind
+ * @returns {string}
+ */
+export function buildCaptureDirective(kind) {
+  const label = KIND_LABEL[kind] || 'notable moment';
+  return [
+    `[auto-reflect] A ${label} just occurred this session.`,
+    `FIRST: fully address the user's request as you normally would — do NOT let this note change your answer.`,
+    `THEN, only if a durable, reusable lesson emerged, append exactly ONE final line of the form:`,
+    `<reflect-capture>LESSON</reflect-capture>`,
+    `where LESSON is a single concise sentence (a pattern, gotcha, or decision+rationale).`,
+    DURABILITY_BAR,
+    `If nothing clears that bar, append nothing — silence is the correct, common outcome. Never emit more than one such line.`,
+  ].join('\n');
+}
+
+// ── Stage 1: rate-limit state ───────────────────────────────────────────────
+
+function stateFilePath(projectRoot) {
+  return resolve(projectRoot, '.moflo', STATE_FILE);
+}
+
+/**
+ * Decide whether an injection is allowed now, given persisted state. Limits:
+ * one directive per INJECT_WINDOW_MS, and at most INJECT_MAX_PER_SESSION per
+ * session. A new session id resets the per-session counter.
+ *
+ * @param {{sessionId?: string|null, lastInjectMs?: number, count?: number}|null} state
+ * @param {string|null} sessionId
+ * @param {number} now
+ * @returns {boolean}
+ */
+export function injectionAllowed(state, sessionId, now) {
+  if (!state || typeof state !== 'object') return true;
+  const sameSession = state.sessionId && sessionId && state.sessionId === sessionId;
+  if (!sameSession) return true; // fresh session — window + counter reset
+  if (typeof state.lastInjectMs === 'number' && now - state.lastInjectMs < INJECT_WINDOW_MS) return false;
+  if (typeof state.count === 'number' && state.count >= INJECT_MAX_PER_SESSION) return false;
+  return true;
+}
+
+/** Read rate-limit state (never throws). */
+export function readReflectState(projectRoot) {
+  try {
+    return JSON.parse(readFileSync(stateFilePath(projectRoot), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Persist rate-limit state after an injection, incrementing the per-session
+ *  counter (resets when the session id changes). */
+export function recordInjection(projectRoot, sessionId, now, prevState = null) {
+  const sameSession = prevState && prevState.sessionId === sessionId;
+  const count = sameSession && typeof prevState.count === 'number' ? prevState.count + 1 : 1;
+  atomicWriteJson(stateFilePath(projectRoot), { sessionId: sessionId ?? null, lastInjectMs: now, count });
+}
+
+// ── Stage 1: <reflect-capture> tag extraction (pure) ────────────────────────
+
+const CAPTURE_TAG_RE = /<reflect-capture>([\s\S]*?)<\/reflect-capture>/gi;
+// Drop the directive's own placeholder + non-lessons.
+const PLACEHOLDER_RE = /^(lesson|none|n\/?a|nothing)$/i;
+
+/** Extract lesson strings from a block of assistant text. Bounded + de-noised.
+ *  Uses matchAll (fresh internal iterator) rather than exec-with-/g so there's
+ *  no shared lastIndex state to reset/leak across calls. */
+export function extractCaptureTags(text) {
+  const out = [];
+  if (typeof text !== 'string' || !text) return out;
+  for (const m of text.matchAll(CAPTURE_TAG_RE)) {
+    const lesson = String(m[1] || '').replace(/\s+/g, ' ').trim();
+    if (lesson.length < 8) continue;            // empties / fragments
+    if (PLACEHOLDER_RE.test(lesson)) continue;  // the directive's "LESSON" placeholder
+    out.push(lesson.slice(0, MAX_LESSON_CHARS));
+  }
+  return out;
+}
+
+/**
+ * Extract captures from a transcript tail, restricted to ASSISTANT-role
+ * messages. This is what keeps the directive's own example tag (which rides in
+ * UserPromptSubmit context, not assistant output) from being scraped as a real
+ * capture. Tolerates a truncated leading JSONL line.
+ *
+ * @param {string} tailText - raw JSONL tail
+ * @returns {string[]}
+ */
+export function extractCapturesFromTranscript(tailText) {
+  const out = [];
+  if (typeof tailText !== 'string' || !tailText) return out;
+  for (const line of tailText.split('\n')) {
+    const t = line.trim();
+    if (!t || t[0] !== '{') continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; } // partial / non-JSON line
+    const role = obj?.message?.role ?? obj?.role;
+    if (role !== 'assistant') continue;
+    let content = obj?.message?.content ?? obj?.content;
+    if (Array.isArray(content)) {
+      content = content.map((b) => (typeof b === 'string' ? b : b?.text || '')).join('\n');
+    }
+    if (typeof content !== 'string') continue;
+    for (const lesson of extractCaptureTags(content)) out.push(lesson);
+  }
+  return out;
+}
+
+// ── Ledger (.moflo/reflect-ledger.json) ─────────────────────────────────────
+
+function ledgerFilePath(projectRoot) {
+  return resolve(projectRoot, '.moflo', LEDGER_FILE);
+}
+
+/** Atomic temp+rename JSON write (crash-safe; a half-write never lands). */
+function atomicWriteJson(dest, obj) {
+  mkdirSync(dirname(dest), { recursive: true });
+  const tmp = `${dest}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+  writeFileSync(tmp, JSON.stringify(obj), 'utf-8');
+  renameSync(tmp, dest);
+}
+
+/** Read the ledger (never throws; returns an empty ledger on absence/malformed). */
+export function readLedger(projectRoot) {
+  try {
+    const obj = JSON.parse(readFileSync(ledgerFilePath(projectRoot), 'utf-8'));
+    if (obj && Array.isArray(obj.entries)) return obj;
+  } catch {
+    // absent or mid-write — start fresh
+  }
+  return { entries: [] };
+}
+
+/** Entries not yet distilled, oldest first. */
+export function pendingEntries(ledger) {
+  const entries = ledger && Array.isArray(ledger.entries) ? ledger.entries : [];
+  return entries.filter((e) => e && !e.distilled && typeof e.lesson === 'string');
+}
+
+function normalizeLesson(s) {
+  return String(s || '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** Cap ledger size — drop distilled entries first (keep KEEP_DISTILLED newest),
+ *  then oldest pending if still over cap. Pure; returns a new entries array.
+ *  Membership is keyed by entry id (a Set), not object reference, so the cap
+ *  stays correct even if entries are ever cloned (e.g. a JSON round-trip). */
+function capEntries(entries) {
+  if (entries.length <= MAX_LEDGER_ENTRIES) return entries;
+  const distilled = entries.filter((e) => e.distilled);
+  // Keep the newest KEEP_DISTILLED distilled, preserving order.
+  const keptDistilledIds = new Set(
+    (distilled.length > KEEP_DISTILLED ? distilled.slice(distilled.length - KEEP_DISTILLED) : distilled)
+      .map((e) => e.id),
+  );
+  let merged = entries.filter((e) => (e.distilled ? keptDistilledIds.has(e.id) : true));
+  if (merged.length > MAX_LEDGER_ENTRIES) {
+    // Still over — drop oldest pending (front of array).
+    const overflow = merged.length - MAX_LEDGER_ENTRIES;
+    let dropped = 0;
+    merged = merged.filter((e) => {
+      if (dropped < overflow && !e.distilled) { dropped++; return false; }
+      return true;
+    });
+  }
+  return merged;
+}
+
+/**
+ * Append new captures to the ledger, skipping ones whose lesson already exists
+ * (normalized) — the Stop scrape re-reads an overlapping tail each turn, so
+ * dedup-on-append prevents the same lesson landing twice. Dedup is best-effort
+ * (read-then-write, not a transaction): correct because Claude Code serialises a
+ * session's Stop hooks, so there is no concurrent writer to race against. The
+ * distill's separate semantic dedup (≥0.80) is the real backstop.
+ *
+ * @param {string} projectRoot
+ * @param {Array<{lesson: string, kind?: string, sessionId?: string|null}>} captures
+ * @param {number} [now]
+ * @returns {number} count actually appended
+ */
+export function appendLedgerEntries(projectRoot, captures, now = Date.now()) {
+  const list = Array.isArray(captures) ? captures : [];
+  if (list.length === 0) return 0;
+  const ledger = readLedger(projectRoot);
+  const seen = new Set(ledger.entries.map((e) => normalizeLesson(e.lesson)));
+  let appended = 0;
+  for (const c of list) {
+    const lesson = String(c?.lesson || '').replace(/\s+/g, ' ').trim().slice(0, MAX_LESSON_CHARS);
+    if (lesson.length < 8) continue;
+    const norm = normalizeLesson(lesson);
+    if (seen.has(norm)) continue;
+    seen.add(norm);
+    ledger.entries.push({
+      id: `${now.toString(36)}-${randomBytes(3).toString('hex')}`,
+      lesson,
+      kind: c?.kind || null,
+      sessionId: c?.sessionId ?? null,
+      capturedAt: now,
+      distilled: false,
+    });
+    appended++;
+  }
+  if (appended === 0) return 0;
+  ledger.entries = capEntries(ledger.entries);
+  atomicWriteJson(ledgerFilePath(projectRoot), ledger);
+  return appended;
+}
+
+/**
+ * Mark the given entry ids distilled. New captures that arrived during the
+ * distill run keep `distilled:false` and survive for the next pass.
+ *
+ * @param {string} projectRoot
+ * @param {string[]} ids
+ * @returns {number} count marked
+ */
+export function markLedgerDistilled(projectRoot, ids) {
+  const idSet = new Set(Array.isArray(ids) ? ids : []);
+  if (idSet.size === 0) return 0;
+  const ledger = readLedger(projectRoot);
+  let marked = 0;
+  for (const e of ledger.entries) {
+    if (e && idSet.has(e.id) && !e.distilled) { e.distilled = true; marked++; }
+  }
+  if (marked === 0) return 0;
+  ledger.entries = capEntries(ledger.entries);
+  atomicWriteJson(ledgerFilePath(projectRoot), ledger);
+  return marked;
+}
+
+// ── Stage 2: distill prompt (DRY with #1187 /reflect) ───────────────────────
+
+/**
+ * Build the bounded headless-Haiku distillation prompt over the pending ledger
+ * entries. Reuses the `/reflect` protocol (search → dedup ≥0.80 → store) rather
+ * than forking it, and instructs writes through the MCP memory tools so they
+ * route via the daemon single-writer chokepoint (#981) — writer-safe.
+ *
+ * @param {Array<{lesson: string}>} entries
+ * @returns {string}
+ */
+export function buildDistillPrompt(entries) {
+  const list = (Array.isArray(entries) ? entries : []).filter((e) => e && e.lesson);
+  const numbered = list.map((e, i) => `${i + 1}. ${e.lesson}`).join('\n');
+  return [
+    `You are running moflo's automatic /reflect distillation (#1198) headlessly. Below are raw candidate lessons captured during a recent session — one per line. Persist the durable keepers to long-term memory, deduped. Be terse; do not write files.`,
+    ``,
+    `Candidates:`,
+    numbered,
+    ``,
+    `Procedure — reuse the /reflect protocol, do not invent a new one:`,
+    `1. For EACH candidate, call mcp__moflo__memory_search { namespace: "learnings", query: <bare keywords>, threshold: 0.6, limit: 5 }.`,
+    `2. If the top hit is the SAME fact at similarity >= 0.80, call mcp__moflo__memory_store with that SAME key (upsert), merging any new nuance — do NOT create a near-duplicate.`,
+    `3. Otherwise call mcp__moflo__memory_store { namespace: "learnings", key: <stable descriptive slug>, value: "<lesson> — Why: <why it matters>. How to apply: <what to do next time>.", tags: [<topic>, <area>] }.`,
+    `4. Skip any candidate that does not clear the durability bar below, or that merely restates an existing entry.`,
+    ``,
+    DURABILITY_BAR,
+    ``,
+    `When finished, output one line only: "distilled <new>, updated <merged>, skipped <n>".`,
+  ].join('\n');
+}

--- a/.claude/scripts/lib/reflect.mjs
+++ b/.claude/scripts/lib/reflect.mjs
@@ -19,10 +19,11 @@
  *     judge: the durability gate already passed upstream in the live model, so
  *     unattended runs cannot pollute `learnings` with junk.
  *
- * Default-OFF (moflo.yaml `auto_reflect.enabled`). Every entry point early-
- * returns cheaply when the flag is off OR `CLAUDE_CODE_HEADLESS` is set — the
- * distill's own headless session must never re-enter capture or re-spawn distill
- * (the #860 / infinite-spawn guard the prior finding flagged).
+ * Default-ON (opt out via moflo.yaml `auto_reflect.enabled: false`). Shipped
+ * default-on from #1198; the `rc` dist-tag gated the initial rollout. Every
+ * entry point still early-returns cheaply when the flag is off OR
+ * `CLAUDE_CODE_HEADLESS` is set — the distill's own headless session must never
+ * re-enter capture or re-spawn distill (the #860 / infinite-spawn guard).
  *
  * STORAGE: `.moflo/reflect-ledger.json` (single file) + `.moflo/reflect-state.json`
  * (rate-limit). Deliberately NOT under `.moflo/continuity/` — that directory is
@@ -59,14 +60,15 @@ const STATE_FILE = 'reflect-state.json';
 
 /**
  * Read the `auto_reflect` block from moflo.yaml without a YAML parser. Defaults
- * OFF — auto-reflect touches the session hot path in every consumer and must be
- * opt-in until measured (#1198 blast-radius posture).
+ * ON — opt out with `auto_reflect.enabled: false`. (#1198 ships default-on; the
+ * `rc` dist-tag gated the initial rollout.) Stays ON on a mid-write/malformed
+ * file, consistent with the on default.
  *
  * @param {string} projectRoot
  * @returns {{enabled: boolean}}
  */
 export function readReflectConfig(projectRoot) {
-  const cfg = { enabled: false };
+  const cfg = { enabled: true };
   try {
     const yamlPath = resolve(projectRoot, 'moflo.yaml');
     if (!existsSync(yamlPath)) return cfg;
@@ -74,7 +76,7 @@ export function readReflectConfig(projectRoot) {
     const enabled = text.match(/auto_reflect:\s*\n(?:\s+\w+:.*\n)*?\s+enabled:\s*(true|false)/);
     if (enabled) cfg.enabled = enabled[1] === 'true';
   } catch {
-    // Default OFF keeps the feature inert if the file is mid-write / malformed.
+    // Default ON keeps the feature live if the file is mid-write / malformed.
   }
   return cfg;
 }

--- a/.claude/scripts/lib/shipped-scripts.json
+++ b/.claude/scripts/lib/shipped-scripts.json
@@ -13,7 +13,9 @@
     "index-all.mjs",
     "setup-project.mjs",
     "run-migrations.mjs",
-    "session-continuity.mjs"
+    "session-continuity.mjs",
+    "reflect-capture.mjs",
+    "reflect-distill.mjs"
   ],
   "binHelperFiles": [
     "gate.cjs",

--- a/.claude/scripts/lib/yaml-upgrader.mjs
+++ b/.claude/scripts/lib/yaml-upgrader.mjs
@@ -37,6 +37,17 @@ session_continuity:
 `,
   },
   {
+    key: 'auto_reflect',
+    block: `# Auto-reflect (#1198) — the automatic counterpart to /reflect. When enabled,
+# moflo recognizes durable lessons in the LIVE session (a tiny answer-first note
+# on course-corrections / errors / decisions) and distills them into long-term
+# memory at the next session-start via a cheap headless Haiku pass — deduped.
+# Touches the session hot path, so it ships OFF; turn it on to opt in.
+auto_reflect:
+  enabled: false
+`,
+  },
+  {
     key: 'sandbox',
     block: `# Spell step sandboxing (OS-level process isolation for bash steps)
 # Platform support: macOS (sandbox-exec), Linux/WSL (bwrap). Windows has no OS sandbox.

--- a/.claude/scripts/lib/yaml-upgrader.mjs
+++ b/.claude/scripts/lib/yaml-upgrader.mjs
@@ -42,9 +42,9 @@ session_continuity:
 # moflo recognizes durable lessons in the LIVE session (a tiny answer-first note
 # on course-corrections / errors / decisions) and distills them into long-term
 # memory at the next session-start via a cheap headless Haiku pass — deduped.
-# Touches the session hot path, so it ships OFF; turn it on to opt in.
+# Ships ON; set false to opt out.
 auto_reflect:
-  enabled: false
+  enabled: true
 `,
   },
   {

--- a/.claude/scripts/reflect-capture.mjs
+++ b/.claude/scripts/reflect-capture.mjs
@@ -34,6 +34,7 @@ import {
   readReflectConfig,
   isHeadless,
   detectSignal,
+  recentTranscriptTurn,
   buildCaptureDirective,
   injectionAllowed,
   readReflectState,
@@ -66,16 +67,20 @@ async function detect() {
   const { projectRoot } = ctx;
 
   const input = await readHookStdin();
-  const prompt = input.prompt || input.user_prompt || '';
+  const prompt = (input.prompt || input.user_prompt || '').trim();
+  // No real user prompt (system reminder / task-notification re-invocation) →
+  // there's no "moment" to attach a directive to. Skip — this is the dominant
+  // false-fire source the live dogfood surfaced.
+  if (!prompt) return;
 
   // Cheapest path first: corrections + in-prompt decisions need only the prompt.
-  // Read the (32KB) transcript tail for error→fix / in-transcript decisions ONLY
-  // when the prompt alone produced no signal — saves the read on the common
-  // correction case.
+  // Only when the prompt alone yields nothing do we read the transcript and scope
+  // to the MOST RECENT turn (post-last-user-message) — scanning the full tail
+  // re-fires on stale error/decision markers from earlier in the session.
   let signal = detectSignal(prompt, '');
   if (!signal.hit) {
     const tail = readFileTail(input.transcript_path || input.transcriptPath, TRANSCRIPT_TAIL_BYTES);
-    if (tail) signal = detectSignal(prompt, tail);
+    if (tail) signal = detectSignal(prompt, recentTranscriptTurn(tail));
   }
   if (!signal.hit) return;
 

--- a/.claude/scripts/reflect-capture.mjs
+++ b/.claude/scripts/reflect-capture.mjs
@@ -56,7 +56,7 @@ function warn(msg) {
 function gate() {
   if (isHeadless(process.env)) return null;          // #860 — never run inside the distill's own session
   const projectRoot = findProjectRoot();
-  if (!readReflectConfig(projectRoot).enabled) return null; // default-off
+  if (!readReflectConfig(projectRoot).enabled) return null; // off (opt-out)
   return { projectRoot };
 }
 

--- a/.claude/scripts/reflect-capture.mjs
+++ b/.claude/scripts/reflect-capture.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Auto-reflect Stage 1 — CAPTURE (#1198). One script, two hook entry points:
+ *
+ *   detect  (UserPromptSubmit) — mechanically score the user's prompt + recent
+ *           transcript tail for a strong signal (course-correction / error→fix /
+ *           decision). On a hit, and within rate limits, print an answer-first
+ *           directive asking the LIVE model — which has full context at the
+ *           moment of insight — to append ONE <reflect-capture> line IF a durable
+ *           lesson emerged. Stdout from a UserPromptSubmit hook is added to the
+ *           model's context (same mechanism as .claude/helpers/prompt-hook.mjs).
+ *
+ *   scrape  (Stop) — read the transcript tail, extract <reflect-capture> tags
+ *           from the last ASSISTANT message(s), and append the raw one-liners to
+ *           the JSON ledger (.moflo/reflect-ledger.json). No moflo.db write, no
+ *           dedup yet — the bounded Haiku distill (bin/reflect-distill.mjs) does
+ *           that later, writer-safe, via memory_store.
+ *
+ * Both modes early-return cheaply when auto-reflect is OFF or CLAUDE_CODE_HEADLESS
+ * is set — the distill's own headless session must never re-enter capture (#860).
+ * A hook must NEVER throw: every path is wrapped and degrades to a silent exit 0.
+ *
+ * Invoked by:
+ *   node .claude/scripts/reflect-capture.mjs reflect-detect   (UserPromptSubmit)
+ *   node .claude/scripts/reflect-capture.mjs reflect-scrape    (Stop)
+ *
+ * Cross-platform (Rule #1): Node fs/path primitives only; no shell.
+ */
+
+import { findProjectRoot } from './lib/moflo-paths.mjs';
+import { readHookStdin, readFileTail } from './lib/hook-io.mjs';
+import {
+  TRANSCRIPT_TAIL_BYTES,
+  readReflectConfig,
+  isHeadless,
+  detectSignal,
+  buildCaptureDirective,
+  injectionAllowed,
+  readReflectState,
+  recordInjection,
+  extractCapturesFromTranscript,
+  appendLedgerEntries,
+} from './lib/reflect.mjs';
+
+// Scrape needs to reliably catch the tag at the END of the assistant's reply,
+// which can be a single large JSONL line — read a generous tail. Detect only
+// needs recent error/decision markers, so the smaller shared window suffices.
+const SCRAPE_TAIL_BYTES = 262_144;
+
+function warn(msg) {
+  try { process.stderr.write(`moflo: reflect-capture ${msg}\n`); } catch { /* never throw from a hook */ }
+}
+
+/** Shared preamble: resolve root + config, applying the OFF / headless guards.
+ *  Returns null when the caller should early-exit. */
+function gate() {
+  if (isHeadless(process.env)) return null;          // #860 — never run inside the distill's own session
+  const projectRoot = findProjectRoot();
+  if (!readReflectConfig(projectRoot).enabled) return null; // default-off
+  return { projectRoot };
+}
+
+async function detect() {
+  const ctx = gate();
+  if (!ctx) return;
+  const { projectRoot } = ctx;
+
+  const input = await readHookStdin();
+  const prompt = input.prompt || input.user_prompt || '';
+
+  // Cheapest path first: corrections + in-prompt decisions need only the prompt.
+  // Read the (32KB) transcript tail for error→fix / in-transcript decisions ONLY
+  // when the prompt alone produced no signal — saves the read on the common
+  // correction case.
+  let signal = detectSignal(prompt, '');
+  if (!signal.hit) {
+    const tail = readFileTail(input.transcript_path || input.transcriptPath, TRANSCRIPT_TAIL_BYTES);
+    if (tail) signal = detectSignal(prompt, tail);
+  }
+  if (!signal.hit) return;
+
+  const sessionId = input.session_id || input.sessionId || null;
+  const now = Date.now();
+  const state = readReflectState(projectRoot);
+  if (!injectionAllowed(state, sessionId, now)) return; // rate-limited
+
+  try {
+    process.stdout.write(buildCaptureDirective(signal.kind) + '\n');
+  } catch {
+    return; // broken stdout — don't record an injection that didn't land
+  }
+  recordInjection(projectRoot, sessionId, now, state);
+}
+
+async function scrape() {
+  const ctx = gate();
+  if (!ctx) return;
+  const { projectRoot } = ctx;
+
+  const input = await readHookStdin();
+  const tail = readFileTail(input.transcript_path || input.transcriptPath, SCRAPE_TAIL_BYTES);
+  if (!tail) return;
+
+  const lessons = extractCapturesFromTranscript(tail);
+  if (lessons.length === 0) return;
+
+  const sessionId = input.session_id || input.sessionId || null;
+  appendLedgerEntries(projectRoot, lessons.map((lesson) => ({ lesson, kind: 'captured', sessionId })));
+}
+
+const sub = process.argv[2];
+if (sub === 'reflect-detect') {
+  detect().catch((err) => warn(`detect failed (${err && err.message ? err.message : String(err)})`));
+} else if (sub === 'reflect-scrape') {
+  scrape().catch((err) => warn(`scrape failed (${err && err.message ? err.message : String(err)})`));
+} else {
+  warn(`unknown subcommand "${sub || ''}" (expected: reflect-detect | reflect-scrape)`);
+}

--- a/.claude/scripts/reflect-distill.mjs
+++ b/.claude/scripts/reflect-distill.mjs
@@ -13,7 +13,7 @@
  * pollute `learnings` with junk it invented.
  *
  * GUARDS:
- *   - default-off (auto_reflect.enabled) — exit immediately when off.
+ *   - off (auto_reflect.enabled: false) — exit immediately. Default is ON.
  *   - CLAUDE_CODE_HEADLESS — exit immediately (defensive; the launcher already
  *     won't fire us in headless, but self-guarding prevents any infinite spawn).
  *   - empty ledger — exit without spawning anything.
@@ -97,7 +97,7 @@ function runHeadless(projectRoot, prompt) {
 async function main() {
   if (isHeadless(process.env)) return;                       // #860 self-guard
   const projectRoot = findProjectRoot();
-  if (!readReflectConfig(projectRoot).enabled) return;       // default-off
+  if (!readReflectConfig(projectRoot).enabled) return;       // off (opt-out)
 
   const pending = pendingEntries(readLedger(projectRoot));
   if (pending.length === 0) return;                          // nothing to do — no spawn

--- a/.claude/scripts/reflect-distill.mjs
+++ b/.claude/scripts/reflect-distill.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Auto-reflect Stage 2 — DISTILL (#1198). Fired DETACHED by the session-start
+ * launcher (never inline — the launcher's contract is spawn-and-exit). Runs ONE
+ * bounded headless Haiku `claude --print` that executes #1187's /reflect
+ * distillation over the ledger one-liners (NOT the transcript): dedup-search
+ * `learnings` (≥0.80 → update same key), store via memory_store. Because the
+ * headless session calls memory_store itself, writes route through the daemon
+ * single-writer chokepoint (#981) — writer-safe, no raw cross-process db write.
+ *
+ * Haiku is a FORMATTER, not a judge: the durability gate already passed upstream
+ * in the live model when the lesson was captured, so this unattended pass cannot
+ * pollute `learnings` with junk it invented.
+ *
+ * GUARDS:
+ *   - default-off (auto_reflect.enabled) — exit immediately when off.
+ *   - CLAUDE_CODE_HEADLESS — exit immediately (defensive; the launcher already
+ *     won't fire us in headless, but self-guarding prevents any infinite spawn).
+ *   - empty ledger — exit without spawning anything.
+ *
+ * Only entries in the snapshot we hand to Haiku are marked distilled on success,
+ * so captures that arrive DURING the run survive for the next pass.
+ *
+ * Test seam: MOFLO_REFLECT_DISTILL_NODE_STUB — when set to a path, the model
+ * call is `node <stub> --print <prompt>` instead of `claude --print <prompt>`,
+ * so the spawn is exercisable cross-platform without a real Claude CLI.
+ *
+ * Invoked by: node .claude/scripts/reflect-distill.mjs
+ *
+ * Cross-platform (Rule #1): Node child_process (arg arrays, no shell) + fs/path.
+ */
+
+import { spawn } from 'child_process';
+import { appendFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { findProjectRoot } from './lib/moflo-paths.mjs';
+import {
+  HAIKU_MODEL_ID,
+  readReflectConfig,
+  isHeadless,
+  readLedger,
+  pendingEntries,
+  buildDistillPrompt,
+  markLedgerDistilled,
+} from './lib/reflect.mjs';
+
+/** Cap candidates per pass — keeps the Haiku prompt small (cheap, fast). Extra
+ *  pending entries roll into the next session's pass. */
+const DISTILL_BATCH_MAX = 25;
+/** Hard ceiling on the headless run; killed past this. */
+const DISTILL_TIMEOUT_MS = 120_000;
+
+function log(projectRoot, line) {
+  try {
+    const p = resolve(projectRoot, '.moflo', 'reflect-distill.log');
+    mkdirSync(dirname(p), { recursive: true });
+    appendFileSync(p, `[${new Date().toISOString()}] ${line}\n`, 'utf-8');
+  } catch { /* logging is best-effort — never throw */ }
+}
+
+/** Run the bounded headless distillation. Resolves { success, output }. */
+function runHeadless(projectRoot, prompt) {
+  return new Promise((res) => {
+    const stub = process.env.MOFLO_REFLECT_DISTILL_NODE_STUB;
+    const cmd = stub ? process.execPath : 'claude';
+    const args = stub ? [stub, '--print', prompt] : ['--print', prompt];
+
+    const env = {
+      ...process.env,
+      CLAUDE_CODE_HEADLESS: 'true',     // mark the child so its own hooks no-op (#860)
+      ANTHROPIC_MODEL: HAIKU_MODEL_ID,  // cheap formatter model
+    };
+
+    let child;
+    try {
+      child = spawn(cmd, args, { cwd: projectRoot, env, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+    } catch (err) {
+      res({ success: false, output: '', error: err && err.message ? err.message : String(err) });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (r) => { if (done) return; done = true; clearTimeout(timer); res(r); };
+    const timer = setTimeout(() => {
+      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+      finish({ success: false, output: out, error: `timed out after ${DISTILL_TIMEOUT_MS}ms` });
+    }, DISTILL_TIMEOUT_MS);
+
+    child.stdout?.on('data', (d) => { out += d.toString(); });
+    child.stderr?.on('data', (d) => { out += d.toString(); });
+    child.on('error', (err) => finish({ success: false, output: out, error: err && err.message ? err.message : String(err) }));
+    child.on('close', (code) => finish({ success: code === 0, output: out }));
+  });
+}
+
+async function main() {
+  if (isHeadless(process.env)) return;                       // #860 self-guard
+  const projectRoot = findProjectRoot();
+  if (!readReflectConfig(projectRoot).enabled) return;       // default-off
+
+  const pending = pendingEntries(readLedger(projectRoot));
+  if (pending.length === 0) return;                          // nothing to do — no spawn
+
+  const batch = pending.slice(0, DISTILL_BATCH_MAX);
+  const prompt = buildDistillPrompt(batch);
+
+  const result = await runHeadless(projectRoot, prompt);
+  if (result.success) {
+    const marked = markLedgerDistilled(projectRoot, batch.map((e) => e.id));
+    const summary = String(result.output || '').trim().split('\n').filter(Boolean).pop() || '(no summary)';
+    log(projectRoot, `distilled ${batch.length} candidate(s), marked ${marked} — haiku: ${summary.slice(0, 200)}`);
+  } else {
+    // Leave the ledger untouched so the next session retries.
+    log(projectRoot, `distill failed (${result.error || 'non-zero exit'}) — ${batch.length} candidate(s) retained for retry`);
+  }
+}
+
+main().catch((err) => {
+  try { process.stderr.write(`moflo: reflect-distill failed (${err && err.message ? err.message : String(err)})\n`); } catch { /* ignore */ }
+});

--- a/.claude/scripts/session-continuity.mjs
+++ b/.claude/scripts/session-continuity.mjs
@@ -30,6 +30,7 @@ import { resolve, dirname } from 'path';
 import { findProjectRoot } from './lib/moflo-paths.mjs';
 import { openBackend } from './lib/get-backend.mjs';
 import { scrubSecrets } from './lib/pii-scrub.mjs';
+import { readHookStdin } from './lib/hook-io.mjs';
 import {
   readContinuityConfig,
   readGitState,
@@ -45,23 +46,6 @@ const LEARNINGS_SAMPLE = 5;     // how many recent learnings to fold in as "deci
 
 function warn(msg) {
   try { process.stderr.write(`moflo: session-continuity ${msg}\n`); } catch { /* never throw from a hook */ }
-}
-
-/** Read the Stop hook's JSON stdin (session_id, transcript_path). Bounded so a
- *  missing/withheld stdin can never hang the hook. */
-async function readHookInput() {
-  if (process.stdin.isTTY) return {};
-  return new Promise((res) => {
-    let data = '';
-    let done = false;
-    const parse = (s) => { try { return s ? JSON.parse(s) : {}; } catch { return {}; } };
-    const finish = () => { if (done) return; done = true; res(parse(data)); };
-    process.stdin.setEncoding('utf-8');
-    process.stdin.on('data', (c) => { if (!done) data += c; });
-    process.stdin.on('end', finish);
-    process.stdin.on('error', finish);
-    setTimeout(finish, 500);
-  });
 }
 
 /** First user message (the session goal) from a transcript JSONL head. */
@@ -174,7 +158,7 @@ async function capture() {
   const cfg = readContinuityConfig(projectRoot);
   if (!cfg.capture) return;
 
-  const input = await readHookInput();
+  const input = await readHookStdin();
   const sessionId = input.session_id || input.sessionId || null;
   const now = Date.now();
 

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -15,7 +15,8 @@ import { mofloDir, findProjectRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAME
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyRetiredPrune } from './lib/retired-files.mjs';
-import { makeSyncer, contentEqual } from './lib/file-sync.mjs';
+import { makeSyncer, contentEqual, syncDirRecursive } from './lib/file-sync.mjs';
+import { INTERNAL_SKILLS } from './lib/internal-skills.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
 import {
   readContinuityConfig,
@@ -24,6 +25,11 @@ import {
   selectBestDigest,
   formatInjection,
 } from './lib/session-continuity.mjs';
+import {
+  readReflectConfig,
+  readLedger as readReflectLedger,
+  pendingEntries as pendingReflectEntries,
+} from './lib/reflect.mjs';
 
 // Headless skip (#860). The daemon's headless workers spawn `claude --print`
 // with CLAUDE_CODE_HEADLESS=true (see src/cli/services/headless-worker-
@@ -1152,35 +1158,20 @@ try {
       // because they don't exist in node_modules/moflo/, so they never enter
       // the manifest and never get pruned — same proven safety story as
       // scripts/helpers above.
-      async function syncDirRecursive(srcDir, destPrefix) {
-        if (!existsSync(srcDir)) return;
-        let entries;
-        try {
-          entries = readdirSync(srcDir, { recursive: true, withFileTypes: true });
-        } catch (err) {
-          emitWarning(`${destPrefix} readdir failed (${errMessage(err)})`);
-          return;
-        }
-        for (const entry of entries) {
-          if (!entry.isFile()) continue;
-          if (!entry.name.toLowerCase().endsWith('.md')) continue;
-          const parent = entry.parentPath || entry.path || srcDir;
-          const absSrc = resolve(parent, entry.name);
-          const rel = absSrc.slice(srcDir.length + 1).split(/[\\/]/).join('/');
-          const absDest = resolve(projectRoot, destPrefix, rel);
-          try { mkdirSync(dirname(absDest), { recursive: true }); } catch (err) {
-            emitWarning(`${destPrefix} subdir mkdir failed for ${rel} (${errMessage(err)})`);
-          }
-          await syncFile(absSrc, absDest, `${destPrefix}/${rel}`);
-        }
-      }
+      //
+      // syncDirRecursive lives in bin/lib/file-sync.mjs so the exclusion logic
+      // is unit-testable (tests/bin/file-sync-dir.test.ts). Skills pass
+      // INTERNAL_SKILLS as excludeTopLevel so moflo-internal skills (`/publish`,
+      // `/reset-epic`) ship in the tarball but never land in a consumer project.
       await syncDirRecursive(
         resolve(projectRoot, 'node_modules/moflo/.claude/agents'),
         '.claude/agents',
+        { projectRoot, syncFile, onWarn: emitWarning },
       );
       await syncDirRecursive(
         resolve(projectRoot, 'node_modules/moflo/.claude/skills'),
         '.claude/skills',
+        { projectRoot, syncFile, excludeTopLevel: new Set(INTERNAL_SKILLS), onWarn: emitWarning },
       );
 
       // Sync all shipped guidance files from node_modules/moflo/.claude/guidance/shipped/
@@ -2237,6 +2228,26 @@ try {
   maybeInjectContinuity();
 } catch (err) {
   emitWarning(`continuity injection skipped (${errMessage(err)})`);
+}
+
+// Auto-reflect Stage 2 — DISTILL (#1198). Default-off. When enabled AND the
+// capture ledger holds un-distilled lessons, fire-and-forget the DETACHED
+// distill orchestrator — it runs ONE bounded headless Haiku /reflect over the
+// ledger one-liners and writes `learnings` via memory_store (daemon-routed,
+// writer-safe). The gate here is cheap (a config read + a ledger read); the
+// spawn + model call live entirely in the detached child, so the launcher's
+// spawn-and-exit contract holds. CLAUDE_CODE_HEADLESS is guarded at the top of
+// this file, so a headless session never reaches here (no infinite spawn).
+function maybeFireReflectDistill() {
+  if (!readReflectConfig(projectRoot).enabled) return;
+  if (pendingReflectEntries(readReflectLedger(projectRoot)).length === 0) return;
+  const distillScript = resolveMofloBin(projectRoot, null, 'reflect-distill.mjs');
+  if (distillScript) fireAndForget('node', [distillScript], 'reflect-distill');
+}
+try {
+  maybeFireReflectDistill();
+} catch (err) {
+  emitWarning(`reflect distill spawn skipped (${errMessage(err)})`);
 }
 
 // Bypasses emitMutation — framing, not a mutation, so it must not inflate the count.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -187,6 +187,15 @@
             "timeout": 3000
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/reflect-capture.mjs\" reflect-detect",
+            "timeout": 3000
+          }
+        ]
       }
     ],
     "SubagentStart": [
@@ -232,6 +241,11 @@
           {
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/session-continuity.mjs\" capture",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/scripts/reflect-capture.mjs\" reflect-scrape",
             "timeout": 5000
           }
         ]

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -119,4 +119,4 @@ In `--preview` mode, label it clearly as a preview and note that nothing was wri
 
 - `.claude/guidance/moflo-memory-protocol.md` — namespaces and the store/search protocol
 - `.claude/skills/brainstorm/SKILL.md` — the *pre-execution* counterpart (`/brainstorm` opens a unit of work; `/reflect` closes one)
-- `bin/lib/reflect.mjs` (#1198, auto-reflect) — the *automatic* counterpart. Default-off; recognizes durable lessons in the live session and distills them here via a headless Haiku pass. It reuses this skill's durability bar (the canonical wording lives in `DURABILITY_BAR`) and the same dedup-then-store protocol — Step 2/Step 3 here are the source of truth both paths apply.
+- **Auto-reflect** — the *automatic* counterpart. Instead of waiting for you to run `/reflect`, moflo can recognize durable lessons in the live session and distill them into `learnings` automatically via a cheap background pass. Toggle it with `auto_reflect.enabled` in `moflo.yaml`; it applies the same durability bar and dedup-then-store protocol, so Step 2 / Step 3 here remain the source of truth for both paths.

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -119,3 +119,4 @@ In `--preview` mode, label it clearly as a preview and note that nothing was wri
 
 - `.claude/guidance/moflo-memory-protocol.md` — namespaces and the store/search protocol
 - `.claude/skills/brainstorm/SKILL.md` — the *pre-execution* counterpart (`/brainstorm` opens a unit of work; `/reflect` closes one)
+- `bin/lib/reflect.mjs` (#1198, auto-reflect) — the *automatic* counterpart. Default-off; recognizes durable lessons in the live session and distills them here via a headless Haiku pass. It reuses this skill's durability bar (the canonical wording lives in `DURABILITY_BAR`) and the same dedup-then-store protocol — Step 2/Step 3 here are the source of truth both paths apply.

--- a/bin/lib/hook-io.mjs
+++ b/bin/lib/hook-io.mjs
@@ -1,0 +1,63 @@
+/**
+ * Shared hook I/O primitives for moflo's bin/*.mjs hook handlers.
+ *
+ * Extracted (#1198) so the UserPromptSubmit/Stop capture hook
+ * (reflect-capture.mjs) and the passive session-continuity Stop hook
+ * (session-continuity.mjs) share ONE implementation of "read the hook's JSON
+ * stdin" — a bug in the bounded-read logic gets fixed once, not per copy.
+ *
+ * Cross-platform (Rule #1): Node fs primitives only; no shell.
+ */
+
+import { existsSync, openSync, readSync, closeSync, statSync, readFileSync } from 'fs';
+
+/**
+ * Read a hook's JSON stdin (session_id, transcript_path, prompt, …). Bounded by
+ * a 500ms cap so a missing/withheld stdin can never hang the hook; the timer is
+ * cleared on a normal end so the process exits immediately instead of lingering
+ * up to 500ms. Never throws — returns {} on any parse/IO error.
+ *
+ * @returns {Promise<Record<string, any>>}
+ */
+export async function readHookStdin() {
+  if (process.stdin.isTTY) return {};
+  return new Promise((res) => {
+    let data = '';
+    let done = false;
+    let timer = null;
+    const parse = (s) => { try { return s ? JSON.parse(s) : {}; } catch { return {}; } };
+    const finish = () => { if (done) return; done = true; if (timer) clearTimeout(timer); res(parse(data)); };
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (c) => { if (!done) data += c; });
+    process.stdin.on('end', finish);
+    process.stdin.on('error', finish);
+    timer = setTimeout(finish, 500);
+  });
+}
+
+/**
+ * Read the last `bytes` of a file as UTF-8. Returns '' on any error. The first
+ * (likely partial) line is the caller's concern — JSONL/transcript parsers
+ * tolerate a truncated leading line.
+ *
+ * @param {string} path
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function readFileTail(path, bytes) {
+  try {
+    if (!path || !existsSync(path)) return '';
+    const size = statSync(path).size;
+    if (size <= bytes) return readFileSync(path, 'utf-8');
+    const fd = openSync(path, 'r');
+    try {
+      const buf = Buffer.alloc(bytes);
+      readSync(fd, buf, 0, bytes, size - bytes);
+      return buf.toString('utf-8');
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return '';
+  }
+}

--- a/bin/lib/reflect.mjs
+++ b/bin/lib/reflect.mjs
@@ -120,11 +120,12 @@ const DECISION_PATTERNS = [
 
 // Tight, low-false-positive markers only — tool output mentions "error" benignly
 // all the time, so we anchor on structured failure signals, not the bare word.
+// `[1-9]\d*` (not `\d+`) so a SUCCESS line like "0 failed" never triggers.
 const ERROR_PATTERNS = [
   /"is_error"\s*:\s*true/,
   /\bexit code [1-9]\d*/i,
   /Traceback \(most recent call last\)/,
-  /\b\d+ (failed|failing)\b/i,
+  /\b[1-9]\d* (failed|failing)\b/i,
 ];
 
 function anyMatch(patterns, text) {
@@ -149,6 +150,31 @@ export function detectSignal(prompt, transcriptTail = '') {
   if (anyMatch(DECISION_PATTERNS, p) || anyMatch(DECISION_PATTERNS, t)) return { hit: true, kind: 'decision' };
   if (anyMatch(ERROR_PATTERNS, t)) return { hit: true, kind: 'error_fix' };
   return { hit: false, kind: null };
+}
+
+/**
+ * Text of the MOST RECENT turn — everything in the transcript tail after the
+ * last user message. The detect hook scopes error/decision detection to this
+ * slice so STALE markers from earlier in the session (a test failure 20 turns
+ * ago) don't keep re-firing the capture directive. Falls back to the whole tail
+ * when no user line is present. Tolerates a truncated leading JSONL line.
+ *
+ * @param {string} tailText - raw JSONL tail
+ * @returns {string}
+ */
+export function recentTranscriptTurn(tailText) {
+  if (typeof tailText !== 'string' || !tailText) return '';
+  const lines = tailText.split('\n');
+  let lastUserIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (!t || t[0] !== '{') continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; }
+    const role = obj?.message?.role ?? obj?.role;
+    if (role === 'user') lastUserIdx = i;
+  }
+  return (lastUserIdx >= 0 ? lines.slice(lastUserIdx + 1) : lines).join('\n');
 }
 
 // ── Stage 1: the injected directive (DRY with #1187 /reflect) ───────────────

--- a/bin/lib/reflect.mjs
+++ b/bin/lib/reflect.mjs
@@ -1,0 +1,435 @@
+/**
+ * Auto-reflect (#1198) — pure logic shared by the capture hook
+ * (`bin/reflect-capture.mjs`, wired to UserPromptSubmit + Stop) and the distill
+ * orchestrator (`bin/reflect-distill.mjs`, fired detached by the session-start
+ * launcher).
+ *
+ * DESIGN (owner-signed-off, #1198): two-stage Recognize → Distill.
+ *   - RECOGNIZE happens in the LIVE session. A UserPromptSubmit hook detects a
+ *     strong signal (user correction / error→fix / explicit decision) and, on a
+ *     hit, injects an answer-first directive asking the model — which has full
+ *     context at the moment of insight — to append ONE <reflect-capture> line IF
+ *     a durable lesson emerged. A Stop hook scrapes that tag into a JSON ledger.
+ *     No moflo.db write, no dedup yet — the ledger is raw, high-quality material.
+ *   - DISTILL happens at the NEXT session-start. The launcher fire-and-forgets a
+ *     detached process that runs ONE bounded headless Haiku `claude --print`
+ *     executing #1187's /reflect distillation over the ledger one-liners —
+ *     dedup-search `learnings` (≥0.80 → update same key), store via memory_store
+ *     (routes through the daemon = writer-safe). Haiku is a FORMATTER, not a
+ *     judge: the durability gate already passed upstream in the live model, so
+ *     unattended runs cannot pollute `learnings` with junk.
+ *
+ * Default-OFF (moflo.yaml `auto_reflect.enabled`). Every entry point early-
+ * returns cheaply when the flag is off OR `CLAUDE_CODE_HEADLESS` is set — the
+ * distill's own headless session must never re-enter capture or re-spawn distill
+ * (the #860 / infinite-spawn guard the prior finding flagged).
+ *
+ * STORAGE: `.moflo/reflect-ledger.json` (single file) + `.moflo/reflect-state.json`
+ * (rate-limit). Deliberately NOT under `.moflo/continuity/` — that directory is
+ * rotation-managed by #1185 (`rotateDigests` would delete a stray file there).
+ *
+ * Cross-platform (Rule #1): Node fs/path primitives only; no shell.
+ */
+
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'fs';
+import { resolve, join, dirname } from 'path';
+import { randomBytes } from 'crypto';
+
+// ── Tunables (exported for tests) ───────────────────────────────────────────
+/** Model used for the bounded distillation pass (cheap; Haiku is a formatter). */
+export const HAIKU_MODEL_ID = 'claude-haiku-4-5-20251001';
+/** Min gap between in-session capture directives, so a chatty correction streak
+ *  can't spam the model. */
+export const INJECT_WINDOW_MS = 8 * 60_000;
+/** Hard cap on directives per session (belt-and-braces over the time window). */
+export const INJECT_MAX_PER_SESSION = 6;
+/** Ledger size cap — distilled entries are pruned first, then oldest. */
+export const MAX_LEDGER_ENTRIES = 200;
+/** Keep this many already-distilled entries for idempotency/debug before pruning. */
+export const KEEP_DISTILLED = 50;
+/** Hard cap on a single captured lesson (defensive against a runaway tag). */
+export const MAX_LESSON_CHARS = 320;
+/** Bytes of transcript tail the capture hook scans for signals / tags. */
+export const TRANSCRIPT_TAIL_BYTES = 32_768;
+
+const LEDGER_FILE = 'reflect-ledger.json';
+const STATE_FILE = 'reflect-state.json';
+
+// ── moflo.yaml config (regex read, matching the launcher's no-js-yaml style) ─
+
+/**
+ * Read the `auto_reflect` block from moflo.yaml without a YAML parser. Defaults
+ * OFF — auto-reflect touches the session hot path in every consumer and must be
+ * opt-in until measured (#1198 blast-radius posture).
+ *
+ * @param {string} projectRoot
+ * @returns {{enabled: boolean}}
+ */
+export function readReflectConfig(projectRoot) {
+  const cfg = { enabled: false };
+  try {
+    const yamlPath = resolve(projectRoot, 'moflo.yaml');
+    if (!existsSync(yamlPath)) return cfg;
+    const text = readFileSync(yamlPath, 'utf-8');
+    const enabled = text.match(/auto_reflect:\s*\n(?:\s+\w+:.*\n)*?\s+enabled:\s*(true|false)/);
+    if (enabled) cfg.enabled = enabled[1] === 'true';
+  } catch {
+    // Default OFF keeps the feature inert if the file is mid-write / malformed.
+  }
+  return cfg;
+}
+
+/** True when running inside a spawned headless Claude (the distill pass, or any
+ *  other moflo headless worker). Capture + distill MUST no-op here so the
+ *  distill session can't re-enter capture or re-spawn another distill (#860). */
+export function isHeadless(env = process.env) {
+  return env.CLAUDE_CODE_HEADLESS === 'true' || env.CLAUDE_CODE_HEADLESS === '1';
+}
+
+// ── Stage 1: signal detection (pure) ────────────────────────────────────────
+//
+// Recall over precision by design: the live model's "append nothing" is the
+// real precision filter, so a mis-fire just produces no tag (~zero cost). These
+// patterns aim to catch the genuine "moment of insight", not to be exhaustive.
+
+const CORRECTION_PATTERNS = [
+  /^\s*(no|nope|nah|stop|wait)\b/i,
+  /\bthat'?s (not|wrong|incorrect)\b/i,
+  /\b(that|this) is (wrong|incorrect|not right)\b/i,
+  /\bdo ?n'?t\b/i,
+  /\b(actually|instead)\b/i,
+  /\bi (said|asked|told you|meant|wanted)\b/i,
+  /\byou (were supposed to|should(n'?t)? have|misunderstood|got it wrong)\b/i,
+  /\b(revert|undo|roll ?back)\b/i,
+  /\bwhy did you\b/i,
+  /\bnot what i\b/i,
+  /\b(that'?s|this is) not (it|right|correct)\b/i,
+];
+
+const DECISION_PATTERNS = [
+  /\blet'?s (go with|use|do|stick with)\b/i,
+  /\bwe'?ll (go with|use|do)\b/i,
+  /\b(decided|decision)\b/i,
+  /\bgoing with\b/i,
+  /\bthe plan is\b/i,
+  /\bwe should (use|go with|do)\b/i,
+  /\bi'?ll go with\b/i,
+];
+
+// Tight, low-false-positive markers only — tool output mentions "error" benignly
+// all the time, so we anchor on structured failure signals, not the bare word.
+const ERROR_PATTERNS = [
+  /"is_error"\s*:\s*true/,
+  /\bexit code [1-9]\d*/i,
+  /Traceback \(most recent call last\)/,
+  /\b\d+ (failed|failing)\b/i,
+];
+
+function anyMatch(patterns, text) {
+  if (!text) return false;
+  for (const re of patterns) if (re.test(text)) return true;
+  return false;
+}
+
+/**
+ * Classify the strongest signal in the current turn. `prompt` is the user's
+ * message; `transcriptTail` is recent transcript text (for error→fix / decision
+ * markers that live in the assistant/tool output).
+ *
+ * @param {string} prompt
+ * @param {string} [transcriptTail]
+ * @returns {{hit: boolean, kind: 'correction'|'decision'|'error_fix'|null}}
+ */
+export function detectSignal(prompt, transcriptTail = '') {
+  const p = typeof prompt === 'string' ? prompt : '';
+  const t = typeof transcriptTail === 'string' ? transcriptTail : '';
+  if (anyMatch(CORRECTION_PATTERNS, p)) return { hit: true, kind: 'correction' };
+  if (anyMatch(DECISION_PATTERNS, p) || anyMatch(DECISION_PATTERNS, t)) return { hit: true, kind: 'decision' };
+  if (anyMatch(ERROR_PATTERNS, t)) return { hit: true, kind: 'error_fix' };
+  return { hit: false, kind: null };
+}
+
+// ── Stage 1: the injected directive (DRY with #1187 /reflect) ───────────────
+
+/** The durability bar — single canonical wording shared by the capture
+ *  directive AND the distill prompt, mirroring `.claude/skills/reflect/SKILL.md`
+ *  Step 2 so the automatic path applies the exact same standard as `/reflect`. */
+export const DURABILITY_BAR =
+  'A durable lesson would help a FUTURE session on a DIFFERENT task: a reusable ' +
+  'pattern ("for X do Y because Z"), a recurring gotcha/trap, or a decision plus ' +
+  'the rationale future work must honor. NOT durable: "fixed bug X in file Y" ' +
+  '(that is git history), restating an existing rule, or session state.';
+
+const KIND_LABEL = {
+  correction: 'course-correction',
+  decision: 'decision',
+  error_fix: 'error-then-fix',
+};
+
+/**
+ * Build the answer-first capture directive injected as UserPromptSubmit context.
+ * Answer-first so the user's actual request is never degraded; "append nothing"
+ * is framed as the correct common outcome so a mis-fire is cheap.
+ *
+ * @param {'correction'|'decision'|'error_fix'} kind
+ * @returns {string}
+ */
+export function buildCaptureDirective(kind) {
+  const label = KIND_LABEL[kind] || 'notable moment';
+  return [
+    `[auto-reflect] A ${label} just occurred this session.`,
+    `FIRST: fully address the user's request as you normally would — do NOT let this note change your answer.`,
+    `THEN, only if a durable, reusable lesson emerged, append exactly ONE final line of the form:`,
+    `<reflect-capture>LESSON</reflect-capture>`,
+    `where LESSON is a single concise sentence (a pattern, gotcha, or decision+rationale).`,
+    DURABILITY_BAR,
+    `If nothing clears that bar, append nothing — silence is the correct, common outcome. Never emit more than one such line.`,
+  ].join('\n');
+}
+
+// ── Stage 1: rate-limit state ───────────────────────────────────────────────
+
+function stateFilePath(projectRoot) {
+  return resolve(projectRoot, '.moflo', STATE_FILE);
+}
+
+/**
+ * Decide whether an injection is allowed now, given persisted state. Limits:
+ * one directive per INJECT_WINDOW_MS, and at most INJECT_MAX_PER_SESSION per
+ * session. A new session id resets the per-session counter.
+ *
+ * @param {{sessionId?: string|null, lastInjectMs?: number, count?: number}|null} state
+ * @param {string|null} sessionId
+ * @param {number} now
+ * @returns {boolean}
+ */
+export function injectionAllowed(state, sessionId, now) {
+  if (!state || typeof state !== 'object') return true;
+  const sameSession = state.sessionId && sessionId && state.sessionId === sessionId;
+  if (!sameSession) return true; // fresh session — window + counter reset
+  if (typeof state.lastInjectMs === 'number' && now - state.lastInjectMs < INJECT_WINDOW_MS) return false;
+  if (typeof state.count === 'number' && state.count >= INJECT_MAX_PER_SESSION) return false;
+  return true;
+}
+
+/** Read rate-limit state (never throws). */
+export function readReflectState(projectRoot) {
+  try {
+    return JSON.parse(readFileSync(stateFilePath(projectRoot), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Persist rate-limit state after an injection, incrementing the per-session
+ *  counter (resets when the session id changes). */
+export function recordInjection(projectRoot, sessionId, now, prevState = null) {
+  const sameSession = prevState && prevState.sessionId === sessionId;
+  const count = sameSession && typeof prevState.count === 'number' ? prevState.count + 1 : 1;
+  atomicWriteJson(stateFilePath(projectRoot), { sessionId: sessionId ?? null, lastInjectMs: now, count });
+}
+
+// ── Stage 1: <reflect-capture> tag extraction (pure) ────────────────────────
+
+const CAPTURE_TAG_RE = /<reflect-capture>([\s\S]*?)<\/reflect-capture>/gi;
+// Drop the directive's own placeholder + non-lessons.
+const PLACEHOLDER_RE = /^(lesson|none|n\/?a|nothing)$/i;
+
+/** Extract lesson strings from a block of assistant text. Bounded + de-noised.
+ *  Uses matchAll (fresh internal iterator) rather than exec-with-/g so there's
+ *  no shared lastIndex state to reset/leak across calls. */
+export function extractCaptureTags(text) {
+  const out = [];
+  if (typeof text !== 'string' || !text) return out;
+  for (const m of text.matchAll(CAPTURE_TAG_RE)) {
+    const lesson = String(m[1] || '').replace(/\s+/g, ' ').trim();
+    if (lesson.length < 8) continue;            // empties / fragments
+    if (PLACEHOLDER_RE.test(lesson)) continue;  // the directive's "LESSON" placeholder
+    out.push(lesson.slice(0, MAX_LESSON_CHARS));
+  }
+  return out;
+}
+
+/**
+ * Extract captures from a transcript tail, restricted to ASSISTANT-role
+ * messages. This is what keeps the directive's own example tag (which rides in
+ * UserPromptSubmit context, not assistant output) from being scraped as a real
+ * capture. Tolerates a truncated leading JSONL line.
+ *
+ * @param {string} tailText - raw JSONL tail
+ * @returns {string[]}
+ */
+export function extractCapturesFromTranscript(tailText) {
+  const out = [];
+  if (typeof tailText !== 'string' || !tailText) return out;
+  for (const line of tailText.split('\n')) {
+    const t = line.trim();
+    if (!t || t[0] !== '{') continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; } // partial / non-JSON line
+    const role = obj?.message?.role ?? obj?.role;
+    if (role !== 'assistant') continue;
+    let content = obj?.message?.content ?? obj?.content;
+    if (Array.isArray(content)) {
+      content = content.map((b) => (typeof b === 'string' ? b : b?.text || '')).join('\n');
+    }
+    if (typeof content !== 'string') continue;
+    for (const lesson of extractCaptureTags(content)) out.push(lesson);
+  }
+  return out;
+}
+
+// ── Ledger (.moflo/reflect-ledger.json) ─────────────────────────────────────
+
+function ledgerFilePath(projectRoot) {
+  return resolve(projectRoot, '.moflo', LEDGER_FILE);
+}
+
+/** Atomic temp+rename JSON write (crash-safe; a half-write never lands). */
+function atomicWriteJson(dest, obj) {
+  mkdirSync(dirname(dest), { recursive: true });
+  const tmp = `${dest}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+  writeFileSync(tmp, JSON.stringify(obj), 'utf-8');
+  renameSync(tmp, dest);
+}
+
+/** Read the ledger (never throws; returns an empty ledger on absence/malformed). */
+export function readLedger(projectRoot) {
+  try {
+    const obj = JSON.parse(readFileSync(ledgerFilePath(projectRoot), 'utf-8'));
+    if (obj && Array.isArray(obj.entries)) return obj;
+  } catch {
+    // absent or mid-write — start fresh
+  }
+  return { entries: [] };
+}
+
+/** Entries not yet distilled, oldest first. */
+export function pendingEntries(ledger) {
+  const entries = ledger && Array.isArray(ledger.entries) ? ledger.entries : [];
+  return entries.filter((e) => e && !e.distilled && typeof e.lesson === 'string');
+}
+
+function normalizeLesson(s) {
+  return String(s || '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** Cap ledger size — drop distilled entries first (keep KEEP_DISTILLED newest),
+ *  then oldest pending if still over cap. Pure; returns a new entries array.
+ *  Membership is keyed by entry id (a Set), not object reference, so the cap
+ *  stays correct even if entries are ever cloned (e.g. a JSON round-trip). */
+function capEntries(entries) {
+  if (entries.length <= MAX_LEDGER_ENTRIES) return entries;
+  const distilled = entries.filter((e) => e.distilled);
+  // Keep the newest KEEP_DISTILLED distilled, preserving order.
+  const keptDistilledIds = new Set(
+    (distilled.length > KEEP_DISTILLED ? distilled.slice(distilled.length - KEEP_DISTILLED) : distilled)
+      .map((e) => e.id),
+  );
+  let merged = entries.filter((e) => (e.distilled ? keptDistilledIds.has(e.id) : true));
+  if (merged.length > MAX_LEDGER_ENTRIES) {
+    // Still over — drop oldest pending (front of array).
+    const overflow = merged.length - MAX_LEDGER_ENTRIES;
+    let dropped = 0;
+    merged = merged.filter((e) => {
+      if (dropped < overflow && !e.distilled) { dropped++; return false; }
+      return true;
+    });
+  }
+  return merged;
+}
+
+/**
+ * Append new captures to the ledger, skipping ones whose lesson already exists
+ * (normalized) — the Stop scrape re-reads an overlapping tail each turn, so
+ * dedup-on-append prevents the same lesson landing twice. Dedup is best-effort
+ * (read-then-write, not a transaction): correct because Claude Code serialises a
+ * session's Stop hooks, so there is no concurrent writer to race against. The
+ * distill's separate semantic dedup (≥0.80) is the real backstop.
+ *
+ * @param {string} projectRoot
+ * @param {Array<{lesson: string, kind?: string, sessionId?: string|null}>} captures
+ * @param {number} [now]
+ * @returns {number} count actually appended
+ */
+export function appendLedgerEntries(projectRoot, captures, now = Date.now()) {
+  const list = Array.isArray(captures) ? captures : [];
+  if (list.length === 0) return 0;
+  const ledger = readLedger(projectRoot);
+  const seen = new Set(ledger.entries.map((e) => normalizeLesson(e.lesson)));
+  let appended = 0;
+  for (const c of list) {
+    const lesson = String(c?.lesson || '').replace(/\s+/g, ' ').trim().slice(0, MAX_LESSON_CHARS);
+    if (lesson.length < 8) continue;
+    const norm = normalizeLesson(lesson);
+    if (seen.has(norm)) continue;
+    seen.add(norm);
+    ledger.entries.push({
+      id: `${now.toString(36)}-${randomBytes(3).toString('hex')}`,
+      lesson,
+      kind: c?.kind || null,
+      sessionId: c?.sessionId ?? null,
+      capturedAt: now,
+      distilled: false,
+    });
+    appended++;
+  }
+  if (appended === 0) return 0;
+  ledger.entries = capEntries(ledger.entries);
+  atomicWriteJson(ledgerFilePath(projectRoot), ledger);
+  return appended;
+}
+
+/**
+ * Mark the given entry ids distilled. New captures that arrived during the
+ * distill run keep `distilled:false` and survive for the next pass.
+ *
+ * @param {string} projectRoot
+ * @param {string[]} ids
+ * @returns {number} count marked
+ */
+export function markLedgerDistilled(projectRoot, ids) {
+  const idSet = new Set(Array.isArray(ids) ? ids : []);
+  if (idSet.size === 0) return 0;
+  const ledger = readLedger(projectRoot);
+  let marked = 0;
+  for (const e of ledger.entries) {
+    if (e && idSet.has(e.id) && !e.distilled) { e.distilled = true; marked++; }
+  }
+  if (marked === 0) return 0;
+  ledger.entries = capEntries(ledger.entries);
+  atomicWriteJson(ledgerFilePath(projectRoot), ledger);
+  return marked;
+}
+
+// ── Stage 2: distill prompt (DRY with #1187 /reflect) ───────────────────────
+
+/**
+ * Build the bounded headless-Haiku distillation prompt over the pending ledger
+ * entries. Reuses the `/reflect` protocol (search → dedup ≥0.80 → store) rather
+ * than forking it, and instructs writes through the MCP memory tools so they
+ * route via the daemon single-writer chokepoint (#981) — writer-safe.
+ *
+ * @param {Array<{lesson: string}>} entries
+ * @returns {string}
+ */
+export function buildDistillPrompt(entries) {
+  const list = (Array.isArray(entries) ? entries : []).filter((e) => e && e.lesson);
+  const numbered = list.map((e, i) => `${i + 1}. ${e.lesson}`).join('\n');
+  return [
+    `You are running moflo's automatic /reflect distillation (#1198) headlessly. Below are raw candidate lessons captured during a recent session — one per line. Persist the durable keepers to long-term memory, deduped. Be terse; do not write files.`,
+    ``,
+    `Candidates:`,
+    numbered,
+    ``,
+    `Procedure — reuse the /reflect protocol, do not invent a new one:`,
+    `1. For EACH candidate, call mcp__moflo__memory_search { namespace: "learnings", query: <bare keywords>, threshold: 0.6, limit: 5 }.`,
+    `2. If the top hit is the SAME fact at similarity >= 0.80, call mcp__moflo__memory_store with that SAME key (upsert), merging any new nuance — do NOT create a near-duplicate.`,
+    `3. Otherwise call mcp__moflo__memory_store { namespace: "learnings", key: <stable descriptive slug>, value: "<lesson> — Why: <why it matters>. How to apply: <what to do next time>.", tags: [<topic>, <area>] }.`,
+    `4. Skip any candidate that does not clear the durability bar below, or that merely restates an existing entry.`,
+    ``,
+    DURABILITY_BAR,
+    ``,
+    `When finished, output one line only: "distilled <new>, updated <merged>, skipped <n>".`,
+  ].join('\n');
+}

--- a/bin/lib/reflect.mjs
+++ b/bin/lib/reflect.mjs
@@ -19,10 +19,11 @@
  *     judge: the durability gate already passed upstream in the live model, so
  *     unattended runs cannot pollute `learnings` with junk.
  *
- * Default-OFF (moflo.yaml `auto_reflect.enabled`). Every entry point early-
- * returns cheaply when the flag is off OR `CLAUDE_CODE_HEADLESS` is set — the
- * distill's own headless session must never re-enter capture or re-spawn distill
- * (the #860 / infinite-spawn guard the prior finding flagged).
+ * Default-ON (opt out via moflo.yaml `auto_reflect.enabled: false`). Shipped
+ * default-on from #1198; the `rc` dist-tag gated the initial rollout. Every
+ * entry point still early-returns cheaply when the flag is off OR
+ * `CLAUDE_CODE_HEADLESS` is set — the distill's own headless session must never
+ * re-enter capture or re-spawn distill (the #860 / infinite-spawn guard).
  *
  * STORAGE: `.moflo/reflect-ledger.json` (single file) + `.moflo/reflect-state.json`
  * (rate-limit). Deliberately NOT under `.moflo/continuity/` — that directory is
@@ -59,14 +60,15 @@ const STATE_FILE = 'reflect-state.json';
 
 /**
  * Read the `auto_reflect` block from moflo.yaml without a YAML parser. Defaults
- * OFF — auto-reflect touches the session hot path in every consumer and must be
- * opt-in until measured (#1198 blast-radius posture).
+ * ON — opt out with `auto_reflect.enabled: false`. (#1198 ships default-on; the
+ * `rc` dist-tag gated the initial rollout.) Stays ON on a mid-write/malformed
+ * file, consistent with the on default.
  *
  * @param {string} projectRoot
  * @returns {{enabled: boolean}}
  */
 export function readReflectConfig(projectRoot) {
-  const cfg = { enabled: false };
+  const cfg = { enabled: true };
   try {
     const yamlPath = resolve(projectRoot, 'moflo.yaml');
     if (!existsSync(yamlPath)) return cfg;
@@ -74,7 +76,7 @@ export function readReflectConfig(projectRoot) {
     const enabled = text.match(/auto_reflect:\s*\n(?:\s+\w+:.*\n)*?\s+enabled:\s*(true|false)/);
     if (enabled) cfg.enabled = enabled[1] === 'true';
   } catch {
-    // Default OFF keeps the feature inert if the file is mid-write / malformed.
+    // Default ON keeps the feature live if the file is mid-write / malformed.
   }
   return cfg;
 }

--- a/bin/lib/shipped-scripts.json
+++ b/bin/lib/shipped-scripts.json
@@ -13,7 +13,9 @@
     "index-all.mjs",
     "setup-project.mjs",
     "run-migrations.mjs",
-    "session-continuity.mjs"
+    "session-continuity.mjs",
+    "reflect-capture.mjs",
+    "reflect-distill.mjs"
   ],
   "binHelperFiles": [
     "gate.cjs",

--- a/bin/lib/yaml-upgrader.mjs
+++ b/bin/lib/yaml-upgrader.mjs
@@ -37,6 +37,17 @@ session_continuity:
 `,
   },
   {
+    key: 'auto_reflect',
+    block: `# Auto-reflect (#1198) — the automatic counterpart to /reflect. When enabled,
+# moflo recognizes durable lessons in the LIVE session (a tiny answer-first note
+# on course-corrections / errors / decisions) and distills them into long-term
+# memory at the next session-start via a cheap headless Haiku pass — deduped.
+# Touches the session hot path, so it ships OFF; turn it on to opt in.
+auto_reflect:
+  enabled: false
+`,
+  },
+  {
     key: 'sandbox',
     block: `# Spell step sandboxing (OS-level process isolation for bash steps)
 # Platform support: macOS (sandbox-exec), Linux/WSL (bwrap). Windows has no OS sandbox.

--- a/bin/lib/yaml-upgrader.mjs
+++ b/bin/lib/yaml-upgrader.mjs
@@ -42,9 +42,9 @@ session_continuity:
 # moflo recognizes durable lessons in the LIVE session (a tiny answer-first note
 # on course-corrections / errors / decisions) and distills them into long-term
 # memory at the next session-start via a cheap headless Haiku pass — deduped.
-# Touches the session hot path, so it ships OFF; turn it on to opt in.
+# Ships ON; set false to opt out.
 auto_reflect:
-  enabled: false
+  enabled: true
 `,
   },
   {

--- a/bin/reflect-capture.mjs
+++ b/bin/reflect-capture.mjs
@@ -34,6 +34,7 @@ import {
   readReflectConfig,
   isHeadless,
   detectSignal,
+  recentTranscriptTurn,
   buildCaptureDirective,
   injectionAllowed,
   readReflectState,
@@ -66,16 +67,20 @@ async function detect() {
   const { projectRoot } = ctx;
 
   const input = await readHookStdin();
-  const prompt = input.prompt || input.user_prompt || '';
+  const prompt = (input.prompt || input.user_prompt || '').trim();
+  // No real user prompt (system reminder / task-notification re-invocation) →
+  // there's no "moment" to attach a directive to. Skip — this is the dominant
+  // false-fire source the live dogfood surfaced.
+  if (!prompt) return;
 
   // Cheapest path first: corrections + in-prompt decisions need only the prompt.
-  // Read the (32KB) transcript tail for error→fix / in-transcript decisions ONLY
-  // when the prompt alone produced no signal — saves the read on the common
-  // correction case.
+  // Only when the prompt alone yields nothing do we read the transcript and scope
+  // to the MOST RECENT turn (post-last-user-message) — scanning the full tail
+  // re-fires on stale error/decision markers from earlier in the session.
   let signal = detectSignal(prompt, '');
   if (!signal.hit) {
     const tail = readFileTail(input.transcript_path || input.transcriptPath, TRANSCRIPT_TAIL_BYTES);
-    if (tail) signal = detectSignal(prompt, tail);
+    if (tail) signal = detectSignal(prompt, recentTranscriptTurn(tail));
   }
   if (!signal.hit) return;
 

--- a/bin/reflect-capture.mjs
+++ b/bin/reflect-capture.mjs
@@ -56,7 +56,7 @@ function warn(msg) {
 function gate() {
   if (isHeadless(process.env)) return null;          // #860 — never run inside the distill's own session
   const projectRoot = findProjectRoot();
-  if (!readReflectConfig(projectRoot).enabled) return null; // default-off
+  if (!readReflectConfig(projectRoot).enabled) return null; // off (opt-out)
   return { projectRoot };
 }
 

--- a/bin/reflect-capture.mjs
+++ b/bin/reflect-capture.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Auto-reflect Stage 1 — CAPTURE (#1198). One script, two hook entry points:
+ *
+ *   detect  (UserPromptSubmit) — mechanically score the user's prompt + recent
+ *           transcript tail for a strong signal (course-correction / error→fix /
+ *           decision). On a hit, and within rate limits, print an answer-first
+ *           directive asking the LIVE model — which has full context at the
+ *           moment of insight — to append ONE <reflect-capture> line IF a durable
+ *           lesson emerged. Stdout from a UserPromptSubmit hook is added to the
+ *           model's context (same mechanism as .claude/helpers/prompt-hook.mjs).
+ *
+ *   scrape  (Stop) — read the transcript tail, extract <reflect-capture> tags
+ *           from the last ASSISTANT message(s), and append the raw one-liners to
+ *           the JSON ledger (.moflo/reflect-ledger.json). No moflo.db write, no
+ *           dedup yet — the bounded Haiku distill (bin/reflect-distill.mjs) does
+ *           that later, writer-safe, via memory_store.
+ *
+ * Both modes early-return cheaply when auto-reflect is OFF or CLAUDE_CODE_HEADLESS
+ * is set — the distill's own headless session must never re-enter capture (#860).
+ * A hook must NEVER throw: every path is wrapped and degrades to a silent exit 0.
+ *
+ * Invoked by:
+ *   node .claude/scripts/reflect-capture.mjs reflect-detect   (UserPromptSubmit)
+ *   node .claude/scripts/reflect-capture.mjs reflect-scrape    (Stop)
+ *
+ * Cross-platform (Rule #1): Node fs/path primitives only; no shell.
+ */
+
+import { findProjectRoot } from './lib/moflo-paths.mjs';
+import { readHookStdin, readFileTail } from './lib/hook-io.mjs';
+import {
+  TRANSCRIPT_TAIL_BYTES,
+  readReflectConfig,
+  isHeadless,
+  detectSignal,
+  buildCaptureDirective,
+  injectionAllowed,
+  readReflectState,
+  recordInjection,
+  extractCapturesFromTranscript,
+  appendLedgerEntries,
+} from './lib/reflect.mjs';
+
+// Scrape needs to reliably catch the tag at the END of the assistant's reply,
+// which can be a single large JSONL line — read a generous tail. Detect only
+// needs recent error/decision markers, so the smaller shared window suffices.
+const SCRAPE_TAIL_BYTES = 262_144;
+
+function warn(msg) {
+  try { process.stderr.write(`moflo: reflect-capture ${msg}\n`); } catch { /* never throw from a hook */ }
+}
+
+/** Shared preamble: resolve root + config, applying the OFF / headless guards.
+ *  Returns null when the caller should early-exit. */
+function gate() {
+  if (isHeadless(process.env)) return null;          // #860 — never run inside the distill's own session
+  const projectRoot = findProjectRoot();
+  if (!readReflectConfig(projectRoot).enabled) return null; // default-off
+  return { projectRoot };
+}
+
+async function detect() {
+  const ctx = gate();
+  if (!ctx) return;
+  const { projectRoot } = ctx;
+
+  const input = await readHookStdin();
+  const prompt = input.prompt || input.user_prompt || '';
+
+  // Cheapest path first: corrections + in-prompt decisions need only the prompt.
+  // Read the (32KB) transcript tail for error→fix / in-transcript decisions ONLY
+  // when the prompt alone produced no signal — saves the read on the common
+  // correction case.
+  let signal = detectSignal(prompt, '');
+  if (!signal.hit) {
+    const tail = readFileTail(input.transcript_path || input.transcriptPath, TRANSCRIPT_TAIL_BYTES);
+    if (tail) signal = detectSignal(prompt, tail);
+  }
+  if (!signal.hit) return;
+
+  const sessionId = input.session_id || input.sessionId || null;
+  const now = Date.now();
+  const state = readReflectState(projectRoot);
+  if (!injectionAllowed(state, sessionId, now)) return; // rate-limited
+
+  try {
+    process.stdout.write(buildCaptureDirective(signal.kind) + '\n');
+  } catch {
+    return; // broken stdout — don't record an injection that didn't land
+  }
+  recordInjection(projectRoot, sessionId, now, state);
+}
+
+async function scrape() {
+  const ctx = gate();
+  if (!ctx) return;
+  const { projectRoot } = ctx;
+
+  const input = await readHookStdin();
+  const tail = readFileTail(input.transcript_path || input.transcriptPath, SCRAPE_TAIL_BYTES);
+  if (!tail) return;
+
+  const lessons = extractCapturesFromTranscript(tail);
+  if (lessons.length === 0) return;
+
+  const sessionId = input.session_id || input.sessionId || null;
+  appendLedgerEntries(projectRoot, lessons.map((lesson) => ({ lesson, kind: 'captured', sessionId })));
+}
+
+const sub = process.argv[2];
+if (sub === 'reflect-detect') {
+  detect().catch((err) => warn(`detect failed (${err && err.message ? err.message : String(err)})`));
+} else if (sub === 'reflect-scrape') {
+  scrape().catch((err) => warn(`scrape failed (${err && err.message ? err.message : String(err)})`));
+} else {
+  warn(`unknown subcommand "${sub || ''}" (expected: reflect-detect | reflect-scrape)`);
+}

--- a/bin/reflect-distill.mjs
+++ b/bin/reflect-distill.mjs
@@ -13,7 +13,7 @@
  * pollute `learnings` with junk it invented.
  *
  * GUARDS:
- *   - default-off (auto_reflect.enabled) — exit immediately when off.
+ *   - off (auto_reflect.enabled: false) — exit immediately. Default is ON.
  *   - CLAUDE_CODE_HEADLESS — exit immediately (defensive; the launcher already
  *     won't fire us in headless, but self-guarding prevents any infinite spawn).
  *   - empty ledger — exit without spawning anything.
@@ -97,7 +97,7 @@ function runHeadless(projectRoot, prompt) {
 async function main() {
   if (isHeadless(process.env)) return;                       // #860 self-guard
   const projectRoot = findProjectRoot();
-  if (!readReflectConfig(projectRoot).enabled) return;       // default-off
+  if (!readReflectConfig(projectRoot).enabled) return;       // off (opt-out)
 
   const pending = pendingEntries(readLedger(projectRoot));
   if (pending.length === 0) return;                          // nothing to do — no spawn

--- a/bin/reflect-distill.mjs
+++ b/bin/reflect-distill.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Auto-reflect Stage 2 — DISTILL (#1198). Fired DETACHED by the session-start
+ * launcher (never inline — the launcher's contract is spawn-and-exit). Runs ONE
+ * bounded headless Haiku `claude --print` that executes #1187's /reflect
+ * distillation over the ledger one-liners (NOT the transcript): dedup-search
+ * `learnings` (≥0.80 → update same key), store via memory_store. Because the
+ * headless session calls memory_store itself, writes route through the daemon
+ * single-writer chokepoint (#981) — writer-safe, no raw cross-process db write.
+ *
+ * Haiku is a FORMATTER, not a judge: the durability gate already passed upstream
+ * in the live model when the lesson was captured, so this unattended pass cannot
+ * pollute `learnings` with junk it invented.
+ *
+ * GUARDS:
+ *   - default-off (auto_reflect.enabled) — exit immediately when off.
+ *   - CLAUDE_CODE_HEADLESS — exit immediately (defensive; the launcher already
+ *     won't fire us in headless, but self-guarding prevents any infinite spawn).
+ *   - empty ledger — exit without spawning anything.
+ *
+ * Only entries in the snapshot we hand to Haiku are marked distilled on success,
+ * so captures that arrive DURING the run survive for the next pass.
+ *
+ * Test seam: MOFLO_REFLECT_DISTILL_NODE_STUB — when set to a path, the model
+ * call is `node <stub> --print <prompt>` instead of `claude --print <prompt>`,
+ * so the spawn is exercisable cross-platform without a real Claude CLI.
+ *
+ * Invoked by: node .claude/scripts/reflect-distill.mjs
+ *
+ * Cross-platform (Rule #1): Node child_process (arg arrays, no shell) + fs/path.
+ */
+
+import { spawn } from 'child_process';
+import { appendFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { findProjectRoot } from './lib/moflo-paths.mjs';
+import {
+  HAIKU_MODEL_ID,
+  readReflectConfig,
+  isHeadless,
+  readLedger,
+  pendingEntries,
+  buildDistillPrompt,
+  markLedgerDistilled,
+} from './lib/reflect.mjs';
+
+/** Cap candidates per pass — keeps the Haiku prompt small (cheap, fast). Extra
+ *  pending entries roll into the next session's pass. */
+const DISTILL_BATCH_MAX = 25;
+/** Hard ceiling on the headless run; killed past this. */
+const DISTILL_TIMEOUT_MS = 120_000;
+
+function log(projectRoot, line) {
+  try {
+    const p = resolve(projectRoot, '.moflo', 'reflect-distill.log');
+    mkdirSync(dirname(p), { recursive: true });
+    appendFileSync(p, `[${new Date().toISOString()}] ${line}\n`, 'utf-8');
+  } catch { /* logging is best-effort — never throw */ }
+}
+
+/** Run the bounded headless distillation. Resolves { success, output }. */
+function runHeadless(projectRoot, prompt) {
+  return new Promise((res) => {
+    const stub = process.env.MOFLO_REFLECT_DISTILL_NODE_STUB;
+    const cmd = stub ? process.execPath : 'claude';
+    const args = stub ? [stub, '--print', prompt] : ['--print', prompt];
+
+    const env = {
+      ...process.env,
+      CLAUDE_CODE_HEADLESS: 'true',     // mark the child so its own hooks no-op (#860)
+      ANTHROPIC_MODEL: HAIKU_MODEL_ID,  // cheap formatter model
+    };
+
+    let child;
+    try {
+      child = spawn(cmd, args, { cwd: projectRoot, env, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+    } catch (err) {
+      res({ success: false, output: '', error: err && err.message ? err.message : String(err) });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (r) => { if (done) return; done = true; clearTimeout(timer); res(r); };
+    const timer = setTimeout(() => {
+      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+      finish({ success: false, output: out, error: `timed out after ${DISTILL_TIMEOUT_MS}ms` });
+    }, DISTILL_TIMEOUT_MS);
+
+    child.stdout?.on('data', (d) => { out += d.toString(); });
+    child.stderr?.on('data', (d) => { out += d.toString(); });
+    child.on('error', (err) => finish({ success: false, output: out, error: err && err.message ? err.message : String(err) }));
+    child.on('close', (code) => finish({ success: code === 0, output: out }));
+  });
+}
+
+async function main() {
+  if (isHeadless(process.env)) return;                       // #860 self-guard
+  const projectRoot = findProjectRoot();
+  if (!readReflectConfig(projectRoot).enabled) return;       // default-off
+
+  const pending = pendingEntries(readLedger(projectRoot));
+  if (pending.length === 0) return;                          // nothing to do — no spawn
+
+  const batch = pending.slice(0, DISTILL_BATCH_MAX);
+  const prompt = buildDistillPrompt(batch);
+
+  const result = await runHeadless(projectRoot, prompt);
+  if (result.success) {
+    const marked = markLedgerDistilled(projectRoot, batch.map((e) => e.id));
+    const summary = String(result.output || '').trim().split('\n').filter(Boolean).pop() || '(no summary)';
+    log(projectRoot, `distilled ${batch.length} candidate(s), marked ${marked} — haiku: ${summary.slice(0, 200)}`);
+  } else {
+    // Leave the ledger untouched so the next session retries.
+    log(projectRoot, `distill failed (${result.error || 'non-zero exit'}) — ${batch.length} candidate(s) retained for retry`);
+  }
+}
+
+main().catch((err) => {
+  try { process.stderr.write(`moflo: reflect-distill failed (${err && err.message ? err.message : String(err)})\n`); } catch { /* ignore */ }
+});

--- a/bin/session-continuity.mjs
+++ b/bin/session-continuity.mjs
@@ -30,6 +30,7 @@ import { resolve, dirname } from 'path';
 import { findProjectRoot } from './lib/moflo-paths.mjs';
 import { openBackend } from './lib/get-backend.mjs';
 import { scrubSecrets } from './lib/pii-scrub.mjs';
+import { readHookStdin } from './lib/hook-io.mjs';
 import {
   readContinuityConfig,
   readGitState,
@@ -45,23 +46,6 @@ const LEARNINGS_SAMPLE = 5;     // how many recent learnings to fold in as "deci
 
 function warn(msg) {
   try { process.stderr.write(`moflo: session-continuity ${msg}\n`); } catch { /* never throw from a hook */ }
-}
-
-/** Read the Stop hook's JSON stdin (session_id, transcript_path). Bounded so a
- *  missing/withheld stdin can never hang the hook. */
-async function readHookInput() {
-  if (process.stdin.isTTY) return {};
-  return new Promise((res) => {
-    let data = '';
-    let done = false;
-    const parse = (s) => { try { return s ? JSON.parse(s) : {}; } catch { return {}; } };
-    const finish = () => { if (done) return; done = true; res(parse(data)); };
-    process.stdin.setEncoding('utf-8');
-    process.stdin.on('data', (c) => { if (!done) data += c; });
-    process.stdin.on('end', finish);
-    process.stdin.on('error', finish);
-    setTimeout(finish, 500);
-  });
 }
 
 /** First user message (the session goal) from a transcript JSONL head. */
@@ -174,7 +158,7 @@ async function capture() {
   const cfg = readContinuityConfig(projectRoot);
   if (!cfg.capture) return;
 
-  const input = await readHookInput();
+  const input = await readHookStdin();
   const sessionId = input.session_id || input.sessionId || null;
   const now = Date.now();
 

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -25,6 +25,11 @@ import {
   selectBestDigest,
   formatInjection,
 } from './lib/session-continuity.mjs';
+import {
+  readReflectConfig,
+  readLedger as readReflectLedger,
+  pendingEntries as pendingReflectEntries,
+} from './lib/reflect.mjs';
 
 // Headless skip (#860). The daemon's headless workers spawn `claude --print`
 // with CLAUDE_CODE_HEADLESS=true (see src/cli/services/headless-worker-
@@ -2223,6 +2228,26 @@ try {
   maybeInjectContinuity();
 } catch (err) {
   emitWarning(`continuity injection skipped (${errMessage(err)})`);
+}
+
+// Auto-reflect Stage 2 — DISTILL (#1198). Default-off. When enabled AND the
+// capture ledger holds un-distilled lessons, fire-and-forget the DETACHED
+// distill orchestrator — it runs ONE bounded headless Haiku /reflect over the
+// ledger one-liners and writes `learnings` via memory_store (daemon-routed,
+// writer-safe). The gate here is cheap (a config read + a ledger read); the
+// spawn + model call live entirely in the detached child, so the launcher's
+// spawn-and-exit contract holds. CLAUDE_CODE_HEADLESS is guarded at the top of
+// this file, so a headless session never reaches here (no infinite spawn).
+function maybeFireReflectDistill() {
+  if (!readReflectConfig(projectRoot).enabled) return;
+  if (pendingReflectEntries(readReflectLedger(projectRoot)).length === 0) return;
+  const distillScript = resolveMofloBin(projectRoot, null, 'reflect-distill.mjs');
+  if (distillScript) fireAndForget('node', [distillScript], 'reflect-distill');
+}
+try {
+  maybeFireReflectDistill();
+} catch (err) {
+  emitWarning(`reflect distill spawn skipped (${errMessage(err)})`);
 }
 
 // Bypasses emitMutation — framing, not a mutation, so it must not inflate the count.

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -64,6 +64,17 @@ export interface MofloConfig {
     max_age_hours: number;
   };
 
+  /**
+   * Auto-reflect (#1198) — the automatic counterpart to `/reflect`. When
+   * `enabled`, a UserPromptSubmit hook recognizes durable lessons in the LIVE
+   * session and a session-start pass distills them into the `learnings`
+   * namespace via a bounded headless Haiku run. Touches the session hot path in
+   * every consumer, so it defaults OFF — opt-in until measured (#1198).
+   */
+  auto_reflect: {
+    enabled: boolean;
+  };
+
   memory: {
     /**
      * Memory backend selection. Maps directly to the
@@ -197,6 +208,9 @@ const DEFAULT_CONFIG: MofloConfig = {
     capture: true,
     inject: true,
     max_age_hours: 72,
+  },
+  auto_reflect: {
+    enabled: false,
   },
   memory: {
     backend: 'node-sqlite',
@@ -368,6 +382,9 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
       capture: raw.session_continuity?.capture ?? raw.sessionContinuity?.capture ?? DEFAULT_CONFIG.session_continuity.capture,
       inject: raw.session_continuity?.inject ?? raw.sessionContinuity?.inject ?? DEFAULT_CONFIG.session_continuity.inject,
       max_age_hours: raw.session_continuity?.max_age_hours ?? raw.sessionContinuity?.maxAgeHours ?? DEFAULT_CONFIG.session_continuity.max_age_hours,
+    },
+    auto_reflect: {
+      enabled: raw.auto_reflect?.enabled ?? raw.autoReflect?.enabled ?? DEFAULT_CONFIG.auto_reflect.enabled,
     },
     memory: {
       backend: coerceMemoryBackend(raw.memory?.backend),

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -68,8 +68,8 @@ export interface MofloConfig {
    * Auto-reflect (#1198) — the automatic counterpart to `/reflect`. When
    * `enabled`, a UserPromptSubmit hook recognizes durable lessons in the LIVE
    * session and a session-start pass distills them into the `learnings`
-   * namespace via a bounded headless Haiku run. Touches the session hot path in
-   * every consumer, so it defaults OFF — opt-in until measured (#1198).
+   * namespace via a bounded headless Haiku run. Defaults ON (opt out with
+   * `enabled: false`); the `rc` dist-tag gated the initial rollout.
    */
   auto_reflect: {
     enabled: boolean;
@@ -210,7 +210,7 @@ const DEFAULT_CONFIG: MofloConfig = {
     max_age_hours: 72,
   },
   auto_reflect: {
-    enabled: false,
+    enabled: true,
   },
   memory: {
     backend: 'node-sqlite',

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -233,6 +233,14 @@ session_continuity:
   inject: true
   max_age_hours: 72            # ignore digests older than this when injecting
 
+# Auto-reflect (#1198) — the automatic counterpart to /reflect. When enabled,
+# moflo recognizes durable lessons in the LIVE session (a tiny answer-first note
+# on course-corrections / errors / decisions) and distills them into long-term
+# memory at the next session-start via a cheap headless Haiku pass — deduped.
+# Touches the session hot path, so it ships OFF; turn it on to opt in.
+auto_reflect:
+  enabled: false
+
 # Memory backend
 memory:
   backend: node-sqlite
@@ -343,6 +351,7 @@ export const REQUIRED_TOP_LEVEL_SECTIONS = [
   'gates',
   'auto_index',
   'session_continuity',
+  'auto_reflect',
   'memory',
   'hooks',
   'mcp',

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -237,9 +237,9 @@ session_continuity:
 # moflo recognizes durable lessons in the LIVE session (a tiny answer-first note
 # on course-corrections / errors / decisions) and distills them into long-term
 # memory at the next session-start via a cheap headless Haiku pass — deduped.
-# Touches the session hot path, so it ships OFF; turn it on to opt in.
+# Ships ON; set false to opt out.
 auto_reflect:
-  enabled: false
+  enabled: true
 
 # Memory backend
 memory:

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -201,6 +201,13 @@ function continuityCmd(subcommand: string): string {
   return hookCmdEsm('"$CLAUDE_PROJECT_DIR/.claude/scripts/session-continuity.mjs"', subcommand);
 }
 
+/** Shorthand for the ESM auto-reflect capture command (#1198). Default-OFF in
+ *  the script (gated on auto_reflect.enabled), so wiring it into every consumer
+ *  is inert until opt-in. Lives in .claude/scripts/ beside its ./lib/ helpers. */
+function reflectCaptureCmd(subcommand: string): string {
+  return hookCmdEsm('"$CLAUDE_PROJECT_DIR/.claude/scripts/reflect-capture.mjs"', subcommand);
+}
+
 /** Shorthand for gate commands (lightweight JSON state checks) */
 function gateCmd(subcommand: string): string {
   return hookCmd('"$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs"', subcommand);
@@ -375,6 +382,13 @@ function generateHooksConfig(config: HooksConfig): object {
           { type: 'command', command: gateHookCmd('prompt-state-reset'), timeout: 3000 },
         ],
       },
+      // #1198 — auto-reflect Stage 1 (detect). Default-OFF in-script; injects an
+      // answer-first capture directive only on a strong signal + within limits.
+      {
+        hooks: [
+          { type: 'command', command: reflectCaptureCmd('reflect-detect'), timeout: 3000 },
+        ],
+      },
     ];
   }
 
@@ -419,6 +433,9 @@ function generateHooksConfig(config: HooksConfig): object {
           { type: 'command', command: hookHandlerCmd('session-end'), timeout: 5000 },
           { type: 'command', command: autoMemoryCmd('sync'), timeout: 10000 },
           { type: 'command', command: continuityCmd('capture'), timeout: 5000 },
+          // #1198 — auto-reflect Stage 1 (scrape). Default-OFF in-script; harvests
+          // <reflect-capture> tags from the assistant turn into the ledger.
+          { type: 'command', command: reflectCaptureCmd('reflect-scrape'), timeout: 5000 },
         ],
       },
     ];

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -201,9 +201,9 @@ function continuityCmd(subcommand: string): string {
   return hookCmdEsm('"$CLAUDE_PROJECT_DIR/.claude/scripts/session-continuity.mjs"', subcommand);
 }
 
-/** Shorthand for the ESM auto-reflect capture command (#1198). Default-OFF in
- *  the script (gated on auto_reflect.enabled), so wiring it into every consumer
- *  is inert until opt-in. Lives in .claude/scripts/ beside its ./lib/ helpers. */
+/** Shorthand for the ESM auto-reflect capture command (#1198). Default-ON
+ *  (the script no-ops only when auto_reflect.enabled is false). Lives in
+ *  .claude/scripts/ beside its ./lib/ helpers. */
 function reflectCaptureCmd(subcommand: string): string {
   return hookCmdEsm('"$CLAUDE_PROJECT_DIR/.claude/scripts/reflect-capture.mjs"', subcommand);
 }
@@ -382,7 +382,7 @@ function generateHooksConfig(config: HooksConfig): object {
           { type: 'command', command: gateHookCmd('prompt-state-reset'), timeout: 3000 },
         ],
       },
-      // #1198 — auto-reflect Stage 1 (detect). Default-OFF in-script; injects an
+      // #1198 — auto-reflect Stage 1 (detect). Default-ON; injects an
       // answer-first capture directive only on a strong signal + within limits.
       {
         hooks: [
@@ -433,7 +433,7 @@ function generateHooksConfig(config: HooksConfig): object {
           { type: 'command', command: hookHandlerCmd('session-end'), timeout: 5000 },
           { type: 'command', command: autoMemoryCmd('sync'), timeout: 10000 },
           { type: 'command', command: continuityCmd('capture'), timeout: 5000 },
-          // #1198 — auto-reflect Stage 1 (scrape). Default-OFF in-script; harvests
+          // #1198 — auto-reflect Stage 1 (scrape). Default-ON; harvests
           // <reflect-capture> tags from the assistant turn into the ledger.
           { type: 'command', command: reflectCaptureCmd('reflect-scrape'), timeout: 5000 },
         ],

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -153,7 +153,7 @@ export function getReferenceHookBlock(): HooksTree {
       { hooks: [helperHook('prompt-hook.mjs', '', 3000)] },
       // #931 — Defensive safety-net hook. State reset only, no emission.
       { hooks: [gateHook('prompt-state-reset', 3000)] },
-      // #1198 — auto-reflect capture (detect). Default-OFF in-script.
+      // #1198 — auto-reflect capture (detect). Default-ON (opt-out in-script).
       { hooks: [scriptHookSub('reflect-capture.mjs', 'reflect-detect', 3000)] },
     ],
     SubagentStart: [

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -153,6 +153,8 @@ export function getReferenceHookBlock(): HooksTree {
       { hooks: [helperHook('prompt-hook.mjs', '', 3000)] },
       // #931 — Defensive safety-net hook. State reset only, no emission.
       { hooks: [gateHook('prompt-state-reset', 3000)] },
+      // #1198 — auto-reflect capture (detect). Default-OFF in-script.
+      { hooks: [scriptHookSub('reflect-capture.mjs', 'reflect-detect', 3000)] },
     ],
     SubagentStart: [
       { hooks: [helperHook('subagent-start.cjs', '', 2000)] },
@@ -163,7 +165,7 @@ export function getReferenceHookBlock(): HooksTree {
       },
     ],
     Stop: [
-      { hooks: [handler('session-end', 5000), autoMemory('sync', 10000), scriptHookSub('session-continuity.mjs', 'capture', 5000)] },
+      { hooks: [handler('session-end', 5000), autoMemory('sync', 10000), scriptHookSub('session-continuity.mjs', 'capture', 5000), scriptHookSub('reflect-capture.mjs', 'reflect-scrape', 5000)] },
     ],
     PreCompact: [
       { hooks: [gateCjs('compact-guidance', 3000)] },

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -55,8 +55,8 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   // just fresh `flo init`. Capture is default-on (silent); injection is
   // relevance-gated at session-start.
   { event: 'Stop', pattern: 'session-continuity.mjs' },
-  // #1198 — auto-reflect capture (default-OFF; gated in-script on
-  // auto_reflect.enabled). `reflect-detect` (UserPromptSubmit) injects the
+  // #1198 — auto-reflect capture (default-ON; opt out via
+  // auto_reflect.enabled: false). `reflect-detect` (UserPromptSubmit) injects the
   // answer-first directive on a strong signal; `reflect-scrape` (Stop) harvests
   // <reflect-capture> tags into the ledger. Both share reflect-capture.mjs, so
   // the unique subcommand token (not the shared filename) is the presence
@@ -109,9 +109,9 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   // matcher), like the UserPromptSubmit entries; Claude Code fires every Stop
   // block, so a separate block alongside session-end/sync is fine.
   'session-continuity.mjs':   { event: 'Stop',             matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/session-continuity.mjs" capture', timeout: 5000 } },
-  // #1198 — auto-reflect capture. Default-OFF (the script early-returns unless
-  // auto_reflect.enabled), so wiring these into every consumer is inert until
-  // opt-in. Bare blocks (no matcher), like the other UserPromptSubmit/Stop entries.
+  // #1198 — auto-reflect capture. Default-ON (the script no-ops only when
+  // auto_reflect.enabled is false). Bare blocks (no matcher), like the other
+  // UserPromptSubmit/Stop entries.
   'reflect-detect':           { event: 'UserPromptSubmit', matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/reflect-capture.mjs" reflect-detect', timeout: 3000 } },
   'reflect-scrape':           { event: 'Stop',             matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/reflect-capture.mjs" reflect-scrape', timeout: 5000 } },
 };

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -55,6 +55,14 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   // just fresh `flo init`. Capture is default-on (silent); injection is
   // relevance-gated at session-start.
   { event: 'Stop', pattern: 'session-continuity.mjs' },
+  // #1198 — auto-reflect capture (default-OFF; gated in-script on
+  // auto_reflect.enabled). `reflect-detect` (UserPromptSubmit) injects the
+  // answer-first directive on a strong signal; `reflect-scrape` (Stop) harvests
+  // <reflect-capture> tags into the ledger. Both share reflect-capture.mjs, so
+  // the unique subcommand token (not the shared filename) is the presence
+  // discriminator — same convention as gate-hook subcommands like record-test-run.
+  { event: 'UserPromptSubmit', pattern: 'reflect-detect' },
+  { event: 'Stop', pattern: 'reflect-scrape' },
 ];
 
 /**
@@ -101,6 +109,11 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   // matcher), like the UserPromptSubmit entries; Claude Code fires every Stop
   // block, so a separate block alongside session-end/sync is fine.
   'session-continuity.mjs':   { event: 'Stop',             matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/session-continuity.mjs" capture', timeout: 5000 } },
+  // #1198 — auto-reflect capture. Default-OFF (the script early-returns unless
+  // auto_reflect.enabled), so wiring these into every consumer is inert until
+  // opt-in. Bare blocks (no matcher), like the other UserPromptSubmit/Stop entries.
+  'reflect-detect':           { event: 'UserPromptSubmit', matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/reflect-capture.mjs" reflect-detect', timeout: 3000 } },
+  'reflect-scrape':           { event: 'Stop',             matcher: '',                           hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/scripts/reflect-capture.mjs" reflect-scrape', timeout: 5000 } },
 };
 
 export interface RepairResult {

--- a/tests/bin/hook-io.test.ts
+++ b/tests/bin/hook-io.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for shared hook I/O primitives (#1198) — bin/lib/hook-io.mjs.
+ *
+ * readHookStdin is covered end-to-end by the reflect-capture and
+ * session-continuity subprocess tests; here we cover the pure readFileTail
+ * (small file, tail slice, missing file).
+ *
+ * Cross-platform (Rule #1): temp dirs via path, Node fs only, no shell.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { resolve, join } from 'path';
+
+import { readFileTail } from '../../bin/lib/hook-io.mjs';
+
+let root: string;
+beforeEach(() => {
+  root = resolve(__dirname, '../../.testoutput/.test-hookio-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
+  mkdirSync(root, { recursive: true });
+});
+afterEach(() => { try { rmSync(root, { recursive: true, force: true }); } catch { /* ok */ } });
+
+describe('readFileTail', () => {
+  it('returns the whole file when smaller than the window', () => {
+    const p = join(root, 'small.txt');
+    writeFileSync(p, 'hello world', 'utf-8');
+    expect(readFileTail(p, 1024)).toBe('hello world');
+  });
+
+  it('returns only the last `bytes` for a larger file', () => {
+    const p = join(root, 'big.txt');
+    writeFileSync(p, 'A'.repeat(1000) + 'TAILMARKER', 'utf-8');
+    const tail = readFileTail(p, 20);
+    expect(tail.length).toBe(20);
+    expect(tail).toBe('A'.repeat(10) + 'TAILMARKER'); // 20 - len('TAILMARKER')=10 → 10 A's
+  });
+
+  it("returns '' for a missing file or empty path", () => {
+    expect(readFileTail(join(root, 'nope.txt'), 100)).toBe('');
+    expect(readFileTail('', 100)).toBe('');
+    expect(readFileTail(undefined as unknown as string, 100)).toBe('');
+  });
+});

--- a/tests/bin/reflect-capture.test.ts
+++ b/tests/bin/reflect-capture.test.ts
@@ -3,7 +3,7 @@
  * bin/reflect-capture.mjs (`detect` = UserPromptSubmit, `scrape` = Stop).
  *
  * Driven as a subprocess with JSON on stdin, matching how Claude Code invokes
- * hooks. Verifies the default-off + headless guards, signal-gated injection,
+ * hooks. Verifies the opt-out + headless guards, signal-gated injection,
  * rate-limiting, and the assistant-only tag scrape into the ledger.
  *
  * Cross-platform (Rule #1): temp dirs via path, spawnSync arg arrays, no shell.
@@ -31,6 +31,9 @@ function cleanTempRoot(root: string) {
 }
 function enable(root: string) {
   writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: true\n', 'utf-8');
+}
+function disable(root: string) {
+  writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: false\n', 'utf-8');
 }
 function writeTranscript(root: string, events: object[]): string {
   const p = resolve(root, 'transcript.jsonl');
@@ -62,7 +65,8 @@ describe('reflect-capture detect (UserPromptSubmit)', () => {
     expect(r.stdout).toContain('FIRST');
   });
 
-  it('is silent when the flag is OFF (default)', () => {
+  it('is silent when explicitly disabled (enabled: false)', () => {
+    disable(root);
     const r = run(root, 'detect', { session_id: 's1', prompt: 'No, that is wrong, do it differently' });
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toBe('');
@@ -132,7 +136,8 @@ describe('reflect-capture scrape (Stop)', () => {
     expect(readLedger(root).entries).toHaveLength(0);
   });
 
-  it('is silent + writes nothing when the flag is OFF', () => {
+  it('is silent + writes nothing when explicitly disabled (enabled: false)', () => {
+    disable(root);
     const transcript = writeTranscript(root, [
       { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: '<reflect-capture>A durable lesson that should not be stored.</reflect-capture>' }] } },
     ]);

--- a/tests/bin/reflect-capture.test.ts
+++ b/tests/bin/reflect-capture.test.ts
@@ -94,14 +94,38 @@ describe('reflect-capture detect (UserPromptSubmit)', () => {
     expect(second.stdout.trim()).toBe('');
   });
 
-  it('detects error→fix from the transcript tail', () => {
+  it('detects error→fix from the recent turn', () => {
     enable(root);
     const transcript = writeTranscript(root, [
+      { type: 'user', message: { role: 'user', content: 'run the tests' } },
       { type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_result', text: 'process exited with exit code 1' }] } },
     ]);
     const r = run(root, 'detect', { session_id: 's1', prompt: 'ok keep going', transcript_path: transcript });
     expect(r.stdout).toContain('[auto-reflect]');
     expect(r.stdout).toContain('error-then-fix');
+  });
+
+  it('is silent on a system/notification turn with no real prompt', () => {
+    enable(root);
+    const transcript = writeTranscript(root, [
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_result', text: 'exit code 1' }] } },
+    ]);
+    // empty prompt (task-notification re-invocation) → nothing to attach to
+    const r = run(root, 'detect', { session_id: 's1', prompt: '   ', transcript_path: transcript });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+  });
+
+  it('does NOT fire on a STALE error from before the last user turn', () => {
+    enable(root);
+    const transcript = writeTranscript(root, [
+      { type: 'assistant', message: { role: 'assistant', content: '3 failed earlier' } }, // stale failure
+      { type: 'user', message: { role: 'user', content: 'great, ship it' } },
+      { type: 'assistant', message: { role: 'assistant', content: 'all green now, 0 failed' } },
+    ]);
+    const r = run(root, 'detect', { session_id: 's1', prompt: 'thanks, all set', transcript_path: transcript });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe('');
   });
 });
 

--- a/tests/bin/reflect-capture.test.ts
+++ b/tests/bin/reflect-capture.test.ts
@@ -1,0 +1,153 @@
+/**
+ * End-to-end tests for the auto-reflect capture hook (#1198) —
+ * bin/reflect-capture.mjs (`detect` = UserPromptSubmit, `scrape` = Stop).
+ *
+ * Driven as a subprocess with JSON on stdin, matching how Claude Code invokes
+ * hooks. Verifies the default-off + headless guards, signal-gated injection,
+ * rate-limiting, and the assistant-only tag scrape into the ledger.
+ *
+ * Cross-platform (Rule #1): temp dirs via path, spawnSync arg arrays, no shell.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { resolve, join } from 'path';
+
+import { readLedger } from '../../bin/lib/reflect.mjs';
+
+const CAPTURE_SCRIPT = resolve(__dirname, '../../bin/reflect-capture.mjs');
+
+function makeTempRoot(label: string): string {
+  const root = resolve(
+    __dirname,
+    '../../.testoutput/.test-reflectcap-' + label + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  return root;
+}
+function cleanTempRoot(root: string) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle hold */ }
+}
+function enable(root: string) {
+  writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: true\n', 'utf-8');
+}
+function writeTranscript(root: string, events: object[]): string {
+  const p = resolve(root, 'transcript.jsonl');
+  writeFileSync(p, events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+  return p;
+}
+function run(root: string, sub: 'detect' | 'scrape', input: object, extraEnv: Record<string, string> = {}) {
+  const argv = sub === 'detect' ? 'reflect-detect' : 'reflect-scrape';
+  return spawnSync('node', [CAPTURE_SCRIPT, argv], {
+    cwd: root,
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    timeout: 20_000,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, ...extraEnv },
+  });
+}
+
+describe('reflect-capture detect (UserPromptSubmit)', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot('detect'); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('injects an answer-first directive on a correction (when enabled)', () => {
+    enable(root);
+    const r = run(root, 'detect', { session_id: 's1', prompt: 'No, that is wrong — use the daemon instead' });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('[auto-reflect]');
+    expect(r.stdout).toContain('<reflect-capture>');
+    expect(r.stdout).toContain('FIRST');
+  });
+
+  it('is silent when the flag is OFF (default)', () => {
+    const r = run(root, 'detect', { session_id: 's1', prompt: 'No, that is wrong, do it differently' });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+  });
+
+  it('is silent under CLAUDE_CODE_HEADLESS even when enabled (#860 guard)', () => {
+    enable(root);
+    const r = run(root, 'detect', { session_id: 's1', prompt: "no, that's wrong" }, { CLAUDE_CODE_HEADLESS: 'true' });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+  });
+
+  it('is silent on a neutral prompt', () => {
+    enable(root);
+    const r = run(root, 'detect', { session_id: 's1', prompt: 'Please add a new users endpoint' });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+  });
+
+  it('rate-limits a second fire within the window (same session)', () => {
+    enable(root);
+    const first = run(root, 'detect', { session_id: 's1', prompt: "no, that's wrong" });
+    expect(first.stdout).toContain('[auto-reflect]');
+    const second = run(root, 'detect', { session_id: 's1', prompt: "no, still wrong" });
+    expect(second.stdout.trim()).toBe('');
+  });
+
+  it('detects error→fix from the transcript tail', () => {
+    enable(root);
+    const transcript = writeTranscript(root, [
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_result', text: 'process exited with exit code 1' }] } },
+    ]);
+    const r = run(root, 'detect', { session_id: 's1', prompt: 'ok keep going', transcript_path: transcript });
+    expect(r.stdout).toContain('[auto-reflect]');
+    expect(r.stdout).toContain('error-then-fix');
+  });
+});
+
+describe('reflect-capture scrape (Stop)', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot('scrape'); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('appends an assistant <reflect-capture> tag to the ledger (when enabled)', () => {
+    enable(root);
+    const transcript = writeTranscript(root, [
+      { type: 'user', message: { role: 'user', content: 'do it' } },
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Done.\n<reflect-capture>Route learnings writes through the daemon, never a raw db write.</reflect-capture>' }] } },
+    ]);
+    const r = run(root, 'scrape', { session_id: 's1', transcript_path: transcript });
+    expect(r.status).toBe(0);
+    const led = readLedger(root);
+    expect(led.entries).toHaveLength(1);
+    expect(led.entries[0].lesson).toContain('Route learnings writes through the daemon');
+    expect(led.entries[0].distilled).toBe(false);
+  });
+
+  it('does NOT scrape the injected directive (user-role context only carries the example tag)', () => {
+    enable(root);
+    // Simulate the directive having ridden in as user/context, with no real assistant capture.
+    const transcript = writeTranscript(root, [
+      { type: 'user', message: { role: 'user', content: 'fix it\n<reflect-capture>LESSON</reflect-capture>' } },
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Fixed it, no durable lesson here.' }] } },
+    ]);
+    const r = run(root, 'scrape', { session_id: 's1', transcript_path: transcript });
+    expect(r.status).toBe(0);
+    expect(readLedger(root).entries).toHaveLength(0);
+  });
+
+  it('is silent + writes nothing when the flag is OFF', () => {
+    const transcript = writeTranscript(root, [
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: '<reflect-capture>A durable lesson that should not be stored.</reflect-capture>' }] } },
+    ]);
+    const r = run(root, 'scrape', { session_id: 's1', transcript_path: transcript });
+    expect(r.status).toBe(0);
+    expect(readLedger(root).entries).toHaveLength(0);
+  });
+
+  it('is silent under CLAUDE_CODE_HEADLESS even when enabled (#860 guard)', () => {
+    enable(root);
+    const transcript = writeTranscript(root, [
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: '<reflect-capture>A durable lesson captured in a headless run.</reflect-capture>' }] } },
+    ]);
+    const r = run(root, 'scrape', { session_id: 's1', transcript_path: transcript }, { CLAUDE_CODE_HEADLESS: 'true' });
+    expect(r.status).toBe(0);
+    expect(readLedger(root).entries).toHaveLength(0);
+  });
+});

--- a/tests/bin/reflect-distill.test.ts
+++ b/tests/bin/reflect-distill.test.ts
@@ -1,0 +1,121 @@
+/**
+ * End-to-end tests for the auto-reflect distill orchestrator (#1198) —
+ * bin/reflect-distill.mjs.
+ *
+ * The headless Haiku call is replaced by a node stub via the
+ * MOFLO_REFLECT_DISTILL_NODE_STUB seam, so we can assert the full pipeline
+ * (gates → snapshot → spawn → mark-distilled) cross-platform without a real
+ * Claude CLI.
+ *
+ * Cross-platform (Rule #1): temp dirs via path, spawnSync arg arrays, no shell.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { resolve, join } from 'path';
+
+import { appendLedgerEntries, readLedger, pendingEntries } from '../../bin/lib/reflect.mjs';
+
+const DISTILL_SCRIPT = resolve(__dirname, '../../bin/reflect-distill.mjs');
+
+// A node stub standing in for `claude --print <prompt>`: records the prompt to a
+// marker file, then exits with STUB_EXIT (default 0).
+const STUB_SOURCE = `import { writeFileSync } from 'fs';
+const args = process.argv.slice(2);
+try { writeFileSync(process.env.STUB_MARKER, args.join('\\u0001')); } catch {}
+process.exit(process.env.STUB_EXIT ? Number(process.env.STUB_EXIT) : 0);
+`;
+
+function makeTempRoot(label: string): { root: string; stub: string; marker: string } {
+  const root = resolve(
+    __dirname,
+    '../../.testoutput/.test-reflectdist-' + label + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  const stub = resolve(root, 'stub-claude.mjs');
+  writeFileSync(stub, STUB_SOURCE, 'utf-8');
+  return { root, stub, marker: resolve(root, 'stub-invoked.marker') };
+}
+function cleanTempRoot(root: string) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle hold */ }
+}
+function enable(root: string) {
+  writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: true\n', 'utf-8');
+}
+function runDistill(root: string, stub: string, marker: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync('node', [DISTILL_SCRIPT], {
+    cwd: root,
+    encoding: 'utf-8',
+    timeout: 20_000,
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: root,
+      MOFLO_REFLECT_DISTILL_NODE_STUB: stub,
+      STUB_MARKER: marker,
+      ...extraEnv,
+    },
+  });
+}
+
+describe('reflect-distill', () => {
+  let root: string;
+  let stub: string;
+  let marker: string;
+  beforeEach(() => { ({ root, stub, marker } = makeTempRoot('main')); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('distills the pending snapshot and marks it distilled on success', () => {
+    enable(root);
+    appendLedgerEntries(root, [
+      { lesson: 'Route learnings writes through the daemon, never a raw db write.' },
+      { lesson: 'Guard headless spawns with CLAUDE_CODE_HEADLESS to avoid recursion.' },
+    ]);
+    const r = runDistill(root, stub, marker);
+    expect(r.status).toBe(0);
+
+    // The stub (standing in for Haiku) was invoked with a prompt carrying the candidates.
+    expect(existsSync(marker)).toBe(true);
+    const prompt = readFileSync(marker, 'utf-8');
+    expect(prompt).toContain('Route learnings writes through the daemon');
+    expect(prompt).toContain('mcp__moflo__memory_store');
+
+    // Both entries are now marked distilled.
+    const led = readLedger(root);
+    expect(pendingEntries(led)).toHaveLength(0);
+    expect(led.entries.every((e: any) => e.distilled)).toBe(true);
+  });
+
+  it('does NOT spawn when the ledger has no pending entries', () => {
+    enable(root);
+    const r = runDistill(root, stub, marker);
+    expect(r.status).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it('is a no-op when the flag is OFF (default)', () => {
+    appendLedgerEntries(root, [{ lesson: 'A durable lesson that must not be distilled while off.' }]);
+    const r = runDistill(root, stub, marker);
+    expect(r.status).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+    expect(pendingEntries(readLedger(root))).toHaveLength(1);
+  });
+
+  it('is a no-op under CLAUDE_CODE_HEADLESS even when enabled (#860 self-guard)', () => {
+    enable(root);
+    appendLedgerEntries(root, [{ lesson: 'A durable lesson present during a headless run.' }]);
+    const r = runDistill(root, stub, marker, { CLAUDE_CODE_HEADLESS: 'true' });
+    expect(r.status).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+    expect(pendingEntries(readLedger(root))).toHaveLength(1);
+  });
+
+  it('retains pending entries when the headless run fails (retry next session)', () => {
+    enable(root);
+    appendLedgerEntries(root, [{ lesson: 'A durable lesson whose distill attempt fails this time.' }]);
+    const r = runDistill(root, stub, marker, { STUB_EXIT: '1' });
+    expect(r.status).toBe(0); // the orchestrator itself never errors out
+    expect(existsSync(marker)).toBe(true); // it did try
+    expect(pendingEntries(readLedger(root))).toHaveLength(1); // but nothing marked distilled
+  });
+});

--- a/tests/bin/reflect-distill.test.ts
+++ b/tests/bin/reflect-distill.test.ts
@@ -43,6 +43,9 @@ function cleanTempRoot(root: string) {
 function enable(root: string) {
   writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: true\n', 'utf-8');
 }
+function disable(root: string) {
+  writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: false\n', 'utf-8');
+}
 function runDistill(root: string, stub: string, marker: string, extraEnv: Record<string, string> = {}) {
   return spawnSync('node', [DISTILL_SCRIPT], {
     cwd: root,
@@ -93,7 +96,8 @@ describe('reflect-distill', () => {
     expect(existsSync(marker)).toBe(false);
   });
 
-  it('is a no-op when the flag is OFF (default)', () => {
+  it('is a no-op when explicitly disabled (enabled: false)', () => {
+    disable(root);
     appendLedgerEntries(root, [{ lesson: 'A durable lesson that must not be distilled while off.' }]);
     const r = runDistill(root, stub, marker);
     expect(r.status).toBe(0);

--- a/tests/bin/reflect.test.ts
+++ b/tests/bin/reflect.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for auto-reflect pure logic (#1198) — bin/lib/reflect.mjs.
+ *
+ * Covers config read (default-OFF), headless guard, signal detection,
+ * injection rate-limiting, <reflect-capture> tag extraction (incl. the
+ * assistant-only transcript scrape that ignores the injected directive),
+ * ledger round-trip + dedup + cap + mark-distilled, and the distill prompt.
+ *
+ * Cross-platform (Rule #1): temp dirs via path, Node fs only, no shell.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { resolve, join } from 'path';
+
+import {
+  HAIKU_MODEL_ID,
+  INJECT_WINDOW_MS,
+  INJECT_MAX_PER_SESSION,
+  MAX_LEDGER_ENTRIES,
+  MAX_LESSON_CHARS,
+  DURABILITY_BAR,
+  readReflectConfig,
+  isHeadless,
+  detectSignal,
+  buildCaptureDirective,
+  injectionAllowed,
+  readReflectState,
+  recordInjection,
+  extractCaptureTags,
+  extractCapturesFromTranscript,
+  readLedger,
+  pendingEntries,
+  appendLedgerEntries,
+  markLedgerDistilled,
+  buildDistillPrompt,
+} from '../../bin/lib/reflect.mjs';
+
+function makeTempRoot(label: string): string {
+  const root = resolve(
+    __dirname,
+    '../../.testoutput/.test-reflect-' + label + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  return root;
+}
+function cleanTempRoot(root: string) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle hold — non-fatal */ }
+}
+
+// ── Config (default OFF) ─────────────────────────────────────────────────────
+
+describe('readReflectConfig', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot('cfg'); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('defaults OFF with no moflo.yaml (blast-radius posture)', () => {
+    expect(readReflectConfig(root)).toEqual({ enabled: false });
+  });
+
+  it('defaults OFF when the block is absent', () => {
+    writeFileSync(resolve(root, 'moflo.yaml'), 'auto_update:\n  enabled: true\n');
+    expect(readReflectConfig(root)).toEqual({ enabled: false });
+  });
+
+  it('parses an explicit enabled: true', () => {
+    writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: true\n');
+    expect(readReflectConfig(root)).toEqual({ enabled: true });
+  });
+
+  it('parses an explicit enabled: false', () => {
+    writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: false\n');
+    expect(readReflectConfig(root)).toEqual({ enabled: false });
+  });
+});
+
+describe('isHeadless', () => {
+  it('detects the headless env both forms', () => {
+    expect(isHeadless({ CLAUDE_CODE_HEADLESS: 'true' })).toBe(true);
+    expect(isHeadless({ CLAUDE_CODE_HEADLESS: '1' })).toBe(true);
+    expect(isHeadless({})).toBe(false);
+    expect(isHeadless({ CLAUDE_CODE_HEADLESS: 'false' })).toBe(false);
+  });
+});
+
+// ── Signal detection ─────────────────────────────────────────────────────────
+
+describe('detectSignal', () => {
+  it('flags user corrections', () => {
+    for (const p of [
+      'No, that is wrong — use the daemon instead',
+      "don't hardcode the port",
+      'actually, revert that change',
+      'why did you delete the test?',
+      "that's not what I asked for",
+    ]) {
+      expect(detectSignal(p).kind).toBe('correction');
+    }
+  });
+
+  it('flags explicit decisions (prompt or transcript)', () => {
+    expect(detectSignal("let's go with the launcher approach").kind).toBe('decision');
+    expect(detectSignal('neutral prompt', 'we decided to batch the writes').kind).toBe('decision');
+  });
+
+  it('flags error→fix from structured failure markers in the tail', () => {
+    expect(detectSignal('ok continue', '{"is_error":true}').kind).toBe('error_fix');
+    expect(detectSignal('ok', 'process exited with exit code 1').kind).toBe('error_fix');
+    expect(detectSignal('ok', '3 failed, 10 passed').kind).toBe('error_fix');
+  });
+
+  it('does NOT fire on neutral prompts / benign "error" mentions', () => {
+    expect(detectSignal('Please add a new endpoint for users').hit).toBe(false);
+    // bare word "error" in prose must not trigger error_fix (tight markers only)
+    expect(detectSignal('add better error handling to the parser').hit).toBe(false);
+  });
+
+  it('precedence: correction beats decision beats error_fix', () => {
+    expect(detectSignal("no, let's go with X", '{"is_error":true}').kind).toBe('correction');
+  });
+});
+
+// ── Directive ────────────────────────────────────────────────────────────────
+
+describe('buildCaptureDirective', () => {
+  it('is answer-first and embeds the shared durability bar + the tag format', () => {
+    const d = buildCaptureDirective('correction');
+    expect(d).toContain('FIRST');
+    expect(d).toContain('<reflect-capture>LESSON</reflect-capture>');
+    expect(d).toContain(DURABILITY_BAR);
+    expect(d).toContain('append nothing');
+    expect(d).toContain('course-correction');
+  });
+});
+
+// ── Rate-limiting ────────────────────────────────────────────────────────────
+
+describe('injectionAllowed', () => {
+  const now = 1_000_000;
+  it('allows with no prior state', () => {
+    expect(injectionAllowed(null, 's1', now)).toBe(true);
+  });
+  it('blocks a second fire inside the window (same session)', () => {
+    expect(injectionAllowed({ sessionId: 's1', lastInjectMs: now - 1000, count: 1 }, 's1', now)).toBe(false);
+  });
+  it('allows again after the window elapses', () => {
+    expect(injectionAllowed({ sessionId: 's1', lastInjectMs: now - INJECT_WINDOW_MS - 1, count: 1 }, 's1', now)).toBe(true);
+  });
+  it('blocks once the per-session cap is reached', () => {
+    expect(injectionAllowed({ sessionId: 's1', lastInjectMs: now - INJECT_WINDOW_MS - 1, count: INJECT_MAX_PER_SESSION }, 's1', now)).toBe(false);
+  });
+  it('a new session resets the window + counter', () => {
+    expect(injectionAllowed({ sessionId: 'old', lastInjectMs: now - 1, count: INJECT_MAX_PER_SESSION }, 'new', now)).toBe(true);
+  });
+});
+
+describe('reflect state round-trip', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot('state'); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('recordInjection persists and increments per-session count', () => {
+    expect(readReflectState(root)).toBeNull();
+    recordInjection(root, 's1', 100);
+    let s = readReflectState(root);
+    expect(s).toMatchObject({ sessionId: 's1', lastInjectMs: 100, count: 1 });
+    recordInjection(root, 's1', 200, s);
+    s = readReflectState(root);
+    expect(s.count).toBe(2);
+  });
+
+  it('a new session resets count to 1', () => {
+    recordInjection(root, 's1', 100);
+    const prev = readReflectState(root);
+    recordInjection(root, 's2', 200, prev);
+    expect(readReflectState(root)).toMatchObject({ sessionId: 's2', count: 1 });
+  });
+});
+
+// ── Tag extraction ───────────────────────────────────────────────────────────
+
+describe('extractCaptureTags', () => {
+  it('extracts one or many real lessons, bounded', () => {
+    const text = 'answer\n<reflect-capture>For Windows spell steps, use node -e fs because mkdir is absent.</reflect-capture>';
+    expect(extractCaptureTags(text)).toEqual(['For Windows spell steps, use node -e fs because mkdir is absent.']);
+    const two = '<reflect-capture>Lesson one is long enough.</reflect-capture> mid <reflect-capture>Lesson two is also long.</reflect-capture>';
+    expect(extractCaptureTags(two)).toHaveLength(2);
+  });
+
+  it('drops the directive placeholder, empties and fragments', () => {
+    expect(extractCaptureTags('<reflect-capture>LESSON</reflect-capture>')).toEqual([]);
+    expect(extractCaptureTags('<reflect-capture>   </reflect-capture>')).toEqual([]);
+    expect(extractCaptureTags('<reflect-capture>none</reflect-capture>')).toEqual([]);
+    expect(extractCaptureTags('<reflect-capture>tiny</reflect-capture>')).toEqual([]);
+  });
+
+  it('caps an over-long lesson', () => {
+    const long = 'x'.repeat(MAX_LESSON_CHARS + 200);
+    expect(extractCaptureTags(`<reflect-capture>${long}</reflect-capture>`)[0].length).toBe(MAX_LESSON_CHARS);
+  });
+});
+
+describe('extractCapturesFromTranscript', () => {
+  it('scrapes only assistant-role messages — ignores the injected directive', () => {
+    const directive = buildCaptureDirective('correction'); // contains the example tag
+    const lines = [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'do the thing\n' + directive } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Done.\n<reflect-capture>Route learnings writes through the daemon, never a raw db write.</reflect-capture>' }] } }),
+    ];
+    const got = extractCapturesFromTranscript(lines.join('\n') + '\n');
+    expect(got).toEqual(['Route learnings writes through the daemon, never a raw db write.']);
+  });
+
+  it('tolerates a truncated leading JSONL line', () => {
+    const good = JSON.stringify({ message: { role: 'assistant', content: 'x\n<reflect-capture>A genuinely durable captured lesson here.</reflect-capture>' } });
+    const tail = '{"partial": "cut off mid li\n' + good + '\n';
+    expect(extractCapturesFromTranscript(tail)).toHaveLength(1);
+  });
+});
+
+// ── Ledger ───────────────────────────────────────────────────────────────────
+
+describe('ledger', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot('ledger'); });
+  afterEach(() => cleanTempRoot(root));
+
+  it('append → read round-trips and dedups identical lessons', () => {
+    expect(appendLedgerEntries(root, [{ lesson: 'Lesson alpha is durable here.', kind: 'correction', sessionId: 's1' }])).toBe(1);
+    // identical lesson (re-scraped from an overlapping tail) is skipped
+    expect(appendLedgerEntries(root, [{ lesson: 'Lesson alpha is durable here.', kind: 'correction', sessionId: 's1' }])).toBe(0);
+    const led = readLedger(root);
+    expect(led.entries).toHaveLength(1);
+    expect(pendingEntries(led)).toHaveLength(1);
+    expect(led.entries[0]).toMatchObject({ kind: 'correction', sessionId: 's1', distilled: false });
+    expect(typeof led.entries[0].id).toBe('string');
+  });
+
+  it('skips fragments shorter than the floor', () => {
+    expect(appendLedgerEntries(root, [{ lesson: 'short' }])).toBe(0);
+  });
+
+  it('markLedgerDistilled flips only the given ids; new captures survive', () => {
+    appendLedgerEntries(root, [{ lesson: 'First durable lesson here.' }]);
+    const led = readLedger(root);
+    const id = led.entries[0].id;
+    appendLedgerEntries(root, [{ lesson: 'Second durable lesson here.' }]);
+    expect(markLedgerDistilled(root, [id])).toBe(1);
+    const after = readLedger(root);
+    expect(after.entries.find((e: any) => e.id === id).distilled).toBe(true);
+    // the second, captured "during" the run, stays pending
+    expect(pendingEntries(after)).toHaveLength(1);
+    expect(pendingEntries(after)[0].lesson).toContain('Second');
+  });
+
+  it('readLedger tolerates absent + malformed files', () => {
+    expect(readLedger(root)).toEqual({ entries: [] });
+    writeFileSync(resolve(root, '.moflo', 'reflect-ledger.json'), '{ not json');
+    expect(readLedger(root)).toEqual({ entries: [] });
+  });
+
+  it('caps the ledger at MAX_LEDGER_ENTRIES', () => {
+    const many = Array.from({ length: MAX_LEDGER_ENTRIES + 25 }, (_, i) => ({ lesson: `Durable distinct lesson number ${i} here.` }));
+    appendLedgerEntries(root, many);
+    expect(readLedger(root).entries.length).toBeLessThanOrEqual(MAX_LEDGER_ENTRIES);
+  });
+});
+
+// ── Distill prompt ───────────────────────────────────────────────────────────
+
+describe('buildDistillPrompt', () => {
+  it('reuses the /reflect protocol, numbers candidates, and embeds the bar', () => {
+    const p = buildDistillPrompt([{ lesson: 'Alpha lesson.' }, { lesson: 'Beta lesson.' }]);
+    expect(p).toContain('1. Alpha lesson.');
+    expect(p).toContain('2. Beta lesson.');
+    expect(p).toContain('mcp__moflo__memory_search');
+    expect(p).toContain('mcp__moflo__memory_store');
+    expect(p).toContain('>= 0.80');
+    expect(p).toContain(DURABILITY_BAR);
+  });
+});
+
+describe('exported constants', () => {
+  it('Haiku model id is the cheap formatter model', () => {
+    expect(HAIKU_MODEL_ID).toBe('claude-haiku-4-5-20251001');
+  });
+});

--- a/tests/bin/reflect.test.ts
+++ b/tests/bin/reflect.test.ts
@@ -48,20 +48,20 @@ function cleanTempRoot(root: string) {
   try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows handle hold — non-fatal */ }
 }
 
-// ── Config (default OFF) ─────────────────────────────────────────────────────
+// ── Config (default ON, opt-out) ─────────────────────────────────────────────
 
 describe('readReflectConfig', () => {
   let root: string;
   beforeEach(() => { root = makeTempRoot('cfg'); });
   afterEach(() => cleanTempRoot(root));
 
-  it('defaults OFF with no moflo.yaml (blast-radius posture)', () => {
-    expect(readReflectConfig(root)).toEqual({ enabled: false });
+  it('defaults ON with no moflo.yaml (#1198 ships default-on)', () => {
+    expect(readReflectConfig(root)).toEqual({ enabled: true });
   });
 
-  it('defaults OFF when the block is absent', () => {
+  it('defaults ON when the block is absent', () => {
     writeFileSync(resolve(root, 'moflo.yaml'), 'auto_update:\n  enabled: true\n');
-    expect(readReflectConfig(root)).toEqual({ enabled: false });
+    expect(readReflectConfig(root)).toEqual({ enabled: true });
   });
 
   it('parses an explicit enabled: true', () => {
@@ -69,7 +69,7 @@ describe('readReflectConfig', () => {
     expect(readReflectConfig(root)).toEqual({ enabled: true });
   });
 
-  it('parses an explicit enabled: false', () => {
+  it('opts out on an explicit enabled: false', () => {
     writeFileSync(resolve(root, 'moflo.yaml'), 'auto_reflect:\n  enabled: false\n');
     expect(readReflectConfig(root)).toEqual({ enabled: false });
   });

--- a/tests/bin/reflect.test.ts
+++ b/tests/bin/reflect.test.ts
@@ -23,6 +23,7 @@ import {
   readReflectConfig,
   isHeadless,
   detectSignal,
+  recentTranscriptTurn,
   buildCaptureDirective,
   injectionAllowed,
   readReflectState,
@@ -116,8 +117,44 @@ describe('detectSignal', () => {
     expect(detectSignal('add better error handling to the parser').hit).toBe(false);
   });
 
+  it('does NOT treat a "0 failed" SUCCESS line as error→fix ([1-9] guard)', () => {
+    expect(detectSignal('ok', 'Total passed: 9138, 0 failed').hit).toBe(false);
+    expect(detectSignal('ok', '9138 passed | 0 failed').hit).toBe(false);
+    // a real non-zero failure still fires
+    expect(detectSignal('ok', '3 failed, 10 passed').kind).toBe('error_fix');
+  });
+
   it('precedence: correction beats decision beats error_fix', () => {
     expect(detectSignal("no, let's go with X", '{"is_error":true}').kind).toBe('correction');
+  });
+});
+
+// ── Recent-turn scoping (stale-marker guard) ─────────────────────────────────
+
+describe('recentTranscriptTurn', () => {
+  it('returns only the text after the last user message', () => {
+    const lines = [
+      JSON.stringify({ message: { role: 'assistant', content: '3 failed earlier — STALE' } }),
+      JSON.stringify({ message: { role: 'user', content: 'ok next thing' } }),
+      JSON.stringify({ message: { role: 'assistant', content: [{ type: 'text', text: 'all good, 0 failed' }] } }),
+    ].join('\n') + '\n';
+    const recent = recentTranscriptTurn(lines);
+    expect(recent).toContain('all good, 0 failed');
+    expect(recent).not.toContain('STALE');
+  });
+
+  it('scopes error detection so a stale failure before the last user turn does NOT fire', () => {
+    const lines = [
+      JSON.stringify({ message: { role: 'assistant', content: 'process exited with exit code 1' } }), // stale
+      JSON.stringify({ message: { role: 'user', content: 'great, ship it' } }),
+      JSON.stringify({ message: { role: 'assistant', content: 'done, everything green' } }),
+    ].join('\n') + '\n';
+    expect(detectSignal('great, ship it', recentTranscriptTurn(lines)).hit).toBe(false);
+  });
+
+  it('falls back to the whole tail when no user line is present', () => {
+    const lines = JSON.stringify({ message: { role: 'assistant', content: 'exit code 1 here' } }) + '\n';
+    expect(detectSignal('ok', recentTranscriptTurn(lines)).kind).toBe('error_fix');
   });
 });
 

--- a/tests/bin/yaml-upgrader.test.ts
+++ b/tests/bin/yaml-upgrader.test.ts
@@ -95,10 +95,21 @@ describe('yaml-upgrader', () => {
       expect(content).toContain('tier: auto');
     });
 
+    it('appends auto_reflect block (default-off) when missing (#1198)', () => {
+      writeFileSync(yamlPath, 'project:\n  name: foo\n', 'utf-8');
+      const appended = ensureYamlSections(yamlPath);
+
+      expect(appended).toContain('auto_reflect');
+      const content = readFileSync(yamlPath, 'utf-8');
+      expect(content).toMatch(/^auto_reflect:/m);
+      expect(content).toContain('enabled: false');
+    });
+
     it('is idempotent when all required sections are already present', () => {
       const existing =
         'project:\n  name: foo\n' +
         'session_continuity:\n  capture: true\n  inject: true\n' +
+        'auto_reflect:\n  enabled: false\n' +
         'sandbox:\n  enabled: true\n  tier: full\n';
       writeFileSync(yamlPath, existing, 'utf-8');
 

--- a/tests/bin/yaml-upgrader.test.ts
+++ b/tests/bin/yaml-upgrader.test.ts
@@ -95,14 +95,14 @@ describe('yaml-upgrader', () => {
       expect(content).toContain('tier: auto');
     });
 
-    it('appends auto_reflect block (default-off) when missing (#1198)', () => {
+    it('appends auto_reflect block (default-on) when missing (#1198)', () => {
       writeFileSync(yamlPath, 'project:\n  name: foo\n', 'utf-8');
       const appended = ensureYamlSections(yamlPath);
 
       expect(appended).toContain('auto_reflect');
       const content = readFileSync(yamlPath, 'utf-8');
       expect(content).toMatch(/^auto_reflect:/m);
-      expect(content).toContain('enabled: false');
+      expect(content).toContain('enabled: true');
     });
 
     it('is idempotent when all required sections are already present', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,11 @@ import { defineConfig } from 'vitest/config';
  */
 export const isolationTests = [
   'tests/bin/process-manager-stress.test.ts',
+  // Spawns real `git` subprocesses to build temp repos per probe (#1093 already
+  // moved the classifier probes in-process; setup still shells out). Passes
+  // alone and in lighter runs, but the extra fork load from #1198's new bin
+  // tests tips its git setup past timeout under maxForks=2 Windows contention.
+  'tests/bin/simplify-classify.test.ts',
   'src/cli/memory/database-provider.test.ts',
   'src/cli/__tests__/spells/sandbox-tier-integration.test.ts',
   'src/cli/__tests__/spells/spell-sandboxing.test.ts',


### PR DESCRIPTION
## What

Implements **auto-reflect** (#1198) — the automatic counterpart to `/reflect` (#1187). Captures durable, reusable lessons with **no human in the loop** and distills them into the `learnings` namespace.

**Default-ON, rolled out via the `rc` dist-tag.** Only `npm i moflo@rc` installers get it until it's validated on real projects and `rc` is promoted to `latest`. Opt out any time with `auto_reflect.enabled: false`.

Closes #1198.

## Design — Recognize → Distill

The "obvious" build — a session-end hook that spawns a headless Claude to re-read the whole transcript — is the #860 mechanism and was deferred during #1187. This avoids it:

> **Don't spawn a model for recognition — borrow the one already in the room. Split the cheap mechanical trigger from the irreducible model judgment.**

**1. Recognize (live model, in-session, ~1 line).** A `UserPromptSubmit` hook (`reflect-capture.mjs reflect-detect`) detects a strong signal — course-correction / error→fix / decision — rate-limited (≤1 / 8 min, ≤6 / session) and injects an **answer-first** directive: handle the request as normal, *then* append one `<reflect-capture>…</reflect-capture>` line **only if** a durable lesson emerged. The live model at the moment of insight is the precision filter; a mis-fire just yields no tag. A `Stop` hook (`reflect-scrape`) scrapes assistant-only tags into `.moflo/reflect-ledger.json` (JSON, not `moflo.db` — writer-safe).

**2. Distill (Haiku, detached).** The session-start launcher fire-and-forgets a detached `reflect-distill.mjs` that runs one bounded headless `claude --print --model haiku` executing #1187's `/reflect` protocol over the ledger one-liners (dedup ≥0.80, store via `memory_store` → daemon = writer-safe). **Haiku is a formatter, not a judge** — the durability gate already passed upstream in the live model, so unattended runs can't pollute `learnings`.

**Guards (#860):** every hook + the launcher early-return when `auto_reflect.enabled: false` **or** `CLAUDE_CODE_HEADLESS` is set — the distill's own headless session can never re-enter capture or re-spawn distill.

## Verified before flipping default-on

- **Rule #1 (cross-platform):** `spawn('claude', […], { shell:false, windowsHide:true })` resolves on Windows (exit 0, claude v2.1.150); no `shell:true`/hardcoded paths/separators; prompt bounded (~9 KB). Full suite green on Windows.
- **Learnings land where the protocol searches:** a stored `learnings` entry returns at 0.86 on an explicit `namespace:"learnings"` search (the path CLAUDE.md + the memory-first gate direct). ⚠️ Surfaced a *pre-existing* gap — the bare default (no-namespace) search is code-map-dominant and drops `learnings`/`patterns` hits — filed as **#1201** (it caps the value of all curated memory until fixed; not introduced here).

## Rollout

`rc` (default-on) → author validates on this repo + another project → promote `rc`→`latest`. This repo **dogfoods it now**: `.claude/settings.json` wires the two hooks and the default is on.

## Changes

`bin/lib/reflect.mjs` (pure logic), `bin/lib/hook-io.mjs` (shared hook stdin/tail readers, also adopted by `session-continuity.mjs`), `bin/reflect-capture.mjs`, `bin/reflect-distill.mjs`; wired via `hook-wiring.ts` + `settings-generator.ts` + `hook-block-hash.ts` + `shipped-scripts.json`; `auto_reflect` flag (default true) in `moflo-config.ts` + yaml template + yaml-upgrader back-fill; `.claude/scripts/` mirrors byte-identical. New tests: `reflect`, `reflect-capture`, `reflect-distill`, `hook-io`. **No new dependencies.**

## Consumer impact

- **Default-ON via `rc` tag only** until promoted; opt out with `auto_reflect.enabled: false`.
- Cross-platform (Rule #1); Node `fs`/`path`/`child_process`, no shell.
- Runtime hooks → requires publish + reinstall to take effect.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
