### PR TITLE
fix(memory): default search ranks across all namespaces, not just code-map (#1201)

### DIFF
--- a/src/cli/__tests__/bridge-entries.test.ts
+++ b/src/cli/__tests__/bridge-entries.test.ts
@@ -399,6 +399,60 @@ describe('bridgeSearchEntries — query embedder wiring (#837 Defect A)', () => 
   });
 });
 
+describe('bridgeSearchEntries — cross-namespace candidate selection (#1201)', () => {
+  // Pre-fix, the candidate fetch was `LIMIT 1000` with NO ORDER BY: on a
+  // populated DB the first rows are bulk-indexed code-map, so a no-namespace
+  // search scored ZERO learnings/patterns/etc. The fix orders by created_at
+  // DESC before the cap, so recent curated entries stay in the pool.
+  async function setCreatedAt(key: string, ts: number): Promise<void> {
+    const reg = await getControllerRegistry(dbPath);
+    if (!reg) throw new Error('test bridge registry unavailable');
+    const ctx = getDb(reg);
+    if (!ctx) throw new Error('test bridge db ctx unavailable');
+    const stmt = ctx.db.prepare('UPDATE memory_entries SET created_at = ? WHERE key = ?');
+    stmt.run([ts, key]);
+  }
+
+  it('a recent learnings entry is NOT truncated out of a no-namespace search by an early code-map bulk', async () => {
+    const learnVec = new Float32Array(384); learnVec[0] = 1;
+    const codeVec = new Float32Array(384); codeVec[1] = 1;
+    setBridgeEmbedderForTest({
+      model: 'fast-all-MiniLM-L6-v2',
+      dimensions: 384,
+      embed: vi.fn(async (text: string) => (text.includes('LEARN') ? learnVec : codeVec)),
+    });
+
+    // Insert code-map rows first, learnings last — then pin created_at so the
+    // learnings row is the NEWEST regardless of same-ms insert ties.
+    await bridgeStoreEntry({ key: 'cm1', value: 'code map alpha', namespace: 'code-map', dbPath });
+    await bridgeStoreEntry({ key: 'cm2', value: 'code map beta', namespace: 'code-map', dbPath });
+    await bridgeStoreEntry({ key: 'lesson', value: 'LEARN durable lesson', namespace: 'learnings', dbPath });
+    await setCreatedAt('cm1', 1000);
+    await setCreatedAt('cm2', 2000);
+    await setCreatedAt('lesson', 3000);
+
+    // Tiny cap forces truncation: pre-fix (rowid LIMIT 2) keeps cm1+cm2 and
+    // drops the recent learnings row; post-fix (created_at DESC) keeps it.
+    const prev = process.env.MOFLO_SEARCH_CANDIDATE_CAP;
+    process.env.MOFLO_SEARCH_CANDIDATE_CAP = '2';
+    try {
+      const res = await bridgeSearchEntries({
+        query: 'LEARN durable lesson',
+        namespace: 'all',
+        threshold: 0,
+        dbPath,
+      });
+      expect(res?.success).toBe(true);
+      const keys = res!.results.map(r => r.key);
+      expect(keys).toContain('lesson');            // survived candidate selection
+      expect(res!.results[0]?.namespace).toBe('learnings'); // and ranks top by similarity
+    } finally {
+      if (prev === undefined) delete process.env.MOFLO_SEARCH_CANDIDATE_CAP;
+      else process.env.MOFLO_SEARCH_CANDIDATE_CAP = prev;
+    }
+  });
+});
+
 describe('bridgeDeleteEntry — error surfacing (#963)', () => {
   it('successfully deletes an existing entry and removes it from list', async () => {
     setBridgeEmbedderForTest(new StubEmbedder({ model: 'm', dimensions: 384 }));

--- a/src/cli/memory/bridge-core.ts
+++ b/src/cli/memory/bridge-core.ts
@@ -42,6 +42,27 @@ export function _getBridgeCoherenceCursorForTest(): number | null {
 }
 
 /**
+ * Candidate-pool ceiling for the brute-force search path (#1201).
+ *
+ * The bridge search scores candidates one-by-one (cosine + BM25), so it must
+ * cap how many rows it pulls. The old `LIMIT 1000` with NO `ORDER BY` truncated
+ * by rowid (insertion order): on a populated DB the first 1000 rows are all
+ * bulk-indexed `code-map`, so a no-namespace search silently scored ZERO
+ * `learnings`/`patterns`/etc. — they were invisible to default recall.
+ *
+ * The fix pairs this cap with `ORDER BY created_at DESC`, so when truncation
+ * does happen (DB larger than the cap) it keeps the most RECENT entries — where
+ * curated learnings and recent work live — instead of the oldest rowids.
+ * Realistic DBs (thousands–low tens of thousands) fall under the cap and are
+ * scored in full; measured ~13ms per 1000 rows. Env-overridable for ops tuning
+ * and tests. Beyond the cap, a true HNSW candidate path is the scale answer.
+ */
+export function searchCandidateCap(): number {
+  const raw = Number(process.env.MOFLO_SEARCH_CANDIDATE_CAP);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 25000;
+}
+
+/**
  * Resolve the bridge's project root.
  *
  * Delegates to the canonical resolver in `src/cli/services/project-root.ts`

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -8,7 +8,7 @@
  * @module v3/cli/bridge-entries
  */
 
-import { cosineSim, execRows, generateId, logBridgeError, persistBridgeDb, refreshVectorStatsCache, withDb } from './bridge-core.js';
+import { cosineSim, execRows, generateId, logBridgeError, persistBridgeDb, refreshVectorStatsCache, searchCandidateCap, withDb } from './bridge-core.js';
 import { embeddingResponseFrom, getBridgeEmbedder, resolveBridgeEmbedding } from './bridge-embedder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 
@@ -569,11 +569,17 @@ export async function bridgeSearchEntries(options: {
 
     let rows: Record<string, unknown>[];
     try {
+      // #1201 — ORDER BY created_at DESC before the cap. A bare `LIMIT 1000`
+      // (no ORDER BY) truncated the candidate pool by rowid, so on a populated
+      // DB the first 1000 rows were all bulk-indexed code-map and a
+      // no-namespace search never scored learnings/patterns/etc. Recency
+      // ordering keeps recent curated entries in the pool when truncation hits.
       const sql = `
         SELECT id, key, namespace, content, metadata, embedding
         FROM memory_entries
         WHERE status = 'active' ${nsFilter}
-        LIMIT 1000
+        ORDER BY created_at DESC
+        LIMIT ${searchCandidateCap()}
       `;
       rows = namespace !== 'all' ? execRows(ctx.db, sql, [namespace]) : execRows(ctx.db, sql);
     } catch {

--- a/src/cli/memory/memory-bridge.ts
+++ b/src/cli/memory/memory-bridge.ts
@@ -16,6 +16,7 @@ import {
   generateId,
   getRegistry,
   persistBridgeDb,
+  searchCandidateCap,
   withDb,
 } from './bridge-core.js';
 import {
@@ -142,11 +143,15 @@ export async function bridgeSearchHNSW(
 
     let rows: Record<string, unknown>[];
     try {
+      // #1201 — recency-ordered candidate cap; see searchCandidateCap. A bare
+      // LIMIT truncated by rowid, hiding recent non-code-map namespaces from a
+      // no-namespace search.
       const sql = `
         SELECT id, key, namespace, content, embedding
         FROM memory_entries
         WHERE status = 'active' AND embedding IS NOT NULL ${nsFilter}
-        LIMIT 10000
+        ORDER BY created_at DESC
+        LIMIT ${searchCandidateCap()}
       `;
       rows = nsFilter ? execRows(ctx.db, sql, [options!.namespace]) : execRows(ctx.db, sql);
     } catch {

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -23,7 +23,7 @@ import { HnswLite } from './hnsw-lite.js';
 import { tryLoadHnswSidecar } from './hnsw-persistence.js';
 import { EMBEDDING_MODEL_OPT_OUT, getBridgeEmbedder, isEphemeralNamespace } from './bridge-embedder.js';
 import { parseEmbeddingJson, toFloat32 } from './controllers/_shared.js';
-import { writeVectorStatsJson } from './bridge-core.js';
+import { searchCandidateCap, writeVectorStatsJson } from './bridge-core.js';
 import { serialiseMetadata } from './bridge-entries.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import {
@@ -2246,12 +2246,16 @@ export async function searchEntries(options: {
     const db = openDaemonDatabase(dbPath);
 
     // Get entries with embeddings
+    // #1201 — recency-ordered candidate cap (see searchCandidateCap). A bare
+    // LIMIT truncated by rowid, hiding recent non-code-map namespaces from a
+    // no-namespace search.
     const entries = db.exec(`
       SELECT id, key, namespace, content, metadata, embedding
       FROM memory_entries
       WHERE status = 'active'
         ${namespace !== 'all' ? `AND namespace = '${namespace.replace(/'/g, "''")}'` : ''}
-      LIMIT 1000
+      ORDER BY created_at DESC
+      LIMIT ${searchCandidateCap()}
     `);
 
     const results: { id: string; key: string; content: string; score: number; namespace: string; metadata?: string }[] = [];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,10 @@ export const isolationTests = [
   // load profile as doctor-checks-deep above; same isolation rationale.
   'src/cli/__tests__/doctor-checks-swarm.test.ts',
   'src/cli/__tests__/services/worker-daemon-resource-thresholds.test.ts',
+  // Spawns real fake-daemon processes for PID detection (~5s alone); the
+  // process-spawn + introspection timing intermittently exceeds its timeout
+  // under full-suite fork contention. Passes cleanly in isolation (8/8).
+  'src/cli/__tests__/services/daemon-lock-orphan.test.ts',
   'src/cli/__tests__/spells/connector-lifecycle.test.ts',
   // prerequisites.test.ts split into 4 files (#522) — all share the same
   // dynamic-import load profile, so all four stay on the isolation list.


### PR DESCRIPTION
## What

Fixes #1201 — a no-namespace `memory_search` silently returned **zero** `learnings`/`patterns`/`guidance`/`tests` on any populated project. It was effectively **code-map-only**, which quietly degrades *all* curated-memory recall (and would make auto-reflect's distilled learnings invisible to default search).

## Root cause

The bridge's brute-force search fetched candidates with `LIMIT 1000` and **no `ORDER BY`**, then scored them one-by-one (cosine + BM25). So it only ever scored the first 1000 rows **by rowid (insertion order)**. `code-map` is bulk-indexed first → it filled the entire candidate window → every other namespace fell outside the pool, was never scored, and was invisible. An explicit `namespace:` masked the bug (the filter shrank the pool so all of that namespace's rows fit under the cap) — which is why targeted searches worked and default search didn't.

**Confirmed on a live 4821-entry DB:** the first 1000 rows were `{code-map: 1000}` — **0 of 47** learnings. Post-fix the candidate pool spans all 11 namespaces (all 47 learnings included).

## Fix

`ORDER BY created_at DESC LIMIT <cap>` in all three brute-force candidate fetches — `bridgeSearchEntries` (the daemon path), `bridgeSearchHNSW`, and the `memory-initializer` fallback:

- **Recency-ordered**, so any truncation on a DB larger than the cap keeps recent curated entries instead of arbitrary oldest rowids.
- **Cap is env-overridable** (`MOFLO_SEARCH_CANDIDATE_CAP`, default 25000 via `searchCandidateCap()` in `bridge-core`). Realistic DBs fall under it and are scored in full — measured ~13 ms / 1000 rows, ~65 ms for the full 4815-row dev DB.
- Beyond the cap, a true HNSW candidate path is the scale answer (noted in code; the misleadingly-named `bridgeSearchHNSW` is itself brute-force SQL, not the hnsw-lite graph).

## Tests

- **Regression test** (`bridge-entries.test.ts`): a tiny env-cap forces truncation; asserts a recent cross-namespace entry survives candidate selection **and** ranks top by similarity. Fails on the old rowid `LIMIT`, passes on the fix.
- Moves the heavy real-process-spawn `daemon-lock-orphan.test.ts` to `isolationTests` — it load-flaked during the full-suite run (passes 8/8 alone), same `maxForks` contention rationale as the ~40 entries already there.
- Full suite green: **9090 passed, 0 failed** (Windows, incl. isolation batch).

## Consumer impact

- Affects every consumer with >~1000 memory entries (most populated projects). Pure correctness improvement to default recall; explicit-namespace searches are unchanged.
- Cross-platform (Rule #1): SQL + env only, no platform-sensitive surface.
- Gates the value of #1198 (auto-reflect): distilled lessons land in `learnings`, but default recall couldn't surface them until this fix.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
