### PR TITLE
fix(launcher): commit version stamp on sync success, not deferred to end of §3

### DIFF
--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -953,7 +953,7 @@ try {
       // memory; a concurrent sql.js flush would clobber the cherry-picked
       // rows below, and old-path writes would resurrect ghost files in legacy
       // dirs. Section 4's `hooks.mjs session-start` spawns a fresh daemon
-      // under the current code once 3g writes the version stamp.
+      // under the current code after the version stamp is committed (below).
       const upgradeDaemonLock = resolve(projectRoot, '.moflo', 'daemon.lock');
       if (stopDaemon(upgradeDaemonLock)) {
         emitMutation('stopped daemon for upgrade', 'will restart fresh after upgrade work');
@@ -1297,7 +1297,7 @@ try {
       // The daemon was already stopped above so the lock file is gone and
       // there's no live PID to recycle here. Section 4's `hooks.mjs
       // session-start` will spawn a fresh daemon under the current moflo
-      // image once 3g writes the version stamp.
+      // image after the version stamp is committed (below, on sync success).
 
       // Surface per-file copy failures so the user / Claude can see what
       // didn't sync (#854). The file isn't in the manifest either, so the

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -253,10 +253,24 @@ const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
 // can persist `.moflo/upgrade-notice.json` for the statusline (#636).
 let upgradeNoticeContext = null;
 
-// Deferred so we commit it AFTER every upgrade-work block (see 3g). The stamp
-// is the "launcher fully completed" signal — writing it mid-flight lets an
-// aborted launcher strand consumers on a half-applied upgrade (#730).
-let pendingVersionStampWrite = null;
+// Commit the version stamp = "this version's files are in place". Written the
+// moment sync + manifest succeed (dogfood has no sync to do), NOT deferred to
+// the end of §3 — so a launcher killed by the 5s SessionStart hook-timeout
+// during later best-effort §3 work (hook-drift, CLAUDE.md injection drift,
+// embeddings migration, …) still records the upgrade, and the next session
+// stops re-detecting it. That end-of-§3 deferral was the root of the indefinite
+// "updating…" re-detect loop. #730 is still honored: the stamp commits only
+// after the sync that installs this version's files succeeds; every section
+// after the §3 sync block runs unconditionally + idempotently each session, so
+// an abort past this point strands no upgrade work.
+function commitVersionStamp(stampPath, version) {
+  try {
+    mkdirSync(dirname(stampPath), { recursive: true });
+    writeFileSync(stampPath, version);
+  } catch (err) {
+    emitWarning(`version stamp write failed (${errMessage(err)}) — next launcher will re-detect the upgrade`);
+  }
+}
 
 // 5-min TTL is a safety net for zombie launchers (statusline ignores past-TTL
 // files). The 2-min "completed" TTL lets the user see the post-upgrade badge
@@ -1002,7 +1016,7 @@ try {
       // (the stopDaemon call earlier handled this) and 3a-pre will spawn a
       // fresh daemon under the new code.
       if (isMofloDogfood) {
-        pendingVersionStampWrite = { path: versionStampPath, version: installedVersion };
+        commitVersionStamp(versionStampPath, installedVersion);
         emitMutation('skipped file-sync', 'moflo dogfood — committed dogfood copies preserved');
       } else {
 
@@ -1297,8 +1311,10 @@ try {
         );
       }
 
-      // Manifest reflects synced files immediately; version stamp is deferred
-      // to 3g so an aborted launcher re-runs upgrade detection (#730).
+      // Manifest reflects synced files immediately; the version stamp is
+      // committed right after the manifest write (below), gated on it succeeding
+      // — so an abort BEFORE sync still re-runs upgrade detection (#730), while
+      // an abort AFTER sync no longer strands the stamp in a re-detect loop.
       //
       // Exclude paths that `applyRetiredPrune` just deleted from disk —
       // recording a non-existent file in `installed-files.json` triggers
@@ -1316,7 +1332,7 @@ try {
         const cfDir = resolve(projectRoot, '.moflo');
         if (!existsSync(cfDir)) mkdirSync(cfDir, { recursive: true });
         writeFileSync(manifestPath, JSON.stringify(persistedManifest, null, 2));
-        pendingVersionStampWrite = { path: versionStampPath, version: installedVersion };
+        commitVersionStamp(versionStampPath, installedVersion);
       } catch (err) {
         // #854: manifest write must surface — without it the next launcher
         // can't tell what was installed and the version stamp never gets
@@ -2159,18 +2175,15 @@ if (upgradeNoticeContext) {
   upgradeNoticeFinalized = true;
 }
 
-// ── 3g. Commit deferred version stamp (#730) ────────────────────────────────
-// Written LAST so an abort above leaves the stamp unchanged and the next
-// launcher re-detects the upgrade. Failure here is surfaced (#854) so a
-// permanently-broken stamp write (filesystem permissions, AV holds) doesn't
-// silently strand consumers in re-detect-on-every-session loops.
-if (pendingVersionStampWrite) {
-  try {
-    writeFileSync(pendingVersionStampWrite.path, pendingVersionStampWrite.version);
-  } catch (err) {
-    emitWarning(`version stamp write failed (${errMessage(err)}) — next launcher will re-detect the upgrade`);
-  }
-}
+// ── 3g. (removed) Version stamp now commits eagerly on sync success ──────────
+// The stamp used to be deferred to here ("written LAST", #730). That made it
+// vulnerable to the 5s SessionStart hook-timeout kill: a launcher killed during
+// the best-effort §3 stages above never reached this point, so the stamp stayed
+// stale and every subsequent session re-detected the same upgrade — the
+// indefinite "updating…" loop. The stamp now commits inside §3's sync block the
+// moment this version's files are in place (see commitVersionStamp). #730 is
+// preserved because that commit is gated on sync success; every stage after the
+// sync block runs unconditionally + idempotently each session.
 
 // ── 3h. Clear bootstrap sentinel if section-3 sync resolved it (#975) ───────
 // Section 3 above re-attempts the same file copies the bootstrap was supposed

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -953,7 +953,7 @@ try {
       // memory; a concurrent sql.js flush would clobber the cherry-picked
       // rows below, and old-path writes would resurrect ghost files in legacy
       // dirs. Section 4's `hooks.mjs session-start` spawns a fresh daemon
-      // under the current code once 3g writes the version stamp.
+      // under the current code after the version stamp is committed (below).
       const upgradeDaemonLock = resolve(projectRoot, '.moflo', 'daemon.lock');
       if (stopDaemon(upgradeDaemonLock)) {
         emitMutation('stopped daemon for upgrade', 'will restart fresh after upgrade work');
@@ -1297,7 +1297,7 @@ try {
       // The daemon was already stopped above so the lock file is gone and
       // there's no live PID to recycle here. Section 4's `hooks.mjs
       // session-start` will spawn a fresh daemon under the current moflo
-      // image once 3g writes the version stamp.
+      // image after the version stamp is committed (below, on sync success).
 
       // Surface per-file copy failures so the user / Claude can see what
       // didn't sync (#854). The file isn't in the manifest either, so the

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -253,10 +253,24 @@ const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
 // can persist `.moflo/upgrade-notice.json` for the statusline (#636).
 let upgradeNoticeContext = null;
 
-// Deferred so we commit it AFTER every upgrade-work block (see 3g). The stamp
-// is the "launcher fully completed" signal — writing it mid-flight lets an
-// aborted launcher strand consumers on a half-applied upgrade (#730).
-let pendingVersionStampWrite = null;
+// Commit the version stamp = "this version's files are in place". Written the
+// moment sync + manifest succeed (dogfood has no sync to do), NOT deferred to
+// the end of §3 — so a launcher killed by the 5s SessionStart hook-timeout
+// during later best-effort §3 work (hook-drift, CLAUDE.md injection drift,
+// embeddings migration, …) still records the upgrade, and the next session
+// stops re-detecting it. That end-of-§3 deferral was the root of the indefinite
+// "updating…" re-detect loop. #730 is still honored: the stamp commits only
+// after the sync that installs this version's files succeeds; every section
+// after the §3 sync block runs unconditionally + idempotently each session, so
+// an abort past this point strands no upgrade work.
+function commitVersionStamp(stampPath, version) {
+  try {
+    mkdirSync(dirname(stampPath), { recursive: true });
+    writeFileSync(stampPath, version);
+  } catch (err) {
+    emitWarning(`version stamp write failed (${errMessage(err)}) — next launcher will re-detect the upgrade`);
+  }
+}
 
 // 5-min TTL is a safety net for zombie launchers (statusline ignores past-TTL
 // files). The 2-min "completed" TTL lets the user see the post-upgrade badge
@@ -1002,7 +1016,7 @@ try {
       // (the stopDaemon call earlier handled this) and 3a-pre will spawn a
       // fresh daemon under the new code.
       if (isMofloDogfood) {
-        pendingVersionStampWrite = { path: versionStampPath, version: installedVersion };
+        commitVersionStamp(versionStampPath, installedVersion);
         emitMutation('skipped file-sync', 'moflo dogfood — committed dogfood copies preserved');
       } else {
 
@@ -1297,8 +1311,10 @@ try {
         );
       }
 
-      // Manifest reflects synced files immediately; version stamp is deferred
-      // to 3g so an aborted launcher re-runs upgrade detection (#730).
+      // Manifest reflects synced files immediately; the version stamp is
+      // committed right after the manifest write (below), gated on it succeeding
+      // — so an abort BEFORE sync still re-runs upgrade detection (#730), while
+      // an abort AFTER sync no longer strands the stamp in a re-detect loop.
       //
       // Exclude paths that `applyRetiredPrune` just deleted from disk —
       // recording a non-existent file in `installed-files.json` triggers
@@ -1316,7 +1332,7 @@ try {
         const cfDir = resolve(projectRoot, '.moflo');
         if (!existsSync(cfDir)) mkdirSync(cfDir, { recursive: true });
         writeFileSync(manifestPath, JSON.stringify(persistedManifest, null, 2));
-        pendingVersionStampWrite = { path: versionStampPath, version: installedVersion };
+        commitVersionStamp(versionStampPath, installedVersion);
       } catch (err) {
         // #854: manifest write must surface — without it the next launcher
         // can't tell what was installed and the version stamp never gets
@@ -2159,18 +2175,15 @@ if (upgradeNoticeContext) {
   upgradeNoticeFinalized = true;
 }
 
-// ── 3g. Commit deferred version stamp (#730) ────────────────────────────────
-// Written LAST so an abort above leaves the stamp unchanged and the next
-// launcher re-detects the upgrade. Failure here is surfaced (#854) so a
-// permanently-broken stamp write (filesystem permissions, AV holds) doesn't
-// silently strand consumers in re-detect-on-every-session loops.
-if (pendingVersionStampWrite) {
-  try {
-    writeFileSync(pendingVersionStampWrite.path, pendingVersionStampWrite.version);
-  } catch (err) {
-    emitWarning(`version stamp write failed (${errMessage(err)}) — next launcher will re-detect the upgrade`);
-  }
-}
+// ── 3g. (removed) Version stamp now commits eagerly on sync success ──────────
+// The stamp used to be deferred to here ("written LAST", #730). That made it
+// vulnerable to the 5s SessionStart hook-timeout kill: a launcher killed during
+// the best-effort §3 stages above never reached this point, so the stamp stayed
+// stale and every subsequent session re-detected the same upgrade — the
+// indefinite "updating…" loop. The stamp now commits inside §3's sync block the
+// moment this version's files are in place (see commitVersionStamp). #730 is
+// preserved because that commit is gated on sync success; every stage after the
+// sync block runs unconditionally + idempotently each session.
 
 // ── 3h. Clear bootstrap sentinel if section-3 sync resolved it (#975) ───────
 // Section 3 above re-attempts the same file copies the bootstrap was supposed

--- a/src/cli/__tests__/session-start-launcher-stamp-loop-recovery.test.ts
+++ b/src/cli/__tests__/session-start-launcher-stamp-loop-recovery.test.ts
@@ -169,6 +169,34 @@ describe('launcher #1173 — version-stamp loop recovery', () => {
     expect(result.stdout).not.toMatch(/recovered version stamp/);
   });
 
+  // Eager-commit fix for the indefinite "updating…" re-detect loop.
+  //
+  // ROOT CAUSE: the version stamp used to be deferred to §3g at the very END of
+  // §3 ("written LAST", #730). A launcher killed by the 5s SessionStart
+  // hook-timeout during the best-effort §3 stages above §3g (hook-drift,
+  // CLAUDE.md injection drift, embeddings migration) never reached §3g, so the
+  // stamp stayed stale and every subsequent session re-detected the SAME upgrade
+  // and re-painted "updating…" — forever. On Windows the timeout is a
+  // TerminateProcess (no Node handler runs), so the in-progress notice survived
+  // too, which is the on-disk tell that distinguished a hard kill from a
+  // graceful crash (the latter clears the notice via the exit handler).
+  //
+  // FIX: commit the stamp the moment sync + manifest succeed, inside §3's sync
+  // block — not at the end. A full functional repro needs a kill mid-§3, which
+  // (like the Option D SIGTERM case below) is too platform-flaky to assert
+  // reliably, so this is a source-shape guard: the deferred mechanism is gone
+  // and both sync arms commit eagerly via the helper.
+  it('eager-commit: version stamp commits on sync success, not deferred to end of §3', () => {
+    const launcherSrc = readFileSync(LAUNCHER, 'utf-8');
+    // The deferred mechanism that stranded the stamp on a mid-§3 kill is gone.
+    expect(launcherSrc).not.toMatch(/pendingVersionStampWrite/);
+    // The eager helper exists and is gated on a write failure being surfaced.
+    expect(launcherSrc).toMatch(/function commitVersionStamp\(/);
+    // Both sync arms (dogfood skip-sync + non-dogfood manifest write) commit it.
+    const eagerCommits = launcherSrc.match(/commitVersionStamp\(versionStampPath, installedVersion\)/g) || [];
+    expect(eagerCommits.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('Option D guard: completed notice survives a clean exit (upgradeNoticeFinalized prevents cleanup)', () => {
     // If §3f sets upgradeNoticeFinalized=true correctly, the process.on('exit')
     // handler skips the unlink branch and the short-TTL 'completed' notice

--- a/tests/bin/launcher-854-fixes.test.ts
+++ b/tests/bin/launcher-854-fixes.test.ts
@@ -99,13 +99,13 @@ describe('bin/session-start-launcher.mjs — partial-migration visibility (#854)
 
   it('manifest-write failure is surfaced to stderr (#854)', () => {
     // The inner try around `writeFileSync(manifestPath, ...)` used to be a
-    // bare `catch {}` — when it failed, `pendingVersionStampWrite` never
-    // got queued AND we had no idea why.
+    // bare `catch {}` — when it failed, the version stamp never got committed
+    // AND we had no idea why.
     expect(src).toMatch(/manifest write failed/);
   });
 
   it('version-stamp write failure is surfaced to stderr (#854)', () => {
-    // Same pattern at section 3g — a permanently-broken stamp write
+    // Same pattern in commitVersionStamp — a permanently-broken stamp write
     // (filesystem permissions, AV holds) used to fail silently and strand
     // the consumer in re-detect-on-every-session forever.
     expect(src).toMatch(/version stamp write failed/);

--- a/tests/bin/launcher-928-dogfood-skip.test.ts
+++ b/tests/bin/launcher-928-dogfood-skip.test.ts
@@ -136,11 +136,13 @@ describe('session-start-launcher — dogfood drift skip (#928)', () => {
       expect(src).toMatch(/if\s*\(\s*isMofloDogfood\s*\)\s*manifestDrifted\s*=\s*false/);
     });
 
-    it('skips file-sync stages in dogfood mode but still queues version stamp', () => {
+    it('skips file-sync stages in dogfood mode but still commits version stamp', () => {
       // The if/else fork wraps the entire manifest-based sync block. Dogfood
-      // path queues pendingVersionStampWrite (so we don't re-enter forever)
-      // and emits a visible mutation; consumer path runs the full sync.
-      expect(src).toMatch(/if\s*\(\s*isMofloDogfood\s*\)\s*\{[\s\S]*?pendingVersionStampWrite\s*=/);
+      // path commits the version stamp eagerly (so we don't re-enter forever)
+      // and emits a visible mutation; consumer path runs the full sync. The
+      // stamp commits here on sync success rather than being deferred to the end
+      // of §3 — see the eager-commit fix for the "updating…" re-detect loop.
+      expect(src).toMatch(/if\s*\(\s*isMofloDogfood\s*\)\s*\{[\s\S]*?commitVersionStamp\(/);
       expect(src).toMatch(/skipped file-sync/);
       expect(src).toMatch(/end !isMofloDogfood file-sync branch/);
     });


### PR DESCRIPTION
## Problem

The recurring `📦 X → Y (updating…)` statusline badge never clears after an upgrade.

**Root cause:** the version stamp (`.moflo/moflo-version`) was deferred to §3g at the very **end** of the launcher''s §3 work ("written LAST", #730). A launcher killed by Claude Code''s **5s SessionStart hook timeout** during the best-effort §3 stages above §3g (hook-drift, CLAUDE.md injection-drift hashing, embeddings migration — synchronous, slow on a large `.moflo/moflo.db`) never reached §3g, so the stamp stayed stale and **every subsequent session re-detected the same upgrade** and re-painted the `in-progress` badge — indefinitely.

On Windows the timeout is a `TerminateProcess` (no Node handler runs), so the `in-progress` notice survived too — the on-disk tell of a hard kill vs a graceful crash (which clears it via the exit handler). The #1173 eager-stamp recovery couldn''t break the cycle because it only fires when the prior notice is `completed`, and a kill-before-§3f always leaves it `in-progress`.

## Fix

Commit the stamp the moment **sync + manifest succeed**, inside §3''s sync block (`commitVersionStamp` helper), instead of deferring to §3g. The stamp''s true meaning is "this version''s files are in place" — true right after the manifest write.

**#730 preserved:** the commit is gated on sync success; every stage after the sync block runs unconditionally + idempotently each session, so an abort past this point strands no upgrade work. Robust to *any* later kill — fixes dogfood **and** consumers. The #1173 `completed`-recovery is kept as belt-and-suspenders.

## Review (/flo-simplify, NORMAL tier — 3 reviewers)

- **Quality**: #730 preservation, non-dogfood gating, mirror parity, tests — all CLEAN. Fixed the one finding (stale §3g comments).
- **Reuse / Efficiency**: clean (recovery''s inline write intentionally throws-on-failure vs the helper''s swallow+warn; helper `mkdirSync` is needed safety for the dogfood arm).

## Verification

- `npm run build` OK, `npm run lint` OK, full suite **9159 / 0**.
- Source-shape regression guard added (deferred mechanism gone; both sync arms commit eagerly) — following this file''s precedent for kill-timing behavior too platform-flaky to assert functionally.
- Updated `launcher-928` / `launcher-854` assertions + comments to the new mechanism.

**Caveat:** the real-session repro (hard kill before §3 end) only fully manifests under the 5s timeout + load, so end-to-end confirmation needs the publish + reinstall round-trip.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)