### PR TITLE
fix(launcher): restore both stale .claude/scripts/lib twins + export-parity guard

### DIFF
--- a/.claude/scripts/lib/file-sync.mjs
+++ b/.claude/scripts/lib/file-sync.mjs
@@ -28,13 +28,14 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   statSync,
   unlinkSync,
 } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { dirname } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 
 export const TRANSIENT_CODES = new Set(['EBUSY', 'EPERM', 'EACCES']);
 export const RETRY_BACKOFF_MS = [50, 200, 800];
@@ -197,4 +198,52 @@ export function makeSyncer({ onSuccess } = {}) {
     failures,
     isCircuitOpen: () => circuitOpen,
   };
+}
+
+/**
+ * Recursively sync every `.md` under `srcDir` into `<projectRoot>/<destPrefix>`,
+ * skipping any entry whose top-level directory is listed in `excludeTopLevel`.
+ *
+ * The session-start launcher uses this to mirror `node_modules/moflo/.claude/
+ * agents` and `.claude/skills` into the consumer project. `excludeTopLevel`
+ * keeps moflo-internal skills (`bin/lib/internal-skills.mjs`) out of consumer
+ * installs — without it the blanket copy would land `/publish` and `/reset-epic`
+ * in every consumer (they ship in the tarball but must not be installed).
+ *
+ * Each file is copied through `syncFile` so the manifest, hash-skip, and
+ * retry/breaker behaviour are identical to every other synced path.
+ *
+ * @param {string} srcDir   Absolute source directory (e.g. node_modules/moflo/.claude/skills).
+ * @param {string} destPrefix  Project-relative destination prefix (e.g. '.claude/skills').
+ * @param {object} opts
+ * @param {string} opts.projectRoot  Consumer project root the destPrefix is resolved against.
+ * @param {(src: string, dest: string, key: string) => Promise<unknown>} opts.syncFile  From makeSyncer().
+ * @param {Set<string>|string[]} [opts.excludeTopLevel]  Top-level dir names to skip.
+ * @param {(message: string) => void} [opts.onWarn]  Non-fatal warning sink.
+ */
+export async function syncDirRecursive(srcDir, destPrefix, { projectRoot, syncFile, excludeTopLevel, onWarn } = {}) {
+  if (!existsSync(srcDir)) return;
+  let entries;
+  try {
+    entries = readdirSync(srcDir, { recursive: true, withFileTypes: true });
+  } catch (err) {
+    onWarn?.(`${destPrefix} readdir failed (${errMessage(err)})`);
+    return;
+  }
+  const exclude = excludeTopLevel instanceof Set
+    ? excludeTopLevel
+    : new Set(excludeTopLevel || []);
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.toLowerCase().endsWith('.md')) continue;
+    const parent = entry.parentPath || entry.path || srcDir;
+    const absSrc = resolve(parent, entry.name);
+    // path.relative (not slice) so a trailing separator on srcDir can't shift
+    // the top-level segment and silently defeat the exclusion check.
+    const rel = relative(srcDir, absSrc).split(/[\\/]/).join('/');
+    if (exclude.size > 0 && exclude.has(rel.split('/')[0])) continue;
+    const absDest = resolve(projectRoot, destPrefix, rel);
+    // syncFile owns dir creation (mkdir recursive) — no outer mkdir needed.
+    await syncFile(absSrc, absDest, `${destPrefix}/${rel}`);
+  }
 }

--- a/.claude/scripts/lib/internal-skills.mjs
+++ b/.claude/scripts/lib/internal-skills.mjs
@@ -1,0 +1,16 @@
+/**
+ * Skills that ship in the npm tarball (under `node_modules/moflo/.claude/skills/`)
+ * but must NEVER be installed into consumer projects — strictly moflo-internal
+ * dev tooling. `/publish` bumps moflo's own version and publishes to npm;
+ * `/reset-epic` torches epic test data. Both are meaningless or harmful in a
+ * consumer repo.
+ *
+ * The session-start launcher's recursive skills sync (`syncDirRecursive` in
+ * `file-sync.mjs`) copies every shipped skill into the consumer on each run, so
+ * it MUST skip these. The canonical TypeScript copy is `INTERNAL_SKILLS` in
+ * `src/cli/init/executor.ts` (used by `flo init`). The launcher is a plain
+ * `.mjs` and can't import that TS const across the dist/source depth boundary,
+ * so this leaf mirrors it. `tests/bin/internal-skills-parity.test.ts` asserts
+ * the two lists never drift.
+ */
+export const INTERNAL_SKILLS = ['publish', 'reset-epic'];

--- a/tests/bin/lib-sync.test.ts
+++ b/tests/bin/lib-sync.test.ts
@@ -22,6 +22,40 @@ function cleanTempRoot(root: string) {
   try { rmSync(root, { recursive: true, force: true }); } catch { /* ok */ }
 }
 
+/**
+ * Statically extract the set of named ES-module exports from source, without
+ * executing it. Covers every export form moflo's bin/lib uses today plus the
+ * common ones (default, grouped, class) so a NEW export style added to bin/ but
+ * not propagated to the twin still trips the parity check instead of silently
+ * passing.
+ *
+ * Deliberately a text parser, not a dynamic import(): several bin/lib modules
+ * have import-time side effects (suppress-sqlite-warning patches process
+ * warnings; daemon/db helpers touch the filesystem) that must not run inside a
+ * unit test.
+ */
+function extractNamedExports(src: string): string[] {
+  const names = new Set<string>();
+  // export [async] function[*] NAME | export class NAME | export const|let|var NAME
+  const declRe = /\bexport\s+(?:async\s+)?(?:function\s*\*?|class|const|let|var)\s+([A-Za-z_$][\w$]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = declRe.exec(src))) names.add(m[1]);
+  // export default ...
+  if (/\bexport\s+default\b/.test(src)) names.add('default');
+  // export { a, b as c, type T } — capture the exported binding name
+  const groupRe = /\bexport\s*\{([^}]*)\}/g;
+  while ((m = groupRe.exec(src))) {
+    for (const part of m[1].split(',')) {
+      const seg = part.trim();
+      if (!seg || seg.startsWith('type ')) continue;
+      const asMatch = seg.match(/\bas\s+([A-Za-z_$][\w$]*)\s*$/);
+      const name = asMatch ? asMatch[1] : seg.replace(/^type\s+/, '');
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
+    }
+  }
+  return [...names].sort();
+}
+
 describe('bin/lib/ subdirectory sync', () => {
   let root: string;
   beforeEach(() => { root = makeTempRoot(); });
@@ -82,5 +116,41 @@ describe('bin/lib/ subdirectory sync', () => {
     expect(existsSync(join(libDestDir, 'process-manager.mjs'))).toBe(true);
     expect(existsSync(join(libDestDir, 'registry-cleanup.cjs'))).toBe(true);
     expect(existsSync(join(libDestDir, 'moflo-resolve.mjs'))).toBe(true);
+  });
+});
+
+describe('bin/lib ↔ .claude/scripts/lib committed twin parity (#1196/#1205 launcher-crash guard)', () => {
+  // The launcher runs from .claude/scripts/ and statically imports ./lib/*.mjs.
+  // In the dogfood repo the launcher's own bin/lib→.claude/scripts/lib sync is
+  // SKIPPED (committed dogfood copies are preserved), so the two trees are
+  // hand-maintained twins that silently drift. Two drift modes have each shipped
+  // a crash-dead launcher — caught here so neither recurs:
+  //   #1196 — a MISSING twin (.claude/scripts/lib/internal-skills.mjs absent)
+  //   #1205 — a twin that exists but DROPS a named export the launcher imports
+  //           (.claude/scripts/lib/file-sync.mjs lacked syncDirRecursive) → an
+  //           ESM SyntaxError at link time kills the module before any statement
+  //           (even the diagnostic boot probe) runs.
+  const binLibDir = resolve(__dirname, '../../bin/lib');
+  const scriptsLibDir = resolve(__dirname, '../../.claude/scripts/lib');
+
+  it('every bin/lib file is mirrored as a committed .claude/scripts/lib twin', () => {
+    const missing = readdirSync(binLibDir).filter((f) => !existsSync(join(scriptsLibDir, f)));
+    expect(missing, `bin/lib files with no .claude/scripts/lib twin: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('every .mjs twin exports the exact same named exports as its bin/lib source', () => {
+    const drift: string[] = [];
+    for (const file of readdirSync(binLibDir).filter((f) => f.endsWith('.mjs'))) {
+      const twin = join(scriptsLibDir, file);
+      if (!existsSync(twin)) continue; // presence asserted by the test above
+      const want = extractNamedExports(readFileSync(join(binLibDir, file), 'utf-8'));
+      const got = extractNamedExports(readFileSync(twin, 'utf-8'));
+      if (JSON.stringify(want) !== JSON.stringify(got)) {
+        const lost = want.filter((n) => !got.includes(n));
+        const extra = got.filter((n) => !want.includes(n));
+        drift.push(`${file}: missing=[${lost.join(',')}] extra=[${extra.join(',')}]`);
+      }
+    }
+    expect(drift, `export-signature drift between bin/lib and .claude/scripts/lib:\n${drift.join('\n')}`).toEqual([]);
   });
 });

--- a/tests/bin/lib-sync.test.ts
+++ b/tests/bin/lib-sync.test.ts
@@ -49,7 +49,7 @@ function extractNamedExports(src: string): string[] {
       const seg = part.trim();
       if (!seg || seg.startsWith('type ')) continue;
       const asMatch = seg.match(/\bas\s+([A-Za-z_$][\w$]*)\s*$/);
-      const name = asMatch ? asMatch[1] : seg.replace(/^type\s+/, '');
+      const name = asMatch ? asMatch[1] : seg; // type-only handled by the continue above
       if (/^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
     }
   }
@@ -134,6 +134,9 @@ describe('bin/lib ↔ .claude/scripts/lib committed twin parity (#1196/#1205 lau
   const scriptsLibDir = resolve(__dirname, '../../.claude/scripts/lib');
 
   it('every bin/lib file is mirrored as a committed .claude/scripts/lib twin', () => {
+    // Intentionally all formats, not just .mjs: the launcher's dir-sync mirrors
+    // the whole bin/lib tree, and synced scripts consume the non-.mjs files too
+    // (registry-cleanup.cjs, shipped-scripts.json). A bin/lib-only file is a gap.
     const missing = readdirSync(binLibDir).filter((f) => !existsSync(join(scriptsLibDir, f)));
     expect(missing, `bin/lib files with no .claude/scripts/lib twin: ${missing.join(', ')}`).toEqual([]);
   });


### PR DESCRIPTION
## Problem

The session-start launcher runs from `.claude/scripts/` and statically imports `./lib/*.mjs`. In the dogfood repo the launcher's own `bin/lib -> .claude/scripts/lib` self-sync is **skipped** (committed dogfood copies are preserved), so the two trees are hand-maintained twins that silently drift.

Two drift modes each shipped a **crash-dead launcher** — it died at ESM module load, before any statement ran (including the #1205 Phase 0 boot probe), leaving `launcher-stage-timing.jsonl` absent and the version stamp frozen at `4.10.21-rc.1`:

| Drift mode | Symptom |
|---|---|
| **Missing twin** | `.claude/scripts/lib/internal-skills.mjs` absent -> `ERR_MODULE_NOT_FOUND` |
| **Dropped export** | `.claude/scripts/lib/file-sync.mjs` lacked `syncDirRecursive` (present in `bin/lib`) -> `SyntaxError: ... does not provide an export named 'syncDirRecursive'` at line 18 |

`0a875e7c1` fixed the first (missing twin), but the sibling dropped-export sat one import line away — same bug class, incomplete fix.

## Changes

- **`0a875e7c1`** — restore the missing `internal-skills.mjs` twin
- **`9d55edcf3`** — restore `syncDirRecursive` in the `file-sync.mjs` twin (now byte-identical to its `bin/lib` source) + add an **export-signature + presence parity guard** (`tests/bin/lib-sync.test.ts`) covering both drift modes. Static export parser, not dynamic `import()` (several bin/lib modules have import-time side effects that must not run in a unit test).
- **`cf1099fc6`** — review polish on the guard (drop a dead branch; document that presence intentionally covers all file formats).

## Verification

- `npx vitest run tests/bin/lib-sync.test.ts` -> 7/7 green
- Negative test: reverting the twin to its broken state fails precisely with `file-sync.mjs: missing=[syncDirRecursive]`; restored identical afterward
- Both launcher copies pass `node --check`
- All 24 `.mjs` twins are now byte-identical to their `bin/lib` source

## Consumer impact

Dogfood-only. Consumers receive the correct twins via `executor.ts`'s `bin/lib -> .claude/scripts/lib` sync on `npm install`, which runs **outside** the launcher (immune to the crash); the published `bin/lib/file-sync.mjs` already exports `syncDirRecursive`. The parity guard ships in the test suite to block future drift in CI.

## Not included

The #1205 diagnostic timing probes remain uncommitted in both launcher copies — they must run next session to capture the per-stage timing data this fix finally unblocks.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
