### PR TITLE
refactor(rebrand): back-compat migration of claudeFlow / CLAUDE_FLOW_* to moflo

### DIFF
--- a/.claude/guidance/shipped/moflo-yaml-reference.md
+++ b/.claude/guidance/shipped/moflo-yaml-reference.md
@@ -164,17 +164,17 @@ Config is loaded from `moflo.yaml` at the project root — there is no env var t
 
 ```bash
 # Logging
-CLAUDE_FLOW_LOG_LEVEL=info               # debug | info | warn | error
+MOFLO_LOG_LEVEL=info               # debug | info | warn | error
 
 # MCP Server (stdio transport — no port)
-CLAUDE_FLOW_MCP_TRANSPORT=stdio
+MOFLO_MCP_TRANSPORT=stdio
 
 # Memory backend (legacy SystemConfig env vars — moflo.yaml `memory.backend` is the modern surface)
-CLAUDE_FLOW_MEMORY_BACKEND=sqlite        # informational only; not consumed by selectProvider
-CLAUDE_FLOW_MEMORY_TYPE=sqlite           # SystemConfig override (legacy)
+MOFLO_MEMORY_BACKEND=sqlite        # informational only; not consumed by selectProvider
+MOFLO_MEMORY_TYPE=sqlite           # SystemConfig override (legacy)
 ```
 
-Variable names retain the `CLAUDE_FLOW_` prefix for backward compatibility with consumers upgraded from claude-flow.
+These use the canonical `MOFLO_` prefix. The pre-rebrand `CLAUDE_FLOW_` names are still read as a fallback for one deprecation cycle, so consumers upgraded from `claude-flow` keep working without a manual rename.
 
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -300,10 +300,10 @@
   },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "CLAUDE_FLOW_V3_ENABLED": "true",
-    "CLAUDE_FLOW_HOOKS_ENABLED": "true"
+    "MOFLO_V3_ENABLED": "true",
+    "MOFLO_HOOKS_ENABLED": "true"
   },
-  "claudeFlow": {
+  "moflo": {
     "version": "3.0.0",
     "enabled": true,
     "platform": {

--- a/bin/cli-hooks/statusline.js
+++ b/bin/cli-hooks/statusline.js
@@ -36,10 +36,10 @@ Usage:
   statusline --help       Show this help
 
 Environment Variables:
-  CLAUDE_FLOW_STATUSLINE_REFRESH   Refresh interval in ms
-  CLAUDE_FLOW_SHOW_HOOKS_METRICS   Show hooks metrics (true/false)
-  CLAUDE_FLOW_SHOW_SWARM_ACTIVITY  Show swarm activity (true/false)
-  CLAUDE_FLOW_SHOW_PERFORMANCE     Show performance targets (true/false)
+  MOFLO_STATUSLINE_REFRESH   Refresh interval in ms
+  MOFLO_SHOW_HOOKS_METRICS   Show hooks metrics (true/false)
+  MOFLO_SHOW_SWARM_ACTIVITY  Show swarm activity (true/false)
+  MOFLO_SHOW_PERFORMANCE     Show performance targets (true/false)
 
 Examples:
   statusline                       # Display formatted status
@@ -49,13 +49,17 @@ Examples:
     process.exit(0);
   }
 
-  // Create generator with environment-based config
+  // Create generator with environment-based config.
+  // #1209 — prefer MOFLO_* toggles, fall back to the pre-rebrand CLAUDE_FLOW_*
+  // names so consumers who set the old vars keep their statusline preferences.
+  const showEnv = (suffix) =>
+    process.env['MOFLO_' + suffix] ?? process.env['CLAUDE_' + 'FLOW_' + suffix];
   const generator = new StatuslineGenerator({
     enabled: true,
     refreshOnHook: true,
-    showHooksMetrics: process.env.CLAUDE_FLOW_SHOW_HOOKS_METRICS !== 'false',
-    showSwarmActivity: process.env.CLAUDE_FLOW_SHOW_SWARM_ACTIVITY !== 'false',
-    showPerformance: process.env.CLAUDE_FLOW_SHOW_PERFORMANCE !== 'false',
+    showHooksMetrics: showEnv('SHOW_HOOKS_METRICS') !== 'false',
+    showSwarmActivity: showEnv('SHOW_SWARM_ACTIVITY') !== 'false',
+    showPerformance: showEnv('SHOW_PERFORMANCE') !== 'false',
   });
 
   // Try to read from metrics database or files

--- a/src/cli/__tests__/commands-deep.test.ts
+++ b/src/cli/__tests__/commands-deep.test.ts
@@ -1427,7 +1427,7 @@ describe('Init System', () => {
     });
 
     it('should have all MCP servers enabled', () => {
-      expect(FULL_INIT_OPTIONS.mcp.claudeFlow).toBe(true);
+      expect(FULL_INIT_OPTIONS.mcp.moflo).toBe(true);
       expect(FULL_INIT_OPTIONS.mcp.ruvSwarm).toBe(true);
       expect(FULL_INIT_OPTIONS.mcp.flowNexus).toBe(true);
     });
@@ -1483,12 +1483,14 @@ describe('Init System', () => {
       expect(env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).toBe('1');
     });
 
-    it('should include claudeFlow v3 settings', () => {
+    it('should include moflo v3 settings', () => {
       const settings = generateSettings(DEFAULT_INIT_OPTIONS) as Record<string, unknown>;
-      expect(settings.claudeFlow).toBeDefined();
-      const cf = settings.claudeFlow as Record<string, unknown>;
+      expect(settings.moflo).toBeDefined();
+      const cf = settings.moflo as Record<string, unknown>;
       expect(cf.version).toBe('3.0.0');
       expect(cf.enabled).toBe(true);
+      // The pre-rebrand tree must not be emitted any more (#1209).
+      expect(settings.claudeFlow).toBeUndefined();
     });
 
     it('should deny reading .env files', () => {

--- a/src/cli/__tests__/services/daemon-service.test.ts
+++ b/src/cli/__tests__/services/daemon-service.test.ts
@@ -100,7 +100,7 @@ describe('daemon-service', () => {
       expect(unit).toContain('WorkingDirectory=/home/dev/myapp');
       expect(unit).toContain('WantedBy=default.target');
       expect(unit).toContain('Restart=on-failure');
-      expect(unit).toContain('CLAUDE_FLOW_DAEMON=1');
+      expect(unit).toContain('MOFLO_DAEMON=1');
     });
   });
 

--- a/src/cli/__tests__/services/env-compat-dual-read.test.ts
+++ b/src/cli/__tests__/services/env-compat-dual-read.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Dual-read regression coverage for the claude-flow → moflo rebrand (#1209).
+ *
+ * The rebrand switched every WRITER to emit `MOFLO_*` env vars and the
+ * `moflo.*` settings tree, but READS must keep honouring the pre-rebrand
+ * `CLAUDE_FLOW_*` / `claudeFlow.*` names for at least one deprecation cycle so
+ * a consumer whose shell env, persisted settings.json, or installed systemd
+ * unit still uses the old names keeps working without a manual migration.
+ *
+ * These tests pin that contract:
+ *   1. `readMofloEnv` prefers MOFLO_*, falls back to CLAUDE_FLOW_*.
+ *   2. The update rate-limiter (a real reader) honours BOTH env spellings.
+ *   3. `isHookBlockLocked` (the runtime reader of the settings tree) honours
+ *      BOTH `moflo.hooks.locked` and the legacy `claudeFlow.hooks.locked`.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { readMofloEnv } from '../../services/env-compat.js';
+import { shouldCheckForUpdates } from '../../update/rate-limiter.js';
+import { isHookBlockLocked } from '../../services/hook-block-hash.js';
+
+// Snapshot + restore every env key these tests touch so they don't leak.
+const TOUCHED = [
+  'MOFLO_DUAL_READ_PROBE',
+  'CLAUDE_FLOW_DUAL_READ_PROBE',
+  'MOFLO_AUTO_UPDATE',
+  'CLAUDE_FLOW_AUTO_UPDATE',
+  'MOFLO_FORCE_UPDATE',
+  'CLAUDE_FLOW_FORCE_UPDATE',
+  'CI',
+  'CONTINUOUS_INTEGRATION',
+];
+
+afterEach(() => {
+  for (const key of TOUCHED) delete process.env[key];
+});
+
+describe('env-compat dual-read (#1209)', () => {
+  describe('readMofloEnv', () => {
+    it('returns undefined when neither name is set', () => {
+      expect(readMofloEnv('DUAL_READ_PROBE')).toBeUndefined();
+    });
+
+    it('reads the legacy CLAUDE_FLOW_* name as a fallback', () => {
+      process.env.CLAUDE_FLOW_DUAL_READ_PROBE = 'legacy';
+      expect(readMofloEnv('DUAL_READ_PROBE')).toBe('legacy');
+    });
+
+    it('prefers the canonical MOFLO_* name over the legacy name', () => {
+      process.env.CLAUDE_FLOW_DUAL_READ_PROBE = 'legacy';
+      process.env.MOFLO_DUAL_READ_PROBE = 'canonical';
+      expect(readMofloEnv('DUAL_READ_PROBE')).toBe('canonical');
+    });
+  });
+
+  describe('update rate-limiter honours both env spellings', () => {
+    it('disables auto-update via the legacy CLAUDE_FLOW_AUTO_UPDATE', () => {
+      delete process.env.CI;
+      delete process.env.CONTINUOUS_INTEGRATION;
+      process.env.CLAUDE_FLOW_AUTO_UPDATE = 'false';
+      const result = shouldCheckForUpdates();
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('disabled');
+    });
+
+    it('disables auto-update via the canonical MOFLO_AUTO_UPDATE', () => {
+      delete process.env.CI;
+      delete process.env.CONTINUOUS_INTEGRATION;
+      process.env.MOFLO_AUTO_UPDATE = 'false';
+      const result = shouldCheckForUpdates();
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('disabled');
+    });
+
+    it('forces an update via the canonical MOFLO_FORCE_UPDATE', () => {
+      delete process.env.CI;
+      delete process.env.CONTINUOUS_INTEGRATION;
+      delete process.env.CLAUDE_FLOW_AUTO_UPDATE;
+      process.env.MOFLO_FORCE_UPDATE = 'true';
+      expect(shouldCheckForUpdates().allowed).toBe(true);
+    });
+
+    it('forces an update via the legacy CLAUDE_FLOW_FORCE_UPDATE', () => {
+      delete process.env.CI;
+      delete process.env.CONTINUOUS_INTEGRATION;
+      delete process.env.CLAUDE_FLOW_AUTO_UPDATE;
+      process.env.CLAUDE_FLOW_FORCE_UPDATE = 'true';
+      expect(shouldCheckForUpdates().allowed).toBe(true);
+    });
+  });
+
+  describe('isHookBlockLocked honours both settings trees', () => {
+    it('honours the canonical moflo.hooks.locked', () => {
+      expect(isHookBlockLocked({ moflo: { hooks: { locked: true } } })).toBe(true);
+    });
+
+    it('falls back to the legacy claudeFlow.hooks.locked', () => {
+      expect(isHookBlockLocked({ claudeFlow: { hooks: { locked: true } } })).toBe(true);
+    });
+
+    it('is false when neither tree locks', () => {
+      expect(isHookBlockLocked({ moflo: { hooks: {} } })).toBe(false);
+      expect(isHookBlockLocked({})).toBe(false);
+    });
+  });
+});

--- a/src/cli/__tests__/services/published-package-drift-guard.test.ts
+++ b/src/cli/__tests__/services/published-package-drift-guard.test.ts
@@ -509,6 +509,68 @@ describe('published-package drift guard (issue #585)', () => {
         `Offenders:\n  ${offenders.join('\n  ')}`,
     ).toEqual([]);
   });
+
+  it('no production code *writes* CLAUDE_FLOW_* env vars or the claudeFlow.* settings tree (#1209)', () => {
+    // Issue #1209: the claude-flow → moflo rebrand migrated every WRITER to
+    // emit `MOFLO_*` env vars and the `moflo.*` settings tree. READS still
+    // accept the pre-rebrand names as a fallback (see services/env-compat.ts
+    // and hook-block-hash.ts), so this guard is deliberately write-only: it
+    // flags new writers that would re-introduce the legacy brand into a
+    // consumer's environment, .mcp.json, settings.json, or systemd unit.
+    //
+    // The write shapes below intentionally do NOT match: reads
+    // (`readMofloEnv('X')`, `existingEnv.CLAUDE_FLOW_X || …`), comparisons
+    // (`=== '1'`), deletions (`delete x.claudeFlow`), the upstream package-list
+    // identifier `CLAUDE_FLOW_PACKAGES`, or the legacy `.claude-flow` dir
+    // constant `LEGACY_CLAUDE_FLOW_DIR`. If a genuine new writer is required
+    // (e.g. a migration codepath), add the marker `LEGACY-ENV-WRITE` on the
+    // same line.
+    const SCAN_ROOTS = [
+      join(REPO_ROOT, 'src', 'cli'),
+      join(REPO_ROOT, 'bin'),
+      join(REPO_ROOT, 'scripts'),
+      join(REPO_ROOT, '.claude', 'guidance', 'shipped'),
+      join(REPO_ROOT, '.claude', 'helpers'),
+      join(REPO_ROOT, '.claude', 'skills'),
+    ];
+    const WRITE_PATTERNS: RegExp[] = [
+      /\bCLAUDE_FLOW_[A-Z0-9_]+\s*:/,                  // object-literal env key: `CLAUDE_FLOW_X: 'v'`
+      /process\.env\.CLAUDE_FLOW_[A-Z0-9_]+\s*=(?!=)/, // assignment: `process.env.CLAUDE_FLOW_X = …`
+      /\bCLAUDE_FLOW_[A-Z0-9_]+=(?!=)/,                // KEY=value string: systemd unit, .env, help text
+      /\.claudeFlow\s*=(?!=)/,                          // settings member write: `settings.claudeFlow = …`
+    ];
+    const ALLOWED_MARKERS = /LEGACY-ENV-WRITE/;
+    const offenders: string[] = [];
+    for (const root of SCAN_ROOTS) {
+      if (!existsSync(root)) continue;
+      for (const file of walkAll(root)) {
+        if (file.endsWith('published-package-drift-guard.test.ts')) continue;
+        if (/[/\\]__tests__[/\\]/.test(file)) continue;
+        if (file.endsWith('.db') || file.endsWith('.bin') || file.endsWith('.wasm')) continue;
+        const text = readFileSync(file, 'utf8');
+        if (!text.includes('CLAUDE_FLOW_') && !text.includes('claudeFlow')) continue;
+        const rel = relative(REPO_ROOT, file).replace(/\\/g, '/');
+        const lines = text.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i];
+          if (isCommentLine(line)) continue;
+          if (ALLOWED_MARKERS.test(line)) continue;
+          if (WRITE_PATTERNS.some((re) => re.test(line))) {
+            offenders.push(`${rel}:${i + 1}`);
+          }
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Production code WRITES legacy claude-flow branding (#1209 migrated every\n` +
+        `writer to MOFLO_* / moflo.*). Switch the writer to the MOFLO_* env name\n` +
+        `or the moflo.* settings key (reads still fall back to the old name).\n` +
+        `If a legacy write is genuinely required, add a "LEGACY-ENV-WRITE" marker\n` +
+        `on the same line.\n` +
+        `Offenders:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([]);
+  });
 });
 
 /**

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -18,6 +18,7 @@ import { spawn, execFile, execFileSync } from 'child_process';
 import { join, resolve, isAbsolute } from 'path';
 import * as fs from 'fs';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { readMofloEnv } from '../services/env-compat.js';
 
 /**
  * Resolve the dashboard port from CLI flag and env, in that precedence order.
@@ -76,7 +77,7 @@ const startCommand: Command = {
     const noDashboard = ctx.flags.noDashboard as boolean;
     const rawDashboardPort = ctx.flags.dashboardPort as string | undefined;
     const projectRoot = process.cwd();
-    const isDaemonProcess = process.env.CLAUDE_FLOW_DAEMON === '1';
+    const isDaemonProcess = readMofloEnv('DAEMON') === '1';
 
     // Resolve dashboard port; see `resolveDashboardPort` for precedence.
     const portResult = resolveDashboardPort(rawDashboardPort, process.env.MOFLO_DAEMON_PORT);
@@ -145,7 +146,7 @@ const startCommand: Command = {
       process.env.MOFLO_IS_DAEMON = '1';
 
       // Acquire atomic daemon lock (prevents duplicate daemons).
-      // Always acquire here — even when spawned as a child (CLAUDE_FLOW_DAEMON=1)
+      // Always acquire here — even when spawned as a child (MOFLO_DAEMON=1)
       // because on Windows the parent's child.pid is the shell PID (cmd.exe),
       // not the actual node process. The child must write its own real PID.
       const lockResult = acquireDaemonLock(projectRoot);
@@ -433,7 +434,7 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean, maxCpu
 
   const daemonEnv = {
     ...process.env,
-    CLAUDE_FLOW_DAEMON: '1',
+    MOFLO_DAEMON: '1',
     // #981 — daemon process must skip its own write-routing client.
     MOFLO_IS_DAEMON: '1',
     // Prevent macOS SIGHUP kill when terminal closes

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -710,7 +710,7 @@ export async function checkHookBlockDrift(): Promise<HealthCheck> {
     return {
       name: 'Hook Block Drift',
       status: 'pass',
-      message: 'drift check skipped — claudeFlow.hooks.locked: true',
+      message: 'drift check skipped — moflo.hooks.locked: true',
     };
   }
   // #896: respect `auto_update.hook_block_drift: off` — opt-out for consumers
@@ -745,7 +745,7 @@ export async function checkHookBlockDrift(): Promise<HealthCheck> {
     name: 'Hook Block Drift',
     status: 'warn',
     message: parts.join(', '),
-    fix: 'set auto_update.hook_block_drift: regenerate in moflo.yaml, or claudeFlow.hooks.locked: true to suppress',
+    fix: 'set auto_update.hook_block_drift: regenerate in moflo.yaml, or moflo.hooks.locked: true to suppress',
   };
 }
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -21,6 +21,7 @@ import {
 } from '../mcp-server.js';
 import { listMCPTools, callMCPTool, hasTool, getToolMetadata } from '../mcp-client.js';
 import { acquireDaemonLock, releaseDaemonLock, getDaemonLockHolder } from '../services/daemon-lock.js';
+import { readMofloEnv } from '../services/env-compat.js';
 
 // MCP tools categories
 const TOOL_CATEGORIES = [
@@ -266,7 +267,7 @@ const statusCommand: Command = {
       // If PID-based check says not running, detect stdio mode
       if (!status.running) {
         const isStdio = !process.stdin.isTTY;
-        const envTransport = process.env.CLAUDE_FLOW_MCP_TRANSPORT;
+        const envTransport = readMofloEnv('MCP_TRANSPORT');
         if (isStdio || envTransport === 'stdio') {
           status = {
             running: true,

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -62,7 +62,7 @@ const checkCommand: Command = {
     const { flags } = ctx;
 
     if (flags.force) {
-      process.env.CLAUDE_FLOW_FORCE_UPDATE = 'true';
+      process.env.MOFLO_FORCE_UPDATE = 'true';
     }
 
     try {
@@ -125,7 +125,7 @@ const checkCommand: Command = {
 
       return { success: true };
     } finally {
-      delete process.env.CLAUDE_FLOW_FORCE_UPDATE;
+      delete process.env.MOFLO_FORCE_UPDATE;
     }
   },
 };
@@ -140,7 +140,7 @@ const allCommand: Command = {
   ],
   async action(ctx: CommandContext): Promise<CommandResult> {
     const { flags } = ctx;
-    process.env.CLAUDE_FLOW_FORCE_UPDATE = 'true';
+    process.env.MOFLO_FORCE_UPDATE = 'true';
 
     try {
       output.printInfo('Checking for updates...');
@@ -204,7 +204,7 @@ const allCommand: Command = {
 
       return { success: failed.length === 0 };
     } finally {
-      delete process.env.CLAUDE_FLOW_FORCE_UPDATE;
+      delete process.env.MOFLO_FORCE_UPDATE;
     }
   },
 };
@@ -327,8 +327,8 @@ const updateCommand: Command = {
     output.writeln();
     output.writeln('Environment Variables:');
     output.printList([
-      `${output.dim('CLAUDE_FLOW_AUTO_UPDATE=false')}  - Disable auto-update`,
-      `${output.dim('CLAUDE_FLOW_FORCE_UPDATE=true')} - Force update check`,
+      `${output.dim('MOFLO_AUTO_UPDATE=false')}  - Disable auto-update`,
+      `${output.dim('MOFLO_FORCE_UPDATE=true')} - Force update check`,
     ]);
     output.writeln();
     output.writeln('Run "flo update <subcommand> --help" for subcommand help');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -556,14 +556,14 @@ export class CLI {
       ? spawn(`"${process.execPath}" ${spawnArgs.map(a => `"${a}"`).join(' ')}`, [], {
           cwd: projectRoot,
           stdio: ['ignore', openSync(logFile, 'a'), openSync(logFile, 'a')],
-          env: { ...process.env, CLAUDE_FLOW_DAEMON: '1' },
+          env: { ...process.env, MOFLO_DAEMON: '1' },
           shell: true, windowsHide: true,
         })
       : spawn(process.execPath, spawnArgs, {
           cwd: projectRoot,
           detached: true,
           stdio: ['ignore', openSync(logFile, 'a'), openSync(logFile, 'a')],
-          env: { ...process.env, CLAUDE_FLOW_DAEMON: '1' },
+          env: { ...process.env, MOFLO_DAEMON: '1' },
         });
 
     child.unref();

--- a/src/cli/init/executor.ts
+++ b/src/cli/init/executor.ts
@@ -32,6 +32,7 @@ import { writeEnvrc } from './envrc-generator.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 import { locateMofloRootPath } from '../services/moflo-require.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { readMofloEnv } from '../services/env-compat.js';
 
 /**
  * Skills to copy based on configuration. Exported for integrity tests.
@@ -259,16 +260,20 @@ function mergeSettingsForUpgrade(existing: Record<string, unknown>): Record<stri
   // Mac/Linux: Use bash-compatible commands with 2>/dev/null
   // NOTE: teammateIdleCmd and taskCompletedCmd were removed.
   // TeammateIdle/TaskCompleted are not valid Claude Code hook events and caused warnings.
-  // Agent Teams hook config lives in claudeFlow.agentTeams.hooks instead.
+  // Agent Teams hook config lives in moflo.agentTeams.hooks instead.
 
   // 1. Merge env vars (preserve existing, add new)
   const existingEnv = (existing.env as Record<string, string>) || {};
   const newEnv: Record<string, string> = {
     ...existingEnv,
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-    CLAUDE_FLOW_V3_ENABLED: existingEnv.CLAUDE_FLOW_V3_ENABLED || 'true',
-    CLAUDE_FLOW_HOOKS_ENABLED: existingEnv.CLAUDE_FLOW_HOOKS_ENABLED || 'true',
+    // #1209 — emit MOFLO_* names; carry any pre-rebrand value forward, then
+    // drop the legacy keys so a consumer's settings.json ends up clean.
+    MOFLO_V3_ENABLED: existingEnv.MOFLO_V3_ENABLED || existingEnv.CLAUDE_FLOW_V3_ENABLED || 'true',
+    MOFLO_HOOKS_ENABLED: existingEnv.MOFLO_HOOKS_ENABLED || existingEnv.CLAUDE_FLOW_HOOKS_ENABLED || 'true',
   };
+  delete newEnv.CLAUDE_FLOW_V3_ENABLED;
+  delete newEnv.CLAUDE_FLOW_HOOKS_ENABLED;
   // Remove stale PATH override — ${PATH} isn't expanded by Claude Code,
   // which replaces the inherited PATH and breaks node resolution in hooks.
   delete newEnv.PATH;
@@ -328,7 +333,7 @@ function mergeSettingsForUpgrade(existing: Record<string, unknown>): Record<stri
   // Remove them if they exist from a previous init.
   delete (merged.hooks as Record<string, unknown>).TeammateIdle;
   delete (merged.hooks as Record<string, unknown>).TaskCompleted;
-  // Their configuration lives in claudeFlow.agentTeams.hooks instead.
+  // Their configuration lives in moflo.agentTeams.hooks instead.
 
   // 3. Fix statusLine config (remove invalid fields, ensure correct format)
   // Claude Code only supports: type, command, padding
@@ -340,13 +345,20 @@ function mergeSettingsForUpgrade(existing: Record<string, unknown>): Record<stri
     // Remove invalid fields: refreshMs, enabled (not supported by Claude Code)
   };
 
-  // 4. Merge claudeFlow settings (preserve existing, add agentTeams + memory)
-  const existingClaudeFlow = (existing.claudeFlow as Record<string, unknown>) || {};
-  const existingMemory = (existingClaudeFlow.memory as Record<string, unknown>) || {};
-  merged.claudeFlow = {
-    ...existingClaudeFlow,
-    version: existingClaudeFlow.version || '3.0.0',
-    enabled: existingClaudeFlow.enabled !== false,
+  // 4. Merge moflo settings (preserve existing, add agentTeams + memory).
+  // #1209 — read the canonical `moflo.*` tree, falling back to the pre-rebrand
+  // `claudeFlow.*` tree, write `moflo.*`, then drop the legacy tree so the
+  // consumer's settings.json migrates in place. The `hooks.locked` escape
+  // hatch survives the move via the spread.
+  const existingMofloTree =
+    (existing.moflo as Record<string, unknown>) ||
+    (existing.claudeFlow as Record<string, unknown>) ||
+    {};
+  const existingMemory = (existingMofloTree.memory as Record<string, unknown>) || {};
+  merged.moflo = {
+    ...existingMofloTree,
+    version: existingMofloTree.version || '3.0.0',
+    enabled: existingMofloTree.enabled !== false,
     agentTeams: {
       enabled: true,
       teammateMode: 'auto',
@@ -370,6 +382,8 @@ function mergeSettingsForUpgrade(existing: Record<string, unknown>): Record<stri
       agentScopes: existingMemory.agentScopes ?? { enabled: true },
     },
   };
+  // Drop the pre-rebrand tree now that its content lives under `moflo.*`.
+  delete merged.claudeFlow;
 
   // 5. Repair any missing required hook wirings (same logic doctor --fix uses)
   repairHookWiring(merged);
@@ -664,8 +678,8 @@ export async function executeUpgrade(targetDir: string, _upgradeSettings = false
             'hooks.TeammateIdle (removed — not a valid Claude Code hook)',
             'hooks.TaskCompleted (removed — not a valid Claude Code hook)',
             'hooks (repaired missing gate wirings)',
-            'claudeFlow.agentTeams',
-            'claudeFlow.memory (learningBridge, memoryGraph, agentScopes)',
+            'moflo.agentTeams',
+            'moflo.memory (learningBridge, memoryGraph, agentScopes)',
             'statusLine',
           ];
         } catch (settingsError) {
@@ -779,7 +793,7 @@ export async function executeUpgradeWithMissing(targetDir: string, _upgradeSetti
     const sourceCommandsDir = findSourceDir('commands');
 
     // Debug: Log source directories found
-    if (process.env.DEBUG || process.env.CLAUDE_FLOW_DEBUG) {
+    if (process.env.DEBUG || readMofloEnv('DEBUG')) {
       console.log('[DEBUG] Source directories:');
       console.log(`  Skills: ${sourceSkillsDir || 'NOT FOUND'}`);
       console.log(`  Agents: ${sourceAgentsDir || 'NOT FOUND'}`);
@@ -789,7 +803,7 @@ export async function executeUpgradeWithMissing(targetDir: string, _upgradeSetti
     // Add missing skills
     if (sourceSkillsDir) {
       const allSkills = Object.values(SKILLS_MAP).flat();
-      const debugMode = process.env.DEBUG || process.env.CLAUDE_FLOW_DEBUG;
+      const debugMode = process.env.DEBUG || readMofloEnv('DEBUG');
       if (debugMode) {
         console.log(`[DEBUG] Checking ${allSkills.length} skills from SKILLS_MAP`);
       }

--- a/src/cli/init/mcp-generator.ts
+++ b/src/cli/init/mcp-generator.ts
@@ -75,17 +75,19 @@ export function generateMCPConfig(options: InitOptions): object {
   // demand via ToolSearch instead of putting 150+ schemas into context at startup.
   const deferProps = config.toolDefer ? { toolDefer: 'deferred' } : {};
 
+  // #1209 — write MOFLO_* into the consumer's .mcp.json; the runtime readers
+  // (loader.ts etc.) still accept the pre-rebrand CLAUDE_FLOW_* names.
   const mcpEnv = {
     ...npmEnv,
-    CLAUDE_FLOW_MODE: 'v3',
-    CLAUDE_FLOW_HOOKS_ENABLED: 'true',
-    CLAUDE_FLOW_TOPOLOGY: options.runtime.topology,
-    CLAUDE_FLOW_MAX_AGENTS: String(options.runtime.maxAgents),
-    CLAUDE_FLOW_MEMORY_BACKEND: options.runtime.memoryBackend,
+    MOFLO_MODE: 'v3',
+    MOFLO_HOOKS_ENABLED: 'true',
+    MOFLO_TOPOLOGY: options.runtime.topology,
+    MOFLO_MAX_AGENTS: String(options.runtime.maxAgents),
+    MOFLO_MEMORY_BACKEND: options.runtime.memoryBackend,
   };
 
-  // Claude Flow MCP server (core) — use direct node when locally installed
-  if (config.claudeFlow) {
+  // moflo MCP server (core) — use direct node when locally installed
+  if (config.moflo) {
     const projectRoot = options.targetDir ?? process.cwd();
     const localCli = findMofloCli(projectRoot);
 
@@ -143,7 +145,7 @@ export function generateMCPCommands(options: InitOptions): string[] {
 
   const cmdPrefix = isWindows ? 'cmd /c ' : '';
 
-  if (config.claudeFlow) {
+  if (config.moflo) {
     const projectRoot = options.targetDir ?? process.cwd();
     const localCli = findMofloCli(projectRoot);
     if (localCli) {

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -47,23 +47,26 @@ export function generateSettings(options: InitOptions): object {
   };
 
   // Note: Claude Code expects 'model' to be a string, not an object
-  // Model preferences are stored in claudeFlow settings instead
+  // Model preferences are stored in moflo settings instead
   // settings.model = 'claude-sonnet-4-5-20250929'; // Uncomment if you want to set a default model
 
   // Add Agent Teams configuration (experimental feature)
   settings.env = {
     // Enable Claude Code Agent Teams for multi-agent coordination
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-    // Claude Flow specific environment
-    CLAUDE_FLOW_V3_ENABLED: 'true',
-    CLAUDE_FLOW_HOOKS_ENABLED: 'true',
+    // moflo-specific environment (#1209 — emit MOFLO_*; readers still accept
+    // the pre-rebrand CLAUDE_FLOW_* names as a fallback via env-compat.ts)
+    MOFLO_V3_ENABLED: 'true',
+    MOFLO_HOOKS_ENABLED: 'true',
   };
 
   // Detect platform for platform-aware configuration
   const platform = detectPlatform();
 
-  // Add V3-specific settings
-  settings.claudeFlow = {
+  // Add V3-specific settings (#1209 — canonical `moflo.*` tree; the pre-rebrand
+  // `claudeFlow.*` tree is still read as a fallback by hook-block-hash + the
+  // upgrade merge for consumers who haven't re-run init yet)
+  settings.moflo = {
     version: '3.0.0',
     enabled: true,
     platform: {
@@ -466,7 +469,7 @@ function generateHooksConfig(config: HooksConfig): object {
   }
 
   // NOTE: TeammateIdle and TaskCompleted are NOT valid Claude Code hook events.
-  // Their configuration lives in claudeFlow.agentTeams.hooks instead (see generateSettings).
+  // Their configuration lives in moflo.agentTeams.hooks instead (see generateSettings).
 
   return hooks;
 }

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -148,8 +148,8 @@ export interface StatuslineConfig {
  * MCP configuration
  */
 export interface MCPConfig {
-  /** Include claude-flow MCP server */
-  claudeFlow: boolean;
+  /** Include the core moflo MCP server */
+  moflo: boolean;
   /** Include ruv-swarm MCP server */
   ruvSwarm: boolean;
   /** Include flow-nexus MCP server */
@@ -368,7 +368,7 @@ export const DEFAULT_INIT_OPTIONS: InitOptions = {
     refreshInterval: 5000,
   },
   mcp: {
-    claudeFlow: true,
+    moflo: true,
     ruvSwarm: false,
     flowNexus: false,
     autoStart: false,
@@ -491,7 +491,7 @@ export const FULL_INIT_OPTIONS: InitOptions = {
     all: true,
   },
   mcp: {
-    claudeFlow: true,
+    moflo: true,
     ruvSwarm: true,
     flowNexus: true,
     autoStart: false,

--- a/src/cli/mcp-server.ts
+++ b/src/cli/mcp-server.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { errorDetail } from './shared/utils/error-detail.js';
 import { findProjectRoot } from './services/project-root.js';
+import { readMofloEnv } from './services/env-compat.js';
 
 // ESM-compatible __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -259,7 +260,7 @@ export class MCPServerManager extends EventEmitter {
       // No PID file found. Detect if we are running in stdio mode
       // (e.g., launched by Claude Code via `claude mcp add`).
       const isStdio = !process.stdin.isTTY;
-      const envTransport = process.env.CLAUDE_FLOW_MCP_TRANSPORT;
+      const envTransport = readMofloEnv('MCP_TRANSPORT');
       if (isStdio || envTransport === 'stdio' || this.options.transport === 'stdio') {
         return {
           running: true,

--- a/src/cli/runtime/headless.ts
+++ b/src/cli/runtime/headless.ts
@@ -9,7 +9,7 @@
  *   npx moflo headless --benchmark
  *
  * Environment:
- *   CLAUDE_FLOW_HEADLESS=true
+ *   MOFLO_HEADLESS=true
  *   CLAUDE_CODE_HEADLESS=true
  *
  * @module v3/cli/runtime/headless
@@ -29,6 +29,7 @@ import {
   batchCosineSim,
   flashAttentionSearch
 } from '../memory/memory-initializer.js';
+import { readMofloEnv } from '../services/env-compat.js';
 
 // ============================================================================
 // Types
@@ -120,7 +121,7 @@ Options:
   -h, --help            Show help
 
 Environment:
-  CLAUDE_FLOW_HEADLESS=true   Enable headless mode
+  MOFLO_HEADLESS=true         Enable headless mode
   CLAUDE_CODE_HEADLESS=true   Enable Claude Code headless
 
 Examples:
@@ -297,7 +298,7 @@ async function showStatus(): Promise<void> {
   console.log(`  Entries: ${hnsw.entryCount}`);
 
   console.log('\nEnvironment:');
-  console.log(`  CLAUDE_FLOW_HEADLESS: ${process.env.CLAUDE_FLOW_HEADLESS || 'not set'}`);
+  console.log(`  MOFLO_HEADLESS: ${readMofloEnv('HEADLESS') || 'not set'}`);
   console.log(`  CLAUDE_CODE_HEADLESS: ${process.env.CLAUDE_CODE_HEADLESS || 'not set'}`);
   console.log(`  NODE_ENV: ${process.env.NODE_ENV || 'development'}`);
 }
@@ -307,7 +308,7 @@ async function showStatus(): Promise<void> {
  */
 async function main(): Promise<void> {
   // Set headless environment
-  process.env.CLAUDE_FLOW_HEADLESS = 'true';
+  process.env.MOFLO_HEADLESS = 'true';
 
   const config = parseArgs();
 

--- a/src/cli/services/daemon-readiness.ts
+++ b/src/cli/services/daemon-readiness.ts
@@ -122,7 +122,7 @@ async function defaultStartDaemon(projectRoot: string): Promise<boolean> {
     const spawnArgs = [cliPath, 'daemon', 'start', '--foreground', '--quiet'];
     const daemonEnv = {
       ...process.env,
-      CLAUDE_FLOW_DAEMON: '1',
+      MOFLO_DAEMON: '1',
       ...(process.platform === 'darwin' ? { NOHUP: '1' } : {}),
     };
 

--- a/src/cli/services/daemon-service.ts
+++ b/src/cli/services/daemon-service.ts
@@ -213,7 +213,7 @@ function generateSystemdUnit(projectRoot: string, nodePath: string, cliPath: str
     `WorkingDirectory=${projectRoot}`,
     'Restart=on-failure',
     'RestartSec=10',
-    `Environment=CLAUDE_FLOW_DAEMON=1`,
+    `Environment=MOFLO_DAEMON=1`,
     '',
     '[Install]',
     'WantedBy=default.target',

--- a/src/cli/services/env-compat.ts
+++ b/src/cli/services/env-compat.ts
@@ -1,0 +1,30 @@
+/**
+ * Backward-compatible environment-variable reader for the claude-flow → moflo
+ * rebrand (issue #1209).
+ *
+ * Reads the canonical `MOFLO_<suffix>` variable first, falling back to the
+ * pre-rebrand `CLAUDE_FLOW_<suffix>` name. Every writer across the codebase
+ * emits ONLY `MOFLO_*`; this fallback exists so consumers whose shell env or
+ * already-persisted files (e.g. an installed systemd unit written by an older
+ * moflo) still set the old names keep working without a manual migration.
+ *
+ * Deprecation window: keep the `CLAUDE_FLOW_*` fallback for at least one
+ * release cycle after the rebrand ships, then drop both this fallback and the
+ * writer-side exemption in `published-package-drift-guard.test.ts`.
+ *
+ * Zero imports on purpose — safe to import from any layer (including
+ * `shared/core/config`) without risking a cycle.
+ */
+
+const MOFLO_PREFIX = 'MOFLO_';
+const LEGACY_PREFIX = 'CLAUDE_FLOW_';
+
+/**
+ * Read an env var by its `MOFLO_<suffix>` name, falling back to the legacy
+ * `CLAUDE_FLOW_<suffix>` name. Returns `undefined` when neither is set.
+ *
+ * @param suffix the shared variable suffix, e.g. `'MAX_AGENTS'`, `'DAEMON'`.
+ */
+export function readMofloEnv(suffix: string): string | undefined {
+  return process.env[MOFLO_PREFIX + suffix] ?? process.env[LEGACY_PREFIX + suffix];
+}

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -338,12 +338,11 @@ export function computeHookBlockDrift(
  * `claudeFlow.hooks.locked: true` (legacy alias) in their settings.json —
  * a sentinel that suppresses drift surfacing entirely.
  *
- * The `claudeFlow.*` settings tree is a pre-rebrand legacy name that survives
- * in writers + readers across the codebase. Renaming the whole tree is a
- * separate effort; this one reader accepts `moflo.hooks.locked` ahead of the
- * legacy key so the #1180 escape hatch is documented under the canonical
- * brand from day one and consumers never have to migrate the key after we
- * tell them to set it.
+ * The `claudeFlow.*` settings tree was migrated to `moflo.*` in #1209: every
+ * writer now emits `moflo.*` and the upgrade merge folds an existing
+ * `claudeFlow.*` tree into `moflo.*`. This reader keeps the `claudeFlow.hooks.locked`
+ * fallback for one deprecation cycle so a consumer who set the escape hatch but
+ * hasn't re-run init yet stays covered.
  */
 export function isHookBlockLocked(settings: unknown): boolean {
   const root = settings as Record<string, unknown> | null | undefined;

--- a/src/cli/shared/core/config/loader.ts
+++ b/src/cli/shared/core/config/loader.ts
@@ -10,6 +10,7 @@ import os from 'os';
 import type { SystemConfig } from './schema.js';
 import { validateSystemConfig, type ValidationResult } from './validator.js';
 import { defaultSystemConfig, mergeWithDefaults } from './defaults.js';
+import { readMofloEnv } from '../../../services/env-compat.js';
 
 /**
  * Configuration source type
@@ -70,32 +71,40 @@ async function loadJsonConfig(path: string): Promise<unknown> {
 function loadEnvConfig(): Partial<SystemConfig> {
   const config: Partial<SystemConfig> = {};
 
+  // Env reads go through readMofloEnv (MOFLO_* preferred, CLAUDE_FLOW_* legacy
+  // fallback — see env-compat.ts / #1209).
+  const envMaxAgents = readMofloEnv('MAX_AGENTS');
+  const envDataDir = readMofloEnv('DATA_DIR');
+  const envMemoryType = readMofloEnv('MEMORY_TYPE');
+  const envMcpTransport = readMofloEnv('MCP_TRANSPORT');
+  const envSwarmTopology = readMofloEnv('SWARM_TOPOLOGY');
+
   // Orchestrator settings
-  if (process.env.CLAUDE_FLOW_MAX_AGENTS) {
+  if (envMaxAgents) {
     config.orchestrator = {
       ...defaultSystemConfig.orchestrator,
       lifecycle: {
         ...defaultSystemConfig.orchestrator.lifecycle,
-        maxConcurrentAgents: parseInt(process.env.CLAUDE_FLOW_MAX_AGENTS, 10),
+        maxConcurrentAgents: parseInt(envMaxAgents, 10),
       },
     };
   }
 
   // Data directory
-  if (process.env.CLAUDE_FLOW_DATA_DIR) {
+  if (envDataDir) {
     config.orchestrator = {
       ...config.orchestrator,
       ...defaultSystemConfig.orchestrator,
       session: {
         ...defaultSystemConfig.orchestrator.session,
-        dataDir: process.env.CLAUDE_FLOW_DATA_DIR,
+        dataDir: envDataDir,
       },
     };
   }
 
   // Memory type
-  if (process.env.CLAUDE_FLOW_MEMORY_TYPE) {
-    const memoryType = process.env.CLAUDE_FLOW_MEMORY_TYPE as NonNullable<SystemConfig['memory']>['type'];
+  if (envMemoryType) {
+    const memoryType = envMemoryType as NonNullable<SystemConfig['memory']>['type'];
     if (['sqlite', 'agentdb', 'hybrid', 'redis', 'memory'].includes(memoryType)) {
       config.memory = {
         ...(defaultSystemConfig.memory ?? { type: 'hybrid' }),
@@ -106,8 +115,8 @@ function loadEnvConfig(): Partial<SystemConfig> {
 
   // MCP transport (only 'stdio' is supported; env var kept for forward-compat but narrowed)
   const defaultMcp = defaultSystemConfig.mcp ?? { name: 'moflo', version: '3.0.0', transport: { type: 'stdio' as const } };
-  if (process.env.CLAUDE_FLOW_MCP_TRANSPORT) {
-    const transport = process.env.CLAUDE_FLOW_MCP_TRANSPORT;
+  if (envMcpTransport) {
+    const transport = envMcpTransport;
     if (transport === 'stdio') {
       config.mcp = {
         ...defaultMcp,
@@ -119,12 +128,12 @@ function loadEnvConfig(): Partial<SystemConfig> {
     }
   }
 
-  // CLAUDE_FLOW_MCP_PORT removed — stdio transport does not use a port.
+  // MOFLO_MCP_PORT / CLAUDE_FLOW_MCP_PORT removed — stdio transport does not use a port.
 
   // Swarm topology
   const defaultSwarm = defaultSystemConfig.swarm ?? { topology: 'hierarchical-mesh' as const, maxAgents: 20 };
-  if (process.env.CLAUDE_FLOW_SWARM_TOPOLOGY) {
-    const topology = process.env.CLAUDE_FLOW_SWARM_TOPOLOGY as NonNullable<SystemConfig['swarm']>['topology'];
+  if (envSwarmTopology) {
+    const topology = envSwarmTopology as NonNullable<SystemConfig['swarm']>['topology'];
     if (['hierarchical', 'mesh', 'ring', 'star', 'adaptive', 'hierarchical-mesh'].includes(topology)) {
       config.swarm = {
         ...defaultSwarm,

--- a/src/cli/update/rate-limiter.ts
+++ b/src/cli/update/rate-limiter.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { readMofloEnv } from '../services/env-compat.js';
 
 export interface RateLimitState {
   lastCheck: string;
@@ -69,12 +70,12 @@ export function shouldCheckForUpdates(
   }
 
   // Skip if explicitly disabled
-  if (process.env.CLAUDE_FLOW_AUTO_UPDATE === 'false') {
+  if (readMofloEnv('AUTO_UPDATE') === 'false') {
     return { allowed: false, reason: 'Auto-update disabled via environment' };
   }
 
   // Force update if requested
-  if (process.env.CLAUDE_FLOW_FORCE_UPDATE === 'true') {
+  if (readMofloEnv('FORCE_UPDATE') === 'true') {
     return { allowed: true };
   }
 

--- a/src/helpers/docs/installation.md
+++ b/src/helpers/docs/installation.md
@@ -176,14 +176,14 @@ Add to your `.claude/settings.json`:
 ### Environment Variables (Optional)
 ```bash
 # Linux/macOS
-export CLAUDE_FLOW_V3_MODE=enabled
-export CLAUDE_FLOW_HELPERS_DIR=.claude/helpers
-export CLAUDE_FLOW_PLATFORM=auto
+export MOFLO_V3_MODE=enabled
+export MOFLO_HELPERS_DIR=.claude/helpers
+export MOFLO_PLATFORM=auto
 
 # Windows (PowerShell)
-$env:CLAUDE_FLOW_V3_MODE = "enabled"
-$env:CLAUDE_FLOW_HELPERS_DIR = ".claude\helpers"
-$env:CLAUDE_FLOW_PLATFORM = "auto"
+$env:MOFLO_V3_MODE = "enabled"
+$env:MOFLO_HELPERS_DIR = ".claude\helpers"
+$env:MOFLO_PLATFORM = "auto"
 ```
 
 ## 🔧 Post-Installation Verification


### PR DESCRIPTION
## Summary
- Migrates the last load-bearing pre-rebrand surface — the `CLAUDE_FLOW_*` environment variables and the `settings.claudeFlow.*` tree — to `MOFLO_*` / `settings.moflo.*`, **alias-preserving** so existing consumers keep working.
- Writers now emit only the new names; every read goes through one `readMofloEnv()` helper that falls back to the legacy name for one deprecation cycle.

## Changes
- **New helper** `src/cli/services/env-compat.ts` — `readMofloEnv(suffix)` = `process.env['MOFLO_'+suffix] ?? process.env['CLAUDE_FLOW_'+suffix]` (zero imports → safe from `shared/core`). All reads routed through it: `loader`, `daemon`, `mcp`, `mcp-server`, `headless`, `rate-limiter`, `executor` DEBUG.
- **Writers → `MOFLO_*`**: daemon spawn env (`index.ts`, `daemon.ts`, `daemon-readiness.ts`) + **persisted systemd unit** (`daemon-service.ts`; `daemon.ts` reader dual-reads so old units still match), consumer `settings.json` env (`settings-generator`, `executor`), consumer `.mcp.json` env (`mcp-generator`), force-update flag (`update.ts`), headless self-marker (`headless.ts`).
- **`settings.claudeFlow.*` → `settings.moflo.*`**: `settings-generator` writes `moflo`; the upgrade-merge in `executor.ts` folds an existing `claudeFlow` tree into `moflo` and deletes the legacy tree (the `hooks.locked` escape hatch survives via the spread); `hook-block-hash.isHookBlockLocked` keeps the `claudeFlow.hooks.locked` fallback.
- **Internal key** `InitOptions.mcp.claudeFlow` → `moflo` (no alias — not consumer-persisted).
- **Guard + tests**: write-only invariant added to `published-package-drift-guard.test.ts` (no production writer may emit `CLAUDE_FLOW_*`/`claudeFlow.*`); new `env-compat-dual-read.test.ts` proves `MOFLO_*` preference **and** legacy fallback for the helper, rate-limiter, and settings reader.
- **Docs**: `moflo-yaml-reference.md`, `installation.md`, and the repo's own `.claude/settings.json` updated to the `MOFLO_*` end-state.

### Deliberately out of scope (distinct concepts)
`checker.ts` `CLAUDE_FLOW_PACKAGES` (upstream npm pkg names), `moflo-paths` `LEGACY_CLAUDE_FLOW_DIR` (`.claude-flow` dir), `init.ts` local `claudeFlow` var ("`.moflo/config.yaml` exists"), plugin-store `claudeFlowVersions` (compat schema).

## Consumer blast radius: HIGH (alias-preserving)
A consumer on the current version with `CLAUDE_FLOW_*` shell env, `claudeFlow.*` in `settings.json`, or an installed systemd unit keeps working unchanged; their settings auto-migrate on the next `flo init`/upgrade.

## Test plan
- [x] `npm run build` clean (tsc)
- [x] Full suite green — 9184 passed, 0 failed
- [x] New write-only drift-guard invariant passes
- [x] Dual-read regression test (MOFLO_* preferred + CLAUDE_FLOW_* fallback) passes
- [x] `/flo-simplify` (SMALL, single reviewer) — migration confirmed correct
- [ ] release-smoke (CI)

Closes #1209

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)