### PR TITLE
fix(v3-progress): compute DDD/module metrics for the flat post-collapse layout

### DIFF
--- a/src/cli/shared/services/v3-progress.service.ts
+++ b/src/cli/shared/services/v3-progress.service.ts
@@ -73,10 +73,10 @@ export interface ProgressChangeEvent {
 // Constants
 // ============================================================================
 
-// Utility/service packages follow DDD differently - their services ARE the application layer
-const UTILITY_PACKAGES = new Set([
-  'cli', 'hooks', 'mcp', 'shared', 'testing', 'agents', 'integration',
-  'embeddings', 'deployment', 'performance', 'plugins', 'providers'
+// Directories under src/cli that are NOT source modules — tests, generated/non-TS
+// assets, build tooling, and type-only declarations — excluded from module/DDD counts.
+const NON_MODULE_DIRS = new Set([
+  '__tests__', 'node_modules', 'agents', 'data', 'types', 'scripts',
 ]);
 
 // Target metrics for 100% completion
@@ -370,42 +370,59 @@ export class V3ProgressService extends EventEmitter {
     packages: { total: number; withDDD: number; target: number; list: string[] };
     ddd: { explicit: number; utility: number };
   }> {
-    const packagesPath = this.cliPath;
+    // Post-collapse (#586) the codebase is one package whose modules are flat
+    // directories under src/cli — there is no nested `<pkg>/src/domain` layer to
+    // probe. "DDD structure" here = whether a source module exposes a clean public
+    // API boundary (an `index.ts` barrel): modules that further decompose into
+    // sub-domains (nested dirs) are `explicit`; cohesive single-layer modules whose
+    // service IS the application layer are `utility`. Source dirs with no barrel are
+    // counted in `total` but not `withDDD`, so the ratio is real boundary adoption.
+    const modulesRoot = this.cliPath;
     const list: string[] = [];
     let explicit = 0;
     let utility = 0;
 
     try {
-      const dirs = await fs.readdir(packagesPath, { withFileTypes: true });
+      const dirs = await fs.readdir(modulesRoot, { withFileTypes: true });
 
       for (const dir of dirs) {
-        // Skip hidden directories
-        if (!dir.isDirectory() || dir.name.startsWith('.')) continue;
+        if (!dir.isDirectory() || dir.name.startsWith('.') || NON_MODULE_DIRS.has(dir.name)) {
+          continue;
+        }
 
+        let entries;
+        try {
+          entries = await fs.readdir(join(modulesRoot, dir.name), { withFileTypes: true });
+        } catch {
+          continue;
+        }
+
+        // Only count real source modules (skip asset-only / empty dirs).
+        const hasSource = entries.some(
+          e => e.isFile() && /\.m?ts$/.test(e.name) && !e.name.endsWith('.d.ts')
+        );
+        if (!hasSource) continue;
         list.push(dir.name);
 
-        // Check for DDD structure
-        try {
-          const srcPath = join(packagesPath, dir.name, 'src');
-          const srcDirs = await fs.readdir(srcPath, { withFileTypes: true });
-          const hasDomain = srcDirs.some(d => d.isDirectory() && d.name === 'domain');
-          const hasApp = srcDirs.some(d => d.isDirectory() && d.name === 'application');
+        // A public API barrel is the post-collapse "has DDD structure" signal.
+        if (!entries.some(e => e.isFile() && e.name === 'index.ts')) continue;
 
-          if (hasDomain || hasApp) {
-            explicit++;
-          } else if (UTILITY_PACKAGES.has(dir.name)) {
-            utility++;
-          }
-        } catch {
-          // Check if it's a utility package without src
-          if (UTILITY_PACKAGES.has(dir.name)) {
-            utility++;
-          }
-        }
+        // Decomposed into internal sub-domains (nested dirs) = explicit DDD;
+        // otherwise a cohesive single-layer module = utility.
+        const hasSubDomains = entries.some(
+          e => e.isDirectory() && !e.name.startsWith('.') &&
+            e.name !== '__tests__' && e.name !== 'node_modules'
+        );
+        if (hasSubDomains) explicit++;
+        else utility++;
       }
     } catch {
       // Return defaults
     }
+
+    // Sort for deterministic output across platforms — fs.readdir order is
+    // filesystem-dependent (NTFS sorts, ext4 does not, APFS varies).
+    list.sort();
 
     return {
       packages: {


### PR DESCRIPTION
Follow-up to the limitation flagged in #1214: the `V3ProgressService` DDD metric was broken for the post-#586 flat `src/cli` layout. Now fixed.

## Problem

`countPackages` probed each subdir for `<pkg>/src/domain` or `<pkg>/src/application` — the **pre-#586 multi-workspace shape**. Post-collapse, `src/cli` modules are flat dirs with no nested `src/domain`, so the check always found 0 → `explicit: 0`, DDD progress `0%`, and `total`/`codebase` fell back to hardcoded constants. (Vestigial since #1214 repointed the scan from the dead `v3/@claude-flow/` tree to `src/cli`.)

## Fix

Redefine "DDD structure" for the flat layout:
- **module** = a `src/cli` subdir with `.ts` source (excluding tests/assets/build via `NON_MODULE_DIRS`)
- **withDDD** = modules exposing a clean public-API barrel (`index.ts`) — the post-collapse equivalent of a bounded domain
- **explicit** = barreled **and** decomposed into sub-domains (nested dirs); **utility** = barreled but flat (the service *is* the application layer)
- barrel-less source dirs count toward `total` but not `withDDD`, so the ratio is **real boundary adoption**, not a trivial 100%

Removed the stale `UTILITY_PACKAGES` constant (old workspace names).

## Result (this repo)

| | before | after |
|---|---|---|
| `dddProgress` | 0% | **81%** (17 barreled ÷ 21 source modules) |
| `ddd.explicit` / `utility` | 0 / stale | **9** / **8** |
| `codebase` | 0 / 0 (fallback) | **920 files / 335,617 lines** |
| `overall` | fallback-inflated | **97%** |

The 4 barrel-less source dirs (`config`, `infrastructure`, `plugins`, `runtime`) are the real adoption gap. `persist()` feeds the statusline unchanged (`domains.completed = withDDD`, `domains.total = total`).

## Rule #1 (cross-platform)

Pure `path.join` + `fs.readdir({withFileTypes})`; exact lowercase `index.ts`/dir-name matching (correct — catches a miscased barrel that'd break on Linux). Added `list.sort()` so output is deterministic across NTFS (sorted) / ext4 (unsorted) / APFS (varies). Per-dir `try/catch` degrades gracefully on an unreadable subdir.

## Verification

- ✅ `tsc` clean; full two-pass suite **9074 passed, 0 failed** (run on the final code)
- ✅ Metric validated end-to-end against the repo (numbers above)
- ✅ `/flo-simplify` SMALL reviewer: clean (one consistency nit — `node_modules` exclusion in the sub-domain check — applied)
- ✅ No test asserts the old values; statusline `persist()` shape unchanged

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)