### PR TITLE
fix(doctor): tolerate hive-mind_memory write-through propagation race (#1206)

### DIFF
--- a/src/cli/__tests__/doctor-checks-swarm.test.ts
+++ b/src/cli/__tests__/doctor-checks-swarm.test.ts
@@ -12,8 +12,10 @@ import { describe, expect, it } from 'vitest';
 import {
   checkSwarmFunctional,
   checkHiveMindFunctional,
+  _probeHiveMemoryGetForTest,
   type FunctionalHealthCheck,
 } from '../commands/doctor-checks-swarm.js';
+import type { FunctionalCheckDetail, ToolHandler } from '../commands/doctor-checks-functional-shared.js';
 
 function expectFunctionalShape(result: FunctionalHealthCheck) {
   expect(result.name).toBeTruthy();
@@ -108,6 +110,136 @@ describe('doctor-checks-swarm', () => {
       // No subcheck should have failed.
       const failures = details.filter(d => d.status === 'fail');
       expect(failures, `subcheck failures: ${JSON.stringify(failures, null, 2)}`).toHaveLength(0);
+    });
+  });
+
+  // #1206: the hive-mind_memory set→get subcheck flaked on a stressed CI
+  // runner — an immediate get returning exists=false right after a successful
+  // set was reported as a hard write-through failure when it was actually async
+  // propagation lag. The fix mirrors the #1111/#1120 pattern on Memory Access:
+  // bounded-retry the get; demote to warn when the value lands late; keep a
+  // hard fail when it never lands (protected-surface guarantee, epic #798).
+  //
+  // Driven through the `_probeHiveMemoryGetForTest` seam with a synthetic
+  // hive-mind_memory tool and an injected no-op sleep so the classification is
+  // exercised without real backoff delays — same approach as the
+  // buildEmptyHnswTools / buildStaleNeighborTools harnesses in
+  // doctor-checks-memory-access.test.ts.
+  describe('checkHiveMindFunctional — #1206 write-through propagation race', () => {
+    // A hive-mind_memory whose `get` reports exists=false for the first
+    // `missesBeforeHit` reads, then returns the stored sentinel — models the
+    // write-through propagation lag the issue describes. `everLands:false`
+    // never returns the value (a genuine write-through break).
+    function buildLaggyHiveMemory(opts: {
+      missesBeforeHit: number;
+      sentinel: string;
+      everLands?: boolean;
+    }): ToolHandler[] {
+      let getCalls = 0;
+      return [
+        {
+          name: 'hive-mind_memory',
+          handler: async (input) => {
+            if (input.action === 'get') {
+              getCalls++;
+              const landed = (opts.everLands ?? true) && getCalls > opts.missesBeforeHit;
+              return landed
+                ? { exists: true, value: { sentinel: opts.sentinel } }
+                : { exists: false, value: null };
+            }
+            return { success: true };
+          },
+        },
+      ];
+    }
+
+    const noSleep = async () => { /* skip real backoff in tests */ };
+
+    it('passes when the first get already sees the value (happy path, no added latency)', async () => {
+      const details: FunctionalCheckDetail[] = [];
+      await _probeHiveMemoryGetForTest(
+        buildLaggyHiveMemory({ missesBeforeHit: 0, sentinel: 's1' }),
+        'k', 's1', details, { sleep: noSleep },
+      );
+      const d = details.find(x => x.id === 'hive-mind_memory.get');
+      expect(d, 'hive-mind_memory.get subcheck must be recorded').toBeDefined();
+      expect(d!.status, `expected pass, got ${d!.status}: ${d!.message}`).toBe('pass');
+      expect((d!.observed as { attempts?: number }).attempts).toBe(1);
+      expect(details.filter(x => x.status === 'fail')).toHaveLength(0);
+    });
+
+    it('demotes to warn when get is exists=false at first but lands on a bounded retry', async () => {
+      const details: FunctionalCheckDetail[] = [];
+      await _probeHiveMemoryGetForTest(
+        buildLaggyHiveMemory({ missesBeforeHit: 2, sentinel: 's2' }),
+        'k', 's2', details, { sleep: noSleep },
+      );
+      const d = details.find(x => x.id === 'hive-mind_memory.get');
+      expect(d, 'hive-mind_memory.get subcheck must be recorded').toBeDefined();
+      expect(d!.status, `expected warn, got ${d!.status}: ${d!.message}`).toBe('warn');
+      expect(d!.message).toMatch(/write-through propagation race/i);
+      // The whole point of the fix: a propagation lag is never a fail.
+      expect(details.filter(x => x.status === 'fail')).toHaveLength(0);
+    });
+
+    it('keeps a hard fail when the value never lands within the retry budget', async () => {
+      const details: FunctionalCheckDetail[] = [];
+      await _probeHiveMemoryGetForTest(
+        buildLaggyHiveMemory({ missesBeforeHit: 99, sentinel: 's3', everLands: false }),
+        'k', 's3', details, { sleep: noSleep },
+      );
+      const d = details.find(x => x.id === 'hive-mind_memory.get');
+      expect(d, 'hive-mind_memory.get subcheck must be recorded').toBeDefined();
+      expect(d!.status, `expected fail, got ${d!.status}`).toBe('fail');
+      expect(d!.message).toMatch(/write-through to Memory DB is broken/i);
+      // Exhausted the full budget: 1 immediate read + 3 bounded retries.
+      expect((d!.observed as { attempts?: number }).attempts).toBe(4);
+    });
+
+    it('keeps a hard fail when every get throws (transient error never clears)', async () => {
+      const details: FunctionalCheckDetail[] = [];
+      const tools: ToolHandler[] = [{
+        name: 'hive-mind_memory',
+        handler: async (input) => {
+          if (input.action === 'get') throw new Error('memory backend offline');
+          return { success: true };
+        },
+      }];
+      await _probeHiveMemoryGetForTest(tools, 'k', 's', details, { sleep: noSleep });
+      const d = details.find(x => x.id === 'hive-mind_memory.get');
+      expect(d, 'hive-mind_memory.get subcheck must be recorded').toBeDefined();
+      expect(d!.status, `expected fail, got ${d!.status}`).toBe('fail');
+      expect(d!.message).toMatch(/threw on every attempt/i);
+      // Same budget as the never-lands case: 1 immediate + 3 bounded retries.
+      expect((d!.observed as { attempts?: number; threw?: boolean }).attempts).toBe(4);
+      expect((d!.observed as { threw?: boolean }).threw).toBe(true);
+    });
+
+    it('fails immediately on a value mismatch — a clobber is a real bug, not a race', async () => {
+      const details: FunctionalCheckDetail[] = [];
+      const tools: ToolHandler[] = [{
+        name: 'hive-mind_memory',
+        handler: async (input) =>
+          input.action === 'get'
+            ? { exists: true, value: { sentinel: 'WRONG' } }
+            : { success: true },
+      }];
+      await _probeHiveMemoryGetForTest(tools, 'k', 'EXPECTED', details, { sleep: noSleep });
+      const d = details.find(x => x.id === 'hive-mind_memory.get');
+      expect(d, 'hive-mind_memory.get subcheck must be recorded').toBeDefined();
+      expect(d!.status).toBe('fail');
+      expect(d!.message).toMatch(/value mismatch/i);
+      // No retries burned on a clobber — failed on the first read.
+      expect((d!.observed as { attempts?: number }).attempts).toBe(1);
+    });
+
+    it('fails when the hive-mind_memory tool is not registered', async () => {
+      const details: FunctionalCheckDetail[] = [];
+      await _probeHiveMemoryGetForTest([], 'k', 's', details, { sleep: noSleep });
+      const d = details.find(x => x.id === 'hive-mind_memory.get');
+      expect(d, 'hive-mind_memory.get subcheck must be recorded').toBeDefined();
+      expect(d!.status).toBe('fail');
+      expect(d!.message).toMatch(/not registered/i);
     });
   });
 

--- a/src/cli/commands/doctor-checks-swarm.ts
+++ b/src/cli/commands/doctor-checks-swarm.ts
@@ -12,6 +12,7 @@
  * the dev tree and in `node_modules/moflo/...` consumer installs.
  */
 
+import { errorDetail } from '../shared/utils/error-detail.js';
 import {
   type FunctionalCheckDetail,
   type FunctionalHealthCheck,
@@ -213,6 +214,151 @@ export async function checkSwarmFunctional(): Promise<FunctionalHealthCheck> {
 }
 
 // ============================================================================
+// Hive-Mind write-through propagation race (#1206)
+// ============================================================================
+
+/**
+ * Standard bounded backoff (ms) for the `hive-mind_memory` set→get
+ * write-through propagation retry. Same budget as the project-wide transient
+ * retry pattern (see `feedback_transient_retry_circuit_breaker.md`).
+ */
+const HIVE_MEMORY_GET_RETRY_DELAYS_MS = [50, 200, 800];
+
+const backoffSleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+interface HiveMemoryGetOut {
+  exists?: boolean;
+  value?: { sentinel?: string };
+}
+
+const HIVE_MEMORY_GET_META = {
+  id: 'hive-mind_memory.get',
+  mcpTool: 'hive-mind_memory',
+  expected: 'memory get returns previously-set value (proves shared store, not in-memory only)',
+};
+
+/**
+ * #1206: probe `hive-mind_memory` get after a successful set, tolerating async
+ * write-through propagation lag. Mirrors the #1111/#1120 fix on the
+ * `Memory Access Functional` check: an immediate `exists=false` right after a
+ * successful set is most often a propagation race (slow disk / fork contention
+ * / 429-throttled cold start on a stressed CI runner), not a genuine
+ * write-through break.
+ *
+ * Classification:
+ *   - `exists=true` + matching sentinel on the first read → **pass**.
+ *   - `exists=false` (or a transient throw) → **retry** with bounded backoff
+ *     (50/200/800ms). A late landing → **warn** (write-through works, just
+ *     lagged). Budget exhausted with no landing → **fail** (a real
+ *     write-through break is a protected-surface regression and MUST stay a
+ *     hard fail — ⛔ swarm/hive-mind rule; never hide a real disconnect).
+ *   - `exists=true` + wrong sentinel → **fail** immediately, no retries: a
+ *     value clobber is a real bug, not a propagation race.
+ *
+ * `opts` injects the backoff schedule + sleep so the regression test exercises
+ * the classification without real delays.
+ */
+async function probeHiveMemoryGet(
+  hiveMindTools: ToolHandler[],
+  probeKey: string,
+  sentinel: string,
+  details: FunctionalCheckDetail[],
+  opts?: { delaysMs?: number[]; sleep?: (ms: number) => Promise<void> },
+): Promise<void> {
+  const tool = getTool(hiveMindTools, 'hive-mind_memory');
+  if (!tool?.handler) {
+    details.push({
+      ...HIVE_MEMORY_GET_META, status: 'fail',
+      observed: { reason: 'tool-not-registered' },
+      message: 'MCP tool "hive-mind_memory" not registered in the loaded tool array',
+    });
+    return;
+  }
+  const handler = tool.handler;
+  const delays = opts?.delaysMs ?? HIVE_MEMORY_GET_RETRY_DELAYS_MS;
+  const sleep = opts?.sleep ?? backoffSleep;
+
+  type GetResult =
+    | { kind: 'landed' }
+    | { kind: 'mismatch'; message: string }
+    | { kind: 'missing' }
+    | { kind: 'threw'; message: string };
+
+  const getOnce = async (): Promise<GetResult> => {
+    try {
+      const raw = (await handler({ action: 'get', key: probeKey })) as HiveMemoryGetOut;
+      if (!raw?.exists) return { kind: 'missing' };
+      if (raw.value?.sentinel !== sentinel) {
+        return { kind: 'mismatch', message: `value mismatch: expected sentinel="${sentinel}", got ${JSON.stringify(raw.value)}` };
+      }
+      return { kind: 'landed' };
+    } catch (err) {
+      return { kind: 'threw', message: errorDetail(err, { firstLineOnly: true }) };
+    }
+  };
+
+  let attempts = 1;
+  let result = await getOnce();
+  if (result.kind === 'landed') {
+    details.push({ ...HIVE_MEMORY_GET_META, status: 'pass', observed: { exists: true, attempts } });
+    return;
+  }
+  if (result.kind === 'mismatch') {
+    details.push({ ...HIVE_MEMORY_GET_META, status: 'fail', observed: { exists: true, attempts }, message: result.message });
+    return;
+  }
+
+  // exists=false (or a transient throw) — retry with bounded backoff to absorb
+  // async write-through propagation lag.
+  for (const delay of delays) {
+    await sleep(delay);
+    result = await getOnce();
+    attempts++;
+    if (result.kind === 'landed') {
+      const retries = attempts - 1;
+      details.push({
+        ...HIVE_MEMORY_GET_META, status: 'warn',
+        observed: { exists: true, attempts, retriedAfterMs: delays.slice(0, retries) },
+        message: `hive-mind write-through propagation race — get returned exists=false immediately after a successful set, but the value landed after ${retries} bounded retr${retries === 1 ? 'y' : 'ies'} (write-through works, propagation just lagged; expected under slow disk / fork contention / throttled cold start on a stressed runner)`,
+      });
+      return;
+    }
+    if (result.kind === 'mismatch') {
+      details.push({ ...HIVE_MEMORY_GET_META, status: 'fail', observed: { exists: true, attempts }, message: result.message });
+      return;
+    }
+  }
+
+  // Budget exhausted and the value never landed — a genuine write-through break
+  // is a protected-surface regression and must stay a hard fail. The threw case
+  // never observed an `exists` value, so don't report a misleading exists=false.
+  const message = result.kind === 'threw'
+    ? `get threw on every attempt over ${attempts} tries (last: ${result.message})`
+    : `get returned exists=false after a successful set and ${attempts} bounded attempts — write-through to Memory DB is broken`;
+  const observed = result.kind === 'threw'
+    ? { threw: true, attempts }
+    : { exists: false, attempts };
+  details.push({ ...HIVE_MEMORY_GET_META, status: 'fail', observed, message });
+}
+
+/**
+ * #1206 regression-test seam. Drives {@link probeHiveMemoryGet} with a
+ * synthetic `hiveMindTools` array and an injectable sleep so the test
+ * exercises the bounded-retry → warn/fail/pass classification without real
+ * backoff delays. Not part of the public doctor surface — real callers use
+ * {@link checkHiveMindFunctional}.
+ */
+export async function _probeHiveMemoryGetForTest(
+  hiveMindTools: ToolHandler[],
+  probeKey: string,
+  sentinel: string,
+  details: FunctionalCheckDetail[],
+  opts?: { delaysMs?: number[]; sleep?: (ms: number) => Promise<void> },
+): Promise<void> {
+  return probeHiveMemoryGet(hiveMindTools, probeKey, sentinel, details, opts);
+}
+
+// ============================================================================
 // Hive-Mind Functional Check
 // ============================================================================
 
@@ -348,17 +494,13 @@ export async function checkHiveMindFunctional(): Promise<FunctionalHealthCheck> 
   });
 
   if ((setOut as { success?: boolean } | undefined)?.success === true) {
-    await safeInvoke(hiveMindTools, 'hive-mind_memory', { action: 'get', key: probeKey }, details, {
-      id: 'hive-mind_memory.get',
-      mcpTool: 'hive-mind_memory',
-      expected: 'memory get returns previously-set value (proves shared store, not in-memory only)',
-      assert: (raw) => {
-        const out = raw as { exists?: boolean; value?: { sentinel?: string } };
-        if (!out?.exists) return 'get returned exists=false after a successful set — write-through to Memory DB is broken';
-        if (out.value?.sentinel !== sentinel) return `value mismatch: expected sentinel="${sentinel}", got ${JSON.stringify(out.value)}`;
-        return null;
-      },
-    });
+    // #1206: a get returning exists=false immediately after a successful set is
+    // most often async write-through propagation lag, not a genuine
+    // write-through break (mirrors the #1111/#1120 fix on Memory Access).
+    // Retry with bounded backoff: a late landing demotes to warn; never
+    // landing stays a hard fail (⛔ a real write-through break is a
+    // protected-surface regression and must not be hidden).
+    await probeHiveMemoryGet(hiveMindTools, probeKey, sentinel, details);
   }
 
   // 7. Cleanup — graceful shutdown (best-effort; failures here aren't a regression signal).


### PR DESCRIPTION
## Summary

The `Hive-Mind Functional` doctor subcheck flaked on the `hive-mind_memory` set→get write-through round-trip under CI load — the same async-populated-state assertion bug class as #1111 / #1120 (which hardened the analogous `Memory Access Functional` subcheck).

**Root cause.** `checkHiveMindFunctional` (subcheck #6) wrote a sentinel via `hive-mind_memory` `set`, then **immediately** read it back via `get` and asserted `exists === true` with no tolerance for async write-through propagation. On a stressed runner (slow disk, fork contention, `registry HTTP 429`, onnxruntime still initializing during cold start) the write-through had not propagated by read time → `get` returned `exists=false` → hard **fail**, reporting a healthy write-through as broken.

## Changes

- `src/cli/commands/doctor-checks-swarm.ts` — extracted `probeHiveMemoryGet`, which bounded-retries the `get` with the standard 50/200/800 ms backoff before deciding:
  - `exists=true` + matching sentinel on the first read → **pass** (no added latency)
  - `exists=false` (or a transient throw) → **retry**; a late landing → **warn** (`hive-mind write-through propagation race`)
  - budget exhausted (1 immediate + 3 retries) with no landing → hard **fail**
  - `exists=true` + wrong sentinel → **fail** immediately, no retries (a clobber is a real bug, not a race)
- `src/cli/__tests__/doctor-checks-swarm.test.ts` — 6 new cases driven by a synthetic `hive-mind_memory` tool + injected no-op sleep (mirrors `buildEmptyHnswTools`/`buildStaleNeighborTools`).

## Protected-surface guarantee (⛔ epic #798)

The fix tolerates a transient propagation lag **without** weakening the regression tripwire: a value that never lands stays a hard fail, and a value clobber fails immediately. A genuine write-through break is never hidden — verified by the `never lands`, `every get throws`, and `value mismatch` test cases.

## Testing

- [x] Unit tests pass — `doctor-checks-swarm.test.ts` 11/11 (`--config vitest.isolation.config.ts`)
- [x] E2E pass — `tests/system/hive-mind-e2e.test.ts` 5/5 (real MessageBus + coordinator)
- [x] `tsc` clean
- [ ] Manual testing done

Closes #1206
