### PR TITLE
fix(auto-meditate): deterministic provenance + wider decision capture

### DIFF
--- a/.claude/scripts/lib/meditate.mjs
+++ b/.claude/scripts/lib/meditate.mjs
@@ -39,11 +39,12 @@ import { randomBytes } from 'crypto';
 // ── Tunables (exported for tests) ───────────────────────────────────────────
 /** Model used for the bounded distillation pass (cheap; Haiku is a formatter). */
 export const HAIKU_MODEL_ID = 'claude-haiku-4-5-20251001';
-/** Min gap between in-session capture directives, so a chatty correction streak
- *  can't spam the model. */
-export const INJECT_WINDOW_MS = 8 * 60_000;
+/** Min gap between in-session capture directives — a debounce so a burst of
+ *  signals in quick succession injects the directive at most once per window.
+ *  Shorter window = more capture opportunities (and more injected context). */
+export const INJECT_WINDOW_MS = 5 * 60_000;
 /** Hard cap on directives per session (belt-and-braces over the time window). */
-export const INJECT_MAX_PER_SESSION = 6;
+export const INJECT_MAX_PER_SESSION = 10;
 /** Ledger size cap — distilled entries are pruned first, then oldest. */
 export const MAX_LEDGER_ENTRIES = 200;
 /** Keep this many already-distilled entries for idempotency/debug before pruning. */
@@ -148,8 +149,23 @@ const DECISION_PATTERNS = [
   /\b(decided|decision)\b/i,
   /\bgoing with\b/i,
   /\bthe plan is\b/i,
+  /\bthe approach is\b/i,
   /\bwe should (use|go with|do)\b/i,
   /\bi'?ll go with\b/i,
+  // Selection / preference / finalization phrasing.
+  /\bgo with (option|approach|the|that|a)\b/i,
+  /\bi'?d rather\b/i,
+  /\b(we'?ll|let'?s) keep\b/i,
+  /\bfinal (decision|answer|call)\b/i,
+  // Approval ATTACHED to a concrete action/decision — "go ahead and ship the
+  // fix", "ok, use the daemon", "proceed with option B". Bare approval alone
+  // ("ok"/"yes"/"go ahead"/"sounds good") deliberately does NOT fire: it must
+  // carry an action to count as a decision moment, else it would trip on nearly
+  // every agreeing turn and burn the per-session injection budget. The live
+  // model's "append nothing" remains the final precision filter.
+  /\bgo ahead (and|with)\b/i,
+  /\bproceed with\b/i,
+  /\b(yes|yeah|yep|sure|ok|okay|sounds good|lgtm)[\s,!.]+(go with|use|ship|build|implement|add|proceed)\b/i,
 ];
 
 // Tight, low-false-positive markers only — tool output mentions "error" benignly
@@ -160,6 +176,32 @@ const ERROR_PATTERNS = [
   /\bexit code [1-9]\d*/i,
   /Traceback \(most recent call last\)/,
   /\b[1-9]\d* (failed|failing)\b/i,
+];
+
+// Bare approval that, on its own, looks like mere assent ("yes", "ok", "go
+// ahead") — but confirms a real decision when the PRIOR assistant turn proposed
+// one. Anchored at the start of the user's message so it matches a reply that
+// LEADS with approval. Paired with PROPOSAL_PATTERNS below as the precision gate.
+const APPROVAL_PATTERNS = [
+  /^\s*(y(es|ep|eah|up)?|sure|ok(ay)?|kk?|roger|agreed?|perfect|great|nice|sounds good|lgtm|do it|go ahead|proceed|approved?|let'?s do it|make it so|ship it)\b/i,
+];
+
+// Proposal / recommendation / options language the assistant uses when it asks
+// the user to choose or approve. Scanned against the recent transcript tail; a
+// match here means a bare approval in the prompt is confirming a real decision,
+// so "yes" after "I recommend we use the daemon" fires, but "ok thanks" after a
+// plain status report does not. Recall-biased — the live model still filters.
+const PROPOSAL_PATTERNS = [
+  /\bi (propose|recommend|suggest|advise)\b/i,
+  /\bi'?(d|ll) (recommend|suggest|propose|go with|use|implement|add|build|refactor)\b/i,
+  /\bwe (could|should|can|might) (use|go with|implement|refactor|add|switch|split)\b/i,
+  /\b(option|approach|plan|choice) (a|b|c|1|2|3|one|two)\b/i,
+  /\b(two|three|several|a few) (options|approaches|choices|ways)\b/i,
+  /\bshould i (proceed|go ahead|use|implement|start|continue|create|add)\b/i,
+  /\b(would|do) you (like|want) me to\b/i,
+  /\bhere'?s (the|my|a) (plan|approach|proposal|recommendation)\b/i,
+  /\brecommendation\b/i,
+  /\bpropos(e|ed|al)\b/i,
 ];
 
 function anyMatch(patterns, text) {
@@ -182,6 +224,12 @@ export function detectSignal(prompt, transcriptTail = '') {
   const t = typeof transcriptTail === 'string' ? transcriptTail : '';
   if (anyMatch(CORRECTION_PATTERNS, p)) return { hit: true, kind: 'correction' };
   if (anyMatch(DECISION_PATTERNS, p) || anyMatch(DECISION_PATTERNS, t)) return { hit: true, kind: 'decision' };
+  // Bare approval in the prompt that confirms a proposal/recommendation the
+  // assistant made in the immediately prior turn — "yes"/"go ahead" answering
+  // "I recommend we use the daemon". The prior-turn proposal (in transcriptTail)
+  // is the precision gate: a contextless "ok thanks" with nothing proposed above
+  // it does NOT fire.
+  if (anyMatch(APPROVAL_PATTERNS, p) && anyMatch(PROPOSAL_PATTERNS, t)) return { hit: true, kind: 'decision' };
   if (anyMatch(ERROR_PATTERNS, t)) return { hit: true, kind: 'error_fix' };
   return { hit: false, kind: null };
 }
@@ -241,11 +289,11 @@ export function buildCaptureDirective(kind) {
   return [
     `[auto-meditate] A ${label} just occurred this session.`,
     `FIRST: fully address the user's request as you normally would — do NOT let this note change your answer.`,
-    `THEN, only if a durable, reusable lesson emerged, append exactly ONE final line of the form:`,
+    `THEN, if a reusable lesson emerged, append exactly ONE final line of the form:`,
     `<meditate-capture>LESSON</meditate-capture>`,
     `where LESSON is a single concise sentence (a pattern, gotcha, or decision+rationale).`,
     DURABILITY_BAR,
-    `If nothing clears that bar, append nothing — silence is the correct, common outcome. Never emit more than one such line.`,
+    `When in doubt, capture it — a borderline lesson is cheap and the distill dedups; append nothing only for pure session state or git history. Never emit more than one such line.`,
   ].join('\n');
 }
 

--- a/.claude/scripts/meditate-distill.mjs
+++ b/.claude/scripts/meditate-distill.mjs
@@ -69,6 +69,10 @@ function runHeadless(projectRoot, prompt) {
       ...process.env,
       CLAUDE_CODE_HEADLESS: 'true',     // mark the child so its own hooks no-op (#860)
       ANTHROPIC_MODEL: HAIKU_MODEL_ID,  // cheap formatter model
+      // Deterministic provenance: the write path stamps source:auto-meditate on
+      // these learnings writes even if Haiku omits the tag it's asked to add
+      // (#1203 follow-up). Honoured by storeEntry in memory/entries-write.ts.
+      MOFLO_LEARNINGS_SOURCE: 'auto-meditate',
     };
 
     let child;

--- a/bin/lib/meditate.mjs
+++ b/bin/lib/meditate.mjs
@@ -39,11 +39,12 @@ import { randomBytes } from 'crypto';
 // ── Tunables (exported for tests) ───────────────────────────────────────────
 /** Model used for the bounded distillation pass (cheap; Haiku is a formatter). */
 export const HAIKU_MODEL_ID = 'claude-haiku-4-5-20251001';
-/** Min gap between in-session capture directives, so a chatty correction streak
- *  can't spam the model. */
-export const INJECT_WINDOW_MS = 8 * 60_000;
+/** Min gap between in-session capture directives — a debounce so a burst of
+ *  signals in quick succession injects the directive at most once per window.
+ *  Shorter window = more capture opportunities (and more injected context). */
+export const INJECT_WINDOW_MS = 5 * 60_000;
 /** Hard cap on directives per session (belt-and-braces over the time window). */
-export const INJECT_MAX_PER_SESSION = 6;
+export const INJECT_MAX_PER_SESSION = 10;
 /** Ledger size cap — distilled entries are pruned first, then oldest. */
 export const MAX_LEDGER_ENTRIES = 200;
 /** Keep this many already-distilled entries for idempotency/debug before pruning. */
@@ -148,8 +149,23 @@ const DECISION_PATTERNS = [
   /\b(decided|decision)\b/i,
   /\bgoing with\b/i,
   /\bthe plan is\b/i,
+  /\bthe approach is\b/i,
   /\bwe should (use|go with|do)\b/i,
   /\bi'?ll go with\b/i,
+  // Selection / preference / finalization phrasing.
+  /\bgo with (option|approach|the|that|a)\b/i,
+  /\bi'?d rather\b/i,
+  /\b(we'?ll|let'?s) keep\b/i,
+  /\bfinal (decision|answer|call)\b/i,
+  // Approval ATTACHED to a concrete action/decision — "go ahead and ship the
+  // fix", "ok, use the daemon", "proceed with option B". Bare approval alone
+  // ("ok"/"yes"/"go ahead"/"sounds good") deliberately does NOT fire: it must
+  // carry an action to count as a decision moment, else it would trip on nearly
+  // every agreeing turn and burn the per-session injection budget. The live
+  // model's "append nothing" remains the final precision filter.
+  /\bgo ahead (and|with)\b/i,
+  /\bproceed with\b/i,
+  /\b(yes|yeah|yep|sure|ok|okay|sounds good|lgtm)[\s,!.]+(go with|use|ship|build|implement|add|proceed)\b/i,
 ];
 
 // Tight, low-false-positive markers only — tool output mentions "error" benignly
@@ -160,6 +176,32 @@ const ERROR_PATTERNS = [
   /\bexit code [1-9]\d*/i,
   /Traceback \(most recent call last\)/,
   /\b[1-9]\d* (failed|failing)\b/i,
+];
+
+// Bare approval that, on its own, looks like mere assent ("yes", "ok", "go
+// ahead") — but confirms a real decision when the PRIOR assistant turn proposed
+// one. Anchored at the start of the user's message so it matches a reply that
+// LEADS with approval. Paired with PROPOSAL_PATTERNS below as the precision gate.
+const APPROVAL_PATTERNS = [
+  /^\s*(y(es|ep|eah|up)?|sure|ok(ay)?|kk?|roger|agreed?|perfect|great|nice|sounds good|lgtm|do it|go ahead|proceed|approved?|let'?s do it|make it so|ship it)\b/i,
+];
+
+// Proposal / recommendation / options language the assistant uses when it asks
+// the user to choose or approve. Scanned against the recent transcript tail; a
+// match here means a bare approval in the prompt is confirming a real decision,
+// so "yes" after "I recommend we use the daemon" fires, but "ok thanks" after a
+// plain status report does not. Recall-biased — the live model still filters.
+const PROPOSAL_PATTERNS = [
+  /\bi (propose|recommend|suggest|advise)\b/i,
+  /\bi'?(d|ll) (recommend|suggest|propose|go with|use|implement|add|build|refactor)\b/i,
+  /\bwe (could|should|can|might) (use|go with|implement|refactor|add|switch|split)\b/i,
+  /\b(option|approach|plan|choice) (a|b|c|1|2|3|one|two)\b/i,
+  /\b(two|three|several|a few) (options|approaches|choices|ways)\b/i,
+  /\bshould i (proceed|go ahead|use|implement|start|continue|create|add)\b/i,
+  /\b(would|do) you (like|want) me to\b/i,
+  /\bhere'?s (the|my|a) (plan|approach|proposal|recommendation)\b/i,
+  /\brecommendation\b/i,
+  /\bpropos(e|ed|al)\b/i,
 ];
 
 function anyMatch(patterns, text) {
@@ -182,6 +224,12 @@ export function detectSignal(prompt, transcriptTail = '') {
   const t = typeof transcriptTail === 'string' ? transcriptTail : '';
   if (anyMatch(CORRECTION_PATTERNS, p)) return { hit: true, kind: 'correction' };
   if (anyMatch(DECISION_PATTERNS, p) || anyMatch(DECISION_PATTERNS, t)) return { hit: true, kind: 'decision' };
+  // Bare approval in the prompt that confirms a proposal/recommendation the
+  // assistant made in the immediately prior turn — "yes"/"go ahead" answering
+  // "I recommend we use the daemon". The prior-turn proposal (in transcriptTail)
+  // is the precision gate: a contextless "ok thanks" with nothing proposed above
+  // it does NOT fire.
+  if (anyMatch(APPROVAL_PATTERNS, p) && anyMatch(PROPOSAL_PATTERNS, t)) return { hit: true, kind: 'decision' };
   if (anyMatch(ERROR_PATTERNS, t)) return { hit: true, kind: 'error_fix' };
   return { hit: false, kind: null };
 }
@@ -241,11 +289,11 @@ export function buildCaptureDirective(kind) {
   return [
     `[auto-meditate] A ${label} just occurred this session.`,
     `FIRST: fully address the user's request as you normally would — do NOT let this note change your answer.`,
-    `THEN, only if a durable, reusable lesson emerged, append exactly ONE final line of the form:`,
+    `THEN, if a reusable lesson emerged, append exactly ONE final line of the form:`,
     `<meditate-capture>LESSON</meditate-capture>`,
     `where LESSON is a single concise sentence (a pattern, gotcha, or decision+rationale).`,
     DURABILITY_BAR,
-    `If nothing clears that bar, append nothing — silence is the correct, common outcome. Never emit more than one such line.`,
+    `When in doubt, capture it — a borderline lesson is cheap and the distill dedups; append nothing only for pure session state or git history. Never emit more than one such line.`,
   ].join('\n');
 }
 

--- a/bin/meditate-distill.mjs
+++ b/bin/meditate-distill.mjs
@@ -69,6 +69,10 @@ function runHeadless(projectRoot, prompt) {
       ...process.env,
       CLAUDE_CODE_HEADLESS: 'true',     // mark the child so its own hooks no-op (#860)
       ANTHROPIC_MODEL: HAIKU_MODEL_ID,  // cheap formatter model
+      // Deterministic provenance: the write path stamps source:auto-meditate on
+      // these learnings writes even if Haiku omits the tag it's asked to add
+      // (#1203 follow-up). Honoured by storeEntry in memory/entries-write.ts.
+      MOFLO_LEARNINGS_SOURCE: 'auto-meditate',
     };
 
     let child;

--- a/docs/blog/distill-vs-simplify.md
+++ b/docs/blog/distill-vs-simplify.md
@@ -1,0 +1,132 @@
+# Distill: The Same Code Review as `/simplify`, Sized to the Change
+
+**Purpose:** Explain how MoFlo's `/distill` (aka `/flo-simplify`) compares to Claude Code's built-in `/simplify` skill. The two do nearly the same review — the difference is that `/simplify` runs its full three-agent pass on every diff, while distill measures the diff first and runs only as much review as the change warrants.
+
+---
+
+## Two tools that do almost the same thing
+
+Claude Code ships a built-in `/simplify` skill. It's good. Point it at your working tree and it runs a parallel, multi-agent review of your recently changed code, then cleans up what it finds — duplicated logic, missed abstractions, the O(n²) loop that should be a hash lookup. The natural place for it is right after you've got something working, before you open a PR.
+
+MoFlo has a skill that does the same job: `/distill` (its formal name is `/flo-simplify` — we renamed it from `/simplify` specifically to avoid colliding with the built-in). It reviews the same axes, fixes the same kinds of problems, and lives in the same pre-PR slot in your workflow.
+
+So this isn't a "look how different we are" post. The two skills are deliberately close — close enough that the honest comparison is narrow and specific. This post is about that narrow difference, because it turns out to matter on every diff you'll ever run it against.
+
+(One quick disambiguation, since it tripped me up while writing this: Claude Code *also* has a separate `/code-review` skill, which is a read-only correctness-bug review. That's a different tool with a different job. The head-to-head here is distill vs. `/simplify` — the code-cleanup skill, not the bug-finder.)
+
+---
+
+## What the built-in `/simplify` does
+
+Credit first: `/simplify` is a well-designed skill, and distill shares its DNA. When you invoke it, it spins up **three specialized agents in parallel** over your changed files:
+
+- **Code Reuse** — duplicated logic, missed abstractions, opportunities to consolidate.
+- **Code Quality** — readability, structure, naming, conventions.
+- **Efficiency** — performance issues and wasted work.
+
+Then it does the part that makes it more than a linter: it **aggregates the findings, fixes each valid one directly in your code, and silently skips the ones it decides are false positives**. It operates at the architectural level, not on formatting; it focuses on what you recently changed rather than the whole repo; and it's careful — it won't strip code that looks redundant but is actually defensive, and it preserves external behavior.
+
+If that description sounds like a tool you'd want before every PR, you're right. That's exactly why MoFlo has one too.
+
+---
+
+## Where distill is identical (no point pretending otherwise)
+
+Being straight about the overlap makes the real difference legible:
+
+- **Same three axes.** Distill reviews reuse, quality, and efficiency — the same orthogonal split.
+- **Same fix-don't-just-flag behavior.** Distill aggregates findings, fixes each one directly, and notes-and-skips false positives without arguing. (Our skill's wording and the built-in's are nearly word-for-word — this is shared design philosophy, not coincidence.)
+- **Same workflow slot.** Both are the "clean it up before humans review it" step, scoped to the diff.
+- **Same safety instinct.** Distill re-runs your tests after fixing and reverts any fix that breaks them.
+
+If the review quality were the whole story, you wouldn't need distill — the built-in is fine. The story is what each tool does *before* it decides how hard to look.
+
+---
+
+## Where distill differs: it sizes the review to the diff
+
+The built-in `/simplify` runs a **fixed three-agent fan-out**. Every invocation, three parallel agents, regardless of whether you changed six lines or six hundred. There's no scope classifier deciding how much review the change deserves — the orchestration is constant.
+
+Distill's one structural difference is that it **measures the diff first**, with a small, deterministic, unit-tested classifier, and then runs only as much review as the change warrants. The classifier parses the unified diff, counts added/removed declarations, detects structural moves, flags security-sensitive paths, and returns a tier, a model, and an agent count. Here's the real classifier deciding five representative diffs:
+
+```
+typo in 1 file (8 LOC)                     -> TRIVIAL  sonnet  agents:0  | ≤10 LOC, 1 file, no declaration changes
+refactor one function (140 LOC, 2 files)   -> SMALL    sonnet  agents:1  | small/medium diff
+decomposition: 6 files, 5 fns moved        -> SMALL    haiku   agents:1  | mostly relocation: 5 added, 5 removed, net +0
+big new subsystem (620 LOC)                -> NORMAL   sonnet  agents:3  | >500 LOC changed
+security path + new logic                  -> NORMAL   sonnet  agents:3  | security-sensitive path with new logic
+```
+
+That single difference cascades into several concrete advantages.
+
+### 1. You don't pay for three agents on a small change
+
+Most real diffs are small — a tweaked function, an extracted constant, an added early-return. The built-in fans out three parallel agents for those. Distill runs **one** focused agent that covers all three axes (this is its default tier), because on a single-file edit three agents duplicate each other's work rather than covering new ground. Same coverage, roughly a third of the token cost, on the diffs you run most often.
+
+### 2. A typo gets zero agents, not three
+
+When the classifier proves a change is below the threshold where review adds any value — a trimmed comment, a renamed private helper, a reformatted block — distill stamps the gate and exits in seconds with **no agent at all**. The built-in still fans out its three agents to conclude there's nothing to fix. Distill spends nothing to reach the same answer.
+
+### 3. The heavy fan-out is reserved for changes that earn it
+
+Distill escalates to the full three-agent pass only when the diff is genuinely cross-cutting — 500+ lines of real volume, a broad new subsystem, security-sensitive code with new logic. At that point three agents *cover orthogonal ground* instead of overlapping, and the cost is justified. The built-in runs that same heavy pass for the cross-cutting change and the one-liner alike.
+
+### 4. It tells a move apart from a rewrite
+
+Look at the third row of the table. A 330-LOC decomposition across six files *looks* huge by line count, but it's a pure relocation — code that already worked, just moved. Distill judges by declaration *balance* (roughly equal additions and removals), recognizes the move, and drops to a single cheap agent checking for copy-paste divergence and dead-after-move code. The built-in's fixed fan-out has no concept of this — it runs the full three-agent review on code that didn't change behavior. (Distill learned this the hard way: we shipped the over-eager version first and watched it burn tokens on decompositions.)
+
+### 5. It routes the model to the work
+
+The built-in uses Claude Code's standard sub-agent model defaults. Distill picks the model from the diff shape: **Haiku** for mechanical relocations (~5× cheaper, and pattern-matching is all a move needs), **Sonnet** for real logic changes, and **never Opus** — code review is breadth-bound, not depth-bound, so the three-Sonnet fan-out *is* the high-effort tier and Opus buys nothing. Cheap model on cheap diffs, capable model on hard ones, decided automatically.
+
+### 6. A re-run doesn't re-pay
+
+Run distill, let it fix a few things, run it again to confirm. Distill recognizes a **validation pass**: if the only changes since the last run are the fixes it drove, it self-reviews in one pass instead of re-fanning-out — the expensive survey already happened. The built-in has no memory of a prior run; every invocation starts cold and fans out again.
+
+### 7. It's wired into the PR gate
+
+Distill is part of MoFlo's pre-PR gate, and the gate uses the *same* classifier to get out of your way: a trivial diff, or a tiny review-fix tweak on an already-reviewed branch, auto-passes the "has this been reviewed?" check without even invoking the skill. The built-in `/simplify` is a standalone command — running it, and tracking whether it ran, is on you.
+
+---
+
+## Side by side
+
+| | Built-in `/simplify` | MoFlo `/distill` (`/flo-simplify`) |
+|---|---|---|
+| **Review axes** | Reuse + quality + efficiency | Reuse + quality + efficiency (same) |
+| **Action** | Aggregates findings, fixes directly, skips false positives | Same — plus re-runs tests and reverts a fix that breaks them |
+| **Effort model** | Fixed three-agent fan-out, every diff | Classifier sizes it: 0 / 1 / 3 agents by tier |
+| **Tiny/trivial diffs** | Still fans out three agents | Zero agents — gate stamp and exit |
+| **Typical small diffs** | Three agents | One focused agent, all three axes |
+| **Move vs. rewrite** | No distinction — full pass either way | Detects relocation, drops to one cheap agent |
+| **Model** | Standard sub-agent defaults | Routed per diff (haiku ↔ sonnet; never opus) |
+| **Re-run after fixes** | Fans out again | Validation pass — self-review, no re-fan-out |
+| **Workflow integration** | Standalone command | Wired into the PR gate; auto-skips trivial diffs |
+| **Scope decision** | Prompt-driven, constant | Deterministic, unit-tested classifier |
+
+---
+
+## The irony, and why it matters
+
+There's a small irony in a skill named `/simplify` that does the maximal thing — three parallel agents — on every change, including the changes that don't need it. Distill's whole premise is to apply the simplify ethos to the *review itself*: don't over-engineer the review of a six-line diff.
+
+The expensive part of code review was never the reading. It's the *calibration* — knowing how hard to look. Review a trivial change with full machinery and you've burned tokens and time for no signal. The built-in pushes a good review through one fixed gear. Distill keeps the same review and adds a transmission: a deterministic classifier that reads the same diff you would, applies rules that are written down and tested, and engages exactly as many agents — on exactly as expensive a model — as the change calls for.
+
+For occasional use, the difference is a rounding error. Run a cleanup pass before every PR, every day, across a team, and "the same review at a third of the cost on the common case, zero cost on the trivial case" compounds into real money and real latency.
+
+---
+
+## So which do you use?
+
+If you have Claude Code and not MoFlo, `/simplify` is a genuinely good tool — use it. If you're already running MoFlo, `/distill` gives you the same review with the cost calibrated to each diff and folded into the issue-to-PR workflow (the `/flo` skill runs distill as a step automatically). They're not rivals so much as the same idea with one of them tuned for running constantly.
+
+Write the code. Let distill keep it lean — without charging you a three-agent review to discover a typo was just a typo.
+
+---
+
+## See Also
+
+- `.claude/skills/flo-simplify/SKILL.md` — Full `/flo-simplify` reference: tiers, validation pass, model selection, gate stamp
+- `.claude/skills/distill/SKILL.md` — The `/distill` alias
+- `bin/simplify-classify.cjs` — The deterministic diff classifier (parse → decide → dispatch)
+- `docs/blog/writing-better-docs-for-claude.md` — Companion post on MoFlo's `/guidance` and `/eldar`

--- a/src/cli/__tests__/services/learnings-provenance.test.ts
+++ b/src/cli/__tests__/services/learnings-provenance.test.ts
@@ -96,4 +96,52 @@ describe('storeEntry: learnings source provenance', () => {
     const tags = (bridgeCalls[0].tags as string[]) || [];
     expect(tags).not.toContain('source:manual');
   });
+
+  // #1203 follow-up — MOFLO_LEARNINGS_SOURCE makes provenance deterministic for a
+  // known writer context (the auto-meditate distill) instead of relying on a
+  // headless model to remember the tag.
+  it('uses MOFLO_LEARNINGS_SOURCE as the default source when set and no source tag', async () => {
+    const prev = process.env.MOFLO_LEARNINGS_SOURCE;
+    process.env.MOFLO_LEARNINGS_SOURCE = 'auto-meditate';
+    try {
+      const { storeEntry } = await import('../../memory/memory-initializer.js');
+      await storeEntry({ key: 'l:env', value: 'a distilled lesson', namespace: 'learnings', tags: ['topic'] });
+      const tags = bridgeCalls[0].tags as string[];
+      expect(tags).toEqual(expect.arrayContaining(['topic', 'source:auto-meditate']));
+      expect(tags).not.toContain('source:manual');
+    } finally {
+      if (prev === undefined) delete process.env.MOFLO_LEARNINGS_SOURCE;
+      else process.env.MOFLO_LEARNINGS_SOURCE = prev;
+    }
+  });
+
+  it('an explicit source tag still wins over MOFLO_LEARNINGS_SOURCE', async () => {
+    const prev = process.env.MOFLO_LEARNINGS_SOURCE;
+    process.env.MOFLO_LEARNINGS_SOURCE = 'auto-meditate';
+    try {
+      const { storeEntry } = await import('../../memory/memory-initializer.js');
+      await storeEntry({ key: 'l:env2', value: 'x', namespace: 'learnings', tags: ['source:meditate-manual'] });
+      const tags = bridgeCalls[0].tags as string[];
+      expect(tags).toContain('source:meditate-manual');
+      expect(tags).not.toContain('source:auto-meditate');
+    } finally {
+      if (prev === undefined) delete process.env.MOFLO_LEARNINGS_SOURCE;
+      else process.env.MOFLO_LEARNINGS_SOURCE = prev;
+    }
+  });
+
+  it('falls back to source:manual when MOFLO_LEARNINGS_SOURCE is not a bare slug', async () => {
+    const prev = process.env.MOFLO_LEARNINGS_SOURCE;
+    process.env.MOFLO_LEARNINGS_SOURCE = 'bad value;rm';
+    try {
+      const { storeEntry } = await import('../../memory/memory-initializer.js');
+      await storeEntry({ key: 'l:env3', value: 'x', namespace: 'learnings' });
+      const tags = bridgeCalls[0].tags as string[];
+      expect(tags).toContain('source:manual');
+      expect(tags.some((t) => t.startsWith('source:bad'))).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.MOFLO_LEARNINGS_SOURCE;
+      else process.env.MOFLO_LEARNINGS_SOURCE = prev;
+    }
+  });
 });

--- a/src/cli/memory/entries-write.ts
+++ b/src/cli/memory/entries-write.ts
@@ -70,7 +70,17 @@ export async function storeEntry(options: {
   if (options.namespace === 'learnings') {
     const tags = options.tags ?? [];
     if (!tags.some((t) => typeof t === 'string' && t.startsWith('source:'))) {
-      options = { ...options, tags: [...tags, 'source:manual'] };
+      // Default provenance is `source:manual`, but a writer running in a known
+      // context can declare its own origin deterministically via the
+      // MOFLO_LEARNINGS_SOURCE env (the auto-meditate distill sets it to
+      // `auto-meditate`) so attribution never depends on a headless model
+      // remembering to pass the tag. Validated to a bare slug so a stray env
+      // value can't inject arbitrary tag text. (#1203 follow-up)
+      const envSource = process.env.MOFLO_LEARNINGS_SOURCE;
+      const source = envSource && /^[a-z0-9][a-z0-9-]*$/i.test(envSource)
+        ? `source:${envSource}`
+        : 'source:manual';
+      options = { ...options, tags: [...tags, source] };
     }
   }
 

--- a/tests/bin/meditate.test.ts
+++ b/tests/bin/meditate.test.ts
@@ -154,6 +154,52 @@ describe('detectSignal', () => {
     expect(detectSignal('neutral prompt', 'we decided to batch the writes').kind).toBe('decision');
   });
 
+  it('flags additional selection / preference / finalization phrasing', () => {
+    for (const p of [
+      'go with option B',
+      "i'd rather extract a helper",
+      "let's keep the existing schema",
+      'the approach is to cache the result',
+      'final decision: ship the daemon fix',
+    ]) {
+      expect(detectSignal(p).kind).toBe('decision');
+    }
+  });
+
+  it('flags approval ATTACHED to a concrete action/decision', () => {
+    for (const p of [
+      'go ahead and ship the daemon fix',
+      'ok, use the daemon approach',
+      'yes, build the parser',
+      'proceed with option B',
+      'sounds good, go with the cache',
+    ]) {
+      expect(detectSignal(p).kind).toBe('decision');
+    }
+  });
+
+  it('flags bare approval that confirms a proposal in the prior assistant turn', () => {
+    const prior = 'I recommend we use the daemon for the write path. Should I proceed?';
+    for (const p of ['yes', 'ok', 'go ahead', 'sounds good', 'sure, do it']) {
+      expect(detectSignal(p, prior).kind).toBe('decision');
+    }
+  });
+
+  it('bare approval does NOT fire when the prior turn proposed nothing', () => {
+    const prior = 'Done — the tests pass and I committed the change.';
+    for (const p of ['ok', 'yes', 'thanks', 'great']) {
+      expect(detectSignal(p, prior).hit).toBe(false);
+    }
+  });
+
+  it('bare approval with no prior proposal in context stays non-firing', () => {
+    // With an empty tail there is no proposal to confirm, so bare assent does
+    // not fire — only approval coupled to an action (prior turn or same message).
+    for (const p of ['ok', 'yes', 'sure', 'go ahead', 'sounds good', 'great, ship it']) {
+      expect(detectSignal(p).hit).toBe(false);
+    }
+  });
+
   it('flags error→fix from structured failure markers in the tail', () => {
     expect(detectSignal('ok continue', '{"is_error":true}').kind).toBe('error_fix');
     expect(detectSignal('ok', 'process exited with exit code 1').kind).toBe('error_fix');
@@ -210,11 +256,12 @@ describe('recentTranscriptTurn', () => {
 // ── Directive ────────────────────────────────────────────────────────────────
 
 describe('buildCaptureDirective', () => {
-  it('is answer-first and embeds the shared durability bar + the tag format', () => {
+  it('is answer-first, leans toward capture, and embeds the durability bar + tag format', () => {
     const d = buildCaptureDirective('correction');
     expect(d).toContain('FIRST');
     expect(d).toContain('<meditate-capture>LESSON</meditate-capture>');
     expect(d).toContain(DURABILITY_BAR);
+    expect(d).toContain('When in doubt, capture it');
     expect(d).toContain('append nothing');
     expect(d).toContain('course-correction');
   });


### PR DESCRIPTION
## Summary

Two related fixes to **auto-meditate** (moflo's automatic learnings capture), plus a docs blog post. Goal: make automatic capture both **trustworthy** (correct provenance) and **wider** (capture more real decisions) without disrupting flow.

## Provenance determinism — `833e3928c`

**Problem.** Auto-distilled learnings only received the `source:auto-meditate` tag if the headless Haiku distill *remembered* to pass it. When it didn't, the #1203 write-path safety net stamped `source:manual`, **mislabeling** auto-captured lessons in the Luminarium "Learnings" panel. No post-#1203 distill had run yet, so this was untested in practice.

**Fix.** `storeEntry` (`entries-write.ts`) now honors a `MOFLO_LEARNINGS_SOURCE` env as the default source for `learnings` writes that carry no `source:*` tag (validated to a bare slug). The distill (`meditate-distill.mjs`, both twins) sets it to `auto-meditate`, so attribution is deterministic regardless of what the model emits. The stamp runs before #981 daemon routing, so it lands in the payload either way. **Env-guarded → byte-identical behavior for every non-distill write.**

## Wider decision capture — same commit

- **Cross-turn approval detection:** a bare `yes` / `ok` / `go ahead` now fires a capture when the **prior assistant turn proposed a decision** (gated on proposal/recommendation language in the transcript tail). A contextless "ok thanks" after a plain status report stays silent.
- **Same-message approval+action** (`ok, use the daemon`) and **selection/finalization** phrasing (`go with option B`, `final decision`, `i'd rather`).
- Per-session cap **6 → 10**, debounce window **8m → 5m**, and the capture directive disposition flips to **"when in doubt, capture it."**
- Quality stays protected downstream by the live-model durability bar **and** the distill's ≥0.80 dedup/merge.

## Docs blog — `674f55334`

`docs/blog/distill-vs-simplify.md` — compares `/distill` (`/flo-simplify`) to Claude Code's built-in `/simplify`: same three-axis (reuse/quality/efficiency) auto-fixing review, but `/distill` sizes effort to the diff via the deterministic `simplify-classify` classifier (0/1/3 agents + model routing) instead of a fixed three-agent fan-out on every diff. Classifier output shown in the post is real.

## Testing

- **Full suite green: 9106 passed, 0 failed** (Pass 1 parallel: 387 files; Pass 2 isolation: 47 files; 26 skipped).
- New coverage in `learnings-provenance.test.ts` (env-driven provenance) and `meditate.test.ts` (cross-turn approval, approval-attached-to-action, bare-approval non-firing).
- `bin/` ↔ `.claude/scripts/` twins verified byte-identical.

## Consumer impact / rollout

- The `entries-write.ts` provenance change ships to consumers (and this repo's dogfood write path) on the **next publish**; the `.claude/scripts` hook-script changes are live at session start. The change is **env-guarded**, so all non-distill writes are unchanged.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
