### PR TITLE
feat(distill): escalate to opus for genuinely architectural diffs

### DIFF
--- a/.claude/helpers/simplify-classify.cjs
+++ b/.claude/helpers/simplify-classify.cjs
@@ -232,6 +232,7 @@ function parseDiff(diff) {
     // for other code. Aggregate net → relocation/churn cancels to ~0.
     tsjsLOC: tsjsAdded + tsjsDeleted,
     tsjsNetDecls: tsjsDeclAdded - tsjsDeclRemoved,
+    tsjsDeclAdded,
     otherNetAdded: otherAdded - otherDeleted,
     otherLOC: otherAdded + otherDeleted,
     files: [...files.keys()],
@@ -293,12 +294,16 @@ function decide(stats) {
   //                       prompt, not an auto-switch.
   const tsjsLOC = stats.tsjsLOC || 0;
   const tsjsNetDecls = stats.tsjsNetDecls || 0;
+  const tsjsDeclAdded = stats.tsjsDeclAdded || 0;
   const otherNetAdded = stats.otherNetAdded || 0;
 
+  // The new-subsystem triggers count TS/JS declarations only (tsjs-scoped, not
+  // global) so a docs/data file with a fenced `export function` code sample
+  // can't leak into the opus gate — consistent with the net-new-logic contract.
   const handoffTriggers = [];
   if (tsjsLOC > 4000 && tsjsNetDecls >= 25) handoffTriggers.push(`${tsjsLOC} LOC of TS/JS with ${tsjsNetDecls} net-new declarations`);
   if (otherNetAdded > 3000) handoffTriggers.push(`${otherNetAdded} net-new lines of non-TS/JS source`);
-  if (stats.newFiles >= 10 && stats.declAdded >= 30 && stats.netDecls >= 20) handoffTriggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+  if (stats.newFiles >= 10 && tsjsDeclAdded >= 30 && tsjsNetDecls >= 20) handoffTriggers.push(`${stats.newFiles} new files with ${tsjsDeclAdded} new TS/JS declarations`);
 
   if (handoffTriggers.length > 0) {
     return {
@@ -311,7 +316,7 @@ function decide(stats) {
   const deepTriggers = [];
   if (tsjsLOC > 1500 && tsjsNetDecls >= 10) deepTriggers.push(`${tsjsLOC} LOC of TS/JS with ${tsjsNetDecls} net-new declarations`);
   if (otherNetAdded > 1200) deepTriggers.push(`${otherNetAdded} net-new lines of non-TS/JS source`);
-  if (stats.newFiles >= 5 && stats.declAdded >= 15 && stats.netDecls >= 10) deepTriggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+  if (stats.newFiles >= 5 && tsjsDeclAdded >= 15 && tsjsNetDecls >= 10) deepTriggers.push(`${stats.newFiles} new files with ${tsjsDeclAdded} new TS/JS declarations`);
   if (stats.securityHit && stats.netDecls >= 8) deepTriggers.push(`security-sensitive path with ${stats.netDecls} net-new declarations`);
 
   if (deepTriggers.length > 0) {

--- a/.claude/helpers/simplify-classify.cjs
+++ b/.claude/helpers/simplify-classify.cjs
@@ -7,17 +7,28 @@
  * deterministic and unit-testable instead of a prose decision Claude makes
  * over and over per run.
  *
- * Rule: default to single-agent Sonnet review. Only escalate to a 3-agent
- * fan-out when diff signals genuinely warrant it. Opus is never selected —
- * the existing skill already documents that.
+ * Rule: default to single-agent Sonnet review. Escalate to a 3-agent Sonnet
+ * fan-out (NORMAL) when diff signals warrant it, and to a 3-agent Opus fan-out
+ * (DEEP) only for genuinely architectural diffs — ordinary review is
+ * breadth-bound (Sonnet wins), but architectural review is depth-bound (Opus
+ * earns its cost). The most extreme diffs additionally suggest handing off to
+ * Claude Code's built-in /simplify via escalate.suggested. (#1222 follow-up)
+ *
+ * Opus escalation is gated on genuine new-logic evidence, NEVER raw volume:
+ * TS/JS uses net-new declarations; other languages use net-new lines
+ * (added − deleted, aggregate → relocation/churn cancels out). Noise
+ * (lockfiles, snapshots, generated/vendored) and docs/data never count toward
+ * the opus bar. So a lockfile bump, a reformatting sweep, or a big rename can
+ * never reach Opus.
  *
  * Outputs JSON:
  *   {
- *     "tier": "TRIVIAL" | "SMALL" | "NORMAL",
- *     "model": "sonnet",
+ *     "tier": "TRIVIAL" | "SMALL" | "NORMAL" | "DEEP",
+ *     "model": "sonnet" | "haiku" | "opus",
  *     "agentCount": 0 | 1 | 3,
+ *     "escalate": { suggested: bool, target: "builtin-simplify"|null, reason: string|null },
  *     "reasoning": [string, ...],
- *     "stats": { added, deleted, fileCount, declAdded, declRemoved, ... }
+ *     "stats": { added, deleted, fileCount, declAdded, declRemoved, tsjsLOC, tsjsNetDecls, otherNetAdded, ... }
  *   }
  *
  * Usage:
@@ -45,34 +56,97 @@ const SECURITY_PATHS = [
   /(?:^|[\\\/])\.claude[\\\/]helpers[\\\/]gate/i,
 ];
 
-function safeExec(cmd) {
-  try { return execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }); }
-  catch { return ''; }
+// ── File-family classification for the opus-escalation gate (#1222) ───────────
+// Opus is gated on genuine new-logic evidence, never raw volume — so generated
+// noise and docs/data are stripped before measuring, and TS/JS (where the decl
+// parser is accurate) is measured by net-new declarations while other languages
+// fall back to net-new lines.
+
+// Generated / vendored noise — inflates LOC without adding reviewable logic.
+const NOISE_FILE = [
+  /(?:^|[\\\/])(?:package-lock\.json|npm-shrinkwrap\.json|yarn\.lock|pnpm-lock\.yaml|bun\.lockb?|composer\.lock|Cargo\.lock|poetry\.lock|Gemfile\.lock|go\.sum)$/i,
+  /\.snap$/i,
+  /(?:^|[\\\/])__snapshots__[\\\/]/i,
+  /(?:^|[\\\/])(?:dist|build|out|coverage|node_modules)[\\\/]/i,
+  /\.min\.(?:js|css)$/i,
+  /\.(?:map|bundle\.js)$/i,
+  /(?:^|[\\\/])vendor[\\\/]/i,
+];
+
+// Docs / data — reviewed at normal tiers, but never counted toward the opus bar.
+const DOCDATA_FILE = /\.(?:md|mdx|markdown|txt|rst|json|json5|ya?ml|toml|ini|cfg|conf|xml|csv|tsv|svg|properties|env)$/i;
+
+// TS/JS source — the declaration parser is accurate here, so the opus gate uses
+// net-new declarations for these files.
+const TSJS_FILE = /\.(?:ts|tsx|js|jsx|mjs|cjs|mts|cts)$/i;
+
+/**
+ * Bucket a file path into the family the opus-escalation gate cares about:
+ * 'noise' / 'docdata' (both excluded from the opus bar), 'tsjs' (decl-gated),
+ * or 'othercode' (net-line-gated). Pure function over the path string.
+ */
+function fileFamily(filename) {
+  if (NOISE_FILE.some((rx) => rx.test(filename))) return 'noise';
+  if (TSJS_FILE.test(filename)) return 'tsjs';
+  if (DOCDATA_FILE.test(filename)) return 'docdata';
+  return 'othercode';
+}
+
+// Default "no escalation" marker attached to every non-DEEP decision so the
+// output shape (decision.escalate) is stable for every consumer.
+function noEscalate() {
+  return { suggested: false, target: null, reason: null };
+}
+
+function safeExec(cmd, opts) {
+  try {
+    return execSync(cmd, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(opts && opts.cwd ? { cwd: opts.cwd } : {}),
+    });
+  } catch { return ''; }
 }
 
 // Detect the consumer's default branch. Hardcoding 'main' silently miscalibrates
 // classification on repos that use 'master', 'develop', etc. — empty diff →
 // TRIVIAL → gate stamps clean without any real review.
 let _cachedDefaultBranch = null;
-function detectDefaultBranch() {
-  if (_cachedDefaultBranch !== null) return _cachedDefaultBranch;
+function detectDefaultBranch(cwd) {
+  // Cache by cwd so tests probing multiple repos in-process don't return a
+  // single stale value; CLI use passes no cwd and benefits from the cache.
+  if (cwd === undefined && _cachedDefaultBranch !== null) return _cachedDefaultBranch;
+  const opts = cwd ? { cwd } : undefined;
 
   // Preferred: origin/HEAD points to whatever the remote considers default.
-  const symbolic = safeExec('git symbolic-ref --short refs/remotes/origin/HEAD').trim();
-  if (symbolic.startsWith('origin/')) return (_cachedDefaultBranch = symbolic.slice('origin/'.length));
+  const symbolic = safeExec('git symbolic-ref --short refs/remotes/origin/HEAD', opts).trim();
+  if (symbolic.startsWith('origin/')) {
+    const v = symbolic.slice('origin/'.length);
+    if (cwd === undefined) _cachedDefaultBranch = v;
+    return v;
+  }
 
   // Fallback: local init.defaultBranch (set by `git init -b <name>` or config).
-  const configured = safeExec('git config --get init.defaultBranch').trim();
-  if (configured) return (_cachedDefaultBranch = configured);
+  const configured = safeExec('git config --get init.defaultBranch', opts).trim();
+  if (configured) {
+    if (cwd === undefined) _cachedDefaultBranch = configured;
+    return configured;
+  }
 
   // Last resort: 'main' (most common modern default).
-  return (_cachedDefaultBranch = 'main');
+  if (cwd === undefined) _cachedDefaultBranch = 'main';
+  return 'main';
 }
 
-function readDiffFromGit(base) {
+function _resetCacheForTest() {
+  _cachedDefaultBranch = null;
+}
+
+function readDiffFromGit(base, cwd) {
+  const opts = cwd ? { cwd } : undefined;
   // Combined diff: committed-since-base + working-tree
-  const committed = safeExec(`git diff ${base}...HEAD`);
-  const working = safeExec('git diff HEAD');
+  const committed = safeExec(`git diff ${base}...HEAD`, opts);
+  const working = safeExec('git diff HEAD', opts);
   return committed + (working ? '\n' + working : '');
 }
 
@@ -125,6 +199,11 @@ function parseDiff(diff) {
   let added = 0, deleted = 0, declAdded = 0, declRemoved = 0;
   let newFiles = 0, renamedFiles = 0;
   let securityHit = false;
+  // Family-segregated signals for the opus-escalation gate (#1222). Noise +
+  // docs/data still contribute to the global totals (so existing
+  // TRIVIAL/SMALL/NORMAL routing is unchanged) but never to the opus bar.
+  let tsjsAdded = 0, tsjsDeleted = 0, tsjsDeclAdded = 0, tsjsDeclRemoved = 0;
+  let otherAdded = 0, otherDeleted = 0;
   for (const f of files.values()) {
     added += f.added;
     deleted += f.deleted;
@@ -133,6 +212,14 @@ function parseDiff(diff) {
     if (f.isNew) newFiles++;
     if (f.isRenamed) renamedFiles++;
     if (SECURITY_PATHS.some(rx => rx.test(f.filename))) securityHit = true;
+
+    const fam = fileFamily(f.filename);
+    if (fam === 'tsjs') {
+      tsjsAdded += f.added; tsjsDeleted += f.deleted;
+      tsjsDeclAdded += f.declAdded; tsjsDeclRemoved += f.declRemoved;
+    } else if (fam === 'othercode') {
+      otherAdded += f.added; otherDeleted += f.deleted;
+    }
   }
 
   return {
@@ -141,6 +228,12 @@ function parseDiff(diff) {
     fileCount: files.size,
     newFiles, renamedFiles,
     securityHit,
+    // Opus-gate signals (#1222): net-new declarations for TS/JS, net-new lines
+    // for other code. Aggregate net → relocation/churn cancels to ~0.
+    tsjsLOC: tsjsAdded + tsjsDeleted,
+    tsjsNetDecls: tsjsDeclAdded - tsjsDeclRemoved,
+    otherNetAdded: otherAdded - otherDeleted,
+    otherLOC: otherAdded + otherDeleted,
     files: [...files.keys()],
   };
 }
@@ -154,13 +247,13 @@ function decide(stats) {
   const totalChange = stats.added + stats.deleted;
 
   if (totalChange === 0) {
-    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, reasoning: ['empty diff — nothing to review'], stats };
+    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, escalate: noEscalate(), reasoning: ['empty diff — nothing to review'], stats };
   }
 
   // TRIVIAL: tiny diff, no declarations changed
   if (totalChange <= 10 && stats.fileCount <= 1 && stats.netDecls === 0 && stats.declAdded === 0 && stats.declRemoved === 0) {
     reasoning.push(`≤10 LOC in 1 file with no declaration changes`);
-    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, reasoning, stats };
+    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, escalate: noEscalate(), reasoning, stats };
   }
 
   // Mechanical relocation detection — the #906 case.
@@ -182,11 +275,56 @@ function decide(stats) {
     // Haiku is sufficient for mechanical moves: code already existed and worked,
     // so review reduces to copy-paste-divergence / dead-after-move pattern checks
     // — exactly haiku's strength. ~5x cheaper than sonnet on relocation-shape diffs.
-    return { tier: 'SMALL', model: 'haiku', agentCount: 1, reasoning, stats };
+    return { tier: 'SMALL', model: 'haiku', agentCount: 1, escalate: noEscalate(), reasoning, stats };
+  }
+
+  // ── Architectural escalation to Opus (#1222) ────────────────────────────────
+  // Two rungs above NORMAL, BOTH gated on genuine new-logic evidence so volume
+  // alone never escalates: TS/JS by net-new declarations, other languages by
+  // net-new lines. The relocation guard above already returned SMALL, so
+  // mechanical moves never reach here, and noise/docs/data were stripped from
+  // these signals in parseDiff.
+  //
+  //   • DEEP            → runs a 3-agent Opus pass automatically (depth-bound
+  //                       architectural review; ordinary review stays Sonnet).
+  //   • DEEP + handoff  → also suggests Claude Code's built-in /simplify for the
+  //                       most extreme diffs (escalate.suggested = true). The
+  //                       Opus pass still runs as the floor; the handoff is a
+  //                       prompt, not an auto-switch.
+  const tsjsLOC = stats.tsjsLOC || 0;
+  const tsjsNetDecls = stats.tsjsNetDecls || 0;
+  const otherNetAdded = stats.otherNetAdded || 0;
+
+  const handoffTriggers = [];
+  if (tsjsLOC > 4000 && tsjsNetDecls >= 25) handoffTriggers.push(`${tsjsLOC} LOC of TS/JS with ${tsjsNetDecls} net-new declarations`);
+  if (otherNetAdded > 3000) handoffTriggers.push(`${otherNetAdded} net-new lines of non-TS/JS source`);
+  if (stats.newFiles >= 10 && stats.declAdded >= 30 && stats.netDecls >= 20) handoffTriggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+
+  if (handoffTriggers.length > 0) {
+    return {
+      tier: 'DEEP', model: 'opus', agentCount: 3,
+      escalate: { suggested: true, target: 'builtin-simplify', reason: handoffTriggers.join('; ') },
+      reasoning: handoffTriggers, stats,
+    };
+  }
+
+  const deepTriggers = [];
+  if (tsjsLOC > 1500 && tsjsNetDecls >= 10) deepTriggers.push(`${tsjsLOC} LOC of TS/JS with ${tsjsNetDecls} net-new declarations`);
+  if (otherNetAdded > 1200) deepTriggers.push(`${otherNetAdded} net-new lines of non-TS/JS source`);
+  if (stats.newFiles >= 5 && stats.declAdded >= 15 && stats.netDecls >= 10) deepTriggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+  if (stats.securityHit && stats.netDecls >= 8) deepTriggers.push(`security-sensitive path with ${stats.netDecls} net-new declarations`);
+
+  if (deepTriggers.length > 0) {
+    return {
+      tier: 'DEEP', model: 'opus', agentCount: 3,
+      escalate: noEscalate(),
+      reasoning: deepTriggers, stats,
+    };
   }
 
   // Escalation triggers — any one trips NORMAL (3 agents).
-  // Always Sonnet — Opus is never the right model for /simplify per skill rule.
+  // Sonnet — ordinary cross-cutting review is breadth-bound, so 3 Sonnet agents
+  // are the right tool; Opus is reserved for the DEEP (architectural) tier above.
   const triggers = [];
   if (totalChange > 500) triggers.push(`>500 LOC changed (${totalChange})`);
   if (stats.fileCount >= 5 && stats.netDecls >= 3) triggers.push(`${stats.fileCount} files with ${stats.netDecls} net new declarations`);
@@ -194,21 +332,21 @@ function decide(stats) {
   if (stats.newFiles >= 3 && stats.declAdded >= 5) triggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
 
   if (triggers.length > 0) {
-    return { tier: 'NORMAL', model: 'sonnet', agentCount: 3, reasoning: triggers, stats };
+    return { tier: 'NORMAL', model: 'sonnet', agentCount: 3, escalate: noEscalate(), reasoning: triggers, stats };
   }
 
   // Default: SMALL — single sonnet agent
   reasoning.push(`small/medium diff: ${totalChange} LOC across ${stats.fileCount} file(s), +${stats.declAdded}/-${stats.declRemoved} decls`);
-  return { tier: 'SMALL', model: 'sonnet', agentCount: 1, reasoning, stats };
+  return { tier: 'SMALL', model: 'sonnet', agentCount: 1, escalate: noEscalate(), reasoning, stats };
 }
 
 function classifyDiff(diffText) {
   return decide(parseDiff(diffText));
 }
 
-function classifyFromGit(base) {
-  const resolved = base || detectDefaultBranch();
-  return classifyDiff(readDiffFromGit(resolved));
+function classifyFromGit(base, cwd) {
+  const resolved = base || detectDefaultBranch(cwd);
+  return classifyDiff(readDiffFromGit(resolved, cwd));
 }
 
 if (require.main === module) {
@@ -232,4 +370,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { parseDiff, decide, classifyDiff, classifyFromGit, detectDefaultBranch };
+module.exports = { parseDiff, decide, classifyDiff, classifyFromGit, detectDefaultBranch, _resetCacheForTest };

--- a/.claude/skills/flo-simplify/SKILL.md
+++ b/.claude/skills/flo-simplify/SKILL.md
@@ -28,11 +28,12 @@ The classifier auto-detects the repo's default branch (origin/HEAD, then `init.d
 Output:
 ```json
 {
-  "tier": "TRIVIAL" | "SMALL" | "NORMAL",
-  "model": "sonnet",
+  "tier": "TRIVIAL" | "SMALL" | "NORMAL" | "DEEP",
+  "model": "sonnet" | "haiku" | "opus",
   "agentCount": 0 | 1 | 3,
+  "escalate": { "suggested": false, "target": null, "reason": null },
   "reasoning": ["..."],
-  "stats": { "added": ..., "deleted": ..., "declAdded": ..., "declRemoved": ..., "netDecls": ..., "fileCount": ..., "securityHit": ... }
+  "stats": { "added": ..., "deleted": ..., "declAdded": ..., "declRemoved": ..., "netDecls": ..., "fileCount": ..., "securityHit": ..., "tsjsLOC": ..., "tsjsNetDecls": ..., "otherNetAdded": ... }
 }
 ```
 
@@ -69,6 +70,17 @@ Reserved for **genuinely cross-cutting** changes that single-agent review can't 
 
 Three agents exist to cover orthogonal axes (Reuse / Quality / Efficiency) when the change is broad enough that one agent's tool-call budget can't survey it all. For single-file edits, one focused agent always covers all three axes — three is duplication, not coverage.
 
+### DEEP — three parallel Opus agents (architectural, rare)
+The top rung, for genuinely **architectural** change where *depth* of reasoning — not just breadth — earns Opus's cost (judging whether a large refactor picked the right abstractions is reasoning, not surveying). The classifier escalates to DEEP only on real new-logic evidence, **never raw volume** — any of:
+- `>1500 LOC of TS/JS AND ≥10 net-new declarations`
+- `>1200 net-new lines of non-TS/JS source` (other languages are gated on net lines because the declaration parser is TS/JS-shaped)
+- `5+ new files AND ≥15 new declarations AND ≥10 net` (a real new subsystem)
+- `security-sensitive path AND ≥8 net-new declarations`
+
+DEEP runs **automatically — no prompt.** Noise (lockfiles, snapshots, generated/vendored) and docs/data are stripped before measuring, and the signal is *net of churn* (TS/JS by net-new declarations, other code by net-new lines), so a lockfile bump, a reformatting sweep, or a large rename/relocation can never reach Opus — they cancel to ~0 and stay SMALL/NORMAL.
+
+For the most **extreme** diffs (`>4000 LOC TS/JS + ≥25 net decls`, `>3000 net-new non-TS/JS lines`, or `10+ new files + ≥30 decls + ≥20 net`), the classifier also sets `escalate.suggested = true` with `target: "builtin-simplify"`. The Opus pass still runs as the floor; you then **offer** the user a handoff to Claude Code's built-in `/simplify` (Phase 3) — a suggestion, not an auto-switch.
+
 ## Phase 2.5: Validation pass (re-run after fixes)
 
 If `/flo-simplify` already ran on this branch in this session AND the only edits since are fixes driven by the prior pass's findings, default to **self-review tier** regardless of LOC count. The fan-out already happened; the fix is small relative to the diff that was already reviewed.
@@ -79,7 +91,7 @@ Escalate one tier (self-review → SMALL agent) only if the fix introduced any o
 - A new dependency or import from a previously-untouched module
 - A change to control flow not covered in the original findings
 
-Do **not** escalate to NORMAL on a validation pass. If the fix is so structural that NORMAL is warranted, treat it as a fresh diff and start over from Phase 1.
+Do **not** escalate to NORMAL or DEEP on a validation pass. If the fix is so structural that NORMAL/DEEP is warranted, treat it as a fresh diff and start over from Phase 1.
 
 ## Phase 2.7: Model selection
 
@@ -87,7 +99,7 @@ Do **not** escalate to NORMAL on a validation pass. If the fix is so structural 
 
 - `sonnet` (default) — real logic changes, single agent or three-agent fan-out.
 - `haiku` — mostly-relocation diffs (mechanical moves where pattern-matching beats deep reasoning, ~5x cheaper).
-- `opus` — never. Code review is breadth-bound, not depth-bound; the three-agent fan-out at sonnet is the high-effort tier.
+- `opus` — the **DEEP** tier only. Architectural review is depth-bound (judging whether a large refactor picked the right abstractions is reasoning, not surveying), so the classifier returns opus when — and only when — the diff clears the DEEP bar. Never pick opus yourself for SMALL/NORMAL; ordinary review is breadth-bound and three sonnet agents are the right tool.
 
 If you fell back to prose rules in Phase 2 (no classifier available), use `sonnet` unconditionally. Pass the classifier's `model` field verbatim to Agent's `model` parameter.
 
@@ -122,6 +134,15 @@ Launch three agents in a single message — Reuse, Quality, Efficiency — passi
 **Quality**: redundant state, parameter sprawl, copy-paste with variation, leaky abstractions, stringly-typed code, nested conditionals 3+ levels, unnecessary comments (WHAT-explanations, task references).
 
 **Efficiency**: unnecessary work, missed concurrency, hot-path bloat, recurring no-op updates, TOCTOU existence checks, unbounded structures, over-broad reads.
+
+### DEEP: three parallel Opus agents (architectural) — and maybe a handoff
+Same three-agent fan-out as NORMAL (Reuse / Quality / Efficiency in one message), but pass `model: "opus"` to each — the classifier already decided depth is warranted. **Print one line first** so the heavier cost is never silent, e.g. `distill: DEEP — 1,800 LOC of new logic, ran opus depth pass`.
+
+If the classifier set `escalate.suggested = true`, then **after** the Opus pass finishes, surface a handoff suggestion to the user — never switch automatically:
+
+> This change is large enough (`<escalate.reason>`) that Claude Code's built-in `/simplify` — a deeper, heavier multi-agent pass — may add value beyond this review. Want to run it? It costs more tokens, so it's your call.
+
+Then stop and let the user decide. Do **not** invoke the built-in `/simplify` yourself — the handoff is the user's choice, and the Opus pass you just ran already covers the diff.
 
 ## Phase 4: Fix or skip
 

--- a/bin/simplify-classify.cjs
+++ b/bin/simplify-classify.cjs
@@ -232,6 +232,7 @@ function parseDiff(diff) {
     // for other code. Aggregate net → relocation/churn cancels to ~0.
     tsjsLOC: tsjsAdded + tsjsDeleted,
     tsjsNetDecls: tsjsDeclAdded - tsjsDeclRemoved,
+    tsjsDeclAdded,
     otherNetAdded: otherAdded - otherDeleted,
     otherLOC: otherAdded + otherDeleted,
     files: [...files.keys()],
@@ -293,12 +294,16 @@ function decide(stats) {
   //                       prompt, not an auto-switch.
   const tsjsLOC = stats.tsjsLOC || 0;
   const tsjsNetDecls = stats.tsjsNetDecls || 0;
+  const tsjsDeclAdded = stats.tsjsDeclAdded || 0;
   const otherNetAdded = stats.otherNetAdded || 0;
 
+  // The new-subsystem triggers count TS/JS declarations only (tsjs-scoped, not
+  // global) so a docs/data file with a fenced `export function` code sample
+  // can't leak into the opus gate — consistent with the net-new-logic contract.
   const handoffTriggers = [];
   if (tsjsLOC > 4000 && tsjsNetDecls >= 25) handoffTriggers.push(`${tsjsLOC} LOC of TS/JS with ${tsjsNetDecls} net-new declarations`);
   if (otherNetAdded > 3000) handoffTriggers.push(`${otherNetAdded} net-new lines of non-TS/JS source`);
-  if (stats.newFiles >= 10 && stats.declAdded >= 30 && stats.netDecls >= 20) handoffTriggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+  if (stats.newFiles >= 10 && tsjsDeclAdded >= 30 && tsjsNetDecls >= 20) handoffTriggers.push(`${stats.newFiles} new files with ${tsjsDeclAdded} new TS/JS declarations`);
 
   if (handoffTriggers.length > 0) {
     return {
@@ -311,7 +316,7 @@ function decide(stats) {
   const deepTriggers = [];
   if (tsjsLOC > 1500 && tsjsNetDecls >= 10) deepTriggers.push(`${tsjsLOC} LOC of TS/JS with ${tsjsNetDecls} net-new declarations`);
   if (otherNetAdded > 1200) deepTriggers.push(`${otherNetAdded} net-new lines of non-TS/JS source`);
-  if (stats.newFiles >= 5 && stats.declAdded >= 15 && stats.netDecls >= 10) deepTriggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+  if (stats.newFiles >= 5 && tsjsDeclAdded >= 15 && tsjsNetDecls >= 10) deepTriggers.push(`${stats.newFiles} new files with ${tsjsDeclAdded} new TS/JS declarations`);
   if (stats.securityHit && stats.netDecls >= 8) deepTriggers.push(`security-sensitive path with ${stats.netDecls} net-new declarations`);
 
   if (deepTriggers.length > 0) {

--- a/bin/simplify-classify.cjs
+++ b/bin/simplify-classify.cjs
@@ -7,17 +7,28 @@
  * deterministic and unit-testable instead of a prose decision Claude makes
  * over and over per run.
  *
- * Rule: default to single-agent Sonnet review. Only escalate to a 3-agent
- * fan-out when diff signals genuinely warrant it. Opus is never selected —
- * the existing skill already documents that.
+ * Rule: default to single-agent Sonnet review. Escalate to a 3-agent Sonnet
+ * fan-out (NORMAL) when diff signals warrant it, and to a 3-agent Opus fan-out
+ * (DEEP) only for genuinely architectural diffs — ordinary review is
+ * breadth-bound (Sonnet wins), but architectural review is depth-bound (Opus
+ * earns its cost). The most extreme diffs additionally suggest handing off to
+ * Claude Code's built-in /simplify via escalate.suggested. (#1222 follow-up)
+ *
+ * Opus escalation is gated on genuine new-logic evidence, NEVER raw volume:
+ * TS/JS uses net-new declarations; other languages use net-new lines
+ * (added − deleted, aggregate → relocation/churn cancels out). Noise
+ * (lockfiles, snapshots, generated/vendored) and docs/data never count toward
+ * the opus bar. So a lockfile bump, a reformatting sweep, or a big rename can
+ * never reach Opus.
  *
  * Outputs JSON:
  *   {
- *     "tier": "TRIVIAL" | "SMALL" | "NORMAL",
- *     "model": "sonnet",
+ *     "tier": "TRIVIAL" | "SMALL" | "NORMAL" | "DEEP",
+ *     "model": "sonnet" | "haiku" | "opus",
  *     "agentCount": 0 | 1 | 3,
+ *     "escalate": { suggested: bool, target: "builtin-simplify"|null, reason: string|null },
  *     "reasoning": [string, ...],
- *     "stats": { added, deleted, fileCount, declAdded, declRemoved, ... }
+ *     "stats": { added, deleted, fileCount, declAdded, declRemoved, tsjsLOC, tsjsNetDecls, otherNetAdded, ... }
  *   }
  *
  * Usage:
@@ -44,6 +55,48 @@ const SECURITY_PATHS = [
   /(?:^|[\\\/])bin[\\\/]session-start-launcher\./i,
   /(?:^|[\\\/])\.claude[\\\/]helpers[\\\/]gate/i,
 ];
+
+// ── File-family classification for the opus-escalation gate (#1222) ───────────
+// Opus is gated on genuine new-logic evidence, never raw volume — so generated
+// noise and docs/data are stripped before measuring, and TS/JS (where the decl
+// parser is accurate) is measured by net-new declarations while other languages
+// fall back to net-new lines.
+
+// Generated / vendored noise — inflates LOC without adding reviewable logic.
+const NOISE_FILE = [
+  /(?:^|[\\\/])(?:package-lock\.json|npm-shrinkwrap\.json|yarn\.lock|pnpm-lock\.yaml|bun\.lockb?|composer\.lock|Cargo\.lock|poetry\.lock|Gemfile\.lock|go\.sum)$/i,
+  /\.snap$/i,
+  /(?:^|[\\\/])__snapshots__[\\\/]/i,
+  /(?:^|[\\\/])(?:dist|build|out|coverage|node_modules)[\\\/]/i,
+  /\.min\.(?:js|css)$/i,
+  /\.(?:map|bundle\.js)$/i,
+  /(?:^|[\\\/])vendor[\\\/]/i,
+];
+
+// Docs / data — reviewed at normal tiers, but never counted toward the opus bar.
+const DOCDATA_FILE = /\.(?:md|mdx|markdown|txt|rst|json|json5|ya?ml|toml|ini|cfg|conf|xml|csv|tsv|svg|properties|env)$/i;
+
+// TS/JS source — the declaration parser is accurate here, so the opus gate uses
+// net-new declarations for these files.
+const TSJS_FILE = /\.(?:ts|tsx|js|jsx|mjs|cjs|mts|cts)$/i;
+
+/**
+ * Bucket a file path into the family the opus-escalation gate cares about:
+ * 'noise' / 'docdata' (both excluded from the opus bar), 'tsjs' (decl-gated),
+ * or 'othercode' (net-line-gated). Pure function over the path string.
+ */
+function fileFamily(filename) {
+  if (NOISE_FILE.some((rx) => rx.test(filename))) return 'noise';
+  if (TSJS_FILE.test(filename)) return 'tsjs';
+  if (DOCDATA_FILE.test(filename)) return 'docdata';
+  return 'othercode';
+}
+
+// Default "no escalation" marker attached to every non-DEEP decision so the
+// output shape (decision.escalate) is stable for every consumer.
+function noEscalate() {
+  return { suggested: false, target: null, reason: null };
+}
 
 function safeExec(cmd, opts) {
   try {
@@ -146,6 +199,11 @@ function parseDiff(diff) {
   let added = 0, deleted = 0, declAdded = 0, declRemoved = 0;
   let newFiles = 0, renamedFiles = 0;
   let securityHit = false;
+  // Family-segregated signals for the opus-escalation gate (#1222). Noise +
+  // docs/data still contribute to the global totals (so existing
+  // TRIVIAL/SMALL/NORMAL routing is unchanged) but never to the opus bar.
+  let tsjsAdded = 0, tsjsDeleted = 0, tsjsDeclAdded = 0, tsjsDeclRemoved = 0;
+  let otherAdded = 0, otherDeleted = 0;
   for (const f of files.values()) {
     added += f.added;
     deleted += f.deleted;
@@ -154,6 +212,14 @@ function parseDiff(diff) {
     if (f.isNew) newFiles++;
     if (f.isRenamed) renamedFiles++;
     if (SECURITY_PATHS.some(rx => rx.test(f.filename))) securityHit = true;
+
+    const fam = fileFamily(f.filename);
+    if (fam === 'tsjs') {
+      tsjsAdded += f.added; tsjsDeleted += f.deleted;
+      tsjsDeclAdded += f.declAdded; tsjsDeclRemoved += f.declRemoved;
+    } else if (fam === 'othercode') {
+      otherAdded += f.added; otherDeleted += f.deleted;
+    }
   }
 
   return {
@@ -162,6 +228,12 @@ function parseDiff(diff) {
     fileCount: files.size,
     newFiles, renamedFiles,
     securityHit,
+    // Opus-gate signals (#1222): net-new declarations for TS/JS, net-new lines
+    // for other code. Aggregate net → relocation/churn cancels to ~0.
+    tsjsLOC: tsjsAdded + tsjsDeleted,
+    tsjsNetDecls: tsjsDeclAdded - tsjsDeclRemoved,
+    otherNetAdded: otherAdded - otherDeleted,
+    otherLOC: otherAdded + otherDeleted,
     files: [...files.keys()],
   };
 }
@@ -175,13 +247,13 @@ function decide(stats) {
   const totalChange = stats.added + stats.deleted;
 
   if (totalChange === 0) {
-    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, reasoning: ['empty diff — nothing to review'], stats };
+    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, escalate: noEscalate(), reasoning: ['empty diff — nothing to review'], stats };
   }
 
   // TRIVIAL: tiny diff, no declarations changed
   if (totalChange <= 10 && stats.fileCount <= 1 && stats.netDecls === 0 && stats.declAdded === 0 && stats.declRemoved === 0) {
     reasoning.push(`≤10 LOC in 1 file with no declaration changes`);
-    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, reasoning, stats };
+    return { tier: 'TRIVIAL', model: 'sonnet', agentCount: 0, escalate: noEscalate(), reasoning, stats };
   }
 
   // Mechanical relocation detection — the #906 case.
@@ -203,11 +275,56 @@ function decide(stats) {
     // Haiku is sufficient for mechanical moves: code already existed and worked,
     // so review reduces to copy-paste-divergence / dead-after-move pattern checks
     // — exactly haiku's strength. ~5x cheaper than sonnet on relocation-shape diffs.
-    return { tier: 'SMALL', model: 'haiku', agentCount: 1, reasoning, stats };
+    return { tier: 'SMALL', model: 'haiku', agentCount: 1, escalate: noEscalate(), reasoning, stats };
+  }
+
+  // ── Architectural escalation to Opus (#1222) ────────────────────────────────
+  // Two rungs above NORMAL, BOTH gated on genuine new-logic evidence so volume
+  // alone never escalates: TS/JS by net-new declarations, other languages by
+  // net-new lines. The relocation guard above already returned SMALL, so
+  // mechanical moves never reach here, and noise/docs/data were stripped from
+  // these signals in parseDiff.
+  //
+  //   • DEEP            → runs a 3-agent Opus pass automatically (depth-bound
+  //                       architectural review; ordinary review stays Sonnet).
+  //   • DEEP + handoff  → also suggests Claude Code's built-in /simplify for the
+  //                       most extreme diffs (escalate.suggested = true). The
+  //                       Opus pass still runs as the floor; the handoff is a
+  //                       prompt, not an auto-switch.
+  const tsjsLOC = stats.tsjsLOC || 0;
+  const tsjsNetDecls = stats.tsjsNetDecls || 0;
+  const otherNetAdded = stats.otherNetAdded || 0;
+
+  const handoffTriggers = [];
+  if (tsjsLOC > 4000 && tsjsNetDecls >= 25) handoffTriggers.push(`${tsjsLOC} LOC of TS/JS with ${tsjsNetDecls} net-new declarations`);
+  if (otherNetAdded > 3000) handoffTriggers.push(`${otherNetAdded} net-new lines of non-TS/JS source`);
+  if (stats.newFiles >= 10 && stats.declAdded >= 30 && stats.netDecls >= 20) handoffTriggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+
+  if (handoffTriggers.length > 0) {
+    return {
+      tier: 'DEEP', model: 'opus', agentCount: 3,
+      escalate: { suggested: true, target: 'builtin-simplify', reason: handoffTriggers.join('; ') },
+      reasoning: handoffTriggers, stats,
+    };
+  }
+
+  const deepTriggers = [];
+  if (tsjsLOC > 1500 && tsjsNetDecls >= 10) deepTriggers.push(`${tsjsLOC} LOC of TS/JS with ${tsjsNetDecls} net-new declarations`);
+  if (otherNetAdded > 1200) deepTriggers.push(`${otherNetAdded} net-new lines of non-TS/JS source`);
+  if (stats.newFiles >= 5 && stats.declAdded >= 15 && stats.netDecls >= 10) deepTriggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
+  if (stats.securityHit && stats.netDecls >= 8) deepTriggers.push(`security-sensitive path with ${stats.netDecls} net-new declarations`);
+
+  if (deepTriggers.length > 0) {
+    return {
+      tier: 'DEEP', model: 'opus', agentCount: 3,
+      escalate: noEscalate(),
+      reasoning: deepTriggers, stats,
+    };
   }
 
   // Escalation triggers — any one trips NORMAL (3 agents).
-  // Always Sonnet — Opus is never the right model for /simplify per skill rule.
+  // Sonnet — ordinary cross-cutting review is breadth-bound, so 3 Sonnet agents
+  // are the right tool; Opus is reserved for the DEEP (architectural) tier above.
   const triggers = [];
   if (totalChange > 500) triggers.push(`>500 LOC changed (${totalChange})`);
   if (stats.fileCount >= 5 && stats.netDecls >= 3) triggers.push(`${stats.fileCount} files with ${stats.netDecls} net new declarations`);
@@ -215,12 +332,12 @@ function decide(stats) {
   if (stats.newFiles >= 3 && stats.declAdded >= 5) triggers.push(`${stats.newFiles} new files with ${stats.declAdded} new declarations`);
 
   if (triggers.length > 0) {
-    return { tier: 'NORMAL', model: 'sonnet', agentCount: 3, reasoning: triggers, stats };
+    return { tier: 'NORMAL', model: 'sonnet', agentCount: 3, escalate: noEscalate(), reasoning: triggers, stats };
   }
 
   // Default: SMALL — single sonnet agent
   reasoning.push(`small/medium diff: ${totalChange} LOC across ${stats.fileCount} file(s), +${stats.declAdded}/-${stats.declRemoved} decls`);
-  return { tier: 'SMALL', model: 'sonnet', agentCount: 1, reasoning, stats };
+  return { tier: 'SMALL', model: 'sonnet', agentCount: 1, escalate: noEscalate(), reasoning, stats };
 }
 
 function classifyDiff(diffText) {

--- a/docs/blog/distill-vs-simplify.md
+++ b/docs/blog/distill-vs-simplify.md
@@ -55,6 +55,7 @@ refactor one function (140 LOC, 2 files)   -> SMALL    sonnet  agents:1  | small
 decomposition: 6 files, 5 fns moved        -> SMALL    haiku   agents:1  | mostly relocation: 5 added, 5 removed, net +0
 big new subsystem (620 LOC)                -> NORMAL   sonnet  agents:3  | >500 LOC changed
 security path + new logic                  -> NORMAL   sonnet  agents:3  | security-sensitive path with new logic
+architectural subsystem (1.8k LOC, +12)    -> DEEP     opus    agents:3  | net-new logic clears the architectural bar
 ```
 
 That single difference cascades into several concrete advantages.
@@ -67,9 +68,11 @@ Most real diffs are small — a tweaked function, an extracted constant, an adde
 
 When the classifier proves a change is below the threshold where review adds any value — a trimmed comment, a renamed private helper, a reformatted block — distill stamps the gate and exits in seconds with **no agent at all**. The built-in still fans out its three agents to conclude there's nothing to fix. Distill spends nothing to reach the same answer.
 
-### 3. The heavy fan-out is reserved for changes that earn it
+### 3. The heavy fan-out is reserved for changes that earn it — and steps up further for the ones that really do
 
 Distill escalates to the full three-agent pass only when the diff is genuinely cross-cutting — 500+ lines of real volume, a broad new subsystem, security-sensitive code with new logic. At that point three agents *cover orthogonal ground* instead of overlapping, and the cost is justified. The built-in runs that same heavy pass for the cross-cutting change and the one-liner alike.
+
+Calibration runs in *both* directions. For the rare **architectural** diff — a genuinely new subsystem, thousands of lines of net-new logic — distill steps *up* a rung to **DEEP**: the same three-agent fan-out, but on **Opus**, because judging whether a large refactor picked the right abstractions is depth-bound reasoning, not breadth-bound surveying. That runs automatically, with a one-line notice so the heavier cost is never silent. For the most extreme diffs, distill finishes its Opus pass and then *suggests* you hand off to Claude Code's built-in `/simplify` for an even deeper look — a prompt, never an automatic switch. Crucially, this upward escalation is gated on **net-new-logic evidence, never raw volume**: net-new declarations in TS/JS, net-new lines in other languages, measured net of churn with lockfiles, snapshots, generated files, and docs stripped out. A 2,000-line lockfile bump, a reformatting sweep, or a big rename never trips it — there's no new logic to reason about, so there's nothing for Opus to earn.
 
 ### 4. It tells a move apart from a rewrite
 
@@ -77,7 +80,7 @@ Look at the third row of the table. A 330-LOC decomposition across six files *lo
 
 ### 5. It routes the model to the work
 
-The built-in uses Claude Code's standard sub-agent model defaults. Distill picks the model from the diff shape: **Haiku** for mechanical relocations (~5× cheaper, and pattern-matching is all a move needs), **Sonnet** for real logic changes, and **never Opus** — code review is breadth-bound, not depth-bound, so the three-Sonnet fan-out *is* the high-effort tier and Opus buys nothing. Cheap model on cheap diffs, capable model on hard ones, decided automatically.
+The built-in uses Claude Code's standard sub-agent model defaults. Distill picks the model from the diff shape: **Haiku** for mechanical relocations (~5× cheaper, and pattern-matching is all a move needs), **Sonnet** for ordinary logic changes, and **Opus** for the rare architectural diff where depth of reasoning earns its cost (see #3 — ordinary review is breadth-bound, so three Sonnet agents are the right tool; architectural review is depth-bound). Cheap model on cheap diffs, capable model on hard ones, the depth model only when the change is genuinely architectural — decided automatically.
 
 ### 6. A re-run doesn't re-pay
 
@@ -99,7 +102,8 @@ Distill is part of MoFlo's pre-PR gate, and the gate uses the *same* classifier 
 | **Tiny/trivial diffs** | Still fans out three agents | Zero agents — gate stamp and exit |
 | **Typical small diffs** | Three agents | One focused agent, all three axes |
 | **Move vs. rewrite** | No distinction — full pass either way | Detects relocation, drops to one cheap agent |
-| **Model** | Standard sub-agent defaults | Routed per diff (haiku ↔ sonnet; never opus) |
+| **Architectural diffs** | Three agents, same as any diff | Steps up to three Opus agents; suggests built-in `/simplify` on extreme outliers |
+| **Model** | Standard sub-agent defaults | Routed per diff: haiku → sonnet → opus (opus only for architectural diffs) |
 | **Re-run after fixes** | Fans out again | Validation pass — self-review, no re-fan-out |
 | **Workflow integration** | Standalone command | Wired into the PR gate; auto-skips trivial diffs |
 | **Scope decision** | Prompt-driven, constant | Deterministic, unit-tested classifier |

--- a/tests/bin/simplify-classify.test.ts
+++ b/tests/bin/simplify-classify.test.ts
@@ -296,6 +296,24 @@ index 0000000..abc
   return diff;
 }
 
+/** A new TS subsystem spread across 5 new files (≥15 new declarations, ≥10
+ *  net) but well under the 1500-LOC bar — isolates the "new subsystem" DEEP
+ *  trigger from the volume trigger. Declarations are TS/JS-scoped. */
+function deepNewSubsystemDiff(): string {
+  let diff = '';
+  for (let f = 0; f < 5; f++) {
+    diff += `diff --git a/src/engine/mod${f}.ts b/src/engine/mod${f}.ts
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/src/engine/mod${f}.ts
+@@ -0,0 +1,18 @@
+`;
+    for (let i = 0; i < 3; i++) diff += `+export function mod${f}fn${i}(x: number): number {\n+  return x + ${i};\n+}\n`;
+  }
+  return diff;
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('simplify-classify: pure logic via require()', () => {
@@ -471,11 +489,23 @@ describe('simplify-classify: opus escalation (DEEP + handoff)', () => {
     expect(d.stats.tsjsNetDecls).toBe(0);
   });
 
-  it('a 1,300-line non-TS/JS relocation nets to ~0 and never reaches opus', () => {
+  it('a 1,300-line non-TS/JS relocation nets to exactly 0 and never reaches opus', () => {
     const d = classifyDiff(otherLangRelocationDiff());
     expect(d.tier).not.toBe('DEEP');
     expect(d.model).not.toBe('opus');
-    expect(d.stats.otherNetAdded).toBeLessThanOrEqual(0);
+    expect(d.stats.otherNetAdded).toBe(0);
+  });
+
+  it('a new TS subsystem (5 new files, ≥15 net decls, <1500 LOC) → DEEP via the new-subsystem trigger', () => {
+    const d = classifyDiff(deepNewSubsystemDiff());
+    expect(d.tier).toBe('DEEP');
+    expect(d.model).toBe('opus');
+    expect(d.escalate.suggested).toBe(false);
+    // The volume trigger did NOT fire — this isolates the new-files/decls path.
+    expect(d.stats.tsjsLOC).toBeLessThanOrEqual(1500);
+    expect(d.stats.newFiles).toBeGreaterThanOrEqual(5);
+    expect(d.stats.tsjsDeclAdded).toBeGreaterThanOrEqual(15);
+    expect(d.reasoning.join(' ')).toMatch(/new files/i);
   });
 
   it('a 3,000-line markdown doc never reaches opus (docs excluded from the bar)', () => {

--- a/tests/bin/simplify-classify.test.ts
+++ b/tests/bin/simplify-classify.test.ts
@@ -10,7 +10,8 @@
  *   - small logic edit          → SMALL / 1 agent
  *   - large diff with new logic → NORMAL / 3 agents
  *   - security-path + new logic → NORMAL / 3 agents
- *   - never returns opus        → ALL cases
+ *   - architectural new logic   → DEEP / 3 opus agents (auto; extreme → handoff suggested)
+ *   - volume without new logic   → never opus (lockfile / reformat / rename / docs)
  *   - default-branch detection  → consumer's actual default branch, not hardcoded 'main'
  */
 import { describe, it, expect, afterEach } from 'vitest';
@@ -190,6 +191,111 @@ index abc..def 100644
 `;
 }
 
+/** A genuinely architectural TS diff: a new ~1,600-LOC module with 12 new
+ *  exported functions. tsjsLOC > 1500 AND netDecls ≥ 10 → DEEP / opus. */
+function deepTsjsSubsystemDiff(): string {
+  let diff = `diff --git a/src/engine/planner.ts b/src/engine/planner.ts
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/src/engine/planner.ts
+@@ -0,0 +1,1592 @@
+`;
+  for (let i = 0; i < 12; i++) diff += `+export function plannerStep${i}(input: string): string {\n`;
+  for (let j = 0; j < 1580; j++) diff += `+  const step${j} = ${j};\n`;
+  return diff;
+}
+
+/** A genuinely architectural non-TS/JS diff: a new ~1,300-LOC Go service.
+ *  otherNetAdded > 1200 → DEEP / opus (other languages gate on net lines, since
+ *  the declaration parser is TS/JS-shaped). */
+function deepOtherLangDiff(): string {
+  let diff = `diff --git a/server/scheduler.go b/server/scheduler.go
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/server/scheduler.go
+@@ -0,0 +1,1300 @@
+`;
+  for (let j = 0; j < 1300; j++) diff += `+\tx${j} := ${j}\n`;
+  return diff;
+}
+
+/** An extreme architectural diff: a new ~4,230-LOC TS module with 30 new
+ *  functions. Trips the handoff bar → DEEP / opus / escalate.suggested. */
+function handoffDiff(): string {
+  let diff = `diff --git a/src/engine/megamodule.ts b/src/engine/megamodule.ts
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/src/engine/megamodule.ts
+@@ -0,0 +1,4230 @@
+`;
+  for (let i = 0; i < 30; i++) diff += `+export function mega${i}(input: string): string {\n`;
+  for (let j = 0; j < 4200; j++) diff += `+  const v${j} = ${j};\n`;
+  return diff;
+}
+
+/** A 2,500-line lockfile bump — large but pure noise. Must NEVER reach opus. */
+function lockfileBumpDiff(): string {
+  let diff = `diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index abc..def 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -1,5 +1,2505 @@
+`;
+  for (let j = 0; j < 2500; j++) diff += `+  pkg${j}: 1.0.0\n`;
+  return diff;
+}
+
+/** An 1,800-line reformat of one TS file: added ≈ deleted, zero net new
+ *  declarations. Volume is high but there is no new logic — must NOT reach opus. */
+function reformatSweepDiff(): string {
+  let diff = `diff --git a/src/big.ts b/src/big.ts
+index abc..def 100644
+--- a/src/big.ts
++++ b/src/big.ts
+@@ -1,900 +1,900 @@
+`;
+  for (let j = 0; j < 900; j++) diff += `-const a${j}=${j};\n`;
+  for (let j = 0; j < 900; j++) diff += `+const a${j} = ${j};\n`;
+  return diff;
+}
+
+/** A 1,300-line non-TS/JS relocation: code moved from one Go file to another.
+ *  Net-new lines cancel to ~0 → must NOT reach opus. */
+function otherLangRelocationDiff(): string {
+  let diff = `diff --git a/server/a.go b/server/a.go
+index abc..def 100644
+--- a/server/a.go
++++ b/server/a.go
+@@ -1,1300 +1,0 @@
+`;
+  for (let j = 0; j < 1300; j++) diff += `-\tx${j} := ${j}\n`;
+  diff += `diff --git a/server/b.go b/server/b.go
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/server/b.go
+@@ -0,0 +1,1300 @@
+`;
+  for (let j = 0; j < 1300; j++) diff += `+\tx${j} := ${j}\n`;
+  return diff;
+}
+
+/** A 3,000-line new markdown doc. Docs never count toward the opus bar. */
+function bigMarkdownDiff(): string {
+  let diff = `diff --git a/docs/guide.md b/docs/guide.md
+new file mode 100644
+index 0000000..abc
+--- /dev/null
++++ b/docs/guide.md
+@@ -0,0 +1,3000 @@
+`;
+  for (let j = 0; j < 3000; j++) diff += `+line ${j}\n`;
+  return diff;
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('simplify-classify: pure logic via require()', () => {
@@ -239,9 +345,10 @@ describe('simplify-classify: pure logic via require()', () => {
     expect(decision.agentCount).toBe(0);
   });
 
-  it('never returns opus, regardless of input', () => {
-    // Code review is breadth-bound, not depth-bound — opus is never the right
-    // model. Sonnet (default) and haiku (mechanical relocations) are valid.
+  it('does not return opus for sub-architectural diffs', () => {
+    // Opus is reserved for the DEEP (architectural) tier. Ordinary diffs —
+    // relocations, typos, small/medium logic edits, even a 600-LOC change or a
+    // security touch — stay sonnet/haiku. DEEP/opus is covered in its own block.
     for (const fixture of [
       mechanicalDecompositionDiff(),
       trivialTypoDiff(),
@@ -309,6 +416,81 @@ describe('simplify-classify: decide() boundary cases', () => {
     });
     // Security hit alone does not escalate — only security + new declarations
     expect(decision.agentCount).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('simplify-classify: opus escalation (DEEP + handoff)', () => {
+  // The opus rungs are gated on genuine NEW-LOGIC evidence — net-new
+  // declarations for TS/JS, net-new lines for other code — never raw volume.
+  // The positive cases trip the bar; the negative guards prove that high
+  // volume WITHOUT new logic (lockfile bump, reformat, rename, docs) stays off
+  // opus. This block is the tuning contract for "only escalate when warranted".
+
+  it('architectural TS subsystem (>1500 LOC, ≥10 net decls) → DEEP / 3 opus agents, no handoff', () => {
+    const d = classifyDiff(deepTsjsSubsystemDiff());
+    expect(d.tier).toBe('DEEP');
+    expect(d.model).toBe('opus');
+    expect(d.agentCount).toBe(3);
+    expect(d.escalate.suggested).toBe(false);
+    expect(d.stats.tsjsLOC).toBeGreaterThan(1500);
+    expect(d.stats.tsjsNetDecls).toBeGreaterThanOrEqual(10);
+  });
+
+  it('architectural non-TS/JS diff (>1200 net-new lines) → DEEP / opus via the net-line gate', () => {
+    const d = classifyDiff(deepOtherLangDiff());
+    expect(d.tier).toBe('DEEP');
+    expect(d.model).toBe('opus');
+    expect(d.escalate.suggested).toBe(false);
+    expect(d.stats.otherNetAdded).toBeGreaterThan(1200);
+    // No TS/JS in this diff — the escalation came purely from net-new lines.
+    expect(d.stats.tsjsLOC).toBe(0);
+  });
+
+  it('extreme diff → DEEP / opus AND suggests the built-in /simplify handoff', () => {
+    const d = classifyDiff(handoffDiff());
+    expect(d.tier).toBe('DEEP');
+    expect(d.model).toBe('opus');
+    expect(d.escalate.suggested).toBe(true);
+    expect(d.escalate.target).toBe('builtin-simplify');
+    expect(typeof d.escalate.reason).toBe('string');
+  });
+
+  // ── Negative guards — high volume WITHOUT new logic must never reach opus ──
+  it('a 2,500-line lockfile bump never reaches opus (noise stripped)', () => {
+    const d = classifyDiff(lockfileBumpDiff());
+    expect(d.tier).not.toBe('DEEP');
+    expect(d.model).not.toBe('opus');
+    expect(d.stats.tsjsLOC).toBe(0);
+    expect(d.stats.otherNetAdded).toBe(0);
+  });
+
+  it('an 1,800-line reformat with zero net-new declarations never reaches opus', () => {
+    const d = classifyDiff(reformatSweepDiff());
+    expect(d.tier).not.toBe('DEEP');
+    expect(d.model).not.toBe('opus');
+    expect(d.stats.tsjsNetDecls).toBe(0);
+  });
+
+  it('a 1,300-line non-TS/JS relocation nets to ~0 and never reaches opus', () => {
+    const d = classifyDiff(otherLangRelocationDiff());
+    expect(d.tier).not.toBe('DEEP');
+    expect(d.model).not.toBe('opus');
+    expect(d.stats.otherNetAdded).toBeLessThanOrEqual(0);
+  });
+
+  it('a 3,000-line markdown doc never reaches opus (docs excluded from the bar)', () => {
+    const d = classifyDiff(bigMarkdownDiff());
+    expect(d.tier).not.toBe('DEEP');
+    expect(d.model).not.toBe('opus');
+    expect(d.stats.tsjsLOC).toBe(0);
+    expect(d.stats.otherNetAdded).toBe(0);
+  });
+
+  it('every non-DEEP decision carries a stable escalate=false shape', () => {
+    for (const fixture of [trivialTypoDiff(), smallLogicEditDiff(), largeNewLogicDiff(), mechanicalDecompositionDiff()]) {
+      const d = classifyDiff(fixture);
+      expect(d.escalate).toEqual({ suggested: false, target: null, reason: null });
+    }
   });
 });
 


### PR DESCRIPTION
## What

Adds a **DEEP** review tier to the `/flo-simplify` (`/distill`) classifier that runs a 3-agent **Opus** review automatically for genuinely architectural diffs, plus an `escalate.suggested` signal that offers a handoff to Claude Code''s built-in `/simplify` on the most extreme diffs. The Opus pass always runs as the floor; the handoff is a prompt, never an auto-switch.

Previously distill capped at NORMAL (3 Sonnet agents) and hard-banned Opus. The rationale "code review is breadth-bound" holds for ordinary review but not for *architectural* review, which is depth-bound — judging whether a large refactor picked the right abstractions is reasoning, not surveying.

## Tuning: gated on net-new-logic, never raw volume

Opus only escalates on genuine new-logic evidence, measured *net of churn*:
- **TS/JS** -> net-new declarations (`>1500 LOC + >=10 net decls` for DEEP)
- **other languages** -> net-new lines (`>1200 net-new lines`)
- noise (lockfiles, snapshots, `dist/`, `vendor/`, min/maps) and docs/data are stripped before measuring

Negative-guard tests prove the bar holds — a lockfile bump, a reformat, a non-TS/JS relocation, and a big markdown doc all stay off Opus.

## Escalation ladder
| Tier | Agents | Model | Behavior |
|---|---|---|---|
| TRIVIAL | 0 | — | gate stamp |
| SMALL | 1 | haiku/sonnet | |
| NORMAL | 3 | sonnet | cross-cutting |
| **DEEP** | 3 | **opus** | architectural — auto |
| **DEEP + handoff** | 3 | opus | + suggests built-in /simplify |

## Files
- `bin/simplify-classify.cjs` (+ byte-identical `.claude/helpers/` twin) — DEEP tier, `escalate` field, per-language family stats
- `.claude/skills/flo-simplify/SKILL.md` — DEEP docs, reversed "opus never" rule, handoff phase
- `docs/blog/distill-vs-simplify.md` — updated for bidirectional calibration
- `tests/bin/simplify-classify.test.ts` — 9 new cases (positive + negative guards)

## Dogfooding
Ran `/distill` on this branch (classified NORMAL). Its own review caught that the new-subsystem triggers used global decl counts instead of TS/JS-scoped — fixed in the third commit, plus the previously-uncovered new-subsystem test.

## Testing
- Classifier: 27/27
- Full suite Pass 1: 7981 passed / 0 failed; gate-helpers 256/256, gate-snapshot 14/14
- One unrelated pre-existing isolation flake (`daemon-lock-orphan`, a fork-contention timeout) passes 8/8 alone.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)