### PR TITLE
chore(socket): suppress usesEval false positive in anti-eval tooling

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,23 @@
+# Socket Security configuration (https://docs.socket.dev/docs/socket-yml)
+# Read by the Socket GitHub App on pull requests. Not published to npm
+# (not in package.json "files"), so this only affects moflo's own repo scans.
+version: 2
+
+issueRules:
+  # ── usesEval: suppressed (confirmed false positive) ──────────────────────
+  # MoFlo NEVER calls eval() or new Function(). The only occurrences of the
+  # text "eval(" in the codebase are part of moflo's OWN anti-eval security
+  # tooling — non-executable string literals and regexes:
+  #
+  #   src/cli/commands/security.ts:139  — /eval\s*\(/g regex used by the
+  #       `flo security` scanner to DETECT eval in the user's scanned code.
+  #   src/cli/commands/neural.ts:1461   — 'eval(' in a blocklist that REJECTS
+  #       neural patterns containing dangerous tokens.
+  #   src/cli/guidance/analyzer.ts:2655 — { must-not-contain: 'eval(' } guidance
+  #       assertion that FORBIDS generated code from using eval.
+  #
+  # These are the defensive side of the ledger; removing/obfuscating them would
+  # weaken moflo's posture, not improve it. moflo's own gates (the scanner +
+  # the must-not-contain assertion) plus code review remain the active guard
+  # against a real eval being introduced.
+  usesEval: false


### PR DESCRIPTION
## Summary
- MoFlo never calls `eval()` or `new Function()`. Verified across source and the published `dist/` output — there are zero real call sites.
- The only occurrences of the text `eval(` are non-executable string literals / regexes in moflo's **own anti-eval security tooling**:
  - `src/cli/commands/security.ts:139` — `/eval\s*\(/g` regex the `flo security` scanner uses to **detect** eval in the user's scanned code.
  - `src/cli/commands/neural.ts:1461` — `'eval('` in a blocklist that **rejects** neural patterns containing dangerous tokens.
  - `src/cli/guidance/analyzer.ts:2655` — `must-not-contain: 'eval('` guidance assertion that **forbids** generated code from using eval.
- Adds a documented `socket.yml` (`issueRules: usesEval: false`) so the Socket GitHub App stops raising the `usesEval` alert on repo PR scans.

## Notes
- `socket.yml` is **not** in `package.json`'s `files` allowlist, so it is not published to consumer installs — it only affects moflo's own repo scans.
- Tradeoff: `issueRules` is repo-wide for the eval alert (Socket offers no per-line first-party suppression; the `@SocketSecurity ignore` bot command is dependency-only). moflo's own gates (the scanner + the must-not-contain assertion) plus code review remain the active guard against a real eval being introduced.
- Socket's public package report at socket.dev/npm/package/moflo is a separate surface computed from the tarball and is unaffected by this config.

## Test plan
- [x] `socket.yml` parses as valid YAML (`version: 2`, `issueRules.usesEval: false`)
- [ ] Socket GitHub App PR check no longer reports `usesEval`

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)