### PR TITLE
feat(memory): durable-only shared store for cross-worktree learnings (#1232)

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -2112,13 +2112,25 @@ try {
 // learnings back into the local DB. Runs BEFORE the daemon spawns so the
 // freshly-seeded rows are present when the daemon builds its in-memory HNSW
 // index — that's what makes the cross-worktree repro (#1231) pass. No-op when
-// the feature is off, so consumers without a durable_path pay only a config
-// parse. Best-effort: a sync failure must never block session start.
+// the feature is off. Best-effort: a sync failure must never block session start.
 try {
-  const durablePaths = [
-    resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/durable-sync.js'),
-    resolve(projectRoot, 'dist/src/cli/services/durable-sync.js'),
-  ];
+  // Cheap pre-gate so solo users (the overwhelming majority) pay nothing here —
+  // no module load, no moflo.yaml parse. The feature is only live when the env
+  // override is set or moflo.yaml has an UNcommented `durable_path:` line (the
+  // generated config ships a commented example, which this regex ignores).
+  const durableYamlPath = resolve(projectRoot, 'moflo.yaml');
+  let durableEnabled = Boolean(process.env.MOFLO_DURABLE_PATH);
+  if (!durableEnabled && existsSync(durableYamlPath)) {
+    try {
+      durableEnabled = /^[ \t]*durable_path[ \t]*:/m.test(readFileSync(durableYamlPath, 'utf-8'));
+    } catch { /* unreadable yaml — treat as not-configured */ }
+  }
+  const durablePaths = durableEnabled
+    ? [
+        resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/durable-sync.js'),
+        resolve(projectRoot, 'dist/src/cli/services/durable-sync.js'),
+      ]
+    : [];
   const durablePath = durablePaths.find((p) => existsSync(p));
   if (durablePath) {
     const { syncDurableAtSessionStart } = await import(pathToFileURL(durablePath).href);

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -2106,6 +2106,44 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
+// ── 3e-1232. Sync durable namespaces with the shared store BEFORE daemon ────
+// When `memory.durable_path` (or MOFLO_DURABLE_PATH) is set, flush this
+// worktree's learnings to the shared store and seed any sibling-workspace
+// learnings back into the local DB. Runs BEFORE the daemon spawns so the
+// freshly-seeded rows are present when the daemon builds its in-memory HNSW
+// index — that's what makes the cross-worktree repro (#1231) pass. No-op when
+// the feature is off, so consumers without a durable_path pay only a config
+// parse. Best-effort: a sync failure must never block session start.
+try {
+  const durablePaths = [
+    resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/durable-sync.js'),
+    resolve(projectRoot, 'dist/src/cli/services/durable-sync.js'),
+  ];
+  const durablePath = durablePaths.find((p) => existsSync(p));
+  if (durablePath) {
+    const { syncDurableAtSessionStart } = await import(pathToFileURL(durablePath).href);
+    const result = await syncDurableAtSessionStart({ projectRoot });
+    if (result?.seededToLocal > 0) {
+      emitMutation(
+        'seeded shared learnings',
+        `${plural(result.seededToLocal, 'durable entry')} pulled from the shared store`,
+      );
+    }
+    if (result?.flushedToShared > 0) {
+      emitMutation(
+        'shared local learnings',
+        `${plural(result.flushedToShared, 'durable entry')} pushed to the shared store`,
+      );
+    }
+  }
+} catch (err) {
+  // Non-fatal — durable sync reconciles on the next session start.
+  try {
+    const msg = err && err.message ? err.message : String(err);
+    process.stderr.write(`durable-memory sync skipped: ${msg}\n`);
+  } catch { /* writing the failure itself must not throw */ }
+}
+
 // ── 3e-1057. Run unmet schema migrations BEFORE daemon spawn ────────────────
 // run-migrations.mjs walks `bin/migrations/*.mjs` and invokes each that has
 // not been recorded in `.moflo/migrations.json`. Each migration opens sql.js

--- a/src/cli/__tests__/memory/store-entry-routing.test.ts
+++ b/src/cli/__tests__/memory/store-entry-routing.test.ts
@@ -18,8 +18,11 @@ import { randomUUID } from 'node:crypto';
 // We're testing the live storeEntry/deleteEntry from memory-initializer, NOT
 // a mock — so we DON'T `vi.mock` memory-initializer here.
 
-// Mock moflo-config so daemon is enabled regardless of repo state
-const mockLoadConfig = vi.fn();
+// Mock moflo-config so daemon is enabled regardless of repo state.
+// `vi.hoisted` so the mock var is initialized before the hoisted vi.mock
+// factory runs — required now that moflo-config sits in the static import
+// graph (memory-initializer → entries-write → durable-sync → moflo-config, #1232).
+const { mockLoadConfig } = vi.hoisted(() => ({ mockLoadConfig: vi.fn() }));
 vi.mock('../../config/moflo-config.js', () => ({
   loadMofloConfig: mockLoadConfig,
 }));

--- a/src/cli/__tests__/services/durable-sync.test.ts
+++ b/src/cli/__tests__/services/durable-sync.test.ts
@@ -237,4 +237,15 @@ describe('writeThroughDurable (#1232)', () => {
       writeThroughDurable('learnings', { projectRoot: root, config: configWithDurable(root, undefined) }),
     ).resolves.toBeUndefined();
   });
+
+  it('swallows a config/path-resolution throw — never fails the caller write', async () => {
+    const root = await makeRoot('moflo-wt-');
+    // A malformed config (no `.memory`) makes resolveDurablePath throw. Since the
+    // caller's local write has ALREADY persisted, write-through must swallow it
+    // rather than propagate (the throw used to escape the try/catch — regression
+    // guard for the epic-review fix).
+    await expect(
+      writeThroughDurable('learnings', { projectRoot: root, config: {} as unknown as MofloConfig }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/src/cli/__tests__/services/durable-sync.test.ts
+++ b/src/cli/__tests__/services/durable-sync.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the cross-installation durable-memory sync (#1232, epic #1231).
+ *
+ * Covers:
+ *   - resolveDurablePath: off by default, env > config precedence, relative
+ *     resolution, and the self-reference guard.
+ *   - flush/seed round-trip: a learning written in worktree A reaches worktree
+ *     B's local DB through a shared store (the original #1231 repro, at the
+ *     service layer).
+ *   - syncDurableAtSessionStart: bidirectional union, no-op when unconfigured.
+ *   - writeThroughDurable: propagates durable namespaces, no-ops non-durable
+ *     namespaces and the unconfigured case (byte-identical behaviour AC).
+ *
+ * Uses real node:sqlite DBs in tmp dirs — the sync is pure file IO with no
+ * daemon, so it exercises the genuine copy path. All paths go through
+ * path.join / os.tmpdir for cross-platform safety (Rule #1).
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  resolveDurablePath,
+  seedDurableFromShared,
+  flushDurableToShared,
+  syncDurableAtSessionStart,
+  writeThroughDurable,
+} from '../../services/durable-sync.js';
+import { loadMofloConfig, type MofloConfig } from '../../config/moflo-config.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch {
+      /* Windows file-lock — non-fatal for tests */
+    }
+  }
+});
+
+// resolveDurablePath/writeThroughDurable read MOFLO_DURABLE_PATH — keep the
+// env clean between cases so one test can't leak config into the next.
+const savedEnv = process.env.MOFLO_DURABLE_PATH;
+beforeEach(() => {
+  delete process.env.MOFLO_DURABLE_PATH;
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.MOFLO_DURABLE_PATH;
+  else process.env.MOFLO_DURABLE_PATH = savedEnv;
+});
+
+async function makeRoot(prefix = 'moflo-durable-'): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+/** Config with an explicit durable_path, built off the real defaults. */
+function configWithDurable(root: string, durablePath?: string): MofloConfig {
+  const cfg = loadMofloConfig(root);
+  cfg.memory.durable_path = durablePath;
+  return cfg;
+}
+
+/** Seed a V3 memory DB at `dbPath` with the given (namespace, key) rows. */
+function makeDbWith(
+  dbPath: string,
+  rows: Array<{ key: string; namespace: string; content?: string; embedding?: number[] }>,
+): Promise<void> {
+  return makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const r of rows) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, embedding) VALUES (?, ?, ?, ?, ?)`,
+        [
+          `id-${r.namespace}-${r.key}`,
+          r.key,
+          r.namespace,
+          r.content ?? `content-${r.key}`,
+          r.embedding ? JSON.stringify(r.embedding) : null,
+        ],
+      );
+    }
+  });
+}
+
+function readRows(dbPath: string): Array<{ namespace: string; key: string; embedding: string | null }> {
+  if (!existsSync(dbPath)) return [];
+  const db = new DatabaseSync(dbPath);
+  try {
+    return db.prepare(
+      `SELECT namespace, key, embedding FROM memory_entries ORDER BY namespace, key`,
+    ).all() as Array<{ namespace: string; key: string; embedding: string | null }>;
+  } finally {
+    db.close();
+  }
+}
+
+describe('resolveDurablePath (#1232)', () => {
+  it('returns null (not-configured) when no env and no config', async () => {
+    const root = await makeRoot();
+    const r = resolveDurablePath(root, configWithDurable(root, undefined));
+    expect(r.path).toBeNull();
+    expect(r.skipped).toBe('not-configured');
+  });
+
+  it('uses memory.durable_path from config (absolute)', async () => {
+    const root = await makeRoot();
+    const shared = join(await makeRoot('moflo-shared-'), 'durable.db');
+    const r = resolveDurablePath(root, configWithDurable(root, shared));
+    expect(r.path).toBe(shared);
+  });
+
+  it('resolves a relative durable_path against the project root', async () => {
+    const root = await makeRoot();
+    const r = resolveDurablePath(root, configWithDurable(root, 'shared/durable.db'));
+    expect(r.path).toBe(join(root, 'shared', 'durable.db'));
+  });
+
+  it('env MOFLO_DURABLE_PATH takes precedence over config', async () => {
+    const root = await makeRoot();
+    const envShared = join(await makeRoot('moflo-env-'), 'env-durable.db');
+    process.env.MOFLO_DURABLE_PATH = envShared;
+    const r = resolveDurablePath(root, configWithDurable(root, '/some/config/path.db'));
+    expect(r.path).toBe(envShared);
+  });
+
+  it('guards against the durable path aliasing the local DB', async () => {
+    const root = await makeRoot();
+    const r = resolveDurablePath(root, configWithDurable(root, memoryDbPath(root)));
+    expect(r.path).toBeNull();
+    expect(r.skipped).toBe('same-as-local');
+  });
+});
+
+describe('flush + seed round-trip (#1231 repro at service layer)', () => {
+  it('a learning in worktree A reaches worktree B via the shared store', async () => {
+    const rootA = await makeRoot('moflo-wtA-');
+    const rootB = await makeRoot('moflo-wtB-');
+    const shared = join(await makeRoot('moflo-shared-'), 'durable.db');
+
+    // A has a learning (with an embedding so search would work post-seed).
+    await makeDbWith(memoryDbPath(rootA), [
+      { key: 'lesson-1', namespace: 'learnings', content: 'worrying does no good', embedding: [0.1, 0.2, 0.3] },
+      { key: 'codemap-1', namespace: 'code-map', content: 'structural — must NOT travel' },
+    ]);
+    // B starts empty (fresh worktree, no local DB yet).
+
+    const flush = await flushDurableToShared(rootA, shared);
+    expect(flush.copied).toBe(1); // only the learning, not the code-map row
+
+    const seed = await seedDurableFromShared(rootB, shared);
+    expect(seed.copied).toBe(1);
+
+    const bRows = readRows(memoryDbPath(rootB));
+    expect(bRows).toHaveLength(1);
+    expect(bRows[0]).toMatchObject({ namespace: 'learnings', key: 'lesson-1' });
+    // Embedding carried forward verbatim → searchable in B.
+    expect(bRows[0].embedding).toBe(JSON.stringify([0.1, 0.2, 0.3]));
+    // Structural namespace stayed local to A — never entered the shared store.
+    expect(readRows(shared).some((r) => r.namespace === 'code-map')).toBe(false);
+  });
+
+  it('seed is a no-op when the shared store does not exist yet', async () => {
+    const root = await makeRoot();
+    const shared = join(await makeRoot('moflo-shared-'), 'missing.db');
+    const seed = await seedDurableFromShared(root, shared);
+    expect(seed.copied).toBe(0);
+    expect(existsSync(memoryDbPath(root))).toBe(false);
+  });
+});
+
+describe('syncDurableAtSessionStart (#1232)', () => {
+  it('unions durable rows in both directions', async () => {
+    const root = await makeRoot('moflo-wt-');
+    const shared = join(await makeRoot('moflo-shared-'), 'durable.db');
+
+    // Local has X; shared already has Y (from a sibling workspace).
+    await makeDbWith(memoryDbPath(root), [{ key: 'local-x', namespace: 'learnings' }]);
+    await makeDbWith(shared, [{ key: 'shared-y', namespace: 'learnings' }]);
+
+    const report = await syncDurableAtSessionStart({ projectRoot: root, config: configWithDurable(root, shared) });
+    expect(report.durablePath).toBe(shared);
+    expect(report.flushedToShared).toBe(1); // local-x → shared
+    expect(report.seededToLocal).toBe(1); // shared-y → local
+
+    const localKeys = readRows(memoryDbPath(root)).map((r) => r.key).sort();
+    const sharedKeys = readRows(shared).map((r) => r.key).sort();
+    expect(localKeys).toEqual(['local-x', 'shared-y']);
+    expect(sharedKeys).toEqual(['local-x', 'shared-y']);
+  });
+
+  it('is a no-op when unconfigured (no files touched)', async () => {
+    const root = await makeRoot();
+    const report = await syncDurableAtSessionStart({ projectRoot: root, config: configWithDurable(root, undefined) });
+    expect(report.durablePath).toBeNull();
+    expect(report.skipped).toBe('not-configured');
+    expect(report.flushedToShared).toBe(0);
+    expect(report.seededToLocal).toBe(0);
+    expect(existsSync(memoryDbPath(root))).toBe(false);
+  });
+});
+
+describe('writeThroughDurable (#1232)', () => {
+  it('propagates a durable namespace to the shared store', async () => {
+    const root = await makeRoot('moflo-wt-');
+    const shared = join(await makeRoot('moflo-shared-'), 'durable.db');
+    await makeDbWith(memoryDbPath(root), [{ key: 'fresh-lesson', namespace: 'learnings' }]);
+
+    await writeThroughDurable('learnings', { projectRoot: root, config: configWithDurable(root, shared) });
+
+    expect(readRows(shared).map((r) => r.key)).toEqual(['fresh-lesson']);
+  });
+
+  it('no-ops for a non-durable namespace', async () => {
+    const root = await makeRoot('moflo-wt-');
+    const shared = join(await makeRoot('moflo-shared-'), 'durable.db');
+    await makeDbWith(memoryDbPath(root), [{ key: 'cm', namespace: 'code-map' }]);
+
+    await writeThroughDurable('code-map', { projectRoot: root, config: configWithDurable(root, shared) });
+
+    expect(existsSync(shared)).toBe(false);
+  });
+
+  it('no-ops when the feature is off (byte-identical behaviour)', async () => {
+    const root = await makeRoot('moflo-wt-');
+    await makeDbWith(memoryDbPath(root), [{ key: 'lesson', namespace: 'learnings' }]);
+    // No durable_path configured anywhere — must not throw, must not create state.
+    await expect(
+      writeThroughDurable('learnings', { projectRoot: root, config: configWithDurable(root, undefined) }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -95,6 +95,19 @@ export interface MofloConfig {
     backend: MofloMemoryBackend;
     embedding_model: string;
     namespace: string;
+    /**
+     * Optional absolute path to a **durable-only** shared memory DB (#1232).
+     * When set, the durable namespaces (`learnings`, `knowledge`) are seeded
+     * from this store on session-start and written through to it on each
+     * durable write, so every git worktree / Conductor workspace of the same
+     * project shares one learnings store while structural namespaces stay
+     * local per checkout. Absent (the default) → behavior is unchanged.
+     *
+     * Resolved absolute (relative values are taken against the project root)
+     * and overridable per-process via the `MOFLO_DURABLE_PATH` env var. See
+     * `src/cli/services/durable-sync.ts`.
+     */
+    durable_path?: string;
   };
 
   hooks: {
@@ -392,6 +405,14 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
       backend: coerceMemoryBackend(raw.memory?.backend),
       embedding_model: raw.memory?.embedding_model || raw.memory?.embeddingModel || DEFAULT_CONFIG.memory.embedding_model,
       namespace: raw.memory?.namespace || DEFAULT_CONFIG.memory.namespace,
+      // #1232 — optional shared durable store. Accept snake_case + camelCase;
+      // a non-string (or absent) value leaves the feature off. Resolution to
+      // an absolute path happens lazily in durable-sync.ts, not here, so the
+      // launcher's cold-start config parse stays path-IO-free.
+      durable_path: (() => {
+        const v = raw.memory?.durable_path ?? raw.memory?.durablePath;
+        return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+      })(),
     },
     hooks: {
       pre_edit: raw.hooks?.pre_edit ?? raw.hooks?.preEdit ?? DEFAULT_CONFIG.hooks.pre_edit,
@@ -600,6 +621,11 @@ memory:
   backend: node-sqlite         # node-sqlite (default) | rvf (pure-TS fallback) | json (last resort). Passed to createDatabase() as the preferred provider.
   embedding_model: Xenova/all-MiniLM-L6-v2
   namespace: default
+  # durable_path: /abs/path/outside/repo/moflo-durable.db
+  #   Optional shared store for durable namespaces (learnings, knowledge) so all
+  #   git worktrees / Conductor workspaces of this project share one learnings DB.
+  #   Structural namespaces (code-map, guidance, tests) stay local per checkout.
+  #   Absolute path recommended; overridable per-process via MOFLO_DURABLE_PATH.
 
 # Hook toggles (all on by default — disable to slim down)
 hooks:

--- a/src/cli/memory/entries-write.ts
+++ b/src/cli/memory/entries-write.ts
@@ -11,8 +11,10 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { memoryDbPath } from '../services/moflo-paths.js';
+import { findProjectRoot } from '../services/project-root.js';
 import { openDaemonDatabase } from './daemon-backend.js';
 import { ensureSchemaColumns } from './schema.js';
 import { generateEmbedding } from './embedding-model.js';
@@ -23,6 +25,23 @@ import { EMBEDDING_MODEL_OPT_OUT, getBridgeEmbedder, isEphemeralNamespace } from
 import { toFloat32 } from './controllers/_shared.js';
 import { serialiseMetadata } from './bridge-entries.js';
 import { logRoutingFault, writeVectorStatsCache } from './entries-shared.js';
+import { writeThroughDurable } from '../services/durable-sync.js';
+
+/**
+ * Propagate a just-persisted durable write to the shared store (#1232). The
+ * caller passes the project root the row actually landed under so the flush
+ * sources from the SAME `.moflo/moflo.db` (process.cwd() can differ from the
+ * project root in subshells/tests). In the long-lived daemon the flush is
+ * fire-and-forget so it never adds shared-store I/O latency to the user's
+ * write; a short-lived CLI process awaits it so it can't exit before the row
+ * reaches the shared store. `writeThroughDurable` swallows its own errors and
+ * is a no-op unless `memory.durable_path` is set, so this is safe either way.
+ */
+async function propagateDurable(namespace: string, projectRoot: string): Promise<void> {
+  const flush = writeThroughDurable(namespace, { projectRoot });
+  if (process.env.MOFLO_IS_DAEMON === '1') { void flush; return; }
+  await flush;
+}
 
 /**
  * Store an entry directly via node:sqlite.
@@ -127,7 +146,16 @@ export async function storeEntry(options: {
   const bridge = await getBridge();
   if (bridge) {
     const bridgeResult = await bridge.bridgeStoreEntry(options);
-    if (bridgeResult) return bridgeResult;
+    if (bridgeResult) {
+      // #1232 — propagate durable writes to the shared store. Best-effort and
+      // guarded; a no-op unless `memory.durable_path` is configured AND this is
+      // a durable namespace. When the daemon handled a routed write it reaches
+      // this same bridge path, so the flush happens exactly once (in whichever
+      // process actually persisted the row). The bridge resolves its DB via
+      // findProjectRoot(), so source the flush from the same root.
+      if (bridgeResult.success) await propagateDurable(options.namespace ?? 'default', findProjectRoot());
+      return bridgeResult;
+    }
   }
 
   // Fallback: direct node:sqlite write via the unified factory.
@@ -283,6 +311,13 @@ export async function storeEntry(options: {
 
     // Update statusline cache with exact counts
     writeVectorStatsCache(dbPath, { vectorCount: vecCount, namespaces: nsCount, missing: missingCount });
+
+    // #1232 — write-through durable namespaces to the shared store (no-op
+    // unless configured). Mirrors the bridge path above for the direct-write
+    // fallback. Source the flush from the root the row actually landed under
+    // (`dbPath` = <root>/.moflo/moflo.db) rather than process.cwd(), which can
+    // differ from the project root.
+    await propagateDurable(namespace, path.dirname(path.dirname(dbPath)));
 
     return {
       success: true,

--- a/src/cli/services/cherry-pick-learnings.ts
+++ b/src/cli/services/cherry-pick-learnings.ts
@@ -46,6 +46,20 @@ import { openDaemonDatabase, type SqlJsLikeDatabase } from '../memory/daemon-bac
 /** Namespaces preserved across upgrades. Everything else is derived. */
 export const DURABLE_NAMESPACES = ['learnings', 'knowledge'] as const;
 
+const DURABLE_NAMESPACE_SET: ReadonlySet<string> = new Set(DURABLE_NAMESPACES);
+
+/**
+ * Return `true` if a namespace is durable (user-authored, worth sharing across
+ * installations) — i.e. a member of {@link DURABLE_NAMESPACES}. Used by the
+ * cross-installation sharing layer (#1232) to decide which writes flow through
+ * to a shared durable store. Note `knowledge` writes are soft-redirected to
+ * `learnings` before reaching the write path, so in practice this matches
+ * `learnings`; `knowledge` is kept for back-compat reads.
+ */
+export function isDurableNamespace(namespace: string): boolean {
+  return DURABLE_NAMESPACE_SET.has(namespace);
+}
+
 /**
  * Reasons a single source contributed zero rows. Exported so callers can
  * branch on the cause without duplicating string literals.

--- a/src/cli/services/durable-sync.ts
+++ b/src/cli/services/durable-sync.ts
@@ -180,13 +180,16 @@ export async function writeThroughDurable(
   opts: { projectRoot?: string; config?: MofloConfig } = {},
 ): Promise<void> {
   if (!isDurableNamespace(namespace)) return;
-  const projectRoot = opts.projectRoot ?? findProjectRoot();
-  const { path: durablePath } = resolveDurablePath(projectRoot, opts.config);
-  if (!durablePath) return;
   try {
+    // Everything after the cheap namespace check is inside the guard: a throw
+    // from findProjectRoot / loadMofloConfig (inside resolveDurablePath) / the
+    // flush must NEVER fail the caller's write, which has already persisted.
+    // Write-through is advisory — the next session-start flush reconciles.
+    const projectRoot = opts.projectRoot ?? findProjectRoot();
+    const { path: durablePath } = resolveDurablePath(projectRoot, opts.config);
+    if (!durablePath) return;
     await flushDurableToShared(projectRoot, durablePath);
   } catch {
-    // Write-through is advisory; the local write already succeeded. The next
-    // session-start flush will reconcile. Never surface this to the caller.
+    // Swallow entirely — see the rationale above.
   }
 }

--- a/src/cli/services/durable-sync.ts
+++ b/src/cli/services/durable-sync.ts
@@ -1,0 +1,192 @@
+/**
+ * Cross-installation durable-memory sharing (#1232, epic #1231).
+ *
+ * Problem: `.moflo/` is gitignored, so every git worktree / Conductor
+ * workspace of the same project starts with an empty `learnings` namespace —
+ * durable knowledge is lost when a workspace rotates.
+ *
+ * Solution: an optional **durable-only** shared SQLite store (configured via
+ * `memory.durable_path` in moflo.yaml or the `MOFLO_DURABLE_PATH` env). It
+ * holds ONLY the durable namespaces ({@link DURABLE_NAMESPACES} — `learnings`,
+ * `knowledge`). Each install keeps its own local `.moflo/moflo.db` for
+ * structural + ephemeral namespaces (which are branch-specific and cheaply
+ * re-indexable, so sharing them would churn/stale). Two flows keep the
+ * durable slice in sync:
+ *
+ *   - **seed** (shared → local) on session-start, so a fresh workspace inherits
+ *     accumulated learnings.
+ *   - **flush / write-through** (local → shared) on session-start and after
+ *     every durable write, so a new learning propagates to sibling workspaces
+ *     by their next session-start.
+ *
+ * Both directions are a single call to {@link cherryPickLearningsFromLegacy}
+ * with source/target swapped — it already copies durable rows with
+ * `INSERT OR IGNORE` on `UNIQUE(namespace, key)` (conflict-free, idempotent,
+ * embeddings carried forward verbatim). No new SQL lives here.
+ *
+ * Safety: the shared store is a plain transfer DB — moflo never *searches* it
+ * directly, so it has no HNSW sidecar and no index-divergence concern. Row
+ * writes are append-mostly and low-frequency (only `/meditate`, "remember
+ * this", and auto-meditate write durable rows), and node:sqlite + WAL
+ * serialises concurrent writers without the sql.js whole-file clobber that
+ * older builds risked (see `cross-process-writer-race-1061.test.ts`).
+ *
+ * @module cli/services/durable-sync
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { findProjectRoot } from './project-root.js';
+import { normalizeProjectRoot } from './daemon-port.js';
+import { memoryDbPath } from './moflo-paths.js';
+import { loadMofloConfig, type MofloConfig } from '../config/moflo-config.js';
+import {
+  cherryPickLearningsFromLegacy,
+  DURABLE_NAMESPACES,
+  isDurableNamespace,
+  type CherryPickResult,
+} from './cherry-pick-learnings.js';
+
+export { isDurableNamespace };
+
+/** Per-direction outcome for {@link syncDurableAtSessionStart}. */
+export interface DurableSyncReport {
+  /** Resolved absolute durable-store path, or `null` when the feature is off. */
+  durablePath: string | null;
+  /** Reason the sync was a no-op, when `durablePath` is null. */
+  skipped?: 'not-configured' | 'same-as-local';
+  /** Rows copied local → shared (flush direction). */
+  flushedToShared: number;
+  /** Rows copied shared → local (seed direction). */
+  seededToLocal: number;
+}
+
+/**
+ * Resolve a path that may not exist yet to a stable absolute form for identity
+ * comparison. Reuses {@link normalizeProjectRoot} (the #1145 reference impl) so
+ * both sides of any comparison fold identically: it realpath's symlinks (macOS
+ * `/var/folders` → `/private/var/folders`) and lowercases on Windows (NTFS is
+ * case-insensitive). When the target doesn't exist yet — the common first-flush
+ * case — we realpath the nearest existing parent and rejoin the tail so a
+ * symlinked parent dir still normalises identically (Rule #1).
+ */
+function stableAbsolute(p: string): string {
+  const abs = path.resolve(p);
+  if (fs.existsSync(abs)) return normalizeProjectRoot(abs);
+  return normalizeProjectRoot(path.join(normalizeProjectRoot(path.dirname(abs)), path.basename(abs)));
+}
+
+/**
+ * Resolve the configured durable-store path to an absolute path, or `null`
+ * when the feature is off (no env, no `memory.durable_path`) or misconfigured
+ * (points at this project's own local DB — syncing a DB with itself is a
+ * no-op, so we disable rather than thrash).
+ *
+ * Precedence: `MOFLO_DURABLE_PATH` env > `memory.durable_path` (moflo.yaml).
+ * Relative values resolve against the project root.
+ */
+export function resolveDurablePath(
+  projectRoot: string = findProjectRoot(),
+  config?: MofloConfig,
+): { path: string | null; skipped?: DurableSyncReport['skipped'] } {
+  const envRaw = process.env.MOFLO_DURABLE_PATH?.trim();
+  const cfgRaw = (config ?? loadMofloConfig(projectRoot)).memory.durable_path?.trim();
+  const raw = envRaw && envRaw.length > 0 ? envRaw : cfgRaw;
+  if (!raw) return { path: null, skipped: 'not-configured' };
+
+  const abs = path.isAbsolute(raw) ? path.resolve(raw) : path.resolve(projectRoot, raw);
+  // Self-reference guard — never let the shared store alias the local DB.
+  if (stableAbsolute(abs) === stableAbsolute(memoryDbPath(projectRoot))) {
+    return { path: null, skipped: 'same-as-local' };
+  }
+  return { path: abs };
+}
+
+/**
+ * Seed durable rows from the shared store into this project's local DB.
+ * Shared is the source, local `.moflo/moflo.db` the target. No-op when the
+ * shared store doesn't exist yet (nothing to seed).
+ */
+export async function seedDurableFromShared(
+  projectRoot: string,
+  durablePath: string,
+): Promise<CherryPickResult> {
+  return cherryPickLearningsFromLegacy({
+    projectRoot,
+    legacyPaths: [durablePath],
+    toPath: memoryDbPath(projectRoot),
+    namespaces: DURABLE_NAMESPACES,
+  });
+}
+
+/**
+ * Flush durable rows from this project's local DB into the shared store.
+ * Local is the source, the shared store the target (created on first flush).
+ */
+export async function flushDurableToShared(
+  projectRoot: string,
+  durablePath: string,
+): Promise<CherryPickResult> {
+  return cherryPickLearningsFromLegacy({
+    projectRoot,
+    legacyPaths: [memoryDbPath(projectRoot)],
+    toPath: durablePath,
+    namespaces: DURABLE_NAMESPACES,
+  });
+}
+
+/**
+ * Bidirectional durable sync run once at session-start: flush local → shared
+ * (bootstraps pre-existing local learnings into the shared store), then seed
+ * shared → local (pulls in sibling workspaces' learnings). Both directions are
+ * `INSERT OR IGNORE`, so the result is the union of durable rows on both sides
+ * with no conflicts. Safe to call unconditionally — a no-op when unconfigured.
+ *
+ * Intended to run BEFORE the daemon starts so the freshly-seeded rows are
+ * present when the daemon builds its in-memory HNSW index.
+ */
+export async function syncDurableAtSessionStart(
+  opts: { projectRoot?: string; config?: MofloConfig } = {},
+): Promise<DurableSyncReport> {
+  const projectRoot = opts.projectRoot ?? findProjectRoot();
+  const { path: durablePath, skipped } = resolveDurablePath(projectRoot, opts.config);
+  if (!durablePath) {
+    return { durablePath: null, skipped, flushedToShared: 0, seededToLocal: 0 };
+  }
+
+  // Flush first so this worktree's existing learnings land in the shared store
+  // before we seed — keeps the very first opt-in symmetric across workspaces.
+  const flush = await flushDurableToShared(projectRoot, durablePath);
+  const seed = await seedDurableFromShared(projectRoot, durablePath);
+  return {
+    durablePath,
+    flushedToShared: flush.copied,
+    seededToLocal: seed.copied,
+  };
+}
+
+/**
+ * Write-through hook: after a durable-namespace write lands in the local DB,
+ * propagate the durable slice to the shared store so sibling workspaces see it
+ * on their next session-start (or sooner). Best-effort and fully guarded — a
+ * misconfigured or unreachable shared store never fails the original write.
+ *
+ * No-op (returns immediately, zero IO) when the namespace isn't durable or the
+ * feature is off, so consumers without `durable_path` see byte-identical
+ * behaviour to today.
+ */
+export async function writeThroughDurable(
+  namespace: string,
+  opts: { projectRoot?: string; config?: MofloConfig } = {},
+): Promise<void> {
+  if (!isDurableNamespace(namespace)) return;
+  const projectRoot = opts.projectRoot ?? findProjectRoot();
+  const { path: durablePath } = resolveDurablePath(projectRoot, opts.config);
+  if (!durablePath) return;
+  try {
+    await flushDurableToShared(projectRoot, durablePath);
+  } catch {
+    // Write-through is advisory; the local write already succeeded. The next
+    // session-start flush will reconcile. Never surface this to the caller.
+  }
+}


### PR DESCRIPTION
## Summary

First story of epic #1231 (sharing moflo knowledge across installations). Adds an optional **durable-only shared memory store** so all git worktrees / Conductor workspaces of a project share one `learnings` DB, while structural namespaces stay local per checkout.

Solves the original repro: a learning stored in worktree A is found in worktree B after B's next session-start — without sharing the whole DB (which would churn `code-map` across branches and cause HNSW index divergence).

## How it works

- **`memory.durable_path`** config (+ `MOFLO_DURABLE_PATH` env), **default off** → byte-identical behavior for existing consumers.
- Durable slice = `learnings` + `knowledge` only (the existing `DURABLE_NAMESPACES`). Everything else stays local.
- **Seed** (shared→local) at session-start + **flush / write-through** (local→shared) at session-start and after each durable write.
- Both directions are a single call to the existing `cherryPickLearningsFromLegacy` with source/target swapped — `INSERT OR IGNORE` on `UNIQUE(namespace,key)`, embeddings carried forward, **no new SQL**.
- The shared store is a plain transfer DB (never searched directly) → **no HNSW sidecar, no index divergence**; node:sqlite + WAL keeps concurrent writers safe (no sql.js clobber).

## Changes

- `src/cli/services/durable-sync.ts` (new) — `resolveDurablePath`, `seedDurableFromShared`, `flushDurableToShared`, `syncDurableAtSessionStart`, `writeThroughDurable`.
- `src/cli/services/cherry-pick-learnings.ts` — `isDurableNamespace` helper.
- `src/cli/config/moflo-config.ts` — optional `memory.durable_path` (parse + generated-yaml comment).
- `src/cli/memory/entries-write.ts` — write-through after bridge + direct persist (fires once in whichever process persists).
- `bin/session-start-launcher.mjs` — always-run seed block before daemon spawn.

## Cross-platform / blast radius (Rules #1 & #2)

- Path identity reuses `normalizeProjectRoot` (realpath symlinks + Windows case-fold, #1145) — both sides fold identically.
- Flush sources from the same project root the write landed under (not `process.cwd()`, which can differ in subshells/tests).
- Daemon write-through is fire-and-forget (no added latency); a short-lived CLI awaits so it can't exit before the flush completes.
- Feature off by default → zero change for consumers without `durable_path`.

## Testing

- [x] New `durable-sync.test.ts` — 12 cases: resolve precedence/relative/self-guard, flush+seed A→B round-trip (with embedding carry + structural-namespace isolation), bidirectional union, write-through (durable / non-durable / off), no-op-when-unconfigured.
- [x] Full `memory/` + `services/` suites green (761 tests).
- [x] Config, routing, cherry-pick, drift-guard, project-root-twin suites green.
- [ ] Manual end-to-end in a real Conductor setup (follow-up).

## Known v1 tradeoff

`writeThroughDurable` re-copies all durable rows local→shared per durable write (`INSERT OR IGNORE`, most are no-ops). Bounded and rare (only `/meditate`, "remember this", auto-meditate); a `max(updated_at)` high-water mark is the follow-up optimization.

Closes #1232

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
