### PR TITLE
feat(memory): flo memory sync — portable durable artifact for multi-machine sharing (#1233)

### DIFF
--- a/src/cli/__tests__/commands/memory-sync.test.ts
+++ b/src/cli/__tests__/commands/memory-sync.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for `flo memory sync` (#1233, epic #1231).
+ *
+ * The sync command wraps the durable cherry-pick primitive into one
+ * direction-aware verb for same-user multi-machine sharing:
+ *   --to <path>    export the durable slice (learnings, knowledge) to an artifact
+ *   --from <path>  merge an artifact back into the local DB
+ *
+ * We drive the command's `action` directly with a mocked `findProjectRoot` so we
+ * can point the "project root" at a tmp dir and exercise the genuine copy path
+ * (real node:sqlite DBs, no daemon). All paths go through path.join / os.tmpdir
+ * for cross-platform safety (Rule #1).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+// findProjectRoot is the only cwd-dependent input — pin it to a tmp root per test.
+const hoisted = vi.hoisted(() => ({ root: '' }));
+vi.mock('../../services/project-root.js', () => ({
+  findProjectRoot: () => hoisted.root,
+}));
+
+import { memoryCommand } from '../../commands/memory.js';
+import { output } from '../../output.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+import type { CommandContext, CommandResult, Command } from '../../types.js';
+
+const syncCommand = memoryCommand.subcommands!.find((c) => c.name === 'sync') as Command;
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch {
+      /* Windows file-lock — non-fatal for tests */
+    }
+  }
+});
+
+async function makeRoot(prefix = 'moflo-sync-'): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function ctxWith(flags: Record<string, string>): CommandContext {
+  return { args: [], flags: { _: [], ...flags }, cwd: hoisted.root, interactive: false };
+}
+
+/** Run the sync action against a given project root. */
+function runSync(root: string, flags: Record<string, string>): Promise<CommandResult> {
+  hoisted.root = root;
+  return syncCommand.action!(ctxWith(flags));
+}
+
+function makeDbWith(
+  dbPath: string,
+  rows: Array<{ key: string; namespace: string; content?: string; embedding?: number[] }>,
+): Promise<void> {
+  return makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const r of rows) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, embedding) VALUES (?, ?, ?, ?, ?)`,
+        [
+          `id-${r.namespace}-${r.key}`,
+          r.key,
+          r.namespace,
+          r.content ?? `content-${r.key}`,
+          r.embedding ? JSON.stringify(r.embedding) : null,
+        ],
+      );
+    }
+  });
+}
+
+function readRows(dbPath: string): Array<{ namespace: string; key: string; embedding: string | null }> {
+  if (!existsSync(dbPath)) return [];
+  const db = new DatabaseSync(dbPath);
+  try {
+    return db.prepare(
+      `SELECT namespace, key, embedding FROM memory_entries ORDER BY namespace, key`,
+    ).all() as Array<{ namespace: string; key: string; embedding: string | null }>;
+  } finally {
+    db.close();
+  }
+}
+
+describe('flo memory sync — direction validation', () => {
+  it('errors when neither --to nor --from is given', async () => {
+    const root = await makeRoot();
+    const res = await runSync(root, {});
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+  });
+
+  it('errors when both --to and --from are given', async () => {
+    const root = await makeRoot();
+    const res = await runSync(root, { to: join(root, 'a.db'), from: join(root, 'b.db') });
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+  });
+});
+
+describe('flo memory sync --to (export)', () => {
+  it('writes only durable namespaces to the artifact, embeddings preserved', async () => {
+    const root = await makeRoot();
+    const artifact = join(await makeRoot('moflo-art-'), 'durable.db');
+    await makeDbWith(memoryDbPath(root), [
+      { key: 'lesson-1', namespace: 'learnings', embedding: [0.1, 0.2, 0.3] },
+      { key: 'kb-1', namespace: 'knowledge' },
+      { key: 'cm-1', namespace: 'code-map' }, // structural — must NOT travel
+    ]);
+
+    const res = await runSync(root, { to: artifact });
+    expect(res.success).toBe(true);
+    expect((res.data as { copied: number }).copied).toBe(2);
+
+    const rows = readRows(artifact);
+    expect(rows.map((r) => `${r.namespace}/${r.key}`).sort()).toEqual([
+      'knowledge/kb-1',
+      'learnings/lesson-1',
+    ]);
+    const lesson = rows.find((r) => r.key === 'lesson-1');
+    expect(lesson?.embedding).toBe(JSON.stringify([0.1, 0.2, 0.3]));
+  });
+
+  it('warns and no-ops when the local DB does not exist yet', async () => {
+    const root = await makeRoot();
+    const artifact = join(await makeRoot('moflo-art-'), 'durable.db');
+    const res = await runSync(root, { to: artifact });
+    expect(res.success).toBe(true);
+    expect(existsSync(artifact)).toBe(false);
+  });
+
+  it('expands a leading ~ to the home directory (cross-platform)', async () => {
+    const root = await makeRoot();
+    const fakeHome = await makeRoot('moflo-home-');
+    // os.homedir() reads HOME on POSIX and USERPROFILE on Windows (libuv) —
+    // set both so the test is platform-agnostic (Rule #1).
+    const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    try {
+      await makeDbWith(memoryDbPath(root), [{ key: 'l', namespace: 'learnings' }]);
+      const res = await runSync(root, { to: '~/durable.db' });
+      expect(res.success).toBe(true);
+      expect(existsSync(join(fakeHome, 'durable.db'))).toBe(true);
+    } finally {
+      for (const k of ['HOME', 'USERPROFILE'] as const) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k];
+      }
+    }
+  });
+
+  it('warns instead of claiming a copy when --to aliases the local DB', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [{ key: 'l', namespace: 'learnings' }]);
+    const warn = vi.spyOn(output, 'printWarning').mockImplementation(() => {});
+
+    const res = await runSync(root, { to: memoryDbPath(root) });
+    expect(res.success).toBe(true);
+    expect((res.data as { copied: number }).copied).toBe(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('local memory DB itself'));
+  });
+});
+
+describe('flo memory sync --from (import/merge)', () => {
+  it('merges durable rows from an artifact into the local DB', async () => {
+    const root = await makeRoot();
+    const artifact = join(await makeRoot('moflo-art-'), 'durable.db');
+    await makeDbWith(artifact, [
+      { key: 'lesson-x', namespace: 'learnings', embedding: [0.4, 0.5] },
+      { key: 'cm-x', namespace: 'code-map' }, // structural — filtered out on import
+    ]);
+
+    const res = await runSync(root, { from: artifact });
+    expect(res.success).toBe(true);
+    expect((res.data as { copied: number }).copied).toBe(1);
+
+    const localRows = readRows(memoryDbPath(root));
+    expect(localRows).toHaveLength(1);
+    expect(localRows[0]).toMatchObject({ namespace: 'learnings', key: 'lesson-x' });
+    expect(localRows[0].embedding).toBe(JSON.stringify([0.4, 0.5]));
+  });
+
+  it('is idempotent — re-running --from copies zero on the second pass', async () => {
+    const root = await makeRoot();
+    const artifact = join(await makeRoot('moflo-art-'), 'durable.db');
+    await makeDbWith(artifact, [{ key: 'lesson-y', namespace: 'learnings' }]);
+
+    const first = await runSync(root, { from: artifact });
+    expect((first.data as { copied: number }).copied).toBe(1);
+
+    const second = await runSync(root, { from: artifact });
+    expect(second.success).toBe(true);
+    expect((second.data as { copied: number }).copied).toBe(0); // INSERT OR IGNORE
+    expect(readRows(memoryDbPath(root))).toHaveLength(1);
+  });
+
+  it('errors when the artifact does not exist', async () => {
+    const root = await makeRoot();
+    const res = await runSync(root, { from: join(root, 'nope.db') });
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+  });
+
+  it('warns instead of claiming a merge when --from aliases the local DB', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [{ key: 'l', namespace: 'learnings' }]);
+    const warn = vi.spyOn(output, 'printWarning').mockImplementation(() => {});
+
+    const res = await runSync(root, { from: memoryDbPath(root) });
+    expect(res.success).toBe(true);
+    expect((res.data as { copied: number }).copied).toBe(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('local memory DB itself'));
+  });
+
+  it('warns (not errors) when the artifact is not a moflo DB', async () => {
+    const root = await makeRoot();
+    const notMoflo = join(await makeRoot('moflo-art-'), 'random.db');
+    const db = new DatabaseSync(notMoflo);
+    db.exec('CREATE TABLE unrelated (id INTEGER)');
+    db.close();
+
+    const res = await runSync(root, { from: notMoflo });
+    expect(res.success).toBe(true); // schema mismatch is a graceful no-op
+    expect(readRows(memoryDbPath(root))).toHaveLength(0);
+  });
+});
+
+describe('flo memory sync — round-trip (#1231 repro, command layer)', () => {
+  it('a learning exported from machine A appears on machine B after import', async () => {
+    const machineA = await makeRoot('moflo-A-');
+    const machineB = await makeRoot('moflo-B-');
+    const artifact = join(await makeRoot('moflo-sync-folder-'), 'durable.db');
+
+    await makeDbWith(memoryDbPath(machineA), [
+      { key: 'worry-lesson', namespace: 'learnings', content: 'worrying does no good', embedding: [0.9] },
+    ]);
+
+    const exp = await runSync(machineA, { to: artifact });
+    expect((exp.data as { copied: number }).copied).toBe(1);
+
+    const imp = await runSync(machineB, { from: artifact });
+    expect((imp.data as { copied: number }).copied).toBe(1);
+
+    const bRows = readRows(memoryDbPath(machineB));
+    expect(bRows).toEqual([{ namespace: 'learnings', key: 'worry-lesson', embedding: JSON.stringify([0.9]) }]);
+  });
+});

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as pathModule from 'path';
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
@@ -13,7 +14,7 @@ import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { openDaemonDatabase, type SqlJsLikeDatabase } from '../memory/daemon-backend.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
-import { legacySwarmPath, runtimePath } from '../services/moflo-paths.js';
+import { legacySwarmPath, runtimePath, memoryDbPath } from '../services/moflo-paths.js';
 import { resolveBridgeDbPath } from '../memory/bridge-core.js';
 import { findProjectRoot } from '../services/project-root.js';
 
@@ -2991,11 +2992,151 @@ const restoreLearningsCommand: Command = {
   },
 };
 
+/**
+ * Expand a leading `~` to the user's home directory before path resolution.
+ * `path.resolve` does NOT do this — `~/x` would resolve to `<cwd>/~/x`. Handles
+ * both POSIX (`~/`) and Windows (`~\`) separators and bare `~` (Rule #1); a
+ * `~user` form is left untouched (we only resolve the current user's home).
+ */
+function expandHome(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) {
+    return pathModule.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
+
+// Sync command (#1233, epic #1231) — portable durable artifact for same-user
+// multi-machine sharing. One durable-aware verb over the existing cherry-pick
+// primitive: it carries the durable slice (learnings, knowledge) to/from a
+// portable SQLite artifact you keep in a synced folder (Dropbox/iCloud) or copy
+// by hand. Embeddings ride along verbatim (no lossy re-embed) and the merge is
+// INSERT OR IGNORE on UNIQUE(namespace, key), so re-running --from is a no-op.
+//   --to <path>    flush local durable namespaces → artifact (created if absent)
+//   --from <path>  merge an artifact → local durable namespaces
+const syncCommand: Command = {
+  name: 'sync',
+  description: 'Export/import durable learnings to a portable artifact for multi-machine sharing',
+  options: [
+    {
+      name: 'to',
+      description: 'Write the durable slice (learnings, knowledge) to this artifact path',
+      type: 'string',
+    },
+    {
+      name: 'from',
+      description: 'Merge a durable artifact at this path into the local DB',
+      type: 'string',
+    },
+  ],
+  examples: [
+    {
+      command: 'flo memory sync --to ~/Dropbox/moflo/durable.db',
+      description: 'Export durable learnings to a synced folder',
+    },
+    {
+      command: 'flo memory sync --from ~/Dropbox/moflo/durable.db',
+      description: 'Merge durable learnings carried from another machine',
+    },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const to = ctx.flags.to as string | undefined;
+    const from = ctx.flags.from as string | undefined;
+    if ((!to && !from) || (to && from)) {
+      output.printError('Specify exactly one direction: --to <path> (export) or --from <path> (import).');
+      return { success: false, exitCode: 1 };
+    }
+
+    const projectRoot = findProjectRoot();
+    const localDb = memoryDbPath(projectRoot);
+    const { cherryPickLearningsFromLegacy, DURABLE_NAMESPACES, CHERRY_PICK_SKIP_REASONS } = await import(
+      '../services/cherry-pick-learnings.js'
+    );
+    const plural = (n: number): string => (n === 1 ? 'y' : 'ies');
+
+    const SELF = CHERRY_PICK_SKIP_REASONS.SELF_REFERENCE;
+
+    try {
+      if (to) {
+        const artifact = pathModule.resolve(expandHome(to));
+        if (!fs.existsSync(localDb)) {
+          output.printWarning(`No local memory DB at ${localDb} — nothing to export yet.`);
+          return { success: true, data: { copied: 0 } };
+        }
+        const result = await cherryPickLearningsFromLegacy({
+          projectRoot,
+          legacyPaths: [localDb],
+          toPath: artifact,
+          namespaces: DURABLE_NAMESPACES,
+        });
+        // The only no-op cherry-pick can hit here (source is our own valid DB)
+        // is the artifact aliasing the local DB — surface it, don't claim a copy.
+        if (result.sources[0]?.reason === SELF) {
+          output.printWarning(`--to path is the local memory DB itself (${artifact}) — nothing to export.`);
+          return { success: true, data: result };
+        }
+        output.printSuccess(`Exported ${result.copied} durable entr${plural(result.copied)} to ${artifact}`);
+        if (result.considered > result.copied) {
+          output.printInfo(`${result.considered - result.copied} already present in the artifact (skipped).`);
+        }
+        return { success: true, data: result };
+      }
+
+      // --from: merge the artifact into the local durable namespaces.
+      const artifact = pathModule.resolve(expandHome(from!));
+      if (!fs.existsSync(artifact)) {
+        output.printError(`Artifact not found: ${artifact}`);
+        return { success: false, exitCode: 1 };
+      }
+      const result = await cherryPickLearningsFromLegacy({
+        projectRoot,
+        legacyPaths: [artifact],
+        toPath: localDb,
+        namespaces: DURABLE_NAMESPACES,
+      });
+      const report = result.sources[0];
+      if (report?.reason === CHERRY_PICK_SKIP_REASONS.SCHEMA_MISMATCH) {
+        output.printWarning(`Artifact has no memory_entries table — not a moflo durable artifact: ${artifact}`);
+        return { success: true, data: result };
+      }
+      if (report?.reason === CHERRY_PICK_SKIP_REASONS.OPEN_FAILED) {
+        output.printError(`Could not open artifact: ${artifact}`);
+        return { success: false, exitCode: 1, data: result };
+      }
+      if (report?.reason === SELF) {
+        output.printWarning(`--from path is the local memory DB itself (${artifact}) — nothing to merge.`);
+        return { success: true, data: result };
+      }
+      // No recognised source report at all (e.g. the artifact vanished between
+      // the existsSync check above and the open — TOCTOU): a 0/0 result is not
+      // a real merge, so don't report success as if rows moved.
+      if (!report && result.considered === 0) {
+        output.printWarning(`No durable entries read from ${artifact} — it may have been moved or emptied.`);
+        return { success: true, data: result };
+      }
+      output.printSuccess(`Merged ${result.copied} durable entr${plural(result.copied)} from ${artifact}`);
+      if (result.considered > result.copied) {
+        const dupes = result.considered - result.copied;
+        output.printInfo(`${dupes} duplicate${dupes === 1 ? '' : 's'} skipped (conflict-free merge).`);
+      }
+      if (result.copied > 0) {
+        output.printInfo(
+          'Restart your Claude Code session (or run `flo memory rebuild-index`) so the merged learnings are searchable.',
+        );
+      }
+      return { success: true, data: result };
+    } catch (error) {
+      output.printError(`memory sync failed: ${error instanceof Error ? error.message : String(error)}`);
+      return { success: false, exitCode: 1 };
+    }
+  },
+};
+
 // Main memory command
 export const memoryCommand: Command = {
   name: 'memory',
   description: 'Memory management commands',
-  subcommands: [initMemoryCommand, storeCommand, retrieveCommand, searchCommand, listCommand, deleteCommand, statsCommand, configureCommand, cleanupCommand, compressCommand, exportCommand, importCommand, indexGuidanceCommand, rebuildIndexCommand, codeMapCommand, refreshCommand, restoreLearningsCommand],
+  subcommands: [initMemoryCommand, storeCommand, retrieveCommand, searchCommand, listCommand, deleteCommand, statsCommand, configureCommand, cleanupCommand, compressCommand, exportCommand, importCommand, indexGuidanceCommand, rebuildIndexCommand, codeMapCommand, refreshCommand, restoreLearningsCommand, syncCommand],
   options: [],
   examples: [
     { command: 'flo memory store -k "key" -v "value"', description: 'Store data' },
@@ -3026,7 +3167,8 @@ export const memoryCommand: Command = {
       `${output.highlight('rebuild-index')}   - Regenerate embeddings for memory entries`,
       `${output.highlight('code-map')}        - Generate structural code map`,
       `${output.highlight('refresh')}         - Reindex all content, rebuild embeddings, cleanup, and vacuum`,
-      `${output.highlight('restore-learnings')} - Cherry-pick learnings/knowledge from a legacy DB`
+      `${output.highlight('restore-learnings')} - Cherry-pick learnings/knowledge from a legacy DB`,
+      `${output.highlight('sync')}             - Export/import durable learnings to a portable artifact (multi-machine)`
     ]);
 
     return { success: true };


### PR DESCRIPTION
## Summary

Story 2 of epic #1231 (sharing moflo knowledge across installations). Adds **`flo memory sync --to/--from <path>`** — one durable-aware verb to carry `learnings` + `knowledge` across machines (laptop / desktop / CI) via a synced folder (Dropbox, iCloud, …) or a hand-copied file.

```
flo memory sync --to   ~/Dropbox/moflo/durable.db   # export durable slice → artifact
flo memory sync --from ~/Dropbox/moflo/durable.db   # merge artifact → local DB
```

## Design decision — SQLite artifact via cherry-pick reuse (not JSONL)

The artifact is a **portable SQLite `.db`**, written/read by reusing the existing, battle-tested `cherryPickLearningsFromLegacy` primitive (what `restore-learnings` uses) in both directions — *not* a new JSONL serializer. Why:

- **Embeddings ride along verbatim** — no lossy/expensive re-embed on import. JSONL would force re-embedding or a brand-new vector format ("no new serialization format if the existing one suffices" → it does).
- **Conflict-free + idempotent** — `INSERT OR IGNORE` on `UNIQUE(namespace, key)`; re-running `--from` copies zero.
- **Durable-only** — only `learnings`/`knowledge` (`DURABLE_NAMESPACES`) enter the artifact; `code-map`/ephemeral never leak.
- **Zero new code path** — independent of the unmerged Story 1 (#1232); branches off `main`.

The diffable/JSONL artifact is **deferred to Story 3 (#1234, git-tracked team artifact)**, where text-diffability and merge-conflict resolution are actually load-bearing. For same-user multi-machine via a synced folder, the writer is one person writing sequentially — a binary transfer file is correct.

> Note: while here I found the `memory_export`/`memory_import` MCP tools that the existing `flo memory export/import` commands call **are not registered** anywhere (`memory-tools.ts` only has store/retrieve/search/get_neighbors/delete/list/stats) — those two commands are effectively dead. Out of scope to fix here; flagging for a follow-up.

## Cross-platform (Rule #1 — mandatory)

- `path.join`/`path.resolve` only — no hardcoded separators or `/tmp`.
- `~` expansion handles `~/` **and** `~\` and bare `~` (`os.homedir()`), so the documented examples work even when quoted/programmatic. (Shells expand `~` themselves interactively; matches the `restore-learnings` precedent otherwise.)
- Artifact is a **binary SQLite DB** → no line-ending/encoding surface at all.
- Tests use `os.tmpdir()` + `mkdtemp`, `rm` with `maxRetries` (Windows file-lock), and drive `~` via `HOME`/`USERPROFILE` env (libuv reads both) rather than spying — no platform branch.

## Robustness folded in from review

- **Self-reference** (artifact path aliases the local DB, either direction) → a clear warning, not a false `"merged N"` success.
- **TOCTOU** (artifact vanishes between the `existsSync` check and open) → `0/0` reported as a warning, not success.
- **Not-a-moflo-DB** (`SCHEMA_MISMATCH`) → graceful warning + success; **open failure** → error.
- `--from` prints a restart / `flo memory rebuild-index` nudge so merged rows enter the daemon's in-memory HNSW index (direct-to-disk writes don't until it rebuilds).

## Testing

- [x] New `memory-sync.test.ts` — 12 cases: direction validation, `--to` durable-only export + embedding preservation, `--to` no-local-DB no-op, `~` expansion, `--to`/`--from` self-reference warnings, `--from` merge + embedding round-trip, `--from` idempotency, missing-artifact error, not-a-moflo-DB warning, A→B round-trip (the #1231 repro at the command layer).
- [x] `commands` / `commands-deep` / `cherry-pick-learnings` / `built-in-commands` suites green (534 with the new file).
- [x] `tsc` build clean.
- [ ] Manual end-to-end across two real machines via a synced folder (follow-up).

Closes #1233. Part of epic #1231.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
