### PR TITLE
feat(memory): git-tracked team learnings artifact (JSONL) for multi-user sharing (#1234)

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -2225,6 +2225,58 @@ function runMigrationsAndAnnounce(runnerPath) {
   }
 }
 
+// ── 3e-1234. Import the git-tracked team learnings artifact BEFORE daemon spawn ─
+// Opt-in (#1234, epic #1231): when memory.team_artifact (or MOFLO_TEAM_ARTIFACT)
+// points at a committed JSONL file, merge it into the local durable namespaces
+// so teammates' learnings (pulled via git) are present when the daemon builds
+// its HNSW index in section 4. INSERT OR IGNORE → idempotent + first-write-wins.
+// Fully guarded: a disabled/absent artifact is a silent no-op, and any failure
+// is non-fatal (the next session-start retries). Runs every session (teammates
+// pull frequently without a moflo version bump), unlike the upgrade-gated
+// cherry-pick in section 3.
+try {
+  // Cheap pre-gate so solo users (the overwhelming majority) pay nothing here —
+  // no module load, no moflo.yaml parse. The feature is only live when an env
+  // override is set, the default artifact already exists, or moflo.yaml has an
+  // UNcommented `team_artifact:` line (the generated config ships a commented
+  // example, which this regex deliberately ignores). Only then import the service.
+  const defaultArtifact = resolve(projectRoot, '.moflo', 'shared', 'learnings.jsonl');
+  const yamlPath = resolve(projectRoot, 'moflo.yaml');
+  let teamEnabled = Boolean(process.env.MOFLO_TEAM_ARTIFACT) || existsSync(defaultArtifact);
+  if (!teamEnabled && existsSync(yamlPath)) {
+    try {
+      teamEnabled = /^[ \t]*team_artifact[ \t]*:/m.test(readFileSync(yamlPath, 'utf-8'));
+    } catch { /* unreadable yaml — treat as not-configured */ }
+  }
+  const teamSyncPaths = teamEnabled
+    ? [
+        resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/team-artifact-sync.js'),
+        resolve(projectRoot, 'dist/src/cli/services/team-artifact-sync.js'),
+      ]
+    : [];
+  const teamSyncPath = teamSyncPaths.find((p) => existsSync(p));
+  if (teamSyncPath) {
+    const mod = await import(pathToFileURL(teamSyncPath).href);
+    if (typeof mod.resolveTeamArtifactPath === 'function' && typeof mod.importTeamArtifact === 'function') {
+      const artifactPath = mod.resolveTeamArtifactPath(projectRoot);
+      if (artifactPath && existsSync(artifactPath)) {
+        const report = mod.importTeamArtifact({ projectRoot, artifactPath });
+        if (report?.imported > 0) {
+          emitMutation(
+            'merged team learnings',
+            `${plural(report.imported, 'shared learning')} imported from the git-tracked team artifact`,
+          );
+        }
+      }
+    }
+  }
+} catch (err) {
+  try {
+    const msg = err && err.message ? err.message : String(err);
+    process.stderr.write(`team-artifact import skipped: ${msg}\n`);
+  } catch { /* stderr write must not throw */ }
+}
+
 // ── 3f. Flip the upgrade notice to "completed" (#636, #738) ─────────────────
 // See the TTL rationale at the constants above for why we switch to a
 // short-TTL completed badge instead of clearing the file.

--- a/src/cli/__tests__/commands/memory-team.test.ts
+++ b/src/cli/__tests__/commands/memory-team.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration tests for `flo memory team-export` / `team-import` (#1234).
+ *
+ * Drives the command actions directly with a mocked `findProjectRoot` pinned to
+ * a tmp root, exercising default-path resolution (`.moflo/shared/learnings.jsonl`),
+ * the `.gitignore` track side-effect, and the export→import round-trip through
+ * the real services. Cross-platform paths via path.join / os.tmpdir (Rule #1).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+const hoisted = vi.hoisted(() => ({ root: '' }));
+vi.mock('../../services/project-root.js', () => ({
+  findProjectRoot: () => hoisted.root,
+}));
+
+import { memoryCommand } from '../../commands/memory.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+import type { CommandContext, CommandResult, Command } from '../../types.js';
+
+const teamExport = memoryCommand.subcommands!.find((c) => c.name === 'team-export') as Command;
+const teamImport = memoryCommand.subcommands!.find((c) => c.name === 'team-import') as Command;
+
+const tmpDirs: string[] = [];
+afterEach(() => vi.restoreAllMocks());
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch {
+      /* Windows file-lock — non-fatal */
+    }
+  }
+});
+
+async function makeRoot(prefix = 'moflo-team-cmd-'): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function ctxWith(flags: Record<string, string>): CommandContext {
+  return { args: [], flags: { _: [], ...flags }, cwd: hoisted.root, interactive: false };
+}
+
+function run(cmd: Command, root: string, flags: Record<string, string> = {}): Promise<CommandResult> {
+  hoisted.root = root;
+  return cmd.action!(ctxWith(flags));
+}
+
+function seedLearnings(root: string, rows: Array<{ key: string; namespace: string }>): Promise<void> {
+  return makeMemoryDb(memoryDbPath(root), MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const r of rows) {
+      db.run(`INSERT INTO memory_entries (id, key, namespace, content) VALUES (?, ?, ?, ?)`, [
+        `id-${r.namespace}-${r.key}`,
+        r.key,
+        r.namespace,
+        `content-${r.key}`,
+      ]);
+    }
+  });
+}
+
+describe('flo memory team-export', () => {
+  it('writes the default artifact and tracks it in .gitignore', async () => {
+    const root = await makeRoot();
+    await seedLearnings(root, [
+      { key: 'l1', namespace: 'learnings' },
+      { key: 'cm', namespace: 'code-map' },
+    ]);
+
+    const res = await run(teamExport, root);
+    expect(res.success).toBe(true);
+    expect((res.data as { added: number }).added).toBe(1); // durable only
+
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    expect(existsSync(artifact)).toBe(true);
+
+    // gitignore was created so the shared subtree is tracked.
+    const gitignore = readFileSync(join(root, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('!/.moflo/shared/');
+  });
+});
+
+describe('flo memory team-import', () => {
+  it('errors when the artifact is absent', async () => {
+    const root = await makeRoot();
+    const res = await run(teamImport, root);
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+  });
+
+  it('round-trips: export on A, import on B surfaces the same learning', async () => {
+    const devA = await makeRoot('moflo-A-');
+    const devB = await makeRoot('moflo-B-');
+    const artifact = join(await makeRoot('moflo-share-'), 'learnings.jsonl');
+
+    await seedLearnings(devA, [{ key: 'shared-lesson', namespace: 'learnings' }]);
+    const exp = await run(teamExport, devA, { to: artifact });
+    expect((exp.data as { added: number }).added).toBe(1);
+
+    const imp = await run(teamImport, devB, { from: artifact });
+    expect(imp.success).toBe(true);
+    expect((imp.data as { imported: number }).imported).toBe(1);
+
+    const db = new DatabaseSync(memoryDbPath(devB));
+    try {
+      const rows = db.prepare(`SELECT namespace, key FROM memory_entries`).all();
+      expect(rows).toEqual([{ namespace: 'learnings', key: 'shared-lesson' }]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/cli/__tests__/services/team-artifact-sync.test.ts
+++ b/src/cli/__tests__/services/team-artifact-sync.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Tests for the git-tracked team learnings artifact (#1234, epic #1231).
+ *
+ * Covers:
+ *   - resolveTeamArtifactPath: off by default, env > config precedence, relative.
+ *   - exportTeamArtifact: only durable namespaces, no embeddings in the file,
+ *     provenance stamped, first-write-wins (existing lines preserved), sorted.
+ *   - importTeamArtifact: JSONL → local DB INSERT OR IGNORE, provenance retained
+ *     in metadata, idempotent re-import, malformed lines skipped.
+ *   - round-trip A→B (the #1234 repro at the service layer).
+ *   - ensureSharedArtifactTracked: rewrites a bare `.moflo/` ignore to
+ *     `.moflo/*` + a negation, idempotently; creates a .gitignore when absent.
+ *
+ * Real node:sqlite DBs + real files in tmp dirs (pure IO, no daemon). All paths
+ * via path.join / os.tmpdir for cross-platform safety (Rule #1).
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+import {
+  resolveTeamArtifactPath,
+  exportTeamArtifact,
+  importTeamArtifact,
+  ensureSharedArtifactTracked,
+  DEFAULT_TEAM_ARTIFACT_REL,
+  type TeamArtifactEntry,
+} from '../../services/team-artifact-sync.js';
+import { loadMofloConfig, type MofloConfig } from '../../config/moflo-config.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+import { DatabaseSync } from 'node:sqlite';
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch {
+      /* Windows file-lock — non-fatal for tests */
+    }
+  }
+});
+
+const savedEnv = process.env.MOFLO_TEAM_ARTIFACT;
+beforeEach(() => {
+  delete process.env.MOFLO_TEAM_ARTIFACT;
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.MOFLO_TEAM_ARTIFACT;
+  else process.env.MOFLO_TEAM_ARTIFACT = savedEnv;
+});
+
+async function makeRoot(prefix = 'moflo-team-'): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function configWith(root: string, teamArtifact?: string): MofloConfig {
+  const cfg = loadMofloConfig(root);
+  cfg.memory.team_artifact = teamArtifact;
+  return cfg;
+}
+
+function makeDbWith(
+  dbPath: string,
+  rows: Array<{ key: string; namespace: string; content?: string; embedding?: number[]; tags?: string[] }>,
+): Promise<void> {
+  return makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const r of rows) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, embedding, tags) VALUES (?, ?, ?, ?, ?, ?)`,
+        [
+          `id-${r.namespace}-${r.key}`,
+          r.key,
+          r.namespace,
+          r.content ?? `content-${r.key}`,
+          r.embedding ? JSON.stringify(r.embedding) : null,
+          r.tags ? JSON.stringify(r.tags) : null,
+        ],
+      );
+    }
+  });
+}
+
+function readArtifactLines(artifactPath: string): TeamArtifactEntry[] {
+  if (!existsSync(artifactPath)) return [];
+  return readFileSync(artifactPath, 'utf-8')
+    .split(/\r?\n/)
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as TeamArtifactEntry);
+}
+
+function readDbRows(dbPath: string): Array<{ namespace: string; key: string; embedding: string | null; metadata: string | null }> {
+  if (!existsSync(dbPath)) return [];
+  const db = new DatabaseSync(dbPath);
+  try {
+    return db
+      .prepare(`SELECT namespace, key, embedding, metadata FROM memory_entries ORDER BY namespace, key`)
+      .all() as Array<{ namespace: string; key: string; embedding: string | null; metadata: string | null }>;
+  } finally {
+    db.close();
+  }
+}
+
+const NOW = '2026-06-28T00:00:00.000Z';
+
+describe('resolveTeamArtifactPath (#1234)', () => {
+  it('returns null when unconfigured (solo default)', async () => {
+    const root = await makeRoot();
+    expect(resolveTeamArtifactPath(root, configWith(root, undefined))).toBeNull();
+  });
+
+  it('resolves a relative config path against the project root', async () => {
+    const root = await makeRoot();
+    expect(resolveTeamArtifactPath(root, configWith(root, '.moflo/shared/learnings.jsonl'))).toBe(
+      join(root, '.moflo', 'shared', 'learnings.jsonl'),
+    );
+  });
+
+  it('env MOFLO_TEAM_ARTIFACT takes precedence over config', async () => {
+    const root = await makeRoot();
+    const envPath = join(await makeRoot('moflo-env-'), 'team.jsonl');
+    process.env.MOFLO_TEAM_ARTIFACT = envPath;
+    expect(resolveTeamArtifactPath(root, configWith(root, '/some/config.jsonl'))).toBe(envPath);
+  });
+});
+
+describe('exportTeamArtifact (#1234)', () => {
+  it('writes only durable namespaces, no embeddings, provenance stamped', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+    await makeDbWith(memoryDbPath(root), [
+      { key: 'lesson-1', namespace: 'learnings', content: 'worrying does no good', embedding: [0.1, 0.2], tags: ['t'] },
+      { key: 'kb-1', namespace: 'knowledge' },
+      { key: 'cm-1', namespace: 'code-map' }, // structural — must NOT travel
+    ]);
+
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW });
+    expect(report.added).toBe(2);
+    expect(report.total).toBe(2);
+
+    const lines = readArtifactLines(artifact);
+    expect(lines.map((l) => `${l.namespace}/${l.key}`).sort()).toEqual(['knowledge/kb-1', 'learnings/lesson-1']);
+    const lesson = lines.find((l) => l.key === 'lesson-1')!;
+    // No embedding field in the diffable artifact.
+    expect((lesson as Record<string, unknown>).embedding).toBeUndefined();
+    expect(lesson.tags).toEqual(['t']);
+    expect(lesson.provenance.author).toBeTruthy();
+    expect(lesson.provenance.source).toBeTruthy();
+    expect(lesson.provenance.sharedAt).toBe(NOW);
+  });
+
+  it('is sorted by (namespace, key) for deterministic diffs', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    await makeDbWith(memoryDbPath(root), [
+      { key: 'zeta', namespace: 'learnings' },
+      { key: 'alpha', namespace: 'learnings' },
+      { key: 'mid', namespace: 'knowledge' },
+    ]);
+    exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW });
+    const keys = readArtifactLines(artifact).map((l) => `${l.namespace}/${l.key}`);
+    expect(keys).toEqual(['knowledge/mid', 'learnings/alpha', 'learnings/zeta']);
+  });
+
+  it('first-write-wins: an existing artifact entry is never overwritten on re-export', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    mkdirSync(dirname(artifact), { recursive: true });
+    // A teammate already shared lesson-1 with their own provenance.
+    const original: TeamArtifactEntry = {
+      namespace: 'learnings',
+      key: 'lesson-1',
+      content: 'original teammate content',
+      type: 'semantic',
+      provenance: { author: 'Teammate A', source: 'host-a', sharedAt: '2020-01-01T00:00:00.000Z' },
+    };
+    writeFileSync(artifact, JSON.stringify(original) + '\n', 'utf-8');
+
+    // Locally we have a different lesson-1 + a brand-new lesson-2.
+    await makeDbWith(memoryDbPath(root), [
+      { key: 'lesson-1', namespace: 'learnings', content: 'my divergent content' },
+      { key: 'lesson-2', namespace: 'learnings' },
+    ]);
+    const report = exportTeamArtifact({ projectRoot: root, artifactPath: artifact, sharedAt: NOW });
+    expect(report.added).toBe(1); // only lesson-2
+
+    const lines = readArtifactLines(artifact);
+    const lesson1 = lines.find((l) => l.key === 'lesson-1')!;
+    expect(lesson1.content).toBe('original teammate content'); // preserved
+    expect(lesson1.provenance.author).toBe('Teammate A'); // preserved
+  });
+});
+
+describe('importTeamArtifact (#1234)', () => {
+  it('merges durable rows with provenance retained, no embedding (regenerated later)', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    const entry: TeamArtifactEntry = {
+      namespace: 'learnings',
+      key: 'lesson-x',
+      content: 'shared insight',
+      type: 'semantic',
+      tags: ['team'],
+      provenance: { author: 'Dev A', source: 'laptop-a', sharedAt: NOW },
+    };
+    writeFileSync(artifact, JSON.stringify(entry) + '\n', 'utf-8');
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.imported).toBe(1);
+
+    const rows = readDbRows(memoryDbPath(root));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ namespace: 'learnings', key: 'lesson-x' });
+    expect(rows[0].embedding).toBeNull(); // regenerated by the daemon index pass
+    expect(JSON.parse(rows[0].metadata!).provenance.author).toBe('Dev A');
+  });
+
+  it('is idempotent and first-write-wins (existing local row survives re-import)', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    const entry: TeamArtifactEntry = {
+      namespace: 'learnings',
+      key: 'dup',
+      content: 'from artifact',
+      type: 'semantic',
+      provenance: { author: 'A', source: 'h', sharedAt: NOW },
+    };
+    writeFileSync(artifact, JSON.stringify(entry) + '\n', 'utf-8');
+
+    const first = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(first.imported).toBe(1);
+    const second = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(second.imported).toBe(0); // INSERT OR IGNORE
+    expect(readDbRows(memoryDbPath(root))).toHaveLength(1);
+  });
+
+  it('coerces an out-of-CHECK-set type to semantic instead of silently dropping', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    const entry = {
+      namespace: 'learnings',
+      key: 'weird-type',
+      content: 'c',
+      type: 'totally-invalid-type',
+      provenance: { author: 'A', source: 'h', sharedAt: NOW },
+    };
+    writeFileSync(artifact, JSON.stringify(entry) + '\n', 'utf-8');
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.imported).toBe(1); // imported, not dropped
+    const db = new DatabaseSync(memoryDbPath(root));
+    try {
+      const row = db.prepare(`SELECT type FROM memory_entries WHERE key='weird-type'`).get() as { type: string };
+      expect(row.type).toBe('semantic');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('skips non-durable namespaces (only learnings/knowledge are shared)', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    const rows = [
+      { namespace: 'learnings', key: 'keep', content: 'c', type: 'semantic', provenance: { author: 'A', source: 'h', sharedAt: NOW } },
+      { namespace: 'code-map', key: 'drop', content: 'c', type: 'semantic', provenance: { author: 'A', source: 'h', sharedAt: NOW } },
+    ];
+    writeFileSync(artifact, rows.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf-8');
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.imported).toBe(1);
+    expect(report.skippedNonDurable).toBe(1);
+    expect(report.considered).toBe(1); // non-durable not counted as "considered"
+    expect(readDbRows(memoryDbPath(root)).map((r) => r.namespace)).toEqual(['learnings']);
+  });
+
+  it('skips malformed lines without throwing', async () => {
+    const root = await makeRoot();
+    const artifact = join(root, 'team.jsonl');
+    const good: TeamArtifactEntry = {
+      namespace: 'learnings',
+      key: 'ok',
+      content: 'c',
+      type: 'semantic',
+      provenance: { author: 'A', source: 'h', sharedAt: NOW },
+    };
+    writeFileSync(artifact, `${JSON.stringify(good)}\n{not valid json\n{"missing":"keys"}\n`, 'utf-8');
+
+    const report = importTeamArtifact({ projectRoot: root, artifactPath: artifact });
+    expect(report.imported).toBe(1);
+    expect(report.skippedMalformed).toBe(2);
+  });
+});
+
+describe('round-trip A→B (#1234 repro, service layer)', () => {
+  it('a learning shared by dev A appears in dev B after import', async () => {
+    const devA = await makeRoot('moflo-A-');
+    const devB = await makeRoot('moflo-B-');
+    const artifact = join(await makeRoot('moflo-shared-'), 'learnings.jsonl');
+
+    await makeDbWith(memoryDbPath(devA), [
+      { key: 'pattern-1', namespace: 'learnings', content: 'always realpath both sides' },
+      { key: 'cm', namespace: 'code-map' }, // must not leak
+    ]);
+
+    const exp = exportTeamArtifact({ projectRoot: devA, artifactPath: artifact, sharedAt: NOW });
+    expect(exp.added).toBe(1);
+
+    const imp = importTeamArtifact({ projectRoot: devB, artifactPath: artifact });
+    expect(imp.imported).toBe(1);
+
+    const bRows = readDbRows(memoryDbPath(devB));
+    expect(bRows.map((r) => `${r.namespace}/${r.key}`)).toEqual(['learnings/pattern-1']);
+  });
+});
+
+describe('ensureSharedArtifactTracked (#1234)', () => {
+  it('rewrites a bare `.moflo/` ignore to `.moflo/*` + a negation', async () => {
+    const root = await makeRoot();
+    const gitignore = join(root, '.gitignore');
+    writeFileSync(gitignore, 'node_modules/\n.moflo/\ndist/\n', 'utf-8');
+
+    const action = ensureSharedArtifactTracked(root, join(root, '.moflo', 'shared', 'learnings.jsonl'));
+    expect(action).toBe('updated');
+
+    const lines = readFileSync(gitignore, 'utf-8').split('\n');
+    expect(lines).toContain('.moflo/*');
+    expect(lines).not.toContain('.moflo/'); // bare rule replaced
+    expect(lines).toContain('!/.moflo/shared/');
+    // negation must come after the contents rule for git to honour it
+    expect(lines.indexOf('!/.moflo/shared/')).toBeGreaterThan(lines.indexOf('.moflo/*'));
+  });
+
+  it('is idempotent — a second call makes no change', async () => {
+    const root = await makeRoot();
+    const gitignore = join(root, '.gitignore');
+    writeFileSync(gitignore, '.moflo/\n', 'utf-8');
+    const artifact = join(root, '.moflo', 'shared', 'learnings.jsonl');
+
+    ensureSharedArtifactTracked(root, artifact);
+    const after1 = readFileSync(gitignore, 'utf-8');
+    const action2 = ensureSharedArtifactTracked(root, artifact);
+    expect(action2).toBe('unchanged');
+    expect(readFileSync(gitignore, 'utf-8')).toBe(after1);
+  });
+
+  it('creates a .gitignore when none exists', async () => {
+    const root = await makeRoot();
+    const action = ensureSharedArtifactTracked(root, join(root, '.moflo', 'shared', 'learnings.jsonl'));
+    expect(action).toBe('created');
+    const content = readFileSync(join(root, '.gitignore'), 'utf-8');
+    expect(content).toContain('!/.moflo/shared/');
+  });
+
+  it('removes a bare `.moflo/` even when a `.moflo/*` contents rule already exists', async () => {
+    const root = await makeRoot();
+    const gitignore = join(root, '.gitignore');
+    // Both rules present — git still can't re-include because the bare dir is excluded.
+    writeFileSync(gitignore, '.moflo/\n.moflo/*\n', 'utf-8');
+
+    const action = ensureSharedArtifactTracked(root, join(root, '.moflo', 'shared', 'learnings.jsonl'));
+    expect(action).toBe('updated');
+
+    const lines = readFileSync(gitignore, 'utf-8').split('\n');
+    expect(lines).not.toContain('.moflo/'); // bare rule stripped
+    expect(lines).toContain('.moflo/*');
+    expect(lines).toContain('!/.moflo/shared/');
+  });
+
+  it('leaves .gitignore untouched for a custom artifact outside .moflo/', async () => {
+    const root = await makeRoot();
+    const gitignore = join(root, '.gitignore');
+    writeFileSync(gitignore, 'node_modules/\n', 'utf-8');
+    const before = readFileSync(gitignore, 'utf-8');
+
+    const action = ensureSharedArtifactTracked(root, join(root, 'team', 'shared.jsonl'));
+    expect(action).toBe('unchanged');
+    expect(readFileSync(gitignore, 'utf-8')).toBe(before);
+  });
+
+  it('default artifact rel path is .moflo/shared/learnings.jsonl', () => {
+    expect(DEFAULT_TEAM_ARTIFACT_REL).toBe(join('.moflo', 'shared', 'learnings.jsonl'));
+  });
+});

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -3132,11 +3132,109 @@ const syncCommand: Command = {
   },
 };
 
+// Team-share commands (#1234, epic #1231) — a git-tracked JSONL artifact the
+// team commits. `team-export` writes the local durable slice into it (merge,
+// first-write-wins, provenance-stamped) and makes it git-trackable; session-
+// start (and `team-import`) merge it back into the local DB. Diffable JSONL is
+// what makes this reviewable + merge-friendly, unlike the SQLite artifacts of
+// stories #1232/#1233.
+function resolveTeamArtifact(projectRoot: string, explicit: unknown): Promise<string> {
+  return import('../services/team-artifact-sync.js').then(({ resolveTeamArtifactPath, DEFAULT_TEAM_ARTIFACT_REL }) => {
+    if (typeof explicit === 'string' && explicit.trim().length > 0) {
+      return pathModule.resolve(explicit.trim());
+    }
+    return resolveTeamArtifactPath(projectRoot) ?? pathModule.resolve(projectRoot, DEFAULT_TEAM_ARTIFACT_REL);
+  });
+}
+
+const teamExportCommand: Command = {
+  name: 'team-export',
+  description: 'Write durable learnings into the git-tracked team artifact (JSONL) for sharing',
+  options: [
+    {
+      name: 'to',
+      description: 'Artifact path (default: memory.team_artifact or .moflo/shared/learnings.jsonl)',
+      type: 'string',
+    },
+  ],
+  examples: [
+    { command: 'flo memory team-export', description: 'Merge local learnings into the team artifact, then git add + commit it' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const projectRoot = findProjectRoot();
+    const artifactPath = await resolveTeamArtifact(projectRoot, ctx.flags.to);
+    try {
+      const { exportTeamArtifact, ensureSharedArtifactTracked } = await import('../services/team-artifact-sync.js');
+      const report = exportTeamArtifact({ projectRoot, artifactPath, sharedAt: new Date().toISOString() });
+      const gitignore = ensureSharedArtifactTracked(projectRoot, artifactPath);
+
+      const rel = pathModule.relative(projectRoot, artifactPath) || artifactPath;
+      output.printSuccess(`Shared ${report.added} new durable entr${report.added === 1 ? 'y' : 'ies'} → ${rel}`);
+      output.printInfo(`Artifact now holds ${report.total} entr${report.total === 1 ? 'y' : 'ies'}.`);
+      if (gitignore !== 'unchanged') {
+        output.printInfo(`.gitignore ${gitignore} so the shared artifact is tracked while the rest of .moflo/ stays ignored.`);
+      }
+      output.printInfo(`Commit it to share: git add ${rel} && git commit -m "share learnings"`);
+      return { success: true, data: report };
+    } catch (error) {
+      output.printError(`team-export failed: ${error instanceof Error ? error.message : String(error)}`);
+      return { success: false, exitCode: 1 };
+    }
+  },
+};
+
+const teamImportCommand: Command = {
+  name: 'team-import',
+  description: 'Merge the git-tracked team artifact (JSONL) into the local learnings',
+  options: [
+    {
+      name: 'from',
+      description: 'Artifact path (default: memory.team_artifact or .moflo/shared/learnings.jsonl)',
+      type: 'string',
+    },
+  ],
+  examples: [
+    { command: 'flo memory team-import', description: 'Merge teammates shared learnings after a git pull' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const projectRoot = findProjectRoot();
+    const artifactPath = await resolveTeamArtifact(projectRoot, ctx.flags.from);
+    if (!fs.existsSync(artifactPath)) {
+      output.printError(`Team artifact not found: ${artifactPath}`);
+      output.printInfo('A teammate runs `flo memory team-export` + commits it first.');
+      return { success: false, exitCode: 1 };
+    }
+    try {
+      const { importTeamArtifact } = await import('../services/team-artifact-sync.js');
+      const report = importTeamArtifact({ projectRoot, artifactPath });
+      output.printSuccess(`Merged ${report.imported} durable entr${report.imported === 1 ? 'y' : 'ies'} from the team artifact`);
+      if (report.considered > report.imported) {
+        output.printInfo(`${report.considered - report.imported} already present (skipped, conflict-free).`);
+      }
+      if (report.skippedMalformed > 0) {
+        output.printWarning(`${report.skippedMalformed} malformed line${report.skippedMalformed === 1 ? '' : 's'} skipped.`);
+      }
+      if (report.skippedNonDurable > 0) {
+        output.printWarning(`${report.skippedNonDurable} non-durable entr${report.skippedNonDurable === 1 ? 'y' : 'ies'} skipped (only learnings/knowledge are shared).`);
+      }
+      if (report.imported > 0) {
+        output.printInfo(
+          'Restart your Claude Code session (or run `flo memory rebuild-index`) so the merged learnings are embedded + searchable.',
+        );
+      }
+      return { success: true, data: report };
+    } catch (error) {
+      output.printError(`team-import failed: ${error instanceof Error ? error.message : String(error)}`);
+      return { success: false, exitCode: 1 };
+    }
+  },
+};
+
 // Main memory command
 export const memoryCommand: Command = {
   name: 'memory',
   description: 'Memory management commands',
-  subcommands: [initMemoryCommand, storeCommand, retrieveCommand, searchCommand, listCommand, deleteCommand, statsCommand, configureCommand, cleanupCommand, compressCommand, exportCommand, importCommand, indexGuidanceCommand, rebuildIndexCommand, codeMapCommand, refreshCommand, restoreLearningsCommand, syncCommand],
+  subcommands: [initMemoryCommand, storeCommand, retrieveCommand, searchCommand, listCommand, deleteCommand, statsCommand, configureCommand, cleanupCommand, compressCommand, exportCommand, importCommand, indexGuidanceCommand, rebuildIndexCommand, codeMapCommand, refreshCommand, restoreLearningsCommand, syncCommand, teamExportCommand, teamImportCommand],
   options: [],
   examples: [
     { command: 'flo memory store -k "key" -v "value"', description: 'Store data' },
@@ -3168,7 +3266,9 @@ export const memoryCommand: Command = {
       `${output.highlight('code-map')}        - Generate structural code map`,
       `${output.highlight('refresh')}         - Reindex all content, rebuild embeddings, cleanup, and vacuum`,
       `${output.highlight('restore-learnings')} - Cherry-pick learnings/knowledge from a legacy DB`,
-      `${output.highlight('sync')}             - Export/import durable learnings to a portable artifact (multi-machine)`
+      `${output.highlight('sync')}             - Export/import durable learnings to a portable artifact (multi-machine)`,
+      `${output.highlight('team-export')}      - Write durable learnings to the git-tracked team artifact (JSONL)`,
+      `${output.highlight('team-import')}      - Merge the team artifact into local learnings`
     ]);
 
     return { success: true };

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -108,6 +108,14 @@ export interface MofloConfig {
      * `src/cli/services/durable-sync.ts`.
      */
     durable_path?: string;
+    /**
+     * Optional path to a **git-tracked** team learnings artifact (JSONL),
+     * default `.moflo/shared/learnings.jsonl` (#1234, epic #1231). When set,
+     * session-start import-merges it into the local durable namespaces so a team
+     * accumulates each other's learnings about the same repo. Undefined = off
+     * (solo default). `MOFLO_TEAM_ARTIFACT` overrides. Relative → project root.
+     */
+    team_artifact?: string;
   };
 
   hooks: {
@@ -413,6 +421,10 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
         const v = raw.memory?.durable_path ?? raw.memory?.durablePath;
         return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
       })(),
+      team_artifact: (() => {
+        const v = raw.memory?.team_artifact ?? raw.memory?.teamArtifact;
+        return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+      })(),
     },
     hooks: {
       pre_edit: raw.hooks?.pre_edit ?? raw.hooks?.preEdit ?? DEFAULT_CONFIG.hooks.pre_edit,
@@ -626,6 +638,7 @@ memory:
   #   git worktrees / Conductor workspaces of this project share one learnings DB.
   #   Structural namespaces (code-map, guidance, tests) stay local per checkout.
   #   Absolute path recommended; overridable per-process via MOFLO_DURABLE_PATH.
+  # team_artifact: .moflo/shared/learnings.jsonl  # opt-in (#1234): git-track this JSONL to share learnings across a team. Session-start import-merges it; "flo memory team-export" writes it. Leave unset for solo use.
 
 # Hook toggles (all on by default — disable to slim down)
 hooks:

--- a/src/cli/services/cherry-pick-learnings.ts
+++ b/src/cli/services/cherry-pick-learnings.ts
@@ -61,6 +61,26 @@ export function isDurableNamespace(namespace: string): boolean {
 }
 
 /**
+ * The canonical 14-column durable-row `INSERT OR IGNORE` statement. Exported so
+ * the team-artifact import (#1234) binds the EXACT same column order — a drift
+ * between the two writers would silently mis-bind or drop rows (INSERT OR IGNORE
+ * swallows the constraint violation). Single source of truth for both.
+ */
+export const DURABLE_INSERT_OR_IGNORE_SQL =
+  `INSERT OR IGNORE INTO memory_entries ` +
+  `(id, key, namespace, content, type, embedding, embedding_model, ` +
+  ` embedding_dimensions, tags, metadata, owner_id, created_at, updated_at, status) ` +
+  `VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+/** True if `db` exposes the `memory_entries` table (durable schema present). */
+export function hasMemoryEntriesTable(db: SqlJsLikeDatabase): boolean {
+  const probe = db.exec(
+    `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_entries' LIMIT 1`,
+  );
+  return Boolean(probe[0]?.values?.[0]);
+}
+
+/**
  * Reasons a single source contributed zero rows. Exported so callers can
  * branch on the cause without duplicating string literals.
  */
@@ -184,12 +204,7 @@ export async function cherryPickLearningsFromLegacy(
       `FROM memory_entries WHERE namespace IN (${placeholders})`;
     // Hoisted prepare — avoids re-parsing the SQL for every INSERT. Matters
     // for legacy DBs with hundreds of learnings rows.
-    insertStmt = targetDb.prepare(
-      `INSERT OR IGNORE INTO memory_entries ` +
-        `(id, key, namespace, content, type, embedding, embedding_model, ` +
-        ` embedding_dimensions, tags, metadata, owner_id, created_at, updated_at, status) ` +
-        `VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    );
+    insertStmt = targetDb.prepare(DURABLE_INSERT_OR_IGNORE_SQL);
 
     for (const sourcePath of legacyPaths) {
       if (sourcePath === target) {
@@ -239,10 +254,7 @@ function readAndInsert(
 
   try {
     // Older / unrelated DBs may not have memory_entries.
-    const probe = sourceDb.exec(
-      `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_entries' LIMIT 1`,
-    );
-    if (!probe[0]?.values?.[0]) {
+    if (!hasMemoryEntriesTable(sourceDb)) {
       return {
         path: sourcePath,
         rowsRead: 0,

--- a/src/cli/services/team-artifact-sync.ts
+++ b/src/cli/services/team-artifact-sync.ts
@@ -1,0 +1,441 @@
+/**
+ * Git-tracked team learnings artifact (#1234, epic #1231).
+ *
+ * Story 1 (#1232) shared a durable SQLite store between worktrees; Story 2
+ * (#1233) carried a durable SQLite artifact between one user's machines. This
+ * story shares durable learnings across a *team*: a **git-tracked JSONL file**
+ * (default `.moflo/shared/learnings.jsonl`, explicitly NOT gitignored) that the
+ * team commits. Each teammate's session-start import-merges it into their local
+ * DB, so the whole team accumulates each other's learnings about the same repo.
+ *
+ * Why JSONL (not the SQLite artifact from #1233): a committed team file must be
+ * **diff-reviewable** and **merge-friendly**. One JSON object per line, sorted
+ * by `(namespace, key)`, makes git diffs line-local and human-readable, and a
+ * git merge of two divergent artifacts is conflict-free for distinct keys.
+ * Embeddings are deliberately omitted from the file — 384 floats per row would
+ * make every diff unreadable — so imported rows are re-embedded by the daemon's
+ * normal index pass (or `flo memory rebuild-index`), exactly as any other
+ * unembedded row.
+ *
+ * Conflict policy: **first-write-wins**, applied two ways, both via the existing
+ * `UNIQUE(namespace, key)` constraint:
+ *   - on re-export, an entry already in the artifact keeps its original line
+ *     (and original author/timestamp) — we never rewrite a teammate's row.
+ *   - on import, `INSERT OR IGNORE` means a row already present locally wins,
+ *     and within the file the first line for a key wins.
+ *
+ * Provenance: each exported entry is stamped with `author` (git user) + `source`
+ * (hostname) so a learning's origin is visible in review and retained on import.
+ *
+ * Opt-in: inert unless `memory.team_artifact` (or `MOFLO_TEAM_ARTIFACT`) points
+ * at a path. Solo users see byte-identical behaviour to today.
+ *
+ * @module cli/services/team-artifact-sync
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { createHash } from 'crypto';
+import { findProjectRoot } from './project-root.js';
+import { memoryDbPath } from './moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../memory/memory-initializer.js';
+import { openDaemonDatabase, type SqlJsLikeDatabase } from '../memory/daemon-backend.js';
+import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
+import { loadMofloConfig, type MofloConfig } from '../config/moflo-config.js';
+import {
+  DURABLE_NAMESPACES,
+  DURABLE_INSERT_OR_IGNORE_SQL,
+  hasMemoryEntriesTable,
+  isDurableNamespace,
+} from './cherry-pick-learnings.js';
+
+/** Allowed `type` values — the schema CHECK set. An out-of-set value would make
+ *  INSERT OR IGNORE silently drop a hand-edited artifact row, so we coerce. */
+const VALID_TYPES: ReadonlySet<string> = new Set([
+  'semantic',
+  'episodic',
+  'procedural',
+  'working',
+  'pattern',
+]);
+const coerceType = (t: string | undefined): string => (t && VALID_TYPES.has(t) ? t : 'semantic');
+
+/** Default artifact path, relative to the project root. POSIX-joined parts. */
+export const DEFAULT_TEAM_ARTIFACT_REL = path.join('.moflo', 'shared', 'learnings.jsonl');
+
+/** Provenance stamped onto each shared entry so its origin survives review. */
+export interface TeamProvenance {
+  /** `git config user.name <user.email>`, or the OS user as a fallback. */
+  author: string;
+  /** Hostname of the machine that first shared the entry. */
+  source: string;
+  /** ISO timestamp the entry was first written to the artifact. */
+  sharedAt: string;
+}
+
+/** One durable learning as a single JSONL line. Embeddings are intentionally omitted. */
+export interface TeamArtifactEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  type: string;
+  tags?: string[];
+  /** Epoch-ms creation time (the `created_at` column is INTEGER NOT NULL). */
+  created_at?: number;
+  provenance: TeamProvenance;
+}
+
+export interface ExportReport {
+  artifactPath: string;
+  /** Entries newly added to the artifact this run (excludes ones already present). */
+  added: number;
+  /** Total entries in the artifact after the merge. */
+  total: number;
+}
+
+export interface ImportReport {
+  artifactPath: string;
+  /** Rows actually inserted into the local DB (excludes duplicates). */
+  imported: number;
+  /** Durable rows read from the artifact (well-formed, durable-namespace lines). */
+  considered: number;
+  /** Malformed JSONL lines skipped (bad JSON or missing namespace/key). */
+  skippedMalformed: number;
+  /** Well-formed lines skipped for being outside the durable namespaces. */
+  skippedNonDurable: number;
+}
+
+const KEY_SEP = String.fromCharCode(0); // in-memory dedup separator (collision-proof, kept out of source as a literal NUL)
+const entryMapKey = (namespace: string, key: string): string => `${namespace}${KEY_SEP}${key}`;
+
+/**
+ * Resolve the configured team-artifact path to an absolute path, or `null` when
+ * the feature is off (no env, no `memory.team_artifact`). Precedence:
+ * `MOFLO_TEAM_ARTIFACT` env > `memory.team_artifact` (moflo.yaml). Relative
+ * values resolve against the project root (Rule #1 — always `path.resolve`).
+ */
+export function resolveTeamArtifactPath(
+  projectRoot: string = findProjectRoot(),
+  config?: MofloConfig,
+): string | null {
+  const envRaw = process.env.MOFLO_TEAM_ARTIFACT?.trim();
+  const cfgRaw = (config ?? loadMofloConfig(projectRoot)).memory.team_artifact?.trim();
+  const raw = envRaw && envRaw.length > 0 ? envRaw : cfgRaw;
+  if (!raw) return null;
+  return path.isAbsolute(raw) ? path.resolve(raw) : path.resolve(projectRoot, raw);
+}
+
+/** Best-effort author string: `git user.name <user.email>`, else OS user. */
+function resolveAuthor(projectRoot: string): string {
+  const git = (args: string[]): string => {
+    try {
+      // spawnSync without a shell — never interpolate into a shell string (Rule #1).
+      const r = spawnSync('git', args, { cwd: projectRoot, encoding: 'utf-8', timeout: 2000 });
+      return r.status === 0 ? (r.stdout || '').trim() : '';
+    } catch {
+      return '';
+    }
+  };
+  const name = git(['config', 'user.name']);
+  const email = git(['config', 'user.email']);
+  if (name && email) return `${name} <${email}>`;
+  if (name) return name;
+  try {
+    return os.userInfo().username || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/** Stable host identifier for provenance; never throws. */
+function resolveSource(): string {
+  try {
+    return os.hostname() || 'unknown-host';
+  } catch {
+    return 'unknown-host';
+  }
+}
+
+/** Read + parse an existing artifact into a (namespace,key) → entry map. Missing file → empty. */
+function readArtifact(artifactPath: string): { entries: Map<string, TeamArtifactEntry>; malformed: number } {
+  const entries = new Map<string, TeamArtifactEntry>();
+  let malformed = 0;
+  if (!fs.existsSync(artifactPath)) return { entries, malformed };
+  const raw = fs.readFileSync(artifactPath, 'utf-8');
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: TeamArtifactEntry | null = null;
+    try {
+      obj = JSON.parse(trimmed) as TeamArtifactEntry;
+    } catch {
+      malformed++;
+      continue;
+    }
+    if (!obj || typeof obj.namespace !== 'string' || typeof obj.key !== 'string') {
+      malformed++;
+      continue;
+    }
+    const mapKey = entryMapKey(obj.namespace, obj.key);
+    // First line for a key wins (first-write-wins inside the file).
+    if (!entries.has(mapKey)) entries.set(mapKey, obj);
+  }
+  return { entries, malformed };
+}
+
+/** Serialise entries to JSONL, sorted by (namespace, key) for deterministic, reviewable diffs. */
+function serializeArtifact(entries: Iterable<TeamArtifactEntry>): string {
+  const sorted = [...entries].sort((a, b) =>
+    a.namespace === b.namespace ? a.key.localeCompare(b.key) : a.namespace.localeCompare(b.namespace),
+  );
+  return sorted.map((e) => JSON.stringify(e)).join('\n') + (sorted.length ? '\n' : '');
+}
+
+/** SELECT the local durable rows (learnings, knowledge) to be shared. */
+function readLocalDurableRows(localDbPath: string): TeamArtifactEntry[] {
+  if (!fs.existsSync(localDbPath)) return [];
+  let db: SqlJsLikeDatabase;
+  try {
+    db = openDaemonDatabase(localDbPath);
+  } catch {
+    return [];
+  }
+  try {
+    if (!hasMemoryEntriesTable(db)) return [];
+    const placeholders = DURABLE_NAMESPACES.map(() => '?').join(',');
+    const stmt = db.prepare(
+      `SELECT namespace, key, content, type, tags, created_at FROM memory_entries ` +
+        `WHERE namespace IN (${placeholders})`,
+    );
+    stmt.bind(DURABLE_NAMESPACES.slice());
+    const rows: TeamArtifactEntry[] = [];
+    while (stmt.step()) {
+      const r = stmt.getAsObject();
+      rows.push({
+        namespace: String(r.namespace),
+        key: String(r.key),
+        content: r.content == null ? '' : String(r.content),
+        type: r.type == null ? 'semantic' : String(r.type),
+        tags: parseTags(r.tags),
+        created_at: r.created_at == null ? undefined : Number(r.created_at),
+        // Provenance is filled by the caller (export) — placeholder here.
+        provenance: { author: '', source: '', sharedAt: '' },
+      });
+    }
+    stmt.free();
+    return rows;
+  } finally {
+    db.close();
+  }
+}
+
+function parseTags(raw: unknown): string[] | undefined {
+  if (raw == null) return undefined;
+  if (Array.isArray(raw)) return raw.map(String);
+  try {
+    const parsed = JSON.parse(String(raw));
+    return Array.isArray(parsed) ? parsed.map(String) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Export the local durable slice into the team artifact (merge, not overwrite).
+ * Existing artifact entries keep their original line/provenance (first-write-wins);
+ * only local durable rows whose key is absent are appended, stamped with this
+ * machine's provenance. The artifact is rewritten sorted + atomically.
+ */
+export function exportTeamArtifact(opts: {
+  projectRoot?: string;
+  artifactPath: string;
+  sharedAt: string;
+  config?: MofloConfig;
+}): ExportReport {
+  const projectRoot = opts.projectRoot ?? findProjectRoot();
+  const localDbPath = memoryDbPath(projectRoot);
+  const { entries } = readArtifact(opts.artifactPath);
+  const author = resolveAuthor(projectRoot);
+  const source = resolveSource();
+
+  let added = 0;
+  for (const row of readLocalDurableRows(localDbPath)) {
+    const mapKey = entryMapKey(row.namespace, row.key);
+    if (entries.has(mapKey)) continue; // never rewrite an existing (teammate's) entry
+    entries.set(mapKey, { ...row, provenance: { author, source, sharedAt: opts.sharedAt } });
+    added++;
+  }
+
+  fs.mkdirSync(path.dirname(opts.artifactPath), { recursive: true });
+  atomicWriteFileSync(opts.artifactPath, serializeArtifact(entries.values()));
+  return { artifactPath: opts.artifactPath, added, total: entries.size };
+}
+
+/**
+ * Import-merge the team artifact into the local durable namespaces. `INSERT OR
+ * IGNORE` on `UNIQUE(namespace, key)` makes this idempotent and first-write-wins
+ * (existing local rows survive). Embeddings are left null — the daemon's index
+ * pass fills them. No-op (zero rows) when the artifact is absent. Never throws on
+ * a malformed line; those are counted and skipped.
+ */
+export function importTeamArtifact(opts: { projectRoot?: string; artifactPath: string }): ImportReport {
+  const projectRoot = opts.projectRoot ?? findProjectRoot();
+  const localDbPath = memoryDbPath(projectRoot);
+  const report: ImportReport = {
+    artifactPath: opts.artifactPath,
+    imported: 0,
+    considered: 0,
+    skippedMalformed: 0,
+    skippedNonDurable: 0,
+  };
+
+  const { entries, malformed } = readArtifact(opts.artifactPath);
+  report.skippedMalformed = malformed;
+  if (entries.size === 0) return report;
+
+  fs.mkdirSync(path.dirname(localDbPath), { recursive: true });
+  const db = openDaemonDatabase(localDbPath);
+  let insertStmt: ReturnType<SqlJsLikeDatabase['prepare']> | null = null;
+  try {
+    db.run(MEMORY_SCHEMA_V3);
+    // Shared column list with the cherry-pick writer — single source of truth so
+    // the two can't drift (a mismatch would mis-bind under INSERT OR IGNORE).
+    insertStmt = db.prepare(DURABLE_INSERT_OR_IGNORE_SQL);
+    // One transaction for the whole batch → a single fsync instead of one per
+    // row on the (enabled) session-start hot path.
+    db.run('BEGIN');
+    try {
+      for (const entry of entries.values()) {
+        // The artifact is hand-editable by design — only durable namespaces
+        // belong in the local durable slice; skip anything else rather than
+        // polluting the DB (and so it isn't mis-counted as a duplicate).
+        if (!isDurableNamespace(entry.namespace)) {
+          report.skippedNonDurable++;
+          continue;
+        }
+        report.considered++;
+        const id = createHash('sha1').update(entryMapKey(entry.namespace, entry.key)).digest('hex');
+        const metadata = JSON.stringify({ provenance: entry.provenance, sharedFrom: 'team-artifact' });
+        // created_at/updated_at are INTEGER NOT NULL — never bind null (INSERT OR
+        // IGNORE would silently drop the row on the constraint violation).
+        const ts = typeof entry.created_at === 'number' ? entry.created_at : Date.now();
+        insertStmt.bind([
+          id,
+          entry.key,
+          entry.namespace,
+          entry.content ?? '',
+          coerceType(entry.type), // out-of-CHECK-set type would be silently dropped otherwise
+          null, // embedding — regenerated by the daemon's index pass
+          null, // embedding_model
+          null, // embedding_dimensions
+          entry.tags ? JSON.stringify(entry.tags) : null,
+          metadata,
+          entry.provenance?.author || null,
+          ts,
+          ts,
+          'active',
+        ]);
+        insertStmt.step();
+        if (db.getRowsModified() > 0) report.imported++;
+        insertStmt.reset();
+      }
+      db.run('COMMIT');
+    } catch (e) {
+      try {
+        db.run('ROLLBACK');
+      } catch {
+        /* best-effort — the close() below also discards an open transaction */
+      }
+      throw e;
+    }
+  } finally {
+    if (insertStmt) {
+      try {
+        insertStmt.free();
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+    db.close();
+  }
+  return report;
+}
+
+/**
+ * Ensure a git-tracked shared artifact is actually trackable. Once `.moflo/` is
+ * gitignored, git won't descend into it to re-include a child — the canonical
+ * fix is to ignore the *contents* (`.moflo/*`) and negate the shared subtree.
+ * This rewrites a bare `.moflo/` rule to that pattern and adds the negation,
+ * idempotently. Gitignore globs always use `/` regardless of OS (Rule #1), so
+ * the artifact path is POSIX-normalised here.
+ *
+ * Returns the action taken so callers can report it.
+ */
+export function ensureSharedArtifactTracked(
+  projectRoot: string,
+  artifactAbsPath: string,
+): 'created' | 'updated' | 'unchanged' {
+  const rel = path.relative(projectRoot, artifactAbsPath).split(path.sep).join('/');
+  // Only the `.moflo/` tree is gitignored-by-default and needs the re-include
+  // dance. A custom artifact elsewhere is assumed already trackable — touching
+  // an unrelated part of .gitignore would be surprising (and could inject a
+  // spurious `.moflo/*` rule). Leave it alone.
+  if (!rel.startsWith('.moflo/')) return 'unchanged';
+
+  const gitignorePath = path.join(projectRoot, '.gitignore');
+  // Negate the artifact's directory subtree (parent of the file), e.g. `.moflo/shared/`.
+  const relDir = rel.slice(0, rel.lastIndexOf('/') + 1);
+  const negation = `!/${relDir}`;
+
+  const existed = fs.existsSync(gitignorePath);
+  const lines = existed ? fs.readFileSync(gitignorePath, 'utf-8').split(/\r?\n/) : [];
+
+  const isBareMoflo = (t: string): boolean =>
+    t === '.moflo/' || t === '/.moflo/' || t === '.moflo' || t === '/.moflo';
+  const isContentsRule = (t: string): boolean => t === '.moflo/*' || t === '/.moflo/*';
+
+  let changed = false;
+  let hasContentsRule = lines.some((l) => isContentsRule(l.trim()));
+
+  // 1. Remove EVERY bare `.moflo/` rule (even when a contents rule also exists —
+  //    git won't descend into an excluded dir, so the bare rule must go).
+  //    Replace the first one with `.moflo/*` if no contents rule exists yet.
+  const next: string[] = [];
+  for (const line of lines) {
+    if (isBareMoflo(line.trim())) {
+      changed = true;
+      if (!hasContentsRule) {
+        next.push('.moflo/*');
+        hasContentsRule = true;
+      }
+      continue; // drop the bare rule
+    }
+    next.push(line);
+  }
+
+  // 2. Ensure a `.moflo/*` contents rule exists at all (fresh file / no .moflo rule).
+  if (!hasContentsRule) {
+    if (next.length && next[next.length - 1].trim() !== '') next.push('');
+    next.push('# moflo team-shared learnings (tracked)');
+    next.push('.moflo/*');
+    hasContentsRule = true;
+    changed = true;
+  }
+
+  // 3. Ensure the negation is present (after the contents rule).
+  const hasNegation = next.some((l) => {
+    const t = l.trim();
+    return t === negation || t === `!${relDir}`;
+  });
+  if (!hasNegation) {
+    next.push(negation);
+    changed = true;
+  }
+
+  if (!changed) return 'unchanged';
+  const content = next.join('\n').replace(/\n+$/, '') + '\n';
+  atomicWriteFileSync(gitignorePath, content);
+  return existed ? 'updated' : 'created';
+}

--- a/tests/system/fixtures/writer-audit-whitelist.json
+++ b/tests/system/fixtures/writer-audit-whitelist.json
@@ -213,6 +213,11 @@
       "notes": "One-time launcher pre-boot cherry-pick"
     },
     {
+      "file": "src/cli/services/team-artifact-sync.ts",
+      "classification": "daemon-offline",
+      "notes": "Imports the git-tracked team JSONL artifact into local moflo.db at session-start before the daemon spawns (#1234); same pre-boot writer shape as cherry-pick. The team-import CLI path matches restore-learnings' offline usage."
+    },
+    {
       "file": "src/cli/services/learning-service.ts",
       "classification": "daemon-offline",
       "notes": "Hooks library save() — S3 verifies caller context and confirms classification"


### PR DESCRIPTION
## Summary

Story 3 of epic #1231 — **team / multi-user** learnings sharing via a **git-tracked JSONL artifact** (default `.moflo/shared/learnings.jsonl`). A teammate exports + commits it; everyone else's session-start import-merges it, so the whole team accumulates each other's learnings about the same repo.

```
flo memory team-export        # merge local learnings → the tracked JSONL, then git add + commit
flo memory team-import        # merge teammates' learnings (also runs automatically at session-start)
```

## Why JSONL here (vs the SQLite artifacts of #1232/#1233)

A committed team file must be **diff-reviewable** and **git-merge-friendly**. One JSON object per line, sorted by `(namespace, key)`, makes diffs line-local and human-readable, and a merge of two divergent artifacts is conflict-free for distinct keys. Embeddings are deliberately **omitted** (384 floats/row would make every diff unreadable) — imported rows re-embed on the daemon's next index pass, like any unembedded row.

This is the format I deliberately deferred from #1233 to here, where diffability is actually load-bearing.

## How it works

- **First-write-wins** both ways via `UNIQUE(namespace, key)`: re-export never rewrites a teammate's line (keeps their author/timestamp); import is `INSERT OR IGNORE` (idempotent; existing local row wins; first line for a key wins).
- **Provenance** (`git user.name <email>` + hostname) stamped on export, retained in each imported row's metadata.
- **Opt-in**: `memory.team_artifact` (or `MOFLO_TEAM_ARTIFACT`); off by default → solo users see byte-identical behaviour. The session-start launcher has a **cheap pre-gate** (env / default-file-exists / uncommented `team_artifact:` in moflo.yaml) so solo users pay **no** module-load or yaml-parse cost.
- **`.gitignore`**: `ensureSharedArtifactTracked` rewrites a bare `.moflo/` to `.moflo/*` + `!/.moflo/shared/` — git can't re-include a file under an excluded parent dir, so the contents-ignore + negation is the only pattern that works. Only touches `.moflo/`-relative artifacts.

## Files

- `src/cli/services/team-artifact-sync.ts` (new) — resolve / export / import / gitignore.
- `src/cli/services/cherry-pick-learnings.ts` — extracted shared `DURABLE_INSERT_OR_IGNORE_SQL` + `hasMemoryEntriesTable` (now used by both durable-row writers).
- `src/cli/commands/memory.ts` — `team-export` / `team-import`.
- `src/cli/config/moflo-config.ts` — `memory.team_artifact`.
- `bin/session-start-launcher.mjs` — gated import-merge block (3e-1234).

## Hardening folded in from a 3-agent Opus review

- **Reuse:** shared `DURABLE_INSERT_OR_IGNORE_SQL` + `hasMemoryEntriesTable` so the cherry-pick copy and the team import can't drift columns under `INSERT OR IGNORE`.
- **Quality (HIGH):** `INSERT OR IGNORE` silently swallows *any* constraint violation — out-of-CHECK-set `type` is now coerced to `semantic`, non-durable namespaces skipped before the insert, and timestamps never bind null, so a 0-import is never mis-reported as "already present".
- **Quality (MEDIUM):** gitignore rewrite strips a bare `.moflo/` even when `.moflo/*` already co-exists, and never injects a spurious `.moflo/*` for a custom artifact outside `.moflo/`.
- **Efficiency:** launcher pre-gate (no cost for solo users) + import wrapped in one transaction (single fsync, not per-row).

## Cross-platform (Rule #1)

`path.join`/`resolve` only; gitignore globs always `/` (POSIX-normalized, never `path.sep`); `spawnSync('git', …)` no-shell (resolves `git.exe`, not the npm `.cmd` trap); **binary-free UTF-8 source** (caught + fixed a stray NUL that made git treat the file as binary); tests use `tmpdir`/`mkdtemp` + env-driven home, no platform branch.

## Testing

- [x] `team-artifact-sync.test.ts` (19) — resolve precedence, durable-only export + provenance + no-embeddings + deterministic sort, first-write-wins, import merge/idempotency/provenance, **type coercion**, **non-durable skip**, malformed-line skip, A→B round-trip, **gitignore** (bare→contents+negation / both-rules / custom-path / idempotent / create).
- [x] `memory-team.test.ts` (3) — command-level export+gitignore, missing-artifact error, A→B round-trip.
- [x] Cherry-pick suite green after the shared-SQL refactor; full services/memory/config/commands/launcher/bin suites green (1767).
- [ ] Manual two-developer end-to-end (commit + pull + session-start) — follow-up.

## Known v1 limitation

The session-start import opens the local DB directly without stopping a same-version daemon (unlike §3's upgrade cherry-pick). node:sqlite + WAL prevents clobber; a held write lock would surface a transient `SQLITE_BUSY` that's caught + retried next session. Routing the import through the daemon's single-writer (#981) is a follow-up.

Closes #1234. Part of epic #1231.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
