### PR TITLE
fix(test): eliminate graph-analyzer flake via mkdtemp unique dirs

### DIFF
--- a/src/cli/__tests__/movector/graph-analyzer.test.ts
+++ b/src/cli/__tests__/movector/graph-analyzer.test.ts
@@ -24,7 +24,7 @@ import {
   type CircularDependency,
   type GraphAnalysisResult,
 } from '../../movector/graph-analyzer.js';
-import { mkdir, writeFile, rm } from 'fs/promises';
+import { mkdir, mkdtemp, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -34,8 +34,11 @@ describe('Graph Analyzer', () => {
   let testDir: string;
 
   beforeEach(async () => {
-    testDir = join(tmpdir(), `graph-test-${Date.now()}`);
-    await mkdir(testDir, { recursive: true });
+    // mkdtemp guarantees a UNIQUE directory per test. The previous
+    // `graph-test-${Date.now()}` collided when tests ran in the same
+    // millisecond, so files from one case (e.g. a circular b.ts) leaked into
+    // the next and flipped its cycle count — a non-deterministic flake.
+    testDir = await mkdtemp(join(tmpdir(), 'graph-test-'));
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary

`graph-analyzer.test.ts` flaked non-deterministically (different cases failed each run, reproducible on clean `main`). Surfaced during the epic #1231 review; pre-existing and unrelated to the epic.

Root cause: `beforeEach` derived the per-test directory from a timestamp —

```js
testDir = join(tmpdir(), `graph-test-${Date.now()}`);
```

Tests run fast and sequentially, so several land in the **same millisecond** → they share one directory. Files from one case (e.g. the circular `b.ts` that imports `a`) leaked into the next case's run, flipping its cycle count. The assertions are count-based (`cycles.length > 0` / `=== 0`), so a contaminated **input** — not analyzer ordering — produced the failures.

## Fix

```js
testDir = await mkdtemp(join(tmpdir(), 'graph-test-'));
```

`mkdtemp` returns an OS-guaranteed unique directory (and creates it, so the separate `mkdir` is dropped). No more cross-test contamination.

## Testing

- [x] Ran the file **10× consecutively — 28 passed / 1 skipped every run** (was failing intermittently before).
- [x] Same class of fix as the `listen(0)` ephemeral-port flake (#1239): let the OS allocate the unique resource instead of constructing a 'probably unique' name.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)