### PR TITLE
chore(deps): raise hono override past the high-sev advisory (>=4.12.25)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2949,9 +2949,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     }
   },
   "overrides": {
-    "hono": ">=4.11.4",
+    "hono": ">=4.12.25",
     "picomatch": ">=2.3.2",
     "protobufjs": ">=7.5.5"
   },


### PR DESCRIPTION
Raises the existing `hono` override floor (`>=4.11.4` → `>=4.12.25`) so it resolves to a safe **4.12.27**, clearing the high-severity advisory that fails the required **Lint & Security** check (`npm audit --omit=dev --audit-level=high`) repo-wide.

hono is transitive (via `@modelcontextprotocol/sdk`) and never imported by moflo — zero source impact. `npm audit --omit=dev --audit-level=high` now exits 0; build + lint clean.

Unblocks the security gate for all branches, including the epic #1231 PRs.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)