### PR TITLE
feat(memory): whole-DB snapshot backup/restore for fast workspace hydration (#1244)

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -2037,6 +2037,52 @@ try {
   } catch { /* writing the failure itself must not throw */ }
 }
 
+// ── 3e-1244. Hydrate a fresh workspace from a whole-DB snapshot BEFORE daemon ─
+// When `memory.hydrate_from` (or MOFLO_HYDRATE_FROM) points at a snapshot AND
+// the local .moflo/moflo.db is absent/empty, restore the whole DB (structural +
+// durable + embeddings) so the first session is searchable without a cold full
+// reindex (#1244, epic #1231). Runs BEFORE the daemon spawns so the restored
+// rows are present when the daemon builds its HNSW index, and BEFORE the purge/
+// sync blocks below so they operate on the hydrated DB. No-clobber: a no-op once
+// the local DB has content. Best-effort: a failure must never block session start.
+try {
+  // Cheap pre-gate so the overwhelming majority (no hydrate configured) pay
+  // nothing — no module load, no moflo.yaml parse. Live only when the env
+  // override is set or moflo.yaml has an UNcommented `hydrate_from:` line (the
+  // generated config ships a commented example, which this regex ignores).
+  const hydrateYamlPath = resolve(projectRoot, 'moflo.yaml');
+  let hydrateEnabled = Boolean(process.env.MOFLO_HYDRATE_FROM);
+  if (!hydrateEnabled && existsSync(hydrateYamlPath)) {
+    try {
+      hydrateEnabled = /^[ \t]*hydrate_from[ \t]*:/m.test(readFileSync(hydrateYamlPath, 'utf-8'));
+    } catch { /* unreadable yaml — treat as not-configured */ }
+  }
+  const hydratePaths = hydrateEnabled
+    ? [
+        resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/snapshot-restore.js'),
+        resolve(projectRoot, 'dist/src/cli/services/snapshot-restore.js'),
+      ]
+    : [];
+  const hydratePath = hydratePaths.find((p) => existsSync(p));
+  if (hydratePath) {
+    const { hydrateAtSessionStart } = await import(pathToFileURL(hydratePath).href);
+    const result = await hydrateAtSessionStart({ projectRoot });
+    if (result?.restored) {
+      const mb = ((result.bytes ?? 0) / (1024 * 1024)).toFixed(1);
+      emitMutation(
+        'hydrated workspace from snapshot',
+        `restored ${mb} MB whole-DB snapshot — search ready without a cold reindex`,
+      );
+    }
+  }
+} catch (err) {
+  // Non-fatal — without a snapshot the workspace just cold-indexes as before.
+  try {
+    const msg = err && err.message ? err.message : String(err);
+    process.stderr.write(`snapshot hydration skipped: ${msg}\n`);
+  } catch { /* writing the failure itself must not throw */ }
+}
+
 // ── 3e-728. Hard-delete leftover soft-delete tombstones (#728) ─────────────
 // Soft-delete was retired in story #728 — `status='deleted'` rows are now
 // unrecoverable bloat from prior moflo versions. Purge any stragglers and

--- a/src/cli/__tests__/services/snapshot-restore.test.ts
+++ b/src/cli/__tests__/services/snapshot-restore.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for whole-DB snapshot backup/restore (#1244, epic #1231).
+ *
+ * Covers:
+ *   - localDbHasContent: false for missing/empty DB, true once rows exist.
+ *   - backupSnapshot: produces a standalone single-file snapshot (no sidecars),
+ *     throws on a missing source / self-reference.
+ *   - restoreSnapshot: seeds an empty workspace (structural + durable rows
+ *     present afterwards), no-clobbers a populated DB unless force, rejects an
+ *     invalid/missing snapshot, purges ephemeral namespaces from the restored
+ *     copy.
+ *   - resolveHydratePath / hydrateAtSessionStart: env > config precedence,
+ *     no-op when unconfigured or the local DB already has content.
+ *
+ * Uses real node:sqlite DBs in tmp dirs — backup/restore is pure file IO with
+ * no daemon. All paths go through path.join / os.tmpdir (Rule #1).
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  localDbHasContent,
+  backupSnapshot,
+  restoreSnapshot,
+  resolveHydratePath,
+  hydrateAtSessionStart,
+  RESTORE_SKIP_REASONS,
+} from '../../services/snapshot-restore.js';
+import { loadMofloConfig, type MofloConfig } from '../../config/moflo-config.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { makeMemoryDb, type FixtureDb } from '../_helpers/legacy-memory-db.js';
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop()!;
+    try {
+      await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    } catch {
+      /* Windows file-lock — non-fatal for tests */
+    }
+  }
+});
+
+const savedEnv = process.env.MOFLO_HYDRATE_FROM;
+beforeEach(() => {
+  delete process.env.MOFLO_HYDRATE_FROM;
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.MOFLO_HYDRATE_FROM;
+  else process.env.MOFLO_HYDRATE_FROM = savedEnv;
+});
+
+async function makeRoot(prefix = 'moflo-snapshot-'): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+// loadMofloConfig returns a shared/cached config object — mutating `cfg.memory`
+// in place would pollute every later loadMofloConfig() in the suite. Clone the
+// memory sub-object so each case is hermetic.
+function configWithHydrate(root: string, hydrateFrom?: string): MofloConfig {
+  const cfg = loadMofloConfig(root);
+  return { ...cfg, memory: { ...cfg.memory, hydrate_from: hydrateFrom } };
+}
+
+/** Seed a V3 memory DB at `dbPath` with (namespace, key) rows. */
+function makeDbWith(
+  dbPath: string,
+  rows: Array<{ key: string; namespace: string; content?: string }>,
+): Promise<void> {
+  return makeMemoryDb(dbPath, MEMORY_SCHEMA_V3, (db: FixtureDb) => {
+    for (const r of rows) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content) VALUES (?, ?, ?, ?)`,
+        [`id-${r.namespace}-${r.key}`, r.key, r.namespace, r.content ?? `content-${r.key}`],
+      );
+    }
+  });
+}
+
+/** Count rows in a DB by namespace (or all when omitted). */
+function rowCount(dbPath: string, namespace?: string): number {
+  const db = new DatabaseSync(dbPath);
+  try {
+    const sql = namespace
+      ? `SELECT COUNT(*) AS n FROM memory_entries WHERE namespace = ?`
+      : `SELECT COUNT(*) AS n FROM memory_entries`;
+    const stmt = db.prepare(sql);
+    const row = (namespace ? stmt.get(namespace) : stmt.get()) as { n: number };
+    return Number(row.n);
+  } finally {
+    db.close();
+  }
+}
+
+describe('localDbHasContent', () => {
+  it('is false for a missing DB', async () => {
+    const root = await makeRoot();
+    expect(localDbHasContent(root)).toBe(false);
+  });
+
+  it('is false for an empty (zero-row) DB', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), []);
+    expect(localDbHasContent(root)).toBe(false);
+  });
+
+  it('is true once a row exists', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [{ key: 'k', namespace: 'learnings' }]);
+    expect(localDbHasContent(root)).toBe(true);
+  });
+});
+
+describe('backupSnapshot', () => {
+  it('writes a standalone single-file snapshot with no sidecars', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [
+      { key: 'a', namespace: 'learnings' },
+      { key: 'b', namespace: 'code-map' },
+    ]);
+    const snap = join(root, 'snap.db');
+    const result = backupSnapshot({ projectRoot: root, toPath: snap });
+
+    expect(result.bytes).toBeGreaterThan(0);
+    expect(existsSync(snap)).toBe(true);
+    expect(existsSync(`${snap}-wal`)).toBe(false);
+    expect(existsSync(`${snap}-shm`)).toBe(false);
+    // Snapshot is a valid DB carrying BOTH structural and durable rows.
+    expect(rowCount(snap)).toBe(2);
+  });
+
+  it('produces a consistent snapshot while the source DB holds an open WAL', async () => {
+    const root = await makeRoot();
+    const dbPath = memoryDbPath(root);
+    await makeDbWith(dbPath, [{ key: 'a', namespace: 'learnings' }]);
+    // Hold an open WAL connection on the source during the backup — VACUUM INTO
+    // must still capture all committed rows into a standalone file.
+    const live = new DatabaseSync(dbPath);
+    live.exec('PRAGMA journal_mode=WAL');
+    live.exec(
+      `INSERT INTO memory_entries (id, key, namespace, content) VALUES ('id2', 'b', 'code-map', 'c')`,
+    );
+    try {
+      const snap = join(root, 'snap.db');
+      const result = backupSnapshot({ projectRoot: root, toPath: snap });
+      expect(result.bytes).toBeGreaterThan(0);
+      expect(existsSync(`${snap}-wal`)).toBe(false);
+      expect(rowCount(snap)).toBe(2);
+    } finally {
+      live.close();
+    }
+  });
+
+  it('throws when there is no local DB to back up', async () => {
+    const root = await makeRoot();
+    expect(() => backupSnapshot({ projectRoot: root, toPath: join(root, 'snap.db') })).toThrow(
+      /nothing to back up/i,
+    );
+  });
+
+  it('throws when --to aliases the local DB', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [{ key: 'a', namespace: 'learnings' }]);
+    expect(() => backupSnapshot({ projectRoot: root, toPath: memoryDbPath(root) })).toThrow(
+      /local memory DB itself/i,
+    );
+  });
+});
+
+describe('restoreSnapshot', () => {
+  it('seeds an empty workspace with the full DB (structural + durable)', async () => {
+    const src = await makeRoot('moflo-snap-src-');
+    await makeDbWith(memoryDbPath(src), [
+      { key: 'a', namespace: 'learnings' },
+      { key: 'b', namespace: 'code-map' },
+      { key: 'c', namespace: 'guidance' },
+    ]);
+    const snap = join(src, 'snap.db');
+    backupSnapshot({ projectRoot: src, toPath: snap });
+
+    const dest = await makeRoot('moflo-snap-dest-');
+    const result = await restoreSnapshot({ projectRoot: dest, fromPath: snap });
+
+    expect(result.restored).toBe(true);
+    expect(rowCount(memoryDbPath(dest))).toBe(3);
+    expect(rowCount(memoryDbPath(dest), 'code-map')).toBe(1);
+    expect(rowCount(memoryDbPath(dest), 'learnings')).toBe(1);
+  });
+
+  it('does not clobber a populated workspace (no force)', async () => {
+    const src = await makeRoot('moflo-snap-src-');
+    await makeDbWith(memoryDbPath(src), [{ key: 'fromSnap', namespace: 'learnings' }]);
+    const snap = join(src, 'snap.db');
+    backupSnapshot({ projectRoot: src, toPath: snap });
+
+    const dest = await makeRoot('moflo-snap-dest-');
+    await makeDbWith(memoryDbPath(dest), [{ key: 'local', namespace: 'learnings' }]);
+
+    const result = await restoreSnapshot({ projectRoot: dest, fromPath: snap });
+    expect(result.restored).toBe(false);
+    expect(result.reason).toBe(RESTORE_SKIP_REASONS.LOCAL_NOT_EMPTY);
+    // Local content is untouched.
+    expect(rowCount(memoryDbPath(dest), 'learnings')).toBe(1);
+  });
+
+  it('overwrites a populated workspace when force is set', async () => {
+    const src = await makeRoot('moflo-snap-src-');
+    await makeDbWith(memoryDbPath(src), [
+      { key: 's1', namespace: 'learnings' },
+      { key: 's2', namespace: 'learnings' },
+    ]);
+    const snap = join(src, 'snap.db');
+    backupSnapshot({ projectRoot: src, toPath: snap });
+
+    const dest = await makeRoot('moflo-snap-dest-');
+    await makeDbWith(memoryDbPath(dest), [{ key: 'local', namespace: 'learnings' }]);
+
+    const result = await restoreSnapshot({ projectRoot: dest, fromPath: snap, force: true });
+    expect(result.restored).toBe(true);
+    expect(rowCount(memoryDbPath(dest), 'learnings')).toBe(2);
+  });
+
+  it('purges ephemeral namespaces from the restored copy', async () => {
+    const src = await makeRoot('moflo-snap-src-');
+    await makeDbWith(memoryDbPath(src), [
+      { key: 'keep', namespace: 'learnings' },
+      { key: 'gone', namespace: 'hive-mind' },
+    ]);
+    const snap = join(src, 'snap.db');
+    backupSnapshot({ projectRoot: src, toPath: snap });
+
+    const dest = await makeRoot('moflo-snap-dest-');
+    const result = await restoreSnapshot({ projectRoot: dest, fromPath: snap });
+
+    expect(result.restored).toBe(true);
+    expect(rowCount(memoryDbPath(dest), 'learnings')).toBe(1);
+    expect(rowCount(memoryDbPath(dest), 'hive-mind')).toBe(0);
+  });
+
+  it('rejects a missing snapshot', async () => {
+    const dest = await makeRoot();
+    const result = await restoreSnapshot({ projectRoot: dest, fromPath: join(dest, 'nope.db') });
+    expect(result.restored).toBe(false);
+    expect(result.reason).toBe(RESTORE_SKIP_REASONS.SNAPSHOT_MISSING);
+  });
+
+  it('rejects a non-moflo file (no memory_entries table)', async () => {
+    const dest = await makeRoot();
+    const bogus = join(dest, 'bogus.db');
+    const db = new DatabaseSync(bogus);
+    db.exec('CREATE TABLE unrelated (x INTEGER)');
+    db.close();
+    const result = await restoreSnapshot({ projectRoot: dest, fromPath: bogus });
+    expect(result.restored).toBe(false);
+    expect(result.reason).toBe(RESTORE_SKIP_REASONS.INVALID_SNAPSHOT);
+  });
+});
+
+describe('resolveHydratePath / hydrateAtSessionStart', () => {
+  it('is off by default', async () => {
+    const root = await makeRoot();
+    expect(resolveHydratePath(root, configWithHydrate(root, undefined))).toBeNull();
+  });
+
+  it('env overrides config', async () => {
+    const root = await makeRoot();
+    process.env.MOFLO_HYDRATE_FROM = join(root, 'env-snap.db');
+    const resolved = resolveHydratePath(root, configWithHydrate(root, join(root, 'cfg-snap.db')));
+    expect(resolved).toBe(join(root, 'env-snap.db'));
+  });
+
+  it('resolves a relative config path against the project root', async () => {
+    const root = await makeRoot();
+    const resolved = resolveHydratePath(root, configWithHydrate(root, 'snaps/local.db'));
+    expect(resolved).toBe(join(root, 'snaps', 'local.db'));
+  });
+
+  it('no-op when unconfigured', async () => {
+    const root = await makeRoot();
+    const result = await hydrateAtSessionStart({
+      projectRoot: root,
+      config: configWithHydrate(root, undefined),
+    });
+    expect(result.restored).toBe(false);
+    expect(result.reason).toBe(RESTORE_SKIP_REASONS.NOT_CONFIGURED);
+  });
+
+  it('hydrates an empty workspace from the configured snapshot', async () => {
+    const src = await makeRoot('moflo-snap-src-');
+    await makeDbWith(memoryDbPath(src), [{ key: 'a', namespace: 'learnings' }]);
+    const snap = join(src, 'snap.db');
+    backupSnapshot({ projectRoot: src, toPath: snap });
+
+    const dest = await makeRoot('moflo-snap-dest-');
+    const result = await hydrateAtSessionStart({
+      projectRoot: dest,
+      config: configWithHydrate(dest, snap),
+    });
+    expect(result.restored).toBe(true);
+    expect(rowCount(memoryDbPath(dest), 'learnings')).toBe(1);
+  });
+
+  it('no-op when the local DB already has content', async () => {
+    const src = await makeRoot('moflo-snap-src-');
+    await makeDbWith(memoryDbPath(src), [{ key: 'a', namespace: 'learnings' }]);
+    const snap = join(src, 'snap.db');
+    backupSnapshot({ projectRoot: src, toPath: snap });
+
+    const dest = await makeRoot('moflo-snap-dest-');
+    await makeDbWith(memoryDbPath(dest), [{ key: 'local', namespace: 'learnings' }]);
+    const result = await hydrateAtSessionStart({
+      projectRoot: dest,
+      config: configWithHydrate(dest, snap),
+    });
+    expect(result.restored).toBe(false);
+    expect(result.reason).toBe(RESTORE_SKIP_REASONS.LOCAL_NOT_EMPTY);
+  });
+});

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -3230,11 +3230,105 @@ const teamImportCommand: Command = {
   },
 };
 
+// Snapshot backup/restore (#1244, epic #1231) — whole-DB hydration for fast
+// cold-start. Unlike `sync`/`team-*` (which move only the durable slice), these
+// move the ENTIRE DB (structural + durable + embeddings) so a fresh workspace
+// is searchable on its first session without a full reindex. Safe because each
+// restored workspace owns its own copy — this is snapshot-restore, NOT the
+// forbidden live whole-DB sharing (see `flo doctor -c shared-db`).
+const backupCommand: Command = {
+  name: 'backup',
+  description: 'Write a whole-DB snapshot (structural + durable + embeddings) for fast workspace hydration',
+  options: [
+    { name: 'to', description: 'Snapshot destination path', type: 'string' },
+  ],
+  examples: [
+    { command: 'flo memory backup --to ~/moflo-snapshots/myproject.db', description: 'Snapshot the local memory DB for seeding fresh workspaces' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const to = ctx.flags.to as string | undefined;
+    if (!to) {
+      output.printError('Specify a destination: --to <snapshot path>.');
+      return { success: false, exitCode: 1 };
+    }
+    const projectRoot = findProjectRoot();
+    try {
+      const { backupSnapshot } = await import('../services/snapshot-restore.js');
+      const result = backupSnapshot({ projectRoot, toPath: pathModule.resolve(expandHome(to)) });
+      const mb = (result.bytes / (1024 * 1024)).toFixed(1);
+      output.printSuccess(`Snapshot written → ${result.target} (${mb} MB)`);
+      output.printInfo('Hydrate a fresh workspace with `flo memory restore --from <path>` or `memory.hydrate_from` in moflo.yaml.');
+      return { success: true, data: result };
+    } catch (error) {
+      output.printError(`memory backup failed: ${error instanceof Error ? error.message : String(error)}`);
+      return { success: false, exitCode: 1 };
+    }
+  },
+};
+
+const restoreCommand: Command = {
+  name: 'restore',
+  description: 'Hydrate the local memory DB from a whole-DB snapshot (no-op unless the local DB is empty)',
+  options: [
+    { name: 'from', description: 'Snapshot source path', type: 'string' },
+    { name: 'force', description: 'Overwrite even when the local DB already has content', type: 'boolean' },
+  ],
+  examples: [
+    { command: 'flo memory restore --from ~/moflo-snapshots/myproject.db', description: 'Seed an empty workspace from a snapshot' },
+    { command: 'flo memory restore --from snap.db --force', description: 'Replace the local DB even if it has content' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const from = ctx.flags.from as string | undefined;
+    if (!from) {
+      output.printError('Specify a source: --from <snapshot path>.');
+      return { success: false, exitCode: 1 };
+    }
+    const projectRoot = findProjectRoot();
+    try {
+      const { restoreSnapshot, RESTORE_SKIP_REASONS } = await import('../services/snapshot-restore.js');
+      const result = await restoreSnapshot({
+        projectRoot,
+        fromPath: pathModule.resolve(expandHome(from)),
+        force: Boolean(ctx.flags.force),
+      });
+      if (result.restored) {
+        const mb = ((result.bytes ?? 0) / (1024 * 1024)).toFixed(1);
+        output.printSuccess(`Restored local memory DB from snapshot (${mb} MB) → ${result.target}`);
+        if ((result.purged ?? 0) > 0) {
+          output.printInfo(`${result.purged} ephemeral row${result.purged === 1 ? '' : 's'} purged from the restored copy.`);
+        }
+        output.printInfo('Restart your Claude Code session so the daemon indexes the restored DB.');
+        return { success: true, data: result };
+      }
+      switch (result.reason) {
+        case RESTORE_SKIP_REASONS.LOCAL_NOT_EMPTY:
+          output.printWarning('Local memory DB already has content — not clobbering it. Use --force to override.');
+          break;
+        case RESTORE_SKIP_REASONS.SNAPSHOT_MISSING:
+          output.printError(`Snapshot not found: ${pathModule.resolve(expandHome(from))}`);
+          return { success: false, exitCode: 1, data: result };
+        case RESTORE_SKIP_REASONS.INVALID_SNAPSHOT:
+          output.printError('Source is not a moflo snapshot (no memory_entries table).');
+          return { success: false, exitCode: 1, data: result };
+        case RESTORE_SKIP_REASONS.SELF_REFERENCE:
+          output.printWarning('--from path is the local memory DB itself — nothing to restore.');
+          break;
+        default:
+          output.printWarning('Restore was a no-op.');
+      }
+      return { success: true, data: result };
+    } catch (error) {
+      output.printError(`memory restore failed: ${error instanceof Error ? error.message : String(error)}`);
+      return { success: false, exitCode: 1 };
+    }
+  },
+};
+
 // Main memory command
 export const memoryCommand: Command = {
   name: 'memory',
   description: 'Memory management commands',
-  subcommands: [initMemoryCommand, storeCommand, retrieveCommand, searchCommand, listCommand, deleteCommand, statsCommand, configureCommand, cleanupCommand, compressCommand, exportCommand, importCommand, indexGuidanceCommand, rebuildIndexCommand, codeMapCommand, refreshCommand, restoreLearningsCommand, syncCommand, teamExportCommand, teamImportCommand],
+  subcommands: [initMemoryCommand, storeCommand, retrieveCommand, searchCommand, listCommand, deleteCommand, statsCommand, configureCommand, cleanupCommand, compressCommand, exportCommand, importCommand, indexGuidanceCommand, rebuildIndexCommand, codeMapCommand, refreshCommand, restoreLearningsCommand, syncCommand, teamExportCommand, teamImportCommand, backupCommand, restoreCommand],
   options: [],
   examples: [
     { command: 'flo memory store -k "key" -v "value"', description: 'Store data' },

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -116,6 +116,18 @@ export interface MofloConfig {
      * (solo default). `MOFLO_TEAM_ARTIFACT` overrides. Relative → project root.
      */
     team_artifact?: string;
+    /**
+     * Optional path to a **whole-DB snapshot** to hydrate a fresh/empty
+     * workspace from on session-start (#1244, epic #1231). When set and the
+     * local `.moflo/moflo.db` is absent/empty, it is restored from this
+     * snapshot BEFORE the daemon spawns — seeding structural + durable +
+     * embedding data so the first session is searchable without a cold
+     * reindex. No-op once the local DB has content (never clobbers an active
+     * workspace). Undefined = off. `MOFLO_HYDRATE_FROM` overrides. Relative →
+     * project root. Take a snapshot with `flo memory backup --to <path>`. See
+     * `src/cli/services/snapshot-restore.ts`.
+     */
+    hydrate_from?: string;
   };
 
   hooks: {
@@ -425,6 +437,12 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
         const v = raw.memory?.team_artifact ?? raw.memory?.teamArtifact;
         return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
       })(),
+      // #1244 — optional whole-DB snapshot to hydrate a fresh workspace from.
+      // Resolution to an absolute path happens lazily in snapshot-restore.ts.
+      hydrate_from: (() => {
+        const v = raw.memory?.hydrate_from ?? raw.memory?.hydrateFrom;
+        return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+      })(),
     },
     hooks: {
       pre_edit: raw.hooks?.pre_edit ?? raw.hooks?.preEdit ?? DEFAULT_CONFIG.hooks.pre_edit,
@@ -639,6 +657,12 @@ memory:
   #   Structural namespaces (code-map, guidance, tests) stay local per checkout.
   #   Absolute path recommended; overridable per-process via MOFLO_DURABLE_PATH.
   # team_artifact: .moflo/shared/learnings.jsonl  # opt-in (#1234): git-track this JSONL to share learnings across a team. Session-start import-merges it; "flo memory team-export" writes it. Leave unset for solo use.
+  # hydrate_from: /abs/path/to/moflo-snapshot.db
+  #   Optional whole-DB snapshot (#1244) to seed a fresh/empty workspace from on
+  #   session-start, skipping the cold full reindex (structural + durable +
+  #   embeddings restored at once). No-op once the local DB has content — never
+  #   clobbers an active workspace. Take one with "flo memory backup --to <path>".
+  #   Overridable per-process via MOFLO_HYDRATE_FROM.
 
 # Hook toggles (all on by default — disable to slim down)
 hooks:

--- a/src/cli/services/configured-path.ts
+++ b/src/cli/services/configured-path.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared resolution for opt-in "configured path" features (env override > a
+ * `moflo.yaml` value), plus a symlink-stable absolute form for path-identity
+ * comparison. Extracted from `durable-sync.ts` (#1232) when `snapshot-restore.ts`
+ * (#1244) grew the same env>config>resolve + self-reference-guard shape — a
+ * single source of truth so the two stay byte-identical (Rule #1 / #1145).
+ *
+ * @module cli/services/configured-path
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { normalizeProjectRoot } from './daemon-port.js';
+
+/**
+ * Resolve a path that may not exist yet to a stable absolute form for identity
+ * comparison. Reuses {@link normalizeProjectRoot} (the #1145 reference impl) so
+ * both sides of any comparison fold identically: it realpath's symlinks (macOS
+ * `/var/folders` → `/private/var/folders`) and lowercases on Windows (NTFS is
+ * case-insensitive). When the target doesn't exist yet — the common first-flush
+ * case — we realpath the nearest existing parent and rejoin the tail so a
+ * symlinked parent dir still normalises identically.
+ */
+export function stableAbsolute(p: string): string {
+  const abs = path.resolve(p);
+  if (fs.existsSync(abs)) return normalizeProjectRoot(abs);
+  return normalizeProjectRoot(
+    path.join(normalizeProjectRoot(path.dirname(abs)), path.basename(abs)),
+  );
+}
+
+/**
+ * Pick a configured path: a non-empty env override wins over the config value;
+ * the chosen value is resolved absolute (relative values against `projectRoot`).
+ * Returns `null` when neither is set — the "feature off" signal. Resolution is
+ * pure string/path work (no IO), so it's safe on the cold-start hot path.
+ */
+export function pickConfiguredPath(
+  envValue: string | undefined,
+  cfgValue: string | undefined,
+  projectRoot: string,
+): string | null {
+  const env = envValue?.trim();
+  const cfg = cfgValue?.trim();
+  const raw = env && env.length > 0 ? env : cfg;
+  if (!raw) return null;
+  return path.isAbsolute(raw) ? path.resolve(raw) : path.resolve(projectRoot, raw);
+}

--- a/src/cli/services/durable-sync.ts
+++ b/src/cli/services/durable-sync.ts
@@ -34,10 +34,9 @@
  * @module cli/services/durable-sync
  */
 
-import * as fs from 'fs';
 import * as path from 'path';
 import { findProjectRoot } from './project-root.js';
-import { normalizeProjectRoot } from './daemon-port.js';
+import { stableAbsolute, pickConfiguredPath } from './configured-path.js';
 import { memoryDbPath } from './moflo-paths.js';
 import { loadMofloConfig, type MofloConfig } from '../config/moflo-config.js';
 import {
@@ -62,39 +61,26 @@ export interface DurableSyncReport {
 }
 
 /**
- * Resolve a path that may not exist yet to a stable absolute form for identity
- * comparison. Reuses {@link normalizeProjectRoot} (the #1145 reference impl) so
- * both sides of any comparison fold identically: it realpath's symlinks (macOS
- * `/var/folders` → `/private/var/folders`) and lowercases on Windows (NTFS is
- * case-insensitive). When the target doesn't exist yet — the common first-flush
- * case — we realpath the nearest existing parent and rejoin the tail so a
- * symlinked parent dir still normalises identically (Rule #1).
- */
-function stableAbsolute(p: string): string {
-  const abs = path.resolve(p);
-  if (fs.existsSync(abs)) return normalizeProjectRoot(abs);
-  return normalizeProjectRoot(path.join(normalizeProjectRoot(path.dirname(abs)), path.basename(abs)));
-}
-
-/**
  * Resolve the configured durable-store path to an absolute path, or `null`
  * when the feature is off (no env, no `memory.durable_path`) or misconfigured
  * (points at this project's own local DB — syncing a DB with itself is a
  * no-op, so we disable rather than thrash).
  *
  * Precedence: `MOFLO_DURABLE_PATH` env > `memory.durable_path` (moflo.yaml).
- * Relative values resolve against the project root.
+ * Relative values resolve against the project root. Path-pick + symlink-stable
+ * identity live in {@link pickConfiguredPath}/{@link stableAbsolute}.
  */
 export function resolveDurablePath(
   projectRoot: string = findProjectRoot(),
   config?: MofloConfig,
 ): { path: string | null; skipped?: DurableSyncReport['skipped'] } {
-  const envRaw = process.env.MOFLO_DURABLE_PATH?.trim();
-  const cfgRaw = (config ?? loadMofloConfig(projectRoot)).memory.durable_path?.trim();
-  const raw = envRaw && envRaw.length > 0 ? envRaw : cfgRaw;
-  if (!raw) return { path: null, skipped: 'not-configured' };
+  const abs = pickConfiguredPath(
+    process.env.MOFLO_DURABLE_PATH,
+    (config ?? loadMofloConfig(projectRoot)).memory.durable_path,
+    projectRoot,
+  );
+  if (!abs) return { path: null, skipped: 'not-configured' };
 
-  const abs = path.isAbsolute(raw) ? path.resolve(raw) : path.resolve(projectRoot, raw);
   // Self-reference guard — never let the shared store alias the local DB.
   if (stableAbsolute(abs) === stableAbsolute(memoryDbPath(projectRoot))) {
     return { path: null, skipped: 'same-as-local' };

--- a/src/cli/services/snapshot-restore.ts
+++ b/src/cli/services/snapshot-restore.ts
@@ -1,0 +1,325 @@
+/**
+ * Whole-DB snapshot backup / restore for fast workspace hydration (#1244, epic #1231).
+ *
+ * Problem: the durable-slice sharing (#1232–#1234) deliberately shares only
+ * `learnings`/`knowledge`, on the premise that structural namespaces "rebuild
+ * cheaply from the indexers". That premise is FALSE on the cold first pass: an
+ * empty `.moflo/moflo.db` gives session-start `index-all` nothing to hash-skip,
+ * so it does the full expensive work — parse every file for `code-map` /
+ * `patterns` / `tests`, chunk all `guidance`, AND run ONNX embedding generation
+ * over all of it. On a large repo that is minutes, not "cheap".
+ *
+ * Solution: a one-time whole-DB SNAPSHOT restore that seeds a fresh/empty
+ * workspace with a complete DB (structural + durable + embeddings), skipping
+ * both the parse and the embed. This is NOT the forbidden whole-DB *live*
+ * sharing (see `flo doctor -c shared-db`):
+ *
+ *   - **Live-sharing** one DB between two running daemons is unsafe — each
+ *     daemon holds its own in-memory HNSW index; concurrent writes never
+ *     propagate, so search silently goes stale.
+ *   - **Snapshot-restore** is safe — after restore each workspace owns its OWN
+ *     copy. There is no second concurrent daemon, so no index divergence, and
+ *     branch drift self-heals via the existing incremental (hash-based) reindex.
+ *
+ * Composes with #1232–#1234: snapshot-restore gives fast cold-start; durable-
+ * slice sharing keeps `learnings` continuously converged afterwards.
+ *
+ * Safety rails:
+ *   - **No clobber.** Restore is a no-op when the local DB already has content,
+ *     unless `force` is explicitly set. A freshly-hydrated workspace never
+ *     overwrites an active one.
+ *   - **Single clean file.** Backup uses `VACUUM INTO`, which writes a fully
+ *     consistent standalone copy of the committed DB regardless of WAL state or
+ *     a concurrent daemon — the snapshot is a self-contained single file with
+ *     no `-wal`/`-shm` dependency, and there's no torn-read window.
+ *   - **No stale sidecars.** Restore strips any leftover `-wal`/`-shm` on the
+ *     local DB AFTER the swap so the restored bytes aren't shadowed by an old
+ *     WAL (and the original's WAL frames aren't dropped on a mid-restore crash).
+ *   - **No ephemeral leak.** After restore, ephemeral namespaces
+ *     (`hive-mind`, epic-state, tasklist trim, …) are purged so a source
+ *     workspace's run-state never bleeds into the hydrated one.
+ *   - **Before the daemon.** {@link hydrateAtSessionStart} runs in the same
+ *     session-start slot as the seed/cherry-pick blocks — before the daemon
+ *     spawns — so there's no two-writer / stale-snapshot race.
+ *
+ * Cross-platform (Rule #1): all IO is `node:fs`; restore is read-bytes +
+ * {@link atomicWriteFileSync} (temp-write → fsync → rename), never a shelled
+ * `cp`. Backup's `VACUUM INTO` + atomic rename goes through node:sqlite.
+ *
+ * @module cli/services/snapshot-restore
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { DatabaseSync } from 'node:sqlite';
+import { findProjectRoot } from './project-root.js';
+import { memoryDbPath } from './moflo-paths.js';
+import { stableAbsolute, pickConfiguredPath } from './configured-path.js';
+import { loadMofloConfig, type MofloConfig } from '../config/moflo-config.js';
+import { openDaemonDatabase, type SqlJsLikeDatabase } from '../memory/daemon-backend.js';
+import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
+import { hasMemoryEntriesTable } from './cherry-pick-learnings.js';
+
+/** WAL sidecar files SQLite keeps next to the main DB. */
+function sidecarPaths(dbPath: string): string[] {
+  return [`${dbPath}-wal`, `${dbPath}-shm`];
+}
+
+/** Remove `-wal`/`-shm` sidecars best-effort so they can't shadow new bytes. */
+function removeSidecars(dbPath: string): void {
+  for (const p of sidecarPaths(dbPath)) {
+    try {
+      if (fs.existsSync(p)) fs.rmSync(p);
+    } catch {
+      /* best-effort — a leftover empty sidecar is harmless on re-open */
+    }
+  }
+}
+
+/**
+ * True when `file` is a SQLite DB carrying a `memory_entries` table. Opens
+ * READ-ONLY on purpose: `openDaemonDatabase` forces `journal_mode=WAL`, which
+ * would write the file's header and litter `-wal`/`-shm` next to a snapshot we
+ * only want to inspect (and throw on read-only media). A read-only handle
+ * validates without mutating. Returns false for a missing/unreadable/non-moflo
+ * file rather than throwing.
+ */
+function fileHasMemoryEntries(file: string): boolean {
+  let db: DatabaseSync | null = null;
+  try {
+    db = new DatabaseSync(file, { readOnly: true });
+    const row = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='memory_entries' LIMIT 1`)
+      .get();
+    return Boolean(row);
+  } catch {
+    return false;
+  } finally {
+    db?.close();
+  }
+}
+
+/** Count rows in `memory_entries`, or `null` when the table/DB is absent. */
+function countMemoryRows(db: SqlJsLikeDatabase): number | null {
+  if (!hasMemoryEntriesTable(db)) return null;
+  const rows = db.exec('SELECT COUNT(*) FROM memory_entries');
+  const n = rows[0]?.values?.[0]?.[0];
+  return typeof n === 'number' ? n : Number(n ?? 0);
+}
+
+/**
+ * True when the local DB exists AND holds at least one `memory_entries` row.
+ * A missing file, a schema-less file, or a zero-row DB all count as "empty" —
+ * the only states where an unforced restore is allowed to seed.
+ */
+export function localDbHasContent(projectRoot: string = findProjectRoot()): boolean {
+  const dbPath = memoryDbPath(projectRoot);
+  if (!fs.existsSync(dbPath)) return false;
+  let db: SqlJsLikeDatabase | null = null;
+  try {
+    db = openDaemonDatabase(dbPath);
+    return (countMemoryRows(db) ?? 0) > 0;
+  } catch {
+    // Unreadable/corrupt local DB — treat as no usable content so a restore
+    // can replace it (the no-clobber guard protects only *valid* content).
+    return false;
+  } finally {
+    db?.close();
+  }
+}
+
+export interface BackupSnapshotOptions {
+  projectRoot?: string;
+  /** Destination snapshot path. */
+  toPath: string;
+}
+
+export interface BackupSnapshotResult {
+  /** Resolved local DB the snapshot was taken from. */
+  source: string;
+  /** Resolved snapshot path written. */
+  target: string;
+  /** Snapshot size in bytes. */
+  bytes: number;
+}
+
+/**
+ * Take a consistent whole-DB snapshot of the local `.moflo/moflo.db`.
+ *
+ * Uses `VACUUM INTO` — SQLite generates a fully-consistent standalone copy of
+ * the committed database into a fresh file, regardless of WAL state or a
+ * concurrent daemon holding the WAL. This avoids the
+ * checkpoint-then-`readFileSync` hazard (a `wal_checkpoint(TRUNCATE)` can come
+ * back `busy` leaving data in the `-wal`, and a concurrent checkpoint can
+ * rewrite the main file mid-read → torn copy). The vacuum lands on a
+ * process-unique temp path, which is then atomically renamed onto `toPath`, so
+ * a crash never leaves a half-written snapshot in place. The result is a
+ * single self-contained file with no sidecar dependency.
+ *
+ * Throws when there is no local DB to back up, when `toPath` aliases the source
+ * (symlink-aware), or when the produced snapshot fails validation.
+ */
+export function backupSnapshot(options: BackupSnapshotOptions): BackupSnapshotResult {
+  const projectRoot = options.projectRoot ?? findProjectRoot();
+  const source = path.resolve(memoryDbPath(projectRoot));
+  const target = path.resolve(options.toPath);
+
+  if (!fs.existsSync(source)) {
+    throw new Error(`No local memory DB at ${source} — nothing to back up yet.`);
+  }
+  // Symlink-aware self-reference guard (Rule #1 / #1145) — a symlinked --to
+  // must not resolve back onto the live DB and VACUUM INTO over it.
+  if (stableAbsolute(target) === stableAbsolute(source)) {
+    throw new Error('--to path is the local memory DB itself — choose a different snapshot path.');
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const tmp = `${target}.tmp.${process.pid}.${process.hrtime.bigint().toString(36)}`;
+  try {
+    if (fs.existsSync(tmp)) fs.rmSync(tmp);
+    const db = openDaemonDatabase(source);
+    try {
+      // VACUUM INTO takes a SQL string literal, not a bound param — double any
+      // single quote in the path so a quote in the dir name can't break out.
+      db.exec(`VACUUM INTO '${tmp.replace(/'/g, "''")}'`);
+    } finally {
+      db.close();
+    }
+    // Guard against a torn/empty vacuum before we publish it.
+    if (!fileHasMemoryEntries(tmp)) {
+      throw new Error('snapshot validation failed — produced file has no memory_entries table.');
+    }
+    fs.renameSync(tmp, target);
+  } catch (err) {
+    try { if (fs.existsSync(tmp)) fs.rmSync(tmp); } catch { /* best-effort cleanup */ }
+    throw err;
+  }
+
+  return { source, target, bytes: fs.statSync(target).size };
+}
+
+/** Why a restore did not seed the local DB. */
+export const RESTORE_SKIP_REASONS = {
+  NOT_CONFIGURED: 'not-configured',
+  SNAPSHOT_MISSING: 'snapshot-missing',
+  INVALID_SNAPSHOT: 'invalid-snapshot',
+  LOCAL_NOT_EMPTY: 'local-not-empty',
+  SELF_REFERENCE: 'self-reference',
+} as const;
+export type RestoreSkipReason = (typeof RESTORE_SKIP_REASONS)[keyof typeof RESTORE_SKIP_REASONS];
+
+export interface RestoreSnapshotOptions {
+  projectRoot?: string;
+  /** Snapshot file to restore from. */
+  fromPath: string;
+  /** Overwrite even when the local DB already has content (default false). */
+  force?: boolean;
+}
+
+export interface RestoreSnapshotResult {
+  /** True when the local DB was replaced from the snapshot. */
+  restored: boolean;
+  /** Set when `restored` is false. */
+  reason?: RestoreSkipReason;
+  /** Resolved local DB path. */
+  target: string;
+  /** Snapshot size in bytes (when restored). */
+  bytes?: number;
+  /** Ephemeral rows purged from the restored DB. */
+  purged?: number;
+}
+
+/**
+ * Restore a whole-DB snapshot into the local `.moflo/moflo.db`, seeding a
+ * fresh workspace with structural + durable + embedding data so its first
+ * session is searchable without a cold reindex.
+ *
+ * No-clobber: returns `{ restored: false, reason: 'local-not-empty' }` when the
+ * local DB already has rows, unless `force` is set. The snapshot is validated
+ * (must carry `memory_entries`) before any local bytes are touched. After a
+ * successful restore, ephemeral namespaces are purged so the source workspace's
+ * run-state never leaks in.
+ */
+export async function restoreSnapshot(
+  options: RestoreSnapshotOptions,
+): Promise<RestoreSnapshotResult> {
+  const projectRoot = options.projectRoot ?? findProjectRoot();
+  const target = path.resolve(memoryDbPath(projectRoot));
+  const from = path.resolve(options.fromPath);
+
+  // Symlink-aware self-reference guard (Rule #1 / #1145).
+  if (stableAbsolute(from) === stableAbsolute(target)) {
+    return { restored: false, reason: RESTORE_SKIP_REASONS.SELF_REFERENCE, target };
+  }
+  if (!fs.existsSync(from)) {
+    return { restored: false, reason: RESTORE_SKIP_REASONS.SNAPSHOT_MISSING, target };
+  }
+  if (!options.force && localDbHasContent(projectRoot)) {
+    return { restored: false, reason: RESTORE_SKIP_REASONS.LOCAL_NOT_EMPTY, target };
+  }
+
+  // Validate the snapshot carries the durable schema BEFORE touching local
+  // bytes — read-only so we never mutate (or sidecar-litter) the source.
+  if (!fileHasMemoryEntries(from)) {
+    return { restored: false, reason: RESTORE_SKIP_REASONS.INVALID_SNAPSHOT, target };
+  }
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  // Atomic-swap the snapshot's bytes onto the local DB, THEN strip any stale
+  // `-wal`/`-shm` so the old WAL can't be replayed onto the new file. (Removing
+  // sidecars BEFORE the swap would, under --force, drop the original DB's
+  // uncheckpointed WAL frames if the process died mid-restore.)
+  const bytes = fs.readFileSync(from);
+  atomicWriteFileSync(target, bytes);
+  removeSidecars(target);
+
+  // Strip the source workspace's ephemeral run-state from the restored copy.
+  let purged = 0;
+  try {
+    const { purgeEphemeralNamespaces } = await import('./ephemeral-namespace-purge.js');
+    const result = await purgeEphemeralNamespaces({ dbPath: target });
+    purged = (result?.purged ?? 0) + (result?.trimmed ?? 0);
+  } catch {
+    // Non-fatal — a leftover ephemeral row is harmless and the next session
+    // start's standalone purge sweeps it.
+  }
+
+  return { restored: true, target, bytes: bytes.length, purged };
+}
+
+/**
+ * Resolve the configured hydrate-from snapshot path, or `null` when the feature
+ * is off. Precedence: `MOFLO_HYDRATE_FROM` env > `memory.hydrate_from`
+ * (moflo.yaml). Relative values resolve against the project root.
+ */
+export function resolveHydratePath(
+  projectRoot: string = findProjectRoot(),
+  config?: MofloConfig,
+): string | null {
+  return pickConfiguredPath(
+    process.env.MOFLO_HYDRATE_FROM,
+    (config ?? loadMofloConfig(projectRoot)).memory.hydrate_from,
+    projectRoot,
+  );
+}
+
+/**
+ * Session-start auto-hydrate: when `memory.hydrate_from` (or
+ * `MOFLO_HYDRATE_FROM`) points at a snapshot AND the local DB is empty, restore
+ * it. Runs BEFORE the daemon spawns (same slot as the durable-sync /
+ * cherry-pick blocks) so the seeded rows are present when the daemon builds its
+ * in-memory HNSW index. A no-op when unconfigured or the local DB already has
+ * content. Best-effort: callers swallow throws so hydration never blocks start.
+ */
+export async function hydrateAtSessionStart(
+  opts: { projectRoot?: string; config?: MofloConfig } = {},
+): Promise<RestoreSnapshotResult> {
+  const projectRoot = opts.projectRoot ?? findProjectRoot();
+  const target = path.resolve(memoryDbPath(projectRoot));
+  const from = resolveHydratePath(projectRoot, opts.config);
+  if (!from) {
+    return { restored: false, reason: RESTORE_SKIP_REASONS.NOT_CONFIGURED, target };
+  }
+  // force stays false — auto-hydrate must never clobber an active workspace.
+  return restoreSnapshot({ projectRoot, fromPath: from });
+}

--- a/tests/system/fixtures/writer-audit-whitelist.json
+++ b/tests/system/fixtures/writer-audit-whitelist.json
@@ -218,6 +218,11 @@
       "notes": "Imports the git-tracked team JSONL artifact into local moflo.db at session-start before the daemon spawns (#1234); same pre-boot writer shape as cherry-pick. The team-import CLI path matches restore-learnings' offline usage."
     },
     {
+      "file": "src/cli/services/snapshot-restore.ts",
+      "classification": "daemon-offline",
+      "notes": "Whole-DB snapshot backup (VACUUM INTO via db.exec) + restore (atomicWriteFileSync of moflo.db) for fast workspace hydration (#1244). Session-start auto-hydrate (block 3e-1244) runs BEFORE the daemon spawns; the backup/restore CLI verbs are manual offline ops — same pre-boot writer shape as cherry-pick/team-artifact."
+    },
+    {
       "file": "src/cli/services/learning-service.ts",
       "classification": "daemon-offline",
       "notes": "Hooks library save() — S3 verifies caller context and confirms classification"


### PR DESCRIPTION
Closes #1244. Part of epic #1231.

## Summary

Adds a one-time **whole-DB snapshot backup/restore** so a freshly-hydrated workspace (Conductor workspace, fresh clone, new worktree) is searchable on its **first session without a cold full reindex**. The durable-slice sharing shipped in #1232–#1234 shares only `learnings`/`knowledge` on the premise that structural namespaces "rebuild cheaply" — false on the cold first pass, where an empty `.moflo/moflo.db` forces a full parse **and** ONNX re-embed of `code-map`/`patterns`/`tests`/`guidance`. A snapshot restore skips both.

### This is NOT whole-DB live-sharing

| Operation | Safe? | Why |
|-----------|-------|-----|
| **Live-sharing** one DB between two running daemons | ❌ | Each daemon holds its own in-memory HNSW index; concurrent writes don't propagate → stale search. This is what `flo doctor -c shared-db` warns against. |
| **Restoring a snapshot** to seed a fresh/empty workspace | ✅ | Each workspace owns its own copy — no second concurrent daemon, no index divergence. Branch drift self-heals via the existing incremental reindex. |

Composes with #1232–#1234: snapshot-restore gives fast cold-start; durable-slice sharing keeps `learnings` continuously converged afterward.

## Surface

- `flo memory backup --to <snapshot>` — `VACUUM INTO` a temp file then atomic rename.
- `flo memory restore --from <snapshot> [--force]` — no-clobber unless the local DB is empty; read-only snapshot validation; strips stale `-wal`/`-shm` after the swap; purges ephemeral namespaces from the restored copy.
- `memory.hydrate_from` (env `MOFLO_HYDRATE_FROM`) — session-start auto-hydrate (launcher block 3e-1244), **before the daemon spawns**, behind a cheap pre-gate so solo users pay nothing.

## Correctness (from a 3-agent Opus review)

- **Backup uses `VACUUM INTO`**, not `wal_checkpoint(TRUNCATE)` + `readFileSync` — the checkpoint can return `busy` (data stranded in `-wal`) and a concurrent daemon can rewrite the main file mid-read (torn copy). `VACUUM INTO` writes a consistent standalone file regardless of WAL state, then an atomic rename publishes it.
- **Snapshot validated via a read-only handle** — `openDaemonDatabase` forces `journal_mode=WAL`, which would write the source header + litter `-wal`/`-shm` (and throw on read-only media).
- **Sidecars stripped after the swap, not before** — removing them before the rename would drop the original DB's uncheckpointed WAL frames on a mid-restore crash (under `--force`).
- **Symlink-aware self-reference guards** (Rule #1 / #1145), not `path.resolve` equality.
- **Post-write validation** before a snapshot is published.

## Reuse

`env > config > resolve` + symlink-stable identity extracted to `configured-path.ts` (`pickConfiguredPath` + `stableAbsolute`); `durable-sync.ts` (#1232) now shares it.

## Cross-platform (Rule #1)

`node:fs` only, atomic rename, no shelling; `VACUUM INTO` via node:sqlite; verified on Node 24.

## Scope decisions

- `sidecarPaths`/content-probe dedup into `memory/init.ts` (reviewer findings #2/#3) **deferred** — would widen blast radius into the load-bearing memory initializer for a minor dedup.
- Restore keeps `atomicWriteFileSync` (fsync + Windows AV-lock verify) over a buffer-free `copyFileSync` — durability on the post-restore daemon-open outweighs one-time memory on a rare path.

## Tests

`snapshot-restore.test.ts` — backup roundtrip, **active-WAL consistency**, no-clobber, `--force`, ephemeral purge, invalid/missing snapshot, hydrate precedence. **695 services + config tests green**; build clean.

## Acceptance criteria

- [x] Fresh workspace restored from a snapshot is searchable without a cold reindex (structural + durable + embeddings present).
- [x] Restore is a no-op (no clobber) when the local DB has content.
- [x] Branch drift reconciles via the existing incremental reindex after restore.
- [x] Backup produces a consistent file even with an active WAL.
- [x] Ephemeral namespaces don't leak from the source snapshot.
- [x] Restore happens before the daemon spawns.
- [x] Cross-platform: `fs`-based, atomic rename, no shelling; checkpoint/vacuum via node:sqlite.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)