### PR TITLE
docs: document shipped snapshot hydration (#1244) + coordination with durable-slice sharing

### DIFF
--- a/.claude/guidance/shipped/moflo-cross-install-memory-sharing.md
+++ b/.claude/guidance/shipped/moflo-cross-install-memory-sharing.md
@@ -16,7 +16,7 @@ moflo's `.moflo/moflo.db` holds three classes of data. Only one is worth sharing
 
 **Never *live-share* the entire `moflo.db` between two running daemons.** node:sqlite + WAL stops concurrent writers from losing rows, but each daemon builds its own in-memory HNSW index — a write in install A never updates install B's index, so search silently returns stale results, and structural namespaces churn across branches. For ongoing sync, share ONLY the durable slice.
 
-> **Not the same thing:** restoring a one-time whole-DB *snapshot* to seed a fresh/empty workspace is safe and fast — each workspace then owns its own copy (no second concurrent daemon, so no index divergence), and the incremental reindex reconciles branch drift. That avoids the cold-start full parse + re-embed and is the right tool when speed-to-ready matters. See [#1244](https://github.com/eric-cielo/moflo/issues/1244). The rule above is specifically about *live concurrent* sharing.
+> **Not the same thing:** restoring a one-time whole-DB *snapshot* to seed a fresh/empty workspace is safe and fast — each workspace then owns its own copy (no second concurrent daemon, so no index divergence), and the incremental reindex reconciles branch drift. That avoids the cold-start full parse + re-embed and is the right tool when speed-to-ready matters. Use `flo memory backup`/`restore` for it — see "Hydrate a Fresh Workspace from a Snapshot" below. The rule above is specifically about *live concurrent* sharing.
 
 ---
 
@@ -29,8 +29,9 @@ Choose by who needs the learnings, not by what is easiest to wire.
 | Same machine, many worktrees / Conductor workspaces | `memory.durable_path` | Point every checkout at one durable-only store; session-start seeds + writes through automatically |
 | One person, many machines | `flo memory sync` | `--to <file>` then `--from <file>` via a synced folder (Dropbox/iCloud) or a hand-copied file |
 | A team sharing one repo | Git-tracked team artifact | `flo memory team-export` writes `.moflo/shared/learnings.jsonl`; teammates' session-start import-merges it after `git pull` |
+| A fresh/empty workspace that must be ready FAST | Whole-DB snapshot (`memory.hydrate_from`) | `flo memory backup --to <snap>` once; a new workspace restores the entire DB so search works on session one — no cold reindex |
 
-All three move the SAME durable slice and dedupe on `UNIQUE(namespace, key)`, so combining them is conflict-free.
+The first three move the SAME durable slice and dedupe on `UNIQUE(namespace, key)`, so combining them is conflict-free. The snapshot is a different tool — a one-time whole-DB seed that composes with the durable-slice modes (see the next section but one).
 
 ---
 
@@ -70,6 +71,33 @@ git add .moflo/shared/learnings.jsonl && git commit -m "share learnings"
 ```
 
 Teammates' session-start import-merges the file after `git pull` (first-write-wins on conflicts; author/host provenance is retained). JSONL keeps git diffs reviewable; embeddings are regenerated on import. Enable it with `memory.team_artifact: .moflo/shared/learnings.jsonl`.
+
+---
+
+## Hydrate a Fresh Workspace from a Snapshot
+
+Use a whole-DB snapshot when a new workspace must be searchable on its FIRST session. An empty `.moflo/moflo.db` forces a full cold reindex — parse every file for `code-map`/`patterns`/`tests`, chunk all `guidance`, AND run ONNX embedding generation over all of it (minutes on a large repo). A snapshot restore skips both the parse and the embed.
+
+```bash
+flo memory backup  --to   ~/moflo-snapshots/myproject.db   # snapshot a warm workspace (VACUUM INTO — consistent even under an active WAL)
+flo memory restore --from ~/moflo-snapshots/myproject.db   # seed a fresh workspace (no-op if the local DB already has content; --force to override)
+```
+
+Auto-hydrate on session-start by setting `memory.hydrate_from` (env `MOFLO_HYDRATE_FROM` overrides):
+
+```yaml
+memory:
+  hydrate_from: /abs/path/to/moflo-snapshot.db   # restored only when the local DB is empty, before the daemon starts
+```
+
+| Behavior | Rule |
+|----------|------|
+| When it restores | Only when the local DB is absent/empty (never clobbers an active workspace unless `--force`) |
+| Ephemeral leak | Source `tasklist`/`hive-mind`/epic-state are purged from the restored copy |
+| Branch drift | Self-heals on the next incremental reindex |
+| Order vs. durable-slice | Hydrate runs BEFORE the durable-slice sync at session-start — snapshot is the fast one-time seed, durable-slice keeps `learnings` converged afterward |
+
+This is NOT whole-DB *live* sharing: each restored workspace owns its own copy, so there is no second concurrent daemon and no HNSW index divergence.
 
 ---
 

--- a/.claude/guidance/shipped/moflo-yaml-reference.md
+++ b/.claude/guidance/shipped/moflo-yaml-reference.md
@@ -62,6 +62,7 @@ memory:
   namespace: default              # Default namespace for memory operations
   # durable_path: ~/.moflo-shared/team-learnings.db   # opt-in (#1232): share durable namespaces (learnings, knowledge) across worktrees / Conductor workspaces. Point at a DEDICATED store, never a full moflo.db. Env override: MOFLO_DURABLE_PATH.
   # team_artifact: .moflo/shared/learnings.jsonl       # opt-in (#1234): git-tracked JSONL the team commits; session-start import-merges it. Env override: MOFLO_TEAM_ARTIFACT. See moflo-cross-install-memory-sharing.md.
+  # hydrate_from: /abs/path/to/moflo-snapshot.db       # opt-in (#1244): whole-DB snapshot to seed a fresh/empty workspace on session-start (skips the cold reindex). No-op once the local DB has content. Take one with "flo memory backup --to <path>". Env override: MOFLO_HYDRATE_FROM.
 
 # Hook toggles (all on by default — disable to slim down)
 hooks:

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ The two are complementary: auto-meditate is the always-on safety net, `/meditate
 
 ### Sharing learnings across installations
 
-The `learnings` (and `knowledge`) namespaces are the **durable** slice of memory — user-authored and worth carrying across checkouts. The rest of the DB (code-map, guidance chunks, run state) is structural or ephemeral and rebuilds cheaply, so it stays local. MoFlo shares only the durable slice — **never the whole `moflo.db`**, which would make each daemon's in-memory search index diverge.
+The `learnings` (and `knowledge`) namespaces are the **durable** slice of memory — user-authored and worth carrying across checkouts. The rest of the DB (code-map, guidance chunks, run state) is structural or ephemeral and rebuilds cheaply, so it stays local. For ongoing sync MoFlo shares only the durable slice — **never *live-shares* the whole `moflo.db`** between two daemons, which would make each daemon's in-memory search index diverge.
 
 Pick the mechanism by topology:
 
@@ -274,8 +274,9 @@ Pick the mechanism by topology:
 | Git worktrees / Conductor workspaces (same machine) | `memory.durable_path` in `moflo.yaml` | Point every checkout at one durable-only store; session-start seeds + writes through automatically |
 | Your own laptop + desktop + CI | `flo memory sync --to/--from <file>` | Export to a synced folder (Dropbox/iCloud) or a copied file, import on the other machine |
 | A whole team on one repo | `flo memory team-export` → commit `.moflo/shared/learnings.jsonl` | Teammates' session-start import-merges it after `git pull` (first-write-wins; author provenance retained) |
+| A fresh workspace that must be ready fast | `flo memory backup/restore` or `memory.hydrate_from` | Seed a new workspace from a **whole-DB snapshot** so it's searchable on session one — no cold reindex. Safe because each workspace owns its own copy (a one-time restore, not live sharing) |
 
-Verify your setup with `flo doctor -c shared-db` (it warns if you've accidentally pointed at a full `moflo.db`). Full guide: [`moflo-cross-install-memory-sharing.md`](.claude/guidance/shipped/moflo-cross-install-memory-sharing.md).
+Verify your setup with `flo doctor -c shared-db` (it warns if you've accidentally pointed at a full `moflo.db` for *live* sharing). Full guide: [`moflo-cross-install-memory-sharing.md`](.claude/guidance/shipped/moflo-cross-install-memory-sharing.md).
 
 ## The Gate System
 

--- a/docs/cross-install-memory-sharing.html
+++ b/docs/cross-install-memory-sharing.html
@@ -73,9 +73,9 @@
     <h1>Cross-Installation Memory Sharing</h1>
     <div class="sub">Epic <strong>#1231</strong> — share moflo's durable <code>learnings</code> across git worktrees, machines, and teams, without corrupting search. This document reads top-to-bottom as a high-level overview; expand any <em>“Detailed design”</em> panel to drill into implementation, decisions, and tests.</div>
     <div class="badges">
-      <span class="badge good">7 PRs merged to main</span>
-      <span class="badge">4 stories + 3 supporting fixes</span>
-      <span class="badge">durable-slice-only design</span>
+      <span class="badge good">8 PRs merged to main</span>
+      <span class="badge">5 stories + 3 supporting fixes</span>
+      <span class="badge">durable-slice sharing + whole-DB hydration</span>
       <span class="badge">cross-platform (Rule #1) verified</span>
       <span class="badge">3-agent architectural review</span>
     </div>
@@ -94,6 +94,7 @@
     <a href="#s1233">#1233 — memory sync</a>
     <a href="#s1234">#1234 — team artifact</a>
     <a href="#s1235">#1235 — docs + doctor</a>
+    <a href="#s1244">#1244 — snapshot hydration</a>
     <a href="#fixes">Supporting fixes</a>
     <a href="#review">Quality &amp; review</a>
     <a href="#xplat">Cross-platform</a>
@@ -110,15 +111,17 @@
       <p class="lede">What we built and why, in one screen.</p>
       <div class="panel">
         <p>moflo stores everything it learns about a project in a local SQLite database (<code>.moflo/moflo.db</code>), which is <strong>gitignored</strong>. That means every fresh git worktree, every Conductor workspace, every new machine, and every teammate starts with an <strong>empty <code>learnings</code> namespace</strong> — accumulated knowledge is silently lost.</p>
-        <p>The fix is built on one key insight: <strong>only a thin slice of the DB is worth sharing</strong> — the user-authored <code>learnings</code> and <code>knowledge</code> namespaces. Everything else (code maps, guidance chunks, run state) is derived or ephemeral and rebuilds cheaply, so it stays local. Sharing the <em>whole</em> DB would make each daemon's in-memory search index diverge.</p>
-        <p>We shipped <strong>three sharing mechanisms</strong> (chosen by topology), plus documentation and a safety check:</p>
+        <p>The fix is built on one key insight: for <em>continuous</em> sharing, <strong>only a thin slice of the DB is worth sharing</strong> — the user-authored <code>learnings</code> and <code>knowledge</code> namespaces. Everything else (code maps, guidance chunks, run state) is derived or ephemeral and rebuilds cheaply, so it stays local. <em>Live</em>-sharing the whole DB between two running daemons would make each daemon's in-memory search index diverge.</p>
+        <p>We shipped <strong>three durable-slice sharing mechanisms</strong> (chosen by topology), <strong>plus a whole-DB snapshot hydration</strong> for fast cold-start, plus documentation and a safety check:</p>
         <div class="grid">
           <div class="card"><div class="topo">Same machine</div><h4>Shared durable store</h4><div class="kv"><code>memory.durable_path</code> — worktrees / Conductor workspaces seed + write-through to one durable-only DB.</div></div>
           <div class="card"><div class="topo">One user, many machines</div><h4>Portable artifact</h4><div class="kv"><code>flo memory sync --to/--from</code> — carry a durable SQLite file via a synced folder.</div></div>
           <div class="card"><div class="topo">A team</div><h4>Git-tracked JSONL</h4><div class="kv"><code>flo memory team-export</code> → commit <code>.moflo/shared/learnings.jsonl</code>; teammates import-merge on pull.</div></div>
-          <div class="card"><div class="topo">Safety &amp; docs</div><h4>Doctor + guidance</h4><div class="kv"><code>flo doctor -c shared-db</code> warns against whole-DB sharing; a shipped guidance doc explains it all.</div></div>
+          <div class="card"><div class="topo">Fast cold-start</div><h4>Whole-DB snapshot</h4><div class="kv"><code>flo memory backup/restore</code> + <code>memory.hydrate_from</code> — seed a fresh workspace with the entire DB so it's searchable on its first session, no cold reindex.</div></div>
+          <div class="card"><div class="topo">Safety &amp; docs</div><h4>Doctor + guidance</h4><div class="kv"><code>flo doctor -c shared-db</code> warns against <em>live</em> whole-DB sharing; a shipped guidance doc explains it all.</div></div>
         </div>
-        <p class="note good"><strong>Status:</strong> all four stories and three supporting fixes are merged to <code>main</code> and verified (build + integration suites green). One acceptance criterion — the live two-worktree end-to-end — is proven at the service-test layer and pending a real-environment run.</p>
+        <p class="note good"><strong>How they compose:</strong> snapshot hydration (<a href="#s1244">#1244</a>) is a <em>one-time</em> seed that gets a new workspace running instantly; the three durable-slice mechanisms then keep <code>learnings</code> continuously converged afterward. At session-start, hydration runs <em>before</em> the durable-slice sync — fast seed first, continuous convergence after.</p>
+        <p class="note good"><strong>Status:</strong> all five stories and three supporting fixes are merged to <code>main</code> and verified (build + integration suites green). One acceptance criterion — the live two-worktree end-to-end — is proven at the service-test layer and pending a real-environment run.</p>
       </div>
     </section>
 
@@ -131,7 +134,7 @@
         <li><strong>Generalized:</strong> the same gap hits any topology where moflo runs from more than one checkout/machine — solo multi-machine, and teams on a shared repo.</li>
         <li><strong>The trap to avoid:</strong> <em>live-sharing</em> one <code>moflo.db</code> between two running daemons. node:sqlite + WAL prevents row loss, but <strong>each daemon builds its own in-memory HNSW index</strong> — a write from install A never updates install B's index, so search silently returns stale results, and structural namespaces churn across branches.</li>
       </ul>
-      <p class="note warn"><strong>A distinct, safe operation (planned — <a href="https://github.com/eric-cielo/moflo/issues/1244">#1244</a>):</strong> restoring a one-time whole-DB <em>snapshot</em> to seed a fresh/empty workspace is <em>not</em> the trap above. Each workspace then owns its own copy (no second concurrent daemon → no index divergence), and the incremental reindex reconciles branch drift. It's the right tool for fast cold-start: an empty DB forces a full parse + ONNX re-embed of all code/patterns/tests/guidance on the first session — minutes on a large repo — which a snapshot skips. "Never share the whole DB" is specifically about <em>live concurrent</em> sharing; snapshot-restore composes with the durable-slice sync (which keeps <code>learnings</code> converged afterward).</p>
+      <p class="note good"><strong>A distinct, safe operation (shipped — <a href="#s1244">#1244</a>):</strong> restoring a one-time whole-DB <em>snapshot</em> to seed a fresh/empty workspace is <em>not</em> the trap above. Each workspace then owns its own copy (no second concurrent daemon → no index divergence), and the incremental reindex reconciles branch drift. It's the right tool for fast cold-start: an empty DB forces a full parse + ONNX re-embed of all code/patterns/tests/guidance on the first session — minutes on a large repo — which a snapshot skips. "Never share the whole DB" is specifically about <em>live concurrent</em> sharing; snapshot-restore composes with the durable-slice sync (which keeps <code>learnings</code> converged afterward).</p>
     </section>
 
     <!-- ===================== MODEL ===================== -->
@@ -144,7 +147,8 @@
         <tr><td><strong>Structural</strong></td><td><code>code-map</code>, guidance chunks, tests, patterns</td><td class="bd">No</td><td>Branch-specific; rebuilds cheaply from the indexers</td></tr>
         <tr><td><strong>Ephemeral</strong></td><td><code>tasklist</code>, <code>hive-mind</code>, epic state</td><td class="bd">No</td><td>Per-run scratch; meaningless in another install</td></tr>
       </table>
-      <p>All three mechanisms move the <em>same</em> durable slice and dedupe on the existing <code>UNIQUE(namespace, key)</code> constraint via <code>INSERT OR IGNORE</code>, so combining them is conflict-free and idempotent.</p>
+      <p>All three durable-slice mechanisms move the <em>same</em> durable slice and dedupe on the existing <code>UNIQUE(namespace, key)</code> constraint via <code>INSERT OR IGNORE</code>, so combining them is conflict-free and idempotent.</p>
+      <p class="note"><strong>The one safe exception:</strong> a whole-DB <em>snapshot</em> (<a href="#s1244">#1244</a>) deliberately carries <em>all three</em> classes at once — that's the point, it skips the cold reindex. It's safe precisely because it's a <em>one-time restore into an empty workspace that then owns its own copy</em>, not a live shared DB. Structural drift self-heals on the next incremental reindex; ephemeral rows are purged on restore so the source workspace's run-state never leaks in.</p>
     </section>
 
     <!-- ===================== SOLUTIONS OVERVIEW ===================== -->
@@ -158,6 +162,7 @@
         <tr><td>A team on one repo</td><td>git-tracked artifact</td><td>JSONL (diffable)</td><td>Regenerated on import</td><td><a href="#s1234">#1234</a></td></tr>
       </table>
       <p class="legend">Why JSONL for teams but SQLite elsewhere: a committed team file must be <strong>diff-reviewable and merge-friendly</strong>; embeddings (384 floats/row) would make every diff unreadable, so they're dropped and regenerated. For the SQLite modes, carrying embeddings verbatim avoids a lossy/expensive re-embed.</p>
+      <p class="note"><strong>A fourth, complementary mechanism — whole-DB hydration (<a href="#s1244">#1244</a>):</strong> the three rows above share the durable <em>slice</em> continuously. Snapshot hydration is different in kind — it copies the <em>entire</em> DB once to make a brand-new workspace searchable instantly (no cold parse + re-embed). Use it to bootstrap; use the durable-slice modes to stay converged. See the <a href="#s1244">#1244 detail</a>.</p>
     </section>
 
     <hr>
@@ -285,6 +290,47 @@
       </details>
     </section>
 
+    <!-- ===================== STORY 1244 ===================== -->
+    <section id="s1244">
+      <h2><span class="num">#1244</span>Whole-DB snapshot hydration — <code>flo memory backup/restore</code></h2>
+      <p class="lede">Seed a fresh workspace with the entire DB so it's searchable on session one — no cold reindex. PR <a href="https://github.com/eric-cielo/moflo/pull/1245">#1245</a></p>
+      <p><strong>High level:</strong> <code>flo memory backup --to &lt;snap&gt;</code> takes a consistent whole-DB snapshot; <code>flo memory restore --from &lt;snap&gt;</code> (or <code>memory.hydrate_from</code> at session-start) restores it into an <em>empty</em> workspace. The restored DB already holds the structural namespaces <em>and</em> their embeddings, so the expensive first-pass parse + ONNX re-embed is skipped entirely.</p>
+      <div class="pillrow">
+        <span class="tag">src/cli/services/snapshot-restore.ts (new)</span>
+        <span class="tag">src/cli/services/configured-path.ts (new, shared)</span>
+        <span class="tag">commands: backup / restore</span>
+        <span class="tag">config: memory.hydrate_from</span>
+        <span class="tag">launcher block 3e-1244</span>
+      </div>
+      <p class="note good"><strong>Why this is safe (not the "never share the whole DB" trap):</strong> the forbidden case is two live daemons writing one DB — their in-memory HNSW indexes diverge. A snapshot restore is a <em>one-time copy into an empty workspace that then owns its own DB</em>. There's no second concurrent daemon, so no index divergence; branch drift self-heals via the existing incremental reindex.</p>
+      <details><summary>Detailed design &amp; implementation</summary>
+      <div class="det-body">
+        <h3>Coordination with durable-slice sharing</h3>
+        <p>The two layers are complementary and run in a deliberate order at session-start (all before the daemon spawns):</p>
+        <pre><code>3e-1244 hydrate  (whole-DB snapshot restore, only if local DB empty)
+   → ephemeral purge → 3e-1232 durable-slice sync → team-import → daemon</code></pre>
+        <p>A new workspace first restores the snapshot (instant search), <em>then</em> the durable-slice sync flushes/seeds <code>learnings</code> against the shared store. Snapshot = fast bootstrap; durable-slice = continuous convergence. They never fight: both are additive (<code>INSERT OR IGNORE</code> on <code>UNIQUE(namespace, key)</code>).</p>
+        <h3>Mechanism</h3>
+        <ul>
+          <li><code>backupSnapshot()</code> — <code>VACUUM INTO</code> a process-unique temp file, then atomic rename onto the target. The result is a self-contained single file (no <code>-wal</code>/<code>-shm</code> dependency).</li>
+          <li><code>restoreSnapshot()</code> — no-clobber unless <code>--force</code>: a no-op when the local DB already has rows. Validates the snapshot read-only, atomic-swaps its bytes onto the local DB, strips stale sidecars, then purges ephemeral namespaces from the restored copy.</li>
+          <li><code>hydrateAtSessionStart()</code> — reads <code>memory.hydrate_from</code> (env <code>MOFLO_HYDRATE_FROM</code>); restores only into an empty workspace, before the daemon builds its HNSW index.</li>
+        </ul>
+        <h3>Correctness fixes folded in (a 3-agent Opus review)</h3>
+        <ul>
+          <li><span class="bd">HIGH:</span> backup uses <code>VACUUM INTO</code>, <em>not</em> <code>wal_checkpoint(TRUNCATE)</code> + <code>readFileSync</code> — the checkpoint can return <code>busy</code> (data stranded in <code>-wal</code>) and a concurrent daemon can rewrite the main file mid-read (torn copy). <code>VACUUM INTO</code> writes a consistent standalone copy regardless of WAL state.</li>
+          <li><span class="bd">HIGH:</span> the snapshot is validated with a <strong>read-only</strong> handle — <code>openDaemonDatabase</code> forces <code>journal_mode=WAL</code>, which would write the source's header and litter <code>-wal</code>/<code>-shm</code> next to a file we only want to inspect (and throw on read-only media).</li>
+          <li><span class="wn">MEDIUM:</span> sidecars are stripped <em>after</em> the atomic swap, not before — removing them first would drop the original DB's uncheckpointed WAL frames on a mid-restore crash under <code>--force</code>.</li>
+          <li><span class="wn">MEDIUM:</span> self-reference guards are symlink-aware (<code>stableAbsolute</code> / <code>realpathSync</code>, ref #1145), not <code>path.resolve</code> equality.</li>
+          <li><span class="wn">Reuse:</span> the <code>env &gt; config &gt; resolve</code> + symlink-stable-identity logic (a near-clone of #1232's) was extracted to <code>configured-path.ts</code> and is now shared by both <code>durable-sync.ts</code> and <code>snapshot-restore.ts</code>.</li>
+          <li><span class="wn">Governance:</span> <code>snapshot-restore.ts</code> was added to the <code>moflo.db</code> writer-audit whitelist (<code>daemon-offline</code>) — caught by the full <code>tests/system</code> suite, not the services-only local run.</li>
+        </ul>
+        <h3>Default-off guarantee</h3>
+        <p><code>hydrate_from</code> defaults <code>undefined</code>; the launcher block 3e-1244 has the same cheap pre-gate as #1232 (env or an uncommented <code>hydrate_from:</code> line), so solo users load no module and parse no yaml each session.</p>
+      </div>
+      </details>
+    </section>
+
     <hr>
 
     <!-- ===================== FIXES ===================== -->
@@ -306,7 +352,7 @@
       <ul>
         <li><strong>Per-story:</strong> each PR ran <code>/flo-simplify</code> (a tiered reviewer; #1234 hit the DEEP tier → 3 parallel Opus reviewers for reuse / quality / efficiency).</li>
         <li><strong>Epic-wide:</strong> three parallel deep reviewers across all branches — <em>architecture &amp; cohesion</em>, <em>Rule #1 cross-platform</em>, and <em>regression &amp; consumer blast-radius</em> — plus a full test-suite run on each branch.</li>
-        <li><strong>Regression caught by the full suite:</strong> <code>team-artifact-sync.ts</code> was missing from the <code>moflo.db</code> writer-audit whitelist (a #1054/#1055 governance lint); added with a <code>daemon-offline</code> classification.</li>
+        <li><strong>Regression caught by the full suite:</strong> <code>team-artifact-sync.ts</code> (#1234) and later <code>snapshot-restore.ts</code> (#1244) were each missing from the <code>moflo.db</code> writer-audit whitelist (a #1054/#1055 governance lint) — both added with a <code>daemon-offline</code> classification. The services-only local run doesn't exercise <code>tests/system</code>, so CI is the backstop.</li>
       </ul>
       <details><summary>Architectural-review verdict (summary)</summary>
       <div class="det-body">
@@ -340,6 +386,7 @@
         <tr><td>No <code>hnsw.index</code> sidecar corruption under any sharing mode</td><td class="ok">✓ by construction — only <code>memory_entries</code> rows shared; doctor guards whole-DB</td></tr>
         <tr><td>Absent any config → byte-identical behavior</td><td class="ok">✓ feature-off tests + launcher pre-gates</td></tr>
         <tr><td>All paths cross-platform</td><td class="ok">✓ 3-branch Rule #1 audit clean</td></tr>
+        <tr><td>Snapshot restore is searchable without a cold reindex; no-clobbers a populated DB; backup consistent under an active WAL (<a href="#s1244">#1244</a>)</td><td class="ok">✓ snapshot-restore unit tests (incl. active-WAL consistency, no-clobber, ephemeral purge)</td></tr>
       </table>
     </section>
 
@@ -349,12 +396,15 @@
       <h3>Config (<code>moflo.yaml</code> · all opt-in, default off)</h3>
       <pre><code>memory:
   # durable_path: ~/.moflo-shared/team-learnings.db   # share durable namespaces across worktrees/Conductor (env: MOFLO_DURABLE_PATH)
-  # team_artifact: .moflo/shared/learnings.jsonl       # git-tracked team JSONL; session-start import-merges (env: MOFLO_TEAM_ARTIFACT)</code></pre>
+  # team_artifact: .moflo/shared/learnings.jsonl       # git-tracked team JSONL; session-start import-merges (env: MOFLO_TEAM_ARTIFACT)
+  # hydrate_from: /abs/path/to/moflo-snapshot.db       # seed a fresh/empty workspace from a whole-DB snapshot (env: MOFLO_HYDRATE_FROM)</code></pre>
       <h3>Commands</h3>
       <pre><code>flo memory sync --to   &lt;file&gt;     # export durable slice → portable artifact
 flo memory sync --from &lt;file&gt;     # merge a portable artifact → local
 flo memory team-export            # write .moflo/shared/learnings.jsonl + make it git-trackable
 flo memory team-import            # merge the team artifact (also runs at session-start)
+flo memory backup  --to   &lt;snap&gt;  # whole-DB snapshot (VACUUM INTO + atomic rename)
+flo memory restore --from &lt;snap&gt;  # hydrate an empty workspace from a snapshot (--force to overwrite)
 flo doctor -c shared-db           # warn if configured toward a shared full moflo.db</code></pre>
       <h3>Merged to <code>main</code></h3>
       <table>
@@ -366,8 +416,10 @@ flo doctor -c shared-db           # warn if configured toward a shared full mofl
         <tr><td class="mono-sm">4a5028816</td><td>#1237</td><td>#1233 memory sync</td></tr>
         <tr><td class="mono-sm">bc9f5ed82</td><td>#1238</td><td>#1234 team artifact</td></tr>
         <tr><td class="mono-sm">ba949b147</td><td>#1241</td><td>#1235 docs + doctor</td></tr>
+        <tr><td class="mono-sm">747ad3c86</td><td>#1243</td><td>README + hub-guidance cross-links</td></tr>
+        <tr><td class="mono-sm">—</td><td>#1245</td><td>#1244 snapshot backup/restore + hydrate</td></tr>
       </table>
-      <p class="legend">Plus PR #1243 (README + hub-guidance cross-links) — open at time of writing.</p>
+      <p class="legend">#1244 (snapshot hydration) was added as a follow-up after the original four stories — it makes the durable-slice sharing practical on large repos by eliminating the cold-start reindex.</p>
     </section>
 
     <!-- ===================== LANDING ===================== -->


### PR DESCRIPTION
Follow-up to #1245 (which shipped #1244). The epic docs merged in #1243 still framed snapshot hydration as a *future* follow-up — this updates them to document the shipped surface and, per review feedback, to explain **how the two layers coordinate**.

## Coordination (the question this answers)

The snapshot-hydration and durable-slice features are **complementary, not competing**, and already coordinate correctly at runtime (no code change needed). At session-start the launcher runs:

```
3e-1244 hydrate (whole-DB snapshot restore, only if local DB empty)
   → ephemeral purge → 3e-1232 durable-slice sync → team-import → daemon
```

A fresh workspace **first** restores the snapshot (instant search, no cold reindex), **then** the durable-slice layer keeps `learnings` continuously converged. Snapshot = one-time fast seed; durable-slice = ongoing convergence. Both are additive (`INSERT OR IGNORE` on `UNIQUE(namespace, key)`), so they never fight.

## Changes

- **`docs/cross-install-memory-sharing.html`** — new `#1244` detail section (VACUUM INTO, read-only validation, post-swap sidecar strip, realpath guards, shared `configured-path.ts`); a fourth "fast cold-start" mechanism card; the §2 "planned" note flipped to "shipped"; AC + shipped-surface + commit-table rows; the coordination ordering spelled out.
- **`moflo-cross-install-memory-sharing.md`** (shipped guidance) — new "Hydrate a Fresh Workspace from a Snapshot" section + topology row; blockquote reframed. **126 lines** (under the 500 cap); follows the guidance authoring rules (Purpose line, imperative, decision table, concrete examples, specific headings, See Also).
- **`moflo-yaml-reference.md`** — `memory.hydrate_from` example.
- **`README.md`** — snapshot row in the sharing table; "live-share" wording precision.

## Verification

- Guidance doc 126 lines (cap 500); HTML tags balanced.
- Rule #1: docs-only change; the underlying #1244 code was audited clean (no shelling, `fs`/`path`/node:sqlite only).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)