### PR TITLE
chore: install moflo@4.10.29-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.0.0",
-        "moflo": "^4.10.28",
+        "moflo": "^4.10.29-rc.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.0"
@@ -3628,9 +3628,9 @@
       }
     },
     "node_modules/moflo": {
-      "version": "4.10.28",
-      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.10.28.tgz",
-      "integrity": "sha512-qe9PjgxUYU1Lt5ZnjokeoT2RtIGM3bFT1AuIp0sqsSkchJzWuOA4ph2t0GHeHD/rYy/Shp9ab9ser9golwswjQ==",
+      "version": "4.10.29-rc.1",
+      "resolved": "https://registry.npmjs.org/moflo/-/moflo-4.10.29-rc.1.tgz",
+      "integrity": "sha512-rXkAlMqvogsfHU3CmjMnEr8nFGkBWOloiuXVvJZlecIDWJeXZ0hxTA2CA8zWPucTQgdVU9aYkyQrwi4dy9KzoQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^8.0.0",
-    "moflo": "^4.10.28",
+    "moflo": "^4.10.29-rc.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"


### PR DESCRIPTION
Install the freshly published `moflo@4.10.29-rc.1` (rc tag) as a devDependency.

- `npm publish --tag rc` ✓ (rc tag; `latest` stays 4.10.28)
- release-smoke run 28380967935 — fully green (3-OS × 2-harness)
- lockfile backfilled (`--package-lock-only --force`); `npm ci --dry-run --legacy-peer-deps` in sync
- restart-pending surfaced + cleared

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)