### PR TITLE
fix(daemon): scope orphan reap by project root, not shared cli.js realpath

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -247,7 +247,17 @@ function readInstallManifest(manifestPath) {
   return { entries, isLegacy };
 }
 
-const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
+const plural = (n, word) => {
+  if (n === 1) return `${n} ${word}`;
+  // Pluralize the final word: consonant+y → -ies (entry → entries), sibilant
+  // endings → -es (box → boxes), otherwise → -s. Naive +s mangled every
+  // 'entry'-style word into 'entrys'.
+  let suffixed;
+  if (/[^aeiou]y$/i.test(word)) suffixed = `${word.slice(0, -1)}ies`;
+  else if (/(?:s|x|z|ch|sh)$/i.test(word)) suffixed = `${word}es`;
+  else suffixed = `${word}s`;
+  return `${n} ${suffixed}`;
+};
 
 // Captured inside the upgrade/drift branch so the post-spawn notice writer
 // can persist `.moflo/upgrade-notice.json` for the statusline (#636).

--- a/src/cli/__tests__/services/daemon-lock-orphan.test.ts
+++ b/src/cli/__tests__/services/daemon-lock-orphan.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, realpathSync } from 'fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, realpathSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { spawn, type ChildProcess } from 'child_process';
@@ -195,6 +195,79 @@ describe('daemon-lock orphan detection (#1150)', () => {
         expect(findProjectDaemonPids(otherDir, { pidsHint: hint })).not.toContain(4242);
       } finally {
         rmDirRetry(otherDir);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Shared moflo install via symlink (git-worktree / Conductor / npm link)
+  // ---------------------------------------------------------------------
+  //
+  // Regression: when a SATELLITE project root symlinks its
+  // `node_modules/moflo` back to a MAIN checkout's physical install — a common
+  // git-worktree / Conductor space-saver, or `npm link moflo` across projects —
+  // both roots' `node_modules/moflo/bin/cli.js` realpath onto the SAME path.
+  // The pre-fix matcher realpath'd the full candidate path, collapsing the two
+  // roots, so `findProjectDaemonPids(satellite)` matched the MAIN repo's running
+  // daemon and `acquireDaemonLock` reaped it as a bogus "same-project orphan"
+  // (a daemon-start in the worktree killed the main repo's daemon). The matcher
+  // must attribute a daemon by its project root, never by the shared binary.
+  describe('shared install via symlink', () => {
+    /** Link satelliteDir/node_modules/moflo → mainDir/node_modules/moflo. Returns false if the OS refuses symlinks. */
+    function linkSatellite(mainDir: string, satelliteDir: string): boolean {
+      const mainBin = join(mainDir, 'node_modules', 'moflo', 'bin');
+      mkdirSync(mainBin, { recursive: true });
+      writeFileSync(join(mainBin, 'cli.js'), FAKE_DAEMON_SCRIPT);
+      mkdirSync(join(satelliteDir, 'node_modules'), { recursive: true });
+      try {
+        symlinkSync(
+          join(mainDir, 'node_modules', 'moflo'),
+          join(satelliteDir, 'node_modules', 'moflo'),
+          // 'junction' links dirs on Windows without elevation.
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
+        return true;
+      } catch {
+        return false; // restricted host (e.g. Windows w/o privilege) — skip
+      }
+    }
+
+    it('does NOT attribute the main repo daemon to a satellite root sharing its install', () => {
+      const mainDir = mkdtempSync(join(tmpdir(), 'orphan-shared-main-'));
+      const satelliteDir = mkdtempSync(join(tmpdir(), 'orphan-shared-sat-'));
+      try {
+        if (!linkSatellite(mainDir, satelliteDir)) return;
+        // Precondition for the bug: both roots' cli.js realpath onto one file.
+        expect(realpathSync(join(satelliteDir, 'node_modules', 'moflo', 'bin', 'cli.js')))
+          .toBe(realpathSync(join(mainDir, 'node_modules', 'moflo', 'bin', 'cli.js')));
+
+        // The main daemon's cmdline records its own real install path.
+        const mainCli = realpathSync(join(mainDir, 'node_modules', 'moflo', 'bin', 'cli.js'));
+        const hint = [{ pid: 4242, cmdline: `"${process.execPath}" ${mainCli} daemon start --moflo` }];
+
+        // The fix: the satellite root must NOT claim (and thus reap) it…
+        expect(findProjectDaemonPids(satelliteDir, { pidsHint: hint })).not.toContain(4242);
+        // …while the main root still owns its own daemon (no #1150 regression).
+        expect(findProjectDaemonPids(mainDir, { pidsHint: hint })).toContain(4242);
+      } finally {
+        rmDirRetry(satelliteDir);
+        rmDirRetry(mainDir);
+      }
+    });
+
+    it('a satellite root still reaps ITS OWN orphan (launched via the symlink path)', () => {
+      const mainDir = mkdtempSync(join(tmpdir(), 'orphan-shared-main2-'));
+      const satelliteDir = mkdtempSync(join(tmpdir(), 'orphan-shared-sat2-'));
+      try {
+        if (!linkSatellite(mainDir, satelliteDir)) return;
+        // A satellite daemon is launched with the satellite's OWN (symlink) path
+        // — Node records argv verbatim, it does not realpath argv[1].
+        const satCli = join(satelliteDir, 'node_modules', 'moflo', 'bin', 'cli.js');
+        const hint = [{ pid: 5252, cmdline: `"${process.execPath}" ${satCli} daemon start --moflo` }];
+        expect(findProjectDaemonPids(satelliteDir, { pidsHint: hint })).toContain(5252);
+      } finally {
+        rmDirRetry(satelliteDir);
+        rmDirRetry(mainDir);
       }
     });
   });

--- a/src/cli/services/daemon-lock.ts
+++ b/src/cli/services/daemon-lock.ts
@@ -500,10 +500,21 @@ export function findProjectDaemonPids(
  *
  * Returns the two layouts moflo ships with — consumer install
  * (`<root>/node_modules/moflo/bin/cli.js`) and dogfood-source
- * (`<root>/bin/cli.js`) — normalised for case-insensitive substring match
- * via the shared `normalizeProjectRoot` helper (which realpaths + lowercases
- * on Windows, matching the #1145 daemon-identity surface so the two checks
- * agree about which root a process belongs to).
+ * (`<root>/bin/cli.js`) — normalised for case-insensitive substring match.
+ *
+ * Realpath the project ROOT PREFIX ONLY (so the macOS `/var/folders` →
+ * `/private/var/folders` rewrite from #1145 still matches a daemon whose
+ * cmdline recorded the realpath'd root), then append the relative CLI path
+ * LITERALLY. We must NOT realpath the full joined path: that resolves a
+ * `node_modules/moflo` symlink, and when two distinct project roots share one
+ * physical moflo install via symlink — a git-worktree / Conductor workspace
+ * that links `node_modules` back to the main checkout, or `npm link moflo` —
+ * every root's `node_modules/moflo/bin/cli.js` realpaths onto the SAME path.
+ * That collapse made `findProjectDaemonPids(rootB)` match rootA's running
+ * daemon, so a daemon-start in the worktree reaped the main repo's daemon as a
+ * bogus "same-project orphan". A daemon's identity is its project root, not the
+ * (shareable) binary it executes — so the root prefix is the only part that may
+ * be realpath-resolved here.
  *
  * Never includes the bare `projectRoot` prefix as a match candidate: an
  * unrelated process (editor, npm script) whose cmdline happens to mention
@@ -515,18 +526,16 @@ function projectCliCandidates(projectRoot: string): string[] {
     join('node_modules', 'moflo', 'bin', 'cli.js'),
     join('bin', 'cli.js'),
   ];
-  // realpath both the input AND each candidate path — on macOS the
-  // command-line records the realpath'd form (`/private/var/folders/...`)
-  // while the cwd-rooted candidate stays under `/var/folders/...`.
+  // normRoot realpaths the ROOT only (#1145). Build both the literal-root and
+  // realpath'd-root forms so the substring match lands whichever the daemon's
+  // cmdline recorded — without ever resolving the node_modules/moflo symlink in
+  // the suffix (which would collapse sibling roots onto a shared install).
   const normRoot = normalizeProjectRoot(projectRoot);
   const out = new Set<string>();
   for (const rel of cliRelatives) {
-    // Apply normalizeForMatch ON TOP of normalizeProjectRoot so the
-    // substring match also tolerates mixed separators in the spawn-recorded
-    // cmdline ("\\" vs "/"). `normalizeProjectRoot` realpaths + lowercases
-    // on Windows; `normalizeForMatch` collapses slashes.
-    out.add(normalizeForMatch(normalizeProjectRoot(join(projectRoot, rel))));
-    out.add(normalizeForMatch(normalizeProjectRoot(join(normRoot, rel))));
+    // normalizeForMatch collapses mixed separators + case-folds on Windows.
+    out.add(normalizeForMatch(join(projectRoot, rel)));
+    out.add(normalizeForMatch(join(normRoot, rel)));
   }
   return Array.from(out).filter(s => s.length > 0);
 }


### PR DESCRIPTION
Fixes #1249.

## Problem

When a project root's `node_modules/moflo` is a **symlink sharing another root's physical install** — a git-worktree / Conductor workspace that links `node_modules` back to the main checkout, or `npm link moflo` across projects — starting a daemon in one root **reaps (kills) the other root's running daemon** as a bogus "same-project orphan". Found while validating #1244: the harness symlinks each temp workspace's `node_modules/moflo` to the repo's, and every launcher run killed the repo daemon ~2s later.

Normal `npm install moflo` consumers are unaffected (separate physical copies → distinct realpaths).

## Root cause

`projectCliCandidates()` in `src/cli/services/daemon-lock.ts` realpathed the **full** candidate path via `normalizeProjectRoot`, resolving the `node_modules/moflo` symlink. That collapsed distinct roots onto one `cli.js` path, so `findProjectDaemonPids(satellite)` matched the main repo's daemon cmdline and `acquireDaemonLock`'s pre-acquire reap SIGTERM→SIGKILL'd it.

The realpath exists for #1145 (macOS `/var/folders` → `/private/var/folders`), but that only needs the **root prefix** resolved — resolving the suffix symlink discards the project-root distinction that defines daemon identity.

## Fix

Realpath the **project-root prefix only**, then append the relative CLI path **literally** — never resolve the `node_modules/moflo` symlink. Both literal-root and realpath'd-root forms are emitted so the substring match lands whichever the daemon's cmdline recorded (#1145 preserved). Same-root orphan reaping (#1150) is preserved: an orphan shares the root, so its cmdline still matches the literal-root candidate.

## Verification

- Patched: `findProjectDaemonPids(satellite)` → `[]` (was `[<repo daemon pid>]`); main root still owns its own daemon.
- New regression tests in `daemon-lock-orphan.test.ts`: satellite-shares-install must not reap main (and main still owns it); satellite still reaps its own orphan launched via the symlink path. Windows-junction-aware with a skip guard.
- **76 daemon tests green** (62 default + 14 isolation), incl. `doctor-fixes-orphan` and #1145 identity suites.

## Also included

A separate cosmetic commit fixes the launcher's `plural()` helper, which rendered "durable entrys" instead of "entries" in #1232 durable-sync session-start mutations.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
