### PR TITLE
feat(memory): auto-produce hydrate seed for worktree/Conductor hydration (#1244)

### DIFF
--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -2471,5 +2471,52 @@ if (hooksScript) {
 
 // Patches are now baked into moflo@4.0.0 source — no runtime patching needed.
 
+// ── 4b-1244. Auto-snapshot: refresh the hydrate seed (producer side) ────────
+// When `memory.snapshot_to` (or MOFLO_SNAPSHOT_TO) is set, the PRIMARY checkout
+// refreshes that whole-DB snapshot when its DB has advanced, so fresh git
+// worktrees / Conductor workspaces always hydrate (§3e-1244) from a current
+// seed. Linked worktrees never produce (they consume). Runs AFTER the daemon is
+// fired above on purpose: VACUUM INTO is concurrency-safe with the daemon, and
+// placing it post-spawn means even a slow/SIGKILLed backup can never delay the
+// daemon. No-op (a fast stat) when the snapshot is already current.
+try {
+  // Cheap pre-gate so the overwhelming majority (no snapshot_to configured) pay
+  // nothing — no module load, no moflo.yaml parse. Live only when the env
+  // override is set or moflo.yaml has an UNcommented `snapshot_to:` line (the
+  // generated config ships a commented example, which this regex ignores).
+  const snapshotYamlPath = resolve(projectRoot, 'moflo.yaml');
+  let snapshotEnabled = Boolean(process.env.MOFLO_SNAPSHOT_TO);
+  if (!snapshotEnabled && existsSync(snapshotYamlPath)) {
+    try {
+      snapshotEnabled = /^[ \t]*snapshot_to[ \t]*:/m.test(readFileSync(snapshotYamlPath, 'utf-8'));
+    } catch { /* unreadable yaml — treat as not-configured */ }
+  }
+  const snapshotPaths = snapshotEnabled
+    ? [
+        resolve(projectRoot, 'node_modules/moflo/dist/src/cli/services/snapshot-restore.js'),
+        resolve(projectRoot, 'dist/src/cli/services/snapshot-restore.js'),
+      ]
+    : [];
+  const snapshotPath = snapshotPaths.find((p) => existsSync(p));
+  if (snapshotPath) {
+    const { autoSnapshotAtSessionStart } = await import(pathToFileURL(snapshotPath).href);
+    const result = await autoSnapshotAtSessionStart({ projectRoot });
+    if (result?.snapshotted) {
+      const mb = ((result.bytes ?? 0) / (1024 * 1024)).toFixed(1);
+      emitMutation(
+        'refreshed memory snapshot',
+        `wrote ${mb} MB whole-DB seed — fresh worktrees hydrate without a cold reindex`,
+      );
+    }
+  }
+} catch (err) {
+  // Non-fatal — a missed snapshot just leaves the previous seed in place; the
+  // next session retries. A failure here must never block session start.
+  try {
+    const msg = err && err.message ? err.message : String(err);
+    process.stderr.write(`memory auto-snapshot skipped: ${msg}\n`);
+  } catch { /* writing the failure itself must not throw */ }
+}
+
 // ── 5. Done — exit immediately ──────────────────────────────────────────────
 process.exit(0);

--- a/src/cli/__tests__/services/snapshot-restore.test.ts
+++ b/src/cli/__tests__/services/snapshot-restore.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -29,6 +29,10 @@ import {
   resolveHydratePath,
   hydrateAtSessionStart,
   RESTORE_SKIP_REASONS,
+  resolveSnapshotToPath,
+  isLinkedWorktree,
+  autoSnapshotAtSessionStart,
+  SNAPSHOT_SKIP_REASONS,
 } from '../../services/snapshot-restore.js';
 import { loadMofloConfig, type MofloConfig } from '../../config/moflo-config.js';
 import { memoryDbPath } from '../../services/moflo-paths.js';
@@ -48,12 +52,16 @@ afterEach(async () => {
 });
 
 const savedEnv = process.env.MOFLO_HYDRATE_FROM;
+const savedSnapshotEnv = process.env.MOFLO_SNAPSHOT_TO;
 beforeEach(() => {
   delete process.env.MOFLO_HYDRATE_FROM;
+  delete process.env.MOFLO_SNAPSHOT_TO;
 });
 afterEach(() => {
   if (savedEnv === undefined) delete process.env.MOFLO_HYDRATE_FROM;
   else process.env.MOFLO_HYDRATE_FROM = savedEnv;
+  if (savedSnapshotEnv === undefined) delete process.env.MOFLO_SNAPSHOT_TO;
+  else process.env.MOFLO_SNAPSHOT_TO = savedSnapshotEnv;
 });
 
 async function makeRoot(prefix = 'moflo-snapshot-'): Promise<string> {
@@ -68,6 +76,18 @@ async function makeRoot(prefix = 'moflo-snapshot-'): Promise<string> {
 function configWithHydrate(root: string, hydrateFrom?: string): MofloConfig {
   const cfg = loadMofloConfig(root);
   return { ...cfg, memory: { ...cfg.memory, hydrate_from: hydrateFrom } };
+}
+
+function configWithSnapshotTo(root: string, snapshotTo?: string): MofloConfig {
+  const cfg = loadMofloConfig(root);
+  return { ...cfg, memory: { ...cfg.memory, snapshot_to: snapshotTo } };
+}
+
+/** Force `path`'s mtime to `whenMs` so staleness compares are deterministic
+ * (avoids filesystem mtime-granularity flakiness). */
+function setMtime(path: string, whenMs: number): void {
+  const secs = whenMs / 1000;
+  utimesSync(path, secs, secs);
 }
 
 /** Seed a V3 memory DB at `dbPath` with (namespace, key) rows. */
@@ -322,5 +342,159 @@ describe('resolveHydratePath / hydrateAtSessionStart', () => {
     });
     expect(result.restored).toBe(false);
     expect(result.reason).toBe(RESTORE_SKIP_REASONS.LOCAL_NOT_EMPTY);
+  });
+});
+
+describe('resolveSnapshotToPath', () => {
+  it('returns null when neither env nor config is set', async () => {
+    const root = await makeRoot();
+    expect(resolveSnapshotToPath(root, configWithSnapshotTo(root, undefined))).toBeNull();
+  });
+
+  it('resolves a relative config value against the project root', async () => {
+    const root = await makeRoot();
+    expect(resolveSnapshotToPath(root, configWithSnapshotTo(root, 'seeds/snap.db'))).toBe(
+      join(root, 'seeds', 'snap.db'),
+    );
+  });
+
+  it('prefers the MOFLO_SNAPSHOT_TO env over the config value', async () => {
+    const root = await makeRoot();
+    const envPath = join(root, 'from-env.db');
+    process.env.MOFLO_SNAPSHOT_TO = envPath;
+    expect(resolveSnapshotToPath(root, configWithSnapshotTo(root, 'from-config.db'))).toBe(envPath);
+  });
+});
+
+describe('isLinkedWorktree', () => {
+  it('is false for a primary checkout (.git is a directory)', async () => {
+    const root = await makeRoot();
+    mkdirSync(join(root, '.git'));
+    expect(isLinkedWorktree(root)).toBe(false);
+  });
+
+  it('is false when there is no .git at all', async () => {
+    const root = await makeRoot();
+    expect(isLinkedWorktree(root)).toBe(false);
+  });
+
+  it('is true for a linked worktree (.git file → gitdir under worktrees/)', async () => {
+    const root = await makeRoot();
+    writeFileSync(join(root, '.git'), 'gitdir: /repo/.git/worktrees/feature-x\n');
+    expect(isLinkedWorktree(root)).toBe(true);
+  });
+
+  it('is false for a submodule (.git file → gitdir under modules/)', async () => {
+    const root = await makeRoot();
+    writeFileSync(join(root, '.git'), 'gitdir: /repo/.git/modules/sub\n');
+    expect(isLinkedWorktree(root)).toBe(false);
+  });
+});
+
+describe('autoSnapshotAtSessionStart', () => {
+  it('is a no-op when snapshot_to is not configured', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [{ key: 'a', namespace: 'learnings' }]);
+    const result = await autoSnapshotAtSessionStart({
+      projectRoot: root,
+      config: configWithSnapshotTo(root, undefined),
+    });
+    expect(result.snapshotted).toBe(false);
+    expect(result.reason).toBe(SNAPSHOT_SKIP_REASONS.NOT_CONFIGURED);
+  });
+
+  it('produces a faithful snapshot from the primary checkout', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [
+      { key: 'a', namespace: 'learnings' },
+      { key: 'b', namespace: 'code-map' },
+      { key: 'c', namespace: 'guidance' },
+    ]);
+    const snap = join(root, 'seed.db');
+    const result = await autoSnapshotAtSessionStart({
+      projectRoot: root,
+      config: configWithSnapshotTo(root, snap),
+    });
+    expect(result.snapshotted).toBe(true);
+    expect(result.target).toBe(snap);
+    expect(existsSync(snap)).toBe(true);
+    expect(rowCount(snap)).toBe(3);
+    // Standalone single file — no sidecars (Rule #1 / hydrate reads it directly).
+    expect(existsSync(`${snap}-wal`)).toBe(false);
+  });
+
+  it('never produces from a linked worktree (Conductor workspace)', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [{ key: 'a', namespace: 'learnings' }]);
+    writeFileSync(join(root, '.git'), 'gitdir: /repo/.git/worktrees/wt-1\n');
+    const snap = join(root, 'seed.db');
+    const result = await autoSnapshotAtSessionStart({
+      projectRoot: root,
+      config: configWithSnapshotTo(root, snap),
+    });
+    expect(result.snapshotted).toBe(false);
+    expect(result.reason).toBe(SNAPSHOT_SKIP_REASONS.LINKED_WORKTREE);
+    expect(existsSync(snap)).toBe(false);
+  });
+
+  it('skips when there is no local DB to snapshot', async () => {
+    const root = await makeRoot();
+    const result = await autoSnapshotAtSessionStart({
+      projectRoot: root,
+      config: configWithSnapshotTo(root, join(root, 'seed.db')),
+    });
+    expect(result.snapshotted).toBe(false);
+    expect(result.reason).toBe(SNAPSHOT_SKIP_REASONS.NO_LOCAL_DB);
+  });
+
+  it('skips when snapshot_to aliases the live DB (self-reference)', async () => {
+    const root = await makeRoot();
+    await makeDbWith(memoryDbPath(root), [{ key: 'a', namespace: 'learnings' }]);
+    const result = await autoSnapshotAtSessionStart({
+      projectRoot: root,
+      config: configWithSnapshotTo(root, memoryDbPath(root)),
+    });
+    expect(result.snapshotted).toBe(false);
+    expect(result.reason).toBe(SNAPSHOT_SKIP_REASONS.SELF_REFERENCE);
+  });
+
+  it('skips when the snapshot is already current (DB has not advanced)', async () => {
+    const root = await makeRoot();
+    const dbPath = memoryDbPath(root);
+    await makeDbWith(dbPath, [{ key: 'a', namespace: 'learnings' }]);
+    const snap = join(root, 'seed.db');
+    const config = configWithSnapshotTo(root, snap);
+
+    // First call produces. Then force the snapshot newer than the DB+sidecars.
+    expect((await autoSnapshotAtSessionStart({ projectRoot: root, config })).snapshotted).toBe(true);
+    const dbTime = Date.now() - 10_000;
+    setMtime(dbPath, dbTime);
+    if (existsSync(`${dbPath}-wal`)) setMtime(`${dbPath}-wal`, dbTime);
+    if (existsSync(`${dbPath}-shm`)) setMtime(`${dbPath}-shm`, dbTime);
+    setMtime(snap, Date.now());
+    const before = statSync(snap).mtimeMs;
+
+    const result = await autoSnapshotAtSessionStart({ projectRoot: root, config });
+    expect(result.snapshotted).toBe(false);
+    expect(result.reason).toBe(SNAPSHOT_SKIP_REASONS.FRESH);
+    // Confirm it did NOT rewrite the snapshot.
+    expect(statSync(snap).mtimeMs).toBe(before);
+  });
+
+  it('re-produces when the DB has advanced past the snapshot', async () => {
+    const root = await makeRoot();
+    const dbPath = memoryDbPath(root);
+    await makeDbWith(dbPath, [{ key: 'a', namespace: 'learnings' }]);
+    const snap = join(root, 'seed.db');
+    const config = configWithSnapshotTo(root, snap);
+
+    expect((await autoSnapshotAtSessionStart({ projectRoot: root, config })).snapshotted).toBe(true);
+    // Force the snapshot OLDER than the DB → it must re-produce.
+    setMtime(snap, Date.now() - 10_000);
+    setMtime(dbPath, Date.now());
+
+    const result = await autoSnapshotAtSessionStart({ projectRoot: root, config });
+    expect(result.snapshotted).toBe(true);
+    expect(rowCount(snap)).toBe(1);
   });
 });

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -128,6 +128,17 @@ export interface MofloConfig {
      * `src/cli/services/snapshot-restore.ts`.
      */
     hydrate_from?: string;
+    /**
+     * Optional path to **auto-produce** a whole-DB snapshot to on session-start
+     * (#1244, epic #1231) — the producer side of {@link hydrate_from}. When set,
+     * the **primary** working tree (never a linked git worktree / Conductor
+     * workspace) refreshes this snapshot when the local DB has advanced past it,
+     * so fresh worktrees always hydrate from a current seed. Set this and
+     * `hydrate_from` to the SAME absolute path: the primary checkout produces,
+     * linked worktrees consume. Undefined = off. `MOFLO_SNAPSHOT_TO` overrides.
+     * Relative → project root. See `src/cli/services/snapshot-restore.ts`.
+     */
+    snapshot_to?: string;
   };
 
   hooks: {
@@ -443,6 +454,13 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
         const v = raw.memory?.hydrate_from ?? raw.memory?.hydrateFrom;
         return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
       })(),
+      // #1244 — optional path to auto-produce a whole-DB snapshot to (producer
+      // side of hydrate_from). Resolution to an absolute path happens lazily in
+      // snapshot-restore.ts, keeping the launcher's cold-start parse path-IO-free.
+      snapshot_to: (() => {
+        const v = raw.memory?.snapshot_to ?? raw.memory?.snapshotTo;
+        return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+      })(),
     },
     hooks: {
       pre_edit: raw.hooks?.pre_edit ?? raw.hooks?.preEdit ?? DEFAULT_CONFIG.hooks.pre_edit,
@@ -663,6 +681,12 @@ memory:
   #   embeddings restored at once). No-op once the local DB has content — never
   #   clobbers an active workspace. Take one with "flo memory backup --to <path>".
   #   Overridable per-process via MOFLO_HYDRATE_FROM.
+  # snapshot_to: /abs/path/to/moflo-snapshot.db
+  #   Producer side of hydrate_from (#1244): the PRIMARY checkout auto-refreshes
+  #   this snapshot on session-start when its DB has advanced, so fresh git
+  #   worktrees / Conductor workspaces always hydrate from a current seed. Linked
+  #   worktrees never produce. Conductor recipe: set hydrate_from AND snapshot_to
+  #   to the SAME absolute path. Overridable per-process via MOFLO_SNAPSHOT_TO.
 
 # Hook toggles (all on by default — disable to slim down)
 hooks:

--- a/src/cli/services/snapshot-restore.ts
+++ b/src/cli/services/snapshot-restore.ts
@@ -76,6 +76,35 @@ function removeSidecars(dbPath: string): void {
   }
 }
 
+/** A backup tmp older than this is certainly orphaned (a live vacuum is seconds). */
+const STALE_SNAPSHOT_TMP_AGE_MS = 60_000;
+
+/**
+ * Best-effort sweep of orphaned `${target}.tmp.<pid>.<rand>` files left by a
+ * backup whose process was SIGKILLed mid-`VACUUM INTO` (e.g. the auto-snapshot
+ * ran inside a session-start hook that hit its timeout — see launcher §3e-1244b).
+ * Only files older than {@link STALE_SNAPSHOT_TMP_AGE_MS} are removed, so a
+ * concurrent in-flight backup's tmp on the same target is never deleted.
+ */
+function sweepStaleSnapshotTmp(target: string): void {
+  try {
+    const dir = path.dirname(target);
+    const prefix = `${path.basename(target)}.tmp.`;
+    const now = Date.now();
+    for (const name of fs.readdirSync(dir)) {
+      if (!name.startsWith(prefix)) continue;
+      const p = path.join(dir, name);
+      try {
+        if (now - fs.statSync(p).mtimeMs > STALE_SNAPSHOT_TMP_AGE_MS) fs.rmSync(p);
+      } catch {
+        /* best-effort — racing another sweep or a live backup is harmless */
+      }
+    }
+  } catch {
+    /* dir missing / unreadable — nothing to sweep */
+  }
+}
+
 /**
  * True when `file` is a SQLite DB carrying a `memory_entries` table. Opens
  * READ-ONLY on purpose: `openDaemonDatabase` forces `journal_mode=WAL`, which
@@ -174,6 +203,7 @@ export function backupSnapshot(options: BackupSnapshotOptions): BackupSnapshotRe
   }
 
   fs.mkdirSync(path.dirname(target), { recursive: true });
+  sweepStaleSnapshotTmp(target);
   const tmp = `${target}.tmp.${process.pid}.${process.hrtime.bigint().toString(36)}`;
   try {
     if (fs.existsSync(tmp)) fs.rmSync(tmp);
@@ -322,4 +352,137 @@ export async function hydrateAtSessionStart(
   }
   // force stays false — auto-hydrate must never clobber an active workspace.
   return restoreSnapshot({ projectRoot, fromPath: from });
+}
+
+// ── Producer side: auto-snapshot (#1244) ────────────────────────────────────
+
+/** Why an auto-snapshot did not produce a fresh seed. */
+export const SNAPSHOT_SKIP_REASONS = {
+  NOT_CONFIGURED: 'not-configured',
+  LINKED_WORKTREE: 'linked-worktree',
+  NO_LOCAL_DB: 'no-local-db',
+  SELF_REFERENCE: 'self-reference',
+  FRESH: 'fresh',
+} as const;
+export type SnapshotSkipReason = (typeof SNAPSHOT_SKIP_REASONS)[keyof typeof SNAPSHOT_SKIP_REASONS];
+
+export interface AutoSnapshotResult {
+  /** True when a fresh snapshot was written to the configured path. */
+  snapshotted: boolean;
+  /** Set when `snapshotted` is false. */
+  reason?: SnapshotSkipReason;
+  /** Resolved snapshot path (when configured). */
+  target?: string;
+  /** Snapshot size in bytes (when produced). */
+  bytes?: number;
+}
+
+/**
+ * Resolve the configured auto-snapshot destination, or `null` when off.
+ * Precedence: `MOFLO_SNAPSHOT_TO` env > `memory.snapshot_to` (moflo.yaml).
+ * Relative values resolve against the project root. Pure path work, no IO.
+ */
+export function resolveSnapshotToPath(
+  projectRoot: string = findProjectRoot(),
+  config?: MofloConfig,
+): string | null {
+  return pickConfiguredPath(
+    process.env.MOFLO_SNAPSHOT_TO,
+    (config ?? loadMofloConfig(projectRoot)).memory.snapshot_to,
+    projectRoot,
+  );
+}
+
+/**
+ * True when `projectRoot` is a **linked** git worktree (a Conductor workspace),
+ * as opposed to the primary working tree. A linked worktree's `.git` is a FILE
+ * containing `gitdir: <common>/worktrees/<id>`; the primary's `.git` is a
+ * DIRECTORY. A submodule's `.git` is also a file but points at `<super>/modules/
+ * <name>` (no `worktrees` segment), so it reads as primary. A missing `.git`
+ * (standalone project) also reads as primary. Pure `node:fs` — no git shell-out
+ * (Rule #1). This is the gate that stops N Conductor workspaces from each
+ * overwriting the shared seed with their own branch-drifted copy.
+ */
+export function isLinkedWorktree(projectRoot: string = findProjectRoot()): boolean {
+  try {
+    const dotgit = path.join(projectRoot, '.git');
+    const st = fs.statSync(dotgit);
+    if (!st.isFile()) return false; // directory (primary) or other → not linked
+    const m = fs.readFileSync(dotgit, 'utf-8').match(/gitdir:\s*(.+)/);
+    if (!m) return false;
+    // Match a `worktrees` path segment on either separator (Rule #1).
+    return /[\\/]worktrees[\\/]/.test(m[1].trim());
+  } catch {
+    return false; // no/unreadable .git → treat as primary (safe to produce)
+  }
+}
+
+/** Newest mtime across the DB and its `-wal`/`-shm` sidecars (WAL writes don't
+ * touch the main file's mtime, so the sidecars must be considered to tell
+ * whether the DB has advanced). Returns 0 when none exist. */
+function latestSourceMtimeMs(source: string): number {
+  let latest = 0;
+  for (const p of [source, ...sidecarPaths(source)]) {
+    try {
+      if (fs.existsSync(p)) latest = Math.max(latest, fs.statSync(p).mtimeMs);
+    } catch {
+      /* unreadable — ignore */
+    }
+  }
+  return latest;
+}
+
+/**
+ * True when the snapshot at `snapshot` is at least as new as the live DB
+ * (including its WAL sidecars) — i.e. the DB has NOT advanced since the last
+ * snapshot, so re-producing would be wasted work. A missing snapshot is never
+ * fresh. mtime comparison only — no content hash, no arbitrary TTL.
+ */
+function isSnapshotFresh(snapshot: string, source: string): boolean {
+  try {
+    if (!fs.existsSync(snapshot)) return false;
+    return fs.statSync(snapshot).mtimeMs >= latestSourceMtimeMs(source);
+  } catch {
+    return false; // can't tell → err toward producing
+  }
+}
+
+/**
+ * Session-start auto-snapshot: when `memory.snapshot_to` (or `MOFLO_SNAPSHOT_TO`)
+ * is set, refresh that whole-DB snapshot so fresh worktrees hydrating via
+ * {@link hydrateAtSessionStart} always seed from a current copy. The producer
+ * side of {@link hydrateAtSessionStart}; set both to the same path for the
+ * Conductor recipe.
+ *
+ * Gated, in order: unconfigured → no-op; a linked git worktree (Conductor
+ * workspace) never produces (only the primary checkout does); no local DB →
+ * nothing to snapshot; self-reference (path aliases the live DB, symlink-aware)
+ * → skip; snapshot already current (DB hasn't advanced) → skip. Otherwise takes
+ * a consistent {@link backupSnapshot}. Best-effort: callers swallow throws so a
+ * backup failure never blocks session start.
+ */
+export async function autoSnapshotAtSessionStart(
+  opts: { projectRoot?: string; config?: MofloConfig } = {},
+): Promise<AutoSnapshotResult> {
+  const projectRoot = opts.projectRoot ?? findProjectRoot();
+  const to = resolveSnapshotToPath(projectRoot, opts.config);
+  if (!to) return { snapshotted: false, reason: SNAPSHOT_SKIP_REASONS.NOT_CONFIGURED };
+  if (isLinkedWorktree(projectRoot)) {
+    return { snapshotted: false, reason: SNAPSHOT_SKIP_REASONS.LINKED_WORKTREE, target: to };
+  }
+
+  const source = path.resolve(memoryDbPath(projectRoot));
+  if (!fs.existsSync(source)) {
+    return { snapshotted: false, reason: SNAPSHOT_SKIP_REASONS.NO_LOCAL_DB, target: to };
+  }
+  // Never VACUUM INTO over the live DB itself (symlink-aware, Rule #1 / #1145).
+  if (stableAbsolute(to) === stableAbsolute(source)) {
+    return { snapshotted: false, reason: SNAPSHOT_SKIP_REASONS.SELF_REFERENCE, target: to };
+  }
+  if (isSnapshotFresh(to, source)) {
+    return { snapshotted: false, reason: SNAPSHOT_SKIP_REASONS.FRESH, target: to };
+  }
+
+  const result = backupSnapshot({ projectRoot, toPath: to });
+  return { snapshotted: true, target: result.target, bytes: result.bytes };
 }


### PR DESCRIPTION
## Summary

Closes the **producer-side** wiring gap in the whole-DB snapshot feature (#1244, epic #1231). `hydrate_from` could *consume* a snapshot to seed a fresh worktree, but nothing *produced* or refreshed that snapshot — so a configured seed could go stale or never exist, and a **default Conductor workspace cold-reindexed from empty** (N concurrent ONNX embedding passes when many workspaces spawn at once).

This adds the symmetric producer.

## What changed

- **`memory.snapshot_to` config** (+ `MOFLO_SNAPSHOT_TO` env), mirroring `hydrate_from`. **Conductor recipe:** set both to the *same* absolute path — the primary checkout produces, linked worktrees consume; roles resolve at runtime.
- **`autoSnapshotAtSessionStart()`** in `snapshot-restore.ts`, gated in order: unconfigured → no-op; **linked git worktree (Conductor workspace) never produces** (only the primary checkout does); no local DB → skip; self-reference (symlink-aware, #1145) → skip; snapshot already current (WAL-aware mtime compare) → skip; else `backupSnapshot` (VACUUM INTO).
- **`isLinkedWorktree()`** — pure `node:fs` (`.git` file whose `gitdir:` has a `worktrees` path segment); **no git shell-out** (Rule #1). Submodule/standalone read as primary.
- **Stale-tmp sweep** in `backupSnapshot` neutralizes SIGKILL-orphaned `.tmp.*` files (age-gated so a concurrent live backup is never disturbed).
- **Launcher §4b-1244**, placed **after** the daemon fire-and-forget so a slow/timed-out backup can never block daemon startup, with the same cheap pre-gate as the hydrate block (unconfigured consumers pay nothing).

## Consumer safety

- **No settings migration.** Wired *inside* the existing launcher every consumer already runs on `SessionStart` — not a new `Stop`/hook entry — so consumers pick it up via `npm install moflo@latest` with **zero `flo init` re-run** (honors the "user never re-runs init" invariant).
- **99% pay nothing** — cheap synchronous pre-gate; unconfigured = no module load, no spawn.
- **Conductor-safe by construction** — the primary-worktree gate stops N workspaces from clobbering the shared seed with branch-drifted copies; each workspace still owns its own copy (no live-share — distinct from the forbidden `flo doctor -c shared-db` path).

## Verification

- Build clean; **763 tests** across touched surfaces (services 701, config 26, launcher 131, writer-audit 3).
- **Real e2e against live git worktrees**: primary produces a 46.1 MB seed → second call skips `fresh` → linked worktree skips `linked-worktree` (produces nothing). Also validated 4-way concurrent hydration into independent copies.
- **Consumer-smoke harness: 49/0/0**, incl. `probe:session-start-launcher — launcher ran cleanly`.

## Round-trip note

The launcher edit ships in source but only takes effect in moflo's own dogfood after publish + reinstall (dogfooding §4); the smoke harness already validated the consumer-install path, so it doesn't gate correctness.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)