### PR TITLE
chore(security): clear Socket prod-dep advisories + upgrade onnxruntime-node (tar, js-yaml, onnx)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "js-yaml": "^5.2.0",
         "lru-cache": "^11.3.5",
-        "onnxruntime-node": "^1.24.3",
+        "onnxruntime-node": "^1.27.0",
         "semver": "^7.7.4",
         "tar": "^7.5.16",
         "valibot": "^1.3.1"
@@ -1791,13 +1791,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -2088,12 +2081,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "license": "MIT"
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2185,12 +2172,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -2852,17 +2833,15 @@
       }
     },
     "node_modules/global-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz",
+      "integrity": "sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
+        "globalthis": "^1.0.2",
+        "matcher": "^4.0.0",
+        "semver": "^7.3.5",
+        "serialize-error": "^8.1.0"
       },
       "engines": {
         "node": ">=10.0"
@@ -3217,12 +3196,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3551,15 +3524,18 @@
       }
     },
     "node_modules/matcher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
+      "integrity": "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3846,15 +3822,15 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
-      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.27.0.tgz",
+      "integrity": "sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-node": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
-      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.27.0.tgz",
+      "integrity": "sha512-QEzGwrvNBgv4uPVdnbHsOGG4G6T96mdlcFI8aAKPjMU8wOPpVocPXb6k3QGkaZagVTv2G9Bnnbo6Z3JdXr1fQw==",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [
@@ -3864,8 +3840,8 @@
       ],
       "dependencies": {
         "adm-zip": "^0.5.16",
-        "global-agent": "^3.0.0",
-        "onnxruntime-common": "1.24.3"
+        "global-agent": "^4.1.3",
+        "onnxruntime-common": "1.27.0"
       }
     },
     "node_modules/optionator": {
@@ -4204,23 +4180,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/roarr": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "detect-node": "^2.0.4",
-        "globalthis": "^1.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "semver-compare": "^1.0.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.16",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
@@ -4313,12 +4272,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "license": "MIT"
-    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -4346,25 +4299,13 @@
       }
     },
     "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^0.13.1"
+        "type-fest": "^0.20.2"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -4516,12 +4457,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -4732,7 +4667,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
       "dependencies": {
         "@anush008/tokenizers": "^0.6.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^5.2.0",
         "lru-cache": "^11.3.5",
         "onnxruntime-node": "^1.24.3",
         "semver": "^7.7.4",
-        "tar": "^7.5.11",
+        "tar": "^7.5.16",
         "valibot": "^1.3.1"
       },
       "bin": {
@@ -31,7 +31,6 @@
         "moflo": "bin/cli.js"
       },
       "devDependencies": {
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.12.2",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
@@ -698,6 +697,29 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
@@ -1233,13 +1255,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2324,6 +2339,29 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -3131,15 +3169,25 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
+      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {
@@ -3669,6 +3717,29 @@
         "mailparser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/moflo/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/ms": {
@@ -4515,9 +4586,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
   "dependencies": {
     "@anush008/tokenizers": "^0.6.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^5.2.0",
     "lru-cache": "^11.3.5",
     "onnxruntime-node": "^1.24.3",
     "semver": "^7.7.4",
-    "tar": "^7.5.11",
+    "tar": "^7.5.16",
     "valibot": "^1.3.1"
   },
   "peerDependencies": {
@@ -90,7 +90,6 @@
     "protobufjs": ">=7.5.5"
   },
   "devDependencies": {
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.12.2",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "js-yaml": "^5.2.0",
     "lru-cache": "^11.3.5",
-    "onnxruntime-node": "^1.24.3",
+    "onnxruntime-node": "^1.27.0",
     "semver": "^7.7.4",
     "tar": "^7.5.16",
     "valibot": "^1.3.1"

--- a/src/cli/__tests__/spells/schema.test.ts
+++ b/src/cli/__tests__/spells/schema.test.ts
@@ -66,7 +66,9 @@ describe('parseYaml', () => {
   });
 
   it('should reject invalid YAML', () => {
-    expect(() => parseYaml(':', 'bad.yaml')).toThrow();
+    // Unclosed flow sequence — malformed across js-yaml versions. (A bare `:`
+    // is a valid empty-key mapping under js-yaml >=5's spec-compliant parser.)
+    expect(() => parseYaml('foo: [1, 2', 'bad.yaml')).toThrow();
   });
 
   it('should reject non-object YAML', () => {

--- a/src/cli/embeddings/fastembed-inline/index.ts
+++ b/src/cli/embeddings/fastembed-inline/index.ts
@@ -21,7 +21,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { AddedToken, Tokenizer } from '@anush008/tokenizers';
-import { InferenceSession, Tensor } from 'onnxruntime-node';
+import { env as ortEnv, InferenceSession, Tensor } from 'onnxruntime-node';
 
 import { resolveCacheDir, retrieveModel, type DownloadDeps } from './model-loader.js';
 
@@ -163,22 +163,30 @@ export class FlagEmbedding {
     if (!existsSync(modelPath)) {
       throw new Error(`Model file not found at ${modelPath}`);
     }
+    // Suppress ORT's WARNING-level chatter on session bring-up. ORT emits a
+    // `[W:onnxruntime ... GetPciBusId] Skipping pci_bus_id` line on Linux Azure
+    // VMs whose `/sys/devices/...` filenames don't match the expected PCI
+    // pattern; the warning is harmless (we run on the CPU EP only) but leaks to
+    // stderr and confuses users into thinking moflo is broken.
+    //
+    // Two log severities are in play and BOTH must be raised:
+    //   - `logSeverityLevel` (per-session, below) covered the warning in ORT
+    //     1.26.x, where it fired during session bring-up.
+    //   - `env.logLevel` (global, here) is required from ORT 1.27.0 on, where
+    //     device discovery runs through the global env logger at EP-init time,
+    //     before any session logger applies — the per-session level no longer
+    //     reaches it (CI consumer-smoke doctor probe regressed on the leak).
+    // 0=verbose, 1=info, 2=warning (default), 3/'error', 4/'fatal'. 'error' is
+    // the right level — genuine session bring-up failures still surface.
+    //
+    // Re-audit when bumping onnxruntime-node: ORT occasionally promotes
+    // deprecation / model-compatibility notices to WARNING that would now be
+    // hidden. If a model upgrade ever lands alongside this, relax both to
+    // warning once to scan the output.
+    ortEnv.logLevel = 'error';
     const session = await InferenceSession.create(modelPath, {
       executionProviders: ['cpu'],
       graphOptimizationLevel: 'all',
-      // Suppress ORT's WARNING-level chatter on session bring-up. ORT 1.26.0
-      // emits a `[W:onnxruntime ... GetPciBusId] Skipping pci_bus_id` line on
-      // Linux Azure VMs whose `/sys/devices/...` filenames don't match the
-      // `[0-9a-f]+:[0-9a-f]+:[0-9a-f]+.[0-9a-f]+` PCI pattern; the warning
-      // is harmless (we run on the CPU EP only) but leaks to stderr and
-      // confuses users into thinking moflo is broken. 0=verbose, 1=info,
-      // 2=warning (default), 3=error, 4=fatal — error is the right level
-      // because session bring-up genuine failures still surface.
-      //
-      // Re-audit when bumping fastembed or onnxruntime-node: ORT
-      // occasionally promotes deprecation / model-compatibility notices to
-      // WARNING that would now be hidden. If a model upgrade ever lands
-      // alongside this suppression, drop to 2 once to scan the output.
       logSeverityLevel: 3,
     });
     return new FlagEmbedding(tokenizer, session);

--- a/src/cli/spells/core/yaml-defaults-writer.ts
+++ b/src/cli/spells/core/yaml-defaults-writer.ts
@@ -186,10 +186,16 @@ function replaceDefaultValue(line: string, newValue: string): string {
 export function formatYamlValue(value: unknown): string {
   if (value === null || value === undefined) return 'null';
   if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+  // js-yaml >=5 defaults newline-containing strings to a block scalar (`|`),
+  // which is multi-line and gets rejected by the single-line `default:`
+  // replacement below. Force inline double-quoting (escaped `\n`) for those so
+  // they stay on one physical line — matching the pre-5 inline behavior.
+  const needsInlineQuoting = typeof value === 'string' && /[\r\n]/.test(value);
   const dumped = yaml.dump(value, {
     flowLevel: 0,
     lineWidth: -1,
     noRefs: true,
+    ...(needsInlineQuoting ? { forceQuotes: true, quotingType: '"' as const } : {}),
   }).replace(/\r?\n$/, '');
   return dumped;
 }


### PR DESCRIPTION
## Summary

Clears the two **production-dependency** advisories that Socket.dev / `npm audit` flag for `moflo` — both ship to every consumer (moflo installs as a `devDependency`, so its own dev tree does not):

| Dep | Before → After | Advisory | Notes |
|-----|----------------|----------|-------|
| `tar` | 7.5.13 → 7.5.19 | moderate — PAX-header file smuggling (≤7.5.15) | range already permitted; lockfile was stale. Floor → `^7.5.16` |
| `js-yaml` | 4.1.1 → 5.2.0 | moderate — quadratic merge-key DoS (only fixed in 5.x) | major bump; `@types/js-yaml` removed (v5 bundles its own types) |

After the bumps: `npm audit --omit=dev` reports **0 vulnerabilities**. The remaining dev-only `esbuild` (low) / `vite` (high) hits come in via `vitest`/`tsx` and never reach a consumer install — out of scope. Inherent Socket flags (install scripts, native binaries, shell/network access) are out of scope — they're core to moflo and the install scripts were audited clean (no network/`child_process`/`eval`).

## Changes

- `package.json` / `package-lock.json` — `tar ^7.5.16` (→7.5.19), `js-yaml ^5.2.0`, drop `@types/js-yaml`.
- `src/cli/spells/core/yaml-defaults-writer.ts` — js-yaml@5 dumps a top-level newline string as a block scalar (`|`) instead of inline double-quoted, which the single-line `default:` line-editor rejects. `formatYamlValue` now forces inline double-quoting (`forceQuotes`/`quotingType:'"'`) **only** for newline-containing strings. Collections with newline strings were already safe (`flowLevel: 0` forces flow style, which forbids block scalars).
- `src/cli/__tests__/spells/schema.test.ts` — js-yaml@5 parses bare `:` as the spec-compliant `{'':''}` rather than throwing; the "rejects invalid YAML" test now uses `'foo: [1, 2'` (unclosed flow seq — malformed under both v4 and v5).

## Consumer impact

Both are production deps → fix reaches consumers via the next `npm install moflo@*`. No migration, no `.moflo/` state change, no hook re-wiring. `js-yaml@5`'s ESM-only + Node≥18 requirements were already met (repo is ESM, Node≥22). All five shipped `js-yaml` call sites (`load`/`dump`/`JSON_SCHEMA`) verified.

## Testing

- [x] Full suite green — 9238 passed, 0 failed
- [x] `tsc` build clean (all js-yaml@5 call sites type-check against bundled types)
- [x] Lint clean (`--max-warnings 0`)
- [x] `npm audit --omit=dev --audit-level=moderate` → 0 vulnerabilities
- [ ] Manual testing done

Closes #1255

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
