### PR TITLE
docs(readme): trim repeated parent-project links to reduce entity dilution

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,13 +955,13 @@ MoFlo started from [Ruflo/Claude Flow](https://github.com/ruvnet/ruflo) but is n
 
 ## Why I Made This
 
-[Ruflo/Claude Flow](https://github.com/ruvnet/ruflo) is an incredible piece of work. The engineering that [rUv](https://github.com/ruvnet) and the contributors put into the original — swarm topologies, hive-mind consensus, HNSW vector search, neural routing, and so much more — made it one of the most comprehensive agent orchestration frameworks available. It was built to support a wide range of scenarios: distributed systems, multi-agent swarms, enterprise orchestration, research workflows, and beyond.
+Ruflo / Claude Flow is an incredible piece of work. The engineering that [rUv](https://github.com/ruvnet) and the contributors put into the original — swarm topologies, hive-mind consensus, HNSW vector search, neural routing, and so much more — made it one of the most comprehensive agent orchestration frameworks available. It was built to support a wide range of scenarios: distributed systems, multi-agent swarms, enterprise orchestration, research workflows, and beyond.
 
 My use case was just one of those many scenarios: day-to-day local coding, enhancing my normal Claude Code experience on a single project. The original supported this — it was all in there — but because the project served so many different needs, I found myself configuring and tailoring things for my specific setup each time I pulled in updates. That isn't a shortcoming of the original; it's the natural trade-off of a tool designed to be that flexible and powerful.
 
 So I started from that foundation and narrowed the focus to my particular corner of it. I baked in the defaults I kept setting manually, added automatic indexing and memory gating at session start, and tuned the out-of-box experience so that `npm install` and `flo init` gets you straight to coding. Over time MoFlo grew its own architecture (workspace collapse, in-tree fastembed runtime, node:sqlite + HNSW memory layer, spell engine, daemon-driven scheduling) and the two projects fully diverged.
 
-If you're exploring the full breadth of agent orchestration, go look at [Ruflo/Claude Flow](https://github.com/ruvnet/ruflo) — it's the real deal. If your needs are similar to mine — a focused, opinionated local dev setup that just works — MoFlo is for you.
+If you're exploring the full breadth of agent orchestration, go look at Ruflo / Claude Flow — it's the real deal. If your needs are similar to mine — a focused, opinionated local dev setup that just works — MoFlo is for you.
 
 ## Contributing
 


### PR DESCRIPTION
## What

Converts two **repeated** `Ruflo/Claude Flow` project links in the README acknowledgment sections to plain text, cutting outbound links to the upstream org from **4 → 2**.

Kept:
- The canonical first project link in the **"Relationship to Ruflo / Claude Flow"** section.
- The **rUv author credit** link (personal acknowledgment).

De-linked (text preserved verbatim):
- The repeated project link in **"Why I Made This"**.
- The repeated project link in the closing "go look at it" line.

## Why

Google currently conflates searches for "moflo" with the upstream fork. Every repeated outbound link to the parent org from our most-authoritative property reinforces that association. This trims the self-inflicted signal **without removing a single word** of the (generous, sincere) acknowledgment — it only reduces link density.

Companion changes applied directly to the repo settings (not in this diff): repo description now leads with "MoFlo" instead of "fork of Ruflo/Claude Flow", `homepage` set to the npm package, and topics expanded 2 → 12.

## Risk

Docs-only, 2 lines changed. No runtime, no consumer surface touched.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)