### PR TITLE
fix(memory): unify code-map into one generator, version the skip-cache

### DIFF
--- a/.claude/scripts/generate-code-map.mjs
+++ b/.claude/scripts/generate-code-map.mjs
@@ -31,7 +31,7 @@ import { fileURLToPath } from 'url';
 import { execSync, execFileSync, spawn } from 'child_process';
 import { memoryDbPath, MOFLO_DIR, findProjectRoot } from './lib/moflo-paths.mjs';
 import { openBackend } from './lib/get-backend.mjs';
-import { applyIncrementalChunks, computeContentListHash } from './lib/incremental-write.mjs';
+import { applyIncrementalChunks, schemeTaggedContentHash } from './lib/incremental-write.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 
 
@@ -41,6 +41,16 @@ const projectRoot = findProjectRoot();
 const NAMESPACE = 'code-map';
 const DB_PATH = memoryDbPath(projectRoot);
 const HASH_CACHE_PATH = resolve(projectRoot, MOFLO_DIR, 'code-map-hash.txt');
+
+// Output-scheme version for the skip-cache (#1260). Bump whenever the emitted
+// key scheme changes (chunk kinds, batch sizes, `file:` granularity) so a
+// generator upgrade forces one rebuild + orphan sweep instead of silently
+// skipping and leaving the previous scheme's rows orphaned. This is also the
+// single source of truth for the code-map scheme now that `flo memory code-map`
+// delegates here rather than shipping a second, divergent generator.
+// v2: unified scheme — invalidates every pre-#1260 cache (bare hash or the
+// old directory-level `flo memory code-map` output) exactly once on pickup.
+const SCHEME_VERSION = 2;
 
 // Directories to exclude from indexing
 const EXCLUDE_DIRS = [
@@ -786,15 +796,16 @@ async function main() {
     return;
   }
 
-  // 2. Check hash for incremental skip
-  const currentHash = computeContentListHash(files);
+  // 2. Check hash for incremental skip — scheme-versioned so a scheme change
+  // invalidates the cache and forces a rebuild + orphan sweep (#1260).
+  const currentHash = schemeTaggedContentHash(files, SCHEME_VERSION);
 
   if (statsOnly) {
     const db = await getDb();
     const count = countNamespace(db);
     db.close();
     log(`Stats: ${files.length} source files, ${count} chunks in code-map namespace`);
-    log(`File list hash: ${currentHash.slice(0, 12)}...`);
+    log(`Scheme v${SCHEME_VERSION}, file list hash: ${currentHash.slice(0, 20)}...`);
     return;
   }
 

--- a/.claude/scripts/lib/incremental-write.mjs
+++ b/.claude/scripts/lib/incremental-write.mjs
@@ -66,6 +66,29 @@ export function computeContentListHash(files) {
 }
 
 /**
+ * Scheme-versioned wrapper around {@link computeContentListHash}. Prefixes the
+ * content hash with `v<schemeVersion>:` so the indexer's skip-cache encodes the
+ * OUTPUT scheme, not just the input file list (#1260).
+ *
+ * Why this is load-bearing: the skip gate short-circuits the whole
+ * extract+write pipeline (including the orphan sweep) whenever the stored hash
+ * matches. If a generator upgrade changes the emitted key scheme (e.g. drops
+ * `file:` entries, or two entry points write divergent shapes) while the source
+ * file list is unchanged, an unversioned hash still matches → the generator
+ * skips → the previous scheme's orphaned rows persist forever. Bumping
+ * `schemeVersion` invalidates every stored cache exactly once, forcing a
+ * rebuild + orphan sweep that reconciles the namespace. Legacy bare-hash caches
+ * (no `v<n>:` prefix) also mismatch, so upgrading consumers self-heal.
+ *
+ * @param {string[]} files - absolute paths
+ * @param {number|string} schemeVersion - monotonically-bumped scheme tag
+ * @returns {string} `v<schemeVersion>:<sha256>`
+ */
+export function schemeTaggedContentHash(files, schemeVersion) {
+  return `v${schemeVersion}:${computeContentListHash(files)}`;
+}
+
+/**
  * Load `key → content` for every active row in the namespace, optionally
  * scoped to keys starting with `keyPrefix` (one doc's chunks at a time —
  * lets per-file indexers like `index-guidance.mjs` content-diff without

--- a/bin/generate-code-map.mjs
+++ b/bin/generate-code-map.mjs
@@ -31,7 +31,7 @@ import { fileURLToPath } from 'url';
 import { execSync, execFileSync, spawn } from 'child_process';
 import { memoryDbPath, MOFLO_DIR, findProjectRoot } from './lib/moflo-paths.mjs';
 import { openBackend } from './lib/get-backend.mjs';
-import { applyIncrementalChunks, computeContentListHash } from './lib/incremental-write.mjs';
+import { applyIncrementalChunks, schemeTaggedContentHash } from './lib/incremental-write.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 
 
@@ -41,6 +41,16 @@ const projectRoot = findProjectRoot();
 const NAMESPACE = 'code-map';
 const DB_PATH = memoryDbPath(projectRoot);
 const HASH_CACHE_PATH = resolve(projectRoot, MOFLO_DIR, 'code-map-hash.txt');
+
+// Output-scheme version for the skip-cache (#1260). Bump whenever the emitted
+// key scheme changes (chunk kinds, batch sizes, `file:` granularity) so a
+// generator upgrade forces one rebuild + orphan sweep instead of silently
+// skipping and leaving the previous scheme's rows orphaned. This is also the
+// single source of truth for the code-map scheme now that `flo memory code-map`
+// delegates here rather than shipping a second, divergent generator.
+// v2: unified scheme — invalidates every pre-#1260 cache (bare hash or the
+// old directory-level `flo memory code-map` output) exactly once on pickup.
+const SCHEME_VERSION = 2;
 
 // Directories to exclude from indexing
 const EXCLUDE_DIRS = [
@@ -786,15 +796,16 @@ async function main() {
     return;
   }
 
-  // 2. Check hash for incremental skip
-  const currentHash = computeContentListHash(files);
+  // 2. Check hash for incremental skip — scheme-versioned so a scheme change
+  // invalidates the cache and forces a rebuild + orphan sweep (#1260).
+  const currentHash = schemeTaggedContentHash(files, SCHEME_VERSION);
 
   if (statsOnly) {
     const db = await getDb();
     const count = countNamespace(db);
     db.close();
     log(`Stats: ${files.length} source files, ${count} chunks in code-map namespace`);
-    log(`File list hash: ${currentHash.slice(0, 12)}...`);
+    log(`Scheme v${SCHEME_VERSION}, file list hash: ${currentHash.slice(0, 20)}...`);
     return;
   }
 

--- a/bin/lib/incremental-write.mjs
+++ b/bin/lib/incremental-write.mjs
@@ -66,6 +66,29 @@ export function computeContentListHash(files) {
 }
 
 /**
+ * Scheme-versioned wrapper around {@link computeContentListHash}. Prefixes the
+ * content hash with `v<schemeVersion>:` so the indexer's skip-cache encodes the
+ * OUTPUT scheme, not just the input file list (#1260).
+ *
+ * Why this is load-bearing: the skip gate short-circuits the whole
+ * extract+write pipeline (including the orphan sweep) whenever the stored hash
+ * matches. If a generator upgrade changes the emitted key scheme (e.g. drops
+ * `file:` entries, or two entry points write divergent shapes) while the source
+ * file list is unchanged, an unversioned hash still matches → the generator
+ * skips → the previous scheme's orphaned rows persist forever. Bumping
+ * `schemeVersion` invalidates every stored cache exactly once, forcing a
+ * rebuild + orphan sweep that reconciles the namespace. Legacy bare-hash caches
+ * (no `v<n>:` prefix) also mismatch, so upgrading consumers self-heal.
+ *
+ * @param {string[]} files - absolute paths
+ * @param {number|string} schemeVersion - monotonically-bumped scheme tag
+ * @returns {string} `v<schemeVersion>:<sha256>`
+ */
+export function schemeTaggedContentHash(files, schemeVersion) {
+  return `v${schemeVersion}:${computeContentListHash(files)}`;
+}
+
+/**
  * Load `key → content` for every active row in the namespace, optionally
  * scoped to keys starting with `keyPrefix` (one doc's chunks at a time —
  * lets per-file indexers like `index-guidance.mjs` content-diff without

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -6,15 +6,13 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as pathModule from 'path';
-import { createHash } from 'crypto';
-import { execSync } from 'child_process';
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { openDaemonDatabase, type SqlJsLikeDatabase } from '../memory/daemon-backend.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
-import { legacySwarmPath, runtimePath, memoryDbPath } from '../services/moflo-paths.js';
+import { memoryDbPath } from '../services/moflo-paths.js';
 import { resolveBridgeDbPath } from '../memory/bridge-core.js';
 import { findProjectRoot } from '../services/project-root.js';
 
@@ -2270,137 +2268,45 @@ const rebuildIndexCommand: Command = {
 };
 
 // ============================================================================
-// code-map subcommand
+// code-map subcommand — delegates to the single shipped generator (#1260)
 // ============================================================================
 
-const EXCLUDE_DIRS = [
-  'back-office-template', 'template', '.claude', 'node_modules',
-  'dist', 'build', '.next', 'coverage',
-];
-
-const DIR_DESCRIPTIONS: Record<string, string> = {
-  entities: 'MikroORM entity definitions',
-  services: 'business logic services',
-  routes: 'Fastify route handlers',
-  middleware: 'request middleware (auth, validation, tenancy)',
-  schemas: 'Zod validation schemas',
-  types: 'TypeScript type definitions',
-  utils: 'utility helpers',
-  config: 'configuration',
-  migrations: 'database migrations',
-  scripts: 'CLI scripts',
-  components: 'React components',
-  pages: 'route page components',
-  contexts: 'React context providers',
-  hooks: 'React custom hooks',
-  layout: 'app shell layout',
-  themes: 'MUI theme configuration',
-  api: 'API client layer',
-  locales: 'i18n translation files',
-  tests: 'test suites',
-  e2e: 'end-to-end tests',
-};
-
-const TS_PATTERNS = [
-  /^export\s+(?:default\s+)?(?:abstract\s+)?class\s+(\w+)(?:\s+extends\s+([\w.]+))?(?:\s+implements\s+([\w,\s.]+))?/,
-  /^export\s+(?:default\s+)?interface\s+(\w+)(?:\s+extends\s+([\w,\s.]+))?/,
-  /^export\s+(?:default\s+)?type\s+(\w+)\s*[=<]/,
-  /^export\s+(?:const\s+)?enum\s+(\w+)/,
-  /^export\s+(?:default\s+)?(?:async\s+)?function\s+(\w+)/,
-  /^export\s+(?:default\s+)?const\s+(\w+)\s*[=:]/,
-];
-
-const ENTITY_DECORATOR = /@Entity\s*\(/;
-const IFACE_MAP_BATCH = 20;
-const TYPE_INDEX_BATCH = 80;
-
-interface ExtractedType {
-  name: string;
-  kind: string;
-  bases: string | null;
-  implements: string | null;
-  isEntity: boolean;
-  file: string;
-}
-
-function detectKind(line: string): string {
-  if (/\bclass\b/.test(line)) return 'class';
-  if (/\binterface\b/.test(line)) return 'interface';
-  if (/\btype\b/.test(line)) return 'type';
-  if (/\benum\b/.test(line)) return 'enum';
-  if (/\bfunction\b/.test(line)) return 'function';
-  if (/\bconst\b/.test(line)) return 'const';
-  return 'export';
-}
-
-function extractTypesFromFile(filePath: string, projectRoot: string): ExtractedType[] {
-  const fullPath = pathModule.resolve(projectRoot, filePath);
-  if (!fs.existsSync(fullPath)) return [];
-
-  let content: string;
-  try {
-    content = fs.readFileSync(fullPath, 'utf-8');
-  } catch {
-    return [];
-  }
-
-  const lines = content.split(/\r?\n/);
-  const types: ExtractedType[] = [];
-  const seen = new Set<string>();
-  let isEntityNext = false;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
-
-    if (ENTITY_DECORATOR.test(line)) {
-      isEntityNext = true;
-      continue;
-    }
-
-    for (const pattern of TS_PATTERNS) {
-      const m = line.match(pattern);
-      if (m && m[1] && !seen.has(m[1])) {
-        seen.add(m[1]);
-        const kind = detectKind(line);
-        const bases = (m[2] || '').trim();
-        const implements_ = (m[3] || '').trim();
-        types.push({
-          name: m[1],
-          kind,
-          bases: bases || null,
-          implements: implements_ || null,
-          isEntity: isEntityNext,
-          file: filePath,
-        });
-        isEntityNext = false;
-        break;
-      }
-    }
-
-    if (isEntityNext && !line.startsWith('@') && !line.startsWith('export') && line.length > 0) {
-      isEntityNext = false;
+/**
+ * Resolve the file-level code-map generator (`bin/generate-code-map.mjs`) for
+ * `cwd`, reusing moflo's canonical bin resolver so this dist CLI command and
+ * the batch indexer (`.claude/scripts/index-all.mjs`) spawn the exact same
+ * script — one generator, one key scheme (#1260).
+ *
+ * Cross-platform: the resolver is located via a cwd-relative path (never a
+ * file-relative `../../../../` depth — that broke #1126) and imported as a
+ * `file://` URL so Windows accepts the absolute path (Rule #1). Returns null
+ * when no copy is found (broken install / not-yet-synced worktree).
+ */
+async function resolveCodeMapGenerator(cwd: string): Promise<string | null> {
+  const { pathToFileURL } = await import('url');
+  const resolverCandidates = [
+    pathModule.join(cwd, 'node_modules', 'moflo', 'bin', 'lib', 'resolve-bin.mjs'),
+    pathModule.join(cwd, 'bin', 'lib', 'resolve-bin.mjs'), // dev / source tree
+  ];
+  for (const resolverPath of resolverCandidates) {
+    if (!fs.existsSync(resolverPath)) continue;
+    try {
+      const { resolveMofloBin } = await import(pathToFileURL(resolverPath).href);
+      return (
+        resolveMofloBin(cwd, 'flo-codemap', 'generate-code-map.mjs', {
+          includeDevFallback: true,
+        }) ?? null
+      );
+    } catch {
+      // Fall through to the next resolver candidate.
     }
   }
-
-  return types;
-}
-
-function getProjectName(filePath: string): string {
-  const parts = filePath.split('/');
-  if (parts[0] === 'packages' && parts.length >= 2) return `${parts[0]}/${parts[1]}`;
-  if (parts[0] === 'back-office' && parts.length >= 2) return `${parts[0]}/${parts[1]}`;
-  if (parts[0] === 'customer-portal' && parts.length >= 2) return `${parts[0]}/${parts[1]}`;
-  if (parts[0] === 'admin-console' && parts.length >= 2) return `${parts[0]}/${parts[1]}`;
-  if (parts[0] === 'webhooks' && parts.length >= 2) return `${parts[0]}/${parts[1]}`;
-  if (parts[0] === 'mobile-app') return 'mobile-app';
-  if (parts[0] === 'tests') return 'tests';
-  if (parts[0] === 'scripts') return 'scripts';
-  return parts[0];
+  return null;
 }
 
 const codeMapCommand: Command = {
   name: 'code-map',
-  description: 'Generate structural code map (project overviews, directory details, type indexes) into code-map namespace',
+  description: 'Generate the structural code map (project overviews, directory details, type + file indexes) into the code-map namespace',
   options: [
     {
       name: 'force',
@@ -2438,318 +2344,52 @@ const codeMapCommand: Command = {
     const verbose = ctx.flags.verbose as boolean;
     const statsOnly = ctx.flags.stats as boolean;
     const skipEmbeddings = ctx.flags.noEmbeddings as boolean;
-    const NAMESPACE = 'code-map';
-
-    const fs = await import('fs');
-    const pathMod = await import('path');
-    const { execSync } = await import('child_process');
-    const { createHash } = await import('crypto');
-
     const cwd = ctx.cwd || process.cwd();
-    // Post-#1168: canonical at `.moflo/memory/code-map-hash.txt`. Legacy
-    // `.swarm/code-map-hash.txt` is read-only fallback for upgrade scenarios.
-    const hashCachePath = runtimePath('memory', 'code-map-hash.txt');
-    const legacyHashCachePath = legacySwarmPath('code-map-hash.txt');
 
     output.writeln();
     output.writeln(output.bold('Generating Code Map'));
     output.writeln(output.dim('─'.repeat(50)));
 
-    // 1. Get source files via git
-    let raw: string;
-    try {
-      raw = execSync(
-        `git ls-files -- "*.ts" "*.tsx" "*.js" "*.mjs" "*.jsx"`,
-        { cwd, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, windowsHide: true }
-      ).trim();
-    } catch {
-      output.printError('Failed to list source files via git. Is this a git repository?');
+    // Single source of truth (#1260): delegate to the one shipped generator —
+    // the same `bin/generate-code-map.mjs` that `index-all.mjs` runs. This
+    // command previously carried a SECOND, divergent generator (directory-level
+    // scheme with no `file:` entries, a path-list-only skip hash at a different
+    // cache path, and a DELETE+reinsert write that nulled embeddings). The two
+    // fought over the `code-map` namespace and accumulated orphaned rows that
+    // neither skip-cache could reconcile. Delegating here makes divergence
+    // structurally impossible.
+    const script = await resolveCodeMapGenerator(cwd);
+    if (!script) {
+      output.printError(
+        'Could not locate the code-map generator (bin/generate-code-map.mjs). Is the moflo package installed?',
+      );
       return { success: false, exitCode: 1 };
     }
 
-    const files = raw ? raw.split(/\r?\n/).filter((f: string) => {
-      for (const ex of EXCLUDE_DIRS) {
-        if (f.startsWith(ex + '/') || f.startsWith(ex + '\\')) return false;
-      }
-      return true;
-    }) : [];
+    const scriptArgs: string[] = [];
+    if (forceRegen) scriptArgs.push('--force');
+    if (verbose) scriptArgs.push('--verbose');
+    if (statsOnly) scriptArgs.push('--stats');
+    if (skipEmbeddings) scriptArgs.push('--no-embeddings');
 
-    if (files.length === 0) {
-      output.writeln('No source files found.');
-      return { success: true };
-    }
-
-    output.writeln(`Found ${files.length} source files`);
-
-    // 2. Hash check
-    const sorted = [...files].sort();
-    const currentHash = createHash('sha256').update(sorted.join('\n')).digest('hex');
-
-    if (statsOnly) {
-      const { db } = await openDb(cwd);
-      const stmt = db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = ?`);
-      stmt.bind([NAMESPACE]);
-      const count = stmt.step() ? (stmt.getAsObject() as any).cnt : 0;
-      stmt.free();
-      db.close();
-      output.writeln(`Stats: ${files.length} source files, ${count} chunks in code-map namespace`);
-      output.writeln(`File list hash: ${currentHash.slice(0, 12)}...`);
-      return { success: true };
-    }
-
-    // Check if unchanged — canonical first, then legacy `.swarm/` fallback.
-    const cachedReadPath = fs.existsSync(hashCachePath)
-      ? hashCachePath
-      : (fs.existsSync(legacyHashCachePath) ? legacyHashCachePath : null);
-    if (!forceRegen && cachedReadPath) {
-      const cached = fs.readFileSync(cachedReadPath, 'utf-8').trim();
-      if (cached === currentHash) {
-        const { db } = await openDb(cwd);
-        const stmt = db.prepare(`SELECT COUNT(*) as cnt FROM memory_entries WHERE namespace = ?`);
-        stmt.bind([NAMESPACE]);
-        const count = stmt.step() ? (stmt.getAsObject() as any).cnt : 0;
-        stmt.free();
-        db.close();
-        if (count > 0) {
-          output.writeln(output.dim(`Skipping -- file list unchanged (${count} chunks in DB)`));
-          return { success: true };
-        }
-      }
-    }
-
-    // 3. Extract types
-    output.writeln('Extracting type declarations...');
-    const allTypes: ExtractedType[] = [];
-    const filesByProject: Record<string, string[]> = {};
-    const typesByProject: Record<string, ExtractedType[]> = {};
-    const typesByDir: Record<string, ExtractedType[]> = {};
-
-    for (const file of files) {
-      const project = getProjectName(file);
-      if (!filesByProject[project]) filesByProject[project] = [];
-      filesByProject[project].push(file);
-
-      const types = extractTypesFromFile(file, cwd);
-      for (const t of types) {
-        allTypes.push(t);
-        if (!typesByProject[project]) typesByProject[project] = [];
-        typesByProject[project].push(t);
-
-        const dir = pathModule.dirname(t.file).replace(/\\/g, '/');
-        if (!typesByDir[dir]) typesByDir[dir] = [];
-        typesByDir[dir].push(t);
-      }
-    }
-
-    output.writeln(`Extracted ${allTypes.length} types from ${Object.keys(filesByProject).length} projects`);
-
-    // 4. Generate chunks
-    const allChunks: Array<{ key: string; content: string; metadata: Record<string, unknown>; tags: string[] }> = [];
-
-    // Project overviews
-    for (const [project, projFiles] of Object.entries(filesByProject)) {
-      const types = typesByProject[project] || [];
-      const dirMap: Record<string, string[]> = {};
-
-      for (const t of types) {
-        const rel = pathModule.relative(project, pathModule.dirname(t.file)).replace(/\\/g, '/') || '(root)';
-        if (!dirMap[rel]) dirMap[rel] = [];
-        dirMap[rel].push(t.name);
-      }
-
-      // Detect primary language
-      let tsx = 0, ts = 0, js = 0;
-      for (const f of projFiles) {
-        const ext = pathModule.extname(f);
-        if (ext === '.tsx' || ext === '.jsx') tsx++;
-        else if (ext === '.ts') ts++;
-        else js++;
-      }
-      const lang = tsx > ts && tsx > js ? 'React/TypeScript' : ts >= js ? 'TypeScript' : 'JavaScript';
-
-      let content = `# ${project} [${lang}, ${projFiles.length} files, ${types.length} types]\n\n`;
-      for (const dir of Object.keys(dirMap).sort()) {
-        const names = dirMap[dir];
-        const lastDir = dir.split('/').pop() || '';
-        const desc = DIR_DESCRIPTIONS[lastDir];
-        const descStr = desc ? ` -- ${desc}` : '';
-        const shown = names.slice(0, 8).join(', ');
-        const overflow = names.length > 8 ? `, ... (+${names.length - 8} more)` : '';
-        content += `  ${dir}${descStr}: ${shown}${overflow}\n`;
-      }
-
-      allChunks.push({
-        key: `project:${project}`,
-        content: content.trim(),
-        metadata: { kind: 'project-overview', project, language: lang, fileCount: projFiles.length, typeCount: types.length },
-        tags: ['project', project],
+    const { execFileSync } = await import('child_process');
+    try {
+      // process.execPath (not bare 'node') so the child uses the exact same
+      // interpreter with no PATH dependency — robust on Windows where the
+      // launching node need not be on PATH (Rule #1). execFileSync passes argv
+      // as an array, so spaces in the path (e.g. "Program Files") are safe.
+      execFileSync(process.execPath, [script, ...scriptArgs], {
+        cwd,
+        stdio: 'inherit',
+        windowsHide: true,
+        timeout: 5 * 60_000,
       });
-    }
-
-    // Directory details
-    for (const [dir, types] of Object.entries(typesByDir)) {
-      if (types.length < 2) continue;
-      const lastDir = dir.split('/').pop() || '';
-      const desc = DIR_DESCRIPTIONS[lastDir];
-      let content = `# ${dir} (${types.length} types)\n`;
-      if (desc) content += `${desc}\n`;
-      content += '\n';
-
-      const sortedTypes = [...types].sort((a, b) => a.name.localeCompare(b.name));
-      for (const t of sortedTypes) {
-        const suffix: string[] = [];
-        if (t.bases) suffix.push(`: ${t.bases}`);
-        if (t.implements) suffix.push(`: ${t.implements}`);
-        const suffixStr = suffix.length ? ` ${suffix.join(' ')}` : '';
-        const fileName = pathModule.basename(t.file);
-        content += `  ${t.name}${suffixStr} (${fileName})\n`;
-      }
-
-      allChunks.push({
-        key: `dir:${dir}`,
-        content: content.trim(),
-        metadata: { kind: 'directory-detail', directory: dir, typeCount: types.length },
-        tags: ['directory', dir.split('/')[0]],
-      });
-    }
-
-    // Interface maps
-    const interfaces = new Map<string, { defined: string; implementations: Array<{ name: string; project: string }> }>();
-    for (const t of allTypes) {
-      if (t.kind === 'interface' && !interfaces.has(t.name)) {
-        interfaces.set(t.name, { defined: t.file, implementations: [] });
-      }
-    }
-    for (const t of allTypes) {
-      if (t.kind !== 'class') continue;
-      const impls = t.implements ? t.implements.split(',').map((s: string) => s.trim()) : [];
-      const bases = t.bases ? [t.bases.trim()] : [];
-      for (const iface of [...impls, ...bases]) {
-        if (interfaces.has(iface)) {
-          interfaces.get(iface)!.implementations.push({ name: t.name, project: getProjectName(t.file) });
-        }
-      }
-    }
-
-    const mapped = Array.from(interfaces.entries())
-      .filter(([, v]) => v.implementations.length > 0)
-      .sort(([a], [b]) => a.localeCompare(b));
-
-    if (mapped.length > 0) {
-      const totalBatches = Math.ceil(mapped.length / IFACE_MAP_BATCH);
-      for (let i = 0; i < mapped.length; i += IFACE_MAP_BATCH) {
-        const batch = mapped.slice(i, i + IFACE_MAP_BATCH);
-        const batchNum = Math.floor(i / IFACE_MAP_BATCH) + 1;
-
-        let content = `# Interface-to-Implementation Map (${batchNum}/${totalBatches})\n\n`;
-        for (const [name, info] of batch) {
-          const implStr = info.implementations.map(impl => `${impl.name} (${impl.project})`).join(', ');
-          content += `  ${name} -> ${implStr}\n`;
-        }
-
-        allChunks.push({
-          key: `iface-map:${batchNum}`,
-          content: content.trim(),
-          metadata: { kind: 'interface-map', batch: batchNum, totalBatches, count: batch.length },
-          tags: ['interface-map'],
-        });
-      }
-    }
-
-    // Type index
-    const sortedAllTypes = [...allTypes].sort((a, b) => a.name.localeCompare(b.name));
-    const typeIdxTotalBatches = Math.ceil(sortedAllTypes.length / TYPE_INDEX_BATCH);
-
-    for (let i = 0; i < sortedAllTypes.length; i += TYPE_INDEX_BATCH) {
-      const batch = sortedAllTypes.slice(i, i + TYPE_INDEX_BATCH);
-      const batchNum = Math.floor(i / TYPE_INDEX_BATCH) + 1;
-
-      let content = `# Type Index (batch ${batchNum}, ${batch.length} types)\n\n`;
-      for (const t of batch) {
-        const ext = pathModule.extname(t.file);
-        const lang = (ext === '.tsx' || ext === '.jsx') ? 'tsx' : ext === '.ts' ? 'ts' : ext === '.mjs' ? 'esm' : 'js';
-        content += `  ${t.name} -> ${t.file} [${lang}]\n`;
-      }
-
-      allChunks.push({
-        key: `type-index:${batchNum}`,
-        content: content.trim(),
-        metadata: { kind: 'type-index', batch: batchNum, totalBatches: typeIdxTotalBatches, count: batch.length },
-        tags: ['type-index'],
-      });
-    }
-
-    output.writeln(`Generated ${allChunks.length} chunks`);
-    if (verbose) {
-      const projectCount = allChunks.filter(c => (c.metadata.kind as string) === 'project-overview').length;
-      const dirCount = allChunks.filter(c => (c.metadata.kind as string) === 'directory-detail').length;
-      const ifaceCount = allChunks.filter(c => (c.metadata.kind as string) === 'interface-map').length;
-      const typeIdxCount = allChunks.filter(c => (c.metadata.kind as string) === 'type-index').length;
-      output.writeln(`  Project overviews: ${projectCount}`);
-      output.writeln(`  Directory details: ${dirCount}`);
-      output.writeln(`  Interface maps:    ${ifaceCount}`);
-      output.writeln(`  Type index:        ${typeIdxCount}`);
-    }
-
-    // 5. Write to DB
-    output.writeln('Writing to memory database...');
-    const { db, dbPath } = await openDb(cwd);
-
-    // Clear old code-map entries
-    db.run(`DELETE FROM memory_entries WHERE namespace = ?`, [NAMESPACE]);
-
-    for (const chunk of allChunks) {
-      batchStoreEntry(db, chunk.key, NAMESPACE, chunk.content, chunk.metadata, chunk.tags);
-    }
-
-    saveAndCloseDb(db, dbPath);
-
-    // Save hash
-    const hashDir = pathModule.dirname(hashCachePath);
-    if (!fs.existsSync(hashDir)) {
-      fs.mkdirSync(hashDir, { recursive: true });
-    }
-    fs.writeFileSync(hashCachePath, currentHash, 'utf-8');
-
-    output.printSuccess(`${allChunks.length} chunks written to code-map namespace`);
-
-    // Generate embeddings unless skipped
-    if (!skipEmbeddings) {
-      output.writeln(output.dim('Generating embeddings for code-map entries...'));
-      try {
-        const { generateEmbedding } = await import('../memory/memory-initializer.js');
-        const { db: db2, dbPath: dbPath2 } = await openDb(cwd);
-
-        const stmt = db2.prepare(
-          `SELECT id, content FROM memory_entries WHERE namespace = ? AND (embedding IS NULL OR embedding = '')`,
-        );
-        stmt.bind([NAMESPACE]);
-        const entries: Array<{ id: string; content: string }> = [];
-        while (stmt.step()) entries.push(stmt.getAsObject() as { id: string; content: string });
-        stmt.free();
-
-        let embedded = 0;
-        for (const entry of entries) {
-          try {
-            const text = entry.content.substring(0, 1500);
-            const { embedding, dimensions, model } = await generateEmbedding(text);
-            db2.run(
-              `UPDATE memory_entries SET embedding = ?, embedding_model = ?, embedding_dimensions = ?, updated_at = ? WHERE id = ?`,
-              [JSON.stringify(embedding), model, dimensions, Date.now(), entry.id]
-            );
-            embedded++;
-          } catch { /* skip */ }
-        }
-
-        if (embedded > 0) {
-          saveAndCloseDb(db2, dbPath2);
-          output.printSuccess(`Generated ${embedded} embeddings`);
-        } else {
-          db2.close();
-        }
-      } catch (err: any) {
-        output.writeln(output.dim(`  Embedding generation skipped: ${err.message}`));
-      }
+    } catch (err) {
+      const code = (err as { status?: number }).status;
+      output.printError(
+        `Code map generation failed${typeof code === 'number' ? ` (exit ${code})` : ''}: ${errorDetail(err)}`,
+      );
+      return { success: false, exitCode: typeof code === 'number' ? code : 1 };
     }
 
     return { success: true };

--- a/tests/bin/incremental-write.test.ts
+++ b/tests/bin/incremental-write.test.ts
@@ -25,6 +25,7 @@ import { resolve } from 'path';
 import {
   applyIncrementalChunks,
   computeContentListHash,
+  schemeTaggedContentHash,
   loadExistingContent,
 } from '../../bin/lib/incremental-write.mjs';
 import { mkdtempSync, writeFileSync, utimesSync, rmSync } from 'fs';
@@ -288,16 +289,99 @@ describe('computeContentListHash (#746)', () => {
 
 describe('indexer source uses content-hash gate (#746)', () => {
   for (const file of ['index-patterns.mjs', 'generate-code-map.mjs', 'index-tests.mjs']) {
-    it(`${file} imports computeContentListHash and dropped the mtime/size hash`, () => {
+    it(`${file} imports the content-hash gate and dropped the mtime/size hash`, () => {
       const src = readFileSync(resolve(BIN, file), 'utf-8');
-      // Helper imported and called.
-      expect(src).toMatch(/computeContentListHash\b/);
+      // Content-hash gate in use. code-map wraps it in the scheme-versioned
+      // variant (#1260); patterns/tests use the bare helper directly.
+      expect(src).toMatch(/\b(computeContentListHash|schemeTaggedContentHash)\b/);
       // Old gates are gone.
       expect(src).not.toMatch(/statSync\([^)]*\)\.mtimeMs/);
       expect(src).not.toMatch(/statSync\([^)]*\)\.size/);
       expect(src).not.toMatch(/^\s*function\s+computeFileListHash\s*\(/m);
     });
   }
+});
+
+describe('schemeTaggedContentHash (#1260)', () => {
+  // Reuse a tmpdir so the wrapped content hash reads real bytes, mirroring the
+  // computeContentListHash suite above.
+  let dir: string;
+
+  function tmpFile(name: string, content: string) {
+    const p = join(dir, name);
+    writeFileSync(p, content);
+    return p;
+  }
+
+  it('prefixes the content hash with the scheme version tag', () => {
+    dir = mkdtempSync(join(tmpdir(), 'moflo-scheme-'));
+    const a = tmpFile('a.ts', 'export const A = 1;');
+    const tagged = schemeTaggedContentHash([a], 2);
+    expect(tagged).toBe(`v2:${computeContentListHash([a])}`);
+    expect(tagged.startsWith('v2:')).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('same files + same version → identical tag (stable skip-cache key)', () => {
+    dir = mkdtempSync(join(tmpdir(), 'moflo-scheme-'));
+    const a = tmpFile('a.ts', 'A');
+    const b = tmpFile('b.ts', 'B');
+    expect(schemeTaggedContentHash([a, b], 3)).toBe(schemeTaggedContentHash([a, b], 3));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('bumping the scheme version invalidates the cache even when files are unchanged', () => {
+    dir = mkdtempSync(join(tmpdir(), 'moflo-scheme-'));
+    const a = tmpFile('a.ts', 'A');
+    // Same file list + content, only the scheme version differs. This is the
+    // core of #1260: a generator upgrade that changes the emitted key scheme
+    // must force a rebuild + orphan sweep rather than silently skipping.
+    expect(schemeTaggedContentHash([a], 1)).not.toBe(schemeTaggedContentHash([a], 2));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('a legacy bare hash never equals a scheme-tagged hash (upgrading consumers self-heal)', () => {
+    dir = mkdtempSync(join(tmpdir(), 'moflo-scheme-'));
+    const a = tmpFile('a.ts', 'A');
+    // Pre-#1260 caches stored the bare hex digest. On pickup the tagged value
+    // mismatches, so the skip is bypassed and the accumulated orphans are swept.
+    expect(schemeTaggedContentHash([a], 2)).not.toBe(computeContentListHash([a]));
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('still tracks content edits (delegates to the content hash)', () => {
+    dir = mkdtempSync(join(tmpdir(), 'moflo-scheme-'));
+    const a = tmpFile('a.ts', 'export const A = 1;');
+    const before = schemeTaggedContentHash([a], 2);
+    writeFileSync(a, 'export const A = 2;');
+    expect(schemeTaggedContentHash([a], 2)).not.toBe(before);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('code-map single source of truth (#1260)', () => {
+  it('generate-code-map.mjs gates on the scheme-versioned hash and declares SCHEME_VERSION', () => {
+    const src = readFileSync(resolve(BIN, 'generate-code-map.mjs'), 'utf-8');
+    expect(src).toMatch(/schemeTaggedContentHash\s*\(/);
+    expect(src).toMatch(/const\s+SCHEME_VERSION\s*=\s*\d+/);
+  });
+
+  it('flo memory code-map delegates to the one shipped generator (no second inline generator)', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../../src/cli/commands/memory.ts'),
+      'utf-8',
+    );
+    // The dist command must spawn bin/generate-code-map.mjs via the canonical
+    // resolver — not carry a divergent directory-level generator (#1260).
+    expect(src).toMatch(/generate-code-map\.mjs/);
+    expect(src).toMatch(/resolveMofloBin/);
+    // The old inline generator's fingerprints are gone: no per-file type
+    // extractor, no TS-only pattern table, no DELETE-then-reinsert of the
+    // whole namespace.
+    expect(src).not.toMatch(/function\s+extractTypesFromFile\s*\(/);
+    expect(src).not.toMatch(/const\s+TS_PATTERNS\s*=/);
+    expect(src).not.toMatch(/DELETE FROM memory_entries WHERE namespace = \?`,\s*\[NAMESPACE\]/);
+  });
 });
 
 describe('indexer source no longer wipes namespace before reinsert (#745)', () => {


### PR DESCRIPTION
## Summary

Fixes #1260. moflo shipped **two divergent `code-map` generators** writing the same `code-map` namespace with incompatible key schemes, and neither could reconcile the other's rows — so scheme drift silently accumulated orphaned entries (a real DB held 1,630 stale `file:` orphans that only a forced `flo memory refresh` cleared).

| Generator | Entry points | Scheme | Skip hash | Write |
|-----------|--------------|--------|-----------|-------|
| `bin/generate-code-map.mjs` (`flo-codemap`) | `index-all.mjs` | file-level (`file:` entries), multi-language | content-aware, `.moflo/code-map-hash.txt` | `applyIncrementalChunks` (orphan-sweep, keeps embeddings) |
| `flo memory code-map` (dist, `memory.ts`) | `flo memory refresh`, on-demand | directory-level, **no `file:` entries**, TS-only | path-list-only, `.moflo/memory/code-map-hash.txt` | `DELETE`+reinsert (nulled embeddings) |

Each owned a **separate** skip-cache and **neither hash encoded the scheme**, so whichever generator ran last won and the other's rows orphaned with no path to reconcile.

## Changes

- **Single source of truth (#1260 fix #1):** `flo memory code-map` now **delegates** to `bin/generate-code-map.mjs` — the same generator `index-all.mjs` runs. One generator, one scheme, one hash file, one orphan-sweep. Deletes ~280 lines of the divergent inline generator from `memory.ts`. Divergence becomes structurally impossible.
- **Scheme-aware skip cache (#1260 fix #2):** new `schemeTaggedContentHash(files, schemeVersion)` (`v<n>:<contentListHash>`); `bin/generate-code-map.mjs` gates on `SCHEME_VERSION` (bumped to **2**). A scheme change — or a legacy bare-hash cache — now mismatches, forcing **exactly one** rebuild + orphan sweep that self-heals accumulated orphans on pickup.
- With one generator + a version-gated cache, the issue's fixes #3/#4 (decouple sweep from skip; cleanup/doctor prune) are no longer needed.

## Cross-platform / install-aware (Rule #1)

- Generator resolved **cwd-relative** via the canonical `resolveMofloBin` (`node_modules/moflo/bin` first, dev fallback after) — never file-relative `../../../../` depth (the #1126 trap).
- The `.mjs` resolver is imported via `pathToFileURL(path).href` so Windows accepts the absolute-path ESM import.
- Child spawned with `process.execPath` (no PATH dependency) + `windowsHide`, argv as an array (spaces safe).

## Consumer impact

Both files ship at runtime. On pickup, the `SCHEME_VERSION` bump triggers **one** forced code-map rebuild (seconds + re-embed of the `code-map` namespace only). `.moflo/` state parses unchanged; no consumer migration. Takes effect after publish + reinstall (runtime layer).

## Testing

- [x] Unit — `schemeTaggedContentHash`: stable per (files, version); version bump ⇒ different tag with unchanged files; legacy bare hash ≠ tagged (forces reconcile); still tracks content edits. Plus source-invariants pinning the single-generator delegation. (`tests/bin/incremental-write.test.ts`, 25 passed)
- [x] Related suites — `indexing-fixes`, `index-fingerprint`, `cross-platform` (114 passed)
- [x] `npm run build` clean; `tsc --noEmit` clean
- [x] E2E — `flo memory code-map --stats` prints the dist header then the delegated `[code-map]` subprocess output; source bin `--stats` shows the `v2:` tag
- [ ] Manual testing done

Closes #1260

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_01QMa4531JXG3YcW1PQigdc1
