### PR TITLE
perf(memory): dedup-by-source + single-call neighbor expansion (#1262)

### DIFF
--- a/.claude/guidance/shipped/moflo-memory-protocol.md
+++ b/.claude/guidance/shipped/moflo-memory-protocol.md
@@ -4,7 +4,7 @@
 
 ## Rule (MUST)
 
-When a search hit carries a non-null `navigation` field, you MUST traverse via `mcp__moflo__memory_get_neighbors` — NOT bulk-retrieve every hit with `memory_retrieve`. The `navigation` crumb is the chunking architecture's contract; bulk-retrieving every search hit defeats it and is a protocol violation. Use `memory_retrieve` only for a single specific key you already hold, or for non-chunk entries where `navigation` is null.
+When a search hit carries a non-null `navigation` field and you need adjacent context, prefer `memory_search` with `expand: 'neighbors'` — it inlines each chunk hit's prev/next content in the SAME call (one round-trip, no re-embedding). Otherwise traverse via `mcp__moflo__memory_get_neighbors`. NEVER bulk-retrieve every hit with `memory_retrieve` — the `navigation` crumb is the chunking architecture's contract, and bulk-retrieving defeats it (protocol violation). NEVER `Read` a chunk's `parentPath` for surrounding context when `expand`/neighbors would do — a full-doc Read costs far more tokens. Use `memory_retrieve` only for a single specific key you already hold, or for non-chunk entries where `navigation` is null.
 
 ---
 
@@ -146,7 +146,8 @@ Once you have a search hit, pick the right follow-up call by what you need next.
 | You want | Use | Why |
 |----------|-----|-----|
 | Find an entry-point | `mcp__moflo__memory_search` | Returns chunk hits with `navigation` (parentDoc, prev/next, chunkTitle) |
-| Adjacent context (1 chunk over) | `mcp__moflo__memory_get_neighbors` `{ key, include: ['prev','next'] }` | One round-trip, shaped entries with full nav |
+| Adjacent context AND you're still searching | `mcp__moflo__memory_search` `{ query, expand: 'neighbors' }` | Cheapest — prev/next content inlined in the search call itself, zero extra round-trips |
+| Adjacent context for a hit you already have | `mcp__moflo__memory_get_neighbors` `{ key, include: ['prev','next'] }` | One round-trip, shaped entries with full nav |
 | Same-section peers (h2/h3 family) | `memory_get_neighbors` `{ include: ['siblings'] }` or `['parent','children']` | Hierarchical traversal — cheaper than re-searching |
 | Full content of one specific chunk | `mcp__moflo__memory_retrieve` `{ key }` | For a key you already hold — never for bulk-retrieving search hits |
 | Whole source doc when truly needed | `Read` `parentPath` from any chunk's nav | Disk read is cheaper than re-indexed `doc-*` |

--- a/src/cli/__tests__/memory-tools-search-cosmetic.test.ts
+++ b/src/cli/__tests__/memory-tools-search-cosmetic.test.ts
@@ -1,6 +1,7 @@
 /**
  * #1053 S6: cosmetic trims to memory_search response.
- *  - default limit: 10 → 8 → 5 (#1262 lever #1)
+ *  - default user-facing limit: 10 → 8 (unchanged by #1262; see dedup below)
+ *  - #1262 lever #1: over-fetch (limit*3) then dedup-by-source, trim to limit
  *  - default threshold: 0.3 → 0.5  (#837 explicit-zero passthrough still respected)
  *  - similarity rounded to 2dp
  *  - searchTime dropped from MCP envelope (CLI keeps it)
@@ -42,10 +43,12 @@ async function getSearchTool(): Promise<MCPTool> {
 }
 
 describe('memory_search — cosmetic trims (#1053 S6)', () => {
-  it('default limit is 5 (#1262 lever #1)', async () => {
+  it('over-fetches limit*3 for dedup headroom, default user limit stays 8 (#1262 lever #1)', async () => {
     const tool = await getSearchTool();
     await tool.handler({ query: 'q' });
-    expect(searchSpy.mock.calls[0]?.[0]?.limit).toBe(5);
+    // searchEntries is asked for the overscan (8*3=24); the handler dedups +
+    // trims back to the user-facing 8 before returning.
+    expect(searchSpy.mock.calls[0]?.[0]?.limit).toBe(24);
   });
 
   it('rounds similarity to 2 decimal places', async () => {

--- a/src/cli/__tests__/memory-tools-search-cosmetic.test.ts
+++ b/src/cli/__tests__/memory-tools-search-cosmetic.test.ts
@@ -1,6 +1,6 @@
 /**
  * #1053 S6: cosmetic trims to memory_search response.
- *  - default limit: 10 → 8
+ *  - default limit: 10 → 8 → 5 (#1262 lever #1)
  *  - default threshold: 0.3 → 0.5  (#837 explicit-zero passthrough still respected)
  *  - similarity rounded to 2dp
  *  - searchTime dropped from MCP envelope (CLI keeps it)
@@ -42,10 +42,10 @@ async function getSearchTool(): Promise<MCPTool> {
 }
 
 describe('memory_search — cosmetic trims (#1053 S6)', () => {
-  it('default limit is 8', async () => {
+  it('default limit is 5 (#1262 lever #1)', async () => {
     const tool = await getSearchTool();
     await tool.handler({ query: 'q' });
-    expect(searchSpy.mock.calls[0]?.[0]?.limit).toBe(8);
+    expect(searchSpy.mock.calls[0]?.[0]?.limit).toBe(5);
   });
 
   it('rounds similarity to 2 decimal places', async () => {

--- a/src/cli/__tests__/memory-tools-search-dedup.test.ts
+++ b/src/cli/__tests__/memory-tools-search-dedup.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #1262 lever #1: dedup-by-source. The same underlying source is often indexed
+ * under multiple keys — a file as `file:<path>` (code-map) AND `pattern:file:<path>`
+ * (patterns), a test as `file:<path>` AND `test-file:<path>`. Those collapse to a
+ * single result slot (highest score kept), so every returned slot is a DISTINCT
+ * source. The handler over-fetches (limit*3) so a full `limit` of uniques survives.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MCPTool } from '../mcp-tools/types.js';
+
+// Score-desc set with deliberate cross-namespace duplication:
+//   src/a.ts   -> file: (0.95), pattern:file: (0.93), test-file: (0.70)  = 1 source
+//   Foo symbol -> pattern:class:Foo (0.92)                                = distinct
+//   src/b.ts   -> file: (0.90)                                            = distinct
+const dupResults = [
+  { id: '1', key: 'file:src/a.ts', namespace: 'code-map', content: 'a', score: 0.95, metadata: undefined },
+  { id: '2', key: 'pattern:class:Foo', namespace: 'patterns', content: 'Foo', score: 0.92, metadata: undefined },
+  { id: '3', key: 'pattern:file:src/a.ts', namespace: 'patterns', content: 'a-pat', score: 0.93, metadata: undefined },
+  { id: '4', key: 'file:src/b.ts', namespace: 'code-map', content: 'b', score: 0.90, metadata: undefined },
+  { id: '5', key: 'test-file:src/a.ts', namespace: 'tests', content: 'a-test', score: 0.70, metadata: undefined },
+];
+
+const searchSpy = vi.fn(async () => ({ success: true, results: dupResults, searchTime: 1 }));
+
+vi.mock('../memory/memory-initializer.js', () => ({
+  storeEntry: vi.fn(),
+  searchEntries: searchSpy,
+  listEntries: vi.fn(),
+  getEntry: vi.fn(),
+  deleteEntry: vi.fn(),
+  initializeMemoryDatabase: vi.fn(async () => ({ success: true, dbPath: '' })),
+  checkMemoryInitialization: vi.fn(async () => ({ initialized: true, dbPath: '', tableExists: true, version: '3.0.0' })),
+}));
+
+vi.mock('../services/spell-gate.js', () => ({
+  GateService: class { recordMemorySearched(): void { /* no-op */ } },
+}));
+
+beforeEach(() => { searchSpy.mockClear(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+async function getSearchTool(): Promise<MCPTool> {
+  const mod = await import('../mcp-tools/memory-tools.js');
+  const t = (mod.memoryTools as MCPTool[]).find(x => x.name === 'memory_search');
+  if (!t) throw new Error('memory_search not registered');
+  return t;
+}
+
+type Envelope = { results: Array<{ key: string; similarity: number }>; total: number };
+
+describe('memory_search — dedup-by-source (#1262 lever #1)', () => {
+  it('collapses same-source representations, keeping the highest-scoring one', async () => {
+    const tool = await getSearchTool();
+    const res = await tool.handler({ query: 'q' }) as Envelope;
+    // src/a.ts appeared 3x (file/pattern:file/test-file) -> one slot, the 0.95 one.
+    const keys = res.results.map(r => r.key);
+    expect(keys).toEqual(['file:src/a.ts', 'pattern:class:Foo', 'file:src/b.ts']);
+    expect(res.total).toBe(3);
+    // The kept src/a.ts slot is the highest-scoring representation.
+    expect(res.results.find(r => r.key === 'file:src/a.ts')?.similarity).toBe(0.95);
+  });
+
+  it('keeps a symbol view (pattern:class) distinct from the file source', async () => {
+    const tool = await getSearchTool();
+    const res = await tool.handler({ query: 'q' }) as Envelope;
+    // pattern:class:Foo is a symbol view, NOT collapsed into any file source.
+    expect(res.results.some(r => r.key === 'pattern:class:Foo')).toBe(true);
+  });
+
+  it('trims to the user-facing limit AFTER dedup', async () => {
+    const tool = await getSearchTool();
+    const res = await tool.handler({ query: 'q', limit: 2 }) as Envelope;
+    expect(res.results.map(r => r.key)).toEqual(['file:src/a.ts', 'pattern:class:Foo']);
+    expect(res.total).toBe(2);
+  });
+});

--- a/src/cli/__tests__/memory-tools-search-expand.test.ts
+++ b/src/cli/__tests__/memory-tools-search-expand.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #1262 lever #3: single-call neighbor expansion + steer-away-from-Read hint.
+ *
+ * - expand:'neighbors' inlines each chunk hit's prev/next chunk content in ONE
+ *   call, so the model doesn't fall back to a full-doc Read for context.
+ * - a `nextStep` steer appears ONLY when chunk hits are present and the caller
+ *   did NOT expand — so the hint costs no tokens on the common case.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MCPTool } from '../mcp-tools/types.js';
+
+// A chunk hit whose compact navigation points at prev/next chunk keys.
+const chunkMeta = JSON.stringify({
+  type: 'chunk',
+  parentDoc: 'doc-1',
+  parentPath: '.claude/guidance/x.md',
+  prevChunk: 'chunk-0',
+  nextChunk: 'chunk-2',
+  chunkTitle: 'Middle',
+});
+
+const searchSpy = vi.fn(async () => ({
+  success: true,
+  results: [{ id: '1', key: 'chunk-1', namespace: 'guidance', content: 'middle body', score: 0.9, metadata: chunkMeta }],
+  searchTime: 1,
+}));
+
+// getEntry resolves the neighbor keys the expansion asks for.
+const getEntrySpy = vi.fn(async ({ key }: { key: string }) => ({
+  found: true,
+  entry: { id: key, key, namespace: 'guidance', content: `${key} body`, accessCount: 0, createdAt: '', updatedAt: '', hasEmbedding: true, tags: [], metadata: undefined },
+}));
+
+vi.mock('../memory/memory-initializer.js', () => ({
+  storeEntry: vi.fn(),
+  searchEntries: searchSpy,
+  listEntries: vi.fn(),
+  getEntry: getEntrySpy,
+  deleteEntry: vi.fn(),
+  initializeMemoryDatabase: vi.fn(async () => ({ success: true, dbPath: '' })),
+  checkMemoryInitialization: vi.fn(async () => ({ initialized: true, dbPath: '', tableExists: true, version: '3.0.0' })),
+}));
+
+vi.mock('../services/spell-gate.js', () => ({
+  GateService: class { recordMemorySearched(): void { /* no-op */ } },
+}));
+
+beforeEach(() => { searchSpy.mockClear(); getEntrySpy.mockClear(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+async function getSearchTool(): Promise<MCPTool> {
+  const mod = await import('../mcp-tools/memory-tools.js');
+  const t = (mod.memoryTools as MCPTool[]).find(x => x.name === 'memory_search');
+  if (!t) throw new Error('memory_search not registered');
+  return t;
+}
+
+type Hit = { key: string; expanded?: Array<{ position: string; key: string; value: unknown }> };
+type Envelope = { results: Hit[]; nextStep?: string };
+
+describe('memory_search — expand + steer (#1262 lever #3)', () => {
+  it('does NOT expand by default and surfaces the steer on chunk hits', async () => {
+    const tool = await getSearchTool();
+    const res = await tool.handler({ query: 'q' }) as Envelope;
+    expect(getEntrySpy).not.toHaveBeenCalled();
+    expect(res.results[0].expanded).toBeUndefined();
+    expect(res.nextStep).toMatch(/expand:'neighbors'/);
+  });
+
+  it("expand:'neighbors' inlines prev/next chunk content in one call", async () => {
+    const tool = await getSearchTool();
+    const res = await tool.handler({ query: 'q', expand: 'neighbors' }) as Envelope;
+    const expanded = res.results[0].expanded ?? [];
+    expect(expanded.map(e => e.key).sort()).toEqual(['chunk-0', 'chunk-2']);
+    expect(expanded.find(e => e.position === 'prev')?.value).toBe('chunk-0 body');
+    expect(expanded.find(e => e.position === 'next')?.value).toBe('chunk-2 body');
+    // When the caller already expanded, the steer must not also fire.
+    expect(res.nextStep).toBeUndefined();
+  });
+
+  it('omits the steer entirely when there are no chunk hits', async () => {
+    searchSpy.mockResolvedValueOnce({
+      success: true,
+      results: [{ id: '1', key: 'plain', namespace: 'learnings', content: 'x', score: 0.9, metadata: undefined }],
+      searchTime: 1,
+    });
+    const tool = await getSearchTool();
+    const res = await tool.handler({ query: 'q' }) as Envelope;
+    expect(res.nextStep).toBeUndefined();
+  });
+});

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -195,6 +195,20 @@ function parseNavigation(
   };
 }
 
+// #1262 lever #1 (dedup-by-source): collapse multiple representations of the
+// SAME underlying source to one result slot. Dogfooding showed a dense query's
+// top-8 is routinely ~40% duplicates — e.g. one file indexed in code-map as
+// `file:<path>` AND in patterns as `pattern:file:<path>`, or a test surfaced as
+// both `file:<path>` and `test-file:<path>`. Path-bearing keys reduce to their
+// path; symbol/chunk/learning keys keep their own identity (a `pattern:class:X`
+// symbol view is NOT the same source as the file, so it survives separately).
+// Operates purely on logical DB keys (always forward-slash), so platform-agnostic.
+function sourceIdOf(key: string): string {
+  const pathMatch = key.match(/^(?:pattern:)?(?:file|test-file|dir):(.+)$/);
+  if (pathMatch) return `src:${pathMatch[1]}`;
+  return key.startsWith('pattern:') ? key.slice('pattern:'.length) : key;
+}
+
 function shapeRetrievedEntry(entry: MemoryEntryWithMeta): RetrievedEntry {
   let value: unknown = entry.content;
   try { value = JSON.parse(entry.content); } catch { /* keep string */ }
@@ -460,7 +474,7 @@ export const memoryTools: MCPTool[] = [
       properties: {
         query: { type: 'string', description: 'Search query (semantic similarity)' },
         namespace: { type: 'string', description: 'Namespace to search (default: all namespaces)' },
-        limit: { type: 'number', description: 'Maximum results (default: 5)' },
+        limit: { type: 'number', description: 'Maximum results (default: 8). Multiple representations of the same source (a file indexed in both code-map and patterns, a test surfaced as both file and test-file) are collapsed to one before this cap, so every slot is a distinct source.' },
         threshold: { type: 'number', description: 'Minimum similarity threshold 0-1 (default: 0.5)' },
         expand: {
           type: 'string',
@@ -476,16 +490,21 @@ export const memoryTools: MCPTool[] = [
 
       const query = input.query as string;
       const namespace = (input.namespace as string) || 'all';
-      // #1053 S6 / #1262 lever #1: tighter defaults — fewer hits, higher
-      // relevance bar. Each returned chunk is injected verbatim into context,
-      // so 5 confident hits beats 8 with marginal tail.
-      const limit = (input.limit as number) || 5;
+      // #1053 S6: injected-token bar. Each returned hit is injected verbatim,
+      // so keep the cap tight — but #1262 dedup (below) makes every one of these
+      // slots a DISTINCT source rather than 8 slots holding ~5 uniques + dupes.
+      const limit = (input.limit as number) || 8;
       // Falsiness check would coerce a caller-supplied 0 to default and silently
       // filter low-similarity matches; use a typeof guard so explicit zero
       // means "no threshold" (#837).
       const threshold = typeof input.threshold === 'number' ? input.threshold : 0.5;
       // #1262 lever #3: opt-in single-call neighbor expansion.
       const wantExpand = input.expand === 'neighbors' || input.expand === true;
+      // #1262 lever #1: over-fetch so dedup-by-source can still return a FULL
+      // `limit` distinct sources. Local HNSW makes the extra hits free (they're
+      // just not injected); 3x headroom clears the ~40% duplication observed in
+      // dogfooding. Capped so an explicit large limit can't blow up the fetch.
+      const overscan = Math.min(limit * 3, 50);
 
       validateMemoryInput(undefined, undefined, query);
 
@@ -493,12 +512,12 @@ export const memoryTools: MCPTool[] = [
         const result = await searchEntries({
           query,
           namespace,
-          limit,
+          limit: overscan,
           threshold,
         });
 
         // Parse JSON values in results
-        const results: SearchHit[] = result.results.map(r => {
+        const mapped: SearchHit[] = result.results.map(r => {
           let value: unknown = r.content;
           try {
             value = JSON.parse(r.content);
@@ -521,6 +540,20 @@ export const memoryTools: MCPTool[] = [
             navigation,
           };
         });
+
+        // #1262 lever #1: collapse duplicate representations of the same source,
+        // keeping the highest-scoring one (results arrive score-desc), then trim
+        // to `limit`. Net effect vs. the old code: `limit` DISTINCT sources
+        // instead of `limit` slots that were often ~40% near-duplicates.
+        const seenSources = new Set<string>();
+        const results: SearchHit[] = [];
+        for (const hit of mapped) {
+          const id = sourceIdOf(hit.key);
+          if (seenSources.has(id)) continue;
+          seenSources.add(id);
+          results.push(hit);
+          if (results.length >= limit) break;
+        }
 
         // #1262 lever #3: when asked, fetch each chunk hit's prev/next content
         // inline (one round-trip) so the model doesn't fall back to a full-doc

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -467,7 +467,7 @@ export const memoryTools: MCPTool[] = [
   },
   {
     name: 'memory_search',
-    description: 'Semantic vector search using HNSW index (150x-12,500x faster than keyword search). On chunk hits (non-null `navigation`), get adjacent context in THIS call via `expand: "neighbors"` — cheaper than a follow-up `Read` of the parent doc, and the preferred path over a separate `memory_get_neighbors` round-trip. See `.claude/guidance/moflo-memory-protocol.md`.',
+    description: 'Semantic vector search using HNSW index (150x-12,500x faster than keyword search). On chunk hits (non-null `navigation`) you MUST get adjacent context via chunk traversal, never a full-doc `Read`: prefer `expand: "neighbors"` in THIS call (cheapest — inlines prev/next), else `memory_get_neighbors`. Bulk `memory_retrieve` per hit is a protocol violation. See `.claude/guidance/moflo-memory-protocol.md`.',
     category: 'memory',
     inputSchema: {
       type: 'object',

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -136,6 +136,24 @@ interface RetrievedEntry {
   backend: string;
 }
 
+// #1262 lever #3: an adjacent chunk inlined into a search hit via expand.
+interface ExpandedNeighbor {
+  position: 'prev' | 'next';
+  key: string;
+  value: unknown;
+}
+
+// A single memory_search hit. `expanded` is populated only when the caller
+// passes expand:'neighbors'.
+interface SearchHit {
+  key: string;
+  namespace: string;
+  value: unknown;
+  similarity: number;
+  navigation: NavigationCompact | null;
+  expanded?: ExpandedNeighbor[];
+}
+
 function parseNavigation(metadataJson: string | undefined, mode: 'full'): NavigationFull | null;
 function parseNavigation(metadataJson: string | undefined, mode: 'compact'): NavigationCompact | null;
 function parseNavigation(
@@ -435,30 +453,39 @@ export const memoryTools: MCPTool[] = [
   },
   {
     name: 'memory_search',
-    description: 'Semantic vector search using HNSW index (150x-12,500x faster than keyword search). When a result has a non-null `navigation` crumb, you MUST traverse via `memory_get_neighbors` — bulk `memory_retrieve` per hit is a protocol violation. See `.claude/guidance/moflo-memory-protocol.md`.',
+    description: 'Semantic vector search using HNSW index (150x-12,500x faster than keyword search). On chunk hits (non-null `navigation`), get adjacent context in THIS call via `expand: "neighbors"` — cheaper than a follow-up `Read` of the parent doc, and the preferred path over a separate `memory_get_neighbors` round-trip. See `.claude/guidance/moflo-memory-protocol.md`.',
     category: 'memory',
     inputSchema: {
       type: 'object',
       properties: {
         query: { type: 'string', description: 'Search query (semantic similarity)' },
         namespace: { type: 'string', description: 'Namespace to search (default: all namespaces)' },
-        limit: { type: 'number', description: 'Maximum results (default: 8)' },
+        limit: { type: 'number', description: 'Maximum results (default: 5)' },
         threshold: { type: 'number', description: 'Minimum similarity threshold 0-1 (default: 0.5)' },
+        expand: {
+          type: 'string',
+          enum: ['neighbors'],
+          description: "Set to 'neighbors' to inline each chunk hit's adjacent (prev/next) chunk content in this single call. Use instead of a follow-up full-doc `Read` when you need surrounding context. Off by default to keep the envelope lean.",
+        },
       },
       required: ['query'],
     },
     handler: async (input) => {
       await ensureInitialized();
-      const { searchEntries } = await getMemoryFunctions();
+      const { searchEntries, getEntry } = await getMemoryFunctions();
 
       const query = input.query as string;
       const namespace = (input.namespace as string) || 'all';
-      // #1053 S6: tighter defaults — fewer hits, higher relevance bar.
-      const limit = (input.limit as number) || 8;
+      // #1053 S6 / #1262 lever #1: tighter defaults — fewer hits, higher
+      // relevance bar. Each returned chunk is injected verbatim into context,
+      // so 5 confident hits beats 8 with marginal tail.
+      const limit = (input.limit as number) || 5;
       // Falsiness check would coerce a caller-supplied 0 to default and silently
       // filter low-similarity matches; use a typeof guard so explicit zero
       // means "no threshold" (#837).
       const threshold = typeof input.threshold === 'number' ? input.threshold : 0.5;
+      // #1262 lever #3: opt-in single-call neighbor expansion.
+      const wantExpand = input.expand === 'neighbors' || input.expand === true;
 
       validateMemoryInput(undefined, undefined, query);
 
@@ -471,7 +498,7 @@ export const memoryTools: MCPTool[] = [
         });
 
         // Parse JSON values in results
-        const results = result.results.map(r => {
+        const results: SearchHit[] = result.results.map(r => {
           let value: unknown = r.content;
           try {
             value = JSON.parse(r.content);
@@ -495,7 +522,45 @@ export const memoryTools: MCPTool[] = [
           };
         });
 
+        // #1262 lever #3: when asked, fetch each chunk hit's prev/next content
+        // inline (one round-trip) so the model doesn't fall back to a full-doc
+        // `Read` for surrounding context. Opt-in keeps the default lean.
+        if (wantExpand) {
+          await Promise.all(
+            results.map(async hit => {
+              const nav = hit.navigation;
+              if (!nav) return; // non-chunk hit — nothing adjacent to fetch
+              const targets = [
+                { position: 'prev' as const, key: nav.prevChunk },
+                { position: 'next' as const, key: nav.nextChunk },
+              ].filter((t): t is { position: 'prev' | 'next'; key: string } => Boolean(t.key));
+              if (targets.length === 0) return;
+              const fetched = await Promise.all(
+                targets.map(async t => {
+                  const res = await getEntry({ key: t.key, namespace: hit.namespace });
+                  if (!res.found || !res.entry) return null;
+                  const entry = res.entry as MemoryEntryWithMeta;
+                  let value: unknown = entry.content;
+                  try { value = JSON.parse(entry.content); } catch { /* keep string */ }
+                  return { position: t.position, key: t.key, value };
+                }),
+              );
+              const neighbors = fetched.filter((n): n is ExpandedNeighbor => n !== null);
+              if (neighbors.length > 0) hit.expanded = neighbors;
+            }),
+          );
+        }
+
         notifyMemoryGate();
+
+        // #1262 lever #3: steer away from full-doc `Read` toward the cheap
+        // adjacent-context path — but only when it's actionable (chunk hits
+        // present and the caller didn't already expand), so the hint itself
+        // costs no tokens on the common case.
+        const nextStep =
+          !wantExpand && results.some(r => r.navigation)
+            ? "Chunk hits present. For adjacent context, re-call memory_search with expand:'neighbors' (one call) rather than Read-ing parentPath — full-doc Read costs far more tokens."
+            : undefined;
 
         // #1053 S6: searchTime dropped from MCP envelope (CLI keeps it for
         // human reading); `backend` retained — doctor reads it (#1053 epic).
@@ -503,6 +568,7 @@ export const memoryTools: MCPTool[] = [
           query,
           results,
           total: results.length,
+          ...(nextStep ? { nextStep } : {}),
           backend: BACKEND_LABEL,
         };
       } catch (error) {


### PR DESCRIPTION
## Summary

Implements #1262 — cutting the tokens `memory_search` injects into context on every memory-first turn, **without** weakening the memory-first gate. Search embeds locally and costs the API nothing; the cost is the result payload. Every change here was validated by dogfooding against our own live index before landing.

## Lever #1 — dedup-by-source (revised away from the issue's limit cut)

The issue floated lowering the default `limit` 8→5. **Dogfooding refuted that:**

- A dense query's top-8 is routinely **~40% duplicates** — the same file indexed in `code-map` as `file:<path>` *and* in `patterns` as `pattern:file:<path>`, or a test surfaced as both `file:` and `test-file:`.
- Truncating 8→5 **dropped genuinely-relevant, non-redundant hits** — e.g. `swarm-coordinator-singleton.ts` sat at rank 7 for a *"swarm coordinator"* query. There's no similarity cliff between rank 5 and rank 8: ranks 6–8 stayed ≥0.80 (the protocol's "confident" bar) across all six probe queries.

So instead of truncating: **over-fetch (`limit*3`), collapse same-source representations to the highest-scoring one, trim to `limit`.** Net effect — `limit` *distinct* sources instead of ~5 uniques + 3 dupes. A **coverage gain and a token cut at once**, strictly better than truncation.

Threshold left at **0.5** — raising to 0.75 would drop useful 0.60–0.79 hits and force costlier Glob/Grep/Read fallback.

## Lever #3 — opt-in `expand: 'neighbors'` + steer away from full-doc `Read`

New opt-in `expand: 'neighbors'` inlines each chunk hit's prev/next content in the **same** search call. Measured on real guidance docs, adjacent context this way costs **4–6× fewer tokens** than the full-doc `Read` the model otherwise falls back to:

| Parent doc | full `Read` | `expand` | ratio |
|---|---|---|---|
| moflo-cross-platform.md | ~1790 tok | ~298 tok | 6.0× |
| consumer-bound-references.md | ~1641 tok | ~410 tok | 4.0× |
| memory-patterns/SKILL.md | ~1346 tok | ~299 tok | 4.5× |

A conditional `nextStep` steer fires **only** on chunk hits when the caller didn't expand — zero token cost on the common case. `moflo-memory-protocol.md` updated to recommend `expand` as the cheapest adjacent-context path.

## Verification

- `tsc --noEmit -p .` — clean
- 31 memory-tool tests + 60 memory integration tests pass, incl. new:
  - `memory-tools-search-dedup.test.ts` — collapse + trim-after-dedup + symbol-view-stays-distinct
  - `memory-tools-search-expand.test.ts` — one-call inline of prev/next, steer fires only when actionable

## Cross-platform / consumer impact (Rule #1 + #2)

- Pure TS/markdown. Dedup operates on logical DB keys (always forward-slash) — no fs paths, shell-outs, EOL, or case-sensitivity concerns.
- Additive MCP surface: an on-current-version consumer sees **richer** (deduped) results and an opt-in `expand` param. No migration, no `.moflo/` state change. Takes effect after publish + reinstall + Claude Code restart (runtime layer).

Closes #1262 (levers #1 + #3; threshold lever consciously declined — see above).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_017cEtLQz4VEeJaAHzHPHtxK
