### PR TITLE
feat(epic): sync parent epic when a standalone story completes

### DIFF
--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -224,6 +224,14 @@ gh issue edit <issue-number> --remove-label "in-progress" --add-label "ready-for
 gh issue comment <issue-number> --body "PR created: <pr-url>"
 ```
 
+If the story body carries an `Epic: #<n>` back-reference (decomposition writes it — `./ticket.md`) **and** `--epic-branch` is not set, sync the parent epic — check this story's box off and close the epic if it was the last:
+
+```bash
+flo epic checkoff <epic-number> <story-number>
+```
+
+Idempotent and safe to skip when there is no back-reference. `--epic-branch` runs skip it — the epic orchestrator owns checklist state there. The box flips when the work is delivered (PR opened), matching the orchestrator; if a PR is later rejected, reopen the epic manually.
+
 ### 5.5 Finalize run record (Flo Runs dashboard)
 
 Update the tasklist row written in Phase 0 with the terminal status. Same `runId`, `upsert: true`. On success:

--- a/.claude/skills/fl/ticket.md
+++ b/.claude/skills/fl/ticket.md
@@ -35,25 +35,47 @@ When promoting to epic:
 2. Each story should be completable in a single PR.
 3. Stories should have clear boundaries (one concern per story).
 4. Order stories by dependency (independent ones first).
-5. Create each story as a GitHub issue with its own Description, Acceptance Criteria, and Test Cases.
-6. Convert the parent issue into an epic with a `## Stories` checklist.
+5. Establish the epic issue **first** so its number exists before the stories do (either the promoted parent issue or a freshly created epic).
+6. Create each story as a GitHub issue with its own Description, Acceptance Criteria, Test Cases, **and an `Epic: #<epic-number>` back-reference line at the top of the body**.
+7. Fill in the epic's `## Stories` checklist with a `- [ ] #<story-number>` line for every story.
+
+The **back-reference is load-bearing**, not decoration: a story is usually worked on later via a standalone `/flo <story>` run, not through `flo epic run`. That standalone run reads the `Epic: #<n>` line to find its parent, check its box off, and close the epic when it is the last story. Without the back-reference the epic silently drifts out of sync — the exact miss this step exists to prevent. See `./phases.md` Phase 5.6.
 
 ## Epic decomposition (score >= 7)
 
+The order matters: the epic must exist before the stories so each story can carry the `Epic: #<n>` back-reference, and the epic's checklist is filled in last.
+
+Pass multi-line bodies as a single literal `--body "..."` string (portable — no `printf`/heredoc, which are not guaranteed on every consumer OS; Rule #1). For very large bodies write the text to a file with the Write tool and use `--body-file <path>`.
+
 ```bash
-# Step 1: create each sub-issue
-gh issue create --title "Story: <story-title>" --body "<## Description + ## Acceptance Criteria + ## Suggested Test Cases>" --label "story"
-# capture the new issue number from output
+# Step 1: establish the epic issue and capture its number (EPIC).
+#   Promoting an existing issue — it *is* the epic; add the label now:
+gh issue edit <parent-number> --add-label "epic"            # EPIC = <parent-number>
+#   Or create a fresh epic with an empty Stories section:
+gh issue create --title "Epic: <title>" --label "epic" --body "<## Overview + empty ## Stories section>"
+# capture EPIC = the epic issue number from whichever path above
 
-# Step 2: repeat for all stories (typically 2–6)
+# Step 2: create each story WITH the Epic back-reference as the first line; capture each number.
+#   (repeat for all stories, typically 2–6)
+gh issue create --title "Story: <story-title>" --label "story" --body "<Epic: #<EPIC> + ## Description + ## Acceptance Criteria + ## Suggested Test Cases>"
 
-# Step 3: build the epic body with a checklist referencing every story number
+# Step 3: fill the epic's ## Stories checklist with a - [ ] #<story> line per story.
+gh issue edit <EPIC> --body "<epic body with the ## Stories checklist filled in>"
+```
 
-# Step 4: update an existing issue into an epic
-gh issue edit <parent-number> --add-label "epic" --body "<epic body with ## Stories checklist>"
+**Story body format** — the first line is the back-reference; the standalone `/flo <story>` run (`./phases.md` Phase 5.6) parses `Epic: #<n>` from it:
 
-# Step 5: or create a new epic
-gh issue create --title "Epic: <title>" --label "epic" --body "<epic body>"
+```markdown
+Epic: #<epic-number>
+
+## Description
+<what and why>
+
+## Acceptance Criteria
+- [ ] ...
+
+## Suggested Test Cases
+- ...
 ```
 
 **Epic body format** — the `## Stories` checklist with `- [ ] #<number>` is what enables epic detection, story extraction, and progress tracking:

--- a/src/cli/commands/epic.ts
+++ b/src/cli/commands/epic.ts
@@ -12,6 +12,7 @@
  *   flo epic run 42 --verbose                Echo each step's stdout/stderr after it completes
  *   flo epic status <epic-number>            Check progress via memory
  *   flo epic reset <epic-number>             Clear epic memory state
+ *   flo epic checkoff <epic> <story>         Check a story off; close the epic if it was the last
  */
 
 import { readFileSync } from 'node:fs';
@@ -23,6 +24,7 @@ import {
   fetchEpicIssue,
   extractStories,
   enrichStoryNames,
+  checkOffStoryInEpic,
 } from '../epic/index.js';
 import type { EpicStrategy } from '../epic/types.js';
 import {
@@ -430,6 +432,38 @@ async function resetEpic(epicNumber: string): Promise<CommandResult> {
 }
 
 // ============================================================================
+// Subcommand: checkoff
+// ============================================================================
+
+async function checkOffStory(epicArg: string, storyArg: string): Promise<CommandResult> {
+  const epic = parseInt(epicArg, 10);
+  const story = parseInt(storyArg, 10);
+  if (isNaN(epic) || isNaN(story)) {
+    return { success: false, message: 'Usage: flo epic checkoff <epic-number> <story-number>' };
+  }
+
+  try {
+    const { checked, epicClosed, alreadyClosed } = await checkOffStoryInEpic(epic, story);
+    const parts: string[] = [];
+    parts.push(
+      checked
+        ? `Checked off story #${story} in epic #${epic}.`
+        : `Story #${story} was already checked (or not listed) in epic #${epic}.`,
+    );
+    if (epicClosed) parts.push(`All stories complete — closed epic #${epic}.`);
+    else if (alreadyClosed) parts.push(`Epic #${epic} was already closed.`);
+    const message = parts.join(' ');
+    console.log(`[epic] ${message}`);
+    return { success: true, message };
+  } catch (err) {
+    return {
+      success: false,
+      message: buildFailureSummary((err as Error).message, { stepId: 'checkoff' }),
+    };
+  }
+}
+
+// ============================================================================
 // Preflight warning interactive resolver
 // ============================================================================
 
@@ -541,6 +575,7 @@ const epicCommand: Command = {
     { command: 'flo epic run 42', description: 'Explicit run subcommand (same as above)' },
     { command: 'flo epic status 42', description: 'Check epic progress' },
     { command: 'flo epic reset 42', description: 'Reset epic state for re-run' },
+    { command: 'flo epic checkoff 42 43', description: 'Check story #43 off in epic #42; close #42 if it was the last story' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const subcommand = ctx.args?.[0];
@@ -550,10 +585,11 @@ const epicCommand: Command = {
       console.log('       flo epic <command> [args] [flags]');
       console.log('');
       console.log('Commands:');
-      console.log('  <issue-number>           Execute epic (shorthand for "run")');
-      console.log('  run <issue-number>       Execute a GitHub epic via spell engine');
-      console.log('  status <epic-number>     Check epic progress');
-      console.log('  reset <epic-number>      Reset epic state for re-run');
+      console.log('  <issue-number>              Execute epic (shorthand for "run")');
+      console.log('  run <issue-number>          Execute a GitHub epic via spell engine');
+      console.log('  status <epic-number>        Check epic progress');
+      console.log('  reset <epic-number>         Reset epic state for re-run');
+      console.log('  checkoff <epic> <story>     Check a story off in its epic; close the epic if it was the last');
       console.log('');
       console.log('Flags:');
       console.log('  --strategy <name>        single-branch (default) or auto-merge');
@@ -604,8 +640,11 @@ const epicCommand: Command = {
       case 'reset':
         return resetEpic(commandArgs[0] || '');
 
+      case 'checkoff':
+        return checkOffStory(commandArgs[0] || '', commandArgs[1] || '');
+
       default:
-        return { success: false, message: `Unknown subcommand: ${subcommand}. Available: run, status, reset` };
+        return { success: false, message: `Unknown subcommand: ${subcommand}. Available: run, status, reset, checkoff` };
     }
   },
 };

--- a/src/cli/epic/detection.ts
+++ b/src/cli/epic/detection.ts
@@ -7,7 +7,7 @@
  * Story #195: Shared epic detection & extraction module.
  */
 
-import { exec } from 'node:child_process';
+import { exec, spawnSync } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { GitHubIssue, StoryDefinition } from './types.js';
 
@@ -160,4 +160,90 @@ export async function findPrForIssue(
   } catch {
     return null;
   }
+}
+
+// ============================================================================
+// Story checkoff (standalone `/flo <story>` runs)
+// ============================================================================
+
+/**
+ * Pure core of the story-checkoff operation — no I/O, unit-testable.
+ *
+ * Flips a story's `- [ ] #<n>` checkbox to `- [x] #<n>` in an epic body and
+ * reports whether the epic is now complete (it has story checkboxes and none
+ * remain unchecked). Word-boundary guarded so #12 never matches inside #123.
+ */
+export function computeEpicCheckoff(
+  body: string,
+  storyNumber: number,
+): { updated: string; checked: boolean; allComplete: boolean } {
+  const pattern = new RegExp(`- \\[ \\] #${storyNumber}(?!\\d)`);
+  const updated = body.replace(pattern, `- [x] #${storyNumber}`);
+  const checked = updated !== body;
+
+  const hasStoryCheckboxes = /- \[[ x]\] #\d+/.test(updated);
+  const hasUnchecked = /- \[ \] #\d+/.test(updated);
+  const allComplete = hasStoryCheckboxes && !hasUnchecked;
+
+  return { updated, checked, allComplete };
+}
+
+export interface CheckOffResult {
+  /** The story's box was flipped (false if already checked or not listed). */
+  readonly checked: boolean;
+  /** The epic was closed because this was the last unchecked story. */
+  readonly epicClosed: boolean;
+  /** The epic was already closed before this call. */
+  readonly alreadyClosed: boolean;
+}
+
+/**
+ * Check a story off in its parent epic's checklist, and close the epic when no
+ * unchecked stories remain. Used by standalone `/flo <story>` runs via
+ * `flo epic checkoff`; the orchestrated `flo epic run` path does its own
+ * checkoff inside the spell (epic-single-branch.yaml).
+ *
+ * Cross-platform (Rule #1): drives `gh` through `spawnSync` arg arrays (no
+ * shell string to escape) and pipes the rewritten body over stdin
+ * (`--body-file -`), the same pattern proven on Windows CI in the spell.
+ */
+export async function checkOffStoryInEpic(
+  epicNumber: number,
+  storyNumber: number,
+): Promise<CheckOffResult> {
+  const issue = await fetchEpicIssue(epicNumber);
+  const { updated, checked, allComplete } = computeEpicCheckoff(issue.body || '', storyNumber);
+
+  if (checked) {
+    const edit = spawnSync('gh', ['issue', 'edit', String(epicNumber), '--body-file', '-'], {
+      input: updated,
+      encoding: 'utf8',
+    });
+    if (edit.status !== 0) {
+      throw new Error(
+        `gh issue edit failed: ${(edit.stderr || edit.error?.message || 'unknown').toString().trim()}`,
+      );
+    }
+  }
+
+  const alreadyClosed = issue.state.toUpperCase() === 'CLOSED';
+  const epicClosed = allComplete && !alreadyClosed;
+  if (epicClosed) {
+    const close = spawnSync(
+      'gh',
+      [
+        'issue', 'close', String(epicNumber),
+        '--reason', 'completed',
+        '--comment', `All stories complete — closed automatically after story #${storyNumber}.`,
+      ],
+      { encoding: 'utf8' },
+    );
+    if (close.status !== 0) {
+      throw new Error(
+        `gh issue close failed: ${(close.stderr || close.error?.message || 'unknown').toString().trim()}`,
+      );
+    }
+  }
+
+  return { checked, epicClosed, alreadyClosed };
 }

--- a/src/cli/epic/index.ts
+++ b/src/cli/epic/index.ts
@@ -10,6 +10,8 @@ export type {
   EpicStrategy,
 } from './types.js';
 
+export type { CheckOffResult } from './detection.js';
+
 export {
   isEpicIssue,
   extractStories,
@@ -17,4 +19,6 @@ export {
   fetchEpicIssue,
   enrichStoryNames,
   findPrForIssue,
+  computeEpicCheckoff,
+  checkOffStoryInEpic,
 } from './detection.js';

--- a/tests/epic-command.test.ts
+++ b/tests/epic-command.test.ts
@@ -88,6 +88,33 @@ describe('epic command structure', () => {
     expect(examples).toContainEqual(expect.stringContaining('--no-merge'));
     expect(examples).toContainEqual(expect.stringContaining('--verbose'));
   });
+
+  it('rejects checkoff with non-numeric args before touching gh', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = await epicCommand.action({ args: ['checkoff', 'abc', 'def'], flags: {} });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Usage: flo epic checkoff');
+    logSpy.mockRestore();
+  });
+
+  it('rejects checkoff missing the story argument', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = await epicCommand.action({ args: ['checkoff', '42'], flags: {} });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('Usage: flo epic checkoff');
+    logSpy.mockRestore();
+  });
+
+  it('lists the checkoff subcommand in help and examples', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = await epicCommand.action({ args: [], flags: {} });
+    expect(result.success).toBe(true);
+    const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('checkoff');
+    logSpy.mockRestore();
+    const examples = epicCommand.examples.map((e: any) => e.command);
+    expect(examples).toContainEqual(expect.stringContaining('checkoff'));
+  });
 });
 
 describe('makeEpicBranchName', () => {

--- a/tests/epic-detection.test.ts
+++ b/tests/epic-detection.test.ts
@@ -9,6 +9,7 @@ import {
   isEpicIssue,
   extractStories,
   extractUncheckedStories,
+  computeEpicCheckoff,
 } from '../src/cli/epic/detection.js';
 import type { GitHubIssue } from '../src/cli/epic/types.js';
 
@@ -142,5 +143,63 @@ describe('extractUncheckedStories', () => {
   it('returns empty for all checked', () => {
     const issue = makeIssue({ body: '- [x] #1\n- [x] #2' });
     expect(extractUncheckedStories(issue)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// computeEpicCheckoff (pure core of `flo epic checkoff`)
+// ============================================================================
+
+describe('computeEpicCheckoff', () => {
+  const epicBody = '## Stories\n\n- [ ] #101 — First\n- [ ] #102 — Second\n- [ ] #103 — Third';
+
+  it('flips the targeted story box and reports it checked', () => {
+    const { updated, checked } = computeEpicCheckoff(epicBody, 102);
+    expect(checked).toBe(true);
+    expect(updated).toContain('- [x] #102 — Second');
+    expect(updated).toContain('- [ ] #101 — First');
+    expect(updated).toContain('- [ ] #103 — Third');
+  });
+
+  it('does not mark complete while other stories remain unchecked', () => {
+    expect(computeEpicCheckoff(epicBody, 102).allComplete).toBe(false);
+  });
+
+  it('marks complete when the last unchecked story is flipped', () => {
+    const body = '- [x] #101\n- [x] #102\n- [ ] #103';
+    const { checked, allComplete } = computeEpicCheckoff(body, 103);
+    expect(checked).toBe(true);
+    expect(allComplete).toBe(true);
+  });
+
+  it('is idempotent — an already-checked story is not re-flipped', () => {
+    const body = '- [x] #101\n- [ ] #102';
+    const { updated, checked, allComplete } = computeEpicCheckoff(body, 101);
+    expect(checked).toBe(false);
+    expect(updated).toBe(body);
+    expect(allComplete).toBe(false); // #102 still open
+  });
+
+  it('respects word boundaries — #12 does not match #123', () => {
+    const body = '- [ ] #12\n- [ ] #123';
+    const { updated } = computeEpicCheckoff(body, 12);
+    expect(updated).toContain('- [x] #12\n');
+    expect(updated).toContain('- [ ] #123');
+  });
+
+  it('does not treat a checkbox-less epic as complete (no false close)', () => {
+    // Bare `## Stories` refs, no `- [ ]` boxes — flipping nothing must not
+    // report allComplete, or the CLI would close an epic with open work.
+    const body = '## Stories\nWe still need #5 and #6.';
+    const { checked, allComplete } = computeEpicCheckoff(body, 5);
+    expect(checked).toBe(false);
+    expect(allComplete).toBe(false);
+  });
+
+  it('reports complete when the target story is already the only checked box left', () => {
+    const body = '- [x] #101\n- [x] #102';
+    const { checked, allComplete } = computeEpicCheckoff(body, 101);
+    expect(checked).toBe(false); // already checked
+    expect(allComplete).toBe(true); // nothing unchecked remains
   });
 });


### PR DESCRIPTION
## Summary

Standalone `/flo <story>` runs left the parent epic out of sync — the story shipped but its checklist box was never ticked and the epic never closed when the last story landed. Only the orchestrated `flo epic run` path handled checkoff.

## Changes
- **ticket.md** — epic decomposition establishes the epic first and writes an `Epic: #<n>` back-reference into each story body (the pointer a later standalone run reads to find its parent).
- **phases.md** — Phase 5.4 calls `flo epic checkoff <epic> <story>`, gated on the back-reference existing and `--epic-branch` not being set. One line — keeps the hot-path skill compact.
- **detection.ts** — `computeEpicCheckoff()` (pure, unit-tested core) + `checkOffStoryInEpic()` which flips the box and closes the epic when no unchecked story remains. Drives `gh` via `spawnSync` arg-arrays and pipes the body over stdin (`--body-file -`) — cross-platform (Rule #1), the pattern proven on Windows CI in the spell.
- **epic.ts** — new `flo epic checkoff <epic> <story>` subcommand (help + examples).

## Testing
- [x] Unit tests: +59 in epic-detection (flip, word-boundary #12≠#123, idempotency, last-story-complete, no-false-close on checkbox-less epics), +27 in epic-command (arg validation, help). 113 related tests pass.
- [x] Build clean.
- [x] Live end-to-end against the test epic: partial checkoff → epic stays OPEN; last story → box flipped + epic auto-CLOSED. Fixture restored afterward.

## Consumer impact
Runtime code — takes effect for consumers on next publish + reinstall. Additive: new subcommand + two skill edits; no change to existing `flo epic run` behavior or the protected swarm/hive surface.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_017JE7G2bhb7vR6YJT4Lsseb