### PR TITLE
feat(workflow): add ENGINE_VERSION constant to runner (#285)

### DIFF
--- a/src/cli/__tests__/spells/engine-version.test.ts
+++ b/src/cli/__tests__/spells/engine-version.test.ts
@@ -1,0 +1,14 @@
+/**
+ * Story #285 (epic #287) — verify the ENGINE_VERSION constant.
+ * Trivial workflow-test story exercising the /flo --sdd flow end-to-end.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ENGINE_VERSION } from '../../spells/core/runner.js';
+
+describe('ENGINE_VERSION (#285)', () => {
+  it('is exported and equals the string "1.0.0"', () => {
+    expect(ENGINE_VERSION).toBe('1.0.0');
+    expect(typeof ENGINE_VERSION).toBe('string');
+  });
+});

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -51,6 +51,9 @@ import {
 import { checkAcceptance, recordAcceptance } from './permission-acceptance.js';
 import { analyzeSpellPermissions, formatSpellPermissionReport } from './permission-disclosure.js';
 
+/** Spell engine version. Story #285 (epic #287) — workflow-test constant. */
+export const ENGINE_VERSION = '1.0.0';
+
 export class SpellCaster {
   private readonly connectorAccessor?: ConnectorAccessorImpl;
 


### PR DESCRIPTION
## Summary
Story #285 (epic #287) — trivial workflow-test constant, driven **end-to-end through the real `/flo --sdd` flow**: spec → review → plan → review → implement-checkpoint → implement → test → verify.

This is a live dogfood run of the SDD feature from PR #1277 against a real ticket.

## Changes
- `src/cli/spells/core/runner.ts` — export `ENGINE_VERSION = '1.0.0'`
- `src/cli/__tests__/spells/engine-version.test.ts` — asserts both acceptance criteria

## SDD artifacts
Authored at `.moflo/specs/add-engine-version-constant-to-workflow-runner/{spec,plan}.md` (gitignored in this repo; git-tracked in a consumer project). Both reviewed; implement checkpoint passed.

## Verify-before-done
Verified against the plan's acceptance criteria (outcome stored to memory `verify:285-engine-version`):
- [x] `ENGINE_VERSION` exported from `src/cli/spells/core/runner.ts`
- [x] value is the string `'1.0.0'`
- [x] test passes

## Note
Reviewer flagged `mcp-client.ts:179` also hardcodes `'1.0.0'` for the same concept — out of scope for this trivial story; noted for future runtime wiring.

Closes #285

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)