### PR TITLE
fix(deps): pin adm-zip >=0.6.0 to clear npm audit high advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,12 +1656,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
   "overrides": {
     "hono": ">=4.12.25",
     "picomatch": ">=2.3.2",
-    "protobufjs": ">=7.5.5"
+    "protobufjs": ">=7.5.5",
+    "adm-zip": ">=0.6.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",


### PR DESCRIPTION
Closes #1282.

## Problem
The required **Lint & Security** check (`npm audit --omit=dev --audit-level=high`) fails on **every** PR — a repo-wide broken window, not tied to any feature branch. `onnxruntime-node@1.27.0` pins `adm-zip@^0.5.16` → resolves `0.5.17`, vulnerable to GHSA-xcpc-8h2w-3j85 (crafted ZIP → 4GB alloc, high). Surfaced while trying to merge #1280.

## Why not bump onnxruntime-node
We're already on the latest (1.27.0), and it — plus every recent version — still declares `adm-zip: ^0.5.16`. No newer onnxruntime pulls a fixed adm-zip; npm's only "fix" is a **downgrade** to 1.21.1 (breaking). So bumping up doesn't resolve it.

## Fix
Pin `adm-zip >=0.6.0` via npm `overrides` — the established pattern here (hono/picomatch/protobufjs are all security pins). Non-breaking: onnxruntime-node uses adm-zip **only** in `script/install-utils.js` (install-time binary extraction), never at runtime; 0.6.0 needs node>=14 (we require >=22).

## Consumer surface (Rule #2)
`overrides` only affects moflo's **own** dependency resolution during its build/publish — it does not propagate into consumer installs of `moflo`. Zero consumer blast radius; unblocks CI.

## Verification
- `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities** (was 2 high)
- onnxruntime-node loads; a 384-dim embedding generates (~387ms)
- embeddings test suite: **185 passed**
- only `package.json` + `package-lock.json` changed

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)