### PR TITLE
fix: preserve CRLF outside marker block in claudemd-injection replace path (#1281)

### DIFF
--- a/src/cli/__tests__/services/claudemd-injection.test.ts
+++ b/src/cli/__tests__/services/claudemd-injection.test.ts
@@ -81,6 +81,16 @@ describe('extractInjectedBlock', () => {
     expect(result).not.toBeNull();
     expect(result!.markerIndex).toBe(0);
   });
+
+  it('returns raw-byte offsets valid against the original CRLF string (#1281)', () => {
+    const crlfBlock = CANONICAL_BLOCK.replace(/\n/g, '\r\n');
+    const file = `# Project\r\n\r\n${crlfBlock}\r\nTrailing.`;
+    const result = extractInjectedBlock(file)!;
+    // start/end index the ORIGINAL bytes: slicing them back out yields the raw
+    // CRLF block verbatim, while .block is its LF-normalised form for compare.
+    expect(file.substring(result.start, result.end)).toBe(crlfBlock);
+    expect(result.block).toBe(CANONICAL_BLOCK);
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -221,6 +231,66 @@ describe('applyInjectionReplacement', () => {
     const second = applyInjectionReplacement(first.contents, CANONICAL);
     expect(second.changed).toBe(false);
     expect(second.contents).toBe(first.contents);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// applyInjectionReplacement — CRLF preservation (#1281)
+//
+// The replace path must splice against the original bytes so a Windows
+// consumer's CRLF line endings OUTSIDE the marker block survive a drift/legacy
+// refresh. Only the canonical block itself is (re)written with LF.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('applyInjectionReplacement — CRLF preservation (#1281)', () => {
+  const staleBlock = `${MARKER_START}\nstale guidance with shipped/ refs\n${MARKER_END}`;
+
+  it('preserves CRLF outside the block when replacing a drifted block', () => {
+    const lf = `# Project\n\nUser line one.\nUser line two.\n\n${staleBlock}\n\n## My Section\n\nLocal content.\n`;
+    const crlf = lf.replace(/\n/g, '\r\n');
+
+    const result = applyInjectionReplacement(crlf, CANONICAL);
+    expect(result.changed).toBe(true);
+
+    // Surrounding user content keeps its CRLF — no wholesale flattening.
+    expect(result.contents).toContain('User line one.\r\nUser line two.');
+    expect(result.contents).toContain('## My Section\r\n');
+    expect(result.contents).toContain('Local content.\r\n');
+    // The canonical block is spliced in with LF (as the generator emits it).
+    expect(result.contents).toContain(CANONICAL_BLOCK);
+    expect(result.contents).not.toContain('stale guidance with shipped/ refs');
+    // Re-running settles to in-sync (offsets + normalised compare agree).
+    expect(computeInjectionDrift(result.contents, CANONICAL).state).toBe('in-sync');
+  });
+
+  it('preserves CRLF outside the block when replacing a legacy block', () => {
+    const legacyBlock = `${LEGACY_MARKER_STARTS[0]}\nold stuff\n${LEGACY_MARKER_ENDS[0]}`;
+    const lf = `# Project\n\nKeep me.\n\n${legacyBlock}\n\n## After\n\nAlso keep.\n`;
+    const crlf = lf.replace(/\n/g, '\r\n');
+
+    const result = applyInjectionReplacement(crlf, CANONICAL);
+    expect(result.changed).toBe(true);
+    expect(result.contents).toContain('Keep me.\r\n');
+    expect(result.contents).toContain('## After\r\n');
+    expect(result.contents).toContain('Also keep.\r\n');
+    expect(result.contents).not.toContain(LEGACY_MARKER_STARTS[0]);
+    expect(result.contents).toContain(CANONICAL_BLOCK);
+    expect(computeInjectionDrift(result.contents, CANONICAL).state).toBe('in-sync');
+  });
+
+  it('leaves an all-LF file with no CR bytes (no regression)', () => {
+    const lf = `# Project\n\n${staleBlock}\n\n## Section\n\nContent.\n`;
+    const result = applyInjectionReplacement(lf, CANONICAL);
+    expect(result.changed).toBe(true);
+    expect(result.contents!.includes('\r')).toBe(false);
+    expect(computeInjectionDrift(result.contents, CANONICAL).state).toBe('in-sync');
+  });
+
+  it('is a no-op on an in-sync CRLF file (does not flatten)', () => {
+    const crlf = `# Project\r\n\r\n${CANONICAL_BLOCK.replace(/\n/g, '\r\n')}\r\n\r\n## Notes\r\nKeep.\r\n`;
+    const result = applyInjectionReplacement(crlf, CANONICAL);
+    expect(result.changed).toBe(false);
+    expect(result.contents).toBe(crlf); // byte-identical — CRLF untouched
   });
 });
 

--- a/src/cli/services/claudemd-injection.ts
+++ b/src/cli/services/claudemd-injection.ts
@@ -69,14 +69,22 @@ export interface InjectionReplacementResult {
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Locate the MoFlo-injected block in `claudeMdContents`, normalising line
- * endings so a CRLF file matches an LF canonical block (Windows consumers
- * regularly hit this — git autocrlf can flip the source bytes on checkout).
+ * Locate the MoFlo-injected block in `claudeMdContents`.
+ *
+ * `start`/`end` are offsets into the **raw** `claudeMdContents` (not a
+ * CRLF-normalised view), so callers can splice against the original bytes and
+ * preserve line endings outside the marker block (#1281). The markers are
+ * CR-free ASCII, so `indexOf` locates them at identical positions in the raw
+ * and normalised views — but only the raw offsets are valid substring bounds
+ * for the untouched original string.
+ *
+ * `block` IS CRLF-normalised, so a byte-for-byte compare against the LF
+ * canonical block works even on a CRLF checkout (Windows consumers regularly
+ * hit this — git autocrlf can flip the source bytes on checkout).
  *
  * Returns null when `contents` is null/undefined/empty, or when no marker
- * pair is found. Includes the marker strings themselves in the extracted
- * block, matching `MARKER_START…MARKER_END` exactly so a byte-for-byte
- * compare against the canonical block works.
+ * pair is found. `block` includes the marker strings themselves, matching
+ * `MARKER_START…MARKER_END` exactly.
  */
 export function extractInjectedBlock(claudeMdContents: string | null | undefined): {
   block: string;
@@ -85,7 +93,6 @@ export function extractInjectedBlock(claudeMdContents: string | null | undefined
   markerIndex: number;
 } | null {
   if (!claudeMdContents) return null;
-  const normalised = claudeMdContents.replace(/\r\n/g, '\n');
 
   // Try the current marker pair first, then each legacy pair. markerIndex:
   //   0  → current MARKER_START/MARKER_END
@@ -94,13 +101,18 @@ export function extractInjectedBlock(claudeMdContents: string | null | undefined
   const ends: readonly string[] = [MARKER_END, ...LEGACY_MARKER_ENDS];
 
   for (let i = 0; i < starts.length; i++) {
-    const startIdx = normalised.indexOf(starts[i]);
+    // Search the RAW string: markers are CR-free, so this matches the
+    // normalised view's positions, but yields offsets valid against the
+    // original bytes for splicing.
+    const startIdx = claudeMdContents.indexOf(starts[i]);
     if (startIdx < 0) continue;
-    const endIdx = normalised.indexOf(ends[i], startIdx + starts[i].length);
+    const endIdx = claudeMdContents.indexOf(ends[i], startIdx + starts[i].length);
     if (endIdx <= startIdx) continue;
     const endInclusive = endIdx + ends[i].length;
     return {
-      block: normalised.substring(startIdx, endInclusive),
+      // Normalise only the extracted block for drift comparison; start/end
+      // remain raw-byte offsets.
+      block: claudeMdContents.substring(startIdx, endInclusive).replace(/\r\n/g, '\n'),
       start: startIdx,
       end: endInclusive,
       markerIndex: i,
@@ -197,11 +209,12 @@ export function applyInjectionReplacement(
     return { contents: claudeMdContents, changed: false, state: 'in-sync' };
   }
 
-  // Operate on the line-ending-normalised view so the byte offsets we record
-  // line up with the actual replacement window. The output keeps LF endings
-  // — the launcher and setup-project both write LF.
-  const normalised = claudeMdContents.replace(/\r\n/g, '\n');
-  const next = normalised.substring(0, extracted.start) + want + normalised.substring(extracted.end);
+  // Splice against the ORIGINAL bytes (extracted.start/end are raw-byte
+  // offsets), so line endings OUTSIDE the marker block are preserved — a CRLF
+  // consumer's surrounding content keeps its CRLF (#1281). Only the canonical
+  // block itself is (re)written with LF, matching what the generator emits.
+  const next =
+    claudeMdContents.substring(0, extracted.start) + want + claudeMdContents.substring(extracted.end);
   return { contents: next, changed: true, state: 'in-sync' };
 }
 


### PR DESCRIPTION
## Summary

Fixes #1281. The drifted/legacy **replace** branch of `applyInjectionReplacement` (`src/cli/services/claudemd-injection.ts`) normalised `CRLF→LF` across the **entire file** before splicing the canonical MoFlo block:

```ts
const normalised = claudeMdContents.replace(/\r\n/g, '\n');
const next = normalised.substring(0, extracted.start) + want + normalised.substring(extracted.end);
```

On a Windows / `core.autocrlf` checkout, refreshing only the stale MoFlo block silently rewrote **all** of the consumer's `CLAUDE.md` line endings to LF — including content **outside** the markers. That contradicts the module's "user content outside the markers is preserved" contract and trips cross-platform **Rule #1 item 4** (line endings).

`claudemd-injection.ts` is zero-import and dynamically loaded by the session-start launcher in **every** consumer, so the change is scoped to its own PR with focused tests.

## Fix

Splice against the **original** bytes, not the normalised view:

- `extractInjectedBlock` now locates markers via `indexOf` on the **raw** string and returns `start`/`end` as offsets into the original bytes. Markers are CR-free ASCII, so they index identically in raw vs normalised views — only the raw offsets are valid substring bounds for the untouched string.
- `.block` stays CRLF-normalised, so drift comparison against the LF canonical block is unchanged.
- The replace path splices `raw.substring(0,start) + want + raw.substring(end)` — EOLs outside the block survive; only the canonical block is written LF (matching what the generator emits).

The `no-marker` append and `no-file` paths were already correct (they never normalised existing content) — only the replace path had the flatten.

## Acceptance criteria

- [x] `applyInjectionReplacement` preserves byte content (incl. CRLF) outside the marker block when replacing a drifted/legacy block
- [x] Regression test: a CRLF `CLAUDE.md` with surrounding user content keeps its CRLF after a drift refresh
- [x] No behaviour change for all-LF files

## Testing

- `claudemd-injection.test.ts` — 27 tests pass, incl. new CRLF-preservation cases (drifted, legacy, all-LF-no-CR, in-sync CRLF byte-identical no-op) + a raw-offset-semantics assertion on `extractInjectedBlock`
- Full injection-related suite (77 tests across 16 files) green
- `tsc --noEmit` clean
- SMALL-tier `/flo-simplify` reviewer pass: no issues (confirmed only in-file caller `computeInjectionDrift` uses `.block`/`.markerIndex`, never the offsets)

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)