### PR TITLE
feat(flo): add --merge/-m to auto-merge the PR once preconditions are met (#1285)

### DIFF
--- a/.claude/skills/fl/SKILL.md
+++ b/.claude/skills/fl/SKILL.md
@@ -54,6 +54,15 @@ Two **independent** modifiers, orthogonal to execution mode (`-n`/`-s`/`-h`) and
 
 Defaults seed from `moflo.yaml` — `sdd.default` and `gates.verify_before_done` — so a project can make either the default; per-run flags override. `--sdd` implies `--verify` (a spec/plan without an enforced verify step drifts). In `-t`/`-r` modes (no implementation) `--verify` is a no-op — emit the one-line ignored note; `--sdd` in `-t` writes the spec/plan **into the ticket** rather than scaffolding artifacts. Full mechanics in `./sdd.md`.
 
+## Auto-merge (#1285)
+
+| Flag | Long | Effect |
+|------|------|--------|
+| `-m` | `--merge` | After the PR is opened, **await its merge preconditions and merge it** (Phase 5.3b) instead of stopping at "PR opened". |
+| `--no-merge` | | Opt a single run out when `moflo.yaml merge.auto: true` turned it on. |
+
+Default seeds from `moflo.yaml merge.auto` (absent ⇒ `false`); the per-run flag overrides. Auto-merge is **orthogonal** to exec mode (`-n`/`-s`/`-h`), `--worktree`, and `--sdd`/`--verify`, and happens strictly **after** the existing gates (tests, simplify, learnings, verify) have let `gh pr create` through — so `--merge` never bypasses a quality gate. It is a documented no-op in `-t`/`-r` (no PR) and under `--epic-branch` (the epic orchestrator owns merging). Merge mechanics — native `--auto` first, poll-then-merge fallback, admin-override caveat — live in `./phases.md` Phase 5.3b.
+
 ## Epic detection
 
 An issue is processed as an epic when any of these hold:
@@ -114,6 +123,12 @@ let titleWords = [];
 let sddMode = false;          // -sd / --sdd  (full spec→plan→implement→verify)
 let verifyMode = false;       // -v  / --verify (verify-before-done only)
 
+// Auto-merge modifier (#1285). Seed from moflo.yaml BEFORE parsing, same as
+// sddMode/verifyMode: read `merge.auto` at the project root (absent ⇒ false).
+// When true, a full run awaits the PR's merge preconditions and merges it
+// (Phase 5.3b) instead of stopping at "PR opened".
+let mergeMode = false;        // -m / --merge  ← moflo.yaml merge.auto
+
 let wfName = null, wfSubcommand = null;
 let wfArgs = [], wfNamedArgs = {};
 
@@ -154,6 +169,9 @@ for (let i = 0; i < args.length; i++) {
   else if (arg === "--no-sdd")                  sddMode = false;
   else if (arg === "-v" || arg === "--verify")  verifyMode = true;
   else if (arg === "--no-verify")               verifyMode = false;
+  // Auto-merge modifier. `-m` is free (`-h` is hive, `-s` is swarm) — no collision.
+  else if (arg === "-m" || arg === "--merge")   mergeMode = true;
+  else if (arg === "--no-merge")                mergeMode = false;
   else if (/^\d+$/.test(arg)) issueNumber = arg;
   else titleWords.push(arg);
 }
@@ -180,6 +198,13 @@ if (sddMode && workflowMode === "research") {
   sddMode = false;
 }
 
+// Auto-merge only applies to a full run that opens a PR. -t/-r never open one,
+// and under --epic-branch the epic orchestrator owns merging — drop it with a note.
+if (mergeMode && (epicBranch || workflowMode === "ticket" || workflowMode === "research")) {
+  console.log("Note: --merge ignored — " + (epicBranch ? "--epic-branch" : workflowMode + " mode") + " does not open a PR to merge.");
+  mergeMode = false;
+}
+
 if (workflowMode === "spell-engine") {
   if (!wfName && !wfSubcommand) throw new Error("Spell name or subcommand required.");
 } else {
@@ -203,3 +228,4 @@ Full mode runs end-to-end without further prompts.
 8. **If `verifyMode`** (always on under `sddMode`): verify the change end-to-end with `/verify` against the plan's acceptance criteria, and store the outcome to memory — `./sdd.md`. This satisfies the verify-before-done gate.
 9. Store learnings via `mcp__moflo__memory_store` — `./phases.md` Phase 5.2
 10. Open PR, update issue status — `./phases.md` Phases 5.3–5.4
+11. **If `mergeMode`:** await the PR's merge preconditions and merge it (native `--auto` preferred, else poll-then-merge) — `./phases.md` Phase 5.3b

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -235,6 +235,44 @@ flo epic checkoff <epic-number> <story-number>
 
 Idempotent and safe to skip when there is no back-reference. `--epic-branch` runs skip it — the epic orchestrator owns checklist state there. The box flips when the work is delivered (PR opened), matching the orchestrator; if a PR is later rejected, reopen the epic manually.
 
+### 5.3b Auto-merge the PR (`mergeMode` / `merge.auto`)
+
+Runs only in **full** workflow mode, only when `mergeMode` is true, and only **after** the PR is open (5.3) and issue status is updated (5.4). Skipped entirely under `--epic-branch` and in `-t`/`-r` (the parser already cleared `mergeMode` there). Because it runs after `gh pr create`, every quality gate (tests, simplify, learnings, verify) has already passed — auto-merge never bypasses them.
+
+**Never merge on red or unknown checks.** Only merge when required checks are affirmatively `SUCCESS` and the state is `MERGEABLE`/`CLEAN`. A green exit code is not proof (see the gotcha below).
+
+Order of preference:
+
+**1. GitHub native auto-merge (preferred).** If the repo allows it, queue the merge and let GitHub land it when required checks + reviews pass — no local polling:
+```bash
+# Is "Allow auto-merge" enabled on the repo?
+gh repo view --json autoMergeAllowed --jq .autoMergeAllowed   # true | false
+# If true:
+gh pr merge <n> --auto --squash --delete-branch
+```
+`--auto` is not `--admin` and is not subject to the classifier denial below. If `autoMergeAllowed` is false or `gh` reports auto-merge is unavailable, fall through to (2).
+
+**2. Poll-then-merge fallback.** Await preconditions locally, then merge. Do **not** rely on `gh pr checks --watch`'s exit code — inspect the rollup explicitly:
+```bash
+gh pr view <n> --json statusCheckRollup,mergeStateStatus,mergeable,reviewDecision,isDraft
+```
+Merge only when: every **required** entry in `statusCheckRollup` is `SUCCESS` (or `NEUTRAL`/`SKIPPED`), `mergeable == "MERGEABLE"`, `mergeStateStatus` is `CLEAN` (or `UNSTABLE` solely from non-required checks), and `isDraft == false`. Re-query on an interval until preconditions hold or a sensible cap elapses (a handful of checks over a few minutes; surface a timeout rather than looping forever). Use a Node timer or `gh ... --watch` for the wait — **never a bash-only `sleep` loop** (Rule #1: not on Windows). Then:
+```bash
+gh pr merge <n> --squash --delete-branch
+```
+
+**3. Admin override (review-required fallback, opt-in).** If the *only* remaining blocker is `reviewDecision == "REVIEW_REQUIRED"` on a repo the actor administers (e.g. a solo repo where GitHub blocks self-approval), an admin squash-merge is the sole path:
+```bash
+gh pr merge <n> --squash --admin --delete-branch
+```
+**Gotcha — the Claude Code auto-mode permission classifier reliably DENIES `gh pr merge --admin`.** When the call is denied, do **not** silently swallow it or retry in a loop. Surface a copy-paste command for the user to run themselves and stop:
+> Admin merge is required (review-required on an administered repo) but was blocked by the permission classifier. Run it manually:
+> `! gh pr merge <n> --squash --admin --delete-branch`
+
+Before any `--admin` merge, re-confirm checks are affirmatively green per the (2) rollup rule — `--admin` bypasses branch protection, so never `--admin` over a red or unknown X (learning `ci-watch-exit-code-not-proof-of-green`).
+
+On a successful merge the branch is deleted (`--delete-branch`) and the `Closes #<n>` reference auto-closes the issue. If merge does not complete (timeout, denied admin, red checks), leave the PR open, report why, and continue to 5.5 — a stuck merge is not a failed run.
+
 ### 5.5 Finalize run record (Flo Runs dashboard)
 
 Update the tasklist row written in Phase 0 with the terminal status. Same `runId`, `upsert: true`. On success:

--- a/bin/lib/yaml-upgrader.mjs
+++ b/bin/lib/yaml-upgrader.mjs
@@ -69,6 +69,16 @@ sdd:
   default: false
 `,
   },
+  {
+    key: 'merge',
+    block: `# Auto-merge the PR at the end of a full /flo run once preconditions are met (#1285).
+# When auto is true, a full /flo run awaits required checks + MERGEABLE state then
+# merges and deletes the branch, instead of stopping at "PR opened". Opt-in;
+# override per-run with --merge / --no-merge.
+merge:
+  auto: false
+`,
+  },
 ];
 
 /**

--- a/moflo.yaml
+++ b/moflo.yaml
@@ -55,6 +55,16 @@ session_continuity:
 auto_meditate:
   enabled: true
 
+# Spec-Driven Development (Epic #1269) — spec -> plan -> implement -> verify.
+# When default is true, every /flo run uses the SDD cycle unless --no-sdd.
+sdd:
+  default: false
+
+# Auto-merge the PR at the end of a full /flo run once preconditions are met (#1285).
+# Opt-in; default false. Override per-run with --merge / --no-merge.
+merge:
+  auto: false
+
 # Memory backend
 memory:
   backend: node-sqlite

--- a/src/cli/__tests__/init-moflo-yaml-template.test.ts
+++ b/src/cli/__tests__/init-moflo-yaml-template.test.ts
@@ -95,6 +95,11 @@ describe('renderMofloYaml', () => {
     expect(yaml).toMatch(/sandbox:\n\s+enabled: false/);
   });
 
+  it('emits merge.auto at false (opt-in, #1285)', () => {
+    const yaml = renderMofloYaml(baselineConfig);
+    expect(yaml).toMatch(/merge:\n\s+auto: false/);
+  });
+
   it('is byte-stable for the same config (no Date.now or randomness)', () => {
     const a = renderMofloYaml(baselineConfig);
     const b = renderMofloYaml(baselineConfig);

--- a/src/cli/__tests__/moflo-config-merge.test.ts
+++ b/src/cli/__tests__/moflo-config-merge.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the `merge` config section added by issue #1285.
+ *
+ * Covers: default false when absent, default false when the section is absent,
+ * explicit true/false round-trips, partial/other-section isolation. Mirrors the
+ * shape of moflo-config-scheduler.test.ts. The seed feeds the `/flo` skill's
+ * `mergeMode` (auto-merge the PR at the end of a full run) — default false so
+ * existing consumers keep the "stop at PR opened" behavior until they opt in.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadMofloConfig } from '../config/moflo-config.js';
+
+describe('moflo-config: merge section', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'moflo-config-merge-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('defaults to auto:false when no config file exists', () => {
+    const config = loadMofloConfig(root);
+    expect(config.merge).toEqual({ auto: false });
+  });
+
+  it('defaults to auto:false when moflo.yaml has no merge section', async () => {
+    await writeFile(join(root, 'moflo.yaml'), 'project:\n  name: test\n');
+    const config = loadMofloConfig(root);
+    expect(config.merge.auto).toBe(false);
+  });
+
+  it('honors merge.auto: true', async () => {
+    await writeFile(join(root, 'moflo.yaml'), 'merge:\n  auto: true\n');
+    const config = loadMofloConfig(root);
+    expect(config.merge.auto).toBe(true);
+  });
+
+  it('honors merge.auto: false explicitly', async () => {
+    await writeFile(join(root, 'moflo.yaml'), 'merge:\n  auto: false\n');
+    const config = loadMofloConfig(root);
+    expect(config.merge.auto).toBe(false);
+  });
+
+  it('does not disturb other config sections', async () => {
+    await writeFile(
+      join(root, 'moflo.yaml'),
+      ['merge:', '  auto: true', 'sdd:', '  default: true', ''].join('\n'),
+    );
+    const config = loadMofloConfig(root);
+    expect(config.merge.auto).toBe(true);
+    expect(config.sdd.default).toBe(true);
+  });
+});

--- a/src/cli/config/moflo-config.ts
+++ b/src/cli/config/moflo-config.ts
@@ -219,6 +219,16 @@ export interface MofloConfig {
     default: boolean;
   };
 
+  /** Auto-merge the PR at the end of a full /flo run (#1285). */
+  merge: {
+    /**
+     * true ⇒ a full /flo run awaits the PR's merge preconditions and merges it
+     * automatically once met, instead of stopping at "PR opened". Opt-in —
+     * default false; overridable per-run with --merge / --no-merge.
+     */
+    auto: boolean;
+  };
+
   spells: {
     userDirs: string[];
     shippedDir?: string;
@@ -332,6 +342,9 @@ const DEFAULT_CONFIG: MofloConfig = {
   },
   sdd: {
     default: false,
+  },
+  merge: {
+    auto: false,
   },
   spells: {
     userDirs: ['.claude/spells'],
@@ -563,6 +576,9 @@ function mergeConfig(raw: Record<string, any>, root: string): MofloConfig {
     },
     sdd: {
       default: raw.sdd?.default ?? DEFAULT_CONFIG.sdd.default,
+    },
+    merge: {
+      auto: raw.merge?.auto ?? DEFAULT_CONFIG.merge.auto,
     },
     spells: {
       // Accept camelCase (`userDirs`) or snake_case (`user_dirs`) to match
@@ -808,6 +824,11 @@ epic:
 # Spec-Driven Development (Epic #1269)
 sdd:
   default: false                 # true = every /flo run uses spec->plan->implement->verify unless --no-sdd
+
+# Auto-merge the PR at the end of a full /flo run once preconditions are met (#1285).
+# Opt-in; default false. Override per-run with --merge / --no-merge.
+merge:
+  auto: false                    # true = a full /flo run merges its PR once required checks pass and it's MERGEABLE
 
 # Spell engine discovery
 # userDirs: directories to scan for user-authored spells (YAML/JSON).

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -247,6 +247,13 @@ auto_meditate:
 sdd:
   default: false
 
+# Auto-merge the PR at the end of a full /flo run once preconditions are met (#1285).
+# When auto is true, a full /flo run awaits required checks + MERGEABLE state then
+# merges and deletes the branch, instead of stopping at "PR opened". Opt-in;
+# override per-run with --merge / --no-merge.
+merge:
+  auto: false
+
 # Memory backend
 memory:
   backend: node-sqlite
@@ -359,6 +366,7 @@ export const REQUIRED_TOP_LEVEL_SECTIONS = [
   'session_continuity',
   'auto_meditate',
   'sdd',
+  'merge',
   'memory',
   'hooks',
   'mcp',

--- a/tests/bin/yaml-upgrader.test.ts
+++ b/tests/bin/yaml-upgrader.test.ts
@@ -107,13 +107,24 @@ describe('yaml-upgrader', () => {
       expect(content).toContain('enabled: true');
     });
 
+    it('appends merge block (default-off) when missing (#1285)', () => {
+      writeFileSync(yamlPath, 'project:\n  name: foo\n', 'utf-8');
+      const appended = ensureYamlSections(yamlPath);
+
+      expect(appended).toContain('merge');
+      const content = readFileSync(yamlPath, 'utf-8');
+      expect(content).toMatch(/^merge:/m);
+      expect(content).toContain('auto: false');
+    });
+
     it('is idempotent when all required sections are already present', () => {
       const existing =
         'project:\n  name: foo\n' +
         'session_continuity:\n  capture: true\n  inject: true\n' +
         'auto_meditate:\n  enabled: false\n' +
         'sandbox:\n  enabled: true\n  tier: full\n' +
-        'sdd:\n  default: false\n';
+        'sdd:\n  default: false\n' +
+        'merge:\n  auto: false\n';
       writeFileSync(yamlPath, existing, 'utf-8');
 
       const firstRun = ensureYamlSections(yamlPath);


### PR DESCRIPTION
## Summary

Adds an opt-in `-m` / `--merge` (and `--no-merge`) flag to the `/flo` (`/fl`) skill plus a new `moflo.yaml` **`merge.auto`** default (`false`), mirroring the `sdd.default` / `-sd` seed-from-config pattern (Epic #1269). When enabled, a full `/flo` run awaits the PR's merge preconditions and merges it automatically instead of stopping at "PR opened".

Absent config + no flag ⇒ **current behavior unchanged** for every existing consumer (opt-in only).

## Changes

- **`.claude/skills/fl/SKILL.md`** — `-m`/`--merge`/`--no-merge` in the arg parser, `mergeMode` seeded from `merge.auto` before parsing (per-run flag overrides), interaction-rule note for `-t`/`-r`/`--epic-branch`, an Auto-merge docs table, and a full-mode flow step.
- **`.claude/skills/fl/phases.md`** — new **Phase 5.3b** documenting the merge order-of-preference: native `gh pr merge --auto` first, poll-then-merge fallback (explicit `statusCheckRollup` inspection, never a bash-only `sleep` loop), and `--admin` only as a review-required fallback. Honors the learned gotchas — never merge on red/unknown checks, and surface the `--admin` classifier-denial as a copy-paste `! gh pr merge …` command rather than looping.
- **`src/cli/config/moflo-config.ts`** — `merge: { auto }` in the interface, `DEFAULT_CONFIG`, the parse block, and the legacy YAML generator.
- **`src/cli/init/moflo-yaml-template.ts`** — render block + `merge` added to `REQUIRED_TOP_LEVEL_SECTIONS`.
- **`bin/lib/yaml-upgrader.mjs`** — `REQUIRED_SECTIONS` entry so existing consumer configs gain the block on next session-start (no re-init).
- **root `moflo.yaml`** — added the `merge:` block (and the previously-missing `sdd:` block so this repo's own config is compliant with `REQUIRED_TOP_LEVEL_SECTIONS`).

## Testing

- [x] `src/cli/__tests__/moflo-config-merge.test.ts` — `merge.auto` present/absent/true/false round-trips; default `false`.
- [x] `init-moflo-yaml-template.test.ts` — renderer emits `merge.auto: false`; `REQUIRED_TOP_LEVEL_SECTIONS` parity holds.
- [x] `tests/bin/yaml-upgrader.test.ts` — merge block appends when missing; idempotent when present.
- [x] Parser verified end-to-end: extracted the SKILL.md `javascript` block and ran all issue arg-parsing cases (`--merge`, `-m`, `--no-merge`, config-default-on + `--no-merge`, config-default-off + `--merge`, no-op notes for `-t`/`-r`/`--epic-branch`, orthogonality with `-s`/`-wt`) — all pass.
- [x] `validateMofloYaml("./moflo.yaml")` → valid, no missing sections.
- [x] Full `tsc` build clean.

## Consumer impact (Rule #2)

Surface: `.claude/skills/{fl,flo}/*` + `moflo.yaml` schema (ships via `flo init` / `npm install moflo`). Failure mode for existing consumers: **none** — key absent ⇒ `false` ⇒ stop-at-PR as today. `--admin` merge is never automatic (classifier denies it; surfaced for manual run).

Closes #1285

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)