### PR TITLE
feat(movector): emit circuit-breaker-aware fallbackModel chains; align docs with native checkpoints (#1272)

### DIFF
--- a/.claude/guidance/shipped/moflo-epic-processing.md
+++ b/.claude/guidance/shipped/moflo-epic-processing.md
@@ -57,6 +57,7 @@ The strategy is resolved with this precedence (highest first):
 
 ## See Also
 
+- `.claude/guidance/moflo-session-continuity.md` — How `epic-state` + git reconciliation resume works vs. native Claude Code checkpoints (`/rewind`, agent-tree)
 - `src/cli/commands/epic.ts` — Epic command implementation
 - `src/cli/config/moflo-config.ts` — `MofloConfig.epic` interface and defaults
 - `.claude/skills/fl/SKILL.md` — `/flo` skill epic handling section

--- a/.claude/guidance/shipped/moflo-session-continuity.md
+++ b/.claude/guidance/shipped/moflo-session-continuity.md
@@ -1,0 +1,71 @@
+# Native Checkpoints vs. MoFlo Continuity — Who Owns Undo and Resume
+
+**Purpose:** Decide which layer owns a given "undo" or "resume" — Claude Code's native checkpoints (`/rewind`, agent-tree checkpointing) or moflo's session-continuity + epic-state — so the two coexist by layering, never by competing. Read this before wiring any resume/rollback behavior into a moflo workflow.
+
+---
+
+## Ownership Decision Table
+
+The two systems solve different problems. Never route a job to the wrong layer or build a moflo mechanism that duplicates a native one.
+
+| You want to… | Owner | Mechanism |
+|--------------|-------|-----------|
+| Undo code edits from earlier THIS session | Native | `/rewind` code checkpoints |
+| Pause/resume a multi-hour agent tree WITHIN a session | Native | Agent-tree checkpointing (beta) |
+| Pick up context ACROSS sessions ("where you left off") | MoFlo | Session-continuity digest |
+| Resume an interrupted `flo epic` from real progress | MoFlo | `epic-state` reconciled against git + the GitHub checklist |
+| Fail over to another model when a tier is unavailable | Native | `fallbackModel` — moflo's router emits the chain |
+
+**Rule:** native checkpoints govern *in-session* rollback of code and agent trees; moflo governs *cross-session* coordination and the durable learning record. They layer; they do not overlap.
+
+---
+
+## Native Checkpoints Are Runtime-Only — Never Couple MoFlo to Them
+
+Native `/rewind`, code checkpoints, and agent-tree checkpoint state live entirely inside the Claude Code runtime. There is **no stable public file or API** for them, and moflo library code (the `flo` CLI, MCP server, hooks, launcher, daemon) is never handed a reference to that state.
+
+**Never read or write native checkpoint state from moflo code.** Coupling to an undocumented runtime format violates the cross-platform rule and the consumer-blast-radius rule — it would break silently on any Claude Code update, in every consumer install. Treat native checkpoints as a black box the human drives; moflo reacts to committed results (git, GitHub), not to session snapshots.
+
+---
+
+## MoFlo Session-Continuity — The Cross-Session Digest
+
+Session-continuity is moflo's narrative bridge between sessions, distinct from native checkpoints. At session end it captures a scrubbed digest — `{goal, decisions, gitState}` — to a rotated JSON store under `.moflo/`. At session start it scores digests by branch match, changed-file overlap, and recency, then injects the best one as a **"Where you left off"** lead.
+
+**Treat the injected digest as a verifiable lead, not ground truth.** It reflects what was true when it was written — re-check the current branch, working tree, and files before acting on it. Configure via `session_continuity: {capture, inject, max_age_hours}` in `moflo.yaml`; both flags default on.
+
+---
+
+## Epic Resume Is Checkpoint-Agnostic — Git Is the Source of Truth
+
+`flo epic` records progress in the `epic-state` memory namespace, but that namespace is an **in-session cache, hard-deleted on every session start** — never rely on it as the durable resume store. The durable sources of truth are the **git epic branch + commits** and the **GitHub issue checklist** (`[ ]` vs `[x]`).
+
+On resume, `epic.ts` reconciles memory against git: it recomputes the `epic/{n}-{slug}` branch and, if the branch is missing or has no commits ahead of the base, discards the memory record and starts fresh. This makes epic resume **independent of native checkpoints** — it works identically whether or not the user used `/rewind`, because truth is re-derived from committed state, not a session snapshot. Do not add native-checkpoint detection to epic resume; it would be unverifiable noise.
+
+---
+
+## Swarm and Hive-Mind Are a Logical Layer Native Nesting Does Not Replace
+
+MoFlo's `UnifiedSwarmCoordinator` is a **logical coordination layer** — an agent registry plus MessageBus routing, consensus voting, and workload-balanced task distribution. "Spawn" registers a tracked record; it never launches a process. Hive-mind is one level deep (queen → flat worker list; workers never spawn sub-workers).
+
+Native 3-level nested subagents solve **process and context isolation for real, executing agents** — an orthogonal concern. Native nesting does not replace the registry, MessageBus, consensus, or task distribution.
+
+**Never rewire swarm/hive-mind onto native nesting.** Reducing coordinator handlers to stubs to "map onto native primitives" is exactly the disconnection the protected-functionality rule forbids, for zero functional gain. The only seam between the two — the subagent bootstrap directive — is already carried in every spawn's metadata and response. Keep every handler wired to the coordinator.
+
+---
+
+## Model Routing Emits Native `fallbackModel` Chains
+
+MoFlo's model router already tracks per-tier circuit-breaker state. Its routing result carries a `fallbackModel` chain: an ordered, circuit-breaker-aware failover list that excludes the primary, drops `inherit` and zero-score tiers, and demotes any open-circuit tier to the tail.
+
+The chain is **advisory** — surfaced to the orchestrator via `hooks_model-route` and `agent_spawn`, then applied when spawning a real subagent. MoFlo never auto-launches a model itself; the orchestrator (or the native `Task` spawn) consumes the chain and maps it onto Claude Code's native `fallbackModel`. A healthy lower tier is always tried before a failing one.
+
+---
+
+## See Also
+
+- `.claude/guidance/moflo-epic-processing.md` — Epic orchestration whose `epic-state` + git reconciliation this doc frames against native checkpoints
+- `.claude/guidance/moflo-claude-swarm-cohesion.md` — Swarm/hive coordination model the "logical layer" note protects
+- `.claude/guidance/moflo-core-guidance.md` — CLI, hooks, swarm, memory, and config hub
+- `src/cli/movector/model-router.ts` — Router that emits the `fallbackModel` chain
+- `src/cli/commands/epic.ts` — Epic resume + git-branch reconciliation

--- a/src/cli/__tests__/mcp-tools-deep.test.ts
+++ b/src/cli/__tests__/mcp-tools-deep.test.ts
@@ -115,6 +115,8 @@ vi.mock('../memory/intelligence.js', () => ({
 // Mock movector modules
 vi.mock('../movector/model-router.js', () => ({
   getModelRouter: vi.fn(() => ({ route: async () => ({ model: 'sonnet', routedBy: 'router' }) })),
+  staticFallbackChain: (primary: string) =>
+    ['opus', 'sonnet', 'haiku'].filter((m) => m !== primary),
 }));
 
 vi.mock('../movector/enhanced-model-router.js', () => ({

--- a/src/cli/__tests__/movector/model-router.test.ts
+++ b/src/cli/__tests__/movector/model-router.test.ts
@@ -9,7 +9,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { ModelRouter, type ClaudeModel } from '../../movector/model-router';
+import {
+  ModelRouter,
+  buildFallbackChain,
+  staticFallbackChain,
+  type ClaudeModel,
+} from '../../movector/model-router';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -195,6 +200,76 @@ describe('ModelRouter selection (issue #891)', () => {
       expect(result.alternatives.find((a) => a.model === 'sonnet')).toBeUndefined();
       expect(result.alternatives.find((a) => a.model === 'opus')).toBeDefined();
       expect(result.costMultiplier).toBeLessThan(1); // sonnet < opus
+    });
+  });
+
+  describe('fallbackModel chain (#1272)', () => {
+    const noFailures: Record<ClaudeModel, number> = {
+      haiku: 0,
+      sonnet: 0,
+      opus: 0,
+      inherit: 0,
+    };
+
+    it('buildFallbackChain excludes the primary and inherit, orders by score', () => {
+      const scores = { haiku: 0.1, sonnet: 0.5, opus: 0.9, inherit: 0.5 } as Record<
+        ClaudeModel,
+        number
+      >;
+      const chain = buildFallbackChain(scores, noFailures, 5, 'haiku');
+      // primary (haiku) and inherit excluded; opus > sonnet by score.
+      expect(chain).toEqual(['opus', 'sonnet']);
+    });
+
+    it('buildFallbackChain drops zero-score models (never useful fallbacks)', () => {
+      const scores = { haiku: 0, sonnet: 0.5, opus: 0.9, inherit: 0 } as Record<
+        ClaudeModel,
+        number
+      >;
+      const chain = buildFallbackChain(scores, noFailures, 5, 'sonnet');
+      expect(chain).toEqual(['opus']); // haiku (0) dropped, sonnet is primary
+    });
+
+    it('buildFallbackChain demotes an OPEN-circuit tier to the tail despite high score', () => {
+      const scores = { haiku: 0.1, sonnet: 0.5, opus: 0.9, inherit: 0 } as Record<
+        ClaudeModel,
+        number
+      >;
+      // opus circuit is open (5 >= threshold 5) → tail despite the best score.
+      const failures = { ...noFailures, opus: 5 };
+      const chain = buildFallbackChain(scores, failures, 5, 'haiku');
+      expect(chain).toEqual(['sonnet', 'opus']);
+    });
+
+    it('route() returns a chain that excludes the primary and lists real tiers', async () => {
+      const result = await router.route('fix a simple typo in the readme comment');
+      expect(result.model).toBe('haiku');
+      expect(result.fallbackModel).not.toContain('haiku');
+      expect(result.fallbackModel).not.toContain('inherit');
+      expect(result.fallbackModel).toContain('sonnet');
+      expect(result.fallbackModel).toContain('opus');
+    });
+
+    it('route() demotes a tier to the chain tail once its circuit opens', async () => {
+      const task = 'fix a simple typo in the readme comment';
+      const before = await router.route(task);
+      expect(before.fallbackModel[0]).toBe('sonnet'); // highest-scoring fallback
+
+      // Open sonnet's circuit (default threshold 5).
+      for (let i = 0; i < 5; i++) router.recordOutcome(task, 'sonnet', 'failure');
+
+      const after = await router.route(task);
+      // sonnet demoted to the tail; opus (healthy) now leads.
+      expect(after.fallbackModel[0]).toBe('opus');
+      expect(after.fallbackModel[after.fallbackModel.length - 1]).toBe('sonnet');
+    });
+
+    it('staticFallbackChain gives a capability-ordered chain excluding primary + inherit', () => {
+      // Derived from MODEL_CAPABILITIES cost tiers: opus > sonnet > haiku.
+      expect(staticFallbackChain('sonnet')).toEqual(['opus', 'haiku']);
+      expect(staticFallbackChain('haiku')).toEqual(['opus', 'sonnet']);
+      expect(staticFallbackChain('opus')).toEqual(['sonnet', 'haiku']);
+      expect(staticFallbackChain('sonnet')).not.toContain('inherit');
     });
   });
 });

--- a/src/cli/__tests__/spells/credentials/default-store.test.ts
+++ b/src/cli/__tests__/spells/credentials/default-store.test.ts
@@ -152,7 +152,12 @@ describe('runner-factory + bridge integration', () => {
     const store = getDefaultCredentialStore({ filePath: credFile });
     expect(await store.get('SEEDED')).toBe('value-from-seed');
     expect(runner).toBeDefined();
-  });
+    // Explicit 20s timeout: this test does real passphrase key-derivation
+    // (scrypt) AND a cold dynamic import of runner-factory's module graph. Under
+    // the full parallel suite (forks pool, maxForks 2) that CPU contention can
+    // push past vitest's default 5s, flaking it (#1278 follow-up). Isolated runs
+    // finish in well under a second.
+  }, 20_000);
 });
 
 describe('readFileSync handling', () => {

--- a/src/cli/mcp-tools/agent-tools.ts
+++ b/src/cli/mcp-tools/agent-tools.ts
@@ -128,6 +128,8 @@ async function determineAgentModel(
   canSkipLLM?: boolean;
   agentBoosterIntent?: string;
   tier?: 1 | 2 | 3;
+  /** Circuit-breaker-aware failover chain, present when the basic router ran. */
+  fallbackModel?: ClaudeModel[];
 }> {
   // 1. Explicit model in config
   if (config.model && ['haiku', 'sonnet', 'opus', 'inherit'].includes(config.model as string)) {
@@ -164,7 +166,11 @@ async function determineAgentModel(
       if (router) {
         try {
           const result = await router.route(task);
-          return { model: result.model, routedBy: 'router' };
+          return {
+            model: result.model,
+            routedBy: 'router',
+            fallbackModel: result.fallbackModel,
+          };
         } catch {
           // Fall through to defaults on router error
         }
@@ -255,6 +261,13 @@ export const agentTools: MCPTool[] = [
         };
       }
 
+      // Advisory failover chain surfaced to the orchestrator alongside `model`.
+      // Router-driven decisions carry a breaker-aware chain; other paths get a
+      // static capability-ordered one (pure fn — no router instance needed).
+      const { staticFallbackChain } = await import('../movector/model-router.js');
+      const fallbackModel =
+        routingResult.fallbackModel ?? staticFallbackChain(routingResult.model);
+
       const response: Record<string, unknown> = {
         success: true,
         agentId: spawned.agentId,
@@ -264,6 +277,7 @@ export const agentTools: MCPTool[] = [
         spawned: spawned.spawned,
         model: routingResult.model,
         modelRoutedBy: routingResult.routedBy,
+        fallbackModel,
         bootstrap: SUBAGENT_BOOTSTRAP_DIRECTIVE,
         createdAt: new Date().toISOString(),
       };

--- a/src/cli/mcp-tools/hooks-tools.ts
+++ b/src/cli/mcp-tools/hooks-tools.ts
@@ -3043,6 +3043,7 @@ export const hooksModelRoute: MCPTool = {
       complexity: result.complexity,
       reasoning: result.reasoning,
       alternatives: result.alternatives,
+      fallbackModel: result.fallbackModel,
       inferenceTimeUs: result.inferenceTimeUs,
       costMultiplier: result.costMultiplier,
       implementation: 'tiny-dancer-neural',

--- a/src/cli/movector/model-router.ts
+++ b/src/cli/movector/model-router.ts
@@ -145,6 +145,13 @@ export interface ModelRoutingResult {
   inferenceTimeUs: number;
   /** Estimated cost multiplier */
   costMultiplier: number;
+  /**
+   * Circuit-breaker-aware ordered failover chain (excludes the primary `model`
+   * and `inherit`). Maps onto Claude Code's native `fallbackModel`: try each in
+   * order if the primary is unavailable. Advisory — the orchestrator/Task tool
+   * consumes it; the router never auto-launches a model itself.
+   */
+  fallbackModel: ClaudeModel[];
 }
 
 /**
@@ -201,6 +208,56 @@ const DEFAULT_CONFIG: ModelRouterConfig = {
   enableCostOptimization: true,
   preferSpeed: true,
 };
+
+// ============================================================================
+// Fallback Chain
+// ============================================================================
+
+/**
+ * Build a circuit-breaker-aware ordered fallback chain from model scores.
+ *
+ * The chain excludes the `primary` and `inherit`, drops zero-score models
+ * (never useful fallbacks), and demotes any tier whose circuit is OPEN
+ * (`consecutiveFailures >= threshold`) to the tail regardless of raw score — so
+ * a healthy but lower-scoring tier is always tried before a failing one. Within
+ * each partition (healthy, then open) models are ordered by descending score.
+ */
+export function buildFallbackChain(
+  scores: Record<ClaudeModel, number>,
+  consecutiveFailures: Record<ClaudeModel, number>,
+  circuitBreakerThreshold: number,
+  primary: ClaudeModel,
+): ClaudeModel[] {
+  const isOpen = (m: ClaudeModel): boolean =>
+    consecutiveFailures[m] >= circuitBreakerThreshold;
+
+  return (Object.entries(scores) as [ClaudeModel, number][])
+    .filter(([m, score]) => m !== primary && m !== 'inherit' && score > 0)
+    .sort((a, b) => {
+      // Healthy tiers first; within a group, higher score first.
+      const openDelta = (isOpen(a[0]) ? 1 : 0) - (isOpen(b[0]) ? 1 : 0);
+      return openDelta !== 0 ? openDelta : b[1] - a[1];
+    })
+    .map(([m]) => m);
+}
+
+/**
+ * Capability-ordered fallback chain (most → least capable) for an already-chosen
+ * `primary`, derived from `MODEL_CAPABILITIES` so it never drifts from the tier
+ * definitions. Excludes the `primary` and `inherit`.
+ *
+ * Breaker-agnostic — for callers that picked a model WITHOUT consulting the
+ * router's circuit breaker (explicit config, Agent Booster, keyword/AST
+ * routing). Router-driven decisions get the breaker-aware chain from `route()`.
+ */
+export function staticFallbackChain(primary: ClaudeModel): ClaudeModel[] {
+  return (Object.keys(MODEL_CAPABILITIES) as ClaudeModel[])
+    .filter((m) => m !== primary && m !== 'inherit')
+    .sort(
+      (a, b) =>
+        MODEL_CAPABILITIES[b].costMultiplier - MODEL_CAPABILITIES[a].costMultiplier,
+    );
+}
 
 // ============================================================================
 // Model Router Implementation
@@ -272,6 +329,12 @@ export class ModelRouter {
         .sort((a, b) => b.score - a.score),
       inferenceTimeUs,
       costMultiplier: MODEL_CAPABILITIES[model].costMultiplier,
+      fallbackModel: buildFallbackChain(
+        adjustedScores,
+        this.consecutiveFailures,
+        this.config.circuitBreakerThreshold,
+        model,
+      ),
     };
 
     // Track decision


### PR DESCRIPTION
## Summary

Aligns moflo with Claude Code's native 2026 features (checkpoints/`/rewind`, agent-tree checkpointing, 3-level nested subagents, `fallbackModel`). Extensive research (3 parallel investigations) established an **honest code-vs-docs-vs-audit split**: moflo is an advisory/coordination layer — not a launcher — and native checkpoint state is runtime-only, so **only `fallbackModel` is a genuine code feature**.

| AC | Disposition | What shipped |
|----|-------------|--------------|
| **#1 fallbackModel** | **Code** | `ModelRouter.route()` emits `fallbackModel: ClaudeModel[]` — a circuit-breaker-aware ordered failover chain. Surfaced in `hooks_model-route` + `agent_spawn`. |
| **#2 epic checkpoint resume** | **Docs** | Native checkpoint state is runtime-only/unreachable; epic resume is already durable + checkpoint-agnostic via git-branch reconciliation. |
| **#3 nested subagents** | **Audit** | Coordinator is a logical layer native nesting doesn't replace; all 6 protected-functionality checks pass. **No coordinator code changed.** |
| **#4 docs** | **New shipped guidance** | `moflo-session-continuity.md` clarifies the layering. |

## The one code feature (AC#1)

- **`buildFallbackChain`** (exported, pure): breaker-aware chain — excludes the primary + `inherit`, drops zero-score tiers, and demotes any **open-circuit** tier to the tail so a healthy lower tier is always tried first. Used by `route()` with live breaker state.
- **`staticFallbackChain`** (exported, pure): capability-ordered chain **derived from `MODEL_CAPABILITIES`** (single source of truth — no parallel ranking to drift). Used by `agent_spawn`'s non-router paths.
- Both surfaced **additively** (new optional-shaped fields) → non-breaking for consumers on the prior version.
- **Advisory by design:** moflo never auto-launches a model. The router hands the orchestrating Claude / native `Task` spawn a recommendation + chain; it maps onto Claude Code's native `fallbackModel`. (Confirmed: `agent_spawn`'s coordinator drops `metadata.model`; the real spawn is the `Task` tool, which moflo can't invoke.)

## Why swarm/hive-mind was NOT touched

Per the protected-functionality rule and the "don't change it for the sake of it" bar: the `UnifiedSwarmCoordinator` is a logical record/MessageBus/consensus/task-distribution layer; native 3-level nesting solves process isolation for *executing* agents — orthogonal. Hive-mind is one level deep (no nesting to map). Rewiring onto native nesting would be exactly the forbidden disconnection, for zero gain. **All 6 protected-functionality checks pass; `swarm-restoration-e2e` stays green.**

## Incidental flake fix

The full-suite run surfaced a **pre-existing** parallel-contention flake in `default-store.test.ts` (unrelated to this change): one integration test does real passphrase scrypt **+** a cold dynamic `import(runner-factory)`, overrunning vitest's default 5s under 2-fork CPU contention (passes <1s isolated). Fixed at the source with a targeted 20s timeout on that test (Broken Window).

## Testing

- 6 new unit tests for the fallback chain (ordering, primary/inherit exclusion, zero-score drop, breaker demotion, static capability order).
- `mcp-tools-deep` mock updated for the new export.
- **Full suite green: 8214 + 1147 passed, 0 failed.** Typecheck clean.

## Cross-platform (Rule #1)

Pure in-memory logic + a Markdown doc — no paths, EOL, shell, or platform surface.

Closes #1272

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
