### PR TITLE
docs(flo): auto-attempt admin merge on review-required; document -w/-m flags in README

### DIFF
--- a/.claude/skills/fl/SKILL.md
+++ b/.claude/skills/fl/SKILL.md
@@ -61,7 +61,7 @@ Defaults seed from `moflo.yaml` — `sdd.default` and `gates.verify_before_done`
 | `-m` | `--merge` | After the PR is opened, **await its merge preconditions and merge it** (Phase 5.3b) instead of stopping at "PR opened". |
 | `--no-merge` | | Opt a single run out when `moflo.yaml merge.auto: true` turned it on. |
 
-Default seeds from `moflo.yaml merge.auto` (absent ⇒ `false`); the per-run flag overrides. Auto-merge is **orthogonal** to exec mode (`-n`/`-s`/`-h`), `--worktree`, and `--sdd`/`--verify`, and happens strictly **after** the existing gates (tests, simplify, learnings, verify) have let `gh pr create` through — so `--merge` never bypasses a quality gate. It is a documented no-op in `-t`/`-r` (no PR) and under `--epic-branch` (the epic orchestrator owns merging). Merge mechanics — native `--auto` first, poll-then-merge fallback, admin-override caveat — live in `./phases.md` Phase 5.3b.
+Default seeds from `moflo.yaml merge.auto` (absent ⇒ `false`); the per-run flag overrides. Auto-merge is **orthogonal** to exec mode (`-n`/`-s`/`-h`), `--worktree`, and `--sdd`/`--verify`, and happens strictly **after** the existing gates (tests, simplify, learnings, verify) have let `gh pr create` through — so `--merge` never bypasses a quality gate. It is a documented no-op in `-t`/`-r` (no PR) and under `--epic-branch` (the epic orchestrator owns merging). Merge mechanics — native `--auto` first, poll-then-merge fallback, then an auto-attempted admin merge when review-required is the only blocker on an administered repo (with a manual-command hand-off if the permission classifier denies it) — live in `./phases.md` Phase 5.3b.
 
 ## Epic detection
 

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -261,15 +261,15 @@ Merge only when: every **required** entry in `statusCheckRollup` is `SUCCESS` (o
 gh pr merge <n> --squash --delete-branch
 ```
 
-**3. Admin override (review-required fallback, opt-in).** If the *only* remaining blocker is `reviewDecision == "REVIEW_REQUIRED"` on a repo the actor administers (e.g. a solo repo where GitHub blocks self-approval), an admin squash-merge is the sole path:
+**3. Admin override (review-required — auto-attempt, then hand off).** If the *only* remaining blocker is `reviewDecision == "REVIEW_REQUIRED"` on a repo the actor administers (e.g. a solo repo where GitHub blocks self-approval), an admin squash-merge is the sole path to land the PR — so under `mergeMode` **attempt it automatically** rather than stopping at a manual command:
 ```bash
 gh pr merge <n> --squash --admin --delete-branch
 ```
-**Gotcha — the Claude Code auto-mode permission classifier reliably DENIES `gh pr merge --admin`.** When the call is denied, do **not** silently swallow it or retry in a loop. Surface a copy-paste command for the user to run themselves and stop:
+**Precondition — re-confirm green first.** Before the `--admin` call, re-confirm checks are affirmatively green per the (2) rollup rule — `--admin` bypasses branch protection, so never `--admin` over a red or unknown X (learning `ci-watch-exit-code-not-proof-of-green`). Admin-attempt is scoped to the review-required case only; never `--admin` to skip a failing or pending required check.
+
+**Fallback if denied — hand off, don't loop.** The Claude Code auto-mode permission classifier may DENY an unattended `gh pr merge --admin` (headless/cron runs especially). If the call is denied, do **not** silently swallow it or retry in a loop — surface a copy-paste command for the user and stop:
 > Admin merge is required (review-required on an administered repo) but was blocked by the permission classifier. Run it manually:
 > `! gh pr merge <n> --squash --admin --delete-branch`
-
-Before any `--admin` merge, re-confirm checks are affirmatively green per the (2) rollup rule — `--admin` bypasses branch protection, so never `--admin` over a red or unknown X (learning `ci-watch-exit-code-not-proof-of-green`).
 
 On a successful merge the branch is deleted (`--delete-branch`) and the `Closes #<n>` reference auto-closes the issue. If merge does not complete (timeout, denied admin, red checks), leave the PR open, report why, and continue to 5.5 — a stuck merge is not a failed run.
 

--- a/README.md
+++ b/README.md
@@ -338,11 +338,13 @@ Inside Claude Code, the `/flo` (or `/fl`) slash command drives GitHub issue exec
 /flo -s <issue>               # Swarm mode (multi-agent coordination)
 /flo -h <issue>               # Hive-mind mode (consensus-based coordination)
 /flo -n <issue>               # Normal mode (default, single agent, no swarm)
+/flo -w <issue>               # Worktree: run the work in a fresh git worktree
 /flo -sd <issue>              # SDD: spec → plan → implement → verify (implies --verify)
 /flo -v <issue>               # Verify-before-done only (no spec/plan front-half)
+/flo -m <issue>               # Auto-merge the PR once required checks pass
 ```
 
-For full options and details, type `/flo` with no arguments — Claude Code will display the complete skill documentation. Also available as `/fl`.
+Flags compose: e.g. `/flo -sd -m <issue>` runs the SDD cycle and auto-merges. Each opt-in modifier has a `--no-*` form (`--no-sdd`, `--no-verify`, `--no-merge`) to override a `moflo.yaml` default for a single run. For full options and details, type `/flo` with no arguments — Claude Code will display the complete skill documentation. Also available as `/fl`.
 
 ### Spec-Driven Development (SDD)
 
@@ -361,6 +363,19 @@ gates:
 ```
 
 `--sdd` implies `--verify` (a spec/plan without an enforced verify step drifts). Manage artifacts directly with `flo sdd` (`spec`, `plan`, `review`, `check`, `list`), and start from a fuzzy idea with **`/commune`**, which can hand its synthesized spec straight into the SDD spine. Wiring status is reported by **`/healer`** (and `/eldar`).
+
+### Auto-merge
+
+- **`-m` / `--merge`** — after the PR is opened, await its merge preconditions and merge it, instead of stopping at "PR opened". Orthogonal to execution mode (`-n`/`-s`/`-h`), `--worktree`, and `--sdd`/`--verify`, and always runs **after** the quality gates (tests, simplify, learnings, verify) have let `gh pr create` through — so `--merge` never bypasses a gate.
+
+It prefers GitHub-native auto-merge, falls back to poll-then-merge once required checks are green, and — when the *only* remaining blocker is review-required on a repo you administer (e.g. a solo repo where GitHub blocks self-approval) — auto-attempts an admin squash-merge. If an unattended admin merge is denied by Claude Code's permission classifier (headless/cron runs), it hands you a copy-paste command rather than looping. It re-confirms checks are green before any admin merge, and never `--admin` over a red or pending required check.
+
+Default seeds from `moflo.yaml`; the per-run flag overrides, and `--no-merge` opts a single run out:
+
+```yaml
+merge:
+  auto: false                 # true → every /flo run auto-merges its PR unless --no-merge
+```
 
 ### Epic handling
 


### PR DESCRIPTION
## Summary

Two related `/flo` documentation changes, following up on the auto-merge feature (#1285).

### 1. `-m` auto-attempts the admin merge (Phase 5.3b step 3)

Previously, when the only remaining merge blocker was **review-required on an administered repo** (e.g. a solo repo where GitHub blocks self-approval), the workflow stopped and handed the user a manual `--admin` command. It now **attempts the admin squash-merge automatically** — the intended behavior of `--merge`, since admin merge is the sole path to land the PR in that case.

Guardrails preserved:
- Re-confirms required checks are affirmatively green **before** any `--admin` merge (`--admin` bypasses branch protection — never over a red/pending check).
- Admin-attempt is scoped to the **review-required** case only.
- If Claude Code's auto-mode permission classifier **denies** an unattended `--admin` (headless/cron), it falls back to the copy-paste hand-off — no retry loop.

### 2. README documents the missing `/flo` flags

The `/flo` quick-reference listed `-t/-r/-s/-h/-n/-sd/-v` but was **missing `-w`/`--worktree` and `-m`/`--merge`**. Added both, plus a note on flag composition and the `--no-*` opt-outs, and a new **Auto-merge** subsection (behavior + `moflo.yaml merge.auto` default) mirroring the existing SDD subsection. `SKILL.md`'s merge-mechanics pointer now describes the escalation.

## Consumer surface / blast radius

Shipped skill guidance (`.claude/skills/fl/`) + README — **docs only, no code**. Consumers running `/flo -m` will now get an auto-attempted admin merge in the review-required case (previously a manual hand-off); the safety re-confirmation and denial fallback are unchanged in spirit.

## Testing

Docs-only. `skill-and-guidance-size-drift` green (SKILL.md 231 lines); no test pins this wording. Cross-platform: guidance text + `gh` commands, no shell/path surface.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
