### PR TITLE
feat(claude-stats): walk subagent transcripts + expose subagent token subtotal (unblocks #1264)

### DIFF
--- a/src/cli/__tests__/services/claude-stats.test.ts
+++ b/src/cli/__tests__/services/claude-stats.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -297,5 +297,113 @@ describe('aggregateClaudeStats', () => {
     // Fresh aggregation produces a structurally identical but distinct object.
     expect(fresh).not.toBe(first);
     expect(fresh.windows.lifetime.tokens.input).toBe(first.windows.lifetime.tokens.input);
+  });
+});
+
+// ============================================================================
+// Subagent transcript walking (#1264)
+// ============================================================================
+
+/** Write a `<sessionId>/subagents/agent-<agentId>.jsonl` transcript under dir. */
+function writeSubagentTranscript(sessionId: string, agentId: string, lines: string[]): void {
+  const subDir = join(dir, sessionId, 'subagents');
+  mkdirSync(subDir, { recursive: true });
+  writeFileSync(join(subDir, `agent-${agentId}.jsonl`), lines.join('\n'));
+}
+
+describe('subagent transcript walking (#1264)', () => {
+  const ts = '2026-05-09T12:00:00Z';
+
+  it('rolls subagent usage into windows + models AND tracks a distinct subtotal', async () => {
+    // Main-loop usage on the top-level transcript.
+    writeFileSync(
+      join(dir, 'main.jsonl'),
+      assistantLine({ ts, sessionId: 'S', model: 'opus', usage: { input_tokens: 100 } }),
+    );
+    // Two subagent transcripts under session S (carry the parent sessionId).
+    writeSubagentTranscript('S', 'a1', [
+      assistantLine({ ts, sessionId: 'S', model: 'sonnet', usage: { input_tokens: 10, output_tokens: 5 } }),
+    ]);
+    writeSubagentTranscript('S', 'a2', [
+      assistantLine({ ts, sessionId: 'S', model: 'haiku', usage: { input_tokens: 3 } }),
+    ]);
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+
+    // Model distribution now includes subagent sonnet/haiku (the #1044 gap fix).
+    const byModel = Object.fromEntries(stats.models.map((m) => [m.model, m.tokens]));
+    expect(byModel.opus).toBe(100);
+    expect(byModel.sonnet).toBe(15);
+    expect(byModel.haiku).toBe(3);
+
+    // Windows reflect the complete total.
+    expect(stats.windows.lifetime.tokens.total).toBe(100 + 15 + 3);
+
+    // Distinct subagent subtotal + transcript count.
+    expect(stats.subagents.transcripts).toBe(2);
+    expect(stats.subagents.tokens.input).toBe(13);
+    expect(stats.subagents.tokens.output).toBe(5);
+    expect(stats.subagents.tokens.total).toBe(15 + 3);
+
+    // The #1264 split: main-loop = lifetime total − subagent total.
+    expect(stats.windows.lifetime.tokens.total - stats.subagents.tokens.total).toBe(100);
+  });
+
+  it('attributes subagent lines to the parent session, no phantom sessions', async () => {
+    writeFileSync(
+      join(dir, 'main.jsonl'),
+      assistantLine({ ts, sessionId: 'P', model: 'opus', usage: { input_tokens: 1 } }),
+    );
+    writeSubagentTranscript('P', 'a1', [
+      assistantLine({ ts, sessionId: 'P', model: 'sonnet', usage: { input_tokens: 1 } }),
+    ]);
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(stats.totalSessions).toBe(1);
+  });
+
+  it('is available when only subagent transcripts exist', async () => {
+    writeSubagentTranscript('S', 'a1', [
+      assistantLine({ ts, sessionId: 'S', model: 'sonnet', usage: { input_tokens: 4 } }),
+    ]);
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(stats.available).toBe(true);
+    expect(stats.subagents.transcripts).toBe(1);
+    expect(stats.subagents.tokens.total).toBe(4);
+  });
+
+  it('invalidates the cache when a new subagent transcript appears', async () => {
+    writeFileSync(
+      join(dir, 'main.jsonl'),
+      assistantLine({ ts, sessionId: 'S', model: 'opus', usage: { input_tokens: 1 } }),
+    );
+    writeSubagentTranscript('S', 'a1', [
+      assistantLine({ ts, sessionId: 'S', model: 'sonnet', usage: { input_tokens: 10 } }),
+    ]);
+    const first = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(first.subagents.transcripts).toBe(1);
+
+    // Adding a second subagent transcript shifts the cache key (count + size).
+    writeSubagentTranscript('S', 'a2', [
+      assistantLine({ ts, sessionId: 'S', model: 'haiku', usage: { input_tokens: 20 } }),
+    ]);
+    const second = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(second).not.toBe(first);
+    expect(second.subagents.transcripts).toBe(2);
+    expect(second.subagents.tokens.total).toBe(30);
+  });
+
+  it('ignores session subdirectories that have no subagents/ folder', async () => {
+    writeFileSync(
+      join(dir, 'main.jsonl'),
+      assistantLine({ ts, sessionId: 'S', model: 'opus', usage: { input_tokens: 1 } }),
+    );
+    // A session subdir with other ancillary data but no subagents/ folder.
+    mkdirSync(join(dir, 'S', 'other'), { recursive: true });
+    writeFileSync(join(dir, 'S', 'other', 'notes.jsonl'), 'ignored');
+
+    const stats = await aggregateClaudeStats('cwd', { projectDir: dir });
+    expect(stats.subagents.transcripts).toBe(0);
+    expect(stats.parseErrors).toBe(0); // the stray file was never opened
   });
 });

--- a/src/cli/services/claude-stats.ts
+++ b/src/cli/services/claude-stats.ts
@@ -5,11 +5,14 @@
  * the JSON shape consumed by The Luminarium's "Claude Stats" tab. Pure I/O
  * + reduce; no persistent storage, no network.
  *
- * Scope: primary-session transcripts only (top-level `*.jsonl`). Per-session
- * `<id>/subagents/agent-*.jsonl` files (Task-tool spawns) are NOT walked, so
- * Sonnet/Haiku usage from /simplify, /ultrareview, etc. is missing from the
- * model distribution. Tracked as a follow-up — when wiring it up, recurse
- * into `subagents/` and roll the subagent mtimes/sizes into the cache key.
+ * Scope: primary-session transcripts (top-level `*.jsonl`) AND per-session
+ * `<id>/subagents/agent-*.jsonl` files (Task-tool spawns). Subagent usage —
+ * the Sonnet/Haiku spend from /flo fan-out, /simplify, /ultrareview, etc. —
+ * rolls into the model distribution and token windows so totals are complete,
+ * and is ALSO tracked as a distinct `subagents` subtotal so callers can split
+ * main-loop context from subagent context (issue #1264). Subagent transcripts
+ * carry their PARENT sessionId, so they attribute to the right session without
+ * inflating the session count. Their mtimes/sizes fold into the cache key.
  *
  * Performance posture:
  *   - Streaming readline (not `readFileSync().split('\n')`) — transcripts
@@ -22,6 +25,7 @@
  */
 
 import { createReadStream } from 'node:fs';
+import type { Dirent } from 'node:fs';
 import { stat, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
@@ -84,6 +88,21 @@ export interface ClaudeStatsShape {
   };
   readonly models: readonly ModelDistribution[];
   readonly tools: readonly ToolUsage[];
+  /**
+   * Subagent (`<id>/subagents/agent-*.jsonl`, Task-tool spawn) subtotal. These
+   * tokens are ALSO included in `windows`/`models` above — this breaks them out
+   * so callers can compute main-loop context (window total − subagent total).
+   */
+  readonly subagents: {
+    readonly transcripts: number;
+    readonly tokens: {
+      readonly input: number;
+      readonly output: number;
+      readonly cacheCreate: number;
+      readonly cacheRead: number;
+      readonly total: number;
+    };
+  };
   /** Sessions whose transcript contained at least one tool_result.is_error. */
   readonly errorSessions: number;
   /** Median + p95 of (last - first timestamp) per session, milliseconds. */
@@ -162,6 +181,8 @@ interface Aggregator {
   toolCounts: Map<string, number>;
   sessions: Map<string, SessionMeta>;
   parseErrors: number;
+  /** Subagent-only token subtotal (also folded into windows/models above). */
+  subagent: { input: number; output: number; cacheCreate: number; cacheRead: number };
 }
 
 function makeAggregator(): Aggregator {
@@ -175,6 +196,7 @@ function makeAggregator(): Aggregator {
     toolCounts: new Map(),
     sessions: new Map(),
     parseErrors: 0,
+    subagent: { input: 0, output: 0, cacheCreate: 0, cacheRead: 0 },
   };
 }
 
@@ -195,8 +217,12 @@ interface JsonlLine {
   };
 }
 
-/** Walk one parsed JSONL line and update the aggregator. */
-function consumeLine(agg: Aggregator, line: JsonlLine, now: number): void {
+/**
+ * Walk one parsed JSONL line and update the aggregator. `isSubagent` marks
+ * lines from `<id>/subagents/agent-*.jsonl` so their usage is additionally
+ * booked to the subagent subtotal (it still counts toward windows/models).
+ */
+function consumeLine(agg: Aggregator, line: JsonlLine, now: number, isSubagent: boolean): void {
   const ts = line.timestamp ? Date.parse(line.timestamp) : NaN;
   const sessionId = line.sessionId;
 
@@ -242,6 +268,14 @@ function consumeLine(agg: Aggregator, line: JsonlLine, now: number): void {
   const modelKey = canonicalModelKey(line.message?.model);
   agg.modelMessages.set(modelKey, (agg.modelMessages.get(modelKey) ?? 0) + 1);
   agg.modelTokens.set(modelKey, (agg.modelTokens.get(modelKey) ?? 0) + totalThisLine);
+
+  // Subagent subtotal — booked in addition to (not instead of) the windows.
+  if (isSubagent) {
+    agg.subagent.input += input;
+    agg.subagent.output += output;
+    agg.subagent.cacheCreate += cc;
+    agg.subagent.cacheRead += cr;
+  }
 
   // Lifetime always.
   bump(agg.lifetime, sessionId, input, output, cc, cr);
@@ -303,7 +337,12 @@ async function listTranscripts(
   return stats.filter((s): s is { path: string; mtimeMs: number; size: number } => s !== null);
 }
 
-async function streamFile(agg: Aggregator, path: string, now: number): Promise<void> {
+async function streamFile(
+  agg: Aggregator,
+  path: string,
+  now: number,
+  isSubagent: boolean,
+): Promise<void> {
   const stream = createReadStream(path, { encoding: 'utf-8' });
   const rl = createInterface({ input: stream, crlfDelay: Infinity });
   for await (const raw of rl) {
@@ -315,8 +354,57 @@ async function streamFile(agg: Aggregator, path: string, now: number): Promise<v
       agg.parseErrors++;
       continue;
     }
-    consumeLine(agg, parsed, now);
+    consumeLine(agg, parsed, now, isSubagent);
   }
+}
+
+/**
+ * List `<id>/subagents/*.jsonl` transcripts (Task-tool spawns) across every
+ * session subdirectory in a project dir, returning [path, mtime, size]. Session
+ * dirs without a `subagents/` folder are skipped silently.
+ */
+async function listSubagentTranscripts(
+  dir: string,
+): Promise<Array<{ path: string; mtimeMs: number; size: number }>> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+
+  const perSession = await Promise.all(
+    entries
+      .filter((e) => e.isDirectory())
+      .map(async (e) => {
+        const subDir = join(dir, e.name, 'subagents');
+        let names: string[];
+        try {
+          names = await readdir(subDir);
+        } catch {
+          // No subagents/ dir for this session (the common case) — skip.
+          return [];
+        }
+        const jsonl = names.filter((n) => n.endsWith('.jsonl'));
+        const stats = await Promise.all(
+          jsonl.map(async (name) => {
+            const full = join(subDir, name);
+            try {
+              const s = await stat(full);
+              return s.isFile() ? { path: full, mtimeMs: s.mtimeMs, size: s.size } : null;
+            } catch {
+              return null;
+            }
+          }),
+        );
+        return stats.filter(
+          (s): s is { path: string; mtimeMs: number; size: number } => s !== null,
+        );
+      }),
+  );
+
+  return perSession.flat();
 }
 
 // ============================================================================
@@ -347,17 +435,21 @@ export async function aggregateClaudeStats(
   const dir = options.projectDir ?? claudeProjectDirFor(cwd);
   const now = options.now ?? Date.now();
 
-  const files = await listTranscripts(dir);
-  if (files.length === 0) {
+  const [files, subFiles] = await Promise.all([
+    listTranscripts(dir),
+    listSubagentTranscripts(dir),
+  ]);
+  if (files.length === 0 && subFiles.length === 0) {
     return emptyShape(dir, Date.now() - startedAt);
   }
 
-  // Cache key: max(mtime) + sum(size). If neither shifts, the prior
-  // aggregation is still valid. Also folds in the number of files so a
-  // delete invalidates correctly.
-  const maxMtime = files.reduce((m, f) => Math.max(m, f.mtimeMs), 0);
-  const totalSize = files.reduce((s, f) => s + f.size, 0);
-  const cacheKey = `${dir}|${files.length}|${maxMtime}|${totalSize}`;
+  // Cache key: per set, max(mtime) + sum(size) + file count. If none shifts,
+  // the prior aggregation is still valid; a delete in either set (count drops)
+  // invalidates correctly. Subagent transcripts are keyed alongside top-level.
+  const allFiles = [...files, ...subFiles];
+  const maxMtime = allFiles.reduce((m, f) => Math.max(m, f.mtimeMs), 0);
+  const totalSize = allFiles.reduce((s, f) => s + f.size, 0);
+  const cacheKey = `${dir}|${files.length}|${subFiles.length}|${maxMtime}|${totalSize}`;
 
   if (!options.skipCache && cache && cache.key === cacheKey && Date.now() - cache.cachedAt < CACHE_TTL_MS) {
     return cache.value;
@@ -366,14 +458,21 @@ export async function aggregateClaudeStats(
   const agg = makeAggregator();
   for (const f of files) {
     try {
-      await streamFile(agg, f.path, now);
+      await streamFile(agg, f.path, now, false);
     } catch (err) {
       // One bad file shouldn't blank the whole tab.
       console.warn(`[claude-stats] failed to read ${f.path}: ${(err as Error).message ?? err}`);
     }
   }
+  for (const f of subFiles) {
+    try {
+      await streamFile(agg, f.path, now, true);
+    } catch (err) {
+      console.warn(`[claude-stats] failed to read subagent ${f.path}: ${(err as Error).message ?? err}`);
+    }
+  }
 
-  const value = freezeAggregator(agg, dir, Date.now() - startedAt);
+  const value = freezeAggregator(agg, dir, subFiles.length, Date.now() - startedAt);
   cache = { key: cacheKey, value, cachedAt: Date.now() };
   return value;
 }
@@ -392,6 +491,7 @@ function emptyShape(dir: string | null, elapsedMs: number): ClaudeStatsShape {
     windows: { today: empty, last7d: empty, last30d: empty, lifetime: empty },
     models: [],
     tools: [],
+    subagents: { transcripts: 0, tokens: { input: 0, output: 0, cacheCreate: 0, cacheRead: 0, total: 0 } },
     errorSessions: 0,
     sessionDurationMs: { median: 0, p95: 0 },
     totalSessions: 0,
@@ -400,7 +500,12 @@ function emptyShape(dir: string | null, elapsedMs: number): ClaudeStatsShape {
   };
 }
 
-function freezeAggregator(agg: Aggregator, dir: string, elapsedMs: number): ClaudeStatsShape {
+function freezeAggregator(
+  agg: Aggregator,
+  dir: string,
+  subagentTranscripts: number,
+  elapsedMs: number,
+): ClaudeStatsShape {
   const models: ModelDistribution[] = [];
   for (const key of agg.modelMessages.keys()) {
     models.push({
@@ -437,6 +542,20 @@ function freezeAggregator(agg: Aggregator, dir: string, elapsedMs: number): Clau
     },
     models,
     tools,
+    subagents: {
+      transcripts: subagentTranscripts,
+      tokens: {
+        input: agg.subagent.input,
+        output: agg.subagent.output,
+        cacheCreate: agg.subagent.cacheCreate,
+        cacheRead: agg.subagent.cacheRead,
+        total:
+          agg.subagent.input +
+          agg.subagent.output +
+          agg.subagent.cacheCreate +
+          agg.subagent.cacheRead,
+      },
+    },
     errorSessions,
     sessionDurationMs: { median, p95 },
     totalSessions: agg.sessions.size,

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -1344,11 +1344,11 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       // view so the numbers aren't read as account-wide truth.
       const disclaimer =
         '<div style="background:#161b22;border:1px solid #30363d;border-left:3px solid #d29922;border-radius:6px;padding:10px 14px;margin-bottom:16px;color:#c9d1d9;font-size:0.85rem;line-height:1.5">' +
-        '<strong>Local primary-session stats only.</strong> Counts what Claude Code wrote to disk for THIS project on THIS machine. ' +
-        '<strong>Excludes sub-sessions spawned by Task-tool agents</strong> ' +
-        '(e.g. <code>/simplify</code>, <code>/ultrareview</code>, Explore) — their Sonnet/Haiku usage is stored in per-session ' +
-        '<code>subagents/</code> transcripts the dashboard doesn\\'t yet read, so totals here skew toward the primary model. ' +
-        'Also excludes claude.ai web sessions, other projects, other devices, and your account-level plan quota.' +
+        '<strong>Local project stats only.</strong> Counts what Claude Code wrote to disk for THIS project on THIS machine — ' +
+        'including sub-sessions spawned by Task-tool agents (e.g. <code>/flo</code> fan-out, <code>/simplify</code>, Explore), ' +
+        'whose Sonnet/Haiku usage is walked from per-session <code>subagents/</code> transcripts and broken out under ' +
+        '<strong>Context Split</strong> below. ' +
+        'Excludes claude.ai web sessions, other projects, other devices, and your account-level plan quota.' +
         '</div>';
 
       if (!cs.available) {
@@ -1360,6 +1360,22 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       }
 
       const w = cs.windows;
+
+      // Context split — main-loop vs subagent (Task-tool spawn) tokens (#1264).
+      // Subagent totals are included in the lifetime window, so main-loop is the
+      // remainder. Guard against an older server shape lacking a subagents field.
+      const sub = cs.subagents || { transcripts: 0, tokens: { total: 0, input: 0, output: 0, cacheCreate: 0, cacheRead: 0 } };
+      const lifeTotal = w.lifetime.tokens.total;
+      const subTotal = sub.tokens.total;
+      const mainTotal = Math.max(0, lifeTotal - subTotal);
+      const pct = (n) => lifeTotal > 0 ? (n / lifeTotal * 100).toFixed(1) + '%' : '—';
+      const splitTable =
+        '<h2>Context Split (lifetime)</h2>' +
+        '<table><thead><tr><th>Context</th><th>Total Tokens</th><th>Share</th></tr></thead><tbody>' +
+        '<tr><td style="font-weight:600">Main loop</td><td>' + fmtCount(mainTotal) + '</td><td>' + pct(mainTotal) + '</td></tr>' +
+        '<tr><td style="font-weight:600">Subagents <span class="dim">(' + fmtCount(sub.transcripts) + ' transcripts)</span></td>' +
+          '<td>' + fmtCount(subTotal) + '</td><td>' + pct(subTotal) + '</td></tr>' +
+        '</tbody></table>';
 
       // Summary windows (today / 7d / 30d / lifetime).
       const winRow = (label, win) => {
@@ -1390,7 +1406,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
             '<td>' + fmtCount(m.tokens) + '</td></tr>').join('')
         : '<tr><td colspan="3" class="empty">No model data</td></tr>';
       const modelsTable =
-        '<h2>Models Used (primary sessions)</h2>' +
+        '<h2>Models Used</h2>' +
         '<table><thead><tr><th>Model</th><th>Messages</th><th>Total Tokens</th></tr></thead>' +
         '<tbody>' + modelRows + '</tbody></table>';
 
@@ -1407,6 +1423,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
       const cards =
         '<div class="grid">' +
         '<div class="stat-card"><div class="label">Total Sessions</div><div class="value">' + fmtCount(cs.totalSessions) + '</div></div>' +
+        '<div class="stat-card"><div class="label">Subagent Tokens</div><div class="value">' + fmtCount(subTotal) + '</div></div>' +
         '<div class="stat-card"><div class="label">Sessions w/ Errors</div><div class="value">' + fmtCount(cs.errorSessions) + '</div></div>' +
         '<div class="stat-card"><div class="label">Median Duration</div><div class="value">' + fmtDuration(cs.sessionDurationMs.median) + '</div></div>' +
         '<div class="stat-card"><div class="label">p95 Duration</div><div class="value">' + fmtDuration(cs.sessionDurationMs.p95) + '</div></div>' +
@@ -1418,7 +1435,7 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
         (cs.parseErrors ? ' &middot; ' + cs.parseErrors + ' lines skipped (parse error)' : '') +
         '</div>';
 
-      el.innerHTML = disclaimer + cards + winTable + modelsTable + toolsTable + footer;
+      el.innerHTML = disclaimer + cards + winTable + splitTable + modelsTable + toolsTable + footer;
     }
 
     // Polling


### PR DESCRIPTION
## Summary

Makes moflo's Claude Stats **see and surface subagent token spend** — the enabling change that **unblocks #1264** ("is outsized moflo `/usage` attribution driven by subagent fan-out?"). #1264 is "measure first," but the measurement tool was blind to its prime suspect: `claude-stats.ts` walked only top-level `*.jsonl` and skipped `<id>/subagents/agent-*.jsonl` (its own header documented this as a never-filed follow-up).

Two layers, both in this PR:

### 1. Data — walk subagent transcripts (`claude-stats.ts`)

- **Rolls subagent usage into the model distribution + token windows** so totals are complete — the documented #1044 gap (Sonnet/Haiku spend from `/flo` fan-out, `/simplify`, Explore was previously missing).
- **Exposes a distinct `subagents: { transcripts, tokens }` subtotal** — so `main-loop = windows.lifetime.tokens.total − subagents.tokens.total`, the split #1264's AC#1 requires.
- **Folds subagent file count/mtime/size into the 30s TTL cache key**.

Subagent lines carry the **parent `sessionId`**, so they attribute to the right session with no phantom sessions. `subagents` is additive — non-breaking.

### 2. UI — Context Split in the Luminarium "Claude Stats" tab (`daemon-dashboard.ts`)

- New **Context Split (lifetime)** table: main-loop vs subagents, with % share + transcript count.
- New **Subagent Tokens** headline card.
- Corrected the disclaimer, which claimed the dashboard "doesn't yet read" subagent transcripts — it now does, and "Models Used" is no longer primary-only.

```
Context Split (lifetime)
  Main loop                4,550,000   36.7%
  Subagents (47 transcripts)  7,850,000   63.3%
```

## Consumer surface / blast radius

`claude-stats.ts` + the dashboard HTML both power the Luminarium tab. Additive field + additive UI; the dashboard route passes the shape through unchanged. Older server shapes are tolerated by a `cs.subagents || {…}` guard in the client JS.

## Testing

+5 subagent unit tests (subtotal correctness, parent-session attribution, available-when-only-subagents, cache invalidation, skip non-`subagents/` subdirs). Data-layer diff reviewed (no blocking issues: double-count, cache-key, cross-platform all sound). Client JS syntax-validated. Typecheck clean; **full suite green (8219 + 1147 passed, 0 failed)**.

## Cross-platform (Rule #1)

`readdir(withFileTypes)` + `path.join`, ENOENT-tolerant on missing `subagents/` dirs, streaming reads, no hardcoded separators.

Unblocks #1264.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
