### PR TITLE
chore: post-deploy review fixes — Rule #1 path nit + README config-reference gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Inside Claude Code, the `/flo` (or `/fl`) slash command drives GitHub issue exec
 /flo -s <issue>               # Swarm mode (multi-agent coordination)
 /flo -h <issue>               # Hive-mind mode (consensus-based coordination)
 /flo -n <issue>               # Normal mode (default, single agent, no swarm)
-/flo -w <issue>               # Worktree: run the work in a fresh git worktree
+/flo -w <issue>               # Worktree: run the work in a fresh git worktree (aliases: -wt, --worktree)
 /flo -sd <issue>              # SDD: spec → plan → implement → verify (implies --verify)
 /flo -v <issue>               # Verify-before-done only (no spec/plan front-half)
 /flo -m <issue>               # Auto-merge the PR once required checks pass
@@ -583,7 +583,7 @@ Inside a Claude Code session in a moflo project, ask **`/luminarium`** — the s
 | **Schedules** | All registered spell schedules (cron / interval / one-time), with run-now and disable controls |
 | **Executions** | Recent spell runs — duration, exit code, step-by-step output |
 | **Memory** | Memory namespace breakdown, vector count, embedder backend, HNSW index health |
-| **Claude Stats** | Per-session Claude Code transcript stats — tokens, tools called, files touched (local primary sessions only) |
+| **Claude Stats** | Per-session Claude Code transcript stats — tokens (with a subagent-token subtotal that splits main-loop context from Task-tool-spawned subagent context), tools called, files touched (local primary sessions only) |
 
 ### Flags
 
@@ -907,6 +907,13 @@ gates:
   memory_first: true                 # Must search memory before file exploration
   task_create_first: true            # Must TaskCreate before Agent tool
   context_tracking: true             # Track context window depletion
+  verify_before_done: false          # Require /verify before `gh pr create` (unless --no-verify)
+
+sdd:
+  default: false                     # true → every /flo run uses the spec→plan→implement→verify cycle unless --no-sdd
+
+merge:
+  auto: false                        # true → every /flo run auto-merges its PR once preconditions pass, unless --no-merge
 
 auto_index:
   guidance: true                     # Auto-index docs on session start

--- a/src/cli/commands/sdd.ts
+++ b/src/cli/commands/sdd.ts
@@ -19,6 +19,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { locateMofloRootPath } from '../services/moflo-require.js';
@@ -225,7 +226,7 @@ function cmdPath(ctx: CommandContext): CommandResult {
 
 function cmdIndex(ctx: CommandContext): CommandResult {
   const root = projectRoot(ctx);
-  const indexer = locateMofloRootPath('bin/index-guidance.mjs');
+  const indexer = locateMofloRootPath(join('bin', 'index-guidance.mjs'));
   if (!indexer) {
     console.log('Guidance indexer not found; specs will be indexed at next session start.');
     return { success: true };


### PR DESCRIPTION
## What

Post-deployment review of the 10 PRs landed since the **4.11.9** deploy (`install moflo@4.11.9` → HEAD), audited against **CLAUDE.md Rule #1 (cross-platform)** and **consumer blast radius**, plus a README-coverage sweep. Findings were overwhelmingly clean — this PR applies the two actionable items.

## Changes

- **`src/cli/commands/sdd.ts`** — replace the hardcoded `/` in `locateMofloRootPath('bin/index-guidance.mjs')` with `join('bin', 'index-guidance.mjs')`. Functionally equivalent (Node tolerates `/` on Windows) but removes the letter-of-law Rule #1 #1 violation and matches the codebase's own preferred form (`moflo-require.ts:252`).
- **`README.md`** — the **Full Configuration Reference** (billed as "the complete set of options") omitted keys added by #1277 / #1286:
  - add `gates.verify_before_done`, and new top-level `sdd:` and `merge:` blocks
  - note the `-wt` / `--worktree` aliases in the `/flo` flag list
  - mention the new subagent-token subtotal (#1290) in the Luminarium **Claude Stats** row

## Review notes (verified clean — no change needed)

- **#1290 claude-stats subagent walk** — Windows `<encoded-cwd>` round-trips (shared #1048 util collapses drive-colon + backslashes to `-`); JSONL reads use `crlfDelay: Infinity`; no path-identity comparison → no realpath obligation.
- **#1277 SDD** — writes canonical LF, **all reads normalize CRLF→LF**, so Windows-editor round-trips are safe; no shell-outs (`spawnSync(process.execPath, …)`); config additive; upgrader in parity with the template's required sections; new doctor checks are fail-open.
- **#1284 CRLF injection fix** — verified correct/complete (splices raw bytes, block normalized only for the drift compare; CRLF regression tests present).
- **No swarm/hive/agent/task surface touched.**

## Out of scope / flagged separately

The working tree also had an **unrelated, pre-existing** modification to `.claude/settings.json` that removes the `check-before-done` and `record-verify-run` verify-gate hooks (the ones #1277 added). It was **deliberately excluded** from this PR and needs a separate decision — see PR discussion.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` on sdd/, parser, claude-stats, claudemd-injection, movector, doctor-checks-sdd, moflo-config-merge — 152 + 75 passing

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_01Wd4PFgTFCWnK3EJLocQHcL
