### PR TITLE
feat(gate): exempt ephemeral tmp/scratch reads from the memory-first gate (#1294 Finding 3)

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var cp = require('child_process');
+var os = require('os');
 
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
@@ -87,6 +88,28 @@ var config = loadGateConfig();
 var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
+
+// #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
+// (background-task output/transcripts, agent scratchpads) are transient tool
+// I/O and never carry indexable project knowledge, so they must not trip the
+// memory-first gate. Cross-platform (Rule #1): os.tmpdir() is correct on every
+// OS; we normalize a leading `/private` on both sides so macOS's
+// /var/folders (os.tmpdir) vs /private/var/folders (realpath) symlink pair
+// still matches (CLAUDE.md #1145). Never hardcode `/tmp`.
+function stripPrivate(p) { return p.indexOf('/private/') === 0 ? p.slice('/private'.length) : p; }
+function isEphemeralPath(fp) {
+  if (!fp) return false;
+  var tmp;
+  try { tmp = path.resolve(os.tmpdir()); } catch (e) { return false; }
+  var t = stripPrivate(tmp);
+  function under(p) { var n = stripPrivate(p); return n === t || n.indexOf(t + path.sep) === 0; }
+  var resolved = path.resolve(fp);
+  if (!under(resolved)) return false;
+  // Under tmp by literal path — confirm it isn't a symlink staged in tmp that
+  // dereferences to a real project file (realpath BOTH sides, CLAUDE.md Rule #2).
+  // On ENOENT (a not-yet-created tmp file) keep the verdict — still ephemeral.
+  try { return under(fs.realpathSync(resolved)); } catch (e) { return true; }
+}
 // #1171 — DANGEROUS gained PowerShell additions to match the matcher widening
 // that now routes the dedicated `PowerShell` tool through check-dangerous-command.
 // POSIX entries still apply because PS will execute them when invoked. Substring
@@ -531,6 +554,7 @@ switch (command) {
     var s = readState();
     if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
+    if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
     process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n');
     process.exit(2);
@@ -540,6 +564,9 @@ switch (command) {
     var s = readState();
     if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var fp = process.env.TOOL_INPUT_file_path || '';
+    // Ephemeral tmp/scratch reads are exempt even when they look like guidance
+    // (a temp copy is still transient tool I/O, not the indexed source).
+    if (isEphemeralPath(fp)) break;
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
     process.stderr.write('BLOCKED: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n');

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var cp = require('child_process');
+var os = require('os');
 
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
@@ -87,6 +88,28 @@ var config = loadGateConfig();
 var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
+
+// #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
+// (background-task output/transcripts, agent scratchpads) are transient tool
+// I/O and never carry indexable project knowledge, so they must not trip the
+// memory-first gate. Cross-platform (Rule #1): os.tmpdir() is correct on every
+// OS; we normalize a leading `/private` on both sides so macOS's
+// /var/folders (os.tmpdir) vs /private/var/folders (realpath) symlink pair
+// still matches (CLAUDE.md #1145). Never hardcode `/tmp`.
+function stripPrivate(p) { return p.indexOf('/private/') === 0 ? p.slice('/private'.length) : p; }
+function isEphemeralPath(fp) {
+  if (!fp) return false;
+  var tmp;
+  try { tmp = path.resolve(os.tmpdir()); } catch (e) { return false; }
+  var t = stripPrivate(tmp);
+  function under(p) { var n = stripPrivate(p); return n === t || n.indexOf(t + path.sep) === 0; }
+  var resolved = path.resolve(fp);
+  if (!under(resolved)) return false;
+  // Under tmp by literal path — confirm it isn't a symlink staged in tmp that
+  // dereferences to a real project file (realpath BOTH sides, CLAUDE.md Rule #2).
+  // On ENOENT (a not-yet-created tmp file) keep the verdict — still ephemeral.
+  try { return under(fs.realpathSync(resolved)); } catch (e) { return true; }
+}
 // #1171 — DANGEROUS gained PowerShell additions to match the matcher widening
 // that now routes the dedicated `PowerShell` tool through check-dangerous-command.
 // POSIX entries still apply because PS will execute them when invoked. Substring
@@ -531,6 +554,7 @@ switch (command) {
     var s = readState();
     if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
+    if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
     process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n');
     process.exit(2);
@@ -540,6 +564,9 @@ switch (command) {
     var s = readState();
     if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var fp = process.env.TOOL_INPUT_file_path || '';
+    // Ephemeral tmp/scratch reads are exempt even when they look like guidance
+    // (a temp copy is still transient tool I/O, not the indexed source).
+    if (isEphemeralPath(fp)) break;
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
     process.stderr.write('BLOCKED: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n');

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -213,6 +213,7 @@ export function generateGateScript(): string {
 'use strict';
 var fs = require('fs');
 var path = require('path');
+var os = require('os');
 
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\\/([a-z])\\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
@@ -288,6 +289,22 @@ var config = loadGateConfig();
 var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
+// #1294 Finding 3 — exempt ephemeral reads/scans under the OS temp dir
+// (background-task output, scratchpads) from the memory-first gate. Mirrors
+// bin/gate.cjs isEphemeralPath. Cross-platform via os.tmpdir(); normalizes a
+// leading /private so macOS /var-vs-/private/var symlink pairs match.
+function stripPrivate(p) { return p.indexOf('/private/') === 0 ? p.slice('/private'.length) : p; }
+function isEphemeralPath(fp) {
+  if (!fp) return false;
+  var tmp;
+  try { tmp = path.resolve(os.tmpdir()); } catch (e) { return false; }
+  var t = stripPrivate(tmp);
+  function under(p) { var n = stripPrivate(p); return n === t || n.indexOf(t + path.sep) === 0; }
+  var resolved = path.resolve(fp);
+  if (!under(resolved)) return false;
+  // Symlink staged in tmp could deref to a real file — realpath both (Rule #2).
+  try { return under(fs.realpathSync(resolved)); } catch (e) { return true; }
+}
 // #1171 — DANGEROUS gained PS additions to match the matcher widening that now
 // routes the PowerShell tool through check-dangerous-command. See bin/gate.cjs.
 var DANGEROUS = ['rm -rf /', 'format c:', 'del /s /q c:\\\\', ':(){:|:&};:', 'mkfs.', '> /dev/sda', 'remove-item -recurse -force c:\\\\', 'remove-item -recurse -force /', 'remove-item -recurse -force ~', 'format-volume', 'clear-disk'];
@@ -487,6 +504,7 @@ switch (command) {
     var s = readState();
     if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
+    if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
     process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search.\\n');
     process.exit(2);
@@ -496,6 +514,7 @@ switch (command) {
     var s = readState();
     if (!s.memoryRequired || isMemorySearchedFor(s)) break;
     var fp = process.env.TOOL_INPUT_file_path || '';
+    if (isEphemeralPath(fp)) break;
     if (fp.indexOf('.claude/guidance/') < 0 && fp.indexOf('.claude\\\\guidance\\\\') < 0) break;
     process.stderr.write('BLOCKED: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\n');
     process.exit(2);

--- a/src/cli/services/spell-gate.ts
+++ b/src/cli/services/spell-gate.ts
@@ -18,6 +18,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { atomicWriteFileSync } from './atomic-file-write.js';
 import { loadMofloConfig } from '../config/moflo-config.js';
 
@@ -111,6 +112,29 @@ const EXEMPT_PATTERNS = [
   'workflow-state',
   'node_modules',
 ];
+
+/**
+ * True when `fp` is an ephemeral file under the OS temp dir (background-task
+ * output/transcripts, agent scratchpads). Such transient tool I/O carries no
+ * indexable project knowledge, so it is exempt from the memory-first gate
+ * (#1294 Finding 3). Mirrors `bin/gate.cjs isEphemeralPath` — keep in sync.
+ * Cross-platform (Rule #1): os.tmpdir() is correct on every OS; a leading
+ * `/private` is normalized on both sides so macOS's /var-vs-/private/var
+ * tmpdir symlink pair still matches (CLAUDE.md #1145). Never hardcode `/tmp`.
+ */
+function isEphemeralPath(fp?: string): boolean {
+  if (!fp) return false;
+  const stripPrivate = (p: string) => (p.startsWith('/private/') ? p.slice('/private'.length) : p);
+  let tmp: string;
+  try { tmp = path.resolve(os.tmpdir()); } catch { return false; }
+  const t = stripPrivate(tmp);
+  const under = (p: string) => { const n = stripPrivate(p); return n === t || n.startsWith(t + path.sep); };
+  const resolved = path.resolve(fp);
+  if (!under(resolved)) return false;
+  // Symlink staged in tmp could point at a real project file — realpath BOTH
+  // sides (CLAUDE.md Rule #2). ENOENT (not-yet-created tmp file) stays ephemeral.
+  try { return under(fs.realpathSync(resolved)); } catch { return true; }
+}
 
 // ============================================================================
 // Service
@@ -211,9 +235,9 @@ export class GateService {
       return { allowed: true };
     }
 
-    // Exempt system paths
+    // Exempt system paths and ephemeral tmp/scratch targets (#1294 Finding 3)
     const target = `${pattern || ''} ${searchPath || ''}`;
-    if (EXEMPT_PATTERNS.some(p => target.includes(p))) {
+    if (isEphemeralPath(searchPath) || EXEMPT_PATTERNS.some(p => target.includes(p))) {
       return { allowed: true };
     }
 
@@ -248,6 +272,11 @@ export class GateService {
     const state = this.readState();
 
     if (state.memorySearched) {
+      return { allowed: true };
+    }
+
+    // Ephemeral tmp/scratch reads are exempt (#1294 Finding 3).
+    if (isEphemeralPath(filePath)) {
       return { allowed: true };
     }
 

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync, execFileSync, spawn, spawnSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, symlinkSync } from 'fs';
 import { resolve, join } from 'path';
 import { tmpdir } from 'os';
 
@@ -366,6 +366,15 @@ describe('gate.cjs: check-before-scan', () => {
     expect(r.exitCode).toBe(0);
   });
 
+  it('exempts scans under the OS temp dir (Finding 3, #1294)', () => {
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_path = join(tmpdir(), 'claude-1000', 'scratch');
+    const r = runGate('check-before-scan', env);
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('BLOCKED');
+  });
+
   it('allows when memoryRequired is false', () => {
     writeState(tmpDir, { memoryRequired: false, memorySearched: false });
     const env = baseEnv(tmpDir);
@@ -412,6 +421,54 @@ describe('gate.cjs: check-before-read', () => {
     env.TOOL_INPUT_file_path = '/project/.claude/settings.json';
     const r = runGate('check-before-read', env);
     expect(r.exitCode).toBe(0);
+  });
+
+  it('exempts ephemeral reads under the OS temp dir (Finding 3, #1294)', () => {
+    // Background-task output / scratchpad files are transient tool I/O — reading
+    // them must not demand a memory search. os.tmpdir() is the same in the gate
+    // subprocess as here, so a path under it is recognised as ephemeral.
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_file_path = join(tmpdir(), 'claude-1000', 'proj', 'sess', 'tasks', 'abc.output');
+    const r = runGate('check-before-read', env);
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('BLOCKED');
+  });
+
+  it('still blocks a real project file whose name merely contains "tmp"', () => {
+    // Guard against an over-broad substring match — /project/tmp-notes.md is NOT
+    // under the OS temp dir, so it stays gated.
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_file_path = '/project/tmp-notes.md';
+    const r = runGate('check-before-read', env);
+    expect(r.exitCode).toBe(2);
+  });
+
+  it('exempts a tmp path even when it contains ".claude/guidance/" (ephemeral check runs first)', () => {
+    // Ordering regression guard: isEphemeralPath must win over the guidance check.
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_file_path = join(tmpdir(), '.claude', 'guidance', 'foo.md');
+    const r = runGate('check-before-read', env);
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('still gates a symlink under tmp that dereferences to a real project file (Rule #2 realpath)', () => {
+    // A link staged in tmp pointing at a real file must NOT be exempted — realpath
+    // escapes tmp, so the gate still applies. (Symlink creation needs privileges
+    // on Windows; skip gracefully there rather than fail.)
+    const link = join(tmpDir, 'sneaky-link.ts');
+    try {
+      symlinkSync(__filename, link); // __filename is a real repo file, not under os.tmpdir()
+    } catch {
+      return; // no symlink privilege (Windows) — nothing to assert
+    }
+    writeState(tmpDir, { memoryRequired: true, memorySearched: false });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_file_path = link;
+    const r = runGate('check-before-read', env);
+    expect(r.exitCode).toBe(2);
   });
 
   it('does NOT exempt .claude/guidance/ from read gate', () => {


### PR DESCRIPTION
## Summary

Closes the last open item from #1294 (Finding 3). The memory-first `check-before-read` gate blocks **all** non-`EXEMPT` reads until a memory search runs — which includes **background-task output and scratchpad files under the OS temp dir**. Those are transient tool I/O with no indexable project knowledge, so reading them shouldn't demand a semantic memory search. (This friction recurred throughout the #1294 work itself.)

## What changed

Adds `isEphemeralPath(fp)` — exempts reads/scans whose path resolves under `os.tmpdir()` — wired as an early-exempt into **both** `check-before-read` and `check-before-scan`, across the representations that must stay consistent:

| File | Role |
|------|------|
| `bin/gate.cjs` | canonical runtime gate |
| `.claude/helpers/gate.cjs` | byte-identical twin (`post-install-bootstrap` asserts) |
| `src/cli/init/helpers-generator.ts` | the `flo init` template shipped to consumers |
| `src/cli/services/spell-gate.ts` | TS `flo gate` CLI path |

## Cross-platform (Rule #1)

`os.tmpdir()` (never a hardcoded `/tmp`), `path.resolve` + `path.sep`, and a `/private` normalization so macOS's `/var/folders` (tmpdir) vs `/private/var/folders` (realpath) symlink pair matches (#1145). Segment-boundary check so `/tmp` never false-matches `/tmpfoo`.

## 3-agent review hardening (before this PR opened)

- **Security (realpath):** a symlink staged *inside* tmp pointing at a real project file had a literal-under-tmp path and would've been exempted. Now `realpathSync` the candidate — **scoped to only paths already resolving under tmp**, so the common non-tmp read never pays for it — and a symlink that dereferences out of tmp stays gated (CLAUDE.md Rule #2). ENOENT (not-yet-created tmp file) stays ephemeral.
- **Consistency gap:** the init template's `check-before-read` is narrow (guidance-only) and originally got the exemption on `check-before-scan` only. Now both paths honor it, so consumers get identical behavior to `bin/gate.cjs`.

## Testing

- [x] `gate-helpers.test.ts` (**268**, isolation config): tmp read exempt · tmp scan exempt · over-match guard (`/project/tmp-notes.md` still blocks) · tmp-path-containing-`.claude/guidance/` ordering · **symlink-escape still gated** (Windows-safe skip)
- [x] TS `spell-gate` parity (**199**)
- [x] `isEphemeralPath` node validation: 9 cross-platform cases (macOS `/private` both directions, `/tmpfoo` boundary) + real-symlink escape + ENOENT
- [x] `tsc` clean; twin `diff -q` identical
- [x] `/verify` — PASS on all 6 criteria

Addresses #1294 (Finding 3)