### PR TITLE
fix(init): auto-approve moflo MCP tools via bare server prefix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -302,7 +302,7 @@
       "MultiEdit(*)",
       "Glob(*)",
       "Grep(*)",
-      "mcp__moflo__:*"
+      "mcp__moflo"
     ],
     "deny": [
       "Read(./.env)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1761,21 +1761,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2562,9 +2575,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -3128,9 +3141,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
-      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "funding": [
         {
           "type": "github",
@@ -4622,17 +4635,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/src/cli/__tests__/commands/doctor-mcp-permissions.test.ts
+++ b/src/cli/__tests__/commands/doctor-mcp-permissions.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for `checkMcpToolPermissions` and its companion `MCP Tool Permissions`
+ * auto-fixer (#1300).
+ *
+ * Failure mode being guarded against: the settings-generator emitted
+ * `mcp__moflo__:*` into `.claude/settings.json` `permissions.allow`. Claude Code
+ * does NOT support wildcards in MCP permission rules, so that string matched no
+ * real tool name and every `mcp__moflo__…` call fell through to a permission
+ * prompt in every consumer install. The generator is fixed going forward; this
+ * check + fix heals already-generated settings.json files in place.
+ *
+ * ## Test isolation
+ *
+ * The check + fix resolve `.claude/settings.json` under `process.cwd()` /
+ * `findProjectRoot()`. We anchor both on a tmp dir via `CLAUDE_PROJECT_DIR`
+ * (honored ahead of any FS walk) plus `process.chdir`, and restore afterwards.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { checkMcpToolPermissions } from '../../commands/doctor-checks-config.js';
+import { autoFixCheck } from '../../commands/doctor-fixes.js';
+
+let tmpDir: string;
+let originalCwd: string;
+let savedProjectDir: string | undefined;
+
+function writeSettings(allow: string[]): string {
+  const claudeDir = join(tmpDir, '.claude');
+  mkdirSync(claudeDir, { recursive: true });
+  const settingsPath = join(claudeDir, 'settings.json');
+  writeFileSync(settingsPath, JSON.stringify({ permissions: { allow, deny: [] } }, null, 2));
+  return settingsPath;
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'moflo-mcp-perms-'));
+  originalCwd = process.cwd();
+  savedProjectDir = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_PROJECT_DIR = tmpDir;
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (savedProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = savedProjectDir;
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe('checkMcpToolPermissions', () => {
+  it('passes when there is no .claude/settings.json', async () => {
+    const result = await checkMcpToolPermissions(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('nothing to verify');
+  });
+
+  it('warns on the malformed mcp__moflo__:* wildcard rule', async () => {
+    writeSettings(['Bash(*)', 'mcp__moflo__:*']);
+    const result = await checkMcpToolPermissions(tmpDir);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('mcp__moflo__:*');
+    expect(result.fix).toBe('flo healer --fix -c mcp-permissions');
+  });
+
+  it('warns on a mcp__moflo__* asterisk pattern too', async () => {
+    writeSettings(['mcp__moflo__*']);
+    const result = await checkMcpToolPermissions(tmpDir);
+    expect(result.status).toBe('warn');
+  });
+
+  it('passes with the correct bare mcp__moflo prefix', async () => {
+    writeSettings(['Bash(*)', 'mcp__moflo']);
+    const result = await checkMcpToolPermissions(tmpDir);
+    expect(result.status).toBe('pass');
+  });
+
+  it('does NOT warn on a valid exact-tool rule (no wildcard)', async () => {
+    // A consumer scoping to individual tools is legitimate — must not fire.
+    writeSettings(['mcp__moflo__memory_store', 'mcp__moflo__memory_search']);
+    const result = await checkMcpToolPermissions(tmpDir);
+    expect(result.status).toBe('pass');
+  });
+
+  it('does not double-report malformed settings.json (owned by Status Line)', async () => {
+    const claudeDir = join(tmpDir, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, 'settings.json'), '{ not valid json');
+    const result = await checkMcpToolPermissions(tmpDir);
+    expect(result.status).toBe('pass');
+  });
+});
+
+describe('autoFixCheck repairs the malformed moflo MCP permission', () => {
+  it('drops the wildcard rule, adds the bare prefix, preserves other rules', async () => {
+    const settingsPath = writeSettings(['Bash(*)', 'Read(*)', 'mcp__moflo__:*']);
+
+    const ok = await autoFixCheck({
+      name: 'MCP Tool Permissions',
+      status: 'warn',
+      message: 'malformed moflo MCP permission rule',
+      fix: 'flo healer --fix -c mcp-permissions',
+    });
+    expect(ok).toBe(true);
+
+    const allow = JSON.parse(readFileSync(settingsPath, 'utf8')).permissions.allow as string[];
+    expect(allow).not.toContain('mcp__moflo__:*');
+    expect(allow).toContain('mcp__moflo');
+    // Unrelated rules survive untouched.
+    expect(allow).toContain('Bash(*)');
+    expect(allow).toContain('Read(*)');
+  });
+
+  it('preserves valid exact-tool rules while adding the bare prefix', async () => {
+    const settingsPath = writeSettings(['mcp__moflo__memory_store', 'mcp__moflo__:*']);
+
+    await autoFixCheck({
+      name: 'MCP Tool Permissions',
+      status: 'warn',
+      message: 'malformed moflo MCP permission rule',
+      fix: 'flo healer --fix -c mcp-permissions',
+    });
+
+    const allow = JSON.parse(readFileSync(settingsPath, 'utf8')).permissions.allow as string[];
+    expect(allow).toContain('mcp__moflo__memory_store'); // valid exact tool kept
+    expect(allow).toContain('mcp__moflo');               // bare prefix added
+    expect(allow).not.toContain('mcp__moflo__:*');       // malformed dropped
+  });
+
+  it('is idempotent — a re-run over healed settings makes no change and the check passes', async () => {
+    const settingsPath = writeSettings(['mcp__moflo__:*']);
+    await autoFixCheck({
+      name: 'MCP Tool Permissions', status: 'warn', message: 'x',
+      fix: 'flo healer --fix -c mcp-permissions',
+    });
+    const afterFirst = readFileSync(settingsPath, 'utf8');
+
+    const recheck = await checkMcpToolPermissions(tmpDir);
+    expect(recheck.status).toBe('pass');
+
+    await autoFixCheck({
+      name: 'MCP Tool Permissions', status: 'warn', message: 'x',
+      fix: 'flo healer --fix -c mcp-permissions',
+    });
+    expect(readFileSync(settingsPath, 'utf8')).toBe(afterFirst);
+  });
+
+  it('writes via atomic rename — no leftover temp debris', async () => {
+    writeSettings(['mcp__moflo__:*']);
+    await autoFixCheck({
+      name: 'MCP Tool Permissions', status: 'warn', message: 'x',
+      fix: 'flo healer --fix -c mcp-permissions',
+    });
+    const debris = readdirSync(join(tmpDir, '.claude')).filter((f) => f.includes('.tmp.'));
+    expect(debris).toEqual([]);
+  });
+});

--- a/src/cli/__tests__/services/hook-block-hash.test.ts
+++ b/src/cli/__tests__/services/hook-block-hash.test.ts
@@ -31,6 +31,21 @@ describe('hook-block-hash — reference parity with settings-generator', () => {
     const reference = getReferenceHookBlock();
     expect(computeHookBlockHash(reference)).toBe(computeHookBlockHash(settings.hooks));
   });
+
+  // Regression: the generated permissions must auto-approve every moflo MCP
+  // tool. Claude Code does NOT support wildcards in MCP permission rules, so the
+  // bare `mcp__moflo` server prefix is the ONLY correct "all tools" form. The
+  // prior `mcp__moflo__:*` matched no real tool name and silently prompted the
+  // user for every mcp__moflo__ call in every consumer install.
+  it('permissions.allow auto-approves all moflo MCP tools via the bare server prefix', () => {
+    const settings = generateSettings(DEFAULT_INIT_OPTIONS) as {
+      permissions?: { allow?: string[] };
+    };
+    const allow = settings.permissions?.allow ?? [];
+    expect(allow).toContain('mcp__moflo');
+    // No malformed pattern-style MCP rule (wildcards are unsupported for MCP).
+    expect(allow.some(rule => /^mcp__moflo__.*[:*]/.test(rule))).toBe(false);
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -91,6 +91,65 @@ export async function checkStatusLine(): Promise<HealthCheck> {
   }
 }
 
+/**
+ * #1300 — the generated `.claude/settings.json` must auto-approve every moflo
+ * MCP tool via the bare `mcp__moflo` server prefix.
+ *
+ * Claude Code does NOT support wildcards in MCP permission rules. The bare
+ * `mcp__<server>` prefix is the only "all tools from this server" form;
+ * `mcp__server__tool` names a single tool. The settings-generator historically
+ * emitted `mcp__moflo__:*`, a wildcard attempt that matches no real tool name,
+ * so every `mcp__moflo__…` call fell through to a permission prompt in every
+ * consumer install (the generator is fixed going forward, but already-generated
+ * settings.json files still carry the stale rule until repaired).
+ *
+ * Detection is deliberately narrow — it fires ONLY on a malformed pattern-style
+ * rule (`mcp__moflo__` followed by a `:` or `*` wildcard), never on a valid
+ * exact-tool rule like `mcp__moflo__memory_store` (which a consumer may list
+ * intentionally). The companion auto-fix (`fixMcpToolPermissions` in
+ * doctor-fixes.ts) drops the malformed rule(s) and ensures the bare prefix.
+ *
+ * Status semantics:
+ *   - pass — no `.claude/settings.json` (fresh fixture; nothing we own to
+ *     assert), OR the file carries no malformed `mcp__moflo__*` pattern rule.
+ *   - warn — a malformed `mcp__moflo__…` wildcard rule is present. Auto-fixable.
+ */
+const MALFORMED_MOFLO_MCP_RULE = /^mcp__moflo__.*[:*]/;
+
+export async function checkMcpToolPermissions(cwd: string = process.cwd()): Promise<HealthCheck> {
+  const name = 'MCP Tool Permissions';
+  const settingsPath = join(cwd, '.claude', 'settings.json');
+  if (!existsSync(settingsPath)) {
+    return { name, status: 'pass', message: 'No .claude/settings.json (nothing to verify)' };
+  }
+
+  let allow: string[];
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as {
+      permissions?: { allow?: unknown };
+    };
+    const raw = settings.permissions?.allow;
+    allow = Array.isArray(raw) ? raw.filter((r): r is string => typeof r === 'string') : [];
+  } catch {
+    // Malformed settings.json is owned by checkStatusLine — don't double-report.
+    return { name, status: 'pass', message: 'settings.json unreadable (reported by Status Line)' };
+  }
+
+  const malformed = allow.filter(rule => MALFORMED_MOFLO_MCP_RULE.test(rule));
+  if (malformed.length > 0) {
+    return {
+      name,
+      status: 'warn',
+      message:
+        `Malformed moflo MCP permission rule (Claude Code has no MCP wildcards): ${malformed.join(', ')} — ` +
+        `matches no real tool name, so every moflo MCP call prompts. Use the bare \`mcp__moflo\` prefix.`,
+      fix: 'flo healer --fix -c mcp-permissions',
+    };
+  }
+
+  return { name, status: 'pass', message: 'moflo MCP tools auto-approved (no malformed rule)' };
+}
+
 // Delegates to daemon-lock module for proper PID + command-line verification
 // (avoids Windows PID-recycling false positives).
 export async function checkDaemonStatus(): Promise<HealthCheck> {

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -745,6 +745,36 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     'Nested .moflo/ Islands': async () => {
       return fixNestedMofloIslands();
     },
+    // #1300 — rewrite a malformed moflo MCP permission rule in
+    // .claude/settings.json. Claude Code has no MCP wildcards, so the stale
+    // `mcp__moflo__:*` (and any `mcp__moflo__…[:*]` pattern) matched no tool and
+    // every moflo MCP call prompted. Drop the malformed rule(s), ensure the bare
+    // `mcp__moflo` prefix (approves all tools), and preserve any valid exact-tool
+    // rules the consumer added. Atomic swap so Claude Code re-reading settings
+    // mid-fix never sees a truncated file.
+    'MCP Tool Permissions': async () => {
+      const settingsPath = join(process.cwd(), '.claude', 'settings.json');
+      if (!existsSync(settingsPath)) return false;
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as {
+          permissions?: { allow?: unknown };
+        };
+        const perms = (settings.permissions ??= {});
+        const rawAllow = Array.isArray(perms.allow) ? perms.allow : [];
+        const malformed = /^mcp__moflo__.*[:*]/;
+        const cleaned = rawAllow.filter(
+          (r): r is string => typeof r === 'string' && !malformed.test(r),
+        );
+        if (!cleaned.includes('mcp__moflo')) cleaned.push('mcp__moflo');
+        perms.allow = cleaned;
+        atomicWriteFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+        output.writeln(output.dim('  Rewrote moflo MCP permission to the bare `mcp__moflo` prefix.'));
+        return true;
+      } catch (e) {
+        output.writeln(output.warning(`  MCP permission repair failed: ${errorDetail(e)}`));
+        return false;
+      }
+    },
     'Status Line': async () => {
       const settingsPath = join(process.cwd(), '.claude', 'settings.json');
       if (!existsSync(settingsPath)) return false;

--- a/src/cli/commands/doctor-registry.ts
+++ b/src/cli/commands/doctor-registry.ts
@@ -42,6 +42,7 @@ import {
   checkDaemonStatus,
   checkDaemonWriteRouting,
   checkMcpServers,
+  checkMcpToolPermissions,
   checkMemoryDatabase,
   checkMemoryDbIntegrity,
   checkMemoryFirstGate,
@@ -83,6 +84,10 @@ export const allChecks: CheckFn[] = [
   // #1229 — loud tripwire for a silently-disabled memory_first gate.
   checkMemoryFirstGate,
   checkStatusLine,
+  // #1300 — standing detector for a malformed moflo MCP permission rule in
+  // .claude/settings.json (the `mcp__moflo__:*` wildcard that Claude Code can't
+  // match, so every moflo MCP call prompts). Cheap: one settings.json read.
+  checkMcpToolPermissions,
   checkDaemonStatus,
   checkDaemonVersionSkew,
   checkDaemonIdentity,
@@ -192,6 +197,9 @@ export const componentMap: Record<string, CheckFn> = {
   'hygiene': checkEmbeddingHygiene,
   'git': checkGit,
   'mcp': checkMcpServers,
+  'mcp-permissions': checkMcpToolPermissions,
+  'mcp-perms': checkMcpToolPermissions,
+  'mcp-tool-permissions': checkMcpToolPermissions,
   'disk': checkDiskSpace,
   'typescript': checkBuildTools,
   'tests': checkTestDirs,

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -32,7 +32,11 @@ export function generateSettings(options: InitOptions): object {
       'MultiEdit(*)',
       'Glob(*)',
       'Grep(*)',
-      'mcp__moflo__:*',
+      // Approve every moflo MCP tool. Claude Code does NOT support wildcards in
+      // MCP permission rules — the bare `mcp__<server>` prefix is the canonical
+      // "all tools from this server" form. The prior `mcp__moflo__:*` matched no
+      // real tool name, so every mcp__moflo__ call fell through to a prompt.
+      'mcp__moflo',
     ],
     deny: [
       'Read(./.env)',


### PR DESCRIPTION
## Summary

The settings-generator emitted `mcp__moflo__:*` into every consumer's `.claude/settings.json` `permissions.allow`. **Claude Code does not support wildcards in MCP permission rules** — the bare `mcp__<server>` prefix is the only "approve all tools from this server" form. As written, `mcp__moflo__:*` matches no real tool name, so **every `mcp__moflo__…` call fell through to a permission prompt in every consumer install**. `Bash(*)`/`Read(*)`/etc. were unaffected, which is why only the moflo MCP tools prompted.

Surfaced by the maintainer repeatedly being prompted for moflo MCP operations in a repo whose `permissions.allow` already "included" moflo.

## Changes

**The fix (all new / regenerated consumers):**
- **`src/cli/init/settings-generator.ts`** — emit `mcp__moflo`.
- **`.claude/settings.json`** — repair this repo's already-generated config.
- **`hook-block-hash.test.ts`** — regression test: `permissions.allow` must contain `mcp__moflo` and no malformed pattern-style MCP rule.

**The heal (existing consumers, no regeneration needed):**
- **`checkMcpToolPermissions`** (`doctor-checks-config.ts`) — standing doctor check that warns when `.claude/settings.json` carries a malformed `mcp__moflo__…[:*]` wildcard rule. Narrow by design: never fires on a valid exact-tool rule like `mcp__moflo__memory_store`; passes when settings.json is absent (adds no consumer-smoke warn).
- **Registry** (`doctor-registry.ts`) — `allChecks` + component slugs `mcp-permissions` / `mcp-perms` / `mcp-tool-permissions`.
- **`MCP Tool Permissions` fix** (`doctor-fixes.ts`) — drops the malformed rule(s), ensures the bare `mcp__moflo`, preserves valid exact-tool + unrelated rules, atomic write, idempotent.
- **`doctor-mcp-permissions.test.ts`** — 10 cases: pass/warn detection + round-trip fix.

Now `/healer --fix` (or `flo doctor --fix -c mcp-permissions`) repairs an already-generated settings.json in place.

## Consumer impact (Rule #2)

- **Surface:** `init/settings-generator` (every `flo init` / regen) + `doctor` (the healer). High blast radius, both now correct.
- **Failure mode for on-current-version consumers:** they carry the stale `mcp__moflo__:*` and keep getting prompted — until they run `/healer --fix`, which now heals it in place (no regen required).
- **Round-trip:** publish + reinstall for the generator + healer to reach consumers; the local `.claude/settings.json` edit takes effect on the next Claude Code restart.

## Testing

- [x] `doctor-mcp-permissions.test.ts` (10) — new check + fix
- [x] `hook-block-hash.test.ts` (27) — incl. permissions regression test
- [x] `doctor-moflo-yaml` + `doctor-mcp-malformed` (32) — no registry regression
- [x] `npm run build` — tsc clean
- Config + generator change; Rule #1 cross-platform: `path.join`, atomic write, no shell/hardcoded separators