### PR TITLE
fix(healer): decouple SDD/verify wiring check & stop false-positive --fix on locked hooks (#1301)

### DIFF
--- a/src/cli/__tests__/commands/doctor-fixes-sdd-wiring.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-sdd-wiring.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the `SDD + Verify Wiring` auto-fix handler (#1301).
+ *
+ * The pre-fix behaviour fell through to `npx moflo init --fix` and reported
+ * `applied: true` on the command's exit code alone — even when the hook block
+ * was LOCKED and init injected nothing. That false positive left a
+ * permanently-red check the healer could never clear. The handler must now:
+ *   - return FALSE (honest) when the block is locked and hooks are missing, and
+ *   - actually graft the missing SDD/verify reference entries + re-verify from
+ *     disk on an unlocked block, returning TRUE only when the wiring landed.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { autoFixCheck } from '../../commands/doctor-fixes.js';
+
+let originalCwd: string;
+let tmpDir: string;
+let prevEnv: string | undefined;
+
+const CHECK: Parameters<typeof autoFixCheck>[0] = {
+  name: 'SDD + Verify Wiring',
+  status: 'fail',
+  message: 'incomplete',
+  fix: 'npx moflo init --fix',
+};
+
+function seedGate(cases: string[]): void {
+  const helpers = join(tmpDir, '.claude', 'helpers');
+  mkdirSync(helpers, { recursive: true });
+  writeFileSync(join(helpers, 'gate.cjs'), cases.map((c) => `case '${c}': { break; }`).join('\n'));
+}
+
+function seedSettings(obj: unknown): void {
+  writeFileSync(join(tmpDir, '.claude', 'settings.json'), JSON.stringify(obj, null, 2));
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = mkdtempSync(join(tmpdir(), 'moflo-sdd-fix-'));
+  process.chdir(tmpDir);
+  prevEnv = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_PROJECT_DIR = tmpDir;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (prevEnv === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = prevEnv;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('SDD + Verify Wiring auto-fix (#1301)', () => {
+  it('returns false (no false positive) when the hook block is locked and hooks are missing', async () => {
+    // sdd off + verify on (default). gate.cjs complete, but settings.json is
+    // locked and lacks the verify hooks — moflo must not claim a fix it can't make.
+    seedGate(['check-before-done', 'record-verify-run']);
+    seedSettings({ moflo: { hooks: { locked: true } }, hooks: {} });
+    writeFileSync(join(tmpDir, 'moflo.yaml'), 'project:\n  name: t\n');
+
+    const before = readFileSync(join(tmpDir, '.claude', 'settings.json'), 'utf8');
+    const ok = await autoFixCheck(CHECK);
+
+    expect(ok).toBe(false);
+    // The locked block is left byte-for-byte untouched.
+    expect(readFileSync(join(tmpDir, '.claude', 'settings.json'), 'utf8')).toBe(before);
+  });
+
+  it('wires the missing verify hooks and reports true on an unlocked block', async () => {
+    // sdd off + verify on (default). gate.cjs complete; settings.json unlocked
+    // but missing the verify hook tokens ⇒ handler grafts them and re-verifies.
+    seedGate(['check-before-done', 'record-verify-run']);
+    seedSettings({ hooks: {} });
+    writeFileSync(join(tmpDir, 'moflo.yaml'), 'project:\n  name: t\n');
+
+    const ok = await autoFixCheck(CHECK);
+
+    expect(ok).toBe(true);
+    const after = readFileSync(join(tmpDir, '.claude', 'settings.json'), 'utf8');
+    expect(after).toMatch(/check-before-done/);
+    expect(after).toMatch(/record-verify-run/);
+    // Scoped graft — the SDD implement gate is NOT pulled in (sdd.default=false).
+    expect(after).not.toMatch(/check-before-implement/);
+  });
+});

--- a/src/cli/__tests__/commands/doctor-fixes-sdd-wiring.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-sdd-wiring.test.ts
@@ -9,10 +9,23 @@
  *   - actually graft the missing SDD/verify reference entries + re-verify from
  *     disk on an unlocked block, returning TRUE only when the wiring landed.
  */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+// Stub the subprocess runner so the uninitialised path delegates to a mock
+// instead of spawning a real `npx moflo init` (slow/networked/flaky in CI).
+// vi.hoisted so the fn exists when the hoisted vi.mock factory references it.
+const { runCommandMock } = vi.hoisted(() => ({
+  runCommandMock: vi.fn(async () => {
+    throw new Error('init blocked in test');
+  }),
+}));
+vi.mock('../../commands/doctor-checks-runtime.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../commands/doctor-checks-runtime.js')>();
+  return { ...actual, runCommand: runCommandMock };
+});
 
 import { autoFixCheck } from '../../commands/doctor-fixes.js';
 
@@ -66,6 +79,23 @@ describe('SDD + Verify Wiring auto-fix (#1301)', () => {
     expect(ok).toBe(false);
     // The locked block is left byte-for-byte untouched.
     expect(readFileSync(join(tmpDir, '.claude', 'settings.json'), 'utf8')).toBe(before);
+  });
+
+  it('does not falsely report success on an uninitialised project (#1301 review)', async () => {
+    // No .claude/ at all. The named handler must NOT short-circuit to true —
+    // every missing* array is empty when nothing is on disk. It must delegate to
+    // `npx moflo init` (the check's own remediation), not silently claim "Fixed".
+    writeFileSync(join(tmpDir, 'moflo.yaml'), 'project:\n  name: t\n');
+    runCommandMock.mockClear();
+
+    const ok = await autoFixCheck(CHECK);
+
+    // The mocked init throws → runFixCommand returns false → honest result.
+    expect(ok).toBe(false);
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock.mock.calls[0][0]).toBe('npx moflo init');
+    // settings.json was never conjured by a short-circuit.
+    expect(existsSync(join(tmpDir, '.claude', 'settings.json'))).toBe(false);
   });
 
   it('wires the missing verify hooks and reports true on an unlocked block', async () => {

--- a/src/cli/__tests__/doctor-checks-sdd.test.ts
+++ b/src/cli/__tests__/doctor-checks-sdd.test.ts
@@ -74,12 +74,53 @@ describe('checkSddVerifyWiring', () => {
     expect(r.message).toMatch(/ENFORCED/);
   });
 
-  it('warns on missing gate case when verify is opted out (not enforced)', async () => {
-    // Opted out → a missing case bites nobody yet, so warn (not fail).
-    wireProject({ gateCases: ['record-verify-run'], yaml: 'project:\n  name: t\ngates:\n  verify_before_done: false\n' });
+  it('passes when both toggles are off even if a gate case is absent (#1301 decoupled)', async () => {
+    // With SDD and verify both opted out there is nothing to enforce, so an
+    // absent case is not flagged — the wiring is checked per enabled feature.
+    wireProject({
+      gateCases: ['record-verify-run'],
+      yaml: 'project:\n  name: t\nsdd:\n  default: false\ngates:\n  verify_before_done: false\n',
+    });
+    const r = await checkSddVerifyWiring();
+    expect(r.status).toBe('pass');
+  });
+
+  it('does NOT require check-before-implement when sdd.default is off (#1301)', async () => {
+    // The core #1301 regression: verify_before_done defaults true, but with
+    // sdd.default=false the SDD implement-gate must not be required. Absent
+    // check-before-implement (gate case + hook token) while the verify wiring
+    // is present ⇒ still passes.
+    wireProject({
+      gateCases: ['check-before-done', 'record-verify-run'],
+      settingsTokens: ['check-before-done', 'record-verify-run'],
+      yaml: 'project:\n  name: t\nsdd:\n  default: false\n',
+    });
+    const r = await checkSddVerifyWiring();
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/ENFORCED/);
+  });
+
+  it('warns (not fails) with a lock-aware message when the hook block is locked (#1301)', async () => {
+    // sdd off + verify on (default). Verify hooks missing from settings.json,
+    // but the hook block is locked ⇒ moflo won't wire it. A hard fail would be
+    // permanently red since init --fix skips locked blocks — so warn + guide.
+    const helpers = join(root, '.claude', 'helpers');
+    mkdirSync(helpers, { recursive: true });
+    writeFileSync(
+      join(helpers, 'gate.cjs'),
+      ['check-before-done', 'record-verify-run'].map((c) => `case '${c}': { break; }`).join('\n'),
+    );
+    writeFileSync(
+      join(root, '.claude', 'settings.json'),
+      JSON.stringify({ moflo: { hooks: { locked: true } }, hooks: {} }),
+    );
+    writeFileSync(join(root, 'moflo.yaml'), 'project:\n  name: t\n');
+
     const r = await checkSddVerifyWiring();
     expect(r.status).toBe('warn');
-    expect(r.message).toMatch(/check-before-done/);
+    expect(r.message).toMatch(/LOCKED/);
+    expect(r.fix).toMatch(/verify_before_done: false/);
+    expect(r.fix).not.toMatch(/^npx moflo init --fix/);
   });
 
   it('fails on missing gate case when verify is enforced', async () => {

--- a/src/cli/commands/doctor-checks-sdd.ts
+++ b/src/cli/commands/doctor-checks-sdd.ts
@@ -7,6 +7,15 @@
  * (via the doctor registry) and, transitively, by `/eldar` (which renders the
  * healer's JSON).
  *
+ * #1301 — the check used to demand ALL three gate tokens whenever EITHER toggle
+ * was on. Because `gates.verify_before_done` defaults to `true`, a consumer who
+ * opted OUT of SDD (`sdd.default: false`) was still forced to carry the SDD
+ * implement-gate (`check-before-implement`) and failed spuriously. The required
+ * set is now decoupled per feature (see `computeSddVerifyRequirements`), and a
+ * LOCKED hook block (`moflo.hooks.locked: true`) — which moflo deliberately
+ * won't rewrite — is reported as a warn with actionable reconciliations rather
+ * than a permanently-red fail that `init --fix` can never clear.
+ *
  * Cross-platform (Rule #1): all paths via path.join; no shelling out.
  */
 
@@ -14,32 +23,61 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { findProjectRoot } from '../services/project-root.js';
 import { loadMofloConfig } from '../config/moflo-config.js';
+import { isHookBlockLocked } from '../services/hook-block-hash.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import type { HealthCheck } from './doctor-types.js';
 
 const NAME = 'SDD + Verify Wiring';
 
-/** The gate cases + hook subcommands that must be present for the feature to work. */
-const REQUIRED_GATE_CASES = ['check-before-done', 'record-verify-run', 'check-before-implement'];
-const REQUIRED_HOOK_TOKENS = ['check-before-done', 'record-verify-run', 'check-before-implement'];
+/**
+ * The SDD implement-gate — required only when `sdd.default === true`. This is
+ * the gate that pauses `/flo` at the implement step for a spec/plan checkpoint.
+ */
+const SDD_GATE_CASES = ['check-before-implement'];
+const SDD_HOOK_TOKENS = ['check-before-implement'];
 
-export async function checkSddVerifyWiring(): Promise<HealthCheck> {
-  const projectDir = findProjectRoot();
+/**
+ * The verify-before-done gate — required only when
+ * `gates.verify_before_done === true`. `check-before-done` blocks `gh pr create`
+ * until a `/verify` run is recorded; `record-verify-run` is the PostToolUse
+ * half that records it.
+ */
+const VERIFY_GATE_CASES = ['check-before-done', 'record-verify-run'];
+const VERIFY_HOOK_TOKENS = ['check-before-done', 'record-verify-run'];
 
+export interface SddVerifyRequirements {
+  sddDefault: boolean;
+  verifyGate: boolean;
+  /** `moflo.hooks.locked: true` — moflo will not rewrite the hook block. */
+  locked: boolean;
+  /** At least one feature toggle is on (its wiring is genuinely enforced). */
+  enforced: boolean;
+  /** `.claude/` has neither gate.cjs nor settings.json — defer to `flo init`. */
+  uninitialised: boolean;
+  /** Hook tokens that must appear in settings.json for the enabled features. */
+  requiredHookTokens: string[];
+  /** gate.cjs `case` names required for the enabled features. */
+  requiredGateCases: string[];
+  /** Required hook tokens absent from settings.json. */
+  missingHooks: string[];
+  /** Required gate cases absent from gate.cjs. */
+  missingGateCases: string[];
+  /** Structural faults independent of the feature toggles (missing/unreadable files). */
+  structural: string[];
+}
+
+/**
+ * Single source of truth for what SDD/verify wiring the consumer's toggles
+ * require and what is actually present. Shared by the health check and the
+ * `--fix` handler so the fixer can honestly re-verify its own work (#1301 — the
+ * old fixer reported `applied: true` on a locked block that it never touched).
+ *
+ * Pure read-only inspection — no file writes.
+ */
+export function computeSddVerifyRequirements(projectDir: string = findProjectRoot()): SddVerifyRequirements {
   const helperGate = join(projectDir, '.claude', 'helpers', 'gate.cjs');
   const settingsPath = join(projectDir, '.claude', 'settings.json');
 
-  // Uninitialised project — defer to `flo init`, don't hard-fail.
-  if (!existsSync(helperGate) && !existsSync(settingsPath)) {
-    return {
-      name: NAME,
-      status: 'warn',
-      message: '.claude/ not initialised — SDD/verify wiring absent',
-      fix: 'npx moflo init',
-    };
-  }
-
-  // Read the two opt-in toggles (best-effort; default false).
   let sddDefault = false;
   let verifyGate = false;
   try {
@@ -50,54 +88,138 @@ export async function checkSddVerifyWiring(): Promise<HealthCheck> {
     /* config unreadable — treat as defaults (both off) */
   }
 
-  const issues: string[] = [];
+  // Decouple the required set per feature (#1301). SDD's implement-gate is
+  // required only under sdd.default; the verify hooks only under
+  // verify_before_done. A verify-only consumer no longer drags in the SDD gate.
+  const requiredHookTokens = [
+    ...(sddDefault ? SDD_HOOK_TOKENS : []),
+    ...(verifyGate ? VERIFY_HOOK_TOKENS : []),
+  ];
+  const requiredGateCases = [
+    ...(sddDefault ? SDD_GATE_CASES : []),
+    ...(verifyGate ? VERIFY_GATE_CASES : []),
+  ];
 
-  // 1. Gate logic present in the installed helper gate.cjs.
+  const uninitialised = !existsSync(helperGate) && !existsSync(settingsPath);
+  const structural: string[] = [];
+  const missingHooks: string[] = [];
+  const missingGateCases: string[] = [];
+  let locked = false;
+
+  // gate.cjs — the installed helper must carry the cases for enabled features.
   if (existsSync(helperGate)) {
     try {
       const gate = readFileSync(helperGate, 'utf8');
-      const missing = REQUIRED_GATE_CASES.filter((c) => !gate.includes(`case '${c}'`));
-      if (missing.length > 0) issues.push(`gate.cjs missing: ${missing.join(', ')}`);
+      for (const c of requiredGateCases) {
+        if (!gate.includes(`case '${c}'`)) missingGateCases.push(c);
+      }
     } catch (e) {
-      issues.push(`cannot read gate.cjs: ${errorDetail(e)}`);
+      structural.push(`cannot read gate.cjs: ${errorDetail(e)}`);
     }
-  } else {
-    issues.push('.claude/helpers/gate.cjs not found');
+  } else if (!uninitialised) {
+    structural.push('.claude/helpers/gate.cjs not found');
   }
 
-  // 2. Hooks wired in settings.json.
+  // settings.json — the hook wiring plus the lock sentinel.
   if (existsSync(settingsPath)) {
     try {
-      const settings = readFileSync(settingsPath, 'utf8');
-      const missing = REQUIRED_HOOK_TOKENS.filter((t) => !settings.includes(t));
-      if (missing.length > 0) issues.push(`settings.json missing hooks: ${missing.join(', ')}`);
+      const raw = readFileSync(settingsPath, 'utf8');
+      for (const t of requiredHookTokens) {
+        if (!raw.includes(t)) missingHooks.push(t);
+      }
+      try {
+        locked = isHookBlockLocked(JSON.parse(raw));
+      } catch {
+        /* unparseable JSON — leave locked=false; structural check below flags it */
+        structural.push('.claude/settings.json is not valid JSON');
+      }
     } catch (e) {
-      issues.push(`cannot read settings.json: ${errorDetail(e)}`);
+      structural.push(`cannot read settings.json: ${errorDetail(e)}`);
     }
-  } else {
-    issues.push('.claude/settings.json not found');
-  }
-
-  const toggles = `sdd.default=${sddDefault}, gates.verify_before_done=${verifyGate}`;
-
-  if (issues.length > 0) {
-    // Wiring is broken. Severity depends on whether the consumer opted in: a
-    // missing gate when verify is ON blocks nothing (fail-open) but breaks the
-    // promised enforcement, so it's a real fault. When both toggles are off the
-    // wiring is still expected (it ships inert), but a missing case only bites
-    // once someone opts in — warn.
-    const enforced = verifyGate || sddDefault;
-    return {
-      name: NAME,
-      status: enforced ? 'fail' : 'warn',
-      message: `SDD/verify wiring incomplete (${toggles}): ${issues.join('; ')}`,
-      fix: 'npx moflo init --fix   # re-syncs gate.cjs + settings.json hooks',
-    };
+  } else if (!uninitialised) {
+    structural.push('.claude/settings.json not found');
   }
 
   return {
+    sddDefault,
+    verifyGate,
+    locked,
+    enforced: sddDefault || verifyGate,
+    uninitialised,
+    requiredHookTokens,
+    requiredGateCases,
+    missingHooks,
+    missingGateCases,
+    structural,
+  };
+}
+
+export async function checkSddVerifyWiring(): Promise<HealthCheck> {
+  const req = computeSddVerifyRequirements(findProjectRoot());
+
+  // Uninitialised project — defer to `flo init`, don't hard-fail.
+  if (req.uninitialised) {
+    return {
+      name: NAME,
+      status: 'warn',
+      message: '.claude/ not initialised — SDD/verify wiring absent',
+      fix: 'npx moflo init',
+    };
+  }
+
+  const toggles = `sdd.default=${req.sddDefault}, gates.verify_before_done=${req.verifyGate}`;
+
+  const issues: string[] = [...req.structural];
+  if (req.missingGateCases.length > 0) issues.push(`gate.cjs missing: ${req.missingGateCases.join(', ')}`);
+  if (req.missingHooks.length > 0) issues.push(`settings.json missing hooks: ${req.missingHooks.join(', ')}`);
+
+  if (issues.length === 0) {
+    return {
+      name: NAME,
+      status: 'pass',
+      message: `SDD/verify wired (${toggles})${req.verifyGate ? ' — verify-before-done ENFORCED' : ''}`,
+    };
+  }
+
+  // Locked hook block: moflo won't rewrite it (init + launcher both skip on
+  // `isHookBlockLocked`), so pointing at `init --fix` is a dead-end and a hard
+  // fail is a permanently-red check the healer can never clear (#1301). When the
+  // ONLY outstanding problem is missing hook tokens in that locked block,
+  // downgrade to warn and hand over the two real reconciliations. gate.cjs and
+  // structural faults are unaffected by the lock, so they still fail normally.
+  if (
+    req.locked &&
+    req.missingHooks.length > 0 &&
+    req.missingGateCases.length === 0 &&
+    req.structural.length === 0
+  ) {
+    const optOut =
+      req.sddDefault && !req.verifyGate
+        ? 'set sdd.default: false'
+        : req.verifyGate && !req.sddDefault
+          ? 'set gates.verify_before_done: false'
+          : 'disable the SDD/verify toggles';
+    return {
+      name: NAME,
+      status: 'warn',
+      message:
+        `SDD/verify wiring incomplete (${toggles}): settings.json missing hooks: ` +
+        `${req.missingHooks.join(', ')} — hook block is LOCKED (moflo.hooks.locked=true), ` +
+        `so moflo will not wire it`,
+      fix:
+        `Reconcile: ${optOut} in moflo.yaml to match the locked block, OR remove ` +
+        `moflo.hooks.locked from .claude/settings.json and run npx moflo init --fix`,
+    };
+  }
+
+  // A missing required token means a feature the consumer turned ON isn't
+  // enforced — a real fault. With both toggles off, `requiredHookTokens`/
+  // `requiredGateCases` are empty, so only structural faults can reach here;
+  // those warn (the wiring ships inert until someone opts in).
+  return {
     name: NAME,
-    status: 'pass',
-    message: `SDD/verify wired (${toggles})${verifyGate ? ' — verify-before-done ENFORCED' : ''}`,
+    status: req.enforced ? 'fail' : 'warn',
+    message: `SDD/verify wiring incomplete (${toggles}): ${issues.join('; ')}`,
+    fix: 'npx moflo init --fix   # re-syncs gate.cjs + settings.json hooks',
   };
 }

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -627,6 +627,15 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       const { computeSddVerifyRequirements } = await import('./doctor-checks-sdd.js');
       const before = computeSddVerifyRequirements(projectDir);
 
+      // Uninitialised `.claude/` — the graft path below assumes settings.json +
+      // gate.cjs already exist, and every `missing*` array is empty when nothing
+      // is on disk. Run the check's own remediation (`npx moflo init`) instead,
+      // preserving the pre-#1301 generic-fallthrough behavior this named handler
+      // now intercepts.
+      if (before.uninitialised) {
+        return runFixCommand('npx moflo init');
+      }
+
       if (before.missingHooks.length === 0 && before.missingGateCases.length === 0 && before.structural.length === 0) {
         return true; // nothing outstanding
       }
@@ -658,7 +667,9 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
           };
           if (scoped.missing.length > 0) {
             applyAdditiveRegeneration(settings, scoped);
-            writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+            // Atomic swap — settings.json is actively re-read by Claude Code, so
+            // a concurrent reader must never see a truncated file (#1015).
+            atomicWriteFileSync(settingsPath, JSON.stringify(settings, null, 2));
           }
         } catch (e) {
           output.writeln(output.warning(`  settings.json hook repair failed: ${errorDetail(e)}`));

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -611,6 +611,72 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     'Gate Health': async () => {
       return fixGateHealthHooks();
     },
+    // #1301 — SDD/verify hook wiring. The generic fall-through used to run
+    // `npx moflo init --fix` and report `applied: true` on its exit code alone,
+    // even when the hook block was LOCKED and init injected nothing — a false
+    // positive over a permanently-red check. This handler:
+    //   1. refuses (returns false) when the block is locked — moflo won't
+    //      rewrite it, so claiming a fix would be a lie;
+    //   2. grafts ONLY the missing SDD/verify reference entries additively
+    //      (`check-before-implement` lives in the reference block but NOT in
+    //      repairHookWiring's REQUIRED_HOOK_WIRING, so the generic repair could
+    //      never add it); and
+    //   3. re-verifies from disk and returns the honest result.
+    'SDD + Verify Wiring': async () => {
+      const projectDir = findProjectRoot();
+      const { computeSddVerifyRequirements } = await import('./doctor-checks-sdd.js');
+      const before = computeSddVerifyRequirements(projectDir);
+
+      if (before.missingHooks.length === 0 && before.missingGateCases.length === 0 && before.structural.length === 0) {
+        return true; // nothing outstanding
+      }
+
+      if (before.locked && before.missingHooks.length > 0) {
+        output.writeln(output.warning(
+          '  Hook block is LOCKED (moflo.hooks.locked=true) — moflo will not wire SDD/verify hooks. ' +
+          'Set the matching toggle to false in moflo.yaml, or remove the lock and re-run.',
+        ));
+        // If the locked hooks are the only gap, there is genuinely nothing we
+        // can do — report honestly rather than a false success.
+        if (before.missingGateCases.length === 0 && before.structural.length === 0) return false;
+      }
+
+      // settings.json hook wiring — additively graft the missing SDD/verify
+      // reference entries (skip when locked; the block above already reported it).
+      const settingsPath = join(projectDir, '.claude', 'settings.json');
+      if (!before.locked && before.missingHooks.length > 0 && existsSync(settingsPath)) {
+        try {
+          const { computeHookBlockDrift, applyAdditiveRegeneration } = await import('../services/hook-block-hash.js');
+          const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+          const report = computeHookBlockDrift((settings.hooks ?? {}) as Record<string, unknown>);
+          // Scope the graft to the tokens this check owns — leave unrelated
+          // drift to the Hook Block Drift check/fixer.
+          const wanted = before.requiredHookTokens;
+          const scoped = {
+            ...report,
+            missing: report.missing.filter((m) => wanted.some((t) => m.command.includes(t))),
+          };
+          if (scoped.missing.length > 0) {
+            applyAdditiveRegeneration(settings, scoped);
+            writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+          }
+        } catch (e) {
+          output.writeln(output.warning(`  settings.json hook repair failed: ${errorDetail(e)}`));
+          return false;
+        }
+      }
+
+      // gate.cjs case drift — reuse the gate-health repair (mirrors bin/helper).
+      if (before.missingGateCases.length > 0) {
+        await fixGateHealthHooks();
+      }
+
+      // Truth check — re-read from disk and confirm the required wiring landed.
+      const after = computeSddVerifyRequirements(projectDir);
+      return after.missingHooks.length === 0
+        && after.missingGateCases.length === 0
+        && after.structural.length === 0;
+    },
     // Refresh the consumer's CLAUDE.md MoFlo block in place using the
     // shared `applyInjectionReplacement` service. Idempotent: a re-run sees
     // `state === 'in-sync'` and the autoFix dispatcher skips this entry.


### PR DESCRIPTION
Closes #1301.

## Problem

The `SDD + Verify Wiring` healer check fails on an existing project after upgrade, and neither `flo healer --fix` nor `flo init --fix` can repair it — `--fix` reports `applied: true` (false positive) while a locked hook block is never touched, leaving a permanently-red check.

Three stacked defects (all confirmed in code):

1. **Over-coupling** — the check demanded all three gate tokens whenever *either* toggle was on. `gates.verify_before_done` defaults to `true` (`moflo-config.ts:299,483`), so a consumer with `sdd.default: false` was still forced to carry the SDD implement-gate (`check-before-implement`) and failed.
2. **False `applied`** — no dedicated fixer, so it fell through to `runFixCommand('npx moflo init --fix')`, which returns `true` on exit code alone even though init respects `moflo.hooks.locked` and injects nothing.
3. **Dead-end remediation** — the `fix` hint pointed at `init --fix`, which by design won't touch a locked block.

## Fix

- **Decouple required wiring per feature** (`doctor-checks-sdd.ts`) — new `computeSddVerifyRequirements()` is the shared source of truth. `check-before-implement` is required only when `sdd.default===true`; the verify hooks only when `verify_before_done===true`.
- **Truthful, lock-aware `--fix` handler** (`doctor-fixes.ts`) — returns `false` on a locked block, additively grafts **only** the missing SDD/verify reference entries (note: `check-before-implement` lives in the reference block but *not* in `repairHookWiring`'s `REQUIRED_HOOK_WIRING`, a latent second bug), then re-reads from disk and re-verifies before reporting success. Delegates to `npx moflo init` on an uninitialised project; atomic settings.json write (#1015 precedent).
- **Lock-aware message** — when the only gap is missing hooks in a locked block, the check warns (not fails) and offers the two real reconciliations: set the matching toggle to `false`, or remove `moflo.hooks.locked` and re-run `init --fix`.

## Tests

- Check tests: decoupling + #1301 regression guard + lock-aware warn.
- Fixer tests: locked -> false + settings untouched; unlocked -> wires verify hooks + re-verifies + scoped; uninitialised -> delegates to init, no silent success.
- Verified: 12 targeted tests + full-project tsc green (/verify PASS, all 6 acceptance criteria).

## Consumer surface (Rule #2)

Ships via `flo healer` / `flo init`. Behavior change: consumers who opted out of both features no longer see the check flag inert wiring (per the issue's "too aggressive" note). Runtime effect requires publish + reinstall (dogfood layers run from `node_modules/moflo`).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_01XCJi19QGCNsFMrmwBLh2st