### PR TITLE
fix(flo): surface resolved run modes so moflo.yaml sdd.default is never ignored

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -345,9 +345,21 @@ function resolveFloRun(promptText) {
   // Applicability: -t/-r never implement, so verify is a no-op there; -r produces
   // no artifacts, so sdd is a no-op too (in -t the spec/plan goes INTO the ticket,
   // so sdd stays on). Only a full non-epic-branch run opens a PR to merge.
-  if (out.workflow === 'ticket' || out.workflow === 'research') out.verify = false;
-  if (out.workflow === 'research' || out.workflow === 'spell-engine') out.sdd = false;
-  if (out.workflow !== 'full' || epicBranch) out.merge = false;
+  // Re-attribute anything applicability turned off, so a false never carries the
+  // source of the value it no longer has. This whole change exists to stop modes
+  // being reported inaccurately — the attribution has to be honest too.
+  if (out.workflow === 'ticket' || out.workflow === 'research') {
+    if (out.verify) out.verifySrc = out.workflow + ' mode does not implement';
+    out.verify = false;
+  }
+  if (out.workflow === 'research' || out.workflow === 'spell-engine') {
+    if (out.sdd) out.sddSrc = out.workflow + ' mode produces no spec artifacts';
+    out.sdd = false;
+  }
+  if (out.workflow !== 'full' || epicBranch) {
+    if (out.merge) out.mergeSrc = epicBranch ? '--epic-branch owns merging' : out.workflow + ' mode opens no PR';
+    out.merge = false;
+  }
   return out;
 }
 

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -104,6 +104,19 @@ function loadSddConfig() {
   return out;
 }
 
+// Parse the top-level `merge:` block from moflo.yaml (#1285). Block-scoped for
+// the same reason as loadSddConfig: a bare `auto:` key can appear under other
+// sections. Cross-platform: tolerates CRLF.
+function loadMergeConfig() {
+  var out = { auto: false };
+  var content = MOFLO_YAML;
+  if (!content) return out;
+  var block = content.match(/^merge:[ \t]*\r?\n((?:[ \t]+.*(?:\r?\n|$))*)/m);
+  if (!block) return out;
+  if (/^\s*auto:\s*true\b/im.test(block[1])) out.auto = true;
+  return out;
+}
+
 // Read moflo.yaml exactly once per gate process (#1297 review): loadGateConfig
 // and loadSddConfig both parse it, and the gate fires on every Write/Edit — a
 // second read is wasted syscalls. Single readFileSync in try/catch (no existsSync
@@ -116,6 +129,7 @@ var MOFLO_YAML = readMofloYaml();
 
 var config = loadGateConfig();
 var sddConf = loadSddConfig();
+var mergeConf = loadMergeConfig();
 var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
@@ -288,16 +302,59 @@ function detectFlMode(promptText) {
   return null;
 }
 
-// #1297 — arm the SDD implement gate from the user prompt. Only /fl or /flo runs
-// can arm it. Explicit -sd/--sdd wins; --no-sdd disarms; otherwise honor the
-// sdd.default config. `-sd` is a distinct token from `-s` (swarm): the `d` sits
-// on the word boundary so `-s\b` never matches `-sd`.
-function detectSddMode(promptText) {
+// Resolve the FULL set of /flo run modifiers from the prompt + moflo.yaml — the
+// single source of truth for both gate arming (#1297) and the authoritative
+// announcement emitted by prompt-reminder. Two consumers, one resolver: a second
+// implementation is exactly how `sdd.default: true` got silently ignored (the
+// skill's prompt carried `let sddMode = false` and the model executed the literal).
+//
+// Precedence per key: explicit --no-X > explicit -x/--X > moflo.yaml > built-in.
+// NOTE the differing built-in defaults: sdd is opt-IN (false), verify is opt-OUT
+// (true, #1294), merge is opt-IN (false, #1285).
+//
+// `-sd` is a distinct token from `-s` (swarm): the `d` sits on the word boundary
+// so `-s\b` never matches `-sd`.
+function resolveFloRun(promptText) {
   var p = promptText || '';
-  if (!/^\s*\/(?:fl|flo)\b/i.test(p)) return false;
-  if (/(?:^|\s)--no-sdd\b/.test(p)) return false;
-  if (/(?:^|\s)(?:-sd|--sdd)\b/.test(p)) return true;
-  return !!sddConf.default;
+  var out = { isFlo: false, workflow: 'full', sdd: false, verify: false, merge: false,
+              sddSrc: 'default', verifySrc: 'default', mergeSrc: 'default' };
+  if (!/^\s*\/(?:fl|flo)\b/i.test(p)) return out;
+  out.isFlo = true;
+
+  // Workflow mode — decides which modifiers are even applicable.
+  if (/(?:^|\s)(?:-wf|--workflow)\b/.test(p)) out.workflow = 'spell-engine';
+  else if (/(?:^|\s)(?:-r|--research)\b/.test(p)) out.workflow = 'research';
+  else if (/(?:^|\s)(?:-t|--ticket)\b/.test(p)) out.workflow = 'ticket';
+  var epicBranch = /(?:^|\s)--epic-branch\b/.test(p);
+
+  if (/(?:^|\s)--no-sdd\b/.test(p)) { out.sdd = false; out.sddSrc = 'flag'; }
+  else if (/(?:^|\s)(?:-sd|--sdd)\b/.test(p)) { out.sdd = true; out.sddSrc = 'flag'; }
+  else if (sddConf.default) { out.sdd = true; out.sddSrc = 'moflo.yaml sdd.default'; }
+
+  if (/(?:^|\s)--no-verify\b/.test(p)) { out.verify = false; out.verifySrc = 'flag'; }
+  else if (/(?:^|\s)(?:-v|--verify)\b/.test(p)) { out.verify = true; out.verifySrc = 'flag'; }
+  else if (!config.verify_before_done) { out.verify = false; out.verifySrc = 'moflo.yaml gates.verify_before_done'; }
+  else { out.verify = true; out.verifySrc = 'default'; }
+  // --sdd implies --verify: a spec/plan without an enforced verify step drifts.
+  if (out.sdd && !out.verify && out.verifySrc !== 'flag') out.verify = true;
+
+  if (/(?:^|\s)--no-merge\b/.test(p)) { out.merge = false; out.mergeSrc = 'flag'; }
+  else if (/(?:^|\s)(?:-m|--merge)\b/.test(p)) { out.merge = true; out.mergeSrc = 'flag'; }
+  else if (mergeConf.auto) { out.merge = true; out.mergeSrc = 'moflo.yaml merge.auto'; }
+
+  // Applicability: -t/-r never implement, so verify is a no-op there; -r produces
+  // no artifacts, so sdd is a no-op too (in -t the spec/plan goes INTO the ticket,
+  // so sdd stays on). Only a full non-epic-branch run opens a PR to merge.
+  if (out.workflow === 'ticket' || out.workflow === 'research') out.verify = false;
+  if (out.workflow === 'research' || out.workflow === 'spell-engine') out.sdd = false;
+  if (out.workflow !== 'full' || epicBranch) out.merge = false;
+  return out;
+}
+
+// #1297 — arm the SDD implement gate from the user prompt. Thin wrapper so the
+// arming decision and the announced decision can never disagree.
+function detectSddMode(promptText) {
+  return resolveFloRun(promptText).sdd;
 }
 
 // Resolve the absolute specs root the same way TS specsRoot does (#1294): split
@@ -981,6 +1038,33 @@ switch (command) {
     applyPromptStateReset(s, prompt);
     s.interactionCount = (s.interactionCount || 0) + 1;
     writeState(s);
+    // Announce the resolved /flo run modifiers. The gate already parsed
+    // moflo.yaml in THIS process (fresh per prompt — a git pull or a mid-session
+    // yaml edit is picked up automatically, no cache to invalidate), so this
+    // costs no extra read. Emitting it is what closes the loop: the skill used
+    // to carry `let sddMode = false` as a literal and the model executed it,
+    // silently ignoring `sdd.default: true`. Only fires on /fl|/flo prompts.
+    var floRun = resolveFloRun(prompt);
+    if (floRun.isFlo) {
+      console.log(
+        '[moflo] /flo run modes (AUTHORITATIVE — use verbatim; do NOT re-derive from the skill defaults): ' +
+        'sdd=' + (floRun.sdd ? 'ON' : 'off') +
+        ' verify=' + (floRun.verify ? 'ON' : 'off') +
+        ' merge=' + (floRun.merge ? 'ON' : 'off') +
+        ' [workflow=' + floRun.workflow + ']'
+      );
+      // Spell out the surprising case: a project default the user did not type.
+      if (floRun.sdd && floRun.sddSrc !== 'flag') {
+        console.log(
+          '[moflo] sdd is ON via ' + floRun.sddSrc + ' — the spec→plan→implement→verify cycle is ' +
+          'MANDATORY this run. Author the spec before editing source (the sdd_gate blocks source ' +
+          'Write/Edit until a reviewed plan exists). One-off opt out: re-run with --no-sdd.'
+        );
+      }
+      if (floRun.merge && floRun.mergeSrc !== 'flag') {
+        console.log('[moflo] merge is ON via ' + floRun.mergeSrc + ' — the PR will be auto-merged. Opt out: --no-merge.');
+      }
+    }
     if (config.context_tracking) {
       var ic = s.interactionCount;
       if (ic > 30) console.log('Context: CRITICAL. Commit, store learnings, suggest new session.');

--- a/.claude/skills/fl/SKILL.md
+++ b/.claude/skills/fl/SKILL.md
@@ -72,7 +72,7 @@ Two **independent** modifiers, orthogonal to execution mode (`-n`/`-s`/`-h`) and
 | `-v` | `--verify` | **Verify-before-done** — a normal run plus the `/verify` skill (the completion gate), no spec/plan front-half. **On by default** (#1294) — this flag only forces it back on for a project that set `gates.verify_before_done: false`. |
 | `--no-sdd`, `--no-verify` | | Opt a single run out. `--no-verify` skips the (default-on) verify step. |
 
-Defaults seed from `moflo.yaml` — `sdd.default` (default **off**) and `gates.verify_before_done` (default **on** since #1294). So the SDD spec/plan ceremony is opt-in, but **verify-before-done runs by default**; per-run flags override (`--no-verify` to skip). `--sdd` implies `--verify` (a spec/plan without an enforced verify step drifts). In `-t`/`-r` modes (no implementation) verify is a no-op — cleared silently, with the one-line ignored note only when the user explicitly passed `-v`/`--verify`; `--sdd` in `-t` writes the spec/plan **into the ticket** rather than scaffolding artifacts. Full mechanics in `./sdd.md`.
+Defaults seed from `moflo.yaml` — `sdd.default` (built-in **off**) and `gates.verify_before_done` (built-in **on** since #1294). So the SDD spec/plan ceremony is opt-in *by default*, but **a project can turn it on for every run** — never assume it is off; resolve it per the "Resolved run modes" section below. Verify-before-done runs by default; per-run flags override (`--no-verify` to skip). `--sdd` implies `--verify` (a spec/plan without an enforced verify step drifts). In `-t`/`-r` modes (no implementation) verify is a no-op — cleared silently, with the one-line ignored note only when the user explicitly passed `-v`/`--verify`; `--sdd` in `-t` writes the spec/plan **into the ticket** rather than scaffolding artifacts. Full mechanics in `./sdd.md`.
 
 ## Auto-merge (#1285)
 
@@ -124,6 +124,35 @@ Read the relevant file before executing that part of the run.
 | `./spell-engine.md` | `-wf` invocations (list, info, execute) |
 | `./sdd.md` | `-sd`/`--sdd` and `-v`/`--verify` — the spec→plan→implement→verify cycle |
 
+## Resolved run modes — read this BEFORE parsing arguments
+
+`sddMode`, `verifyMode`, and `mergeMode` are **config-derived**. Their project defaults live in `moflo.yaml` (`sdd.default`, `gates.verify_before_done`, `merge.auto`), so they cannot be known from this document — you MUST obtain them, never assume them. A run that assumes `sdd=off` on a project with `sdd.default: true` silently skips the entire spec→plan cycle, which is the exact failure this step exists to prevent.
+
+**Primary source — the injected resolution line.** moflo's `prompt-reminder` hook resolves all three from `moflo.yaml` on every `/flo` prompt (fresh process per prompt, so a `git pull` or a mid-session edit to `moflo.yaml` is picked up automatically) and emits them into your context immediately above the user's message:
+
+```
+[moflo] /flo run modes (AUTHORITATIVE — use verbatim; do NOT re-derive from the skill defaults): sdd=ON verify=ON merge=off [workflow=full]
+```
+
+Scan for that `[moflo] /flo run modes` line and assign `sddMode` / `verifyMode` / `mergeMode` from it **verbatim**. It already accounts for flags the user typed, `moflo.yaml` defaults, `--sdd` implying `--verify`, and mode applicability — do not second-guess it.
+
+**Fallback — no such line in context** (hooks disabled, or a consumer on a gate.cjs predating this). Shell out once; the CLI resolves from the same precedence rules:
+
+```bash
+flo sdd mode --args="$ARGUMENTS"
+```
+
+Use `--args=` (with the `=`), **not** `--args <value>` — a value starting with `-` would otherwise be parsed as flags and you would silently get the bare config default back.
+
+```json
+{ "workflow": "full", "sdd": true, "verify": true, "merge": false,
+  "sddSrc": "moflo.yaml sdd.default", "verifySrc": "default", "mergeSrc": "default" }
+```
+
+**Never skip both.** If the injected line is absent and the CLI call fails, say so explicitly to the user and stop rather than proceeding on a guessed mode — a wrongly-assumed `sdd=off` is invisible to the user until the PR lands without a spec.
+
+When `sdd` resolved ON from config rather than a typed flag, state that in your first message (e.g. *"SDD is on via `moflo.yaml sdd.default` — running the spec→plan→implement→verify cycle."*) so the user can `--no-sdd` out before work starts.
+
 ## Argument parsing
 
 ```javascript
@@ -135,20 +164,12 @@ let epicBranch = null;
 let issueNumber = null;
 let titleWords = [];
 
-// SDD/verify modifiers (Epic #1269, #1294). Seed from moflo.yaml BEFORE parsing
-// so a project default applies unless a per-run flag overrides it. Read the two
-// keys from moflo.yaml at the project root — NOTE the different absent-defaults:
-//   sddMode    ← `sdd.default`            (absent ⇒ false — spec/plan is opt-in)
-//   verifyMode ← `gates.verify_before_done` (absent ⇒ TRUE — verify is on by default, #1294)
-let sddMode = false;          // -sd / --sdd  (full spec→plan→implement→verify)
-let verifyMode = true;        // -v / --verify (on by default; --no-verify opts out)
+// SDD / verify / merge modifiers (Epic #1269, #1294, #1285) — DO NOT resolve
+// these here. They are config-derived, and the values below are placeholders,
+// NOT defaults. Take them from the "Resolved run modes" step above; the loop
+// below only applies what the user typed on top of that resolution.
+let sddMode, verifyMode, mergeMode;   // ← assigned from the resolution, never guessed
 let verifyExplicit = false;   // did the user actually type -v/--verify? (drives the -t/-r note only, so it doesn't fire on the default)
-
-// Auto-merge modifier (#1285). Seed from moflo.yaml BEFORE parsing, same as
-// sddMode/verifyMode: read `merge.auto` at the project root (absent ⇒ false).
-// When true, a full run awaits the PR's merge preconditions and merges it
-// (Phase 5.3b) instead of stopping at "PR opened".
-let mergeMode = false;        // -m / --merge  ← moflo.yaml merge.auto
 
 let wfName = null, wfSubcommand = null;
 let wfArgs = [], wfNamedArgs = {};

--- a/.claude/skills/fl/sdd.md
+++ b/.claude/skills/fl/sdd.md
@@ -2,10 +2,12 @@
 
 Spec-Driven Development for `/flo` — Epic #1269. Two independent modifiers:
 
-- **`-sd` / `--sdd`** — run the full **spec → plan → (review) → implement → verify** cycle. Opt-in (`sdd.default` defaults false). Implies verify.
+- **`-sd` / `--sdd`** — run the full **spec → plan → (review) → implement → verify** cycle. Opt-in *by built-in default* (`sdd.default` = false), but **a project can set `sdd.default: true` and turn it on for every run**. Implies verify.
 - **`-v` / `--verify`** — verify-before-done: a normal run plus the completion gate, no spec/plan front-half. **On by default** (`gates.verify_before_done` defaults true, #1294) — `-v` is explicit, `--no-verify` opts out for one run.
 
-Defaults seed from `moflo.yaml` (`sdd.default` = false, `gates.verify_before_done` = true); per-run flags and `--no-sdd` / `--no-verify` override. Both are orthogonal to execution mode (`-n`/`-s`/`-h`) and `--worktree`, so `--sdd -s -wt 42` runs the SDD cycle in a swarm inside a worktree.
+⚠ **Never infer whether SDD is on from these built-in defaults.** They are project-configurable, so the effective value is only knowable at run time. Resolve it as `SKILL.md` § "Resolved run modes" describes — the `[moflo] /flo run modes` line injected into context, or `flo sdd mode --args="$ARGUMENTS"`. Assuming `sdd=off` on a project with `sdd.default: true` silently skips the whole spec/plan cycle and is invisible to the user until the PR lands without a spec.
+
+Precedence: per-run flags and `--no-sdd` / `--no-verify` override `moflo.yaml`, which overrides the built-ins. Both are orthogonal to execution mode (`-n`/`-s`/`-h`) and `--worktree`, so `--sdd -s -wt 42` runs the SDD cycle in a swarm inside a worktree.
 
 The artifact model, paths, and CLI live in `src/cli/sdd/` (`flo sdd …`). The constitution layer (CLAUDE.md + `.claude/guidance/`) is referenced by every stage — never restated in a spec.
 

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -345,9 +345,21 @@ function resolveFloRun(promptText) {
   // Applicability: -t/-r never implement, so verify is a no-op there; -r produces
   // no artifacts, so sdd is a no-op too (in -t the spec/plan goes INTO the ticket,
   // so sdd stays on). Only a full non-epic-branch run opens a PR to merge.
-  if (out.workflow === 'ticket' || out.workflow === 'research') out.verify = false;
-  if (out.workflow === 'research' || out.workflow === 'spell-engine') out.sdd = false;
-  if (out.workflow !== 'full' || epicBranch) out.merge = false;
+  // Re-attribute anything applicability turned off, so a false never carries the
+  // source of the value it no longer has. This whole change exists to stop modes
+  // being reported inaccurately — the attribution has to be honest too.
+  if (out.workflow === 'ticket' || out.workflow === 'research') {
+    if (out.verify) out.verifySrc = out.workflow + ' mode does not implement';
+    out.verify = false;
+  }
+  if (out.workflow === 'research' || out.workflow === 'spell-engine') {
+    if (out.sdd) out.sddSrc = out.workflow + ' mode produces no spec artifacts';
+    out.sdd = false;
+  }
+  if (out.workflow !== 'full' || epicBranch) {
+    if (out.merge) out.mergeSrc = epicBranch ? '--epic-branch owns merging' : out.workflow + ' mode opens no PR';
+    out.merge = false;
+  }
   return out;
 }
 

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -104,6 +104,19 @@ function loadSddConfig() {
   return out;
 }
 
+// Parse the top-level `merge:` block from moflo.yaml (#1285). Block-scoped for
+// the same reason as loadSddConfig: a bare `auto:` key can appear under other
+// sections. Cross-platform: tolerates CRLF.
+function loadMergeConfig() {
+  var out = { auto: false };
+  var content = MOFLO_YAML;
+  if (!content) return out;
+  var block = content.match(/^merge:[ \t]*\r?\n((?:[ \t]+.*(?:\r?\n|$))*)/m);
+  if (!block) return out;
+  if (/^\s*auto:\s*true\b/im.test(block[1])) out.auto = true;
+  return out;
+}
+
 // Read moflo.yaml exactly once per gate process (#1297 review): loadGateConfig
 // and loadSddConfig both parse it, and the gate fires on every Write/Edit — a
 // second read is wasted syscalls. Single readFileSync in try/catch (no existsSync
@@ -116,6 +129,7 @@ var MOFLO_YAML = readMofloYaml();
 
 var config = loadGateConfig();
 var sddConf = loadSddConfig();
+var mergeConf = loadMergeConfig();
 var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
@@ -288,16 +302,59 @@ function detectFlMode(promptText) {
   return null;
 }
 
-// #1297 — arm the SDD implement gate from the user prompt. Only /fl or /flo runs
-// can arm it. Explicit -sd/--sdd wins; --no-sdd disarms; otherwise honor the
-// sdd.default config. `-sd` is a distinct token from `-s` (swarm): the `d` sits
-// on the word boundary so `-s\b` never matches `-sd`.
-function detectSddMode(promptText) {
+// Resolve the FULL set of /flo run modifiers from the prompt + moflo.yaml — the
+// single source of truth for both gate arming (#1297) and the authoritative
+// announcement emitted by prompt-reminder. Two consumers, one resolver: a second
+// implementation is exactly how `sdd.default: true` got silently ignored (the
+// skill's prompt carried `let sddMode = false` and the model executed the literal).
+//
+// Precedence per key: explicit --no-X > explicit -x/--X > moflo.yaml > built-in.
+// NOTE the differing built-in defaults: sdd is opt-IN (false), verify is opt-OUT
+// (true, #1294), merge is opt-IN (false, #1285).
+//
+// `-sd` is a distinct token from `-s` (swarm): the `d` sits on the word boundary
+// so `-s\b` never matches `-sd`.
+function resolveFloRun(promptText) {
   var p = promptText || '';
-  if (!/^\s*\/(?:fl|flo)\b/i.test(p)) return false;
-  if (/(?:^|\s)--no-sdd\b/.test(p)) return false;
-  if (/(?:^|\s)(?:-sd|--sdd)\b/.test(p)) return true;
-  return !!sddConf.default;
+  var out = { isFlo: false, workflow: 'full', sdd: false, verify: false, merge: false,
+              sddSrc: 'default', verifySrc: 'default', mergeSrc: 'default' };
+  if (!/^\s*\/(?:fl|flo)\b/i.test(p)) return out;
+  out.isFlo = true;
+
+  // Workflow mode — decides which modifiers are even applicable.
+  if (/(?:^|\s)(?:-wf|--workflow)\b/.test(p)) out.workflow = 'spell-engine';
+  else if (/(?:^|\s)(?:-r|--research)\b/.test(p)) out.workflow = 'research';
+  else if (/(?:^|\s)(?:-t|--ticket)\b/.test(p)) out.workflow = 'ticket';
+  var epicBranch = /(?:^|\s)--epic-branch\b/.test(p);
+
+  if (/(?:^|\s)--no-sdd\b/.test(p)) { out.sdd = false; out.sddSrc = 'flag'; }
+  else if (/(?:^|\s)(?:-sd|--sdd)\b/.test(p)) { out.sdd = true; out.sddSrc = 'flag'; }
+  else if (sddConf.default) { out.sdd = true; out.sddSrc = 'moflo.yaml sdd.default'; }
+
+  if (/(?:^|\s)--no-verify\b/.test(p)) { out.verify = false; out.verifySrc = 'flag'; }
+  else if (/(?:^|\s)(?:-v|--verify)\b/.test(p)) { out.verify = true; out.verifySrc = 'flag'; }
+  else if (!config.verify_before_done) { out.verify = false; out.verifySrc = 'moflo.yaml gates.verify_before_done'; }
+  else { out.verify = true; out.verifySrc = 'default'; }
+  // --sdd implies --verify: a spec/plan without an enforced verify step drifts.
+  if (out.sdd && !out.verify && out.verifySrc !== 'flag') out.verify = true;
+
+  if (/(?:^|\s)--no-merge\b/.test(p)) { out.merge = false; out.mergeSrc = 'flag'; }
+  else if (/(?:^|\s)(?:-m|--merge)\b/.test(p)) { out.merge = true; out.mergeSrc = 'flag'; }
+  else if (mergeConf.auto) { out.merge = true; out.mergeSrc = 'moflo.yaml merge.auto'; }
+
+  // Applicability: -t/-r never implement, so verify is a no-op there; -r produces
+  // no artifacts, so sdd is a no-op too (in -t the spec/plan goes INTO the ticket,
+  // so sdd stays on). Only a full non-epic-branch run opens a PR to merge.
+  if (out.workflow === 'ticket' || out.workflow === 'research') out.verify = false;
+  if (out.workflow === 'research' || out.workflow === 'spell-engine') out.sdd = false;
+  if (out.workflow !== 'full' || epicBranch) out.merge = false;
+  return out;
+}
+
+// #1297 — arm the SDD implement gate from the user prompt. Thin wrapper so the
+// arming decision and the announced decision can never disagree.
+function detectSddMode(promptText) {
+  return resolveFloRun(promptText).sdd;
 }
 
 // Resolve the absolute specs root the same way TS specsRoot does (#1294): split
@@ -981,6 +1038,33 @@ switch (command) {
     applyPromptStateReset(s, prompt);
     s.interactionCount = (s.interactionCount || 0) + 1;
     writeState(s);
+    // Announce the resolved /flo run modifiers. The gate already parsed
+    // moflo.yaml in THIS process (fresh per prompt — a git pull or a mid-session
+    // yaml edit is picked up automatically, no cache to invalidate), so this
+    // costs no extra read. Emitting it is what closes the loop: the skill used
+    // to carry `let sddMode = false` as a literal and the model executed it,
+    // silently ignoring `sdd.default: true`. Only fires on /fl|/flo prompts.
+    var floRun = resolveFloRun(prompt);
+    if (floRun.isFlo) {
+      console.log(
+        '[moflo] /flo run modes (AUTHORITATIVE — use verbatim; do NOT re-derive from the skill defaults): ' +
+        'sdd=' + (floRun.sdd ? 'ON' : 'off') +
+        ' verify=' + (floRun.verify ? 'ON' : 'off') +
+        ' merge=' + (floRun.merge ? 'ON' : 'off') +
+        ' [workflow=' + floRun.workflow + ']'
+      );
+      // Spell out the surprising case: a project default the user did not type.
+      if (floRun.sdd && floRun.sddSrc !== 'flag') {
+        console.log(
+          '[moflo] sdd is ON via ' + floRun.sddSrc + ' — the spec→plan→implement→verify cycle is ' +
+          'MANDATORY this run. Author the spec before editing source (the sdd_gate blocks source ' +
+          'Write/Edit until a reviewed plan exists). One-off opt out: re-run with --no-sdd.'
+        );
+      }
+      if (floRun.merge && floRun.mergeSrc !== 'flag') {
+        console.log('[moflo] merge is ON via ' + floRun.mergeSrc + ' — the PR will be auto-merged. Opt out: --no-merge.');
+      }
+    }
     if (config.context_tracking) {
       var ic = s.interactionCount;
       if (ic > 30) console.log('Context: CRITICAL. Commit, store learnings, suggest new session.');

--- a/src/cli/__tests__/init/helpers-generator-flo-modes.test.ts
+++ b/src/cli/__tests__/init/helpers-generator-flo-modes.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Drift guard: the gate script embedded in init/helpers-generator.ts is a
+ * hand-maintained verbatim copy of bin/gate.cjs (it is what `flo init` writes to
+ * a consumer's .claude/helpers/gate.cjs before the launcher syncs the canonical
+ * bin/ copy over it). The two have historically drifted whenever one side was
+ * edited alone.
+ *
+ * Rather than diff the sources (they differ by design — the embedded copy has
+ * trimmed comments), generate the script, run it as a real subprocess, and
+ * assert it produces the SAME /flo run-mode announcement as bin/gate.cjs. A
+ * behavioural equivalence check survives cosmetic divergence and catches the
+ * only thing that matters: a consumer on the generated copy resolving
+ * `sdd.default: true` differently from one on the canonical copy.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+import { generateGateScript } from '../../init/helpers-generator.js';
+
+const CANONICAL = resolve(__dirname, '../../../../bin/gate.cjs');
+
+let root: string;
+let generated: string;
+
+beforeAll(() => {
+  root = resolve(tmpdir(), `moflo-gen-gate-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(root, { recursive: true });
+  generated = join(root, 'generated-gate.cjs');
+  writeFileSync(generated, generateGateScript());
+});
+
+afterAll(() => {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+/** Run a gate script's prompt-reminder in a throwaway project; return stdout. */
+function announce(gateScript: string, prompt: string, moflo: string): string {
+  const proj = join(root, `p-${Math.random().toString(36).slice(2, 10)}`);
+  mkdirSync(join(proj, '.claude'), { recursive: true });
+  writeFileSync(join(proj, 'moflo.yaml'), moflo);
+  return execFileSync('node', [gateScript, 'prompt-reminder'], {
+    env: {
+      ...(process.env as Record<string, string>),
+      CLAUDE_PROJECT_DIR: proj,
+      CLAUDE_USER_PROMPT: prompt,
+      TOOL_INPUT_command: '',
+      TOOL_INPUT_file_path: '',
+      TOOL_INPUT_skill: '',
+      HOOK_SESSION_ID: '',
+    },
+    encoding: 'utf-8',
+    timeout: 30000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+/** Just the run-modes line, so interactionCount-driven Context warnings don't matter. */
+function modesLine(out: string): string {
+  return out.split(/\r?\n/).find((l) => l.includes('/flo run modes')) ?? '';
+}
+
+const CASES: Array<[string, string]> = [
+  ['/flo 42', 'sdd:\n  default: true\n'],
+  ['/flo 42', ''],
+  ['/flo -sd 42', ''],
+  ['/flo --no-sdd 42', 'sdd:\n  default: true\n'],
+  ['/flo -s 42', 'sdd:\n  default: true\n'],
+  ['/flo -r 42', 'sdd:\n  default: true\n'],
+  ['/flo -t 42', 'sdd:\n  default: true\n'],
+  ['/flo 42', 'merge:\n  auto: true\n'],
+  ['/flo 42', 'gates:\n  verify_before_done: false\n'],
+  ['/flo -sd --no-verify 42', ''],
+];
+
+describe('generated gate.cjs matches bin/gate.cjs on /flo run modes', () => {
+  it('is syntactically valid', () => {
+    expect(() => execFileSync('node', ['--check', generated], { stdio: 'pipe' })).not.toThrow();
+  });
+
+  it.each(CASES)('resolves %j (config %j) identically to the canonical gate', (prompt, moflo) => {
+    const fromGenerated = modesLine(announce(generated, prompt, moflo));
+    const fromCanonical = modesLine(announce(CANONICAL, prompt, moflo));
+    expect(fromGenerated).not.toBe('');
+    expect(fromGenerated).toBe(fromCanonical);
+  });
+
+  it('emits the config-sourced sdd explainer, same as the canonical gate', () => {
+    const out = announce(generated, '/flo 42', 'sdd:\n  default: true\n');
+    expect(out).toContain('sdd is ON via moflo.yaml sdd.default');
+    expect(out).toContain('MANDATORY');
+  });
+
+  it('stays silent for a non-/flo prompt', () => {
+    expect(announce(generated, 'fix a bug', 'sdd:\n  default: true\n')).not.toContain('/flo run modes');
+  });
+});

--- a/src/cli/__tests__/sdd/sdd-mode-resolve.test.ts
+++ b/src/cli/__tests__/sdd/sdd-mode-resolve.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for `flo sdd mode` — the CLI fallback that resolves a /flo run's
+ * sdd/verify/merge modifiers from moflo.yaml + the run's flags.
+ *
+ * This is the backup path for the authoritative announcement that
+ * bin/gate.cjs prompt-reminder normally injects. Consumers with hooks disabled
+ * (or a gate.cjs predating the announcement) shell out to this instead, so its
+ * precedence MUST match resolveFloRun in bin/gate.cjs exactly.
+ *
+ * Also guards the `--args=` calling convention: `--args <value>` silently
+ * degrades to `args=true` when the value starts with `-`, which would resolve
+ * every run to the bare config default — the exact silent-wrong-answer failure
+ * this whole change exists to eliminate.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+
+const CLI = resolve(__dirname, '../../../../bin/cli.js');
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = resolve(tmpdir(), `moflo-sdd-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+  // findProjectRoot needs a marker; .git makes tmpDir the root rather than
+  // walking up into the real repo and picking up ITS moflo.yaml.
+  mkdirSync(join(tmpDir, '.git'), { recursive: true });
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+function resolveModes(floArgs: string, moflo = ''): Record<string, unknown> {
+  writeFileSync(join(tmpDir, 'moflo.yaml'), moflo);
+  const out = execFileSync('node', [CLI, 'sdd', 'mode', `--args=${floArgs}`], {
+    cwd: tmpDir, encoding: 'utf-8', timeout: 60000, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return JSON.parse(out);
+}
+
+const SDD_ON = 'sdd:\n  default: true\n';
+
+describe('flo sdd mode', () => {
+  it('resolves sdd from moflo.yaml sdd.default for a bare run', () => {
+    expect(resolveModes('42', SDD_ON)).toMatchObject({ sdd: true, sddSrc: 'moflo.yaml sdd.default' });
+  });
+
+  it('defaults sdd off with no config (opt-in)', () => {
+    expect(resolveModes('42')).toMatchObject({ sdd: false });
+  });
+
+  it('an explicit flag outranks the config and is attributed to the flag', () => {
+    expect(resolveModes('-sd 42')).toMatchObject({ sdd: true, sddSrc: 'flag' });
+    expect(resolveModes('--no-sdd 42', SDD_ON)).toMatchObject({ sdd: false, sddSrc: 'flag' });
+  });
+
+  it('parses a value beginning with "-" (the --args= convention)', () => {
+    // Regression: `--args "-sd 42"` degraded to args=true and lost the flags.
+    expect(resolveModes('-sd 42')).toMatchObject({ sdd: true, sddSrc: 'flag' });
+  });
+
+  it('does not mistake -s (swarm) for -sd (sdd)', () => {
+    expect(resolveModes('-s 42')).toMatchObject({ sdd: false });
+  });
+
+  it('verify is on by default and opt-out via gates.verify_before_done', () => {
+    expect(resolveModes('42')).toMatchObject({ verify: true });
+    expect(resolveModes('42', 'gates:\n  verify_before_done: false\n')).toMatchObject({ verify: false });
+  });
+
+  it('--sdd implies verify, but --no-verify still wins', () => {
+    expect(resolveModes('-sd 42', 'gates:\n  verify_before_done: false\n')).toMatchObject({ verify: true });
+    expect(resolveModes('-sd --no-verify 42')).toMatchObject({ sdd: true, verify: false });
+  });
+
+  it('merge follows merge.auto and its per-run overrides', () => {
+    expect(resolveModes('42', 'merge:\n  auto: true\n')).toMatchObject({ merge: true, mergeSrc: 'moflo.yaml merge.auto' });
+    expect(resolveModes('--no-merge 42', 'merge:\n  auto: true\n')).toMatchObject({ merge: false });
+    expect(resolveModes('-m 42')).toMatchObject({ merge: true, mergeSrc: 'flag' });
+  });
+
+  it('clears inapplicable modifiers per workflow mode', () => {
+    expect(resolveModes('-t 42', SDD_ON)).toMatchObject({ workflow: 'ticket', sdd: true, verify: false, merge: false });
+    expect(resolveModes('-r 42', SDD_ON)).toMatchObject({ workflow: 'research', sdd: false, verify: false });
+    expect(resolveModes('--epic-branch foo 42', 'merge:\n  auto: true\n')).toMatchObject({ merge: false });
+  });
+
+  it('handles an empty argument string', () => {
+    expect(resolveModes('', SDD_ON)).toMatchObject({ workflow: 'full', sdd: true });
+  });
+});

--- a/src/cli/__tests__/sdd/sdd-mode-resolve.test.ts
+++ b/src/cli/__tests__/sdd/sdd-mode-resolve.test.ts
@@ -93,4 +93,66 @@ describe('flo sdd mode', () => {
   it('handles an empty argument string', () => {
     expect(resolveModes('', SDD_ON)).toMatchObject({ workflow: 'full', sdd: true });
   });
+
+  it('re-attributes a mode that applicability turned off', () => {
+    // A false must never carry the source of the value it no longer has.
+    expect(resolveModes('-r 42', SDD_ON)).toMatchObject({
+      sdd: false, sddSrc: 'research mode produces no spec artifacts',
+    });
+    expect(resolveModes('--epic-branch foo 42', 'merge:\n  auto: true\n')).toMatchObject({
+      merge: false, mergeSrc: '--epic-branch owns merging',
+    });
+  });
+});
+
+/**
+ * The CLI fallback and bin/gate.cjs are separate implementations of the same
+ * precedence rules — exactly the shape that let `sdd.default: true` be enforced
+ * by one and ignored by the other. Assert they agree on every axis, so a change
+ * to one that is not mirrored into the other fails here rather than in a
+ * consumer's silently-non-SDD run.
+ */
+describe('flo sdd mode agrees with bin/gate.cjs', () => {
+  const GATE = resolve(__dirname, '../../../../bin/gate.cjs');
+
+  function gateModes(floArgs: string, moflo: string): Record<string, boolean | string> {
+    writeFileSync(join(tmpDir, 'moflo.yaml'), moflo);
+    const out = execFileSync('node', [GATE, 'prompt-reminder'], {
+      env: {
+        ...(process.env as Record<string, string>),
+        CLAUDE_PROJECT_DIR: tmpDir,
+        CLAUDE_USER_PROMPT: `/flo ${floArgs}`,
+        TOOL_INPUT_command: '', TOOL_INPUT_file_path: '', TOOL_INPUT_skill: '', HOOK_SESSION_ID: '',
+      },
+      encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const line = out.split(/\r?\n/).find((l) => l.includes('/flo run modes')) ?? '';
+    const grab = (k: string) => (line.match(new RegExp(`${k}=(ON|off)`)) || [])[1] === 'ON';
+    return {
+      sdd: grab('sdd'), verify: grab('verify'), merge: grab('merge'),
+      workflow: (line.match(/workflow=(\w[\w-]*)/) || [])[1] ?? '',
+    };
+  }
+
+  const CASES: Array<[string, string]> = [
+    ['42', SDD_ON],
+    ['42', ''],
+    ['-sd 42', ''],
+    ['--no-sdd 42', SDD_ON],
+    ['-s 42', SDD_ON],
+    ['-r 42', SDD_ON],
+    ['-t 42', SDD_ON],
+    ['-sd --no-verify 42', ''],
+    ['42', 'merge:\n  auto: true\n'],
+    ['--no-merge 42', 'merge:\n  auto: true\n'],
+    ['42', 'gates:\n  verify_before_done: false\n'],
+    ['--epic-branch foo 42', 'merge:\n  auto: true\n'],
+  ];
+
+  it.each(CASES)('resolves %j (config %j) the same way', (floArgs, moflo) => {
+    const cli = resolveModes(floArgs, moflo);
+    expect({
+      sdd: cli.sdd, verify: cli.verify, merge: cli.merge, workflow: cli.workflow,
+    }).toEqual(gateModes(floArgs, moflo));
+  });
 });

--- a/src/cli/commands/sdd.ts
+++ b/src/cli/commands/sdd.ts
@@ -16,6 +16,7 @@
  *   flo sdd path <slug> [spec|plan]  Print the artifact path (for skill shell-out)
  *   flo sdd embed <slug>             Print spec+plan as a PR-body block (#1297)
  *   flo sdd index                    Re-index specs into memory now (also runs at session start)
+ *   flo sdd mode --args "<flo args>" Resolve sdd/verify/merge for a /flo run as JSON
  */
 
 import { spawnSync } from 'node:child_process';
@@ -24,6 +25,7 @@ import { dirname, join } from 'node:path';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { findProjectRoot } from '../services/project-root.js';
+import { loadMofloConfig } from '../config/moflo-config.js';
 import { locateMofloRootPath } from '../services/moflo-require.js';
 import {
   type SddArtifactKind,
@@ -251,6 +253,80 @@ function cmdList(ctx: CommandContext): CommandResult {
   return { success: true, data: specs };
 }
 
+/**
+ * Resolve the effective `/flo` run modifiers from an argument string + moflo.yaml
+ * and print them as JSON. This is the FALLBACK path for the authoritative
+ * announcement that `bin/gate.cjs prompt-reminder` normally injects on every
+ * `/flo` prompt — consumers with hooks disabled (or a gate.cjs predating this
+ * change) still get a deterministic answer by shelling out to this.
+ *
+ * Exists because the `/flo` skill used to carry `let sddMode = false` as a
+ * literal beside a comment saying "seed from moflo.yaml"; the model executed the
+ * literal and `sdd.default: true` was silently ignored. Config-derived run modes
+ * must be COMPUTED, never described in prose next to a contradicting default.
+ *
+ * Precedence per key: `--no-X` > `-x`/`--X` > moflo.yaml > built-in. Built-in
+ * defaults differ deliberately: sdd is opt-in (false), verify is opt-out (true,
+ * #1294), merge is opt-in (false, #1285).
+ *
+ * SYNC: mirrors `resolveFloRun` in bin/gate.cjs (and its copy in
+ * init/helpers-generator.ts). Any precedence change MUST land in all three.
+ */
+function cmdMode(ctx: CommandContext): CommandResult {
+  // MUST be passed as `--args=<value>`, not `--args <value>`: the flag parser
+  // only consumes a following token as a value when it does not start with `-`,
+  // so `--args "-sd 42"` would silently degrade to `args=true` and resolve every
+  // run to the bare config default. The `=` form bypasses that lookahead.
+  // parseValue may coerce a bare numeric ("42") to a number — coerce back.
+  const flagArgs = ctx.flags?.args;
+  const raw = (typeof flagArgs === 'string' || typeof flagArgs === 'number')
+    ? String(flagArgs)
+    : (ctx.args ?? []).slice(1).join(' ');
+  // Tokenize on whitespace so `-sd` is matched as a whole token — it is NOT
+  // `-s` (swarm) + `d`.
+  const tokens = raw.trim().split(/\s+/).filter(Boolean);
+  const has = (...names: string[]): boolean => names.some((n) => tokens.includes(n));
+
+  const cfg = loadMofloConfig(projectRoot(ctx));
+
+  let workflow: 'full' | 'ticket' | 'research' | 'spell-engine' = 'full';
+  if (has('-wf', '--workflow')) workflow = 'spell-engine';
+  else if (has('-r', '--research')) workflow = 'research';
+  else if (has('-t', '--ticket')) workflow = 'ticket';
+  const epicBranch = has('--epic-branch');
+
+  let sdd = false;
+  let sddSrc = 'default';
+  if (has('--no-sdd')) { sdd = false; sddSrc = 'flag'; }
+  else if (has('-sd', '--sdd')) { sdd = true; sddSrc = 'flag'; }
+  else if (cfg.sdd.default) { sdd = true; sddSrc = 'moflo.yaml sdd.default'; }
+
+  let verify: boolean;
+  let verifySrc = 'default';
+  if (has('--no-verify')) { verify = false; verifySrc = 'flag'; }
+  else if (has('-v', '--verify')) { verify = true; verifySrc = 'flag'; }
+  else if (!cfg.gates.verify_before_done) { verify = false; verifySrc = 'moflo.yaml gates.verify_before_done'; }
+  else { verify = true; }
+  // --sdd implies --verify: a spec/plan without an enforced verify step drifts.
+  if (sdd && !verify && verifySrc !== 'flag') verify = true;
+
+  let merge = false;
+  let mergeSrc = 'default';
+  if (has('--no-merge')) { merge = false; mergeSrc = 'flag'; }
+  else if (has('-m', '--merge')) { merge = true; mergeSrc = 'flag'; }
+  else if (cfg.merge.auto) { merge = true; mergeSrc = 'moflo.yaml merge.auto'; }
+
+  // Applicability: -t/-r never implement, so verify is a no-op there; -r and -wf
+  // produce no spec artifacts (in -t the spec/plan goes INTO the ticket, so sdd
+  // stays on). Only a full, non-epic-branch run opens a PR to merge.
+  if (workflow === 'ticket' || workflow === 'research') verify = false;
+  if (workflow === 'research' || workflow === 'spell-engine') sdd = false;
+  if (workflow !== 'full' || epicBranch) merge = false;
+
+  console.log(JSON.stringify({ workflow, sdd, verify, merge, sddSrc, verifySrc, mergeSrc }, null, 2));
+  return { success: true };
+}
+
 function cmdPath(ctx: CommandContext): CommandResult {
   const root = projectRoot(ctx);
   const slug = slugify(ctx.args[1] || '');
@@ -322,7 +398,8 @@ Spec-Driven Development artifacts (.moflo/specs/<slug>/{spec,plan}.md):
   list                     List every spec slug
   path <slug> [spec|plan]  Print the artifact path
   embed <slug>             Print spec+plan as a collapsible block for the PR body
-  index                    Re-index specs into memory now`;
+  index                    Re-index specs into memory now
+  mode --args "<flo args>" Resolve sdd/verify/merge for a /flo run as JSON (moflo.yaml + flags)`;
 
 const sddCommand: Command = {
   name: 'sdd',
@@ -351,6 +428,8 @@ const sddCommand: Command = {
         return cmdStatus(ctx);
       case 'list':
         return cmdList(ctx);
+      case 'mode':
+        return cmdMode(ctx);
       case 'path':
         return cmdPath(ctx);
       case 'embed':

--- a/src/cli/commands/sdd.ts
+++ b/src/cli/commands/sdd.ts
@@ -319,9 +319,20 @@ function cmdMode(ctx: CommandContext): CommandResult {
   // Applicability: -t/-r never implement, so verify is a no-op there; -r and -wf
   // produce no spec artifacts (in -t the spec/plan goes INTO the ticket, so sdd
   // stays on). Only a full, non-epic-branch run opens a PR to merge.
-  if (workflow === 'ticket' || workflow === 'research') verify = false;
-  if (workflow === 'research' || workflow === 'spell-engine') sdd = false;
-  if (workflow !== 'full' || epicBranch) merge = false;
+  // Re-attribute anything applicability turned off — a false must never carry the
+  // source of the value it no longer has. SYNC: mirrors bin/gate.cjs.
+  if (workflow === 'ticket' || workflow === 'research') {
+    if (verify) verifySrc = `${workflow} mode does not implement`;
+    verify = false;
+  }
+  if (workflow === 'research' || workflow === 'spell-engine') {
+    if (sdd) sddSrc = `${workflow} mode produces no spec artifacts`;
+    sdd = false;
+  }
+  if (workflow !== 'full' || epicBranch) {
+    if (merge) mergeSrc = epicBranch ? '--epic-branch owns merging' : `${workflow} mode opens no PR`;
+    merge = false;
+  }
 
   console.log(JSON.stringify({ workflow, sdd, verify, merge, sddSrc, verifySrc, mergeSrc }, null, 2));
   return { success: true };

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -442,9 +442,20 @@ function resolveFloRun(promptText) {
   else if (/(?:^|\\s)(?:-m|--merge)\\b/.test(p)) { out.merge = true; out.mergeSrc = 'flag'; }
   else if (mergeConf.auto) { out.merge = true; out.mergeSrc = 'moflo.yaml merge.auto'; }
 
-  if (out.workflow === 'ticket' || out.workflow === 'research') out.verify = false;
-  if (out.workflow === 'research' || out.workflow === 'spell-engine') out.sdd = false;
-  if (out.workflow !== 'full' || epicBranch) out.merge = false;
+  // Re-attribute anything applicability turned off — a false must never carry
+  // the source of the value it no longer has. SYNC: mirrors bin/gate.cjs.
+  if (out.workflow === 'ticket' || out.workflow === 'research') {
+    if (out.verify) out.verifySrc = out.workflow + ' mode does not implement';
+    out.verify = false;
+  }
+  if (out.workflow === 'research' || out.workflow === 'spell-engine') {
+    if (out.sdd) out.sddSrc = out.workflow + ' mode produces no spec artifacts';
+    out.sdd = false;
+  }
+  if (out.workflow !== 'full' || epicBranch) {
+    if (out.merge) out.mergeSrc = epicBranch ? '--epic-branch owns merging' : out.workflow + ' mode opens no PR';
+    out.merge = false;
+  }
   return out;
 }
 

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -303,6 +303,18 @@ function loadSddConfig() {
   return out;
 }
 
+// #1285 — parse the top-level merge: block. Block-scoped like loadSddConfig.
+// SYNC: mirrors bin/gate.cjs loadMergeConfig.
+function loadMergeConfig() {
+  var out = { auto: false };
+  var content = MOFLO_YAML;
+  if (!content) return out;
+  var block = content.match(/^merge:[ \\t]*\\r?\\n((?:[ \\t]+.*(?:\\r?\\n|$))*)/m);
+  if (!block) return out;
+  if (/^\\s*auto:\\s*true\\b/im.test(block[1])) out.auto = true;
+  return out;
+}
+
 // #1297 — read moflo.yaml once (both loaders parse it; gate fires on every
 // Write/Edit). SYNC: mirrors bin/gate.cjs readMofloYaml.
 function readMofloYaml() {
@@ -313,6 +325,7 @@ var MOFLO_YAML = readMofloYaml();
 
 var config = loadGateConfig();
 var sddConf = loadSddConfig();
+var mergeConf = loadMergeConfig();
 var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
@@ -398,13 +411,47 @@ function detectFlMode(promptText) {
   return null;
 }
 
-// #1297 — arm the SDD implement gate from a /flo prompt. SYNC: mirrors bin/gate.cjs.
-function detectSddMode(promptText) {
+// Resolve ALL /flo run modifiers from the prompt + moflo.yaml. Single source of
+// truth for gate arming AND the authoritative announcement below — a second
+// implementation is how sdd.default got silently ignored. Precedence per key:
+// --no-X > -x/--X > moflo.yaml > built-in (sdd opt-in, verify opt-out, merge
+// opt-in). SYNC: mirrors bin/gate.cjs resolveFloRun.
+function resolveFloRun(promptText) {
   var p = promptText || '';
-  if (!/^\\s*\\/(?:fl|flo)\\b/i.test(p)) return false;
-  if (/(?:^|\\s)--no-sdd\\b/.test(p)) return false;
-  if (/(?:^|\\s)(?:-sd|--sdd)\\b/.test(p)) return true;
-  return !!sddConf.default;
+  var out = { isFlo: false, workflow: 'full', sdd: false, verify: false, merge: false,
+              sddSrc: 'default', verifySrc: 'default', mergeSrc: 'default' };
+  if (!/^\\s*\\/(?:fl|flo)\\b/i.test(p)) return out;
+  out.isFlo = true;
+
+  if (/(?:^|\\s)(?:-wf|--workflow)\\b/.test(p)) out.workflow = 'spell-engine';
+  else if (/(?:^|\\s)(?:-r|--research)\\b/.test(p)) out.workflow = 'research';
+  else if (/(?:^|\\s)(?:-t|--ticket)\\b/.test(p)) out.workflow = 'ticket';
+  var epicBranch = /(?:^|\\s)--epic-branch\\b/.test(p);
+
+  if (/(?:^|\\s)--no-sdd\\b/.test(p)) { out.sdd = false; out.sddSrc = 'flag'; }
+  else if (/(?:^|\\s)(?:-sd|--sdd)\\b/.test(p)) { out.sdd = true; out.sddSrc = 'flag'; }
+  else if (sddConf.default) { out.sdd = true; out.sddSrc = 'moflo.yaml sdd.default'; }
+
+  if (/(?:^|\\s)--no-verify\\b/.test(p)) { out.verify = false; out.verifySrc = 'flag'; }
+  else if (/(?:^|\\s)(?:-v|--verify)\\b/.test(p)) { out.verify = true; out.verifySrc = 'flag'; }
+  else if (!config.verify_before_done) { out.verify = false; out.verifySrc = 'moflo.yaml gates.verify_before_done'; }
+  else { out.verify = true; out.verifySrc = 'default'; }
+  if (out.sdd && !out.verify && out.verifySrc !== 'flag') out.verify = true;
+
+  if (/(?:^|\\s)--no-merge\\b/.test(p)) { out.merge = false; out.mergeSrc = 'flag'; }
+  else if (/(?:^|\\s)(?:-m|--merge)\\b/.test(p)) { out.merge = true; out.mergeSrc = 'flag'; }
+  else if (mergeConf.auto) { out.merge = true; out.mergeSrc = 'moflo.yaml merge.auto'; }
+
+  if (out.workflow === 'ticket' || out.workflow === 'research') out.verify = false;
+  if (out.workflow === 'research' || out.workflow === 'spell-engine') out.sdd = false;
+  if (out.workflow !== 'full' || epicBranch) out.merge = false;
+  return out;
+}
+
+// #1297 — arm the SDD implement gate from a /flo prompt. Thin wrapper so the
+// armed decision and the announced decision can never disagree.
+function detectSddMode(promptText) {
+  return resolveFloRun(promptText).sdd;
 }
 
 // SDD specs-root resolution + artifact helpers for check-before-implement.
@@ -789,6 +836,30 @@ switch (command) {
     applyPromptStateReset(s, prompt);
     s.interactionCount = (s.interactionCount || 0) + 1;
     writeState(s);
+    // Announce the resolved /flo run modifiers. moflo.yaml was already parsed in
+    // THIS process (fresh per prompt — a git pull or mid-session yaml edit is
+    // picked up automatically, no cache to invalidate), so this costs no extra
+    // read. SYNC: mirrors bin/gate.cjs prompt-reminder.
+    var floRun = resolveFloRun(prompt);
+    if (floRun.isFlo) {
+      console.log(
+        '[moflo] /flo run modes (AUTHORITATIVE — use verbatim; do NOT re-derive from the skill defaults): ' +
+        'sdd=' + (floRun.sdd ? 'ON' : 'off') +
+        ' verify=' + (floRun.verify ? 'ON' : 'off') +
+        ' merge=' + (floRun.merge ? 'ON' : 'off') +
+        ' [workflow=' + floRun.workflow + ']'
+      );
+      if (floRun.sdd && floRun.sddSrc !== 'flag') {
+        console.log(
+          '[moflo] sdd is ON via ' + floRun.sddSrc + ' — the spec→plan→implement→verify cycle is ' +
+          'MANDATORY this run. Author the spec before editing source (the sdd_gate blocks source ' +
+          'Write/Edit until a reviewed plan exists). One-off opt out: re-run with --no-sdd.'
+        );
+      }
+      if (floRun.merge && floRun.mergeSrc !== 'flag') {
+        console.log('[moflo] merge is ON via ' + floRun.mergeSrc + ' — the PR will be auto-merged. Opt out: --no-merge.');
+      }
+    }
     if (config.context_tracking) {
       var ic = s.interactionCount;
       if (ic > 30) console.log('Context: CRITICAL. Commit, store learnings, suggest new session.');

--- a/tests/bin/gate-flo-run-modes.test.ts
+++ b/tests/bin/gate-flo-run-modes.test.ts
@@ -1,0 +1,165 @@
+/**
+ * System tests for the authoritative /flo run-mode announcement.
+ *
+ * Context: `moflo.yaml sdd.default: true` was being silently ignored. The
+ * resolution logic in bin/gate.cjs was correct and already re-read moflo.yaml on
+ * every prompt, but it never SURFACED the result — and the /flo skill carried
+ * `let sddMode = false` as a literal beside a comment saying "seed from
+ * moflo.yaml", so the model executed the literal and ran a non-SDD cycle.
+ *
+ * These tests run the real bin/gate.cjs as a subprocess (as Claude Code invokes
+ * it via the UserPromptSubmit hook) and assert:
+ *   - a /flo prompt emits the `[moflo] /flo run modes` line on stdout
+ *   - the announced sdd/verify/merge values honor moflo.yaml, per-run flags, and
+ *     flag-over-config precedence
+ *   - a config-sourced ON (one the user did not type) gets the extra explainer
+ *   - non-/flo prompts emit nothing (zero cost for ordinary work)
+ *   - the announcement always agrees with the armed state.sddMode — one resolver,
+ *     so the gate and the announcement can never disagree
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+
+const GATE = resolve(__dirname, '../../bin/gate.cjs');
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = resolve(tmpdir(), `moflo-flo-modes-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+/** Run prompt-reminder for `prompt` against an optional moflo.yaml; return stdout + armed state. */
+function run(prompt: string, moflo?: string): { out: string; state: Record<string, unknown> } {
+  if (moflo !== undefined) writeFileSync(join(tmpDir, 'moflo.yaml'), moflo);
+  const env = {
+    ...(process.env as Record<string, string>),
+    CLAUDE_PROJECT_DIR: tmpDir,
+    CLAUDE_USER_PROMPT: prompt,
+    TOOL_INPUT_command: '',
+    TOOL_INPUT_file_path: '',
+    TOOL_INPUT_skill: '',
+    HOOK_SESSION_ID: '',
+  };
+  const out = execFileSync('node', [GATE, 'prompt-reminder'], {
+    env, encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const f = join(tmpDir, '.claude', 'workflow-state.json');
+  const state = existsSync(f) ? JSON.parse(readFileSync(f, 'utf-8')) : {};
+  return { out, state };
+}
+
+/** Pull the `sdd=`/`verify=`/`merge=` values out of the announcement line. */
+function modes(out: string): Record<string, string> | null {
+  const line = out.split(/\r?\n/).find((l) => l.includes('/flo run modes'));
+  if (!line) return null;
+  const grab = (k: string) => (line.match(new RegExp(k + '=(ON|off)')) || [])[1];
+  return { sdd: grab('sdd'), verify: grab('verify'), merge: grab('merge') };
+}
+
+const SDD_ON = 'sdd:\n  default: true\n';
+
+describe('prompt-reminder: /flo run-mode announcement', () => {
+  it('emits nothing for a non-/flo prompt', () => {
+    expect(run('fix a bug', SDD_ON).out).not.toContain('/flo run modes');
+  });
+
+  it('announces sdd=ON for a bare /flo when moflo.yaml sets sdd.default: true', () => {
+    // The exact regression: bare /flo on an sdd-default project must not read as off.
+    expect(modes(run('/flo 42', SDD_ON).out)).toMatchObject({ sdd: 'ON' });
+  });
+
+  it('attributes a config-sourced sdd=ON to moflo.yaml and states the cycle is mandatory', () => {
+    const { out } = run('/flo 42', SDD_ON);
+    expect(out).toContain('sdd is ON via moflo.yaml sdd.default');
+    expect(out).toContain('MANDATORY');
+  });
+
+  it('omits the explainer when the user typed the flag themselves', () => {
+    const { out } = run('/flo -sd 42', '');
+    expect(modes(out)).toMatchObject({ sdd: 'ON' });
+    expect(out).not.toContain('sdd is ON via');
+  });
+
+  it('announces sdd=off for a bare /flo with no config', () => {
+    expect(modes(run('/flo 42', '').out)).toMatchObject({ sdd: 'off' });
+  });
+
+  it('--no-sdd overrides sdd.default: true', () => {
+    expect(modes(run('/flo --no-sdd 42', SDD_ON).out)).toMatchObject({ sdd: 'off' });
+  });
+
+  it('-s (swarm) is not mistaken for -sd (sdd)', () => {
+    expect(modes(run('/flo -s 42', '').out)).toMatchObject({ sdd: 'off' });
+  });
+
+  it('verify is ON by default (#1294) and off when gates.verify_before_done: false', () => {
+    expect(modes(run('/flo 42', '').out)).toMatchObject({ verify: 'ON' });
+    const off = 'gates:\n  verify_before_done: false\n';
+    expect(modes(run('/flo 42', off).out)).toMatchObject({ verify: 'off' });
+  });
+
+  it('--sdd implies verify even when gates.verify_before_done: false', () => {
+    const off = 'gates:\n  verify_before_done: false\n';
+    expect(modes(run('/flo -sd 42', off).out)).toMatchObject({ sdd: 'ON', verify: 'ON' });
+  });
+
+  it('--no-verify still wins over the --sdd implication', () => {
+    expect(modes(run('/flo -sd --no-verify 42', '').out)).toMatchObject({ sdd: 'ON', verify: 'off' });
+  });
+
+  it('merge follows moflo.yaml merge.auto and is attributed when not typed', () => {
+    const { out } = run('/flo 42', 'merge:\n  auto: true\n');
+    expect(modes(out)).toMatchObject({ merge: 'ON' });
+    expect(out).toContain('merge is ON via moflo.yaml merge.auto');
+  });
+
+  it('--no-merge overrides merge.auto: true', () => {
+    expect(modes(run('/flo --no-merge 42', 'merge:\n  auto: true\n').out)).toMatchObject({ merge: 'off' });
+  });
+
+  it('does not confuse a merge.auto key with sdd.default (block scoping)', () => {
+    // A bare `auto: true` under another section must not turn merge on.
+    const other = 'epic:\n  auto: true\n\nsdd:\n  default: true\n';
+    expect(modes(run('/flo 42', other).out)).toMatchObject({ sdd: 'ON', merge: 'off' });
+  });
+
+  it('clears verify in -t/-r (no implementation) and sdd in -r (no artifacts)', () => {
+    expect(modes(run('/flo -t 42', SDD_ON).out)).toMatchObject({ sdd: 'ON', verify: 'off' });
+    expect(modes(run('/flo -r 42', SDD_ON).out)).toMatchObject({ sdd: 'off', verify: 'off' });
+  });
+
+  it('clears merge under --epic-branch (the epic orchestrator owns merging)', () => {
+    const cfg = 'merge:\n  auto: true\n';
+    expect(modes(run('/flo --epic-branch foo 42', cfg).out)).toMatchObject({ merge: 'off' });
+  });
+
+  it('the announced sdd always matches the armed state.sddMode', () => {
+    // One resolver feeds both — a divergence here is the bug class this fixes.
+    for (const [prompt, cfg] of [
+      ['/flo 42', SDD_ON], ['/flo -sd 42', ''], ['/flo --no-sdd 42', SDD_ON],
+      ['/flo -s 42', ''], ['/flo -r 42', SDD_ON], ['/flo -t 42', SDD_ON],
+    ] as const) {
+      const { out, state } = run(prompt, cfg);
+      expect(modes(out)!.sdd === 'ON', `${prompt} (cfg=${JSON.stringify(cfg)})`).toBe(state.sddMode === true);
+    }
+  });
+
+  it('picks up a moflo.yaml edit on the very next prompt (no cache to invalidate)', () => {
+    // Fresh process per prompt is what makes a git pull mid-session safe.
+    expect(modes(run('/flo 42', '').out)).toMatchObject({ sdd: 'off' });
+    expect(modes(run('/flo 42', SDD_ON).out)).toMatchObject({ sdd: 'ON' });
+  });
+
+  it('tolerates CRLF line endings in moflo.yaml (Rule #1)', () => {
+    expect(modes(run('/flo 42', 'sdd:\r\n  default: true\r\n').out)).toMatchObject({ sdd: 'ON' });
+  });
+});


### PR DESCRIPTION
## Problem

`moflo.yaml sdd.default: true` was silently ignored — a `/flo` run resolved `sdd=off` and skipped the entire spec→plan cycle without the user noticing.

The resolution logic in `bin/gate.cjs` was already correct and already re-read `moflo.yaml` on every prompt. But it never **surfaced** the result, and the `/flo` skill carried this:

```js
// SDD/verify modifiers... Seed from moflo.yaml BEFORE parsing
let sddMode = false;          // -sd / --sdd
```

A comment saying "seed from moflo.yaml" next to a literal `false` loses every time — the model executes the literal. The `sdd_gate` backstop only fires on a source `Write`, so runs that edited only docs (or ended before implementing) never tripped it. Enforcement without announcement is invisible.

## Fix

**Gate** — `bin/gate.cjs`, mirrored into `init/helpers-generator.ts` and `.claude/helpers/`

- `resolveFloRun()`: one resolver for `sdd`/`verify`/`merge` + workflow mode. Precedence `--no-X` > `-x/--X` > `moflo.yaml` > built-in, with source attribution. `detectSddMode` is now a thin wrapper over it, so the **armed** gate state and the **announced** value cannot disagree.
- `loadMergeConfig()` — block-scoped like `loadSddConfig`, so a stray `auto: true` under another section can't turn auto-merge on.
- `prompt-reminder` (UserPromptSubmit) emits on `/flo` prompts only:

```
[moflo] /flo run modes (AUTHORITATIVE — use verbatim; do NOT re-derive from the skill defaults): sdd=ON verify=ON merge=off [workflow=full]
[moflo] sdd is ON via moflo.yaml sdd.default — the spec→plan→implement→verify cycle is MANDATORY this run. …
```

The second line fires only when a mode came from config rather than a typed flag. Zero extra reads (the process already parsed `moflo.yaml`), nothing emitted for non-`/flo` prompts, and **fresh per prompt** — a `git pull` or mid-session yaml edit is picked up with no cache to invalidate. That's why this is resolve-at-use rather than cache-at-session-start: no invalidation to get wrong, no context cost on sessions that never run `/flo`.

**Skill** — `.claude/skills/fl/`

Literals replaced with `let sddMode, verifyMode, mergeMode;` plus a new "Resolved run modes" section: take them from the injected line, else fall back to `flo sdd mode --args="$ARGUMENTS"`, else say so and stop rather than guess. `sdd.md` now states the built-in defaults are project-configurable and must never be assumed.

**CLI** — `src/cli/commands/sdd.ts`

`flo sdd mode` resolves the same precedence via `loadMofloConfig()` and prints JSON. The `--args=` form is required: `--args <value>` degrades to `args=true` when the value starts with `-`, silently returning the bare config default.

## Behaviour change

`-r`/`-wf` now clear `sddMode` (previously `-sd -r` armed the gate). This matches what `SKILL.md` already documented (*"`--sdd` ignored — research mode produces no artifacts"*); no test asserted the old shape.

## Tests — 54 new, full suite green at 9495

| File | Covers |
|---|---|
| `tests/bin/gate-flo-run-modes.test.ts` | Announcement correctness, precedence, `-s` vs `-sd`, block scoping, CRLF, next-prompt pickup, announced-matches-armed across 6 combos |
| `src/cli/__tests__/sdd/sdd-mode-resolve.test.ts` | CLI fallback incl. the `--args=` regression, plus a 12-case cross-check that `flo sdd mode` and `bin/gate.cjs` resolve identically |
| `src/cli/__tests__/init/helpers-generator-flo-modes.test.ts` | Drift guard: runs the generated fallback copy as a subprocess, asserts identical announcements to `bin/gate.cjs` across 10 cases |

The precedence rules necessarily exist in three places — `bin/gate.cjs` is zero-bootstrap CJS and can't import the TS config loader, and `helpers-generator.ts` embeds a verbatim copy by design. Both duplications are now pinned by **behavioural** equivalence tests (run each copy, compare output) rather than source diffs, so they survive the cosmetic divergence between the copies while catching any real drift.

## Review + verification

`/flo-simplify` classified this DEEP (security-sensitive path, 12 net-new decls). Two findings, both fixed in 7080c0e7d: cleared modes were keeping the attribution of the value they no longer had, and nothing asserted the CLI agreed with the gate. Validation pass clean.

`/verify` — **PASS 7/7**. No SDD plan/spec or ticket existed (non-SDD run), so criteria were inferred from the reported symptom and stated as such. Beyond the unit tests, two criteria were proven with live gate output: a bare `/flo` on an `sdd.default: true` project emitting the AUTHORITATIVE line, and two consecutive prompts with `moflo.yaml` edited between them flipping `sdd=off` → `sdd=ON` (the "after a git pull" case).

## Consumer impact

`bin/gate.cjs`, `helpers-generator.ts` and `.claude/skills/**` all ship — needs publish + reinstall. Additive: an older gate means no injected line (skill falls through to the CLI); an older skill with the new gate just sees an extra informational line. No `.moflo/` state change, no migration.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_01VMp6y7r5jfSMy5V6Ji3pdG
