### PR TITLE
fix(tests): stop CLI subprocesses leaking orphaned daemons

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -529,6 +529,21 @@ export class CLI {
    * Non-blocking — fires and forgets. Errors are silently swallowed.
    */
   private async maybeAutoStartDaemon(): Promise<void> {
+    // Test-only kill switch. A test that shells the CLI into a throwaway tmp
+    // project gets `daemon.auto_start: true` from DEFAULT_CONFIG (no moflo.yaml
+    // there to say otherwise), so EVERY such invocation spawned a detached,
+    // unref'd daemon. When the test then removed its tmp dir, the daemon
+    // survived holding a deleted cwd — no lockfile left to contend for, no
+    // project root to match, so nothing ever reclaimed it. One full suite run
+    // leaked several; they accumulated across runs into dozens of ~87MB
+    // processes that only `doctor --fix` could reap.
+    //
+    // Set in vitest.setup.ts alongside MOFLO_TEST_TRUST_DAEMON_PID and
+    // MOFLO_TEST_SKIP_ORPHAN_SCAN. Subprocesses inherit it, which is what makes
+    // it reach the spawned CLI. Production never sets it; a test that genuinely
+    // wants autostart can delete it in its own beforeEach, same as the others.
+    if (process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART === '1') return;
+
     const config = loadMofloConfig(process.cwd());
     if (!config.daemon.auto_start) return;
 

--- a/tests/system/no-leaked-daemons.test.ts
+++ b/tests/system/no-leaked-daemons.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression guard: shelling out to the CLI from a test must not leak a daemon.
+ *
+ * `CLI.maybeAutoStartDaemon()` is gated on `daemon.auto_start`, which is `true`
+ * in DEFAULT_CONFIG. A test that runs `bin/cli.js` inside a throwaway tmp
+ * project has no `moflo.yaml` to say otherwise, so every invocation spawned a
+ * `detached: true` + `unref()`'d daemon. When the test removed its tmp dir the
+ * daemon survived holding a deleted cwd — permanently orphaned, because there
+ * is no lockfile left to contend for and no project root to match it to. One
+ * full suite run leaked several; across runs they accumulated into dozens of
+ * ~87MB processes that only `doctor --fix` could reap (63 were found in one
+ * dogfood session).
+ *
+ * `MOFLO_TEST_SKIP_DAEMON_AUTOSTART=1` (set in vitest.setup.ts, inherited by
+ * subprocesses) closes it. This test proves the guard actually reaches the
+ * spawned CLI rather than merely being set — the failure mode was precisely a
+ * mitigation that looked present but never applied (the old comment in
+ * worktree-durable-sharing-e2e.test.ts claimed MOFLO_DAEMON_PORT prevented the
+ * spawn; it only steers write routing).
+ *
+ * POSIX-only assertions: counting live processes portably needs `ps`/`/proc`,
+ * and the Windows tasklist chain is exactly what vitest.setup.ts disables
+ * elsewhere for cost. The guard itself is platform-independent (a single env
+ * check before any spawn), so covering it on POSIX is sufficient.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const CLI = path.join(REPO_ROOT, 'bin', 'cli.js');
+const POSIX = process.platform !== 'win32';
+const CAN_RUN = POSIX && fs.existsSync(CLI);
+
+/**
+ * Count live daemons started from this repo's SOURCE tree. Session daemons run
+ * from `node_modules/moflo/bin/cli.js`, so keying on the source path counts
+ * only test-spawned ones and never touches the developer's real daemon.
+ */
+function sourceTreeDaemons(): number {
+  const needle = path.join(REPO_ROOT, 'bin', 'cli.js');
+  let out = '';
+  try {
+    out = execFileSync('ps', ['-eo', 'args'], { encoding: 'utf-8' });
+  } catch {
+    return -1; // ps unavailable — caller skips
+  }
+  return out
+    .split(/\r?\n/)
+    .filter((l) => l.includes(needle) && l.includes('daemon') && l.includes('start'))
+    // Exclude our own `ps` pipeline / shell, whose argv contains the needle.
+    .filter((l) => !l.includes('-eo') && !l.includes('ps '))
+    .length;
+}
+
+describe('no leaked daemons from CLI subprocesses', () => {
+  it.skipIf(!CAN_RUN)('repeated `flo` calls in a throwaway project spawn no daemon', () => {
+    const before = sourceTreeDaemons();
+    if (before < 0) return; // no ps — nothing to assert
+
+    const dir = fs.mkdtempSync(path.join(tmpdir(), 'no-leak-daemon-'));
+    try {
+      // No moflo.yaml here on purpose — that is the exact condition that made
+      // DEFAULT_CONFIG's `auto_start: true` apply and leak.
+      expect(fs.existsSync(path.join(dir, 'moflo.yaml'))).toBe(false);
+
+      // Use a REAL subcommand, not `--version`: version/help short-circuit
+      // before CLI init reaches maybeAutoStartDaemon, so probing with them
+      // passes even with the guard removed. Verified by hand — `--version` in a
+      // tmp project spawns nothing either way, while `memory list` spawns a
+      // daemon with the guard cleared and none with it set.
+      for (let i = 0; i < 3; i++) {
+        try {
+          execFileSync(process.execPath, [CLI, 'memory', 'list', '-n', 'learnings'], {
+            cwd: dir,
+            encoding: 'utf-8',
+            env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
+            stdio: ['ignore', 'pipe', 'pipe'],
+            timeout: 60_000,
+          });
+        } catch {
+          /* exit code is irrelevant — we only care that nothing was spawned */
+        }
+      }
+
+      // Autostart is fire-and-forget; give a spawn time to appear if it happened.
+      execFileSync(process.execPath, ['-e', 'setTimeout(()=>{},1500)'], { timeout: 10_000 });
+
+      expect(
+        sourceTreeDaemons(),
+        'a CLI subprocess spawned a daemon — MOFLO_TEST_SKIP_DAEMON_AUTOSTART is not reaching it',
+      ).toBe(before);
+    } finally {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }, 120_000);
+
+  it('vitest.setup.ts sets the guard, and the CLI honors it before any spawn', () => {
+    // The env half.
+    expect(process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART).toBe('1');
+
+    // The source half: the check must sit ahead of loadMofloConfig, or a repo
+    // with `auto_start: true` would still spawn before reaching it.
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'src', 'cli', 'index.ts'), 'utf-8');
+    const fn = src.indexOf('private async maybeAutoStartDaemon');
+    expect(fn, 'maybeAutoStartDaemon not found — did it get renamed?').toBeGreaterThan(-1);
+    const body = src.slice(fn, fn + 2500);
+    const guard = body.indexOf('MOFLO_TEST_SKIP_DAEMON_AUTOSTART');
+    const cfg = body.indexOf('loadMofloConfig');
+    expect(guard, 'autostart guard missing').toBeGreaterThan(-1);
+    expect(guard, 'guard must precede the config read').toBeLessThan(cfg);
+  });
+});

--- a/tests/system/no-leaked-daemons.test.ts
+++ b/tests/system/no-leaked-daemons.test.ts
@@ -47,11 +47,12 @@ function sourceTreeDaemons(): number {
   } catch {
     return -1; // ps unavailable — caller skips
   }
+  // Match `daemon start` as a contiguous phrase, not two independent
+  // substrings — `l.includes('daemon') && l.includes('start')` would also match
+  // an unrelated command that happened to mention both words.
   return out
     .split(/\r?\n/)
-    .filter((l) => l.includes(needle) && l.includes('daemon') && l.includes('start'))
-    // Exclude our own `ps` pipeline / shell, whose argv contains the needle.
-    .filter((l) => !l.includes('-eo') && !l.includes('ps '))
+    .filter((l) => l.includes(needle) && /\bdaemon\s+start\b/.test(l))
     .length;
 }
 
@@ -85,7 +86,10 @@ describe('no leaked daemons from CLI subprocesses', () => {
         }
       }
 
-      // Autostart is fire-and-forget; give a spawn time to appear if it happened.
+      // Autostart is fire-and-forget, so a spawn needs a moment to become
+      // visible to `ps`. Sleep via a node subprocess rather than `sleep` — the
+      // latter does not exist on Windows, and this file's other assertions are
+      // POSIX-gated but the delay should not be the reason why (Rule #1).
       execFileSync(process.execPath, ['-e', 'setTimeout(()=>{},1500)'], { timeout: 10_000 });
 
       expect(

--- a/tests/system/worktree-durable-sharing-e2e.test.ts
+++ b/tests/system/worktree-durable-sharing-e2e.test.ts
@@ -75,7 +75,14 @@ function initRepo(prefix: string): string {
 function flo(cwd: string, ...args: string[]): string {
   const env = { ...process.env, CLAUDE_PROJECT_DIR: cwd };
   // Force direct-DB writes: a closed daemon port makes the routing health-probe
-  // fail fast, so the store never depends on (or spawns) a daemon.
+  // fail fast, so the store never depends on a daemon.
+  //
+  // This does NOT stop one being spawned — the port only steers write ROUTING,
+  // while autostart is gated on `daemon.auto_start` (true in DEFAULT_CONFIG,
+  // and these tmp repos have no moflo.yaml to override it). That gap leaked a
+  // detached daemon per invocation, orphaned the moment the tmp dir was
+  // removed. MOFLO_TEST_SKIP_DAEMON_AUTOSTART (vitest.setup.ts, inherited here
+  // through process.env) is what actually prevents the spawn.
   env.MOFLO_DAEMON_PORT = '44571';
   delete env.MOFLO_DURABLE_PATH; // exercise auto-derivation, not an override
   return execFileSync(process.execPath, [CLI, ...args], {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -50,6 +50,19 @@ process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
 // surviving load. Production never sets this env var.
 process.env.MOFLO_TEST_TRUST_DAEMON_PID = '1';
 
+// Skip the CLI's daemon autostart. Tests that shell out to `bin/cli.js` inside
+// a throwaway tmp project hit `maybeAutoStartDaemon` with DEFAULT_CONFIG
+// (`daemon.auto_start: true`), which spawns a detached + unref'd daemon. The
+// test then removes its tmp dir and the daemon survives with a deleted cwd —
+// permanently orphaned, since there is no lockfile left to contend for and no
+// project root to match it to. These accumulated across suite runs into dozens
+// of ~87MB processes that only `doctor --fix` reaped.
+//
+// Subprocesses inherit this via `{ ...process.env }`, which is what makes it
+// reach the spawned CLI. A test that genuinely wants autostart deletes it in
+// its own `beforeEach`, same as the two vars below.
+process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART = '1';
+
 // #1150 — skip the same-project orphan scan in `acquireDaemonLock` for the
 // same reasons as TRUST_DAEMON_PID above: the PowerShell/CIM enumeration on
 // Windows is expensive and tests using synthetic tempDir-rooted "daemons"
@@ -72,5 +85,8 @@ beforeEach(() => {
   }
   if (process.env.MOFLO_TEST_SKIP_ORPHAN_SCAN !== '1') {
     process.env.MOFLO_TEST_SKIP_ORPHAN_SCAN = '1';
+  }
+  if (process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART !== '1') {
+    process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART = '1';
   }
 });


### PR DESCRIPTION
## Problem

A dogfood session accumulated **63 orphaned daemons** (~87MB RSS each, ~5.5GB total) that only `doctor --fix` could reap. Surfaced by `doctor --strict` failing during a publish.

`CLI.maybeAutoStartDaemon()` is gated on `daemon.auto_start`, which is `true` in `DEFAULT_CONFIG`:

```js
const config = loadMofloConfig(process.cwd());
if (!config.daemon.auto_start) return;   // true by default
const holder = getDaemonLockHolder(process.cwd());
if (holder) return;
// ... spawn(detached: true) + child.unref()
```

A test shelling out to `bin/cli.js` inside a throwaway tmp project has **no `moflo.yaml`** to override that, so every invocation spawned a detached, unref'd daemon. When the test then removed its tmp dir, the daemon survived holding a **deleted cwd**:

```
pid=3617586  etime=00:13
  cwd=/tmp/e2e-wt-main-OKwcnP  (deleted)
  bin=/home/eswann/Projects/moflo/bin/cli.js
```

Nothing ever reclaimed them — no lockfile left to contend for, no project root to match against — so they accumulated across suite runs indefinitely.

`worktree-durable-sharing-e2e.test.ts` *believed* it was protected. It set `MOFLO_DAEMON_PORT` to a closed port with a comment saying the store "never depends on (or spawns) a daemon". That only steers write **routing**; it never touched the autostart gate. A mitigation that looked present but never applied.

## Fix

Follows the existing `MOFLO_TEST_*` idiom already in `vitest.setup.ts` (`TRUST_DAEMON_PID`, `SKIP_ORPHAN_SCAN`): one env check at the top of `maybeAutoStartDaemon`, **ahead of the config read**. Subprocesses inherit it through `{ ...process.env }`, which is what makes it reach the spawned CLI.

Also corrected the misleading comment in the e2e test to describe what actually prevents the spawn.

## Verification

| Check | Before | After |
|---|---|---|
| `tests/system/` | 2 → 3 daemons | 1 → 1 |
| Full suite | leaked several | 2 → 2 (both survivors are the legitimate per-project daemons) |
| Hand probe (`memory list` in tmp project) | guard cleared: 3 → 4 | guard set: 4 → 4 |

- **Guard proved load-bearing**: temporarily disabled it in `vitest.setup.ts`; both new tests failed, the leak assertion counting a real spawned process (`expected 1 to be +0`).
- **Other projects unaffected**: a second session's daemon (`waxstak/code`) survived every full suite run untouched, still sole daemon for its root.
- Full suite **9497 passed / 0 failed**.

## Two notes on the regression test

1. The first draft probed with `flo --version` — which **short-circuits before CLI init reaches `maybeAutoStartDaemon`**, so it passed even with the guard removed. Vacuous; only running the negative case exposed it. The committed version probes with `memory list`, and the file documents why.
2. A follow-up cleanup changed the test's own matching logic (independent substrings to anchored `\bdaemon\s+start\b`). The negative case was **re-run after that change** — a cleanup to a detector can silently re-vacuum it.

## Consumer impact

`src/cli/index.ts` ships, so the guard reaches consumers on the next publish — but it is **inert** there. `MOFLO_TEST_SKIP_DAEMON_AUTOSTART` is written only by `vitest.setup.ts` and read only by `src/cli/index.ts`; no production path sets it (verified by grep). No behaviour change for any real install, so this doesn't warrant a release on its own.

## Not covered here

A daemon whose project root is deleted out from under it still idles forever rather than exiting. That's consumer-facing — it would also bite a user who deletes a project with a live daemon — and is worth a separate change.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_01VMp6y7r5jfSMy5V6Ji3pdG
