### PR TITLE
fix(context): trim always-resident listing footprint + record retained retired files (#1307)

### DIFF
--- a/.claude/agents/base-template-generator.md
+++ b/.claude/agents/base-template-generator.md
@@ -1,6 +1,6 @@
 ---
 name: base-template-generator
-description: Use this agent when you need to create foundational templates, boilerplate code, or starter configurations for new projects, components, or features. This agent excels at generating clean, well-structured base templates that follow best practices and can be easily customized. Examples: <example>Context: User needs to start a new React component and wants a solid foundation. user: 'I need to create a new user profile component' assistant: 'I'll use the base-template-generator agent to create a comprehensive React component template with proper structure, TypeScript definitions, and styling setup.' <commentary>Since the user needs a foundational template for a new component, use the base-template-generator agent to create a well-structured starting point.</commentary></example> <example>Context: User is setting up a new API endpoint and needs a template. user: 'Can you help me set up a new REST API endpoint for user management?' assistant: 'I'll use the base-template-generator agent to create a complete API endpoint template with proper error handling, validation, and documentation structure.' <commentary>The user needs a foundational template for an API endpoint, so use the base-template-generator agent to provide a comprehensive starting point.</commentary></example>
+description: Create foundational templates, boilerplate code, and starter configurations for new projects, components, or features. Use for scaffolding a new component, API endpoint, model, config, or test suite from scratch.
 color: orange
 ---
 
@@ -18,6 +18,26 @@ Search these namespaces depending on your task:
 On chunk hits where `navigation` is non-null, traverse via `mcp__moflo__memory_get_neighbors`. Bulk `mcp__moflo__memory_retrieve` is a protocol violation — see `.claude/guidance/moflo-memory-protocol.md`.
 
 You are a Base Template Generator, an expert architect specializing in creating clean, well-structured foundational templates and boilerplate code. Your expertise lies in establishing solid starting points that follow industry best practices, maintain consistency, and provide clear extension paths.
+
+## When you get dispatched
+
+Worked examples of the requests that route here — these live in the body, not the
+frontmatter `description`, because the description is always-resident routing
+context while this body only loads on dispatch.
+
+<example>
+Context: User needs to start a new React component and wants a solid foundation.
+user: 'I need to create a new user profile component'
+assistant: 'I'll use the base-template-generator agent to create a comprehensive React component template with proper structure, TypeScript definitions, and styling setup.'
+<commentary>Since the user needs a foundational template for a new component, use the base-template-generator agent to create a well-structured starting point.</commentary>
+</example>
+
+<example>
+Context: User is setting up a new API endpoint and needs a template.
+user: 'Can you help me set up a new REST API endpoint for user management?'
+assistant: 'I'll use the base-template-generator agent to create a complete API endpoint template with proper error handling, validation, and documentation structure.'
+<commentary>The user needs a foundational template for an API endpoint, so use the base-template-generator agent to provide a comprehensive starting point.</commentary>
+</example>
 
 Your core responsibilities:
 - Generate comprehensive base templates for components, modules, APIs, configurations, and project structures

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -713,7 +713,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -726,7 +726,7 @@ switch (command) {
     if (isEphemeralPath(fp)) break;
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -775,10 +775,11 @@ switch (command) {
     // "Memory namespace hint: ..." sentence so the BLOCK message stays uniform.
     var hint = s2.lastNamespaceHint || classifyBashNamespaceHint(cmd) || '';
     process.stderr.write(
-      'BLOCKED: Search memory before reading files via Bash.\n' +
+      'BLOCKED [moflo memory_first gate]: Search memory before reading files via Bash.\n' +
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\n' +
       (hint ? hint + '\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' +
+      'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.\n' +
       'Disable per-gate via moflo.yaml: gates: memory_first: false\n'
     );
     process.exit(2);

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -134,6 +134,13 @@ var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
 
+// Appended to every memory-first denial. Without it, a context audit of Claude
+// Code's denial telemetry reads moflo's gate enforcements as permission-setup
+// failures and "fixes" them with allow rules — which cannot override a hook
+// block at all (#1307 finding 5). Naming the gate makes the cause self-evident.
+var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.';
+var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
+
 // #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
 // (background-task output/transcripts, agent scratchpads) are transient tool
 // I/O and never carry indexable project knowledge, so they must not trip the
@@ -713,7 +720,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -726,7 +733,7 @@ switch (command) {
     if (isEphemeralPath(fp)) break;
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -779,8 +786,8 @@ switch (command) {
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\n' +
       (hint ? hint + '\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' +
-      'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.\n' +
-      'Disable per-gate via moflo.yaml: gates: memory_first: false\n'
+      GATE_ORIGIN_NOTE + '\n' +
+      GATE_DISABLE_NOTE + '\n'
     );
     process.exit(2);
     break;

--- a/.claude/scripts/lib/retired-files.mjs
+++ b/.claude/scripts/lib/retired-files.mjs
@@ -202,6 +202,64 @@ export function applyRetiredPrune(projectRoot, manifestPath) {
 }
 
 /**
+ * Reconcile an existing retained record against what is actually on disk.
+ *
+ * `writeRetainedRecord` only runs inside the launcher's UPGRADE branch (that
+ * is where `applyRetiredPrune` lives), so on its own it cannot keep the record
+ * honest: a user who reads the record and deletes the files would keep a
+ * record naming those files until their next moflo upgrade — the record would
+ * outlive what it describes, which is the same "not actionable" complaint
+ * #1307 raised about the truncated banner.
+ *
+ * This runs on EVERY session start instead, and is written to cost nothing in
+ * the common case: one `existsSync` when no record is present (overwhelmingly
+ * the norm), and only then a stat per retained entry.
+ *
+ * Never throws — advisory bookkeeping must not break session start.
+ *
+ * @param {string} projectRoot
+ * @returns {{ changed: boolean, removed: string[], remaining: number }}
+ */
+export function reconcileRetainedRecord(projectRoot) {
+  const result = { changed: false, removed: [], remaining: 0 };
+  const abs = resolve(projectRoot, RETAINED_RECORD_REL);
+  try {
+    if (!existsSync(abs)) return result;               // fast path — no record
+    // Corrupt/hand-edited record: drop it rather than reason about it. Parsed
+    // in its own try so a JSON error lands here and the bad file is actually
+    // removed, instead of falling to the outer catch and lingering forever.
+    let parsed = null;
+    try {
+      parsed = JSON.parse(readFileSync(abs, 'utf-8'));
+    } catch { /* handled below */ }
+    if (!parsed || !Array.isArray(parsed.retained)) {
+      unlinkSync(abs);
+      result.changed = true;
+      return result;
+    }
+    const stillPresent = [];
+    for (const entry of parsed.retained) {
+      if (entry && typeof entry.path === 'string' && existsSync(resolve(projectRoot, entry.path))) {
+        stillPresent.push(entry);
+      } else if (entry && typeof entry.path === 'string') {
+        result.removed.push(entry.path);
+      }
+    }
+    result.remaining = stillPresent.length;
+    if (result.removed.length === 0) return result;    // nothing to do
+    result.changed = true;
+    if (stillPresent.length === 0) {
+      unlinkSync(abs);
+      return result;
+    }
+    writeFileSync(abs, JSON.stringify({ ...parsed, retained: stillPresent }, null, 2) + '\n', 'utf-8');
+    return result;
+  } catch {
+    return result;
+  }
+}
+
+/**
  * Persist the retained (customized-and-therefore-preserved) retired files to
  * `.moflo/retired-retained.json` (#1307 finding 3).
  *

--- a/.claude/scripts/lib/retired-files.mjs
+++ b/.claude/scripts/lib/retired-files.mjs
@@ -33,9 +33,16 @@
  * @module bin/lib/retired-files
  */
 
-import { existsSync, readFileSync, unlinkSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
 import { createHash } from 'crypto';
+
+/**
+ * Consumer-relative path of the retained-files record written by
+ * `writeRetainedRecord`. Exported so tests and `flo healer` resolve the same
+ * location instead of re-deriving the string.
+ */
+export const RETAINED_RECORD_REL = join('.moflo', 'retired-retained.json');
 
 /**
  * Compute sha256 of file content. Returns null on read errors so the caller
@@ -156,17 +163,29 @@ export function classifyRetiredFile(projectRoot, entry) {
  * Failures are non-fatal — a single un-deletable file (Windows AV hold,
  * EBUSY) must not stop pruning the rest. The caller surfaces the report.
  *
+ * `preserved` is the flat path list the launcher banner samples from;
+ * `preservedDetails` carries the same set with the manifest's retirement
+ * provenance attached, for the machine-readable record (#1307 finding 3).
+ *
  * @param {string} projectRoot
  * @param {string} manifestPath
- * @returns {{ pruned: string[], preserved: string[], unknown: string[], failed: Array<{path:string, message:string}> }}
+ * @returns {{ pruned: string[], preserved: string[], preservedDetails: Array<{path:string, retiredIn?:string, retiredBy?:string}>, unknown: string[], failed: Array<{path:string, message:string}> }}
  */
 export function applyRetiredPrune(projectRoot, manifestPath) {
   const { entries } = loadRetiredManifest(manifestPath);
-  const report = { pruned: [], preserved: [], unknown: [], failed: [] };
+  const report = { pruned: [], preserved: [], preservedDetails: [], unknown: [], failed: [] };
   for (const entry of entries) {
     const { action } = classifyRetiredFile(projectRoot, entry);
     if (action === 'absent') continue;
-    if (action === 'preserve') { report.preserved.push(entry.path); continue; }
+    if (action === 'preserve') {
+      report.preserved.push(entry.path);
+      report.preservedDetails.push({
+        path: entry.path,
+        ...(entry.retiredIn ? { retiredIn: entry.retiredIn } : {}),
+        ...(entry.retiredBy ? { retiredBy: entry.retiredBy } : {}),
+      });
+      continue;
+    }
     if (action === 'unknown') { report.unknown.push(entry.path); continue; }
     // action === 'prune'
     try {
@@ -180,4 +199,47 @@ export function applyRetiredPrune(projectRoot, manifestPath) {
     }
   }
   return report;
+}
+
+/**
+ * Persist the retained (customized-and-therefore-preserved) retired files to
+ * `.moflo/retired-retained.json` (#1307 finding 3).
+ *
+ * Before this, the only place the retained set appeared was a launcher stdout
+ * banner truncated to 5 entries — so "delete manually if unwanted" was not
+ * actionable for the remainder, and nothing on disk let you reconstruct the
+ * set (`installed-files.json` doesn't track pre-#948 agents/skills).
+ *
+ * The record is advisory state, not a manifest: it is rewritten from scratch
+ * on every launcher run, and deleted when nothing is retained so a stale file
+ * never claims paths the consumer has since removed.
+ *
+ * Never throws — a failure to write an advisory record must not break session
+ * start on any consumer. Returns the absolute path written, or null.
+ *
+ * @param {string} projectRoot
+ * @param {Array<{path:string, retiredIn?:string, retiredBy?:string}>} preservedDetails
+ * @param {string} [mofloVersion] - version that produced this record, if known
+ * @returns {string|null} absolute path written, or null if nothing was written
+ */
+export function writeRetainedRecord(projectRoot, preservedDetails, mofloVersion) {
+  const abs = resolve(projectRoot, RETAINED_RECORD_REL);
+  try {
+    if (!Array.isArray(preservedDetails) || preservedDetails.length === 0) {
+      // Nothing retained — drop any record from a previous run.
+      if (existsSync(abs)) unlinkSync(abs);
+      return null;
+    }
+    mkdirSync(dirname(abs), { recursive: true });
+    const payload = {
+      version: 1,
+      note: 'Retired moflo files preserved because they were customized locally. Safe to delete manually if unwanted; moflo will not remove them.',
+      ...(mofloVersion ? { mofloVersion } : {}),
+      retained: preservedDetails,
+    };
+    writeFileSync(abs, JSON.stringify(payload, null, 2) + '\n', 'utf-8');
+    return abs;
+  } catch {
+    return null;
+  }
 }

--- a/.claude/skills/distill/SKILL.md
+++ b/.claude/skills/distill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: distill
-description: Alias for /flo-simplify. Review changed code for reuse, quality, and efficiency, then fix any issues found — effort scales to the diff size.
+description: Alias for /flo-simplify — see that skill's description.
 ---
 
 # /distill is an alias for /flo-simplify

--- a/.claude/skills/perf-audit/SKILL.md
+++ b/.claude/skills/perf-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: perf-audit
-description: Alias for /quicken. Ad-hoc performance audit — reveals N+1 queries, needless re-renders, missing caching, memory leaks, and redundant computation in your diff (or a named path), and prescribes the fix inline.
+description: Alias for /quicken — see that skill's description.
 arguments: "[path or area | --all]"
 ---
 

--- a/.claude/skills/test-gaps/SKILL.md
+++ b/.claude/skills/test-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-gaps
-description: Alias for /ward. Ad-hoc test-gap audit — reveals untested functions, uncovered edge cases, and missing error-handling/integration tests in your diff (or a named path), and conjures ready-to-paste test skeletons inline.
+description: Alias for /ward — see that skill's description.
 arguments: "[path or area | --all]"
 ---
 

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -713,7 +713,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -726,7 +726,7 @@ switch (command) {
     if (isEphemeralPath(fp)) break;
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -775,10 +775,11 @@ switch (command) {
     // "Memory namespace hint: ..." sentence so the BLOCK message stays uniform.
     var hint = s2.lastNamespaceHint || classifyBashNamespaceHint(cmd) || '';
     process.stderr.write(
-      'BLOCKED: Search memory before reading files via Bash.\n' +
+      'BLOCKED [moflo memory_first gate]: Search memory before reading files via Bash.\n' +
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\n' +
       (hint ? hint + '\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' +
+      'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.\n' +
       'Disable per-gate via moflo.yaml: gates: memory_first: false\n'
     );
     process.exit(2);

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -134,6 +134,13 @@ var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
 
+// Appended to every memory-first denial. Without it, a context audit of Claude
+// Code's denial telemetry reads moflo's gate enforcements as permission-setup
+// failures and "fixes" them with allow rules — which cannot override a hook
+// block at all (#1307 finding 5). Naming the gate makes the cause self-evident.
+var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.';
+var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
+
 // #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
 // (background-task output/transcripts, agent scratchpads) are transient tool
 // I/O and never carry indexable project knowledge, so they must not trip the
@@ -713,7 +720,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -726,7 +733,7 @@ switch (command) {
     if (isEphemeralPath(fp)) break;
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -779,8 +786,8 @@ switch (command) {
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\n' +
       (hint ? hint + '\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' +
-      'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.\n' +
-      'Disable per-gate via moflo.yaml: gates: memory_first: false\n'
+      GATE_ORIGIN_NOTE + '\n' +
+      GATE_DISABLE_NOTE + '\n'
     );
     process.exit(2);
     break;

--- a/bin/lib/retired-files.mjs
+++ b/bin/lib/retired-files.mjs
@@ -202,6 +202,64 @@ export function applyRetiredPrune(projectRoot, manifestPath) {
 }
 
 /**
+ * Reconcile an existing retained record against what is actually on disk.
+ *
+ * `writeRetainedRecord` only runs inside the launcher's UPGRADE branch (that
+ * is where `applyRetiredPrune` lives), so on its own it cannot keep the record
+ * honest: a user who reads the record and deletes the files would keep a
+ * record naming those files until their next moflo upgrade — the record would
+ * outlive what it describes, which is the same "not actionable" complaint
+ * #1307 raised about the truncated banner.
+ *
+ * This runs on EVERY session start instead, and is written to cost nothing in
+ * the common case: one `existsSync` when no record is present (overwhelmingly
+ * the norm), and only then a stat per retained entry.
+ *
+ * Never throws — advisory bookkeeping must not break session start.
+ *
+ * @param {string} projectRoot
+ * @returns {{ changed: boolean, removed: string[], remaining: number }}
+ */
+export function reconcileRetainedRecord(projectRoot) {
+  const result = { changed: false, removed: [], remaining: 0 };
+  const abs = resolve(projectRoot, RETAINED_RECORD_REL);
+  try {
+    if (!existsSync(abs)) return result;               // fast path — no record
+    // Corrupt/hand-edited record: drop it rather than reason about it. Parsed
+    // in its own try so a JSON error lands here and the bad file is actually
+    // removed, instead of falling to the outer catch and lingering forever.
+    let parsed = null;
+    try {
+      parsed = JSON.parse(readFileSync(abs, 'utf-8'));
+    } catch { /* handled below */ }
+    if (!parsed || !Array.isArray(parsed.retained)) {
+      unlinkSync(abs);
+      result.changed = true;
+      return result;
+    }
+    const stillPresent = [];
+    for (const entry of parsed.retained) {
+      if (entry && typeof entry.path === 'string' && existsSync(resolve(projectRoot, entry.path))) {
+        stillPresent.push(entry);
+      } else if (entry && typeof entry.path === 'string') {
+        result.removed.push(entry.path);
+      }
+    }
+    result.remaining = stillPresent.length;
+    if (result.removed.length === 0) return result;    // nothing to do
+    result.changed = true;
+    if (stillPresent.length === 0) {
+      unlinkSync(abs);
+      return result;
+    }
+    writeFileSync(abs, JSON.stringify({ ...parsed, retained: stillPresent }, null, 2) + '\n', 'utf-8');
+    return result;
+  } catch {
+    return result;
+  }
+}
+
+/**
  * Persist the retained (customized-and-therefore-preserved) retired files to
  * `.moflo/retired-retained.json` (#1307 finding 3).
  *

--- a/bin/lib/retired-files.mjs
+++ b/bin/lib/retired-files.mjs
@@ -33,9 +33,16 @@
  * @module bin/lib/retired-files
  */
 
-import { existsSync, readFileSync, unlinkSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
 import { createHash } from 'crypto';
+
+/**
+ * Consumer-relative path of the retained-files record written by
+ * `writeRetainedRecord`. Exported so tests and `flo healer` resolve the same
+ * location instead of re-deriving the string.
+ */
+export const RETAINED_RECORD_REL = join('.moflo', 'retired-retained.json');
 
 /**
  * Compute sha256 of file content. Returns null on read errors so the caller
@@ -156,17 +163,29 @@ export function classifyRetiredFile(projectRoot, entry) {
  * Failures are non-fatal — a single un-deletable file (Windows AV hold,
  * EBUSY) must not stop pruning the rest. The caller surfaces the report.
  *
+ * `preserved` is the flat path list the launcher banner samples from;
+ * `preservedDetails` carries the same set with the manifest's retirement
+ * provenance attached, for the machine-readable record (#1307 finding 3).
+ *
  * @param {string} projectRoot
  * @param {string} manifestPath
- * @returns {{ pruned: string[], preserved: string[], unknown: string[], failed: Array<{path:string, message:string}> }}
+ * @returns {{ pruned: string[], preserved: string[], preservedDetails: Array<{path:string, retiredIn?:string, retiredBy?:string}>, unknown: string[], failed: Array<{path:string, message:string}> }}
  */
 export function applyRetiredPrune(projectRoot, manifestPath) {
   const { entries } = loadRetiredManifest(manifestPath);
-  const report = { pruned: [], preserved: [], unknown: [], failed: [] };
+  const report = { pruned: [], preserved: [], preservedDetails: [], unknown: [], failed: [] };
   for (const entry of entries) {
     const { action } = classifyRetiredFile(projectRoot, entry);
     if (action === 'absent') continue;
-    if (action === 'preserve') { report.preserved.push(entry.path); continue; }
+    if (action === 'preserve') {
+      report.preserved.push(entry.path);
+      report.preservedDetails.push({
+        path: entry.path,
+        ...(entry.retiredIn ? { retiredIn: entry.retiredIn } : {}),
+        ...(entry.retiredBy ? { retiredBy: entry.retiredBy } : {}),
+      });
+      continue;
+    }
     if (action === 'unknown') { report.unknown.push(entry.path); continue; }
     // action === 'prune'
     try {
@@ -180,4 +199,47 @@ export function applyRetiredPrune(projectRoot, manifestPath) {
     }
   }
   return report;
+}
+
+/**
+ * Persist the retained (customized-and-therefore-preserved) retired files to
+ * `.moflo/retired-retained.json` (#1307 finding 3).
+ *
+ * Before this, the only place the retained set appeared was a launcher stdout
+ * banner truncated to 5 entries — so "delete manually if unwanted" was not
+ * actionable for the remainder, and nothing on disk let you reconstruct the
+ * set (`installed-files.json` doesn't track pre-#948 agents/skills).
+ *
+ * The record is advisory state, not a manifest: it is rewritten from scratch
+ * on every launcher run, and deleted when nothing is retained so a stale file
+ * never claims paths the consumer has since removed.
+ *
+ * Never throws — a failure to write an advisory record must not break session
+ * start on any consumer. Returns the absolute path written, or null.
+ *
+ * @param {string} projectRoot
+ * @param {Array<{path:string, retiredIn?:string, retiredBy?:string}>} preservedDetails
+ * @param {string} [mofloVersion] - version that produced this record, if known
+ * @returns {string|null} absolute path written, or null if nothing was written
+ */
+export function writeRetainedRecord(projectRoot, preservedDetails, mofloVersion) {
+  const abs = resolve(projectRoot, RETAINED_RECORD_REL);
+  try {
+    if (!Array.isArray(preservedDetails) || preservedDetails.length === 0) {
+      // Nothing retained — drop any record from a previous run.
+      if (existsSync(abs)) unlinkSync(abs);
+      return null;
+    }
+    mkdirSync(dirname(abs), { recursive: true });
+    const payload = {
+      version: 1,
+      note: 'Retired moflo files preserved because they were customized locally. Safe to delete manually if unwanted; moflo will not remove them.',
+      ...(mofloVersion ? { mofloVersion } : {}),
+      retained: preservedDetails,
+    };
+    writeFileSync(abs, JSON.stringify(payload, null, 2) + '\n', 'utf-8');
+    return abs;
+  } catch {
+    return null;
+  }
 }

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -14,7 +14,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { mofloDir, findProjectRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAMES } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
-import { applyRetiredPrune } from './lib/retired-files.mjs';
+import { applyRetiredPrune, writeRetainedRecord, RETAINED_RECORD_REL } from './lib/retired-files.mjs';
 import { makeSyncer, contentEqual, syncDirRecursive } from './lib/file-sync.mjs';
 import { INTERNAL_SKILLS } from './lib/internal-skills.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
@@ -1292,17 +1292,43 @@ try {
             `${plural(report.pruned.length, 'file')} matching known-shipped content removed`,
           );
         }
+        // Always reconcile the retained record — including writing none when
+        // nothing is retained, so a record from a previous run doesn't outlive
+        // the files it names (#1307 finding 3).
+        // Version read locally rather than reusing §2's `installedVersion` —
+        // that binding is scoped to the auto-update branch and this block must
+        // not depend on it (an out-of-scope reference would be swallowed by
+        // the surrounding catch as a bogus "prune skipped" warning).
+        let recordVersion;
+        try {
+          recordVersion = JSON.parse(readFileSync(
+            resolve(projectRoot, 'node_modules/moflo/package.json'), 'utf-8',
+          )).version;
+        } catch { /* record just omits the version */ }
+        const retainedRecordPath = writeRetainedRecord(
+          projectRoot,
+          report.preservedDetails,
+          recordVersion,
+        );
         if (report.preserved.length > 0) {
           // stdout (not stderr) so Claude sees this in `additionalContext`
           // and can surface to the user — these aren't failures, just
           // consumer-customized files we deliberately left alone.
+          //
+          // The banner samples; the full list goes to the record file. Before
+          // the record existed the truncated banner was the ONLY place these
+          // paths appeared, and it scrolls away — so "delete manually" wasn't
+          // actionable past the 5th entry.
           const sample = report.preserved.slice(0, 5).map((p) => `  - ${p}`).join('\n');
           const more = report.preserved.length > 5
             ? `\n  …and ${report.preserved.length - 5} more`
             : '';
+          const where = retainedRecordPath
+            ? `\n  full list: ${RETAINED_RECORD_REL}`
+            : '';
           try {
             process.stdout.write(
-              `moflo: retained ${plural(report.preserved.length, 'customized retired file')} (delete manually if unwanted):\n${sample}${more}\n`,
+              `moflo: retained ${plural(report.preserved.length, 'customized retired file')} (delete manually if unwanted):\n${sample}${more}${where}\n`,
             );
           } catch { /* non-fatal */ }
         }

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -1295,16 +1295,24 @@ try {
         // Always reconcile the retained record — including writing none when
         // nothing is retained, so a record from a previous run doesn't outlive
         // the files it names (#1307 finding 3).
-        // Version read locally rather than reusing §2's `installedVersion` —
-        // that binding is scoped to the auto-update branch and this block must
-        // not depend on it (an out-of-scope reference would be swallowed by
-        // the surrounding catch as a bogus "prune skipped" warning).
+        //
+        // The version is only read when there is actually something to record.
+        // Nothing-retained is the overwhelmingly common case, and this runs on
+        // every session start in every consumer — an unconditional read +
+        // JSON.parse here would be pure hot-path waste.
+        //
+        // Read locally rather than reusing §2's `installedVersion`: that
+        // binding is scoped to the auto-update branch, and an out-of-scope
+        // reference would be swallowed by the surrounding catch as a bogus
+        // "prune skipped" warning.
         let recordVersion;
-        try {
-          recordVersion = JSON.parse(readFileSync(
-            resolve(projectRoot, 'node_modules/moflo/package.json'), 'utf-8',
-          )).version;
-        } catch { /* record just omits the version */ }
+        if (report.preservedDetails.length > 0) {
+          try {
+            recordVersion = JSON.parse(readFileSync(
+              resolve(projectRoot, 'node_modules/moflo/package.json'), 'utf-8',
+            )).version;
+          } catch { /* record just omits the version */ }
+        }
         const retainedRecordPath = writeRetainedRecord(
           projectRoot,
           report.preservedDetails,

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -14,7 +14,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { mofloDir, findProjectRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAMES } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
-import { applyRetiredPrune, writeRetainedRecord, RETAINED_RECORD_REL } from './lib/retired-files.mjs';
+import { applyRetiredPrune, writeRetainedRecord, reconcileRetainedRecord, RETAINED_RECORD_REL } from './lib/retired-files.mjs';
 import { makeSyncer, contentEqual, syncDirRecursive } from './lib/file-sync.mjs';
 import { INTERNAL_SKILLS } from './lib/internal-skills.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
@@ -2423,6 +2423,26 @@ if (upgradeNoticeContext) {
 // moment this version's files are in place (see commitVersionStamp). #730 is
 // preserved because that commit is gated on sync success; every stage after the
 // sync block runs unconditionally + idempotently each session.
+
+// ── 3g-1307. Keep the retained-retired record honest every session ──────────
+// The record is WRITTEN in §3's upgrade branch (that is where the retired-file
+// prune runs), but it must not survive the files it names — a user who reads
+// it and deletes those files would otherwise keep a record listing them until
+// their next moflo upgrade. Reconciling here, unconditionally, closes that.
+// Costs one existsSync when no record is present, which is the normal state.
+try {
+  const rec = reconcileRetainedRecord(projectRoot);
+  if (rec.changed) {
+    emitMutation(
+      'reconciled retained-retired record',
+      rec.remaining === 0
+        ? 'all retained files removed by the user — record dropped'
+        : `${plural(rec.removed.length, 'entry')} dropped, ${rec.remaining} still retained`,
+    );
+  }
+} catch (err) {
+  emitWarning(`retained-record reconcile skipped (${errMessage(err)})`);
+}
 
 // ── 3h. Clear bootstrap sentinel if section-3 sync resolved it (#975) ───────
 // Section 3 above re-attempts the same file copies the bootstrap was supposed

--- a/package-lock.json
+++ b/package-lock.json
@@ -3141,9 +3141,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",
@@ -4481,9 +4481,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -4706,9 +4706,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
-      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"

--- a/src/cli/__tests__/skill-and-guidance-size-drift.test.ts
+++ b/src/cli/__tests__/skill-and-guidance-size-drift.test.ts
@@ -28,7 +28,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { findRepoRoot } from './_helpers/repo-walk.js';
 
@@ -37,6 +37,11 @@ const SKILLS_DIR = join(REPO_ROOT, '.claude/skills');
 const GUIDANCE_DIR = join(REPO_ROOT, '.claude/guidance');
 const AGENTS_DIR = join(REPO_ROOT, '.claude/agents');
 const MAX_LINES = 500;
+// Always-resident frontmatter `description` caps — see the description-cap
+// tests below for why these differ between agents, skills, and aliases.
+const MAX_DESC_CHARS_AGENT = 400;
+const MAX_DESC_CHARS_SKILL = 700;
+const MAX_DESC_CHARS_ALIAS = 120;
 
 function countLines(path: string): number {
   return readFileSync(path, 'utf-8').split(/\r?\n/).length;
@@ -118,6 +123,85 @@ function isAgentEntry(absPath: string): boolean {
   return /^name:\s*\S+/m.test(fm[1]);
 }
 
+// Extract the YAML frontmatter `description` value, joining continuation
+// lines. YAML block scalars (`description: |`) and plain multi-line values
+// both fold to a single space-joined string; the value ends at the next
+// top-level key or the end of the frontmatter. Returns '' when absent.
+function frontmatterDescription(absPath: string): string {
+  const text = readFileSync(absPath, 'utf-8');
+  const fm = text.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
+  if (!fm) return '';
+  const lines = fm[1].split(/\r?\n/);
+  const collected: string[] = [];
+  let capturing = false;
+  for (const line of lines) {
+    if (!capturing) {
+      const start = line.match(/^description:\s*(.*)$/);
+      if (!start) continue;
+      capturing = true;
+      // Strip a block-scalar indicator (`|`, `>`, `|-`, …) — it's syntax, not text.
+      const first = start[1].replace(/^[|>][-+]?\s*$/, '');
+      if (first) collected.push(first);
+      continue;
+    }
+    // A new top-level key ends the value; indented lines continue it.
+    if (/^[A-Za-z_][A-Za-z0-9_-]*:/.test(line)) break;
+    collected.push(line.trim());
+  }
+  return collected.join(' ').trim();
+}
+
+describe('frontmatterDescription parser', () => {
+  // Rule #1: this parser is the ONLY thing standing between a 1,300-char
+  // description and the always-resident listing. If it fails to extract a
+  // description it returns '', every cap below silently passes, and the guard
+  // becomes decorative. CRLF is the realistic way that happens — moflo ships
+  // LF and `.gitattributes` pins `eol=lf`, but a Windows contributor's editor
+  // or a relaxed checkout can still produce CRLF frontmatter. A parser anchored
+  // on bare \n would score those files as 0 chars and wave anything through.
+  const write = (name: string, body: string): string => {
+    const dir = join(REPO_ROOT, '.testoutput', 'fm-parse');
+    mkdirSync(dir, { recursive: true });
+    const p = join(dir, name);
+    writeFileSync(p, body);
+    return p;
+  };
+
+  it('extracts a single-line description', () => {
+    const p = write('single.md', '---\nname: a\ndescription: Hello there.\ncolor: red\n---\nbody\n');
+    expect(frontmatterDescription(p)).toBe('Hello there.');
+  });
+
+  it('extracts an equivalent description from CRLF frontmatter', () => {
+    const lf = write('eol-lf.md', '---\nname: a\ndescription: Hello there.\ncolor: red\n---\nbody\n');
+    const crlf = write('eol-crlf.md', '---\r\nname: a\r\ndescription: Hello there.\r\ncolor: red\r\n---\r\nbody\r\n');
+    expect(frontmatterDescription(crlf)).toBe(frontmatterDescription(lf));
+    expect(frontmatterDescription(crlf)).not.toBe('');
+  });
+
+  it('folds a multi-line description and stops at the next top-level key', () => {
+    const p = write('multi.md', '---\nname: a\ndescription: First line\n  second line\nthird line\ncolor: red\n---\n');
+    expect(frontmatterDescription(p)).toBe('First line second line third line');
+  });
+
+  it('folds a block scalar without leaking the indicator', () => {
+    const p = write('block.md', '---\nname: a\ndescription: |\n  Line one.\n  Line two.\ncolor: red\n---\n');
+    expect(frontmatterDescription(p)).toBe('Line one. Line two.');
+  });
+
+  it('returns empty string when there is no frontmatter or no description', () => {
+    expect(frontmatterDescription(write('none.md', 'just a body\n'))).toBe('');
+    expect(frontmatterDescription(write('nodesc.md', '---\nname: a\ncolor: red\n---\n'))).toBe('');
+  });
+
+  it('measures the real base-template-generator description as non-empty', () => {
+    // End-to-end anchor: if the parser ever stops seeing the real file, the
+    // caps go vacuous. #1307 finding 4 is exactly this file.
+    const real = join(AGENTS_DIR, 'base-template-generator.md');
+    expect(frontmatterDescription(real).length).toBeGreaterThan(0);
+  });
+});
+
 describe('skill + guidance + agent size drift guard', () => {
   it(`every SKILL.md entry stays under ${MAX_LINES} lines`, () => {
     const offenders = listSkillEntries()
@@ -179,6 +263,110 @@ describe('skill + guidance + agent size drift guard', () => {
         'Fix: extract long sections into companion .md files in the same agent',
         'directory (progressive disclosure). The entry .md should link to them.',
         'Companion files (no YAML frontmatter) are exempt from the cap.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  // ── Frontmatter `description` caps (#1307 finding 4) ────────────────────
+  //
+  // The body caps above bound what loads ON DISPATCH. The `description` is a
+  // different cost class: it is ALWAYS-RESIDENT — Claude Code lists every
+  // installed skill and agent (name + description) in the system prompt of
+  // every session, whether or not it is ever invoked. A description is a
+  // ROUTING HINT; worked examples, protocols, and procedure belong in the
+  // body, which the caps above already govern.
+  //
+  // What this caught: `base-template-generator`'s description embedded two
+  // full `<example>` dialogues with `<commentary>` blocks — 1,287 chars, 43%
+  // of the entire agent listing, resident in every consumer session forever.
+  //
+  // Separate caps because the two surfaces have different jobs: an agent
+  // description is a short "dispatch me for X", while a skill description
+  // legitimately encodes trigger conditions ("Use when…") that drive routing.
+  it('no skill or agent `description` embeds <example> blocks', () => {
+    const offenders = [
+      ...listSkillEntries(),
+      ...[...walkAgents(AGENTS_DIR)].filter(isAgentEntry),
+    ]
+      .map((p) => ({ path: relFromRepo(p), description: frontmatterDescription(p) }))
+      .filter((e) => /<example>|<commentary>/.test(e.description))
+      .map((e) => e.path);
+
+    expect(
+      offenders,
+      [
+        'Frontmatter `description` containing <example>/<commentary> blocks:',
+        '',
+        ...offenders.map((p) => `  - ${p}`),
+        '',
+        'The description is always-resident routing context in every session.',
+        'Move worked examples into the body, which only loads on invocation.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it(`every agent \`description\` stays under ${MAX_DESC_CHARS_AGENT} chars`, () => {
+    const offenders = [...walkAgents(AGENTS_DIR)]
+      .filter(isAgentEntry)
+      .map((p) => ({ path: relFromRepo(p), chars: frontmatterDescription(p).length }))
+      .filter((e) => e.chars > MAX_DESC_CHARS_AGENT)
+      .sort((a, b) => b.chars - a.chars);
+
+    expect(
+      offenders,
+      [
+        `Agent descriptions exceeding the ${MAX_DESC_CHARS_AGENT}-char cap:`,
+        '',
+        ...offenders.map((o) => `  - ${o.path} (${o.chars} chars)`),
+        '',
+        'The description is always-resident in every consumer session. Keep it',
+        'to a routing hint ("dispatch me for X") and move detail into the body.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it(`every SKILL.md \`description\` stays under ${MAX_DESC_CHARS_SKILL} chars`, () => {
+    const offenders = listSkillEntries()
+      .map((p) => ({ path: relFromRepo(p), chars: frontmatterDescription(p).length }))
+      .filter((e) => e.chars > MAX_DESC_CHARS_SKILL)
+      .sort((a, b) => b.chars - a.chars);
+
+    expect(
+      offenders,
+      [
+        `SKILL.md descriptions exceeding the ${MAX_DESC_CHARS_SKILL}-char cap:`,
+        '',
+        ...offenders.map((o) => `  - ${o.path} (${o.chars} chars)`),
+        '',
+        'The description is always-resident in every consumer session. Keep it',
+        'to the trigger conditions that drive routing; move procedure into the',
+        'body or a companion file.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  // Alias skills (pointer skills that defer wholesale to a canonical skill)
+  // must NOT restate the canonical's behavioral description: two descriptions
+  // of the same behavior compete for the same intent, so "clean up this diff"
+  // ties between `distill` and `flo-simplify`. The alias only needs to be
+  // findable by name. See #1307 finding 2.
+  it('alias skills keep a pointer-only description', () => {
+    const offenders = listSkillEntries()
+      .map((p) => ({ path: relFromRepo(p), description: frontmatterDescription(p) }))
+      .filter((e) => /^Alias for \//.test(e.description))
+      .filter((e) => e.description.length > MAX_DESC_CHARS_ALIAS)
+      .sort((a, b) => b.description.length - a.description.length);
+
+    expect(
+      offenders,
+      [
+        `Alias skill descriptions exceeding the ${MAX_DESC_CHARS_ALIAS}-char cap:`,
+        '',
+        ...offenders.map((o) => `  - ${o.path} (${o.description.length} chars)`),
+        '',
+        'An alias description should point at the canonical skill and stop —',
+        'e.g. "Alias for /ward — see that skill\'s description." Restating the',
+        'canonical behavior creates routing ambiguity between the two entries.',
       ].join('\n'),
     ).toEqual([]);
   });

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -638,7 +638,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED: Search memory before exploring files. Use mcp__moflo__memory_search.\\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search.\\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -648,7 +648,7 @@ switch (command) {
     var fp = process.env.TOOL_INPUT_file_path || '';
     if (isEphemeralPath(fp)) break;
     if (fp.indexOf('.claude/guidance/') < 0 && fp.indexOf('.claude\\\\guidance\\\\') < 0) break;
-    process.stderr.write('BLOCKED: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -680,10 +680,11 @@ switch (command) {
     // See bin/gate.cjs check-bash-memory for full rationale.
     var hint = s2.lastNamespaceHint || classifyBashNamespaceHint(cmd) || '';
     process.stderr.write(
-      'BLOCKED: Search memory before reading files via Bash.\\n' +
+      'BLOCKED [moflo memory_first gate]: Search memory before reading files via Bash.\\n' +
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\\n' +
       (hint ? hint + '\\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\\n' +
+      'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.\\n' +
       'Disable per-gate via moflo.yaml: gates: memory_first: false\\n'
     );
     process.exit(2);

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -329,6 +329,12 @@ var mergeConf = loadMergeConfig();
 var command = process.argv[2];
 
 var EXEMPT = ['.claude/', '.claude\\\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state', 'node_modules', 'moflo.yaml'];
+
+// Appended to every memory-first denial so a context audit doesn't read gate
+// enforcement as permission misconfiguration (#1307 finding 5). SYNC: mirrors
+// bin/gate.cjs GATE_ORIGIN_NOTE / GATE_DISABLE_NOTE.
+var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.';
+var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
 // #1294 Finding 3 — exempt ephemeral reads/scans under the OS temp dir
 // (background-task output, scratchpads) from the memory-first gate. Mirrors
 // bin/gate.cjs isEphemeralPath. Cross-platform via os.tmpdir(); normalizes a
@@ -638,7 +644,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search.\\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search.\\n' + GATE_ORIGIN_NOTE + '\\n' + GATE_DISABLE_NOTE + '\\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -648,7 +654,7 @@ switch (command) {
     var fp = process.env.TOOL_INPUT_file_path || '';
     if (isEphemeralPath(fp)) break;
     if (fp.indexOf('.claude/guidance/') < 0 && fp.indexOf('.claude\\\\guidance\\\\') < 0) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\nThis is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it. Disable via moflo.yaml: gates: memory_first: false\\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\n' + GATE_ORIGIN_NOTE + '\\n' + GATE_DISABLE_NOTE + '\\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -684,8 +690,8 @@ switch (command) {
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\\n' +
       (hint ? hint + '\\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\\n' +
-      'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.\\n' +
-      'Disable per-gate via moflo.yaml: gates: memory_first: false\\n'
+      GATE_ORIGIN_NOTE + '\\n' +
+      GATE_DISABLE_NOTE + '\\n'
     );
     process.exit(2);
     break;

--- a/tests/bin/launcher-948-retired-prune.test.ts
+++ b/tests/bin/launcher-948-retired-prune.test.ts
@@ -22,6 +22,8 @@ import {
   loadRetiredManifest,
   classifyRetiredFile,
   applyRetiredPrune,
+  writeRetainedRecord,
+  RETAINED_RECORD_REL,
 } from '../../bin/lib/retired-files.mjs';
 
 function makeTempRoot(label: string): string {
@@ -405,6 +407,101 @@ describe('retired-files helper (#948)', () => {
       const report = applyRetiredPrune(root, manifestPath);
       expect(report.pruned).toContain('.claude/agents/v3/perf.md');
       expect(existsSync(join(root, '.claude/agents/v3/perf.md'))).toBe(false);
+    });
+  });
+
+  // ── Retained record (#1307 finding 3) ──────────────────────────────────
+  //
+  // Before this, the retained set appeared ONLY in a launcher stdout banner
+  // truncated to 5 entries, and nothing on disk let you reconstruct it — so
+  // "delete manually if unwanted" was not actionable past the 5th file.
+  describe('writeRetainedRecord', () => {
+    let root: string;
+    beforeEach(() => { root = makeTempRoot('retained'); });
+    afterEach(() => { cleanTempRoot(root); });
+
+    const recordPath = () => join(root, RETAINED_RECORD_REL);
+
+    it('writes the FULL retained set, not a truncated sample', () => {
+      // 10 entries — the exact case the 5-entry banner sample hides.
+      const details = Array.from({ length: 10 }, (_, i) => ({
+        path: `.claude/agents/group/agent-${i}.md`,
+        retiredIn: '4.12.1',
+        retiredBy: '#932',
+      }));
+
+      const written = writeRetainedRecord(root, details, '4.12.1');
+
+      expect(written).toBe(recordPath());
+      const parsed = JSON.parse(readFileSync(recordPath(), 'utf-8'));
+      expect(parsed.version).toBe(1);
+      expect(parsed.mofloVersion).toBe('4.12.1');
+      expect(parsed.retained).toHaveLength(10);
+      expect(parsed.retained.map((r: { path: string }) => r.path))
+        .toContain('.claude/agents/group/agent-9.md');
+      // Provenance from the manifest rides along so the user can see WHY.
+      expect(parsed.retained[0]).toMatchObject({ retiredIn: '4.12.1', retiredBy: '#932' });
+    });
+
+    it('omits optional fields that the manifest did not carry', () => {
+      writeRetainedRecord(root, [{ path: '.claude/agents/a.md' }]);
+      const parsed = JSON.parse(readFileSync(recordPath(), 'utf-8'));
+      expect(parsed.retained[0]).toEqual({ path: '.claude/agents/a.md' });
+      expect(parsed.mofloVersion).toBeUndefined();
+    });
+
+    it('deletes a stale record when nothing is retained any more', () => {
+      // User deletes the retained files after reading the record; the next
+      // launcher run must not leave a record claiming paths that are gone.
+      writeRetainedRecord(root, [{ path: '.claude/agents/a.md' }]);
+      expect(existsSync(recordPath())).toBe(true);
+
+      const written = writeRetainedRecord(root, []);
+      expect(written).toBeNull();
+      expect(existsSync(recordPath())).toBe(false);
+    });
+
+    it('is a no-op (not a throw) when there is nothing to write and no record exists', () => {
+      expect(writeRetainedRecord(root, [])).toBeNull();
+      expect(existsSync(recordPath())).toBe(false);
+    });
+
+    it('never throws on an unwritable target — session start must not break', () => {
+      // `.moflo` occupied by a FILE, so mkdirSync of the parent dir fails.
+      // A consumer hitting this must still get a session, not a crash.
+      writeFileSync(join(root, '.moflo'), 'not a directory');
+      expect(() => writeRetainedRecord(root, [{ path: '.claude/agents/a.md' }])).not.toThrow();
+      expect(writeRetainedRecord(root, [{ path: '.claude/agents/a.md' }])).toBeNull();
+    });
+
+    it('creates .moflo/ when the project has none yet', () => {
+      expect(existsSync(join(root, '.moflo'))).toBe(false);
+      writeRetainedRecord(root, [{ path: '.claude/agents/a.md' }]);
+      expect(existsSync(recordPath())).toBe(true);
+    });
+
+    it('applyRetiredPrune surfaces preservedDetails aligned with preserved', () => {
+      const customized = '# my customized version\n';
+      writeAt(root, '.claude/agents/consensus/raft-manager.md', customized);
+      const manifestPath = join(root, 'retired-files.json');
+      writeFileSync(manifestPath, JSON.stringify({
+        version: 1,
+        retired: [{
+          path: '.claude/agents/consensus/raft-manager.md',
+          retiredIn: '4.12.0',
+          retiredBy: '#932',
+          knownContentHashes: [sha256Of('different shipped content\n')],
+        }],
+      }));
+
+      const report = applyRetiredPrune(root, manifestPath);
+
+      expect(report.preserved).toEqual(['.claude/agents/consensus/raft-manager.md']);
+      expect(report.preservedDetails).toEqual([{
+        path: '.claude/agents/consensus/raft-manager.md',
+        retiredIn: '4.12.0',
+        retiredBy: '#932',
+      }]);
     });
   });
 });

--- a/tests/bin/launcher-948-retired-prune.test.ts
+++ b/tests/bin/launcher-948-retired-prune.test.ts
@@ -23,6 +23,7 @@ import {
   classifyRetiredFile,
   applyRetiredPrune,
   writeRetainedRecord,
+  reconcileRetainedRecord,
   RETAINED_RECORD_REL,
 } from '../../bin/lib/retired-files.mjs';
 
@@ -478,6 +479,76 @@ describe('retired-files helper (#948)', () => {
       expect(existsSync(join(root, '.moflo'))).toBe(false);
       writeRetainedRecord(root, [{ path: '.claude/agents/a.md' }]);
       expect(existsSync(recordPath())).toBe(true);
+    });
+
+    // reconcileRetainedRecord runs on EVERY session start, unlike
+    // writeRetainedRecord which only runs in the launcher's upgrade branch.
+    // Without it a user who reads the record and deletes the files keeps a
+    // record naming them until their next moflo upgrade — caught by end-to-end
+    // launcher verification, not by the writeRetainedRecord unit tests.
+    describe('reconcileRetainedRecord', () => {
+      it('is a cheap no-op when no record exists', () => {
+        const r = reconcileRetainedRecord(root);
+        expect(r).toEqual({ changed: false, removed: [], remaining: 0 });
+        expect(existsSync(recordPath())).toBe(false);
+      });
+
+      it('leaves the record untouched while every named file still exists', () => {
+        writeAt(root, '.claude/agents/a.md', 'customized\n');
+        writeRetainedRecord(root, [{ path: '.claude/agents/a.md' }], '4.12.1');
+        const before = readFileSync(recordPath(), 'utf-8');
+
+        const r = reconcileRetainedRecord(root);
+
+        expect(r.changed).toBe(false);
+        expect(readFileSync(recordPath(), 'utf-8')).toBe(before);
+      });
+
+      it('drops only the entries whose files the user deleted', () => {
+        writeAt(root, '.claude/agents/kept.md', 'still here\n');
+        writeRetainedRecord(root, [
+          { path: '.claude/agents/kept.md', retiredIn: '4.12.1' },
+          { path: '.claude/agents/deleted.md', retiredIn: '4.12.1' },
+        ], '4.12.1');
+
+        const r = reconcileRetainedRecord(root);
+
+        expect(r.changed).toBe(true);
+        expect(r.removed).toEqual(['.claude/agents/deleted.md']);
+        expect(r.remaining).toBe(1);
+        const rec = JSON.parse(readFileSync(recordPath(), 'utf-8'));
+        expect(rec.retained.map((e: { path: string }) => e.path)).toEqual(['.claude/agents/kept.md']);
+        // Unrelated top-level fields survive the rewrite.
+        expect(rec.mofloVersion).toBe('4.12.1');
+        expect(rec.version).toBe(1);
+      });
+
+      it('deletes the record once the user has removed every retained file', () => {
+        writeRetainedRecord(root, [{ path: '.claude/agents/gone.md' }], '4.12.1');
+        expect(existsSync(recordPath())).toBe(true);
+
+        const r = reconcileRetainedRecord(root);
+
+        expect(r.changed).toBe(true);
+        expect(r.remaining).toBe(0);
+        expect(existsSync(recordPath())).toBe(false);
+      });
+
+      it('drops a corrupt or hand-edited record rather than reasoning about it', () => {
+        mkdirSync(join(root, '.moflo'), { recursive: true });
+        writeFileSync(recordPath(), '{ not json');
+        expect(reconcileRetainedRecord(root).changed).toBe(true);
+        expect(existsSync(recordPath())).toBe(false);
+
+        writeFileSync(recordPath(), JSON.stringify({ version: 1, retained: 'not-an-array' }));
+        expect(reconcileRetainedRecord(root).changed).toBe(true);
+        expect(existsSync(recordPath())).toBe(false);
+      });
+
+      it('never throws on an unreadable record — session start must not break', () => {
+        mkdirSync(recordPath(), { recursive: true }); // a DIRECTORY where the file goes
+        expect(() => reconcileRetainedRecord(root)).not.toThrow();
+      });
     });
 
     it('applyRetiredPrune surfaces preservedDetails aligned with preserved', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -109,6 +109,33 @@ export const isolationTests = [
   // real subsystem; reliably fits in 10 s alone, can drift past full-suite
   // per-test ceilings under fork contention.
   'src/cli/__tests__/doctor-checks-memory-access.test.ts',
+  // Issue #1310 — tests that `spawnSync` the REAL session-start launcher.
+  //
+  // Confirmed mechanism, not a guess: under full-suite fork contention
+  // `session-start-launcher-daemon-behind.test.ts` failed with
+  // `expected null to be +0` and an EMPTY stderr — that is the spawnSync
+  // TIMEOUT signature (the child is killed, so `status` is null and nothing
+  // was written), not an assertion about launcher behavior. It passes 5/5
+  // alone. Same story as `daemon-lock-orphan.test.ts` above.
+  //
+  // The whole family is listed rather than only the file that happened to
+  // flake: each one boots the launcher end-to-end against a temp consumer
+  // (fs sync, manifest walks, fire-and-forget child spawns) on a fixed
+  // per-call timeout, so which one loses the race is arbitrary. Same
+  // reasoning as the four `prerequisites-*` files above.
+  //
+  // Files that merely READ or import from the launcher (lib-sync,
+  // launcher-948-retired-prune, install-manifest, …) are deliberately NOT
+  // here — they carry none of the subprocess cost and belong in the fast pass.
+  'src/cli/__tests__/session-start-launcher-daemon-behind.test.ts',
+  'src/cli/__tests__/session-start-launcher-stamp-loop-recovery.test.ts',
+  'src/cli/__tests__/bootstrap-sentinel-promotion.test.ts',
+  'tests/bin/launcher-854-fixes.test.ts',
+  'tests/bin/launcher-928-dogfood-skip.test.ts',
+  'tests/bin/launcher-headless-skip.test.ts',
+  'tests/bin/launcher-visibility.test.ts',
+  'tests/bin/prompt-hook-restart-notice.test.ts',
+  'tests/system/launcher-version-skew-upgrade-boundary.test.ts',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
Closes #1307. Closes #1311. Closes #1310.

Addresses findings 2, 3, 4, and 5 of #1307. **Finding 1 is deliberately not addressed here** — it turned out to rest on a defect that has to land first, filed as #1308.

Nothing is removed. Every skill and agent still installs, still lists, and still dispatches identically.

## Why finding 1 isn't in this PR

#1307's headline was the largest number (~1,656 est. tokens from 19 never-invoked skills), but pruning on usage telemetry is self-fulfilling: the listing *is* the discovery mechanism, so a skill that isn't listed can never be invoked, which then "confirms" it was unused. That's the functionality loss the report was trying to avoid.

While checking whether an allowlist was even implementable, the real defect surfaced: **moflo already has a skill-category selection mechanism and it is entirely non-functional** — `SkillsConfig` keys (`core`/`github`/`browser`) don't match `SKILLS_MAP` keys (`core`/`memory`/`spells`), so `flo init` never installs the `memory` or `spells` categories at all, and the launcher's `syncDirRecursive` blanket-copies everything anyway. Any skill profile is dead on arrival until that's fixed. Details in **#1308**.

## What's here

### Finding 4 — `base-template-generator` description (~330 est. tok/session)

Its frontmatter `description` embedded two full `<example>` dialogues with `<commentary>` blocks: **1,287 chars, 43% of the entire agent listing**, resident in every consumer session whether or not the agent is ever dispatched. Every other agent's description is well-behaved (largest peer: 259 chars).

A description is a routing hint; worked examples belong in the body, which only loads on dispatch. The examples moved verbatim into a "When you get dispatched" section — relocated, not deleted.

### Finding 2 — alias skills restated their canonical's description

| Alias | Was | Now |
|---|---|---|
| `test-gaps` | 218 ch | 46 ch |
| `perf-audit` | 208 ch | 48 ch |
| `distill` | 140 ch | 52 ch |

Beyond the tokens, the real cost was **routing ambiguity**: two descriptions of the same behavior competing for the same intent, so "clean up this diff" tied between `distill` and `flo-simplify`. Trimmed to the pointer-only form `flo` already used. Explicit `/test-gaps` still resolves on name match; auto-routing now lands on the canonical entry.

Aliases stay as real skill directories — Claude Code resolves skill names from the listing, so #1307's suggested "resolve aliases at dispatch" would have broken `/distill` outright.

### Finding 3 — retained retired files were unrecoverable

Customized retired files are preserved on upgrade (correct) and reported in a launcher banner **truncated to 5 entries**. That banner was the only record — it scrolls away, and `installed-files.json` can't reconstruct the set. So "delete manually if unwanted" wasn't actionable past the 5th file.

New `writeRetainedRecord` writes the full set to `.moflo/retired-retained.json` with the manifest's `retiredIn`/`retiredBy` provenance; the banner now points at it.

A second commit was needed here, and it's the most useful thing in this PR — see **Verification** below. `writeRetainedRecord` only runs inside the launcher's *upgrade* branch, so stale-record cleanup never fired on an ordinary session. `reconcileRetainedRecord` now runs unconditionally at session start (one `existsSync` when no record exists), dropping entries whose files are gone and deleting the record once none remain.

### Finding 5 — gate denials looked like permission misconfiguration

The memory-first gate's block message didn't identify itself, so a `/doctor` context audit read 41 gate enforcements as "41 permission failures" — and allow-rules can't override a hook block anyway. All three memory-first denials (scan, read, bash) now carry a `[moflo memory_first gate]` tag, state plainly that they're a moflo hook rather than a Claude Code permission rule, and name the `moflo.yaml gates.memory_first` toggle.

Applied to **both** emitters: `bin/gate.cjs` (canonical, synced to `.claude/helpers/gate.cjs`) and `helpers-generator.ts` (what `flo init` writes).

## Guards added

`skill-and-guidance-size-drift.test.ts` capped bodies but never `description` — the always-resident cost class — so finding 4 could recur silently. Added four caps plus a parser suite:

- no `<example>`/`<commentary>` in any skill or agent description
- agent descriptions ≤ 400 chars
- skill descriptions ≤ 700 chars (they legitimately encode trigger conditions)
- alias descriptions ≤ 120 chars (pointer-only)

**Verified non-vacuous:** reverting only the asset fixes (keeping the tests) fails exactly 3 of these, reporting the pre-fix measurements — `base-template-generator` at 1,287 chars, and all three aliases over the alias cap.

## Rule #1 — cross-platform audit

- **The parser is the single point of failure for all four caps.** If `frontmatterDescription` can't parse a file it returns `''` and every cap silently passes — the guard goes decorative. CRLF is the realistic way that happens on a Windows checkout. It handles `\r?\n`, and 6 unit tests pin it, including an **LF/CRLF equivalence case** and an end-to-end anchor on the real agent file so the caps can't go vacuous unnoticed.
- **Paths** — `path.join`/`resolve`/`dirname` throughout; `RETAINED_RECORD_REL` is built with `join` so it renders with the native separator in the banner. No hardcoded `/` or `/tmp`.
- **Failure tolerance** — `writeRetainedRecord` never throws; a write failure degrades to no-record rather than breaking session start. Covered by a test that occupies `.moflo` with a *file* so the parent `mkdir` fails (throws on both POSIX and Windows).
- **`.moflo/` creation** — covered for the project-has-no-`.moflo`-yet case.
- **Twin parity** — `bin/lib/retired-files.mjs` synced byte-identical to its committed `.claude/scripts/lib/` twin. The parity guard caught this on the first full run; `.gitattributes` `eol=lf` keeps both copies LF.
- **No spurious mode changes** — an initial `copyFileSync` flipped `.claude/helpers/gate.cjs` to 755; reverted to 644 so the diff carries no mode noise.

## Rule #2 — consumer impact

- **Surfaces touched:** the session-start launcher (runs in every consumer, every session start), `gate.cjs` (both copies), and shipped `.claude/agents` + `.claude/skills` assets.
- **Failure mode for a consumer upgrading into this:** none identified. The record file is new, additive, gitignored state whose absence is the normal case; existing `.moflo/` state still parses; hooks still wire. No migration.
- **Round-trip cost:** launcher + gate changes are runtime — they need publish + reinstall + Claude Code restart to take effect. The asset and test changes take effect from source.

## Test evidence

Six full-suite runs on this branch, two on `main` as a baseline. Reporting all of it because the picture is not perfectly clean:

| Run | Result |
|---|---|
| 1 | ✗ `tests/bin/lib-sync.test.ts` twin-parity — **a real failure caused by this change** (new exports not mirrored to the `.claude/scripts/lib/` twin). Fixed by syncing. |
| 2 | ✗ `schedule-acceptance-check.test.ts` — untouched by this diff, passes individually |
| 3 | ✓ clean |
| 4 | ✗ `memory-movector-deep.test.ts` — untouched by this diff, passes individually |
| 5 | ✓ clean (post-simplify commit) |
| 6 | ✓ clean (post-simplify commit) |
| `main` ×2 | ✓ clean, 9,497 passed |

Final state: **9,520 passed, 0 failed**, four consecutive clean runs.

**On the two flakes — I am not claiming these are pre-existing.** Both were single, *different*, unrelated tests; both pass individually; both predate the simplify commit; and neither has recurred in three runs since. But `main` came back clean 2-for-2, and two runs is not enough to rule `main` out at the ~1-in-3 rate observed here. Distinguishing "this branch adds 41 tests and tips marginal ones over" from "the suite flakes at this rate regardless" needs more `main` runs than I did.

One concrete lead, independent of this PR: **the suite's own total varies run to run** — 9,514 and 9,486 on this branch, 9,497 on `main` — so it is not executing a fixed set of tests each time. That nondeterminism is a plausible mechanism for which tests end up sharing the parallel pool. Filed separately rather than absorbed here.

## Review pass

`/flo-simplify` classified this NORMAL and found two real issues, fixed in the second commit:

- **Efficiency** — the retained-record version argument read and parsed `node_modules/moflo/package.json` *unconditionally*, before checking whether anything was actually retained. Nothing-retained is the common case and this runs on every session start in every consumer, so that was guaranteed hot-path waste. Now guarded. (The #860 failure shape in miniature: invisible locally, paid N times across consumers.)
- **Quality** — the gate-origin and toggle sentences were duplicated across all three denials in both emitters (6 copies) — exactly the setup where a later edit updates one and leaves the rest stale. Extracted to `GATE_ORIGIN_NOTE` / `GATE_DISABLE_NOTE`, matching the `var EXEMPT` / `var DANGEROUS` idiom already in those files.
- **Reuse** — no findings. The inline `package.json` read matches four prior sites in the same launcher, and `atomic-file-write.ts` is unusable from a `.mjs` launcher across the dist/source depth boundary.

The refactored denials were then **functionally exercised**, not just compiled: `check-before-read` and `check-before-scan` each emit the full message with both constants interpolated and exit 2, and the `flo init` template was rendered via `generateGateScript()` + `node --check` (constant declared once, literal down from three copies to one).

## Verification — what running the real entrypoint caught

`/verify` exercised the actual `bin/session-start-launcher.mjs` against a temp consumer project (8 customized retired agents — deliberately more than the banner's 5-entry sample). **It failed, and the failure was the most valuable finding in this PR.**

`writeRetainedRecord` had seven green unit tests, *including one explicitly asserting "deletes a stale record when nothing is retained any more."* All passed. But the launcher only calls it inside the upgrade branch — that's where `applyRetiredPrune` lives — so on an ordinary session start the cleanup never ran. A user who read the record, deleted the files it named, and kept working would keep a record listing files that no longer exist until their next moflo upgrade: the record outliving what it describes, which is the *same* "not actionable" complaint finding 3 was raised about. The unit tests were blind to it because they called the helper directly, and my first commit's claim that the record "never outlives the files it names" was too strong.

Worth noting the *first* end-to-end attempt failed for a different reason — matching versions meant the upgrade branch never ran at all. That failure was itself informative: it located the gating condition.

Final end-to-end state, all confirmed against a real launcher run:

| Check | Result |
|---|---|
| Record written with all 8 entries + provenance | ✅ |
| Banner points at the record path | ✅ |
| 8th entry (the one the banner truncates) present | ✅ |
| After deleting all 8 files, next ordinary session removes the record | ✅ (was ❌ before the second commit) |

Also fixed while testing it: `JSON.parse` sat inside the broad try/catch, so a corrupt or hand-edited record fell through and lingered forever instead of being dropped.

Six regression tests now cover the reconcile path — partial deletion (drop only missing entries, keep the rest *and* the top-level fields), corrupt records, and an unreadable-record case that must not throw.

## Net effect

**~372 est. tokens/session** of always-resident context recovered (10,828 → 9,339 description chars measured across shipped agents + skills), plus two regression guards and one UX fix — with zero capability change.



---

# Added after review: two adjacent blockers, rolled in on request

## `npm audit` gate — fixed (#1311)

`Lint & Security` was failing on **every** PR regardless of contents. The gate is `--audit-level=high`, so of five advisories only one was load-bearing. All three fixable ones were already permitted by our declared ranges — the lockfile was simply stale. **Lockfile-only, no manifest edit:**

| Package | | Severity |
|---|---|---|
| `js-yaml` | 5.2.1 → **5.2.2** | **high** (GHSA-pm4m-ph32-ghv5) |
| `tar` | 7.5.19 → **7.5.22** | moderate |
| `valibot` | 1.3.1 → **1.4.2** | moderate |

**`@hono/node-server` left unfixed, deliberately.** It arrives only via `@modelcontextprotocol/sdk`, which pins `^1.19.9`; the fix needs `>=2.0.5`. Upgrading the SDK isn't available — `1.29.0` is latest and every release since `1.25.0` pins the v1 adapter. An `overrides` force was considered and rejected: the SDK is written against adapter v1 and it's the MCP server surface. Exposure doesn't justify it — the SDK imports only `getRequestListener`, never `serveStatic` where the advisory lives, and moflo uses `StdioClientTransport`, not the streamable-HTTP transport. **The vulnerable path is unreachable here.** Both remaining entries are moderate and don't fail the gate.

## Suite non-determinism — root-caused and fixed (#1310)

The suite reported a different total every run (9486 / 9497 / 9514 / 9520) and flaked a different single test each time. **Both symptoms were one phenomenon.**

`session-start-launcher-daemon-behind.test.ts` failed with `expected null to be +0` and an **empty stderr** — the `spawnSync` timeout signature (child killed by signal, writes nothing), not an assertion about launcher behaviour. It passes 5/5 alone. A file that times out this way contributes **zero passes**, which is what made the totals drift.

Fix: added the **9** files that actually `spawnSync` the launcher to the existing `isolationTests` list — no new mechanism. The whole family, not just the one that flaked, since each boots the launcher on a fixed timeout and which one loses the race is arbitrary (same grouping logic as the `prerequisites-*` set already there). The 22 files that merely *read* the launcher stay in the fast pass.

| | Total passed |
|---|---|
| Before | 9486 / 9497 / 9514 / 9520 |
| After | **9520 × 4, identical** |

Four consecutive runs, 0 failed. Tests job also went **5m42s → 3m27s**.

Two earlier flakes (`schedule-acceptance-check`, `memory-movector-deep`) are a different mode — neither spawns a subprocess — and haven't recurred; noted on #1310 rather than lumped in speculatively.

## CI

All six checks green: Build, Lint & Security, Tests, consumer, populated, file-sync.
