### PR TITLE
fix(init): make skill-category selection actually work (#1308)

### DIFF
--- a/.claude/guidance/shipped/moflo-yaml-reference.md
+++ b/.claude/guidance/shipped/moflo-yaml-reference.md
@@ -123,14 +123,54 @@ auto_update:
   helpers: true                          # Sync .claude/helpers/ from moflo source
   hook_block_drift: regenerate           # warn | regenerate | off (default: regenerate since #1227)
   claudemd_injection_drift: regenerate   # warn | regenerate | off
+
+# Which skill categories to install (OPTIONAL — omit to get every skill)
+skills:
+  categories: [core, memory, spells]     # core | memory | spells
 ```
 
 If your `moflo.yaml` predates the `sandbox:` or `auto_update:` blocks, they are auto-appended on the next session start — you never need to re-run `moflo init` after a version bump.
+
+### Narrowing Installed Skills with `skills.categories`
+
+**Omit the `skills:` block entirely to receive every moflo skill — that is the default and the recommended setting.** Add `skills.categories` only when you want a smaller always-resident skill listing, and expect to lose the commands in the categories you drop.
+
+Every installed skill's name and description sit in Claude's context in every session, so a project that will never author a spell can reclaim that space. The cost is real but small — the full set is roughly 2,000 tokens.
+
+| Category | Skills | Drop it when |
+|----------|--------|--------------|
+| `core` | `/fl`, `/healer`, `/verify`, `/flo-simplify`, `/eldar`, `/quicken`, `/ward`, `/divine`, `/meditate`, `/guidance`, `/commune`, `/luminarium` | Never — these are the everyday commands |
+| `memory` | `/memory-patterns`, `/vector-search`, `/memory-optimization`, `/memory-team`, `/memory-worktree` | You are not building on moflo's memory stack and have finished any team/worktree sharing setup |
+| `spells` | `/spell-builder`, `/spell-schedule`, `/connector-builder` | You do not author or schedule spells in this project |
+
+Both YAML list styles work:
+
+```yaml
+skills:
+  categories: [core, memory]
+```
+
+```yaml
+skills:
+  categories:
+    - core
+    - memory
+```
+
+**Key behaviors:**
+
+- **Omitting `skills:` means no restriction.** Every shipped skill syncs on every session start, exactly as before this option existed.
+- **`/flo` and `/fl` are never gated.** The ticket spell is the primary entry point and installs regardless of selection.
+- **An unknown category name is ignored, not fatal.** A typo narrows nothing rather than silently stripping your skills.
+- **Narrowing stops future syncing; it does not delete.** Skills already on disk stay until you remove them — moflo will not re-add them once excluded, so delete the directories under `.claude/skills/` to reclaim the context.
+- **Re-widening is instant.** Add the category back and the next session start restores its skills.
 
 ### Key Behaviors
 
 | Config | Effect |
 |--------|--------|
+| `skills.categories` omitted | Install every skill (default) |
+| `skills.categories: [core]` | Install only core skills; `memory` + `spells` stop syncing |
 | `auto_index.guidance: false` | Skip guidance indexing on session start |
 | `auto_index.code_map: false` | Skip code map generation on session start |
 | `auto_meditate.enabled: false` | Opt out of automatic session-lesson distillation (`/meditate` still works manually) |

--- a/.claude/scripts/lib/skill-categories.mjs
+++ b/.claude/scripts/lib/skill-categories.mjs
@@ -1,0 +1,153 @@
+/**
+ * Skill-category selection for the session-start launcher (#1308).
+ *
+ * ## Why this leaf exists
+ *
+ * The launcher syncs every shipped skill into the consumer on each run
+ * (`syncDirRecursive` in `file-sync.mjs`). Before #1308 that sync was
+ * unconditional except for `INTERNAL_SKILLS`, which meant a consumer could not
+ * narrow their installed skill set: whatever `flo init` selected, the next
+ * session start put everything back. The category structure in `SKILLS_MAP` was
+ * therefore dead config.
+ *
+ * To honour a selection the launcher has to know which skill belongs to which
+ * category. The canonical map is `SKILLS_MAP` in `src/cli/init/executor.ts`,
+ * but the launcher is a plain `.mjs` and cannot import that TS const across the
+ * dist/source depth boundary — so this leaf mirrors it, exactly as
+ * `internal-skills.mjs` mirrors `INTERNAL_SKILLS`.
+ * `tests/bin/skill-categories-parity.test.ts` asserts the two never drift.
+ *
+ * ## Default is "everything"
+ *
+ * A consumer with no `skills:` block in `moflo.yaml` must keep getting every
+ * skill — anything else would silently delete capability on upgrade for every
+ * existing install (Rule #2). `parseSkillCategories` returns `null` for
+ * "unconfigured", and `computeExcludedSkills(null, …)` excludes nothing beyond
+ * the internal skills.
+ *
+ * @module bin/lib/skill-categories
+ */
+
+/**
+ * Mirror of `SKILLS_MAP` in `src/cli/init/executor.ts`. Keep in sync — the
+ * parity test fails otherwise.
+ */
+export const SKILL_CATEGORIES_MAP = {
+  core: [
+    'commune',
+    'eldar',
+    'guidance',
+    'healer',
+    'flo-simplify',
+    'distill',
+    'luminarium',
+    'reasoningbank-intelligence',
+    'meditate',
+    'divine',
+    'quicken',
+    'perf-audit',
+    'ward',
+    'test-gaps',
+    'verify',
+  ],
+  memory: [
+    'memory-patterns',
+    'memory-optimization',
+    'vector-search',
+    'memory-worktree',
+    'memory-team',
+  ],
+  spells: [
+    'spell-builder',
+    'spell-schedule',
+    'connector-builder',
+  ],
+};
+
+/** Every category name, in declaration order. */
+export const SKILL_CATEGORY_NAMES = Object.keys(SKILL_CATEGORIES_MAP);
+
+/**
+ * Skills installed by `moflo-init.ts` outside `SKILLS_MAP` (the `/flo` + `/fl`
+ * ticket spell). They are the primary entry point and are never category-gated
+ * — excluding them would break the headline workflow.
+ */
+export const ALWAYS_INSTALLED_SKILLS = ['flo', 'fl'];
+
+/**
+ * Extract the selected skill categories from raw `moflo.yaml` text.
+ *
+ * Regex-based on purpose: the launcher deliberately avoids a YAML dependency
+ * (see the `auto_update` parsing it sits beside). Both YAML list styles are
+ * accepted because either is what a hand-editing consumer will write:
+ *
+ *     skills:
+ *       categories: [core, memory]
+ *
+ *     skills:
+ *       categories:
+ *         - core
+ *         - memory
+ *
+ * @param {string} yamlContent
+ * @returns {string[]|null} selected categories, or null when unconfigured
+ *   (meaning "no restriction" — sync everything). An explicitly EMPTY list
+ *   returns `[]`, which is a real selection meaning "core-and-always only".
+ */
+export function parseSkillCategories(yamlContent) {
+  if (typeof yamlContent !== 'string' || yamlContent.length === 0) return null;
+
+  // Flow style: categories: [a, b]
+  const flow = yamlContent.match(/^[ \t]*skills:[ \t]*\r?\n(?:[ \t]+[^\r\n]*\r?\n)*?[ \t]+categories:[ \t]*\[([^\]]*)\]/m);
+  if (flow) {
+    return flow[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+      .filter((s) => s.length > 0);
+  }
+
+  // Block style: categories:\n  - a\n  - b
+  const block = yamlContent.match(/^[ \t]*skills:[ \t]*\r?\n(?:[ \t]+[^\r\n]*\r?\n)*?[ \t]+categories:[ \t]*\r?\n((?:[ \t]*-[ \t]*[^\r\n]+\r?\n?)+)/m);
+  if (block) {
+    return block[1]
+      .split(/\r?\n/)
+      .map((line) => line.match(/^[ \t]*-[ \t]*(.+?)[ \t]*$/))
+      .filter(Boolean)
+      .map((m) => m[1].replace(/^['"]|['"]$/g, '').trim())
+      .filter((s) => s.length > 0);
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the set of top-level skill directory names the launcher must NOT
+ * sync, given a selection.
+ *
+ * Unknown category names in the selection are ignored rather than treated as
+ * "select nothing" — a typo in `moflo.yaml` should not silently strip a
+ * consumer's skills. Skills that belong to no category at all are always kept
+ * for the same reason: this function can only ever exclude a skill it can
+ * positively attribute to an UNSELECTED category.
+ *
+ * @param {string[]|null} selected - from `parseSkillCategories`
+ * @param {string[]} internalSkills - INTERNAL_SKILLS (never installed)
+ * @returns {Set<string>} top-level names to exclude from the sync
+ */
+export function computeExcludedSkills(selected, internalSkills = []) {
+  const excluded = new Set(internalSkills);
+  if (!Array.isArray(selected)) return excluded; // unconfigured → no restriction
+
+  const keep = new Set(ALWAYS_INSTALLED_SKILLS);
+  for (const category of selected) {
+    for (const skill of SKILL_CATEGORIES_MAP[category] || []) keep.add(skill);
+  }
+
+  for (const [category, skills] of Object.entries(SKILL_CATEGORIES_MAP)) {
+    if (selected.includes(category)) continue;
+    for (const skill of skills) {
+      if (!keep.has(skill)) excluded.add(skill);
+    }
+  }
+  return excluded;
+}

--- a/bin/lib/skill-categories.mjs
+++ b/bin/lib/skill-categories.mjs
@@ -1,0 +1,153 @@
+/**
+ * Skill-category selection for the session-start launcher (#1308).
+ *
+ * ## Why this leaf exists
+ *
+ * The launcher syncs every shipped skill into the consumer on each run
+ * (`syncDirRecursive` in `file-sync.mjs`). Before #1308 that sync was
+ * unconditional except for `INTERNAL_SKILLS`, which meant a consumer could not
+ * narrow their installed skill set: whatever `flo init` selected, the next
+ * session start put everything back. The category structure in `SKILLS_MAP` was
+ * therefore dead config.
+ *
+ * To honour a selection the launcher has to know which skill belongs to which
+ * category. The canonical map is `SKILLS_MAP` in `src/cli/init/executor.ts`,
+ * but the launcher is a plain `.mjs` and cannot import that TS const across the
+ * dist/source depth boundary — so this leaf mirrors it, exactly as
+ * `internal-skills.mjs` mirrors `INTERNAL_SKILLS`.
+ * `tests/bin/skill-categories-parity.test.ts` asserts the two never drift.
+ *
+ * ## Default is "everything"
+ *
+ * A consumer with no `skills:` block in `moflo.yaml` must keep getting every
+ * skill — anything else would silently delete capability on upgrade for every
+ * existing install (Rule #2). `parseSkillCategories` returns `null` for
+ * "unconfigured", and `computeExcludedSkills(null, …)` excludes nothing beyond
+ * the internal skills.
+ *
+ * @module bin/lib/skill-categories
+ */
+
+/**
+ * Mirror of `SKILLS_MAP` in `src/cli/init/executor.ts`. Keep in sync — the
+ * parity test fails otherwise.
+ */
+export const SKILL_CATEGORIES_MAP = {
+  core: [
+    'commune',
+    'eldar',
+    'guidance',
+    'healer',
+    'flo-simplify',
+    'distill',
+    'luminarium',
+    'reasoningbank-intelligence',
+    'meditate',
+    'divine',
+    'quicken',
+    'perf-audit',
+    'ward',
+    'test-gaps',
+    'verify',
+  ],
+  memory: [
+    'memory-patterns',
+    'memory-optimization',
+    'vector-search',
+    'memory-worktree',
+    'memory-team',
+  ],
+  spells: [
+    'spell-builder',
+    'spell-schedule',
+    'connector-builder',
+  ],
+};
+
+/** Every category name, in declaration order. */
+export const SKILL_CATEGORY_NAMES = Object.keys(SKILL_CATEGORIES_MAP);
+
+/**
+ * Skills installed by `moflo-init.ts` outside `SKILLS_MAP` (the `/flo` + `/fl`
+ * ticket spell). They are the primary entry point and are never category-gated
+ * — excluding them would break the headline workflow.
+ */
+export const ALWAYS_INSTALLED_SKILLS = ['flo', 'fl'];
+
+/**
+ * Extract the selected skill categories from raw `moflo.yaml` text.
+ *
+ * Regex-based on purpose: the launcher deliberately avoids a YAML dependency
+ * (see the `auto_update` parsing it sits beside). Both YAML list styles are
+ * accepted because either is what a hand-editing consumer will write:
+ *
+ *     skills:
+ *       categories: [core, memory]
+ *
+ *     skills:
+ *       categories:
+ *         - core
+ *         - memory
+ *
+ * @param {string} yamlContent
+ * @returns {string[]|null} selected categories, or null when unconfigured
+ *   (meaning "no restriction" — sync everything). An explicitly EMPTY list
+ *   returns `[]`, which is a real selection meaning "core-and-always only".
+ */
+export function parseSkillCategories(yamlContent) {
+  if (typeof yamlContent !== 'string' || yamlContent.length === 0) return null;
+
+  // Flow style: categories: [a, b]
+  const flow = yamlContent.match(/^[ \t]*skills:[ \t]*\r?\n(?:[ \t]+[^\r\n]*\r?\n)*?[ \t]+categories:[ \t]*\[([^\]]*)\]/m);
+  if (flow) {
+    return flow[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+      .filter((s) => s.length > 0);
+  }
+
+  // Block style: categories:\n  - a\n  - b
+  const block = yamlContent.match(/^[ \t]*skills:[ \t]*\r?\n(?:[ \t]+[^\r\n]*\r?\n)*?[ \t]+categories:[ \t]*\r?\n((?:[ \t]*-[ \t]*[^\r\n]+\r?\n?)+)/m);
+  if (block) {
+    return block[1]
+      .split(/\r?\n/)
+      .map((line) => line.match(/^[ \t]*-[ \t]*(.+?)[ \t]*$/))
+      .filter(Boolean)
+      .map((m) => m[1].replace(/^['"]|['"]$/g, '').trim())
+      .filter((s) => s.length > 0);
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the set of top-level skill directory names the launcher must NOT
+ * sync, given a selection.
+ *
+ * Unknown category names in the selection are ignored rather than treated as
+ * "select nothing" — a typo in `moflo.yaml` should not silently strip a
+ * consumer's skills. Skills that belong to no category at all are always kept
+ * for the same reason: this function can only ever exclude a skill it can
+ * positively attribute to an UNSELECTED category.
+ *
+ * @param {string[]|null} selected - from `parseSkillCategories`
+ * @param {string[]} internalSkills - INTERNAL_SKILLS (never installed)
+ * @returns {Set<string>} top-level names to exclude from the sync
+ */
+export function computeExcludedSkills(selected, internalSkills = []) {
+  const excluded = new Set(internalSkills);
+  if (!Array.isArray(selected)) return excluded; // unconfigured → no restriction
+
+  const keep = new Set(ALWAYS_INSTALLED_SKILLS);
+  for (const category of selected) {
+    for (const skill of SKILL_CATEGORIES_MAP[category] || []) keep.add(skill);
+  }
+
+  for (const [category, skills] of Object.entries(SKILL_CATEGORIES_MAP)) {
+    if (selected.includes(category)) continue;
+    for (const skill of skills) {
+      if (!keep.has(skill)) excluded.add(skill);
+    }
+  }
+  return excluded;
+}

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -17,6 +17,7 @@ import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyRetiredPrune } from './lib/retired-files.mjs';
 import { makeSyncer, contentEqual, syncDirRecursive } from './lib/file-sync.mjs';
 import { INTERNAL_SKILLS } from './lib/internal-skills.mjs';
+import { parseSkillCategories, computeExcludedSkills } from './lib/skill-categories.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
 import {
   readContinuityConfig,
@@ -839,6 +840,9 @@ let autoUpdateConfig = {
   // refresh CLAUDE.md on their own — there is no other auto-refresh path.
   claudemdInjectionDrift: 'regenerate',
 };
+// #1308 — skill categories the consumer opted into via moflo.yaml. `null` =
+// unconfigured = no restriction (every shipped skill syncs, as before).
+let selectedSkillCategories = null;
 try {
   const mofloYaml = resolve(projectRoot, 'moflo.yaml');
   if (existsSync(mofloYaml)) {
@@ -859,6 +863,10 @@ try {
     if (helpersMatch) autoUpdateConfig.helpers = helpersMatch[1] === 'true';
     if (driftMatch) autoUpdateConfig.hookBlockDrift = driftMatch[1];
     if (claudemdMatch) autoUpdateConfig.claudemdInjectionDrift = claudemdMatch[1];
+    // #1308 — optional `skills: categories: [...]` selection. null means
+    // unconfigured, which must keep meaning "sync everything" so no existing
+    // consumer loses skills on upgrade.
+    selectedSkillCategories = parseSkillCategories(yamlContent);
   }
 } catch (err) {
   // Defaults (all true) keep the upgrade flow alive but the user should
@@ -1216,10 +1224,24 @@ try {
         '.claude/agents',
         { projectRoot, syncFile, onWarn: emitWarning },
       );
+      // #1308 — excludeTopLevel is INTERNAL_SKILLS plus, when the consumer has
+      // opted into a `skills: categories: [...]` selection in moflo.yaml, every
+      // skill belonging to an unselected category. With no selection the set is
+      // just INTERNAL_SKILLS, i.e. byte-for-byte the pre-#1308 behaviour — a
+      // silent narrowing on upgrade would strip capability from every existing
+      // consumer (Rule #2), so "unconfigured" must always mean "everything".
+      const excludedSkills = computeExcludedSkills(selectedSkillCategories, INTERNAL_SKILLS);
+      if (selectedSkillCategories) {
+        emitMutation(
+          'applied skills selection',
+          `categories [${selectedSkillCategories.join(', ')}] — ` +
+          `${plural(excludedSkills.size - INTERNAL_SKILLS.length, 'skill')} not synced`,
+        );
+      }
       await syncDirRecursive(
         resolve(projectRoot, 'node_modules/moflo/.claude/skills'),
         '.claude/skills',
-        { projectRoot, syncFile, excludeTopLevel: new Set(INTERNAL_SKILLS), onWarn: emitWarning },
+        { projectRoot, syncFile, excludeTopLevel: excludedSkills, onWarn: emitWarning },
       );
 
       // Sync all shipped guidance files from node_modules/moflo/.claude/guidance/shipped/

--- a/src/cli/__tests__/init-copy-maps.test.ts
+++ b/src/cli/__tests__/init-copy-maps.test.ts
@@ -119,11 +119,36 @@ describe('init copy maps — no hardcoded property access (structural regression
     expect(hardcodedAccess).toEqual([]);
   });
 
-  it('copy functions use Object.entries() for iteration', () => {
-    // Verify the pattern: for (const [key, ...] of Object.entries(COMMANDS_MAP))
+  it('copy functions iterate their map generically, never category by category', () => {
+    // The invariant is "adding a category requires no edit to the copy
+    // function" — the #690/#694 orphan class. `Object.entries(...)` is one way
+    // to satisfy it, not the invariant itself.
     expect(source).toContain('Object.entries(COMMANDS_MAP)');
-    expect(source).toContain('Object.entries(SKILLS_MAP)');
     expect(source).toContain('Object.entries(AGENTS_MAP)');
+
+    // copySkills iterates SKILL_CATEGORIES — the declared single source of
+    // truth — and indexes SKILLS_MAP dynamically (#1308). That is strictly
+    // stronger than Object.entries here: SKILLS_MAP is typed
+    // `Record<SkillCategory, string[]>`, so adding a category to
+    // SKILL_CATEGORIES makes a missing SKILLS_MAP key a COMPILE error, and
+    // vice versa. Object.entries could not catch that — and its inverse, a
+    // SKILLS_MAP key with no matching config key, is exactly the drift that
+    // silently disabled the `memory` and `spells` categories.
+    const iteratesGenerically =
+      source.includes('Object.entries(SKILLS_MAP)') ||
+      (source.includes('of SKILL_CATEGORIES') && source.includes('SKILLS_MAP[category]'));
+    expect(
+      iteratesGenerically,
+      'copySkills must iterate SKILLS_MAP generically (Object.entries, or SKILL_CATEGORIES + dynamic index)',
+    ).toBe(true);
+  });
+
+  it('SKILLS_MAP is typed by the category union so it cannot drift from the config', () => {
+    // Guards the #1308 root cause directly: a `Record<string, string[]>`
+    // annotation is what allowed SKILLS_MAP to hold keys the config never
+    // declared, with an `as keyof typeof` cast hiding the mismatch.
+    expect(source).toContain('Record<SkillCategory, string[]>');
+    expect(source).not.toContain('skillsConfig[key as keyof typeof skillsConfig]');
   });
 });
 

--- a/src/cli/__tests__/init-skill-selection-1308.test.ts
+++ b/src/cli/__tests__/init-skill-selection-1308.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Behaviour tests for skill-category selection (#1308).
+ *
+ * The pre-existing drift guard (`skills-classification-drift.test.ts`) asserts
+ * only CLASSIFICATION completeness — that every shipped skill dir appears in
+ * `SKILLS_MAP` or `INTERNAL_SKILLS`. That passed happily while the selection
+ * mechanism was completely broken, because it never asserted that selecting a
+ * category actually installs that category and nothing else.
+ *
+ * These tests assert the behaviour instead.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { executeInit, SKILLS_MAP, INTERNAL_SKILLS } from '../init/executor.js';
+import {
+  DEFAULT_INIT_OPTIONS,
+  MINIMAL_INIT_OPTIONS,
+  FULL_INIT_OPTIONS,
+  SKILL_CATEGORIES,
+  type InitOptions,
+} from '../init/types.js';
+import { findRepoRoot } from './_helpers/repo-walk.js';
+
+const REPO_ROOT = findRepoRoot(import.meta.url);
+
+function makeTarget(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'skill-select-1308-'));
+  mkdirSync(join(dir, '.claude'), { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fixture', version: '0.0.0' }));
+  return dir;
+}
+
+/** Install with ONLY the skills component, so nothing else muddies the result. */
+async function installSkills(target: string, skills: InitOptions['skills']): Promise<string[]> {
+  await executeInit({
+    ...MINIMAL_INIT_OPTIONS,
+    targetDir: target,
+    sourceBaseDir: join(REPO_ROOT, '.claude'),
+    components: {
+      settings: false, skills: true, commands: false, agents: false, helpers: false,
+      statusline: false, mcp: false, runtime: false, claudeMd: false, pathSetup: false,
+    },
+    skills,
+  });
+  const dir = join(target, '.claude', 'skills');
+  return existsSync(dir) ? readdirSync(dir).sort() : [];
+}
+
+describe('skill-category selection installs what was selected (#1308)', () => {
+  let target: string;
+  beforeEach(() => { target = makeTarget(); });
+  afterEach(() => { try { rmSync(target, { recursive: true, force: true }); } catch { /* ok */ } });
+
+  it('core-only installs exactly the core set — no memory, no spells', async () => {
+    const installed = await installSkills(target, {
+      core: true, memory: false, spells: false, all: false,
+    });
+
+    for (const skill of SKILLS_MAP.core) expect(installed).toContain(skill);
+    for (const skill of SKILLS_MAP.memory) expect(installed).not.toContain(skill);
+    for (const skill of SKILLS_MAP.spells) expect(installed).not.toContain(skill);
+  });
+
+  it('memory category is reachable at all — it was not before #1308', async () => {
+    // The regression under test: `memory` was a SKILLS_MAP key with no matching
+    // config key, so this selection installed ZERO skills.
+    const installed = await installSkills(target, {
+      core: false, memory: true, spells: false, all: false,
+    });
+
+    expect(installed.length).toBeGreaterThan(0);
+    for (const skill of SKILLS_MAP.memory) expect(installed).toContain(skill);
+    for (const skill of SKILLS_MAP.core) expect(installed).not.toContain(skill);
+  });
+
+  it('spells category is reachable at all — it was not before #1308', async () => {
+    const installed = await installSkills(target, {
+      core: false, memory: false, spells: true, all: false,
+    });
+
+    expect(installed.length).toBeGreaterThan(0);
+    for (const skill of SKILLS_MAP.spells) expect(installed).toContain(skill);
+  });
+
+  it('every declared category installs a non-empty set', async () => {
+    // Guards the general shape of the bug rather than the two instances of it:
+    // no category may be declared-but-unreachable.
+    for (const category of SKILL_CATEGORIES) {
+      const dir = makeTarget();
+      try {
+        const skills = { core: false, memory: false, spells: false, all: false };
+        skills[category] = true;
+        const installed = await installSkills(dir, skills);
+        expect(installed.length, `category "${category}" installed nothing`).toBeGreaterThan(0);
+      } finally {
+        try { rmSync(dir, { recursive: true, force: true }); } catch { /* ok */ }
+      }
+    }
+  });
+
+  it('all:true installs every category and overrides the individual flags', async () => {
+    const installed = await installSkills(target, {
+      core: false, memory: false, spells: false, all: true,
+    });
+
+    for (const skills of Object.values(SKILLS_MAP)) {
+      for (const skill of skills) expect(installed).toContain(skill);
+    }
+  });
+
+  it('never installs INTERNAL_SKILLS, whatever is selected', async () => {
+    const installed = await installSkills(target, {
+      core: true, memory: true, spells: true, all: true,
+    });
+    for (const skill of INTERNAL_SKILLS) expect(installed).not.toContain(skill);
+  });
+
+  it('DEFAULT selects every category — consumers must not lose skills on upgrade', () => {
+    // Rule #2. The launcher already syncs everything, so DEFAULT selecting a
+    // subset would leave init and the launcher disagreeing (which is how the
+    // bug hid). Assert the presets directly rather than via an install.
+    for (const category of SKILL_CATEGORIES) {
+      expect(DEFAULT_INIT_OPTIONS.skills[category], `DEFAULT must select "${category}"`).toBe(true);
+      expect(FULL_INIT_OPTIONS.skills[category], `FULL must select "${category}"`).toBe(true);
+    }
+    // MINIMAL is deliberately core-only.
+    expect(MINIMAL_INIT_OPTIONS.skills.core).toBe(true);
+    expect(MINIMAL_INIT_OPTIONS.skills.memory).toBe(false);
+    expect(MINIMAL_INIT_OPTIONS.skills.spells).toBe(false);
+  });
+
+  it('no preset declares a key that is not a real category', () => {
+    // `github` / `browser` were exactly this: config keys selecting nothing.
+    const allowed = new Set<string>([...SKILL_CATEGORIES, 'all']);
+    for (const [name, preset] of Object.entries({
+      DEFAULT: DEFAULT_INIT_OPTIONS, MINIMAL: MINIMAL_INIT_OPTIONS, FULL: FULL_INIT_OPTIONS,
+    })) {
+      for (const key of Object.keys(preset.skills)) {
+        expect(allowed.has(key), `${name}_INIT_OPTIONS.skills has dead key "${key}"`).toBe(true);
+      }
+    }
+  });
+});

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_INIT_OPTIONS,
   MINIMAL_INIT_OPTIONS,
   FULL_INIT_OPTIONS,
+  SKILL_CATEGORIES,
   type InitOptions,
 } from '../init/index.js';
 
@@ -419,18 +420,39 @@ const wizardCommand: Command = {
         options.components.mcp = components.includes('mcp');
         options.components.runtime = components.includes('runtime');
 
-        // Skills selection
+        // Skills selection.
+        //
+        // #1308: this used to offer 'Core' and 'GitHub'. 'GitHub' mapped to
+        // `options.skills.github`, which has no matching SKILLS_MAP category —
+        // so ticking it did nothing at all, and the `memory` / `spells`
+        // categories were never offered. The options now mirror
+        // SKILL_CATEGORIES, so every choice here selects real skills.
         if (options.components.skills) {
           const skillSets = await multiSelect({
             message: 'Select skill sets:',
             options: [
-              { value: 'core', label: 'Core', hint: 'Swarm, memory, SPARC, ReasoningBank skills', selected: true },
-              { value: 'github', label: 'GitHub', hint: 'GitHub integration skills', selected: true },
+              { value: 'core', label: 'Core', hint: '/fl, /healer, /verify, /flo-simplify, /eldar …', selected: true },
+              { value: 'memory', label: 'Memory', hint: 'Memory patterns, vector search, team/worktree sharing', selected: true },
+              { value: 'spells', label: 'Spells', hint: 'Spell authoring, scheduling, connectors', selected: true },
             ],
           });
 
-          options.skills.core = skillSets.includes('core');
-          options.skills.github = skillSets.includes('github');
+          for (const category of SKILL_CATEGORIES) {
+            options.skills[category] = skillSets.includes(category);
+          }
+
+          // A selection made here governs what init COPIES, but the
+          // session-start launcher re-syncs shipped skills on every run and
+          // reads its own selection from moflo.yaml. Without that block the
+          // narrowing silently reverts on the next session — the #1308 trap.
+          // Say so rather than let the user discover it.
+          const narrowed = SKILL_CATEGORIES.filter((c) => !skillSets.includes(c));
+          if (narrowed.length > 0) {
+            output.printInfo(
+              `To keep ${narrowed.join(' + ')} skills from returning on the next session, add to moflo.yaml:\n` +
+              `  skills:\n    categories: [${skillSets.join(', ')}]`,
+            );
+          }
         }
 
         // Hooks selection
@@ -655,10 +677,13 @@ const checkCommand: Command = {
 const skillsCommand: Command = {
   name: 'skills',
   description: 'Initialize only skills',
+  // Flags mirror SKILL_CATEGORIES. `--github` used to be offered here and
+  // installed nothing — there is no GitHub skill category (#1308).
   options: [
-    { name: 'all', description: 'Install all skills', type: 'boolean', default: false },
-    { name: 'core', description: 'Install core skills', type: 'boolean', default: true },
-    { name: 'github', description: 'Install GitHub skills', type: 'boolean', default: false },
+    { name: 'all', description: 'Install every skill category', type: 'boolean', default: false },
+    { name: 'core', description: 'Install core skills (/fl, /healer, /verify, …)', type: 'boolean', default: true },
+    { name: 'memory', description: 'Install memory skills (patterns, vector search, sharing)', type: 'boolean', default: false },
+    { name: 'spells', description: 'Install spell skills (authoring, scheduling, connectors)', type: 'boolean', default: false },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const options: InitOptions = {
@@ -680,8 +705,8 @@ const skillsCommand: Command = {
       skills: {
         all: ctx.flags.all as boolean,
         core: ctx.flags.core as boolean,
-        github: ctx.flags.github as boolean,
-        browser: false,
+        memory: ctx.flags.memory as boolean,
+        spells: ctx.flags.spells as boolean,
       },
     };
 

--- a/src/cli/init/executor.ts
+++ b/src/cli/init/executor.ts
@@ -13,8 +13,8 @@ import { dirname } from 'path';
 // ESM-compatible __dirname
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-import type { InitOptions, InitResult, PlatformInfo } from './types.js';
-import { detectPlatform, DEFAULT_INIT_OPTIONS } from './types.js';
+import type { InitOptions, InitResult, PlatformInfo, SkillCategory } from './types.js';
+import { detectPlatform, DEFAULT_INIT_OPTIONS, SKILL_CATEGORIES } from './types.js';
 import { generateSettingsJson, generateSettings } from './settings-generator.js';
 import { generateMCPJson } from './mcp-generator.js';
 import {
@@ -43,7 +43,9 @@ import { readMofloEnv } from '../services/env-compat.js';
 // cruft). New additions MUST pass the same audit, otherwise the drift-guard
 // test (skills-classification-drift.test.ts) fails. See INTERNAL_SKILLS for
 // skills that ship in the tarball but are deliberately NOT installed.
-export const SKILLS_MAP: Record<string, string[]> = {
+// Typed by SkillCategory (not `string`) so this map and `SkillsConfig` cannot
+// drift apart again — see SKILL_CATEGORIES in types.ts for what that drift cost.
+export const SKILLS_MAP: Record<SkillCategory, string[]> = {
   core: [
     'commune',
     'eldar',
@@ -1013,8 +1015,13 @@ async function copySkills(
     // Copy all available skills
     Object.values(SKILLS_MAP).forEach(skills => skillsToCopy.push(...skills));
   } else {
-    for (const [key, skills] of Object.entries(SKILLS_MAP)) {
-      if (skillsConfig[key as keyof typeof skillsConfig]) skillsToCopy.push(...skills);
+    // Iterate SKILL_CATEGORIES rather than Object.entries + a cast. The cast
+    // was what let `SKILLS_MAP`'s keys drift away from `SkillsConfig`'s without
+    // a type error, silently disabling the `memory` and `spells` categories
+    // (#1308). Indexing a typed Record by the category union needs no cast, so
+    // the compiler now enforces that every category is selectable.
+    for (const category of SKILL_CATEGORIES) {
+      if (skillsConfig[category]) skillsToCopy.push(...SKILLS_MAP[category]);
     }
   }
 

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -10,6 +10,8 @@ export {
   type InitResult,
   type HooksConfig,
   type SkillsConfig,
+  type SkillCategory,
+  SKILL_CATEGORIES,
   type CommandsConfig,
   type AgentsConfig,
   type StatuslineConfig,

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -59,18 +59,32 @@ export interface HooksConfig {
 }
 
 /**
- * Skills configuration
+ * The skill categories `SKILLS_MAP` partitions shipped skills into.
+ *
+ * This list is the single source of truth (#1308). `SkillsConfig` is DERIVED
+ * from it and `SKILLS_MAP` is TYPED by it, so the two can never drift again.
+ *
+ * They did drift, silently, and it disabled the whole selection mechanism:
+ * `SkillsConfig` declared `core`/`github`/`browser` while `SKILLS_MAP` keyed on
+ * `core`/`memory`/`spells`. `copySkills` joins them by key, so `memory` and
+ * `spells` resolved to `undefined` → falsy → never installed, while
+ * `github`/`browser` selected nothing at all. An `as keyof typeof` cast in the
+ * lookup suppressed the type error that would otherwise have caught it. Adding
+ * a category to one side without the other is now a compile error.
  */
-export interface SkillsConfig {
-  /** Include core skills (swarm, memory, sparc, reasoningbank) */
-  core: boolean;
-  /** Include GitHub integration skills */
-  github: boolean;
-  /** Include browser automation skills (agent-browser) */
-  browser: boolean;
-  /** Include all available skills */
+export const SKILL_CATEGORIES = ['core', 'memory', 'spells'] as const;
+
+/** A key of `SKILLS_MAP` — see {@link SKILL_CATEGORIES}. */
+export type SkillCategory = (typeof SKILL_CATEGORIES)[number];
+
+/**
+ * Skills configuration — one boolean per {@link SKILL_CATEGORIES} entry, plus
+ * `all` as an override that selects every category regardless of the flags.
+ */
+export type SkillsConfig = Record<SkillCategory, boolean> & {
+  /** Include every category, ignoring the individual flags */
   all: boolean;
-}
+};
 
 /**
  * Commands configuration
@@ -328,10 +342,15 @@ export const DEFAULT_INIT_OPTIONS: InitOptions = {
     timeout: 5000,
     continueOnError: true,
   },
+  // Every category. This is not a behaviour change: the session-start launcher
+  // syncs all shipped skills on every run regardless of what init selected, so
+  // consumers already end up with all of them. Pre-#1308 this said
+  // `core/github/browser`, which resolved to core-only — meaning `flo init` and
+  // the launcher disagreed, and init's answer simply lost. Now they agree.
   skills: {
     core: true,
-    github: true,
-    browser: true,
+    memory: true,
+    spells: true,
     all: false,
   },
   commands: {
@@ -419,10 +438,11 @@ export const MINIMAL_INIT_OPTIONS: InitOptions = {
     stop: false,
     notification: false,
   },
+  // Minimal deliberately stays core-only — that is the point of the preset.
   skills: {
     core: true,
-    github: false,
-    browser: false,
+    memory: false,
+    spells: false,
     all: false,
   },
   agents: {
@@ -478,8 +498,8 @@ export const FULL_INIT_OPTIONS: InitOptions = {
   },
   skills: {
     core: true,
-    github: true,
-    browser: true,
+    memory: true,
+    spells: true,
     all: true,
   },
   commands: {

--- a/tests/bin/launcher-1308-skill-selection.test.ts
+++ b/tests/bin/launcher-1308-skill-selection.test.ts
@@ -1,0 +1,128 @@
+/**
+ * End-to-end launcher test for skill-category selection (#1308).
+ *
+ * Why this exists as well as the unit tests: #1307 taught the lesson the hard
+ * way. `writeRetainedRecord` had seven green unit tests, including one that
+ * explicitly asserted the behaviour that turned out to be broken — because the
+ * tests called the helper directly while the LAUNCHER only invoked it under a
+ * condition the tests never reproduced. Unit-testing
+ * `computeExcludedSkills` proves the set arithmetic, not that the launcher
+ * actually passes it to `syncDirRecursive`.
+ *
+ * So this spawns the real `bin/session-start-launcher.mjs` against a temp
+ * consumer and asserts what lands on disk.
+ *
+ * On the isolation list (vitest.config.ts) — it spawns the launcher and copies
+ * the shipped skills tree, exactly the profile #1310 showed times out under
+ * parallel fork contention.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { findRepoRoot } from '../../src/cli/__tests__/_helpers/repo-walk.js';
+import { SKILLS_MAP, INTERNAL_SKILLS } from '../../src/cli/init/executor.js';
+
+const REPO_ROOT = findRepoRoot(import.meta.url);
+const LAUNCHER = join(REPO_ROOT, 'bin', 'session-start-launcher.mjs');
+
+/**
+ * Build a consumer fixture with a version SKEW — the launcher's §3 sync (which
+ * owns the skills copy) only runs when the installed version differs from the
+ * recorded stamp. A fixture without skew silently exercises nothing, which is
+ * precisely how #1307's first end-to-end attempt produced a false negative.
+ */
+function makeConsumer(mofloYamlBody: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'launcher-1308-'));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  const pkgDir = join(root, 'node_modules', 'moflo');
+  mkdirSync(join(pkgDir, 'bin'), { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'fixture', version: '0.0.0' }));
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'moflo', version: '4.12.1' }));
+  writeFileSync(join(pkgDir, 'bin', 'cli.js'), 'process.exit(0);\n');
+  writeFileSync(join(root, '.moflo', 'moflo-version'), '4.12.0');
+  cpSync(join(REPO_ROOT, '.claude', 'skills'), join(pkgDir, '.claude', 'skills'), { recursive: true });
+  writeFileSync(join(root, 'moflo.yaml'), `auto_update:\n  enabled: true\n${mofloYamlBody}`);
+  return root;
+}
+
+function runLauncher(cwd: string) {
+  return spawnSync('node', [LAUNCHER], {
+    cwd, encoding: 'utf-8', timeout: 90_000,
+    env: { ...process.env, CI: '1', CLAUDE_PROJECT_DIR: cwd }, input: '',
+  });
+}
+
+function installedSkills(root: string): string[] {
+  const dir = join(root, '.claude', 'skills');
+  return existsSync(dir) ? readdirSync(dir).sort() : [];
+}
+
+/**
+ * Prove the launcher's §3 sync branch actually executed, rather than inferring
+ * it from files that a fixture could have created itself. The launcher commits
+ * the version stamp only on sync success, so a flipped stamp is unforgeable
+ * evidence that the branch under test ran. Without this the suite could pass
+ * against a launcher that silently skipped the whole section.
+ */
+function assertSyncBranchRan(root: string, res: { status: number | null; stderr: string }) {
+  expect(res.status, `launcher stderr: ${res.stderr}`).toBe(0);
+  expect(
+    readFileSync(join(root, '.moflo', 'moflo-version'), 'utf-8').trim(),
+    'version stamp did not flip — the §3 sync branch never ran, so this test proved nothing',
+  ).toBe('4.12.1');
+}
+
+describe('launcher honours skills.categories (#1308)', () => {
+  let root: string | undefined;
+  afterEach(() => {
+    if (root) { try { rmSync(root, { recursive: true, force: true }); } catch { /* ok */ } }
+    root = undefined;
+  });
+
+  it('syncs only the selected categories', () => {
+    root = makeConsumer('skills:\n  categories: [core]\n');
+
+    const res = runLauncher(root);
+    assertSyncBranchRan(root, res);
+
+    const got = installedSkills(root);
+    for (const s of SKILLS_MAP.core) expect(got).toContain(s);
+    for (const s of SKILLS_MAP.memory) expect(got).not.toContain(s);
+    for (const s of SKILLS_MAP.spells) expect(got).not.toContain(s);
+    // /flo + /fl are the headline entry point and are never category-gated.
+    expect(got).toContain('flo');
+    expect(got).toContain('fl');
+  });
+
+  it('syncs EVERYTHING when moflo.yaml has no skills block (Rule #2)', () => {
+    // The upgrade path for every existing consumer. If this ever fails, an
+    // upgrade silently deletes skills from projects that never opted in.
+    root = makeConsumer('');
+
+    const res = runLauncher(root);
+    assertSyncBranchRan(root, res);
+
+    const got = installedSkills(root);
+    for (const skills of Object.values(SKILLS_MAP)) {
+      for (const s of skills) expect(got).toContain(s);
+    }
+    for (const s of INTERNAL_SKILLS) expect(got).not.toContain(s);
+  });
+
+  it('accepts block-style YAML and multiple categories', () => {
+    root = makeConsumer('skills:\n  categories:\n    - core\n    - spells\n');
+
+    const res = runLauncher(root);
+    assertSyncBranchRan(root, res);
+
+    const got = installedSkills(root);
+    for (const s of SKILLS_MAP.spells) expect(got).toContain(s);
+    for (const s of SKILLS_MAP.memory) expect(got).not.toContain(s);
+  });
+});

--- a/tests/bin/skill-categories-parity.test.ts
+++ b/tests/bin/skill-categories-parity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Drift guard + unit tests for the launcher's skill-category selection (#1308).
+ *
+ * `bin/lib/skill-categories.mjs` mirrors `SKILLS_MAP` from
+ * `src/cli/init/executor.ts` because the launcher is a plain `.mjs` and cannot
+ * import that TS const across the dist/source depth boundary. Same arrangement
+ * as `internal-skills.mjs` / `internal-skills-parity.test.ts`.
+ *
+ * The parity test matters more than usual here: #1308 exists precisely because
+ * two representations of the skill categories drifted apart silently and
+ * disabled the whole selection mechanism. A mirror is a second chance to make
+ * that same mistake, so it is pinned.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SKILL_CATEGORIES_MAP,
+  SKILL_CATEGORY_NAMES,
+  ALWAYS_INSTALLED_SKILLS,
+  parseSkillCategories,
+  computeExcludedSkills,
+} from '../../bin/lib/skill-categories.mjs';
+import { SKILLS_MAP, INTERNAL_SKILLS } from '../../src/cli/init/executor.js';
+import { SKILL_CATEGORIES } from '../../src/cli/init/types.js';
+
+describe('skill-categories parity with SKILLS_MAP (#1308)', () => {
+  it('mirrors the canonical SKILLS_MAP exactly', () => {
+    expect(SKILL_CATEGORIES_MAP).toEqual(SKILLS_MAP);
+  });
+
+  it('category names match SKILL_CATEGORIES, the single source of truth', () => {
+    expect(SKILL_CATEGORY_NAMES.slice().sort()).toEqual([...SKILL_CATEGORIES].sort());
+  });
+
+  it('every SKILLS_MAP key is a declared SKILL_CATEGORIES entry (the #1308 bug)', () => {
+    // The original defect: SKILLS_MAP had keys (`memory`, `spells`) that the
+    // config type did not declare, so they could never be selected.
+    for (const key of Object.keys(SKILLS_MAP)) {
+      expect(SKILL_CATEGORIES).toContain(key);
+    }
+  });
+});
+
+describe('parseSkillCategories', () => {
+  it('returns null when moflo.yaml has no skills block (unconfigured)', () => {
+    expect(parseSkillCategories('auto_update:\n  enabled: true\n')).toBeNull();
+  });
+
+  it('returns null for empty or non-string input', () => {
+    expect(parseSkillCategories('')).toBeNull();
+    expect(parseSkillCategories(undefined as unknown as string)).toBeNull();
+  });
+
+  it('parses flow style: categories: [core, memory]', () => {
+    const yaml = 'skills:\n  categories: [core, memory]\n';
+    expect(parseSkillCategories(yaml)).toEqual(['core', 'memory']);
+  });
+
+  it('parses block style with leading dashes', () => {
+    const yaml = 'skills:\n  categories:\n    - core\n    - spells\n';
+    expect(parseSkillCategories(yaml)).toEqual(['core', 'spells']);
+  });
+
+  it('strips quotes in both styles', () => {
+    expect(parseSkillCategories('skills:\n  categories: ["core", \'memory\']\n'))
+      .toEqual(['core', 'memory']);
+    expect(parseSkillCategories('skills:\n  categories:\n    - "core"\n'))
+      .toEqual(['core']);
+  });
+
+  it('handles CRLF line endings (Rule #1)', () => {
+    // A Windows consumer hand-editing moflo.yaml writes CRLF. A parser anchored
+    // on bare \n would return null and silently ignore their selection.
+    const lf = 'skills:\n  categories:\n    - core\n    - memory\n';
+    expect(parseSkillCategories(lf.replace(/\n/g, '\r\n'))).toEqual(['core', 'memory']);
+    expect(parseSkillCategories('skills:\r\n  categories: [core]\r\n')).toEqual(['core']);
+  });
+
+  it('parses an explicitly empty flow list as a real (empty) selection', () => {
+    // Distinct from unconfigured: [] means "only the always-installed skills".
+    expect(parseSkillCategories('skills:\n  categories: []\n')).toEqual([]);
+  });
+
+  it('is not confused by an unrelated top-level key named categories', () => {
+    expect(parseSkillCategories('other:\n  categories: [nope]\n')).toBeNull();
+  });
+
+  it('tolerates intervening keys inside the skills block', () => {
+    const yaml = 'skills:\n  profile: custom\n  categories: [core]\n';
+    expect(parseSkillCategories(yaml)).toEqual(['core']);
+  });
+});
+
+describe('computeExcludedSkills', () => {
+  it('excludes only INTERNAL_SKILLS when unconfigured — pre-#1308 behaviour', () => {
+    // Rule #2: this is the path every existing consumer takes. Any extra
+    // exclusion here silently strips their skills on upgrade.
+    const excluded = computeExcludedSkills(null, INTERNAL_SKILLS);
+    expect([...excluded].sort()).toEqual([...INTERNAL_SKILLS].sort());
+  });
+
+  it('excludes unselected categories when a selection is present', () => {
+    const excluded = computeExcludedSkills(['core'], INTERNAL_SKILLS);
+    for (const skill of SKILLS_MAP.memory) expect(excluded).toContain(skill);
+    for (const skill of SKILLS_MAP.spells) expect(excluded).toContain(skill);
+    for (const skill of SKILLS_MAP.core) expect(excluded).not.toContain(skill);
+  });
+
+  it('never excludes the /flo + /fl ticket spell', () => {
+    // Installed by moflo-init.ts outside SKILLS_MAP; it is the headline entry
+    // point, so no selection may gate it away.
+    const excluded = computeExcludedSkills([], INTERNAL_SKILLS);
+    for (const skill of ALWAYS_INSTALLED_SKILLS) expect(excluded).not.toContain(skill);
+  });
+
+  it('selecting every category excludes nothing beyond INTERNAL_SKILLS', () => {
+    const excluded = computeExcludedSkills([...SKILL_CATEGORY_NAMES], INTERNAL_SKILLS);
+    expect([...excluded].sort()).toEqual([...INTERNAL_SKILLS].sort());
+  });
+
+  it('ignores an unknown category rather than stripping everything', () => {
+    // A typo in moflo.yaml must not silently wipe the consumer's skills.
+    const excluded = computeExcludedSkills(['core', 'typoed-category'], INTERNAL_SKILLS);
+    for (const skill of SKILLS_MAP.core) expect(excluded).not.toContain(skill);
+  });
+
+  it('still excludes INTERNAL_SKILLS even when a selection is present', () => {
+    const excluded = computeExcludedSkills(['core', 'memory', 'spells'], INTERNAL_SKILLS);
+    for (const s of INTERNAL_SKILLS) expect(excluded).toContain(s);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -113,6 +113,33 @@ export const isolationTests = [
   // tree per fixture. Same spawn-the-launcher profile #1310 showed exceeds its
   // spawnSync timeout under parallel fork contention.
   'tests/bin/launcher-1308-skill-selection.test.ts',
+  // Issue #1310 — tests that `spawnSync` the REAL session-start launcher.
+  //
+  // Confirmed mechanism, not a guess: under full-suite fork contention
+  // `session-start-launcher-daemon-behind.test.ts` failed with
+  // `expected null to be +0` and an EMPTY stderr — that is the spawnSync
+  // TIMEOUT signature (the child is killed, so `status` is null and nothing
+  // was written), not an assertion about launcher behavior. It passes 5/5
+  // alone. Same story as `daemon-lock-orphan.test.ts` above.
+  //
+  // The whole family is listed rather than only the file that happened to
+  // flake: each one boots the launcher end-to-end against a temp consumer
+  // (fs sync, manifest walks, fire-and-forget child spawns) on a fixed
+  // per-call timeout, so which one loses the race is arbitrary. Same
+  // reasoning as the four `prerequisites-*` files above.
+  //
+  // Files that merely READ or import from the launcher (lib-sync,
+  // launcher-948-retired-prune, install-manifest, …) are deliberately NOT
+  // here — they carry none of the subprocess cost and belong in the fast pass.
+  'src/cli/__tests__/session-start-launcher-daemon-behind.test.ts',
+  'src/cli/__tests__/session-start-launcher-stamp-loop-recovery.test.ts',
+  'src/cli/__tests__/bootstrap-sentinel-promotion.test.ts',
+  'tests/bin/launcher-854-fixes.test.ts',
+  'tests/bin/launcher-928-dogfood-skip.test.ts',
+  'tests/bin/launcher-headless-skip.test.ts',
+  'tests/bin/launcher-visibility.test.ts',
+  'tests/bin/prompt-hook-restart-notice.test.ts',
+  'tests/system/launcher-version-skew-upgrade-boundary.test.ts',
 ];
 
 export default defineConfig({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -109,6 +109,10 @@ export const isolationTests = [
   // real subsystem; reliably fits in 10 s alone, can drift past full-suite
   // per-test ceilings under fork contention.
   'src/cli/__tests__/doctor-checks-memory-access.test.ts',
+  // #1308 — spawns the real launcher three times and copies the shipped skills
+  // tree per fixture. Same spawn-the-launcher profile #1310 showed exceeds its
+  // spawnSync timeout under parallel fork contention.
+  'tests/bin/launcher-1308-skill-selection.test.ts',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
Closes #1308. Follow-up to #1307 finding 1, which #1309 deliberately did not address because it rested on this defect.

moflo shipped a skill-category selection mechanism that **did nothing**.

## Three compounding breakages

1. **Key mismatch.** `SkillsConfig` declared `core`/`github`/`browser`; `SKILLS_MAP` keyed on `core`/`memory`/`spells`. `copySkills` joins them *by key*, so `memory` and `spells` resolved to `undefined` → falsy → **never installed**, and `github`/`browser` selected nothing at all. An `as keyof typeof` cast in the lookup suppressed the type error that would have caught it.
2. **Unreachable presets.** DEFAULT and MINIMAL both set `all: false`, so `memory` and `spells` were reachable only through FULL.
3. **The launcher overrode everything.** It blanket-syncs every shipped skill except `INTERNAL_SKILLS`, so whatever init selected came back on the next session start.

Net: the categories were dead config, and the interactive wizard offered a **"GitHub" skill set that installed nothing**.

## Fixes

**Single source of truth.** `SKILL_CATEGORIES` in `types.ts` now defines the categories; `SkillsConfig` is derived from it (`Record<SkillCategory, boolean>`) and `SKILLS_MAP` is typed `Record<SkillCategory, string[]>`. Adding a category to one side without the other is now a **compile error**. The cast is gone — `copySkills` iterates `SKILL_CATEGORIES` and indexes the typed map, which needs no cast.

> The type change immediately earned its keep: it **failed the build** on a second dead `github` site (`flo init skills --github`) that the cast had been hiding.

**Wizard and CLI offer real categories.** Core / Memory / Spells replace the dead "GitHub" option; `flo init skills` swaps `--github` for `--memory` / `--spells`.

**The launcher honours a selection.** New `bin/lib/skill-categories.mjs` parses an optional `skills: categories: [...]` block from `moflo.yaml` (both YAML list styles, CRLF-safe) and computes the exclusion set handed to `syncDirRecursive`. It mirrors `SKILLS_MAP` because the launcher is `.mjs` and cannot import TS across the dist/source boundary — the same arrangement as `internal-skills.mjs`, with a parity test so the mirror cannot drift.

## Consumer impact (Rule #2)

**No consumer's installed skill set changes.** Unconfigured — every existing project — still means "sync everything", with an explicit end-to-end test for that exact upgrade path.

`DEFAULT_INIT_OPTIONS` now selects all three categories. That is a *correction*, not a behaviour change: the launcher already delivered all of them, so init and the launcher simply stop disagreeing.

Safety properties, all tested:

- `/flo` + `/fl` are never category-gated
- an unknown category name is **ignored**, not treated as "select nothing" — a typo can't strip your skills
- `INTERNAL_SKILLS` stay excluded under every selection
- `categories: []` (explicit) is distinct from omitting the block, and the two are never conflated

Narrowing **stops future syncing; it does not delete**. moflo will not remove skills a consumer already has. Documented, with the whole option, in `moflo-yaml-reference.md`.

**Known limitation, surfaced rather than hidden:** the wizard cannot persist its own choice — `moflo.yaml` is written by `moflo-init.ts`, a different flow from `executor.ts` where selection lives. So a narrowing selection would silently revert next session. Rather than ship that trap quietly, the wizard now prints the exact `moflo.yaml` block needed to make it stick.

## Verification

End-to-end against the **real launcher** — the #1307 lesson was that helper unit tests cannot prove the launcher wires them up. Three fixtures, each with a version skew so the §3 sync branch actually runs:

| moflo.yaml | Skills synced | Result |
|---|---|---|
| `categories: [core]` | 17 | memory + spells absent |
| *(no skills block)* | **25** | nothing stripped |
| `categories:` block-style `[core, spells]` | 20 | memory absent |

The e2e asserts the **version stamp flipped** — the launcher writes it only on sync success, so that is unforgeable evidence the branch under test ran, rather than inferring it from files a fixture could have created itself.

**Full suite: 9528 passed, 0 failed — three consecutive identical totals.**

### One catch worth recording

The first full run on this branch returned **9513 passed, 0 failed**. Not a #1308 bug: this branch was cut from `main` and therefore lacked the #1310 isolation fix living on #1309's branch, so 15 tests silently timed out and were never counted. Cherry-picked `04e8f3be9`; totals became 9528 ×3. That is independent confirmation the #1310 diagnosis was correct — and a reminder that a dropping total with zero failures means tests didn't run.

### Guard updated, not weakened

`init-copy-maps.test.ts` asserted `Object.entries(SKILLS_MAP)` as a *proxy* for "iterates generically". The typed loop satisfies the real invariant (adding a category needs no copy-function edit) more strongly, so the guard now accepts either form and gained a test pinning the `Record<SkillCategory, …>` annotation and the cast's absence.

New tests: 19 parity/parser, 8 selection-behaviour, 3 launcher e2e. The pre-existing drift guard stayed green throughout because it only asserted *classification* completeness — never that selecting a category installs it.
