### PR TITLE
docs(init): correct skills.categories empty-list contract + pin it (#1308)

### DIFF
--- a/.claude/scripts/lib/skill-categories.mjs
+++ b/.claude/scripts/lib/skill-categories.mjs
@@ -91,8 +91,13 @@ export const ALWAYS_INSTALLED_SKILLS = ['flo', 'fl'];
  *
  * @param {string} yamlContent
  * @returns {string[]|null} selected categories, or null when unconfigured
- *   (meaning "no restriction" — sync everything). An explicitly EMPTY list
- *   returns `[]`, which is a real selection meaning "core-and-always only".
+ *   (meaning "no restriction" — sync everything).
+ *
+ *   An explicitly empty list returns `[]`, which is a REAL selection and is not
+ *   the same as `null`: it excludes every category, leaving only
+ *   {@link ALWAYS_INSTALLED_SKILLS} (`/flo` + `/fl`). That is a legitimate
+ *   "bare minimum" choice, but it is a much stronger statement than omitting
+ *   the block, so the two must never be conflated.
  */
 export function parseSkillCategories(yamlContent) {
   if (typeof yamlContent !== 'string' || yamlContent.length === 0) return null;

--- a/bin/lib/skill-categories.mjs
+++ b/bin/lib/skill-categories.mjs
@@ -91,8 +91,13 @@ export const ALWAYS_INSTALLED_SKILLS = ['flo', 'fl'];
  *
  * @param {string} yamlContent
  * @returns {string[]|null} selected categories, or null when unconfigured
- *   (meaning "no restriction" — sync everything). An explicitly EMPTY list
- *   returns `[]`, which is a real selection meaning "core-and-always only".
+ *   (meaning "no restriction" — sync everything).
+ *
+ *   An explicitly empty list returns `[]`, which is a REAL selection and is not
+ *   the same as `null`: it excludes every category, leaving only
+ *   {@link ALWAYS_INSTALLED_SKILLS} (`/flo` + `/fl`). That is a legitimate
+ *   "bare minimum" choice, but it is a much stronger statement than omitting
+ *   the block, so the two must never be conflated.
  */
 export function parseSkillCategories(yamlContent) {
   if (typeof yamlContent !== 'string' || yamlContent.length === 0) return null;

--- a/tests/bin/skill-categories-parity.test.ts
+++ b/tests/bin/skill-categories-parity.test.ts
@@ -113,6 +113,20 @@ describe('computeExcludedSkills', () => {
     for (const skill of ALWAYS_INSTALLED_SKILLS) expect(excluded).not.toContain(skill);
   });
 
+  it('an EXPLICIT empty list excludes every category — not the same as unconfigured', () => {
+    // `categories: []` is a real "bare minimum" selection; omitting the block
+    // is "no restriction". Conflating them would either strip every skill from
+    // consumers who never opted in, or silently ignore an explicit request.
+    const explicitlyEmpty = computeExcludedSkills([], INTERNAL_SKILLS);
+    const unconfigured = computeExcludedSkills(null, INTERNAL_SKILLS);
+
+    for (const skills of Object.values(SKILLS_MAP)) {
+      for (const s of skills) expect(explicitlyEmpty).toContain(s);
+    }
+    expect([...unconfigured].sort()).toEqual([...INTERNAL_SKILLS].sort());
+    expect(explicitlyEmpty.size).toBeGreaterThan(unconfigured.size);
+  });
+
   it('selecting every category excludes nothing beyond INTERNAL_SKILLS', () => {
     const excluded = computeExcludedSkills([...SKILL_CATEGORY_NAMES], INTERNAL_SKILLS);
     expect([...excluded].sort()).toEqual([...INTERNAL_SKILLS].sort());


### PR DESCRIPTION
Follow-up to #1312. These changes were made during that PR's review pass but **never committed** — the PR body claimed them, so this makes the claim true.

## What was wrong

The JSDoc on `parseSkillCategories` described an explicit `categories: []` as meaning *"core-and-always only"*. It does not — an empty list excludes **every** category, leaving only `ALWAYS_INSTALLED_SKILLS` (`/flo` + `/fl`). Verified directly:

```
computeExcludedSkills([], INTERNAL_SKILLS) → 25 exclusions, includes 'healer'
```

**No behaviour change** — the code was always correct, only the contract describing it was wrong. But it documents a consumer-facing `moflo.yaml` setting, and the wrong version invited someone to write `categories: []` expecting to keep their core skills and instead lose all of them.

Adds the test that pins it: `[]` and an omitted block must never be conflated — one excludes everything, the other excludes nothing. That distinction *is* the Rule #2 guarantee for existing consumers, so it deserves a test rather than a comment.

Twin re-synced to `.claude/scripts/lib/`.

## How it went missing

Worth recording, since nothing failed: the edit was made, the twin synced, and the suite ran green — then a cherry-pick intervened before `git add`, and the change sat in the working tree through the PR, CI, and squash merge. Local green proved nothing, because the suite tests the working tree while CI tested a branch that didn't contain the change. Caught by grepping the merged ref (`git show origin/main:<path>`) rather than trusting local state.

Full suite: 9551 passed, 0 failed.
