### PR TITLE
fix(daemon): anchor .moflo state on the resolved project root (#1315)

### DIFF
--- a/.claude/scripts/hooks.mjs
+++ b/.claude/scripts/hooks.mjs
@@ -26,7 +26,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { createProcessManager } from './lib/process-manager.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
-import { findProjectRoot } from './lib/moflo-paths.mjs';
+import { resolveStateRoot } from './lib/moflo-paths.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -35,7 +35,10 @@ const __dirname = dirname(__filename);
 // in bin/ during development but gets synced to .claude/scripts/ in consumer
 // projects, so __dirname-relative paths break. findProjectRoot() works
 // everywhere and resolves identically to the TS bridge (see lib/moflo-paths.mjs).
-const projectRoot = findProjectRoot();
+// #1315 — resolveStateRoot, NOT findProjectRoot: this layer mkdirs
+// `.moflo/` state, and findProjectRoot honors CLAUDE_PROJECT_DIR verbatim,
+// so a sub-workspace-rooted session minted an island here every start.
+const projectRoot = resolveStateRoot();
 const logFile = resolve(projectRoot, '.moflo', 'logs', 'hooks.log');
 try { mkdirSync(dirname(logFile), { recursive: true }); } catch { /* best effort */ }
 const pm = createProcessManager(projectRoot);

--- a/.claude/scripts/lib/moflo-paths.mjs
+++ b/.claude/scripts/lib/moflo-paths.mjs
@@ -12,7 +12,7 @@
  * helpers no longer ship: the version-bump-gated cherry-pick lives entirely
  * in the launcher and the TS service `cli/services/cherry-pick-learnings.ts`.
  */
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { basename, dirname, join, parse, resolve } from 'node:path';
 
 export const MOFLO_DIR = '.moflo';
@@ -127,6 +127,42 @@ export function findAncestorMofloRoot(dir) {
  * @param {{ cwd?: string; honorEnv?: boolean }} [opts]
  * @returns {string} absolute project root
  */
+/**
+ * Pure-JS twin of `src/cli/services/project-root.ts:resolveStateRoot()` (#1315).
+ *
+ * Use this — never `findProjectRoot()` — anywhere the bin/hook layer is about
+ * to CREATE `.moflo/` state. `findProjectRoot` returns `CLAUDE_PROJECT_DIR`
+ * verbatim, and Claude Code sets that to the SESSION directory; in a monorepo
+ * session rooted at a sub-workspace the launcher therefore mkdir'd a `.moflo/`
+ * island there every session. That made the healer's nested-island fix a
+ * perpetual loop: archive it, next session re-mints it.
+ *
+ * Semantics (kept in lockstep with the TS side): an EXISTING
+ * `CLAUDE_PROJECT_DIR` wins outright and is never climbed above — the marker
+ * walk has no upper bound, so climbing past an explicit anchor would let a
+ * stray ancestor `.moflo/moflo.db` capture every project beneath it. Otherwise
+ * walk up from cwd and take the topmost marker, which is what stops a
+ * sub-directory invocation from minting an island where it stands. A value
+ * naming a directory that does not exist is ignored rather than materialized.
+ *
+ * @param {{ cwd?: string }} [opts]
+ * @returns {string} absolute project root
+ */
+export function resolveStateRoot(opts) {
+  const envDir = process.env.CLAUDE_PROJECT_DIR;
+  const envAbs = envDir ? resolve(envDir) : undefined;
+  const resolved = envAbs && existsSync(envAbs)
+    ? envAbs
+    : findProjectRoot({ honorEnv: false, cwd: opts?.cwd });
+  // Canonicalize so this compares equal to the realpath'd root the TS side
+  // derives (macOS /var → /private/var). Falls back when the path is absent.
+  try {
+    return realpathSync(resolve(resolved));
+  } catch {
+    return resolve(resolved);
+  }
+}
+
 export function findProjectRoot(opts) {
   const honorEnv = opts?.honorEnv !== false;
   if (honorEnv && process.env.CLAUDE_PROJECT_DIR) {

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -11,7 +11,7 @@ import { spawn, execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { mofloDir, findProjectRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAMES } from './lib/moflo-paths.mjs';
+import { mofloDir, resolveStateRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAMES } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyRetiredPrune } from './lib/retired-files.mjs';
@@ -61,7 +61,10 @@ function sessionStartMirrorHeader(file) {
 // first, then walk up for .moflo/moflo.db / .swarm/memory.db / CLAUDE.md+pkg /
 // package.json / .git. Inline walks here have caused N writers to land on
 // different DBs than the bridge reads from — never reintroduce one.
-const projectRoot = findProjectRoot();
+// #1315 — resolveStateRoot, NOT findProjectRoot: this layer mkdirs
+// `.moflo/` state, and findProjectRoot honors CLAUDE_PROJECT_DIR verbatim,
+// so a sub-workspace-rooted session minted an island here every start.
+const projectRoot = resolveStateRoot();
 
 // Monorepo nested-.moflo guard (#1174). After the resolver fix, findProjectRoot
 // returns the topmost ancestor with .moflo/moflo.db, so an ancestor still

--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -26,7 +26,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { createProcessManager } from './lib/process-manager.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
-import { findProjectRoot } from './lib/moflo-paths.mjs';
+import { resolveStateRoot } from './lib/moflo-paths.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -35,7 +35,10 @@ const __dirname = dirname(__filename);
 // in bin/ during development but gets synced to .claude/scripts/ in consumer
 // projects, so __dirname-relative paths break. findProjectRoot() works
 // everywhere and resolves identically to the TS bridge (see lib/moflo-paths.mjs).
-const projectRoot = findProjectRoot();
+// #1315 — resolveStateRoot, NOT findProjectRoot: this layer mkdirs
+// `.moflo/` state, and findProjectRoot honors CLAUDE_PROJECT_DIR verbatim,
+// so a sub-workspace-rooted session minted an island here every start.
+const projectRoot = resolveStateRoot();
 const logFile = resolve(projectRoot, '.moflo', 'logs', 'hooks.log');
 try { mkdirSync(dirname(logFile), { recursive: true }); } catch { /* best effort */ }
 const pm = createProcessManager(projectRoot);

--- a/bin/lib/moflo-paths.mjs
+++ b/bin/lib/moflo-paths.mjs
@@ -12,7 +12,7 @@
  * helpers no longer ship: the version-bump-gated cherry-pick lives entirely
  * in the launcher and the TS service `cli/services/cherry-pick-learnings.ts`.
  */
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { basename, dirname, join, parse, resolve } from 'node:path';
 
 export const MOFLO_DIR = '.moflo';
@@ -127,6 +127,42 @@ export function findAncestorMofloRoot(dir) {
  * @param {{ cwd?: string; honorEnv?: boolean }} [opts]
  * @returns {string} absolute project root
  */
+/**
+ * Pure-JS twin of `src/cli/services/project-root.ts:resolveStateRoot()` (#1315).
+ *
+ * Use this — never `findProjectRoot()` — anywhere the bin/hook layer is about
+ * to CREATE `.moflo/` state. `findProjectRoot` returns `CLAUDE_PROJECT_DIR`
+ * verbatim, and Claude Code sets that to the SESSION directory; in a monorepo
+ * session rooted at a sub-workspace the launcher therefore mkdir'd a `.moflo/`
+ * island there every session. That made the healer's nested-island fix a
+ * perpetual loop: archive it, next session re-mints it.
+ *
+ * Semantics (kept in lockstep with the TS side): an EXISTING
+ * `CLAUDE_PROJECT_DIR` wins outright and is never climbed above — the marker
+ * walk has no upper bound, so climbing past an explicit anchor would let a
+ * stray ancestor `.moflo/moflo.db` capture every project beneath it. Otherwise
+ * walk up from cwd and take the topmost marker, which is what stops a
+ * sub-directory invocation from minting an island where it stands. A value
+ * naming a directory that does not exist is ignored rather than materialized.
+ *
+ * @param {{ cwd?: string }} [opts]
+ * @returns {string} absolute project root
+ */
+export function resolveStateRoot(opts) {
+  const envDir = process.env.CLAUDE_PROJECT_DIR;
+  const envAbs = envDir ? resolve(envDir) : undefined;
+  const resolved = envAbs && existsSync(envAbs)
+    ? envAbs
+    : findProjectRoot({ honorEnv: false, cwd: opts?.cwd });
+  // Canonicalize so this compares equal to the realpath'd root the TS side
+  // derives (macOS /var → /private/var). Falls back when the path is absent.
+  try {
+    return realpathSync(resolve(resolved));
+  } catch {
+    return resolve(resolved);
+  }
+}
+
 export function findProjectRoot(opts) {
   const honorEnv = opts?.honorEnv !== false;
   if (honorEnv && process.env.CLAUDE_PROJECT_DIR) {

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -11,7 +11,7 @@ import { spawn, execFileSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { mofloDir, findProjectRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAMES } from './lib/moflo-paths.mjs';
+import { mofloDir, resolveStateRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAMES } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
 import { applyRetiredPrune, writeRetainedRecord, reconcileRetainedRecord, RETAINED_RECORD_REL } from './lib/retired-files.mjs';
@@ -62,7 +62,10 @@ function sessionStartMirrorHeader(file) {
 // first, then walk up for .moflo/moflo.db / .swarm/memory.db / CLAUDE.md+pkg /
 // package.json / .git. Inline walks here have caused N writers to land on
 // different DBs than the bridge reads from — never reintroduce one.
-const projectRoot = findProjectRoot();
+// #1315 — resolveStateRoot, NOT findProjectRoot: this layer mkdirs
+// `.moflo/` state, and findProjectRoot honors CLAUDE_PROJECT_DIR verbatim,
+// so a sub-workspace-rooted session minted an island here every start.
+const projectRoot = resolveStateRoot();
 
 // Monorepo nested-.moflo guard (#1174). After the resolver fix, findProjectRoot
 // returns the topmost ancestor with .moflo/moflo.db, so an ancestor still

--- a/harness/consumer-smoke/lib/checks.mjs
+++ b/harness/consumer-smoke/lib/checks.mjs
@@ -1853,12 +1853,22 @@ export async function killConsumerBackgroundProcesses(consumerDir) {
   }
 }
 
-// Belt-and-suspenders: the auto-start daemon path in src/cli/index.ts spawns
-// `daemon start --foreground --quiet` via raw spawn() and never registers
-// the PID with ProcessManager. flo daemon stop reaches it via lock holder
-// most of the time, but a daemon spawned during a late check may not have
-// acquired the lock by the time stopConsumerDaemon ran. Read the lock file
-// directly and kill the process tree as a final pass.
+// Belt-and-suspenders final pass: read the lock file directly and kill the
+// process tree.
+//
+// `flo daemon stop` reaches the daemon via the lock holder most of the time,
+// but a daemon spawned during a late check may not have acquired the lock yet
+// when stopConsumerDaemon ran.
+//
+// NB (#1315): do NOT try to identify the daemon by its command line. Several
+// paths emit a byte-identical `daemon start --foreground --quiet` — the
+// auto-start in src/cli/index.ts, `startBackgroundDaemon` in commands/daemon.ts
+// (which re-execs every plain `daemon start --quiet` in that form), the spell
+// scheduler's defaultStartDaemon, and the generated systemd/launchd/schtasks
+// entries. Nor is ProcessManager registration a reliable discriminator: only
+// index.ts and daemon-readiness.ts register, so a launcher-descended daemon is
+// absent from the registry while an auto-started one is present. The lock file
+// is the only dependable handle.
 function killDaemonByLockFile(consumerDir) {
   const lockFile = join(consumerDir, '.moflo', 'daemon.lock');
   if (!existsSync(lockFile)) return 0;

--- a/src/cli/__tests__/daemon-dashboard-1145.test.ts
+++ b/src/cli/__tests__/daemon-dashboard-1145.test.ts
@@ -103,8 +103,12 @@ function makeProjectRoot(): string {
 describe('GET /api/health (#1145)', () => {
   it('returns 200 with projectRoot, pid, version, uptimeMs', async () => {
     const root = makeProjectRoot();
-    const port = 45000 + Math.floor(Math.random() * 100);
-    const handle = await startDashboard(makeDaemon(), { port, projectRoot: root });
+    // Port 0 (honored by startDashboard) instead of a guessed one. An
+    // explicitly-pinned port deliberately does NOT fall back on EADDRINUSE, so
+    // a random pick colliding with a concurrent test failed this outright.
+    // These tests assert /api/health content, not port selection, and already
+    // read the bound port back off the handle.
+    const handle = await startDashboard(makeDaemon(), { port: 0, projectRoot: root });
     handles.push(handle);
 
     const { status, body } = await getJson(handle.port, '/api/health');
@@ -117,8 +121,7 @@ describe('GET /api/health (#1145)', () => {
   });
 
   it('reports the requesting cwd when projectRoot opt is omitted', async () => {
-    const port = 46000 + Math.floor(Math.random() * 100);
-    const handle = await startDashboard(makeDaemon(), { port });
+    const handle = await startDashboard(makeDaemon(), { port: 0 });
     handles.push(handle);
 
     const { status, body } = await getJson(handle.port, '/api/health');
@@ -170,13 +173,21 @@ describe('Per-project port allocation (#1145)', () => {
 
 describe('Bind exhaustion (#1145 §9.4)', () => {
   it('throws when the explicitly-pinned port is in use', async () => {
-    const port = 47000 + Math.floor(Math.random() * 100);
-    // First server claims the port.
+    // First server claims a port. Bind ephemeral (0) and read back what the OS
+    // gave us, rather than guessing: the blocker itself used to race concurrent
+    // tests for a random port and fail on EADDRINUSE before the assertion under
+    // test ever ran. Taking whatever port we're handed is strictly better here,
+    // since the point is only that the port IS occupied.
     const blocker = http.createServer((_, res) => res.end('blocker'));
     await new Promise<void>((resolve, reject) => {
       blocker.on('error', reject);
-      blocker.listen(port, '127.0.0.1', () => resolve());
+      blocker.listen(0, '127.0.0.1', () => resolve());
     });
+    const blockerAddress = blocker.address();
+    if (typeof blockerAddress !== 'object' || blockerAddress === null) {
+      throw new Error('blocker: server.address() did not return an AddressInfo');
+    }
+    const port = blockerAddress.port;
 
     try {
       await expect(

--- a/src/cli/__tests__/doctor-nested-moflo-islands.test.ts
+++ b/src/cli/__tests__/doctor-nested-moflo-islands.test.ts
@@ -49,7 +49,9 @@ describe('checkNestedMofloIslands (#1174)', () => {
 
     const result = await checkNestedMofloIslands(root);
     expect(result.status).toBe('warn');
-    expect(result.message).toContain('1 nested');
+    // #1315 split the message by class: "with state" (#1174) vs
+    // "daemon-minted, no moflo.db" (#1315). This one has a moflo.db.
+    expect(result.message).toContain('1 with state');
     expect(result.message).toContain(path.join('packages', 'api'));
     expect(result.fix).toContain('nested-moflo');
   });
@@ -65,7 +67,35 @@ describe('checkNestedMofloIslands (#1174)', () => {
 
     const result = await checkNestedMofloIslands(root);
     expect(result.status).toBe('warn');
-    expect(result.message).toContain('2 nested');
+    expect(result.message).toContain('2 with state');
+  });
+
+  it('detects a daemon-minted .moflo/ husk with no moflo.db (#1315)', async () => {
+    // The residue the #1315 bug actually produces: `daemon.lock`,
+    // `daemon-state.json`, `metrics/` — and NO moflo.db, because `flo init`
+    // never ran here. The pre-#1315 scan keyed on moflo.db and saw nothing.
+    seedMofloDb(root);
+    const stray = path.join(root, 'back-office', 'ui');
+    fs.mkdirSync(path.join(stray, '.moflo', 'metrics'), { recursive: true });
+    fs.writeFileSync(path.join(stray, '.moflo', 'daemon-state.json'), '{}');
+
+    const result = await checkNestedMofloIslands(root);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('daemon-minted');
+    expect(result.message).toContain(path.join('back-office', 'ui'));
+    expect(findNestedMofloDirsForFix(root)).toContain(stray);
+  });
+
+  it('finds a husk seven levels deep (past the old depth-5 bound)', async () => {
+    // The waxstak case verbatim. At the old maxDepth of 5 the walk reported a
+    // clean tree while this sat there with a live daemon bound to it.
+    seedMofloDb(root);
+    const deep = path.join(root, 'back-office', 'ui', 'src', 'layout', 'Dashboard', 'Header', 'HeaderContent');
+    fs.mkdirSync(path.join(deep, '.moflo', 'metrics'), { recursive: true });
+
+    const result = await checkNestedMofloIslands(root);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('HeaderContent');
   });
 
   it('does not recurse below a nested island', async () => {

--- a/src/cli/__tests__/memory/daemon-identity-mismatch.test.ts
+++ b/src/cli/__tests__/memory/daemon-identity-mismatch.test.ts
@@ -33,7 +33,6 @@ interface FakeDaemon {
 async function spawnFakeDaemon(opts: {
   projectRoot?: string;
   healthStatus?: number; // 200 (with body) / 404 (legacy)
-  port: number;
 }): Promise<FakeDaemon> {
   const server = http.createServer((req, res) => {
     const url = req.url ?? '';
@@ -67,13 +66,25 @@ async function spawnFakeDaemon(opts: {
     res.end();
   });
 
+  // Ephemeral port (0), not a guessed one. The previous
+  // `40000 + random(1000)` scheme bound a caller-picked port with
+  // `on('error', reject)` and no retry, so an EADDRINUSE from any concurrently
+  // running test failed the run outright — a real contributor to the
+  // non-deterministic full-suite result. Port 0 cannot collide, and it is also
+  // the Windows-safest choice: Rule #1 §8's "avoid 49152-65535" applies to
+  // HARDCODED binds (Windows reserves ranges in there), whereas letting the OS
+  // assign never returns an excluded port.
   await new Promise<void>((resolve, reject) => {
     server.on('error', reject);
-    server.listen(opts.port, '127.0.0.1', () => resolve());
+    server.listen(0, '127.0.0.1', () => resolve());
   });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) {
+    throw new Error('fake daemon: server.address() did not return an AddressInfo');
+  }
 
   return {
-    port: opts.port,
+    port: address.port,
     stop: () => new Promise<void>((r) => server.close(() => r())),
   };
 }
@@ -122,10 +133,8 @@ describe('isDaemonAvailable with identity check (#1145)', () => {
   it('returns true when daemon reports matching projectRoot', async () => {
     const root = makeProjectRoot();
     setProjectRoot(root);
-    const port = 40000 + Math.floor(Math.random() * 1000);
-    process.env.MOFLO_DAEMON_PORT = String(port);
-
-    const daemon = await spawnFakeDaemon({ port, projectRoot: root });
+    const daemon = await spawnFakeDaemon({ projectRoot: root });
+    process.env.MOFLO_DAEMON_PORT = String(daemon.port);
     cleanup.push(daemon.stop);
 
     expect(await isDaemonAvailable()).toBe(true);
@@ -134,13 +143,10 @@ describe('isDaemonAvailable with identity check (#1145)', () => {
   it('returns false on projectRoot mismatch + emits stderr warn for the mismatched port', async () => {
     const root = makeProjectRoot();
     setProjectRoot(root);
-    const port = 41000 + Math.floor(Math.random() * 1000);
-    process.env.MOFLO_DAEMON_PORT = String(port);
-
     const daemon = await spawnFakeDaemon({
-      port,
       projectRoot: '/some/foreign/project',
     });
+    process.env.MOFLO_DAEMON_PORT = String(daemon.port);
     cleanup.push(daemon.stop);
 
     expect(await isDaemonAvailable()).toBe(false);
@@ -149,7 +155,7 @@ describe('isDaemonAvailable with identity check (#1145)', () => {
     // Filter to warns for OUR port so a parallel test pointing at a
     // different fake daemon can't leak in.
     const portWarns = writes.filter(
-      (s) => typeof s === 'string' && new RegExp(`daemon at 127\\.0\\.0\\.1:${port}\\b`).test(s),
+      (s) => typeof s === 'string' && new RegExp(`daemon at 127\\.0\\.0\\.1:${daemon.port}\\b`).test(s),
     );
     expect(portWarns.length).toBe(1);
     expect(portWarns[0]).toMatch(/claims project '\/some\/foreign\/project'/);
@@ -162,7 +168,7 @@ describe('isDaemonAvailable with identity check (#1145)', () => {
     expect(await isDaemonAvailable()).toBe(false);
     const writes2 = stderrSpy.mock.calls.flatMap((c) => [c[0] as string]);
     const portWarns2 = writes2.filter(
-      (s) => typeof s === 'string' && new RegExp(`daemon at 127\\.0\\.0\\.1:${port}\\b`).test(s),
+      (s) => typeof s === 'string' && new RegExp(`daemon at 127\\.0\\.0\\.1:${daemon.port}\\b`).test(s),
     );
     expect(portWarns2.length).toBe(1);
   });
@@ -170,13 +176,10 @@ describe('isDaemonAvailable with identity check (#1145)', () => {
   it('treats 404 on /api/health as a legacy daemon (routes)', async () => {
     const root = makeProjectRoot();
     setProjectRoot(root);
-    const port = 42000 + Math.floor(Math.random() * 1000);
-    process.env.MOFLO_DAEMON_PORT = String(port);
-
     const daemon = await spawnFakeDaemon({
-      port,
       healthStatus: 404,
     });
+    process.env.MOFLO_DAEMON_PORT = String(daemon.port);
     cleanup.push(daemon.stop);
 
     // Legacy daemon — port-discovery is the primary defence; identity
@@ -189,10 +192,8 @@ describe('isDaemonAvailable with identity check (#1145)', () => {
   it('tryDaemonList routes through identity-matched daemon', async () => {
     const root = makeProjectRoot();
     setProjectRoot(root);
-    const port = 43000 + Math.floor(Math.random() * 1000);
-    process.env.MOFLO_DAEMON_PORT = String(port);
-
-    const daemon = await spawnFakeDaemon({ port, projectRoot: root });
+    const daemon = await spawnFakeDaemon({ projectRoot: root });
+    process.env.MOFLO_DAEMON_PORT = String(daemon.port);
     cleanup.push(daemon.stop);
 
     const result = await tryDaemonList({ limit: 10 });
@@ -203,10 +204,8 @@ describe('isDaemonAvailable with identity check (#1145)', () => {
   it('tryDaemonList refuses to route through identity-mismatched daemon', async () => {
     const root = makeProjectRoot();
     setProjectRoot(root);
-    const port = 44000 + Math.floor(Math.random() * 1000);
-    process.env.MOFLO_DAEMON_PORT = String(port);
-
-    const daemon = await spawnFakeDaemon({ port, projectRoot: '/elsewhere' });
+    const daemon = await spawnFakeDaemon({ projectRoot: '/elsewhere' });
+    process.env.MOFLO_DAEMON_PORT = String(daemon.port);
     cleanup.push(daemon.stop);
 
     const result = await tryDaemonList({ limit: 10 });

--- a/src/cli/__tests__/memory/store-entry-routing.test.ts
+++ b/src/cli/__tests__/memory/store-entry-routing.test.ts
@@ -117,11 +117,32 @@ async function startFakeDaemon(): Promise<FakeDaemon> {
     });
   });
 
-  const port = 30000 + Math.floor(Math.random() * 10000);
+  // Bind an OS-assigned ephemeral port (0) rather than guessing a random one.
+  //
+  // This used to be `30000 + Math.floor(Math.random() * 10000)` with
+  // `server.on('error', reject)` and no retry, so any EADDRINUSE failed the
+  // test outright. Nearly every `it` in this file starts a fake daemon, and a
+  // full parallel suite has many workers binding in the same range — so the
+  // collisions were rare individually but near-certain across a whole run.
+  // That is one of the intermittent failures behind the non-deterministic
+  // suite result; it passes every time in isolation because nothing else is
+  // competing for ports. Port 0 makes collision structurally impossible.
+  //
+  // Cross-platform note (CLAUDE.md Rule #1 §8): the "use 40000-44999, avoid
+  // 49152-65535" guidance is about HARDCODING a port — Windows reserves ranges
+  // (Hyper-V/WinNAT) inside the dynamic block and an explicit bind there gets
+  // EACCES. Port 0 is the opposite: the OS picks, and it never hands out a port
+  // it has excluded. So this is strictly safer on Windows than any fixed range,
+  // not an exception to that rule. Do not "fix" it back to a literal port.
   await new Promise<void>((resolve, reject) => {
     server.on('error', reject);
-    server.listen(port, '127.0.0.1', () => resolve());
+    server.listen(0, '127.0.0.1', () => resolve());
   });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) {
+    throw new Error('fake daemon: server.address() did not return an AddressInfo');
+  }
+  const port = address.port;
 
   return {
     port,

--- a/src/cli/__tests__/services/daemon-root-1315.test.ts
+++ b/src/cli/__tests__/services/daemon-root-1315.test.ts
@@ -1,0 +1,369 @@
+/**
+ * #1315 — `daemon start` minted a `.moflo/` island at cwd instead of resolving
+ * the project root, re-seeding the daemon-island failure mode #1174 closed.
+ *
+ * Two defects, both covered here:
+ *   1. The daemon anchored on `process.cwd()`, so any sub-workspace invocation
+ *      created a rival state dir (and a rival daemon, because the
+ *      already-running check looked for a lock at that same wrong place).
+ *   2. `CLAUDE_PROJECT_DIR` short-circuits `findProjectRoot()` before Pass A.
+ *      Claude Code sets it to the SESSION directory and the spawned daemon
+ *      inherits it, so even code that resolved "correctly" landed on the
+ *      sub-workspace.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync, readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname, sep, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { resolveStateRoot, _resetStateRootCacheForTest } from '../../services/project-root.js';
+import { WorkerDaemon } from '../../services/worker-daemon.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Create `<dir>/.moflo/moflo.db` — the marker Pass A keys on. */
+function seedMofloState(dir: string): void {
+  mkdirSync(join(dir, '.moflo'), { recursive: true });
+  writeFileSync(join(dir, '.moflo', 'moflo.db'), '');
+}
+
+describe('#1315 — daemon root resolution', () => {
+  let root: string;
+  let subWorkspace: string;
+  let deepDir: string;
+  const savedEnv = process.env.CLAUDE_PROJECT_DIR;
+
+  beforeEach(() => {
+    // realpath both sides — macOS reports /var/folders but resolves to
+    // /private/var/folders, which would break every comparison below.
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-1315-')));
+    seedMofloState(root);
+
+    // A sub-workspace with its own package.json but NO moflo state — exactly
+    // the waxstak `back-office/ui` shape from the report.
+    subWorkspace = join(root, 'back-office', 'ui');
+    mkdirSync(subWorkspace, { recursive: true });
+    writeFileSync(join(subWorkspace, 'package.json'), '{"name":"ui"}');
+
+    // The seven-levels-deep case: a React component folder, self-evidently
+    // not a project root.
+    deepDir = join(subWorkspace, 'src', 'layout', 'Dashboard', 'Header', 'HeaderContent');
+    mkdirSync(deepDir, { recursive: true });
+
+    delete process.env.CLAUDE_PROJECT_DIR;
+    // Each case builds a fresh tmp tree; drop any memoized anchor so results
+    // are proven by a real walk rather than inherited from a prior case.
+    _resetStateRootCacheForTest();
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = savedEnv;
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  it('resolves to the monorepo root from a sub-workspace cwd', () => {
+    expect(resolveStateRoot({ cwd: subWorkspace })).toBe(root);
+  });
+
+  it('resolves to the root from a directory seven levels deep', () => {
+    expect(resolveStateRoot({ cwd: deepDir })).toBe(root);
+  });
+
+  it('never climbs above an explicit CLAUDE_PROJECT_DIR', () => {
+    // The anti-hijack property, and the reason the env is authoritative rather
+    // than merely a starting point for the walk.
+    //
+    // Pass A has NO upper bound: it runs to the filesystem root and takes the
+    // topmost `.moflo/moflo.db`. If the walk were allowed to climb past an
+    // explicit anchor, one stray `flo init` in an ancestor — `$HOME`, or an
+    // outer checkout a scratch project happens to live inside — would silently
+    // capture every project beneath it and mutate the wrong tree.
+    //
+    // Here `root` is an initialized ancestor of `subWorkspace`. With the env
+    // naming the sub-workspace, the sub-workspace is the answer.
+    process.env.CLAUDE_PROJECT_DIR = subWorkspace;
+    expect(resolveStateRoot({ cwd: subWorkspace })).toBe(subWorkspace);
+    expect(resolveStateRoot({ cwd: subWorkspace })).not.toBe(root);
+  });
+
+  it('ignores a CLAUDE_PROJECT_DIR naming a directory that does not exist', () => {
+    // Callers mkdir whatever this returns, so honoring a typo'd or stale value
+    // would materialize `.moflo/` at the typo path. Fall back to the walk.
+    process.env.CLAUDE_PROJECT_DIR = join(root, 'no-such-directory');
+    expect(resolveStateRoot({ cwd: subWorkspace })).toBe(root);
+  });
+
+  it('honors CLAUDE_PROJECT_DIR when it does hold moflo state', () => {
+    // A genuine override must still work — this is how a user legitimately
+    // points moflo at a project other than the one cwd sits in.
+    const other = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-1315-other-')));
+    try {
+      seedMofloState(other);
+      process.env.CLAUDE_PROJECT_DIR = other;
+      expect(resolveStateRoot({ cwd: subWorkspace })).toBe(other);
+    } finally {
+      rmSync(other, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
+  it('absolutizes a CLAUDE_PROJECT_DIR carrying a trailing separator', () => {
+    // The env value is caller-supplied; an anchor with a trailing sep would
+    // produce `<root>//.moflo` paths that compare unequal to the canonical one.
+    const other = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-1315-sep-')));
+    try {
+      seedMofloState(other);
+      process.env.CLAUDE_PROJECT_DIR = other + sep;
+      expect(resolveStateRoot({ cwd: subWorkspace })).toBe(other);
+    } finally {
+      rmSync(other, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
+  it('never crosses a project boundary when CLAUDE_PROJECT_DIR names another tree', () => {
+    // The dangerous shape. `CLAUDE_PROJECT_DIR` points at a project that is not
+    // yet initialized (no `.moflo/moflo.db`), while cwd sits inside a DIFFERENT,
+    // fully-initialized project. An "ignore the env unless it has moflo.db,
+    // else walk from cwd" rule resolves to the STRANGER'S root — so the
+    // uninitialized project silently reads and writes the other project's
+    // database. That is strictly worse than the island bug being fixed.
+    //
+    // Correct behavior: the env var picks the tree, so an un-initialized
+    // project resolves to itself and touches nobody else's state.
+    const stranger = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-1315-stranger-')));
+    try {
+      seedMofloState(stranger);                       // a fully-initialized project
+      const strangerInner = join(stranger, 'src');
+      mkdirSync(strangerInner, { recursive: true });
+
+      const fresh = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-1315-uninit-')));
+      try {
+        process.env.CLAUDE_PROJECT_DIR = fresh;       // named project, no moflo.db yet
+        // cwd is inside the stranger — the boundary that must not be crossed.
+        expect(resolveStateRoot({ cwd: strangerInner })).toBe(fresh);
+        expect(resolveStateRoot({ cwd: strangerInner })).not.toBe(stranger);
+      } finally {
+        rmSync(fresh, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      }
+    } finally {
+      rmSync(stranger, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
+  it('walks to the topmost marker when no env anchor is set — the #1315 fix', () => {
+    // With CLAUDE_PROJECT_DIR unset (the CLI case — it is NOT exported to
+    // Bash-tool subprocesses), every state site used to take `process.cwd()`
+    // raw and mint an island wherever it stood. The walk lands on the
+    // canonical root instead, however deep the invocation.
+    delete process.env.CLAUDE_PROJECT_DIR;
+    expect(resolveStateRoot({ cwd: deepDir })).toBe(root);
+    expect(resolveStateRoot({ cwd: subWorkspace })).toBe(root);
+  });
+
+  it('does not cache a fall-through result, so flo init is not shadowed', () => {
+    // A tree with NO moflo state anywhere resolves via Pass B/C. Caching that
+    // would mean the anchor computed before `flo init` outlived the `.moflo/`
+    // it then created — the resolver handing back a stale root is the exact
+    // failure class this whole change exists to remove.
+    const fresh = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-1315-fresh-')));
+    try {
+      const inner = join(fresh, 'pkg');
+      mkdirSync(inner, { recursive: true });
+      writeFileSync(join(fresh, 'package.json'), '{"name":"fresh"}');
+
+      const before = resolveStateRoot({ cwd: inner });
+      expect(before).toBe(fresh); // Pass C — nearest package.json
+
+      // Now the project gets initialized ABOVE the previously-resolved root.
+      seedMofloState(fresh);
+      const after = resolveStateRoot({ cwd: inner });
+      expect(after).toBe(fresh);
+
+      // And a marker-proven result IS reused: deleting the marker afterwards
+      // must not change the answer, proving it came from the memo.
+      rmSync(join(fresh, '.moflo'), { recursive: true, force: true });
+      expect(resolveStateRoot({ cwd: inner })).toBe(fresh);
+    } finally {
+      rmSync(fresh, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+  });
+
+  it('never creates a .moflo directory as a side effect of resolving', () => {
+    resolveStateRoot({ cwd: deepDir });
+    resolveStateRoot({ cwd: subWorkspace });
+    // The whole point of the bug: resolution must be read-only.
+    expect(existsSync(join(deepDir, '.moflo'))).toBe(false);
+    expect(existsSync(join(subWorkspace, '.moflo'))).toBe(false);
+  });
+});
+
+describe('#1315 — daemon subcommands anchor on the resolved root', () => {
+  // `start` alone is not enough. `getDaemon()` builds a WorkerDaemon whose
+  // constructor unconditionally mkdirs `<root>/.moflo` and `<root>/.moflo/logs`,
+  // so a cwd-anchored `status`/`trigger`/`enable` mints an island too — a
+  // creation path independent of `start`. And a cwd-anchored `stop` cannot find
+  // the root daemon that `start` now correctly binds.
+  const src = readFileSync(join(HERE, '..', '..', 'commands', 'daemon.ts'), 'utf-8');
+
+  it('every subcommand resolves its root instead of using cwd', () => {
+    // start, stop, status, trigger, enable, install, uninstall.
+    const uses = src.match(/resolveStateRoot\(\)/g) ?? [];
+    expect(uses.length, 'expected 7 resolveStateRoot() call sites').toBe(7);
+    expect(src, 'getDaemon must never be handed raw cwd')
+      .not.toMatch(/getDaemon\(process\.cwd\(\)\)/);
+  });
+
+  it('leaves no cwd-anchored projectRoot in the daemon command family', () => {
+    // `install`/`uninstall` matter most: `installDaemonService` bakes the root
+    // into a launchd plist / systemd unit / schtasks entry, so a cwd-anchored
+    // install persists an island across reboots.
+    const anchors = src.match(/^\s*const projectRoot = process\.cwd\(\);/gm) ?? [];
+    expect(anchors.length, 'no subcommand may anchor on cwd').toBe(0);
+  });
+});
+
+describe('#1315 — daemon exits when its project root is deleted', () => {
+  let dir: string;
+  let daemon: WorkerDaemon | null = null;
+  const savedDaemonEnv = process.env.MOFLO_DAEMON;
+
+  beforeEach(() => {
+    // CRITICAL: shutdownIfRootVanished calls process.exit(0) when
+    // MOFLO_DAEMON === '1'. Vitest workers inherit the ambient environment, so
+    // leaving it set would kill the test runner rather than fail a test.
+    delete process.env.MOFLO_DAEMON;
+    dir = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-1315-root-')));
+  });
+
+  afterEach(async () => {
+    try { await daemon?.stop(); } catch { /* already stopped */ }
+    daemon = null;
+    if (savedDaemonEnv === undefined) delete process.env.MOFLO_DAEMON;
+    else process.env.MOFLO_DAEMON = savedDaemonEnv;
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  it('keeps running while the root exists', async () => {
+    daemon = new WorkerDaemon(dir, { autoStart: false });
+    await daemon.start();
+    const vanished = await (daemon as any).shutdownIfRootVanished();
+    expect(vanished).toBe(false);
+  });
+
+  it('shuts down instead of recreating a deleted root', async () => {
+    daemon = new WorkerDaemon(dir, { autoStart: false });
+    // MUST start(): `stop()` early-returns when `running === false`, so a
+    // daemon that was never started never reaches saveState()/log() — the
+    // very writers that could recreate the husk. Asserting on an unstarted
+    // daemon would pass vacuously without exercising the path under test.
+    await daemon.start();
+
+    // Simulate `git worktree remove`: the whole tree goes, daemon still alive.
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+
+    const vanished = await (daemon as any).shutdownIfRootVanished();
+    expect(vanished).toBe(true);
+    // The defining symptom of the bug: the husk must NOT come back, even
+    // though shutdown ran the state-persist and logging paths.
+    expect(existsSync(dir)).toBe(false);
+    expect(existsSync(join(dir, '.moflo'))).toBe(false);
+  });
+
+  it('distinguishes ENOENT from a transient stat failure', () => {
+    // `existsSync` swallows EVERY error and returns false, so EACCES / EIO / a
+    // disconnected SMB share / a sleeping network volume would be
+    // indistinguishable from "deleted" — and the daemon would exit(0) on one
+    // bad sample. `statSync` + an explicit ENOENT check is the difference
+    // between "the project is gone" and "I couldn't tell".
+    //
+    // Asserted at the source rather than by mocking: `node:fs` is a frozen ESM
+    // namespace so `vi.spyOn` cannot replace `statSync`, and mocking the whole
+    // module would also intercept the daemon's own writes. This pins the
+    // invariant that actually regressed.
+    const src = readFileSync(join(HERE, '..', '..', 'services', 'worker-daemon.ts'), 'utf-8');
+    const fn = src.indexOf('private async shutdownIfRootVanished');
+    expect(fn, 'shutdownIfRootVanished not found — renamed?').toBeGreaterThan(-1);
+    const body = src.slice(fn, fn + 2000);
+    // Strip comments — the explanation below deliberately NAMES the banned
+    // call, and a naive scan would match its own rationale.
+    const code = body
+      .split('\n')
+      .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+      .join('\n');
+
+    expect(code, 'must stat, not existsSync').toMatch(/statSync\(this\.projectRoot\)/);
+    expect(code, 'existsSync cannot distinguish EACCES from ENOENT').not.toMatch(/existsSync/);
+    expect(code, 'only ENOENT means the root is gone').toMatch(/ENOENT/);
+    // The self-exit gate must honor the legacy env prefix too, or a daemon
+    // started from an older OS service unit clears its timers but never exits.
+    expect(code, 'gate on readMofloEnv, not raw process.env.MOFLO_DAEMON')
+      .toMatch(/readMofloEnv\('DAEMON'\)/);
+  });
+});
+
+describe('#1315 — no state-minting site anchors on process.cwd()', () => {
+  // Repo-wide guard. The per-file assertions above only covered daemon.ts, and
+  // that is exactly how `runtime/headless.ts:runDaemon` was missed on the first
+  // pass: `startDaemon(process.cwd())` builds a WorkerDaemon, and that
+  // constructor mkdirs the state dir it is handed. Anything that CREATES
+  // `.moflo/` must resolve its root first.
+  const MINTING_PATTERNS: ReadonlyArray<{ re: RegExp; why: string }> = [
+    { re: /getDaemon\(process\.cwd\(\)\)/, why: 'WorkerDaemon ctor mkdirs .moflo + .moflo/logs' },
+    { re: /startDaemon\(process\.cwd\(\)\)/, why: 'delegates to the WorkerDaemon ctor' },
+    { re: /new WorkerDaemon\(process\.cwd\(\)/, why: 'ctor mkdirs .moflo + .moflo/logs' },
+    { re: /new HeadlessWorkerExecutor\(process\.cwd\(\)/, why: 'ctor mkdirs .moflo/reports + logs/headless' },
+    { re: /(?:path\.)?join\(process\.cwd\(\), *['"]\.moflo['"]/, why: 'builds a .moflo path from cwd' },
+  ];
+
+  function collectSourceFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true, recursive: true }) as any[]) {
+      if (!entry.isFile() || !entry.name.endsWith('.ts')) continue;
+      const parent: string = entry.parentPath ?? entry.path;
+      if (parent.includes('__tests__')) continue;
+      out.push(join(parent, entry.name));
+    }
+    return out;
+  }
+
+  it('finds no cwd-anchored .moflo creation anywhere under src/cli', () => {
+    const cliRoot = join(HERE, '..', '..');
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles(cliRoot)) {
+      const lines = readFileSync(file, 'utf-8').split('\n');
+      lines.forEach((line, i) => {
+        // Ignore comments — several of them quote the old pattern on purpose.
+        const code = line.trim();
+        if (code.startsWith('//') || code.startsWith('*') || code.startsWith('/*')) return;
+        for (const { re, why } of MINTING_PATTERNS) {
+          if (re.test(line)) {
+            offenders.push(`${relative(cliRoot, file)}:${i + 1} — ${why}`);
+          }
+        }
+      });
+    }
+    expect(offenders, `use resolveStateRoot() instead:\n  ${offenders.join('\n  ')}`).toEqual([]);
+  });
+});
+
+describe('#1315 — auto-start must not mint state', () => {
+  it('maybeAutoStartDaemon bails instead of mkdir-ing a missing state dir', () => {
+    // Source-level guard, mirroring tests/system/no-leaked-daemons.test.ts.
+    // A behavioural test would have to spawn a real daemon; this pins the
+    // invariant that actually regressed without that cost.
+    const src = readFileSync(join(HERE, '..', '..', 'index.ts'), 'utf-8');
+    const fn = src.indexOf('private async maybeAutoStartDaemon');
+    expect(fn, 'maybeAutoStartDaemon not found — renamed?').toBeGreaterThan(-1);
+    const body = src.slice(fn, fn + 3500);
+
+    expect(body, 'auto-start must not create .moflo').not.toMatch(/mkdirSync/);
+    expect(body, 'auto-start must return when state dir is absent')
+      .toMatch(/if \(!existsSync\(stateDir\)\) return;/);
+    expect(body, 'auto-start must anchor on the resolved root, not cwd')
+      .toMatch(/resolveStateRoot\(\)/);
+    expect(body, 'no raw process.cwd() anchoring left').not.toMatch(/loadMofloConfig\(process\.cwd\(\)\)/);
+    expect(body, 'lock check must use the resolved root')
+      .not.toMatch(/getDaemonLockHolder\(process\.cwd\(\)\)/);
+  });
+});

--- a/src/cli/__tests__/services/schedule-acceptance-check.test.ts
+++ b/src/cli/__tests__/services/schedule-acceptance-check.test.ts
@@ -6,7 +6,7 @@
  * permissions, so users know they need to manually cast once first.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -26,6 +26,24 @@ describe('checkScheduleAcceptance (#1037)', () => {
   let projectRoot: string;
   let userSpellDir: string;
   let mofloYaml: string;
+
+  // Warm the spell engine before any `it` runs.
+  //
+  // `checkScheduleAcceptance` → `buildGrimoire` → `loadSpellEngine`, which
+  // dynamically imports the entire `spells/index.js` module graph and caches it
+  // (`engine-loader.ts`). Whichever test triggered it first paid that cold
+  // import inside its own 5 s budget — fine in isolation (~700 ms for the whole
+  // file), but under a full parallel suite the same import took >5 s and the
+  // FIRST test in the file timed out. That is the intermittent failure this
+  // file contributed to the non-deterministic suite result: not a logic bug, a
+  // one-time setup cost charged to a test-sized timeout.
+  //
+  // Paying it in `beforeAll` with room to breathe makes every `it` fast and
+  // keeps the cost where it belongs — setup, not assertion.
+  beforeAll(async () => {
+    const { loadSpellEngine } = await import('../../services/engine-loader.js');
+    await loadSpellEngine();
+  }, 60_000);
 
   beforeEach(() => {
     // OS-assigned unique temp dir — `Date.now()+Math.random()` name-building

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -10,6 +10,7 @@ import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { resolveStateRoot } from '../services/project-root.js';
 
 /**
  * Update swarm-activity.json metrics with absolute agent count.
@@ -20,7 +21,10 @@ import * as path from 'path';
  */
 function syncSwarmAgentCount(absoluteCount: number): void {
   try {
-    const metricsDir = path.join(process.cwd(), '.moflo', 'metrics');
+    // #1315 — resolved root, not cwd. This mkdirs, so a subdirectory
+    // invocation minted a `.moflo/metrics/` island; and the statusline reads
+    // this file from the ROOT, so a cwd-anchored write was invisible to it.
+    const metricsDir = path.join(resolveStateRoot(), '.moflo', 'metrics');
     const activityPath = path.join(metricsDir, 'swarm-activity.json');
 
     let data: Record<string, unknown> = {
@@ -54,7 +58,8 @@ function syncSwarmAgentCount(absoluteCount: number): void {
  */
 function readSwarmAgentCount(): number {
   try {
-    const activityPath = path.join(process.cwd(), '.moflo', 'metrics', 'swarm-activity.json');
+    // #1315 — must read from the same root `syncSwarmAgentCount` writes to.
+    const activityPath = path.join(resolveStateRoot(), '.moflo', 'metrics', 'swarm-activity.json');
     if (!fs.existsSync(activityPath)) return 0;
     const data = JSON.parse(fs.readFileSync(activityPath, 'utf-8'));
     return Math.max(0, (data?.swarm?.agent_count as number) || 0);

--- a/src/cli/commands/benchmark.ts
+++ b/src/cli/commands/benchmark.ts
@@ -10,6 +10,9 @@ import { output } from '../output.js';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { errorDetail } from '../shared/utils/error-detail.js';
+// #1315 — benchmark results are `.moflo/` state; anchor them at the resolved
+// root so a subdirectory run doesn't mint an island to save into.
+import { resolveStateRoot } from '../services/project-root.js';
 
 // ============================================================================
 // Pretrain Benchmark Subcommand
@@ -54,7 +57,7 @@ const pretrainCommand: Command = {
 
       // Save to file if requested
       if (saveFile) {
-        const resultsDir = join(process.cwd(), '.moflo', 'benchmarks');
+        const resultsDir = join(resolveStateRoot(), '.moflo', 'benchmarks');
         if (!existsSync(resultsDir)) {
           mkdirSync(resultsDir, { recursive: true });
         }
@@ -446,7 +449,7 @@ const allCommand: Command = {
     // Save if requested
     const saveFile = ctx.flags.save as string | undefined;
     if (saveFile) {
-      const resultsDir = join(process.cwd(), '.moflo', 'benchmarks');
+      const resultsDir = join(resolveStateRoot(), '.moflo', 'benchmarks');
       if (!existsSync(resultsDir)) {
         mkdirSync(resultsDir, { recursive: true });
       }

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -19,6 +19,7 @@ import { join, resolve, isAbsolute } from 'path';
 import * as fs from 'fs';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { readMofloEnv } from '../services/env-compat.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 /**
  * Resolve the dashboard port from CLI flag and env, in that precedence order.
@@ -76,7 +77,13 @@ const startCommand: Command = {
     const foreground = ctx.flags.foreground as boolean;
     const noDashboard = ctx.flags.noDashboard as boolean;
     const rawDashboardPort = ctx.flags.dashboardPort as string | undefined;
-    const projectRoot = process.cwd();
+    // #1315 — the shared chokepoint. Every daemon-start path lands here:
+    // `maybeAutoStartDaemon`, the session-start launcher, bin/hooks.mjs, the
+    // daemon recycler, the scheduler, and the OS service definitions. Each one
+    // spawns with a cwd it inherited from the caller, so anchoring on
+    // `process.cwd()` let ANY of them mint a `.moflo/` island in a
+    // sub-workspace while resolving its own binary from the root install.
+    const projectRoot = resolveStateRoot();
     const isDaemonProcess = readMofloEnv('DAEMON') === '1';
 
     // Resolve dashboard port; see `resolveDashboardPort` for precedence.
@@ -368,12 +375,35 @@ function validatePath(path: string, label: string): void {
 }
 
 /**
+ * Validate the resolved project root (#1315).
+ *
+ * Separate from `validatePath` because containment is meaningless for the root
+ * itself — it IS the boundary every other path is checked against. Passing it
+ * to `validatePath` would either compare it against `process.cwd()` (which now
+ * fails legitimately, since the root is an ANCESTOR of cwd for any
+ * sub-workspace invocation) or against itself (a tautology that silently
+ * retires the check). Assert the properties that actually matter instead:
+ * injection-free and absolute.
+ */
+function validateProjectRoot(root: string): void {
+  if (root.includes('\0')) {
+    throw new Error('Project root contains null bytes');
+  }
+  if (/[;&|`$<>]/.test(root)) {
+    throw new Error('Project root contains shell metacharacters');
+  }
+  if (!isAbsolute(root)) {
+    throw new Error(`Project root is not absolute: ${root}`);
+  }
+}
+
+/**
  * Start daemon as a detached background process
  */
 async function startBackgroundDaemon(projectRoot: string, quiet: boolean, maxCpuLoad?: string, minFreeMemory?: string, dashboardPort?: number, noDashboard?: boolean): Promise<CommandResult> {
   // Validate and resolve project root
   const resolvedRoot = resolve(projectRoot);
-  validatePath(resolvedRoot, 'Project root');
+  validateProjectRoot(resolvedRoot);
 
   const stateDir = join(resolvedRoot, '.moflo');
   const logFile = join(stateDir, 'daemon.log');
@@ -434,6 +464,13 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean, maxCpu
 
   const daemonEnv = {
     ...process.env,
+    // #1315 — PIN the child's project dir to the root we just resolved.
+    // Without this the daemon inherited the SESSION's `CLAUDE_PROJECT_DIR`
+    // (a sub-workspace), and so did everything it spawns — headless Claude,
+    // hooks, MCP — all of which resolve through `findProjectRoot()` and would
+    // anchor back on the sub-workspace, re-minting the island this fix
+    // removes. Pinning it closes the whole inherited-env class in one place.
+    CLAUDE_PROJECT_DIR: resolvedRoot,
     MOFLO_DAEMON: '1',
     // #981 — daemon process must skip its own write-routing client.
     MOFLO_IS_DAEMON: '1',
@@ -521,7 +558,10 @@ const stopCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const quiet = ctx.flags.quiet as boolean;
-    const projectRoot = process.cwd();
+    // #1315 — must match `start`'s anchor. Anchoring on cwd here would look for
+    // the lock in a sub-workspace, miss the root daemon, and report "not
+    // running" while it kept going.
+    const projectRoot = resolveStateRoot();
 
     try {
       if (!quiet) {
@@ -653,7 +693,12 @@ const statusCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const verbose = ctx.flags.verbose as boolean;
     const showModes = ctx.flags.showModes as boolean;
-    const projectRoot = process.cwd();
+    // #1315 — `getDaemon` constructs a WorkerDaemon, and that constructor
+    // unconditionally mkdirs `<root>/.moflo` and `<root>/.moflo/logs`
+    // (`worker-daemon.ts`). Anchoring on cwd meant a read-only-looking
+    // `flo daemon status` MINTED a state-dir island in whatever directory it
+    // was run from — a creation path entirely separate from `start`.
+    const projectRoot = resolveStateRoot();
 
     try {
       const daemon = getDaemon(projectRoot);
@@ -815,7 +860,9 @@ const triggerCommand: Command = {
     }
 
     try {
-      const daemon = getDaemon(process.cwd());
+      // #1315 — resolved root, not cwd: the WorkerDaemon constructor creates
+      // the state dir it is pointed at.
+      const daemon = getDaemon(resolveStateRoot());
 
       const spinner = output.createSpinner({ text: `Running ${workerType} worker...`, spinner: 'dots' });
       spinner.start();
@@ -864,7 +911,9 @@ const enableCommand: Command = {
     }
 
     try {
-      const daemon = getDaemon(process.cwd());
+      // #1315 — resolved root, not cwd (see `trigger`). Enabling a worker on a
+      // cwd-anchored daemon also wrote its state to the wrong `.moflo`.
+      const daemon = getDaemon(resolveStateRoot());
       daemon.setWorkerEnabled(workerType, !disable);
 
       output.printSuccess(`Worker ${workerType} ${disable ? 'disabled' : 'enabled'}`);
@@ -889,7 +938,11 @@ const installCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const quiet = ctx.flags.quiet as boolean;
-    const projectRoot = process.cwd();
+    // #1315 — the highest-stakes anchor of the family. `installDaemonService`
+    // BAKES this path into a launchd plist / systemd unit / schtasks entry
+    // (`daemon-service.ts`), so a cwd-anchored install persisted an island
+    // across reboots — the one variant that outlives `flo doctor --fix`.
+    const projectRoot = resolveStateRoot();
 
     try {
       const result = installDaemonService(projectRoot);
@@ -925,10 +978,30 @@ const uninstallCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const quiet = ctx.flags.quiet as boolean;
-    const projectRoot = process.cwd();
+    // #1315 — must match `install`'s anchor, or uninstall looks for a service
+    // registered under a different root and silently leaves it in place.
+    const projectRoot = resolveStateRoot();
 
     try {
       const result = uninstallDaemonService(projectRoot);
+
+      // #1315 — also sweep the LEGACY cwd-anchored registration. The service
+      // name is `sha256(resolvedRoot)`, so a consumer who ran `flo daemon
+      // install` from a sub-directory before this fix has a plist/unit/task
+      // named for THAT path. Resolving correctly now makes it unreachable:
+      // uninstall would report success while the old service stayed enabled
+      // and re-spawned a sub-root daemon at every login, with no supported way
+      // to remove it. Best-effort and silent — on the overwhelmingly common
+      // path cwd IS the root and this is a no-op.
+      const legacyRoot = resolve(process.cwd());
+      if (legacyRoot !== projectRoot) {
+        try {
+          const legacy = uninstallDaemonService(legacyRoot);
+          if (legacy.success && !quiet) {
+            output.printSuccess(`Also removed a legacy service registered at ${legacyRoot}`);
+          }
+        } catch { /* nothing registered there — expected */ }
+      }
 
       if (!quiet) {
         if (result.success) {

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -26,7 +26,7 @@ import {
   memoryDbPath,
 } from '../services/moflo-paths.js';
 import { probeDbIntegrity } from '../services/memory-db-integrity-repair.js';
-import { findProjectRoot } from '../services/project-root.js';
+import { findProjectRoot, resolveStateRoot } from '../services/project-root.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import type { HealthCheck } from './doctor-types.js';
 
@@ -440,7 +440,16 @@ export async function checkSwarmResidue(): Promise<HealthCheck> {
  * `/repo/packages/api/.moflo`), aligned with `findProjectRoot()` semantics.
  */
 interface NestedScanResult {
+  /** Nested roots holding real state (`.moflo/moflo.db`) — classic #1174 islands. */
   islands: string[];
+  /**
+   * Nested `.moflo/` directories with NO `moflo.db` (#1315). These are minted
+   * by the daemon and by cwd-anchored commands, never by `flo init`, so they
+   * hold only `daemon.lock` / `daemon-state.json` / `metrics/`. The pre-#1315
+   * scan keyed exclusively on `moflo.db` and was therefore blind to exactly
+   * the residue the #1315 bug produces.
+   */
+  husks: string[];
   truncated: boolean;
 }
 
@@ -454,12 +463,25 @@ interface NestedScanResult {
  */
 const NESTED_BFS_MAX_FOUND = 50;
 
-function scanNestedMofloDirs(root: string, maxDepth: number = 5): NestedScanResult {
-  const found: string[] = [];
+/**
+ * Depth bound for the nested-`.moflo/` walk.
+ *
+ * #1315 raised this from 5 to 8. The waxstak report found a stray seven levels
+ * deep (`back-office/ui/src/layout/Dashboard/Header/HeaderContent/.moflo`) —
+ * inside a React component folder, because ANY cwd could mint one. At depth 5
+ * the healer silently walked past it and reported a clean tree. The walk skips
+ * `node_modules`/`.git`/build output via `COMMON_WALK_SKIP_NAMES`, so the extra
+ * three levels cost little on a real repo.
+ */
+const NESTED_SCAN_MAX_DEPTH = 8;
+
+function scanNestedMofloDirs(root: string, maxDepth: number = NESTED_SCAN_MAX_DEPTH): NestedScanResult {
+  const islands: string[] = [];
+  const husks: string[] = [];
   let truncated = false;
 
   function walk(dir: string, depth: number): void {
-    if (found.length >= NESTED_BFS_MAX_FOUND) {
+    if (islands.length + husks.length >= NESTED_BFS_MAX_FOUND) {
       truncated = true;
       return;
     }
@@ -475,9 +497,16 @@ function scanNestedMofloDirs(root: string, maxDepth: number = 5): NestedScanResu
       if (lower.startsWith('.moflo')) continue;
       if (entry.name.startsWith('.') && depth > 0) continue;
       const childDir = join(dir, entry.name);
-      if (existsSync(join(childDir, '.moflo', 'moflo.db'))) {
-        found.push(childDir);
-        if (found.length >= NESTED_BFS_MAX_FOUND) {
+      // #1315 — key on the `.moflo/` DIRECTORY, then classify by whether it
+      // holds `moflo.db`. Keying on `moflo.db` alone (the pre-#1315 predicate)
+      // made every daemon-minted husk invisible.
+      if (existsSync(join(childDir, '.moflo'))) {
+        if (existsSync(join(childDir, '.moflo', 'moflo.db'))) {
+          islands.push(childDir);
+        } else {
+          husks.push(childDir);
+        }
+        if (islands.length + husks.length >= NESTED_BFS_MAX_FOUND) {
           truncated = true;
           return;
         }
@@ -490,15 +519,11 @@ function scanNestedMofloDirs(root: string, maxDepth: number = 5): NestedScanResu
         continue;
       }
       walk(childDir, depth + 1);
-      if (found.length >= NESTED_BFS_MAX_FOUND) return;
+      if (islands.length + husks.length >= NESTED_BFS_MAX_FOUND) return;
     }
   }
   walk(root, 0);
-  return { islands: found, truncated };
-}
-
-function findNestedMofloDirs(root: string, maxDepth: number = 5): string[] {
-  return scanNestedMofloDirs(root, maxDepth).islands;
+  return { islands, husks, truncated };
 }
 
 /**
@@ -508,7 +533,11 @@ function findNestedMofloDirs(root: string, maxDepth: number = 5): string[] {
  * (the consumer joins `.moflo` itself).
  */
 export function findNestedMofloDirsForFix(root: string): string[] {
-  return findNestedMofloDirs(root);
+  // #1315 — husks are archived alongside stateful islands. Archiving is a
+  // rename to `.moflo-archived-<ISO>/`, so it is non-destructive either way,
+  // and leaving husks in place lets the daemons bound to them keep running.
+  const { islands, husks } = scanNestedMofloDirs(root);
+  return [...islands, ...husks];
 }
 
 /**
@@ -529,7 +558,9 @@ export function findNestedMofloDirsForFix(root: string): string[] {
  * first.
  */
 export async function checkNestedMofloIslands(cwd?: string): Promise<HealthCheck> {
-  const root = cwd ?? findProjectRoot();
+  // #1315 — must match the anchor `fixNestedMofloIslands` uses, or the check
+  // and its own auto-fix disagree about which tree they are talking about.
+  const root = cwd ?? resolveStateRoot();
   let scan: NestedScanResult;
   try {
     scan = scanNestedMofloDirs(root);
@@ -540,20 +571,33 @@ export async function checkNestedMofloIslands(cwd?: string): Promise<HealthCheck
       message: `Walk failed: ${errorDetail(e, { firstLineOnly: true })}`,
     };
   }
-  const { islands, truncated } = scan;
-  if (islands.length === 0) {
+  const { islands, husks, truncated } = scan;
+  if (islands.length === 0 && husks.length === 0) {
     return {
       name: 'Nested .moflo/ Islands',
       status: 'pass',
       message: 'No nested .moflo/ directories detected',
     };
   }
-  const rels = islands.map(p => relative(root, p) || '.');
-  const truncNote = truncated ? ' (walk truncated at depth 5 — deeper islands may exist)' : '';
+  const rel = (p: string) => relative(root, p) || '.';
+  const parts: string[] = [];
+  if (islands.length) {
+    // Stateful: created by `flo init` in a sub-workspace (#1174).
+    parts.push(`${islands.length} with state (#1174): ${islands.map(rel).join(', ')}`);
+  }
+  if (husks.length) {
+    // Stateless: minted by the daemon or a cwd-anchored command (#1315). Worth
+    // naming separately because the remedy differs — these mean something is
+    // still resolving its root from cwd, not that someone ran `flo init` wrong.
+    parts.push(`${husks.length} daemon-minted, no moflo.db (#1315): ${husks.map(rel).join(', ')}`);
+  }
+  const truncNote = truncated
+    ? ` (walk truncated at depth ${NESTED_SCAN_MAX_DEPTH} or ${NESTED_BFS_MAX_FOUND} results — more may exist)`
+    : '';
   return {
     name: 'Nested .moflo/ Islands',
     status: 'warn',
-    message: `${islands.length} nested .moflo/ ${islands.length === 1 ? 'directory' : 'directories'} (#1174): ${rels.join(', ')}${truncNote}`,
+    message: `${parts.join('; ')}${truncNote}`,
     fix: 'flo healer --fix -c nested-moflo',
   };
 }

--- a/src/cli/commands/doctor-checks-memory.ts
+++ b/src/cli/commands/doctor-checks-memory.ts
@@ -11,6 +11,7 @@ import { memoryDbCandidatePaths } from '../services/moflo-paths.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { openDaemonDatabase } from '../memory/daemon-backend.js';
 import type { HealthCheck } from './doctor-types.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 /** Skew (cached / live count delta) above which the cache is treated as stale. */
 const VECTOR_STATS_SKEW_WARN_THRESHOLD = 0.2;
@@ -40,10 +41,10 @@ async function countEmbeddedRowsFromDb(dbPath: string): Promise<number | null> {
 }
 
 export async function checkEmbeddings(): Promise<HealthCheck> {
-  const liveDbPath = memoryDbCandidatePaths(process.cwd()).find((p) => existsSync(p));
+  const liveDbPath = memoryDbCandidatePaths(resolveStateRoot()).find((p) => existsSync(p));
 
   // 1. Fast path: read cached vector-stats.json if available
-  const statsPath = join(process.cwd(), '.moflo', 'vector-stats.json');
+  const statsPath = join(resolveStateRoot(), '.moflo', 'vector-stats.json');
   try {
     if (existsSync(statsPath)) {
       const stats = JSON.parse(readFileSync(statsPath, 'utf8'));

--- a/src/cli/commands/doctor-checks-writers-audit.ts
+++ b/src/cli/commands/doctor-checks-writers-audit.ts
@@ -26,6 +26,7 @@ import { join } from 'path';
 import { getDaemonLockHolder } from '../services/daemon-lock.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import type { HealthCheck } from './doctor-types.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 const SCAN_TIMEOUT_MS_WIN = 10_000;
 const SCAN_TIMEOUT_MS_POSIX = 5_000;
@@ -139,7 +140,10 @@ export function findForeignWriters(
  * running a known cross-process writer. Lists every offender so the user can
  * SIGKILL them by PID.
  */
-export async function checkWritersAudit(cwd: string = process.cwd()): Promise<HealthCheck> {
+// #1315 — the default anchor is the RESOLVED root, not cwd. Running the healer
+// from a sub-workspace previously audited whatever `.moflo` happened to sit
+// under that directory (often a stray) while reporting on "the project".
+export async function checkWritersAudit(cwd: string = resolveStateRoot()): Promise<HealthCheck> {
   const name = 'Writers Audit';
   try {
     const daemonPid = getDaemonLockHolder(cwd);

--- a/src/cli/commands/doctor-embedding-hygiene.ts
+++ b/src/cli/commands/doctor-embedding-hygiene.ts
@@ -39,6 +39,7 @@ import {
   EPHEMERAL_NAMESPACES,
   EPHEMERAL_NAMESPACE_PREFIXES,
 } from '../memory/bridge-embedder.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 export interface HealthCheck {
   name: string;
@@ -166,7 +167,7 @@ export async function checkEmbeddingHygiene(): Promise<HealthCheck> {
 }
 
 function resolveMemoryDb(): string | null {
-  return memoryDbCandidatePaths(process.cwd()).find((p) => existsSync(p)) ?? null;
+  return memoryDbCandidatePaths(resolveStateRoot()).find((p) => existsSync(p)) ?? null;
 }
 
 async function loadModelGroups(dbPath: string): Promise<ModelGroup[] | null> {

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -13,7 +13,7 @@ import { errorDetail } from '../shared/utils/error-detail.js';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 import { findProjectDaemonPids, getDaemonLockHolder } from '../services/daemon-lock.js';
-import { findProjectRoot } from '../services/project-root.js';
+import { findProjectRoot, resolveStateRoot } from '../services/project-root.js';
 import { legacyMemoryDbPath, legacyMemoryDbBakPath, memoryDbPath, mofloDir } from '../services/moflo-paths.js';
 import { findZombieProcesses } from './doctor-zombies.js';
 import { inspectMcpConfigs } from './doctor-checks-config.js';
@@ -278,7 +278,19 @@ async function stopNestedDaemons(subRoot: string): Promise<{ stopped: number[]; 
   let pids: number[] = [];
   try {
     pids = findProjectDaemonPids(subRoot);
-  } catch { return { stopped: [], remaining: [], denied: [] }; }
+  } catch { /* cmdline scan unavailable — the lock-file probe below still runs */ }
+
+  // #1315 — the cmdline scan alone cannot see a HUSK daemon. `projectCliCandidates`
+  // matches processes whose command line invokes `<subRoot>/node_modules/moflo/bin/cli.js`,
+  // but a husk daemon resolved its binary from the ROOT install and only its
+  // CWD was the sub-directory — so nothing matches, nothing is reaped, and the
+  // archive that follows either fails EBUSY on Windows (open daemon.log fd) or
+  // succeeds on POSIX only for the daemon's next tick to recreate the dir.
+  // The lock file is the dependable handle: a husk always contains one.
+  try {
+    const holder = getDaemonLockHolder(subRoot);
+    if (holder !== null && !pids.includes(holder)) pids.push(holder);
+  } catch { /* no lock or unreadable — nothing more we can do */ }
 
   if (pids.length === 0) return { stopped: [], remaining: [], denied: [] };
 
@@ -347,7 +359,11 @@ async function stopNestedDaemons(subRoot: string): Promise<{ stopped: number[]; 
  *     inode; the daemon keeps writing to a now-archived path until it exits.
  */
 async function fixNestedMofloIslands(): Promise<boolean> {
-  const root = findProjectRoot();
+  // #1315 — `resolveStateRoot`, not `findProjectRoot`. The latter returns
+  // `CLAUDE_PROJECT_DIR` unconditionally, so running the healer from a
+  // sub-workspace session would scan for islands starting AT a sub-workspace —
+  // missing the real ones above it, and treating that directory as canonical.
+  const root = resolveStateRoot();
   let islands: string[];
   try {
     const { findNestedMofloDirsForFix } = await import('./doctor-checks-config.js');
@@ -439,7 +455,7 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     },
     'Config File': async () => {
       try {
-        const cfDir = join(process.cwd(), '.moflo');
+        const cfDir = join(resolveStateRoot(), '.moflo');
         if (!existsSync(cfDir)) mkdirSync(cfDir, { recursive: true });
         return runFixCommand('npx moflo config init');
       } catch {

--- a/src/cli/commands/doctor-zombies.ts
+++ b/src/cli/commands/doctor-zombies.ts
@@ -13,6 +13,7 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { getDaemonLockHolder, isDaemonProcess, releaseDaemonLock } from '../services/daemon-lock.js';
 import type { HealthCheck } from './doctor-types.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 // Cmdline capture/display caps + scan timeouts. Hoisted so the values
 // used to size buffers and format messages are visible in one place.
@@ -58,8 +59,8 @@ function isProcessAlive(pid: number): boolean {
 // Fast path: kill processes tracked in the shared ProcessManager registry.
 // This avoids the expensive OS-level process scan for known background tasks.
 export function killTrackedProcesses(): number {
-  const registryFile = join(process.cwd(), '.moflo', 'background-pids.json');
-  const lockFile = join(process.cwd(), '.moflo', 'spawn.lock');
+  const registryFile = join(resolveStateRoot(), '.moflo', 'background-pids.json');
+  const lockFile = join(resolveStateRoot(), '.moflo', 'spawn.lock');
   let killed = 0;
   try {
     if (existsSync(registryFile)) {
@@ -92,7 +93,7 @@ export function killTrackedProcesses(): number {
 // findZombieProcesses() flags every running indexer step as a zombie.
 function readTrackedBackgroundPids(): Set<number> {
   const result = new Set<number>();
-  const registryFile = join(process.cwd(), '.moflo', 'background-pids.json');
+  const registryFile = join(resolveStateRoot(), '.moflo', 'background-pids.json');
   try {
     if (!existsSync(registryFile)) return result;
     const entries = JSON.parse(readFileSync(registryFile, 'utf-8'));

--- a/src/cli/commands/embeddings.ts
+++ b/src/cli/commands/embeddings.ts
@@ -20,6 +20,7 @@ import { memoryDbPath, MEMORY_DB_FILE, MOFLO_DIR } from '../services/moflo-paths
 import * as embeddings from '../embeddings/index.js';
 import { openDaemonDatabase } from '../memory/daemon-backend.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 const DEFAULT_DB_PATH_FLAG = `${MOFLO_DIR}/${MEMORY_DB_FILE}`;
 
@@ -125,7 +126,7 @@ const searchCommand: Command = {
     const namespace = ctx.flags.collection as string || 'default';
     const limit = parseInt(ctx.flags.limit as string || '10', 10);
     const threshold = parseFloat(ctx.flags.threshold as string || '0.5');
-    const dbPath = ctx.flags.dbPath as string || memoryDbPath(process.cwd());
+    const dbPath = ctx.flags.dbPath as string || memoryDbPath(resolveStateRoot());
 
     if (!query) {
       output.printError('Query is required');
@@ -407,7 +408,7 @@ const collectionsCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const action = ctx.flags.action as string || 'list';
-    const dbPath = ctx.flags.dbPath as string || memoryDbPath(process.cwd());
+    const dbPath = ctx.flags.dbPath as string || memoryDbPath(resolveStateRoot());
 
     output.writeln();
     output.writeln(output.bold('Embedding Collections (Namespaces)'));
@@ -692,7 +693,10 @@ export const initCommand: Command = {
       const fs = await import('fs');
       const path = await import('path');
 
-      const configDir = path.join(process.cwd(), '.moflo');
+      // #1315 — resolved root, not cwd. This mkdirs below, so `flo embeddings
+      // init` from a subdirectory minted an island holding an embeddings config
+      // the rest of the stack would never look at.
+      const configDir = path.join(resolveStateRoot(), '.moflo');
       const configPath = path.join(configDir, 'embeddings.json');
 
       // Second-session path: config already exists. Skip download / rewrite,
@@ -1064,7 +1068,8 @@ const neuralCommand: Command = {
     // Check if embeddings config exists
     const fs = await import('fs');
     const path = await import('path');
-    const configPath = path.join(process.cwd(), '.moflo', 'embeddings.json');
+    // #1315 — must read from the root `init` writes to.
+    const configPath = path.join(resolveStateRoot(), '.moflo', 'embeddings.json');
 
     if (!fs.existsSync(configPath)) {
       output.printWarning('Embeddings not initialized');
@@ -1643,7 +1648,7 @@ const migrateCommand: Command = {
     { command: 'flo embeddings migrate -d .custom/mem.db', description: 'Migrate a custom DB' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const dbPath = (ctx.flags.db as string) || memoryDbPath(process.cwd());
+    const dbPath = (ctx.flags.db as string) || memoryDbPath(resolveStateRoot());
     try {
       const ran = await runEmbeddingsMigrationIfNeeded({ dbPath });
       return { success: true, data: { ran } };

--- a/src/cli/commands/hooks.ts
+++ b/src/cli/commands/hooks.ts
@@ -10,6 +10,9 @@ import { select, confirm, input } from '../prompt.js';
 import { callMCPTool, MCPClientError } from '../mcp-client.js';
 import { memoryDbCandidatePaths } from '../services/moflo-paths.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+// #1315 — the intelligence/maturity probes below read `.moflo/` state; anchor
+// them at the resolved root so a subdirectory invocation doesn't report zeroes.
+import { resolveStateRoot } from '../services/project-root.js';
 
 // Hook types
 const HOOK_TYPES = [
@@ -3131,7 +3134,7 @@ const statuslineCommand: Command = {
 
     // Get learning stats from memory database
     function getLearningStats() {
-      const memoryPaths = memoryDbCandidatePaths(process.cwd());
+      const memoryPaths = memoryDbCandidatePaths(resolveStateRoot());
 
       let patterns = 0;
       let sessions = 0;
@@ -3248,7 +3251,7 @@ const statuslineCommand: Command = {
 
       // 1. Check learning.json for REAL intelligence metrics first
       const learningJsonPaths = [
-        path.join(process.cwd(), '.moflo', 'learning.json'),
+        path.join(resolveStateRoot(), '.moflo', 'learning.json'),
         path.join(process.cwd(), '.claude', '.moflo', 'learning.json'),
         path.join(process.cwd(), '.swarm', 'learning.json'),
       ];
@@ -3276,7 +3279,7 @@ const statuslineCommand: Command = {
         let maturityScore = 0;
         // Check for key project files/dirs
         if (fs.existsSync(path.join(process.cwd(), '.claude'))) maturityScore += 15;
-        if (fs.existsSync(path.join(process.cwd(), '.moflo'))) maturityScore += 15;
+        if (fs.existsSync(path.join(resolveStateRoot(), '.moflo'))) maturityScore += 15;
         if (fs.existsSync(path.join(process.cwd(), 'CLAUDE.md'))) maturityScore += 10;
         if (fs.existsSync(path.join(process.cwd(), 'claude-flow.config.json'))) maturityScore += 10;
         if (fs.existsSync(path.join(process.cwd(), '.swarm'))) maturityScore += 10;
@@ -3399,10 +3402,10 @@ const statuslineCommand: Command = {
 
     // Check for direct database files first. Canonical first, legacies after.
     const dbPaths = [
-      ...memoryDbCandidatePaths(process.cwd()),
+      ...memoryDbCandidatePaths(resolveStateRoot()),
       path.join(process.cwd(), 'memory.db'),
       path.join(process.cwd(), '.agentdb', 'memory.db'),
-      path.join(process.cwd(), '.moflo', 'memory', 'agentdb.db'),
+      path.join(resolveStateRoot(), '.moflo', 'memory', 'agentdb.db'),
     ];
     for (const dbPath of dbPaths) {
       if (fs.existsSync(dbPath)) {
@@ -3419,7 +3422,7 @@ const statuslineCommand: Command = {
     // Check for AgentDB directories if no direct db found
     if (agentdbStats.vectorCount === 0) {
       const agentdbDirs = [
-        path.join(process.cwd(), '.moflo', 'agentdb'),
+        path.join(resolveStateRoot(), '.moflo', 'agentdb'),
         path.join(process.cwd(), '.swarm', 'agentdb'),
         path.join(process.cwd(), 'data', 'agentdb'),
         path.join(process.cwd(), '.agentdb'),
@@ -3445,7 +3448,7 @@ const statuslineCommand: Command = {
 
     // Check for HNSW index files
     const hnswPaths = [
-      path.join(process.cwd(), '.moflo', 'hnsw'),
+      path.join(resolveStateRoot(), '.moflo', 'hnsw'),
       path.join(process.cwd(), '.swarm', 'hnsw'),
       path.join(process.cwd(), 'data', 'hnsw'),
     ];
@@ -3466,7 +3469,7 @@ const statuslineCommand: Command = {
     }
 
     // Check for vectors.json file
-    const vectorsPath = path.join(process.cwd(), '.moflo', 'vectors.json');
+    const vectorsPath = path.join(resolveStateRoot(), '.moflo', 'vectors.json');
     if (fs.existsSync(vectorsPath) && agentdbStats.vectorCount === 0) {
       try {
         const data = JSON.parse(fs.readFileSync(vectorsPath, 'utf-8'));

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { LEGACY_SWARM_DIR, memoryDbCandidatePaths, mofloDir } from '../services/moflo-paths.js';
 import { findProjectRoot } from '../services/project-root.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 // Get dynamic swarm status from memory/session files
 function getSwarmStatus(swarmId?: string) {
@@ -24,7 +25,7 @@ function getSwarmStatus(swarmId?: string) {
   const canonicalSwarmDir = path.join(mofloDir(projectRoot), 'swarm');
   const legacySwarmDir = path.join(projectRoot, LEGACY_SWARM_DIR);
   const sessionDir = path.join(process.cwd(), '.claude', 'sessions');
-  const memoryPaths = memoryDbCandidatePaths(process.cwd());
+  const memoryPaths = memoryDbCandidatePaths(resolveStateRoot());
 
   // Check for active swarm state file — canonical first, then legacy.
   let swarmStateFile = path.join(canonicalSwarmDir, 'state.json');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { runStartupUpdateCheck } from './update/index.js';
 import { loadMofloConfig } from './config/moflo-config.js';
 import { getDaemonLockHolder } from './services/daemon-lock.js';
 import { registerBackgroundPid } from './services/process-registry.js';
+import { resolveStateRoot } from './services/project-root.js';
 import { VERSION } from './version.js';
 
 export { VERSION };
@@ -544,25 +545,37 @@ export class CLI {
     // wants autostart can delete it in its own beforeEach, same as the others.
     if (process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART === '1') return;
 
-    const config = loadMofloConfig(process.cwd());
+    // #1315 — anchor on the resolved project root, NOT cwd. Pre-fix, a `flo`
+    // invocation from a sub-workspace read the config from there, looked for a
+    // lock there (never finding the root daemon's, so the "already running?"
+    // check below always passed), and then spawned a second daemon bound to a
+    // freshly-minted `.moflo/` island.
+    const projectRoot = resolveStateRoot();
+
+    const config = loadMofloConfig(projectRoot);
     if (!config.daemon.auto_start) return;
 
-    // Already running?
-    const holder = getDaemonLockHolder(process.cwd());
+    // Already running? Checked at the resolved root so a subdirectory
+    // invocation sees the root daemon instead of spawning a rival.
+    const holder = getDaemonLockHolder(projectRoot);
     if (holder) return;
 
     // Dynamically import to avoid circular deps and keep CLI startup fast
     const { spawn } = await import('child_process');
     const { join } = await import('path');
-    const { existsSync, openSync, mkdirSync } = await import('fs');
+    const { existsSync, openSync } = await import('fs');
     const { locateMofloCliBin } = await import('./services/moflo-require.js');
 
     const cliPath = locateMofloCliBin();
     if (!cliPath) return;
 
-    const projectRoot = process.cwd();
     const stateDir = join(projectRoot, '.moflo');
-    if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
+    // #1315 — an implicit auto-start must never MINT state. If there's no
+    // `.moflo/` at the resolved root this isn't an initialized moflo project,
+    // and creating one here is what produced stray islands seven levels deep
+    // inside consumer source trees. `flo init` and the explicit `daemon start`
+    // path still create it; auto-start only ever attaches to what exists.
+    if (!existsSync(stateDir)) return;
     const logFile = join(stateDir, 'daemon.log');
 
     const isWin = process.platform === 'win32';

--- a/src/cli/memory/bridge-core.ts
+++ b/src/cli/memory/bridge-core.ts
@@ -14,7 +14,7 @@ import {
   memoryDbPath,
   MOFLO_DIR,
 } from '../services/moflo-paths.js';
-import { findProjectRoot } from '../services/project-root.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 // When run via npx, CWD may be node_modules/moflo — walk up to find actual project
 let _projectRoot: string | undefined;
@@ -75,7 +75,13 @@ export function searchCandidateCap(): number {
  */
 function getProjectRoot(): string {
   if (_projectRoot) return _projectRoot;
-  _projectRoot = findProjectRoot();
+  // #1315 — MUST be the same resolver `entries-read`/`entries-write` use, or
+  // the bridge and the entry writers open DIFFERENT `.moflo/moflo.db` files.
+  // `findProjectRoot()` returns `CLAUDE_PROJECT_DIR` unvalidated, so in a
+  // Claude Code session rooted at a sub-workspace the bridge would anchor
+  // there while the writers anchored at the true root — the split-brain this
+  // module's own header warns about.
+  _projectRoot = resolveStateRoot();
   return _projectRoot;
 }
 

--- a/src/cli/memory/daemon-write-client.ts
+++ b/src/cli/memory/daemon-write-client.ts
@@ -38,7 +38,7 @@
  */
 
 import * as http from 'node:http';
-import { findProjectRoot } from '../services/project-root.js';
+import { resolveStateRoot } from '../services/project-root.js';
 import {
   resolveClientPort,
   LEGACY_DEFAULT_PORT,
@@ -52,7 +52,7 @@ import {
 
 /**
  * Read-only legacy default exported for tests; the actual port comes from
- * `getDaemonPort()` which delegates to `resolveClientPort(findProjectRoot())`.
+ * `getDaemonPort()` which delegates to `resolveClientPort(resolveStateRoot())`.
  * Routes through `LEGACY_DEFAULT_PORT` so no literal port number lives in
  * this file — see `daemon-port.ts` and the no-fixed-port regression guard.
  */
@@ -191,7 +191,7 @@ export function _resetForTest(): void {
 /**
  * Resolve the daemon HTTP port for this project.
  *
- * Delegates to `resolveClientPort(findProjectRoot())`:
+ * Delegates to `resolveClientPort(resolveStateRoot())`:
  *   1. `MOFLO_DAEMON_PORT` env override (consumer pin)
  *   2. `port` field in `<projectRoot>/.moflo/daemon.lock` (server records
  *      the actual bound port after startup — #1145)
@@ -205,7 +205,7 @@ export function _resetForTest(): void {
 let _portCache: { port: number; projectRoot: string } | null = null;
 
 function getDaemonPort(): number {
-  const projectRoot = findProjectRoot();
+  const projectRoot = resolveStateRoot();
   if (_portCache && _portCache.projectRoot === projectRoot) return _portCache.port;
   const port = resolveClientPort(projectRoot);
   _portCache = { port, projectRoot };
@@ -317,7 +317,7 @@ export async function isDaemonAvailable(): Promise<boolean> {
  */
 async function isDaemonIdentityMatch(port: number): Promise<boolean> {
   const now = Date.now();
-  const ourProjectRoot = findProjectRoot();
+  const ourProjectRoot = resolveStateRoot();
 
   if (
     identityCache &&

--- a/src/cli/memory/database-provider.ts
+++ b/src/cli/memory/database-provider.ts
@@ -23,6 +23,7 @@ import {
   MemoryEntryUpdate,
 } from './types.js';
 import { SqliteBackend, SqliteBackendConfig } from './sqlite-backend.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 /**
  * Available database provider types.
@@ -309,14 +310,22 @@ export function getPlatformInfo(): PlatformInfo {
  * Wrapped in a dynamic import so the memory subtree doesn't pull
  * `js-yaml` / `fs` into hot paths (e.g. the in-memory test backend).
  *
- * Memoised per (cwd, process) — a test suite or daemon that opens many
- * DBs in sequence parses moflo.yaml once. Keyed on cwd so a test that
- * `chdir`s into a temp dir gets a fresh resolution.
+ * Memoised per (resolved state root, process) — a test suite or daemon that
+ * opens many DBs in sequence parses moflo.yaml once. Keyed on the resolved
+ * root so a test that `chdir`s into a temp dir still gets a fresh resolution
+ * (an un-initialized temp dir resolves to itself).
+ *
+ * #1315 — this reads the BACKEND while the rest of the memory layer resolves
+ * the DB PATH. Both must anchor on the same root or they disagree: with the
+ * path fixed to `<root>/.moflo/moflo.db` but the config still read from cwd, a
+ * `flo` invocation from a sub-directory found no moflo.yaml, fell back to the
+ * DEFAULT backend, and opened the root's database with a different engine than
+ * the daemon was using it with.
  */
 const _resolvedProviderCache = new Map<string, DatabaseProvider | null>();
 
 async function preferredProviderFromConfig(verbose: boolean): Promise<DatabaseProvider | null> {
-  const key = process.cwd();
+  const key = resolveStateRoot();
   if (_resolvedProviderCache.has(key)) {
     return _resolvedProviderCache.get(key) ?? null;
   }
@@ -324,7 +333,7 @@ async function preferredProviderFromConfig(verbose: boolean): Promise<DatabasePr
     const { loadMofloConfig, resolveDatabaseProvider } = await import(
       '../config/moflo-config.js'
     );
-    const cfg = loadMofloConfig();
+    const cfg = loadMofloConfig(key);
     const resolved = resolveDatabaseProvider(cfg.memory.backend);
     if (verbose) {
       console.log(

--- a/src/cli/memory/entries-read.ts
+++ b/src/cli/memory/entries-read.ts
@@ -20,6 +20,7 @@ import { getBridge } from './bridge-loader.js';
 import { tryDaemonGet, tryDaemonSearch, tryDaemonList } from './daemon-write-client.js';
 import { searchCandidateCap } from './bridge-core.js';
 import { cosineSim, logRoutingFault } from './entries-shared.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 /**
  * Search entries via node:sqlite with vector similarity.
@@ -94,7 +95,7 @@ export async function searchEntries(options: {
     dbPath: customPath
   } = options;
 
-  const dbPath = customPath || memoryDbPath(process.cwd());
+  const dbPath = customPath || memoryDbPath(resolveStateRoot());
   const startTime = Date.now();
 
   try {
@@ -258,7 +259,7 @@ export async function listEntries(options: {
     dbPath: customPath
   } = options;
 
-  const dbPath = customPath || memoryDbPath(process.cwd());
+  const dbPath = customPath || memoryDbPath(resolveStateRoot());
 
   try {
     if (!fs.existsSync(dbPath)) {
@@ -392,7 +393,7 @@ export async function getEntry(options: {
     dbPath: customPath
   } = options;
 
-  const dbPath = customPath || memoryDbPath(process.cwd());
+  const dbPath = customPath || memoryDbPath(resolveStateRoot());
 
   try {
     if (!fs.existsSync(dbPath)) {
@@ -485,7 +486,7 @@ export async function getNamespaceCounts(dbPath?: string): Promise<{
   total: number;
   withEmbeddings: number;
 }> {
-  const resolvedPath = dbPath || memoryDbPath(process.cwd());
+  const resolvedPath = dbPath || memoryDbPath(resolveStateRoot());
 
   if (!fs.existsSync(resolvedPath)) {
     return { namespaces: {}, total: 0, withEmbeddings: 0 };

--- a/src/cli/memory/entries-write.ts
+++ b/src/cli/memory/entries-write.ts
@@ -26,6 +26,7 @@ import { toFloat32 } from './controllers/_shared.js';
 import { serialiseMetadata } from './bridge-entries.js';
 import { logRoutingFault, writeVectorStatsCache } from './entries-shared.js';
 import { writeThroughDurable } from '../services/durable-sync.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 /**
  * Propagate a just-persisted durable write to the shared store (#1232). The
@@ -170,7 +171,7 @@ export async function storeEntry(options: {
     upsert = false
   } = options;
 
-  const dbPath = customPath || memoryDbPath(process.cwd());
+  const dbPath = customPath || memoryDbPath(resolveStateRoot());
 
   try {
     if (!fs.existsSync(dbPath)) {
@@ -440,7 +441,7 @@ export async function deleteEntry(options: {
     dbPath: customPath
   } = options;
 
-  const dbPath = customPath || memoryDbPath(process.cwd());
+  const dbPath = customPath || memoryDbPath(resolveStateRoot());
 
   try {
     if (!fs.existsSync(dbPath)) {

--- a/src/cli/memory/hnsw-singleton.ts
+++ b/src/cli/memory/hnsw-singleton.ts
@@ -21,6 +21,7 @@ import { parseEmbeddingJson } from './controllers/_shared.js';
 import { memoryDbPath } from '../services/moflo-paths.js';
 import { openDaemonDatabase } from './daemon-backend.js';
 import { getBridge, isBridgeLoaded } from './bridge-loader.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 interface HNSWEntry {
   id: string;
@@ -71,7 +72,7 @@ export async function getHNSWIndex(options?: {
     // Use HnswLite pure TS implementation (no native dependencies).
 
     // Persistent storage paths — colocated with the canonical memory DB.
-    const dbPath = options?.dbPath || memoryDbPath(process.cwd());
+    const dbPath = options?.dbPath || memoryDbPath(resolveStateRoot());
     const dbDir = path.dirname(dbPath);
     if (!fs.existsSync(dbDir)) {
       fs.mkdirSync(dbDir, { recursive: true });

--- a/src/cli/memory/init.ts
+++ b/src/cli/memory/init.ts
@@ -20,6 +20,7 @@ import {
 import { openDaemonDatabase } from './daemon-backend.js';
 import { getBridge } from './bridge-loader.js';
 import { MEMORY_SCHEMA_V3, getInitialMetadata, type MemoryInitResult } from './schema.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 /**
  * Check for legacy database installations and migrate if needed
@@ -41,12 +42,17 @@ export async function checkAndMigrateLegacy(options: {
   // probe still catches consumers whose launcher migration deferred. The
   // bare `memory.db` and `.claude/memory.db`/`data/memory.db` entries are
   // older still.
+  // #1315 — every probe anchors on the RESOLVED root, not cwd. These look for
+  // a pre-#727 database to migrate from, and that database lives at the
+  // project root; probing cwd meant a `flo` run from any sub-directory found
+  // nothing and silently skipped the migration.
+  const stateRoot = resolveStateRoot();
   const legacyPaths = [
-    legacyMemoryDbPath(process.cwd()),
-    path.join(process.cwd(), MOFLO_DIR, 'memory.db'),
-    path.join(process.cwd(), 'memory.db'),
-    path.join(process.cwd(), '.claude', 'memory.db'),
-    path.join(process.cwd(), 'data', 'memory.db'),
+    legacyMemoryDbPath(stateRoot),
+    path.join(stateRoot, MOFLO_DIR, 'memory.db'),
+    path.join(stateRoot, 'memory.db'),
+    path.join(stateRoot, '.claude', 'memory.db'),
+    path.join(stateRoot, 'data', 'memory.db'),
   ];
 
   for (const legacyPath of legacyPaths) {
@@ -186,7 +192,7 @@ export async function initializeMemoryDatabase(options: {
     migrate = true
   } = options;
 
-  const dbPath = customPath || memoryDbPath(process.cwd());
+  const dbPath = customPath || memoryDbPath(resolveStateRoot());
   const dbDir = path.dirname(dbPath);
 
   try {
@@ -340,7 +346,7 @@ export async function checkMemoryInitialization(dbPath?: string): Promise<{
   };
   tables?: string[];
 }> {
-  const path_ = dbPath || memoryDbPath(process.cwd());
+  const path_ = dbPath || memoryDbPath(resolveStateRoot());
 
   if (!fs.existsSync(path_)) {
     return { initialized: false };
@@ -394,7 +400,7 @@ export async function applyTemporalDecay(dbPath?: string): Promise<{
   patternsDecayed: number;
   error?: string;
 }> {
-  const path_ = dbPath || memoryDbPath(process.cwd());
+  const path_ = dbPath || memoryDbPath(resolveStateRoot());
 
   try {
     const db = openDaemonDatabase(path_);

--- a/src/cli/memory/learnings-overview.ts
+++ b/src/cli/memory/learnings-overview.ts
@@ -19,6 +19,7 @@
 import * as fs from 'fs';
 import { memoryDbPath } from '../services/moflo-paths.js';
 import { openDaemonDatabase } from './daemon-backend.js';
+import { resolveStateRoot } from '../services/project-root.js';
 
 /** The namespace this overview is scoped to. */
 const LEARNINGS_NAMESPACE = 'learnings';
@@ -124,7 +125,7 @@ export async function getLearningsOverview(options?: {
   // finite positive integer so a stray float/NaN/≤0 can't produce bad SQL.
   const recentLimit = toPositiveInt(options?.recentLimit, DEFAULT_RECENT_LIMIT);
   const bodyCap = toPositiveInt(options?.bodyCap, DEFAULT_BODY_CAP);
-  const resolvedPath = options?.dbPath || memoryDbPath(process.cwd());
+  const resolvedPath = options?.dbPath || memoryDbPath(resolveStateRoot());
 
   if (!fs.existsSync(resolvedPath)) {
     return { ...EMPTY };

--- a/src/cli/runtime/headless.ts
+++ b/src/cli/runtime/headless.ts
@@ -19,6 +19,7 @@ import { HeadlessWorkerExecutor, HEADLESS_WORKER_TYPES, type HeadlessWorkerType 
 import { WorkerDaemon, getDaemon, startDaemon, stopDaemon } from '../services/worker-daemon.js';
 import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { resolveStateRoot } from '../services/project-root.js';
 import {
   initializeIntelligence,
   benchmarkAdaptation,
@@ -137,7 +138,10 @@ Examples:
 async function runWorker(workerType: HeadlessWorkerType, timeout: number): Promise<void> {
   console.log(`[Headless] Starting worker: ${workerType}`);
 
-  const executor = new HeadlessWorkerExecutor(process.cwd(), {
+  // #1315 — the HeadlessWorkerExecutor constructor unconditionally creates
+  // `<root>/.moflo/reports` and `<root>/.moflo/logs/headless`, so handing it
+  // raw cwd minted an island wherever the headless runtime happened to start.
+  const executor = new HeadlessWorkerExecutor(resolveStateRoot(), {
     maxConcurrent: 1,
     defaultTimeoutMs: timeout
   });
@@ -170,8 +174,9 @@ async function runWorker(workerType: HeadlessWorkerType, timeout: number): Promi
 async function runDaemon(): Promise<void> {
   console.log('[Headless] Starting daemon mode...');
 
-  // Start the daemon
-  const daemon = await startDaemon(process.cwd());
+  // Start the daemon. #1315 — resolved root, not cwd: `startDaemon` builds a
+  // WorkerDaemon and that constructor creates the state dir it is handed.
+  const daemon = await startDaemon(resolveStateRoot());
 
   console.log('[Headless] Daemon started');
   console.log('[Headless] Press Ctrl+C to stop');

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -31,7 +31,7 @@ import {
 import { aggregateClaudeStats, emptyClaudeStatsShape } from './claude-stats.js';
 import { serverPortCandidates, LEGACY_DEFAULT_PORT } from './daemon-port.js';
 import { writeLockPort } from './daemon-lock.js';
-import { findProjectRoot } from './project-root.js';
+import { resolveStateRoot } from './project-root.js';
 import { readOwnMofloVersion } from './daemon-lock.js';
 
 // ============================================================================
@@ -57,7 +57,7 @@ export interface DashboardOptions {
   /**
    * Absolute project root the daemon is serving. Stamped into
    * `/api/health` so clients can verify they're hitting their own
-   * project's daemon (#1145). Defaults to `findProjectRoot()`.
+   * project's daemon (#1145). Defaults to `resolveStateRoot()`.
    */
   projectRoot?: string;
 }
@@ -192,7 +192,7 @@ function tryParseSafe(s: string): unknown {
  * Build the `/api/health` response (#1145).
  *
  * Identity payload — clients compare `projectRoot` against their own
- * `findProjectRoot()` and refuse to route to this daemon on mismatch.
+ * `resolveStateRoot()` and refuse to route to this daemon on mismatch.
  * Also surfaces `pid`, `version`, and `uptimeMs` for healer-class
  * diagnostics and orphan-daemon detection.
  *
@@ -203,7 +203,7 @@ function handleHealth(daemon: WorkerDaemon, opts: DashboardOptions): object {
   const startedAt = status.startedAt instanceof Date ? status.startedAt : null;
   return {
     status: 'ok',
-    projectRoot: opts.projectRoot ?? findProjectRoot(),
+    projectRoot: opts.projectRoot ?? resolveStateRoot(),
     pid: status.pid ?? process.pid,
     version: readOwnMofloVersion() ?? null,
     uptimeMs: startedAt ? Date.now() - startedAt.getTime() : 0,
@@ -729,7 +729,7 @@ export async function startDashboard(
   daemon: WorkerDaemon,
   opts: DashboardOptions,
 ): Promise<DashboardHandle> {
-  const projectRoot = opts.projectRoot ?? findProjectRoot();
+  const projectRoot = opts.projectRoot ?? resolveStateRoot();
   const candidates = buildBindCandidates(opts.port, projectRoot, MAX_PORT_ATTEMPTS);
 
   let lastErr: unknown = null;

--- a/src/cli/services/embeddings-migration.ts
+++ b/src/cli/services/embeddings-migration.ts
@@ -26,9 +26,10 @@ import {
   CANONICAL_EMBEDDING_MODEL,
   EMBEDDINGS_VERSION,
 } from '../embeddings/migration/types.js';
+import { resolveStateRoot } from './project-root.js';
 
 export interface RunEmbeddingsMigrationOptions {
-  /** Path to the memory DB. Defaults to `<cwd>/.moflo/moflo.db`. */
+  /** Path to the memory DB. Defaults to `<resolved project root>/.moflo/moflo.db` (#1315). */
   dbPath?: string;
   /** Output stream for the renderer. Defaults to `process.stderr`. */
   out?: NodeJS.WritableStream & { isTTY?: boolean };
@@ -65,7 +66,7 @@ export async function runEmbeddingsMigrationIfNeeded(
   const fs = await import('fs');
   const path = await import('path');
 
-  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(process.cwd()));
+  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(resolveStateRoot()));
   if (!fs.existsSync(dbPath)) return false;
 
   // node:sqlite via the unified factory (Phase 5 / #1084). The migration

--- a/src/cli/services/ephemeral-namespace-purge.ts
+++ b/src/cli/services/ephemeral-namespace-purge.ts
@@ -36,9 +36,10 @@ import {
 } from '../memory/bridge-embedder.js';
 import { memoryDbPath } from './moflo-paths.js';
 import { openDaemonDatabase } from '../memory/daemon-backend.js';
+import { resolveStateRoot } from './project-root.js';
 
 export interface PurgeEphemeralNamespacesOptions {
-  /** Path to the memory DB. Defaults to `<cwd>/.moflo/moflo.db`. */
+  /** Path to the memory DB. Defaults to `<resolved project root>/.moflo/moflo.db` (#1315). */
   dbPath?: string;
   /**
    * Override the tasklist retention cap. Defaults to
@@ -69,7 +70,7 @@ export async function purgeEphemeralNamespaces(
   const fs = await import('fs');
   const path = await import('path');
 
-  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(process.cwd()));
+  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(resolveStateRoot()));
   if (!fs.existsSync(dbPath)) return { purged: 0, trimmed: 0 };
 
   // node:sqlite via the unified factory (Phase 5 / #1084). WAL persists each
@@ -152,7 +153,7 @@ export async function purgeEphemeralNamespaces(
 }
 
 export interface PurgeMemoryProbeNamespacesOptions {
-  /** Path to the memory DB. Defaults to `<cwd>/.moflo/moflo.db`. */
+  /** Path to the memory DB. Defaults to `<resolved project root>/.moflo/moflo.db` (#1315). */
   dbPath?: string;
 }
 
@@ -182,7 +183,7 @@ export async function purgeMemoryProbeNamespaces(
   const fs = await import('fs');
   const path = await import('path');
 
-  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(process.cwd()));
+  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(resolveStateRoot()));
   if (!fs.existsSync(dbPath)) return { purged: 0 };
 
   const prefixes = Array.from(PURGE_ON_SESSION_START_PREFIXES);

--- a/src/cli/services/project-root.ts
+++ b/src/cli/services/project-root.ts
@@ -44,7 +44,7 @@
  * fragmentation.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { resolve, dirname, parse, join, basename } from 'node:path';
 
 export interface FindProjectRootOptions {
@@ -86,6 +86,119 @@ export function findAncestorMofloRoot(dir: string): string | null {
     cursor = parent;
   }
   return null;
+}
+
+/**
+ * Memo for {@link resolveStateRoot}, keyed on the two inputs that can change
+ * within a process: the starting directory and `CLAUDE_PROJECT_DIR`.
+ *
+ * Only MARKER-PROVEN results are cached — i.e. resolutions that landed on a
+ * directory actually holding `.moflo/moflo.db`. That distinction is what makes
+ * the cache safe: an existing `moflo.db` does not move during a process
+ * lifetime, whereas a fall-through result (Pass B/C, no moflo state anywhere)
+ * is exactly the case `flo init` is about to invalidate by creating one. So
+ * the un-cached path stays correct and the cached path stays stable.
+ *
+ * Motivation: a single `flo doctor` run resolves independently from ~6 check
+ * modules, each re-walking the ancestor chain.
+ */
+const stateRootCache = new Map<string, string>();
+
+/** Clear the {@link resolveStateRoot} memo. Test seam only. */
+export function _resetStateRootCacheForTest(): void {
+  stateRootCache.clear();
+}
+
+/**
+ * Resolve the anchor that any code READING OR WRITING `.moflo/` state must use
+ * (#1315). Use this instead of `process.cwd()` anywhere a `.moflo/` path is
+ * built — the daemon, the healer, and any command that persists metrics,
+ * benchmarks, or reports.
+ *
+ * `findProjectRoot()` short-circuits on `CLAUDE_PROJECT_DIR` before Pass A.
+ * That is correct for most callers, but wrong for state anchoring: Claude Code
+ * sets the variable to the SESSION's directory, hooks inherit it, and a spawned
+ * daemon inherits it again via `daemonEnv` (`commands/daemon.ts`). In a
+ * monorepo session rooted at a sub-workspace the whole chain therefore agreed
+ * the project root was the sub-workspace, and `daemon start` minted a fresh
+ * `.moflo/` there — re-seeding the daemon islands #1174 was closed for.
+ *
+ * The rule here: an existing `CLAUDE_PROJECT_DIR` wins outright — it is what
+ * Claude Code says the project is, and the marker walk is never allowed to
+ * climb above it. Otherwise walk up from cwd and take the TOPMOST
+ * `.moflo/moflo.db`, which is the canonical root for a monorepo. That walk is
+ * the actual #1315 fix: the state sites previously used `process.cwd()` raw,
+ * so every sub-directory invocation minted an island where it stood.
+ *
+ * Why the env is not merely a starting point: the walk has no upper bound, so
+ * climbing past an explicit anchor lets any stray ancestor marker capture every
+ * project beneath it. See the note in `resolveStateRootUncached`.
+ *
+ * Deliberately a separate export rather than a change inside `findProjectRoot`
+ * itself: that resolver is shared with the MCP server, the memory bridge, and
+ * the gate hooks, whose env-override semantics are load-bearing elsewhere.
+ * Callers that merely need "which project am I in" should keep using
+ * `findProjectRoot`; callers that are about to CREATE something use this.
+ */
+export function resolveStateRoot(opts?: { cwd?: string }): string {
+  const envDir = process.env.CLAUDE_PROJECT_DIR;
+  const cacheKey = `${opts?.cwd ?? process.cwd()}\0${envDir ?? ''}`;
+  const cached = stateRootCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const resolved = resolveStateRootUncached(opts, envDir);
+  // Cache only a marker-proven anchor — see the note on `stateRootCache`.
+  if (existsSync(join(resolved, '.moflo', 'moflo.db'))) {
+    stateRootCache.set(cacheKey, resolved);
+  }
+  return resolved;
+}
+
+function resolveStateRootUncached(opts: { cwd?: string } | undefined, envDir: string | undefined): string {
+  // An explicitly-set `CLAUDE_PROJECT_DIR` is AUTHORITATIVE and is never
+  // climbed above. Claude Code sets it to the project the user opened, and the
+  // marker walk has no upper bound — it runs to the filesystem root and takes
+  // the TOPMOST `.moflo/moflo.db`. Letting it climb past an explicit anchor
+  // means any stray ancestor marker captures every project beneath it: one
+  // accidental `flo init` in `$HOME` silently re-roots everything, and a
+  // scratch project created inside another checkout resolves to that checkout
+  // and mutates it. (Verified, not hypothetical: with the climb enabled the
+  // session-start launcher operated on this repo instead of its fixture.)
+  //
+  // A typo'd or stale value naming a directory that does not exist is ignored
+  // — callers mkdir what we return, so honoring it would materialize `.moflo/`
+  // at the typo path.
+  const envAbs = envDir ? resolve(envDir) : undefined;
+  if (envAbs && existsSync(envAbs)) {
+    return canonicalize(envAbs);
+  }
+
+  // No usable env anchor: walk up from cwd. This is the #1315 fix proper —
+  // the state-anchoring sites used to take `process.cwd()` raw, so any
+  // sub-directory invocation minted an island there. Pass A's topmost-wins
+  // walk lands on the canonical root instead.
+  const resolved = findProjectRoot({ honorEnv: false, cwd: opts?.cwd });
+
+  return canonicalize(resolved);
+}
+
+/**
+ * Absolutize + realpath a resolved root.
+ *
+ * The env value is caller-supplied and may be relative or carry a trailing
+ * separator, and on macOS `/var/folders/...` must collapse to
+ * `/private/var/folders/...` or this root won't compare equal to the realpath'd
+ * one `daemon-port.ts:normalizeProjectRoot` derives for same-project matching
+ * (CLAUDE.md Rule #1 §2). Falls back to the un-canonicalized path when it
+ * doesn't exist, which is the right degradation — never throw from a resolver.
+ */
+function canonicalize(p: string): string {
+  const abs = resolve(p);
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
 }
 
 export function findProjectRoot(opts?: FindProjectRootOptions): string {

--- a/src/cli/services/soft-delete-purge.ts
+++ b/src/cli/services/soft-delete-purge.ts
@@ -21,9 +21,10 @@
 
 import { memoryDbPath } from './moflo-paths.js';
 import { openDaemonDatabase } from '../memory/daemon-backend.js';
+import { resolveStateRoot } from './project-root.js';
 
 export interface PurgeSoftDeletedOptions {
-  /** Path to the memory DB. Defaults to `<cwd>/.moflo/moflo.db`. */
+  /** Path to the memory DB. Defaults to `<resolved project root>/.moflo/moflo.db` (#1315). */
   dbPath?: string;
 }
 
@@ -46,7 +47,7 @@ export async function purgeSoftDeletedEntries(
   const fs = await import('fs');
   const path = await import('path');
 
-  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(process.cwd()));
+  const dbPath = path.resolve(options.dbPath ?? memoryDbPath(resolveStateRoot()));
   if (!fs.existsSync(dbPath)) return { purged: 0 };
 
   // node:sqlite via the unified factory (Phase 5 / #1084). WAL persists each

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -24,7 +24,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { existsSync, mkdirSync, writeFileSync, readFileSync, appendFileSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, appendFileSync, statSync } from 'fs';
 import { atomicWriteFileSync } from './atomic-file-write.js';
 import { mofloDir } from './moflo-paths.js';
 import { cpus } from 'os';
@@ -46,6 +46,7 @@ import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import { calculateDelay } from '../production/retry.js';
 import { CircuitBreaker } from '../production/circuit-breaker.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { readMofloEnv } from './env-compat.js';
 
 // Worker types matching hooks-tools.ts. `audit`, `predict`, `document`
 // were removed in #970; `optimize` + `testgaps` were removed in #1258 (moved
@@ -702,6 +703,68 @@ export class WorkerDaemon extends EventEmitter {
   }
 
   /**
+   * #1315 — exit when the project root has been deleted out from under us.
+   *
+   * A daemon started inside a git worktree outlived `git worktree remove`: the
+   * directory was gone, `git worktree list`/`prune` both reported clean, yet
+   * every tick the worker paths called `mkdirSync(stateDir, {recursive:true})`
+   * and RECREATED the deleted tree just to write `daemon-state.json` and
+   * `metrics/` into it. Deleting the husk by hand simply got it back on the
+   * next tick, because nothing ever asked whether the root still existed.
+   *
+   * Checked at the top of each tick, before any writer runs.
+   *
+   * Cross-platform (CLAUDE.md Rule #1): `existsSync` is platform-neutral, but
+   * the SCENARIO is mostly POSIX — Windows refuses to remove a directory that
+   * is a live process's cwd (sharing violation), and the daemon is spawned with
+   * `cwd: projectRoot`. So on Windows this check simply never fires, which is
+   * correct rather than a gap: the husk-recreation it guards against cannot
+   * happen there. No `process.platform` branch is warranted.
+   *
+   * @returns true when shutdown was initiated (caller must stop immediately).
+   */
+  private async shutdownIfRootVanished(): Promise<boolean> {
+    // `statSync`, NOT `existsSync`. `existsSync` swallows every error and
+    // returns false, so EACCES, EIO, a disconnected SMB share, or a sleeping
+    // network volume would be indistinguishable from "deleted" and would exit
+    // a perfectly healthy daemon on one bad sample. Only ENOENT means gone.
+    try {
+      statSync(this.projectRoot);
+      return false; // still there
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        // Can't tell — assume present. A false positive kills a healthy
+        // daemon, which is far worse than one more tick of an orphan.
+        return false;
+      }
+    }
+
+    this.log('warn', `Project root ${this.projectRoot} no longer exists — shutting down instead of recreating it`);
+    try {
+      await this.stop();
+    } catch {
+      /* best effort — we're leaving either way */
+    }
+    // Only a genuine daemon process may take the process down with it. A CLI
+    // command or a test that happens to hold a WorkerDaemon must not be
+    // exited out from under itself. `MOFLO_TEST_NO_DAEMON_SELF_EXIT` is the
+    // test-runner kill switch (vitest.setup.ts) — without it a vitest worker
+    // that inherited MOFLO_DAEMON would exit(0) mid-run and report every
+    // remaining test as passed.
+    // `readMofloEnv('DAEMON')`, not raw `process.env.MOFLO_DAEMON` — it also
+    // honors the legacy `CLAUDE_FLOW_DAEMON` prefix, which is what OS service
+    // units written by older moflo versions still set. Reading only the modern
+    // name left those daemons clearing their timers but never exiting: a live
+    // process still holding its dashboard port. Matches how `daemon.ts`
+    // identifies a daemon process.
+    const isDaemonProcess = readMofloEnv('DAEMON') === '1';
+    if (isDaemonProcess && process.env.MOFLO_TEST_NO_DAEMON_SELF_EXIT !== '1') {
+      process.exit(0);
+    }
+    return true;
+  }
+
+  /**
    * Schedule a worker to run at intervals with staggered start
    */
   private scheduleWorker(workerConfig: WorkerConfig): void {
@@ -720,6 +783,8 @@ export class WorkerDaemon extends EventEmitter {
 
     const runAndReschedule = async () => {
       if (!this.running) return;
+      // #1315 — before any writer runs, confirm we still have a project.
+      if (await this.shutdownIfRootVanished()) return;
 
       // Use concurrency-controlled execution (P0 fix)
       await this.executeWorkerWithConcurrencyControl(workerConfig);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -63,6 +63,15 @@ process.env.MOFLO_TEST_TRUST_DAEMON_PID = '1';
 // its own `beforeEach`, same as the two vars below.
 process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART = '1';
 
+// #1315 — disarm the daemon's deleted-root self-exit inside the test runner.
+// `WorkerDaemon.shutdownIfRootVanished()` calls `process.exit(0)` when it sees
+// `MOFLO_DAEMON=1`, which is correct for a real daemon whose project was
+// deleted. But tests routinely build a WorkerDaemon over a tmp dir and then
+// remove it, and a vitest worker that inherited `MOFLO_DAEMON` would exit(0)
+// mid-run — reporting every remaining test as passed. Fail loudly, never
+// silently green. The self-exit test clears this in its own `beforeEach`.
+process.env.MOFLO_TEST_NO_DAEMON_SELF_EXIT = '1';
+
 // #1150 — skip the same-project orphan scan in `acquireDaemonLock` for the
 // same reasons as TRUST_DAEMON_PID above: the PowerShell/CIM enumeration on
 // Windows is expensive and tests using synthetic tempDir-rooted "daemons"
@@ -88,5 +97,8 @@ beforeEach(() => {
   }
   if (process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART !== '1') {
     process.env.MOFLO_TEST_SKIP_DAEMON_AUTOSTART = '1';
+  }
+  if (process.env.MOFLO_TEST_NO_DAEMON_SELF_EXIT !== '1') {
+    process.env.MOFLO_TEST_NO_DAEMON_SELF_EXIT = '1';
   }
 });


### PR DESCRIPTION
Fixes #1315.

## The bug

`daemon start` created a `.moflo/` state directory at whatever cwd it was launched from, with no project-root resolution and no `flo init` involved. In a monorepo that manufactures the exact "daemon islands" precondition #1174 was closed for eliminating — #1174 fixed which *existing* `.moflo` gets resolved; this is about moflo **creating** new ones where none should exist.

Reported against 4.12.2 with three concurrent daemons for one repo, one stray seven levels deep inside a React component folder.

## What it actually was

Not a single site. Every state-anchoring path took `process.cwd()` raw, so any invocation from a sub-directory minted an island there while resolving its own binary from the root install — which is why the reporter saw `node <root>/node_modules/moflo/bin/cli.js` with a sub-workspace cwd.

`flo daemon status` did it too, through the `WorkerDaemon` constructor's unconditional `mkdir`. A read-only-looking command that creates state.

## The fix

New `resolveStateRoot()` replaces `process.cwd()` everywhere `.moflo/` is read or written. An existing `CLAUDE_PROJECT_DIR` wins outright and is **never climbed above**; otherwise walk up and take the topmost `.moflo/moflo.db`.

The env var is authoritative rather than a starting point on purpose. The marker walk has no upper bound, so climbing past an explicit anchor lets one stray `flo init` in an ancestor capture every project beneath it. That is not hypothetical — an earlier iteration of this patch made the session-start launcher operate on this repo instead of its own test fixture.

## Also fixed, found while tracing consistency

| | |
|---|---|
| **Bridge/writer split-brain** | `bridge-core` resolved the DB via `findProjectRoot` while the entry writers used the new resolver — two writers, one database, different anchors. `daemon-write-client` and `daemon-dashboard` aligned too, since the daemon **port** and identity check derive from the root. |
| **Backend/path disagreement** | `database-provider` read `memory.backend` from cwd while the DB path resolved to the root, so a configured backend was ignored from a sub-directory. |
| **Deleted-root recreation** | The daemon recreated a removed worktree instead of exiting. Now stats each tick and shuts down on `ENOENT` — `statSync`, not `existsSync`, which swallows `EACCES`/`EIO` and would kill a healthy daemon on one bad sample. |
| **Healer was blind to the residue** | The island scan required `.moflo/moflo.db` and stopped at depth 5, so daemon-minted husks were invisible. Now classifies husks separately, reaches depth 8, and reaps their daemons via the lock file — the cmdline matcher cannot see them, because a husk daemon runs the *root's* `cli.js`. |
| **Hook layer kept re-minting** | `bin/lib/moflo-paths.mjs` gained a twin, so the launcher stops recreating the husk every session (which made the healer a perpetual warn→fix→warn loop). |
| **Inherited env** | `daemonEnv` pins `CLAUDE_PROJECT_DIR` to the resolved root, closing the class for every spawned child. |
| **Orphaned OS service** | `daemon uninstall` also sweeps a legacy cwd-anchored registration; the service name is a hash of the root, so an install from a sub-directory would otherwise be unreachable and re-spawn at every login. |

## Suite flakes, fixed at the cause

Two pre-existing non-deterministic failures, verified against clean `main` before touching them:

- A cold spell-engine dynamic import charged to a single test's 5s budget (now warmed in `beforeAll`).
- Random-port binds with no collision handling. Now ephemeral port 0 — **safer on Windows** than any fixed range, since Rule #1 §8's "avoid 49152-65535" targets *hardcoded* binds against reserved blocks, and the OS never assigns from one.

## Consumer impact

- Strays stop appearing.
- A root `auto_start: false` now genuinely suppresses sub-directory autostart, which it silently did not before — `loadMofloConfig` does not walk up, so a sub-directory invocation fell back to `DEFAULT_CONFIG` (`auto_start: true`).
- No migration. No `.moflo/` format change.

**Release note:** stop the daemon or restart the session after upgrading. In a monorepo the old daemon anchored at a sub-path and bound its port from there; the new client resolves the true root, so until it is recycled `flo daemon status` may report "not running" while the old one lives on. The launcher's version recycler handles this automatically on the next session.

## Verification

- `npm test` (parallel + isolation): **0 failures**, repeated runs
- `npm run lint` (`--max-warnings 0`), `npm run build`: clean
- `npm run test:smoke` (packs and installs into a throwaway consumer): **49 passed, 0 failed**
- New `daemon-root-1315.test.ts` — 17 tests, key guards **mutation-tested** (reverting the fix makes them fail)
- A repo-wide source guard fails with `file:line` if any state-minting site anchors on cwd again — added after a sibling call site four lines from a fixed one was missed

## Review focus

`src/cli/services/project-root.ts`. The resolver semantics went through three iterations, two of which were wrong in ways that passed a full review and repeated clean test runs. The middle version would have had an uninitialized project read and write a *different* project's database. That case is pinned by a test now, but it is the part most worth a second pair of eyes.

Not addressed here: the MCP tool surface (`mcp-tools/*`) still resolves via `findProjectRoot` for its own JSON state — separate files, not the database, and out of scope for this fix.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_01AURZd9bPKwQxLqLYeBovsk
