### PR TITLE
chore(deps): clear MCP SDK + hono advisories, patch brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anush008/tokenizers": "^0.6.0",
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "js-yaml": "^5.2.0",
         "lru-cache": "^11.3.5",
         "onnxruntime-node": "^1.27.0",
@@ -729,12 +729,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -798,12 +798,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1798,9 +1798,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@anush008/tokenizers": "^0.6.0",
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "js-yaml": "^5.2.0",
     "lru-cache": "^11.3.5",
     "onnxruntime-node": "^1.27.0",


### PR DESCRIPTION
## Summary

Clears both moderate npm-audit advisories and one of the two `brace-expansion` findings.

| package | from | to | scope |
|---|---|---|---|
| `@modelcontextprotocol/sdk` | 1.29.0 | 1.30.0 | **prod, direct** |
| `@hono/node-server` | 1.19.14 | 2.0.12 | transitive, via the SDK |
| `brace-expansion` | 1.1.14 / 2.1.0 | 1.1.16 / 2.1.3 | dev-only |

Lockfile churn is exactly these packages — nothing else moved.

## On the hono major bump

`@hono/node-server` 1.x → 2.x looks alarming but is not a forced override. The SDK declares the same dual range on **both** versions:

```json
"@hono/node-server": "^1.19.9 || ^2.0.5"
```

So 2.0.12 is inside what the SDK already supports. We were pinned to 1.19.14 only because the lockfile held that branch of the `||`. GHSA-frvp-7c67-39w9 (path traversal in `serve-static` on Windows via encoded `%5C`) has **no fix in the 1.x line**, so 2.x is the only remediation path.

Note this also means the SDK bump alone does nothing for the hono advisory — 1.29.0 and 1.30.0 declare identical ranges. The two changes are independent.

## Reachability

Not reachable at runtime in moflo either way: `mcp-server.ts:59` is stdio-only (http/websocket were removed), and `hono` appears only in the SDK's `streamableHttp` transport and its `examples/`. This is updated for a clean audit and for consumers' own scanners, not because we were exposed.

## Consumer surface (Rule #2)

- **Surface touched**: `package.json` `dependencies` — ships to every consumer.
- **Floor raised** `^1.0.0` → `^1.30.0` so a fresh consumer install cannot resolve back to a vulnerable SDK. This narrows the accepted range; deliberate, for the security floor.
- **Failure mode**: a consumer pinning an older SDK in their own tree would now see a peer/resolution bump. Low risk — 1.30.0 is current and semver-minor from what we shipped.
- **Round-trip**: lockfile + manifest only; no runtime code change, so no publish-then-reinstall dance beyond the normal release.
- `brace-expansion` is dev-only (via `eslint@8`, `@typescript-eslint/parser@7`) and never installed for consumers.

## Deliberately NOT fixed here

`brace-expansion` **GHSA-mh99-v99m-4gvg** (high, CVSS 7.5, OOM DoS) covers `<=5.0.7`. No release in the 1.x or 2.x lines clears it, so the patch bumps in this PR fix only the companion advisory GHSA-3jxr-9vmj-r5cp. The sole remediation is migrating off `eslint@8` / `@typescript-eslint@7` — tracked in #1319.

`npm audit` reports this as **14 high** findings. That is **one** advisory plus **13 dependents** in the eslint chain, listed because npm's remediation path is now a major eslint bump. Same single exposure, louder presentation.

## Verification

- `npm run build` (tsc) — clean
- `npm test` — **9517 passed, 0 failed** (within this repo's normal 9499–9570 band)
- `npm run lint` (`--max-warnings 0`) — clean

Three-platform smoke runs in CI on this PR; the hono 1.x→2.x jump is the piece that most wants it.

---
🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)

https://claude.ai/code/session_01AURZd9bPKwQxLqLYeBovsk
