### PR TITLE
chore: remove client project identifiers and guard against recurrence

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -310,7 +310,7 @@
     ]
   },
   "attribution": {
-    "commit": "Co-Authored-By: moflo <noreply@motailz.com>",
+    "commit": "Co-Authored-By: moflo <noreply@cielolimitada.com>",
     "pr": "🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)"
   },
   "env": {

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -182,7 +182,7 @@ git commit -m "type(scope): description
 
 Closes #<issue-number>
 
-Co-Authored-By: moflo <noreply@motailz.com>"
+Co-Authored-By: moflo <noreply@cielolimitada.com>"
 ```
 
 ### 5.1b Verify-before-done (default; skipped only with `--no-verify`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,44 @@ See `feedback_consumer_blast_radius.md` (auto-memory) for the full posture.
 
 ---
 
+## ⚠ Rule #3 — No client or contributor project names, ever
+
+**moflo is open source and installs into consumer projects. A client's project name, personal
+filesystem path, or contact domain appearing anywhere in this repo is a disclosure leak.** Not a
+style nit, and not limited to shipped code — git history is permanent.
+
+**The vector is issue resolution.** These names arrive when an outside project files a PR or issue
+and the fix gets written up citing where the bug was seen. Writing `Symptoms in the wild
+(<their-project>/code)` into a regression test's header feels like good provenance and is exactly
+how 38 files got contaminated — including 9 runtime `output.writeln` banners that printed a client
+domain into every consumer's terminal, and the `Co-Authored-By` trailer `flo init` stamps into
+every consumer's `.claude/settings.json`.
+
+**When resolving an issue or PR that originated outside moflo, never record the reporter's
+identity.** Cite the issue number — that is the durable, non-leaking reference.
+
+Below, `<client>` stands in for the real name — written literally here so these examples do not
+themselves trip the guard.
+
+| Instead of | Write |
+|---|---|
+| `Symptoms in the wild (<client>/code, 4.9.7 → 4.9.8)` | `Symptoms in the wild (a consumer project, 4.9.7 → 4.9.8)` |
+| `/Users/eric/Projects/<client>/code` | `/Users/eric/Projects/consumer-app/code` |
+| `const <client>Block = [...]` | `const consumerBlock = [...]` |
+| `<client>-style stale block` | `consumer-style stale block` |
+| `noreply@<client>.com` | `noreply@cielolimitada.com` |
+
+Applies to every surface: runtime strings, JSDoc headers, test fixture names and paths, commit
+trailers, and `docs/internal/**` post-mortems.
+
+**Enforced by** `tests/guards/client-name-leak-guard.test.ts`, which matches the *shapes* these
+identifiers take (project dir under a home path, contact domain in an email, domain on an
+attribution line) rather than any list of names — so a brand-new name trips it on first use. The
+guard holds no denylist on purpose: spelling the names out to block them would recreate the leak.
+If it goes red, replace the identifier with a neutral placeholder — do not add it to an allowlist.
+
+---
+
 ## ⚠ Dogfooding & local-vs-installed delivery — mandatory reading
 
 MoFlo dogfoods itself: the daemon, hooks, statusline, MCP server, and embeddings indexer ALL run from `node_modules/moflo/...` (NOT from the source tree). Source edits don't take effect for those runtime layers until publish + reinstall + Claude Code restart. Resolving paths between the source tree and the installed package has dist-vs-source depth pitfalls that bite every consumer if you get them wrong.

--- a/docs/internal/1145-daemon-port-collision-analysis.md
+++ b/docs/internal/1145-daemon-port-collision-analysis.md
@@ -14,7 +14,7 @@ Consequences proven on the audit machine:
 
 - **Reads are wrong**: project B's `flo memory stats` / `memory list` / `memory retrieve` return project A's data.
 - **Writes are wrong** (chokepoint surface): project B's MCP `memory_store` / `memory_delete`, `flo memory store/delete` CLI, swarm persistence, aidefence, and write-through-adapter land in project A's `.moflo/moflo.db` — **lost from B, foreign in A**. Indexers and migrations are safe (they bypass HTTP — see §6).
-- **Orphan daemons accumulate**: same-project daemon proliferation. waxstack has TWO live daemons (3118, 3119) because stale-daemon detection failed.
+- **Orphan daemons accumulate**: same-project daemon proliferation. consumer-app has TWO live daemons (3118, 3119) because stale-daemon detection failed.
 - **No surface signal**: nothing logs, no health probe disagrees, daemon.lock contains no port — discovery is impossible without `netstat`.
 
 The original consumer-reported symptom (`memory_stats reports totalEntries:0`) is one downstream effect among seven stacked bugs (§4).
@@ -28,10 +28,10 @@ Three moflo daemons running on the audit machine at the time of investigation:
 | PID | Port | Project | Version | Identity |
 |-----|------|---------|---------|----------|
 | 19580 | 3117 | `C:/Users/eric/Projects/moflo` (moflo-dev) | 4.10.6 | First to bind; owns the default port |
-| 23040 | 3118 | `C:/Users/eric/Projects/motailz/code` (waxstack) | 4.10.7 | **Orphan** — not in any daemon.lock |
-| 30344 | 3119 | `C:/Users/eric/Projects/motailz/code` (waxstack) | 4.10.7 | Current — owns waxstack's `.moflo/daemon.lock` |
+| 23040 | 3118 | `C:/Users/eric/Projects/consumer-app/code` | 4.10.7 | **Orphan** — not in any daemon.lock |
+| 30344 | 3119 | `C:/Users/eric/Projects/consumer-app/code` | 4.10.7 | Current — owns consumer-app's `.moflo/daemon.lock` |
 
-`waxstack/.moflo/daemon.lock`:
+`consumer-app/.moflo/daemon.lock`:
 ```json
 {"pid":30344,"startedAt":1778845531679,"label":"moflo-daemon","version":"4.10.7"}
 ```
@@ -41,7 +41,7 @@ Three moflo daemons running on the audit machine at the time of investigation:
 ### Direct reproducer
 
 ```bash
-# From waxstack, with daemon routing enabled (default):
+# From consumer-app, with daemon routing enabled (default):
 $ flo memory stats
   Total Entries:        0       # LIE. DB has 5,909.
 
@@ -54,7 +54,7 @@ $ MOFLO_DISABLE_DAEMON_ROUTING=1 flo memory stats
 ```
 
 Verified via direct `node:sqlite` open of both DB files:
-- waxstack DB: 5,909 rows; namespaces `guidance` (2,620), `code-map` (1,414), `patterns` (1,297), `tests` (489)
+- consumer-app DB: 5,909 rows; namespaces `guidance` (2,620), `code-map` (1,414), `patterns` (1,297), `tests` (489)
 - moflo-dev DB: 4,364 rows; namespaces `code-map` (1,385), `guidance` (1,018), `patterns` (971), `tests` (852)
 - Different content, totally distinct projects.
 
@@ -66,7 +66,7 @@ $ curl 127.0.0.1:3117/api/memory/list -d '{"limit":5}'
   → moflo-dev rows (4,364 total)
 
 $ curl 127.0.0.1:3118/api/memory/list -d '{"limit":5}'
-  → waxstack rows (5,909 total) — first row: chunk-guidance-analysis-output-location-4
+  → consumer-app rows (5,909 total) — first row: chunk-guidance-analysis-output-location-4
 
 $ curl 127.0.0.1:3119/api/memory/list -d '{"limit":5}'
   → identical to 3118 (same DB file)
@@ -182,21 +182,21 @@ Detailed audit results (parallel to `docs/internal/1054-writer-audit.md` and `98
 
 During the daemon-overlap window:
 
-- **Foreign rows landed in moflo-dev's DB** from every chokepoint write originating in waxstack: MCP `memory_store` (Claude session "remember this", agent memory, hive-mind state), `flo memory store/delete` CLI, swarm coordination, aidefence learnings.
-- **Lost rows from waxstack's DB**: the same writes never reached waxstack's local file. No shadow copy. Data is gone unless the user reconstructs from the foreign DB.
-- **Intact in waxstack**: indexer-populated namespaces (`guidance`, `code-map`, `tests`, `patterns`) and learning-service `learned_patterns` (in-session writes). These bypass HTTP and write direct.
+- **Foreign rows landed in moflo-dev's DB** from every chokepoint write originating in consumer-app: MCP `memory_store` (Claude session "remember this", agent memory, hive-mind state), `flo memory store/delete` CLI, swarm coordination, aidefence learnings.
+- **Lost rows from consumer-app's DB**: the same writes never reached consumer-app's local file. No shadow copy. Data is gone unless the user reconstructs from the foreign DB.
+- **Intact in consumer-app**: indexer-populated namespaces (`guidance`, `code-map`, `tests`, `patterns`) and learning-service `learned_patterns` (in-session writes). These bypass HTTP and write direct.
 - **Intact in moflo-dev (its own namespaces)**: indexers ran direct against moflo-dev's DB too, so its `guidance`/`code-map`/`tests`/`patterns` are correct. The pollution shows up in `learnings`/`tasklist`/`swarm-*`/`default` namespaces (the MCP-store-targeted set).
 
-Spot-check on the audit machine: moflo-dev's `learnings` namespace had 27 entries. Surface inspection of recent rows showed moflo-internal content (e.g., `1140-dead-mjs-collapse-residue`) — no obvious waxstack pollution in the visible sample. A full audit requires diffing every MCP-store-routable namespace against waxstack's expected content. Out of scope for the fix PR; tracked as recovery surface (§10).
+Spot-check on the audit machine: moflo-dev's `learnings` namespace had 27 entries. Surface inspection of recent rows showed moflo-internal content (e.g., `1140-dead-mjs-collapse-residue`) — no obvious consumer-app pollution in the visible sample. A full audit requires diffing every MCP-store-routable namespace against consumer-app's expected content. Out of scope for the fix PR; tracked as recovery surface (§10).
 
 ---
 
 ## 7. Sidecar / HNSW Pollution Status
 
-| File | moflo-dev | waxstack | Polluted? |
+| File | moflo-dev | consumer-app | Polluted? |
 |------|-----------|----------|-----------|
-| `.moflo/moflo.db` | 49 MB, 4,364 rows | 60 MB, 5,909 rows | **Yes** (foreign chokepoint rows in moflo-dev; missing chokepoint rows in waxstack) |
-| `.moflo/hnsw.index` | 7.2 MB | 9.9 MB | **Indirect** — HNSW is rebuilt server-side by the daemon owning the project. waxstack's HNSW reflects waxstack's local DB (correct shape). moflo-dev's HNSW reflects moflo-dev's DB (including foreign rows it absorbed). |
+| `.moflo/moflo.db` | 49 MB, 4,364 rows | 60 MB, 5,909 rows | **Yes** (foreign chokepoint rows in moflo-dev; missing chokepoint rows in consumer-app) |
+| `.moflo/hnsw.index` | 7.2 MB | 9.9 MB | **Indirect** — HNSW is rebuilt server-side by the daemon owning the project. consumer-app's HNSW reflects consumer-app's local DB (correct shape). moflo-dev's HNSW reflects moflo-dev's DB (including foreign rows it absorbed). |
 | `.moflo/embeddings.json` | 317 B | 317 B | LOW — small bookkeeping; not a primary risk |
 | `.moflo/daemon.lock` | per-project, valid PID | per-project, valid PID | **Schema gap** — no port field; clients can't discover bound port |
 | `.moflo/daemon-state.json` | per-project | per-project | OK — describes the daemon's own workers, project-local |
@@ -204,8 +204,8 @@ Spot-check on the audit machine: moflo-dev's `learnings` namespace had 27 entrie
 
 HNSW pollution implications:
 
-- waxstack's `.moflo/hnsw.index` is **complete for direct-write content** (indexers wrote rows + embeddings local; HNSW rebuild covered them). It's **missing vectors** for chokepoint writes that went elsewhere — so semantic-search in waxstack will fail to surface anything the user stored via MCP during the overlap window.
-- moflo-dev's `.moflo/hnsw.index` includes **foreign vectors** for waxstack's chokepoint writes (HNSW rebuild covered the rows physically present in moflo-dev's DB regardless of origin). A search in moflo-dev surfaces waxstack content as plausible hits.
+- consumer-app's `.moflo/hnsw.index` is **complete for direct-write content** (indexers wrote rows + embeddings local; HNSW rebuild covered them). It's **missing vectors** for chokepoint writes that went elsewhere — so semantic-search in consumer-app will fail to surface anything the user stored via MCP during the overlap window.
+- moflo-dev's `.moflo/hnsw.index` includes **foreign vectors** for consumer-app's chokepoint writes (HNSW rebuild covered the rows physically present in moflo-dev's DB regardless of origin). A search in moflo-dev surfaces consumer-app content as plausible hits.
 
 Recovery requires HNSW rebuild after row migration (§10).
 
@@ -307,7 +307,7 @@ Add `GET /api/health` to the daemon (currently 404):
 ```json
 {
   "status": "ok",
-  "projectRoot": "C:\\Users\\eric\\Projects\\motailz\\code",
+  "projectRoot": "C:\\Users\\eric\\Projects\\consumer-app\\code",
   "pid": 30344,
   "version": "4.10.7",
   "uptimeMs": 36043927
@@ -322,7 +322,7 @@ Every client call probes `/api/health` (cached for 5 seconds, invalidated on rou
 
 ### 9.4 Hard-fail on bind failure with non-default port
 
-When `tryListenOnPort` exhausts the deterministic-range candidates and falls into the legacy retry, the daemon **must exit non-zero** rather than stay alive doing internal-worker-only work. Today's silent half-alive state (waxstack PID 30344) is the trap.
+When `tryListenOnPort` exhausts the deterministic-range candidates and falls into the legacy retry, the daemon **must exit non-zero** rather than stay alive doing internal-worker-only work. Today's silent half-alive state (consumer-app PID 30344) is the trap.
 
 Spawn launcher detects the non-zero exit, retries up to N times with exponential backoff, then surfaces to healer.
 

--- a/scripts/smoke-mcp-malformed.mjs
+++ b/scripts/smoke-mcp-malformed.mjs
@@ -1,5 +1,5 @@
 // One-off consumer-realistic smoke for the #1126 healer fix.
-// Stages a `.mcp.json` shaped like the motailz failure (unescaped Windows
+// Stages a `.mcp.json` shaped like the consumer-project failure (unescaped Windows
 // backslashes), runs the shipped checkMcpServers + autoFixCheck against it,
 // and reports before/after state. Not part of the test suite — manual repro
 // for verifying consumer behavior after a dist rebuild.
@@ -17,7 +17,7 @@ fs.writeFileSync(
   JSON.stringify({ name: 'fake-consumer', version: '0.0.0' }, null, 2),
 );
 
-// The exact motailz failure shape: backslash-Windows path inside JSON string
+// The exact consumer-project failure shape: backslash-Windows path inside JSON string
 // without the `\\` escapes. JSON.parse throws on `\U`, `\m`, etc.
 const cliPath = path.join(consumer, 'node_modules', 'moflo', 'bin', 'cli.js');
 const bad =

--- a/src/cli/__tests__/commands/doctor-mcp-malformed.test.ts
+++ b/src/cli/__tests__/commands/doctor-mcp-malformed.test.ts
@@ -90,7 +90,7 @@ describe('inspectMcpConfigs', () => {
   it('returns malformed when .mcp.json has unescaped Windows backslashes', () => {
     // The exact shape that caused #1126 — produced by an older writer that
     // string-concatenated instead of JSON.stringify-ing. `String.raw` keeps
-    // every backslash literal so the on-disk bytes match what motailz had:
+    // every backslash literal so the on-disk bytes match what the consumer project had:
     // `"C:\Users\..."` inside a JSON string is unescaped → JSON.parse throws.
     const bad = String.raw`{
   "mcpServers": {

--- a/src/cli/__tests__/doctor-claudemd-injection-drift.test.ts
+++ b/src/cli/__tests__/doctor-claudemd-injection-drift.test.ts
@@ -87,9 +87,9 @@ describe('checkClaudeMdInjectionDrift — five states', () => {
     expect(result.message).toContain('off');
   });
 
-  it("repairs the motailz-style stale block when the fix is applied", async () => {
-    // Frozen fixture replicating motailz/code/CLAUDE.md (pre-1142 state).
-    const motailzBlock = [
+  it("repairs the consumer-style stale block when the fix is applied", async () => {
+    // Frozen fixture replicating consumer-app/code/CLAUDE.md (pre-1142 state).
+    const consumerBlock = [
       MARKER_START,
       '## MoFlo — AI Agent Orchestration',
       '',
@@ -101,7 +101,7 @@ describe('checkClaudeMdInjectionDrift — five states', () => {
       '`.claude/guidance/shipped/moflo-core-guidance.md`',
       MARKER_END,
     ].join('\n');
-    writeFileSync(join(tmpDir, 'CLAUDE.md'), `# Project\n\n${motailzBlock}\n`);
+    writeFileSync(join(tmpDir, 'CLAUDE.md'), `# Project\n\n${consumerBlock}\n`);
 
     // First check: drifted.
     const before = await checkClaudeMdInjectionDrift();

--- a/src/cli/__tests__/services/claudemd-injection.test.ts
+++ b/src/cli/__tests__/services/claudemd-injection.test.ts
@@ -128,9 +128,9 @@ describe('computeInjectionDrift — five states', () => {
     expect(report.state).toBe('drifted');
   });
 
-  it("treats motailz-style stale block as 'drifted'", () => {
-    // Frozen fixture replicating the broken state captured from motailz/code.
-    const motailzBlock = [
+  it("treats consumer-style stale block as 'drifted'", () => {
+    // Frozen fixture replicating the broken state captured from consumer-app/code.
+    const consumerBlock = [
       MARKER_START,
       '## MoFlo — AI Agent Orchestration',
       '',
@@ -142,7 +142,7 @@ describe('computeInjectionDrift — five states', () => {
       '`.claude/guidance/shipped/moflo-core-guidance.md`',
       MARKER_END,
     ].join('\n');
-    const file = `# Project\n\n${motailzBlock}\n`;
+    const file = `# Project\n\n${consumerBlock}\n`;
     const report = computeInjectionDrift(file, CANONICAL);
     expect(report.state).toBe('drifted');
   });
@@ -201,8 +201,8 @@ describe('applyInjectionReplacement', () => {
     expect(result.state).toBe('in-sync');
   });
 
-  it('repairs the motailz-style fixture to produce in-sync output', () => {
-    const motailzBlock = [
+  it('repairs the consumer-style fixture to produce in-sync output', () => {
+    const consumerBlock = [
       MARKER_START,
       '## MoFlo (old)',
       '',
@@ -210,7 +210,7 @@ describe('applyInjectionReplacement', () => {
       '`.claude/guidance/shipped/moflo-core-guidance.md`',
       MARKER_END,
     ].join('\n');
-    const before = `# Project\n\n${motailzBlock}\n`;
+    const before = `# Project\n\n${consumerBlock}\n`;
 
     const result = applyInjectionReplacement(before, CANONICAL);
     expect(result.changed).toBe(true);

--- a/src/cli/__tests__/services/daemon-port.test.ts
+++ b/src/cli/__tests__/services/daemon-port.test.ts
@@ -222,7 +222,7 @@ describe('JS twin parity (bin/lib/daemon-port.mjs)', () => {
       '/project-a',
       '/project-b-unique',
       'C:\\Users\\eric\\Projects\\moflo',
-      '/Users/eric/Projects/motailz/code',
+      '/Users/eric/Projects/consumer-app/code',
     ];
     for (const p of testPaths) {
       expect(jsTwin.resolveProjectPort(p)).toBe(resolveProjectPort(p));

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -11,7 +11,7 @@
  * - Module communities using Louvain algorithm
  * - Circular dependency detection
  *
- * Created with motailz.com
+ * Created with cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';

--- a/src/cli/commands/claims.ts
+++ b/src/cli/commands/claims.ts
@@ -2,7 +2,7 @@
  * V3 CLI Claims Command
  * Claims-based authorization, permissions, and access control
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -402,7 +402,7 @@ export const claimsCommand: Command = {
       'admin:*   - Administrative operations',
     ]);
     output.writeln();
-    output.writeln(output.dim('Created with ❤️ by motailz.com'));
+    output.writeln(output.dim('Created with ❤️ by cielolimitada.com'));
     return { success: true };
   },
 };

--- a/src/cli/commands/completions.ts
+++ b/src/cli/commands/completions.ts
@@ -2,7 +2,7 @@
  * V3 CLI Completions Command
  * Shell completions for bash, zsh, fish, powershell
  *
- * Created with motailz.com
+ * Created with cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';

--- a/src/cli/commands/deployment.ts
+++ b/src/cli/commands/deployment.ts
@@ -2,7 +2,7 @@
  * V3 CLI Deployment Command
  * Deployment management, environments, rollbacks
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -315,7 +315,7 @@ export const deploymentCommand: Command = {
       'Deployment previews for PRs',
     ]);
     output.writeln();
-    output.writeln(output.dim('Created with ❤️ by motailz.com'));
+    output.writeln(output.dim('Created with ❤️ by cielolimitada.com'));
     return { success: true };
   },
 };

--- a/src/cli/commands/diagnose.ts
+++ b/src/cli/commands/diagnose.ts
@@ -8,7 +8,7 @@
  *
  * All test data is cleaned up after each test — no code or state is left behind.
  *
- * Created with motailz.com
+ * Created with cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -11,7 +11,7 @@
  * so these checks work both in the dev repo AND in consumer projects where
  * moflo is installed under node_modules/moflo/.
  *
- * Created with motailz.com
+ * Created with cielolimitada.com
  */
 
 import { existsSync, readFileSync, statSync } from 'fs';

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -8,7 +8,7 @@
  * `doctor-registry.ts`; rendering helpers live in `doctor-render.ts`.
  * This file is orchestration only.
  *
- * Created with motailz.com
+ * Created with cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';

--- a/src/cli/commands/embeddings.ts
+++ b/src/cli/commands/embeddings.ts
@@ -10,7 +10,7 @@
  * - Neural substrate integration
  * - Persistent SQLite cache
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -1726,7 +1726,7 @@ export const embeddingsCommand: Command = {
       'Hyperbolic: Better hierarchical representation',
     ]);
     output.writeln();
-    output.writeln(output.dim('Created with ❤️ by motailz.com'));
+    output.writeln(output.dim('Created with ❤️ by cielolimitada.com'));
     return { success: true };
   },
 };

--- a/src/cli/commands/github.ts
+++ b/src/cli/commands/github.ts
@@ -4,7 +4,7 @@
  *
  * Uses `gh` CLI for GitHub API calls and project detection from moflo.yaml.
  *
- * Created with motailz.com
+ * Created with cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';

--- a/src/cli/commands/neural.ts
+++ b/src/cli/commands/neural.ts
@@ -2,7 +2,7 @@
  * V3 CLI Neural Command
  * Neural pattern training, MoE, Flash Attention, pattern learning
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -1666,7 +1666,7 @@ export const neuralCommand: Command = {
     output.writeln();
     output.writeln('Use --help with subcommands for more info');
     output.writeln();
-    output.writeln(output.dim('Created with ❤️ by motailz.com'));
+    output.writeln(output.dim('Created with ❤️ by cielolimitada.com'));
     return { success: true };
   },
 };

--- a/src/cli/commands/performance.ts
+++ b/src/cli/commands/performance.ts
@@ -2,7 +2,7 @@
  * V3 CLI Performance Command
  * Performance profiling, benchmarking, optimization, metrics
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -643,7 +643,7 @@ export const performanceCommand: Command = {
       'Memory: Int8 quantized weight storage',
     ]);
     output.writeln();
-    output.writeln(output.dim('Created with ❤️ by motailz.com'));
+    output.writeln(output.dim('Created with ❤️ by cielolimitada.com'));
     return { success: true };
   },
 };

--- a/src/cli/commands/plugins.ts
+++ b/src/cli/commands/plugins.ts
@@ -3,7 +3,7 @@
  * Plugin management, installation, and lifecycle
  * Now uses IPFS-based decentralized registry for discovery
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -922,7 +922,7 @@ export const pluginsCommand: Command = {
     ]);
     output.writeln();
     output.writeln(output.dim('Run "flo plugins list --official" to see all official plugins'));
-    output.writeln(output.dim('Created with ❤️ by motailz.com'));
+    output.writeln(output.dim('Created with ❤️ by cielolimitada.com'));
     return { success: true };
   },
 };

--- a/src/cli/commands/providers.ts
+++ b/src/cli/commands/providers.ts
@@ -2,7 +2,7 @@
  * V3 CLI Providers Command
  * Manage AI providers, models, and configurations
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -251,7 +251,7 @@ export const providersCommand: Command = {
       'Agentic Flow (optimized ONNX with SIMD)',
     ]);
     output.writeln();
-    output.writeln(output.dim('Created with ❤️ by motailz.com'));
+    output.writeln(output.dim('Created with ❤️ by cielolimitada.com'));
     return { success: true };
   },
 };

--- a/src/cli/commands/retire.ts
+++ b/src/cli/commands/retire.ts
@@ -13,7 +13,7 @@
  * `retired-files.json` live at the moflo package root and don't ship to
  * consumer projects.
  *
- * Created with motailz.com
+ * Created with cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';

--- a/src/cli/commands/route.ts
+++ b/src/cli/commands/route.ts
@@ -8,7 +8,7 @@
  * - Confidence scoring
  * - Learning from feedback
  *
- * Created with love by motailz.com
+ * Created with love by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';

--- a/src/cli/commands/security.ts
+++ b/src/cli/commands/security.ts
@@ -2,7 +2,7 @@
  * V3 CLI Security Command
  * Security scanning, CVE detection, threat modeling, vulnerability management
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -599,7 +599,7 @@ export const securityCommand: Command = {
     output.writeln();
     output.writeln('Use --help with subcommands for more info');
     output.writeln();
-    output.writeln(output.dim('Created with ❤️ by motailz.com'));
+    output.writeln(output.dim('Created with ❤️ by cielolimitada.com'));
     return { success: true };
   },
 };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,7 @@
  * V3 CLI Main Entry Point
  * MoFlo V4 CLI
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { Command, CommandContext, CommandResult, CLIError } from './types.js';
@@ -427,7 +427,7 @@ export class CLI {
 
     this.output.writeln(this.output.dim(`Run "${this.name} <command> --help" for command help`));
     this.output.writeln();
-    this.output.writeln(this.output.dim('Created with ❤️ by motailz.com'));
+    this.output.writeln(this.output.dim('Created with ❤️ by cielolimitada.com'));
     this.output.writeln();
   }
 

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -46,7 +46,7 @@ export function generateSettings(options: InitOptions): object {
 
   // Add claude-flow attribution for git commits and PRs
   settings.attribution = {
-    commit: 'Co-Authored-By: moflo <noreply@motailz.com>',
+    commit: 'Co-Authored-By: moflo <noreply@cielolimitada.com>',
     pr: '🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)',
   };
 

--- a/src/cli/mcp-tools/security-tools.ts
+++ b/src/cli/mcp-tools/security-tools.ts
@@ -9,7 +9,7 @@
  * - aidefence_is_safe: Boolean-only quick check
  * - aidefence_has_pii: PII-only check
  *
- * Created with ❤️ by motailz.com
+ * Created with ❤️ by cielolimitada.com
  */
 
 import type { MCPTool, MCPToolResult } from './types.js';

--- a/src/cli/movector/flash-attention.ts
+++ b/src/cli/movector/flash-attention.ts
@@ -12,7 +12,7 @@
  *
  * Target: 2-5x speedup on CPU vs naive attention
  *
- * Created with love by motailz.com
+ * Created with love by cielolimitada.com
  */
 
 // ============================================================================

--- a/src/cli/movector/vector-db.ts
+++ b/src/cli/movector/vector-db.ts
@@ -8,7 +8,7 @@
  *
  * Gracefully degrades when native backend is not available.
  *
- * Created with love by motailz.com
+ * Created with love by cielolimitada.com
  */
 
 // ============================================================================

--- a/src/cli/services/daemon-lock.ts
+++ b/src/cli/services/daemon-lock.ts
@@ -115,7 +115,7 @@ export function acquireDaemonLock(
   //     running but the lock unlinked, and
   // (b) the second-spawn case (lock absent, prior daemon alive) is exactly
   //     the failure mode that produced two-daemons-per-project in #1145's
-  //     waxstack audit.
+  //     consumer-app audit.
   const lockHolderPid = readLockPayload(lock)?.pid;
   reapSameProjectOrphans(projectRoot, pid, lockHolderPid, opts.pidsHint);
 

--- a/src/cli/services/movector-training.ts
+++ b/src/cli/services/movector-training.ts
@@ -9,7 +9,7 @@
  *
  * Backward Compatible: All v1 exported APIs preserved.
  *
- * Created with love by motailz.com
+ * Created with love by cielolimitada.com
  */
 
 import { createLoRAAdapter, type LoRAAdapter } from '../movector/lora-adapter.js';

--- a/src/cli/services/spell-gate.ts
+++ b/src/cli/services/spell-gate.ts
@@ -3,7 +3,7 @@
  * Enforces TaskCreate + memory-first patterns before agent spawning
  * and file exploration. Tracks context bracket by interaction count.
  *
- * Ported from Motailz .claude/scripts/spell-gate.mjs into MoFlo core.
+ * Ported from a consumer project's .claude/scripts/spell-gate.mjs into MoFlo core.
  *
  * Gate types:
  *   check-before-agent     — blocks Agent tool if no TaskCreate or no memory search

--- a/src/cli/suggest.ts
+++ b/src/cli/suggest.ts
@@ -2,7 +2,7 @@
  * V3 CLI Smart Error Suggestions
  * Levenshtein distance and command suggestions
  *
- * Created with motailz.com
+ * Created with cielolimitada.com
  */
 
 /**

--- a/tests/bin/launcher-854-fixes.test.ts
+++ b/tests/bin/launcher-854-fixes.test.ts
@@ -2,7 +2,7 @@
  * Regression tests for issue #854 — partial-migration loops in the
  * SessionStart launcher and the HNSW chicken-and-egg in build-embeddings.
  *
- * Symptoms in the wild (motailz/code, latent across moflo 4.8.x → 4.9.2):
+ * Symptoms in the wild (consumer-app/code, latent across moflo 4.8.x → 4.9.2):
  *   - `.moflo/moflo-version` never landed → every session re-detected the
  *     upgrade and re-ran the same broken sync sequence.
  *   - `.claude/helpers/gate.cjs` (and several others) stayed at the

--- a/tests/bin/launcher-866-bin-anchor.test.ts
+++ b/tests/bin/launcher-866-bin-anchor.test.ts
@@ -2,7 +2,7 @@
  * Regression tests for issue #866 — stale-install repair races indexer chain
  * spawn, leaving an orphan running pre-upgrade argv.
  *
- * Symptom in the wild (motailz, 4.9.7 → 4.9.8 upgrade):
+ * Symptom in the wild (a consumer project, 4.9.7 → 4.9.8 upgrade):
  *   - Launcher spawned `node .claude/scripts/index-all.mjs` from stale 4.9.7
  *     bytes (still has `--force`).
  *   - Section 3 sync overwrote `.claude/scripts/index-all.mjs` ~43 s later.

--- a/tests/bin/launcher-948-retired-prune.test.ts
+++ b/tests/bin/launcher-948-retired-prune.test.ts
@@ -276,7 +276,7 @@ describe('retired-files helper (#948)', () => {
     });
 
     it('prunes when consumer hash matches the 4th-or-later historic shipped version (#1133)', () => {
-      // Reproduces the motailz-style stale-install case the 3-hash cap missed:
+      // Reproduces the consumer-style stale-install case the 3-hash cap missed:
       // consumer installed an older moflo, file content matches a hash that
       // was sliced off the manifest under the legacy 3-cap. With the widened
       // window the manifest carries every historic hash, so the prune fires.
@@ -284,7 +284,7 @@ describe('retired-files helper (#948)', () => {
       const middle = '# moflo 4.7 shipped this\n';
       const newer  = '# moflo 4.8 shipped this\n';
       const newest = '# moflo 4.9 shipped this\n';
-      const consumer = oldest; // motailz-equivalent — frozen on 4.6 content
+      const consumer = oldest; // consumer-equivalent — frozen on 4.6 content
 
       writeAt(root, '.claude/agents/v3/stale.md', consumer);
       const manifestPath = writeManifest([

--- a/tests/bin/launcher-headless-skip.test.ts
+++ b/tests/bin/launcher-headless-skip.test.ts
@@ -2,7 +2,7 @@
  * Regression tests for issue #860 — session-start launcher must early-exit
  * when invoked from a daemon-spawned headless Claude session.
  *
- * Symptoms in the wild (motailz/code, 2026-05-02): the daemon's headless
+ * Symptoms in the wild (consumer-app/code, 2026-05-02): the daemon's headless
  * workers (optimize/testgaps/etc.) spawn `claude --print` with
  * CLAUDE_CODE_HEADLESS=true; each spawned Claude inherits SessionStart
  * hooks, which re-enter this launcher and fork the indexer chain →

--- a/tests/guards/client-name-leak-guard.test.ts
+++ b/tests/guards/client-name-leak-guard.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Structural guard against client / demo project identifiers leaking into the
+ * repo.
+ *
+ * moflo is open source and installs into consumer projects, so any engagement's
+ * project name, personal filesystem path, or contact domain that drifts in here
+ * is a disclosure leak — not a style nit. It has happened: provenance notes from
+ * demo engagements reached 38 tracked files, including runtime `output.writeln`
+ * banners that printed a client domain into every consumer's terminal and the
+ * `Co-Authored-By` trailer that `flo init` stamps into every consumer's
+ * `.claude/settings.json`.
+ *
+ * This guard deliberately holds NO list of forbidden names. A denylist would
+ * have to spell the client names out in an open-source repo and in git history
+ * forever, recreating the leak it exists to prevent — and it could only ever
+ * catch names someone already knew to add. Instead it matches the *shapes* those
+ * identifiers take and allowlists the handful that are legitimately ours, so a
+ * brand-new client name nobody has seen trips it on first use.
+ *
+ * Three shapes, each covering a surface that actually leaked:
+ *   1. a project directory under someone's home dir  (fixture paths, repro notes)
+ *   2. a contact domain in an email address          (the commit trailer)
+ *   3. a domain on an attribution line               (the "Created with" banners)
+ *
+ * If a case here goes RED, do not add the name to an allowlist to silence it —
+ * replace the identifier with a neutral placeholder (`consumer-app`,
+ * `a consumer project`, `example.com`). The allowlists below are for moflo's own
+ * identity and for generic placeholders, nothing else.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT } from './_helpers/eslint-harness.js';
+
+/**
+ * A project directory sitting under a user's home dir. Covers POSIX
+ * (`/Users/…`, `/home/…`) and Windows (`C:\Users\…`, `C:/Users/…`), and both
+ * single- and double-escaped separators so JSON/TS string literals match too.
+ */
+const HOME_PROJECT_PATH =
+  /(?:\/Users\/|\/home\/|[A-Za-z]:[\\/]{1,2}Users[\\/]{1,2})[A-Za-z0-9._-]+[\\/]{1,2}(?:Projects|projects|Development|dev|repos|workspace|src)[\\/]{1,2}([A-Za-z0-9._-]+)/g;
+
+const EMAIL_DOMAIN = /[A-Za-z0-9._%-]+@((?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,})/g;
+
+const ATTRIBUTION_LINE = /created with|built by|crafted by|made by/i;
+const DOMAIN_TOKEN = /\b((?:[A-Za-z0-9-]+\.)+(?:com|net|org|io|dev|ai|co))\b/g;
+
+/** moflo's own project dir, plus neutral placeholders used in fixtures. */
+const ALLOWED_PROJECT_DIRS = new Set([
+  'moflo',
+  'consumer-app',
+  'some_project',
+  'some_project.v2',
+  'project-a',
+  'project-b',
+  'my-project',
+  'test-project',
+  'example',
+  'foo',
+  'bar',
+]);
+
+/** moflo's own domains, plus RFC-style placeholder domains. */
+const ALLOWED_DOMAINS = new Set([
+  'cielolimitada.com',
+  'github.com',
+  'users.noreply.github.com',
+  'anthropic.com',
+  'npmjs.com',
+  'example.com',
+  'example.org',
+  'test.com',
+  'domain.com',
+  'email.com',
+  'vendor.com',
+  'e.com',
+  'moflo.test',
+  'db.internal',
+]);
+
+/**
+ * Lockfiles carry third-party maintainer emails, which are neither ours to
+ * change nor a client leak. This guard's own source is skipped because it
+ * describes the patterns it hunts for.
+ */
+const SKIP_FILES = new Set([
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  join('tests', 'guards', 'client-name-leak-guard.test.ts').split(/[\\/]/).join('/'),
+]);
+
+export interface Leak {
+  kind: 'project-dir' | 'email-domain' | 'attribution-domain';
+  value: string;
+}
+
+/** Pure scanner so the shapes can be exercised without touching the tree. */
+export function scanText(text: string): Leak[] {
+  const leaks: Leak[] = [];
+
+  for (const m of text.matchAll(HOME_PROJECT_PATH)) {
+    if (!ALLOWED_PROJECT_DIRS.has(m[1])) leaks.push({ kind: 'project-dir', value: m[1] });
+  }
+
+  for (const m of text.matchAll(EMAIL_DOMAIN)) {
+    if (!ALLOWED_DOMAINS.has(m[1])) leaks.push({ kind: 'email-domain', value: m[1] });
+  }
+
+  for (const line of text.split(/\r?\n/)) {
+    if (!ATTRIBUTION_LINE.test(line)) continue;
+    for (const m of line.matchAll(DOMAIN_TOKEN)) {
+      if (!ALLOWED_DOMAINS.has(m[1])) leaks.push({ kind: 'attribution-domain', value: m[1] });
+    }
+  }
+
+  return leaks;
+}
+
+function trackedTextFiles(): string[] {
+  // execFileSync + array args: no shell, so this behaves identically on Windows.
+  // `-z` (NUL-delimited) because git quote-escapes non-ASCII paths under the
+  // default core.quotePath — those entries would then fail to read and be
+  // silently skipped, i.e. unscanned, which is the one failure mode a leak
+  // guard must not have. NUL output is also immune to newlines in filenames.
+  // maxBuffer is explicit: the default is 1 MB and this listing is ~60 KB today,
+  // but a silent ENOBUFS as the repo grows would look like a guard bug rather
+  // than an outgrown buffer.
+  return execFileSync('git', ['ls-files', '-z'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+    .split('\u0000')
+    .filter(Boolean)
+    .filter((rel) => !SKIP_FILES.has(rel));
+}
+
+describe('client-name leak guard — project dir under a home path', () => {
+  it('flags an unknown project dir in a POSIX path', () => {
+    expect(scanText("const root = '/Users/dev/Projects/acme-portal/code';")).toContainEqual({
+      kind: 'project-dir',
+      value: 'acme-portal',
+    });
+  });
+
+  it('flags an unknown project dir in a Windows path, including escaped separators', () => {
+    expect(scanText('"projectRoot": "C:\\\\Users\\\\dev\\\\Projects\\\\acme-portal\\\\code"'))
+      .toContainEqual({ kind: 'project-dir', value: 'acme-portal' });
+  });
+
+  it('allows moflo and the neutral placeholder', () => {
+    expect(scanText("'/Users/dev/Projects/moflo'")).toEqual([]);
+    expect(scanText("'/Users/dev/Projects/consumer-app/code'")).toEqual([]);
+  });
+});
+
+describe('client-name leak guard — contact domain', () => {
+  it('flags a non-placeholder domain in an email address', () => {
+    expect(scanText('Co-Authored-By: moflo <noreply@acme-portal.com>')).toContainEqual({
+      kind: 'email-domain',
+      value: 'acme-portal.com',
+    });
+  });
+
+  it('allows the moflo trailer and placeholder domains', () => {
+    expect(scanText('Co-Authored-By: moflo <noreply@cielolimitada.com>')).toEqual([]);
+    expect(scanText('const user = "someone@example.com";')).toEqual([]);
+  });
+});
+
+describe('client-name leak guard — attribution banner', () => {
+  it('flags a foreign domain on an attribution line', () => {
+    expect(scanText(' * Created with love by acme-portal.com')).toContainEqual({
+      kind: 'attribution-domain',
+      value: 'acme-portal.com',
+    });
+  });
+
+  it('flags the runtime-banner form too', () => {
+    expect(scanText("output.writeln(output.dim('Created with \u2764 by acme-portal.com'));"))
+      .toContainEqual({ kind: 'attribution-domain', value: 'acme-portal.com' });
+  });
+
+  it('allows the moflo attribution', () => {
+    expect(scanText(' * Created with \u2764 by cielolimitada.com')).toEqual([]);
+  });
+
+  it('ignores domains on non-attribution lines', () => {
+    expect(scanText('See https://some-vendor-docs.io/guide for details')).toEqual([]);
+  });
+});
+
+describe('client-name leak guard — live fire over tracked files', () => {
+  it('finds no client identifiers anywhere in the tracked tree', () => {
+    const offenders: string[] = [];
+
+    for (const rel of trackedTextFiles()) {
+      let text: string;
+      try {
+        text = readFileSync(join(REPO_ROOT, rel), 'utf8');
+      } catch {
+        continue; // unreadable or removed between ls-files and read
+      }
+      if (text.includes('\u0000')) continue; // binary
+
+      for (const leak of scanText(text)) {
+        offenders.push(`${rel}: ${leak.kind} -> ${leak.value}`);
+      }
+    }
+
+    // Printed in full so a failure names the file and the identifier directly.
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Removes two outside project identifiers that had drifted into the repo, and adds a structural guard so a new one trips on first use.

## Why

moflo is open source and installs into consumer projects, so a client's project name, personal filesystem path, or contact domain in this repo is a disclosure leak rather than a style nit.

The identifiers arrived via issue resolution: an outside project filed a PR or issue, and the fix write-up cited where the bug was seen. That is how 38 files became contaminated.

Two surfaces had real consumer blast radius:

- **9 runtime `output.writeln` banners** printed a client domain into every consumer's terminal
- **`src/cli/init/settings-generator.ts`** stamped a `Co-Authored-By` trailer with that domain into every consumer's `.claude/settings.json` on `flo init`

## Changes

**Scrubbed — 38 files, 4 surfaces**

| Surface | Count |
|---|---|
| Runtime attribution banners | 9 |
| JSDoc file-header banners | 22 |
| `Co-Authored-By` trailer sites | 3 |
| Provenance notes, fixture names, fixture paths in tests + `docs/internal/**` | 24 |

Attribution and the commit trailer now use the project's own domain. Provenance references use neutral placeholders (`a consumer project`, `consumer-app`, `consumerBlock`) that keep the why-this-test-exists context without the name.

**Added — `tests/guards/client-name-leak-guard.test.ts`**

The guard holds **no denylist by design**: spelling the names out to block them would record them in an open-source repo and in git history permanently — recreating the leak it exists to prevent — and could only ever catch names someone already knew to add.

It instead matches the *shapes* these identifiers take, against an allowlist of values that are legitimately ours:

1. a project directory under a home path (`/Users/…`, `/home/…`, `C:\Users\…`, including escaped separators)
2. a contact domain in an email address
3. a domain on an attribution line

So an unseen name trips it on first use. 10 tests — positive and negative per shape, plus a live-fire scan over all 1,501 tracked files.

**Added — CLAUDE.md Rule #3**

Addresses the authoring path so the names are not written in the first place: when resolving an outside issue or PR, cite the issue number, never the reporter's identity. Includes a before/after table.

## Verification

- Full suite: **9,616 passed, 0 failed**
- `tsc --noEmit`, `npm run lint`, `npm run build` — all exit 0
- Guard proven to fail red against a staged canary, then green after removal
- Final sweep across tracked source **and** built `dist/`: zero occurrences
- Rule #3 confirmed to sit outside the `MOFLO:INJECTED` block, so regeneration will not clobber it

## Notes for review

- `src/cli/services/daemon-lock.ts` is the only shipped-source behaviour-adjacent file touched, and the change is a comment.
- The two `tests/bin/launcher-*` files are in `vitest.config.ts`'s `isolationTests`, so they were run separately via `vitest.isolation.config.ts` (24 tests, both pass).
- Git history still contains the identifiers. A rewrite was scoped and deliberately declined: 289 published npm versions are immutable and carry the same strings, so full erasure is unachievable, and a rewrite of 1,368 commits would break every clone and open PR for partial benefit.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
