### PR TITLE
fix(indexer): index .mjs/.cjs so the hook/gate runtime is searchable (#1337)

### DIFF
--- a/.claude/scripts/generate-code-map.mjs
+++ b/.claude/scripts/generate-code-map.mjs
@@ -168,7 +168,7 @@ function readCodeMapConfig() {
   const defaults = {
     directories: ['src'],
     extensions: [
-      '.ts', '.tsx', '.js', '.mjs', '.jsx',         // JS/TS
+      '.ts', '.tsx', '.js', '.mjs', '.cjs', '.jsx', // JS/TS
       '.py', '.pyi',                                  // Python
       '.go',                                           // Go
       '.java', '.kt', '.kts',                         // JVM
@@ -210,6 +210,18 @@ function readCodeMapConfig() {
   } catch { return defaults; }
 }
 
+/**
+ * Extension of `p`, lowercased.
+ *
+ * Rule #1: NTFS (Windows) and APFS (macOS) are case-insensitive by default, so a
+ * file committed as `Foo.MJS` is routine there. `extname()` returns the literal
+ * `.MJS` on every platform — including Linux — so an exact compare against a
+ * lowercase list silently skips the file everywhere. Normalise both sides. (#1337)
+ */
+function normExt(p) {
+  return extname(p).toLowerCase();
+}
+
 /** Walk a directory tree collecting source files (filesystem fallback). */
 function walkDir(dir, extensions, excludeSet, maxDepth = 8, depth = 0) {
   if (depth > maxDepth) return [];
@@ -225,8 +237,7 @@ function walkDir(dir, extensions, excludeSet, maxDepth = 8, depth = 0) {
     if (entry.isDirectory()) {
       results.push(...walkDir(rel, extensions, excludeSet, maxDepth, depth + 1));
     } else if (entry.isFile()) {
-      const ext = extname(entry.name);
-      if (extensions.has(ext)) results.push(rel);
+      if (extensions.has(normExt(entry.name))) results.push(rel);
     }
   }
   return results;
@@ -234,11 +245,18 @@ function walkDir(dir, extensions, excludeSet, maxDepth = 8, depth = 0) {
 
 function getSourceFiles() {
   const config = readCodeMapConfig();
-  const extSet = new Set(config.extensions);
+  // Lowercase the configured list too, so `extensions: [".MJS"]` in a consumer's
+  // moflo.yaml still matches the normalised extension of a scanned file.
+  const extSet = new Set(config.extensions.map(e => e.toLowerCase()));
   const excludeSet = new Set(config.exclude);
 
-  // Build git glob patterns from configured extensions
-  const gitGlobArgs = config.extensions.map(ext => `*${ext}`);
+  // Build git glob patterns from configured extensions.
+  // `:(icase)` is required, not cosmetic: git pathspec globs are case-sensitive
+  // regardless of `core.ignorecase` (verified on git 2.43 with the setting both
+  // on and off), so a bare `*.mjs` misses a committed `Foo.MJS` on every
+  // platform. This is the primary enumeration path — normalising `extname()` in
+  // the filesystem fallback alone would leave it broken. (#1337)
+  const gitGlobArgs = config.extensions.map(ext => `:(icase)*${ext}`);
 
   // Try git ls-files first (fast, respects .gitignore)
   try {
@@ -415,19 +433,48 @@ const EXT_TO_LANG = {
 
 const ENTITY_DECORATOR = /@Entity\s*\(/;
 
-function extractTypes(filePath) {
+/**
+ * Dispatch-command string literals (`case 'check-before-done':`).
+ *
+ * Symbol extraction alone leaves command routers unsearchable: in `bin/gate.cjs`
+ * the gate names exist only as `case` labels, so the one token a agent would
+ * actually query on ("check-before-done") never reached the index. Indexing the
+ * file made it present but still unfindable. (#1337)
+ *
+ * Deliberately narrow — `case` labels only, and only those bearing an internal
+ * separator, so it adds routing vocabulary without pulling in arbitrary strings.
+ */
+const DISPATCH_CASE = /\bcase\s+['"`]([A-Za-z][\w.:-]{2,60})['"`]\s*:/g;
+const MAX_COMMANDS = 40;
+
+function extractDispatchCommands(content) {
+  const found = new Set();
+  for (const m of content.matchAll(DISPATCH_CASE)) {
+    // Internal separator required: skips bare enum-ish words (`case 'open':`)
+    // while keeping real command names (`check-before-pr`, `hooks:post-edit`).
+    if (/[.:-]/.test(m[1])) found.add(m[1]);
+    if (found.size >= MAX_COMMANDS) break;
+  }
+  return [...found];
+}
+
+/**
+ * Read a source file once and extract both its type declarations and its
+ * dispatch-command literals. Single read: `generateFileEntries` used to
+ * re-open every file for commands, doubling I/O across the whole tree.
+ */
+function extractFileFacts(filePath) {
   const fullPath = resolve(projectRoot, filePath);
-  if (!existsSync(fullPath)) return [];
+  if (!existsSync(fullPath)) return { types: [], commands: [] };
 
   let content;
   try {
     content = readFileSync(fullPath, 'utf-8');
   } catch {
-    return [];
+    return { types: [], commands: [] };
   }
 
-  const ext = extname(filePath);
-  const lang = EXT_TO_LANG[ext] || 'ts';
+  const lang = EXT_TO_LANG[normExt(filePath)] || 'ts';
   const patterns = LANG_PATTERNS[lang] || LANG_PATTERNS.ts;
 
   const lines = content.split('\n');
@@ -471,7 +518,7 @@ function extractTypes(filePath) {
     }
   }
 
-  return types;
+  return { types, commands: extractDispatchCommands(content) };
 }
 
 function detectKind(line, name, lang) {
@@ -516,7 +563,6 @@ function getDirDescription(dirName) {
 }
 
 function detectLanguage(filePath) {
-  const ext = extname(filePath);
   const langMap = {
     '.tsx': 'React/TypeScript', '.jsx': 'React/JavaScript',
     '.ts': 'TypeScript', '.mjs': 'ESM', '.cjs': 'CommonJS', '.js': 'JavaScript',
@@ -530,7 +576,7 @@ function detectLanguage(filePath) {
     '.php': 'PHP',
     '.c': 'C', '.h': 'C/C++ Header', '.cpp': 'C++', '.hpp': 'C++ Header', '.cc': 'C++',
   };
-  return langMap[ext] || 'Unknown';
+  return langMap[normExt(filePath)] || 'Unknown';
 }
 
 // ---------------------------------------------------------------------------
@@ -714,7 +760,7 @@ function generateTypeIndex(allTypes) {
  * This enables precise semantic search: a query for "CompanyAuditLog" will match
  * the specific file entry rather than being diluted across a batch of 80 types.
  */
-function generateFileEntries(typesByFile) {
+function generateFileEntries(typesByFile, commandsByFile) {
   const chunks = [];
 
   for (const [filePath, types] of Object.entries(typesByFile)) {
@@ -742,6 +788,11 @@ function generateFileEntries(typesByFile) {
       // For files without detected exports, include a summary line
       // so the file is still discoverable via semantic search
       content += '\nSource file (no detected exports)\n';
+    }
+
+    const commands = commandsByFile[filePath];
+    if (commands && commands.length > 0) {
+      content += `\nHandles commands: ${commands.join(', ')}\n`;
     }
 
     // Build tags for filtering
@@ -833,17 +884,19 @@ async function main() {
   const typesByProject = {};
   const typesByDir = {};
   const typesByFile = {};
+  const commandsByFile = {};
 
   for (const file of files) {
     const project = getProjectName(file);
     if (!filesByProject[project]) filesByProject[project] = [];
     filesByProject[project].push(file);
 
-    const types = extractTypes(file);
+    const { types, commands } = extractFileFacts(file);
 
     // Track ALL files for file-level entries (not just those with types)
     // This ensures plain JS projects without explicit exports still get indexed
     typesByFile[file] = types;
+    if (commands.length > 0) commandsByFile[file] = commands;
 
     for (const t of types) {
       allTypes.push(t);
@@ -866,7 +919,7 @@ async function main() {
   const dirChunks = generateDirectoryDetails(typesByDir);
   const ifaceChunks = generateInterfaceMaps(allTypes);
   const typeIdxChunks = generateTypeIndex(allTypes);
-  const fileChunks = generateFileEntries(typesByFile);
+  const fileChunks = generateFileEntries(typesByFile, commandsByFile);
 
   const allChunks = [...projectChunks, ...dirChunks, ...ifaceChunks, ...typeIdxChunks, ...fileChunks];
 

--- a/.claude/scripts/index-patterns.mjs
+++ b/.claude/scripts/index-patterns.mjs
@@ -48,7 +48,7 @@ const statsOnly = args.includes('--stats');
 function log(msg) { console.log(`[index-patterns] ${msg}`); }
 function debug(msg) { if (verbose) console.log(`[index-patterns]   ${msg}`); }
 
-const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.py', '.go', '.rs']);
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.go', '.rs']);
 const EXCLUDE_DIRS = new Set([
   'node_modules', 'dist', 'build', '.next', 'coverage',
   '.claude', '.swarm', '.moflo', '.git', 'template',
@@ -123,7 +123,7 @@ function collectSourceFiles(dir, maxDepth = 8, depth = 0) {
     const fullPath = resolve(dir, entry.name);
     if (entry.isDirectory()) {
       files.push(...collectSourceFiles(fullPath, maxDepth, depth + 1));
-    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(extname(entry.name))) {
+    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
       files.push(fullPath);
     }
   }

--- a/.claude/scripts/index-tests.mjs
+++ b/.claude/scripts/index-tests.mjs
@@ -58,7 +58,7 @@ const TEST_FILE_PATTERNS = [
   /\.test-\w+\.\w+$/,
 ];
 
-const TEST_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs']);
+const TEST_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
 
 const EXCLUDE_DIRS = new Set([
   'node_modules', 'dist', 'build', '.next', 'coverage',
@@ -193,8 +193,10 @@ function getTestFiles() {
   // Strategy 1: git ls-files for tracked test files
   let gitFiles = [];
   try {
+    // `:(icase)` — git pathspec globs are case-sensitive regardless of
+    // core.ignorecase, so `Foo.Test.mjs` would otherwise be skipped (#1337).
     const raw = execFileSync(
-      'git', ['ls-files', '--', '*.test.*', '*.spec.*', '*.test-*'],
+      'git', ['ls-files', '--', ':(icase)*.test.*', ':(icase)*.spec.*', ':(icase)*.test-*'],
       { cwd: projectRoot, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, windowsHide: true }
     ).trim();
 
@@ -207,7 +209,7 @@ function getTestFiles() {
             if (f.startsWith(ex + '/')) return false;
           }
           // Only include recognized extensions
-          const ext = extname(f);
+          const ext = extname(f).toLowerCase();
           return TEST_EXTENSIONS.has(ext);
         });
     }
@@ -239,7 +241,7 @@ function walkTestFiles(dir, results) {
           walkTestFiles(resolve(dir, entry.name), results);
         }
       } else if (entry.isFile()) {
-        const ext = extname(entry.name);
+        const ext = extname(entry.name).toLowerCase();
         if (!TEST_EXTENSIONS.has(ext)) continue;
 
         // Include if it matches test patterns OR if it's inside a test directory

--- a/bin/generate-code-map.mjs
+++ b/bin/generate-code-map.mjs
@@ -168,7 +168,7 @@ function readCodeMapConfig() {
   const defaults = {
     directories: ['src'],
     extensions: [
-      '.ts', '.tsx', '.js', '.mjs', '.jsx',         // JS/TS
+      '.ts', '.tsx', '.js', '.mjs', '.cjs', '.jsx', // JS/TS
       '.py', '.pyi',                                  // Python
       '.go',                                           // Go
       '.java', '.kt', '.kts',                         // JVM
@@ -210,6 +210,18 @@ function readCodeMapConfig() {
   } catch { return defaults; }
 }
 
+/**
+ * Extension of `p`, lowercased.
+ *
+ * Rule #1: NTFS (Windows) and APFS (macOS) are case-insensitive by default, so a
+ * file committed as `Foo.MJS` is routine there. `extname()` returns the literal
+ * `.MJS` on every platform — including Linux — so an exact compare against a
+ * lowercase list silently skips the file everywhere. Normalise both sides. (#1337)
+ */
+function normExt(p) {
+  return extname(p).toLowerCase();
+}
+
 /** Walk a directory tree collecting source files (filesystem fallback). */
 function walkDir(dir, extensions, excludeSet, maxDepth = 8, depth = 0) {
   if (depth > maxDepth) return [];
@@ -225,8 +237,7 @@ function walkDir(dir, extensions, excludeSet, maxDepth = 8, depth = 0) {
     if (entry.isDirectory()) {
       results.push(...walkDir(rel, extensions, excludeSet, maxDepth, depth + 1));
     } else if (entry.isFile()) {
-      const ext = extname(entry.name);
-      if (extensions.has(ext)) results.push(rel);
+      if (extensions.has(normExt(entry.name))) results.push(rel);
     }
   }
   return results;
@@ -234,11 +245,18 @@ function walkDir(dir, extensions, excludeSet, maxDepth = 8, depth = 0) {
 
 function getSourceFiles() {
   const config = readCodeMapConfig();
-  const extSet = new Set(config.extensions);
+  // Lowercase the configured list too, so `extensions: [".MJS"]` in a consumer's
+  // moflo.yaml still matches the normalised extension of a scanned file.
+  const extSet = new Set(config.extensions.map(e => e.toLowerCase()));
   const excludeSet = new Set(config.exclude);
 
-  // Build git glob patterns from configured extensions
-  const gitGlobArgs = config.extensions.map(ext => `*${ext}`);
+  // Build git glob patterns from configured extensions.
+  // `:(icase)` is required, not cosmetic: git pathspec globs are case-sensitive
+  // regardless of `core.ignorecase` (verified on git 2.43 with the setting both
+  // on and off), so a bare `*.mjs` misses a committed `Foo.MJS` on every
+  // platform. This is the primary enumeration path — normalising `extname()` in
+  // the filesystem fallback alone would leave it broken. (#1337)
+  const gitGlobArgs = config.extensions.map(ext => `:(icase)*${ext}`);
 
   // Try git ls-files first (fast, respects .gitignore)
   try {
@@ -415,19 +433,48 @@ const EXT_TO_LANG = {
 
 const ENTITY_DECORATOR = /@Entity\s*\(/;
 
-function extractTypes(filePath) {
+/**
+ * Dispatch-command string literals (`case 'check-before-done':`).
+ *
+ * Symbol extraction alone leaves command routers unsearchable: in `bin/gate.cjs`
+ * the gate names exist only as `case` labels, so the one token a agent would
+ * actually query on ("check-before-done") never reached the index. Indexing the
+ * file made it present but still unfindable. (#1337)
+ *
+ * Deliberately narrow — `case` labels only, and only those bearing an internal
+ * separator, so it adds routing vocabulary without pulling in arbitrary strings.
+ */
+const DISPATCH_CASE = /\bcase\s+['"`]([A-Za-z][\w.:-]{2,60})['"`]\s*:/g;
+const MAX_COMMANDS = 40;
+
+function extractDispatchCommands(content) {
+  const found = new Set();
+  for (const m of content.matchAll(DISPATCH_CASE)) {
+    // Internal separator required: skips bare enum-ish words (`case 'open':`)
+    // while keeping real command names (`check-before-pr`, `hooks:post-edit`).
+    if (/[.:-]/.test(m[1])) found.add(m[1]);
+    if (found.size >= MAX_COMMANDS) break;
+  }
+  return [...found];
+}
+
+/**
+ * Read a source file once and extract both its type declarations and its
+ * dispatch-command literals. Single read: `generateFileEntries` used to
+ * re-open every file for commands, doubling I/O across the whole tree.
+ */
+function extractFileFacts(filePath) {
   const fullPath = resolve(projectRoot, filePath);
-  if (!existsSync(fullPath)) return [];
+  if (!existsSync(fullPath)) return { types: [], commands: [] };
 
   let content;
   try {
     content = readFileSync(fullPath, 'utf-8');
   } catch {
-    return [];
+    return { types: [], commands: [] };
   }
 
-  const ext = extname(filePath);
-  const lang = EXT_TO_LANG[ext] || 'ts';
+  const lang = EXT_TO_LANG[normExt(filePath)] || 'ts';
   const patterns = LANG_PATTERNS[lang] || LANG_PATTERNS.ts;
 
   const lines = content.split('\n');
@@ -471,7 +518,7 @@ function extractTypes(filePath) {
     }
   }
 
-  return types;
+  return { types, commands: extractDispatchCommands(content) };
 }
 
 function detectKind(line, name, lang) {
@@ -516,7 +563,6 @@ function getDirDescription(dirName) {
 }
 
 function detectLanguage(filePath) {
-  const ext = extname(filePath);
   const langMap = {
     '.tsx': 'React/TypeScript', '.jsx': 'React/JavaScript',
     '.ts': 'TypeScript', '.mjs': 'ESM', '.cjs': 'CommonJS', '.js': 'JavaScript',
@@ -530,7 +576,7 @@ function detectLanguage(filePath) {
     '.php': 'PHP',
     '.c': 'C', '.h': 'C/C++ Header', '.cpp': 'C++', '.hpp': 'C++ Header', '.cc': 'C++',
   };
-  return langMap[ext] || 'Unknown';
+  return langMap[normExt(filePath)] || 'Unknown';
 }
 
 // ---------------------------------------------------------------------------
@@ -714,7 +760,7 @@ function generateTypeIndex(allTypes) {
  * This enables precise semantic search: a query for "CompanyAuditLog" will match
  * the specific file entry rather than being diluted across a batch of 80 types.
  */
-function generateFileEntries(typesByFile) {
+function generateFileEntries(typesByFile, commandsByFile) {
   const chunks = [];
 
   for (const [filePath, types] of Object.entries(typesByFile)) {
@@ -742,6 +788,11 @@ function generateFileEntries(typesByFile) {
       // For files without detected exports, include a summary line
       // so the file is still discoverable via semantic search
       content += '\nSource file (no detected exports)\n';
+    }
+
+    const commands = commandsByFile[filePath];
+    if (commands && commands.length > 0) {
+      content += `\nHandles commands: ${commands.join(', ')}\n`;
     }
 
     // Build tags for filtering
@@ -833,17 +884,19 @@ async function main() {
   const typesByProject = {};
   const typesByDir = {};
   const typesByFile = {};
+  const commandsByFile = {};
 
   for (const file of files) {
     const project = getProjectName(file);
     if (!filesByProject[project]) filesByProject[project] = [];
     filesByProject[project].push(file);
 
-    const types = extractTypes(file);
+    const { types, commands } = extractFileFacts(file);
 
     // Track ALL files for file-level entries (not just those with types)
     // This ensures plain JS projects without explicit exports still get indexed
     typesByFile[file] = types;
+    if (commands.length > 0) commandsByFile[file] = commands;
 
     for (const t of types) {
       allTypes.push(t);
@@ -866,7 +919,7 @@ async function main() {
   const dirChunks = generateDirectoryDetails(typesByDir);
   const ifaceChunks = generateInterfaceMaps(allTypes);
   const typeIdxChunks = generateTypeIndex(allTypes);
-  const fileChunks = generateFileEntries(typesByFile);
+  const fileChunks = generateFileEntries(typesByFile, commandsByFile);
 
   const allChunks = [...projectChunks, ...dirChunks, ...ifaceChunks, ...typeIdxChunks, ...fileChunks];
 

--- a/bin/index-patterns.mjs
+++ b/bin/index-patterns.mjs
@@ -48,7 +48,7 @@ const statsOnly = args.includes('--stats');
 function log(msg) { console.log(`[index-patterns] ${msg}`); }
 function debug(msg) { if (verbose) console.log(`[index-patterns]   ${msg}`); }
 
-const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.py', '.go', '.rs']);
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.go', '.rs']);
 const EXCLUDE_DIRS = new Set([
   'node_modules', 'dist', 'build', '.next', 'coverage',
   '.claude', '.swarm', '.moflo', '.git', 'template',
@@ -123,7 +123,7 @@ function collectSourceFiles(dir, maxDepth = 8, depth = 0) {
     const fullPath = resolve(dir, entry.name);
     if (entry.isDirectory()) {
       files.push(...collectSourceFiles(fullPath, maxDepth, depth + 1));
-    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(extname(entry.name))) {
+    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
       files.push(fullPath);
     }
   }

--- a/bin/index-tests.mjs
+++ b/bin/index-tests.mjs
@@ -58,7 +58,7 @@ const TEST_FILE_PATTERNS = [
   /\.test-\w+\.\w+$/,
 ];
 
-const TEST_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs']);
+const TEST_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
 
 const EXCLUDE_DIRS = new Set([
   'node_modules', 'dist', 'build', '.next', 'coverage',
@@ -193,8 +193,10 @@ function getTestFiles() {
   // Strategy 1: git ls-files for tracked test files
   let gitFiles = [];
   try {
+    // `:(icase)` — git pathspec globs are case-sensitive regardless of
+    // core.ignorecase, so `Foo.Test.mjs` would otherwise be skipped (#1337).
     const raw = execFileSync(
-      'git', ['ls-files', '--', '*.test.*', '*.spec.*', '*.test-*'],
+      'git', ['ls-files', '--', ':(icase)*.test.*', ':(icase)*.spec.*', ':(icase)*.test-*'],
       { cwd: projectRoot, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, windowsHide: true }
     ).trim();
 
@@ -207,7 +209,7 @@ function getTestFiles() {
             if (f.startsWith(ex + '/')) return false;
           }
           // Only include recognized extensions
-          const ext = extname(f);
+          const ext = extname(f).toLowerCase();
           return TEST_EXTENSIONS.has(ext);
         });
     }
@@ -239,7 +241,7 @@ function walkTestFiles(dir, results) {
           walkTestFiles(resolve(dir, entry.name), results);
         }
       } else if (entry.isFile()) {
-        const ext = extname(entry.name);
+        const ext = extname(entry.name).toLowerCase();
         if (!TEST_EXTENSIONS.has(ext)) continue;
 
         // Include if it matches test patterns OR if it's inside a test directory

--- a/moflo.yaml
+++ b/moflo.yaml
@@ -16,7 +16,7 @@ guidance:
 code_map:
   directories:
     - src
-  extensions: [".js", ".ts"]
+  extensions: [".js", ".ts", ".mjs", ".cjs"]
   exclude: [node_modules, dist, .next, coverage, build, __pycache__, target, .git]
   namespace: code-map
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2468,9 +2468,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2468,9 +2468,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2858,9 +2858,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "picomatch": ">=2.3.2",
     "protobufjs": ">=7.5.5",
     "adm-zip": ">=0.6.0",
-    "fast-uri": ">=3.1.5 <4.0.0",
+    "fast-uri": ">=4.1.2",
     "ip-address": ">=10.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
     "hono": ">=4.12.25",
     "picomatch": ">=2.3.2",
     "protobufjs": ">=7.5.5",
-    "adm-zip": ">=0.6.0"
+    "adm-zip": ">=0.6.0",
+    "fast-uri": ">=3.1.5 <4.0.0",
+    "ip-address": ">=10.4.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",

--- a/src/cli/__tests__/code-map-extensions.test.ts
+++ b/src/cli/__tests__/code-map-extensions.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Regression tests for #1337 — `.mjs`/`.cjs` were excluded from the code-map,
+ * making moflo's entire hook/gate/launcher runtime invisible to `memory_search`
+ * while the `memory_first` gate blocked the tools that would have found it.
+ *
+ * Two distinct defects are covered:
+ *
+ *   1. Extension coverage — `.cjs` was absent from the indexer defaults, from
+ *      the pattern/test indexers, and (the consumer-facing root cause) from the
+ *      `SOURCE_EXTENSIONS` list that `flo init` uses to write every consumer's
+ *      `code_map.extensions`. Because an explicit `extensions:` key shadows the
+ *      indexer defaults, fixing the defaults alone fixed nothing downstream.
+ *
+ *   2. Case normalisation (Rule #1) — `extname()` returns the literal `.MJS`
+ *      for a file committed as `Foo.MJS` on *every* platform, and git pathspec
+ *      globs are case-sensitive regardless of `core.ignorecase`. NTFS and APFS
+ *      are case-insensitive by default, so such filenames are routine there.
+ *
+ * These assert against the real shipped sources and real `git` behaviour rather
+ * than re-implementing the logic — a replicated-logic test cannot catch a drift
+ * between the test's copy and what actually ships.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+import { detectExtensions } from '../init/moflo-yaml-template.js';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf-8');
+
+/** Every enumeration surface that must agree on which JS flavours are sources. */
+const JS_SOURCE_SURFACES = [
+  { file: 'bin/generate-code-map.mjs', anchor: "'.ts', '.tsx', '.js'" },
+  { file: 'bin/index-patterns.mjs', anchor: 'SOURCE_EXTENSIONS' },
+  { file: 'bin/index-tests.mjs', anchor: 'TEST_EXTENSIONS' },
+];
+
+describe('#1337 extension coverage', () => {
+  it.each(JS_SOURCE_SURFACES)('$file lists both .mjs and .cjs', ({ file, anchor }) => {
+    const src = read(file);
+    const line = src.split('\n').find(l => l.includes(anchor) && l.includes('.ts'));
+    expect(line, `no extension list found near "${anchor}"`).toBeDefined();
+    expect(line).toContain("'.mjs'");
+    expect(line).toContain("'.cjs'");
+  });
+
+  it('flo init detects .mjs/.cjs as source extensions (consumer surface)', () => {
+    // The generated moflo.yaml `extensions:` key SHADOWS the indexer defaults,
+    // so this list — not generate-code-map.mjs — is what consumers actually get.
+    const src = read('src/cli/init/moflo-yaml-template.ts');
+    const block = src.slice(src.indexOf('const SOURCE_EXTENSIONS'), src.indexOf('const SOURCE_EXTENSIONS') + 300);
+    expect(block).toContain("'.mjs'");
+    expect(block).toContain("'.cjs'");
+  });
+
+  it('this repo indexes its own bin/ runtime', () => {
+    const yaml = read('moflo.yaml');
+    const exts = yaml.match(/code_map:[\s\S]*?extensions:\s*\[([^\]]+)\]/)?.[1] ?? '';
+    expect(exts).toContain('.mjs');
+    expect(exts).toContain('.cjs');
+  });
+
+  it('the code-map language maps already knew about .cjs — the omission was an oversight', () => {
+    // EXT_TO_LANG and detectLanguage both mapped '.cjs' while the enumeration
+    // list did not, which is what made the gap silent rather than loud.
+    const src = read('bin/generate-code-map.mjs');
+    expect(src).toContain("'.cjs': 'ts'");
+    expect(src).toContain("'.cjs': 'CommonJS'");
+  });
+});
+
+describe('#1337 case normalisation (Rule #1)', () => {
+  it('every extname() comparison in the indexers is case-normalised', () => {
+    const offenders: string[] = [];
+    for (const file of ['bin/generate-code-map.mjs', 'bin/index-patterns.mjs', 'bin/index-tests.mjs']) {
+      read(file).split('\n').forEach((line, i) => {
+        if (!line.includes('extname(')) return;
+        if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) return;
+        if (line.includes('import ')) return;
+        if (line.includes('.toLowerCase()')) return;
+        offenders.push(`${file}:${i + 1}: ${line.trim()}`);
+      });
+    }
+    expect(offenders, 'un-normalised extname() call sites').toEqual([]);
+  });
+
+  it('git ls-files pathspecs use :(icase)', () => {
+    // The filesystem walk is only the FALLBACK. git ls-files is the primary
+    // enumeration path, so normalising extname() alone leaves the real gap open.
+    // Globs reach `git ls-files` either inline (index-tests) or via a built
+    // array (generate-code-map), so scan every line that constructs one.
+    const bare: string[] = [];
+    let globLines = 0;
+    for (const file of ['bin/generate-code-map.mjs', 'bin/index-tests.mjs']) {
+      read(file).split('\n').forEach((line, i) => {
+        if (line.trimStart().startsWith('*') || line.trimStart().startsWith('//')) return;
+        // A pathspec glob: a quoted/templated string starting with `*`.
+        if (!/['"`]\*|\$\{ext\}/.test(line)) return;
+        if (!/ls-files|GlobArgs|pathspec/i.test(line) && !/['"`](?::\(icase\))?\*\./.test(line)) return;
+        globLines++;
+        if (!line.includes(':(icase)')) bare.push(`${file}:${i + 1}: ${line.trim()}`);
+      });
+    }
+    expect(globLines, 'no git pathspec globs found — did the call sites move?').toBeGreaterThan(0);
+    expect(bare, 'case-sensitive git pathspec globs').toEqual([]);
+  });
+
+  it('detectExtensions() lowercases what it discovers', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'moflo-1337-'));
+    try {
+      const src = path.join(root, 'src');
+      mkdirSync(src, { recursive: true });
+      // Distinct basenames on purpose: `a.mjs` + `a.MJS` would collide on the
+      // case-insensitive filesystems this test exists to protect.
+      writeFileSync(path.join(src, 'runtime.mjs'), 'export const a = 1;\n');
+      writeFileSync(path.join(src, 'gate.cjs'), 'module.exports = {};\n');
+      writeFileSync(path.join(src, 'Legacy.CJS'), 'module.exports = {};\n');
+
+      const exts = detectExtensions(root, ['src']);
+      expect(exts).toContain('.mjs');
+      expect(exts).toContain('.cjs');
+      expect(exts.every(e => e === e.toLowerCase())).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('#1337 dispatch-command indexing', () => {
+  // Indexing bin/gate.cjs made it PRESENT but still unfindable: its gate names
+  // live only as `case` string literals, so the one token a caller would query
+  // on never reached the index. Presence and findability are separate wins.
+  const src = read('bin/generate-code-map.mjs');
+
+  it('file entries include dispatch-command literals', () => {
+    expect(src).toContain('extractDispatchCommands');
+    expect(src).toContain('Handles commands:');
+  });
+
+  it('the extractor requires an internal separator (no bare enum words)', () => {
+    const pattern = src.match(/const DISPATCH_CASE = (\/.*\/g);/)?.[1];
+    expect(pattern, 'DISPATCH_CASE regex not found').toBeDefined();
+    // Rebuild the shipped regex and the shipped separator guard.
+    const re = new RegExp(pattern!.slice(1, -2), 'g');
+    const sample = `
+      switch (cmd) {
+        case 'check-before-done': return 1;
+        case 'hooks:post-edit': return 2;
+        case 'open': return 3;
+        case 'a': return 4;
+      }`;
+    const hits = [...sample.matchAll(re)].map(m => m[1]).filter(s => /[.:-]/.test(s));
+    expect(hits).toContain('check-before-done');
+    expect(hits).toContain('hooks:post-edit');
+    expect(hits).not.toContain('open');
+    expect(hits).not.toContain('a');
+  });
+
+  it("gate.cjs's own gate names are extractable", () => {
+    const gate = read('bin/gate.cjs');
+    const re = new RegExp(read('bin/generate-code-map.mjs').match(/const DISPATCH_CASE = \/(.*)\/g;/)![1], 'g');
+    const names = [...gate.matchAll(re)].map(m => m[1]).filter(s => /[.:-]/.test(s));
+    expect(names).toContain('check-before-done');
+  });
+});
+
+describe('#1337 git pathspec case-sensitivity (the reason :(icase) is required)', () => {
+  let repo: string | null = null;
+  let gitAvailable = true;
+
+  const git = (args: string[], cwd: string) =>
+    execFileSync('git', ['-c', 'user.email=t@example.com', '-c', 'user.name=t', ...args], {
+      cwd,
+      encoding: 'utf-8',
+      windowsHide: true,
+    });
+
+  beforeAll(() => {
+    try {
+      // realpath both sides: macOS tmpdir is a symlink (/var -> /private/var).
+      repo = mkdtempSync(path.join(tmpdir(), 'moflo-1337-git-'));
+      git(['init', '-q', '.'], repo);
+      writeFileSync(path.join(repo, 'lower.mjs'), 'export const a = 1;\n');
+      writeFileSync(path.join(repo, 'Upper.MJS'), 'export const b = 2;\n');
+      git(['add', '-A'], repo);
+    } catch {
+      gitAvailable = false;
+    }
+  });
+
+  afterAll(() => {
+    if (repo && existsSync(repo)) rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('a bare *.mjs pathspec misses an uppercase extension', () => {
+    if (!gitAvailable || !repo) return;
+    const out = git(['ls-files', '--', '*.mjs'], repo).trim().split('\n').filter(Boolean);
+    expect(out).toContain('lower.mjs');
+    expect(out).not.toContain('Upper.MJS');
+  });
+
+  it(':(icase) finds both — and is a superset, so nothing drops out', () => {
+    if (!gitAvailable || !repo) return;
+    const out = git(['ls-files', '--', ':(icase)*.mjs'], repo).trim().split('\n').filter(Boolean);
+    expect(out).toContain('lower.mjs');
+    expect(out).toContain('Upper.MJS');
+  });
+});

--- a/src/cli/__tests__/init-moflo-yaml-template.test.ts
+++ b/src/cli/__tests__/init-moflo-yaml-template.test.ts
@@ -124,9 +124,11 @@ describe('defaultMofloYamlConfig', () => {
     expect(config.testDirs).toEqual(['tests']);
   });
 
-  it('falls back to .ts/.tsx/.js/.jsx when no source files exist', () => {
+  it('falls back to the JS/TS family when no source files exist', () => {
+    // .mjs/.cjs included since #1337 — the fallback seeds a consumer's
+    // code_map.extensions, and omitting them left ESM/CJS runtime unindexed.
     const config = defaultMofloYamlConfig(root);
-    expect(config.detectedExts).toEqual(['.ts', '.tsx', '.js', '.jsx']);
+    expect(config.detectedExts).toEqual(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
   });
 
   it('detects existing src/ with .ts files', () => {
@@ -319,6 +321,6 @@ describe('discovery walk safety', () => {
   });
 
   it('detectExtensions falls back when src/ does not exist', () => {
-    expect(detectExtensions(root, ['src'])).toEqual(['.ts', '.tsx', '.js', '.jsx']);
+    expect(detectExtensions(root, ['src'])).toEqual(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
   });
 });

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -25,8 +25,14 @@ const WALK_SKIP_DIRS = new Set([
   '.swarm', '.moflo', 'packages',
 ]);
 
+// `.mjs`/`.cjs` are first-class JS sources, not build artifacts — moflo's own
+// hook/gate/launcher runtime is written in them. Omitting them here made every
+// consumer's generated `code_map.extensions` exclude them, so an explicit list
+// from `flo init` shadowed the indexer defaults and left that code unsearchable
+// (#1337).
 const SOURCE_EXTENSIONS = [
-  '.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java', '.kt', '.swift', '.rb', '.cs',
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.py', '.go', '.rs', '.java', '.kt', '.swift', '.rb', '.cs',
 ];
 
 // Mirror of `MofloInitAnswers` (defined in moflo-init.ts) plus render-only
@@ -137,7 +143,9 @@ function scanExtensions(dir: string, extensions: Set<string>, depth: number, max
     if (entry.isDirectory() && !['node_modules', '.git', 'dist', 'build'].includes(entry.name)) {
       scanExtensions(path.join(dir, entry.name), extensions, depth + 1, maxDepth);
     } else if (entry.isFile()) {
-      const ext = path.extname(entry.name);
+      // Lowercase before matching: NTFS/APFS are case-insensitive, so a file
+      // committed as `Foo.MJS` yields `.MJS` and would miss an exact compare.
+      const ext = path.extname(entry.name).toLowerCase();
       if (SOURCE_EXTENSIONS.includes(ext)) extensions.add(ext);
     }
   }
@@ -151,7 +159,7 @@ export function detectExtensions(root: string, srcDirs: string[]): string[] {
       try { scanExtensions(fullDir, extensions, 0, 3); } catch { /* skip */ }
     }
   }
-  return extensions.size > 0 ? [...extensions].sort() : ['.ts', '.tsx', '.js', '.jsx'];
+  return extensions.size > 0 ? [...extensions].sort() : ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
 }
 
 export function defaultMofloYamlConfig(root: string): MofloYamlConfig {


### PR DESCRIPTION
Closes #1337.

moflo's hook, gate, launcher and indexer runtime was invisible to `memory_search` while the `memory_first` gate blocked the `Grep`/`Read` tools that would otherwise have found it. A retrieval gap in a store agents are *required* to consult first costs wasted turns plus a plausible wrong answer.

## Validation of the report

Four factual claims in the issue confirmed against the live index (code-map held **0** `.mjs` and **0** `.cjs` entries; `gate.cjs`, `gate-hook.mjs`, `index-fingerprint.mjs` all absent, `bin/cli.js` present). Three parts of the analysis needed correcting, and each changed the fix:

**The proposed fix missed the primary code path.** `walkDir`'s `extname` compare is only the filesystem *fallback*. Real enumeration is `git ls-files -- '*.mjs'`, and git pathspec globs are case-sensitive — verified on git 2.43 with `core.ignorecase` both on and off, so it is not a platform-config artifact. Normalising `extname()` alone would have left the actual path broken. Now uses `:(icase)`.

**The platform reasoning was inverted.** The issue argued the bug is "invisible on Linux" because `.MJS`/`.mjs` are distinct names there. In fact `extname('Foo.MJS')` returns `.MJS` on *every* platform and the Set lookup fails identically everywhere — what varies is incidence, not detectability. Useful consequence: the fix needs no `process.platform` branching.

**The consumer-facing root cause is a file the issue never names.** `SOURCE_EXTENSIONS` in `src/cli/init/moflo-yaml-template.ts` lacked both `.mjs` and `.cjs`, and `flo init` writes that *detected* list into every consumer's `moflo.yaml`. An explicit `extensions:` key shadows the indexer defaults — so patching `generate-code-map.mjs:171` alone would have fixed nothing for any consumer that had run init. It is also why this repo had `[".js", ".ts"]`. AC4 is unsatisfiable without this.

Also wider than code-map: `index-patterns.mjs` and `index-tests.mjs` had the same `.cjs` omission.

## Findability is a separate defect from presence

Indexing `bin/gate.cjs` made it PRESENT but still unranked — its gate names exist only as `case` string literals, so the one token an agent would query on never reached the index. File entries now include dispatch-command literals, extracted during the read that already happens (no extra I/O).

## Verification

| # | Acceptance criterion | Evidence | Verdict |
|---|---|---|---|
| 1 | `gate.cjs`, `gate-hook.mjs`, `index-fingerprint.mjs` in code-map | DB query: all PRESENT (were ABSENT) | ✅ |
| 2 | `check-before-done gate implementation` returns `gate.cjs` top 3 | **rank 1 @ 0.82** (was absent from top 5) | ✅ |
| 3 | Uppercase-extension file is indexed | E2E: committed `UpperProbe.CJS` → indexed, `Language: CommonJS`, command extracted; probe removed, no stale rows | ✅ |
| 4 | Consumers get `.cjs` by default without editing moflo.yaml | `renderMofloYaml(defaultMofloYamlConfig(tmp))` → `extensions: [".cjs", ".mjs", ".ts"]` | ✅ |
| 5 | No previously-indexed file drops out | `:(icase)` proven strict superset (md5-identical on this repo); code-map grew 1461 → 1570 monotonically | ✅ |

`bin/lib/index-fingerprint.mjs` also went from absent to **rank 2 @ 0.84** on the issue's other query.

Full suite **9630 passed / 0 failed**; lint clean.

## Cross-platform (Rule #1)

- Extension comparison lowercased on both sides at every call site, incl. the init detector.
- `:(icase)` is git-core pathspec magic, platform-independent; passed via `execFileSync` array args so no shell quoting is involved. On a pre-1.9 git it errors into the existing fallback walk, which is now also case-correct.
- Tests use `os.tmpdir()` + `path.join`, and deliberately avoid same-name case variants (`a.mjs`/`a.MJS`) that would collide on NTFS/APFS.

## Consumer impact (Rule #2)

Surface touched: `bin/` indexers (synced to `.claude/scripts/`) and the `flo init` template. Existing consumers keep their current `moflo.yaml` — their `extensions:` list is only widened on a fresh init or a manual edit; the indexer default fix covers those with no `code_map` block. No migration, no state format change. Picking this up re-indexes and adds entries; nothing drops.

## Tests

New `src/cli/__tests__/code-map-extensions.test.ts` (14 tests) asserts against the **real shipped sources and real `git` behaviour** rather than re-implementing the logic — the existing indexing tests replicate logic inline, which is why this bug survived them. Includes a guard that fails on any un-normalised `extname()` compare or bare pathspec glob, so the Rule #1 half can't silently regress. Both halves mutation-tested: reverting either fix turns the suite red.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)