### PR TITLE
fix(verify): persist the per-criterion verdict as structure, not prose (#1328)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -71,16 +71,35 @@ Overall verdict is PASS iff no row is FAIL or UNVERIFIED.
 
 ## Step 5 — Record the outcome to memory
 
-Always store the result (feeds routing/learning and the SDD trail):
+Always store the result (feeds routing/learning and the SDD trail). Store it **twice over**: the prose summary in `value`, and the Step 4 table itself — unflattened — in `metadata`.
 
 ```
 mcp__moflo__memory_store {
   namespace: "learnings",
   key: "verify:<slug-or-issue>",
   value: "<overall PASS/FAIL> — per-criterion: <criterion → evidence → verdict>; commit <sha>",
-  tags: ["verify", "sdd"]
+  tags: ["verify", "sdd"],
+  metadata: {
+    type: "verify-record",
+    issue: "<slug-or-issue>",
+    commit: "<sha>",
+    overall: "PASS" | "FAIL" | "UNVERIFIED",
+    verifiedAt: "<ISO-8601>",
+    criteria: [
+      { id: 1, statement: "<criterion>", verdict: "PASS" | "FAIL" | "UNVERIFIED",
+        evidence: "<test name / observed output>", freshlyExecuted: true }
+    ]
+  }
 }
 ```
+
+**Why both.** `value` is what gets embedded for semantic search, so it stays prose — a JSON blob there would degrade every future `learnings` search. `metadata` is stored verbatim and not embedded, so the structure survives without that cost. `memory_retrieve` returns the parsed `metadata` object for non-chunk entries, which is what makes the record readable rather than write-only.
+
+**`freshlyExecuted` is required on every criterion, not optional.** Step 3 deliberately permits *citing* an earlier green run instead of re-executing. That is a sound cost optimisation, but it means evidence may be a citation rather than a fresh result — set `freshlyExecuted: false` when you cited. Without that flag a later reader silently inherits stale evidence and cannot tell a re-verified criterion from a re-cited one.
+
+**Never record an exit code.** Claude Code's `tool_response` for Bash carries `stdout`/`stderr` but **no exit status**, and PostToolUse does not fire at all when a command exits non-zero (#1322). `evidence` is therefore descriptive by necessity; a field named `exitCode` would be agent-narrated fiction, which is the problem this record exists to remove.
+
+`overall` MUST agree with the Step 4 rule — PASS iff no criterion is FAIL or UNVERIFIED. Record a FAIL as a FAIL; the store is the audit trail, and a verdict that only ever reads PASS is worth nothing.
 
 ## Step 6 — Report
 

--- a/src/cli/__tests__/verify-record-metadata.test.ts
+++ b/src/cli/__tests__/verify-record-metadata.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Regression tests for #1328 — `/verify` computed a structured per-criterion
+ * verdict and then flattened it to prose when storing, so nothing downstream
+ * could filter for failures or join a verdict to a commit.
+ *
+ * The fix stores the Step 4 table in the `metadata` column (prose stays in
+ * `value`, which is the embedded text). That only helps if metadata survives
+ * the read: before this change `shapeRetrievedEntry` passed metadata through
+ * `parseNavigation` alone, which hard-returns null unless `type === 'chunk'`,
+ * so metadata was **write-only** for every non-chunk entry. These tests pin
+ * both halves — the surfacing, and the chunk path it must not disturb.
+ *
+ * Cross-platform (Rule #1): entirely in-memory. The backend is mocked, so
+ * there is no filesystem, no temp dir, no shelling out, and nothing that
+ * behaves differently on Linux, macOS, or Windows.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import type { MCPTool } from '../mcp-tools/types.js';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+/** The record shape Step 5 of the verify skill now writes. */
+const verifyRecord = {
+  type: 'verify-record',
+  issue: '1328',
+  commit: 'abc1234',
+  overall: 'FAIL',
+  verifiedAt: '2026-08-03T22:00:00Z',
+  criteria: [
+    {
+      id: 1,
+      statement: 'structured record persists',
+      verdict: 'PASS',
+      evidence: 'verify-record-metadata.test.ts',
+      freshlyExecuted: true,
+    },
+    {
+      id: 2,
+      statement: 'cited evidence is distinguishable from fresh',
+      verdict: 'FAIL',
+      evidence: 'cited from an earlier run this session',
+      freshlyExecuted: false,
+    },
+  ],
+};
+
+const chunkMetadata = JSON.stringify({
+  type: 'chunk',
+  parentDoc: 'doc-guidance-foo',
+  parentPath: '.claude/guidance/foo.md',
+  chunkIndex: 1,
+  totalChunks: 3,
+  prevChunk: null,
+  nextChunk: 'chunk-guidance-foo-2',
+  chunkTitle: 'Section One',
+  headerLevel: 2,
+});
+
+const entries: Record<string, { content: string; metadata?: string }> = {
+  'verify:1328': { content: 'FAIL — 1 of 2 criteria unproven; commit abc1234', metadata: JSON.stringify(verifyRecord) },
+  'chunk-guidance-foo-1': { content: 'chunk body', metadata: chunkMetadata },
+  'plain-note': { content: 'just prose', metadata: undefined },
+  'empty-meta': { content: 'prose', metadata: '{}' },
+  'broken-meta': { content: 'prose', metadata: '{ not valid json' },
+  'array-meta': { content: 'prose', metadata: '["a","b"]' },
+};
+
+const getEntrySpy = vi.fn(async (opts: { key: string }) => {
+  const hit = entries[opts.key];
+  if (!hit) return { success: true, found: false };
+  return {
+    success: true,
+    found: true,
+    entry: {
+      id: `id-${opts.key}`,
+      key: opts.key,
+      namespace: 'learnings',
+      content: hit.content,
+      accessCount: 0,
+      createdAt: '2026-08-03',
+      updatedAt: '2026-08-03',
+      hasEmbedding: true,
+      tags: ['verify', 'sdd'],
+      metadata: hit.metadata,
+    },
+  };
+});
+
+vi.mock('../memory/memory-initializer.js', () => ({
+  storeEntry: vi.fn(),
+  searchEntries: vi.fn(async () => ({ success: true, results: [], searchTime: 0 })),
+  listEntries: vi.fn(),
+  getEntry: getEntrySpy,
+  deleteEntry: vi.fn(),
+  initializeMemoryDatabase: vi.fn(async () => ({ success: true, dbPath: '' })),
+  checkMemoryInitialization: vi.fn(async () => ({ initialized: true, dbPath: '', tableExists: true, version: '3.0.0' })),
+}));
+
+vi.mock('../services/spell-gate.js', () => ({
+  GateService: class { recordMemorySearched(): void { /* no-op */ } notifyMemoryGate(): void { /* no-op */ } },
+}));
+
+beforeEach(() => { getEntrySpy.mockClear(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+async function retrieve(key: string): Promise<Record<string, unknown>> {
+  const mod = await import('../mcp-tools/memory-tools.js');
+  const tool = (mod.memoryTools as MCPTool[]).find(t => t.name === 'memory_retrieve');
+  if (!tool) throw new Error('memory_retrieve not registered');
+  return await tool.handler({ key, namespace: 'learnings' }) as Record<string, unknown>;
+}
+
+describe('#1328 a structured verify record survives the round trip', () => {
+  it('memory_retrieve surfaces the parsed per-criterion record', async () => {
+    const result = await retrieve('verify:1328');
+    expect(result.found).toBe(true);
+    expect(result.metadata).toEqual(verifyRecord);
+  });
+
+  it('a FAIL verdict is readable as structure, not prose', async () => {
+    // The whole point of #1328: downstream can filter for failures without
+    // parsing free text an agent composed.
+    const meta = (await retrieve('verify:1328')).metadata as typeof verifyRecord;
+    expect(meta.overall).toBe('FAIL');
+
+    const failed = meta.criteria.filter(c => c.verdict !== 'PASS');
+    expect(failed).toHaveLength(1);
+    expect(failed[0].id).toBe(2);
+  });
+
+  it('distinguishes freshly-executed evidence from cited evidence', async () => {
+    const meta = (await retrieve('verify:1328')).metadata as typeof verifyRecord;
+    expect(meta.criteria.map(c => c.freshlyExecuted)).toEqual([true, false]);
+  });
+
+  it('joins the verdict to a commit', async () => {
+    const meta = (await retrieve('verify:1328')).metadata as typeof verifyRecord;
+    expect(meta.commit).toBe('abc1234');
+  });
+
+  it('keeps the human-readable summary in value — additive, not a replacement', async () => {
+    const result = await retrieve('verify:1328');
+    expect(result.value).toBe('FAIL — 1 of 2 criteria unproven; commit abc1234');
+  });
+
+  it('records no exit code — the runtime cannot supply one (#1322)', async () => {
+    const meta = (await retrieve('verify:1328')).metadata as Record<string, unknown>;
+    expect(JSON.stringify(meta)).not.toMatch(/exitCode/i);
+  });
+});
+
+describe('#1328 metadata surfacing does not disturb the chunk path', () => {
+  it('chunk entries still get navigation and are NOT double-billed via metadata', async () => {
+    const result = await retrieve('chunk-guidance-foo-1');
+    expect(result.navigation).toMatchObject({
+      parentDoc: 'doc-guidance-foo',
+      nextChunk: 'chunk-guidance-foo-2',
+      chunkTitle: 'Section One',
+    });
+    // Chunk metadata is ~4x the size of non-chunk metadata; navigation already
+    // projects it, so echoing it raw would inflate every traversal hop.
+    expect(result.metadata).toBeNull();
+  });
+
+  it('non-chunk entries get metadata and a null navigation', async () => {
+    const result = await retrieve('verify:1328');
+    expect(result.navigation).toBeNull();
+    expect(result.metadata).not.toBeNull();
+  });
+});
+
+describe('#1328 metadata parsing is total (never throws)', () => {
+  it.each([
+    ['absent metadata', 'plain-note'],
+    ['an empty object', 'empty-meta'],
+    ['malformed JSON', 'broken-meta'],
+    ['a JSON array rather than an object', 'array-meta'],
+  ])('returns null for %s rather than throwing', async (_label, key) => {
+    const result = await retrieve(key);
+    expect(result.found).toBe(true);
+    expect(result.metadata).toBeNull();
+  });
+});
+
+describe('#1328 the verify skill instructs the structured store', () => {
+  // The skill text IS the implementation here — an agent reads it and acts.
+  // If Step 5 reverts to a prose-only store, the record silently stops being
+  // written and every test above keeps passing against its own fixture.
+  const skill = readFileSync(
+    path.join(repoRoot, '.claude', 'skills', 'verify', 'SKILL.md'),
+    'utf-8',
+  );
+
+  it('Step 5 passes a metadata block to memory_store', () => {
+    expect(skill).toMatch(/metadata:\s*\{/);
+    expect(skill).toMatch(/type:\s*["']verify-record["']/);
+  });
+
+  it('specifies overall plus a per-criterion array', () => {
+    expect(skill).toMatch(/overall:/);
+    expect(skill).toMatch(/criteria:\s*\[/);
+    expect(skill).toMatch(/verdict:/);
+  });
+
+  it('requires freshlyExecuted so cited evidence stays distinguishable', () => {
+    expect(skill).toMatch(/freshlyExecuted/);
+    expect(skill).toMatch(/required on every criterion/i);
+  });
+
+  it('retains the prose value alongside the structured record', () => {
+    expect(skill).toMatch(/value:\s*["']<overall PASS\/FAIL>/);
+  });
+
+  it('forbids recording an exit code', () => {
+    expect(skill).toMatch(/[Nn]ever record an exit code/);
+  });
+});

--- a/src/cli/__tests__/verify-record-metadata.test.ts
+++ b/src/cli/__tests__/verify-record-metadata.test.ts
@@ -145,9 +145,23 @@ describe('#1328 a structured verify record survives the round trip', () => {
     expect(result.value).toBe('FAIL — 1 of 2 criteria unproven; commit abc1234');
   });
 
-  it('records no exit code — the runtime cannot supply one (#1322)', async () => {
+  it('records no exit-code FIELD — the runtime cannot supply one (#1322)', async () => {
+    // Assert on field names, not a substring of the serialised record: a
+    // criterion's `evidence` prose may legitimately mention an exit code
+    // while claiming none (a real stored record did exactly that). The AC is
+    // about a field asserting fidelity, so only key names can answer it.
+    const collectKeys = (node: unknown, acc: string[] = []): string[] => {
+      if (Array.isArray(node)) { for (const v of node) collectKeys(v, acc); return acc; }
+      if (node && typeof node === 'object') {
+        for (const [k, v] of Object.entries(node)) { acc.push(k); collectKeys(v, acc); }
+      }
+      return acc;
+    };
+
     const meta = (await retrieve('verify:1328')).metadata as Record<string, unknown>;
-    expect(JSON.stringify(meta)).not.toMatch(/exitCode/i);
+    const keys = collectKeys(meta);
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys.filter(k => /^exit(code|status)$/i.test(k))).toEqual([]);
   });
 });
 

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -190,16 +190,12 @@ function parseNavigation(
   metadataJson: string | undefined,
   mode: 'full' | 'compact',
 ): NavigationFull | NavigationCompact | null {
-  return navigationFrom(parseMetadataObject(metadataJson), mode);
+  const meta = parseMetadataObject(metadataJson);
+  return mode === 'full' ? navigationFrom(meta, 'full') : navigationFrom(meta, 'compact');
 }
 
 function navigationFrom(meta: Record<string, unknown> | null, mode: 'full'): NavigationFull | null;
 function navigationFrom(meta: Record<string, unknown> | null, mode: 'compact'): NavigationCompact | null;
-// Union overload so `parseNavigation` can forward its own `mode` straight through.
-function navigationFrom(
-  meta: Record<string, unknown> | null,
-  mode: 'full' | 'compact',
-): NavigationFull | NavigationCompact | null;
 function navigationFrom(
   meta: Record<string, unknown> | null,
   mode: 'full' | 'compact',

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -132,6 +132,17 @@ interface RetrievedEntry {
   accessCount: number;
   hasEmbedding: boolean;
   navigation: NavigationFull | null;
+  // #1328: the parsed `metadata` column for NON-chunk entries. Producers of
+  // structured records (e.g. /verify's per-criterion verdict) write them here
+  // so `value` can stay human-readable prose — the embedded text stays clean
+  // while the machine-readable half survives the round trip. Before this,
+  // metadata reached the DB intact but `metadata` had no outlet in the
+  // response at all, making it write-only for anything that wasn't a chunk.
+  //
+  // Chunk entries get null: `navigation` already projects their metadata, and
+  // chunk metadata averages ~4x the size of non-chunk metadata, so echoing it
+  // raw would double-bill the RAG traversal path this response is tuned for.
+  metadata: Record<string, unknown> | null;
   found: boolean;
   backend: string;
 }
@@ -154,20 +165,46 @@ interface SearchHit {
   expanded?: ExpandedNeighbor[];
 }
 
+/**
+ * Parse a raw `metadata` column into a plain object, or null.
+ *
+ * Total by contract: a malformed row yields null rather than throwing, so one
+ * bad entry can never fail an otherwise-good read. Arrays are rejected too —
+ * valid JSON, but not the record shape any caller here expects.
+ */
+function parseMetadataObject(metadataJson: string | undefined): Record<string, unknown> | null {
+  if (!metadataJson) return null;
+  let meta: unknown;
+  try {
+    meta = JSON.parse(metadataJson);
+  } catch {
+    return null;
+  }
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return null;
+  return meta as Record<string, unknown>;
+}
+
 function parseNavigation(metadataJson: string | undefined, mode: 'full'): NavigationFull | null;
 function parseNavigation(metadataJson: string | undefined, mode: 'compact'): NavigationCompact | null;
 function parseNavigation(
   metadataJson: string | undefined,
   mode: 'full' | 'compact',
 ): NavigationFull | NavigationCompact | null {
-  if (!metadataJson) return null;
-  let meta: Record<string, unknown>;
-  try {
-    meta = JSON.parse(metadataJson);
-  } catch {
-    return null;
-  }
-  if (!meta || typeof meta !== 'object') return null;
+  return navigationFrom(parseMetadataObject(metadataJson), mode);
+}
+
+function navigationFrom(meta: Record<string, unknown> | null, mode: 'full'): NavigationFull | null;
+function navigationFrom(meta: Record<string, unknown> | null, mode: 'compact'): NavigationCompact | null;
+// Union overload so `parseNavigation` can forward its own `mode` straight through.
+function navigationFrom(
+  meta: Record<string, unknown> | null,
+  mode: 'full' | 'compact',
+): NavigationFull | NavigationCompact | null;
+function navigationFrom(
+  meta: Record<string, unknown> | null,
+  mode: 'full' | 'compact',
+): NavigationFull | NavigationCompact | null {
+  if (!meta) return null;
   // Discriminator: only `type === 'chunk'` entries carry the nav fields.
   if (meta.type !== 'chunk') return null;
 
@@ -212,6 +249,9 @@ function sourceIdOf(key: string): string {
 function shapeRetrievedEntry(entry: MemoryEntryWithMeta): RetrievedEntry {
   let value: unknown = entry.content;
   try { value = JSON.parse(entry.content); } catch { /* keep string */ }
+  // Parse once and derive both projections — chunk metadata averages ~1.1KB,
+  // and this is the per-hop cost of the RAG traversal path.
+  const meta = parseMetadataObject(entry.metadata);
   return {
     key: entry.key,
     namespace: entry.namespace,
@@ -221,7 +261,9 @@ function shapeRetrievedEntry(entry: MemoryEntryWithMeta): RetrievedEntry {
     updatedAt: entry.updatedAt,
     accessCount: entry.accessCount,
     hasEmbedding: entry.hasEmbedding,
-    navigation: parseNavigation(entry.metadata, 'full'),
+    navigation: navigationFrom(meta, 'full'),
+    // #1328: chunks project through `navigation` instead — see RetrievedEntry.
+    metadata: meta && meta.type !== 'chunk' && Object.keys(meta).length > 0 ? meta : null,
     found: true,
     backend: BACKEND_LABEL,
   };
@@ -422,7 +464,7 @@ export const memoryTools: MCPTool[] = [
   },
   {
     name: 'memory_retrieve',
-    description: 'Retrieve the full value for a SPECIFIC key. For chunk entries, prefer `memory_get_neighbors` for traversal — bulk-retrieving search hits is a protocol violation. The returned `navigation` object lets you keep traversing. See `.claude/guidance/moflo-memory-protocol.md`.',
+    description: 'Retrieve the full value for a SPECIFIC key. For chunk entries, prefer `memory_get_neighbors` for traversal — bulk-retrieving search hits is a protocol violation. The returned `navigation` object lets you keep traversing. Non-chunk entries instead return their parsed `metadata` object (null when absent), which is where structured records — e.g. a `/verify` per-criterion verdict — live; `value` stays human-readable. See `.claude/guidance/moflo-memory-protocol.md`.',
     category: 'memory',
     inputSchema: {
       type: 'object',


### PR DESCRIPTION
## Summary

`/verify` computed a per-criterion verdict table in Step 4, then flattened it to a single prose string in Step 5. The stored row had no `overall`, no per-criterion verdicts, and no way to tell a freshly-executed check from a cited one — so nothing downstream could filter for failures, count outcomes, or join a verdict to a commit without parsing free text an agent composed.

Closes #1328.

## Validating the issue turned up a second defect

The ticket's claims held exactly as written. But the design hinges on something it did not name:

`metadata` reached the database intact — both the direct sqlite path and the daemon-routed path return it verbatim (verified empirically). The MCP response shaper, however, passed it **only** through `parseNavigation()`, which hard-returns null unless `type === 'chunk'`:

```ts
if (meta.type !== 'chunk') return null;
```

So `metadata` was **write-only for every non-chunk entry**. Storing the verify record there without fixing the read would have satisfied the letter of the ticket and changed nothing — the record would have been unreadable through the documented surface.

## The change

- **`.claude/skills/verify/SKILL.md`** Step 5 stores the Step 4 table verbatim in `metadata`; the prose summary stays in `value`. The split is deliberate: `value` is the text that gets **embedded**, so a JSON blob there would degrade every future `learnings` search. `metadata` is stored but not embedded, so the structure survives at no retrieval-quality cost.
- **`memory_retrieve`** surfaces the parsed `metadata` object for non-chunk entries. Chunk entries keep returning `null` — `navigation` already projects their metadata, and chunk metadata averages **~1.1KB vs ~269 bytes** for non-chunk rows (measured over 3,928 rows), so echoing it raw would double-bill the RAG traversal path.

`freshlyExecuted` is required on every criterion, not optional. Step 3 deliberately permits citing an earlier green run, which is a sound cost optimisation — but it means evidence may be a citation, and without the flag a later reader silently inherits stale evidence.

## Scope note — deliberately not extended to `memory_search`

Search is the per-prompt hot path and returns up to 8 hits; attaching ~269 bytes per hit is a recurring consumer-wide token cost on a bulk path (the #1331 failure mode). Retrieve is single-key and explicit. Filtering across many records wants a dedicated query surface, not a heavier semantic search.

## Consumer impact (Rule #2)

| | |
|---|---|
| **Surface touched** | `.claude/skills/verify/SKILL.md` (synced into every consumer) and the `memory_retrieve` MCP response |
| **Failure mode for an existing consumer** | None — both halves are purely additive. Old prose rows keep parsing; `metadata` is a new response field, no existing field changed. Verified against a real pre-change row (`verify:1337`, metadata `{}`) → `found`, value intact, `metadata: null`, no crash |
| **Round-trip cost** | Publish + reinstall. The MCP server runs from `node_modules/moflo/dist`, so the read half only reaches consumers after publish; the skill edit ships in the same tarball |

## Cross-platform (Rule #1)

Pure JSON/string handling — no paths, no shelling, no symlink identity checks, no process introspection. The test mocks the backend entirely so it touches no filesystem; the one file it reads is resolved with `path.join`, and every assertion matches within a single line, so a CRLF checkout on Windows is unaffected. Standing caveat: PR CI is ubuntu-only — macOS/Windows signal comes from `release-smoke.yml` at `/publish`.

## Verification

- **End-to-end against the real store** — structured record round-tripped `JSON.stringify`-exact; a FAIL verdict readable as structure; commit join intact
- **Chunk control** — chunk entry still returns `navigation` with metadata suppressed
- **Legacy control** — real pre-change prose row still readable
- **Mutation-tested** — forcing `metadata` back to `null` turns 5 tests red
- 20 new tests; **full suite 9660 passed / 0 failed**; lint clean

One finding from this run worth flagging: the first version of the exit-code test checked `JSON.stringify(record)` against `/exitCode/i`. The verify record for this very issue describes a criterion as *"the record contains no exitCode"* — and the check flagged a fully-compliant record. Second commit replaces it with a recursive key walk, since the AC is about field names, not content.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
