### PR TITLE
fix(mcp): label synthetic tool responses at the call site (#1324, #1325)

### DIFF
--- a/src/cli/__tests__/mcp-tools/synthetic-labeling.test.ts
+++ b/src/cli/__tests__/mcp-tools/synthetic-labeling.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Issues #1324 and #1325 — MCP tools that return fabricated data must say so.
+ *
+ * Several registered tools return hardcoded literals, `Math.random()` draws, or
+ * local-only state that never reaches the service they appear to describe.
+ * Two of them actively asserted authenticity (`_real: true`, a description
+ * advertising "REAL metrics"), which is the part that makes the numbers
+ * undiscountable rather than merely useless.
+ *
+ * These tests pin the labeling in the two places a caller can see it — the
+ * `description` returned by `tools/list`, and every response object — and pin
+ * the boundary just as hard: tools that genuinely measure something must NOT
+ * be labelled, or the marker degrades into noise.
+ *
+ * Cross-platform (Rule #1): the only filesystem contact is a `mkdtemp` project
+ * root built with `path.join`; no shell, no platform-specific path literal.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { MCPTool } from '../../mcp-tools/types.js';
+
+let fakeProjectRoot = '';
+vi.mock('../../services/project-root.js', () => ({
+  findProjectRoot: () => fakeProjectRoot,
+}));
+
+import {
+  applySyntheticNotices,
+  withSyntheticNotice,
+  SYNTHETIC_PREFIX,
+} from '../../mcp-tools/synthetic.js';
+import { getMofloVersion, UNKNOWN_VERSION } from '../../services/moflo-version.js';
+import { githubTools } from '../../mcp-tools/github-tools.js';
+import { performanceTools } from '../../mcp-tools/performance-tools.js';
+import { systemTools } from '../../mcp-tools/system-tools.js';
+import { neuralTools } from '../../mcp-tools/neural-tools.js';
+import { hooksTools } from '../../mcp-tools/hooks-tools.js';
+
+const ALL_TOOLS: MCPTool[] = [
+  ...githubTools,
+  ...performanceTools,
+  ...systemTools,
+  ...neuralTools,
+  ...hooksTools,
+];
+
+const byName = (name: string): MCPTool => {
+  const tool = ALL_TOOLS.find(t => t.name === name);
+  if (!tool) throw new Error(`tool not registered: ${name}`);
+  return tool;
+};
+
+/** Every tool #1324 + #1325 require to carry the marker. */
+const LABELLED = [
+  'github_repo_analyze',
+  'github_pr_manage',
+  'github_issue_track',
+  'github_metrics',
+  'performance_report',
+  'system_health',
+  'neural_train',
+  'neural_predict',
+  'hooks_metrics',
+  'hooks_intelligence',
+  'hooks_intelligence-reset',
+];
+
+/**
+ * Tools in the same files that DO measure something. Labelling these would put
+ * a SYNTHETIC banner on real results, which is the mirror-image failure.
+ */
+const NOT_LABELLED = [
+  'performance_benchmark',
+  'neural_patterns',
+  'neural_status',
+  'hooks_list',
+];
+
+/** Handlers cheap enough to invoke — neural_predict is excluded deliberately. */
+const CHEAP_HANDLER_CASES: Array<{ name: string; input: Record<string, unknown> }> = [
+  { name: 'github_repo_analyze', input: { owner: 'o', repo: 'r' } },
+  { name: 'github_pr_manage', input: { action: 'list' } },
+  { name: 'github_issue_track', input: { action: 'list' } },
+  { name: 'github_metrics', input: { metric: 'all' } },
+  { name: 'performance_report', input: { format: 'summary' } },
+  { name: 'system_health', input: {} },
+  { name: 'neural_train', input: { modelType: 'classifier', epochs: 1 } },
+  { name: 'hooks_metrics', input: { period: '24h' } },
+  { name: 'hooks_intelligence', input: { showStatus: true } },
+  { name: 'hooks_intelligence-reset', input: {} },
+];
+
+beforeEach(() => {
+  fakeProjectRoot = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-synthetic-')));
+  writeFileSync(join(fakeProjectRoot, 'package.json'), '{"name":"fake"}');
+});
+
+afterEach(() => {
+  try { rmSync(fakeProjectRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+  fakeProjectRoot = '';
+});
+
+describe('withSyntheticNotice', () => {
+  const base: MCPTool = {
+    name: 'sample',
+    description: 'Do a thing',
+    category: 'test',
+    inputSchema: { type: 'object', properties: {} },
+    handler: async () => ({ success: true, value: 1 }),
+  };
+
+  it('appends the notice to the description with the greppable prefix', () => {
+    const wrapped = withSyntheticNotice(base, 'nothing is measured');
+    expect(wrapped.description).toBe(`Do a thing. ${SYNTHETIC_PREFIX} nothing is measured`);
+  });
+
+  it('adds the marker and the notice to an object response', async () => {
+    const wrapped = withSyntheticNotice(base, 'nothing is measured');
+    const result = await wrapped.handler({}) as Record<string, unknown>;
+    expect(result.synthetic).toBe(true);
+    expect(result.syntheticNotice).toContain('nothing is measured');
+    // The honest fields survive — this is labeling, not a rewrite.
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(1);
+  });
+
+  it('overrides a handler that returns its own contradicting marker', async () => {
+    const liar: MCPTool = { ...base, handler: async () => ({ synthetic: false, ok: true }) };
+    const result = await withSyntheticNotice(liar, 'x').handler({}) as Record<string, unknown>;
+    expect(result.synthetic).toBe(true);
+  });
+
+  it('passes a non-object result through rather than reshaping it', async () => {
+    const stringy: MCPTool = { ...base, handler: async () => 'plain text' };
+    expect(await withSyntheticNotice(stringy, 'x').handler({})).toBe('plain text');
+  });
+
+  it('passes an array result through rather than spreading it into an object', async () => {
+    const arrayed: MCPTool = { ...base, handler: async () => [1, 2, 3] };
+    expect(await withSyntheticNotice(arrayed, 'x').handler({})).toEqual([1, 2, 3]);
+  });
+
+  it('lets handler errors propagate — the wrapper must not swallow failures', async () => {
+    const thrower: MCPTool = { ...base, handler: async () => { throw new Error('boom'); } };
+    await expect(withSyntheticNotice(thrower, 'x').handler({})).rejects.toThrow('boom');
+  });
+
+  it('preserves every other tool field', () => {
+    const wrapped = withSyntheticNotice(base, 'x');
+    expect(wrapped.name).toBe('sample');
+    expect(wrapped.category).toBe('test');
+    expect(wrapped.inputSchema).toEqual(base.inputSchema);
+  });
+
+  it('forwards the context argument to the inner handler', async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const spy: MCPTool = { ...base, handler: async (_i, ctx) => { seen.push(ctx); return {}; } };
+    await withSyntheticNotice(spy, 'x').handler({}, { sessionId: 'abc' });
+    expect(seen[0]).toEqual({ sessionId: 'abc' });
+  });
+
+  it('applySyntheticNotices leaves a tool absent from the map untouched', () => {
+    const other: MCPTool = { ...base, name: 'honest' };
+    const [labelled, untouched] = applySyntheticNotices([base, other], { sample: 'x' });
+    expect(labelled.description).toContain(SYNTHETIC_PREFIX);
+    expect(untouched.description).toBe('Do a thing');
+    expect(untouched).toBe(other);
+  });
+});
+
+describe('labelled tools (#1324, #1325 AC: markers present)', () => {
+  it.each(LABELLED)('%s carries the notice in its description', name => {
+    expect(byName(name).description).toContain(SYNTHETIC_PREFIX);
+  });
+
+  it.each(CHEAP_HANDLER_CASES)('$name returns synthetic: true', async ({ name, input }) => {
+    const result = await byName(name).handler(input) as Record<string, unknown>;
+    expect(result.synthetic).toBe(true);
+    expect(String(result.syntheticNotice)).toContain(SYNTHETIC_PREFIX);
+  });
+
+  it('every labelled tool has a notice that actually says something', () => {
+    for (const name of LABELLED) {
+      const notice = byName(name).description.split(SYNTHETIC_PREFIX)[1] ?? '';
+      expect(notice.trim().length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('boundary — measured tools must stay unlabelled', () => {
+  it.each(NOT_LABELLED)('%s is not marked synthetic in its description', name => {
+    expect(byName(name).description).not.toContain(SYNTHETIC_PREFIX);
+  });
+
+  it('performance_benchmark still reports _real: true, because it really measures', async () => {
+    const result = await byName('performance_benchmark').handler({
+      suite: 'io', iterations: 5, warmup: false,
+    }) as Record<string, unknown>;
+    expect(result._real).toBe(true);
+    expect(result.synthetic).toBeUndefined();
+  });
+});
+
+describe('#1324 — github_pr_manage', () => {
+  const tool = () => byName('github_pr_manage');
+
+  it('states at the call site that no GitHub API call is made', () => {
+    // The pre-fix description was the four words "Manage pull requests"; the
+    // no-API-calls contract lived only in a source header comment, which an
+    // agent selecting a tool never sees.
+    expect(tool().description.toLowerCase()).toContain('no github api call is made');
+    expect(tool().description).not.toBe('Manage pull requests');
+  });
+
+  it('marks a fabricated merge record', async () => {
+    const result = await tool().handler({ action: 'merge', prNumber: 42 }) as Record<string, unknown>;
+    expect(result.synthetic).toBe(true);
+    // Behaviour is unchanged — still reports merged, still returns success.
+    expect(result.action).toBe('merged');
+    expect(result.success).toBe(true);
+  });
+
+  it('marks a fabricated review approval', async () => {
+    const result = await tool().handler({ action: 'review', prNumber: 42 }) as Record<string, unknown>;
+    expect(result.synthetic).toBe(true);
+    expect((result.review as Record<string, unknown>).status).toBe('approved');
+  });
+
+  it('marks the honest list action too — local state is still not GitHub', async () => {
+    const result = await tool().handler({ action: 'list' }) as Record<string, unknown>;
+    expect(result.synthetic).toBe(true);
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.pullRequests)).toBe(true);
+  });
+
+  it('marks the unknown-action error path', async () => {
+    const result = await tool().handler({ action: 'nope' }) as Record<string, unknown>;
+    expect(result.success).toBe(false);
+    expect(result.synthetic).toBe(true);
+  });
+});
+
+describe('#1325 — no response claims authenticity it does not have', () => {
+  it('performance_report no longer returns _real in summary format', async () => {
+    const result = await byName('performance_report').handler({ format: 'summary' }) as Record<string, unknown>;
+    expect(result._real).toBeUndefined();
+    expect(result.synthetic).toBe(true);
+  });
+
+  it('performance_report no longer returns _real in detailed format', async () => {
+    const result = await byName('performance_report').handler({ format: 'detailed' }) as Record<string, unknown>;
+    expect(result._real).toBeUndefined();
+    expect(result.synthetic).toBe(true);
+  });
+
+  it('performance_report still reports the CPU and memory it genuinely measures', async () => {
+    const result = await byName('performance_report').handler({ format: 'summary' }) as Record<string, unknown>;
+    expect(result.cpu).toMatch(/%$/);
+    expect(result.memory).toMatch(/MB \/ \d+MB$/);
+  });
+
+  it('hooks_intelligence no longer advertises REAL metrics', () => {
+    expect(byName('hooks_intelligence').description).not.toMatch(/REAL metrics/i);
+  });
+
+  it('hooks_intelligence-reset warns that nothing is reset', () => {
+    // The strongest case in the set: the others misreport state, this one
+    // reports an action that never happened.
+    expect(byName('hooks_intelligence-reset').description).toContain('NOTHING IS RESET');
+  });
+
+  it('hooks_metrics is labelled, since period is accepted and ignored', async () => {
+    const oneHour = await byName('hooks_metrics').handler({ period: '1h' }) as Record<string, unknown>;
+    const thirtyDays = await byName('hooks_metrics').handler({ period: '30d' }) as Record<string, unknown>;
+    expect(oneHour.synthetic).toBe(true);
+    // Documents the behaviour the notice describes: identical numbers, and the
+    // only difference is the echoed period and the timestamp.
+    expect(oneHour.agents).toEqual(thirtyDays.agents);
+    expect(oneHour.commands).toEqual(thirtyDays.commands);
+  });
+});
+
+describe('#1325 — version is derived, not hardcoded', () => {
+  const pkgVersion = (): string => {
+    const pkg = JSON.parse(readFileSync(resolve(__dirname, '../../../../package.json'), 'utf-8'));
+    return pkg.version as string;
+  };
+
+  it('getMofloVersion resolves this package.json', () => {
+    expect(getMofloVersion()).toBe(pkgVersion());
+    expect(getMofloVersion()).not.toBe(UNKNOWN_VERSION);
+  });
+
+  it('is stable across calls', () => {
+    expect(getMofloVersion()).toBe(getMofloVersion());
+  });
+
+  it('hooks_intelligence reports the real version, not the 3.0.0-alpha.102 literal', async () => {
+    const result = await byName('hooks_intelligence').handler({ showStatus: true }) as Record<string, unknown>;
+    expect(result.version).toBe(pkgVersion());
+    expect(result.version).not.toBe('3.0.0-alpha.102');
+  });
+});

--- a/src/cli/mcp-server.ts
+++ b/src/cli/mcp-server.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { errorDetail } from './shared/utils/error-detail.js';
 import { findProjectRoot } from './services/project-root.js';
+import { getMofloVersion } from './services/moflo-version.js';
 import { readMofloEnv } from './services/env-compat.js';
 
 // ESM-compatible __dirname
@@ -335,22 +336,7 @@ export class MCPServerManager extends EventEmitter {
     const { listMCPTools, callMCPTool, hasTool } = await import('./mcp-client.js');
 
     // Read version dynamically from root moflo package.json
-    let VERSION = '4.6.3';
-    try {
-      const { readFileSync } = await import('fs');
-      const { dirname: _d, join: _j } = await import('path');
-      const { fileURLToPath: _f } = await import('url');
-      let _dir = _d(_f(import.meta.url));
-      for (;;) {
-        try {
-          const _pkg = JSON.parse(readFileSync(_j(_dir, 'package.json'), 'utf8'));
-          if (_pkg.name === 'moflo' && _pkg.version) { VERSION = _pkg.version; break; }
-        } catch {}
-        const _p = _d(_dir);
-        if (_p === _dir) break;
-        _dir = _p;
-      }
-    } catch {}
+    const VERSION = getMofloVersion();
     const sessionId = `mcp-${Date.now()}-${randomUUID().slice(0, 8)}`;
 
     // Log to stderr to not corrupt stdout
@@ -544,7 +530,9 @@ export class MCPServerManager extends EventEmitter {
             id: message.id,
             result: {
               protocolVersion: '2024-11-05',
-              serverInfo: { name: 'moflo', version: '3.0.0' },
+              // The `initialize` reply is where a client learns the server
+              // version; this reported 3.0.0 from a 4.x package (#1325).
+              serverInfo: { name: 'moflo', version: getMofloVersion() },
               capabilities: {
                 tools: { listChanged: true },
                 resources: { subscribe: true, listChanged: true },

--- a/src/cli/mcp-tools/github-tools.ts
+++ b/src/cli/mcp-tools/github-tools.ts
@@ -10,6 +10,7 @@
  */
 
 import type { MCPTool } from './types.js';
+import { applySyntheticNotices } from './synthetic.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
@@ -72,10 +73,10 @@ function saveGitHubStore(store: GitHubStore): void {
   writeFileSync(getGitHubPath(), JSON.stringify(store, null, 2), 'utf-8');
 }
 
-export const githubTools: MCPTool[] = [
+const rawGithubTools: MCPTool[] = [
   {
     name: 'github_repo_analyze',
-    description: 'Analyze a GitHub repository',
+    description: 'Record a placeholder repository analysis in local state',
     category: 'github',
     inputSchema: {
       type: 'object',
@@ -129,7 +130,7 @@ export const githubTools: MCPTool[] = [
   },
   {
     name: 'github_pr_manage',
-    description: 'Manage pull requests',
+    description: 'Track pull-request coordination state locally',
     category: 'github',
     inputSchema: {
       type: 'object',
@@ -231,7 +232,7 @@ export const githubTools: MCPTool[] = [
   },
   {
     name: 'github_issue_track',
-    description: 'Track and manage issues',
+    description: 'Track issue coordination state locally',
     category: 'github',
     inputSchema: {
       type: 'object',
@@ -316,7 +317,7 @@ export const githubTools: MCPTool[] = [
   },
   {
     name: 'github_metrics',
-    description: 'Get repository metrics and statistics',
+    description: 'Return placeholder repository metrics',
     category: 'github',
     inputSchema: {
       type: 'object',
@@ -365,3 +366,20 @@ export const githubTools: MCPTool[] = [
     },
   },
 ];
+
+/**
+ * Every tool in this file is local-only, so all four are labelled (#1324).
+ * The header comment above has said so since the file was written — but a
+ * source comment is invisible to the agent choosing a tool, which is exactly
+ * how a fabricated `merged`/`approved` record ends up read as a real one.
+ */
+export const githubTools: MCPTool[] = applySyntheticNotices(rawGithubTools, {
+  github_repo_analyze:
+    'no repository is read and no GitHub API call is made. Metrics, code quality, test coverage and security-issue counts are generated placeholders, not measurements.',
+  github_pr_manage:
+    'local coordination state only — no GitHub API call is made, so no PR is created, reviewed, merged or closed on GitHub. "approved" and "merged" results describe nothing that happened. Use the `gh` CLI or a GitHub MCP server for real operations.',
+  github_issue_track:
+    'local coordination state only — no GitHub API call is made, so no issue is created, updated, closed or assigned on GitHub. Use the `gh` CLI or a GitHub MCP server for real operations.',
+  github_metrics:
+    'no repository is read and no GitHub API call is made. Every count is a generated placeholder and changes on each call.',
+});

--- a/src/cli/mcp-tools/hooks-tools.ts
+++ b/src/cli/mcp-tools/hooks-tools.ts
@@ -8,6 +8,8 @@ import { dirname, join, resolve, extname } from 'path';
 import type { MCPTool } from './types.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { findProjectRoot } from '../services/project-root.js';
+import { withSyntheticNotice } from './synthetic.js';
+import { getMofloVersion } from '../services/moflo-version.js';
 
 // Real vector search functions - lazy loaded to avoid circular imports
 let searchEntriesFn: ((options: {
@@ -940,9 +942,9 @@ export const hooksRoute: MCPTool = {
   },
 };
 
-export const hooksMetrics: MCPTool = {
+export const hooksMetrics: MCPTool = withSyntheticNotice({
   name: 'hooks_metrics',
-  description: 'View learning metrics dashboard',
+  description: 'Return a placeholder learning-metrics dashboard',
   inputSchema: {
     type: 'object',
     properties: {
@@ -951,6 +953,8 @@ export const hooksMetrics: MCPTool = {
     },
   },
   handler: async (params: Record<string, unknown>) => {
+    // `period` is echoed back but never applied (#1325) — every branch below
+    // is a literal, so 1h and 30d return byte-identical numbers.
     const period = (params.period as string) || '24h';
 
     return {
@@ -980,7 +984,7 @@ export const hooksMetrics: MCPTool = {
       lastUpdated: new Date().toISOString(),
     };
   },
-};
+}, 'every value is a hardcoded literal. `period` is accepted and ignored, so 1h and 30d return identical numbers; nothing here is counted, routed or executed.');
 
 export const hooksList: MCPTool = {
   name: 'hooks_list',
@@ -2170,9 +2174,9 @@ export const hooksSessionRestore: MCPTool = {
 };
 
 // Intelligence hook - MoVector intelligence system
-export const hooksIntelligence: MCPTool = {
+export const hooksIntelligence: MCPTool = withSyntheticNotice({
   name: 'hooks_intelligence',
-  description: 'MoVector intelligence system status (shows REAL metrics from memory store)',
+  description: 'MoVector intelligence system status',
   inputSchema: {
     type: 'object',
     properties: {
@@ -2260,6 +2264,9 @@ export const hooksIntelligence: MCPTool = {
         memory: realStats.memory,
         routing: realStats.routing,
       },
+      // Nothing checks these subsystems (#1325). The list is a literal, so
+      // `partial` and `notImplemented` are empty by construction — this
+      // asserts that all twelve work no matter what state they are in.
       implementationStatus: {
         working: [
           'memory-store', 'embeddings', 'trajectory-recording', 'claims', 'swarm-coordination',
@@ -2269,13 +2276,13 @@ export const hooksIntelligence: MCPTool = {
         partial: [],
         notImplemented: [],
       },
-      version: '3.0.0-alpha.102',
+      version: getMofloVersion(),
     };
   },
-};
+}, 'the "real" counts read `.moflo/memory/store.json`, a JSON store this version no longer writes, so they resolve to zeros rather than reflecting the memory backend. `implementationStatus` is a hardcoded list asserting all twelve subsystems work, checked against nothing.');
 
 // Intelligence reset hook
-export const hooksIntelligenceReset: MCPTool = {
+export const hooksIntelligenceReset: MCPTool = withSyntheticNotice({
   name: 'hooks_intelligence-reset',
   description: 'Reset intelligence learning state',
   inputSchema: {
@@ -2283,6 +2290,15 @@ export const hooksIntelligenceReset: MCPTool = {
     properties: {},
   },
   handler: async () => {
+    // This handler has no side effects at all — it clears nothing and the
+    // three counts are literals (#1325). It is the worst of the labelled set:
+    // the others report a state falsely, this one reports an ACTION that
+    // never happened, and a caller can act on believing state was cleared.
+    //
+    // Labelling is not the fix here — it is a floor. The real repair is
+    // either a working reset or an explicit failure, and both are behaviour
+    // changes tracked separately. Until then the response at least stops
+    // presenting itself as a completed reset.
     return {
       reset: true,
       cleared: {
@@ -2293,7 +2309,7 @@ export const hooksIntelligenceReset: MCPTool = {
       timestamp: new Date().toISOString(),
     };
   },
-};
+}, 'NOTHING IS RESET. This handler has no side effects — no trajectory, pattern or index entry is cleared, and the counts below are hardcoded literals, not a tally of what was removed. Do not treat a call to this tool as having cleared any state.');
 
 // Pattern store/search hooks - REAL implementation using storeEntry
 export const hooksPatternStore: MCPTool = {

--- a/src/cli/mcp-tools/neural-tools.ts
+++ b/src/cli/mcp-tools/neural-tools.ts
@@ -11,6 +11,7 @@
  */
 
 import type { MCPTool } from './types.js';
+import { applySyntheticNotices } from './synthetic.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
@@ -169,10 +170,10 @@ function cosineSimilarity(a: number[], b: number[]): number {
   return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB) || 1);
 }
 
-export const neuralTools: MCPTool[] = [
+const rawNeuralTools: MCPTool[] = [
   {
     name: 'neural_train',
-    description: 'Train a neural model',
+    description: 'Register a model entry with a placeholder accuracy',
     category: 'neural',
     inputSchema: {
       type: 'object',
@@ -207,7 +208,11 @@ export const neuralTools: MCPTool[] = [
       store.models[modelId] = model;
       saveNeuralStore(store);
 
-      // Simulate training
+      // No training happens (#1325). The sleep below is not work, and the
+      // accuracy assigned after it is a random draw in [0.85, 0.95) — it is
+      // unrelated to `input.data`, `epochs` or `learningRate`, all of which
+      // are recorded and never used. Note this accuracy is PERSISTED, so
+      // `neural_status`'s avgAccuracy averages these placeholders too.
       await new Promise(resolve => setTimeout(resolve, 100));
 
       model.status = 'ready';
@@ -228,7 +233,7 @@ export const neuralTools: MCPTool[] = [
   },
   {
     name: 'neural_predict',
-    description: 'Make predictions using a neural model',
+    description: 'Embed the input for real, and return placeholder predictions',
     category: 'neural',
     inputSchema: {
       type: 'object',
@@ -252,7 +257,10 @@ export const neuralTools: MCPTool[] = [
         return { success: false, error: 'Model not ready' };
       }
 
-      // Simulate predictions
+      // The labels are a fixed list and the confidences are random draws
+      // (#1325) — no model is consulted, and the ranking does not depend on
+      // `inputText`. The embedding computed below IS real; the predictions
+      // sitting beside it in the same response are not.
       const predictions = [
         { label: 'coder', confidence: 0.75 + Math.random() * 0.2 },
         { label: 'researcher', confidence: 0.5 + Math.random() * 0.3 },
@@ -454,3 +462,19 @@ export const neuralTools: MCPTool[] = [
     },
   },
 ];
+
+/**
+ * `neural_patterns` and `neural_status` are left unlabelled: their embeddings
+ * come from the real embedding service and their cosine similarity is really
+ * computed, so blanket-labelling the file would put a SYNTHETIC banner on the
+ * one part of it that measures something. `neural_status.avgAccuracy` is the
+ * exception — it averages the placeholder accuracies `neural_train` persists —
+ * which is called out at the assignment site rather than by mislabelling the
+ * whole tool.
+ */
+export const neuralTools: MCPTool[] = applySyntheticNotices(rawNeuralTools, {
+  neural_train:
+    'no model is trained. The call sleeps 100ms and assigns a random accuracy in [0.85, 0.95); `epochs`, `learningRate` and `data` are recorded but never used. The accuracy is persisted, so later readers inherit it.',
+  neural_predict:
+    'the returned `embedding` is real, computed by the embedding service. The `predictions` are not — the labels are a fixed list with random confidences and do not depend on the input.',
+});

--- a/src/cli/mcp-tools/performance-tools.ts
+++ b/src/cli/mcp-tools/performance-tools.ts
@@ -11,6 +11,7 @@
  */
 
 import type { MCPTool } from './types.js';
+import { applySyntheticNotices } from './synthetic.js';
 import * as os from 'node:os';
 import { createJsonStore } from './json-store.js';
 
@@ -48,10 +49,10 @@ const store = createJsonStore<PerfStore>({
   defaults: () => ({ metrics: [], benchmarks: {}, version: '3.0.0' }),
 });
 
-export const performanceTools: MCPTool[] = [
+const rawPerformanceTools: MCPTool[] = [
   {
     name: 'performance_report',
-    description: 'Generate performance report',
+    description: 'Report process CPU and memory, with placeholder latency and throughput',
     category: 'performance',
     inputSchema: {
       type: 'object',
@@ -84,6 +85,11 @@ export const performanceTools: MCPTool[] = [
           total: Math.round(totalMem / 1024 / 1024),
           heap: Math.round(memUsage.heapUsed / 1024 / 1024),
         },
+        // NOT measured (#1325). Nothing in this process is timed to produce
+        // these; the seeds below are constants, and every later call averages
+        // this tool's own prior outputs — so the numbers converge on the seed
+        // no matter how the system actually behaves. Left as-is because
+        // changing them is a behaviour change; the tool is labelled instead.
         latency: {
           avg: state.metrics.length > 0 ? state.metrics.slice(-10).reduce((s, m) => s + m.latency.avg, 0) / Math.min(state.metrics.length, 10) : 50,
           p50: state.metrics.length > 0 ? state.metrics.slice(-10).reduce((s, m) => s + m.latency.p50, 0) / Math.min(state.metrics.length, 10) : 40,
@@ -106,7 +112,6 @@ export const performanceTools: MCPTool[] = [
 
       if (format === 'summary') {
         return {
-          _real: true,
           status: 'healthy',
           cpu: `${currentMetrics.cpu.usage.toFixed(1)}%`,
           memory: `${currentMetrics.memory.used}MB / ${currentMetrics.memory.total}MB`,
@@ -128,7 +133,6 @@ export const performanceTools: MCPTool[] = [
         : 'stable';
 
       return {
-        _real: true,
         current: currentMetrics,
         history,
         system: {
@@ -284,3 +288,19 @@ export const performanceTools: MCPTool[] = [
     },
   },
 ];
+
+/**
+ * Only `performance_report` is labelled. `performance_benchmark` genuinely
+ * measures — it runs real workloads and times them with `performance.now()`,
+ * so its `_real: true` is accurate and stays. (The `Math.random()` calls in
+ * its benchmark functions generate the workload; they are not the result.)
+ *
+ * `performance_report`'s `_real: true` was removed rather than kept alongside
+ * the notice: a response cannot be both authentic and synthetic, and a wrong
+ * authenticity claim is worse than an unlabelled number — a caller can
+ * discount an unmarked figure, but not one asserted as measured (#1325).
+ */
+export const performanceTools: MCPTool[] = applySyntheticNotices(rawPerformanceTools, {
+  performance_report:
+    'CPU, memory and heap are measured from this process. Latency and throughput are NOT — they seed to constants and each call averages this tool\'s own prior outputs, so they describe no real request.',
+});

--- a/src/cli/mcp-tools/synthetic.ts
+++ b/src/cli/mcp-tools/synthetic.ts
@@ -1,0 +1,78 @@
+/**
+ * Synthetic-response labeling for MCP tools (#1324, #1325).
+ *
+ * Several registered MCP tools return values that look like measurements but
+ * are not: hardcoded literals, `Math.random()` draws, or local coordination
+ * state that never reaches the service it appears to describe. They stay
+ * registered — removing them would break callers that use the honest parts —
+ * but a caller must be able to tell the difference, and today it cannot.
+ *
+ * `withSyntheticNotice` attaches one notice in both places a caller can see:
+ *
+ * - **`description`**, which the MCP server returns verbatim from
+ *   `tools/list`, so the contract is visible at tool-*selection* time. A
+ *   source-file header comment is not — that was the gap in #1324.
+ * - **every response object**, so a record captured from a call is still
+ *   self-describing afterwards, when nobody remembers which tool produced it.
+ *
+ * Wrapping the tool rather than editing each `return` is deliberate: these
+ * handlers have 20+ return sites between them, and a missed one produces
+ * exactly the unlabelled fabrication this module exists to prevent.
+ *
+ * This is labeling only. No handler's success/failure behaviour changes, and
+ * nothing that works today starts failing — see the issues for why the
+ * behaviour fixes (`merge` reporting success for a PR it never found,
+ * `hooks_intelligence-reset` reporting a reset it never performs) are tracked
+ * separately.
+ */
+
+import type { MCPTool } from './types.js';
+
+/**
+ * Uppercase so it survives an agent skimming a long tool list, and greppable
+ * so a consumer can audit which of their tools are labelled.
+ */
+export const SYNTHETIC_PREFIX = 'SYNTHETIC:';
+
+/**
+ * Wrap a tool so its description and every object response carry `notice`.
+ *
+ * Non-object returns (a bare string, an array) pass through untouched — there
+ * is nowhere to attach a field without changing the response's shape, and a
+ * shape change is a behaviour change. No such handler exists among the tools
+ * wrapped today; the guard is here so adding one later fails visibly as an
+ * unlabelled response rather than a corrupted one.
+ */
+export function withSyntheticNotice<T extends MCPTool>(tool: T, notice: string): T {
+  const inner = tool.handler;
+  const full = `${SYNTHETIC_PREFIX} ${notice}`;
+
+  return {
+    ...tool,
+    description: `${tool.description}. ${full}`,
+    handler: async (input, context) => {
+      const result = await inner(input, context);
+      if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
+      // Spread first: the marker is authoritative and must win over any
+      // same-named field a handler happens to return.
+      return { ...(result as Record<string, unknown>), synthetic: true, syntheticNotice: full };
+    },
+  };
+}
+
+/**
+ * Apply per-tool notices to a tool array by name.
+ *
+ * A name absent from `notices` passes through unwrapped, which is the correct
+ * default: tools in these files that genuinely measure something
+ * (`performance_benchmark` times real work, `neural_patterns` computes real
+ * cosine similarity) must not be labelled synthetic. The labeling test pins
+ * both sets by name, so an omission on either side is caught rather than
+ * shipped.
+ */
+export function applySyntheticNotices(tools: MCPTool[], notices: Record<string, string>): MCPTool[] {
+  return tools.map(tool => {
+    const notice = notices[tool.name];
+    return notice ? withSyntheticNotice(tool, notice) : tool;
+  });
+}

--- a/src/cli/mcp-tools/system-tools.ts
+++ b/src/cli/mcp-tools/system-tools.ts
@@ -9,6 +9,7 @@
  */
 
 import type { MCPTool } from './types.js';
+import { applySyntheticNotices } from './synthetic.js';
 import { createJsonStore } from './json-store.js';
 
 interface SystemMetrics {
@@ -39,10 +40,10 @@ const store = createJsonStore<SystemMetrics>({
   }),
 });
 
-export const systemTools: MCPTool[] = [
+const rawSystemTools: MCPTool[] = [
   {
     name: 'system_health',
-    description: 'Perform system health check',
+    description: 'Report component health from mostly-placeholder checks',
     category: 'system',
     inputSchema: {
       type: 'object',
@@ -56,6 +57,11 @@ export const systemTools: MCPTool[] = [
       const metrics = store.load();
       const checks: Array<{ name: string; status: string; latency: number; message?: string }> = [];
 
+      // Nothing below is probed (#1325): every `status` except `neural` is the
+      // literal 'healthy', and every `latency` is a random draw rather than a
+      // timed round-trip. A component that is genuinely down still reports
+      // healthy here. Left as-is — a real probe is a behaviour change — so the
+      // tool carries a synthetic notice instead.
       // Core checks
       checks.push({
         name: 'swarm',
@@ -126,3 +132,14 @@ export const systemTools: MCPTool[] = [
     },
   },
 ];
+
+/**
+ * `score` IS computed (`healthy / total`), so it is not a literal — but it is
+ * computed from inputs that are almost all hardcoded, which makes the number
+ * arithmetic over placeholders rather than a measurement. The notice says so
+ * rather than claiming the whole response is invented.
+ */
+export const systemTools: MCPTool[] = applySyntheticNotices(rawSystemTools, {
+  system_health:
+    'no component is probed. Every status except `neural` is hardcoded healthy and every latency is a random draw, so `score` is arithmetic over placeholders — a failing component still reports healthy. The `fix` parameter is accepted and ignored.',
+});

--- a/src/cli/services/daemon-lock.ts
+++ b/src/cli/services/daemon-lock.ts
@@ -50,7 +50,10 @@ export function lockPath(projectRoot: string): string {
 /**
  * Read this daemon's own moflo package version by walking up from the
  * compiled module location until a `package.json` with `"name": "moflo"`
- * is found. Mirrors the pattern in `mcp-server.ts:260-279`. Returns
+ * is found. Duplicates `services/moflo-version.ts:getMofloVersion`, kept
+ * separate on purpose: this one must NOT cache (the launcher compares a
+ * running daemon's version against the installed package across an upgrade)
+ * and returns `undefined` rather than a placeholder. Returns
  * `undefined` if the package.json can't be located — the launcher treats
  * an undefined version the same as a mismatch, so this stays safe.
  */

--- a/src/cli/services/moflo-version.ts
+++ b/src/cli/services/moflo-version.ts
@@ -1,0 +1,63 @@
+/**
+ * Resolve moflo's own package version at runtime.
+ *
+ * Walks upward from this file looking for the `package.json` whose `name` is
+ * `moflo`. The upward walk — rather than a fixed `../../..` — is what makes
+ * one implementation correct from both layouts this code runs in:
+ *
+ * - source tree:  `src/cli/services/`      -> repo-root `package.json`
+ * - installed:    `.../moflo/dist/src/cli/services/` -> `.../moflo/package.json`
+ *
+ * The depth differs between those two, so any hardcoded relative path is wrong
+ * in one of them. Matching on `name === 'moflo'` also means a consumer's own
+ * `package.json` encountered on the way up is skipped rather than reported as
+ * moflo's version.
+ *
+ * Cross-platform (Rule #1): `dirname`/`join` build every path, and the
+ * `dirname(dir) === dir` termination reaches the root identically on POSIX
+ * (`/`) and Windows (`C:\`).
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Reported when the walk finds no moflo `package.json` — never throws. */
+export const UNKNOWN_VERSION = 'unknown';
+
+let cached: string | null = null;
+
+/**
+ * moflo's version string, or {@link UNKNOWN_VERSION} if it cannot be resolved.
+ *
+ * Callers are diagnostic surfaces (MCP `initialize`, status reporting), so a
+ * missing or unreadable `package.json` degrades to a placeholder rather than
+ * failing the call.
+ */
+export function getMofloVersion(): string {
+  if (cached !== null) return cached;
+
+  let version = UNKNOWN_VERSION;
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (;;) {
+      try {
+        const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
+        if (pkg.name === 'moflo' && typeof pkg.version === 'string') {
+          version = pkg.version;
+          break;
+        }
+      } catch {
+        // No package.json here, or unreadable — keep walking up.
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // import.meta.url unavailable in an exotic host — keep the placeholder.
+  }
+
+  cached = version;
+  return version;
+}


### PR DESCRIPTION
Closes #1324
Closes #1325

Eleven registered MCP tools return hardcoded literals, `Math.random()` draws, or local-only state that never reaches the service they appear to describe. Nothing in the request/response exchange distinguished those results from measurements, and two tools actively asserted authenticity — the part that makes the numbers undiscountable rather than merely useless.

Both issues proposed the same least-intrusive shape, and #1325 explicitly said "consistent with #1324", so they are fixed together. They also overlap in `github-tools.ts`.

**Labeling only.** No handler's success/failure behaviour changes and nothing that works today starts failing.

## The gap the tickets named

`github-tools.ts` has carried a prominent `NO actual GitHub API calls are made` banner at the top of the file since it was written. But the description an MCP caller receives was the four words `Manage pull requests`. A source comment is invisible to the agent choosing a tool — so an agent selects a PR manager, calls `merge`, and gets back a record indistinguishable from a real one. This repo merges via real `gh pr merge`, which is exactly where a fabricated `merged`/`approved` record could be mistaken for evidence a PR passed review.

## What changed

A `withSyntheticNotice` wrapper attaches one notice in both places a caller can see it:

- the `description` the MCP server returns verbatim from `tools/list`, so the contract is visible at tool-**selection** time
- every response object, so a captured record stays self-describing afterwards

Wrapping the tool rather than editing each `return` was deliberate — these handlers have 20+ return sites between them, and a missed one produces exactly the unlabelled fabrication this exists to prevent.

**The boundary is pinned as hard as the labels.** `performance_benchmark` times real workloads, `neural_patterns` computes real cosine similarity, `neural_status` reports real store counts — all three are asserted *unlabelled* by name. A SYNTHETIC banner on a real result degrades the marker into noise.

### False authenticity claims removed, not labelled around

A response cannot be both measured and synthetic:

- `performance_report`'s `_real: true` — its latency seeds to constants `50/40/100/200` and then averages its own prior outputs, so it converges on the seed regardless of system behaviour. Kept on `performance_benchmark`, where it is accurate.
- `hooks_intelligence`'s `shows REAL metrics from memory store` — it reads `.moflo/memory/store.json`, a path this version no longer writes, so the "real" counts resolved to zeros.

### Two stale version literals

`hooks_intelligence` reported `3.0.0-alpha.102` from a 4.x package. Found while verifying: the MCP `initialize` reply — where a client actually learns the server version — reported a hardcoded `3.0.0`. Both now derive from `package.json` via a new `getMofloVersion()`, which walks upward to the `package.json` named `moflo` because the depth differs between the source tree and an installed `node_modules/moflo` — any fixed relative path is wrong in one of them. This also removes the inline copy of that walk from `mcp-server.ts`.

## Beyond the issues

- **`github_repo_analyze`** fabricates `testCoverage` and `securityIssues` exactly the way `github_metrics` does — the two fields that most invite trust — so it is labelled too, along with `github_issue_track`.
- **`hooks_intelligence-reset`** is labelled despite #1325 excluding it. Labeling is *not* the fix for a handler that reports an action it never performs — it clears nothing while reporting 12,500 HNSW entries removed — but it is a floor, and leaving the single worst case as the only unlabelled one was not defensible. Its notice leads with `NOTHING IS RESET`. The real repair, a working reset or an explicit failure, is a behaviour decision still to be taken.

## Known, deliberately not fixed here

Behaviour changes, out of scope for a labeling PR — each is recorded in the issues:

- `github_pr_manage merge` returns `success: true` for a PR number absent from the store
- `github_pr_manage create` builds `.../pull/pr-<timestamp>`, which is not a valid PR URL
- `neural_train` **persists** its placeholder accuracy, so `neural_status.avgAccuracy` averages placeholders — called out at the assignment site
- `hooks-tools.ts` resolves the memory path against `process.cwd()` rather than the project root. Left alone on purpose: correcting it could start surfacing a stale `store.json` as current data, which is worse than the zeros it returns now.

`readOwnMofloVersion` in `daemon-lock.ts` duplicates the new helper and was **not** consolidated — it must not cache (the launcher compares a running daemon's version against the installed package across an upgrade) and daemon identity is not the place for a drive-by cleanup. The reason is now recorded in its docstring.

## Consumer impact

- **Surface:** `src/cli/mcp-tools/` — every consumer's MCP server.
- **Failure mode:** responses gain two keys and descriptions gain a suffix. Purely additive; a consumer reading known fields is unaffected. `tools/list` costs ~2KB more per session. Agents should now *avoid* these tools where they were previously misled into using them — which is the intent.
- **Round-trip:** needs publish + reinstall to take effect in dogfood, since the MCP server runs from `node_modules/moflo`.

## Verification

- 50 new tests in `src/cli/__tests__/mcp-tools/synthetic-labeling.test.ts`, covering the wrapper (marker override, non-object passthrough, error propagation, context forwarding), both the labelled and unlabelled sets by name, and each AC from both issues.
- Full suite **9735 passed / 0 failed**; build and lint clean.
- An end-to-end probe through the real MCP registry rather than the module exports — a label present on the export but lost in registration would have surfaced there. It confirmed all eleven tools registered and labelled, the three measured tools unlabelled, `synthetic=true` on live `callMCPTool` responses, and `version=4.12.3` matching `package.json`.

Cross-platform (Rule #1): no new path handling beyond `getMofloVersion`, which uses `dirname`/`join` and a root-termination check that behaves identically on POSIX and Windows. Test temp roots go through `realpathSync` for macOS `/var` → `/private/var`.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)