### PR TITLE
fix(spells): agent step fails loudly instead of faking success (#1334)

### DIFF
--- a/.claude/guidance/shipped/moflo-spell-engine.md
+++ b/.claude/guidance/shipped/moflo-spell-engine.md
@@ -1,6 +1,6 @@
 # Spell Engine — Definition Format & Step Types
 
-**Purpose:** How to define a spell (YAML/JSON schema, arguments, steps, variable interpolation) and a reference for the nine built-in step command types. For execution mechanics (running, dry-run, error codes, pause/resume, layering, credentials), see `.claude/guidance/moflo-spell-runner.md`.
+**Purpose:** How to define a spell (YAML/JSON schema, arguments, steps, variable interpolation) and a reference for the built-in step command types. For execution mechanics (running, dry-run, error codes, pause/resume, layering, credentials), see `.claude/guidance/moflo-spell-runner.md`.
 
 ---
 
@@ -96,16 +96,16 @@ steps:
     config:
       command: "curl -s {args.api_url}"
   - id: process
-    type: agent
+    type: bash
     config:
-      prompt: "Analyze this response: {fetch-url.stdout}"
+      command: 'claude -p "Analyze this response: {fetch-url.stdout}"'
 ```
 
 ---
 
 ## Step Command Types
 
-**Nine built-in step types are registered automatically.** Each implements `execute()`, `validate()`, `describeOutputs()`, and optional `rollback()`. To add new step types via JS/TS files, YAML composite steps, or `moflo-step-*` npm packages, see `.claude/guidance/moflo-spell-custom-steps.md`.
+**Fifteen built-in step types are registered automatically** (one of them, `agent`, is registered but not executable — see below). Each implements `execute()`, `validate()`, `describeOutputs()`, and optional `rollback()`. To add new step types via JS/TS files, YAML composite steps, or `moflo-step-*` npm packages, see `.claude/guidance/moflo-spell-custom-steps.md`.
 
 ### bash — Run a Shell Command
 
@@ -122,18 +122,21 @@ steps:
 
 ---
 
-### agent — Spawn a Claude Subagent
+### agent — NOT EXECUTABLE
+
+**Do not use this step type.** It has never spawned a subagent — moflo has no agent spawner in the spell runner. It is still registered so existing spell YAML keeps parsing, but casting it now always fails with an explanatory error (#1334). Earlier versions returned `success: true` and a `result` string for work that never happened.
+
+**To run a Claude subagent from a spell, use a `bash` step:**
 
 ```yaml
 - id: research
-  type: agent
+  type: bash
   config:
-    agentType: "researcher"     # Required. researcher, coder, tester, etc.
-    prompt: "Find all API endpoints in {args.directory}"  # Required.
-    background: false           # Optional. Default false.
+    command: 'claude -p "Find all API endpoints in {args.directory}"'
+    timeout: 300000
 ```
 
-**Outputs:** `result` (string), `agentType` (string), `prompt` (string).
+**Outputs:** none — the step always fails. `agentType` and `prompt` are echoed in the failure for diagnosis only.
 
 ---
 

--- a/.claude/skills/connector-builder/SKILL.md
+++ b/.claude/skills/connector-builder/SKILL.md
@@ -118,12 +118,13 @@ steps:
       command: "echo 'preparing...'"
 
   - name: use-<name>
-    type: agent
+    type: <name>          # the step command registered in Step 4
     config:
-      prompt: |
-        Use the <name> connector to <action-1>.
-        Access via context.tools.execute('<name>', '<action-1>', { ... })
+      action: <action-1>
+      # ...action params
 ```
+
+**Do not reach a connector from an `agent` step.** That step type has never been executable. A connector is reached from its own step command (Step 4 above), from a composite step's `tool` action, or from a custom step command.
 
 ---
 

--- a/.claude/skills/spell-builder/SKILL.md
+++ b/.claude/skills/spell-builder/SKILL.md
@@ -314,11 +314,12 @@ steps:
     output: audit-result
 
   - id: analyze-findings
-    type: agent
+    type: bash
     config:
-      prompt: |
-        Analyze the npm audit results and filter for severity >= {args.severity}.
-        Audit output: {scan-deps.result}
+      command: |
+        claude -p "Analyze these npm audit results and filter for severity >= {args.severity}.
+        Audit output: {scan-deps.stdout}"
+      timeout: 300000
     output: analysis
 
   - id: save-report

--- a/.claude/skills/spell-builder/architecture.md
+++ b/.claude/skills/spell-builder/architecture.md
@@ -136,11 +136,11 @@ steps:
     output: inbox          # ← stores output as "inbox"
 
   - id: process
-    type: agent
+    type: bash
     config:
-      prompt: |
-        Emails: {inbox.emails}            # ← references inbox output
-        Total: {inbox.totalEmails}
+      command: |
+        claude -p "Emails: {inbox.emails}   # ← references inbox output
+        Total: {inbox.totalEmails}"
 ```
 
 **Variable reference rules:**

--- a/.claude/skills/spell-builder/connectors/github-cli/README.md
+++ b/.claude/skills/spell-builder/connectors/github-cli/README.md
@@ -1,31 +1,36 @@
 # `github-cli` — GitHub CLI Connector
 
-**Purpose:** Use this connector to execute GitHub CLI operations from agent steps or as the backing connector for the `github` step command. Choose this when you need programmatic access to GitHub issues, PRs, and repos.
+**Purpose:** Use this connector as the backing connector for the `github` step command, or from a custom step command. Choose this when you need programmatic access to GitHub issues, PRs, and repos.
 
 ## Usage
 
+From a spell, reach this connector through the `github` step, which delegates to it:
+
 ```yaml
-- id: list-open-bugs
-  type: agent
+- id: fetch-bug
+  type: github
   config:
-    prompt: |
-      Use the github-cli connector to find open bugs.
-      Call context.tools.execute('github-cli', 'issue-list', {
-        repo: 'my-org/backend-api',
-        labels: ['bug'],
-        state: 'open'
-      })
+    action: issue-fetch
+    issue: 42
+    fields: ["number", "title", "labels", "state"]
 ```
+
+> Earlier revisions of this file showed an `agent` step calling `context.tools.execute(...)` from a prompt. The `agent` step type has never been executable — use the `github` step, a composite step's `tool` action, or a custom step command.
 
 ## Actions
 
-| Action | Description |
-|--------|-------------|
-| `issue-create` | Create a new GitHub issue |
-| `issue-list` | List issues with optional filters |
-| `pr-create` | Create a pull request |
-| `pr-list` | List pull requests with optional filters |
-| `repo-view` | View repository metadata |
+Taken from `VALID_ACTIONS` in `src/cli/spells/connectors/github-cli.ts`. `issue-create`, `issue-list`, `pr-list` and `repo-view` were listed here previously but have never existed.
+
+| Action | Required params | Description |
+|--------|-----------------|-------------|
+| `issue-fetch` | `issue` | Fetch issue details as JSON (`fields` selects columns) |
+| `issue-edit` | `issue` | Edit an existing issue |
+| `pr-create` | `title` | Create a pull request |
+| `pr-merge` | `pr` or `issue` | Merge a PR (`mergeMethod`: squash \| merge \| rebase) |
+| `pr-find` | `head` or `search` | Find a PR by head branch or search query |
+| `label` | (`issue` or `pr`) + `labels` | Add/remove labels |
+| `comment` | (`issue` or `pr`) + `body` | Post a comment |
+| `repo-info` | — | View repository metadata |
 
 ## Direct Usage
 

--- a/.claude/skills/spell-builder/connectors/http/README.md
+++ b/.claude/skills/spell-builder/connectors/http/README.md
@@ -1,21 +1,28 @@
 # `http` — HTTP Requests
 
-**Purpose:** Use this connector to make HTTP requests to any URL from within agent steps. Choose this when you need to call REST APIs, fetch data, or post payloads during spell execution.
+**Purpose:** Use this connector to make HTTP requests to any URL. Choose this when you need to call REST APIs, fetch data, or post payloads during spell execution.
 
 ## Usage
 
+Unlike `playwright`/`github-cli`/`local-outlook`, this connector has **no dedicated step type**. Reach it from a composite (YAML) step's `tool` action:
+
 ```yaml
-- id: fetch-status
-  type: agent
-  config:
-    prompt: |
-      Use the http connector to check the deployment status.
-      Call context.tools.execute('http', 'request', {
-        method: 'GET',
-        url: 'https://api.myapp.com/deploy/status',
-        headers: { 'Authorization': 'Bearer {credentials.API_TOKEN}' }
-      })
+name: fetch-status
+inputs:
+  token: { type: string }
+actions:
+  - tool: http
+    action: request
+    params:
+      method: GET
+      url: "https://api.myapp.com/deploy/status"
+      headers:
+        Authorization: "Bearer ${inputs.token}"
 ```
+
+…or from a custom step command via the Direct Usage API below. See `.claude/guidance/moflo-spell-custom-steps.md`.
+
+> Earlier revisions of this file showed an `agent` step calling `context.tools.execute(...)` from a prompt. The `agent` step type has never been executable.
 
 ## Actions
 

--- a/.claude/skills/spell-builder/connectors/local-outlook/README.md
+++ b/.claude/skills/spell-builder/connectors/local-outlook/README.md
@@ -4,17 +4,18 @@
 
 ## Usage
 
+From a spell, reach this connector through the `outlook` step, which delegates to it:
+
 ```yaml
 - id: check-for-invoices
-  type: agent
+  type: outlook
   config:
-    prompt: |
-      Use the local-outlook connector to search for recent invoices.
-      Call context.tools.execute('local-outlook', 'search', {
-        query: 'invoice from:billing@vendor.com',
-        limit: 5
-      })
+    action: search
+    query: "invoice from:billing@vendor.com"
+    limit: 5
 ```
+
+> Earlier revisions of this file showed an `agent` step calling `context.tools.execute(...)` from a prompt. The `agent` step type has never been executable — use the `outlook` step, a composite step's `tool` action, or a custom step command.
 
 ## Actions
 

--- a/.claude/skills/spell-builder/connectors/playwright/README.md
+++ b/.claude/skills/spell-builder/connectors/playwright/README.md
@@ -1,20 +1,22 @@
 # `playwright` — Browser Automation Connector
 
-**Purpose:** Use this connector for low-level browser automation via Playwright. Choose this when you need direct browser control from agent steps, or when building browser-based connectors like `local-outlook`.
+**Purpose:** Use this connector for low-level browser automation via Playwright. Choose this when you need direct browser control from a step command, or when building browser-based connectors like `local-outlook`.
 
 ## Usage
 
+From a spell, reach this connector through the `browser` step, which delegates to it:
+
 ```yaml
 - id: take-screenshot
-  type: agent
+  type: browser
   config:
-    prompt: |
-      Use the playwright connector to screenshot the homepage.
-      Call context.tools.execute('playwright', 'navigate', {
-        url: 'https://myapp.com'
-      })
-      Then call context.tools.execute('playwright', 'screenshot', {})
+    actions:
+      - action: navigate
+        url: "https://myapp.com"
+      - action: screenshot
 ```
+
+> Earlier revisions of this file showed an `agent` step calling `context.tools.execute(...)` from a prompt. The `agent` step type has never been executable — use the `browser` step, a composite step's `tool` action, or a custom step command.
 
 ## Actions
 

--- a/.claude/skills/spell-builder/steps/agent/README.md
+++ b/.claude/skills/spell-builder/steps/agent/README.md
@@ -1,36 +1,40 @@
-# `agent` — Spawn a Claude Subagent
+# `agent` — NOT EXECUTABLE
 
-**Purpose:** Use this step to delegate a task to a Claude subagent and capture its response. Choose this over `bash` when the task requires reasoning, code generation, or research rather than a deterministic command.
+**Purpose:** Document that this step type does not work, so it is not offered when authoring a spell. It is registered but has never spawned a subagent — moflo has no agent spawner in the spell runner. Casting it always fails.
 
-## Usage
+**Do not add `agent` steps to a spell.** Previously the step returned `success: true` with `result: "Agent task prepared: <type>"`, so spells containing one completed green and downstream steps consumed that string as though it were agent output. It now fails with an explanatory error instead.
+
+The type stays registered on purpose: removing it would turn a silently-useless step into a hard parse error for any existing spell YAML that contains one.
+
+## Use this instead
+
+Run the Claude CLI from a `bash` step:
 
 ```yaml
 - id: research
-  type: agent
+  type: bash
   config:
-    agentType: researcher
-    prompt: "Find all REST API endpoints in src/ and list their HTTP methods and paths"
-    model: claude-sonnet-5
-    background: false
+    command: 'claude -p "Find all REST API endpoints in src/ and list their HTTP methods and paths"'
+    timeout: 300000
 ```
 
-## Config
+This is what moflo's own shipped spells do — see `src/cli/spells/definitions/epic-auto-merge.yaml`.
 
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `prompt` | Yes | — | Task prompt for the agent |
-| `agentType` | No | `coder` | Agent specialization: `researcher`, `coder`, `tester`, `reviewer` |
-| `model` | No | system default | Model override (e.g. `claude-sonnet-5`) |
-| `systemPrompt` | No | — | Custom system prompt replacing the default |
-| `background` | No | `false` | Run without waiting for the result |
+**Note on cost:** a `bash` step invoking `claude -p` has no spend ceiling, which matters most for daemon-scheduled spells. Set a `timeout` and prefer `failOnError: true`.
+
+## If you are reading an older spell
+
+| Old `agent` config | Replacement |
+|---|---|
+| `prompt` | the prompt text inside `claude -p "..."` |
+| `agentType` | no equivalent — describe the role in the prompt |
+| `background` | no equivalent — the bash step waits |
+
+`model` and `systemPrompt` were documented here previously but were never implemented — the step's `configSchema` only ever accepted `prompt`, `agentType`, and `background`.
 
 ## Outputs
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `result` | string | Agent response text |
-| `agentType` | string | Agent type that was used |
-| `prompt` | string | Prompt that was sent |
+None. The step always fails. `agentType` and `prompt` are echoed in the failure data for diagnosis only; there is no `result`.
 
 ## Source
 

--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -229,22 +229,21 @@ Executes a command in a child process and captures stdout, stderr, and the exit 
 
 Set `failOnError: false` to capture the exit code without failing the spell — useful for commands where a non-zero exit is informational rather than fatal.
 
-### `agent` — Spawn a Claude Subagent
+### `agent` — NOT EXECUTABLE
 
-Delegates a task to a Claude subagent and captures its response.
+**Do not use this step type.** It has never spawned a subagent — there is no agent spawner in the spell runner. It stays registered so existing spell YAML keeps parsing, but casting it always fails with an explanatory error (#1334). Earlier versions returned `success: true` and a `result` string for work that never happened.
+
+To run a Claude subagent from a spell, use a `bash` step:
 
 ```yaml
 - id: research
-  type: agent
+  type: bash
   config:
-    agentType: researcher        # Agent specialization
-    prompt: "Find all API endpoints in the project"
-    background: false            # Wait for completion (default: false)
+    command: 'claude -p "Find all API endpoints in the project"'
+    timeout: 300000
 ```
 
-**Outputs:** `result`, `agentType`, `prompt`
-
-The `agentType` maps to your AI client's agent types — `researcher`, `coder`, `tester`, `reviewer`, etc.
+**Outputs:** none — the step always fails. `agentType` and `prompt` are echoed in the failure for diagnosis only.
 
 ### `condition` — Branch the Spell
 

--- a/src/cli/__tests__/spells/agent-step-not-executable.test.ts
+++ b/src/cli/__tests__/spells/agent-step-not-executable.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Agent Step — spell-level behaviour (#1334).
+ *
+ * `built-in-commands.test.ts` covers `agentCommand.execute()` directly. These
+ * tests assert the two acceptance criteria that are only meaningful one level
+ * up — that a *spell* containing an `agent` step fails its cast, and that such
+ * a spell still parses and schema-validates so an upgrade does not break it.
+ *
+ * A command-level assertion cannot prove either: the runner could in principle
+ * swallow a step failure, and parse/validate runs before any command executes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SpellCaster } from '../../spells/core/runner.js';
+import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
+import { agentCommand, AGENT_STEP_NOT_EXECUTABLE } from '../../spells/commands/agent-command.js';
+import { validateSpellDefinition } from '../../spells/schema/validator.js';
+import { parseSpell } from '../../spells/schema/parser.js';
+import { makeCredentials, makeMemory } from './helpers.js';
+import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
+
+/** A spell of the exact shape the shipped docs used to teach. */
+const AGENT_SPELL_YAML = `
+name: research-spell
+version: "1.0"
+steps:
+  - id: research
+    type: agent
+    config:
+      agentType: researcher
+      prompt: "Find all API endpoints"
+`;
+
+function agentSpell(): SpellDefinition {
+  return {
+    name: 'research-spell',
+    steps: [
+      { id: 'research', type: 'agent', config: { agentType: 'researcher', prompt: 'Find all API endpoints' } },
+    ],
+  };
+}
+
+function makeRunner(): SpellCaster {
+  const registry = new StepCommandRegistry();
+  registry.register(agentCommand);
+  return new SpellCaster(registry, makeCredentials(), makeMemory());
+}
+
+describe('agent step — spell level (#1334)', () => {
+  // AC 1 — the headline criterion. Before this change the cast returned
+  // success:true and downstream steps consumed "Agent task prepared: ...".
+  it('a spell containing an agent step does not report success', async () => {
+    const result = await makeRunner().run(agentSpell(), {});
+    expect(result.success).toBe(false);
+  });
+
+  // AC 2, at the level a spell author actually sees it.
+  it('surfaces the not-executable reason in the cast result', async () => {
+    const result = await makeRunner().run(agentSpell(), {});
+    const serialised = JSON.stringify(result);
+    expect(serialised).toContain('not executable');
+    expect(serialised).toContain('claude -p');
+  });
+
+  it('produces no consumable result output for downstream steps', async () => {
+    const result = await makeRunner().run(agentSpell(), {});
+    expect(JSON.stringify(result)).not.toContain('Agent task prepared');
+  });
+
+  // AC 4 — the reason the step type was kept registered rather than deleted.
+  // Parsing and validation must stay green so an upgrade does not turn a
+  // silently-useless step into a hard error on a consumer's existing spell.
+  it('existing agent-step YAML still parses', () => {
+    const parsed = parseSpell(AGENT_SPELL_YAML, 'research-spell.yaml');
+    expect(parsed.definition.steps[0].type).toBe('agent');
+  });
+
+  it('existing agent-step YAML still validates', () => {
+    const parsed = parseSpell(AGENT_SPELL_YAML, 'research-spell.yaml');
+    const result = validateSpellDefinition(parsed.definition);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('exports the failure message so callers can match on it', () => {
+    expect(AGENT_STEP_NOT_EXECUTABLE).toContain('"agent" step type is not executable');
+  });
+});

--- a/src/cli/__tests__/spells/built-in-commands.test.ts
+++ b/src/cli/__tests__/spells/built-in-commands.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
-import { agentCommand } from '../../spells/commands/agent-command.js';
+import { agentCommand, AGENT_STEP_NOT_EXECUTABLE } from '../../spells/commands/agent-command.js';
 import { bashCommand } from '../../spells/commands/bash-command.js';
 import { conditionCommand } from '../../spells/commands/condition-command.js';
 import { promptCommand } from '../../spells/commands/prompt-command.js';
@@ -69,16 +69,71 @@ describe('agentCommand', () => {
     expect(result.errors[0].path).toBe('prompt');
   });
 
-  it('should execute and return agent config', async () => {
+  // #1334: this step spawns nothing and must not report success. The previous
+  // version of this test asserted `success === true`, which is what let the
+  // fabricated result ship.
+  it('should fail rather than report success for work it never performs', async () => {
     const ctx = createContext();
     const output = await agentCommand.execute(
       { prompt: 'test task', agentType: 'researcher', background: true },
       ctx,
     );
-    expect(output.success).toBe(true);
+    expect(output.success).toBe(false);
+    expect(output.error).toBe(AGENT_STEP_NOT_EXECUTABLE);
+    // Still echoes what was asked for, so the failure is diagnosable.
     expect(output.data.agentType).toBe('researcher');
     expect(output.data.prompt).toBe('test task');
-    expect(output.data.background).toBe(true);
+  });
+
+  it('should name the step type and the working alternative in the error', async () => {
+    const output = await agentCommand.execute({ prompt: 'x' }, createContext());
+    expect(output.error).toMatch(/"agent" step type is not executable/);
+    expect(output.error).toMatch(/claude -p/);
+  });
+
+  // The message reaches consumer terminals, where #NNNN resolves against their
+  // repo rather than moflo's.
+  it('should not put a moflo issue number in consumer-visible strings', () => {
+    expect(AGENT_STEP_NOT_EXECUTABLE).not.toMatch(/#\d{3,4}/);
+    expect(agentCommand.description).not.toMatch(/#\d{3,4}/);
+  });
+
+  // A stale `{step.result}` reference must not replace the not-executable
+  // message with an interpolation error — those references are common in
+  // exactly the spells that contain an `agent` step.
+  it('should still report not-executable when the prompt has a bad reference', async () => {
+    const output = await agentCommand.execute(
+      { prompt: 'use {nonexistent.result} here' },
+      createContext(),
+    );
+    expect(output.success).toBe(false);
+    expect(output.error).toBe(AGENT_STEP_NOT_EXECUTABLE);
+  });
+
+  it('should never produce a `result` output authors could consume', async () => {
+    const output = await agentCommand.execute({ prompt: 'x' }, createContext());
+    expect(output.data.result).toBeUndefined();
+    expect(agentCommand.describeOutputs().map(o => o.name)).not.toContain('result');
+  });
+
+  // AC #4 — existing spell YAML containing an `agent` step must still parse and
+  // validate; only execution changed. Deleting the step type would break this.
+  it('should still validate existing spell config unchanged', () => {
+    const result = agentCommand.validate(
+      { prompt: 'test task', agentType: 'researcher', background: true },
+      createContext(),
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  // The `claude` prerequisite gated preflight on a binary this step cannot use,
+  // so a machine without it reported "Install Claude CLI" instead of the reason.
+  it('should declare no prerequisites', () => {
+    expect(agentCommand.prerequisites ?? []).toHaveLength(0);
+  });
+
+  it('should keep the agent capability so scope enforcement still applies', () => {
+    expect(agentCommand.capabilities?.map(c => c.type)).toContain('agent');
   });
 
   it('should interpolate variables in prompt', async () => {

--- a/src/cli/spells/commands/agent-command.ts
+++ b/src/cli/spells/commands/agent-command.ts
@@ -1,5 +1,22 @@
 /**
- * Agent Step Command — spawns a Claude subagent.
+ * Agent Step Command — declared but NOT executable (#1334).
+ *
+ * This step type has never spawned anything. moflo has no agent spawner in the
+ * spell runner, and nothing anywhere reads the invocation this command used to
+ * "prepare" — it returned `success: true` with `result: "Agent task prepared"`
+ * for work that never happened, so a spell containing an `agent` step completed
+ * green and downstream steps consumed that string as though it were agent
+ * output.
+ *
+ * It now fails loudly instead. The type stays **registered** on purpose: it is
+ * public spell-authoring surface, and removing it would turn a silently-useless
+ * step into a hard parse error for any consumer whose spell YAML contains one.
+ * `validate()` and `configSchema` are therefore unchanged — existing spells
+ * still parse and validate; they just no longer report success.
+ *
+ * The capability scope check runs *before* the failure so a scope violation
+ * still surfaces as a scope violation (#258) rather than being masked by the
+ * generic not-executable error.
  */
 
 import type {
@@ -11,19 +28,21 @@ import type {
   ValidationResult,
   OutputDescriptor,
   JSONSchema,
-  Prerequisite,
 } from '../types/step-command.types.js';
 import { interpolateString } from '../core/interpolation.js';
-import { commandExists } from '../core/prerequisite-checker.js';
 
-const agentPrerequisites: readonly Prerequisite[] = [
-  {
-    name: 'claude',
-    check: () => commandExists('claude'),
-    installHint: 'Install Claude CLI: npm install -g @anthropic-ai/claude-code',
-    url: 'https://docs.anthropic.com/en/docs/claude-code',
-  },
-];
+/**
+ * Returned by every in-scope execution. Names the step type and the working
+ * alternative, because a caller who hits this is mid-spell and needs the
+ * substitution, not a diagnosis.
+ *
+ * Carries no issue number: this reaches consumer terminals, and `#NNNN`
+ * resolves against the consumer's own repo, not moflo's.
+ */
+export const AGENT_STEP_NOT_EXECUTABLE =
+  'The "agent" step type is not executable: moflo has no agent spawner, so no subagent is started. '
+  + 'It previously reported success without running anything. '
+  + 'To run a Claude subagent from a spell, use a "bash" step invoking `claude -p "<prompt>"`.';
 
 /** Typed config for the agent step command. */
 export interface AgentStepConfig extends StepConfig {
@@ -34,10 +53,12 @@ export interface AgentStepConfig extends StepConfig {
 
 export const agentCommand: StepCommand<AgentStepConfig> = {
   type: 'agent',
-  description: 'Spawn a Claude subagent to perform a task',
+  description: 'NOT EXECUTABLE — declared so existing spells still parse; always fails',
   capabilities: [{ type: 'agent' }],
   defaultMofloLevel: 'memory',
-  prerequisites: agentPrerequisites,
+  // No prerequisites. The `claude` CLI used to be required here, which gated
+  // preflight on a binary this step cannot use — a consumer without `claude`
+  // got "Install Claude CLI" instead of the real reason.
   configSchema: {
     type: 'object',
     properties: {
@@ -61,12 +82,26 @@ export const agentCommand: StepCommand<AgentStepConfig> = {
 
   async execute(config: AgentStepConfig, context: CastingContext): Promise<StepOutput> {
     const start = Date.now();
-    const prompt = interpolateString(config.prompt, context);
+
+    // agentType is interpolated strictly — the scope check below must see the
+    // resolved value, so an unresolvable one has to fail rather than be waved
+    // through. The prompt is echoed for diagnosis only, so a bad reference in
+    // it must not replace the not-executable message with an interpolation
+    // error: spells with an `agent` step are exactly the ones holding stale
+    // `{step.result}` references, since that output never existed.
     const agentType = config.agentType
       ? interpolateString(config.agentType, context)
       : 'general-purpose';
+    let prompt: string;
+    try {
+      prompt = interpolateString(config.prompt, context);
+    } catch {
+      prompt = config.prompt;
+    }
 
-    // Enforce agent capability scope (Issue #258 — gateway enforcement)
+    // Enforce agent capability scope first (Issue #258 — gateway enforcement).
+    // Ordering is load-bearing: a denied agent type must report the denial, not
+    // the not-executable message, or scope violations become invisible.
     try {
       context.gateway.checkAgent(agentType);
     } catch (err) {
@@ -78,26 +113,21 @@ export const agentCommand: StepCommand<AgentStepConfig> = {
       };
     }
 
-    // Agent execution is delegated to the spell runner's agent spawner.
-    // This command prepares the invocation; actual spawning is handled externally.
     return {
-      success: true,
-      data: {
-        agentType,
-        prompt,
-        background: Boolean(config.background),
-        result: `Agent task prepared: ${agentType}`,
-      },
+      success: false,
+      data: { agentType, prompt },
+      error: AGENT_STEP_NOT_EXECUTABLE,
       duration: Date.now() - start,
     };
   },
 
+  // Only the fields the failure actually carries. `result` and `background`
+  // were listed here but can never be produced, which is what let authors
+  // reference `{step.result}` expecting agent output.
   describeOutputs(): OutputDescriptor[] {
     return [
       { name: 'agentType', type: 'string' },
       { name: 'prompt', type: 'string' },
-      { name: 'background', type: 'boolean' },
-      { name: 'result', type: 'string' },
     ];
   },
 };

--- a/tests/capability-gateway.test.ts
+++ b/tests/capability-gateway.test.ts
@@ -15,7 +15,7 @@ import {
   formatSpellDisclosure,
 } from '../src/cli/spells/core/capability-gateway.js';
 import type { StepCapability, CastingContext } from '../src/cli/spells/types/step-command.types.js';
-import { agentCommand } from '../src/cli/spells/commands/agent-command.js';
+import { agentCommand, AGENT_STEP_NOT_EXECUTABLE } from '../src/cli/spells/commands/agent-command.js';
 import { githubCommand } from '../src/cli/spells/commands/github-command.js';
 import { memoryCommand } from '../src/cli/spells/commands/memory-command.js';
 
@@ -154,7 +154,12 @@ describe('agent-command gateway enforcement', () => {
     expect(result.error).toMatch(/outside allowed scope/);
   });
 
-  it('allows agent spawning when agent type matches scope', async () => {
+  // These two used to assert `success: true` as a proxy for "the gateway let it
+  // through". That conflated permitted-by-scope with actually-ran, and the step
+  // never ran anything (#1334). The step now always fails, so the assertion is
+  // that the failure is NOT a scope denial — which is what these tests are
+  // actually about.
+  it('passes scope check when agent type matches scope', async () => {
     const caps: StepCapability[] = [{ type: 'agent', scope: ['researcher'] }];
     const gw = new CapabilityGateway(caps, 'test-task', 'agent');
     const ctx = makeContext(caps, gw);
@@ -164,10 +169,11 @@ describe('agent-command gateway enforcement', () => {
       ctx,
     );
 
-    expect(result.success).toBe(true);
+    expect(result.error).not.toMatch(/outside allowed scope/);
+    expect(result.error).toBe(AGENT_STEP_NOT_EXECUTABLE);
   });
 
-  it('allows any agent type when scope is unrestricted', async () => {
+  it('passes scope check for any agent type when scope is unrestricted', async () => {
     const caps: StepCapability[] = [{ type: 'agent' }];
     const gw = new CapabilityGateway(caps, 'test-task', 'agent');
     const ctx = makeContext(caps, gw);
@@ -177,7 +183,8 @@ describe('agent-command gateway enforcement', () => {
       ctx,
     );
 
-    expect(result.success).toBe(true);
+    expect(result.error).not.toMatch(/outside allowed scope/);
+    expect(result.error).toBe(AGENT_STEP_NOT_EXECUTABLE);
   });
 });
 


### PR DESCRIPTION
## What

The spell `agent` step reported `success: true` for work it never performed. It validated config, enforced agent capability scope, then returned `result: "Agent task prepared: <type>"` — and nothing spawned. A spell containing an `agent` step completed green while downstream steps consumed that string as though it were agent output.

It now fails with an error naming the step type and the working substitute.

Closes #1334.

## Validation before implementing

Every claim in the ticket verified against source:

- `agentType` appears in `src/cli/spells/**` only inside `agent-command.ts` and `capability-gateway.ts` (the scope check). `"Agent task prepared"` appears at exactly one site repo-wide — its own producer. There is no agent spawner in the runner.
- The failure was **pinned green by four assertions**. `built-in-commands.test.ts` asserted `success === true`; three tests in `tests/capability-gateway.test.ts` used `success: true` as a proxy for *the gateway permitted this agent type*. That conflation is what let the fabricated success survive review.

## Why fail loudly rather than delete the step

An external audit recommended deleting it. The ticket argued against, and that holds: the type is registered public spell-authoring surface, so removal turns a silently-useless step into a **hard parse error** on upgrade for any consumer whose YAML contains one. `validate()` and `configSchema` are untouched, so existing spells still parse — proven by a test, not asserted.

Implementing real spawning was also considered and rejected: it would add a second unbounded `claude -p` spend surface while #1335 documents the existing one as unresolved.

## The documentation was as much of the defect as the return value

Same shape as #1324, where the tool description a caller reads was the bug. Both `.claude/guidance/shipped/**` and `.claude/skills/**/*.md` are in `package.json` `files` and sync into consumer projects. Fixing only the code would have shipped instructions that now produce a hard failure. Seven surfaces taught the step as working:

| Surface | What it claimed |
|---|---|
| shipped spell-engine guidance + `docs/SPELLS.md` | step reference with a `result` output |
| `spell-builder/steps/agent/README.md` | full README documenting `model` and `systemPrompt` config fields **that were never implemented** |
| `spell-builder/SKILL.md`, `architecture.md`, `connector-builder/SKILL.md` | worked examples chaining into an `agent` step |
| four connector READMEs | each taught that its connector is reached *from inside* an `agent` step |

Connectors are **not** stranded: `playwright`/`github-cli`/`local-outlook` have dedicated step types that delegate to `context.tools`, and `http` is reachable from a composite step's `tool` action (`composite-command.ts:233-247`). Their examples now use those paths, and each replacement was checked against the real schema rather than written from the prose.

## Also fixed

- **Dropped the `claude` CLI prerequisite.** It gated preflight on a binary this step cannot use, so a consumer without `claude` was told to install it instead of the real reason.
- **Trimmed `result`/`background` from `describeOutputs()`.** Neither can ever be produced — that listing is what let authors reference `{step.result}` expecting agent output. (Safe: `describeOutputs` is duck-typed in `directory-step-loader.ts:139`, never consulted by the schema validator.)
- **Prompt interpolation made non-fatal.** A stale `{step.result}` reference would otherwise replace the not-executable message with an interpolation error — and those references live in exactly the spells that contain an `agent` step. `agentType` interpolation stays strict, because the scope check must see a resolved value.
- **No moflo issue numbers in consumer-visible strings.** `#NNNN` resolves against the consumer's repo, not moflo's — the `tests/skills/` guards enforce this for skill docs, and the same reasoning applies to the runtime error message and step description. Pinned by a test.

Adjacent corrections found while rewriting the examples, each verified against source:

- the github-cli action table listed `issue-create`, `issue-list`, `pr-list`, `repo-view` — **none have ever existed** in `VALID_ACTIONS`
- the spell-builder example referenced `{scan-deps.result}` on a `bash` step whose outputs are `stdout`/`stderr`/`exitCode`
- shipped guidance said "Nine built-in step types"; fifteen are registered

## Consumer impact

A spell with an `agent` step changes from silently passing to failing with an explanatory error. **That is the point** — the step never did the work, and the previous behaviour fed a fabricated string into downstream steps. Spells that need it non-fatal can set `continueOnError: true`. No migration, no `.moflo/` state change, no round-trip required for the doc half.

## Testing

Full suite **9748 passed / 0 failed**, lint clean (`--max-warnings 0`), build clean.

A gap surfaced during `/verify`: the command-level tests could not prove the ticket's headline criterion, because the runner could in principle swallow a step failure. Added `agent-step-not-executable.test.ts`, which drives `SpellCaster.run` end-to-end on a spell of the exact shape the docs used to teach:

```
[spell] Step 1/1: failed "research" — The "agent" step type is not executable: moflo has no agent spawner...
```

The three capability-gateway tests were rewritten to assert the failure is **not** a scope denial, rather than that the step succeeded — which is what those tests were always actually about.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
