### PR TITLE
fix(cli): commands report success for work they never perform (#1346)

### DIFF
--- a/src/cli/__tests__/cli.test.ts
+++ b/src/cli/__tests__/cli.test.ts
@@ -62,6 +62,32 @@ describe('CLI', () => {
       const output = consoleOutput.join('');
       expect(output).toMatch(/v\d+\.\d+\.\d+/);
     });
+
+    // `flo plugins install pkg --version 1.2.3` printed "flo v4.12.4-rc.1" and
+    // returned without installing anything: the global boolean `--version`
+    // swallowed the flag, and the global handler fired before the command ran.
+    // A command that declares its own value-taking `--version` must receive the
+    // value and execute.
+    it('does not hijack --version when the command declares it as a value option', async () => {
+      let received: unknown = 'NOT_CALLED';
+      const mockCommand: Command = {
+        name: 'testinstall',
+        description: 'Test command',
+        options: [
+          { name: 'version', short: 'v', type: 'string', description: 'Version to install' }
+        ],
+        action: async (ctx) => {
+          received = ctx.flags.version;
+          return { success: true };
+        }
+      };
+
+      cli['parser'].registerCommand(mockCommand);
+      await cli.run(['testinstall', 'mypkg', '--version', '1.2.3']);
+
+      expect(received).toBe('1.2.3');
+      expect(consoleOutput.join('')).not.toContain(`flo v${VERSION}`);
+    });
   });
 
   describe('Help Command', () => {

--- a/src/cli/__tests__/commands.test.ts
+++ b/src/cli/__tests__/commands.test.ts
@@ -4,6 +4,10 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { _resetStateRootCacheForTest } from '../services/project-root.js';
 import { agentCommand } from '../commands/agent.js';
 import { swarmCommand } from '../commands/swarm.js';
 import { memoryCommand } from '../commands/memory.js';
@@ -655,15 +659,40 @@ describe('Memory Commands', () => {
 
 describe('Config Commands', () => {
   let ctx: CommandContext;
+  let projectDir: string;
+  let envBackup: string | undefined;
 
+  // `flo config` writes real files, so every case gets a throwaway project
+  // root. CLAUDE_PROJECT_DIR is authoritative for `resolveStateRoot`, so it
+  // must point at the fixture — otherwise a test run inside a Claude Code
+  // session resolves to the developer's actual repo and writes there.
+  // realpathSync both sides: macOS hands out /var/folders paths that resolve
+  // to /private/var/folders, and resolveStateRoot canonicalizes.
   beforeEach(() => {
+    projectDir = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-config-test-')));
+    envBackup = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = projectDir;
+    _resetStateRootCacheForTest();
+
     ctx = {
       args: [],
       flags: { _: [] },
-      cwd: '/test',
+      cwd: projectDir,
       interactive: false
     };
   });
+
+  afterEach(() => {
+    if (envBackup === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = envBackup;
+    _resetStateRootCacheForTest();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  const configFile = () => join(projectDir, '.moflo', 'config.json');
+  const readConfigFile = () => JSON.parse(readFileSync(configFile(), 'utf8'));
+  const subcommand = (name: string) => configCommand.subcommands!.find(c => c.name === name)!;
+  const runInit = async () => subcommand('init').action!({ ...ctx, flags: { _: [] } });
 
   describe('config init', () => {
     it('should initialize configuration', async () => {
@@ -676,6 +705,17 @@ describe('Config Commands', () => {
       expect(result.data).toHaveProperty('version');
     });
 
+    // The regression this whole module exists for: `init` reported success
+    // without writing anything, so the healer's `Config File` auto-fix claimed
+    // "applied" on every run while the warning never cleared.
+    it('writes a parseable config file to disk', async () => {
+      const result = await runInit();
+
+      expect(result.success).toBe(true);
+      expect(existsSync(configFile())).toBe(true);
+      expect(readConfigFile()).toMatchObject({ version: '3.0.0', swarm: { topology: 'hybrid' } });
+    });
+
     it('should initialize with V3 mode', async () => {
       const initCmd = configCommand.subcommands?.find(c => c.name === 'init');
 
@@ -684,6 +724,28 @@ describe('Config Commands', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('v3Mode', true);
+      expect(readConfigFile()).toMatchObject({ v3Mode: true });
+    });
+
+    it('refuses to clobber an existing config without --force', async () => {
+      await runInit();
+      await subcommand('set').action!({ ...ctx, flags: { key: 'swarm.maxAgents', value: '42', _: [] } });
+
+      const result = await subcommand('init').action!({ ...ctx, flags: { _: [] } });
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(readConfigFile().swarm.maxAgents).toBe(42);
+    });
+
+    it('overwrites an existing config with --force', async () => {
+      await runInit();
+      await subcommand('set').action!({ ...ctx, flags: { key: 'swarm.maxAgents', value: '42', _: [] } });
+
+      const result = await subcommand('init').action!({ ...ctx, flags: { force: true, _: [] } });
+
+      expect(result.success).toBe(true);
+      expect(readConfigFile().swarm.maxAgents).toBe(15);
     });
   });
 
@@ -707,6 +769,22 @@ describe('Config Commands', () => {
 
       expect(result.success).toBe(true);
     });
+
+    it('reads back what set wrote, not a hardcoded default', async () => {
+      await runInit();
+      await subcommand('set').action!({ ...ctx, flags: { key: 'swarm.topology', value: 'mesh', _: [] } });
+
+      const result = await subcommand('get').action!({ ...ctx, args: ['swarm.topology'], flags: { _: [] } });
+
+      expect(result.data).toEqual({ key: 'swarm.topology', value: 'mesh' });
+    });
+
+    it('fails on an unknown key', async () => {
+      const result = await subcommand('get').action!({ ...ctx, args: ['swarm.nonesuch'], flags: { _: [] } });
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+    });
   });
 
   describe('config set', () => {
@@ -719,7 +797,28 @@ describe('Config Commands', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('key', 'swarm.maxAgents');
-      expect(result.data).toHaveProperty('value', '20');
+      // Coerced to the type already at that key, so the stored value is usable
+      // as a number rather than the string the shell handed us.
+      expect(result.data).toHaveProperty('value', 20);
+      expect(readConfigFile().swarm.maxAgents).toBe(20);
+    });
+
+    it('coerces booleans and rejects non-numbers for numeric keys', async () => {
+      const ok = await subcommand('set').action!({ ...ctx, flags: { key: 'swarm.autoScale', value: 'false', _: [] } });
+      expect(ok.success).toBe(true);
+      expect(readConfigFile().swarm.autoScale).toBe(false);
+
+      const bad = await subcommand('set').action!({ ...ctx, flags: { key: 'swarm.maxAgents', value: 'lots', _: [] } });
+      expect(bad.success).toBe(false);
+      expect(readConfigFile().swarm.maxAgents).toBe(15);
+    });
+
+    it('rejects an unknown key instead of silently creating it', async () => {
+      const result = await subcommand('set').action!({ ...ctx, flags: { key: 'swarm.nonesuch', value: '1', _: [] } });
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(existsSync(configFile())).toBe(false);
     });
 
     it('should fail without key and value', async () => {
@@ -741,6 +840,23 @@ describe('Config Commands', () => {
       expect(result.success).toBe(true);
       expect(Array.isArray(result.data)).toBe(true);
     });
+
+    it('persists --enable / --disable instead of ignoring the flag', async () => {
+      await runInit();
+
+      await subcommand('providers').action!({ ...ctx, flags: { enable: 'ollama', _: [] } });
+      expect(readConfigFile().providers.find((p: { name: string }) => p.name === 'ollama').enabled).toBe(true);
+
+      await subcommand('providers').action!({ ...ctx, flags: { disable: 'ollama', _: [] } });
+      expect(readConfigFile().providers.find((p: { name: string }) => p.name === 'ollama').enabled).toBe(false);
+    });
+
+    it('fails on an unknown provider', async () => {
+      const result = await subcommand('providers').action!({ ...ctx, flags: { enable: 'nonesuch', _: [] } });
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+    });
   });
 
   describe('config reset', () => {
@@ -754,6 +870,15 @@ describe('Config Commands', () => {
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('reset', true);
     });
+
+    it('restores changed values on disk', async () => {
+      await runInit();
+      await subcommand('set').action!({ ...ctx, flags: { key: 'swarm.maxAgents', value: '99', _: [] } });
+
+      await subcommand('reset').action!({ ...ctx, flags: { force: true, section: 'swarm', _: [] } });
+
+      expect(readConfigFile().swarm.maxAgents).toBe(15);
+    });
   });
 
   describe('config export', () => {
@@ -766,6 +891,17 @@ describe('Config Commands', () => {
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('config');
     });
+
+    it('writes the export file it reports', async () => {
+      await runInit();
+
+      const result = await subcommand('export').action!({ ...ctx, flags: { output: 'out/cfg.json', _: [] } });
+
+      expect(result.success).toBe(true);
+      const exported = JSON.parse(readFileSync(join(projectDir, 'out', 'cfg.json'), 'utf8'));
+      expect(exported).toMatchObject({ version: '3.0.0' });
+      expect(exported.exportedAt).toBeTruthy();
+    });
   });
 
   describe('config import', () => {
@@ -773,11 +909,20 @@ describe('Config Commands', () => {
       const importCmd = configCommand.subcommands?.find(c => c.name === 'import');
       expect(importCmd).toBeDefined();
 
+      writeFileSync(join(projectDir, 'config.json'), JSON.stringify({ swarm: { topology: 'ring', maxAgents: 7 } }));
       ctx.flags = { file: './config.json', _: [] };
       const result = await importCmd!.action!(ctx);
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('imported', true);
+      expect(readConfigFile()).toMatchObject({ swarm: { topology: 'ring', maxAgents: 7 } });
+    });
+
+    it('fails when the source file does not exist', async () => {
+      const result = await subcommand('import').action!({ ...ctx, flags: { file: './nope.json', _: [] } });
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
     });
 
     it('should fail without file path', async () => {

--- a/src/cli/__tests__/commands.test.ts
+++ b/src/cli/__tests__/commands.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, existsS
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { _resetStateRootCacheForTest } from '../services/project-root.js';
+import { cliConfigPath } from '../config/cli-config-store.js';
 import { agentCommand } from '../commands/agent.js';
 import { swarmCommand } from '../commands/swarm.js';
 import { memoryCommand } from '../commands/memory.js';
@@ -689,14 +690,16 @@ describe('Config Commands', () => {
     rmSync(projectDir, { recursive: true, force: true });
   });
 
-  const configFile = () => join(projectDir, '.moflo', 'config.json');
+  // Use the store's own resolver rather than rebuilding the path — a literal
+  // here would silently fork from CLI_CONFIG_CANDIDATES[0].
+  const configFile = () => cliConfigPath(projectDir);
   const readConfigFile = () => JSON.parse(readFileSync(configFile(), 'utf8'));
   const subcommand = (name: string) => configCommand.subcommands!.find(c => c.name === name)!;
   const runInit = async () => subcommand('init').action!({ ...ctx, flags: { _: [] } });
 
   describe('config init', () => {
     it('should initialize configuration', async () => {
-      const initCmd = configCommand.subcommands?.find(c => c.name === 'init');
+      const initCmd = subcommand('init');
       expect(initCmd).toBeDefined();
 
       const result = await initCmd!.action!(ctx);
@@ -717,10 +720,10 @@ describe('Config Commands', () => {
     });
 
     it('should initialize with V3 mode', async () => {
-      const initCmd = configCommand.subcommands?.find(c => c.name === 'init');
+      const initCmd = subcommand('init');
 
       ctx.flags = { v3: true, _: [] };
-      const result = await initCmd!.action!(ctx);
+      const result = await initCmd.action!(ctx);
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('v3Mode', true);
@@ -751,11 +754,11 @@ describe('Config Commands', () => {
 
   describe('config get', () => {
     it('should get configuration value', async () => {
-      const getCmd = configCommand.subcommands?.find(c => c.name === 'get');
+      const getCmd = subcommand('get');
       expect(getCmd).toBeDefined();
 
       ctx.args = ['swarm.topology'];
-      const result = await getCmd!.action!(ctx);
+      const result = await getCmd.action!(ctx);
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('key');
@@ -763,9 +766,9 @@ describe('Config Commands', () => {
     });
 
     it('should show all config when no key provided', async () => {
-      const getCmd = configCommand.subcommands?.find(c => c.name === 'get');
+      const getCmd = subcommand('get');
 
-      const result = await getCmd!.action!(ctx);
+      const result = await getCmd.action!(ctx);
 
       expect(result.success).toBe(true);
     });
@@ -789,11 +792,11 @@ describe('Config Commands', () => {
 
   describe('config set', () => {
     it('should set configuration value', async () => {
-      const setCmd = configCommand.subcommands?.find(c => c.name === 'set');
+      const setCmd = subcommand('set');
       expect(setCmd).toBeDefined();
 
       ctx.flags = { key: 'swarm.maxAgents', value: '20', _: [] };
-      const result = await setCmd!.action!(ctx);
+      const result = await setCmd.action!(ctx);
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('key', 'swarm.maxAgents');
@@ -822,9 +825,9 @@ describe('Config Commands', () => {
     });
 
     it('should fail without key and value', async () => {
-      const setCmd = configCommand.subcommands?.find(c => c.name === 'set');
+      const setCmd = subcommand('set');
 
-      const result = await setCmd!.action!(ctx);
+      const result = await setCmd.action!(ctx);
 
       expect(result.success).toBe(false);
     });
@@ -832,10 +835,10 @@ describe('Config Commands', () => {
 
   describe('config providers', () => {
     it('should list providers', async () => {
-      const providersCmd = configCommand.subcommands?.find(c => c.name === 'providers');
+      const providersCmd = subcommand('providers');
       expect(providersCmd).toBeDefined();
 
-      const result = await providersCmd!.action!(ctx);
+      const result = await providersCmd.action!(ctx);
 
       expect(result.success).toBe(true);
       expect(Array.isArray(result.data)).toBe(true);
@@ -861,11 +864,11 @@ describe('Config Commands', () => {
 
   describe('config reset', () => {
     it('should reset configuration', async () => {
-      const resetCmd = configCommand.subcommands?.find(c => c.name === 'reset');
+      const resetCmd = subcommand('reset');
       expect(resetCmd).toBeDefined();
 
       ctx.flags = { force: true, _: [] };
-      const result = await resetCmd!.action!(ctx);
+      const result = await resetCmd.action!(ctx);
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('reset', true);
@@ -883,10 +886,10 @@ describe('Config Commands', () => {
 
   describe('config export', () => {
     it('should export configuration', async () => {
-      const exportCmd = configCommand.subcommands?.find(c => c.name === 'export');
+      const exportCmd = subcommand('export');
       expect(exportCmd).toBeDefined();
 
-      const result = await exportCmd!.action!(ctx);
+      const result = await exportCmd.action!(ctx);
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('config');
@@ -906,12 +909,12 @@ describe('Config Commands', () => {
 
   describe('config import', () => {
     it('should import configuration', async () => {
-      const importCmd = configCommand.subcommands?.find(c => c.name === 'import');
+      const importCmd = subcommand('import');
       expect(importCmd).toBeDefined();
 
       writeFileSync(join(projectDir, 'config.json'), JSON.stringify({ swarm: { topology: 'ring', maxAgents: 7 } }));
       ctx.flags = { file: './config.json', _: [] };
-      const result = await importCmd!.action!(ctx);
+      const result = await importCmd.action!(ctx);
 
       expect(result.success).toBe(true);
       expect(result.data).toHaveProperty('imported', true);
@@ -926,9 +929,9 @@ describe('Config Commands', () => {
     });
 
     it('should fail without file path', async () => {
-      const importCmd = configCommand.subcommands?.find(c => c.name === 'import');
+      const importCmd = subcommand('import');
 
-      const result = await importCmd!.action!(ctx);
+      const result = await importCmd.action!(ctx);
 
       expect(result.success).toBe(false);
     });

--- a/src/cli/__tests__/commands/doctor-fixes-config-file.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-config-file.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the `Config File` auto-fix.
+ *
+ * The regression being pinned: the fix used to `return runFixCommand('npx
+ * moflo config init')` — i.e. report success from an exit code. `config init`
+ * printed "Creating claude-flow.config.json..." and wrote nothing, so
+ * `flo doctor --fix` listed the fix as `applied: true` on every single run
+ * while the `Config File` warning never cleared. The fix must now derive its
+ * verdict from the file existing on disk.
+ *
+ * Validates that the fix:
+ *  - returns false when the command exits 0 but leaves no file behind
+ *  - returns true once a config file is actually present
+ *  - short-circuits (no command run) when a config already exists
+ *  - honours every candidate filename the check recognises, incl. legacy names
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { fixConfigFile } from '../../commands/doctor-fixes.js';
+import { CLI_CONFIG_CANDIDATES, cliConfigPath } from '../../config/cli-config-store.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-config-fix-')));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('Config File auto-fix', () => {
+  it('reports failure when the command exits 0 but writes nothing', async () => {
+    // Exactly the old `config init`: succeeds loudly, touches no filesystem.
+    const applied = await fixConfigFile({ root: tmpDir, run: async () => true });
+
+    expect(applied).toBe(false);
+  });
+
+  it('reports success once the command actually writes the config', async () => {
+    const applied = await fixConfigFile({
+      root: tmpDir,
+      run: async () => {
+        writeFileSync(cliConfigPath(tmpDir), JSON.stringify({ version: '3.0.0' }));
+        return true;
+      },
+    });
+
+    expect(applied).toBe(true);
+  });
+
+  it('reports success even when the command reports failure, if the file landed', async () => {
+    const applied = await fixConfigFile({
+      root: tmpDir,
+      run: async () => {
+        writeFileSync(cliConfigPath(tmpDir), JSON.stringify({ version: '3.0.0' }));
+        return false;
+      },
+    });
+
+    expect(applied).toBe(true);
+  });
+
+  it('short-circuits without running the command when a config exists', async () => {
+    mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+    writeFileSync(cliConfigPath(tmpDir), JSON.stringify({ version: '3.0.0' }));
+
+    let ran = false;
+    const applied = await fixConfigFile({
+      root: tmpDir,
+      run: async () => {
+        ran = true;
+        return true;
+      },
+    });
+
+    expect(applied).toBe(true);
+    expect(ran).toBe(false);
+  });
+
+  it.each([...CLI_CONFIG_CANDIDATES])('recognises %s as an existing config', async (candidate) => {
+    const target = join(tmpDir, candidate);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, '{}');
+
+    let ran = false;
+    const applied = await fixConfigFile({ root: tmpDir, run: async () => { ran = true; return true; } });
+
+    expect(applied).toBe(true);
+    expect(ran).toBe(false);
+  });
+});

--- a/src/cli/__tests__/commands/embeddings-chunk-file.test.ts
+++ b/src/cli/__tests__/commands/embeddings-chunk-file.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for `flo embeddings chunk --file`.
+ *
+ * Two defects, one surface: `--text` was `required` at the parser level while
+ * `--file` was documented as the alternative ("File to chunk (instead of
+ * text)") and carried its own example, `flo embeddings chunk -f doc.txt
+ * --strategy paragraph`. That example could not run — the parser rejected it
+ * with "Required option missing: --text" — and even when the requirement was
+ * satisfied, the action never read `ctx.flags.file`, so it chunked the empty
+ * string. A declared, described, exampled option that did nothing.
+ *
+ * Validates that chunk:
+ *  - chunks a file's contents when given --file
+ *  - still chunks --text
+ *  - errors cleanly on a missing file and when given neither source
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { embeddingsCommand } from '../../commands/embeddings.js';
+import type { CommandContext } from '../../types.js';
+
+const chunkCommand = () => embeddingsCommand.subcommands!.find(c => c.name === 'chunk')!;
+
+let tmpDir: string;
+let ctx: CommandContext;
+
+beforeEach(() => {
+  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-chunk-')));
+  ctx = { args: [], flags: { _: [] }, cwd: tmpDir, interactive: false };
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('embeddings chunk', () => {
+  it('does not require --text at the parser level', () => {
+    const text = chunkCommand().options!.find(o => o.name === 'text')!;
+
+    // The requirement is what made `chunk -f doc.txt` impossible.
+    expect(text.required).toBeFalsy();
+  });
+
+  it('chunks the contents of --file', async () => {
+    const path = join(tmpDir, 'doc.txt');
+    writeFileSync(path, 'Alpha sentence here. Beta sentence here. Gamma sentence here.');
+
+    const result = await chunkCommand().action!({ ...ctx, flags: { file: path, _: [] } });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('still chunks --text', async () => {
+    const result = await chunkCommand().action!({
+      ...ctx,
+      flags: { text: 'One sentence. Two sentence.', _: [] },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  // Rule #1: a document must chunk identically regardless of the platform it
+  // was authored on. `chunking.ts` splits paragraphs on /\n\n+/, which a
+  // CRLF file's \r\n\r\n does not match — so without normalization the same
+  // file chunks differently on Windows than on POSIX.
+  it('chunks a CRLF file identically to its LF twin', async () => {
+    const paragraphs = [
+      'First paragraph here with some content.',
+      'Second paragraph here with some content.',
+      'Third paragraph here with some content.',
+    ];
+    const lfPath = join(tmpDir, 'lf.txt');
+    const crlfPath = join(tmpDir, 'crlf.txt');
+    writeFileSync(lfPath, paragraphs.join('\n\n'));
+    writeFileSync(crlfPath, paragraphs.join('\r\n\r\n'));
+
+    const run = async (path: string) =>
+      chunkCommand().action!({ ...ctx, flags: { file: path, strategy: 'paragraph', _: [] } });
+
+    const lf = await run(lfPath);
+    const crlf = await run(crlfPath);
+
+    expect(lf.success).toBe(true);
+    expect(crlf.success).toBe(true);
+    expect(crlf.data).toEqual(lf.data);
+  });
+
+  it('errors when the file does not exist', async () => {
+    const result = await chunkCommand().action!({
+      ...ctx,
+      flags: { file: join(tmpDir, 'nope.txt'), _: [] },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('errors when given neither --text nor --file', async () => {
+    const result = await chunkCommand().action!({ ...ctx, flags: { _: [] } });
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/src/cli/__tests__/config/cli-config-store.test.ts
+++ b/src/cli/__tests__/config/cli-config-store.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the CLI JSON config store — the file behind `flo config` and the
+ * doctor's `Config File` check.
+ *
+ * Validates that the store:
+ *  - writes the canonical `.moflo/config.json` and reads it back
+ *  - prefers the canonical file, then legacy `claude-flow.*` names (#699)
+ *  - writes back to whichever file the project already has
+ *  - merges a partial file over defaults instead of returning it raw
+ *  - surfaces corrupt JSON as an error rather than silently defaulting
+ *  - coerces `set` values to the type already at that key
+ *  - rejects unknown keys and prototype-polluting ones
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  CliConfigParseError,
+  cliConfigPath,
+  defaultCliConfig,
+  findCliConfigFile,
+  flattenConfig,
+  getConfigValue,
+  loadCliConfig,
+  resetSection,
+  saveCliConfig,
+  setConfigValue,
+} from '../../config/cli-config-store.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-config-store-')));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('cli-config-store', () => {
+  describe('save + load', () => {
+    it('round-trips through .moflo/config.json', () => {
+      const written = saveCliConfig(tmpDir, defaultCliConfig());
+
+      expect(written).toBe(cliConfigPath(tmpDir));
+      expect(loadCliConfig(tmpDir)).toMatchObject({
+        path: cliConfigPath(tmpDir),
+        config: { version: '3.0.0', swarm: { maxAgents: 15 } },
+      });
+    });
+
+    it('creates the .moflo directory when absent', () => {
+      saveCliConfig(tmpDir, defaultCliConfig());
+
+      expect(JSON.parse(readFileSync(cliConfigPath(tmpDir), 'utf8'))).toHaveProperty('version');
+    });
+
+    it('returns defaults and a null path when no config exists', () => {
+      const { config, path } = loadCliConfig(tmpDir);
+
+      expect(path).toBeNull();
+      expect(config).toEqual(defaultCliConfig());
+    });
+
+    it('merges a partial file over defaults', () => {
+      mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+      writeFileSync(cliConfigPath(tmpDir), JSON.stringify({ swarm: { topology: 'ring' } }));
+
+      const { config } = loadCliConfig(tmpDir);
+
+      expect(config.swarm.topology).toBe('ring');
+      expect(config.swarm.maxAgents).toBe(15); // default survives
+      expect(config.memory.backend).toBe('hybrid');
+    });
+
+    it('throws on corrupt JSON instead of silently defaulting', () => {
+      mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+      writeFileSync(cliConfigPath(tmpDir), '{ not json');
+
+      expect(() => loadCliConfig(tmpDir)).toThrow(CliConfigParseError);
+    });
+  });
+
+  describe('candidate precedence', () => {
+    it('prefers .moflo/config.json over a legacy root file', () => {
+      mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+      writeFileSync(cliConfigPath(tmpDir), JSON.stringify({ swarm: { topology: 'canonical' } }));
+      writeFileSync(join(tmpDir, 'claude-flow.config.json'), JSON.stringify({ swarm: { topology: 'legacy' } }));
+
+      expect(findCliConfigFile(tmpDir)).toBe(cliConfigPath(tmpDir));
+      expect(loadCliConfig(tmpDir).config.swarm.topology).toBe('canonical');
+    });
+
+    it('reads a pre-#699 claude-flow.config.json when it is all that exists', () => {
+      writeFileSync(join(tmpDir, 'claude-flow.config.json'), JSON.stringify({ swarm: { topology: 'legacy' } }));
+
+      expect(loadCliConfig(tmpDir).config.swarm.topology).toBe('legacy');
+    });
+
+    it('writes back to the file the project already has', () => {
+      const legacy = join(tmpDir, 'moflo.config.json');
+      writeFileSync(legacy, JSON.stringify({ swarm: { topology: 'ring' } }));
+
+      const written = saveCliConfig(tmpDir, defaultCliConfig());
+
+      expect(written).toBe(legacy);
+      expect(findCliConfigFile(tmpDir)).toBe(legacy);
+    });
+  });
+
+  describe('getConfigValue', () => {
+    it('reads nested and array paths', () => {
+      const config = defaultCliConfig();
+
+      expect(getConfigValue(config, 'swarm.topology')).toEqual({ found: true, value: 'hybrid' });
+      expect(getConfigValue(config, 'providers.0.name')).toEqual({ found: true, value: 'anthropic' });
+    });
+
+    it('reports unknown and out-of-range paths as not found', () => {
+      const config = defaultCliConfig();
+
+      expect(getConfigValue(config, 'swarm.nonesuch').found).toBe(false);
+      expect(getConfigValue(config, 'providers.99.name').found).toBe(false);
+      expect(getConfigValue(config, '').found).toBe(false);
+    });
+  });
+
+  describe('setConfigValue', () => {
+    it('coerces to the type already at the key', () => {
+      const config = defaultCliConfig();
+
+      expect(setConfigValue(config, 'swarm.maxAgents', '20')).toEqual({ ok: true, value: 20 });
+      expect(setConfigValue(config, 'swarm.autoScale', 'off')).toEqual({ ok: true, value: false });
+      expect(setConfigValue(config, 'swarm.topology', 'mesh')).toEqual({ ok: true, value: 'mesh' });
+      expect(config.swarm).toMatchObject({ maxAgents: 20, autoScale: false, topology: 'mesh' });
+    });
+
+    it('rejects values that do not fit the key type', () => {
+      const config = defaultCliConfig();
+
+      expect(setConfigValue(config, 'swarm.maxAgents', 'lots').ok).toBe(false);
+      expect(setConfigValue(config, 'swarm.autoScale', 'maybe').ok).toBe(false);
+      expect(config.swarm.maxAgents).toBe(15);
+    });
+
+    it('rejects a whole section as a value', () => {
+      const result = setConfigValue(defaultCliConfig(), 'swarm', 'mesh');
+
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects unknown keys rather than creating them', () => {
+      const config = defaultCliConfig();
+
+      expect(setConfigValue(config, 'swarm.nonesuch', '1').ok).toBe(false);
+      expect(config.swarm).not.toHaveProperty('nonesuch');
+    });
+
+    it('rejects prototype-polluting keys', () => {
+      const config = defaultCliConfig();
+
+      expect(setConfigValue(config, '__proto__.polluted', 'yes').ok).toBe(false);
+      expect(setConfigValue(config, 'swarm.constructor', 'yes').ok).toBe(false);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('writes into array entries', () => {
+      const config = defaultCliConfig();
+
+      expect(setConfigValue(config, 'providers.0.enabled', 'false')).toEqual({ ok: true, value: false });
+      expect(config.providers[0].enabled).toBe(false);
+    });
+  });
+
+  describe('flattenConfig', () => {
+    it('produces dotted leaf keys', () => {
+      const flat = flattenConfig(defaultCliConfig());
+
+      expect(flat['swarm.topology']).toBe('hybrid');
+      expect(flat['providers.0.name']).toBe('anthropic');
+      expect(Object.values(flat).every((v) => typeof v !== 'object')).toBe(true);
+    });
+  });
+
+  describe('resetSection', () => {
+    it('restores one section and leaves the rest alone', () => {
+      const config = defaultCliConfig();
+      setConfigValue(config, 'swarm.maxAgents', '99');
+      setConfigValue(config, 'memory.cacheSize', '1');
+
+      const reset = resetSection(config, 'swarm');
+
+      expect(reset.swarm.maxAgents).toBe(15);
+      expect(reset.memory.cacheSize).toBe(1);
+    });
+
+    it('restores everything for "all" while preserving mode flags', () => {
+      const config = defaultCliConfig({ v3: false, sparc: true });
+      setConfigValue(config, 'swarm.maxAgents', '99');
+
+      const reset = resetSection(config, 'all');
+
+      expect(reset.swarm.maxAgents).toBe(15);
+      expect(reset.v3Mode).toBe(false);
+      expect(reset.sparc).toBe(true);
+    });
+  });
+});

--- a/src/cli/__tests__/config/cli-config-store.test.ts
+++ b/src/cli/__tests__/config/cli-config-store.test.ts
@@ -76,6 +76,24 @@ describe('cli-config-store', () => {
       expect(config.memory.backend).toBe('hybrid');
     });
 
+    // deepMerge is structural, not validating: a hand-edited file could put a
+    // string where an array belongs and produce a CliConfig that lies about its
+    // own type, throwing on the first `.find`.
+    it('restores a section whose type the file contradicts', () => {
+      mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
+      writeFileSync(
+        cliConfigPath(tmpDir),
+        JSON.stringify({ providers: 'not-an-array', swarm: 42, memory: { backend: 'rvf' } }),
+      );
+
+      const { config } = loadCliConfig(tmpDir);
+
+      expect(Array.isArray(config.providers)).toBe(true);
+      expect(config.swarm.topology).toBe('hybrid');
+      // A section that IS well-formed keeps the user's value.
+      expect(config.memory.backend).toBe('rvf');
+    });
+
     it('throws on corrupt JSON instead of silently defaulting', () => {
       mkdirSync(join(tmpDir, '.moflo'), { recursive: true });
       writeFileSync(cliConfigPath(tmpDir), '{ not json');
@@ -125,6 +143,16 @@ describe('cli-config-store', () => {
       expect(getConfigValue(config, 'swarm.nonesuch').found).toBe(false);
       expect(getConfigValue(config, 'providers.99.name').found).toBe(false);
       expect(getConfigValue(config, '').found).toBe(false);
+    });
+
+    // Filtering empty segments away would make this silently valid, which
+    // contradicts the loud-failure contract setConfigValue relies on.
+    it('rejects keys with empty segments rather than collapsing them', () => {
+      const config = defaultCliConfig();
+
+      expect(getConfigValue(config, 'swarm..topology').found).toBe(false);
+      expect(getConfigValue(config, '.swarm.topology').found).toBe(false);
+      expect(setConfigValue(config, 'swarm..topology', 'mesh').ok).toBe(false);
     });
   });
 
@@ -182,6 +210,17 @@ describe('cli-config-store', () => {
       expect(flat['swarm.topology']).toBe('hybrid');
       expect(flat['providers.0.name']).toBe('anthropic');
       expect(Object.values(flat).every((v) => typeof v !== 'object')).toBe(true);
+    });
+
+    // An empty container is a leaf: recursing over zero entries would drop the
+    // key, so `providers: []` would read as "not configured" rather than
+    // "configured empty".
+    it('keeps empty objects and arrays visible', () => {
+      const config = { ...defaultCliConfig(), providers: [] };
+
+      const flat = flattenConfig(config);
+
+      expect(flat.providers).toBe('[]');
     });
   });
 

--- a/src/cli/__tests__/parser.test.ts
+++ b/src/cli/__tests__/parser.test.ts
@@ -400,6 +400,88 @@ describe('CommandParser', () => {
       expect(errors[0]).toContain('Invalid value for --count');
     });
 
+    // A command option must SHADOW the same-named global, not stack with it.
+    // Stacking made every collision unsatisfiable — `flo config export
+    // --format yaml` had to satisfy both the command's ['json','yaml'] and the
+    // global's ['text','json','table'], so it errored whatever the user typed.
+    it('lets a command option shadow a same-named global option', () => {
+      const cmd: Command = {
+        name: 'export',
+        description: 'Export',
+        options: [
+          { name: 'format', type: 'string', choices: ['json', 'yaml'], description: 'Export format' },
+        ],
+      };
+
+      expect(parser.validateFlags({ _: [], format: 'yaml' }, cmd)).toEqual([]);
+      // The command's choices still apply — shadowing narrows, it doesn't skip.
+      expect(parser.validateFlags({ _: [], format: 'table' }, cmd).length).toBe(1);
+    });
+
+    it('applies a command option default over the global default of the same name', () => {
+      const cmd: Command = {
+        name: 'export',
+        description: 'Export',
+        options: [
+          { name: 'format', type: 'string', default: 'json', choices: ['json', 'yaml'], description: 'Export format' },
+        ],
+      };
+      parser.registerCommand(cmd);
+
+      const result = parser.parse(['export']);
+
+      // Without this, the global's 'text' default is injected and then fails
+      // the command's own choices — a command broken with no flags at all.
+      expect(result.flags.format).toBe('json');
+      expect(parser.validateFlags(result.flags, cmd)).toEqual([]);
+    });
+
+    // Guard on blast radius: 455 command options across the CLI declare
+    // defaults the parser has never applied, 28 of them giving a boolean the
+    // truthy STRING 'false'. Only options that shadow a global may have their
+    // default applied — applying all of them flips flags like --force to ON.
+    it('does not apply command defaults for options that do not shadow a global', () => {
+      const cmd: Command = {
+        name: 'init',
+        description: 'Init',
+        options: [
+          { name: 'force', type: 'boolean', default: 'false', description: 'Force' },
+        ],
+      };
+      parser.registerCommand(cmd);
+
+      const result = parser.parse(['init']);
+
+      expect(result.flags.force).toBeUndefined();
+    });
+
+    // A command that redefines a global BOOLEAN as a value-taking option must
+    // be parsed as value-taking. `plugins install pkg --version 1.2.3` used to
+    // yield `version: true` with '1.2.3' stranded in positionals, which then
+    // tripped the global --version handler: it printed the moflo version and
+    // returned without installing anything.
+    it('parses a global boolean redefined as a value option as value-taking', () => {
+      const cmd: Command = {
+        name: 'install',
+        description: 'Install',
+        options: [
+          { name: 'version', short: 'v', type: 'string', description: 'Version to install' },
+        ],
+      };
+      parser.registerCommand(cmd);
+
+      const result = parser.parse(['install', 'mypkg', '--version', '1.2.3']);
+
+      expect(result.flags.version).toBe('1.2.3');
+      expect(result.positional).toEqual(['mypkg']);
+    });
+
+    it('still parses the global --version as a boolean when no command shadows it', () => {
+      const result = parser.parse(['--version']);
+
+      expect(result.flags.version).toBe(true);
+    });
+
     it('should report unknown flags when allowUnknownFlags is false', () => {
       const strictParser = new CommandParser({ allowUnknownFlags: false });
       const errors = strictParser.validateFlags({ _: [], unknown: true });

--- a/src/cli/__tests__/parser.test.ts
+++ b/src/cli/__tests__/parser.test.ts
@@ -482,6 +482,35 @@ describe('CommandParser', () => {
       expect(result.flags.version).toBe(true);
     });
 
+    // The value-omitted half of the same bug: `--version` with nothing after it
+    // fell through to `true`, which is exactly what the global version handler
+    // keys on, so it printed the moflo version instead of running the command.
+    it('does not fall back to `true` when a declared value option is given no value', () => {
+      const cmd: Command = {
+        name: 'install',
+        description: 'Install',
+        options: [
+          { name: 'version', short: 'v', type: 'string', description: 'Version to install' },
+          { name: 'force', type: 'boolean', description: 'Force' },
+        ],
+      };
+      parser.registerCommand(cmd);
+
+      expect(parser.parse(['install', 'pkg', '--version']).flags.version).toBe('');
+      expect(parser.parse(['install', 'pkg', '--version', '--force']).flags.version).toBe('');
+      // The boolean sibling is unaffected.
+      expect(parser.parse(['install', 'pkg', '--force']).flags.force).toBe(true);
+    });
+
+    it('leaves an UNDECLARED valueless flag as `true`', () => {
+      const cmd: Command = { name: 'adhoc', description: 'Adhoc', options: [] };
+      parser.registerCommand(cmd);
+
+      // Undeclared flags keep legacy behaviour — narrowing that would change
+      // every command that reads an ad-hoc flag.
+      expect(parser.parse(['adhoc', '--whatever']).flags.whatever).toBe(true);
+    });
+
     it('should report unknown flags when allowUnknownFlags is false', () => {
       const strictParser = new CommandParser({ allowUnknownFlags: false });
       const errors = strictParser.validateFlags({ _: [], unknown: true });

--- a/src/cli/commands/benchmark.ts
+++ b/src/cli/commands/benchmark.ts
@@ -22,11 +22,14 @@ const pretrainCommand: Command = {
   name: 'pretrain',
   description: 'Benchmark self-learning pre-training system (SONA, EWC++, MoE)',
   options: [
-    { name: 'iterations', short: 'i', type: 'number', description: 'Benchmark iterations', default: '100' },
-    { name: 'warmup', short: 'w', type: 'number', description: 'Warmup iterations', default: '10' },
+    { name: 'iterations', short: 'i', type: 'number', description: 'Benchmark iterations', default: 100 },
+    { name: 'warmup', short: 'w', type: 'number', description: 'Warmup iterations', default: 10 },
     { name: 'output', short: 'o', type: 'string', description: 'Output format: text, json', default: 'text' },
     { name: 'save', short: 's', type: 'string', description: 'Save results to file' },
-    { name: 'verbose', short: 'v', type: 'boolean', description: 'Verbose output', default: 'false' },
+    // Boolean default, not the string 'false' — this option shadows the global
+    // --verbose, so its default is the one the parser applies, and 'false' is
+    // a truthy string that would turn verbose ON by default.
+    { name: 'verbose', short: 'v', type: 'boolean', description: 'Verbose output', default: false },
   ],
   examples: [
     { command: 'flo benchmark pretrain', description: 'Run pre-training benchmarks' },
@@ -92,9 +95,9 @@ const neuralCommand: Command = {
   name: 'neural',
   description: 'Benchmark neural operations (embeddings, WASM, Flash Attention)',
   options: [
-    { name: 'iterations', short: 'i', type: 'number', description: 'Benchmark iterations', default: '100' },
-    { name: 'dimension', short: 'd', type: 'number', description: 'Embedding dimension', default: '384' },
-    { name: 'vectors', short: 'n', type: 'number', description: 'Number of test vectors', default: '1000' },
+    { name: 'iterations', short: 'i', type: 'number', description: 'Benchmark iterations', default: 100 },
+    { name: 'dimension', short: 'd', type: 'number', description: 'Embedding dimension', default: 384 },
+    { name: 'vectors', short: 'n', type: 'number', description: 'Number of test vectors', default: 1000 },
     { name: 'output', short: 'o', type: 'string', description: 'Output format: text, json', default: 'text' },
   ],
   examples: [
@@ -270,7 +273,7 @@ const memoryCommand: Command = {
   name: 'memory',
   description: 'Benchmark memory operations (HNSW search, store, retrieve)',
   options: [
-    { name: 'iterations', short: 'i', type: 'number', description: 'Benchmark iterations', default: '100' },
+    { name: 'iterations', short: 'i', type: 'number', description: 'Benchmark iterations', default: 100 },
     { name: 'output', short: 'o', type: 'string', description: 'Output format: text, json', default: 'text' },
   ],
   examples: [
@@ -398,7 +401,7 @@ const allCommand: Command = {
   name: 'all',
   description: 'Run all benchmark suites',
   options: [
-    { name: 'iterations', short: 'i', type: 'number', description: 'Benchmark iterations', default: '50' },
+    { name: 'iterations', short: 'i', type: 'number', description: 'Benchmark iterations', default: 50 },
     { name: 'output', short: 'o', type: 'string', description: 'Output format: text, json', default: 'text' },
     { name: 'save', short: 's', type: 'string', description: 'Save results to file' },
   ],

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -266,7 +266,7 @@ const setCommand: Command = {
 
     let target: string;
     try {
-      target = saveCliConfig(root, config);
+      target = saveCliConfig(root, config, { path: loaded.path ?? undefined });
     } catch (err) {
       output.printError(`Failed to write configuration: ${(err as Error).message}`);
       return { success: false, exitCode: 1 };
@@ -351,7 +351,7 @@ const providersCommand: Command = {
     if (mutated) {
       let target: string;
       try {
-        target = saveCliConfig(root, config);
+        target = saveCliConfig(root, config, { path: loaded.path ?? undefined });
       } catch (err) {
         output.printError(`Failed to write configuration: ${(err as Error).message}`);
         return { success: false, exitCode: 1 };
@@ -443,7 +443,7 @@ const resetCommand: Command = {
 
     let target: string;
     try {
-      target = saveCliConfig(root, resetSection(loaded.config, section));
+      target = saveCliConfig(root, resetSection(loaded.config, section), { path: loaded.path ?? undefined });
     } catch (err) {
       output.printError(`Failed to write configuration: ${(err as Error).message}`);
       return { success: false, exitCode: 1 };

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,11 +1,79 @@
 /**
  * V3 CLI Config Command
  * Configuration management
+ *
+ * Every subcommand here reads and writes a real file — see
+ * `../config/cli-config-store.ts` for the store and for why that is worth
+ * stating: this family used to print "Creating ..." and "Configuration
+ * updated" without touching the filesystem, which made `flo doctor --fix`
+ * report the `Config File` warning as fixed forever.
+ *
+ * `show` and `generate` are the odd pair out: they operate on **moflo.yaml**
+ * via `../config/moflo-config.ts`, not on the JSON config.
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { extname, isAbsolute, relative, resolve, sep } from 'node:path';
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
-import { select, confirm, input } from '../prompt.js';
+import { confirm } from '../prompt.js';
+import { resolveStateRoot } from '../services/project-root.js';
+import {
+  CliConfigParseError,
+  RESETTABLE_SECTIONS,
+  cliConfigPath,
+  defaultCliConfig,
+  findCliConfigFile,
+  flattenConfig,
+  getConfigValue,
+  loadCliConfig,
+  resetSection,
+  saveCliConfig,
+  setConfigValue,
+  writeJsonFile,
+  writeTextFile,
+  type CliConfig,
+  type CliConfigProvider,
+  type ResettableSection,
+} from '../config/cli-config-store.js';
+
+/**
+ * Anchor config reads/writes at the state root — `resolveStateRoot`, not
+ * `findProjectRoot`, because this command CREATES `.moflo/` content and must
+ * land on the monorepo's canonical anchor rather than minting an island in a
+ * sub-workspace (#1315).
+ */
+function configRoot(ctx: CommandContext): string {
+  return resolveStateRoot({ cwd: ctx.cwd || process.cwd() });
+}
+
+/**
+ * Path relative to the project root, for display. Builds the `./` prefix from
+ * `path.sep` so Windows shows `.\.moflo\config.json` rather than a mixed
+ * `./.moflo\config.json`.
+ */
+function displayPath(root: string, target: string): string {
+  const rel = relative(root, target);
+  return rel && !rel.startsWith('..') ? `.${sep}${rel}` : target;
+}
+
+/**
+ * Load config, printing the parse error and returning `null` when the file on
+ * disk is corrupt. Callers exit 1 on `null` rather than silently falling back
+ * to defaults — a config that cannot be read is a failure, not a default.
+ */
+function loadOrReport(root: string): { config: CliConfig; path: string | null } | null {
+  try {
+    return loadCliConfig(root);
+  } catch (err) {
+    if (err instanceof CliConfigParseError) {
+      output.printError(err.message);
+      output.writeln(output.dim('  Fix the JSON syntax, or run `flo config init --force` to rewrite it.'));
+      return null;
+    }
+    throw err;
+  }
+}
 
 // Init configuration
 const initCommand: Command = {
@@ -35,59 +103,30 @@ const initCommand: Command = {
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const sparc = ctx.flags.sparc as boolean;
     const v3 = ctx.flags.v3 as boolean;
+    const force = ctx.flags.force as boolean;
+    const root = configRoot(ctx);
+
+    const existing = findCliConfigFile(root);
+    if (existing && !force) {
+      output.printError(`Configuration already exists: ${displayPath(root, existing)}`);
+      output.writeln(output.dim('  Re-run with --force to overwrite it.'));
+      return { success: false, exitCode: 1 };
+    }
 
     output.writeln();
     output.printInfo('Initializing MoFlo configuration...');
     output.writeln();
 
-    // Create default configuration
-    const config = {
-      version: '3.0.0',
-      v3Mode: v3,
-      sparc: sparc,
-      agents: {
-        defaultType: 'coder',
-        maxConcurrent: 15,
-        autoSpawn: true,
-        timeout: 300
-      },
-      swarm: {
-        topology: 'hybrid',
-        maxAgents: 15,
-        autoScale: true,
-        coordinationStrategy: 'consensus'
-      },
-      memory: {
-        backend: 'hybrid',
-        path: './data/memory',
-        cacheSize: 256,
-        enableHNSW: true
-      },
-      mcp: {
-        transport: 'stdio',
-        autoStart: true,
-        tools: 'all'
-      },
-      providers: [
-        { name: 'anthropic', priority: 1, enabled: true },
-        { name: 'openrouter', priority: 2, enabled: false },
-        { name: 'ollama', priority: 3, enabled: false }
-      ]
-    };
-
-    output.writeln(output.dim('  Creating claude-flow.config.json...'));
-    output.writeln(output.dim('  Creating .moflo/ directory...'));
-
-    if (sparc) {
-      output.writeln(output.dim('  Initializing SPARC methodology...'));
-      output.writeln(output.dim('  Creating SPARC workflow files...'));
+    const config = defaultCliConfig({ v3, sparc });
+    const target = existing ?? cliConfigPath(root);
+    try {
+      saveCliConfig(root, config, { path: target });
+    } catch (err) {
+      output.printError(`Failed to write ${displayPath(root, target)}: ${(err as Error).message}`);
+      return { success: false, exitCode: 1 };
     }
 
-    if (v3) {
-      output.writeln(output.dim('  Enabling V3 15-agent coordination...'));
-      output.writeln(output.dim('  Configuring AgentDB integration...'));
-      output.writeln(output.dim('  Setting up Flash Attention optimization...'));
-    }
+    output.writeln(output.dim(`  Wrote ${displayPath(root, target)}`));
 
     output.writeln();
     output.printTable({
@@ -108,7 +147,7 @@ const initCommand: Command = {
 
     output.writeln();
     output.printSuccess('Configuration initialized');
-    output.writeln(output.dim('  Config file: ./claude-flow.config.json'));
+    output.writeln(output.dim(`  Config file: ${displayPath(root, target)}`));
 
     return { success: true, data: config };
   }
@@ -132,23 +171,15 @@ const getCommand: Command = {
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const key = ctx.flags.key as string || ctx.args[0];
+    const root = configRoot(ctx);
 
-    // Default config values (loaded from actual config when available)
-    const configValues: Record<string, unknown> = {
-      'version': '3.0.0',
-      'v3Mode': true,
-      'swarm.topology': 'hybrid',
-      'swarm.maxAgents': 15,
-      'swarm.autoScale': true,
-      'memory.backend': 'hybrid',
-      'memory.cacheSize': 256,
-      'mcp.transport': 'stdio',
-      'agents.defaultType': 'coder',
-      'agents.maxConcurrent': 15
-    };
+    const loaded = loadOrReport(root);
+    if (!loaded) return { success: false, exitCode: 1 };
+    const { config, path } = loaded;
 
     if (!key) {
-      // Show all config
+      const configValues = flattenConfig(config);
+
       if (ctx.flags.format === 'json') {
         output.printJson(configValues);
         return { success: true, data: configValues };
@@ -156,11 +187,12 @@ const getCommand: Command = {
 
       output.writeln();
       output.writeln(output.bold('Current Configuration'));
+      output.writeln(output.dim(path ? `  ${displayPath(root, path)}` : '  (no config file — showing defaults)'));
       output.writeln();
 
       output.printTable({
         columns: [
-          { key: 'key', header: 'Key', width: 25 },
+          { key: 'key', header: 'Key', width: 30 },
           { key: 'value', header: 'Value', width: 30 }
         ],
         data: Object.entries(configValues).map(([k, v]) => ({ key: k, value: String(v) }))
@@ -169,9 +201,9 @@ const getCommand: Command = {
       return { success: true, data: configValues };
     }
 
-    const value = configValues[key];
+    const { found, value } = getConfigValue(config, key);
 
-    if (value === undefined) {
+    if (!found) {
       output.printError(`Configuration key not found: ${key}`);
       return { success: false, exitCode: 1 };
     }
@@ -179,7 +211,7 @@ const getCommand: Command = {
     if (ctx.flags.format === 'json') {
       output.printJson({ key, value });
     } else {
-      output.writeln(`${key} = ${value}`);
+      output.writeln(`${key} = ${typeof value === 'object' ? JSON.stringify(value) : String(value)}`);
     }
 
     return { success: true, data: { key, value } };
@@ -191,19 +223,21 @@ const setCommand: Command = {
   name: 'set',
   description: 'Set configuration value',
   options: [
+    // Not `required` at the parser level: these are also accepted
+    // positionally (`flo config set swarm.maxAgents 20`, this command's own
+    // documented example), and a parser-level requirement rejects that form
+    // before the action can read ctx.args. The action validates instead.
     {
       name: 'key',
       short: 'k',
       description: 'Configuration key',
-      type: 'string',
-      required: true
+      type: 'string'
     },
     {
       name: 'value',
       short: 'v',
       description: 'Configuration value',
-      type: 'string',
-      required: true
+      type: 'string'
     }
   ],
   examples: [
@@ -219,10 +253,29 @@ const setCommand: Command = {
       return { success: false, exitCode: 1 };
     }
 
-    output.printInfo(`Setting ${key} = ${value}`);
-    output.printSuccess('Configuration updated');
+    const root = configRoot(ctx);
+    const loaded = loadOrReport(root);
+    if (!loaded) return { success: false, exitCode: 1 };
+    const { config } = loaded;
 
-    return { success: true, data: { key, value } };
+    const result = setConfigValue(config, key, String(value));
+    if (!result.ok) {
+      output.printError(`Cannot set ${key}: ${result.error}`);
+      return { success: false, exitCode: 1 };
+    }
+
+    let target: string;
+    try {
+      target = saveCliConfig(root, config);
+    } catch (err) {
+      output.printError(`Failed to write configuration: ${(err as Error).message}`);
+      return { success: false, exitCode: 1 };
+    }
+
+    output.printInfo(`Setting ${key} = ${String(result.value)}`);
+    output.printSuccess(`Configuration updated (${displayPath(root, target)})`);
+
+    return { success: true, data: { key, value: result.value } };
   }
 };
 
@@ -255,12 +308,62 @@ const providersCommand: Command = {
     }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const providers = [
-      { name: 'anthropic', model: 'claude-3-5-sonnet-20241022', priority: 1, enabled: true, status: 'Active' },
-      { name: 'openrouter', model: 'claude-3.5-sonnet', priority: 2, enabled: false, status: 'Disabled' },
-      { name: 'ollama', model: 'llama3.2', priority: 3, enabled: false, status: 'Disabled' },
-      { name: 'gemini', model: 'gemini-2.0-flash', priority: 4, enabled: false, status: 'Disabled' }
-    ];
+    const root = configRoot(ctx);
+    const loaded = loadOrReport(root);
+    if (!loaded) return { success: false, exitCode: 1 };
+    const { config } = loaded;
+
+    const add = ctx.flags.add as string | undefined;
+    const remove = ctx.flags.remove as string | undefined;
+    const enable = ctx.flags.enable as string | undefined;
+    const disable = ctx.flags.disable as string | undefined;
+
+    const find = (name: string): CliConfigProvider | undefined =>
+      config.providers.find((p) => p.name.toLowerCase() === name.toLowerCase());
+
+    let mutated = false;
+
+    if (add) {
+      if (find(add)) {
+        output.printError(`Provider already exists: ${add}`);
+        return { success: false, exitCode: 1 };
+      }
+      const priority = config.providers.reduce((max, p) => Math.max(max, p.priority), 0) + 1;
+      config.providers.push({ name: add, priority, enabled: false });
+      mutated = true;
+    }
+
+    for (const [name, action] of [[remove, 'remove'], [enable, 'enable'], [disable, 'disable']] as const) {
+      if (!name) continue;
+      const provider = find(name);
+      if (!provider) {
+        output.printError(`Provider not found: ${name}`);
+        return { success: false, exitCode: 1 };
+      }
+      if (action === 'remove') {
+        config.providers = config.providers.filter((p) => p !== provider);
+      } else {
+        provider.enabled = action === 'enable';
+      }
+      mutated = true;
+    }
+
+    if (mutated) {
+      let target: string;
+      try {
+        target = saveCliConfig(root, config);
+      } catch (err) {
+        output.printError(`Failed to write configuration: ${(err as Error).message}`);
+        return { success: false, exitCode: 1 };
+      }
+      output.printSuccess(`Providers updated (${displayPath(root, target)})`);
+    }
+
+    const providers = config.providers.map((p) => ({
+      ...p,
+      model: p.model ?? '',
+      status: p.enabled ? 'Active' : 'Disabled'
+    }));
 
     if (ctx.flags.format === 'json') {
       output.printJson(providers);
@@ -307,12 +410,18 @@ const resetCommand: Command = {
       name: 'section',
       description: 'Reset specific section only',
       type: 'string',
-      choices: ['agents', 'swarm', 'memory', 'mcp', 'providers', 'all']
+      choices: [...RESETTABLE_SECTIONS]
     }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const force = ctx.flags.force as boolean;
-    const section = ctx.flags.section as string || 'all';
+    const section = (ctx.flags.section as string || 'all') as ResettableSection;
+
+    if (!RESETTABLE_SECTIONS.includes(section)) {
+      output.printError(`Unknown section: ${section}`);
+      output.writeln(output.dim(`  Valid sections: ${RESETTABLE_SECTIONS.join(', ')}`));
+      return { success: false, exitCode: 1 };
+    }
 
     if (!force && ctx.interactive) {
       const confirmed = await confirm({
@@ -326,10 +435,23 @@ const resetCommand: Command = {
       }
     }
 
-    output.printInfo(`Resetting ${section} configuration...`);
-    output.printSuccess('Configuration reset to defaults');
+    const root = configRoot(ctx);
+    const loaded = loadOrReport(root);
+    if (!loaded) return { success: false, exitCode: 1 };
 
-    return { success: true, data: { section, reset: true } };
+    output.printInfo(`Resetting ${section} configuration...`);
+
+    let target: string;
+    try {
+      target = saveCliConfig(root, resetSection(loaded.config, section));
+    } catch (err) {
+      output.printError(`Failed to write configuration: ${(err as Error).message}`);
+      return { success: false, exitCode: 1 };
+    }
+
+    output.printSuccess(`Configuration reset to defaults (${displayPath(root, target)})`);
+
+    return { success: true, data: { section, reset: true, path: target } };
   }
 };
 
@@ -354,23 +476,43 @@ const exportCommand: Command = {
     }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const outputPath = ctx.flags.output as string || './claude-flow.config.export.json';
+    const format = (ctx.flags.format as string) || 'json';
+    if (format !== 'json' && format !== 'yaml') {
+      output.printError(`Unsupported export format: ${format}`);
+      output.writeln(output.dim('  Valid formats: json, yaml'));
+      return { success: false, exitCode: 1 };
+    }
 
-    const config = {
-      version: '3.0.0',
-      exportedAt: new Date().toISOString(),
-      agents: { defaultType: 'coder', maxConcurrent: 15 },
-      swarm: { topology: 'hybrid', maxAgents: 15 },
-      memory: { backend: 'hybrid', cacheSize: 256 },
-      mcp: { transport: 'stdio', tools: 'all' }
-    };
+    const root = configRoot(ctx);
+    const loaded = loadOrReport(root);
+    if (!loaded) return { success: false, exitCode: 1 };
 
-    output.printInfo(`Exporting configuration to ${outputPath}...`);
-    output.printJson(config);
+    const requested = ctx.flags.output as string | undefined;
+    const defaultName = `moflo.config.export.${format === 'yaml' ? 'yaml' : 'json'}`;
+    const outputPath = requested
+      ? (isAbsolute(requested) ? requested : resolve(root, requested))
+      : resolve(root, defaultName);
+
+    const config = { ...loaded.config, exportedAt: new Date().toISOString() };
+
+    output.printInfo(`Exporting configuration to ${displayPath(root, outputPath)}...`);
+
+    try {
+      if (format === 'yaml') {
+        const { dump } = await import('js-yaml');
+        writeTextFile(outputPath, dump(config));
+      } else {
+        writeJsonFile(outputPath, config);
+      }
+    } catch (err) {
+      output.printError(`Failed to write ${displayPath(root, outputPath)}: ${(err as Error).message}`);
+      return { success: false, exitCode: 1 };
+    }
+
     output.writeln();
     output.printSuccess('Configuration exported');
 
-    return { success: true, data: { path: outputPath, config } };
+    return { success: true, data: { path: outputPath, format, config } };
   }
 };
 
@@ -379,12 +521,13 @@ const importCommand: Command = {
   name: 'import',
   description: 'Import configuration',
   options: [
+    // Also accepted positionally (`flo config import ./cfg.json`) — see the
+    // note on `set`.
     {
       name: 'file',
       short: 'f',
       description: 'Configuration file path',
-      type: 'string',
-      required: true
+      type: 'string'
     },
     {
       name: 'merge',
@@ -402,17 +545,61 @@ const importCommand: Command = {
       return { success: false, exitCode: 1 };
     }
 
+    const root = configRoot(ctx);
+    const source = isAbsolute(file) ? file : resolve(root, file);
+
+    if (!existsSync(source)) {
+      output.printError(`Configuration file not found: ${file}`);
+      return { success: false, exitCode: 1 };
+    }
+
+    let incoming: unknown;
+    try {
+      const raw = readFileSync(source, 'utf8');
+      if (extname(source).toLowerCase() === '.yaml' || extname(source).toLowerCase() === '.yml') {
+        const { load } = await import('js-yaml');
+        incoming = load(raw);
+      } else {
+        incoming = JSON.parse(raw);
+      }
+    } catch (err) {
+      output.printError(`Could not parse ${file}: ${(err as Error).message}`);
+      return { success: false, exitCode: 1 };
+    }
+
+    if (typeof incoming !== 'object' || incoming === null || Array.isArray(incoming)) {
+      output.printError(`Not a configuration object: ${file}`);
+      return { success: false, exitCode: 1 };
+    }
+
     output.printInfo(`Importing configuration from ${file}...`);
 
+    // Merge mode layers the file over what is on disk; replace mode layers it
+    // over defaults, so an incomplete file still yields a complete config.
+    let base: CliConfig;
     if (merge) {
+      const loaded = loadOrReport(root);
+      if (!loaded) return { success: false, exitCode: 1 };
+      base = loaded.config;
       output.writeln(output.dim('  Merging with existing configuration...'));
     } else {
+      base = defaultCliConfig();
       output.writeln(output.dim('  Replacing existing configuration...'));
     }
 
-    output.printSuccess('Configuration imported');
+    const imported: CliConfig = { ...base, ...(incoming as Partial<CliConfig>) };
 
-    return { success: true, data: { file, merge, imported: true } };
+    let target: string;
+    try {
+      target = saveCliConfig(root, imported);
+    } catch (err) {
+      output.printError(`Failed to write configuration: ${(err as Error).message}`);
+      return { success: false, exitCode: 1 };
+    }
+
+    output.printSuccess(`Configuration imported (${displayPath(root, target)})`);
+
+    return { success: true, data: { file, merge, imported: true, path: target } };
   }
 };
 

--- a/src/cli/commands/deployment.ts
+++ b/src/cli/commands/deployment.ts
@@ -17,7 +17,7 @@ const deployCommand: Command = {
     { name: 'version', short: 'v', type: 'string', description: 'Version to deploy', default: 'latest' },
     { name: 'dry-run', short: 'd', type: 'boolean', description: 'Simulate deployment without changes' },
     { name: 'force', short: 'f', type: 'boolean', description: 'Force deployment without checks' },
-    { name: 'rollback-on-fail', type: 'boolean', description: 'Auto rollback on failure', default: 'true' },
+    { name: 'rollback-on-fail', type: 'boolean', description: 'Auto rollback on failure', default: true },
   ],
   examples: [
     { command: 'flo deployment deploy -e prod', description: 'Deploy to production' },
@@ -113,7 +113,7 @@ const rollbackCommand: Command = {
   options: [
     { name: 'env', short: 'e', type: 'string', description: 'Environment to rollback', required: true },
     { name: 'version', short: 'v', type: 'string', description: 'Specific version to rollback to' },
-    { name: 'steps', short: 's', type: 'number', description: 'Number of versions to rollback', default: '1' },
+    { name: 'steps', short: 's', type: 'number', description: 'Number of versions to rollback', default: 1 },
   ],
   examples: [
     { command: 'flo deployment rollback -e prod', description: 'Rollback production' },
@@ -163,7 +163,7 @@ const historyCommand: Command = {
   description: 'View deployment history',
   options: [
     { name: 'env', short: 'e', type: 'string', description: 'Filter by environment' },
-    { name: 'limit', short: 'l', type: 'number', description: 'Number of entries', default: '10' },
+    { name: 'limit', short: 'l', type: 'number', description: 'Number of entries', default: 10 },
   ],
   examples: [
     { command: 'flo deployment history', description: 'Show all history' },
@@ -243,7 +243,7 @@ const logsCommand: Command = {
     { name: 'deployment', short: 'd', type: 'string', description: 'Deployment ID' },
     { name: 'env', short: 'e', type: 'string', description: 'Environment' },
     { name: 'follow', short: 'f', type: 'boolean', description: 'Follow log output' },
-    { name: 'lines', short: 'n', type: 'number', description: 'Number of lines', default: '50' },
+    { name: 'lines', short: 'n', type: 'number', description: 'Number of lines', default: 50 },
   ],
   examples: [
     { command: 'flo deployment logs -e prod', description: 'View production logs' },

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -26,45 +26,47 @@ import {
   memoryDbPath,
 } from '../services/moflo-paths.js';
 import { probeDbIntegrity } from '../services/memory-db-integrity-repair.js';
+import { CLI_CONFIG_CANDIDATES } from '../config/cli-config-store.js';
 import { findProjectRoot, resolveStateRoot } from '../services/project-root.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import type { HealthCheck } from './doctor-types.js';
 
 export async function checkConfigFile(): Promise<HealthCheck> {
-  // JSON configs (parse-validated). LEGACY-CONFIG: `.claude-flow.json` and
-  // `claude-flow.config.json` filenames are still recognised so consumers
-  // upgrading from pre-#699 moflo builds keep working
-  // without manual rename. Drift guard exempts these via LEGACY-CONFIG marker.
-  const jsonPaths = [
-    '.moflo/config.json',
-    'moflo.config.json',
-    'claude-flow.config.json', // LEGACY-CONFIG: pre-#699 fallback
-    '.claude-flow.json',       // LEGACY-CONFIG: pre-#699 fallback
-  ];
+  // Resolve against the state root, not the bare cwd: running `flo doctor`
+  // from a subdirectory used to report "no config file" for a project that has
+  // one, and the auto-fix (which writes at the state root) could never clear
+  // the warning it raised. Same anchor as `flo config` (#1315).
+  const root = resolveStateRoot();
 
-  for (const configPath of jsonPaths) {
+  // JSON configs (parse-validated). The candidate list lives in the config
+  // store so this check, `flo config`, and the doctor auto-fix all agree on
+  // which files count. LEGACY-CONFIG: `claude-flow.*` names are still
+  // recognised there so consumers upgrading from pre-#699 moflo builds keep
+  // working without a manual rename.
+  for (const candidate of CLI_CONFIG_CANDIDATES) {
+    const configPath = join(root, candidate);
     if (existsSync(configPath)) {
       try {
         const content = readFileSync(configPath, 'utf8');
         JSON.parse(content);
-        return { name: 'Config File', status: 'pass', message: `Found: ${configPath}` };
+        return { name: 'Config File', status: 'pass', message: `Found: ${candidate}` };
       } catch {
-        return { name: 'Config File', status: 'fail', message: `Invalid JSON: ${configPath}`, fix: 'Fix JSON syntax in config file' };
+        return { name: 'Config File', status: 'fail', message: `Invalid JSON: ${candidate}`, fix: 'Fix JSON syntax in config file' };
       }
     }
   }
 
   // YAML configs (existence-checked only — no heavy yaml parser dependency).
   const yamlPaths = [
-    '.moflo/config.yaml',
-    '.moflo/config.yml',
+    join('.moflo', 'config.yaml'),
+    join('.moflo', 'config.yml'),
     'moflo.config.yaml',
     'claude-flow.config.yaml', // LEGACY-CONFIG: pre-#699 fallback
   ];
 
-  for (const configPath of yamlPaths) {
-    if (existsSync(configPath)) {
-      return { name: 'Config File', status: 'pass', message: `Found: ${configPath}` };
+  for (const candidate of yamlPaths) {
+    if (existsSync(join(root, candidate))) {
+      return { name: 'Config File', status: 'pass', message: `Found: ${candidate}` };
     }
   }
 

--- a/src/cli/commands/doctor-checks-config.ts
+++ b/src/cli/commands/doctor-checks-config.ts
@@ -26,7 +26,7 @@ import {
   memoryDbPath,
 } from '../services/moflo-paths.js';
 import { probeDbIntegrity } from '../services/memory-db-integrity-repair.js';
-import { CLI_CONFIG_CANDIDATES } from '../config/cli-config-store.js';
+import { CLI_CONFIG_CANDIDATES, CLI_CONFIG_YAML_CANDIDATES } from '../config/cli-config-store.js';
 import { findProjectRoot, resolveStateRoot } from '../services/project-root.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import type { HealthCheck } from './doctor-types.js';
@@ -57,14 +57,7 @@ export async function checkConfigFile(): Promise<HealthCheck> {
   }
 
   // YAML configs (existence-checked only — no heavy yaml parser dependency).
-  const yamlPaths = [
-    join('.moflo', 'config.yaml'),
-    join('.moflo', 'config.yml'),
-    'moflo.config.yaml',
-    'claude-flow.config.yaml', // LEGACY-CONFIG: pre-#699 fallback
-  ];
-
-  for (const candidate of yamlPaths) {
+  for (const candidate of CLI_CONFIG_YAML_CANDIDATES) {
     if (existsSync(join(root, candidate))) {
       return { name: 'Config File', status: 'pass', message: `Found: ${candidate}` };
     }

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -58,7 +58,11 @@ export async function fixConfigFile(
     if (!existsSync(cfDir)) mkdirSync(cfDir, { recursive: true });
     await run('npx moflo config init');
     return findCliConfigFile(root) !== null;
-  } catch {
+  } catch (e) {
+    // Leave a crumb rather than a bare `catch {}` — #854 is four versions of
+    // consumer-invisible breakage caused by exactly that shape in the launcher
+    // upgrade flow.
+    output.writeln(output.warning(`  Config File fix failed: ${errorDetail(e)}`));
     return false;
   }
 }

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -31,6 +31,39 @@ async function runFixCommand(cmd: string): Promise<boolean> {
 }
 
 /**
+ * Fix the `Config File` check by creating the project's JSON config.
+ *
+ * The return value is derived from the file being on disk afterwards, NOT from
+ * the exit code of `config init`. That distinction is the whole fix: the
+ * command used to print "Creating claude-flow.config.json..." and exit 0
+ * without a single filesystem call, so `--fix` reported `applied: true` on
+ * every run while the warning it claimed to fix never cleared. An exit code is
+ * a claim; the file is the evidence.
+ *
+ * `deps` is injectable so tests can pin both branches without spawning npx —
+ * in particular the regression case, where the command "succeeds" and leaves
+ * nothing behind.
+ */
+export async function fixConfigFile(
+  deps: { root?: string; run?: (cmd: string) => Promise<boolean> } = {},
+): Promise<boolean> {
+  try {
+    const root = deps.root ?? resolveStateRoot();
+    const run = deps.run ?? runFixCommand;
+    const { findCliConfigFile } = await import('../config/cli-config-store.js');
+
+    if (findCliConfigFile(root)) return true;
+
+    const cfDir = mofloDir(root);
+    if (!existsSync(cfDir)) mkdirSync(cfDir, { recursive: true });
+    await run('npx moflo config init');
+    return findCliConfigFile(root) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Fix Gate Health failures: bin/.claude-helpers gate.cjs drift AND missing
  * settings.json hook wiring. The check has three independent failure modes
  * and the prior fix only handled hook wiring — leaving bin/helper drift
@@ -453,15 +486,7 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
         return runFixCommand('npx moflo memory init --force');
       }
     },
-    'Config File': async () => {
-      try {
-        const cfDir = join(resolveStateRoot(), '.moflo');
-        if (!existsSync(cfDir)) mkdirSync(cfDir, { recursive: true });
-        return runFixCommand('npx moflo config init');
-      } catch {
-        return false;
-      }
-    },
+    'Config File': fixConfigFile,
     // moflo.yaml auto-create. The session-start launcher already runs
     // `ensureMofloYamlExists` (see bin/session-start-launcher.mjs § 3d-yaml-create,
     // #895) but it can miss when the launcher itself was old at upgrade time —

--- a/src/cli/commands/embeddings.ts
+++ b/src/cli/commands/embeddings.ts
@@ -864,11 +864,11 @@ const chunkCommand: Command = {
     // the parser let it through.
     let text: string;
     if (file) {
-      if (!existsSync(file)) {
-        output.printError(`File not found: ${file}`);
-        return { success: false, exitCode: 1 };
-      }
       try {
+        // Read first and let ENOENT report the missing file, rather than
+        // stat-then-read: the existence check was both a second syscall and a
+        // TOCTOU window this catch already covers.
+        //
         // Normalize CRLF → LF: `chunking.ts` splits paragraphs on /\n\n+/,
         // which a Windows-authored file's \r\n\r\n does not match, so the same
         // document would chunk differently depending on the platform it was
@@ -877,7 +877,12 @@ const chunkCommand: Command = {
         // already-stored embeddings.
         text = readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
       } catch (err) {
-        output.printError(`Could not read ${file}: ${(err as Error).message}`);
+        const code = (err as NodeJS.ErrnoException).code;
+        output.printError(
+          code === 'ENOENT'
+            ? `File not found: ${file}`
+            : `Could not read ${file}: ${(err as Error).message}`,
+        );
         return { success: false, exitCode: 1 };
       }
     } else {

--- a/src/cli/commands/embeddings.ts
+++ b/src/cli/commands/embeddings.ts
@@ -13,6 +13,7 @@
  * Created with ❤️ by cielolimitada.com
  */
 
+import { existsSync, readFileSync } from 'node:fs';
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { runEmbeddingsMigrationIfNeeded } from '../services/embeddings-migration.js';
@@ -113,8 +114,8 @@ const searchCommand: Command = {
   options: [
     { name: 'query', short: 'q', type: 'string', description: 'Search query', required: true },
     { name: 'collection', short: 'c', type: 'string', description: 'Namespace to search', default: 'default' },
-    { name: 'limit', short: 'l', type: 'number', description: 'Max results', default: '10' },
-    { name: 'threshold', short: 't', type: 'number', description: 'Similarity threshold (0-1)', default: '0.5' },
+    { name: 'limit', short: 'l', type: 'number', description: 'Max results', default: 10 },
+    { name: 'threshold', short: 't', type: 'number', description: 'Similarity threshold (0-1)', default: 0.5 },
     { name: 'db-path', type: 'string', description: 'Database path', default: DEFAULT_DB_PATH_FLAG },
   ],
   examples: [
@@ -514,8 +515,8 @@ const indexCommand: Command = {
   options: [
     { name: 'action', short: 'a', type: 'string', description: 'Action: build, rebuild, status, optimize', default: 'status' },
     { name: 'collection', short: 'c', type: 'string', description: 'Collection/namespace name' },
-    { name: 'ef-construction', type: 'number', description: 'HNSW ef_construction parameter', default: '200' },
-    { name: 'm', type: 'number', description: 'HNSW M parameter', default: '16' },
+    { name: 'ef-construction', type: 'number', description: 'HNSW ef_construction parameter', default: 200 },
+    { name: 'm', type: 'number', description: 'HNSW M parameter', default: 16 },
   ],
   examples: [
     { command: 'flo embeddings index', description: 'Show index status' },
@@ -661,11 +662,11 @@ export const initCommand: Command = {
   description: 'Initialize embedding subsystem with ONNX model and hyperbolic config',
   options: [
     { name: 'model', short: 'm', type: 'string', description: 'ONNX model ID', default: 'all-MiniLM-L6-v2' },
-    { name: 'hyperbolic', type: 'boolean', description: 'Enable hyperbolic (Poincaré ball) embeddings', default: 'true' },
+    { name: 'hyperbolic', type: 'boolean', description: 'Enable hyperbolic (Poincaré ball) embeddings', default: true },
     { name: 'curvature', short: 'c', type: 'string', description: 'Poincaré ball curvature (use --curvature=-1 for negative)', default: '-1' },
-    { name: 'download', short: 'd', type: 'boolean', description: 'Download model during init', default: 'true' },
+    { name: 'download', short: 'd', type: 'boolean', description: 'Download model during init', default: true },
     { name: 'cache-size', type: 'string', description: 'LRU cache entries', default: '256' },
-    { name: 'force', short: 'f', type: 'boolean', description: 'Overwrite existing configuration', default: 'false' },
+    { name: 'force', short: 'f', type: 'boolean', description: 'Overwrite existing configuration', default: false },
   ],
   examples: [
     { command: 'flo embeddings init', description: 'Initialize with defaults' },
@@ -841,9 +842,13 @@ const chunkCommand: Command = {
   name: 'chunk',
   description: 'Chunk text for embedding with overlap',
   options: [
-    { name: 'text', short: 't', type: 'string', description: 'Text to chunk', required: true },
-    { name: 'max-size', short: 's', type: 'number', description: 'Max chunk size in chars', default: '512' },
-    { name: 'overlap', short: 'o', type: 'number', description: 'Overlap between chunks', default: '50' },
+    // Not `required`: --file is the documented alternative ("instead of
+    // text"), and a parser-level requirement made its own example
+    // (`chunk -f doc.txt`) impossible to run. The action validates that
+    // exactly one source was given.
+    { name: 'text', short: 't', type: 'string', description: 'Text to chunk' },
+    { name: 'max-size', short: 's', type: 'number', description: 'Max chunk size in chars', default: 512 },
+    { name: 'overlap', short: 'o', type: 'number', description: 'Overlap between chunks', default: 50 },
     { name: 'strategy', type: 'string', description: 'Strategy: character, sentence, paragraph, token', default: 'sentence' },
     { name: 'file', short: 'f', type: 'string', description: 'File to chunk (instead of text)' },
   ],
@@ -852,7 +857,38 @@ const chunkCommand: Command = {
     { command: 'flo embeddings chunk -f doc.txt --strategy paragraph', description: 'Chunk file by paragraph' },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const text = ctx.flags.text as string || '';
+    const file = ctx.flags.file as string | undefined;
+
+    // --file was declared, described as "instead of text", and given its own
+    // example — but never read here, so it chunked the empty string even once
+    // the parser let it through.
+    let text: string;
+    if (file) {
+      if (!existsSync(file)) {
+        output.printError(`File not found: ${file}`);
+        return { success: false, exitCode: 1 };
+      }
+      try {
+        // Normalize CRLF → LF: `chunking.ts` splits paragraphs on /\n\n+/,
+        // which a Windows-authored file's \r\n\r\n does not match, so the same
+        // document would chunk differently depending on the platform it was
+        // written on. Normalizing here keeps `--file` platform-independent
+        // without touching the shared splitter, whose boundaries determine
+        // already-stored embeddings.
+        text = readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+      } catch (err) {
+        output.printError(`Could not read ${file}: ${(err as Error).message}`);
+        return { success: false, exitCode: 1 };
+      }
+    } else {
+      text = ctx.flags.text as string || '';
+    }
+
+    if (!text) {
+      output.printError('Nothing to chunk — pass --text or --file');
+      return { success: false, exitCode: 1 };
+    }
+
     const maxSize = parseInt(ctx.flags.maxSize as string || '512', 10);
     const overlap = parseInt(ctx.flags.overlap as string || '50', 10);
     const strategy = ctx.flags.strategy as string || 'sentence';
@@ -882,7 +918,7 @@ const chunkCommand: Command = {
     output.writeln();
     output.writeln(output.dim(`Total: ${result.totalChunks} chunks from ${result.originalLength} chars`));
 
-    return { success: true };
+    return { success: true, data: result };
   },
 };
 
@@ -935,7 +971,7 @@ const hyperbolicCommand: Command = {
   description: 'Hyperbolic embedding operations (Poincaré ball)',
   options: [
     { name: 'action', short: 'a', type: 'string', description: 'Action: convert, distance, centroid', default: 'convert' },
-    { name: 'curvature', short: 'c', type: 'number', description: 'Hyperbolic curvature', default: '-1' },
+    { name: 'curvature', short: 'c', type: 'number', description: 'Hyperbolic curvature', default: -1 },
     { name: 'input', short: 'i', type: 'string', description: 'Input embedding(s) JSON' },
   ],
   examples: [
@@ -1203,7 +1239,7 @@ export const modelsCommand: Command = {
   description: 'List and download embedding models',
   options: [
     { name: 'download', short: 'd', type: 'string', description: 'Model ID to download' },
-    { name: 'list', short: 'l', type: 'boolean', description: 'List available models', default: 'true' },
+    { name: 'list', short: 'l', type: 'boolean', description: 'List available models', default: true },
   ],
   examples: [
     { command: 'flo embeddings models', description: 'List models' },
@@ -1394,8 +1430,8 @@ const warmupCommand: Command = {
   name: 'warmup',
   description: 'Preload embedding model for faster subsequent operations',
   options: [
-    { name: 'background', short: 'b', type: 'boolean', description: 'Run warmup in background daemon', default: 'false' },
-    { name: 'test', short: 't', type: 'boolean', description: 'Run test embedding after warmup', default: 'true' },
+    { name: 'background', short: 'b', type: 'boolean', description: 'Run warmup in background daemon', default: false },
+    { name: 'test', short: 't', type: 'boolean', description: 'Run test embedding after warmup', default: true },
   ],
   examples: [
     { command: 'flo embeddings warmup', description: 'Preload model with test' },
@@ -1481,9 +1517,9 @@ const benchmarkCommand: Command = {
   name: 'benchmark',
   description: 'Run embedding performance benchmarks',
   options: [
-    { name: 'iterations', short: 'n', type: 'number', description: 'Number of iterations', default: '10' },
-    { name: 'batch-size', short: 'b', type: 'number', description: 'Batch size for batch test', default: '5' },
-    { name: 'full', short: 'f', type: 'boolean', description: 'Run full benchmark suite', default: 'false' },
+    { name: 'iterations', short: 'n', type: 'number', description: 'Number of iterations', default: 10 },
+    { name: 'batch-size', short: 'b', type: 'number', description: 'Batch size for batch test', default: 5 },
+    { name: 'full', short: 'f', type: 'boolean', description: 'Run full benchmark suite', default: false },
   ],
   examples: [
     { command: 'flo embeddings benchmark', description: 'Quick benchmark' },
@@ -1640,8 +1676,11 @@ const migrateCommand: Command = {
     'Re-embed existing vectors using the current neural model (runs automatically on session start if needed)',
   options: [
     { name: 'db', short: 'd', type: 'string', description: 'Path to memory DB', default: DEFAULT_DB_PATH_FLAG },
-    { name: 'batch-size', short: 'b', type: 'number', description: 'Batch size', default: '128' },
-    { name: 'verbose', short: 'v', type: 'boolean', description: 'Verbose output', default: 'false' },
+    { name: 'batch-size', short: 'b', type: 'number', description: 'Batch size', default: 128 },
+    // Boolean default, not the string 'false' — this option shadows the global
+    // --verbose, so its default is the one the parser applies, and 'false' is
+    // a truthy string that would turn verbose ON by default.
+    { name: 'verbose', short: 'v', type: 'boolean', description: 'Verbose output', default: false },
   ],
   examples: [
     { command: 'flo embeddings migrate', description: `Migrate ${DEFAULT_DB_PATH_FLAG} to current version` },

--- a/src/cli/commands/guidance.ts
+++ b/src/cli/commands/guidance.ts
@@ -15,7 +15,7 @@ const compileCommand: Command = {
     { name: 'root', short: 'r', type: 'string', description: 'Root guidance file path', default: './CLAUDE.md' },
     { name: 'local', short: 'l', type: 'string', description: 'Local guidance overlay file path' },
     { name: 'output', short: 'o', type: 'string', description: 'Output directory for compiled bundle' },
-    { name: 'json', type: 'boolean', description: 'Output as JSON', default: 'false' },
+    { name: 'json', type: 'boolean', description: 'Output as JSON', default: false },
   ],
   examples: [
     { command: 'flo guidance compile', description: 'Compile default CLAUDE.md' },
@@ -95,9 +95,9 @@ const retrieveCommand: Command = {
     { name: 'task', short: 't', type: 'string', description: 'Task description', required: true },
     { name: 'root', short: 'r', type: 'string', description: 'Root guidance file path', default: './CLAUDE.md' },
     { name: 'local', short: 'l', type: 'string', description: 'Local overlay file path' },
-    { name: 'max-shards', short: 'n', type: 'number', description: 'Maximum number of shards to retrieve', default: '5' },
+    { name: 'max-shards', short: 'n', type: 'number', description: 'Maximum number of shards to retrieve', default: 5 },
     { name: 'intent', short: 'i', type: 'string', description: 'Override detected intent' },
-    { name: 'json', type: 'boolean', description: 'Output as JSON', default: 'false' },
+    { name: 'json', type: 'boolean', description: 'Output as JSON', default: false },
   ],
   examples: [
     { command: 'flo guidance retrieve -t "Fix SQL injection in user search"', description: 'Retrieve guidance for a security task' },
@@ -194,7 +194,7 @@ const gatesCommand: Command = {
     { name: 'command', short: 'c', type: 'string', description: 'Command to evaluate' },
     { name: 'content', type: 'string', description: 'Content to check for secrets' },
     { name: 'tool', short: 't', type: 'string', description: 'Tool name to check against allowlist' },
-    { name: 'json', type: 'boolean', description: 'Output as JSON', default: 'false' },
+    { name: 'json', type: 'boolean', description: 'Output as JSON', default: false },
   ],
   examples: [
     { command: 'flo guidance gates -c "rm -rf /tmp"', description: 'Check if a command is destructive' },
@@ -283,7 +283,7 @@ const statusCommand: Command = {
   name: 'status',
   description: 'Show guidance control plane status and metrics',
   options: [
-    { name: 'json', type: 'boolean', description: 'Output as JSON', default: 'false' },
+    { name: 'json', type: 'boolean', description: 'Output as JSON', default: false },
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const jsonOutput = ctx.flags.json === true;
@@ -343,11 +343,11 @@ const optimizeCommand: Command = {
   options: [
     { name: 'root', short: 'r', type: 'string', description: 'Root guidance file path', default: './CLAUDE.md' },
     { name: 'local', short: 'l', type: 'string', description: 'Local overlay file path' },
-    { name: 'apply', short: 'a', type: 'boolean', description: 'Apply optimizations to the file', default: 'false' },
+    { name: 'apply', short: 'a', type: 'boolean', description: 'Apply optimizations to the file', default: false },
     { name: 'context-size', short: 's', type: 'string', description: 'Target context size: compact, standard, full', default: 'standard' },
-    { name: 'target-score', type: 'number', description: 'Target composite score (0-100)', default: '90' },
-    { name: 'max-iterations', type: 'number', description: 'Maximum optimization iterations', default: '5' },
-    { name: 'json', type: 'boolean', description: 'Output as JSON', default: 'false' },
+    { name: 'target-score', type: 'number', description: 'Target composite score (0-100)', default: 90 },
+    { name: 'max-iterations', type: 'number', description: 'Maximum optimization iterations', default: 5 },
+    { name: 'json', type: 'boolean', description: 'Output as JSON', default: false },
   ],
   examples: [
     { command: 'flo guidance optimize', description: 'Analyze current CLAUDE.md and show suggestions' },
@@ -464,7 +464,7 @@ const abTestCommand: Command = {
     { name: 'config-b', short: 'b', type: 'string', description: 'Path to Config B (candidate CLAUDE.md)', default: './CLAUDE.md' },
     { name: 'tasks', short: 't', type: 'string', description: 'Path to custom task JSON file (array of ABTask objects)' },
     { name: 'work-dir', short: 'w', type: 'string', description: 'Working directory for test execution' },
-    { name: 'json', type: 'boolean', description: 'Output as JSON', default: 'false' },
+    { name: 'json', type: 'boolean', description: 'Output as JSON', default: false },
   ],
   examples: [
     { command: 'flo guidance ab-test', description: 'Run default A/B test (no guidance vs ./CLAUDE.md)' },

--- a/src/cli/commands/hooks.ts
+++ b/src/cli/commands/hooks.ts
@@ -3639,7 +3639,7 @@ const tokenOptimizeCommand: Command = {
   name: 'token-optimize',
   description: 'Anti-drift swarm config for efficient multi-agent runs (30-50% savings)',
   options: [
-    { name: 'agents', short: 'A', type: 'number', description: 'Agent count for optimal config', default: '6' },
+    { name: 'agents', short: 'A', type: 'number', description: 'Agent count for optimal config', default: 6 },
     { name: 'report', short: 'r', type: 'boolean', description: 'Generate optimization report' },
     { name: 'stats', short: 's', type: 'boolean', description: 'Show token savings statistics' },
   ],

--- a/src/cli/commands/neural.ts
+++ b/src/cli/commands/neural.ts
@@ -18,18 +18,18 @@ const trainCommand: Command = {
   description: 'Train neural patterns with WASM SIMD acceleration (MicroLoRA + Flash Attention)',
   options: [
     { name: 'pattern', short: 'p', type: 'string', description: 'Pattern type: coordination, optimization, prediction, security, testing', default: 'coordination' },
-    { name: 'epochs', short: 'e', type: 'number', description: 'Number of training epochs', default: '50' },
+    { name: 'epochs', short: 'e', type: 'number', description: 'Number of training epochs', default: 50 },
     { name: 'data', short: 'd', type: 'string', description: 'Training data file or inline JSON' },
     { name: 'model', short: 'm', type: 'string', description: 'Model ID to train' },
-    { name: 'learning-rate', short: 'l', type: 'number', description: 'Learning rate', default: '0.01' },
-    { name: 'batch-size', short: 'b', type: 'number', description: 'Batch size', default: '32' },
-    { name: 'dim', type: 'number', description: 'Embedding dimension (max 256)', default: '256' },
-    { name: 'wasm', short: 'w', type: 'boolean', description: 'Use MoVector WASM acceleration', default: 'true' },
-    { name: 'flash', type: 'boolean', description: 'Enable Flash Attention (memory-efficient attention)', default: 'true' },
-    { name: 'moe', type: 'boolean', description: 'Enable Mixture of Experts routing', default: 'false' },
-    { name: 'hyperbolic', type: 'boolean', description: 'Enable hyperbolic attention for hierarchical patterns', default: 'false' },
-    { name: 'contrastive', type: 'boolean', description: 'Use contrastive learning (InfoNCE)', default: 'true' },
-    { name: 'curriculum', type: 'boolean', description: 'Enable curriculum learning', default: 'false' },
+    { name: 'learning-rate', short: 'l', type: 'number', description: 'Learning rate', default: 0.01 },
+    { name: 'batch-size', short: 'b', type: 'number', description: 'Batch size', default: 32 },
+    { name: 'dim', type: 'number', description: 'Embedding dimension (max 256)', default: 256 },
+    { name: 'wasm', short: 'w', type: 'boolean', description: 'Use MoVector WASM acceleration', default: true },
+    { name: 'flash', type: 'boolean', description: 'Enable Flash Attention (memory-efficient attention)', default: true },
+    { name: 'moe', type: 'boolean', description: 'Enable Mixture of Experts routing', default: false },
+    { name: 'hyperbolic', type: 'boolean', description: 'Enable hyperbolic attention for hierarchical patterns', default: false },
+    { name: 'contrastive', type: 'boolean', description: 'Use contrastive learning (InfoNCE)', default: true },
+    { name: 'curriculum', type: 'boolean', description: 'Enable curriculum learning', default: false },
   ],
   examples: [
     { command: 'flo neural train -p coordination -e 100', description: 'Train coordination patterns' },
@@ -560,7 +560,7 @@ const patternsCommand: Command = {
   options: [
     { name: 'action', short: 'a', type: 'string', description: 'Action: analyze, learn, predict, list', default: 'list' },
     { name: 'query', short: 'q', type: 'string', description: 'Pattern query for search' },
-    { name: 'limit', short: 'l', type: 'number', description: 'Max patterns to return', default: '10' },
+    { name: 'limit', short: 'l', type: 'number', description: 'Max patterns to return', default: 10 },
   ],
   examples: [
     { command: 'flo neural patterns --action list', description: 'List all patterns' },
@@ -667,7 +667,7 @@ const predictCommand: Command = {
   description: 'Make AI predictions using trained models',
   options: [
     { name: 'input', short: 'i', type: 'string', description: 'Input text to predict routing for', required: true },
-    { name: 'k', short: 'k', type: 'number', description: 'Number of top predictions', default: '5' },
+    { name: 'k', short: 'k', type: 'number', description: 'Number of top predictions', default: 5 },
     { name: 'format', short: 'f', type: 'string', description: 'Output format: json, table', default: 'table' },
   ],
   examples: [
@@ -932,8 +932,8 @@ const exportCommand: Command = {
     { name: 'model', short: 'm', type: 'string', description: 'Model ID or category to export' },
     { name: 'output', short: 'o', type: 'string', description: 'Output file path (optional)' },
     { name: 'ipfs', short: 'i', type: 'boolean', description: 'Pin to IPFS (requires Pinata credentials)' },
-    { name: 'sign', short: 's', type: 'boolean', description: 'Sign with Ed25519 key', default: 'true' },
-    { name: 'strip-pii', type: 'boolean', description: 'Strip potential PII from export', default: 'true' },
+    { name: 'sign', short: 's', type: 'boolean', description: 'Sign with Ed25519 key', default: true },
+    { name: 'strip-pii', type: 'boolean', description: 'Strip potential PII from export', default: true },
     { name: 'name', short: 'n', type: 'string', description: 'Custom name for exported model' },
   ],
   examples: [
@@ -1302,8 +1302,8 @@ const importCommand: Command = {
   options: [
     { name: 'cid', short: 'c', type: 'string', description: 'IPFS CID to import from' },
     { name: 'file', short: 'f', type: 'string', description: 'Local file to import' },
-    { name: 'verify', short: 'v', type: 'boolean', description: 'Verify Ed25519 signature', default: 'true' },
-    { name: 'merge', type: 'boolean', description: 'Merge with existing patterns (vs replace)', default: 'true' },
+    { name: 'verify', short: 'v', type: 'boolean', description: 'Verify Ed25519 signature', default: true },
+    { name: 'merge', type: 'boolean', description: 'Merge with existing patterns (vs replace)', default: true },
     { name: 'category', type: 'string', description: 'Only import patterns from specific category' },
   ],
   examples: [
@@ -1525,9 +1525,9 @@ const benchmarkCommand: Command = {
   name: 'benchmark',
   description: 'Benchmark MoVector WASM training performance',
   options: [
-    { name: 'dim', short: 'd', type: 'number', description: 'Embedding dimension (max 256)', default: '256' },
-    { name: 'iterations', short: 'i', type: 'number', description: 'Number of iterations', default: '1000' },
-    { name: 'keys', short: 'k', type: 'number', description: 'Number of keys for attention', default: '100' },
+    { name: 'dim', short: 'd', type: 'number', description: 'Embedding dimension (max 256)', default: 256 },
+    { name: 'iterations', short: 'i', type: 'number', description: 'Number of iterations', default: 1000 },
+    { name: 'keys', short: 'k', type: 'number', description: 'Number of keys for attention', default: 100 },
   ],
   examples: [
     { command: 'flo neural benchmark', description: 'Run default benchmark' },

--- a/src/cli/commands/performance.ts
+++ b/src/cli/commands/performance.ts
@@ -14,8 +14,8 @@ const benchmarkCommand: Command = {
   description: 'Run performance benchmarks',
   options: [
     { name: 'suite', short: 's', type: 'string', description: 'Benchmark suite: all, wasm, neural, memory, search', default: 'all' },
-    { name: 'iterations', short: 'i', type: 'number', description: 'Number of iterations', default: '100' },
-    { name: 'warmup', short: 'w', type: 'number', description: 'Warmup iterations', default: '10' },
+    { name: 'iterations', short: 'i', type: 'number', description: 'Number of iterations', default: 100 },
+    { name: 'warmup', short: 'w', type: 'number', description: 'Warmup iterations', default: 10 },
     { name: 'output', short: 'o', type: 'string', description: 'Output format: text, json, csv', default: 'text' },
   ],
   examples: [
@@ -252,7 +252,7 @@ const profileCommand: Command = {
   description: 'Profile application performance',
   options: [
     { name: 'type', short: 't', type: 'string', description: 'Profile type: cpu, memory, io, all', default: 'all' },
-    { name: 'duration', short: 'd', type: 'number', description: 'Duration in seconds', default: '30' },
+    { name: 'duration', short: 'd', type: 'number', description: 'Duration in seconds', default: 30 },
     { name: 'output', short: 'o', type: 'string', description: 'Output file for profile data' },
   ],
   examples: [

--- a/src/cli/commands/security.ts
+++ b/src/cli/commands/security.ts
@@ -340,7 +340,7 @@ const auditCommand: Command = {
   description: 'Security audit logging and compliance',
   options: [
     { name: 'action', short: 'a', type: 'string', description: 'Action: log, list, export, clear', default: 'list' },
-    { name: 'limit', short: 'l', type: 'number', description: 'Number of entries to show', default: '20' },
+    { name: 'limit', short: 'l', type: 'number', description: 'Number of entries to show', default: 20 },
     { name: 'filter', short: 'f', type: 'string', description: 'Filter by event type' },
   ],
   examples: [
@@ -430,7 +430,7 @@ const defendCommand: Command = {
     { name: 'input', short: 'i', type: 'string', description: 'Input text to scan for threats' },
     { name: 'file', short: 'f', type: 'string', description: 'File to scan for threats' },
     { name: 'quick', short: 'Q', type: 'boolean', description: 'Quick scan (faster, less detailed)' },
-    { name: 'learn', short: 'l', type: 'boolean', description: 'Enable learning mode', default: 'true' },
+    { name: 'learn', short: 'l', type: 'boolean', description: 'Enable learning mode', default: true },
     { name: 'stats', short: 's', type: 'boolean', description: 'Show detection statistics' },
     { name: 'output', short: 'o', type: 'string', description: 'Output format: text, json', default: 'text' },
   ],

--- a/src/cli/config/cli-config-store.ts
+++ b/src/cli/config/cli-config-store.ts
@@ -1,0 +1,327 @@
+/**
+ * CLI JSON config store — the file behind `flo config init|get|set|reset|
+ * export|import|providers`, and the file the healer's `Config File` check
+ * looks for.
+ *
+ * Two neighbouring config surfaces exist; this module is deliberately none of
+ * them:
+ *   - `src/cli/config/moflo-config.ts` owns **moflo.yaml** (gates, sdd,
+ *     daemon, memory backend). `flo config show|generate` operate on that.
+ *   - `src/cli/shared/core/config/loader.ts` owns the `SystemConfig` schema
+ *     loaded from bare `moflo.config.json`-style files in cwd / `~/.moflo`.
+ *
+ * This module owns the project-local `.moflo/config.json` — the first entry in
+ * the doctor's `Config File` candidate list and the path its auto-fix creates.
+ *
+ * Before this module existed the whole `flo config` family was display-only:
+ * `init` printed "Creating claude-flow.config.json..." and returned
+ * `success: true` without a single filesystem call, so `flo doctor --fix`
+ * reported the `Config File` warning as fixed on every run while the warning
+ * never cleared. Same defect class as the synthetic MCP responses labelled at
+ * the call site in #1324/#1325: a success report for work that never happened.
+ *
+ * @module moflo/cli/config/cli-config-store
+ */
+
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
+import { mofloDir } from '../services/moflo-paths.js';
+
+/** A configured AI provider entry. */
+export interface CliConfigProvider {
+  name: string;
+  model?: string;
+  priority: number;
+  enabled: boolean;
+}
+
+/** Shape of `.moflo/config.json`. */
+export interface CliConfig {
+  version: string;
+  v3Mode: boolean;
+  sparc: boolean;
+  agents: {
+    defaultType: string;
+    maxConcurrent: number;
+    autoSpawn: boolean;
+    timeout: number;
+  };
+  swarm: {
+    topology: string;
+    maxAgents: number;
+    autoScale: boolean;
+    coordinationStrategy: string;
+  };
+  memory: {
+    backend: string;
+    path: string;
+    cacheSize: number;
+    enableHNSW: boolean;
+  };
+  mcp: {
+    transport: string;
+    autoStart: boolean;
+    tools: string;
+  };
+  providers: CliConfigProvider[];
+}
+
+/**
+ * Candidate filenames, canonical first. Mirrors the list in
+ * `doctor-checks-config.ts:checkConfigFile` so the healer's check and this
+ * store never disagree about whether a config exists — the mismatch that let
+ * the old auto-fix "succeed" against a file the check couldn't see.
+ *
+ * `claude-flow.*` entries are LEGACY-CONFIG: pre-#699 names, still read so
+ * consumers upgrading from older moflo builds keep their existing file.
+ */
+export const CLI_CONFIG_CANDIDATES = [
+  join('.moflo', 'config.json'),
+  'moflo.config.json',
+  'claude-flow.config.json', // LEGACY-CONFIG: pre-#699 fallback
+  '.claude-flow.json',       // LEGACY-CONFIG: pre-#699 fallback
+] as const;
+
+/** Absolute path of the canonical config file for a project root. */
+export function cliConfigPath(projectRoot: string): string {
+  return join(mofloDir(projectRoot), 'config.json');
+}
+
+/**
+ * Absolute path of the config file that actually exists, canonical first, or
+ * `null` when the project has none.
+ */
+export function findCliConfigFile(projectRoot: string): string | null {
+  for (const candidate of CLI_CONFIG_CANDIDATES) {
+    const path = join(projectRoot, candidate);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
+/** Default configuration. Values match what `flo config` reported pre-fix. */
+export function defaultCliConfig(opts: { v3?: boolean; sparc?: boolean } = {}): CliConfig {
+  return {
+    version: '3.0.0',
+    v3Mode: opts.v3 ?? true,
+    sparc: opts.sparc ?? false,
+    agents: {
+      defaultType: 'coder',
+      maxConcurrent: 15,
+      autoSpawn: true,
+      timeout: 300,
+    },
+    swarm: {
+      topology: 'hybrid',
+      maxAgents: 15,
+      autoScale: true,
+      coordinationStrategy: 'consensus',
+    },
+    memory: {
+      backend: 'hybrid',
+      path: './data/memory',
+      cacheSize: 256,
+      enableHNSW: true,
+    },
+    mcp: {
+      transport: 'stdio',
+      autoStart: true,
+      tools: 'all',
+    },
+    providers: [
+      { name: 'anthropic', model: 'claude-sonnet-5', priority: 1, enabled: true },
+      { name: 'openrouter', model: 'claude-sonnet-5', priority: 2, enabled: false },
+      { name: 'ollama', model: 'llama3.2', priority: 3, enabled: false },
+      { name: 'gemini', model: 'gemini-2.0-flash', priority: 4, enabled: false },
+    ],
+  };
+}
+
+/** Thrown when a config file exists but cannot be parsed. */
+export class CliConfigParseError extends Error {
+  constructor(public readonly path: string, cause: unknown) {
+    super(`Invalid JSON in ${path}: ${cause instanceof Error ? cause.message : String(cause)}`);
+    this.name = 'CliConfigParseError';
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Deep-merge `patch` over `base`. Arrays are replaced wholesale, not merged. */
+function deepMerge<T>(base: T, patch: unknown): T {
+  if (!isPlainObject(patch)) return base;
+  if (!isPlainObject(base)) return patch as T;
+
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(patch)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+    const current = result[key];
+    result[key] = isPlainObject(value) && isPlainObject(current) ? deepMerge(current, value) : value;
+  }
+  return result as T;
+}
+
+/**
+ * Load the project's config, merged over defaults. `path` is `null` when no
+ * file exists — callers get usable defaults either way, and can tell the
+ * difference.
+ *
+ * @throws {CliConfigParseError} when a config file exists but is not valid JSON.
+ */
+export function loadCliConfig(projectRoot: string): { config: CliConfig; path: string | null } {
+  const path = findCliConfigFile(projectRoot);
+  if (!path) return { config: defaultCliConfig(), path: null };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    throw new CliConfigParseError(path, err);
+  }
+  return { config: deepMerge(defaultCliConfig(), parsed), path };
+}
+
+/**
+ * Write `config` and return the path written. Writes to the existing file when
+ * there is one (so a consumer's root-level `moflo.config.json` keeps being the
+ * file they edit), otherwise creates the canonical `.moflo/config.json`.
+ */
+export function saveCliConfig(
+  projectRoot: string,
+  config: CliConfig,
+  opts: { path?: string } = {},
+): string {
+  const target = opts.path ?? findCliConfigFile(projectRoot) ?? cliConfigPath(projectRoot);
+  writeJsonFile(target, config);
+  return target;
+}
+
+/** Write `content` to `path` atomically, creating parent dirs as needed. */
+export function writeTextFile(path: string, content: string): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  atomicWriteFileSync(path, content);
+}
+
+/** Serialize `value` as pretty JSON to `path`, creating parent dirs. */
+export function writeJsonFile(path: string, value: unknown): void {
+  writeTextFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/** Split a dot-notation key, rejecting prototype-polluting segments. */
+function splitKey(key: string): string[] | null {
+  const segments = key.split('.').filter((s) => s.length > 0);
+  if (segments.length === 0) return null;
+  if (segments.some((s) => s === '__proto__' || s === 'constructor' || s === 'prototype')) return null;
+  return segments;
+}
+
+/**
+ * Read a dot-notation key (`swarm.topology`, `providers.0.enabled`).
+ * `found: false` for keys the config does not define.
+ */
+export function getConfigValue(config: CliConfig, key: string): { found: boolean; value?: unknown } {
+  const segments = splitKey(key);
+  if (!segments) return { found: false };
+
+  let current: unknown = config;
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object') return { found: false };
+    if (Array.isArray(current)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= current.length) return { found: false };
+      current = current[index];
+    } else {
+      if (!Object.prototype.hasOwnProperty.call(current, segment)) return { found: false };
+      current = (current as Record<string, unknown>)[segment];
+    }
+  }
+  return { found: true, value: current };
+}
+
+/**
+ * Coerce a CLI string to the type of the value already at that key, so
+ * `flo config set swarm.maxAgents 20` stores the number 20, not "20".
+ */
+function coerceValue(raw: string, current: unknown): { ok: true; value: unknown } | { ok: false; error: string } {
+  if (typeof current === 'number') {
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return { ok: false, error: `expected a number, got "${raw}"` };
+    return { ok: true, value: parsed };
+  }
+  if (typeof current === 'boolean') {
+    if (/^(true|1|yes|on)$/i.test(raw)) return { ok: true, value: true };
+    if (/^(false|0|no|off)$/i.test(raw)) return { ok: true, value: false };
+    return { ok: false, error: `expected a boolean, got "${raw}"` };
+  }
+  if (typeof current === 'object' && current !== null) {
+    return { ok: false, error: 'is a section, not a value — set one of its keys instead' };
+  }
+  return { ok: true, value: raw };
+}
+
+/**
+ * Set a dot-notation key in place. Rejects keys the config does not already
+ * define — a typo should fail loudly, not silently create a key nothing reads.
+ */
+export function setConfigValue(
+  config: CliConfig,
+  key: string,
+  raw: string,
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  const segments = splitKey(key);
+  if (!segments) return { ok: false, error: `invalid key: "${key}"` };
+
+  const existing = getConfigValue(config, key);
+  if (!existing.found) return { ok: false, error: `unknown key: ${key}` };
+
+  const coerced = coerceValue(raw, existing.value);
+  if (!coerced.ok) return coerced;
+
+  const parentSegments = segments.slice(0, -1);
+  const leaf = segments[segments.length - 1];
+  const parent = parentSegments.length === 0
+    ? { found: true, value: config as unknown }
+    : getConfigValue(config, parentSegments.join('.'));
+  if (!parent.found || parent.value === null || typeof parent.value !== 'object') {
+    return { ok: false, error: `unknown key: ${key}` };
+  }
+
+  if (Array.isArray(parent.value)) {
+    (parent.value as unknown[])[Number(leaf)] = coerced.value;
+  } else {
+    (parent.value as Record<string, unknown>)[leaf] = coerced.value;
+  }
+  return { ok: true, value: coerced.value };
+}
+
+/** Flatten to dotted leaf keys for tabular display. */
+export function flattenConfig(value: unknown, prefix = ''): Record<string, unknown> {
+  const flat: Record<string, unknown> = {};
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => Object.assign(flat, flattenConfig(item, `${prefix}${index}.`)));
+    return flat;
+  }
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      Object.assign(flat, flattenConfig(child, `${prefix}${key}.`));
+    }
+    return flat;
+  }
+  flat[prefix.replace(/\.$/, '')] = value;
+  return flat;
+}
+
+/** Config sections `flo config reset --section` accepts. */
+export const RESETTABLE_SECTIONS = ['agents', 'swarm', 'memory', 'mcp', 'providers', 'all'] as const;
+export type ResettableSection = (typeof RESETTABLE_SECTIONS)[number];
+
+/** Return `config` with `section` (or everything) restored to defaults. */
+export function resetSection(config: CliConfig, section: ResettableSection): CliConfig {
+  const defaults = defaultCliConfig({ v3: config.v3Mode, sparc: config.sparc });
+  if (section === 'all') return defaults;
+  return { ...config, [section]: defaults[section] } as CliConfig;
+}

--- a/src/cli/config/cli-config-store.ts
+++ b/src/cli/config/cli-config-store.ts
@@ -68,9 +68,9 @@ export interface CliConfig {
 }
 
 /**
- * Candidate filenames, canonical first. Mirrors the list in
- * `doctor-checks-config.ts:checkConfigFile` so the healer's check and this
- * store never disagree about whether a config exists — the mismatch that let
+ * Candidate filenames, canonical first. `doctor-checks-config.ts:checkConfigFile`
+ * imports this list rather than keeping its own, so the healer's check and this
+ * store cannot disagree about whether a config exists — the mismatch that let
  * the old auto-fix "succeed" against a file the check couldn't see.
  *
  * `claude-flow.*` entries are LEGACY-CONFIG: pre-#699 names, still read so
@@ -81,6 +81,17 @@ export const CLI_CONFIG_CANDIDATES = [
   'moflo.config.json',
   'claude-flow.config.json', // LEGACY-CONFIG: pre-#699 fallback
   '.claude-flow.json',       // LEGACY-CONFIG: pre-#699 fallback
+] as const;
+
+/**
+ * YAML config filenames. Existence-checked only — no yaml parse — and shared
+ * with the doctor for the same anti-drift reason as the JSON list above.
+ */
+export const CLI_CONFIG_YAML_CANDIDATES = [
+  join('.moflo', 'config.yaml'),
+  join('.moflo', 'config.yml'),
+  'moflo.config.yaml',
+  'claude-flow.config.yaml', // LEGACY-CONFIG: pre-#699 fallback
 ] as const;
 
 /** Absolute path of the canonical config file for a project root. */
@@ -181,7 +192,28 @@ export function loadCliConfig(projectRoot: string): { config: CliConfig; path: s
   } catch (err) {
     throw new CliConfigParseError(path, err);
   }
-  return { config: deepMerge(defaultCliConfig(), parsed), path };
+  return { config: coerceShape(deepMerge(defaultCliConfig(), parsed)), path };
+}
+
+/**
+ * Restore any section whose type the file contradicts. `deepMerge` is
+ * structural, not validating, so a hand-edited `"providers": "x"` would
+ * survive as a `CliConfig` that lies about its own type and throws the first
+ * time something calls `.find` on it. Falling back to the default for just the
+ * malformed section keeps the rest of the user's file intact.
+ */
+function coerceShape(config: CliConfig): CliConfig {
+  const defaults = defaultCliConfig();
+  const repaired = { ...config };
+
+  if (!Array.isArray(repaired.providers)) repaired.providers = defaults.providers;
+
+  for (const section of ['agents', 'swarm', 'memory', 'mcp'] as const) {
+    if (!isPlainObject(repaired[section])) {
+      (repaired as Record<string, unknown>)[section] = defaults[section];
+    }
+  }
+  return repaired;
 }
 
 /**
@@ -201,8 +233,8 @@ export function saveCliConfig(
 
 /** Write `content` to `path` atomically, creating parent dirs as needed. */
 export function writeTextFile(path: string, content: string): void {
-  const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  // recursive mkdir is already idempotent — no existence check needed.
+  mkdirSync(dirname(path), { recursive: true });
   atomicWriteFileSync(path, content);
 }
 
@@ -211,10 +243,15 @@ export function writeJsonFile(path: string, value: unknown): void {
   writeTextFile(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-/** Split a dot-notation key, rejecting prototype-polluting segments. */
+/**
+ * Split a dot-notation key, rejecting prototype-polluting segments and empty
+ * ones. Empty segments are rejected rather than filtered out: silently
+ * accepting `swarm..topology` contradicts the loud-failure contract that
+ * `setConfigValue` relies on to catch typos.
+ */
 function splitKey(key: string): string[] | null {
-  const segments = key.split('.').filter((s) => s.length > 0);
-  if (segments.length === 0) return null;
+  const segments = key.split('.');
+  if (segments.length === 0 || segments.some((s) => s.length === 0)) return null;
   if (segments.some((s) => s === '__proto__' || s === 'constructor' || s === 'prototype')) return null;
   return segments;
 }
@@ -298,20 +335,36 @@ export function setConfigValue(
   return { ok: true, value: coerced.value };
 }
 
-/** Flatten to dotted leaf keys for tabular display. */
+/**
+ * Flatten to dotted leaf keys for tabular display. An EMPTY object or array is
+ * itself a leaf — recursing over zero entries would otherwise drop the key
+ * entirely, so `providers: []` would vanish from `flo config get` and read as
+ * "not configured" rather than "configured empty".
+ */
 export function flattenConfig(value: unknown, prefix = ''): Record<string, unknown> {
   const flat: Record<string, unknown> = {};
+  const key = prefix.replace(/\.$/, '');
+
   if (Array.isArray(value)) {
+    if (value.length === 0) {
+      flat[key] = '[]';
+      return flat;
+    }
     value.forEach((item, index) => Object.assign(flat, flattenConfig(item, `${prefix}${index}.`)));
     return flat;
   }
   if (isPlainObject(value)) {
-    for (const [key, child] of Object.entries(value)) {
-      Object.assign(flat, flattenConfig(child, `${prefix}${key}.`));
+    const entries = Object.entries(value);
+    if (entries.length === 0) {
+      flat[key] = '{}';
+      return flat;
+    }
+    for (const [childKey, child] of entries) {
+      Object.assign(flat, flattenConfig(child, `${prefix}${childKey}.`));
     }
     return flat;
   }
-  flat[prefix.replace(/\.$/, '')] = value;
+  flat[key] = value;
   return flat;
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -123,8 +123,48 @@ export class CLI {
       let parseResult = this.parser.parse(args);
       let { command: commandPath, flags, positional } = parseResult;
 
+      // Handle lazy-loaded commands that weren't recognized by the parser.
+      // If commandPath is empty but positional has a command name, check if
+      // it's lazy-loadable.
+      if (commandPath.length === 0 && positional.length > 0 && !positional[0].startsWith('-')) {
+        const potentialCommand = positional[0];
+        if (hasCommand(potentialCommand)) {
+          // This is a lazy-loaded command, treat it as the command
+          commandPath.push(potentialCommand);
+          positional.shift();
+        }
+      }
+
+      // Resolve the command BEFORE the global-flag handling below, so those
+      // checks see flags parsed against the command's own option tree.
+      // The first parse happens without knowledge of a lazily-loaded command's
+      // options, so `plugins install pkg --version 1.2.3` parsed `--version`
+      // under the GLOBAL boolean rule, came out as `version: true`, and hit the
+      // version handler below — printing "flo v4.12.4-rc.1" and returning
+      // without installing anything. Re-parsing here makes flags authoritative.
+      let command = commandPath[0]
+        ? this.parser.getCommand(commandPath[0]) || getCommand(commandPath[0])
+        : undefined;
+
+      if (!command && commandPath[0] && hasCommand(commandPath[0])) {
+        command = await getCommandAsync(commandPath[0]);
+        if (command) {
+          // Registering the newly-loaded command also restores scoped
+          // short-flag aliases for its nested subcommand options, which the
+          // first parse could not apply.
+          this.parser.registerCommand(command);
+          parseResult = this.parser.parse(args);
+          ({ command: commandPath, flags, positional } = parseResult);
+        }
+      }
+
       // Handle global flags
-      if (flags.version || flags.V) {
+      // Strict `=== true`: the global `--version` is a boolean, so a genuine
+      // global usage always yields exactly `true`. Commands that redefine
+      // `--version` as a value-taking option (plugins install/upgrade,
+      // deployment deploy/rollback) yield a string, and those must NOT be
+      // hijacked into printing the moflo version and returning.
+      if (flags.version === true || flags.V === true) {
         this.showVersion();
         return;
       }
@@ -159,17 +199,6 @@ export class CLI {
         this.maybeAutoStartDaemon().catch(() => {/* silent */});
       }
 
-      // Handle lazy-loaded commands that weren't recognized by the parser
-      // If commandPath is empty but positional has a command name, check if it's lazy-loadable
-      if (commandPath.length === 0 && positional.length > 0 && !positional[0].startsWith('-')) {
-        const potentialCommand = positional[0];
-        if (hasCommand(potentialCommand)) {
-          // This is a lazy-loaded command, treat it as the command
-          commandPath.push(potentialCommand);
-          positional.shift();
-        }
-      }
-
       // No command - show help or suggest correction
       if (commandPath.length === 0 || flags.help || flags.h) {
         if (commandPath.length > 0) {
@@ -189,27 +218,9 @@ export class CLI {
         return;
       }
 
-      // Find and execute command
+      // Find and execute command. Resolution + any lazy load already happened
+      // above, before global-flag handling — see the note there.
       const commandName = commandPath[0];
-      // First check the parser's registry (for dynamically registered commands)
-      // Then fall back to the static registry, then try lazy loading
-      let command = this.parser.getCommand(commandName) || getCommand(commandName);
-
-      // If not found in sync registry, try lazy loading
-      if (!command && hasCommand(commandName)) {
-        command = await getCommandAsync(commandName);
-        if (command) {
-          // The first parse happened without knowledge of this command's
-          // subcommand tree, so scoped short-flag aliases for any nested
-          // subcommand options weren't applied — and a globally-registered
-          // command's `-x` would have hijacked the value. Register the
-          // newly-loaded command and re-parse so flags reflect the leaf
-          // command's options.
-          this.parser.registerCommand(command);
-          parseResult = this.parser.parse(args);
-          ({ command: commandPath, flags, positional } = parseResult);
-        }
-      }
 
       if (!command) {
         this.output.printError(`Unknown command: ${commandName}`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,12 +158,12 @@ export class CLI {
         }
       }
 
-      // Handle global flags
       // Strict `=== true`: the global `--version` is a boolean, so a genuine
       // global usage always yields exactly `true`. Commands that redefine
       // `--version` as a value-taking option (plugins install/upgrade,
-      // deployment deploy/rollback) yield a string, and those must NOT be
-      // hijacked into printing the moflo version and returning.
+      // deployment deploy/rollback) yield a string — or '' when the value is
+      // omitted — and those must NOT be hijacked into printing the moflo
+      // version and returning.
       if (flags.version === true || flags.V === true) {
         this.showVersion();
         return;

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -367,9 +367,6 @@ export class CommandParser {
   }
 
   /**
-   * Get boolean flags scoped to a specific command/subcommand.
-   */
-  /**
    * Names declared as value-taking (non-boolean) by the resolved command or a
    * global, command winning. The mirror of `getScopedBooleanFlags`: that set
    * says "takes no value", this one says "REQUIRES one".
@@ -384,6 +381,9 @@ export class CommandParser {
     return flags;
   }
 
+  /**
+   * Get boolean flags scoped to a specific command/subcommand.
+   */
   private getScopedBooleanFlags(resolvedCmd?: Command): Set<string> {
     const flags = this.getBooleanFlags();
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -204,8 +204,9 @@ export class CommandParser {
       i++;
     }
 
-    // Apply defaults
-    this.applyDefaults(result.flags);
+    // Apply defaults. The resolved leaf command is passed so its own option
+    // defaults win over an identically-named global — see applyDefaults.
+    this.applyDefaults(result.flags, deepestCmd);
 
     return result;
   }
@@ -361,8 +362,19 @@ export class CommandParser {
 
     if (resolvedCmd?.options) {
       for (const opt of resolvedCmd.options) {
+        const key = this.normalizeKey(opt.name);
         if (opt.type === 'boolean') {
-          flags.add(this.normalizeKey(opt.name));
+          flags.add(key);
+        } else {
+          // A command that redefines a global BOOLEAN as a value-taking option
+          // must also un-register it as boolean — otherwise the parser eats the
+          // flag and drops its value into positionals. `plugins install pkg
+          // --version 1.2.3` parsed as `version: true` + a stray '1.2.3'
+          // positional, which then tripped the global `--version` handler: it
+          // printed "flo v4.12.4-rc.1" and exited without installing anything.
+          // Same for `plugins upgrade` and `deployment deploy|rollback`.
+          // Mirrors buildScopedAliases, where the command already wins.
+          flags.delete(key);
         }
       }
     }
@@ -411,10 +423,31 @@ export class CommandParser {
     return flags;
   }
 
-  private applyDefaults(flags: ParsedFlags): void {
-    // Apply global option defaults
+  private applyDefaults(flags: ParsedFlags, command?: Command): void {
+    // Only options that SHADOW a global participate here. This is deliberately
+    // not a general "apply every command default" pass: 455 command options
+    // declare defaults the parser has never applied, and 28 of those give a
+    // boolean the truthy STRING 'false' — switching them all on would flip
+    // flags like --force and --full to ON by default across the whole CLI.
+    // The bug being fixed is narrower: a global's default was injected over a
+    // command's own declaration. `flo config export` declares `--format`
+    // defaulting to 'json'; the global's 'text' landed instead and then failed
+    // the command's own `choices`, so the command errored with no flag at all.
+    const shadowed = new Set<string>();
+    for (const opt of command?.options ?? []) {
+      const key = this.normalizeKey(opt.name);
+      if (!this.globalOptions.some(g => this.normalizeKey(g.name) === key)) continue;
+      shadowed.add(key);
+      if (flags[key] === undefined && opt.default !== undefined) {
+        flags[key] = opt.default as string | boolean | number | string[];
+      }
+    }
+
+    // Apply global option defaults, except where the command shadows them —
+    // there the command's declaration (or absence of one) is authoritative.
     for (const opt of this.globalOptions) {
       const key = this.normalizeKey(opt.name);
+      if (shadowed.has(key)) continue;
       if (flags[key] === undefined && opt.default !== undefined) {
         flags[key] = opt.default as string | boolean | number | string[];
       }
@@ -433,11 +466,19 @@ export class CommandParser {
 
   validateFlags(flags: ParsedFlags, command?: Command): string[] {
     const errors: string[] = [];
-    const allOptions = [...this.globalOptions];
 
-    if (command?.options) {
-      allOptions.push(...command.options);
+    // A command option SHADOWS a global of the same name instead of stacking
+    // with it. Stacking made every collision unsatisfiable: `--format yaml` on
+    // `flo config export` had to pass BOTH the command's ['json','yaml'] and
+    // the global's ['text','json','table'], so the flag was rejected no matter
+    // what the user typed. Same for `flo memory export --format csv`. 22 such
+    // collisions exist across 18 command files (format, verbose, quiet,
+    // version, config, help) — the specific declaration is the intended one.
+    const byName = new Map<string, CommandOption>();
+    for (const opt of [...this.globalOptions, ...(command?.options ?? [])]) {
+      byName.set(this.normalizeKey(opt.name), opt);
     }
+    const allOptions = [...byName.values()];
 
     // Check required flags
     for (const opt of allOptions) {

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -146,6 +146,7 @@ export class CommandParser {
     const deepestCmd = chain[chain.length - 1];
     const aliases = this.buildScopedAliases(deepestCmd);
     const booleanFlags = this.getScopedBooleanFlags(deepestCmd);
+    const valueFlags = this.getScopedValueFlags(deepestCmd);
 
     let i = 0;
     let parsingFlags = true;
@@ -162,7 +163,7 @@ export class CommandParser {
 
       // Handle flags
       if (parsingFlags && arg.startsWith('-')) {
-        const parseResult = this.parseFlag(args, i, aliases, booleanFlags);
+        const parseResult = this.parseFlag(args, i, aliases, booleanFlags, valueFlags);
 
         // Apply to result flags
         Object.assign(result.flags, parseResult.flags);
@@ -219,11 +220,22 @@ export class CommandParser {
     args: string[],
     index: number,
     aliases: Record<string, string>,
-    booleanFlags: Set<string>
+    booleanFlags: Set<string>,
+    valueFlags: Set<string> = new Set()
   ): { flags: ParsedFlags; nextIndex: number } {
     const flags: ParsedFlags = { _: [] };
     const arg = args[index];
     let nextIndex = index + 1;
+
+    /**
+     * A flag that ran out of value. A DECLARED value-taking option becomes ''
+     * rather than `true`: `true` is how `--version` (redefined as a string by
+     * plugins/deployment) slipped back into the global boolean handler and
+     * printed the moflo version instead of running the command. '' stays falsy
+     * and trips the required-option check. Undeclared flags keep the legacy
+     * `true` so `--some-adhoc-flag` behaves as before.
+     */
+    const missingValue = (key: string): string | boolean => (valueFlags.has(key) ? '' : true);
 
     if (arg.startsWith('--')) {
       // Long flag
@@ -248,7 +260,7 @@ export class CommandParser {
           flags[normalizedKey] = this.parseValue(args[nextIndex]);
           nextIndex++;
         } else {
-          flags[normalizedKey] = true;
+          flags[normalizedKey] = missingValue(normalizedKey);
         }
       }
     } else if (arg.startsWith('-')) {
@@ -266,7 +278,7 @@ export class CommandParser {
           flags[normalizedKey] = this.parseValue(args[nextIndex]);
           nextIndex++;
         } else {
-          flags[normalizedKey] = true;
+          flags[normalizedKey] = missingValue(normalizedKey);
         }
       } else {
         // Multiple short flags combined (e.g., -abc)
@@ -357,6 +369,21 @@ export class CommandParser {
   /**
    * Get boolean flags scoped to a specific command/subcommand.
    */
+  /**
+   * Names declared as value-taking (non-boolean) by the resolved command or a
+   * global, command winning. The mirror of `getScopedBooleanFlags`: that set
+   * says "takes no value", this one says "REQUIRES one".
+   */
+  private getScopedValueFlags(resolvedCmd?: Command): Set<string> {
+    const flags = new Set<string>();
+    for (const opt of [...this.globalOptions, ...(resolvedCmd?.options ?? [])]) {
+      const key = this.normalizeKey(opt.name);
+      if (opt.type && opt.type !== 'boolean') flags.add(key);
+      else flags.delete(key);
+    }
+    return flags;
+  }
+
   private getScopedBooleanFlags(resolvedCmd?: Command): Set<string> {
     const flags = this.getBooleanFlags();
 

--- a/tests/guards/command-option-defaults-guard.test.ts
+++ b/tests/guards/command-option-defaults-guard.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Guard: a CLI option's declared `default` must match its declared `type`.
+ *
+ * `default: 'false'` on a boolean is a truthy STRING; `default: '100'` on a
+ * number string-concatenates under arithmetic (`'100' + 1 === '1001'`). These
+ * sat harmless for a long time only because the parser never applied
+ * command-level option defaults at all — 455 of them across the CLI were dead
+ * letters. The moment `applyDefaults` started honouring them, every
+ * `default: 'false'` flipped its flag ON: `--force`, `--full`, `--background`,
+ * `--verbose`. Loaded-gun shapes, not style nits, so they get a guard.
+ *
+ * Note the asymmetry that makes this invisible: the parser DOES coerce
+ * user-supplied values (`--limit 10` arrives as the number 10), so only the
+ * declared default escapes coercion. A wrong default is therefore silent right
+ * up until it is the value in play.
+ *
+ * Only options that shadow a global option currently have their default
+ * applied (see `CommandParser.applyDefaults`), so most are still dormant —
+ * which is exactly why a regression here would go unnoticed until someone
+ * widens that rule.
+ *
+ * Walks the REAL registered command tree rather than grepping source, so an
+ * option built programmatically is covered too.
+ *
+ * If this goes red: write the literal, not the string — `default: false`,
+ * `default: 100`.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { getCommandNames, getCommandAsync } from '../../src/cli/commands/index.js';
+import type { Command } from '../../src/cli/types.js';
+
+async function collectOptions(): Promise<Array<{ path: string; name: string; default: unknown; type?: string }>> {
+  const found: Array<{ path: string; name: string; default: unknown; type?: string }> = [];
+  const seen = new Set<string>();
+
+  const walk = (cmd: Command, ancestors: string[]): void => {
+    const segments = [...ancestors, cmd.name];
+    const key = segments.join(' ');
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    for (const opt of cmd.options ?? []) {
+      found.push({ path: key, name: opt.name, default: opt.default, type: opt.type });
+    }
+    for (const sub of cmd.subcommands ?? []) walk(sub, segments);
+  };
+
+  for (const name of getCommandNames()) {
+    const cmd = await getCommandAsync(name);
+    if (cmd) walk(cmd, []);
+  }
+
+  return found;
+}
+
+/** The JS typeof a declared `type` must produce for its default. */
+const EXPECTED_TYPEOF: Record<string, string> = {
+  boolean: 'boolean',
+  number: 'number',
+  string: 'string',
+};
+
+describe('CLI option default types', () => {
+  it('no boolean option declares a string default', async () => {
+    const options = await collectOptions();
+
+    const offenders = options
+      .filter(o => o.type === 'boolean' && typeof o.default === 'string')
+      .map(o => `${o.path} --${o.name} (default: ${JSON.stringify(o.default)})`);
+
+    expect(
+      offenders,
+      `Boolean options must use a real boolean default — a string 'false' is TRUTHY.\n` +
+        `Write \`default: false\`, not \`default: 'false'\`.\n` +
+        `Offenders:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('no number option declares a string default', async () => {
+    const options = await collectOptions();
+
+    const offenders = options
+      .filter(o => o.type === 'number' && typeof o.default === 'string')
+      .map(o => `${o.path} --${o.name} (default: ${JSON.stringify(o.default)})`);
+
+    expect(
+      offenders,
+      `Number options must use a real number default — a string default skips the\n` +
+        `coercion the parser applies to user-supplied values, so '100' + 1 === '1001'.\n` +
+        `Write \`default: 100\`, not \`default: '100'\`.\n` +
+        `Offenders:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  // The general rule the two cases above are instances of, so a new `type`
+  // (or a string option defaulted to a number) is caught without another case.
+  it('every declared default matches its declared type', async () => {
+    const options = await collectOptions();
+
+    const offenders = options
+      .filter(o => o.default !== undefined && o.type !== undefined)
+      .filter(o => {
+        const expected = EXPECTED_TYPEOF[o.type as string];
+        // Unknown/array-ish types are out of scope for this guard.
+        return expected !== undefined && typeof o.default !== expected;
+      })
+      .map(o => `${o.path} --${o.name}: type '${o.type}' but default is ${typeof o.default} (${JSON.stringify(o.default)})`);
+
+    expect(
+      offenders,
+      `An option's default must be a literal of its declared type.\n` +
+        `Offenders:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('walks a meaningful number of commands (guard is actually reaching the tree)', async () => {
+    const options = await collectOptions();
+
+    // Cheap canary: if lazy loading breaks and the walk silently sees nothing,
+    // the assertion above would pass vacuously.
+    expect(options.length).toBeGreaterThan(500);
+  });
+});


### PR DESCRIPTION
Closes #1346.

Found while running `/healer --fix`: the `Config File` fix reported
`applied: true` on every run while the warning it claimed to fix never cleared.
`config.ts` had **no filesystem import at all**.

## What changed

| Area | Before | After |
|---|---|---|
| `flo config` | Printed "Creating…" + `[OK]`, wrote nothing. `get` hardcoded, `set`/`reset`/`import` no-op, `export` wrote nothing, `providers` ignored its flags | Real `.moflo/config.json` store; every subcommand reads/writes it |
| Healer `Config File` fix | `return runFixCommand(...)` — exit code as proof | Verdict derived from the file existing; injectable runner |
| Parser collisions | Command option **stacked** with same-named global → 45 collisions unsatisfiable | Command option **shadows** the global |
| `--version <value>` | Swallowed as boolean → global handler printed the version and exited | Parsed as value-taking; command runs |
| Option defaults | 63 declaring a type-contradicting default | Corrected + guarded |
| `embeddings chunk --file` | Unreachable, and unread even if reached | Reads the file, CRLF-normalized |

## The severe one

```
$ flo plugins install somepkg --version 1.2.3
flo v4.12.4-rc.1          # printed the version and exited. Nothing installed.
```

`plugins install`, `plugins upgrade`, `deployment deploy`, `deployment rollback`.
Now installs `somepkg@1.2.3`.

## Scope decisions

**Command defaults are applied only where they shadow a global.** My first pass
applied *all* command-option defaults — that is 455 options the parser has never
honoured, including 28 booleans defaulting to the truthy string `'false'`, which
would have flipped `--force`/`--full`/`--background` ON across the CLI. Narrowed,
with a guard pinning the boundary.

**CRLF normalized at the read, not in `chunking.ts`.** That splitter's boundaries
determine already-stored embeddings; widening its regex would silently re-chunk
everything indexed to date.

**Dead positional fallbacks left alone.** 18 commands mark a flag `required`
while their action has an unreachable `ctx.args[0]` fallback. Cosmetic, in
`hooks.ts` (the hook runtime every consumer session invokes), and the audit that
found them proved unreliable at the line level — it mismapped `spell schedule
create` onto `spell cast`, whose fallback is live. Not worth the risk.

## Consumer impact

`flo config`, the healer, and `parser.ts` ship in `dist/`. With no config file
present `get` returns the same values as before, so nothing changes until someone
writes one. No migration; an existing legacy `claude-flow.config.json` keeps
being read *and* written back to. One deliberate change: `config init` exits 1 on
an existing config instead of always exiting 0 — `--force` overwrites.

Shadowing can only accept invocations that previously errored, never reject new
ones.

## Verification

- **9818 tests passing, 0 failed**; lint and `tsc` clean; healer 47 passed / 0
  warnings / 0 failures.
- 11 declaration classes audited across 323 commands — all zero. 45-collision
  behavioural sweep clean.
- New guards proven red on a reintroduced regression before being trusted.
- End-to-end against the built CLI: init/re-init/`--force` exit 0/1/0, positional
  and flag `set` both persist, `maxAgents` stored as number `20`, `providers
  --enable` persists, yaml+json export land on disk, CRLF and LF files chunk
  identically.
- **Rule #1**: `join`/`resolve`/`sep` throughout, no hardcoded `/tmp`, no
  shelling out, tests use `os.tmpdir()` + `realpathSync` on both sides, no ports
  bound, LF per `.gitattributes`. Verified on Linux only — CI's three-platform
  smoke is the real check, especially the macOS and Ubuntu runs.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
