### PR TITLE
fix(deps): resolve all three security advisories via lockfile refresh (#1350)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,9 +1795,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2787,9 +2787,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3730,9 +3730,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes #1350.

All three advisories resolved by a lockfile refresh. Every patched version
already satisfied its parent's existing range, so none of this needed an
`overrides` pin, a major bump, or an upstream release — the lockfile was simply
pinned below the fix.

| package | was | now | advisory | reaches consumers? |
|---|---|---|---|---|
| `hono` | 4.12.27 | 4.13.0 | GHSA-8j4g-w8fx-2239 (`<4.12.34`) | **yes** |
| `brace-expansion` | 5.0.8 | 5.0.9 | GHSA-rgw5-rvv9-x895 (`<5.0.9`) | no — `eslint` → `minimatch` |
| `postcss` | 8.5.20 | 8.5.25 | `<=8.5.22` | no — `vitest` → `vite` |

**`npm audit`: 3 vulnerabilities (1 high, 2 moderate) → 0**, both with and
without `--omit=dev`.

## Why this wasn't blocked on the MCP SDK

`@modelcontextprotocol/sdk` is already at **1.30.0, the latest published**, and
requires `hono ^4.11.4` — a range `4.13.0` satisfies. The SDK's declared range
never excluded the patched version. (#1350's original description said this
needed an SDK release or an override; that was wrong and is corrected in a
comment there.)

## Scope

`package.json` is **untouched** — all three are transitive and already within
range. The entire diff is 9 lines of `package-lock.json`: version, resolved,
and integrity for exactly these three packages, nothing else.

## Verification

- `npm audit` 0 / `npm audit --omit=dev` 0
- Full suite **9823 passed, 0 failed**; `tsc` and `eslint --max-warnings 0` clean
- Toolchain sanity after their own transitive deps moved: `eslint --version`
  10.8.0, `vitest --version` 4.1.5, and `flo mcp start` still initialises in
  stdio mode (hono is the one that ships, so that path matters most)
- Healer 47 passed / 0 warnings / 0 failures

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
