### PR TITLE
fix(cli): register the 19 MCP tools shipped commands already call

### DIFF
--- a/src/cli/__tests__/commands-deep.test.ts
+++ b/src/cli/__tests__/commands-deep.test.ts
@@ -130,10 +130,12 @@ describe('Command Definitions', () => {
       expectValidCommand(agentCommand, 'agent');
     });
 
-    it('should have 8 subcommands', () => {
-      expectHasSubcommands(agentCommand, 8);
+    // 'logs' was removed in #1349: it called the unregistered agent_logs
+    // tool and no agent-log source exists to back it.
+    it('should have 7 subcommands', () => {
+      expectHasSubcommands(agentCommand, 7);
       expectSubcommandNames(agentCommand, [
-        'spawn', 'list', 'status', 'stop', 'metrics', 'pool', 'health', 'logs',
+        'spawn', 'list', 'status', 'stop', 'metrics', 'pool', 'health',
       ]);
     });
 

--- a/src/cli/__tests__/mcp-tools-callsite-guard.test.ts
+++ b/src/cli/__tests__/mcp-tools-callsite-guard.test.ts
@@ -1,0 +1,262 @@
+/**
+ * MCP Tool Call-site Guard (#1349)
+ *
+ * The inverse of `mcp-tools-drift-guard.test.ts`. That guard walks
+ * registered → consumer ("is every tool used?"). This one walks
+ * consumer → registered ("does every call resolve?").
+ *
+ * Before #1349, 23 shipped CLI subcommands called `callMCPTool('<name>')` with
+ * names the registry never held. Each printed its normal progress output and
+ * then failed with `MCP tool not found: <name>` — and two of them swallowed
+ * that error and reported success for work that never happened, while a third
+ * group dropped `flo status` into a fabricated all-zeros fallback on every
+ * run. Nothing in CI noticed, because a missing handler is a runtime lookup
+ * miss, not a type error: `callMCPTool` takes a plain `string`.
+ *
+ * Failure mode this catches: someone writes a CLI command against a tool they
+ * intend to add and never adds it, or deletes/renames a handler while a call
+ * site still references the old name.
+ *
+ * @module v3/cli/__tests__/mcp-tools-callsite-guard
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const SRC_DIR = join(REPO_ROOT, 'src');
+const TOOLS_DIR = join(REPO_ROOT, 'src', 'cli', 'mcp-tools');
+
+/**
+ * Call sites that intentionally reference a non-existent tool — negative-path
+ * tests asserting the "not found" error, and doc examples. Keyed by the tool
+ * name, valued with a justification.
+ */
+const ALLOWLIST: Record<string, string> = {};
+
+interface CallSite {
+  tool: string;
+  file: string;
+  line: number;
+}
+
+/** Registered tool names, read from the modules `mcp-client.ts` actually imports. */
+function collectRegisteredTools(): Set<string> {
+  const client = readFileSync(join(TOOLS_DIR, '..', 'mcp-client.ts'), 'utf8');
+  const importRe = /import\s+\{\s*(\w+)\s*\}\s+from\s+['"]\.\/mcp-tools\/([\w-]+)\.js['"]/g;
+  const files = new Set<string>();
+  for (const m of client.matchAll(importRe)) files.add(`${m[2]}.ts`);
+
+  const names = new Set<string>();
+  for (const fname of files) {
+    const src = readFileSync(join(TOOLS_DIR, fname), 'utf8');
+    // Same shape as the drift guard: `<category>_<action>` with an underscore,
+    // so inner object keys like `{ name: 'mcp' }` don't register as tools.
+    for (const m of src.matchAll(/^\s*name:\s*['"]([a-z][a-z0-9-]*_[a-z0-9_-]+)['"]/gm)) {
+      names.add(m[1]);
+    }
+  }
+  return names;
+}
+
+/** `export const TOOL_X = 'name' as const` → TOOL_X ↦ name. */
+function loadToolNameConstants(): Map<string, string> {
+  const map = new Map<string, string>();
+  let src: string;
+  try {
+    src = readFileSync(join(TOOLS_DIR, 'tool-names.ts'), 'utf8');
+  } catch {
+    return map;
+  }
+  for (const m of src.matchAll(/export\s+const\s+(\w+)\s*=\s*['"]([\w-]+)['"]\s+as\s+const/g)) {
+    map.set(m[1], m[2]);
+  }
+  return map;
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  let names: string[];
+  try { names = readdirSync(dir); } catch { return out; }
+  for (const entry of names) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      if (entry === 'node_modules' || entry === 'dist' || entry === '.git') continue;
+      walk(full, out);
+    } else if (st.isFile() && /\.ts$/.test(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Blank out comments while preserving byte offsets and newlines, so a
+ * `callMCPTool('example')` written in prose is not mistaken for a call site.
+ *
+ * This is load-bearing, not tidiness: the scan below spans an inline generic
+ * type argument with `[^(]*`, which matches newlines — without stripping,
+ * every JSDoc block that documents the call shape (including this file's own)
+ * registers as a bogus call to a tool named `name`.
+ */
+/**
+ * Is the `/` at `idx` the start of a regex literal rather than division?
+ *
+ * Decided by the previous non-whitespace token: after a value (identifier,
+ * number, `)`, `]`) a slash is division; after an operator, punctuator, or a
+ * keyword like `return` it opens a regex.
+ */
+function isRegexStart(src: string, idx: number): boolean {
+  let j = idx - 1;
+  while (j >= 0 && /\s/.test(src[j])) j--;
+  if (j < 0) return true;
+  const prev = src[j];
+  if ('(,=:[!&|?{};+-*~^%<>'.includes(prev)) return true;
+  // `return /re/`, `typeof /re/`, `case /re/` — keyword, not a value.
+  const word = /[A-Za-z_$][\w$]*$/.exec(src.slice(Math.max(0, j - 11), j + 1));
+  return word ? ['return', 'typeof', 'case', 'in', 'of', 'delete', 'void', 'instanceof'].includes(word[0]) : false;
+}
+
+function stripComments(src: string): string {
+  const out = src.split('');
+  let i = 0;
+  const blank = (from: number, to: number): void => {
+    for (let k = from; k < to && k < out.length; k++) {
+      if (out[k] !== '\n') out[k] = ' ';
+    }
+  };
+
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+
+    if (c === '/' && next === '/') {
+      const end = src.indexOf('\n', i);
+      blank(i, end === -1 ? src.length : end);
+      i = end === -1 ? src.length : end;
+    } else if (c === '/' && next === '*') {
+      const end = src.indexOf('*/', i + 2);
+      const stop = end === -1 ? src.length : end + 2;
+      blank(i, stop);
+      i = stop;
+    } else if (c === '/' && isRegexStart(src, i)) {
+      // A regex literal, not division. Skipping it matters because regexes in
+      // this codebase contain unbalanced quotes (`/['"]/` appears in this very
+      // file); without this branch the scanner would enter string-skip mode at
+      // that quote and swallow real code — potentially hiding an unregistered
+      // call site, which is the one thing this guard must never do.
+      i++;
+      let inClass = false;
+      while (i < src.length) {
+        const ch = src[i];
+        if (ch === '\\') { i += 2; continue; }
+        if (ch === '\n') break;           // unterminated — bail, don't consume
+        if (ch === '[') inClass = true;
+        else if (ch === ']') inClass = false;
+        else if (ch === '/' && !inClass) { i++; break; }
+        i++;
+      }
+    } else if (c === '"' || c === "'" || c === '`') {
+      // Skip the string body so a `//` or `/*` inside it isn't treated as a
+      // comment opener. String contents themselves stay intact.
+      i++;
+      while (i < src.length) {
+        if (src[i] === '\\') { i += 2; continue; }
+        if (src[i] === c) { i++; break; }
+        i++;
+      }
+    } else {
+      i++;
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * Collect every literal and constant-mediated `callMCPTool` call site.
+ *
+ * The `[^(]*` span skips an inline generic type argument, since call sites are
+ * written with a multi-line inline result type. Type arguments contain no open
+ * paren, so the first one reached belongs to the call itself.
+ */
+function collectCallSites(files: string[]): CallSite[] {
+  const constants = loadToolNameConstants();
+  const callRe = /callMCPTool\b[^(]*\(\s*(?:['"]([\w-]+)['"]|([A-Z][A-Z0-9_]+))/g;
+  const sites: CallSite[] = [];
+
+  for (const file of files) {
+    const raw = readFileSync(file, 'utf8');
+    if (!raw.includes('callMCPTool')) continue;
+    // The client defines callMCPTool; its own examples are not call sites.
+    if (file.endsWith(join('cli', 'mcp-client.ts'))) continue;
+
+    const src = stripComments(raw);
+    for (const m of src.matchAll(callRe)) {
+      const tool = m[1] ?? constants.get(m[2]!);
+      // An unresolvable SCREAMING_CONSTANT is a dynamic name, not a literal
+      // call site — out of scope for this guard.
+      if (!tool) continue;
+      const line = src.slice(0, m.index).split('\n').length;
+      sites.push({ tool, file: relative(REPO_ROOT, file), line });
+    }
+  }
+  return sites;
+}
+
+let registered: Set<string>;
+let callSites: CallSite[];
+
+describe('MCP Tool Call-site Guard (#1349)', () => {
+  beforeAll(() => {
+    registered = collectRegisteredTools();
+    callSites = collectCallSites(walk(SRC_DIR));
+  });
+
+  it('finds call sites and registered tools to compare', () => {
+    expect(registered.size).toBeGreaterThan(50);
+    expect(callSites.length).toBeGreaterThan(50);
+  });
+
+  it('every callMCPTool call site names a registered tool', () => {
+    const unresolved = callSites.filter(
+      s => !registered.has(s.tool) && !(s.tool in ALLOWLIST)
+    );
+
+    const byTool = new Map<string, CallSite[]>();
+    for (const site of unresolved) {
+      if (!byTool.has(site.tool)) byTool.set(site.tool, []);
+      byTool.get(site.tool)!.push(site);
+    }
+
+    const hint = byTool.size === 0 ? '' :
+      `\n\n${byTool.size} MCP tool name(s) called but never registered:\n` +
+      [...byTool.entries()]
+        .map(([tool, sites]) =>
+          `  - ${tool}\n${sites.map(s => `      ${s.file}:${s.line}`).join('\n')}`)
+        .join('\n') +
+      `\n\nEach one fails at runtime with "MCP tool not found: <name>" the moment ` +
+      `the command runs.\nFix: register a handler in src/cli/mcp-tools/ (and import it in ` +
+      `mcp-client.ts),\nremove the CLI surface, or — for a deliberate negative-path test — ` +
+      `add the name\nto ALLOWLIST in this file with a justification.`;
+
+    expect([...byTool.keys()], hint).toEqual([]);
+  });
+
+  it('no allowlist entry names a tool that is now registered or uncalled', () => {
+    const called = new Set(callSites.map(s => s.tool));
+    const stale = Object.keys(ALLOWLIST).filter(
+      name => registered.has(name) || !called.has(name)
+    );
+    expect(stale, `Stale allowlist entries: ${stale.join(', ')}`).toEqual([]);
+  });
+
+  it('every allowlist entry has a real justification', () => {
+    for (const [name, why] of Object.entries(ALLOWLIST)) {
+      expect(why.trim().length, `${name} needs a justification`).toBeGreaterThan(10);
+    }
+  });
+});

--- a/src/cli/__tests__/mcp-tools/memory-admin-safety.test.ts
+++ b/src/cli/__tests__/mcp-tools/memory-admin-safety.test.ts
@@ -1,0 +1,141 @@
+/**
+ * memory_cleanup safety invariants (#1349)
+ *
+ * Both properties here are data-loss-class and were caught in review rather
+ * than by a test, which is exactly why they get one:
+ *
+ *  1. Counting candidates must not delete. The first shape of this handler
+ *     deleted on the same call that produced the counts, so the CLI's
+ *     "Delete N entries?" prompt was asked *after* the rows were gone and
+ *     answering "no" printed "Cleanup cancelled" over a completed deletion.
+ *
+ *  2. The unusable-entry rule must require an explicit age cutoff. It keys on
+ *     `embedding IS NULL`, which means "the embedding model did not run" —
+ *     on a project where the model never loaded that is every row, so without
+ *     the cutoff a bare `flo memory cleanup` selected the whole store.
+ *
+ * @module v3/cli/__tests__/mcp-tools/memory-admin-safety
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { memoryAdminTools } from '../../mcp-tools/memory-admin-tools.js';
+import { memoryDbPath } from '../../services/moflo-paths.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/schema.js';
+
+const cleanup = memoryAdminTools.find(t => t.name === 'memory_cleanup')!;
+
+/** Rule #1: os.tmpdir()/path.join only — never a hardcoded /tmp. */
+let root: string;
+let originalCwd: string;
+
+function activeRows(): number {
+  const db = new DatabaseSync(memoryDbPath(root));
+  try {
+    return (db.prepare("SELECT COUNT(*) AS c FROM memory_entries WHERE status = 'active'")
+      .get() as { c: number }).c;
+  } finally {
+    db.close();
+  }
+}
+
+function seed(rows: Array<{ key: string; expiresAt?: number; embedding?: string }>): void {
+  const db = new DatabaseSync(memoryDbPath(root));
+  try {
+    db.exec(MEMORY_SCHEMA_V3);
+    const now = Date.now();
+    for (const [i, r] of rows.entries()) {
+      db.prepare(
+        `INSERT INTO memory_entries
+           (id, key, namespace, content, embedding, created_at, updated_at, expires_at, access_count, status)
+         VALUES (?, ?, 'default', 'content', ?, ?, ?, ?, 0, 'active')`
+      ).run(`e${i}`, r.key, r.embedding ?? null, now, now, r.expiresAt ?? null);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  root = mkdtempSync(join(tmpdir(), 'moflo-cleanup-'));
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  process.chdir(root);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('memory_cleanup safety (#1349)', () => {
+  it('counting candidates does not delete anything', async () => {
+    seed([{ key: 'expired', expiresAt: Date.now() - 60_000 }, { key: 'live' }]);
+    expect(activeRows()).toBe(2);
+
+    const result = await cleanup.handler({}) as {
+      dryRun: boolean;
+      candidates: { expired: number; total: number };
+    };
+
+    expect(result.dryRun).toBe(true);
+    expect(result.candidates.expired).toBe(1);
+    // The whole point: it found the candidate and left it alone.
+    expect(activeRows()).toBe(2);
+  });
+
+  it('deletes only when apply is explicitly requested', async () => {
+    seed([{ key: 'expired', expiresAt: Date.now() - 60_000 }, { key: 'live' }]);
+
+    const result = await cleanup.handler({ apply: true }) as {
+      dryRun: boolean;
+      deleted: { entries: number };
+    };
+
+    expect(result.dryRun).toBe(false);
+    expect(result.deleted.entries).toBe(1);
+    expect(activeRows()).toBe(1);
+  });
+
+  it('does not target embedding-less entries without an explicit age cutoff', async () => {
+    // Every row has a NULL embedding — the state of any project whose
+    // embedding model never loaded.
+    seed([{ key: 'a' }, { key: 'b' }, { key: 'c' }]);
+
+    const result = await cleanup.handler({}) as {
+      candidates: { lowQuality: number; total: number };
+    };
+
+    expect(result.candidates.lowQuality).toBe(0);
+    expect(result.candidates.total).toBe(0);
+    expect(activeRows()).toBe(3);
+  });
+
+  it('targets embedding-less entries once an age cutoff is given', async () => {
+    seed([{ key: 'a' }, { key: 'b' }]);
+
+    const result = await cleanup.handler({ olderThan: '0s' }) as {
+      candidates: { lowQuality: number };
+    };
+
+    expect(result.candidates.lowQuality).toBe(2);
+    // Still a count-only call, so nothing is gone yet.
+    expect(activeRows()).toBe(2);
+  });
+
+  it('leaves entries that still have an embedding alone', async () => {
+    seed([
+      { key: 'vectorized', embedding: JSON.stringify([0.1, 0.2]) },
+      { key: 'bare' },
+    ]);
+
+    const result = await cleanup.handler({ olderThan: '0s' }) as {
+      candidates: { lowQuality: number };
+    };
+
+    expect(result.candidates.lowQuality).toBe(1);
+  });
+});

--- a/src/cli/__tests__/mcp-tools/memory-admin-safety.test.ts
+++ b/src/cli/__tests__/mcp-tools/memory-admin-safety.test.ts
@@ -18,12 +18,13 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { memoryAdminTools } from '../../mcp-tools/memory-admin-tools.js';
 import { memoryDbPath } from '../../services/moflo-paths.js';
+import { _resetStateRootCacheForTest } from '../../services/project-root.js';
 import { MEMORY_SCHEMA_V3 } from '../../memory/schema.js';
 
 const cleanup = memoryAdminTools.find(t => t.name === 'memory_cleanup')!;
@@ -31,6 +32,7 @@ const cleanup = memoryAdminTools.find(t => t.name === 'memory_cleanup')!;
 /** Rule #1: os.tmpdir()/path.join only — never a hardcoded /tmp. */
 let root: string;
 let originalCwd: string;
+let originalProjectDir: string | undefined;
 
 function activeRows(): number {
   const db = new DatabaseSync(memoryDbPath(root));
@@ -61,13 +63,33 @@ function seed(rows: Array<{ key: string; expiresAt?: number; embedding?: string 
 
 beforeEach(() => {
   originalCwd = process.cwd();
-  root = mkdtempSync(join(tmpdir(), 'moflo-cleanup-'));
+  originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+
+  // realpath both sides: on macOS os.tmpdir() is /var/folders/... while
+  // resolveStateRoot canonicalizes to /private/var/folders/... (Rule #1 §2),
+  // and the assertions below must read the same file the handler writes.
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-cleanup-')));
   mkdirSync(join(root, '.moflo'), { recursive: true });
+
+  // These two lines are the safety interlock, not setup boilerplate.
+  // resolveStateRoot() treats CLAUDE_PROJECT_DIR as AUTHORITATIVE and never
+  // climbs above it, so process.chdir alone does NOT redirect the handler:
+  // run inside a Claude Code session, `apply: true` below would delete real
+  // TTL-expired rows from the developer's own .moflo/moflo.db. The marker
+  // file anchors the fallback marker-walk to this temp root as well, so
+  // neither resolution path can escape it.
+  process.env.CLAUDE_PROJECT_DIR = root;
+  writeFileSync(memoryDbPath(root), '');
+  _resetStateRootCacheForTest();
+
   process.chdir(root);
 });
 
 afterEach(() => {
   process.chdir(originalCwd);
+  if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+  _resetStateRootCacheForTest();
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/src/cli/__tests__/p1-commands.test.ts
+++ b/src/cli/__tests__/p1-commands.test.ts
@@ -87,11 +87,13 @@ vi.mock('../mcp-client.js', () => ({
         entries: 100,
         size: 1024000,
         namespaces: [{ name: 'default', entries: 100 }],
+        // Mirrors the real memory_detailed-stats shape (#1349): write
+        // latency and cache hit rate are not tracked by the store, so the
+        // mock must not advertise them either.
         performance: {
           avgSearchTime: 0.5,
-          avgWriteTime: 1.2,
-          cacheHitRate: 0.85,
-          hnswEnabled: true
+          hnswEnabled: true,
+          indexedVectors: 100
         }
       };
     }
@@ -178,6 +180,7 @@ vi.mock('../mcp-client.js', () => ({
 
     if (toolName === 'task_retry') {
       return {
+        success: true,
         taskId: input.taskId,
         newTaskId: `task-retry-${Date.now()}`,
         previousStatus: 'failed',

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -810,108 +810,6 @@ const healthCommand: Command = {
   }
 };
 
-// Agent logs subcommand
-const logsCommand: Command = {
-  name: 'logs',
-  description: 'Show agent activity logs',
-  options: [
-    {
-      name: 'id',
-      short: 'i',
-      description: 'Agent ID',
-      type: 'string'
-    },
-    {
-      name: 'tail',
-      short: 'n',
-      description: 'Number of recent entries',
-      type: 'number',
-      default: 50
-    },
-    {
-      name: 'level',
-      short: 'l',
-      description: 'Minimum log level',
-      type: 'string',
-      choices: ['debug', 'info', 'warn', 'error'],
-      default: 'info'
-    },
-    {
-      name: 'follow',
-      short: 'f',
-      description: 'Follow log output',
-      type: 'boolean',
-      default: false
-    },
-    {
-      name: 'since',
-      description: 'Show logs since (e.g., "1h", "30m")',
-      type: 'string'
-    }
-  ],
-  examples: [
-    { command: 'flo agent logs -i agent-001', description: 'Show agent logs' },
-    { command: 'flo agent logs -i agent-001 -f', description: 'Follow agent logs' },
-    { command: 'flo agent logs -l error --since 1h', description: 'Show errors from last hour' }
-  ],
-  action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const agentId = ctx.args[0] || ctx.flags.id as string;
-    const tail = ctx.flags.tail as number;
-    const level = ctx.flags.level as string;
-
-    if (!agentId) {
-      output.printError('Agent ID is required. Use --id or -i');
-      return { success: false, exitCode: 1 };
-    }
-
-    try {
-      const result = await callMCPTool<{
-        agentId: string;
-        entries: Array<{
-          timestamp: string;
-          level: 'debug' | 'info' | 'warn' | 'error';
-          message: string;
-          context?: Record<string, unknown>;
-        }>;
-        total: number;
-      }>('agent_logs', {
-        agentId,
-        tail,
-        level,
-        since: ctx.flags.since,
-      });
-
-      if (ctx.flags.format === 'json') {
-        output.printJson(result);
-        return { success: true, data: result };
-      }
-
-      output.writeln();
-      output.writeln(output.bold(`Logs for ${agentId}`));
-      output.writeln(output.dim(`Showing ${result.entries.length} of ${result.total} entries`));
-      output.writeln();
-
-      for (const entry of result.entries) {
-        const time = new Date(entry.timestamp).toLocaleTimeString();
-        const levelStr = formatLogLevel(entry.level);
-        output.writeln(`${output.dim(time)} ${levelStr} ${entry.message}`);
-        if (entry.context && Object.keys(entry.context).length > 0) {
-          output.writeln(output.dim(`  ${JSON.stringify(entry.context)}`));
-        }
-      }
-
-      return { success: true, data: result };
-    } catch (error) {
-      if (error instanceof MCPClientError) {
-        output.printError(`Logs error: ${error.message}`);
-      } else {
-        output.printError(`Unexpected error: ${String(error)}`);
-      }
-      return { success: false, exitCode: 1 };
-    }
-  }
-};
-
 function formatLogLevel(level: string): string {
   switch (level) {
     case 'debug':
@@ -931,7 +829,7 @@ function formatLogLevel(level: string): string {
 export const agentCommand: Command = {
   name: 'agent',
   description: 'Agent management commands',
-  subcommands: [spawnCommand, listCommand, statusCommand, stopCommand, metricsCommand, poolCommand, healthCommand, logsCommand],
+  subcommands: [spawnCommand, listCommand, statusCommand, stopCommand, metricsCommand, poolCommand, healthCommand],
   options: [],
   examples: [
     { command: 'flo agent spawn -t coder', description: 'Spawn a coder agent' },

--- a/src/cli/commands/hive-mind.ts
+++ b/src/cli/commands/hive-mind.ts
@@ -962,12 +962,21 @@ const taskCommand: Command = {
         priority: string;
         requiresConsensus: boolean;
         estimatedTime: string;
+        error?: string;
       }>('hive-mind_task', {
         description,
         priority,
         requireConsensus,
         timeout,
       });
+
+      // An uninitialized hive comes back as { error }, not as a throw. Reading
+      // result.assignedTo.join() on that shape crashed with a TypeError
+      // instead of printing the actual problem (#1349).
+      if (result.error) {
+        output.printError(result.error);
+        return { success: false, exitCode: 1 };
+      }
 
       if (ctx.flags.format === 'json') {
         output.printJson(result);
@@ -995,87 +1004,6 @@ const taskCommand: Command = {
     } catch (error) {
       if (error instanceof MCPClientError) {
         output.printError(`Task submission error: ${error.message}`);
-      } else {
-        output.printError(`Unexpected error: ${String(error)}`);
-      }
-      return { success: false, exitCode: 1 };
-    }
-  }
-};
-
-// Optimize memory subcommand
-const optimizeMemoryCommand: Command = {
-  name: 'optimize-memory',
-  description: 'Optimize hive memory and patterns',
-  options: [
-    {
-      name: 'aggressive',
-      short: 'a',
-      description: 'Aggressive optimization',
-      type: 'boolean',
-      default: false
-    },
-    {
-      name: 'threshold',
-      description: 'Quality threshold for pattern retention',
-      type: 'number',
-      default: 0.7
-    }
-  ],
-  action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const aggressive = ctx.flags.aggressive as boolean;
-    const threshold = ctx.flags.threshold as number;
-
-    output.printInfo('Optimizing hive memory...');
-
-    const spinner = output.createSpinner({ text: 'Analyzing patterns...', spinner: 'dots' });
-    spinner.start();
-
-    try {
-      const result = await callMCPTool<{
-        optimized: boolean;
-        before: { patterns: number; memory: string };
-        after: { patterns: number; memory: string };
-        removed: number;
-        consolidated: number;
-        timeMs: number;
-      }>('hive-mind_optimize-memory', {
-        aggressive,
-        qualityThreshold: threshold,
-      });
-
-      spinner.succeed('Memory optimized');
-
-      if (ctx.flags.format === 'json') {
-        output.printJson(result);
-        return { success: true, data: result };
-      }
-
-      output.writeln();
-      output.printTable({
-        columns: [
-          { key: 'metric', header: 'Metric', width: 20 },
-          { key: 'before', header: 'Before', width: 15, align: 'right' },
-          { key: 'after', header: 'After', width: 15, align: 'right' }
-        ],
-        data: [
-          { metric: 'Patterns', before: result.before.patterns, after: result.after.patterns },
-          { metric: 'Memory', before: result.before.memory, after: result.after.memory }
-        ]
-      });
-
-      output.writeln();
-      output.printList([
-        `Patterns removed: ${result.removed}`,
-        `Patterns consolidated: ${result.consolidated}`,
-        `Optimization time: ${result.timeMs}ms`
-      ]);
-
-      return { success: true, data: result };
-    } catch (error) {
-      spinner.fail('Optimization failed');
-      if (error instanceof MCPClientError) {
-        output.printError(`Optimization error: ${error.message}`);
       } else {
         output.printError(`Unexpected error: ${String(error)}`);
       }
@@ -1286,7 +1214,7 @@ export const hiveMindCommand: Command = {
   name: 'hive-mind',
   aliases: ['hive'],
   description: 'Queen-led consensus-based multi-agent coordination',
-  subcommands: [initCommand, spawnCommand, statusCommand, taskCommand, joinCommand, leaveCommand, consensusCommand, broadcastCommand, memorySubCommand, optimizeMemoryCommand, shutdownCommand],
+  subcommands: [initCommand, spawnCommand, statusCommand, taskCommand, joinCommand, leaveCommand, consensusCommand, broadcastCommand, memorySubCommand, shutdownCommand],
   options: [],
   examples: [
     { command: 'flo hive-mind init -t hierarchical-mesh', description: 'Initialize hive' },
@@ -1311,7 +1239,6 @@ export const hiveMindCommand: Command = {
       `${output.highlight('consensus')}       - Manage consensus proposals`,
       `${output.highlight('broadcast')}       - Broadcast message to workers`,
       `${output.highlight('memory')}          - Access shared memory`,
-      `${output.highlight('optimize-memory')} - Optimize patterns and memory`,
       `${output.highlight('shutdown')}        - Shutdown the hive`
     ]);
     output.writeln();

--- a/src/cli/commands/hooks.ts
+++ b/src/cli/commands/hooks.ts
@@ -2548,7 +2548,7 @@ const coverageRouteCommand: Command = {
           reason: string;
         }>;
         routing: {
-          primaryAgent: string;
+          primaryAgent: string | null;
           confidence: number;
           reason: string;
           coverageImpact: string;
@@ -2559,7 +2559,7 @@ const coverageRouteCommand: Command = {
           totalGaps: number;
           criticalGaps: number;
           avgCoverage: number;
-        };
+        } | null;
       }>('hooks_coverage-route', {
         task,
         threshold,
@@ -2576,7 +2576,7 @@ const coverageRouteCommand: Command = {
       output.writeln();
       output.printBox(
         [
-          `Agent: ${output.highlight(result.routing.primaryAgent)}`,
+          `Agent: ${result.routing.primaryAgent ? output.highlight(result.routing.primaryAgent) : output.dim('none — no coverage data to route on')}`,
           `Confidence: ${(result.routing.confidence * 100).toFixed(1)}%`,
           `Coverage-Aware: ${result.coverageAware ? output.success('Yes') : output.dim('No coverage data')}`,
           `Reason: ${result.routing.reason}`
@@ -2601,7 +2601,7 @@ const coverageRouteCommand: Command = {
         });
       }
 
-      if (result.metrics.filesAnalyzed > 0) {
+      if (result.metrics && result.metrics.filesAnalyzed > 0) {
         output.writeln();
         output.writeln(output.bold('Coverage Metrics'));
         output.printList([
@@ -2691,7 +2691,7 @@ const coverageSuggestCommand: Command = {
           overallLineCoverage: number;
           overallBranchCoverage: number;
           filesBelowThreshold: number;
-        };
+        } | null;
         prioritizedFiles: string[];
         movectorAvailable: boolean;
       }>('hooks_coverage-suggest', {
@@ -2708,14 +2708,20 @@ const coverageSuggestCommand: Command = {
       }
 
       output.writeln();
+      // summary is null when no coverage artifact exists — print the absence
+      // rather than a block of zeros that reads as a real measurement (#1349).
       output.printBox(
         [
           `Path: ${output.highlight(result.path)}`,
-          `Files Analyzed: ${result.summary.totalFiles}`,
-          `Line Coverage: ${result.summary.overallLineCoverage.toFixed(1)}%`,
-          `Branch Coverage: ${result.summary.overallBranchCoverage.toFixed(1)}%`,
-          `Below Threshold: ${result.summary.filesBelowThreshold} files`,
-          `MoVector: ${result.movectorAvailable ? output.success('Available') : output.dim('Not installed')}`
+          ...(result.summary
+            ? [
+                `Files Analyzed: ${result.summary.totalFiles}`,
+                `Line Coverage: ${result.summary.overallLineCoverage.toFixed(1)}%`,
+                `Branch Coverage: ${result.summary.overallBranchCoverage.toFixed(1)}%`,
+                `Below Threshold: ${result.summary.filesBelowThreshold} files`,
+              ]
+            : []),
+          `Coverage Data: ${result.movectorAvailable ? output.success('Found') : output.dim('No coverage report')}`
         ].join('\n'),
         'Coverage Summary'
       );
@@ -2814,7 +2820,7 @@ const coverageGapsCommand: Command = {
           overallBranchCoverage: number;
           filesBelowThreshold: number;
           coverageThreshold: number;
-        };
+        } | null;
         agentAssignments: Record<string, string[]>;
         movectorAvailable: boolean;
       }>('hooks_coverage-gaps', {
@@ -2837,11 +2843,15 @@ const coverageGapsCommand: Command = {
       output.writeln();
       output.printBox(
         [
-          `Total Files: ${result.summary.totalFiles}`,
-          `Line Coverage: ${result.summary.overallLineCoverage.toFixed(1)}%`,
-          `Branch Coverage: ${result.summary.overallBranchCoverage.toFixed(1)}%`,
-          `Below ${result.summary.coverageThreshold}%: ${result.summary.filesBelowThreshold} files`,
-          `MoVector: ${result.movectorAvailable ? output.success('Available') : output.dim('Not installed')}`
+          ...(result.summary
+            ? [
+                `Total Files: ${result.summary.totalFiles}`,
+                `Line Coverage: ${result.summary.overallLineCoverage.toFixed(1)}%`,
+                `Branch Coverage: ${result.summary.overallBranchCoverage.toFixed(1)}%`,
+                `Below ${result.summary.coverageThreshold}%: ${result.summary.filesBelowThreshold} files`,
+              ]
+            : []),
+          `Coverage Data: ${result.movectorAvailable ? output.success('Found') : output.dim('No coverage report')}`
         ].join('\n'),
         'Coverage Gap Analysis'
       );
@@ -2869,7 +2879,14 @@ const coverageGapsCommand: Command = {
         });
       } else {
         output.writeln();
-        output.printSuccess('No coverage gaps found! All files meet threshold.');
+        // "All files meet threshold" and "we never found a coverage report"
+        // are different facts; reporting the first for the second is how a
+        // command claims a clean bill of health it never checked (#1349).
+        if (!result.movectorAvailable) {
+          output.printWarning('No coverage report found — run your test suite with coverage first.');
+        } else {
+          output.printSuccess('No coverage gaps found! All files meet threshold.');
+        }
       }
 
       if (groupByAgent && Object.keys(result.agentAssignments).length > 0) {
@@ -3946,239 +3963,6 @@ const modelStatsCommand: Command = {
   }
 };
 
-// Teammate Idle command - Agent Teams integration
-const teammateIdleCommand: Command = {
-  name: 'teammate-idle',
-  description: 'Handle idle teammate in Agent Teams - auto-assign tasks or notify lead',
-  options: [
-    {
-      name: 'auto-assign',
-      short: 'a',
-      description: 'Automatically assign pending tasks to idle teammate',
-      type: 'boolean',
-      default: true
-    },
-    {
-      name: 'check-task-list',
-      short: 'c',
-      description: 'Check shared task list for available work',
-      type: 'boolean',
-      default: true
-    },
-    {
-      name: 'teammate-id',
-      short: 't',
-      description: 'ID of the idle teammate',
-      type: 'string'
-    },
-    {
-      name: 'team-name',
-      description: 'Team name for context',
-      type: 'string'
-    }
-  ],
-  examples: [
-    { command: 'flo hooks teammate-idle --auto-assign true', description: 'Auto-assign tasks to idle teammate' },
-    { command: 'flo hooks teammate-idle -t worker-1 --check-task-list', description: 'Check tasks for specific teammate' }
-  ],
-  action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const autoAssign = ctx.flags.autoAssign !== false;
-    const checkTaskList = ctx.flags.checkTaskList !== false;
-    const teammateId = ctx.flags.teammateId as string;
-    const teamName = ctx.flags.teamName as string;
-
-    if (ctx.flags.format !== 'json') {
-      output.printInfo(`Teammate idle hook triggered${teammateId ? ` for: ${output.highlight(teammateId)}` : ''}`);
-    }
-
-    try {
-      const result = await callMCPTool<{
-        success: boolean;
-        teammateId: string;
-        action: 'assigned' | 'waiting' | 'notified';
-        taskAssigned?: {
-          taskId: string;
-          subject: string;
-          priority: string;
-        };
-        pendingTasks: number;
-        message: string;
-      }>('hooks_teammate-idle', {
-        autoAssign,
-        checkTaskList,
-        teammateId,
-        teamName,
-        timestamp: Date.now(),
-      });
-
-      if (ctx.flags.format === 'json') {
-        output.printJson(result);
-        return { success: true, data: result };
-      }
-
-      output.writeln();
-      if (result.action === 'assigned' && result.taskAssigned) {
-        output.printSuccess(`Task assigned: ${result.taskAssigned.subject}`);
-        output.printList([
-          `Task ID: ${result.taskAssigned.taskId}`,
-          `Priority: ${result.taskAssigned.priority}`,
-          `Pending tasks remaining: ${result.pendingTasks}`
-        ]);
-      } else if (result.action === 'waiting') {
-        output.printInfo('No pending tasks available - teammate waiting for work');
-      } else {
-        output.printInfo(`Team lead notified: ${result.message}`);
-      }
-
-      return { success: true, data: result };
-    } catch (error) {
-      // Graceful fallback - don't fail hard, just report
-      if (ctx.flags.format === 'json') {
-        output.printJson({ success: true, action: 'waiting', message: 'Teammate idle - no MCP server' });
-      } else {
-        output.printInfo('Teammate idle - awaiting task assignment');
-      }
-      return { success: true };
-    }
-  }
-};
-
-// Task Completed command - Agent Teams integration
-const taskCompletedCommand: Command = {
-  name: 'task-completed',
-  description: 'Handle task completion in Agent Teams - train patterns and notify lead',
-  options: [
-    {
-      name: 'task-id',
-      short: 'i',
-      description: 'ID of the completed task',
-      type: 'string',
-      required: true
-    },
-    {
-      name: 'train-patterns',
-      short: 'p',
-      description: 'Train neural patterns from successful task',
-      type: 'boolean',
-      default: true
-    },
-    {
-      name: 'notify-lead',
-      short: 'n',
-      description: 'Notify team lead of task completion',
-      type: 'boolean',
-      default: true
-    },
-    {
-      name: 'success',
-      short: 's',
-      description: 'Whether the task succeeded',
-      type: 'boolean',
-      default: true
-    },
-    {
-      name: 'quality',
-      short: 'q',
-      description: 'Quality score (0-1)',
-      type: 'number'
-    },
-    {
-      name: 'teammate-id',
-      short: 't',
-      description: 'ID of the teammate that completed the task',
-      type: 'string'
-    }
-  ],
-  examples: [
-    { command: 'flo hooks task-completed -i task-123 --train-patterns', description: 'Complete task and train patterns' },
-    { command: 'flo hooks task-completed -i task-456 --notify-lead --quality 0.95', description: 'Complete with quality score' }
-  ],
-  action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const taskId = ctx.args[0] || ctx.flags.taskId as string;
-    const trainPatterns = ctx.flags.trainPatterns !== false;
-    const notifyLead = ctx.flags.notifyLead !== false;
-    const success = ctx.flags.success !== false;
-    const quality = ctx.flags.quality as number;
-    const teammateId = ctx.flags.teammateId as string;
-
-    if (!taskId) {
-      output.printError('Task ID is required. Use --task-id or -i flag.');
-      return { success: false, exitCode: 1 };
-    }
-
-    if (ctx.flags.format !== 'json') {
-      output.printInfo(`Task completed: ${output.highlight(taskId)}`);
-    }
-
-    try {
-      const result = await callMCPTool<{
-        success: boolean;
-        taskId: string;
-        patternsLearned: number;
-        leadNotified: boolean;
-        metrics: {
-          duration: number;
-          quality: number;
-          learningUpdates: number;
-        };
-        nextTask?: {
-          taskId: string;
-          subject: string;
-        };
-      }>('hooks_task-completed', {
-        taskId,
-        trainPatterns,
-        notifyLead,
-        success,
-        quality,
-        teammateId,
-        timestamp: Date.now(),
-      });
-
-      if (ctx.flags.format === 'json') {
-        output.printJson(result);
-        return { success: true, data: result };
-      }
-
-      output.writeln();
-      output.printSuccess(`Task ${taskId} marked complete`);
-
-      output.writeln();
-      output.writeln(output.bold('Completion Metrics'));
-      output.printTable({
-        columns: [
-          { key: 'metric', header: 'Metric', width: 25 },
-          { key: 'value', header: 'Value', width: 20, align: 'right' }
-        ],
-        data: [
-          { metric: 'Patterns Learned', value: result.patternsLearned },
-          { metric: 'Quality Score', value: quality ? `${(quality * 100).toFixed(0)}%` : 'N/A' },
-          { metric: 'Lead Notified', value: result.leadNotified ? 'Yes' : 'No' },
-          { metric: 'Learning Updates', value: result.metrics?.learningUpdates || 0 }
-        ]
-      });
-
-      if (result.nextTask) {
-        output.writeln();
-        output.printInfo(`Next available task: ${result.nextTask.subject}`);
-      }
-
-      return { success: true, data: result };
-    } catch (error) {
-      // Graceful fallback
-      if (ctx.flags.format === 'json') {
-        output.printJson({ success: true, taskId, message: 'Task completed - patterns pending' });
-      } else {
-        output.printSuccess(`Task ${taskId} completed`);
-        if (trainPatterns) {
-          output.printInfo('Pattern training queued for next sync');
-        }
-      }
-      return { success: true };
-    }
-  }
-};
-
 // Learn subcommand — store a learning pattern
 const learnCommand: Command = {
   name: 'learn',
@@ -4414,8 +4198,6 @@ export const hooksCommand: Command = {
     preBashCommand,
     postBashCommand,
     // Agent Teams integration
-    teammateIdleCommand,
-    taskCompletedCommand,
     // Learning service commands
     learnCommand,
     patternsCommand,
@@ -4468,10 +4250,6 @@ export const hooksCommand: Command = {
       `${output.highlight('learn')}          - Store a learning pattern`,
       `${output.highlight('patterns')}       - List learned patterns`,
       `${output.highlight('consolidate')}    - Promote, prune, and deduplicate patterns`,
-      '',
-      output.bold('Agent Teams:'),
-      `${output.highlight('teammate-idle')}  - Handle idle teammate (auto-assign tasks)`,
-      `${output.highlight('task-completed')} - Handle task completion (train patterns)`
     ]);
     output.writeln();
     output.writeln('Run "flo hooks <subcommand> --help" for subcommand help');

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -835,12 +835,13 @@ const cleanupCommand: Command = {
           return { success: true, data: result };
         }
         if (!force) {
-          output.printJson({
+          const pending = {
             ...result,
             applied: false,
             reason: 'Confirmation required — re-run with --force to delete.',
-          });
-          return { success: true, data: result };
+          };
+          output.printJson(pending);
+          return { success: true, data: pending };
         }
         result = await callMCPTool<CleanupResult>('memory_cleanup', { ...cleanupArgs, apply: true });
         output.printJson(result);

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -769,12 +769,6 @@ const cleanupCommand: Command = {
       default: false
     },
     {
-      name: 'low-quality',
-      short: 'l',
-      description: 'Delete low quality patterns (threshold)',
-      type: 'number'
-    },
-    {
       name: 'namespace',
       short: 'n',
       description: 'Clean specific namespace only',
@@ -804,7 +798,7 @@ const cleanupCommand: Command = {
     output.printInfo('Analyzing memory for cleanup...');
 
     try {
-      const result = await callMCPTool<{
+      type CleanupResult = {
         dryRun: boolean;
         candidates: {
           expired: number;
@@ -822,15 +816,20 @@ const cleanupCommand: Command = {
           formatted: string;
         };
         duration: number;
-      }>('memory_cleanup', {
-        dryRun,
+      };
+
+      const cleanupArgs = {
         olderThan: ctx.flags.olderThan,
         expiredOnly: ctx.flags.expiredOnly,
-        lowQualityThreshold: ctx.flags.lowQuality,
         namespace: ctx.flags.namespace,
-      });
+      };
 
-      if (ctx.flags.format === 'json') {
+      // Two-phase by design: this first call only counts. Nothing is deleted
+      // until the apply:true call below, so declining the prompt genuinely
+      // leaves the store untouched (#1349).
+      let result = await callMCPTool<CleanupResult>('memory_cleanup', cleanupArgs);
+
+      if (ctx.flags.format === 'json' && dryRun) {
         output.printJson(result);
         return { success: true, data: result };
       }
@@ -845,33 +844,44 @@ const cleanupCommand: Command = {
         data: [
           { category: 'Expired (TTL)', count: result.candidates.expired },
           { category: 'Stale (unused)', count: result.candidates.stale },
-          { category: 'Low Quality', count: result.candidates.lowQuality },
+          { category: 'Unusable (no vector)', count: result.candidates.lowQuality },
           { category: output.bold('Total'), count: output.bold(String(result.candidates.total)) }
         ]
       });
 
-      if (!dryRun && result.candidates.total > 0 && !force) {
+      if (dryRun) return { success: true, data: result };
+
+      if (result.candidates.total === 0) {
+        output.writeln();
+        output.printInfo('Nothing to clean');
+        return { success: true, data: result };
+      }
+
+      if (!force) {
         const confirmed = await confirm({
-          message: `Delete ${result.candidates.total} entries (${result.freed.formatted})?`,
+          message: `Delete ${result.candidates.total} entries?`,
           default: false
         });
 
         if (!confirmed) {
-          output.printInfo('Cleanup cancelled');
+          output.printInfo('Cleanup cancelled — nothing was deleted');
           return { success: true, data: result };
         }
       }
 
-      if (!dryRun) {
-        output.writeln();
-        output.printSuccess(`Cleaned ${result.deleted.entries} entries`);
-        output.printList([
-          `Vectors removed: ${result.deleted.vectors}`,
-          `Patterns removed: ${result.deleted.patterns}`,
-          `Space freed: ${result.freed.formatted}`,
-          `Duration: ${result.duration}ms`
-        ]);
+      result = await callMCPTool<CleanupResult>('memory_cleanup', { ...cleanupArgs, apply: true });
+
+      if (ctx.flags.format === 'json') {
+        output.printJson(result);
+        return { success: true, data: result };
       }
+
+      output.writeln();
+      output.printSuccess(`Cleaned ${result.deleted.entries} entries`);
+      output.printList([
+        `Space freed: ${result.freed.formatted}`,
+        `Duration: ${result.duration}ms`
+      ]);
 
       return { success: true, data: result };
     } catch (error) {
@@ -907,19 +917,6 @@ const compressCommand: Command = {
       default: 'all'
     },
     {
-      name: 'quantize',
-      short: 'z',
-      description: 'Enable vector quantization (reduces memory 4-32x)',
-      type: 'boolean',
-      default: false
-    },
-    {
-      name: 'bits',
-      description: 'Quantization bits (4, 8, 16)',
-      type: 'number',
-      default: 8
-    },
-    {
       name: 'rebuild-index',
       short: 'r',
       description: 'Rebuild HNSW index after compression',
@@ -929,19 +926,17 @@ const compressCommand: Command = {
   ],
   examples: [
     { command: 'flo memory compress', description: 'Balanced compression' },
-    { command: 'flo memory compress --quantize --bits 4', description: '4-bit quantization (32x reduction)' },
-    { command: 'flo memory compress -l max -t vectors', description: 'Max compression on vectors' }
+    { command: 'flo memory compress -l max', description: 'Max compression (checkpoints the WAL first)' },
+    { command: 'flo memory compress --no-rebuild-index', description: 'Compact without dropping the HNSW index' }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
     const level = ctx.flags.level as string || 'balanced';
     const target = ctx.flags.target as string || 'all';
-    const quantize = ctx.flags.quantize as boolean;
-    const bits = ctx.flags.bits as number || 8;
     const rebuildIndex = ctx.flags.rebuildIndex as boolean ?? true;
 
     output.writeln();
     output.writeln(output.bold('Memory Compression'));
-    output.writeln(output.dim(`Level: ${level}, Target: ${target}, Quantize: ${quantize ? `${bits}-bit` : 'no'}`));
+    output.writeln(output.dim(`Level: ${level}, Target: ${target}`));
     output.writeln();
 
     const spinner = output.createSpinner({ text: 'Analyzing current storage...', spinner: 'dots' });
@@ -971,16 +966,14 @@ const compressCommand: Command = {
           indexRebuilt: boolean;
         };
         performance: {
-          searchLatencyBefore: number;
-          searchLatencyAfter: number;
+          searchLatencyBefore: number | null;
+          searchLatencyAfter: number | null;
           searchSpeedup: string;
         };
         duration: number;
       }>('memory_compress', {
         level,
         target,
-        quantize,
-        bits,
         rebuildIndex,
       });
 
@@ -1014,7 +1007,6 @@ const compressCommand: Command = {
         [
           `Compression Ratio: ${result.compression.ratio.toFixed(2)}x`,
           `Space Saved: ${result.compression.formattedSaved}`,
-          `Quantization: ${result.compression.quantizationApplied ? `Yes (${bits}-bit)` : 'No'}`,
           `Index Rebuilt: ${result.compression.indexRebuilt ? 'Yes' : 'No'}`,
           `Duration: ${(result.duration / 1000).toFixed(1)}s`
         ].join('\n'),
@@ -1022,10 +1014,14 @@ const compressCommand: Command = {
       );
 
       if (result.performance) {
+        // A probe that threw reports null, not 0 — "unavailable" beats
+        // rendering a failure as 0.00ms (infinitely fast).
+        const fmtLatency = (ms: number | null): string =>
+          ms === null ? 'unavailable' : `${ms.toFixed(2)}ms`;
         output.writeln();
         output.writeln(output.bold('Performance Impact'));
         output.printList([
-          `Search latency: ${result.performance.searchLatencyBefore.toFixed(2)}ms → ${result.performance.searchLatencyAfter.toFixed(2)}ms`,
+          `Search latency: ${fmtLatency(result.performance.searchLatencyBefore)} → ${fmtLatency(result.performance.searchLatencyAfter)}`,
           `Speedup: ${output.success(result.performance.searchSpeedup)}`
         ]);
       }
@@ -1177,12 +1173,24 @@ const importCommand: Command = {
           patterns: number;
         };
         skipped: number;
+        failed: number;
+        errors: string[];
         duration: number;
       }>('memory_import', {
         inputPath,
         merge: ctx.flags.merge ?? true,
         namespace: ctx.flags.namespace,
       });
+
+      // An import where nothing landed is not a success, and entries the
+      // store refused must not be reported as skipped duplicates (#1349).
+      if (result.failed > 0) {
+        output.printError(`Import failed for ${result.failed} entr${result.failed === 1 ? 'y' : 'ies'}`);
+        for (const err of result.errors ?? []) output.printError(`  ${err}`);
+        if (result.imported.entries === 0) {
+          return { success: false, exitCode: 1, data: result };
+        }
+      }
 
       output.printSuccess(`Imported from ${result.inputPath}`);
       output.printList([

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -808,8 +808,6 @@ const cleanupCommand: Command = {
         };
         deleted: {
           entries: number;
-          vectors: number;
-          patterns: number;
         };
         freed: {
           bytes: number;
@@ -829,7 +827,22 @@ const cleanupCommand: Command = {
       // leaves the store untouched (#1349).
       let result = await callMCPTool<CleanupResult>('memory_cleanup', cleanupArgs);
 
-      if (ctx.flags.format === 'json' && dryRun) {
+      // JSON output implies a non-interactive caller, so never prompt on this
+      // path: report the candidates and require --force to actually delete.
+      if (ctx.flags.format === 'json') {
+        if (dryRun || result.candidates.total === 0) {
+          output.printJson(result);
+          return { success: true, data: result };
+        }
+        if (!force) {
+          output.printJson({
+            ...result,
+            applied: false,
+            reason: 'Confirmation required — re-run with --force to delete.',
+          });
+          return { success: true, data: result };
+        }
+        result = await callMCPTool<CleanupResult>('memory_cleanup', { ...cleanupArgs, apply: true });
         output.printJson(result);
         return { success: true, data: result };
       }
@@ -871,12 +884,9 @@ const cleanupCommand: Command = {
 
       result = await callMCPTool<CleanupResult>('memory_cleanup', { ...cleanupArgs, apply: true });
 
-      if (ctx.flags.format === 'json') {
-        output.printJson(result);
-        return { success: true, data: result };
-      }
-
       output.writeln();
+      // Report what the apply call actually removed, not the count the user
+      // was shown — an entry can expire between the two phases.
       output.printSuccess(`Cleaned ${result.deleted.entries} entries`);
       output.printList([
         `Space freed: ${result.freed.formatted}`,

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -95,7 +95,7 @@ async function getSystemStatus(): Promise<{
     entries: number;
     size: string;
     backend: string;
-    performance: { searchTime: number; cacheHitRate: number };
+    performance: { searchTime: number | null };
   };
   tasks: {
     total: number;
@@ -131,13 +131,16 @@ async function getSystemStatus(): Promise<{
       // MCP not running
     }
 
-    // Get memory status
+    // #1349 — this used to call `memory_stats`, which returns none of
+    // `entries` / `size` / `performance`; dereferencing `.performance` threw
+    // and dropped the whole command into its all-zeros fallback. Use the
+    // detailed-stats tool, whose shape this actually needs.
     const memoryStatus = await callMCPTool<{
       entries: number;
       size: number;
       backend: string;
-      performance: { avgSearchTime: number; cacheHitRate: number };
-    }>('memory_stats', {});
+      performance: { avgSearchTime: number | null };
+    }>('memory_detailed-stats', {});
 
     // Get task status
     const taskStatus = await callMCPTool<{
@@ -168,8 +171,7 @@ async function getSystemStatus(): Promise<{
         size: formatBytes(memoryStatus.size),
         backend: memoryStatus.backend,
         performance: {
-          searchTime: memoryStatus.performance.avgSearchTime,
-          cacheHitRate: memoryStatus.performance.cacheHitRate
+          searchTime: memoryStatus.performance.avgSearchTime
         }
       },
       tasks: taskStatus,
@@ -195,7 +197,7 @@ async function getSystemStatus(): Promise<{
         entries: 0,
         size: '0 B',
         backend: 'none',
-        performance: { searchTime: 0, cacheHitRate: 0 }
+        performance: { searchTime: null }
       },
       tasks: { total: 0, pending: 0, running: 0, completed: 0, failed: 0 },
       performance: {
@@ -280,8 +282,8 @@ function displayStatus(status: Awaited<ReturnType<typeof getSystemStatus>>): voi
       { property: 'Backend', value: status.memory.backend },
       { property: 'Entries', value: status.memory.entries },
       { property: 'Size', value: status.memory.size },
-      { property: 'Search Time', value: `${status.memory.performance.searchTime.toFixed(2)}ms` },
-      { property: 'Cache Hit Rate', value: `${(status.memory.performance.cacheHitRate * 100).toFixed(1)}%` }
+      // null means the probe never ran — say so rather than print 0.00ms.
+      { property: 'Search Time', value: status.memory.performance.searchTime === null ? 'not measured' : `${status.memory.performance.searchTime.toFixed(2)}ms` }
     ]
   });
   output.writeln();
@@ -550,7 +552,7 @@ const tasksCommand: Command = {
     try {
       const result = await callMCPTool<{
         tasks: Array<{
-          id: string;
+          taskId: string;
           type: string;
           status: string;
           priority: string;
@@ -584,7 +586,9 @@ const tasksCommand: Command = {
           { key: 'progress', header: 'Progress', width: 10 }
         ],
         data: result.tasks.map(t => ({
-          id: t.id,
+          // task_list projects the coordinator id as `taskId`; reading `id`
+          // left the ID column blank on every row (#1349).
+          id: t.taskId,
           type: t.type,
           status: formatHealth(t.status),
           priority: t.priority,
@@ -617,12 +621,11 @@ const memoryCommand: Command = {
         size: number;
         namespaces: Array<{ name: string; entries: number }>;
         performance: {
-          avgSearchTime: number;
-          avgWriteTime: number;
-          cacheHitRate: number;
+          avgSearchTime: number | null;
           hnswEnabled: boolean;
+          indexedVectors: number;
         };
-      }>('memory_detailed-stats', {});
+      }>('memory_detailed-stats', { measureLatency: true });
 
       if (ctx.flags.format === 'json') {
         output.printJson(result);
@@ -642,7 +645,7 @@ const memoryCommand: Command = {
           { property: 'Backend', value: result.backend },
           { property: 'Total Entries', value: result.entries.toLocaleString() },
           { property: 'Storage Size', value: formatBytes(result.size) },
-          { property: 'HNSW Index', value: result.performance.hnswEnabled ? 'Enabled' : 'Disabled' }
+          { property: 'HNSW Index', value: result.performance.hnswEnabled ? 'Active' : 'Not built (search falls back to scan)' }
         ]
       });
 
@@ -654,9 +657,10 @@ const memoryCommand: Command = {
           { key: 'value', header: 'Value', width: 20, align: 'right' }
         ],
         data: [
-          { metric: 'Avg Search Time', value: `${result.performance.avgSearchTime.toFixed(2)}ms` },
-          { metric: 'Avg Write Time', value: `${result.performance.avgWriteTime.toFixed(2)}ms` },
-          { metric: 'Cache Hit Rate', value: `${(result.performance.cacheHitRate * 100).toFixed(1)}%` }
+          // Only metrics the store actually measures — write latency and
+          // cache hit rate are not tracked anywhere, so they are not shown.
+          { metric: 'Avg Search Time', value: result.performance.avgSearchTime === null ? 'unavailable' : `${result.performance.avgSearchTime.toFixed(2)}ms` },
+          { metric: 'Indexed Vectors', value: result.performance.indexedVectors.toLocaleString() }
         ]
       });
 

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -703,14 +703,25 @@ const retryCommand: Command = {
 
     try {
       const result = await callMCPTool<{
+        success: boolean;
         taskId: string;
         newTaskId: string;
         previousStatus: string;
         status: string;
+        error?: string;
       }>('task_retry', {
         taskId,
         resetState
       });
+
+      // The handler reports an unknown/unretryable task by returning
+      // success:false, not by throwing — so the catch below never sees it.
+      // Without this check, `task retry does-not-exist` printed
+      // "Task retried / New task ID: undefined" and exited 0 (#1349).
+      if (!result.success) {
+        output.printError(`Failed to retry task: ${result.error ?? 'unknown error'}`);
+        return { success: false, exitCode: 1, data: result };
+      }
 
       output.writeln();
       output.printSuccess(`Task ${taskId} retried`);

--- a/src/cli/mcp-client.ts
+++ b/src/cli/mcp-client.ts
@@ -26,6 +26,11 @@ import { performanceTools } from './mcp-tools/performance-tools.js';
 import { githubTools } from './mcp-tools/github-tools.js';
 import { coordinationTools } from './mcp-tools/coordination-tools.js';
 import { moflodbTools } from './mcp-tools/moflodb-tools.js';
+// #1349 — handlers for tool names shipped CLI commands were already calling.
+import { progressTools } from './mcp-tools/progress-tools.js';
+import { coverageTools } from './mcp-tools/coverage-tools.js';
+import { memoryAdminTools } from './mcp-tools/memory-admin-tools.js';
+import { analysisTools } from './mcp-tools/analysis-tools.js';
 import { errorDetail } from './shared/utils/error-detail.js';
 
 /**
@@ -58,6 +63,10 @@ registerTools([
   ...githubTools,
   ...coordinationTools,
   ...moflodbTools,
+  ...progressTools,
+  ...coverageTools,
+  ...memoryAdminTools,
+  ...analysisTools,
 ]);
 
 /**

--- a/src/cli/mcp-tools/analysis-tools.ts
+++ b/src/cli/mcp-tools/analysis-tools.ts
@@ -1,0 +1,116 @@
+/**
+ * Analysis + MCP-introspection MCP Tools for CLI
+ *
+ * `analyze_diff` (called by `flo analyze diff`) and `mcp_status` (called by
+ * `flo status`) were both invoked by shipped commands but never registered,
+ * so each died with `MCP tool not found` (#1349).
+ *
+ * `analyze_diff` composes the existing, tested `movector/diff-classifier`
+ * helpers; `mcp_status` reuses the same PID/lock probe `flo mcp status`
+ * already relies on, so it reports whether the server is genuinely up rather
+ * than the hardcoded "not running" the status dashboard used to print.
+ *
+ * @module v3/cli/mcp-tools/analysis-tools
+ */
+
+import type { MCPTool } from './types.js';
+
+/** Path fragments that make a change security- or contract-sensitive. */
+const SECURITY_PATTERNS = /security|auth|crypto|secret|token|password|credential/i;
+const BREAKING_PATTERNS = /migration|schema|\bapi\b|public|index\.ts$|types?\.ts$/i;
+const TEST_PATTERNS = /\.(test|spec)\.[cm]?[jt]sx?$|__tests__|\btests?\//i;
+
+export const analysisTools: MCPTool[] = [
+  {
+    name: 'analyze_diff',
+    description: 'Analyse a git diff for risk, change classification, and suggested reviewers',
+    category: 'analysis',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Git ref to diff against (default HEAD)' },
+      },
+    },
+    handler: async (input) => {
+      const ref = String(input.ref ?? 'HEAD');
+      const {
+        getGitDiffNumstatAsync,
+        assessFileRisk,
+        assessOverallRisk,
+        classifyDiff,
+        suggestReviewers,
+      } = await import('../movector/diff-classifier.js');
+
+      const files = await getGitDiffNumstatAsync(ref);
+      const fileRisks = files.map(assessFileRisk);
+      const risk = assessOverallRisk(files, fileRisks);
+      const classification = classifyDiff(files);
+
+      const totalChanges = files.reduce((sum, f) => sum + f.additions + f.deletions, 0);
+      const testFiles = files.filter(f => TEST_PATTERNS.test(f.path));
+      const sourceFiles = files.filter(f => !TEST_PATTERNS.test(f.path));
+
+      return {
+        ref,
+        timestamp: new Date().toISOString(),
+        files: files.map(f => ({
+          path: f.path,
+          status: f.status,
+          additions: f.additions,
+          deletions: f.deletions,
+          binary: f.binary,
+        })),
+        risk: {
+          overall: risk.overall,
+          score: risk.score,
+          breakdown: {
+            fileCount: files.length,
+            totalChanges,
+            highRiskFiles: fileRisks
+              .filter(r => r.risk === 'high' || r.risk === 'critical')
+              .map(r => r.file),
+            securityConcerns: files
+              .filter(f => SECURITY_PATTERNS.test(f.path))
+              .map(f => f.path),
+            breakingChanges: files
+              .filter(f => BREAKING_PATTERNS.test(f.path))
+              .map(f => f.path),
+            testCoverage: sourceFiles.length === 0
+              ? 'no source changes'
+              : testFiles.length === 0
+                ? 'no test files changed'
+                : `${testFiles.length} test file(s) alongside ${sourceFiles.length} source file(s)`,
+          },
+        },
+        classification,
+        fileRisks: fileRisks.map(r => ({
+          path: r.file,
+          risk: r.risk,
+          score: r.score,
+          reasons: r.reasons,
+        })),
+        recommendedReviewers: suggestReviewers(files, fileRisks),
+      };
+    },
+  },
+  {
+    name: 'mcp_status',
+    description: 'Report whether the moflo MCP server is running, and on which transport',
+    category: 'system',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async () => {
+      const { getMCPServerStatus } = await import('../mcp-server.js');
+      const status = await getMCPServerStatus();
+      return {
+        running: status.running === true,
+        transport: status.transport ?? 'stdio',
+        pid: status.pid ?? null,
+      };
+    },
+  },
+];
+
+export default analysisTools;

--- a/src/cli/mcp-tools/coverage-tools.ts
+++ b/src/cli/mcp-tools/coverage-tools.ts
@@ -1,0 +1,230 @@
+/**
+ * Coverage MCP Tools for CLI
+ *
+ * The wrapper `src/cli/movector/coverage-router.ts` has been waiting for since
+ * it grew a section literally headed "Additional Exports for MCP Tools
+ * (coverage-tools.ts)". That file was never written, so `flo hooks
+ * coverage-gaps|coverage-route|coverage-suggest` died with `MCP tool not
+ * found` on every invocation (#1349).
+ *
+ * The router owns all the analysis; these handlers only translate its
+ * file-shaped results into the gap-shaped records the CLI renderers read
+ * (`filePath` / `coveragePercent` / `gapType` / `suggestedAgents`).
+ *
+ * @module v3/cli/mcp-tools/coverage-tools
+ */
+
+import type { MCPTool } from './types.js';
+import { findProjectRoot } from '../services/project-root.js';
+import { classifyGap, type GapSeverity } from '../movector/coverage-router.js';
+
+function gapReason(file: string, coverage: number, threshold: number, gapType: GapSeverity): string {
+  return `${file} is at ${coverage.toFixed(1)}% line coverage, ${(threshold - coverage).toFixed(1)} points below the ${threshold}% threshold (${gapType})`;
+}
+
+async function router() {
+  return import('../movector/coverage-router.js');
+}
+
+interface Summary {
+  totalFiles: number;
+  overallLineCoverage: number;
+  overallBranchCoverage: number;
+  filesBelowThreshold: number;
+}
+
+/**
+ * With no coverage artifact there is nothing to summarize, so `summary` is
+ * null rather than a block of zeros. Zeros here rendered as "Line Coverage:
+ * 0.0% / Below Threshold: 0 files" — a measurement of a file that was never
+ * read, printed directly beneath "No coverage report" (#1349).
+ */
+async function summarize(threshold: number, projectRoot: string): Promise<{
+  summary: Summary | null;
+  found: boolean;
+}> {
+  const { loadCoverageReport } = await router();
+  const report = await loadCoverageReport(projectRoot);
+  if (!report) {
+    return { found: false, summary: null };
+  }
+  return {
+    found: true,
+    summary: {
+      totalFiles: report.byFile.length,
+      overallLineCoverage: report.byType.line,
+      overallBranchCoverage: report.byType.branch,
+      filesBelowThreshold: report.byFile.filter(f => f.lineCoverage < threshold).length,
+    },
+  };
+}
+
+export const coverageTools: MCPTool[] = [
+  {
+    name: 'hooks_coverage-gaps',
+    description: 'List every file below the coverage threshold, with a suggested test agent per file',
+    category: 'hooks',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        threshold: { type: 'number', description: 'Coverage percentage to measure gaps against (default 80)' },
+        groupByAgent: { type: 'boolean', description: 'Group the gap files by suggested agent (default true)' },
+      },
+    },
+    handler: async (input) => {
+      const threshold = typeof input.threshold === 'number' ? input.threshold : 80;
+      const projectRoot = findProjectRoot();
+      const { coverageGaps } = await router();
+
+      const result = await coverageGaps({
+        projectRoot,
+        threshold,
+        groupByAgent: input.groupByAgent !== false,
+      });
+      const { summary, found } = await summarize(threshold, projectRoot);
+
+      return {
+        success: true,
+        gaps: result.gaps.map(g => {
+          const gapType = classifyGap(g.gap);
+          return {
+            filePath: g.file,
+            coveragePercent: g.currentCoverage,
+            gapType,
+            complexity: g.priority,
+            priority: g.priority,
+            suggestedAgents: [g.suggestedAgent],
+            reason: gapReason(g.file, g.currentCoverage, threshold, gapType),
+          };
+        }),
+        summary: summary ? { ...summary, coverageThreshold: threshold } : null,
+        agentAssignments: result.byAgent,
+        movectorAvailable: found,
+      };
+    },
+  },
+  {
+    name: 'hooks_coverage-route',
+    description: 'Route a task to an agent using the project coverage report to prioritise the weakest files',
+    category: 'hooks',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task: { type: 'string', description: 'The task to route' },
+        threshold: { type: 'number', description: 'Coverage percentage to measure gaps against (default 80)' },
+        useNativeBackend: { type: 'boolean', description: 'Prefer the native coverage backend when present' },
+      },
+      required: ['task'],
+    },
+    handler: async (input) => {
+      const task = String(input.task ?? '');
+      const threshold = typeof input.threshold === 'number' ? input.threshold : 80;
+      const projectRoot = findProjectRoot();
+      const { coverageRoute, coverageGaps } = await router();
+
+      const route = await coverageRoute(task, {
+        projectRoot,
+        threshold,
+        useNativeBackend: input.useNativeBackend === true,
+      });
+      const gapsResult = await coverageGaps({ projectRoot, threshold });
+      const { summary, found } = await summarize(threshold, projectRoot);
+
+      const gaps = gapsResult.gaps.map(g => {
+        const gapType = classifyGap(g.gap);
+        return {
+          filePath: g.file,
+          coveragePercent: g.currentCoverage,
+          gapType,
+          priority: g.priority,
+          suggestedAgents: [g.suggestedAgent],
+          reason: gapReason(g.file, g.currentCoverage, threshold, gapType),
+        };
+      });
+
+      // The primary agent is the one owning the most gap files. With no
+      // coverage report there is no basis for a routing decision, so return
+      // null instead of defaulting to 'tester' — a confident-looking answer
+      // derived from nothing is what #1349 is about.
+      const ranked = Object.entries(gapsResult.byAgent).sort((a, b) => b[1].length - a[1].length);
+      const primaryAgent = found ? ranked[0]?.[0] ?? null : null;
+      const criticalGaps = gaps.filter(g => g.gapType === 'critical').length;
+
+      return {
+        success: true,
+        task,
+        coverageAware: found,
+        gaps,
+        routing: {
+          primaryAgent,
+          confidence: found && primaryAgent ? Math.min(1, route.impactScore || 0.5) : 0,
+          reason: found && primaryAgent
+            ? `${route.action}: ${primaryAgent} owns ${ranked[0]?.[1].length ?? 0} of ${gaps.length} gap files`
+            : 'No coverage report found — routing is not coverage-aware',
+          coverageImpact: summary
+            ? `${criticalGaps} critical gap(s) across ${summary.filesBelowThreshold} file(s) below ${threshold}%`
+            : 'unknown',
+        },
+        suggestions: route.gaps.flatMap(g => g.suggestedTests).slice(0, 5),
+        metrics: summary
+          ? {
+              filesAnalyzed: summary.totalFiles,
+              totalGaps: gaps.length,
+              criticalGaps,
+              avgCoverage: summary.overallLineCoverage,
+            }
+          : null,
+      };
+    },
+  },
+  {
+    name: 'hooks_coverage-suggest',
+    description: 'Suggest coverage improvements for files under a path, ranked by priority',
+    category: 'hooks',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Path prefix to analyse' },
+        threshold: { type: 'number', description: 'Coverage percentage to measure gaps against (default 80)' },
+        limit: { type: 'number', description: 'Maximum suggestions to return (default 20)' },
+      },
+      required: ['path'],
+    },
+    handler: async (input) => {
+      const path = String(input.path ?? '');
+      const threshold = typeof input.threshold === 'number' ? input.threshold : 80;
+      const projectRoot = findProjectRoot();
+      const { coverageSuggest } = await router();
+
+      const result = await coverageSuggest(path, {
+        projectRoot,
+        threshold,
+        limit: typeof input.limit === 'number' ? input.limit : 20,
+      });
+      const { summary, found } = await summarize(threshold, projectRoot);
+
+      return {
+        success: true,
+        path,
+        suggestions: result.suggestions.map(s => {
+          const gapType = classifyGap(s.gap);
+          return {
+            filePath: s.file,
+            coveragePercent: s.currentCoverage,
+            gapType,
+            priority: s.priority,
+            suggestedAgents: [],
+            reason: s.suggestedTests.length > 0
+              ? s.suggestedTests.join('; ')
+              : gapReason(s.file, s.currentCoverage, threshold, gapType),
+          };
+        }),
+        summary,
+        prioritizedFiles: result.suggestions.map(s => s.file),
+        movectorAvailable: found,
+      };
+    },
+  },
+];
+
+export default coverageTools;

--- a/src/cli/mcp-tools/hive-mind-tools.ts
+++ b/src/cli/mcp-tools/hive-mind-tools.ts
@@ -941,4 +941,81 @@ export const hiveMindTools: MCPTool[] = [
       return { action, error: 'Unknown action' };
     },
   },
+  {
+    // #1349 — `flo hive-mind task` called this and it was never registered.
+    // Protected surface (CLAUDE.md): the task is submitted through the shared
+    // UnifiedSwarmCoordinator, and a consensus request goes out over the
+    // MessageBus — no synthetic task IDs, no file-based store.
+    name: 'hive-mind_task',
+    description: 'Submit a task to the hive, optionally gated on worker consensus',
+    category: 'hive-mind',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        description: { type: 'string', description: 'What the hive should do' },
+        priority: { type: 'string', description: 'critical | high | normal | low | background' },
+        requireConsensus: { type: 'boolean', description: 'Require a consensus vote before execution' },
+        timeout: { type: 'number', description: 'Task timeout in milliseconds' },
+      },
+      required: ['description'],
+    },
+    handler: async (input) => {
+      if (!hiveState.initialized) {
+        return { error: 'Hive-mind not initialized. Run hive-mind/init first.' };
+      }
+
+      const description = String(input.description ?? '').trim();
+      if (!description) {
+        return { error: 'description must be a non-empty string' };
+      }
+
+      const priority = String(input.priority ?? 'normal');
+      const requiresConsensus = input.requireConsensus === true;
+      const timeoutMs = typeof input.timeout === 'number' && input.timeout > 0
+        ? input.timeout
+        : SWARM_CONSTANTS.DEFAULT_TASK_TIMEOUT_MS;
+
+      const coordinator = await getSwarmCoordinator();
+      const taskId = await coordinator.submitTask({
+        type: 'coordination',
+        name: `hive-task-${randomBytes(4).toString('hex')}`,
+        description,
+        priority: priority as never,
+        dependencies: [],
+        input: null,
+        timeoutMs,
+        retries: 0,
+        maxRetries: 3,
+        metadata: { hiveId: hiveState.hiveId, requiresConsensus },
+      });
+
+      if (requiresConsensus) {
+        const bus = await getMessageBus();
+        await bus.broadcastUnified({
+          type: 'consensus',
+          from: hiveState.queen?.agentId ?? hiveState.hiveId,
+          payload: { taskId, description, priority },
+          content: `Consensus requested for task ${taskId}: ${description}`,
+          namespace: HIVE_NS,
+          priority: 'high',
+          requiresAck: false,
+          ttlMs: CONSENSUS_TTL_MS,
+        });
+      }
+
+      const created = coordinator.getTask(taskId);
+      // Report who the coordinator actually assigned, not who might pick it up.
+      const assignedTo = created?.assignedTo ? [created.assignedTo.id] : [];
+
+      return {
+        taskId,
+        description,
+        status: created?.status ?? 'queued',
+        assignedTo,
+        priority,
+        requiresConsensus,
+        estimatedTime: `${Math.round(timeoutMs / 1000)}s timeout`,
+      };
+    },
+  },
 ];

--- a/src/cli/mcp-tools/memory-admin-tools.ts
+++ b/src/cli/mcp-tools/memory-admin-tools.ts
@@ -1,0 +1,591 @@
+/**
+ * Memory administration MCP Tools for CLI
+ *
+ * `memory_export` / `memory_import` / `memory_cleanup` / `memory_compress` /
+ * `memory_detailed-stats` were called by `flo memory export|import|cleanup|
+ * compress` and `flo status memory` but never registered, so each command
+ * printed its progress banner and then died with `MCP tool not found` (#1349).
+ *
+ * Every number these handlers report is measured, not modelled: byte counts
+ * come from `statSync` on the real artifact, entry counts from the rows
+ * actually written, and search latency from a timed query. Deletes route
+ * through `deleteEntry` so they honour the daemon single-writer path (#981)
+ * rather than issuing raw SQL against a database another process may own.
+ *
+ * @module v3/cli/mcp-tools/memory-admin-tools
+ */
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type { MCPTool } from './types.js';
+import { BACKEND_LABEL } from '../memory/database-provider.js';
+// Every handler here reads or writes the store, so each must pass through the
+// same init/migration gate the core memory tools use. Without it, a project
+// whose DB has not been created yet has no `memory_entries` table and writes
+// silently no-op — which is how an import "succeeded" against nothing.
+import { ensureInitialized } from './memory-tools.js';
+import { memoryDbPath } from '../services/moflo-paths.js';
+import { resolveStateRoot } from '../services/project-root.js';
+
+interface ExportedEntry {
+  key: string;
+  namespace: string;
+  content: string;
+  tags: string[];
+  metadata: string | null;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number | null;
+  embedding: string | null;
+}
+
+function dbPath(): string {
+  return memoryDbPath(resolveStateRoot());
+}
+
+function dbSizeBytes(): number {
+  const path = dbPath();
+  return existsSync(path) ? statSync(path).size : 0;
+}
+
+// NOTE: a fourth copy of this (commands/status.ts:71, commands/embeddings.ts:503,
+// plugins/store/ipfs-client.ts:385 — the last already exported). Consolidating
+// them is a cross-cutting change with its own output-format risk, so it is left
+// for a follow-up rather than folded into this fix.
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 2)} ${units[i]}`;
+}
+
+async function openDb() {
+  const { openDaemonDatabase } = await import('../memory/daemon-backend.js');
+  return openDaemonDatabase(dbPath());
+}
+
+/** Run a read-only query and return rows as arrays of primitives. */
+async function query(sql: string): Promise<unknown[][]> {
+  if (!existsSync(dbPath())) return [];
+  const db = await openDb();
+  try {
+    const result = db.exec(sql);
+    return result[0]?.values ?? [];
+  } finally {
+    db.close();
+  }
+}
+
+function sqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Read active entries for export.
+ *
+ * `withEmbeddings` is a cost lever, not a formatting one: a 384-dim vector
+ * serializes to ~8 KB, so selecting the column for a CSV or a
+ * `includeVectors:false` export would materialize hundreds of MB on a large
+ * store purely to discard it.
+ */
+async function readAllEntries(namespace?: string, withEmbeddings = true): Promise<ExportedEntry[]> {
+  const where = namespace
+    ? `WHERE status = 'active' AND namespace = ${sqlString(namespace)}`
+    : `WHERE status = 'active'`;
+  const embeddingCol = withEmbeddings ? 'embedding' : 'NULL AS embedding';
+  const rows = await query(
+    `SELECT key, namespace, content, tags, metadata, created_at, updated_at, expires_at, ${embeddingCol} ` +
+    `FROM memory_entries ${where} ORDER BY namespace, key`
+  );
+  return rows.map(r => ({
+    key: String(r[0]),
+    namespace: String(r[1]),
+    content: String(r[2] ?? ''),
+    tags: parseTags(r[3]),
+    metadata: r[4] == null ? null : String(r[4]),
+    createdAt: Number(r[5] ?? 0),
+    updatedAt: Number(r[6] ?? 0),
+    expiresAt: r[7] == null ? null : Number(r[7]),
+    embedding: r[8] == null ? null : String(r[8]),
+  }));
+}
+
+function parseTags(raw: unknown): string[] {
+  if (raw == null) return [];
+  try {
+    const parsed = JSON.parse(String(raw));
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+function toCsv(entries: ExportedEntry[]): string {
+  const cell = (v: unknown): string => `"${String(v ?? '').replace(/"/g, '""')}"`;
+  const header = ['key', 'namespace', 'content', 'tags', 'createdAt', 'updatedAt'];
+  const lines = [header.join(',')];
+  for (const e of entries) {
+    lines.push([
+      cell(e.key), cell(e.namespace), cell(e.content),
+      cell(e.tags.join('|')), cell(e.createdAt), cell(e.updatedAt),
+    ].join(','));
+  }
+  // LF on every platform, deliberately (Rule #1 item 4): a fixed terminator
+  // keeps an export byte-identical across Windows/macOS/Linux, and every CSV
+  // reader accepts LF. Platform EOL here would make the same store hash
+  // differently per OS.
+  return lines.join('\n') + '\n';
+}
+
+/** `30d`, `12h`, `90m` → milliseconds. Returns null when unparseable. */
+function parseDuration(raw: unknown): number | null {
+  if (raw == null) return null;
+  const m = /^(\d+)\s*([smhdw])$/i.exec(String(raw).trim());
+  if (!m) return null;
+  const n = Number(m[1]);
+  const unit = m[2].toLowerCase();
+  const scale: Record<string, number> = {
+    s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000,
+  };
+  return n * scale[unit];
+}
+
+export const memoryAdminTools: MCPTool[] = [
+  {
+    name: 'memory_export',
+    description: 'Export memory entries to a JSON or CSV file on disk',
+    category: 'memory',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        outputPath: { type: 'string', description: 'File to write' },
+        format: { type: 'string', description: 'json (default) or csv' },
+        namespace: { type: 'string', description: 'Export only this namespace' },
+        includeVectors: { type: 'boolean', description: 'Include embeddings in a JSON export (default true)' },
+      },
+      required: ['outputPath'],
+    },
+    handler: async (input) => {
+      await ensureInitialized();
+      const outputPath = resolve(String(input.outputPath ?? ''));
+      const format = String(input.format ?? 'json').toLowerCase();
+      const includeVectors = input.includeVectors !== false;
+      const namespace = input.namespace ? String(input.namespace) : undefined;
+
+      // CSV has no column for a vector, so neither path needs the bytes.
+      const wantVectors = includeVectors && format !== 'csv';
+      const entries = await readAllEntries(namespace, wantVectors);
+      const vectors = entries.filter(e => e.embedding != null).length;
+
+      const dir = dirname(outputPath);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+      if (format === 'csv') {
+        writeFileSync(outputPath, toCsv(entries), 'utf8');
+      } else {
+        const payload = {
+          version: 1,
+          backend: BACKEND_LABEL,
+          exportedAt: new Date().toISOString(),
+          namespace: namespace ?? null,
+          entries,
+        };
+        writeFileSync(outputPath, JSON.stringify(payload, null, 2), 'utf8');
+      }
+
+      return {
+        outputPath,
+        format,
+        exported: {
+          entries: entries.length,
+          // Counted from the rows actually written, so a CSV or a
+          // vector-less export reports 0 because 0 landed.
+          vectors,
+        },
+        fileSize: formatBytes(statSync(outputPath).size),
+      };
+    },
+  },
+  {
+    name: 'memory_import',
+    description: 'Import memory entries from a file written by memory_export',
+    category: 'memory',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        inputPath: { type: 'string', description: 'File to read' },
+        merge: { type: 'boolean', description: 'Skip keys that already exist instead of overwriting (default true)' },
+        namespace: { type: 'string', description: 'Override the namespace every entry is imported into' },
+      },
+      required: ['inputPath'],
+    },
+    handler: async (input) => {
+      await ensureInitialized();
+      const started = Date.now();
+      const inputPath = resolve(String(input.inputPath ?? ''));
+      if (!existsSync(inputPath)) {
+        throw new Error(`Import file not found: ${inputPath}`);
+      }
+      const merge = input.merge !== false;
+      const overrideNs = input.namespace ? String(input.namespace) : undefined;
+
+      const parsed = JSON.parse(readFileSync(inputPath, 'utf8')) as {
+        entries?: Array<Partial<ExportedEntry>>;
+      };
+      const incoming = Array.isArray(parsed.entries) ? parsed.entries : [];
+
+      const { storeEntry, getEntry } = await import('../memory/memory-initializer.js');
+
+      let entries = 0;
+      let vectors = 0;
+      let skipped = 0;
+      // Kept apart from `skipped` on purpose: an entry the store refused is
+      // not a duplicate, and folding the two together is how a wholly failed
+      // import reads as "3 duplicates skipped" (#1349).
+      let failed = 0;
+      const errors: string[] = [];
+
+      for (const e of incoming) {
+        if (!e.key) {
+          failed++;
+          errors.push('entry with no key');
+          continue;
+        }
+        const namespace = overrideNs ?? e.namespace ?? 'default';
+
+        if (merge) {
+          const existing = await getEntry({ key: e.key, namespace });
+          if (existing.found) { skipped++; continue; }
+        }
+
+        let precomputedEmbedding: number[] | undefined;
+        if (e.embedding) {
+          try {
+            const vec = JSON.parse(e.embedding);
+            if (Array.isArray(vec) && vec.length > 0) precomputedEmbedding = vec.map(Number);
+          } catch {
+            // Corrupt vector in the dump — import the text, regenerate later.
+          }
+        }
+
+        const result = await storeEntry({
+          key: e.key,
+          value: String(e.content ?? ''),
+          namespace,
+          tags: e.tags,
+          metadata: e.metadata ?? undefined,
+          precomputedEmbedding,
+          // `generateEmbeddingFlag` gates the whole embedding branch, not just
+          // the generate-vs-reuse choice: with it false, storeEntry writes a
+          // NULL embedding and ignores `precomputedEmbedding` entirely. It
+          // must stay true for a dumped vector to survive the round trip.
+          generateEmbeddingFlag: true,
+          upsert: true,
+        });
+
+        if (result.success) {
+          entries++;
+          // Count what storeEntry reports it persisted, never what we sent.
+          if (result.embedding) vectors++;
+        } else {
+          failed++;
+          if (errors.length < 5) {
+            errors.push(`${namespace}/${e.key}: ${result.error ?? 'store failed'}`);
+          }
+        }
+      }
+
+      return {
+        inputPath,
+        imported: { entries, vectors },
+        skipped,
+        failed,
+        errors,
+        duration: Date.now() - started,
+      };
+    },
+  },
+  {
+    name: 'memory_cleanup',
+    description: 'Find and optionally delete expired, stale, or unusable memory entries',
+    category: 'memory',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        apply: { type: 'boolean', description: 'Actually delete. Omit (the default) to report candidates only.' },
+        dryRun: { type: 'boolean', description: 'Deprecated alias — cleanup is dry by default; pass apply:true to delete.' },
+        olderThan: { type: 'string', description: 'Age cutoff for stale/unusable entries, e.g. "30d"' },
+        expiredOnly: { type: 'boolean', description: 'Only consider TTL-expired entries' },
+        namespace: { type: 'string', description: 'Restrict cleanup to one namespace' },
+      },
+    },
+    handler: async (input) => {
+      await ensureInitialized();
+      const started = Date.now();
+      // Deleting is opt-IN. The caller must ask for it explicitly: the CLI
+      // computes candidates, prompts, and only then re-calls with apply:true.
+      // Previously this deleted on the same call that counted candidates, so
+      // answering "no" at the prompt printed "Cleanup cancelled" after the
+      // rows were already gone (#1349).
+      const dryRun = input.apply !== true;
+      const expiredOnly = input.expiredOnly === true;
+      const namespace = input.namespace ? String(input.namespace) : undefined;
+      const staleMs = parseDuration(input.olderThan);
+      const now = Date.now();
+
+      const nsClause = namespace ? ` AND namespace = ${sqlString(namespace)}` : '';
+      const select = (cond: string): string =>
+        `SELECT key, namespace FROM memory_entries WHERE status = 'active' AND ${cond}${nsClause}`;
+
+      const expired = await query(select(`expires_at IS NOT NULL AND expires_at < ${now}`));
+
+      const stale = !expiredOnly && staleMs != null
+        ? await query(select(
+            `expires_at IS NULL AND COALESCE(last_accessed_at, updated_at, created_at) < ${now - staleMs}`
+          ))
+        : [];
+
+      // "Unusable" = no embedding (so invisible to semantic search), never
+      // read back, AND older than the caller's cutoff.
+      //
+      // The age gate is a safety interlock, not a refinement. A NULL embedding
+      // means "the embedding model did not run", which on a project where the
+      // model never loaded is EVERY row — without `olderThan` this rule
+      // selected the entire store for deletion by default. Requiring an
+      // explicit cutoff means an unqualified cleanup can only ever remove
+      // TTL-expired rows.
+      const lowQuality = !expiredOnly && staleMs != null
+        ? await query(select(
+            `embedding IS NULL AND COALESCE(access_count, 0) = 0 ` +
+            `AND COALESCE(last_accessed_at, updated_at, created_at) < ${now - staleMs}`
+          ))
+        : [];
+
+      const seen = new Set<string>();
+      const targets: Array<{ key: string; namespace: string }> = [];
+      for (const rows of [expired, stale, lowQuality]) {
+        for (const row of rows) {
+          const key = String(row[0]);
+          const ns = String(row[1]);
+          const id = `${ns} ${key}`;
+          if (seen.has(id)) continue;
+          seen.add(id);
+          targets.push({ key, namespace: ns });
+        }
+      }
+
+      const candidates = {
+        expired: expired.length,
+        stale: stale.length,
+        lowQuality: lowQuality.length,
+        total: targets.length,
+      };
+
+      if (dryRun) {
+        return {
+          dryRun: true,
+          candidates,
+          deleted: { entries: 0 },
+          freed: { bytes: 0, formatted: '0 B' },
+          duration: Date.now() - started,
+        };
+      }
+
+      const sizeBefore = dbSizeBytes();
+      const { deleteEntry } = await import('../memory/memory-initializer.js');
+      let deleted = 0;
+      for (const target of targets) {
+        const result = await deleteEntry(target);
+        if (result.deleted) deleted++;
+      }
+      const freedBytes = Math.max(0, sizeBefore - dbSizeBytes());
+
+      return {
+        dryRun: false,
+        candidates,
+        deleted: { entries: deleted },
+        freed: { bytes: freedBytes, formatted: formatBytes(freedBytes) },
+        duration: Date.now() - started,
+      };
+    },
+  },
+  {
+    name: 'memory_compress',
+    description: 'Reclaim memory database space (SQLite VACUUM) and optionally rebuild the HNSW index',
+    category: 'memory',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        level: { type: 'string', description: 'fast | balanced | max — max also runs an incremental integrity pass' },
+        target: { type: 'string', description: 'Reserved; VACUUM compacts the whole store' },
+        rebuildIndex: { type: 'boolean', description: 'Drop and rebuild the in-process HNSW index (default true)' },
+      },
+    },
+    handler: async (input) => {
+      await ensureInitialized();
+      const started = Date.now();
+      const rebuildIndex = input.rebuildIndex !== false;
+      const level = String(input.level ?? 'balanced');
+
+      if (!existsSync(dbPath())) {
+        throw new Error(`No memory database at ${dbPath()} — run "flo memory init" first`);
+      }
+
+      // VACUUM needs an exclusive lock and is the one mutation here that does
+      // NOT route through the storeEntry/deleteEntry chokepoint. Epic #1054's
+      // single-writer invariant says a CLI process must not write moflo.db
+      // while the daemon owns it, so refuse loudly instead of racing it — a
+      // blocked VACUUM would otherwise stall or fail as SQLITE_BUSY.
+      // getDaemonLockHolder already ran isProcessAlive + isDaemonProcess before
+      // returning a PID, so re-checking cannot change the answer — and on
+      // Windows it would re-run the tasklist/powershell probe (up to 8s per
+      // daemon-lock.ts) for nothing.
+      const { getDaemonLockHolder } = await import('../services/daemon-lock.js');
+      const { findProjectRoot } = await import('../services/project-root.js');
+      const holder = getDaemonLockHolder(findProjectRoot());
+      if (holder !== null && holder !== process.pid) {
+        throw new Error(
+          `The moflo daemon (PID ${holder}) currently owns the memory database. ` +
+          `Compression needs exclusive access — stop it first with "flo daemon stop", ` +
+          `then re-run "flo memory compress".`
+        );
+      }
+
+      const { searchEntries, clearHNSWIndex, getHNSWStatus } = await import('../memory/memory-initializer.js');
+
+      const timeSearch = async (): Promise<number> => {
+        const t0 = performance.now();
+        try {
+          await searchEntries({ query: 'compression latency probe', limit: 5 });
+        } catch {
+          // A failed probe must not be reported as a fast one.
+          return -1;
+        }
+        return performance.now() - t0;
+      };
+
+      // Warm up first. The very first search in a process pays embedding-model
+      // load (tens of ms); timing that as the "before" sample and a warm query
+      // as the "after" reports a 30x speedup that compression did not produce.
+      await timeSearch();
+
+      const bytesBefore = dbSizeBytes();
+      const latencyBefore = await timeSearch();
+
+      const db = await openDb();
+      try {
+        if (level === 'max') db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+        db.exec('VACUUM');
+      } finally {
+        db.close();
+      }
+
+      let indexRebuilt = false;
+      if (rebuildIndex) {
+        clearHNSWIndex();
+        // The index is lazily rebuilt on next search; time that rebuild as
+        // part of the "after" latency rather than claiming it was free.
+        indexRebuilt = true;
+      }
+
+      const bytesAfter = dbSizeBytes();
+      const latencyAfter = await timeSearch();
+      const bytesSaved = Math.max(0, bytesBefore - bytesAfter);
+
+      const speedup = latencyBefore > 0 && latencyAfter > 0
+        ? `${(latencyBefore / latencyAfter).toFixed(2)}x`
+        : 'n/a';
+
+      const sizes = (total: number) => ({
+        totalSize: formatBytes(total),
+        vectorsSize: 'n/a',
+        textSize: 'n/a',
+        patternsSize: 'n/a',
+        indexSize: 'n/a',
+      });
+
+      return {
+        before: sizes(bytesBefore),
+        after: sizes(bytesAfter),
+        compression: {
+          // before/after — a store compacted 100MB->80MB is 1.25x smaller.
+          // after/before yielded 0.8 and printed as "0.80x", reading as growth.
+          ratio: bytesAfter > 0 ? Number((bytesBefore / bytesAfter).toFixed(4)) : 1,
+          bytesSaved,
+          formattedSaved: formatBytes(bytesSaved),
+          // Embedding quantization is not applied to stored rows — the CLI no
+          // longer advertises a --quantize flag, and this stays honest.
+          quantizationApplied: false,
+          indexRebuilt,
+        },
+        performance: {
+          // null, not 0 — a probe that threw is unknown latency, and 0.00ms
+          // renders as infinitely fast (the exact inversion #1349 is about).
+          searchLatencyBefore: latencyBefore < 0 ? null : Number(latencyBefore.toFixed(2)),
+          searchLatencyAfter: latencyAfter < 0 ? null : Number(latencyAfter.toFixed(2)),
+          searchSpeedup: speedup,
+        },
+        hnsw: getHNSWStatus(),
+        duration: Date.now() - started,
+      };
+    },
+  },
+  {
+    name: 'memory_detailed-stats',
+    description: 'Memory store statistics with per-namespace counts, on-disk size, and measured search latency',
+    category: 'memory',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        measureLatency: {
+          type: 'boolean',
+          description: 'Run a timed search to measure latency. Off by default — the probe loads the embedding model.',
+        },
+      },
+    },
+    handler: async (input) => {
+      await ensureInitialized();
+      const { getNamespaceCounts, getHNSWStatus, searchEntries } =
+        await import('../memory/memory-initializer.js');
+
+      const counts = await getNamespaceCounts();
+
+      // Opt-in: the first search in a process loads the embedding model and
+      // lazily builds the HNSW index — hundreds of ms to seconds. `flo status`
+      // is expected to be instant, so it does not ask for this; `flo status
+      // memory` does. null means "not measured", never 0.
+      let avgSearchTime: number | null = null;
+      if (input.measureLatency === true) {
+        const t0 = performance.now();
+        try {
+          await searchEntries({ query: 'status probe', limit: 5 });
+          avgSearchTime = Number((performance.now() - t0).toFixed(2));
+        } catch {
+          avgSearchTime = null;
+        }
+      }
+
+      // Reports the in-process index as it stands. Without a probe it is
+      // legitimately "not built" — said plainly rather than forcing an
+      // expensive build just to make the status line look better.
+      const hnsw = getHNSWStatus();
+
+      return {
+        backend: BACKEND_LABEL,
+        entries: counts.total,
+        entriesWithEmbeddings: counts.withEmbeddings,
+        size: dbSizeBytes(),
+        namespaces: Object.entries(counts.namespaces)
+          .map(([name, entries]) => ({ name, entries }))
+          .sort((a, b) => b.entries - a.entries),
+        performance: {
+          avgSearchTime,
+          hnswEnabled: hnsw.available && hnsw.initialized,
+          indexedVectors: hnsw.entryCount,
+        },
+      };
+    },
+  },
+];
+
+export default memoryAdminTools;

--- a/src/cli/mcp-tools/memory-admin-tools.ts
+++ b/src/cli/mcp-tools/memory-admin-tools.ts
@@ -313,7 +313,7 @@ export const memoryAdminTools: MCPTool[] = [
       type: 'object',
       properties: {
         apply: { type: 'boolean', description: 'Actually delete. Omit (the default) to report candidates only.' },
-        dryRun: { type: 'boolean', description: 'Deprecated alias — cleanup is dry by default; pass apply:true to delete.' },
+        dryRun: { type: 'boolean', description: 'Ignored. Cleanup is dry unless apply:true is passed; accepted only so older callers do not error.' },
         olderThan: { type: 'string', description: 'Age cutoff for stale/unusable entries, e.g. "30d"' },
         expiredOnly: { type: 'boolean', description: 'Only consider TTL-expired entries' },
         namespace: { type: 'string', description: 'Restrict cleanup to one namespace' },

--- a/src/cli/mcp-tools/memory-tools.ts
+++ b/src/cli/mcp-tools/memory-tools.ts
@@ -341,7 +341,7 @@ async function getMemoryFunctions() {
 /**
  * Ensure memory database is initialized and migrate legacy data if needed
  */
-async function ensureInitialized(): Promise<void> {
+export async function ensureInitialized(): Promise<void> {
   const { initializeMemoryDatabase, checkMemoryInitialization, storeEntry } = await getMemoryFunctions();
 
   // Check if already initialized

--- a/src/cli/mcp-tools/progress-tools.ts
+++ b/src/cli/mcp-tools/progress-tools.ts
@@ -1,0 +1,157 @@
+/**
+ * Progress MCP Tools for CLI
+ *
+ * Wraps the existing `V3ProgressService` (src/cli/shared/services/v3-progress.service.ts),
+ * which already backs the statusline. Before #1349 `flo progress check|summary|sync`
+ * and `flo hooks progress` called `progress_check` / `progress_summary` /
+ * `progress_sync` — none of which were ever registered — so every invocation
+ * died with `MCP tool not found` after printing its spinner.
+ *
+ * The service is the source of truth; these handlers only marshal its output
+ * into the shape the CLI renderers already expect.
+ *
+ * @module v3/cli/mcp-tools/progress-tools
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type { MCPTool } from './types.js';
+import { findProjectRoot } from '../services/project-root.js';
+import { MOFLO_DIR } from '../services/moflo-paths.js';
+
+/**
+ * These tools measure *moflo's own* implementation progress by counting its
+ * `src/cli` tree — they are only meaningful inside the moflo source repo.
+ *
+ * The gate is load-bearing, not defensive. V3ProgressService answers an
+ * unreadable tree with invented values, not an error: `countCliCommands`
+ * catches and returns `commands: TARGETS.CLI_COMMANDS` (i.e. 100%), and
+ * `countCodebase` ends with `totalFiles || 419, totalLines || 290913`. Run in
+ * a consumer project that has no `src/` at all, it therefore reports
+ * "28/28 commands, 419 files, 290,913 lines" with total confidence. Refusing
+ * up front is the difference between a useless answer and a false one — which
+ * is the whole point of #1349.
+ */
+async function createService(): Promise<{
+  service: import('../shared/services/v3-progress.service.js').V3ProgressService;
+  outputPath: string;
+}> {
+  const { V3ProgressService } = await import('../shared/services/v3-progress.service.js');
+  const projectRoot = findProjectRoot();
+
+  if (!existsSync(join(projectRoot, 'src', 'cli', 'commands'))) {
+    throw new Error(
+      'Progress metrics track moflo\'s own implementation and require the moflo ' +
+      `source tree; ${projectRoot} has no src/cli/commands. This command only ` +
+      'applies inside the moflo repository.'
+    );
+  }
+
+  // Own the output path here and hand it to the service, so this module and
+  // V3ProgressService cannot drift to two different metrics files.
+  const outputPath = join(projectRoot, MOFLO_DIR, 'metrics', 'v3-progress.json');
+  return { service: new V3ProgressService({ projectRoot, outputPath }), outputPath };
+}
+
+export const progressTools: MCPTool[] = [
+  {
+    name: 'progress_check',
+    description: 'Calculate moflo implementation progress (CLI commands, MCP tools, hooks, packages, DDD coverage)',
+    category: 'progress',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        detailed: {
+          type: 'boolean',
+          description: 'Include the per-area breakdown as well as the overall percentage',
+        },
+      },
+    },
+    handler: async (input) => {
+      const { service } = await createService();
+      const metrics = await service.calculate();
+
+      // `overall` is what every caller renders; `progress` is kept as an alias
+      // because progress.ts reads `result.overall ?? result.progress`.
+      const base = {
+        overall: metrics.overall,
+        progress: metrics.overall,
+        lastUpdated: metrics.lastUpdated,
+      };
+
+      if (!input.detailed) return base;
+
+      return {
+        ...base,
+        cli: metrics.cli,
+        mcp: metrics.mcp,
+        hooks: metrics.hooks,
+        packages: {
+          progress: metrics.packages.progress,
+          total: metrics.packages.total,
+          target: metrics.packages.target,
+          withDDD: metrics.packages.withDDD,
+        },
+        ddd: { progress: metrics.ddd.progress },
+        codebase: metrics.codebase,
+      };
+    },
+  },
+  {
+    name: 'progress_summary',
+    description: 'Human-readable summary of moflo implementation progress',
+    category: 'progress',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async () => {
+      const { service } = await createService();
+      return { summary: await service.getSummary() };
+    },
+  },
+  {
+    name: 'progress_sync',
+    description: 'Recalculate implementation progress and persist it to .moflo/metrics/v3-progress.json',
+    category: 'progress',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async () => {
+      const startedAt = Date.now();
+      const { service, outputPath: path } = await createService();
+      // sync() is calculate() + persist(); calling both was a re-implementation.
+      const metrics = await service.sync();
+
+      // #1346's lesson: derive the verdict from the artifact, not from the
+      // call returning. `persist()` swallows its own write errors and only
+      // emits 'error', so a bare `await` proves nothing about the file.
+      // Existence alone is not proof either — a stale file from a previous
+      // run would make a failed write look successful — so require an mtime
+      // at or after the moment this call began.
+      let persisted = false;
+      let lastUpdated = metrics.lastUpdated;
+      if (existsSync(path)) {
+        const stat = statSync(path);
+        // Allow 1s of filesystem timestamp granularity (some filesystems
+        // truncate mtime to whole seconds, which can land just below startedAt).
+        if (stat.mtimeMs >= startedAt - 1000) {
+          persisted = true;
+          lastUpdated = stat.mtime.toISOString();
+        }
+      }
+
+      return {
+        progress: metrics.overall,
+        persisted,
+        lastUpdated,
+        message: persisted
+          ? `Progress synced to ${path}`
+          : `Progress calculated but could not be written to ${path}`,
+      };
+    },
+  },
+];
+
+export default progressTools;

--- a/src/cli/mcp-tools/session-tools.ts
+++ b/src/cli/mcp-tools/session-tools.ts
@@ -35,6 +35,11 @@ interface SessionRecord {
   };
 }
 
+/** Count keys in a session data bucket (memory/tasks/agents), 0 when absent. */
+function countOf(bucket: unknown): number {
+  return bucket && typeof bucket === 'object' ? Object.keys(bucket as object).length : 0;
+}
+
 function getSessionDir(): string {
   return storeDir(SESSION_DIR);
 }
@@ -317,6 +322,127 @@ export const sessionTools: MCPTool[] = [
         sessionId,
         deleted: false,
         error: 'Session not found',
+      };
+    },
+  },
+  {
+    // #1349 — `flo session export` with no ID called this to resolve "the
+    // current session"; it was never registered. The store has no explicit
+    // active-session marker, so "current" is defined as the most recently
+    // saved session. Throwing when there are none is what lets the CLI print
+    // "No active session" instead of exporting something arbitrary.
+    name: 'session_current',
+    description: 'Resolve the current session (the most recently saved one)',
+    category: 'session',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async () => {
+      const sessions = listSessions();
+      if (sessions.length === 0) {
+        throw new Error('No sessions have been saved');
+      }
+      const [latest] = sessions.sort(
+        (a, b) => new Date(b.savedAt).getTime() - new Date(a.savedAt).getTime()
+      );
+      return {
+        sessionId: latest.sessionId,
+        name: latest.name,
+        savedAt: latest.savedAt,
+        stats: latest.stats,
+      };
+    },
+  },
+  {
+    name: 'session_export',
+    description: 'Export a saved session as a portable object',
+    category: 'session',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sessionId: { type: 'string', description: 'Session to export' },
+        includeMemory: { type: 'boolean', description: 'Include the memory snapshot (default true)' },
+      },
+      required: ['sessionId'],
+    },
+    handler: async (input) => {
+      const sessionId = input.sessionId as string;
+      const session = loadSession(sessionId);
+      if (!session) {
+        throw new Error(`Session not found: ${sessionId}`);
+      }
+
+      const includeMemory = input.includeMemory !== false;
+      const data: SessionRecord = includeMemory
+        ? session
+        : { ...session, data: { ...session.data, memory: undefined } };
+
+      return {
+        sessionId,
+        data,
+        stats: {
+          agentCount: session.stats?.agents ?? countOf(session.data?.agents),
+          taskCount: session.stats?.tasks ?? countOf(session.data?.tasks),
+          memoryEntries: includeMemory
+            ? session.stats?.memoryEntries ?? countOf(session.data?.memory)
+            : 0,
+        },
+      };
+    },
+  },
+  {
+    name: 'session_import',
+    description: 'Import a session object previously produced by session_export',
+    category: 'session',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        data: { type: 'object', description: 'The exported session object' },
+        name: { type: 'string', description: 'Name for the imported session' },
+        activate: { type: 'boolean', description: 'Make the imported session the current one' },
+      },
+      required: ['data'],
+    },
+    handler: async (input) => {
+      const incoming = (input.data ?? {}) as Partial<SessionRecord>;
+      if (!incoming || typeof incoming !== 'object') {
+        throw new Error('Import payload must be a session object');
+      }
+
+      const importedAt = new Date().toISOString();
+      // A fresh ID keeps an import from silently overwriting a local session
+      // that happens to share the source's ID.
+      const sessionId = `imported-${Date.now()}`;
+      const agentsImported = incoming.stats?.agents ?? countOf(incoming.data?.agents);
+      const tasksImported = incoming.stats?.tasks ?? countOf(incoming.data?.tasks);
+      const memoryEntriesImported =
+        incoming.stats?.memoryEntries ?? countOf(incoming.data?.memory);
+
+      const record: SessionRecord = {
+        sessionId,
+        name: (input.name as string) || incoming.name || sessionId,
+        description: incoming.description,
+        // `activate` makes this the newest session, which is what
+        // session_current resolves to.
+        savedAt: input.activate === true ? importedAt : incoming.savedAt || importedAt,
+        stats: {
+          tasks: tasksImported,
+          agents: agentsImported,
+          memoryEntries: memoryEntriesImported,
+          totalSize: incoming.stats?.totalSize ?? 0,
+        },
+        data: incoming.data,
+      };
+
+      saveSession(record);
+
+      return {
+        sessionId,
+        name: record.name,
+        importedAt,
+        stats: { agentsImported, tasksImported, memoryEntriesImported },
+        activated: input.activate === true,
       };
     },
   },

--- a/src/cli/mcp-tools/task-tools.ts
+++ b/src/cli/mcp-tools/task-tools.ts
@@ -245,7 +245,13 @@ export const taskTools: MCPTool[] = [
 
       if (input.status) {
         const statuses = (input.status as string).split(',').map(s => s.trim());
-        tasks = tasks.filter(t => statuses.includes(t.status));
+        // 'all' is the documented "no filter" sentinel — `flo status tasks`
+        // and `flo task list --status all` both pass it. Matching it as a
+        // literal status made those commands report zero tasks while
+        // task_summary, reading the same coordinator, reported them (#1349).
+        if (!statuses.includes('all')) {
+          tasks = tasks.filter(t => statuses.includes(t.status));
+        }
       }
       if (input.type) {
         tasks = tasks.filter(t => t.type === input.type);
@@ -469,6 +475,102 @@ export const taskTools: MCPTool[] = [
       } catch (err) {
         return { success: false, taskId: v.taskId, error: (err as Error).message };
       }
+    },
+  },
+  {
+    // #1349 — `flo task retry` called this and it was never registered.
+    // Protected surface (CLAUDE.md): resubmission goes through
+    // coordinator.submitTask, never a JSON-store write.
+    name: 'task_retry',
+    description: 'Resubmit a finished task to the coordinator as a new task',
+    category: 'task',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taskId: { type: 'string', description: 'Task to retry' },
+        resetState: { type: 'boolean', description: 'Drop the original task input/result instead of carrying it over' },
+      },
+      required: ['taskId'],
+    },
+    handler: async (input) => {
+      const v = validateTaskId(input);
+      if (!v.ok) return { success: false, taskId: v.taskId, error: v.error };
+
+      const coordinator = await getSwarmCoordinator();
+      const previous = coordinator.getTask(v.taskId);
+      if (!previous) {
+        return { success: false, taskId: v.taskId, error: 'task_not_found' };
+      }
+
+      const resetState = input.resetState === true;
+      try {
+        const newTaskId = await coordinator.submitTask({
+          type: previous.type,
+          name: previous.name,
+          description: previous.description,
+          priority: previous.priority,
+          dependencies: [],
+          input: resetState ? null : previous.input ?? null,
+          timeoutMs: previous.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          retries: 0,
+          maxRetries: previous.maxRetries ?? DEFAULT_MAX_RETRIES,
+          metadata: {
+            ...(previous.metadata ?? {}),
+            retryOf: v.taskId,
+          },
+        });
+
+        const created = coordinator.getTask(newTaskId);
+        return {
+          success: true,
+          taskId: v.taskId,
+          newTaskId,
+          previousStatus: previous.status,
+          status: created?.status ?? 'queued',
+        };
+      } catch (err) {
+        return { success: false, taskId: v.taskId, error: (err as Error).message };
+      }
+    },
+  },
+  {
+    // #1349 — `flo status` called this on every run; because it was missing,
+    // the throw reached getSystemStatus's outer catch and the whole command
+    // rendered its all-zeros "not running" fallback regardless of real state.
+    name: 'task_summary',
+    description: 'Counts of tasks by status, as used by the status dashboard',
+    category: 'task',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    handler: async () => {
+      const coordinator = await getSwarmCoordinator();
+      const tasks = coordinator.getAllTasks();
+
+      const counts = { total: tasks.length, pending: 0, running: 0, completed: 0, failed: 0 };
+      for (const task of tasks) {
+        switch (task.status) {
+          case 'created':
+          case 'queued':
+          case 'assigned':
+            counts.pending++;
+            break;
+          case 'running':
+          case 'paused':
+            counts.running++;
+            break;
+          case 'completed':
+            counts.completed++;
+            break;
+          case 'failed':
+          case 'timeout':
+          case 'cancelled':
+            counts.failed++;
+            break;
+        }
+      }
+      return counts;
     },
   },
 ];

--- a/src/cli/movector/coverage-router.ts
+++ b/src/cli/movector/coverage-router.ts
@@ -11,7 +11,9 @@
 // Caching for Performance
 // ============================================================================
 
-import { mofloImport } from '../services/moflo-require.js';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, join, normalize, resolve } from 'node:path';
 
 /**
  * Cache for coverage data (1 minute TTL)
@@ -361,6 +363,49 @@ export interface CoverageGapsOptions extends CoverageRouteOptions {
   groupByAgent?: boolean;
 }
 
+export type GapSeverity = 'critical' | 'high' | 'medium' | 'low';
+
+/**
+ * Bucket a coverage shortfall by severity.
+ *
+ * Shares the 50/30/15 thresholds with `calculateFilePriority` below on
+ * purpose — the two answer the same question (how bad is this gap) and had
+ * drifted into separate copies once the MCP wrappers landed (#1349).
+ */
+export function classifyGap(gap: number): GapSeverity {
+  if (gap >= 50) return 'critical';
+  if (gap >= 30) return 'high';
+  if (gap >= 15) return 'medium';
+  return 'low';
+}
+
+/**
+ * Normalize a path fragment for cross-platform substring matching.
+ *
+ * Rule #1: Istanbul records absolute keys using the OS separator, so on
+ * Windows `byFile[].path` is `C:\repo\src\cli\foo.ts` while callers pass
+ * `src/cli`. A raw `includes` therefore matched nothing on Windows and
+ * everything on POSIX — `hooks_coverage-suggest` silently returned zero
+ * suggestions. Compare on a separator- and case-normalized form instead.
+ */
+export function normalizePathFragment(value: string): string {
+  return value.split(/[\\/]+/).join('/').toLowerCase();
+}
+
+/**
+ * Load the project's coverage report, or null when no coverage artifact exists.
+ *
+ * Exported for the MCP wrappers (#1349): `hooks_coverage-*` needs the report's
+ * `byType` totals for its summary, which the task-shaped helpers below don't
+ * surface.
+ */
+export async function loadCoverageReport(
+  projectRoot?: string,
+  skipCache?: boolean
+): Promise<CoverageReport | null> {
+  return loadProjectCoverage(projectRoot, skipCache);
+}
+
 /**
  * Route a task based on coverage analysis
  */
@@ -409,8 +454,10 @@ export async function coverageSuggest(
     };
   }
 
-  // Filter files matching the path
-  const matchingFiles = coverage.byFile.filter(f => f.path.includes(path));
+  // Filter files matching the path (separator/case-normalized — see
+  // normalizePathFragment; a raw `includes` never matched on Windows).
+  const needle = normalizePathFragment(path);
+  const matchingFiles = coverage.byFile.filter(f => normalizePathFragment(f.path).includes(needle));
   const belowThreshold = matchingFiles.filter(f => f.lineCoverage < threshold);
 
   const suggestions = belowThreshold
@@ -484,8 +531,6 @@ export async function coverageGaps(
  * Returns null if path is invalid or attempts traversal
  */
 function validateProjectPath(inputPath: string | undefined): string | null {
-  const { resolve, normalize, isAbsolute } = require('path');
-
   // Default to cwd if not provided
   const basePath = inputPath || process.cwd();
 
@@ -531,10 +576,6 @@ async function loadProjectCoverage(projectRoot?: string, skipCache?: boolean): P
       return cached.report;
     }
   }
-
-  const { existsSync } = require('fs');
-  const { readFile } = require('fs/promises');
-  const { join, normalize } = require('path');
 
   // Try common coverage locations (all relative to validated root)
   const coverageLocations = [

--- a/src/cli/movector/diff-classifier.ts
+++ b/src/cli/movector/diff-classifier.ts
@@ -2,7 +2,10 @@
  * Diff Classifier for Change Analysis
  */
 
-import { mofloImport } from '../services/moflo-require.js';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 export interface DiffClassifierConfig {
   maxDiffSize: number;
@@ -392,7 +395,6 @@ export function getGitDiffNumstat(ref: string = 'HEAD'): DiffFile[] {
     return cached.files;
   }
 
-  const { execFileSync } = require('child_process');
   try {
     // SECURITY: Use execFileSync with args array instead of shell string
     // This prevents command injection via the ref parameter
@@ -467,19 +469,18 @@ export async function getGitDiffNumstatAsync(ref: string = 'HEAD'): Promise<Diff
     return cached.files;
   }
 
-  const { execFile } = require('child_process');
-  const { promisify } = require('util');
-  const execFileAsync = promisify(execFile);
-
   try {
     // SECURITY: Use execFile with args array instead of shell string
+    // windowsHide matches the sync twin above — without it Windows flashes
+    // a console window per git call, and analyze_diff runs these from the
+    // MCP server where there is no terminal to flash into.
     const { stdout: numstatOutput } = await execFileAsync('git', [
       'diff', '--numstat', '--diff-filter=ACDMRTUXB', ref
-    ], { maxBuffer: 10 * 1024 * 1024 });
+    ], { maxBuffer: 10 * 1024 * 1024, windowsHide: true });
 
     const { stdout: statusOutput } = await execFileAsync('git', [
       'diff', '--name-status', ref
-    ], { maxBuffer: 10 * 1024 * 1024 });
+    ], { maxBuffer: 10 * 1024 * 1024, windowsHide: true });
 
     const stdout = numstatOutput + '---STATUS---' + statusOutput;
 

--- a/tests/system/fixtures/writer-audit-whitelist.json
+++ b/tests/system/fixtures/writer-audit-whitelist.json
@@ -83,6 +83,11 @@
       "notes": "MCP handlers funnel through chokepoint"
     },
     {
+      "file": "src/cli/mcp-tools/memory-admin-tools.ts",
+      "classification": "daemon-offline",
+      "notes": "#1349 export/import/cleanup/detailed-stats use db.exec only for SELECTs and route every delete through the deleteEntry chokepoint. memory_compress is the sole direct mutation (VACUUM + wal_checkpoint) and self-enforces the offline precondition: it reads the daemon lock and refuses with an explicit error when a live daemon owns the DB, rather than racing it."
+    },
+    {
       "file": "src/cli/swarm/swarm-persistence.ts",
       "classification": "daemon-rpc",
       "notes": "Cross-process; DI'd through chokepoint"


### PR DESCRIPTION
## Summary

23 CLI subcommands called `callMCPTool('<name>')` with names the MCP registry never held. All 23 confirmed unregistered at runtime, but **the failure was not uniform** as the issue assumed — and two of the three modes are worse than the reported one:

| Class | Count | Behaviour |
|---|---|---|
| **A — honest error** | 18 | prints progress, then `MCP tool not found` |
| **B — reports SUCCESS falsely** | 2 | `hooks task-completed` / `teammate-idle` caught the error and returned `{success:true}`, printing "Task t1 completed / Pattern training queued" |
| **C — fabricated data** | 3 | `task_summary` threw inside `getSystemStatus`, so **`flo status` unconditionally rendered its all-zeros fallback** — `[STOPPED]`, `Backend: none`, `0 entries`, `MCP: Not running` — in a freshly `flo init`'d project |

19 tools are now registered and 4 unbacked surfaces removed.

## Why this was mostly wiring, not building

The backing services already existed and were tested — only the MCP layer was missing. `movector/coverage-router.ts` even carries a section header reading **`Additional Exports for MCP Tools (coverage-tools.ts)`** for a file that was never written.

| Tools | Backed by |
|---|---|
| `progress_check\|summary\|sync` | `shared/services/v3-progress.service.ts` |
| `hooks_coverage-{gaps,route,suggest}` | `movector/coverage-router.ts` |
| `analyze_diff` | `movector/diff-classifier.ts` |
| `mcp_status` | `mcp-server.getMCPServerStatus` |
| `memory_export\|import\|cleanup\|compress\|detailed-stats` | memory store + `daemon-backend` |
| `session_current\|export\|import` | existing session file store |
| `task_retry\|summary`, `hive-mind_task` | `UnifiedSwarmCoordinator` |

**Removed** (no backing exists; implementing would mean inventing data): `flo agent logs`, `flo hive-mind optimize-memory`, `flo hooks task-completed`, `flo hooks teammate-idle`.

## Also fixed — all found while verifying, not from the issue

- **`movector/{coverage-router,diff-classifier}.ts` used CommonJS `require()` in an ESM build** and threw on every call. Nothing noticed because their only callers were the unregistered tools.
- **`memory_stats` returns no `performance`/`entries`/`size`**, yet `getSystemStatus` dereferenced `.performance` — a second, independent cause of the fabricated `flo status`.
- **`task_list` treated the `'all'` sentinel as a literal status**, so `flo status tasks` reported none while `flo status` reported them.
- **`task_retry` / `hive-mind_task` returned `{success:false}` / `{error}` to CLI code that only handled throws** — printing "[OK] Task retried / New task ID: undefined", or a TypeError.
- **`memory_cleanup` deleted on the same call that counted candidates.** The CLI then asked "Delete N entries?" and printing "Cleanup cancelled" over a completed deletion. Deletion is now opt-in (`apply:true`); the CLI counts → prompts → applies.
- **Its unusable-entry rule keyed on `embedding IS NULL` with no age gate** — that is *every row* on a project whose embedding model never loaded, so a bare `flo memory cleanup` could select the whole store. Now requires an explicit `--older-than`.
- **`progress_*` would have reported `28/28 commands, 419 files, 290,913 lines` in a consumer project with no `src/` at all**, because `V3ProgressService` answers an unreadable tree with invented values (`countCodebase` literally ends `totalFiles || 419`). Registering the handler would have turned an honest error into a confident lie; the handlers now refuse outside the moflo source tree.
- Removed advertised-but-unbacked options (`--quantize`/`--bits`, `--low-quality`) and unmeasured outputs (`patterns`/`vectors` counts, cache hit rate, write latency). Unmeasured latency reports `null`, never `0.00ms`.
- A `memory_compress` "30.20x speedup" was really first-search embedding-model load; a warm-up now precedes timing, and it honestly reports `0.46x`.
- `flo memory cleanup --format json` printed the human candidate table and then blocked on an interactive confirm — wrong for the caller that asked for JSON, and liable to hang without a TTY. JSON mode is now non-interactive: it reports candidates and requires `--force` to delete.
- `memory_detailed-stats` ran a real semantic search (loading the embedding model) on every `flo status`. The probe is now opt-in; `flo status` skips it and prints "not measured" rather than a fabricated `0.00ms`.

## Rule #1 (cross-platform)

- `coverageSuggest` compared OS-separator paths against a `/`-style needle — it matched nothing on Windows and everything on POSIX, so `hooks_coverage-suggest` would have shipped returning zero suggestions on Windows. Both sides are now separator/case-normalized.
- Added `windowsHide: true` to the async `git` calls (the sync twin already had it) — `analyze_diff` runs them from the MCP server.
- Dropped a redundant `isDaemonProcess` re-probe worth up to **8s on Windows** (`getDaemonLockHolder` already performed it).
- New files use `node:path`/`node:fs` only — no hardcoded separators, `/tmp`, or `HOME`. CSV export pins LF deliberately so an export is byte-identical across platforms.

## Single-writer invariant

`memory_compress` is the only direct `moflo.db` mutation (`VACUUM` + `wal_checkpoint`). Rather than force-fit a whitelist classification, it **reads the daemon lock and refuses** when a live daemon owns the DB, so epic #1054's single-writer rule holds. Whitelisted as `daemon-offline` with that self-enforcement documented.

## The guard

`src/cli/__tests__/mcp-tools-callsite-guard.test.ts` — the inverse of the existing drift guard. That one walks *registered → consumer*; this one walks *consumer → registered*, so a call site naming a tool that does not exist fails the suite.

Proven to work: removing `progressTools`, then `coverageTools`, from the registry turns it red naming the exact tools, and green on restore. Its comment-stripper has explicit regex-literal handling — without it, a regex containing an unbalanced quote (`/['"]/`) would swallow real code and could hide an unregistered call site.

## Testing

- [x] `npm test` — **9832 passed / 0 failed** / 7 skipped
- [x] `eslint src/cli --max-warnings 0` clean; `tsc --noEmit` clean
- [x] 5 new tests in `mcp-tools/memory-admin-safety.test.ts`, verified to **fail** against the pre-fix cleanup logic
- [x] Every one of the 19 tools exercised through the real CLI, including a full memory export → import → semantic-search round-trip across two projects (embeddings survive, search returns the entry at 0.72)
- [x] Cleanup safety proven live: a count-only call left all 6 rows; `apply:true` removed exactly the 1 expired row
- [ ] Windows/macOS — Linux only locally; CI's three-platform smoke is the real check

## Consumer impact

`tools/list` grows from 108 → 127 tools, so every consumer's MCP tool list gains 19 entries. That is inherent to the issue's "implement the handler" resolution; flagging it explicitly in case you'd prefer a visibility flag for the moflo-internal ones (`progress_*`) as a follow-up.

## Known, deliberately not fixed here

- `session_list` and `flo status agents` have pre-existing field-mapping bugs (`session_list` returns `sessionId`/`savedAt`; the table reads `id`/`status`/`agents`, rendering `undefined` / `Invalid Date`). Pre-existing in tools this PR does not touch — worth its own issue.
- `formatBytes` now has four copies (`status.ts`, `embeddings.ts`, `ipfs-client.ts`, and this PR's). Consolidating carries output-format risk across unrelated commands; noted in code for a follow-up.
- `V3ProgressService`'s invented fallbacks (`|| 419`) are gated at the handler, not removed — the statusline still consumes that service.

Closes #1349
