### PR TITLE
ci: restore macOS + Windows to the per-PR smoke matrices

### DIFF
--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -51,25 +51,36 @@ concurrency:
 
 jobs:
   smoke:
-    # Per-PR + push-to-main: ubuntu-only consumer and populated smoke.
-    # Cross-OS coverage (mac + windows) runs in `release-smoke.yml` on
-    # workflow_dispatch, gated by the /publish skill. This split exists
-    # because mac runners bill at 10× and windows at 2× — paying that on
-    # every doc tweak / typo fix was the dominant CI cost. Pre-split per-PR
-    # cost was ~197 equivalent-minutes (the smoke matrix alone was ~182);
-    # post-split per-PR cost is ~29 eq-min. The full matrix is paid once
-    # per publish instead of once per PR.
+    # Full 3-OS × 2-harness matrix on every PR + push-to-main.
     #
-    # Job-name template ("${harness} / ${os}") is preserved verbatim so the
-    # protected-branch required status checks `consumer / ubuntu-latest` and
-    # `populated / ubuntu-latest` continue to post. The four removed mac +
-    # windows contexts MUST be deleted from branch protection in the same
-    # change that lands this file — see the PR body for the gh api call.
+    # History: #1175 trimmed this to ubuntu-only because mac runners bill at
+    # 10× and windows at 2×, making the matrix the dominant CI cost at ~197
+    # equivalent-minutes/PR versus ~29 after the trim. That was the right
+    # trade *at high PR throughput* — the win it bought was explicitly
+    # per-PR throughput at scale.
+    #
+    # Restored deliberately: moflo's change rate has slowed, so the per-PR
+    # multiplier now applies to far fewer runs, while the cost of missing a
+    # platform bug rose. Publish-time-only coverage means a Windows-specific
+    # defect is found after the change has already merged — #1349 shipped
+    # three Windows-only fixes (path-separator normalization that made a
+    # command silently return nothing on NTFS, a missing windowsHide, an 8s
+    # process probe) with no Windows CI on the PR, and Rule #1's own
+    # cautionary case (#1145) shipped for exactly this reason.
+    #
+    # `release-smoke.yml` still runs the same matrix at publish time; that
+    # is now a second line of defence rather than the only one.
+    #
+    # Job-name template ("${harness} / ${os}") is unchanged, so the existing
+    # `consumer / ubuntu-latest` and `populated / ubuntu-latest` required
+    # contexts keep posting. The four mac + windows contexts removed from
+    # branch protection by #1175 must be re-added for those legs to actually
+    # block a merge — until then they run and report but are advisory.
     name: ${{ matrix.harness }} / ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         harness: [consumer, populated]
     runs-on: ${{ matrix.os }}
     # Acceptance criterion: < 5 min on Ubuntu. Cap all runners conservatively

--- a/.github/workflows/file-sync-smoke.yml
+++ b/.github/workflows/file-sync-smoke.yml
@@ -64,14 +64,24 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Per-PR + push-to-main: ubuntu-only file-sync smoke. Cross-OS coverage
-  # for NTFS / APFS rename semantics runs in `release-smoke.yml` on
-  # workflow_dispatch (gated by /publish). Same cost-driven split as
-  # consumer-install-smoke. The workflow_dispatch trigger below is kept
-  # so maintainers can still kick off this lightweight suite on demand.
+  # Native: NTFS / APFS / ext4 each have their own lock + rename semantics.
+  # Bug #975's failure venue was DrvFs (covered separately below) but the
+  # other native filesystems have caught a long tail of platform-specific
+  # rename behavior, so we run all three on every change.
+  #
+  # #1175 trimmed this to ubuntu-only on cost grounds and moved cross-OS
+  # coverage to publish time; restored here because moflo's change rate has
+  # slowed, so the per-PR runner multiplier applies to far fewer runs while
+  # the cost of finding a rename-semantics bug only at publish stayed high.
+  # These legs are cheap in wall-clock terms — windows runs ~1m07s, well
+  # inside the CI `Tests` job, so they do not extend the critical path.
   native:
-    name: ubuntu-latest
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Restores macOS + Windows to the two per-PR smoke matrices, reverting the matrix half of #1175.

## Why now

#1175's trim was correct and well-argued: macOS runners bill at **10×** and Windows at **2×**, making the full matrix **~197 eq-min/PR** versus **~29** after trimming. The win it bought was explicitly *per-PR throughput at scale*.

moflo's change rate has slowed, so that multiplier now applies to far fewer runs — while the cost of finding a platform bug only at publish time hasn't fallen.

**The gap is not hypothetical.** #1349 shipped three Windows-only fixes with no Windows CI on the PR:
- a path-separator comparison that made `hooks_coverage-suggest` silently return **zero results on NTFS** (it matched everything on POSIX, so ubuntu CI was green)
- a missing `windowsHide`, flashing a console window per `git` call from the MCP server
- a redundant process probe costing **up to 8s** on Windows

Rule #1's own cautionary case (#1145) shipped for exactly this reason — single-platform verification.

## Cost

Wall-clock is cheap because legs run in parallel. Measured from the 2026-08-04 full-matrix run:

| Leg | Wall clock |
|---|---|
| populated / windows | **3m46s** ← new critical path |
| consumer / windows | 3m01s |
| populated / macos | 1m25s |
| file-sync / windows | 1m07s |
| consumer / macos | 1m06s |

Current critical path is CI `Tests` at **2m38s**, so the gate grows by **~1m10s**. Every macOS leg and every file-sync leg finishes inside the existing Tests window and is effectively free in wall-clock terms.

Caveat: those durations exclude **runner queue time**, which is typically longer for macOS/Windows and is invisible in job timings — perceived latency may be higher on a cold queue.

Billing is *not* helped by parallelism: #1175's ~170–230 eq-min/PR returns in full. That is the real cost of this change, accepted deliberately.

## Changes

- `consumer-install-smoke.yml`: `matrix.os` → `[ubuntu-latest, macos-latest, windows-latest]` (2 harnesses × 3 OS)
- `file-sync-smoke.yml`: restored to its pre-#1175 matrix shape (NTFS / APFS / ext4 each have distinct lock + rename semantics)
- `release-smoke.yml` unchanged — same matrix still runs at publish time, now as a second line of defence rather than the only one
- Job-name templates unchanged, so the existing `consumer / ubuntu-latest` and `populated / ubuntu-latest` required contexts keep posting

## Follow-up in this PR's wake

The four contexts #1175 removed from branch protection (`consumer / macos-latest`, `consumer / windows-latest`, `populated / macos-latest`, `populated / windows-latest`) need re-adding for the new legs to **block** a merge rather than just report. Deliberately done *after* this lands and the contexts are observed posting — adding a required context that nothing produces would block every PR.

`file-sync`'s contexts were never required, even before #1175, so making them required would be a new policy rather than a restoration — flagged, not assumed.

## Testing

- [x] Both workflows parse; matrices confirmed as 3-OS
- [x] `file-sync` steps are already cross-platform (`npm ci` / `npm run build` / `npx vitest`) — no bash-only constructs
- [x] This PR is itself the test: the six new legs run here for the first time
