### PR TITLE
ci: stop file-sync's required contexts blocking every unrelated PR

### DIFF
--- a/.github/workflows/file-sync-smoke.yml
+++ b/.github/workflows/file-sync-smoke.yml
@@ -26,19 +26,24 @@ name: File-sync smoke (#976)
 #   B6 upgrade-notice round-trip (in-progress → completed)
 
 on:
+  # Deliberately NOT path-filtered on pull_request.
+  #
+  # These three jobs are required status checks on `main`. A required context
+  # that never reports does not "pass by default" — GitHub waits for it
+  # indefinitely, so a path filter here blocks every PR that does not touch a
+  # listed file. That is exactly what happened once the contexts were made
+  # required: PR #1356 went 9/9 green and still sat at BLOCKED.
+  #
+  # The alternative — a mirrored skip-workflow with inverse `paths-ignore`
+  # posting identically-named jobs — keeps the filter but splits the job names
+  # across two files that must never drift, and a drift there silently stops
+  # the gate enforcing anything. Running for real is the cheaper guarantee:
+  # measured at 69s (windows) / 37s (ubuntu) / 29s (macos), all comfortably
+  # inside the CI `Tests` job, so this adds no wall-clock to a PR.
+  #
+  # The `push` trigger below keeps its filter — nothing gates on those runs.
   pull_request:
     branches: [main, 'epic/*']
-    paths:
-      - 'bin/lib/file-sync.mjs'
-      - 'bin/lib/shipped-scripts.mjs'
-      - 'bin/lib/shipped-scripts.json'
-      - 'bin/session-start-launcher.mjs'
-      - 'scripts/post-install-bootstrap.mjs'
-      - 'src/cli/__tests__/file-sync-helper.test.ts'
-      - 'src/cli/__tests__/post-install-bootstrap.test.ts'
-      - 'src/cli/__tests__/bootstrap-sentinel-promotion.test.ts'
-      - 'src/cli/__tests__/shipped-scripts-manifest.test.ts'
-      - '.github/workflows/file-sync-smoke.yml'
   push:
     branches: [main, 'epic/*']
     paths:


### PR DESCRIPTION
## The bug

Making `ubuntu-latest` / `macos-latest` / `windows-latest` required status checks on `main` (previous session, alongside #1355) missed that `file-sync-smoke.yml` is **path-filtered**.

A required status check that never reports does **not** pass by default — GitHub waits for it indefinitely. So every PR that doesn't touch one of the nine listed file-sync paths is permanently blocked from a normal merge.

**#1356 is the live demonstration:**

```
checks:            9/9 SUCCESS
mergeable:         MERGEABLE
mergeStateStatus:  BLOCKED      <-- waiting on 3 contexts that will never post
```

## The fix

Drop the `paths:` filter from the `pull_request` trigger so the three contexts always report. The `push` trigger keeps its filter — nothing gates on those runs.

## Cost

Measured from the last real file-sync run (`30915985332`):

| Leg | Duration |
|---|---|
| `windows-latest` | 69s |
| `ubuntu-latest` | 37s |
| `macos-latest` | 29s |

All three finish well inside the CI `Tests` job (2m37s), so this adds **no wall-clock** to a PR. Billing delta is roughly **8 equivalent-minutes** (1× ubuntu + 10× macos + 2× windows).

Caveat, same as #1355: these durations come from the API's `started_at → completed_at` and exclude runner queue time, which is typically longer for macOS and Windows.

## Why not the skip-workflow pattern

The canonical alternative is a second workflow with inverse `paths-ignore` posting identically-named jobs that pass trivially. It preserves the filter and costs no runner time — but it splits the job names across two files that must never drift, and if they ever do, the gate silently stops enforcing anything while still showing green. Running the legs for real is the cheaper guarantee for a workflow this fast.

## Verification

- YAML re-parsed: `on.pull_request` is `{branches: [main, epic/*]}` with no `paths`; `on.push` still carries `branches` + `paths`; job name template `${{ matrix.os }}` and the 3-OS matrix are unchanged, so the posted context names still match the required ones exactly.
- The three file-sync contexts (`ubuntu-latest`, `macos-latest`, `windows-latest`) do report on this PR.

**This PR is not, by itself, proof that the fix works.** It edits
`.github/workflows/file-sync-smoke.yml`, which was already one of the nine
entries in the old `paths:` list — so file-sync would have run here regardless.

The genuine proof is #1356: it touches none of those nine paths, so it is
currently missing all three contexts. Once this merges and #1356 is updated
from `main`, file-sync should run there and take it to 12/12. If it does not,
this fix is wrong and #1356 stays blocked.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
