### PR TITLE
fix(cross-platform): stop reading Windows' zeroed loadavg as a real measurement (#1358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Windows worker daemon had no CPU backpressure (#1358)
+
+`os.loadavg()` is a Unix concept; Node documents it as always returning
+`[0, 0, 0]` on Windows. `WorkerDaemon.canRunWorker()` gated dispatch on
+`loadavg()[0] > maxCpuLoad`, and `maxCpuLoad` is validated `> 0`, so on Windows
+that branch was unreachable — the daemon dispatched workers regardless of load
+while still appearing to throttle, because the memory gate below it kept firing.
+
+**Behaviour change for Windows consumers.** The CPU gate is now explicitly
+skipped rather than accidentally satisfied, and the daemon logs one warn line
+per run naming the platform and the threshold that is no longer being applied.
+Memory backpressure is unchanged and still applies on every platform. Workers
+that previously always dispatched may now defer under memory pressure with a
+clearer reason attached.
+
+Substituting `os.cpus()` tick deltas was considered and rejected: they measure
+utilisation percentage where `maxCpuLoad` is run-queue depth (default
+`cores * 0.8`, scaled against cgroup quotas by `getEffectiveCpuCount()`), so
+feeding one into the other would silently re-scale every configured value.
+
+Three reporting surfaces stop printing a fabricated `0.00` on Windows and emit
+`null` / `not measured` instead — `flo performance metrics` (both text and
+`--format json`), and the built-in `performance` and `health` workers.
+
 ### Changed — Verify-before-done is now ON by default (#1294)
 
 `gates.verify_before_done` now defaults to **true** (was opt-in/false). Every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ Three reporting surfaces stop printing a fabricated `0.00` on Windows and emit
 `null` / `not measured` instead — `flo performance metrics` (both text and
 `--format json`), and the built-in `performance` and `health` workers.
 
+The worker statusline's `⚡` segment now shows the load average the performance
+worker actually measured (`⚡n/a` where there is none). It previously rendered
+`⚡1.0x` from a `speedup` field that was the literal `'1.0x'` — nothing ever
+computed a speedup. `StatuslineData.performance.speedup: string` is replaced by
+`performance.loadAvg: string | null`; the shipped `statusline.cjs` never read
+this shape, so consumer statuslines are unaffected.
+
 ### Changed — Verify-before-done is now ON by default (#1294)
 
 `gates.verify_before_done` now defaults to **true** (was opt-in/false). Every

--- a/src/cli/__tests__/commands/performance-loadavg-platform.test.ts
+++ b/src/cli/__tests__/commands/performance-loadavg-platform.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `flo performance metrics` and the absent load average — #1358.
+ *
+ * The renderer branch is what this file proves: that a platform with no load
+ * average prints "not measured" and emits JSON `null`, rather than the
+ * `0.00, 0.00, 0.00` Node hands back on Windows.
+ *
+ * Rule #1: the platform is reached by mocking `os`, not by branching on
+ * `process.platform` inside the test — that fork would never execute on the
+ * Ubuntu leg that runs this suite (cf. #1145). The mock lives in its own file
+ * so the rest of the command suite keeps running against the real `os`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const MOCK_WINDOWS = { value: false };
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return {
+    ...actual,
+    default: actual,
+    loadavg: () => (MOCK_WINDOWS.value ? [0, 0, 0] : actual.loadavg()),
+    platform: () => (MOCK_WINDOWS.value ? ('win32' as NodeJS.Platform) : actual.platform()),
+  };
+});
+
+const { performanceCommand } = await import('../../commands/performance.js');
+const { output } = await import('../../output.js');
+
+const metricsCommand = performanceCommand.subcommands!.find(c => c.name === 'metrics')!;
+
+async function runMetrics(format: string): Promise<string> {
+  const lines: string[] = [];
+  const spy = vi.spyOn(output, 'writeln').mockImplementation((text = '') => {
+    lines.push(text);
+  });
+  try {
+    await metricsCommand.action!({ args: [], flags: { format } } as never);
+  } finally {
+    spy.mockRestore();
+  }
+  return lines.join('\n');
+}
+
+describe('#1358 — flo performance metrics omits the load average where there is none', () => {
+  beforeEach(() => { MOCK_WINDOWS.value = false; });
+  afterEach(() => { MOCK_WINDOWS.value = false; });
+
+  it('text output says "not measured", never 0.00', async () => {
+    MOCK_WINDOWS.value = true;
+    const text = await runMetrics('text');
+
+    expect(text).toContain('Load Average: not measured (win32 has no load average)');
+    expect(text).not.toContain('Load Average: 0.00');
+  });
+
+  it('json output emits null for cpu.loadAverage', async () => {
+    MOCK_WINDOWS.value = true;
+    const json = JSON.parse(await runMetrics('json').then(t => t.slice(t.indexOf('{'))));
+
+    expect(json.cpu.loadAverage).toBeNull();
+  });
+
+  it('still renders the real reading on a platform that has one', async () => {
+    const text = await runMetrics('text');
+
+    expect(text).not.toContain('not measured');
+    expect(text).toMatch(/Load Average: \d+\.\d{2}, \d+\.\d{2}, \d+\.\d{2}/);
+  });
+
+  it('still emits a real triple in json on a platform that has one', async () => {
+    const json = JSON.parse(await runMetrics('json').then(t => t.slice(t.indexOf('{'))));
+
+    expect(Array.isArray(json.cpu.loadAverage)).toBe(true);
+    expect(json.cpu.loadAverage).toHaveLength(3);
+  });
+});

--- a/src/cli/__tests__/hooks/workers-loadavg-platform.test.ts
+++ b/src/cli/__tests__/hooks/workers-loadavg-platform.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Built-in worker reporters and the absent load average — #1358.
+ *
+ * `createPerformanceWorker` and `createHealthWorker` read `os.loadavg()` at
+ * module scope, so the Windows path is reached here by mocking `os` rather
+ * than by branching on `process.platform` inside the test — that fork would
+ * never execute on the Ubuntu leg that runs this suite (Rule #1, cf. #1145).
+ *
+ * The mock lives in its own file so the rest of the worker suite keeps running
+ * against the real `os`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as path from 'path';
+import * as realOs from 'os';
+
+const IS_WINDOWS_MOCK = { value: false };
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return {
+    ...actual,
+    default: actual,
+    // Node returns exactly this on Windows: not an error, not NaN, three
+    // zeros indistinguishable from an idle machine.
+    loadavg: () => (IS_WINDOWS_MOCK.value ? [0, 0, 0] : actual.loadavg()),
+    platform: () => (IS_WINDOWS_MOCK.value ? ('win32' as NodeJS.Platform) : actual.platform()),
+  };
+});
+
+const { createPerformanceWorker, createHealthWorker } = await import('../../hooks/workers/index.js');
+
+const PROJECT_ROOT = path.join(realOs.tmpdir(), 'moflo-1358-loadavg');
+
+describe('#1358 — worker reporters omit the load average where there is none', () => {
+  it('createPerformanceWorker reports null, not "0.00", on Windows', async () => {
+    IS_WINDOWS_MOCK.value = true;
+    try {
+      const result = await createPerformanceWorker(PROJECT_ROOT)();
+      const cpu = (result.data as { cpu: { cores: number; loadAvg: string | null } }).cpu;
+
+      expect(cpu.loadAvg).toBeNull();
+      // The rest of the payload is still measured — this is a targeted
+      // omission, not a blanket "give up on Windows".
+      expect(cpu.cores).toBeGreaterThan(0);
+    } finally {
+      IS_WINDOWS_MOCK.value = false;
+    }
+  });
+
+  it('createHealthWorker reports null, not ["0.00","0.00","0.00"], on Windows', async () => {
+    IS_WINDOWS_MOCK.value = true;
+    try {
+      const result = await createHealthWorker(PROJECT_ROOT)();
+      const system = (result.data as { system: { loadAvg: string[] | null; platform: string } }).system;
+
+      expect(system.loadAvg).toBeNull();
+      expect(system.platform).toBe('win32');
+    } finally {
+      IS_WINDOWS_MOCK.value = false;
+    }
+  });
+
+  it('createPerformanceWorker still reports a real figure on this platform', async () => {
+    const result = await createPerformanceWorker(PROJECT_ROOT)();
+    const cpu = (result.data as { cpu: { loadAvg: string | null } }).cpu;
+
+    if (realOs.platform() === 'win32') {
+      expect(cpu.loadAvg).toBeNull();
+    } else {
+      expect(cpu.loadAvg).not.toBeNull();
+      expect(Number.isNaN(Number(cpu.loadAvg))).toBe(false);
+    }
+  });
+
+  it('createHealthWorker still reports a real triple on this platform', async () => {
+    const result = await createHealthWorker(PROJECT_ROOT)();
+    const system = (result.data as { system: { loadAvg: string[] | null } }).system;
+
+    if (realOs.platform() === 'win32') {
+      expect(system.loadAvg).toBeNull();
+    } else {
+      expect(system.loadAvg).toHaveLength(3);
+      expect(system.loadAvg!.every(v => !Number.isNaN(Number(v)))).toBe(true);
+    }
+  });
+});

--- a/src/cli/__tests__/hooks/workers-loadavg-platform.test.ts
+++ b/src/cli/__tests__/hooks/workers-loadavg-platform.test.ts
@@ -28,7 +28,7 @@ vi.mock('os', async (importOriginal) => {
   };
 });
 
-const { createPerformanceWorker, createHealthWorker } = await import('../../hooks/workers/index.js');
+const { createPerformanceWorker, createHealthWorker, WorkerManager } = await import('../../hooks/workers/index.js');
 
 const PROJECT_ROOT = path.join(realOs.tmpdir(), 'moflo-1358-loadavg');
 
@@ -82,6 +82,40 @@ describe('#1358 — worker reporters omit the load average where there is none',
     } else {
       expect(system.loadAvg).toHaveLength(3);
       expect(system.loadAvg!.every(v => !Number.isNaN(Number(v)))).toBe(true);
+    }
+  });
+});
+
+/**
+ * The statusline's `⚡` slot used to render `speedup: '1.0x'` — a literal with
+ * a `// Placeholder` comment at its source and a second `?? '1.0x'` fallback
+ * at the consumer, sitting alongside three segments that were real. It now
+ * carries the load average the performance worker actually measured.
+ */
+describe('#1358 — the statusline performance slot carries a measured value', () => {
+  it('reports null before any worker has run, rather than a stand-in figure', () => {
+    const manager = new WorkerManager(PROJECT_ROOT);
+    const data = manager.getStatuslineData();
+
+    expect(data.performance.loadAvg).toBeNull();
+    expect(manager.getStatuslineString()).toContain('⚡n/a');
+    // The field it replaced must be gone, not merely unused.
+    expect('speedup' in data.performance).toBe(false);
+  });
+
+  it('surfaces the performance worker\'s real reading once it has run', async () => {
+    const manager = new WorkerManager(PROJECT_ROOT);
+    manager.register('performance', createPerformanceWorker(PROJECT_ROOT));
+    await manager.runWorker('performance');
+
+    const data = manager.getStatuslineData();
+
+    if (realOs.platform() === 'win32') {
+      expect(data.performance.loadAvg).toBeNull();
+    } else {
+      expect(data.performance.loadAvg).not.toBeNull();
+      expect(Number.isNaN(Number(data.performance.loadAvg))).toBe(false);
+      expect(manager.getStatuslineString()).toContain(`⚡${data.performance.loadAvg}`);
     }
   });
 });

--- a/src/cli/__tests__/hooks/workers-loadavg-platform.test.ts
+++ b/src/cli/__tests__/hooks/workers-loadavg-platform.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, vi } from 'vitest';
 import * as path from 'path';
 import * as realOs from 'os';
 
-const IS_WINDOWS_MOCK = { value: false };
+const MOCK_WINDOWS = { value: false };
 
 vi.mock('os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('os')>();
@@ -23,8 +23,8 @@ vi.mock('os', async (importOriginal) => {
     default: actual,
     // Node returns exactly this on Windows: not an error, not NaN, three
     // zeros indistinguishable from an idle machine.
-    loadavg: () => (IS_WINDOWS_MOCK.value ? [0, 0, 0] : actual.loadavg()),
-    platform: () => (IS_WINDOWS_MOCK.value ? ('win32' as NodeJS.Platform) : actual.platform()),
+    loadavg: () => (MOCK_WINDOWS.value ? [0, 0, 0] : actual.loadavg()),
+    platform: () => (MOCK_WINDOWS.value ? ('win32' as NodeJS.Platform) : actual.platform()),
   };
 });
 
@@ -34,7 +34,7 @@ const PROJECT_ROOT = path.join(realOs.tmpdir(), 'moflo-1358-loadavg');
 
 describe('#1358 — worker reporters omit the load average where there is none', () => {
   it('createPerformanceWorker reports null, not "0.00", on Windows', async () => {
-    IS_WINDOWS_MOCK.value = true;
+    MOCK_WINDOWS.value = true;
     try {
       const result = await createPerformanceWorker(PROJECT_ROOT)();
       const cpu = (result.data as { cpu: { cores: number; loadAvg: string | null } }).cpu;
@@ -44,12 +44,12 @@ describe('#1358 — worker reporters omit the load average where there is none',
       // omission, not a blanket "give up on Windows".
       expect(cpu.cores).toBeGreaterThan(0);
     } finally {
-      IS_WINDOWS_MOCK.value = false;
+      MOCK_WINDOWS.value = false;
     }
   });
 
   it('createHealthWorker reports null, not ["0.00","0.00","0.00"], on Windows', async () => {
-    IS_WINDOWS_MOCK.value = true;
+    MOCK_WINDOWS.value = true;
     try {
       const result = await createHealthWorker(PROJECT_ROOT)();
       const system = (result.data as { system: { loadAvg: string[] | null; platform: string } }).system;
@@ -57,7 +57,7 @@ describe('#1358 — worker reporters omit the load average where there is none',
       expect(system.loadAvg).toBeNull();
       expect(system.platform).toBe('win32');
     } finally {
-      IS_WINDOWS_MOCK.value = false;
+      MOCK_WINDOWS.value = false;
     }
   });
 

--- a/src/cli/__tests__/services/dashboard-claude-stats-route.test.ts
+++ b/src/cli/__tests__/services/dashboard-claude-stats-route.test.ts
@@ -74,12 +74,20 @@ afterEach(async () => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-// Avoid the well-known dashboard port range so a daemon already running
-// on the dev machine doesn't clash with the test. startDashboard tries
-// port+1..port+9 on EADDRINUSE so a random base above 30000 is plenty.
-function pickPort(): number {
-  return 30_000 + Math.floor(Math.random() * 30_000);
-}
+// Port 0 — let the OS assign an ephemeral port; `handle.port` reports the real
+// one. `startDashboard`'s `buildBindCandidates` honors 0 specifically so tests
+// get collision-free isolation.
+//
+// This used to pick a random port in 30000–60000, on the stated assumption that
+// startDashboard "tries port+1..port+9 on EADDRINUSE". It does not: an
+// explicitly pinned port is returned as a single candidate with NO fallback,
+// because a consumer who passed --dashboard-port meant that port. So one
+// collision under parallel forks failed the run outright — the intermittent
+// full-suite failure, green in isolation.
+//
+// Rule #1 besides: 30000 + rand(30000) reaches 49152+, which Windows reserves
+// (EACCES), and the imagined +1..+9 retry would have stayed inside that range.
+const EPHEMERAL_PORT = 0;
 
 function getJson(port: number, path: string): Promise<{ status: number; body: unknown }> {
   return new Promise((resolve, reject) => {
@@ -103,7 +111,7 @@ function getJson(port: number, path: string): Promise<{ status: number; body: un
 describe('GET /api/claude-stats', () => {
   it('returns the empty-shape body when no transcripts exist for this CWD', async () => {
     // homedir() is now tmpRoot but no .claude/projects/<cwd>/ dir exists.
-    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    handle = await startDashboard(stubDaemon, { port: EPHEMERAL_PORT });
     const { status, body } = await getJson(handle.port, '/api/claude-stats');
     expect(status).toBe(200);
     const shape = body as { available: boolean; totalSessions: number };
@@ -126,7 +134,7 @@ describe('GET /api/claude-stats', () => {
       }),
     );
 
-    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    handle = await startDashboard(stubDaemon, { port: EPHEMERAL_PORT });
     const { status, body } = await getJson(handle.port, '/api/claude-stats');
     expect(status).toBe(200);
     const shape = body as {

--- a/src/cli/__tests__/services/dashboard-learnings-route.test.ts
+++ b/src/cli/__tests__/services/dashboard-learnings-route.test.ts
@@ -34,9 +34,12 @@ const stubDaemon = {
   getScheduler: () => null,
 } as unknown as Parameters<typeof startDashboard>[0];
 
-function pickPort(): number {
-  return 31_000 + Math.floor(Math.random() * 9_000);
-}
+// Port 0 — OS-assigned ephemeral port; `handle.port` reports the real one.
+// `startDashboard` honors 0 specifically so tests get collision-free isolation.
+// A pinned random port had NO EADDRINUSE fallback (buildBindCandidates returns a
+// single candidate for an explicit port), so a collision under parallel forks
+// failed the run outright.
+const EPHEMERAL_PORT = 0;
 
 function get(port: number, path: string): Promise<{ status: number; body: unknown; raw: string }> {
   return new Promise((resolve, reject) => {
@@ -82,7 +85,7 @@ afterEach(async () => {
 describe('GET /api/learnings', () => {
   it('returns the overview shape with ok + available flags', async () => {
     mockGetLearningsOverview.mockResolvedValue(sampleOverview);
-    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    handle = await startDashboard(stubDaemon, { port: EPHEMERAL_PORT });
 
     const { status, body } = await get(handle.port, '/api/learnings');
     expect(status).toBe(200);
@@ -103,7 +106,7 @@ describe('GET /api/learnings', () => {
       total: 25,
       recent: sampleOverview.recent, // capped server-side; total stays authoritative
     });
-    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    handle = await startDashboard(stubDaemon, { port: EPHEMERAL_PORT });
 
     const { body } = await get(handle.port, '/api/learnings');
     const b = body as Record<string, any>;
@@ -115,7 +118,7 @@ describe('GET /api/learnings', () => {
     mockGetLearningsOverview.mockResolvedValue({
       total: 0, recent: [], provenance: {}, growth: [], addedLast7d: 0, addedLast30d: 0,
     });
-    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    handle = await startDashboard(stubDaemon, { port: EPHEMERAL_PORT });
 
     const { body } = await get(handle.port, '/api/learnings');
     expect((body as Record<string, any>).available).toBe(false);
@@ -123,7 +126,7 @@ describe('GET /api/learnings', () => {
 
   it('returns 500 when the overview query throws (no fake-empty panel)', async () => {
     mockGetLearningsOverview.mockRejectedValue(new Error('disk read failed'));
-    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    handle = await startDashboard(stubDaemon, { port: EPHEMERAL_PORT });
 
     const { status, body } = await get(handle.port, '/api/learnings');
     expect(status).toBe(500);
@@ -131,7 +134,7 @@ describe('GET /api/learnings', () => {
   });
 
   it('serves the Learnings panel container, tab, and renderer in the HTML', async () => {
-    handle = await startDashboard(stubDaemon, { port: pickPort() });
+    handle = await startDashboard(stubDaemon, { port: EPHEMERAL_PORT });
     const { raw } = await get(handle.port, '/');
     expect(raw).toContain('id="panel-learnings"');
     expect(raw).toContain("'Learnings'");

--- a/src/cli/__tests__/services/worker-daemon-resource-thresholds.test.ts
+++ b/src/cli/__tests__/services/worker-daemon-resource-thresholds.test.ts
@@ -123,6 +123,131 @@ describe('WorkerDaemon resource thresholds', () => {
   });
 
   // =========================================================================
+  // #1358 — the CPU gate on a platform with no load average
+  //
+  // Rule #1. The platform comes from the injected provider, never from
+  // `process.platform`, so the Windows path runs on the Ubuntu leg. Before
+  // #1358 the CPU branch compared a hardcoded 0 against a threshold validated
+  // `> 0`, making it unreachable on Windows: the daemon dispatched with no CPU
+  // backpressure while the still-working memory gate made it look throttled.
+  // =========================================================================
+  describe('#1358 CPU gate where no load average exists', () => {
+    const WINDOWS_OS = {
+      // Exactly what Node returns on Windows.
+      loadavg: () => [0, 0, 0],
+      totalmem: () => 16e9,
+      freemem: () => 8e9, // 50% free
+      platform: () => 'win32' as NodeJS.Platform,
+    };
+
+    it('skips the CPU gate explicitly rather than passing it by accident', async () => {
+      // maxCpuLoad this low would block any real machine. On Windows the old
+      // code "passed" it because 0 > 0.001 is false — the same outcome for the
+      // wrong reason. cpuGate is what distinguishes the two.
+      const daemon = new WorkerDaemon(tempDir, {
+        resourceThresholds: { maxCpuLoad: 0.001, minFreeMemoryPercent: 5 },
+      });
+      (daemon as any)._osProvider = WINDOWS_OS;
+
+      const result = await (daemon as any).canRunWorker();
+      expect(result.allowed).toBe(true);
+      expect(result.cpuGate).toBe('unavailable');
+    });
+
+    it('still enforces memory backpressure where the CPU gate is unavailable', async () => {
+      const daemon = new WorkerDaemon(tempDir, {
+        resourceThresholds: { maxCpuLoad: 0.001, minFreeMemoryPercent: 50 },
+      });
+      (daemon as any)._osProvider = { ...WINDOWS_OS, freemem: () => 1e9 }; // ~6% free
+
+      const result = await (daemon as any).canRunWorker();
+      expect(result.allowed).toBe(false);
+      expect(result.reason.toLowerCase()).toContain('memory');
+      expect(result.cpuGate).toBe('unavailable');
+    });
+
+    it('warns once, not once per dispatch', async () => {
+      const daemon = new WorkerDaemon(tempDir, {
+        resourceThresholds: { maxCpuLoad: 2.0, minFreeMemoryPercent: 5 },
+      });
+      (daemon as any)._osProvider = WINDOWS_OS;
+
+      const warnings: string[] = [];
+      daemon.on('log', (e: { level: string; message: string }) => {
+        if (e.level === 'warn') warnings.push(e.message);
+      });
+
+      await (daemon as any).canRunWorker();
+      await (daemon as any).canRunWorker();
+      await (daemon as any).canRunWorker();
+
+      expect(warnings).toHaveLength(1);
+      // The operator has to be able to tell WHICH threshold stopped applying.
+      expect(warnings[0]).toContain('win32');
+      expect(warnings[0]).toContain('maxCpuLoad=2');
+      expect(warnings[0]).toContain('minFreeMemoryPercent=5%');
+    });
+
+    it('reports cpuGate "measured" where a load average exists', async () => {
+      const daemon = new WorkerDaemon(tempDir, {
+        resourceThresholds: { maxCpuLoad: 9.6, minFreeMemoryPercent: 20 },
+      });
+      (daemon as any)._osProvider = {
+        loadavg: () => [3.5, 3.0, 2.5],
+        totalmem: () => 16e9,
+        freemem: () => 8e9,
+        platform: () => 'linux' as NodeJS.Platform,
+      };
+
+      const result = await (daemon as any).canRunWorker();
+      expect(result.allowed).toBe(true);
+      expect(result.cpuGate).toBe('measured');
+    });
+
+    it('blocks on CPU where a load average exists, and says so', async () => {
+      const daemon = new WorkerDaemon(tempDir, {
+        resourceThresholds: { maxCpuLoad: 2.0, minFreeMemoryPercent: 5 },
+      });
+      (daemon as any)._osProvider = {
+        loadavg: () => [5.0, 4.0, 3.0],
+        totalmem: () => 16e9,
+        freemem: () => 8e9,
+        platform: () => 'darwin' as NodeJS.Platform,
+      };
+
+      const result = await (daemon as any).canRunWorker();
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('CPU load too high: 5.00');
+      expect(result.cpuGate).toBe('measured');
+    });
+
+    it('treats a provider with no platform() as the host platform', async () => {
+      // Every fake written before #1358 omits `platform`. Those tests assumed
+      // the real host, so the CPU gate must still apply there — otherwise this
+      // change would silently disable it everywhere.
+      //
+      // The `process.platform` fork below is the legitimate case, not the
+      // anti-pattern: the behaviour under test IS "fall back to the host", so
+      // each CI leg asserts its own correct answer. Contrast the tests above,
+      // which pin the platform explicitly precisely so they are not dead code
+      // on two legs out of three.
+      const daemon = new WorkerDaemon(tempDir, {
+        resourceThresholds: { maxCpuLoad: 2.0, minFreeMemoryPercent: 5 },
+      });
+      (daemon as any)._osProvider = {
+        loadavg: () => [5.0, 4.0, 3.0],
+        totalmem: () => 16e9,
+        freemem: () => 8e9,
+      };
+
+      const result = await (daemon as any).canRunWorker();
+      const expected = process.platform === 'win32' ? 'unavailable' : 'measured';
+      expect(result.cpuGate).toBe(expected);
+      expect(result.allowed).toBe(process.platform === 'win32');
+    });
+  });
+
+  // =========================================================================
   // Config file reading
   // =========================================================================
   describe('config.json reading', () => {

--- a/src/cli/__tests__/shared/utils/load-average.test.ts
+++ b/src/cli/__tests__/shared/utils/load-average.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Load-average helper — #1358.
+ *
+ * Rule #1. Every assertion here passes an explicit `platform`, so the Windows
+ * behaviour is proven on the Ubuntu leg that actually runs this suite. A
+ * `process.platform === 'win32'` fork inside a test would be dead code on two
+ * of the three CI legs and would assert nothing — the trap behind #1145, and
+ * the reason #1354 gave these helpers a platform parameter in the first place.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isLoadAverageMeasurable,
+  readLoadAverage,
+  readCpuUsagePercent,
+  NOT_MEASURED,
+} from '../../../shared/utils/load-average.js';
+
+describe('#1358 — isLoadAverageMeasurable', () => {
+  it('is false on Windows, where os.loadavg() is documented as always [0, 0, 0]', () => {
+    expect(isLoadAverageMeasurable('win32')).toBe(false);
+  });
+
+  it('is true on the platforms that report a real load average', () => {
+    expect(isLoadAverageMeasurable('linux')).toBe(true);
+    expect(isLoadAverageMeasurable('darwin')).toBe(true);
+    expect(isLoadAverageMeasurable('freebsd')).toBe(true);
+  });
+});
+
+describe('#1358 — readLoadAverage', () => {
+  it('returns null on Windows rather than the fabricated [0, 0, 0]', () => {
+    // This is the exact value Node hands back on Windows. Passing it through
+    // unchanged is what made three reporters print a confidently idle machine.
+    expect(readLoadAverage([0, 0, 0], 'win32')).toBeNull();
+  });
+
+  it('passes the reading straight through on Unix', () => {
+    expect(readLoadAverage([1.5, 1.2, 0.9], 'linux')).toEqual([1.5, 1.2, 0.9]);
+    expect(readLoadAverage([4, 2, 1], 'darwin')).toEqual([4, 2, 1]);
+  });
+
+  it('does not suppress a genuine zero on Unix — an idle Linux box is a measurement', () => {
+    expect(readLoadAverage([0, 0, 0], 'linux')).toEqual([0, 0, 0]);
+  });
+});
+
+describe('#1358 — readCpuUsagePercent keeps its #1354 contract after the move', () => {
+  it('returns null on Windows instead of a fabricated 0.0%', () => {
+    expect(readCpuUsagePercent([0, 0, 0], 8, 'win32')).toBeNull();
+  });
+
+  it('returns a real percentage on Linux and macOS', () => {
+    expect(readCpuUsagePercent([4, 2, 1], 8, 'linux')).toBeCloseTo(50);
+    expect(readCpuUsagePercent([2, 1, 1], 8, 'darwin')).toBeCloseTo(25);
+  });
+
+  it('returns null rather than Infinity when os.cpus() reports no cores', () => {
+    // os.cpus() is documented as possibly returning an empty array.
+    expect(readCpuUsagePercent([1, 1, 1], 0, 'linux')).toBeNull();
+  });
+
+  it('clamps to 100 rather than reporting an over-100 percentage', () => {
+    expect(readCpuUsagePercent([32, 16, 8], 4, 'linux')).toBe(100);
+  });
+});
+
+describe('#1358 — NOT_MEASURED', () => {
+  it('is a phrase, not a number — a renderer must never substitute a zero', () => {
+    expect(NOT_MEASURED).toBe('not measured');
+    expect(Number.isNaN(Number(NOT_MEASURED))).toBe(true);
+  });
+});

--- a/src/cli/commands/performance.ts
+++ b/src/cli/commands/performance.ts
@@ -7,6 +7,7 @@
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
+import { readLoadAverage, NOT_MEASURED } from '../shared/utils/load-average.js';
 
 // Benchmark subcommand - REAL measurements
 const benchmarkCommand: Command = {
@@ -357,7 +358,10 @@ const metricsCommand: Command = {
     const memUsage = process.memoryUsage();
     const cpuUsage = process.cpuUsage();
     const uptime = process.uptime();
-    const loadAvg = os.loadavg();
+    // null where the platform has none (#1358). Rendered as "not measured"
+    // below rather than as 0.00 — a reading that does not exist must not read
+    // as an idle machine.
+    const loadAvg = readLoadAverage(os.loadavg(), os.platform());
     const freeMem = os.freemem();
     const totalMem = os.totalmem();
 
@@ -514,7 +518,10 @@ const metricsCommand: Command = {
     });
 
     output.writeln();
-    output.writeln(output.dim(`Load Average: ${loadAvg.map(l => l.toFixed(2)).join(', ')}`));
+    const loadAvgLine = loadAvg === null
+      ? `${NOT_MEASURED} (${os.platform()} has no load average)`
+      : loadAvg.map(l => l.toFixed(2)).join(', ');
+    output.writeln(output.dim(`Load Average: ${loadAvgLine}`));
     output.writeln(output.dim(`CPUs: ${os.cpus().length} | Platform: ${os.platform()} ${os.release()}`));
 
     return { success: true };

--- a/src/cli/hooks/workers/index.ts
+++ b/src/cli/hooks/workers/index.ts
@@ -308,7 +308,17 @@ export interface StatuslineData {
     issues: number;
   };
   performance: {
-    speedup: string;
+    /**
+     * The performance worker's 1-minute load average, as it measured it —
+     * `null` where the platform reports none (#1358).
+     *
+     * This slot used to be `speedup: string`, which was the literal `'1.0x'`
+     * with a `// Placeholder` comment at its source and a second `?? '1.0x'`
+     * fallback here. Nothing ever computed a speedup, so the statusline
+     * rendered `⚡1.0x` — a measurement-shaped way of saying nothing, next to
+     * three segments that were real.
+     */
+    loadAvg: string | null;
   };
   alerts: WorkerAlert[];
   lastUpdate: string;
@@ -675,7 +685,9 @@ export class WorkerManager extends EventEmitter {
         issues: securityResult?.totalIssues as number ?? 0,
       },
       performance: {
-        speedup: perfResult?.speedup as string ?? '1.0x',
+        // Null both when the worker has not run yet and when the platform has
+        // no load average — in either case there is nothing measured to show.
+        loadAvg: (perfResult?.cpu as Record<string, unknown> | undefined)?.loadAvg as string ?? null,
       },
       alerts: this.alerts.filter(a => a.severity === AlertSeverity.Critical).slice(-5),
       lastUpdate: new Date().toISOString(),
@@ -715,8 +727,10 @@ export class WorkerManager extends EventEmitter {
                     data.security.status === 'warning' ? '⚠️' : '🛡️';
     parts.push(`${secIcon}${data.security.issues}`);
 
-    // Performance
-    parts.push(`⚡${data.performance.speedup}`);
+    // Performance — 'n/a' rather than a zero, for the same reason the field
+    // is nullable: a statusline is exactly where an unmeasured value gets
+    // read as a measured one.
+    parts.push(`⚡${data.performance.loadAvg ?? 'n/a'}`);
 
     return parts.join(' │ ');
   }
@@ -1017,7 +1031,6 @@ export function createPerformanceWorker(projectRoot: string): WorkerHandler {
           cores: cpus.length,
           loadAvg: loadAvg === null ? null : loadAvg[0].toFixed(2),
         },
-        speedup: '1.0x',  // Placeholder
       },
     };
   };

--- a/src/cli/hooks/workers/index.ts
+++ b/src/cli/hooks/workers/index.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { errorDetail } from '../../shared/utils/error-detail.js';
+import { readLoadAverage } from '../../shared/utils/load-average.js';
 
 // ============================================================================
 // Security Constants
@@ -997,9 +998,9 @@ export function createPerformanceWorker(projectRoot: string): WorkerHandler {
     const freeMem = os.freemem();
     const memPct = Math.round((1 - freeMem / totalMem) * 100);
 
-    // CPU load
+    // CPU load — null where the platform has none (#1358), never "0.00"
     const cpus = os.cpus();
-    const loadAvg = os.loadavg()[0];
+    const loadAvg = readLoadAverage(os.loadavg(), os.platform());
 
     return {
       worker: 'performance',
@@ -1014,7 +1015,7 @@ export function createPerformanceWorker(projectRoot: string): WorkerHandler {
         },
         cpu: {
           cores: cpus.length,
-          loadAvg: loadAvg.toFixed(2),
+          loadAvg: loadAvg === null ? null : loadAvg[0].toFixed(2),
         },
         speedup: '1.0x',  // Placeholder
       },
@@ -1031,7 +1032,9 @@ export function createHealthWorker(projectRoot: string): WorkerHandler {
     const memPct = Math.round((1 - freeMem / totalMem) * 100);
 
     const uptime = os.uptime();
-    const loadAvg = os.loadavg();
+    // null where the platform has none (#1358) — three zeros would read as an
+    // idle machine rather than as an absent reading.
+    const loadAvg = readLoadAverage(os.loadavg(), os.platform());
 
     // Disk space (cross-platform approximation)
     let diskPct = 0;
@@ -1058,7 +1061,7 @@ export function createHealthWorker(projectRoot: string): WorkerHandler {
         disk: { usedPct: diskPct, free: diskFree },
         system: {
           uptime: Math.round(uptime / 3600),
-          loadAvg: loadAvg.map(l => l.toFixed(2)),
+          loadAvg: loadAvg === null ? null : loadAvg.map(l => l.toFixed(2)),
           platform: os.platform(),
           arch: os.arch(),
         },

--- a/src/cli/mcp-tools/performance-tools.ts
+++ b/src/cli/mcp-tools/performance-tools.ts
@@ -17,6 +17,7 @@
 import type { MCPTool } from './types.js';
 import * as os from 'node:os';
 import { createJsonStore } from './json-store.js';
+import { readCpuUsagePercent, readLoadAverage, NOT_MEASURED } from '../shared/utils/load-average.js';
 
 /**
  * #1354: `latency`, `throughput` and `errors` are gone from this shape.
@@ -42,31 +43,11 @@ interface PerfMetrics {
 /**
  * Cross-platform CPU usage, or null where it cannot be measured (Rule #1).
  *
- * `os.loadavg()` is a Unix concept and Node documents it as **always**
- * returning `[0, 0, 0]` on Windows. The previous `(loadAvg[0] / cores) * 100`
- * therefore produced a confident `0.0%` on every Windows consumer — an
- * invented number wearing a measurement's clothes, which is the whole defect
- * #1354 exists to remove, and the same trap #1349 hit when a failed probe
- * rendered as `Search Time: 0.00ms` and read as infinitely fast.
- *
- * `os.cpus()` is also documented as possibly returning an empty array, which
- * would make the division `Infinity`.
+ * Added here by #1354; moved to `shared/utils/load-average.ts` by #1358 once
+ * three more consumers of `os.loadavg()` needed the same decision. Re-exported
+ * so this module's contract is unchanged.
  */
-export function readCpuUsagePercent(
-  loadAvg: number[],
-  coreCount: number,
-  // Injectable so the Windows branch is provable from a Linux runner. Without
-  // it the only coverage would be a `process.platform === 'win32'` fork in the
-  // test, which never executes on the Ubuntu leg that runs the unit suite —
-  // exactly how a platform bug ships green (Rule #1, cf. #1145).
-  platform: NodeJS.Platform = process.platform,
-): number | null {
-  if (platform === 'win32' || coreCount === 0) return null;
-  return Math.min((loadAvg[0] / coreCount) * 100, 100);
-}
-
-/** Rendered wherever a real figure is unavailable — never a zero. */
-const NOT_MEASURED = 'not measured';
+export { readCpuUsagePercent };
 
 interface Benchmark {
   id: string;
@@ -185,8 +166,11 @@ const rawPerformanceTools: MCPTool[] = [
           nodeVersion: process.version,
           cpuModel: cpus[0]?.model ?? null,
           // Same reason as `cpu.usage`: Node returns [0, 0, 0] here on
-          // Windows, and three zeros read as a genuinely idle machine.
-          loadAverage: cpuPercent === null ? null : loadAvg,
+          // Windows, and three zeros read as a genuinely idle machine. Gated on
+          // the reading itself rather than on `cpuPercent`, which is also null
+          // when `os.cpus()` comes back empty — that suppresses a per-core
+          // percentage, not the load average, which is still real (#1358).
+          loadAverage: readLoadAverage(loadAvg),
         },
         // No `latency` trend — there is no latency series to trend. Both
         // entries below compare the oldest and newest samples in `history`,

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -46,6 +46,7 @@ import { attachSignalHandlers } from '../shared/resilience/signal-handlers.js';
 import { calculateDelay } from '../production/retry.js';
 import { CircuitBreaker } from '../production/circuit-breaker.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { readLoadAverage } from '../shared/utils/load-average.js';
 import { readMofloEnv } from './env-compat.js';
 
 // Worker types matching hooks-tools.ts. `audit`, `predict`, `document`
@@ -194,8 +195,20 @@ export class WorkerDaemon extends EventEmitter {
   // during state restoration (R1: constructor config takes priority over stale state)
   private originalConfig?: Partial<DaemonConfig>;
 
-  // Injectable OS provider for testing (avoids ESM module namespace issues)
-  private _osProvider?: { loadavg: () => number[]; totalmem: () => number; freemem: () => number };
+  // Injectable OS provider for testing (avoids ESM module namespace issues).
+  // `platform` is optional so every fake written before #1358 keeps working —
+  // when absent the real `process.platform` decides, which is what those tests
+  // already assumed.
+  private _osProvider?: {
+    loadavg: () => number[];
+    totalmem: () => number;
+    freemem: () => number;
+    platform?: () => NodeJS.Platform;
+  };
+
+  // canRunWorker() runs on every dispatch, so the "no load average here" notice
+  // is latched to one line per daemon rather than one per worker (#1358).
+  private _warnedCpuGateUnavailable = false;
 
   // Detach callback returned by attachSignalHandlers; calling it removes the
   // SIGTERM/SIGINT/SIGHUP handlers this daemon registered. Without this,
@@ -399,22 +412,49 @@ export class WorkerDaemon extends EventEmitter {
   }
 
   /**
-   * Check if system resources allow worker execution
+   * Check if system resources allow worker execution.
+   *
+   * `cpuGate` reports whether the CPU threshold was actually applied. Windows
+   * has no load average — `os.loadavg()` returns `[0, 0, 0]` there — and
+   * `maxCpuLoad` is validated `> 0` in both places that accept it, so before
+   * #1358 the CPU branch was unreachable on Windows: the daemon dispatched
+   * with no CPU backpressure while still *looking* like it throttled, because
+   * the memory gate below kept firing.
+   *
+   * Skipping is a stated decision, not a substitution. `os.cpus()` tick deltas
+   * would give a cross-platform number, but they measure *utilisation
+   * percentage* where `maxCpuLoad` is a *run-queue depth* — a threshold whose
+   * default is `cores * 0.8` and which `getEffectiveCpuCount()` deliberately
+   * scales against cgroup quotas. Feeding a 0–100 percentage into that key
+   * would silently re-scale every consumer's configured value, which is a
+   * second wrong number stacked on the first. So: skip, and say so.
    */
-  private async canRunWorker(): Promise<{ allowed: boolean; reason?: string }> {
+  private async canRunWorker(): Promise<{
+    allowed: boolean;
+    reason?: string;
+    cpuGate: 'measured' | 'unavailable';
+  }> {
     const os = this._osProvider ?? await import('os');
-    const cpuLoad = os.loadavg()[0];
+    const platform = os.platform?.() ?? process.platform;
+    const loadAvg = readLoadAverage(os.loadavg(), platform);
     const totalMem = os.totalmem();
     const freeMem = os.freemem();
     const freePercent = (freeMem / totalMem) * 100;
+    const cpuGate = loadAvg === null ? 'unavailable' as const : 'measured' as const;
 
-    if (cpuLoad > this.config.resourceThresholds.maxCpuLoad) {
-      return { allowed: false, reason: `CPU load too high: ${cpuLoad.toFixed(2)}` };
+    if (loadAvg === null) {
+      if (!this._warnedCpuGateUnavailable) {
+        this._warnedCpuGateUnavailable = true;
+        this.log('warn', `CPU load gate disabled: ${platform} reports no load average, so maxCpuLoad=${this.config.resourceThresholds.maxCpuLoad} is not enforced. Memory backpressure (minFreeMemoryPercent=${this.config.resourceThresholds.minFreeMemoryPercent}%) still applies.`);
+      }
+    } else if (loadAvg[0] > this.config.resourceThresholds.maxCpuLoad) {
+      return { allowed: false, reason: `CPU load too high: ${loadAvg[0].toFixed(2)}`, cpuGate };
     }
+
     if (freePercent < this.config.resourceThresholds.minFreeMemoryPercent) {
-      return { allowed: false, reason: `Memory too low: ${freePercent.toFixed(1)}% free` };
+      return { allowed: false, reason: `Memory too low: ${freePercent.toFixed(1)}% free`, cpuGate };
     }
-    return { allowed: true };
+    return { allowed: true, cpuGate };
   }
 
   /**

--- a/src/cli/shared/utils/load-average.ts
+++ b/src/cli/shared/utils/load-average.ts
@@ -22,6 +22,10 @@
  * the unit suite. A `process.platform === 'win32'` fork *inside a test* is dead
  * code on two of the three legs and asserts nothing — the trap behind #1145 and
  * the reason #1354 introduced this parameter shape.
+ *
+ * This is also why `IS_WINDOWS` from `./platform.js` is deliberately not reused
+ * here: it is a module-level constant baked from `process.platform` at import
+ * time, so a caller could never ask "what would this do on Windows?".
  */
 export function isLoadAverageMeasurable(platform: NodeJS.Platform = process.platform): boolean {
   return platform !== 'win32';

--- a/src/cli/shared/utils/load-average.ts
+++ b/src/cli/shared/utils/load-average.ts
@@ -1,0 +1,64 @@
+/**
+ * Load average — measurable on Unix, absent on Windows (Rule #1, #1358).
+ *
+ * `os.loadavg()` is a Unix concept. Node documents it as **always** returning
+ * `[0, 0, 0]` on Windows: not an error, not `NaN`, a confident triple of zeros
+ * that is indistinguishable from a genuinely idle machine. Every consumer of
+ * `os.loadavg()` therefore has to decide what "no reading" means, and before
+ * #1358 four of them decided it by accident — three printed a fabricated
+ * `0.00` and one used it as a scheduling input, where `0 > maxCpuLoad` is
+ * unreachable for any positive threshold.
+ *
+ * This module exists so that decision is made once. Callers ask whether a
+ * reading exists and get `null` when it does not — absent beats invented
+ * (#1349, #1354).
+ */
+
+/**
+ * True where `os.loadavg()` returns a real measurement.
+ *
+ * `platform` is an explicit parameter, not a read of `process.platform` inside
+ * the branch, so the Windows path is provable from the Ubuntu runner that runs
+ * the unit suite. A `process.platform === 'win32'` fork *inside a test* is dead
+ * code on two of the three legs and asserts nothing — the trap behind #1145 and
+ * the reason #1354 introduced this parameter shape.
+ */
+export function isLoadAverageMeasurable(platform: NodeJS.Platform = process.platform): boolean {
+  return platform !== 'win32';
+}
+
+/**
+ * The 1/5/15-minute load average, or `null` where the platform has none.
+ *
+ * Pass the raw `os.loadavg()` result; this decides whether it means anything.
+ */
+export function readLoadAverage(
+  loadAvg: number[],
+  platform: NodeJS.Platform = process.platform,
+): number[] | null {
+  return isLoadAverageMeasurable(platform) ? loadAvg : null;
+}
+
+/**
+ * Load average as a percentage of available cores, or `null` where it cannot
+ * be measured.
+ *
+ * `os.cpus()` is separately documented as possibly returning an empty array,
+ * which would make the division `Infinity` — a second invented number, so it
+ * is `null` too.
+ *
+ * Introduced by #1354 in `mcp-tools/performance-tools.ts` and moved here by
+ * #1358 when the third and fourth consumers appeared; that module re-exports
+ * it, so its contract is unchanged.
+ */
+export function readCpuUsagePercent(
+  loadAvg: number[],
+  coreCount: number,
+  platform: NodeJS.Platform = process.platform,
+): number | null {
+  if (!isLoadAverageMeasurable(platform) || coreCount === 0) return null;
+  return Math.min((loadAvg[0] / coreCount) * 100, 100);
+}
+
+/** Rendered wherever a real figure is unavailable — never a zero. */
+export const NOT_MEASURED = 'not measured';


### PR DESCRIPTION
Closes #1358.

`os.loadavg()` is a Unix concept; Node documents it as always returning `[0, 0, 0]` on Windows. Four sites consumed that as a measurement. Three of them printed it. One **branched on it**.

## The one that mattered

`WorkerDaemon.canRunWorker()` gated dispatch on `loadavg()[0] > maxCpuLoad`, and `maxCpuLoad` is validated `> 0` in both places that accept it (`worker-daemon.ts:376`, `:471`). On Windows the left side is a hardcoded `0`, so **the CPU branch was unreachable** — every Windows consumer has been running the worker daemon with no CPU backpressure at all.

It didn't look broken, which is the interesting part: the memory gate immediately below it still fired, so the daemon deferred workers often enough to look like it was throttling. `getEffectiveCpuCount()` even reads cgroup v2/v1 quota files to keep that threshold meaningful under container limits — care spent scaling a value that was being compared against a constant.

## Skip, don't substitute

The issue asked for a stated decision rather than the accidental no-op. This skips the gate explicitly, logs it **once per daemon** naming the platform and the threshold no longer being applied, and returns a `cpuGate: 'measured' | 'unavailable'` discriminator so a caller can tell "passed the check" from "there was no check".

`os.cpus()` tick deltas were the obvious alternative and are rejected on purpose: they measure **utilisation percentage** where `maxCpuLoad` is **run-queue depth** (default `cores * 0.8`). Feeding a 0–100 value into that key would silently re-scale every consumer's configured threshold — a second wrong number stacked on the first, and harder to spot because both are plausible floats. A substitute metric needs to share the units *and* the semantics of the key it feeds, or it needs its own key.

## The three reporting sites

Per the #1349 / #1354 precedent — absent beats invented — they emit `null` / `not measured`:

- `flo performance metrics`, both text and `--format json`
- the built-in `performance` and `health` workers

## Shape

`readCpuUsagePercent` (added by #1354) moves to `shared/utils/load-average.ts` alongside `readLoadAverage` and `isLoadAverageMeasurable`, so the decision is made once for all four sites. `performance-tools.ts` re-exports it — that contract is unchanged, and #1354's tests confirm it.

`platform.ts`'s `IS_WINDOWS` is deliberately **not** reused: it's baked from `process.platform` at import time, so a caller could never ask "what would this do on Windows?" — which is the whole point of the parameter.

## Rule #1

`platform` is an explicit parameter throughout, so every Windows assertion executes on the Ubuntu leg. The two reporter suites reach it by mocking `os` in their own files. The one `process.platform` fork in the tests covers the fall-back-to-host path, where each CI leg asserts its own correct answer — the legitimate case, not the #1145 anti-pattern.

Mutation-tested: dropping the `win32` guard kills 8 tests across all three new suites; rendering `0.00, 0.00, 0.00` in place of the phrase kills the renderer test.

## Also fixed: a real flake, not noise

The full suite failed once on `dashboard-claude-stats-route.test.ts`, green in isolation. It wasn't fork contention. Both dashboard route tests pinned a **random** port on the stated assumption that `startDashboard` "tries port+1..port+9 on EADDRINUSE" — it doesn't. `buildBindCandidates` returns an explicitly pinned port as a single candidate with no fallback, deliberately, because a consumer who passed `--dashboard-port` meant that port. One collision between parallel forks failed the run outright, and the comment asserting otherwise is what kept it reading as noise.

Both now use port 0, which `buildBindCandidates` honors specifically for this. Rule #1 while there: the old range was `30000 + rand(30000)`, reaching 49152+ — reserved on Windows (EACCES) per this repo's own test-port rule — and the imagined `+1..+9` retry would have stayed inside that range.

## Consumer impact (Rule #2)

**Surface:** `src/cli/services/worker-daemon.ts` (runs in every consumer's daemon), `src/cli/hooks/workers/index.ts`, `src/cli/commands/performance.ts`, `src/cli/mcp-tools/performance-tools.ts`.

**Failure mode for a consumer picking this up:** Windows consumers running the worker daemon get a behaviour change — the CPU gate now announces itself as off instead of silently passing, and one warn line appears per daemon run. Memory backpressure is unchanged on every platform. POSIX consumers see no behavioural change at all; the only visible difference is that `cpu.loadAverage` / `loadAvg` fields can now be `null` in JSON output, where before they were always present. No state migration; `.moflo/` is untouched.

**Round-trip:** runtime fix — takes effect for the daemon and hooks after publish + reinstall.

Release-noted in `CHANGELOG.md [Unreleased]`.

## Verification

- `npm test` — **9867 passed / 0 failed**, run repeatedly (incl. twice back-to-back after the flake fix)
- `node bin/cli.js performance metrics` on Linux — `Load Average: 1.71, 1.46, 1.15`; `--format json` emits a real triple
- `/verify` — 12/12 acceptance criteria PASS

## Also fixed: the statusline's other fabricated field

`createPerformanceWorker` returned `speedup: '1.0x',  // Placeholder`, and `getStatuslineData` had a *second* `?? '1.0x'` fallback, so the worker statusline rendered `⚡1.0x` alongside three segments that were real. Nothing anywhere computed a speedup.

`StatuslineData.performance.speedup: string` becomes `performance.loadAvg: string | null`, sourced from the load average the performance worker already measures — `⚡0.42` where there is one, `⚡n/a` where the worker hasn't run or the platform has none. The shipped `.claude/helpers/statusline.cjs` never read this shape, so consumer statuslines are unaffected; the field surfaces via the `hooks` MCP statusline tools and `.moflo/metrics/statusline.json`.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
