### PR TITLE
fix(gates): credit the testing gate on an outcome, not an invocation (#1322)

### DIFF
--- a/.claude/helpers/gate-hook.mjs
+++ b/.claude/helpers/gate-hook.mjs
@@ -71,6 +71,40 @@ if (hookContext.tool_input && typeof hookContext.tool_input === 'object') {
   });
 }
 
+// #1322: forward the parts of tool_response that actually exist, so a gate can
+// observe an OUTCOME rather than only the intent it was handed.
+//
+// Claude Code's PostToolUse payload carries NO exit status — probed on v2.1.220,
+// tool_response for a Bash call is {stdout, stderr, interrupted, isImage,
+// noOutputExpected}. PostToolUse also does not fire at all when the command
+// exits non-zero, so the only case a gate can still be fooled by is an exit code
+// MASKED by a pipe or `|| true`, where the response looks clean. The runner's
+// own output is the sole remaining signal; record-test-run reads it in gate.cjs.
+//
+// Tail, not head. Every test runner prints its pass/fail summary LAST, so
+// clipping the front of a long log would discard the exact lines this exists to
+// read. Bounds are deliberately tight — Windows caps the whole environment
+// block at ~32K wide chars and fails the spawn rather than truncating, and
+// TOOL_INPUT_command is already forwarded uncapped alongside these.
+var MAX_RESPONSE_STDOUT = 4096;
+var MAX_RESPONSE_STDERR = 2048;
+function tailOf(value, max) {
+  return value.length > max ? value.slice(value.length - max) : value;
+}
+if (hookContext.tool_response && typeof hookContext.tool_response === 'object') {
+  var resp = hookContext.tool_response;
+  if (typeof resp.stdout === 'string' && resp.stdout) {
+    env.TOOL_RESPONSE_stdout = tailOf(resp.stdout, MAX_RESPONSE_STDOUT);
+  }
+  if (typeof resp.stderr === 'string' && resp.stderr) {
+    env.TOOL_RESPONSE_stderr = tailOf(resp.stderr, MAX_RESPONSE_STDERR);
+  }
+  // Boolean — the string-typed forwarding above would drop it silently.
+  if (typeof resp.interrupted === 'boolean') {
+    env.TOOL_RESPONSE_interrupted = String(resp.interrupted);
+  }
+}
+
 // Run gate.cjs with the enriched environment
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -498,6 +498,53 @@ function applyPromptStateReset(state, promptText) {
 // and language-native test commands. The bare-runner arm is anchored so that
 // `npm install jest`, `grep -r vitest src/`, and similar don't false-positive.
 var TEST_RUNNER_RE = /(?:^|[^a-z])(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?(?:test|t)(?:[:\s]|$)|\b(?:npx|pnpx)\s+(?:vitest|jest|mocha|ava|tap|jasmine|pytest)\b|(?:^|;|&&|\|\|)\s*(?:vitest|jest|pytest|mocha|jasmine|tap|ava)\s|\b(?:cargo|go|deno|dotnet|mvn)\s+test\b|\bgradle\w*\s+test\b/i;
+// #1322 — failure markers in a test runner's own OUTPUT.
+//
+// This is deliberately not an exit-code check: Claude Code's PostToolUse payload
+// carries no exit status, and PostToolUse does not fire at all when a command
+// exits non-zero — so an unmasked red suite already leaves testsRun false, by
+// accident of the hook lifecycle rather than by design. What DOES defeat the
+// gate is a masked exit (`npm test | tail -20`, `npm test || true`,
+// `npm test 2>&1 | grep -i fail`): the pipeline exits 0, PostToolUse fires with
+// a clean-looking response, and a red suite credits the gate. Output is the only
+// signal left, and it is genuinely weaker than a status — see the ticket.
+//
+// Every arm matches a SUMMARY shape a runner emits, never a bare "fail", which
+// occurs constantly in ordinary passing test names ("returns null when the
+// lookup failed"). The count arm excludes an explicit zero so jest's
+// `0 failed, 12 passed` cannot self-block.
+//
+// The count arm's trailing lookahead is what keeps a GREEN run from blocking
+// itself. Mocha's default spec reporter prints every passing test name, so
+// `npm test | tail -20` on a green suite legitimately contains lines like
+// `✓ handles 2 failed retries`. A real summary is followed by a delimiter or a
+// line end (`3 failed | 40 passed`, `1 failed, 2 passed`, `1 failing`), never by
+// more prose — so a lowercase word after the count means it is a sentence, not a
+// tally. `tests`/`test` is exempted because `2 failed tests` is a real summary.
+// Same-line whitespace only: at a line end there is nothing to disqualify.
+var TEST_FAILURE_RE = new RegExp([
+  '\\b(?!0\\b)\\d+\\s+(?:tests?\\s+)?(?:failed|failing|failures?)\\b(?![^\\S\\n]+(?!tests?\\b)[a-z])', // vitest/jest/pytest/mocha counts
+  '^\\s*(?:FAIL|FAILED)\\b',                                          // vitest + jest per-file, pytest FAILED
+  '^\\s*---\\s*FAIL:',                                                // go test
+  '\\btest result:\\s*FAILED\\b',                                     // cargo
+  '^npm ERR!',                                                        // npm wrapper around any of the above
+].join('|'), 'im');
+
+/**
+ * #1322 — why a just-fired record-test-run must NOT be credited, or null.
+ *
+ * Absent output is not evidence of failure: a quiet green `npm test > /dev/null`
+ * and a silently-masked red one are indistinguishable, and treating the pair as
+ * failures would block every consumer who redirects test output. Absent means
+ * unknown, and unknown keeps the pre-#1322 behaviour.
+ */
+function detectTestFailure() {
+  if (process.env.TOOL_RESPONSE_interrupted === 'true') return 'the run was interrupted';
+  var out = (process.env.TOOL_RESPONSE_stdout || '') + '\n' + (process.env.TOOL_RESPONSE_stderr || '');
+  if (!out.trim()) return null;
+  var hit = out.match(TEST_FAILURE_RE);
+  return hit ? 'output reports "' + hit[0].trim().slice(0, 40) + '"' : null;
+}
 // Edits to these don't change runtime behaviour, so they don't invalidate prior test/simplify runs.
 // Lock files and .gitignore are tracked but inert; package.json/*.yaml ARE source — they reset.
 var EDIT_RESET_SKIP_BOTH_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\/])(CHANGELOG(?:\.md)?|\.env\.example|package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$/i;
@@ -809,8 +856,17 @@ switch (command) {
   case 'record-test-run': {
     var cmd = process.env.TOOL_INPUT_command || '';
     if (TEST_RUNNER_RE.test(cmd)) {
+      // #1322 — a red run is evidence AGAINST the gate, so it also clears a
+      // flag an earlier green run earned. Without the reset, `npm test` (green)
+      // followed by an edit and `npm test | tail -20` (red) would leave the
+      // gate satisfied by the stale first run — the edit resets testsRun, but
+      // the masked red run would immediately set it back.
+      var failure = detectTestFailure();
       var s = readState();
-      if (!s.testsRun) {
+      if (failure) {
+        if (s.testsRun) { s.testsRun = false; writeState(s); }
+        process.stderr.write('gate: record-test-run not credited — ' + failure + '\n');
+      } else if (!s.testsRun) {
         s.testsRun = true;
         writeState(s);
       }
@@ -1018,7 +1074,7 @@ switch (command) {
       }
     }
     var missing = [];
-    if (config.testing_gate && !s.testsRun) missing.push('tests have not run since the last code edit (run npm test, vitest, jest, pytest, or similar)');
+    if (config.testing_gate && !s.testsRun) missing.push('tests have not run green since the last code edit (run npm test, vitest, jest, pytest, or similar — a run whose output reports failures does not count, #1322)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/flo-simplify (or /distill) has not run since the last code edit');
     if (config.learnings_gate && !s.learningsStored) missing.push('learnings have not been stored (call mcp__moflo__memory_store)');
     if (missing.length === 0) break;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — a masked test failure satisfied the testing gate (#1322)
+
+`record-test-run` set `testsRun = true` from the submitted command string alone,
+never looking at what the run produced. `gate-hook.mjs` parsed the hook payload's
+`tool_response` and then discarded it, so no gate could observe an outcome.
+
+The exposure is narrower than it first appears, and the ticket was rewritten
+around a probe rather than the original filing. Claude Code's PostToolUse hook
+does not fire at all when a Bash command exits non-zero, so an ordinary red suite
+already left the flag false — by accident of the hook lifecycle, not by design.
+What did defeat the gate is a **masked** exit: `npm test | tail -20`,
+`npm test || true`, `npm test 2>&1 | grep -i fail`. The pipeline exits 0,
+PostToolUse fires with a clean-looking response, and a red suite credited the
+gate.
+
+`tool_response.stdout` / `.stderr` (tail-kept, bounded to 4 KB / 2 KB so the
+Windows ~32 KB environment-block limit is never risked — runners print their
+summary last) and `.interrupted` now reach `gate.cjs` as `TOOL_RESPONSE_*`. A
+matched test command whose output carries a failure summary is not credited, and
+**clears** a `testsRun` an earlier green run had earned.
+
+There is no exit status anywhere in the payload, so this is output inspection,
+not exit-code fidelity — a genuinely weaker signal, and the code says so. Only
+summary shapes count (`2 failed`, `1 failing`, line-start `FAIL`/`FAILED`,
+`--- FAIL:`, `test result: FAILED`, `npm ERR!`); a bare "fail" never does,
+because it occurs constantly in ordinary passing test names. An explicit
+`0 failed` does not match, and empty output still credits — a quiet green
+`npm test > /dev/null` is indistinguishable from a silently-masked red one, so
+absent stays unknown.
+
+Also fixes pre-existing drift in the third copy of the bridge: `flo init` wrote
+a `gate-hook.mjs` that never received #1332's structured-input forwarding and
+still shelled out via `execSync` string concatenation, so consumers ran one
+bridge after init and another after the next session start. The generator now
+emits `bin/gate-hook.mjs` byte-for-byte, pinned by
+`tests/guards/gate-hook-parity-guard.test.ts`.
+
 ### Fixed — Windows worker daemon had no CPU backpressure (#1358)
 
 `os.loadavg()` is a Unix concept; Node documents it as always returning

--- a/bin/gate-hook.mjs
+++ b/bin/gate-hook.mjs
@@ -71,6 +71,40 @@ if (hookContext.tool_input && typeof hookContext.tool_input === 'object') {
   });
 }
 
+// #1322: forward the parts of tool_response that actually exist, so a gate can
+// observe an OUTCOME rather than only the intent it was handed.
+//
+// Claude Code's PostToolUse payload carries NO exit status — probed on v2.1.220,
+// tool_response for a Bash call is {stdout, stderr, interrupted, isImage,
+// noOutputExpected}. PostToolUse also does not fire at all when the command
+// exits non-zero, so the only case a gate can still be fooled by is an exit code
+// MASKED by a pipe or `|| true`, where the response looks clean. The runner's
+// own output is the sole remaining signal; record-test-run reads it in gate.cjs.
+//
+// Tail, not head. Every test runner prints its pass/fail summary LAST, so
+// clipping the front of a long log would discard the exact lines this exists to
+// read. Bounds are deliberately tight — Windows caps the whole environment
+// block at ~32K wide chars and fails the spawn rather than truncating, and
+// TOOL_INPUT_command is already forwarded uncapped alongside these.
+var MAX_RESPONSE_STDOUT = 4096;
+var MAX_RESPONSE_STDERR = 2048;
+function tailOf(value, max) {
+  return value.length > max ? value.slice(value.length - max) : value;
+}
+if (hookContext.tool_response && typeof hookContext.tool_response === 'object') {
+  var resp = hookContext.tool_response;
+  if (typeof resp.stdout === 'string' && resp.stdout) {
+    env.TOOL_RESPONSE_stdout = tailOf(resp.stdout, MAX_RESPONSE_STDOUT);
+  }
+  if (typeof resp.stderr === 'string' && resp.stderr) {
+    env.TOOL_RESPONSE_stderr = tailOf(resp.stderr, MAX_RESPONSE_STDERR);
+  }
+  // Boolean — the string-typed forwarding above would drop it silently.
+  if (typeof resp.interrupted === 'boolean') {
+    env.TOOL_RESPONSE_interrupted = String(resp.interrupted);
+  }
+}
+
 // Run gate.cjs with the enriched environment
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -498,6 +498,53 @@ function applyPromptStateReset(state, promptText) {
 // and language-native test commands. The bare-runner arm is anchored so that
 // `npm install jest`, `grep -r vitest src/`, and similar don't false-positive.
 var TEST_RUNNER_RE = /(?:^|[^a-z])(?:npm|yarn|pnpm|bun)\s+(?:run\s+)?(?:test|t)(?:[:\s]|$)|\b(?:npx|pnpx)\s+(?:vitest|jest|mocha|ava|tap|jasmine|pytest)\b|(?:^|;|&&|\|\|)\s*(?:vitest|jest|pytest|mocha|jasmine|tap|ava)\s|\b(?:cargo|go|deno|dotnet|mvn)\s+test\b|\bgradle\w*\s+test\b/i;
+// #1322 — failure markers in a test runner's own OUTPUT.
+//
+// This is deliberately not an exit-code check: Claude Code's PostToolUse payload
+// carries no exit status, and PostToolUse does not fire at all when a command
+// exits non-zero — so an unmasked red suite already leaves testsRun false, by
+// accident of the hook lifecycle rather than by design. What DOES defeat the
+// gate is a masked exit (`npm test | tail -20`, `npm test || true`,
+// `npm test 2>&1 | grep -i fail`): the pipeline exits 0, PostToolUse fires with
+// a clean-looking response, and a red suite credits the gate. Output is the only
+// signal left, and it is genuinely weaker than a status — see the ticket.
+//
+// Every arm matches a SUMMARY shape a runner emits, never a bare "fail", which
+// occurs constantly in ordinary passing test names ("returns null when the
+// lookup failed"). The count arm excludes an explicit zero so jest's
+// `0 failed, 12 passed` cannot self-block.
+//
+// The count arm's trailing lookahead is what keeps a GREEN run from blocking
+// itself. Mocha's default spec reporter prints every passing test name, so
+// `npm test | tail -20` on a green suite legitimately contains lines like
+// `✓ handles 2 failed retries`. A real summary is followed by a delimiter or a
+// line end (`3 failed | 40 passed`, `1 failed, 2 passed`, `1 failing`), never by
+// more prose — so a lowercase word after the count means it is a sentence, not a
+// tally. `tests`/`test` is exempted because `2 failed tests` is a real summary.
+// Same-line whitespace only: at a line end there is nothing to disqualify.
+var TEST_FAILURE_RE = new RegExp([
+  '\\b(?!0\\b)\\d+\\s+(?:tests?\\s+)?(?:failed|failing|failures?)\\b(?![^\\S\\n]+(?!tests?\\b)[a-z])', // vitest/jest/pytest/mocha counts
+  '^\\s*(?:FAIL|FAILED)\\b',                                          // vitest + jest per-file, pytest FAILED
+  '^\\s*---\\s*FAIL:',                                                // go test
+  '\\btest result:\\s*FAILED\\b',                                     // cargo
+  '^npm ERR!',                                                        // npm wrapper around any of the above
+].join('|'), 'im');
+
+/**
+ * #1322 — why a just-fired record-test-run must NOT be credited, or null.
+ *
+ * Absent output is not evidence of failure: a quiet green `npm test > /dev/null`
+ * and a silently-masked red one are indistinguishable, and treating the pair as
+ * failures would block every consumer who redirects test output. Absent means
+ * unknown, and unknown keeps the pre-#1322 behaviour.
+ */
+function detectTestFailure() {
+  if (process.env.TOOL_RESPONSE_interrupted === 'true') return 'the run was interrupted';
+  var out = (process.env.TOOL_RESPONSE_stdout || '') + '\n' + (process.env.TOOL_RESPONSE_stderr || '');
+  if (!out.trim()) return null;
+  var hit = out.match(TEST_FAILURE_RE);
+  return hit ? 'output reports "' + hit[0].trim().slice(0, 40) + '"' : null;
+}
 // Edits to these don't change runtime behaviour, so they don't invalidate prior test/simplify runs.
 // Lock files and .gitignore are tracked but inert; package.json/*.yaml ARE source — they reset.
 var EDIT_RESET_SKIP_BOTH_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\/])(CHANGELOG(?:\.md)?|\.env\.example|package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$/i;
@@ -809,8 +856,17 @@ switch (command) {
   case 'record-test-run': {
     var cmd = process.env.TOOL_INPUT_command || '';
     if (TEST_RUNNER_RE.test(cmd)) {
+      // #1322 — a red run is evidence AGAINST the gate, so it also clears a
+      // flag an earlier green run earned. Without the reset, `npm test` (green)
+      // followed by an edit and `npm test | tail -20` (red) would leave the
+      // gate satisfied by the stale first run — the edit resets testsRun, but
+      // the masked red run would immediately set it back.
+      var failure = detectTestFailure();
       var s = readState();
-      if (!s.testsRun) {
+      if (failure) {
+        if (s.testsRun) { s.testsRun = false; writeState(s); }
+        process.stderr.write('gate: record-test-run not credited — ' + failure + '\n');
+      } else if (!s.testsRun) {
         s.testsRun = true;
         writeState(s);
       }
@@ -1018,7 +1074,7 @@ switch (command) {
       }
     }
     var missing = [];
-    if (config.testing_gate && !s.testsRun) missing.push('tests have not run since the last code edit (run npm test, vitest, jest, pytest, or similar)');
+    if (config.testing_gate && !s.testsRun) missing.push('tests have not run green since the last code edit (run npm test, vitest, jest, pytest, or similar — a run whose output reports failures does not count, #1322)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/flo-simplify (or /distill) has not run since the last code edit');
     if (config.learnings_gate && !s.learningsStored) missing.push('learnings have not been stored (call mcp__moflo__memory_store)');
     if (missing.length === 0) break;

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -556,6 +556,53 @@ function applyPromptStateReset(state, promptText) {
   state.activeSddSlug = null;
 }
 var TEST_RUNNER_RE = /(?:^|[^a-z])(?:npm|yarn|pnpm|bun)\\s+(?:run\\s+)?(?:test|t)(?:[:\\s]|$)|\\b(?:npx|pnpx)\\s+(?:vitest|jest|mocha|ava|tap|jasmine|pytest)\\b|(?:^|;|&&|\\|\\|)\\s*(?:vitest|jest|pytest|mocha|jasmine|tap|ava)\\s|\\b(?:cargo|go|deno|dotnet|mvn)\\s+test\\b|\\bgradle\\w*\\s+test\\b/i;
+// #1322 — failure markers in a test runner's own OUTPUT.
+//
+// This is deliberately not an exit-code check: Claude Code's PostToolUse payload
+// carries no exit status, and PostToolUse does not fire at all when a command
+// exits non-zero — so an unmasked red suite already leaves testsRun false, by
+// accident of the hook lifecycle rather than by design. What DOES defeat the
+// gate is a masked exit (\`npm test | tail -20\`, \`npm test || true\`,
+// \`npm test 2>&1 | grep -i fail\`): the pipeline exits 0, PostToolUse fires with
+// a clean-looking response, and a red suite credits the gate. Output is the only
+// signal left, and it is genuinely weaker than a status — see the ticket.
+//
+// Every arm matches a SUMMARY shape a runner emits, never a bare "fail", which
+// occurs constantly in ordinary passing test names ("returns null when the
+// lookup failed"). The count arm excludes an explicit zero so jest's
+// \`0 failed, 12 passed\` cannot self-block.
+//
+// The count arm's trailing lookahead is what keeps a GREEN run from blocking
+// itself. Mocha's default spec reporter prints every passing test name, so
+// \`npm test | tail -20\` on a green suite legitimately contains lines like
+// \`✓ handles 2 failed retries\`. A real summary is followed by a delimiter or a
+// line end (\`3 failed | 40 passed\`, \`1 failed, 2 passed\`, \`1 failing\`), never by
+// more prose — so a lowercase word after the count means it is a sentence, not a
+// tally. \`tests\`/\`test\` is exempted because \`2 failed tests\` is a real summary.
+// Same-line whitespace only: at a line end there is nothing to disqualify.
+var TEST_FAILURE_RE = new RegExp([
+  '\\\\b(?!0\\\\b)\\\\d+\\\\s+(?:tests?\\\\s+)?(?:failed|failing|failures?)\\\\b(?![^\\\\S\\\\n]+(?!tests?\\\\b)[a-z])', // vitest/jest/pytest/mocha counts
+  '^\\\\s*(?:FAIL|FAILED)\\\\b',                                          // vitest + jest per-file, pytest FAILED
+  '^\\\\s*---\\\\s*FAIL:',                                                // go test
+  '\\\\btest result:\\\\s*FAILED\\\\b',                                     // cargo
+  '^npm ERR!',                                                        // npm wrapper around any of the above
+].join('|'), 'im');
+
+/**
+ * #1322 — why a just-fired record-test-run must NOT be credited, or null.
+ *
+ * Absent output is not evidence of failure: a quiet green \`npm test > /dev/null\`
+ * and a silently-masked red one are indistinguishable, and treating the pair as
+ * failures would block every consumer who redirects test output. Absent means
+ * unknown, and unknown keeps the pre-#1322 behaviour.
+ */
+function detectTestFailure() {
+  if (process.env.TOOL_RESPONSE_interrupted === 'true') return 'the run was interrupted';
+  var out = (process.env.TOOL_RESPONSE_stdout || '') + '\\n' + (process.env.TOOL_RESPONSE_stderr || '');
+  if (!out.trim()) return null;
+  var hit = out.match(TEST_FAILURE_RE);
+  return hit ? 'output reports "' + hit[0].trim().slice(0, 40) + '"' : null;
+}
 var EDIT_RESET_SKIP_BOTH_RE = /\\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\\\\/])(CHANGELOG(?:\\.md)?|\\.env\\.example|package-lock\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb)$/i;
 // #1297 — path-inert dirs (.github/workflows etc.); SYNC: mirrors bin/gate.cjs EDIT_RESET_SKIP_PATH_RE.
 var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\\\\/])\\.github[\\\\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\\\\/.]|$)/i;
@@ -713,8 +760,14 @@ switch (command) {
   case 'record-test-run': {
     var cmd = process.env.TOOL_INPUT_command || '';
     if (TEST_RUNNER_RE.test(cmd)) {
+      // #1322 — a red run is evidence AGAINST the gate, so it also clears a
+      // flag an earlier green run earned.
+      var failure = detectTestFailure();
       var s = readState();
-      if (!s.testsRun) {
+      if (failure) {
+        if (s.testsRun) { s.testsRun = false; writeState(s); }
+        process.stderr.write('gate: record-test-run not credited — ' + failure + '\\n');
+      } else if (!s.testsRun) {
         s.testsRun = true;
         writeState(s);
       }
@@ -824,7 +877,7 @@ switch (command) {
     if (!/(?:^|&&\\s*|\\|\\|\\s*|;\\s*)\\s*(?:[A-Z_][A-Z0-9_]*=\\S+\\s+)*gh\\s+pr\\s+create\\b/.test(cmd)) break;
     var s = readState();
     var missing = [];
-    if (config.testing_gate && !s.testsRun) missing.push('tests have not run since the last code edit (run npm test, vitest, jest, pytest, or similar)');
+    if (config.testing_gate && !s.testsRun) missing.push('tests have not run green since the last code edit (run npm test, vitest, jest, pytest, or similar — a run whose output reports failures does not count, #1322)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/flo-simplify (or /distill) has not run since the last code edit');
     if (config.learnings_gate && !s.learningsStored) missing.push('learnings have not been stored (call mcp__moflo__memory_store)');
     if (missing.length === 0) break;
@@ -950,15 +1003,24 @@ switch (command) {
 
 /**
  * Generate gate-hook.mjs — ESM wrapper that reads Claude Code stdin JSON
- * and passes tool_name + tool_input to gate.cjs via environment variables.
+ * and passes tool_name + tool_input + tool_response to gate.cjs via env vars.
  *
  * Claude Code hooks receive context as JSON on stdin but don't set env vars
  * for tool input. This script bridges that gap. It also translates exit code 1
  * from gate.cjs into exit code 2 (which Claude Code requires to block tools).
+ *
+ * **This must stay byte-identical to `bin/gate-hook.mjs`** — the launcher syncs
+ * that file into the same `.claude/helpers/gate-hook.mjs` this generator writes,
+ * so any divergence means `flo init` emits one bridge and the next session start
+ * silently swaps in another. It had drifted exactly that way before #1322: the
+ * generated copy never received #1332's structured-input forwarding and still
+ * shelled out via `execSync` string concatenation. Parity is pinned by
+ * `tests/guards/gate-hook-parity-guard.test.ts` — when you change one, copy the
+ * whole file across; do not hand-merge.
  */
 export function generateGateHookScript(): string {
   return `#!/usr/bin/env node
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { resolve } from 'path';
 
 var command = process.argv[2];
@@ -985,24 +1047,91 @@ try { if (stdinData.trim()) hookContext = JSON.parse(stdinData); } catch (e) {}
 var env = Object.assign({}, process.env);
 if (hookContext.tool_name) env.TOOL_NAME = hookContext.tool_name;
 // Forward Claude Code's session_id so gate.cjs can enforce memory-first
-// per-actor (#838) — each spawned subagent has its own session_id.
+// per-actor (#838) — each spawned subagent gets its own session_id, so a
+// shared workflow-state.json no longer lets one subagent's directive be
+// silently satisfied by the parent's earlier search.
 if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
   env.HOOK_SESSION_ID = hookContext.session_id;
 }
+// #1332: structured tool inputs are forwarded as JSON, not dropped.
+//
+// This previously forwarded ONLY string values, so any object-valued input was
+// invisible to gate.cjs. That blocked the verify-before-done gate from reading
+// \`/verify\`'s per-criterion verdict, which #1328 stores in memory_store's
+// \`metadata\` — an object. Parsing the verdict out of the prose \`value\` string
+// instead would re-create exactly the free-text dependency #1328 removed.
+//
+// Cross-platform (Rule #1): Windows caps a single environment variable at
+// ~32KB and the whole block at ~32K wide chars, and exceeding it fails the
+// spawn rather than truncating. Newly-forwarded values are therefore skipped
+// when oversized, not clipped — a truncated JSON blob would parse as malformed
+// on the far side and read as a corrupt record rather than an absent one.
+// \`metadata\` is capped at 64KB by memory_store, so a real verdict never nears
+// this. STRING values keep their previous uncapped behaviour byte-for-byte:
+// gate.cjs reads TOOL_INPUT_command, and dropping an oversized heredoc command
+// would silently stop check-dangerous-command from firing on the exact inputs
+// most worth checking.
+var MAX_STRUCTURED_LEN = 16384;
 if (hookContext.tool_input && typeof hookContext.tool_input === 'object') {
   Object.keys(hookContext.tool_input).forEach(function(key) {
-    if (typeof hookContext.tool_input[key] === 'string') {
-      env['TOOL_INPUT_' + key] = hookContext.tool_input[key];
+    var raw = hookContext.tool_input[key];
+    if (typeof raw === 'string') {
+      env['TOOL_INPUT_' + key] = raw;
+      return;
     }
+    var val;
+    if (typeof raw === 'number' || typeof raw === 'boolean') {
+      val = String(raw);
+    } else if (raw && typeof raw === 'object') {
+      try { val = JSON.stringify(raw); } catch (e) { return; }
+    } else {
+      return; // null/undefined/function — nothing meaningful to forward
+    }
+    if (val.length > MAX_STRUCTURED_LEN) return;
+    env['TOOL_INPUT_' + key] = val;
   });
+}
+
+// #1322: forward the parts of tool_response that actually exist, so a gate can
+// observe an OUTCOME rather than only the intent it was handed.
+//
+// Claude Code's PostToolUse payload carries NO exit status — probed on v2.1.220,
+// tool_response for a Bash call is {stdout, stderr, interrupted, isImage,
+// noOutputExpected}. PostToolUse also does not fire at all when the command
+// exits non-zero, so the only case a gate can still be fooled by is an exit code
+// MASKED by a pipe or \`|| true\`, where the response looks clean. The runner's
+// own output is the sole remaining signal; record-test-run reads it in gate.cjs.
+//
+// Tail, not head. Every test runner prints its pass/fail summary LAST, so
+// clipping the front of a long log would discard the exact lines this exists to
+// read. Bounds are deliberately tight — Windows caps the whole environment
+// block at ~32K wide chars and fails the spawn rather than truncating, and
+// TOOL_INPUT_command is already forwarded uncapped alongside these.
+var MAX_RESPONSE_STDOUT = 4096;
+var MAX_RESPONSE_STDERR = 2048;
+function tailOf(value, max) {
+  return value.length > max ? value.slice(value.length - max) : value;
+}
+if (hookContext.tool_response && typeof hookContext.tool_response === 'object') {
+  var resp = hookContext.tool_response;
+  if (typeof resp.stdout === 'string' && resp.stdout) {
+    env.TOOL_RESPONSE_stdout = tailOf(resp.stdout, MAX_RESPONSE_STDOUT);
+  }
+  if (typeof resp.stderr === 'string' && resp.stderr) {
+    env.TOOL_RESPONSE_stderr = tailOf(resp.stderr, MAX_RESPONSE_STDERR);
+  }
+  // Boolean — the string-typed forwarding above would drop it silently.
+  if (typeof resp.interrupted === 'boolean') {
+    env.TOOL_RESPONSE_interrupted = String(resp.interrupted);
+  }
 }
 
 // Run gate.cjs with the enriched environment
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\\/([a-z])\\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');
 try {
-  var output = execSync('node "' + gateScript + '" ' + command, {
-    env: env, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe']
+  var output = execFileSync('node', [gateScript, command], {
+    env: env, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true
   });
   if (output.trim()) process.stdout.write(output);
   process.exit(0);

--- a/tests/bin/gate-hook-tool-response-1322.test.ts
+++ b/tests/bin/gate-hook-tool-response-1322.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for #1322's gate-hook.mjs change — `tool_response` is forwarded to
+ * gate.cjs so a gate can observe an OUTCOME, not only the intent it was handed.
+ *
+ * The payload shape asserted here is the one Claude Code actually delivers,
+ * probed on v2.1.220: `{stdout, stderr, interrupted, isImage, noOutputExpected}`
+ * with **no exit status anywhere**. Nothing in this file should ever grow an
+ * `exitCode` expectation — that field's absence is the premise of the fix.
+ *
+ * These run the real bin/gate-hook.mjs as a subprocess with a hook payload on
+ * stdin, exactly as Claude Code invokes it, and use a stub gate.cjs that dumps
+ * the TOOL_RESPONSE_* environment it received.
+ *
+ * Cross-platform (Rule #1): temp roots go through `realpathSync` (macOS
+ * /var -> /private/var); the stub gate is spawned by the hook itself via
+ * execFileSync with an argv array, so no shell is involved on any platform.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+
+const HOOK = resolve(__dirname, '../../bin/gate-hook.mjs');
+
+let tmpDir: string;
+
+/** Stand in for gate.cjs: print every TOOL_RESPONSE_* var it was handed. */
+const STUB_GATE = `
+var out = {};
+Object.keys(process.env).forEach(function (k) {
+  if (k.indexOf('TOOL_RESPONSE_') === 0) out[k.slice('TOOL_RESPONSE_'.length)] = process.env[k];
+});
+process.stdout.write(JSON.stringify(out));
+`;
+
+function runHook(payload: Record<string, unknown>): Record<string, string> {
+  // Delete rather than blank any TOOL_RESPONSE_* the outer process carries: an
+  // empty-string var is still a *present* key, which would mask the
+  // absent-means-absent assertions below.
+  const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('TOOL_RESPONSE_')) delete env[key];
+  }
+  env.CLAUDE_PROJECT_DIR = tmpDir;
+
+  const stdout = execFileSync('node', [HOOK, 'record-test-run'], {
+    input: JSON.stringify({ tool_name: 'Bash', ...payload }),
+    env,
+    encoding: 'utf-8',
+    timeout: 30000,
+    windowsHide: true,
+  });
+  return JSON.parse(stdout || '{}');
+}
+
+beforeEach(() => {
+  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-hook-1322-')));
+  mkdirSync(join(tmpDir, '.claude', 'helpers'), { recursive: true });
+  writeFileSync(join(tmpDir, '.claude', 'helpers', 'gate.cjs'), STUB_GATE);
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('#1322 gate-hook forwards tool_response', () => {
+  it('forwards stdout and stderr', () => {
+    const env = runHook({
+      tool_response: { stdout: 'Tests  2 failed | 8 passed', stderr: 'warn: slow', interrupted: false },
+    });
+    expect(env.stdout).toBe('Tests  2 failed | 8 passed');
+    expect(env.stderr).toBe('warn: slow');
+  });
+
+  it('coerces the interrupted boolean to a string', () => {
+    // The pre-existing tool_input loop forwards only strings; copying that
+    // shape would silently drop `interrupted`, which is a boolean.
+    expect(runHook({ tool_response: { interrupted: true } }).interrupted).toBe('true');
+    expect(runHook({ tool_response: { interrupted: false } }).interrupted).toBe('false');
+  });
+
+  it('forwards nothing when tool_response is absent (PreToolUse)', () => {
+    // gate-hook.mjs runs on PreToolUse for five commands where tool_response
+    // cannot exist. Absent must stay absent — never a fabricated default.
+    expect(runHook({ tool_input: { command: 'npm test' } })).toEqual({});
+  });
+
+  it('ignores a non-object tool_response', () => {
+    expect(runHook({ tool_response: 'plain string result' })).toEqual({});
+    expect(runHook({ tool_response: null })).toEqual({});
+  });
+
+  it('omits empty stdout/stderr rather than forwarding empty strings', () => {
+    const env = runHook({ tool_response: { stdout: '', stderr: '', interrupted: false } });
+    expect(env.stdout).toBeUndefined();
+    expect(env.stderr).toBeUndefined();
+    expect(env.interrupted).toBe('false');
+  });
+
+  it('keeps the TAIL of oversized stdout, not the head', () => {
+    // Every runner prints its pass/fail summary LAST. Clipping the front of a
+    // long log would discard the exact lines the gate exists to read.
+    const summary = 'Tests  3 failed | 40 passed';
+    const env = runHook({ tool_response: { stdout: 'x'.repeat(20000) + summary } });
+    expect(env.stdout).toHaveLength(4096);
+    expect(env.stdout.endsWith(summary)).toBe(true);
+  });
+
+  it('bounds stderr too', () => {
+    const env = runHook({ tool_response: { stderr: 'y'.repeat(9000) + 'TAILMARK' } });
+    expect(env.stderr).toHaveLength(2048);
+    expect(env.stderr.endsWith('TAILMARK')).toBe(true);
+  });
+
+  it('keeps the combined forwarded payload well inside the Windows env budget', () => {
+    // Windows caps the whole environment block at ~32K wide chars and fails the
+    // spawn outright rather than truncating. TOOL_INPUT_command is already
+    // forwarded uncapped alongside these, so these two must stay small.
+    const env = runHook({ tool_response: { stdout: 'a'.repeat(99999), stderr: 'b'.repeat(99999) } });
+    expect(env.stdout.length + env.stderr.length).toBeLessThanOrEqual(8192);
+  });
+});

--- a/tests/bin/gate-test-outcome-1322.test.ts
+++ b/tests/bin/gate-test-outcome-1322.test.ts
@@ -1,0 +1,155 @@
+/**
+ * #1322 — `record-test-run` credits an OUTCOME, not an invocation.
+ *
+ * Background, because the obvious reading of this file is wrong: Claude Code's
+ * PostToolUse hook does **not** fire when a Bash command exits non-zero, so an
+ * ordinary red suite already left `testsRun` false before this change — by
+ * accident of the hook lifecycle, not by design. The defect is narrower: when
+ * the non-zero exit is MASKED (`npm test | tail -20`, `npm test || true`,
+ * `npm test 2>&1 | grep -i fail`) the pipeline exits 0, PostToolUse fires with a
+ * clean-looking response, and a red suite credits the gate.
+ *
+ * There is no exit status in the payload to consult, so the signal is the
+ * runner's own output. That is genuinely weaker than a status, and the tests
+ * below pin both directions of the trade: real failure summaries must be
+ * caught, and the phrasings that merely *look* like failures must not be.
+ *
+ * gate.cjs is spawned exactly as the hook spawns it. Cross-platform (Rule #1):
+ * no shell, argv arrays only, temp roots via realpathSync.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+
+const GATE = resolve(__dirname, '../../bin/gate.cjs');
+
+let tmpDir: string;
+
+interface Response { stdout?: string; stderr?: string; interrupted?: boolean }
+
+function stateFile(): string {
+  return join(tmpDir, '.claude', 'workflow-state.json');
+}
+
+function writeState(patch: Record<string, unknown>): void {
+  writeFileSync(stateFile(), JSON.stringify(patch));
+}
+
+function readTestsRun(): boolean {
+  return JSON.parse(readFileSync(stateFile(), 'utf-8')).testsRun;
+}
+
+/** Run record-test-run with the env gate-hook.mjs would have built. */
+function record(cmd: string, response: Response = {}): string {
+  const r = spawnSync('node', [GATE, 'record-test-run'], {
+    env: {
+      ...(process.env as Record<string, string>),
+      CLAUDE_PROJECT_DIR: tmpDir,
+      TOOL_INPUT_command: cmd,
+      TOOL_RESPONSE_stdout: response.stdout ?? '',
+      TOOL_RESPONSE_stderr: response.stderr ?? '',
+      TOOL_RESPONSE_interrupted: response.interrupted === undefined ? '' : String(response.interrupted),
+    },
+    encoding: 'utf-8',
+    timeout: 30000,
+    windowsHide: true,
+  });
+  return r.stderr || '';
+}
+
+beforeEach(() => {
+  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-gate-1322-')));
+  mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+  writeState({ testsRun: false });
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('#1322 a masked red suite does not credit the gate', () => {
+  it('leaves testsRun false when output reports failures', () => {
+    const stderr = record('npm test 2>&1 | tail -20', {
+      stdout: ' Test Files  1 failed | 40 passed (41)\n      Tests  3 failed | 9864 passed (9867)',
+    });
+    expect(readTestsRun()).toBe(false);
+    expect(stderr).toContain('record-test-run not credited');
+  });
+
+  it('CLEARS a testsRun already earned by an earlier green run', () => {
+    // Without the reset, `npm test` (green) then an edit then
+    // `npm test | tail -20` (red) leaves the gate satisfied: the edit resets
+    // the flag and the masked red run immediately sets it back.
+    writeState({ testsRun: true });
+    record('npm test || true', { stdout: 'Tests  1 failed | 2 passed' });
+    expect(readTestsRun()).toBe(false);
+  });
+
+  it.each([
+    ['vitest / jest counts', 'Tests  2 failed | 8 passed (10)'],
+    ['jest summary line', 'Tests:       1 failed, 2 passed, 3 total'],
+    ['pytest summary', '=========== 1 failed, 2 passed in 0.42s ==========='],
+    ['mocha', '  1 failing'],
+    ['vitest per-file marker', 'FAIL  src/cli/__tests__/foo.test.ts > does a thing'],
+    ['pytest per-test marker', 'FAILED tests/test_x.py::test_y - assert 1 == 2'],
+    ['go test', '--- FAIL: TestThing (0.00s)'],
+    ['cargo', 'test result: FAILED. 1 passed; 1 failed; 0 ignored'],
+    ['npm wrapper', 'npm ERR! Test failed.  See above for more details.'],
+    // The lookahead that rejects prose must not reject these: a tally at a line
+    // end has nothing after it, and "2 failed tests" is a summary, not a phrase.
+    ['a tally at end of line', 'Summary of all failing tests\n  2 failed'],
+    ['an explicit "N failed tests"', '4 failed tests, 20 passed'],
+  ])('detects a %s failure summary', (_label, output) => {
+    record('npm test | cat', { stdout: output });
+    expect(readTestsRun()).toBe(false);
+  });
+
+  it('does not credit an interrupted run', () => {
+    record('npm test', { stdout: 'partial output', interrupted: true });
+    expect(readTestsRun()).toBe(false);
+  });
+});
+
+describe('#1322 green and ambiguous runs are unaffected', () => {
+  it('still credits a genuinely passing run', () => {
+    record('npm test', { stdout: ' Test Files  41 passed (41)\n      Tests  9867 passed (9867)' });
+    expect(readTestsRun()).toBe(true);
+  });
+
+  it('still credits a run with no captured output', () => {
+    // A quiet green `npm test > /dev/null` and a silently-masked red one are
+    // indistinguishable. Absent means unknown, and unknown keeps the
+    // pre-#1322 behaviour rather than blocking every consumer who redirects.
+    record('npm test > /dev/null');
+    expect(readTestsRun()).toBe(true);
+  });
+
+  it('treats an explicit zero count as passing', () => {
+    // `0 failed` must not self-block — some reporters always print the segment.
+    record('npm test', { stdout: 'Tests:       0 failed, 12 passed, 12 total' });
+    expect(readTestsRun()).toBe(true);
+  });
+
+  it.each([
+    ['a passing test whose NAME contains "failed"', '  ✓ returns null when the lookup failed (3 ms)'],
+    ['a passing test whose name contains "failure"', '  ✓ surfaces a failure reason to the caller'],
+    ['prose mentioning failures', 'Note: retries on transient failure are covered elsewhere'],
+    ['a zero-failure cargo line', 'test result: ok. 42 passed; 0 failed; 0 ignored'],
+    // Mocha's default spec reporter prints every PASSING test name, so a green
+    // `npm test | tail -20` genuinely contains lines shaped like a tally. These
+    // are the false positives that would block a legitimate PR.
+    ['a passing mocha test named with a count', '    ✓ retries 2 failed requests before giving up'],
+    ['a passing test named with a failure count', '  ✓ reports 3 failing shards to the coordinator'],
+  ])('does not false-positive on %s', (_label, output) => {
+    record('npm test', { stdout: `${output}\n Tests  12 passed (12)` });
+    expect(readTestsRun()).toBe(true);
+  });
+
+  it('ignores tool_response entirely for a non-test command', () => {
+    record('git status', { stdout: 'Tests  3 failed' });
+    expect(readTestsRun()).toBe(false); // unchanged — never matched TEST_RUNNER_RE
+  });
+});

--- a/tests/guards/gate-hook-parity-guard.test.ts
+++ b/tests/guards/gate-hook-parity-guard.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Guard: the three copies of the gate bridge must be one file (#1322).
+ *
+ * `.claude/helpers/gate-hook.mjs` in a consumer project has **two** writers:
+ * `flo init` writes `generateGateHookScript()`'s output, and the session-start
+ * launcher syncs `bin/gate-hook.mjs` over the top. When those disagree, a
+ * consumer runs one bridge after init and a different one after the next
+ * session start — a difference that is invisible locally and reproduces only
+ * in a freshly-inited project.
+ *
+ * It had drifted exactly that way: the generated copy never received #1332's
+ * structured-input forwarding and still shelled out through `execSync` string
+ * concatenation where `bin/` uses `execFileSync` with an argv array. Nothing
+ * caught it because no test compared them.
+ *
+ * If this goes red, copy `bin/gate-hook.mjs` across wholesale — do not
+ * hand-merge, and do not relax the comparison.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { generateGateHookScript } from '../../src/cli/init/helpers-generator.js';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const BIN_BRIDGE = resolve(REPO_ROOT, 'bin/gate-hook.mjs');
+const DOGFOOD_BRIDGE = resolve(REPO_ROOT, '.claude/helpers/gate-hook.mjs');
+
+/** Line endings are normalised: git may check these out as CRLF on Windows. */
+function read(path: string): string {
+  return readFileSync(path, 'utf-8').replace(/\r\n/g, '\n');
+}
+
+describe('gate-hook.mjs parity', () => {
+  it('the generator emits byte-for-byte what bin/ ships', () => {
+    expect(generateGateHookScript().replace(/\r\n/g, '\n')).toBe(read(BIN_BRIDGE));
+  });
+
+  it('the dogfood copy matches bin/ (the launcher syncs it — a diff means it is stale)', () => {
+    expect(read(DOGFOOD_BRIDGE)).toBe(read(BIN_BRIDGE));
+  });
+
+  it('forwards tool_response, without ever claiming an exit status (#1322)', () => {
+    // Claude Code's payload has no exit code. A `TOOL_RESPONSE_exitCode` here
+    // would be a fabricated field — the exact class of invention #1349/#1354
+    // removed elsewhere. Pinned so a future edit cannot reintroduce the claim.
+    const bridge = read(BIN_BRIDGE);
+    expect(bridge).toContain('TOOL_RESPONSE_stdout');
+    expect(bridge).toContain('TOOL_RESPONSE_interrupted');
+    expect(bridge).not.toMatch(/exitCode|exit_code|exitStatus/);
+  });
+});


### PR DESCRIPTION
Closes #1322

## What was actually wrong

`record-test-run` set `testsRun = true` from the submitted command string alone. `gate-hook.mjs` parsed the hook payload's `tool_response` and then threw it away, so no gate could observe what a run produced.

**The ticket's original premise was wrong, and this PR follows the probe instead.** Claude Code's PostToolUse hook does not fire at all when a Bash command exits non-zero, so an ordinary red suite already left the flag false — by accident of the hook lifecycle, not by design. The issue body has been rewritten around what the probe established.

What *does* defeat the gate is a **masked** exit:

```
npm test | tail -20
npm test 2>&1 | grep -i fail
npm test || true
```

The pipeline exits 0, PostToolUse fires with a clean-looking response, and a red suite credits the gate.

## The signal, and its honest limits

There is **no exit status anywhere in the payload** — probed on v2.1.220, `tool_response` is `{stdout, stderr, interrupted, isImage, noOutputExpected}`. So this is output inspection, which is genuinely weaker than a status. The code says so rather than implying fidelity it does not have, and a guard test asserts the bridge never grows an `exitCode` field.

- **Bridge** — forwards `stdout`/`stderr` and `interrupted` as `TOOL_RESPONSE_*`. **Tail**-kept, because runners print their summary last, and bounded to 4 KB / 2 KB so the Windows ~32 KB environment-block limit is never risked. `interrupted` is a boolean, so it needs `String()` — the existing string-typed loop would have dropped the one field silently.
- **Gate** — only **summary shapes** count (`2 failed`, `1 failing`, line-start `FAIL`/`FAILED`, `--- FAIL:`, `test result: FAILED`, `npm ERR!`). A bare "fail" never does; it occurs constantly in passing test names.
- A matched failure **clears** a `testsRun` an earlier green run had earned.
- **Empty output still credits.** A quiet green `npm test > /dev/null` and a silently-masked red one are indistinguishable, so absent stays unknown rather than becoming a block.

### The false positive that mattered

Self-review caught this before it shipped: mocha's default spec reporter prints every **passing** test name, so a green `npm test | tail -20` genuinely contains lines like `✓ retries 2 failed requests`. A naive `\d+ failed` would have blocked legitimate PRs. A trailing lookahead now separates a tally (followed by a delimiter or a line end) from prose (followed by a lowercase word), exempting `N failed tests`. Both directions are pinned by tests.

## Drift fixed along the way

The third copy of the bridge was **already** wrong. `flo init` wrote a `gate-hook.mjs` that never received #1332's structured-input forwarding and still shelled out via `execSync` string concatenation — so a consumer ran one bridge after init and a different one after the next session start. Nothing caught it because no test compared them.

The generator now emits `bin/gate-hook.mjs` byte-for-byte, pinned by `tests/guards/gate-hook-parity-guard.test.ts`.

## Consumer impact

| | |
|---|---|
| **Surface** | `bin/gate-hook.mjs`, `bin/gate.cjs`, `src/cli/init/helpers-generator.ts` — every consumer's hook path |
| **Failure mode** | None on upgrade. Forwarding is additive (no existing gate reads these names) and the credit path is unchanged except when output reports failures. Consumers who pipe test output will now correctly *not* be credited for a red run |
| **Round-trip** | Runtime fix — needs publish + reinstall to take effect in a consumer |

## Verification

- **9902 passed / 0 failed** (+35 new tests)
- **End-to-end through the real bridge**, not only unit seams: masked red with multi-line vitest output took `testsRun` true → false; masked green set it true
- **The generated consumer copy was executed** in a scratch dir and reproduced the behaviour identically — `flo init` parity proven, not assumed
- **Live dogfood** — this session's own full-suite run was credited through the modified gate
- **Mutation-tested**: disabling detection killed 12 tests; head-instead-of-tail truncation killed 2

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
