### PR TITLE
fix(gates): stop the verify and simplify gates invalidating each other (#1348)

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -139,6 +139,14 @@ var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state
 // failures and "fixes" them with allow rules — which cannot override a hook
 // block at all (#1307 finding 5). Naming the gate makes the cause self-evident.
 var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.';
+
+// #1348 — the pre-PR gates are order-dependent and each block message named only
+// its own missing gate, so a caller could satisfy them one at a time forever:
+// /flo-simplify may edit code (which resets tests and verify), and /verify must
+// not, so simplify strictly precedes verify. Both blocking gates print this.
+// /verify's Step 5 memory_store carries the verdict AND stamps learnings, which
+// is why learnings has no separate step here.
+var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\n';
 var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
 
 // #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
@@ -555,7 +563,13 @@ var EDIT_RESET_SKIP_BOTH_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^
 // they shouldn't reset testsRun/simplifyRun the way a real source edit does.
 // Trailing terminator includes `.` so the single-file template form
 // `.github/PULL_REQUEST_TEMPLATE.md` matches alongside the directory form.
-var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\/])\.github[\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\/.]|$)/i;
+// #1348 — `.moflo/` joins them. It is moflo's own gitignored state directory
+// (daemon locks, memory db, SDD spec/plan artifacts), so nothing written there
+// can appear in the branch diff, and a spec edit invalidating the test run is
+// pure noise. Scoped to the reset only — deliberately NOT added to EXEMPT,
+// which would also un-gate reads of `.moflo/specs/**`, and those are indexed
+// guidance that memory-first should still route through a search.
+var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\/])\.github[\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\/.]|$)|(?:^|[\\\/])\.moflo[\\\/]/i;
 // Test files: invalidate the testing gate (tests are stale once test code changes)
 // but NOT the simplify gate — /simplify already reviewed the production code; touching
 // a test file or fixture doesn't expose new untested surface for code review (#908).
@@ -961,6 +975,17 @@ switch (command) {
       overall = 'UNVERIFIED';
     }
     var vs = readState();
+    // #1348 — refuse a verdict for a run that is no longer live. `verifyRun`
+    // false here means a code edit fired reset-edit-gates between the /verify
+    // invocation and this store, so the verdict describes pre-edit code.
+    // Recording it anyway produced the contradictory `verifyRun:false,
+    // verifyOutcome:'PASS'` state that check-before-done's four-way message
+    // chain has no branch for — it reports "a code edit invalidated the previous
+    // verification" while a PASS sits in state, which reads as a gate bug.
+    if (!vs.verifyRun) {
+      process.stderr.write('gate: record-verify-outcome — "' + mKey + '" arrived after a code edit invalidated the run; verdict not recorded (re-run /verify)\n');
+      break;
+    }
     vs.verifyOutcome = overall;
     writeState(vs);
     break;
@@ -971,6 +996,17 @@ switch (command) {
     // (.github/workflows/, .github/ISSUE_TEMPLATE/, .github/PULL_REQUEST_TEMPLATE/, #1176):
     // no gate reset — editing these doesn't expose new runtime surface.
     if (fp && (EDIT_RESET_SKIP_BOTH_RE.test(fp) || EDIT_RESET_SKIP_PATH_RE.test(fp))) break;
+    // #1348 — a scratchpad write under the OS temp dir is transient tool I/O and
+    // can never reach the branch diff, but it used to reset tests + simplify +
+    // verify like any source change: a /verify run that jotted a probe cleared
+    // the /flo-simplify stamp, and the two gates invalidated each other with no
+    // ordering that satisfied both. Reuses the predicate the memory-first gate
+    // already trusts for these paths (#1294) rather than a second one.
+    // Scope: tmp-only, NOT project-root containment — so a project rooted under
+    // tmp has its own edits skipped too (pinned in the #1348 tests). Containment
+    // is the more general rule, but it fails OPEN when the root can't be
+    // resolved, and a gate that silently stops resetting is the worse failure.
+    if (isEphemeralPath(fp)) break;
     var s = readState();
     // Test-only edits invalidate testsRun but preserve simplifyRun (#908).
     var isTestOnly = fp && EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE.test(fp);
@@ -1088,6 +1124,10 @@ switch (command) {
     if (s.lastResetBy && s.lastResetBy.file) {
       process.stderr.write('Last gate reset: ' + s.lastResetBy.file + ' (' + (s.lastResetBy.gates || []).join(', ') + ')\n');
     }
+    // #1348 — name the order, not just the missing gate. Satisfying one gate can
+    // invalidate another (/flo-simplify edits code, which resets tests + verify),
+    // so "what is missing" alone left callers rediscovering the sequence by trial.
+    process.stderr.write(ORDER_HINT);
     process.stderr.write('Disable per-gate via moflo.yaml:\n');
     process.stderr.write('  gates:\n    testing_gate: false\n    simplify_gate: false\n    learnings_gate: false\n');
     process.exit(2);
@@ -1138,7 +1178,12 @@ switch (command) {
       // recorded a structured outcome (interrupted, or it stored prose only).
       process.stderr.write('  - /verify ran but recorded no verdict — re-run it so it stores a structured result\n');
       process.stderr.write('    (Step 5 of the verify skill must pass metadata.overall to memory_store)\n');
+      // #1348 — the trap this state sets: re-invoking /verify CLEARS any prior
+      // verdict by design (#1332), so the obvious recovery lands right back here
+      // unless Step 5 completes. Say so, rather than letting it be rediscovered.
+      process.stderr.write('    Re-invoking /verify clears the prior verdict, so a re-run that skips Step 5 lands here again.\n');
     }
+    process.stderr.write(ORDER_HINT);
     process.stderr.write('Disable via moflo.yaml:\n');
     process.stderr.write('  gates:\n    verify_before_done: false\n');
     process.exit(2);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — the verify and simplify gates invalidated each other before a PR (#1348)
+
+Opening a PR needs both `/flo-simplify` and `/verify` to have run, and satisfying
+one could clear the other. Every individual block was correct, so the loop was
+invisible from any single message; the reporter escaped only by discovering an
+undocumented ordering by trial.
+
+Two mechanisms produced it. `reset-edit-gates` treated **any** `Write`/`Edit` as a
+code edit — including a scratch probe under the OS temp dir, which can never reach
+the branch diff — so a `/verify` run that jotted one cleared the `/flo-simplify`
+stamp it had nothing to do with. And `record-verify-outcome` wrote its verdict
+without checking the run was still live, so a store arriving after an edit-reset
+produced the self-contradictory `verifyRun: false` beside `verifyOutcome: 'PASS'`,
+a state `check-before-done`'s message chain has no branch for.
+
+Now: writes under the OS temp dir and into moflo's own gitignored `.moflo/` state
+directory no longer reset a gate (reusing the predicate the memory-first gate
+already trusts for these paths, #1294); a verdict for an invalidated run is refused
+with a stderr crumb instead of recorded; and both blocking gates print the working
+order — tests → `/flo-simplify` → `/verify` → its `memory_store` verdict → PR —
+rather than naming only whichever gate happens to be missing. The "ran but recorded
+no verdict" branch also states that re-invoking `/verify` clears the prior verdict
+(#1332, by design), which is why the obvious recovery used to land back in the same
+place.
+
+Consumers pick this up with the gate itself; no migration, and no `.moflo/` state
+changes shape.
+
 ### Fixed — the TaskCreate reminder claimed to block, and shipped that claim (#1326)
 
 `check-before-agent` printed *"Task tool is blocked until then"* on stdout with no

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -139,6 +139,14 @@ var EXEMPT = ['.claude/', '.claude\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-state
 // failures and "fixes" them with allow rules — which cannot override a hook
 // block at all (#1307 finding 5). Naming the gate makes the cause self-evident.
 var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.';
+
+// #1348 — the pre-PR gates are order-dependent and each block message named only
+// its own missing gate, so a caller could satisfy them one at a time forever:
+// /flo-simplify may edit code (which resets tests and verify), and /verify must
+// not, so simplify strictly precedes verify. Both blocking gates print this.
+// /verify's Step 5 memory_store carries the verdict AND stamps learnings, which
+// is why learnings has no separate step here.
+var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\n';
 var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
 
 // #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
@@ -555,7 +563,13 @@ var EDIT_RESET_SKIP_BOTH_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^
 // they shouldn't reset testsRun/simplifyRun the way a real source edit does.
 // Trailing terminator includes `.` so the single-file template form
 // `.github/PULL_REQUEST_TEMPLATE.md` matches alongside the directory form.
-var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\/])\.github[\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\/.]|$)/i;
+// #1348 — `.moflo/` joins them. It is moflo's own gitignored state directory
+// (daemon locks, memory db, SDD spec/plan artifacts), so nothing written there
+// can appear in the branch diff, and a spec edit invalidating the test run is
+// pure noise. Scoped to the reset only — deliberately NOT added to EXEMPT,
+// which would also un-gate reads of `.moflo/specs/**`, and those are indexed
+// guidance that memory-first should still route through a search.
+var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\/])\.github[\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\/.]|$)|(?:^|[\\\/])\.moflo[\\\/]/i;
 // Test files: invalidate the testing gate (tests are stale once test code changes)
 // but NOT the simplify gate — /simplify already reviewed the production code; touching
 // a test file or fixture doesn't expose new untested surface for code review (#908).
@@ -961,6 +975,17 @@ switch (command) {
       overall = 'UNVERIFIED';
     }
     var vs = readState();
+    // #1348 — refuse a verdict for a run that is no longer live. `verifyRun`
+    // false here means a code edit fired reset-edit-gates between the /verify
+    // invocation and this store, so the verdict describes pre-edit code.
+    // Recording it anyway produced the contradictory `verifyRun:false,
+    // verifyOutcome:'PASS'` state that check-before-done's four-way message
+    // chain has no branch for — it reports "a code edit invalidated the previous
+    // verification" while a PASS sits in state, which reads as a gate bug.
+    if (!vs.verifyRun) {
+      process.stderr.write('gate: record-verify-outcome — "' + mKey + '" arrived after a code edit invalidated the run; verdict not recorded (re-run /verify)\n');
+      break;
+    }
     vs.verifyOutcome = overall;
     writeState(vs);
     break;
@@ -971,6 +996,17 @@ switch (command) {
     // (.github/workflows/, .github/ISSUE_TEMPLATE/, .github/PULL_REQUEST_TEMPLATE/, #1176):
     // no gate reset — editing these doesn't expose new runtime surface.
     if (fp && (EDIT_RESET_SKIP_BOTH_RE.test(fp) || EDIT_RESET_SKIP_PATH_RE.test(fp))) break;
+    // #1348 — a scratchpad write under the OS temp dir is transient tool I/O and
+    // can never reach the branch diff, but it used to reset tests + simplify +
+    // verify like any source change: a /verify run that jotted a probe cleared
+    // the /flo-simplify stamp, and the two gates invalidated each other with no
+    // ordering that satisfied both. Reuses the predicate the memory-first gate
+    // already trusts for these paths (#1294) rather than a second one.
+    // Scope: tmp-only, NOT project-root containment — so a project rooted under
+    // tmp has its own edits skipped too (pinned in the #1348 tests). Containment
+    // is the more general rule, but it fails OPEN when the root can't be
+    // resolved, and a gate that silently stops resetting is the worse failure.
+    if (isEphemeralPath(fp)) break;
     var s = readState();
     // Test-only edits invalidate testsRun but preserve simplifyRun (#908).
     var isTestOnly = fp && EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE.test(fp);
@@ -1088,6 +1124,10 @@ switch (command) {
     if (s.lastResetBy && s.lastResetBy.file) {
       process.stderr.write('Last gate reset: ' + s.lastResetBy.file + ' (' + (s.lastResetBy.gates || []).join(', ') + ')\n');
     }
+    // #1348 — name the order, not just the missing gate. Satisfying one gate can
+    // invalidate another (/flo-simplify edits code, which resets tests + verify),
+    // so "what is missing" alone left callers rediscovering the sequence by trial.
+    process.stderr.write(ORDER_HINT);
     process.stderr.write('Disable per-gate via moflo.yaml:\n');
     process.stderr.write('  gates:\n    testing_gate: false\n    simplify_gate: false\n    learnings_gate: false\n');
     process.exit(2);
@@ -1138,7 +1178,12 @@ switch (command) {
       // recorded a structured outcome (interrupted, or it stored prose only).
       process.stderr.write('  - /verify ran but recorded no verdict — re-run it so it stores a structured result\n');
       process.stderr.write('    (Step 5 of the verify skill must pass metadata.overall to memory_store)\n');
+      // #1348 — the trap this state sets: re-invoking /verify CLEARS any prior
+      // verdict by design (#1332), so the obvious recovery lands right back here
+      // unless Step 5 completes. Say so, rather than letting it be rediscovered.
+      process.stderr.write('    Re-invoking /verify clears the prior verdict, so a re-run that skips Step 5 lands here again.\n');
     }
+    process.stderr.write(ORDER_HINT);
     process.stderr.write('Disable via moflo.yaml:\n');
     process.stderr.write('  gates:\n    verify_before_done: false\n');
     process.exit(2);

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -335,6 +335,9 @@ var EXEMPT = ['.claude/', '.claude\\\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-sta
 // bin/gate.cjs GATE_ORIGIN_NOTE / GATE_DISABLE_NOTE.
 var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.';
 var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
+// #1348 — the pre-PR gates are order-dependent; naming only the missing one left
+// callers to rediscover the sequence by trial. SYNC: mirrors bin/gate.cjs.
+var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\\n';
 // #1294 Finding 3 — exempt ephemeral reads/scans under the OS temp dir
 // (background-task output, scratchpads) from the memory-first gate. Mirrors
 // bin/gate.cjs isEphemeralPath. Cross-platform via os.tmpdir(); normalizes a
@@ -605,7 +608,9 @@ function detectTestFailure() {
 }
 var EDIT_RESET_SKIP_BOTH_RE = /\\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^|[\\\\\\/])(CHANGELOG(?:\\.md)?|\\.env\\.example|package-lock\\.json|pnpm-lock\\.yaml|yarn\\.lock|bun\\.lockb)$/i;
 // #1297 — path-inert dirs (.github/workflows etc.); SYNC: mirrors bin/gate.cjs EDIT_RESET_SKIP_PATH_RE.
-var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\\\\/])\\.github[\\\\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\\\\/.]|$)/i;
+// #1348 — plus \`.moflo/\`, moflo's own gitignored state dir: nothing written
+// there can reach the branch diff, so it must not invalidate a gate.
+var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\\\\/])\\.github[\\\\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\\\\/.]|$)|(?:^|[\\\\\\/])\\.moflo[\\\\\\/]/i;
 // Test files: invalidate testsRun but preserve simplifyRun (#908) — /simplify
 // already reviewed the production code, touching tests/fixtures doesn't expose
 // new untested surface for code review.
@@ -820,14 +825,22 @@ switch (command) {
     var overall = typeof parsedMeta.overall === 'string' ? parsedMeta.overall.toUpperCase() : '';
     if (overall !== 'PASS' && overall !== 'FAIL' && overall !== 'UNVERIFIED') overall = 'UNVERIFIED';
     var vs = readState();
+    // #1348 — a verdict that arrives after a code edit cleared verifyRun
+    // describes pre-edit code; recording it leaves state self-contradictory.
+    if (!vs.verifyRun) break;
     vs.verifyOutcome = overall;
     writeState(vs);
     break;
   }
   case 'reset-edit-gates': {
     var fp = process.env.TOOL_INPUT_file_path || '';
-    // Inert files (markdown, lockfiles, CHANGELOG, .env.example): no gate reset.
-    if (fp && EDIT_RESET_SKIP_BOTH_RE.test(fp)) break;
+    // Inert files (markdown, lockfiles, CHANGELOG, .env.example) and inert paths
+    // (.github meta dirs, .moflo state): no gate reset.
+    if (fp && (EDIT_RESET_SKIP_BOTH_RE.test(fp) || EDIT_RESET_SKIP_PATH_RE.test(fp))) break;
+    // #1348 — a scratchpad write under the OS temp dir is transient tool I/O,
+    // never a code edit, so it must not reset tests/simplify/verify. SYNC:
+    // mirrors bin/gate.cjs, which carries the full rationale.
+    if (isEphemeralPath(fp)) break;
     var s = readState();
     // Test-only edits invalidate testsRun but preserve simplifyRun (#908).
     var isTestOnly = fp && EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE.test(fp);
@@ -891,6 +904,7 @@ switch (command) {
     if (s.lastResetBy && s.lastResetBy.file) {
       process.stderr.write('Last gate reset: ' + s.lastResetBy.file + ' (' + (s.lastResetBy.gates || []).join(', ') + ')\\n');
     }
+    process.stderr.write(ORDER_HINT);
     process.stderr.write('Disable per-gate via moflo.yaml:\\n');
     process.stderr.write('  gates:\\n    testing_gate: false\\n    simplify_gate: false\\n    learnings_gate: false\\n');
     process.exit(2);
@@ -916,7 +930,11 @@ switch (command) {
       process.stderr.write('  - /verify ran and returned ' + s.verifyOutcome + ' — fix the failing criteria, then re-run /verify\\n');
     } else {
       process.stderr.write('  - /verify ran but recorded no verdict — re-run it so it stores a structured result\\n');
+      // #1348 — re-invoking /verify clears the prior verdict by design (#1332),
+      // so the obvious recovery lands back here unless Step 5 completes.
+      process.stderr.write('    Re-invoking /verify clears the prior verdict, so a re-run that skips Step 5 lands here again.\\n');
     }
+    process.stderr.write(ORDER_HINT);
     process.stderr.write('Disable via moflo.yaml:\\n');
     process.stderr.write('  gates:\\n    verify_before_done: false\\n');
     process.exit(2);

--- a/tests/bin/gate-invalidation-order-1348.test.ts
+++ b/tests/bin/gate-invalidation-order-1348.test.ts
@@ -1,0 +1,299 @@
+/**
+ * System tests for #1348 — the pre-PR gates invalidated each other.
+ *
+ * Reported symptom: `/flo-simplify` then `gh pr create` blocked on verify;
+ * `/verify` then `gh pr create` blocked on simplify *again*; and re-running
+ * `/verify` to recover left `verifyOutcome` null, because re-invoking it clears
+ * any prior verdict by design (#1332). Every individual block was correct, so
+ * the loop was invisible from any single message — the reporter escaped it only
+ * by discovering an undocumented ordering.
+ *
+ * Two mechanisms produced it, and both are pinned here:
+ *
+ *   1. `reset-edit-gates` counted ANY Write/Edit as a code edit, including a
+ *      scratch probe under the OS temp dir that can never reach the branch diff.
+ *      A `/verify` run that jotted one cleared the `/flo-simplify` stamp.
+ *   2. `record-verify-outcome` wrote a verdict without checking that the run was
+ *      still live, so a store arriving after an edit-reset produced the
+ *      self-contradictory `verifyRun:false, verifyOutcome:'PASS'`.
+ *
+ * The third assertion class is the messages: a block now names the working
+ * ORDER, not only the gate that happens to be missing.
+ *
+ * Each test runs the real `bin/gate.cjs` as a subprocess, the way a hook does.
+ *
+ * Cross-platform (Rule #1): temp roots go through `realpathSync` (macOS
+ * /var -> /private/var), every path is built with `join`, and the gate is
+ * spawned via an argv array rather than a shell string.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+
+import { generateGateScript } from '../../src/cli/init/helpers-generator.js';
+
+const GATE = resolve(__dirname, '../../bin/gate.cjs');
+const PR_COMMAND = 'gh pr create --title x --body y';
+
+let tmpDir: string;
+
+function baseEnv(projectDir: string): Record<string, string> {
+  return {
+    ...(process.env as Record<string, string>),
+    CLAUDE_PROJECT_DIR: projectDir,
+    TOOL_INPUT_command: '',
+    TOOL_INPUT_file_path: '',
+    TOOL_INPUT_skill: '',
+    TOOL_INPUT_key: '',
+    TOOL_INPUT_metadata: '',
+    CLAUDE_USER_PROMPT: '',
+    HOOK_SESSION_ID: '',
+  };
+}
+
+/**
+ * spawnSync rather than execFileSync: the recorder crumbs this file asserts on
+ * are written to stderr while exiting 0, and an exec helper that only captures
+ * stderr from the throw path would report them as absent.
+ */
+function runGate(command: string, env: Record<string, string>): { stdout: string; stderr: string; exitCode: number } {
+  const r = spawnSync('node', [GATE, command], {
+    env, encoding: 'utf-8', timeout: 30000, windowsHide: true,
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', exitCode: r.status ?? 1 };
+}
+
+function readState(projectDir: string): Record<string, unknown> {
+  const f = join(projectDir, '.claude', 'workflow-state.json');
+  if (!existsSync(f)) return {};
+  return JSON.parse(readFileSync(f, 'utf-8'));
+}
+
+function writeState(projectDir: string, state: Record<string, unknown>): void {
+  writeFileSync(join(projectDir, '.claude', 'workflow-state.json'), JSON.stringify(state, null, 2));
+}
+
+/** A verify record shaped exactly as /verify Step 5 (#1328) writes it. */
+function verifyRecord(overall: string): string {
+  return JSON.stringify({
+    type: 'verify-record',
+    issue: '1348',
+    commit: 'abc1234',
+    overall,
+    verifiedAt: '2026-08-04T00:00:00Z',
+    criteria: [{ id: 1, statement: 'a criterion', verdict: overall, evidence: 'a test', freshlyExecuted: true }],
+  });
+}
+
+/** All three edit-resettable gates satisfied — the state just before `gh pr create`. */
+const READY = { testsRun: true, simplifyRun: true, learningsStored: true, verifyRun: true, verifyOutcome: 'PASS' };
+
+beforeEach(() => {
+  tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-gate-1348-')));
+  mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('#1348 a write that cannot reach the branch diff does not reset a gate', () => {
+  it('a scratchpad write under the OS temp dir leaves every gate standing', () => {
+    writeState(tmpDir, READY);
+    const env = baseEnv(tmpDir);
+    // The real shape: <tmpdir>/claude-<uid>/<project-slug>/<session>/scratchpad/probe.mjs
+    env.TOOL_INPUT_file_path = join(tmpdir(), 'claude-1000', 'proj', 'sess', 'scratchpad', 'probe.mjs');
+    runGate('reset-edit-gates', env);
+
+    expect(readState(tmpDir)).toMatchObject(READY);
+  });
+
+  it('a .moflo/ write leaves every gate standing — it is gitignored state', () => {
+    writeState(tmpDir, READY);
+    const env = baseEnv(tmpDir);
+    // Deliberately NOT `specs/plan.md`: markdown is already inert by extension,
+    // so that path would pass whether or not `.moflo/` is recognised. Use the
+    // persisted task state — a real .moflo file with a resetting extension.
+    env.TOOL_INPUT_file_path = join('project', '.moflo', 'tasks', 'state.json');
+    runGate('reset-edit-gates', env);
+
+    expect(readState(tmpDir)).toMatchObject(READY);
+  });
+
+  it('the same file outside .moflo/ does reset — proving the path is what is read', () => {
+    writeState(tmpDir, READY);
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_file_path = join('project', 'tasks', 'state.json');
+    runGate('reset-edit-gates', env);
+
+    expect(readState(tmpDir).testsRun).toBe(false);
+  });
+
+  it('a real source edit still resets tests, simplify AND verify', () => {
+    // The counterweight: the skips above must not have widened into "nothing
+    // resets". Without this, #1348's fix would silently disable the gates.
+    writeState(tmpDir, READY);
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_file_path = join('project', 'src', 'cli', 'thing.ts');
+    runGate('reset-edit-gates', env);
+
+    const s = readState(tmpDir);
+    expect(s.testsRun).toBe(false);
+    expect(s.simplifyRun).toBe(false);
+    expect(s.verifyRun).toBe(false);
+    expect(s.verifyOutcome).toBeNull();
+  });
+
+  it('a tmp-rooted project has its own source edits skipped too — the known scope limit', () => {
+    // Not the behaviour you would design from scratch: the skip is tmp-scoped,
+    // so a project that itself lives under os.tmpdir() (test fixtures, some CI
+    // checkouts) gets its real source edits skipped as well. Pinned rather than
+    // hidden, because it is the price of reusing isEphemeralPath instead of
+    // project-root containment — see the scope note in bin/gate.cjs. Acceptable
+    // because it errs toward resetting less, and consumer projects are not in
+    // tmp; if that ever stops being true, containment is the fix.
+    writeState(tmpDir, READY);
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_file_path = join(tmpDir, 'src', 'thing.ts');
+    runGate('reset-edit-gates', env);
+
+    expect(readState(tmpDir)).toMatchObject(READY);
+  });
+});
+
+describe('#1348 a verdict is refused once its run has been invalidated', () => {
+  it('does not record a PASS that arrives after a code edit cleared verifyRun', () => {
+    writeState(tmpDir, { verifyRun: false, verifyOutcome: null });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_key = 'verify:1348';
+    env.TOOL_INPUT_metadata = verifyRecord('PASS');
+    const r = runGate('record-verify-outcome', env);
+
+    const s = readState(tmpDir);
+    expect(s.verifyOutcome).toBeNull();
+    // The state combination this prevents — verifyRun false with a PASS beside
+    // it — has no branch in check-before-done's message chain, so it surfaces as
+    // "a code edit invalidated the previous verification" while a PASS sits in
+    // state, which reads as a gate bug rather than as the stale verdict it is.
+    expect(s.verifyRun).toBe(false);
+    expect(r.stderr).toContain('arrived after a code edit invalidated the run');
+  });
+
+  it('still records the verdict for a live run', () => {
+    writeState(tmpDir, { verifyRun: true, verifyOutcome: null });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_key = 'verify:1348';
+    env.TOOL_INPUT_metadata = verifyRecord('PASS');
+    runGate('record-verify-outcome', env);
+
+    expect(readState(tmpDir).verifyOutcome).toBe('PASS');
+  });
+
+  it('records a FAIL for a live run — refusal keys on liveness, not on verdict', () => {
+    writeState(tmpDir, { verifyRun: true, verifyOutcome: null });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_key = 'verify:1348';
+    env.TOOL_INPUT_metadata = verifyRecord('FAIL');
+    runGate('record-verify-outcome', env);
+
+    expect(readState(tmpDir).verifyOutcome).toBe('FAIL');
+  });
+});
+
+describe('#1348 a block names the order, not just the missing gate', () => {
+  it('check-before-pr prints the working order', () => {
+    writeState(tmpDir, { testsRun: false, simplifyRun: false, learningsStored: false });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_command = PR_COMMAND;
+    const r = runGate('check-before-pr', env);
+
+    expect(r.exitCode).toBe(2);
+    // Read the ordering off the hint LINE, not off the whole stderr: the
+    // missing-gate list above it already mentions /flo-simplify, so a
+    // whole-buffer indexOf comparison would pass without the hint saying
+    // anything about order at all.
+    const hint = r.stderr.split('\n').find((l) => l.includes('Order that satisfies all of them'));
+    expect(hint).toBeDefined();
+    // Simplify strictly precedes verify: /flo-simplify may edit code (which
+    // resets verify), and /verify must not. An order that put them the other way
+    // round is the loop this ticket is about.
+    expect(hint!.indexOf('/flo-simplify')).toBeGreaterThanOrEqual(0);
+    expect(hint!.indexOf('/flo-simplify')).toBeLessThan(hint!.indexOf('/verify'));
+  });
+
+  it('check-before-done prints the order and warns that re-running clears the verdict', () => {
+    // The "ran but no verdict" state, whose obvious recovery — re-run /verify —
+    // clears the verdict again and lands right back here (#1332 by design).
+    writeState(tmpDir, { verifyRun: true, verifyOutcome: null });
+    const env = baseEnv(tmpDir);
+    env.TOOL_INPUT_command = PR_COMMAND;
+    const r = runGate('check-before-done', env);
+
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('recorded no verdict');
+    expect(r.stderr).toContain('Re-invoking /verify clears the prior verdict');
+    expect(r.stderr).toContain('Order that satisfies all of them');
+  });
+});
+
+describe('#1348 the reported loop no longer happens', () => {
+  it('simplify, then a verify run that writes a scratch probe, opens the PR', () => {
+    const env = baseEnv(tmpDir);
+    writeState(tmpDir, { testsRun: true, learningsStored: true });
+
+    // /flo-simplify
+    runGate('record-skill-run', { ...env, TOOL_INPUT_skill: 'flo-simplify' });
+    // /verify — invocation clears any prior verdict (#1332)
+    runGate('record-verify-run', { ...env, TOOL_INPUT_skill: 'verify' });
+    // ...and jots a probe into the scratchpad while checking a criterion. This
+    // is the step that used to clear simplifyRun, testsRun and verifyRun.
+    runGate('reset-edit-gates', {
+      ...env,
+      TOOL_INPUT_file_path: join(tmpdir(), 'claude-1000', 'proj', 'sess', 'scratchpad', 'check.mjs'),
+    });
+    // /verify Step 5 stores the structured verdict
+    runGate('record-verify-outcome', { ...env, TOOL_INPUT_key: 'verify:1348', TOOL_INPUT_metadata: verifyRecord('PASS') });
+    runGate('record-learnings-stored', env);
+
+    const beforePr = readState(tmpDir);
+    expect(beforePr.simplifyRun).toBe(true);
+    expect(beforePr.verifyRun).toBe(true);
+    expect(beforePr.verifyOutcome).toBe('PASS');
+
+    expect(runGate('check-before-pr', { ...env, TOOL_INPUT_command: PR_COMMAND }).exitCode).toBe(0);
+    expect(runGate('check-before-done', { ...env, TOOL_INPUT_command: PR_COMMAND }).exitCode).toBe(0);
+  });
+});
+
+describe('#1348 the generated gate carries the same fixes', () => {
+  // `flo init` copies the package's own .claude/helpers/gate.cjs (guarded for
+  // byte-parity with bin/ in gate-hook-parity-guard), but generateGateScript()
+  // is the fallback template and had already drifted — it never consulted
+  // EDIT_RESET_SKIP_PATH_RE at all. Pin the #1348 invariants on it too, so the
+  // fix cannot ship to one audience and not the other.
+  const generated = generateGateScript();
+
+  it('skips ephemeral and path-inert writes in reset-edit-gates', () => {
+    const body = generated.slice(generated.indexOf("case 'reset-edit-gates'"));
+    const caseBody = body.slice(0, body.indexOf("case 'check-before-implement'"));
+    expect(caseBody).toContain('isEphemeralPath(fp)');
+    expect(caseBody).toContain('EDIT_RESET_SKIP_PATH_RE.test(fp)');
+  });
+
+  it('treats .moflo/ as path-inert', () => {
+    expect(generated).toMatch(/EDIT_RESET_SKIP_PATH_RE = .*moflo/);
+  });
+
+  it('refuses a verdict for a run that is no longer live', () => {
+    const body = generated.slice(generated.indexOf("case 'record-verify-outcome'"));
+    expect(body.slice(0, body.indexOf("case 'reset-edit-gates'"))).toContain('if (!vs.verifyRun) break;');
+  });
+
+  it('prints the order from both blocking gates', () => {
+    expect(generated).toContain('Order that satisfies all of them');
+    expect(generated.match(/process\.stderr\.write\(ORDER_HINT\)/g)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #1348.

Opening a PR needs both `/flo-simplify` and `/verify` to have run, and satisfying one could clear the other. Every individual block was correct, so the loop was invisible from any single message — the reporter escaped only by discovering an undocumented ordering by trial.

## Root cause

Two independent mechanisms, both confirmed in source and reproduced in tests.

**`reset-edit-gates` counted every `Write`/`Edit` as a code edit.** It skipped only on extension/path patterns, so a scratch probe under the OS temp dir — which can never reach the branch diff — reset `testsRun`, `simplifyRun` and `verifyRun` exactly like a source change. That is the unconfirmed `simplifyRun` reset from the report: a `/verify` run that jots a probe clears the `/flo-simplify` stamp it had nothing to do with. The codebase already had the right predicate — `isEphemeralPath`, added in #1294 so the memory-first gate would stop counting temp-dir reads as project reads. The reset half simply never adopted it.

**`record-verify-outcome` wrote its verdict without checking the run was live.** If an edit fired `reset-edit-gates` between the `/verify` invocation and its Step 5 store, the store still landed, producing `verifyRun: false` beside `verifyOutcome: 'PASS'`. `check-before-done`'s four-way message chain has no branch for that combination, so it reports *"a code edit invalidated the previous verification"* while a PASS sits in state — which reads as a gate bug rather than the stale verdict it is. #1332 closed the reverse direction; the write path was the half left open.

## What changed

- Writes under the OS temp dir, and into moflo's own gitignored `.moflo/` state directory, no longer reset a gate.
- A verdict for an invalidated run is refused with a stderr crumb instead of recorded.
- Both blocking gates print the working order — tests → `/flo-simplify` → `/verify` → its `memory_store` verdict → PR — rather than naming only whichever gate happens to be missing.
- The *"ran but recorded no verdict"* branch states that re-invoking `/verify` clears the prior verdict (#1332, by design), which is why the obvious recovery used to land back in the same place.
- Mirrored into `generateGateScript()`, which had also never consulted `EDIT_RESET_SKIP_PATH_RE` at all.

## Deliberately not done

The ticket's third suggestion — don't clear `verifyOutcome` when the tree is unchanged — is **not** implemented. It would weaken #1332's guarantee that a run in progress cannot inherit a previous issue's PASS, and it needs a tree snapshot at verdict time. With the two causes above fixed the state can no longer go contradictory, so the clearing behaviour stops being a trap; the message now says it out loud instead.

`.moflo/` is fixed on the reset side only. Adding it to `EXEMPT` would also un-gate reads of `.moflo/specs/**`, which are indexed guidance that memory-first should still route through a search.

## Known scope limit

The skip is tmp-scoped, not project-root containment, so a project rooted **under** `os.tmpdir()` has its own source edits skipped too. Pinned in a named test rather than hidden. Containment is the more general rule but fails *open* when the root can't be resolved, and a gate that silently stops resetting is the worse failure.

## Consumer impact

Consumers pick this up with the gate itself — no migration, and no `.moflo/` state changes shape. Anyone with `verify_before_done` + `simplify_gate` on stops hitting the loop on their first gated PR.

## Verification

`tests/bin/gate-invalidation-order-1348.test.ts` — 15 tests, each spawning the real `bin/gate.cjs` as a subprocess. Cross-platform (Rule #1): `realpathSync` temp roots, `join`-built paths, argv-array spawn.

All three behavioural fixes were mutation-tested; reverting each killed the tests that claim it. Full suite **9927 passed / 0 failed**; lint and `tsc` clean. `/verify` **PASS on 8/8** recorded under `verify:1348`.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)