### PR TITLE
fix(statusline): decide upgrade liveness by pid probe, not by rendering (#1363)

### DIFF
--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -13,7 +13,6 @@
  * - Shared settings cache across functions
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
@@ -646,27 +645,59 @@ function getUpgradeNotice() {
     kind: data.kind === 'repair' ? 'repair' : 'upgrade',
     from: typeof data.from === 'string' ? data.from : '',
     to: typeof data.to === 'string' ? data.to : '',
+    // Absent on notices written by a pre-#1363-followup launcher.
+    pid: Number.isInteger(data.pid) && data.pid > 0 ? data.pid : null,
   };
 }
 
-// #1363: an 'upgrade' notice that still reads 'in-progress' when we render is
-// never live work. Claude Code paints the statusline only AFTER the SessionStart
-// hook returns, and the launcher flips the notice to 'completed' the moment the
-// upgrade functionally lands (commitVersionStamp) — so reaching this code with
-// 'in-progress' means the launcher died before finishing its sync: killed by the
-// 5s hook timeout via SIGKILL, or Windows TerminateProcess, neither of which runs
-// the launcher's cleanup handlers. Rendering "(updating…)" there advertises
-// progress nothing is making, and because the TTL is only evaluated when Claude
-// Code re-invokes this script, that badge stays frozen on screen until the next
-// repaint. Report the stall instead, and point at the fix.
+// Is the launcher that wrote an 'in-progress' notice still running?
+//   true  — alive, the work it announced is really in flight
+//   false — provably gone, so the notice is stranded
+//   null  — unknowable (no pid recorded); callers must treat this as "alive"
+// Signal 0 is a liveness probe, not a signal delivery — supported on Windows
+// as well as POSIX. EPERM means the pid exists but is owned by another user.
+// Cheap enough for a statusline; never shell out to ps/tasklist here.
+function isLauncherAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return !!err && err.code === 'EPERM';
+  }
+}
+
+// #1363 follow-up. #1363 assumed that an 'upgrade' notice still reading
+// 'in-progress' at render time was never live work — the reasoning being that
+// Claude Code paints the statusline only AFTER the SessionStart hook returns,
+// so only a launcher killed mid-sync could leave one behind. That premise is
+// false: Claude Code repaints the statusline WHILE the SessionStart hook is
+// still running, and the launcher's in-progress window (daemon stop + legacy
+// cherry-pick, everything between writeUpgradeNotice('in-progress') and
+// commitVersionStamp) is seconds wide. A perfectly healthy upgrade is therefore
+// routinely observed mid-flight, and #1363 painted a red "upgrade interrupted
+// (run /healer)" over it — an alarming lie, and because the TTL is only
+// evaluated on re-invocation, one that stayed frozen on screen until the next
+// repaint. Worse than the stale "(updating…)" it replaced.
 //
-// 'repair' notices are exempt: §0's bootstrap sentinel deliberately holds an
-// in-progress one open to keep the healer prompt in front of the user until §3h
-// resolves it, so there the in-flight state is the intended signal.
+// So don't infer liveness from the fact that we are rendering. Ask the OS: the
+// launcher stamps its pid into the notice and isLauncherAlive() probes it. Only
+// a provably dead launcher counts as stalled; an unknown pid (a notice written
+// by an older launcher — precisely the state during the upgrade that installs
+// this file) reads as live, so version skew can never manufacture a false alarm.
+//
+// Even when stalled, this is not an error the user must repair: the launcher
+// died before committing the version stamp, so the next session re-detects the
+// upgrade and re-runs it idempotently. Say what happens next; don't cry wolf.
+//
+// 'repair' notices are exempt from all of this: §0's bootstrap sentinel
+// deliberately holds an in-progress one open to keep the healer prompt in front
+// of the user until §3h resolves it, so there the in-flight state is intended.
 function formatUpgradeNoticeSegment(notice) {
   if (!notice) return '';
   const inFlight = notice.status === 'in-progress';
-  const stalledUpgrade = inFlight && notice.kind !== 'repair';
+  const stalledUpgrade =
+    inFlight && notice.kind !== 'repair' && isLauncherAlive(notice.pid) === false;
   const suffix = inFlight && !stalledUpgrade ? ` ${c.dim}(updating…)${c.reset}` : '';
   // Pick body text: repair > stalled upgrade > completed "upgraded to"
   // > bare "upgraded" fallback when no version is known.
@@ -674,7 +705,7 @@ function formatUpgradeNoticeSegment(notice) {
   if (notice.kind === 'repair') {
     body = 'install repaired';
   } else if (stalledUpgrade) {
-    return `${c.brightRed}📦 upgrade interrupted${c.reset} ${c.dim}(run /healer)${c.reset}`;
+    body = 'upgrade resumes next session';
   } else {
     const target = notice.to || notice.from || '';
     body = target ? `upgraded to ${target}` : 'upgraded';

--- a/.claude/helpers/statusline.cjs
+++ b/.claude/helpers/statusline.cjs
@@ -657,13 +657,21 @@ function getUpgradeNotice() {
 // Signal 0 is a liveness probe, not a signal delivery — supported on Windows
 // as well as POSIX. EPERM means the pid exists but is owned by another user.
 // Cheap enough for a statusline; never shell out to ps/tasklist here.
+//
+// Unlike daemon-lock.ts:isDaemonProcess*, this does NOT defend against pid
+// reuse by matching the process cmdline — that costs a ps/tasklist spawn, which
+// a statusline repainted on every keystroke cannot afford. The exposure is one
+// recycled pid inside the notice's 5-minute TTL, and it degrades to "(updating…)"
+// on a notice whose launcher is gone: the pre-#1363 rendering, self-limiting at
+// TTL. Cheap and occasionally over-optimistic beats slow, and beats the red
+// false alarm this replaces.
 function isLauncherAlive(pid) {
   if (!Number.isInteger(pid) || pid <= 0) return null;
   try {
     process.kill(pid, 0);
     return true;
   } catch (err) {
-    return !!err && err.code === 'EPERM';
+    return err?.code === 'EPERM';
   }
 }
 

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -286,8 +286,9 @@ let upgradeNoticeContext = null;
 // functionally landed — means a kill during the best-effort tail leaves a
 // truthful terminal badge instead. A kill BEFORE this point deliberately
 // leaves 'in-progress': that upgrade really didn't land, and both the exit
-// handler (graceful) and the statusline's stalled-upgrade rendering (SIGKILL)
-// surface it honestly rather than claiming success.
+// handler (graceful) and the statusline's stranded-notice rendering (SIGKILL,
+// detected by probing the recorded pid) surface it honestly rather than
+// claiming success.
 function commitVersionStamp(stampPath, version) {
   try {
     mkdirSync(dirname(stampPath), { recursive: true });
@@ -305,10 +306,12 @@ function commitVersionStamp(stampPath, version) {
 
 // 5-min TTL is a safety net for zombie launchers (statusline ignores past-TTL
 // files). The 2-min "completed" TTL lets the user see the post-upgrade badge
-// briefly in the next session render (Claude Code renders the statusline only
-// AFTER the SessionStart hook returns, so the in-progress badge has effectively
-// zero visibility window). The next session-start's section 0-pre wipes any
-// leftover, so a stale completed notice can't linger past one session.
+// briefly. Do NOT reason about these windows as if the in-progress notice were
+// invisible: Claude Code repaints the statusline DURING this hook, so the
+// in-progress badge really is seen (#1363 follow-up — assuming otherwise is
+// what produced the false "upgrade interrupted" alarm). The next session-start's
+// section 0-pre wipes any leftover, so a stale notice can't linger past one
+// session.
 const UPGRADE_NOTICE_INPROGRESS_TTL_MS = 5 * 60 * 1000;
 const UPGRADE_NOTICE_COMPLETED_TTL_MS = 2 * 60 * 1000;
 const UPGRADE_NOTICE_PATH = () => join(mofloDir(projectRoot), 'upgrade-notice.json');
@@ -333,6 +336,12 @@ function buildAndWriteNotice(context, status) {
       at: new Date(now).toISOString(),
       expiresAt: new Date(now + ttlMs).toISOString(),
       changes: 0,
+      // #1363 follow-up: lets the statusline tell "work is genuinely running"
+      // from "the launcher died holding this notice" by probing the pid,
+      // instead of inferring it from the fact that it is rendering at all.
+      // Claude Code repaints DURING the SessionStart hook, so that inference
+      // flagged every healthy upgrade as interrupted.
+      pid: process.pid,
     };
     writeFileSync(UPGRADE_NOTICE_PATH(), JSON.stringify(notice, null, 2));
   } catch { /* non-fatal — statusline just won't show the segment */ }
@@ -990,11 +999,11 @@ try {
       // Open the statusline notice before the long-running upgrade work
       // (manifest sync, daemon recycle, embeddings migration). commitVersionStamp
       // flips it to a 2-min "completed" badge the moment the upgrade lands
-      // (#1363; TTL rationale at the constants above). Nothing paints while
-      // this value is live — Claude Code renders the statusline only after the
-      // hook returns — so 'in-progress' surviving to paint time means the
-      // launcher died before the sync finished, which is what the statusline's
-      // stalled-upgrade rendering reports.
+      // (#1363; TTL rationale at the constants above). This value IS painted —
+      // Claude Code repaints the statusline while this hook runs, and the window
+      // below (daemon stop + cherry-pick) is seconds wide. The statusline tells
+      // live work from a stranded notice by probing the pid recorded in it, not
+      // by assuming it can only observe one of the two (#1363 follow-up).
       writeUpgradeNotice('in-progress');
 
       // Stop the daemon BEFORE any DB writes (#851). It was started under the

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -287,8 +287,9 @@ let upgradeNoticeContext = null;
 // functionally landed — means a kill during the best-effort tail leaves a
 // truthful terminal badge instead. A kill BEFORE this point deliberately
 // leaves 'in-progress': that upgrade really didn't land, and both the exit
-// handler (graceful) and the statusline's stalled-upgrade rendering (SIGKILL)
-// surface it honestly rather than claiming success.
+// handler (graceful) and the statusline's stranded-notice rendering (SIGKILL,
+// detected by probing the recorded pid) surface it honestly rather than
+// claiming success.
 function commitVersionStamp(stampPath, version) {
   try {
     mkdirSync(dirname(stampPath), { recursive: true });
@@ -306,10 +307,12 @@ function commitVersionStamp(stampPath, version) {
 
 // 5-min TTL is a safety net for zombie launchers (statusline ignores past-TTL
 // files). The 2-min "completed" TTL lets the user see the post-upgrade badge
-// briefly in the next session render (Claude Code renders the statusline only
-// AFTER the SessionStart hook returns, so the in-progress badge has effectively
-// zero visibility window). The next session-start's section 0-pre wipes any
-// leftover, so a stale completed notice can't linger past one session.
+// briefly. Do NOT reason about these windows as if the in-progress notice were
+// invisible: Claude Code repaints the statusline DURING this hook, so the
+// in-progress badge really is seen (#1363 follow-up — assuming otherwise is
+// what produced the false "upgrade interrupted" alarm). The next session-start's
+// section 0-pre wipes any leftover, so a stale notice can't linger past one
+// session.
 const UPGRADE_NOTICE_INPROGRESS_TTL_MS = 5 * 60 * 1000;
 const UPGRADE_NOTICE_COMPLETED_TTL_MS = 2 * 60 * 1000;
 const UPGRADE_NOTICE_PATH = () => join(mofloDir(projectRoot), 'upgrade-notice.json');
@@ -334,6 +337,12 @@ function buildAndWriteNotice(context, status) {
       at: new Date(now).toISOString(),
       expiresAt: new Date(now + ttlMs).toISOString(),
       changes: 0,
+      // #1363 follow-up: lets the statusline tell "work is genuinely running"
+      // from "the launcher died holding this notice" by probing the pid,
+      // instead of inferring it from the fact that it is rendering at all.
+      // Claude Code repaints DURING the SessionStart hook, so that inference
+      // flagged every healthy upgrade as interrupted.
+      pid: process.pid,
     };
     writeFileSync(UPGRADE_NOTICE_PATH(), JSON.stringify(notice, null, 2));
   } catch { /* non-fatal — statusline just won't show the segment */ }
@@ -998,11 +1007,11 @@ try {
       // Open the statusline notice before the long-running upgrade work
       // (manifest sync, daemon recycle, embeddings migration). commitVersionStamp
       // flips it to a 2-min "completed" badge the moment the upgrade lands
-      // (#1363; TTL rationale at the constants above). Nothing paints while
-      // this value is live — Claude Code renders the statusline only after the
-      // hook returns — so 'in-progress' surviving to paint time means the
-      // launcher died before the sync finished, which is what the statusline's
-      // stalled-upgrade rendering reports.
+      // (#1363; TTL rationale at the constants above). This value IS painted —
+      // Claude Code repaints the statusline while this hook runs, and the window
+      // below (daemon stop + cherry-pick) is seconds wide. The statusline tells
+      // live work from a stranded notice by probing the pid recorded in it, not
+      // by assuming it can only observe one of the two (#1363 follow-up).
       writeUpgradeNotice('in-progress');
 
       // Stop the daemon BEFORE any DB writes (#851). It was started under the

--- a/src/cli/__tests__/statusline-upgrade-notice.test.ts
+++ b/src/cli/__tests__/statusline-upgrade-notice.test.ts
@@ -9,13 +9,19 @@
 //   #743 — statusline renders ONLY status='in-progress' notices. Stale legacy
 //          files cannot turn the segment into a permanent column.
 //   completed-state — section 3f writes status='completed' with 2-min TTL
-//          instead of deleting; gives the post-upgrade badge a real visibility
-//          window because Claude Code paints the statusline only AFTER the
-//          SessionStart hook returns. Section 0-pre still wipes any leftover
-//          at the next launcher run, capping lifetime at one session.
+//          instead of deleting, giving the post-upgrade badge a visibility
+//          window. Section 0-pre still wipes any leftover at the next launcher
+//          run, capping lifetime at one session.
+//   #1363 — the 'completed' flip moves up to commitVersionStamp, so a launcher
+//          killed during the best-effort tail still leaves a terminal state.
+//   #1363 follow-up — Claude Code repaints the statusline DURING the
+//          SessionStart hook, not only after it returns. #1363 assumed
+//          otherwise and rendered every mid-flight upgrade as "interrupted".
+//          In-flight vs. stranded is now decided by probing the launcher pid
+//          recorded in the notice.
 //
-// These tests pin both the #743 stale-file rejection and the new completed
-// contract.
+// These tests pin the #743 stale-file rejection, the completed contract, and
+// the three liveness cases (live pid / dead pid / no pid).
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
@@ -85,6 +91,15 @@ function runStatusline(cwd: string, args: string[] = ['--json-compact']): RunRes
   };
 }
 
+// A pid that is guaranteed not to be running: spawn a trivial process, let it
+// exit, then reuse its pid. Portable (no /proc, no tasklist) and far safer than
+// picking an arbitrary high number, which can collide with a live process.
+function makeDeadPid(): number {
+  const probe = spawnSync(process.execPath, ['-e', ''], { encoding: 'utf-8', timeout: 25_000 });
+  if (!probe.pid) throw new Error('could not spawn probe process to obtain a dead pid');
+  return probe.pid;
+}
+
 function writeNotice(root: string, body: unknown) {
   const dir = join(root, '.moflo');
   mkdirSync(dir, { recursive: true });
@@ -93,8 +108,10 @@ function writeNotice(root: string, body: unknown) {
 
 describe('statusline upgrade-notice (#636 / #738 / #743)', () => {
   let root: string;
+  let deadPid: number;
   beforeEach(() => {
     root = makeTempRoot();
+    deadPid = makeDeadPid();
   });
   afterEach(() => {
     cleanTempRoot(root);
@@ -126,17 +143,79 @@ describe('statusline upgrade-notice (#636 / #738 / #743)', () => {
     expect(plain).not.toContain('changes');
   });
 
-  // #1363 — this case used to assert "4.8.79 → 4.8.80 (updating…)". That
-  // wording is unreachable in practice and actively misleading: Claude Code
-  // paints the statusline only AFTER the SessionStart hook returns, and the
-  // launcher now flips the notice to 'completed' at commitVersionStamp — the
-  // moment the upgrade functionally lands. So an in-progress UPGRADE notice
-  // observed at render time always means the launcher died before finishing
-  // its sync (hook-timeout SIGKILL, Windows TerminateProcess — neither runs
-  // the cleanup handlers). Since the TTL is only evaluated on re-invocation,
-  // that badge then sat frozen on screen advertising progress nothing was
-  // making. It now reports the stall and points at the healer.
-  it('reports a stalled upgrade instead of claiming work is in flight', () => {
+  // #1363 follow-up — #1363 asserted here that an in-progress UPGRADE notice
+  // seen at render time always meant a dead launcher, on the premise that
+  // Claude Code paints only AFTER the SessionStart hook returns. It does not:
+  // it repaints DURING the hook, so a healthy upgrade is routinely observed
+  // inside the launcher's in-progress window and #1363 painted a red "upgrade
+  // interrupted (run /healer)" over it. Liveness now comes from probing the
+  // pid the launcher stamps into the notice, not from the act of rendering.
+  it('shows live progress while the launcher that wrote the notice is running', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      status: 'in-progress',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now - 5_000).toISOString(),
+      expiresAt: new Date(now + 5 * 60_000).toISOString(),
+      changes: 0,
+      pid: process.pid, // this test process stands in for a live launcher
+    });
+
+    const { stdout, status } = runStatusline(root);
+    expect(status).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.upgradeNotice).toEqual({
+      status: 'in-progress',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      pid: process.pid,
+    });
+
+    const compact = runStatusline(root, ['--compact']);
+    // eslint-disable-next-line no-control-regex
+    const plain = compact.stdout.replace(/\x1B\[[0-9;]*m/g, '');
+    expect(plain).toContain('upgraded to 4.8.80');
+    expect(plain).toContain('updating');
+    expect(plain).not.toContain('interrupted');
+    expect(plain).not.toContain('/healer');
+  });
+
+  // A launcher killed before commitVersionStamp (5s hook-timeout SIGKILL,
+  // Windows TerminateProcess — neither runs the cleanup handlers) strands the
+  // notice. That is reported as a stall, but NOT as an error: the version
+  // stamp was never written, so the next session re-detects the upgrade and
+  // re-runs it idempotently. Nothing for the user to repair.
+  it('reports a stranded notice as resuming, without raising an error', () => {
+    const now = Date.now();
+    writeNotice(root, {
+      status: 'in-progress',
+      kind: 'upgrade',
+      from: '4.8.79',
+      to: '4.8.80',
+      at: new Date(now - 5_000).toISOString(),
+      expiresAt: new Date(now + 5 * 60_000).toISOString(),
+      changes: 0,
+      pid: deadPid,
+    });
+
+    const compact = runStatusline(root, ['--compact']);
+    // eslint-disable-next-line no-control-regex
+    const plain = compact.stdout.replace(/\x1B\[[0-9;]*m/g, '');
+    expect(plain).toContain('upgrade resumes next session');
+    expect(plain).not.toContain('interrupted');
+    expect(plain).not.toContain('/healer');
+    expect(plain).not.toContain('updating');
+    expect(plain).not.toContain('changes');
+  });
+
+  // Version skew (Rule #2): during the very upgrade that installs this
+  // statusline, the notice on disk was written by the PREVIOUS launcher, which
+  // records no pid. Unknown liveness must read as live — a pid-less notice
+  // must never be reported as stalled.
+  it('treats a pid-less notice from an older launcher as live, not stalled', () => {
     const now = Date.now();
     writeNotice(root, {
       status: 'in-progress',
@@ -148,24 +227,13 @@ describe('statusline upgrade-notice (#636 / #738 / #743)', () => {
       changes: 0,
     });
 
-    const { stdout, status } = runStatusline(root);
-    expect(status).toBe(0);
-    const json = JSON.parse(stdout);
-    // The parsed notice is unchanged — only the rendering differs.
-    expect(json.upgradeNotice).toEqual({
-      status: 'in-progress',
-      kind: 'upgrade',
-      from: '4.8.79',
-      to: '4.8.80',
-    });
-
     const compact = runStatusline(root, ['--compact']);
     // eslint-disable-next-line no-control-regex
     const plain = compact.stdout.replace(/\x1B\[[0-9;]*m/g, '');
-    expect(plain).toContain('upgrade interrupted');
-    expect(plain).toContain('/healer');
-    expect(plain).not.toContain('updating');
-    expect(plain).not.toContain('changes');
+    expect(plain).toContain('upgraded to 4.8.80');
+    expect(plain).toContain('updating');
+    expect(plain).not.toContain('interrupted');
+    expect(plain).not.toContain('resumes');
   });
 
   // The stall rendering must not swallow the version-bump case where the
@@ -285,6 +353,8 @@ describe('statusline upgrade-notice (#636 / #738 / #743)', () => {
       kind: 'upgrade',
       from: '4.8.79',
       to: '4.8.80',
+      // Notice written here without one; liveness is irrelevant once terminal.
+      pid: null,
     });
 
     const compact = runStatusline(root, ['--compact']);


### PR DESCRIPTION
Follow-up to #1363, which shipped a fix built on a false premise and turned a stale badge into a red error.

## The premise that was wrong

#1363 put this inference into the statusline, and repeated it verbatim in three launcher comment blocks and a test:

> Claude Code paints the statusline only AFTER the SessionStart hook returns, so an `in-progress` notice observed at render time always means the launcher died mid-flight.

**Claude Code repaints the statusline WHILE the SessionStart hook is still running.** The launcher's in-progress window — everything between `writeUpgradeNotice('in-progress')` and `commitVersionStamp`, i.e. a daemon stop plus a legacy-row cherry-pick — is seconds wide, so a perfectly healthy upgrade is observed mid-flight as a matter of course. #1363 painted a brightRed `📦 upgrade interrupted (run /healer)` over it.

Observed on a `4.12.4-rc.2` → `4.12.4-rc.3` upgrade that demonstrably succeeded: notice ended at `status: "completed"`, `.moflo/moflo-version` = `4.12.4-rc.3`, `flo healer` 46/47 — while the statusline called the upgrade interrupted.

It also did not fix the reported symptom. The stuck badge (issue cause 1: no repaint while the session idles) is not addressable from moflo's side; #1363 only changed *which text freezes on screen*, from a stale `(updating…)` to a red error. That is a regression.

## The fix

Don't infer liveness from the act of rendering — ask the OS.

- The launcher stamps `pid: process.pid` into `upgrade-notice.json`.
- The statusline probes it with `process.kill(pid, 0)` — a liveness check, not a signal delivery, supported on Windows as well as POSIX (`EPERM` = alive, owned by another user). No `ps`/`tasklist` spawn; far too slow for a statusline.

| notice state | renders |
|---|---|
| `in-progress`, pid alive | `📦 upgraded to X (updating…)` |
| `in-progress`, pid dead | `📦 upgrade resumes next session` |
| `in-progress`, no pid | `📦 upgraded to X (updating…)` |

The stranded case is deliberately **not** an error: the launcher died before `commitVersionStamp`, so the version stamp is unwritten and the next session re-detects and re-runs the upgrade idempotently. Nothing to repair, so no red and no `/healer` prompt.

The no-pid row is the version-skew case: during the very upgrade that installs this statusline, the notice on disk was written by the **previous** launcher and carries no pid. Unknown liveness must read as live. Pinned by test.

This probe deliberately does not defend against pid reuse the way `daemon-lock.ts:isDaemonProcess*` does — cmdline matching costs a `ps`/`tasklist` spawn a statusline cannot afford. The exposure is one recycled pid inside the notice's 5-minute TTL, degrading to `(updating…)`, i.e. the pre-#1363 rendering, self-limiting at TTL. Documented at the call site.

The false premise is also rewritten out of all three launcher comment blocks and the test header — left in place it would seed the same wrong fix again.

## Consumer blast radius (Rule #2)

- **Surfaces:** `.claude/helpers/statusline.cjs` (shipped via `files`) and `bin/session-start-launcher.mjs` (synced into consumer `.claude/scripts/`). The dogfood copy at `.claude/scripts/session-start-launcher.mjs` is updated in lockstep.
- **Failure mode for an on-the-current-version consumer:** none. Cosmetic rendering change only; a consumer mid-upgrade hits the no-pid row and gets the benign pre-#1363 wording.
- **State:** `upgrade-notice.json` shape is unchanged — `pid` is additive and optional. No migration.
- **Round-trip:** both are runtime layers, so this needs publish + reinstall to take effect for consumers.

## Cross-platform (Rule #1)

`process.kill(pid, 0)` is a documented platform-independent existence probe. No shell-out, no path or separator literals, no `/tmp`. The test obtains a guaranteed-dead pid by spawning a trivial process and reusing its pid — portable, no `/proc`, no `tasklist`, and safer than picking an arbitrary high number.

## Verification

- `statusline-upgrade-notice.test.ts` rewritten: the `expect(plain).toContain('upgrade interrupted')` assertion is gone, replaced by live-pid / dead-pid / no-pid cases. 13/13.
- Full suite: **9942 passed, 0 failed** (re-run after the final edit). `tsc --noEmit` clean, eslint clean.
- All three cases rendered against the real `statusline.cjs` — no red in any of them.
- `/verify` PASS on the revised acceptance criteria (recorded to memory as `verify:1363-followup`).
- Also cleared a pre-existing eslint error in `statusline.cjs` (stale `eslint-disable` for a rule that no longer exists).

## Two defects found while doing this, not fixed here

1. `.claude/scripts/session-start-launcher.mjs` — the dogfood copy that actually runs in this repo — is stale against `bin/session-start-launcher.mjs`: it is missing #1308's skill-category selection entirely. Dogfood skips the file-sync, so that copy only updates by hand and #1308 did not. #1308 is therefore not exercised in dogfood at all. Wants its own issue and probably a byte-parity guard.
2. The simplify gate cannot be satisfied on a simplify → fix → re-simplify cycle. The post-review edit correctly resets `simplifyRun`, but re-invoking the skill is short-circuited by the harness as "already loaded", so no `Skill` tool call is made and `record-skill-run` never re-fires. The gate then blocks `gh pr create` with no reachable way to clear it.

Refs #1363

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)