### PR TITLE
fix(dogfood): resync the launcher copy and guard every bin/ -> .claude/ pair

### DIFF
--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -14,9 +14,10 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { mofloDir, resolveStateRoot, findAncestorMofloRoot, COMMON_WALK_SKIP_NAMES } from './lib/moflo-paths.mjs';
 import { repairMemoryDbIfCorrupt } from './lib/db-repair.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
-import { applyRetiredPrune } from './lib/retired-files.mjs';
+import { applyRetiredPrune, writeRetainedRecord, reconcileRetainedRecord, RETAINED_RECORD_REL } from './lib/retired-files.mjs';
 import { makeSyncer, contentEqual, syncDirRecursive } from './lib/file-sync.mjs';
 import { INTERNAL_SKILLS } from './lib/internal-skills.mjs';
+import { parseSkillCategories, computeExcludedSkills } from './lib/skill-categories.mjs';
 import { loadShippedScripts } from './lib/shipped-scripts.mjs';
 import {
   readContinuityConfig,
@@ -869,6 +870,9 @@ let autoUpdateConfig = {
   // refresh CLAUDE.md on their own — there is no other auto-refresh path.
   claudemdInjectionDrift: 'regenerate',
 };
+// #1308 — skill categories the consumer opted into via moflo.yaml. `null` =
+// unconfigured = no restriction (every shipped skill syncs, as before).
+let selectedSkillCategories = null;
 try {
   const mofloYaml = resolve(projectRoot, 'moflo.yaml');
   if (existsSync(mofloYaml)) {
@@ -889,6 +893,10 @@ try {
     if (helpersMatch) autoUpdateConfig.helpers = helpersMatch[1] === 'true';
     if (driftMatch) autoUpdateConfig.hookBlockDrift = driftMatch[1];
     if (claudemdMatch) autoUpdateConfig.claudemdInjectionDrift = claudemdMatch[1];
+    // #1308 — optional `skills: categories: [...]` selection. null means
+    // unconfigured, which must keep meaning "sync everything" so no existing
+    // consumer loses skills on upgrade.
+    selectedSkillCategories = parseSkillCategories(yamlContent);
   }
 } catch (err) {
   // Defaults (all true) keep the upgrade flow alive but the user should
@@ -1250,10 +1258,24 @@ try {
         '.claude/agents',
         { projectRoot, syncFile, onWarn: emitWarning },
       );
+      // #1308 — excludeTopLevel is INTERNAL_SKILLS plus, when the consumer has
+      // opted into a `skills: categories: [...]` selection in moflo.yaml, every
+      // skill belonging to an unselected category. With no selection the set is
+      // just INTERNAL_SKILLS, i.e. byte-for-byte the pre-#1308 behaviour — a
+      // silent narrowing on upgrade would strip capability from every existing
+      // consumer (Rule #2), so "unconfigured" must always mean "everything".
+      const excludedSkills = computeExcludedSkills(selectedSkillCategories, INTERNAL_SKILLS);
+      if (selectedSkillCategories) {
+        emitMutation(
+          'applied skills selection',
+          `categories [${selectedSkillCategories.join(', ')}] — ` +
+          `${plural(excludedSkills.size - INTERNAL_SKILLS.length, 'skill')} not synced`,
+        );
+      }
       await syncDirRecursive(
         resolve(projectRoot, 'node_modules/moflo/.claude/skills'),
         '.claude/skills',
-        { projectRoot, syncFile, excludeTopLevel: new Set(INTERNAL_SKILLS), onWarn: emitWarning },
+        { projectRoot, syncFile, excludeTopLevel: excludedSkills, onWarn: emitWarning },
       );
 
       // Sync all shipped guidance files from node_modules/moflo/.claude/guidance/shipped/
@@ -1326,17 +1348,51 @@ try {
             `${plural(report.pruned.length, 'file')} matching known-shipped content removed`,
           );
         }
+        // Always reconcile the retained record — including writing none when
+        // nothing is retained, so a record from a previous run doesn't outlive
+        // the files it names (#1307 finding 3).
+        //
+        // The version is only read when there is actually something to record.
+        // Nothing-retained is the overwhelmingly common case, and this runs on
+        // every session start in every consumer — an unconditional read +
+        // JSON.parse here would be pure hot-path waste.
+        //
+        // Read locally rather than reusing §2's `installedVersion`: that
+        // binding is scoped to the auto-update branch, and an out-of-scope
+        // reference would be swallowed by the surrounding catch as a bogus
+        // "prune skipped" warning.
+        let recordVersion;
+        if (report.preservedDetails.length > 0) {
+          try {
+            recordVersion = JSON.parse(readFileSync(
+              resolve(projectRoot, 'node_modules/moflo/package.json'), 'utf-8',
+            )).version;
+          } catch { /* record just omits the version */ }
+        }
+        const retainedRecordPath = writeRetainedRecord(
+          projectRoot,
+          report.preservedDetails,
+          recordVersion,
+        );
         if (report.preserved.length > 0) {
           // stdout (not stderr) so Claude sees this in `additionalContext`
           // and can surface to the user — these aren't failures, just
           // consumer-customized files we deliberately left alone.
+          //
+          // The banner samples; the full list goes to the record file. Before
+          // the record existed the truncated banner was the ONLY place these
+          // paths appeared, and it scrolls away — so "delete manually" wasn't
+          // actionable past the 5th entry.
           const sample = report.preserved.slice(0, 5).map((p) => `  - ${p}`).join('\n');
           const more = report.preserved.length > 5
             ? `\n  …and ${report.preserved.length - 5} more`
             : '';
+          const where = retainedRecordPath
+            ? `\n  full list: ${RETAINED_RECORD_REL}`
+            : '';
           try {
             process.stdout.write(
-              `moflo: retained ${plural(report.preserved.length, 'customized retired file')} (delete manually if unwanted):\n${sample}${more}\n`,
+              `moflo: retained ${plural(report.preserved.length, 'customized retired file')} (delete manually if unwanted):\n${sample}${more}${where}\n`,
             );
           } catch { /* non-fatal */ }
         }
@@ -2420,6 +2476,26 @@ try {
 // moment this version's files are in place (see commitVersionStamp). #730 is
 // preserved because that commit is gated on sync success; every stage after the
 // sync block runs unconditionally + idempotently each session.
+
+// ── 3g-1307. Keep the retained-retired record honest every session ──────────
+// The record is WRITTEN in §3's upgrade branch (that is where the retired-file
+// prune runs), but it must not survive the files it names — a user who reads
+// it and deletes those files would otherwise keep a record listing them until
+// their next moflo upgrade. Reconciling here, unconditionally, closes that.
+// Costs one existsSync when no record is present, which is the normal state.
+try {
+  const rec = reconcileRetainedRecord(projectRoot);
+  if (rec.changed) {
+    emitMutation(
+      'reconciled retained-retired record',
+      rec.remaining === 0
+        ? 'all retained files removed by the user — record dropped'
+        : `${plural(rec.removed.length, 'entry')} dropped, ${rec.remaining} still retained`,
+    );
+  }
+} catch (err) {
+  emitWarning(`retained-record reconcile skipped (${errMessage(err)})`);
+}
 
 // ── 3h. Clear bootstrap sentinel if section-3 sync resolved it (#975) ───────
 // Section 3 above re-attempts the same file copies the bootstrap was supposed

--- a/tests/guards/dogfood-copy-parity-guard.test.ts
+++ b/tests/guards/dogfood-copy-parity-guard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Guard: every dogfood copy under `.claude/` must be byte-identical to the
+ * `bin/` file the launcher syncs into it.
+ *
+ * In a consumer project, `bin/session-start-launcher.mjs` copies itself and its
+ * siblings into `.claude/scripts/` and `.claude/helpers/` on session start
+ * (`syncFile` → `atomicCopy`, verbatim — no transformation). In moflo's OWN
+ * repo that sync is deliberately skipped (#928: the destinations are committed
+ * git files and copying `node_modules/moflo` content over them would clobber
+ * in-flight work). The consequence is that these copies only ever update when
+ * someone edits them by hand — and the dogfood copies are what moflo itself
+ * runs.
+ *
+ * When they drift, moflo runs different code than it ships, which is precisely
+ * the environment that is supposed to catch shipping bugs. It had drifted:
+ * `.claude/scripts/session-start-launcher.mjs` sat two changes behind `bin/`,
+ * missing #1307's `reconcileRetainedRecord` — which runs unconditionally every
+ * session — so the dogfood repo silently never reconciled its retained-retired
+ * record. Nothing caught it because no test compared the pair.
+ *
+ * If this goes red, copy the `bin/` file across wholesale. Do not hand-merge,
+ * and do not add an exception: a file that legitimately differs does not belong
+ * in the synced set at all.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+
+/**
+ * Destination → source-root pairs, mirroring what the launcher syncs.
+ * `.claude/helpers/` and `.claude/scripts/` both come from `bin/`; their
+ * `lib/` and `migrations/` subtrees come from the matching `bin/` subtree.
+ */
+const SYNCED_TREES: ReadonlyArray<{ dest: string; src: string }> = [
+  { dest: '.claude/scripts', src: 'bin' },
+  { dest: '.claude/scripts/lib', src: 'bin/lib' },
+  { dest: '.claude/scripts/migrations', src: 'bin/migrations' },
+  { dest: '.claude/scripts/migrations/lib', src: 'bin/migrations/lib' },
+  { dest: '.claude/helpers', src: 'bin' },
+];
+
+/** Line endings are normalised: git may check these out as CRLF on Windows. */
+function read(path: string): string {
+  return readFileSync(path, 'utf-8').replace(/\r\n/g, '\n');
+}
+
+/**
+ * Every dest file that HAS a bin/ counterpart. A dest file without one is not a
+ * dogfood copy at all — `.claude/helpers/statusline.cjs` and the git hooks are
+ * sources in their own right — so it is skipped rather than failed.
+ */
+function syncedPairs(): Array<{ label: string; destPath: string; srcPath: string }> {
+  const pairs: Array<{ label: string; destPath: string; srcPath: string }> = [];
+  for (const { dest, src } of SYNCED_TREES) {
+    const destDir = resolve(REPO_ROOT, dest);
+    if (!existsSync(destDir)) continue;
+    for (const name of readdirSync(destDir)) {
+      const destPath = join(destDir, name);
+      if (!statSync(destPath).isFile()) continue;
+      const srcPath = resolve(REPO_ROOT, src, name);
+      if (!existsSync(srcPath) || !statSync(srcPath).isFile()) continue;
+      pairs.push({ label: `${dest}/${name} <- ${src}/${name}`, destPath, srcPath });
+    }
+  }
+  return pairs;
+}
+
+describe('dogfood copy parity (bin/ -> .claude/)', () => {
+  const pairs = syncedPairs();
+
+  // A guard that silently matched nothing would be worse than no guard: it
+  // would go green forever if the mapping above ever stopped resolving.
+  it('finds the synced dogfood copies to compare', () => {
+    expect(pairs.length).toBeGreaterThan(20);
+    expect(pairs.map((p) => p.label)).toContain(
+      '.claude/scripts/session-start-launcher.mjs <- bin/session-start-launcher.mjs',
+    );
+  });
+
+  it.each(pairs.map((p) => [p.label, p] as const))(
+    'is byte-identical: %s',
+    (_label, pair) => {
+      expect(read(pair.destPath)).toBe(read(pair.srcPath));
+    },
+  );
+});


### PR DESCRIPTION
`.claude/scripts/session-start-launcher.mjs` — the launcher moflo's own repo actually runs, wired in `.claude/settings.json` — was two changes behind `bin/session-start-launcher.mjs`.

In a consumer project the launcher syncs itself into `.claude/scripts/` on session start. In moflo's own repo that sync is deliberately skipped (#928: the destinations are committed git files, and copying `node_modules` content over them clobbers in-flight work). So the dogfood copies only update when someone edits them by hand — and #1307 and #1308 did not.

## Behavioural impact, stated precisely

| change | in `bin/` | in the stale dogfood copy | ran in dogfood? |
|---|---|---|---|
| #1307 `reconcileRetainedRecord` | yes | **no** | **yes — unconditional, every session** |
| #1308 `computeExcludedSkills` | yes | no | no — sits inside the sync branch dogfood skips by design |

Only the #1307 half is a real regression: it runs unconditionally outside the skipped sync branch, so this repo has silently never reconciled its retained-retired record. An earlier writeup of this drift led with #1308; that half does **not** change dogfood behaviour, and syncing the file does not make #1308 exercised here.

## The fix

`syncFile` → `atomicCopy` is verbatim with no transformation, so byte-identical is the correct target and the fix is a straight copy. Verified before copying: `.claude/scripts/lib/` already carried `skill-categories.mjs` and `retired-files.mjs`, so the newer launcher's top-level imports resolve. Verified after: parses, a headless run reaches the `CLAUDE_CODE_HEADLESS` guard (which sits after all imports), LF endings preserved.

## The guard

`tests/guards/dogfood-copy-parity-guard.test.ts` enumerates every `.claude/{scripts,helpers}` file with a `bin/` counterpart — including the `lib/` and `migrations/` subtrees — and asserts byte equality, CRLF-normalised for Windows checkouts (Rule #1). 53 pairs.

It is data-driven, so a newly synced file is covered automatically rather than needing a new assertion. A `.claude/` file with no `bin/` counterpart (`statusline.cjs`, the git hooks, `auto-memory-hook.mjs`) is a source in its own right and is skipped, not failed. It also asserts it found the pairs at all, so a broken mapping cannot make the guard silently vacuous.

**Mutation-tested**, per the standing rule that a parity assertion which cannot fail is worse than none: appending one line to the dogfood launcher turns it red on exactly that pair; reverting turns it green.

Note it now double-covers `gate.cjs` / `gate-hook.mjs` alongside `gate-hook-parity-guard.test.ts`. Harmless — the older guard additionally asserts generator parity, so neither subsumes the other.

## Consumer blast radius (Rule #2)

**None.** `.claude/scripts/**` is not in `package.json` `files`; consumers receive `bin/` and the launcher syncs it into their `.claude/scripts/` at session start. This only corrects moflo's own dogfood copy. The guard is a test. No round-trip, no migration, nothing for a consumer to do.

## Verification

- Full suite: **9996 passed, 0 failed.**
- Guard: 54/54, mutation-tested red-then-green.
- `/verify` PASS on all 6 criteria (recorded as `verify:dogfood-launcher-parity`).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)