### PR TITLE
fix(gates): pin gate credit to the code it describes, not to observed edits

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -634,9 +634,16 @@ function fingerprintIncludes(rel, scope) {
 }
 
 /**
- * Paths reported by `git status --porcelain=v1 -uall -z`. Rename and copy
- * entries carry a second NUL-terminated token (the origin path) that must be
- * consumed, or it would be misread as the next entry's status bytes.
+ * Paths reported by `git status --porcelain=v1 -uall -z`, as
+ * `{ path, orig }` — `orig` set only for renames and copies.
+ *
+ * A rename emits `R  <new>\0<old>\0`: two NUL-terminated tokens for one entry.
+ * The origin token must be consumed or it is misread as the next entry's status
+ * bytes, AND it must be reported, because a rename means the old path no longer
+ * exists. Dropping it on the floor leaves the old path in the content map — the
+ * fingerprint would then carry a phantom entry that disappears the moment the
+ * rename is committed, expiring credit on a commit that changed no content.
+ * That is the same defect content-addressing was introduced to remove.
  */
 function parsePorcelainZ(raw) {
   var out = [];
@@ -644,9 +651,10 @@ function parsePorcelainZ(raw) {
   for (var i = 0; i < parts.length; i++) {
     var entry = parts[i];
     if (!entry || entry.length < 4) continue;
-    var xy = entry.slice(0, 2);
-    out.push(entry.slice(3));
-    if (xy.charAt(0) === 'R' || xy.charAt(0) === 'C') i++; // skip origin path
+    var xy = entry.charAt(0);
+    var rec = { path: entry.slice(3), orig: null };
+    if (xy === 'R' || xy === 'C') { rec.orig = parts[i + 1] || null; i++; }
+    out.push(rec);
   }
   return out;
 }
@@ -704,7 +712,11 @@ function computeCreditFingerprint(scope) {
     var changed = parsePorcelainZ(git(['status', '--porcelain=v1', '-uall', '-z']));
     var live = [];
     for (var j = 0; j < changed.length; j++) {
-      var rel = changed[j];
+      var rel = changed[j].path;
+      // A rename's origin path is gone from the content — drop it, or it
+      // lingers until the rename is committed and then vanishes, moving the
+      // fingerprint on a commit that changed nothing.
+      if (changed[j].orig) delete byPath[changed[j].orig];
       var abs = path.resolve(PROJECT_DIR, rel);
       var isFile = false;
       try { isFile = fs.statSync(abs).isFile(); } catch (e) { isFile = false; }

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -672,36 +672,74 @@ function creditFingerprint(scope) {
 function computeCreditFingerprint(scope) {
   var git = function (args) {
     return cp.execFileSync('git', args, {
-      cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 5000, windowsHide: true,
-      maxBuffer: 8 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
+      cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 10000, windowsHide: true,
+      maxBuffer: 64 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
     });
   };
-  var head;
+  // Fingerprint the CONTENT of the working tree, never (HEAD + delta). Those
+  // are not the same thing: `git commit` moves changes from the working tree
+  // into HEAD without altering a single byte of code, and a HEAD-based
+  // fingerprint would expire every credit on commit — forcing a pointless
+  // re-run of the tests that just passed on exactly this code. Content-
+  // addressing also makes the fingerprint stable across amend, stash/pop, and
+  // any branch switch that lands on identical content, while still moving the
+  // moment real content differs.
+  //
+  // Unchanged files contribute git's own blob hashes (free, already computed);
+  // only files git reports as changed or untracked are hashed here.
+  var tracked;
   try {
-    head = git(['rev-parse', 'HEAD']).trim();
-  } catch (e) { return null; }
-  if (!head) return null;
-  var parts = ['head:' + head];
+    tracked = git(['ls-tree', '-r', '-z', 'HEAD']);
+  } catch (e) { return null; } // no git, no repo, or no commit yet
+  var byPath = Object.create(null);
+  var entries = String(tracked).split('\0');
+  for (var i = 0; i < entries.length; i++) {
+    // "<mode> <type> <object>\t<path>"
+    var tab = entries[i].indexOf('\t');
+    if (tab < 0) continue;
+    var meta = entries[i].slice(0, tab).split(' ');
+    byPath[entries[i].slice(tab + 1)] = meta[2];
+  }
   try {
-    var files = parsePorcelainZ(git(['status', '--porcelain=v1', '-uall', '-z']));
-    files.sort();
-    for (var i = 0; i < files.length; i++) {
-      var rel = files[i];
-      if (!fingerprintIncludes(rel, scope)) continue;
+    var changed = parsePorcelainZ(git(['status', '--porcelain=v1', '-uall', '-z']));
+    var live = [];
+    for (var j = 0; j < changed.length; j++) {
+      var rel = changed[j];
       var abs = path.resolve(PROJECT_DIR, rel);
-      var body;
-      try {
-        body = crypto.createHash('sha1').update(fs.readFileSync(abs)).digest('hex');
-      } catch (e) {
-        body = 'absent'; // deleted, or unreadable — either way, a change
+      var isFile = false;
+      try { isFile = fs.statSync(abs).isFile(); } catch (e) { isFile = false; }
+      // A path git reports but that is gone (or is not a regular file) is
+      // absent from the content, so it must leave the map entirely.
+      if (!isFile) { delete byPath[rel]; continue; }
+      if (rel.indexOf('\n') >= 0) { delete byPath[rel]; continue; } // unhashable via --stdin-paths
+      live.push(rel);
+    }
+    if (live.length) {
+      // `git hash-object` — NOT a raw sha1 of the bytes. A git blob id hashes
+      // "blob <size>\0" plus the content, and applies the same clean filters
+      // and core.autocrlf normalisation git would apply on checkin. Hashing the
+      // raw bytes here instead would produce a different string than ls-tree
+      // reports for identical content, so a file would appear to "change" the
+      // moment it was committed — and on Windows, whenever autocrlf rewrote its
+      // line endings. One batched call covers every changed path.
+      var hashed = cp.execFileSync('git', ['hash-object', '--stdin-paths'], {
+        cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 10000, windowsHide: true,
+        maxBuffer: 64 * 1024 * 1024, input: live.join('\n') + '\n',
+        stdio: ['pipe', 'pipe', 'ignore'],
+      }).trim().split('\n');
+      for (var m = 0; m < live.length; m++) {
+        if (hashed[m]) byPath[live[m]] = hashed[m].trim();
       }
-      parts.push(rel + ':' + body);
     }
   } catch (e) {
-    // HEAD resolved but status failed — fingerprint on HEAD alone rather than
-    // returning null, so a committed change still invalidates credit.
+    // status failed — fall back to the committed tree alone rather than null,
+    // so the fingerprint still tracks committed content.
   }
-  return crypto.createHash('sha1').update(parts.join('\n')).digest('hex');
+  var paths = Object.keys(byPath).filter(function (p) { return fingerprintIncludes(p, scope); });
+  paths.sort();
+  var h = crypto.createHash('sha1');
+  for (var k = 0; k < paths.length; k++) h.update(paths[k] + ':' + byPath[paths[k]] + '\n');
+  return h.digest('hex');
 }
 
 /**

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -4,11 +4,16 @@ var fs = require('fs');
 var path = require('path');
 var cp = require('child_process');
 var os = require('os');
+var crypto = require('crypto');
 
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, verifyRun: false, verifyOutcome: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
+// testsFingerprint / simplifyFingerprint / verifyFingerprint pin each credit to
+// the code it describes, so a change made outside Write/Edit/MultiEdit (a Bash
+// write, a branch switch, the next issue in the same session) invalidates it.
+// See creditFingerprint() for why the boolean flags alone cannot.
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, testsFingerprint: null, simplifyRun: false, simplifySnapshotSha: null, simplifyFingerprint: null, verifyRun: false, verifyOutcome: null, verifyFingerprint: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -585,6 +590,138 @@ var SOURCE_FILE_RE = /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|rb|java|kt|swift|c|cc|cp
 // — gives a more specific reason than "no source files" in that subset.
 var DOCS_ONLY_RE = /\.(md|markdown|txt|rst|adoc|html?|pdf|png|jpe?g|gif|svg|webp|ico|bmp)$/i;
 
+// ── Content-addressed gate credit ───────────────────────────────────────────
+// A boolean `testsRun`/`simplifyRun`/`verifyRun` answers "was an edit
+// observed?" — which is only equivalent to "does this credit still describe the
+// code?" if every mutation flows through Write/Edit/MultiEdit. It does not.
+// `node -e` with fs.writeFileSync, `sed -i`, shell redirection, `cp`, and every
+// git operation that moves the tree (checkout, pull, merge, rebase, apply)
+// change source without firing PostToolUse on those tools, so reset-edit-gates
+// never runs and credit earned beforehand survives the change. Demonstrated by
+// earning full credit, appending an execSync call to a source file via Bash,
+// and watching check-before-pr allow the PR. Multi-issue sessions have the same
+// shape: nothing is per-prompt, so issue B inherits issue A's credit.
+//
+// Every one of #908 / #1176 / #1322 / #1332 / #1348 refined WHICH tool call to
+// watch. None of them could close this, because the observer is the wrong
+// primitive. So stop observing mutations and fingerprint the code itself: HEAD
+// plus the content of every changed and untracked file. Recompute at check
+// time; any mismatch means the credit describes different code and is stale. No
+// tool can bypass it, because it watches no tools.
+//
+// Scope mirrors the reset predicates so their intentional exemptions survive.
+// Inert files (#1176) and `.github/` + `.moflo/` paths never contribute, so a
+// markdown or spec edit still leaves a test run standing. 'nontest' also drops
+// test files, preserving #908: touching a test does not invalidate /simplify.
+//
+// isEphemeralPath is deliberately NOT applied — it exists for agent scratchpads
+// outside the project, and `git status` cannot report those.
+// The gate's own state file must never contribute: recording a credit writes
+// it, which would change the very fingerprint the credit is pinned to and make
+// every credit instantly stale. It is gitignored in moflo's repo, but a
+// consumer project need not ignore it, and there the self-reference would
+// deadlock their gate permanently — so exclude it by name rather than trusting
+// .gitignore. Scoped to this one file: `.claude/` also holds real source
+// (helpers/, scripts/) that must keep counting.
+var FINGERPRINT_SELF_RE = /(?:^|[\\\/])\.claude[\\\/]workflow-state\.json$/i;
+
+function fingerprintIncludes(rel, scope) {
+  if (FINGERPRINT_SELF_RE.test(rel)) return false;
+  if (EDIT_RESET_SKIP_BOTH_RE.test(rel)) return false;
+  if (EDIT_RESET_SKIP_PATH_RE.test(rel)) return false;
+  if (scope === 'nontest' && EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE.test(rel)) return false;
+  return true;
+}
+
+/**
+ * Paths reported by `git status --porcelain=v1 -uall -z`. Rename and copy
+ * entries carry a second NUL-terminated token (the origin path) that must be
+ * consumed, or it would be misread as the next entry's status bytes.
+ */
+function parsePorcelainZ(raw) {
+  var out = [];
+  var parts = String(raw).split('\0');
+  for (var i = 0; i < parts.length; i++) {
+    var entry = parts[i];
+    if (!entry || entry.length < 4) continue;
+    var xy = entry.slice(0, 2);
+    out.push(entry.slice(3));
+    if (xy.charAt(0) === 'R' || xy.charAt(0) === 'C') i++; // skip origin path
+  }
+  return out;
+}
+
+/**
+ * Fingerprint of the code a gate credit describes, or null when it cannot be
+ * computed (no git, no repo, no commits). Null is the fail-open signal: callers
+ * fall back to the flag alone, so non-git projects behave exactly as before.
+ */
+// Memoised per scope. check-before-pr tests three credits and check-before-done
+// a fourth, and each computation shells out to `git status -uall` over the whole
+// tree. The gate process is short-lived and single-shot — it exits before any
+// tool it gates can run — so nothing can change underneath the cache.
+var FINGERPRINT_CACHE = {};
+
+function creditFingerprint(scope) {
+  if (Object.prototype.hasOwnProperty.call(FINGERPRINT_CACHE, scope)) return FINGERPRINT_CACHE[scope];
+  var value = computeCreditFingerprint(scope);
+  FINGERPRINT_CACHE[scope] = value;
+  return value;
+}
+
+function computeCreditFingerprint(scope) {
+  var git = function (args) {
+    return cp.execFileSync('git', args, {
+      cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 5000, windowsHide: true,
+      maxBuffer: 8 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  };
+  var head;
+  try {
+    head = git(['rev-parse', 'HEAD']).trim();
+  } catch (e) { return null; }
+  if (!head) return null;
+  var parts = ['head:' + head];
+  try {
+    var files = parsePorcelainZ(git(['status', '--porcelain=v1', '-uall', '-z']));
+    files.sort();
+    for (var i = 0; i < files.length; i++) {
+      var rel = files[i];
+      if (!fingerprintIncludes(rel, scope)) continue;
+      var abs = path.resolve(PROJECT_DIR, rel);
+      var body;
+      try {
+        body = crypto.createHash('sha1').update(fs.readFileSync(abs)).digest('hex');
+      } catch (e) {
+        body = 'absent'; // deleted, or unreadable — either way, a change
+      }
+      parts.push(rel + ':' + body);
+    }
+  } catch (e) {
+    // HEAD resolved but status failed — fingerprint on HEAD alone rather than
+    // returning null, so a committed change still invalidates credit.
+  }
+  return crypto.createHash('sha1').update(parts.join('\n')).digest('hex');
+}
+
+/**
+ * Is a credit still live? `flag` is the legacy boolean, `stored` the fingerprint
+ * captured when it was earned.
+ *
+ * Fail-open on an uncomputable fingerprint (non-git project) — the gate keeps
+ * its previous semantics there rather than blocking work it cannot reason about.
+ * Fail-CLOSED on a missing stored fingerprint: that is credit earned by a
+ * pre-upgrade gate, and it carries no evidence about which code it covered. The
+ * cost is re-running once on the first PR after upgrade, which self-heals.
+ */
+function creditIsLive(flag, stored, scope) {
+  if (!flag) return false;
+  var now = creditFingerprint(scope);
+  if (now === null) return true;
+  if (!stored) return false;
+  return stored === now;
+}
+
 // Classifier-aware simplify gate skip. Returns a string reason if the gate
 // can be auto-passed, or null if /simplify must run. Uses simplify-classify.cjs
 // so the gate's "trivial" definition matches the skill's exactly.
@@ -881,11 +1018,19 @@ switch (command) {
       var failure = detectTestFailure();
       var s = readState();
       if (failure) {
-        if (s.testsRun) { s.testsRun = false; writeState(s); }
+        if (s.testsRun) { s.testsRun = false; s.testsFingerprint = null; writeState(s); }
         process.stderr.write('gate: record-test-run not credited — ' + failure + '\n');
-      } else if (!s.testsRun) {
-        s.testsRun = true;
-        writeState(s);
+      } else {
+        // Re-stamp on every green run, not only the first: the tree may have
+        // moved since the last one, and this run is evidence about the tree as
+        // it is NOW. Gating on `!s.testsRun` would keep the older fingerprint
+        // and discard the fresher evidence.
+        var testsFp = creditFingerprint('all');
+        if (!s.testsRun || s.testsFingerprint !== testsFp) {
+          s.testsRun = true;
+          s.testsFingerprint = testsFp;
+          writeState(s);
+        }
       }
     } else if (cmd) {
       // #1176 — emit a stderr crumb when invoked with a non-empty command that
@@ -905,6 +1050,10 @@ switch (command) {
       var s = readState();
       var changed = false;
       if (!s.simplifyRun) { s.simplifyRun = true; changed = true; }
+      // 'nontest' scope: a later test-only edit must not invalidate this review
+      // (#908), so test files are excluded from what the credit is pinned to.
+      var simplifyFp = creditFingerprint('nontest');
+      if (s.simplifyFingerprint !== simplifyFp) { s.simplifyFingerprint = simplifyFp; changed = true; }
       // Snapshot HEAD so check-before-pr can classify delta-since-simplify and
       // skip a redundant /simplify re-run when only trivial fixes followed.
       // Non-fatal — gate falls through to current behaviour without the snapshot.
@@ -941,9 +1090,11 @@ switch (command) {
       // #1332: invoking /verify starts a verification; it does not conclude
       // one. Clear any prior verdict so the run in progress cannot inherit the
       // PASS from a previous issue and satisfy check-before-done on its own.
-      if (!s.verifyRun || s.verifyOutcome) {
+      var verifyFp = creditFingerprint('all');
+      if (!s.verifyRun || s.verifyOutcome || s.verifyFingerprint !== verifyFp) {
         s.verifyRun = true;
         s.verifyOutcome = null;
+        s.verifyFingerprint = verifyFp;
         writeState(s);
       }
     } else if (vName) {
@@ -1099,6 +1250,22 @@ switch (command) {
       }
     }
     var s = readState();
+    // Expire any credit whose fingerprint no longer matches the code before
+    // reading the flags. This is what catches the mutations reset-edit-gates
+    // structurally cannot see — Bash writes, git checkout/pull/merge, and the
+    // next issue in the same session — so the flags below mean "still true of
+    // THIS code", not merely "was true at some point this session".
+    var expired = [];
+    if (s.testsRun && !creditIsLive(s.testsRun, s.testsFingerprint, 'all')) {
+      s.testsRun = false; s.testsFingerprint = null; expired.push('tests');
+    }
+    if (s.simplifyRun && !creditIsLive(s.simplifyRun, s.simplifyFingerprint, 'nontest')) {
+      s.simplifyRun = false; s.simplifyFingerprint = null; expired.push('simplify');
+    }
+    if ((s.verifyRun || s.verifyOutcome) && !creditIsLive(s.verifyRun, s.verifyFingerprint, 'all')) {
+      s.verifyRun = false; s.verifyOutcome = null; s.verifyFingerprint = null; expired.push('verify');
+    }
+    if (expired.length) writeState(s);
     // Classifier-aware skip: if delta-since-snapshot or whole-branch diff is
     // TRIVIAL, satisfy the simplify gate silently. Reuses the same classifier
     // the skill uses — same "trivial" definition, no drift. Same threshold that
@@ -1120,6 +1287,13 @@ switch (command) {
     process.stderr.write('BLOCKED: gh pr create requires the following before opening a PR:\n');
     for (var i = 0; i < missing.length; i++) {
       process.stderr.write('  - ' + missing[i] + '\n');
+    }
+    if (expired.length) {
+      process.stderr.write(
+        'Expired because the code changed since they ran (' + expired.join(', ') +
+        ') — this includes changes made outside Write/Edit, e.g. a Bash write, ' +
+        'git checkout/pull, or moving on to a different change in the same session.\n',
+      );
     }
     if (s.lastResetBy && s.lastResetBy.file) {
       process.stderr.write('Last gate reset: ' + s.lastResetBy.file + ' (' + (s.lastResetBy.gates || []).join(', ') + ')\n');
@@ -1156,6 +1330,17 @@ switch (command) {
       }
     }
     var sd = readState();
+    // Expire a verdict that no longer describes the code, for the same reason
+    // check-before-pr does: a PASS earned before a Bash write, a branch switch,
+    // or the next change in this session is evidence about different code.
+    // #1332 made the gate read the outcome instead of attendance; this makes it
+    // read an outcome that is still ABOUT the thing being shipped.
+    var verifyStale = (sd.verifyRun || sd.verifyOutcome)
+      && !creditIsLive(sd.verifyRun, sd.verifyFingerprint, 'all');
+    if (verifyStale) {
+      sd.verifyRun = false; sd.verifyOutcome = null; sd.verifyFingerprint = null;
+      writeState(sd);
+    }
     // #1332: gate on the OUTCOME, not on attendance. Before this, `verifyRun`
     // alone opened the gate, so a /verify returning FAIL satisfied it exactly
     // as a PASS did — a failing verdict is still a successful tool invocation.
@@ -1165,7 +1350,11 @@ switch (command) {
     // rather than emitting one message that fits none of them.
     var invalidated = sd.lastResetBy && sd.lastResetBy.file
       && (sd.lastResetBy.gates || []).indexOf('verify') >= 0;
-    if (!sd.verifyRun && invalidated) {
+    if (verifyStale) {
+      process.stderr.write('  - the code changed since /verify ran — re-run /verify\n');
+      process.stderr.write('    (detected by content, so this covers changes made outside Write/Edit:\n');
+      process.stderr.write('     a Bash write, git checkout/pull, or a different change in the same session)\n');
+    } else if (!sd.verifyRun && invalidated) {
       process.stderr.write('  - a code edit invalidated the previous verification — re-run /verify\n');
       process.stderr.write('Last gate reset: ' + sd.lastResetBy.file + ' (verify)\n');
     } else if (!sd.verifyRun) {

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -651,9 +651,15 @@ function parsePorcelainZ(raw) {
   for (var i = 0; i < parts.length; i++) {
     var entry = parts[i];
     if (!entry || entry.length < 4) continue;
-    var xy = entry.charAt(0);
+    // Check BOTH status columns, not just the staged one: git reports a rename
+    // as `R ` when staged and can report ` R` for one detected in the worktree.
+    // Missing the second form would leave the origin token unconsumed, and it
+    // would then be read as the next entry's status bytes — misaligning every
+    // entry after it. R and C always emit an origin token, so consuming one
+    // whenever either column shows them cannot over-consume.
+    var st = entry.slice(0, 2);
     var rec = { path: entry.slice(3), orig: null };
-    if (xy === 'R' || xy === 'C') { rec.orig = parts[i + 1] || null; i++; }
+    if (st.indexOf('R') >= 0 || st.indexOf('C') >= 0) { rec.orig = parts[i + 1] || null; i++; }
     out.push(rec);
   }
   return out;

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -634,9 +634,16 @@ function fingerprintIncludes(rel, scope) {
 }
 
 /**
- * Paths reported by `git status --porcelain=v1 -uall -z`. Rename and copy
- * entries carry a second NUL-terminated token (the origin path) that must be
- * consumed, or it would be misread as the next entry's status bytes.
+ * Paths reported by `git status --porcelain=v1 -uall -z`, as
+ * `{ path, orig }` — `orig` set only for renames and copies.
+ *
+ * A rename emits `R  <new>\0<old>\0`: two NUL-terminated tokens for one entry.
+ * The origin token must be consumed or it is misread as the next entry's status
+ * bytes, AND it must be reported, because a rename means the old path no longer
+ * exists. Dropping it on the floor leaves the old path in the content map — the
+ * fingerprint would then carry a phantom entry that disappears the moment the
+ * rename is committed, expiring credit on a commit that changed no content.
+ * That is the same defect content-addressing was introduced to remove.
  */
 function parsePorcelainZ(raw) {
   var out = [];
@@ -644,9 +651,10 @@ function parsePorcelainZ(raw) {
   for (var i = 0; i < parts.length; i++) {
     var entry = parts[i];
     if (!entry || entry.length < 4) continue;
-    var xy = entry.slice(0, 2);
-    out.push(entry.slice(3));
-    if (xy.charAt(0) === 'R' || xy.charAt(0) === 'C') i++; // skip origin path
+    var xy = entry.charAt(0);
+    var rec = { path: entry.slice(3), orig: null };
+    if (xy === 'R' || xy === 'C') { rec.orig = parts[i + 1] || null; i++; }
+    out.push(rec);
   }
   return out;
 }
@@ -704,7 +712,11 @@ function computeCreditFingerprint(scope) {
     var changed = parsePorcelainZ(git(['status', '--porcelain=v1', '-uall', '-z']));
     var live = [];
     for (var j = 0; j < changed.length; j++) {
-      var rel = changed[j];
+      var rel = changed[j].path;
+      // A rename's origin path is gone from the content — drop it, or it
+      // lingers until the rename is committed and then vanishes, moving the
+      // fingerprint on a commit that changed nothing.
+      if (changed[j].orig) delete byPath[changed[j].orig];
       var abs = path.resolve(PROJECT_DIR, rel);
       var isFile = false;
       try { isFile = fs.statSync(abs).isFile(); } catch (e) { isFile = false; }

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -672,36 +672,74 @@ function creditFingerprint(scope) {
 function computeCreditFingerprint(scope) {
   var git = function (args) {
     return cp.execFileSync('git', args, {
-      cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 5000, windowsHide: true,
-      maxBuffer: 8 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
+      cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 10000, windowsHide: true,
+      maxBuffer: 64 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
     });
   };
-  var head;
+  // Fingerprint the CONTENT of the working tree, never (HEAD + delta). Those
+  // are not the same thing: `git commit` moves changes from the working tree
+  // into HEAD without altering a single byte of code, and a HEAD-based
+  // fingerprint would expire every credit on commit — forcing a pointless
+  // re-run of the tests that just passed on exactly this code. Content-
+  // addressing also makes the fingerprint stable across amend, stash/pop, and
+  // any branch switch that lands on identical content, while still moving the
+  // moment real content differs.
+  //
+  // Unchanged files contribute git's own blob hashes (free, already computed);
+  // only files git reports as changed or untracked are hashed here.
+  var tracked;
   try {
-    head = git(['rev-parse', 'HEAD']).trim();
-  } catch (e) { return null; }
-  if (!head) return null;
-  var parts = ['head:' + head];
+    tracked = git(['ls-tree', '-r', '-z', 'HEAD']);
+  } catch (e) { return null; } // no git, no repo, or no commit yet
+  var byPath = Object.create(null);
+  var entries = String(tracked).split('\0');
+  for (var i = 0; i < entries.length; i++) {
+    // "<mode> <type> <object>\t<path>"
+    var tab = entries[i].indexOf('\t');
+    if (tab < 0) continue;
+    var meta = entries[i].slice(0, tab).split(' ');
+    byPath[entries[i].slice(tab + 1)] = meta[2];
+  }
   try {
-    var files = parsePorcelainZ(git(['status', '--porcelain=v1', '-uall', '-z']));
-    files.sort();
-    for (var i = 0; i < files.length; i++) {
-      var rel = files[i];
-      if (!fingerprintIncludes(rel, scope)) continue;
+    var changed = parsePorcelainZ(git(['status', '--porcelain=v1', '-uall', '-z']));
+    var live = [];
+    for (var j = 0; j < changed.length; j++) {
+      var rel = changed[j];
       var abs = path.resolve(PROJECT_DIR, rel);
-      var body;
-      try {
-        body = crypto.createHash('sha1').update(fs.readFileSync(abs)).digest('hex');
-      } catch (e) {
-        body = 'absent'; // deleted, or unreadable — either way, a change
+      var isFile = false;
+      try { isFile = fs.statSync(abs).isFile(); } catch (e) { isFile = false; }
+      // A path git reports but that is gone (or is not a regular file) is
+      // absent from the content, so it must leave the map entirely.
+      if (!isFile) { delete byPath[rel]; continue; }
+      if (rel.indexOf('\n') >= 0) { delete byPath[rel]; continue; } // unhashable via --stdin-paths
+      live.push(rel);
+    }
+    if (live.length) {
+      // `git hash-object` — NOT a raw sha1 of the bytes. A git blob id hashes
+      // "blob <size>\0" plus the content, and applies the same clean filters
+      // and core.autocrlf normalisation git would apply on checkin. Hashing the
+      // raw bytes here instead would produce a different string than ls-tree
+      // reports for identical content, so a file would appear to "change" the
+      // moment it was committed — and on Windows, whenever autocrlf rewrote its
+      // line endings. One batched call covers every changed path.
+      var hashed = cp.execFileSync('git', ['hash-object', '--stdin-paths'], {
+        cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 10000, windowsHide: true,
+        maxBuffer: 64 * 1024 * 1024, input: live.join('\n') + '\n',
+        stdio: ['pipe', 'pipe', 'ignore'],
+      }).trim().split('\n');
+      for (var m = 0; m < live.length; m++) {
+        if (hashed[m]) byPath[live[m]] = hashed[m].trim();
       }
-      parts.push(rel + ':' + body);
     }
   } catch (e) {
-    // HEAD resolved but status failed — fingerprint on HEAD alone rather than
-    // returning null, so a committed change still invalidates credit.
+    // status failed — fall back to the committed tree alone rather than null,
+    // so the fingerprint still tracks committed content.
   }
-  return crypto.createHash('sha1').update(parts.join('\n')).digest('hex');
+  var paths = Object.keys(byPath).filter(function (p) { return fingerprintIncludes(p, scope); });
+  paths.sort();
+  var h = crypto.createHash('sha1');
+  for (var k = 0; k < paths.length; k++) h.update(paths[k] + ':' + byPath[paths[k]] + '\n');
+  return h.digest('hex');
 }
 
 /**

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -4,11 +4,16 @@ var fs = require('fs');
 var path = require('path');
 var cp = require('child_process');
 var os = require('os');
+var crypto = require('crypto');
 
 var PROJECT_DIR = (process.env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var STATE_FILE = path.join(PROJECT_DIR, '.claude', 'workflow-state.json');
 
-var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, simplifyRun: false, simplifySnapshotSha: null, verifyRun: false, verifyOutcome: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
+// testsFingerprint / simplifyFingerprint / verifyFingerprint pin each credit to
+// the code it describes, so a change made outside Write/Edit/MultiEdit (a Bash
+// write, a branch switch, the next issue in the same session) invalidates it.
+// See creditFingerprint() for why the boolean flags alone cannot.
+var STATE_DEFAULTS = { tasksCreated: false, taskCount: 0, memorySearched: false, memorySearchedBy: {}, memoryRequired: true, learningsStored: false, testsRun: false, testsFingerprint: null, simplifyRun: false, simplifySnapshotSha: null, simplifyFingerprint: null, verifyRun: false, verifyOutcome: null, verifyFingerprint: null, interactionCount: 0, sessionStart: null, lastBlockedAt: null, lastNamespaceHint: '', lastNamespaceHintEmittedBy: {}, flMode: null, swarmInitialized: false, hiveInitialized: false, sddMode: false, activeSddSlug: null };
 
 // Per-actor memory-search tracking (#838). The legacy `memorySearched` boolean
 // is session-wide, so once the parent searches memory, every spawned subagent
@@ -585,6 +590,138 @@ var SOURCE_FILE_RE = /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|rb|java|kt|swift|c|cc|cp
 // — gives a more specific reason than "no source files" in that subset.
 var DOCS_ONLY_RE = /\.(md|markdown|txt|rst|adoc|html?|pdf|png|jpe?g|gif|svg|webp|ico|bmp)$/i;
 
+// ── Content-addressed gate credit ───────────────────────────────────────────
+// A boolean `testsRun`/`simplifyRun`/`verifyRun` answers "was an edit
+// observed?" — which is only equivalent to "does this credit still describe the
+// code?" if every mutation flows through Write/Edit/MultiEdit. It does not.
+// `node -e` with fs.writeFileSync, `sed -i`, shell redirection, `cp`, and every
+// git operation that moves the tree (checkout, pull, merge, rebase, apply)
+// change source without firing PostToolUse on those tools, so reset-edit-gates
+// never runs and credit earned beforehand survives the change. Demonstrated by
+// earning full credit, appending an execSync call to a source file via Bash,
+// and watching check-before-pr allow the PR. Multi-issue sessions have the same
+// shape: nothing is per-prompt, so issue B inherits issue A's credit.
+//
+// Every one of #908 / #1176 / #1322 / #1332 / #1348 refined WHICH tool call to
+// watch. None of them could close this, because the observer is the wrong
+// primitive. So stop observing mutations and fingerprint the code itself: HEAD
+// plus the content of every changed and untracked file. Recompute at check
+// time; any mismatch means the credit describes different code and is stale. No
+// tool can bypass it, because it watches no tools.
+//
+// Scope mirrors the reset predicates so their intentional exemptions survive.
+// Inert files (#1176) and `.github/` + `.moflo/` paths never contribute, so a
+// markdown or spec edit still leaves a test run standing. 'nontest' also drops
+// test files, preserving #908: touching a test does not invalidate /simplify.
+//
+// isEphemeralPath is deliberately NOT applied — it exists for agent scratchpads
+// outside the project, and `git status` cannot report those.
+// The gate's own state file must never contribute: recording a credit writes
+// it, which would change the very fingerprint the credit is pinned to and make
+// every credit instantly stale. It is gitignored in moflo's repo, but a
+// consumer project need not ignore it, and there the self-reference would
+// deadlock their gate permanently — so exclude it by name rather than trusting
+// .gitignore. Scoped to this one file: `.claude/` also holds real source
+// (helpers/, scripts/) that must keep counting.
+var FINGERPRINT_SELF_RE = /(?:^|[\\\/])\.claude[\\\/]workflow-state\.json$/i;
+
+function fingerprintIncludes(rel, scope) {
+  if (FINGERPRINT_SELF_RE.test(rel)) return false;
+  if (EDIT_RESET_SKIP_BOTH_RE.test(rel)) return false;
+  if (EDIT_RESET_SKIP_PATH_RE.test(rel)) return false;
+  if (scope === 'nontest' && EDIT_RESET_SKIP_SIMPLIFY_ONLY_RE.test(rel)) return false;
+  return true;
+}
+
+/**
+ * Paths reported by `git status --porcelain=v1 -uall -z`. Rename and copy
+ * entries carry a second NUL-terminated token (the origin path) that must be
+ * consumed, or it would be misread as the next entry's status bytes.
+ */
+function parsePorcelainZ(raw) {
+  var out = [];
+  var parts = String(raw).split('\0');
+  for (var i = 0; i < parts.length; i++) {
+    var entry = parts[i];
+    if (!entry || entry.length < 4) continue;
+    var xy = entry.slice(0, 2);
+    out.push(entry.slice(3));
+    if (xy.charAt(0) === 'R' || xy.charAt(0) === 'C') i++; // skip origin path
+  }
+  return out;
+}
+
+/**
+ * Fingerprint of the code a gate credit describes, or null when it cannot be
+ * computed (no git, no repo, no commits). Null is the fail-open signal: callers
+ * fall back to the flag alone, so non-git projects behave exactly as before.
+ */
+// Memoised per scope. check-before-pr tests three credits and check-before-done
+// a fourth, and each computation shells out to `git status -uall` over the whole
+// tree. The gate process is short-lived and single-shot — it exits before any
+// tool it gates can run — so nothing can change underneath the cache.
+var FINGERPRINT_CACHE = {};
+
+function creditFingerprint(scope) {
+  if (Object.prototype.hasOwnProperty.call(FINGERPRINT_CACHE, scope)) return FINGERPRINT_CACHE[scope];
+  var value = computeCreditFingerprint(scope);
+  FINGERPRINT_CACHE[scope] = value;
+  return value;
+}
+
+function computeCreditFingerprint(scope) {
+  var git = function (args) {
+    return cp.execFileSync('git', args, {
+      cwd: PROJECT_DIR, encoding: 'utf-8', timeout: 5000, windowsHide: true,
+      maxBuffer: 8 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  };
+  var head;
+  try {
+    head = git(['rev-parse', 'HEAD']).trim();
+  } catch (e) { return null; }
+  if (!head) return null;
+  var parts = ['head:' + head];
+  try {
+    var files = parsePorcelainZ(git(['status', '--porcelain=v1', '-uall', '-z']));
+    files.sort();
+    for (var i = 0; i < files.length; i++) {
+      var rel = files[i];
+      if (!fingerprintIncludes(rel, scope)) continue;
+      var abs = path.resolve(PROJECT_DIR, rel);
+      var body;
+      try {
+        body = crypto.createHash('sha1').update(fs.readFileSync(abs)).digest('hex');
+      } catch (e) {
+        body = 'absent'; // deleted, or unreadable — either way, a change
+      }
+      parts.push(rel + ':' + body);
+    }
+  } catch (e) {
+    // HEAD resolved but status failed — fingerprint on HEAD alone rather than
+    // returning null, so a committed change still invalidates credit.
+  }
+  return crypto.createHash('sha1').update(parts.join('\n')).digest('hex');
+}
+
+/**
+ * Is a credit still live? `flag` is the legacy boolean, `stored` the fingerprint
+ * captured when it was earned.
+ *
+ * Fail-open on an uncomputable fingerprint (non-git project) — the gate keeps
+ * its previous semantics there rather than blocking work it cannot reason about.
+ * Fail-CLOSED on a missing stored fingerprint: that is credit earned by a
+ * pre-upgrade gate, and it carries no evidence about which code it covered. The
+ * cost is re-running once on the first PR after upgrade, which self-heals.
+ */
+function creditIsLive(flag, stored, scope) {
+  if (!flag) return false;
+  var now = creditFingerprint(scope);
+  if (now === null) return true;
+  if (!stored) return false;
+  return stored === now;
+}
+
 // Classifier-aware simplify gate skip. Returns a string reason if the gate
 // can be auto-passed, or null if /simplify must run. Uses simplify-classify.cjs
 // so the gate's "trivial" definition matches the skill's exactly.
@@ -881,11 +1018,19 @@ switch (command) {
       var failure = detectTestFailure();
       var s = readState();
       if (failure) {
-        if (s.testsRun) { s.testsRun = false; writeState(s); }
+        if (s.testsRun) { s.testsRun = false; s.testsFingerprint = null; writeState(s); }
         process.stderr.write('gate: record-test-run not credited — ' + failure + '\n');
-      } else if (!s.testsRun) {
-        s.testsRun = true;
-        writeState(s);
+      } else {
+        // Re-stamp on every green run, not only the first: the tree may have
+        // moved since the last one, and this run is evidence about the tree as
+        // it is NOW. Gating on `!s.testsRun` would keep the older fingerprint
+        // and discard the fresher evidence.
+        var testsFp = creditFingerprint('all');
+        if (!s.testsRun || s.testsFingerprint !== testsFp) {
+          s.testsRun = true;
+          s.testsFingerprint = testsFp;
+          writeState(s);
+        }
       }
     } else if (cmd) {
       // #1176 — emit a stderr crumb when invoked with a non-empty command that
@@ -905,6 +1050,10 @@ switch (command) {
       var s = readState();
       var changed = false;
       if (!s.simplifyRun) { s.simplifyRun = true; changed = true; }
+      // 'nontest' scope: a later test-only edit must not invalidate this review
+      // (#908), so test files are excluded from what the credit is pinned to.
+      var simplifyFp = creditFingerprint('nontest');
+      if (s.simplifyFingerprint !== simplifyFp) { s.simplifyFingerprint = simplifyFp; changed = true; }
       // Snapshot HEAD so check-before-pr can classify delta-since-simplify and
       // skip a redundant /simplify re-run when only trivial fixes followed.
       // Non-fatal — gate falls through to current behaviour without the snapshot.
@@ -941,9 +1090,11 @@ switch (command) {
       // #1332: invoking /verify starts a verification; it does not conclude
       // one. Clear any prior verdict so the run in progress cannot inherit the
       // PASS from a previous issue and satisfy check-before-done on its own.
-      if (!s.verifyRun || s.verifyOutcome) {
+      var verifyFp = creditFingerprint('all');
+      if (!s.verifyRun || s.verifyOutcome || s.verifyFingerprint !== verifyFp) {
         s.verifyRun = true;
         s.verifyOutcome = null;
+        s.verifyFingerprint = verifyFp;
         writeState(s);
       }
     } else if (vName) {
@@ -1099,6 +1250,22 @@ switch (command) {
       }
     }
     var s = readState();
+    // Expire any credit whose fingerprint no longer matches the code before
+    // reading the flags. This is what catches the mutations reset-edit-gates
+    // structurally cannot see — Bash writes, git checkout/pull/merge, and the
+    // next issue in the same session — so the flags below mean "still true of
+    // THIS code", not merely "was true at some point this session".
+    var expired = [];
+    if (s.testsRun && !creditIsLive(s.testsRun, s.testsFingerprint, 'all')) {
+      s.testsRun = false; s.testsFingerprint = null; expired.push('tests');
+    }
+    if (s.simplifyRun && !creditIsLive(s.simplifyRun, s.simplifyFingerprint, 'nontest')) {
+      s.simplifyRun = false; s.simplifyFingerprint = null; expired.push('simplify');
+    }
+    if ((s.verifyRun || s.verifyOutcome) && !creditIsLive(s.verifyRun, s.verifyFingerprint, 'all')) {
+      s.verifyRun = false; s.verifyOutcome = null; s.verifyFingerprint = null; expired.push('verify');
+    }
+    if (expired.length) writeState(s);
     // Classifier-aware skip: if delta-since-snapshot or whole-branch diff is
     // TRIVIAL, satisfy the simplify gate silently. Reuses the same classifier
     // the skill uses — same "trivial" definition, no drift. Same threshold that
@@ -1120,6 +1287,13 @@ switch (command) {
     process.stderr.write('BLOCKED: gh pr create requires the following before opening a PR:\n');
     for (var i = 0; i < missing.length; i++) {
       process.stderr.write('  - ' + missing[i] + '\n');
+    }
+    if (expired.length) {
+      process.stderr.write(
+        'Expired because the code changed since they ran (' + expired.join(', ') +
+        ') — this includes changes made outside Write/Edit, e.g. a Bash write, ' +
+        'git checkout/pull, or moving on to a different change in the same session.\n',
+      );
     }
     if (s.lastResetBy && s.lastResetBy.file) {
       process.stderr.write('Last gate reset: ' + s.lastResetBy.file + ' (' + (s.lastResetBy.gates || []).join(', ') + ')\n');
@@ -1156,6 +1330,17 @@ switch (command) {
       }
     }
     var sd = readState();
+    // Expire a verdict that no longer describes the code, for the same reason
+    // check-before-pr does: a PASS earned before a Bash write, a branch switch,
+    // or the next change in this session is evidence about different code.
+    // #1332 made the gate read the outcome instead of attendance; this makes it
+    // read an outcome that is still ABOUT the thing being shipped.
+    var verifyStale = (sd.verifyRun || sd.verifyOutcome)
+      && !creditIsLive(sd.verifyRun, sd.verifyFingerprint, 'all');
+    if (verifyStale) {
+      sd.verifyRun = false; sd.verifyOutcome = null; sd.verifyFingerprint = null;
+      writeState(sd);
+    }
     // #1332: gate on the OUTCOME, not on attendance. Before this, `verifyRun`
     // alone opened the gate, so a /verify returning FAIL satisfied it exactly
     // as a PASS did — a failing verdict is still a successful tool invocation.
@@ -1165,7 +1350,11 @@ switch (command) {
     // rather than emitting one message that fits none of them.
     var invalidated = sd.lastResetBy && sd.lastResetBy.file
       && (sd.lastResetBy.gates || []).indexOf('verify') >= 0;
-    if (!sd.verifyRun && invalidated) {
+    if (verifyStale) {
+      process.stderr.write('  - the code changed since /verify ran — re-run /verify\n');
+      process.stderr.write('    (detected by content, so this covers changes made outside Write/Edit:\n');
+      process.stderr.write('     a Bash write, git checkout/pull, or a different change in the same session)\n');
+    } else if (!sd.verifyRun && invalidated) {
       process.stderr.write('  - a code edit invalidated the previous verification — re-run /verify\n');
       process.stderr.write('Last gate reset: ' + sd.lastResetBy.file + ' (verify)\n');
     } else if (!sd.verifyRun) {

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -651,9 +651,15 @@ function parsePorcelainZ(raw) {
   for (var i = 0; i < parts.length; i++) {
     var entry = parts[i];
     if (!entry || entry.length < 4) continue;
-    var xy = entry.charAt(0);
+    // Check BOTH status columns, not just the staged one: git reports a rename
+    // as `R ` when staged and can report ` R` for one detected in the worktree.
+    // Missing the second form would leave the origin token unconsumed, and it
+    // would then be read as the next entry's status bytes — misaligning every
+    // entry after it. R and C always emit an origin token, so consuming one
+    // whenever either column shows them cannot over-consume.
+    var st = entry.slice(0, 2);
     var rec = { path: entry.slice(3), orig: null };
-    if (xy === 'R' || xy === 'C') { rec.orig = parts[i + 1] || null; i++; }
+    if (st.indexOf('R') >= 0 || st.indexOf('C') >= 0) { rec.orig = parts[i + 1] || null; i++; }
     out.push(rec);
   }
   return out;

--- a/tests/bin/gate-credit-fingerprint.test.ts
+++ b/tests/bin/gate-credit-fingerprint.test.ts
@@ -140,6 +140,29 @@ describe('gate credit is pinned to the code it describes', () => {
     expect(r.status).toBe(0);
   });
 
+  it('handles a rename without expiring credit when the rename is committed', () => {
+    // `git status -z` emits a rename as two NUL-terminated tokens for one
+    // entry. If the origin token is consumed but not removed from the content
+    // map, the old path lingers as a phantom until the rename is committed and
+    // then vanishes — expiring credit on a commit that changed no content.
+    git('mv', 'src.js', 'renamed.js');
+    earnFullCredit(); // credit earned with the rename staged but uncommitted
+    git('commit', '-qm', 'commit the rename');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(r.status).toBe(0);
+  });
+
+  it('expires credit when a rename happens after it was earned', () => {
+    earnFullCredit();
+    git('mv', 'src.js', 'renamed.js');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.status).toBe(2);
+  });
+
   it('survives a branch switch that lands on identical content', () => {
     // Content-addressing, not ref-watching: the same code reached by a
     // different route is the same code, and the credit still describes it.

--- a/tests/bin/gate-credit-fingerprint.test.ts
+++ b/tests/bin/gate-credit-fingerprint.test.ts
@@ -113,7 +113,7 @@ describe('gate credit is pinned to the code it describes', () => {
     expect(r.status).toBe(2);
   });
 
-  it('blocks after the change is committed, too — HEAD is part of the fingerprint', () => {
+  it('blocks after the change is committed, too', () => {
     earnFullCredit();
     appendFileSync(join(root, 'src.js'), 'export const evil = 2;\n');
     git('add', '-A');
@@ -122,6 +122,37 @@ describe('gate credit is pinned to the code it describes', () => {
     const r = gate('check-before-pr', PR_CMD);
     expect(r.stderr).toContain('BLOCKED');
     expect(r.status).toBe(2);
+  });
+
+  it('does NOT expire credit merely because the work was committed', () => {
+    // The fingerprint is over CONTENT, not (HEAD + delta). `git commit` moves
+    // changes from the working tree into HEAD without altering a byte of code,
+    // so credit earned on the uncommitted change must survive committing it.
+    // A HEAD-based fingerprint failed this: every commit after a green test run
+    // demanded a pointless re-run of the tests that just passed on that code.
+    appendFileSync(join(root, 'src.js'), 'export const feature = 2;\n');
+    earnFullCredit(); // tests/simplify/verify run against the uncommitted change
+    git('add', '-A');
+    git('commit', '-qm', 'commit the very code that was just verified');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(r.status).toBe(0);
+  });
+
+  it('survives a branch switch that lands on identical content', () => {
+    // Content-addressing, not ref-watching: the same code reached by a
+    // different route is the same code, and the credit still describes it.
+    appendFileSync(join(root, 'src.js'), 'export const feature = 2;\n');
+    git('add', '-A');
+    git('commit', '-qm', 'work');
+    git('checkout', '-q', '-b', 'twin');
+    earnFullCredit();
+    git('checkout', '-q', '-');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(r.status).toBe(0);
   });
 
   it('blocks after a branch switch moves the tree', () => {

--- a/tests/bin/gate-credit-fingerprint.test.ts
+++ b/tests/bin/gate-credit-fingerprint.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Gate credit is content-addressed, not observation-based.
+ *
+ * `testsRun` / `simplifyRun` / `verifyRun` used to be plain booleans cleared by
+ * `reset-edit-gates`, which fires PostToolUse on `^(Write|Edit|MultiEdit)$`.
+ * That equates "credit is still valid" with "no edit was observed", which only
+ * holds if every mutation flows through those three tools. It does not:
+ *
+ *   - `node -e` with fs.writeFileSync, `sed -i`, `cp`, shell redirection
+ *   - every git operation that moves the tree: checkout, pull, merge, rebase
+ *   - simply moving to the next change in the same session (nothing is
+ *     per-prompt; `learningsStored` is session-scoped by explicit design)
+ *
+ * Reproduced before the fix: earn full credit, append an `execSync` call to a
+ * source file via Bash, commit — and `check-before-pr` exited 0, allowing the
+ * PR with no re-test, no re-review, no re-verify.
+ *
+ * Each credit is now pinned to a fingerprint of the code it describes (HEAD plus
+ * the content of every changed/untracked file), recomputed at check time. These
+ * tests drive gate.cjs as a subprocess exactly as the hooks do, so they exercise
+ * the real recorder → checker path rather than a reimplementation of it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, appendFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const GATE = resolve(REPO_ROOT, 'bin/gate.cjs');
+
+let root: string;
+
+/** Run gate.cjs the way the hook bridge does: command + TOOL_INPUT_* env. */
+function gate(cmd: string, env: Record<string, string> = {}) {
+  const r = spawnSync(process.execPath, [GATE, cmd], {
+    cwd: root,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, ...env },
+  });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+function git(...args: string[]) {
+  const r = spawnSync('git', args, { cwd: root, encoding: 'utf-8', timeout: 30_000 });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout;
+}
+
+function readStateFile() {
+  return JSON.parse(readFileSync(join(root, '.claude', 'workflow-state.json'), 'utf-8'));
+}
+
+function writeStateFile(patch: Record<string, unknown>) {
+  const p = join(root, '.claude', 'workflow-state.json');
+  const cur = JSON.parse(readFileSync(p, 'utf-8'));
+  writeFileSync(p, JSON.stringify({ ...cur, ...patch }, null, 2));
+}
+
+/** Earn every PR-gate credit legitimately, through the real recorders. */
+function earnFullCredit() {
+  gate('record-skill-run', { TOOL_INPUT_skill: 'flo-simplify' });
+  gate('record-test-run', {
+    TOOL_INPUT_command: 'npm test',
+    TOOL_RESPONSE_stdout: 'Test Files 3 passed (3)\nTests 42 passed (42)',
+  });
+  gate('record-skill-run', { TOOL_INPUT_skill: 'verify' });
+  gate('record-verify-run', { TOOL_INPUT_skill: 'verify' });
+  writeStateFile({ learningsStored: true, verifyOutcome: 'PASS' });
+}
+
+const PR_CMD = { TOOL_INPUT_command: 'gh pr create --title x --body y' };
+
+beforeEach(() => {
+  // Deliberately NOT under os.tmpdir(): isEphemeralPath exempts tmp-rooted
+  // projects from gate resets (#1348), which would mask what these assert.
+  root = resolve(REPO_ROOT, '.testoutput', `gate-fp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'fp-test', version: '0.0.0' }));
+  writeFileSync(join(root, 'src.js'), 'export const safe = 1;\n');
+  git('init', '-q', '.');
+  git('config', 'user.email', 't@t.t');
+  git('config', 'user.name', 't');
+  git('add', '-A');
+  git('commit', '-qm', 'init');
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows may hold handles — non-fatal */
+  }
+});
+
+describe('gate credit is pinned to the code it describes', () => {
+  it('passes when nothing changed since the credits were earned', () => {
+    earnFullCredit();
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(r.status).toBe(0);
+  });
+
+  it('blocks after a source write made outside Write/Edit (the original bypass)', () => {
+    earnFullCredit();
+    // The mutation reset-edit-gates structurally cannot see.
+    appendFileSync(join(root, 'src.js'), 'export const evil = 2;\n');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('the code changed since they ran');
+    expect(r.status).toBe(2);
+  });
+
+  it('blocks after the change is committed, too — HEAD is part of the fingerprint', () => {
+    earnFullCredit();
+    appendFileSync(join(root, 'src.js'), 'export const evil = 2;\n');
+    git('add', '-A');
+    git('commit', '-qm', 'bash-written change');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.status).toBe(2);
+  });
+
+  it('blocks after a branch switch moves the tree', () => {
+    git('checkout', '-q', '-b', 'other');
+    appendFileSync(join(root, 'src.js'), 'export const other = 3;\n');
+    git('add', '-A');
+    git('commit', '-qm', 'other work');
+    git('checkout', '-q', '-');
+    git('checkout', '-q', '-b', 'feature');
+    earnFullCredit();
+    // Credit earned on `feature`; now the tree moves underneath it.
+    git('merge', '-q', 'other', '-m', 'merge other');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.status).toBe(2);
+  });
+
+  it('blocks a brand-new untracked source file', () => {
+    earnFullCredit();
+    writeFileSync(join(root, 'sneaky.js'), 'export const sneaky = 4;\n');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.status).toBe(2);
+  });
+
+  it('does NOT block on an inert-file edit — markdown never invalidated a run (#1176)', () => {
+    earnFullCredit();
+    writeFileSync(join(root, 'README.md'), '# docs change\n');
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(r.status).toBe(0);
+  });
+
+  it('does NOT block simplify on a test-only edit, preserving #908', () => {
+    earnFullCredit();
+    mkdirSync(join(root, 'tests'), { recursive: true });
+    writeFileSync(join(root, 'tests', 'a.test.js'), 'it("x", () => {});\n');
+
+    const r = gate('check-before-pr', PR_CMD);
+    // The testing gate SHOULD go stale (test code changed) while the simplify
+    // review of production code stands — the exact split #908 intended.
+    expect(r.stderr).toContain('tests have not run green');
+    expect(r.stderr).not.toContain('/flo-simplify (or /distill) has not run');
+  });
+
+  it('treats credit with no recorded fingerprint as stale (pre-upgrade state)', () => {
+    earnFullCredit();
+    // Exactly what an older gate left behind: flags set, no fingerprints.
+    writeStateFile({ testsFingerprint: null, simplifyFingerprint: null, verifyFingerprint: null });
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.status).toBe(2);
+  });
+
+  it('clears the stale flags in state, so the block is not re-derived every call', () => {
+    earnFullCredit();
+    appendFileSync(join(root, 'src.js'), 'export const evil = 2;\n');
+    gate('check-before-pr', PR_CMD);
+
+    const s = readStateFile();
+    expect(s.testsRun).toBe(false);
+    expect(s.testsFingerprint).toBeNull();
+  });
+
+  it('re-earning credit on the changed code passes again', () => {
+    earnFullCredit();
+    appendFileSync(join(root, 'src.js'), 'export const evil = 2;\n');
+    expect(gate('check-before-pr', PR_CMD).stderr).toContain('BLOCKED');
+
+    earnFullCredit(); // re-run tests / simplify / verify against the new tree
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(r.status).toBe(0);
+  });
+
+  it('expires a PASS verdict at check-before-done when the code moved', () => {
+    earnFullCredit();
+    expect(gate('check-before-done', PR_CMD).status).toBe(0);
+
+    appendFileSync(join(root, 'src.js'), 'export const evil = 2;\n');
+
+    const r = gate('check-before-done', PR_CMD);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain('the code changed since /verify ran');
+  });
+
+  it('does not count its own state file — recording credit must not invalidate it', () => {
+    // These fixtures have no .gitignore, so `.claude/workflow-state.json` is an
+    // untracked file inside the repo. If it contributed to the fingerprint,
+    // writing a credit would change the fingerprint that credit is pinned to and
+    // every credit would be stale the instant it was earned — an unsatisfiable
+    // gate. moflo's own repo ignores that path, so this only ever surfaced in a
+    // consumer that does not, which is precisely why the exclusion is by name
+    // rather than delegated to .gitignore.
+    earnFullCredit();
+    const before = readStateFile();
+    expect(before.testsFingerprint).toBeTruthy();
+
+    // Touch state again the way any later recorder would.
+    gate('record-test-run', {
+      TOOL_INPUT_command: 'npm test',
+      TOOL_RESPONSE_stdout: 'Tests 42 passed (42)',
+    });
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(readStateFile().testsFingerprint).toBe(before.testsFingerprint);
+  });
+
+  it('falls back to flag-only outside a git repo, rather than blocking work it cannot reason about', () => {
+    rmSync(join(root, '.git'), { recursive: true, force: true });
+    earnFullCredit();
+
+    const r = gate('check-before-pr', PR_CMD);
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(r.status).toBe(0);
+  });
+});

--- a/tests/bin/gate-simplify-snapshot.test.ts
+++ b/tests/bin/gate-simplify-snapshot.test.ts
@@ -93,6 +93,24 @@ function writeState(projectDir: string, state: Record<string, unknown>): void {
   writeFileSync(stateFile, JSON.stringify(state, null, 2));
 }
 
+/**
+ * Earn the testing credit through the real recorder, so it carries the content
+ * fingerprint check-before-pr requires. Hand-setting `testsRun: true` used to
+ * suffice; it no longer does, because a credit is now pinned to the code it
+ * describes and a bare flag carries no evidence about which code that was.
+ *
+ * Call this AFTER the test's edits — that is the real order (edit, run tests,
+ * open the PR). Crediting beforehand would correctly expire at the gate, and
+ * these tests are about the simplify path, not about stale test runs.
+ */
+function creditTests(env: Record<string, string>): void {
+  runGate('record-test-run', {
+    ...env,
+    TOOL_INPUT_command: 'npm test',
+    TOOL_RESPONSE_stdout: 'Test Files 2 passed (2)\nTests 12 passed (12)',
+  });
+}
+
 beforeEach(() => {
   tmpDir = makeTmpRepo();
 });
@@ -137,13 +155,13 @@ describe('gate snapshot path — TRIVIAL delta-since-simplify auto-passes', () =
     // normally fire (edit-reset-gates flips simplifyRun back to false).
     const s = readState(tmpDir) as any;
     s.simplifyRun = false;
-    s.testsRun = true;
     s.learningsStored = true;
     writeState(tmpDir, s);
 
     // Make a 2-line trivial edit and commit it
     writeFileSync(join(tmpDir, 'src.ts'), 'export const X = 1;\n// fix typo in comment\n');
     execSync('git add -A && git commit -q -m "typo"', { cwd: tmpDir });
+    creditTests(env);
 
     // gh pr create — should auto-pass via snapshot classifier
     env.TOOL_INPUT_command = 'gh pr create --title "fix typo"';
@@ -195,7 +213,8 @@ describe('gate baseline path — TRIVIAL whole-branch diff auto-passes', () => {
     execSync('git add -A && git commit -q -m "typo"', { cwd: tmpDir });
 
     // No /simplify ever ran — testsRun true, learningsStored true, simplifyRun false
-    writeState(tmpDir, { testsRun: true, simplifyRun: false, learningsStored: true });
+    writeState(tmpDir, { simplifyRun: false, learningsStored: true });
+    creditTests(env);
 
     env.TOOL_INPUT_command = 'gh pr create --title "typo"';
     const r = runGate('check-before-pr', env);
@@ -312,7 +331,6 @@ describe('gate SMALL review-fix shape — snapshot path (#1176)', () => {
     const s = readState(tmpDir) as any;
     expect(typeof s.simplifySnapshotSha, 'snapshot SHA must be stamped').toBe('string');
     s.simplifyRun = false; // simulate post-edit reset
-    s.testsRun = true;
     s.learningsStored = true;
     writeState(tmpDir, s);
 
@@ -322,6 +340,7 @@ describe('gate SMALL review-fix shape — snapshot path (#1176)', () => {
       Array(14).fill('// review fix: clarify intent').join('\n') + '\n';
     writeFileSync(join(tmpDir, 'src.ts'), tweaked);
     execSync('git add -A && git commit -q -m "apply review fixes"', { cwd: tmpDir });
+    creditTests(env);
 
     env.TOOL_INPUT_command = 'gh pr create --title "review fixes"';
     const r = runGate('check-before-pr', env);


### PR DESCRIPTION
The PR gates could be bypassed completely. Demonstrated, not theorised: earn full credit, append an `execSync` call to a source file via Bash, commit — `check-before-pr` exited **0** and allowed the PR with no re-test, no re-review, no re-verify.

## Why

`testsRun` / `simplifyRun` / `verifyRun` were booleans cleared by `reset-edit-gates`, wired to `^(Write|Edit|MultiEdit)$`. That equates *"this credit is still valid"* with *"no edit was observed"* — true only if every mutation flows through those three tools. It does not:

- `node -e` with `fs.writeFileSync`, `sed -i`, `cp`, shell redirection
- every git operation that moves the tree: `checkout`, `pull`, `merge`, `rebase`
- simply moving to the next change in the same session — nothing is per-prompt, and `learningsStored` is session-scoped by explicit design

#908, #1176, #1322, #1332 and #1348 each refined *which tool call to watch*. None could close this, because **the observer is the wrong primitive.**

## The fix

Stop observing mutations; fingerprint the code. Each credit is pinned to git's own blob id per path over the committed tree with changed and untracked files overlaid, recomputed at check time. A mismatch means the credit describes different code, so it expires. Nothing can bypass it, because it watches no tools.

Scope mirrors the existing reset predicates so their intentional exemptions survive unchanged:

- inert files (#1176) and `.github/` + `.moflo/` paths never contribute — a markdown or spec edit still leaves a test run standing
- the simplify fingerprint excludes test files, preserving #908

The gate's own state file is excluded **by name**. Recording a credit writes it, so counting it would change the fingerprint that credit is pinned to and expire every credit the instant it was earned. It is gitignored in moflo's repo, which is why this would only ever have bitten a consumer who does not ignore it — where it would deadlock their gate permanently. Found by the tests, not by inspection.

## Content, not (HEAD + delta)

Three defects surfaced during the work, each the same class as the one being fixed — all caught by running the gate against its own change:

1. A `HEAD + delta` fingerprint expired credit on **every commit**. Committing moves changes from the working tree into HEAD without altering a byte, so every commit after a green run would have demanded a pointless re-run.
2. A rename's origin path lingered as a phantom map entry that vanished when the rename was committed — same false expiry, different door.
3. The rename check read only the staged status column, so a worktree-detected rename (`" R"`) left its origin token unconsumed and misaligned every subsequent entry in the parse.

The overlay uses `git hash-object --stdin-paths`, not a raw sha1 of the bytes: a git blob id hashes `"blob <size>\0"` plus content and applies the same clean filters and `core.autocrlf` normalisation git uses on checkin. Raw-byte hashing produced a different string than `ls-tree` reports for identical content — so a file appeared to change the moment it was committed, and on Windows would have appeared to change whenever autocrlf rewrote its line endings (Rule #1).

## Consumer blast radius (Rule #2)

`bin/gate.cjs` is what `flo init` writes and the launcher syncs, so this reaches every consumer.

- **Fail-open** where the fingerprint cannot be computed (no git, no commits): those projects keep today's semantics rather than being blocked by a check that cannot reason about them.
- **Fail-closed** on credit with no recorded fingerprint — pre-upgrade state carrying no evidence about which code it covered. A consumer's first PR after upgrading re-runs tests once, then self-heals.
- No state migration: the three fingerprint fields are additive and default to `null`.
- Dogfood copy resynced (parity-guarded as of #1365).

Cost: **67ms** for a complete `check-before-pr` including fingerprinting on the moflo repo. Memoised per scope — `check-before-pr` tests three credits and `check-before-done` a fourth, and the gate process is single-shot so nothing can change underneath the cache.

## Verification

`tests/bin/gate-credit-fingerprint.test.ts` drives `gate.cjs` as a subprocess the way the hooks do — 17 cases covering the original bypass, its committed and branch-switch variants, new untracked files, the exemptions that must NOT expire, commit/rename/branch-switch operations that change no content, missing-fingerprint upgrade state, re-earning credit, verdict expiry at `check-before-done`, the non-git fallback, and the state-file self-reference.

`gate-simplify-snapshot.test.ts` set `testsRun: true` by hand before its edits; that shortcut is no longer equivalent to earning credit, so its setup now runs the real recorder after the edit — the real order: edit, run tests, open the PR.

- Full suite: **10013 passed, 0 failed.** Lint clean.
- All 8 gate/guard suites green (134 tests).
- `/verify` PASS on 8 criteria (recorded as `verify:gate-credit-content-addressed`).

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)