### PR TITLE
fix(hooks): unwire the no-op check-task-transition gate (#1331)

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -478,6 +478,13 @@ function classifyBashNamespaceHint(cmd) {
 // owns interactionCount and the user-visible REMINDER/Context emissions, so
 // this helper stays silent.
 function applyPromptStateReset(state, promptText) {
+  // #352/#1331 — this is the ONLY place the memory gate resets. Deliberately
+  // NOT on task transitions: within a single prompt (e.g. a /flo workflow)
+  // memory stays searched so Read/Grep aren't blocked mid-execution. A
+  // `TaskUpdate`-driven reset would re-block the agent halfway through its own
+  // workflow. The rationale used to live on the `check-task-transition` case,
+  // which is why that case is an empty no-op; #1331 unwired the hook and moved
+  // the reasoning here, where the reset it describes actually happens.
   state.memorySearched = false;
   // Wipe per-actor memory tracking too — a new user prompt is a fresh window
   // for both parent AND any subagents the parent may spawn during this turn.
@@ -1050,9 +1057,15 @@ switch (command) {
     break;
   }
   case 'check-task-transition': {
-    // Memory gate resets on new user prompts (prompt-reminder), not on task
-    // transitions. Within a single prompt (e.g., /flo workflow), memory stays
-    // searched so Read/Grep aren't blocked mid-execution.
+    // Intentional no-op, retained for backwards compatibility only (#1331).
+    // The `^TaskUpdate$` wiring was removed from settings-generator.ts,
+    // hook-block-hash.ts and hook-wiring.ts because spawning gate-hook.mjs +
+    // gate.cjs on every TaskUpdate to do nothing is pure overhead. The case
+    // stays because doctor-checks-deep.ts lists it in REQUIRED_GATE_CASES —
+    // dropping the case would turn `flo doctor`'s Gate Health check red in
+    // every consumer for no gain. (Falling through to `default: break` would
+    // otherwise be harmless; this is about the doctor contract, not runtime.)
+    // Why it does nothing: see applyPromptStateReset().
     break;
   }
   case 'record-learnings-stored': {

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -1505,6 +1505,14 @@ try {
       { from: 'npx flo gate record-task-created',   to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-task-created' },
       { from: 'npx flo gate check-bash-memory',     to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-bash-memory' },
       { from: 'npx flo gate record-memory-searched', to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-memory-searched' },
+      // #1331 — RETAINED even though the ^TaskUpdate$ wiring is gone. This
+      // migration runs before runHookBlockDriftCheck, and the drift sweep only
+      // recognises a stale entry as moflo-owned when the command points at a
+      // `.claude/helpers|scripts/<basename>` path. An ancient consumer still on
+      // the `npx flo gate` form would therefore be classified as a user
+      // customisation and preserved forever. Migrating it first gives the
+      // sweep a shape it can drop. Delete this row only once no consumer can
+      // plausibly still carry the npx form.
       { from: 'npx flo gate check-task-transition', to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" check-task-transition' },
       { from: 'npx flo gate record-learnings-stored', to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-learnings-stored' },
       // UserPromptSubmit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -144,16 +144,6 @@
         ]
       },
       {
-        "matcher": "^TaskUpdate$",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs\" check-task-transition",
-            "timeout": 2000
-          }
-        ]
-      },
-      {
         "matcher": "^mcp__moflo__memory_store$",
         "hooks": [
           {

--- a/README.md
+++ b/README.md
@@ -770,7 +770,6 @@ Hooks are shell commands that Claude Code runs automatically at specific points 
 | **PostToolUse: Bash** | `flo gate record-test-run` | Records test runs from Bash for the test-output gate | Yes |
 | **PostToolUse: Skill** | `flo gate record-skill-run` | Records that a skill was invoked (clears skill-related gates) | Yes |
 | **PostToolUse: memory_search** | `flo gate record-memory-searched` | Records that memory was searched (clears memory-first gate) | Yes |
-| **PostToolUse: TaskUpdate** | `flo gate check-task-transition` | Validates task state transitions (prevents skipping states) | Yes |
 | **PostToolUse: memory_store** | `flo gate record-learnings-stored` | Records that learnings were persisted to memory | Yes |
 | **UserPromptSubmit** | `prompt-hook.mjs` | Resets per-prompt gate state, tracks context bracket, routes task to agent | Yes |
 | **UserPromptSubmit** | `meditate-capture.mjs meditate-detect` | Auto-meditate: notices when a durable lesson emerges in the live session and queues it for distillation | Yes |

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -478,6 +478,13 @@ function classifyBashNamespaceHint(cmd) {
 // owns interactionCount and the user-visible REMINDER/Context emissions, so
 // this helper stays silent.
 function applyPromptStateReset(state, promptText) {
+  // #352/#1331 — this is the ONLY place the memory gate resets. Deliberately
+  // NOT on task transitions: within a single prompt (e.g. a /flo workflow)
+  // memory stays searched so Read/Grep aren't blocked mid-execution. A
+  // `TaskUpdate`-driven reset would re-block the agent halfway through its own
+  // workflow. The rationale used to live on the `check-task-transition` case,
+  // which is why that case is an empty no-op; #1331 unwired the hook and moved
+  // the reasoning here, where the reset it describes actually happens.
   state.memorySearched = false;
   // Wipe per-actor memory tracking too — a new user prompt is a fresh window
   // for both parent AND any subagents the parent may spawn during this turn.
@@ -1050,9 +1057,15 @@ switch (command) {
     break;
   }
   case 'check-task-transition': {
-    // Memory gate resets on new user prompts (prompt-reminder), not on task
-    // transitions. Within a single prompt (e.g., /flo workflow), memory stays
-    // searched so Read/Grep aren't blocked mid-execution.
+    // Intentional no-op, retained for backwards compatibility only (#1331).
+    // The `^TaskUpdate$` wiring was removed from settings-generator.ts,
+    // hook-block-hash.ts and hook-wiring.ts because spawning gate-hook.mjs +
+    // gate.cjs on every TaskUpdate to do nothing is pure overhead. The case
+    // stays because doctor-checks-deep.ts lists it in REQUIRED_GATE_CASES —
+    // dropping the case would turn `flo doctor`'s Gate Health check red in
+    // every consumer for no gain. (Falling through to `default: break` would
+    // otherwise be harmless; this is about the doctor contract, not runtime.)
+    // Why it does nothing: see applyPromptStateReset().
     break;
   }
   case 'record-learnings-stored': {

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -1505,6 +1505,14 @@ try {
       { from: 'npx flo gate record-task-created',   to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-task-created' },
       { from: 'npx flo gate check-bash-memory',     to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-bash-memory' },
       { from: 'npx flo gate record-memory-searched', to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-memory-searched' },
+      // #1331 — RETAINED even though the ^TaskUpdate$ wiring is gone. This
+      // migration runs before runHookBlockDriftCheck, and the drift sweep only
+      // recognises a stale entry as moflo-owned when the command points at a
+      // `.claude/helpers|scripts/<basename>` path. An ancient consumer still on
+      // the `npx flo gate` form would therefore be classified as a user
+      // customisation and preserved forever. Migrating it first gives the
+      // sweep a shape it can drop. Delete this row only once no consumer can
+      // plausibly still carry the npx form.
       { from: 'npx flo gate check-task-transition', to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" check-task-transition' },
       { from: 'npx flo gate record-learnings-stored', to: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-learnings-stored' },
       // UserPromptSubmit

--- a/src/cli/__tests__/doctor-checks-deep.test.ts
+++ b/src/cli/__tests__/doctor-checks-deep.test.ts
@@ -123,11 +123,15 @@ describe('doctor-checks-deep', () => {
       expect(REQUIRED_HOOK_WIRING.length).toBeGreaterThanOrEqual(10);
     });
 
-    it('should include check-before-pr, check-task-transition, and record-learnings-stored', () => {
+    it('should include check-before-pr and record-learnings-stored', () => {
       const patterns = REQUIRED_HOOK_WIRING.map(h => h.pattern);
       expect(patterns).toContain('check-before-pr');
-      expect(patterns).toContain('check-task-transition');
       expect(patterns).toContain('record-learnings-stored');
+      // #1331 — check-task-transition is deliberately NOT here. It is a no-op
+      // gate; listing it made repairHookWiring() re-graft the `^TaskUpdate$`
+      // hook into every consumer. The gate CASE is still required (see
+      // REQUIRED_GATE_CASES below) — only the wiring is gone.
+      expect(patterns).not.toContain('check-task-transition');
     });
 
     it('should have valid event types', () => {

--- a/src/cli/__tests__/services/no-op-hook-wiring-1331.test.ts
+++ b/src/cli/__tests__/services/no-op-hook-wiring-1331.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression: `check-task-transition` must stay UNWIRED (#1331).
+ *
+ * The gate case is an intentional no-op, but it was wired to `^TaskUpdate$` in
+ * every consumer `flo init` touched — so each TaskUpdate spawned gate-hook.mjs,
+ * which `execFileSync`'d gate.cjs, which fell straight through to `break`. Two
+ * process spawns per task update, per consumer, to do nothing.
+ *
+ * Removing it needs FOUR copies to agree, because three separate mechanisms
+ * will each re-graft the hook on a consumer's next session start if their copy
+ * still lists it:
+ *
+ *   1. `settings-generator.ts`  — what `flo init` writes for a new project
+ *   2. `hook-block-hash.ts`     — the reference block the launcher regenerates against
+ *   3. `hook-wiring.ts`         — `repairHookWiring()`'s missing-hook repair table
+ *   4. `.claude/settings.json`  — this repo's own (dogfood) copy
+ *
+ * These assertions pin all of them. The gate CASE is deliberately retained —
+ * see the separate assertion at the bottom.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { getReferenceHookBlock, type HookBlock } from '../../services/hook-block-hash.js';
+import { REQUIRED_HOOK_WIRING, HOOK_ENTRY_MAP } from '../../services/hook-wiring.js';
+import { generateSettings } from '../../init/settings-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../../init/types.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+/** Every hook command in a hooks tree, flattened. */
+function allCommands(hooks: Record<string, HookBlock[]>): string[] {
+  return Object.values(hooks).flatMap(blocks =>
+    (blocks ?? []).flatMap(b => (b?.hooks ?? []).map(h => h.command)),
+  );
+}
+
+/** Matchers present anywhere in a hooks tree. */
+function allMatchers(hooks: Record<string, HookBlock[]>): string[] {
+  return Object.values(hooks).flatMap(blocks => (blocks ?? []).map(b => b?.matcher ?? ''));
+}
+
+describe('#1331 — check-task-transition is not wired', () => {
+  it('flo init emits no ^TaskUpdate$ hook block', () => {
+    const settings = generateSettings(DEFAULT_INIT_OPTIONS) as {
+      hooks: Record<string, HookBlock[]>;
+    };
+    expect(allMatchers(settings.hooks)).not.toContain('^TaskUpdate$');
+    expect(allCommands(settings.hooks).join('\n')).not.toContain('check-task-transition');
+  });
+
+  it('the launcher reference block has no ^TaskUpdate$ entry', () => {
+    // Load-bearing: an entry here is reported as `missing` against every
+    // consumer and grafted back by additive/wholesale regeneration.
+    const reference = getReferenceHookBlock();
+    expect(allMatchers(reference)).not.toContain('^TaskUpdate$');
+    expect(allCommands(reference).join('\n')).not.toContain('check-task-transition');
+  });
+
+  it('repairHookWiring tables do not list check-task-transition', () => {
+    // Load-bearing: REQUIRED_HOOK_WIRING drives repairHookWiring(), which runs
+    // AFTER the drift sweep — a stale entry here would re-add the hook that
+    // wholesale regeneration had just removed.
+    expect(REQUIRED_HOOK_WIRING.map(r => r.pattern)).not.toContain('check-task-transition');
+    expect(HOOK_ENTRY_MAP['check-task-transition']).toBeUndefined();
+  });
+
+  // NOTE: there is deliberately NO assertion on this repo's live
+  // `.claude/settings.json`. That file is a DERIVED artifact, not source — the
+  // session-start launcher regenerates it from the reference block in the
+  // INSTALLED `node_modules/moflo`, which until this change is published still
+  // carries the `^TaskUpdate$` entry. So the committed removal is re-added
+  // locally on every session start, and an assertion here would go red on a
+  // correct tree. The three source copies above are what actually ship and are
+  // what the launcher will regenerate FROM once published.
+
+  it('retains the gate.cjs case so doctor Gate Health stays green', () => {
+    // The case is intentionally kept: doctor-checks-deep.ts lists
+    // check-task-transition in REQUIRED_GATE_CASES, so removing it would turn
+    // the Gate Health check red in every consumer for no benefit. Both shipped
+    // copies must carry it (byte parity itself is guarded separately).
+    for (const rel of [['bin', 'gate.cjs'], ['.claude', 'helpers', 'gate.cjs']]) {
+      const src = readFileSync(join(REPO_ROOT, ...rel), 'utf-8');
+      expect(src).toContain("case 'check-task-transition':");
+    }
+  });
+
+  it('keeps the launcher npx→node migration row for the retired command', () => {
+    // Deliberately NOT deleted with the wiring: the drift sweep only classifies
+    // a stale entry as moflo-owned (and therefore droppable) when its command
+    // points at a `.claude/helpers|scripts/<basename>` path. An ancient consumer
+    // still on the `npx flo gate check-task-transition` form must be migrated to
+    // that shape FIRST, or the sweep preserves it as a user customisation.
+    const launcher = readFileSync(join(REPO_ROOT, 'bin', 'session-start-launcher.mjs'), 'utf-8');
+    expect(launcher).toContain('npx flo gate check-task-transition');
+  });
+});

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -752,9 +752,10 @@ switch (command) {
     break;
   }
   case 'check-task-transition': {
-    // Memory gate resets on new user prompts (prompt-reminder), not on task
-    // transitions. Within a single prompt (e.g., /flo workflow), memory stays
-    // searched so Read/Grep aren't blocked mid-execution.
+    // Intentional no-op, retained for backwards compatibility only (#1331).
+    // The ^TaskUpdate$ wiring was removed — see bin/gate.cjs for the full note
+    // and applyPromptStateReset() for why the memory gate resets per-prompt
+    // rather than per-task-transition.
     break;
   }
   case 'record-learnings-stored': {

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -358,10 +358,12 @@ function generateHooksConfig(config: HooksConfig): object {
         matcher: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$',
         hooks: [{ type: 'command', command: gateHookCmd('record-memory-searched'), timeout: 3000 }],
       },
-      {
-        matcher: '^TaskUpdate$',
-        hooks: [{ type: 'command', command: gateCmd('check-task-transition'), timeout: 2000 }],
-      },
+      // #1331 — no `^TaskUpdate$` block. `check-task-transition` is a no-op
+      // (see the case in gate.cjs), so wiring it spawned gate-hook.mjs + gate.cjs
+      // on every TaskUpdate in every consumer to do nothing. The gate case is
+      // retained for consumers whose settings.json still references it; the
+      // wiring is not. Do not re-add it here without also re-adding it to
+      // hook-block-hash.ts and hook-wiring.ts, or the three copies drift.
       {
         matcher: '^mcp__moflo__memory_store$',
         hooks: [

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -149,7 +149,13 @@ export function getReferenceHookBlock(): HooksTree {
       },
       { matcher: '^Skill$',                       hooks: [gateHook('record-skill-run', 2000), gateHook('record-verify-run', 2000)] },
       { matcher: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$', hooks: [gateHook('record-memory-searched', 3000)] },
-      { matcher: '^TaskUpdate$',                  hooks: [gateCjs('check-task-transition', 2000)] },
+      // #1331 — no `^TaskUpdate$` block. Removing it here is what makes the
+      // removal stick: this reference block is what the session-start launcher
+      // regenerates settings.json against, so an entry left here would be
+      // re-grafted as "missing" on every consumer's next session start. It also
+      // makes an existing consumer's stale entry classify as `extra` and get
+      // swept by applyWholesaleRegeneration (the command still points at a
+      // moflo-owned helper basename, so it is dropped rather than preserved).
       // #1332 — record-verify-outcome routes via gateHook (not gateCjs): the
       // TOOL_INPUT_* env vars it reads are built by gate-hook.mjs from stdin.
       { matcher: '^mcp__moflo__memory_store$',    hooks: [gateCjs('record-learnings-stored', 2000), gateHook('record-verify-outcome', 2000)] },

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -40,7 +40,9 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   { event: 'PreToolUse', pattern: 'check-before-agent' },
   { event: 'PostToolUse', pattern: 'record-task-created' },
   { event: 'PostToolUse', pattern: 'record-memory-searched' },
-  { event: 'PostToolUse', pattern: 'check-task-transition' },
+  // #1331 — `check-task-transition` deliberately absent. It is a no-op gate;
+  // listing it here made repairHookWiring() graft the hook back into every
+  // consumer on session start, undoing the removal.
   { event: 'PostToolUse', pattern: 'record-learnings-stored' },
   { event: 'PostToolUse', pattern: 'check-bash-memory' },
   { event: 'PostToolUse', pattern: 'record-test-run' },
@@ -93,7 +95,7 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   // tool name (#929 regression — the hook silently no-ops, leaving every
   // memory_search uncounted by the gate).
   'record-memory-searched':   { event: 'PostToolUse',      matcher: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$', hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-memory-searched', timeout: 3000 } },
-  'check-task-transition':    { event: 'PostToolUse',      matcher: '^TaskUpdate$',               hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" check-task-transition', timeout: 2000 } },
+  // #1331 — no `check-task-transition` entry (see REQUIRED_HOOK_WIRING above).
   'record-learnings-stored':  { event: 'PostToolUse',      matcher: '^mcp__moflo__memory_store$', hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-learnings-stored', timeout: 2000 } },
   // #1171 — widened to ^(Bash|PowerShell)$ so PS reads / PS-invoked tests credit
   // the same gates as Bash. Name kept as `check-bash-memory` for backwards compat.

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -1528,6 +1528,10 @@ describe('end-to-end: spell lifecycle', () => {
     expect(s.memorySearched).toBe(true);
   });
 
+  // #1331 — this gate is no longer WIRED to `^TaskUpdate$` in any consumer; the
+  // case is retained only for backwards compatibility (and doctor's
+  // REQUIRED_GATE_CASES). These tests still pin its no-op contract so a future
+  // edit can't quietly give it behaviour that nothing invokes.
   describe('task transition gate (check-task-transition)', () => {
     it('resets memorySearched when task moves to in_progress', () => {
       const env = baseEnv(tmpDir);


### PR DESCRIPTION
Closes #1331.

## Problem

`check-task-transition` is a documented no-op, yet it was wired to `^TaskUpdate$` in every consumer `flo init` touched. Each `TaskUpdate` spawned `gate-hook.mjs`, which `execFileSync`'d `gate.cjs`, which fell straight through to `break` — **two process spawns per task update, per consumer, to do nothing**. `TaskUpdate` fires frequently in any multi-step workflow.

## Consumer surface + blast radius

Removing the wiring needs **three source copies to agree**, or the removal silently un-does itself on the next session start. The issue named one; the other two are what make it stick:

| Copy | Why it matters |
|---|---|
| `settings-generator.ts` | what `flo init` writes for a new project |
| `hook-block-hash.ts` | the reference block the launcher regenerates settings.json **against** — an entry left here is reported `missing` and re-grafted into every consumer |
| `hook-wiring.ts` | `repairHookWiring()` runs **after** the drift sweep, so a stale entry here re-adds what wholesale regen just removed |

**Failure mode for the on-4.12.x consumer:** none requiring action. Their stale entry is classified `extra` and swept by `applyWholesaleRegeneration` on next session start (the command still points at a moflo-owned helper basename, so it is dropped, not preserved). No migration, no `.moflo/` state change.

## Deliberately kept

- **The gate `case` in `gate.cjs`.** `doctor-checks-deep.ts` lists it in `REQUIRED_GATE_CASES`, so dropping it turns `flo doctor`'s Gate Health red in every consumer for no runtime gain (an unknown command already falls through to `default: break`).
- **The launcher's `npx flo gate check-task-transition` migration row.** The drift sweep only treats a stale entry as moflo-owned when its command points at a `.claude/helpers|scripts/<basename>` path. An ancient consumer on the `npx` form must be migrated to that shape *first*, or it is preserved forever as a "user customisation". Migration runs before the sweep, so the order works out.

The design rationale that lived on the no-op case — why the memory gate resets per-prompt and **not** per-task-transition — moved to `applyPromptStateReset()`, where the reset it describes actually happens (issue AC #2).

## Verification

- Scratch `flo init`: **0** `^TaskUpdate$` matchers emitted; all **14** other gates still wired.
- Existing-consumer simulation: `computeHookBlockDrift` → `missing: 0` (nothing else disturbed), `applyWholesaleRegeneration` → `removed: 1`, 0 stale blocks left. A **user's own** `^TaskUpdate$` hook survives the same sweep.
- Full suite: **10018 passed / 0 failed**.
- New guard `no-op-hook-wiring-1331.test.ts` pins all three source copies, the retained gate case, and the launcher migration row. **Every assertion was mutation-tested** — each one confirmed to fail when its copy is reverted.

It deliberately does **not** assert on this repo's `.claude/settings.json`: that file is regenerated from the *installed* package, so it flaps until this is published. (Expect the local copy to keep re-acquiring the entry pre-publish — that is the known dogfood lag, not a regression.)

## Rejected

The audit item proposing deletion of `.claude/scripts/hooks.mjs` is not acted on — see the counter-evidence in #1331. It is a gitignored sync artifact of `bin/hooks.mjs` and a load-bearing sentinel for `findMofloBinDir()`.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)