### PR TITLE
fix(gate): make the MCP-dependent gates satisfiable without MCP (#1338)

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -158,6 +158,10 @@ var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: f
 // mcp__moflo__memory_search there points the reader at the one thing that cannot
 // work; this CLI path credits the gate identically and needs no MCP.
 var MCP_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this credits the gate too: npx flo memory search --query "<topic>" --namespace <ns>';
+// #1338 follow-up — the swarm/hive gate's equivalent. The CLI runs the same
+// in-process handler and persists the swarm, so it satisfies this gate for
+// real; it is recorded only on success (PostToolUse, #1322).
+var COORD_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this satisfies the gate too:';
 
 // #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
 // (background-task output/transcripts, agent scratchpads) are transient tool
@@ -242,8 +246,13 @@ function commandBasename(tok) {
   return (cut >= 0 ? t.slice(cut + 1) : t).toLowerCase();
 }
 
-/** Does one shell segment invoke a moflo memory search? */
-function segmentCreditsMemorySearch(seg) {
+/**
+ * The moflo subcommand one shell segment invokes, as lowercased positional
+ * args (`['memory','search']`, `['swarm','init']`), or null when the segment
+ * does not invoke moflo at all. A dedicated search binary reports the
+ * subcommand it is — that is all `flo-search` does.
+ */
+function mofloSubcommand(seg) {
   var tokens = seg.trim().split(/\s+/).filter(Boolean);
   var i = 0;
   // Skip shell noise ahead of the entrypoint: env assignments (`FOO=bar flo …`),
@@ -255,18 +264,24 @@ function segmentCreditsMemorySearch(seg) {
     if (CREDIT_RUNNER_RE.test(commandBasename(tok))) { i++; continue; }
     break;
   }
-  if (i >= tokens.length) return false;
+  if (i >= tokens.length) return null;
   var entry = commandBasename(tokens[i]);
-  if (CREDIT_SEARCH_BIN_RE.test(entry)) return true;
-  if (!CREDIT_CLI_RE.test(entry)) return false;
+  if (CREDIT_SEARCH_BIN_RE.test(entry)) return ['memory', 'search'];
+  if (!CREDIT_CLI_RE.test(entry)) return null;
   // Positional args after the CLI entrypoint; flags carry no subcommand.
   var rest = [];
   for (var j = i + 1; j < tokens.length; j++) {
     if (tokens[j].charAt(0) !== '-') rest.push(tokens[j].toLowerCase());
   }
-  if (!rest.length) return false;
-  if (CREDIT_MEMORY_COMPOUND_RE.test(rest[0])) return true;
-  return rest[0] === 'memory' && rest.length > 1 && CREDIT_MEMORY_VERB_RE.test(rest[1]);
+  return rest;
+}
+
+/** Does one shell segment invoke a moflo memory search? */
+function segmentCreditsMemorySearch(seg) {
+  var sub = mofloSubcommand(seg);
+  if (!sub || !sub.length) return false;
+  if (CREDIT_MEMORY_COMPOUND_RE.test(sub[0])) return true;
+  return sub[0] === 'memory' && sub.length > 1 && CREDIT_MEMORY_VERB_RE.test(sub[1]);
 }
 
 /**
@@ -281,11 +296,50 @@ function creditsMemorySearch(rawCmd) {
   // entrypoint containing one of these — so non-matches cost one regex, not a
   // strip + split + tokenize.
   if (!CREDIT_HINT_RE.test(rawCmd || '')) return false;
-  var segments = stripQuotedAndHeredocs(rawCmd).split(/[;|&\n]+/);
+  return mofloSegments(rawCmd).some(segmentCreditsMemorySearch);
+}
+
+/** Shell segments of a command, quoted bodies stripped. */
+function mofloSegments(rawCmd) {
+  return stripQuotedAndHeredocs(rawCmd || '').split(/[;|&\n]+/);
+}
+
+/**
+ * #1338 follow-up — which protected-coordination init, if any, did this shell
+ * command run? Returns 'swarm', 'hive', or null.
+ *
+ * `flo swarm init` and `flo hive-mind init` are NOT second-class stand-ins for
+ * the MCP tools: the CLI dispatches in-process through the same TOOL_REGISTRY
+ * handler the MCP server exposes (`mcp-client.ts` callMCPTool), and the
+ * resulting swarm is persisted (#806 agents/topology, #1329 tasks), so a later
+ * process — including a restarted MCP server — hydrates the same swarm.
+ *
+ * This matters because Claude Code spawns stdio MCP servers once at session
+ * start and never respawns them. Before this, `record-swarm-init` fired only on
+ * `mcp__moflo__swarm_init`, so a session that lost its MCP server hit the #952
+ * gate with NO way to satisfy it: `/fl -s` blocked every Agent spawn and told
+ * the reader to call a tool that did not exist in that session. Unlike the
+ * memory gate, there was not even an unadvertised escape.
+ *
+ * Deliberately wired PostToolUse, not PreToolUse where the memory credit lives:
+ * Claude Code does not fire PostToolUse when a command exits non-zero (#1322),
+ * so only an init that actually SUCCEEDED credits the gate. A failed init must
+ * never open it — that would be the silent-degradation failure CLAUDE.md's
+ * protected-functionality rule exists to prevent.
+ */
+function bashCoordinationInit(rawCmd) {
+  // Cheap reject, same hot-path discipline as creditsMemorySearch: every
+  // crediting form names a moflo entrypoint AND the `init` subcommand.
+  if (!CREDIT_HINT_RE.test(rawCmd || '') || !/\binit\b/i.test(rawCmd)) return null;
+  var segments = mofloSegments(rawCmd);
   for (var i = 0; i < segments.length; i++) {
-    if (segmentCreditsMemorySearch(segments[i])) return true;
+    var sub = mofloSubcommand(segments[i]);
+    if (!sub || sub.length < 2 || sub[1] !== 'init') continue;
+    if (sub[0] === 'swarm') return 'swarm';
+    // `hive` is the registered alias for `hive-mind` (commands/hive-mind.ts).
+    if (sub[0] === 'hive-mind' || sub[0] === 'hive') return 'hive';
   }
-  return false;
+  return null;
 }
 // BLOCK: read-like Bash commands that bypass the existing check-before-read /
 // check-before-scan gates by going through the shell. Anchored to the start of
@@ -1033,6 +1087,7 @@ switch (command) {
       if (s.flMode === 'swarm' && !s.swarmInitialized) {
         process.stderr.write('BLOCKED: /fl was invoked with -s/--swarm but mcp__moflo__swarm_init has not been called.\n');
         process.stderr.write('Run mcp__moflo__swarm_init first, then mcp__moflo__agent_spawn for each role, then dispatch Agent.\n');
+        process.stderr.write(COORD_FALLBACK_NOTE + '  npx flo swarm init --topology hierarchical  (then: npx flo agent spawn --type <role>)\n');
         process.stderr.write('See .claude/skills/fl/execution-modes.md "SWARM mode" and CLAUDE.md "⛔ Protected functionality".\n');
         process.stderr.write('Disable via moflo.yaml: gates: swarm_invocation_gate: false\n');
         process.exit(2);
@@ -1040,6 +1095,7 @@ switch (command) {
       if (s.flMode === 'hive' && !s.hiveInitialized) {
         process.stderr.write('BLOCKED: /fl was invoked with -h/--hive but mcp__moflo__hive-mind_init has not been called.\n');
         process.stderr.write('Run mcp__moflo__hive-mind_init first, then dispatch Agent or hive-mind workers.\n');
+        process.stderr.write(COORD_FALLBACK_NOTE + '  npx flo hive-mind init  (then: npx flo hive-mind spawn)\n');
         process.stderr.write('See .claude/skills/fl/execution-modes.md "HIVE-MIND mode" and CLAUDE.md "⛔ Protected functionality".\n');
         process.stderr.write('Disable via moflo.yaml: gates: swarm_invocation_gate: false\n');
         process.exit(2);
@@ -1053,6 +1109,21 @@ switch (command) {
     var s = readState();
     if (!s.swarmInitialized) {
       s.swarmInitialized = true;
+      writeState(s);
+    }
+    break;
+  }
+  case 'record-bash-swarm-init': {
+    // #1338 follow-up — the CLI half of record-swarm-init / record-hive-init.
+    // Wired PostToolUse[Bash|PowerShell], so it only sees commands that
+    // succeeded (#1322). See bashCoordinationInit for why the CLI route is a
+    // real satisfaction of the #952 gate and not a stand-in.
+    var kind = bashCoordinationInit(process.env.TOOL_INPUT_command || '');
+    if (!kind) break;
+    var s = readState();
+    var flag = kind === 'swarm' ? 'swarmInitialized' : 'hiveInitialized';
+    if (!s[flag]) {
+      s[flag] = true;
       writeState(s);
     }
     break;

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -153,6 +153,11 @@ var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule 
 // is why learnings has no separate step here.
 var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\n';
 var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
+// #1338 — Claude Code spawns stdio MCP servers once at session start and never
+// respawns them, so a session can outlive its moflo MCP connection. Naming only
+// mcp__moflo__memory_search there points the reader at the one thing that cannot
+// work; this CLI path credits the gate identically and needs no MCP.
+var MCP_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this credits the gate too: npx flo memory search --query "<topic>" --namespace <ns>';
 
 // #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
 // (background-task output/transcripts, agent scratchpads) are transient tool
@@ -193,11 +198,95 @@ var DANGEROUS = [
 
 // #1132 — Bash memory-first gate.
 //
-// CREDIT: the legacy detector that marks the gate satisfied when Claude
-// manually invokes a memory-search CLI (flo-search, the moflo MCP search via
-// shell, etc.). Preserved verbatim from the pre-#1132 behaviour so existing
-// recipes keep crediting the gate.
-var CREDIT_MEMORY_SEARCH_RE = /semantic-search|memory search|memory retrieve|memory-search/;
+// CREDIT: marks the gate satisfied when Claude invokes a memory-search CLI
+// (`flo memory search`, `flo-search`, `semantic-search.mjs`) from the shell —
+// the escape hatch that keeps the gate satisfiable when the moflo MCP server
+// is not connected to the session.
+//
+// #1338 — this used to be an unanchored substring test
+// (/semantic-search|memory search|memory retrieve|memory-search/) against the
+// whole command, so `echo "memory search"` — or a `git commit -m` mentioning
+// the phrase — satisfied the gate for the rest of the prompt. That is the
+// opposite discipline from READ_LIKE_BASH_RE directly below, which is
+// deliberately anchored. Credit now requires a real INVOCATION, matched by
+// BASENAME so Rule #1 holds: `flo`, `flo.cmd`, `npx.cmd flo`, `node ./bin/cli.js`
+// and `node C:\...\bin\cli.js` all credit, with either path separator.
+var CREDIT_RUNNER_RE = /^(?:npx|npm|pnpm|yarn|bun|bunx|deno|node|nodejs|tsx|ts-node)(?:\.(?:cmd|exe|bat|ps1))?$/i;
+// Sub-words of a runner invocation that are not the entrypoint itself
+// (`pnpm dlx flo`, `npm exec -- flo`, `npx -y flo`).
+var CREDIT_RUNNER_SKIP_RE = /^(?:dlx|exec|run|-y|--yes|-q|--quiet|--silent|--no-install|--)$/i;
+// The moflo CLI, under every name package.json binds it to (plus the raw entry
+// script, for `node node_modules/moflo/bin/cli.js`).
+var CREDIT_CLI_RE = /^(?:flo|moflo|claude-flow|cli\.js|cli\.mjs)(?:\.(?:cmd|exe|bat|ps1))?$/i;
+// A search entrypoint — every invocation of these IS a memory search.
+var CREDIT_SEARCH_BIN_RE = /^(?:flo-search(?:\.(?:cmd|exe|bat|ps1))?|semantic-search\.mjs)$/i;
+// Substring every crediting form must contain — the hot-path pre-filter. Covers
+// flo / moflo / flo-search / claude-flow (all contain "flo"), cli.js|cli.mjs,
+// and semantic-search.mjs.
+var CREDIT_HINT_RE = /flo|cli\.m?js|semantic-search/i;
+// `flo memory search` / `flo memory retrieve`, and the hyphen/underscore spellings.
+var CREDIT_MEMORY_VERB_RE = /^(?:search|retrieve)$/i;
+var CREDIT_MEMORY_COMPOUND_RE = /^memory[-_](?:search|retrieve)$/i;
+
+/**
+ * Last path segment of a token, lowercased. Splits on BOTH separators, unlike
+ * path.basename, which only honours the HOST's separator (Rule #1): an agent on
+ * POSIX can legitimately type `node .claude\scripts\semantic-search.mjs`, and a
+ * Windows-shaped path must resolve the same wherever the gate happens to run.
+ */
+function commandBasename(tok) {
+  var t = tok.replace(/^["']+|["']+$/g, '');
+  var cut = t.lastIndexOf('/');
+  var bs = t.lastIndexOf('\\');
+  if (bs > cut) cut = bs;
+  return (cut >= 0 ? t.slice(cut + 1) : t).toLowerCase();
+}
+
+/** Does one shell segment invoke a moflo memory search? */
+function segmentCreditsMemorySearch(seg) {
+  var tokens = seg.trim().split(/\s+/).filter(Boolean);
+  var i = 0;
+  // Skip shell noise ahead of the entrypoint: env assignments (`FOO=bar flo …`),
+  // sudo, package runners and their flags.
+  while (i < tokens.length) {
+    var tok = tokens[i];
+    if (tok === 'sudo' || /^[A-Za-z_][A-Za-z0-9_]*=/.test(tok)) { i++; continue; }
+    if (CREDIT_RUNNER_SKIP_RE.test(tok)) { i++; continue; }
+    if (CREDIT_RUNNER_RE.test(commandBasename(tok))) { i++; continue; }
+    break;
+  }
+  if (i >= tokens.length) return false;
+  var entry = commandBasename(tokens[i]);
+  if (CREDIT_SEARCH_BIN_RE.test(entry)) return true;
+  if (!CREDIT_CLI_RE.test(entry)) return false;
+  // Positional args after the CLI entrypoint; flags carry no subcommand.
+  var rest = [];
+  for (var j = i + 1; j < tokens.length; j++) {
+    if (tokens[j].charAt(0) !== '-') rest.push(tokens[j].toLowerCase());
+  }
+  if (!rest.length) return false;
+  if (CREDIT_MEMORY_COMPOUND_RE.test(rest[0])) return true;
+  return rest[0] === 'memory' && rest.length > 1 && CREDIT_MEMORY_VERB_RE.test(rest[1]);
+}
+
+/**
+ * CREDIT test for a whole Bash/PowerShell command. Quoted bodies are stripped
+ * first (so a commit message quoting "memory search" cannot credit), then each
+ * shell segment is checked at its own start — `cd repo && flo memory search`
+ * credits, `echo "flo memory search"` does not.
+ */
+function creditsMemorySearch(rawCmd) {
+  // Cheap reject first. This runs on EVERY Bash call in every consumer, ahead
+  // of the block arm's regexes, and every crediting form necessarily names an
+  // entrypoint containing one of these — so non-matches cost one regex, not a
+  // strip + split + tokenize.
+  if (!CREDIT_HINT_RE.test(rawCmd || '')) return false;
+  var segments = stripQuotedAndHeredocs(rawCmd).split(/[;|&\n]+/);
+  for (var i = 0; i < segments.length; i++) {
+    if (segmentCreditsMemorySearch(segments[i])) return true;
+  }
+  return false;
+}
 // BLOCK: read-like Bash commands that bypass the existing check-before-read /
 // check-before-scan gates by going through the shell. Anchored to the start of
 // the line so subcommands inside pipelines or `npm install grep` don't trip.
@@ -984,7 +1073,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + MCP_FALLBACK_NOTE + '\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -997,7 +1086,7 @@ switch (command) {
     if (isEphemeralPath(fp)) break;
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + MCP_FALLBACK_NOTE + '\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -1025,7 +1114,7 @@ switch (command) {
 
     // 1) CREDIT — preserved behavior. A real memory-search invocation flips
     // the gate flag so subsequent Read/Grep/Glob within this prompt pass.
-    if (CREDIT_MEMORY_SEARCH_RE.test(cmd)) {
+    if (creditsMemorySearch(cmd)) {
       var s = readState();
       if (markMemorySearched(s)) writeState(s);
       break;
@@ -1050,6 +1139,7 @@ switch (command) {
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\n' +
       (hint ? hint + '\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' +
+      MCP_FALLBACK_NOTE + '\n' +
       GATE_ORIGIN_NOTE + '\n' +
       GATE_DISABLE_NOTE + '\n'
     );

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -158,6 +158,10 @@ var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: f
 // mcp__moflo__memory_search there points the reader at the one thing that cannot
 // work; this CLI path credits the gate identically and needs no MCP.
 var MCP_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this credits the gate too: npx flo memory search --query "<topic>" --namespace <ns>';
+// #1338 follow-up — the swarm/hive gate's equivalent. The CLI runs the same
+// in-process handler and persists the swarm, so it satisfies this gate for
+// real; it is recorded only on success (PostToolUse, #1322).
+var COORD_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this satisfies the gate too:';
 
 // #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
 // (background-task output/transcripts, agent scratchpads) are transient tool
@@ -242,8 +246,13 @@ function commandBasename(tok) {
   return (cut >= 0 ? t.slice(cut + 1) : t).toLowerCase();
 }
 
-/** Does one shell segment invoke a moflo memory search? */
-function segmentCreditsMemorySearch(seg) {
+/**
+ * The moflo subcommand one shell segment invokes, as lowercased positional
+ * args (`['memory','search']`, `['swarm','init']`), or null when the segment
+ * does not invoke moflo at all. A dedicated search binary reports the
+ * subcommand it is — that is all `flo-search` does.
+ */
+function mofloSubcommand(seg) {
   var tokens = seg.trim().split(/\s+/).filter(Boolean);
   var i = 0;
   // Skip shell noise ahead of the entrypoint: env assignments (`FOO=bar flo …`),
@@ -255,18 +264,24 @@ function segmentCreditsMemorySearch(seg) {
     if (CREDIT_RUNNER_RE.test(commandBasename(tok))) { i++; continue; }
     break;
   }
-  if (i >= tokens.length) return false;
+  if (i >= tokens.length) return null;
   var entry = commandBasename(tokens[i]);
-  if (CREDIT_SEARCH_BIN_RE.test(entry)) return true;
-  if (!CREDIT_CLI_RE.test(entry)) return false;
+  if (CREDIT_SEARCH_BIN_RE.test(entry)) return ['memory', 'search'];
+  if (!CREDIT_CLI_RE.test(entry)) return null;
   // Positional args after the CLI entrypoint; flags carry no subcommand.
   var rest = [];
   for (var j = i + 1; j < tokens.length; j++) {
     if (tokens[j].charAt(0) !== '-') rest.push(tokens[j].toLowerCase());
   }
-  if (!rest.length) return false;
-  if (CREDIT_MEMORY_COMPOUND_RE.test(rest[0])) return true;
-  return rest[0] === 'memory' && rest.length > 1 && CREDIT_MEMORY_VERB_RE.test(rest[1]);
+  return rest;
+}
+
+/** Does one shell segment invoke a moflo memory search? */
+function segmentCreditsMemorySearch(seg) {
+  var sub = mofloSubcommand(seg);
+  if (!sub || !sub.length) return false;
+  if (CREDIT_MEMORY_COMPOUND_RE.test(sub[0])) return true;
+  return sub[0] === 'memory' && sub.length > 1 && CREDIT_MEMORY_VERB_RE.test(sub[1]);
 }
 
 /**
@@ -281,11 +296,50 @@ function creditsMemorySearch(rawCmd) {
   // entrypoint containing one of these — so non-matches cost one regex, not a
   // strip + split + tokenize.
   if (!CREDIT_HINT_RE.test(rawCmd || '')) return false;
-  var segments = stripQuotedAndHeredocs(rawCmd).split(/[;|&\n]+/);
+  return mofloSegments(rawCmd).some(segmentCreditsMemorySearch);
+}
+
+/** Shell segments of a command, quoted bodies stripped. */
+function mofloSegments(rawCmd) {
+  return stripQuotedAndHeredocs(rawCmd || '').split(/[;|&\n]+/);
+}
+
+/**
+ * #1338 follow-up — which protected-coordination init, if any, did this shell
+ * command run? Returns 'swarm', 'hive', or null.
+ *
+ * `flo swarm init` and `flo hive-mind init` are NOT second-class stand-ins for
+ * the MCP tools: the CLI dispatches in-process through the same TOOL_REGISTRY
+ * handler the MCP server exposes (`mcp-client.ts` callMCPTool), and the
+ * resulting swarm is persisted (#806 agents/topology, #1329 tasks), so a later
+ * process — including a restarted MCP server — hydrates the same swarm.
+ *
+ * This matters because Claude Code spawns stdio MCP servers once at session
+ * start and never respawns them. Before this, `record-swarm-init` fired only on
+ * `mcp__moflo__swarm_init`, so a session that lost its MCP server hit the #952
+ * gate with NO way to satisfy it: `/fl -s` blocked every Agent spawn and told
+ * the reader to call a tool that did not exist in that session. Unlike the
+ * memory gate, there was not even an unadvertised escape.
+ *
+ * Deliberately wired PostToolUse, not PreToolUse where the memory credit lives:
+ * Claude Code does not fire PostToolUse when a command exits non-zero (#1322),
+ * so only an init that actually SUCCEEDED credits the gate. A failed init must
+ * never open it — that would be the silent-degradation failure CLAUDE.md's
+ * protected-functionality rule exists to prevent.
+ */
+function bashCoordinationInit(rawCmd) {
+  // Cheap reject, same hot-path discipline as creditsMemorySearch: every
+  // crediting form names a moflo entrypoint AND the `init` subcommand.
+  if (!CREDIT_HINT_RE.test(rawCmd || '') || !/\binit\b/i.test(rawCmd)) return null;
+  var segments = mofloSegments(rawCmd);
   for (var i = 0; i < segments.length; i++) {
-    if (segmentCreditsMemorySearch(segments[i])) return true;
+    var sub = mofloSubcommand(segments[i]);
+    if (!sub || sub.length < 2 || sub[1] !== 'init') continue;
+    if (sub[0] === 'swarm') return 'swarm';
+    // `hive` is the registered alias for `hive-mind` (commands/hive-mind.ts).
+    if (sub[0] === 'hive-mind' || sub[0] === 'hive') return 'hive';
   }
-  return false;
+  return null;
 }
 // BLOCK: read-like Bash commands that bypass the existing check-before-read /
 // check-before-scan gates by going through the shell. Anchored to the start of
@@ -1033,6 +1087,7 @@ switch (command) {
       if (s.flMode === 'swarm' && !s.swarmInitialized) {
         process.stderr.write('BLOCKED: /fl was invoked with -s/--swarm but mcp__moflo__swarm_init has not been called.\n');
         process.stderr.write('Run mcp__moflo__swarm_init first, then mcp__moflo__agent_spawn for each role, then dispatch Agent.\n');
+        process.stderr.write(COORD_FALLBACK_NOTE + '  npx flo swarm init --topology hierarchical  (then: npx flo agent spawn --type <role>)\n');
         process.stderr.write('See .claude/skills/fl/execution-modes.md "SWARM mode" and CLAUDE.md "⛔ Protected functionality".\n');
         process.stderr.write('Disable via moflo.yaml: gates: swarm_invocation_gate: false\n');
         process.exit(2);
@@ -1040,6 +1095,7 @@ switch (command) {
       if (s.flMode === 'hive' && !s.hiveInitialized) {
         process.stderr.write('BLOCKED: /fl was invoked with -h/--hive but mcp__moflo__hive-mind_init has not been called.\n');
         process.stderr.write('Run mcp__moflo__hive-mind_init first, then dispatch Agent or hive-mind workers.\n');
+        process.stderr.write(COORD_FALLBACK_NOTE + '  npx flo hive-mind init  (then: npx flo hive-mind spawn)\n');
         process.stderr.write('See .claude/skills/fl/execution-modes.md "HIVE-MIND mode" and CLAUDE.md "⛔ Protected functionality".\n');
         process.stderr.write('Disable via moflo.yaml: gates: swarm_invocation_gate: false\n');
         process.exit(2);
@@ -1053,6 +1109,21 @@ switch (command) {
     var s = readState();
     if (!s.swarmInitialized) {
       s.swarmInitialized = true;
+      writeState(s);
+    }
+    break;
+  }
+  case 'record-bash-swarm-init': {
+    // #1338 follow-up — the CLI half of record-swarm-init / record-hive-init.
+    // Wired PostToolUse[Bash|PowerShell], so it only sees commands that
+    // succeeded (#1322). See bashCoordinationInit for why the CLI route is a
+    // real satisfaction of the #952 gate and not a stand-in.
+    var kind = bashCoordinationInit(process.env.TOOL_INPUT_command || '');
+    if (!kind) break;
+    var s = readState();
+    var flag = kind === 'swarm' ? 'swarmInitialized' : 'hiveInitialized';
+    if (!s[flag]) {
+      s[flag] = true;
       writeState(s);
     }
     break;

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -153,6 +153,11 @@ var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule 
 // is why learnings has no separate step here.
 var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\n';
 var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
+// #1338 — Claude Code spawns stdio MCP servers once at session start and never
+// respawns them, so a session can outlive its moflo MCP connection. Naming only
+// mcp__moflo__memory_search there points the reader at the one thing that cannot
+// work; this CLI path credits the gate identically and needs no MCP.
+var MCP_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this credits the gate too: npx flo memory search --query "<topic>" --namespace <ns>';
 
 // #1294 Finding 3 — reads/scans of EPHEMERAL files under the OS temp dir
 // (background-task output/transcripts, agent scratchpads) are transient tool
@@ -193,11 +198,95 @@ var DANGEROUS = [
 
 // #1132 — Bash memory-first gate.
 //
-// CREDIT: the legacy detector that marks the gate satisfied when Claude
-// manually invokes a memory-search CLI (flo-search, the moflo MCP search via
-// shell, etc.). Preserved verbatim from the pre-#1132 behaviour so existing
-// recipes keep crediting the gate.
-var CREDIT_MEMORY_SEARCH_RE = /semantic-search|memory search|memory retrieve|memory-search/;
+// CREDIT: marks the gate satisfied when Claude invokes a memory-search CLI
+// (`flo memory search`, `flo-search`, `semantic-search.mjs`) from the shell —
+// the escape hatch that keeps the gate satisfiable when the moflo MCP server
+// is not connected to the session.
+//
+// #1338 — this used to be an unanchored substring test
+// (/semantic-search|memory search|memory retrieve|memory-search/) against the
+// whole command, so `echo "memory search"` — or a `git commit -m` mentioning
+// the phrase — satisfied the gate for the rest of the prompt. That is the
+// opposite discipline from READ_LIKE_BASH_RE directly below, which is
+// deliberately anchored. Credit now requires a real INVOCATION, matched by
+// BASENAME so Rule #1 holds: `flo`, `flo.cmd`, `npx.cmd flo`, `node ./bin/cli.js`
+// and `node C:\...\bin\cli.js` all credit, with either path separator.
+var CREDIT_RUNNER_RE = /^(?:npx|npm|pnpm|yarn|bun|bunx|deno|node|nodejs|tsx|ts-node)(?:\.(?:cmd|exe|bat|ps1))?$/i;
+// Sub-words of a runner invocation that are not the entrypoint itself
+// (`pnpm dlx flo`, `npm exec -- flo`, `npx -y flo`).
+var CREDIT_RUNNER_SKIP_RE = /^(?:dlx|exec|run|-y|--yes|-q|--quiet|--silent|--no-install|--)$/i;
+// The moflo CLI, under every name package.json binds it to (plus the raw entry
+// script, for `node node_modules/moflo/bin/cli.js`).
+var CREDIT_CLI_RE = /^(?:flo|moflo|claude-flow|cli\.js|cli\.mjs)(?:\.(?:cmd|exe|bat|ps1))?$/i;
+// A search entrypoint — every invocation of these IS a memory search.
+var CREDIT_SEARCH_BIN_RE = /^(?:flo-search(?:\.(?:cmd|exe|bat|ps1))?|semantic-search\.mjs)$/i;
+// Substring every crediting form must contain — the hot-path pre-filter. Covers
+// flo / moflo / flo-search / claude-flow (all contain "flo"), cli.js|cli.mjs,
+// and semantic-search.mjs.
+var CREDIT_HINT_RE = /flo|cli\.m?js|semantic-search/i;
+// `flo memory search` / `flo memory retrieve`, and the hyphen/underscore spellings.
+var CREDIT_MEMORY_VERB_RE = /^(?:search|retrieve)$/i;
+var CREDIT_MEMORY_COMPOUND_RE = /^memory[-_](?:search|retrieve)$/i;
+
+/**
+ * Last path segment of a token, lowercased. Splits on BOTH separators, unlike
+ * path.basename, which only honours the HOST's separator (Rule #1): an agent on
+ * POSIX can legitimately type `node .claude\scripts\semantic-search.mjs`, and a
+ * Windows-shaped path must resolve the same wherever the gate happens to run.
+ */
+function commandBasename(tok) {
+  var t = tok.replace(/^["']+|["']+$/g, '');
+  var cut = t.lastIndexOf('/');
+  var bs = t.lastIndexOf('\\');
+  if (bs > cut) cut = bs;
+  return (cut >= 0 ? t.slice(cut + 1) : t).toLowerCase();
+}
+
+/** Does one shell segment invoke a moflo memory search? */
+function segmentCreditsMemorySearch(seg) {
+  var tokens = seg.trim().split(/\s+/).filter(Boolean);
+  var i = 0;
+  // Skip shell noise ahead of the entrypoint: env assignments (`FOO=bar flo …`),
+  // sudo, package runners and their flags.
+  while (i < tokens.length) {
+    var tok = tokens[i];
+    if (tok === 'sudo' || /^[A-Za-z_][A-Za-z0-9_]*=/.test(tok)) { i++; continue; }
+    if (CREDIT_RUNNER_SKIP_RE.test(tok)) { i++; continue; }
+    if (CREDIT_RUNNER_RE.test(commandBasename(tok))) { i++; continue; }
+    break;
+  }
+  if (i >= tokens.length) return false;
+  var entry = commandBasename(tokens[i]);
+  if (CREDIT_SEARCH_BIN_RE.test(entry)) return true;
+  if (!CREDIT_CLI_RE.test(entry)) return false;
+  // Positional args after the CLI entrypoint; flags carry no subcommand.
+  var rest = [];
+  for (var j = i + 1; j < tokens.length; j++) {
+    if (tokens[j].charAt(0) !== '-') rest.push(tokens[j].toLowerCase());
+  }
+  if (!rest.length) return false;
+  if (CREDIT_MEMORY_COMPOUND_RE.test(rest[0])) return true;
+  return rest[0] === 'memory' && rest.length > 1 && CREDIT_MEMORY_VERB_RE.test(rest[1]);
+}
+
+/**
+ * CREDIT test for a whole Bash/PowerShell command. Quoted bodies are stripped
+ * first (so a commit message quoting "memory search" cannot credit), then each
+ * shell segment is checked at its own start — `cd repo && flo memory search`
+ * credits, `echo "flo memory search"` does not.
+ */
+function creditsMemorySearch(rawCmd) {
+  // Cheap reject first. This runs on EVERY Bash call in every consumer, ahead
+  // of the block arm's regexes, and every crediting form necessarily names an
+  // entrypoint containing one of these — so non-matches cost one regex, not a
+  // strip + split + tokenize.
+  if (!CREDIT_HINT_RE.test(rawCmd || '')) return false;
+  var segments = stripQuotedAndHeredocs(rawCmd).split(/[;|&\n]+/);
+  for (var i = 0; i < segments.length; i++) {
+    if (segmentCreditsMemorySearch(segments[i])) return true;
+  }
+  return false;
+}
 // BLOCK: read-like Bash commands that bypass the existing check-before-read /
 // check-before-scan gates by going through the shell. Anchored to the start of
 // the line so subcommands inside pipelines or `npm install grep` don't trip.
@@ -984,7 +1073,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + MCP_FALLBACK_NOTE + '\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -997,7 +1086,7 @@ switch (command) {
     if (isEphemeralPath(fp)) break;
     var isGuidance = fp.indexOf('.claude/guidance/') >= 0 || fp.indexOf('.claude\\guidance\\') >= 0;
     if (!isGuidance && EXEMPT.some(function(p) { return fp.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading files. Use mcp__moflo__memory_search. On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' + MCP_FALLBACK_NOTE + '\n' + GATE_ORIGIN_NOTE + '\n' + GATE_DISABLE_NOTE + '\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -1025,7 +1114,7 @@ switch (command) {
 
     // 1) CREDIT — preserved behavior. A real memory-search invocation flips
     // the gate flag so subsequent Read/Grep/Glob within this prompt pass.
-    if (CREDIT_MEMORY_SEARCH_RE.test(cmd)) {
+    if (creditsMemorySearch(cmd)) {
       var s = readState();
       if (markMemorySearched(s)) writeState(s);
       break;
@@ -1050,6 +1139,7 @@ switch (command) {
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\n' +
       (hint ? hint + '\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\n' +
+      MCP_FALLBACK_NOTE + '\n' +
       GATE_ORIGIN_NOTE + '\n' +
       GATE_DISABLE_NOTE + '\n'
     );

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -487,6 +487,9 @@ const REQUIRED_GATE_CASES = [
   'record-learnings-stored',
   'record-test-run',
   'record-skill-run',
+  // #1338 follow-up — CLI half of the #952 swarm/hive init recorders. A gate.cjs
+  // without it leaves an MCP-less session unable to satisfy the swarm gate.
+  'record-bash-swarm-init',
   // Story #1274 (Epic #1269) — verify-before-done gate + its recorder.
   'record-verify-run',
   'check-before-done',

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -335,6 +335,9 @@ var EXEMPT = ['.claude/', '.claude\\\\', 'CLAUDE.md', 'MEMORY.md', 'workflow-sta
 // bin/gate.cjs GATE_ORIGIN_NOTE / GATE_DISABLE_NOTE.
 var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule — allow-rules cannot override it.';
 var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
+// #1338 — a session can outlive its moflo MCP connection (Claude Code spawns
+// stdio servers once, at session start). SYNC: mirrors bin/gate.cjs.
+var MCP_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this credits the gate too: npx flo memory search --query "<topic>" --namespace <ns>';
 // #1348 — the pre-PR gates are order-dependent; naming only the missing one left
 // callers to rediscover the sequence by trial. SYNC: mirrors bin/gate.cjs.
 var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\\n';
@@ -360,7 +363,55 @@ var DANGEROUS = ['rm -rf /', 'format c:', 'del /s /q c:\\\\', ':(){:|:&};:', 'mk
 // #1132 — Bash memory-first gate regexes. See bin/gate.cjs for documentation.
 // #1171 — READ_LIKE extended with PS-native exploration forms (Get-ChildItem -Recurse,
 // dir /s, Format-Hex). Plain Get-ChildItem stays uncovered (ls-equivalent).
-var CREDIT_MEMORY_SEARCH_RE = /semantic-search|memory search|memory retrieve|memory-search/;
+// #1338 — CREDIT requires a real memory-search INVOCATION, not any command that
+// merely contains the phrase. Matched by basename so flo, flo.cmd, npx.cmd flo
+// and node C:\\\\...\\\\cli.js all credit (Rule #1).
+// SYNC: duplicated verbatim in bin/gate.cjs — see there for full rationale.
+var CREDIT_RUNNER_RE = /^(?:npx|npm|pnpm|yarn|bun|bunx|deno|node|nodejs|tsx|ts-node)(?:\\.(?:cmd|exe|bat|ps1))?$/i;
+var CREDIT_RUNNER_SKIP_RE = /^(?:dlx|exec|run|-y|--yes|-q|--quiet|--silent|--no-install|--)$/i;
+var CREDIT_CLI_RE = /^(?:flo|moflo|claude-flow|cli\\.js|cli\\.mjs)(?:\\.(?:cmd|exe|bat|ps1))?$/i;
+var CREDIT_SEARCH_BIN_RE = /^(?:flo-search(?:\\.(?:cmd|exe|bat|ps1))?|semantic-search\\.mjs)$/i;
+var CREDIT_HINT_RE = /flo|cli\\.m?js|semantic-search/i;
+var CREDIT_MEMORY_VERB_RE = /^(?:search|retrieve)$/i;
+var CREDIT_MEMORY_COMPOUND_RE = /^memory[-_](?:search|retrieve)$/i;
+// Splits on BOTH separators — path.basename honours only the host's (Rule #1).
+function commandBasename(tok) {
+  var t = tok.replace(/^["']+|["']+$/g, '');
+  var cut = t.lastIndexOf('/');
+  var bs = t.lastIndexOf('\\\\');
+  if (bs > cut) cut = bs;
+  return (cut >= 0 ? t.slice(cut + 1) : t).toLowerCase();
+}
+function segmentCreditsMemorySearch(seg) {
+  var tokens = seg.trim().split(/\\s+/).filter(Boolean);
+  var i = 0;
+  while (i < tokens.length) {
+    var tok = tokens[i];
+    if (tok === 'sudo' || /^[A-Za-z_][A-Za-z0-9_]*=/.test(tok)) { i++; continue; }
+    if (CREDIT_RUNNER_SKIP_RE.test(tok)) { i++; continue; }
+    if (CREDIT_RUNNER_RE.test(commandBasename(tok))) { i++; continue; }
+    break;
+  }
+  if (i >= tokens.length) return false;
+  var entry = commandBasename(tokens[i]);
+  if (CREDIT_SEARCH_BIN_RE.test(entry)) return true;
+  if (!CREDIT_CLI_RE.test(entry)) return false;
+  var rest = [];
+  for (var j = i + 1; j < tokens.length; j++) {
+    if (tokens[j].charAt(0) !== '-') rest.push(tokens[j].toLowerCase());
+  }
+  if (!rest.length) return false;
+  if (CREDIT_MEMORY_COMPOUND_RE.test(rest[0])) return true;
+  return rest[0] === 'memory' && rest.length > 1 && CREDIT_MEMORY_VERB_RE.test(rest[1]);
+}
+function creditsMemorySearch(rawCmd) {
+  if (!CREDIT_HINT_RE.test(rawCmd || '')) return false;
+  var segments = stripQuotedAndHeredocs(rawCmd).split(/[;|&\\n]+/);
+  for (var i = 0; i < segments.length; i++) {
+    if (segmentCreditsMemorySearch(segments[i])) return true;
+  }
+  return false;
+}
 var READ_LIKE_BASH_RE = /^\\s*(?:cat|head|tail|less|more|bat|xxd|od|hexdump)\\b|^\\s*(?:grep|rg|ag|fgrep|egrep|find|fd)\\b|^\\s*sed\\s+-n\\b|^\\s*awk\\s+(?!.*<<)|^\\s*type\\s+\\S*[\\\\/.]|^\\s*(?:Get-Content|gc|Select-String|sls)\\b|^\\s*(?:Get-ChildItem|gci)\\b[^|]*-Recurse\\b|^\\s*dir\\b[^|]*\\s\\/[sS]\\b|^\\s*Format-Hex\\b/i;
 var BASH_CARVE_OUT_RE = /^\\s*(npm|npx|pnpm|yarn|bun|node|deno|tsx|ts-node)\\s|^\\s*(git|gh|hub)\\s|^\\s*(docker|kubectl|helm|terraform)\\s|^\\s*(curl|wget|http|fetch)\\s|^\\s*(jq|yq|xq)\\s|^\\s*(echo|printf|true|false|sleep|test|\\[)\\s|^\\s*cat\\s+(<<|<<<)|^\\s*cat\\s+[^|]*\\s*>|^\\s*tee\\b|^\\s*find\\s+.+?-(delete|exec\\s+rm)\\b/;
 // #1171 follow-up — strip quoted bodies + heredocs before DANGEROUS substring
@@ -699,7 +750,7 @@ switch (command) {
     var target = (process.env.TOOL_INPUT_pattern || '') + ' ' + (process.env.TOOL_INPUT_path || '');
     if (isEphemeralPath(process.env.TOOL_INPUT_path)) break;
     if (EXEMPT.some(function(p) { return target.indexOf(p) >= 0; })) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search.\\n' + GATE_ORIGIN_NOTE + '\\n' + GATE_DISABLE_NOTE + '\\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before exploring files. Use mcp__moflo__memory_search.\\n' + MCP_FALLBACK_NOTE + '\\n' + GATE_ORIGIN_NOTE + '\\n' + GATE_DISABLE_NOTE + '\\n');
     process.exit(2);
   }
   case 'check-before-read': {
@@ -709,7 +760,7 @@ switch (command) {
     var fp = process.env.TOOL_INPUT_file_path || '';
     if (isEphemeralPath(fp)) break;
     if (fp.indexOf('.claude/guidance/') < 0 && fp.indexOf('.claude\\\\guidance\\\\') < 0) break;
-    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\n' + GATE_ORIGIN_NOTE + '\\n' + GATE_DISABLE_NOTE + '\\n');
+    process.stderr.write('BLOCKED [moflo memory_first gate]: Search memory before reading guidance files. Use mcp__moflo__memory_search.\\n' + MCP_FALLBACK_NOTE + '\\n' + GATE_ORIGIN_NOTE + '\\n' + GATE_DISABLE_NOTE + '\\n');
     process.exit(2);
   }
   case 'record-task-created': {
@@ -727,7 +778,7 @@ switch (command) {
   case 'check-bash-memory': {
     // #1132 — credit + block. See bin/gate.cjs for full documentation.
     var cmd = process.env.TOOL_INPUT_command || '';
-    if (CREDIT_MEMORY_SEARCH_RE.test(cmd)) {
+    if (creditsMemorySearch(cmd)) {
       var s = readState();
       if (markMemorySearched(s)) writeState(s);
       break;
@@ -745,6 +796,7 @@ switch (command) {
       'Example: mcp__moflo__memory_search { query: "<topic>", namespace: "<one of: guidance | code-map | patterns | learnings | tests>" }\\n' +
       (hint ? hint + '\\n' : '') +
       'On chunk hits, traverse via mcp__moflo__memory_get_neighbors — see .claude/guidance/moflo-memory-protocol.md\\n' +
+      MCP_FALLBACK_NOTE + '\\n' +
       GATE_ORIGIN_NOTE + '\\n' +
       GATE_DISABLE_NOTE + '\\n'
     );

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -338,6 +338,8 @@ var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: f
 // #1338 — a session can outlive its moflo MCP connection (Claude Code spawns
 // stdio servers once, at session start). SYNC: mirrors bin/gate.cjs.
 var MCP_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this credits the gate too: npx flo memory search --query "<topic>" --namespace <ns>';
+// #1338 follow-up — swarm/hive equivalent. SYNC: mirrors bin/gate.cjs.
+var COORD_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (MCP server not connected), this satisfies the gate too:';
 // #1348 — the pre-PR gates are order-dependent; naming only the missing one left
 // callers to rediscover the sequence by trial. SYNC: mirrors bin/gate.cjs.
 var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\\n';
@@ -382,7 +384,7 @@ function commandBasename(tok) {
   if (bs > cut) cut = bs;
   return (cut >= 0 ? t.slice(cut + 1) : t).toLowerCase();
 }
-function segmentCreditsMemorySearch(seg) {
+function mofloSubcommand(seg) {
   var tokens = seg.trim().split(/\\s+/).filter(Boolean);
   var i = 0;
   while (i < tokens.length) {
@@ -392,25 +394,42 @@ function segmentCreditsMemorySearch(seg) {
     if (CREDIT_RUNNER_RE.test(commandBasename(tok))) { i++; continue; }
     break;
   }
-  if (i >= tokens.length) return false;
+  if (i >= tokens.length) return null;
   var entry = commandBasename(tokens[i]);
-  if (CREDIT_SEARCH_BIN_RE.test(entry)) return true;
-  if (!CREDIT_CLI_RE.test(entry)) return false;
+  if (CREDIT_SEARCH_BIN_RE.test(entry)) return ['memory', 'search'];
+  if (!CREDIT_CLI_RE.test(entry)) return null;
   var rest = [];
   for (var j = i + 1; j < tokens.length; j++) {
     if (tokens[j].charAt(0) !== '-') rest.push(tokens[j].toLowerCase());
   }
-  if (!rest.length) return false;
-  if (CREDIT_MEMORY_COMPOUND_RE.test(rest[0])) return true;
-  return rest[0] === 'memory' && rest.length > 1 && CREDIT_MEMORY_VERB_RE.test(rest[1]);
+  return rest;
+}
+function mofloSegments(rawCmd) {
+  return stripQuotedAndHeredocs(rawCmd || '').split(/[;|&\\n]+/);
+}
+function segmentCreditsMemorySearch(seg) {
+  var sub = mofloSubcommand(seg);
+  if (!sub || !sub.length) return false;
+  if (CREDIT_MEMORY_COMPOUND_RE.test(sub[0])) return true;
+  return sub[0] === 'memory' && sub.length > 1 && CREDIT_MEMORY_VERB_RE.test(sub[1]);
 }
 function creditsMemorySearch(rawCmd) {
   if (!CREDIT_HINT_RE.test(rawCmd || '')) return false;
-  var segments = stripQuotedAndHeredocs(rawCmd).split(/[;|&\\n]+/);
+  return mofloSegments(rawCmd).some(segmentCreditsMemorySearch);
+}
+// #1338 follow-up — the CLI runs the SAME in-process handler the MCP tool does
+// and persists the swarm, so it satisfies the #952 gate for real. Recorded only
+// on success (PostToolUse, #1322). SYNC: bin/gate.cjs has the full rationale.
+function bashCoordinationInit(rawCmd) {
+  if (!CREDIT_HINT_RE.test(rawCmd || '') || !/\\binit\\b/i.test(rawCmd)) return null;
+  var segments = mofloSegments(rawCmd);
   for (var i = 0; i < segments.length; i++) {
-    if (segmentCreditsMemorySearch(segments[i])) return true;
+    var sub = mofloSubcommand(segments[i]);
+    if (!sub || sub.length < 2 || sub[1] !== 'init') continue;
+    if (sub[0] === 'swarm') return 'swarm';
+    if (sub[0] === 'hive-mind' || sub[0] === 'hive') return 'hive';
   }
-  return false;
+  return null;
 }
 var READ_LIKE_BASH_RE = /^\\s*(?:cat|head|tail|less|more|bat|xxd|od|hexdump)\\b|^\\s*(?:grep|rg|ag|fgrep|egrep|find|fd)\\b|^\\s*sed\\s+-n\\b|^\\s*awk\\s+(?!.*<<)|^\\s*type\\s+\\S*[\\\\/.]|^\\s*(?:Get-Content|gc|Select-String|sls)\\b|^\\s*(?:Get-ChildItem|gci)\\b[^|]*-Recurse\\b|^\\s*dir\\b[^|]*\\s\\/[sS]\\b|^\\s*Format-Hex\\b/i;
 var BASH_CARVE_OUT_RE = /^\\s*(npm|npx|pnpm|yarn|bun|node|deno|tsx|ts-node)\\s|^\\s*(git|gh|hub)\\s|^\\s*(docker|kubectl|helm|terraform)\\s|^\\s*(curl|wget|http|fetch)\\s|^\\s*(jq|yq|xq)\\s|^\\s*(echo|printf|true|false|sleep|test|\\[)\\s|^\\s*cat\\s+(<<|<<<)|^\\s*cat\\s+[^|]*\\s*>|^\\s*tee\\b|^\\s*find\\s+.+?-(delete|exec\\s+rm)\\b/;
@@ -711,6 +730,7 @@ switch (command) {
       if (s.flMode === 'swarm' && !s.swarmInitialized) {
         process.stderr.write('BLOCKED: /fl was invoked with -s/--swarm but mcp__moflo__swarm_init has not been called.\\n');
         process.stderr.write('Run mcp__moflo__swarm_init first, then mcp__moflo__agent_spawn for each role, then dispatch Agent.\\n');
+        process.stderr.write(COORD_FALLBACK_NOTE + '  npx flo swarm init --topology hierarchical  (then: npx flo agent spawn --type <role>)\\n');
         process.stderr.write('See .claude/skills/fl/execution-modes.md "SWARM mode" and CLAUDE.md "⛔ Protected functionality".\\n');
         process.stderr.write('Disable via moflo.yaml: gates: swarm_invocation_gate: false\\n');
         process.exit(2);
@@ -718,10 +738,22 @@ switch (command) {
       if (s.flMode === 'hive' && !s.hiveInitialized) {
         process.stderr.write('BLOCKED: /fl was invoked with -h/--hive but mcp__moflo__hive-mind_init has not been called.\\n');
         process.stderr.write('Run mcp__moflo__hive-mind_init first, then dispatch Agent or hive-mind workers.\\n');
+        process.stderr.write(COORD_FALLBACK_NOTE + '  npx flo hive-mind init  (then: npx flo hive-mind spawn)\\n');
         process.stderr.write('See .claude/skills/fl/execution-modes.md "HIVE-MIND mode" and CLAUDE.md "⛔ Protected functionality".\\n');
         process.stderr.write('Disable via moflo.yaml: gates: swarm_invocation_gate: false\\n');
         process.exit(2);
       }
+    }
+    break;
+  }
+  case 'record-bash-swarm-init': {
+    // #1338 follow-up — CLI half of record-swarm-init/record-hive-init. Wired
+    // PostToolUse so only a SUCCEEDED init credits (#1322). SYNC: bin/gate.cjs.
+    var kind = bashCoordinationInit(process.env.TOOL_INPUT_command || '');
+    if (kind) {
+      var sc = readState();
+      var flag = kind === 'swarm' ? 'swarmInitialized' : 'hiveInitialized';
+      if (!sc[flag]) { sc[flag] = true; writeState(sc); }
     }
     break;
   }

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -335,6 +335,17 @@ function generateHooksConfig(config: HooksConfig): object {
         hooks: [
           // #1132 — check-bash-memory moved to PreToolUse (above).
           { type: 'command', command: gateHookCmd('record-test-run'), timeout: 2000 },
+          // #1338 follow-up — CLI half of the #952 swarm/hive init recorders.
+          // PostToolUse deliberately: it does not fire on a non-zero exit
+          // (#1322), so only an init that actually succeeded credits the gate.
+          //
+          // Cost: a 6th gate spawn on the Bash path (~30ms), on top of the 4
+          // PreToolUse + 1 PostToolUse already there. Folding it into
+          // record-test-run would save that spawn but make the case name lie
+          // AND make `flo swarm init` emit record-test-run's "no-op" crumb, so
+          // the separate, honestly-named hook wins. The handler early-rejects
+          // on two regexes, so the added work per Bash call is negligible.
+          { type: 'command', command: gateHookCmd('record-bash-swarm-init'), timeout: 2000 },
         ],
       },
       {

--- a/src/cli/services/hook-block-hash.ts
+++ b/src/cli/services/hook-block-hash.ts
@@ -145,7 +145,7 @@ export function getReferenceHookBlock(): HooksTree {
         // #1132 — check-bash-memory moved to PreToolUse (above).
         // #1171 — widened to cover `PowerShell` tool.
         matcher: '^(Bash|PowerShell)$',
-        hooks: [gateHook('record-test-run', 2000)],
+        hooks: [gateHook('record-test-run', 2000), gateHook('record-bash-swarm-init', 2000)],
       },
       { matcher: '^Skill$',                       hooks: [gateHook('record-skill-run', 2000), gateHook('record-verify-run', 2000)] },
       { matcher: '^mcp__moflo__memory_(search|retrieve|list|stats|store)$', hooks: [gateHook('record-memory-searched', 3000)] },

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -46,6 +46,11 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   { event: 'PostToolUse', pattern: 'record-learnings-stored' },
   { event: 'PostToolUse', pattern: 'check-bash-memory' },
   { event: 'PostToolUse', pattern: 'record-test-run' },
+  // #1338 follow-up — CLI half of the #952 swarm/hive init recorders. Listed
+  // here so an existing consumer picks it up via repairHookWiring on session
+  // start; without it, only consumers who re-run `flo init` would get the
+  // escape, and the deadlock would persist everywhere else.
+  { event: 'PostToolUse', pattern: 'record-bash-swarm-init' },
   { event: 'PostToolUse', pattern: 'record-skill-run' },
   // Story #1274 — record the native /verify skill run so check-before-done is satisfied.
   { event: 'PostToolUse', pattern: 'record-verify-run' },
@@ -101,6 +106,8 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   // the same gates as Bash. Name kept as `check-bash-memory` for backwards compat.
   'check-bash-memory':        { event: 'PostToolUse',      matcher: '^(Bash|PowerShell)$',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" check-bash-memory', timeout: 2000 } },
   'record-test-run':          { event: 'PostToolUse',      matcher: '^(Bash|PowerShell)$',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-test-run', timeout: 2000 } },
+  // #1338 follow-up — same Bash/PowerShell PostToolUse block as record-test-run.
+  'record-bash-swarm-init':   { event: 'PostToolUse',      matcher: '^(Bash|PowerShell)$',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-bash-swarm-init', timeout: 2000 } },
   'record-skill-run':         { event: 'PostToolUse',      matcher: '^Skill$',                    hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-skill-run', timeout: 2000 } },
   // Story #1274 — record the native /verify skill run (same ^Skill$ matcher as record-skill-run).
   'record-verify-run':        { event: 'PostToolUse',      matcher: '^Skill$',                    hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-verify-run', timeout: 2000 } },

--- a/tests/bin/gate-memory-fallback-1338.test.ts
+++ b/tests/bin/gate-memory-fallback-1338.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The memory_first gate must be escapable without MCP, and creditable only by a
+ * real search (#1338).
+ *
+ * Two opposite defects lived on adjacent lines of `bin/gate.cjs`:
+ *
+ *   - The block messages named ONLY `mcp__moflo__memory_search`. Claude Code
+ *     spawns stdio MCP servers once at session start and never respawns them,
+ *     so a session whose moflo server died is told to unblock itself with a
+ *     tool that does not exist in it. The CLI escape hatch existed and worked —
+ *     it was simply never surfaced.
+ *   - `CREDIT_MEMORY_SEARCH_RE` was an unanchored substring test, so
+ *     `echo "memory search"` — or a commit message mentioning this very issue —
+ *     satisfied the gate for the rest of the prompt. Strict block regex, loose
+ *     credit regex, three lines apart.
+ *
+ * These drive `gate.cjs` as a subprocess exactly as the hooks do, and cover the
+ * full arc the ticket describes: blocked → run the suggested fallback → credited.
+ *
+ * Cross-platform (Rule #1): the invocation forms below include `npx.cmd`, a
+ * backslash-separated Windows path and a forward-slash POSIX one, because
+ * credit is matched on the command BASENAME, not on a separator.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { generateGateScript } from '../../src/cli/init/helpers-generator.js';
+
+const GATE = resolve(__dirname, '../../bin/gate.cjs');
+
+let root: string;
+
+function env(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    ...(process.env as Record<string, string>),
+    CLAUDE_PROJECT_DIR: root,
+    TOOL_INPUT_command: '',
+    TOOL_INPUT_pattern: '',
+    TOOL_INPUT_path: '',
+    TOOL_INPUT_file_path: '',
+    CLAUDE_USER_PROMPT: '',
+    HOOK_SESSION_ID: '',
+    ...extra,
+  };
+}
+
+/** Run a gate script (bin/ by default) the way the hook bridge does. */
+function runGate(command: string, extra: Record<string, string> = {}, script = GATE) {
+  const r = spawnSync(process.execPath, [script, command], {
+    env: env(extra),
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+function writeState(state: Record<string, unknown>) {
+  writeFileSync(join(root, '.claude', 'workflow-state.json'), JSON.stringify(state, null, 2));
+}
+
+function readState(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(root, '.claude', 'workflow-state.json'), 'utf-8'));
+}
+
+/** A source path outside the project — never tmp-exempt (#1294 finding 3). */
+const READ_TARGET = resolve('/', 'workspace', 'proj', 'src', 'app.ts');
+
+/** Does this command satisfy the gate? Asked of the real recorder path. */
+function credits(cmd: string, script = GATE): boolean {
+  writeState({ memoryRequired: true, memorySearched: false });
+  runGate('check-bash-memory', { TOOL_INPUT_command: cmd }, script);
+  return readState().memorySearched === true;
+}
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'gate-1338-')));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows may hold handles — non-fatal */
+  }
+});
+
+describe('memory_first block messages name a working non-MCP fallback', () => {
+  const FALLBACK = 'npx flo memory search --query "<topic>" --namespace <ns>';
+
+  beforeEach(() => writeState({ memoryRequired: true, memorySearched: false }));
+
+  it('check-before-read names it', () => {
+    const r = runGate('check-before-read', { TOOL_INPUT_file_path: READ_TARGET });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.stderr).toContain(FALLBACK);
+  });
+
+  it('check-before-scan names it', () => {
+    const r = runGate('check-before-scan', { TOOL_INPUT_pattern: '**/*.ts' });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain(FALLBACK);
+  });
+
+  it('check-bash-memory names it', () => {
+    const r = runGate('check-bash-memory', { TOOL_INPUT_command: 'grep -rn TODO src/' });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain(FALLBACK);
+  });
+
+  it('says why the fallback exists, so the reader knows when to reach for it', () => {
+    const r = runGate('check-before-read', { TOOL_INPUT_file_path: READ_TARGET });
+    expect(r.stderr).toContain('MCP server not connected');
+  });
+});
+
+describe('blocked → run the suggested fallback → credited (the full arc)', () => {
+  it('the exact command the block message prints unblocks the read', () => {
+    writeState({ memoryRequired: true, memorySearched: false });
+
+    const blocked = runGate('check-before-read', { TOOL_INPUT_file_path: READ_TARGET });
+    expect(blocked.status).toBe(2);
+
+    // Take the fallback verbatim off the message and fill in the placeholders,
+    // exactly as an agent following the instruction would.
+    const suggested = blocked.stderr
+      .split('\n')
+      .find((l) => l.includes('npx flo memory search'))!
+      .replace(/^.*?(npx flo memory search)/, '$1')
+      .replace('<topic>', 'memory_first gate')
+      .replace('<ns>', 'guidance');
+
+    const credited = runGate('check-bash-memory', { TOOL_INPUT_command: suggested });
+    expect(credited.status).toBe(0);
+    expect(readState().memorySearched).toBe(true);
+
+    const after = runGate('check-before-read', { TOOL_INPUT_file_path: READ_TARGET });
+    expect(after.stderr).not.toContain('BLOCKED');
+    expect(after.status).toBe(0);
+  });
+});
+
+describe('credit requires a real memory-search invocation', () => {
+  // Every one of these ran a search. Losing any of them would strand a consumer
+  // whose documented recipe stopped working.
+  it.each([
+    ['flo memory search --query "auth" --namespace patterns'],
+    ['npx flo memory search --query "auth" --namespace guidance --limit 5'],
+    ["npx flo memory search --query 'task keywords' --namespace patterns"],
+    ['npx moflo memory search --query "auth"'],
+    ['npx moflo memory retrieve --key auth-pattern'],
+    ['npx flo-search semantic-search "patterns"'],
+    ['flo-search "auth" --namespace patterns'],
+    ['npx -y flo memory search --query "auth"'],
+    ['pnpm dlx flo memory search --query "auth"'],
+    ['cd /workspace/proj && flo memory search --query "auth"'],
+    ['node ./node_modules/moflo/bin/cli.js memory search --query "auth"'],
+    ['node .claude/scripts/semantic-search.mjs "auth"'],
+    // Windows spellings — shims and backslashes must credit identically.
+    ['npx.cmd flo memory search --query "auth"'],
+    ['flo.cmd memory search --query "auth"'],
+    ['node C:\\proj\\node_modules\\moflo\\bin\\cli.js memory search --query "auth"'],
+    ['node .claude\\scripts\\semantic-search.mjs "auth"'],
+  ])('credits %s', (cmd) => {
+    expect(credits(cmd)).toBe(true);
+  });
+
+  // None of these searched anything. The old regex credited all of them.
+  it.each([
+    ['echo "memory search"'],
+    ['echo memory-search'],
+    ['git commit -m "fix(gate): anchor the memory search credit regex"'],
+    ['git commit -m "notes" -m "ran semantic-search earlier"'],
+    ['npm install grep-memory-search'],
+    ['printf "%s" "memory retrieve"'],
+  ])('does NOT credit %s', (cmd) => {
+    expect(credits(cmd)).toBe(false);
+  });
+
+  it('does not let a read-like command credit itself by mentioning the phrase', () => {
+    // The sharpest form of the bug: the blocked command carries its own escape.
+    writeState({ memoryRequired: true, memorySearched: false });
+    const r = runGate('check-bash-memory', { TOOL_INPUT_command: 'grep -rn "memory search" src/' });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('BLOCKED');
+    expect(readState().memorySearched).not.toBe(true);
+  });
+});
+
+describe('the flo-init fallback template keeps parity (#1338)', () => {
+  // `flo init` writes a consumer's gate from the package's .claude/helpers copy;
+  // generateGateScript() is the fallback for when source helpers can't be found.
+  // A consumer landing on that path must get the same gate, not the old one.
+  let script: string;
+
+  beforeEach(() => {
+    script = join(root, 'generated-gate.cjs');
+    writeFileSync(script, generateGateScript());
+  });
+
+  it('names the fallback in its block messages', () => {
+    writeState({ memoryRequired: true, memorySearched: false });
+    const r = runGate('check-bash-memory', { TOOL_INPUT_command: 'grep -rn TODO src/' }, script);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('npx flo memory search');
+  });
+
+  it('credits a real invocation and refuses a bare mention', () => {
+    expect(credits('npx flo memory search --query "auth"', script)).toBe(true);
+    expect(credits('echo "memory search"', script)).toBe(false);
+  });
+});

--- a/tests/bin/gate-swarm-cli-escape-1338.test.ts
+++ b/tests/bin/gate-swarm-cli-escape-1338.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The #952 swarm/hive gate must be satisfiable without MCP (#1338 follow-up).
+ *
+ * `record-swarm-init` / `record-hive-init` fired only on `mcp__moflo__swarm_init`
+ * / `mcp__moflo__hive-mind_init`. Claude Code spawns stdio MCP servers once at
+ * session start and never respawns them, so a session that lost its moflo
+ * server hit `/fl -s` with NO way to satisfy the gate: every Agent spawn hard
+ * blocked, telling the reader to call a tool that did not exist in that session.
+ * Unlike the memory_first gate — which at least had an unadvertised CLI escape —
+ * this one had none short of disabling the gate in moflo.yaml.
+ *
+ * The CLI is a real satisfaction of the gate, not a stand-in: `flo swarm init`
+ * dispatches in-process through the same TOOL_REGISTRY handler the MCP server
+ * exposes (`mcp-client.ts` callMCPTool), and the swarm is persisted, so a later
+ * process sees the same swarmId. Verified by hand against the installed CLI
+ * before this recorder was written.
+ *
+ * Two invariants matter most and are asserted below:
+ *   1. Only a *succeeded* init credits. The recorder is wired PostToolUse,
+ *      which Claude Code does not fire on a non-zero exit (#1322). Crediting a
+ *      failed init would open the gate with no swarm behind it — the silent
+ *      degradation CLAUDE.md's protected-functionality rule forbids.
+ *   2. Swarm and hive credit their OWN flag only. Cross-crediting would let
+ *      `/fl -h` proceed on a swarm that is not a hive.
+ *
+ * Cross-platform (Rule #1): the invocation forms include `npx.cmd` and a
+ * backslash-separated path, because the matcher keys on command basename.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { REQUIRED_HOOK_WIRING, HOOK_ENTRY_MAP, repairHookWiring } from '../../src/cli/services/hook-wiring.js';
+import { getReferenceHookBlock } from '../../src/cli/services/hook-block-hash.js';
+import { generateGateScript } from '../../src/cli/init/helpers-generator.js';
+
+const GATE = resolve(__dirname, '../../bin/gate.cjs');
+
+let root: string;
+
+function runGate(command: string, extra: Record<string, string> = {}, script = GATE) {
+  const r = spawnSync(process.execPath, [script, command], {
+    env: {
+      ...(process.env as Record<string, string>),
+      CLAUDE_PROJECT_DIR: root,
+      TOOL_INPUT_command: '',
+      HOOK_SESSION_ID: '',
+      ...extra,
+    },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+function writeState(state: Record<string, unknown>) {
+  writeFileSync(join(root, '.claude', 'workflow-state.json'), JSON.stringify(state, null, 2));
+}
+
+function readState(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(root, '.claude', 'workflow-state.json'), 'utf-8'));
+}
+
+/** Run a command through the CLI-init recorder and report what it credited. */
+function recorded(cmd: string, script = GATE) {
+  writeState({ flMode: 'swarm', swarmInitialized: false, hiveInitialized: false });
+  runGate('record-bash-swarm-init', { TOOL_INPUT_command: cmd }, script);
+  const s = readState();
+  return { swarm: s.swarmInitialized === true, hive: s.hiveInitialized === true };
+}
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'gate-swarm-cli-')));
+  mkdirSync(join(root, '.claude'), { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows may hold handles — non-fatal */
+  }
+});
+
+describe('the swarm/hive block names the CLI route', () => {
+  it('swarm mode names flo swarm init', () => {
+    writeState({ flMode: 'swarm', swarmInitialized: false });
+    const r = runGate('check-before-agent');
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('npx flo swarm init');
+    expect(r.stderr).toContain('MCP server not connected');
+  });
+
+  it('hive mode names flo hive-mind init', () => {
+    writeState({ flMode: 'hive', hiveInitialized: false });
+    const r = runGate('check-before-agent');
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('npx flo hive-mind init');
+  });
+});
+
+describe('blocked → run the CLI init → unblocked (the escape that did not exist)', () => {
+  it('swarm', () => {
+    writeState({ flMode: 'swarm', swarmInitialized: false });
+    expect(runGate('check-before-agent').status).toBe(2);
+
+    runGate('record-bash-swarm-init', { TOOL_INPUT_command: 'npx flo swarm init --topology hierarchical' });
+    expect(readState().swarmInitialized).toBe(true);
+
+    const after = runGate('check-before-agent');
+    expect(after.stderr).not.toContain('BLOCKED');
+    expect(after.status).toBe(0);
+  });
+
+  it('hive', () => {
+    writeState({ flMode: 'hive', hiveInitialized: false });
+    expect(runGate('check-before-agent').status).toBe(2);
+
+    runGate('record-bash-swarm-init', { TOOL_INPUT_command: 'npx flo hive-mind init' });
+    expect(readState().hiveInitialized).toBe(true);
+    expect(runGate('check-before-agent').status).toBe(0);
+  });
+});
+
+describe('only a real init credits, and only its own mode', () => {
+  it.each([
+    ['flo swarm init'],
+    ['npx flo swarm init --topology mesh --max-agents 5'],
+    ['npx.cmd flo swarm init'],
+    ['node .\\node_modules\\moflo\\bin\\cli.js swarm init'],
+    ['cd /workspace/proj && npx flo swarm init'],
+  ])('credits swarm for %s', (cmd) => {
+    expect(recorded(cmd)).toEqual({ swarm: true, hive: false });
+  });
+
+  it.each([
+    ['flo hive-mind init'],
+    ['npx flo hive-mind init --workers 4'],
+    ['npx flo hive init'],
+  ])('credits hive for %s', (cmd) => {
+    expect(recorded(cmd)).toEqual({ swarm: false, hive: true });
+  });
+
+  it.each([
+    ['echo "flo swarm init"'],
+    ['git commit -m "wire flo swarm init into the gate"'],
+    ['flo swarm status'],
+    ['flo swarm'],
+    ['git init'],
+    ['npm init -y'],
+    ['flo memory search --query "swarm init"'],
+  ])('credits nothing for %s', (cmd) => {
+    expect(recorded(cmd)).toEqual({ swarm: false, hive: false });
+  });
+});
+
+describe('the recorder is wired where only success reaches it', () => {
+  // The whole honesty argument rests on this: PostToolUse does not fire when a
+  // command exits non-zero (#1322), so a failed `flo swarm init` cannot credit.
+  // If someone moves this to PreToolUse, the gate starts opening on failures.
+  it('is a PostToolUse hook, not PreToolUse', () => {
+    const req = REQUIRED_HOOK_WIRING.find((h) => h.pattern === 'record-bash-swarm-init');
+    expect(req?.event).toBe('PostToolUse');
+    expect(HOOK_ENTRY_MAP['record-bash-swarm-init'].event).toBe('PostToolUse');
+  });
+
+  it('rides the Bash/PowerShell block, so PowerShell sessions record too (Rule #1)', () => {
+    expect(HOOK_ENTRY_MAP['record-bash-swarm-init'].matcher).toBe('^(Bash|PowerShell)$');
+    const post = getReferenceHookBlock().PostToolUse as Array<{ matcher?: string; hooks: Array<{ command: string }> }>;
+    const block = post.find((b) => b.matcher === '^(Bash|PowerShell)$');
+    expect(block?.hooks.some((h) => h.command.includes('record-bash-swarm-init'))).toBe(true);
+  });
+
+  it('grafts itself into an existing consumer that predates it', () => {
+    // Without the REQUIRED_HOOK_WIRING entry, only consumers who re-run
+    // `flo init` would get the escape — everyone else keeps the deadlock.
+    const settings = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: '^(Bash|PowerShell)$',
+            hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-test-run', timeout: 2000 }],
+          },
+        ],
+      },
+    };
+    const { settings: repaired, repaired: fixed } = repairHookWiring(settings);
+    expect(fixed).toContain('record-bash-swarm-init');
+
+    const block = (repaired.hooks as Record<string, Array<{ matcher?: string; hooks: Array<{ command: string }> }>>)
+      .PostToolUse.find((b) => b.matcher === '^(Bash|PowerShell)$');
+    expect(block?.hooks.some((h) => h.command.includes('record-bash-swarm-init'))).toBe(true);
+  });
+});
+
+describe('the flo-init fallback template carries the same escape', () => {
+  let script: string;
+
+  beforeEach(() => {
+    script = join(root, 'generated-gate.cjs');
+    writeFileSync(script, generateGateScript());
+  });
+
+  it('names the CLI route when it blocks', () => {
+    writeState({ flMode: 'swarm', swarmInitialized: false });
+    const r = runGate('check-before-agent', {}, script);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('npx flo swarm init');
+  });
+
+  it('records a real init and ignores a mention', () => {
+    expect(recorded('npx flo swarm init', script)).toEqual({ swarm: true, hive: false });
+    expect(recorded('echo "flo swarm init"', script)).toEqual({ swarm: false, hive: false });
+  });
+});


### PR DESCRIPTION
Closes #1338

Claude Code spawns stdio MCP servers **once** at session start and never respawns them. A session can therefore outlive its moflo MCP connection — and two gates respond to that by blocking work and instructing the reader to call a tool that does not exist in the session. This PR fixes both, and tightens a credit check that was letting any string through.

## 1. `memory_first` — the escape existed but was never named (the ticket)

The block messages named only `mcp__moflo__memory_search`, while the gate blocked the `Read`/`Grep`/`sed`/`find` calls needed to diagnose the failure. A working CLI escape hatch existed all along and credited the gate; it was discoverable only by reading `gate.cjs` *after* being blocked from reading it. All three messages (`check-before-read`, `check-before-scan`, `check-bash-memory`) now also print:

```
npx flo memory search --query "<topic>" --namespace <ns>
```

## 2. The credit regex was the inverse defect

`CREDIT_MEMORY_SEARCH_RE` was an unanchored substring test against the whole command, sitting directly beside a block regex that is deliberately anchored. `echo "memory search"`, a `git commit -m` about this very issue, or the quoted argument of the blocked `grep` itself all earned credit for the rest of the prompt.

Credit now requires a real **invocation**: quoted bodies stripped, command split into shell segments, each checked at its own start — runners and env assignments skipped, then the entrypoint matched by **basename** against the moflo CLI (`flo`/`moflo`/`claude-flow`/`cli.js`) or a search binary (`flo-search`/`semantic-search.mjs`), with `memory search`/`memory retrieve` required after the CLI form.

## 3. The swarm/hive gate had no escape at all

Found while reviewing (1): `record-swarm-init` / `record-hive-init` fired **only** on the MCP tools. So an MCP-less session running `/fl -s` hit the #952 gate with nothing that could satisfy it — every Agent spawn hard-blocked, pointing at an uncallable tool, with no remedy short of disabling the gate in `moflo.yaml`. Strictly worse than (1), which at least had an unadvertised escape.

A new `record-bash-swarm-init` recorder credits the gate from a genuine `flo swarm init` / `flo hive-mind init`, and both block messages name the route.

**Why the CLI genuinely satisfies this gate, rather than faking it:**

- `flo swarm init` dispatches **in-process** through the same `TOOL_REGISTRY` handler the MCP server exposes (`mcp-client.ts:117-128`) — it *is* the MCP handler, not a parallel implementation.
- The swarm is persisted (#806 agents/topology, #1329 tasks), so a later process — including a restarted MCP server — hydrates the same swarm. Confirmed by hand before the recorder was written: `flo swarm init` produced a swarmId that a **separate** `flo swarm status` process reported back.
- Wired **PostToolUse**, not the PreToolUse arm where the memory credit lives. Claude Code does not fire PostToolUse on a non-zero exit (#1322), so only an init that actually **succeeded** credits. A failed init opening the gate would be the silent degradation CLAUDE.md's protected-functionality rule exists to prevent — a test pins the event so a later refactor cannot quietly move it.

## Rule #1 — cross-platform

Basename matching splits on **both** separators (`path.basename` honours only the host's, and an agent on POSIX can legitimately type `node .claude\scripts\semantic-search.mjs`), so `flo`, `flo.cmd`, `npx.cmd flo`, `node ./bin/cli.js` and `node C:\...\bin\cli.js` all resolve identically wherever the gate runs — pinned by Windows-spelling cases in both test files. The swarm recorder rides the existing `^(Bash|PowerShell)$` block, so PowerShell sessions record the same way. Suggested commands use double quotes, which bash, PowerShell and cmd all accept.

## Rule #2 — consumer blast radius

- **Surface:** `bin/gate.cjs` (+ `.claude/helpers/` copy + `generateGateScript()` init fallback) — runs on every consumer's `Read`/`Grep`/`Bash`; plus one hook appended to a PostToolUse block every consumer already has.
- **What stops crediting:** only text that never searched anything. Every documented recipe still credits — `flo memory search`, `flo-search`, `npx flo memory search --query '...' --namespace patterns`, `node .claude/scripts/semantic-search.mjs`.
- **Migration:** none. No new matcher block, no state format change, no settings shape change. A `REQUIRED_HOOK_WIRING` entry makes `repairHookWiring` graft the new hook in at session start for consumers who never re-run `flo init` — pinned by a test that repairs a pre-change settings object.
- **Cost:** a 6th gate spawn on the Bash path (~30ms) alongside the 4 PreToolUse + 1 PostToolUse already there; the handler early-rejects on two regexes. Folding it into `record-test-run` would save the spawn but make that case name lie and emit its "no-op" crumb on every `flo swarm init` — rationale recorded at the wiring site.
- **Round-trip:** runtime files — needs publish + reinstall + Claude Code restart to reach consumers (and to reach our own dogfood: the installed 4.12.4-rc.3 predates this, so its `repairHookWiring` can't add the new hook to a current session).

> The ticket cited `.claude/scripts/` as the sync target; the actual synced surface is `.claude/helpers/gate.cjs` — which is also what `flo init` copies a consumer's gate from — plus the generator fallback. Both are covered.

## Verification

Two new test files, 54 tests, driving `gate.cjs` as a subprocess exactly as the hooks do:

- **The full arc, both gates.** `tests/bin/gate-memory-fallback-1338.test.ts` lifts the suggested command **verbatim off the block message**, runs it, and asserts the previously-blocked read now passes. `tests/bin/gate-swarm-cli-escape-1338.test.ts` does the same blocked → CLI init → unblocked arc for swarm and hive, and asserts they never cross-credit.
- **Mutation-checked.** Stashing the source changes fails 15/30 and 17/24 respectively — the suites discriminate rather than passing vacuously.
- **The real bridge.** A Claude Code structured stdin payload piped through `gate-hook.mjs record-bash-swarm-init` flipped `swarmInitialized` and left `hiveInitialized` false, exit 0.
- **Observed live.** While writing this, a real Bash call in the session was blocked by the dogfooded gate and printed the new fallback line.
- Full suite **10072 passed / 0 failed**, lint clean, `tsc` clean.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
