### PR TITLE
fix(agents): make the personas' worked MCP examples executable (#1330)

### DIFF
--- a/.claude/agents/core/coder.md
+++ b/.claude/agents/core/coder.md
@@ -195,36 +195,29 @@ src/
 ## MCP Tool Integration
 
 ### Memory Coordination
-```javascript
-// Report implementation status
-mcp__moflo__memory_store {
-    key: "swarm/coder/status",
-  namespace: "coordination",
-  value: JSON.stringify({
-    agent: "coder",
-    status: "implementing",
-    feature: "user authentication",
-    files: ["auth.service.ts", "auth.controller.ts"],
-    timestamp: Date.now()
-  })
-}
 
+Store decisions that outlive this run, in the namespaces named in your operating
+context above. Prose in `value` — it is what gets embedded, so a JSON blob
+retrieves badly; structure goes in `metadata`, stored verbatim.
+
+```javascript
 // Share code decisions
 mcp__moflo__memory_store {
-    key: "swarm/shared/implementation",
-  namespace: "coordination",
-  value: JSON.stringify({
-    type: "code",
+  namespace: "patterns",
+  key: "auth-service-shape",
+  value: "Auth is a singleton service behind a factory so the jwt signer can be swapped in tests; endpoints are /auth/login and /auth/logout on the express router.",
+  metadata: {
     patterns: ["singleton", "factory"],
     dependencies: ["express", "jwt"],
-    api_endpoints: ["/auth/login", "/auth/logout"]
-  })
+    apiEndpoints: ["/auth/login", "/auth/logout"]
+  }
 }
 
-// Check dependencies
-mcp__moflo__memory_retrieve {
-    key: "swarm/shared/dependencies",
-  namespace: "coordination"
+// Look up what an earlier agent established. Semantic search first — reach for
+// memory_retrieve only when you already know the exact key.
+mcp__moflo__memory_search {
+  query: "auth service dependencies",
+  namespace: "patterns"
 }
 ```
 
@@ -232,7 +225,7 @@ mcp__moflo__memory_retrieve {
 ```javascript
 // Track implementation metrics
 mcp__moflo__performance_benchmark {
-  type: "code",
+  suite: "memory",
   iterations: 10
 }
 

--- a/.claude/agents/core/planner.md
+++ b/.claude/agents/core/planner.md
@@ -114,45 +114,67 @@ plan:
 ## MCP Tool Integration
 
 ### Task Orchestration
+
+Submit the breakdown to the coordinator. A task ID only exists once the
+coordinator has issued it — storing a breakdown in memory dispatches nothing,
+and polling an ID you invented yourself always comes back empty.
+
 ```javascript
-// Orchestrate complex tasks
-
-// Share task breakdown
-mcp__moflo__memory_store {
-    key: "swarm/planner/task-breakdown",
-  namespace: "coordination",
-  value: JSON.stringify({
-    main_task: "authentication",
-    subtasks: [
-      {id: "1", task: "Research auth libraries", assignee: "researcher"},
-      {id: "2", task: "Design auth flow", assignee: "architect"},
-      {id: "3", task: "Implement auth service", assignee: "coder"},
-      {id: "4", task: "Write auth tests", assignee: "tester"}
-    ],
-    dependencies: {"3": ["1", "2"], "4": ["3"]}
-  })
+// Submit the whole breakdown in one call. Tasks are load-balanced across
+// available agents; `type` must be one of research | analysis | coding |
+// testing | review | documentation | coordination | consensus | custom.
+mcp__moflo__task_orchestrate {
+  tasks: [
+    { type: "research",      description: "Research auth libraries",  priority: "high" },
+    { type: "analysis",      description: "Design auth flow",         priority: "high" },
+    { type: "coding",        description: "Implement auth service",   priority: "normal" },
+    { type: "testing",       description: "Write auth tests",         priority: "normal" }
+  ]
 }
+// → { success: true, submitted: 4, assigned: 3, queued: 1,
+//     tasks: [ { taskId: "task_...", status: "assigned", ... }, ... ] }
 
-// Monitor task progress
+// Poll an ID the coordinator returned — never one you named yourself.
 mcp__moflo__task_status {
-  taskId: "auth-implementation"
+  taskId: "<taskId from the response above>"
 }
+
+// Or survey everything in flight instead of polling one at a time.
+mcp__moflo__task_list { status: "running,queued" }
 ```
+
+Use `mcp__moflo__task_create` for a single task; it takes the same fields and
+returns the same projection, including the `taskId`.
+
+**Ordering lives on the native Task layer, not here.** `task_create` and
+`task_orchestrate` accept no dependency field — the coordinator load-balances
+what you submit. Express prerequisites with `TaskUpdate({ addBlockedBy: [...] })`
+on the native tasks, per *What → Native Tasks; How → MoFlo orchestration* in
+`.claude/guidance/moflo-claude-swarm-cohesion.md`.
 
 ### Memory Coordination
+
+Live task state belongs to the coordinator — read it with `task_status` /
+`task_list` rather than mirroring it into memory. Store what stays useful after
+this run: a decision and its rationale that a future agent would otherwise have
+to rediscover.
+
 ```javascript
-// Report planning status
+// Prose in `value` — it is what gets embedded, so a JSON blob retrieves badly.
+// Structure goes in `metadata`, which is stored verbatim and not embedded.
 mcp__moflo__memory_store {
-    key: "swarm/planner/status",
-  namespace: "coordination",
-  value: JSON.stringify({
-    agent: "planner",
-    status: "planning",
-    tasks_planned: 12,
-    estimated_hours: 24,
-    timestamp: Date.now()
-  })
+  namespace: "patterns",
+  key: "auth-rollout-sequencing",
+  value: "Auth work is sequenced research → design → implement → test because the library choice determines the flow design; parallelising design against research produced rework twice.",
+  metadata: {
+    plannedTasks: 12,
+    blockedOn: ["library selection"]
+  }
 }
 ```
 
-Remember: A good plan executed now is better than a perfect plan executed never. Focus on creating actionable, practical plans that drive progress. Always coordinate through memory.
+Use the namespaces named in this agent's operating context above — `patterns`
+for reusable approaches, `learnings` for decisions and gotchas. The `swarm-*`
+namespaces are the coordinator's own persistence; do not write to them.
+
+Remember: A good plan executed now is better than a perfect plan executed never. Focus on creating actionable, practical plans that drive progress. Dispatch through the coordinator; use memory for what outlives the run.

--- a/.claude/agents/core/researcher.md
+++ b/.claude/agents/core/researcher.md
@@ -119,36 +119,29 @@ read specific-file.ts
 ## MCP Tool Integration
 
 ### Memory Coordination
-```javascript
-// Report research status
-mcp__moflo__memory_store {
-    key: "swarm/researcher/status",
-  namespace: "coordination",
-  value: JSON.stringify({
-    agent: "researcher",
-    status: "analyzing",
-    focus: "authentication system",
-    files_reviewed: 25,
-    timestamp: Date.now()
-  })
-}
 
+Store findings that stay useful after this run, in the namespaces named in your
+operating context above. Prose in `value` — it is what gets embedded, so a JSON
+blob retrieves badly; structure goes in `metadata`, stored verbatim.
+
+```javascript
 // Share research findings
 mcp__moflo__memory_store {
-    key: "swarm/shared/research-findings",
-  namespace: "coordination",
-  value: JSON.stringify({
-    patterns_found: ["MVC", "Repository", "Factory"],
+  namespace: "patterns",
+  key: "auth-stack-survey",
+  value: "Auth here is passport + jwt behind an MVC/repository split; the passport version is two majors behind and there is no rate limiting on the login route.",
+  metadata: {
+    patternsFound: ["MVC", "Repository", "Factory"],
     dependencies: ["express", "passport", "jwt"],
-    potential_issues: ["outdated auth library", "missing rate limiting"],
     recommendations: ["upgrade passport", "add rate limiter"]
-  })
+  }
 }
 
-// Check prior research
+// Check prior research. memory_search is semantic — it takes a `query`, not a
+// key glob. Pivot the query on the bare symbol or topic.
 mcp__moflo__memory_search {
-  pattern: "swarm/shared/research-*",
-  namespace: "coordination",
+  query: "authentication stack",
+  namespace: "patterns",
   limit: 10
 }
 ```
@@ -171,14 +164,14 @@ mcp__moflo__agent_status {
 - Share findings with planner for task decomposition via memory
 - Provide context to coder for implementation through shared memory
 - Supply tester with edge cases and scenarios in memory
-- Document all findings in coordination memory
+- Document findings in the `patterns` namespace so later agents retrieve them
 
 ## Best Practices
 
 1. **Be Thorough**: Check multiple sources and validate findings
 2. **Stay Organized**: Structure research logically and maintain clear notes
 3. **Think Critically**: Question assumptions and verify claims
-4. **Document Everything**: Store all findings in coordination memory
+4. **Document Everything**: Store findings in `patterns` (or `learnings` for decisions and gotchas)
 5. **Iterate**: Refine research based on new discoveries
 6. **Share Early**: Update memory frequently for real-time coordination
 

--- a/.claude/agents/core/reviewer.md
+++ b/.claude/agents/core/reviewer.md
@@ -269,36 +269,29 @@ npm run complexity-check
 ## MCP Tool Integration
 
 ### Memory Coordination
-```javascript
-// Report review status
-mcp__moflo__memory_store {
-    key: "swarm/reviewer/status",
-  namespace: "coordination",
-  value: JSON.stringify({
-    agent: "reviewer",
-    status: "reviewing",
-    files_reviewed: 12,
-    issues_found: {critical: 2, major: 5, minor: 8},
-    timestamp: Date.now()
-  })
-}
 
+Store findings that outlive this run, in the namespaces named in your operating
+context above. Prose in `value` — it is what gets embedded, so a JSON blob
+retrieves badly; structure goes in `metadata`, stored verbatim.
+
+```javascript
 // Share review findings
 mcp__moflo__memory_store {
-    key: "swarm/shared/review-findings",
-  namespace: "coordination",
-  value: JSON.stringify({
-    security_issues: ["SQL injection in auth.js:45"],
-    performance_issues: ["N+1 queries in user.service.ts"],
-    code_quality: {score: 7.8, coverage: "78%"},
-    action_items: ["Fix SQL injection", "Optimize queries", "Add tests"]
-  })
+  namespace: "patterns",
+  key: "auth-review-findings",
+  value: "Login builds its SQL by string concatenation (auth.js:45) and the user service loads roles per-row inside a loop, so both the injection risk and the N+1 come from the same request path.",
+  metadata: {
+    securityIssues: ["SQL injection in auth.js:45"],
+    performanceIssues: ["N+1 queries in user.service.ts"],
+    actionItems: ["Fix SQL injection", "Batch the role lookup", "Add tests"]
+  }
 }
 
-// Check implementation details
-mcp__moflo__memory_retrieve {
-    key: "swarm/coder/status",
-  namespace: "coordination"
+// Look up what the implementer established. Semantic search first — reach for
+// memory_retrieve only when you already know the exact key.
+mcp__moflo__memory_search {
+  query: "auth service shape",
+  namespace: "patterns"
 }
 ```
 
@@ -311,7 +304,7 @@ mcp__moflo__analyze_diff {
 
 // Scan the diff for prompt-injection and unsafe content
 mcp__moflo__aidefence_scan {
-  content: "<the diff or file under review>"
+  input: "<the diff or file under review>"
 }
 ```
 

--- a/.claude/agents/core/tester.md
+++ b/.claude/agents/core/tester.md
@@ -251,35 +251,30 @@ describe('Security', () => {
 ## MCP Tool Integration
 
 ### Memory Coordination
-```javascript
-// Report test status
-mcp__moflo__memory_store {
-    key: "swarm/tester/status",
-  namespace: "coordination",
-  value: JSON.stringify({
-    agent: "tester",
-    status: "running tests",
-    test_suites: ["unit", "integration", "e2e"],
-    timestamp: Date.now()
-  })
-}
 
-// Share test results
+Store what stays useful after this run, in the namespaces named in your
+operating context above. Prose in `value` — it is what gets embedded, so a JSON
+blob retrieves badly; structure goes in `metadata`, stored verbatim.
+
+```javascript
+// Share what the run revealed, not the raw tally
 mcp__moflo__memory_store {
-    key: "swarm/shared/test-results",
-  namespace: "coordination",
-  value: JSON.stringify({
+  namespace: "patterns",
+  key: "auth-suite-flakiness",
+  value: "The two failing auth tests both assert on token expiry against a real clock, so they fail whenever the suite runs slowly under load — freeze the clock rather than widening the tolerance.",
+  metadata: {
     passed: 145,
     failed: 2,
     coverage: "87%",
     failures: ["auth.test.ts:45", "api.test.ts:123"]
-  })
+  }
 }
 
-// Check implementation status
-mcp__moflo__memory_retrieve {
-    key: "swarm/coder/status",
-  namespace: "coordination"
+// Look up what the implementer established. Semantic search first — reach for
+// memory_retrieve only when you already know the exact key.
+mcp__moflo__memory_search {
+  query: "auth service shape",
+  namespace: "patterns"
 }
 ```
 
@@ -287,7 +282,7 @@ mcp__moflo__memory_retrieve {
 ```javascript
 // Run performance benchmarks
 mcp__moflo__performance_benchmark {
-  type: "test",
+  suite: "all",
   iterations: 100
 }
 

--- a/tests/guards/agent-persona-mcp-examples-1330.test.ts
+++ b/tests/guards/agent-persona-mcp-examples-1330.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Guard: a worked example in a shipped agent persona must be executable (#1330).
+ *
+ * `planner.md` demonstrated task orchestration by storing a subtask breakdown as
+ * a JSON blob in memory and then polling `task_status { taskId:
+ * "auth-implementation" }`. That ID was never submitted to anything —
+ * `task_create` / `task_orchestrate` were never called — so the poll could only
+ * ever come back empty. Both calls individually "succeed", so nothing errors;
+ * the reader just gets a breakdown nothing dispatches.
+ *
+ * The cost was not hypothetical: an external audit read that example and
+ * concluded `mcp__moflo__task_*` was "wired to nothing" and should be retired.
+ * The tools are fully wired (#1329) — the example was what was broken. A
+ * persona is the worked example someone copies, so a wrong one is worse than
+ * none.
+ *
+ * These personas ship to every consumer (`.claude/agents/**` is synced by
+ * `flo init`), which is why this is pinned rather than fixed once. The checks
+ * run against the LIVE tool registry, so a schema change that invalidates a
+ * documented call fails here rather than in a consumer's session.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve, relative } from 'node:path';
+
+import { listMCPTools } from '../../src/cli/mcp-client.js';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const AGENTS_DIR = resolve(REPO_ROOT, '.claude/agents');
+
+function markdownFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...markdownFiles(full));
+    else if (entry.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+const PERSONAS = markdownFiles(AGENTS_DIR).map((path) => ({
+  path,
+  rel: relative(REPO_ROOT, path).replace(/\\/g, '/'), // Rule #1: stable ids on Windows
+  text: readFileSync(path, 'utf-8').replace(/\r\n/g, '\n'),
+}));
+
+/**
+ * Tool schemas as the server actually exposes them — not a copy.
+ *
+ * The registry keys are BARE names (`memory_store`); the `mcp__moflo__` prefix
+ * is what the MCP server prepends when publishing them, and is how personas
+ * spell them. Keyed both ways so the guard reads naturally either side.
+ */
+const SCHEMAS = new Map(
+  listMCPTools().flatMap((t) => [
+    [t.name, t.inputSchema] as const,
+    [`mcp__moflo__${t.name}`, t.inputSchema] as const,
+  ]),
+);
+
+/**
+ * Documented `mcp__moflo__<tool> { ... }` calls, with the argument names used.
+ *
+ * Deliberately shallow: it reads the top-level `key:` tokens of the call's
+ * brace block and ignores nested object bodies, which is all the schema check
+ * needs and keeps the parser from needing to be a JS parser. Known limit — a
+ * brace inside a string literal would throw the depth count off. No persona
+ * has one; if that changes, this fails loudly rather than passing silently,
+ * which is the right way round for a guard.
+ */
+function documentedCalls(text: string): Array<{ tool: string; args: string[]; line: number }> {
+  const calls: Array<{ tool: string; args: string[]; line: number }> = [];
+  const re = /mcp__moflo__([a-z0-9_-]+)\s*\{/gi;
+  for (let m = re.exec(text); m !== null; m = re.exec(text)) {
+    const tool = `mcp__moflo__${m[1]}`;
+    // Walk to the matching close brace, tracking depth.
+    let depth = 0;
+    let i = m.index + m[0].length - 1;
+    const start = i;
+    for (; i < text.length; i++) {
+      if (text[i] === '{') depth++;
+      else if (text[i] === '}') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    const body = text.slice(start + 1, i);
+    // Top-level keys only: blank out nested brace/bracket bodies first.
+    let flat = body;
+    let prev = '';
+    while (flat !== prev) {
+      prev = flat;
+      flat = flat.replace(/\{[^{}]*\}/g, '').replace(/\[[^[\]]*\]/g, '');
+    }
+    const args = [...flat.matchAll(/(?:^|,)\s*["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*:/g)].map((a) => a[1]);
+    calls.push({ tool, args, line: text.slice(0, m.index).split('\n').length });
+  }
+  return calls;
+}
+
+describe('every mcp__moflo__ call documented in an agent persona is executable', () => {
+  it('finds calls to check (guards against a parser that silently matches nothing)', () => {
+    const total = PERSONAS.reduce((n, p) => n + documentedCalls(p.text).length, 0);
+    expect(total).toBeGreaterThan(5);
+  });
+
+  it('names only tools the server actually registers', () => {
+    const unknown: string[] = [];
+    for (const p of PERSONAS) {
+      for (const c of documentedCalls(p.text)) {
+        if (!SCHEMAS.has(c.tool)) unknown.push(`${p.rel}:${c.line} → ${c.tool}`);
+      }
+    }
+    expect(unknown).toEqual([]);
+  });
+
+  it('passes only arguments the tool schema declares', () => {
+    // This is the check that catches the #1330 class directly: researcher.md
+    // called memory_search with `pattern: "swarm/shared/research-*"`, an
+    // argument memory_search has never had.
+    const bogus: string[] = [];
+    for (const p of PERSONAS) {
+      for (const c of documentedCalls(p.text)) {
+        const schema = SCHEMAS.get(c.tool);
+        const props = Object.keys((schema?.properties ?? {}) as Record<string, unknown>);
+        if (!props.length) continue;
+        for (const arg of c.args) {
+          if (!props.includes(arg)) bogus.push(`${p.rel}:${c.line} → ${c.tool} has no argument "${arg}"`);
+        }
+      }
+    }
+    expect(bogus).toEqual([]);
+  });
+
+  it('supplies every argument the tool schema requires', () => {
+    const missing: string[] = [];
+    for (const p of PERSONAS) {
+      for (const c of documentedCalls(p.text)) {
+        const schema = SCHEMAS.get(c.tool);
+        const required = (schema?.required ?? []) as string[];
+        for (const req of required) {
+          if (!c.args.includes(req)) missing.push(`${p.rel}:${c.line} → ${c.tool} omits required "${req}"`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('a persona never names a namespace its own operating context omits', () => {
+  // The self-consistency check. `coordination` was named twice in planner.md
+  // while the header six lines above listed the real namespaces — the file
+  // contradicted itself, and four sibling personas carried the same blob.
+  // Deriving the allowed set from each file means no hardcoded list to rot.
+  function declaredNamespaces(text: string): Set<string> {
+    const header = text.split('Search these namespaces depending on your task:')[1];
+    if (!header) return new Set();
+    const block = header.split(/\n\s*\n/)[0];
+    return new Set([...block.matchAll(/^-\s+`([a-z0-9-]+)`/gim)].map((m) => m[1]));
+  }
+
+  function namespacesUsed(text: string): string[] {
+    return [...new Set([...text.matchAll(/namespace:\s*["']([a-z0-9-]+)["']/gi)].map((m) => m[1]))];
+  }
+
+  // Every persona, not just the ones that happen to use a namespace today —
+  // so the declaration block itself is pinned, and a persona that starts using
+  // namespaces tomorrow is already covered.
+  for (const p of PERSONAS) {
+    it(p.rel, () => {
+      const declared = declaredNamespaces(p.text);
+      const used = namespacesUsed(p.text);
+
+      // A persona that names namespaces must declare them, or there is nothing
+      // to check it against — that omission is itself the failure.
+      if (used.length > 0) expect(declared.size).toBeGreaterThan(0);
+
+      expect(used.filter((ns) => !declared.has(ns))).toEqual([]);
+    });
+  }
+});
+
+describe('planner.md — every task ID queried traces to a call that produced one', () => {
+  const planner = PERSONAS.find((p) => p.rel.endsWith('core/planner.md'))!;
+
+  /** One `### <title>` section, stopping at the next heading of any level. */
+  function section(title: string): string {
+    const after = planner.text.split(`### ${title}`)[1] ?? '';
+    return after.split(/\n#{1,4}\s/)[0];
+  }
+
+  it('submits to the coordinator before querying status', () => {
+    const submitAt = planner.text.search(/mcp__moflo__task_(orchestrate|create)\s*\{/);
+    const statusAt = planner.text.search(/mcp__moflo__task_status\s*\{/);
+    expect(submitAt).toBeGreaterThan(-1);
+    expect(statusAt).toBeGreaterThan(submitAt);
+  });
+
+  it('never polls a hand-written task ID', () => {
+    // The original: `task_status { taskId: "auth-implementation" }` — an ID no
+    // call ever returned. A literal here is the defect; a placeholder that
+    // points back at the response is the fix.
+    const polls = [...planner.text.matchAll(/task_status\s*\{[^}]*taskId:\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(polls.length).toBeGreaterThan(0);
+    for (const id of polls) {
+      expect(id).toMatch(/^</); // e.g. "<taskId from the response above>"
+    }
+  });
+
+  it('does not present memory_store as the dispatch mechanism', () => {
+    // Storing a breakdown dispatches nothing. The orchestration section must
+    // reach the coordinator; memory is for what outlives the run.
+    const orchestration = section('Task Orchestration');
+    expect(orchestration).toContain('task_orchestrate');
+    expect(orchestration).not.toContain('memory_store');
+  });
+
+  it('does not imply task_create accepts dependencies', () => {
+    // buildTaskInput hardcodes `dependencies: []` — the MCP layer takes none.
+    // Documenting one would recreate this ticket's defect in a new form.
+    const createSchema = SCHEMAS.get('mcp__moflo__task_create');
+    const props = Object.keys((createSchema?.properties ?? {}) as Record<string, unknown>);
+    expect(props).not.toContain('dependencies');
+
+    const orchestration = section('Task Orchestration');
+    expect(orchestration).not.toMatch(/dependencies:\s*[{[]/);
+    // ...and says where ordering actually belongs, so the reader isn't stranded.
+    expect(orchestration).toContain('addBlockedBy');
+  });
+});


### PR DESCRIPTION
Closes #1330

## What was wrong

`planner.md` demonstrated task orchestration by storing a subtask breakdown as a JSON blob in memory, then polling `task_status { taskId: "auth-implementation" }`. That ID was never submitted to anything — `task_create` / `task_orchestrate` were never called — so the poll could only ever come back empty. Both calls individually succeed, so nothing errors; the reader just gets a breakdown that nothing dispatches.

The cost was not hypothetical. An external audit read that example and concluded `mcp__moflo__task_*` was "wired to nothing" and should be retired. The tools are fully wired to the coordinator (#1329) — **the example was what was broken.** A persona is the worked example someone copies, so a wrong one is worse than none.

## The fix

The orchestration example now submits through `task_orchestrate`, shows the response it returns, and polls an ID that came from that response. Two things it deliberately does **not** do:

- **Express dependencies through `task_create`.** `buildTaskInput` hardcodes `dependencies: []` (`task-tools.ts:151`) and neither task tool exposes the field. Documenting one would recreate this ticket's defect in a new form — so the example points at `TaskUpdate({ addBlockedBy: [...] })`, per *What → Native Tasks; How → MoFlo orchestration*.
- **Mirror live task state into memory.** The coordinator owns it; `task_status` / `task_list` read it.

## Rolled in — same class, not split into follow-ups

Every one of these is "a documented call that cannot work as written":

| Where | Was | Is |
|---|---|---|
| planner, researcher, tester, coder, reviewer | `namespace: "coordination"` | `patterns` — the dead namespace was named by **five** personas while each one's own "Operating context" header, six lines above, listed the real ones |
| `researcher.md` | `memory_search { pattern: "swarm/shared/research-*" }` | `query:` — `memory_search` requires `query` and has no `pattern` |
| `reviewer.md` | `aidefence_scan { content: … }` | `input:` — and it is *required* |
| `coder.md`, `tester.md` | `performance_benchmark { type: "code" }` | `suite:` — an enum of all\|memory\|neural\|swarm\|io |

The last three were found **by the new guard, not by reading.** Shared-findings blobs also moved to prose in `value` with structure in `metadata`, since `value` is what gets embedded and a JSON blob retrieves badly.

## The guard

`tests/guards/agent-persona-mcp-examples-1330.test.ts` checks every documented `mcp__moflo__*` call across all 16 personas against the **live** tool registry (`listMCPTools()`) — not a copied schema, which would rot exactly the way the example did:

- the tool exists; every argument passed is in its schema; every required argument is supplied
- each persona names only namespaces its **own header declares** — an invariant derived from the file, so there is no hardcoded list to maintain
- planner-specific: submits before polling, never polls a literal ID, keeps `memory_store` out of the dispatch path, and does not imply a `dependencies` field the schema lacks

Note the registry is keyed by **bare** name (`memory_store`); the `mcp__moflo__` prefix is what the server prepends. A non-vacuity test asserts the parser actually finds calls, so a regex that matches nothing can't pass as a clean bill of health.

## Rule #2 — consumer blast radius

`.claude/agents/**` ships to every consumer via `flo init`, so this is the example everyone copies — which is why it is now pinned rather than merely corrected. **No behaviour change:** `git diff main...HEAD -- src/` is empty; the whole change is 5 persona docs and 1 test. No migration, no round-trip — docs land on the consumer's next `flo init` / sync.

## Verification

- **Ran the rewritten example.** `task_orchestrate` with the four documented task definitions verbatim → `submitted: 4, assigned: 4, queued: 0, rejected: 0` with real coordinator IDs; `task_status` with one of those returned IDs resolved to the assigned research task; `task_list { status: "running,queued" }` listed them. The four probe tasks were cancelled afterwards.
- **AC4 proven by the diff**, not asserted: 0 lines under `src/cli/mcp-tools/`, 0 under `src/` at all.
- **Mutation-checked:** stashing the doc changes fails 11 of 24 tests, covering every acceptance criterion.
- Full suite **10096 passed / 0 failed**, lint clean.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
