### PR TITLE
fix(doctor): stop the swarm probe accumulating agent and task rows (#1370)

### DIFF
--- a/src/cli/__tests__/swarm/ephemeral-probe-persistence-1370.test.ts
+++ b/src/cli/__tests__/swarm/ephemeral-probe-persistence-1370.test.ts
@@ -1,0 +1,138 @@
+/**
+ * A health probe must not accumulate state (#1370).
+ *
+ * `flo doctor`'s swarm check spawns a real agent and submits a real task to
+ * prove the coordinator path is wired (the #798 tripwire). Both were persisted:
+ * #1329 made task state durable, and agent rows have been durable since #806.
+ * Nothing removed them, so every doctor run grew the store — and once 15 agent
+ * rows had piled up, the coordinator's cap rejected the probe spawn and the
+ * check failed on every subsequent run. A health check that breaks itself by
+ * being used is worse than no health check.
+ *
+ * The fix is "never write it", not "write then delete it". Persistence writes
+ * resolve on hand-off to the daemon rather than on commit, so a delete issued
+ * after a spawn/submit cannot be ordered against it — verified the hard way:
+ * a delete-after-write version still left rows behind on every run.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createUnifiedSwarmCoordinator } from '../../swarm/unified-coordinator.js';
+import type { SwarmPersistence } from '../../swarm/swarm-persistence.js';
+
+/** Records what the coordinator asked the store to do. */
+function recordingPersistence() {
+  const persistedTasks: string[] = [];
+  const persistedAgents: string[] = [];
+  const removedAgents: string[] = [];
+  return {
+    calls: { persistedTasks, persistedAgents, removedAgents },
+    fake: {
+      persistTask: async (task: { id: { id: string } }) => { persistedTasks.push(task.id.id); },
+      persistAgent: async (agent: { id: { id: string } }) => { persistedAgents.push(agent.id.id); },
+      removeAgent: async (agentId: string) => { removedAgents.push(agentId); },
+      loadTasks: async () => [],
+      loadAgents: async () => [],
+      loadTopology: async () => undefined,
+      persistTopology: async () => {},
+      loadConsensusHistory: async () => [],
+      persistConsensus: async () => {},
+    } as unknown as SwarmPersistence,
+  };
+}
+
+/** Let the microtask-scheduled persist flush run. */
+const settle = () => new Promise<void>((r) => setTimeout(r, 10));
+
+let coordinator: ReturnType<typeof createUnifiedSwarmCoordinator>;
+let store: ReturnType<typeof recordingPersistence>;
+
+beforeEach(async () => {
+  coordinator = createUnifiedSwarmCoordinator();
+  await coordinator.initialize();
+  store = recordingPersistence();
+  coordinator.attachPersistence(store.fake);
+});
+
+describe('ephemeral tasks are never written to the store', () => {
+  it('persists an ordinary task', async () => {
+    const id = await coordinator.submitTask({
+      type: 'coding', name: 't', description: 'real work',
+      priority: 'normal', dependencies: [], input: null,
+      timeoutMs: 1000, retries: 0, maxRetries: 1, metadata: {},
+    });
+    await settle();
+    expect(store.calls.persistedTasks).toContain(id);
+  });
+
+  it('does not persist one marked ephemeral', async () => {
+    const id = await coordinator.submitTask({
+      type: 'coding', name: 't', description: 'doctor-functional-probe',
+      priority: 'normal', dependencies: [], input: null,
+      timeoutMs: 1000, retries: 0, maxRetries: 1,
+      metadata: { ephemeral: true },
+    });
+    await settle();
+    expect(store.calls.persistedTasks).not.toContain(id);
+  });
+
+  it('stays out of the store across its whole lifecycle, not just at submit', async () => {
+    // The leak was a row left mid-lifecycle: submit wrote it, and the completion
+    // that would have made it terminal never landed. Every transition must be
+    // silent, or the row reappears in exactly the state the retention trim
+    // refuses to reclaim.
+    const id = await coordinator.submitTask({
+      type: 'coding', name: 't', description: 'doctor-functional-probe',
+      priority: 'normal', dependencies: [], input: null,
+      timeoutMs: 1000, retries: 0, maxRetries: 1,
+      metadata: { ephemeral: true },
+    });
+    await coordinator.completeTask(id, { ok: true });
+    await settle();
+    expect(store.calls.persistedTasks).toEqual([]);
+  });
+});
+
+describe('ephemeral agents are never written to the store', () => {
+  it('persists an ordinary agent', async () => {
+    const { agentId } = await coordinator.spawnAgent({ id: 'agent-real-1', type: 'coder' });
+    await settle();
+    expect(store.calls.persistedAgents).toContain(agentId);
+  });
+
+  it('does not persist one spawned with ephemeral metadata', async () => {
+    const { agentId } = await coordinator.spawnAgent({
+      id: 'agent-probe-1', type: 'coder', metadata: { ephemeral: true },
+    });
+    await settle();
+    expect(store.calls.persistedAgents).not.toContain(agentId);
+  });
+
+  it('leaves nothing behind over spawn → terminate, the doctor probe cycle', async () => {
+    const { agentId } = await coordinator.spawnAgent({
+      id: 'agent-probe-2', type: 'coder', metadata: { ephemeral: true },
+    });
+    await coordinator.terminateAgent(agentId, { force: true, reason: 'test' });
+    await settle();
+    expect(store.calls.persistedAgents).toEqual([]);
+  });
+
+  it('repeated probe cycles never grow the store — the cap failure', async () => {
+    // 20 cycles is past the 15-agent cap that took the check down.
+    for (let i = 0; i < 20; i++) {
+      const { agentId } = await coordinator.spawnAgent({
+        id: `agent-probe-loop-${i}`, type: 'coder', metadata: { ephemeral: true },
+      });
+      const taskId = await coordinator.submitTask({
+        type: 'coding', name: 't', description: 'doctor-functional-probe',
+        priority: 'normal', dependencies: [], input: null,
+        timeoutMs: 1000, retries: 0, maxRetries: 1,
+        metadata: { ephemeral: true },
+      });
+      await coordinator.completeTask(taskId, { ok: true });
+      await coordinator.terminateAgent(agentId, { force: true, reason: 'test' });
+      await settle();
+    }
+    expect(store.calls.persistedAgents).toEqual([]);
+    expect(store.calls.persistedTasks).toEqual([]);
+  });
+});

--- a/src/cli/commands/doctor-checks-swarm.ts
+++ b/src/cli/commands/doctor-checks-swarm.ts
@@ -83,7 +83,13 @@ export async function checkSwarmFunctional(): Promise<FunctionalHealthCheck> {
   });
 
   // 2. agent_spawn registers an agent on the live coordinator.
-  const spawnOut = (await safeInvoke(agentTools, 'agent_spawn', { agentType: 'coder' }, details, {
+  // #1370 — `ephemeral` keeps the probe agent out of the store. Without it the
+  // spawn wrote a row every run and the terminate below could not reliably
+  // delete it, so the rows piled up until the coordinator's agent cap was
+  // reached and this very check started failing on every subsequent run.
+  const spawnOut = (await safeInvoke(agentTools, 'agent_spawn', {
+    agentType: 'coder', config: { ephemeral: true },
+  }, details, {
     id: 'agent_spawn.coordinator-backed',
     mcpTool: 'agent_spawn',
     expected: 'success=true with an agentId issued by coordinator.spawnAgent (not a JSON-store write)',
@@ -166,7 +172,12 @@ export async function checkSwarmFunctional(): Promise<FunctionalHealthCheck> {
 
   // 7. task_create round-trips through coordinator.submitTask.
   const taskOut = (await safeInvoke(taskTools, 'task_create', {
-    type: 'coding', description: 'doctor-functional-probe',
+    type: 'coding',
+    description: 'doctor-functional-probe',
+    // #1370 — health-check exhaust, not work: the coordinator must exercise the
+    // full submit/assign/complete path without leaving a durable row behind.
+    metadata: { ephemeral: true },
+    // (the probe agent opts out the same way, via agent_spawn's `config`)
   }, details, {
     id: 'task_create.coordinator-submit',
     mcpTool: 'task_create',

--- a/src/cli/swarm/unified-coordinator.ts
+++ b/src/cli/swarm/unified-coordinator.ts
@@ -183,6 +183,8 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
   private persistence?: SwarmPersistence;
   private topologyPersistScheduled = false;
   private taskPersistScheduled = false;
+  /** Agents that must never be written to the store — see `spawnAgent` (#1370). */
+  private ephemeralAgents = new Set<string>();
   /** Tasks mutated since the last flush. Keeps a flush O(changed), not O(all). */
   private dirtyTasks: Set<string> = new Set();
 
@@ -975,12 +977,14 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
 
   private async syncAgentToPersistence(agentId: string): Promise<void> {
     if (!this.persistence) return;
+    if (this.ephemeralAgents.has(agentId)) return;
     const agent = this.state.agents.get(agentId);
     if (!agent) return;
     await this.persistence.persistAgent(agent, this.agentDomainMap.get(agentId));
   }
 
   private async removeAgentFromPersistence(agentId: string): Promise<void> {
+    this.ephemeralAgents.delete(agentId);
     if (!this.persistence) return;
     await this.persistence.removeAgent(agentId);
   }
@@ -1014,6 +1018,16 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
    */
   private scheduleTaskPersist(taskId: string): void {
     if (!this.persistence) return;
+    // #1370 — an EPHEMERAL task is never durable. `flo doctor`'s swarm check
+    // submits a real task to prove `task_create` round-trips, and since #1329
+    // made task state durable that probe wrote a row on every run.
+    //
+    // Deliberately "never write it" rather than "write then delete it": the
+    // write is asynchronous past the promise the coordinator awaits (memory
+    // writes route through the daemon), so a delete issued after it can still
+    // lose the race and leave the row behind — observed, repeatedly, before
+    // this. Not persisting has no race to lose.
+    if (this.state.tasks.get(taskId)?.metadata?.ephemeral === true) return;
     this.dirtyTasks.add(taskId);
     if (this.taskPersistScheduled) return;
     this.taskPersistScheduled = true;
@@ -1913,6 +1927,19 @@ export class UnifiedSwarmCoordinator extends EventEmitter implements IUnifiedSwa
       topologyRole: options.type === 'queen' ? 'queen' : 'worker',
       connections: [],
     };
+
+    // #1370 — an agent marked `ephemeral` is never written to the store.
+    // `flo doctor` spawns a probe agent per run and terminates it, but the
+    // spawn's write is fire-and-forget and resolves on hand-off to the daemon
+    // rather than on commit, so the terminate's delete could not reliably beat
+    // it. A row was left every run until the agent cap was reached and the
+    // swarm check failed for good. Not writing has no race to lose.
+    //
+    // Marked BEFORE registering, since registration is what schedules the write
+    // (the MCP spawn surface always supplies a pre-generated id).
+    if (options.metadata?.ephemeral === true && options.id) {
+      this.ephemeralAgents.add(options.id);
+    }
 
     // Determine domain and agent number
     let domain: AgentDomain;


### PR DESCRIPTION
Closes #1370

## What was wrong

`flo doctor`'s swarm check spawns a real agent and submits a real task to prove the coordinator path is wired (the #798 stub tripwire). Both got persisted — task state since #1329, agent rows since #806 — and nothing removed them. Every doctor run grew the store. Observed here after a day of normal use: **33 task rows and 15 agent rows**, essentially all probes.

**The agent half is the serious one.** At 15 rows the coordinator's cap rejected the probe spawn, so the check failed on every subsequent run:

```
CHECK: Swarm Functional -> fail | 4/10 subcheck(s) failed
  (e.g. agent_spawn: "Maximum agents (15) reached")
```

A health check that breaks itself by being used. Agent persistence is **released**, so consumers can already be sitting at the cap; the task half arrived with #1329 and is still unpublished.

## The fix

Both probes are marked `ephemeral` and are never written to the store.

**"Never write it" rather than "write then delete it"** — which is what I tried first. Persistence writes resolve on hand-off to the daemon rather than on commit, so a delete issued after a spawn/submit cannot be ordered against the write. Two delete-after-write versions — one awaiting the in-flight task flush, one tracking the spawn write per agent — **both still left a row on every run**, measured by rerunning the check and counting. Not persisting has no race to lose, and it deletes code instead of adding a cleanup path.

The probes opt in through argument shapes that already existed: `metadata` on `task_create`, `config` on `agent_spawn` (which the handler folds into agent metadata). No new tool arguments, no new persistence API, no migration.

## Protected surface (CLAUDE.md ⛔)

This touches `unified-coordinator.ts` and the swarm doctor check, so the wiring invariants were held explicitly: the probes still flow through `coordinator.spawnAgent` / `submitTask` / `completeTask` / `terminateAgent`, and the check still reports **9 subchecks OK** covering `agent_spawn.coordinator-backed`, `task_create.coordinator-submit`, `task_complete.coordinator-state` and `agent_terminate.coordinator-removes`. Only the probes' *durability* changed — nothing was disconnected or stubbed. Two control tests assert ordinary tasks and agents still persist, so the suite cannot pass by disabling persistence outright.

## Verification (dogfooding)

Verified against the **local build**, not `npx flo` — the installed copy has neither fix. Reading through its long-lived MCP server was actively misleading: its hydrated in-memory coordinator shows a stale view that made one early measurement look like the fix had failed.

| | before | after |
|---|---|---|
| `swarm-agents` over 4 runs | 5 → 6 → 7 → 8 | 8 → 8 → 8 → 8 |
| `swarm-tasks` over 4 runs | grew every run | 4 → 4 → 4 → 4 |
| check status | fail at the cap | 9 subchecks OK |

- 7 unit tests; **5 fail against the pre-fix coordinator**, the 2 that pass being the "ordinary state still persists" controls.
- Full suite **10103 passed / 0 failed**, lint and `tsc` clean.

## Follow-up, not silently dropped

The ticket's "sweep pre-existing rows" criterion is **not** implemented. I built it, then removed it as over-engineering: no consumer can hold a task backlog (#1329 unpublished), and an automatic sweep of persisted *agent* rows is unsafe because a hydrated row is indistinguishable from a live agent. The 15 accumulated dogfood rows were cleared by hand. **A consumer already at the 15-agent cap still needs a manual clear** — worth a `doctor --fix` prune in its own change, where the destructive step can be user-invoked.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
