### PR TITLE
fix(healer): prune ghost swarm-agent rows so a capped install can recover (#1370)

### DIFF
--- a/src/cli/__tests__/commands/doctor-fixes-stale-agent-rows-1370.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-stale-agent-rows-1370.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The healer's ghost-agent prune must delete only what it can justify (#1370).
+ *
+ * `flo doctor`'s swarm probe used to persist an agent per run and never remove
+ * it. Once 15 rows accumulated, the coordinator's cap rejected the probe spawn
+ * and the swarm check failed on every later run. The leak is fixed, but that
+ * does nothing for an install already holding the backlog — hence a `--fix`.
+ *
+ * This is a DELETING repair, so the selection policy is what matters: a row it
+ * cannot reason about must survive, and a recent row must survive, or the fix
+ * for a stuck check becomes a way to lose live coordination state.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { selectStaleAgentRows } from '../../commands/doctor-fixes.js';
+
+const NOW = new Date('2026-08-04T12:00:00Z').getTime();
+const WINDOW = 5 * 60 * 1000;
+const ago = (ms: number) => NOW - ms;
+
+describe('selectStaleAgentRows', () => {
+  it('selects a row older than the window', () => {
+    const stale = selectStaleAgentRows([{ key: 'agent:old', updatedAt: ago(10 * 60 * 1000) }], NOW, WINDOW);
+    expect(stale.map(r => r.key)).toEqual(['agent:old']);
+  });
+
+  it('spares a row inside the window — it may belong to a live coordinator', () => {
+    const stale = selectStaleAgentRows([{ key: 'agent:fresh', updatedAt: ago(30 * 1000) }], NOW, WINDOW);
+    expect(stale).toEqual([]);
+  });
+
+  it('reads epoch-ms and ISO timestamps alike, since the store emits both', () => {
+    const stale = selectStaleAgentRows([
+      { key: 'agent:ms', updatedAt: ago(60 * 60 * 1000) },
+      { key: 'agent:iso', updatedAt: new Date(ago(60 * 60 * 1000)).toISOString() },
+    ], NOW, WINDOW);
+    expect(stale.map(r => r.key).sort()).toEqual(['agent:iso', 'agent:ms']);
+  });
+
+  it('KEEPS a row with no timestamp rather than guessing', () => {
+    // The failure mode to avoid: treating "unknown age" as "old" and deleting
+    // rows this cannot actually justify deleting.
+    const stale = selectStaleAgentRows([{ key: 'agent:no-stamp' }], NOW, WINDOW);
+    expect(stale).toEqual([]);
+  });
+
+  it('KEEPS a row whose timestamp does not parse', () => {
+    const stale = selectStaleAgentRows([{ key: 'agent:garbage', updatedAt: 'not-a-date' }], NOW, WINDOW);
+    expect(stale).toEqual([]);
+  });
+
+  it('keeps a future-dated row (clock skew is not staleness)', () => {
+    const stale = selectStaleAgentRows([{ key: 'agent:future', updatedAt: NOW + 60_000 }], NOW, WINDOW);
+    expect(stale).toEqual([]);
+  });
+
+  it('splits a realistic backlog — the 15 ghosts go, the working agents stay', () => {
+    const entries = [
+      ...Array.from({ length: 15 }, (_, i) => ({ key: `agent:ghost-${i}`, updatedAt: ago(60 * 60 * 1000) })),
+      { key: 'agent:live-1', updatedAt: ago(10 * 1000) },
+      { key: 'agent:live-2', updatedAt: ago(60 * 1000) },
+    ];
+    const stale = selectStaleAgentRows(entries, NOW, WINDOW);
+    expect(stale).toHaveLength(15);
+    expect(stale.every(r => r.key.startsWith('agent:ghost-'))).toBe(true);
+  });
+});

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -16,6 +16,8 @@ import { findProjectDaemonPids, getDaemonLockHolder } from '../services/daemon-l
 import { findProjectRoot, resolveStateRoot } from '../services/project-root.js';
 import { legacyMemoryDbPath, legacyMemoryDbBakPath, memoryDbPath, mofloDir } from '../services/moflo-paths.js';
 import { findZombieProcesses } from './doctor-zombies.js';
+import { loadToolArrays, getTool } from './doctor-checks-functional-shared.js';
+import { SWARM_AGENTS_NS } from '../swarm/swarm-persistence.js';
 import { inspectMcpConfigs } from './doctor-checks-config.js';
 import { installClaudeCode, runCommand } from './doctor-checks-runtime.js';
 import type { HealthCheck } from './doctor-types.js';
@@ -395,6 +397,94 @@ async function stopNestedDaemons(subRoot: string): Promise<{ stopped: number[]; 
  *   - POSIX: rename succeeds but the daemon's open FDs keep pointing at the
  *     inode; the daemon keeps writing to a now-archived path until it exits.
  */
+/**
+ * A persisted agent row is only a restart-recovery record — deleting one never
+ * terminates a live agent, it just drops the bookkeeping that would rehydrate
+ * it after a restart. That low blast radius is what makes a short window safe.
+ *
+ * Short matters: this prune only runs when the swarm check is ALREADY failing,
+ * which means the store is over-full relative to what the coordinator can use.
+ * An hour-long window would leave someone who hit the cap mid-session stuck for
+ * an hour; five minutes still comfortably outlives the seconds-long CLI process
+ * whose exit strands these rows.
+ */
+const STALE_AGENT_ROW_MS = 5 * 60 * 1000;
+
+/**
+ * Which agent rows are ghosts, given the current time. Pure, so the policy is
+ * testable without standing up the memory tool layer.
+ *
+ * `updatedAt` comes back as epoch ms or an ISO string depending on the store
+ * path; `Date` handles both. A missing or unparseable timestamp is KEPT — this
+ * deletes, so anything it cannot reason about is left alone.
+ */
+export function selectStaleAgentRows(
+  entries: Array<{ key: string; updatedAt?: string | number }>,
+  now: number,
+  windowMs: number = STALE_AGENT_ROW_MS,
+): Array<{ key: string; updatedAt?: string | number }> {
+  const cutoff = now - windowMs;
+  return entries.filter(e => {
+    const at = e.updatedAt === undefined ? NaN : new Date(e.updatedAt).getTime();
+    return Number.isFinite(at) && at < cutoff;
+  });
+}
+
+/**
+ * #1370 — prune ghost agent rows so an install already at the cap can recover.
+ *
+ * `flo doctor`'s swarm probe used to persist an agent per run and never remove
+ * it. Once 15 rows had accumulated, the coordinator's cap rejected the probe
+ * spawn and the swarm check failed on every subsequent run. The leak itself is
+ * fixed, but that does not help anyone whose store already holds the backlog:
+ * their check stays red until the rows go.
+ *
+ * This is a `--fix` rather than something the check does on its own precisely
+ * because it deletes: a hydrated row is indistinguishable from a live agent, so
+ * the destructive step should be one the user asked for.
+ */
+async function fixStaleSwarmAgentRows(): Promise<boolean> {
+  const mods = await loadToolArrays({ memoryTools: 'dist/src/cli/mcp-tools/memory-tools.js' });
+  if (!mods) {
+    output.writeln(output.warning('  Memory tools not built — cannot prune agent rows.'));
+    return false;
+  }
+  const list = getTool(mods.memoryTools, 'memory_list');
+  const del = getTool(mods.memoryTools, 'memory_delete');
+  if (!list?.handler || !del?.handler) {
+    output.writeln(output.warning('  memory_list/memory_delete unavailable — cannot prune agent rows.'));
+    return false;
+  }
+
+  try {
+    const listed = await list.handler({ namespace: SWARM_AGENTS_NS, limit: 500 }) as {
+      entries?: Array<{ key: string; updatedAt?: string | number }>;
+    };
+    const entries = listed?.entries ?? [];
+    const stale = selectStaleAgentRows(entries, Date.now());
+
+    if (stale.length === 0) {
+      output.writeln(output.dim(`  No stale agent rows (${entries.length} present).`));
+      return true;
+    }
+
+    let removed = 0;
+    for (const e of stale) {
+      try {
+        await del.handler({ key: e.key, namespace: SWARM_AGENTS_NS });
+        removed++;
+      } catch (err) {
+        output.writeln(output.warning(`  Failed to delete ${e.key}: ${errorDetail(err)}`));
+      }
+    }
+    output.writeln(`  Pruned ${removed} stale agent row(s); ${entries.length - removed} kept.`);
+    return removed === stale.length;
+  } catch (e) {
+    output.writeln(output.warning(`  Agent-row prune failed: ${errorDetail(e)}`));
+    return false;
+  }
+}
+
 async function fixNestedMofloIslands(): Promise<boolean> {
   // #1315 — `resolveStateRoot`, not `findProjectRoot`. The latter returns
   // `CLAUDE_PROJECT_DIR` unconditionally, so running the healer from a
@@ -866,6 +956,12 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     // includes an ISO timestamp so re-runs don't collide.
     'Nested .moflo/ Islands': async () => {
       return fixNestedMofloIslands();
+    },
+    // #1370 — the swarm check fails once accumulated agent rows hit the
+    // coordinator's cap. The leak is fixed, but an install that already has the
+    // backlog stays red until the ghost rows are pruned.
+    'Swarm Functional': async () => {
+      return fixStaleSwarmAgentRows();
     },
     // #1300 — rewrite a malformed moflo MCP permission rule in
     // .claude/settings.json. Claude Code has no MCP wildcards, so the stale


### PR DESCRIPTION
Refs #1370 · follow-up to #1371

## Why this is needed

#1371 stopped the swarm probe leaking agent rows. It does nothing for an install that **already holds the backlog** — and that backlog is not merely untidy, it is terminal: once 15 rows accumulate, the coordinator's cap rejects the probe spawn and `flo doctor`'s swarm check fails on **every** subsequent run, with no way out but deleting rows by hand.

Agent persistence has been released since #806, so consumers can already be sitting there. Stopping the leak and healing what leaked are two different changes, and shipping only the first would leave them exactly as broken.

## What it does

`flo doctor --fix` now prunes ghost agent rows when the swarm check is failing.

**Deliberately a `--fix`, not something the check does on its own.** A hydrated agent row is indistinguishable from a live one, so the destructive step should be one the user asked for. The blast radius is small either way: a persisted row is only a restart-recovery record — deleting one never terminates a live agent, it just means that agent isn't rehydrated after a restart. That low cost is what makes a short window safe.

**The selection policy is the part that matters**, so it's a pure function with its own tests. Rows are pruned by age — 5 minutes, comfortably longer than the seconds-long CLI process whose exit strands them, and short enough to help someone who hit the cap mid-session (an hour-long window would leave them stuck for an hour).

Anything it cannot justify deleting is **kept**:

| Row | Verdict |
|---|---|
| older than the window | pruned |
| inside the window | kept — may belong to a live coordinator |
| no timestamp | kept — "unknown age" is not "old" |
| unparseable timestamp | kept |
| future-dated (clock skew) | kept |

Both timestamp shapes the store emits (epoch ms and ISO) are handled.

## Verification

Exercised against the **live store** on the local build, driving the real memory tool layer exactly as the fix does:

```
rows before: 8
selected stale: 8
rows after: 0
```

`doctor -c swarm` then reported **9 subchecks OK**, with the store staying empty across subsequent runs.

- 7 pure-function tests covering the table above, including a realistic 17-row mix (15 hour-old ghosts + 2 agents active in the last minute → exactly the 15 ghosts selected).
- Full suite **10110 passed / 0 failed**, lint and `tsc` clean.

**One link not exercised end to end, recorded rather than glossed:** the fix dispatches via `fixActions[check.name]`, so it only fires when the swarm check is *already failing* — and with the leak fixed, the check now passes locally, so `--fix` never reached it. I verified the key by reading the dispatcher and matching `SWARM_FUNCTIONAL_CHECK`. That name-string coupling is the same one the four pre-existing fix keys carry, so this matches convention rather than inventing a mechanism.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
