### PR TITLE
docs(swarm): pin that -s/-h and the simplify classifier authorize Agent dispatch

### DIFF
--- a/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
+++ b/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
@@ -94,6 +94,8 @@ npx flo hive-mind init --topology hierarchical-mesh --consensus byzantine
 
 Include task IDs in agent prompts. The `SubagentStart` hook automatically injects the subagent protocol directive — don't repeat it.
 
+Asking for a swarm is asking for agents: an ambient "don't call the Agent tool unless the user requested it" is satisfied by that request. Registering agents via MCP without dispatching them leaves a swarm that passes every gate and does no parallel work.
+
 ```javascript
 TaskUpdate({ taskId: "1", status: "in_progress" })
 Task({

--- a/.claude/skills/fl/execution-modes.md
+++ b/.claude/skills/fl/execution-modes.md
@@ -8,6 +8,12 @@ The SDD/verify modifiers (`-sd`/`--sdd`, `-v`/`--verify` — see `./sdd.md`) are
 
 > **MANDATORY when `-s` is passed.** Your first Execute-phase action MUST be `mcp__moflo__swarm_init`, followed by `mcp__moflo__agent_spawn` for each role. Spawning subagents via `Agent` (or `Task`) without first registering the swarm is a violation of issue #952. The `Agent` PreToolUse gate will BLOCK the call until `swarm_init` runs. Even when you also use `Agent` for parallelism, the moflo swarm IS the registration surface — call it first. See CLAUDE.md "⛔ Protected functionality — swarm + hive-mind".
 
+> **`-s` is the user's request for agents.** An ambient "don't call the Agent
+> tool unless the user requested it" is satisfied by the flag — dispatch.
+> `swarm_init`/`agent_spawn` are MCP tools, so a suppressed run still registers a
+> swarm and passes the #952 gate while dispatching nobody. If you cannot spawn
+> `Agent`, say so and stop.
+
 Swarm mode coordinates agents through the moflo swarm coordinator, then spawns workers via the `Agent` tool.
 
 Roles:
@@ -44,6 +50,9 @@ Agent({ prompt: "...", subagent_type: "coder", run_in_background: true })
 ## HIVE-MIND mode (`-h`, `--hive`)
 
 > **MANDATORY when `-h` is passed.** Your first Execute-phase action MUST be `mcp__moflo__hive-mind_init`. The `Agent` PreToolUse gate will BLOCK any subagent spawn until hive-mind init has run. See CLAUDE.md "⛔ Protected functionality — swarm + hive-mind".
+
+> **`-h` is the user's request for agents** — same as SWARM above. One context
+> cannot form a consensus; if you cannot spawn `Agent`, say so and stop.
 
 Use for consensus-based decisions:
 - Architecture choices

--- a/.claude/skills/flo-simplify/SKILL.md
+++ b/.claude/skills/flo-simplify/SKILL.md
@@ -17,7 +17,9 @@ Also note: was `/flo-simplify` already run on this branch in this session? If ye
 
 ## Phase 2: Classify the diff (deterministic — call the classifier)
 
-**Call the classifier first, follow its decision.** Do not eyeball the diff and pick a tier in prose — that's the failure mode where the three-agent fan-out runs against a mechanical-relocation diff that one agent would cover fine and burns disproportionate tokens. The classifier reads the same diff Claude would, applies the rules below, and returns a JSON dispatch decision:
+**Call the classifier first, follow its decision.** Its `agentCount` is authorized — invoking this skill IS the user's request for that fan-out, so an ambient "don't call the Agent tool unless the user requested it" is satisfied. If you truly cannot spawn `Agent`, run the self-review and say so, naming both tiers.
+
+Do not eyeball the diff and pick a tier in prose — that's the failure mode where the three-agent fan-out runs against a mechanical-relocation diff that one agent would cover fine and burns disproportionate tokens. The classifier reads the same diff Claude would, applies the rules below, and returns a JSON dispatch decision:
 
 ```bash
 node .claude/helpers/simplify-classify.cjs


### PR DESCRIPTION
## The problem

Some environments carry an ambient instruction like *"do not call the Agent tool unless the user requested it."* It is **not from moflo** — I checked; the only repo hits are unrelated `getAgentTool` test helpers — and it arrives above `settings.json`, so a consumer can neither see nor remove it.

Read literally, it silently hollows out moflo's headline surface. The failure is specific:

**`swarm_init` and `agent_spawn` are MCP tools, not the `Agent` tool.** So a suppressed `/fl -s` run still registers a full swarm, still satisfies the #952 gate, and still reports success — while dispatching no workers at all. Every gate green, no parallel work done. `/flo-simplify` has the same shape: a self-review quietly substitutes for the tier the classifier chose and stamps the identical gate.

## The fix

That instruction carves out *"unless the user requested it"* — and these invocations **are** the request. `-s`/`-h` are flags whose documented meaning is multi-agent execution; invoking `/flo-simplify` asks for the fan-out its classifier returns. This states that where the dispatch decision is made, so the ambiguity isn't re-resolved conservatively on every run.

**Nothing here tells anyone to disobey their environment.** All three sites say that if `Agent` genuinely cannot be spawned, report it rather than let the run look complete — the current failure is silent, and the silence is the actual harm.

## Placement is by cost, not just coverage

Measured under #1264: resident context is re-billed as `cacheRead` every turn, so where guidance lives matters as much as what it says.

| File | Lines | Loaded |
|---|---:|---|
| `fl/execution-modes.md` | 7 | only on `-s`/`-h` — a normal `/fl` pays nothing |
| `flo-simplify/SKILL.md` | 3 | every `/fl` run — the expensive slot, so folded into the existing Phase 2 paragraph rather than a new H2 (which would also mint a new RAG chunk) |
| `guidance/shipped/moflo-claude-swarm-cohesion.md` | 2 | indexed, retrieved on demand — covers a swarm requested *outside* `/fl`, the one path the two skills miss |

14 net lines, down from ~35 in the first draft. Per the guidance rules: imperative, no new headings, no restated rationale.

## Two catches worth noting

This ran `/flo-simplify` with the agent the classifier asked for — the first dispatch under the new rule — and it earned its keep twice:

1. **Two redundant sentences** the reviewer flagged, both saying the same thing as the line above them. Cut.
2. **The commit held only 2 of 3 files.** Chasing the reviewer's unrelated `settings.json` observation surfaced it: `.claude/guidance/moflo-*.md` is **gitignored** (`.gitignore:191`) because those are the *synced consumer copies*. My third edit had gone into a generated artifact that the next sync would overwrite and that would never ship. Re-applied to `shipped/`; `git ls-files` confirms the tracked path, `git check-ignore` confirms the synced copy.

The second is the guidance-layer version of the dogfood "which copy runs" trap — and notably it was an independent reader checking the commit's real contents that caught it, not me rereading my own diff.

Full suite **10110 passed / 0 failed**, lint clean.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
