### PR TITLE
fix(gates): report the task list moflo told you to open (#1374)

### DIFF
--- a/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
+++ b/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
@@ -119,6 +119,8 @@ TaskList()  // Shows what's now unblocked
 TaskUpdate({ taskId: "2", status: "in_progress" })  // Next agent starts
 ```
 
+Close every task you open. moflo's PR gate reads the session transcript on `gh pr create` and prints `N tasks created this session, M still open` (#1374) — an unclosed list reports as unfinished work on the PR. Mark tasks that no longer apply `status: "deleted"`; that closes the loop exactly like `completed`.
+
 ---
 
 ## Coordinator Responsibilities

--- a/.claude/helpers/gate-hook.mjs
+++ b/.claude/helpers/gate-hook.mjs
@@ -32,6 +32,15 @@ if (hookContext.tool_name) env.TOOL_NAME = hookContext.tool_name;
 if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
   env.HOOK_SESSION_ID = hookContext.session_id;
 }
+// #1374 — forward the transcript path so a gate can read what the session
+// actually DID, not only what workflow-state.json was told about it. Used by
+// check-before-pr to count TaskCreate calls against terminal TaskUpdate calls;
+// the alternative — a `^TaskUpdate$` PostToolUse observer — is the wiring #1331
+// removed as pure hot-path overhead, and the transcript already holds the answer.
+// Absent on hosts that don't send it: gates treat that as "unknown" and stay silent.
+if (typeof hookContext.transcript_path === 'string' && hookContext.transcript_path) {
+  env.HOOK_TRANSCRIPT_PATH = hookContext.transcript_path;
+}
 // #1332: structured tool inputs are forwarded as JSON, not dropped.
 //
 // This previously forwarded ONLY string values, so any object-valued input was

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -1039,6 +1039,120 @@ function getChangedFilesVsBase() {
   } catch (e) { return null; }
 }
 
+// #1374 — the missing half of the TaskCreate reminder.
+//
+// moflo nags you to OPEN a task list (check-before-agent) and then never looks
+// again: `taskCount` only counts up, so a run that creates four tasks and closes
+// none satisfies every gate. That is the exact shape of an abandoned list.
+//
+// The ledger is read from the session TRANSCRIPT, and both alternatives were
+// rejected on evidence rather than taste:
+//
+//   - A `^TaskUpdate$` PostToolUse observer feeding a counter is the wiring
+//     #1331 removed as pure hot-path overhead. It would also have to survive
+//     applyPromptStateReset, whereas a transcript read holds no state to reset.
+//   - Claude Code's own task store (`~/.claude/tasks/session-<id>/`) is ground
+//     truth but unreachable: measured on v2.1.220, the id keying that directory
+//     does NOT rotate on `/clear`, so a session whose transcript is <A> writes
+//     its tasks under the pre-clear id <B> — and <A> is what the bridge forwards
+//     as HOOK_SESSION_ID. There is no path from the hook environment to the dir.
+//
+// Cost lands only where it is already justified: the sole caller runs after
+// check-before-pr's `gh pr create` match, i.e. once per PR attempt, never on the
+// per-tool path.
+//
+// Returns null when the transcript is missing, oversized, unreadable, or records
+// no TaskCreate at all — the caller then stays silent rather than guessing.
+// Sized against measurement, not a round number: a 3.4MB transcript (the largest
+// in a week of local sessions) costs ~55ms to scan, so ~16ms/MB. 16MB is ~4x the
+// worst observed session and lands near 260ms — a chunk of the hook's 2000ms
+// budget, but a bounded one. Past the cap the ledger goes silent rather than
+// risking the timeout, since a hook that times out is worse than one that
+// declines to comment. Unrelated to `TRANSCRIPT_TAIL_BYTES` in bin/lib/meditate.mjs
+// despite the similar name — that one truncates to a tail window, which cannot
+// work here (a TaskCreate from early in the session falls outside any tail).
+var TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024;
+function readTaskLedger() {
+  var tp = process.env.HOOK_TRANSCRIPT_PATH || '';
+  if (!tp) return null;
+  var raw;
+  try {
+    var st = fs.statSync(tp);
+    if (!st.isFile() || st.size > TRANSCRIPT_MAX_BYTES) return null;
+    raw = fs.readFileSync(tp, 'utf-8');
+  } catch (e) { return null; }
+  var created = 0;                       // TaskCreate CALLS seen
+  var pendingCreates = {};               // tool_use id → awaiting its result
+  var createdIds = {};                   // task ids this transcript actually opened
+  var createdIdCount = 0;
+  var latest = {};                       // task id → most recent status seen
+  // Walked by newline index rather than raw.split('\n'): the split would hold a
+  // second full-size copy of a multi-MB transcript alongside the first, and the
+  // scan needs one line at a time.
+  var pos = 0;
+  while (pos <= raw.length) {
+    var nl = raw.indexOf('\n', pos);
+    var line = nl < 0 ? raw.slice(pos) : raw.slice(pos, nl);
+    pos = nl < 0 ? raw.length + 1 : nl + 1;
+    // Cheap pre-filter. A multi-MB transcript has a handful of task lines and
+    // tens of thousands of others; JSON.parse on every line is the whole cost.
+    if (line.indexOf('TaskCreate') < 0 && line.indexOf('TaskUpdate') < 0
+      && line.indexOf('created successfully') < 0) continue;
+    var entry;
+    try { entry = JSON.parse(line); } catch (e) { continue; }
+    var content = entry && entry.message && entry.message.content;
+    if (!Array.isArray(content)) continue;
+    for (var j = 0; j < content.length; j++) {
+      var block = content[j];
+      if (!block) continue;
+      // The created ids come from TaskCreate's RESULT, because the call itself
+      // carries no id. Without them `created` (a count of calls) and the closed
+      // set (a set of ids) are different units: a TaskUpdate naming a task from
+      // before this transcript — one carried across `/clear`, which is exactly
+      // what Claude Code's task store does — would discount a task it never
+      // opened, and the advisory would under-report the open list.
+      if (block.type === 'tool_result') {
+        if (!pendingCreates[block.tool_use_id]) continue;
+        delete pendingCreates[block.tool_use_id];
+        var text = typeof block.content === 'string' ? block.content : JSON.stringify(block.content);
+        var m = /Task #(\S+) created successfully/.exec(text || '');
+        if (m && !createdIds[m[1]]) { createdIds[m[1]] = true; createdIdCount++; }
+        continue;
+      }
+      // Structural, not substring. A line that merely MENTIONS TaskCreate — this
+      // ticket's own discussion, a guidance excerpt, a shell command echoing the
+      // phrase — is text, and counting it would inflate the created total on
+      // exactly the sessions most likely to reach a PR gate. Correlating on
+      // tool_use_id is what keeps such an echo out of the created ids too.
+      if (block.type !== 'tool_use') continue;
+      if (block.name === 'TaskCreate') {
+        created++;
+        if (block.id) pendingCreates[block.id] = true;
+        continue;
+      }
+      if (block.name !== 'TaskUpdate') continue;
+      var input = block.input || {};
+      var id = input.taskId != null ? input.taskId : input.task_id;
+      var status = input.status;
+      if (id == null || typeof status !== 'string' || !status) continue;
+      // Last write wins — transcript order is chronological, so a task reopened
+      // after completion is correctly counted as open again.
+      latest[String(id)] = status;
+    }
+  }
+  if (created === 0) return null;
+  // A create whose result never landed (interrupted call, truncated transcript)
+  // is counted OPEN: it was opened, and nothing observed it being closed.
+  var open = created - createdIdCount;
+  Object.keys(createdIds).forEach(function(id) {
+    // `deleted` closes the loop as legitimately as `completed`: a task removed
+    // because it no longer applies is not an abandoned one.
+    if (latest[id] !== 'completed' && latest[id] !== 'deleted') open++;
+  });
+  if (open > created) open = created;
+  return { created: created, closed: created - open, open: open };
+}
+
 switch (command) {
   case 'check-before-agent': {
     // Mostly advisory. The TaskCreate + memory reminders below go to stdout and
@@ -1457,6 +1571,27 @@ switch (command) {
     // optional ENV=val prefix segment catches `GH_TOKEN=x gh pr create`.
     var cmd = process.env.TOOL_INPUT_command || '';
     if (!/(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/.test(cmd)) break;
+    // #1374 — close the loop the TaskCreate reminder opens. Advisory: stdout,
+    // no exit, and worded as a reminder, because a message may only claim to
+    // block when it blocks (#1326). An open task list is a reporting failure,
+    // not a quality failure — blocking the PR on it would be a new deadlock.
+    //
+    // Deliberately ABOVE the no-source exemption below: a docs-only PR can
+    // abandon a list exactly like a source PR can, and the exemption is about
+    // testing/simplify/learnings, not about whether the run told the user what
+    // it did. Gated on the same `task_create_first` flag as the reminder itself
+    // so the two halves are always consistent — a project that turned the nag
+    // off is not then nagged about the other end of it.
+    if (config.task_create_first) {
+      var ledger = readTaskLedger();
+      if (ledger && ledger.open > 0) {
+        process.stdout.write(
+          'REMINDER: ' + ledger.created + ' task' + (ledger.created === 1 ? '' : 's') +
+          ' created this session, ' + ledger.open + ' still open. Close them with ' +
+          'TaskUpdate (status: completed), or delete the ones that no longer apply, ' +
+          'so the run does not report done over an unfinished list.\n');
+      }
+    }
     // No-source-files exemption (#1176, supersedes the original docs-only path).
     // If every file changed vs the merge-base is either a docs/image file or a
     // path-inert file (.github/workflows/, ISSUE_TEMPLATE/, PULL_REQUEST_TEMPLATE/)

--- a/bin/gate-hook.mjs
+++ b/bin/gate-hook.mjs
@@ -32,6 +32,15 @@ if (hookContext.tool_name) env.TOOL_NAME = hookContext.tool_name;
 if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
   env.HOOK_SESSION_ID = hookContext.session_id;
 }
+// #1374 — forward the transcript path so a gate can read what the session
+// actually DID, not only what workflow-state.json was told about it. Used by
+// check-before-pr to count TaskCreate calls against terminal TaskUpdate calls;
+// the alternative — a `^TaskUpdate$` PostToolUse observer — is the wiring #1331
+// removed as pure hot-path overhead, and the transcript already holds the answer.
+// Absent on hosts that don't send it: gates treat that as "unknown" and stay silent.
+if (typeof hookContext.transcript_path === 'string' && hookContext.transcript_path) {
+  env.HOOK_TRANSCRIPT_PATH = hookContext.transcript_path;
+}
 // #1332: structured tool inputs are forwarded as JSON, not dropped.
 //
 // This previously forwarded ONLY string values, so any object-valued input was

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -1039,6 +1039,120 @@ function getChangedFilesVsBase() {
   } catch (e) { return null; }
 }
 
+// #1374 — the missing half of the TaskCreate reminder.
+//
+// moflo nags you to OPEN a task list (check-before-agent) and then never looks
+// again: `taskCount` only counts up, so a run that creates four tasks and closes
+// none satisfies every gate. That is the exact shape of an abandoned list.
+//
+// The ledger is read from the session TRANSCRIPT, and both alternatives were
+// rejected on evidence rather than taste:
+//
+//   - A `^TaskUpdate$` PostToolUse observer feeding a counter is the wiring
+//     #1331 removed as pure hot-path overhead. It would also have to survive
+//     applyPromptStateReset, whereas a transcript read holds no state to reset.
+//   - Claude Code's own task store (`~/.claude/tasks/session-<id>/`) is ground
+//     truth but unreachable: measured on v2.1.220, the id keying that directory
+//     does NOT rotate on `/clear`, so a session whose transcript is <A> writes
+//     its tasks under the pre-clear id <B> — and <A> is what the bridge forwards
+//     as HOOK_SESSION_ID. There is no path from the hook environment to the dir.
+//
+// Cost lands only where it is already justified: the sole caller runs after
+// check-before-pr's `gh pr create` match, i.e. once per PR attempt, never on the
+// per-tool path.
+//
+// Returns null when the transcript is missing, oversized, unreadable, or records
+// no TaskCreate at all — the caller then stays silent rather than guessing.
+// Sized against measurement, not a round number: a 3.4MB transcript (the largest
+// in a week of local sessions) costs ~55ms to scan, so ~16ms/MB. 16MB is ~4x the
+// worst observed session and lands near 260ms — a chunk of the hook's 2000ms
+// budget, but a bounded one. Past the cap the ledger goes silent rather than
+// risking the timeout, since a hook that times out is worse than one that
+// declines to comment. Unrelated to `TRANSCRIPT_TAIL_BYTES` in bin/lib/meditate.mjs
+// despite the similar name — that one truncates to a tail window, which cannot
+// work here (a TaskCreate from early in the session falls outside any tail).
+var TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024;
+function readTaskLedger() {
+  var tp = process.env.HOOK_TRANSCRIPT_PATH || '';
+  if (!tp) return null;
+  var raw;
+  try {
+    var st = fs.statSync(tp);
+    if (!st.isFile() || st.size > TRANSCRIPT_MAX_BYTES) return null;
+    raw = fs.readFileSync(tp, 'utf-8');
+  } catch (e) { return null; }
+  var created = 0;                       // TaskCreate CALLS seen
+  var pendingCreates = {};               // tool_use id → awaiting its result
+  var createdIds = {};                   // task ids this transcript actually opened
+  var createdIdCount = 0;
+  var latest = {};                       // task id → most recent status seen
+  // Walked by newline index rather than raw.split('\n'): the split would hold a
+  // second full-size copy of a multi-MB transcript alongside the first, and the
+  // scan needs one line at a time.
+  var pos = 0;
+  while (pos <= raw.length) {
+    var nl = raw.indexOf('\n', pos);
+    var line = nl < 0 ? raw.slice(pos) : raw.slice(pos, nl);
+    pos = nl < 0 ? raw.length + 1 : nl + 1;
+    // Cheap pre-filter. A multi-MB transcript has a handful of task lines and
+    // tens of thousands of others; JSON.parse on every line is the whole cost.
+    if (line.indexOf('TaskCreate') < 0 && line.indexOf('TaskUpdate') < 0
+      && line.indexOf('created successfully') < 0) continue;
+    var entry;
+    try { entry = JSON.parse(line); } catch (e) { continue; }
+    var content = entry && entry.message && entry.message.content;
+    if (!Array.isArray(content)) continue;
+    for (var j = 0; j < content.length; j++) {
+      var block = content[j];
+      if (!block) continue;
+      // The created ids come from TaskCreate's RESULT, because the call itself
+      // carries no id. Without them `created` (a count of calls) and the closed
+      // set (a set of ids) are different units: a TaskUpdate naming a task from
+      // before this transcript — one carried across `/clear`, which is exactly
+      // what Claude Code's task store does — would discount a task it never
+      // opened, and the advisory would under-report the open list.
+      if (block.type === 'tool_result') {
+        if (!pendingCreates[block.tool_use_id]) continue;
+        delete pendingCreates[block.tool_use_id];
+        var text = typeof block.content === 'string' ? block.content : JSON.stringify(block.content);
+        var m = /Task #(\S+) created successfully/.exec(text || '');
+        if (m && !createdIds[m[1]]) { createdIds[m[1]] = true; createdIdCount++; }
+        continue;
+      }
+      // Structural, not substring. A line that merely MENTIONS TaskCreate — this
+      // ticket's own discussion, a guidance excerpt, a shell command echoing the
+      // phrase — is text, and counting it would inflate the created total on
+      // exactly the sessions most likely to reach a PR gate. Correlating on
+      // tool_use_id is what keeps such an echo out of the created ids too.
+      if (block.type !== 'tool_use') continue;
+      if (block.name === 'TaskCreate') {
+        created++;
+        if (block.id) pendingCreates[block.id] = true;
+        continue;
+      }
+      if (block.name !== 'TaskUpdate') continue;
+      var input = block.input || {};
+      var id = input.taskId != null ? input.taskId : input.task_id;
+      var status = input.status;
+      if (id == null || typeof status !== 'string' || !status) continue;
+      // Last write wins — transcript order is chronological, so a task reopened
+      // after completion is correctly counted as open again.
+      latest[String(id)] = status;
+    }
+  }
+  if (created === 0) return null;
+  // A create whose result never landed (interrupted call, truncated transcript)
+  // is counted OPEN: it was opened, and nothing observed it being closed.
+  var open = created - createdIdCount;
+  Object.keys(createdIds).forEach(function(id) {
+    // `deleted` closes the loop as legitimately as `completed`: a task removed
+    // because it no longer applies is not an abandoned one.
+    if (latest[id] !== 'completed' && latest[id] !== 'deleted') open++;
+  });
+  if (open > created) open = created;
+  return { created: created, closed: created - open, open: open };
+}
+
 switch (command) {
   case 'check-before-agent': {
     // Mostly advisory. The TaskCreate + memory reminders below go to stdout and
@@ -1457,6 +1571,27 @@ switch (command) {
     // optional ENV=val prefix segment catches `GH_TOKEN=x gh pr create`.
     var cmd = process.env.TOOL_INPUT_command || '';
     if (!/(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/.test(cmd)) break;
+    // #1374 — close the loop the TaskCreate reminder opens. Advisory: stdout,
+    // no exit, and worded as a reminder, because a message may only claim to
+    // block when it blocks (#1326). An open task list is a reporting failure,
+    // not a quality failure — blocking the PR on it would be a new deadlock.
+    //
+    // Deliberately ABOVE the no-source exemption below: a docs-only PR can
+    // abandon a list exactly like a source PR can, and the exemption is about
+    // testing/simplify/learnings, not about whether the run told the user what
+    // it did. Gated on the same `task_create_first` flag as the reminder itself
+    // so the two halves are always consistent — a project that turned the nag
+    // off is not then nagged about the other end of it.
+    if (config.task_create_first) {
+      var ledger = readTaskLedger();
+      if (ledger && ledger.open > 0) {
+        process.stdout.write(
+          'REMINDER: ' + ledger.created + ' task' + (ledger.created === 1 ? '' : 's') +
+          ' created this session, ' + ledger.open + ' still open. Close them with ' +
+          'TaskUpdate (status: completed), or delete the ones that no longer apply, ' +
+          'so the run does not report done over an unfinished list.\n');
+      }
+    }
     // No-source-files exemption (#1176, supersedes the original docs-only path).
     // If every file changed vs the merge-base is either a docs/image file or a
     // path-inert file (.github/workflows/, ISSUE_TEMPLATE/, PULL_REQUEST_TEMPLATE/)

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -1159,6 +1159,15 @@ if (hookContext.tool_name) env.TOOL_NAME = hookContext.tool_name;
 if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
   env.HOOK_SESSION_ID = hookContext.session_id;
 }
+// #1374 — forward the transcript path so a gate can read what the session
+// actually DID, not only what workflow-state.json was told about it. Used by
+// check-before-pr to count TaskCreate calls against terminal TaskUpdate calls;
+// the alternative — a \`^TaskUpdate$\` PostToolUse observer — is the wiring #1331
+// removed as pure hot-path overhead, and the transcript already holds the answer.
+// Absent on hosts that don't send it: gates treat that as "unknown" and stay silent.
+if (typeof hookContext.transcript_path === 'string' && hookContext.transcript_path) {
+  env.HOOK_TRANSCRIPT_PATH = hookContext.transcript_path;
+}
 // #1332: structured tool inputs are forwarded as JSON, not dropped.
 //
 // This previously forwarded ONLY string values, so any object-valued input was

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -52,6 +52,10 @@ function baseEnv(projectDir: string): Record<string, string> {
     // bucket they target (#931). Tests that exercise per-session emission
     // override HOOK_SESSION_ID after building env.
     HOOK_SESSION_ID: '',
+    // Same reason (#1374): the open-task ledger reads the transcript the bridge
+    // forwards, and an inherited path from the outer session would make the
+    // "silent when absent" cases pass or fail depending on who ran the suite.
+    HOOK_TRANSCRIPT_PATH: '',
   };
 }
 
@@ -1727,6 +1731,251 @@ describe('end-to-end: spell lifecycle', () => {
     });
   });
 
+  // #1374 — the completion half of the TaskCreate reminder. moflo used to push
+  // `TaskCreate` and then never look again, so a run that opened four tasks and
+  // closed none satisfied every gate. These pin the reporting side: the ledger
+  // comes from the session transcript (no `^TaskUpdate$` observer — that wiring
+  // is what #1331 removed as hot-path overhead), it counts CALLS not mentions,
+  // and it reminds without ever claiming to block (#1326).
+  describe('open-task advisory at the PR gate (#1374)', () => {
+    /** One transcript line as Claude Code writes it: a tool_use block. */
+    function toolUse(name: string, input: Record<string, unknown>, id = 'toolu_x'): string {
+      return JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] },
+      });
+    }
+
+    /**
+     * A TaskCreate CALL plus the tool_result that names the id it was assigned —
+     * both lines, because the call itself carries no id and the ledger has to
+     * correlate them to know which ids this transcript actually opened.
+     */
+    function taskCreate(taskId: string): string[] {
+      const useId = `toolu_create_${taskId}`;
+      return [
+        toolUse('TaskCreate', { subject: `task ${taskId}`, description: 'd' }, useId),
+        JSON.stringify({
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: useId, content: `Task #${taskId} created successfully: task ${taskId}` }],
+          },
+        }),
+      ];
+    }
+
+    /** Write a JSONL transcript into the temp project and point the env at it. */
+    function withTranscript(env: Record<string, string>, lines: string[], eol = '\n'): void {
+      const p = join(tmpDir, 'transcript.jsonl');
+      writeFileSync(p, lines.join(eol) + eol);
+      env.HOOK_TRANSCRIPT_PATH = p;
+    }
+
+    /** All blocking gates satisfied, so only the advisory can appear. */
+    function prReady(env: Record<string, string>): void {
+      writeState(tmpDir, { testsRun: true, simplifyRun: true, learningsStored: true });
+      env.TOOL_INPUT_command = 'gh pr create --title "test"';
+    }
+
+    it('reports the open count when tasks were created and not closed', () => {
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [
+        ...taskCreate('1'),
+        ...taskCreate('2'),
+        ...taskCreate('3'),
+        toolUse('TaskUpdate', { taskId: '1', status: 'completed' }),
+      ]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).toContain('3 tasks created this session, 2 still open');
+      // Advisory, not a gate: it must never change the exit code (#1326).
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).not.toContain('BLOCKED');
+    });
+
+    it('stays silent when every created task reached a terminal status', () => {
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [
+        ...taskCreate('1'),
+        ...taskCreate('2'),
+        toolUse('TaskUpdate', { taskId: '1', status: 'in_progress' }),
+        toolUse('TaskUpdate', { taskId: '1', status: 'completed' }),
+        toolUse('TaskUpdate', { taskId: '2', status: 'deleted' }),
+      ]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).not.toContain('still open');
+      expect(r.exitCode).toBe(0);
+    });
+
+    it('counts a task reopened after completion as open again', () => {
+      // Last write wins — the transcript is chronological, so a completed task
+      // moved back to in_progress is genuinely unfinished at PR time.
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [
+        ...taskCreate('1'),
+        toolUse('TaskUpdate', { taskId: '1', status: 'completed' }),
+        toolUse('TaskUpdate', { taskId: '1', status: 'in_progress' }),
+      ]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).toContain('1 task created this session, 1 still open');
+    });
+
+    it('does not let a task carried across /clear discount this session', () => {
+      // The bug this pins: counting CREATE CALLS against a SET OF CLOSED IDS
+      // mixes units. Claude Code's task store survives `/clear`, so closing a
+      // task from before this transcript is routine — and it must not cancel out
+      // a task this session opened and left open.
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [
+        toolUse('TaskUpdate', { taskId: '7', status: 'completed' }),  // stale, pre-/clear
+        ...taskCreate('9'),
+        toolUse('TaskUpdate', { taskId: '8', status: 'deleted' }),    // stale, pre-/clear
+      ]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).toContain('1 task created this session, 1 still open');
+    });
+
+    it('counts a create whose result never landed as open', () => {
+      // Interrupted call or truncated transcript: it was opened, and nothing
+      // observed it closing. Reporting it open is the conservative read.
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [
+        ...taskCreate('1'),
+        toolUse('TaskUpdate', { taskId: '1', status: 'completed' }),
+        toolUse('TaskCreate', { subject: 'orphan', description: 'd' }, 'toolu_orphan'),
+      ]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).toContain('2 tasks created this session, 1 still open');
+    });
+
+    it('reads a snake_case task_id as well as taskId', () => {
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [
+        ...taskCreate('1'),
+        toolUse('TaskUpdate', { task_id: '1', status: 'completed' }),
+      ]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).not.toContain('still open');
+    });
+
+    it('reads a CRLF transcript (Rule #1 — Windows checkouts and hosts)', () => {
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [...taskCreate('1'), ...taskCreate('2'),
+        toolUse('TaskUpdate', { taskId: '1', status: 'completed' })], '\r\n');
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).toContain('2 tasks created this session, 1 still open');
+    });
+
+    it('counts tool CALLS, not text that merely mentions the tool names', () => {
+      // The failure this pins: a substring scan would count this ticket's own
+      // discussion — and a transcript that talks about TaskCreate is exactly the
+      // kind of session that then reaches a PR gate.
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'moflo nags TaskCreate but never observes TaskUpdate' }] },
+        }),
+        // A Bash call that PRINTS the phrase — e.g. this ticket's own transcript
+        // analysis. Correlating on tool_use_id is what keeps it out of the ledger.
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_some_bash', content: 'Task #1 created successfully (TaskCreate)' }] },
+        }),
+      ]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).not.toContain('still open');
+    });
+
+    it('survives the per-prompt state reset that made the previous gate a no-op', () => {
+      // AC of #1374: a counter in workflow-state would have to be exempted from
+      // applyPromptStateReset by hand. The transcript holds no state to reset,
+      // so a fresh prompt between TaskCreate and `gh pr create` changes nothing.
+      const env = baseEnv(tmpDir);
+      withTranscript(env, [...taskCreate('1'), ...taskCreate('2')]);
+      env.CLAUDE_USER_PROMPT = 'now open the pull request please';
+      runGate('prompt-reminder', env);
+      prReady(env);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).toContain('2 tasks created this session, 2 still open');
+    });
+
+    it('still reports while the PR is blocked for another reason', () => {
+      const env = baseEnv(tmpDir);
+      writeState(tmpDir, { testsRun: false, simplifyRun: true, learningsStored: true });
+      env.TOOL_INPUT_command = 'gh pr create --title "test"';
+      withTranscript(env, taskCreate('1'));
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode).toBe(2);
+      expect(r.stdout).toContain('1 task created this session, 1 still open');
+    });
+
+    it('is silent when task_create_first is off — both halves or neither', () => {
+      // The reminder to OPEN a list and the reminder to CLOSE it are one
+      // feature. A project that turned the nag off must not get the other end.
+      writeFileSync(join(tmpDir, 'moflo.yaml'), 'gates:\n  task_create_first: false\n');
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [toolUse('TaskCreate', { subject: 'a', description: 'a' })]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).not.toContain('still open');
+    });
+
+    it('is silent when the host forwards no transcript path', () => {
+      // Older Claude Code builds: unknown is not the same as zero, so say nothing.
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      env.HOOK_TRANSCRIPT_PATH = '';
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).not.toContain('still open');
+      expect(r.exitCode).toBe(0);
+    });
+
+    it('is silent when the transcript path does not exist', () => {
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      env.HOOK_TRANSCRIPT_PATH = join(tmpDir, 'no-such-transcript.jsonl');
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).not.toContain('still open');
+      expect(r.exitCode).toBe(0);
+    });
+
+    it('tolerates malformed transcript lines without failing the gate', () => {
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      withTranscript(env, [
+        '{not json at all',
+        '',
+        ...taskCreate('1'),
+        '{"message":{"content":"TaskUpdate as a bare string"}}',
+      ]);
+      const r = runGate('check-before-pr', env);
+      expect(r.stdout).toContain('1 task created this session, 1 still open');
+      expect(r.exitCode).toBe(0);
+    });
+
+    it('never reads the transcript for a non-PR command', () => {
+      // The cost argument in #1374 AC5: the ledger sits behind the `gh pr create`
+      // match, so the per-tool Bash path never touches the file. Pointed at a
+      // directory — a read would throw or hang; the gate must not even try.
+      const env = baseEnv(tmpDir);
+      prReady(env);
+      env.TOOL_INPUT_command = 'npm test';
+      env.HOOK_TRANSCRIPT_PATH = tmpDir;
+      const r = runGate('check-before-pr', env);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).not.toContain('still open');
+    });
+  });
+
   // Story #1274 (Epic #1269) + #1294 — verify-before-done gate. ON by default:
   // #1294 ships a real /verify skill and has /flo delegate to it, so the default
   // path must ENFORCE (an unset toggle blocks an unverified `gh pr create`).
@@ -2310,6 +2559,47 @@ describe('gate-hook.mjs: session_id forwarding (#838)', () => {
     const s = readState(tmpDir) as { memorySearched: boolean; memorySearchedBy: Record<string, boolean> };
     expect(s.memorySearched).toBe(true);
     expect(s.memorySearchedBy['subagent-Z']).toBe(true);
+  });
+});
+
+// #1374 — the bridge must hand the gate the transcript path, or check-before-pr
+// has no ledger to read and silently reports nothing. Exercised end-to-end
+// through gate-hook.mjs (not by setting the env directly) because the
+// forwarding step is the part that can regress.
+describe('gate-hook.mjs: transcript_path forwarding (#1374)', () => {
+  it('forwards transcript_path so the PR gate can count open tasks', async () => {
+    writeState(tmpDir, { testsRun: true, simplifyRun: true, learningsStored: true });
+    const transcript = join(tmpDir, 'transcript.jsonl');
+    writeFileSync(transcript, [
+      JSON.stringify({ message: { content: [{ type: 'tool_use', id: 'tu_1', name: 'TaskCreate', input: { subject: 'a', description: 'a' } }] } }),
+      JSON.stringify({ message: { content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'Task #1 created successfully: a' }] } }),
+      JSON.stringify({ message: { content: [{ type: 'tool_use', id: 'tu_2', name: 'TaskCreate', input: { subject: 'b', description: 'b' } }] } }),
+      JSON.stringify({ message: { content: [{ type: 'tool_result', tool_use_id: 'tu_2', content: 'Task #2 created successfully: b' }] } }),
+      JSON.stringify({ message: { content: [{ type: 'tool_use', name: 'TaskUpdate', input: { taskId: '1', status: 'completed' } }] } }),
+    ].join('\n') + '\n');
+
+    const r = await runEsmWithStdin(GATE_HOOK, ['check-before-pr'], {
+      session_id: 'sess-1',
+      transcript_path: transcript,
+      tool_name: 'Bash',
+      tool_input: { command: 'gh pr create --title "test"' },
+      hook_event_name: 'PreToolUse',
+    }, baseEnv(tmpDir));
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('2 tasks created this session, 1 still open');
+  });
+
+  it('is silent when the host sends no transcript_path', async () => {
+    writeState(tmpDir, { testsRun: true, simplifyRun: true, learningsStored: true });
+    const r = await runEsmWithStdin(GATE_HOOK, ['check-before-pr'], {
+      session_id: 'sess-1',
+      tool_name: 'Bash',
+      tool_input: { command: 'gh pr create --title "test"' },
+      hook_event_name: 'PreToolUse',
+    }, baseEnv(tmpDir));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('still open');
   });
 });
 


### PR DESCRIPTION
Closes #1374.

## The gap

moflo's task surface was one-directional. `check-before-agent` nags `REMINDER: Use TaskCreate before spawning agents`, `record-task-created` increments `taskCount`, and **nothing observes `TaskUpdate`** — that wiring was removed in #1331. Since `taskCount` only counts up, a run that opened four tasks and closed none satisfied every moflo check. That is precisely the shape of an abandoned list.

## Measured first — and it changed the plan

Per the protocol in the issue, this ran against the retained transcript corpus (unseeded: those sessions predate anyone measuring task hygiene) rather than a live test that would be invalidated by its own seeding.

| | |
|---|---|
| sessions | 27 |
| sessions with ≥1 `TaskCreate` | 4 |
| tasks created | 19 |
| tasks reaching `completed` | 18 |
| completion ratio | **94.7%** |
| genuinely abandoned sessions | **0** |

Three limits, stated rather than buried: the corpus is **two days deep** (so the "used to work, now doesn't" claim is untestable against it), there is **no non-moflo control group** (one project directory, all four task-bearing sessions ran `/fl`), and **n=4**.

Conclusion: no moflo-side regression is confirmed, and **proposal 3 — dropping the `TaskCreate` nag — is not supported**. The data supports closing the loop cheaply instead, which is what this does.

## The change

`check-before-pr` reads the session transcript once, on the `gh pr create` match:

```
REMINDER: 4 tasks created this session, 2 still open. Close them with TaskUpdate
(status: completed), or delete the ones that no longer apply, so the run does not
report done over an unfinished list.
```

**Advisory, never blocking** (#1326). An open list is a reporting failure, not a quality failure; a fifth blocking condition on `gh pr create` would be a new deadlock. Gated on the same `task_create_first` flag as the reminder, so both halves are on or off together (AC3).

## Why the transcript, not a counter

| Alternative | Why not |
|---|---|
| `^TaskUpdate$` PostToolUse observer | The wiring #1331 removed as pure hot-path overhead. Re-adding it also means re-grafting every consumer's `settings.json` hook block plus `hook-block-hash` / `hook-wiring` / doctor `REQUIRED_GATE_CASES`. |
| Claude Code's own task store | Ground truth, but **unreachable**. `~/.claude/tasks/session-<id>/` is keyed by an id that does **not** rotate on `/clear` — measured on v2.1.220, a session whose transcript is `52d160f9…` writes its tasks under `session-09f8a2d3…`, the pre-clear id. `HOOK_SESSION_ID` carries the post-clear id, so there is no path from the hook environment to that directory. |

The transcript read sits behind the `gh pr create` regex, so the per-tool `Bash` path never touches it. It holds no state, so it survives `applyPromptStateReset` **by construction** rather than by a hand-written exemption (AC2).

## Cost (AC5)

Measured on a 3.4 MB transcript — the largest in a week of local sessions — against a 2000 ms hook timeout:

| Path | Cost |
|---|---|
| non-PR `Bash` call | **37 ms** (unchanged — ledger not reached) |
| `gh pr create` attempt | **92 ms**, once per PR |

`settings.json` is untouched, so there is no new spawn anywhere and no consumer re-graft. The file scan walks by newline index (not `raw.split('\n')`, which would hold a second full-size copy) and pre-filters lines by substring before `JSON.parse`. Capped at 16 MB — ~4× the worst observed session, ~260 ms — past which the ledger goes silent rather than risk the timeout.

## Correctness detail worth reading

Created ids are recovered by correlating each `TaskCreate`'s `tool_use.id` with its `tool_result`, **not** by counting calls against a set of closed ids. Those are different units: `TaskCreate` carries no id at all, and because Claude Code's task list survives `/clear`, closing a pre-existing task is routine — each one would have cancelled out a task this session actually left open, with the `Math.max(0, …)` floor turning the undercount into a confident "0 still open". Caught by the quality review pass, pinned by `does not let a task carried across /clear discount this session`. Correlating on `tool_use_id` also keeps a Bash call that merely *prints* `Task #N created successfully` out of the ledger.

## Scoped out (AC4)

Stale lists surviving `/clear` and compaction are **harness-owned** — a fresh transcript inherits the previous session's list, entirely inside Claude Code. Nothing moflo can change affects it, so it is not pretended-at here. The evidence an upstream report would need is recorded in the issue and in the `readTaskLedger` comment.

## Consumer surface

`bin/gate.cjs` + `bin/gate-hook.mjs`, their `.claude/helpers/` dogfood copies, and the byte-identical `generateGateHookScript()` template (parity guard). **Failure mode for a consumer on the previous version: none.** The advisory is additive, silent when the host forwards no `transcript_path`, and changes no gate outcome. `generateGateScript()`'s reduced fallback is deliberately left alone, as with every prior gate change — the launcher syncs the real gate over it.

## Verification

- 17 new tests covering the advisory, the silence conditions, the `/clear` carry-over case, an unresolved create, `snake_case task_id`, CRLF transcripts (Rule #1), malformed lines, and the non-PR path never touching the file.
- Full suite **10135 passed / 0 failed**; `npm run lint` and `tsc` clean.
- Dogfooded live: the gate ran against this session's real transcript and reported the correct open count.
- `/verify`: **PASS** on all five acceptance criteria.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
