### PR TITLE
feat(metrics): join token cost to /flo runs, and stop tests eating the ledger (#1333)

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -1772,6 +1772,14 @@ switch (command) {
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
     applyPromptStateReset(s, prompt);
     s.interactionCount = (s.interactionCount || 0) + 1;
+    // Record the MAIN-LOOP session id so `flo run finalize` can attribute
+    // transcript token usage to a run (#1333). UserPromptSubmit fires only for
+    // the top-level session — subagents never submit a user prompt — so unlike
+    // the per-actor `memorySearchedBy` map this is unambiguously the session
+    // whose transcript carries the run. Survives applyPromptStateReset by being
+    // written after it; refreshed every prompt, so a /clear that mints a new id
+    // is picked up on the next turn rather than going stale.
+    if (process.env.HOOK_SESSION_ID) s.sessionId = process.env.HOOK_SESSION_ID;
     writeState(s);
     // Announce the resolved /flo run modifiers. The gate already parsed
     // moflo.yaml in THIS process (fresh per prompt — a git pull or a mid-session

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -4,44 +4,25 @@ Phase-by-phase notes for the full `/flo <issue>` run. Phase 2 (Ticket) lives in 
 
 ## Phase 0: Record run start (Flo Runs dashboard)
 
-Before research, write a row to the `tasklist` namespace so the Luminarium "Flo Runs" tab shows this run live and after the next session restart (#968). Skip this phase ONLY when `--epic-branch` is set — the epic orchestrator owns the parent record and the per-story spell engine writes its own row.
+Before research, open a run record so the Luminarium "Flo Runs" tab shows this run live and after the next session restart (#968), and so Phase 5.5 can price it. Skip this phase ONLY when `--epic-branch` is set — the epic orchestrator owns the parent record and the per-story spell engine writes its own row.
 
-Compute and **remember** for Phase 5:
-- `runId` — `flo-<issue-number-or-"new">-<startedAt-ms>` (sortable, unique).
-- `startedAt` — `Date.now()` snapshot (ms since epoch).
+One command. It builds the record, derives the run id, and picks up the session id `gate.cjs` stamped on this prompt:
 
-Pick the matching `context.type`:
-| Mode | type | label format |
-|------|------|--------------|
-| Full / ticket on existing issue | `ticket` | `#<n> — <title>` |
-| `-r` research | `research` | `#<n> — Research` |
-| `-t` with title (no issue # yet) | `new-ticket` | `New: <title>` |
-| Epic detected | `epic` | `Epic #<n> — <title> (0/<total> stories)` |
-| `-wf <spell>` | `spell` | `<spell-name> → <args>` |
-
-Then call once:
-
-```
-mcp__moflo__memory_store
-  namespace: "tasklist"
-  key: "<runId>"
-  upsert: true
-  value: {
-    "status": "running",
-    "context": {
-      "type": "<ticket|research|new-ticket|epic|spell>",
-      "label": "<computed label>",
-      "issueNumber": <n | omit>,
-      "issueTitle": "<title | omit>",
-      "execMode": "<normal|swarm|hive>"
-    },
-    "spellName": "<same as label>",
-    "startedAt": <startedAt>,
-    "updatedAt": "<new Date().toISOString()>"
-  }
+```bash
+flo runs start --issue <n> --title "<issue title>" --exec-mode <normal|swarm|hive>
 ```
 
-The schema mirrors `storeFloRunRecord` in `src/cli/services/daemon-dashboard.ts` — keep it in sync if you ever change one. The session-start launcher retains the most recent ~200 tasklist rows so this record outlives the session and renders in the Flo Runs tab on subsequent restarts.
+Flag the mode when it isn't a plain ticket run: `--research` (`-r`), `--new-ticket --title "<t>"` (`-t` with no issue yet), `--epic`, or `--spell <name>` (`-wf`). It prints one JSON line — **remember the `runId` for Phase 5.5**:
+
+```
+[INFO] {"runId":"flo-1333-1785891035226","startedAt":1785891035226,"sessionId":"52d160f9-…"}
+```
+
+`sessionId: null` means no session id was stamped (the gate has not seen a prompt yet, or you are outside Claude Code). The run still records; only its token cost will be unmeasurable.
+
+Do **not** hand-write a `memory_store` call for this. The record shape lives in `storeFloRunRecord` (`src/cli/services/daemon-dashboard.ts`) and `flo runs start` is its only caller — #1333 replaced a copy of the schema that lived here in prose, which produced exactly one record across the whole retained corpus because it depended on remembering to perform it.
+
+The session-start launcher retains the most recent ~200 tasklist rows, so this record outlives the session and renders in the Flo Runs tab on subsequent restarts.
 
 ## Phase 1: Research (also `-r`)
 
@@ -240,6 +221,20 @@ flo epic checkoff <epic-number> <story-number>
 ```
 
 Idempotent and safe to skip when there is no back-reference. `--epic-branch` runs skip it — the epic orchestrator owns checklist state there. The box flips when the work is delivered (PR opened), matching the orchestrator; if a PR is later rejected, reopen the epic manually.
+
+### 5.5 Close the run record
+
+Close the record Phase 0 opened, using the `runId` it printed. This is what snapshots the run's token cost — `finalize` reads the session transcript for the run's window and stores the rollup **in the same record**, so cost and outcome finally share a key (#1333):
+
+```bash
+flo runs finalize --run-id <runId>            # or: --status failed --error "<summary>"
+```
+
+Run it after the PR is open (5.3) so the rollup covers the whole run. Skipped under `--epic-branch` along with Phase 0.
+
+Snapshot rather than compute-on-read because Claude Code prunes `~/.claude/projects/**` — measured at roughly two days of history, so a cost joined at read time would be correct today and zero next week.
+
+`tokens.transcripts: 0` in the stored record means the run's cost could **not** be measured (no transcript, or no session id was stamped), which is not the same as a run that cost nothing. `success` means the run reached a terminal state without reporting an error — it is not a verification that the work was correct, and nothing here should be described as one (#1322).
 
 ### 5.3b Auto-merge the PR (`mergeMode` / `merge.auto`)
 

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -1772,6 +1772,14 @@ switch (command) {
     var prompt = process.env.CLAUDE_USER_PROMPT || '';
     applyPromptStateReset(s, prompt);
     s.interactionCount = (s.interactionCount || 0) + 1;
+    // Record the MAIN-LOOP session id so `flo run finalize` can attribute
+    // transcript token usage to a run (#1333). UserPromptSubmit fires only for
+    // the top-level session — subagents never submit a user prompt — so unlike
+    // the per-actor `memorySearchedBy` map this is unambiguously the session
+    // whose transcript carries the run. Survives applyPromptStateReset by being
+    // written after it; refreshed every prompt, so a /clear that mints a new id
+    // is picked up on the next turn rather than going stale.
+    if (process.env.HOOK_SESSION_ID) s.sessionId = process.env.HOOK_SESSION_ID;
     writeState(s);
     // Announce the resolved /flo run modifiers. The gate already parsed
     // moflo.yaml in THIS process (fresh per prompt — a git pull or a mid-session

--- a/src/cli/__tests__/commands/runs-command.test.ts
+++ b/src/cli/__tests__/commands/runs-command.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for `flo runs start|finalize|show` (#1333).
+ *
+ * The behaviour under test is the ledger contract: one code path owns the
+ * `flo-*` record, finalize snapshots token cost into THAT record (not a
+ * parallel store), and a run whose cost cannot be measured says so rather than
+ * reporting zero as if it were a measurement.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CommandContext } from '../../types.js';
+
+const SESSION = '11111111-2222-3333-4444-555555555555';
+
+/** In-memory stand-in for the shared accessor: records every write. */
+const writes: Array<{ namespace: string; key: string; value: unknown }> = [];
+const store = new Map<string, unknown>();
+
+vi.mock('../../services/daemon-dashboard.js', async () => {
+  const actual = await vi.importActual<typeof import('../../services/daemon-dashboard.js')>(
+    '../../services/daemon-dashboard.js',
+  );
+  return {
+    ...actual,
+    // Only the accessor is faked — buildFloRunContext and storeFloRunRecord
+    // stay real, so these specs exercise the shipped record shape.
+    getSharedMemoryAccessor: async () => ({
+      async read(namespace: string, key: string) {
+        return store.get(`${namespace}::${key}`) ?? null;
+      },
+      async write(namespace: string, key: string, value: unknown) {
+        // Mirrors createDashboardMemoryAccessor in the detail that bites:
+        // `write` JSON-stringifies and `read` hands the RAW STRING back
+        // unparsed (only its `search` path parses). An object-in/object-out
+        // double let a broken `finalize` pass every spec here — dogfooding
+        // caught it, not the suite. Keep the asymmetry.
+        const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+        writes.push({ namespace, key, value: JSON.parse(serialized) });
+        store.set(`${namespace}::${key}`, serialized);
+      },
+      async search() { return []; },
+    }),
+  };
+});
+
+const { runsCommand, readStampedSessionId } = await import('../../commands/runs.js');
+const { _resetStateRootCacheForTest } = await import('../../services/project-root.js');
+
+let root: string;
+const ORIGINAL_PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR;
+
+function ctx(args: string[], flags: Record<string, string | boolean> = {}): CommandContext {
+  return { args, flags: { _: [], ...flags }, cwd: root, interactive: false };
+}
+
+function stampSession(sessionId: string): void {
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  writeFileSync(
+    join(root, '.claude', 'workflow-state.json'),
+    JSON.stringify({ interactionCount: 3, sessionId }),
+    'utf-8',
+  );
+}
+
+beforeEach(() => {
+  writes.length = 0;
+  store.clear();
+  // realpath: macOS hands back /var/folders/... while resolveStateRoot
+  // canonicalizes to /private/var/folders/... (see CLAUDE.md Rule #1 / #1145).
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'moflo-run-cmd-')));
+  process.env.CLAUDE_PROJECT_DIR = root;
+  _resetStateRootCacheForTest();
+});
+
+afterEach(() => {
+  if (ORIGINAL_PROJECT_DIR === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = ORIGINAL_PROJECT_DIR;
+  _resetStateRootCacheForTest();
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('readStampedSessionId', () => {
+  it('reads the id gate.cjs stamps on UserPromptSubmit', () => {
+    stampSession(SESSION);
+    expect(readStampedSessionId(root)).toBe(SESSION);
+  });
+
+  it('returns null when there is no state file or no id in it', () => {
+    expect(readStampedSessionId(root)).toBeNull();
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(join(root, '.claude', 'workflow-state.json'), '{"interactionCount":1}', 'utf-8');
+    expect(readStampedSessionId(root)).toBeNull();
+  });
+
+  it('returns null on a corrupt state file rather than throwing', () => {
+    mkdirSync(join(root, '.claude'), { recursive: true });
+    writeFileSync(join(root, '.claude', 'workflow-state.json'), '{not json', 'utf-8');
+    expect(readStampedSessionId(root)).toBeNull();
+  });
+});
+
+describe('flo runs start', () => {
+  it('writes one running record to tasklist, keyed by a derived run id', async () => {
+    stampSession(SESSION);
+    const result = await runsCommand.action(
+      ctx(['start'], { issue: '1333', title: 'Join tokens to runs' }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].namespace).toBe('tasklist');
+    expect(writes[0].key).toMatch(/^flo-1333-\d+$/);
+
+    const record = writes[0].value as Record<string, unknown>;
+    expect(record.status).toBe('running');
+    expect(record.sessionId).toBe(SESSION);
+    expect((record.context as { issueNumber: number }).issueNumber).toBe(1333);
+    expect((record.context as { label: string }).label).toBe('#1333 — Join tokens to runs');
+  });
+
+  it('honours an explicit --run-id and --started-at', async () => {
+    await runsCommand.action(
+      ctx(['start'], { issue: '7', title: 'x', runId: 'flo-7-42', startedAt: '42' }),
+    );
+    expect(writes[0].key).toBe('flo-7-42');
+    expect((writes[0].value as { startedAt: number }).startedAt).toBe(42);
+  });
+
+  it('records no sessionId when none is stamped — nothing to attribute against', async () => {
+    await runsCommand.action(ctx(['start'], { issue: '9', title: 'y' }));
+    expect((writes[0].value as Record<string, unknown>).sessionId).toBeUndefined();
+  });
+
+  it('reads flags under the camelCase key the parser emits AND the declared kebab name', async () => {
+    // parser.ts:normalizeKey rewrites `--session-id` to `sessionId` before the
+    // command runs, so a lookup on the declared kebab name alone silently misses
+    // every multi-word flag — the CLI accepted `--session-id` and recorded null
+    // while the specs, written in kebab, passed. Pin both shapes so neither the
+    // parser's contract nor the fallback can rot unnoticed.
+    await runsCommand.action(
+      ctx(['start'], { issue: '1', title: 'camel', runId: 'flo-camel', sessionId: 'sess-camel' }),
+    );
+    expect(writes[0].key).toBe('flo-camel');
+    expect((writes[0].value as { sessionId: string }).sessionId).toBe('sess-camel');
+
+    writes.length = 0;
+    await runsCommand.action(
+      ctx(['start'], { issue: '1', title: 'kebab', 'run-id': 'flo-kebab', 'session-id': 'sess-kebab' }),
+    );
+    expect(writes[0].key).toBe('flo-kebab');
+    expect((writes[0].value as { sessionId: string }).sessionId).toBe('sess-kebab');
+  });
+
+  it('builds a research context under --research', async () => {
+    await runsCommand.action(ctx(['start'], { issue: '5', title: 'z', research: true }));
+    expect((writes[0].value as { context: { type: string } }).context.type).toBe('research');
+  });
+});
+
+describe('flo runs finalize', () => {
+  async function startRun(): Promise<string> {
+    stampSession(SESSION);
+    await runsCommand.action(
+      ctx(['start'], { issue: '1333', title: 'Join tokens', runId: 'flo-1333-1000', startedAt: '1000' }),
+    );
+    writes.length = 0;
+    return 'flo-1333-1000';
+  }
+
+  it('writes the token rollup into the SAME tasklist record — no parallel store', async () => {
+    const runId = await startRun();
+    const result = await runsCommand.action(ctx(['finalize'], { runId: runId }));
+
+    expect(result.success).toBe(true);
+    // Exactly one write, to the same namespace and key the run already had.
+    // This is what makes the rollup inherit the 200-row tasklist trim rather
+    // than needing orphan handling of its own.
+    expect(writes).toHaveLength(1);
+    expect(writes[0].namespace).toBe('tasklist');
+    expect(writes[0].key).toBe(runId);
+
+    const record = writes[0].value as Record<string, unknown>;
+    expect(record.status).toBe('completed');
+    expect(record.success).toBe(true);
+    expect(record.tokens).toBeDefined();
+  });
+
+  it('preserves the context and startedAt from the running record', async () => {
+    const runId = await startRun();
+    await runsCommand.action(ctx(['finalize'], { runId: runId, endedAt: '5000' }));
+
+    const record = writes[0].value as Record<string, unknown>;
+    expect((record.context as { issueNumber: number }).issueNumber).toBe(1333);
+    expect(record.startedAt).toBe(1000);
+    expect(record.duration).toBe(4000);
+  });
+
+  it('records a zeroed rollup with transcripts: 0 when the transcript is absent', async () => {
+    const runId = await startRun();
+    await runsCommand.action(ctx(['finalize'], { runId: runId }));
+
+    const tokens = (writes[0].value as { tokens: Record<string, number> }).tokens;
+    expect(tokens.total).toBe(0);
+    // Not a measurement of zero cost — a statement that nothing was measurable.
+    expect(tokens.transcripts).toBe(0);
+  });
+
+  it('marks a failed run without claiming a verified outcome', async () => {
+    const runId = await startRun();
+    await runsCommand.action(
+      ctx(['finalize'], { runId: runId, status: 'failed', error: 'tests red' }),
+    );
+
+    const record = writes[0].value as Record<string, unknown>;
+    expect(record.status).toBe('failed');
+    expect(record.success).toBe(false);
+    expect(record.error).toBe('tests red');
+    // The record must not carry anything that reads as external verification
+    // (#1322 — no exit-code signal exists to back such a claim).
+    expect(Object.keys(record)).not.toContain('verified');
+    expect(Object.keys(record)).not.toContain('verifiedOutcome');
+  });
+
+  it('fails loudly when the run was never started', async () => {
+    const result = await runsCommand.action(ctx(['finalize'], { runId: 'flo-does-not-exist' }));
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(writes).toHaveLength(0);
+  });
+
+  it('rejects a status outside completed|failed', async () => {
+    const runId = await startRun();
+    const result = await runsCommand.action(ctx(['finalize'], { runId: runId, status: 'running' }));
+    expect(result.success).toBe(false);
+    expect(writes).toHaveLength(0);
+  });
+
+  it('requires --run-id', async () => {
+    const result = await runsCommand.action(ctx(['finalize']));
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe('flo runs show', () => {
+  it('prints the stored record', async () => {
+    await runsCommand.action(ctx(['start'], { issue: '3', title: 'q', runId: 'flo-3-1' }));
+    const result = await runsCommand.action(ctx(['show'], { runId: 'flo-3-1' }));
+    expect(result.success).toBe(true);
+    expect((result.data as { status: string }).status).toBe('running');
+  });
+
+  it('fails for an unknown id', async () => {
+    const result = await runsCommand.action(ctx(['show'], { runId: 'nope' }));
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('flo runs <unknown>', () => {
+  it('rejects an unknown subcommand', async () => {
+    const result = await runsCommand.action(ctx(['wibble']));
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
+++ b/src/cli/__tests__/services/ephemeral-namespace-purge.test.ts
@@ -151,6 +151,50 @@ describe('purgeEphemeralNamespaces (#729, #968)', () => {
     }
   });
 
+  it('trims a run record and its token rollup as one unit (#1333)', async () => {
+    // The rollup lives INSIDE the tasklist record rather than in a namespace of
+    // its own, and this is the property that buys: the existing trim reclaims
+    // both together, so there is no window in which a rollup outlives the run
+    // it describes and becomes an orphan needing its own retention rules.
+    const withTokens = (i: number) =>
+      JSON.stringify({
+        status: 'completed',
+        success: true,
+        startedAt: 1_700_000_000_000 + i,
+        sessionId: 'sess-abc',
+        tokens: { input: 10 * i, output: i, cacheCreate: 0, cacheRead: 0, total: 11 * i, transcripts: 1, messages: 2, parseErrors: 0 },
+      });
+
+    const dbPath = await makeTmpDb((db) => {
+      const base = 1_700_000_000_000;
+      for (let i = 0; i < 5; i++) {
+        db.run(
+          `INSERT INTO memory_entries (id, key, namespace, content, status, created_at) VALUES (?, ?, ?, ?, 'active', ?)`,
+          [`run-${i}`, `flo-${i}-${base + i}`, 'tasklist', withTokens(i), base + i * 1000],
+        );
+      }
+    });
+
+    const result = await purgeEphemeralNamespaces({ dbPath, tasklistRetentionCap: 2 });
+    expect(result.trimmed).toBe(3);
+
+    const db = openDaemonDatabase(dbPath);
+    try {
+      const rows = db.exec(`SELECT content FROM memory_entries WHERE namespace = 'tasklist' ORDER BY created_at ASC`);
+      const contents = (rows[0]?.values ?? []).map(r => JSON.parse(String(r[0])));
+      expect(contents).toHaveLength(2);
+      // Survivors keep their rollups; nothing was left behind by the trimmed rows.
+      for (const c of contents) expect(c.tokens.total).toBeGreaterThan(0);
+    } finally {
+      db.close();
+    }
+
+    // No sibling namespace was created to hold rollups separately — that is
+    // what would have required orphan handling.
+    expect(countByNamespace(dbPath, 'tokens')).toBe(0);
+    expect(countByNamespace(dbPath, 'run-tokens')).toBe(0);
+  });
+
   it('is idempotent: a clean DB returns zero counts and preserves rows', async () => {
     const dbPath = await makeTmpDb((db) => {
       db.run(

--- a/src/cli/__tests__/services/run-token-rollup.test.ts
+++ b/src/cli/__tests__/services/run-token-rollup.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for per-run token attribution (#1333).
+ *
+ * The unit under test answers "what did THIS run cost", so the cases that
+ * matter are the ones where a naive sum would over-attribute: usage outside the
+ * run's window, usage from another session, and usage on lines that carry no
+ * timestamp to place them by.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  computeRunTokens,
+  emptyRunTokenRollup,
+} from '../../services/run-token-rollup.js';
+
+const SESSION = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), 'moflo-rollup-'));
+});
+
+afterEach(() => {
+  try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+/** One assistant line carrying usage, stamped at `iso`. */
+function usageLine(
+  iso: string,
+  usage: Partial<Record<'input_tokens' | 'output_tokens' | 'cache_creation_input_tokens' | 'cache_read_input_tokens', number>>,
+): string {
+  return JSON.stringify({
+    type: 'assistant',
+    timestamp: iso,
+    sessionId: SESSION,
+    message: { role: 'assistant', model: 'claude-opus-5', usage },
+  });
+}
+
+function writeTranscript(sessionId: string, lines: string[], eol = '\n'): void {
+  writeFileSync(join(projectDir, `${sessionId}.jsonl`), lines.join(eol) + eol, 'utf-8');
+}
+
+function writeSubagentTranscript(sessionId: string, name: string, lines: string[]): void {
+  const dir = join(projectDir, sessionId, 'subagents');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${name}.jsonl`), lines.join('\n') + '\n', 'utf-8');
+}
+
+const T0 = Date.parse('2026-08-04T10:00:00.000Z');
+const MIN = 60_000;
+
+describe('computeRunTokens', () => {
+  it('sums only the usage inside the run window', async () => {
+    writeTranscript(SESSION, [
+      usageLine('2026-08-04T09:59:00.000Z', { input_tokens: 999 }),   // before
+      usageLine('2026-08-04T10:01:00.000Z', { input_tokens: 10, output_tokens: 5 }),
+      usageLine('2026-08-04T10:02:00.000Z', { cache_read_input_tokens: 7 }),
+      usageLine('2026-08-04T10:30:00.000Z', { input_tokens: 888 }),   // after
+    ]);
+
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+
+    expect(r.input).toBe(10);
+    expect(r.output).toBe(5);
+    expect(r.cacheRead).toBe(7);
+    expect(r.total).toBe(22);
+    expect(r.messages).toBe(2);
+  });
+
+  it('includes subagent transcripts — Task-tool spend is part of the run cost', async () => {
+    writeTranscript(SESSION, [usageLine('2026-08-04T10:01:00.000Z', { input_tokens: 100 })]);
+    writeSubagentTranscript(SESSION, 'agent-reviewer', [
+      usageLine('2026-08-04T10:02:00.000Z', { output_tokens: 40 }),
+    ]);
+
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+
+    expect(r.total).toBe(140);
+    expect(r.transcripts).toBe(2);
+  });
+
+  it('ignores another session entirely', async () => {
+    writeTranscript('other-session', [
+      usageLine('2026-08-04T10:01:00.000Z', { input_tokens: 500 }),
+    ]);
+
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+
+    expect(r).toEqual(emptyRunTokenRollup());
+  });
+
+  it('reports transcripts: 0 when the transcript has been pruned', async () => {
+    // Distinguishing "cost nothing" from "could not be measured" is the whole
+    // point of the field — a pruned transcript must not read as a free run.
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+
+    expect(r.total).toBe(0);
+    expect(r.transcripts).toBe(0);
+  });
+
+  it('drops usage lines with no parseable timestamp rather than guessing', async () => {
+    writeTranscript(SESSION, [
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: SESSION,
+        message: { usage: { input_tokens: 4242 } },
+      }),
+    ]);
+
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+
+    expect(r.total).toBe(0);
+    expect(r.messages).toBe(0);
+  });
+
+  it('ignores non-assistant lines that mention usage', async () => {
+    writeTranscript(SESSION, [
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-08-04T10:01:00.000Z',
+        sessionId: SESSION,
+        message: { usage: { input_tokens: 777 } },
+      }),
+      usageLine('2026-08-04T10:01:30.000Z', { input_tokens: 3 }),
+    ]);
+
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+
+    expect(r.total).toBe(3);
+  });
+
+  it('tolerates a CRLF transcript (Rule #1)', async () => {
+    writeTranscript(SESSION, [
+      usageLine('2026-08-04T10:01:00.000Z', { input_tokens: 11 }),
+      usageLine('2026-08-04T10:02:00.000Z', { output_tokens: 22 }),
+    ], '\r\n');
+
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+
+    expect(r.total).toBe(33);
+  });
+
+  it('counts malformed lines without losing the valid ones', async () => {
+    writeTranscript(SESSION, [
+      '{"usage": not json',
+      usageLine('2026-08-04T10:01:00.000Z', { input_tokens: 9 }),
+    ]);
+
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+
+    expect(r.total).toBe(9);
+    expect(r.parseErrors).toBe(1);
+  });
+
+  it('returns the empty rollup for an inverted or missing window', async () => {
+    writeTranscript(SESSION, [usageLine('2026-08-04T10:01:00.000Z', { input_tokens: 5 })]);
+
+    const inverted = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0 + 5 * MIN, toMs: T0,
+    });
+    expect(inverted).toEqual(emptyRunTokenRollup());
+
+    const noSession = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: '', fromMs: T0, toMs: T0 + 5 * MIN,
+    });
+    expect(noSession).toEqual(emptyRunTokenRollup());
+  });
+
+  it('treats window bounds as inclusive', async () => {
+    writeTranscript(SESSION, [
+      usageLine(new Date(T0).toISOString(), { input_tokens: 1 }),
+      usageLine(new Date(T0 + MIN).toISOString(), { input_tokens: 2 }),
+    ]);
+
+    const r = await computeRunTokens(process.cwd(), {
+      projectDir, sessionId: SESSION, fromMs: T0, toMs: T0 + MIN,
+    });
+
+    expect(r.total).toBe(3);
+  });
+});

--- a/src/cli/__tests__/spell-tools-engine.test.ts
+++ b/src/cli/__tests__/spell-tools-engine.test.ts
@@ -7,17 +7,48 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { spellTools, invalidateRegistry } from '../mcp-tools/spell-tools.js';
+import { _resetSharedMemoryAccessorForTest } from '../services/daemon-dashboard.js';
+import { _resetStateRootCacheForTest } from '../services/project-root.js';
 
 // Disable sandbox at the engine layer so the bash steps below run unsandboxed
 // regardless of host capability. Without this, sandbox.enabled=true in the
 // project's moflo.yaml + Windows-without-Docker makes the engine bail out on
 // the prerequisite check before any step runs.
 const ORIGINAL_SANDBOX_ENV = process.env.MOFLO_SANDBOX_DISABLED;
-beforeAll(() => { process.env.MOFLO_SANDBOX_DISABLED = '1'; });
+
+// These specs drive the REAL engine, and a completed cast writes a `tasklist`
+// row via `SpellRunner.storeProgress`. Without an anchor of its own that lands
+// in the developer's actual `.moflo/moflo.db`: measured at 96 of 97 rows in this
+// repo's live store, which buried genuine /flo run records well inside the
+// 200-row retention cap (#1333). `resolveStateRoot()` treats an existing
+// CLAUDE_PROJECT_DIR as authoritative, so pointing it at a scratch dir sends the
+// whole memory stack — DB path and moflo.yaml backend resolution alike — there.
+const ORIGINAL_PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR;
+let scratchRoot: string;
+
+beforeAll(() => {
+  process.env.MOFLO_SANDBOX_DISABLED = '1';
+  scratchRoot = mkdtempSync(join(tmpdir(), 'moflo-spell-engine-'));
+  process.env.CLAUDE_PROJECT_DIR = scratchRoot;
+  // Both caches memoise on the pre-override anchor; drop them so the accessor
+  // this file builds resolves against the scratch dir.
+  _resetStateRootCacheForTest();
+  _resetSharedMemoryAccessorForTest();
+});
+
 afterAll(() => {
   if (ORIGINAL_SANDBOX_ENV === undefined) delete process.env.MOFLO_SANDBOX_DISABLED;
   else process.env.MOFLO_SANDBOX_DISABLED = ORIGINAL_SANDBOX_ENV;
+
+  if (ORIGINAL_PROJECT_DIR === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = ORIGINAL_PROJECT_DIR;
+  _resetStateRootCacheForTest();
+  _resetSharedMemoryAccessorForTest();
+  try { rmSync(scratchRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
 });
 
 function findTool(name: string) {

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -79,6 +79,9 @@ const commandLoaders: Record<string, CommandLoader> = {
   sdd: () => import('./sdd.js'),
   // GitHub Repository Setup
   github: () => import('./github.js'),
+  // /flo run ledger + per-run token rollup (#1333).
+  // Named `runs`, not `run`: `cast` already claims `run` as a global alias.
+  runs: () => import('./runs.js'),
 };
 
 // Cache for loaded commands

--- a/src/cli/commands/runs.ts
+++ b/src/cli/commands/runs.ts
@@ -1,0 +1,286 @@
+/**
+ * `flo runs start|finalize|show` — the run ledger (#1333).
+ *
+ * A `/flo` run's record used to be written by the MODEL: `.claude/skills/fl/phases.md`
+ * Phase 0 carried a hand-copied JSON shape and asked for a `memory_store` call,
+ * while the equivalent code path (`storeFloRunRecord`) sat unused. Two copies of
+ * one schema, and the copy that ran was contingent on an agent remembering to
+ * run it — measured compliance across the retained corpus was a single record.
+ *
+ * These subcommands are that single code path. The skill now shells to them, so
+ * the schema has one home, and `finalize` additionally snapshots the run's token
+ * cost so `tasklist` rows carry (run, tokens, completed-without-error).
+ *
+ * On the tuple's third element: `success` reports that the run reached a
+ * terminal state without reporting an error. It is NOT externally-verified
+ * outcome data — Claude Code's hook payload carries no exit code and PostToolUse
+ * does not fire on Bash failure (#1322). Nothing here should be relabelled to
+ * imply otherwise.
+ *
+ * Cross-platform (Rule #1): pure Node — no shell, no POSIX-only path handling.
+ *
+ * Created with cielolimitada.com
+ */
+
+import type { Command, CommandContext, CommandResult } from '../types.js';
+import type { FloRunContext } from '../spells/types/runner.types.js';
+import { output } from '../output.js';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  buildFloRunContext,
+  storeFloRunRecord,
+  getSharedMemoryAccessor,
+} from '../services/daemon-dashboard.js';
+import { computeRunTokens, emptyRunTokenRollup } from '../services/run-token-rollup.js';
+import { resolveStateRoot } from '../services/project-root.js';
+
+const TASKLIST_NAMESPACE = 'tasklist';
+
+/**
+ * Read the main-loop Claude Code session id stamped by `gate.cjs`'s
+ * `prompt-reminder` case on every UserPromptSubmit.
+ *
+ * Returns null outside a Claude Code session (a bare `flo runs start` from a
+ * terminal), which is correct: with no session there is no transcript, and
+ * `finalize` will record a zeroed rollup rather than attribute someone else's
+ * spend to the run.
+ */
+export function readStampedSessionId(root: string): string | null {
+  const statePath = join(root, '.claude', 'workflow-state.json');
+  if (!existsSync(statePath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, 'utf-8')) as { sessionId?: unknown };
+    return typeof parsed.sessionId === 'string' && parsed.sessionId ? parsed.sessionId : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize what `MemoryAccessor.read` hands back.
+ *
+ * The dashboard accessor JSON-stringifies on `write` but returns the raw
+ * `entry.content` on `read` — only its `search` path parses. So a record that
+ * round-trips through the store comes back as a STRING, and treating it as an
+ * object silently makes every field undefined.
+ */
+function parseRunRecord(raw: unknown): StoredRunRecord | null {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as StoredRunRecord;
+    } catch {
+      return null;
+    }
+  }
+  return typeof raw === 'object' ? (raw as StoredRunRecord) : null;
+}
+
+/** Stored shape of a `flo-*` tasklist row. Mirrors `storeFloRunRecord`. */
+interface StoredRunRecord {
+  status?: string;
+  context?: FloRunContext;
+  startedAt?: number;
+  sessionId?: string;
+  duration?: number;
+  success?: boolean;
+}
+
+/**
+ * Look a flag up under both spellings.
+ *
+ * `parser.ts:normalizeKey` rewrites `--session-id` to `sessionId` before a
+ * command ever sees it, so the declared kebab name is NOT the key on `flags`.
+ * Accepting both keeps the option table readable in one shape while matching
+ * what the parser actually delivers — and is why this indirection exists rather
+ * than indexing `ctx.flags` directly at each call site.
+ */
+function rawFlag(ctx: CommandContext, name: string): unknown {
+  const camel = name.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+  return ctx.flags[camel] ?? ctx.flags[name];
+}
+
+function flagStr(ctx: CommandContext, name: string): string | undefined {
+  const v = rawFlag(ctx, name);
+  // A numeric-looking value (`--run-id 42`) is coerced to a number by
+  // `parseValue`; stringify rather than dropping it.
+  if (typeof v === 'number') return String(v);
+  return typeof v === 'string' && v ? v : undefined;
+}
+
+function flagNum(ctx: CommandContext, name: string): number | undefined {
+  const v = rawFlag(ctx, name);
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string' && v.trim()) {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+function flagBool(ctx: CommandContext, name: string): boolean {
+  return rawFlag(ctx, name) === true;
+}
+
+async function startRun(ctx: CommandContext): Promise<CommandResult> {
+  const root = resolveStateRoot({ cwd: ctx.cwd });
+  const startedAt = flagNum(ctx, 'started-at') ?? Date.now();
+  const issue = flagNum(ctx, 'issue');
+  const title = flagStr(ctx, 'title');
+  const spellName = flagStr(ctx, 'spell');
+  const execModeRaw = flagStr(ctx, 'exec-mode');
+  const execMode =
+    execModeRaw === 'swarm' || execModeRaw === 'hive' ? execModeRaw : 'normal';
+
+  const context = buildFloRunContext({
+    ...(issue !== undefined ? { issueNumber: issue } : {}),
+    ...(title !== undefined ? { issueTitle: title } : {}),
+    ...(spellName !== undefined ? { spellName } : {}),
+    execMode,
+    ...(flagBool(ctx, 'epic') ? { isEpic: true } : {}),
+    ...(flagBool(ctx, 'research') ? { isResearch: true } : {}),
+    ...(flagBool(ctx, 'new-ticket')
+      ? { isNewTicket: true, ...(title !== undefined ? { ticketTitle: title } : {}) }
+      : {}),
+  });
+
+  const runId =
+    flagStr(ctx, 'run-id') ?? `flo-${issue !== undefined ? issue : 'new'}-${startedAt}`;
+  const sessionId = flagStr(ctx, 'session-id') ?? readStampedSessionId(root) ?? undefined;
+
+  const memory = await getSharedMemoryAccessor();
+  if (!memory) {
+    output.printWarning('memory unavailable — run will not appear in The Luminarium');
+    return { success: false, message: 'memory accessor unavailable', exitCode: 1 };
+  }
+
+  await storeFloRunRecord(memory, runId, context, 'running', {
+    startedAt,
+    ...(sessionId ? { sessionId } : {}),
+  });
+
+  // Machine-readable so the skill can capture runId without re-deriving it.
+  output.printInfo(JSON.stringify({ runId, startedAt, sessionId: sessionId ?? null }));
+  return { success: true, data: { runId, startedAt, sessionId: sessionId ?? null } };
+}
+
+async function finalizeRun(ctx: CommandContext): Promise<CommandResult> {
+  const root = resolveStateRoot({ cwd: ctx.cwd });
+  const runId = flagStr(ctx, 'run-id');
+  if (!runId) {
+    output.printError('flo runs finalize requires --run-id');
+    return { success: false, message: 'missing --run-id', exitCode: 1 };
+  }
+  const statusRaw = flagStr(ctx, 'status') ?? 'completed';
+  if (statusRaw !== 'completed' && statusRaw !== 'failed') {
+    output.printError(`--status must be "completed" or "failed" (got "${statusRaw}")`);
+    return { success: false, message: 'invalid --status', exitCode: 1 };
+  }
+
+  const memory = await getSharedMemoryAccessor();
+  if (!memory) {
+    output.printWarning('memory unavailable — run record not finalized');
+    return { success: false, message: 'memory accessor unavailable', exitCode: 1 };
+  }
+
+  const prior = parseRunRecord(await memory.read(TASKLIST_NAMESPACE, runId));
+  if (!prior || !prior.context) {
+    output.printError(`no run record found for ${runId} — was "flo runs start" called?`);
+    return { success: false, message: 'run record not found', exitCode: 1 };
+  }
+
+  const startedAt = prior.startedAt ?? flagNum(ctx, 'started-at');
+  const endedAt = flagNum(ctx, 'ended-at') ?? Date.now();
+  const sessionId = flagStr(ctx, 'session-id') ?? prior.sessionId ?? readStampedSessionId(root);
+
+  // Attribute only what this session spent inside the run's window. With no
+  // session id there is nothing to attribute against — record the zeroed
+  // rollup rather than guess, so a reader can tell "cost nothing" from
+  // "could not be measured" via `transcripts: 0`.
+  // Anchor on the state root, NOT ctx.cwd: Claude Code encodes its project dir
+  // from the directory the session was opened in, so finalizing from a
+  // sub-directory (or anywhere in a monorepo below the root) would encode a
+  // path with no transcripts and silently record a zeroed rollup — the #1315
+  // failure shape.
+  const tokens =
+    sessionId && startedAt !== undefined
+      ? await computeRunTokens(root, { sessionId, fromMs: startedAt, toMs: endedAt })
+      : emptyRunTokenRollup();
+
+  const errorSummary = flagStr(ctx, 'error');
+  await storeFloRunRecord(memory, runId, prior.context, statusRaw, {
+    ...(startedAt !== undefined ? { startedAt, duration: endedAt - startedAt } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(errorSummary ? { error: errorSummary } : {}),
+    tokens,
+  });
+
+  output.printInfo(
+    JSON.stringify({ runId, status: statusRaw, tokens, sessionId: sessionId ?? null }),
+  );
+  return { success: true, data: { runId, status: statusRaw, tokens } };
+}
+
+async function showRun(ctx: CommandContext): Promise<CommandResult> {
+  const runId = flagStr(ctx, 'run-id') ?? ctx.args[1];
+  if (!runId) {
+    output.printError('flo runs show requires a run id');
+    return { success: false, message: 'missing run id', exitCode: 1 };
+  }
+  const memory = await getSharedMemoryAccessor();
+  if (!memory) {
+    return { success: false, message: 'memory accessor unavailable', exitCode: 1 };
+  }
+  // Parse for the same reason `finalize` does — `read` returns the raw stored
+  // string, and printing that gives an escaped one-liner instead of a record.
+  const record = parseRunRecord(await memory.read(TASKLIST_NAMESPACE, runId));
+  if (!record) {
+    output.printError(`no run record found for ${runId}`);
+    return { success: false, message: 'run record not found', exitCode: 1 };
+  }
+  output.printInfo(JSON.stringify(record, null, 2));
+  return { success: true, data: record };
+}
+
+export const runsCommand: Command = {
+  name: 'runs',
+  description:
+    'Record a /flo run and its token cost — usage: flo runs start --issue <n> --title <t> | flo runs finalize --run-id <id> | flo runs show <id>',
+  options: [
+    { name: 'run-id', description: 'Run identifier (start: generated if omitted)', type: 'string' },
+    { name: 'issue', description: 'GitHub issue number', type: 'string' },
+    { name: 'title', description: 'Issue or ticket title', type: 'string' },
+    { name: 'spell', description: 'Spell name for -wf runs', type: 'string' },
+    { name: 'exec-mode', description: 'normal | swarm | hive', type: 'string', default: 'normal' },
+    { name: 'epic', description: 'Record as an epic run', type: 'boolean', default: false },
+    { name: 'research', description: 'Record as a research (-r) run', type: 'boolean', default: false },
+    { name: 'new-ticket', description: 'Record as a new-ticket (-t) run', type: 'boolean', default: false },
+    { name: 'session-id', description: 'Claude Code session id (defaults to the stamped one)', type: 'string' },
+    { name: 'started-at', description: 'Run start, ms since epoch', type: 'string' },
+    { name: 'ended-at', description: 'Run end, ms since epoch (finalize)', type: 'string' },
+    { name: 'status', description: 'completed | failed (finalize)', type: 'string', default: 'completed' },
+    { name: 'error', description: 'Error summary when --status failed', type: 'string' },
+  ],
+  examples: [
+    { command: 'flo runs start --issue 1333 --title "Join tokens to runs"', description: 'Open a run record' },
+    { command: 'flo runs finalize --run-id flo-1333-1785891035226', description: 'Close it and snapshot token cost' },
+    { command: 'flo runs show flo-1333-1785891035226', description: 'Print the stored record' },
+  ],
+  action: async (ctx: CommandContext): Promise<CommandResult> => {
+    const sub = ctx.args[0];
+    switch (sub) {
+      case 'start':
+        return startRun(ctx);
+      case 'finalize':
+        return finalizeRun(ctx);
+      case 'show':
+        return showRun(ctx);
+      default:
+        output.printError(`unknown subcommand "${sub ?? ''}" — expected start | finalize | show`);
+        return { success: false, message: 'unknown subcommand', exitCode: 1 };
+    }
+  },
+};
+
+export default runsCommand;

--- a/src/cli/services/daemon-dashboard.ts
+++ b/src/cli/services/daemon-dashboard.ts
@@ -17,6 +17,7 @@ import { createServer, type Server, type IncomingMessage, type ServerResponse } 
 import type { WorkerDaemon } from './worker-daemon.js';
 import type { MemoryAccessor } from '../spells/types/step-command.types.js';
 import type { FloRunContext } from '../spells/types/runner.types.js';
+import type { RunTokenRollup } from './run-token-rollup.js';
 import type { SchedulerErrorCode } from '../spells/scheduler/scheduler.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import {
@@ -451,13 +452,31 @@ export function buildFloRunContext(opts: {
 /**
  * Store a flo run record to the tasklist namespace for dashboard display.
  * Used by non-spell-engine /flo invocations (ticket, research, epic).
+ *
+ * This is the ONE writer of `flo-*` run records (#1333). It used to be dead
+ * code shadowed by a hand-copied schema in `.claude/skills/fl/phases.md`, which
+ * told the model to `memory_store` the same shape itself; compliance across the
+ * retained corpus was 1 record. `flo run start` / `flo run finalize` now call
+ * through here, so the schema has a single home and the write is not contingent
+ * on an agent remembering to perform it.
  */
 export async function storeFloRunRecord(
   memory: MemoryAccessor,
   runId: string,
   context: FloRunContext,
   status: 'running' | 'completed' | 'failed',
-  extra?: { startedAt?: number; duration?: number; error?: string },
+  extra?: {
+    startedAt?: number;
+    duration?: number;
+    error?: string;
+    /** Claude Code session id — the join key from run record to transcript (#1333). */
+    sessionId?: string;
+    /**
+     * Token rollup for the run. Snapshotted at finalize rather than joined on
+     * read, because Claude Code prunes transcripts — see `run-token-rollup.ts`.
+     */
+    tokens?: RunTokenRollup;
+  },
 ): Promise<void> {
   try {
     const record: Record<string, unknown> = {
@@ -468,6 +487,12 @@ export async function storeFloRunRecord(
     };
     if (extra?.startedAt) record.startedAt = extra.startedAt;
     if (extra?.duration != null) record.duration = extra.duration;
+    if (extra?.sessionId) record.sessionId = extra.sessionId;
+    if (extra?.tokens) record.tokens = extra.tokens;
+    // `success` means "the run reached a terminal state without reporting an
+    // error". It is NOT a verification that the work was correct — no such
+    // signal exists (#1322: hook payloads carry no exit code). Do not rename
+    // this to anything that reads as a verified outcome.
     if (status === 'completed') record.success = true;
     if (status === 'failed') {
       record.success = false;

--- a/src/cli/services/run-token-rollup.ts
+++ b/src/cli/services/run-token-rollup.ts
@@ -1,0 +1,228 @@
+/**
+ * Per-run token attribution — issue #1333.
+ *
+ * `claude-stats.ts` answers "what has this project spent"; it aggregates every
+ * transcript in the project dir into windows and model distributions. It cannot
+ * answer "what did THIS run cost", because a run is a stretch of wall-clock
+ * inside one session, and nothing in that aggregation is keyed to a run.
+ *
+ * This module is the narrow counterpart: given a session id and a time window,
+ * sum the `usage` counters for exactly that slice. The result is written into
+ * the run's existing `tasklist` record (see `storeFloRunRecord`), so cost and
+ * outcome finally share a key.
+ *
+ * Deliberately NOT folded into `claude-stats.ts`: that module's aggregation is
+ * on the dashboard's hot path behind a 30s cache, and #1333 requires its
+ * behaviour to stay byte-identical. This reads one session's files, not the
+ * whole project dir.
+ *
+ * Why persist rather than join on read: the retained transcript corpus is
+ * shallow — measured at ~2 days on this repo — because Claude Code prunes
+ * `~/.claude/projects/**`. A rollup computed on demand would report a run's
+ * cost correctly today and zero next week. Snapshotting at finalize time is
+ * what makes the number durable.
+ *
+ * Cross-platform (Rule #1): pure `node:fs` + `path.join`, no shell, and the
+ * reader tolerates CRLF because `readline` splits on both.
+ */
+
+import { createReadStream } from 'node:fs';
+import { stat, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import { claudeProjectDirFor } from '../shared/utils/claude-projects-path.js';
+
+/**
+ * Token counters for one run. Field names mirror `ClaudeStatsWindow['tokens']`
+ * so a reader that already understands the stats shape needs no translation.
+ */
+export interface RunTokenRollup {
+  readonly input: number;
+  readonly output: number;
+  readonly cacheCreate: number;
+  readonly cacheRead: number;
+  readonly total: number;
+  /** Transcript files actually read (main + subagent). 0 ⇒ nothing attributed. */
+  readonly transcripts: number;
+  /** Assistant messages whose usage was counted — the sample size behind the sum. */
+  readonly messages: number;
+  /** Lines that failed to parse; surfaced so a silent zero is distinguishable. */
+  readonly parseErrors: number;
+}
+
+export interface ComputeRunTokensOptions {
+  /** Project directory whose transcripts to read. Defaults to `cwd`'s encoding. */
+  readonly projectDir?: string;
+  /** Claude Code session id — the transcript basename. */
+  readonly sessionId: string;
+  /** Window start, ms since epoch (inclusive). */
+  readonly fromMs: number;
+  /**
+   * Window end, ms since epoch (inclusive). Defaults to `Date.now()` at call
+   * time — a run being finalized ends now.
+   */
+  readonly toMs?: number;
+}
+
+interface UsageLine {
+  type?: string;
+  timestamp?: string;
+  message?: {
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+}
+
+interface MutableRollup {
+  input: number;
+  output: number;
+  cacheCreate: number;
+  cacheRead: number;
+  messages: number;
+  parseErrors: number;
+}
+
+/** The all-zero rollup — returned when no transcript is attributable. */
+export function emptyRunTokenRollup(): RunTokenRollup {
+  return {
+    input: 0,
+    output: 0,
+    cacheCreate: 0,
+    cacheRead: 0,
+    total: 0,
+    transcripts: 0,
+    messages: 0,
+    parseErrors: 0,
+  };
+}
+
+/**
+ * Collect the transcript files attributable to one session: the session's own
+ * `<sessionId>.jsonl` plus every `<sessionId>/subagents/*.jsonl` (Task-tool
+ * spawns, which carry their parent's session id and are part of the run's
+ * real cost). Missing files are simply absent from the result — a session with
+ * no subagents is the common case, not an error.
+ */
+async function sessionTranscripts(projectDir: string, sessionId: string): Promise<string[]> {
+  const paths: string[] = [];
+
+  const main = join(projectDir, `${sessionId}.jsonl`);
+  try {
+    if ((await stat(main)).isFile()) paths.push(main);
+  } catch {
+    // No main transcript (pruned, or the id is wrong) — subagents may still exist.
+  }
+
+  const subDir = join(projectDir, sessionId, 'subagents');
+  let names: string[];
+  try {
+    names = await readdir(subDir);
+  } catch {
+    return paths;
+  }
+  for (const name of names) {
+    if (!name.endsWith('.jsonl')) continue;
+    const full = join(subDir, name);
+    try {
+      if ((await stat(full)).isFile()) paths.push(full);
+    } catch {
+      // Rotated mid-listing — skip.
+    }
+  }
+  return paths;
+}
+
+async function streamUsage(
+  acc: MutableRollup,
+  path: string,
+  fromMs: number,
+  toMs: number,
+): Promise<void> {
+  const rl = createInterface({
+    input: createReadStream(path, { encoding: 'utf-8' }),
+    crlfDelay: Infinity,
+  });
+  for await (const raw of rl) {
+    if (!raw) continue;
+    // Cheap reject before JSON.parse — most lines carry no usage at all.
+    if (raw.indexOf('"usage"') < 0) continue;
+    let line: UsageLine;
+    try {
+      line = JSON.parse(raw) as UsageLine;
+    } catch {
+      acc.parseErrors++;
+      continue;
+    }
+    if (line.type !== 'assistant') continue;
+    const usage = line.message?.usage;
+    if (!usage) continue;
+
+    // A line with no parseable timestamp cannot be placed in the window. Drop
+    // it rather than guess — over-attributing another run's spend to this one
+    // is worse than under-reporting, because the number is meant to be joined.
+    const ts = line.timestamp ? Date.parse(line.timestamp) : NaN;
+    if (!Number.isFinite(ts) || ts < fromMs || ts > toMs) continue;
+
+    acc.input += usage.input_tokens ?? 0;
+    acc.output += usage.output_tokens ?? 0;
+    acc.cacheCreate += usage.cache_creation_input_tokens ?? 0;
+    acc.cacheRead += usage.cache_read_input_tokens ?? 0;
+    acc.messages++;
+  }
+}
+
+/**
+ * Sum the token usage recorded for `sessionId` between `fromMs` and `toMs`.
+ *
+ * Returns {@link emptyRunTokenRollup} — never throws — when the project dir or
+ * transcript is absent. A run whose transcript has been pruned is a run with
+ * no attributable cost, which is exactly what a zeroed rollup with
+ * `transcripts: 0` communicates to a reader.
+ */
+export async function computeRunTokens(
+  cwd: string,
+  options: ComputeRunTokensOptions,
+): Promise<RunTokenRollup> {
+  const projectDir = options.projectDir ?? claudeProjectDirFor(cwd);
+  const toMs = options.toMs ?? Date.now();
+  const { sessionId, fromMs } = options;
+
+  if (!sessionId || !Number.isFinite(fromMs) || !Number.isFinite(toMs) || toMs < fromMs) {
+    return emptyRunTokenRollup();
+  }
+
+  const paths = await sessionTranscripts(projectDir, sessionId);
+  if (paths.length === 0) return emptyRunTokenRollup();
+
+  const acc: MutableRollup = {
+    input: 0, output: 0, cacheCreate: 0, cacheRead: 0, messages: 0, parseErrors: 0,
+  };
+  let read = 0;
+  for (const path of paths) {
+    // Counted before streaming, not after: a file that throws part-way has
+    // already contributed its parsed lines to `acc`, so incrementing only on
+    // clean completion would report a transcript count lower than the number
+    // actually folded into the sum.
+    read++;
+    try {
+      await streamUsage(acc, path, fromMs, toMs);
+    } catch {
+      // One unreadable transcript must not blank the whole rollup.
+    }
+  }
+
+  return {
+    input: acc.input,
+    output: acc.output,
+    cacheCreate: acc.cacheCreate,
+    cacheRead: acc.cacheRead,
+    total: acc.input + acc.output + acc.cacheCreate + acc.cacheRead,
+    transcripts: read,
+    messages: acc.messages,
+    parseErrors: acc.parseErrors,
+  };
+}

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -931,6 +931,53 @@ describe('gate.cjs: prompt-reminder', () => {
     expect(readState(tmpDir).memoryRequired).toBe(false);
   });
 
+  // #1333 — `flo run finalize` attributes transcript token usage to a run, and
+  // needs the MAIN-LOOP session id to do it. UserPromptSubmit is the one hook
+  // that only the top-level session triggers, which is why the stamp lives here
+  // rather than alongside the per-actor `memorySearchedBy` map.
+  it('stamps the main-loop session id for run token attribution', () => {
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'implement the token rollup for flo runs';
+    env.HOOK_SESSION_ID = 'sess-main-1333';
+    runGate('prompt-reminder', env);
+    expect(readState(tmpDir).sessionId).toBe('sess-main-1333');
+  });
+
+  it('refreshes the stamped session id when a new session submits a prompt', () => {
+    // A /clear mints a new session id; the stale one must not stick, or the
+    // rollup would read the previous session's transcript.
+    writeState(tmpDir, { sessionId: 'sess-old' });
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'continue the work on the rollup';
+    env.HOOK_SESSION_ID = 'sess-new';
+    runGate('prompt-reminder', env);
+    expect(readState(tmpDir).sessionId).toBe('sess-new');
+  });
+
+  it('leaves a previously stamped session id alone when the host sends none', () => {
+    // Older Claude Code hosts (and direct CLI invocations) forward no
+    // session_id. Clearing the stamp there would silently disable attribution
+    // for the rest of the session.
+    writeState(tmpDir, { sessionId: 'sess-kept' });
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'keep going with the implementation work';
+    runGate('prompt-reminder', env);
+    expect(readState(tmpDir).sessionId).toBe('sess-kept');
+  });
+
+  it('survives the per-prompt state reset', () => {
+    // applyPromptStateReset runs first and wipes per-prompt flags; the stamp is
+    // written after it precisely so attribution outlives the reset.
+    writeState(tmpDir, { memorySearched: true, sessionId: 'sess-persist' });
+    const env = baseEnv(tmpDir);
+    env.CLAUDE_USER_PROMPT = 'fix the authentication bug in the login page';
+    env.HOOK_SESSION_ID = 'sess-persist';
+    runGate('prompt-reminder', env);
+    const s = readState(tmpDir);
+    expect(s.memorySearched).toBe(false); // reset did run
+    expect(s.sessionId).toBe('sess-persist');
+  });
+
   it('classifies "ok" as directive (no memory)', () => {
     const env = baseEnv(tmpDir);
     env.CLAUDE_USER_PROMPT = 'ok';

--- a/tests/guards/test-store-isolation-guard.test.ts
+++ b/tests/guards/test-store-isolation-guard.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Guard: a test that drives the real spell engine must anchor its state at a
+ * scratch directory, not the developer's project.
+ *
+ * `SpellRunner.storeProgress` writes a `tasklist` row on every terminal spell
+ * run. Tests that call the real `spell_cast` / `spell_execute` MCP handlers
+ * therefore persist into whatever `.moflo/moflo.db` `resolveStateRoot()` picks
+ * — and with no override that is the repo you are working in. Measured on this
+ * repo (#1333): 96 of 97 live `tasklist` rows were `execute-test` echo probes
+ * emitted by `npm test`, against a `TASKLIST_RETENTION_CAP` of 200. Two days of
+ * running the suite was enough to evict every genuine `/flo` run record, which
+ * is the data the cap exists to retain.
+ *
+ * The fix is one line of setup: point `CLAUDE_PROJECT_DIR` at a temp dir before
+ * the first handler call (`resolveStateRoot` treats an existing value as
+ * authoritative) and restore it afterwards.
+ *
+ * If this goes red, do NOT add the file to an exemption list — give it the
+ * scratch anchor. A test that mutates the developer's real store is a test that
+ * corrupts the data another feature is measured against.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, relative } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+
+/** Roots that hold test files capable of reaching the real engine. */
+const TEST_ROOTS = ['src/cli/__tests__', 'tests'] as const;
+
+/**
+ * Importing this module gets you the live MCP handlers, which construct a real
+ * runner backed by `getSharedMemoryAccessor()`.
+ */
+const REAL_ENGINE_IMPORT = /from\s+['"][^'"]*mcp-tools\/spell-tools\.js['"]/;
+
+/**
+ * The handlers that actually RUN a spell, and so reach
+ * `SpellRunner.storeProgress` → `memory.write('tasklist', …)`. The import alone
+ * is not enough to require an anchor: `spell_list` and `spell_create` return
+ * definitions without executing anything, and demanding a scratch dir from a
+ * schema-only suite would be cargo-culted setup that future readers delete.
+ */
+const EXECUTES_A_SPELL = /\bspell_(cast|execute|resume)\b/;
+
+/**
+ * The anchor override. Any assignment counts — the guard checks that the file
+ * takes responsibility for its state root, not how it phrases it.
+ */
+const ANCHORS_STATE_ROOT = /CLAUDE_PROJECT_DIR\s*=/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    let isDir: boolean;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (isDir) {
+      if (name === 'node_modules' || name === 'fixtures') continue;
+      walk(full, out);
+    } else if (name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('guard: tests must not write to the real .moflo store', () => {
+  const files = TEST_ROOTS.flatMap((root) => walk(join(REPO_ROOT, root)));
+
+  it('finds test files to check (guard is not silently vacuous)', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  /** Files this guard considers in scope — computed once, asserted non-empty below. */
+  const engineDriving = files.filter((file) => {
+    // The guard describes itself; skip so its own regexes don't trip it.
+    if (file === __filename) return false;
+    const source = readFileSync(file, 'utf-8');
+    return REAL_ENGINE_IMPORT.test(source) && EXECUTES_A_SPELL.test(source);
+  });
+
+  it('still matches at least one engine-driving test (patterns have not gone stale)', () => {
+    // Without this, a rename of `spell_cast` or of the tools module would make
+    // the guard below pass by matching nothing at all — green, and worthless.
+    expect(engineDriving.map((f) => relative(REPO_ROOT, f))).not.toEqual([]);
+  });
+
+  it('every test driving the real spell engine anchors CLAUDE_PROJECT_DIR at a scratch dir', () => {
+    const offenders: string[] = [];
+
+    for (const file of engineDriving) {
+      if (ANCHORS_STATE_ROOT.test(readFileSync(file, 'utf-8'))) continue;
+      offenders.push(relative(REPO_ROOT, file));
+    }
+
+    expect(
+      offenders,
+      `These tests import the real spell-tools handlers but never override ` +
+        `CLAUDE_PROJECT_DIR, so their spell runs write tasklist rows into the ` +
+        `developer's own .moflo/moflo.db (#1333). Give each a mkdtempSync anchor ` +
+        `in beforeAll and restore it in afterAll — do not exempt them.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Token measurement and run outcomes lived in the same system and never met, so "what did this run cost" had no answer.

I measured the store before building, and it changed the shape of the work. Of **97 `tasklist` rows, 96 were `execute-test` echo probes written by `npm test`** into the developer's own `.moflo/moflo.db` — 33 ms each, zero tokens — and exactly **1** was a real `/flo` run. Against `TASKLIST_RETENTION_CAP = 200`, the retention horizon was never "200 runs"; it was **~2 days before test noise evicted every genuine record**. Joining token rollups to that namespace as it stood would have keyed them to test exhaust.

Two more findings followed:

- **The run record was prompt-owned.** `.claude/skills/fl/phases.md` Phase 0 carried a hand-copied JSON schema and asked the model to `memory_store` it. Compliance across the retained corpus was one record — the `/flo` run that produced this analysis didn't write one either.
- **`storeFloRunRecord` was dead code**: exported, tested, cited by `phases.md:44` as the schema of record, with no non-test caller. Two copies of one schema, and the copy that ran depended on remembering to run it.

So this PR does the prerequisites and the join together, as one change.

## Changes

- **Test isolation** — `spell-tools-engine.test.ts` anchors `CLAUDE_PROJECT_DIR` at a scratch dir before the first handler call. `tests/guards/test-store-isolation-guard.test.ts` fails if an engine-driving test skips that, with a non-vacuity check so a rename can't make it silently pass.
- **`flo runs start | finalize | show`** (`src/cli/commands/runs.ts`) — the single writer of `flo-*` records, calling the now-live `storeFloRunRecord`. Named `runs` because `cast` already claims `run` as a global alias.
- **`run-token-rollup.ts`** — sums `usage` for one session inside the run's window, including its `subagents/*.jsonl` (Task-tool spend is part of the cost). Kept out of `claude-stats.ts` so `/api/claude-stats` is untouched.
- **`gate.cjs`** stamps the main-loop session id on `UserPromptSubmit` — the one hook a subagent never triggers, so attribution targets the right transcript. No `settings.json` change, so consumers need no hook re-graft.
- **`phases.md`** Phase 0 now shells to `flo runs start`; new Phase 5.5 closes the record.

## Decisions the ticket left open

| Question | Decision | Why |
|---|---|---|
| Rollup in the record, or its own retention? | **Same record** | Trimmed and capped with the run; no orphan handling needed. |
| Persist, or join at read time? | **Persist** | Claude Code prunes transcripts (~2 days measured); a read-time join is correct today and zero next week. |
| Price spell runs too? | **No** | `agent-command.ts` is non-executable (#1334) — spells spend no tokens of their own. |

## Scope kept honest

`success` means the run reached a terminal state without reporting an error. It is **not** externally-verified outcome data — no such signal exists (#1322: hook payloads carry no exit code, PostToolUse doesn't fire on Bash failure). The achievable tuple is `(run, tokens, completed-without-error)`, and `tokens.transcripts: 0` distinguishes *couldn't be measured* from *cost nothing*.

## Testing

Dogfooded end-to-end against this session's real transcript — `finalize` recorded 59,125,946 tokens across 4 transcripts / 392 messages, and `show` read it back by run id. That dogfood caught two bugs the specs had missed:

- the CLI parser rewrites `--session-id` → `sessionId`, so kebab-keyed lookups silently returned undefined — and the tests, also written in kebab, passed;
- `MemoryAccessor.read` returns the raw stored **string** (only `search` parses), so `finalize` reported "no run record found" for a row that was in the DB.

Both are now fixed, and the test double mirrors the real accessor's stringify-on-write / raw-on-read asymmetry so it would fail rather than hide them.

- [x] Full suite: **10171 passed / 0 failed**
- [x] `npm run lint` clean, `tsc` clean
- [x] Guard tests green, including the new isolation guard
- [x] `/verify` PASS on all 7 acceptance criteria (`verify:1333`)
- [x] Manual/dogfood verification of `start`, `finalize`, and `show`

Reviewed at DEEP tier by self-review across reuse/quality/efficiency rather than the classifier's 3-Opus fan-out (agent dispatch not authorized in this session); it found the `ctx.cwd`-vs-state-root anchoring bug fixed here.

Closes #1333
