### PR TITLE
feat(spells): bound spend on daemon-scheduled spells that invoke claude -p (#1335)

### DIFF
--- a/.claude/guidance/shipped/moflo-spell-scheduling.md
+++ b/.claude/guidance/shipped/moflo-spell-scheduling.md
@@ -87,6 +87,29 @@ Practical floors:
 
 ---
 
+## Bounding Spend on Unattended Runs
+
+**Set `spells.budget.scheduled` before scheduling any spell that invokes `claude -p`.** A scheduled run is unattended: nothing observes how many times it calls the model, so a loop step or a too-frequent cron can spend without a signal until the bill arrives. The ceiling is opt-in and absent by default.
+
+```yaml
+spells:
+  budget:
+    scheduled:
+      maxModelInvocations: 20     # `claude -p` spawns allowed per run
+      maxWallClockMs: 1800000     # 30 minutes end to end
+```
+
+| Ceiling | Enforced | On breach |
+|---------|----------|-----------|
+| `maxModelInvocations` | Reservation before the process spawns | The spawn is refused — a denied invocation is never billed |
+| `maxWallClockMs` | Deadline timer on the run's abort signal | The in-flight step is aborted |
+
+**A breach aborts the run and ignores `continueOnError`.** It surfaces three ways: a `BUDGET_EXCEEDED` error on the result, `abortReason: budget-exceeded` plus a structured `budgetBreach` in the run's `tasklist` record, and a warning line in the daemon log.
+
+**This is a proxy for spend, not a measurement of it.** moflo counts invocations, not tokens — metering would require changing what a bash step returns to downstream steps. Use `spells.budget.interactive` (configured separately, never inherited from `scheduled`) to cap session-attached runs, and a per-spell `budget:` block to tighten a single spell. Full key reference: `.claude/guidance/moflo-yaml-reference.md`.
+
+---
+
 ## Storage Namespaces
 
 **Two memory namespaces back the scheduler.** Both are project-scoped — schedules and history don't leak across projects.
@@ -221,5 +244,6 @@ If step 5 is empty, jump straight to the failure-modes table above — don't loo
 - `.claude/guidance/moflo-spell-engine.md` — Definition format, step types, variable interpolation
 - `.claude/guidance/moflo-spell-runner.md` — Execution lifecycle, dry-run, layering, errors
 - `.claude/guidance/moflo-spell-sandboxing.md` — Capability levels (`read`/`hooks`/`swarm`) referenced by the `mofloLevel` cap
+- `.claude/guidance/moflo-yaml-reference.md` — Full `spells.budget` key reference and the per-spell `budget:` block
 - `.claude/guidance/moflo-spell-troubleshooting.md` — Broader spell failure-mode catalog beyond scheduling
 - `.claude/guidance/moflo-core-guidance.md` — CLI, hooks, daemon, MCP reference hub

--- a/.claude/guidance/shipped/moflo-yaml-reference.md
+++ b/.claude/guidance/shipped/moflo-yaml-reference.md
@@ -116,6 +116,15 @@ sandbox:
   enabled: false                  # Set to true to wrap bash steps in an OS sandbox
   tier: auto                      # auto | denylist-only | full
 
+# Spell spend ceilings (OPTIONAL — omit for unbounded runs, which is the default)
+spells:
+  budget:
+    scheduled:                    # Daemon-scheduled runs (cron/interval/at)
+      maxModelInvocations: 20     # Max `claude -p` spawns per run
+      maxWallClockMs: 1800000     # Max run duration (30 min)
+    interactive:                  # Session-attached runs — omit to leave uncapped
+      maxModelInvocations: 50
+
 # Auto-update on session start (refreshes consumer assets when moflo upgrades)
 auto_update:
   enabled: true                          # Master toggle for version-change auto-sync
@@ -130,6 +139,35 @@ skills:
 ```
 
 If your `moflo.yaml` predates the `sandbox:` or `auto_update:` blocks, they are auto-appended on the next session start — you never need to re-run `moflo init` after a version bump.
+
+### Bounding Spell Spend with `spells.budget`
+
+**Set `spells.budget.scheduled` on any project whose spells invoke `claude -p` from a cron or interval schedule.** A scheduled spell runs unattended, so a loop step or a mistyped cron can invoke the model repeatedly with nothing observing the spend until the bill arrives. The ceiling bounds worst-case exposure.
+
+| Key | Counts | On breach |
+|-----|--------|-----------|
+| `maxModelInvocations` | `claude -p` spawns detected in bash steps | The next spawn is refused **before** the process starts, and the run aborts |
+| `maxWallClockMs` | Elapsed time since the run started | The in-flight step is aborted and the run ends |
+
+**Both keys are optional and both default to unlimited.** Omitting the `spells:` block entirely leaves every run exactly as it behaves without this setting.
+
+**`scheduled` and `interactive` are configured separately, and neither inherits from the other.** Setting `scheduled` never caps a `flo spell cast` you run yourself — session-attached runs stay uncapped until you add `interactive` explicitly.
+
+A spell may also declare its own `budget:` block; the effective ceiling is the **stricter** of the two, so a project cap can tighten a spell and a spell can tighten itself further, but neither can loosen the other:
+
+```yaml
+# my-spell.yaml — this spell should never call the model more than twice
+name: my-spell
+budget:
+  maxModelInvocations: 2
+steps:
+  - id: analyze
+    type: bash
+    config:
+      command: claude -p "summarize the diff"
+```
+
+A breach ends the run with a `BUDGET_EXCEEDED` error, records `abortReason: budget-exceeded` plus a structured `budgetBreach` (`kind`, `limit`, `observed`) in the run's record, and — on the daemon path — writes a warning line to the daemon log. `continueOnError` does not suppress it.
 
 ### Narrowing Installed Skills with `skills.categories`
 
@@ -259,4 +297,5 @@ Global registration is useful for ad-hoc projects where you don't want to commit
 - `.claude/guidance/moflo-core-guidance.md` — Hub: getting started, anti-drift defaults, troubleshooting
 - `.claude/guidance/moflo-cli-reference.md` — Commands, agents, hooks, hive-mind, ruvector — the surfaces this config gates
 - `.claude/guidance/moflo-spell-sandboxing.md` — What `sandbox:` actually does at the bash-step boundary, with capability/permission interaction
+- `.claude/guidance/moflo-spell-scheduling.md` — Where `scheduler:` and `spells.budget.scheduled` take effect: the unattended run loop
 - `.claude/guidance/moflo-settings-injection.md` — What moflo writes into `.claude/settings.json` (the hook wiring; complementary to `moflo.yaml` toggles)

--- a/src/cli/__tests__/services/daemon-spell-executor.test.ts
+++ b/src/cli/__tests__/services/daemon-spell-executor.test.ts
@@ -45,6 +45,7 @@ function makeEngine(): EngineModule & {
   bridgeExecuteSpell: Mock;
   bridgeCancelSpell: Mock;
   loadSandboxConfigFromProject: Mock;
+  loadSpellBudgetFromProject: Mock;
 } {
   const emptySandbox: SandboxConfig = {
     enabled: false,
@@ -66,6 +67,8 @@ function makeEngine(): EngineModule & {
     SpellScheduler: vi.fn() as unknown as EngineModule['SpellScheduler'],
     runSpellFromContent: vi.fn(),
     loadSandboxConfigFromProject: vi.fn().mockResolvedValue(emptySandbox),
+    // Default: no ceiling configured — the behaviour every install has today.
+    loadSpellBudgetFromProject: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -373,5 +376,114 @@ describe('DaemonSpellExecutor — yaml reload (real Grimoire)', () => {
     const [secondDef] = engine.bridgeExecuteSpell.mock.calls[1];
     expect(secondDef.version).toBe('2.0');
     expect(secondDef.steps[0].config.command).toBe('echo after');
+  });
+
+  // ── Spend ceiling (#1335) ───────────────────────────────────────────────
+
+  describe('spend ceiling', () => {
+    it('passes the scheduled ceiling from moflo.yaml to the engine', async () => {
+      const registry = makeRegistry({ 'my-spell': makeDefinition({ name: 'my-spell' }) });
+      engine.loadSpellBudgetFromProject.mockResolvedValue({ maxModelInvocations: 7 });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      await exec.execute('my-spell', {});
+
+      expect(engine.loadSpellBudgetFromProject).toHaveBeenCalledWith('/p', 'scheduled');
+      const [, , opts] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(opts.budget).toEqual({ maxModelInvocations: 7 });
+    });
+
+    it('omits budget entirely when nothing is configured', async () => {
+      // Issue #1335 AC3: unset means today's behaviour exactly. A `budget:
+      // undefined` key would still be a shape change for anything reading the
+      // options object, so the key must be absent, not present-and-empty.
+      const registry = makeRegistry({ 'my-spell': makeDefinition({ name: 'my-spell' }) });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      await exec.execute('my-spell', {});
+
+      const [, , opts] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(Object.keys(opts)).not.toContain('budget');
+    });
+
+    it('prefers an explicitly injected ceiling over moflo.yaml', async () => {
+      const registry = makeRegistry({ 'my-spell': makeDefinition({ name: 'my-spell' }) });
+      const exec = new DaemonSpellExecutor({
+        registry, projectRoot: '/p', engine,
+        budgetConfig: { maxWallClockMs: 1234 },
+      });
+
+      await exec.execute('my-spell', {});
+
+      expect(engine.loadSpellBudgetFromProject).not.toHaveBeenCalled();
+      const [, , opts] = engine.bridgeExecuteSpell.mock.calls[0];
+      expect(opts.budget).toEqual({ maxWallClockMs: 1234 });
+    });
+
+    it('re-reads the ceiling on every fire, so a yaml edit lands without restart', async () => {
+      const registry = makeRegistry({ 'my-spell': makeDefinition({ name: 'my-spell' }) });
+      engine.loadSpellBudgetFromProject
+        .mockResolvedValueOnce({ maxModelInvocations: 2 })
+        .mockResolvedValueOnce({ maxModelInvocations: 9 });
+      const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+
+      await exec.execute('my-spell', {});
+      await exec.execute('my-spell', {});
+
+      expect(engine.bridgeExecuteSpell.mock.calls[0][2].budget).toEqual({ maxModelInvocations: 2 });
+      expect(engine.bridgeExecuteSpell.mock.calls[1][2].budget).toEqual({ maxModelInvocations: 9 });
+    });
+
+    it('logs a breach so it reaches the daemon log, not only the run record', async () => {
+      // A ceiling that fires silently in an unattended process is
+      // indistinguishable from the runaway it prevented.
+      const registry = makeRegistry({ 'my-spell': makeDefinition({ name: 'my-spell' }) });
+      engine.bridgeExecuteSpell.mockResolvedValue({
+        spellId: 'scheduled-my-spell-1',
+        success: false,
+        steps: [],
+        outputs: {},
+        errors: [{ code: 'BUDGET_EXCEEDED', message: 'ceiling of 2 exceeded' }],
+        duration: 12,
+        cancelled: false,
+      } satisfies SpellResult);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+        const result = await exec.execute('my-spell', {});
+
+        expect(result.success).toBe(false);
+        expect(warn).toHaveBeenCalledTimes(1);
+        const line = String(warn.mock.calls[0][0]);
+        expect(line).toContain('spend ceiling');
+        expect(line).toContain('my-spell');
+        expect(line).toContain('ceiling of 2 exceeded');
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('stays quiet for an ordinary failure', async () => {
+      const registry = makeRegistry({ 'my-spell': makeDefinition({ name: 'my-spell' }) });
+      engine.bridgeExecuteSpell.mockResolvedValue({
+        spellId: 'scheduled-my-spell-1',
+        success: false,
+        steps: [],
+        outputs: {},
+        errors: [{ code: 'STEP_EXECUTION_FAILED', message: 'boom' }],
+        duration: 12,
+        cancelled: false,
+      } satisfies SpellResult);
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const exec = new DaemonSpellExecutor({ registry, projectRoot: '/p', engine });
+        await exec.execute('my-spell', {});
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
 });

--- a/src/cli/__tests__/spells/run-budget.test.ts
+++ b/src/cli/__tests__/spells/run-budget.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Tests for the spell run budget primitive (#1335).
+ *
+ * The unit under test is a safety ceiling, so the cases that matter are the
+ * ones where a mistake fails OPEN — a config typo silently meaning "no
+ * ceiling", a merge that loosens instead of tightens, a breach that does not
+ * latch. Each of those leaves an unattended spell unbounded, which is the
+ * exact exposure the feature exists to close.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createRunBudget,
+  hasBudgetLimit,
+  loadSpellBudgetFromProject,
+  mergeSpellBudgets,
+  resolveSpellBudgetConfig,
+  SpellRunBudget,
+} from '../../spells/core/run-budget.js';
+
+const scratchDirs: string[] = [];
+
+function scratchProject(yaml?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'moflo-budget-'));
+  scratchDirs.push(dir);
+  if (yaml !== undefined) writeFileSync(join(dir, 'moflo.yaml'), yaml, 'utf-8');
+  return dir;
+}
+
+afterEach(() => {
+  while (scratchDirs.length > 0) {
+    const dir = scratchDirs.pop();
+    if (dir) { try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ } }
+  }
+});
+
+// ============================================================================
+// Config parsing
+// ============================================================================
+
+describe('resolveSpellBudgetConfig', () => {
+  it('reads camelCase keys', () => {
+    expect(resolveSpellBudgetConfig({ maxModelInvocations: 5, maxWallClockMs: 1000 }))
+      .toEqual({ maxModelInvocations: 5, maxWallClockMs: 1000 });
+  });
+
+  it('reads snake_case keys, matching the sandbox block', () => {
+    expect(resolveSpellBudgetConfig({ max_model_invocations: 7, max_wall_clock_ms: 2000 }))
+      .toEqual({ maxModelInvocations: 7, maxWallClockMs: 2000 });
+  });
+
+  it('drops non-positive and non-numeric limits instead of clamping them', () => {
+    // A clamped `0` would become a ceiling nobody asked for; a coerced string
+    // would enforce a number the user never wrote. Dropping is the only
+    // reading that cannot silently change what runs.
+    expect(resolveSpellBudgetConfig({ maxModelInvocations: 0 })).toBeUndefined();
+    expect(resolveSpellBudgetConfig({ maxModelInvocations: -3 })).toBeUndefined();
+    expect(resolveSpellBudgetConfig({ maxWallClockMs: '5000' })).toBeUndefined();
+    expect(resolveSpellBudgetConfig({ maxWallClockMs: Number.NaN })).toBeUndefined();
+    expect(resolveSpellBudgetConfig({ maxWallClockMs: Infinity })).toBeUndefined();
+  });
+
+  it('keeps the usable half of a partly-broken block', () => {
+    expect(resolveSpellBudgetConfig({ maxModelInvocations: 4, maxWallClockMs: -1 }))
+      .toEqual({ maxModelInvocations: 4 });
+  });
+
+  it('returns undefined for absent, empty, or non-object input', () => {
+    expect(resolveSpellBudgetConfig(undefined)).toBeUndefined();
+    expect(resolveSpellBudgetConfig({})).toBeUndefined();
+    expect(resolveSpellBudgetConfig(null)).toBeUndefined();
+    expect(resolveSpellBudgetConfig('20')).toBeUndefined();
+  });
+});
+
+describe('mergeSpellBudgets', () => {
+  it('takes the stricter of each limit', () => {
+    expect(mergeSpellBudgets(
+      { maxModelInvocations: 20, maxWallClockMs: 1000 },
+      { maxModelInvocations: 5, maxWallClockMs: 9000 },
+    )).toEqual({ maxModelInvocations: 5, maxWallClockMs: 1000 });
+  });
+
+  it('tightens in both directions — neither source is privileged', () => {
+    const config = { maxModelInvocations: 10 };
+    const definition = { maxModelInvocations: 2 };
+    expect(mergeSpellBudgets(config, definition).maxModelInvocations).toBe(2);
+    expect(mergeSpellBudgets(definition, config).maxModelInvocations).toBe(2);
+  });
+
+  it('carries a limit only one side declares', () => {
+    expect(mergeSpellBudgets({ maxModelInvocations: 3 }, { maxWallClockMs: 500 }))
+      .toEqual({ maxModelInvocations: 3, maxWallClockMs: 500 });
+  });
+
+  it('returns the other side when one is absent', () => {
+    expect(mergeSpellBudgets(undefined, { maxWallClockMs: 5 })).toEqual({ maxWallClockMs: 5 });
+    expect(mergeSpellBudgets({ maxWallClockMs: 5 }, undefined)).toEqual({ maxWallClockMs: 5 });
+    expect(mergeSpellBudgets(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('hasBudgetLimit', () => {
+  it('is false for undefined and for an object with no limits', () => {
+    expect(hasBudgetLimit(undefined)).toBe(false);
+    expect(hasBudgetLimit({})).toBe(false);
+  });
+
+  it('is true when either limit is set', () => {
+    expect(hasBudgetLimit({ maxModelInvocations: 1 })).toBe(true);
+    expect(hasBudgetLimit({ maxWallClockMs: 1 })).toBe(true);
+  });
+});
+
+// ============================================================================
+// moflo.yaml loading
+// ============================================================================
+
+describe('loadSpellBudgetFromProject', () => {
+  it('reads the scheduled slot', async () => {
+    const dir = scratchProject([
+      'spells:',
+      '  budget:',
+      '    scheduled:',
+      '      maxModelInvocations: 12',
+      '      maxWallClockMs: 600000',
+    ].join('\n'));
+
+    expect(await loadSpellBudgetFromProject(dir, 'scheduled'))
+      .toEqual({ maxModelInvocations: 12, maxWallClockMs: 600000 });
+  });
+
+  it('leaves the interactive path unconfigured when only scheduled is set', async () => {
+    // Issue #1335 AC5: session-attached spells are unaffected unless the user
+    // explicitly configures them. Configuring the daemon must not reach them.
+    const dir = scratchProject([
+      'spells:',
+      '  budget:',
+      '    scheduled:',
+      '      maxModelInvocations: 12',
+    ].join('\n'));
+
+    expect(await loadSpellBudgetFromProject(dir, 'interactive')).toBeUndefined();
+  });
+
+  it('reads the interactive slot when it is configured', async () => {
+    const dir = scratchProject([
+      'spells:',
+      '  budget:',
+      '    interactive:',
+      '      maxModelInvocations: 50',
+    ].join('\n'));
+
+    expect(await loadSpellBudgetFromProject(dir, 'interactive'))
+      .toEqual({ maxModelInvocations: 50 });
+  });
+
+  it('returns undefined — never throws — for missing, empty, or malformed yaml', async () => {
+    expect(await loadSpellBudgetFromProject(scratchProject(), 'scheduled')).toBeUndefined();
+    expect(await loadSpellBudgetFromProject(scratchProject('sandbox:\n  enabled: true\n'), 'scheduled'))
+      .toBeUndefined();
+    expect(await loadSpellBudgetFromProject(scratchProject('spells: [oops\n'), 'scheduled'))
+      .toBeUndefined();
+    expect(await loadSpellBudgetFromProject(join(tmpdir(), 'moflo-budget-does-not-exist'), 'scheduled'))
+      .toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Runtime enforcement
+// ============================================================================
+
+describe('createRunBudget', () => {
+  it('returns null when nothing is configured — the opt-in guarantee', () => {
+    // Not "a permissive budget": with no ceilings the runner must construct
+    // nothing at all, so the code path is byte-identical to today's.
+    expect(createRunBudget(undefined)).toBeNull();
+    expect(createRunBudget({})).toBeNull();
+  });
+
+  it('returns a budget when at least one ceiling is set', () => {
+    const budget = createRunBudget({ maxModelInvocations: 1 });
+    expect(budget).toBeInstanceOf(SpellRunBudget);
+    budget?.dispose();
+  });
+});
+
+describe('SpellRunBudget — model-invocation ceiling', () => {
+  it('allows exactly the configured number of reservations', () => {
+    const budget = new SpellRunBudget({ maxModelInvocations: 2 });
+    expect(budget.tryConsumeModelInvocation()).toBe(true);
+    expect(budget.tryConsumeModelInvocation()).toBe(true);
+    expect(budget.tryConsumeModelInvocation()).toBe(false);
+    expect(budget.modelInvocations).toBe(2);
+    budget.dispose();
+  });
+
+  it('latches a breach carrying the numbers, not only prose', () => {
+    const budget = new SpellRunBudget({ maxModelInvocations: 1 });
+    budget.tryConsumeModelInvocation();
+    budget.tryConsumeModelInvocation();
+
+    expect(budget.breach).toMatchObject({
+      kind: 'model-invocations',
+      limit: 1,
+      observed: 2,
+    });
+    expect(budget.breach?.message).toContain('maxModelInvocations');
+    budget.dispose();
+  });
+
+  it('stays denied once breached', () => {
+    const budget = new SpellRunBudget({ maxModelInvocations: 1 });
+    budget.tryConsumeModelInvocation();
+    expect(budget.tryConsumeModelInvocation()).toBe(false);
+    expect(budget.tryConsumeModelInvocation()).toBe(false);
+    budget.dispose();
+  });
+
+  it('does NOT abort the signal — the runner stops the run, not the budget', () => {
+    // Aborting here would mark the remaining steps "cancelled" and race the
+    // rollback the runner is about to start; the caller is already returning
+    // a step failure.
+    const budget = new SpellRunBudget({ maxModelInvocations: 1 });
+    budget.tryConsumeModelInvocation();
+    budget.tryConsumeModelInvocation();
+
+    expect(budget.signal.aborted).toBe(false);
+    budget.dispose();
+  });
+
+  it('never denies when only a wall-clock ceiling is configured', () => {
+    const budget = new SpellRunBudget({ maxWallClockMs: 60_000 });
+    for (let i = 0; i < 100; i++) expect(budget.tryConsumeModelInvocation()).toBe(true);
+    expect(budget.breach).toBeNull();
+    budget.dispose();
+  });
+});
+
+describe('SpellRunBudget — wall-clock ceiling', () => {
+  it('latches and aborts once the deadline passes', () => {
+    let now = 1_000;
+    const budget = new SpellRunBudget({ maxWallClockMs: 500 }, { now: () => now });
+
+    budget.checkWallClock();
+    expect(budget.breach).toBeNull();
+    expect(budget.signal.aborted).toBe(false);
+
+    now = 1_600;
+    budget.checkWallClock();
+
+    expect(budget.breach).toMatchObject({ kind: 'wall-clock', limit: 500, observed: 600 });
+    // Unlike the invocation ceiling there is no in-flight caller to hand a
+    // failure to, so aborting is the only way to stop a long-running step.
+    expect(budget.signal.aborted).toBe(true);
+    budget.dispose();
+  });
+
+  it('treats the deadline as reached, not merely passed', () => {
+    let now = 0;
+    const budget = new SpellRunBudget({ maxWallClockMs: 100 }, { now: () => now });
+    now = 100;
+    budget.checkWallClock();
+    expect(budget.breach?.kind).toBe('wall-clock');
+    budget.dispose();
+  });
+
+  it('checkWallClock is inert when no wall-clock ceiling is configured', () => {
+    let now = 0;
+    const budget = new SpellRunBudget({ maxModelInvocations: 1 }, { now: () => now });
+    now = 10_000_000;
+    budget.checkWallClock();
+    expect(budget.breach).toBeNull();
+    budget.dispose();
+  });
+
+  it('does not overwrite an already-latched invocation breach', () => {
+    let now = 0;
+    const budget = new SpellRunBudget(
+      { maxModelInvocations: 1, maxWallClockMs: 100 },
+      { now: () => now },
+    );
+    budget.tryConsumeModelInvocation();
+    budget.tryConsumeModelInvocation();
+    now = 5_000;
+    budget.checkWallClock();
+
+    // First breach wins — it is the one that actually stopped the run.
+    expect(budget.breach?.kind).toBe('model-invocations');
+    budget.dispose();
+  });
+
+  it('fires from its own timer without anyone calling checkWallClock', async () => {
+    const budget = new SpellRunBudget({ maxWallClockMs: 5 });
+    await new Promise<void>((resolve) => {
+      budget.signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+    expect(budget.breach?.kind).toBe('wall-clock');
+    budget.dispose();
+  });
+});
+
+describe('SpellRunBudget — signal composition', () => {
+  it('aborts when the caller aborts, with no breach recorded', () => {
+    const parent = new AbortController();
+    const budget = new SpellRunBudget({ maxModelInvocations: 5 }, { parentSignal: parent.signal });
+
+    parent.abort();
+
+    expect(budget.signal.aborted).toBe(true);
+    // A user cancellation is not a ceiling breach — conflating them would
+    // report every ctrl-C as an overrun.
+    expect(budget.breach).toBeNull();
+    budget.dispose();
+  });
+
+  it('starts aborted when the caller already aborted', () => {
+    const parent = new AbortController();
+    parent.abort();
+    const budget = new SpellRunBudget({ maxModelInvocations: 5 }, { parentSignal: parent.signal });
+
+    expect(budget.signal.aborted).toBe(true);
+    budget.dispose();
+  });
+
+  it('dispose detaches from the parent signal', () => {
+    const parent = new AbortController();
+    const budget = new SpellRunBudget({ maxWallClockMs: 60_000 }, { parentSignal: parent.signal });
+
+    budget.dispose();
+    parent.abort();
+
+    expect(budget.signal.aborted).toBe(false);
+  });
+
+  it('dispose is idempotent', () => {
+    const budget = new SpellRunBudget({ maxWallClockMs: 60_000 });
+    expect(() => { budget.dispose(); budget.dispose(); }).not.toThrow();
+  });
+});

--- a/src/cli/__tests__/spells/spell-budget-enforcement.test.ts
+++ b/src/cli/__tests__/spells/spell-budget-enforcement.test.ts
@@ -21,6 +21,7 @@ import { StepCommandRegistry } from '../../spells/core/step-command-registry.js'
 import { SpellRunBudget } from '../../spells/core/run-budget.js';
 import type { RunBudgetAccessor } from '../../spells/core/run-budget.js';
 import { validateSpellDefinition } from '../../spells/schema/validator.js';
+import { bridgeExecuteSpell } from '../../spells/factory/runner-bridge.js';
 import type {
   CastingContext,
   CredentialAccessor,
@@ -422,6 +423,63 @@ describe('SpellCaster spend ceiling', () => {
 
     expect(result.success).toBe(true);
     expect(result.errors).toEqual([]);
+    expect(memory.tasklist.at(-1)?.abortReason).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// End to end, through the bridge the daemon actually calls
+// ============================================================================
+
+describe('bridgeExecuteSpell spend ceiling', () => {
+  it('aborts a real spell whose bash steps exhaust the invocation ceiling', async () => {
+    // The daemon path is DaemonSpellExecutor → bridgeExecuteSpell → SpellCaster
+    // → bashCommand. The unit tests above cover each link; this covers the
+    // seam between them, using the real runner and the real bash step so a
+    // ceiling that never reaches the runner cannot pass.
+    const memory = recordingMemory();
+    const spell: SpellDefinition = {
+      name: 'e2e-budget-spell',
+      steps: [
+        { id: 'call1', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
+        { id: 'call2', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
+      ],
+    };
+
+    const result = await bridgeExecuteSpell(spell, {}, {
+      spellId: 'scheduled-e2e-budget-spell-1',
+      memory,
+      budget: { maxModelInvocations: 1 },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('BUDGET_EXCEEDED');
+    // Step 1 was allowed to run; step 2 was refused before spawning.
+    expect(result.steps[0].status).toBe('succeeded');
+    expect(result.steps[1].status).toBe('failed');
+    expect(memory.tasklist.at(-1)).toMatchObject({
+      abortReason: 'budget-exceeded',
+      budgetBreach: { kind: 'model-invocations', limit: 1, observed: 2 },
+    });
+  });
+
+  it('runs the same spell to completion with no ceiling configured', async () => {
+    const memory = recordingMemory();
+    const spell: SpellDefinition = {
+      name: 'e2e-unbudgeted-spell',
+      steps: [
+        { id: 'call1', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
+        { id: 'call2', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
+      ],
+    };
+
+    const result = await bridgeExecuteSpell(spell, {}, {
+      spellId: 'scheduled-e2e-unbudgeted-spell-1',
+      memory,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.steps.every(s => s.status === 'succeeded')).toBe(true);
     expect(memory.tasklist.at(-1)?.abortReason).toBeUndefined();
   });
 });

--- a/src/cli/__tests__/spells/spell-budget-enforcement.test.ts
+++ b/src/cli/__tests__/spells/spell-budget-enforcement.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Tests for spend-ceiling enforcement across the runner and the bash step (#1335).
+ *
+ * `run-budget.test.ts` covers the primitive in isolation. This file covers the
+ * two places the ceiling has to actually bite:
+ *
+ *   1. `bashCommand` — a denied reservation must stop the process from being
+ *      spawned at all, because a spawn that is killed afterwards has already
+ *      been billed.
+ *   2. `SpellCaster` — a breach must end the run, bypass `continueOnError`,
+ *      and write the reason into the run's `tasklist` record.
+ *
+ * The absence cases matter as much as the presence ones: with no ceiling
+ * configured the engine must behave exactly as it did before this feature.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { bashCommand } from '../../spells/commands/bash-command.js';
+import { SpellCaster } from '../../spells/core/runner.js';
+import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
+import { SpellRunBudget } from '../../spells/core/run-budget.js';
+import type { RunBudgetAccessor } from '../../spells/core/run-budget.js';
+import { validateSpellDefinition } from '../../spells/schema/validator.js';
+import type {
+  CastingContext,
+  CredentialAccessor,
+  MemoryAccessor,
+  StepCommand,
+} from '../../spells/types/step-command.types.js';
+import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
+import { createMockContext } from './helpers.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * A command that matches `CLAUDE_HEADLESS_RE` but is harmless to run: `echo`
+ * consumes the rest as literal arguments. Lets a test assert both halves —
+ * that a permitted reservation really does spawn, and that a denied one
+ * really does not — without invoking a billed model.
+ */
+const MODEL_SHAPED_COMMAND = 'echo claude -p hello';
+
+function budgetSpy(allow: boolean): RunBudgetAccessor & { calls: number } {
+  return {
+    calls: 0,
+    tryConsumeModelInvocation(this: { calls: number }) { this.calls++; return allow; },
+    breach: allow ? null : {
+      kind: 'model-invocations', limit: 1, observed: 2, message: 'ceiling hit',
+    },
+  } as RunBudgetAccessor & { calls: number };
+}
+
+const credentials: CredentialAccessor = {
+  async get() { return undefined; },
+  async has() { return false; },
+  async store() { /* no-op */ },
+};
+
+/** Records every `tasklist` write so a test can read the terminal record. */
+function recordingMemory(): MemoryAccessor & { tasklist: Record<string, unknown>[] } {
+  const tasklist: Record<string, unknown>[] = [];
+  return {
+    tasklist,
+    async read() { return null; },
+    async write(namespace: string, _key: string, value: unknown) {
+      if (namespace === 'tasklist') tasklist.push(value as Record<string, unknown>);
+    },
+    async search() { return []; },
+  };
+}
+
+/**
+ * A step type standing in for "a step that calls the model", so runner-level
+ * tests never spawn a process. It reserves through the context budget exactly
+ * the way `bashCommand` does, and fails the step when denied.
+ */
+function modelStep(): StepCommand {
+  return {
+    type: 'model',
+    description: 'stand-in for a step that spawns claude -p',
+    configSchema: { type: 'object' },
+    validate: () => ({ valid: true, errors: [] }),
+    async execute(_config, context: CastingContext) {
+      if (context.budget && !context.budget.tryConsumeModelInvocation()) {
+        return { success: false, data: {}, error: context.budget.breach?.message ?? 'denied' };
+      }
+      return { success: true, data: { ok: true } };
+    },
+    describeOutputs: () => [{ name: 'ok', type: 'boolean' }],
+  };
+}
+
+/** A step that advances an injected clock, so wall-clock tests need no timers. */
+function slowStep(advanceMs: number, clock: { now: number }): StepCommand {
+  return {
+    type: 'slow',
+    description: 'advances the injected clock',
+    configSchema: { type: 'object' },
+    validate: () => ({ valid: true, errors: [] }),
+    async execute() {
+      clock.now += advanceMs;
+      return { success: true, data: {} };
+    },
+    describeOutputs: () => [],
+  };
+}
+
+function casterWith(commands: StepCommand[], memory: MemoryAccessor): SpellCaster {
+  const registry = new StepCommandRegistry();
+  for (const cmd of commands) registry.register(cmd, 'built-in');
+  return new SpellCaster(registry, credentials, memory);
+}
+
+function modelSpell(stepCount: number, overrides: Partial<SpellDefinition> = {}): SpellDefinition {
+  return {
+    name: 'budget-spell',
+    steps: Array.from({ length: stepCount }, (_, i) => ({
+      id: `m${i + 1}`, type: 'model', config: {},
+    })),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// bashCommand — the spawn point
+// ============================================================================
+
+describe('bashCommand spend ceiling', () => {
+  it('refuses to spawn when the reservation is denied', async () => {
+    const budget = budgetSpy(false);
+    const output = await bashCommand.execute(
+      { command: MODEL_SHAPED_COMMAND },
+      createMockContext({ budget }),
+    );
+
+    expect(output.success).toBe(false);
+    expect(output.error).toContain('ceiling hit');
+    // -1 is the engine's "no process ran" exit code. A real spawn of the echo
+    // above would have exited 0, so this is what proves nothing was billed.
+    expect(output.data.exitCode).toBe(-1);
+    expect(output.data.stdout).toBe('');
+    expect(budget.calls).toBe(1);
+  });
+
+  it('spawns normally when the reservation is granted', async () => {
+    const budget = budgetSpy(true);
+    const output = await bashCommand.execute(
+      { command: MODEL_SHAPED_COMMAND },
+      createMockContext({ budget }),
+    );
+
+    expect(output.success).toBe(true);
+    expect(output.data.exitCode).toBe(0);
+    expect(budget.calls).toBe(1);
+  });
+
+  it('does not consume budget for a command that spawns no model', async () => {
+    const budget = budgetSpy(true);
+    const output = await bashCommand.execute(
+      { command: 'echo plain' },
+      createMockContext({ budget }),
+    );
+
+    expect(output.success).toBe(true);
+    expect(String(output.data.stdout)).toContain('plain');
+    expect(budget.calls).toBe(0);
+  });
+
+  it('leaves the step untouched when no budget is configured', async () => {
+    const output = await bashCommand.execute(
+      { command: MODEL_SHAPED_COMMAND },
+      createMockContext(),
+    );
+
+    expect(output.success).toBe(true);
+    expect(output.data.exitCode).toBe(0);
+  });
+
+  it('reserves only after the destructive denylist has had its say', async () => {
+    // A command the denylist blocks must not burn a reservation it never used.
+    const budget = budgetSpy(true);
+    const output = await bashCommand.execute(
+      { command: 'claude -p x && rm -rf /' },
+      createMockContext({ budget }),
+    );
+
+    expect(output.success).toBe(false);
+    expect(budget.calls).toBe(0);
+  });
+
+  it('does not reserve for a run that is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const budget = budgetSpy(true);
+
+    const output = await bashCommand.execute(
+      { command: MODEL_SHAPED_COMMAND },
+      createMockContext({ budget, abortSignal: controller.signal }),
+    );
+
+    expect(output.success).toBe(false);
+    expect(budget.calls).toBe(0);
+  });
+});
+
+// ============================================================================
+// SpellCaster — the run loop
+// ============================================================================
+
+describe('SpellCaster spend ceiling', () => {
+  it('aborts the run when the model-invocation ceiling is spent', async () => {
+    const memory = recordingMemory();
+    const caster = casterWith([modelStep()], memory);
+
+    const result = await caster.run(modelSpell(4), {}, {
+      budget: { maxModelInvocations: 2 },
+      skipAcceptanceCheck: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('BUDGET_EXCEEDED');
+    expect(result.steps.filter(s => s.status === 'succeeded')).toHaveLength(2);
+    // Step 3 is the denial; step 4 never runs.
+    expect(result.steps[3].status).toBe('skipped');
+  });
+
+  it('bypasses continueOnError — a ceiling a step can opt out of is not a ceiling', async () => {
+    const memory = recordingMemory();
+    const caster = casterWith([modelStep()], memory);
+
+    const spell: SpellDefinition = {
+      name: 'opt-out',
+      steps: [
+        { id: 'm1', type: 'model', config: {}, continueOnError: true },
+        { id: 'm2', type: 'model', config: {}, continueOnError: true },
+        { id: 'm3', type: 'model', config: {}, continueOnError: true },
+      ],
+    };
+
+    const result = await caster.run(spell, {}, {
+      budget: { maxModelInvocations: 1 },
+      skipAcceptanceCheck: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('BUDGET_EXCEEDED');
+    expect(result.steps[2].status).toBe('skipped');
+  });
+
+  it('reports a wall-clock breach as BUDGET_EXCEEDED, not SPELL_CANCELLED', async () => {
+    // The deadline aborts the run's signal, so without the breach check the
+    // run would surface as an ordinary user cancellation and lose the reason.
+    const clock = { now: 1_000 };
+    const memory = recordingMemory();
+    const caster = casterWith([slowStep(400, clock)], memory);
+    const spy = vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+
+    try {
+      const spell: SpellDefinition = {
+        name: 'slow-spell',
+        steps: [
+          { id: 's1', type: 'slow', config: {} },
+          { id: 's2', type: 'slow', config: {} },
+          { id: 's3', type: 'slow', config: {} },
+        ],
+      };
+      const result = await caster.run(spell, {}, {
+        budget: { maxWallClockMs: 500 },
+        skipAcceptanceCheck: true,
+      });
+
+      const codes = result.errors.map(e => e.code);
+      expect(codes).toContain('BUDGET_EXCEEDED');
+      expect(codes).not.toContain('SPELL_CANCELLED');
+      // A ceiling breach is moflo stopping an overrun, not the caller
+      // stopping the run — dashboards need to tell those apart.
+      expect(result.cancelled).toBe(false);
+      expect(result.success).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('interrupts an in-flight step when the deadline fires mid-step', async () => {
+    // The between-steps check alone cannot stop a single long-running step —
+    // which is the shape a runaway `claude -p` actually takes. This exercises
+    // the deadline timer aborting the signal the step is waiting on.
+    const hanging: StepCommand = {
+      type: 'hanging',
+      description: 'waits until the run is aborted',
+      configSchema: { type: 'object' },
+      validate: () => ({ valid: true, errors: [] }),
+      execute(_c, context: CastingContext) {
+        return new Promise((_resolve, reject) => {
+          context.abortSignal?.addEventListener(
+            'abort', () => reject(new Error('aborted')), { once: true },
+          );
+        });
+      },
+      describeOutputs: () => [],
+    };
+
+    const memory = recordingMemory();
+    const caster = casterWith([hanging], memory);
+    const result = await caster.run(
+      { name: 'hanging-spell', steps: [{ id: 'h1', type: 'hanging', config: {} }] },
+      {},
+      { budget: { maxWallClockMs: 20 }, skipAcceptanceCheck: true },
+    );
+
+    expect(result.errors.map(e => e.code)).toContain('BUDGET_EXCEEDED');
+    expect(result.cancelled).toBe(false);
+    expect(memory.tasklist.at(-1)?.budgetBreach).toMatchObject({ kind: 'wall-clock', limit: 20 });
+  });
+
+  it('records the breach in the run tasklist record, structured', async () => {
+    const memory = recordingMemory();
+    const caster = casterWith([modelStep()], memory);
+
+    await caster.run(modelSpell(3), {}, {
+      budget: { maxModelInvocations: 1 },
+      skipAcceptanceCheck: true,
+    });
+
+    const terminal = memory.tasklist.at(-1);
+    expect(terminal?.status).toBe('failed');
+    expect(terminal?.abortReason).toBe('budget-exceeded');
+    expect(terminal?.budgetBreach).toEqual({
+      kind: 'model-invocations', limit: 1, observed: 2,
+    });
+    expect(String(terminal?.error)).toContain('model-invocation ceiling');
+  });
+
+  it('composes the definition budget with the caller budget, strictest first', async () => {
+    const memory = recordingMemory();
+    const caster = casterWith([modelStep()], memory);
+
+    const result = await caster.run(
+      modelSpell(4, { budget: { maxModelInvocations: 1 } }),
+      {},
+      { budget: { maxModelInvocations: 3 }, skipAcceptanceCheck: true },
+    );
+
+    expect(result.errors.map(e => e.code)).toContain('BUDGET_EXCEEDED');
+    expect(result.steps.filter(s => s.status === 'succeeded')).toHaveLength(1);
+  });
+
+  it('applies a definition budget even when the caller configured none', async () => {
+    const memory = recordingMemory();
+    const caster = casterWith([modelStep()], memory);
+
+    const result = await caster.run(
+      modelSpell(3, { budget: { maxModelInvocations: 1 } }),
+      {},
+      { skipAcceptanceCheck: true },
+    );
+
+    expect(result.errors.map(e => e.code)).toContain('BUDGET_EXCEEDED');
+  });
+
+  it('puts no budget on the casting context when none is configured', async () => {
+    // The opt-in guarantee at the surface a step command actually sees.
+    const seen: Array<RunBudgetAccessor | undefined> = [];
+    const probe: StepCommand = {
+      type: 'probe',
+      description: 'records the context budget',
+      configSchema: { type: 'object' },
+      validate: () => ({ valid: true, errors: [] }),
+      async execute(_c, context: CastingContext) {
+        seen.push(context.budget);
+        return { success: true, data: {} };
+      },
+      describeOutputs: () => [],
+    };
+
+    const memory = recordingMemory();
+    const caster = casterWith([probe], memory);
+    const spell: SpellDefinition = {
+      name: 'probe-spell', steps: [{ id: 'p1', type: 'probe', config: {} }],
+    };
+
+    const withoutBudget = await caster.run(spell, {}, { skipAcceptanceCheck: true });
+    expect(withoutBudget.success).toBe(true);
+    expect(seen).toEqual([undefined]);
+
+    seen.length = 0;
+    const withBudget = await caster.run(spell, {}, {
+      budget: { maxModelInvocations: 5 }, skipAcceptanceCheck: true,
+    });
+    expect(withBudget.success).toBe(true);
+    expect(seen[0]).toBeInstanceOf(SpellRunBudget);
+  });
+
+  it('still reports a caller cancellation as SPELL_CANCELLED under a budget', async () => {
+    // A budget must not relabel every abort as an overrun.
+    const controller = new AbortController();
+    const memory = recordingMemory();
+    const caster = casterWith([modelStep()], memory);
+    controller.abort();
+
+    const result = await caster.run(modelSpell(2), {}, {
+      budget: { maxModelInvocations: 5 },
+      signal: controller.signal,
+      skipAcceptanceCheck: true,
+    });
+
+    expect(result.cancelled).toBe(true);
+    expect(result.errors.map(e => e.code)).toContain('SPELL_CANCELLED');
+    expect(result.errors.map(e => e.code)).not.toContain('BUDGET_EXCEEDED');
+  });
+
+  it('runs a spell to completion when it stays inside its ceiling', async () => {
+    const memory = recordingMemory();
+    const caster = casterWith([modelStep()], memory);
+
+    const result = await caster.run(modelSpell(2), {}, {
+      budget: { maxModelInvocations: 5 },
+      skipAcceptanceCheck: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(memory.tasklist.at(-1)?.abortReason).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Definition validation
+// ============================================================================
+
+describe('budget block validation', () => {
+  function validate(budget: unknown) {
+    const def = {
+      name: 'b', steps: [{ id: 's1', type: 'noop', config: {} }],
+      ...(budget !== undefined ? { budget } : {}),
+    } as unknown as SpellDefinition;
+    return validateSpellDefinition(def, { knownStepTypes: ['noop'] })
+      .errors.filter(e => e.path.startsWith('budget'));
+  }
+
+  it('accepts an absent, empty, or well-formed block', () => {
+    expect(validate(undefined)).toHaveLength(0);
+    expect(validate({})).toHaveLength(0);
+    expect(validate({ maxModelInvocations: 3, maxWallClockMs: 1000 })).toHaveLength(0);
+  });
+
+  it('rejects a non-object budget', () => {
+    expect(validate('20')).toContainEqual({ path: 'budget', message: 'budget must be an object' });
+    expect(validate([1, 2])).toContainEqual({ path: 'budget', message: 'budget must be an object' });
+  });
+
+  it('rejects an unknown key rather than silently ignoring it', () => {
+    // A typo that parses as "no ceiling" is the failure that costs money: the
+    // author believes the spell is capped and the daemon runs it unbounded.
+    const errors = validate({ maxModelInvokations: 5 });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].path).toBe('budget.maxModelInvokations');
+    expect(errors[0].message).toContain('maxModelInvocations');
+  });
+
+  it('rejects limits that are not positive numbers', () => {
+    expect(validate({ maxModelInvocations: 0 })[0].path).toBe('budget.maxModelInvocations');
+    expect(validate({ maxWallClockMs: -1 })[0].path).toBe('budget.maxWallClockMs');
+    expect(validate({ maxWallClockMs: '1000' })[0].path).toBe('budget.maxWallClockMs');
+  });
+});

--- a/src/cli/mcp-tools/spell-tools.ts
+++ b/src/cli/mcp-tools/spell-tools.ts
@@ -106,12 +106,17 @@ async function executeAndTrack(
   const tracked = trackStart(spellId, definition.name, definition.description);
 
   try {
-    const sandboxConfig = await engine.loadSandboxConfigFromProject(findProjectRoot());
+    const projectRoot = findProjectRoot();
+    const sandboxConfig = await engine.loadSandboxConfigFromProject(projectRoot);
+    // Session-attached cast: only the `interactive` ceiling applies, and only
+    // when the project configured one (#1335 AC5).
+    const budget = await engine.loadSpellBudgetFromProject(projectRoot, 'interactive');
     const memory = await getSharedMemoryAccessor();
     const result = await engine.bridgeExecuteSpell(definition, args, {
       spellId,
       sandboxConfig,
       forceCredentialReprompt: options.forceCredentialReprompt,
+      ...(budget ? { budget } : {}),
       ...(memory ? { memory } : {}),
     });
     trackResult(tracked, result);
@@ -272,9 +277,12 @@ export const spellTools: MCPTool[] = [
 
       // Run from raw content via bridge
       const engine = await loadSpellEngine();
-      const sandboxConfig = await engine.loadSandboxConfigFromProject(findProjectRoot());
+      const contentProjectRoot = findProjectRoot();
+      const sandboxConfig = await engine.loadSandboxConfigFromProject(contentProjectRoot);
+      const budget = await engine.loadSpellBudgetFromProject(contentProjectRoot, 'interactive');
       const result = await engine.bridgeRunSpell(content, sourceFile, args, {
         dryRun, sandboxConfig, forceCredentialReprompt,
+        ...(budget ? { budget } : {}),
       });
       const tracked = trackStart(result.spellId, spellName);
       trackResult(tracked, result);

--- a/src/cli/services/daemon-spell-executor.ts
+++ b/src/cli/services/daemon-spell-executor.ts
@@ -22,6 +22,7 @@ import {
   loadSpellEngine,
   type EngineModule,
   type SandboxConfig,
+  type SpellBudgetConfig,
 } from './engine-loader.js';
 
 export interface DaemonSpellExecutorOptions {
@@ -37,6 +38,12 @@ export interface DaemonSpellExecutorOptions {
   readonly engine?: EngineModule;
   /** Optional sandbox config override (else auto-loaded from moflo.yaml). */
   readonly sandboxConfig?: SandboxConfig;
+  /**
+   * Optional spend-ceiling override (#1335). When omitted, the executor loads
+   * `spells.budget.scheduled` from moflo.yaml. Absent from both ⇒ no ceiling,
+   * which is the behaviour every install has today.
+   */
+  readonly budgetConfig?: SpellBudgetConfig;
 }
 
 export class DaemonSpellExecutor implements SpellExecutor {
@@ -45,6 +52,7 @@ export class DaemonSpellExecutor implements SpellExecutor {
   private readonly memory?: MemoryAccessor;
   private readonly defaultMofloLevel?: MofloLevel;
   private readonly explicitSandbox?: SandboxConfig;
+  private readonly explicitBudget?: SpellBudgetConfig;
   private engine?: EngineModule;
 
   constructor(opts: DaemonSpellExecutorOptions) {
@@ -54,6 +62,7 @@ export class DaemonSpellExecutor implements SpellExecutor {
     this.defaultMofloLevel = opts.defaultMofloLevel;
     this.engine = opts.engine;
     this.explicitSandbox = opts.sandboxConfig;
+    this.explicitBudget = opts.budgetConfig;
   }
 
   exists(spellName: string): boolean {
@@ -103,12 +112,29 @@ export class DaemonSpellExecutor implements SpellExecutor {
     try {
       const sandboxConfig = this.explicitSandbox
         ?? await engine.loadSandboxConfigFromProject(this.projectRoot);
-      return await engine.bridgeExecuteSpell(definition, args, {
+      // Spend ceiling for the unattended path (#1335). Loaded per execute so a
+      // moflo.yaml edit reaches the next fire without a daemon restart — the
+      // same reason `registry.invalidate()` runs above.
+      const budget = this.explicitBudget
+        ?? await engine.loadSpellBudgetFromProject(this.projectRoot, 'scheduled');
+      const result = await engine.bridgeExecuteSpell(definition, args, {
         spellId,
         projectRoot: this.projectRoot,
         memory: this.memory,
         sandboxConfig,
+        ...(budget ? { budget } : {}),
       });
+      // Surface a breach on stderr so it lands in the daemon log, not only in
+      // the run's tasklist record. A ceiling that fires silently in an
+      // unattended process is indistinguishable from the runaway it prevented.
+      const budgetErr = result.errors.find(e => e.code === 'BUDGET_EXCEEDED');
+      if (budgetErr) {
+        console.warn(
+          `[daemon-spell-executor] spend ceiling aborted "${loaded.definition.name}" ` +
+          `(${spellId}): ${budgetErr.message}`,
+        );
+      }
+      return result;
     } catch (err) {
       return failedResult(
         spellId,

--- a/src/cli/services/engine-loader.ts
+++ b/src/cli/services/engine-loader.ts
@@ -20,6 +20,7 @@ import type {
   RegistryOptions,
 } from '../spells/registry/spell-registry.js';
 import type { SandboxConfig } from '../spells/core/platform-sandbox.js';
+import type { SpellBudgetConfig, SpellBudgetMode } from '../spells/core/run-budget.js';
 import type {
   SpellScheduler,
   SpellExecutor,
@@ -33,6 +34,7 @@ export type { SpellDefinition };
 export type { Grimoire };
 export type { PreflightWarning, PreflightWarningDecision, PreflightWarningHandler };
 export type { SandboxConfig };
+export type { SpellBudgetConfig, SpellBudgetMode };
 export type { SpellScheduler, SpellExecutor, SchedulerOptions };
 
 /**
@@ -48,6 +50,7 @@ export interface EngineModule {
       projectRoot?: string;
       memory?: unknown;
       sandboxConfig?: SandboxConfig;
+      budget?: SpellBudgetConfig;
       forceCredentialReprompt?: boolean;
     },
   ) => Promise<SpellResult>;
@@ -59,6 +62,7 @@ export interface EngineModule {
       projectRoot?: string;
       memory?: unknown;
       sandboxConfig?: SandboxConfig;
+      budget?: SpellBudgetConfig;
       forceCredentialReprompt?: boolean;
     },
   ) => Promise<SpellResult>;
@@ -77,6 +81,10 @@ export interface EngineModule {
     options?: Record<string, unknown>,
   ) => Promise<SpellResult>;
   loadSandboxConfigFromProject: (projectRoot: string) => Promise<SandboxConfig>;
+  loadSpellBudgetFromProject: (
+    projectRoot: string,
+    mode: SpellBudgetMode,
+  ) => Promise<SpellBudgetConfig | undefined>;
   registerTTYPauser: (pauser: () => { release: () => void }) => () => void;
 }
 

--- a/src/cli/spells/commands/bash-command.ts
+++ b/src/cli/spells/commands/bash-command.ts
@@ -176,6 +176,24 @@ export const bashCommand: StepCommand<BashStepConfig> = {
       };
     }
 
+    // ── Spend ceiling (#1335) ────────────────────────────────────────
+    // Reserve against the run's model-invocation budget before spawning a
+    // billed `claude -p`. Placed last among the pre-spawn checks so nothing
+    // that would bail anyway — a denylist hit, an already-aborted run — burns
+    // a reservation, and still before the spawn so a denial costs nothing.
+    // Absent budget ⇒ untouched path.
+    if (context.budget && CLAUDE_HEADLESS_RE.test(command)) {
+      if (!context.budget.tryConsumeModelInvocation()) {
+        return {
+          success: false,
+          data: { stdout: '', stderr: '', exitCode: -1 },
+          error: context.budget.breach?.message
+            ?? 'Spell run exceeded its model-invocation ceiling',
+          duration: Date.now() - start,
+        };
+      }
+    }
+
     const elapsed = () => `${((Date.now() - start) / 1000).toFixed(1)}s`;
     const cmdPreview = redactSensitiveFlags(command.length > 80 ? command.slice(0, 77) + '...' : command);
 

--- a/src/cli/spells/core/run-budget.ts
+++ b/src/cli/spells/core/run-budget.ts
@@ -1,0 +1,369 @@
+/**
+ * Spell Run Budget — issue #1335.
+ *
+ * Spells spawn billed `claude -p` processes from bash steps. Nothing observed
+ * or bounded that spend, and the exposure concentrates on the daemon-scheduled
+ * path: a cron spell runs unattended, can invoke the model repeatedly, and a
+ * misconfigured schedule or a loop step burns budget with no signal until a
+ * bill arrives.
+ *
+ * This module bounds worst-case exposure with two ceilings:
+ *
+ *   - `maxModelInvocations` — how many detected `claude -p` spawns one run may
+ *     make. Reserved BEFORE the process starts, so a denied invocation costs
+ *     nothing.
+ *   - `maxWallClockMs` — how long one run may take end to end.
+ *
+ * This is deliberately a **proxy for spend, not a measurement of it.** True
+ * metering would mean injecting `--output-format json` into the spawned
+ * `claude -p` and parsing `usage` from its stdout — which changes what a bash
+ * step returns to downstream steps and breaks every spell that consumes a
+ * model step's text output. The ceiling buys bounded exposure without touching
+ * the `claude -p` contract.
+ *
+ * Both ceilings are opt-in. `createRunBudget` returns `null` when neither is
+ * configured, and the runner then takes exactly the code path it takes today.
+ *
+ * Cross-platform (Rule #1): pure JS timers and `AbortController`, and the one
+ * file read goes through `path.join` — no shell, no platform branches.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+type YamlModule = { load: (s: string) => unknown; default?: { load: (s: string) => unknown } };
+
+// ============================================================================
+// Config
+// ============================================================================
+
+/**
+ * Ceilings for a single spell run. Every field is optional; an object with no
+ * usable field is equivalent to no budget at all.
+ */
+export interface SpellBudgetConfig {
+  /** Max detected `claude -p` spawns per run. Unset ⇒ unlimited. */
+  readonly maxModelInvocations?: number;
+  /** Max wall-clock duration of the run, in ms. Unset ⇒ unlimited. */
+  readonly maxWallClockMs?: number;
+}
+
+/** Which ceiling was hit. */
+export type BudgetLimitKind = 'model-invocations' | 'wall-clock';
+
+/**
+ * A latched ceiling breach. Carries the numbers rather than only a message so
+ * the run's `tasklist` record stays machine-readable — a reader asking "why
+ * did this run stop" should not have to parse prose.
+ */
+export interface BudgetBreach {
+  readonly kind: BudgetLimitKind;
+  /** The configured ceiling. */
+  readonly limit: number;
+  /** What was observed when the ceiling was hit (attempt count, or elapsed ms). */
+  readonly observed: number;
+  /** User-facing explanation, safe to surface in logs and error messages. */
+  readonly message: string;
+}
+
+/**
+ * The slice of the budget a step command sees. Narrow on purpose: a step may
+ * reserve an invocation and read the breach, but may not reconfigure the
+ * ceiling or clear a breach.
+ */
+export interface RunBudgetAccessor {
+  /**
+   * Reserve one model invocation.
+   *
+   * Returns false when the ceiling is spent (or already breached), in which
+   * case the caller MUST NOT spawn — the breach is latched and the runner
+   * will abort the run on its next check.
+   */
+  tryConsumeModelInvocation(): boolean;
+  /** The latched breach, or null while the run is still within its ceilings. */
+  readonly breach: BudgetBreach | null;
+}
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+/**
+ * Coerce one configured limit. Anything that is not a finite number greater
+ * than zero is dropped rather than clamped: a `maxModelInvocations: 0` that
+ * silently became 1 would be a ceiling the user did not ask for, and a
+ * ceiling of literally zero would make every model step fail — neither is a
+ * plausible reading of the config, so treating it as "unset" is the only safe
+ * interpretation.
+ */
+function positiveLimit(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
+  return value;
+}
+
+/**
+ * Resolve a budget from raw `moflo.yaml` data. Accepts camelCase and
+ * snake_case keys, matching `resolveSandboxConfig`.
+ *
+ * Returns undefined when nothing usable is configured, so callers can treat
+ * "no budget block" and "a budget block full of junk" identically.
+ */
+export function resolveSpellBudgetConfig(raw?: unknown): SpellBudgetConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const rec = raw as Record<string, unknown>;
+
+  const maxModelInvocations = positiveLimit(
+    rec.maxModelInvocations ?? rec.max_model_invocations,
+  );
+  const maxWallClockMs = positiveLimit(rec.maxWallClockMs ?? rec.max_wall_clock_ms);
+
+  if (maxModelInvocations === undefined && maxWallClockMs === undefined) return undefined;
+  return {
+    ...(maxModelInvocations !== undefined ? { maxModelInvocations } : {}),
+    ...(maxWallClockMs !== undefined ? { maxWallClockMs } : {}),
+  };
+}
+
+/**
+ * Combine two budgets under "most strict wins" — the same composition rule
+ * `sandbox.required` uses (#878). Either source may tighten a ceiling; neither
+ * can loosen what the other requires.
+ */
+export function mergeSpellBudgets(
+  a?: SpellBudgetConfig,
+  b?: SpellBudgetConfig,
+): SpellBudgetConfig | undefined {
+  if (!a) return b;
+  if (!b) return a;
+
+  const pick = (x?: number, y?: number): number | undefined => {
+    if (x === undefined) return y;
+    if (y === undefined) return x;
+    return Math.min(x, y);
+  };
+
+  const maxModelInvocations = pick(a.maxModelInvocations, b.maxModelInvocations);
+  const maxWallClockMs = pick(a.maxWallClockMs, b.maxWallClockMs);
+  if (maxModelInvocations === undefined && maxWallClockMs === undefined) return undefined;
+  return {
+    ...(maxModelInvocations !== undefined ? { maxModelInvocations } : {}),
+    ...(maxWallClockMs !== undefined ? { maxWallClockMs } : {}),
+  };
+}
+
+/** True when the config carries at least one enforceable ceiling. */
+export function hasBudgetLimit(config?: SpellBudgetConfig): boolean {
+  if (!config) return false;
+  return config.maxModelInvocations !== undefined || config.maxWallClockMs !== undefined;
+}
+
+/**
+ * Which execution path a run is on. The two are configured separately because
+ * they carry different risk: a scheduled run is unattended and can loop
+ * unobserved, while a session-attached run has a human watching it who can
+ * ctrl-C. Issue #1335 requires interactive runs to stay unaffected unless the
+ * user explicitly configures them, which falls out of `spells.budget.interactive`
+ * being absent by default.
+ */
+export type SpellBudgetMode = 'scheduled' | 'interactive';
+
+/**
+ * Load the ceiling for one execution path from a project's `moflo.yaml`:
+ *
+ * ```yaml
+ * spells:
+ *   budget:
+ *     scheduled:
+ *       maxModelInvocations: 20
+ *       maxWallClockMs: 1800000
+ * ```
+ *
+ * Returns undefined on any failure — missing file, parse error, absent block,
+ * unusable values. A budget is a safety ceiling, not a correctness
+ * requirement, so an unreadable config must not stop a run that works today.
+ */
+export async function loadSpellBudgetFromProject(
+  projectRoot: string,
+  mode: SpellBudgetMode,
+): Promise<SpellBudgetConfig | undefined> {
+  try {
+    const content = readFileSync(join(projectRoot, 'moflo.yaml'), 'utf-8');
+    const mod = await import('js-yaml') as YamlModule;
+    const yaml = mod.default ?? mod;
+    const raw = yaml.load(content) as {
+      spells?: { budget?: Record<string, unknown> };
+    } | null;
+    return resolveSpellBudgetConfig(raw?.spells?.budget?.[mode]);
+  } catch {
+    return undefined;
+  }
+}
+
+// ============================================================================
+// Runtime
+// ============================================================================
+
+export interface RunBudgetOptions {
+  /** Caller's cancellation signal; the budget's signal aborts when it does. */
+  readonly parentSignal?: AbortSignal;
+  /** Clock injection point for tests. Defaults to `Date.now`. */
+  readonly now?: () => number;
+}
+
+/**
+ * A live budget for one spell run.
+ *
+ * Owns an {@link AbortSignal} that fires when either the caller's signal
+ * aborts or the wall-clock deadline passes. The runner threads that signal
+ * through to steps in place of the caller's, so a deadline breach interrupts
+ * an in-flight step rather than waiting for it to return.
+ */
+export class SpellRunBudget implements RunBudgetAccessor {
+  private readonly controller = new AbortController();
+  private readonly now: () => number;
+  private readonly startedAt: number;
+  private readonly deadlineAt: number | null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private parentAbortListener: (() => void) | null = null;
+  private parentSignal: AbortSignal | undefined;
+  private invocations = 0;
+  private latched: BudgetBreach | null = null;
+
+  constructor(
+    private readonly config: SpellBudgetConfig,
+    options: RunBudgetOptions = {},
+  ) {
+    this.now = options.now ?? Date.now;
+    this.startedAt = this.now();
+    this.deadlineAt = config.maxWallClockMs !== undefined
+      ? this.startedAt + config.maxWallClockMs
+      : null;
+
+    this.parentSignal = options.parentSignal;
+    if (this.parentSignal) {
+      if (this.parentSignal.aborted) {
+        this.controller.abort();
+      } else {
+        this.parentAbortListener = () => this.controller.abort();
+        this.parentSignal.addEventListener('abort', this.parentAbortListener, { once: true });
+      }
+    }
+
+    if (config.maxWallClockMs !== undefined && !this.controller.signal.aborted) {
+      this.timer = setTimeout(() => this.breachWallClock(), config.maxWallClockMs);
+      // Never hold the process open for a ceiling that will be disposed when
+      // the run ends. `unref` is absent on the browser-shaped timer type, so
+      // it is called defensively.
+      this.timer.unref?.();
+    }
+  }
+
+  /** Signal to hand to steps: aborts on caller cancellation OR deadline. */
+  get signal(): AbortSignal {
+    return this.controller.signal;
+  }
+
+  get breach(): BudgetBreach | null {
+    return this.latched;
+  }
+
+  /** Model invocations reserved so far — the sample behind a count breach. */
+  get modelInvocations(): number {
+    return this.invocations;
+  }
+
+  tryConsumeModelInvocation(): boolean {
+    if (this.latched) return false;
+
+    const max = this.config.maxModelInvocations;
+    if (max === undefined) {
+      this.invocations++;
+      return true;
+    }
+
+    const attempt = this.invocations + 1;
+    if (attempt > max) {
+      // Deliberately does NOT abort the signal. The caller is returning a
+      // step failure right now; aborting here would mark the remaining steps
+      // "cancelled" and race the rollback that the runner is about to run.
+      // The runner's own breach check stops the run one statement later.
+      this.latched = {
+        kind: 'model-invocations',
+        limit: max,
+        observed: attempt,
+        message:
+          `Spell run exceeded its model-invocation ceiling: ${max} allowed, ` +
+          `attempt ${attempt} denied before spawning. Raise ` +
+          `\`spells.budget.*.maxModelInvocations\` in moflo.yaml (or the spell's ` +
+          `own \`budget\` block) if this run legitimately needs more.`,
+      };
+      return false;
+    }
+
+    this.invocations = attempt;
+    return true;
+  }
+
+  /**
+   * Latch a wall-clock breach if the deadline has passed.
+   *
+   * The deadline timer normally does this on its own. The runner also calls it
+   * between steps so enforcement does not depend on timer delivery — under a
+   * fake clock, or when the event loop was blocked by a long synchronous step,
+   * the timer may not have run yet.
+   */
+  checkWallClock(): void {
+    if (this.latched || this.deadlineAt === null) return;
+    if (this.now() < this.deadlineAt) return;
+    this.breachWallClock();
+  }
+
+  /** Release the deadline timer and the parent-signal listener. */
+  dispose(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.parentSignal && this.parentAbortListener) {
+      this.parentSignal.removeEventListener('abort', this.parentAbortListener);
+      this.parentAbortListener = null;
+    }
+  }
+
+  private breachWallClock(): void {
+    if (this.latched) return;
+    const limit = this.config.maxWallClockMs;
+    if (limit === undefined) return;
+
+    const observed = this.now() - this.startedAt;
+    this.latched = {
+      kind: 'wall-clock',
+      limit,
+      observed,
+      message:
+        `Spell run exceeded its wall-clock ceiling: ${limit}ms allowed, ` +
+        `${observed}ms elapsed. The run was aborted. Raise ` +
+        `\`spells.budget.*.maxWallClockMs\` in moflo.yaml (or the spell's own ` +
+        `\`budget\` block) if this run legitimately takes longer.`,
+    };
+    // Unlike the invocation ceiling, there is no in-flight caller to hand a
+    // failure to — the only way to stop a long-running step is to abort it.
+    this.controller.abort();
+  }
+}
+
+/**
+ * Build a budget for one run, or return null when nothing is configured.
+ *
+ * Returning null rather than a permissive budget is what makes the feature
+ * opt-in at the code level and not just the config level: with no ceilings the
+ * runner never constructs a budget, never swaps the abort signal, and never
+ * puts anything on the casting context.
+ */
+export function createRunBudget(
+  config: SpellBudgetConfig | undefined,
+  options: RunBudgetOptions = {},
+): SpellRunBudget | null {
+  if (!hasBudgetLimit(config)) return null;
+  return new SpellRunBudget(config as SpellBudgetConfig, options);
+}

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -50,6 +50,10 @@ import {
 } from './platform-sandbox.js';
 import { checkAcceptance, recordAcceptance } from './permission-acceptance.js';
 import { analyzeSpellPermissions, formatSpellPermissionReport } from './permission-disclosure.js';
+import {
+  createRunBudget, mergeSpellBudgets,
+  type BudgetBreach, type RunBudgetAccessor,
+} from './run-budget.js';
 
 /** Spell engine version. Story #285 (epic #287) — workflow-test constant. */
 export const ENGINE_VERSION = '1.0.0';
@@ -270,6 +274,19 @@ export class SpellCaster {
     const completedSteps: CompletedStep[] = [];
     let cancelled = false;
 
+    // Spend ceiling (#1335). Null — and therefore an untouched code path —
+    // whenever neither the caller nor the definition configured a limit.
+    // When present, its signal replaces the caller's for the whole run so a
+    // wall-clock breach interrupts an in-flight step instead of waiting for
+    // one to return.
+    const budget = createRunBudget(
+      mergeSpellBudgets(options.budget, definition.budget),
+      { parentSignal: options.signal },
+    );
+    const runOptions: RunnerOptions = budget
+      ? { ...options, signal: budget.signal }
+      : options;
+
     const credentialPatterns = buildCredentialPatterns(options.credentialValues ?? []);
     const credentialNames = collectCredentialNames(definition.steps);
     const resolvedCredentials: Record<string, unknown> = {};
@@ -284,13 +301,14 @@ export class SpellCaster {
     }
 
     const state: StepExecutionState = {
-      variables, resolvedArgs, spellId, options,
+      variables, resolvedArgs, spellId, options: runOptions,
       credentialPatterns, resolvedCredentials,
       spellMofloLevel: definition.mofloLevel,
       parentMofloLevel: options.parentMofloLevel,
       nestingDepth: options.nestingDepth ?? 0,
       maxNestingDepth: options.maxNestingDepth ?? DEFAULT_MAX_NESTING_DEPTH,
       effectiveSandbox,
+      ...(budget ? { budget } : {}),
     };
 
     try {
@@ -314,7 +332,16 @@ export class SpellCaster {
         break;
       }
 
-      if (options.signal?.aborted) {
+      // Checked before the abort check below, because a wall-clock breach
+      // aborts the signal — reading the signal first would report the run as
+      // a plain cancellation and lose the reason.
+      budget?.checkWallClock();
+      if (budget?.breach) {
+        this.markRemaining(definition, i, 'skipped', stepResults);
+        break;
+      }
+
+      if (runOptions.signal?.aborted) {
         cancelled = true;
         this.markRemaining(definition, i, 'cancelled', stepResults);
         break;
@@ -432,16 +459,42 @@ export class SpellCaster {
           break;
         }
       }
+
+      // A ceiling a step can opt out of is not a ceiling — this deliberately
+      // ignores `continueOnError`. Reached when the step that tripped the
+      // budget declared `continueOnError: true`, or when it succeeded and the
+      // breach came from elsewhere. Rollback is left to the terminal block
+      // below so the breach path rolls back exactly once.
+      if (budget?.breach) {
+        this.markRemaining(definition, i + 1, 'skipped', stepResults);
+        break;
+      }
     }
 
-    if (cancelled) {
+    const breach: BudgetBreach | null = budget?.breach ?? null;
+
+    if (cancelled || breach) {
       if (completedSteps.length > 0) await this.doRollback(completedSteps, state, stepResults);
+    }
+    if (cancelled && !breach) {
       errors.push({ code: 'SPELL_CANCELLED', message: 'Spell was cancelled' });
     }
+    if (breach) {
+      // Pushed last so it reads as the reason the run stopped, ahead of the
+      // step failure the denial itself produced.
+      errors.push({ code: 'BUDGET_EXCEEDED', message: breach.message });
+    }
 
-    const finalStatus = cancelled ? 'cancelled' : errors.length > 0 ? 'failed' : 'completed';
+    // A breach reports as `failed`, not `cancelled`, even when the wall-clock
+    // abort surfaced through a cancelled step: `cancelled` in this engine means
+    // "the caller stopped it", and a ceiling breach is moflo stopping a run
+    // that overran. Dashboards and oncall need to tell those apart.
+    const finalStatus = breach
+      ? 'failed'
+      : cancelled ? 'cancelled' : errors.length > 0 ? 'failed' : 'completed';
     await this.storeProgress(spellId, finalStatus, stepResults.length, definition.steps.length, {
       spellName: definition.name, startedAt: startTime, errors, steps: stepResults, context,
+      ...(breach ? { budgetBreach: breach } : {}),
     });
 
     const outputs: Record<string, unknown> = {};
@@ -451,9 +504,13 @@ export class SpellCaster {
       }
     }
 
-    return { spellId, success: errors.length === 0 && !cancelled,
-      steps: stepResults, outputs, errors, duration: Date.now() - startTime, cancelled };
+    return { spellId, success: errors.length === 0 && !cancelled && !breach,
+      steps: stepResults, outputs, errors, duration: Date.now() - startTime,
+      cancelled: breach ? false : cancelled };
     } finally {
+      // Release the budget's deadline timer and parent-signal listener before
+      // anything else — it is the only thing here holding a live timer.
+      budget?.dispose();
       // Dispose any connectors that were lazily initialized during step execution
       if (this.connectorAccessor) {
         await this.connectorAccessor.disposeAll();
@@ -524,7 +581,7 @@ export class SpellCaster {
     state: StepExecutionState, index: number,
   ) {
     const ctxBuilder = (v: Record<string, unknown>, a: Record<string, unknown>, sid: string, si: number, sig?: AbortSignal) =>
-      this.buildContext(v, a, sid, si, sig, state.effectiveSandbox);
+      this.buildContext(v, a, sid, si, sig, state.effectiveSandbox, state.budget);
     return executeSingleStep(step, state, index, this.registry, ctxBuilder);
   }
 
@@ -726,18 +783,24 @@ export class SpellCaster {
   private buildContext(
     variables: Record<string, unknown>, args: Record<string, unknown>,
     spellId: string, stepIndex: number, signal?: AbortSignal,
-    sandbox?: EffectiveSandbox,
+    sandbox?: EffectiveSandbox, budget?: RunBudgetAccessor,
   ): CastingContext {
     return { variables, args, credentials: this.credentials, memory: this.memory,
       taskId: `${spellId}-step-${stepIndex}`, spellId, stepIndex, abortSignal: signal,
       gateway: DENY_ALL_GATEWAY,
       ...(this.connectorAccessor ? { tools: this.connectorAccessor } : {}),
-      ...(sandbox ? { sandbox } : {}) };
+      ...(sandbox ? { sandbox } : {}),
+      ...(budget ? { budget } : {}) };
   }
 
   private async storeProgress(
     wfId: string, status: string, done: number, total: number,
-    extra?: { spellName?: string; startedAt?: number; errors?: SpellError[]; steps?: StepResult[]; context?: FloRunContext },
+    extra?: {
+      spellName?: string; startedAt?: number; errors?: SpellError[];
+      steps?: StepResult[]; context?: FloRunContext;
+      /** Ceiling that stopped this run (#1335) — absent on every other path. */
+      budgetBreach?: BudgetBreach;
+    },
   ) {
     try {
       const now = Date.now();
@@ -757,6 +820,17 @@ export class SpellCaster {
       // Include error summary on terminal states
       if (extra?.errors && extra.errors.length > 0 && (status === 'failed' || status === 'cancelled')) {
         record.error = extra.errors.map(e => e.message).join('; ');
+      }
+      // Why the run stopped, structured (#1335). `error` above carries the
+      // same thing as prose; a reader asking "did a ceiling stop this" should
+      // not have to grep a message for it.
+      if (extra?.budgetBreach) {
+        record.abortReason = 'budget-exceeded';
+        record.budgetBreach = {
+          kind: extra.budgetBreach.kind,
+          limit: extra.budgetBreach.limit,
+          observed: extra.budgetBreach.observed,
+        };
       }
       // Include per-step results for dashboard diagnostics
       if (extra?.steps && extra.steps.length > 0) {

--- a/src/cli/spells/core/step-executor.ts
+++ b/src/cli/spells/core/step-executor.ts
@@ -51,6 +51,8 @@ export interface StepExecutionState {
   readonly maxNestingDepth: number;
   /** Resolved sandbox state for this spell run (Issue #410). */
   readonly effectiveSandbox?: import('./platform-sandbox.js').EffectiveSandbox;
+  /** Spend ceiling for this run, when one is configured (Issue #1335). */
+  readonly budget?: import('./run-budget.js').RunBudgetAccessor;
 }
 
 /**

--- a/src/cli/spells/factory/runner-bridge.ts
+++ b/src/cli/spells/factory/runner-bridge.ts
@@ -13,6 +13,7 @@ import type { SpellResult } from '../types/runner.types.js';
 import type { CredentialAccessor, MemoryAccessor } from '../types/step-command.types.js';
 import type { SandboxConfig } from '../core/platform-sandbox.js';
 import { loadSandboxConfigFromProject } from '../core/platform-sandbox.js';
+import type { SpellBudgetConfig } from '../core/run-budget.js';
 import { createRunner, runSpellFromContent } from './runner-factory.js';
 import { getDefaultCredentialStore } from '../credentials/default-store.js';
 
@@ -50,6 +51,7 @@ export async function bridgeRunSpell(
     credentials?: CredentialAccessor;
     projectRoot?: string;
     sandboxConfig?: SandboxConfig;
+    budget?: SpellBudgetConfig;
     forceCredentialReprompt?: boolean;
   } = {},
 ): Promise<SpellResult> {
@@ -70,6 +72,7 @@ export async function bridgeRunSpell(
       forceCredentialReprompt: options.forceCredentialReprompt,
       ...(options.projectRoot ? { projectRoot: options.projectRoot } : {}),
       ...(sandboxConfig ? { sandboxConfig } : {}),
+      ...(options.budget ? { budget: options.budget } : {}),
     });
     return result;
   } finally {
@@ -89,6 +92,7 @@ export async function bridgeExecuteSpell(
     credentials?: CredentialAccessor;
     projectRoot?: string;
     sandboxConfig?: SandboxConfig;
+    budget?: SpellBudgetConfig;
     forceCredentialReprompt?: boolean;
   } = {},
 ): Promise<SpellResult> {
@@ -106,6 +110,7 @@ export async function bridgeExecuteSpell(
       forceCredentialReprompt: options.forceCredentialReprompt,
       ...(options.projectRoot ? { projectRoot: options.projectRoot } : {}),
       ...(sandboxConfig ? { sandboxConfig } : {}),
+      ...(options.budget ? { budget: options.budget } : {}),
     });
   } finally {
     activeSpells.delete(spellId);

--- a/src/cli/spells/factory/runner-factory.ts
+++ b/src/cli/spells/factory/runner-factory.ts
@@ -17,6 +17,7 @@ import { parseSpell } from '../schema/parser.js';
 import { validateSpellDefinition } from '../schema/validator.js';
 import { SpellConnectorRegistry } from '../registry/connector-registry.js';
 import { loadSandboxConfigFromProject } from '../core/platform-sandbox.js';
+import { loadSpellBudgetFromProject } from '../core/run-budget.js';
 import { errorDetail } from '../../shared/utils/error-detail.js';
 import { getDefaultCredentialStore } from '../credentials/default-store.js';
 
@@ -124,6 +125,17 @@ export async function runSpellFromContent(
   if (!runnerOptions.sandboxConfig && runnerOptions.projectRoot) {
     const autoCfg = await loadSandboxConfigFromProject(runnerOptions.projectRoot);
     (runnerOptions as { sandboxConfig?: typeof autoCfg }).sandboxConfig = autoCfg;
+  }
+
+  // Same auto-load for the spend ceiling (#1335), but from the `interactive`
+  // slot: everything reaching this function is a session-attached run (CLI
+  // cast, MCP cast). The daemon path builds its options explicitly and passes
+  // the `scheduled` ceiling. Absent config ⇒ undefined ⇒ no budget at all.
+  if (!runnerOptions.budget && runnerOptions.projectRoot) {
+    const autoBudget = await loadSpellBudgetFromProject(runnerOptions.projectRoot, 'interactive');
+    if (autoBudget) {
+      (runnerOptions as { budget?: typeof autoBudget }).budget = autoBudget;
+    }
   }
 
   return runner.run(definition, args, runnerOptions);

--- a/src/cli/spells/index.ts
+++ b/src/cli/spells/index.ts
@@ -109,6 +109,20 @@ export {
 } from './core/platform-sandbox.js';
 
 export {
+  createRunBudget,
+  resolveSpellBudgetConfig,
+  mergeSpellBudgets,
+  hasBudgetLimit,
+  loadSpellBudgetFromProject,
+  SpellRunBudget,
+  type SpellBudgetConfig,
+  type SpellBudgetMode,
+  type BudgetBreach,
+  type BudgetLimitKind,
+  type RunBudgetAccessor,
+} from './core/run-budget.js';
+
+export {
   resolveScopePath,
   type SandboxWrapResult,
 } from './core/sandbox-utils.js';

--- a/src/cli/spells/schema/validator.ts
+++ b/src/cli/spells/schema/validator.ts
@@ -22,7 +22,7 @@ import type {
 import { isValidMofloLevel } from '../core/capability-validator.js';
 import { MOFLO_LEVEL_ORDER } from '../types/step-command.types.js';
 import { validateSchedule } from '../scheduler/cron-parser.js';
-import { validateTopLevel, validateArguments, matchesArgumentType, validateSandbox } from './validators/top-level.js';
+import { validateTopLevel, validateArguments, matchesArgumentType, validateSandbox, validateBudget } from './validators/top-level.js';
 import { validateSteps } from './validators/steps.js';
 import { validatePrerequisites } from './validators/prerequisites.js';
 import { validateVariableReferences } from './validators/references.js';
@@ -44,6 +44,7 @@ export function validateSpellDefinition(
 
   validateTopLevel(def, errors);
   validateSandbox(def, errors);
+  validateBudget(def, errors);
 
   if (def.mofloLevel !== undefined && !isValidMofloLevel(def.mofloLevel)) {
     errors.push({

--- a/src/cli/spells/schema/validators/top-level.ts
+++ b/src/cli/spells/schema/validators/top-level.ts
@@ -95,6 +95,46 @@ export function validateSandbox(def: SpellDefinition, errors: ValidationError[])
   }
 }
 
+/**
+ * Validate a spell's optional `budget` block (issue #1335).
+ *
+ * A typo here is silent and expensive in the wrong direction: an unrecognised
+ * key means "no ceiling", so a spell the author believed was capped would run
+ * unbounded on the daemon. Reject the shape at parse time instead.
+ */
+export function validateBudget(def: SpellDefinition, errors: ValidationError[]): void {
+  const budget = (def as { budget?: unknown }).budget;
+  if (budget === undefined) return;
+
+  if (budget === null || typeof budget !== 'object' || Array.isArray(budget)) {
+    errors.push({ path: 'budget', message: 'budget must be an object' });
+    return;
+  }
+
+  const known = ['maxModelInvocations', 'maxWallClockMs'] as const;
+  const rec = budget as Record<string, unknown>;
+
+  for (const key of Object.keys(rec)) {
+    if (!(known as readonly string[]).includes(key)) {
+      errors.push({
+        path: `budget.${key}`,
+        message: `unknown budget key "${key}". Valid keys: ${known.join(', ')}`,
+      });
+    }
+  }
+
+  for (const key of known) {
+    const value = rec[key];
+    if (value === undefined) continue;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+      errors.push({
+        path: `budget.${key}`,
+        message: `budget.${key} must be a number greater than 0`,
+      });
+    }
+  }
+}
+
 /** Check whether a value matches a declared ArgumentType. */
 export function matchesArgumentType(value: unknown, type: ArgumentType): boolean {
   switch (type) {

--- a/src/cli/spells/types/runner.types.ts
+++ b/src/cli/spells/types/runner.types.ts
@@ -8,6 +8,7 @@ import type { StepOutput, ValidationError, MofloLevel, PrerequisiteResult } from
 import type { PermissionLevel, ResolvedPermissions } from '../core/permission-resolver.js';
 import type { PermissionWarning, RiskLevel } from '../core/permission-disclosure.js';
 import type { SandboxConfig } from '../core/platform-sandbox.js';
+import type { SpellBudgetConfig } from '../core/run-budget.js';
 import type { PreflightResolution } from './spell-definition.types.js';
 
 // ============================================================================
@@ -35,6 +36,7 @@ export type SpellErrorCode =
   | 'MISSING_CREDENTIAL'
   | 'CREDENTIAL_LIKELY_STALE'
   | 'SANDBOX_REQUIRED'
+  | 'BUDGET_EXCEEDED'
   | 'SPELL_CANCELLED';
 
 // ============================================================================
@@ -184,6 +186,13 @@ export interface RunnerOptions {
 
   /** OS-level sandbox configuration from moflo.yaml. */
   readonly sandboxConfig?: SandboxConfig;
+
+  /**
+   * Spend ceilings for this run (issue #1335). Composed with the spell
+   * definition's own `budget` block under "most strict wins". Omit — or pass
+   * a config with no limits — for today's unbounded behaviour.
+   */
+  readonly budget?: SpellBudgetConfig;
 
   /** Project root for acceptance gate storage (.moflo/accepted-permissions/). */
   readonly projectRoot?: string;

--- a/src/cli/spells/types/spell-definition.types.ts
+++ b/src/cli/spells/types/spell-definition.types.ts
@@ -6,6 +6,7 @@
 
 import type { CapabilityType, MofloLevel } from './step-command.types.js';
 import type { PermissionLevel } from '../core/permission-resolver.js';
+import type { SpellBudgetConfig } from '../core/run-budget.js';
 import type { ScheduleDefinition } from '../scheduler/schedule.types.js';
 
 // ============================================================================
@@ -222,6 +223,13 @@ export interface SpellDefinition {
    * global `sandbox` config in `moflo.yaml` under "more strict wins".
    */
   readonly sandbox?: SandboxRequirement;
+  /**
+   * Per-spell spend ceilings (issue #1335). Composes with `spells.budget.*`
+   * in `moflo.yaml` under "more strict wins" — a spell that knows it should
+   * never call the model more than twice can say so, and a project ceiling
+   * can still tighten it further.
+   */
+  readonly budget?: SpellBudgetConfig;
 }
 
 // ============================================================================

--- a/src/cli/spells/types/step-command.types.ts
+++ b/src/cli/spells/types/step-command.types.ts
@@ -125,6 +125,13 @@ export interface CastingContext {
   readonly permissionLevel?: import('../core/permission-resolver.js').PermissionLevel;
   /** Effective sandbox state for OS-level confinement (Issue #410). */
   readonly sandbox?: import('../core/platform-sandbox.js').EffectiveSandbox;
+  /**
+   * Spend ceiling for this run (Issue #1335). Present only when the project
+   * or the spell configured one — absent means unbounded, which is the
+   * default. A command that spawns a billed model process must reserve
+   * through this before starting the process.
+   */
+  readonly budget?: import('../core/run-budget.js').RunBudgetAccessor;
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #1335.

Spells spawn billed `claude -p` processes from bash steps with no accounting and no ceiling. The exposure concentrates on the daemon path: a cron spell runs unattended, can invoke the model repeatedly, and nothing observes or bounds the spend until a bill arrives.

## What this adds

Two opt-in ceilings per run, both **proxies for spend rather than measurements of it**:

| Ceiling | Counts | Enforced |
|---|---|---|
| `maxModelInvocations` | bash steps matching the existing `CLAUDE_HEADLESS_RE` | reservation **before** the process spawns — a denied invocation is never billed |
| `maxWallClockMs` | elapsed since the run started | deadline timer on the run's abort signal, plus a between-steps check |

The ticket's expensive option — injecting `--output-format json` and parsing `usage` from the spawned process's stdout — was **not** taken: it changes what a bash step returns to downstream steps and would break every spell consuming a model step's text output.

## Configuration

```yaml
# moflo.yaml
spells:
  budget:
    scheduled:                  # daemon-scheduled runs
      maxModelInvocations: 20
      maxWallClockMs: 1800000
    interactive:                # session-attached — absent ⇒ no ceiling
      maxModelInvocations: 50
```

plus an optional per-spell `budget:` block. The effective ceiling is the **stricter** of the two, mirroring `sandbox.required` (#878). `scheduled` and `interactive` are configured separately and neither inherits from the other, so capping the daemon never reaches a `flo spell cast` you run yourself.

## Where enforcement lives, and why

**In the runner, not the scheduler.** The scheduler can only abort; it cannot count `claude -p` spawns, and an abort arriving mid-spawn has already been billed. The runner owns the step loop and builds the `CastingContext` every step reads, so it is the only place that can deny the *next* spawn rather than kill the current one.

A breach latches and **bypasses `continueOnError`** — a ceiling a step can opt out of is not a ceiling. The run ends with a new `BUDGET_EXCEEDED` code, reported as `failed` rather than `cancelled` so an overrun is distinguishable from a user ctrl-C.

## Consumer surface and blast radius

| Question | Answer |
|---|---|
| Surface touched | Spell engine (`spells/core`, `spells/commands`, `spells/factory`, `spells/schema`), `daemon-spell-executor`, `spell-tools` MCP, shipped guidance |
| Failure mode for a consumer on the current version | None. With no `spells.budget` and no per-spell `budget:`, `createRunBudget` returns **null** — the runner constructs no budget, swaps no signal, and puts nothing on the casting context. The options key is absent, not present-and-undefined. |
| Migration | None. No `.moflo/` state change, no hook re-graft, no `settings.json` change. |
| Round-trip | Publish-then-reinstall — the daemon, MCP server, and spell engine all run from `node_modules/moflo/`. |

## Observability

A breach surfaces three ways: `BUDGET_EXCEEDED` on the result, `abortReason: budget-exceeded` plus a structured `budgetBreach` (`kind` / `limit` / `observed`) in the run's `tasklist` record — which is the same record #1333's token rollup keys to, so "what did this run cost and why did it stop" now share a key — and a warning line from `DaemonSpellExecutor` so it lands in the daemon log. A ceiling that fires silently in an unattended process is indistinguishable from the runaway it prevented.

## Verification

`/verify` **PASS on all 5 acceptance criteria** (recorded as `verify:1335`).

One gap surfaced *during* verification rather than after: the `bridgeExecuteSpell` seam had no covering test, so a ceiling the bridge accepted and dropped before `runner.run` would have passed everything. Closed with an end-to-end pair through the real runner and real bash step (`470e74f84`) before the verdict was issued.

- Full suite **10230 passed / 0 failed**
- `eslint --max-warnings 0` clean, `tsc --noEmit` clean
- 55 new specs across `run-budget.test.ts`, `spell-budget-enforcement.test.ts`, and the daemon executor suite

Rule #1: pure JS timers and `AbortController`, the one file read goes through `path.join`, `timer.unref?.()` guarded, no shell and no platform branches.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
