### PR TITLE
feat(spells): bound daemon spend across runs, not just within one (#1380)

### DIFF
--- a/.claude/guidance/shipped/moflo-spell-scheduling.md
+++ b/.claude/guidance/shipped/moflo-spell-scheduling.md
@@ -89,24 +89,30 @@ Practical floors:
 
 ## Bounding Spend on Unattended Runs
 
-**Set `spells.budget.scheduled` before scheduling any spell that invokes `claude -p`.** A scheduled run is unattended: nothing observes how many times it calls the model, so a loop step or a too-frequent cron can spend without a signal until the bill arrives. The ceiling is opt-in and absent by default.
+**Set `spells.budget.scheduled` before scheduling any spell that invokes `claude -p`.** A scheduled run is unattended: nothing observes how many times it calls the model, so a loop step or a too-frequent cron can spend without a signal until the bill arrives. `flo init` writes these values into new projects; existing projects are untouched on upgrade and must opt in.
 
 ```yaml
 spells:
   budget:
     scheduled:
-      maxModelInvocations: 20     # `claude -p` spawns allowed per run
-      maxWallClockMs: 1800000     # 30 minutes end to end
+      maxModelInvocations: 30     # `claude -p` spawns allowed per run
+      maxWallClockMs: 2400000     # 40 minutes end to end
+      dailyModelInvocations: 300  # rolling 24h across ALL scheduled runs
 ```
 
-| Ceiling | Enforced | On breach |
-|---------|----------|-----------|
-| `maxModelInvocations` | Reservation before the process spawns | The spawn is refused — a denied invocation is never billed |
-| `maxWallClockMs` | Deadline timer on the run's abort signal | The in-flight step is aborted |
+| Ceiling | Scope | Enforced | On breach |
+|---------|-------|----------|-----------|
+| `maxModelInvocations` | One run | Reservation before the process spawns | The spawn is refused — a denied invocation is never billed |
+| `maxWallClockMs` | One run | Deadline timer on the run's abort signal | The in-flight step is aborted |
+| `dailyModelInvocations` | Every run in this project, trailing 24h | Reservation checked against the on-disk ledger | The spawn is refused before the process starts |
+
+**Set `dailyModelInvocations`, not just the per-run keys — a per-run ceiling cannot bound a schedule.** The two answer different questions. A per-run ceiling asks "did this run go haywire"; the daily one asks "is this project spending more than I meant to." A five-minute cron under a 30-invocation per-run cap satisfies the per-run check 288 times a day and still reaches 8,640 invocations. Only the rolling window sees the total.
+
+The count persists in `.moflo/spell-invocation-ledger.json` and is checked **before** the per-run ceiling, so a breach message names the limit that actually stopped the run. Delete the file to reset the window; a corrupt or unreadable ledger fails open rather than blocking every scheduled run.
 
 **A breach aborts the run and ignores `continueOnError`.** It surfaces three ways: a `BUDGET_EXCEEDED` error on the result, `abortReason: budget-exceeded` plus a structured `budgetBreach` in the run's `tasklist` record, and a warning line in the daemon log.
 
-**This is a proxy for spend, not a measurement of it.** moflo counts invocations, not tokens — metering would require changing what a bash step returns to downstream steps. Use `spells.budget.interactive` (configured separately, never inherited from `scheduled`) to cap session-attached runs, and a per-spell `budget:` block to tighten a single spell. Full key reference: `.claude/guidance/moflo-yaml-reference.md`.
+**This is a proxy for spend, not a measurement of it.** moflo counts invocations, not tokens — metering would require changing what a bash step returns to downstream steps, and `claude -p "say hi"` counts the same as `claude -p "refactor this subsystem"`. Use `spells.budget.interactive` (configured separately, never inherited from `scheduled`, and deliberately loose because a human is present) to cap session-attached runs, and a per-spell `budget:` block to tighten a single spell. Full key reference: `.claude/guidance/moflo-yaml-reference.md`.
 
 ---
 

--- a/.claude/guidance/shipped/moflo-yaml-reference.md
+++ b/.claude/guidance/shipped/moflo-yaml-reference.md
@@ -116,14 +116,16 @@ sandbox:
   enabled: false                  # Set to true to wrap bash steps in an OS sandbox
   tier: auto                      # auto | denylist-only | full
 
-# Spell spend ceilings (OPTIONAL — omit for unbounded runs, which is the default)
+# Spell spend ceilings (written by `flo init`; delete a key for unlimited)
 spells:
   budget:
     scheduled:                    # Daemon-scheduled runs (cron/interval/at)
-      maxModelInvocations: 20     # Max `claude -p` spawns per run
-      maxWallClockMs: 1800000     # Max run duration (30 min)
-    interactive:                  # Session-attached runs — omit to leave uncapped
-      maxModelInvocations: 50
+      maxModelInvocations: 30     # Max `claude -p` spawns per run
+      maxWallClockMs: 2400000     # Max run duration (40 min)
+      dailyModelInvocations: 300  # Rolling 24h across ALL scheduled runs
+    interactive:                  # Session-attached runs — a human is watching
+      maxModelInvocations: 200
+      maxWallClockMs: 14400000    # 4 hours
 
 # Auto-update on session start (refreshes consumer assets when moflo upgrades)
 auto_update:
@@ -146,12 +148,23 @@ If your `moflo.yaml` predates the `sandbox:` or `auto_update:` blocks, they are 
 
 | Key | Counts | On breach |
 |-----|--------|-----------|
-| `maxModelInvocations` | `claude -p` spawns detected in bash steps | The next spawn is refused **before** the process starts, and the run aborts |
+| `maxModelInvocations` | `claude -p` spawns detected in bash steps, this run | The next spawn is refused **before** the process starts, and the run aborts |
 | `maxWallClockMs` | Elapsed time since the run started | The in-flight step is aborted and the run ends |
+| `dailyModelInvocations` | `claude -p` spawns across **all** runs sharing this project root in a trailing 24h | The next spawn is refused before the process starts, and the run aborts |
 
-**Both keys are optional and both default to unlimited.** Omitting the `spells:` block entirely leaves every run exactly as it behaves without this setting.
+**Treat these as runaway backstops, not cost controls.** An invocation is not a unit of spend — `claude -p "say hi"` and `claude -p "refactor this subsystem"` each count as one. The per-run keys catch a loop that spawns the model forever; `dailyModelInvocations` is the one that tracks a bill.
 
-**`scheduled` and `interactive` are configured separately, and neither inherits from the other.** Setting `scheduled` never caps a `flo spell cast` you run yourself — session-attached runs stay uncapped until you add `interactive` explicitly.
+**Pick `dailyModelInvocations` deliberately — a per-run ceiling cannot bound a schedule.** A five-minute cron under a 30-invocation per-run cap still permits 8,640 invocations a day, and every one of them satisfies the per-run check. Only the rolling window notices.
+
+The rolling count lives in `.moflo/spell-invocation-ledger.json`, bucketed by clock hour, so the window covers between 23 and 24 hours depending on where "now" falls. That granularity is deliberate: it keeps the file bounded at ~24 entries however high the volume, and it is ample for catching an order-of-magnitude overrun. Delete the file to reset the window. An unreadable or corrupt ledger **fails open** — a safety ceiling must never block runs that would otherwise work.
+
+**Every key is optional and each defaults to unlimited.** Deleting a key restores unbounded behavior for that dimension; deleting the `spells.budget` block restores it for all of them.
+
+**`scheduled` and `interactive` are configured separately, and neither inherits from the other.** Setting `scheduled` never caps a `flo spell cast` you run yourself, and vice versa. The `interactive` values `flo init` writes are deliberately loose — a human is present who can interrupt the run — so raise them freely if one ever fires on you. Note `interactive` applies per **spell cast**, not per Claude Code session: a long session with compaction between tasks never touches it.
+
+**A resumed spell re-applies the `interactive` ceiling with a fresh wall clock.** Time spent suspended does not count against it.
+
+`flo init` writes this block into new projects. Existing projects are **not** modified on upgrade — add the block yourself to opt in.
 
 A spell may also declare its own `budget:` block; the effective ceiling is the **stricter** of the two, so a project cap can tighten a spell and a spell can tighten itself further, but neither can loosen the other:
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,6 +115,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs\" record-test-run",
             "timeout": 2000
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs\" record-bash-swarm-init",
+            "timeout": 2000
           }
         ]
       },

--- a/moflo.yaml
+++ b/moflo.yaml
@@ -127,6 +127,33 @@ spells:
     - .claude/spells
     - spells/dev
 
+  # Spend ceilings for spells that spawn `claude -p` from a bash step.
+  #
+  # These are RUNAWAY BACKSTOPS, not cost controls. Their job is to stop a loop
+  # that spawns the model forever — not to tune your bill. Any per-run number is
+  # somewhat arbitrary; what matters is that it is finite.
+  #
+  # An invocation is not a unit of spend: `claude -p "say hi"` and
+  # `claude -p "refactor this subsystem"` both count as one. Treat the count as
+  # a proxy, and `dailyModelInvocations` as the number that tracks your bill.
+  budget:
+    # Daemon-fired runs. Nobody is watching, so these are the tight ones.
+    scheduled:
+      maxModelInvocations: 30       # per run
+      maxWallClockMs: 2400000       # 40 min — longer than this at 3am is stuck, not working
+      # Rolling 24h across ALL scheduled runs. A per-run ceiling bounds one bad
+      # run; this bounds a misconfigured schedule (a 5-min cron × 30 = 8,640/day,
+      # every one of which passes the per-run check).
+      dailyModelInvocations: 300
+
+    # `flo spell cast` / MCP cast. A human is present and can ctrl-C, so this is
+    # deliberately loose — raise it freely if it ever fires on you.
+    # Note: this is per SPELL CAST, not per Claude Code session. Long sessions
+    # with compaction between tasks never touch it.
+    interactive:
+      maxModelInvocations: 200
+      maxWallClockMs: 14400000      # 4 hours
+
 # Spell step sandboxing (OS-level process isolation for bash steps)
 # Platform support: macOS (sandbox-exec), Linux/WSL (bwrap). Windows has no OS sandbox.
 # Tiers:

--- a/src/cli/__tests__/init-moflo-yaml-template.test.ts
+++ b/src/cli/__tests__/init-moflo-yaml-template.test.ts
@@ -19,6 +19,8 @@ import {
   discoverGuidanceDirs,
   type MofloYamlConfig,
 } from '../init/moflo-yaml-template.js';
+import * as yaml from 'js-yaml';
+import { resolveSpellBudgetConfig } from '../spells/core/run-budget.js';
 
 function makeTempRoot(label: string): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), `moflo-yaml-${label}-`));
@@ -322,5 +324,58 @@ describe('discovery walk safety', () => {
 
   it('detectExtensions falls back when src/ does not exist', () => {
     expect(detectExtensions(root, ['src'])).toEqual(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+  });
+});
+
+// ============================================================================
+// Spend ceilings (#1335 follow-up)
+// ============================================================================
+
+/**
+ * The budget block the template ships is a worked example that nothing else
+ * exercises: if a key name drifts, the block still parses as valid YAML and
+ * every generated project silently runs unbounded. These tests feed the
+ * rendered template through the same resolver the runner uses, so a typo
+ * fails here rather than in a consumer's bill.
+ */
+describe('renderMofloYaml — spend ceilings', () => {
+  let root: string;
+
+  beforeEach(() => { root = makeTempRoot('budget'); });
+  afterEach(() => { cleanRoot(root); });
+
+  function budgetOf(mode: 'scheduled' | 'interactive') {
+    const parsed = yaml.load(renderMofloYaml(defaultMofloYamlConfig(root))) as {
+      spells?: { budget?: Record<string, unknown> };
+    };
+    return resolveSpellBudgetConfig(parsed?.spells?.budget?.[mode]);
+  }
+
+  it('renders a scheduled ceiling the resolver actually recognises', () => {
+    expect(budgetOf('scheduled')).toEqual({
+      maxModelInvocations: 30,
+      maxWallClockMs: 2400000,
+      dailyModelInvocations: 300,
+    });
+  });
+
+  it('renders an interactive ceiling the resolver actually recognises', () => {
+    expect(budgetOf('interactive')).toEqual({
+      maxModelInvocations: 200,
+      maxWallClockMs: 14400000,
+    });
+  });
+
+  it('caps scheduled runs more tightly than interactive ones', () => {
+    const scheduled = budgetOf('scheduled')!;
+    const interactive = budgetOf('interactive')!;
+    // Unattended runs are the exposure; a template that shipped these the
+    // other way round would be worse than shipping neither.
+    expect(scheduled.maxModelInvocations!).toBeLessThan(interactive.maxModelInvocations!);
+    expect(scheduled.maxWallClockMs!).toBeLessThan(interactive.maxWallClockMs!);
+  });
+
+  it('bounds the daemon across runs, not only within one', () => {
+    expect(budgetOf('scheduled')!.dailyModelInvocations).toBeGreaterThan(0);
   });
 });

--- a/src/cli/__tests__/spells/helpers.ts
+++ b/src/cli/__tests__/spells/helpers.ts
@@ -10,6 +10,11 @@ import type {
   MemoryAccessor,
 } from '../../spells/types/step-command.types.js';
 import type { ICapabilityGateway } from '../../spells/core/capability-gateway.js';
+import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
+import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
+import { builtinCommands } from '../../spells/commands/index.js';
+import { analyzeSpellPermissions } from '../../spells/core/permission-disclosure.js';
+import { recordAcceptance } from '../../spells/core/permission-acceptance.js';
 
 /** Allow-all gateway for tests — no capability is denied. */
 export const ALLOW_ALL_GATEWAY: ICapabilityGateway = {
@@ -86,4 +91,30 @@ export function createMockContext(overrides?: Partial<CastingContext>): CastingC
     gateway: ALLOW_ALL_GATEWAY,
     ...overrides,
   };
+}
+
+/**
+ * A bash command that matches the runner's `claude -p` detection regex without
+ * invoking a billed model: `echo` consumes the rest as literal arguments. Lets
+ * a test assert both halves — that a permitted reservation really does spawn,
+ * and that a denied one really does not.
+ */
+export const MODEL_SHAPED_COMMAND = 'echo claude -p hello';
+
+/**
+ * Record the permission acceptance a spell would have received at cast time.
+ *
+ * Any run given a `projectRoot` passes the first-run permission gate
+ * (`runner.ts` keys it on `options.projectRoot`), and a spell with bash steps
+ * is "higher risk" so it is not auto-accepted. Real spells are accepted once by
+ * their owner; tests that fabricate definitions record it themselves.
+ */
+export async function preAcceptSpell(
+  definition: SpellDefinition,
+  projectRoot: string,
+): Promise<void> {
+  const registry = new StepCommandRegistry();
+  for (const cmd of builtinCommands) registry.register(cmd, 'built-in');
+  const report = analyzeSpellPermissions(definition, registry);
+  await recordAcceptance(projectRoot, definition.name, report.permissionHash);
 }

--- a/src/cli/__tests__/spells/pause-resume.test.ts
+++ b/src/cli/__tests__/spells/pause-resume.test.ts
@@ -22,6 +22,22 @@ import { builtinCommands } from '../../spells/commands/index.js';
 import { analyzeSpellPermissions } from '../../spells/core/permission-disclosure.js';
 import { recordAcceptance } from '../../spells/core/permission-acceptance.js';
 
+/**
+ * Observe the sandbox config load without replacing its behaviour — the fix
+ * under test is that `resumeSpell` consults it at all.
+ */
+const loadSandboxSpy = vi.fn();
+vi.mock('../../spells/core/platform-sandbox.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../spells/core/platform-sandbox.js')>();
+  return {
+    ...actual,
+    loadSandboxConfigFromProject: (root: string) => {
+      loadSandboxSpy(root);
+      return actual.loadSandboxConfigFromProject(root);
+    },
+  };
+});
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -355,5 +371,35 @@ describe('resumeSpell — project config', () => {
 
     expect(result.errors.some(e => e.code === 'BUDGET_EXCEEDED')).toBe(false);
     expect(result.success).toBe(true);
+  });
+
+  it('re-applies the project sandbox config to the resumed half', async () => {
+    // The other half of the same bug: a resumed run dropped `sandbox` for
+    // exactly the reason it dropped `budget`.
+    //
+    // Asserted by observing the load rather than its OS effect: whether
+    // `tier: full` engages or refuses depends on whether bwrap/sandbox-exec
+    // exists on the runner, which differs across the three platforms moflo
+    // ships to (Rule #1). What is platform-independent — and what was actually
+    // broken — is that the project's config was never consulted at all.
+    writeFileSync(
+      join(projectRoot, 'moflo.yaml'),
+      'sandbox:\n  enabled: true\n  tier: denylist-only\n',
+      'utf-8',
+    );
+    const memory = createMockMemory();
+    const definition: SpellDefinition = {
+      name: 'sandboxed-spell',
+      steps: [{ id: 's1', type: 'wait', config: { duration: 0 } }],
+    };
+    await preAccept(definition);
+    await persistPausedState(
+      buildPausedState('wf-sandbox', definition, 0, {}, [], {}),
+      memory,
+    );
+
+    await resumeSpell('wf-sandbox', { memory, projectRoot });
+
+    expect(loadSandboxSpy).toHaveBeenCalledWith(projectRoot);
   });
 });

--- a/src/cli/__tests__/spells/pause-resume.test.ts
+++ b/src/cli/__tests__/spells/pause-resume.test.ts
@@ -17,10 +17,7 @@ import {
   resumeSpell,
   cleanupStalePaused,
 } from '../../spells/factory/pause-resume.js';
-import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
-import { builtinCommands } from '../../spells/commands/index.js';
-import { analyzeSpellPermissions } from '../../spells/core/permission-disclosure.js';
-import { recordAcceptance } from '../../spells/core/permission-acceptance.js';
+import { MODEL_SHAPED_COMMAND, preAcceptSpell } from './helpers.js';
 
 /**
  * Observe the sandbox config load without replacing its behaviour — the fix
@@ -261,12 +258,6 @@ describe('cleanupStalePaused', () => {
 // Project config on the resumed half (#1335 follow-up)
 // ============================================================================
 
-/**
- * A bash command that matches the runner's `claude -p` detection regex without
- * spawning anything billed. Same device the #1335 enforcement tests use.
- */
-const MODEL_SHAPED_COMMAND = 'echo claude -p hello';
-
 describe('resumeSpell — project config', () => {
   let projectRoot: string;
 
@@ -278,21 +269,6 @@ describe('resumeSpell — project config', () => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  /**
-   * Threading `projectRoot` also subjects a resumed spell to the permission
-   * acceptance gate (`runner.ts:119` keys it on `options.projectRoot`), which
-   * is correct — it re-checks the permission hash of a definition that came
-   * back off disk, matching the tamper-defense re-validation already in
-   * `resumeSpell`. A real resume inherits the acceptance recorded at cast
-   * time; these tests fabricate paused state directly, so they record it here.
-   */
-  async function preAccept(definition: SpellDefinition): Promise<void> {
-    const registry = new StepCommandRegistry();
-    for (const cmd of builtinCommands) registry.register(cmd, 'built-in');
-    const report = analyzeSpellPermissions(definition, registry);
-    await recordAcceptance(projectRoot, definition.name, report.permissionHash);
-  }
-
   async function pausedTwoModelSteps(memory: MemoryAccessor) {
     const definition: SpellDefinition = {
       name: 'model-spell',
@@ -301,7 +277,7 @@ describe('resumeSpell — project config', () => {
         { id: 'm2', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
       ],
     };
-    await preAccept(definition);
+    await preAcceptSpell(definition, projectRoot);
     await persistPausedState(
       buildPausedState('wf-budget', definition, 0, {}, [], {}),
       memory,
@@ -392,7 +368,7 @@ describe('resumeSpell — project config', () => {
       name: 'sandboxed-spell',
       steps: [{ id: 's1', type: 'wait', config: { duration: 0 } }],
     };
-    await preAccept(definition);
+    await preAcceptSpell(definition, projectRoot);
     await persistPausedState(
       buildPausedState('wf-sandbox', definition, 0, {}, [], {}),
       memory,

--- a/src/cli/__tests__/spells/pause-resume.test.ts
+++ b/src/cli/__tests__/spells/pause-resume.test.ts
@@ -4,7 +4,10 @@
  * Story #140: Tests for spell pause/resume mechanism.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { MemoryAccessor } from '../../spells/types/step-command.types.js';
 import type { StepResult } from '../../spells/types/runner.types.js';
 import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
@@ -14,6 +17,10 @@ import {
   resumeSpell,
   cleanupStalePaused,
 } from '../../spells/factory/pause-resume.js';
+import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
+import { builtinCommands } from '../../spells/commands/index.js';
+import { analyzeSpellPermissions } from '../../spells/core/permission-disclosure.js';
+import { recordAcceptance } from '../../spells/core/permission-acceptance.js';
 
 // ============================================================================
 // Helpers
@@ -231,5 +238,122 @@ describe('cleanupStalePaused', () => {
     expect(cleaned).toBe(1);
     expect(await memory.read('spell-paused', 'wf-stale')).toBeNull();
     expect(await memory.read('spell-paused', 'wf-fresh')).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// Project config on the resumed half (#1335 follow-up)
+// ============================================================================
+
+/**
+ * A bash command that matches the runner's `claude -p` detection regex without
+ * spawning anything billed. Same device the #1335 enforcement tests use.
+ */
+const MODEL_SHAPED_COMMAND = 'echo claude -p hello';
+
+describe('resumeSpell — project config', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'moflo-resume-budget-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  /**
+   * Threading `projectRoot` also subjects a resumed spell to the permission
+   * acceptance gate (`runner.ts:119` keys it on `options.projectRoot`), which
+   * is correct — it re-checks the permission hash of a definition that came
+   * back off disk, matching the tamper-defense re-validation already in
+   * `resumeSpell`. A real resume inherits the acceptance recorded at cast
+   * time; these tests fabricate paused state directly, so they record it here.
+   */
+  async function preAccept(definition: SpellDefinition): Promise<void> {
+    const registry = new StepCommandRegistry();
+    for (const cmd of builtinCommands) registry.register(cmd, 'built-in');
+    const report = analyzeSpellPermissions(definition, registry);
+    await recordAcceptance(projectRoot, definition.name, report.permissionHash);
+  }
+
+  async function pausedTwoModelSteps(memory: MemoryAccessor) {
+    const definition: SpellDefinition = {
+      name: 'model-spell',
+      steps: [
+        { id: 'm1', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
+        { id: 'm2', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
+      ],
+    };
+    await preAccept(definition);
+    await persistPausedState(
+      buildPausedState('wf-budget', definition, 0, {}, [], {}),
+      memory,
+    );
+  }
+
+  it('applies the interactive ceiling to the resumed half when projectRoot is given', async () => {
+    writeFileSync(
+      join(projectRoot, 'moflo.yaml'),
+      'spells:\n  budget:\n    interactive:\n      maxModelInvocations: 1\n',
+      'utf-8',
+    );
+    const memory = createMockMemory();
+    await pausedTwoModelSteps(memory);
+
+    const result = await resumeSpell('wf-budget', { memory, projectRoot });
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some(e => e.code === 'BUDGET_EXCEEDED')).toBe(true);
+  });
+
+  it('runs uncapped when projectRoot is omitted — the pre-fix behaviour, now opt-out not default', async () => {
+    writeFileSync(
+      join(projectRoot, 'moflo.yaml'),
+      'spells:\n  budget:\n    interactive:\n      maxModelInvocations: 1\n',
+      'utf-8',
+    );
+    const memory = createMockMemory();
+    await pausedTwoModelSteps(memory);
+
+    // No projectRoot ⇒ nothing to load from ⇒ both steps run.
+    const result = await resumeSpell('wf-budget', { memory });
+
+    expect(result.errors.some(e => e.code === 'BUDGET_EXCEEDED')).toBe(false);
+  });
+
+  it('does not cap a resumed run when the project configures no ceiling', async () => {
+    writeFileSync(join(projectRoot, 'moflo.yaml'), 'spells:\n  userDirs: []\n', 'utf-8');
+    const memory = createMockMemory();
+    await pausedTwoModelSteps(memory);
+
+    const result = await resumeSpell('wf-budget', { memory, projectRoot });
+
+    expect(result.errors.some(e => e.code === 'BUDGET_EXCEEDED')).toBe(false);
+  });
+
+  it('starts the resumed wall clock fresh rather than counting time spent paused', async () => {
+    // Paused 10 minutes ago, ceiling is 1 minute. A resumed run that inherited
+    // the original start time would breach immediately; a fresh one must not.
+    writeFileSync(
+      join(projectRoot, 'moflo.yaml'),
+      'spells:\n  budget:\n    interactive:\n      maxWallClockMs: 60000\n',
+      'utf-8',
+    );
+    const memory = createMockMemory();
+    const definition: SpellDefinition = {
+      name: 'quick-spell',
+      steps: [{ id: 's1', type: 'wait', config: { duration: 0 } }],
+    };
+    const state = {
+      ...buildPausedState('wf-clock', definition, 0, {}, [], {}),
+      pausedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    };
+    await persistPausedState(state, memory);
+
+    const result = await resumeSpell('wf-clock', { memory, projectRoot });
+
+    expect(result.errors.some(e => e.code === 'BUDGET_EXCEEDED')).toBe(false);
+    expect(result.success).toBe(true);
   });
 });

--- a/src/cli/__tests__/spells/run-ledger.test.ts
+++ b/src/cli/__tests__/spells/run-ledger.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Rolling-window invocation ledger tests.
+ *
+ * The per-run ceiling from #1335 is unit-tested in run-budget.test.ts. What
+ * matters here is the property that ceiling could not have: a count that
+ * OUTLIVES the run, so a schedule firing every five minutes cannot satisfy a
+ * per-run ceiling thousands of times a day.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import {
+  InvocationLedger,
+  ledgerPathFor,
+  LEDGER_WINDOW_MS,
+} from '../../spells/core/run-ledger.js';
+import {
+  createRunBudget,
+  mergeSpellBudgets,
+  resolveSpellBudgetConfig,
+  hasBudgetLimit,
+} from '../../spells/core/run-budget.js';
+import { validateBudget } from '../../spells/schema/validators/top-level.js';
+import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
+import type { ValidationError } from '../../spells/types/step-command.types.js';
+
+const HOUR = 60 * 60 * 1000;
+
+describe('InvocationLedger', () => {
+  let root: string;
+  let path: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'moflo-ledger-'));
+    path = ledgerPathFor(root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('starts empty when no file exists', () => {
+    expect(new InvocationLedger(path).count()).toBe(0);
+  });
+
+  it('counts what it records', () => {
+    const ledger = new InvocationLedger(path);
+    ledger.record();
+    ledger.record();
+    ledger.record();
+    expect(ledger.count()).toBe(3);
+  });
+
+  it('persists across instances — the whole point of the ledger', () => {
+    new InvocationLedger(path).record();
+    new InvocationLedger(path).record();
+    // A fresh instance, as a later scheduled run would construct.
+    expect(new InvocationLedger(path).count()).toBe(2);
+  });
+
+  it('creates .moflo/ when it does not exist yet', () => {
+    expect(existsSync(dirname(path))).toBe(false);
+    new InvocationLedger(path).record();
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it('drops invocations that fell out of the trailing window', () => {
+    let now = Date.UTC(2026, 0, 2, 12, 0, 0);
+    const ledger = new InvocationLedger(path, { now: () => now });
+    ledger.record();
+    ledger.record();
+    expect(ledger.count()).toBe(2);
+
+    now += LEDGER_WINDOW_MS + HOUR;
+    expect(ledger.count()).toBe(0);
+  });
+
+  it('keeps invocations still inside the window', () => {
+    let now = Date.UTC(2026, 0, 2, 12, 0, 0);
+    const ledger = new InvocationLedger(path, { now: () => now });
+    ledger.record();
+
+    now += 20 * HOUR; // still under 24h
+    ledger.record();
+    expect(ledger.count()).toBe(2);
+  });
+
+  it('prunes on write so the file cannot grow without bound', () => {
+    let now = Date.UTC(2026, 0, 2, 0, 0, 0);
+    const ledger = new InvocationLedger(path, { now: () => now });
+    // 100 hours of activity — only ~24 buckets may survive.
+    for (let i = 0; i < 100; i++) {
+      ledger.record();
+      now += HOUR;
+    }
+    const buckets = JSON.parse(readFileSync(path, 'utf-8')).buckets as Record<string, number>;
+    expect(Object.keys(buckets).length).toBeLessThanOrEqual(25);
+  });
+
+  it('reports remaining against a limit', () => {
+    const ledger = new InvocationLedger(path);
+    ledger.record();
+    ledger.record();
+    expect(ledger.remaining(5)).toBe(3);
+    expect(ledger.remaining(1)).toBe(0);
+  });
+
+  it('fails open on a corrupt file rather than blocking every run', () => {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, '{ not json', 'utf-8');
+    const ledger = new InvocationLedger(path);
+    expect(ledger.count()).toBe(0);
+    ledger.record();
+    expect(ledger.count()).toBe(1);
+  });
+
+  it('fails open on a ledger written by a future version', () => {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ version: 99, buckets: { '1': 500 } }), 'utf-8');
+    expect(new InvocationLedger(path).count()).toBe(0);
+  });
+
+  it('ignores non-numeric bucket values instead of producing NaN', () => {
+    mkdirSync(dirname(path), { recursive: true });
+    const bucket = String(Math.floor(Date.now() / HOUR));
+    writeFileSync(
+      path,
+      JSON.stringify({ version: 1, buckets: { [bucket]: 2, junk: 'x' } }),
+      'utf-8',
+    );
+    expect(new InvocationLedger(path).count()).toBe(2);
+  });
+
+  it('does not throw when the path is unwritable', () => {
+    // A directory where the file should be — write fails, record swallows it.
+    mkdirSync(path, { recursive: true });
+    expect(() => new InvocationLedger(path).record()).not.toThrow();
+  });
+});
+
+describe('ledgerPathFor', () => {
+  it('places the ledger under .moflo/ in the project root', () => {
+    const p = ledgerPathFor(join('a', 'b'));
+    expect(p).toBe(join('a', 'b', '.moflo', 'spell-invocation-ledger.json'));
+  });
+});
+
+// ============================================================================
+// Daily ceiling on the budget
+// ============================================================================
+
+describe('SpellRunBudget — daily ceiling', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'moflo-daily-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('denies once the rolling window is spent', () => {
+    const budget = createRunBudget({ dailyModelInvocations: 2 }, { ledgerDir: root })!;
+    expect(budget.tryConsumeModelInvocation()).toBe(true);
+    expect(budget.tryConsumeModelInvocation()).toBe(true);
+    expect(budget.tryConsumeModelInvocation()).toBe(false);
+    expect(budget.breach?.kind).toBe('daily-model-invocations');
+    expect(budget.breach?.limit).toBe(2);
+  });
+
+  it('carries the spend across runs — a second run inherits the first run\'s count', () => {
+    const first = createRunBudget({ dailyModelInvocations: 3 }, { ledgerDir: root })!;
+    first.tryConsumeModelInvocation();
+    first.tryConsumeModelInvocation();
+    first.dispose();
+
+    // A separate run, as the next scheduled fire would be.
+    const second = createRunBudget({ dailyModelInvocations: 3 }, { ledgerDir: root })!;
+    expect(second.tryConsumeModelInvocation()).toBe(true);
+    expect(second.tryConsumeModelInvocation()).toBe(false);
+    expect(second.breach?.kind).toBe('daily-model-invocations');
+    expect(second.breach?.observed).toBe(3);
+  });
+
+  it('does NOT abort the signal on a daily breach — the runner owns the stop', () => {
+    const budget = createRunBudget({ dailyModelInvocations: 1 }, { ledgerDir: root })!;
+    budget.tryConsumeModelInvocation();
+    expect(budget.tryConsumeModelInvocation()).toBe(false);
+    expect(budget.signal.aborted).toBe(false);
+  });
+
+  it('is inert without a ledger directory, leaving per-run ceilings intact', () => {
+    const budget = createRunBudget({ dailyModelInvocations: 1, maxModelInvocations: 2 })!;
+    expect(budget.tryConsumeModelInvocation()).toBe(true);
+    expect(budget.tryConsumeModelInvocation()).toBe(true);
+    // Stopped by the per-run ceiling, not the (unenforceable) daily one.
+    expect(budget.tryConsumeModelInvocation()).toBe(false);
+    expect(budget.breach?.kind).toBe('model-invocations');
+  });
+
+  it('reports the daily ceiling first when both are exhausted', () => {
+    const ledger = new InvocationLedger(ledgerPathFor(root));
+    ledger.record();
+    ledger.record();
+
+    const budget = createRunBudget(
+      { dailyModelInvocations: 2, maxModelInvocations: 5 },
+      { ledgerDir: root },
+    )!;
+    expect(budget.tryConsumeModelInvocation()).toBe(false);
+    expect(budget.breach?.kind).toBe('daily-model-invocations');
+  });
+
+  it('records to the ledger only for invocations it actually granted', () => {
+    const budget = createRunBudget(
+      { maxModelInvocations: 1, dailyModelInvocations: 10 },
+      { ledgerDir: root },
+    )!;
+    budget.tryConsumeModelInvocation();          // granted
+    budget.tryConsumeModelInvocation();          // denied by the per-run ceiling
+    expect(new InvocationLedger(ledgerPathFor(root)).count()).toBe(1);
+  });
+
+  it('does not touch the ledger when no daily ceiling is configured', () => {
+    const budget = createRunBudget({ maxModelInvocations: 5 }, { ledgerDir: root })!;
+    budget.tryConsumeModelInvocation();
+    expect(existsSync(ledgerPathFor(root))).toBe(false);
+  });
+});
+
+// ============================================================================
+// Config plumbing
+// ============================================================================
+
+describe('dailyModelInvocations config', () => {
+  it('is enough on its own to constitute a budget', () => {
+    expect(hasBudgetLimit({ dailyModelInvocations: 5 })).toBe(true);
+    expect(createRunBudget({ dailyModelInvocations: 5 })).not.toBeNull();
+  });
+
+  it('parses from camelCase and snake_case', () => {
+    expect(resolveSpellBudgetConfig({ dailyModelInvocations: 7 }))
+      .toEqual({ dailyModelInvocations: 7 });
+    expect(resolveSpellBudgetConfig({ daily_model_invocations: 7 }))
+      .toEqual({ dailyModelInvocations: 7 });
+  });
+
+  it('drops a non-positive value rather than clamping it', () => {
+    expect(resolveSpellBudgetConfig({ dailyModelInvocations: 0 })).toBeUndefined();
+    expect(resolveSpellBudgetConfig({ dailyModelInvocations: -3 })).toBeUndefined();
+  });
+
+  it('merges under most-strict-wins', () => {
+    expect(mergeSpellBudgets(
+      { dailyModelInvocations: 100 },
+      { dailyModelInvocations: 20 },
+    )).toEqual({ dailyModelInvocations: 20 });
+  });
+
+  it('is accepted by the spell budget-block validator', () => {
+    const errors: ValidationError[] = [];
+    validateBudget({ budget: { dailyModelInvocations: 40 } } as unknown as SpellDefinition, errors);
+    expect(errors).toEqual([]);
+  });
+
+  it('still rejects an unknown neighbouring key', () => {
+    const errors: ValidationError[] = [];
+    validateBudget({ budget: { dailyModelInvokations: 40 } } as unknown as SpellDefinition, errors);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('dailyModelInvocations');
+  });
+});

--- a/src/cli/__tests__/spells/spell-budget-enforcement.test.ts
+++ b/src/cli/__tests__/spells/spell-budget-enforcement.test.ts
@@ -23,9 +23,6 @@ import type { RunBudgetAccessor } from '../../spells/core/run-budget.js';
 import { validateSpellDefinition } from '../../spells/schema/validator.js';
 import { bridgeExecuteSpell } from '../../spells/factory/runner-bridge.js';
 import { ledgerPathFor } from '../../spells/core/run-ledger.js';
-import { builtinCommands } from '../../spells/commands/index.js';
-import { analyzeSpellPermissions } from '../../spells/core/permission-disclosure.js';
-import { recordAcceptance } from '../../spells/core/permission-acceptance.js';
 import { mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -36,19 +33,11 @@ import type {
   StepCommand,
 } from '../../spells/types/step-command.types.js';
 import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
-import { createMockContext } from './helpers.js';
+import { createMockContext, MODEL_SHAPED_COMMAND, preAcceptSpell } from './helpers.js';
 
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/**
- * A command that matches `CLAUDE_HEADLESS_RE` but is harmless to run: `echo`
- * consumes the rest as literal arguments. Lets a test assert both halves —
- * that a permitted reservation really does spawn, and that a denied one
- * really does not — without invoking a billed model.
- */
-const MODEL_SHAPED_COMMAND = 'echo claude -p hello';
 
 function budgetSpy(allow: boolean): RunBudgetAccessor & { calls: number } {
   return {
@@ -490,19 +479,6 @@ describe('bridgeExecuteSpell spend ceiling', () => {
     expect(memory.tasklist.at(-1)?.abortReason).toBeUndefined();
   });
 
-  /**
-   * A spell with bash steps is "higher risk", so passing a `projectRoot`
-   * engages the first-run permission gate. Real scheduled spells are accepted
-   * once by their owner; these tests fabricate definitions, so they record the
-   * acceptance themselves rather than assert against a prompt.
-   */
-  async function preAccept(spell: SpellDefinition, projectRoot: string): Promise<void> {
-    const registry = new StepCommandRegistry();
-    for (const cmd of builtinCommands) registry.register(cmd, 'built-in');
-    const report = analyzeSpellPermissions(spell, registry);
-    await recordAcceptance(projectRoot, spell.name, report.permissionHash);
-  }
-
   it('carries the daily ceiling from one real run into the next (#1380)', async () => {
     // The property a per-run ceiling cannot have. Two separate
     // bridgeExecuteSpell calls — as two consecutive scheduled fires would be —
@@ -517,7 +493,7 @@ describe('bridgeExecuteSpell spend ceiling', () => {
           { id: 'call2', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
         ],
       };
-      await preAccept(spell, projectRoot);
+      await preAcceptSpell(spell, projectRoot);
       const opts = { projectRoot, budget: { dailyModelInvocations: 3 } };
 
       const first = await bridgeExecuteSpell(spell, {}, {
@@ -554,7 +530,7 @@ describe('bridgeExecuteSpell spend ceiling', () => {
         name: 'e2e-perrun-only',
         steps: [{ id: 'call1', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } }],
       };
-      await preAccept(spell, projectRoot);
+      await preAcceptSpell(spell, projectRoot);
       const opts = { projectRoot, budget: { maxModelInvocations: 5 } };
 
       for (const n of [1, 2, 3]) {

--- a/src/cli/__tests__/spells/spell-budget-enforcement.test.ts
+++ b/src/cli/__tests__/spells/spell-budget-enforcement.test.ts
@@ -22,6 +22,13 @@ import { SpellRunBudget } from '../../spells/core/run-budget.js';
 import type { RunBudgetAccessor } from '../../spells/core/run-budget.js';
 import { validateSpellDefinition } from '../../spells/schema/validator.js';
 import { bridgeExecuteSpell } from '../../spells/factory/runner-bridge.js';
+import { ledgerPathFor } from '../../spells/core/run-ledger.js';
+import { builtinCommands } from '../../spells/commands/index.js';
+import { analyzeSpellPermissions } from '../../spells/core/permission-disclosure.js';
+import { recordAcceptance } from '../../spells/core/permission-acceptance.js';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type {
   CastingContext,
   CredentialAccessor,
@@ -481,6 +488,85 @@ describe('bridgeExecuteSpell spend ceiling', () => {
     expect(result.success).toBe(true);
     expect(result.steps.every(s => s.status === 'succeeded')).toBe(true);
     expect(memory.tasklist.at(-1)?.abortReason).toBeUndefined();
+  });
+
+  /**
+   * A spell with bash steps is "higher risk", so passing a `projectRoot`
+   * engages the first-run permission gate. Real scheduled spells are accepted
+   * once by their owner; these tests fabricate definitions, so they record the
+   * acceptance themselves rather than assert against a prompt.
+   */
+  async function preAccept(spell: SpellDefinition, projectRoot: string): Promise<void> {
+    const registry = new StepCommandRegistry();
+    for (const cmd of builtinCommands) registry.register(cmd, 'built-in');
+    const report = analyzeSpellPermissions(spell, registry);
+    await recordAcceptance(projectRoot, spell.name, report.permissionHash);
+  }
+
+  it('carries the daily ceiling from one real run into the next (#1380)', async () => {
+    // The property a per-run ceiling cannot have. Two separate
+    // bridgeExecuteSpell calls — as two consecutive scheduled fires would be —
+    // sharing only a project root. If the ledger did not reach the runner, the
+    // second run would succeed exactly like the first.
+    const projectRoot = mkdtempSync(join(tmpdir(), 'moflo-daily-e2e-'));
+    try {
+      const spell: SpellDefinition = {
+        name: 'e2e-daily-spell',
+        steps: [
+          { id: 'call1', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
+          { id: 'call2', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } },
+        ],
+      };
+      await preAccept(spell, projectRoot);
+      const opts = { projectRoot, budget: { dailyModelInvocations: 3 } };
+
+      const first = await bridgeExecuteSpell(spell, {}, {
+        ...opts, spellId: 'scheduled-e2e-daily-1', memory: recordingMemory(),
+      });
+      expect(first.success).toBe(true);
+
+      // Two invocations spent; the ceiling is 3. The second run gets one more
+      // and is refused on its second step.
+      const memory = recordingMemory();
+      const second = await bridgeExecuteSpell(spell, {}, {
+        ...opts, spellId: 'scheduled-e2e-daily-2', memory,
+      });
+
+      expect(second.success).toBe(false);
+      expect(second.errors.map(e => e.code)).toContain('BUDGET_EXCEEDED');
+      expect(second.steps[0].status).toBe('succeeded');
+      expect(second.steps[1].status).toBe('failed');
+      expect(memory.tasklist.at(-1)).toMatchObject({
+        abortReason: 'budget-exceeded',
+        budgetBreach: { kind: 'daily-model-invocations', limit: 3, observed: 3 },
+      });
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves consecutive runs uncapped when only per-run ceilings are set', async () => {
+    // Guards the inverse: the ledger must not engage for a project that
+    // configured no daily ceiling, however many runs it performs.
+    const projectRoot = mkdtempSync(join(tmpdir(), 'moflo-daily-off-'));
+    try {
+      const spell: SpellDefinition = {
+        name: 'e2e-perrun-only',
+        steps: [{ id: 'call1', type: 'bash', config: { command: MODEL_SHAPED_COMMAND } }],
+      };
+      await preAccept(spell, projectRoot);
+      const opts = { projectRoot, budget: { maxModelInvocations: 5 } };
+
+      for (const n of [1, 2, 3]) {
+        const r = await bridgeExecuteSpell(spell, {}, {
+          ...opts, spellId: `scheduled-perrun-${n}`, memory: recordingMemory(),
+        });
+        expect(r.success).toBe(true);
+      }
+      expect(existsSync(ledgerPathFor(projectRoot))).toBe(false);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli/init/moflo-yaml-template.ts
+++ b/src/cli/init/moflo-yaml-template.ts
@@ -295,6 +295,35 @@ sandbox:
   enabled: false                 # Set to true to wrap bash steps in an OS sandbox
   tier: auto                     # auto | denylist-only | full
 
+# Spend ceilings for spells that spawn \`claude -p\` from a bash step.
+#
+# These are RUNAWAY BACKSTOPS, not cost controls. Their job is to stop a loop
+# that spawns the model forever — not to tune your bill. Any per-run number is
+# somewhat arbitrary; what matters is that it is finite.
+#
+# An invocation is not a unit of spend: \`claude -p "say hi"\` and
+# \`claude -p "refactor this subsystem"\` both count as one. Treat the count as a
+# proxy, and \`dailyModelInvocations\` as the number that tracks your bill.
+#
+# Delete a key to make that ceiling unlimited.
+spells:
+  budget:
+    # Daemon-fired runs. Nobody is watching, so these are the tight ones.
+    scheduled:
+      maxModelInvocations: 30      # per run
+      maxWallClockMs: 2400000      # 40 min — longer than this unattended is stuck, not working
+      # Rolling 24h across ALL scheduled runs. A per-run ceiling bounds one bad
+      # run; this bounds a misconfigured schedule (a 5-min cron x 30 = 8,640/day,
+      # every one of which passes the per-run check).
+      dailyModelInvocations: 300
+
+    # \`flo spell cast\` / MCP cast. A human is present and can ctrl-C, so this is
+    # deliberately loose — raise it freely if it ever fires on you. Note it is
+    # per SPELL CAST, not per Claude Code session: long sessions never touch it.
+    interactive:
+      maxModelInvocations: 200
+      maxWallClockMs: 14400000     # 4 hours
+
 # Status line display (shown at bottom of Claude Code)
 # mode: "compact" (default), "single-line", or "dashboard" (full multi-line)
 status_line:

--- a/src/cli/spells/core/run-budget.ts
+++ b/src/cli/spells/core/run-budget.ts
@@ -30,6 +30,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { InvocationLedger, ledgerPathFor } from './run-ledger.js';
 
 type YamlModule = { load: (s: string) => unknown; default?: { load: (s: string) => unknown } };
 
@@ -46,10 +47,20 @@ export interface SpellBudgetConfig {
   readonly maxModelInvocations?: number;
   /** Max wall-clock duration of the run, in ms. Unset ⇒ unlimited. */
   readonly maxWallClockMs?: number;
+  /**
+   * Max detected `claude -p` spawns across ALL runs sharing this project root
+   * in a trailing 24h. Unset ⇒ unlimited.
+   *
+   * This is the ceiling that tracks a bill. The per-run ceilings above bound
+   * one bad run; only this one bounds a misconfigured schedule, which can
+   * satisfy a per-run ceiling thousands of times a day. Requires a project
+   * root to be enforceable — see {@link RunBudgetOptions.ledgerDir}.
+   */
+  readonly dailyModelInvocations?: number;
 }
 
 /** Which ceiling was hit. */
-export type BudgetLimitKind = 'model-invocations' | 'wall-clock';
+export type BudgetLimitKind = 'model-invocations' | 'wall-clock' | 'daily-model-invocations';
 
 /**
  * A latched ceiling breach. Carries the numbers rather than only a message so
@@ -116,11 +127,19 @@ export function resolveSpellBudgetConfig(raw?: unknown): SpellBudgetConfig | und
     rec.maxModelInvocations ?? rec.max_model_invocations,
   );
   const maxWallClockMs = positiveLimit(rec.maxWallClockMs ?? rec.max_wall_clock_ms);
+  const dailyModelInvocations = positiveLimit(
+    rec.dailyModelInvocations ?? rec.daily_model_invocations,
+  );
 
-  if (maxModelInvocations === undefined && maxWallClockMs === undefined) return undefined;
+  if (
+    maxModelInvocations === undefined
+    && maxWallClockMs === undefined
+    && dailyModelInvocations === undefined
+  ) return undefined;
   return {
     ...(maxModelInvocations !== undefined ? { maxModelInvocations } : {}),
     ...(maxWallClockMs !== undefined ? { maxWallClockMs } : {}),
+    ...(dailyModelInvocations !== undefined ? { dailyModelInvocations } : {}),
   };
 }
 
@@ -144,17 +163,25 @@ export function mergeSpellBudgets(
 
   const maxModelInvocations = pick(a.maxModelInvocations, b.maxModelInvocations);
   const maxWallClockMs = pick(a.maxWallClockMs, b.maxWallClockMs);
-  if (maxModelInvocations === undefined && maxWallClockMs === undefined) return undefined;
+  const dailyModelInvocations = pick(a.dailyModelInvocations, b.dailyModelInvocations);
+  if (
+    maxModelInvocations === undefined
+    && maxWallClockMs === undefined
+    && dailyModelInvocations === undefined
+  ) return undefined;
   return {
     ...(maxModelInvocations !== undefined ? { maxModelInvocations } : {}),
     ...(maxWallClockMs !== undefined ? { maxWallClockMs } : {}),
+    ...(dailyModelInvocations !== undefined ? { dailyModelInvocations } : {}),
   };
 }
 
 /** True when the config carries at least one enforceable ceiling. */
 export function hasBudgetLimit(config?: SpellBudgetConfig): boolean {
   if (!config) return false;
-  return config.maxModelInvocations !== undefined || config.maxWallClockMs !== undefined;
+  return config.maxModelInvocations !== undefined
+    || config.maxWallClockMs !== undefined
+    || config.dailyModelInvocations !== undefined;
 }
 
 /**
@@ -208,6 +235,17 @@ export interface RunBudgetOptions {
   readonly parentSignal?: AbortSignal;
   /** Clock injection point for tests. Defaults to `Date.now`. */
   readonly now?: () => number;
+  /**
+   * Project root whose `.moflo/` holds the rolling-window ledger. Required for
+   * `dailyModelInvocations` to do anything — without it there is nowhere to
+   * persist a count that outlives the run, so the daily ceiling is silently
+   * inert. Every path that configures a daily ceiling also has a project root
+   * (the daemon and `runSpellFromContent` both do), so this is a wiring
+   * invariant rather than a user-facing constraint.
+   */
+  readonly ledgerDir?: string;
+  /** Pre-built ledger, for tests. Overrides `ledgerDir` when both are given. */
+  readonly ledger?: InvocationLedger;
 }
 
 /**
@@ -228,11 +266,17 @@ export class SpellRunBudget implements RunBudgetAccessor {
   private parentSignal: AbortSignal | undefined;
   private invocations = 0;
   private latched: BudgetBreach | null = null;
+  private readonly ledger: InvocationLedger | null;
 
   constructor(
     private readonly config: SpellBudgetConfig,
     options: RunBudgetOptions = {},
   ) {
+    this.ledger = config.dailyModelInvocations !== undefined
+      ? options.ledger ?? (options.ledgerDir
+        ? new InvocationLedger(ledgerPathFor(options.ledgerDir), { ...(options.now ? { now: options.now } : {}) })
+        : null)
+      : null;
     this.now = options.now ?? Date.now;
     this.startedAt = this.now();
     this.deadlineAt = config.maxWallClockMs !== undefined
@@ -275,9 +319,16 @@ export class SpellRunBudget implements RunBudgetAccessor {
   tryConsumeModelInvocation(): boolean {
     if (this.latched) return false;
 
+    // Daily ceiling first. It is the broader constraint — being inside the
+    // per-run allowance is irrelevant when the project has already spent its
+    // day — and checking it first means the breach a user sees names the
+    // ceiling that actually stopped them.
+    if (!this.tryConsumeDaily()) return false;
+
     const max = this.config.maxModelInvocations;
     if (max === undefined) {
       this.invocations++;
+      this.ledger?.record();
       return true;
     }
 
@@ -301,7 +352,37 @@ export class SpellRunBudget implements RunBudgetAccessor {
     }
 
     this.invocations = attempt;
+    this.ledger?.record();
     return true;
+  }
+
+  /**
+   * Check the rolling-window ceiling, latching a breach when it is spent.
+   * Returns true when there is no daily ceiling configured or room remains.
+   *
+   * Like the per-run invocation ceiling and unlike the wall clock, this does
+   * NOT abort the signal — the caller is about to return a step failure, and
+   * aborting here would race the rollback the runner is about to run.
+   */
+  private tryConsumeDaily(): boolean {
+    const limit = this.config.dailyModelInvocations;
+    if (limit === undefined || !this.ledger) return true;
+
+    const used = this.ledger.count();
+    if (used < limit) return true;
+
+    this.latched = {
+      kind: 'daily-model-invocations',
+      limit,
+      observed: used,
+      message:
+        `Project exceeded its rolling 24h model-invocation ceiling: ${limit} ` +
+        `allowed, ${used} already spent across scheduled runs. This run was ` +
+        `stopped before spawning. Raise ` +
+        `\`spells.budget.scheduled.dailyModelInvocations\` in moflo.yaml, or ` +
+        `check whether a schedule is firing more often than intended.`,
+    };
+    return false;
   }
 
   /**

--- a/src/cli/spells/core/run-budget.ts
+++ b/src/cli/spells/core/run-budget.ts
@@ -244,8 +244,24 @@ export interface RunBudgetOptions {
    * invariant rather than a user-facing constraint.
    */
   readonly ledgerDir?: string;
-  /** Pre-built ledger, for tests. Overrides `ledgerDir` when both are given. */
-  readonly ledger?: InvocationLedger;
+}
+
+/**
+ * Build the ledger backing a daily ceiling, or null when there is nothing to
+ * enforce (no daily limit configured) or nowhere to persist it (no project
+ * root). Extracted from the constructor because inlining it there produced a
+ * three-level ternary that read as if the two null cases were related.
+ */
+function ledgerFor(
+  config: SpellBudgetConfig,
+  options: RunBudgetOptions,
+): InvocationLedger | null {
+  if (config.dailyModelInvocations === undefined) return null;
+  if (!options.ledgerDir) return null;
+  return new InvocationLedger(
+    ledgerPathFor(options.ledgerDir),
+    { ...(options.now ? { now: options.now } : {}) },
+  );
 }
 
 /**
@@ -272,11 +288,7 @@ export class SpellRunBudget implements RunBudgetAccessor {
     private readonly config: SpellBudgetConfig,
     options: RunBudgetOptions = {},
   ) {
-    this.ledger = config.dailyModelInvocations !== undefined
-      ? options.ledger ?? (options.ledgerDir
-        ? new InvocationLedger(ledgerPathFor(options.ledgerDir), { ...(options.now ? { now: options.now } : {}) })
-        : null)
-      : null;
+    this.ledger = ledgerFor(config, options);
     this.now = options.now ?? Date.now;
     this.startedAt = this.now();
     this.deadlineAt = config.maxWallClockMs !== undefined

--- a/src/cli/spells/core/run-ledger.ts
+++ b/src/cli/spells/core/run-ledger.ts
@@ -1,0 +1,160 @@
+/**
+ * Rolling-window invocation ledger — the cross-run half of the spend ceiling.
+ *
+ * #1335 bounded a single spell run. That bounds the blast radius of one bad
+ * run and nothing else: the daemon's defining property is that it fires
+ * repeatedly with nobody watching, so a 5-minute schedule with a 30-invocation
+ * per-run ceiling still permits 8,640 invocations a day, every one of which
+ * passes the per-run check. The per-run ceiling catches a runaway loop; this
+ * catches a runaway *schedule*.
+ *
+ * Storage is a small JSON file under `.moflo/`, bucketed by clock hour rather
+ * than one entry per invocation. Two reasons:
+ *
+ *   - The file stays bounded at <= 24 entries no matter the volume, so a
+ *     misconfigured cron cannot grow it without limit — which would be an
+ *     amusing way for a spend guard to become the incident.
+ *   - Read-modify-write per invocation stays cheap.
+ *
+ * The cost is granularity: the window covers between 23 and 24 hours of real
+ * time depending on where "now" sits inside the current hour. That is well
+ * within tolerance for a backstop whose job is catching an order-of-magnitude
+ * overrun, and it is documented rather than papered over.
+ *
+ * Concurrency: one daemon owns a project root (enforced by daemon-lock), so
+ * the read-modify-write here is effectively single-writer. State is re-read
+ * immediately before each write to keep the lost-update window as small as
+ * possible without taking a file lock — a dropped increment under-counts a
+ * safety ceiling slightly, which is the correct direction to fail.
+ *
+ * Cross-platform (Rule #1): `path.join` throughout, no shell, and writes go
+ * through the shared `atomicWriteFileSync` helper (fsync + rename, with the
+ * Windows AV-settle verify).
+ */
+
+import { readFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { atomicWriteFileSync } from '../../shared/utils/atomic-file-write.js';
+
+/** Trailing window the ledger counts over. */
+export const LEDGER_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const BUCKET_MS = 60 * 60 * 1000;
+const LEDGER_VERSION = 1;
+
+/** Persisted shape. Bucket keys are epoch-hour indices, stringified. */
+interface LedgerFile {
+  version: number;
+  buckets: Record<string, number>;
+}
+
+/**
+ * Path of the ledger for a project. Exported so tests and diagnostics can
+ * find it without rebuilding the path by hand (Rule #1: never hand-assemble
+ * a path with a literal separator).
+ */
+export function ledgerPathFor(projectRoot: string): string {
+  return join(projectRoot, '.moflo', 'spell-invocation-ledger.json');
+}
+
+export interface LedgerOptions {
+  /** Clock injection point for tests. Defaults to `Date.now`. */
+  readonly now?: () => number;
+  /** Trailing window length. Defaults to {@link LEDGER_WINDOW_MS}. */
+  readonly windowMs?: number;
+}
+
+/**
+ * A rolling count of model invocations across every run that shares a project
+ * root. Constructed per run; state lives on disk, so it survives daemon
+ * restarts and spans runs that never see each other.
+ */
+export class InvocationLedger {
+  private readonly now: () => number;
+  private readonly windowMs: number;
+
+  constructor(
+    private readonly filePath: string,
+    options: LedgerOptions = {},
+  ) {
+    this.now = options.now ?? Date.now;
+    this.windowMs = options.windowMs ?? LEDGER_WINDOW_MS;
+  }
+
+  /** Invocations recorded in the trailing window. */
+  count(): number {
+    const buckets = this.live(this.read().buckets);
+    let total = 0;
+    for (const n of Object.values(buckets)) total += n;
+    return total;
+  }
+
+  /**
+   * Record one invocation. Best-effort: a ledger that cannot be written must
+   * not fail a run that would otherwise work, for the same reason
+   * `loadSpellBudgetFromProject` swallows its errors — this is a safety
+   * ceiling, not a correctness requirement.
+   */
+  record(): void {
+    try {
+      const state = this.read();
+      const buckets = this.live(state.buckets);
+      const key = String(Math.floor(this.now() / BUCKET_MS));
+      buckets[key] = (buckets[key] ?? 0) + 1;
+      this.write({ version: LEDGER_VERSION, buckets });
+    } catch {
+      /* see doc — under-counting a backstop beats failing a working run */
+    }
+  }
+
+  /** How many invocations remain before `limit` is reached in this window. */
+  remaining(limit: number): number {
+    return Math.max(0, limit - this.count());
+  }
+
+  // --------------------------------------------------------------------
+  // Persistence
+  // --------------------------------------------------------------------
+
+  private read(): LedgerFile {
+    try {
+      const parsed = JSON.parse(readFileSync(this.filePath, 'utf-8')) as unknown;
+      if (!parsed || typeof parsed !== 'object') return emptyLedger();
+      const rec = parsed as Partial<LedgerFile>;
+      if (rec.version !== LEDGER_VERSION || !rec.buckets || typeof rec.buckets !== 'object') {
+        // A future or corrupt version reads as empty rather than throwing.
+        // Failing open is right for a ceiling: an unreadable ledger must not
+        // block every scheduled run in the project.
+        return emptyLedger();
+      }
+      return { version: LEDGER_VERSION, buckets: { ...rec.buckets } };
+    } catch {
+      return emptyLedger();
+    }
+  }
+
+  private write(state: LedgerFile): void {
+    mkdirSync(dirname(this.filePath), { recursive: true });
+    atomicWriteFileSync(this.filePath, JSON.stringify(state));
+  }
+
+  /**
+   * Drop buckets that have fallen out of the trailing window. Pruning on every
+   * read is what keeps the file bounded — there is no separate cleanup pass to
+   * forget to schedule.
+   */
+  private live(buckets: Record<string, number>): Record<string, number> {
+    const oldest = Math.floor((this.now() - this.windowMs) / BUCKET_MS);
+    const kept: Record<string, number> = {};
+    for (const [key, n] of Object.entries(buckets)) {
+      const bucket = Number(key);
+      if (!Number.isFinite(bucket) || typeof n !== 'number' || !Number.isFinite(n)) continue;
+      if (bucket >= oldest) kept[key] = n;
+    }
+    return kept;
+  }
+}
+
+function emptyLedger(): LedgerFile {
+  return { version: LEDGER_VERSION, buckets: {} };
+}

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -281,7 +281,12 @@ export class SpellCaster {
     // one to return.
     const budget = createRunBudget(
       mergeSpellBudgets(options.budget, definition.budget),
-      { parentSignal: options.signal },
+      {
+        ...(options.signal ? { parentSignal: options.signal } : {}),
+        // Where the rolling-window ledger lives. Absent projectRoot leaves the
+        // daily ceiling inert — the per-run ceilings still apply.
+        ...(options.projectRoot ? { ledgerDir: options.projectRoot } : {}),
+      },
     );
     const runOptions: RunnerOptions = budget
       ? { ...options, signal: budget.signal }

--- a/src/cli/spells/factory/pause-resume.ts
+++ b/src/cli/spells/factory/pause-resume.ts
@@ -11,6 +11,8 @@ import type { SpellResult, StepResult } from '../types/runner.types.js';
 import { createRunner, noopMemory } from './runner-factory.js';
 import { validateSpellDefinition } from '../schema/validator.js';
 import { sanitizeObjectKeys } from '../core/interpolation.js';
+import { loadSandboxConfigFromProject } from '../core/platform-sandbox.js';
+import { loadSpellBudgetFromProject } from '../core/run-budget.js';
 
 // ============================================================================
 // Types
@@ -40,6 +42,15 @@ export interface ResumeOptions {
   readonly variables?: Record<string, unknown>;
   /** Memory accessor for reading paused state and storing progress. */
   readonly memory?: MemoryAccessor;
+  /**
+   * Project root, used to re-apply the project's sandbox config (#878) and
+   * spend ceiling (#1335) to the resumed half of the run.
+   *
+   * Without it a resumed spell runs with neither, which made
+   * suspend-then-resume an escape hatch from both — the remaining steps ran
+   * unsandboxed and uncapped no matter what `moflo.yaml` said.
+   */
+  readonly projectRoot?: string;
 }
 
 const PAUSE_NAMESPACE = 'spell-paused';
@@ -160,14 +171,36 @@ export async function resumeSpell(
   const variables = { ...state.variables, ...options.variables };
 
   // Create runner and execute remaining steps
-  const runner = createRunner({ memory });
+  const { projectRoot } = options;
+  const runner = createRunner({ memory, ...(projectRoot ? { projectRoot } : {}) });
   const remainingDefinition: SpellDefinition = {
     ...definition,
     steps: definition.steps.slice(state.nextStepIndex),
   };
 
+  // Re-apply the project's sandbox + ceiling to the resumed half. This path
+  // calls `runner.run` directly rather than going through
+  // `runSpellFromContent`, so it does not inherit that function's auto-load —
+  // it has to do the same work itself or the remaining steps run unprotected.
+  //
+  // The ceiling comes from the `interactive` slot and starts fresh: a resumed
+  // run is a new run with its own wall clock, and time spent paused (up to 24h
+  // by default) must not count against it.
+  const sandboxConfig = projectRoot
+    ? await loadSandboxConfigFromProject(projectRoot)
+    : undefined;
+  const budget = projectRoot
+    ? await loadSpellBudgetFromProject(projectRoot, 'interactive')
+    : undefined;
+
   const startTime = Date.now();
-  const result = await runner.run(remainingDefinition, state.args, { spellId, initialVariables: variables });
+  const result = await runner.run(remainingDefinition, state.args, {
+    spellId,
+    initialVariables: variables,
+    ...(sandboxConfig ? { sandboxConfig } : {}),
+    ...(budget ? { budget } : {}),
+    ...(projectRoot ? { projectRoot } : {}),
+  });
 
   // Clean up paused state on completion
   await memory.write(PAUSE_NAMESPACE, spellId, null);

--- a/src/cli/spells/schema/validators/top-level.ts
+++ b/src/cli/spells/schema/validators/top-level.ts
@@ -111,7 +111,7 @@ export function validateBudget(def: SpellDefinition, errors: ValidationError[]):
     return;
   }
 
-  const known = ['maxModelInvocations', 'maxWallClockMs'] as const;
+  const known = ['maxModelInvocations', 'maxWallClockMs', 'dailyModelInvocations'] as const;
   const rec = budget as Record<string, unknown>;
 
   for (const key of Object.keys(rec)) {

--- a/tests/bin/yaml-upgrader.test.ts
+++ b/tests/bin/yaml-upgrader.test.ts
@@ -46,6 +46,17 @@ describe('yaml-upgrader', () => {
       expect(keys).toContain('sandbox');
     });
 
+    it('does NOT register spells — spend ceilings must not switch on during an upgrade (#1380)', () => {
+      // `flo init` writes `spells.budget` into NEW projects. Registering it
+      // here would append it to every existing consumer's moflo.yaml on their
+      // next session start, activating ceilings for projects that never asked.
+      // A scheduled spell legitimately making 40 model calls at 3am would start
+      // failing because its owner ran `npm install`. Opting in stays the
+      // owner's decision; see moflo-yaml-reference.md.
+      const keys = REQUIRED_SECTIONS.map((s: any) => s.key);
+      expect(keys).not.toContain('spells');
+    });
+
     it('each section has a key and a block that starts with a comment', () => {
       for (const section of REQUIRED_SECTIONS) {
         expect(typeof section.key).toBe('string');


### PR DESCRIPTION
Closes #1380.

## Why

#1335 shipped per-run spend ceilings for spells that spawn `claude -p`. They bound the blast radius of **one** run and nothing else.

The daemon's defining property is repetition. A five-minute schedule under a 30-invocation per-run ceiling satisfies the per-run check 288 times a day and still reaches 8,640 invocations — every one of them passing every check moflo performed. Per-run ceilings catch a runaway loop; nothing caught a runaway *schedule*.

Two gaps surfaced while scoping it: the ceilings were opt-in and invisible (nothing wrote the block, so no project had one unless its owner already knew the feature existed), and `resumeSpell` bypassed them entirely.

## What

**`spells.budget.*.dailyModelInvocations`** — a rolling 24h count across all runs sharing a project root, persisted in `.moflo/spell-invocation-ledger.json`.

- Hour-bucketed rather than one entry per invocation, so the file stays <= 24 entries however high the volume. A spend guard that grows without bound would be a poor sort of spend guard. The cost is granularity: the window covers 23-24h depending on where "now" sits. Documented, not papered over.
- Pruned on every read — no cleanup pass to forget to schedule.
- Checked **before** the per-run ceiling, so a breach names the limit that actually stopped the run.
- Fails open on a corrupt or future-version ledger, and swallows write errors. Under-counting a backstop beats failing a working run.
- Inert without a `projectRoot` — nowhere to persist a cross-run count. Per-run ceilings still apply.

**`resumeSpell` re-applies project config.** It built its runner with `createRunner({ memory })` and called `runner.run` directly, skipping the auto-load in `runSpellFromContent`. Resumed steps ran with no sandbox (#878) *and* no ceiling regardless of `moflo.yaml`. The wall clock starts fresh — time spent suspended (up to 24h) must not count against it.

**`flo init` writes the block** with live values and comments explaining they are runaway backstops, not cost controls.

## Consumer impact (Rule #2)

| | |
|---|---|
| **Surface** | `src/cli/spells/core/**`, `src/cli/init/moflo-yaml-template.ts`, shipped guidance |
| **Existing installs** | **Unchanged.** Deliberately not added to `yaml-upgrader`'s `REQUIRED_SECTIONS` — that appends to existing configs, which would activate ceilings during an `npm install` for projects that never asked. A spell legitimately making 40 model calls at 3am should not start failing because its owner upgraded. Guarded by a test. |
| **New projects** | Get the block from `flo init`, visible and editable |
| **Round-trip** | Publish + reinstall before the ceiling is live in dogfood — the spell engine and daemon run from `node_modules/moflo/` |

### Values

Any per-run number is arbitrary; its job is catching pathology, not tuning cost. `dailyModelInvocations` is the one that maps to a bill.

| Slot | `maxModelInvocations` | `maxWallClockMs` | `dailyModelInvocations` |
|---|---|---|---|
| `scheduled` | 30 | 40 min | 300 |
| `interactive` | 200 | 4 h | — |

`interactive` is deliberately loose — a human is present who can interrupt — and applies per **spell cast**, not per Claude Code session.

### Behaviour change worth flagging

Threading `projectRoot` into `resumeSpell` also subjects resumed spells to the permission acceptance gate, which keys on `options.projectRoot`. Judged correct: it re-checks the permission hash of a definition read back off disk, matching the tamper-defense re-validation `resumeSpell` already performed on that data. A legitimately-resumed spell inherits the acceptance recorded at cast time, so it is a no-op in practice.

## Why not measure tokens

That is the honest metric and it is not cheap. `headless-worker-executor.ts:173` declares `tokensUsed` but nothing populates it. Real numbers mean forcing `--output-format json` and parsing the result envelope, which changes stdout shape for every spell bash step that greps text output. Invocation count plus wall clock are adequate proxies; revisit if the rolling window proves too coarse.

## Verification

- Full suite **10,268 passed / 0 failed**; `tsc --noEmit` and `eslint --max-warnings 0` clean
- `/verify` **PASS on all 7 acceptance criteria**, after finding and closing three coverage gaps rather than waiving them — the cross-run seam (the same gap that bit #1335: every link unit-tested, the seam unproven), the sandbox half of the resume fix, and the upgrade-safety contract
- Cross-platform: `path.join` throughout, writes via the shared `atomicWriteFileSync` (fsync + rename + Windows AV-settle verify), no shell. The sandbox test observes the config load rather than its OS effect, because whether `tier: full` engages or refuses depends on bwrap/sandbox-exec being present — which differs across the three platforms moflo ships to.

Generated with [moflo](https://github.com/eric-cielo/moflo)