### PR TITLE
feat(spells): opt-in per-step retry for transient failures (#1336)

### DIFF
--- a/.claude/guidance/shipped/moflo-spell-runner.md
+++ b/.claude/guidance/shipped/moflo-spell-runner.md
@@ -93,6 +93,40 @@ const result = loadSpellByName('deploy-staging', { /* same options */ });
 
 **Set `continueOnError: true` on a step to keep running after failure.** The failed step is recorded in results but execution continues. Without this flag, a step failure triggers rollback of completed steps and terminates the spell.
 
+### retry
+
+**Add a `retry` block to a step that can fail transiently — a flaky HTTP call, a rate limit, a momentary network drop.** Without it, one transient failure discards every completed step in the run. This matters most on the scheduled path, where a run dying at step 7 of 9 at 3am produces a failed record and no work.
+
+```yaml
+- id: fetch-report
+  type: http
+  retry:
+    attempts: 3          # total attempts INCLUDING the first
+    backoffMs: 1000      # base delay before attempt 2; doubles thereafter
+    maxDelayMs: 30000    # optional: ceiling on any single delay
+    maxTotalDelayMs: 60000  # optional: ceiling on the sum of all delays
+```
+
+**Retry is opt-in per step and never applied by default.** Blanket retry is wrong for non-idempotent work — silently re-running a step that posts to Slack or writes a file is worse than failing. A step with no `retry` block runs exactly once, exactly as before.
+
+**Only non-deterministic failures are retried.**
+
+| Failure | Retried? | Why |
+|---------|----------|-----|
+| Step returned failure / threw | Yes | The classic transient case |
+| Step timed out | Yes | May succeed when the upstream recovers |
+| Capability violation, unknown step type, invalid config | No | Deterministic — N attempts produce one outcome at N times the cost |
+| Auth-shaped error (401, expired token) | No | Owned by the credential-refresh path below, which can actually fix it |
+| Cancelled | No | The run is already tearing down |
+
+**Backoff is bounded twice and interruptible.** Each delay is capped by `maxDelayMs`, their sum by `maxTotalDelayMs` (60s default) — so `attempts: 50` cannot stall a scheduled run. Once the aggregate budget is spent, remaining attempts run back-to-back rather than being cancelled. The wait also aborts on the run's signal, so a wall-clock ceiling breach (`spells.budget.*.maxWallClockMs`) cuts a backoff short instead of being served after it. Delays carry ±10% jitter so a `parallel` block of steps hitting the same rate limit does not retry in lockstep.
+
+**Each attempt is billed independently.** A retried step that spawns `claude -p` consumes one `maxModelInvocations` reservation per attempt — retry and the spend ceiling compose, and the ceiling wins.
+
+**`attempts` appears in the step result** only when the step declared a `retry` block, so a step that succeeded on attempt 3 is distinguishable from one that succeeded immediately, and records for existing spells are unchanged.
+
+An unrecognised key inside `retry` is a validation error, not a silent "no retry" — the same failure direction the budget block uses.
+
 ---
 
 ## Pause and Resume

--- a/src/cli/__tests__/spells/step-retry.test.ts
+++ b/src/cli/__tests__/spells/step-retry.test.ts
@@ -391,3 +391,56 @@ describe('retry vs credential refresh', () => {
     expect(result.success).toBe(true);
   });
 });
+
+// ============================================================================
+// Interaction with the spend ceiling (#1335)
+// ============================================================================
+
+describe('retry vs the spend ceiling', () => {
+  /** A step that reserves against the budget the way bashCommand does. */
+  function modelStep(): StepCommand & { calls: number } {
+    const cmd = {
+      calls: 0,
+      type: 'flaky',
+      description: 'reserves a model invocation, then fails transiently',
+      configSchema: { type: 'object' },
+      validate: () => ({ valid: true, errors: [] }),
+      async execute(_c: unknown, context: { budget?: { tryConsumeModelInvocation(): boolean; breach: { message: string } | null } }) {
+        cmd.calls++;
+        if (context.budget && !context.budget.tryConsumeModelInvocation()) {
+          return { success: false, data: {}, error: context.budget.breach?.message ?? 'denied' };
+        }
+        return { success: false, data: {}, error: 'transient upstream failure' };
+      },
+      describeOutputs: () => [],
+    };
+    return cmd as unknown as StepCommand & { calls: number };
+  }
+
+  it('bills every attempt separately rather than once per step', async () => {
+    // Retry must not be a way to get extra model calls for free.
+    const cmd = modelStep();
+    const result = await casterWith(cmd).run(
+      spellWith({ attempts: 4, backoffMs: 1 }), {},
+      { budget: { maxModelInvocations: 10 } },
+    );
+
+    expect(cmd.calls).toBe(4);
+    expect(result.success).toBe(false);
+  });
+
+  it('stops retrying once the ceiling latches a breach', async () => {
+    // A latched breach denies every later reservation, so further attempts
+    // cannot succeed — retrying would only spend backoff on a doomed run.
+    // With attempts: 10 and no check, this burns all ten.
+    const cmd = modelStep();
+    const result = await casterWith(cmd).run(
+      spellWith({ attempts: 10, backoffMs: 1 }), {},
+      { budget: { maxModelInvocations: 2 } },
+    );
+
+    // 2 granted, then the attempt that trips the ceiling. No further retries.
+    expect(cmd.calls).toBe(3);
+    expect(result.errors.map(e => e.code)).toContain('BUDGET_EXCEEDED');
+  });
+});

--- a/src/cli/__tests__/spells/step-retry.test.ts
+++ b/src/cli/__tests__/spells/step-retry.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Per-step retry tests (#1336).
+ *
+ * Two halves: the primitive in isolation, then the seam — a real SpellCaster
+ * run where a step actually fails and actually recovers. The absence cases
+ * carry as much weight as the presence ones: a step without `retry` must
+ * behave exactly as it does today, including running exactly once.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveStepRetry,
+  isRetryableFailure,
+  computeBackoffMs,
+  abortableDelay,
+  DEFAULT_BACKOFF_MS,
+  DEFAULT_MAX_DELAY_MS,
+  DEFAULT_MAX_TOTAL_DELAY_MS,
+} from '../../spells/core/step-retry.js';
+import { SpellCaster } from '../../spells/core/runner.js';
+import { StepCommandRegistry } from '../../spells/core/step-command-registry.js';
+import { validateSpellDefinition } from '../../spells/schema/validator.js';
+import type { StepCommand, CredentialAccessor, MemoryAccessor } from '../../spells/types/step-command.types.js';
+import type { SpellDefinition } from '../../spells/types/spell-definition.types.js';
+
+// ============================================================================
+// Config resolution
+// ============================================================================
+
+describe('resolveStepRetry', () => {
+  it('returns undefined for an absent block', () => {
+    expect(resolveStepRetry(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for attempts: 1 — a retry that would never retry', () => {
+    // Callers rely on this to take the pre-feature code path rather than
+    // loop once, so "no retry block" and "a useless retry block" are identical.
+    expect(resolveStepRetry({ attempts: 1 })).toBeUndefined();
+  });
+
+  it('returns undefined when attempts is missing, zero, or negative', () => {
+    expect(resolveStepRetry({ backoffMs: 500 })).toBeUndefined();
+    expect(resolveStepRetry({ attempts: 0 })).toBeUndefined();
+    expect(resolveStepRetry({ attempts: -2 })).toBeUndefined();
+  });
+
+  it('applies defaults for the delay knobs', () => {
+    expect(resolveStepRetry({ attempts: 3 })).toEqual({
+      attempts: 3,
+      backoffMs: DEFAULT_BACKOFF_MS,
+      maxDelayMs: DEFAULT_MAX_DELAY_MS,
+      maxTotalDelayMs: DEFAULT_MAX_TOTAL_DELAY_MS,
+    });
+  });
+
+  it('accepts camelCase and snake_case', () => {
+    expect(resolveStepRetry({ attempts: 2, backoff_ms: 250 })?.backoffMs).toBe(250);
+    expect(resolveStepRetry({ attempts: 2, backoffMs: 250 })?.backoffMs).toBe(250);
+  });
+
+  it('floors a fractional attempt count', () => {
+    expect(resolveStepRetry({ attempts: 3.7 })?.attempts).toBe(3);
+  });
+});
+
+// ============================================================================
+// Which failures are worth another attempt
+// ============================================================================
+
+describe('isRetryableFailure', () => {
+  it('retries execution failures and timeouts', () => {
+    expect(isRetryableFailure('STEP_EXECUTION_FAILED')).toBe(true);
+    expect(isRetryableFailure('STEP_TIMEOUT')).toBe(true);
+  });
+
+  it('does NOT retry deterministic failures', () => {
+    // These produce the same result on every attempt, so N tries cost N times
+    // as much for one outcome — and under #1335 can burn a spend ceiling.
+    expect(isRetryableFailure('CAPABILITY_DENIED')).toBe(false);
+    expect(isRetryableFailure('STEP_VALIDATION_FAILED')).toBe(false);
+    expect(isRetryableFailure('UNKNOWN_STEP_TYPE')).toBe(false);
+    expect(isRetryableFailure('MOFLO_LEVEL_DENIED')).toBe(false);
+  });
+
+  it('does NOT retry a cancelled step — the run is already tearing down', () => {
+    expect(isRetryableFailure('STEP_CANCELLED')).toBe(false);
+  });
+
+  it('does not retry an absent error code', () => {
+    expect(isRetryableFailure(undefined)).toBe(false);
+  });
+});
+
+// ============================================================================
+// Backoff
+// ============================================================================
+
+describe('computeBackoffMs', () => {
+  const fixedJitter = { random: () => 0.5 }; // → multiplier exactly 1.0
+  const cfg = { attempts: 5, backoffMs: 100, maxDelayMs: 10_000, maxTotalDelayMs: 60_000 };
+
+  it('grows exponentially from the base delay', () => {
+    expect(computeBackoffMs(cfg, 1, 0, fixedJitter)).toBe(100);
+    expect(computeBackoffMs(cfg, 2, 0, fixedJitter)).toBe(200);
+    expect(computeBackoffMs(cfg, 3, 0, fixedJitter)).toBe(400);
+  });
+
+  it('caps any single delay at maxDelayMs', () => {
+    const capped = { ...cfg, maxDelayMs: 250 };
+    expect(computeBackoffMs(capped, 5, 0, fixedJitter)).toBe(250);
+  });
+
+  it('never lets the running total exceed maxTotalDelayMs', () => {
+    const tight = { ...cfg, maxTotalDelayMs: 150 };
+    expect(computeBackoffMs(tight, 1, 0, fixedJitter)).toBe(100);
+    expect(computeBackoffMs(tight, 2, 100, fixedJitter)).toBe(50); // not 200
+  });
+
+  it('returns 0 once the aggregate budget is spent, so attempts continue without waiting', () => {
+    const tight = { ...cfg, maxTotalDelayMs: 100 };
+    expect(computeBackoffMs(tight, 2, 100, fixedJitter)).toBe(0);
+  });
+
+  it('applies +/-10% jitter so parallel steps do not retry in lockstep', () => {
+    const low = computeBackoffMs(cfg, 1, 0, { random: () => 0 });
+    const high = computeBackoffMs(cfg, 1, 0, { random: () => 1 });
+    expect(low).toBe(90);
+    expect(high).toBe(110);
+  });
+});
+
+describe('abortableDelay', () => {
+  it('resolves after the delay', async () => {
+    const start = Date.now();
+    await abortableDelay(30);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(20);
+  });
+
+  it('resolves immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const start = Date.now();
+    await abortableDelay(5_000, controller.signal);
+    expect(Date.now() - start).toBeLessThan(200);
+  });
+
+  it('cuts a long wait short when the signal aborts mid-delay', async () => {
+    // This is what makes a wall-clock ceiling breach (#1335) interrupt a
+    // backoff rather than be served after it.
+    const controller = new AbortController();
+    const start = Date.now();
+    setTimeout(() => controller.abort(), 20);
+    await abortableDelay(5_000, controller.signal);
+    expect(Date.now() - start).toBeLessThan(1_000);
+  });
+
+  it('resolves immediately for a zero delay', async () => {
+    await expect(abortableDelay(0)).resolves.toBeUndefined();
+  });
+});
+
+// ============================================================================
+// End to end through the real runner
+// ============================================================================
+
+const credentials: CredentialAccessor = {
+  async get() { return undefined; },
+  async has() { return false; },
+  async store() { /* no-op */ },
+};
+
+function memory(): MemoryAccessor {
+  return { async read() { return null; }, async write() {}, async search() { return []; } };
+}
+
+/** A step that fails `failTimes` times, then succeeds. Counts its calls. */
+function flakyStep(failTimes: number): StepCommand & { calls: number } {
+  const cmd = {
+    calls: 0,
+    type: 'flaky',
+    description: 'fails a fixed number of times then succeeds',
+    configSchema: { type: 'object' },
+    validate: () => ({ valid: true, errors: [] }),
+    async execute() {
+      cmd.calls++;
+      if (cmd.calls <= failTimes) {
+        return { success: false, data: {}, error: 'transient upstream failure' };
+      }
+      return { success: true, data: { recovered: true } };
+    },
+    describeOutputs: () => [{ name: 'recovered', type: 'boolean' as const }],
+  };
+  return cmd;
+}
+
+function casterWith(cmd: StepCommand): SpellCaster {
+  const registry = new StepCommandRegistry();
+  registry.register(cmd, 'built-in');
+  return new SpellCaster(registry, credentials, memory());
+}
+
+function spellWith(retry?: Record<string, unknown>): SpellDefinition {
+  return {
+    name: 'retry-spell',
+    steps: [{ id: 'flaky', type: 'flaky', config: {}, ...(retry ? { retry } : {}) }],
+  } as SpellDefinition;
+}
+
+describe('SpellCaster step retry', () => {
+  it('completes the run when a step fails transiently then succeeds', async () => {
+    const cmd = flakyStep(2);
+    const result = await casterWith(cmd).run(
+      spellWith({ attempts: 3, backoffMs: 1 }), {},
+    );
+
+    expect(result.success).toBe(true);
+    expect(cmd.calls).toBe(3);
+    expect(result.steps[0].status).toBe('succeeded');
+  });
+
+  it('reports the attempt count, so a third-try success is distinguishable', async () => {
+    const cmd = flakyStep(2);
+    const result = await casterWith(cmd).run(spellWith({ attempts: 3, backoffMs: 1 }), {});
+    expect(result.steps[0].attempts).toBe(3);
+  });
+
+  it('reports attempts: 1 when a retry-configured step succeeds first try', async () => {
+    const cmd = flakyStep(0);
+    const result = await casterWith(cmd).run(spellWith({ attempts: 3, backoffMs: 1 }), {});
+    expect(result.steps[0].attempts).toBe(1);
+    expect(cmd.calls).toBe(1);
+  });
+
+  it('fails the run after exhausting attempts, recording how many were spent', async () => {
+    const cmd = flakyStep(99);
+    const result = await casterWith(cmd).run(spellWith({ attempts: 3, backoffMs: 1 }), {});
+
+    expect(result.success).toBe(false);
+    expect(cmd.calls).toBe(3);
+    expect(result.steps[0].attempts).toBe(3);
+    expect(result.steps[0].status).toBe('failed');
+  });
+
+  it('runs a step without a retry block exactly once, with no attempts field', async () => {
+    // The no-change guarantee for every existing spell.
+    const cmd = flakyStep(99);
+    const result = await casterWith(cmd).run(spellWith(), {});
+
+    expect(cmd.calls).toBe(1);
+    expect(result.success).toBe(false);
+    expect(result.steps[0].attempts).toBeUndefined();
+  });
+
+  it('treats attempts: 1 as no retry at all', async () => {
+    const cmd = flakyStep(99);
+    const result = await casterWith(cmd).run(spellWith({ attempts: 1 }), {});
+    expect(cmd.calls).toBe(1);
+    expect(result.steps[0].attempts).toBeUndefined();
+  });
+
+  it('does not retry a deterministic failure even when retry is configured', async () => {
+    // A validation failure will fail identically forever; spending three
+    // attempts on it is pure waste.
+    const cmd: StepCommand = {
+      type: 'flaky',
+      description: 'always invalid',
+      configSchema: { type: 'object' },
+      validate: () => ({ valid: false, errors: [{ path: 'x', message: 'nope' }] }),
+      execute: async () => ({ success: true, data: {} }),
+      describeOutputs: () => [],
+    };
+    const spy = vi.spyOn(cmd, 'validate');
+
+    const result = await casterWith(cmd).run(spellWith({ attempts: 5, backoffMs: 1 }), {});
+
+    expect(result.success).toBe(false);
+    expect(result.steps[0].errorCode).toBe('STEP_VALIDATION_FAILED');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops retrying when the run is cancelled mid-backoff', async () => {
+    const cmd = flakyStep(99);
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 25);
+
+    const result = await casterWith(cmd).run(
+      spellWith({ attempts: 20, backoffMs: 50 }), {}, { signal: controller.signal },
+    );
+
+    // Without the abort check it would have burned all 20 attempts.
+    expect(cmd.calls).toBeLessThan(20);
+    expect(result.success).toBe(false);
+  });
+
+  it('bounds total waiting so a scheduled run cannot stall indefinitely', async () => {
+    const cmd = flakyStep(99);
+    const start = Date.now();
+
+    await casterWith(cmd).run(
+      spellWith({ attempts: 6, backoffMs: 1_000, maxTotalDelayMs: 60 }), {},
+    );
+
+    // Six attempts at 1s exponential backoff would be ~31s unbounded.
+    expect(cmd.calls).toBe(6);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+});
+
+// ============================================================================
+// Definition validation
+// ============================================================================
+
+describe('retry block validation', () => {
+  function errorsFor(retry: unknown): string[] {
+    const def = {
+      name: 'v', steps: [{ id: 's1', type: 'bash', config: {}, retry }],
+    } as unknown as SpellDefinition;
+    return validateSpellDefinition(def).errors.map(e => e.message);
+  }
+
+  it('accepts a well-formed block', () => {
+    expect(errorsFor({ attempts: 3, backoffMs: 500 })).toEqual([]);
+  });
+
+  it('rejects an unknown key rather than silently meaning "no retry"', () => {
+    const errors = errorsFor({ attempts: 3, backofMs: 500 });
+    expect(errors.some(m => m.includes('unknown retry key "backofMs"'))).toBe(true);
+  });
+
+  it('rejects a non-object retry value', () => {
+    expect(errorsFor(3).some(m => m.includes('retry must be an object'))).toBe(true);
+    expect(errorsFor([]).some(m => m.includes('retry must be an object'))).toBe(true);
+  });
+
+  it('requires attempts when a retry block is present', () => {
+    expect(errorsFor({ backoffMs: 100 }).some(m => m.includes('retry.attempts is required'))).toBe(true);
+  });
+
+  it('rejects non-positive numbers', () => {
+    expect(errorsFor({ attempts: 0 }).some(m => m.includes('greater than 0'))).toBe(true);
+    expect(errorsFor({ attempts: 3, backoffMs: -1 }).some(m => m.includes('greater than 0'))).toBe(true);
+  });
+
+  it('leaves a step with no retry block valid', () => {
+    const def = { name: 'v', steps: [{ id: 's1', type: 'bash', config: {} }] } as SpellDefinition;
+    expect(validateSpellDefinition(def).valid).toBe(true);
+  });
+});
+
+// ============================================================================
+// Precedence over the credential-refresh path (#1042)
+// ============================================================================
+
+describe('retry vs credential refresh', () => {
+  /** A step that always fails with an auth-shaped error. */
+  function authFailingStep(): StepCommand & { calls: number } {
+    const cmd = {
+      calls: 0,
+      type: 'flaky',
+      description: 'always fails with an auth-shaped error',
+      configSchema: { type: 'object' },
+      validate: () => ({ valid: true, errors: [] }),
+      async execute() {
+        cmd.calls++;
+        return { success: false, data: {}, error: 'HTTP 401 Unauthorized: invalid token' };
+      },
+      describeOutputs: () => [],
+    };
+    return cmd;
+  }
+
+  it('does not burn retry attempts on an auth-shaped failure', async () => {
+    // The credential path (#1042) runs AFTER runStep returns, so without this
+    // carve-out a stale token would be retried to exhaustion — with backoff —
+    // before the re-prompt that could actually fix it was ever offered.
+    const cmd = authFailingStep();
+    const result = await casterWith(cmd).run(
+      spellWith({ attempts: 5, backoffMs: 1_000 }), {},
+    );
+
+    expect(cmd.calls).toBe(1);
+    expect(result.success).toBe(false);
+  });
+
+  it('still retries a non-auth failure from the same step type', async () => {
+    // Guards the carve-out against over-reach: only auth SHAPE is exempt.
+    const cmd = flakyStep(1);
+    const result = await casterWith(cmd).run(spellWith({ attempts: 3, backoffMs: 1 }), {});
+
+    expect(cmd.calls).toBe(2);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -29,6 +29,9 @@ import { executeParallelSteps } from './parallel-executor.js';
 import { rollbackSteps, type CompletedStep } from './rollback-orchestrator.js';
 import { buildCredentialPatterns, addCredentialPattern, collectCredentialNames } from './credential-masker.js';
 import { executeSingleStep, type StepExecutionState } from './step-executor.js';
+import {
+  resolveStepRetry, isRetryableFailure, computeBackoffMs, abortableDelay,
+} from './step-retry.js';
 import { collectPrerequisites, resolveUnmetPrerequisites } from './prerequisite-checker.js';
 import { classifyAuthError, type AuthErrorMatch } from './auth-error-classifier.js';
 import { readLineFromStdin } from './stdin-reader.js';
@@ -581,13 +584,46 @@ export class SpellCaster {
     return null;
   }
 
-  private runStep(
+  private async runStep(
     step: import('../types/spell-definition.types.js').StepDefinition,
     state: StepExecutionState, index: number,
   ) {
     const ctxBuilder = (v: Record<string, unknown>, a: Record<string, unknown>, sid: string, si: number, sig?: AbortSignal) =>
       this.buildContext(v, a, sid, si, sig, state.effectiveSandbox, state.budget);
-    return executeSingleStep(step, state, index, this.registry, ctxBuilder);
+    const attempt = () => executeSingleStep(step, state, index, this.registry, ctxBuilder);
+
+    const retry = resolveStepRetry(step.retry);
+    if (!retry) return attempt();
+
+    // Opt-in retry (#1336). Deliberately wraps the WHOLE step rather than just
+    // `command.execute`: a step's rollback runs inside executeSingleStep on
+    // failure, and re-running after that rollback is what makes a retry safe
+    // for a step that got halfway.
+    let result = await attempt();
+    let attemptsMade = 1;
+    let totalDelay = 0;
+
+    while (attemptsMade < retry.attempts) {
+      if (result.status !== 'failed' || !isRetryableFailure(result.errorCode)) break;
+      // Hand auth-shaped failures straight to the credential-refresh path
+      // (#1042), which runs after this returns. Retrying a stale credential
+      // cannot fix it — it only burns the attempts and delays the re-prompt
+      // that would. That path owns this failure shape; generic retry does not.
+      if (classifyAuthError(this.collectStepErrorText(result))) break;
+      if (state.options.signal?.aborted) break;
+
+      const delay = computeBackoffMs(retry, attemptsMade, totalDelay);
+      totalDelay += delay;
+      await abortableDelay(delay, state.options.signal);
+      // The wait may have been cut short by a cancellation or a wall-clock
+      // ceiling breach; re-check rather than spend an attempt on a dying run.
+      if (state.options.signal?.aborted) break;
+
+      result = await attempt();
+      attemptsMade++;
+    }
+
+    return { ...result, attempts: attemptsMade };
   }
 
   /**

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -610,6 +610,10 @@ export class SpellCaster {
       // cannot fix it — it only burns the attempts and delays the re-prompt
       // that would. That path owns this failure shape; generic retry does not.
       if (classifyAuthError(this.collectStepErrorText(result))) break;
+      // A latched spend-ceiling breach (#1335) denies every subsequent
+      // reservation, so further attempts cannot succeed — they would only
+      // spend backoff on a run the runner is about to abort anyway.
+      if (state.budget?.breach) break;
       if (state.options.signal?.aborted) break;
 
       const delay = computeBackoffMs(retry, attemptsMade, totalDelay);

--- a/src/cli/spells/core/step-retry.ts
+++ b/src/cli/spells/core/step-retry.ts
@@ -24,6 +24,24 @@
  * The credential-refresh retry in `runner.ts` is a separate concern with its
  * own semantics and takes precedence; this never wraps it.
  *
+ * ## Why not `shared/resilience/retry.ts` or `production/retry.ts`
+ *
+ * Both already do exponential backoff, and neither fits — the mismatch is the
+ * failure protocol, not the math:
+ *
+ *   - Both retry on a **thrown** exception. A spell step signals failure by
+ *     *returning* `StepOutput.success === false`. Adapting would mean throwing
+ *     the failure away to re-raise it, losing the output, the error code, and
+ *     the rollback bookkeeping the executor already did.
+ *   - `shared/resilience` wraps every attempt in its own `withTimeout`. Steps
+ *     already own their timeout (`config.timeout` / `defaultStepTimeout`);
+ *     a second one would silently shorten it.
+ *   - Neither sleeps on an `AbortSignal`, which is precisely what lets a
+ *     wall-clock ceiling breach cut a backoff short here.
+ *
+ * The shared helpers stay right for their callers. Reach for them when
+ * retrying a promise that throws; reach for this when retrying a spell step.
+ *
  * Cross-platform (Rule #1): pure timers and `AbortSignal`, no shell, no
  * platform branches.
  */

--- a/src/cli/spells/core/step-retry.ts
+++ b/src/cli/spells/core/step-retry.ts
@@ -1,0 +1,168 @@
+/**
+ * Per-step retry — issue #1336.
+ *
+ * A spell step had no retry. A flaky HTTP call, a rate-limit response, or a
+ * momentary network drop failed the whole run and discarded every completed
+ * step, for a cause that would likely have succeeded seconds later. That hurts
+ * most on the daemon-scheduled path, where a run dying at step 7 of 9 at 3am
+ * produces a failed record and no work.
+ *
+ * Three deliberate constraints:
+ *
+ *   - **Opt-in per step.** Blanket retry is wrong: silently re-running a step
+ *     that posts to Slack or writes a file is worse than failing. A step
+ *     without a `retry` block behaves exactly as it does today.
+ *   - **Only non-deterministic failures retry.** A capability violation, an
+ *     unknown step type, or a schema-invalid config will fail identically on
+ *     every attempt — retrying them just burns wall clock, and under #1335 it
+ *     can burn a spend ceiling too. See {@link isRetryableFailure}.
+ *   - **Bounded, and interruptible.** Backoff is capped per-delay and in
+ *     aggregate, and the wait aborts on the run's signal — which is the
+ *     budget-composed signal, so a wall-clock ceiling breach cuts a backoff
+ *     short instead of being served after it.
+ *
+ * The credential-refresh retry in `runner.ts` is a separate concern with its
+ * own semantics and takes precedence; this never wraps it.
+ *
+ * Cross-platform (Rule #1): pure timers and `AbortSignal`, no shell, no
+ * platform branches.
+ */
+
+import type { SpellErrorCode } from '../types/runner.types.js';
+
+// ============================================================================
+// Config
+// ============================================================================
+
+export interface StepRetryConfig {
+  /** Total attempts INCLUDING the first. `1` means no retry. */
+  readonly attempts: number;
+  /** Base delay in ms before the second attempt; doubles thereafter. */
+  readonly backoffMs?: number;
+  /** Ceiling on any single delay. */
+  readonly maxDelayMs?: number;
+  /** Ceiling on the sum of all delays for this step. */
+  readonly maxTotalDelayMs?: number;
+}
+
+/** Base delay when a step declares `retry` without one. */
+export const DEFAULT_BACKOFF_MS = 1_000;
+/** Ceiling on any single backoff, when the step declares none. */
+export const DEFAULT_MAX_DELAY_MS = 30_000;
+/**
+ * Ceiling on total backoff for one step, when the step declares none.
+ *
+ * Exists so a step cannot stall a scheduled run indefinitely (#1336 AC5) even
+ * if someone writes `attempts: 50`. It bounds *waiting*, not the attempts
+ * themselves — once exhausted, remaining attempts run back-to-back.
+ */
+export const DEFAULT_MAX_TOTAL_DELAY_MS = 60_000;
+
+/**
+ * Error codes worth a second attempt.
+ *
+ * Everything omitted here is deterministic: the same input produces the same
+ * failure, so N attempts cost N times as much and produce one outcome.
+ * `STEP_CANCELLED` is excluded for a different reason — the run is already
+ * being torn down, and retrying would fight the teardown.
+ */
+const RETRYABLE_CODES: ReadonlySet<string> = new Set<SpellErrorCode>([
+  'STEP_EXECUTION_FAILED',
+  'STEP_TIMEOUT',
+]);
+
+/** Whether a failed step's error code justifies another attempt. */
+export function isRetryableFailure(errorCode: string | undefined): boolean {
+  return errorCode !== undefined && RETRYABLE_CODES.has(errorCode);
+}
+
+/**
+ * Normalise a step's `retry` block.
+ *
+ * Returns undefined when retry is absent or resolves to a single attempt, so
+ * callers can treat "no retry block" and "a retry block that does nothing"
+ * identically — and so the executor takes its pre-feature code path in both
+ * cases rather than looping once.
+ */
+export function resolveStepRetry(raw?: unknown): StepRetryConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const rec = raw as Record<string, unknown>;
+
+  const attempts = positiveInt(rec.attempts);
+  if (attempts === undefined || attempts <= 1) return undefined;
+
+  const backoffMs = positiveInt(rec.backoffMs ?? rec.backoff_ms) ?? DEFAULT_BACKOFF_MS;
+  const maxDelayMs = positiveInt(rec.maxDelayMs ?? rec.max_delay_ms) ?? DEFAULT_MAX_DELAY_MS;
+  const maxTotalDelayMs =
+    positiveInt(rec.maxTotalDelayMs ?? rec.max_total_delay_ms) ?? DEFAULT_MAX_TOTAL_DELAY_MS;
+
+  return { attempts, backoffMs, maxDelayMs, maxTotalDelayMs };
+}
+
+function positiveInt(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
+  return Math.floor(value);
+}
+
+// ============================================================================
+// Backoff
+// ============================================================================
+
+export interface BackoffOptions {
+  /** Randomness source for jitter, injectable so tests are deterministic. */
+  readonly random?: () => number;
+}
+
+/**
+ * Delay before the attempt that follows `attemptsMade` failures.
+ *
+ * Exponential from `backoffMs`, capped by `maxDelayMs`, then reduced so the
+ * running total never exceeds `maxTotalDelayMs`. Returns 0 once the aggregate
+ * budget is spent — remaining attempts still run, just without waiting.
+ *
+ * Jitter is +/-10%, applied before the caps. Spells have a `parallel` step
+ * type, so a fan-out of steps hitting the same rate limit would otherwise
+ * retry in exact lockstep and reproduce the burst that rate-limited them.
+ */
+export function computeBackoffMs(
+  config: StepRetryConfig,
+  attemptsMade: number,
+  totalDelaySoFar: number,
+  options: BackoffOptions = {},
+): number {
+  const base = config.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const maxDelay = config.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const maxTotal = config.maxTotalDelayMs ?? DEFAULT_MAX_TOTAL_DELAY_MS;
+
+  const remaining = maxTotal - totalDelaySoFar;
+  if (remaining <= 0) return 0;
+
+  const exponential = base * Math.pow(2, Math.max(0, attemptsMade - 1));
+  const random = options.random ?? Math.random;
+  const jittered = exponential * (0.9 + random() * 0.2);
+
+  return Math.max(0, Math.round(Math.min(jittered, maxDelay, remaining)));
+}
+
+/**
+ * Wait `ms`, resolving early if `signal` aborts.
+ *
+ * Resolving rather than rejecting on abort is deliberate: the caller checks
+ * the signal itself and returns a cancelled step result. Rejecting here would
+ * make an abort during backoff look like a different failure than an abort
+ * during execution, which it is not.
+ */
+export function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return Promise.resolve();
+  return new Promise<void>(resolve => {
+    const timer = setTimeout(finish, ms);
+    // Never hold the process open for a backoff whose run is over.
+    timer.unref?.();
+    function finish(): void {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', finish);
+      resolve();
+    }
+    signal?.addEventListener('abort', finish, { once: true });
+  });
+}

--- a/src/cli/spells/schema/validators/steps.ts
+++ b/src/cli/spells/schema/validators/steps.ts
@@ -62,6 +62,8 @@ export function validateSteps(
     const capErrors = validateStepCapabilities(step, path);
     errors.push(...capErrors);
 
+    validateStepRetry(step, errors, path);
+
     if (step.mofloLevel !== undefined) {
       if (!isValidMofloLevel(step.mofloLevel)) {
         errors.push({
@@ -178,4 +180,55 @@ function findSimilar(target: string, candidates: readonly string[]): string[] {
       return common >= 3 || c.startsWith(target.slice(0, 3));
     })
     .slice(0, 3);
+}
+
+/**
+ * Validate a step's optional `retry` block (issue #1336).
+ *
+ * Fails the same direction the budget validator does: an unrecognised key
+ * means "no retry", so a step its author believed was resilient would fail on
+ * the first flake. Reject the shape at parse time instead of at 3am.
+ */
+export function validateStepRetry(
+  step: StepDefinition,
+  errors: ValidationError[],
+  path: string,
+): void {
+  const retry = (step as { retry?: unknown }).retry;
+  if (retry === undefined) return;
+
+  if (retry === null || typeof retry !== 'object' || Array.isArray(retry)) {
+    errors.push({ path: `${path}.retry`, message: 'retry must be an object' });
+    return;
+  }
+
+  const known = ['attempts', 'backoffMs', 'maxDelayMs', 'maxTotalDelayMs'] as const;
+  const rec = retry as Record<string, unknown>;
+
+  for (const key of Object.keys(rec)) {
+    if (!(known as readonly string[]).includes(key)) {
+      errors.push({
+        path: `${path}.retry.${key}`,
+        message: `unknown retry key "${key}". Valid keys: ${known.join(', ')}`,
+      });
+    }
+  }
+
+  for (const key of known) {
+    const value = rec[key];
+    if (value === undefined) continue;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+      errors.push({
+        path: `${path}.retry.${key}`,
+        message: `retry.${key} must be a number greater than 0`,
+      });
+    }
+  }
+
+  if (rec.attempts === undefined) {
+    errors.push({
+      path: `${path}.retry.attempts`,
+      message: 'retry.attempts is required when a retry block is present',
+    });
+  }
 }

--- a/src/cli/spells/types/runner.types.ts
+++ b/src/cli/spells/types/runner.types.ts
@@ -57,6 +57,14 @@ export interface StepResult {
   readonly rollbackError?: string;
   /** The interpolated config that was actually executed (for rollback). */
   readonly interpolatedConfig?: Record<string, unknown>;
+  /**
+   * How many attempts this step took, counting the first (Issue #1336).
+   *
+   * Present only when the step declared a `retry` block, so a step that
+   * succeeded on attempt 3 is distinguishable from one that succeeded
+   * immediately — and so records for every existing spell stay byte-identical.
+   */
+  readonly attempts?: number;
 }
 
 // ============================================================================

--- a/src/cli/spells/types/spell-definition.types.ts
+++ b/src/cli/spells/types/spell-definition.types.ts
@@ -7,6 +7,7 @@
 import type { CapabilityType, MofloLevel } from './step-command.types.js';
 import type { PermissionLevel } from '../core/permission-resolver.js';
 import type { SpellBudgetConfig } from '../core/run-budget.js';
+import type { StepRetryConfig } from '../core/step-retry.js';
 import type { ScheduleDefinition } from '../scheduler/schedule.types.js';
 
 // ============================================================================
@@ -62,6 +63,13 @@ export interface StepDefinition {
    * nested loop/condition/parallel bodies) and evaluated before step 1.
    */
   readonly prerequisites?: readonly PrerequisiteSpec[];
+  /**
+   * Retry this step on a transient failure (Issue #1336). Opt-in per step:
+   * blanket retry would silently re-run non-idempotent work like a Slack post
+   * or a file write. Only non-deterministic failures are retried — see
+   * `isRetryableFailure` in `core/step-retry.ts`.
+   */
+  readonly retry?: StepRetryConfig;
 }
 
 /**


### PR DESCRIPTION
Closes #1336.

## Why

A spell step had no retry. A flaky HTTP call, a rate-limit response, or a momentary network drop failed the whole run and discarded every completed step. That hurts most on the daemon-scheduled path, where a run dying at step 7 of 9 at 3am produces a failed record and no work, for a cause that would likely have succeeded seconds later.

The only existing retry is credential-specific (#1042) and deliberately does not generalise.

## What

A per-step `retry` block:

```yaml
- id: fetch-report
  type: http
  retry:
    attempts: 3             # total attempts INCLUDING the first
    backoffMs: 1000         # base delay before attempt 2; doubles thereafter
    maxDelayMs: 30000       # optional: ceiling on any single delay
    maxTotalDelayMs: 60000  # optional: ceiling on the sum of all delays
```

**Opt-in per step.** Blanket retry silently re-runs non-idempotent work — a Slack post, a file write — which is worse than failing. A step with no `retry` block runs exactly once, unchanged. `attempts: 1` resolves to no retry at all, so the runner takes its pre-feature code path rather than looping once.

**Only non-deterministic failures retry.** A capability violation, unknown step type, or invalid config fails identically on every attempt, so N tries cost N times as much for one outcome.

### Two carve-outs for failures that cannot succeed

Both cost real wall clock on a run that is already doomed, and both were found during implementation and verification rather than guessed at:

- **Auth-shaped failures** go straight to the credential-refresh path (#1042). That path runs *after* the step returns, so without the carve-out a stale token would be retried to exhaustion, with backoff, before the re-prompt that could actually fix it was ever offered.
- **A latched spend-ceiling breach** (#1335) stops the loop. A budget denial returns `success: false`, which surfaces as the retryable `STEP_EXECUTION_FAILED` — but a latched breach denies every subsequent reservation, so `attempts: 10` with a 1s base would have burned ~17 minutes of exponential backoff on a spawn that could never be granted.

### Bounded and interruptible

Each delay is capped by `maxDelayMs`, their sum by `maxTotalDelayMs` (60s default), so `attempts: 50` cannot stall a scheduled run — once the aggregate budget is spent, remaining attempts run back-to-back rather than being cancelled. The wait also aborts on the run's signal, which is the budget-composed signal, so a wall-clock ceiling breach cuts a backoff short instead of being served after it. Delays carry +/-10% jitter so a `parallel` block hitting one rate limit does not retry in lockstep.

Each attempt reserves against `maxModelInvocations` independently — retry is not a route to extra model calls.

## Consumer impact (Rule #2)

| | |
|---|---|
| **Surface** | `src/cli/spells/core/**`, spell schema validation, shipped guidance |
| **Failure mode on upgrade** | None. Retry is absent by default and every existing spell keeps running each step exactly once. `StepResult.attempts` is present only when a step declares `retry`, so existing run records are byte-identical. |
| **Round-trip** | Publish + reinstall before it is live in dogfood — the spell engine runs from `node_modules/moflo/` |

An unrecognised key inside `retry` is a validation error rather than a silent "no retry", matching the budget block: the expensive direction to fail is a step whose author believed it was resilient.

## Why not the existing retry helpers

`shared/resilience/retry.ts` and `production/retry.ts` both do exponential backoff, and neither fits — the mismatch is the failure protocol, not the math. Both retry on a **thrown** exception, while a spell step signals failure by *returning* `StepOutput.success === false`; adapting would mean discarding the output, error code, and rollback bookkeeping to re-raise it. `shared/resilience` also imposes its own per-attempt timeout, which would silently shorten a step's own, and neither sleeps on an `AbortSignal`. The reason is recorded in the new module's header so the next reader consolidates deliberately or not at all.

## Verification

- Full suite **10,306 passed / 0 failed**; `tsc --noEmit` and `eslint --max-warnings 0` clean
- `/verify` **PASS on all 5 acceptance criteria**. It found the spend-ceiling interaction above, which was fixed rather than waived.
- The 31 existing credential-retry tests pass unchanged, which is the specific evidence for "the credential path is unchanged"
- Cross-platform (Rule #1): pure timers and `AbortSignal`, no shell, no platform branches

Generated with [moflo](https://github.com/eric-cielo/moflo)