### PR TITLE
fix(memory): reconcile the HNSW sidecar instead of rebuilding it (#1384)

### DIFF
--- a/.claude/scripts/build-embeddings.mjs
+++ b/.claude/scripts/build-embeddings.mjs
@@ -24,7 +24,7 @@ const FASTEMBED_INLINE = 'dist/src/cli/embeddings/fastembed-inline/index.js';
 const BRIDGE_CORE = 'dist/src/cli/memory/bridge-core.js';
 const HNSW_PERSISTENCE = 'dist/src/cli/memory/hnsw-persistence.js';
 const { writeVectorStatsJson } = await import(mofloInternalURL(BRIDGE_CORE));
-const { buildAndWriteHnswSidecar } = await import(mofloInternalURL(HNSW_PERSISTENCE));
+const { syncHnswSidecar } = await import(mofloInternalURL(HNSW_PERSISTENCE));
 
 const projectRoot = findProjectRoot();
 const DB_PATH = memoryDbPath(projectRoot);
@@ -189,23 +189,44 @@ function writeVectorStatsCache(stats, nsStats) {
 // Main
 // ============================================================================
 
-// Build (or skip) the HNSW sidecar — shared between the all-embedded fast path
-// and the post-embedding finalize path. Issue #854: the early-return path used
-// to skip this entirely, leaving consumers with `hasHnsw: false` permanently
-// after the embeddings migration deleted the stale sidecar without rebuilding.
-// `stats` is passed in by both call sites so we don't redundantly run the
-// COUNT aggregate the caller already executed. `alwaysRebuild` is set by the
-// post-embedding path because newly-embedded rows always invalidate the
-// existing sidecar.
-async function ensureHnswSidecar(stats, { alwaysRebuild = false } = {}) {
-  if (stats.withEmbeddings <= 0) return false;
+// Reconcile the HNSW sidecar with the database — shared between the
+// all-embedded fast path and the post-embedding finalize path. Issue #854: the
+// early-return path used to skip this entirely, leaving consumers with
+// `hasHnsw: false` permanently after the embeddings migration deleted the
+// stale sidecar without rebuilding. `stats` is passed in by both call sites so
+// we don't redundantly run the COUNT aggregate the caller already executed.
+//
+// #1384: the post-embedding path used to force a full reconstruction, so
+// embedding a single row re-inserted every vector in the store — quadratic in
+// store size, ~19s for a one-row backlog on 5k vectors. `syncHnswSidecar`
+// applies only the difference and falls back to a full rebuild solely when
+// reconciliation is impossible (or `--force` asked for one), so rows already
+// indexed are never re-read or re-inserted.
+async function ensureHnswSidecar(stats) {
   const sidecarExists = existsSync(hnswIndexPath(projectRoot));
-  if (sidecarExists && !force && !alwaysRebuild) return false;
-  log(sidecarExists ? 'Rebuilding HNSW sidecar...' : 'Building HNSW sidecar...');
-  const result = await buildAndWriteHnswSidecar(DB_PATH, projectRoot, {
+  // Nothing embedded and nothing on disk — there is no graph to converge on.
+  // (An existing sidecar still gets synced, so emptying the store evicts it.)
+  if (stats.withEmbeddings <= 0 && !sidecarExists) return false;
+  const result = await syncHnswSidecar(DB_PATH, projectRoot, {
     dimensions: EMBEDDING_DIMS,
+    force,
   });
-  log(`HNSW sidecar: ${result.vectorCount} vectors → ${result.sidecarPath} (${(result.bytes / 1024).toFixed(1)} KB)`);
+  if (result.mode === 'unchanged') {
+    debug(`HNSW sidecar already current: ${result.vectorCount} vectors`);
+    return false;
+  }
+  if (result.mode === 'full') {
+    log(`HNSW sidecar: full rebuild (${result.reason})`);
+  }
+  log(
+    `HNSW sidecar: ${result.vectorCount} vectors (+${result.added} / -${result.removed}) → ` +
+    `${result.sidecarPath} (${(result.bytes / 1024).toFixed(1)} KB)`,
+  );
+  if (result.skippedIds.length > 0) {
+    log(`  ⚠ ${result.skippedIds.length} row(s) skipped — malformed or wrong-dimension embedding:`);
+    for (const id of result.skippedIds.slice(0, 20)) log(`      ${id}`);
+    if (result.skippedIds.length > 20) log(`      … +${result.skippedIds.length - 20} more`);
+  }
   if (!existsSync(result.sidecarPath)) {
     throw new Error(`HNSW sidecar missing after write: ${result.sidecarPath}`);
   }
@@ -323,11 +344,10 @@ async function main() {
   }
   log('═══════════════════════════════════════════════════════════');
 
-  // Rebuild the HNSW sidecar before vector-stats so `hasHnsw` reflects the
-  // post-rebuild state in the same session (#854). Newly-embedded rows
-  // invalidate the existing sidecar, so we force the rebuild here even
-  // when the sidecar already exists.
-  await ensureHnswSidecar(stats, { alwaysRebuild: true });
+  // Reconcile the HNSW sidecar before vector-stats so `hasHnsw` reflects the
+  // post-sync state in the same session (#854). The rows just embedded are
+  // added to the existing graph rather than triggering a rebuild of it (#1384).
+  await ensureHnswSidecar(stats);
 
   writeVectorStatsCache(stats, nsStats);
   db.close();

--- a/bin/build-embeddings.mjs
+++ b/bin/build-embeddings.mjs
@@ -24,7 +24,7 @@ const FASTEMBED_INLINE = 'dist/src/cli/embeddings/fastembed-inline/index.js';
 const BRIDGE_CORE = 'dist/src/cli/memory/bridge-core.js';
 const HNSW_PERSISTENCE = 'dist/src/cli/memory/hnsw-persistence.js';
 const { writeVectorStatsJson } = await import(mofloInternalURL(BRIDGE_CORE));
-const { buildAndWriteHnswSidecar } = await import(mofloInternalURL(HNSW_PERSISTENCE));
+const { syncHnswSidecar } = await import(mofloInternalURL(HNSW_PERSISTENCE));
 
 const projectRoot = findProjectRoot();
 const DB_PATH = memoryDbPath(projectRoot);
@@ -189,23 +189,44 @@ function writeVectorStatsCache(stats, nsStats) {
 // Main
 // ============================================================================
 
-// Build (or skip) the HNSW sidecar — shared between the all-embedded fast path
-// and the post-embedding finalize path. Issue #854: the early-return path used
-// to skip this entirely, leaving consumers with `hasHnsw: false` permanently
-// after the embeddings migration deleted the stale sidecar without rebuilding.
-// `stats` is passed in by both call sites so we don't redundantly run the
-// COUNT aggregate the caller already executed. `alwaysRebuild` is set by the
-// post-embedding path because newly-embedded rows always invalidate the
-// existing sidecar.
-async function ensureHnswSidecar(stats, { alwaysRebuild = false } = {}) {
-  if (stats.withEmbeddings <= 0) return false;
+// Reconcile the HNSW sidecar with the database — shared between the
+// all-embedded fast path and the post-embedding finalize path. Issue #854: the
+// early-return path used to skip this entirely, leaving consumers with
+// `hasHnsw: false` permanently after the embeddings migration deleted the
+// stale sidecar without rebuilding. `stats` is passed in by both call sites so
+// we don't redundantly run the COUNT aggregate the caller already executed.
+//
+// #1384: the post-embedding path used to force a full reconstruction, so
+// embedding a single row re-inserted every vector in the store — quadratic in
+// store size, ~19s for a one-row backlog on 5k vectors. `syncHnswSidecar`
+// applies only the difference and falls back to a full rebuild solely when
+// reconciliation is impossible (or `--force` asked for one), so rows already
+// indexed are never re-read or re-inserted.
+async function ensureHnswSidecar(stats) {
   const sidecarExists = existsSync(hnswIndexPath(projectRoot));
-  if (sidecarExists && !force && !alwaysRebuild) return false;
-  log(sidecarExists ? 'Rebuilding HNSW sidecar...' : 'Building HNSW sidecar...');
-  const result = await buildAndWriteHnswSidecar(DB_PATH, projectRoot, {
+  // Nothing embedded and nothing on disk — there is no graph to converge on.
+  // (An existing sidecar still gets synced, so emptying the store evicts it.)
+  if (stats.withEmbeddings <= 0 && !sidecarExists) return false;
+  const result = await syncHnswSidecar(DB_PATH, projectRoot, {
     dimensions: EMBEDDING_DIMS,
+    force,
   });
-  log(`HNSW sidecar: ${result.vectorCount} vectors → ${result.sidecarPath} (${(result.bytes / 1024).toFixed(1)} KB)`);
+  if (result.mode === 'unchanged') {
+    debug(`HNSW sidecar already current: ${result.vectorCount} vectors`);
+    return false;
+  }
+  if (result.mode === 'full') {
+    log(`HNSW sidecar: full rebuild (${result.reason})`);
+  }
+  log(
+    `HNSW sidecar: ${result.vectorCount} vectors (+${result.added} / -${result.removed}) → ` +
+    `${result.sidecarPath} (${(result.bytes / 1024).toFixed(1)} KB)`,
+  );
+  if (result.skippedIds.length > 0) {
+    log(`  ⚠ ${result.skippedIds.length} row(s) skipped — malformed or wrong-dimension embedding:`);
+    for (const id of result.skippedIds.slice(0, 20)) log(`      ${id}`);
+    if (result.skippedIds.length > 20) log(`      … +${result.skippedIds.length - 20} more`);
+  }
   if (!existsSync(result.sidecarPath)) {
     throw new Error(`HNSW sidecar missing after write: ${result.sidecarPath}`);
   }
@@ -323,11 +344,10 @@ async function main() {
   }
   log('═══════════════════════════════════════════════════════════');
 
-  // Rebuild the HNSW sidecar before vector-stats so `hasHnsw` reflects the
-  // post-rebuild state in the same session (#854). Newly-embedded rows
-  // invalidate the existing sidecar, so we force the rebuild here even
-  // when the sidecar already exists.
-  await ensureHnswSidecar(stats, { alwaysRebuild: true });
+  // Reconcile the HNSW sidecar before vector-stats so `hasHnsw` reflects the
+  // post-sync state in the same session (#854). The rows just embedded are
+  // added to the existing graph rather than triggering a rebuild of it (#1384).
+  await ensureHnswSidecar(stats);
 
   writeVectorStatsCache(stats, nsStats);
   db.close();

--- a/src/cli/__tests__/memory/hnsw-persistence.test.ts
+++ b/src/cli/__tests__/memory/hnsw-persistence.test.ts
@@ -37,6 +37,7 @@ function seedDb(dbPath: string): string[] {
     namespace TEXT,
     content TEXT,
     embedding TEXT,
+    updated_at INTEGER,
     status TEXT
   )`);
 
@@ -46,17 +47,17 @@ function seedDb(dbPath: string): string[] {
     ids.push(id);
     const vec = Array.from({ length: DIM }, (_, j) => Math.sin(i * 0.7 + j * 0.3));
     db.run(
-      `INSERT INTO memory_entries (id, key, namespace, content, embedding, status)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-      [id, `key-${i}`, 'patterns', `content ${i}`, JSON.stringify(vec), 'active'],
+      `INSERT INTO memory_entries (id, key, namespace, content, embedding, updated_at, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [id, `key-${i}`, 'patterns', `content ${i}`, JSON.stringify(vec), 1_700_000_000_000, 'active'],
     );
   }
 
   // Mix in one entry with no embedding (must be ignored by buildAndWriteHnswSidecar).
   db.run(
-    `INSERT INTO memory_entries (id, key, namespace, content, embedding, status)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    ['row-no-embedding', 'no-embed', 'patterns', 'skipped', null, 'active'],
+    `INSERT INTO memory_entries (id, key, namespace, content, embedding, updated_at, status)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ['row-no-embedding', 'no-embed', 'patterns', 'skipped', null, 1_700_000_000_000, 'active'],
   );
 
   db.close();

--- a/src/cli/__tests__/memory/hnsw-sidecar-sync.test.ts
+++ b/src/cli/__tests__/memory/hnsw-sidecar-sync.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Lazy HNSW sidecar reconciliation (#1384).
+ *
+ * Before this, every run that embedded a single row passed
+ * `{ alwaysRebuild: true }` and re-inserted the entire store — quadratic in
+ * store size, because `HnswLite.add()` scans every existing vector. The graph
+ * also never lost the vectors of rows that had gone away: `applyIncrementalChunks`
+ * gives an edited chunk a brand-new id, so each edit orphaned the old one.
+ *
+ * These tests pin both halves — laziness (already-indexed rows are never
+ * re-added) and completeness (departed, replaced, and newly-embedded rows all
+ * converge) — plus the narrow set of conditions under which a full rebuild is
+ * still correct.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import {
+  buildAndWriteHnswSidecar,
+  hnswManifestPath,
+  syncHnswSidecar,
+  tryLoadHnswSidecar,
+} from '../../memory/hnsw-persistence.js';
+import { HnswLite } from '../../memory/hnsw-lite.js';
+import { hnswIndexPath, MOFLO_DIR, MEMORY_DB_FILE } from '../../services/moflo-paths.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+
+const DIM = 8;
+const ROW_COUNT = 12;
+
+function vectorFor(seed: number): number[] {
+  return Array.from({ length: DIM }, (_, j) => Number(Math.sin(seed * 0.7 + j * 0.3).toFixed(6)));
+}
+
+function withDb<T>(dbPath: string, fn: (db: ReturnType<typeof openDaemonDatabase>) => T): T {
+  const db = openDaemonDatabase(dbPath);
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function seedDb(dbPath: string): string[] {
+  return withDb(dbPath, (db) => {
+    db.run(`CREATE TABLE memory_entries (
+      id TEXT PRIMARY KEY,
+      key TEXT,
+      namespace TEXT,
+      content TEXT,
+      embedding TEXT,
+      updated_at INTEGER,
+      status TEXT
+    )`);
+
+    const ids: string[] = [];
+    for (let i = 0; i < ROW_COUNT; i++) {
+      const id = `row-${i.toString().padStart(3, '0')}`;
+      ids.push(id);
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, embedding, updated_at, status)
+         VALUES (?, ?, ?, ?, ?, ?, 'active')`,
+        [id, `key-${i}`, 'patterns', `content ${i}`, JSON.stringify(vectorFor(i)), 1_700_000_000_000],
+      );
+    }
+    return ids;
+  });
+}
+
+function insertRow(dbPath: string, id: string, key: string, embedding: number[] | null): void {
+  withDb(dbPath, (db) => {
+    db.run(
+      `INSERT INTO memory_entries (id, key, namespace, content, embedding, updated_at, status)
+       VALUES (?, ?, ?, ?, ?, ?, 'active')`,
+      [
+        id, key, 'patterns', `content for ${key}`,
+        embedding === null ? null : JSON.stringify(embedding),
+        1_700_000_000_000,
+      ],
+    );
+  });
+}
+
+function sidecarIds(projectRoot: string): string[] {
+  const loaded = tryLoadHnswSidecar(projectRoot);
+  return loaded ? [...loaded.ids()] : [];
+}
+
+describe('hnsw-persistence — syncHnswSidecar (#1384)', () => {
+  let tmp: string;
+  let dbPath: string;
+  let ids: string[];
+
+  beforeEach(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1384-'));
+    fs.mkdirSync(path.join(tmp, MOFLO_DIR));
+    dbPath = path.join(tmp, MOFLO_DIR, MEMORY_DB_FILE);
+    ids = seedDb(dbPath);
+    // Establish the baseline sidecar every laziness assertion measures against.
+    await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  describe('laziness — already-indexed rows are left alone', () => {
+    it('writes nothing at all when the DB has not changed', async () => {
+      const serialize = vi.spyOn(HnswLite.prototype, 'serialize');
+      const add = vi.spyOn(HnswLite.prototype, 'add');
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.mode).toBe('unchanged');
+      expect(result.added).toBe(0);
+      expect(result.removed).toBe(0);
+      expect(result.bytes).toBe(0);
+      expect(result.vectorCount).toBe(ROW_COUNT);
+      expect(add).not.toHaveBeenCalled();
+      expect(serialize).not.toHaveBeenCalled();
+    });
+
+    it('embedding one new row touches only that row', async () => {
+      insertRow(dbPath, 'row-new', 'key-new', vectorFor(99));
+      const add = vi.spyOn(HnswLite.prototype, 'add');
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.mode).toBe('incremental');
+      expect(result.added).toBe(1);
+      expect(result.removed).toBe(0);
+      // The whole point: 1 insertion, not ROW_COUNT + 1.
+      expect(add).toHaveBeenCalledTimes(1);
+      expect(add.mock.calls[0][0]).toBe('row-new');
+      expect(sidecarIds(tmp).sort()).toEqual([...ids, 'row-new'].sort());
+    });
+  });
+
+  describe('completeness — every divergence converges', () => {
+    it('evicts the old chunk id when a doc is edited (no orphan accumulation)', async () => {
+      // Exactly what applyIncrementalChunks does to a changed chunk: same key,
+      // brand-new id.
+      withDb(dbPath, (db) => {
+        db.run(`DELETE FROM memory_entries WHERE id = ?`, [ids[3]]);
+        db.run(
+          `INSERT INTO memory_entries (id, key, namespace, content, embedding, updated_at, status)
+           VALUES (?, ?, ?, ?, ?, ?, 'active')`,
+          [
+            'row-003-edited', 'key-3', 'patterns', 'edited content',
+            JSON.stringify(vectorFor(42)), 1_700_000_000_001,
+          ],
+        );
+      });
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.mode).toBe('incremental');
+      expect(result.added).toBe(1);
+      expect(result.removed).toBe(1);
+      const after = sidecarIds(tmp);
+      expect(after).not.toContain(ids[3]);
+      expect(after).toContain('row-003-edited');
+      expect(after).toHaveLength(ROW_COUNT);
+    });
+
+    it('drops a deleted row from the graph', async () => {
+      withDb(dbPath, (db) => db.run(`DELETE FROM memory_entries WHERE id = ?`, [ids[0]]));
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.removed).toBe(1);
+      expect(sidecarIds(tmp)).not.toContain(ids[0]);
+    });
+
+    it('drops a row whose embedding was cleared', async () => {
+      withDb(dbPath, (db) =>
+        db.run(`UPDATE memory_entries SET embedding = NULL WHERE id = ?`, [ids[1]]));
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.removed).toBe(1);
+      expect(sidecarIds(tmp)).not.toContain(ids[1]);
+    });
+
+    it('replaces the vector when a row is re-embedded under the SAME id', async () => {
+      // bridgeAddToHNSW, the embeddings migration, and build-embeddings all
+      // UPDATE ... WHERE id = ?. An id-only diff would call this "already
+      // indexed" and keep serving the superseded vector.
+      const replacement = vectorFor(500);
+      withDb(dbPath, (db) =>
+        db.run(`UPDATE memory_entries SET embedding = ? WHERE id = ?`,
+          [JSON.stringify(replacement), ids[2]]));
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.mode).toBe('incremental');
+      expect(result.added).toBe(1);
+      expect(result.vectorCount).toBe(ROW_COUNT);
+
+      const loaded = tryLoadHnswSidecar(tmp)!;
+      const hits = loaded.search(new Float32Array(replacement), 1);
+      expect(hits[0].id).toBe(ids[2]);
+      expect(hits[0].score).toBeGreaterThan(0.999);
+    });
+
+    it('re-adds a row whose updated_at moved, even if the embedding text looks the same', async () => {
+      // Second, independent discriminator in the stamp: a writer that rewrites
+      // an embedding is caught by `updated_at` even in the (vanishingly rare)
+      // case where length and leading floats coincide.
+      withDb(dbPath, (db) =>
+        db.run(`UPDATE memory_entries SET updated_at = ? WHERE id = ?`, [1_700_000_009_999, ids[6]]));
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.mode).toBe('incremental');
+      expect(result.added).toBe(1);
+      expect(result.vectorCount).toBe(ROW_COUNT);
+    });
+
+    it('keeps the graph searchable for rows added incrementally', async () => {
+      const fresh = vectorFor(777);
+      insertRow(dbPath, 'row-fresh', 'key-fresh', fresh);
+      await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      const loaded = tryLoadHnswSidecar(tmp)!;
+      const hits = loaded.search(new Float32Array(fresh), 1);
+      expect(hits[0].id).toBe('row-fresh');
+    });
+  });
+
+  describe('full rebuild — only when reconciliation cannot be trusted', () => {
+    it('force rebuilds from scratch and says so', async () => {
+      const add = vi.spyOn(HnswLite.prototype, 'add');
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM, force: true });
+
+      expect(result.mode).toBe('full');
+      expect(result.reason).toBe('forced');
+      expect(add).toHaveBeenCalledTimes(ROW_COUNT);
+    });
+
+    it('rebuilds when the sidecar is absent', async () => {
+      fs.rmSync(hnswIndexPath(tmp));
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      expect(result.mode).toBe('full');
+      expect(result.reason).toBe('no sidecar');
+      expect(result.vectorCount).toBe(ROW_COUNT);
+    });
+
+    it('rebuilds when the sidecar is unreadable', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      fs.writeFileSync(hnswIndexPath(tmp), Buffer.from('NOT A SIDECAR'));
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      expect(result.mode).toBe('full');
+      expect(result.reason).toBe('sidecar unreadable');
+    });
+
+    it('rebuilds when the manifest is missing — the upgrade path', async () => {
+      fs.rmSync(hnswManifestPath(tmp));
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      expect(result.mode).toBe('full');
+      expect(result.reason).toBe('no usable manifest');
+      // …and one rebuild is all it costs: the next run is incremental again.
+      expect((await syncHnswSidecar(dbPath, tmp, { dimensions: DIM })).mode).toBe('unchanged');
+    });
+
+    it('rebuilds when the manifest no longer describes the sidecar', async () => {
+      const manifest = JSON.parse(fs.readFileSync(hnswManifestPath(tmp), 'utf-8'));
+      manifest.ids[0] = 'an-id-the-sidecar-has-never-heard-of';
+      fs.writeFileSync(hnswManifestPath(tmp), JSON.stringify(manifest));
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      expect(result.mode).toBe('full');
+      expect(result.reason).toBe('manifest does not match sidecar');
+    });
+
+    it('rebuilds when the manifest is corrupt', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      fs.writeFileSync(hnswManifestPath(tmp), '{ not json');
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      expect(result.mode).toBe('full');
+      expect(result.reason).toBe('no usable manifest');
+    });
+
+    it('rebuilds when the requested index parameters differ from the stored ones', async () => {
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM, m: 32 });
+      expect(result.mode).toBe('full');
+      expect(result.reason).toBe('index parameters changed');
+    });
+
+    it('buildAndWriteHnswSidecar leaves a manifest, so an explicit rebuild stays reconcilable', async () => {
+      fs.rmSync(hnswManifestPath(tmp));
+      await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      expect(fs.existsSync(hnswManifestPath(tmp))).toBe(true);
+      expect((await syncHnswSidecar(dbPath, tmp, { dimensions: DIM })).mode).toBe('unchanged');
+    });
+  });
+
+  describe('malformed embeddings are surfaced, not silently dropped', () => {
+    it('reports the id of a new row whose embedding will not parse', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      withDb(dbPath, (db) =>
+        db.run(
+          `INSERT INTO memory_entries (id, key, namespace, content, embedding, updated_at, status)
+           VALUES (?, ?, ?, ?, ?, ?, 'active')`,
+          ['row-broken', 'key-broken', 'patterns', 'x', 'not-json-at-all', 1_700_000_000_000],
+        ));
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.skippedIds).toEqual(['row-broken']);
+      expect(result.added).toBe(0);
+      expect(sidecarIds(tmp)).not.toContain('row-broken');
+      expect(warn.mock.calls.map(c => String(c[0])).join('\n')).toContain('row-broken');
+    });
+
+    it('reports and evicts an indexed row whose embedding became wrong-dimension', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      withDb(dbPath, (db) =>
+        db.run(`UPDATE memory_entries SET embedding = ? WHERE id = ?`,
+          [JSON.stringify([1, 2, 3]), ids[4]]));
+
+      const result = await syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.skippedIds).toEqual([ids[4]]);
+      expect(result.removed).toBe(1);
+      expect(sidecarIds(tmp)).not.toContain(ids[4]);
+    });
+
+    it('names skipped rows on the full-rebuild path too', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      withDb(dbPath, (db) =>
+        db.run(`UPDATE memory_entries SET embedding = ? WHERE id = ?`,
+          [JSON.stringify([1, 2, 3]), ids[5]]));
+
+      const result = await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(result.skippedIds).toEqual([ids[5]]);
+      expect(warn.mock.calls.map(c => String(c[0])).join('\n')).toContain(ids[5]);
+    });
+  });
+
+  it('throws when the source DB is missing — fail-loud parity with the rebuild path', async () => {
+    await expect(
+      syncHnswSidecar(path.join(tmp, 'nope.db'), tmp, { dimensions: DIM }),
+    ).rejects.toThrow(/db not found/);
+  });
+});
+
+describe('hnsw-persistence — chain wiring (#1384 regression guard)', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+  it('`memory rebuild-index` reconciles by default and only rebuilds under --force', () => {
+    // The session-start chain runs `build-embeddings` and then
+    // `memory rebuild-index`. Both write the sidecar, so leaving either on the
+    // wholesale-rebuild path costs a full re-index every session no matter
+    // what the other one does.
+    const file = path.join(repoRoot, 'src', 'cli', 'commands', 'memory.ts');
+    const text = fs.readFileSync(file, 'utf-8');
+    const fn = text.match(/const\s+writeSidecarOrFail\s*=[\s\S]*?\n {4}\};/);
+    expect(fn, 'writeSidecarOrFail must exist').toBeTruthy();
+    expect(fn![0]).toMatch(/syncHnswSidecar\(dbPath,\s*cwd,\s*\{\s*force:\s*forceAll\s*\}\)/);
+    expect(fn![0]).not.toMatch(/buildAndWriteHnswSidecar/);
+  });
+});

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -2171,12 +2171,26 @@ const rebuildIndexCommand: Command = {
     // (no-work-needed early return and post-embedding completion). Throws
     // are caught here to surface a clean CommandResult; the index-all.mjs
     // hnsw-rebuild step relies on the non-zero exit when this fails.
+    //
+    // #1384: reconcile rather than rebuild. `--force` still reconstructs the
+    // graph from scratch — that is what the flag asks for — but the default
+    // path applies only the difference, so the session-start chain no longer
+    // re-inserts every vector each time a single row gets embedded.
     const writeSidecarOrFail = async (showBytes: boolean): Promise<CommandResult | null> => {
-      const { buildAndWriteHnswSidecar } = await import('../memory/hnsw-persistence.js');
+      const { syncHnswSidecar } = await import('../memory/hnsw-persistence.js');
       try {
-        const result = await buildAndWriteHnswSidecar(dbPath, cwd);
+        const result = await syncHnswSidecar(dbPath, cwd, { force: forceAll });
         const tail = showBytes ? ` (${(result.bytes / 1024).toFixed(1)} KB)` : '';
-        output.writeln(`  HNSW sidecar:    ${result.vectorCount} vectors → ${result.sidecarPath}${tail}`);
+        const detail = result.mode === 'unchanged'
+          ? ' (already current)'
+          : ` (+${result.added} / -${result.removed}${result.mode === 'full' ? `, full rebuild: ${result.reason}` : ''})`;
+        output.writeln(`  HNSW sidecar:    ${result.vectorCount} vectors${detail} → ${result.sidecarPath}${tail}`);
+        if (result.skippedIds.length > 0) {
+          output.writeln(output.dim(
+            `  Skipped ${result.skippedIds.length} row(s) with malformed or wrong-dimension embeddings: ` +
+            `${result.skippedIds.slice(0, 20).join(', ')}${result.skippedIds.length > 20 ? ', …' : ''}`,
+          ));
+        }
         if (!fs.existsSync(result.sidecarPath)) {
           output.printError(`HNSW sidecar missing after write: ${result.sidecarPath}`);
           return { success: false, exitCode: 1 };

--- a/src/cli/memory/hnsw-lite.ts
+++ b/src/cli/memory/hnsw-lite.ts
@@ -30,6 +30,35 @@ export class HnswLite {
     return this.vectors.size;
   }
 
+  /**
+   * Construction parameters, exposed read-only so persistence code can decide
+   * whether a loaded sidecar is compatible with the index it was asked for
+   * (#1384). A dimension/metric/m/efConstruction mismatch makes incremental
+   * reconciliation meaningless — the caller must rebuild from scratch.
+   */
+  get params(): Readonly<{ dimensions: number; m: number; efConstruction: number; metric: HnswMetric }> {
+    return {
+      dimensions: this.dimensions,
+      m: this.maxNeighbors,
+      efConstruction: this.efConstruction,
+      metric: this.metric,
+    };
+  }
+
+  /**
+   * Read-only enumeration of the ids currently in the graph. Reconciliation
+   * (#1384) diffs this against the DB's id set, so it must not expose the
+   * backing map — `keys()` hands out an iterator over strings only.
+   */
+  ids(): IterableIterator<string> {
+    return this.vectors.keys();
+  }
+
+  /** Whether `id` currently has a vector in the graph. */
+  has(id: string): boolean {
+    return this.vectors.has(id);
+  }
+
   add(id: string, vector: Float32Array): void {
     this.vectors.set(id, vector);
 

--- a/src/cli/memory/hnsw-persistence.ts
+++ b/src/cli/memory/hnsw-persistence.ts
@@ -13,6 +13,35 @@
  *
  * The sidecar binary format is owned by `HnswLite.serialize()` /
  * `HnswLite.load()` — see hnsw-lite.ts.
+ *
+ * ## Incremental reconciliation (#1384)
+ *
+ * `syncHnswSidecar()` is the lazy counterpart to `buildAndWriteHnswSidecar()`:
+ * it loads the existing graph and applies only the difference against the DB
+ * rather than re-inserting every vector. `HnswLite.add()` runs a full scan per
+ * insertion, so a wholesale rebuild is quadratic in store size — embedding one
+ * new row used to re-index the entire store.
+ *
+ * Reconciling by id alone is not sufficient. Several writers replace a row's
+ * embedding *in place* under the same id (`bridgeAddToHNSW`, the embeddings
+ * migration's `updateBatch`, `build-embeddings`' `updateEmbedding` after a
+ * `strip-context-preambles`-style NULL-out). An id-only diff would treat those
+ * rows as "already indexed" and keep serving the superseded vector forever.
+ *
+ * So the sidecar is paired with a manifest (`.moflo/hnsw.manifest.json`) that
+ * records, per id, a stamp derived from the embedding column itself —
+ * `<length>:<first 64 characters>`. That is a pure function of the stored
+ * vector, so it needs no cooperation from writers (an `updated_at` stamp would
+ * silently miss any writer that forgets to bump it, and one such writer already
+ * exists). Two genuinely different 384-float JSON payloads agreeing on both
+ * total length and their leading floats is not a case that arises in practice,
+ * and reading 64 characters per row keeps the check cheap enough to run every
+ * session — reading whole embeddings back just to hash them would reintroduce a
+ * per-session tax proportional to store size.
+ *
+ * The manifest is written after the sidecar. A crash between the two leaves a
+ * manifest that no longer describes the graph, which the id-set cross-check
+ * detects on the next run and heals with one full rebuild.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -41,11 +70,178 @@ export interface HnswBuildResult {
   vectorCount: number;
   /** Bytes written. */
   bytes: number;
+  /** Row ids dropped because their embedding was malformed or the wrong dimension. */
+  skippedIds: string[];
+}
+
+export interface HnswSyncResult extends HnswBuildResult {
+  /**
+   * `full` — the graph was rebuilt from scratch; `incremental` — only the
+   * difference was applied; `unchanged` — the sidecar already matched the DB
+   * and nothing was written.
+   */
+  mode: 'full' | 'incremental' | 'unchanged';
+  /** Why a full rebuild was chosen. Always set when `mode === 'full'`. */
+  reason?: string;
+  /** Vectors inserted during this sync. */
+  added: number;
+  /** Vectors evicted during this sync. */
+  removed: number;
+}
+
+/** Manifest format version — bump to force every consumer through one rebuild. */
+const MANIFEST_VERSION = 1;
+const MANIFEST_FILENAME = 'hnsw.manifest.json';
+/**
+ * Characters of the embedding JSON folded into each stamp. 64 covers the first
+ * ~7 floats at full precision, which is far more discriminating than needed.
+ *
+ * The residual hole, stated plainly: a replacement vector that matches its
+ * predecessor's `updated_at`, total length, AND leading ~7 floats reads as
+ * unchanged, and the superseded vector keeps being served. Every writer that
+ * replaces an embedding sets `updated_at` (`build-embeddings`, `rebuild-index`,
+ * `bridgeAddToHNSW`), so closing that requires two independent coincidences.
+ * The alternative — reading whole embeddings back to hash them — puts a cost
+ * proportional to store size on every session, which is the problem #1384
+ * exists to remove.
+ */
+const STAMP_PREFIX_CHARS = 64;
+/** How many skipped ids to name in the warning before truncating. */
+const SKIPPED_IDS_LOGGED = 20;
+/** Params per `IN (...)` batch — stays under the lowest SQLITE_MAX_VARIABLE_NUMBER. */
+const ID_BATCH_SIZE = 400;
+
+const EMBEDDED_ROWS_WHERE = `status = 'active' AND embedding IS NOT NULL AND embedding != ''`;
+/** Single definition of the stamp's SQL projection — see `stampOf` for its shape. */
+const STAMP_COLUMNS =
+  `updated_at AS stamped_at, length(embedding) AS len, substr(embedding, 1, ${STAMP_PREFIX_CHARS}) AS head`;
+
+/** The one place a stamp string is composed, so the two readers cannot drift. */
+function stampOf(stampedAt: unknown, len: unknown, head: unknown): string {
+  return `${String(stampedAt)}:${String(len)}:${String(head)}`;
+}
+
+interface SidecarManifest {
+  version: number;
+  dimensions: number;
+  m: number;
+  efConstruction: number;
+  metric: string;
+  /** Index-aligned with `stamps`. */
+  ids: string[];
+  stamps: string[];
+}
+
+interface StampedRow {
+  id: string;
+  stamp: string;
+}
+
+/**
+ * Sibling of the sidecar. Exported for tests; no other subsystem reads it, so
+ * it deliberately does not live in `services/moflo-paths.ts` with the paths
+ * that are part of moflo's on-disk contract.
+ */
+export function hnswManifestPath(projectRoot: string): string {
+  return path.join(path.dirname(hnswIndexPath(projectRoot)), MANIFEST_FILENAME);
+}
+
+function resolveOptions(options: HnswBuildOptions): Required<HnswBuildOptions> {
+  return {
+    dimensions: options.dimensions ?? 384,
+    m: options.m ?? 16,
+    efConstruction: options.efConstruction ?? 200,
+    metric: options.metric ?? 'cosine',
+  };
+}
+
+/**
+ * Read `(id, stamp)` for every active row carrying an embedding. Only 64
+ * characters of each embedding cross the SQLite boundary, so this stays cheap
+ * on stores far larger than the one moflo dogfoods on.
+ */
+function readStampedRows(db: ReturnType<typeof openDaemonDatabase>): StampedRow[] {
+  const rows = db.exec(
+    `SELECT id, ${STAMP_COLUMNS} FROM memory_entries WHERE ${EMBEDDED_ROWS_WHERE}`,
+  );
+  const values = rows[0]?.values ?? [];
+  return values.map((row) => {
+    const [id, stampedAt, len, head] = row as [unknown, unknown, unknown, unknown];
+    return { id: String(id), stamp: stampOf(stampedAt, len, head) };
+  });
+}
+
+/** Fetch embeddings for a specific id set, batched to respect SQLite's param cap. */
+function readEmbeddingsFor(
+  db: ReturnType<typeof openDaemonDatabase>,
+  ids: readonly string[],
+): Map<string, unknown> {
+  const out = new Map<string, unknown>();
+  for (let i = 0; i < ids.length; i += ID_BATCH_SIZE) {
+    const batch = ids.slice(i, i + ID_BATCH_SIZE);
+    const placeholders = batch.map(() => '?').join(', ');
+    const rows = db.exec(
+      `SELECT id, embedding FROM memory_entries
+        WHERE ${EMBEDDED_ROWS_WHERE} AND id IN (${placeholders})`,
+      batch,
+    );
+    for (const row of rows[0]?.values ?? []) {
+      const [id, embedding] = row as [unknown, unknown];
+      out.set(String(id), embedding);
+    }
+  }
+  return out;
+}
+
+function warnSkipped(skippedIds: readonly string[]): void {
+  if (skippedIds.length === 0) return;
+  const shown = skippedIds.slice(0, SKIPPED_IDS_LOGGED).join(', ');
+  const more = skippedIds.length > SKIPPED_IDS_LOGGED
+    ? ` (+${skippedIds.length - SKIPPED_IDS_LOGGED} more)`
+    : '';
+  console.warn(
+    `[hnsw-persistence] skipped ${skippedIds.length} row(s) with malformed or wrong-dimension embeddings: ${shown}${more}`,
+  );
+}
+
+function writeSidecarAndManifest(
+  hnsw: HnswLite,
+  projectRoot: string,
+  stamps: ReadonlyMap<string, string>,
+): { sidecarPath: string; bytes: number } {
+  const sidecarPath = hnswIndexPath(projectRoot);
+  fs.mkdirSync(path.dirname(sidecarPath), { recursive: true });
+  const out = hnsw.serialize();
+  atomicWriteFileSync(sidecarPath, out);
+
+  // Manifest second: if the sidecar write throws we never advance the manifest,
+  // so the pair on disk stays coherent.
+  const params = hnsw.params;
+  const ids: string[] = [];
+  const stampList: string[] = [];
+  for (const id of hnsw.ids()) {
+    const stamp = stamps.get(id);
+    if (stamp === undefined) continue;
+    ids.push(id);
+    stampList.push(stamp);
+  }
+  const manifest: SidecarManifest = {
+    version: MANIFEST_VERSION,
+    dimensions: params.dimensions,
+    m: params.m,
+    efConstruction: params.efConstruction,
+    metric: params.metric,
+    ids,
+    stamps: stampList,
+  };
+  atomicWriteFileSync(hnswManifestPath(projectRoot), JSON.stringify(manifest));
+  return { sidecarPath, bytes: out.length };
 }
 
 /**
  * Build an HnswLite from every active row in `dbPath` that has an embedding,
- * then atomically write the sidecar to `<projectRoot>/.moflo/hnsw.index`.
+ * then atomically write the sidecar to `<projectRoot>/.moflo/hnsw.index` and
+ * its reconciliation manifest alongside it.
  *
  * Throws on any failure — write errors, dimension mismatches, or empty
  * indexes. Callers (rebuild-index, build-embeddings.mjs, index-all.mjs)
@@ -56,10 +252,7 @@ export async function buildAndWriteHnswSidecar(
   projectRoot: string,
   options: HnswBuildOptions = {},
 ): Promise<HnswBuildResult> {
-  const dimensions = options.dimensions ?? 384;
-  const m = options.m ?? 16;
-  const efConstruction = options.efConstruction ?? 200;
-  const metric = options.metric ?? 'cosine';
+  const { dimensions, m, efConstruction, metric } = resolveOptions(options);
 
   if (!fs.existsSync(dbPath)) {
     throw new Error(`buildAndWriteHnswSidecar: db not found at ${dbPath}`);
@@ -72,37 +265,176 @@ export async function buildAndWriteHnswSidecar(
   const db = openDaemonDatabase(dbPath);
 
   const hnsw = new HnswLite(dimensions, m, efConstruction, metric);
-  let skipped = 0;
+  const stamps = new Map<string, string>();
+  const skippedIds: string[] = [];
 
   try {
     const rows = db.exec(
-      `SELECT id, embedding FROM memory_entries
-       WHERE status = 'active' AND embedding IS NOT NULL AND embedding != ''`,
+      `SELECT id, embedding, ${STAMP_COLUMNS} FROM memory_entries WHERE ${EMBEDDED_ROWS_WHERE}`,
     );
     const values = rows[0]?.values ?? [];
     for (const row of values) {
-      const [id, embeddingJson] = row as [string, unknown];
+      const [rawId, embeddingJson, stampedAt, len, head] =
+        row as [unknown, unknown, unknown, unknown, unknown];
+      const id = String(rawId);
       const vec = parseEmbeddingJson(embeddingJson);
       if (!vec || vec.length !== dimensions) {
-        skipped++;
+        skippedIds.push(id);
         continue;
       }
-      hnsw.add(String(id), vec);
+      hnsw.add(id, vec);
+      stamps.set(id, stampOf(stampedAt, len, head));
     }
   } finally {
     db.close();
   }
 
-  if (skipped > 0) {
-    console.warn(`[hnsw-persistence] skipped ${skipped} rows with malformed or wrong-dimension embeddings`);
+  warnSkipped(skippedIds);
+
+  const { sidecarPath, bytes } = writeSidecarAndManifest(hnsw, projectRoot, stamps);
+  return { sidecarPath, vectorCount: hnsw.size, bytes, skippedIds };
+}
+
+/**
+ * Bring `<projectRoot>/.moflo/hnsw.index` into agreement with `dbPath` by
+ * applying only the difference (#1384).
+ *
+ * Rows already indexed with an unchanged embedding are left completely alone —
+ * their vectors are never re-read, re-decoded, or re-inserted. Rows that
+ * departed the DB (or lost their embedding) are evicted, which is what stops
+ * edited chunks — `applyIncrementalChunks` gives a changed chunk a brand-new id
+ * — from accumulating orphaned vectors that keep answering searches.
+ *
+ * Falls back to a full rebuild, with the reason recorded on the result and
+ * logged, when reconciliation cannot be trusted: `force`, no sidecar, an
+ * unreadable sidecar, a missing/corrupt manifest, a manifest that no longer
+ * matches the sidecar's contents, or a change to dimensions/metric/m/
+ * efConstruction.
+ */
+export async function syncHnswSidecar(
+  dbPath: string,
+  projectRoot: string,
+  options: HnswBuildOptions & { force?: boolean } = {},
+): Promise<HnswSyncResult> {
+  const { dimensions, m, efConstruction, metric } = resolveOptions(options);
+
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`syncHnswSidecar: db not found at ${dbPath}`);
   }
 
-  const sidecarPath = hnswIndexPath(projectRoot);
-  fs.mkdirSync(path.dirname(sidecarPath), { recursive: true });
-  const out = hnsw.serialize();
-  atomicWriteFileSync(sidecarPath, out);
+  const fullRebuild = async (reason: string): Promise<HnswSyncResult> => {
+    const built = await buildAndWriteHnswSidecar(dbPath, projectRoot, options);
+    return { ...built, mode: 'full', reason, added: built.vectorCount, removed: 0 };
+  };
 
-  return { sidecarPath, vectorCount: hnsw.size, bytes: out.length };
+  if (options.force) return fullRebuild('forced');
+
+  const hnsw = tryLoadHnswSidecar(projectRoot);
+  if (!hnsw) {
+    return fullRebuild(
+      fs.existsSync(hnswIndexPath(projectRoot)) ? 'sidecar unreadable' : 'no sidecar',
+    );
+  }
+
+  const manifest = readManifest(projectRoot);
+  if (!manifest) return fullRebuild('no usable manifest');
+
+  const params = hnsw.params;
+  if (
+    manifest.dimensions !== dimensions || params.dimensions !== dimensions ||
+    manifest.m !== m || params.m !== m ||
+    manifest.efConstruction !== efConstruction || params.efConstruction !== efConstruction ||
+    manifest.metric !== metric || params.metric !== metric
+  ) {
+    return fullRebuild('index parameters changed');
+  }
+
+  // The manifest is only meaningful if it still describes this exact graph.
+  const known = new Map<string, string>();
+  for (let i = 0; i < manifest.ids.length; i++) known.set(manifest.ids[i], manifest.stamps[i]);
+  if (known.size !== hnsw.size) return fullRebuild('manifest does not match sidecar');
+  for (const id of known.keys()) {
+    if (!hnsw.has(id)) return fullRebuild('manifest does not match sidecar');
+  }
+
+  const db = openDaemonDatabase(dbPath);
+  let added = 0;
+  let removed = 0;
+  const skippedIds: string[] = [];
+  try {
+    const current = readStampedRows(db);
+    const currentStamps = new Map(current.map((r) => [r.id, r.stamp]));
+
+    // In the DB but absent from the sidecar, or present with a superseded
+    // vector — the only ids whose embeddings get read at all.
+    const toAdd: string[] = [];
+    for (const { id, stamp } of current) {
+      if (known.get(id) !== stamp) toAdd.push(id);
+    }
+    // In the sidecar but gone from the DB (deleted, or its embedding cleared).
+    const toRemove: string[] = [];
+    for (const id of known.keys()) {
+      if (!currentStamps.has(id)) toRemove.push(id);
+    }
+
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      return {
+        sidecarPath: hnswIndexPath(projectRoot),
+        vectorCount: hnsw.size,
+        bytes: 0,
+        skippedIds: [],
+        mode: 'unchanged',
+        added: 0,
+        removed: 0,
+      };
+    }
+
+    for (const id of toRemove) {
+      hnsw.remove(id);
+      known.delete(id);
+      removed++;
+    }
+
+    const embeddings = readEmbeddingsFor(db, toAdd);
+    for (const id of toAdd) {
+      // Absent from the second query means the row was deleted between the two
+      // reads — a benign race with a concurrent writer, not corruption. Evict
+      // it and stay quiet; the next run picks up whatever the writer left.
+      const vanished = !embeddings.has(id);
+      const vec = vanished ? null : parseEmbeddingJson(embeddings.get(id));
+      if (!vec || vec.length !== dimensions) {
+        if (!vanished) skippedIds.push(id);
+        // A row whose vector no longer parses must not keep its old entry.
+        if (hnsw.has(id)) {
+          hnsw.remove(id);
+          removed++;
+        }
+        known.delete(id);
+        continue;
+      }
+      // Replace rather than overwrite so the previous vector's back-edges go
+      // with it — `add()` on an existing id would leave them dangling.
+      if (hnsw.has(id)) hnsw.remove(id);
+      hnsw.add(id, vec);
+      known.set(id, currentStamps.get(id)!);
+      added++;
+    }
+  } finally {
+    db.close();
+  }
+
+  warnSkipped(skippedIds);
+
+  const { sidecarPath, bytes } = writeSidecarAndManifest(hnsw, projectRoot, known);
+  return {
+    sidecarPath,
+    vectorCount: hnsw.size,
+    bytes,
+    skippedIds,
+    mode: 'incremental',
+    added,
+    removed,
+  };
 }
 
 /**
@@ -127,4 +459,32 @@ export function tryLoadHnswSidecar(projectRoot: string): HnswLite | null {
     console.warn(`[hnsw-persistence] load failed for ${sidecarPath}: ${(err as Error).message} — will rebuild from SQL`);
     return null;
   }
+}
+
+/**
+ * Load the reconciliation manifest. Returns null when it is absent, unreadable,
+ * from another format version, or structurally invalid — every one of which
+ * sends `syncHnswSidecar` down the full-rebuild path.
+ */
+function readManifest(projectRoot: string): SidecarManifest | null {
+  const manifestPath = hnswManifestPath(projectRoot);
+  if (!fs.existsSync(manifestPath)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  } catch (err) {
+    console.warn(`[hnsw-persistence] manifest unreadable at ${manifestPath}: ${(err as Error).message}`);
+    return null;
+  }
+  const m = parsed as Partial<SidecarManifest>;
+  if (
+    !m || m.version !== MANIFEST_VERSION ||
+    typeof m.dimensions !== 'number' || typeof m.m !== 'number' ||
+    typeof m.efConstruction !== 'number' || typeof m.metric !== 'string' ||
+    !Array.isArray(m.ids) || !Array.isArray(m.stamps) ||
+    m.ids.length !== m.stamps.length
+  ) {
+    return null;
+  }
+  return m as SidecarManifest;
 }

--- a/src/cli/memory/index.ts
+++ b/src/cli/memory/index.ts
@@ -193,7 +193,7 @@ export { RvfBackend } from './rvf-backend.js';
 export type { RvfBackendConfig } from './rvf-backend.js';
 export { HnswLite, cosineSimilarity } from './hnsw-lite.js';
 export type { HnswSearchResult } from './hnsw-lite.js';
-export { buildAndWriteHnswSidecar, tryLoadHnswSidecar } from './hnsw-persistence.js';
+export { buildAndWriteHnswSidecar, syncHnswSidecar, tryLoadHnswSidecar } from './hnsw-persistence.js';
 export type { HnswBuildOptions, HnswBuildResult } from './hnsw-persistence.js';
 export { HNSWIndex } from './hnsw-index.js';
 export { CacheManager, TieredCacheManager } from './cache-manager.js';

--- a/tests/bin/hnsw-sidecar-doc-edit-chain.test.ts
+++ b/tests/bin/hnsw-sidecar-doc-edit-chain.test.ts
@@ -1,0 +1,211 @@
+/**
+ * End-to-end laziness across the two halves of the indexing chain (#1384).
+ *
+ * `applyIncrementalChunks` (#1057) is already lazy at the DB layer: unchanged
+ * chunks keep their embedding, a changed chunk is rewritten under a BRAND-NEW
+ * id, and departed chunks are deleted. The sidecar was not — it was rebuilt
+ * wholesale on every run, which both cost a full re-index per session and
+ * masked the fact that nothing ever evicted the ids the DB layer had retired.
+ *
+ * This test drives the real sequence a doc edit produces — index, edit one
+ * section and append another, re-index, embed only the rows that lost their
+ * vector, reconcile — and pins that the sidecar ends up agreeing with the DB
+ * while touching only the rows that actually changed.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { applyIncrementalChunks } from '../../bin/lib/incremental-write.mjs';
+import { syncHnswSidecar, tryLoadHnswSidecar } from '../../src/cli/memory/hnsw-persistence.js';
+import { HnswLite } from '../../src/cli/memory/hnsw-lite.js';
+import { MOFLO_DIR, MEMORY_DB_FILE } from '../../src/cli/services/moflo-paths.js';
+
+const DIM = 8;
+const NS = 'guidance';
+
+function vectorFor(seed: number): number[] {
+  return Array.from({ length: DIM }, (_, j) => Number(Math.sin(seed * 0.9 + j * 0.4).toFixed(6)));
+}
+
+async function openWriter(dbPath: string) {
+  const { openBackend } = await import('../../bin/lib/get-backend.mjs');
+  return openBackend(process.cwd(), { dbPath });
+}
+
+async function createSchema(dbPath: string): Promise<void> {
+  const db = await openWriter(dbPath);
+  db.run(`
+    CREATE TABLE memory_entries (
+      id TEXT PRIMARY KEY,
+      key TEXT NOT NULL,
+      namespace TEXT DEFAULT 'default',
+      content TEXT NOT NULL,
+      type TEXT DEFAULT 'semantic',
+      embedding TEXT,
+      embedding_model TEXT DEFAULT 'local',
+      embedding_dimensions INTEGER,
+      tags TEXT,
+      metadata TEXT,
+      owner_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+      updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+      expires_at INTEGER,
+      last_accessed_at INTEGER,
+      access_count INTEGER DEFAULT 0,
+      status TEXT DEFAULT 'active',
+      UNIQUE(namespace, key)
+    )
+  `);
+  db.close();
+}
+
+/** Re-index a doc's chunks the way the guidance indexer does. */
+async function reindex(dbPath: string, chunks: Array<{ key: string; content: string }>) {
+  const db = await openWriter(dbPath);
+  const counts = applyIncrementalChunks(db, NS, chunks);
+  db.close();
+  return counts;
+}
+
+/**
+ * Stand-in for build-embeddings: vectorise exactly the rows that lack an
+ * embedding, keyed off content so a chunk's vector is a function of its text.
+ */
+async function embedMissing(dbPath: string): Promise<string[]> {
+  const db = await openWriter(dbPath);
+  const stmt = db.prepare(
+    `SELECT id, content FROM memory_entries
+      WHERE status = 'active' AND (embedding IS NULL OR embedding = '')`,
+  );
+  const pending: Array<{ id: string; content: string }> = [];
+  while (stmt.step()) pending.push(stmt.getAsObject() as { id: string; content: string });
+  stmt.free();
+
+  for (const { id, content } of pending) {
+    db.run(
+      `UPDATE memory_entries SET embedding = ?, embedding_dimensions = ?, updated_at = ? WHERE id = ?`,
+      [JSON.stringify(vectorFor(content.length)), DIM, Date.now(), id],
+    );
+  }
+  db.close();
+  return pending.map(p => p.id);
+}
+
+async function idsByKey(dbPath: string): Promise<Map<string, string>> {
+  const db = await openWriter(dbPath);
+  const stmt = db.prepare(`SELECT key, id FROM memory_entries WHERE namespace = ?`);
+  stmt.bind([NS]);
+  const out = new Map<string, string>();
+  while (stmt.step()) {
+    const row = stmt.getAsObject() as { key: string; id: string };
+    out.set(row.key, row.id);
+  }
+  stmt.free();
+  db.close();
+  return out;
+}
+
+describe('doc edit → re-index → sidecar reconciliation (#1384)', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true });
+  });
+
+  it('adds the appended section, retires the edited chunk, and leaves the rest untouched', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'moflo-1384-chain-'));
+    roots.push(root);
+    mkdirSync(join(root, MOFLO_DIR));
+    const dbPath = join(root, MOFLO_DIR, MEMORY_DB_FILE);
+    await createSchema(dbPath);
+
+    // ── Session 1: index the doc and embed it ────────────────────────────
+    await reindex(dbPath, [
+      { key: 'chunk-intro', content: 'intro' },
+      { key: 'chunk-body', content: 'body text' },
+      { key: 'chunk-outro', content: 'outro paragraph!' },
+    ]);
+    await embedMissing(dbPath);
+
+    const first = await syncHnswSidecar(dbPath, root, { dimensions: DIM });
+    expect(first.mode).toBe('full');
+    expect(first.vectorCount).toBe(3);
+
+    const before = await idsByKey(dbPath);
+
+    // ── Session 2: edit one section, append another ──────────────────────
+    const counts = await reindex(dbPath, [
+      { key: 'chunk-intro', content: 'intro' },                    // unchanged
+      { key: 'chunk-body', content: 'body text, revised again' },  // edited
+      { key: 'chunk-outro', content: 'outro paragraph!' },         // unchanged
+      { key: 'chunk-appendix', content: 'a freshly appended section' }, // new
+    ]);
+    expect(counts).toMatchObject({ inserted: 1, updated: 1, unchanged: 2, removed: 0 });
+
+    // The DB layer's laziness: only the edited + new chunks lost their vector.
+    const needEmbedding = await embedMissing(dbPath);
+    expect(needEmbedding).toHaveLength(2);
+
+    const after = await idsByKey(dbPath);
+    expect(after.get('chunk-intro')).toBe(before.get('chunk-intro'));
+    expect(after.get('chunk-outro')).toBe(before.get('chunk-outro'));
+    // The load-bearing detail — an edited chunk keeps its key but gets a new id.
+    expect(after.get('chunk-body')).not.toBe(before.get('chunk-body'));
+
+    // ── Reconcile ────────────────────────────────────────────────────────
+    const add = vi.spyOn(HnswLite.prototype, 'add');
+    const second = await syncHnswSidecar(dbPath, root, { dimensions: DIM });
+
+    expect(second.mode).toBe('incremental');
+    expect(second.added).toBe(2);   // revised body + appendix
+    expect(second.removed).toBe(1); // the retired body id
+    expect(add).toHaveBeenCalledTimes(2);
+    expect(second.vectorCount).toBe(4);
+
+    const graph = tryLoadHnswSidecar(root)!;
+    const live = new Set(graph.ids());
+    expect(live.has(before.get('chunk-body')!)).toBe(false); // no orphan
+    expect(live.has(after.get('chunk-body')!)).toBe(true);
+    expect(live.has(after.get('chunk-appendix')!)).toBe(true);
+    expect(live.has(after.get('chunk-intro')!)).toBe(true);
+    expect(live.has(after.get('chunk-outro')!)).toBe(true);
+
+    // The appended section is retrievable — it is genuinely in the graph, not
+    // merely counted.
+    const hits = graph.search(new Float32Array(vectorFor('a freshly appended section'.length)), 1);
+    expect(hits[0].id).toBe(after.get('chunk-appendix'));
+
+    // ── Session 3: nothing changed — no work, no write ───────────────────
+    const serialize = vi.spyOn(HnswLite.prototype, 'serialize');
+    const third = await syncHnswSidecar(dbPath, root, { dimensions: DIM });
+    expect(third.mode).toBe('unchanged');
+    expect(serialize).not.toHaveBeenCalled();
+  });
+
+  it('evicts every chunk of a doc that stopped being indexed', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'moflo-1384-chain-'));
+    roots.push(root);
+    mkdirSync(join(root, MOFLO_DIR));
+    const dbPath = join(root, MOFLO_DIR, MEMORY_DB_FILE);
+    await createSchema(dbPath);
+
+    await reindex(dbPath, [
+      { key: 'doc-a:1', content: 'alpha' },
+      { key: 'doc-b:1', content: 'beta chunk' },
+    ]);
+    await embedMissing(dbPath);
+    await syncHnswSidecar(dbPath, root, { dimensions: DIM });
+
+    // doc-b is deleted from the repo — the indexer stops producing its chunks.
+    await reindex(dbPath, [{ key: 'doc-a:1', content: 'alpha' }]);
+
+    const result = await syncHnswSidecar(dbPath, root, { dimensions: DIM });
+    expect(result.mode).toBe('incremental');
+    expect(result.added).toBe(0);
+    expect(result.removed).toBe(1);
+    expect(result.vectorCount).toBe(1);
+  });
+});

--- a/tests/bin/launcher-854-fixes.test.ts
+++ b/tests/bin/launcher-854-fixes.test.ts
@@ -134,7 +134,9 @@ describe('bin/build-embeddings.mjs — HNSW rebuild on the all-embedded fast pat
     expect(src).toMatch(/async\s+function\s+ensureHnswSidecar\s*\(/);
     const fn = src.match(/async\s+function\s+ensureHnswSidecar\s*\([^)]*\)\s*\{[\s\S]*?\n\}/);
     expect(fn, 'ensureHnswSidecar must exist').toBeTruthy();
-    expect(fn![0]).toMatch(/buildAndWriteHnswSidecar\(/);
+    // #1384 replaced the unconditional rebuild with reconciliation; the
+    // helper still converges the sidecar, it just no longer reconstructs it.
+    expect(fn![0]).toMatch(/syncHnswSidecar\(/);
     expect(fn![0]).toMatch(/existsSync\([^)]*hnswIndexPath\(/);
   });
 
@@ -159,12 +161,15 @@ describe('bin/build-embeddings.mjs — HNSW rebuild on the all-embedded fast pat
     expect(idxCache, 'writeVectorStatsCache must run after the HNSW build').toBeGreaterThan(idxBuild);
   });
 
-  it('post-embedding finalize calls ensureHnswSidecar with alwaysRebuild', () => {
-    // After embedding generation, freshly-embedded rows invalidate the
-    // existing sidecar, so the post-embedding path must force a rebuild
-    // (not just rebuild-if-missing). The early-return path uses the
-    // default rebuild-if-missing semantic.
-    expect(src).toMatch(/ensureHnswSidecar\(\s*stats\s*,\s*\{\s*alwaysRebuild:\s*true\s*\}/);
+  it('post-embedding finalize never forces a wholesale rebuild (#1384)', () => {
+    // #854 made this path pass `{ alwaysRebuild: true }` on the premise that
+    // freshly-embedded rows invalidate the sidecar. They don't — they need to
+    // be ADDED to it. Because `HnswLite.add()` scans every existing vector,
+    // that premise turned "embed one row" into a re-index of the whole store.
+    // The convergence #854 wanted survives via syncHnswSidecar; the
+    // reconstruction does not.
+    expect(src).not.toMatch(/alwaysRebuild/);
+    expect(src).toMatch(/await\s+ensureHnswSidecar\(stats\)/);
   });
 });
 


### PR DESCRIPTION
Fixes #1384.

## What was wrong

`bin/build-embeddings.mjs` ended every run that embedded at least one row with `ensureHnswSidecar(stats, { alwaysRebuild: true })`. `buildAndWriteHnswSidecar` then allocated a fresh `HnswLite` and re-inserted **every** active row carrying an embedding.

`HnswLite.add()` calls `findNearest()` → `bruteForce()`, which scans every vector already in the graph. So construction is quadratic, and embedding one new chunk re-indexed the entire store.

The comment justifying it — *"Newly-embedded rows invalidate the existing sidecar"* — had the premise backwards. New rows don't invalidate the graph; they need to be **added** to it.

Underneath that, a second defect the rebuild was masking: nothing ever removed vectors for rows that had gone away. `applyIncrementalChunks` gives an **edited chunk a brand-new id** while keeping its key, and the sidecar is keyed by id — so every edit orphaned a vector, and every deleted doc orphaned its whole set. Discarding the graph each run hid it. Fixing the cost without fixing that would have turned a slow path into a wrong one.

## What this does

`syncHnswSidecar()` applies the difference instead of reconstructing:

| state | action |
|---|---|
| in DB with an embedding, absent from the graph | `add` |
| in the graph, gone from the DB (deleted, or embedding cleared) | `remove` |
| in both, same vector | untouched — this is the laziness |

Only the ids being added have their embeddings read and decoded at all.

### Why an id diff alone isn't enough

Several writers replace a row's embedding **in place under the same id** — `bridgeAddToHNSW`, the embeddings migration's `updateBatch`, and `build-embeddings`' `updateEmbedding` after a `strip-context-preambles`-style NULL-out. An id-only diff calls those "already indexed" and keeps serving the superseded vector indefinitely.

So the sidecar is paired with `.moflo/hnsw.manifest.json` recording a per-id stamp of `updated_at` + `length(embedding)` + the embedding's leading 64 characters. That is derived from the row itself, so it needs no cooperation from writers — an `updated_at`-only stamp would silently miss `sqljs-migration-store.updateBatch`, which doesn't bump it. Reading whole embeddings back to hash them properly was rejected: it reintroduces a per-session cost proportional to store size, which is the problem being fixed. The residual hole is stated in the source: a replacement vector matching its predecessor's `updated_at`, total length, *and* leading ~7 floats.

The manifest is written **after** the sidecar, so a crash between the two leaves a manifest that no longer describes the graph — caught by the id-set cross-check and healed with one full rebuild.

### When a full rebuild still happens

`--force`, and only these otherwise, each logging its reason: no sidecar, unreadable sidecar, missing or corrupt manifest, manifest not matching the graph, changed dimensions/metric/m/efConstruction.

`flo memory rebuild-index` moves to the same path (`--force` still rebuilds). It runs immediately after `build-embeddings` in the session-start chain and both write the sidecar, so leaving either on the wholesale path would have undone the other's fix.

Rows dropped for malformed or wrong-dimension embeddings are now **named** in the warning and returned on the result, rather than counted.

## Measured

On this repo's real store, 5,310 vectors:

```
first run after upgrade   19.4s   full rebuild — manifest absent
nothing changed            0.07s
one newly embedded row     0.11s  (was 19.4s)
--force                    19.2s
```

Consumers pay exactly one full rebuild on upgrade, when the manifest is first written.

## Consumer impact

- **Surface touched** — `bin/build-embeddings.mjs` + its `.claude/scripts/` twin (session-start chain, every consumer), `flo memory rebuild-index`, and `src/cli/memory/hnsw-persistence.ts` in `dist/`.
- **Failure mode for an on-version consumer** — none. `.moflo/` state still parses; the new manifest is additive and its absence is a recognised rebuild reason. `buildAndWriteHnswSidecar` keeps its signature and behaviour, so `memory/index.ts` re-exports and any external caller are unaffected.
- **Round-trip** — runtime fix, needs publish + reinstall to take effect in a dogfooding checkout.
- `buildAndWriteHnswSidecar` now reads `updated_at`, which is part of `MEMORY_SCHEMA_V3` and already written by every embedding writer.

## Reviewer findings applied

- Stamp SQL and formatting were defined twice — collapsed to one `STAMP_COLUMNS` / `stampOf` pair.
- A row deleted between the stamp read and the embedding read was misreported as malformed — now distinguished from a parse failure and evicted quietly.
- The `updated_at` component was added to the stamp as a second independent discriminator, in response to the collision note.
- Efficiency review flagged that both chain steps run a full reconciliation pass even when nothing changed. Real, but measured at 0.07s each on 5,310 vectors and O(n) with a small constant rather than O(n² log n) — a timestamp-based short-circuit would reintroduce exactly the WAL-mtime fragility #1383 is about, so it was left alone deliberately.

## Tests

23 new tests — `src/cli/__tests__/memory/hnsw-sidecar-sync.test.ts` (laziness, completeness, every rebuild reason, malformed-row reporting) and `tests/bin/hnsw-sidecar-doc-edit-chain.test.ts`, which drives the real `applyIncrementalChunks` writer through index → edit + append → re-index → reconcile.

`tests/bin/launcher-854-fixes.test.ts` flips: the assertion that the post-embedding path passes `alwaysRebuild: true` becomes an assertion that nothing does. #854's actual goal — the sidecar converging on the all-embedded fast path — is unchanged and still pinned.

Full suite: 10,329 passed, 0 failed. Lint clean.

## Out of scope

The quadratic construction still applies to a genuine full rebuild. Making `findNearest` use the graph rather than a brute-force scan would fix it, but it changes recall characteristics and belongs in its own change.

#1383 is unblocked by this and can now gate `build-embeddings` on the actual DB condition without a full reconstruction per session.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)
