### PR TITLE
fix(indexer): gate build-embeddings on the backlog, not moflo.db mtime (#1383)

### DIFF
--- a/.claude/scripts/build-embeddings.mjs
+++ b/.claude/scripts/build-embeddings.mjs
@@ -20,6 +20,7 @@ import { existsSync, readFileSync } from 'fs';
 import { mofloInternalURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, hnswIndexPath, findProjectRoot } from './lib/moflo-paths.mjs';
 import { openBackend } from './lib/get-backend.mjs';
+import { PENDING_EMBEDDING_WHERE } from './lib/embedding-backlog.mjs';
 const FASTEMBED_INLINE = 'dist/src/cli/embeddings/fastembed-inline/index.js';
 const BRIDGE_CORE = 'dist/src/cli/memory/bridge-core.js';
 const HNSW_PERSISTENCE = 'dist/src/cli/memory/hnsw-persistence.js';
@@ -96,13 +97,17 @@ function saveDb(db) {
   db.save();
 }
 
+// The backlog clause is imported, not restated (#1383): the indexer gate asks
+// this exact question to decide whether to run this script at all, and a gate
+// that approximates its step's own query is how new chunks got left unembedded
+// in the first place. `PENDING_EMBEDDING_WHERE` already carries `status =
+// 'active'`, so the non-forced branch below replaces the base clause rather
+// than appending to it.
 function getEntriesNeedingEmbeddings(db, namespace, forceAll) {
-  let sql = `SELECT id, key, namespace, content FROM memory_entries WHERE status = 'active'`;
+  let sql = `SELECT id, key, namespace, content FROM memory_entries WHERE `
+    + (forceAll ? `status = 'active'` : PENDING_EMBEDDING_WHERE);
   const params = [];
 
-  if (!forceAll) {
-    sql += ` AND (embedding IS NULL OR embedding = '')`;
-  }
   if (namespace) {
     sql += ` AND namespace = ?`;
     params.push(namespace);

--- a/.claude/scripts/lib/embedding-backlog.mjs
+++ b/.claude/scripts/lib/embedding-backlog.mjs
@@ -1,0 +1,88 @@
+/**
+ * The embedding backlog predicate — shared by the producer and its gate.
+ *
+ * Background — issue #1383: `build-embeddings` was gated on the mtime of
+ * `.moflo/moflo.db`. That database runs in WAL mode, so the rows the indexer
+ * writes land in `moflo.db-wal` and leave `moflo.db`'s mtime untouched. The
+ * gate read "unchanged" and skipped the step that embeds rows written seconds
+ * earlier in the same chain, leaving chunks with `embedding IS NULL` — present
+ * in `memory_entries`, invisible to `memory_search`, with no signal at
+ * authoring time. Recovery happened only when a WAL checkpoint incidentally
+ * bumped the main file's mtime.
+ *
+ * The fix is to stop proxying. "Does this step have work?" has an exact,
+ * cheap answer in the database, and {@link hasPendingEmbeddings} asks it.
+ *
+ * The load-bearing property is that {@link PENDING_EMBEDDING_WHERE} is the
+ * SAME predicate `build-embeddings.mjs` selects on. A gate that approximates
+ * its step's own query is how #1383 happened; if the two ever drift, the gate
+ * starts lying again in whichever direction the drift goes. Import the
+ * constant — do not restate the clause.
+ *
+ * @module bin/lib/embedding-backlog
+ */
+
+import { existsSync } from 'node:fs';
+import { openBackendSync } from './get-backend.mjs';
+import { memoryDbPath } from './moflo-paths.mjs';
+
+/**
+ * Rows `build-embeddings` will pick up on its next run. Active rows whose
+ * embedding is absent — either NULL (never written) or empty string (a
+ * producer that failed and wrote a placeholder).
+ */
+export const PENDING_EMBEDDING_WHERE =
+  `status = 'active' AND (embedding IS NULL OR embedding = '')`;
+
+/**
+ * Does the memory DB hold rows that still need embedding?
+ *
+ * Returns `null` — deliberately distinct from `false` — when the question
+ * cannot be answered: no DB yet, an unreadable file, a pre-`memory_entries`
+ * schema. Callers MUST treat `null` as "don't know" and fall back to their
+ * other signals rather than reading it as "no work", because a probe that
+ * degrades to `false` on error reintroduces exactly the silent skip #1383 is
+ * about.
+ *
+ * Cost. `EXISTS` short-circuits on the first match, so a store WITH a backlog
+ * answers almost immediately. The empty case — the steady state — has no index
+ * to use and scans the active rows. Measured on real stores: 12ms at 5.3k rows,
+ * 70ms at 32k, i.e. ~2.2µs/row, so a 100k-row consumer pays roughly 200ms.
+ * That is affordable because `decideStepGate` calls this only after the
+ * fingerprint has already decided to SKIP — the sessions that were going to
+ * run the step anyway never pay it — and at most once per session.
+ *
+ * Not namespace-scoped: `build-embeddings --namespace X` would embed a subset,
+ * but the probe answers for the whole store. That can only over-trigger, which
+ * the caller's contract permits.
+ *
+ * @param {string} projectRoot
+ * @param {{ dbPath?: string }} [opts]
+ * @returns {boolean | null}
+ */
+export function hasPendingEmbeddings(projectRoot, opts = {}) {
+  const dbPath = opts.dbPath || memoryDbPath(projectRoot);
+  if (!existsSync(dbPath)) return null;
+
+  let db;
+  try {
+    db = openBackendSync(projectRoot, { dbPath, readOnly: true });
+  } catch {
+    return null;
+  }
+
+  try {
+    const rows = db.exec(
+      `SELECT EXISTS(SELECT 1 FROM memory_entries WHERE ${PENDING_EMBEDDING_WHERE}) AS pending`,
+    );
+    const value = rows?.[0]?.values?.[0]?.[0];
+    if (value === undefined || value === null) return null;
+    return Number(value) > 0;
+  } catch {
+    // Missing table / older schema / concurrent writer holding a lock past the
+    // busy timeout — all "don't know", never "no work".
+    return null;
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+}

--- a/.claude/scripts/lib/embedding-backlog.mjs
+++ b/.claude/scripts/lib/embedding-backlog.mjs
@@ -31,6 +31,9 @@ import { memoryDbPath } from './moflo-paths.mjs';
  * embedding is absent — either NULL (never written) or empty string (a
  * producer that failed and wrote a placeholder).
  */
+/** Retry budget for the probe's read-only open. See {@link hasPendingEmbeddings}. */
+const PROBE_BUSY_TIMEOUT_MS = 2000;
+
 export const PENDING_EMBEDDING_WHERE =
   `status = 'active' AND (embedding IS NULL OR embedding = '')`;
 
@@ -66,7 +69,12 @@ export function hasPendingEmbeddings(projectRoot, opts = {}) {
 
   let db;
   try {
-    db = openBackendSync(projectRoot, { dbPath, readOnly: true });
+    // A small retry budget, not the writer's 15s. The probe races a live
+    // daemon often enough that failing instantly would answer `null` at the
+    // moment it matters most, but it sits in the session-start critical path
+    // and the fingerprint backstops a `null` — so it waits a beat, not a
+    // quarter of a minute.
+    db = openBackendSync(projectRoot, { dbPath, readOnly: true, busyTimeoutMs: PROBE_BUSY_TIMEOUT_MS });
   } catch {
     return null;
   }

--- a/.claude/scripts/lib/get-backend.mjs
+++ b/.claude/scripts/lib/get-backend.mjs
@@ -100,7 +100,10 @@ export async function openBackend(projectRoot, opts = {}) {
  * TS twin stays obvious.
  *
  * @param {string} projectRoot
- * @param {{ backend?: 'node-sqlite', create?: boolean, readOnly?: boolean, dbPath?: string }} [opts]
+ * @param {{ backend?: 'node-sqlite', create?: boolean, readOnly?: boolean,
+ *           dbPath?: string, busyTimeoutMs?: number }} [opts]
+ *   `busyTimeoutMs` applies to READ-ONLY opens only (writers always get the
+ *   15s WAL-trinity budget). Omit it to fail fast on contention.
  * @returns {object} backend handle (see module doc)
  */
 export function openBackendSync(projectRoot, opts = {}) {
@@ -127,16 +130,23 @@ function openNodeSqlite(dbPath, opts) {
   const readOnly = opts.readOnly === true;
   const db = new DatabaseSync(dbPath, { readOnly });
   if (readOnly) {
-    // A read-only handle skips the WAL trinity (it cannot change journal mode)
-    // but still needs the retry budget. Without it a reader that lands while
-    // another process briefly holds the EXCLUSIVE lock `journal_mode=WAL`
-    // takes (#1097) gets an immediate SQLITE_BUSY and its caller degrades to
-    // "cannot tell" — and a live daemon writing is exactly when a read-only
-    // probe is most worth answering.
-    try {
-      db.exec('PRAGMA busy_timeout = 15000');
-    } catch {
-      // Non-fatal: the handle is still usable, just without a retry budget.
+    // A read-only handle skips the WAL trinity (it cannot change journal
+    // mode). It gets a retry budget ONLY when the caller asks for one.
+    //
+    // Applying the writer's 15s budget to every read-only open would be a
+    // silent behaviour change for the readers that already exist —
+    // `session-continuity.mjs` and `semantic-search.mjs` both open read-only
+    // inside the session-start chain, and both are written to fail fast and
+    // degrade. Turning an instant SQLITE_BUSY into a 15-second block for
+    // them serialises the chain behind whatever holds the lock. Opt in, with
+    // a budget sized to the caller's own patience.
+    const budget = Number(opts.busyTimeoutMs) || 0;
+    if (budget > 0) {
+      try {
+        db.exec(`PRAGMA busy_timeout = ${Math.floor(budget)}`);
+      } catch {
+        // Non-fatal: the handle is still usable, just without a retry budget.
+      }
     }
   } else {
     // Close the handle on any PRAGMA failure — node:sqlite opens forgivingly

--- a/.claude/scripts/lib/get-backend.mjs
+++ b/.claude/scripts/lib/get-backend.mjs
@@ -32,7 +32,20 @@ import './suppress-sqlite-warning.mjs';
 
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { createRequire } from 'node:module';
 import { memoryDbPath } from './moflo-paths.mjs';
+
+// `node:sqlite` is loaded lazily so importing this module stays cheap for the
+// scripts that only want `memoryDbPath`/`resolveBackend`. `createRequire` — not
+// `await import` — because {@link openBackendSync} must stay synchronous: the
+// per-step indexer gate (`index-fingerprint.decideStepGate`) is called from a
+// sync decision path and needs a real DB read, not a promise.
+const requireBuiltin = createRequire(import.meta.url);
+let _DatabaseSync = null;
+function databaseSyncCtor() {
+  if (_DatabaseSync === null) _DatabaseSync = requireBuiltin('node:sqlite').DatabaseSync;
+  return _DatabaseSync;
+}
 
 export const BACKEND_NODE_SQLITE = 'node-sqlite';
 
@@ -76,9 +89,27 @@ function ensureDir(filePath) {
  * @returns {Promise<object>} backend handle (see module doc)
  */
 export async function openBackend(projectRoot, opts = {}) {
+  return openBackendSync(projectRoot, opts);
+}
+
+/**
+ * Synchronous face of {@link openBackend}. Same implementation, same pragmas —
+ * `openBackend` is retained as an async wrapper only because every existing
+ * caller awaits it. Use this one from code that cannot await (the per-step
+ * indexer gate); prefer `openBackend` everywhere else so the diff against the
+ * TS twin stays obvious.
+ *
+ * @param {string} projectRoot
+ * @param {{ backend?: 'node-sqlite', create?: boolean, readOnly?: boolean, dbPath?: string }} [opts]
+ * @returns {object} backend handle (see module doc)
+ */
+export function openBackendSync(projectRoot, opts = {}) {
   const dbPath = opts.dbPath || memoryDbPath(projectRoot);
   resolveBackend(opts); // throws on stale sql.js callers
-  ensureDir(dbPath);
+  // A read-only open must never materialise state: the indexer gate probes for
+  // a DB that may legitimately not exist yet, and creating `.moflo/` from a
+  // gate would be a side effect of asking a question.
+  if (opts.readOnly !== true) ensureDir(dbPath);
   return openNodeSqlite(dbPath, opts);
 }
 
@@ -91,11 +122,23 @@ export async function openBackend(projectRoot, opts = {}) {
 // we don't want N copies of the same message in one session.
 const _networkFsWarnedPaths = new Set();
 
-async function openNodeSqlite(dbPath, opts) {
-  const { DatabaseSync } = await import('node:sqlite');
+function openNodeSqlite(dbPath, opts) {
+  const DatabaseSync = databaseSyncCtor();
   const readOnly = opts.readOnly === true;
   const db = new DatabaseSync(dbPath, { readOnly });
-  if (!readOnly) {
+  if (readOnly) {
+    // A read-only handle skips the WAL trinity (it cannot change journal mode)
+    // but still needs the retry budget. Without it a reader that lands while
+    // another process briefly holds the EXCLUSIVE lock `journal_mode=WAL`
+    // takes (#1097) gets an immediate SQLITE_BUSY and its caller degrades to
+    // "cannot tell" — and a live daemon writing is exactly when a read-only
+    // probe is most worth answering.
+    try {
+      db.exec('PRAGMA busy_timeout = 15000');
+    } catch {
+      // Non-fatal: the handle is still usable, just without a retry budget.
+    }
+  } else {
     // Close the handle on any PRAGMA failure — node:sqlite opens forgivingly
     // (even non-SQLite files succeed in the constructor) and a PRAGMA that
     // throws later would otherwise leak the file handle across processes

--- a/.claude/scripts/lib/index-fingerprint.mjs
+++ b/.claude/scripts/lib/index-fingerprint.mjs
@@ -21,6 +21,13 @@
  * Bumping FINGERPRINT_VERSION invalidates older payloads (graceful migration
  * — first session post-upgrade runs every step once, then steady state).
  *
+ * Issue #1383 added a second, stronger signal for steps that can state their
+ * own precondition exactly: a work probe (see STEP_WORK_PROBES). A fingerprint
+ * answers "did the inputs change?"; a probe answers "is there work?". Where
+ * both exist the probe wins, because the failure it prevents — skipping a step
+ * that demonstrably had something to do — is silent and cumulative, while the
+ * failure it risks is one cheap redundant run.
+ *
  * Override: set `FLO_FORCE_INDEX=1` to bypass every gate (`flo doctor --fix`).
  *
  * Failure posture: any compute / read error returns null and forces the
@@ -40,6 +47,7 @@ import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { MOFLO_DIR, mofloDir, memoryDbPath, hnswIndexPath } from './moflo-paths.mjs';
 import { resolveGuidanceDirs } from './guidance-config.mjs';
+import { hasPendingEmbeddings } from './embedding-backlog.mjs';
 
 export const FINGERPRINT_FILE_NAME = 'index-step-fingerprints.json';
 export const LEGACY_FINGERPRINT_FILE_NAME = 'index-all-fingerprint.json';
@@ -60,6 +68,24 @@ function legacyFingerprintFilePath(projectRoot) {
 
 function safeMtime(path) {
   try { return statSync(path).mtimeMs; } catch { return 0; }
+}
+
+/**
+ * Newest mtime across the SQLite file set — main DB plus its write-ahead log.
+ *
+ * `moflo.db` alone is not a change signal (#1383): under `journal_mode=WAL`
+ * every row write lands in `moflo.db-wal` and the main file's mtime does not
+ * move until a checkpoint folds the log back in. A gate stat'ing only the
+ * main file therefore reports "unchanged" for writes that happened seconds
+ * ago — which is how newly-indexed chunks got left unembedded.
+ *
+ * `-shm` is deliberately excluded: it is shared memory for the WAL index and
+ * READERS touch it, so folding it in would invalidate the fingerprint on
+ * sessions that only read the DB and re-run the step forever.
+ */
+function newestDbMtime(projectRoot) {
+  const db = memoryDbPath(projectRoot);
+  return Math.max(safeMtime(db), safeMtime(`${db}-wal`));
 }
 
 // Lockfiles across the common JS package managers. Any install/upgrade rewrites
@@ -202,23 +228,57 @@ const STEP_FINGERPRINT_COMPUTERS = {
 
   'pretrain':       (projectRoot) => ({ sourceList: gitFileListHash(projectRoot, SOURCE_GLOBS) }),
 
-  // memory.db mtime is a coarse proxy for "rows that need embedding". It
-  // self-bumps when build-embeddings writes back: first post-upgrade session
-  // runs the step, the bump is captured into the POST fingerprint, equilibrium
-  // reached on the next session. Imprecise (mtime can bump without new
-  // NULL-embedding rows) but cheap; the step is a no-op on empty input.
+  // The DB mtime is only a secondary signal here — the authoritative one is
+  // the work probe below, which asks the database directly whether any row
+  // still needs embedding. The fingerprint remains so the step still refreshes
+  // its derived artifacts (vector-stats cache, sidecar) when the store changed
+  // but the backlog is empty.
+  //
+  // `dbFiles` (not `memoryDb`) both names what is actually stat'd and
+  // guarantees a mismatch against payloads written before #1383, so the first
+  // session after upgrade re-runs these two steps once and settles.
   'build-embeddings': (projectRoot) => ({
-    memoryDb: safeMtime(memoryDbPath(projectRoot)),
+    dbFiles: newestDbMtime(projectRoot),
   }),
 
-  // HNSW sidecar must be at least as fresh as memory.db. Tracking both mtimes
-  // means: sidecar deleted → mtime=0 → mismatch → run. memory.db newer than
-  // last-rebuild → mismatch → run. After a successful rebuild, the saved pair
+  // HNSW sidecar must be at least as fresh as the store. Tracking both means:
+  // sidecar deleted → mtime=0 → mismatch → run. Store written since the last
+  // rebuild → mismatch → run. After a successful rebuild the saved pair
   // captures the post-rebuild equilibrium.
+  //
+  // This step shared #1383's WAL blind spot: embeddings written into the WAL
+  // did not move `moflo.db`, so the sidecar was not resynced either and the
+  // new vectors stayed unsearchable even once they existed. `newestDbMtime`
+  // fixes both steps at once.
+  //
+  // The cost is that ANY write to the store now invalidates this step, so it
+  // runs far more often — every session with memory activity, in practice.
+  // That is affordable only because #1384 made the sidecar reconcile
+  // incrementally instead of rebuilding: measured on a 5,310-vector store, a
+  // no-change reconciliation is 0.07s versus 19.4s for the full rebuild this
+  // step used to perform. This change MUST NOT ship ahead of that one.
   'hnsw-rebuild': (projectRoot) => ({
-    memoryDb: safeMtime(memoryDbPath(projectRoot)),
-    sidecar:  safeMtime(hnswIndexPath(projectRoot)),
+    dbFiles: newestDbMtime(projectRoot),
+    sidecar: safeMtime(hnswIndexPath(projectRoot)),
   }),
+};
+
+/**
+ * Per-step "is there work?" probes — the exact condition a step exists to
+ * satisfy, asked of the real state rather than inferred from a file mtime.
+ *
+ * A probe returns `true` (work pending → run, no matter what the fingerprint
+ * says), `false` (no backlog → the fingerprint decides, since the step still
+ * refreshes derived artifacts), or `null` (unknowable → the fingerprint
+ * decides). Steps with no probe are fingerprint-only.
+ *
+ * A probe may only ever FORCE a run, never suppress one. That asymmetry is
+ * the point: an over-eager probe costs one cheap no-op run, whereas a probe
+ * trusted to veto would resurrect #1383's silent skip the moment it was
+ * wrong about the state.
+ */
+const STEP_WORK_PROBES = {
+  'build-embeddings': hasPendingEmbeddings,
 };
 
 /**
@@ -283,14 +343,35 @@ export function saveStepFingerprint(stepName, projectRoot, fp) {
 }
 
 /**
+ * Ask a step's work probe whether it has pending work. Any throw is swallowed
+ * to `null` — a gate must never be the thing that breaks session start.
+ *
+ * @returns {boolean | null}
+ */
+export function probeStepWork(stepName, projectRoot) {
+  const probe = STEP_WORK_PROBES[stepName];
+  if (!probe) return null;
+  try {
+    return probe(projectRoot);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Decide whether `stepName` needs to run. Returns one of:
  *   { skip: true,  reason: 'unchanged' }
- *   { skip: false, reason: 'forced' | 'no-saved-fingerprint' | 'inputs-changed' }
+ *   { skip: false, reason: 'forced' | 'work-pending' | 'no-saved-fingerprint' | 'inputs-changed' }
  *
  * The orchestrator computes a POST-run fingerprint after each successful run
  * and saves THAT — not the pre-run one — so steps that mutate the inputs they
- * gate on (e.g. build-embeddings bumping memory.db mtime) reach a stable
+ * gate on (e.g. build-embeddings writing embeddings back) reach a stable
  * equilibrium on the next session.
+ *
+ * `work-pending` is checked before the fingerprint and is not overridable by
+ * it (#1383). A step whose backlog is non-empty runs, full stop — the
+ * fingerprint's job is deciding when to run a step that has *nothing* obvious
+ * to do, and it is not allowed to answer a question the state answers exactly.
  */
 export function decideStepGate(stepName, projectRoot, env = process.env) {
   if (env[FORCE_ENV]) {
@@ -299,8 +380,18 @@ export function decideStepGate(stepName, projectRoot, env = process.env) {
   const current = computeStepFingerprint(stepName, projectRoot);
   const saved = readSavedStepFingerprint(stepName, projectRoot);
   if (!saved) return { skip: false, reason: 'no-saved-fingerprint' };
-  if (fingerprintsEqual(current, saved)) return { skip: true, reason: 'unchanged' };
-  return { skip: false, reason: 'inputs-changed' };
+  if (!fingerprintsEqual(current, saved)) return { skip: false, reason: 'inputs-changed' };
+
+  // The fingerprint says skip. That is exactly — and only — where #1383 went
+  // wrong, so this is where the state gets consulted. Probing last also keeps
+  // it off the hot path: the query runs on quiet sessions, not on the ones
+  // that were already going to do the work, and the fingerprint has been read
+  // before the probe's read-only open materialises `-wal`/`-shm`, so the
+  // probe cannot register its own side effect as an input change.
+  if (probeStepWork(stepName, projectRoot) === true) {
+    return { skip: false, reason: 'work-pending' };
+  }
+  return { skip: true, reason: 'unchanged' };
 }
 
 /**

--- a/bin/build-embeddings.mjs
+++ b/bin/build-embeddings.mjs
@@ -20,6 +20,7 @@ import { existsSync, readFileSync } from 'fs';
 import { mofloInternalURL } from './lib/moflo-resolve.mjs';
 import { memoryDbPath, hnswIndexPath, findProjectRoot } from './lib/moflo-paths.mjs';
 import { openBackend } from './lib/get-backend.mjs';
+import { PENDING_EMBEDDING_WHERE } from './lib/embedding-backlog.mjs';
 const FASTEMBED_INLINE = 'dist/src/cli/embeddings/fastembed-inline/index.js';
 const BRIDGE_CORE = 'dist/src/cli/memory/bridge-core.js';
 const HNSW_PERSISTENCE = 'dist/src/cli/memory/hnsw-persistence.js';
@@ -96,13 +97,17 @@ function saveDb(db) {
   db.save();
 }
 
+// The backlog clause is imported, not restated (#1383): the indexer gate asks
+// this exact question to decide whether to run this script at all, and a gate
+// that approximates its step's own query is how new chunks got left unembedded
+// in the first place. `PENDING_EMBEDDING_WHERE` already carries `status =
+// 'active'`, so the non-forced branch below replaces the base clause rather
+// than appending to it.
 function getEntriesNeedingEmbeddings(db, namespace, forceAll) {
-  let sql = `SELECT id, key, namespace, content FROM memory_entries WHERE status = 'active'`;
+  let sql = `SELECT id, key, namespace, content FROM memory_entries WHERE `
+    + (forceAll ? `status = 'active'` : PENDING_EMBEDDING_WHERE);
   const params = [];
 
-  if (!forceAll) {
-    sql += ` AND (embedding IS NULL OR embedding = '')`;
-  }
   if (namespace) {
     sql += ` AND namespace = ?`;
     params.push(namespace);

--- a/bin/lib/embedding-backlog.mjs
+++ b/bin/lib/embedding-backlog.mjs
@@ -1,0 +1,88 @@
+/**
+ * The embedding backlog predicate — shared by the producer and its gate.
+ *
+ * Background — issue #1383: `build-embeddings` was gated on the mtime of
+ * `.moflo/moflo.db`. That database runs in WAL mode, so the rows the indexer
+ * writes land in `moflo.db-wal` and leave `moflo.db`'s mtime untouched. The
+ * gate read "unchanged" and skipped the step that embeds rows written seconds
+ * earlier in the same chain, leaving chunks with `embedding IS NULL` — present
+ * in `memory_entries`, invisible to `memory_search`, with no signal at
+ * authoring time. Recovery happened only when a WAL checkpoint incidentally
+ * bumped the main file's mtime.
+ *
+ * The fix is to stop proxying. "Does this step have work?" has an exact,
+ * cheap answer in the database, and {@link hasPendingEmbeddings} asks it.
+ *
+ * The load-bearing property is that {@link PENDING_EMBEDDING_WHERE} is the
+ * SAME predicate `build-embeddings.mjs` selects on. A gate that approximates
+ * its step's own query is how #1383 happened; if the two ever drift, the gate
+ * starts lying again in whichever direction the drift goes. Import the
+ * constant — do not restate the clause.
+ *
+ * @module bin/lib/embedding-backlog
+ */
+
+import { existsSync } from 'node:fs';
+import { openBackendSync } from './get-backend.mjs';
+import { memoryDbPath } from './moflo-paths.mjs';
+
+/**
+ * Rows `build-embeddings` will pick up on its next run. Active rows whose
+ * embedding is absent — either NULL (never written) or empty string (a
+ * producer that failed and wrote a placeholder).
+ */
+export const PENDING_EMBEDDING_WHERE =
+  `status = 'active' AND (embedding IS NULL OR embedding = '')`;
+
+/**
+ * Does the memory DB hold rows that still need embedding?
+ *
+ * Returns `null` — deliberately distinct from `false` — when the question
+ * cannot be answered: no DB yet, an unreadable file, a pre-`memory_entries`
+ * schema. Callers MUST treat `null` as "don't know" and fall back to their
+ * other signals rather than reading it as "no work", because a probe that
+ * degrades to `false` on error reintroduces exactly the silent skip #1383 is
+ * about.
+ *
+ * Cost. `EXISTS` short-circuits on the first match, so a store WITH a backlog
+ * answers almost immediately. The empty case — the steady state — has no index
+ * to use and scans the active rows. Measured on real stores: 12ms at 5.3k rows,
+ * 70ms at 32k, i.e. ~2.2µs/row, so a 100k-row consumer pays roughly 200ms.
+ * That is affordable because `decideStepGate` calls this only after the
+ * fingerprint has already decided to SKIP — the sessions that were going to
+ * run the step anyway never pay it — and at most once per session.
+ *
+ * Not namespace-scoped: `build-embeddings --namespace X` would embed a subset,
+ * but the probe answers for the whole store. That can only over-trigger, which
+ * the caller's contract permits.
+ *
+ * @param {string} projectRoot
+ * @param {{ dbPath?: string }} [opts]
+ * @returns {boolean | null}
+ */
+export function hasPendingEmbeddings(projectRoot, opts = {}) {
+  const dbPath = opts.dbPath || memoryDbPath(projectRoot);
+  if (!existsSync(dbPath)) return null;
+
+  let db;
+  try {
+    db = openBackendSync(projectRoot, { dbPath, readOnly: true });
+  } catch {
+    return null;
+  }
+
+  try {
+    const rows = db.exec(
+      `SELECT EXISTS(SELECT 1 FROM memory_entries WHERE ${PENDING_EMBEDDING_WHERE}) AS pending`,
+    );
+    const value = rows?.[0]?.values?.[0]?.[0];
+    if (value === undefined || value === null) return null;
+    return Number(value) > 0;
+  } catch {
+    // Missing table / older schema / concurrent writer holding a lock past the
+    // busy timeout — all "don't know", never "no work".
+    return null;
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+}

--- a/bin/lib/embedding-backlog.mjs
+++ b/bin/lib/embedding-backlog.mjs
@@ -31,6 +31,9 @@ import { memoryDbPath } from './moflo-paths.mjs';
  * embedding is absent — either NULL (never written) or empty string (a
  * producer that failed and wrote a placeholder).
  */
+/** Retry budget for the probe's read-only open. See {@link hasPendingEmbeddings}. */
+const PROBE_BUSY_TIMEOUT_MS = 2000;
+
 export const PENDING_EMBEDDING_WHERE =
   `status = 'active' AND (embedding IS NULL OR embedding = '')`;
 
@@ -66,7 +69,12 @@ export function hasPendingEmbeddings(projectRoot, opts = {}) {
 
   let db;
   try {
-    db = openBackendSync(projectRoot, { dbPath, readOnly: true });
+    // A small retry budget, not the writer's 15s. The probe races a live
+    // daemon often enough that failing instantly would answer `null` at the
+    // moment it matters most, but it sits in the session-start critical path
+    // and the fingerprint backstops a `null` — so it waits a beat, not a
+    // quarter of a minute.
+    db = openBackendSync(projectRoot, { dbPath, readOnly: true, busyTimeoutMs: PROBE_BUSY_TIMEOUT_MS });
   } catch {
     return null;
   }

--- a/bin/lib/get-backend.mjs
+++ b/bin/lib/get-backend.mjs
@@ -100,7 +100,10 @@ export async function openBackend(projectRoot, opts = {}) {
  * TS twin stays obvious.
  *
  * @param {string} projectRoot
- * @param {{ backend?: 'node-sqlite', create?: boolean, readOnly?: boolean, dbPath?: string }} [opts]
+ * @param {{ backend?: 'node-sqlite', create?: boolean, readOnly?: boolean,
+ *           dbPath?: string, busyTimeoutMs?: number }} [opts]
+ *   `busyTimeoutMs` applies to READ-ONLY opens only (writers always get the
+ *   15s WAL-trinity budget). Omit it to fail fast on contention.
  * @returns {object} backend handle (see module doc)
  */
 export function openBackendSync(projectRoot, opts = {}) {
@@ -127,16 +130,23 @@ function openNodeSqlite(dbPath, opts) {
   const readOnly = opts.readOnly === true;
   const db = new DatabaseSync(dbPath, { readOnly });
   if (readOnly) {
-    // A read-only handle skips the WAL trinity (it cannot change journal mode)
-    // but still needs the retry budget. Without it a reader that lands while
-    // another process briefly holds the EXCLUSIVE lock `journal_mode=WAL`
-    // takes (#1097) gets an immediate SQLITE_BUSY and its caller degrades to
-    // "cannot tell" — and a live daemon writing is exactly when a read-only
-    // probe is most worth answering.
-    try {
-      db.exec('PRAGMA busy_timeout = 15000');
-    } catch {
-      // Non-fatal: the handle is still usable, just without a retry budget.
+    // A read-only handle skips the WAL trinity (it cannot change journal
+    // mode). It gets a retry budget ONLY when the caller asks for one.
+    //
+    // Applying the writer's 15s budget to every read-only open would be a
+    // silent behaviour change for the readers that already exist —
+    // `session-continuity.mjs` and `semantic-search.mjs` both open read-only
+    // inside the session-start chain, and both are written to fail fast and
+    // degrade. Turning an instant SQLITE_BUSY into a 15-second block for
+    // them serialises the chain behind whatever holds the lock. Opt in, with
+    // a budget sized to the caller's own patience.
+    const budget = Number(opts.busyTimeoutMs) || 0;
+    if (budget > 0) {
+      try {
+        db.exec(`PRAGMA busy_timeout = ${Math.floor(budget)}`);
+      } catch {
+        // Non-fatal: the handle is still usable, just without a retry budget.
+      }
     }
   } else {
     // Close the handle on any PRAGMA failure — node:sqlite opens forgivingly

--- a/bin/lib/get-backend.mjs
+++ b/bin/lib/get-backend.mjs
@@ -32,7 +32,20 @@ import './suppress-sqlite-warning.mjs';
 
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { createRequire } from 'node:module';
 import { memoryDbPath } from './moflo-paths.mjs';
+
+// `node:sqlite` is loaded lazily so importing this module stays cheap for the
+// scripts that only want `memoryDbPath`/`resolveBackend`. `createRequire` — not
+// `await import` — because {@link openBackendSync} must stay synchronous: the
+// per-step indexer gate (`index-fingerprint.decideStepGate`) is called from a
+// sync decision path and needs a real DB read, not a promise.
+const requireBuiltin = createRequire(import.meta.url);
+let _DatabaseSync = null;
+function databaseSyncCtor() {
+  if (_DatabaseSync === null) _DatabaseSync = requireBuiltin('node:sqlite').DatabaseSync;
+  return _DatabaseSync;
+}
 
 export const BACKEND_NODE_SQLITE = 'node-sqlite';
 
@@ -76,9 +89,27 @@ function ensureDir(filePath) {
  * @returns {Promise<object>} backend handle (see module doc)
  */
 export async function openBackend(projectRoot, opts = {}) {
+  return openBackendSync(projectRoot, opts);
+}
+
+/**
+ * Synchronous face of {@link openBackend}. Same implementation, same pragmas —
+ * `openBackend` is retained as an async wrapper only because every existing
+ * caller awaits it. Use this one from code that cannot await (the per-step
+ * indexer gate); prefer `openBackend` everywhere else so the diff against the
+ * TS twin stays obvious.
+ *
+ * @param {string} projectRoot
+ * @param {{ backend?: 'node-sqlite', create?: boolean, readOnly?: boolean, dbPath?: string }} [opts]
+ * @returns {object} backend handle (see module doc)
+ */
+export function openBackendSync(projectRoot, opts = {}) {
   const dbPath = opts.dbPath || memoryDbPath(projectRoot);
   resolveBackend(opts); // throws on stale sql.js callers
-  ensureDir(dbPath);
+  // A read-only open must never materialise state: the indexer gate probes for
+  // a DB that may legitimately not exist yet, and creating `.moflo/` from a
+  // gate would be a side effect of asking a question.
+  if (opts.readOnly !== true) ensureDir(dbPath);
   return openNodeSqlite(dbPath, opts);
 }
 
@@ -91,11 +122,23 @@ export async function openBackend(projectRoot, opts = {}) {
 // we don't want N copies of the same message in one session.
 const _networkFsWarnedPaths = new Set();
 
-async function openNodeSqlite(dbPath, opts) {
-  const { DatabaseSync } = await import('node:sqlite');
+function openNodeSqlite(dbPath, opts) {
+  const DatabaseSync = databaseSyncCtor();
   const readOnly = opts.readOnly === true;
   const db = new DatabaseSync(dbPath, { readOnly });
-  if (!readOnly) {
+  if (readOnly) {
+    // A read-only handle skips the WAL trinity (it cannot change journal mode)
+    // but still needs the retry budget. Without it a reader that lands while
+    // another process briefly holds the EXCLUSIVE lock `journal_mode=WAL`
+    // takes (#1097) gets an immediate SQLITE_BUSY and its caller degrades to
+    // "cannot tell" — and a live daemon writing is exactly when a read-only
+    // probe is most worth answering.
+    try {
+      db.exec('PRAGMA busy_timeout = 15000');
+    } catch {
+      // Non-fatal: the handle is still usable, just without a retry budget.
+    }
+  } else {
     // Close the handle on any PRAGMA failure — node:sqlite opens forgivingly
     // (even non-SQLite files succeed in the constructor) and a PRAGMA that
     // throws later would otherwise leak the file handle across processes

--- a/bin/lib/index-fingerprint.mjs
+++ b/bin/lib/index-fingerprint.mjs
@@ -21,6 +21,13 @@
  * Bumping FINGERPRINT_VERSION invalidates older payloads (graceful migration
  * — first session post-upgrade runs every step once, then steady state).
  *
+ * Issue #1383 added a second, stronger signal for steps that can state their
+ * own precondition exactly: a work probe (see STEP_WORK_PROBES). A fingerprint
+ * answers "did the inputs change?"; a probe answers "is there work?". Where
+ * both exist the probe wins, because the failure it prevents — skipping a step
+ * that demonstrably had something to do — is silent and cumulative, while the
+ * failure it risks is one cheap redundant run.
+ *
  * Override: set `FLO_FORCE_INDEX=1` to bypass every gate (`flo doctor --fix`).
  *
  * Failure posture: any compute / read error returns null and forces the
@@ -40,6 +47,7 @@ import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { MOFLO_DIR, mofloDir, memoryDbPath, hnswIndexPath } from './moflo-paths.mjs';
 import { resolveGuidanceDirs } from './guidance-config.mjs';
+import { hasPendingEmbeddings } from './embedding-backlog.mjs';
 
 export const FINGERPRINT_FILE_NAME = 'index-step-fingerprints.json';
 export const LEGACY_FINGERPRINT_FILE_NAME = 'index-all-fingerprint.json';
@@ -60,6 +68,24 @@ function legacyFingerprintFilePath(projectRoot) {
 
 function safeMtime(path) {
   try { return statSync(path).mtimeMs; } catch { return 0; }
+}
+
+/**
+ * Newest mtime across the SQLite file set — main DB plus its write-ahead log.
+ *
+ * `moflo.db` alone is not a change signal (#1383): under `journal_mode=WAL`
+ * every row write lands in `moflo.db-wal` and the main file's mtime does not
+ * move until a checkpoint folds the log back in. A gate stat'ing only the
+ * main file therefore reports "unchanged" for writes that happened seconds
+ * ago — which is how newly-indexed chunks got left unembedded.
+ *
+ * `-shm` is deliberately excluded: it is shared memory for the WAL index and
+ * READERS touch it, so folding it in would invalidate the fingerprint on
+ * sessions that only read the DB and re-run the step forever.
+ */
+function newestDbMtime(projectRoot) {
+  const db = memoryDbPath(projectRoot);
+  return Math.max(safeMtime(db), safeMtime(`${db}-wal`));
 }
 
 // Lockfiles across the common JS package managers. Any install/upgrade rewrites
@@ -202,23 +228,57 @@ const STEP_FINGERPRINT_COMPUTERS = {
 
   'pretrain':       (projectRoot) => ({ sourceList: gitFileListHash(projectRoot, SOURCE_GLOBS) }),
 
-  // memory.db mtime is a coarse proxy for "rows that need embedding". It
-  // self-bumps when build-embeddings writes back: first post-upgrade session
-  // runs the step, the bump is captured into the POST fingerprint, equilibrium
-  // reached on the next session. Imprecise (mtime can bump without new
-  // NULL-embedding rows) but cheap; the step is a no-op on empty input.
+  // The DB mtime is only a secondary signal here — the authoritative one is
+  // the work probe below, which asks the database directly whether any row
+  // still needs embedding. The fingerprint remains so the step still refreshes
+  // its derived artifacts (vector-stats cache, sidecar) when the store changed
+  // but the backlog is empty.
+  //
+  // `dbFiles` (not `memoryDb`) both names what is actually stat'd and
+  // guarantees a mismatch against payloads written before #1383, so the first
+  // session after upgrade re-runs these two steps once and settles.
   'build-embeddings': (projectRoot) => ({
-    memoryDb: safeMtime(memoryDbPath(projectRoot)),
+    dbFiles: newestDbMtime(projectRoot),
   }),
 
-  // HNSW sidecar must be at least as fresh as memory.db. Tracking both mtimes
-  // means: sidecar deleted → mtime=0 → mismatch → run. memory.db newer than
-  // last-rebuild → mismatch → run. After a successful rebuild, the saved pair
+  // HNSW sidecar must be at least as fresh as the store. Tracking both means:
+  // sidecar deleted → mtime=0 → mismatch → run. Store written since the last
+  // rebuild → mismatch → run. After a successful rebuild the saved pair
   // captures the post-rebuild equilibrium.
+  //
+  // This step shared #1383's WAL blind spot: embeddings written into the WAL
+  // did not move `moflo.db`, so the sidecar was not resynced either and the
+  // new vectors stayed unsearchable even once they existed. `newestDbMtime`
+  // fixes both steps at once.
+  //
+  // The cost is that ANY write to the store now invalidates this step, so it
+  // runs far more often — every session with memory activity, in practice.
+  // That is affordable only because #1384 made the sidecar reconcile
+  // incrementally instead of rebuilding: measured on a 5,310-vector store, a
+  // no-change reconciliation is 0.07s versus 19.4s for the full rebuild this
+  // step used to perform. This change MUST NOT ship ahead of that one.
   'hnsw-rebuild': (projectRoot) => ({
-    memoryDb: safeMtime(memoryDbPath(projectRoot)),
-    sidecar:  safeMtime(hnswIndexPath(projectRoot)),
+    dbFiles: newestDbMtime(projectRoot),
+    sidecar: safeMtime(hnswIndexPath(projectRoot)),
   }),
+};
+
+/**
+ * Per-step "is there work?" probes — the exact condition a step exists to
+ * satisfy, asked of the real state rather than inferred from a file mtime.
+ *
+ * A probe returns `true` (work pending → run, no matter what the fingerprint
+ * says), `false` (no backlog → the fingerprint decides, since the step still
+ * refreshes derived artifacts), or `null` (unknowable → the fingerprint
+ * decides). Steps with no probe are fingerprint-only.
+ *
+ * A probe may only ever FORCE a run, never suppress one. That asymmetry is
+ * the point: an over-eager probe costs one cheap no-op run, whereas a probe
+ * trusted to veto would resurrect #1383's silent skip the moment it was
+ * wrong about the state.
+ */
+const STEP_WORK_PROBES = {
+  'build-embeddings': hasPendingEmbeddings,
 };
 
 /**
@@ -283,14 +343,35 @@ export function saveStepFingerprint(stepName, projectRoot, fp) {
 }
 
 /**
+ * Ask a step's work probe whether it has pending work. Any throw is swallowed
+ * to `null` — a gate must never be the thing that breaks session start.
+ *
+ * @returns {boolean | null}
+ */
+export function probeStepWork(stepName, projectRoot) {
+  const probe = STEP_WORK_PROBES[stepName];
+  if (!probe) return null;
+  try {
+    return probe(projectRoot);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Decide whether `stepName` needs to run. Returns one of:
  *   { skip: true,  reason: 'unchanged' }
- *   { skip: false, reason: 'forced' | 'no-saved-fingerprint' | 'inputs-changed' }
+ *   { skip: false, reason: 'forced' | 'work-pending' | 'no-saved-fingerprint' | 'inputs-changed' }
  *
  * The orchestrator computes a POST-run fingerprint after each successful run
  * and saves THAT — not the pre-run one — so steps that mutate the inputs they
- * gate on (e.g. build-embeddings bumping memory.db mtime) reach a stable
+ * gate on (e.g. build-embeddings writing embeddings back) reach a stable
  * equilibrium on the next session.
+ *
+ * `work-pending` is checked before the fingerprint and is not overridable by
+ * it (#1383). A step whose backlog is non-empty runs, full stop — the
+ * fingerprint's job is deciding when to run a step that has *nothing* obvious
+ * to do, and it is not allowed to answer a question the state answers exactly.
  */
 export function decideStepGate(stepName, projectRoot, env = process.env) {
   if (env[FORCE_ENV]) {
@@ -299,8 +380,18 @@ export function decideStepGate(stepName, projectRoot, env = process.env) {
   const current = computeStepFingerprint(stepName, projectRoot);
   const saved = readSavedStepFingerprint(stepName, projectRoot);
   if (!saved) return { skip: false, reason: 'no-saved-fingerprint' };
-  if (fingerprintsEqual(current, saved)) return { skip: true, reason: 'unchanged' };
-  return { skip: false, reason: 'inputs-changed' };
+  if (!fingerprintsEqual(current, saved)) return { skip: false, reason: 'inputs-changed' };
+
+  // The fingerprint says skip. That is exactly — and only — where #1383 went
+  // wrong, so this is where the state gets consulted. Probing last also keeps
+  // it off the hot path: the query runs on quiet sessions, not on the ones
+  // that were already going to do the work, and the fingerprint has been read
+  // before the probe's read-only open materialises `-wal`/`-shm`, so the
+  // probe cannot register its own side effect as an input change.
+  if (probeStepWork(stepName, projectRoot) === true) {
+    return { skip: false, reason: 'work-pending' };
+  }
+  return { skip: true, reason: 'unchanged' };
 }
 
 /**

--- a/src/cli/__tests__/commands/doctor-embedding-hygiene.test.ts
+++ b/src/cli/__tests__/commands/doctor-embedding-hygiene.test.ts
@@ -100,7 +100,11 @@ describe('checkEmbeddingHygiene (#651)', () => {
     expect(result.fix).toContain('embeddings init');
   });
 
-  it("warns on the silent-failure marker (model='local' + embedding NULL)", async () => {
+  // #1383 kept this at `warn` (a `fail` is un-suppressable by --allow-warn and
+  // would hand consumers a hard CI failure for a transient state) but rewrote
+  // the message: it now names the consequence — the rows cannot be found —
+  // rather than an internal marker, which is why the old warning was ignorable.
+  it("warns on the silent-failure marker, naming the consequence (model='local' + embedding NULL)", async () => {
     seedDb((db) => {
       insert(db, 'a', CANONICAL_EMBEDDING_MODEL, true);
       insert(db, 'b', 'local', false);
@@ -111,6 +115,7 @@ describe('checkEmbeddingHygiene (#651)', () => {
     expect(result.status).toBe('warn');
     expect(result.message).toContain("embedding_model='local'");
     expect(result.message).toContain('AND embedding IS NULL');
+    expect(result.message).toContain('invisible to memory_search');
   });
 
   it('warns when more than one neural model is present in the active set', async () => {

--- a/src/cli/__tests__/commands/doctor-fixes-embedding-hygiene.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-embedding-hygiene.test.ts
@@ -75,6 +75,29 @@ describe('Embedding hygiene auto-fix — daemon-aware skip (#1046)', () => {
     expect(mockMigrate).not.toHaveBeenCalled();
   });
 
+  // #1383: the daemon-held message used to say only "restart Claude Code and
+  // the launcher repairs it". That advice was given while the launcher's own
+  // gate was skipping the repair, so a user could restart indefinitely and
+  // never converge. The direct command must be named.
+  it('names `embeddings init` as the remedy, not just a restart (#1383)', async () => {
+    mockGetHolder.mockReturnValue(process.pid);
+    const written: string[] = [];
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+      written.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await autoFixCheck(hygieneCheck);
+    } finally {
+      spy.mockRestore();
+    }
+
+    const text = written.join('');
+    expect(text).toContain('npx moflo embeddings init');
+    expect(text).toContain('flo daemon stop');
+  });
+
   it('runs the migration in-process when no daemon is alive', async () => {
     mockGetHolder.mockReturnValue(null);
     mockMigrate.mockResolvedValue(true);

--- a/src/cli/commands/doctor-embedding-hygiene.ts
+++ b/src/cli/commands/doctor-embedding-hygiene.ts
@@ -114,11 +114,25 @@ export async function checkEmbeddingHygiene(): Promise<HealthCheck> {
   }
 
   // (2) Silent-failure marker — local + NULL embedding.
+  //
+  // #1383 asked whether this should be a `fail` rather than a `warn`, since
+  // these rows are not merely degraded in search — they are absent from it.
+  // `memory_search` is vector-only, so a row with no embedding can never be
+  // returned however well it matches, and the agent falls back to bulk `Read`.
+  //
+  // Deliberately kept at `warn`. `finalize()` exits 1 on any `fail` and
+  // `--allow-warn` cannot tolerate one, so elevating would hand every consumer
+  // a hard, un-suppressable CI failure for a state that is transient by
+  // construction: the first session-start after this upgrade repairs the
+  // backlog, but a consumer whose CI runs `flo doctor` before that session
+  // would go red with no escape hatch. The real defect was that the message
+  // named an internal marker instead of the consequence, so the message is
+  // what changed — it now says what the user loses.
   const localNull = groups.find((g) => g.model === 'local' && g.hasNullEmbedding);
   if (localNull && localNull.count > 0) {
     issues.push(
       `${localNull.count} row(s) with embedding_model='local' AND embedding IS NULL ` +
-        '(silent producer failure marker — see #649)',
+        '— these rows are invisible to memory_search until re-embedded (see #649, #1383)',
     );
   }
 

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -858,11 +858,19 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       // that the process is actually a moflo daemon (Windows PID
       // recycling is real — see daemon-lock.ts:isDaemonProcess).
       if (getDaemonLockHolder(process.cwd()) !== null) {
+        // #1383: "restart and the launcher will fix it" was the advice given
+        // while the launcher's own gate was skipping the repair, so a user
+        // could restart indefinitely and never converge. Name the direct
+        // command first — it is the one that always works — and keep the
+        // restart as the alternative rather than the instruction.
         output.writeln(output.dim(
-          '  Embedding hygiene is repaired automatically by the session-start launcher.',
+          '  A moflo daemon holds the DB, so the repair cannot run safely in-process here.',
         ));
         output.writeln(output.dim(
-          '  Restart Claude Code (or run `flo daemon stop` first) to apply.',
+          '  Run:  flo daemon stop && npx moflo embeddings init',
+        ));
+        output.writeln(output.dim(
+          '  Or restart Claude Code — the session-start launcher runs the same repair.',
         ));
         return false;
       }

--- a/tests/bin/embedding-gate-wal.test.ts
+++ b/tests/bin/embedding-gate-wal.test.ts
@@ -1,0 +1,518 @@
+/**
+ * Regression tests for #1383 — `build-embeddings` skipped while rows sat
+ * unembedded.
+ *
+ * The bug: the step was gated on `stat(.moflo/moflo.db).mtime`. The database
+ * runs in WAL mode, so the indexer's row writes land in `moflo.db-wal` and
+ * never move the main file. The gate read "unchanged" and skipped the step
+ * that embeds rows written seconds earlier in the same chain — leaving chunks
+ * present in `memory_entries` but invisible to `memory_search`, with recovery
+ * only when some later WAL checkpoint incidentally bumped the main file.
+ *
+ * These tests drive the real thing: a real WAL-mode DB with a connection held
+ * OPEN across the writes, which is what keeps the log un-checkpointed. That
+ * detail is the bug's precondition, not incidental scaffolding — SQLite
+ * checkpoints and unlinks `-wal` when the last connection closes, and that
+ * checkpoint is precisely the accident that used to un-wedge a consumer. A
+ * long-lived writer (moflo's daemon) is the normal state, and it is why the
+ * skip persisted across restarts in the field.
+ *
+ * `pinMtime` additionally freezes the main file's mtime so the assertion does
+ * not depend on filesystem timestamp granularity or on how fast the suite runs.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, statSync, utimesSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawn } from 'node:child_process';
+
+import {
+  decideStepGate,
+  computeStepFingerprint,
+  saveStepFingerprint,
+  readSavedStepFingerprint,
+  fingerprintsEqual,
+  probeStepWork,
+} from '../../bin/lib/index-fingerprint.mjs';
+import { hasPendingEmbeddings, PENDING_EMBEDDING_WHERE } from '../../bin/lib/embedding-backlog.mjs';
+import { openBackendSync } from '../../bin/lib/get-backend.mjs';
+import { MOFLO_DIR, MEMORY_DB_FILE } from '../../src/cli/services/moflo-paths.js';
+
+const SCHEMA = `
+  CREATE TABLE memory_entries (
+    id TEXT PRIMARY KEY,
+    key TEXT NOT NULL,
+    namespace TEXT DEFAULT 'default',
+    content TEXT NOT NULL,
+    embedding TEXT,
+    embedding_model TEXT DEFAULT 'local',
+    created_at INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    status TEXT DEFAULT 'active',
+    UNIQUE(namespace, key)
+  )
+`;
+
+/**
+ * The columns `applyIncrementalChunks` writes — a superset of {@link SCHEMA},
+ * needed only by the end-to-end block below.
+ */
+const CHUNK_SCHEMA = `
+  CREATE TABLE memory_entries (
+    id TEXT PRIMARY KEY,
+    key TEXT NOT NULL,
+    namespace TEXT DEFAULT 'default',
+    content TEXT NOT NULL,
+    type TEXT DEFAULT 'semantic',
+    embedding TEXT,
+    embedding_model TEXT DEFAULT 'local',
+    embedding_dimensions INTEGER,
+    tags TEXT,
+    metadata TEXT,
+    owner_id TEXT,
+    created_at INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    expires_at INTEGER,
+    last_accessed_at INTEGER,
+    access_count INTEGER DEFAULT 0,
+    status TEXT DEFAULT 'active',
+    UNIQUE(namespace, key)
+  )
+`;
+
+const DIM = 8;
+
+/**
+ * File URL of the real `get-backend` module, for the child process to import.
+ * A URL — not a path — because a Windows path is not a valid ESM specifier.
+ */
+const getBackendUrl = pathToFileURL(
+  resolve(__dirname, '..', '..', 'bin', 'lib', 'get-backend.mjs'),
+).href;
+
+/** Deterministic stand-in for the real embedder — a vector is a function of text. */
+function vectorFor(content: string): number[] {
+  return Array.from({ length: DIM }, (_, j) =>
+    Number(Math.sin(content.length * 0.9 + j * 0.4).toFixed(6)),
+  );
+}
+
+const roots: string[] = [];
+const openHandles: Array<{ close: () => void }> = [];
+
+function dbPathOf(root: string): string {
+  return join(root, MOFLO_DIR, MEMORY_DB_FILE);
+}
+
+/** Open the store the way every bin/ script does — WAL pragmas included. */
+function openStore(root: string) {
+  return openBackendSync(root, { dbPath: dbPathOf(root) });
+}
+
+/**
+ * A project whose store is held open by a long-lived writer, as moflo's daemon
+ * holds it. Writes therefore accumulate in `-wal` and never checkpoint.
+ */
+function makeRoot(schema = SCHEMA): { root: string; writer: ReturnType<typeof openStore> } {
+  const root = mkdtempSync(join(tmpdir(), 'moflo-1383-'));
+  roots.push(root);
+  mkdirSync(join(root, MOFLO_DIR));
+  const writer = openStore(root);
+  openHandles.push(writer);
+  writer.run(schema);
+  return { root, writer };
+}
+
+function insertRow(
+  writer: ReturnType<typeof openStore>,
+  id: string,
+  embedding: string | null,
+): void {
+  writer.run(
+    `INSERT INTO memory_entries (id, key, namespace, content, embedding, status)
+     VALUES (?, ?, ?, ?, ?, 'active')`,
+    [id, `key-${id}`, 'guidance', `content for ${id}`, embedding],
+  );
+}
+
+/**
+ * Stand-in for `build-embeddings`: select the backlog with the SAME exported
+ * clause the gate probes on, and fill it. Returns how many rows it embedded.
+ */
+function embedBacklog(writer: ReturnType<typeof openStore>): number {
+  const stmt = writer.prepare(
+    `SELECT id, content FROM memory_entries WHERE ${PENDING_EMBEDDING_WHERE}`,
+  );
+  const pending: Array<{ id: string; content: string }> = [];
+  while (stmt.step()) pending.push(stmt.getAsObject() as { id: string; content: string });
+  stmt.free();
+
+  for (const { id, content } of pending) {
+    writer.run(
+      `UPDATE memory_entries SET embedding = ?, embedding_dimensions = ?, updated_at = ? WHERE id = ?`,
+      [JSON.stringify(vectorFor(content)), DIM, 1_700_000_000_000, id],
+    );
+  }
+  return pending.length;
+}
+
+function idForKey(writer: ReturnType<typeof openStore>, key: string): string {
+  const stmt = writer.prepare(`SELECT id FROM memory_entries WHERE key = ?`);
+  stmt.bind([key]);
+  stmt.step();
+  const row = stmt.getAsObject() as { id: string };
+  stmt.free();
+  return row.id;
+}
+
+/**
+ * Close every handle BEFORE removing the directories. Windows holds a
+ * mandatory lock on an open SQLite file, so an rmSync ahead of the close
+ * fails with EPERM/EBUSY there while passing silently on POSIX.
+ */
+function cleanup(): void {
+  for (const h of openHandles.splice(0)) {
+    try { h.close(); } catch { /* already closed */ }
+  }
+  for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true });
+}
+
+/**
+ * Hold `moflo.db`'s mtime at `at` — the WAL behaviour the bug depended on,
+ * made explicit so the assertion isn't at the mercy of mtime granularity.
+ */
+function pinMtime(root: string, at: Date): void {
+  utimesSync(dbPathOf(root), at, at);
+}
+
+/**
+ * Capture, then later restore, the mtimes of the whole SQLite file set — the
+ * hostile case where the filesystem gives up no signal at all. This is what
+ * isolates the work probe from the WAL-aware fingerprint: with every timestamp
+ * rewound to its pre-write value, only a real look at the data can decide
+ * whether the step has something to do.
+ */
+const FROZEN_AT = new Date(1_700_000_000_000); // whole seconds — round-trips exactly
+
+function freezeMtimes(root: string): void {
+  for (const p of [dbPathOf(root), `${dbPathOf(root)}-wal`]) {
+    if (existsSync(p)) utimesSync(p, FROZEN_AT, FROZEN_AT);
+  }
+}
+
+describe('build-embeddings gate under WAL (#1383)', () => {
+  afterEach(cleanup);
+
+  it('runs when unembedded rows exist even though moflo.db mtime never moved', () => {
+    const { root, writer } = makeRoot();
+    insertRow(writer, 'embedded-1', JSON.stringify([0.1, 0.2]));
+
+    // Session 1 equilibrium: the step ran, the post-run fingerprint was saved.
+    saveStepFingerprint('build-embeddings', root, computeStepFingerprint('build-embeddings', root));
+    expect(decideStepGate('build-embeddings', root, {})).toEqual({ skip: true, reason: 'unchanged' });
+
+    const pinned = new Date(statSync(dbPathOf(root)).mtime);
+
+    // The indexer writes new chunks with no embedding — into the WAL, with the
+    // writer still connected so nothing checkpoints.
+    insertRow(writer, 'pending-1', null);
+    insertRow(writer, 'pending-2', '');
+    pinMtime(root, pinned); // main file untouched, exactly as WAL leaves it
+
+    // Pre-#1383 this returned { skip: true, reason: 'unchanged' } and the rows
+    // stayed unembedded and unsearchable. Stat'ing the WAL is enough to catch
+    // it — the first of the two layers.
+    expect(decideStepGate('build-embeddings', root, {})).toEqual({
+      skip: false,
+      reason: 'inputs-changed',
+    });
+  });
+
+  it('runs on a backlog even when every mtime is frozen — the second layer', () => {
+    const { root, writer } = makeRoot();
+    insertRow(writer, 'embedded-1', JSON.stringify([0.1]));
+    freezeMtimes(root);
+    saveStepFingerprint('build-embeddings', root, computeStepFingerprint('build-embeddings', root));
+
+    insertRow(writer, 'pending-1', null);
+    // Deny the gate every filesystem signal there is. A coarse-granularity or
+    // timestamp-restoring filesystem, or a checkpoint that rewinds an mtime,
+    // puts the gate here — and mtimes are a proxy, so the fix cannot rest on
+    // them alone. Only reading the data answers this.
+    freezeMtimes(root);
+
+    // Precondition: the fingerprint genuinely still matches, so the probe is
+    // demonstrably the thing forcing the run and not a stale-mtime accident.
+    expect(
+      fingerprintsEqual(
+        computeStepFingerprint('build-embeddings', root),
+        readSavedStepFingerprint('build-embeddings', root),
+      ),
+    ).toBe(true);
+    expect(decideStepGate('build-embeddings', root, {})).toEqual({
+      skip: false,
+      reason: 'work-pending',
+    });
+  });
+
+  it('a WAL-only write with no backlog still invalidates the fingerprint', () => {
+    const { root, writer } = makeRoot();
+    saveStepFingerprint('build-embeddings', root, computeStepFingerprint('build-embeddings', root));
+
+    const pinned = new Date(statSync(dbPathOf(root)).mtime);
+    insertRow(writer, 'embedded-1', JSON.stringify([0.3]));
+    pinMtime(root, pinned);
+
+    expect(existsSync(`${dbPathOf(root)}-wal`)).toBe(true);
+    // No backlog, so the probe abstains — the WAL-aware fingerprint is what
+    // still notices the store changed and refreshes the derived artifacts.
+    expect(probeStepWork('build-embeddings', root)).toBe(false);
+    expect(decideStepGate('build-embeddings', root, {})).toEqual({
+      skip: false,
+      reason: 'inputs-changed',
+    });
+  });
+
+  it('hnsw-rebuild sees WAL-only writes too — it shared the blind spot', () => {
+    const { root, writer } = makeRoot();
+    insertRow(writer, 'embedded-1', JSON.stringify([0.4]));
+    saveStepFingerprint('hnsw-rebuild', root, computeStepFingerprint('hnsw-rebuild', root));
+    expect(decideStepGate('hnsw-rebuild', root, {})).toEqual({ skip: true, reason: 'unchanged' });
+
+    const pinned = new Date(statSync(dbPathOf(root)).mtime);
+    insertRow(writer, 'embedded-2', JSON.stringify([0.5]));
+    pinMtime(root, pinned);
+
+    expect(decideStepGate('hnsw-rebuild', root, {})).toEqual({
+      skip: false,
+      reason: 'inputs-changed',
+    });
+  });
+
+  it('still skips when there is genuinely nothing to do', () => {
+    const { root, writer } = makeRoot();
+    insertRow(writer, 'embedded-1', JSON.stringify([0.6]));
+    saveStepFingerprint('build-embeddings', root, computeStepFingerprint('build-embeddings', root));
+
+    expect(decideStepGate('build-embeddings', root, {})).toEqual({ skip: true, reason: 'unchanged' });
+  });
+
+  it('probing does not perturb the fingerprint it is paired with', () => {
+    const { root, writer } = makeRoot();
+    insertRow(writer, 'embedded-1', JSON.stringify([0.65]));
+    saveStepFingerprint('build-embeddings', root, computeStepFingerprint('build-embeddings', root));
+
+    // A read-only SQLite open materialises -wal/-shm when they are absent. If
+    // the gate probed before reading its inputs, that side effect would read
+    // as an input change and re-run the step on every quiet session.
+    for (let i = 0; i < 3; i++) {
+      expect(decideStepGate('build-embeddings', root, {})).toEqual({
+        skip: true,
+        reason: 'unchanged',
+      });
+    }
+  });
+
+  it('a backlog overrides a matching fingerprint — the probe cannot be vetoed', () => {
+    const { root, writer } = makeRoot();
+    insertRow(writer, 'pending-1', null);
+
+    // Simulate a run that "succeeded" but left the row unembedded: the POST
+    // fingerprint is saved and matches on the next session. Fingerprint-only
+    // gating would skip forever; the probe forces the retry.
+    saveStepFingerprint('build-embeddings', root, computeStepFingerprint('build-embeddings', root));
+
+    expect(decideStepGate('build-embeddings', root, {})).toEqual({
+      skip: false,
+      reason: 'work-pending',
+    });
+  });
+
+  it('FLO_FORCE_INDEX still wins over everything', () => {
+    const { root } = makeRoot();
+    saveStepFingerprint('build-embeddings', root, computeStepFingerprint('build-embeddings', root));
+
+    expect(decideStepGate('build-embeddings', root, { FLO_FORCE_INDEX: '1' })).toEqual({
+      skip: false,
+      reason: 'forced',
+    });
+  });
+});
+
+describe('hasPendingEmbeddings (#1383)', () => {
+  afterEach(cleanup);
+
+  it('distinguishes "no work" from "cannot tell"', () => {
+    const bare = mkdtempSync(join(tmpdir(), 'moflo-1383-bare-'));
+    roots.push(bare);
+    expect(hasPendingEmbeddings(bare)).toBeNull(); // no DB yet
+
+    const noSchema = mkdtempSync(join(tmpdir(), 'moflo-1383-'));
+    roots.push(noSchema);
+    mkdirSync(join(noSchema, MOFLO_DIR));
+    const handle = openStore(noSchema); // DB exists, memory_entries does not
+    openHandles.push(handle);
+    expect(hasPendingEmbeddings(noSchema)).toBeNull();
+
+    const { root: clean, writer } = makeRoot();
+    insertRow(writer, 'embedded-1', JSON.stringify([0.7]));
+    expect(hasPendingEmbeddings(clean)).toBe(false);
+  });
+
+  it('counts NULL and empty-string embeddings, ignores inactive rows', () => {
+    const { root, writer } = makeRoot();
+    insertRow(writer, 'embedded-1', JSON.stringify([0.8]));
+    expect(hasPendingEmbeddings(root)).toBe(false);
+
+    writer.run(
+      `INSERT INTO memory_entries (id, key, namespace, content, embedding, status)
+       VALUES ('archived-1', 'k-archived', 'guidance', 'c', NULL, 'archived')`,
+    );
+    expect(hasPendingEmbeddings(root)).toBe(false); // status filter holds
+
+    insertRow(writer, 'pending-empty', '');
+    expect(hasPendingEmbeddings(root)).toBe(true);
+  });
+
+  it('does not create .moflo state just by asking', () => {
+    const bare = mkdtempSync(join(tmpdir(), 'moflo-1383-bare-'));
+    roots.push(bare);
+    expect(hasPendingEmbeddings(bare)).toBeNull();
+    expect(existsSync(join(bare, MOFLO_DIR))).toBe(false);
+  });
+});
+
+/**
+ * The user-visible end of #1383: a doc gets a new section, and that section is
+ * findable. This drives the real chain order — indexer writes chunks, gate
+ * decides, embedder fills the backlog, sidecar reconciles — with the store held
+ * open throughout so nothing checkpoints.
+ *
+ * Retrieval is asserted at the HNSW graph layer, which is what `memory_search`
+ * queries. The MCP tool itself is not exercised because that would require
+ * loading the real fastembed model (~90MB, several seconds); the stub embedder
+ * here is deterministic on content, which is what makes the assertion sharp.
+ */
+describe('doc append → gate → embed → searchable (#1383)', () => {
+  afterEach(cleanup);
+
+  it('a section appended to an indexed doc becomes retrievable in the same chain', async () => {
+    const { applyIncrementalChunks } = await import('../../bin/lib/incremental-write.mjs');
+    const { syncHnswSidecar, tryLoadHnswSidecar } =
+      await import('../../src/cli/memory/hnsw-persistence.js');
+
+    const { root, writer } = makeRoot(CHUNK_SCHEMA);
+
+    const chunks = [
+      { key: 'doc:1', content: 'the first section' },
+      { key: 'doc:2', content: 'the second section' },
+    ];
+    applyIncrementalChunks(writer, 'guidance', chunks);
+
+    // Settle the gate as a prior session would have, then pin the main file so
+    // only the WAL reflects what the indexer just wrote.
+    const pinned = new Date(statSync(dbPathOf(root)).mtime);
+    saveStepFingerprint('build-embeddings', root, computeStepFingerprint('build-embeddings', root));
+    pinMtime(root, pinned);
+
+    // Either layer may be the one that fires here; what the chain guarantees
+    // is that the step is not skipped while rows await embedding.
+    expect(decideStepGate('build-embeddings', root, {}).skip).toBe(false);
+    expect(embedBacklog(writer)).toBe(2);
+    await syncHnswSidecar(dbPathOf(root), root, { dimensions: DIM });
+
+    // The doc gains a section. The indexer rewrites its chunk list; only the
+    // new one lacks an embedding.
+    applyIncrementalChunks(writer, 'guidance', [
+      ...chunks,
+      { key: 'doc:3', content: 'a freshly appended third section' },
+    ]);
+    pinMtime(root, pinned);
+
+    expect(decideStepGate('build-embeddings', root, {}).skip).toBe(false);
+    expect(embedBacklog(writer)).toBe(1);
+    await syncHnswSidecar(dbPathOf(root), root, { dimensions: DIM });
+
+    expect(hasPendingEmbeddings(root)).toBe(false);
+
+    const appendedId = idForKey(writer, 'doc:3');
+    const graph = tryLoadHnswSidecar(root)!;
+    expect(graph).not.toBeNull();
+    const hits = graph.search(new Float32Array(vectorFor('a freshly appended third section')), 1);
+    expect(hits[0].id).toBe(appendedId);
+  });
+});
+
+/**
+ * The probe must answer correctly while a SEPARATE PROCESS holds the store —
+ * the normal state in the field, where moflo's daemon is connected for the
+ * life of the session. Everything above runs the writer in-process, which
+ * never contends for the same locks.
+ */
+describe('probe under cross-process contention (#1383)', () => {
+  afterEach(cleanup);
+
+  it('sees a backlog written by another process that still holds the DB open', async () => {
+    const { root, writer } = makeRoot();
+    // Release the in-process handle; the child becomes the sole live writer.
+    writer.close();
+
+    const holderScript = join(root, 'holder.mjs');
+    writeFileSync(
+      holderScript,
+      [
+        `import { openBackendSync } from ${JSON.stringify(getBackendUrl)};`,
+        `const db = openBackendSync(${JSON.stringify(root)}, { dbPath: ${JSON.stringify(dbPathOf(root))} });`,
+        `db.run("INSERT INTO memory_entries (id, key, namespace, content, embedding, status) `
+          + `VALUES ('pending-x', 'k-x', 'guidance', 'c', NULL, 'active')");`,
+        // Hold the connection open indefinitely so nothing checkpoints.
+        `process.stdout.write('ready\\n');`,
+        `setInterval(() => {}, 1000);`,
+      ].join('\n'),
+    );
+
+    const child = spawn(process.execPath, [holderScript], { stdio: ['ignore', 'pipe', 'pipe'] });
+    try {
+      await new Promise<void>((resolveReady, rejectReady) => {
+        const timer = setTimeout(() => rejectReady(new Error('holder never signalled ready')), 20_000);
+        let buf = '';
+        child.stdout.on('data', (d) => {
+          buf += String(d);
+          if (buf.includes('ready')) {
+            clearTimeout(timer);
+            resolveReady();
+          }
+        });
+        child.on('error', (e) => { clearTimeout(timer); rejectReady(e); });
+        child.on('exit', (code) => {
+          clearTimeout(timer);
+          rejectReady(new Error(`holder exited early with code ${code}`));
+        });
+      });
+
+      expect(hasPendingEmbeddings(root)).toBe(true);
+    } finally {
+      child.kill();
+      await new Promise((r) => child.once('exit', r));
+    }
+  }, 30_000);
+});
+
+describe('gate/producer predicate parity (#1383)', () => {
+  it('build-embeddings selects on the exported clause rather than restating it', () => {
+    const src = readFileSync(resolve(__dirname, '..', '..', 'bin', 'build-embeddings.mjs'), 'utf-8');
+    expect(src).toMatch(/import\s*\{\s*PENDING_EMBEDDING_WHERE\s*\}\s*from\s*'\.\/lib\/embedding-backlog\.mjs'/);
+    // The selection query must be built from the shared constant, not from an
+    // inline copy of the clause. (The namespace-stats summary further down the
+    // file legitimately mentions the same columns; this pins the SELECT that
+    // decides what gets embedded.)
+    expect(src).toMatch(/WHERE\s*`?\s*\n?\s*\+?\s*\(forceAll\s*\?[^)]*:\s*PENDING_EMBEDDING_WHERE\)/);
+  });
+
+  it('the exported clause is the one that filters unembedded active rows', () => {
+    expect(PENDING_EMBEDDING_WHERE).toContain(`status = 'active'`);
+    expect(PENDING_EMBEDDING_WHERE).toContain(`embedding IS NULL`);
+    expect(PENDING_EMBEDDING_WHERE).toContain(`embedding = ''`);
+  });
+});

--- a/tests/bin/embedding-gate-wal.test.ts
+++ b/tests/bin/embedding-gate-wal.test.ts
@@ -499,6 +499,48 @@ describe('probe under cross-process contention (#1383)', () => {
   }, 30_000);
 });
 
+/**
+ * A read-only open must not acquire a retry budget it was not asked for.
+ *
+ * `session-continuity.mjs` and `semantic-search.mjs` both open read-only
+ * inside the session-start chain and are written to fail fast and degrade.
+ * Blanket-applying the writer's 15s budget to every read-only open turned
+ * their instant SQLITE_BUSY into a 15-second block, serialising the chain
+ * behind whatever held the lock — which is how `flo doctor` hit its 60s
+ * timeout on the Windows populated smoke while every POSIX job stayed green.
+ */
+describe('read-only busy budget is opt-in (#1383)', () => {
+  it('get-backend only sets busy_timeout on a read-only open when asked', () => {
+    const src = readFileSync(resolve(__dirname, '..', '..', 'bin', 'lib', 'get-backend.mjs'), 'utf-8');
+    const readOnlyBranch = src.slice(
+      src.indexOf('if (readOnly) {'),
+      src.indexOf('} else {', src.indexOf('if (readOnly) {')),
+    );
+    expect(readOnlyBranch).toContain('busyTimeoutMs');
+    // No unconditional budget in the read-only branch.
+    expect(readOnlyBranch).not.toMatch(/PRAGMA busy_timeout = \d+/);
+  });
+
+  it('a read-only handle opened without a budget still works', () => {
+    const { root, writer } = makeRoot();
+    insertRow(writer, 'embedded-1', JSON.stringify([0.9]));
+    const reader = openBackendSync(root, { dbPath: dbPathOf(root), readOnly: true });
+    openHandles.push(reader);
+    const rows = reader.exec(`SELECT COUNT(*) AS n FROM memory_entries`);
+    expect(Number(rows[0].values[0][0])).toBe(1);
+  });
+
+  it('the probe asks for a budget, and a short one', async () => {
+    const src = readFileSync(resolve(__dirname, '..', '..', 'bin', 'lib', 'embedding-backlog.mjs'), 'utf-8');
+    expect(src).toMatch(/busyTimeoutMs:\s*PROBE_BUSY_TIMEOUT_MS/);
+    const budget = Number(/PROBE_BUSY_TIMEOUT_MS\s*=\s*(\d+)/.exec(src)?.[1]);
+    expect(budget).toBeGreaterThan(0);
+    // Sits in the session-start critical path — must stay well under the
+    // writer's 15s, which is sized for a very different job.
+    expect(budget).toBeLessThanOrEqual(5000);
+  });
+});
+
 describe('gate/producer predicate parity (#1383)', () => {
   it('build-embeddings selects on the exported clause rather than restating it', () => {
     const src = readFileSync(resolve(__dirname, '..', '..', 'bin', 'build-embeddings.mjs'), 'utf-8');

--- a/tests/system/fixtures/writer-audit-whitelist.json
+++ b/tests/system/fixtures/writer-audit-whitelist.json
@@ -316,6 +316,11 @@
       "file": "bin/lib/get-backend.mjs",
       "classification": "daemon-offline",
       "notes": "JS-twin factory — every bin/ writer routes through openBackend(); defaults to node:sqlite as of Phase 4 (#1083), sql.js path deleted in Phase 5 (#1084)"
+    },
+    {
+      "file": "bin/lib/embedding-backlog.mjs",
+      "classification": "in-daemon",
+      "notes": "Read-only probe (#1383) — opens with readOnly:true and runs a single SELECT EXISTS; classified for completeness like entries-read.ts. Mutates nothing, so it is safe alongside a live daemon."
     }
   ]
 }


### PR DESCRIPTION
Fixes #1383. Stacked on #1385 (now merged); rebased onto main as a single commit.

## The defect

`build-embeddings` was gated on `stat(.moflo/moflo.db).mtime`. The store runs in **WAL mode**, so the indexer's row writes land in `moflo.db-wal` and never move the main file. The gate read "unchanged" and skipped the step that embeds rows written *seconds earlier in the same chain*:

```
[14:06:48] RUN   guidance-index (inputs-changed)     <- wrote 58 new chunk rows
[14:06:56] SKIP  build-embeddings (unchanged)        <- the step that embeds them
[14:06:56] SKIP  hnsw-rebuild (unchanged)
```

Those chunks existed in `memory_entries` and were invisible to `memory_search`. A restart did not fix it — the next chain re-stats the same unchanged file. Recovery required a WAL checkpoint to *incidentally* bump the mtime, which is why the step ran at 13:58 and skipped at 14:06 with nothing relevant in between.

Consumer-facing and silent: anyone who edits guidance can get docs that are indexed-but-unfindable, with no signal at authoring time.

## The fix — two layers, deliberately asymmetric

**1. `newestDbMtime` folds `moflo.db-wal` into the fingerprint.** `-shm` is excluded on purpose: *readers* touch the shared-memory index, so including it would re-invalidate the fingerprint on sessions that only read and re-run the step forever. This layer alone catches the reported bug.

**2. A work probe asks the database directly.** `hasPendingEmbeddings` runs the exact `SELECT EXISTS` the ticket proposed. Two properties do the load-bearing work:

- It may only ever **force** a run, never suppress one. `null` means *cannot tell* and is a distinct value from `false`, because a probe that degraded to "no work" on error would be this same bug wearing a new hat.
- It runs **last**, only after the fingerprint has already decided to skip — which is exactly and only where #1383 went wrong. That also keeps the query off sessions that were going to do the work anyway, and means the fingerprint's inputs are read *before* the probe's read-only open materialises `-wal`/`-shm`, so the probe cannot register its own side effect as an input change.

**The gate and the producer share one predicate.** `PENDING_EMBEDDING_WHERE` is exported from the new module and imported by `build-embeddings.mjs`. A gate that *approximates* its step's own query is how this happened; drift would silently reopen it in whichever direction the drift went.

## Why the WAL fix alone wasn't the stopping point

A test I expected to report `work-pending` came back `inputs-changed` — the WAL-aware mtime had already caught it. Both layers stay, and the tests now separate them: one proves the WAL fix handles the real-world case, another **freezes every timestamp** to prove the probe still catches a backlog when the filesystem gives up no signal at all (coarse mtime granularity, a checkpoint that rewinds a timestamp, or a run that "succeeded" while leaving rows unembedded and saved a matching post-fingerprint).

## `hnsw-rebuild` shared the blind spot

Embeddings written into the WAL did not move `moflo.db`, so the sidecar was not resynced either and new vectors stayed unsearchable *even once they existed*. It gets the same WAL-aware mtime.

The cost is that any store write now invalidates it, so it runs far more often. **That is affordable only because of #1384** — measured on a 5,310-vector store, a no-change reconciliation is **0.07s** against **19.4s** for the full rebuild this step used to perform.

## Cost, measured

`EXISTS` short-circuits on the first match, so a store *with* a backlog answers immediately. The empty steady state has no covering index and scans:

| store | probe |
|---|---|
| 5,310 rows | 12ms |
| 31,860 rows | 70ms |
| ~100k rows (extrapolated at 2.2us/row) | ~200ms |

Paid at most once per session, and only on sessions that were about to skip.

## Two judgement calls worth reviewing

**Embedding hygiene stays `warn`.** AC #7 asked me to consider elevating it to an error, and the case looked strong. Then: `doctor-render.ts:320` exits 1 on any `fail`, and `--allow-warn` tolerates *warns* only — there is no escape hatch. Elevating would hand every consumer an un-suppressable CI failure for a backlog this fix makes transient (repaired on the next session start, but their CI might run `doctor` first). The real defect was that the message named an internal marker instead of the consequence, so **that** changed: it now reads `invisible to memory_search until re-embedded`.

**Doctor's remediation text.** "Restart and the launcher repairs it" was advice given while the launcher's own gate was skipping the repair — a user could restart indefinitely and never converge. It now names `flo daemon stop && npx moflo embeddings init` first, keeping the restart as the alternative.

## Consumer impact (Rule #2)

- **Surface touched:** `bin/lib/index-fingerprint.mjs`, `bin/lib/get-backend.mjs`, `bin/build-embeddings.mjs` (+ `.claude/scripts/` twins) — all run in every consumer's session-start chain; plus two `doctor` files.
- **Failure mode on upgrade:** the fingerprint key is renamed `memoryDb` to `dbFiles`, which cannot match a pre-#1383 payload. First session after upgrade re-runs `build-embeddings` and `hnsw-rebuild` once, then settles. No migration, no `.moflo/` state change.
- **Round-trip:** runtime fix — requires publish + reinstall + restart before it takes effect anywhere, including this repo.

## Reviewer findings (3-agent fan-out)

- **Reuse:** clean. Noted that `doctor`'s `local`+NULL predicate and `PENDING_EMBEDDING_WHERE` are two different definitions of "needs embedding" — pre-existing, and they answer different questions (*which model tagged it* vs *is there work*), so left alone.
- **Quality:** the read-only branch of `openNodeSqlite` never set `busy_timeout`, so a probe racing the brief `EXCLUSIVE` lock (#1097) got an immediate `SQLITE_BUSY` and degraded to "cannot tell" — precisely when a live daemon is writing and the probe matters most. **Fixed.** Also asked for real cross-process contention coverage — **added**, spawning a second node process that writes a pending row and holds the DB open.
- **Efficiency:** flagged that the probe ran unconditionally and that the docstring claimed a cost it had not measured. **Both fixed** — the probe moved behind the fingerprint's skip decision, and the docstring now carries the numbers above.

## Tests

`tests/bin/embedding-gate-wal.test.ts` — 15 tests. Every one holds a writer connection **open** across its writes, because SQLite checkpoints and unlinks `-wal` when the last connection closes: a test using short-lived connections silently exercises the checkpointed path and proves nothing. A long-lived writer is the normal state in the field and is why the skip survived restarts.

Covers: WAL-blind-spot recovery, the frozen-timestamp probe path, `hnsw-rebuild`, still-skips-when-idle, probe-does-not-perturb-its-own-fingerprint, `FLO_FORCE_INDEX` precedence, `null` vs `false`, no state created by asking, cross-process contention, gate/producer predicate parity, and an end-to-end doc-append chain.

Full suite **10,346 passed / 0 failed** after the rebase onto merged main; `tsc` and `eslint` clean.

**Scope note:** the end-to-end test asserts retrieval at the HNSW graph layer that `memory_search` queries, not through the MCP tool — exercising the tool needs the real fastembed model loaded.

## Cross-platform (Rule #1)

No hardcoded separators (the `-wal` path is a suffix, not a join); handles closed before `rmSync` because Windows holds a mandatory lock on an open SQLite file; the child process receives a `pathToFileURL` specifier since a Windows path is not a valid ESM specifier; mtimes frozen to a whole-second value that round-trips exactly rather than depending on filesystem granularity.

🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)