### PR TITLE
fix(status): report the HNSW index that serves the search, not the caller's

### DIFF
--- a/src/cli/__tests__/memory/hnsw-lite-serialize.test.ts
+++ b/src/cli/__tests__/memory/hnsw-lite-serialize.test.ts
@@ -111,4 +111,26 @@ describe('HnswLite serialize / load', () => {
     buf.writeUInt32LE(2, 24);
     expect(() => HnswLite.load(buf)).toThrow(/size mismatch|arity mismatch/);
   });
+
+  describe('readHeader — status reads without decoding the graph (#1387)', () => {
+    it('reports the graph parameters from the header bytes alone', () => {
+      const buf = buildIndex(3, 8).serialize();
+
+      const header = HnswLite.readHeader(buf.subarray(0, HnswLite.HEADER_BYTES));
+
+      expect(header).toMatchObject({
+        metric: 'cosine',
+        dimensions: 8,
+        vectorCount: 3,
+      });
+    });
+
+    it('applies the same validation load() does, so the two cannot disagree', () => {
+      const bad = Buffer.alloc(HnswLite.HEADER_BYTES);
+      bad.write('NOTMAGIC', 0, 'ascii');
+
+      expect(() => HnswLite.readHeader(bad)).toThrow(/bad magic/);
+      expect(() => HnswLite.readHeader(Buffer.alloc(8))).toThrow(/too small/);
+    });
+  });
 });

--- a/src/cli/__tests__/memory/hnsw-status-reporting.test.ts
+++ b/src/cli/__tests__/memory/hnsw-status-reporting.test.ts
@@ -1,0 +1,180 @@
+/**
+ * HNSW status is reported for the index that serves the search (#1387).
+ *
+ * `getHNSWStatus()` reports the calling process's singleton. That was a fair
+ * proxy until #1058 routed reads through the daemon's RPC — after which
+ * `searchEntries` returns before ever touching `searchHNSWIndex`, so the MCP
+ * server and CLI never build a local index, and `flo status memory` told
+ * healthy installs their index did not exist. The report inverted with health:
+ * it only read "Active" in a process that had *failed* to reach the daemon.
+ *
+ * These tests pin the daemon-routed case specifically (no local singleton,
+ * sidecar on disk), the honest negative (no sidecar at all — the fix must not
+ * be unconditionally optimistic), and the "present but uncountable" case that
+ * must not collapse to zero.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { buildAndWriteHnswSidecar, hnswManifestPath, readHnswSidecarStatus } from '../../memory/hnsw-persistence.js';
+import { clearHNSWIndex, getEffectiveHNSWStatus, getHNSWStatus } from '../../memory/hnsw-singleton.js';
+import { hnswIndexPath, MOFLO_DIR, MEMORY_DB_FILE } from '../../services/moflo-paths.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+import { hnswIndexLabel } from '../../commands/status.js';
+
+const DIM = 8;
+const ROW_COUNT = 7;
+
+function vectorFor(seed: number): number[] {
+  return Array.from({ length: DIM }, (_, j) => Number(Math.sin(seed * 0.7 + j * 0.3).toFixed(6)));
+}
+
+function seedDb(dbPath: string): void {
+  const db = openDaemonDatabase(dbPath);
+  try {
+    db.run(`CREATE TABLE memory_entries (
+      id TEXT PRIMARY KEY,
+      key TEXT,
+      namespace TEXT,
+      content TEXT,
+      embedding TEXT,
+      updated_at INTEGER,
+      status TEXT
+    )`);
+    for (let i = 0; i < ROW_COUNT; i++) {
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, embedding, updated_at, status)
+         VALUES (?, ?, ?, ?, ?, ?, 'active')`,
+        [`row-${i}`, `key-${i}`, 'patterns', `content ${i}`, JSON.stringify(vectorFor(i)), 1_700_000_000_000],
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
+
+describe('HNSW status reporting (#1387)', () => {
+  let tmp: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1387-'));
+    fs.mkdirSync(path.join(tmp, MOFLO_DIR));
+    dbPath = path.join(tmp, MOFLO_DIR, MEMORY_DB_FILE);
+    seedDb(dbPath);
+    // Every assertion below is about a process that has NOT built a local
+    // index — which is every non-daemon process since #1058.
+    clearHNSWIndex();
+  });
+
+  afterEach(() => {
+    clearHNSWIndex();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  describe('readHnswSidecarStatus', () => {
+    it('reports the sidecar absent, with a count of zero, when none was written', () => {
+      expect(readHnswSidecarStatus(tmp)).toEqual({ present: false, vectorCount: 0, dimensions: null });
+    });
+
+    it('counts vectors from the header, not by deserializing the graph', async () => {
+      await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      expect(readHnswSidecarStatus(tmp)).toEqual({
+        present: true,
+        vectorCount: ROW_COUNT,
+        dimensions: DIM,
+      });
+    });
+
+    it('counts a sidecar that has no manifest beside it', async () => {
+      await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      // A pre-#1384 sidecar, or the losing half of a torn write. The count
+      // lives in the graph's own header, so it survives losing the manifest.
+      fs.rmSync(hnswManifestPath(tmp));
+
+      expect(readHnswSidecarStatus(tmp)).toEqual({
+        present: true,
+        vectorCount: ROW_COUNT,
+        dimensions: DIM,
+      });
+    });
+
+    it('reports an unknown count — not zero — when the header is unreadable', async () => {
+      await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      fs.writeFileSync(hnswIndexPath(tmp), Buffer.from('not an hnsw sidecar'));
+
+      const status = readHnswSidecarStatus(tmp);
+
+      expect(status.present).toBe(true);
+      expect(status.vectorCount).toBeNull();
+    });
+
+    it('treats a directory at the sidecar path as absent on every platform', () => {
+      // POSIX opens a directory read-only and fails at the first read; Windows
+      // refuses the open. Both must land on the same answer.
+      fs.mkdirSync(hnswIndexPath(tmp));
+
+      expect(readHnswSidecarStatus(tmp)).toEqual({ present: false, vectorCount: 0, dimensions: null });
+    });
+  });
+
+  describe('getEffectiveHNSWStatus — the daemon-routed case', () => {
+    it('reports the on-disk sidecar when this process built no index of its own', async () => {
+      await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      // The state the bug reported as "not built": nothing local at all.
+      expect(getHNSWStatus().entryCount).toBe(0);
+
+      const status = getEffectiveHNSWStatus(tmp);
+
+      expect(status.available).toBe(true);
+      expect(status.initialized).toBe(true);
+      expect(status.entryCount).toBe(ROW_COUNT);
+      expect(status.dimensions).toBe(DIM);
+      expect(status.source).toBe('sidecar');
+    });
+
+    it('still reports not-built when there is genuinely no sidecar', () => {
+      const status = getEffectiveHNSWStatus(tmp);
+
+      expect(status.available).toBe(false);
+      expect(status.initialized).toBe(false);
+      expect(status.entryCount).toBe(0);
+      expect(status.source).toBe('none');
+    });
+
+    it('carries the unknown count through rather than reporting an empty index', async () => {
+      await buildAndWriteHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      fs.writeFileSync(hnswIndexPath(tmp), Buffer.from('not an hnsw sidecar'));
+
+      const status = getEffectiveHNSWStatus(tmp);
+
+      expect(status.available).toBe(true);
+      expect(status.entryCount).toBeNull();
+      expect(status.source).toBe('sidecar');
+    });
+  });
+
+  describe('hnswIndexLabel — what `flo status memory` prints', () => {
+    it('names the sidecar so a routed answer is not mistaken for a local build', () => {
+      expect(hnswIndexLabel({ hnswEnabled: true, hnswSource: 'sidecar' }))
+        .toBe('Active (on-disk sidecar)');
+    });
+
+    it('says Active plainly when this process holds the index', () => {
+      expect(hnswIndexLabel({ hnswEnabled: true, hnswSource: 'process' })).toBe('Active');
+    });
+
+    it('keeps the scan-fallback warning for a genuinely missing index', () => {
+      expect(hnswIndexLabel({ hnswEnabled: false, hnswSource: 'none' }))
+        .toBe('Not built (search falls back to scan)');
+    });
+
+    it('falls back to plain Active for a moflo predating the source field', () => {
+      expect(hnswIndexLabel({ hnswEnabled: true })).toBe('Active');
+    });
+  });
+});

--- a/src/cli/commands/neural.ts
+++ b/src/cli/commands/neural.ts
@@ -416,13 +416,13 @@ const statusCommand: Command = {
     try {
       // Import real implementations
       const { getIntelligenceStats, initializeIntelligence, benchmarkAdaptation } = await import('../memory/intelligence.js');
-      const { getHNSWStatus, loadEmbeddingModel } = await import('../memory/memory-initializer.js');
+      const { getEffectiveHNSWStatus, loadEmbeddingModel } = await import('../memory/memory-initializer.js');
       const training = await import('../services/movector-training.js');
 
       // Initialize if needed and get real stats
       await initializeIntelligence();
       const stats = getIntelligenceStats();
-      const hnswStatus = getHNSWStatus();
+      const hnswStatus = getEffectiveHNSWStatus();
 
       // Quick benchmark for actual adaptation time
       const adaptBench = benchmarkAdaptation(100);
@@ -474,7 +474,7 @@ const statusCommand: Command = {
             component: 'HNSW Index',
             status: hnswStatus.available ? output.success('Ready') : output.dim('Not loaded'),
             details: hnswStatus.available
-              ? `${hnswStatus.entryCount} vectors, ${hnswStatus.dimensions}-dim`
+              ? `${hnswStatus.entryCount ?? 'unknown'} vectors, ${hnswStatus.dimensions}-dim`
               : 'Not initialized',
           },
           {

--- a/src/cli/commands/performance.ts
+++ b/src/cli/commands/performance.ts
@@ -41,7 +41,7 @@ const benchmarkCommand: Command = {
       generateEmbedding,
       batchCosineSim,
       flashAttentionSearch,
-      getHNSWStatus,
+      getEffectiveHNSWStatus,
       storeEntry,
       searchEntries,
     } = await import('../memory/memory-initializer.js');
@@ -123,9 +123,13 @@ const benchmarkCommand: Command = {
     // 3. HNSW Search Benchmark
     if (suite === 'all' || suite === 'search') {
       spinner.setText('Benchmarking HNSW search...');
-      const hnswStatus = getHNSWStatus();
+      // The searches below go through `searchEntries`, which since #1058 is
+      // served by the daemon — so gate on the index that answers them, not on
+      // this process's own singleton, which a routed read never builds (#1387).
+      const hnswStatus = getEffectiveHNSWStatus();
+      const indexedVectors = hnswStatus.entryCount ?? 0;
 
-      if (hnswStatus.available && hnswStatus.entryCount > 0) {
+      if (hnswStatus.available && indexedVectors > 0) {
         const searchTimes: number[] = [];
         const testQueries = [
           'error handling patterns',
@@ -151,10 +155,10 @@ const benchmarkCommand: Command = {
         const mean = searchTimes.reduce((a, b) => a + b, 0) / searchTimes.length;
         // Brute force baseline: ~0.5μs per vector comparison, 1000 vectors = 0.5ms
         // HNSW is O(log n) approximate-nearest-neighbor (ANN) search
-        const baselineBruteForce = hnswStatus.entryCount * 0.0005;
+        const baselineBruteForce = indexedVectors * 0.0005;
         const speedup = baselineBruteForce / (mean / 1000);
         results.push({
-          operation: `HNSW Search (n=${hnswStatus.entryCount})`,
+          operation: `HNSW Search (n=${indexedVectors})`,
           mean: `${mean.toFixed(2)}ms`,
           p95: `${percentile(searchTimes, 95).toFixed(2)}ms`,
           p99: `${percentile(searchTimes, 99).toFixed(2)}ms`,
@@ -377,9 +381,9 @@ const metricsCommand: Command = {
     let cacheHitRate = 'N/A';
     let hnswEntries = 0;
     try {
-      const { getHNSWStatus } = await import('../memory/memory-initializer.js');
-      const status = getHNSWStatus();
-      hnswEntries = status?.entryCount || 0;
+      const { getEffectiveHNSWStatus } = await import('../memory/memory-initializer.js');
+      const status = getEffectiveHNSWStatus();
+      hnswEntries = status?.entryCount ?? 0;
     } catch { /* HNSW not initialized */ }
 
     // Try to get real cache stats

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -606,6 +606,21 @@ const tasksCommand: Command = {
   }
 };
 
+/**
+ * Render the `HNSW Index` row (#1387).
+ *
+ * Names which index answered, because "Active" alone hid the bug this replaces:
+ * the row said "Not built" on every healthy install, since a daemon-routed read
+ * never builds a local index for the CLI to find. Exported for tests.
+ */
+export function hnswIndexLabel(performance: {
+  hnswEnabled: boolean;
+  hnswSource?: 'process' | 'sidecar' | 'none';
+}): string {
+  if (!performance.hnswEnabled) return 'Not built (search falls back to scan)';
+  return performance.hnswSource === 'sidecar' ? 'Active (on-disk sidecar)' : 'Active';
+}
+
 // Memory subcommand
 const memoryCommand: Command = {
   name: 'memory',
@@ -620,7 +635,10 @@ const memoryCommand: Command = {
         performance: {
           avgSearchTime: number | null;
           hnswEnabled: boolean;
-          indexedVectors: number;
+          // null = a sidecar is present but its vector count is unknown (#1387).
+          indexedVectors: number | null;
+          // Absent when talking to a moflo predating #1387.
+          hnswSource?: 'process' | 'sidecar' | 'none';
         };
       }>('memory_detailed-stats', { measureLatency: true });
 
@@ -642,7 +660,7 @@ const memoryCommand: Command = {
           { property: 'Backend', value: result.backend },
           { property: 'Total Entries', value: result.entries.toLocaleString() },
           { property: 'Storage Size', value: formatBytes(result.size) },
-          { property: 'HNSW Index', value: result.performance.hnswEnabled ? 'Active' : 'Not built (search falls back to scan)' }
+          { property: 'HNSW Index', value: hnswIndexLabel(result.performance) }
         ]
       });
 
@@ -657,7 +675,7 @@ const memoryCommand: Command = {
           // Only metrics the store actually measures — write latency and
           // cache hit rate are not tracked anywhere, so they are not shown.
           { metric: 'Avg Search Time', value: result.performance.avgSearchTime === null ? 'unavailable' : `${result.performance.avgSearchTime.toFixed(2)}ms` },
-          { metric: 'Indexed Vectors', value: result.performance.indexedVectors.toLocaleString() }
+          { metric: 'Indexed Vectors', value: result.performance.indexedVectors === null ? 'unknown' : result.performance.indexedVectors.toLocaleString() }
         ]
       });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -729,6 +729,7 @@ export {
   addToHNSWIndex,
   searchHNSWIndex,
   getHNSWStatus,
+  getEffectiveHNSWStatus,
   clearHNSWIndex,
   quantizeInt8,
   dequantizeInt8,

--- a/src/cli/mcp-tools/memory-admin-tools.ts
+++ b/src/cli/mcp-tools/memory-admin-tools.ts
@@ -545,7 +545,7 @@ export const memoryAdminTools: MCPTool[] = [
     },
     handler: async (input) => {
       await ensureInitialized();
-      const { getNamespaceCounts, getHNSWStatus, searchEntries } =
+      const { getNamespaceCounts, getEffectiveHNSWStatus, searchEntries } =
         await import('../memory/memory-initializer.js');
 
       const counts = await getNamespaceCounts();
@@ -565,10 +565,12 @@ export const memoryAdminTools: MCPTool[] = [
         }
       }
 
-      // Reports the in-process index as it stands. Without a probe it is
-      // legitimately "not built" — said plainly rather than forcing an
-      // expensive build just to make the status line look better.
-      const hnsw = getHNSWStatus();
+      // The index that will serve the search, not this process's own singleton.
+      // Reporting the singleton was true until #1058 routed reads through the
+      // daemon; after that it read "not built" precisely when the daemon was
+      // healthy, because a routed read never builds a local index (#1387).
+      // `hnswSource` tells the caller which one answered.
+      const hnsw = getEffectiveHNSWStatus();
 
       return {
         backend: BACKEND_LABEL,
@@ -581,7 +583,11 @@ export const memoryAdminTools: MCPTool[] = [
         performance: {
           avgSearchTime,
           hnswEnabled: hnsw.available && hnsw.initialized,
+          // null, not 0 — a sidecar with no readable manifest has an unknown
+          // vector count, and 0 renders as an empty index (the same inversion
+          // this field already avoids for `avgSearchTime`).
           indexedVectors: hnsw.entryCount,
+          hnswSource: hnsw.source,
         },
       };
     },

--- a/src/cli/memory/hnsw-lite.ts
+++ b/src/cli/memory/hnsw-lite.ts
@@ -6,6 +6,21 @@ export interface HnswSearchResult {
 export type HnswMetric = 'cosine' | 'dot' | 'euclidean';
 const METRICS: readonly HnswMetric[] = ['cosine', 'dot', 'euclidean'];
 
+/**
+ * The fixed-size prefix of a serialized sidecar — everything a caller can learn
+ * about the graph without decoding it. See {@link HnswLite.serialize} for the
+ * byte layout.
+ */
+export interface HnswSerialHeader {
+  metric: HnswMetric;
+  dimensions: number;
+  m: number;
+  efConstruction: number;
+  vectorCount: number;
+  /** Length of the UTF-8 JSON section that follows the header. */
+  jsonLen: number;
+}
+
 const SERIAL_MAGIC = Buffer.from('MFLOHNSW', 'ascii');
 const SERIAL_VERSION = 1;
 const SERIAL_HEADER_BYTES = 32;
@@ -216,32 +231,53 @@ export class HnswLite {
     return out;
   }
 
+  /** Bytes {@link HnswLite.readHeader} needs — the serialized header's size. */
+  static readonly HEADER_BYTES = SERIAL_HEADER_BYTES;
+
+  /**
+   * Decode the fixed 32-byte header of a serialize() buffer (#1387).
+   *
+   * A status caller that only wants "how many vectors does this sidecar hold"
+   * can read {@link HnswLite.HEADER_BYTES} bytes and call this, instead of
+   * loading an 8MB graph or parsing a manifest that lists every id. Applies the
+   * same magic/version/metric checks {@link HnswLite.load} does — the two share
+   * one definition of a well-formed sidecar rather than two copies of the byte
+   * offsets that could drift apart.
+   */
+  static readHeader(buf: Buffer): HnswSerialHeader {
+    if (buf.length < SERIAL_HEADER_BYTES) {
+      throw new Error(`HnswLite.readHeader: buffer too small (${buf.length} < ${SERIAL_HEADER_BYTES})`);
+    }
+    if (buf.compare(SERIAL_MAGIC, 0, SERIAL_MAGIC.length, 0, SERIAL_MAGIC.length) !== 0) {
+      throw new Error(`HnswLite.readHeader: bad magic, expected MFLOHNSW`);
+    }
+    const version = buf.readUInt8(8);
+    if (version !== SERIAL_VERSION) {
+      throw new Error(`HnswLite.readHeader: unsupported version ${version} (expected ${SERIAL_VERSION})`);
+    }
+    const metricCode = buf.readUInt8(9);
+    const metric = METRICS[metricCode];
+    if (!metric) {
+      throw new Error(`HnswLite.readHeader: unknown metric code ${metricCode}`);
+    }
+    return {
+      metric,
+      dimensions: buf.readUInt32LE(12),
+      m: buf.readUInt32LE(16),
+      efConstruction: buf.readUInt32LE(20),
+      vectorCount: buf.readUInt32LE(24),
+      jsonLen: buf.readUInt32LE(28),
+    };
+  }
+
   /**
    * Reconstruct an HnswLite from a serialize() buffer. Throws on bad magic,
    * unknown version, or truncated payload — callers should catch and fall
    * back to rebuilding from the source-of-truth (SQL embedding column).
    */
   static load(buf: Buffer): HnswLite {
-    if (buf.length < SERIAL_HEADER_BYTES) {
-      throw new Error(`HnswLite.load: buffer too small (${buf.length} < ${SERIAL_HEADER_BYTES})`);
-    }
-    if (buf.compare(SERIAL_MAGIC, 0, SERIAL_MAGIC.length, 0, SERIAL_MAGIC.length) !== 0) {
-      throw new Error(`HnswLite.load: bad magic, expected MFLOHNSW`);
-    }
-    const version = buf.readUInt8(8);
-    if (version !== SERIAL_VERSION) {
-      throw new Error(`HnswLite.load: unsupported version ${version} (expected ${SERIAL_VERSION})`);
-    }
-    const metricCode = buf.readUInt8(9);
-    const metric = METRICS[metricCode];
-    if (!metric) {
-      throw new Error(`HnswLite.load: unknown metric code ${metricCode}`);
-    }
-    const dimensions = buf.readUInt32LE(12);
-    const m = buf.readUInt32LE(16);
-    const efConstruction = buf.readUInt32LE(20);
-    const vectorCount = buf.readUInt32LE(24);
-    const jsonLen = buf.readUInt32LE(28);
+    const { metric, dimensions, m, efConstruction, vectorCount, jsonLen } =
+      HnswLite.readHeader(buf);
 
     const expectedSize =
       SERIAL_HEADER_BYTES + jsonLen + vectorCount * dimensions * SERIAL_FLOAT_BYTES;

--- a/src/cli/memory/hnsw-persistence.ts
+++ b/src/cli/memory/hnsw-persistence.ts
@@ -462,6 +462,74 @@ export function tryLoadHnswSidecar(projectRoot: string): HnswLite | null {
 }
 
 /**
+ * What the on-disk sidecar reports about itself, read from its header alone
+ * (#1387). One open + one 32-byte read — no graph decode, and no manifest
+ * parse either, so the cost is independent of store size and a status command
+ * can call it unconditionally.
+ */
+export interface HnswSidecarStatus {
+  /** The sidecar file exists at `<projectRoot>/.moflo/hnsw.index`. */
+  present: boolean;
+  /**
+   * Vectors the sidecar holds, per the count its own header records.
+   *
+   * `null` means "present, count unknown" — the file is there but its header
+   * is truncated or malformed. Deliberately not `0`, which would read as an
+   * index that exists and is empty.
+   */
+  vectorCount: number | null;
+  /** Embedding dimensions per the header; null when the header is unreadable. */
+  dimensions: number | null;
+}
+
+/**
+ * Report the sidecar's on-disk state (#1387).
+ *
+ * The in-process HNSW singleton answers "did *this* process build an index",
+ * which since the #1058 read-routing preamble is `no` in every non-daemon
+ * process. This answers the question a status command actually means: does an
+ * index exist for the daemon to serve searches from, and how many vectors is
+ * it carrying.
+ *
+ * Reads the sidecar's own header rather than the manifest's `ids` array: it is
+ * the count the graph itself carries (so it stays right for a sidecar written
+ * before the manifest existed), and it costs one small read instead of a JSON
+ * parse proportional to store size.
+ */
+export function readHnswSidecarStatus(projectRoot: string): HnswSidecarStatus {
+  const sidecarPath = hnswIndexPath(projectRoot);
+  // `0`, not `null`: no file at all is a known count of nothing. The null-means-
+  // unknown rule applies to a sidecar that IS there but will not parse.
+  const absent = { present: false, vectorCount: 0, dimensions: null };
+
+  // stat before open, and require a regular file: POSIX happily opens a
+  // directory read-only and fails at the first read, while Windows refuses the
+  // open outright. Deciding here keeps both platforms on the same answer.
+  try {
+    if (!fs.statSync(sidecarPath).isFile()) return absent;
+  } catch {
+    return absent;
+  }
+
+  let fd: number;
+  try {
+    fd = fs.openSync(sidecarPath, 'r');
+  } catch {
+    return absent;
+  }
+  try {
+    const head = Buffer.alloc(HnswLite.HEADER_BYTES);
+    const read = fs.readSync(fd, head, 0, head.length, 0);
+    const header = HnswLite.readHeader(head.subarray(0, read));
+    return { present: true, vectorCount: header.vectorCount, dimensions: header.dimensions };
+  } catch {
+    return { present: true, vectorCount: null, dimensions: null };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
  * Load the reconciliation manifest. Returns null when it is absent, unreadable,
  * from another format version, or structurally invalid — every one of which
  * sends `syncHnswSidecar` down the full-rebuild path.

--- a/src/cli/memory/hnsw-singleton.ts
+++ b/src/cli/memory/hnsw-singleton.ts
@@ -16,7 +16,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { HnswLite } from './hnsw-lite.js';
-import { tryLoadHnswSidecar } from './hnsw-persistence.js';
+import { readHnswSidecarStatus, tryLoadHnswSidecar } from './hnsw-persistence.js';
 import { parseEmbeddingJson } from './controllers/_shared.js';
 import { memoryDbPath } from '../services/moflo-paths.js';
 import { openDaemonDatabase } from './daemon-backend.js';
@@ -295,6 +295,79 @@ export function getHNSWStatus(): {
     initialized: hnswIndex?.initialized ?? false,
     entryCount: hnswIndex?.entries.size ?? 0,
     dimensions: hnswIndex?.dimensions ?? 384
+  };
+}
+
+/**
+ * Where an {@link EffectiveHNSWStatus} answer came from.
+ *
+ * - `process` — this process built an index and it holds vectors.
+ * - `sidecar` — this process has no index of its own; the answer describes
+ *   `.moflo/hnsw.index`, which is what the daemon serves searches from.
+ * - `none` — neither exists. The index really is not built.
+ */
+export type HNSWStatusSource = 'process' | 'sidecar' | 'none';
+
+export interface EffectiveHNSWStatus {
+  available: boolean;
+  initialized: boolean;
+  /** `null` only when a sidecar exists but its vector count is unknowable. */
+  entryCount: number | null;
+  dimensions: number;
+  source: HNSWStatusSource;
+}
+
+/**
+ * Status of the index that will actually serve a search — not the caller's
+ * own singleton (#1387).
+ *
+ * {@link getHNSWStatus} reports process-local state, which was a fair proxy
+ * until #1058 routed reads through the daemon's RPC. Since then `searchEntries`
+ * returns before ever touching `searchHNSWIndex`, so in the MCP server and CLI
+ * the local singleton is never built — and reporting it told healthy installs
+ * their index did not exist. The status inverted with health: it read `Active`
+ * only in a process that had *failed* to reach the daemon.
+ *
+ * So: use the local index when one is genuinely populated, and otherwise fall
+ * back to the sidecar on disk. Callers that specifically want process-local
+ * state (a benchmark about to search in-process, a rebuild's before/after)
+ * should keep calling {@link getHNSWStatus}.
+ */
+export function getEffectiveHNSWStatus(projectRoot?: string): EffectiveHNSWStatus {
+  const local = getHNSWStatus();
+
+  // `initialized && entryCount > 0` rather than `available` — a bridge-loaded
+  // process reports available/initialized with a null singleton behind it, and
+  // its entryCount of 0 is an artifact, not a measurement. A local index that
+  // is genuinely built-but-empty falls through here too, which is the intended
+  // answer both ways: with a sidecar on disk that is the more useful report,
+  // and with none, an index holding zero vectors answers no search anyway.
+  if (local.initialized && local.entryCount > 0) {
+    return { ...local, source: 'process' };
+  }
+
+  try {
+    const sidecar = readHnswSidecarStatus(projectRoot ?? resolveStateRoot());
+    if (sidecar.present) {
+      return {
+        available: true,
+        initialized: true,
+        entryCount: sidecar.vectorCount,
+        dimensions: sidecar.dimensions ?? local.dimensions,
+        source: 'sidecar',
+      };
+    }
+  } catch {
+    // An unreadable state root is not evidence of a missing index, but there
+    // is nothing left to consult — fall through to the honest negative.
+  }
+
+  return {
+    available: false,
+    initialized: false,
+    entryCount: 0,
+    dimensions: local.dimensions,
+    source: 'none',
   };
 }
 

--- a/src/cli/memory/memory-initializer.ts
+++ b/src/cli/memory/memory-initializer.ts
@@ -49,6 +49,7 @@ export {
   addToHNSWIndex,
   searchHNSWIndex,
   getHNSWStatus,
+  getEffectiveHNSWStatus,
   clearHNSWIndex,
 } from './hnsw-singleton.js';
 

--- a/src/cli/runtime/headless.ts
+++ b/src/cli/runtime/headless.ts
@@ -26,7 +26,7 @@ import {
   getIntelligenceStats
 } from '../memory/intelligence.js';
 import {
-  getHNSWStatus,
+  getEffectiveHNSWStatus,
   batchCosineSim,
   flashAttentionSearch
 } from '../memory/memory-initializer.js';
@@ -242,9 +242,9 @@ async function runBenchmarks(): Promise<BenchmarkResults> {
 
   // HNSW Status
   console.log('\n3. HNSW Index Status...');
-  const hnswStatus = getHNSWStatus();
-  console.log(`   Entries indexed: ${hnswStatus.entryCount}`);
-  console.log(`   Initialized: ${hnswStatus.initialized}`);
+  const hnswStatus = getEffectiveHNSWStatus();
+  console.log(`   Entries indexed: ${hnswStatus.entryCount ?? 'unknown'}`);
+  console.log(`   Initialized: ${hnswStatus.initialized} (${hnswStatus.source})`);
 
   // Intelligence Stats
   console.log('\n4. Intelligence System Stats...');
@@ -265,7 +265,7 @@ async function runBenchmarks(): Promise<BenchmarkResults> {
       speedup
     },
     hnsw: {
-      entriesIndexed: hnswStatus.entryCount,
+      entriesIndexed: hnswStatus.entryCount ?? 0,
       searchTime: flashTime
     }
   };
@@ -297,10 +297,10 @@ async function showStatus(): Promise<void> {
   console.log(`  Patterns learned: ${stats.patternsLearned}`);
 
   // HNSW
-  const hnsw = getHNSWStatus();
+  const hnsw = getEffectiveHNSWStatus();
   console.log('\nHNSW Index:');
-  console.log(`  Initialized: ${hnsw.initialized}`);
-  console.log(`  Entries: ${hnsw.entryCount}`);
+  console.log(`  Initialized: ${hnsw.initialized} (${hnsw.source})`);
+  console.log(`  Entries: ${hnsw.entryCount ?? 'unknown'}`);
 
   console.log('\nEnvironment:');
   console.log(`  MOFLO_HEADLESS: ${readMofloEnv('HEADLESS') || 'not set'}`);


### PR DESCRIPTION
## Summary

`flo status memory` told every healthy install its vector index did not exist:

```
HNSW Index      Not built (search falls back to scan)
Indexed Vectors 0
```

`getHNSWStatus()` reports the **calling process's** in-memory singleton. That was a fair proxy until #1058 added the read-side routing preamble — since then `searchEntries` returns through the daemon's RPC before ever touching `searchHNSWIndex`, so the MCP server and CLI never build a local index. The status inverted with health: it would only read `Active` in a process that had *failed* to reach the daemon.

The rational consumer response to that line is `flo memory rebuild-index` — a full, needless rebuild that changes nothing. Worse for triage, it made real index problems indistinguishable from this false one.

## Changes

- **`getEffectiveHNSWStatus()`** (`memory/hnsw-singleton.ts`) — reports the index that will actually serve the search: the local one when it is genuinely populated, otherwise the sidecar on disk. Carries a `source: 'process' | 'sidecar' | 'none'` so a routed answer is distinguishable from a local build. `getHNSWStatus()` is unchanged and still correct for callers that mean "did *I* build one" (`performance.ts` benchmarks, `embeddings.ts` before/after a rebuild).
- **`readHnswSidecarStatus()`** (`memory/hnsw-persistence.ts`) — reads presence, vector count and dimensions from the sidecar's own 32-byte header. `statSync().isFile()` before `openSync`, because POSIX opens a directory read-only and fails at the first read while Windows refuses the open — the guard keeps both platforms on one answer.
- **`HnswLite.readHeader()` / `HnswLite.HEADER_BYTES`** (`memory/hnsw-lite.ts`) — the header decoder extracted out of `HnswLite.load()`, which now calls it. One definition of a well-formed sidecar instead of two copies of the byte offsets. 0.24ms and constant in store size, versus 2.6ms to `JSON.parse` a 625KB manifest for `ids.length` — and the header count stays right for a sidecar written before the manifest format existed.
- **`memory_detailed-stats`** sources `hnswEnabled` / `indexedVectors` from the effective status and adds `hnswSource`. `status.ts` renders `Active (on-disk sidecar)` vs `Active`, and `unknown` for an uncountable index.

### Second commit — the same defect on three more surfaces

Every other reporting-only caller of `getHNSWStatus()` had it too. One was not cosmetic:

- **`flo performance benchmark --suite search` was dead**, not merely mislabelled. The gate read the local singleton, found 0, and printed `HNSW Search | N/A | No index` on every healthy install — while the searches it gates go through `searchEntries`, which the daemon serves fine. The count also feeds the `n=` label and the brute-force baseline, so it was load-bearing.
- `flo performance metrics --format json` reported `cache.hnswEntries: 0`.
- `flo neural status` reported `HNSW Index | Not loaded | Not initialized`.
- `runtime/headless.ts` printed 0 entries in both its benchmark and status paths; both now name the `source` alongside `initialized`.

Left on the process-local getter deliberately, because each genuinely means "did *I* build one": `embeddings.ts:540,616` (builds the index, then measures before/after), `embeddings.ts:1368` (reports this process's resident RAM footprint — the sidecar's count would describe memory nobody allocated), and `memory.ts:322` (calls `getHNSWIndex` first).

## Consumer impact

- **Surface**: `flo status memory` and the `memory_detailed-stats` MCP tool — both ship to every consumer.
- **Failure mode fixed**: no consumer is told to rebuild an index that was fine all along.
- **Behaviour change**: `indexedVectors` widens from `number` to `number | null` — a sidecar whose header will not parse has an unknown count, and `0` renders as an empty index. The only in-repo consumer (`status.ts`) handles null. `hnswSource` is additive and optional; the MCP tool declares no output schema, so nothing validates against the old shape.
- **Round-trip**: runtime fix — needs publish + reinstall before consumers see it.

## Verification

End-to-end against the live dogfood store — this branch's build against the installed pre-fix build, minutes apart on the same `.moflo`:

| Command | installed 4.12.4-rc.6 | this branch |
|---|---|---|
| `status memory` | `Not built (search fall...` / `0` | `Active (on-disk sidecar)` / `5,324` |
| `performance benchmark --suite search` | `HNSW Search \| N/A \| No index` | `HNSW Search (n=5324) \| 3.39ms \| ~786x` |
| `performance metrics --format json` | `hnswEntries: 0` | `hnswEntries: 5324` |
| `neural status` | `Not loaded` / `Not initialized` | `Ready` / `5324 vectors, 384-dim` |

`5,324` is the sidecar header's count and the manifest's `ids.length`. `.moflo/vector-stats.json` read `5,325` at that moment, so the reported number provably is not the stale statusline cache.

## Testing

- [x] Unit tests pass — new `src/cli/__tests__/memory/hnsw-status-reporting.test.ts` (13 cases) pins the daemon-routed case by asserting the local singleton is empty *before* checking the report, plus the honest negative (no sidecar → not built), the unknown-count case, and the POSIX/Windows directory-at-the-path parity. `HnswLite.readHeader` covered directly in `hnsw-lite-serialize.test.ts`.
- [x] Full suite: 10,363 passed, 0 failed
- [x] Manual testing done — the table above

Closes #1387
