### PR TITLE
fix(indexer): serialise HNSW sidecar writers behind a single-writer lock

### DIFF
--- a/.claude/scripts/index-patterns.mjs
+++ b/.claude/scripts/index-patterns.mjs
@@ -326,9 +326,15 @@ async function main() {
 
   // Trigger embedding generation in background. Register with the shared
   // ProcessManager (#886) so doctor's zombie scan allowlists it and the
-  // session-end / smoke-teardown drain reaps it. Stable label dedupes against
-  // the index-all chain's later `build-embeddings` step when both run within
-  // the same lock window.
+  // session-end / smoke-teardown drain reaps it.
+  //
+  // The label is namespace-scoped on purpose, and it does NOT dedupe against
+  // the sibling index steps or index-all's own `build-embeddings` — `pm.spawn`
+  // matches labels exactly, so those are four distinct labels. A shared label
+  // would dedupe, but by *skipping* the later run rather than queueing it,
+  // which would leave that namespace's rows unembedded until something else
+  // triggered a pass. The overlap is instead made safe at the point it
+  // actually hurts: `syncHnswSidecar` serialises sidecar writers (#1388).
   try {
     const embeddingScript = resolveMofloBin(
       projectRoot, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true },

--- a/bin/index-patterns.mjs
+++ b/bin/index-patterns.mjs
@@ -326,9 +326,15 @@ async function main() {
 
   // Trigger embedding generation in background. Register with the shared
   // ProcessManager (#886) so doctor's zombie scan allowlists it and the
-  // session-end / smoke-teardown drain reaps it. Stable label dedupes against
-  // the index-all chain's later `build-embeddings` step when both run within
-  // the same lock window.
+  // session-end / smoke-teardown drain reaps it.
+  //
+  // The label is namespace-scoped on purpose, and it does NOT dedupe against
+  // the sibling index steps or index-all's own `build-embeddings` — `pm.spawn`
+  // matches labels exactly, so those are four distinct labels. A shared label
+  // would dedupe, but by *skipping* the later run rather than queueing it,
+  // which would leave that namespace's rows unembedded until something else
+  // triggered a pass. The overlap is instead made safe at the point it
+  // actually hurts: `syncHnswSidecar` serialises sidecar writers (#1388).
   try {
     const embeddingScript = resolveMofloBin(
       projectRoot, 'flo-embeddings', 'build-embeddings.mjs', { includeDevFallback: true },

--- a/src/cli/__tests__/memory/hnsw-sidecar-lock.test.ts
+++ b/src/cli/__tests__/memory/hnsw-sidecar-lock.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Single-writer lock for the HNSW sidecar pair (#1388).
+ *
+ * The failure this guards against is not a torn write — both files are written
+ * atomically. It is that a writer decides *what* to write by loading the graph
+ * and diffing it against the DB, so two writers that each load the same
+ * starting graph both compute a diff against it and the loser's work is
+ * overwritten wholesale. Serialising only the write would not help; the lock
+ * has to span load → diff → write.
+ *
+ * These tests pin the lock's own contract (mutual exclusion, release on throw,
+ * reclaiming a lock nobody holds) and the property that matters at the call
+ * site: concurrent `syncHnswSidecar` calls converge on a sidecar holding every
+ * embedded row, rather than whichever writer finished last.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import {
+  hnswLockPath,
+  pendingLockChainCount,
+  withHnswSidecarLock,
+} from '../../memory/hnsw-sidecar-lock.js';
+import { syncHnswSidecar, tryLoadHnswSidecar } from '../../memory/hnsw-persistence.js';
+import { MOFLO_DIR, MEMORY_DB_FILE } from '../../services/moflo-paths.js';
+import { openDaemonDatabase } from '../../memory/daemon-backend.js';
+
+const DIM = 8;
+
+function vectorFor(seed: number): number[] {
+  return Array.from({ length: DIM }, (_, j) => Number(Math.sin(seed * 0.7 + j * 0.3).toFixed(6)));
+}
+
+function withDb<T>(dbPath: string, fn: (db: ReturnType<typeof openDaemonDatabase>) => T): T {
+  const db = openDaemonDatabase(dbPath);
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function createSchema(dbPath: string): void {
+  withDb(dbPath, (db) => {
+    db.run(`CREATE TABLE memory_entries (
+      id TEXT PRIMARY KEY,
+      key TEXT,
+      namespace TEXT,
+      content TEXT,
+      embedding TEXT,
+      updated_at INTEGER,
+      status TEXT
+    )`);
+  });
+}
+
+function insertRows(dbPath: string, namespace: string, count: number, seedBase: number): void {
+  withDb(dbPath, (db) => {
+    for (let i = 0; i < count; i++) {
+      const seed = seedBase + i;
+      db.run(
+        `INSERT INTO memory_entries (id, key, namespace, content, embedding, updated_at, status)
+         VALUES (?, ?, ?, ?, ?, ?, 'active')`,
+        [`${namespace}-${i}`, `key-${seed}`, namespace, `content ${seed}`,
+          JSON.stringify(vectorFor(seed)), 1_700_000_000_000],
+      );
+    }
+  });
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('hnsw-sidecar-lock (#1388)', () => {
+  let tmp: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1388-'));
+    fs.mkdirSync(path.join(tmp, MOFLO_DIR));
+    dbPath = path.join(tmp, MOFLO_DIR, MEMORY_DB_FILE);
+    createSchema(dbPath);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  describe('mutual exclusion', () => {
+    it('never runs two critical sections at once', async () => {
+      let concurrent = 0;
+      let peak = 0;
+
+      const section = async () => {
+        concurrent++;
+        peak = Math.max(peak, concurrent);
+        await delay(10);
+        concurrent--;
+      };
+
+      await Promise.all(
+        Array.from({ length: 8 }, () => withHnswSidecarLock(tmp, section)),
+      );
+
+      expect(peak).toBe(1);
+    });
+
+    it('runs them in the order they asked, so no waiter is starved', async () => {
+      const order: number[] = [];
+
+      await Promise.all(
+        Array.from({ length: 5 }, (_, i) =>
+          withHnswSidecarLock(tmp, async () => {
+            order.push(i);
+            await delay(5);
+          }),
+        ),
+      );
+
+      expect(order).toEqual([0, 1, 2, 3, 4]);
+    });
+  });
+
+  describe('release', () => {
+    it('removes the lock file after a successful run', async () => {
+      await withHnswSidecarLock(tmp, async () => {
+        expect(fs.existsSync(hnswLockPath(tmp))).toBe(true);
+      });
+
+      expect(fs.existsSync(hnswLockPath(tmp))).toBe(false);
+    });
+
+    it('releases when the critical section throws, and propagates the error', async () => {
+      await expect(
+        withHnswSidecarLock(tmp, async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+
+      expect(fs.existsSync(hnswLockPath(tmp))).toBe(false);
+    });
+
+    it('keeps serialising after a critical section throws', async () => {
+      const ran: string[] = [];
+
+      const failing = withHnswSidecarLock(tmp, async () => {
+        ran.push('failing');
+        throw new Error('boom');
+      }).catch(() => undefined);
+      const following = withHnswSidecarLock(tmp, async () => { ran.push('following'); });
+
+      await Promise.all([failing, following]);
+
+      expect(ran).toEqual(['failing', 'following']);
+    });
+  });
+
+  describe('a project root without a state directory yet', () => {
+    it('creates .moflo on demand rather than failing to acquire', async () => {
+      // The common path skips `mkdirSync` entirely — `.moflo/` exists for any
+      // project with a database to index — so the directory is created lazily
+      // off the ENOENT retry. That branch needs its own coverage precisely
+      // because normal runs never reach it.
+      const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1388-bare-'));
+      try {
+        expect(fs.existsSync(path.join(bare, MOFLO_DIR))).toBe(false);
+
+        let ran = false;
+        await withHnswSidecarLock(bare, async () => { ran = true; });
+
+        expect(ran).toBe(true);
+        expect(fs.existsSync(path.join(bare, MOFLO_DIR))).toBe(true);
+        expect(fs.existsSync(hnswLockPath(bare))).toBe(false);
+      } finally {
+        fs.rmSync(bare, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      }
+    });
+  });
+
+  describe('giving up on a live holder', () => {
+    it('throws rather than writing alongside a holder that is still alive', async () => {
+      // Our own pid, stamped now: alive and not stale, so the only way out is
+      // the deadline. Breaking the lock here would run concurrently with a
+      // confirmed-live writer — the race the module exists to close.
+      fs.writeFileSync(
+        hnswLockPath(tmp),
+        JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+      );
+
+      let ran = false;
+      await expect(
+        withHnswSidecarLock(tmp, async () => { ran = true; }, { acquireTimeoutMs: 120 }),
+      ).rejects.toThrow(/still held by pid/);
+
+      expect(ran).toBe(false);
+      // The holder's lock is left untouched — it is still theirs.
+      expect(fs.existsSync(hnswLockPath(tmp))).toBe(true);
+    });
+
+    it('names the blocking pid so a wedged lock is diagnosable', async () => {
+      fs.writeFileSync(
+        hnswLockPath(tmp),
+        JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+      );
+
+      await expect(
+        withHnswSidecarLock(tmp, async () => undefined, { acquireTimeoutMs: 120 }),
+      ).rejects.toThrow(new RegExp(`pid ${process.pid}`));
+    });
+  });
+
+  describe('the in-process chain drains', () => {
+    it('tracks nothing once every caller has settled', async () => {
+      await Promise.all(
+        Array.from({ length: 6 }, () => withHnswSidecarLock(tmp, async () => { await delay(1); })),
+      );
+
+      expect(pendingLockChainCount()).toBe(0);
+    });
+
+    it('drains even when callers reject', async () => {
+      await Promise.all([
+        withHnswSidecarLock(tmp, async () => { throw new Error('boom'); }).catch(() => undefined),
+        withHnswSidecarLock(tmp, async () => undefined),
+      ]);
+
+      expect(pendingLockChainCount()).toBe(0);
+    });
+  });
+
+  describe('reclaiming a lock nobody holds', () => {
+    it('takes over a lock whose holder process has exited', async () => {
+      // PID 0x7FFFFFFF is beyond any real pid_max on the platforms we ship to.
+      fs.writeFileSync(
+        hnswLockPath(tmp),
+        JSON.stringify({ pid: 2_147_483_647, startedAt: Date.now() }),
+      );
+
+      let ran = false;
+      await withHnswSidecarLock(tmp, async () => { ran = true; });
+
+      expect(ran).toBe(true);
+      expect(fs.existsSync(hnswLockPath(tmp))).toBe(false);
+    });
+
+    it('takes over a lock left half-written by a killed process', async () => {
+      fs.writeFileSync(hnswLockPath(tmp), '{"pid":123,"star');
+
+      let ran = false;
+      await withHnswSidecarLock(tmp, async () => { ran = true; });
+
+      expect(ran).toBe(true);
+    });
+
+    it('takes over a lock older than the staleness cap even if its pid is live', async () => {
+      // Our own pid is unambiguously alive — only the age can free this one,
+      // which is the Windows pid-recycling backstop.
+      fs.writeFileSync(
+        hnswLockPath(tmp),
+        JSON.stringify({ pid: process.pid, startedAt: Date.now() - 60 * 60_000 }),
+      );
+
+      let ran = false;
+      await withHnswSidecarLock(tmp, async () => { ran = true; });
+
+      expect(ran).toBe(true);
+    });
+  });
+
+  describe('what the lock buys at the call site', () => {
+    it('holds the lock for the whole sync, not just the write', async () => {
+      // The discriminating test: a competitor asking for the lock while a sync
+      // is in flight must be made to wait. Remove the wrapper from
+      // `syncHnswSidecar` and the competitor runs first, because nothing is
+      // holding anything — which is precisely the pre-#1388 behaviour.
+      insertRows(dbPath, 'patterns', 40, 0);
+      const order: string[] = [];
+
+      const sync = syncHnswSidecar(dbPath, tmp, { dimensions: DIM })
+        .then(() => { order.push('sync'); });
+      // Yield once so the sync has taken the lock before the competitor asks.
+      await delay(0);
+      const competitor = withHnswSidecarLock(tmp, async () => { order.push('competitor'); });
+
+      await Promise.all([sync, competitor]);
+
+      expect(order).toEqual(['sync', 'competitor']);
+    });
+
+    it('converges on every embedded row when writers overlap', async () => {
+      // Three namespace-scoped writers, exactly the shape index-patterns,
+      // index-reference and index-guidance produce. Pre-#1388 the last one to
+      // finish decided the sidecar's contents and the others' rows vanished.
+      insertRows(dbPath, 'patterns', 5, 0);
+      insertRows(dbPath, 'reference', 5, 100);
+      insertRows(dbPath, 'guidance', 5, 200);
+
+      await Promise.all([
+        syncHnswSidecar(dbPath, tmp, { dimensions: DIM }),
+        syncHnswSidecar(dbPath, tmp, { dimensions: DIM }),
+        syncHnswSidecar(dbPath, tmp, { dimensions: DIM }),
+      ]);
+
+      const loaded = tryLoadHnswSidecar(tmp);
+      expect(loaded?.size).toBe(15);
+      expect(fs.existsSync(hnswLockPath(tmp))).toBe(false);
+    });
+
+    it('does not lose rows a writer added while another writer was mid-flight', async () => {
+      insertRows(dbPath, 'patterns', 5, 0);
+
+      // First sync establishes a sidecar; the second starts against a DB that
+      // grew in between. Both must be reflected, not just the later one.
+      const first = syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+      insertRows(dbPath, 'reference', 4, 100);
+      const second = syncHnswSidecar(dbPath, tmp, { dimensions: DIM });
+
+      await Promise.all([first, second]);
+
+      expect(tryLoadHnswSidecar(tmp)?.size).toBe(9);
+    });
+
+    it('leaves no lock behind when the guarded operation fails', async () => {
+      await expect(
+        syncHnswSidecar(path.join(tmp, MOFLO_DIR, 'missing.db'), tmp, { dimensions: DIM }),
+      ).rejects.toThrow(/db not found/);
+
+      expect(fs.existsSync(hnswLockPath(tmp))).toBe(false);
+    });
+  });
+});

--- a/src/cli/memory/hnsw-persistence.ts
+++ b/src/cli/memory/hnsw-persistence.ts
@@ -48,6 +48,7 @@ import * as path from 'node:path';
 
 import { atomicWriteFileSync } from '../services/atomic-file-write.js';
 import { HnswLite } from './hnsw-lite.js';
+import { withHnswSidecarLock } from './hnsw-sidecar-lock.js';
 import { parseEmbeddingJson } from './controllers/_shared.js';
 import { hnswIndexPath } from '../services/moflo-paths.js';
 import { openDaemonDatabase } from './daemon-backend.js';
@@ -252,6 +253,23 @@ export async function buildAndWriteHnswSidecar(
   projectRoot: string,
   options: HnswBuildOptions = {},
 ): Promise<HnswBuildResult> {
+  return withHnswSidecarLock(projectRoot, () =>
+    buildAndWriteHnswSidecarUnlocked(dbPath, projectRoot, options),
+  );
+}
+
+/**
+ * The body of {@link buildAndWriteHnswSidecar}, minus the lock.
+ *
+ * Exists so `syncHnswSidecar`'s full-rebuild fallback can reach it while
+ * already holding the lock — {@link withHnswSidecarLock} is not re-entrant,
+ * so calling the public wrapper from inside it would deadlock (#1388).
+ */
+async function buildAndWriteHnswSidecarUnlocked(
+  dbPath: string,
+  projectRoot: string,
+  options: HnswBuildOptions,
+): Promise<HnswBuildResult> {
   const { dimensions, m, efConstruction, metric } = resolveOptions(options);
 
   if (!fs.existsSync(dbPath)) {
@@ -316,6 +334,20 @@ export async function syncHnswSidecar(
   projectRoot: string,
   options: HnswBuildOptions & { force?: boolean } = {},
 ): Promise<HnswSyncResult> {
+  // The lock spans load → diff → write, not just the write: a writer decides
+  // what to persist by diffing the graph it loaded, so serialising only the
+  // write would still let a second writer act on a pre-first-writer snapshot
+  // and overwrite it wholesale (#1388).
+  return withHnswSidecarLock(projectRoot, () =>
+    syncHnswSidecarUnlocked(dbPath, projectRoot, options),
+  );
+}
+
+async function syncHnswSidecarUnlocked(
+  dbPath: string,
+  projectRoot: string,
+  options: HnswBuildOptions & { force?: boolean },
+): Promise<HnswSyncResult> {
   const { dimensions, m, efConstruction, metric } = resolveOptions(options);
 
   if (!fs.existsSync(dbPath)) {
@@ -323,7 +355,7 @@ export async function syncHnswSidecar(
   }
 
   const fullRebuild = async (reason: string): Promise<HnswSyncResult> => {
-    const built = await buildAndWriteHnswSidecar(dbPath, projectRoot, options);
+    const built = await buildAndWriteHnswSidecarUnlocked(dbPath, projectRoot, options);
     return { ...built, mode: 'full', reason, added: built.vectorCount, removed: 0 };
   };
 

--- a/src/cli/memory/hnsw-sidecar-lock.ts
+++ b/src/cli/memory/hnsw-sidecar-lock.ts
@@ -1,0 +1,291 @@
+/**
+ * Single-writer lock for the HNSW sidecar pair (#1388).
+ *
+ * `.moflo/hnsw.index` and `.moflo/hnsw.manifest.json` are each written
+ * atomically, but they are two independent writes with nothing tying them
+ * together — and, more importantly, a writer decides *what* to write by
+ * loading the sidecar and diffing it against the DB long before it writes.
+ * Two writers therefore clobber each other even though neither write is torn:
+ * both load the same starting graph, both compute a diff against it, and the
+ * loser's result is simply overwritten. Observed on 4.12.4-rc.6, where the
+ * sidecar ended a run holding 5199 vectors while the DB had 5219.
+ *
+ * The concurrency is not accidental. `index-all.mjs` runs its steps in
+ * sequence, but `index-patterns`/`index-reference`/`index-guidance` each
+ * fire-and-forget their own namespace-scoped `build-embeddings`, and
+ * `pm.spawn` dedups on exact label equality — so `build-embeddings-patterns`,
+ * `build-embeddings-reference`, `build-embeddings-guidance` and index-all's
+ * own `build-embeddings` are four distinct labels that never dedup against
+ * each other. `flo memory rebuild-index` can join them at any moment.
+ *
+ * So the lock has to span **load → diff → write**, not just the write. Held
+ * only around the write, the second writer would still be acting on a graph
+ * it read before the first writer's result existed, and last-writer-wins
+ * would survive untouched. Held across the whole operation, the second writer
+ * blocks, then loads the first writer's freshly written sidecar and adds only
+ * its own new rows — which is exactly the incremental path #1384 built.
+ *
+ * ## Why this shape
+ *
+ * `writeFileSync(..., { flag: 'wx' })` is `O_CREAT | O_EXCL`: the write fails
+ * with EEXIST if the file exists, atomically, on Linux, macOS and Windows
+ * alike. It is the same primitive `services/daemon-lock.ts` uses, for the same
+ * reason — no `flock`, no advisory-lock assumptions, no platform branch.
+ *
+ * This lock differs from the daemon's in one way that matters: the daemon's is
+ * fail-fast (the loser must not run), this one **waits** (the loser must run,
+ * just afterwards). Losing an embedding run would leave rows unsearchable
+ * until the next session, which is the class of bug #1383 exists to prevent.
+ *
+ * @module memory/hnsw-sidecar-lock
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { hnswIndexPath } from '../services/moflo-paths.js';
+
+const LOCK_FILENAME = 'hnsw.lock';
+
+/** How often to retry acquiring while another process holds the lock. */
+const POLL_INTERVAL_MS = 50;
+
+/**
+ * How long to wait for a live holder before giving up — and **throwing**.
+ *
+ * The tempting alternative, breaking the lock and proceeding, is wrong: by
+ * this point the holder has been confirmed alive and non-stale on every poll,
+ * so taking the lock means running concurrently with it. That is precisely the
+ * load→diff→write race this module exists to close, reintroduced silently
+ * under a `console.warn`.
+ *
+ * Throwing is contained. Embedding happens before the sidecar step, so the
+ * rows are already committed to the DB; `build-embeddings.mjs` logs the error
+ * to `background.log` and exits non-zero, and the next indexing pass
+ * reconciles. A wedged lock costs one deferred reconcile, not a corrupt graph.
+ *
+ * A full rebuild of a large consumer store is seconds, so 120s of contention
+ * already means something is wrong and should say so.
+ */
+const ACQUIRE_TIMEOUT_MS = 120_000;
+
+/**
+ * Age past which a lock is presumed abandoned even if a live process claims it.
+ *
+ * The liveness probe below already reclaims a lock whose holder has exited.
+ * This is the backstop for the case it cannot see: a recycled PID on Windows
+ * now belonging to an unrelated process, which would otherwise read as "the
+ * holder is alive" forever.
+ */
+const STALE_LOCK_MS = 10 * 60_000;
+
+interface LockPayload {
+  pid: number;
+  startedAt: number;
+}
+
+/** `<projectRoot>/.moflo/hnsw.lock`, beside the sidecar it guards. */
+export function hnswLockPath(projectRoot: string): string {
+  return path.join(path.dirname(hnswIndexPath(projectRoot)), LOCK_FILENAME);
+}
+
+/**
+ * In-process serialisation, keyed by lock path.
+ *
+ * The file lock is cross-process; this covers the same-process case, where two
+ * concurrent `await syncHnswSidecar(...)` calls in one runtime (the daemon
+ * servicing two requests, a test driving both entry points) would otherwise
+ * each see no lock file and both proceed. Chaining their promises means the
+ * file lock only ever arbitrates between distinct processes, which is what it
+ * is good at.
+ */
+const inProcessChain = new Map<string, Promise<unknown>>();
+
+/**
+ * How many lock paths the in-process chain is currently tracking.
+ *
+ * Exported for tests. The map must drain back to zero once every caller has
+ * settled — an earlier revision compared the wrong promise reference in its
+ * cleanup, so the entry was never removed and the map grew one slot per lock
+ * path for the life of the process. That leak is invisible from the outside,
+ * which is exactly why it needs an assertion of its own.
+ */
+export function pendingLockChainCount(): number {
+  return inProcessChain.size;
+}
+
+/**
+ * Is `pid` a process that could still be holding the lock?
+ *
+ * The zombie branch is not optional here. `kill(pid, 0)` succeeds for a
+ * process that has exited but not been reaped, and `build-embeddings` is
+ * spawned by an indexer that often outlives it — so its corpse can sit
+ * unreaped, and treating it as a live holder would make every waiter poll a
+ * dead process until the staleness cap. `services/daemon-lock.ts` learned this
+ * the same way; the logic below is deliberately kept in step with it.
+ *
+ * Not shared with that copy on purpose: daemon-lock treats EPERM as *dead*,
+ * which is right for it (it pairs the probe with a command-line check and
+ * wants to reclaim locks left by unrelated processes) and wrong here, where
+ * treating another user's live process as dead would mean writing alongside
+ * it. Unifying them means changing daemon-lock's semantics, which is not this
+ * fix's blast radius.
+ */
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+  } catch (err) {
+    // EPERM means the process exists but belongs to another user — alive for
+    // our purposes. Only ESRCH is proof of absence.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+  if (process.platform === 'linux') {
+    try {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf-8');
+      // The comm field can contain spaces and parens, so index from the last
+      // ')' — state is the character two positions after it.
+      const lastParen = stat.lastIndexOf(')');
+      if (lastParen !== -1 && stat.charAt(lastParen + 2) === 'Z') return false;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      // /proc unavailable (a container without it) — keep the kill(0) verdict.
+    }
+  }
+  return true;
+}
+
+function readLock(lockFile: string): LockPayload | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(lockFile, 'utf-8')) as Partial<LockPayload>;
+    if (typeof parsed.pid !== 'number' || typeof parsed.startedAt !== 'number') return null;
+    return { pid: parsed.pid, startedAt: parsed.startedAt };
+  } catch {
+    // Missing (released between EEXIST and this read) or unparseable (a
+    // half-written lock from a process killed mid-write). Both mean "nothing
+    // trustworthy is holding this".
+    return null;
+  }
+}
+
+/** Remove a lock we have judged abandoned. Losing the race to do so is fine. */
+function breakLock(lockFile: string): void {
+  try {
+    fs.unlinkSync(lockFile);
+  } catch {
+    /* already gone, or another waiter broke it first */
+  }
+}
+
+/**
+ * True when the on-disk lock should not stop us: absent, unparseable, held by
+ * a process that has exited, or older than {@link STALE_LOCK_MS}.
+ */
+function isReclaimable(lockFile: string, now: number): boolean {
+  const held = readLock(lockFile);
+  if (!held) return true;
+  if (!isProcessAlive(held.pid)) return true;
+  return now - held.startedAt > STALE_LOCK_MS;
+}
+
+/**
+ * Run `fn` with exclusive access to the sidecar pair at `projectRoot`.
+ *
+ * Serialises against other processes via the lock file and against other
+ * callers in this process via a promise chain. Always releases, including when
+ * `fn` throws — the caller's error propagates unchanged.
+ *
+ * Not re-entrant, deliberately: nesting two calls would deadlock on the
+ * in-process chain. Callers compose by keeping an unlocked core function and
+ * wrapping only at the public entry points.
+ */
+export async function withHnswSidecarLock<T>(
+  projectRoot: string,
+  fn: () => Promise<T>,
+  /**
+   * `acquireTimeoutMs` overrides {@link ACQUIRE_TIMEOUT_MS}. A seam for tests:
+   * the give-up branch is the one place this module refuses to write, and at
+   * the production value it would take two minutes of held contention to
+   * reach. Production callers pass nothing.
+   */
+  options: { acquireTimeoutMs?: number } = {},
+): Promise<T> {
+  const lockFile = hnswLockPath(projectRoot);
+  const previous = inProcessChain.get(lockFile) ?? Promise.resolve();
+
+  // Chain regardless of how the previous holder finished — a rejection there
+  // is that caller's problem, not a reason to stop serialising.
+  const run = previous
+    .catch(() => undefined)
+    .then(() => acquireThenRun(lockFile, fn, options.acquireTimeoutMs ?? ACQUIRE_TIMEOUT_MS));
+  // Track the settled-swallowing wrapper, not `run` itself, and compare against
+  // that same reference below — comparing against `run` never matches, which
+  // silently turned the cleanup into a no-op and leaked one entry per lock path.
+  const tracked = run.catch(() => undefined);
+  inProcessChain.set(lockFile, tracked);
+
+  try {
+    return await run;
+  } finally {
+    // Drop the entry only while we are still the tail. A later caller that has
+    // already chained onto us owns the slot, and must keep it.
+    if (inProcessChain.get(lockFile) === tracked) {
+      inProcessChain.delete(lockFile);
+    }
+  }
+}
+
+async function acquireThenRun<T>(
+  lockFile: string,
+  fn: () => Promise<T>,
+  acquireTimeoutMs: number,
+): Promise<T> {
+  const payload: LockPayload = { pid: process.pid, startedAt: Date.now() };
+  const deadline = payload.startedAt + acquireTimeoutMs;
+
+  for (;;) {
+    try {
+      fs.writeFileSync(lockFile, JSON.stringify(payload), { flag: 'wx' });
+      break;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+
+      // `.moflo/` exists for any project with a database to index, so this is
+      // the cold path, not a per-acquire `mkdirSync` on the common one.
+      if (code === 'ENOENT') {
+        fs.mkdirSync(path.dirname(lockFile), { recursive: true });
+        continue;
+      }
+      if (code !== 'EEXIST') throw err;
+
+      const now = Date.now();
+      if (isReclaimable(lockFile, now)) {
+        breakLock(lockFile);
+        continue;
+      }
+      if (now >= deadline) {
+        // Deliberately not `breakLock` + proceed: every poll to here confirmed
+        // the holder alive and non-stale, so taking the lock now would run
+        // concurrently with it — the exact race this module closes.
+        const holder = readLock(lockFile);
+        throw new Error(
+          `hnsw sidecar lock at ${lockFile} still held by pid ${holder?.pid ?? 'unknown'} ` +
+          `after ${acquireTimeoutMs}ms; skipping this reconcile rather than writing alongside it`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    // Only remove a lock still carrying our payload. A hold that outlives
+    // STALE_LOCK_MS can be reclaimed out from under us, and by then the file
+    // belongs to whoever took it — deleting theirs would hand a third writer a
+    // lock nobody holds.
+    const current = readLock(lockFile);
+    if (current && current.pid === payload.pid && current.startedAt === payload.startedAt) {
+      breakLock(lockFile);
+    }
+  }
+}

--- a/tests/system/hnsw-sidecar-concurrent-writers-1388.test.ts
+++ b/tests/system/hnsw-sidecar-concurrent-writers-1388.test.ts
@@ -1,0 +1,253 @@
+/**
+ * System E2E: concurrent HNSW sidecar writers (#1388).
+ *
+ * The bug in the wild was cross-process, not cross-async: `index-patterns`,
+ * `index-reference` and `index-guidance` each fire-and-forget their own
+ * namespace-scoped `build-embeddings`, `pm.spawn` dedups on exact label
+ * equality so those four labels never match, and each spawned process ends by
+ * writing `.moflo/hnsw.index`. On 4.12.4-rc.6 two of them interleaved and the
+ * sidecar was left holding 5199 vectors while the DB had 5219 — the older
+ * writer's graph overwrote the newer one's.
+ *
+ * In-process tests (`src/cli/__tests__/memory/hnsw-sidecar-lock.test.ts`)
+ * cover the promise-chain half. This suite covers the half that only real
+ * subprocesses can prove: that the `O_CREAT | O_EXCL` lock file actually
+ * excludes across process boundaries, on all three platforms we ship to.
+ * Rule #1 lives or dies here — there is no `flock`, so if the primitive
+ * behaved differently on Windows this is where it would surface.
+ *
+ * Cross-platform: spawns via `process.execPath`, paths via node:path, temp
+ * roots under `os.tmpdir()`, cleanup tolerant of Windows handle-release
+ * latency.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawn } from 'node:child_process';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DIST_LOCK = path.join(REPO_ROOT, 'dist', 'src', 'cli', 'memory', 'hnsw-sidecar-lock.js');
+const DIST_PERSISTENCE = path.join(REPO_ROOT, 'dist', 'src', 'cli', 'memory', 'hnsw-persistence.js');
+const DIST_BACKEND = path.join(REPO_ROOT, 'dist', 'src', 'cli', 'memory', 'daemon-backend.js');
+
+const DIM = 8;
+/** Long enough that overlapping holds are unmistakable, short enough to stay quick. */
+const HOLD_MS = 300;
+
+function moduleUrl(filePath: string): string {
+  return 'file://' + filePath.replace(/\\/g, '/');
+}
+
+interface HoldWindow {
+  role: string;
+  enteredAt: number;
+  exitedAt: number;
+}
+
+/** Run one subprocess and parse the single JSON line it prints. */
+function runScript<T>(scriptPath: string, source: string): Promise<T> {
+  fs.writeFileSync(scriptPath, source, 'utf-8');
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += String(d); });
+    child.stderr.on('data', (d) => { stderr += String(d); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${path.basename(scriptPath)} exited ${code}: ${stderr || stdout}`));
+        return;
+      }
+      const line = stdout.trim().split(/\r?\n/).filter(Boolean).pop();
+      if (!line) {
+        reject(new Error(`${path.basename(scriptPath)} printed nothing. stderr: ${stderr}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(line) as T);
+      } catch (err) {
+        reject(new Error(`${path.basename(scriptPath)} printed non-JSON: ${line} (${err})`));
+      }
+    });
+  });
+}
+
+describe('HNSW sidecar concurrent writers (#1388)', () => {
+  let tmp: string;
+  let scriptDir: string;
+  let dbPath: string;
+  let distMissing = false;
+
+  beforeAll(() => {
+    // A source-only checkout has no dist. Skip loudly rather than fail with an
+    // unresolvable-import error that reads like a real defect.
+    distMissing = !fs.existsSync(DIST_LOCK) || !fs.existsSync(DIST_PERSISTENCE);
+    if (distMissing) {
+      console.warn(
+        `[hnsw-sidecar-concurrent-writers] skipping suite — ${DIST_LOCK} not found. Run: npm run build`,
+      );
+    }
+  });
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1388-sys-'));
+    fs.mkdirSync(path.join(tmp, '.moflo'));
+    scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'moflo-1388-scripts-'));
+    dbPath = path.join(tmp, '.moflo', 'moflo.db');
+  });
+
+  afterEach(() => {
+    for (const dir of [tmp, scriptDir]) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      } catch {
+        /* best-effort — Windows can hold a brief handle */
+      }
+    }
+  });
+
+  it('never lets two processes hold the sidecar lock at once', async () => {
+    if (distMissing) return;
+
+    const roles = ['patterns', 'reference', 'guidance', 'rebuild-index'];
+    const windows = await Promise.all(
+      roles.map((role) =>
+        runScript<HoldWindow>(
+          path.join(scriptDir, `holder-${role}.mjs`),
+          `
+          import { withHnswSidecarLock } from ${JSON.stringify(moduleUrl(DIST_LOCK))};
+          const root = ${JSON.stringify(tmp)};
+          let enteredAt = 0;
+          await withHnswSidecarLock(root, async () => {
+            enteredAt = Date.now();
+            await new Promise(r => setTimeout(r, ${HOLD_MS}));
+          });
+          console.log(JSON.stringify({ role: ${JSON.stringify(role)}, enteredAt, exitedAt: Date.now() }));
+          `,
+        ),
+      ),
+    );
+
+    expect(windows).toHaveLength(roles.length);
+
+    // Sort by entry and require each hold to end before the next begins. With
+    // no lock every process enters immediately and these intervals all overlap.
+    const ordered = [...windows].sort((a, b) => a.enteredAt - b.enteredAt);
+    for (let i = 1; i < ordered.length; i++) {
+      const previous = ordered[i - 1];
+      const current = ordered[i];
+      expect(
+        previous.exitedAt,
+        `${previous.role} was still holding the lock when ${current.role} entered`,
+      ).toBeLessThanOrEqual(current.enteredAt);
+    }
+
+    // Serialised holds cannot finish faster than their sum.
+    const span = Math.max(...windows.map((w) => w.exitedAt)) -
+      Math.min(...windows.map((w) => w.enteredAt));
+    expect(span).toBeGreaterThanOrEqual(HOLD_MS * (roles.length - 1));
+  }, 60_000);
+
+  it('releases the lock file when every writer has finished', async () => {
+    if (distMissing) return;
+
+    await Promise.all(
+      ['a', 'b'].map((role) =>
+        runScript<HoldWindow>(
+          path.join(scriptDir, `release-${role}.mjs`),
+          `
+          import { withHnswSidecarLock } from ${JSON.stringify(moduleUrl(DIST_LOCK))};
+          let enteredAt = 0;
+          await withHnswSidecarLock(${JSON.stringify(tmp)}, async () => {
+            enteredAt = Date.now();
+            await new Promise(r => setTimeout(r, 20));
+          });
+          console.log(JSON.stringify({ role: ${JSON.stringify(role)}, enteredAt, exitedAt: Date.now() }));
+          `,
+        ),
+      ),
+    );
+
+    expect(fs.existsSync(path.join(tmp, '.moflo', 'hnsw.lock'))).toBe(false);
+  }, 60_000);
+
+  it('keeps every namespace\'s rows when three writers embed and sync at once', async () => {
+    if (distMissing) return;
+
+    // The shape from the wild: each process writes its own namespace's rows and
+    // then reconciles the shared sidecar. Pre-#1388 the last writer to finish
+    // decided the contents and the others' vectors were dropped.
+    const namespaces = ['patterns', 'reference', 'guidance'];
+    const rowsPerNamespace = 6;
+
+    const results = await Promise.all(
+      namespaces.map((namespace, index) =>
+        runScript<{ namespace: string; vectorCount: number; mode: string; reason?: string }>(
+          path.join(scriptDir, `writer-${namespace}.mjs`),
+          `
+          import { openDaemonDatabase } from ${JSON.stringify(moduleUrl(DIST_BACKEND))};
+          import { syncHnswSidecar } from ${JSON.stringify(moduleUrl(DIST_PERSISTENCE))};
+
+          const dbPath = ${JSON.stringify(dbPath)};
+          const root = ${JSON.stringify(tmp)};
+          const namespace = ${JSON.stringify(namespace)};
+          const seedBase = ${index * 100};
+          const vectorFor = (seed) =>
+            Array.from({ length: ${DIM} }, (_, j) => Number(Math.sin(seed * 0.7 + j * 0.3).toFixed(6)));
+
+          const db = openDaemonDatabase(dbPath);
+          try {
+            db.run(\`CREATE TABLE IF NOT EXISTS memory_entries (
+              id TEXT PRIMARY KEY, key TEXT, namespace TEXT, content TEXT,
+              embedding TEXT, updated_at INTEGER, status TEXT
+            )\`);
+            for (let i = 0; i < ${rowsPerNamespace}; i++) {
+              db.run(
+                \`INSERT OR REPLACE INTO memory_entries
+                   (id, key, namespace, content, embedding, updated_at, status)
+                 VALUES (?, ?, ?, ?, ?, ?, 'active')\`,
+                [namespace + '-' + i, 'key-' + (seedBase + i), namespace,
+                 'content ' + (seedBase + i), JSON.stringify(vectorFor(seedBase + i)),
+                 1700000000000],
+              );
+            }
+          } finally {
+            db.close();
+          }
+
+          const result = await syncHnswSidecar(dbPath, root, { dimensions: ${DIM} });
+          console.log(JSON.stringify({
+            namespace, vectorCount: result.vectorCount, mode: result.mode, reason: result.reason,
+          }));
+          `,
+        ),
+      ),
+    );
+
+    expect(results).toHaveLength(namespaces.length);
+
+    // At most one full rebuild across the whole pass. The first writer finds no
+    // sidecar and legitimately builds one; every writer after it inherits a
+    // valid index+manifest pair and reconciles incrementally. Unserialised,
+    // each writer found the same absent-or-mismatched pair and rebuilt from
+    // scratch — the quadratic work #1384 exists to avoid, paid N times over.
+    const fullRebuilds = results.filter((r) => r.mode === 'full');
+    expect(
+      fullRebuilds.length,
+      `expected at most one full rebuild, got ${fullRebuilds.map((r) => r.reason).join(', ')}`,
+    ).toBeLessThanOrEqual(1);
+
+    // Read the final sidecar the way a cold-start consumer would.
+    const { tryLoadHnswSidecar } = await import(moduleUrl(DIST_PERSISTENCE)) as {
+      tryLoadHnswSidecar: (root: string) => { size: number } | null;
+    };
+    const loaded = tryLoadHnswSidecar(tmp);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.size).toBe(namespaces.length * rowsPerNamespace);
+    expect(fs.existsSync(path.join(tmp, '.moflo', 'hnsw.lock'))).toBe(false);
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary

Concurrent `build-embeddings` processes clobbered each other's HNSW sidecar. Observed on 4.12.4-rc.6, two interleaved and the sidecar was left holding 5199 vectors while the DB had 5219 — rows that were embedded but unsearchable until the next pass rebuilt from scratch.

The overlap is structural, not incidental. `index-all.mjs` runs its steps in sequence, but `index-patterns`, `index-reference` and `index-guidance` each fire-and-forget their own namespace-scoped `build-embeddings`, and `pm.spawn` dedups on **exact label equality** — so `build-embeddings-patterns`, `build-embeddings-reference`, `build-embeddings-guidance` and index-all's own `build-embeddings` are four distinct labels that never match. `flo memory rebuild-index` can join at any moment.

## The load-bearing detail

**The lock spans load → diff → write, not just the write.**

Every write here was already atomic — `atomicWriteFileSync` on both files — and that is exactly what made this easy to misdiagnose. No write was ever torn. The loss came from *when the decision was made*: a writer decides what to persist by loading the graph and diffing it against the DB, long before it writes. Two writers each load the same starting graph, each compute a diff against it, and the loser's result is overwritten wholesale.

A lock around only `writeSidecarAndManifest` would leave that completely intact. Held across the whole operation, the second writer blocks, then loads the first writer's freshly written sidecar and adds only its own new rows — which is the incremental path #1384 built.

## Changes

- **`src/cli/memory/hnsw-sidecar-lock.ts`** (new) — waiting single-writer lock. `writeFileSync(..., { flag: 'wx' })` (`O_CREAT | O_EXCL`) across processes, promise chain within one. Same primitive as `daemon-lock.ts`; no `flock`, no platform branch.
- **`hnsw-persistence.ts`** — `syncHnswSidecar` and `buildAndWriteHnswSidecar` each keep an unlocked core, so the full-rebuild fallback reaches the core rather than deadlocking on the non-reentrant lock.
- **`bin/index-patterns.mjs`** — corrected a comment claiming a dedup that never happened, and synced its `.claude/scripts/` copy.

### Design decisions worth reviewing

**It waits rather than failing fast.** Unlike the daemon's lock, the loser here *must* run — dropping an embedding run would leave rows unsearchable until the next session, the class of bug #1383 exists to prevent.

**On timeout it throws rather than breaking the lock.** The first cut broke the lock and proceeded, which a reviewer correctly caught: by that point every poll has confirmed the holder alive and non-stale, so taking the lock means running alongside them — the very race this closes, hidden under a `console.warn`. Throwing is contained because embedding commits to the DB *before* the sidecar step: `build-embeddings.mjs` logs to `background.log` and exits non-zero, and the next pass reconciles. A wedged lock costs one deferred reconcile, not a corrupt graph.

**Labels stay namespace-scoped.** Unifying them so `pm.spawn` dedups is tempting and wrong: it *skips* the later run rather than queueing it, so a namespace's rows would sit unembedded until something else triggered a pass — trading a self-healing race for silent staleness.

## Verification — live A/B on the dogfood store

Three concurrent namespace-scoped `build-embeddings` against the real 5,344-vector store, with a real per-namespace backlog:

| | shipped 4.12.4-rc.6 | with this change |
|---|---|---|
| writer results | all three `5344 (+1 / -0)` | `5345 (+1)`, `5347 (+2)`, third a no-op |
| final state | last writer wins | DB 5347 = sidecar 5347 = manifest 5347 |
| full rebuilds | — | 0 |
| new `database is locked` | — | none (2 before, 2 after) |

The left column is the bug caught live: three writers each computing the same delta off the same stale snapshot. (The fix was staged into `node_modules/moflo/dist/` for the right column, since `bin/build-embeddings.mjs` resolves the installed package, not the source tree; `node_modules` was restored afterwards and the probe rows deleted.)

## Testing

Both suites were **mutation-tested, not trusted green**:

- Bypassing the lock fails 3 of the 12 original unit tests and the cross-process interval-overlap test.
- Reverting each review-found defect fails its own 2 new tests.

- [x] Unit — `src/cli/__tests__/memory/hnsw-sidecar-lock.test.ts` (17 cases): mutual exclusion, FIFO ordering, release on throw, reclaiming dead/half-written/ancient locks, throwing on a live holder, chain drain, lazy `.moflo` creation
- [x] System — `tests/system/hnsw-sidecar-concurrent-writers-1388.test.ts` (3 cases): real subprocesses, non-overlapping hold windows, at most one full rebuild, final vector count
- [x] Full suite: 10,383 passed, 0 failed
- [x] Manual testing done — the table above

Honest note on which test carries the load: the "keeps every namespace's rows" case **passes even with the lock removed**, because that row-loss race is timing-dependent. It is a no-corruption/no-deadlock assertion. The interval-overlap test is the discriminator.

## Consumer impact

- **Surface**: `bin/build-embeddings.mjs` (the background indexing chain on every consumer) and `flo memory rebuild-index`.
- **Failure mode fixed**: no consumer's index pass burns redundant full rebuilds or leaves freshly-embedded rows unsearchable.
- **New failure mode**: a genuinely wedged lock now fails the reconcile loudly after 120s instead of writing alongside the holder. Self-healing on the next pass.
- **Round-trip**: runtime fix — needs publish + reinstall.

## Known residuals

- `hnsw.index` and `hnsw.manifest.json` are still two atomic writes, not one atomic operation. No mismatched pair is observable today because every writer serialises and no unlocked reader reads both files — but that rests on an audit of readers, not on construction. A future reader that reads both without the lock reopens it.
- The `database is locked` evidence is one observation on one machine; this change reduces DB contention only indirectly.

Closes #1388
