### PR TITLE
fix(gates): make verify + swarm gates satisfiable on upgraded projects; remove attribution

### DIFF
--- a/.claude/guidance/internal/upgrade-contract.md
+++ b/.claude/guidance/internal/upgrade-contract.md
@@ -1,6 +1,6 @@
 # MoFlo Upgrade Contract
 
-**Purpose:** The standing rules for changes that touch the install/upgrade surface (`bin/`, settings.json, hooks, moflo.yaml, claudemd-generator). Reference this whenever you add or change a config surface, a hook wiring, a helper script, or anything that ships into a consumer's `.claude/` tree.
+**Purpose:** The standing rules for changes that touch the install/upgrade surface (`bin/`, settings.json, hooks, moflo.yaml, claudemd-generator). Read it **before designing** any change to a config surface, a hook wiring, a helper script, or anything that ships into a consumer's `.claude/` tree — not at PR time, when the upgrade path has already been designed around.
 
 > **The rule: a user bumping their moflo version must never have to run `moflo init` again.** Every new capability we ship must auto-apply on the next session start after `npm install moflo@latest`. No manual action, no "re-run init to pick up the new thing," no "set this flag in your yaml." If a user has to do anything except restart their session, we've shipped a broken upgrade.
 
@@ -12,6 +12,24 @@ This is a CRITICAL invariant. Every PR that adds or changes a config surface MUS
 - `shipped/moflo-settings-injection.md` — what moflo writes into `.claude/`, the three sync mechanisms (static copy, generator output, surgical patch), and the self-heal contract for `.claude/settings.json`.
 
 If a consumer-facing change to the launcher or settings flow doesn't update one of those, it's incomplete.
+
+## Design for the upgrade path first — it is never an afterthought
+
+**Decide how a change reaches an already-installed consumer BEFORE writing the code, not after the feature works locally.** The upgrade path is a primary design input, ranked alongside correctness and cross-platform support (Rule #1) — not a box ticked at review time.
+
+The failure mode always has the same shape, and it is invisible from inside the moflo repo: the *fresh-install* path gets the new capability — because you edited a generator, and the generator is what you tested — while the *upgrade* path silently does not. Every consumer who ran `flo init` before your change is then running a configuration your new code assumes cannot exist.
+
+Ask these three questions **at design time**, in this order:
+
+| # | Question | If you can't answer it |
+|---|----------|------------------------|
+| 1 | Which mechanism in §Scope carries this to a consumer who already ran `flo init`? | Stop. You are about to ship a fresh-install-only change. |
+| 2 | What does a consumer on the *previous* version experience between `npm install` and their next session start? | Stop. Sequence the change so no window leaves them worse off than before. |
+| 3 | If the new code reads state the old version never wrote, what happens when it is absent? | Stop. Add the migration or a tolerant default — never let missing state read as a failed check. |
+
+**A change is fresh-install-only if you edited a generator and nothing else.** `settings-generator.ts`, `helpers-generator.ts`, `moflo-init.ts`, and `claudemd-generator.ts` run on `flo init`. They do **not** run on upgrade. The upgrade counterpart is always a second edit somewhere in §Scope — usually `REQUIRED_HOOK_WIRING` + `HOOK_ENTRY_MAP`, a `HOOK_REWRITE_RULES` entry, or the yaml upgrader.
+
+**Never tighten a gate without shipping its satisfier to existing consumers in the same change.** A gate that gets stricter on upgrade while the mechanism satisfying it lands only on fresh install does not degrade gracefully — it becomes a gate that *cannot pass*, whose only remedy is disabling it. See #1332 in §Historical violations.
 
 ## Scope — what auto-upgrades
 
@@ -71,12 +89,15 @@ That rule applies to **static helper scripts** — files with no per-project con
 
 The distinction is *user-owned files get additive patches; tool-owned files get replaced*.
 
-## Pre-merge checklist for config-surface changes
+## Pre-merge checklist for consumer-surface changes
 
-Before merging any PR that touches config, ask:
+Before merging any PR that touches config, hooks, helpers, or anything listed in §Scope, ask:
 
 - [ ] If a user upgrades moflo and does **nothing else**, does the new capability work?
 - [ ] If the answer involves "they need to run `moflo init`" or "they need to add X to their yaml" — the PR is incomplete
+- [ ] Did you edit a generator? Name the matching §Scope mechanism you edited alongside it — "the generator emits it" is not an upgrade path
+- [ ] If this change makes a gate or check stricter, does the thing that satisfies it reach existing consumers in this same PR?
+- [ ] Does `flo doctor` detect the absence of whatever this adds, or would it report healthy while the consumer is broken?
 - [ ] Are defaults chosen so the feature is discoverable (either on-by-default or clearly commented when off)?
 - [ ] Is the yaml block documented in the relevant `docs/` page, including how to change it?
 
@@ -84,6 +105,7 @@ Before merging any PR that touches config, ask:
 
 - **v4.x sandbox block** — shipped with `enabled: false` and no auto-append; users couldn't find the setting even though it existed in the schema. Fixed by (1) adding block to init template, (2) adding session-start yaml upgrader.
 - **#879 record-memory-searched gate.cjs wiring** — when [#838](https://github.com/eric-cielo/moflo/issues/838) added per-actor memory-search tracking, the check-side hooks (`check-before-scan`, `check-before-read`) were wired through `gate-hook.mjs` (which forwards stdin `session_id` as `HOOK_SESSION_ID`) but the record-side hook (`record-memory-searched`) stayed on direct `gate.cjs`. The asymmetry left the per-actor map empty in production, blocking every Read inside a turn. Fixed by (1) updating both generators to use `gateHookCmd`/`gateHook`, (2) adding a `HOOK_REWRITE_RULES` entry so existing consumers auto-heal, (3) tightening the cross-platform alignment test to assert wrapper-vs-direct usage per command. The lesson: any time a gate command grows session_id awareness, audit BOTH its check-side wiring AND every record-side path that should stamp the per-actor map.
+- **#1332 `record-verify-outcome` never reached upgraded consumers** — [#1332](https://github.com/eric-cielo/moflo/issues/1332) tightened `check-before-done` to require `verifyOutcome === 'PASS'`, and wired the hook that writes that field into `settings-generator.ts` only. It was never added to `REQUIRED_HOOK_WIRING` / `HOOK_ENTRY_MAP`, so `repairHookWiring()` could not graft it into an existing project and `flo doctor` reported hook wiring healthy. Every project that upgraded rather than freshly `init`ed got a verify-before-done gate that **could not be satisfied**: `/verify` stored a correct `PASS` verdict, nothing transcribed it into `workflow-state.json`, and the only escape was `gates.verify_before_done: false`. Reported from the field in [#1392](https://github.com/eric-cielo/moflo/issues/1392). Two compounding lessons: (1) the change tightened a gate for existing consumers while shipping its satisfier to new consumers only — the exact anti-pattern in §Design for the upgrade path first; (2) the same wiring is duplicated across `settings-generator.ts`, `hook-block-hash.ts`, and `hook-wiring.ts`, only the first two were updated, and a source comment warned about the drift where a test was needed.
 
 ## See Also
 

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -132,6 +132,26 @@ function readMofloYaml() {
 }
 var MOFLO_YAML = readMofloYaml();
 
+// #1394 — is the hook that transcribes /verify's verdict into workflow-state.json
+// actually wired? Distinguishes "the agent skipped Step 5" from "nothing exists
+// to record the verdict", which need opposite remedies: the first is fixed by
+// re-running /verify, the second cannot be.
+//
+// Deliberately NOT hoisted to module scope like MOFLO_YAML: this is only ever
+// consulted on an already-blocked check-before-done path, so reading it eagerly
+// would add a syscall to every Write/Edit to answer a question almost no gate
+// invocation asks. Substring match (not a JSON walk) so it holds regardless of
+// which matcher block a consumer's hook lives in, or how they hand-edited it.
+// Unreadable/malformed settings → true, so a parse failure falls back to the
+// pre-existing generic message rather than asserting a wiring bug that may not
+// exist.
+function isVerifyOutcomeHookWired() {
+  try {
+    return fs.readFileSync(path.join(PROJECT_DIR, '.claude', 'settings.json'), 'utf-8')
+      .indexOf('record-verify-outcome') >= 0;
+  } catch (e) { return true; }
+}
+
 var config = loadGateConfig();
 var sddConf = loadSddConfig();
 var mergeConf = loadMergeConfig();
@@ -724,7 +744,22 @@ var EDIT_RESET_SKIP_BOTH_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^
 // pure noise. Scoped to the reset only — deliberately NOT added to EXEMPT,
 // which would also un-gate reads of `.moflo/specs/**`, and those are indexed
 // guidance that memory-first should still route through a search.
-var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\/])\.github[\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\/.]|$)|(?:^|[\\\/])\.moflo[\\\/]/i;
+// #1395 — `.claude/` CONFIG joins them, by the same "doesn't expose new runtime
+// surface" reasoning: hook wiring, skills and guidance are not the code under
+// verification. This is the stronger case, in fact — it is the directory a user
+// edits *because a gate told them to*. Before this, fixing hook wiring on a
+// gate's own instruction reset verifyRun and invalidated the verification the
+// fix existed to let through, so the recovery was: fix wiring → verification
+// invalidated → restart session → re-run /verify → retry (#1392 field report).
+//
+// Scoped to config, NOT all of `.claude/**`: `scripts/` and `helpers/` hold
+// executable runtime surface (gate.cjs itself lives there), and editing
+// executable code SHOULD still invalidate a verification. Listing the config
+// subdirectories explicitly keeps that invariant intact.
+//
+// Both separators in every alternative — a bare `/` here would silently no-op
+// on Windows, where TOOL_INPUT paths arrive backslashed (Rule #1).
+var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\/])\.github[\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\/.]|$)|(?:^|[\\\/])\.moflo[\\\/]|(?:^|[\\\/])\.claude[\\\/](?:settings(?:\.local)?\.json$|skills[\\\/]|guidance[\\\/]|agents[\\\/])/i;
 // Test files: invalidate the testing gate (tests are stale once test code changes)
 // but NOT the simplify gate — /simplify already reviewed the production code; touching
 // a test file or fixture doesn't expose new untested surface for code review (#908).
@@ -1728,14 +1763,25 @@ switch (command) {
       process.stderr.write('  - /verify ran and returned ' + sd.verifyOutcome + ' — fix the failing criteria, then re-run /verify\n');
       process.stderr.write('    (a FAIL is a real result, not a gate error; the PR is blocked because the change did not meet its acceptance criteria)\n');
     } else {
-      // Ran, but no verdict reached the gate: /verify was invoked and never
-      // recorded a structured outcome (interrupted, or it stored prose only).
-      process.stderr.write('  - /verify ran but recorded no verdict — re-run it so it stores a structured result\n');
-      process.stderr.write('    (Step 5 of the verify skill must pass metadata.overall to memory_store)\n');
-      // #1348 — the trap this state sets: re-invoking /verify CLEARS any prior
-      // verdict by design (#1332), so the obvious recovery lands right back here
-      // unless Step 5 completes. Say so, rather than letting it be rediscovered.
-      process.stderr.write('    Re-invoking /verify clears the prior verdict, so a re-run that skips Step 5 lands here again.\n');
+      // Ran, but no verdict reached the gate. TWO very different causes, and
+      // #1394 exists because they used to share one message that fit only the
+      // first: either /verify never recorded a structured outcome, or the hook
+      // that TRANSCRIBES the outcome is not wired, in which case a perfectly
+      // correct verdict was stored and nothing could carry it to the gate.
+      // Blaming the agent for the second case sends the user into an unbounded
+      // retry loop — re-running /verify cannot fix absent wiring.
+      if (!isVerifyOutcomeHookWired()) {
+        process.stderr.write('  - `record-verify-outcome` is not wired in .claude/settings.json — the verdict cannot be recorded\n');
+        process.stderr.write('    /verify may well have passed; nothing exists to transcribe its result, so re-running it will not help.\n');
+        process.stderr.write('    Fix: run `flo doctor --fix`, restart the session (Claude Code loads hooks only at start), then re-run /verify.\n');
+      } else {
+        process.stderr.write('  - /verify ran but recorded no verdict — re-run it so it stores a structured result\n');
+        process.stderr.write('    (Step 5 of the verify skill must pass metadata.overall to memory_store)\n');
+        // #1348 — the trap this state sets: re-invoking /verify CLEARS any prior
+        // verdict by design (#1332), so the obvious recovery lands right back here
+        // unless Step 5 completes. Say so, rather than letting it be rediscovered.
+        process.stderr.write('    Re-invoking /verify clears the prior verdict, so a re-run that skips Step 5 lands here again.\n');
+      }
     }
     process.stderr.write(ORDER_HINT);
     process.stderr.write('Disable via moflo.yaml:\n');

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -1591,6 +1591,18 @@ try {
             settingsChanges.push(`repaired ${plural(repaired.length, 'hook wiring')}`);
           }
         }
+        // #1398 — strip the legacy attribution block. Claude Code reads this key
+        // and injects it into the agent's instructions, so an upgraded consumer
+        // keeps stamping moflo's identity into their commits until it is removed;
+        // dropping it from the generator alone only fixes fresh installs.
+        // `typeof` guard so an older installed moflo without the export is a
+        // silent no-op rather than a session-start crash.
+        if (typeof mod.removeLegacyAttribution === 'function') {
+          if (mod.removeLegacyAttribution(settings)) {
+            dirty = true;
+            settingsChanges.push('removed legacy attribution block');
+          }
+        }
       }
     } catch (err) {
       emitWarning(`hook-wiring repair skipped (${errMessage(err)})`);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -309,10 +309,6 @@
       "Read(./.env.*)"
     ]
   },
-  "attribution": {
-    "commit": "Co-Authored-By: moflo <noreply@cielolimitada.com>",
-    "pr": "🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)"
-  },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "MOFLO_V3_ENABLED": "true",

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -161,10 +161,12 @@ The `check-before-pr` gate blocks `gh pr create` until `/flo-simplify` has run s
 git add <specific files>
 git commit -m "type(scope): description
 
-Closes #<issue-number>
-
-Co-Authored-By: moflo <noreply@cielolimitada.com>"
+Closes #<issue-number>"
 ```
+
+**No attribution trailer.** Do not add `Co-Authored-By:`, `Generated with …`, or any
+other tool-attribution line to commits or PR bodies (#1398). This is the consumer's
+repository and their git history is permanent — moflo does not sign their commits.
 
 ### 5.1b Verify-before-done (default; skipped only with `--no-verify`)
 **Delegate to the `/verify` skill** — `Skill({ skill: "verify" })`, passing the issue number or spec slug. That skill owns the mechanics (locate acceptance criteria → reuse Phase 4's already-green tests, no double verify → map each criterion → run only uncovered checks → record the outcome). Don't restate them here or verify in prose — *invoking* `/verify` is what records the run and satisfies the `check-before-done` gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,9 @@ style nit, and not limited to shipped code — git history is permanent.
 and the fix gets written up citing where the bug was seen. Writing `Symptoms in the wild
 (<their-project>/code)` into a regression test's header feels like good provenance and is exactly
 how 38 files got contaminated — including 9 runtime `output.writeln` banners that printed a client
-domain into every consumer's terminal, and the `Co-Authored-By` trailer `flo init` stamps into
-every consumer's `.claude/settings.json`.
+domain into every consumer's terminal, and the `Co-Authored-By` trailer `flo init` used to stamp
+into every consumer's `.claude/settings.json` (removed outright in #1398 — moflo no longer writes
+any attribution; see the note below).
 
 **When resolving an issue or PR that originated outside moflo, never record the reporter's
 identity.** Cite the issue number — that is the durable, non-leaking reference.
@@ -82,6 +83,13 @@ themselves trip the guard.
 
 Applies to every surface: runtime strings, JSDoc headers, test fixture names and paths, commit
 trailers, and `docs/internal/**` post-mortems.
+
+**No attribution trailers at all (#1398).** Separate from the leak rule above: moflo does not add
+`Co-Authored-By:`, `Generated with …`, or any other tool-attribution line to commits or PR bodies —
+not in consumer projects and not in this repo. A consumer's git history is theirs and is permanent;
+signing it is not moflo's call. The `attribution` block is no longer written by `flo init`, is
+stripped from existing projects on session start, and the `git-commit` safety hook defaults to
+adding nothing. Do not reintroduce any of it.
 
 **Enforced by** `tests/guards/client-name-leak-guard.test.ts`, which matches the *shapes* these
 identifiers take (project dir under a home path, contact domain in an email, domain on an

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -132,6 +132,26 @@ function readMofloYaml() {
 }
 var MOFLO_YAML = readMofloYaml();
 
+// #1394 — is the hook that transcribes /verify's verdict into workflow-state.json
+// actually wired? Distinguishes "the agent skipped Step 5" from "nothing exists
+// to record the verdict", which need opposite remedies: the first is fixed by
+// re-running /verify, the second cannot be.
+//
+// Deliberately NOT hoisted to module scope like MOFLO_YAML: this is only ever
+// consulted on an already-blocked check-before-done path, so reading it eagerly
+// would add a syscall to every Write/Edit to answer a question almost no gate
+// invocation asks. Substring match (not a JSON walk) so it holds regardless of
+// which matcher block a consumer's hook lives in, or how they hand-edited it.
+// Unreadable/malformed settings → true, so a parse failure falls back to the
+// pre-existing generic message rather than asserting a wiring bug that may not
+// exist.
+function isVerifyOutcomeHookWired() {
+  try {
+    return fs.readFileSync(path.join(PROJECT_DIR, '.claude', 'settings.json'), 'utf-8')
+      .indexOf('record-verify-outcome') >= 0;
+  } catch (e) { return true; }
+}
+
 var config = loadGateConfig();
 var sddConf = loadSddConfig();
 var mergeConf = loadMergeConfig();
@@ -724,7 +744,22 @@ var EDIT_RESET_SKIP_BOTH_RE = /\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:^
 // pure noise. Scoped to the reset only — deliberately NOT added to EXEMPT,
 // which would also un-gate reads of `.moflo/specs/**`, and those are indexed
 // guidance that memory-first should still route through a search.
-var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\/])\.github[\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\/.]|$)|(?:^|[\\\/])\.moflo[\\\/]/i;
+// #1395 — `.claude/` CONFIG joins them, by the same "doesn't expose new runtime
+// surface" reasoning: hook wiring, skills and guidance are not the code under
+// verification. This is the stronger case, in fact — it is the directory a user
+// edits *because a gate told them to*. Before this, fixing hook wiring on a
+// gate's own instruction reset verifyRun and invalidated the verification the
+// fix existed to let through, so the recovery was: fix wiring → verification
+// invalidated → restart session → re-run /verify → retry (#1392 field report).
+//
+// Scoped to config, NOT all of `.claude/**`: `scripts/` and `helpers/` hold
+// executable runtime surface (gate.cjs itself lives there), and editing
+// executable code SHOULD still invalidate a verification. Listing the config
+// subdirectories explicitly keeps that invariant intact.
+//
+// Both separators in every alternative — a bare `/` here would silently no-op
+// on Windows, where TOOL_INPUT paths arrive backslashed (Rule #1).
+var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\/])\.github[\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\/.]|$)|(?:^|[\\\/])\.moflo[\\\/]|(?:^|[\\\/])\.claude[\\\/](?:settings(?:\.local)?\.json$|skills[\\\/]|guidance[\\\/]|agents[\\\/])/i;
 // Test files: invalidate the testing gate (tests are stale once test code changes)
 // but NOT the simplify gate — /simplify already reviewed the production code; touching
 // a test file or fixture doesn't expose new untested surface for code review (#908).
@@ -1728,14 +1763,25 @@ switch (command) {
       process.stderr.write('  - /verify ran and returned ' + sd.verifyOutcome + ' — fix the failing criteria, then re-run /verify\n');
       process.stderr.write('    (a FAIL is a real result, not a gate error; the PR is blocked because the change did not meet its acceptance criteria)\n');
     } else {
-      // Ran, but no verdict reached the gate: /verify was invoked and never
-      // recorded a structured outcome (interrupted, or it stored prose only).
-      process.stderr.write('  - /verify ran but recorded no verdict — re-run it so it stores a structured result\n');
-      process.stderr.write('    (Step 5 of the verify skill must pass metadata.overall to memory_store)\n');
-      // #1348 — the trap this state sets: re-invoking /verify CLEARS any prior
-      // verdict by design (#1332), so the obvious recovery lands right back here
-      // unless Step 5 completes. Say so, rather than letting it be rediscovered.
-      process.stderr.write('    Re-invoking /verify clears the prior verdict, so a re-run that skips Step 5 lands here again.\n');
+      // Ran, but no verdict reached the gate. TWO very different causes, and
+      // #1394 exists because they used to share one message that fit only the
+      // first: either /verify never recorded a structured outcome, or the hook
+      // that TRANSCRIBES the outcome is not wired, in which case a perfectly
+      // correct verdict was stored and nothing could carry it to the gate.
+      // Blaming the agent for the second case sends the user into an unbounded
+      // retry loop — re-running /verify cannot fix absent wiring.
+      if (!isVerifyOutcomeHookWired()) {
+        process.stderr.write('  - `record-verify-outcome` is not wired in .claude/settings.json — the verdict cannot be recorded\n');
+        process.stderr.write('    /verify may well have passed; nothing exists to transcribe its result, so re-running it will not help.\n');
+        process.stderr.write('    Fix: run `flo doctor --fix`, restart the session (Claude Code loads hooks only at start), then re-run /verify.\n');
+      } else {
+        process.stderr.write('  - /verify ran but recorded no verdict — re-run it so it stores a structured result\n');
+        process.stderr.write('    (Step 5 of the verify skill must pass metadata.overall to memory_store)\n');
+        // #1348 — the trap this state sets: re-invoking /verify CLEARS any prior
+        // verdict by design (#1332), so the obvious recovery lands right back here
+        // unless Step 5 completes. Say so, rather than letting it be rediscovered.
+        process.stderr.write('    Re-invoking /verify clears the prior verdict, so a re-run that skips Step 5 lands here again.\n');
+      }
     }
     process.stderr.write(ORDER_HINT);
     process.stderr.write('Disable via moflo.yaml:\n');

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -1591,6 +1591,18 @@ try {
             settingsChanges.push(`repaired ${plural(repaired.length, 'hook wiring')}`);
           }
         }
+        // #1398 — strip the legacy attribution block. Claude Code reads this key
+        // and injects it into the agent's instructions, so an upgraded consumer
+        // keeps stamping moflo's identity into their commits until it is removed;
+        // dropping it from the generator alone only fixes fresh installs.
+        // `typeof` guard so an older installed moflo without the export is a
+        // silent no-op rather than a session-start crash.
+        if (typeof mod.removeLegacyAttribution === 'function') {
+          if (mod.removeLegacyAttribution(settings)) {
+            dirty = true;
+            settingsChanges.push('removed legacy attribution block');
+          }
+        }
       }
     } catch (err) {
       emitWarning(`hook-wiring repair skipped (${errMessage(err)})`);

--- a/src/cli/__tests__/commands-deep.test.ts
+++ b/src/cli/__tests__/commands-deep.test.ts
@@ -1473,9 +1473,12 @@ describe('Init System', () => {
       expect(perms.deny).toBeDefined();
     });
 
-    it('should include attribution', () => {
+    it('should NOT include attribution (#1398)', () => {
+      // moflo does not sign a consumer's commits. The generator used to write a
+      // Co-Authored-By trailer and a "Generated with moflo" PR banner here;
+      // nothing read the key, and the attribution itself is unwanted.
       const settings = generateSettings(DEFAULT_INIT_OPTIONS) as Record<string, unknown>;
-      expect(settings.attribution).toBeDefined();
+      expect(settings.attribution).toBeUndefined();
     });
 
     it('should include env with agent teams enabled', () => {

--- a/src/cli/__tests__/services/hook-wiring-generator-parity-1393.test.ts
+++ b/src/cli/__tests__/services/hook-wiring-generator-parity-1393.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Structural drift guard — #1393 (Epic #1392).
+ *
+ * The same hook wiring is duplicated across three files:
+ *
+ *   1. `init/settings-generator.ts`  — what a FRESH `flo init` writes
+ *   2. `services/hook-block-hash.ts` — block-hash bookkeeping
+ *   3. `services/hook-wiring.ts`     — what `repairHookWiring()` grafts into
+ *                                      an EXISTING project on session start
+ *
+ * Only (1) runs on `flo init`; only (3) runs on upgrade. A hook added to (1)
+ * alone reaches new consumers and silently never reaches upgraded ones.
+ *
+ * That is exactly how #1332 shipped: `record-verify-outcome` was wired in the
+ * generator only, so every project that upgraded rather than re-running
+ * `flo init` got a verify-before-done gate it could not satisfy — `/verify`
+ * stored a correct PASS verdict, nothing transcribed it into
+ * workflow-state.json, and the only escape was disabling the gate outright.
+ * `flo doctor` reported hook wiring healthy throughout, because the healer
+ * re-exports the same incomplete list.
+ *
+ * settings-generator.ts carried a comment warning that the three copies must
+ * not drift. A comment is not a guard. This is the guard.
+ *
+ * See `.claude/guidance/internal/upgrade-contract.md`
+ *   § "Design for the upgrade path first — it is never an afterthought".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { REQUIRED_HOOK_WIRING, HOOK_ENTRY_MAP, repairHookWiring } from '../../services/hook-wiring.js';
+
+const GENERATOR_PATH = join(__dirname, '..', '..', 'init', 'settings-generator.ts');
+
+/**
+ * Gate subcommands the generator emits that are deliberately NOT repaired into
+ * existing consumers. Every entry needs a reason and an issue number — an
+ * unexplained exclusion is indistinguishable from the drift this guard exists
+ * to catch.
+ */
+const DELIBERATELY_NOT_REPAIRED: Record<string, string> = {
+  // #1227 — advisory-only pre-implementation nudge. Fresh installs get it; it is
+  // not load-bearing for any gate, so it is not worth a settings.json write on
+  // every existing consumer.
+  'check-before-implement': '#1227 — advisory only; not gate-load-bearing',
+  // #1393 — emitted CONDITIONALLY (`if (config.preCompact)` in the generator),
+  // unlike every other entry here. REQUIRED_HOOK_WIRING has no notion of a
+  // condition, so listing it would force the PreCompact hook back on for
+  // consumers who deliberately set `preCompact: false`. It is guidance emission,
+  // not a gate, so its absence degrades quality rather than deadlocking a run.
+  // Repairing config-conditional hooks needs a conditional repair mechanism —
+  // tracked separately rather than bodged in here.
+  'compact-guidance': '#1393 — config-conditional (config.preCompact); repairing it would override an opt-out',
+};
+
+// NOTE: `check-task-transition` is deliberately NOT listed. #1331 removed it from
+// the generator as well, so it never reaches this comparison — and the
+// "stale exclusion" test below fails if someone re-adds it here out of caution.
+
+/**
+ * Extract every `gateCmd('x')` / `gateHookCmd('x')` subcommand the generator emits.
+ *
+ * Read as source text rather than by invoking generateSettings(): the guard must
+ * catch a hook that is emitted under a conditional branch (an option flag, a
+ * platform check) which a single generateSettings() call would not exercise.
+ */
+function generatorGateSubcommands(): Set<string> {
+  const src = readFileSync(GENERATOR_PATH, 'utf-8');
+  const found = new Set<string>();
+  for (const m of src.matchAll(/\bgate(?:Hook)?Cmd\(\s*'([^']+)'\s*\)/g)) {
+    found.add(m[1]);
+  }
+  return found;
+}
+
+describe('#1393 — settings-generator ↔ hook-wiring parity', () => {
+  it('finds gate subcommands in the generator (guard is actually looking at something)', () => {
+    // Self-check: a regex that silently matches nothing would make every
+    // assertion below vacuously pass.
+    expect(generatorGateSubcommands().size).toBeGreaterThan(10);
+  });
+
+  it('every gate hook the generator emits is either repaired into existing projects or explicitly excluded', () => {
+    const required = new Set(REQUIRED_HOOK_WIRING.map(h => h.pattern));
+    const unreachable = [...generatorGateSubcommands()]
+      .filter(cmd => !required.has(cmd))
+      .filter(cmd => !(cmd in DELIBERATELY_NOT_REPAIRED));
+
+    expect(
+      unreachable,
+      `These hooks are written by \`flo init\` but never grafted into an existing ` +
+      `project by repairHookWiring(), so consumers who UPGRADE never get them:\n` +
+      unreachable.map(c => `  - ${c}`).join('\n') +
+      `\n\nFix by adding each to REQUIRED_HOOK_WIRING + HOOK_ENTRY_MAP in ` +
+      `services/hook-wiring.ts, or — if it genuinely should not be repaired — to ` +
+      `DELIBERATELY_NOT_REPAIRED in this file with an issue number and a reason.`,
+    ).toEqual([]);
+  });
+
+  it('every REQUIRED_HOOK_WIRING pattern has a HOOK_ENTRY_MAP entry', () => {
+    // Without the map entry, repairHookWiring() hits `if (!entry) continue` and
+    // skips the hook — listing the pattern alone repairs nothing. This is the
+    // second half of how #1332's gap survived review.
+    const missing = REQUIRED_HOOK_WIRING
+      .map(h => h.pattern)
+      .filter(p => !HOOK_ENTRY_MAP[p]);
+
+    expect(
+      missing,
+      `Listed in REQUIRED_HOOK_WIRING but absent from HOOK_ENTRY_MAP — ` +
+      `repairHookWiring() will silently skip these: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every DELIBERATELY_NOT_REPAIRED entry is still emitted by the generator', () => {
+    // Keeps the exclusion list honest: once the generator stops emitting a hook,
+    // its exclusion is dead weight that would mask a real future drift.
+    const emitted = generatorGateSubcommands();
+    const stale = Object.keys(DELIBERATELY_NOT_REPAIRED).filter(c => !emitted.has(c));
+
+    expect(
+      stale,
+      `Excluded here but no longer emitted by settings-generator.ts — remove the ` +
+      `stale exclusion: ${stale.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('record-verify-outcome is repaired into existing projects and routes via gate-hook.mjs (#1393)', () => {
+    // The regression under test. Routing matters as much as presence: the
+    // TOOL_INPUT_* env vars gate.cjs reads are built by gate-hook.mjs from the
+    // hook's stdin payload, so a direct gate.cjs invocation would fire and
+    // record nothing — the gate would stay closed with the hook "present".
+    expect(REQUIRED_HOOK_WIRING.map(h => h.pattern)).toContain('record-verify-outcome');
+
+    const entry = HOOK_ENTRY_MAP['record-verify-outcome'];
+    expect(entry).toBeDefined();
+    expect(entry.event).toBe('PostToolUse');
+    expect(entry.matcher).toBe('^mcp__moflo__memory_store$');
+    expect(entry.hook.command).toContain('gate-hook.mjs');
+    expect(entry.hook.command).not.toMatch(/gate\.cjs/);
+  });
+});
+
+/**
+ * The upgrade path itself — the point of the story. A pre-#1332 consumer has the
+ * `^mcp__moflo__memory_store$` block WITH record-learnings-stored and WITHOUT
+ * record-verify-outcome. Repair must append into that existing block.
+ */
+describe('#1393 — a pre-#1332 project self-heals on session start', () => {
+  /** Settings as `flo init` wrote them before #1332 added the transcriber. */
+  function preFixSettings(): Record<string, unknown> {
+    return {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: '^mcp__moflo__memory_store$',
+            hooks: [{
+              type: 'command',
+              command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-learnings-stored',
+              timeout: 2000,
+            }],
+          },
+        ],
+      },
+    };
+  }
+
+  function commandsFor(settings: Record<string, unknown>, matcher: string): string[] {
+    const hooks = settings.hooks as Record<string, Array<Record<string, unknown>>>;
+    return (hooks.PostToolUse || [])
+      .filter(b => b.matcher === matcher)
+      .flatMap(b => (b.hooks as Array<{ command: string }>) || [])
+      .map(h => h.command);
+  }
+
+  it('grafts record-verify-outcome into the existing memory_store block', () => {
+    const settings = preFixSettings();
+    const { repaired } = repairHookWiring(settings);
+
+    expect(repaired).toContain('record-verify-outcome');
+
+    const cmds = commandsFor(settings, '^mcp__moflo__memory_store$');
+    expect(cmds.some(c => c.includes('record-verify-outcome'))).toBe(true);
+    // Appended, not replaced — the consumer's existing hook survives.
+    expect(cmds.some(c => c.includes('record-learnings-stored'))).toBe(true);
+  });
+
+  it('does not create a second memory_store block', () => {
+    const settings = preFixSettings();
+    repairHookWiring(settings);
+
+    const hooks = settings.hooks as Record<string, Array<Record<string, unknown>>>;
+    const blocks = hooks.PostToolUse.filter(b => b.matcher === '^mcp__moflo__memory_store$');
+    expect(blocks).toHaveLength(1);
+  });
+
+  it('is idempotent — a second session start changes nothing', () => {
+    const settings = preFixSettings();
+    repairHookWiring(settings);
+    const afterFirst = JSON.stringify(settings);
+
+    const { repaired } = repairHookWiring(settings);
+
+    expect(repaired).not.toContain('record-verify-outcome');
+    expect(JSON.stringify(settings)).toBe(afterFirst);
+  });
+
+  it('routes the grafted hook through gate-hook.mjs, so it can actually see the verdict', () => {
+    // Presence is not enough. gate.cjs reads TOOL_INPUT_* env vars that
+    // gate-hook.mjs builds from the hook's stdin payload; wired directly to
+    // gate.cjs the hook fires and records nothing, leaving the gate shut with
+    // the wiring looking correct.
+    const settings = preFixSettings();
+    repairHookWiring(settings);
+
+    const cmd = commandsFor(settings, '^mcp__moflo__memory_store$')
+      .find(c => c.includes('record-verify-outcome'));
+    expect(cmd).toContain('gate-hook.mjs');
+  });
+
+  it('grafts the swarm/hive MCP recorders that #1338 left behind', () => {
+    // Same defect class, protected surface: without these, check-before-agent
+    // blocks every Agent spawn under `/fl -s` and `/fl -h` on an upgraded
+    // project, and the MCP init call that should release it credits nothing.
+    const settings = preFixSettings();
+    const { repaired } = repairHookWiring(settings);
+
+    expect(repaired).toContain('record-swarm-init');
+    expect(repaired).toContain('record-hive-init');
+    expect(commandsFor(settings, '^mcp__moflo__swarm_init$')
+      .some(c => c.includes('record-swarm-init'))).toBe(true);
+    expect(commandsFor(settings, '^mcp__moflo__hive-mind_init$')
+      .some(c => c.includes('record-hive-init'))).toBe(true);
+  });
+});

--- a/src/cli/__tests__/services/remove-legacy-attribution-1398.test.ts
+++ b/src/cli/__tests__/services/remove-legacy-attribution-1398.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #1398 (Epic #1392) — moflo must not sign a consumer's commits.
+ *
+ * `settings.attribution` is read by CLAUDE CODE, not by moflo: the harness
+ * injects `attribution.commit` / `attribution.pr` into the agent's instructions,
+ * which is how `Co-Authored-By: moflo …` and the "Generated with moflo" PR banner
+ * reached commits. Nothing in moflo's own source reads the key, so it reads as
+ * dead config from inside this repo — it is not.
+ *
+ * That is why removing it from `settings-generator.ts` is only half a fix: fresh
+ * installs stop getting it, while every UPGRADED project keeps the key it was
+ * given at init and keeps stamping moflo's identity into a git history that
+ * cannot be rewritten. See `internal/upgrade-contract.md` § "Design for the
+ * upgrade path first".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { removeLegacyAttribution } from '../../services/hook-wiring.js';
+import { generateSettings } from '../../init/settings-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../../init/types.js';
+
+const MOFLO_COMMIT = 'Co-Authored-By: moflo <noreply@cielolimitada.com>';
+const MOFLO_PR = '\u{1F916} Generated with [moflo](https://github.com/eric-cielo/moflo)';
+
+describe('#1398 — fresh installs get no attribution', () => {
+  it('generateSettings emits no attribution key', () => {
+    const settings = generateSettings(DEFAULT_INIT_OPTIONS) as Record<string, unknown>;
+    expect(settings.attribution).toBeUndefined();
+  });
+
+  it('no moflo attribution string survives anywhere in generated settings', () => {
+    // Broader than the key check: catches the block being reintroduced under a
+    // different name or nested somewhere else.
+    const json = JSON.stringify(generateSettings(DEFAULT_INIT_OPTIONS));
+    expect(json).not.toContain('Co-Authored-By');
+    expect(json).not.toContain('Generated with');
+  });
+});
+
+describe('#1398 — upgraded projects are healed', () => {
+  it('removes the exact block flo init used to write', () => {
+    const settings: Record<string, unknown> = {
+      attribution: { commit: MOFLO_COMMIT, pr: MOFLO_PR },
+      permissions: { allow: [] },
+    };
+
+    expect(removeLegacyAttribution(settings)).toBe(true);
+    expect(settings.attribution).toBeUndefined();
+    // Untouched neighbours — this must not become a settings rewrite.
+    expect(settings.permissions).toEqual({ allow: [] });
+  });
+
+  it('is idempotent — a second session start changes nothing', () => {
+    const settings: Record<string, unknown> = {
+      attribution: { commit: MOFLO_COMMIT, pr: MOFLO_PR },
+    };
+    removeLegacyAttribution(settings);
+
+    expect(removeLegacyAttribution(settings)).toBe(false);
+  });
+
+  it('reports no change on settings that never had the block', () => {
+    const settings: Record<string, unknown> = { permissions: { allow: [] } };
+    expect(removeLegacyAttribution(settings)).toBe(false);
+    expect(settings).toEqual({ permissions: { allow: [] } });
+  });
+
+  it('removes only the commit half when the consumer replaced the pr half', () => {
+    const settings: Record<string, unknown> = {
+      attribution: { commit: MOFLO_COMMIT, pr: 'Ship it' },
+    };
+
+    expect(removeLegacyAttribution(settings)).toBe(true);
+    expect(settings.attribution).toEqual({ pr: 'Ship it' });
+  });
+
+  it('leaves a consumer-authored attribution block completely alone', () => {
+    // We remove OUR string, not the concept. A team that deliberately set their
+    // own trailer keeps it.
+    const theirs = {
+      commit: 'Co-Authored-By: Their Bot <bot@their-company.example>',
+      pr: 'Built by our platform team',
+    };
+    const settings: Record<string, unknown> = { attribution: { ...theirs } };
+
+    expect(removeLegacyAttribution(settings)).toBe(false);
+    expect(settings.attribution).toEqual(theirs);
+  });
+
+  it('reports no change for a malformed attribution value, and never throws', () => {
+    // Asserting the RETURN value, not just the absence of a throw: a bogus value
+    // reported as "changed" would trigger a settings.json rewrite on every
+    // session start. `[]` is the interesting case — `typeof [] === 'object'`, so
+    // it reaches the object path and needs an explicit Array.isArray guard.
+    for (const bad of [null, undefined, 'a string', 42, [], true]) {
+      const settings: Record<string, unknown> = { attribution: bad };
+      expect(() => removeLegacyAttribution(settings)).not.toThrow();
+      expect(removeLegacyAttribution(settings), `value: ${JSON.stringify(bad)}`).toBe(false);
+      expect(settings.attribution).toBe(bad);
+    }
+  });
+});

--- a/src/cli/__tests__/services/remove-legacy-attribution-1398.test.ts
+++ b/src/cli/__tests__/services/remove-legacy-attribution-1398.test.ts
@@ -77,8 +77,11 @@ describe('#1398 — upgraded projects are healed', () => {
   it('leaves a consumer-authored attribution block completely alone', () => {
     // We remove OUR string, not the concept. A team that deliberately set their
     // own trailer keeps it.
+    // Placeholder domain only — `example.com` is sanctioned by the client-name
+    // leak guard. A realistic-looking company domain here trips it (Rule #3),
+    // which is exactly what happened on this test's first draft.
     const theirs = {
-      commit: 'Co-Authored-By: Their Bot <bot@their-company.example>',
+      commit: 'Co-Authored-By: Their Bot <bot@example.com>',
       pr: 'Built by our platform team',
     };
     const settings: Record<string, unknown> = { attribution: { ...theirs } };

--- a/src/cli/__tests__/shared/hooks/git-commit.test.ts
+++ b/src/cli/__tests__/shared/hooks/git-commit.test.ts
@@ -143,25 +143,41 @@ describe('GitCommitHook', () => {
   });
 
   describe('co-author addition', () => {
-    it('should add co-author by default', async () => {
+    // #1398 — attribution is OFF by default now. Tool attribution in a
+    // consumer's permanent git history is not moflo's to add; it must be an
+    // explicit opt-in, so these assert the default is silence.
+    it('should NOT add co-author by default (#1398)', async () => {
       const result = await gitCommit.process('Add feature');
+
+      expect(result.coAuthorAdded).toBe(false);
+      expect(result.modifiedMessage).not.toContain('Co-Authored-By');
+    });
+
+    it('should NOT add a Claude Code reference by default (#1398)', async () => {
+      const result = await gitCommit.process('Add feature');
+
+      expect(result.modifiedMessage).not.toContain('Generated with');
+      expect(result.modifiedMessage).not.toContain('Claude Code');
+    });
+
+    it('does not append its own trailer alongside a user-written one (#1398)', async () => {
+      const result = await gitCommit.process('Add feature\n\nCo-Authored-By: Someone <some@email.com>');
+
+      // NOTE: this hook rewrites the subject to conventional form and drops the
+      // body, so the user's own trailer does not survive either. That is
+      // pre-existing behaviour, unrelated to #1398, and is asserted here only so
+      // the next reader is not surprised — see the follow-up note in #1398.
+      expect(result.modifiedMessage).toBe('feat: add feature');
+      expect(result.modifiedMessage).not.toContain('Claude');
+    });
+
+    it('still adds co-author when explicitly opted in', async () => {
+      // The capability is retained, just no longer default-on.
+      const hook = createGitCommitHook(registry, { addCoAuthor: true });
+      const result = await hook.process('Add feature');
 
       expect(result.coAuthorAdded).toBe(true);
       expect(result.modifiedMessage).toContain('Co-Authored-By:');
-      expect(result.modifiedMessage).toContain('Claude');
-    });
-
-    it('should add Claude Code reference', async () => {
-      const result = await gitCommit.process('Add feature');
-
-      expect(result.modifiedMessage).toContain('Claude Code');
-    });
-
-    it('should not duplicate co-author if already present', async () => {
-      const result = await gitCommit.process('Add feature\n\nCo-Authored-By: Someone <some@email.com>');
-
-      // Should still add Claude co-author
-      expect(result.modifiedMessage).toContain('Claude');
     });
   });
 
@@ -230,6 +246,8 @@ describe('GitCommitHook', () => {
 
     it('should allow custom co-author', async () => {
       const hook = createGitCommitHook(registry, {
+        // #1398 — addCoAuthor now defaults false, so opting in is explicit.
+        addCoAuthor: true,
         coAuthor: { name: 'Custom AI', email: 'ai@example.com' },
       });
       const result = await hook.process('Add feature');
@@ -273,7 +291,8 @@ describe('GitCommitHook', () => {
       const config = gitCommit.getConfig();
 
       expect(config.maxSubjectLength).toBeDefined();
-      expect(config.addCoAuthor).toBe(true);
+      // #1398 — attribution defaults off.
+      expect(config.addCoAuthor).toBe(false);
     });
 
     it('should update config', () => {
@@ -312,11 +331,9 @@ describe('GitCommitHook', () => {
       // Should have ticket reference
       expect(result.modifiedMessage).toContain('AUTH-123');
 
-      // Should have Claude reference
-      expect(result.modifiedMessage).toContain('Claude Code');
-
-      // Should have co-author
-      expect(result.modifiedMessage).toContain('Co-Authored-By');
+      // #1398 — no attribution of any kind unless explicitly opted in.
+      expect(result.modifiedMessage).not.toContain('Claude Code');
+      expect(result.modifiedMessage).not.toContain('Co-Authored-By');
     });
 
     it('should return original message unchanged in result', async () => {

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -323,6 +323,18 @@ function readMofloYaml() {
 }
 var MOFLO_YAML = readMofloYaml();
 
+// #1394 — is the hook that transcribes /verify's verdict wired at all?
+// Distinguishes "agent skipped Step 5" from "nothing can record the verdict";
+// only the first is fixable by re-running /verify. Lazy (blocked path only);
+// unreadable settings → true so a parse failure keeps the generic message.
+// SYNC: mirrors bin/gate.cjs isVerifyOutcomeHookWired.
+function isVerifyOutcomeHookWired() {
+  try {
+    return fs.readFileSync(path.join(PROJECT_DIR, '.claude', 'settings.json'), 'utf-8')
+      .indexOf('record-verify-outcome') >= 0;
+  } catch (e) { return true; }
+}
+
 var config = loadGateConfig();
 var sddConf = loadSddConfig();
 var mergeConf = loadMergeConfig();
@@ -680,7 +692,10 @@ var EDIT_RESET_SKIP_BOTH_RE = /\\.(md|markdown|txt|rst|adoc|lock|gitignore)$|(?:
 // #1297 — path-inert dirs (.github/workflows etc.); SYNC: mirrors bin/gate.cjs EDIT_RESET_SKIP_PATH_RE.
 // #1348 — plus \`.moflo/\`, moflo's own gitignored state dir: nothing written
 // there can reach the branch diff, so it must not invalidate a gate.
-var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\\\\/])\\.github[\\\\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\\\\/.]|$)|(?:^|[\\\\\\/])\\.moflo[\\\\\\/]/i;
+// #1395 — \`.claude/\` CONFIG (settings/skills/guidance/agents) joins them: it is
+// not the code under verification, and it is the directory a user edits because
+// a gate told them to. \`scripts/\`/\`helpers/\` stay OUT — they are executable.
+var EDIT_RESET_SKIP_PATH_RE = /(?:^|[\\\\\\/])\\.github[\\\\\\/](?:workflows|ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE)(?:[\\\\\\/.]|$)|(?:^|[\\\\\\/])\\.moflo[\\\\\\/]|(?:^|[\\\\\\/])\\.claude[\\\\\\/](?:settings(?:\\.local)?\\.json$|skills[\\\\\\/]|guidance[\\\\\\/]|agents[\\\\\\/])/i;
 // Test files: invalidate testsRun but preserve simplifyRun (#908) — /simplify
 // already reviewed the production code, touching tests/fixtures doesn't expose
 // new untested surface for code review.
@@ -1013,6 +1028,12 @@ switch (command) {
       process.stderr.write('  - the change has not been verified since the last code edit (run /verify)\\n');
     } else if (s.verifyOutcome === 'FAIL' || s.verifyOutcome === 'UNVERIFIED') {
       process.stderr.write('  - /verify ran and returned ' + s.verifyOutcome + ' — fix the failing criteria, then re-run /verify\\n');
+      // #1394 — two causes, opposite remedies. Re-running /verify cannot fix
+      // absent wiring, so never prescribe it when the transcriber is missing.
+    } else if (!isVerifyOutcomeHookWired()) {
+      process.stderr.write('  - \`record-verify-outcome\` is not wired in .claude/settings.json — the verdict cannot be recorded\\n');
+      process.stderr.write('    /verify may well have passed; nothing exists to transcribe its result, so re-running it will not help.\\n');
+      process.stderr.write('    Fix: run \`flo doctor --fix\`, restart the session, then re-run /verify.\\n');
     } else {
       process.stderr.write('  - /verify ran but recorded no verdict — re-run it so it stores a structured result\\n');
       // #1348 — re-invoking /verify clears the prior verdict by design (#1332),

--- a/src/cli/init/moflo-init.ts
+++ b/src/cli/init/moflo-init.ts
@@ -32,7 +32,7 @@ import {
   computeHookBlockDrift,
   isHookBlockLocked,
 } from '../services/hook-block-hash.js';
-import { rewriteIncorrectHookWiring } from '../services/hook-wiring.js';
+import { rewriteIncorrectHookWiring, removeLegacyAttribution } from '../services/hook-wiring.js';
 
 export { discoverTestDirs };
 
@@ -333,11 +333,19 @@ function generateHooks(root: string, force?: boolean, _answers?: MofloInitAnswer
     preserved = extraCount - removed;
   }
 
-  // Ensure statusLine + permissions/env/attribution scaffold is present —
-  // mirrors the existing moflo-init.ts UX but no longer overwrites user
-  // values that are already set.
+  // #1398 — strip the legacy attribution block on this path too, so `flo init`
+  // on an existing project and `doctor --fix` heal it as well as session start.
+  // NOT inert: Claude Code reads `settings.attribution` and injects it into the
+  // agent's instructions, so leaving it keeps moflo's trailer on the consumer's
+  // commits regardless of what the generator now emits.
+  const strippedAttribution = removeLegacyAttribution(existing);
+
+  // Ensure statusLine + permissions/env scaffold is present — mirrors the
+  // existing moflo-init.ts UX but no longer overwrites user values that are
+  // already set. `attribution` is deliberately absent from the scaffold list:
+  // the generator no longer emits it, so it could only ever copy `undefined`.
   const canonical = generateSettings({ ...DEFAULT_INIT_OPTIONS, targetDir: root, force: true }) as Record<string, unknown>;
-  const scaffoldKeys = ['statusLine', 'permissions', 'env', 'attribution'] as const;
+  const scaffoldKeys = ['statusLine', 'permissions', 'env'] as const;
   const scaffoldAdded: string[] = [];
   for (const key of scaffoldKeys) {
     if (existing[key] == null && canonical[key] != null) {
@@ -346,7 +354,8 @@ function generateHooks(root: string, force?: boolean, _answers?: MofloInitAnswer
     }
   }
 
-  const dirty = rewroteCommands > 0 || added > 0 || removed > 0 || scaffoldAdded.length > 0;
+  const dirty = rewroteCommands > 0 || added > 0 || removed > 0 || scaffoldAdded.length > 0
+    || strippedAttribution;
   if (!dirty) {
     return { name: '.claude/settings.json', status: 'skipped', detail: 'already at canonical reference' };
   }
@@ -361,6 +370,7 @@ function generateHooks(root: string, force?: boolean, _answers?: MofloInitAnswer
   if (preserved > 0) parts.push(`✓${preserved} preserved`);
   if (rewroteCommands > 0) parts.push(`↻${rewroteCommands} rewrites`);
   if (scaffoldAdded.length > 0) parts.push(`+scaffold (${scaffoldAdded.join(',')})`);
+  if (strippedAttribution) parts.push('-attribution (#1398)');
   return { name: '.claude/settings.json', status: 'updated', detail: parts.join(', ') };
 }
 

--- a/src/cli/init/settings-generator.ts
+++ b/src/cli/init/settings-generator.ts
@@ -44,11 +44,11 @@ export function generateSettings(options: InitOptions): object {
     ],
   };
 
-  // Add claude-flow attribution for git commits and PRs
-  settings.attribution = {
-    commit: 'Co-Authored-By: moflo <noreply@cielolimitada.com>',
-    pr: '🤖 Generated with [moflo](https://github.com/eric-cielo/moflo)',
-  };
+  // #1398 — no attribution block. moflo used to write a `Co-Authored-By` trailer
+  // and a "Generated with moflo" PR banner into every consumer's settings.json.
+  // Nothing ever read the key (the /flo skill hardcoded the literal instead), and
+  // stamping a tool's identity into someone else's permanent git history is not
+  // moflo's call to make. Do not reintroduce — see issue #1398.
 
   // Note: Claude Code expects 'model' to be a string, not an object
   // Model preferences are stored in moflo settings instead

--- a/src/cli/services/hook-wiring.ts
+++ b/src/cli/services/hook-wiring.ts
@@ -16,6 +16,47 @@ interface HookEntry {
   timeout: number;
 }
 
+/**
+ * #1398 — remove the legacy `attribution` block from a consumer's settings.json.
+ *
+ * This is NOT cosmetic cleanup. `settings.attribution` is read by Claude Code
+ * itself, which injects `attribution.commit` / `attribution.pr` into the agent's
+ * instructions — which is how the `Co-Authored-By: moflo …` trailer and the
+ * "Generated with moflo" PR banner actually reached commits. No moflo code reads
+ * the key, so it looks inert from inside this repo; it is not.
+ *
+ * Consequence: dropping the block from `settings-generator.ts` fixes FRESH
+ * installs only. Every project that upgrades keeps the key it was given at init
+ * and keeps stamping moflo's identity into its own permanent git history. The
+ * generator edit without this one is precisely the fresh-install-only change
+ * `internal/upgrade-contract.md` § "Design for the upgrade path first" warns about.
+ *
+ * Deletes only the exact keys moflo wrote. A consumer who set their own
+ * `attribution` deliberately keeps it — we remove ours, not theirs.
+ *
+ * @returns true when the settings object was modified.
+ */
+export function removeLegacyAttribution(settings: Record<string, unknown>): boolean {
+  const attribution = settings.attribution as Record<string, unknown> | undefined;
+  // Array.isArray guard: `typeof [] === 'object'`, so a bogus array value would
+  // otherwise fall through to the empty-object check below and be reported as a
+  // change we didn't make — a spurious settings.json write on every session start.
+  if (!attribution || typeof attribution !== 'object' || Array.isArray(attribution)) return false;
+
+  const MOFLO_COMMIT = 'Co-Authored-By: moflo <noreply@cielolimitada.com>';
+  const MOFLO_PR = '\u{1F916} Generated with [moflo](https://github.com/eric-cielo/moflo)';
+
+  let changed = false;
+  if (attribution.commit === MOFLO_COMMIT) { delete attribution.commit; changed = true; }
+  if (attribution.pr === MOFLO_PR) { delete attribution.pr; changed = true; }
+
+  // Drop the now-empty container so the key doesn't linger as a puzzle for the
+  // next reader. A block still holding consumer-set values is left alone.
+  if (Object.keys(attribution).length === 0) { delete settings.attribution; changed = true; }
+
+  return changed;
+}
+
 interface HookEntryMapping {
   event: string;
   matcher: string;
@@ -51,9 +92,30 @@ export const REQUIRED_HOOK_WIRING: ReadonlyArray<{ event: string; pattern: strin
   // start; without it, only consumers who re-run `flo init` would get the
   // escape, and the deadlock would persist everywhere else.
   { event: 'PostToolUse', pattern: 'record-bash-swarm-init' },
+  // #1393 (found by the generator-parity guard) — the MCP halves that #1338
+  // left behind. check-before-agent hard-blocks every Agent spawn under
+  // `/fl -s` until `swarmInitialized` (gate.cjs:1201) and under `/fl -h` until
+  // `hiveInitialized` (gate.cjs:1209); these are the hooks that set them.
+  // #1338 added only the CLI half above, so on an UPGRADED consumer the
+  // primary path — the skill calling mcp__moflo__swarm_init — credited
+  // nothing and swarm/hive runs deadlocked exactly like #1392's verify gate.
+  // Routed via gate.cjs (not gate-hook.mjs) to match getReferenceHookBlock()
+  // in hook-block-hash.ts:164-165 — if the two disagree the drift detector
+  // fights the repair path every session start.
+  { event: 'PostToolUse', pattern: 'record-swarm-init' },
+  { event: 'PostToolUse', pattern: 'record-hive-init' },
   { event: 'PostToolUse', pattern: 'record-skill-run' },
   // Story #1274 — record the native /verify skill run so check-before-done is satisfied.
   { event: 'PostToolUse', pattern: 'record-verify-run' },
+  // #1393 — the transcriber that turns /verify's stored verdict into
+  // `verifyOutcome` on workflow-state.json. #1332 tightened check-before-done to
+  // require verifyOutcome === 'PASS' but wired this hook in settings-generator
+  // ONLY, so every project that UPGRADED (rather than re-running `flo init`) got
+  // a verify-before-done gate that could not be satisfied — /verify stored a
+  // correct PASS, nothing transcribed it, and the sole escape was
+  // `gates: verify_before_done: false`. Listed here so repairHookWiring grafts
+  // it in on next session start.
+  { event: 'PostToolUse', pattern: 'record-verify-outcome' },
   { event: 'PostToolUse', pattern: 'reset-edit-gates' },
   // First UserPromptSubmit hook (prompt-hook.mjs internally calls
   // `gate.cjs prompt-reminder`). Substring check tolerates either the
@@ -109,8 +171,21 @@ export const HOOK_ENTRY_MAP: Record<string, HookEntryMapping> = {
   // #1338 follow-up — same Bash/PowerShell PostToolUse block as record-test-run.
   'record-bash-swarm-init':   { event: 'PostToolUse',      matcher: '^(Bash|PowerShell)$',        hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-bash-swarm-init', timeout: 2000 } },
   'record-skill-run':         { event: 'PostToolUse',      matcher: '^Skill$',                    hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-skill-run', timeout: 2000 } },
+  // #1393 — MCP halves of the swarm/hive init recorders. gate.cjs (not
+  // gate-hook.mjs) and these exact matchers mirror hook-block-hash.ts:164-165
+  // and settings-generator.ts; all four copies must agree or the drift
+  // detector and repairHookWiring undo each other on every session start.
+  'record-swarm-init':        { event: 'PostToolUse',      matcher: '^mcp__moflo__swarm_init$',   hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-swarm-init', timeout: 2000 } },
+  'record-hive-init':         { event: 'PostToolUse',      matcher: '^mcp__moflo__hive-mind_init$', hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate.cjs" record-hive-init', timeout: 2000 } },
   // Story #1274 — record the native /verify skill run (same ^Skill$ matcher as record-skill-run).
   'record-verify-run':        { event: 'PostToolUse',      matcher: '^Skill$',                    hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-verify-run', timeout: 2000 } },
+  // #1393 — shares the ^mcp__moflo__memory_store$ block with record-learnings-stored;
+  // repairHookWiring appends it there rather than creating a second block.
+  // MUST route through gate-hook.mjs, NOT gate.cjs: the TOOL_INPUT_* env vars
+  // gate.cjs reads are built by gate-hook.mjs from the hook's stdin payload, so a
+  // direct gate.cjs invocation would see neither the key nor the `metadata` object
+  // carrying the verdict — the hook would fire and record nothing.
+  'record-verify-outcome':    { event: 'PostToolUse',      matcher: '^mcp__moflo__memory_store$', hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" record-verify-outcome', timeout: 2000 } },
   'reset-edit-gates':         { event: 'PostToolUse',      matcher: '^(Write|Edit|MultiEdit)$',   hook: { type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/.claude/helpers/gate-hook.mjs" reset-edit-gates', timeout: 2000 } },
   // #931 — Agent-time advisory; never blocks. Pulled the TaskCreate REMINDER
   // and namespace hint out of prompt-reminder so they fire only when Claude is

--- a/src/cli/shared/hooks/safety/git-commit.ts
+++ b/src/cli/shared/hooks/safety/git-commit.ts
@@ -198,9 +198,13 @@ const DEFAULT_CONFIG: CommitConfig = {
   maxSubjectLength: 72,
   maxBodyLength: 100,
   requireConventional: true,
-  addCoAuthor: true,
+  // #1398 — both default OFF. This hook used to append a "Generated with …"
+  // line and a Co-Authored-By trailer to every commit it processed. Tool
+  // attribution in a consumer's git history is permanent and not moflo's to
+  // add; callers who genuinely want it must opt in explicitly.
+  addCoAuthor: false,
   coAuthor: DEFAULT_CO_AUTHOR,
-  addClaudeReference: true,
+  addClaudeReference: false,
 };
 
 /**

--- a/tests/bin/gate-verify-wiring-1394-1395.test.ts
+++ b/tests/bin/gate-verify-wiring-1394-1395.test.ts
@@ -1,0 +1,166 @@
+/**
+ * #1394 + #1395 (Epic #1392) — gate.cjs behaviour around the verify transcriber.
+ *
+ * #1394: `check-before-done` must distinguish "the agent skipped Step 5" from
+ *        "the hook that transcribes the verdict is not wired". They need opposite
+ *        remedies; the old single message fit only the first, so a correct verdict
+ *        read as agent error and the prescribed fix (re-run /verify) could never
+ *        work.
+ * #1395: editing `.claude/` CONFIG must not reset the verify/test/simplify gates —
+ *        otherwise repairing hook wiring on a gate's own instruction invalidates
+ *        the verification the repair existed to permit.
+ *
+ * Both assertions are made against the SHIPPED `bin/gate.cjs` source, and the
+ * three copies are asserted identical, because the copy that actually runs in a
+ * consumer is the synced one — not this repo's source tree.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const BIN_GATE = join(REPO_ROOT, 'bin', 'gate.cjs');
+const HELPERS_GATE = join(REPO_ROOT, '.claude', 'helpers', 'gate.cjs');
+
+const gateSrc = readFileSync(BIN_GATE, 'utf-8');
+
+/**
+ * Pull the live EDIT_RESET_SKIP_PATH_RE out of the shipped source and evaluate
+ * it, rather than restating the pattern here. A copy of the regex in the test
+ * would keep passing after the real one regressed.
+ */
+function editResetSkipRe(): RegExp {
+  const m = gateSrc.match(/^var EDIT_RESET_SKIP_PATH_RE = (\/.*\/i);$/m);
+  if (!m) throw new Error('EDIT_RESET_SKIP_PATH_RE not found in bin/gate.cjs');
+  // eslint-disable-next-line no-eval
+  return eval(m[1]) as RegExp;
+}
+
+describe('#1395 — .claude config edits do not reset the gates', () => {
+  const re = editResetSkipRe();
+
+  // Both separators everywhere: TOOL_INPUT paths arrive backslashed on Windows,
+  // and a POSIX-only pattern would silently never match there (Rule #1).
+  const exempt = [
+    '.claude/settings.json',
+    '.claude\\settings.json',
+    '.claude/settings.local.json',
+    'repo/.claude/settings.json',
+    '.claude/skills/fl/SKILL.md',
+    '.claude\\skills\\fl\\SKILL.md',
+    '.claude/guidance/internal/upgrade-contract.md',
+    '.claude/agents/reviewer.md',
+  ];
+  for (const p of exempt) {
+    it(`exempts ${p}`, () => {
+      expect(re.test(p)).toBe(true);
+    });
+  }
+
+  // The invariant #1395 must NOT break: editing executable code still
+  // invalidates a verification, including executable code under .claude/.
+  const stillResets = [
+    'src/cli/services/hook-wiring.ts',
+    'bin/gate.cjs',
+    '.claude/scripts/index-all.mjs',
+    '.claude\\scripts\\index-all.mjs',
+    '.claude/helpers/gate.cjs',
+    '.claude/helpers/gate-hook.mjs',
+  ];
+  for (const p of stillResets) {
+    it(`still resets on ${p}`, () => {
+      expect(re.test(p)).toBe(false);
+    });
+  }
+
+  it('does not exempt a .claude-prefixed path outside the directory', () => {
+    // Guards against an unanchored alternative matching e.g. `src/.claudex/`.
+    expect(re.test('src/.claudex/settings.json')).toBe(false);
+    expect(re.test('myclaude/settings.json')).toBe(false);
+  });
+
+  it('keeps the pre-existing #1176/#1348 exemptions', () => {
+    expect(re.test('.github/workflows/ci.yml')).toBe(true);
+    expect(re.test('.github/PULL_REQUEST_TEMPLATE.md')).toBe(true);
+    expect(re.test('.moflo/specs/foo/plan.md')).toBe(true);
+    expect(re.test('src/index.ts')).toBe(false);
+  });
+});
+
+describe('#1394 — check-before-done names the real cause', () => {
+  it('defines isVerifyOutcomeHookWired', () => {
+    expect(gateSrc).toContain('function isVerifyOutcomeHookWired()');
+  });
+
+  it('branches the no-verdict message on whether the hook is wired', () => {
+    expect(gateSrc).toContain('if (!isVerifyOutcomeHookWired())');
+    expect(gateSrc).toContain('`record-verify-outcome` is not wired in .claude/settings.json');
+  });
+
+  it('prescribes flo doctor --fix and a restart, not a futile /verify re-run', () => {
+    const idx = gateSrc.indexOf('is not wired in .claude/settings.json');
+    const branch = gateSrc.slice(idx, idx + 600);
+    expect(branch).toContain('flo doctor --fix');
+    expect(branch).toContain('restart the session');
+    expect(branch).toContain('will not help');
+  });
+
+  it('keeps the original Step 5 message for the genuinely-missing-verdict case', () => {
+    expect(gateSrc).toContain('Step 5 of the verify skill must pass metadata.overall to memory_store');
+    expect(gateSrc).toContain('Re-invoking /verify clears the prior verdict');
+  });
+
+  it('falls back to the generic message when settings.json is unreadable', () => {
+    // The catch must return TRUE ("assume wired"), so a parse failure produces
+    // the pre-existing message rather than asserting a wiring bug that may not
+    // exist. Returning false here would make every malformed-settings project
+    // see a confident, wrong diagnosis.
+    const fn = gateSrc.slice(
+      gateSrc.indexOf('function isVerifyOutcomeHookWired()'),
+      gateSrc.indexOf('function isVerifyOutcomeHookWired()') + 500,
+    );
+    expect(fn).toMatch(/catch \(e\) \{ return true; \}/);
+  });
+
+  it('reads settings lazily, not at module scope', () => {
+    // check-before-done is the only caller and only on an already-blocked path.
+    // Hoisting the read would add a syscall to every Write/Edit in every consumer.
+    expect(gateSrc).not.toMatch(/^var VERIFY_HOOK_WIRED = /m);
+  });
+});
+
+describe('gate.cjs copies stay in sync (consumer runs the synced copy)', () => {
+  it('bin/gate.cjs and .claude/helpers/gate.cjs are byte-identical', () => {
+    expect(readFileSync(HELPERS_GATE, 'utf-8')).toBe(gateSrc);
+  });
+
+  /**
+   * The generator holds a THIRD copy of this regex, hand-escaped for a TS
+   * template literal (`[\\\/]` becomes `[\\\\\\/]`). Double-escaping is silent
+   * when wrong: the pattern still compiles, it just stops matching. Compare the
+   * compiled sources so a mis-escape fails here instead of in a consumer.
+   */
+  /** Built once — both assertions below read the same generated source. */
+  let generated: string;
+  beforeAll(async () => {
+    const { generateGateScript } = await import(
+      join(REPO_ROOT, 'dist', 'src', 'cli', 'init', 'helpers-generator.js')
+    );
+    generated = generateGateScript();
+  });
+
+  it('helpers-generator emits the same EDIT_RESET_SKIP_PATH_RE as bin/gate.cjs (#1395)', () => {
+    const m = generated.match(/^var EDIT_RESET_SKIP_PATH_RE = (\/.*\/i);$/m);
+    expect(m, 'EDIT_RESET_SKIP_PATH_RE missing from generated gate.cjs').toBeTruthy();
+
+    // eslint-disable-next-line no-eval
+    const generatedRe = eval(m![1]) as RegExp;
+    expect(generatedRe.source).toBe(editResetSkipRe().source);
+  });
+
+  it('helpers-generator emits the #1394 wiring branch', () => {
+    expect(generated).toContain('function isVerifyOutcomeHookWired()');
+    expect(generated).toContain('is not wired in .claude/settings.json');
+  });
+});


### PR DESCRIPTION
## Summary

Five defects from one field-reported `/fl` run on `4.12.4-rc.8` (#1392), plus one the fix's own guard uncovered. They share a single cause: **changes that reached fresh `flo init` installs and never reached projects that upgraded.**

The reporting project got to `4.12.4-rc.8` by upgrading, not by re-running `flo init` — which is why the whole cluster was invisible in-repo.

## The chain

**#1393 — verify-before-done was unsatisfiable on every upgraded project.** #1332 tightened `check-before-done` to require `verifyOutcome === 'PASS'` while wiring the hook that *writes* that field into `settings-generator.ts` only. `repairHookWiring()` could not graft it into an existing project, and `flo doctor` reported hook wiring healthy throughout. `/verify` stored a correct `PASS`, nothing transcribed it, and the only remedy available to a user was `gates.verify_before_done: false`. Now in `REQUIRED_HOOK_WIRING` + `HOOK_ENTRY_MAP`, routed through `gate-hook.mjs` — `gate.cjs` alone never sees the `TOOL_INPUT_*` payload carrying the verdict, so a "present" hook wired directly would fire and record nothing.

**#1399 — the same omission on protected surface, found by the new guard on its first run.** `record-swarm-init` / `record-hive-init` were also generator-only, so on an upgraded project `check-before-agent` blocked *every* Agent spawn under `/fl -s` and `/fl -h` while the MCP init call credited nothing. #1338 hit this exact problem and fixed only the CLI half; the MCP halves are the path the skill actually uses. Routed via `gate.cjs` to match `hook-block-hash.ts:164-165` — if the repair path and the drift reference disagree on routing, they undo each other every session start.

**#1394 — the block message sent users into an unbounded retry loop.** With the transcriber unwired, the gate blamed the agent for skipping Step 5 and prescribed re-running `/verify`, which cannot fix absent wiring. It now distinguishes the two states and points at `flo doctor --fix`.

**#1395 — the prescribed repair invalidated itself.** Editing `.claude/settings.json` to fix hook wiring tripped `reset-edit-gates` and cleared `verifyRun`. Config (`settings*.json`, `skills/`, `guidance/`, `agents/`) is now exempt by the same "doesn't expose new runtime surface" reasoning that already exempts `.github/workflows/`. `.claude/scripts/` and `.claude/helpers/` deliberately still reset — editing executable code should still invalidate a verification.

**#1398 — moflo no longer signs anyone's commits.** No `Co-Authored-By`, no "Generated with" banner, in consumer projects or here.

> Worth flagging for review: `settings.attribution` is read by **Claude Code**, not by moflo. Nothing in this source tree reads it, which made it look like dead config — but the harness injects it into the agent's instructions, and that is how the trailer actually reached commits. So dropping it from the generator alone would have fixed fresh installs only. `removeLegacyAttribution()` strips it on session start and on `flo init`, removing only the exact strings moflo wrote and leaving a consumer-authored block alone.

## The guard is the durable part

`settings-generator.ts` carried a comment warning its wiring must not drift from `hook-block-hash.ts` and `hook-wiring.ts`. A comment is not a guard. `hook-wiring-generator-parity-1393.test.ts` now asserts every gate hook the generator emits is either repaired into existing projects or on an explicit exclusion list with a reason and an issue number.

It found #1399 immediately, and flagged `compact-guidance` — excluded with rationale, since it is emitted conditionally on `config.preCompact` and `REQUIRED_HOOK_WIRING` has no notion of a condition, so repairing it would override a deliberate opt-out.

## Guidance

`.claude/guidance/internal/upgrade-contract.md` gains **§ Design for the upgrade path first — it is never an afterthought**: the three design-time questions, the "you edited a generator and nothing else" test, and the rule that a gate must never tighten without its satisfier reaching existing consumers in the same change. #1332 is recorded under Historical violations.

## Testing

- [x] Full suite: **10,427 passed, 0 failed**
- [x] Upgraded-consumer simulation against `dist/` — a pre-#1332 `settings.json` gains all three hooks with correct routing, keeps the consumer's own hooks and `permissions`, produces no duplicate matcher block, and is byte-stable on a second pass
- [x] Both `check-before-done` message branches exercised by running the real `bin/gate.cjs` against synthetic projects
- [x] `reset-edit-gates` verified in both directions (config preserved; source and executable `.claude/` paths still reset)
- [x] New guard mutation-tested — reverting the fix fails 4 tests, so it cannot pass vacuously
- [x] Cross-platform (Rule #1): the `.claude` regex branch matches both `/` and `\`; the hand-escaped copy inside the TS template literal is asserted to compile to a byte-identical pattern
- [x] Dogfooding: `bin/gate.cjs` ↔ `.claude/helpers/gate.cjs` and both launcher copies kept byte-identical (the parity guard caught one miss during this work)

**One caveat, stated rather than buried:** a first attempt at the `reset-edit-gates` probe was invalid — the synthetic project was rooted under `os.tmpdir()`, so `isEphemeralPath()` (#1348) short-circuited every case and it passed vacuously in *both* directions. Re-rooted outside tmp before the result was trusted.

## Not verified here

#1399's post-publish criterion — a live `/fl -s` Agent spawn on a genuinely upgraded consumer — cannot be checked before publish: hooks run from `node_modules/moflo` and Claude Code loads them only at session start. The wiring it depends on is verified end-to-end against `dist/`; the live run is a **post-release check** and is recorded as deferred, not as passed.

Closes #1393
Closes #1394
Closes #1395
Closes #1398
Closes #1399
