### PR TITLE
fix(memory,hooks): stop the entry cache fabricating row fields; forward session_id (#1396, #1397)

### DIFF
--- a/.claude/helpers/prompt-hook.mjs
+++ b/.claude/helpers/prompt-hook.mjs
@@ -23,6 +23,15 @@ try { if (stdinData.trim()) hookContext = JSON.parse(stdinData); } catch (e) {}
 var userPrompt = hookContext.user_prompt || hookContext.prompt || '';
 var env = Object.assign({}, process.env, { CLAUDE_USER_PROMPT: userPrompt });
 
+// #1397 — forward Claude Code's session_id, same contract as gate-hook.mjs:33.
+// `prompt-reminder` stamps it onto workflow-state.json (gate.cjs), which is the
+// only place `flo runs start` can read it from; without it every run record got
+// sessionId:null and a zeroed token rollup. prompt-reminder is invoked through
+// THIS wrapper, not gate-hook.mjs, so the id has to be forwarded here too.
+if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
+  env.HOOK_SESSION_ID = hookContext.session_id;
+}
+
 // Run prompt-reminder via gate.cjs
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');

--- a/bin/prompt-hook.mjs
+++ b/bin/prompt-hook.mjs
@@ -23,6 +23,15 @@ try { if (stdinData.trim()) hookContext = JSON.parse(stdinData); } catch (e) {}
 var userPrompt = hookContext.user_prompt || hookContext.prompt || '';
 var env = Object.assign({}, process.env, { CLAUDE_USER_PROMPT: userPrompt });
 
+// #1397 — forward Claude Code's session_id, same contract as gate-hook.mjs:33.
+// `prompt-reminder` stamps it onto workflow-state.json (gate.cjs), which is the
+// only place `flo runs start` can read it from; without it every run record got
+// sessionId:null and a zeroed token rollup. prompt-reminder is invoked through
+// THIS wrapper, not gate-hook.mjs, so the id has to be forwarded here too.
+if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
+  env.HOOK_SESSION_ID = hookContext.session_id;
+}
+
 // Run prompt-reminder via gate.cjs
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\/([a-z])\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');

--- a/src/cli/__tests__/memory/bridge-entry-cache-shape-1396.test.ts
+++ b/src/cli/__tests__/memory/bridge-entry-cache-shape-1396.test.ts
@@ -1,0 +1,251 @@
+/**
+ * #1396 (Epic #1392) — the entry cache must carry the FULL row shape.
+ *
+ * Symptom in the field: every `mcp__moflo__memory_store` call that passed
+ * `tags` read back with `tags: []`, `accessCount: 0`, and a `storedAt` equal to
+ * roughly *retrieval* time. `metadata` on the same call survived.
+ *
+ * Root cause: `bridgeStoreEntry` warmed the entry cache with
+ * `{id,key,namespace,content,embedding,metadata}` only, while
+ * `bridgeGetEntry`'s cache-hit branch returns the cached value verbatim and
+ * substitutes defaults for anything missing — `tags: []`, `accessCount: 0`,
+ * and `new Date()` for the timestamps. So for the cache's TTL after any write,
+ * a retrieve reported plausible-looking but fabricated values. #1064 had added
+ * `metadata` to that cache write for exactly this reason, which is precisely
+ * why metadata survived and the rest did not.
+ *
+ * Nothing was ever lost on disk — the INSERT always wrote tags correctly. These
+ * tests therefore assert the CACHE-HIT path specifically (`cacheHit === true`),
+ * because a test that silently fell through to the disk read would pass against
+ * the unfixed code and prove nothing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  _resetProjectRootForTest,
+  shutdownBridge,
+} from '../../memory/bridge-core.js';
+import { bridgeStoreEntry, bridgeGetEntry, bridgeStoreEntries } from '../../memory/memory-bridge.js';
+
+describe('entry cache shape (#1396)', () => {
+  let tempDir: string;
+  let projectRoot: string;
+  let dbPath: string;
+  let originalCwd: string;
+  let originalProjectDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), 'moflo-1396-cache-'));
+    projectRoot = tempDir;
+    fs.mkdirSync(path.join(projectRoot, '.moflo'), { recursive: true });
+    dbPath = path.join(projectRoot, '.moflo', 'moflo.db');
+
+    originalCwd = process.cwd();
+    originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = projectRoot;
+    process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+
+    await shutdownBridge();
+    _resetProjectRootForTest();
+  });
+
+  afterEach(async () => {
+    await shutdownBridge();
+    _resetProjectRootForTest();
+    if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+    delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+    try { process.chdir(originalCwd); } catch { /* ignore */ }
+    try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('round-trips tags through a cache hit', async () => {
+    const stored = await bridgeStoreEntry({
+      key: 'k-tags',
+      value: 'body',
+      namespace: 'ns-1396',
+      tags: ['alpha', 'beta'],
+      upsert: true,
+    });
+    expect(stored?.success).toBe(true);
+
+    const got = await bridgeGetEntry({ key: 'k-tags', namespace: 'ns-1396' });
+
+    // The assertion that makes this test meaningful: the store warmed the
+    // cache, so this read MUST be served from it. If it ever falls through to
+    // disk, the tags below would pass for the wrong reason.
+    expect(got?.cacheHit).toBe(true);
+    expect(got?.entry?.tags).toEqual(['alpha', 'beta']);
+  });
+
+  it('keeps tags and metadata intact together on a cache hit', async () => {
+    await bridgeStoreEntry({
+      key: 'k-both',
+      value: 'body',
+      namespace: 'ns-1396',
+      tags: ['verify', 'sdd'],
+      metadata: { type: 'verify-record', overall: 'PASS' },
+      upsert: true,
+    });
+
+    const got = await bridgeGetEntry({ key: 'k-both', namespace: 'ns-1396' });
+    expect(got?.cacheHit).toBe(true);
+    expect(got?.entry?.tags).toEqual(['verify', 'sdd']);
+    expect(JSON.parse(got!.entry!.metadata!)).toMatchObject({
+      type: 'verify-record',
+      overall: 'PASS',
+    });
+  });
+
+  it('reports an empty tag list — not a crash — when none were supplied', async () => {
+    await bridgeStoreEntry({ key: 'k-none', value: 'body', namespace: 'ns-1396', upsert: true });
+
+    const got = await bridgeGetEntry({ key: 'k-none', namespace: 'ns-1396' });
+    expect(got?.cacheHit).toBe(true);
+    expect(got?.entry?.tags).toEqual([]);
+  });
+
+  it('reports the store time, not the retrieval time, as createdAt', async () => {
+    const before = Date.now();
+    await bridgeStoreEntry({ key: 'k-time', value: 'body', namespace: 'ns-1396', tags: ['t'], upsert: true });
+    const after = Date.now();
+
+    const got = await bridgeGetEntry({ key: 'k-time', namespace: 'ns-1396' });
+    expect(got?.cacheHit).toBe(true);
+
+    // Bounded against the store window rather than a sleep — a wall-clock delay
+    // is the flakiness vector CLAUDE.md's broken-window rule calls out, and the
+    // pre-fix value (a fresh `new Date()` at read time) is an ISO STRING, so it
+    // fails the numeric check regardless of how fast the test runs.
+    const createdAt = got!.entry!.createdAt as number;
+    expect(typeof createdAt).toBe('number');
+    expect(createdAt).toBeGreaterThanOrEqual(before);
+    expect(createdAt).toBeLessThanOrEqual(after);
+
+    // And it must agree with what actually landed on disk.
+    const probeDb = new DatabaseSync(dbPath);
+    try {
+      const row = probeDb.prepare(
+        'SELECT created_at, tags FROM memory_entries WHERE key = ? AND namespace = ?',
+      ).get('k-time', 'ns-1396') as { created_at: number; tags: string | null };
+      expect(row.created_at).toBe(createdAt);
+      expect(JSON.parse(row.tags!)).toEqual(['t']);
+    } finally {
+      probeDb.close();
+    }
+  });
+
+  it('increments accessCount across repeated reads and holds createdAt steady', async () => {
+    await bridgeStoreEntry({ key: 'k-count', value: 'body', namespace: 'ns-1396', tags: ['x'], upsert: true });
+
+    const first = await bridgeGetEntry({ key: 'k-count', namespace: 'ns-1396' });
+    const second = await bridgeGetEntry({ key: 'k-count', namespace: 'ns-1396' });
+    const third = await bridgeGetEntry({ key: 'k-count', namespace: 'ns-1396' });
+
+    expect(first?.entry?.accessCount).toBe(1);
+    expect(second?.entry?.accessCount).toBe(2);
+    expect(third?.entry?.accessCount).toBe(3);
+
+    // Timestamps are a property of the row, not of reading it.
+    expect(second?.entry?.createdAt).toBe(first?.entry?.createdAt);
+    expect(third?.entry?.createdAt).toBe(first?.entry?.createdAt);
+    expect(third?.entry?.tags).toEqual(['x']);
+  });
+
+  it('reports hasEmbedding consistently across a cache hit and a disk read', async () => {
+    await bridgeStoreEntry({
+      key: 'k-emb',
+      value: 'body with enough text to embed',
+      namespace: 'ns-1396',
+      tags: ['e'],
+      generateEmbeddingFlag: true,
+      upsert: true,
+    });
+
+    const fromCache = await bridgeGetEntry({ key: 'k-emb', namespace: 'ns-1396' });
+    expect(fromCache?.cacheHit).toBe(true);
+
+    // Drop the cache the way expiry would, then read the same row from disk.
+    // Pre-fix these two disagreed: the store path cached `embedding` with no
+    // `hasEmbedding`, the read path cached `hasEmbedding` with no `embedding`,
+    // and the cache-hit branch only ever consulted `embedding` — so the same
+    // row flipped to hasEmbedding:false on the second retrieve.
+    await shutdownBridge();
+    _resetProjectRootForTest();
+
+    const fromDisk = await bridgeGetEntry({ key: 'k-emb', namespace: 'ns-1396' });
+    expect(fromDisk?.cacheHit).toBe(false);
+    expect(fromDisk?.entry?.hasEmbedding).toBe(fromCache?.entry?.hasEmbedding);
+    expect(fromDisk?.entry?.tags).toEqual(['e']);
+
+    // Now warm again from that disk read and confirm the re-cached shape holds.
+    const reCached = await bridgeGetEntry({ key: 'k-emb', namespace: 'ns-1396' });
+    expect(reCached?.cacheHit).toBe(true);
+    expect(reCached?.entry?.hasEmbedding).toBe(fromDisk?.entry?.hasEmbedding);
+    expect(reCached?.entry?.tags).toEqual(['e']);
+  });
+
+  it('treats a pre-#1396 partial cache value as a miss and self-heals from disk', async () => {
+    // An in-place upgrade can leave old-shape values sitting in a live L1 cache.
+    // Serving one means fabricating the missing columns — the bug itself — so
+    // the reader must fall through to disk instead.
+    await bridgeStoreEntry({
+      key: 'k-stale',
+      value: 'body',
+      namespace: 'ns-1396',
+      tags: ['kept'],
+      upsert: true,
+    });
+
+    // Re-plant the exact pre-fix shape under the same cache key.
+    const { getRegistry } = await import('../../memory/bridge-core.js');
+    const registry = await getRegistry();
+    const cache = registry?.get('tieredCache');
+    expect(cache, 'tiered cache must be available for this test to mean anything').toBeTruthy();
+    await cache.set('entry:ns-1396:k-stale', {
+      id: 'entry_stale',
+      key: 'k-stale',
+      namespace: 'ns-1396',
+      content: 'body',
+      embedding: null,
+      metadata: '{}',
+    });
+
+    const got = await bridgeGetEntry({ key: 'k-stale', namespace: 'ns-1396' });
+
+    // Fell through to disk rather than serving the partial...
+    expect(got?.cacheHit).toBe(false);
+    // ...and therefore reported the row's real tags instead of `[]`.
+    expect(got?.entry?.tags).toEqual(['kept']);
+    expect(typeof got?.entry?.createdAt).toBe('number');
+
+    // The disk read re-cached the full shape, so the next read is a clean hit.
+    const next = await bridgeGetEntry({ key: 'k-stale', namespace: 'ns-1396' });
+    expect(next?.cacheHit).toBe(true);
+    expect(next?.entry?.tags).toEqual(['kept']);
+  });
+
+  it('warms the full shape from the bulk-store path too', async () => {
+    // bridgeStoreEntries carries its own copy of the cache-value construction,
+    // so it regresses independently of the single-store path.
+    const results = await bridgeStoreEntries([
+      { key: 'b-1', value: 'body one', namespace: 'ns-1396', tags: ['one'], upsert: true },
+      { key: 'b-2', value: 'body two', namespace: 'ns-1396', tags: ['two', 'more'], upsert: true },
+    ]);
+    expect(results?.every(r => r.success)).toBe(true);
+
+    const one = await bridgeGetEntry({ key: 'b-1', namespace: 'ns-1396' });
+    const two = await bridgeGetEntry({ key: 'b-2', namespace: 'ns-1396' });
+
+    expect(one?.cacheHit).toBe(true);
+    expect(two?.cacheHit).toBe(true);
+    expect(one?.entry?.tags).toEqual(['one']);
+    expect(two?.entry?.tags).toEqual(['two', 'more']);
+    expect(typeof one?.entry?.createdAt).toBe('number');
+  });
+});

--- a/src/cli/__tests__/services/reembed-preserves-tags-1396.test.ts
+++ b/src/cli/__tests__/services/reembed-preserves-tags-1396.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #1396 (Epic #1392) — the re-embed / re-index path must preserve every column
+ * it does not own.
+ *
+ * The field report named the background re-embed as the prime suspect for the
+ * dropped `tags` ("a re-persist path that reconstructs the row without carrying
+ * tags forward would explain both symptoms"). It was not the culprit — the real
+ * cause was the entry cache being warmed with a partial value, covered by
+ * `bridge-entry-cache-shape-1396.test.ts`.
+ *
+ * The suspicion was still worth nailing down permanently, because the failure
+ * mode it describes is real and has happened before: #1067 was exactly a
+ * re-persist that used `INSERT OR REPLACE` with only the embedding columns and
+ * silently reset metadata/tags/expires_at. This is the ticket's "regression
+ * guard that matters" — a re-embed must replace the embedding and nothing else.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { migrateStore } from '../../embeddings/migration/index.js';
+import { MockBatchEmbedder } from '../../embeddings/__tests__/migration/mock-batch-embedder.js';
+import { SqlJsMemoryEntriesStore } from '../../services/sqljs-migration-store.js';
+import { MEMORY_SCHEMA_V3 } from '../../memory/memory-initializer.js';
+import { openDaemonDatabase, type SqlJsLikeDatabase } from '../../memory/daemon-backend.js';
+
+function freshV3Db(): SqlJsLikeDatabase {
+  const db = openDaemonDatabase(':memory:');
+  db.run(MEMORY_SCHEMA_V3);
+  return db;
+}
+
+function readRow(db: SqlJsLikeDatabase, id: string) {
+  const res = db.exec(
+    `SELECT tags, metadata, created_at, updated_at, access_count, embedding
+     FROM memory_entries WHERE id = '${id.replace(/'/g, "''")}'`,
+  );
+  const row = res[0]?.values[0];
+  if (!row) throw new Error(`row ${id} vanished`);
+  return {
+    tags: row[0] === null ? null : String(row[0]),
+    metadata: row[1] === null ? null : String(row[1]),
+    createdAt: Number(row[2]),
+    updatedAt: row[3] === null ? null : Number(row[3]),
+    accessCount: Number(row[4]),
+    embedding: row[5] === null ? null : String(row[5]),
+  };
+}
+
+describe('re-embed preserves non-embedding columns (#1396)', () => {
+  it('keeps tags, metadata, created_at and access_count across a full re-embed', async () => {
+    const db = freshV3Db();
+    const createdAt = 1_700_000_000_000;
+    db.run(
+      `INSERT INTO memory_entries
+         (id, key, namespace, content, tags, metadata, created_at, updated_at, access_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        'r1', 'k-r1', 'learnings', 'a learning worth keeping',
+        JSON.stringify(['testing', 'source:manual']),
+        JSON.stringify({ type: 'note', overall: 'PASS' }),
+        createdAt, createdAt, 7,
+      ],
+    );
+
+    const before = readRow(db, 'r1');
+    expect(before.embedding).toBeNull();
+
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db');
+    const result = await migrateStore({ store, embedder: new MockBatchEmbedder(8), batchSize: 10 });
+    expect(result.success).toBe(true);
+    expect(result.itemsMigrated).toBe(1);
+
+    const after = readRow(db, 'r1');
+
+    // The one thing a re-embed IS allowed to change.
+    expect(after.embedding).not.toBeNull();
+    expect(JSON.parse(after.embedding!)).toHaveLength(8);
+
+    // Everything else must be byte-identical. A row-reconstructing re-persist
+    // — the #1067 shape, and what the field report suspected here — fails these.
+    expect(after.tags).toBe(before.tags);
+    expect(JSON.parse(after.tags!)).toEqual(['testing', 'source:manual']);
+    expect(after.metadata).toBe(before.metadata);
+    expect(after.createdAt).toBe(createdAt);
+    expect(after.accessCount).toBe(7);
+    db.close();
+  });
+
+  it('leaves a row with no tags equally untouched', async () => {
+    const db = freshV3Db();
+    db.run(
+      `INSERT INTO memory_entries (id, key, content, created_at) VALUES (?, ?, ?, ?)`,
+      ['r2', 'k-r2', 'no tags here', 1_700_000_000_000],
+    );
+
+    const store = new SqlJsMemoryEntriesStore(db, 'memory.db');
+    await migrateStore({ store, embedder: new MockBatchEmbedder(8), batchSize: 10 });
+
+    const after = readRow(db, 'r2');
+    expect(after.tags).toBeNull();
+    expect(after.createdAt).toBe(1_700_000_000_000);
+    expect(after.embedding).not.toBeNull();
+    db.close();
+  });
+});

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -1309,6 +1309,12 @@ try { if (stdinData.trim()) hookContext = JSON.parse(stdinData); } catch (e) {}
 var userPrompt = hookContext.user_prompt || hookContext.prompt || '';
 var env = Object.assign({}, process.env, { CLAUDE_USER_PROMPT: userPrompt });
 
+// #1397 — forward session_id so prompt-reminder can stamp it onto
+// workflow-state.json; \`flo runs start\` has no other source for it.
+if (typeof hookContext.session_id === 'string' && hookContext.session_id) {
+  env.HOOK_SESSION_ID = hookContext.session_id;
+}
+
 // Run prompt-reminder via gate.cjs
 var projectDir = (env.CLAUDE_PROJECT_DIR || process.cwd()).replace(/^\\/([a-z])\\//i, '$1:/');
 var gateScript = resolve(projectDir, '.claude/helpers/gate.cjs');

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -810,8 +810,13 @@ export async function bridgeGetEntry(options: {
     // row and re-caches the full shape. Self-heals on the first read after an
     // in-place upgrade, and since the L1 cache is in-memory only, nothing
     // outlives the process anyway.
+    // `content !== undefined` rather than a truthy test: a row whose content is
+    // legitimately `''` would otherwise fail this check on every read, be
+    // re-fetched from disk, re-cached as `''`, and fail again — a permanent
+    // cache bypass for that key. Pre-existing, but this is the condition it
+    // lives in.
     const usableCache = cached
-      && cached.content
+      && cached.content !== undefined
       && cached.createdAt !== undefined
       && cached.hasEmbedding !== undefined
       && Array.isArray(cached.tags);
@@ -822,6 +827,15 @@ export async function bridgeGetEntry(options: {
       // cache TTL reported the same count forever — and `accessCount` is an
       // orderable field (query-builder's `sortBy('accessCount')`) plus a stats
       // input, so the hottest rows ranked as the coldest.
+      //
+      // ACCEPTED TRADE-OFF: this makes a cache hit perform one indexed write.
+      // The alternative — bump only the cached copy — keeps hits read-only but
+      // leaves the PERSISTED counter undercounting exactly the hot rows, which
+      // is the defect being fixed, since ordering and stats read the column and
+      // not the cache. A hit is still cheaper than the disk read it replaces
+      // (no SELECT, no tag/metadata parse), and the pre-cache code issued this
+      // same UPDATE on every read. Debouncing is the lever if it ever shows up
+      // in a profile.
       //
       // The UPDATE is `access_count + 1` evaluated by SQLite, so the stored
       // counter stays correct under concurrency; only the cached copy can lose

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -33,6 +33,40 @@ function makeEntryCacheKey(namespace: string, key: string): string {
   return `entry:${safeNs}:${safeKey}`;
 }
 
+/**
+ * The canonical shape of an entry-cache value — identical to what
+ * {@link bridgeGetEntry} returns, because a cache hit returns it verbatim.
+ *
+ * #1396: every writer that warms this cache MUST produce the full shape. An
+ * omitted field is not merely absent on read — the cache-hit branch substitutes
+ * a *default that reads as real data*: `tags: []`, `accessCount: 0`, and
+ * timestamps defaulting to "now", i.e. RETRIEVAL time. The store paths warmed
+ * the cache with `{id,key,namespace,content,embedding,metadata}` only, so for
+ * the cache's 5-minute TTL after any write, `memory_retrieve` reported a row
+ * with no tags, a zero access count, and a `storedAt` equal to the moment it
+ * was read. The row on disk was correct throughout — the loss was read-side and
+ * temporary, never a failed write.
+ *
+ * `metadata` was added to the store-path cache value by #1064 for exactly this
+ * reason; the remaining fields were not, which is why metadata survived and
+ * tags did not. `cacheSet` takes this type rather than `any`, so the next field
+ * added to the read shape cannot be half-wired the same way — an incomplete
+ * writer is a compile error rather than a silent read-side fabrication.
+ */
+interface CachedEntry {
+  id: string;
+  key: string;
+  namespace: string;
+  content: string;
+  accessCount: number;
+  /** Epoch ms, as stored on disk — not an ISO string. */
+  createdAt: number | string;
+  updatedAt: number | string;
+  hasEmbedding: boolean;
+  tags: string[];
+  metadata?: string;
+}
+
 /** Normalise `metadata` for the `metadata` TEXT column; `undefined` → `'{}'` (#1064). */
 export function serialiseMetadata(metadata: Record<string, unknown> | string | undefined): string {
   if (metadata == null) return '{}';
@@ -95,7 +129,8 @@ async function cacheGet(registry: any, cacheKey: string): Promise<any | null> {
   return (await cache.get(cacheKey)) ?? null;
 }
 
-async function cacheSet(registry: any, cacheKey: string, value: any): Promise<void> {
+/** Typed on purpose (#1396) — a partial cache value is a compile error, not a silent read-side data loss. */
+async function cacheSet(registry: any, cacheKey: string, value: CachedEntry): Promise<void> {
   const cache = registry.get('tieredCache');
   if (!cache) return;
   await cache.set(cacheKey, value);
@@ -325,9 +360,18 @@ export async function bridgeStoreEntry(options: {
       // Without this, chunk-row producers writing through the chokepoint would
       // get `{}` back from cache and the full metadata from disk — exactly the
       // divergence the cache is supposed to mask.
+      //
+      // #1396 — and the same argument applies to every other column the reader
+      // returns. Warm the FULL CachedEntry shape, not just the embedding and
+      // metadata, or a retrieve inside the cache TTL reports empty tags, a zero
+      // access count, and a storedAt of "now".
       await cacheSet(registry, cacheKey, {
         id, key, namespace, content: value,
-        embedding: embeddingJson,
+        accessCount: 0,
+        createdAt: now,
+        updatedAt: now,
+        hasEmbedding: !!embeddingJson,
+        tags,
         metadata: metadataJson,
       });
     } catch (err) {
@@ -397,7 +441,7 @@ export async function bridgeStoreEntries(items: Array<{
      * the cache would be warm with rows that never reached disk — the
      * exact divergence #982 is fixing in the single-store path. Defer.
      */
-    const deferredBookkeeping: Array<{ cacheKey: string; cacheValue: unknown; entryId: string; entryKey: string; namespace: string; hasEmbedding: boolean }> = [];
+    const deferredBookkeeping: Array<{ cacheKey: string; cacheValue: CachedEntry; entryId: string; entryKey: string; namespace: string; hasEmbedding: boolean }> = [];
     let anyEmbedded = false;
     let anyWritten = false;
 
@@ -469,10 +513,14 @@ export async function bridgeStoreEntries(items: Array<{
 
       deferredBookkeeping.push({
         cacheKey: makeEntryCacheKey(namespace, key),
-        // #1064 — keep cache shape in sync with disk (see single-store path).
+        // #1064 / #1396 — keep cache shape in sync with disk (see single-store path).
         cacheValue: {
           id, key, namespace, content: value,
-          embedding: embeddingJson,
+          accessCount: 0,
+          createdAt: now,
+          updatedAt: now,
+          hasEmbedding: !!embeddingJson,
+          tags,
           metadata: metadataJson,
         },
         entryId: id,
@@ -744,18 +792,8 @@ export async function bridgeGetEntry(options: {
 }): Promise<{
   success: boolean;
   found: boolean;
-  entry?: {
-    id: string;
-    key: string;
-    namespace: string;
-    content: string;
-    accessCount: number;
-    createdAt: string;
-    updatedAt: string;
-    hasEmbedding: boolean;
-    tags: string[];
-    metadata?: string;
-  };
+  /** Exactly the cached shape — a cache hit returns the stored value verbatim (#1396). */
+  entry?: CachedEntry;
   cacheHit?: boolean;
   error?: string;
 } | null> {
@@ -764,24 +802,57 @@ export async function bridgeGetEntry(options: {
 
     const cacheKey = makeEntryCacheKey(namespace, key);
     const cached = await cacheGet(registry, cacheKey);
-    if (cached && cached.content) {
-      return {
-        success: true,
-        found: true,
-        cacheHit: true,
-        entry: {
-          id: String(cached.id || ''),
-          key: cached.key || key,
-          namespace: cached.namespace || namespace,
-          content: cached.content || '',
-          accessCount: cached.accessCount ?? 0,
-          createdAt: cached.createdAt || new Date().toISOString(),
-          updatedAt: cached.updatedAt || new Date().toISOString(),
-          hasEmbedding: !!cached.embedding,
-          tags: cached.tags || [],
-          metadata: cached.metadata || undefined,
-        },
+
+    // A value written by a pre-#1396 build carries only
+    // `{id,key,namespace,content,embedding,metadata}`. Serving it means
+    // fabricating the absent columns — which IS the bug — so treat a partial
+    // value as a miss and fall through to the disk read, which returns the true
+    // row and re-caches the full shape. Self-heals on the first read after an
+    // in-place upgrade, and since the L1 cache is in-memory only, nothing
+    // outlives the process anyway.
+    const usableCache = cached
+      && cached.content
+      && cached.createdAt !== undefined
+      && cached.hasEmbedding !== undefined
+      && Array.isArray(cached.tags);
+
+    if (usableCache) {
+      // #1396 — a cache hit is still an access. The access_count bump used to
+      // live only on the disk path below, so a row read repeatedly inside the
+      // cache TTL reported the same count forever — and `accessCount` is an
+      // orderable field (query-builder's `sortBy('accessCount')`) plus a stats
+      // input, so the hottest rows ranked as the coldest.
+      //
+      // The UPDATE is `access_count + 1` evaluated by SQLite, so the stored
+      // counter stays correct under concurrency; only the cached copy can lose
+      // a racing increment, and the next disk read resyncs it. No persist call
+      // here on purpose — the disk path below has never had one either, because
+      // #1058 removed the read-side `db.export()` writeback that clobbered
+      // concurrent writers. Under node:sqlite the UPDATE is durable regardless.
+      const accessCount = (cached.accessCount ?? 0) + 1;
+      try {
+        ctx.db.prepare(
+          `UPDATE memory_entries SET access_count = access_count + 1, last_accessed_at = ? WHERE id = ?`,
+        ).run([Date.now(), String(cached.id || '')]);
+      } catch {
+        // Non-fatal
+      }
+
+      const entry: CachedEntry = {
+        id: String(cached.id || ''),
+        key: cached.key || key,
+        namespace: cached.namespace || namespace,
+        content: cached.content,
+        accessCount,
+        createdAt: cached.createdAt,
+        updatedAt: cached.updatedAt,
+        hasEmbedding: cached.hasEmbedding,
+        tags: cached.tags,
+        metadata: cached.metadata || undefined,
       };
+      await cacheSet(registry, cacheKey, entry);
+
+      return { success: true, found: true, cacheHit: true, entry };
     }
 
     let row: any;

--- a/src/cli/memory/entries-read.ts
+++ b/src/cli/memory/entries-read.ts
@@ -348,8 +348,15 @@ export async function getEntry(options: {
     namespace: string;
     content: string;
     accessCount: number;
-    createdAt: string;
-    updatedAt: string;
+    /**
+     * Epoch ms, as stored on disk. Declared `string` until #1396 — but every
+     * path that reads `created_at`/`updated_at` off a row returns the INTEGER
+     * column verbatim (the sql.js fallback below merely casts it away), so the
+     * old signature described no real caller. Widened rather than coerced:
+     * `memory_retrieve` has always emitted the number.
+     */
+    createdAt: number | string;
+    updatedAt: number | string;
     hasEmbedding: boolean;
     tags: string[];
     metadata?: string;

--- a/tests/bin/prompt-hook-session-id-1397.test.ts
+++ b/tests/bin/prompt-hook-session-id-1397.test.ts
@@ -1,0 +1,106 @@
+/**
+ * #1397 (Epic #1392) — prompt-hook.mjs must forward Claude Code's session_id.
+ *
+ * `prompt-reminder` stamps `HOOK_SESSION_ID` onto `.claude/workflow-state.json`
+ * (gate.cjs), and `readStampedSessionId()` in `flo runs start` has no other
+ * source for it. But `prompt-reminder` is invoked through prompt-hook.mjs, NOT
+ * gate-hook.mjs — and only gate-hook.mjs forwarded the id. So the stamp never
+ * happened, every `flo runs` record carried `sessionId: null`, and its token
+ * rollup was permanently zero (unrecoverable once Claude Code prunes the
+ * transcript ~2 days later).
+ *
+ * This is the #879-shaped asymmetry — wrapper forwards, direct invocation
+ * doesn't — so the test drives the real script end-to-end rather than asserting
+ * on its source text.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const BIN_HOOK = join(REPO_ROOT, 'bin', 'prompt-hook.mjs');
+const HELPERS_HOOK = join(REPO_ROOT, '.claude', 'helpers', 'prompt-hook.mjs');
+
+/**
+ * Drive prompt-hook.mjs against a throwaway project whose `.claude/helpers/
+ * gate.cjs` is a stub that simply dumps the env vars it received. That isolates
+ * the one behaviour under test — what the wrapper puts in the child env —
+ * without dragging the real gate's state machine in.
+ */
+function runPromptHook(payload: Record<string, unknown>): Record<string, string> {
+  const projectDir = mkdtempSync(join(tmpdir(), 'moflo-1397-'));
+  mkdirSync(join(projectDir, '.claude', 'helpers'), { recursive: true });
+  writeFileSync(
+    join(projectDir, '.claude', 'helpers', 'gate.cjs'),
+    // Report both vars so an absent id is distinguishable from an empty one.
+    'process.stdout.write(JSON.stringify({\n' +
+    '  HOOK_SESSION_ID: process.env.HOOK_SESSION_ID === undefined ? "<unset>" : process.env.HOOK_SESSION_ID,\n' +
+    '  CLAUDE_USER_PROMPT: process.env.CLAUDE_USER_PROMPT === undefined ? "<unset>" : process.env.CLAUDE_USER_PROMPT,\n' +
+    '}));\n',
+  );
+
+  const out = execFileSync(process.execPath, [BIN_HOOK], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+    timeout: 20000,
+  });
+
+  return JSON.parse(out.trim());
+}
+
+describe('#1397 — prompt-hook forwards session_id to gate.cjs', () => {
+  it('sets HOOK_SESSION_ID from the stdin payload', () => {
+    const env = runPromptHook({ session_id: 'sess-abc-123', prompt: 'hello' });
+    expect(env.HOOK_SESSION_ID).toBe('sess-abc-123');
+  });
+
+  it('still forwards the user prompt (no regression to the existing var)', () => {
+    const env = runPromptHook({ session_id: 'sess-abc-123', prompt: 'hello' });
+    expect(env.CLAUDE_USER_PROMPT).toBe('hello');
+  });
+
+  it('leaves HOOK_SESSION_ID unset when the host sends no session_id', () => {
+    // Outside Claude Code this is the correct outcome — `flo runs` records a
+    // null sessionId and a zeroed rollup by design, which must not become an
+    // empty-string id that reads as "stamped".
+    const env = runPromptHook({ prompt: 'hello' });
+    expect(env.HOOK_SESSION_ID).toBe('<unset>');
+  });
+
+  it('leaves HOOK_SESSION_ID unset for a non-string or empty session_id', () => {
+    expect(runPromptHook({ session_id: '', prompt: 'x' }).HOOK_SESSION_ID).toBe('<unset>');
+    expect(runPromptHook({ session_id: 12345, prompt: 'x' }).HOOK_SESSION_ID).toBe('<unset>');
+  });
+});
+
+describe('#1397 — the copy a consumer runs stays in sync', () => {
+  it('bin/prompt-hook.mjs and .claude/helpers/prompt-hook.mjs are byte-identical', () => {
+    // `.claude/helpers/` is what actually executes; bin/ is the sync source
+    // (binHelperFiles in bin/lib/shipped-scripts.json).
+    expect(readFileSync(HELPERS_HOOK, 'utf-8')).toBe(readFileSync(BIN_HOOK, 'utf-8'));
+  });
+
+  it('prompt-hook.mjs is in the shipped manifest, so an upgrade delivers it', () => {
+    // The upgrade path for this fix IS the manifest entry: existing consumers
+    // get the regenerated file from the session-start launcher's version-change
+    // sync, with no `flo init` re-run. Without this entry the fix would reach
+    // fresh installs only.
+    const manifest = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'bin', 'lib', 'shipped-scripts.json'), 'utf-8'),
+    ) as { binHelperFiles: string[] };
+    expect(manifest.binHelperFiles).toContain('prompt-hook.mjs');
+  });
+
+  it('the flo-init generator emits the forwarding too (fresh installs)', async () => {
+    const { generatePromptHookScript } = await import(
+      join(REPO_ROOT, 'dist', 'src', 'cli', 'init', 'helpers-generator.js')
+    );
+    const generated: string = generatePromptHookScript();
+    expect(generated).toContain('HOOK_SESSION_ID');
+    expect(generated).toContain("typeof hookContext.session_id === 'string'");
+  });
+});


### PR DESCRIPTION
Closes #1396. Closes #1397. The last two stories of epic #1392.

## #1396 — `memory_store` appeared to discard `tags`

**Nothing was ever lost.** The `INSERT` always wrote tags correctly. A direct
`node:sqlite` probe of a row that `memory_retrieve` had just reported as `tags: []`
showed `["probe-alpha","probe-beta"]` and the correct `created_at` sitting on disk.

The store paths warmed the entry cache with `{id,key,namespace,content,embedding,metadata}`
only, while `bridgeGetEntry`'s cache-hit branch returns the cached value verbatim and
substitutes defaults for whatever is absent — `tags: []`, `accessCount: 0`, and `new Date()`
for the timestamps. So for the cache's 5-minute TTL after any write, a retrieve reported
plausible-looking **fabricated** values. All three reported symptoms, one cause.

Two corrections to the field report:

- **The re-embed path is innocent.** Both its statements are column-targeted
  (`SET embedding = ?, embedding_dimensions = ?` … `WHERE id = ?`) and cannot reach `tags`.
  Guarded anyway — the suspected failure mode is real and happened in #1067.
- **Why `metadata` survived and tags didn't**: #1064 added `metadata` to that same cache
  write by hand. Patching one field of a shape mismatch is precisely why the rest regressed.

Fixes:

- `CachedEntry` is now the declared parameter type of `cacheSet`, so a partial cache value
  is a **compile error** rather than a silent read-side fabrication.
- Both store paths (single + bulk) warm the full shape.
- A cache hit bumps `access_count` too — it previously only happened on a disk read, so
  repeat reads inside the TTL left the hottest rows ranked coldest (`sortBy('accessCount')`).
- A **pre-fix partial value still in a live cache is treated as a MISS** and falls through to
  disk, so an in-place upgrade self-heals on first read instead of serving invented columns.
- `createdAt`/`updatedAt` declared `number | string`; every path has always returned the
  INTEGER column verbatim, so the old `string` described no real caller.

## #1397 — every `flo runs` record had zero token cost

`prompt-hook.mjs` never forwarded `hookContext.session_id`, so `prompt-reminder` could not
stamp `sessionId` onto `workflow-state.json` and `readStampedSessionId()` had no source.
Only `gate-hook.mjs` forwarded it — the #879-shaped wrapper/direct asymmetry. Fixed in
`bin/`, the synced `.claude/helpers/` copy, and the `flo init` generator.

## Upgrade path

- `prompt-hook.mjs` is in `binHelperFiles`, so existing consumers get it from the
  session-start version-change sync — **no `flo init` re-run**. Asserted by a test, because
  a generator-only fix reaching fresh installs only is the exact defect epic #1392 exists for.
- The #1396 half ships in `dist/` and takes effect on MCP/daemon restart.
- **No data migration** — disk rows were never wrong.

## Verification

- `npm test` — **10,444 passed, 0 failed**, run with every new file **staged**, so the
  tracked-file guards (`client-name-leak-guard` scans `git ls-files`) actually saw them.
  That blind spot produced a false local green on #1400 last session.
- New tests confirmed **load-bearing**: reverted against unfixed code, 9 of 14 failed. The
  cache tests assert `cacheHit === true` so the disk path cannot mask a regression.
- #1397's chain proven end-to-end minus Claude Code itself: ran the real
  `gate.cjs prompt-reminder` with `HOOK_SESSION_ID` set → `workflow-state.json` read back
  `sessionId: "sess-e2e-777"`; with no env → no `sessionId` key, the documented
  outside-Claude-Code behaviour.

## Two things worth a reviewer's eye

**1. Scope call on an AC I wrote.** #1396's AC asked for tags to round-trip through
`memory_search` and `memory_list`. Neither has **ever** included tags in its response
envelope, so nothing there was broken by the bug or changed by the fix. I did not add them:
for `search` that is a per-hit token cost on the hottest path in every consumer, and the
memory protocol keeps that envelope deliberately compact. Flagged rather than silently
expanded or silently dropped — say the word if you want it.

**2. Accepted trade-off.** Two independent reviews flagged that a cache hit now performs one
indexed write. Bumping only the cached copy would keep hits read-only, but would leave the
*persisted* counter undercounting exactly the hot rows — the defect being fixed, since
ordering and stats read the column, not the cache. A hit is still cheaper than the disk read
it replaces, and the pre-cache code issued this same UPDATE on every read. Documented in
place; debouncing is the lever if it ever shows up in a profile.

Third-copy parity (`node_modules/moflo/bin/`) necessarily lags until publish + reinstall.