### PR TITLE
perf(memory): throttle the access_count write on entry-cache hits (#1402)

### DIFF
--- a/src/cli/__tests__/memory/access-count-throttle-1402.test.ts
+++ b/src/cli/__tests__/memory/access-count-throttle-1402.test.ts
@@ -1,0 +1,245 @@
+/**
+ * #1402 — the `access_count` write on an entry-cache hit is throttled per key.
+ *
+ * #1396 made a cache hit bump `access_count`, which is correct: the counter feeds
+ * `sortBy('accessCount')` and stats, so a row read repeatedly inside the cache
+ * TTL must not look untouched. But `bridgeGetEntry` runs inside fan-out loops —
+ * the dashboard's `/api/schedules` and `/api/spells` handlers issue up to 300
+ * `getEntry` calls between them and the browser polls both every 5s, so a
+ * write-per-hit is ~60 writes/sec against the same handful of keys.
+ *
+ * The contract these tests pin down: **defer writes, never lose counts.** The
+ * caller-visible `accessCount` still increments on every single read; the DB
+ * write is coalesced; and once the interval elapses the persisted total reflects
+ * every accumulated hit.
+ *
+ * Time is driven with `vi.setSystemTime`, never a real sleep — a 30s interval
+ * tested by sleeping would be both slow and exactly the flakiness vector
+ * CLAUDE.md's broken-window rule calls out.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  _resetProjectRootForTest,
+  shutdownBridge,
+} from '../../memory/bridge-core.js';
+import { bridgeStoreEntry, bridgeGetEntry } from '../../memory/memory-bridge.js';
+
+/** Must match ACCESS_FLUSH_INTERVAL_MS in bridge-entries.ts. */
+const FLUSH_INTERVAL_MS = 30_000;
+
+describe('access_count write throttle (#1402)', () => {
+  let tempDir: string;
+  let dbPath: string;
+  let originalProjectDir: string | undefined;
+
+  /** Reads the PERSISTED counter, bypassing the bridge cache entirely. */
+  function persistedAccessCount(key: string): number {
+    const probe = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      const row = probe.prepare(
+        'SELECT access_count FROM memory_entries WHERE key = ? AND namespace = ?',
+      ).get(key, 'ns-1402') as { access_count: number } | undefined;
+      return row ? Number(row.access_count) : -1;
+    } finally {
+      probe.close();
+    }
+  }
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), 'moflo-1402-'));
+    fs.mkdirSync(path.join(tempDir, '.moflo'), { recursive: true });
+    dbPath = path.join(tempDir, '.moflo', 'moflo.db');
+
+    originalProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = tempDir;
+    process.env.MOFLO_DISABLE_DAEMON_ROUTING = '1';
+
+    await shutdownBridge();
+    _resetProjectRootForTest();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await shutdownBridge();
+    _resetProjectRootForTest();
+    if (originalProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = originalProjectDir;
+    delete process.env.MOFLO_DISABLE_DAEMON_ROUTING;
+    try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('coalesces a burst of cache hits into a single write, losing no counts', async () => {
+    await bridgeStoreEntry({ key: 'k', value: 'body', namespace: 'ns-1402', tags: ['t'], upsert: true });
+
+    // First read flushes immediately (no prior stamp) and starts the interval.
+    const first = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(first?.cacheHit).toBe(true);
+    const afterFirst = persistedAccessCount('k');
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 1000);
+
+    // Four more hits well inside the interval — none may write.
+    for (let i = 0; i < 4; i++) {
+      const r = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+      expect(r?.cacheHit).toBe(true);
+    }
+    expect(persistedAccessCount('k')).toBe(afterFirst);
+
+    // Cross the interval; the next hit flushes all five deferred accesses
+    // (the four above plus its own) in one write.
+    vi.setSystemTime(Date.now() + FLUSH_INTERVAL_MS + 1);
+    const sixth = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(sixth?.cacheHit).toBe(true);
+
+    expect(persistedAccessCount('k')).toBe(afterFirst + 5);
+  });
+
+  it('increments the returned accessCount on every read regardless of flush timing', async () => {
+    await bridgeStoreEntry({ key: 'k', value: 'body', namespace: 'ns-1402', tags: ['t'], upsert: true });
+
+    const seen: number[] = [];
+    const first = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    seen.push(first!.entry!.accessCount);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 1000);
+    for (let i = 0; i < 4; i++) {
+      const r = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+      seen.push(r!.entry!.accessCount);
+    }
+
+    // Monotonic +1 per read — the #1396 guarantee, unaffected by throttling.
+    expect(seen).toEqual([seen[0], seen[0] + 1, seen[0] + 2, seen[0] + 3, seen[0] + 4]);
+  });
+
+  it('never leaks throttle bookkeeping into the returned entry', async () => {
+    await bridgeStoreEntry({ key: 'k', value: 'body', namespace: 'ns-1402', tags: ['t'], upsert: true });
+
+    const hit = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(hit?.cacheHit).toBe(true);
+    expect(Object.keys(hit!.entry!)).not.toContain('pendingAccessDelta');
+    expect(Object.keys(hit!.entry!)).not.toContain('lastAccessFlushAt');
+
+    // And on the disk path, which caches a separately-built record.
+    await shutdownBridge();
+    _resetProjectRootForTest();
+    const miss = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(miss?.cacheHit).toBe(false);
+    expect(Object.keys(miss!.entry!)).not.toContain('pendingAccessDelta');
+    expect(Object.keys(miss!.entry!)).not.toContain('lastAccessFlushAt');
+  });
+
+  it('does not double-count the access a disk read already wrote', async () => {
+    await bridgeStoreEntry({ key: 'k', value: 'body', namespace: 'ns-1402', tags: ['t'], upsert: true });
+
+    // Drop the cache so the next read takes the disk path, which writes its own +1.
+    await shutdownBridge();
+    _resetProjectRootForTest();
+    const fromDisk = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(fromDisk?.cacheHit).toBe(false);
+    const afterDiskRead = persistedAccessCount('k');
+
+    // A hit immediately after must NOT flush — the disk read just stamped the
+    // interval. Without that stamp the delta would flush at once and the single
+    // disk access would land in the column twice.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 1000);
+    const hit = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(hit?.cacheHit).toBe(true);
+    expect(persistedAccessCount('k')).toBe(afterDiskRead);
+
+    // After the interval it flushes exactly the deferred hits: the one above
+    // plus the one crossing the boundary.
+    vi.setSystemTime(Date.now() + FLUSH_INTERVAL_MS + 1);
+    await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(persistedAccessCount('k')).toBe(afterDiskRead + 2);
+  });
+
+  it('loses no counts when the same key is read concurrently', async () => {
+    // The neighbour fan-out issues parallel getEntry calls and two hits can
+    // share an adjacent chunk key, so same-key concurrency is reachable on
+    // exactly the workload this throttle exists for.
+    //
+    // If the delta were accumulated by rebuilding the cached record and writing
+    // it back, both callers would read the same delta across the await boundary
+    // and the second write would clobber the first — an access dropped
+    // permanently, never reaching the DB. Mutating the shared cached object in
+    // place makes the increment atomic under Node's single thread.
+    await bridgeStoreEntry({ key: 'k', value: 'body', namespace: 'ns-1402', tags: [], upsert: true });
+
+    // Prime the cache and stamp the interval so none of the parallel reads flush.
+    await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    const baseline = persistedAccessCount('k');
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 1000);
+
+    const PARALLEL = 20;
+    const results = await Promise.all(
+      Array.from({ length: PARALLEL }, () => bridgeGetEntry({ key: 'k', namespace: 'ns-1402' })),
+    );
+    expect(results.every(r => r?.cacheHit === true)).toBe(true);
+    expect(persistedAccessCount('k')).toBe(baseline); // still inside the interval
+
+    // Every one of the 20 concurrent accesses must survive to the DB.
+    vi.setSystemTime(Date.now() + FLUSH_INTERVAL_MS + 1);
+    await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(persistedAccessCount('k')).toBe(baseline + PARALLEL + 1);
+  });
+
+  it('upgrade path: a cached record predating the throttle flushes rather than throwing', async () => {
+    // An in-place upgrade cannot strand old-shape records (the L1 cache is
+    // in-memory and the process restarts), but the read must still tolerate a
+    // record with neither bookkeeping field — absent fields mean "never
+    // flushed", which flushes immediately rather than deferring forever.
+    await bridgeStoreEntry({ key: 'k', value: 'body', namespace: 'ns-1402', tags: ['t'], upsert: true });
+    await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    const baseline = persistedAccessCount('k');
+
+    const { getRegistry } = await import('../../memory/bridge-core.js');
+    const registry = await getRegistry();
+    const cache = registry?.get('tieredCache');
+    expect(cache, 'tiered cache must be available for this test to mean anything').toBeTruthy();
+
+    // A complete #1396-era record: full read shape, no throttle fields.
+    // `TieredCacheManager.get` is async but hands back the stored object by
+    // reference, so deleting here strips the live cached record — which is also
+    // what makes the production in-place increment work.
+    const current = await cache.get('entry:ns-1402:k');
+    expect(current, 'cached record must be reachable').toBeTruthy();
+    delete current.pendingAccessDelta;
+    delete current.lastAccessFlushAt;
+
+    const hit = await bridgeGetEntry({ key: 'k', namespace: 'ns-1402' });
+    expect(hit?.cacheHit).toBe(true);
+    expect(hit?.entry?.tags).toEqual(['t']);
+    expect(persistedAccessCount('k')).toBe(baseline + 1);
+  });
+
+  it('throttles each key independently', async () => {
+    await bridgeStoreEntry({ key: 'a', value: 'body a', namespace: 'ns-1402', tags: [], upsert: true });
+    await bridgeStoreEntry({ key: 'b', value: 'body b', namespace: 'ns-1402', tags: [], upsert: true });
+
+    await bridgeGetEntry({ key: 'a', namespace: 'ns-1402' });
+    const aBaseline = persistedAccessCount('a');
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 1000);
+
+    // `a` is inside its interval and must not write; `b` has never flushed, so
+    // its first hit writes immediately. One key's throttle must not gate another.
+    await bridgeGetEntry({ key: 'a', namespace: 'ns-1402' });
+    expect(persistedAccessCount('a')).toBe(aBaseline);
+
+    const bBefore = persistedAccessCount('b');
+    await bridgeGetEntry({ key: 'b', namespace: 'ns-1402' });
+    expect(persistedAccessCount('b')).toBe(bBefore + 1);
+  });
+});

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -887,18 +887,25 @@ export async function bridgeGetEntry(options: {
       // Under node:sqlite the UPDATE is durable regardless.
       const now = Date.now();
 
-      // MUTATE THE CACHED RECORD IN PLACE — do not rebuild it. `cacheGet`
-      // returns the stored object by reference (`TieredCacheManager.get`
-      // returns `node.value.data`, no clone) and both get/set are synchronous,
-      // so two concurrent same-key reads share this object and these two lines
-      // are a read-modify-write with no `await` between read and write — atomic
-      // under Node's single thread. Building a replacement record and writing
-      // it back with `cacheSet` instead would reintroduce a lost update: both
-      // callers would read the same delta across the await boundary and the
-      // second write would clobber the first, permanently dropping an access.
-      // That interleaving is reachable on the very workload this throttle is
-      // for — the neighbor fan-out fetches adjacent chunk keys in parallel and
-      // two hits can share a neighbor.
+      // MUTATE THE CACHED RECORD IN PLACE — do not rebuild it.
+      //
+      // The guarantee this rests on is OBJECT IDENTITY, not synchrony:
+      // `TieredCacheManager.get` is async, but it hands back the stored object
+      // unchanged from `CacheManager.get`, which returns `node.value.data` with
+      // no clone. So every concurrent reader of this key holds the SAME object,
+      // and the two lines below are a read-modify-write with no `await` between
+      // the read and the write — atomic under Node's single thread.
+      //
+      // Building a replacement record and writing it back with `cacheSet`
+      // instead reintroduces a lost update: both callers read the same delta
+      // across the await boundary and the second write clobbers the first,
+      // permanently dropping an access. That interleaving is reachable on the
+      // very workload this throttle is for — the neighbour fan-out fetches
+      // adjacent chunk keys in parallel and two hits can share a neighbour.
+      //
+      // If the cache ever starts cloning on read, the delta stops accumulating
+      // and this silently under-persists. `loses no counts when the same key is
+      // read concurrently` is the test that would catch it.
       cached.accessCount = (cached.accessCount ?? 0) + 1;
       cached.pendingAccessDelta = (cached.pendingAccessDelta ?? 0) + 1;
 

--- a/src/cli/memory/bridge-entries.ts
+++ b/src/cli/memory/bridge-entries.ts
@@ -67,6 +67,51 @@ interface CachedEntry {
   metadata?: string;
 }
 
+/**
+ * What actually goes into the cache: the returned entry plus access-throttle
+ * bookkeeping (#1402).
+ *
+ * These two fields MUST NOT reach a caller. `bridgeGetEntry` builds the returned
+ * `CachedEntry` separately and spreads it into the record, so `memory_retrieve`
+ * and `memory_get_neighbors` never see them.
+ */
+interface CachedEntryRecord extends CachedEntry {
+  /** Cache hits counted for this key since the last `access_count` flush. */
+  pendingAccessDelta?: number;
+  /** Epoch ms of the last `access_count` write for this key. */
+  lastAccessFlushAt?: number;
+}
+
+/**
+ * Minimum gap between `access_count` writes for a single key (#1402).
+ *
+ * #1396 made a cache hit bump `access_count`, which is correct — the counter
+ * feeds `sortBy('accessCount')` and stats, so a row read repeatedly inside the
+ * cache TTL must not look untouched. But `bridgeGetEntry` is called in fan-out
+ * loops, not once per user retrieve: the dashboard's `/api/schedules` and
+ * `/api/spells` handlers issue up to 300 `getEntry` calls between them, and the
+ * browser polls both every 5s — ~60 writes/sec against the same hot keys, where
+ * before the fix it was zero I/O.
+ *
+ * A global debounce timer would need a flush-on-exit hook, and moflo's
+ * short-lived CLI processes would silently drop counts on exit — the same
+ * "observability that quietly lies" failure #1396 existed to remove. Throttling
+ * per key needs no timer and no exit hook: the delta rides on the cached record
+ * itself, which every hit already touches.
+ *
+ * KNOWN RESIDUAL — not lossless, and deliberately so. If the cache evicts a
+ * record (5-minute TTL, or LRU at 10k entries) while its delta is unflushed,
+ * those accesses are gone; likewise a process crash mid-interval. Draining on
+ * eviction would mean issuing async DB work from `CacheManager.evictLRU`, a
+ * synchronous path in a different module — real blast radius on the memory
+ * chokepoint to recover at most one interval's counts for a key that, by virtue
+ * of being evicted, is not in a hot read loop. The keys this throttle exists
+ * for flush every interval, well inside the TTL. `access_count` feeds ordering
+ * and stats, not accounting, so a bounded undercount on cold keys is the right
+ * trade; a systematic undercount of HOT keys — the #1396 defect — is not.
+ */
+const ACCESS_FLUSH_INTERVAL_MS = 30_000;
+
 /** Normalise `metadata` for the `metadata` TEXT column; `undefined` → `'{}'` (#1064). */
 export function serialiseMetadata(metadata: Record<string, unknown> | string | undefined): string {
   if (metadata == null) return '{}';
@@ -130,7 +175,7 @@ async function cacheGet(registry: any, cacheKey: string): Promise<any | null> {
 }
 
 /** Typed on purpose (#1396) — a partial cache value is a compile error, not a silent read-side data loss. */
-async function cacheSet(registry: any, cacheKey: string, value: CachedEntry): Promise<void> {
+async function cacheSet(registry: any, cacheKey: string, value: CachedEntryRecord): Promise<void> {
   const cache = registry.get('tieredCache');
   if (!cache) return;
   await cache.set(cacheKey, value);
@@ -828,43 +873,71 @@ export async function bridgeGetEntry(options: {
       // orderable field (query-builder's `sortBy('accessCount')`) plus a stats
       // input, so the hottest rows ranked as the coldest.
       //
-      // ACCEPTED TRADE-OFF: this makes a cache hit perform one indexed write.
-      // The alternative — bump only the cached copy — keeps hits read-only but
-      // leaves the PERSISTED counter undercounting exactly the hot rows, which
-      // is the defect being fixed, since ordering and stats read the column and
-      // not the cache. A hit is still cheaper than the disk read it replaces
-      // (no SELECT, no tag/metadata parse), and the pre-cache code issued this
-      // same UPDATE on every read. Debouncing is the lever if it ever shows up
-      // in a profile.
+      // #1402 — the write is THROTTLED per key. Every hit still increments the
+      // count the caller sees; the DB write is coalesced to at most one per
+      // ACCESS_FLUSH_INTERVAL_MS, because this function runs inside fan-out
+      // loops (see the constant's docstring) where a write-per-hit is ~60
+      // writes/sec against the same handful of keys.
       //
-      // The UPDATE is `access_count + 1` evaluated by SQLite, so the stored
-      // counter stays correct under concurrency; only the cached copy can lose
-      // a racing increment, and the next disk read resyncs it. No persist call
-      // here on purpose — the disk path below has never had one either, because
-      // #1058 removed the read-side `db.export()` writeback that clobbered
-      // concurrent writers. Under node:sqlite the UPDATE is durable regardless.
-      const accessCount = (cached.accessCount ?? 0) + 1;
-      try {
-        ctx.db.prepare(
-          `UPDATE memory_entries SET access_count = access_count + 1, last_accessed_at = ? WHERE id = ?`,
-        ).run([Date.now(), String(cached.id || '')]);
-      } catch {
-        // Non-fatal
+      // The UPDATE adds the accumulated delta and is evaluated by SQLite, so
+      // the stored counter stays correct under concurrency and never depends on
+      // a client-computed absolute. No persist call here on purpose — the disk
+      // path below has never had one either, because #1058 removed the
+      // read-side `db.export()` writeback that clobbered concurrent writers.
+      // Under node:sqlite the UPDATE is durable regardless.
+      const now = Date.now();
+
+      // MUTATE THE CACHED RECORD IN PLACE — do not rebuild it. `cacheGet`
+      // returns the stored object by reference (`TieredCacheManager.get`
+      // returns `node.value.data`, no clone) and both get/set are synchronous,
+      // so two concurrent same-key reads share this object and these two lines
+      // are a read-modify-write with no `await` between read and write — atomic
+      // under Node's single thread. Building a replacement record and writing
+      // it back with `cacheSet` instead would reintroduce a lost update: both
+      // callers would read the same delta across the await boundary and the
+      // second write would clobber the first, permanently dropping an access.
+      // That interleaving is reachable on the very workload this throttle is
+      // for — the neighbor fan-out fetches adjacent chunk keys in parallel and
+      // two hits can share a neighbor.
+      cached.accessCount = (cached.accessCount ?? 0) + 1;
+      cached.pendingAccessDelta = (cached.pendingAccessDelta ?? 0) + 1;
+
+      // A record with no flush stamp (pre-#1402 shape, or one this process has
+      // never flushed) flushes immediately rather than waiting out the interval.
+      const lastFlushAt = cached.lastAccessFlushAt ?? 0;
+      if (now - lastFlushAt >= ACCESS_FLUSH_INTERVAL_MS) {
+        try {
+          ctx.db.prepare(
+            `UPDATE memory_entries SET access_count = access_count + ?, last_accessed_at = ? WHERE id = ?`,
+          ).run([cached.pendingAccessDelta, now, String(cached.id || '')]);
+          // Clear ONLY after the write lands. Clearing on a throw would discard
+          // the accumulated hits outright — the throttle defers writes, it does
+          // not drop them.
+          cached.pendingAccessDelta = 0;
+          cached.lastAccessFlushAt = now;
+        } catch {
+          // Non-fatal — the delta rides along to the next attempt.
+        }
       }
 
+      // Built field-by-field from the cached record rather than spread from it,
+      // so the throttle bookkeeping can never surface in an MCP response.
       const entry: CachedEntry = {
         id: String(cached.id || ''),
         key: cached.key || key,
         namespace: cached.namespace || namespace,
         content: cached.content,
-        accessCount,
+        accessCount: cached.accessCount,
         createdAt: cached.createdAt,
         updatedAt: cached.updatedAt,
         hasEmbedding: cached.hasEmbedding,
         tags: cached.tags,
         metadata: cached.metadata || undefined,
       };
-      await cacheSet(registry, cacheKey, entry);
+
+      // No `cacheSet` here: the record above IS the cached object and was
+      // updated in place, so writing a copy back would be redundant work on the
+      // hot path — and would reopen the lost-update window this branch closes.
 
       return { success: true, found: true, cacheHit: true, entry };
     }
@@ -891,10 +964,15 @@ export async function bridgeGetEntry(options: {
 
     if (!row) return { success: true, found: false };
 
+    // The disk path writes its own +1 immediately (it is by definition not a
+    // repeat read), so it doubles as this key's flush point: stamp `now` below
+    // and start the delta at 0 so the next cache hit begins a fresh interval
+    // rather than re-counting this access (#1402).
+    const diskReadAt = Date.now();
     try {
       ctx.db.prepare(
         `UPDATE memory_entries SET access_count = access_count + 1, last_accessed_at = ? WHERE id = ?`,
-      ).run([Date.now(), row.id]);
+      ).run([diskReadAt, row.id]);
     } catch {
       // Non-fatal
     }
@@ -917,7 +995,11 @@ export async function bridgeGetEntry(options: {
       metadata: row.metadata != null ? String(row.metadata) : undefined,
     };
 
-    await cacheSet(registry, cacheKey, entry);
+    await cacheSet(registry, cacheKey, {
+      ...entry,
+      pendingAccessDelta: 0,
+      lastAccessFlushAt: diskReadAt,
+    });
 
     return { success: true, found: true, cacheHit: false, entry };
   });


### PR DESCRIPTION
Closes #1402. Follow-up to #1396 (PR #1401), raised by two independent reviews there.

## Problem

#1396 made an entry-cache **hit** bump `access_count` — correct, since the counter feeds
`sortBy('accessCount')` and stats, so a row read repeatedly inside the cache TTL must not
look untouched. But it assumed `bridgeGetEntry` is called about once per retrieve. It is not:

| Call site | Fan-out |
|---|---|
| `/api/schedules` -> `handleSchedules` | up to 100 `getEntry` |
| `/api/spells` -> `handleSpells` | **two** wildcard searches, up to 200 |
| `memory_search` + `expand: "neighbors"` | up to 2 x limit = 16, on the hottest path |

The dashboard polls both endpoints unconditionally every 5s (`setInterval(poll, 5000)`), so
hot keys took **~60 writes/sec** where the cache previously did zero I/O.

## Fix — per-key throttle

Every hit still increments the caller-visible `accessCount`. The DB write is coalesced to at
most one per 30s per key, issuing `SET access_count = access_count + <delta>` so SQLite
evaluates the arithmetic and the persisted counter is never a client-computed absolute.

Chosen over a **global debounce timer**, which would need a flush-on-exit hook that moflo's
short-lived CLI processes would silently drop counts through — the same "observability that
quietly lies" failure #1396 existed to remove.

## The review catch worth reading

My first implementation accumulated the delta by rebuilding the cached record and writing it
back with `cacheSet`. Review found a **genuine lost-update race**: two concurrent same-key
reads both read the delta across the `await` boundary, and the second write clobbers the
first — an access dropped permanently, never reaching the DB. That interleaving is reachable
on this exact workload, since the neighbour fan-out fetches adjacent chunk keys in parallel
and two hits can share a neighbour.

Fixed by **mutating the cached record in place**, making the increment a read-modify-write
with no `await` between read and write — atomic under Node's single thread. The guarantee is
**object identity**: the tiered cache hands back the stored object with no clone. I verified
that empirically rather than assuming it — and a later self-review caught that my own comment
had asserted the wrong reason for it (claimed get/set were synchronous; `TieredCacheManager.get`
is in fact async). Corrected, because wrong reasoning about a concurrency invariant misleads
the next reader more than no comment would. The comment now also names the test that fails if
the cache ever starts cloning on read.

## Known residual — documented, not hidden

Cache eviction (5-min TTL / 10k LRU) or a crash mid-interval loses that key's unflushed delta.
Draining on eviction means async DB work inside a synchronous `CacheManager.evictLRU` in
another module — real blast radius on the memory chokepoint to recover at most one interval's
counts for a key that, by virtue of being evicted, is not in a hot read loop.

## Rule #1 (cross-platform)

Pure TypeScript. No `process.platform` branch, hardcoded path, separator literal, or
shell-out. Tests drive time with `vi.setSystemTime` rather than sleeping out a 30s interval —
a real sleep would be both slow and exactly the flakiness vector the broken-window rule calls
out.

## Upgrade path

Ships in `dist/`; there is **no** `bin/` or `.claude/` copy of this file, so no sync or
three-copy parity concern. No generator, no settings, no state migration, no schema change
(`access_count` / `last_accessed_at` are pre-existing columns).

The one "new code reads state the old version never wrote" question is the throttle fields.
They live only in the **in-memory** L1 cache, which has no disk tier and does not survive the
restart an upgrade requires — and a record lacking them is treated as "never flushed", so it
flushes immediately rather than deferring forever. Covered by a dedicated test that strips
both fields off a live cached record.

Because this runs from `node_modules/moflo/dist/`, it takes effect for the MCP server and
daemon only after publish + reinstall + restart. No window leaves a consumer worse off: the
old code keeps its write-per-hit behaviour until the restart, and both versions' writes are
additive.

## Verification

- `npm test` — **10,451 passed, 0 failed**, with new files staged so the tracked-file guards scanned them.
- Tests confirmed **load-bearing**: reverted and rebuilt, 3 of the 5 original tests failed —
  exactly the coalescing assertions. The 2 that passed either way are the #1396 regression
  guards (monotonic `accessCount`, no bookkeeping leak), which is the correct outcome.
- Counter assertions read through a **separate read-only sqlite connection**, bypassing the
  bridge cache, so a test cannot confirm the cache to itself.