### PR TITLE
fix(retired-files): stop retiring agents the package still ships (#1414)

### DIFF
--- a/.claude/guidance/internal/retirement-workflow.md
+++ b/.claude/guidance/internal/retirement-workflow.md
@@ -106,6 +106,8 @@ flo retire --rebuild-hashes
 
 Walks each existing entry's path, re-derives `knownContentHashes[]` from every reachable commit, and unions with the prior list. Idempotent — re-runs produce no diff once the manifest is saturated. Commit the regenerated file.
 
+This is also the heal command for a still-shipped entry: it drops every entry whose path is back in the tree and names each one on stdout. Never hand-edit the manifest to remove them.
+
 ---
 
 ## What NOT To Do
@@ -113,7 +115,33 @@ Walks each existing entry's path, re-derives `knownContentHashes[]` from every r
 - **Don't delete `retired-files.json` entries** to "clean up" old retirements. Consumers may still be on a moflo version old enough to have those files; pruning them from the manifest reverts the cleanup. Entries can be expired only after we're confident no consumer is on an affected version (~12 months minimum).
 - **Don't hand-edit `knownContentHashes[]`** unless you're fixing a verified mistake. The hashes come from git's authoritative content; rewriting them by hand is how silent-prune-of-customized-file regressions happen.
 - **Don't run `flo retire` from outside moflo's source repo.** It will refuse. The `retired-files.json` lives at the moflo package root and doesn't ship to consumer `node_modules/` for editing.
-- **Don't add a `retired-files.json` entry for a deleted file that is later restored.** Either remove the entry in the same PR that restores the file, or leave both — but never ship a manifest entry for a path that exists in `node_modules/moflo/`. The entry would be a no-op for unmodified consumers (file matches a hash, gets pruned, then restored on next sync) and a destructive flap for customized consumers (prune notice, restore, prune notice every upgrade).
+- **Don't add a `retired-files.json` entry for a deleted file that is later restored.** Never ship a manifest entry for a path that exists in `node_modules/moflo/` — see *Never Retire a Path the Package Still Ships* below.
+
+---
+
+## Never Retire a Path the Package Still Ships
+
+A retired path can come back — someone restores the file under the same name in a later PR. Withdraw the manifest entry in that same PR.
+
+The stale entry's `knownContentHashes` hold only pre-deletion content, while the file on the consumer's disk is the current shipped content that Mechanism A just wrote. Nothing matches, so `classifyRetiredFile` returns `preserve` and the launcher prints on every session start:
+
+```
+moflo: retained 10 customized retired files (delete manually if unwanted)
+```
+
+Both halves are false — the files were never customized and are not retired — and the notice invites deleting agent definitions that `agent-router`, `swarm`, and `.claude/skills/flo-simplify/SKILL.md` resolve by name. Ten shipped core agents sat in this state from the alpha era until #1414.
+
+The other branch is worse. When a recorded hash *does* match the restored content, the launcher prunes the file, Mechanism A syncs it back from the package next session, and the prune fires again — a delete-restore flap on every upgrade, forever.
+
+Three layers now enforce it, so a violation cannot survive to a consumer:
+
+| Layer | Where | Behaviour |
+|---|---|---|
+| Author | `scripts/build-retired-files.mjs` | `--seed` skips a resurrected path; `--rebuild-hashes` drops one and names it; `--add` warns that the deletion must land in this PR |
+| Build | `tests/guards/retired-manifest-shipped-path-guard.test.ts` | Fails when any entry names a path in the tracked tree. No exemption list — a path in the tree is a path that ships |
+| Run | `bin/lib/retired-files.mjs` | `classifyRetiredFile` returns `shipped` when the installed package still has the path, so a contradictory entry is skipped rather than pruned or reported |
+
+Ask the package what it ships, never the manifest — the package cannot drift from the truth. The run-time check is deliberately one-directional: it can only turn a delete into a skip.
 
 ---
 
@@ -121,7 +149,8 @@ Walks each existing entry's path, re-derives `knownContentHashes[]` from every r
 
 - `bin/session-start-launcher.mjs` — section 3 manifest sync (Mechanism A) + retired-files prune block (Mechanism B)
 - `bin/lib/retired-files.mjs` — `loadRetiredManifest`, `classifyRetiredFile`, `applyRetiredPrune`
-- `scripts/build-retired-files.mjs` — `--seed` (bulk), `--add` (single-path), `--rebuild-hashes` (full-history backfill)
+- `scripts/build-retired-files.mjs` — `--seed` (bulk), `--add` (single-path), `--rebuild-hashes` (full-history backfill + still-shipped heal)
+- `tests/guards/retired-manifest-shipped-path-guard.test.ts` — build-time guard for the still-shipped rule
 - `src/cli/commands/retire.ts` — `flo retire <path>` and `flo retire --rebuild-hashes` thin wrappers that call the build script
 - `tests/bin/launcher-948-retired-prune.test.ts` — unit tests for the prune helper
 - `tests/scripts/build-retired-files.test.ts` — unit tests for `hashesForPath` + rebuild invariants (#1133)

--- a/.claude/scripts/lib/retired-files.mjs
+++ b/.claude/scripts/lib/retired-files.mjs
@@ -123,6 +123,8 @@ export function loadRetiredManifest(manifestPath) {
 /**
  * Decide what to do with a consumer-side path against a retirement entry:
  *
+ *   - 'shipped'    — the installed package STILL ships this path, so the
+ *                    manifest entry contradicts the package; skip it entirely
  *   - 'absent'     — path doesn't exist on disk; nothing to do
  *   - 'prune'      — file exists and content hash matches a known-shipped
  *                    value; safe to delete (consumer didn't customize)
@@ -131,13 +133,34 @@ export function loadRetiredManifest(manifestPath) {
  *   - 'unknown'    — file exists but its hash couldn't be read (transient
  *                    error); leave alone, retry next session
  *
+ * The `shipped` check exists because a path can be retired and later RESTORED
+ * under the same name (#1414). The stale entry then holds only pre-deletion
+ * hashes, so the consumer's copy — which moflo itself just synced from the
+ * package — matches nothing and is reported as a customized retired file every
+ * session. Asking the package what it ships is the only source that cannot
+ * drift from the manifest, so it wins.
+ *
+ * `packageRoot` is optional and defaults to no cross-check: callers that don't
+ * know where the package lives keep exactly the pre-#1414 semantics.
+ *
+ * Order matters. The consumer-path check runs FIRST because most entries are
+ * `absent` on a typical install (already pruned, or never had the file), and
+ * those need no package stat at all — this runs on every consumer's session
+ * start, where a doubled stat count is 10-40ms on Windows with a scanner or a
+ * network `node_modules`. Entries that are absent locally are also exactly the
+ * ones a contradiction cannot hurt: there is nothing to delete or report.
+ *
  * @param {string} projectRoot
  * @param {{path:string, knownContentHashes:string[]}} entry
- * @returns {{ action: 'absent'|'prune'|'preserve'|'unknown', actualHash: string|null }}
+ * @param {string|null} [packageRoot] - root of the installed moflo package
+ * @returns {{ action: 'shipped'|'absent'|'prune'|'preserve'|'unknown', actualHash: string|null }}
  */
-export function classifyRetiredFile(projectRoot, entry) {
+export function classifyRetiredFile(projectRoot, entry, packageRoot = null) {
   const abs = resolve(projectRoot, entry.path);
   if (!existsSync(abs)) return { action: 'absent', actualHash: null };
+  if (packageRoot && existsSync(resolve(packageRoot, entry.path))) {
+    return { action: 'shipped', actualHash: null };
+  }
   const actualHash = fileSha256(abs);
   if (!actualHash) return { action: 'unknown', actualHash: null };
   if (entry.knownContentHashes.includes(actualHash)) {
@@ -167,15 +190,24 @@ export function classifyRetiredFile(projectRoot, entry) {
  * `preservedDetails` carries the same set with the manifest's retirement
  * provenance attached, for the machine-readable record (#1307 finding 3).
  *
+ * `shipped` collects entries the installed package still ships (#1414). They
+ * are neither pruned nor preserved — the manifest is simply wrong about them,
+ * and reporting them as retained is what produced the false banner. Nothing
+ * reads it today; it is here so the return value is a complete accounting of
+ * every entry's disposition rather than silently dropping one class, and so
+ * tests can assert the skip happened instead of inferring it from an absence.
+ *
  * @param {string} projectRoot
  * @param {string} manifestPath
- * @returns {{ pruned: string[], preserved: string[], preservedDetails: Array<{path:string, retiredIn?:string, retiredBy?:string}>, unknown: string[], failed: Array<{path:string, message:string}> }}
+ * @param {string|null} [packageRoot] - root of the installed moflo package
+ * @returns {{ pruned: string[], preserved: string[], preservedDetails: Array<{path:string, retiredIn?:string, retiredBy?:string}>, shipped: string[], unknown: string[], failed: Array<{path:string, message:string}> }}
  */
-export function applyRetiredPrune(projectRoot, manifestPath) {
+export function applyRetiredPrune(projectRoot, manifestPath, packageRoot = null) {
   const { entries } = loadRetiredManifest(manifestPath);
-  const report = { pruned: [], preserved: [], preservedDetails: [], unknown: [], failed: [] };
+  const report = { pruned: [], preserved: [], preservedDetails: [], shipped: [], unknown: [], failed: [] };
   for (const entry of entries) {
-    const { action } = classifyRetiredFile(projectRoot, entry);
+    const { action } = classifyRetiredFile(projectRoot, entry, packageRoot);
+    if (action === 'shipped') { report.shipped.push(entry.path); continue; }
     if (action === 'absent') continue;
     if (action === 'preserve') {
       report.preserved.push(entry.path);

--- a/.claude/scripts/session-start-launcher.mjs
+++ b/.claude/scripts/session-start-launcher.mjs
@@ -1334,13 +1334,18 @@ try {
       // prune when the consumer's file matches a known-shipped hash —
       // customized files (different hash) get preserved with a one-line
       // notice the user can act on.
+      //
+      // The package root is passed so entries can be cross-checked against
+      // what moflo actually ships (#1414). A path can be retired and later
+      // RESTORED under the same name; the stale entry then carries only
+      // pre-deletion hashes, so the copy Mechanism A just synced matches
+      // nothing and gets reported as a "customized retired file" on every
+      // session — inviting the user to delete an agent the CLI still routes to.
       let prunedRetiredPaths = new Set();
       try {
-        const retiredManifestPath = resolve(
-          projectRoot,
-          'node_modules/moflo/retired-files.json',
-        );
-        const report = applyRetiredPrune(projectRoot, retiredManifestPath);
+        const mofloPackageRoot = resolve(projectRoot, 'node_modules', 'moflo');
+        const retiredManifestPath = resolve(mofloPackageRoot, 'retired-files.json');
+        const report = applyRetiredPrune(projectRoot, retiredManifestPath, mofloPackageRoot);
         prunedRetiredPaths = new Set(report.pruned);
         if (report.pruned.length > 0) {
           emitMutation(
@@ -1365,7 +1370,7 @@ try {
         if (report.preservedDetails.length > 0) {
           try {
             recordVersion = JSON.parse(readFileSync(
-              resolve(projectRoot, 'node_modules/moflo/package.json'), 'utf-8',
+              resolve(mofloPackageRoot, 'package.json'), 'utf-8',
             )).version;
           } catch { /* record just omits the version */ }
         }

--- a/bin/lib/retired-files.mjs
+++ b/bin/lib/retired-files.mjs
@@ -123,6 +123,8 @@ export function loadRetiredManifest(manifestPath) {
 /**
  * Decide what to do with a consumer-side path against a retirement entry:
  *
+ *   - 'shipped'    — the installed package STILL ships this path, so the
+ *                    manifest entry contradicts the package; skip it entirely
  *   - 'absent'     — path doesn't exist on disk; nothing to do
  *   - 'prune'      — file exists and content hash matches a known-shipped
  *                    value; safe to delete (consumer didn't customize)
@@ -131,13 +133,34 @@ export function loadRetiredManifest(manifestPath) {
  *   - 'unknown'    — file exists but its hash couldn't be read (transient
  *                    error); leave alone, retry next session
  *
+ * The `shipped` check exists because a path can be retired and later RESTORED
+ * under the same name (#1414). The stale entry then holds only pre-deletion
+ * hashes, so the consumer's copy — which moflo itself just synced from the
+ * package — matches nothing and is reported as a customized retired file every
+ * session. Asking the package what it ships is the only source that cannot
+ * drift from the manifest, so it wins.
+ *
+ * `packageRoot` is optional and defaults to no cross-check: callers that don't
+ * know where the package lives keep exactly the pre-#1414 semantics.
+ *
+ * Order matters. The consumer-path check runs FIRST because most entries are
+ * `absent` on a typical install (already pruned, or never had the file), and
+ * those need no package stat at all — this runs on every consumer's session
+ * start, where a doubled stat count is 10-40ms on Windows with a scanner or a
+ * network `node_modules`. Entries that are absent locally are also exactly the
+ * ones a contradiction cannot hurt: there is nothing to delete or report.
+ *
  * @param {string} projectRoot
  * @param {{path:string, knownContentHashes:string[]}} entry
- * @returns {{ action: 'absent'|'prune'|'preserve'|'unknown', actualHash: string|null }}
+ * @param {string|null} [packageRoot] - root of the installed moflo package
+ * @returns {{ action: 'shipped'|'absent'|'prune'|'preserve'|'unknown', actualHash: string|null }}
  */
-export function classifyRetiredFile(projectRoot, entry) {
+export function classifyRetiredFile(projectRoot, entry, packageRoot = null) {
   const abs = resolve(projectRoot, entry.path);
   if (!existsSync(abs)) return { action: 'absent', actualHash: null };
+  if (packageRoot && existsSync(resolve(packageRoot, entry.path))) {
+    return { action: 'shipped', actualHash: null };
+  }
   const actualHash = fileSha256(abs);
   if (!actualHash) return { action: 'unknown', actualHash: null };
   if (entry.knownContentHashes.includes(actualHash)) {
@@ -167,15 +190,24 @@ export function classifyRetiredFile(projectRoot, entry) {
  * `preservedDetails` carries the same set with the manifest's retirement
  * provenance attached, for the machine-readable record (#1307 finding 3).
  *
+ * `shipped` collects entries the installed package still ships (#1414). They
+ * are neither pruned nor preserved — the manifest is simply wrong about them,
+ * and reporting them as retained is what produced the false banner. Nothing
+ * reads it today; it is here so the return value is a complete accounting of
+ * every entry's disposition rather than silently dropping one class, and so
+ * tests can assert the skip happened instead of inferring it from an absence.
+ *
  * @param {string} projectRoot
  * @param {string} manifestPath
- * @returns {{ pruned: string[], preserved: string[], preservedDetails: Array<{path:string, retiredIn?:string, retiredBy?:string}>, unknown: string[], failed: Array<{path:string, message:string}> }}
+ * @param {string|null} [packageRoot] - root of the installed moflo package
+ * @returns {{ pruned: string[], preserved: string[], preservedDetails: Array<{path:string, retiredIn?:string, retiredBy?:string}>, shipped: string[], unknown: string[], failed: Array<{path:string, message:string}> }}
  */
-export function applyRetiredPrune(projectRoot, manifestPath) {
+export function applyRetiredPrune(projectRoot, manifestPath, packageRoot = null) {
   const { entries } = loadRetiredManifest(manifestPath);
-  const report = { pruned: [], preserved: [], preservedDetails: [], unknown: [], failed: [] };
+  const report = { pruned: [], preserved: [], preservedDetails: [], shipped: [], unknown: [], failed: [] };
   for (const entry of entries) {
-    const { action } = classifyRetiredFile(projectRoot, entry);
+    const { action } = classifyRetiredFile(projectRoot, entry, packageRoot);
+    if (action === 'shipped') { report.shipped.push(entry.path); continue; }
     if (action === 'absent') continue;
     if (action === 'preserve') {
       report.preserved.push(entry.path);

--- a/bin/session-start-launcher.mjs
+++ b/bin/session-start-launcher.mjs
@@ -1334,13 +1334,18 @@ try {
       // prune when the consumer's file matches a known-shipped hash —
       // customized files (different hash) get preserved with a one-line
       // notice the user can act on.
+      //
+      // The package root is passed so entries can be cross-checked against
+      // what moflo actually ships (#1414). A path can be retired and later
+      // RESTORED under the same name; the stale entry then carries only
+      // pre-deletion hashes, so the copy Mechanism A just synced matches
+      // nothing and gets reported as a "customized retired file" on every
+      // session — inviting the user to delete an agent the CLI still routes to.
       let prunedRetiredPaths = new Set();
       try {
-        const retiredManifestPath = resolve(
-          projectRoot,
-          'node_modules/moflo/retired-files.json',
-        );
-        const report = applyRetiredPrune(projectRoot, retiredManifestPath);
+        const mofloPackageRoot = resolve(projectRoot, 'node_modules', 'moflo');
+        const retiredManifestPath = resolve(mofloPackageRoot, 'retired-files.json');
+        const report = applyRetiredPrune(projectRoot, retiredManifestPath, mofloPackageRoot);
         prunedRetiredPaths = new Set(report.pruned);
         if (report.pruned.length > 0) {
           emitMutation(
@@ -1365,7 +1370,7 @@ try {
         if (report.preservedDetails.length > 0) {
           try {
             recordVersion = JSON.parse(readFileSync(
-              resolve(projectRoot, 'node_modules/moflo/package.json'), 'utf-8',
+              resolve(mofloPackageRoot, 'package.json'), 'utf-8',
             )).version;
           } catch { /* record just omits the version */ }
         }

--- a/retired-files.json
+++ b/retired-files.json
@@ -2,34 +2,12 @@
   "version": 1,
   "retired": [
     {
-      "path": ".claude/agents/analysis/code-analyzer.md",
-      "knownContentHashes": [
-        "sha256:259bd298e1f6cf297ab5354e4701bec9cf0020bc22a66bba96c09cc580af47f0"
-      ],
-      "retiredIn": "2.0.0-alpha.121"
-    },
-    {
       "path": ".claude/agents/analysis/code-review/analyze-code-quality.md",
       "knownContentHashes": [
         "sha256:468851022f67047982c5abb8a2a74a5fb0fe330fe0821f7c91c859697d72162e",
         "sha256:b865110a1694598fcfa9c1eb319014eb87461df35aaaaa6c820a41a5535346ad"
       ],
       "retiredIn": "4.8.12"
-    },
-    {
-      "path": ".claude/agents/architecture/system-design/arch-system-design.md",
-      "knownContentHashes": [
-        "sha256:7330ff870b23d2d6c05a415fdd9cc7ee6ff49a2cc48a33eb1962b830106abf3b"
-      ],
-      "retiredIn": "3.0.0-alpha.1"
-    },
-    {
-      "path": ".claude/agents/base-template-generator.md",
-      "knownContentHashes": [
-        "sha256:1bea126c6853067e650e432b1e5cedf588f3161c4995eb1e2e97d04733e24d83",
-        "sha256:4b957343021823020828d6d213126243bad177f29984fc09545814b88fcfa87a"
-      ],
-      "retiredIn": "2.0.0-alpha.121"
     },
     {
       "path": ".claude/agents/consensus/byzantine-coordinator.md",
@@ -97,41 +75,6 @@
       "retiredBy": "#932"
     },
     {
-      "path": ".claude/agents/core/coder.md",
-      "knownContentHashes": [
-        "sha256:fd11f4cf99f74e7db021947e0ecc10f8fd3e5afb357433bcf68058905abf0116"
-      ],
-      "retiredIn": "2.0.0-alpha.121"
-    },
-    {
-      "path": ".claude/agents/core/planner.md",
-      "knownContentHashes": [
-        "sha256:1ea85a5cf770f62e7e40e612be9fc5d779dd265f77fa942ee6f8d1c3950127c3"
-      ],
-      "retiredIn": "2.0.0-alpha.121"
-    },
-    {
-      "path": ".claude/agents/core/researcher.md",
-      "knownContentHashes": [
-        "sha256:e486075522aef212f49ab79659130521fe362779daf0919fac17f2d1f16576a6"
-      ],
-      "retiredIn": "2.0.0-alpha.121"
-    },
-    {
-      "path": ".claude/agents/core/reviewer.md",
-      "knownContentHashes": [
-        "sha256:664518900259644124b28d4b0e92be3ca139fa391920fc0e97b309649bc093fd"
-      ],
-      "retiredIn": "2.0.0-alpha.121"
-    },
-    {
-      "path": ".claude/agents/core/tester.md",
-      "knownContentHashes": [
-        "sha256:26f05967316ebbda9b96b7262fe80500d158fcd2f75f1adba1d28c99d882f6e7"
-      ],
-      "retiredIn": "2.0.0-alpha.121"
-    },
-    {
       "path": ".claude/agents/data/ml/data-ml-model.md",
       "knownContentHashes": [
         "sha256:dfcd3745237c80daa26a9f819cc58f2396e3863c1add36da727e1a526097b014",
@@ -149,21 +92,6 @@
         "sha256:c636bb38b48e714c12d00c7869b11ce8e39a21db8e1aa451c2f5013638fdedab"
       ],
       "retiredIn": "4.8.12"
-    },
-    {
-      "path": ".claude/agents/devops/ci-cd/ops-cicd-github.md",
-      "knownContentHashes": [
-        "sha256:daa1ca3b2e116167dd4d057b64d96bd40c00bfd1d6a3ad3c607dd9129db7a032"
-      ],
-      "retiredIn": "3.0.0-alpha.1"
-    },
-    {
-      "path": ".claude/agents/documentation/api-docs/docs-api-openapi.md",
-      "knownContentHashes": [
-        "sha256:0a24f98cd97229b746a2f89f2cdfe09fac0ee8dcd757073017fee91e951b7f7f",
-        "sha256:0cec8892de681a157cb3d56af8e336020dae58ec4a51c0e1dcaf6cfd90c61cd7"
-      ],
-      "retiredIn": "3.0.0-alpha.1"
     },
     {
       "path": ".claude/agents/dual-mode/codex-coordinator.md",

--- a/scripts/build-retired-files.mjs
+++ b/scripts/build-retired-files.mjs
@@ -18,7 +18,14 @@
  *   --rebuild-hashes
  *     Re-derive `knownContentHashes[]` for every existing entry from full
  *     git history. Used to backfill entries written under the legacy 3-hash
- *     cap that left pre-cutoff consumer installs un-prunable (#1133).
+ *     cap that left pre-cutoff consumer installs un-prunable (#1133), and to
+ *     drop entries whose path has since been restored to the tree (#1414).
+ *
+ * Every mode upholds one invariant: an entry may never name a path moflo still
+ * ships. Such an entry can only resolve to "customized, retained" on every
+ * consumer forever, because its hashes predate the content the package now
+ * installs. `tests/guards/retired-manifest-shipped-path-guard.test.ts` enforces
+ * it at build time; `bin/lib/retired-files.mjs` skips violators at run time.
  *
  * The `version: 1` schema lives at the moflo package root and ships to
  * consumers via package.json `files`. Launcher reads it on every upgrade
@@ -65,6 +72,52 @@ function sha256(buf) {
  */
 function unionHashes(a, b) {
   return Array.from(new Set([...a, ...b]));
+}
+
+/**
+ * Paths git tracks, `/`-separated exactly as git reports them. Computed once —
+ * every caller below asks the same question of the same tree.
+ *
+ * `-z` because git quote-escapes non-ASCII paths under the default
+ * `core.quotePath`, and a mangled entry would silently read as "not tracked".
+ */
+let trackedPathsCache = null;
+function trackedPaths() {
+  if (trackedPathsCache) return trackedPathsCache;
+  const NUL = String.fromCharCode(0);
+  trackedPathsCache = new Set(gitOk(['ls-files', '-z']).split(NUL).filter(Boolean));
+  return trackedPathsCache;
+}
+
+/**
+ * True when moflo ships `path` again under the same name — deleted at some
+ * point, but back in the tree. See the module header for why such an entry can
+ * never be correct.
+ *
+ * Gate on the TRACKED tree, not `existsSync`. Dropping an entry is destructive
+ * and irreversible, and an untracked stray under `.claude/agents/` — precisely
+ * what Mechanism A leaves behind when dogfooding — would otherwise make
+ * `--rebuild-hashes` delete a legitimate retirement. Tracked is also what the
+ * npm tarball ships and what `tests/guards/retired-manifest-shipped-path-guard.test.ts`
+ * asserts, so the author-time and build-time predicates cannot disagree.
+ */
+function isResurrected(path) {
+  return trackedPaths().has(path.replace(/\\/g, '/'));
+}
+
+/**
+ * Remove every entry whose path is back in the tree, returning the dropped
+ * paths. Shared by `--seed` and `--rebuild-hashes` so neither can leave a
+ * contradiction the other would have cleaned.
+ */
+function dropResurrected(manifest) {
+  const dropped = [];
+  manifest.retired = manifest.retired.filter((entry) => {
+    if (!isResurrected(entry.path)) return true;
+    dropped.push(entry.path);
+    return false;
+  });
+  return dropped;
 }
 
 /**
@@ -173,14 +226,25 @@ function findRetirementPrFromCommitMessage(commit) {
 
 function seed() {
   const manifest = loadManifest();
+  // Clean before walking. Skipping resurrected paths during the walk stops new
+  // contradictions entering, but says nothing about ones already recorded — a
+  // seed that reported "10 skipped" while leaving all 10 in place would read as
+  // handled when nothing had been fixed.
+  const dropped = dropResurrected(manifest);
   const existing = new Map(manifest.retired.map((e) => [e.path, e]));
   const deletionCommits = findDeletionCommits();
   let added = 0;
   let updated = 0;
+  const skipped = new Set();
   for (const { commit, deletedPaths } of deletionCommits) {
     const retiredIn = versionAtCommit(commit);
     const retiredBy = findRetirementPrFromCommitMessage(commit);
     for (const path of deletedPaths) {
+      // The path was deleted here but is back in the tree — moflo ships it
+      // again, so it is not retired and must not enter the manifest (#1414).
+      // Counted in a Set: a delete → restore → delete path appears in several
+      // deletion commits and would otherwise inflate the tally.
+      if (isResurrected(path)) { skipped.add(path); continue; }
       // Walk from the deletion commit itself — `git show <deletion>:<path>`
       // raises (path absent at deletion) and is skipped, while every prior
       // touch of the file is enumerated. Full history, no cap (#1133).
@@ -208,7 +272,13 @@ function seed() {
     }
   }
   writeManifest(manifest);
-  process.stdout.write(`retired-files.json: +${added} added, ${updated} updated, ${manifest.retired.length} total\n`);
+  process.stdout.write(
+    `retired-files.json: +${added} added, ${updated} updated, ${skipped.size} skipped and ` +
+    `${dropped.length} dropped (path restored), ${manifest.retired.length} total\n`,
+  );
+  for (const path of dropped) {
+    process.stdout.write(`  dropped ${path} — still shipped, so not retired\n`);
+  }
 }
 
 function addOne(args) {
@@ -218,6 +288,19 @@ function addOne(args) {
     throw new Error(`--add <path> must start with one of: ${TARGET_PREFIXES.join(', ')}`);
   }
   const manifest = loadManifest();
+  // git still tracks the path, so the deletion has not been staged yet. That is
+  // legitimate mid-PR — `flo retire` is meant to be usable before the deletion
+  // is committed — but it is also exactly how a still-shipped path lands in the
+  // manifest (#1414), and nothing here can tell the two apart until CI sees the
+  // merged tree. Warn rather than refuse, and name the guard that decides.
+  if (isResurrected(path)) {
+    process.stderr.write(
+      `warning: ${path} is still tracked by git — the deletion is not staged.\n` +
+      `  Retiring a path moflo still ships produces a permanent "customized retired file"\n` +
+      `  notice in every consumer. Make sure the deletion lands in this PR —\n` +
+      `  tests/guards/retired-manifest-shipped-path-guard.test.ts fails the build otherwise.\n`,
+    );
+  }
   // Walk from the deletion commit (the file is gone) or from HEAD (file
   // still tracked because the user is preparing the entry on a branch where
   // the deletion isn't committed yet).
@@ -265,6 +348,12 @@ function addOne(args) {
  *
  * Entries with no resolvable git history are reported but left alone — the
  * existing hashes may still be load-bearing for some consumer.
+ *
+ * Entries whose path is back in the tree ARE dropped (#1414). Re-deriving
+ * hashes for a path moflo still ships cannot make the entry correct — the
+ * consumer's copy is the current shipped content by construction, so the entry
+ * can only ever resolve to "customized, retained". This is the heal command the
+ * build-time guard points at.
  */
 function rebuild() {
   const manifest = loadManifest();
@@ -273,6 +362,7 @@ function rebuild() {
   let orphaned = 0;
   let totalHashesBefore = 0;
   let totalHashesAfter = 0;
+  const dropped = dropResurrected(manifest);
   for (const entry of manifest.retired) {
     const prior = entry.knownContentHashes || [];
     totalHashesBefore += prior.length;
@@ -298,8 +388,12 @@ function rebuild() {
   writeManifest(manifest);
   process.stdout.write(
     `retired-files.json: ${updated} updated, ${unchanged} unchanged, ${orphaned} no-resolvable-history, ` +
+    `${dropped.length} dropped (path restored), ` +
     `${manifest.retired.length} total entries; hashes ${totalHashesBefore} → ${totalHashesAfter}\n`,
   );
+  for (const path of dropped) {
+    process.stdout.write(`  dropped ${path} — still shipped, so not retired\n`);
+  }
 }
 
 function parseArgs(argv) {
@@ -318,10 +412,11 @@ function parseArgs(argv) {
   return out;
 }
 
-// Exports kept narrow — tests need to exercise hash walking and the rebuild
-// loop, but seed()/addOne() drive end-user side effects (writing the manifest)
-// that tests cover via subprocess spawn rather than direct call.
-export { hashesForPath, sha256, loadManifest, manifestPath, repoRoot };
+// Exports kept narrow — tests need to exercise hash walking, the resurrection
+// predicate, and the deletion walk, but seed()/addOne()/rebuild() drive
+// end-user side effects (rewriting the tracked manifest) that a test must not
+// trigger: the guard suite reads retired-files.json concurrently.
+export { hashesForPath, sha256, loadManifest, manifestPath, repoRoot, isResurrected, findDeletionCommits };
 
 // CLI dispatch fires only when invoked directly, not when imported by tests.
 // Empty argv[1] (no script path on the command line — e.g. `node -e ...`)

--- a/src/cli/commands/retire.ts
+++ b/src/cli/commands/retire.ts
@@ -59,7 +59,7 @@ export const retireCommand: Command = {
     },
     {
       name: 'rebuild-hashes',
-      description: 'Recompute knownContentHashes[] for every existing entry from full git history (#1133 backfill)',
+      description: 'Recompute knownContentHashes[] for every entry from full git history, and drop entries whose path is back in the tree (#1133 backfill, #1414 heal)',
       type: 'boolean',
       default: false,
     },

--- a/tests/bin/launcher-1414-still-shipped-retirement.test.ts
+++ b/tests/bin/launcher-1414-still-shipped-retirement.test.ts
@@ -1,0 +1,171 @@
+/**
+ * End-to-end: the launcher never reports a still-shipped path as a retained
+ * customized retired file (#1414).
+ *
+ * `tests/bin/launcher-948-retired-prune.test.ts` covers the helper in isolation.
+ * That is not enough here — the defect being fixed was never in the helper's
+ * logic, it was in what the launcher *hands* the helper. Passing the package
+ * root is a call-site change, and a call-site change is only verifiable by
+ * running the call site. So this spawns `bin/session-start-launcher.mjs` against
+ * a staged consumer project, exactly as Claude Code's SessionStart hook does.
+ *
+ * The staged project reproduces the reported state: `retired-files.json` names
+ * `.claude/agents/core/coder.md`, whose recorded hashes are the pre-deletion
+ * content, while both the package and the consumer hold the restored content.
+ *
+ * Every assertion here is paired with a **negative control** — a genuinely
+ * retired path that must still be pruned in the same run. Without it, a session
+ * where Mechanism B never executed at all would satisfy "no retention banner"
+ * and the test would be worthless.
+ *
+ * The temp-root / spawn helpers below are deliberately local rather than shared.
+ * Seven launcher test files already carry their own copies; extracting a common
+ * harness is worth doing, but as its own change — not folded into a fix that
+ * touches the session-start hot path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { createHash } from 'crypto';
+import { resolve, join, dirname } from 'path';
+
+const LAUNCHER = resolve(__dirname, '../../bin/session-start-launcher.mjs');
+
+/** Restored under the same name after an alpha-era retirement — the #1414 shape. */
+const RESTORED = join('.claude', 'agents', 'core', 'coder.md');
+/** Deleted and never brought back — the control that proves Mechanism B ran. */
+const RETIRED = join('.claude', 'agents', 'v3', 'genuinely-retired.md');
+
+const PRE_DELETION_CONTENT = '# coder\n\nthe content that shipped before the alpha-era deletion\n';
+const RESTORED_CONTENT = '# coder\n\nthe content moflo ships today\n';
+const RETIRED_CONTENT = '# a real retirement\n';
+
+function sha256Of(content: string): string {
+  return 'sha256:' + createHash('sha256').update(content).digest('hex');
+}
+
+function makeTempRoot(): string {
+  const root = resolve(
+    __dirname,
+    '../../.testoutput/.test-1414-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
+  );
+  mkdirSync(root, { recursive: true });
+  // package.json is the project-root marker the launcher walks up to find.
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'launcher-1414-test', version: '0.0.0' }));
+  return root;
+}
+
+function cleanTempRoot(root: string) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows may hold handles */ }
+}
+
+function writeAt(root: string, rel: string, content: string) {
+  const abs = join(root, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+function runLauncher(cwd: string): { stdout: string; stderr: string; status: number | null } {
+  // CLAUDE_PROJECT_DIR anchors the unified findProjectRoot (#1057); without it
+  // the walk-up skips the temp root's bare package.json and lands on moflo's
+  // own repo. Production Claude Code always sets it.
+  const result = spawnSync('node', [LAUNCHER], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 60_000,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
+  });
+  return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status };
+}
+
+/**
+ * Stage a consumer mid-upgrade (stamp 9.9.8 → package 9.9.9) so the launcher
+ * enters the branch that owns Mechanism B.
+ *
+ * `packageShipsRestored` is the single variable under test: when true the
+ * package still carries `RESTORED`, which is the contradiction; when false the
+ * same manifest entry describes a real retirement and must behave as it always
+ * has. Holding everything else fixed is what makes the pair a controlled
+ * comparison rather than two unrelated scenarios.
+ */
+function stageProject(root: string, packageShipsRestored: boolean) {
+  const pkgRoot = join(root, 'node_modules', 'moflo');
+  mkdirSync(pkgRoot, { recursive: true });
+  writeFileSync(join(pkgRoot, 'package.json'), JSON.stringify({ name: 'moflo', version: '9.9.9' }));
+  mkdirSync(join(root, '.moflo'), { recursive: true });
+  writeFileSync(join(root, '.moflo', 'moflo-version'), '9.9.8');
+
+  writeFileSync(join(pkgRoot, 'retired-files.json'), JSON.stringify({
+    version: 1,
+    retired: [
+      // Hashes predate the restoration — the state that produced the false
+      // "customized" verdict on every consumer.
+      { path: RESTORED.replace(/\\/g, '/'), retiredIn: '2.0.0-alpha.121', knownContentHashes: [sha256Of(PRE_DELETION_CONTENT)] },
+      { path: RETIRED.replace(/\\/g, '/'), retiredIn: '4.9.22', knownContentHashes: [sha256Of(RETIRED_CONTENT)] },
+    ],
+  }));
+
+  if (packageShipsRestored) writeAt(pkgRoot, RESTORED, RESTORED_CONTENT);
+
+  // Consumer-side copies. `RESTORED` holds today's shipped content, so it
+  // matches no recorded hash; `RETIRED` matches its recorded hash exactly.
+  writeAt(root, RESTORED, RESTORED_CONTENT);
+  writeAt(root, RETIRED, RETIRED_CONTENT);
+}
+
+const RETENTION_BANNER = /retained \d+ customized retired file/;
+
+describe('session-start launcher — still-shipped retirement entries (#1414)', () => {
+  let root: string;
+  beforeEach(() => { root = makeTempRoot(); });
+  afterEach(() => { cleanTempRoot(root); });
+
+  it('leaves a still-shipped path alone and prints no retention banner', () => {
+    stageProject(root, true);
+
+    // An affected consumer does not arrive clean — a previous session already
+    // wrote a record naming these files under a reason that was never true.
+    // Asserting only "no record is created" would miss the case that actually
+    // matters: the stale one has to go.
+    const recordPath = join(root, '.moflo', 'retired-retained.json');
+    writeFileSync(recordPath, JSON.stringify({
+      version: 1,
+      mofloVersion: '9.9.8',
+      retained: [{ path: RESTORED.replace(/\\/g, '/'), retiredIn: '2.0.0-alpha.121' }],
+    }));
+    expect(existsSync(recordPath), 'precondition: the stale record must exist before the run').toBe(true);
+
+    const { stdout, status } = runLauncher(root);
+    expect(status, `launcher exited non-zero:\n${stdout}`).toBe(0);
+
+    // Negative control first: if this fails, Mechanism B did not run and every
+    // other assertion below is vacuous.
+    expect(
+      existsSync(join(root, RETIRED)),
+      'genuinely-retired file survived — Mechanism B never executed, so this test proves nothing',
+    ).toBe(false);
+
+    expect(existsSync(join(root, RESTORED)), 'still-shipped agent was deleted').toBe(true);
+    expect(stdout).not.toMatch(RETENTION_BANNER);
+    expect(
+      existsSync(recordPath),
+      'the stale retained record survived — a consumer would keep being told these files are customized',
+    ).toBe(false);
+  });
+
+  it('still reports a genuine retention when the package really dropped the path', () => {
+    // Same manifest, same consumer files — only the package copy is withheld.
+    // Proves the fix discriminates on what the package ships rather than
+    // suppressing the retention path wholesale.
+    stageProject(root, false);
+
+    const { stdout, status } = runLauncher(root);
+    expect(status, `launcher exited non-zero:\n${stdout}`).toBe(0);
+
+    expect(existsSync(join(root, RETIRED))).toBe(false);
+    expect(existsSync(join(root, RESTORED)), 'customized retired file must be preserved').toBe(true);
+    expect(stdout).toMatch(RETENTION_BANNER);
+    expect(existsSync(join(root, '.moflo', 'retired-retained.json'))).toBe(true);
+  });
+});

--- a/tests/bin/launcher-948-retired-prune.test.ts
+++ b/tests/bin/launcher-948-retired-prune.test.ts
@@ -575,4 +575,122 @@ describe('retired-files helper (#948)', () => {
       }]);
     });
   });
+
+  // ── Still-shipped cross-check (#1414) ──────────────────────────────────
+  //
+  // A path can be retired and later RESTORED under the same name. The stale
+  // manifest entry then holds only pre-deletion hashes, so the copy moflo's own
+  // manifest sync just wrote from the package matches nothing and is reported
+  // as a customized retired file on every session — telling the user to delete
+  // agents that agent-router and swarm resolve by name. Ten shipped core agents
+  // were in exactly that state.
+  //
+  // Asking the installed package what it ships is the only source that cannot
+  // drift, so it overrides the manifest. The check is conservative in the safe
+  // direction: it can only ever turn a delete into a skip.
+  describe('still-shipped cross-check', () => {
+    let root: string;
+    let pkgRoot: string;
+    beforeEach(() => {
+      root = makeTempRoot('shipped');
+      pkgRoot = makeTempRoot('shipped-pkg');
+    });
+    afterEach(() => { cleanTempRoot(root); cleanTempRoot(pkgRoot); });
+
+    const REL = '.claude/agents/core/coder.md';
+
+    function manifestFor(entries: Array<{path:string; knownContentHashes:string[]}>) {
+      const p = join(root, 'retired-files.json');
+      writeFileSync(p, JSON.stringify({ version: 1, retired: entries }));
+      return p;
+    }
+
+    it('classifies a still-shipped path as shipped, whatever the on-disk content', () => {
+      writeAt(root, REL, '# current shipped content\n');
+      writeAt(pkgRoot, REL, '# current shipped content\n');
+
+      const entry = { path: REL, knownContentHashes: [sha256Of('# the ancient pre-deletion content\n')] };
+      // Without the package root this is the pre-#1414 verdict: hash mismatch
+      // reads as a user customization.
+      expect(classifyRetiredFile(root, entry).action).toBe('preserve');
+      expect(classifyRetiredFile(root, entry, pkgRoot).action).toBe('shipped');
+    });
+
+    it('classifies as shipped even when the hash WOULD have matched', () => {
+      // The prune direction matters more than the preserve direction: a
+      // contradictory entry whose hash happens to match would delete a file the
+      // package still ships, and Mechanism A would put it back next session —
+      // a delete/restore flap on every upgrade.
+      const content = '# shipped\n';
+      writeAt(root, REL, content);
+      writeAt(pkgRoot, REL, content);
+
+      const entry = { path: REL, knownContentHashes: [sha256Of(content)] };
+      expect(classifyRetiredFile(root, entry).action).toBe('prune');
+      expect(classifyRetiredFile(root, entry, pkgRoot).action).toBe('shipped');
+    });
+
+    it('leaves the verdict alone for a path the package genuinely dropped', () => {
+      const content = '# shipped\n';
+      writeAt(root, REL, content);
+      // pkgRoot deliberately has no copy — a real retirement.
+
+      const entry = { path: REL, knownContentHashes: [sha256Of(content)] };
+      expect(classifyRetiredFile(root, entry, pkgRoot).action).toBe('prune');
+    });
+
+    it('applyRetiredPrune reports shipped entries separately and touches nothing', () => {
+      const stale = '# ancient\n';
+      writeAt(root, REL, '# current shipped content\n');
+      writeAt(pkgRoot, REL, '# current shipped content\n');
+      writeAt(root, '.claude/agents/v3/really-retired.md', stale);
+
+      const manifestPath = manifestFor([
+        { path: REL, knownContentHashes: [sha256Of(stale)] },
+        { path: '.claude/agents/v3/really-retired.md', knownContentHashes: [sha256Of(stale)] },
+      ]);
+
+      const report = applyRetiredPrune(root, manifestPath, pkgRoot);
+
+      expect(report.shipped).toEqual([REL]);
+      expect(report.preserved).toEqual([]);
+      expect(report.preservedDetails).toEqual([]);
+      expect(existsSync(join(root, REL))).toBe(true);
+
+      // The genuine retirement still prunes — the cross-check is per-entry, not
+      // a global off switch.
+      expect(report.pruned).toEqual(['.claude/agents/v3/really-retired.md']);
+      expect(existsSync(join(root, '.claude/agents/v3/really-retired.md'))).toBe(false);
+    });
+
+    it('omitting the package root preserves pre-#1414 behaviour exactly', () => {
+      const stale = '# ancient\n';
+      writeAt(root, REL, '# current shipped content\n');
+      writeAt(pkgRoot, REL, '# current shipped content\n');
+
+      const manifestPath = manifestFor([{ path: REL, knownContentHashes: [sha256Of(stale)] }]);
+
+      const report = applyRetiredPrune(root, manifestPath);
+      expect(report.shipped).toEqual([]);
+      expect(report.preserved).toEqual([REL]);
+    });
+
+    it('feeds an empty preserved set into writeRetainedRecord, clearing a stale record', () => {
+      // The end-to-end payoff for an affected consumer: on the upgrade that
+      // carries this fix, the record naming 10 falsely-retained files is not
+      // rewritten — it is deleted.
+      const stale = '# ancient\n';
+      writeAt(root, REL, '# current shipped content\n');
+      writeAt(pkgRoot, REL, '# current shipped content\n');
+      const manifestPath = manifestFor([{ path: REL, knownContentHashes: [sha256Of(stale)] }]);
+
+      const before = applyRetiredPrune(root, manifestPath);
+      expect(writeRetainedRecord(root, before.preservedDetails, '4.12.4')).not.toBeNull();
+      expect(existsSync(join(root, RETAINED_RECORD_REL))).toBe(true);
+
+      const after = applyRetiredPrune(root, manifestPath, pkgRoot);
+      expect(writeRetainedRecord(root, after.preservedDetails, '4.12.5')).toBeNull();
+      expect(existsSync(join(root, RETAINED_RECORD_REL))).toBe(false);
+    });
+  });
 });

--- a/tests/guards/retired-manifest-shipped-path-guard.test.ts
+++ b/tests/guards/retired-manifest-shipped-path-guard.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `retired-files.json` may never name a path moflo still ships (#1414).
+ *
+ * The manifest tells every consumer's launcher which shipped files to delete on
+ * upgrade, gated on a content-hash match. An entry for a path that is BACK in
+ * the tree is self-contradictory: its `knownContentHashes` hold only the
+ * pre-deletion content, while the file on the consumer's disk is whatever
+ * moflo's own manifest sync just wrote from the package. Nothing matches, the
+ * launcher classifies it `preserve`, and every session prints
+ *
+ *     moflo: retained N customized retired files (delete manually if unwanted)
+ *
+ * for files that were never customized and are not retired — pointing the user
+ * at agent definitions that `agent-router`, `swarm`, and `flo-simplify` resolve
+ * by name. Ten shipped core agents sat in that state because
+ * `scripts/build-retired-files.mjs --seed` walks deletion commits and never
+ * asked whether the path came back.
+ *
+ * The rule is already written down in `.claude/guidance/internal/retirement-workflow.md`
+ * ("never ship a manifest entry for a path that exists in `node_modules/moflo/`").
+ * This is what enforces it.
+ *
+ * NO EXEMPTIONS. A path in the tree is a path that ships, and there is no
+ * version of "retired but still shipped" that is coherent. If this goes red,
+ * withdraw the entry — `flo retire --rebuild-hashes` drops every offender and
+ * reports what it removed. Do not add an allowlist.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { REPO_ROOT } from './_helpers/eslint-harness.js';
+import { trackedFiles } from './_helpers/tracked-files.js';
+
+const MANIFEST_PATH = join(REPO_ROOT, 'retired-files.json');
+
+interface RetiredEntry {
+  path: string;
+  retiredIn?: string;
+  retiredBy?: string;
+}
+
+/**
+ * git already reports `/`-separated paths on every platform, so only the
+ * manifest side can carry `\` — from a hand edit on Windows. Normalizing it
+ * stops such an entry slipping through by failing to string-match.
+ */
+function normalize(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+/**
+ * Entries naming a path that is present in the tracked tree. Pure, so the
+ * detector can be exercised against a synthetic manifest below rather than
+ * only against the real one — a guard that has never been seen to fire is a
+ * guard nobody knows works.
+ */
+export function shippedPathOffenders(
+  entries: readonly RetiredEntry[],
+  tracked: ReadonlySet<string>,
+): string[] {
+  return entries
+    .filter((entry) => tracked.has(normalize(entry.path)))
+    .map((entry) => `${entry.path}${entry.retiredIn ? ` (retiredIn ${entry.retiredIn})` : ''}`);
+}
+
+/**
+ * Parsed here rather than through `loadManifest` from `scripts/build-retired-files.mjs`.
+ * A guard that reuses the loader belonging to the tool it guards inherits that
+ * tool's bugs — a loader that silently dropped entries would take the guard
+ * green with it.
+ */
+function loadEntries(): RetiredEntry[] {
+  const parsed = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as { retired?: RetiredEntry[] };
+  return parsed.retired ?? [];
+}
+
+/**
+ * The WHOLE tracked tree, not just `.claude`. Scoping the listing to the
+ * prefixes the retirement tooling accepts today would leave the guard silently
+ * under-scanning the moment those prefixes change — and a guard that checks
+ * less than it claims is the one failure mode a guard must not have. Paths are
+ * matched exactly, so widening the set costs nothing in false positives.
+ *
+ * Tracked-only, deliberately: an untracked working-tree file is not something
+ * the npm tarball can ship, and keying on the tracked set is what makes a local
+ * run and CI agree.
+ *
+ * Hoisted — `git ls-files` is a subprocess and every test here asks the same
+ * question of the same tree.
+ */
+let trackedCache: Set<string> | null = null;
+function trackedRepoPaths(): Set<string> {
+  trackedCache ??= new Set(trackedFiles());
+  return trackedCache;
+}
+
+describe('retired-files.json never names a still-shipped path (#1414)', () => {
+  it('has no entry whose path is present in the tracked tree', () => {
+    const entries = loadEntries();
+    const tracked = trackedRepoPaths();
+
+    // Both sides must be non-empty or the assertion below passes vacuously —
+    // a broken loader would otherwise read as a clean guard forever.
+    expect(entries.length, 'retired-files.json parsed to zero entries — loader regressed').toBeGreaterThan(0);
+    expect(tracked.size, 'git ls-files returned nothing — listing regressed').toBeGreaterThan(0);
+
+    const offenders = shippedPathOffenders(entries, tracked);
+
+    expect(
+      offenders,
+      `retired-files.json names ${offenders.length} path(s) moflo still ships:\n  ${offenders.join('\n  ')}\n\n` +
+        `Such an entry can only ever resolve to "customized, retained" on a consumer, because its\n` +
+        `knownContentHashes predate the content the package now installs. Withdraw it:\n` +
+        `  flo retire --rebuild-hashes\n` +
+        `Do not allowlist it here.`,
+    ).toEqual([]);
+  });
+
+  it('detects a violation when one is present', () => {
+    // The real manifest is clean, so prove the detector fires against a
+    // synthetic entry pointing at a file that genuinely is in the tree.
+    const tracked = trackedRepoPaths();
+    const [victim] = [...tracked].sort();
+    expect(victim, 'no tracked path to build the negative case from').toBeTruthy();
+
+    const offenders = shippedPathOffenders(
+      [{ path: victim, retiredIn: '9.9.9' }, { path: '.claude/agents/gone/never-existed.md' }],
+      tracked,
+    );
+
+    expect(offenders).toEqual([`${victim} (retiredIn 9.9.9)`]);
+  });
+
+  it('every manifest path is expressed with forward slashes', () => {
+    // The launcher resolves these with path.resolve, which tolerates either
+    // separator — but the guard above, `flo doctor`, and every diff review read
+    // them as strings. One backslash entry would compare unequal everywhere.
+    const offenders = loadEntries()
+      .map((entry) => entry.path)
+      .filter((p) => p.includes('\\'));
+    expect(offenders, `retired-files.json paths must use '/': ${offenders.join(', ')}`).toEqual([]);
+  });
+});

--- a/tests/scripts/build-retired-files.test.ts
+++ b/tests/scripts/build-retired-files.test.ts
@@ -165,4 +165,54 @@ describe('build-retired-files.mjs (#1133)', () => {
       }
     });
   });
+
+  // ── Resurrected paths (#1414) ────────────────────────────────────────────
+  //
+  // `--seed` walks deletion commits, and a path deleted in the alpha era can
+  // have been restored since. Recording it anyway produces an entry whose
+  // hashes predate the content moflo now installs, so every consumer reports it
+  // as a customized retired file forever. Ten shipped core agents were in that
+  // state.
+  //
+  // These read the real repo and never write the manifest — the guard suite
+  // reads it concurrently, and a test that rewrites a tracked file to observe
+  // the effect would race it.
+  describe('resurrected-path skip', () => {
+    it('isResurrected is true for a path that was deleted and later restored', () => {
+      // Deleted in the 2.0.0-alpha era, shipped again today.
+      const path = '.claude/agents/core/coder.md';
+      const deletionLog = spawnSync(
+        'git',
+        ['log', '--diff-filter=D', '--pretty=format:%H', '-n', '1', '--', path],
+        { cwd: repoRoot, encoding: 'utf-8' },
+      );
+      expect((deletionLog.stdout || '').trim(), `${path} was never deleted — pick another fixture`).not.toBe('');
+      expect(buildRetired.isResurrected(path)).toBe(true);
+    });
+
+    it('isResurrected is false for a path that stayed retired', () => {
+      expect(buildRetired.isResurrected('.claude/agents/sona/sona-learning-optimizer.md')).toBe(false);
+    });
+
+    it('no path that a seed walk would find is both deleted-in-history and back in the tree', () => {
+      // The seed-side statement of the invariant: enumerate exactly what
+      // `--seed` enumerates, and assert every resurrected path it encounters is
+      // absent from the committed manifest. Pre-fix this listed 10 paths.
+      const deleted = new Set<string>();
+      for (const commit of buildRetired.findDeletionCommits()) {
+        for (const p of commit.deletedPaths) deleted.add(p);
+      }
+      expect(deleted.size, 'deletion walk found nothing — shallow clone or walk regressed').toBeGreaterThan(0);
+
+      const recorded = new Set(loadManifest().retired.map((e) => e.path));
+      const offenders = [...deleted].filter((p) => buildRetired.isResurrected(p) && recorded.has(p)).sort();
+
+      expect(
+        offenders,
+        `retired-files.json records ${offenders.length} path(s) that were deleted but are back in the tree:\n` +
+          `  ${offenders.join('\n  ')}\n` +
+          `Run \`flo retire --rebuild-hashes\` to drop them.`,
+      ).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1414.

## What was wrong

`retired-files.json` named **10 paths the package still ships** — core agents deleted in the
2.0.0-alpha / 3.0.0-alpha era and later restored under the same name, whose manifest entries were
never withdrawn.

Their `knownContentHashes` hold only pre-deletion content, while the file on the consumer's disk is
the current shipped content that Mechanism A just wrote. Nothing matches, so `classifyRetiredFile`
returns `preserve` and every session printed:

```
moflo: retained 10 customized retired files (delete manually if unwanted)
```

Both halves were false, and the notice invited deleting agent definitions that `agent-router`,
`swarm`, and `flo-simplify/SKILL.md` resolve by name.

The invariant was already written down in `internal/retirement-workflow.md` — nothing enforced it.
`--seed` walks `git log --diff-filter=D` and never asked whether a deleted path came back, so the
contradiction was reproducible from the tooling rather than a one-off hand edit.

## Consumer surface and blast radius

| Surface | Change | Failure mode for a 4.12.4 consumer |
|---|---|---|
| `retired-files.json` (ships) | 10 entries withdrawn, 232 → 222 | none — pure removal; 72 deletions, 0 additions, hash total unchanged |
| `bin/lib/retired-files.mjs` (session-start hot path) | optional `packageRoot` cross-check | none — omitting it is byte-for-byte the old behaviour; the check can only turn a delete into a skip |
| `bin/session-start-launcher.mjs` (hot path) | passes the package root | banner stops; `.moflo/retired-retained.json` is deleted rather than rewritten |
| `scripts/build-retired-files.mjs` (dev-only, not shipped) | still-shipped guard in all three modes | none |
| `src/cli/commands/retire.ts` | `--rebuild-hashes` help text | none |

No migration. Existing `.moflo/` state parses unchanged. **Requires publish + reinstall** before the
runtime layer takes effect for consumers — but the runtime cross-check fixes the symptom even against
a stale manifest, so an affected install is repaired by the upgrade alone.

## Three predicates, one tree

All three key on the **git-tracked** set, so author time, build time, and run time cannot disagree:

- **Author** — `--seed` skips and drops, `--rebuild-hashes` heals and names each entry it removed,
  `--add` warns while the deletion is still unstaged
- **Build** — `tests/guards/retired-manifest-shipped-path-guard.test.ts`, scanning the whole tracked
  tree so it can never under-scan. No exemption list
- **Run** — `classifyRetiredFile` takes the installed package root and returns `shipped`, so an entry
  that escapes CI still cannot reach a consumer

The consumer-path stat runs before the package stat: most entries are `absent` on a real install and
need no package stat at all.

## Verification

- **Guard proven non-vacuous by live fire** — restored the pre-fix manifest, guard went red naming all
  10; restored the fixed manifest, green and byte-identical.
- **Launcher wiring proven end-to-end** — spawns the real launcher against a staged consumer holding a
  **pre-existing** stale record, with a **negative control** (a genuinely retired path must still prune
  in the same run) closing the "Mechanism B never executed" vacuity hole, and a paired case proving
  discrimination rather than blanket suppression. Reverting the call site turns it red.
- **Backward compatibility proven by differential execution** against the pre-change module over all
  232 installed-manifest entries: **0** verdict differences with `packageRoot` omitted.
- **Real-world check against the stale installed 4.12.4 manifest**: exactly 10 flip `preserve → shipped`,
  222 stay `absent → absent`, nothing flips out of `prune` — no legitimate cleanup suppressed.
- **`--seed` / `--rebuild-hashes` / `--add`** each exercised live; rebuild is idempotent on the clean
  manifest; the manifest was restored byte-identical after every mutating check.
- Full suite **10490 passed, 0 failed**; `tsc` clean; `bin/` ↔ `.claude/scripts/` byte-identical.

Rule #1: no shelling out (`execFileSync`/`spawnSync` with array args only), every path via
`path.join`/`resolve`, existence-only checks so there is no realpath or symlink exposure. The
case-insensitivity difference between APFS/NTFS and ext4 lands in the safe direction (skip, never
delete).

## Review

Ran the DEEP three-agent Opus pass. It caught a **data-destruction risk I introduced**: the
author-time predicate used `existsSync` (working tree) while the guard used `git ls-files` (tracked
tree), so an untracked stray under `.claude/agents/` — exactly what Mechanism A leaves behind when
dogfooding — would have made `--rebuild-hashes` permanently delete a legitimate retirement entry with
the guard staying green. Found independently by two of three reviewers; neither the 10k-test suite nor
`tsc` could see it, because it only manifests on a dirty working tree. Both predicates now key on the
tracked set.

`/verify` then found that AC7 was only proving the retained record is never *created* — which proves
nothing for an affected consumer, who already has one that `reconcileRetainedRecord` would have kept.
The e2e now stages a pre-existing record with an asserted precondition.

## Deliberately not in scope

- **Banner wording.** Once entries are honest, "retained N customized retired files" is accurate for
  the only case that can still reach it.
- **109 unrecorded deletions** that `--seed` discovers. Pre-existing drift; adding them retires more
  consumer files and deserves its own change.
- **Shared launcher-spawn test harness.** Seven launcher test files already carry their own copy;
  worth extracting, but not folded into a fix touching the session-start hot path.
- **#1412** — `daemon-service` "should be idempotent" times out under parallel load. Reproduced
  identically on clean `main` with these changes stashed, so pre-existing and separately tracked.
