### PR TITLE
fix(daemon-service): inject the process boundary so unit tests stop shelling out (#1412)

### DIFF
--- a/.github/workflows/file-sync-smoke.yml
+++ b/.github/workflows/file-sync-smoke.yml
@@ -16,6 +16,18 @@ name: File-sync smoke (#976)
 #                                       sentinel write + hash-skip mtime
 #   - bootstrap-sentinel-promotion.test.ts — launcher §0/§3h sentinel +
 #                                            upgrade-notice round-trip
+#   - daemon-service.test.ts          — OS-native service registration
+#                                       (#1412). Not a file-sync test; it rides
+#                                       this matrix because it is the repo's
+#                                       only 3-OS vitest leg and the suite is
+#                                       where separator-flavor bugs hide. The
+#                                       Linux branch derived its systemd unit
+#                                       name with `split('/')`, which returns
+#                                       the WHOLE path under NTFS — invisible
+#                                       to the ubuntu-only `Tests` job. Now the
+#                                       macOS/Linux/Windows branches are all
+#                                       stub-driven, so every leg asserts every
+#                                       branch in ~2s.
 #
 # These three together cover the six #976 acceptance behaviors:
 #   B1 hash-skip preserves mtime
@@ -56,6 +68,8 @@ on:
       - 'src/cli/__tests__/post-install-bootstrap.test.ts'
       - 'src/cli/__tests__/bootstrap-sentinel-promotion.test.ts'
       - 'src/cli/__tests__/shipped-scripts-manifest.test.ts'
+      - 'src/cli/services/daemon-service.ts'
+      - 'src/cli/__tests__/services/daemon-service.test.ts'
       - '.github/workflows/file-sync-smoke.yml'
   workflow_dispatch:
 
@@ -108,4 +122,5 @@ jobs:
           src/cli/__tests__/post-install-bootstrap.test.ts
           src/cli/__tests__/bootstrap-sentinel-promotion.test.ts
           src/cli/__tests__/shipped-scripts-manifest.test.ts
+          src/cli/__tests__/services/daemon-service.test.ts
           tests/bin/launcher-854-fixes.test.ts

--- a/.github/workflows/file-sync-smoke.yml
+++ b/.github/workflows/file-sync-smoke.yml
@@ -116,8 +116,16 @@ jobs:
       - name: Build (tsc only — tests need the source helpers under bin/lib/)
         run: npm run build
 
+      # `--config vitest.isolation.config.ts` is load-bearing, not a tuning knob.
+      # The default config splices `isolationTests` into `exclude`, and vitest's
+      # exclude wins over an explicitly named file — so under the default config
+      # this step silently ran 4 of the 6 files below (bootstrap-sentinel-promotion
+      # and launcher-854-fixes are both on that list) and still exited 0. B5/B6
+      # went uncovered on every platform while the check reported green. The
+      # isolation config carries no test exclude, which is exactly what an
+      # explicit-file leg needs.
       - name: Run file-sync smoke tests
-        run: npx vitest run --reporter=default
+        run: npx vitest run --config vitest.isolation.config.ts --reporter=default
           src/cli/__tests__/file-sync-helper.test.ts
           src/cli/__tests__/post-install-bootstrap.test.ts
           src/cli/__tests__/bootstrap-sentinel-promotion.test.ts

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -167,10 +167,15 @@ jobs:
       - name: Build (tsc only — tests need the source helpers under bin/lib/)
         run: npm run build
 
+      # `--config vitest.isolation.config.ts` is load-bearing — the default
+      # config's `exclude` (which splices in `isolationTests`) wins over an
+      # explicitly named file, so this step silently skipped
+      # bootstrap-sentinel-promotion and launcher-854-fixes and still exited 0.
       - name: Run file-sync smoke tests
-        run: npx vitest run --reporter=default
+        run: npx vitest run --config vitest.isolation.config.ts --reporter=default
           src/cli/__tests__/file-sync-helper.test.ts
           src/cli/__tests__/post-install-bootstrap.test.ts
           src/cli/__tests__/bootstrap-sentinel-promotion.test.ts
           src/cli/__tests__/shipped-scripts-manifest.test.ts
+          src/cli/__tests__/services/daemon-service.test.ts
           tests/bin/launcher-854-fixes.test.ts

--- a/src/cli/__tests__/services/daemon-service.test.ts
+++ b/src/cli/__tests__/services/daemon-service.test.ts
@@ -4,12 +4,30 @@
  * Validates OS-native service installation/uninstallation
  * for macOS (launchd), Linux (systemd), and Windows (schtasks).
  *
- * Uses real temp directories with platform mocking.
+ * These are UNIT tests: the process boundary (`runCommand`) and the home
+ * directory (`homeDir`) are both injected, so no test here invokes the host's
+ * service manager or writes outside its temp dir. That is deliberate (#1412):
+ *
+ *  - The real calls carry 10s (systemctl) / 15s (schtasks) subprocess timeouts,
+ *    double vitest's 5s per-test budget. A single slow `systemctl --user` under
+ *    full-suite contention could not be absorbed, so the file timed out
+ *    intermittently while passing in isolation. Asserting the commands that
+ *    *would* be issued removes the wait entirely rather than hiding it behind a
+ *    raised timeout.
+ *  - `systemctl --user enable/disable/stop` and the plist write were not
+ *    sandboxed — running the suite on a Linux workstation performed real
+ *    service registration in the developer's systemd user session.
+ *
+ * Injecting `platform` also makes all three branches assertable from any host,
+ * which the old `process.platform` override could not do for Windows (schtasks
+ * does not exist on POSIX). The genuinely integration-level path — real
+ * `execSync`, real systemd — lives in `tests/system/daemon-service-systemd.test.ts`
+ * with a timeout above the subprocess ceiling.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, mkdirSync, existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { basename, join, sep } from 'path';
 import { tmpdir } from 'os';
 
 // Import internals for testing
@@ -19,23 +37,41 @@ import {
   uninstallDaemonService,
   _generatePlist,
   _generateSystemdUnit,
-  _plistPath,
-  _systemdUnitPath,
   _schtasksName,
   _projectRootSlug,
+  type CommandRunner,
 } from '../../services/daemon-service.js';
+
+/**
+ * Recording stand-in for `execSync`. Records the command and returns — the
+ * whole point is that no subprocess is spawned, so nothing here can wait.
+ * `failWith` reproduces the non-zero-exit path (execSync throws) for the
+ * branches that swallow service-manager errors.
+ */
+function recordingRunner(failWith?: Error): { runCommand: CommandRunner; commands: string[] } {
+  const commands: string[] = [];
+  return {
+    commands,
+    runCommand: (command) => {
+      commands.push(command);
+      if (failWith) throw failWith;
+    },
+  };
+}
 
 describe('daemon-service', () => {
   let tempDir: string;
+  let homeDir: string;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'daemon-service-test-'));
+    homeDir = mkdtempSync(join(tmpdir(), 'daemon-service-home-'));
     mkdirSync(join(tempDir, '.moflo'), { recursive: true });
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
-    vi.restoreAllMocks();
+    rmSync(homeDir, { recursive: true, force: true });
   });
 
   // =========================================================================
@@ -120,25 +156,11 @@ describe('daemon-service', () => {
   // =========================================================================
   describe('isDaemonInstalled', () => {
     it('should return false when no service file exists (darwin)', () => {
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, 'platform', { value: 'darwin', writable: true });
-
-      try {
-        expect(isDaemonInstalled(tempDir)).toBe(false);
-      } finally {
-        Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
-      }
+      expect(isDaemonInstalled(tempDir, { platform: 'darwin', homeDir })).toBe(false);
     });
 
     it('should return false when no service file exists (linux)', () => {
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, 'platform', { value: 'linux', writable: true });
-
-      try {
-        expect(isDaemonInstalled(tempDir)).toBe(false);
-      } finally {
-        Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
-      }
+      expect(isDaemonInstalled(tempDir, { platform: 'linux', homeDir })).toBe(false);
     });
   });
 
@@ -146,66 +168,82 @@ describe('daemon-service', () => {
   // Install and uninstall (macOS)
   // =========================================================================
   describe('install/uninstall macOS', () => {
-    const originalPlatform = process.platform;
-
-    beforeEach(() => {
-      Object.defineProperty(process, 'platform', { value: 'darwin', writable: true });
-    });
-
-    afterEach(() => {
-      Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
-    });
+    const darwin = (runCommand?: CommandRunner) =>
+      ({ platform: 'darwin', homeDir, runCommand } as const);
 
     it('should write plist file on install', () => {
-      const result = installDaemonService(tempDir);
+      const { runCommand, commands } = recordingRunner();
+      const result = installDaemonService(tempDir, darwin(runCommand));
 
       expect(result.success).toBe(true);
       expect(result.servicePath).toBeTruthy();
       expect(result.message).toContain('installed');
       expect(result.message).toContain('login');
 
-      // Verify file exists
+      // Verify file exists — and inside the injected home, not the real one
       expect(existsSync(result.servicePath!)).toBe(true);
+      expect(result.servicePath!.startsWith(homeDir + sep)).toBe(true);
 
       // Verify content
       const content = readFileSync(result.servicePath!, 'utf-8');
       expect(content).toContain('<key>Label</key>');
       expect(content).toContain('<key>RunAtLoad</key>');
+
+      // Install is a pure file write on macOS — no launchctl call
+      expect(commands).toEqual([]);
     });
 
     it('should be idempotent — second install overwrites without error', () => {
-      const first = installDaemonService(tempDir);
+      const { runCommand } = recordingRunner();
+      const first = installDaemonService(tempDir, darwin(runCommand));
       expect(first.success).toBe(true);
 
-      const second = installDaemonService(tempDir);
+      const second = installDaemonService(tempDir, darwin(runCommand));
       expect(second.success).toBe(true);
       expect(second.servicePath).toBe(first.servicePath);
     });
 
-    it('should remove plist file on uninstall', () => {
-      // Install first
-      const installResult = installDaemonService(tempDir);
+    it('should unload via launchctl and remove plist file on uninstall', () => {
+      const install = recordingRunner();
+      const installResult = installDaemonService(tempDir, darwin(install.runCommand));
       expect(installResult.success).toBe(true);
       expect(existsSync(installResult.servicePath!)).toBe(true);
 
-      // launchctl unload will fail in tests (not a real plist) but the try/catch handles it
-      const uninstallResult = uninstallDaemonService(tempDir);
+      const uninstall = recordingRunner();
+      const uninstallResult = uninstallDaemonService(tempDir, darwin(uninstall.runCommand));
       expect(uninstallResult.success).toBe(true);
       expect(uninstallResult.message).toContain('removed');
+      expect(existsSync(installResult.servicePath!)).toBe(false);
+
+      expect(uninstall.commands).toEqual([`launchctl unload "${installResult.servicePath}"`]);
+    });
+
+    it('should still remove the plist when launchctl unload fails', () => {
+      const installResult = installDaemonService(tempDir, darwin(recordingRunner().runCommand));
+      expect(existsSync(installResult.servicePath!)).toBe(true);
+
+      // launchctl exits non-zero when the job was never loaded — must be swallowed
+      const failing = recordingRunner(new Error('Could not find specified service'));
+      const uninstallResult = uninstallDaemonService(tempDir, darwin(failing.runCommand));
+
+      expect(uninstallResult.success).toBe(true);
       expect(existsSync(installResult.servicePath!)).toBe(false);
     });
 
     it('should succeed gracefully when uninstalling with no service', () => {
-      const result = uninstallDaemonService(tempDir);
+      const { runCommand, commands } = recordingRunner();
+      const result = uninstallDaemonService(tempDir, darwin(runCommand));
       expect(result.success).toBe(true);
       expect(result.message).toContain('not installed');
+      // Nothing to unload — must not shell out at all
+      expect(commands).toEqual([]);
     });
 
     it('should detect installed service', () => {
-      expect(isDaemonInstalled(tempDir)).toBe(false);
+      expect(isDaemonInstalled(tempDir, darwin())).toBe(false);
 
-      installDaemonService(tempDir);
-      expect(isDaemonInstalled(tempDir)).toBe(true);
+      installDaemonService(tempDir, darwin(recordingRunner().runCommand));
+      expect(isDaemonInstalled(tempDir, darwin())).toBe(true);
     });
   });
 
@@ -213,26 +251,20 @@ describe('daemon-service', () => {
   // Install and uninstall (Linux)
   // =========================================================================
   describe('install/uninstall Linux', () => {
-    const originalPlatform = process.platform;
-
-    beforeEach(() => {
-      Object.defineProperty(process, 'platform', { value: 'linux', writable: true });
-      // systemctl calls will fail in tests but the try/catch handles it
-    });
-
-    afterEach(() => {
-      Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
-    });
+    const linux = (runCommand?: CommandRunner) =>
+      ({ platform: 'linux', homeDir, runCommand } as const);
 
     it('should write systemd unit file on install', () => {
-      const result = installDaemonService(tempDir);
+      const { runCommand } = recordingRunner();
+      const result = installDaemonService(tempDir, linux(runCommand));
 
       expect(result.success).toBe(true);
       expect(result.servicePath).toBeTruthy();
       expect(result.message).toContain('installed');
 
-      // Verify file exists
+      // Verify file exists — inside the injected home, not ~/.config
       expect(existsSync(result.servicePath!)).toBe(true);
+      expect(result.servicePath!.startsWith(homeDir + sep)).toBe(true);
 
       // Verify content
       const content = readFileSync(result.servicePath!, 'utf-8');
@@ -242,29 +274,160 @@ describe('daemon-service', () => {
       expect(content).toContain('WantedBy=default.target');
     });
 
+    it('should issue daemon-reload then enable on install — and nothing else', () => {
+      const { runCommand, commands } = recordingRunner();
+      const result = installDaemonService(tempDir, linux(runCommand));
+
+      expect(commands).toEqual([
+        'systemctl --user daemon-reload',
+        `systemctl --user enable ${basename(result.servicePath!)}`,
+      ]);
+    });
+
+    it('should pass a bare unit name to systemctl, never a path', () => {
+      // Regression guard for Rule #1. The unit name was derived with
+      // `dest.split('/').pop()`, which returns the WHOLE path when the
+      // separator is `\` — so the Linux branch built a malformed
+      // `systemctl enable C:\...\unit.service` the moment it ran from a
+      // Windows host. `basename` binds to the host's separator flavor and is
+      // correct everywhere.
+      //
+      // Honest scope: on a POSIX host this assertion is near-vacuous (the path
+      // it inspects has no backslash to begin with). It only bites on Windows,
+      // which is why this file was added to the 3-OS leg in
+      // `.github/workflows/file-sync-smoke.yml` — the ubuntu-only `Tests` job
+      // cannot catch this class.
+      const { runCommand, commands } = recordingRunner();
+      installDaemonService(tempDir, linux(runCommand));
+
+      const enable = commands.find((c) => c.includes('enable'))!;
+      const unitArg = enable.split(' ').pop()!;
+      expect(unitArg).not.toContain('/');
+      expect(unitArg).not.toContain('\\');
+      expect(unitArg).toMatch(/^moflo-daemon-.+\.service$/);
+    });
+
     it('should be idempotent — second install overwrites without error', () => {
-      const first = installDaemonService(tempDir);
+      const { runCommand } = recordingRunner();
+      const first = installDaemonService(tempDir, linux(runCommand));
       expect(first.success).toBe(true);
 
-      const second = installDaemonService(tempDir);
+      const second = installDaemonService(tempDir, linux(runCommand));
       expect(second.success).toBe(true);
+      expect(second.servicePath).toBe(first.servicePath);
     });
 
     it('should remove unit file on uninstall', () => {
-      const installResult = installDaemonService(tempDir);
+      const installResult = installDaemonService(tempDir, linux(recordingRunner().runCommand));
       expect(installResult.success).toBe(true);
       expect(existsSync(installResult.servicePath!)).toBe(true);
 
-      const uninstallResult = uninstallDaemonService(tempDir);
+      const uninstall = recordingRunner();
+      const uninstallResult = uninstallDaemonService(tempDir, linux(uninstall.runCommand));
       expect(uninstallResult.success).toBe(true);
       expect(uninstallResult.message).toContain('removed');
       expect(existsSync(installResult.servicePath!)).toBe(false);
+
+      const unitName = basename(installResult.servicePath!);
+      expect(uninstall.commands).toEqual([
+        `systemctl --user disable ${unitName}`,
+        `systemctl --user stop ${unitName}`,
+        'systemctl --user daemon-reload',
+      ]);
+    });
+
+    it('should still remove the unit file when systemctl is unavailable', () => {
+      const installResult = installDaemonService(tempDir, linux(recordingRunner().runCommand));
+      expect(existsSync(installResult.servicePath!)).toBe(true);
+
+      // No systemd on this host (containers, CI) — install and uninstall must
+      // both report success and leave the filesystem consistent regardless.
+      const failing = recordingRunner(new Error('systemctl: command not found'));
+      const uninstallResult = uninstallDaemonService(tempDir, linux(failing.runCommand));
+
+      expect(uninstallResult.success).toBe(true);
+      expect(existsSync(installResult.servicePath!)).toBe(false);
+    });
+
+    it('should report install success when systemctl is unavailable', () => {
+      const failing = recordingRunner(new Error('systemctl: command not found'));
+      const result = installDaemonService(tempDir, linux(failing.runCommand));
+
+      expect(result.success).toBe(true);
+      expect(existsSync(result.servicePath!)).toBe(true);
+      // The first failure aborts the try block — enable is never reached
+      expect(failing.commands).toEqual(['systemctl --user daemon-reload']);
     });
 
     it('should succeed gracefully when uninstalling with no service', () => {
-      const result = uninstallDaemonService(tempDir);
+      const { runCommand, commands } = recordingRunner();
+      const result = uninstallDaemonService(tempDir, linux(runCommand));
       expect(result.success).toBe(true);
       expect(result.message).toContain('not installed');
+      expect(commands).toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  // Install and uninstall (Windows) — assertable from any host now that the
+  // schtasks boundary is injected. Previously unreachable off Windows.
+  // =========================================================================
+  describe('install/uninstall Windows', () => {
+    const win = (runCommand: CommandRunner) =>
+      ({ platform: 'win32', homeDir, runCommand } as const);
+
+    it('should register an ONLOGON task on install', () => {
+      const { runCommand, commands } = recordingRunner();
+      const result = installDaemonService(tempDir, win(runCommand));
+
+      expect(result.success).toBe(true);
+      expect(result.servicePath).toBe(_schtasksName(tempDir));
+      expect(result.message).toContain('Task Scheduler');
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toContain('schtasks /Create');
+      expect(commands[0]).toContain(`/TN "${_schtasksName(tempDir)}"`);
+      expect(commands[0]).toContain('/SC ONLOGON');
+      // /F makes re-registration idempotent
+      expect(commands[0]).toContain('/F');
+      expect(commands[0]).toContain('daemon start --foreground --quiet');
+    });
+
+    it('should report failure when schtasks rejects the create', () => {
+      const failing = recordingRunner(new Error('ERROR: Access is denied.'));
+      const result = installDaemonService(tempDir, win(failing.runCommand));
+
+      expect(result.success).toBe(false);
+      expect(result.servicePath).toBeNull();
+      expect(result.message).toContain('Failed to create scheduled task');
+      expect(result.message).toContain('Access is denied');
+    });
+
+    it('should delete the task on uninstall', () => {
+      const { runCommand, commands } = recordingRunner();
+      const result = uninstallDaemonService(tempDir, win(runCommand));
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('removed');
+      expect(commands).toEqual([`schtasks /Delete /TN "${_schtasksName(tempDir)}" /F`]);
+    });
+
+    it('should report not-installed when the task does not exist', () => {
+      // schtasks /Delete exits non-zero for an unknown task name
+      const failing = recordingRunner(new Error('ERROR: The system cannot find the file specified.'));
+      const result = uninstallDaemonService(tempDir, win(failing.runCommand));
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('not installed');
+    });
+
+    it('should detect the task via schtasks /Query', () => {
+      const present = recordingRunner();
+      expect(isDaemonInstalled(tempDir, win(present.runCommand))).toBe(true);
+      expect(present.commands).toEqual([`schtasks /Query /TN "${_schtasksName(tempDir)}"`]);
+
+      const absent = recordingRunner(new Error('ERROR: The system cannot find the file specified.'));
+      expect(isDaemonInstalled(tempDir, win(absent.runCommand))).toBe(false);
     });
   });
 
@@ -288,30 +451,20 @@ describe('daemon-service', () => {
   // =========================================================================
   describe('unsupported platform', () => {
     it('should return failure for unknown platforms', () => {
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, 'platform', { value: 'freebsd', writable: true });
+      const { runCommand, commands } = recordingRunner();
+      const options = { platform: 'freebsd', homeDir, runCommand } as const;
 
-      try {
-        const result = installDaemonService(tempDir);
-        expect(result.success).toBe(false);
-        expect(result.message).toContain('Unsupported platform');
+      const result = installDaemonService(tempDir, options);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Unsupported platform');
 
-        const uninstallResult = uninstallDaemonService(tempDir);
-        expect(uninstallResult.success).toBe(false);
-      } finally {
-        Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
-      }
+      const uninstallResult = uninstallDaemonService(tempDir, options);
+      expect(uninstallResult.success).toBe(false);
+      expect(commands).toEqual([]);
     });
 
     it('should return false for isDaemonInstalled on unknown platform', () => {
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, 'platform', { value: 'freebsd', writable: true });
-
-      try {
-        expect(isDaemonInstalled(tempDir)).toBe(false);
-      } finally {
-        Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
-      }
+      expect(isDaemonInstalled(tempDir, { platform: 'freebsd', homeDir })).toBe(false);
     });
   });
 });

--- a/src/cli/services/daemon-service.ts
+++ b/src/cli/services/daemon-service.ts
@@ -11,7 +11,7 @@
 
 import * as fs from 'fs';
 import { createHash } from 'crypto';
-import { dirname, join, resolve } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
 import { locateMofloCliBin } from './moflo-require.js';
@@ -32,6 +32,45 @@ export interface ServiceUninstallResult {
   message: string;
 }
 
+/** Options accepted by the injected command runner — a subset of `execSync`'s. */
+export interface CommandRunnerOptions {
+  timeout: number;
+  stdio?: 'ignore';
+  windowsHide?: boolean;
+  cwd?: string;
+}
+
+/**
+ * The process boundary this module shells out across. Throws on non-zero exit,
+ * exactly like `execSync` — every call site here relies on that to decide
+ * whether the service manager accepted the command.
+ */
+export type CommandRunner = (command: string, options: CommandRunnerOptions) => void;
+
+export interface DaemonServiceOptions {
+  /**
+   * Replaces the real `execSync`. Unit tests pass a recording stub so they
+   * assert the commands that *would* be issued instead of invoking the host's
+   * service manager — see #1412 (real `systemctl --user` calls made the tests
+   * both unsandboxed and unable to fit inside vitest's 5s timeout).
+   */
+  readonly runCommand?: CommandRunner;
+  /** Target a platform branch other than the host's. Test injection. */
+  readonly platform?: NodeJS.Platform;
+  /**
+   * Root the service file is written under. Test injection — keeps unit tests
+   * out of the developer's real `~/Library/LaunchAgents` and
+   * `~/.config/systemd/user`. When set, `XDG_CONFIG_HOME` is deliberately
+   * ignored so an ambient value cannot leak the write back out of the sandbox.
+   */
+  readonly homeDir?: string;
+}
+
+/** Real process boundary. Kept thin so the stub and the default stay swappable. */
+const execSyncRunner: CommandRunner = (command, options) => {
+  execSync(command, options);
+};
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -47,16 +86,20 @@ const SCHTASKS_NAME = 'MoFloDaemon';
 /**
  * Check if the daemon service is registered for the current platform.
  */
-export function isDaemonInstalled(projectRoot: string): boolean {
+export function isDaemonInstalled(
+  projectRoot: string,
+  options: DaemonServiceOptions = {},
+): boolean {
   const resolvedRoot = resolve(projectRoot);
-  const platform = process.platform;
+  const platform = options.platform ?? process.platform;
+  const run = options.runCommand ?? execSyncRunner;
 
   if (platform === 'darwin') {
-    return isDaemonInstalledMacOS(resolvedRoot);
+    return isDaemonInstalledMacOS(resolvedRoot, options);
   } else if (platform === 'linux') {
-    return isDaemonInstalledLinux(resolvedRoot);
+    return isDaemonInstalledLinux(resolvedRoot, options);
   } else if (platform === 'win32') {
-    return isDaemonInstalledWindows(resolvedRoot);
+    return isDaemonInstalledWindows(resolvedRoot, run);
   }
 
   return false;
@@ -65,20 +108,24 @@ export function isDaemonInstalled(projectRoot: string): boolean {
 /**
  * Install the daemon as an OS-native login service.
  */
-export function installDaemonService(projectRoot: string): ServiceInstallResult {
+export function installDaemonService(
+  projectRoot: string,
+  options: DaemonServiceOptions = {},
+): ServiceInstallResult {
   const resolvedRoot = resolve(projectRoot);
   validateProjectRoot(resolvedRoot);
 
-  const platform = process.platform;
+  const platform = options.platform ?? process.platform;
+  const run = options.runCommand ?? execSyncRunner;
   const nodePath = process.execPath;
   const cliPath = resolveCliPath();
 
   if (platform === 'darwin') {
-    return installMacOS(resolvedRoot, nodePath, cliPath);
+    return installMacOS(resolvedRoot, nodePath, cliPath, options);
   } else if (platform === 'linux') {
-    return installLinux(resolvedRoot, nodePath, cliPath);
+    return installLinux(resolvedRoot, nodePath, cliPath, run, options);
   } else if (platform === 'win32') {
-    return installWindows(resolvedRoot, nodePath, cliPath);
+    return installWindows(resolvedRoot, nodePath, cliPath, run);
   }
 
   return {
@@ -91,17 +138,21 @@ export function installDaemonService(projectRoot: string): ServiceInstallResult 
 /**
  * Uninstall the daemon OS-native login service.
  */
-export function uninstallDaemonService(projectRoot: string): ServiceUninstallResult {
+export function uninstallDaemonService(
+  projectRoot: string,
+  options: DaemonServiceOptions = {},
+): ServiceUninstallResult {
   const resolvedRoot = resolve(projectRoot);
   validateProjectRoot(resolvedRoot);
-  const platform = process.platform;
+  const platform = options.platform ?? process.platform;
+  const run = options.runCommand ?? execSyncRunner;
 
   if (platform === 'darwin') {
-    return uninstallMacOS(resolvedRoot);
+    return uninstallMacOS(resolvedRoot, run, options);
   } else if (platform === 'linux') {
-    return uninstallLinux(resolvedRoot);
+    return uninstallLinux(resolvedRoot, run, options);
   } else if (platform === 'win32') {
-    return uninstallWindows(resolvedRoot);
+    return uninstallWindows(resolvedRoot, run);
   }
 
   return {
@@ -114,9 +165,9 @@ export function uninstallDaemonService(projectRoot: string): ServiceUninstallRes
 // macOS — launchd
 // ---------------------------------------------------------------------------
 
-function plistPath(projectRoot: string): string {
+function plistPath(projectRoot: string, options: DaemonServiceOptions = {}): string {
   const slug = projectRootSlug(projectRoot);
-  return join(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.${slug}.plist`);
+  return join(options.homeDir ?? homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.${slug}.plist`);
 }
 
 function generatePlist(projectRoot: string, nodePath: string, cliPath: string): string {
@@ -156,8 +207,13 @@ function generatePlist(projectRoot: string, nodePath: string, cliPath: string): 
   ].join('\n');
 }
 
-function installMacOS(projectRoot: string, nodePath: string, cliPath: string): ServiceInstallResult {
-  const dest = plistPath(projectRoot);
+function installMacOS(
+  projectRoot: string,
+  nodePath: string,
+  cliPath: string,
+  options: DaemonServiceOptions,
+): ServiceInstallResult {
+  const dest = plistPath(projectRoot, options);
   const dir = dirname(dest);
   fs.mkdirSync(dir, { recursive: true });
 
@@ -171,8 +227,12 @@ function installMacOS(projectRoot: string, nodePath: string, cliPath: string): S
   };
 }
 
-function uninstallMacOS(projectRoot: string): ServiceUninstallResult {
-  const dest = plistPath(projectRoot);
+function uninstallMacOS(
+  projectRoot: string,
+  run: CommandRunner,
+  options: DaemonServiceOptions,
+): ServiceUninstallResult {
+  const dest = plistPath(projectRoot, options);
 
   if (!fs.existsSync(dest)) {
     return { success: true, message: 'Daemon service is not installed.' };
@@ -180,24 +240,29 @@ function uninstallMacOS(projectRoot: string): ServiceUninstallResult {
 
   // Unload before removing (ignore errors — may not be loaded)
   try {
-    execSync(`launchctl unload "${dest}"`, { timeout: 5000, stdio: 'ignore' });
+    run(`launchctl unload "${dest}"`, { timeout: 5000, stdio: 'ignore' });
   } catch { /* not loaded — fine */ }
 
   fs.unlinkSync(dest);
   return { success: true, message: `Daemon service removed from ${dest}.` };
 }
 
-function isDaemonInstalledMacOS(projectRoot: string): boolean {
-  return fs.existsSync(plistPath(projectRoot));
+function isDaemonInstalledMacOS(projectRoot: string, options: DaemonServiceOptions): boolean {
+  return fs.existsSync(plistPath(projectRoot, options));
 }
 
 // ---------------------------------------------------------------------------
 // Linux — systemd --user
 // ---------------------------------------------------------------------------
 
-function systemdUnitPath(projectRoot: string): string {
+function systemdUnitPath(projectRoot: string, options: DaemonServiceOptions = {}): string {
   const slug = projectRootSlug(projectRoot);
-  const configDir = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  // An injected homeDir is a sandbox boundary — XDG_CONFIG_HOME must not
+  // override it, or an ambient value would redirect the write back to the
+  // developer's real config tree.
+  const configDir = options.homeDir
+    ? join(options.homeDir, '.config')
+    : process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
   return join(configDir, 'systemd', 'user', `${SYSTEMD_UNIT.replace('.service', '')}-${slug}.service`);
 }
 
@@ -221,8 +286,14 @@ function generateSystemdUnit(projectRoot: string, nodePath: string, cliPath: str
   ].join('\n');
 }
 
-function installLinux(projectRoot: string, nodePath: string, cliPath: string): ServiceInstallResult {
-  const dest = systemdUnitPath(projectRoot);
+function installLinux(
+  projectRoot: string,
+  nodePath: string,
+  cliPath: string,
+  run: CommandRunner,
+  options: DaemonServiceOptions,
+): ServiceInstallResult {
+  const dest = systemdUnitPath(projectRoot, options);
   const dir = dirname(dest);
   fs.mkdirSync(dir, { recursive: true });
 
@@ -231,9 +302,8 @@ function installLinux(projectRoot: string, nodePath: string, cliPath: string): S
 
   // Reload systemd and enable
   try {
-    execSync('systemctl --user daemon-reload', { timeout: 10000, stdio: 'ignore' });
-    const unitName = dest.split('/').pop()!;
-    execSync(`systemctl --user enable ${unitName}`, { timeout: 10000, stdio: 'ignore' });
+    run('systemctl --user daemon-reload', { timeout: 10000, stdio: 'ignore' });
+    run(`systemctl --user enable ${basename(dest)}`, { timeout: 10000, stdio: 'ignore' });
   } catch {
     // systemctl may not be available in all environments
   }
@@ -245,8 +315,12 @@ function installLinux(projectRoot: string, nodePath: string, cliPath: string): S
   };
 }
 
-function uninstallLinux(projectRoot: string): ServiceUninstallResult {
-  const dest = systemdUnitPath(projectRoot);
+function uninstallLinux(
+  projectRoot: string,
+  run: CommandRunner,
+  options: DaemonServiceOptions,
+): ServiceUninstallResult {
+  const dest = systemdUnitPath(projectRoot, options);
 
   if (!fs.existsSync(dest)) {
     return { success: true, message: 'Daemon service is not installed.' };
@@ -254,23 +328,23 @@ function uninstallLinux(projectRoot: string): ServiceUninstallResult {
 
   // Disable and stop before removing
   try {
-    const unitName = dest.split('/').pop()!;
-    execSync(`systemctl --user disable ${unitName}`, { timeout: 10000, stdio: 'ignore' });
-    execSync(`systemctl --user stop ${unitName}`, { timeout: 10000, stdio: 'ignore' });
+    const unitName = basename(dest);
+    run(`systemctl --user disable ${unitName}`, { timeout: 10000, stdio: 'ignore' });
+    run(`systemctl --user stop ${unitName}`, { timeout: 10000, stdio: 'ignore' });
   } catch { /* may not be running */ }
 
   fs.unlinkSync(dest);
 
   // Reload systemd
   try {
-    execSync('systemctl --user daemon-reload', { timeout: 10000, stdio: 'ignore' });
+    run('systemctl --user daemon-reload', { timeout: 10000, stdio: 'ignore' });
   } catch { /* ignore */ }
 
   return { success: true, message: `Daemon service removed from ${dest}.` };
 }
 
-function isDaemonInstalledLinux(projectRoot: string): boolean {
-  return fs.existsSync(systemdUnitPath(projectRoot));
+function isDaemonInstalledLinux(projectRoot: string, options: DaemonServiceOptions): boolean {
+  return fs.existsSync(systemdUnitPath(projectRoot, options));
 }
 
 // ---------------------------------------------------------------------------
@@ -282,13 +356,18 @@ function schtasksName(projectRoot: string): string {
   return `${SCHTASKS_NAME}-${slug}`;
 }
 
-function installWindows(projectRoot: string, nodePath: string, cliPath: string): ServiceInstallResult {
+function installWindows(
+  projectRoot: string,
+  nodePath: string,
+  cliPath: string,
+  run: CommandRunner,
+): ServiceInstallResult {
   const taskName = schtasksName(projectRoot);
 
   // Build schtasks command — ONLOGON trigger, user-level
   // Use /F to force overwrite if already exists (idempotent)
   try {
-    execSync(
+    run(
       `schtasks /Create /TN "${taskName}" /TR "\\"${nodePath}\\" \\"${cliPath}\\" daemon start --foreground --quiet" /SC ONLOGON /F`,
       { timeout: 15000, windowsHide: true, cwd: projectRoot, stdio: 'ignore' },
     );
@@ -307,11 +386,11 @@ function installWindows(projectRoot: string, nodePath: string, cliPath: string):
   };
 }
 
-function uninstallWindows(projectRoot: string): ServiceUninstallResult {
+function uninstallWindows(projectRoot: string, run: CommandRunner): ServiceUninstallResult {
   const taskName = schtasksName(projectRoot);
 
   try {
-    execSync(
+    run(
       `schtasks /Delete /TN "${taskName}" /F`,
       { timeout: 15000, windowsHide: true, stdio: 'ignore' },
     );
@@ -323,10 +402,10 @@ function uninstallWindows(projectRoot: string): ServiceUninstallResult {
   return { success: true, message: `Daemon task "${taskName}" removed from Task Scheduler.` };
 }
 
-function isDaemonInstalledWindows(projectRoot: string): boolean {
+function isDaemonInstalledWindows(projectRoot: string, run: CommandRunner): boolean {
   const taskName = schtasksName(projectRoot);
   try {
-    execSync(`schtasks /Query /TN "${taskName}"`, {
+    run(`schtasks /Query /TN "${taskName}"`, {
       timeout: 10000,
       windowsHide: true,
       stdio: 'ignore',

--- a/tests/system/daemon-service-systemd.test.ts
+++ b/tests/system/daemon-service-systemd.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Integration guard: the daemon-service Linux branch against REAL systemd.
+ *
+ * The unit tests (`src/cli/__tests__/services/daemon-service.test.ts`) inject a
+ * stub runner and never spawn a subprocess — that is what makes them fast and
+ * host-independent. This file is the other half of #1412: it exercises the real
+ * `execSync` path exactly once, so a change that breaks the actual command
+ * strings cannot pass on stub assertions alone.
+ *
+ * Two properties this file must hold, both of them the reason #1412 was filed:
+ *
+ * 1. **Timeout headroom.** `installDaemonService` issues up to 2 × 10s
+ *    subprocess calls and `uninstallDaemonService` up to 3 × 10s. A test that
+ *    may wait on them must allow more than their sum — vitest's default 5s is
+ *    less than a SINGLE call's budget, which is arithmetically unsatisfiable
+ *    and is precisely how the old unit tests produced timeouts that read as
+ *    random flakiness. Hence the explicit 90s below.
+ *
+ * 2. **No registration in the developer's session.** `homeDir` is a temp dir,
+ *    so the unit file lands outside every path the user systemd manager
+ *    searches. `systemctl --user enable` therefore fails with "unit file does
+ *    not exist" — a real round-trip through the real binary, with no service
+ *    actually registered. Running the suite on a Linux workstation must never
+ *    leave state behind in `~/.config/systemd/user`.
+ *
+ * Skipped off Linux, and on Linux hosts without a responsive `systemctl --user`
+ * (containers, CI runners with no user session bus).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  installDaemonService,
+  uninstallDaemonService,
+  isDaemonInstalled,
+} from '../../src/cli/services/daemon-service.js';
+
+/** Worst case is uninstall's 3 × 10s chain; allow 3× headroom over that. */
+const SUBPROCESS_CEILING_MS = 90_000;
+
+function hasUserSystemd(): boolean {
+  if (process.platform !== 'linux') return false;
+  try {
+    // Cheapest probe that proves the user manager is answering. Deliberately
+    // capped well under the 10s the service code allows — a host this slow to
+    // answer is one where the integration assertions prove nothing anyway.
+    execSync('systemctl --user show --property=Version', { timeout: 5000, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const CAN_RUN = hasUserSystemd();
+
+describe('daemon-service against real systemd', () => {
+  let projectRoot: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'daemon-systemd-root-'));
+    homeDir = mkdtempSync(join(tmpdir(), 'daemon-systemd-home-'));
+    mkdirSync(join(projectRoot, '.moflo'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(!CAN_RUN)(
+    'installs and uninstalls through real systemctl without registering a unit',
+    () => {
+      const options = { platform: 'linux', homeDir } as const;
+
+      const install = installDaemonService(projectRoot, options);
+      expect(install.success).toBe(true);
+      expect(existsSync(install.servicePath!)).toBe(true);
+      expect(isDaemonInstalled(projectRoot, options)).toBe(true);
+
+      const unit = readFileSync(install.servicePath!, 'utf-8');
+      expect(unit).toContain('[Service]');
+      expect(unit).toContain(`WorkingDirectory=${projectRoot}`);
+
+      // The unit went to the sandboxed home, not the real config tree.
+      expect(install.servicePath!.startsWith(homeDir)).toBe(true);
+
+      const uninstall = uninstallDaemonService(projectRoot, options);
+      expect(uninstall.success).toBe(true);
+      expect(existsSync(install.servicePath!)).toBe(false);
+      expect(isDaemonInstalled(projectRoot, options)).toBe(false);
+    },
+    SUBPROCESS_CEILING_MS,
+  );
+
+  it.skipIf(!CAN_RUN)(
+    'leaves the real user systemd session untouched',
+    () => {
+      const options = { platform: 'linux', homeDir } as const;
+      const install = installDaemonService(projectRoot, options);
+      // Key on THIS run's unit name, not the `moflo-daemon-` prefix — a
+      // developer dogfooding moflo legitimately has a real unit registered for
+      // their own project, and asserting the prefix is absent would fail on
+      // their machine for the wrong reason.
+      const unitName = basename(install.servicePath!);
+
+      try {
+        const registered = execSync('systemctl --user list-unit-files --no-pager --no-legend', {
+          timeout: 10_000,
+          encoding: 'utf-8',
+        });
+        expect(registered).not.toContain(unitName);
+      } finally {
+        uninstallDaemonService(projectRoot, options);
+      }
+    },
+    SUBPROCESS_CEILING_MS,
+  );
+});


### PR DESCRIPTION
Closes #1412.

## The diagnosis

`daemon-service.test.ts` timed out intermittently under the full parallel suite and passed every time in isolation. That reads as contention noise, but it was **arithmetically unsatisfiable**: the tests are synchronous and look like pure filesystem work, yet `installDaemonService` shelled out to the real service manager with **10s** `execSync` timeouts — double vitest's **5s** per-test budget. `uninstallDaemonService` chains three such calls, so its worst case was 30s against a 5s allowance. A single slow `systemctl --user` could never be absorbed.

Raising the timeout, or moving the file to `isolationTests`, would have hidden the actual defect: unit tests invoking the host's service manager.

## The fix

Extract the process boundary behind an injectable `runCommand` defaulting to the real `execSync`, plus `platform` and `homeDir` injection. Unit tests now assert the commands that *would* be issued and never spawn a subprocess.

## The second bug: these tests were not sandboxed

`installDaemonService(tempDir)` redirected the unit-file write but **not** `systemctl --user enable/disable/stop`. Running the suite on a Linux workstation performed real service registration.

This was not theoretical. On the machine this was diagnosed on, **328 orphaned units** had accumulated in `~/.config/systemd/user` over three days of test runs — **all 328 symlinked into `default.target.wants`**, i.e. enabled. Each pointed at a deleted `/tmp` `WorkingDirectory` and carried `Restart=on-failure` / `RestartSec=10`, so on next login systemd would have tried to start 328 daemons that all fail and retry forever.

`homeDir` injection closes it. `XDG_CONFIG_HOME` is deliberately ignored when `homeDir` is set, so an ambient value cannot redirect the write back out of the sandbox.

## Rule #1: the platform injection exposed a latent cross-platform bug

The systemd unit name was derived with `dest.split('/').pop()`. Under NTFS that returns the **whole path**, so the Linux branch built a malformed `systemctl enable C:\...\unit.service` the moment it ran from a Windows host. Now `basename`, which binds to the host's separator flavor.

**CI could not have caught this.** `ci.yml` runs the unit suite on `ubuntu-latest` only; the three-OS matrices in `consumer-install-smoke` / `release-smoke` run the smoke harness, not vitest. The repo's only 3-OS vitest leg is the `native` job in `file-sync-smoke.yml`, so `daemon-service.test.ts` is added there — ~2s, and that job's `pull_request` trigger is deliberately unfiltered. The macOS and Windows branches previously had **no coverage on any host**.

## Consumer blast radius

`src/cli/services/daemon-service.ts` ships to every consumer via `dist/`. **No consumer-visible change and no publish round-trip required** — every new parameter is optional and the defaults reproduce prior behavior exactly (`execSync` runner, `homedir()`, `process.platform`, XDG precedence preserved when `homeDir` is absent). The one behavioral delta, `basename` vs `split('/')`, is identical on POSIX and the Linux branch is unreachable on Windows in production. Ships as `dist/src/cli/**/*.js` — no `shipped-scripts.json` entry (not a bin script), and the new system test does not ship (`npm pack --dry-run`: 0 `tests/system` entries).

## Verification

- **5 consecutive full-suite runs**: 10502 passed / 0 failed each, no timeout.
- **Sandboxing proven empirically**: 0 units in the real `~/.config/systemd/user` across 4 full-suite runs, where dozens accumulated per run before.
- All 5 acceptance criteria PASS (`/verify` record `verify:1412`).

One genuinely integration-level test is kept under `tests/system/`, gated on a responsive `systemctl --user` and given a 90s timeout that exceeds the sum of the inner subprocess budgets. It skips on CI (GitHub runners have no user session bus), which is stated in the file rather than implied to be covered.

## Also fixed here (found while verifying the above)

`file-sync-smoke.yml`'s `native` job named six test files but ran **four**. vitest'''s `exclude` wins over an explicitly named CLI path, and `vitest.config.ts` splices `isolationTests` into `exclude` — `bootstrap-sentinel-promotion.test.ts` and `launcher-854-fixes.test.ts` are both on that list, so they were silently skipped on every platform while the job exited 0. #976'''s B5 (sentinel write/read/clear) and B6 (upgrade-notice round-trip) went uncovered behind a green check.

`vitest.isolation.config.ts` carries no test `exclude` — it exists precisely for "the runner passes specific files" — so pointing these legs at it makes the named list authoritative. Locally: **4 files / 74 tests before, 6 files / 97 tests after**. Same one-flag fix applied to `release-smoke.yml`'''s copy of the leg, which also gains `daemon-service.test.ts` for parity.