### PR TITLE
fix(gate): sanitise shell data before matching gh pr create (#1410)

### DIFF
--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -963,6 +963,45 @@ function creditIsLive(flag, stored, scope) {
   return stored === now;
 }
 
+// #1410 — is this Bash command actually a `gh pr create` invocation? Delegates
+// to pr-create-command.cjs, which sanitises data regions (quotes, heredoc
+// bodies, comments) before looking for the command, so the gate neither misses
+// real invocations (newline-separated, piped, parenthesised) nor fires on
+// commands that merely quote the literal (`git commit -m "...gh pr create..."`).
+//
+// Fail-safe, in BOTH directions, because this runs on every Bash call in every
+// consumer. gate-hook.mjs maps a non-zero exit from this script to exit 2, so an
+// uncaught throw here does not degrade one gate — it blocks every Bash call the
+// consumer makes. So a load failure (partial `.claude/helpers` sync mid-upgrade,
+// hand-pruned install) AND a throw from the matcher itself both fall back to the
+// pre-#1410 regex: previous behaviour, not a wedged session.
+//
+// Not silent (#854, hook-authoring §4): the fallback path advises on stderr and
+// continues. If this ever fires it means the matcher crashed, which is worth
+// being loud about — and it cannot spam a healthy session, because a healthy
+// session never reaches it.
+var LEGACY_PR_CREATE_RE = /(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/;
+var prCreateMatcher = null;
+function isPrCreateCommand(cmd) {
+  if (prCreateMatcher === null) {
+    try {
+      prCreateMatcher = require('./pr-create-command.cjs').isPrCreateCommand;
+    } catch (e) {
+      prCreateMatcher = false;
+      process.stderr.write('moflo: pr-create-command.cjs unavailable (' + (e && e.message) + ') — PR gates fall back to the legacy matcher. Run `npx flo doctor --fix`.\n');
+    }
+    if (typeof prCreateMatcher !== 'function') prCreateMatcher = false;
+  }
+  if (prCreateMatcher) {
+    try {
+      return prCreateMatcher(cmd);
+    } catch (e) {
+      process.stderr.write('moflo: pr-create matcher threw (' + (e && e.message) + ') — falling back to the legacy matcher. Please report with the command that triggered it.\n');
+    }
+  }
+  return LEGACY_PR_CREATE_RE.test(cmd);
+}
+
 // Classifier-aware simplify gate skip. Returns a string reason if the gate
 // can be auto-passed, or null if /simplify must run. Uses simplify-classify.cjs
 // so the gate's "trivial" definition matches the skill's exactly.
@@ -1600,12 +1639,12 @@ switch (command) {
     break;
   }
   case 'check-before-pr': {
-    // Anchored to command-start (or chained via && / || / ;) so heredoc bodies
-    // and quoted strings that contain the literal "gh pr create" don't trip
-    // the gate during regular `git commit -m "...gh pr create..."` flows. The
-    // optional ENV=val prefix segment catches `GH_TOKEN=x gh pr create`.
+    // Anchored to command-start so heredoc bodies and quoted strings that
+    // contain the literal "gh pr create" don't trip the gate during regular
+    // `git commit -m "...gh pr create..."` flows, while still catching the
+    // chained, piped, parenthesised, and multi-line shapes (#1410).
     var cmd = process.env.TOOL_INPUT_command || '';
-    if (!/(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/.test(cmd)) break;
+    if (!isPrCreateCommand(cmd)) break;
     // #1374 — close the loop the TaskCreate reminder opens. Advisory: stdout,
     // no exit, and worded as a reminder, because a message may only claim to
     // block when it blocks (#1326). An open task list is a reporting failure,
@@ -1716,7 +1755,7 @@ switch (command) {
     // command (docs-only diffs are exempt, so this never blocks a docs PR).
     if (!config.verify_before_done) break;
     var cmd = process.env.TOOL_INPUT_command || '';
-    if (!/(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/.test(cmd)) break;
+    if (!isPrCreateCommand(cmd)) break;
     // No-source-files exemption — a docs-only / path-inert diff needs no verify.
     var changedD = getChangedFilesVsBase();
     if (changedD && changedD.length > 0) {

--- a/.claude/helpers/pr-create-command.cjs
+++ b/.claude/helpers/pr-create-command.cjs
@@ -1,0 +1,434 @@
+'use strict';
+
+/**
+ * Does this Bash command actually invoke `gh pr create`?
+ *
+ * Issue #1410. The gates in `gate.cjs` (`check-before-pr`, `check-before-done`)
+ * used to answer this with a single regex applied to raw command text:
+ *
+ *   /(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/
+ *
+ * That was wrong in both directions at once. It MISSED shapes people routinely
+ * type — a newline-separated multi-line command, `cat body.md | gh pr create
+ * --body-file -`, `( gh pr create )` — each of which opened a PR with every gate
+ * silently skipped. And it FIRED on commands that merely quote the literal — a
+ * `git commit -m "...gh pr create..."`, a `node -e '...'` probe, a heredoc body —
+ * blocking work that has nothing to do with opening a PR.
+ *
+ * One cause, both symptoms: a regex over raw text cannot tell a command from a
+ * string that quotes one. That is why the obvious repair (widen the separator
+ * set to include newline and `|`) makes the over-match strictly worse — every
+ * heredoc body line starting with the literal would become a match.
+ *
+ * So: two passes.
+ *
+ *   1. `sanitizeShellData` blanks the regions that are data rather than command
+ *      — comments, heredoc bodies, all quote flavours, escapes — replacing them
+ *      with spaces and PRESERVING LENGTH, so nothing outside a blanked region
+ *      shifts or merges.
+ *   2. `isPrCreateCommand` searches the sanitised text for the literal, then
+ *      walks BACKWARDS from each hit to confirm it starts a command.
+ *
+ * Four traps, three of which are silent BYPASSES (the gate stops blocking with
+ * no signal at all), are handled deliberately below and are marked `TRAP` at
+ * their sites:
+ *
+ *   - `<<<` is a herestring, not a heredoc. Reading it as a heredoc opener
+ *     means the delimiter is never found, the "body" blanks the rest of the
+ *     input, and a real invocation on the next line is swallowed.
+ *   - Heredoc headers are matched with a STICKY regex, never against a
+ *     fixed-size `slice(i, i + N)` window. A window truncates a bare delimiter
+ *     longer than it, registers the truncated prefix as the delimiter, and the
+ *     real terminator line then never matches — body blanks to EOF.
+ *   - `\` + newline is a line continuation, not a separator: the words after it
+ *     are arguments, and heredoc bodies queued on that line do not start there.
+ *   - Left-context stays OUT of the regex. `(?:^|[\n;&|(){}])\s*(?:NAME=val\s+)*gh…`
+ *     is quadratic on sanitised input (long runs of spaces that `\s*` consumes,
+ *     fails on, and backtracks through at every position). Searching for the
+ *     literal first and walking back by hand is flat.
+ *
+ * Mirrored verbatim into `.claude/helpers/pr-create-command.cjs` — the dogfood
+ * parity guard enforces byte-identity. Dependency-free CommonJS, `node:`
+ * builtins only (it uses none), so it loads from either location.
+ */
+
+/**
+ * Chars that can immediately precede a command word. `<` and `>` are absent on
+ * purpose: `> out.txt gh pr create` is a redirect target followed by arguments
+ * in the shapes we care about, not a fresh command.
+ *
+ * The backtick is present — and is deliberately NOT blanked as data the way
+ * quotes are. #1410's write-up lists backticks with the quote flavours, but an
+ * UNQUOTED backtick is command substitution: blanking it would make
+ * `` `gh pr create` `` stop blocking, i.e. exactly the silent-bypass class the
+ * issue is about. Backticks inside `"…"` are still blanked with the rest of the
+ * quoted run, which is where the over-match risk actually lives.
+ */
+var SEPARATOR_CHARS = '\n;&|(){}`';
+
+/**
+ * Words that may sit between a separator and the command without changing the
+ * fact that a command follows. Kept short and literal — anything not listed
+ * (e.g. `echo`) correctly makes the walk fail, because its following words are
+ * arguments, not a command.
+ */
+var PREFIX_WORDS = ['!', 'then', 'else', 'elif', 'do', 'time', 'command', 'builtin', 'exec', 'env', 'nohup', 'xargs', 'sudo'];
+
+/** `NAME=value` prefix, e.g. `GH_TOKEN=x gh pr create`. Bounded to one word. */
+var ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=\S*$/;
+
+/**
+ * Heredoc header, matched STICKY at a known index. Alternatives, in order:
+ * `'DELIM'`, `"DELIM"`, `$'DELIM'`, bare DELIM. The quoted forms come first so
+ * a quoted delimiter is never mis-read as a bare one starting with a quote.
+ */
+var HEREDOC_RE = /<<(-?)[ \t]*(?:'([^'\n]*)'|"([^"\n]*)"|\$'([^'\n]*)'|([^\s;&|<>()'"`]+))/y;
+
+/** The invocation itself. No left-context — see the fourth trap above. */
+var PR_CREATE_RE = /gh\s+pr\s+create\b/g;
+
+/**
+ * Pre-sanitise reject: `gh` as a whole token. A bare `indexOf('gh')` is far too
+ * weak — "gh" is a common English digraph, so `highlight`, `github`, `though`,
+ * and `flight` all fall through to the full two-pass scan on a hook that runs as
+ * a fresh process on every Bash call, at both gate call sites.
+ *
+ * Safe against false negatives: `PR_CREATE_RE` requires whitespace after `gh`,
+ * and sanitising only ever replaces characters with spaces — it never turns a
+ * non-word character into a word one — so a `gh` that survives to match here
+ * cannot have had a word character in front of it in the raw text.
+ *
+ * No quantifiers, so the scan is linear with no backtracking.
+ */
+var GH_TOKEN_RE = /(?:^|[^A-Za-z0-9_])gh(?![A-Za-z0-9_])/;
+
+/** Horizontal whitespace only. `\n` is a separator and must not be skipped as blank. */
+function isBlank(ch) {
+  return ch === ' ' || ch === '\t' || ch === '\r';
+}
+
+/** A `#` opens a comment only when it begins a word. */
+function startsWord(cmd, i) {
+  if (i === 0) return true;
+  var prev = cmd.charAt(i - 1);
+  return isBlank(prev) || prev === '\n' || SEPARATOR_CHARS.indexOf(prev) !== -1;
+}
+
+/**
+ * How deep `$(…)` inside `"…"` inside `$(…)` is followed before giving up and
+ * leaving the region blanked. Nothing real nests anywhere near this; the cap
+ * exists so a pathological input cannot recurse into a stack overflow.
+ */
+var MAX_SUBSTITUTION_DEPTH = 8;
+
+/**
+ * Replace every data region with spaces, preserving length. What remains is
+ * command text — the only thing safe to match a command against.
+ *
+ * Exported for tests: asserting on the sanitised string is how the blanking
+ * rules are pinned independently of the matcher on top of them.
+ *
+ * @param {string} cmd
+ * @param {number} [depth] internal — substitution recursion depth
+ * @returns {string} same length as `cmd`
+ */
+function sanitizeShellData(cmd, depth) {
+  var n = cmd.length;
+  var out = cmd.split('');
+  var pending = [];
+  var level = depth || 0;
+  var i = 0;
+
+  function blank(from, to) {
+    var stop = to > n ? n : to;
+    for (var k = from; k < stop; k++) out[k] = ' ';
+  }
+
+  /** Copy `raw`'s chars back into `out` at `from` — the inverse of `blank`. */
+  function restore(from, raw) {
+    for (var k = 0; k < raw.length; k++) out[from + k] = raw.charAt(k);
+  }
+
+  /** Scan a quoted run from `i` to its closing `close`, honouring `\` escapes if asked. */
+  function closingIndex(from, close, escapes) {
+    var j = from;
+    while (j < n) {
+      var ch = cmd.charAt(j);
+      if (escapes && ch === '\\') { j += 2; continue; }
+      if (ch === close) return j + 1;
+      j++;
+    }
+    return n;
+  }
+
+  /**
+   * Index of the `)` closing the `(` at `openIdx`, or -1 before `limit`.
+   * Skips quoted runs so a `)` inside a string doesn't close the substitution.
+   */
+  function matchingParen(openIdx, limit) {
+    var d = 0;
+    var k = openIdx;
+    while (k < limit) {
+      var ch = cmd.charAt(k);
+      if (ch === '\\') { k += 2; continue; }
+      if (ch === "'") { k = closingIndex(k + 1, "'", false); continue; }
+      if (ch === '"') { k = doubleQuoteEnd(k + 1); continue; }
+      if (ch === '(') d++;
+      else if (ch === ')') { d--; if (d === 0) return k; }
+      k++;
+    }
+    return -1;
+  }
+
+  /**
+   * Index just past the `"` that closes the run opened before `from`.
+   *
+   * Not `closingIndex(from, '"', true)`: quoting RESTARTS inside a command
+   * substitution, so in `"a $(cmd "b") c"` the quotes around `b` belong to the
+   * substitution and do not end the outer run. Scanning for the next unescaped
+   * `"` would cut the run short at `b`'s opening quote and leave the second half
+   * — including anything the substitution runs — mis-parsed.
+   *
+   * Mutually recursive with `matchingParen`; both only ever move forward, so the
+   * pair terminates.
+   */
+  function doubleQuoteEnd(from) {
+    var j = from;
+    while (j < n) {
+      var ch = cmd.charAt(j);
+      if (ch === '\\') { j += 2; continue; }
+      if (ch === '"') return j + 1;
+      if (ch === '$' && cmd.charAt(j + 1) === '(') {
+        var close = matchingParen(j + 1, n);
+        if (close !== -1) { j = close + 1; continue; }
+        j += 2;
+        continue;
+      }
+      if (ch === '`') {
+        var bt = cmd.indexOf('`', j + 1);
+        if (bt !== -1) { j = bt + 1; continue; }
+      }
+      j++;
+    }
+    return n;
+  }
+
+  /**
+   * A double-quoted run and an unquoted-delimiter heredoc body are data —
+   * EXCEPT for the command substitutions inside them, which the shell still
+   * runs. Blanking those wholesale would leave `echo "$(gh pr create)"` and its
+   * heredoc equivalent as silent bypasses, so restore each `$(…)` / `` `…` ``
+   * region over the already-blanked range: its delimiters (both of which the
+   * backwards walk reads as separators) plus its body, sanitised in its own
+   * right so quoting INSIDE the substitution still applies.
+   *
+   * `'…'`, `$'…'` and quoted-delimiter heredocs (`<<'EOF'`) are left blanked —
+   * the shell does not expand those, so there is nothing to restore.
+   */
+  function restoreSubstitutions(from, to) {
+    if (level >= MAX_SUBSTITUTION_DEPTH) return;
+    var k = from;
+    while (k < to) {
+      var ch = cmd.charAt(k);
+      if (ch === '\\') { k += 2; continue; }
+      var openLen = 0;
+      var close = -1;
+      if (ch === '$' && cmd.charAt(k + 1) === '(') {
+        openLen = 2;
+        close = matchingParen(k + 1, to);
+      } else if (ch === '`') {
+        openLen = 1;
+        close = cmd.indexOf('`', k + 1);
+        if (close >= to) close = -1;
+      }
+      if (close === -1) { k++; continue; }
+      restore(k, cmd.slice(k, k + openLen));
+      restore(close, cmd.charAt(close));
+      restore(k + openLen, sanitizeShellData(cmd.slice(k + openLen, close), level + 1));
+      k = close + 1;
+    }
+  }
+
+  /**
+   * Blank one heredoc body, starting at `start` (the first char of the line
+   * after the newline that ended the header's logical line).
+   *
+   * Blanks each body line's content and the terminator line's content, leaving
+   * every newline in place — so the text after the heredoc still begins after a
+   * real separator, and offsets outside the body are untouched.
+   *
+   * Returns the index to resume scanning from. An unterminated heredoc blanks to
+   * end of input, which is what the shell does with it too.
+   */
+  function blankHeredocBody(start, delim, stripTabs, expands) {
+    var pos = start;
+    while (pos < n) {
+      var eol = cmd.indexOf('\n', pos);
+      var lineEnd = eol === -1 ? n : eol;
+      var line = cmd.slice(pos, lineEnd);
+      // CRLF: the terminator is the line's content, not its line ending.
+      if (line.charAt(line.length - 1) === '\r') line = line.slice(0, -1);
+      var candidate = stripTabs ? line.replace(/^\t+/, '') : line;
+      blank(pos, lineEnd);
+      if (expands) restoreSubstitutions(pos, lineEnd);
+      if (candidate === delim) return eol === -1 ? n : eol + 1;
+      if (eol === -1) return n;
+      pos = eol + 1;
+    }
+    return n;
+  }
+
+  while (i < n) {
+    var c = cmd.charAt(i);
+
+    // TRAP: `\` + newline is a line continuation. Blanking BOTH characters keeps
+    // the logical line going, so the words after it stay arguments — otherwise
+    // `cat <<EOF \` + newline + `gh pr create` reads as a command when the shell
+    // reads it as arguments to `cat`. Any other `\x` is an escape; blanking the
+    // pair likewise stops `\;` and friends from reading as separators.
+    if (c === '\\') {
+      blank(i, i + 2);
+      i += 2;
+      continue;
+    }
+
+    if (c === '#' && startsWord(cmd, i)) {
+      var eol = cmd.indexOf('\n', i);
+      if (eol === -1) eol = n;
+      blank(i, eol);
+      i = eol;
+      continue;
+    }
+
+    if (c === '<' && cmd.charAt(i + 1) === '<') {
+      // TRAP: `<<<` is a herestring. Skip the operator — its word is handled by
+      // the ordinary quote/plain-text rules below.
+      if (cmd.charAt(i + 2) === '<') { i += 3; continue; }
+      // TRAP: sticky match at `i`, no window, no substring copy.
+      HEREDOC_RE.lastIndex = i;
+      var h = HEREDOC_RE.exec(cmd);
+      if (h) {
+        var delim = h[2] !== undefined ? h[2] : h[3] !== undefined ? h[3] : h[4] !== undefined ? h[4] : h[5];
+        // A BARE delimiter (`<<EOF`) expands `$(…)` in the body; any quoted form
+        // (`<<'EOF'`, `<<"EOF"`, `<<$'EOF'`) suppresses expansion entirely.
+        pending.push({ delim: delim, stripTabs: h[1] === '-', expands: h[5] !== undefined });
+        blank(i, i + h[0].length);
+        i += h[0].length;
+        continue;
+      }
+      // Not a header we recognise (`<< ;`, `<<` at end of input) — treat as text.
+      i += 2;
+      continue;
+    }
+
+    // `$'...'` processes `\` escapes; plain `'...'` does not.
+    if (c === '$' && cmd.charAt(i + 1) === "'") {
+      var ansiEnd = closingIndex(i + 2, "'", true);
+      blank(i, ansiEnd);
+      i = ansiEnd;
+      continue;
+    }
+
+    if (c === "'") {
+      var sqEnd = closingIndex(i + 1, "'", false);
+      blank(i, sqEnd);
+      i = sqEnd;
+      continue;
+    }
+
+    if (c === '"') {
+      var dqEnd = doubleQuoteEnd(i + 1);
+      blank(i, dqEnd);
+      // Substitutions inside the run still execute — see restoreSubstitutions.
+      restoreSubstitutions(i + 1, dqEnd - 1);
+      i = dqEnd;
+      continue;
+    }
+
+    if (c === '\n') {
+      i++;
+      // Bodies for every heredoc announced on the logical line just ended, in
+      // the order they were announced (`cat <<A <<B` reads A's body then B's).
+      while (pending.length > 0) {
+        var hd = pending.shift();
+        i = blankHeredocBody(i, hd.delim, hd.stripTabs, hd.expands);
+      }
+      continue;
+    }
+
+    i++;
+  }
+
+  return out.join('');
+}
+
+/**
+ * Does the token at `idx` in sanitised text `s` begin a command? True when what
+ * precedes it is the start of input, a separator, or a run of `NAME=value` /
+ * command-prefix words that itself bottoms out at one of those.
+ */
+function startsCommand(s, idx) {
+  // The hit must be the whole command word. `PR_CREATE_RE` carries no leading
+  // `\b`, so it can land mid-token — and the backwards walk below would then
+  // read a TRUNCATED prefix as a command prefix: `dogh pr create` yields `do`,
+  // which is in PREFIX_WORDS, and `FOO=bargh pr create` yields `FOO=bar`, which
+  // matches ASSIGNMENT_RE. Both are one unrelated token; both used to over-match.
+  //
+  // A leading `\b` would not fix it on its own — `\b` admits `=`, so the command
+  // in `FOO=gh pr create` (which is `pr`, not `gh`) would still walk back over
+  // `FOO=` and report a command start.
+  //
+  // Checking the whole token rather than just the character before it also keeps
+  // an invocation BY PATH working: `/usr/bin/gh pr create`, `./gh pr create`, and
+  // on Windows `C:/tools/gh` or `/c/tools/gh` — the forms that are valid command
+  // words for the shell the Bash tool runs.
+  //
+  // Only `/` is accepted as the separator, deliberately. A `\` is an ESCAPE here
+  // and is blanked in pass 1, so it can never reach this token; accepting it too
+  // would be unreachable code. The cost is that a backslash-escaped invocation
+  // (`C:\tools\gh`, or `\gh`) is not recognised — a miss, not an over-block, and
+  // the same miss the pre-#1410 regex had. Blanking the escape is what makes
+  // `echo a\; gh pr create` correctly NOT read as a command, which is worth more.
+  var tokenStart = idx;
+  while (tokenStart > 0 && !isBlank(s.charAt(tokenStart - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(tokenStart - 1)) === -1) tokenStart--;
+  var token = s.slice(tokenStart, idx + 2);
+  if (token !== 'gh' && !/\/gh$/.test(token)) return false;
+
+  var i = tokenStart;
+  for (;;) {
+    while (i > 0 && isBlank(s.charAt(i - 1))) i--;
+    if (i === 0) return true;
+    if (SEPARATOR_CHARS.indexOf(s.charAt(i - 1)) !== -1) return true;
+    var end = i;
+    while (i > 0 && !isBlank(s.charAt(i - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(i - 1)) === -1) i--;
+    if (i === end) return false;
+    var word = s.slice(i, end);
+    if (!ASSIGNMENT_RE.test(word) && PREFIX_WORDS.indexOf(word) === -1) return false;
+  }
+}
+
+/**
+ * True when `cmd` invokes `gh pr create` as a command — not when it merely
+ * contains those words inside a string, comment, or heredoc body.
+ *
+ * @param {string} cmd raw Bash command text (Claude Code's `tool_input.command`)
+ * @returns {boolean}
+ */
+function isPrCreateCommand(cmd) {
+  // Fast reject before sanitising. These gates run on EVERY Bash call, and a
+  // large non-`gh` command would otherwise pay the full two-pass cost. `indexOf`
+  // first because it is the cheapest possible screen; the token check then
+  // discards the digraph false positives (`highlight`, `github`, `though`) that
+  // `indexOf` alone lets through.
+  if (typeof cmd !== 'string' || cmd.indexOf('gh') === -1) return false;
+  if (!GH_TOKEN_RE.test(cmd)) return false;
+  var s = sanitizeShellData(cmd);
+  PR_CREATE_RE.lastIndex = 0;
+  var m;
+  while ((m = PR_CREATE_RE.exec(s)) !== null) {
+    if (startsCommand(s, m.index)) return true;
+  }
+  return false;
+}
+
+module.exports = { isPrCreateCommand: isPrCreateCommand, sanitizeShellData: sanitizeShellData };

--- a/.claude/helpers/pr-create-command.cjs
+++ b/.claude/helpers/pr-create-command.cjs
@@ -111,7 +111,14 @@ function isBlank(ch) {
 function startsWord(cmd, i) {
   if (i === 0) return true;
   var prev = cmd.charAt(i - 1);
-  return isBlank(prev) || prev === '\n' || SEPARATOR_CHARS.indexOf(prev) !== -1;
+  return isBlank(prev) || SEPARATOR_CHARS.indexOf(prev) !== -1;
+}
+
+/** Index of the first character of the whitespace/separator-delimited token containing `from`. */
+function tokenStartAt(s, from) {
+  var k = from;
+  while (k > 0 && !isBlank(s.charAt(k - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(k - 1)) === -1) k--;
+  return k;
 }
 
 /**
@@ -389,8 +396,7 @@ function startsCommand(s, idx) {
   // (`C:\tools\gh`, or `\gh`) is not recognised — a miss, not an over-block, and
   // the same miss the pre-#1410 regex had. Blanking the escape is what makes
   // `echo a\; gh pr create` correctly NOT read as a command, which is worth more.
-  var tokenStart = idx;
-  while (tokenStart > 0 && !isBlank(s.charAt(tokenStart - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(tokenStart - 1)) === -1) tokenStart--;
+  var tokenStart = tokenStartAt(s, idx);
   var token = s.slice(tokenStart, idx + 2);
   if (token !== 'gh' && !/\/gh$/.test(token)) return false;
 
@@ -400,7 +406,7 @@ function startsCommand(s, idx) {
     if (i === 0) return true;
     if (SEPARATOR_CHARS.indexOf(s.charAt(i - 1)) !== -1) return true;
     var end = i;
-    while (i > 0 && !isBlank(s.charAt(i - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(i - 1)) === -1) i--;
+    i = tokenStartAt(s, i);
     if (i === end) return false;
     var word = s.slice(i, end);
     if (!ASSIGNMENT_RE.test(word) && PREFIX_WORDS.indexOf(word) === -1) return false;

--- a/.claude/scripts/lib/shipped-scripts.json
+++ b/.claude/scripts/lib/shipped-scripts.json
@@ -22,7 +22,8 @@
     "gate-hook.mjs",
     "prompt-hook.mjs",
     "hook-handler.cjs",
-    "simplify-classify.cjs"
+    "simplify-classify.cjs",
+    "pr-create-command.cjs"
   ],
   "sourceHelperFiles": [
     "auto-memory-hook.mjs",

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -963,6 +963,45 @@ function creditIsLive(flag, stored, scope) {
   return stored === now;
 }
 
+// #1410 — is this Bash command actually a `gh pr create` invocation? Delegates
+// to pr-create-command.cjs, which sanitises data regions (quotes, heredoc
+// bodies, comments) before looking for the command, so the gate neither misses
+// real invocations (newline-separated, piped, parenthesised) nor fires on
+// commands that merely quote the literal (`git commit -m "...gh pr create..."`).
+//
+// Fail-safe, in BOTH directions, because this runs on every Bash call in every
+// consumer. gate-hook.mjs maps a non-zero exit from this script to exit 2, so an
+// uncaught throw here does not degrade one gate — it blocks every Bash call the
+// consumer makes. So a load failure (partial `.claude/helpers` sync mid-upgrade,
+// hand-pruned install) AND a throw from the matcher itself both fall back to the
+// pre-#1410 regex: previous behaviour, not a wedged session.
+//
+// Not silent (#854, hook-authoring §4): the fallback path advises on stderr and
+// continues. If this ever fires it means the matcher crashed, which is worth
+// being loud about — and it cannot spam a healthy session, because a healthy
+// session never reaches it.
+var LEGACY_PR_CREATE_RE = /(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/;
+var prCreateMatcher = null;
+function isPrCreateCommand(cmd) {
+  if (prCreateMatcher === null) {
+    try {
+      prCreateMatcher = require('./pr-create-command.cjs').isPrCreateCommand;
+    } catch (e) {
+      prCreateMatcher = false;
+      process.stderr.write('moflo: pr-create-command.cjs unavailable (' + (e && e.message) + ') — PR gates fall back to the legacy matcher. Run `npx flo doctor --fix`.\n');
+    }
+    if (typeof prCreateMatcher !== 'function') prCreateMatcher = false;
+  }
+  if (prCreateMatcher) {
+    try {
+      return prCreateMatcher(cmd);
+    } catch (e) {
+      process.stderr.write('moflo: pr-create matcher threw (' + (e && e.message) + ') — falling back to the legacy matcher. Please report with the command that triggered it.\n');
+    }
+  }
+  return LEGACY_PR_CREATE_RE.test(cmd);
+}
+
 // Classifier-aware simplify gate skip. Returns a string reason if the gate
 // can be auto-passed, or null if /simplify must run. Uses simplify-classify.cjs
 // so the gate's "trivial" definition matches the skill's exactly.
@@ -1600,12 +1639,12 @@ switch (command) {
     break;
   }
   case 'check-before-pr': {
-    // Anchored to command-start (or chained via && / || / ;) so heredoc bodies
-    // and quoted strings that contain the literal "gh pr create" don't trip
-    // the gate during regular `git commit -m "...gh pr create..."` flows. The
-    // optional ENV=val prefix segment catches `GH_TOKEN=x gh pr create`.
+    // Anchored to command-start so heredoc bodies and quoted strings that
+    // contain the literal "gh pr create" don't trip the gate during regular
+    // `git commit -m "...gh pr create..."` flows, while still catching the
+    // chained, piped, parenthesised, and multi-line shapes (#1410).
     var cmd = process.env.TOOL_INPUT_command || '';
-    if (!/(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/.test(cmd)) break;
+    if (!isPrCreateCommand(cmd)) break;
     // #1374 — close the loop the TaskCreate reminder opens. Advisory: stdout,
     // no exit, and worded as a reminder, because a message may only claim to
     // block when it blocks (#1326). An open task list is a reporting failure,
@@ -1716,7 +1755,7 @@ switch (command) {
     // command (docs-only diffs are exempt, so this never blocks a docs PR).
     if (!config.verify_before_done) break;
     var cmd = process.env.TOOL_INPUT_command || '';
-    if (!/(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/.test(cmd)) break;
+    if (!isPrCreateCommand(cmd)) break;
     // No-source-files exemption — a docs-only / path-inert diff needs no verify.
     var changedD = getChangedFilesVsBase();
     if (changedD && changedD.length > 0) {

--- a/bin/lib/shipped-scripts.json
+++ b/bin/lib/shipped-scripts.json
@@ -22,7 +22,8 @@
     "gate-hook.mjs",
     "prompt-hook.mjs",
     "hook-handler.cjs",
-    "simplify-classify.cjs"
+    "simplify-classify.cjs",
+    "pr-create-command.cjs"
   ],
   "sourceHelperFiles": [
     "auto-memory-hook.mjs",

--- a/bin/pr-create-command.cjs
+++ b/bin/pr-create-command.cjs
@@ -1,0 +1,434 @@
+'use strict';
+
+/**
+ * Does this Bash command actually invoke `gh pr create`?
+ *
+ * Issue #1410. The gates in `gate.cjs` (`check-before-pr`, `check-before-done`)
+ * used to answer this with a single regex applied to raw command text:
+ *
+ *   /(?:^|&&\s*|\|\|\s*|;\s*)\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*gh\s+pr\s+create\b/
+ *
+ * That was wrong in both directions at once. It MISSED shapes people routinely
+ * type — a newline-separated multi-line command, `cat body.md | gh pr create
+ * --body-file -`, `( gh pr create )` — each of which opened a PR with every gate
+ * silently skipped. And it FIRED on commands that merely quote the literal — a
+ * `git commit -m "...gh pr create..."`, a `node -e '...'` probe, a heredoc body —
+ * blocking work that has nothing to do with opening a PR.
+ *
+ * One cause, both symptoms: a regex over raw text cannot tell a command from a
+ * string that quotes one. That is why the obvious repair (widen the separator
+ * set to include newline and `|`) makes the over-match strictly worse — every
+ * heredoc body line starting with the literal would become a match.
+ *
+ * So: two passes.
+ *
+ *   1. `sanitizeShellData` blanks the regions that are data rather than command
+ *      — comments, heredoc bodies, all quote flavours, escapes — replacing them
+ *      with spaces and PRESERVING LENGTH, so nothing outside a blanked region
+ *      shifts or merges.
+ *   2. `isPrCreateCommand` searches the sanitised text for the literal, then
+ *      walks BACKWARDS from each hit to confirm it starts a command.
+ *
+ * Four traps, three of which are silent BYPASSES (the gate stops blocking with
+ * no signal at all), are handled deliberately below and are marked `TRAP` at
+ * their sites:
+ *
+ *   - `<<<` is a herestring, not a heredoc. Reading it as a heredoc opener
+ *     means the delimiter is never found, the "body" blanks the rest of the
+ *     input, and a real invocation on the next line is swallowed.
+ *   - Heredoc headers are matched with a STICKY regex, never against a
+ *     fixed-size `slice(i, i + N)` window. A window truncates a bare delimiter
+ *     longer than it, registers the truncated prefix as the delimiter, and the
+ *     real terminator line then never matches — body blanks to EOF.
+ *   - `\` + newline is a line continuation, not a separator: the words after it
+ *     are arguments, and heredoc bodies queued on that line do not start there.
+ *   - Left-context stays OUT of the regex. `(?:^|[\n;&|(){}])\s*(?:NAME=val\s+)*gh…`
+ *     is quadratic on sanitised input (long runs of spaces that `\s*` consumes,
+ *     fails on, and backtracks through at every position). Searching for the
+ *     literal first and walking back by hand is flat.
+ *
+ * Mirrored verbatim into `.claude/helpers/pr-create-command.cjs` — the dogfood
+ * parity guard enforces byte-identity. Dependency-free CommonJS, `node:`
+ * builtins only (it uses none), so it loads from either location.
+ */
+
+/**
+ * Chars that can immediately precede a command word. `<` and `>` are absent on
+ * purpose: `> out.txt gh pr create` is a redirect target followed by arguments
+ * in the shapes we care about, not a fresh command.
+ *
+ * The backtick is present — and is deliberately NOT blanked as data the way
+ * quotes are. #1410's write-up lists backticks with the quote flavours, but an
+ * UNQUOTED backtick is command substitution: blanking it would make
+ * `` `gh pr create` `` stop blocking, i.e. exactly the silent-bypass class the
+ * issue is about. Backticks inside `"…"` are still blanked with the rest of the
+ * quoted run, which is where the over-match risk actually lives.
+ */
+var SEPARATOR_CHARS = '\n;&|(){}`';
+
+/**
+ * Words that may sit between a separator and the command without changing the
+ * fact that a command follows. Kept short and literal — anything not listed
+ * (e.g. `echo`) correctly makes the walk fail, because its following words are
+ * arguments, not a command.
+ */
+var PREFIX_WORDS = ['!', 'then', 'else', 'elif', 'do', 'time', 'command', 'builtin', 'exec', 'env', 'nohup', 'xargs', 'sudo'];
+
+/** `NAME=value` prefix, e.g. `GH_TOKEN=x gh pr create`. Bounded to one word. */
+var ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=\S*$/;
+
+/**
+ * Heredoc header, matched STICKY at a known index. Alternatives, in order:
+ * `'DELIM'`, `"DELIM"`, `$'DELIM'`, bare DELIM. The quoted forms come first so
+ * a quoted delimiter is never mis-read as a bare one starting with a quote.
+ */
+var HEREDOC_RE = /<<(-?)[ \t]*(?:'([^'\n]*)'|"([^"\n]*)"|\$'([^'\n]*)'|([^\s;&|<>()'"`]+))/y;
+
+/** The invocation itself. No left-context — see the fourth trap above. */
+var PR_CREATE_RE = /gh\s+pr\s+create\b/g;
+
+/**
+ * Pre-sanitise reject: `gh` as a whole token. A bare `indexOf('gh')` is far too
+ * weak — "gh" is a common English digraph, so `highlight`, `github`, `though`,
+ * and `flight` all fall through to the full two-pass scan on a hook that runs as
+ * a fresh process on every Bash call, at both gate call sites.
+ *
+ * Safe against false negatives: `PR_CREATE_RE` requires whitespace after `gh`,
+ * and sanitising only ever replaces characters with spaces — it never turns a
+ * non-word character into a word one — so a `gh` that survives to match here
+ * cannot have had a word character in front of it in the raw text.
+ *
+ * No quantifiers, so the scan is linear with no backtracking.
+ */
+var GH_TOKEN_RE = /(?:^|[^A-Za-z0-9_])gh(?![A-Za-z0-9_])/;
+
+/** Horizontal whitespace only. `\n` is a separator and must not be skipped as blank. */
+function isBlank(ch) {
+  return ch === ' ' || ch === '\t' || ch === '\r';
+}
+
+/** A `#` opens a comment only when it begins a word. */
+function startsWord(cmd, i) {
+  if (i === 0) return true;
+  var prev = cmd.charAt(i - 1);
+  return isBlank(prev) || prev === '\n' || SEPARATOR_CHARS.indexOf(prev) !== -1;
+}
+
+/**
+ * How deep `$(…)` inside `"…"` inside `$(…)` is followed before giving up and
+ * leaving the region blanked. Nothing real nests anywhere near this; the cap
+ * exists so a pathological input cannot recurse into a stack overflow.
+ */
+var MAX_SUBSTITUTION_DEPTH = 8;
+
+/**
+ * Replace every data region with spaces, preserving length. What remains is
+ * command text — the only thing safe to match a command against.
+ *
+ * Exported for tests: asserting on the sanitised string is how the blanking
+ * rules are pinned independently of the matcher on top of them.
+ *
+ * @param {string} cmd
+ * @param {number} [depth] internal — substitution recursion depth
+ * @returns {string} same length as `cmd`
+ */
+function sanitizeShellData(cmd, depth) {
+  var n = cmd.length;
+  var out = cmd.split('');
+  var pending = [];
+  var level = depth || 0;
+  var i = 0;
+
+  function blank(from, to) {
+    var stop = to > n ? n : to;
+    for (var k = from; k < stop; k++) out[k] = ' ';
+  }
+
+  /** Copy `raw`'s chars back into `out` at `from` — the inverse of `blank`. */
+  function restore(from, raw) {
+    for (var k = 0; k < raw.length; k++) out[from + k] = raw.charAt(k);
+  }
+
+  /** Scan a quoted run from `i` to its closing `close`, honouring `\` escapes if asked. */
+  function closingIndex(from, close, escapes) {
+    var j = from;
+    while (j < n) {
+      var ch = cmd.charAt(j);
+      if (escapes && ch === '\\') { j += 2; continue; }
+      if (ch === close) return j + 1;
+      j++;
+    }
+    return n;
+  }
+
+  /**
+   * Index of the `)` closing the `(` at `openIdx`, or -1 before `limit`.
+   * Skips quoted runs so a `)` inside a string doesn't close the substitution.
+   */
+  function matchingParen(openIdx, limit) {
+    var d = 0;
+    var k = openIdx;
+    while (k < limit) {
+      var ch = cmd.charAt(k);
+      if (ch === '\\') { k += 2; continue; }
+      if (ch === "'") { k = closingIndex(k + 1, "'", false); continue; }
+      if (ch === '"') { k = doubleQuoteEnd(k + 1); continue; }
+      if (ch === '(') d++;
+      else if (ch === ')') { d--; if (d === 0) return k; }
+      k++;
+    }
+    return -1;
+  }
+
+  /**
+   * Index just past the `"` that closes the run opened before `from`.
+   *
+   * Not `closingIndex(from, '"', true)`: quoting RESTARTS inside a command
+   * substitution, so in `"a $(cmd "b") c"` the quotes around `b` belong to the
+   * substitution and do not end the outer run. Scanning for the next unescaped
+   * `"` would cut the run short at `b`'s opening quote and leave the second half
+   * — including anything the substitution runs — mis-parsed.
+   *
+   * Mutually recursive with `matchingParen`; both only ever move forward, so the
+   * pair terminates.
+   */
+  function doubleQuoteEnd(from) {
+    var j = from;
+    while (j < n) {
+      var ch = cmd.charAt(j);
+      if (ch === '\\') { j += 2; continue; }
+      if (ch === '"') return j + 1;
+      if (ch === '$' && cmd.charAt(j + 1) === '(') {
+        var close = matchingParen(j + 1, n);
+        if (close !== -1) { j = close + 1; continue; }
+        j += 2;
+        continue;
+      }
+      if (ch === '`') {
+        var bt = cmd.indexOf('`', j + 1);
+        if (bt !== -1) { j = bt + 1; continue; }
+      }
+      j++;
+    }
+    return n;
+  }
+
+  /**
+   * A double-quoted run and an unquoted-delimiter heredoc body are data —
+   * EXCEPT for the command substitutions inside them, which the shell still
+   * runs. Blanking those wholesale would leave `echo "$(gh pr create)"` and its
+   * heredoc equivalent as silent bypasses, so restore each `$(…)` / `` `…` ``
+   * region over the already-blanked range: its delimiters (both of which the
+   * backwards walk reads as separators) plus its body, sanitised in its own
+   * right so quoting INSIDE the substitution still applies.
+   *
+   * `'…'`, `$'…'` and quoted-delimiter heredocs (`<<'EOF'`) are left blanked —
+   * the shell does not expand those, so there is nothing to restore.
+   */
+  function restoreSubstitutions(from, to) {
+    if (level >= MAX_SUBSTITUTION_DEPTH) return;
+    var k = from;
+    while (k < to) {
+      var ch = cmd.charAt(k);
+      if (ch === '\\') { k += 2; continue; }
+      var openLen = 0;
+      var close = -1;
+      if (ch === '$' && cmd.charAt(k + 1) === '(') {
+        openLen = 2;
+        close = matchingParen(k + 1, to);
+      } else if (ch === '`') {
+        openLen = 1;
+        close = cmd.indexOf('`', k + 1);
+        if (close >= to) close = -1;
+      }
+      if (close === -1) { k++; continue; }
+      restore(k, cmd.slice(k, k + openLen));
+      restore(close, cmd.charAt(close));
+      restore(k + openLen, sanitizeShellData(cmd.slice(k + openLen, close), level + 1));
+      k = close + 1;
+    }
+  }
+
+  /**
+   * Blank one heredoc body, starting at `start` (the first char of the line
+   * after the newline that ended the header's logical line).
+   *
+   * Blanks each body line's content and the terminator line's content, leaving
+   * every newline in place — so the text after the heredoc still begins after a
+   * real separator, and offsets outside the body are untouched.
+   *
+   * Returns the index to resume scanning from. An unterminated heredoc blanks to
+   * end of input, which is what the shell does with it too.
+   */
+  function blankHeredocBody(start, delim, stripTabs, expands) {
+    var pos = start;
+    while (pos < n) {
+      var eol = cmd.indexOf('\n', pos);
+      var lineEnd = eol === -1 ? n : eol;
+      var line = cmd.slice(pos, lineEnd);
+      // CRLF: the terminator is the line's content, not its line ending.
+      if (line.charAt(line.length - 1) === '\r') line = line.slice(0, -1);
+      var candidate = stripTabs ? line.replace(/^\t+/, '') : line;
+      blank(pos, lineEnd);
+      if (expands) restoreSubstitutions(pos, lineEnd);
+      if (candidate === delim) return eol === -1 ? n : eol + 1;
+      if (eol === -1) return n;
+      pos = eol + 1;
+    }
+    return n;
+  }
+
+  while (i < n) {
+    var c = cmd.charAt(i);
+
+    // TRAP: `\` + newline is a line continuation. Blanking BOTH characters keeps
+    // the logical line going, so the words after it stay arguments — otherwise
+    // `cat <<EOF \` + newline + `gh pr create` reads as a command when the shell
+    // reads it as arguments to `cat`. Any other `\x` is an escape; blanking the
+    // pair likewise stops `\;` and friends from reading as separators.
+    if (c === '\\') {
+      blank(i, i + 2);
+      i += 2;
+      continue;
+    }
+
+    if (c === '#' && startsWord(cmd, i)) {
+      var eol = cmd.indexOf('\n', i);
+      if (eol === -1) eol = n;
+      blank(i, eol);
+      i = eol;
+      continue;
+    }
+
+    if (c === '<' && cmd.charAt(i + 1) === '<') {
+      // TRAP: `<<<` is a herestring. Skip the operator — its word is handled by
+      // the ordinary quote/plain-text rules below.
+      if (cmd.charAt(i + 2) === '<') { i += 3; continue; }
+      // TRAP: sticky match at `i`, no window, no substring copy.
+      HEREDOC_RE.lastIndex = i;
+      var h = HEREDOC_RE.exec(cmd);
+      if (h) {
+        var delim = h[2] !== undefined ? h[2] : h[3] !== undefined ? h[3] : h[4] !== undefined ? h[4] : h[5];
+        // A BARE delimiter (`<<EOF`) expands `$(…)` in the body; any quoted form
+        // (`<<'EOF'`, `<<"EOF"`, `<<$'EOF'`) suppresses expansion entirely.
+        pending.push({ delim: delim, stripTabs: h[1] === '-', expands: h[5] !== undefined });
+        blank(i, i + h[0].length);
+        i += h[0].length;
+        continue;
+      }
+      // Not a header we recognise (`<< ;`, `<<` at end of input) — treat as text.
+      i += 2;
+      continue;
+    }
+
+    // `$'...'` processes `\` escapes; plain `'...'` does not.
+    if (c === '$' && cmd.charAt(i + 1) === "'") {
+      var ansiEnd = closingIndex(i + 2, "'", true);
+      blank(i, ansiEnd);
+      i = ansiEnd;
+      continue;
+    }
+
+    if (c === "'") {
+      var sqEnd = closingIndex(i + 1, "'", false);
+      blank(i, sqEnd);
+      i = sqEnd;
+      continue;
+    }
+
+    if (c === '"') {
+      var dqEnd = doubleQuoteEnd(i + 1);
+      blank(i, dqEnd);
+      // Substitutions inside the run still execute — see restoreSubstitutions.
+      restoreSubstitutions(i + 1, dqEnd - 1);
+      i = dqEnd;
+      continue;
+    }
+
+    if (c === '\n') {
+      i++;
+      // Bodies for every heredoc announced on the logical line just ended, in
+      // the order they were announced (`cat <<A <<B` reads A's body then B's).
+      while (pending.length > 0) {
+        var hd = pending.shift();
+        i = blankHeredocBody(i, hd.delim, hd.stripTabs, hd.expands);
+      }
+      continue;
+    }
+
+    i++;
+  }
+
+  return out.join('');
+}
+
+/**
+ * Does the token at `idx` in sanitised text `s` begin a command? True when what
+ * precedes it is the start of input, a separator, or a run of `NAME=value` /
+ * command-prefix words that itself bottoms out at one of those.
+ */
+function startsCommand(s, idx) {
+  // The hit must be the whole command word. `PR_CREATE_RE` carries no leading
+  // `\b`, so it can land mid-token — and the backwards walk below would then
+  // read a TRUNCATED prefix as a command prefix: `dogh pr create` yields `do`,
+  // which is in PREFIX_WORDS, and `FOO=bargh pr create` yields `FOO=bar`, which
+  // matches ASSIGNMENT_RE. Both are one unrelated token; both used to over-match.
+  //
+  // A leading `\b` would not fix it on its own — `\b` admits `=`, so the command
+  // in `FOO=gh pr create` (which is `pr`, not `gh`) would still walk back over
+  // `FOO=` and report a command start.
+  //
+  // Checking the whole token rather than just the character before it also keeps
+  // an invocation BY PATH working: `/usr/bin/gh pr create`, `./gh pr create`, and
+  // on Windows `C:/tools/gh` or `/c/tools/gh` — the forms that are valid command
+  // words for the shell the Bash tool runs.
+  //
+  // Only `/` is accepted as the separator, deliberately. A `\` is an ESCAPE here
+  // and is blanked in pass 1, so it can never reach this token; accepting it too
+  // would be unreachable code. The cost is that a backslash-escaped invocation
+  // (`C:\tools\gh`, or `\gh`) is not recognised — a miss, not an over-block, and
+  // the same miss the pre-#1410 regex had. Blanking the escape is what makes
+  // `echo a\; gh pr create` correctly NOT read as a command, which is worth more.
+  var tokenStart = idx;
+  while (tokenStart > 0 && !isBlank(s.charAt(tokenStart - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(tokenStart - 1)) === -1) tokenStart--;
+  var token = s.slice(tokenStart, idx + 2);
+  if (token !== 'gh' && !/\/gh$/.test(token)) return false;
+
+  var i = tokenStart;
+  for (;;) {
+    while (i > 0 && isBlank(s.charAt(i - 1))) i--;
+    if (i === 0) return true;
+    if (SEPARATOR_CHARS.indexOf(s.charAt(i - 1)) !== -1) return true;
+    var end = i;
+    while (i > 0 && !isBlank(s.charAt(i - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(i - 1)) === -1) i--;
+    if (i === end) return false;
+    var word = s.slice(i, end);
+    if (!ASSIGNMENT_RE.test(word) && PREFIX_WORDS.indexOf(word) === -1) return false;
+  }
+}
+
+/**
+ * True when `cmd` invokes `gh pr create` as a command — not when it merely
+ * contains those words inside a string, comment, or heredoc body.
+ *
+ * @param {string} cmd raw Bash command text (Claude Code's `tool_input.command`)
+ * @returns {boolean}
+ */
+function isPrCreateCommand(cmd) {
+  // Fast reject before sanitising. These gates run on EVERY Bash call, and a
+  // large non-`gh` command would otherwise pay the full two-pass cost. `indexOf`
+  // first because it is the cheapest possible screen; the token check then
+  // discards the digraph false positives (`highlight`, `github`, `though`) that
+  // `indexOf` alone lets through.
+  if (typeof cmd !== 'string' || cmd.indexOf('gh') === -1) return false;
+  if (!GH_TOKEN_RE.test(cmd)) return false;
+  var s = sanitizeShellData(cmd);
+  PR_CREATE_RE.lastIndex = 0;
+  var m;
+  while ((m = PR_CREATE_RE.exec(s)) !== null) {
+    if (startsCommand(s, m.index)) return true;
+  }
+  return false;
+}
+
+module.exports = { isPrCreateCommand: isPrCreateCommand, sanitizeShellData: sanitizeShellData };

--- a/bin/pr-create-command.cjs
+++ b/bin/pr-create-command.cjs
@@ -111,7 +111,14 @@ function isBlank(ch) {
 function startsWord(cmd, i) {
   if (i === 0) return true;
   var prev = cmd.charAt(i - 1);
-  return isBlank(prev) || prev === '\n' || SEPARATOR_CHARS.indexOf(prev) !== -1;
+  return isBlank(prev) || SEPARATOR_CHARS.indexOf(prev) !== -1;
+}
+
+/** Index of the first character of the whitespace/separator-delimited token containing `from`. */
+function tokenStartAt(s, from) {
+  var k = from;
+  while (k > 0 && !isBlank(s.charAt(k - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(k - 1)) === -1) k--;
+  return k;
 }
 
 /**
@@ -389,8 +396,7 @@ function startsCommand(s, idx) {
   // (`C:\tools\gh`, or `\gh`) is not recognised — a miss, not an over-block, and
   // the same miss the pre-#1410 regex had. Blanking the escape is what makes
   // `echo a\; gh pr create` correctly NOT read as a command, which is worth more.
-  var tokenStart = idx;
-  while (tokenStart > 0 && !isBlank(s.charAt(tokenStart - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(tokenStart - 1)) === -1) tokenStart--;
+  var tokenStart = tokenStartAt(s, idx);
   var token = s.slice(tokenStart, idx + 2);
   if (token !== 'gh' && !/\/gh$/.test(token)) return false;
 
@@ -400,7 +406,7 @@ function startsCommand(s, idx) {
     if (i === 0) return true;
     if (SEPARATOR_CHARS.indexOf(s.charAt(i - 1)) !== -1) return true;
     var end = i;
-    while (i > 0 && !isBlank(s.charAt(i - 1)) && SEPARATOR_CHARS.indexOf(s.charAt(i - 1)) === -1) i--;
+    i = tokenStartAt(s, i);
     if (i === end) return false;
     var word = s.slice(i, end);
     if (!ASSIGNMENT_RE.test(word) && PREFIX_WORDS.indexOf(word) === -1) return false;

--- a/tests/bin/gate-pr-create-matcher-1410.test.ts
+++ b/tests/bin/gate-pr-create-matcher-1410.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Gate-boundary tests for the #1410 PR-create matcher.
+ *
+ * pr-create-command.test.ts proves the matcher. This proves the GATES USE IT —
+ * a distinction that matters here because the old regex was duplicated at two
+ * call sites (`check-before-pr` and `check-before-done`) and a fix applied to
+ * one of them would leave the other bypassable while every unit test stayed
+ * green. Each shape is therefore asserted at both gates.
+ *
+ * Blocking is the gate's only signal, so the two failure directions are:
+ *   - a real invocation that exits 0 → PR opens with every gate skipped, silently
+ *   - quoted text that exits 2      → unrelated work is blocked
+ *
+ * Runs the real `bin/gate.cjs` as a subprocess with no credits earned, which is
+ * the state a genuine PR-create attempt has to be refused from.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, copyFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const GATE = resolve(REPO_ROOT, 'bin/gate.cjs');
+const MATCHER = resolve(REPO_ROOT, 'bin/pr-create-command.cjs');
+
+let root: string;
+
+/** Run a gate script the way the hook bridge does: subcommand + TOOL_INPUT_* env. */
+function runGate(script: string, sub: string, command: string) {
+  const r = spawnSync(process.execPath, [script, sub], {
+    cwd: root,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, TOOL_INPUT_command: command },
+  });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+const gate = (sub: string, command: string) => runGate(GATE, sub, command);
+
+function git(...args: string[]) {
+  const r = spawnSync('git', args, { cwd: root, encoding: 'utf-8', timeout: 30_000 });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout;
+}
+
+const lines = (...l: string[]): string => l.join('\n');
+
+beforeEach(() => {
+  // Under the repo, not os.tmpdir(): isEphemeralPath exempts tmp-rooted projects
+  // from gate behaviour these assertions depend on (#1348).
+  root = resolve(REPO_ROOT, '.testoutput', `gate-1410-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'pr-matcher-test', version: '0.0.0' }));
+  writeFileSync(join(root, 'src.js'), 'export const safe = 1;\n');
+  git('init', '-q', '.');
+  git('config', 'user.email', 't@t.t');
+  git('config', 'user.name', 't');
+  git('add', '-A');
+  git('commit', '-qm', 'init');
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows may hold handles — non-fatal */
+  }
+});
+
+/** Shapes that open a PR: both gates must refuse them with no credit earned. */
+const MUST_BLOCK: Array<[string, string]> = [
+  ['chained (worked before #1410)', 'cd /repo && gh pr create --fill'],
+  ['newline-separated', lines('cd /repo', 'gh pr create --fill')],
+  ['piped body file', 'cat body.md | gh pr create --body-file -'],
+  ['parenthesised subshell', '( gh pr create --fill )'],
+  ['heredoc-fed body', lines('gh pr create --body-file - <<EOF', 'body text', 'EOF')],
+];
+
+/** Text that only quotes the literal: neither gate may block it. */
+const MUST_PASS: Array<[string, string]> = [
+  ['commit message', 'git commit -m "run cd /r && gh pr create next"'],
+  ['node -e probe', `node -e 'cd /r && gh pr create'`],
+  ['heredoc body', lines('cat <<EOF > notes.md', 'then cd /r && gh pr create', 'EOF')],
+  ['issue body describing the form', 'gh issue create --title x --body "use cd /r && gh pr create"'],
+];
+
+describe('check-before-pr uses the #1410 matcher', () => {
+  for (const [label, cmd] of MUST_BLOCK) {
+    it(`blocks: ${label}`, () => {
+      const r = gate('check-before-pr', cmd);
+      expect(r.stderr).toContain('BLOCKED');
+      expect(r.status).toBe(2);
+    });
+  }
+
+  for (const [label, cmd] of MUST_PASS) {
+    it(`does not block: ${label}`, () => {
+      const r = gate('check-before-pr', cmd);
+      expect(r.stderr).not.toContain('BLOCKED');
+      expect(r.status).toBe(0);
+    });
+  }
+});
+
+describe('check-before-done uses the #1410 matcher', () => {
+  // The second call site. It carried an identical copy of the old regex, so it
+  // is the one a single-site fix would leave behind.
+  for (const [label, cmd] of MUST_BLOCK) {
+    it(`blocks: ${label}`, () => {
+      const r = gate('check-before-done', cmd);
+      expect(r.stderr).toContain('BLOCKED');
+      expect(r.status).toBe(2);
+    });
+  }
+
+  for (const [label, cmd] of MUST_PASS) {
+    it(`does not block: ${label}`, () => {
+      const r = gate('check-before-done', cmd);
+      expect(r.stderr).not.toContain('BLOCKED');
+      expect(r.status).toBe(0);
+    });
+  }
+});
+
+describe('matcher module missing — degrades, never wedges', () => {
+  // gate-hook.mjs maps ANY non-zero exit from gate.cjs to exit 2, so an
+  // unhandled failure to load the sibling would not degrade one gate — it would
+  // block every Bash call the consumer makes. The window is real: a consumer
+  // upgrading picks up gate.cjs and pr-create-command.cjs in the same sync pass,
+  // and a pass that half-completes leaves exactly this state.
+  function gateWithoutMatcher(sub: string, command: string) {
+    const helpers = join(root, '.claude', 'helpers');
+    mkdirSync(helpers, { recursive: true });
+    const lone = join(helpers, 'gate.cjs');
+    copyFileSync(GATE, lone);
+    return runGate(lone, sub, command);
+  }
+
+  it('still refuses a PR-create command, via the legacy matcher', () => {
+    const r = gateWithoutMatcher('check-before-pr', 'cd /repo && gh pr create --fill');
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.status).toBe(2);
+  });
+
+  it('advises on stderr rather than failing silently', () => {
+    const r = gateWithoutMatcher('check-before-pr', 'cd /repo && gh pr create --fill');
+    expect(r.stderr).toContain('pr-create-command.cjs unavailable');
+    expect(r.stderr).toContain('flo doctor --fix');
+  });
+
+  it('does not block an ordinary command', () => {
+    const r = gateWithoutMatcher('check-before-pr', 'npm test');
+    expect(r.stderr).not.toContain('BLOCKED');
+    expect(r.status).toBe(0);
+  });
+
+  it('recovers once the sibling is present', () => {
+    const helpers = join(root, '.claude', 'helpers');
+    mkdirSync(helpers, { recursive: true });
+    copyFileSync(GATE, join(helpers, 'gate.cjs'));
+    copyFileSync(MATCHER, join(helpers, 'pr-create-command.cjs'));
+    // A shape only the new matcher catches — proof the sibling is the one answering.
+    const r = runGate(join(helpers, 'gate.cjs'), 'check-before-pr', lines('cd /repo', 'gh pr create --fill'));
+    expect(r.stderr).not.toContain('unavailable');
+    expect(r.stderr).toContain('BLOCKED');
+    expect(r.status).toBe(2);
+  });
+});
+
+describe('shipped copies stay in step', () => {
+  // gate.cjs ships from two places and the matcher now does too. The dogfood
+  // parity guard covers bin/ -> .claude/, this covers the manifest that makes
+  // the sync happen at all — without the entry, consumers get the new gate.cjs
+  // and no sibling, i.e. the degraded path above, forever.
+  it('lists the matcher in the shipped-scripts manifest', () => {
+    const manifest = JSON.parse(readFileSync(resolve(REPO_ROOT, 'bin/lib/shipped-scripts.json'), 'utf-8'));
+    expect(manifest.binHelperFiles).toContain('pr-create-command.cjs');
+  });
+
+  it('leaves no inline PR-create regex behind in either gate copy', () => {
+    for (const p of ['bin/gate.cjs', '.claude/helpers/gate.cjs']) {
+      const src = readFileSync(resolve(REPO_ROOT, p), 'utf-8');
+      // One occurrence only: the named legacy fallback constant.
+      const hits = src.match(/gh\\s\+pr\\s\+create/g) || [];
+      expect(hits, `${p} should reference the legacy regex exactly once`).toHaveLength(1);
+      expect(src).toContain('LEGACY_PR_CREATE_RE');
+      expect(src).toContain("require('./pr-create-command.cjs')");
+    }
+  });
+});

--- a/tests/bin/launcher-928-dogfood-skip.test.ts
+++ b/tests/bin/launcher-928-dogfood-skip.test.ts
@@ -85,6 +85,7 @@ function stageDriftScenario(root: string, pkgName: string) {
     'index-tests.mjs', 'index-patterns.mjs', 'index-reference.mjs', 'index-all.mjs',
     'setup-project.mjs', 'run-migrations.mjs', 'session-continuity.mjs',
     'gate-hook.mjs', 'prompt-hook.mjs', 'hook-handler.cjs', 'simplify-classify.cjs',
+    'pr-create-command.cjs',
   ]) {
     writeFileSync(join(nmDir, 'bin', f), '');
   }

--- a/tests/bin/pr-create-command.test.ts
+++ b/tests/bin/pr-create-command.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Unit tests for bin/pr-create-command.cjs — the `gh pr create` matcher behind
+ * the `check-before-pr` and `check-before-done` gates (issue #1410).
+ *
+ * The matcher it replaced was wrong in both directions at once, so every test
+ * here belongs to one of three groups and the file is organised that way:
+ *
+ *   - MATCHES     — shapes that open a PR. A miss here is a SILENT BYPASS: the
+ *                   gate's only signal is blocking, so nothing says it didn't run.
+ *   - NO MATCH    — text that merely quotes the literal. A hit here blocks work
+ *                   that has nothing to do with opening a PR.
+ *   - TRAPS       — the specific ways an "obvious" fix regresses. Three of the
+ *                   four are bypasses introduced *while* fixing the original bug,
+ *                   which is why they get their own cases rather than being
+ *                   folded into the two groups above.
+ *
+ * In-process `require` — no subprocess per case, so the matrix stays cheap.
+ * The gate-boundary behaviour (that the hook actually blocks/passes on these
+ * shapes) is covered separately in gate-pr-create-matcher-1410.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { isPrCreateCommand, sanitizeShellData } from '../../bin/pr-create-command.cjs';
+
+/** Readable multi-line fixtures without leaning on template-literal indentation. */
+const lines = (...l: string[]): string => l.join('\n');
+
+// ── Shapes that DO open a PR ─────────────────────────────────────────────────
+
+describe('pr-create-command: invocations that must match', () => {
+  const cases: Array<[string, string]> = [
+    ['bare', 'gh pr create'],
+    ['with flags', 'gh pr create --fill --base main'],
+    ['extra whitespace between words', 'gh   pr\t create --fill'],
+    ['indented', '    gh pr create --fill'],
+    ['&&-chained', 'cd /repo && gh pr create'],
+    ['||-chained', 'gh pr view || gh pr create'],
+    [';-chained', 'git add -A; gh pr create'],
+    ['env prefix', 'GH_TOKEN=x gh pr create'],
+    ['several env prefixes', 'GH_TOKEN=x GH_HOST=github.com gh pr create --fill'],
+    // The three shapes #1410 reported as missed outright.
+    ['newline-separated', lines('cd /repo', 'gh pr create --fill')],
+    ['piped body file', 'cat body.md | gh pr create --body-file -'],
+    ['parenthesised subshell', '( gh pr create )'],
+    // Neighbours of those three that the same repair has to cover.
+    ['brace group', '{ gh pr create; }'],
+    ['command substitution', 'echo $(gh pr create --fill)'],
+    ['backtick substitution', 'echo `gh pr create --fill`'],
+    ['negated', '! gh pr create'],
+    ['env(1) prefix', 'env GH_TOKEN=x gh pr create'],
+    ['CRLF-separated', 'cd /repo\r\ngh pr create --fill'],
+    ['continued onto the next line', lines('gh pr create \\', '  --fill --base main')],
+    ['heredoc body supplies the PR body', lines('gh pr create --body-file - <<EOF', 'some body', 'EOF')],
+    ['after a comment line', lines('# open the PR with gh pr create once tests pass', 'gh pr create --fill')],
+    ['after a completed heredoc', lines('cat <<EOF > body.md', 'run gh pr create when ready', 'EOF', 'gh pr create --body-file body.md')],
+    ['after a herestring line', lines('grep -q x <<<"$BODY"', 'gh pr create --fill')],
+    // Invocation by path. The token containing the hit is what's checked, so a
+    // path ending in the binary still reads as a command — a character-before
+    // check would reject all three of these.
+    ['absolute path', '/usr/local/bin/gh pr create --fill'],
+    ['relative path', './gh pr create --fill'],
+    ['path after a chain', 'cd /repo && /usr/bin/gh pr create'],
+    // Windows, in the forms that are actually valid command words for the shell
+    // the Bash tool runs. A bare `C:\tools\gh` is NOT one of them — there the
+    // backslashes are escapes, so the shell sees `C:toolsgh` and so do we.
+    ['Windows drive path with forward slashes', 'C:/tools/gh pr create --fill'],
+    ['Windows MSYS-style path', '/c/tools/gh pr create --fill'],
+  ];
+
+  for (const [label, cmd] of cases) {
+    it(`matches: ${label}`, () => {
+      expect(isPrCreateCommand(cmd)).toBe(true);
+    });
+  }
+});
+
+// ── Text that only quotes the literal ────────────────────────────────────────
+
+describe('pr-create-command: quoted text that must not match', () => {
+  const cases: Array<[string, string]> = [
+    // The two over-matches observed in real sessions.
+    ['commit message', 'git commit -m "run cd /r && gh pr create next"'],
+    ['node -e script string', `node -e 'const s = "cd /r && gh pr create"'`],
+    // Filing a ticket *about* the matcher was blocked by the matcher.
+    ['issue body describing the chained form', 'gh issue create --title x --body "use cd /r && gh pr create"'],
+    ['single-quoted grep pattern', `git log --grep 'gh pr create'`],
+    ["$'...' ANSI-C string", `printf $'cd /r && gh pr create\\n'`],
+    ['heredoc body', lines('cat <<EOF', 'cd /r && gh pr create', 'EOF')],
+    ['quoted-delimiter heredoc body', lines("cat <<'EOF'", 'cd /r && gh pr create', 'EOF')],
+    ['tab-stripped heredoc body', lines('cat <<-EOF', '\t\tgh pr create', '\tEOF')],
+    ['second of two heredocs on one line', lines('cat <<A <<B', 'foo', 'A', 'gh pr create', 'B')],
+    ['CRLF heredoc body', 'cat <<EOF\r\ngh pr create\r\nEOF\r\n'],
+    ['comment', '# gh pr create once the tests pass'],
+    ['trailing comment', 'git status  # then gh pr create'],
+    // A comment quoting the CHAINED form. Distinct from the two above: the `&&`
+    // inside it is a separator, so without comment blanking the backwards walk
+    // stops there and reports a command start. Mutation-confirmed — dropping
+    // comment blanking leaves the two cases above green and only this one red.
+    ['comment quoting the chained form', '# first cd /repo && gh pr create, then merge'],
+    // Single-quoted with no inner double quotes. The `node -e` case above stays
+    // green even without single-quote blanking, because its inner `"…"` gets
+    // blanked instead — this one has nothing to fall back on.
+    ['single-quoted chained form', `node -e 'cd /r && gh pr create'`],
+    // Near-misses on the command itself.
+    ['different subcommand', 'gh pr list --state open'],
+    ['longer word', 'gh pr createx'],
+    ['no space', 'ghpr create'],
+    ['argument to another command', 'echo gh pr create'],
+    ['argument to a two-word command', 'git config alias.x gh pr create'],
+    // The literal search carries no leading \b, so a hit can land MID-TOKEN. The
+    // backwards walk would then read a truncated prefix as a command prefix:
+    // `do` is in PREFIX_WORDS, `FOO=bar` matches ASSIGNMENT_RE. Both of these are
+    // one unrelated token, and both used to over-match.
+    ['mid-token hit whose prefix is a command keyword', 'dogh pr create'],
+    ['mid-token hit whose prefix looks like an assignment', 'FOO=bargh pr create'],
+    ['mid-token hit after other keywords', 'timegh pr create'],
+    // `gh` as an assignment VALUE — the command here is `pr`, not `gh`. A leading
+    // \b would admit this one, because `=` is a non-word character.
+    ['gh as an assignment value', 'FOO=gh pr create'],
+  ];
+
+  for (const [label, cmd] of cases) {
+    it(`does not match: ${label}`, () => {
+      expect(isPrCreateCommand(cmd)).toBe(false);
+    });
+  }
+
+  it('does not match empty or non-string input', () => {
+    expect(isPrCreateCommand('')).toBe(false);
+    expect(isPrCreateCommand(undefined as unknown as string)).toBe(false);
+    expect(isPrCreateCommand(null as unknown as string)).toBe(false);
+  });
+});
+
+// ── The four traps ───────────────────────────────────────────────────────────
+
+describe('pr-create-command: trap — `<<<` is a herestring, not a heredoc', () => {
+  // Reading `<<<` as a heredoc opener never finds a delimiter, so the "body"
+  // blanks the rest of the input and swallows the real invocation below it.
+  it('does not swallow the following line (bare word)', () => {
+    expect(isPrCreateCommand(lines('grep -q x <<<EOF', 'gh pr create --fill'))).toBe(true);
+  });
+
+  it('does not swallow the following line (quoted word)', () => {
+    expect(isPrCreateCommand(lines(`grep -q x <<<'some text'`, 'gh pr create --fill'))).toBe(true);
+  });
+
+  it('treats the herestring word itself as data, not a command', () => {
+    expect(isPrCreateCommand(`grep -q x <<<'gh pr create'`)).toBe(false);
+  });
+});
+
+describe('pr-create-command: trap — heredoc delimiters longer than any window', () => {
+  // Matching the header against `cmd.slice(i, i + N)` truncates a bare delimiter
+  // longer than N: the truncated prefix registers as the delimiter, the real
+  // terminator never matches, and the body blanks to EOF — swallowing whatever
+  // follows the heredoc.
+  const long = 'D'.repeat(200);
+
+  it('terminates a bare over-long delimiter', () => {
+    const cmd = lines(`cat <<${long}`, 'gh pr create inside the body', long, 'gh pr create --fill');
+    expect(isPrCreateCommand(cmd)).toBe(true);
+    // and the body copy is still data
+    expect(isPrCreateCommand(lines(`cat <<${long}`, 'gh pr create inside the body', long))).toBe(false);
+  });
+
+  it('terminates a quoted over-long delimiter', () => {
+    const cmd = lines(`cat <<'${long}'`, 'gh pr create inside the body', long, 'gh pr create --fill');
+    expect(isPrCreateCommand(cmd)).toBe(true);
+  });
+
+  it('blanks an unterminated heredoc through end of input', () => {
+    expect(isPrCreateCommand(lines('cat <<EOF', 'gh pr create'))).toBe(false);
+  });
+
+  // `<<-` strips leading tabs from the TERMINATOR too. Getting that wrong fails
+  // in the safe-looking direction on a body-only fixture (the terminator is
+  // never found, so the body blanks to EOF and the literal inside it still
+  // doesn't match) — it only shows up as a bypass on what comes AFTER.
+  it('finds a tab-indented terminator so the heredoc does not run to EOF', () => {
+    expect(isPrCreateCommand(lines('cat <<-EOF', '\tbody text', '\tEOF', 'gh pr create --fill'))).toBe(true);
+  });
+});
+
+describe('pr-create-command: trap — `\\` + newline is a continuation, not a separator', () => {
+  // The logical line keeps going, so the words after it are arguments to `cat`,
+  // and the heredoc queued on that line does not start until the next real newline.
+  it('does not treat the continued words as a new command', () => {
+    expect(isPrCreateCommand(lines('cat <<EOF \\', 'gh pr create', 'EOF'))).toBe(false);
+  });
+
+  it('still starts the heredoc body after the real newline', () => {
+    const cmd = lines('cat <<EOF \\', '  --flag', 'gh pr create in the body', 'EOF', 'gh pr create --fill');
+    expect(isPrCreateCommand(cmd)).toBe(true);
+    expect(isPrCreateCommand(lines('cat <<EOF \\', '  --flag', 'gh pr create in the body', 'EOF'))).toBe(false);
+  });
+
+  it('does not let an escaped separator start a command', () => {
+    expect(isPrCreateCommand('echo a\\; gh pr create')).toBe(false);
+  });
+
+  // The heredoc cases above stay green even if the newline is left unblanked —
+  // the heredoc body then swallows the literal, so the answer is right for the
+  // wrong reason. Without a heredoc there is nothing to swallow it: leaving the
+  // newline turns a continuation into a separator and the arguments read as a
+  // command. Mutation-confirmed as the only case that catches this directly.
+  it('treats continued words as arguments, not a new command', () => {
+    expect(isPrCreateCommand(lines('echo some args \\', 'gh pr create'))).toBe(false);
+  });
+});
+
+describe('pr-create-command: command substitutions inside quoted data', () => {
+  // A double-quoted run and a bare-delimiter heredoc body are data, EXCEPT for
+  // the substitutions inside them — those still run. Blanking them wholesale
+  // (the obvious reading of "blank the quoted regions") makes each of these a
+  // silent bypass. `'…'` and `<<'EOF'` suppress expansion, so they stay data.
+  const SQ = "'";
+  const BT = '`';
+
+  const expand: Array<[string, string]> = [
+    ['$( ) inside double quotes', 'echo "PR: $(gh pr create --fill)"'],
+    ['backtick inside double quotes', `echo "PR: ${BT}gh pr create${BT}"`],
+    ['nested double quotes inside the substitution', 'echo "PR: $(gh pr create --title "x" --fill)"'],
+    ['nested single quotes inside the substitution', `echo "PR: $(gh pr create --title ${SQ}x${SQ})"`],
+    ['two levels of substitution', 'echo "a $(echo "b $(gh pr create)")"'],
+    ['bare-delimiter heredoc body', lines('cat <<EOF', 'url: $(gh pr create --fill)', 'EOF')],
+  ];
+  for (const [label, cmd] of expand) {
+    it(`matches: ${label}`, () => expect(isPrCreateCommand(cmd)).toBe(true));
+  }
+
+  const suppressed: Array<[string, string]> = [
+    ['single quotes suppress expansion', `echo ${SQ}$(gh pr create)${SQ}`],
+    ['quoted-delimiter heredoc suppresses expansion', lines(`cat <<${SQ}EOF${SQ}`, 'url: $(gh pr create)', 'EOF')],
+    // Restoring a substitution must not un-blank the literal text around it.
+    ['literal text after a substitution in the same run', 'echo "$(date) then gh pr create here"'],
+  ];
+  for (const [label, cmd] of suppressed) {
+    it(`does not match: ${label}`, () => expect(isPrCreateCommand(cmd)).toBe(false));
+  }
+
+  it('does not hang or throw on unbalanced input', () => {
+    expect(isPrCreateCommand('echo "$(gh pr create')).toBe(false);
+    expect(isPrCreateCommand('echo "$(gh pr create "')).toBe(false);
+  });
+
+  it('caps pathological nesting instead of overflowing the stack', () => {
+    // The cap trades a miss for a crash — and a crash in a PreToolUse hook is
+    // not a missed gate, it is every Bash call blocked.
+    const deep = '"$('.repeat(40) + 'gh pr create' + ')"'.repeat(40);
+    expect(typeof isPrCreateCommand(deep)).toBe('boolean');
+  });
+});
+
+describe('pr-create-command: trap — cost stays bounded on every Bash call', () => {
+  // These gates run on EVERY Bash call, so the two failure modes are (a) paying
+  // the two-pass cost for commands that obviously cannot match, and (b) the
+  // quadratic backtracking a leading-context regex causes on sanitised input
+  // (long runs of spaces that `\s*` consumes, fails on, and backtracks through).
+  //
+  // The bounds below are deliberately loose — they exist to catch catastrophic
+  // blowup, not to police microseconds, because a tight timing assertion under
+  // CI fork contention is a flake generator.
+  it('does not pay the two-pass cost for the `gh` digraph in ordinary words', () => {
+    // "gh" is a common English digraph, so a bare indexOf('gh') screen lets
+    // highlight/github/though/flight through to the full scan on every Bash call.
+    const words = ['highlight', 'github.com/org/repo', 'though', 'flight', 'ghost'];
+    const big = words.join(' ') + ' ' + 'x'.repeat(200_000);
+    const t0 = process.hrtime.bigint();
+    expect(isPrCreateCommand(big)).toBe(false);
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    expect(ms).toBeLessThan(50);
+  });
+
+  it('fast-rejects a large command with no `gh` in it', () => {
+    const big = lines('cat <<EOF', 'x'.repeat(100_000), 'EOF');
+    const t0 = process.hrtime.bigint();
+    expect(isPrCreateCommand(big)).toBe(false);
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    expect(ms).toBeLessThan(50);
+  });
+
+  it('stays responsive on heredoc-heavy input that does contain `gh`', () => {
+    const blocks: string[] = [];
+    for (let i = 0; i < 800; i++) blocks.push(`cat <<EOF${i}`, 'gh pr create in a body', `EOF${i}`);
+    blocks.push('gh pr create --fill');
+    const cmd = lines(...blocks);
+    const t0 = process.hrtime.bigint();
+    expect(isPrCreateCommand(cmd)).toBe(true);
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    expect(ms).toBeLessThan(500);
+  });
+});
+
+// ── Sanitiser invariants ─────────────────────────────────────────────────────
+
+describe('pr-create-command: sanitizeShellData', () => {
+  it('preserves length so offsets outside blanked regions do not shift', () => {
+    const fixtures = [
+      'git commit -m "cd /r && gh pr create"',
+      lines('cat <<EOF', 'body', 'EOF', 'gh pr create'),
+      lines('cat <<EOF \\', '  --flag', 'body', 'EOF'),
+      `printf $'a\\nb'`,
+      '# comment only',
+      'grep x <<<"word"',
+    ];
+    for (const f of fixtures) expect(sanitizeShellData(f)).toHaveLength(f.length);
+  });
+
+  it('blanks quoted data but leaves command text intact', () => {
+    expect(sanitizeShellData('git commit -m "gh pr create"')).toBe('git commit -m' + ' '.repeat(15));
+  });
+
+  it('keeps newlines outside blanked regions so separators survive', () => {
+    const out = sanitizeShellData(lines('cat <<EOF', 'body', 'EOF', 'gh pr create'));
+    expect(out.split('\n')).toHaveLength(4);
+    expect(out.split('\n')[3]).toBe('gh pr create');
+  });
+});


### PR DESCRIPTION
Fixes #1410.

`gate.cjs` decided whether a Bash command was a PR-create with one regex over raw
command text, at two call sites. It was wrong in both directions at once: it
missed shapes people routinely type — turning a blocking gate into an optional
one with no signal — and it fired on commands that merely quote the literal,
blocking work unrelated to opening a PR.

One cause, both symptoms: a regex over raw text cannot tell a command from a
string that quotes one. Widening the separator set (the obvious repair) makes the
over-match strictly worse, because every heredoc body line beginning with the
literal becomes a match.

## What changed

New `pr-create-command.cjs` — dependency-free CommonJS, mirrored into `bin/` and
`.claude/helpers/` per the `simplify-classify.cjs` precedent — does two passes:

1. **Blank the data regions**, preserving length so nothing outside a blanked
   region shifts: `#` comments, heredoc bodies (`<<EOF`, `<<'EOF'`, `<<-EOF`,
   several announced on one line), `'…'`, `$'…'`, `"…"`, and `\` escapes.
2. **Search the sanitised text** for `gh\s+pr\s+create\b`, then walk *backwards*
   to confirm the hit starts a command — input start, a separator, or a run of
   `NAME=value` / command-prefix words bottoming out at one of those.

Both `check-before-pr` and `check-before-done` now call it; no inline PR-create
regex remains except the named legacy fallback.

| Shape | Before | After |
|---|---|---|
| `cd /repo` + newline + `gh pr create` | miss (gate bypassed) | match |
| `cat body.md \| gh pr create --body-file -` | miss (gate bypassed) | match |
| `( gh pr create )` | miss (gate bypassed) | match |
| `git commit -m "…gh pr create…"` | blocked | passes |
| `node -e '…gh pr create…'` | blocked | passes |
| heredoc body containing the literal | blocked | passes |

## Traps handled

Each of these is a requirement with its own test, not a note — three are silent
bypasses, i.e. the gate stops blocking with no signal at all.

- **`<<<` is a herestring, not a heredoc.** Read as a heredoc opener, the
  delimiter is never found, the "body" blanks to EOF, and a real invocation on the
  next line is swallowed.
- **Sticky heredoc headers.** Matching against `cmd.slice(i, i + N)` truncates a
  bare delimiter longer than the window, so the terminator never matches and the
  body blanks to EOF. A `/y` regex with `lastIndex = i` has no window.
- **`\` + newline is a continuation.** The words after it are arguments, and the
  heredocs queued on that line do not start there.
- **Left-context stays out of the regex** — it is quadratic on sanitised input.
  Plus a fast reject on `!cmd.includes('gh')` before sanitising, since these gates
  run on every Bash call.

Two deviations from the report's suggested implementation, both closing bypasses
rather than adding scope:

- **Backticks are command context, not data.** Blanking them would make
  `` `gh pr create` `` stop blocking. Backticks inside `"…"` are still blanked
  with the rest of the run, which is where the over-match risk actually lives.
- **Substitutions inside `"…"` and bare-delimiter heredocs are restored** as
  command text, sanitised recursively — the shell still runs them, so
  `echo "$(gh pr create)"` was otherwise a bypass. Quoting restarts inside
  `$( )`, so the double-quote scanner skips substitution regions when finding its
  closing quote. Depth-capped at 8 so pathological nesting cannot overflow the
  stack.

## Fail-safe both ways

`gate-hook.mjs` maps any non-zero exit from `gate.cjs` to exit 2 — so an uncaught
throw here would not degrade one gate, it would block **every Bash call** in the
consumer's session. Both the `require()` and the call into the matcher fall back
to the pre-#1410 regex, and the fallback advises on stderr naming
`npx flo doctor --fix` rather than failing silently (#854). Tested by running
`gate.cjs` alone in a helpers dir with no sibling.

## Tests

- `tests/bin/pr-create-command.test.ts` — 70 unit cases: must-match, must-not-match,
  the four traps, substitution handling, and sanitiser invariants.
- `tests/bin/gate-pr-create-matcher-1410.test.ts` — the gate boundary. Every shape
  asserted at **both** call sites, because a fix applied to one would leave the
  other bypassable with every unit test still green. Plus the degraded-path and
  manifest-entry cases.

Each defence was mutation-checked: removing it must turn a specific test red.
The first run had 5 survivors, 4 of which were real test gaps (a comment quoting
the *chained* form, a single-quoted string with no inner double quotes, a
continuation with no heredoc to swallow it, and a `<<-` terminator) — those cases
are now in the suite and 15/15 mutants are killed.

## Consumer impact

| | |
|---|---|
| Surface | `.claude/helpers/gate.cjs` (PreToolUse, every Bash call) + `bin/` mirror, one new mirrored helper, `binHelperFiles` manifest |
| Upgrade | Launcher syncs `gate.cjs` and `pr-create-command.cjs` in the same pass. A half-completed pass degrades to the legacy matcher with an advisory — it does not wedge the session. No `.moflo/` state change, no migration. |
| Round-trip | Hook layer: publish + `npm install` + Claude Code restart before it takes effect in a live session. The `flo gate` CLI path picks the source edit up immediately. |

Cross-platform: pure string processing, no `node:` builtins, no paths, no shelling
out; CRLF-tolerant (heredoc terminators and separators), and both new `.cjs` files
are LF per `.gitattributes`.

Verified live in the dogfood session, not only in tests: the newline-separated
invocation now blocks (previously a silent bypass), and a command quoting the
chained form now runs (previously blocked).
