### PR TITLE
fix(mcp): mint MCP session IDs from a CSPRNG instead of Math.random

### DIFF
--- a/src/cli/mcp-tools/session-tools.ts
+++ b/src/cli/mcp-tools/session-tools.ts
@@ -5,6 +5,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, unlinkSync, statSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import type { MCPTool } from './types.js';
 import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
@@ -144,7 +145,7 @@ export const sessionTools: MCPTool[] = [
       required: ['name'],
     },
     handler: async (input) => {
-      const sessionId = `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const sessionId = `session-${Date.now()}-${randomBytes(6).toString('hex')}`;
 
       // Load related data based on options
       const data = loadRelatedStores({

--- a/src/cli/shared/mcp/session-manager.ts
+++ b/src/cli/shared/mcp/session-manager.ts
@@ -14,6 +14,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { randomBytes } from 'node:crypto';
 import {
   MCPSession,
   SessionState,
@@ -365,7 +366,7 @@ export class SessionManager extends EventEmitter {
    * Generate a unique session ID
    */
   private generateSessionId(): string {
-    return `session-${++this.sessionCounter}-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+    return `session-${++this.sessionCounter}-${Date.now()}-${randomBytes(6).toString('hex')}`;
   }
 
   /**


### PR DESCRIPTION
Resolves 6 CodeQL `js/insecure-randomness` alerts (#8, #9, #10, #11, #12, #13) — the `Math.random()` half of the code-scanning triage.

## What changed

Two session-ID generators swapped `Math.random().toString(36)` for `randomBytes(6).toString('hex')`:

- `src/cli/shared/mcp/session-manager.ts:369`
- `src/cli/mcp-tools/session-tools.ts:148`

That's the whole diff — 4 added, 2 removed.

## Honest framing: this was not an exploitable weakness

Worth saying plainly rather than letting the "high severity" label speak. The MCP server is **stdio / in-process only** — no network transport, no auth — so these IDs never cross a trust boundary. CodeQL's "security context" premise doesn't hold today.

It's still worth doing: `randomBytes` is a strictly better source, it removes a real (if small) collision risk, and it means the IDs stay sound if a network transport is ever added. It is not a fix for a live vulnerability and shouldn't be described as one.

## Consumer impact (Rule #2)

| | |
|---|---|
| **Surface touched** | MCP server + MCP tools → ships as `dist/src/cli/**` |
| **Manifest** | None needed — `src/cli/**/*.ts` is covered by the `files` glob (no `bin/lib/shipped-scripts.json` entry) |
| **Failure mode for an existing consumer** | None. New sessions get a 12-hex suffix instead of ≤6 base36; structure and separators unchanged. Existing `.moflo/sessions/*.json` keep their filenames and still resolve on restore — no migration, no `.moflo/` state reparse |
| **Round-trip cost** | **publish + `npm install`** — the MCP server loads from `node_modules/moflo/`, so this cannot be exercised end-to-end from a source edit |

The only new import is the `node:crypto` builtin, so there is no cross-compile-unit relative path and the dist-vs-source depth trap (#1126) doesn't apply here.

## Verification

`/verify` PASS across 7 criteria, executed rather than asserted:

| Criterion | Evidence |
|---|---|
| No `Math.random()` at either site | diff + grep |
| ID structure preserved | 4000-sample shape check |
| No consumer migration | `getSessionPath`'s sanitizer is identity on both old and new ID forms (4000 new + 500 old) |
| **Cross-platform filename-safe (Rule #1)** | sessionId becomes a filename: 0/4000 Windows-illegal chars, all-lowercase so no APFS/NTFS case collision, no reserved DOS names, maxlen 39 |
| Ships correctly | `npm run build` clean; `randomBytes` present in both compiled `dist/` files |
| Uniqueness | 0 collisions over 4000 |
| No regressions | `security-audit` + `store-paths` (the suites covering these files) 27 passed; 165 passed across the wider MCP surface; 87 across the session suites |

## Two things deliberately left out

**1. Reuse of the existing helper — split to #1423.** Review correctly flagged that `src/cli/shared/security/secure-random.ts` already exists, says *"Replaces Math.random() for security-sensitive operations"*, and has **zero consumers** — which is why these sites survived. Adopting it changes the shipped ID format and deletes a per-process counter, i.e. observable behaviour on a surface that needs publish+reinstall to verify. That belongs in its own PR, not riding a 2-line security fix.

**2. A pre-existing red test — filed as #1422.** `swarm-health.test.ts > returns healthy ... on a fresh swarm` fails on `main`. Confirmed not caused by this change: it reproduces on pristine `origin/main`, deterministically (3/3), and it is the *only* failure across the MCP surface. Tracked separately rather than fixed here, to keep this diff honest.

## Related

Part of the code-scanning triage: #1418 (ReDoS), #1419 (Windows shell escaping), #1420 (workflow token — repo default already flipped to read-only), #1422, #1423.