### PR TITLE
chore(ci): declare contents:read on the four workflows that need no write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ on:
       - '.github/PULL_REQUEST_TEMPLATE/**'
       - 'LICENSE'
 
+# The GITHUB_TOKEN this workflow receives needs nothing beyond reading the
+# repo: no job here pushes, comments, releases, or uploads. Declared
+# explicitly so the intent survives a change to the org/repo default, and
+# because declaring any key drops every unlisted scope to none. (#1420)
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '22'
 

--- a/.github/workflows/consumer-install-smoke.yml
+++ b/.github/workflows/consumer-install-smoke.yml
@@ -39,6 +39,13 @@ on:
       - '.github/PULL_REQUEST_TEMPLATE/**'
       - 'LICENSE'
 
+# The GITHUB_TOKEN this workflow receives needs nothing beyond reading the
+# repo: no job here pushes, comments, releases, or uploads. Declared
+# explicitly so the intent survives a change to the org/repo default, and
+# because declaring any key drops every unlisted scope to none. (#1420)
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '22'
 

--- a/.github/workflows/file-sync-smoke.yml
+++ b/.github/workflows/file-sync-smoke.yml
@@ -73,6 +73,13 @@ on:
       - '.github/workflows/file-sync-smoke.yml'
   workflow_dispatch:
 
+# The GITHUB_TOKEN this workflow receives needs nothing beyond reading the
+# repo: no job here pushes, comments, releases, or uploads. Declared
+# explicitly so the intent survives a change to the org/repo default, and
+# because declaring any key drops every unlisted scope to none. (#1420)
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '22'
 

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -44,6 +44,13 @@ on:
         required: true
         type: string
 
+# The GITHUB_TOKEN this workflow receives needs nothing beyond reading the
+# repo: no job here pushes, comments, releases, or uploads. Declared
+# explicitly so the intent survives a change to the org/repo default, and
+# because declaring any key drops every unlisted scope to none. (#1420)
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '22'
 


### PR DESCRIPTION
Closes the seven `actions/missing-workflow-permissions` alerts (#3, #4, #5, #7, #40, #41, #42). Follow-through on #1420.

## What changed

One identical top-level block added to `ci.yml`, `consumer-install-smoke.yml`, `file-sync-smoke.yml`, `release-smoke.yml`:

```yaml
permissions:
  contents: read
```

`sandbox-image.yml` is deliberately untouched — it already declares its own `contents: read` / `packages: write` at job level, which overrides the default.

## Why this is needed even though the setting is already fixed

The repo's Actions default was `default_workflow_permissions: write` with PR-approval enabled, so every job in these four received a read/write `GITHUB_TOKEN`. **That default has already been flipped to `read`** — that is the control that actually constrains the token, and it is applied and verified.

So why the YAML? I initially claimed on #1420 that the setting change would close these alerts. **It doesn't.** CodeQL's query analyses the workflow file and asks whether a `permissions:` block is declared; it has no visibility into repo settings. Confirmed empirically — `Analyze (actions)` ran and passed on PR #1424 *after* the flip and all seven stayed open.

Two independent reasons to land this, then:
1. It is the only thing that closes the alerts.
2. The in-repo declaration survives someone changing the org/repo default back, and is visible to a reader of the workflow.

## Scope check

None of the four workflows writes anything — no push, no comment, no release, no artifact upload, no `gh`/API call. Confirmed by grep and by an independent review pass.

One subtlety worth recording: the *restricted* default grants `contents: read` **+ `packages: read`** + `metadata: read`, whereas an explicit block granting only `contents: read` drops `packages` to **none**. That's safe here — there is no `.npmrc`, nothing references `npm.pkg.github.com` or ghcr, and `actions/cache` (the only non-trivial action in use) authenticates via the runner's cache service token rather than `GITHUB_TOKEN`.

## Verification

`/verify` PASS across 6 criteria:

| Criterion | Evidence |
|---|---|
| All 5 workflows parse | js-yaml parse of every file in `.github/workflows` |
| `contents: read` top-level in exactly the 4 targets | parsed `permissions` + `git diff --name-only` |
| `sandbox-image.yml` untouched, override intact | 0-line diff vs `origin/main`; `publish={contents:read, packages:write}` still parsed |
| No step needs more than `contents: read` | grep + independent review; `actions/cache` uses the runner cache token |
| **Required checks still fire on a workflow-only PR** | no `paths-ignore` list contains `.github/workflows`; `file-sync-smoke` is unfiltered on `pull_request` by design |
| Guard suites green | `sandbox-image-drift-guard` + `tests/guards` — 132 passed |

That fifth row is the one that could have bitten: this PR touches *only* workflow files, and these are required status checks. A `paths-ignore` covering `.github/workflows/**` would have meant the checks never report and the PR sits BLOCKED forever — the failure mode already documented in `file-sync-smoke.yml`'s own header comment (PR #1356). Verified clear before pushing; this PR's own CI is the live confirmation.

## Related

Code-scanning triage: #1418 (ReDoS), #1419 (shell escaping), #1420 (this), #1422, #1423, PR #1424 (CSPRNG).