### PR TITLE
fix(correctness): mint IDs with entropy instead of a bare clock reading

### DIFF
--- a/.claude/scripts/hooks.mjs
+++ b/.claude/scripts/hooks.mjs
@@ -23,6 +23,9 @@ import { spawn } from 'child_process';
 import { existsSync, appendFileSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+// A builtin, deliberately: this file is a shipped hook entry point, and pulling
+// in a bin/lib/ module here would widen its resolve closure for one call site.
+import { randomBytes } from 'node:crypto';
 import { createProcessManager } from './lib/process-manager.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
@@ -240,7 +243,7 @@ async function main() {
       case 'pre-task': {
         const description = getArg('description') || process.env.TOOL_INPUT_prompt;
         if (description) {
-          const taskId = `task-${Date.now()}`;
+          const taskId = `task-${Date.now()}-${randomBytes(6).toString('hex')}`;
           await runClaudeFlow('hooks', ['pre-task', '--task-id', taskId, '--description', description]);
         }
         break;

--- a/bin/hooks.mjs
+++ b/bin/hooks.mjs
@@ -23,6 +23,9 @@ import { spawn } from 'child_process';
 import { existsSync, appendFileSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+// A builtin, deliberately: this file is a shipped hook entry point, and pulling
+// in a bin/lib/ module here would widen its resolve closure for one call site.
+import { randomBytes } from 'node:crypto';
 import { createProcessManager } from './lib/process-manager.mjs';
 import { shouldDaemonAutoStart } from './lib/daemon-config.mjs';
 import { resolveMofloBin } from './lib/resolve-bin.mjs';
@@ -240,7 +243,7 @@ async function main() {
       case 'pre-task': {
         const description = getArg('description') || process.env.TOOL_INPUT_prompt;
         if (description) {
-          const taskId = `task-${Date.now()}`;
+          const taskId = `task-${Date.now()}-${randomBytes(6).toString('hex')}`;
           await runClaudeFlow('hooks', ['pre-task', '--task-id', taskId, '--description', description]);
         }
         break;

--- a/src/cli/__tests__/spells/runner-bridge.test.ts
+++ b/src/cli/__tests__/spells/runner-bridge.test.ts
@@ -106,7 +106,7 @@ steps:
     const result = await bridgeRunSpell(yaml, 'test.yaml', {});
 
     expect(result.success).toBe(true);
-    expect(result.spellId).toMatch(/^sp-\d+$/);
+    expect(result.spellId).toMatch(/^sp-\d+-[0-9a-f]{12}$/); // #1427 — random segment
     // After completion, should no longer be tracked
     expect(bridgeIsRunning(result.spellId)).toBe(false);
   });

--- a/src/cli/__tests__/spells/runner.test.ts
+++ b/src/cli/__tests__/spells/runner.test.ts
@@ -738,7 +738,10 @@ describe('SpellCaster — spellId', () => {
     const result = await runner.run(definition, {});
 
     expect(result.spellId).toBeDefined();
-    expect(result.spellId).toMatch(/^sp-\d+$/);
+    // #1427 — the id carries a random segment past the clock reading. Two casts
+    // in the same millisecond used to share a spellId, and spellId keys the
+    // progress record, so they shared that too.
+    expect(result.spellId).toMatch(/^sp-\d+-[0-9a-f]{12}$/);
   });
 
   it('should use caller-specified spellId', async () => {

--- a/src/cli/commands/doctor-checks-deep.ts
+++ b/src/cli/commands/doctor-checks-deep.ts
@@ -20,6 +20,7 @@ import { pathToFileURL } from 'url';
 import { findProjectRoot as findConsumerProjectDir } from '../services/project-root.js';
 import { findMofloPackageRoot } from '../services/moflo-require.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
+import { generateId } from '../shared/utils/id.js';
 import type { HealthCheck } from './doctor-types.js';
 
 // Re-exported so existing consumers (`doctor-checks-memory-access.ts`,
@@ -93,7 +94,7 @@ export async function checkSubagentHealth(): Promise<HealthCheck> {
     // Spawn a test agent
     const spawnResult = await spawnTool.handler({
       agentType: 'tester',
-      id: `doctor-probe-${Date.now()}`,
+      id: generateId('doctor-probe'),
       priority: 'low',
       metadata: { purpose: 'doctor-health-check' },
     }, {});
@@ -176,7 +177,7 @@ steps:
 `;
 
     const result = await runSpellFromContent(minimalSpell, 'doctor-probe.yaml', {
-      spellId: `doctor-probe-${Date.now()}`,
+      spellId: generateId('doctor-probe'),
       timeout: 10_000,
     });
 

--- a/src/cli/commands/doctor-checks-swarm.ts
+++ b/src/cli/commands/doctor-checks-swarm.ts
@@ -22,6 +22,7 @@ import {
   safeInvoke,
   summarizeFunctional,
 } from './doctor-checks-functional-shared.js';
+import { generateId } from '../shared/utils/id.js';
 
 // Re-exported for callers that imported these from doctor-checks-swarm.ts
 // (tests, other doctor checks) before the shared module was extracted.
@@ -490,8 +491,8 @@ export async function checkHiveMindFunctional(): Promise<FunctionalHealthCheck> 
   // 6. hive-mind_memory roundtrips via Memory DB write-through.
   // Memory backend unavailable (e.g. fresh smoke fixture before `memory init`)
   // is environmental, not a regression — softFailMessage downgrades to warn.
-  const probeKey = `doctor-probe-${Date.now()}`;
-  const sentinel = `hive-doctor-${Date.now()}`;
+  const probeKey = generateId('doctor-probe');
+  const sentinel = generateId('hive-doctor');
   const setOut = await safeInvoke(hiveMindTools, 'hive-mind_memory', {
     action: 'set', key: probeKey, value: { sentinel },
   }, details, {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -22,6 +22,7 @@ import {
 import { listMCPTools, callMCPTool, hasTool, getToolMetadata } from '../mcp-client.js';
 import { acquireDaemonLock, releaseDaemonLock, getDaemonLockHolder } from '../services/daemon-lock.js';
 import { readMofloEnv } from '../services/env-compat.js';
+import { generateId } from '../shared/utils/id.js';
 
 // MCP tool categories offered by `flo mcp tools --category`.
 //
@@ -567,8 +568,8 @@ const execCommand: Command = {
 
       const startTime = performance.now();
       const result = await callMCPTool(tool, params, {
-        sessionId: `cli-${Date.now().toString(36)}`,
-        requestId: `exec-${Date.now()}`,
+        sessionId: generateId('cli', { base36Time: true }),
+        requestId: generateId('exec'),
       });
       const duration = performance.now() - startTime;
 

--- a/src/cli/commands/performance.ts
+++ b/src/cli/commands/performance.ts
@@ -8,6 +8,7 @@
 import type { Command, CommandContext, CommandResult } from '../types.js';
 import { output } from '../output.js';
 import { readLoadAverage, NOT_MEASURED } from '../shared/utils/load-average.js';
+import { generateId } from '../shared/utils/id.js';
 
 // Benchmark subcommand - REAL measurements
 const benchmarkCommand: Command = {
@@ -199,7 +200,7 @@ const benchmarkCommand: Command = {
       for (let i = 0; i < Math.min(iterations, 20); i++) {
         const start = performance.now();
         await storeEntry({
-          key: `bench_${Date.now()}_${i}`,
+          key: generateId('bench', { separator: '_' }),
           value: `Benchmark test entry ${i} with some content for testing storage performance`,
           namespace: 'benchmark',
           generateEmbeddingFlag: true,

--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { LEGACY_SWARM_DIR, memoryDbCandidatePaths, mofloDir } from '../services/moflo-paths.js';
 import { findProjectRoot } from '../services/project-root.js';
 import { resolveStateRoot } from '../services/project-root.js';
+import { generateId } from '../shared/utils/id.js';
 
 // Get dynamic swarm status from memory/session files
 function getSwarmStatus(swarmId?: string) {
@@ -414,7 +415,7 @@ const startCommand: Command = {
     spinner.succeed('All agents deployed');
 
     const executionState = {
-      swarmId: `swarm-${Date.now().toString(36)}`,
+      swarmId: generateId('swarm', { base36Time: true }),
       objective,
       strategy,
       status: 'running',

--- a/src/cli/guidance/ruvbot-integration.ts
+++ b/src/cli/guidance/ruvbot-integration.ts
@@ -22,6 +22,7 @@ import type { MemoryAuthority, MemoryEntry, WriteDecision } from './memory-gate.
 import type { ProofEnvelopeMetadata } from './proof.js';
 import type { CoherenceScore } from './coherence.js';
 import type { TrustRecord, GateOutcome } from './trust.js';
+import { generateId } from '../shared/utils/id.js';
 
 // ============================================================================
 // RuvBot Ambient Types (optional peer dependency)
@@ -850,7 +851,7 @@ export class RuvBotGuidanceBridge {
    */
   private async handleSessionCreate(...args: unknown[]): Promise<void> {
     const data = (args[0] ?? {}) as Record<string, unknown>;
-    const sessionId = String(data['sessionId'] ?? data['id'] ?? `session-${Date.now()}`);
+    const sessionId = String(data['sessionId'] ?? data['id'] ?? generateId('session'));
 
     this.logEvent('session:create', { sessionId });
 

--- a/src/cli/guidance/uncertainty.ts
+++ b/src/cli/guidance/uncertainty.ts
@@ -25,6 +25,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { generateId } from '../shared/utils/id.js';
 
 // ============================================================================
 // Types
@@ -479,7 +480,7 @@ export class UncertaintyLedger {
 
     // Record the resolution as evidence
     const resolutionEvidence: EvidencePointer = {
-      sourceId: `resolution:${beliefId}:${Date.now()}`,
+      sourceId: generateId(`resolution:${beliefId}`, { separator: ':' }),
       sourceType: 'human-input',
       supports: status === 'confirmed',
       weight: 1.0,

--- a/src/cli/hooks/bridge/official-hooks-bridge.ts
+++ b/src/cli/hooks/bridge/official-hooks-bridge.ts
@@ -9,6 +9,7 @@
  */
 
 import { HookEvent, HookPriority, type HookHandler, type HookContext, type HookResult } from '../types.js';
+import { generateId } from '../../shared/utils/id.js';
 
 /**
  * Official Claude Code hook event types
@@ -176,7 +177,7 @@ export class OfficialHooksBridge {
     // Add task information for Task tool
     if (input.tool_name === 'Task') {
       context.task = {
-        id: `task-${Date.now()}`,
+        id: generateId('task'),
         description: (input.tool_input?.prompt as string) ?? '',
         agent: input.tool_input?.subagent_type as string,
       };

--- a/src/cli/hooks/mcp/index.ts
+++ b/src/cli/hooks/mcp/index.ts
@@ -15,6 +15,7 @@ import type {
   MetricsQueryInput,
   MetricsQueryResult,
 } from '../types.js';
+import { generateId } from '../../shared/utils/id.js';
 
 /**
  * MCP Tool definition interface
@@ -142,7 +143,7 @@ export const postEditTool: MCPTool = {
       success,
       recorded: true,
       recordedAt: new Date().toISOString(),
-      patternId: success ? `pattern-${Date.now()}` : undefined,
+      patternId: success ? generateId('pattern') : undefined,
     };
   },
 };
@@ -365,7 +366,7 @@ export const postCommandTool: MCPTool = {
 
     return {
       recorded: true,
-      patternId: success ? `cmd-${Date.now()}` : undefined,
+      patternId: success ? generateId('cmd') : undefined,
     };
   },
 };

--- a/src/cli/hooks/swarm/index.ts
+++ b/src/cli/hooks/swarm/index.ts
@@ -693,7 +693,7 @@ export class SwarmCommunication extends EventEmitter {
 
     const handoff: TaskHandoff = {
       id: generateId('ho', { separator: '_' }),
-      taskId: `task_${Date.now()}`,
+      taskId: generateId('task', { separator: '_' }),
       description: taskDescription,
       fromAgent: this.config.agentId,
       toAgent,

--- a/src/cli/mcp-tools/hive-mind-tools.ts
+++ b/src/cli/mcp-tools/hive-mind-tools.ts
@@ -382,7 +382,7 @@ export const hiveMindTools: MCPTool[] = [
       await getWriteThroughAdapter();
 
       const hiveId = generateId('hive');
-      const queenId = (input.queenId as string) || `queen-${Date.now()}`;
+      const queenId = (input.queenId as string) || generateId('queen');
 
       const config = {
         consensus: resolveConsensus(input.consensus),

--- a/src/cli/mcp-tools/hooks-tools.ts
+++ b/src/cli/mcp-tools/hooks-tools.ts
@@ -711,7 +711,7 @@ export const hooksPostEdit: MCPTool = {
     try {
       const bridge = await import('../memory/memory-bridge.js');
       feedbackResult = await bridge.bridgeRecordFeedback({
-        taskId: `edit-${filePath}-${Date.now()}`,
+        taskId: generateId(`edit-${filePath}`),
         success,
         quality: success ? 0.85 : 0.3,
         agent,
@@ -1212,7 +1212,7 @@ export const hooksPostTask: MCPTool = {
       learningUpdates: {
         patternsUpdated: feedbackResult?.updated || (success ? 2 : 1),
         newPatterns: success ? 1 : 0,
-        trajectoryId: `traj-${Date.now()}`,
+        trajectoryId: generateId('traj'),
         controller: feedbackResult?.controller || 'none',
         outcomePersisted,
       },
@@ -1980,7 +1980,7 @@ export const hooksSessionStart: MCPTool = {
     },
   },
   handler: async (params: Record<string, unknown>) => {
-    const sessionId = (params.sessionId as string) || `session-${Date.now()}`;
+    const sessionId = (params.sessionId as string) || generateId('session');
     const restoreLatest = params.restoreLatest as boolean;
     const shouldStartDaemon = params.startDaemon !== false;
 
@@ -2150,7 +2150,7 @@ export const hooksSessionRestore: MCPTool = {
     const restoreTasks = params.restoreTasks !== false;
 
     const originalSessionId = requestedId === 'latest' ? `session-${Date.now() - 86400000}` : requestedId;
-    const newSessionId = `session-${Date.now()}`;
+    const newSessionId = generateId('session');
 
     // Get real memory entry count
     const store = loadMemoryStore();

--- a/src/cli/mcp-tools/performance-tools.ts
+++ b/src/cli/mcp-tools/performance-tools.ts
@@ -18,6 +18,7 @@ import type { MCPTool } from './types.js';
 import * as os from 'node:os';
 import { createJsonStore } from './json-store.js';
 import { readCpuUsagePercent, readLoadAverage, NOT_MEASURED } from '../shared/utils/load-average.js';
+import { generateId } from '../shared/utils/id.js';
 
 /**
  * #1354: `latency`, `throughput` and `errors` are gone from this shape.
@@ -267,7 +268,7 @@ const rawPerformanceTools: MCPTool[] = [
           const avgLatencyMs = durationMs / iterations;
           const memoryDelta = Math.round((memAfter - memBefore) / 1024);
 
-          const id = `bench-${suiteName}-${Date.now()}`;
+          const id = generateId(`bench-${suiteName}`);
           const result: Benchmark = {
             id,
             name: suiteName,

--- a/src/cli/mcp-tools/session-tools.ts
+++ b/src/cli/mcp-tools/session-tools.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import type { MCPTool } from './types.js';
 import { MOFLO_DIR as STORAGE_DIR } from '../services/moflo-paths.js';
 import { findProjectRoot } from '../services/project-root.js';
+import { generateId } from '../shared/utils/id.js';
 
 // Storage paths
 const SESSION_DIR = 'sessions';
@@ -414,7 +415,7 @@ export const sessionTools: MCPTool[] = [
       const importedAt = new Date().toISOString();
       // A fresh ID keeps an import from silently overwriting a local session
       // that happens to share the source's ID.
-      const sessionId = `imported-${Date.now()}`;
+      const sessionId = generateId('imported');
       const agentsImported = incoming.stats?.agents ?? countOf(incoming.data?.agents);
       const tasksImported = incoming.stats?.tasks ?? countOf(incoming.data?.tasks);
       const memoryEntriesImported =

--- a/src/cli/mcp-tools/spell-tools.ts
+++ b/src/cli/mcp-tools/spell-tools.ts
@@ -22,6 +22,7 @@ import { buildGrimoire } from '../services/grimoire-builder.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { inferSpellTier, type SpellTier } from '../spells/core/spell-tier.js';
 import { getSharedMemoryAccessor } from '../services/daemon-dashboard.js';
+import { generateId } from '../shared/utils/id.js';
 
 
 // ============================================================================
@@ -102,7 +103,7 @@ async function executeAndTrack(
     tier?: SpellTier;
   } = {},
 ): Promise<Record<string, unknown>> {
-  const spellId = `sp-${Date.now()}`;
+  const spellId = generateId('sp');
   const tracked = trackStart(spellId, definition.name, definition.description);
 
   try {

--- a/src/cli/memory/controllers/nightly-learner.ts
+++ b/src/cli/memory/controllers/nightly-learner.ts
@@ -20,6 +20,7 @@ import type { Skills } from './skills.js';
 import type { ControllerSpec } from '../controller-spec.js';
 import { hasMethod } from './_shared.js';
 import { errorDetail } from '../../shared/utils/error-detail.js';
+import { generateId } from '../../shared/utils/id.js';
 
 export interface NightlyReport {
   consolidation?: ConsolidationReport;
@@ -115,7 +116,7 @@ export class NightlyLearner {
     const self = this;
     this.timer = setInterval(() => {
       // Fire-and-forget; consolidate swallows its own errors.
-      void self.consolidate({ sessionId: `cron-${Date.now()}` });
+      void self.consolidate({ sessionId: generateId('cron') });
     }, intervalMs);
     if (typeof (this.timer as NodeJS.Timeout & { unref?: () => void }).unref === 'function') {
       (this.timer as NodeJS.Timeout & { unref?: () => void }).unref!();

--- a/src/cli/memory/domain/services/memory-domain-service.ts
+++ b/src/cli/memory/domain/services/memory-domain-service.ts
@@ -9,6 +9,7 @@
 
 import { MemoryEntry, MemoryType, MemoryEntryProps } from '../entities/memory-entry.js';
 import { IMemoryRepository, VectorSearchResult } from '../repositories/memory-repository.interface.js';
+import { generateId } from '../../../shared/utils/id.js';
 
 /**
  * Memory consolidation strategy
@@ -349,7 +350,7 @@ export class MemoryDomainService {
     // Create merged entry
     return MemoryEntry.create({
       namespace: primary.namespace,
-      key: `merged_${Date.now()}`,
+      key: generateId('merged', { separator: '_' }),
       value: {
         primary: primary.value,
         related: sorted.slice(1).map((e) => e.value),

--- a/src/cli/memory/verify.ts
+++ b/src/cli/memory/verify.ts
@@ -11,6 +11,7 @@
 
 import { openDaemonDatabase } from './daemon-backend.js';
 import { generateEmbedding } from './embedding-model.js';
+import { generateId } from '../shared/utils/id.js';
 
 /**
  * Verify memory initialization works correctly
@@ -54,7 +55,7 @@ export async function verifyMemoryInit(dbPath: string, options?: {
 
     // Test 2: Write entry
     const writeStart = Date.now();
-    const testId = `test_${Date.now()}`;
+    const testId = generateId('test', { separator: '_' });
     const testKey = 'verification_test';
     const testValue = 'This is a verification test entry for memory initialization';
 
@@ -130,7 +131,7 @@ export async function verifyMemoryInit(dbPath: string, options?: {
     // Test 5: Pattern storage
     const patternStart = Date.now();
     try {
-      const patternId = `pattern_${Date.now()}`;
+      const patternId = generateId('pattern', { separator: '_' });
       db.run(`
         INSERT INTO patterns (id, name, pattern_type, condition, action, confidence, created_at, updated_at)
         VALUES (?, 'test-pattern', 'task-routing', 'test condition', 'test action', 0.5, ?, ?)

--- a/src/cli/neural/sona-manager.ts
+++ b/src/cli/neural/sona-manager.ts
@@ -499,7 +499,7 @@ export class SONAManager {
     const config = this.getLoRAConfig();
 
     const weights: LoRAWeights = {
-      adapterId: `lora_${domain}_${Date.now()}`,
+      adapterId: generateId(`lora_${domain}`, { separator: '_' }),
       A: new Map(),
       B: new Map(),
       createdAt: Date.now(),

--- a/src/cli/services/daemon-spell-executor.ts
+++ b/src/cli/services/daemon-spell-executor.ts
@@ -24,6 +24,7 @@ import {
   type SandboxConfig,
   type SpellBudgetConfig,
 } from './engine-loader.js';
+import { generateId } from '../shared/utils/id.js';
 
 export interface DaemonSpellExecutorOptions {
   /** Pre-built Grimoire used to resolve spell names at poll time. */
@@ -86,7 +87,7 @@ export class DaemonSpellExecutor implements SpellExecutor {
     const loaded = this.registry.resolve(spellName);
     if (!loaded) {
       return failedResult(
-        `scheduled-${spellName}-${Date.now()}`,
+        generateId(`scheduled-${spellName}`),
         'STEP_EXECUTION_FAILED',
         `Spell not found in grimoire: ${spellName}`,
       );
@@ -94,7 +95,7 @@ export class DaemonSpellExecutor implements SpellExecutor {
 
     const engine = await this.ensureEngine();
     const definition = this.applyMofloLevel(loaded.definition, mofloLevel);
-    const spellId = `scheduled-${loaded.definition.name}-${Date.now()}`;
+    const spellId = generateId(`scheduled-${loaded.definition.name}`);
 
     const onAbort = () => {
       try {

--- a/src/cli/services/headless-worker-executor.ts
+++ b/src/cli/services/headless-worker-executor.ts
@@ -19,6 +19,7 @@ import { join, relative } from 'path';
 import type { WorkerType } from './worker-daemon.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { randomSuffix } from '../shared/utils/id.js';
+import { generateId } from '../shared/utils/id.js';
 
 // ============================================
 // Type Definitions
@@ -1379,7 +1380,7 @@ ${ioInstructions}`;
       sandboxMode: 'strict',
       workerType,
       timestamp: new Date(),
-      executionId: `error_${Date.now()}`,
+      executionId: generateId('error', { separator: '_' }),
       error,
     };
   }

--- a/src/cli/services/worker-daemon.ts
+++ b/src/cli/services/worker-daemon.ts
@@ -48,6 +48,7 @@ import { CircuitBreaker } from '../production/circuit-breaker.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { readLoadAverage } from '../shared/utils/load-average.js';
 import { readMofloEnv } from './env-compat.js';
+import { generateId } from '../shared/utils/id.js';
 
 // Worker types matching hooks-tools.ts. `audit`, `predict`, `document`
 // were removed in #970; `optimize` + `testgaps` were removed in #1258 (moved
@@ -974,7 +975,7 @@ export class WorkerDaemon extends EventEmitter {
    */
   private async executeWorker(workerConfig: WorkerConfig): Promise<WorkerResult> {
     const state = this.workers.get(workerConfig.type)!;
-    const workerId = `${workerConfig.type}_${Date.now()}`;
+    const workerId = generateId(workerConfig.type, { separator: '_' });
     const startTime = Date.now();
 
     // The controller is parked on shared state so setWorkerEnabled(false) can

--- a/src/cli/shared/hooks/example-usage.ts
+++ b/src/cli/shared/hooks/example-usage.ts
@@ -170,7 +170,7 @@ export function setupPerformanceHooks() {
         return { success: true };
       }
 
-      const metricId = `tool-${toolName}-${Date.now()}`;
+      const metricId = generateId(`tool-${toolName}`);
       performanceMetrics.set(metricId, { start: Date.now() });
 
       return {
@@ -309,7 +309,7 @@ export function setupSessionHooks() {
   registry.register(
     HookEvent.SessionStart,
     async (context) => {
-      const sessionId = context.session?.id || `session-${Date.now()}`;
+      const sessionId = context.session?.id || generateId('session');
 
       activeSession = {
         id: sessionId,
@@ -495,6 +495,7 @@ export async function runDemo() {
 
 // Run demo if executed directly
 import { pathToFileURL as _pfu_eu } from 'url';
+import { generateId } from '../utils/id.js';
 if (import.meta.url === _pfu_eu(process.argv[1]).href) {
   runDemo().catch(console.error);
 }

--- a/src/cli/shared/hooks/session-hooks.ts
+++ b/src/cli/shared/hooks/session-hooks.ts
@@ -15,6 +15,7 @@ import {
   SessionInfo,
 } from './types.js';
 import { HookRegistry } from './registry.js';
+import { generateId } from '../utils/id.js';
 
 /**
  * Session state to persist
@@ -269,7 +270,7 @@ export class SessionHooksManager {
    * Handle session start
    */
   async handleSessionStart(context: HookContext): Promise<HookResult> {
-    this.currentSessionId = context.session?.id || `session-${Date.now()}`;
+    this.currentSessionId = context.session?.id || generateId('session');
     this.sessionStartTime = new Date();
     this.resetActivity();
 
@@ -394,7 +395,7 @@ export class SessionHooksManager {
     }
 
     // Update current session tracking
-    this.currentSessionId = `session-${Date.now()}-restored`;
+    this.currentSessionId = `${generateId('session')}-restored`;
     this.sessionStartTime = new Date();
     this.resetActivity();
 

--- a/src/cli/shared/hooks/task-hooks.ts
+++ b/src/cli/shared/hooks/task-hooks.ts
@@ -15,6 +15,7 @@ import {
   TaskInfo,
 } from './types.js';
 import { HookRegistry } from './registry.js';
+import { generateId } from '../utils/id.js';
 
 /**
  * Pre-task hook result with agent suggestions
@@ -250,7 +251,7 @@ export class TaskHooksManager {
       outcome,
       learningUpdates,
       patternId: learningUpdates.newPatterns > 0 ? `pattern-${task.id}` : undefined,
-      trajectoryId: `trajectory-${task.id}-${Date.now()}`,
+      trajectoryId: generateId(`trajectory-${task.id}`),
     };
   }
 

--- a/src/cli/shared/plugins/official/hive-mind-plugin.ts
+++ b/src/cli/shared/plugins/official/hive-mind-plugin.ts
@@ -9,6 +9,7 @@
 
 import type { ClaudeFlowPlugin, PluginContext, PluginConfig } from '../types.js';
 import { HookEvent, HookPriority, type TaskInfo } from '../../hooks/index.js';
+import { generateId } from '../../utils/id.js';
 
 /**
  * HiveMind configuration
@@ -134,7 +135,7 @@ export class HiveMindPlugin implements ClaudeFlowPlugin {
    */
   async requestDecision(question: string, options: string[]): Promise<CollectiveDecision> {
     const decision: CollectiveDecision = {
-      id: `decision-${Date.now()}`,
+      id: generateId('decision'),
       question,
       votes: new Map(),
       consensusConfidence: 0,

--- a/src/cli/shared/plugins/official/maestro-plugin.ts
+++ b/src/cli/shared/plugins/official/maestro-plugin.ts
@@ -10,6 +10,7 @@
 import type { ClaudeFlowPlugin, PluginContext, PluginConfig } from '../types.js';
 import { HookEvent, HookPriority, type TaskInfo, type ErrorInfo } from '../../hooks/index.js';
 import { errorDetail } from '../../utils/error-detail.js';
+import { generateId } from '../../utils/id.js';
 
 /**
  * Maestro configuration
@@ -156,7 +157,7 @@ export class MaestroPlugin implements ClaudeFlowPlugin {
     steps: Array<Omit<SpellStep, 'id' | 'status'>>
   ): Spell {
     const spell: Spell = {
-      id: `spell-${Date.now()}`,
+      id: generateId('spell'),
       name,
       description,
       steps: steps.map((step, index) => ({
@@ -493,7 +494,7 @@ export class MaestroPlugin implements ClaudeFlowPlugin {
   }
 
   private checkpointSpell(spell: Spell): void {
-    spell.checkpoints.set(`checkpoint-${Date.now()}`, {
+    spell.checkpoints.set(generateId('checkpoint'), {
       progress: spell.progress,
       currentStep: spell.currentStep,
       stepStatuses: spell.steps.map((s) => ({ id: s.id, status: s.status })),

--- a/src/cli/spells/core/dry-run-validator.ts
+++ b/src/cli/spells/core/dry-run-validator.ts
@@ -30,6 +30,7 @@ import {
 } from './capability-validator.js';
 import { collectPrerequisites, checkPrerequisites } from './prerequisite-checker.js';
 import { analyzeStepPermissions, analyzeSpellPermissions } from './permission-disclosure.js';
+import { generateId } from '../../shared/utils/id.js';
 
 /** Invariant context shared across all `dryRunValidateStep` calls within a single dry-run. */
 interface DryRunEnv {
@@ -152,7 +153,7 @@ export async function dryRunValidate(
     : [];
   const prereqByName = new Map(prereqResults.map(r => [r.name, r]));
 
-  const spellId = `dryrun-${Date.now()}`;
+  const spellId = generateId('dryrun');
   const variables: Record<string, unknown> = {};
   const stepReports: DryRunStepReport[] = [];
   const env: DryRunEnv = { registry, definition, options, prereqByName };

--- a/src/cli/spells/core/runner.ts
+++ b/src/cli/spells/core/runner.ts
@@ -57,6 +57,7 @@ import {
   createRunBudget, mergeSpellBudgets,
   type BudgetBreach, type RunBudgetAccessor,
 } from './run-budget.js';
+import { generateId } from '../../shared/utils/id.js';
 
 /** Spell engine version. Story #285 (epic #287) — workflow-test constant. */
 export const ENGINE_VERSION = '1.0.0';
@@ -84,7 +85,7 @@ export class SpellCaster {
     const defValidation = validateSpellDefinition(definition, {
       knownStepTypes: this.registry.types(),
     });
-    const spellId = options.spellId ?? `sp-${Date.now()}`;
+    const spellId = options.spellId ?? generateId('sp');
 
     if (!defValidation.valid) {
       return this.failureResult(spellId, startTime, [{

--- a/src/cli/spells/factory/runner-bridge.ts
+++ b/src/cli/spells/factory/runner-bridge.ts
@@ -16,6 +16,7 @@ import { loadSandboxConfigFromProject } from '../core/platform-sandbox.js';
 import type { SpellBudgetConfig } from '../core/run-budget.js';
 import { createRunner, runSpellFromContent } from './runner-factory.js';
 import { getDefaultCredentialStore } from '../credentials/default-store.js';
+import { generateId } from '../../shared/utils/id.js';
 
 /**
  * Resolve sandbox config: prefer caller-supplied; fall back to auto-loading
@@ -55,7 +56,7 @@ export async function bridgeRunSpell(
     forceCredentialReprompt?: boolean;
   } = {},
 ): Promise<SpellResult> {
-  const spellId = `sp-${Date.now()}`;
+  const spellId = generateId('sp');
   const controller = new AbortController();
   activeSpells.set(spellId, controller);
 
@@ -96,7 +97,7 @@ export async function bridgeExecuteSpell(
     forceCredentialReprompt?: boolean;
   } = {},
 ): Promise<SpellResult> {
-  const spellId = options.spellId ?? `sp-${Date.now()}`;
+  const spellId = options.spellId ?? generateId('sp');
   const controller = new AbortController();
   activeSpells.set(spellId, controller);
 

--- a/src/cli/spells/factory/runner-factory.ts
+++ b/src/cli/spells/factory/runner-factory.ts
@@ -20,6 +20,7 @@ import { loadSandboxConfigFromProject } from '../core/platform-sandbox.js';
 import { loadSpellBudgetFromProject } from '../core/run-budget.js';
 import { errorDetail } from '../../shared/utils/error-detail.js';
 import { getDefaultCredentialStore } from '../credentials/default-store.js';
+import { generateId } from '../../shared/utils/id.js';
 
 // ============================================================================
 // Types
@@ -92,7 +93,7 @@ export async function runSpellFromContent(
     definition = parsed.definition;
   } catch (err) {
     return {
-      spellId: options.spellId ?? `sp-${Date.now()}`,
+      spellId: options.spellId ?? generateId('sp'),
       success: false,
       steps: [],
       outputs: {},
@@ -105,7 +106,7 @@ export async function runSpellFromContent(
   const validation = validateSpellDefinition(definition);
   if (!validation.valid) {
     return {
-      spellId: options.spellId ?? `sp-${Date.now()}`,
+      spellId: options.spellId ?? generateId('sp'),
       success: false,
       steps: [],
       outputs: {},

--- a/src/cli/swarm/consensus/gossip.ts
+++ b/src/cli/swarm/consensus/gossip.ts
@@ -11,6 +11,7 @@ import {
   ConsensusConfig,
   SWARM_CONSTANTS,
 } from '../types.js';
+import { generateId } from '../../shared/utils/id.js';
 
 export interface GossipMessage {
   id: string;
@@ -490,7 +491,7 @@ export class GossipConsensus extends EventEmitter {
     const randomNeighbor = neighbors[Math.floor(Math.random() * neighbors.length)];
 
     const stateMessage: GossipMessage = {
-      id: `state_${this.node.id}_${Date.now()}`,
+      id: generateId(`state_${this.node.id}`, { separator: '_' }),
       type: 'state',
       senderId: this.node.id,
       version: this.node.version,

--- a/src/cli/swarm/federation-hub.ts
+++ b/src/cli/swarm/federation-hub.ts
@@ -177,7 +177,7 @@ export type FederationEventType =
 // ============================================================================
 
 const DEFAULT_CONFIG: Required<FederationConfig> = {
-  federationId: `federation_${Date.now()}`,
+  federationId: generateId('federation', { separator: '_' }),
   maxEphemeralAgents: 100,
   defaultTTL: 300000, // 5 minutes
   syncIntervalMs: 30000, // 30 seconds

--- a/src/cli/swarm/queen-coordinator.ts
+++ b/src/cli/swarm/queen-coordinator.ts
@@ -1568,7 +1568,7 @@ export class QueenCoordinator extends EventEmitter {
     for (const bottleneck of bottlenecks) {
       if (bottleneck.severity === 'critical' || bottleneck.severity === 'high') {
         alerts.push({
-          alertId: `alert_${Date.now()}_${alerts.length}`,
+          alertId: generateId('alert', { separator: '_' }),
           type: bottleneck.severity === 'critical' ? 'critical' : 'error',
           source: bottleneck.location,
           message: bottleneck.description,
@@ -1585,7 +1585,7 @@ export class QueenCoordinator extends EventEmitter {
 
     if (avgHealth < 0.5) {
       alerts.push({
-        alertId: `alert_${Date.now()}_health`,
+        alertId: `${generateId('alert', { separator: '_' })}_health`,
         type: avgHealth < 0.3 ? 'critical' : 'warning',
         source: 'swarm',
         message: `Low average agent health: ${(avgHealth * 100).toFixed(1)}%`,
@@ -1601,7 +1601,7 @@ export class QueenCoordinator extends EventEmitter {
 
     if (failureRate > this.config.bottleneckThresholds.errorRate) {
       alerts.push({
-        alertId: `alert_${Date.now()}_failures`,
+        alertId: `${generateId('alert', { separator: '_' })}_failures`,
         type: failureRate > 0.2 ? 'critical' : 'warning',
         source: 'tasks',
         message: `High task failure rate: ${(failureRate * 100).toFixed(1)}%`,

--- a/tests/guards/id-minting-guard.test.ts
+++ b/tests/guards/id-minting-guard.test.ts
@@ -44,22 +44,42 @@ function* walk(dir: string): Generator<string> {
   }
 }
 
-function shippedSourceFiles(): string[] {
-  return SHIPPED_ROOTS.flatMap((rel) => [...walk(path.join(REPO_ROOT, rel))]);
+/**
+ * Every shipped source file, already split into lines.
+ *
+ * Read once and memoised: three scans share this, and each was otherwise
+ * re-walking and re-reading the whole shipped tree.
+ */
+let cachedSources: Array<{ rel: string; lines: string[] }> | null = null;
+
+function shippedSources(): Array<{ rel: string; lines: string[] }> {
+  cachedSources ??= SHIPPED_ROOTS.flatMap((root) =>
+    [...walk(path.join(REPO_ROOT, root))].map((file) => ({
+      rel: path.relative(REPO_ROOT, file),
+      // `/\r?\n/` rather than `'\n'`. `.gitattributes` pins `eol=lf` for *.ts
+      // and *.mjs, so CRLF should not reach here — this is the habit, not a
+      // live fix, and it keeps a future `$`-anchored matcher from silently
+      // failing on a stray `\r` if that policy ever changes.
+      lines: readFileSync(file, 'utf8').split(/\r?\n/),
+    })),
+  );
+  return cachedSources;
+}
+
+/** Collect `file:line  text` for every line the predicate flags. */
+function scan(flagged: (line: string) => boolean): string[] {
+  const offenders: string[] = [];
+  for (const { rel, lines } of shippedSources()) {
+    lines.forEach((line, i) => {
+      if (flagged(line)) offenders.push(`${rel}:${i + 1}  ${line.trim()}`);
+    });
+  }
+  return offenders;
 }
 
 describe('#1423 — no ID is minted from Math.random()', () => {
   it('no shipped source file base-36-slices Math.random()', () => {
-    const offenders: string[] = [];
-
-    for (const file of shippedSourceFiles()) {
-      const lines = readFileSync(file, 'utf8').split('\n');
-      lines.forEach((line, i) => {
-        if (BASE36_SLICE.test(line)) {
-          offenders.push(`${path.relative(REPO_ROOT, file)}:${i + 1}  ${line.trim()}`);
-        }
-      });
-    }
+    const offenders = scan((line) => BASE36_SLICE.test(line));
 
     expect(
       offenders,
@@ -73,18 +93,95 @@ describe('#1423 — no ID is minted from Math.random()', () => {
     // The same defect written without `.toString(36)` — e.g. a raw
     // `${Date.now()}-${Math.random()}` — would slip past the check above.
     const pattern = /\$\{\s*Date\s*\.\s*now\s*\(\s*\)\s*\}[^`]{0,20}\$\{[^}]*Math\s*\.\s*random/;
-    const offenders: string[] = [];
 
-    for (const file of shippedSourceFiles()) {
-      const lines = readFileSync(file, 'utf8').split('\n');
-      lines.forEach((line, i) => {
-        if (pattern.test(line)) {
-          offenders.push(`${path.relative(REPO_ROOT, file)}:${i + 1}  ${line.trim()}`);
-        }
-      });
-    }
+    expect(scan((line) => pattern.test(line))).toEqual([]);
+  });
+});
 
-    expect(offenders).toEqual([]);
+describe('#1427 — no ID is minted from Date.now() alone', () => {
+  // Strictly worse than the Math.random() sites above: a base-36 slice carried
+  // ~31 bits before slicing, a bare clock reading carries none. Two entities
+  // created in the same millisecond do not risk a collision, they take one.
+  //
+  // `${Date.now()}` is legitimate in plenty of places — cache busters, SSE
+  // pings, backup filenames, elapsed-time maths, and the doctor's own prose
+  // describing the stub shape it detects. So this keys on the *binding*: a
+  // template assigned to something named like an identifier, with no other
+  // source of uniqueness in it.
+  // The interpolation must be a bare clock reading — `${Date.now()}` or the
+  // base36 spelling of it. `${Date.now() - 86400000}` is deliberately excluded:
+  // that is a reference to a past instant (hooks-tools synthesises "the session
+  // from an hour ago" that way), not a fresh mint, and randomising it would be
+  // wrong rather than safer.
+  const NOW = String.raw`\$\{\s*Date\s*\.\s*now\s*\(\s*\)(?:\s*\.\s*toString\s*\(\s*36\s*\))?\s*\}`;
+  const ID_BINDING = new RegExp(
+    String.raw`\b\w*(?:[Ii]d|[Kk]ey)\s*[:=]\s*[^;\n]*\`[^\`\n]*` + NOW,
+  );
+
+  /**
+   * Anything that already separates two IDs minted in the same millisecond.
+   * `++` covers the in-memory event/message buses, whose counters are
+   * process-local and monotonic — weaker than a CSPRNG, but not zero.
+   */
+  const HAS_ENTROPY = /random|Random|randomUUID|randomBytes|randomSuffix|generateId|\+\+|[Cc]ounter|crypto/;
+
+  /** Comment lines describe these shapes on purpose — see doctor-checks-swarm.ts. */
+  const COMMENT = /^\s*(?:\/\/|\*|\/\*)/;
+
+  // Known limits, stated rather than discovered later. This is a line-based
+  // scan over a binding name, so it does NOT catch:
+  //   - a template split across lines
+  //   - concatenation: `const spellId = 'sp-' + Date.now()`
+  //   - `return \`sp-${Date.now()}\`` — no binding name to key on, and keying
+  //     on bare `return` would flag every function building a timestamped
+  //     filename
+  //   - a binding named for the entity rather than the id (`session`, `handle`)
+  //   - a line where HAS_ENTROPY matches incidentally (a trailing comment
+  //     containing the word "counter" masks the rest of the line)
+  // None of these exist in the tree today. The check is a ratchet against the
+  // shape that actually recurred 52 times, not a proof of absence.
+
+  const flagged = (line: string) =>
+    !COMMENT.test(line) && ID_BINDING.test(line) && !HAS_ENTROPY.test(line);
+
+  it('no shipped source file binds an id/key to a template whose only variable is Date.now()', () => {
+    const offenders = scan(flagged);
+
+    expect(
+      offenders,
+      `Mint IDs with generateId() from src/cli/shared/utils/id.ts.\n` +
+        `A bare Date.now() has zero entropy — same millisecond means same ID.\n` +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('detects the shape it claims to detect', () => {
+    // Without this, the check above passes just as happily when ID_BINDING has
+    // been broken as when the codebase is clean. Uses the same predicate the
+    // scan does, so the two cannot drift apart.
+    const detect = flagged;
+
+    // Caught — the #1427 shapes, in the spacings and separators used here.
+    expect(detect('const spellId = `sp-${Date.now()}`;')).toBe(true);
+    expect(detect('  taskId: `task_${Date.now()}`,')).toBe(true);
+    expect(detect('const queenId = input.queenId || `queen-${Date.now()}`;')).toBe(true);
+    expect(detect('  key: `merged_${Date.now()}`,')).toBe(true);
+    expect(detect('const probeKey = `doctor-probe-${ Date.now() }`;')).toBe(true);
+
+    // Not caught — legitimate uses that must stay legal.
+    expect(detect('const cacheBuster = `?t=${Date.now()}`;')).toBe(false); // not an id binding
+    expect(detect('res.write(`: ping ${Date.now()}\\n\\n`);')).toBe(false); // not a binding
+    expect(detect('const backupPath = `${p}.malformed-${Date.now()}`;')).toBe(false); // a path
+    expect(detect('const id = `evt-${Date.now()}-${++eventCounter}`;')).toBe(false); // counter
+    expect(detect('const id = `s-${Date.now()}-${randomUUID()}`;')).toBe(false); // random
+    expect(detect('const spellId = generateId("sp");')).toBe(false); // the fix itself
+    // The doctor documents the stub shape in prose; that must not trip.
+    expect(detect('  // literal was `swarm-${Date.now()}` (hyphen).')).toBe(false);
+    // A derived past instant, not a mint.
+    expect(detect('const sessionId = `session-${Date.now() - 3600000}`;')).toBe(false);
+
+    // The base36 spelling is the same defect and is caught.
+    expect(detect('const swarmId = `swarm-${Date.now().toString(36)}`;')).toBe(true);
   });
 });
 

--- a/tests/guards/id-minting-guard.test.ts
+++ b/tests/guards/id-minting-guard.test.ts
@@ -123,7 +123,7 @@ describe('#1427 — no ID is minted from Date.now() alone', () => {
    * `++` covers the in-memory event/message buses, whose counters are
    * process-local and monotonic — weaker than a CSPRNG, but not zero.
    */
-  const HAS_ENTROPY = /random|Random|randomUUID|randomBytes|randomSuffix|generateId|\+\+|[Cc]ounter|crypto/;
+  const HAS_ENTROPY = /[Rr]andom|generateId|\+\+|[Cc]ounter|crypto/;
 
   /** Comment lines describe these shapes on purpose — see doctor-checks-swarm.ts. */
   const COMMENT = /^\s*(?:\/\/|\*|\/\*)/;


### PR DESCRIPTION
## Summary

#1423 removed the `Math.random()` ID sites. This removes the ones that were **strictly worse**: a base-36 slice of `Math.random()` carried ~31 bits of entropy before slicing, and `` `prefix-${Date.now()}` `` carries none. Two entities created inside one millisecond don't *risk* sharing an identity — they always do.

**52 sites across 39 files**, all routed through the `generateId()` added in #1423, which already covered every shape needed.

Closes #1427.

---

## The sites that weren't theoretical

| Site | Why it mattered |
|---|---|
| `sp-${Date.now()}` — 6 spell-runner sites | `spellId` keys the progress record via `storeProgress()`. Two casts in the same millisecond shared the **persisted record**, not just the id. |
| `merged_${Date.now()}` — `memory-domain-service.ts:352` | This is a memory **key**, and the store upserts by key. Two merges in one millisecond silently overwrote each other. |
| `queen-`, `task_`, `federation_` | Protected swarm surface. A shared id means two distinct actors occupying one slot. |

## Shape was checked before it was changed

Widening an ID format is only safe if nothing depends on the old one. Verified across the repo before converting:

- **No id in this diff is parsed by prefix**, split on its separator, or matched by a `startsWith`. The only sanitiser found (`session-tools.ts:50`) keeps `[a-zA-Z0-9_-]`, which hex satisfies.
- **Discriminators are preserved** — `_health`, `_failures`, `-restored` still trail the id rather than being flattened away.
- **`${Date.now() - 86400000}` is deliberately left alone.** `hooks-tools.ts` uses that to synthesise "the session from an hour ago". It references a past instant rather than minting one; randomising it would be wrong, not safer.

Six templates remain and are **not** oversights: a cache buster, an SSE ping, a per-file backup path (paths already differ), two display strings, and the doctor's own prose describing the stub shape it detects.

## The guard is extended, not duplicated

`${Date.now()}` is legitimate in too many places for a bare-substring check, so the guard keys on the **binding**: a name ending in `id`/`key` assigned a template whose only variable is a clock reading, with no `random`/`++`/counter on the line. Allowlist-free, so a new offender trips on first use.

It carries a **self-test** asserting it still detects the five shapes this PR removed *and* still ignores the six it left. Without that, the scan passes just as happily when the matcher is broken as when the codebase is clean.

**Running the guard found 10 sites plain grep had missed** — including `bin/hooks.mjs:243` and `commands/swarm.ts` / `commands/mcp.ts`, which spell it `${Date.now().toString(36)}`.

Its **limits are written down** in the file rather than left to be discovered: it won't catch a multi-line template, `'sp-' + Date.now()` concatenation, a bare `return`, or a binding named for the entity instead of the id. Verified none of those exist in the tree today. It's a ratchet against the shape that actually recurred 52 times, not a proof of absence.

## Rule #1 / Rule #2

| | |
|---|---|
| **Surface touched** | `bin/hooks.mjs` (shipped hook entry point), MCP tool handlers, daemon/swarm/spell layers |
| **Failure mode for the on-4.12.4 consumer** | None. IDs are opaque, old-format ids keep reading, no `.moflo/` migration, no config change. |
| **Round-trip cost** | `bin/hooks.mjs` and the MCP layer run from `node_modules/moflo/`, so **publish + reinstall** before it takes effect in a dogfood session. |

- `bin/hooks.mjs` uses `node:crypto` `randomBytes` **inline** rather than importing a `bin/lib/` module. It's a shipped hook entry point, and a builtin adds nothing to its resolve closure — the lesson from #1426, where adding a sibling import to `atomic-file-write.ts` broke the launcher's hand-staged dist closure.
- Its `.claude/scripts/hooks.mjs` mirror is re-synced and **verified byte-identical** (the parity break I hit in #1426).
- **Launcher closure re-checked explicitly:** the intersection of the 34 changed `src/cli` files with the 16 `dist/src/cli/**` paths any `bin/*.mjs` dynamically imports is **empty**.
- No new files, so `shipped-scripts.json` needs no edit. No paths, separators, or shell-outs added.

## Protected surface (swarm / hive-mind)

Touched `hooks/swarm/index.ts`, `swarm/federation-hub.ts`, `swarm/queen-coordinator.ts`, `swarm/consensus/gossip.ts`, `mcp-tools/hive-mind-tools.ts`. All four CLAUDE.md invariants re-verified: `swarm_init` still returns `state.id.id` from the coordinator (`swarm-tools.ts` is untouched), `agent_spawn` still calls `coordinator.spawnAgent`, `task_*` still calls the coordinator, hive-mind still routes through MessageBus. `tests/system/swarm-restoration-e2e.test.ts` + `tests/hive-mind-messagebus.test.ts` green (30 tests).

`doctor-checks-swarm.ts`'s `STUB_SWARM_ID_PATTERN` (`/^swarm-\d+$/`) is **not** blinded by this diff — it inspects the `swarm_init` MCP tool's return value, which this PR doesn't touch.

## From the review pass

- The guard was walking and re-reading the **entire shipped tree three times** (I added the third scan). Now read once and memoised behind a shared `scan(predicate)` helper, which also makes the self-test use the *same* predicate as the scan so the two can't drift.
- Line splitting moved to `/\r?\n/`. `.gitattributes` pins `eol=lf`, so this is the habit rather than a live fix — the comment says so instead of implying a bug that isn't there.
- `bin/lib/incremental-write.mjs` has its own private `generateId`, but it's `mem_`-specific and unexported, so the inline `randomBytes` in `bin/hooks.mjs` isn't duplication.
- **Considered and declined:** migrating this guard's filesystem walk to the shared `tests/guards/_helpers/tracked-files.ts` that three sibling guards use. It's the better helper, but it lists `git ls-files` — the index. This guard's whole value is tripping a new offender on **first use**, and a file that hasn't been `git add`ed yet wouldn't be listed. The existing walk scans strictly more. Left alone.

## Noted, not changed

`federation-hub.ts`'s `federationId` lives in a module-level `DEFAULT_CONFIG`, so it's minted **once per process** rather than per federation. That was equally true before this PR — the entropy now at least separates two processes starting in the same millisecond — but any federation that doesn't pass an explicit id still shares one. Pre-existing design issue, left alone deliberately.

## Testing

- **Full suite: 10,659 passed, 0 failed.** `tsc --noEmit` and `eslint --max-warnings 0` clean.
- Two tests pinned `/^sp-\d+$/` — the defect itself — and now assert the random segment.

## Found along the way — filed, not fixed here

**#1428** — `flo swarm start` prints "All agents deployed" and "Swarm execution started" after a 500 ms spinner delay, without ever calling the coordinator, and hands back a `swarmId` that `flo swarm status` can never resolve. Surfaced because its id was in scope here; rewiring a protected-surface command is a load-bearing change and doesn't belong in a mechanical entropy diff. This PR converts that one line for guard consistency, which is not an endorsement of the path.
