### PR TITLE
fix(doctor): resolve the project root consistently in daemon auto-fixes (#1431)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,11 +141,12 @@ After `npm install` touches moflo, check `.moflo/restart-pending.json` — if pr
 
 ### Monorepos
 
-Moflo state lives at the monorepo root `.moflo/` — never run `flo init` inside a sub-workspace of an existing moflo project, or the MCP server and CLI silently bind to different daemons (issue #1174).
+Moflo state lives at the monorepo root `.moflo/` — never run `flo init` inside a sub-workspace of an existing moflo project, or the MCP server and CLI silently bind to different daemons.
 
 ### Full Reference
 
 - Universal agent rules (memory protocol, git/PR conventions, file org, build/test): `.claude/guidance/moflo-agent-rules.md`
+- Fix small defects in the PR you are already in — don't file them: `.claude/guidance/moflo-inline-fixes.md`
 - Subagent spawn protocol: `.claude/guidance/moflo-subagents.md`
 - Task + swarm coordination: `.claude/guidance/moflo-claude-swarm-cohesion.md`
 - CLI, hooks, swarm, memory, moflo.yaml: `.claude/guidance/moflo-core-guidance.md`

--- a/src/cli/__tests__/commands/doctor-fixes-orphan.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-orphan.test.ts
@@ -8,13 +8,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, realpathSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { spawn, type ChildProcess } from 'child_process';
 import { autoFixCheck } from '../../commands/doctor-fixes.js';
 import { checkDaemonOrphan } from '../../commands/doctor-checks-config.js';
 import { findProjectDaemonPids, lockPath, reapSameProjectOrphans } from '../../services/daemon-lock.js';
+import { findProjectRoot } from '../../services/project-root.js';
 
 const FAKE_DAEMON_SCRIPT = `
 process.stdin.resume();
@@ -38,6 +39,7 @@ describe('Daemon Orphan healer (#1150)', () => {
   let tempDir: string;
   let priorCwd: string;
   let priorSkip: string | undefined;
+  let priorProjectDir: string | undefined;
   let children: ChildProcess[] = [];
 
   beforeEach(() => {
@@ -45,11 +47,22 @@ describe('Daemon Orphan healer (#1150)', () => {
     delete process.env.MOFLO_TEST_SKIP_ORPHAN_SCAN;
 
     priorCwd = process.cwd();
-    tempDir = mkdtempSync(join(tmpdir(), 'orphan-fix-'));
+    // realpathSync: macOS hands out `/var/folders/...` paths that resolve to
+    // `/private/var/folders/...`, and `projectCliCandidates` realpaths the root
+    // prefix before matching a daemon cmdline (#1145). Without this the
+    // candidate paths and the spawned daemon's cmdline never match on macOS.
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'orphan-fix-')));
     mkdirSync(join(tempDir, '.moflo'), { recursive: true });
     mkdirSync(join(tempDir, 'bin'), { recursive: true });
     writeFileSync(join(tempDir, 'bin', 'cli.js'), FAKE_DAEMON_SCRIPT);
     process.chdir(tempDir);
+
+    // #1431 — the fix handlers now resolve via `findProjectRoot()`, which
+    // honors `CLAUDE_PROJECT_DIR` ahead of cwd. Under vitest that variable
+    // points at the real moflo checkout, so without this anchor these tests
+    // would enumerate — and reap — the developer's own running daemons.
+    priorProjectDir = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = tempDir;
   });
 
   afterEach(async () => {
@@ -61,6 +74,8 @@ describe('Daemon Orphan healer (#1150)', () => {
     process.chdir(priorCwd);
     rmSync(tempDir, { recursive: true, force: true });
     if (priorSkip !== undefined) process.env.MOFLO_TEST_SKIP_ORPHAN_SCAN = priorSkip;
+    if (priorProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = priorProjectDir;
   });
 
   function spawnFakeDaemon(): Promise<number> {
@@ -152,4 +167,71 @@ describe('Daemon Orphan healer (#1150)', () => {
     const pids = findProjectDaemonPids(tempDir);
     expect(pids).toEqual([pid1]);
   }, 20000);
+
+  /**
+   * #1431 — the fix used to root itself at `process.cwd()` while
+   * `checkDaemonOrphan` walks up to the project root. Invoked from a
+   * subdirectory the two disagreed: `findProjectDaemonPids(<subdir>)` returns
+   * `[]`, so the handler fell through `pids.length <= 1` and returned `true`.
+   * Doctor printed "Fixed: Daemon Orphan" having reaped nothing.
+   *
+   * Both cases below run the fix from a subdirectory with two live daemons.
+   * They differ only in how the root is reachable — via `CLAUDE_PROJECT_DIR`
+   * (what Claude Code sets, the dominant path) and via the marker walk with
+   * the variable absent (a plain shell). Against the old handler both fail on
+   * the surviving orphan.
+   */
+  describe('fix invoked from a subdirectory (#1431)', () => {
+    async function expectOrphanReapedFromSubdir(subdir: string, pid1: number, pid2: number) {
+      writeFileSync(
+        lockPath(tempDir),
+        JSON.stringify({ pid: pid1, startedAt: Date.now(), label: 'moflo-daemon' }),
+      );
+      process.chdir(subdir);
+
+      const success = await autoFixCheck({
+        name: 'Daemon Orphan',
+        status: 'fail',
+        message: '2 daemons',
+        fix: 'flo healer --fix -c daemon-orphan',
+      });
+
+      // The orphan is gone and the lock-holder survives — i.e. the fix acted
+      // on the same daemons the check counted, rather than reporting a
+      // no-op success.
+      expect(await waitForDead(pid2)).toBe(true);
+      expect(isAlive(pid1)).toBe(true);
+      expect(success).toBe(true);
+    }
+
+    it('reaps the orphan when CLAUDE_PROJECT_DIR anchors the root', async () => {
+      const pid1 = await spawnFakeDaemon();
+      const pid2 = await spawnFakeDaemon();
+      const subdir = join(tempDir, 'packages', 'api');
+      mkdirSync(subdir, { recursive: true });
+      // beforeEach already anchored CLAUDE_PROJECT_DIR at tempDir.
+      await expectOrphanReapedFromSubdir(subdir, pid1, pid2);
+    }, 20000);
+
+    it('reaps the orphan when the root is only reachable by the marker walk', async () => {
+      const pid1 = await spawnFakeDaemon();
+      const pid2 = await spawnFakeDaemon();
+      const subdir = join(tempDir, 'packages', 'api');
+      mkdirSync(subdir, { recursive: true });
+
+      // Drop the env anchor so Pass A's topmost-marker walk is what resolves
+      // the root, and give it the marker it looks for.
+      delete process.env.CLAUDE_PROJECT_DIR;
+      writeFileSync(join(tempDir, '.moflo', 'moflo.db'), '');
+      process.chdir(subdir);
+
+      // Guard: assert the walk lands on tempDir BEFORE running a fix that
+      // reaps processes. If an ancestor of the OS temp dir ever carried a
+      // moflo marker, "topmost wins" would resolve above tempDir — this fails
+      // loudly instead of letting the reap run against a wider root.
+      expect(findProjectRoot()).toBe(tempDir);
+
+      await expectOrphanReapedFromSubdir(subdir, pid1, pid2);
+    }, 20000);
+  });
 });

--- a/src/cli/__tests__/commands/doctor-fixes-orphan.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-orphan.test.ts
@@ -233,5 +233,84 @@ describe('Daemon Orphan healer (#1150)', () => {
 
       await expectOrphanReapedFromSubdir(subdir, pid1, pid2);
     }, 20000);
+
+    /**
+     * The other half of #1431. `findProjectRoot()` Pass A returns the TOPMOST
+     * ancestor with `.moflo/moflo.db` (#1174's monorepo rule). For a checkout
+     * nested inside an unrelated project that walk climbs past the nested
+     * root and lands on the PARENT's — whose daemons are not ours to kill.
+     *
+     * Rooting the fix at `process.cwd()` made this a harmless no-op, because
+     * the scan found no daemons under the nested root. Aligning the fix with
+     * the check must not upgrade that no-op into a kill, so the handler
+     * refuses when a nearer moflo root sits at or above the cwd.
+     */
+    it('refuses to reap the parent project from a nested checkout', async () => {
+      // tempDir is the OUTER project and owns both daemons.
+      const outerPid1 = await spawnFakeDaemon();
+      const outerPid2 = await spawnFakeDaemon();
+      writeFileSync(join(tempDir, '.moflo', 'moflo.db'), '');
+
+      // An unrelated checkout nested inside it, with its own moflo state.
+      const nested = join(tempDir, 'vendor', 'other-project');
+      mkdirSync(join(nested, '.moflo'), { recursive: true });
+      writeFileSync(join(nested, '.moflo', 'moflo.db'), '');
+
+      delete process.env.CLAUDE_PROJECT_DIR;
+      process.chdir(nested);
+
+      // Pass A really does resolve past the nested root to the outer one —
+      // without this the test could pass for the wrong reason.
+      expect(findProjectRoot()).toBe(tempDir);
+
+      const success = await autoFixCheck({
+        name: 'Daemon Orphan',
+        status: 'fail',
+        message: '2 daemons',
+        fix: 'flo healer --fix -c daemon-orphan',
+      });
+
+      expect(success).toBe(false);
+      expect(isAlive(outerPid1)).toBe(true);
+      expect(isAlive(outerPid2)).toBe(true);
+    }, 20000);
+
+    /**
+     * Observed damage, not a hypothetical. An earlier revision of the guard
+     * returned the resolved root whenever the cwd had no moflo marker at or
+     * above it. `findProjectRoot()` returns `CLAUDE_PROJECT_DIR` verbatim, and
+     * that variable is inherited by hooks and test runners whose cwd is an
+     * unrelated temp fixture — so the handler reaped the daemons of the project
+     * the ENVIRONMENT named while running somewhere with no relationship to it.
+     * Under vitest that is the developer's own checkout, and it killed a live
+     * daemon during a full-suite run.
+     *
+     * The cwd must be inside the root before anything is reaped.
+     */
+    it('refuses when the cwd lives outside the env-named project root', async () => {
+      const pid1 = await spawnFakeDaemon();
+      const pid2 = await spawnFakeDaemon();
+
+      // CLAUDE_PROJECT_DIR still names tempDir (beforeEach), but we run from an
+      // unrelated directory that is not underneath it.
+      const outside = realpathSync(mkdtempSync(join(tmpdir(), 'orphan-outside-')));
+      try {
+        process.chdir(outside);
+
+        const success = await autoFixCheck({
+          name: 'Daemon Orphan',
+          status: 'fail',
+          message: '2 daemons',
+          fix: 'flo healer --fix -c daemon-orphan',
+        });
+
+        expect(success).toBe(false);
+        expect(isAlive(pid1)).toBe(true);
+        expect(isAlive(pid2)).toBe(true);
+      } finally {
+        process.chdir(tempDir);
+        rmSync(outside, { recursive: true, force: true });
+      }
+    }, 20000);
   });
 });

--- a/src/cli/__tests__/commands/doctor-fixes-orphan.test.ts
+++ b/src/cli/__tests__/commands/doctor-fixes-orphan.test.ts
@@ -312,5 +312,41 @@ describe('Daemon Orphan healer (#1150)', () => {
         rmSync(outside, { recursive: true, force: true });
       }
     }, 20000);
+
+    /**
+     * `findProjectRoot` Pass A accepts `.moflo/moflo.db` OR a legacy
+     * `.swarm/memory.db` as a root marker. A guard that disambiguates on only
+     * the first is blind to a nested checkout still on the legacy layout —
+     * it sees no nearer root, concludes there is nothing to disambiguate, and
+     * allows the outer project's daemons to be reaped. The guard must test the
+     * same marker set as the resolver it is guarding.
+     */
+    it('refuses from a nested checkout marked only by legacy .swarm/memory.db', async () => {
+      const outerPid1 = await spawnFakeDaemon();
+      const outerPid2 = await spawnFakeDaemon();
+      writeFileSync(join(tempDir, '.moflo', 'moflo.db'), '');
+
+      // Nested project on the pre-migration layout: no `.moflo/moflo.db`.
+      const nested = join(tempDir, 'vendor', 'legacy-project');
+      mkdirSync(join(nested, '.swarm'), { recursive: true });
+      writeFileSync(join(nested, '.swarm', 'memory.db'), '');
+
+      delete process.env.CLAUDE_PROJECT_DIR;
+      process.chdir(nested);
+
+      // Pass A counts the legacy marker too, so it still climbs to tempDir.
+      expect(findProjectRoot()).toBe(tempDir);
+
+      const success = await autoFixCheck({
+        name: 'Daemon Orphan',
+        status: 'fail',
+        message: '2 daemons',
+        fix: 'flo healer --fix -c daemon-orphan',
+      });
+
+      expect(success).toBe(false);
+      expect(isAlive(outerPid1)).toBe(true);
+      expect(isAlive(outerPid2)).toBe(true);
+    }, 20000);
   });
 });

--- a/src/cli/commands/doctor-checks-runtime.ts
+++ b/src/cli/commands/doctor-checks-runtime.ts
@@ -20,25 +20,13 @@ const execAsync = promisify(exec);
  * Execute command asynchronously with proper environment inheritance.
  * Critical for Windows where PATH may not be inherited properly.
  */
-export async function runCommand(
-  command: string,
-  timeoutMs: number = 5000,
-  /**
-   * Working directory for the child. Omitted, the child inherits
-   * `process.cwd()`. The daemon auto-fixes pass the resolved project root so
-   * the respawn lands where they reaped, instead of relying on the spawned
-   * command to independently re-derive the same root from an unrelated cwd
-   * (#1431).
-   */
-  opts_: { cwd?: string } = {},
-): Promise<string> {
+export async function runCommand(command: string, timeoutMs: number = 5000): Promise<string> {
   const opts = {
     encoding: 'utf8' as BufferEncoding,
     timeout: timeoutMs,
     shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
     env: { ...process.env },
     windowsHide: true,
-    ...(opts_.cwd ? { cwd: opts_.cwd } : {}),
   };
   const { stdout } = await execAsync(command, opts);
   const out = (stdout as string).trim();

--- a/src/cli/commands/doctor-checks-runtime.ts
+++ b/src/cli/commands/doctor-checks-runtime.ts
@@ -20,13 +20,25 @@ const execAsync = promisify(exec);
  * Execute command asynchronously with proper environment inheritance.
  * Critical for Windows where PATH may not be inherited properly.
  */
-export async function runCommand(command: string, timeoutMs: number = 5000): Promise<string> {
+export async function runCommand(
+  command: string,
+  timeoutMs: number = 5000,
+  /**
+   * Working directory for the child. Omitted, the child inherits
+   * `process.cwd()`. The daemon auto-fixes pass the resolved project root so
+   * the respawn lands where they reaped, instead of relying on the spawned
+   * command to independently re-derive the same root from an unrelated cwd
+   * (#1431).
+   */
+  opts_: { cwd?: string } = {},
+): Promise<string> {
   const opts = {
     encoding: 'utf8' as BufferEncoding,
     timeout: timeoutMs,
     shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/sh',
     env: { ...process.env },
     windowsHide: true,
+    ...(opts_.cwd ? { cwd: opts_.cwd } : {}),
   };
   const { stdout } = await execAsync(command, opts);
   const out = (stdout as string).trim();

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -23,9 +23,9 @@ import { installClaudeCode, runCommand } from './doctor-checks-runtime.js';
 import type { HealthCheck } from './doctor-types.js';
 
 /** Run a shell command as a fix action. Returns true on exit code 0. */
-async function runFixCommand(cmd: string, cwd?: string): Promise<boolean> {
+async function runFixCommand(cmd: string): Promise<boolean> {
   try {
-    await runCommand(cmd, 30_000, cwd ? { cwd } : {});
+    await runCommand(cmd, 30_000);
     return true;
   } catch {
     return false;
@@ -697,7 +697,7 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
         if (existsSync(lockFile)) unlinkSync(lockFile);
         if (existsSync(pidFile)) unlinkSync(pidFile);
       } catch { /* best effort */ }
-      return runFixCommand('npx moflo daemon start', root);
+      return runFixCommand('npx moflo daemon start');
     },
     // Epic #1054.S5 / #1059 — SIGTERM the stale daemon and let the launcher's
     // existing respawn path (mirrored as `npx moflo daemon start`) pick up the
@@ -715,7 +715,7 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       }
       const lockFile = join(root, '.moflo', 'daemon.lock');
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
-      return runFixCommand('npx moflo daemon start', root);
+      return runFixCommand('npx moflo daemon start');
     },
     // #1150 — terminate same-project orphan daemons. Keep the lock-holder
     // alive if it shows up in the scan (it's the canonical daemon). If the
@@ -748,7 +748,7 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       const lockFile = join(root, '.moflo', 'daemon.lock');
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
       if (survived.length > 0) return false;
-      return runFixCommand('npx moflo daemon start', root);
+      return runFixCommand('npx moflo daemon start');
     },
     // #1145 — daemon claims a different projectRoot than ours (or has no
     // port in its lock so we can't verify). Same recycle pattern as version
@@ -768,7 +768,7 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       }
       const lockFile = join(root, '.moflo', 'daemon.lock');
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
-      return runFixCommand('npx moflo daemon start', root);
+      return runFixCommand('npx moflo daemon start');
     },
     'Embedding Coverage Truth': async () => {
       // Same as the existing Embeddings fix — rebuild the cache by re-running

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -6,14 +6,14 @@
  * if it looks like an `npx`/`npm`/`claude` command.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmdirSync, unlinkSync, writeFileSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmdirSync, unlinkSync, writeFileSync, readdirSync } from 'fs';
+import { isAbsolute, join, relative, resolve } from 'path';
 import { output } from '../output.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 import { findProjectDaemonPids, getDaemonLockHolder } from '../services/daemon-lock.js';
-import { findProjectRoot, resolveStateRoot } from '../services/project-root.js';
+import { findAncestorMofloRoot, findProjectRoot, resolveStateRoot } from '../services/project-root.js';
 import { legacyMemoryDbPath, legacyMemoryDbBakPath, memoryDbPath, mofloDir } from '../services/moflo-paths.js';
 import { findZombieProcesses } from './doctor-zombies.js';
 import { loadToolArrays, getTool } from './doctor-checks-functional-shared.js';
@@ -23,13 +23,68 @@ import { installClaudeCode, runCommand } from './doctor-checks-runtime.js';
 import type { HealthCheck } from './doctor-types.js';
 
 /** Run a shell command as a fix action. Returns true on exit code 0. */
-async function runFixCommand(cmd: string): Promise<boolean> {
+async function runFixCommand(cmd: string, cwd?: string): Promise<boolean> {
   try {
-    await runCommand(cmd, 30_000);
+    await runCommand(cmd, 30_000, cwd ? { cwd } : {});
     return true;
   } catch {
     return false;
   }
+}
+
+/** `realpathSync` if the path exists, else the absolutized string. */
+function canonical(p: string): string {
+  const abs = resolve(p);
+  try { return realpathSync(abs); } catch { return abs; }
+}
+
+/** Nearest `.moflo/moflo.db` at or above `from`, or null. */
+function nearestMofloRoot(from: string): string | null {
+  const abs = resolve(from);
+  if (existsSync(join(abs, '.moflo', 'moflo.db'))) return abs;
+  return findAncestorMofloRoot(abs);
+}
+
+/**
+ * Resolve the project root the daemon auto-fixes may act on, or null to refuse.
+ *
+ * The fixes SIGTERM processes and unlink lock files, so an over-broad root is
+ * not a cosmetic error. `findProjectRoot()` Pass A deliberately returns the
+ * TOPMOST ancestor carrying `.moflo/moflo.db` (#1174, so a monorepo's root
+ * daemon is canonical). For a checkout nested inside an unrelated project that
+ * walk climbs past our own root and lands on the parent's — whose daemons are
+ * not ours to kill. These handlers were previously rooted at `process.cwd()`,
+ * where that case degraded to a harmless no-op (`pids` came back empty), so
+ * aligning them with `checkDaemonOrphan` must not convert a no-op into a kill.
+ *
+ * Refuse whenever a NEARER moflo root sits at or above the cwd and differs
+ * from the resolved root: that is the nested-checkout signature. Both sides are
+ * realpath'd before comparison (Rule #1 §2) — `findProjectRoot` may hand back a
+ * raw `CLAUDE_PROJECT_DIR` while the walk yields a resolved path, and on macOS
+ * `/var/folders` vs `/private/var/folders` would otherwise compare unequal.
+ */
+function daemonFixRoot(): string | null {
+  const root = findProjectRoot();
+  const rootC = canonical(root);
+  const cwdC = canonical(process.cwd());
+
+  // Containment first: the cwd must live inside the root we are about to reap
+  // in. `findProjectRoot` returns `CLAUDE_PROJECT_DIR` verbatim when set, and
+  // that variable is inherited by hooks, test runners, and spawned tools whose
+  // cwd may be somewhere else entirely — a temp fixture, `/`, another repo.
+  // Without this check the handler happily reaps the daemons of whatever
+  // project the environment names, from a cwd with no relationship to it.
+  // `relative` + `isAbsolute` rather than string prefixing: on Windows two
+  // different drive letters yield an absolute result, which must count as
+  // "outside" (Rule #1).
+  const rel = relative(rootC, cwdC);
+  if (rel !== '' && (rel.startsWith('..') || isAbsolute(rel))) return null;
+
+  const nearest = nearestMofloRoot(cwdC);
+  // No moflo state anywhere at or above cwd: nothing to disambiguate, and the
+  // scan will find no same-project daemons anyway.
+  if (nearest === null) return root;
+  return canonical(nearest) === rootC ? root : null;
 }
 
 /**
@@ -607,21 +662,24 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     // Also reaps any same-project orphans whose PIDs aren't recorded in the
     // lock — those are the daemons that survived prior buggy fixes.
     'Daemon Status': async () => {
-      const cwd = process.cwd();
+      // #1431 — same subdirectory-mismatch class as `Daemon Orphan`; this one
+      // also reaps and unlinks, so it takes the same guarded root.
+      const root = daemonFixRoot();
+      if (root === null) return false;
       const { getDaemonLockPayload, reapSameProjectOrphans } = await import('../services/daemon-lock.js');
-      const payload = getDaemonLockPayload(cwd);
+      const payload = getDaemonLockPayload(root);
       if (payload?.pid && payload.pid > 0) {
         try { process.kill(payload.pid, 'SIGTERM'); } catch { /* already dead */ }
       }
       // Wipe other same-project daemons that the lock doesn't account for.
-      reapSameProjectOrphans(cwd);
-      const lockFile = join(cwd, '.moflo', 'daemon.lock');
-      const pidFile = join(cwd, '.moflo', 'daemon.pid');
+      reapSameProjectOrphans(root);
+      const lockFile = join(root, '.moflo', 'daemon.lock');
+      const pidFile = join(root, '.moflo', 'daemon.pid');
       try {
         if (existsSync(lockFile)) unlinkSync(lockFile);
         if (existsSync(pidFile)) unlinkSync(pidFile);
       } catch { /* best effort */ }
-      return runFixCommand('npx moflo daemon start');
+      return runFixCommand('npx moflo daemon start', root);
     },
     // Epic #1054.S5 / #1059 — SIGTERM the stale daemon and let the launcher's
     // existing respawn path (mirrored as `npx moflo daemon start`) pick up the
@@ -629,15 +687,17 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     // bin/session-start-launcher.mjs so the auto-fix matches the launcher's
     // behavior exactly.
     'Daemon Version Skew': async () => {
-      const cwd = process.cwd();
+      // #1431 — same subdirectory-mismatch class as `Daemon Orphan`.
+      const root = daemonFixRoot();
+      if (root === null) return false;
       const { getDaemonLockPayload } = await import('../services/daemon-lock.js');
-      const payload = getDaemonLockPayload(cwd);
+      const payload = getDaemonLockPayload(root);
       if (payload?.pid && payload.pid > 0) {
         try { process.kill(payload.pid, 'SIGTERM'); } catch { /* already dead */ }
       }
-      const lockFile = join(cwd, '.moflo', 'daemon.lock');
+      const lockFile = join(root, '.moflo', 'daemon.lock');
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
-      return runFixCommand('npx moflo daemon start');
+      return runFixCommand('npx moflo daemon start', root);
     },
     // #1150 — terminate same-project orphan daemons. Keep the lock-holder
     // alive if it shows up in the scan (it's the canonical daemon). If the
@@ -651,7 +711,8 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       // the raw cwd, so `flo doctor --fix` from a subdirectory scanned a root
       // with no daemons, fell through `pids.length <= 1`, and reported
       // "Fixed: Daemon Orphan" without reaping anything.
-      const root = findProjectRoot();
+      const root = daemonFixRoot();
+      if (root === null) return false;
       const { findProjectDaemonPids, getDaemonLockHolder, reapSameProjectOrphans } =
         await import('../services/daemon-lock.js');
       const pids = findProjectDaemonPids(root);
@@ -669,7 +730,7 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       const lockFile = join(root, '.moflo', 'daemon.lock');
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
       if (survived.length > 0) return false;
-      return runFixCommand('npx moflo daemon start');
+      return runFixCommand('npx moflo daemon start', root);
     },
     // #1145 — daemon claims a different projectRoot than ours (or has no
     // port in its lock so we can't verify). Same recycle pattern as version
@@ -680,7 +741,8 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       // #1431 — same resolver as `checkDaemonIdentityMatch`; see the note on
       // the `Daemon Orphan` handler above. Reading the lock from a raw cwd
       // would SIGTERM nothing and unlink a path the daemon never wrote.
-      const root = findProjectRoot();
+      const root = daemonFixRoot();
+      if (root === null) return false;
       const { getDaemonLockPayload } = await import('../services/daemon-lock.js');
       const payload = getDaemonLockPayload(root);
       if (payload?.pid && payload.pid > 0) {
@@ -688,7 +750,7 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
       }
       const lockFile = join(root, '.moflo', 'daemon.lock');
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
-      return runFixCommand('npx moflo daemon start');
+      return runFixCommand('npx moflo daemon start', root);
     },
     'Embedding Coverage Truth': async () => {
       // Same as the existing Embeddings fix — rebuild the cache by re-running

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -7,13 +7,13 @@
  */
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmdirSync, unlinkSync, writeFileSync, readdirSync } from 'fs';
-import { isAbsolute, join, relative, resolve } from 'path';
+import { basename, dirname, isAbsolute, join, parse, relative, resolve } from 'path';
 import { output } from '../output.js';
 import { errorDetail } from '../shared/utils/error-detail.js';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 import { findProjectDaemonPids, getDaemonLockHolder } from '../services/daemon-lock.js';
-import { findAncestorMofloRoot, findProjectRoot, resolveStateRoot } from '../services/project-root.js';
+import { findProjectRoot, resolveStateRoot } from '../services/project-root.js';
 import { legacyMemoryDbPath, legacyMemoryDbBakPath, memoryDbPath, mofloDir } from '../services/moflo-paths.js';
 import { findZombieProcesses } from './doctor-zombies.js';
 import { loadToolArrays, getTool } from './doctor-checks-functional-shared.js';
@@ -38,11 +38,36 @@ function canonical(p: string): string {
   try { return realpathSync(abs); } catch { return abs; }
 }
 
-/** Nearest `.moflo/moflo.db` at or above `from`, or null. */
+/**
+ * Pass A's marker test, mirrored exactly.
+ *
+ * `findProjectRoot` treats `.moflo/moflo.db` OR a legacy `.swarm/memory.db` as
+ * equally valid (`project-root.ts` Pass A). Disambiguating on the narrower
+ * signal would leave the guard blind to a nested checkout that has only the
+ * legacy marker — which is the very case it exists to catch. `findAncestorMofloRoot`
+ * is deliberately NOT reused here: it tests only `.moflo/moflo.db`, it is
+ * exclusive of its starting directory, and it has an algorithmic twin in
+ * `bin/lib/moflo-paths.mjs` that `flo init` and the launcher depend on.
+ */
+function hasMofloMarker(dir: string): boolean {
+  return existsSync(join(dir, '.moflo', 'moflo.db')) || existsSync(join(dir, '.swarm', 'memory.db'));
+}
+
+/** Nearest moflo root at or above `from` (inclusive), or null. */
 function nearestMofloRoot(from: string): string | null {
-  const abs = resolve(from);
-  if (existsSync(join(abs, '.moflo', 'moflo.db'))) return abs;
-  return findAncestorMofloRoot(abs);
+  const start = resolve(from);
+  const fsRoot = parse(start).root;
+  let dir = start;
+  while (dir !== fsRoot) {
+    // Same skip as Pass A — a marker inside `node_modules` is a vendored
+    // package's state, not a project root.
+    if (basename(dir) === 'node_modules') { dir = dirname(dir); continue; }
+    if (hasMofloMarker(dir)) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
 }
 
 /**

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -646,22 +646,27 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     // threaded into `reapSameProjectOrphans` so we don't re-run the
     // OS process scan inside it.
     'Daemon Orphan': async () => {
-      const cwd = process.cwd();
+      // #1431 — resolve the root the way `checkDaemonOrphan` does, not with
+      // `process.cwd()`. The check walks up to the project root; the fix used
+      // the raw cwd, so `flo doctor --fix` from a subdirectory scanned a root
+      // with no daemons, fell through `pids.length <= 1`, and reported
+      // "Fixed: Daemon Orphan" without reaping anything.
+      const root = findProjectRoot();
       const { findProjectDaemonPids, getDaemonLockHolder, reapSameProjectOrphans } =
         await import('../services/daemon-lock.js');
-      const pids = findProjectDaemonPids(cwd);
+      const pids = findProjectDaemonPids(root);
       if (pids.length <= 1) return true; // already healthy
 
-      const lockHolder = getDaemonLockHolder(cwd);
+      const lockHolder = getDaemonLockHolder(root);
       if (lockHolder != null && pids.includes(lockHolder)) {
-        const { survived } = reapSameProjectOrphans(cwd, process.pid, lockHolder, pids);
+        const { survived } = reapSameProjectOrphans(root, process.pid, lockHolder, pids);
         return survived.length === 0;
       }
 
       // No identifiable canonical daemon — kill them all, clear the lock,
       // respawn fresh.
-      const { survived } = reapSameProjectOrphans(cwd, process.pid, undefined, pids);
-      const lockFile = join(cwd, '.moflo', 'daemon.lock');
+      const { survived } = reapSameProjectOrphans(root, process.pid, undefined, pids);
+      const lockFile = join(root, '.moflo', 'daemon.lock');
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
       if (survived.length > 0) return false;
       return runFixCommand('npx moflo daemon start');
@@ -672,13 +677,16 @@ export async function autoFixCheck(check: HealthCheck): Promise<boolean> {
     // daemon binds the per-project deterministic port and stamps it into
     // the lock — clients can discover it without guessing.
     'Daemon Identity Match': async () => {
-      const cwd = process.cwd();
+      // #1431 — same resolver as `checkDaemonIdentityMatch`; see the note on
+      // the `Daemon Orphan` handler above. Reading the lock from a raw cwd
+      // would SIGTERM nothing and unlink a path the daemon never wrote.
+      const root = findProjectRoot();
       const { getDaemonLockPayload } = await import('../services/daemon-lock.js');
-      const payload = getDaemonLockPayload(cwd);
+      const payload = getDaemonLockPayload(root);
       if (payload?.pid && payload.pid > 0) {
         try { process.kill(payload.pid, 'SIGTERM'); } catch { /* already dead */ }
       }
-      const lockFile = join(cwd, '.moflo', 'daemon.lock');
+      const lockFile = join(root, '.moflo', 'daemon.lock');
       try { if (existsSync(lockFile)) unlinkSync(lockFile); } catch { /* ok */ }
       return runFixCommand('npx moflo daemon start');
     },

--- a/src/cli/commands/doctor-fixes.ts
+++ b/src/cli/commands/doctor-fixes.ts
@@ -13,7 +13,7 @@ import { errorDetail } from '../shared/utils/error-detail.js';
 import { atomicWriteFileSync } from '../shared/utils/atomic-file-write.js';
 import { repairHookWiring } from '../services/hook-wiring.js';
 import { findProjectDaemonPids, getDaemonLockHolder } from '../services/daemon-lock.js';
-import { findProjectRoot, resolveStateRoot } from '../services/project-root.js';
+import { findProjectRoot, hasMofloStateMarker, resolveStateRoot } from '../services/project-root.js';
 import { legacyMemoryDbPath, legacyMemoryDbBakPath, memoryDbPath, mofloDir } from '../services/moflo-paths.js';
 import { findZombieProcesses } from './doctor-zombies.js';
 import { loadToolArrays, getTool } from './doctor-checks-functional-shared.js';
@@ -39,21 +39,14 @@ function canonical(p: string): string {
 }
 
 /**
- * Pass A's marker test, mirrored exactly.
+ * Nearest moflo root at or above `from` (inclusive), or null.
  *
- * `findProjectRoot` treats `.moflo/moflo.db` OR a legacy `.swarm/memory.db` as
- * equally valid (`project-root.ts` Pass A). Disambiguating on the narrower
- * signal would leave the guard blind to a nested checkout that has only the
- * legacy marker — which is the very case it exists to catch. `findAncestorMofloRoot`
- * is deliberately NOT reused here: it tests only `.moflo/moflo.db`, it is
- * exclusive of its starting directory, and it has an algorithmic twin in
- * `bin/lib/moflo-paths.mjs` that `flo init` and the launcher depend on.
+ * Shares `hasMofloStateMarker` with `findProjectRoot`'s Pass A rather than
+ * restating the marker set: a guard that tests a narrower signal than the
+ * resolver it guards is blind exactly where it matters, which is #1431's
+ * fourth defect. `findAncestorMofloRoot` is deliberately not reused — it tests
+ * only `.moflo/moflo.db`, and it is exclusive of its starting directory.
  */
-function hasMofloMarker(dir: string): boolean {
-  return existsSync(join(dir, '.moflo', 'moflo.db')) || existsSync(join(dir, '.swarm', 'memory.db'));
-}
-
-/** Nearest moflo root at or above `from` (inclusive), or null. */
 function nearestMofloRoot(from: string): string | null {
   const start = resolve(from);
   const fsRoot = parse(start).root;
@@ -62,7 +55,7 @@ function nearestMofloRoot(from: string): string | null {
     // Same skip as Pass A — a marker inside `node_modules` is a vendored
     // package's state, not a project root.
     if (basename(dir) === 'node_modules') { dir = dirname(dir); continue; }
-    if (hasMofloMarker(dir)) return dir;
+    if (hasMofloStateMarker(dir)) return dir;
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;

--- a/src/cli/services/project-root.ts
+++ b/src/cli/services/project-root.ts
@@ -73,6 +73,23 @@ export interface FindProjectRootOptions {
  *
  * Algorithmic twin of `bin/lib/moflo-paths.mjs:findAncestorMofloRoot()`.
  */
+/**
+ * Does `dir` carry moflo state that makes it a project root?
+ *
+ * The single source of truth for Pass A's marker set, exported so callers that
+ * must agree with the resolver cannot drift from it. #1431 is exactly that
+ * drift: `doctor-fixes.ts` guarded its daemon reaps by looking for
+ * `.moflo/moflo.db` alone, went blind to a nested checkout carrying only the
+ * legacy `.swarm/memory.db`, and allowed the parent project's daemons to be
+ * killed. Any new marker belongs here and nowhere else.
+ *
+ * (`bin/lib/moflo-paths.mjs` holds a plain-JS twin for the launcher, which
+ * cannot import TypeScript — keep the two in step.)
+ */
+export function hasMofloStateMarker(dir: string): boolean {
+  return existsSync(join(dir, '.moflo', 'moflo.db')) || existsSync(join(dir, '.swarm', 'memory.db'));
+}
+
 export function findAncestorMofloRoot(dir: string): string | null {
   const start = resolve(dir);
   const fsRoot = parse(start).root;
@@ -221,7 +238,7 @@ export function findProjectRoot(opts?: FindProjectRootOptions): string {
       dir = dirname(dir);
       continue;
     }
-    if (existsSync(join(dir, '.moflo', 'moflo.db')) || existsSync(join(dir, '.swarm', 'memory.db'))) {
+    if (hasMofloStateMarker(dir)) {
       topmostMemoryMarker = dir;
     }
     const parent = dirname(dir);


### PR DESCRIPTION
Fixes #1431.

## The reported defect

`checkDaemonOrphan` walks up to the project root via `findProjectRoot()`; its auto-fix rooted itself at raw `process.cwd()`. Run `flo doctor --fix` from a subdirectory and `findProjectDaemonPids(<subdir>)` returns `[]`, so the handler hit `pids.length <= 1` and returned `true` — printing `Fixed: Daemon Orphan` having reaped nothing. `Daemon Identity Match`, `Daemon Status`, and `Daemon Version Skew` read the lock the same way.

Non-destructive: the early return happened before any reap, so it was a false success report, not data loss.

## Why this is six commits

Aligning a **destructive** fix with a **read-only** check is not a one-line change, and the first attempt proved it. Each revision fixed a hole the previous one opened, and each hole is now pinned by its own negative control.

| # | Hole | Consequence | Found by |
|---|------|-------------|----------|
| 1 | Fix used `process.cwd()`, check used `findProjectRoot()` | False success from a subdirectory | The issue |
| 2 | Pass A returns the **topmost** `.moflo` ancestor, so a nested checkout resolves to the **parent** | Would SIGTERM another project's daemons — a no-op became a kill | Review |
| 3 | Guard returned the root whenever cwd had no marker; `findProjectRoot` returns `CLAUDE_PROJECT_DIR` verbatim | Reaped the project the **environment** named from an unrelated cwd | **Observed** — killed a live daemon during a full-suite run |
| 4 | Guard tested only `.moflo/moflo.db`; Pass A also accepts legacy `.swarm/memory.db` | Nested legacy-layout checkout invisible to the guard | Adversarial review |
| 5 | Hole 4 was fixed by *restating* Pass A's predicate, re-creating the drift precondition | A future third marker would silently narrow the guard again | Simplify self-review |

Hole 3 was real damage on the author's machine, not a hypothetical. It is the reason `daemonFixRoot()` checks containment before anything else.

## The guard

```ts
function daemonFixRoot(): string | null {
  const root = findProjectRoot();
  const rootC = canonical(root);            // realpath BOTH sides (Rule #1 §2)
  const cwdC  = canonical(process.cwd());

  const rel = relative(rootC, cwdC);        // not string prefixing:
  if (rel !== '' && (rel.startsWith('..') || isAbsolute(rel))) return null;

  const nearest = nearestMofloRoot(cwdC);   // mirrors Pass A's marker set
  if (nearest === null) return root;
  return canonical(nearest) === rootC ? root : null;
}
```

`findAncestorMofloRoot` is deliberately **not** reused: it tests only `.moflo/moflo.db`, is exclusive of its starting directory, and has an algorithmic twin in `bin/lib/moflo-paths.mjs` that `flo init` and the session-start launcher depend on.

The daemon respawn keeps its long-standing inherit-cwd behaviour. An earlier revision threaded the resolved root into it; that was reverted because the benefit could never be demonstrated — the spawned daemon re-derives its own root via `resolveStateRoot()`, the suite reports identical counts with and without it, and the only available test would assert argument forwarding rather than effect. `doctor-checks-runtime.ts` is byte-identical to main.

## Rule #1

Containment was verified empirically under both path flavours rather than reasoned about:

```
path.win32 :  D:\other        → REFUSE   (cross-drive)
              C:\elsewhere    → REFUSE   (sibling)
              C:\PROJ\sub     → allow    (NTFS case-insensitivity)
path.posix :  /projector      → REFUSE   (the string-prefix trap)
              /proj/sub       → allow
```

`/projector` is the one that matters — `startsWith('/proj')` would have called it "inside". Both sides are realpath'd, no separators or temp paths are hardcoded, and no shell-outs were added.

## Dogfooding

Doctor and the healer run from `node_modules/moflo`, so **this fix is not live until a publish + reinstall**. Installed 4.12.5 has 0 occurrences of `daemonFixRoot`; the source build has 5.

That also bounds the blast radius of hole 3: it existed only in the source build between two commits on this branch, so no consumer was ever exposed. Installed 4.12.5 keeps the old `process.cwd()` behaviour — buggy from a subdirectory, but safe. Nothing landed in `bin/`, `bin/lib/`, or `.claude/scripts/`, so there is no `shipped-scripts.json` entry or `.claude/helpers` mirror to keep in step.

## Verification

- Default suite **9398 passed** / 10 skipped, isolation batch **10780 passed** / 17 skipped, zero failures. `eslint --max-warnings 0` clean.
- Three negative controls: reverting the source fix fails the two subdirectory tests; neutering the refusal fails the nested-checkout test; narrowing the marker set fails the legacy-layout test.
- The author's daemon (PID 1756979) survived both suite runs — the check that would have caught hole 3 earlier.

One unrelated commit is included: `CLAUDE.md` picked up the block re-injected by the 4.12.5 launcher (adds the inline-fixes reference, drops an issue citation from consumer-facing prose). Generated, not hand-edited.

## Still open

The two-daemon state that started this investigation remains unexplained — same host, no symlinks, all resolvers agreeing, lock untouched, second daemon 16 hours later. Nothing here accounts for it, and it is deliberately not claimed as fixed.
