### PR TITLE
fix(gates): stop the learnings gate manufacturing filler (#1434)

### DIFF
--- a/.claude/guidance/shipped/moflo-agent-rules.md
+++ b/.claude/guidance/shipped/moflo-agent-rules.md
@@ -170,7 +170,22 @@ npx flo memory store --namespace patterns --key "brief-descriptive-key" --value 
 | `patterns` | Solutions to tricky bugs, patterns that worked, gotchas, workarounds |
 | `learnings` | Architectural choices, user-stated decisions, post-mortem insights (`knowledge` is a deprecated alias — writes auto-redirect) |
 
+**Every entry must clear one bar: would it help a future session working on a *different* task?**
+If not, it does not go in memory. `memory_search` returns a **bounded** result set, so a non-durable
+entry does not merely waste space — it permanently displaces a reusable lesson from every future
+search.
+
+**Never store a summary of the run that just happened.** What you changed, which files you touched,
+which tests you ran, and what you decided for this one ticket are git history and belong in the
+commit or PR body. That content is applicable exactly once, so it can only ever crowd out something
+that is applicable repeatedly.
+
 **Skip** generic summaries of retrieved guidance, restated rules, and trivial file-location notes — those waste retrieval bandwidth on every future search.
+
+**A gate never justifies a write.** When a gate demands a memory write and the run produced nothing
+durable, declare that instead of inventing something — a mandatory write with nothing to say
+produces filler by construction. `/flo`'s learnings gate takes
+`node .claude/helpers/gate.cjs record-no-durable-lesson` for exactly this case.
 
 ---
 

--- a/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
+++ b/.claude/guidance/shipped/moflo-claude-swarm-cohesion.md
@@ -132,7 +132,7 @@ Close every task you open. moflo's PR gate reads the session transcript on `gh p
 | 3 | Mark `completed` when results return |
 | 4 | Use `TaskList` to monitor what's unblocked |
 | 5 | Synthesize all agent outputs before proceeding |
-| 6 | Store learnings in memory after completion |
+| 6 | Store a learning after completion **only if** it would help a different future task — a run summary belongs in the PR body, not memory |
 
 ---
 

--- a/.claude/helpers/gate.cjs
+++ b/.claude/helpers/gate.cjs
@@ -172,6 +172,25 @@ var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule 
 // /verify's Step 5 memory_store carries the verdict AND stamps learnings, which
 // is why learnings has no separate step here.
 var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\n';
+// #1434 — the old text ('learnings have not been stored (call memory_store)')
+// named the mechanism but no quality bar, so the cheapest way past it was a
+// summary of the run — audit exhaust that displaces reusable lessons from every
+// future bounded search. Name the bar AND the no-write path here: an escape
+// hatch nobody can find is not an escape hatch (see #1332's gate deadlock).
+//
+// The escape command is built from __filename, not written as a relative path.
+// The caller is the model typing into a Bash tool, NOT a hook: $CLAUDE_PROJECT_DIR
+// is unset there (so the settings.json form would expand to "/.claude/..."), and a
+// bare `.claude/helpers/gate.cjs` breaks from any cwd but the project root. The
+// running script's own absolute path is correct on every OS and from any cwd;
+// double quotes carry Windows separators and spaces through the shell.
+var LEARNINGS_MISSING =
+  'no durable lesson recorded. A lesson qualifies only if it would help a future session ' +
+  'working on a DIFFERENT task — a reusable pattern, a trap, a decision + rationale. ' +
+  'Store one with mcp__moflo__memory_store (namespace "learnings"; use "patterns" for a ' +
+  'reusable code shape). What THIS run changed is git history — it belongs in the PR body, ' +
+  'not in memory. If this run taught nothing new, say so instead of inventing one: ' +
+  'node "' + __filename + '" record-no-durable-lesson';
 var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
 // #1338 — Claude Code spawns stdio MCP servers once at session start and never
 // respawns them, so a session can outlive its moflo MCP connection. Naming only
@@ -1417,11 +1436,30 @@ switch (command) {
     // Why it does nothing: see applyPromptStateReset().
     break;
   }
-  case 'record-learnings-stored': {
+  // #1434 — the gate demanded one memory_store per run whether or not the run
+  // produced a reusable lesson, and a mandatory write with nothing to say
+  // produces filler: a summary of this ticket, this commit, applicable never
+  // again. memory_search returns a bounded set, so each of those displaces a
+  // real lesson from every future search — the cost is retrieval quality, not
+  // disk. Declaring "nothing durable here" is the honest outcome of a run that
+  // learned nothing new, so it has to be reachable without a write; otherwise
+  // the cheapest way past the gate stays the filler write.
+  //
+  // Both credits set the same flag; they differ only in whether the run has
+  // something to say. Sharing the case body keeps that single write in one
+  // place across all three copies of this file.
+  case 'record-learnings-stored':
+  case 'record-no-durable-lesson': {
     var s = readState();
     if (!s.learningsStored) {
       s.learningsStored = true;
       writeState(s);
+    }
+    if (command === 'record-no-durable-lesson') {
+      process.stdout.write(
+        'Learnings gate satisfied: no durable lesson declared for this run.\n' +
+        'What this run did belongs in the PR body, not in memory.\n',
+      );
     }
     break;
   }
@@ -1721,7 +1759,7 @@ switch (command) {
     var missing = [];
     if (config.testing_gate && !s.testsRun) missing.push('tests have not run green since the last code edit (run npm test, vitest, jest, pytest, or similar — a run whose output reports failures does not count)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/flo-simplify (or /distill) has not run since the last code edit');
-    if (config.learnings_gate && !s.learningsStored) missing.push('learnings have not been stored (call mcp__moflo__memory_store)');
+    if (config.learnings_gate && !s.learningsStored) missing.push(LEARNINGS_MISSING);
     if (missing.length === 0) break;
     process.stderr.write('BLOCKED: gh pr create requires the following before opening a PR:\n');
     for (var i = 0; i < missing.length; i++) {

--- a/.claude/skills/fl/SKILL.md
+++ b/.claude/skills/fl/SKILL.md
@@ -106,7 +106,7 @@ research → ticket → execute → tests → simplify → learnings → pr
 | Execute | Assign issue, create branch, implement |
 | Tests | Run unit + integration + E2E |
 | Simplify | Run `/flo-simplify` on changed code |
-| Learnings | Call `mcp__moflo__memory_store` with what was learned |
+| Learnings | Store a **durable** lesson — one that helps a *different* future task — or declare there is none. A run summary belongs in the PR body, never in memory |
 | PR | Open the PR, update issue status |
 
 The tests, simplify, and learnings steps are enforced by hooks. `gh pr create` is blocked by `check-before-pr` until each has run in the current session. Skill text describes the flow; the gates handle compliance.
@@ -270,6 +270,6 @@ Full mode runs end-to-end without further prompts.
 6. Run `/flo-simplify` on changed code; rerun tests if it edits — `./phases.md` Phase 4.5
 7. Commit — `./phases.md` Phase 5.1
 8. **Verify — default, unless `--no-verify`** (`verifyMode`, always on under `sddMode`): delegate to the `/verify` skill — `Skill({ skill: "verify" })`. It checks the change against the acceptance criteria, reusing Phase 4's tests (no double verify) and recording its own outcome; invoking it satisfies the verify-before-done gate. Mechanics live in `.claude/skills/verify/SKILL.md`; trigger/flow in `./phases.md` Phase 5.1b.
-9. Store learnings via `mcp__moflo__memory_store` — `./phases.md` Phase 5.2
+9. Record a durable lesson via `mcp__moflo__memory_store`, or declare there is none — `./phases.md` Phase 5.2
 10. Open PR, update issue status — `./phases.md` Phases 5.3–5.4
 11. **If `mergeMode`:** await the PR's merge preconditions and merge it (native `--auto` preferred, else poll-then-merge) — `./phases.md` Phase 5.3b

--- a/.claude/skills/fl/phases.md
+++ b/.claude/skills/fl/phases.md
@@ -173,18 +173,60 @@ repository and their git history is permanent — moflo does not sign their comm
 
 **When it runs:** by default (`verify_before_done` now defaults true) and always under `--sdd`; `--no-verify` skips it for one run. See `./sdd.md` for triggers and `.claude/skills/verify/SKILL.md` for how verification is performed.
 
-### 5.2 Store learnings
-Before opening the PR, call `mcp__moflo__memory_store` with what was learned. The `check-before-pr` gate blocks `gh pr create` until this has run.
+### 5.2 Record a durable lesson — or declare there isn't one
+
+**A run summary is not a learning.** What this run changed — files touched, the fix applied,
+the decision taken for this ticket — is git history and belongs in the PR body. Writing it to
+memory instead is audit exhaust: one ticket, one commit, applicable never again. `memory_search`
+returns a **bounded** result set, so every such entry permanently displaces a reusable lesson
+from every future search. That cost is retrieval quality, not disk.
+
+Apply the **durability bar** — the same one `/meditate` uses:
+
+> *Would this help a future session working on a **different** task?*
+
+| Store it | Where | Skip it — it is not a lesson |
+|----------|-------|------------------------------|
+| A reusable pattern: "for X, do Y because Z" | `learnings` | "Fixed #<n> by editing `<file>`" → PR body |
+| A trap: "W silently fails when V" | `learnings` | "Added tests for Z" → the test records itself |
+| A decision + rationale future work must honor | `learnings` | "Ran tests, they passed" → the run records itself |
+| A reusable code shape this repo should copy | `patterns` | Restating an existing CLAUDE.md / guidance rule |
+
+Key the entry on the **symptom or rule**, not the ticket. A future session hits the symptom
+without knowing the issue number, so a ticket-shaped key is unfindable exactly when it is needed.
+(An incident narrative may carry the issue as provenance — `1145-daemon-port-collision-fix` — but
+the searchable words must still be the symptom.) A real entry from this repo, abridged:
 
 ```
 mcp__moflo__memory_store:
-  key: "pattern:<topic>"
-  namespace: "patterns"
-  value: "<files changed, patterns used, decisions made>"
-  tags: ["<relevant-tags>"]
+  key: "wal-defeats-db-mtime-as-change-signal"
+  namespace: "learnings"
+  value: "In WAL mode SQLite writes land in the -wal sidecar, so the .db file's mtime
+          stops advancing on write. Any cache or staleness check keyed on db mtime
+          silently never invalidates. Hash the schema+row count, or stat the -wal too."
+  tags: ["sqlite", "caching", "gotcha"]
 ```
 
-This step happens before `gh pr create`, not after.
+Note what makes it durable: it states a rule that holds beyond the ticket that discovered it,
+and a future session hitting a stale-cache symptom finds it without knowing the issue existed.
+
+**If this run taught nothing new, do not invent something.** Declare it and move on — the
+`check-before-pr` gate accepts the declaration in place of a write:
+
+```bash
+node .claude/helpers/gate.cjs record-no-durable-lesson    # from the project root
+```
+
+(When the gate has already blocked, it prints this command with an absolute path — use that
+verbatim and the cwd stops mattering.)
+
+Most runs land here, and that is the expected outcome: a routine fix in a well-understood area
+produces no transferable lesson. One real lesson beats five manufactured ones.
+
+Either path satisfies the gate, and either way it happens before `gh pr create`, not after.
+Note that when `/verify` ran (5.1b, the default), its verdict write has **already** satisfied
+this gate — so reach for `memory_store` here only when you genuinely have a lesson, never to
+unblock the PR.
 
 ### 5.3 Create the PR
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — the learnings gate manufactured filler instead of lessons (#1434)
+
+`check-before-pr` blocked `gh pr create` until some `memory_store` had run, and credited any write
+regardless of namespace or content. That made a memory write mandatory once per `/flo` run whether
+or not the run had learned anything. When it hadn't, the run wrote a summary of itself — audit
+exhaust: one ticket, one commit, applicable never again. Because `memory_search` returns a bounded
+result set, every such entry permanently displaced a reusable lesson from every future search. The
+cost was retrieval quality, not disk.
+
+The namespace was the least of it. `/flo` Phase 5.2 was headed *"Store learnings"* and told the
+agent to record *"what was learned"*, while its worked example filled the value with
+`"<files changed, patterns used, decisions made>"` — a description of the run. The block message
+(*"learnings have not been stored (call memory_store)"*) named a mechanism and no quality bar. And
+with nothing durable to say, no honest path existed: inventing something was the only route to the
+PR. A mandatory write with nothing to say produces filler by construction.
+
+So the mandate is gone rather than re-homed. A run that learned nothing declares it —
+`node .claude/helpers/gate.cjs record-no-durable-lesson` credits the gate with no write at all — and
+the block message now states the bar (*would this help a future session working on a **different**
+task?*), names that escape, and points run narration at the PR body where it belongs. Phase 5.2 and
+the shipped agent rules carry the same bar, and Phase 5.2's example is now a real durable lesson
+instead of a template describing the run. Note that on a default run `/verify`'s verdict write
+already satisfied this gate, so the prescribed second write was redundant besides.
+
+Run records were never the problem and keep their existing home in `flo runs`. Consumers pick this
+up on upgrade; no migration, and existing `learnings` entries are left alone.
+
 ### Fixed — the post-upgrade badge outlived the upgrade, and `flo status` denied working installs (#1363)
 
 Two unrelated defects, both cases of moflo misreporting its own state.

--- a/bin/gate.cjs
+++ b/bin/gate.cjs
@@ -172,6 +172,25 @@ var GATE_ORIGIN_NOTE = 'This is a moflo hook, not a Claude Code permission rule 
 // /verify's Step 5 memory_store carries the verdict AND stamps learnings, which
 // is why learnings has no separate step here.
 var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\n';
+// #1434 — the old text ('learnings have not been stored (call memory_store)')
+// named the mechanism but no quality bar, so the cheapest way past it was a
+// summary of the run — audit exhaust that displaces reusable lessons from every
+// future bounded search. Name the bar AND the no-write path here: an escape
+// hatch nobody can find is not an escape hatch (see #1332's gate deadlock).
+//
+// The escape command is built from __filename, not written as a relative path.
+// The caller is the model typing into a Bash tool, NOT a hook: $CLAUDE_PROJECT_DIR
+// is unset there (so the settings.json form would expand to "/.claude/..."), and a
+// bare `.claude/helpers/gate.cjs` breaks from any cwd but the project root. The
+// running script's own absolute path is correct on every OS and from any cwd;
+// double quotes carry Windows separators and spaces through the shell.
+var LEARNINGS_MISSING =
+  'no durable lesson recorded. A lesson qualifies only if it would help a future session ' +
+  'working on a DIFFERENT task — a reusable pattern, a trap, a decision + rationale. ' +
+  'Store one with mcp__moflo__memory_store (namespace "learnings"; use "patterns" for a ' +
+  'reusable code shape). What THIS run changed is git history — it belongs in the PR body, ' +
+  'not in memory. If this run taught nothing new, say so instead of inventing one: ' +
+  'node "' + __filename + '" record-no-durable-lesson';
 var GATE_DISABLE_NOTE = 'Disable per-gate via moflo.yaml: gates: memory_first: false';
 // #1338 — Claude Code spawns stdio MCP servers once at session start and never
 // respawns them, so a session can outlive its moflo MCP connection. Naming only
@@ -1417,11 +1436,30 @@ switch (command) {
     // Why it does nothing: see applyPromptStateReset().
     break;
   }
-  case 'record-learnings-stored': {
+  // #1434 — the gate demanded one memory_store per run whether or not the run
+  // produced a reusable lesson, and a mandatory write with nothing to say
+  // produces filler: a summary of this ticket, this commit, applicable never
+  // again. memory_search returns a bounded set, so each of those displaces a
+  // real lesson from every future search — the cost is retrieval quality, not
+  // disk. Declaring "nothing durable here" is the honest outcome of a run that
+  // learned nothing new, so it has to be reachable without a write; otherwise
+  // the cheapest way past the gate stays the filler write.
+  //
+  // Both credits set the same flag; they differ only in whether the run has
+  // something to say. Sharing the case body keeps that single write in one
+  // place across all three copies of this file.
+  case 'record-learnings-stored':
+  case 'record-no-durable-lesson': {
     var s = readState();
     if (!s.learningsStored) {
       s.learningsStored = true;
       writeState(s);
+    }
+    if (command === 'record-no-durable-lesson') {
+      process.stdout.write(
+        'Learnings gate satisfied: no durable lesson declared for this run.\n' +
+        'What this run did belongs in the PR body, not in memory.\n',
+      );
     }
     break;
   }
@@ -1721,7 +1759,7 @@ switch (command) {
     var missing = [];
     if (config.testing_gate && !s.testsRun) missing.push('tests have not run green since the last code edit (run npm test, vitest, jest, pytest, or similar — a run whose output reports failures does not count)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/flo-simplify (or /distill) has not run since the last code edit');
-    if (config.learnings_gate && !s.learningsStored) missing.push('learnings have not been stored (call mcp__moflo__memory_store)');
+    if (config.learnings_gate && !s.learningsStored) missing.push(LEARNINGS_MISSING);
     if (missing.length === 0) break;
     process.stderr.write('BLOCKED: gh pr create requires the following before opening a PR:\n');
     for (var i = 0; i < missing.length; i++) {

--- a/src/cli/init/helpers-generator.ts
+++ b/src/cli/init/helpers-generator.ts
@@ -355,6 +355,18 @@ var COORD_FALLBACK_NOTE = 'If mcp__moflo__* tools are unavailable this session (
 // #1348 — the pre-PR gates are order-dependent; naming only the missing one left
 // callers to rediscover the sequence by trial. SYNC: mirrors bin/gate.cjs.
 var ORDER_HINT = 'Order that satisfies all of them: tests green -> /flo-simplify (re-run tests if it edits) -> /verify -> its memory_store verdict -> gh pr create\\n';
+// #1434 — the old text named the mechanism but no quality bar, so the cheapest
+// way past the gate was a summary of the run. The escape command is built from
+// __filename: the caller is the model typing into Bash, where $CLAUDE_PROJECT_DIR
+// is unset and a relative path breaks from any cwd but the project root.
+// SYNC: mirrors bin/gate.cjs.
+var LEARNINGS_MISSING =
+  'no durable lesson recorded. A lesson qualifies only if it would help a future session ' +
+  'working on a DIFFERENT task — a reusable pattern, a trap, a decision + rationale. ' +
+  'Store one with mcp__moflo__memory_store (namespace "learnings"; use "patterns" for a ' +
+  'reusable code shape). What THIS run changed is git history — it belongs in the PR body, ' +
+  'not in memory. If this run taught nothing new, say so instead of inventing one: ' +
+  'node "' + __filename + '" record-no-durable-lesson';
 // #1294 Finding 3 — exempt ephemeral reads/scans under the OS temp dir
 // (background-task output, scratchpads) from the memory-first gate. Mirrors
 // bin/gate.cjs isEphemeralPath. Cross-platform via os.tmpdir(); normalizes a
@@ -857,11 +869,22 @@ switch (command) {
     // rather than per-task-transition.
     break;
   }
-  case 'record-learnings-stored': {
+  // #1434 — a mandatory write with nothing to say produces filler that displaces
+  // reusable lessons from every future bounded search. Both credits set the same
+  // flag and differ only in whether the run has something to say, so they share
+  // one case body. SYNC: mirrors bin/gate.cjs.
+  case 'record-learnings-stored':
+  case 'record-no-durable-lesson': {
     var s = readState();
     if (!s.learningsStored) {
       s.learningsStored = true;
       writeState(s);
+    }
+    if (command === 'record-no-durable-lesson') {
+      process.stdout.write(
+        'Learnings gate satisfied: no durable lesson declared for this run.\\n' +
+        'What this run did belongs in the PR body, not in memory.\\n',
+      );
     }
     break;
   }
@@ -995,7 +1018,7 @@ switch (command) {
     var missing = [];
     if (config.testing_gate && !s.testsRun) missing.push('tests have not run green since the last code edit (run npm test, vitest, jest, pytest, or similar — a run whose output reports failures does not count)');
     if (config.simplify_gate && !s.simplifyRun) missing.push('/flo-simplify (or /distill) has not run since the last code edit');
-    if (config.learnings_gate && !s.learningsStored) missing.push('learnings have not been stored (call mcp__moflo__memory_store)');
+    if (config.learnings_gate && !s.learningsStored) missing.push(LEARNINGS_MISSING);
     if (missing.length === 0) break;
     process.stderr.write('BLOCKED: gh pr create requires the following before opening a PR:\\n');
     for (var i = 0; i < missing.length; i++) {

--- a/tests/bin/gate-helpers.test.ts
+++ b/tests/bin/gate-helpers.test.ts
@@ -1647,7 +1647,7 @@ describe('end-to-end: spell lifecycle', () => {
       const r = runGate('check-before-pr', env);
       expect(r.exitCode).toBe(2);
       expect(r.stderr).toContain('BLOCKED');
-      expect(r.stderr).toContain('learnings have not been stored');
+      expect(r.stderr).toContain('no durable lesson recorded');
     });
 
     it('blocks PR when tests have not run', () => {
@@ -1676,7 +1676,7 @@ describe('end-to-end: spell lifecycle', () => {
       expect(r.exitCode).toBe(2);
       expect(r.stderr).toContain('tests have not run');
       expect(r.stderr).toContain('/flo-simplify (or /distill) has not run');
-      expect(r.stderr).toContain('learnings have not been stored');
+      expect(r.stderr).toContain('no durable lesson recorded');
     });
 
     it('allows PR when all three gates are satisfied', () => {
@@ -1703,7 +1703,7 @@ describe('end-to-end: spell lifecycle', () => {
       env.TOOL_INPUT_command = 'GH_TOKEN=x BUILD_ID=1 gh pr create --title test';
       const r = runGate('check-before-pr', env);
       expect(r.exitCode).toBe(2);
-      expect(r.stderr).toContain('learnings have not been stored');
+      expect(r.stderr).toContain('no durable lesson recorded');
     });
 
     it('does not block non-PR bash commands', () => {

--- a/tests/bin/gate-no-durable-lesson-1434.test.ts
+++ b/tests/bin/gate-no-durable-lesson-1434.test.ts
@@ -1,0 +1,244 @@
+/**
+ * #1434 — the learnings gate must not manufacture filler.
+ *
+ * `check-before-pr` blocked `gh pr create` until SOME `memory_store` had run in
+ * the session, and credited any write regardless of namespace or content. A run
+ * that produced no reusable lesson therefore had exactly one way through: write
+ * a summary of itself. That summary is audit exhaust — one ticket, one commit,
+ * applicable never again — and `memory_search` returns a BOUNDED result set, so
+ * each one permanently displaces a reusable lesson from every future search.
+ * The cost is retrieval quality, not disk.
+ *
+ * Two halves are asserted here:
+ *   1. Declaring "no durable lesson" satisfies the gate without a write, so the
+ *      honest outcome of a run that learned nothing is reachable.
+ *   2. The block message names the durability bar AND that escape. An escape
+ *      hatch nobody can find is not an escape hatch (#1332's gate deadlock),
+ *      and a message naming only the mechanism ("call memory_store") is what
+ *      made the filler write the cheapest path in the first place.
+ *
+ * Assertions run against the SHIPPED `bin/gate.cjs` — the copy a consumer runs
+ * is the synced one, not this repo's source tree — plus the generator that
+ * writes gate.cjs into a fresh project, which is a third copy of the same logic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { appendFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { resolve, join, isAbsolute } from 'path';
+
+import { generateGateScript } from '../../src/cli/init/helpers-generator.js';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const GATE = resolve(REPO_ROOT, 'bin/gate.cjs');
+const PR_CMD = { TOOL_INPUT_command: 'gh pr create --title x --body y' };
+
+let root: string;
+
+/** Run gate.cjs the way the hook bridge does: command + TOOL_INPUT_* env. */
+function gate(cmd: string, env: Record<string, string> = {}) {
+  const r = spawnSync(process.execPath, [GATE, cmd], {
+    cwd: root,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, ...env },
+  });
+  return { status: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+function git(...args: string[]) {
+  const r = spawnSync('git', args, { cwd: root, encoding: 'utf-8', timeout: 30_000 });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout;
+}
+
+function readStateFile(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(root, '.claude', 'workflow-state.json'), 'utf-8'));
+}
+
+/**
+ * Earn every PR credit EXCEPT learnings, through the real recorders, against the
+ * already-dirty tree — credits are fingerprinted to the code they describe
+ * (#1366), so they must be earned after the source edit or they expire and the
+ * block message reports gates this test is not about.
+ */
+function earnCreditsExceptLearnings() {
+  gate('record-skill-run', { TOOL_INPUT_skill: 'flo-simplify' });
+  gate('record-test-run', {
+    TOOL_INPUT_command: 'npm test',
+    TOOL_RESPONSE_stdout: 'Test Files 3 passed (3)\nTests 42 passed (42)',
+  });
+  gate('record-skill-run', { TOOL_INPUT_skill: 'verify' });
+  gate('record-verify-run', { TOOL_INPUT_skill: 'verify' });
+}
+
+beforeEach(() => {
+  // Deliberately NOT under os.tmpdir(): isEphemeralPath exempts tmp-rooted
+  // projects from gate resets (#1348), which would mask what these assert.
+  root = resolve(REPO_ROOT, '.testoutput', `gate-1434-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(join(root, '.claude'), { recursive: true });
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'nl-test', version: '0.0.0' }));
+  writeFileSync(join(root, 'src.js'), 'export const safe = 1;\n');
+  git('init', '-q', '.');
+  git('config', 'user.email', 't@t.t');
+  git('config', 'user.name', 't');
+  git('add', '-A');
+  git('commit', '-qm', 'init');
+  // A real source change, so the no-source-files exemption does not skip the
+  // pre-PR gates outright and leave every assertion below vacuous.
+  appendFileSync(join(root, 'src.js'), 'export const added = 2;\n');
+});
+
+afterEach(() => {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    /* Windows may hold handles — non-fatal */
+  }
+});
+
+describe('#1434 declaring no durable lesson satisfies the learnings gate', () => {
+  it('credits the gate without any memory_store', () => {
+    const r = gate('record-no-durable-lesson');
+    expect(r.status).toBe(0);
+    expect(readStateFile().learningsStored).toBe(true);
+  });
+
+  it('says so on stdout, so the declaration is visible rather than silent', () => {
+    const r = gate('record-no-durable-lesson');
+    expect(r.stdout).toContain('no durable lesson');
+    // Names where the run summary DOES belong — the redirect is the point.
+    expect(r.stdout.toLowerCase()).toContain('pr body');
+  });
+
+  it('lets gh pr create through with no learnings write at all', () => {
+    earnCreditsExceptLearnings();
+    expect(gate('check-before-pr', PR_CMD).stderr).toContain('BLOCKED');
+
+    gate('record-no-durable-lesson');
+    const after = gate('check-before-pr', PR_CMD);
+    expect(after.stderr).not.toContain('BLOCKED');
+    expect(after.status).toBe(0);
+  });
+
+  it('is idempotent and leaves the other credits untouched', () => {
+    earnCreditsExceptLearnings();
+    const before = readStateFile();
+    gate('record-no-durable-lesson');
+    gate('record-no-durable-lesson');
+    const after = readStateFile();
+    expect(after.learningsStored).toBe(true);
+    expect(after.testsRun).toBe(before.testsRun);
+    expect(after.simplifyRun).toBe(before.simplifyRun);
+    expect(after.verifyRun).toBe(before.verifyRun);
+  });
+});
+
+describe('#1434 the block message teaches the bar, not just the mechanism', () => {
+  it('states the durability bar when learnings are missing', () => {
+    earnCreditsExceptLearnings();
+    const { stderr } = gate('check-before-pr', PR_CMD);
+    expect(stderr).toContain('durable lesson');
+    // The bar itself — a lesson must transfer to a DIFFERENT task.
+    expect(stderr).toContain('DIFFERENT task');
+  });
+
+  it('names the no-write escape, so the filler write is never the cheapest path', () => {
+    earnCreditsExceptLearnings();
+    const { stderr } = gate('check-before-pr', PR_CMD);
+    expect(stderr).toContain('record-no-durable-lesson');
+  });
+
+  /**
+   * The escape is typed by the model into a Bash tool, where $CLAUDE_PROJECT_DIR
+   * is NOT set (that is a hook-only variable) and the cwd is not guaranteed to be
+   * the project root. Asserting only that the case name appears would pass on a
+   * command that cannot run — so run the printed command itself, from a cwd that
+   * is deliberately not the project root.
+   */
+  it('prints a command that actually runs from an unrelated cwd', () => {
+    earnCreditsExceptLearnings();
+    const { stderr } = gate('check-before-pr', PR_CMD);
+
+    const printed = stderr.match(/node "([^"]+)" record-no-durable-lesson/);
+    expect(printed, 'block message must print an absolute, quoted script path').not.toBeNull();
+    expect(isAbsolute(printed![1])).toBe(true);
+    expect(stderr).not.toContain('$CLAUDE_PROJECT_DIR');
+
+    const r = spawnSync(process.execPath, [printed![1], 'record-no-durable-lesson'], {
+      cwd: REPO_ROOT, // deliberately NOT the fixture project root
+      encoding: 'utf-8',
+      timeout: 30_000,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+    });
+    expect(r.status).toBe(0);
+    expect(readStateFile().learningsStored).toBe(true);
+  });
+
+  it('redirects run narration to the PR body', () => {
+    earnCreditsExceptLearnings();
+    const { stderr } = gate('check-before-pr', PR_CMD);
+    expect(stderr).toContain('PR body');
+  });
+});
+
+/**
+ * The generated copy is the one a FRESH `flo init` writes, and every existing
+ * test of it only string-matches the source. A syntax error inside the template
+ * literal — a mis-escaped `\n`, an unbalanced brace — would therefore ship to
+ * every new consumer project undetected. Run it for real instead.
+ */
+describe('#1434 the generated gate script runs, not just contains the case', () => {
+  it('credits the gate when executed as a fresh init would write it', () => {
+    const genPath = join(root, 'generated-gate.cjs');
+    writeFileSync(genPath, generateGateScript());
+
+    const r = spawnSync(process.execPath, [genPath, 'record-no-durable-lesson'], {
+      cwd: root,
+      encoding: 'utf-8',
+      timeout: 30_000,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+    });
+
+    // A syntax error surfaces here as a non-zero exit with a parse error on
+    // stderr, which substring-matching the source can never catch.
+    expect(r.stderr).not.toMatch(/SyntaxError|Unexpected token/);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('no durable lesson');
+    expect(readStateFile().learningsStored).toBe(true);
+  });
+});
+
+describe('#1434 all three gate copies carry the fix', () => {
+  const binSrc = readFileSync(GATE, 'utf-8');
+  const helpersSrc = readFileSync(join(REPO_ROOT, '.claude', 'helpers', 'gate.cjs'), 'utf-8');
+  const generated = generateGateScript();
+
+  for (const [name, src] of [
+    ['bin/gate.cjs', binSrc],
+    ['.claude/helpers/gate.cjs', helpersSrc],
+    ['generateGateScript()', generated],
+  ] as const) {
+    it(`${name} handles record-no-durable-lesson`, () => {
+      expect(src).toContain("case 'record-no-durable-lesson'");
+    });
+
+    it(`${name} names the bar and the escape in the block message`, () => {
+      expect(src).toContain('DIFFERENT task');
+      expect(src).toContain('record-no-durable-lesson');
+    });
+
+    /**
+     * The escape path must be the `__filename` TOKEN, resolved when the gate
+     * runs in the consumer. The generator embeds this source inside a template
+     * literal, so a `${__filename}` slip would instead bake the build machine's
+     * absolute path into every consumer's gate message — wrong for them, and a
+     * path disclosure besides. Substring-matching the command name cannot tell
+     * the two apart.
+     */
+    it(`${name} resolves the escape path at runtime, not at build time`, () => {
+      expect(src).toMatch(/'node "' \+ __filename \+ '"/);
+      expect(src).not.toMatch(/node "\/(home|Users)\//);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`check-before-pr` blocked `gh pr create` until some `memory_store` had run, and credited **any**
write regardless of namespace or content. That made a memory write mandatory once per `/flo` run
whether or not the run had learned anything. When it hadn't, the run wrote a summary of itself —
audit exhaust: one ticket, one commit, applicable never again. Because `memory_search` returns a
**bounded** result set, each such entry permanently displaced a reusable lesson from every future
search. The cost was retrieval quality, not disk.

Reported from a consumer project on 4.12.6, where the effect is visible; this repo's `learnings`
namespace is curated by `/meditate` and hid it.

## Why it wasn't already fixed

#1375/#1376 moved `/verify` verdicts out of `learnings`. That was the *sibling* fix — `/flo`
Phase 5.2 never got the same treatment, and the namespace turned out to be the least of it:

1. **The skill prescribed the filler.** Phase 5.2 was headed *"Store learnings"* and asked for
   *"what was learned"*, while its worked example filled the value with
   `"<files changed, patterns used, decisions made>"` — a description of the run. Its example
   namespace said `patterns`, contradicting its own heading; the model followed the noun.
2. **The block message named a mechanism, not a bar.** *"learnings have not been stored (call
   memory_store)"* states no threshold, so the cheapest way past it is a run summary.
3. **A mandatory write with nothing to say guarantees filler.** This is the root cause. There was no
   way to record the honest outcome, so inventing something was the only route to a PR.

Worth noting: `record-learnings-stored` is wired to `^mcp__moflo__memory_store$`, which `/verify`'s
verdict write already trips. On a default run the gate was *already* satisfied before 5.2 — the
prescribed write was redundant as well as harmful.

## Changes

| Surface | Change |
|---|---|
| `bin/gate.cjs`, `.claude/helpers/gate.cjs`, `helpers-generator.ts` | New `record-no-durable-lesson` case credits the gate with **no** write; shares one case body with `record-learnings-stored` so the state write stays in one place across all three copies |
| Block message | States the bar (*would this help a future session on a **different** task?*), names the escape, redirects run narration to the PR body |
| `.claude/skills/fl/phases.md` §5.2 | Rewritten: bar, store/skip routing table, a **real** durable lesson as the example, explicit "if nothing, declare it" |
| `.claude/skills/fl/SKILL.md` | Workflow row + step 9 aligned |
| `.claude/guidance/shipped/moflo-agent-rules.md` | The bar as single source of truth: never store a run summary; a gate never justifies a write |
| `.claude/guidance/shipped/moflo-claude-swarm-cohesion.md` | Dropped the unconditional "store learnings after completion" |

The escape command is built from `__filename` rather than written as a path. The caller is the model
typing into a Bash tool, where `$CLAUDE_PROJECT_DIR` is **unset** — the settings.json hook form would
expand to `node "/.claude/helpers/gate.cjs"` and always fail — and a bare relative path breaks from
any cwd but the project root. The running script's own absolute path is correct on every OS and from
any cwd (Rule #1), quoted so Windows separators and spaces survive the shell.

## Not doing: a separate `flo-runs` namespace

The report suggested re-homing run records. They already have a home — `storeFloRunRecord` /
`flo runs`, backing the Flo Runs dashboard. Re-homing the filler would have preserved the mandate
that manufactures it. Removing the mandate is the fix.

## Consumer impact

Surface touched: the gate (`bin/gate.cjs` + both mirrored copies) and the `/flo` skill — both reach
every consumer. A consumer on 4.12.6 picks this up on `npm install`; no migration, `.moflo/` state
keeps its shape, and existing `learnings` entries are left alone. Runtime effect needs
publish → reinstall → session restart, as with any gate change.

## Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass
- [x] Full suite: **10,699 passed / 0 failed**

New `tests/bin/gate-no-durable-lesson-1434.test.ts` (15 tests) covers: the credit without a write,
`gh pr create` blocked before / passing after, idempotency and credit isolation, the block message's
bar + escape + PR-body redirect, and the printed command **executed from an unrelated cwd** rather
than merely string-matched. It also **runs** the generator's output — no existing test executed
`generateGateScript()`, so a syntax error there could previously have shipped to every fresh
`flo init` undetected.

The `issue-attribution` guard caught a `(#1434)` reference leaking into consumer-facing skill prose;
removed.

Closes #1434
